### PR TITLE
[Model][Bugfix] step3.7-flash: bounds-check per-layer config lookups for MTP layers

### DIFF
--- a/vllm/model_executor/models/step3p5.py
+++ b/vllm/model_executor/models/step3p5.py
@@ -115,6 +115,7 @@ class Step3p5MLP(nn.Module):
         layer_idx = extract_layer_index(prefix)
         if (
             config.swiglu_limits_shared
+            and layer_idx < len(config.swiglu_limits_shared)
             and config.swiglu_limits_shared[layer_idx] is not None
             and config.swiglu_limits_shared[layer_idx] != 0
         ):
@@ -158,11 +159,22 @@ class Step3p5Attention(nn.Module):
         self.total_num_heads = num_heads
         tp_size = get_tensor_model_parallel_world_size()
         self.layer_idx = extract_layer_index(prefix)
+        # Multi-token-prediction / draft layers are constructed with a layer_idx of
+        # num_hidden_layers (one past the base decoder layers), so they fall outside the
+        # per-layer config lists. Bounds-check every per-layer lookup and treat such
+        # layers as standard, non-sliding attention layers.
         if layer_types:
-            enable_sliding_window = layer_types[self.layer_idx] == "sliding_attention"
+            enable_sliding_window = (
+                self.layer_idx < len(layer_types)
+                and layer_types[self.layer_idx] == "sliding_attention"
+            )
         else:
             enable_sliding_window = self.layer_idx % 2 == 0
-        if yarn_only_types and layer_types[self.layer_idx] not in yarn_only_types:
+        if (
+            yarn_only_types
+            and self.layer_idx < len(layer_types)
+            and layer_types[self.layer_idx] not in yarn_only_types
+        ):
             rope_scaling = None
 
         if sliding_window is not None and enable_sliding_window:
@@ -174,7 +186,7 @@ class Step3p5Attention(nn.Module):
             sliding_window = None
 
         if isinstance(rope_theta, list):
-            rope_theta = rope_theta[self.layer_idx]
+            rope_theta = rope_theta[min(self.layer_idx, len(rope_theta) - 1)]
 
         self.rank = get_tensor_model_parallel_rank()
         self.partial_rotary_factor = partial_rotary_factor
@@ -241,7 +253,7 @@ class Step3p5Attention(nn.Module):
             )
 
         self.use_rope = True
-        if use_rope_layers:
+        if use_rope_layers and self.layer_idx < len(use_rope_layers):
             self.use_rope = use_rope_layers[self.layer_idx]
 
         self.attn = Attention(
@@ -435,6 +447,7 @@ class Step3p5DecoderLayer(nn.Module):
             if (
                 getattr(config, "attention_other_setting", None)
                 and getattr(config, "layer_types", [])
+                and layer_idx < len(config.layer_types)
                 and config.layer_types[layer_idx]
                 == config.attention_other_setting["attention_type"]
             ):
@@ -470,7 +483,7 @@ class Step3p5DecoderLayer(nn.Module):
                 use_rope_layers=getattr(config, "use_rope_layers", []),
                 yarn_only_types=getattr(config, "yarn_only_types", []),
                 partial_rotary_factor=partial_rotary_factors[layer_idx]
-                if partial_rotary_factors
+                if partial_rotary_factors and layer_idx < len(partial_rotary_factors)
                 else 1.0,
                 prefix=f"{prefix}.self_attn",
             )


### PR DESCRIPTION
## Purpose

Step3p5 multi-token-prediction (MTP) draft layers are constructed with `layer_idx == num_hidden_layers` — one past the base decoder layers. See `Step3p5AMultiTokenPredictor` in `step3p5_mtp.py`, which builds the draft blocks over `range(num_hidden_layers, num_hidden_layers + num_nextn_predict_layers)`, giving each `mtp_block` a prefix like `...layers.{num_hidden_layers}.mtp_block`.

Several per-layer config lookups in `step3p5.py` index lists of length `num_hidden_layers` by this `layer_idx` **without a bounds check**. So building the MTP block raises `IndexError` and `EngineCore` fails to start whenever `--speculative-config '{"method":"mtp",...}'` is enabled on a model that also sets `layer_types` / `attention_other_setting` (e.g. Step-3.7-Flash):

```
File "vllm/model_executor/models/step3p5.py", in Step3p5DecoderLayer.__init__
    and config.layer_types[layer_idx]
IndexError: list index out of range
```

## Fix

Bounds-check every per-layer lookup keyed by `layer_idx`, matching the guard that already exists for `swiglu_limits` (`... if self.layer_idx < len(swiglu_limits) else None`):

- `Step3p5MLP`: `swiglu_limits_shared[layer_idx]`
- `Step3p5Attention`: `layer_types[self.layer_idx]` (sliding-window and yarn), `rope_theta[self.layer_idx]`, `use_rope_layers[self.layer_idx]`
- `Step3p5DecoderLayer`: `config.layer_types[layer_idx]`, `partial_rotary_factors[layer_idx]`

Out-of-range (MTP / draft) layers now fall back to standard defaults — full attention, no sliding window, no swiglu limit, full rotary. **Base-layer behavior is unchanged** (their indices are always in range).

## Test Plan

Serving Step-3.7-Flash with `--speculative-config '{"method":"mtp","num_speculative_tokens":2}'` previously crashed in `EngineCore` during model load; with this change the MTP draft layers build and the engine starts.
