### PR TITLE
[Docs] Fix broken anchor links in serving/pooling/MoE docs

### DIFF
--- a/docs/design/fused_moe_modular_kernel.md
+++ b/docs/design/fused_moe_modular_kernel.md
@@ -242,4 +242,4 @@ See [Fused MoE Kernel features](./moe_kernel_features.md#fused-moe-modular-all2a
 
 ## FusedMoEExpertsModular
 
-See [Fused MoE Kernel features](./moe_kernel_features.md#fused-moe-experts-kernels) for a list of all the available modular experts.
+See [Fused MoE Kernel features](./moe_kernel_features.md#fused-experts-kernels) for a list of all the available modular experts.

--- a/docs/models/pooling_models/README.md
+++ b/docs/models/pooling_models/README.md
@@ -184,7 +184,7 @@ Our online Server provides endpoints that correspond to the offline APIs:
     - [Classification API](classify.md#online-serving)(`/classify`)
 - Corresponding to `LLM.score`:
     - [Score API](scoring.md#score-api) (`/score`, `/v1/score`)
-    - [Cohere Rerank API](scoring.md#rerank-api) (`/rerank`, `/v1/rerank`, `/v2/rerank`)
+    - [Cohere Rerank API](scoring.md#cohere-rerank-api) (`/rerank`, `/v1/rerank`, `/v2/rerank`)
 - Pooling API (`/pooling`) is similar to `LLM.encode`, being applicable to all types of pooling models.
 
 The following introduces the Pooling API. For other APIs, please refer to the link above.

--- a/docs/models/pooling_models/scoring.md
+++ b/docs/models/pooling_models/scoring.md
@@ -20,7 +20,7 @@ The score models is designed to compute similarity scores between two input prom
     - `LLM.score`
 - Online APIs:
     - [Score API](scoring.md#score-api) (`/score`, `/v1/score`)
-    - [Cohere Rerank API](scoring.md#rerank-api) (`/rerank`, `/v1/rerank`, `/v2/rerank`)
+    - [Cohere Rerank API](scoring.md#cohere-rerank-api) (`/rerank`, `/v1/rerank`, `/v2/rerank`)
 
 !!! note
     Only when a classification model outputs num_labels equal to 1 can it be used as a scoring model and have its scoring API enabled.

--- a/docs/serving/online_serving/README.md
+++ b/docs/serving/online_serving/README.md
@@ -10,7 +10,7 @@ We currently support the following OpenAI APIs:
     - Only applicable to [text generation models](../../models/generative_models.md).
     - *Note: `suffix` parameter is not supported.*
 - [Chat Completions API](./openai_compatible_server.md#chat-api) (`/v1/chat/completions`)
-    - Only applicable to [text generation models](../../models/generative_models.md) with a [chat template](./openai_compatible_server.md#chat-template).
+    - Only applicable to [text generation models](../../models/generative_models.md) with a [chat template](#chat-template).
     - *Note: `user` parameter is ignored.*
     - *Note:* Setting the `parallel_tool_calls` parameter to `false` ensures vLLM only returns zero or one tool call per request. Setting it to `true` (the default) allows returning more than one tool call per request. There is no guarantee more than one tool call will be returned if this is set to `true`, as that behavior is model dependent and not all models are designed to support parallel tool calls.
 - [Chat Completions batch API](./openai_compatible_server.md#chat-api) (`/v1/chat/completions/batch`)
@@ -32,7 +32,7 @@ We currently support the following OpenAI APIs:
 - [Cohere Embed API](../../models/pooling_models/embed.md#cohere-embed-api) (`/v2/embed`)
     - Compatible with [Cohere's Embed API](https://docs.cohere.com/reference/embed)
     - Works with any [embedding model](../../models/pooling_models/embed.md#supported-models), including multimodal models.
-- [Cohere Rerank API](../../models/pooling_models/scoring.md#rerank-api) (`/rerank`, `/v1/rerank`, `/v2/rerank`)
+- [Cohere Rerank API](../../models/pooling_models/scoring.md#cohere-rerank-api) (`/rerank`, `/v1/rerank`, `/v2/rerank`)
     - Implements [Jina AI's v1 rerank API](https://jina.ai/reranker/)
     - compatible with [Cohere's v1 & v2 rerank APIs](https://docs.cohere.com/v2/reference/rerank)
 
@@ -49,7 +49,7 @@ For further details on pooling models, please refer to [this page](../../models/
     - Only applicable to [embedding models](../../models/pooling_models/embed.md).
 - [Scoring Usages](../../models/pooling_models/scoring.md)
     - [Score API](../../models/pooling_models/scoring.md#score-api) (`/score`, `/v1/score`)
-    - [Cohere Rerank API](../../models/pooling_models/scoring.md#rerank-api) (`/rerank`, `/v1/rerank`, `/v2/rerank`)
+    - [Cohere Rerank API](../../models/pooling_models/scoring.md#cohere-rerank-api) (`/rerank`, `/v1/rerank`, `/v2/rerank`)
     - Applicable to [score models](../../models/pooling_models/scoring.md) (cross-encoder, bi-encoder, late-interaction).
 - [Pooling API](../../models/pooling_models/README.md#pooling-api) (`/pooling`)
     - Applicable to all [pooling models](../../models/pooling_models/README.md).
@@ -73,7 +73,7 @@ For further details on speech to text, please refer to [this page](speech_to_tex
     - Applicable to [score models](../../models/pooling_models/scoring.md) (cross-encoder, bi-encoder, late-interaction).
 - [Pooling API](../../models/pooling_models/README.md#pooling-api) (`/pooling`)
     - Applicable to all [pooling models](../../models/pooling_models/README.md).
-- [Generative Scoring API](generative_scoring.md#generative-scoring-api) (`/generative_scoring`)
+- [Generative Scoring API](generative_scoring.md) (`/generative_scoring`)
     - Applicable to [CausalLM models](../../models/generative_models.md) (task `"generate"`).
     - Computes next-token probabilities for specified `label_token_ids`.
 


### PR DESCRIPTION
## Purpose

Four in-page anchors in the docs point at fragments that do not exist on the rendered site, so the links land at the top of the target page instead of the intended section.

| Link | Problem | Fix |
| --- | --- | --- |
| `scoring.md#rerank-api` (4x) | heading is `### Cohere Rerank API` | `#cohere-rerank-api` |
| `moe_kernel_features.md#fused-moe-experts-kernels` | heading is `## Fused Experts Kernels` | `#fused-experts-kernels` |
| `openai_compatible_server.md#chat-template` | the `## Chat Template` section is in `serving/online_serving/README.md`, not in `openai_compatible_server.md` | same-page `#chat-template` |
| `generative_scoring.md#generative-scoring-api` | no such heading in that page | link to the page |

## Test Plan

- Compared every relative `#fragment` link under `docs/` against the anchors actually emitted on <https://docs.vllm.ai> (e.g. `cohere-rerank-api`, `fused-experts-kernels`, `chat-template` on the Online Serving page).
- `markdownlint-cli2` (the version pinned in `.pre-commit-config.yaml`) passes on all four changed files.

## Test Result

`Summary: 0 error(s)` from markdownlint on the changed files; all four replacement anchors exist on the published pages.

## Note

The scan also surfaced a separate class of mismatch: anchors such as `docs/design/fusions.md#allreduce--rmsnorm-fuse_allreduce_rms` are valid for GitHub's slugifier (which markdownlint's MD051 checks against) but not for the site, because `mkdocs.yaml` leaves `toc` on Python-Markdown's default slugify, which collapses repeated separators. Fixing those in the Markdown source would make MD051 fail, so it likely wants a `toc: slugify:` config change instead. Left out of this PR — happy to open a follow-up issue if that's useful.