### PR TITLE
[Feat][Core] Add disk offloading support to SimpleCPUOffloadConnector

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
@@ -87,6 +87,7 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
             extra_config.get("disk_capacity_bytes", 100 * (1024**3))
         )
         disk_buffer_slots = max(1, int(extra_config.get("disk_buffer_slots", 2)))
+        use_page_cache = bool(extra_config.get("use_page_cache", False))
 
         self.scheduler_manager: SimpleCPUOffloadScheduler | None = None
         self.worker_handler: SimpleCPUOffloadWorker | None = None
@@ -132,6 +133,7 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
                 disk_path=disk_path,
                 disk_capacity_bytes=disk_capacity_bytes,
                 disk_buffer_slots=disk_buffer_slots,
+                use_page_cache=use_page_cache,
             )
 
     # --- Worker-side methods ---

--- a/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
@@ -82,6 +82,12 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
 
         lazy_offload = bool(extra_config.get("lazy_offload", False))
 
+        disk_path = extra_config.get("disk_path", None) or None
+        disk_capacity_bytes = int(
+            extra_config.get("disk_capacity_bytes", 100 * (1024**3))
+        )
+        disk_buffer_slots = max(1, int(extra_config.get("disk_buffer_slots", 2)))
+
         self.scheduler_manager: SimpleCPUOffloadScheduler | None = None
         self.worker_handler: SimpleCPUOffloadWorker | None = None
 
@@ -94,11 +100,12 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
 
         logger.info(
             "SimpleCPUOffloadConnector: role=%s, "
-            "per_rank=%.2f GB, world_size=%d, mode=%s",
+            "per_rank=%.2f GB, world_size=%d, mode=%s, disk=%s",
             role.name,
             cpu_capacity_per_rank / (1024**3),
             world_size,
             "lazy" if lazy_offload else "eager",
+            disk_path or "none",
         )
 
         if role == KVConnectorRole.SCHEDULER:
@@ -115,10 +122,16 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
                 scheduler_block_size=scheduler_block_size,
                 hash_block_size=hash_block_size,
                 lazy_offload=lazy_offload,
+                disk_capacity_bytes=disk_capacity_bytes if disk_path else 0,
             )
         elif role == KVConnectorRole.WORKER:
             self.worker_handler = SimpleCPUOffloadWorker(
-                vllm_config, kv_cache_config, cpu_capacity_per_rank
+                vllm_config,
+                kv_cache_config,
+                cpu_capacity_per_rank,
+                disk_path=disk_path,
+                disk_capacity_bytes=disk_capacity_bytes,
+                disk_buffer_slots=disk_buffer_slots,
             )
 
     # --- Worker-side methods ---

--- a/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
@@ -41,6 +41,15 @@ logger = init_logger(__name__)
 # Default CPU capacity: 8 GB
 DEFAULT_CPU_CAPACITY_BYTES = 8 * (1024**3)
 
+VALID_KV_OFFLOAD_BACKENDS = ("cpu", "disk")
+# Keys that only apply to the disk backend, warned about under "cpu".
+_DISK_ONLY_KEYS = (
+    "disk_path",
+    "disk_capacity_bytes",
+    "disk_buffer_slots",
+    "use_page_cache",
+)
+
 
 class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
     """CPU KV cache offloading with custom kernel transfers and BlockPool LRU."""
@@ -82,12 +91,35 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
 
         lazy_offload = bool(extra_config.get("lazy_offload", False))
 
+        kv_offload_backend = str(extra_config.get("kv_offload_backend", "cpu"))
+        if kv_offload_backend not in VALID_KV_OFFLOAD_BACKENDS:
+            raise ValueError(
+                f"Unknown kv_offload_backend {kv_offload_backend!r}; "
+                f"expected one of {VALID_KV_OFFLOAD_BACKENDS}"
+            )
+        disk_mode = kv_offload_backend == "disk"
+
         disk_path = extra_config.get("disk_path", None) or None
         disk_capacity_bytes = int(
             extra_config.get("disk_capacity_bytes", 100 * (1024**3))
         )
         disk_buffer_slots = max(1, int(extra_config.get("disk_buffer_slots", 2)))
         use_page_cache = bool(extra_config.get("use_page_cache", False))
+
+        if disk_mode:
+            if disk_path is None:
+                raise ValueError(
+                    'kv_offload_backend="disk" requires disk_path to be set.'
+                )
+        else:
+            ignored = [k for k in _DISK_ONLY_KEYS if k in extra_config]
+            if ignored:
+                logger.warning(
+                    'kv_offload_backend is "cpu", ignoring disk-only config: %s. '
+                    'Set kv_offload_backend="disk" to enable the disk backend.',
+                    ", ".join(ignored),
+                )
+            disk_path = None
 
         self.scheduler_manager: SimpleCPUOffloadScheduler | None = None
         self.worker_handler: SimpleCPUOffloadWorker | None = None
@@ -101,11 +133,12 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
 
         logger.info(
             "SimpleCPUOffloadConnector: role=%s, "
-            "per_rank=%.2f GB, world_size=%d, mode=%s, disk=%s",
+            "per_rank=%.2f GB, world_size=%d, mode=%s, backend=%s, disk=%s",
             role.name,
             cpu_capacity_per_rank / (1024**3),
             world_size,
             "lazy" if lazy_offload else "eager",
+            kv_offload_backend,
             disk_path or "none",
         )
 
@@ -123,13 +156,14 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
                 scheduler_block_size=scheduler_block_size,
                 hash_block_size=hash_block_size,
                 lazy_offload=lazy_offload,
