### PR TITLE
[Docs] Document ExampleConnector migration for disaggregated prefill

### DIFF
--- a/docs/features/disagg_prefill.md
+++ b/docs/features/disagg_prefill.md
@@ -17,9 +17,43 @@ Two main reasons:
 
 ## Usage example
 
-Now supports 9 types of connectors:
+The built-in KV connector registry includes the following connector names:
+
+- `ExampleConnector`
+- `ExampleHiddenStatesConnector`
+- `LMCacheConnectorV1`
+- `LMCacheMPConnector`
+- `NixlConnector`
+- `NixlPullConnector`
+- `NixlPushConnector`
+- `MultiConnector`
+- `MoRIIOConnector`
+- `OffloadingConnector`
+- `DecodeBenchConnector`
+- `MooncakeConnector`
+- `MooncakeStoreConnector`
+- `FlexKVConnectorV1`
+- `SimpleCPUOffloadConnector`
+- `HF3FSKVConnector`
+
+Common usage examples:
 
 - **ExampleConnector**: refer to [examples/disaggregated/example_connector/run.sh](../../examples/disaggregated/example_connector/run.sh) for the example usage of ExampleConnector disaggregated prefilling.
+
+  !!! note
+      `SharedStorageConnector` was renamed to `ExampleConnector` in
+      [#30201](https://github.com/vllm-project/vllm/pull/30201). If you are
+      following older examples that set `kv_connector` to
+      `SharedStorageConnector`, use `ExampleConnector` instead. The
+      `shared_storage_path` extra config key is still used by ExampleConnector.
+      ExampleConnector is intended for examples and debugging; for production
+      disaggregated prefilling, use a production connector such as NIXL,
+      Mooncake, LMCache, or another infrastructure-backed connector.
+
+  ```bash
+  --kv-transfer-config '{"kv_connector":"ExampleConnector","kv_role":"kv_both","kv_connector_extra_config":{"shared_storage_path":"local_storage"}}'
+  ```
+
 - **LMCacheConnectorV1**: refer to [examples/disaggregated/lmcache/disagg_prefill_lmcache_v1/disagg_example_nixl.sh](../../examples/disaggregated/lmcache/disagg_prefill_lmcache_v1/disagg_example_nixl.sh) for the example usage of LMCacheConnectorV1 disaggregated prefilling which uses NIXL as the underlying KV transmission. LMCache also offers a multi-process (MP) mode via `LMCacheMPConnector`, where a standalone `lmcache server` holds the KV cache shared by one or more vLLM instances; see the [LMCache examples](../../examples/disaggregated/lmcache/README.md) and the [LMCache docs](https://docs.lmcache.ai) for setup.
 - **NixlConnector**: refer to [tests/v1/kv_connector/nixl_integration/run_accuracy_test.sh](../../tests/v1/kv_connector/nixl_integration/run_accuracy_test.sh) for the example usage of NixlConnector disaggregated prefilling which support fully async send/recv. For detailed usage guide, see [NixlConnector Usage Guide](nixl_connector_usage.md). For feature compatibility details, see [NixlConnector Compatibility Matrix](nixl_connector_compatibility.md). You may specify one or multiple NIXL transfer backends, such as:
 


### PR DESCRIPTION
## Summary

- Document that `SharedStorageConnector` was renamed to `ExampleConnector` in #30201.
- Add an updated `ExampleConnector` `shared_storage_path` config snippet for older examples/tutorials.
- Replace the stale "9 types of connectors" text with the current registered connector names from `KVConnectorFactory`.
- Clarify that `ExampleConnector` is for examples/debugging, while production PD should use infrastructure-backed connectors such as NIXL, Mooncake, or LMCache.

Fixes #49399.

## Duplicate-work check

Per `AGENTS.md`, I checked for existing work before opening this PR:

- `gh issue view 49399 --repo vllm-project/vllm --comments`
- `gh pr list --repo vllm-project/vllm --state open --search '49399 OR SharedStorageConnector OR ExampleConnector OR disagg_prefill'`

The search found no open PR addressing the migration-docs gap. The open PRs returned by the broad search were unrelated connector/code changes rather than docs migration guidance.

## Test Plan

- `npx --yes markdownlint-cli2@0.21.0 docs/features/disagg_prefill.md`
  - Result: `Summary: 0 error(s)`
- `uvx pre-commit run markdownlint-cli2 --files docs/features/disagg_prefill.md`
  - Result: `Passed`
- `git diff --check`
  - Result: passed
- Manual verification against `vllm/distributed/kv_transfer/kv_connector/factory.py`
  - Result: the documented connector-name inventory matches the factory registry.

## AI assistance

AI assistance was used to inspect the issue context, prepare the docs patch, and run verification commands. I reviewed the changed lines and test output before submitting.
