### PR TITLE
[Bugfix][Core] Propagate DBO padding through grouped top-k routing

### DIFF
--- a/tests/kernels/moe/test_grouped_topk.py
+++ b/tests/kernels/moe/test_grouped_topk.py
@@ -15,12 +15,53 @@ from vllm.config import (
     get_cached_compilation_config,
     set_current_vllm_config,
 )
+from vllm.forward_context import set_forward_context
+from vllm.model_executor.layers.fused_moe.router import (
+    grouped_topk_router as grouped_topk_module,
+)
 from vllm.model_executor.layers.fused_moe.router.grouped_topk_router import (
     GroupedTopk,
+    GroupedTopKRouter,
     fused_grouped_topk,
 )
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
+
+
+def test_grouped_topk_masks_padding(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(envs, "VLLM_MOE_SKIP_PADDING", True)
+    monkeypatch.setattr(
+        grouped_topk_module.rocm_aiter_ops,
+        "is_fused_moe_enabled",
+        lambda: False,
+    )
+    weights = torch.arange(10, dtype=torch.float32).reshape(5, 2)
+    ids = torch.arange(10, dtype=torch.int32).reshape(5, 2)
+    expected_ids = ids.clone()
+    is_padding = torch.tensor([False, False, False, True, True])
+    monkeypatch.setattr(
+        grouped_topk_module,
+        "grouped_topk",
+        lambda **_: (weights, ids),
+    )
+    router = GroupedTopKRouter(
+        top_k=2,
+        global_num_experts=4,
+        num_expert_group=2,
+        topk_group=1,
+    )
+
+    with set_forward_context(None, VllmConfig(), is_padding=is_padding):
+        masked_weights, masked_ids = router._compute_routing(
+            hidden_states=torch.zeros(5, 2),
+            router_logits=torch.zeros(5, 4),
+            indices_type=None,
+        )
+
+    torch.testing.assert_close(masked_weights, weights)
+    assert masked_ids is ids
+    torch.testing.assert_close(masked_ids[:3], expected_ids[:3])
+    assert torch.all(masked_ids[3:] == -1)
 
 
 @pytest.mark.skipif(

--- a/tests/v1/worker/test_gpu_ubatch_wrapper.py
+++ b/tests/v1/worker/test_gpu_ubatch_wrapper.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm.config import CUDAGraphMode
+from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+from vllm.v1.worker.gpu_ubatch_wrapper import _slice_is_padding
+
+
+def test_slice_is_padding_for_ubatch_context():
+    is_padding = torch.tensor([False, False, False, True, True])
+
+    torch.testing.assert_close(
+        _slice_is_padding(is_padding, slice(0, 3)),
+        torch.tensor([False, False, False]),
+    )
+    torch.testing.assert_close(
+        _slice_is_padding(is_padding, slice(3, 5)),
+        torch.tensor([True, True]),
+    )
+    assert _slice_is_padding(None, slice(0, 3)) is None
+
+
+def test_prepare_moe_padding_mask_only_when_needed():
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.use_moe_padding_mask = True
+    runner.is_padding = SimpleNamespace(gpu=torch.ones(8, dtype=torch.bool))
+
+    assert runner._prepare_moe_padding_mask(4, 4, CUDAGraphMode.NONE) is None
+    assert runner.is_padding.gpu.all()
+
+    mask = runner._prepare_moe_padding_mask(3, 6, CUDAGraphMode.NONE)
+    torch.testing.assert_close(
+        mask,
+        torch.tensor([False, False, False, True, True, True]),
+    )
+
+    # A captured graph must retain the mask pointer even when its dummy input
+    # has no padding; a later replay of the same shape may have padded rows.
+    mask = runner._prepare_moe_padding_mask(4, 4, CUDAGraphMode.FULL)
+    torch.testing.assert_close(mask, torch.zeros(4, dtype=torch.bool))
+
+    runner.use_moe_padding_mask = False
+    assert runner._prepare_moe_padding_mask(3, 6, CUDAGraphMode.FULL) is None

--- a/vllm/model_executor/layers/fused_moe/router/grouped_topk_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/grouped_topk_router.py
@@ -8,6 +8,7 @@ from vllm import _custom_ops as ops
 from vllm import envs as envs
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.distributed.eplb.eplb_state import EplbLayerState
+from vllm.forward_context import get_forward_context, is_forward_context_available
 from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.layers.fused_moe.config import (
     RoutingMethodType,
@@ -23,6 +24,17 @@ from vllm.model_executor.layers.fused_moe.router.fused_topk_bias_router import (
 from vllm.model_executor.layers.fused_moe.router.fused_topk_router import fused_topk
 from vllm.model_executor.utils import maybe_disable_graph_partition
 from vllm.platforms import current_platform
+
+
+def _mask_padding(
+    topk_weights: torch.Tensor, topk_ids: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if envs.VLLM_MOE_SKIP_PADDING and is_forward_context_available():
+        is_padding = get_forward_context().is_padding
+        if is_padding is not None:
+            mask = is_padding[: topk_ids.shape[0]].unsqueeze(1)
+            topk_ids.masked_fill_(mask, -1)
+    return topk_weights, topk_ids
 
 
 def fused_grouped_topk(
@@ -321,7 +333,7 @@ class GroupedTopKRouter(BaseRouter):
                     renormalize=self.renormalize,
                     indices_type=indices_type,
                 )
-            return topk_weights, topk_ids
+            return _mask_padding(topk_weights, topk_ids)
 
         # Select grouped_topk implementation
         if rocm_aiter_ops.is_fused_moe_enabled():
@@ -346,4 +358,4 @@ class GroupedTopKRouter(BaseRouter):
             e_score_correction_bias=self.e_score_correction_bias,
         )
 
-        return topk_weights, topk_ids
+        return _mask_padding(topk_weights, topk_ids)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -475,6 +475,9 @@ class GPUModelRunner(
         parallel_config = self.parallel_config
         self.device = device
         self.dtype = self.model_config.dtype
+        self.use_moe_padding_mask = (
+            envs.VLLM_MOE_SKIP_PADDING and self.model_config.is_moe
+        )
 
         self.check_ep_fault = False
         if parallel_config.data_parallel_size > 1 and self.model_config.is_moe:
@@ -760,6 +763,12 @@ class GPUModelRunner(
 
         # Persistent buffers for CUDA graphs.
         self.input_ids = self._make_buffer(self.max_num_tokens, dtype=torch.int32)
+        # Persistent so CUDA graphs and DBO microbatches see a stable padding
+        # mask. The fused-MoE routers use this to avoid dispatching padding
+        # tokens as real work.
+        self.is_padding = self._make_buffer(
+            self.max_num_tokens, dtype=torch.bool, numpy=False
+        )
         self.positions = torch.zeros(
             self.max_num_tokens, dtype=torch.int64, device=self.device
         )
@@ -1043,6 +1052,26 @@ class GPUModelRunner(
             device=self.device,
             with_numpy=numpy,
         )
+
+    def _prepare_moe_padding_mask(
+        self,
+        num_tokens_unpadded: int,
+        num_tokens_padded: int,
+        cudagraph_mode: CUDAGraphMode,
+    ) -> torch.Tensor | None:
+        # A graph captured for a padded shape must retain the stable mask
+        # address even when its capture input happens to fill the whole shape.
+        # Eager, unpadded batches and dense models do not need the two fills or
+        # the downstream router masking operation.
+        if not self.use_moe_padding_mask or (
+            num_tokens_unpadded == num_tokens_padded
+            and cudagraph_mode is CUDAGraphMode.NONE
+        ):
+            return None
+
+        self.is_padding.gpu[:num_tokens_unpadded].fill_(False)
+        self.is_padding.gpu[num_tokens_unpadded:num_tokens_padded].fill_(True)
+        return self.is_padding.gpu[:num_tokens_padded]
 
     def _get_mamba_bufs(self) -> mamba_utils.MambaBuffers:
         # Only reachable on the ``mamba_cache_mode == "align"`` path.
@@ -4230,6 +4259,9 @@ class GPUModelRunner(
             )
 
             num_tokens_padded = batch_desc.num_tokens
+            is_padding = self._prepare_moe_padding_mask(
+                num_tokens_unpadded, num_tokens_padded, cudagraph_mode
+            )
             num_reqs_padded = (
                 batch_desc.num_reqs if batch_desc.num_reqs is not None else num_reqs
             )
@@ -4382,6 +4414,7 @@ class GPUModelRunner(
                 ubatch_slices=ubatch_slices_padded,
                 slot_mapping=slot_mappings,
                 skip_compiled=has_encoder_input,
+                is_padding=is_padding,
             ),
             record_function_or_nullcontext("gpu_model_runner: forward"),
             self.maybe_get_kv_connector_output(
@@ -5900,6 +5933,9 @@ class GPUModelRunner(
             )
 
         num_tokens_padded = batch_desc.num_tokens
+        is_padding = self._prepare_moe_padding_mask(
+            num_tokens_unpadded, num_tokens_padded, cudagraph_runtime_mode
+        )
         num_reqs_padded = (
             batch_desc.num_reqs if batch_desc.num_reqs is not None else num_reqs
         )
@@ -6077,6 +6113,7 @@ class GPUModelRunner(
                     batch_descriptor=batch_desc,
                     ubatch_slices=ubatch_slices_padded,
                     slot_mapping=slot_mappings,
+                    is_padding=is_padding,
                 ),
             ):
                 outputs = self.model(

--- a/vllm/v1/worker/gpu_ubatch_wrapper.py
+++ b/vllm/v1/worker/gpu_ubatch_wrapper.py
@@ -31,6 +31,12 @@ from vllm.v1.worker.ubatching import UBatchContext, make_ubatch_contexts
 logger = init_logger(__name__)
 
 
+def _slice_is_padding(
+    is_padding: torch.Tensor | None, token_slice: slice
+) -> torch.Tensor | None:
+    return is_padding[token_slice] if is_padding is not None else None
+
+
 def _cat_ubatch_outputs(
     sorted_results: list,
 ) -> "torch.Tensor | tuple[torch.Tensor, ...]":
@@ -353,6 +359,7 @@ class UBatchWrapper:
         dp_metadata,
         batch_descriptor,
         cudagraph_runtime_mode,
+        is_padding,
     ) -> list[UbatchMetadata]:
         # Create one forward context per ubatch
         forward_contexts = []
@@ -368,6 +375,7 @@ class UBatchWrapper:
                     batch_descriptor=batch_descriptor,
                     cudagraph_runtime_mode=cudagraph_runtime_mode,
                     slot_mapping=slot_mapping[i] if has_slot_mapping else None,
+                    is_padding=_slice_is_padding(is_padding, ubatch_slice.token_slice),
                 )
             )
 
@@ -506,6 +514,7 @@ class UBatchWrapper:
                 dp_metadata=ubatch_dp_metadata,
                 batch_descriptor=batch_descriptor,
                 cudagraph_runtime_mode=CUDAGraphMode.NONE,
+                is_padding=forward_context.is_padding,
             )
             with self.sm_control:
                 return self._capture_ubatches(ubatch_metadata, self.runnable)
@@ -532,6 +541,7 @@ class UBatchWrapper:
                 dp_metadata=ubatch_dp_metadata,
                 batch_descriptor=batch_descriptor,
                 cudagraph_runtime_mode=CUDAGraphMode.NONE,
+                is_padding=forward_context.is_padding,
             )
             with self.sm_control:
                 return self._run_ubatches(ubatch_metadata, self.runnable)


### PR DESCRIPTION
The Distributed Tests / DBO group on ROCm fails in [build 11147](https://buildkite.com/vllm/amd-ci/builds/11147/list?jid=019f8bae-0610-4768-8be3-65983033438f&tab=output) when DBO slicing loses the scheduler padding metadata. Grouped top-k can consequently route scheduler-added dummy rows as real expert work. This change maintains a stable padding mask, passes a zero-copy slice into each DBO microbatch context, and invalidates only padding IDs in place before MoE dispatch. In-place masking avoids an additional output-sized allocation, while future native and AITER grouped-top-k integration can fuse the mask into routing itself. No matching open PR was found in searches for grouped-top-k/DBO/MoE padding fixes.