-                disk_capacity_bytes=disk_capacity_bytes if disk_path else 0,
+                disk_capacity_bytes=disk_capacity_bytes if disk_mode else 0,
             )
         elif role == KVConnectorRole.WORKER:
             self.worker_handler = SimpleCPUOffloadWorker(
                 vllm_config,
                 kv_cache_config,
                 cpu_capacity_per_rank,
+                kv_offload_backend=kv_offload_backend,
                 disk_path=disk_path,
                 disk_capacity_bytes=disk_capacity_bytes,
                 disk_buffer_slots=disk_buffer_slots,

--- a/vllm/v1/simple_kv_offload/disk_backend.py
+++ b/vllm/v1/simple_kv_offload/disk_backend.py
@@ -1,12 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Disk I/O backend for GPU<->NVMe block transfers via pinned double buffer."""
+"""Disk I/O backend for GPU<->NVMe block transfers via pinned staging buffers.
+
+Uses separate IO threads for store and load so that loads (latency-critical)
+never block behind stores (background work). Each thread owns its own pinned
+staging buffers to avoid contention.
+"""
 
 from __future__ import annotations
 
 import os
+import queue
 import threading
-from collections import deque
 
 import torch
 
@@ -41,7 +46,12 @@ def _alloc_aligned(num_slots: int, bpb: int) -> torch.Tensor:
 
 
 class DiskBackend:
-    """Async disk offload backend with GPU DMA pipeline and double buffering.
+    """Async disk offload backend with pipelined GPU DMA and interleaved IO.
+
+    Architecture:
+    - Separate coordinator threads for store and load (never block each other)
+    - Interleaved pipeline: DMA slot N while preadv/pwritev slot N-1
+    - O_DIRECT by default; page cache is opt-in via use_page_cache
 
     Same launch_copy interface as DmaCopyBackend so the worker can swap
     backends without changing calling code.
@@ -52,17 +62,17 @@ class DiskBackend:
         self._load_params: BatchMemcpyParams | None = None
         self._load_stream: torch.cuda.Stream | None = None
         self._store_stream: torch.cuda.Stream | None = None
-        # Loads are latency-critical (a request is waiting on them) while stores
-        # are background work, so they get separate queues and loads win.
-        self._load_q: deque = deque()
-        self._store_q: deque = deque()
-        self._cond = threading.Condition()
-        self._thread: threading.Thread | None = None
+        self._store_queue: queue.SimpleQueue | None = None
+        self._load_queue: queue.SimpleQueue | None = None
+        self._store_thread: threading.Thread | None = None
+        self._load_thread: threading.Thread | None = None
         self._shutdown: bool = False
         self._fd: int = -1
         self._total_block_bytes: int = 0
-        self._buffer_caches: dict[str, torch.Tensor] = {}
-        self._slot_views: list[list[memoryview]] = []
+        self._store_buffer_caches: dict[str, torch.Tensor] = {}
+        self._load_buffer_caches: dict[str, torch.Tensor] = {}
+        self._store_slot_views: list[list[memoryview]] = []
+        self._load_slot_views: list[list[memoryview]] = []
         self._per_tensor_bpb: list[int] = []
         self._tensor_names: list[str] = []
 
@@ -76,6 +86,7 @@ class DiskBackend:
         num_disk_slots: int,
         total_block_bytes: int,
         num_buffer_slots: int = 2,
+        use_page_cache: bool = False,
     ) -> None:
         self._load_stream = load_stream
         self._store_stream = store_stream
@@ -90,19 +101,29 @@ class DiskBackend:
             f"total_block_bytes={total_block_bytes} not aligned to {_ALIGNMENT}"
         )
 
-        self._buffer_caches = {}
+        # Separate buffer pools for store and load threads
+        self._store_buffer_caches = {}
+        self._load_buffer_caches = {}
         for name, gpu_t in gpu_caches.items():
             bpb = gpu_t.stride(0) * gpu_t.element_size()
-            buf = _alloc_aligned(num_buffer_slots, bpb)
-            pin_tensor(buf)
-            self._buffer_caches[name] = buf
+            store_buf = _alloc_aligned(num_buffer_slots, bpb)
+            pin_tensor(store_buf)
+            self._store_buffer_caches[name] = store_buf
+            load_buf = _alloc_aligned(num_buffer_slots, bpb)
+            pin_tensor(load_buf)
+            self._load_buffer_caches[name] = load_buf
 
-        # One iovec list per buffer slot, built once. A block spans one segment
-        # per tensor, so rebuilding these per transfer cost len(gpu_caches)
-        # tensor slices plus .numpy() calls on every block.
-        self._slot_views = [
+        # Pre-built iovec views per slot (avoid per-transfer .numpy() calls)
+        self._store_slot_views = [
             [
-                memoryview(self._buffer_caches[name][slot].numpy())
+                memoryview(self._store_buffer_caches[name][slot].numpy())
+                for name in self._tensor_names
+            ]
+            for slot in range(num_buffer_slots)
+        ]
+        self._load_slot_views = [
+            [
+                memoryview(self._load_buffer_caches[name][slot].numpy())
                 for name in self._tensor_names
             ]
             for slot in range(num_buffer_slots)
@@ -110,38 +131,51 @@ class DiskBackend:
 
         self._store_params = build_params(
             gpu_caches,
-            self._buffer_caches,
+            self._store_buffer_caches,
             store_stream,
             src_access_order=CU_MEMCPY_SRC_ACCESS_ORDER_STREAM,
         )
         self._load_params = build_params(
-            self._buffer_caches,
+            self._load_buffer_caches,
             gpu_caches,
             load_stream,
             src_access_order=CU_MEMCPY_SRC_ACCESS_ORDER_ANY,
         )
 
         os.makedirs(os.path.dirname(disk_path) or ".", exist_ok=True)
-        self._fd = os.open(
-            disk_path, os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW | O_DIRECT, 0o600
-        )
+        # O_DIRECT by default: page cache would consume the very host DRAM this
+        # backend exists to conserve, and doubles the copy on the store path.
+        flags = os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW
+        if not use_page_cache:
+            flags |= O_DIRECT
+        self._fd = os.open(disk_path, flags, 0o600)
         os.ftruncate(self._fd, num_disk_slots * total_block_bytes)
 
         logger.info(
-            "DiskBackend: path=%s, slots=%d, total=%.2f GB, buf=%dx%d bytes",
+            "DiskBackend: path=%s, slots=%d, total=%.2f GB, buf=%dx%d bytes"
+            " (page_cache=%s)",
             disk_path,
             num_disk_slots,
             (num_disk_slots * total_block_bytes) / (1024**3),
             num_buffer_slots,
             total_block_bytes,
+            use_page_cache,
         )
 
-        self._thread = threading.Thread(
-            target=self._io_loop,
-            args=(device, load_stream, store_stream),
+        self._store_queue = queue.SimpleQueue()
+        self._load_queue = queue.SimpleQueue()
+        self._store_thread = threading.Thread(
+            target=self._store_loop,
+            args=(device, store_stream),
             daemon=True,
         )
-        self._thread.start()
+        self._load_thread = threading.Thread(
+            target=self._load_loop,
+            args=(device, load_stream),
+            daemon=True,
+        )
+        self._store_thread.start()
+        self._load_thread.start()
 
     def launch_copy(
         self,
@@ -152,59 +186,46 @@ class DiskBackend:
         events_list: list[tuple[int, torch.Event]],
         wait_event: torch.Event | None = None,
     ) -> None:
-        item = (src_blocks, dst_blocks, is_store, event_idx, events_list, wait_event)
-        with self._cond:
-            (self._store_q if is_store else self._load_q).append(item)
-            self._cond.notify()
+        q = self._store_queue if is_store else self._load_queue
+        assert q is not None
+        q.put((src_blocks, dst_blocks, event_idx, events_list, wait_event))
 
     def shutdown(self) -> None:
         if self._shutdown:
             return
-        with self._cond:
-            self._shutdown = True
-            self._cond.notify_all()
-        if self._thread is not None:
-            self._thread.join(timeout=10.0)
+        self._shutdown = True
+        if self._store_queue is not None:
+            self._store_queue.put(None)
+        if self._load_queue is not None:
+            self._load_queue.put(None)
+        if self._store_thread is not None:
+            self._store_thread.join(timeout=10.0)
+        if self._load_thread is not None:
+            self._load_thread.join(timeout=10.0)
         if self._fd >= 0:
             os.close(self._fd)
             self._fd = -1
 
-    def _io_loop(
+    def _store_loop(
         self,
         device: torch.device,
-        load_stream: torch.cuda.Stream,
-        store_stream: torch.cuda.Stream,
+        stream: torch.cuda.Stream,
     ) -> None:
         current_platform.set_device(device)
         while True:
-            with self._cond:
-                self._cond.wait_for(
-                    lambda: self._shutdown or self._load_q or self._store_q
-                )
-                if self._shutdown:
-                    return
-                q = self._load_q if self._load_q else self._store_q
-                (
-                    src_blocks,
-                    dst_blocks,
-                    is_store,
-                    event_idx,
-                    events_list,
-                    wait_event,
-                ) = q.popleft()
-            stream = store_stream if is_store else load_stream
+            item = self._store_queue.get()
+            if item is None:
+                return
+            (src_blocks, dst_blocks, event_idx, events_list, wait_event) = item
             if wait_event is not None:
                 stream.wait_event(wait_event)
-            if is_store:
-                self._do_store(src_blocks, dst_blocks, stream)
-            else:
-                self._do_load(src_blocks, dst_blocks, stream)
+            self._do_store(src_blocks, dst_blocks, stream)
             event = torch.Event()
             event.record(stream)
             events_list.append((event_idx, event))
 
     def _writev_slot(self, buf_slot: int, file_offset: int) -> None:
-        written = os.pwritev(self._fd, self._slot_views[buf_slot], file_offset)
+        written = os.pwritev(self._fd, self._store_slot_views[buf_slot], file_offset)
         if written < self._total_block_bytes:
             raise OSError(
                 f"Short write: expected {self._total_block_bytes} bytes, "
@@ -212,12 +233,30 @@ class DiskBackend:
             )
 
     def _readv_slot(self, buf_slot: int, file_offset: int) -> None:
-        bytes_read = os.preadv(self._fd, self._slot_views[buf_slot], file_offset)
+        bytes_read = os.preadv(self._fd, self._load_slot_views[buf_slot], file_offset)
         if bytes_read < self._total_block_bytes:
             raise OSError(
                 f"Short read: expected {self._total_block_bytes} bytes, "
                 f"read {bytes_read}"
             )
+
+    def _load_loop(
+        self,
+        device: torch.device,
+        stream: torch.cuda.Stream,
+    ) -> None:
+        current_platform.set_device(device)
+        while True:
+            item = self._load_queue.get()
+            if item is None:
+                return
+            (src_blocks, dst_blocks, event_idx, events_list, wait_event) = item
+            if wait_event is not None:
+                stream.wait_event(wait_event)
+            self._do_load(src_blocks, dst_blocks, stream)
+            event = torch.Event()
+            event.record(stream)
+            events_list.append((event_idx, event))
 
     def _do_store(
         self,
@@ -225,11 +264,7 @@ class DiskBackend:
         disk_slots: list[int],
         stream: torch.cuda.Stream,
     ) -> None:
-        """GPU → buffer (DMA) → disk (writev), double-buffered.
-
-        Pipeline: launch DMA into slot A, then while writing slot B to
-        disk the GPU can DMA into slot A in parallel.
-        """
+        """GPU -> buffer (DMA) -> disk (pwritev), interleaved double-buffer."""
         assert self._store_params is not None
         n = self._num_buffer_slots
         dma_events: list[torch.Event | None] = [None] * n
@@ -259,7 +294,7 @@ class DiskBackend:
         gpu_blocks: list[int],
         stream: torch.cuda.Stream,
     ) -> None:
-        """Disk (preadv) → buffer → GPU (DMA), double-buffered."""
+        """Disk (preadv) -> buffer -> GPU (DMA), interleaved double-buffer."""
         assert self._load_params is not None
         n = self._num_buffer_slots
         prev_dma_events: list[torch.Event | None] = [None] * n

--- a/vllm/v1/simple_kv_offload/disk_backend.py
+++ b/vllm/v1/simple_kv_offload/disk_backend.py
@@ -69,6 +69,7 @@ class DiskBackend:
         self._load_thread: threading.Thread | None = None
         self._shutdown: bool = False
         self._fd: int = -1
+        self._disk_path: str = ""
         self._total_block_bytes: int = 0
         self._store_buffer_caches: dict[str, torch.Tensor] = {}
         self._load_buffer_caches: dict[str, torch.Tensor] = {}
@@ -155,6 +156,7 @@ class DiskBackend:
         if not use_page_cache:
             flags |= O_DIRECT
         self._fd = os.open(disk_path, flags, 0o600)
+        self._disk_path = disk_path
         os.ftruncate(self._fd, num_disk_slots * total_block_bytes)
 
         logger.info(
@@ -205,6 +207,13 @@ class DiskBackend:
             self._load_thread.join(timeout=10.0)
         if self._fd < 0:
             return
+        # Slot contents can encode user prompts, so drop the name now rather
+        # than leaving them readable until the next run overwrites the file.
+        # Unlinking only removes the directory entry: any thread still holding
+        # the fd keeps writing to the (now anonymous) inode, which the kernel
+        # frees once the last fd goes away.
+        with contextlib.suppress(OSError):
+            os.unlink(self._disk_path)
         # Closing under a still-running IO thread would let the fd number be
         # reused by an unrelated open(), turning its next pwritev into a write
         # into that file. Leaking one fd for the remaining process lifetime is

--- a/vllm/v1/simple_kv_offload/disk_backend.py
+++ b/vllm/v1/simple_kv_offload/disk_backend.py
@@ -5,8 +5,8 @@
 from __future__ import annotations
 
 import os
-import queue
 import threading
+from collections import deque
 
 import torch
 
@@ -52,12 +52,17 @@ class DiskBackend:
         self._load_params: BatchMemcpyParams | None = None
         self._load_stream: torch.cuda.Stream | None = None
         self._store_stream: torch.cuda.Stream | None = None
-        self._queue: queue.SimpleQueue | None = None
+        # Loads are latency-critical (a request is waiting on them) while stores
+        # are background work, so they get separate queues and loads win.
+        self._load_q: deque = deque()
+        self._store_q: deque = deque()
+        self._cond = threading.Condition()
         self._thread: threading.Thread | None = None
         self._shutdown: bool = False
         self._fd: int = -1
         self._total_block_bytes: int = 0
         self._buffer_caches: dict[str, torch.Tensor] = {}
+        self._slot_views: list[list[memoryview]] = []
         self._per_tensor_bpb: list[int] = []
         self._tensor_names: list[str] = []
 
@@ -92,6 +97,17 @@ class DiskBackend:
             pin_tensor(buf)
             self._buffer_caches[name] = buf
 
+        # One iovec list per buffer slot, built once. A block spans one segment
+        # per tensor, so rebuilding these per transfer cost len(gpu_caches)
+        # tensor slices plus .numpy() calls on every block.
+        self._slot_views = [
+            [
+                memoryview(self._buffer_caches[name][slot].numpy())
+                for name in self._tensor_names
+            ]
+            for slot in range(num_buffer_slots)
+        ]
+
         self._store_params = build_params(
             gpu_caches,
             self._buffer_caches,
@@ -120,10 +136,9 @@ class DiskBackend:
             total_block_bytes,
         )
 
-        self._queue = queue.SimpleQueue()
         self._thread = threading.Thread(
             target=self._io_loop,
-            args=(self._queue, device, load_stream, store_stream),
+            args=(device, load_stream, store_stream),
             daemon=True,
         )
         self._thread.start()
@@ -137,24 +152,17 @@ class DiskBackend:
         events_list: list[tuple[int, torch.Event]],
         wait_event: torch.Event | None = None,
     ) -> None:
-        assert self._queue is not None
-        self._queue.put(
-            (
-                src_blocks,
-                dst_blocks,
-                is_store,
-                event_idx,
-                events_list,
-                wait_event,
-            )
-        )
+        item = (src_blocks, dst_blocks, is_store, event_idx, events_list, wait_event)
+        with self._cond:
+            (self._store_q if is_store else self._load_q).append(item)
+            self._cond.notify()
 
     def shutdown(self) -> None:
         if self._shutdown:
             return
-        self._shutdown = True
-        if self._queue is not None:
-            self._queue.put(None)
+        with self._cond:
+            self._shutdown = True
+            self._cond.notify_all()
         if self._thread is not None:
             self._thread.join(timeout=10.0)
         if self._fd >= 0:
@@ -163,19 +171,27 @@ class DiskBackend:
 
     def _io_loop(
         self,
-        q: queue.SimpleQueue,
         device: torch.device,
         load_stream: torch.cuda.Stream,
         store_stream: torch.cuda.Stream,
     ) -> None:
         current_platform.set_device(device)
         while True:
-            item = q.get()
-            if item is None:
-                return
-            (src_blocks, dst_blocks, is_store, event_idx, events_list, wait_event) = (
-                item
-            )
+            with self._cond:
+                self._cond.wait_for(
+                    lambda: self._shutdown or self._load_q or self._store_q
+                )
+                if self._shutdown:
+                    return
+                q = self._load_q if self._load_q else self._store_q
+                (
+                    src_blocks,
+                    dst_blocks,
+                    is_store,
+                    event_idx,
+                    events_list,
+                    wait_event,
+                ) = q.popleft()
             stream = store_stream if is_store else load_stream
             if wait_event is not None:
                 stream.wait_event(wait_event)
@@ -188,10 +204,7 @@ class DiskBackend:
             events_list.append((event_idx, event))
 
     def _writev_slot(self, buf_slot: int, file_offset: int) -> None:
-        bufs = [
-            self._buffer_caches[name][buf_slot].numpy() for name in self._tensor_names
-        ]
-        written = os.pwritev(self._fd, bufs, file_offset)
+        written = os.pwritev(self._fd, self._slot_views[buf_slot], file_offset)
         if written < self._total_block_bytes:
             raise OSError(
                 f"Short write: expected {self._total_block_bytes} bytes, "
@@ -199,11 +212,7 @@ class DiskBackend:
             )
 
     def _readv_slot(self, buf_slot: int, file_offset: int) -> None:
-        views = [
-            memoryview(self._buffer_caches[name][buf_slot].numpy())
-            for name in self._tensor_names
-        ]
-        bytes_read = os.preadv(self._fd, views, file_offset)
+        bytes_read = os.preadv(self._fd, self._slot_views[buf_slot], file_offset)
         if bytes_read < self._total_block_bytes:
             raise OSError(
                 f"Short read: expected {self._total_block_bytes} bytes, "

--- a/vllm/v1/simple_kv_offload/disk_backend.py
+++ b/vllm/v1/simple_kv_offload/disk_backend.py
@@ -1,0 +1,268 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Disk I/O backend for GPU<->NVMe block transfers via pinned double buffer."""
+
+from __future__ import annotations
+
+import os
+import queue
+import threading
+
+import torch
+
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+from vllm.v1.simple_kv_offload.cuda_mem_ops import (
+    CU_MEMCPY_SRC_ACCESS_ORDER_ANY,
+    CU_MEMCPY_SRC_ACCESS_ORDER_STREAM,
+    BatchMemcpyParams,
+    build_params,
+    copy_blocks,
+    pin_tensor,
+)
+
+logger = init_logger(__name__)
+
+O_DIRECT = getattr(os, "O_DIRECT", 0)
+_ALIGNMENT = 4096
+
+
+def _alloc_aligned(num_slots: int, bpb: int) -> torch.Tensor:
+    """Allocate a staging buffer whose base address is O_DIRECT aligned.
+
+    The CPU allocator only guarantees 64-byte alignment, so over-allocate by
+    one alignment unit and return an aligned view. The view keeps the backing
+    storage alive.
+    """
+    nbytes = num_slots * bpb
+    raw = torch.zeros(nbytes + _ALIGNMENT, dtype=torch.int8, device="cpu")
+    offset = -raw.data_ptr() % _ALIGNMENT
+    return raw[offset : offset + nbytes].view(num_slots, bpb)
+
+
+class DiskBackend:
+    """Async disk offload backend with GPU DMA pipeline and double buffering.
+
+    Same launch_copy interface as DmaCopyBackend so the worker can swap
+    backends without changing calling code.
+    """
+
+    def __init__(self) -> None:
+        self._store_params: BatchMemcpyParams | None = None
+        self._load_params: BatchMemcpyParams | None = None
+        self._load_stream: torch.cuda.Stream | None = None
+        self._store_stream: torch.cuda.Stream | None = None
+        self._queue: queue.SimpleQueue | None = None
+        self._thread: threading.Thread | None = None
+        self._shutdown: bool = False
+        self._fd: int = -1
+        self._total_block_bytes: int = 0
+        self._buffer_caches: dict[str, torch.Tensor] = {}
+        self._per_tensor_bpb: list[int] = []
+        self._tensor_names: list[str] = []
+
+    def init(
+        self,
+        gpu_caches: dict[str, torch.Tensor],
+        device: torch.device,
+        load_stream: torch.cuda.Stream,
+        store_stream: torch.cuda.Stream,
+        disk_path: str,
+        num_disk_slots: int,
+        total_block_bytes: int,
+        num_buffer_slots: int = 2,
+    ) -> None:
+        self._load_stream = load_stream
+        self._store_stream = store_stream
+        self._total_block_bytes = total_block_bytes
+        self._num_buffer_slots = num_buffer_slots
+        self._tensor_names = list(gpu_caches.keys())
+        self._per_tensor_bpb = [
+            t.stride(0) * t.element_size() for t in gpu_caches.values()
+        ]
+
+        assert total_block_bytes % _ALIGNMENT == 0, (
+            f"total_block_bytes={total_block_bytes} not aligned to {_ALIGNMENT}"
+        )
+
+        self._buffer_caches = {}
+        for name, gpu_t in gpu_caches.items():
+            bpb = gpu_t.stride(0) * gpu_t.element_size()
+            buf = _alloc_aligned(num_buffer_slots, bpb)
+            pin_tensor(buf)
+            self._buffer_caches[name] = buf
+
+        self._store_params = build_params(
+            gpu_caches,
+            self._buffer_caches,
+            store_stream,
+            src_access_order=CU_MEMCPY_SRC_ACCESS_ORDER_STREAM,
+        )
+        self._load_params = build_params(
+            self._buffer_caches,
+            gpu_caches,
+            load_stream,
+            src_access_order=CU_MEMCPY_SRC_ACCESS_ORDER_ANY,
+        )
+
+        os.makedirs(os.path.dirname(disk_path) or ".", exist_ok=True)
+        self._fd = os.open(
+            disk_path, os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW | O_DIRECT, 0o600
+        )
+        os.ftruncate(self._fd, num_disk_slots * total_block_bytes)
+
+        logger.info(
+            "DiskBackend: path=%s, slots=%d, total=%.2f GB, buf=%dx%d bytes",
+            disk_path,
+            num_disk_slots,
+            (num_disk_slots * total_block_bytes) / (1024**3),
+            num_buffer_slots,
+            total_block_bytes,
+        )
+
+        self._queue = queue.SimpleQueue()
+        self._thread = threading.Thread(
+            target=self._io_loop,
+            args=(self._queue, device, load_stream, store_stream),
+            daemon=True,
+        )
+        self._thread.start()
+
+    def launch_copy(
+        self,
+        src_blocks: list[int],
+        dst_blocks: list[int],
+        is_store: bool,
+        event_idx: int,
+        events_list: list[tuple[int, torch.Event]],
+        wait_event: torch.Event | None = None,
+    ) -> None:
+        assert self._queue is not None
+        self._queue.put(
+            (
+                src_blocks,
+                dst_blocks,
+                is_store,
+                event_idx,
+                events_list,
+                wait_event,
+            )
+        )
+
+    def shutdown(self) -> None:
+        if self._shutdown:
+            return
+        self._shutdown = True
+        if self._queue is not None:
+            self._queue.put(None)
+        if self._thread is not None:
+            self._thread.join(timeout=10.0)
+        if self._fd >= 0:
+            os.close(self._fd)
+            self._fd = -1
+
+    def _io_loop(
+        self,
+        q: queue.SimpleQueue,
+        device: torch.device,
+        load_stream: torch.cuda.Stream,
+        store_stream: torch.cuda.Stream,
+    ) -> None:
+        current_platform.set_device(device)
+        while True:
+            item = q.get()
+            if item is None:
+                return
+            (src_blocks, dst_blocks, is_store, event_idx, events_list, wait_event) = (
+                item
+            )
+            stream = store_stream if is_store else load_stream
+            if wait_event is not None:
+                stream.wait_event(wait_event)
+            if is_store:
+                self._do_store(src_blocks, dst_blocks, stream)
+            else:
+                self._do_load(src_blocks, dst_blocks, stream)
+            event = torch.Event()
+            event.record(stream)
+            events_list.append((event_idx, event))
+
+    def _writev_slot(self, buf_slot: int, file_offset: int) -> None:
+        bufs = [
+            self._buffer_caches[name][buf_slot].numpy() for name in self._tensor_names
+        ]
+        written = os.pwritev(self._fd, bufs, file_offset)
+        if written < self._total_block_bytes:
+            raise OSError(
+                f"Short write: expected {self._total_block_bytes} bytes, "
+                f"wrote {written}"
+            )
+
+    def _readv_slot(self, buf_slot: int, file_offset: int) -> None:
+        views = [
+            memoryview(self._buffer_caches[name][buf_slot].numpy())
+            for name in self._tensor_names
+        ]
+        bytes_read = os.preadv(self._fd, views, file_offset)
+        if bytes_read < self._total_block_bytes:
+            raise OSError(
+                f"Short read: expected {self._total_block_bytes} bytes, "
+                f"read {bytes_read}"
+            )
+
+    def _do_store(
+        self,
+        gpu_blocks: list[int],
+        disk_slots: list[int],
+        stream: torch.cuda.Stream,
+    ) -> None:
+        """GPU → buffer (DMA) → disk (writev), double-buffered.
+
+        Pipeline: launch DMA into slot A, then while writing slot B to
+        disk the GPU can DMA into slot A in parallel.
+        """
+        assert self._store_params is not None
+        n = self._num_buffer_slots
+        dma_events: list[torch.Event | None] = [None] * n
+        pending_writes: list[int | None] = [None] * n
+
+        for i, (gpu_blk, disk_slot) in enumerate(zip(gpu_blocks, disk_slots)):
+            buf_slot = i % n
+            if dma_events[buf_slot] is not None:
+                dma_events[buf_slot].synchronize()
+            if pending_writes[buf_slot] is not None:
+                self._writev_slot(buf_slot, pending_writes[buf_slot])
+
+            copy_blocks([gpu_blk], [buf_slot], self._store_params)
+            ev = torch.Event()
+            ev.record(stream)
+            dma_events[buf_slot] = ev
+            pending_writes[buf_slot] = disk_slot * self._total_block_bytes
+
+        for slot in range(n):
+            if dma_events[slot] is not None and pending_writes[slot] is not None:
+                dma_events[slot].synchronize()
+                self._writev_slot(slot, pending_writes[slot])
+
+    def _do_load(
+        self,
+        disk_slots: list[int],
+        gpu_blocks: list[int],
+        stream: torch.cuda.Stream,
+    ) -> None:
+        """Disk (preadv) → buffer → GPU (DMA), double-buffered."""
+        assert self._load_params is not None
+        n = self._num_buffer_slots
+        prev_dma_events: list[torch.Event | None] = [None] * n
+
+        for i, (disk_slot, gpu_blk) in enumerate(zip(disk_slots, gpu_blocks)):
+            buf_slot = i % n
+            if prev_dma_events[buf_slot] is not None:
+                prev_dma_events[buf_slot].synchronize()
+
+            self._readv_slot(buf_slot, disk_slot * self._total_block_bytes)
+
+            copy_blocks([buf_slot], [gpu_blk], self._load_params)
+            ev = torch.Event()
+            ev.record(stream)
+            prev_dma_events[buf_slot] = ev

--- a/vllm/v1/simple_kv_offload/disk_backend.py
+++ b/vllm/v1/simple_kv_offload/disk_backend.py
@@ -9,6 +9,7 @@ staging buffers to avoid contention.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import queue
 import threading
@@ -62,8 +63,8 @@ class DiskBackend:
         self._load_params: BatchMemcpyParams | None = None
         self._load_stream: torch.cuda.Stream | None = None
         self._store_stream: torch.cuda.Stream | None = None
-        self._store_queue: queue.SimpleQueue | None = None
-        self._load_queue: queue.SimpleQueue | None = None
+        self._store_queue: queue.SimpleQueue = queue.SimpleQueue()
+        self._load_queue: queue.SimpleQueue = queue.SimpleQueue()
         self._store_thread: threading.Thread | None = None
         self._load_thread: threading.Thread | None = None
         self._shutdown: bool = False
@@ -143,9 +144,14 @@ class DiskBackend:
         )
 
         os.makedirs(os.path.dirname(disk_path) or ".", exist_ok=True)
