### PR TITLE
[Bugfix][Spec Decode] Route dflash on Qwen3DSparkModel arch to dspark

### DIFF
--- a/tests/config/test_dflash_qwen3_dspark_routing.py
+++ b/tests/config/test_dflash_qwen3_dspark_routing.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression test for https://github.com/vllm-project/vllm/issues/49614.
+
+DeepSeek ships the same ``Qwen3DSparkModel`` architecture for both its DSpark
+(``markov_rank > 0``) and DFlash (``markov_rank == 0``) Qwen3 checkpoints.
+``method="dflash"`` on such a checkpoint must be routed to the DSpark path
+(``Qwen3DSparkForCausalLM`` serves both) rather than EAGLE-renamed to the
+unregistered ``DFlashQwen3DSparkModel``, which fails to load.
+"""
+
+import pytest
+
+from vllm.config.speculative import SpeculativeConfig
+
+route = SpeculativeConfig._route_self_contained_qwen3_dspark
+
+
+@pytest.mark.cpu_test
+def test_dflash_on_qwen3dspark_arch_routes_to_dspark():
+    assert (
+        route("dflash", ["Qwen3DSparkModel"], "deepseek-ai/dflash_qwen3_4b_block7")
+        == "dspark"
+    )
+
+
+@pytest.mark.cpu_test
+def test_explicit_dspark_is_unchanged():
+    assert (
+        route("dspark", ["Qwen3DSparkModel"], "deepseek-ai/dspark_qwen3_4b_block7")
+        == "dspark"
+    )
+
+
+@pytest.mark.cpu_test
+def test_standalone_dflash_arch_is_unchanged():
+    # A standalone DFlash checkpoint (DFlashDraftModel arch) keeps method="dflash"
+    # and its normal EAGLE-style arch handling.
+    assert route("dflash", ["DFlashDraftModel"], "z-lab/Qwen3.5-9B-DFlash") == "dflash"
+
+
+@pytest.mark.cpu_test
+def test_other_methods_are_unchanged():
+    assert route("eagle3", ["Qwen3DSparkModel"], "some/model") == "eagle3"

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -910,6 +910,15 @@ class SpeculativeConfig:
                         f"Unsupported speculative method: '{self.method}'"
                     )
 
+                # DeepSeek's self-contained Qwen3 drafts share one arch for the
+                # DSpark and DFlash variants; route a "dflash" method to DSpark so
+                # it is not EAGLE-renamed to an unregistered arch (issue #49614).
+                self.method = self._route_self_contained_qwen3_dspark(
+                    self.method,
+                    self.draft_model_config.architectures,
+                    self.draft_model_config.model,
+                )
+
                 # Replace hf_config for EAGLE draft_model
                 if self.method in ("eagle", "eagle3", "dflash"):
                     from vllm.transformers_utils.configs.eagle import EAGLEConfig
@@ -1048,6 +1057,35 @@ class SpeculativeConfig:
                     )
                 )
         return self
+
+    @staticmethod
+    def _route_self_contained_qwen3_dspark(
+        method: "SpeculativeMethod | None",
+        draft_architectures: list[str],
+        model_name: str,
+    ) -> "SpeculativeMethod | None":
+        """Pick the speculative method for DeepSeek's self-contained Qwen3 drafts.
+
+        DeepSeek ships the SAME ``Qwen3DSparkModel`` architecture for both the
+        DSpark (``markov_rank > 0``) and the DFlash (``markov_rank == 0``)
+        checkpoints, and ``Qwen3DSparkForCausalLM`` serves both (its Markov head
+        is a no-op at ``markov_rank == 0``). A ``method`` of ``"dflash"`` — set
+        explicitly or inferred from a ``"dflash"`` model name (e.g.
+        ``deepseek-ai/dflash_qwen3_4b_block7``) — would otherwise be EAGLE-renamed
+        to the unregistered ``"DFlashQwen3DSparkModel"`` and fail to load, so
+        route it to the DSpark path instead.
+
+        See https://github.com/vllm-project/vllm/issues/49614.
+        """
+        if method == "dflash" and "Qwen3DSparkModel" in draft_architectures:
+            logger.warning_once(
+                "Draft model %s ships the self-contained Qwen3DSparkModel "
+                "architecture; using method='dspark' (which serves both DSpark "
+                "and markov_rank==0 DFlash checkpoints) instead of 'dflash'.",
+                model_name,
+            )
+            return "dspark"
+        return method
 
     def _validate_suffix_decoding(self):
         if not has_arctic_inference():


### PR DESCRIPTION
DeepSeek's DFlash Qwen3 drafts (e.g. `deepseek-ai/dflash_qwen3_4b_block7`) ship the `Qwen3DSparkModel` arch with `markov_rank=0`. With `method="dflash"` — explicit or inferred from the `dflash_*` model name — vLLM EAGLE-renames the arch to the unregistered `DFlashQwen3DSparkModel` and crashes at load. Route these to the DSpark path, which already serves `markov_rank=0` as pure DFlash (its Markov head is a no-op).

Verified on vLLM 0.25.0 (`Qwen/Qwen3-4B` + `dflash_qwen3_4b_block7`): `method="dflash"` before = load crash; after = loads and drafts (acceptance length ~2.6). Adds a CPU unit test for the routing.

Fixes #49614.

🤖 Generated with [Claude Code](https://claude.com/claude-code)