### PR TITLE
[Bugfix] Fix HF benchmark datasets crashing when --hf-split is omitted

### DIFF
--- a/tests/benchmarks/test_hf_dataset_split.py
+++ b/tests/benchmarks/test_hf_dataset_split.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression tests for HuggingFace benchmark datasets loaded without a split.
+
+See https://github.com/vllm-project/vllm/issues/49480: when ``--hf-split`` is
+omitted, ``load_dataset`` returns a split *mapping* (``DatasetDict`` /
+``IterableDatasetDict``). Iterating that mapping yields split names (``str``)
+rather than examples, so sampling used to raise
+``TypeError: string indices must be integers``.
+"""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+from datasets import Dataset, DatasetDict, IterableDatasetDict
+from transformers import AutoTokenizer, PreTrainedTokenizerBase
+
+from vllm.benchmarks.datasets import datasets as datasets_mod
+from vllm.benchmarks.datasets.datasets import ConversationDataset
+
+
+@pytest.fixture(scope="session")
+def hf_tokenizer() -> PreTrainedTokenizerBase:
+    return AutoTokenizer.from_pretrained("openai-community/gpt2")
+
+
+def _conversation_rows(n: int) -> list[dict]:
+    return [
+        {
+            "conversations": [
+                {"from": "human", "value": f"question {i}"},
+                {"from": "gpt", "value": f"answer {i} with enough content"},
+            ]
+        }
+        for i in range(n)
+    ]
+
+
+def _dataset_dict(n: int, splits: tuple[str, ...] = ("train",)) -> DatasetDict:
+    return DatasetDict(
+        {split: Dataset.from_list(_conversation_rows(n)) for split in splits}
+    )
+
+
+def _iterable_dataset_dict(
+    n: int, splits: tuple[str, ...] = ("train",)
+) -> IterableDatasetDict:
+    return IterableDatasetDict(
+        {
+            split: Dataset.from_list(_conversation_rows(n)).to_iterable_dataset()
+            for split in splits
+        }
+    )
+
+
+def _make_dataset(mock_return, dataset_split=None) -> ConversationDataset:
+    """Build a ConversationDataset while mocking the HuggingFace download."""
+    with patch.object(datasets_mod, "load_dataset", return_value=mock_return):
+        return ConversationDataset(
+            dataset_path="Aeala/ShareGPT_Vicuna_unfiltered",
+            dataset_split=dataset_split,
+            random_seed=0,
+        )
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("factory", [_dataset_dict, _iterable_dataset_dict])
+def test_missing_split_does_not_crash_sampling(
+    hf_tokenizer: PreTrainedTokenizerBase, factory
+) -> None:
+    """Omitting --hf-split must not crash sampling (issue #49480).
+
+    Covers both the eager (``DatasetDict``) and streaming
+    (``IterableDatasetDict``) mappings ``load_dataset`` can return.
+    """
+    dataset = _make_dataset(factory(16))
+
+    requests = dataset.sample(
+        tokenizer=hf_tokenizer,
+        num_requests=5,
+        request_id_prefix="req-",
+        output_len=32,
+    )
+
+    assert len(requests) == 5
+    assert all(req.prompt for req in requests)
+
+
+@pytest.mark.benchmark
+def test_missing_split_prefers_train(
+    hf_tokenizer: PreTrainedTokenizerBase, caplog
+) -> None:
+    """With several splits, "train" is chosen even when it isn't first."""
+    mapping = DatasetDict(
+        {
+            "validation": Dataset.from_list(_conversation_rows(4)),
+            "train": Dataset.from_list(_conversation_rows(16)),
+        }
+    )
+
+    with caplog.at_level(logging.WARNING):
+        dataset = _make_dataset(mapping)
+
+    # The mapping was collapsed to a concrete split, not left as a dict.
+    assert not isinstance(dataset.data, (DatasetDict, IterableDatasetDict))
+    # "train" (16 rows) was chosen over the first key "validation" (4 rows).
+    assert len(dataset.data) == 16
+    assert "defaulting to 'train'" in caplog.text
+
+
+@pytest.mark.benchmark
+def test_missing_split_without_train_uses_first(
+    hf_tokenizer: PreTrainedTokenizerBase,
+) -> None:
+    """When there is no "train" split, fall back to the first available one."""
+    mapping = _dataset_dict(6, splits=("test",))
+
+    dataset = _make_dataset(mapping)
+
+    assert not isinstance(dataset.data, (DatasetDict, IterableDatasetDict))
+    assert len(dataset.data) == 6
+
+
+@pytest.mark.benchmark
+def test_explicit_split_is_left_untouched(
+    hf_tokenizer: PreTrainedTokenizerBase,
+) -> None:
+    """A concrete --hf-split yields a Dataset (not a mapping); leave it as-is."""
+    single_split = Dataset.from_list(_conversation_rows(12))
+
+    dataset = _make_dataset(single_split, dataset_split="train")
+
+    assert len(dataset.data) == 12
+    requests = dataset.sample(
+        tokenizer=hf_tokenizer,
+        num_requests=4,
+        request_id_prefix="",
+        output_len=8,
+    )
+    assert len(requests) == 4

--- a/vllm/benchmarks/datasets/datasets.py
+++ b/vllm/benchmarks/datasets/datasets.py
@@ -52,10 +52,12 @@ from vllm.utils.import_utils import PlaceholderModule
 from vllm.utils.mistral import is_mistral_tokenizer
 
 try:
-    from datasets import load_dataset
+    from datasets import DatasetDict, IterableDatasetDict, load_dataset
 except ImportError:
     datasets = PlaceholderModule("datasets")
     load_dataset = datasets.placeholder_attr("load_dataset")
+    DatasetDict = datasets.placeholder_attr("DatasetDict")
+    IterableDatasetDict = datasets.placeholder_attr("IterableDatasetDict")
 
 try:
     import pandas as pd
@@ -3259,7 +3261,7 @@ class HuggingFaceDataset(BenchmarkDataset):
     def __init__(
         self,
         dataset_path: str,
-        dataset_split: str,
+        dataset_split: str | None,
         no_stream: bool = False,
         dataset_subset: str | None = None,
         hf_name: str | None = None,
@@ -3284,6 +3286,24 @@ class HuggingFaceDataset(BenchmarkDataset):
             streaming=self.load_stream,
             trust_remote_code=self.trust_remote_code,
         )
+        # When no split is requested, ``load_dataset`` returns a mapping of
+        # split name -> dataset (DatasetDict / IterableDatasetDict). Iterating
+        # that yields split *names* (str) instead of examples, so downstream
+        # sampling fails with "string indices must be integers". Collapse it to
+        # a single concrete split, preferring "train" when present.
+        if isinstance(self.data, (DatasetDict, IterableDatasetDict)):
+            available_splits = list(self.data.keys())
+            chosen_split = (
+                "train" if "train" in available_splits else available_splits[0]
+            )
+            logger.warning(
+                "No split specified for dataset '%s' (available splits: %s); "
+                "defaulting to '%s'. Pass --hf-split to select one explicitly.",
+                self.dataset_path,
+                available_splits,
+                chosen_split,
+            )
+            self.data = self.data[chosen_split]
         if not getattr(self, "disable_shuffle", False):
             self.data = self.data.shuffle(seed=self.random_seed)
 


### PR DESCRIPTION
## Purpose

`vllm bench serve` crashes with `TypeError: string indices must be integers`
when benchmarking a HuggingFace dataset and `--hf-split` is not passed.

Fixes #49480.

### Root cause

`--hf-split` defaults to `None`, so `HuggingFaceDataset.load_data` calls
`load_dataset(..., split=None, streaming=True)`, which returns a split
*mapping* (`IterableDatasetDict` / `DatasetDict`) instead of a single
dataset. `.shuffle()` and `.filter()` operate per split and succeed, but
iterating the mapping in `sample()` yields split *names* (`str`), so
`item["conversations"]` raises `TypeError: string indices must be integers`.

### Fix

In `HuggingFaceDataset.load_data`, when `load_dataset` returns a split
mapping, collapse it to a single concrete split. It prefers `"train"`,
otherwise the first available split, and logs a warning suggesting
`--hf-split`. Behavior is unchanged when a split is explicitly requested.

## Test Plan

New `tests/benchmarks/test_hf_dataset_split.py`:
- `DatasetDict` and `IterableDatasetDict` no longer crash `sample()`
- `"train"` is preferred when multiple splits exist
- the first split is used when there is no `"train"`
- an explicit `--hf-split` (plain `Dataset`) is left untouched

## Test Result

All new tests pass. The existing `tests/benchmarks` suite collects cleanly
and `test_custom_dataset_seed.py` still passes. Verified end to end against
the real `Aeala/ShareGPT_Vicuna_unfiltered` dataset (streaming): it
reproduces the reported `TypeError` before the fix and succeeds after.

## Follow-up (out of scope)

`ASRDataset.load_data` uses the same `split=None` pattern for a few audio
datasets and could get the same treatment in a follow-up.