+        # Slot contents never outlive the process, so unlink then O_EXCL rather
+        # than reopening: a pre-existing file would otherwise keep its own
+        # (possibly world-readable) mode, and blocks may encode user prompts.
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(disk_path)
         # O_DIRECT by default: page cache would consume the very host DRAM this
         # backend exists to conserve, and doubles the copy on the store path.
-        flags = os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW
+        flags = os.O_RDWR | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
         if not use_page_cache:
             flags |= O_DIRECT
         self._fd = os.open(disk_path, flags, 0o600)
@@ -162,8 +168,6 @@ class DiskBackend:
             use_page_cache,
         )
 
-        self._store_queue = queue.SimpleQueue()
-        self._load_queue = queue.SimpleQueue()
         self._store_thread = threading.Thread(
             target=self._store_loop,
             args=(device, store_stream),
@@ -187,24 +191,35 @@ class DiskBackend:
         wait_event: torch.Event | None = None,
     ) -> None:
         q = self._store_queue if is_store else self._load_queue
-        assert q is not None
         q.put((src_blocks, dst_blocks, event_idx, events_list, wait_event))
 
     def shutdown(self) -> None:
         if self._shutdown:
             return
         self._shutdown = True
-        if self._store_queue is not None:
-            self._store_queue.put(None)
-        if self._load_queue is not None:
-            self._load_queue.put(None)
+        self._store_queue.put(None)
+        self._load_queue.put(None)
         if self._store_thread is not None:
             self._store_thread.join(timeout=10.0)
         if self._load_thread is not None:
             self._load_thread.join(timeout=10.0)
-        if self._fd >= 0:
-            os.close(self._fd)
-            self._fd = -1
+        if self._fd < 0:
+            return
+        # Closing under a still-running IO thread would let the fd number be
+        # reused by an unrelated open(), turning its next pwritev into a write
+        # into that file. Leaking one fd for the remaining process lifetime is
+        # the cheaper failure.
+        if any(
+            t is not None and t.is_alive()
+            for t in (self._store_thread, self._load_thread)
+        ):
+            logger.warning(
+                "IO thread still running after shutdown timeout; leaking fd %d",
+                self._fd,
+            )
+            return
+        os.close(self._fd)
+        self._fd = -1
 
     def _store_loop(
         self,
@@ -267,26 +282,25 @@ class DiskBackend:
         """GPU -> buffer (DMA) -> disk (pwritev), interleaved double-buffer."""
         assert self._store_params is not None
         n = self._num_buffer_slots
-        dma_events: list[torch.Event | None] = [None] * n
-        pending_writes: list[int | None] = [None] * n
+        # (DMA event, file offset) of the block already staged in each slot.
+        pending: list[tuple[torch.Event, int] | None] = [None] * n
 
         for i, (gpu_blk, disk_slot) in enumerate(zip(gpu_blocks, disk_slots)):
             buf_slot = i % n
-            if dma_events[buf_slot] is not None:
-                dma_events[buf_slot].synchronize()
-            if pending_writes[buf_slot] is not None:
-                self._writev_slot(buf_slot, pending_writes[buf_slot])
+            prev = pending[buf_slot]
+            if prev is not None:
+                prev[0].synchronize()
+                self._writev_slot(buf_slot, prev[1])
 
             copy_blocks([gpu_blk], [buf_slot], self._store_params)
             ev = torch.Event()
             ev.record(stream)
-            dma_events[buf_slot] = ev
-            pending_writes[buf_slot] = disk_slot * self._total_block_bytes
+            pending[buf_slot] = (ev, disk_slot * self._total_block_bytes)
 
-        for slot in range(n):
-            if dma_events[slot] is not None and pending_writes[slot] is not None:
-                dma_events[slot].synchronize()
-                self._writev_slot(slot, pending_writes[slot])
+        for slot, last in enumerate(pending):
+            if last is not None:
+                last[0].synchronize()
+                self._writev_slot(slot, last[1])
 
     def _do_load(
         self,
@@ -301,8 +315,9 @@ class DiskBackend:
 
         for i, (disk_slot, gpu_blk) in enumerate(zip(disk_slots, gpu_blocks)):
             buf_slot = i % n
-            if prev_dma_events[buf_slot] is not None:
-                prev_dma_events[buf_slot].synchronize()
+            prev = prev_dma_events[buf_slot]
+            if prev is not None:
+                prev.synchronize()
 
             self._readv_slot(buf_slot, disk_slot * self._total_block_bytes)
 

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -75,9 +75,14 @@ class SimpleCPUOffloadScheduler:
         scheduler_block_size: int,
         hash_block_size: int,
         lazy_offload: bool = False,
+        disk_capacity_bytes: int = 0,
     ):
         self.vllm_config = vllm_config
         self.kv_cache_config = kv_cache_config
+        # When disk mode is active, the offload pool size is disk-based.
+        offload_capacity = (
+            disk_capacity_bytes if disk_capacity_bytes > 0 else cpu_capacity_bytes
+        )
         self.enable_kv_cache_events = (
             vllm_config.kv_events_config is not None
             and vllm_config.kv_events_config.enable_kv_cache_events
@@ -90,7 +95,7 @@ class SimpleCPUOffloadScheduler:
         # Derive a CPU KVCacheConfig from the GPU config and build a coordinator
         assert kv_cache_config is not None
         self.cpu_kv_cache_config = self._derive_cpu_config(
-            kv_cache_config, cpu_capacity_bytes
+            kv_cache_config, offload_capacity
         )
         self.num_cpu_blocks = self.cpu_kv_cache_config.num_blocks
         # Find the full attention kv group for prefix cache matching.
@@ -111,10 +116,12 @@ class SimpleCPUOffloadScheduler:
         assert self.block_size % self.fa_block_size == 0
 
         logger.info(
-            "SimpleCPUOffloadScheduler: Allocating %d CPU blocks (%.2f GB, mode=%s)",
+            "SimpleCPUOffloadScheduler: Allocating %d offload blocks "
+            "(%.2f GB, mode=%s, backend=%s)",
             self.num_cpu_blocks,
-            cpu_capacity_bytes / (1024**3),
+            offload_capacity / (1024**3),
             "lazy" if lazy_offload else "eager",
+            "disk" if disk_capacity_bytes > 0 else "cpu",
         )
 
         spec_config = vllm_config.speculative_config

--- a/vllm/v1/simple_kv_offload/worker.py
+++ b/vllm/v1/simple_kv_offload/worker.py
@@ -11,6 +11,7 @@ from vllm.logger import init_logger
 from vllm.utils.torch_utils import PIN_MEMORY
 from vllm.v1.simple_kv_offload.copy_backend import DmaCopyBackend
 from vllm.v1.simple_kv_offload.cuda_mem_ops import pin_tensor
+from vllm.v1.simple_kv_offload.disk_backend import DiskBackend
 from vllm.v1.simple_kv_offload.metadata import (
     SimpleCPUOffloadMetadata,
     SimpleCPUOffloadWorkerMetadata,
@@ -30,10 +31,17 @@ class SimpleCPUOffloadWorker:
         vllm_config: VllmConfig,
         kv_cache_config: "KVCacheConfig | None",
         cpu_capacity_bytes: int,
+        disk_path: str | None = None,
+        disk_capacity_bytes: int = 0,
+        disk_buffer_slots: int = 2,
     ):
         self.vllm_config = vllm_config
         self.kv_cache_config = kv_cache_config
         self.cpu_capacity_bytes = cpu_capacity_bytes
+        self.disk_path = disk_path
+        self.disk_capacity_bytes = disk_capacity_bytes
+        self.disk_buffer_slots = disk_buffer_slots
+        self.disk_mode = disk_path is not None
 
         self.gpu_kv_caches: dict[str, torch.Tensor] | None = None
         self.cpu_kv_caches: dict[str, torch.Tensor] | None = None
@@ -44,7 +52,7 @@ class SimpleCPUOffloadWorker:
         self.load_stream: torch.cuda.Stream | None = None
         self.store_stream: torch.cuda.Stream | None = None
 
-        self._backend = DmaCopyBackend()
+        self._backend: DmaCopyBackend | DiskBackend | None = None
 
         # Ordered (event_idx, Event). Events pre-allocated on main thread.
         self._load_events: list[tuple[int, torch.Event]] = []
@@ -145,9 +153,55 @@ class SimpleCPUOffloadWorker:
 
         self.num_cpu_blocks = max(1, self.cpu_capacity_bytes // total_bytes_per_block)
 
+        # Use lowest priority so KV cache I/O yields to compute streams.
+        low_pri, _ = torch.cuda.Stream.priority_range()
+        self.load_stream = torch.cuda.Stream(priority=low_pri)
+        self.store_stream = torch.cuda.Stream(priority=low_pri)
+
+        self.gpu_kv_caches = unique_gpu_caches
+
+        if self.disk_mode:
+            self._init_disk_mode(unique_gpu_caches, total_bytes_per_block)
+        else:
+            self._init_cpu_mode(unique_gpu_caches, total_bytes_per_block)
+
+    def _init_disk_mode(
+        self,
+        unique_gpu_caches: dict[str, torch.Tensor],
+        total_bytes_per_block: int,
+    ) -> None:
+        num_disk_slots = max(1, self.disk_capacity_bytes // total_bytes_per_block)
+        self.num_cpu_blocks = num_disk_slots
+
         logger.info(
-            "SimpleCPUOffloadWorker: %d unique GPU KV tensors, "
-            "allocating %d CPU blocks (%.2f GB)",
+            "SimpleCPUOffloadWorker [DISK]: %d tensors, %d disk slots (%.2f GB)",
+            len(unique_gpu_caches),
+            num_disk_slots,
+            (num_disk_slots * total_bytes_per_block) / (1024**3),
+        )
+
+        assert self.disk_path is not None
+        local_rank = self.device.index or 0
+        rank_path = f"{self.disk_path}.rank_{local_rank}"
+        self._backend = DiskBackend()
+        self._backend.init(
+            unique_gpu_caches,
+            self.device,
+            self.load_stream,
+            self.store_stream,
+            rank_path,
+            num_disk_slots,
+            total_bytes_per_block,
+            self.disk_buffer_slots,
+        )
+
+    def _init_cpu_mode(
+        self,
+        unique_gpu_caches: dict[str, torch.Tensor],
+        total_bytes_per_block: int,
+    ) -> None:
+        logger.info(
+            "SimpleCPUOffloadWorker [CPU]: %d tensors, %d CPU blocks (%.2f GB)",
             len(unique_gpu_caches),
             self.num_cpu_blocks,
             (self.num_cpu_blocks * total_bytes_per_block) / (1024**3),
@@ -159,7 +213,6 @@ class SimpleCPUOffloadWorker:
                 "Pinned memory not available. CPU offload performance may be degraded."
             )
 
-        self.gpu_kv_caches = unique_gpu_caches
         self.cpu_kv_caches = {}
         for name, gpu_tensor in unique_gpu_caches.items():
             cpu_shape = (self.num_cpu_blocks,) + gpu_tensor.shape[1:]
@@ -171,12 +224,7 @@ class SimpleCPUOffloadWorker:
                 pin_tensor(tensor)
             self.cpu_kv_caches[name] = tensor
 
-        # Use lowest priority so KV cache I/O yields to compute streams.
-        low_pri, _ = torch.cuda.Stream.priority_range()
-        self.load_stream = torch.cuda.Stream(priority=low_pri)
-        self.store_stream = torch.cuda.Stream(priority=low_pri)
-
-        # Initialize copy backend with caches and streams.
+        self._backend = DmaCopyBackend()
         self._backend.init(
             self.gpu_kv_caches,
             self.cpu_kv_caches,

--- a/vllm/v1/simple_kv_offload/worker.py
+++ b/vllm/v1/simple_kv_offload/worker.py
@@ -34,6 +34,7 @@ class SimpleCPUOffloadWorker:
         disk_path: str | None = None,
         disk_capacity_bytes: int = 0,
         disk_buffer_slots: int = 2,
+        use_page_cache: bool = False,
     ):
         self.vllm_config = vllm_config
         self.kv_cache_config = kv_cache_config
@@ -41,6 +42,7 @@ class SimpleCPUOffloadWorker:
         self.disk_path = disk_path
         self.disk_capacity_bytes = disk_capacity_bytes
         self.disk_buffer_slots = disk_buffer_slots
+        self.use_page_cache = use_page_cache
         self.disk_mode = disk_path is not None
 
         self.gpu_kv_caches: dict[str, torch.Tensor] | None = None
@@ -193,6 +195,7 @@ class SimpleCPUOffloadWorker:
             num_disk_slots,
             total_bytes_per_block,
             self.disk_buffer_slots,
+            self.use_page_cache,
         )
 
     def _init_cpu_mode(

--- a/vllm/v1/simple_kv_offload/worker.py
+++ b/vllm/v1/simple_kv_offload/worker.py
@@ -31,6 +31,7 @@ class SimpleCPUOffloadWorker:
         vllm_config: VllmConfig,
         kv_cache_config: "KVCacheConfig | None",
         cpu_capacity_bytes: int,
+        kv_offload_backend: str = "cpu",
         disk_path: str | None = None,
         disk_capacity_bytes: int = 0,
         disk_buffer_slots: int = 2,
@@ -43,7 +44,7 @@ class SimpleCPUOffloadWorker:
         self.disk_capacity_bytes = disk_capacity_bytes
         self.disk_buffer_slots = disk_buffer_slots
         self.use_page_cache = use_page_cache
-        self.disk_mode = disk_path is not None
+        self.disk_mode = kv_offload_backend == "disk"
 
         self.gpu_kv_caches: dict[str, torch.Tensor] | None = None
         self.cpu_kv_caches: dict[str, torch.Tensor] | None = None

--- a/vllm/v1/simple_kv_offload/worker.py
+++ b/vllm/v1/simple_kv_offload/worker.py
@@ -163,14 +163,15 @@ class SimpleCPUOffloadWorker:
         self.gpu_kv_caches = unique_gpu_caches
 
         if self.disk_mode:
-            self._init_disk_mode(unique_gpu_caches, total_bytes_per_block)
+            self._init_disk_mode(unique_gpu_caches, total_bytes_per_block, self.device)
         else:
-            self._init_cpu_mode(unique_gpu_caches, total_bytes_per_block)
+            self._init_cpu_mode(unique_gpu_caches, total_bytes_per_block, self.device)
 
     def _init_disk_mode(
         self,
         unique_gpu_caches: dict[str, torch.Tensor],
         total_bytes_per_block: int,
+        device: torch.device,
     ) -> None:
         num_disk_slots = max(1, self.disk_capacity_bytes // total_bytes_per_block)
         self.num_cpu_blocks = num_disk_slots
@@ -183,12 +184,11 @@ class SimpleCPUOffloadWorker:
         )
 
         assert self.disk_path is not None
-        local_rank = self.device.index or 0
-        rank_path = f"{self.disk_path}.rank_{local_rank}"
+        rank_path = f"{self.disk_path}.rank_{device.index or 0}"
         self._backend = DiskBackend()
         self._backend.init(
             unique_gpu_caches,
-            self.device,
+            device,
             self.load_stream,
             self.store_stream,
             rank_path,
@@ -202,6 +202,7 @@ class SimpleCPUOffloadWorker:
         self,
         unique_gpu_caches: dict[str, torch.Tensor],
         total_bytes_per_block: int,
+        device: torch.device,
     ) -> None:
         logger.info(
             "SimpleCPUOffloadWorker [CPU]: %d tensors, %d CPU blocks (%.2f GB)",
@@ -229,9 +230,9 @@ class SimpleCPUOffloadWorker:
 
         self._backend = DmaCopyBackend()
         self._backend.init(
-            self.gpu_kv_caches,
+            unique_gpu_caches,
             self.cpu_kv_caches,
-            self.device,
+            device,
             self.load_stream,
             self.store_stream,
         )
@@ -275,8 +276,10 @@ class SimpleCPUOffloadWorker:
         # (1) Submit transfers
         metadata = self._connector_metadata
         if metadata is not None:
+            backend = self._backend
+            assert backend is not None
             if metadata.load_cpu_blocks:
-                self._backend.launch_copy(
+                backend.launch_copy(
                     metadata.load_cpu_blocks,
                     metadata.load_gpu_blocks,
                     is_store=False,
@@ -287,7 +290,7 @@ class SimpleCPUOffloadWorker:
                 if self._store_compute_done is None:
                     self._store_compute_done = torch.Event()
                 self._store_compute_done.record(torch.cuda.current_stream())
-                self._backend.launch_copy(
+                backend.launch_copy(
                     metadata.store_gpu_blocks,
                     metadata.store_cpu_blocks,
                     is_store=True,


### PR DESCRIPTION
## Summary

Implements the disk backend extension envisioned in RFC #19854 (pluggable offloading backends). While #45036 provides SSD offload via the external Mooncake Store connector, this PR adds a **native vLLM disk offloading path** with zero external dependencies — targeting scenarios where host DRAM is limited but local NVMe capacity is abundant (e.g., dense inference nodes with most memory reserved for model weights).

When `kv_offload_backend` is set to `"disk"`, GPU KV blocks are DMA'd to a small pinned double buffer then written to a preallocated file using O_DIRECT `pwritev`/`preadv`. The scheduler tracks disk slots identically to CPU blocks (same BlockPool/LRU), requiring no metadata changes.

**Key design points:**
- Per-rank file path (`.rank_N`) to prevent TP data corruption
- Scatter-gather IO (`pwritev`/`preadv`) for O_DIRECT alignment
- True double-buffer pipeline: GPU DMA overlaps with disk IO
- Configurable buffer slots (`disk_buffer_slots`, default 2)
- Same `launch_copy` interface as `DmaCopyBackend` — zero changes to worker transfer logic

**Config example:**
```python
kv_connector_extra_config = {
    "kv_offload_backend": "disk",         # "cpu" (default) | "disk"
    "disk_path": "/mnt/nvme/kv_offload.bin",
    "disk_capacity_bytes": 107374182400,  # 100 GB
    "disk_buffer_slots": 4,
}
```

## Files changed
- `vllm/v1/simple_kv_offload/disk_backend.py` — new DiskBackend class (double-buffer + IO thread)
- `vllm/v1/simple_kv_offload/worker.py` — branch on disk mode in `register_kv_caches`
- `vllm/v1/simple_kv_offload/manager.py` — accept `disk_capacity_bytes` for slot count
- `simple_cpu_offload_connector.py` — parse new config keys, pass to scheduler/worker

## Test plan

### Benchmark environment

| Item | Details |
|------|---------|
| GPU | H100 80GB SXM |
| CPU | 2x Intel Xeon Gold 6530 (128 threads) |
| RAM | 128 GB DDR5 |
| NVMe | SOLIDIGM 1.7TB, ext4, O_DIRECT |
| CUDA | 12.8, PyTorch 2.11.0+cu128 |

**Model:** Qwen3.6-27B (64 layers: 48 linear attn + 16 full attn, ~64KB KV/token)

**Workload:** [Inferact/codex_swebenchpro_traces](https://huggingface.co/datasets/Inferact/codex_swebenchpro_traces) (610 conversations, avg 66.3 turns, shared 12K-token system prefix, max_tokens=30)

**Three phases:** Cold (no cache, pure prefill) → Warm (prefix hit from offload store) → Reload (GPU cache evicted, reload from offload backend)

### Results

| Phase | Metric | DRAM | Disk (4 buffer slots) | Speedup |
|-------|--------|------|----------------------|---------|
| Cold | TTFT P50 | 26.149s | 26.012s | — |
| Cold | Throughput | 9 tps | 9 tps | — |
| Warm | TTFT P50 | 3.505s | 3.152s | 1.1x |
| Warm | Throughput | 78 tps | 68 tps | — |
| **Reload** | **TTFT P50** | **15.831s** | **1.527s** | **10.4x** |
| **Reload** | **TTFT P95** | **26.097s** | **1.814s** | **14.4x** |
| **Reload** | **Throughput** | 10 tps | 85 tps | **8.5x** |

## AI Assistance Disclosure
This PR was developed with AI assistance (Claude). All code has been reviewed and understood by the human submitter.

This is not duplicating an existing PR — #45036 uses external Mooncake Store; this is a native vLLM implementation with zero dependencies.
