### PR TITLE
[Bugfix] Avoid complex64 advanced indexing in pixtral vision encoder for backend portability

### DIFF
--- a/vllm/model_executor/models/pixtral.py
+++ b/vllm/model_executor/models/pixtral.py
@@ -946,7 +946,12 @@ class VisionTransformer(nn.Module):
 
         # positional embeddings
         positions = position_meshgrid(patch_embeds_list).to(self.device)
-        freqs_cis = self.freqs_cis[positions[:, 0], positions[:, 1]]
+        # Index on the real view instead of the complex64 tensor directly,
+        # because some backends (e.g. Ascend NPU aclnnIndex) do not support
+        # advanced indexing on complex tensors.
+        freqs_cis_real = torch.view_as_real(self.freqs_cis)
+        freqs_cis = torch.view_as_complex(
+            freqs_cis_real[positions[:, 0], positions[:, 1]].contiguous())
 
         # pass through Transformer with a block diagonal mask delimiting images
         if USE_XFORMERS_OPS:

--- a/vllm/model_executor/models/pixtral.py
+++ b/vllm/model_executor/models/pixtral.py
@@ -1007,7 +1007,12 @@ class VisionTransformer(nn.Module):
 
         # positional embeddings
         positions = position_meshgrid(patch_embeds_list).to(self.device)
-        freqs_cis = self.freqs_cis[positions[:, 0], positions[:, 1]]
+        # Index on the real view instead of the complex64 tensor directly,
+        # because some backends (e.g. Ascend NPU aclnnIndex) do not support
+        # advanced indexing on complex tensors.
+        freqs_cis_real = torch.view_as_real(self.freqs_cis)
+        freqs_cis = torch.view_as_complex(
+            freqs_cis_real[positions[:, 0], positions[:, 1]].contiguous())
 
         attention = self.transformer.layers[0].attention.attn
         cu_seqlens, max_seqlen, sequence_lengths = _make_packed_sequence_metadata(


### PR DESCRIPTION
## Purpose

The Pixtral vision encoder (`VisionTransformer.forward` in `vllm/model_executor/models/pixtral.py`) indexes `self.freqs_cis` — a `complex64` tensor — using advanced indexing:

```python
freqs_cis = self.freqs_cis[positions[:, 0], positions[:, 1]]
```

Some backends do not support advanced indexing on complex tensors. For example, the Ascend NPU's `aclnnIndex` operator does not support `complex64`, causing:

```
RuntimeError: Tensor self not implemented for DT_COMPLEX64
```

This blocks Pixtral/Mistral vision models from running on Ascend NPU.

## Modification

Index on the real view of the tensor and convert back to complex, which is mathematically equivalent and supported across all backends:

```python
freqs_cis_real = torch.view_as_real(self.freqs_cis)
freqs_cis = torch.view_as_complex(
    freqs_cis_real[positions[:, 0], positions[:, 1]].contiguous())
```

`torch.view_as_real` / `torch.view_as_complex` are standard PyTorch APIs for lossless complex ↔ real conversion. This change is fully equivalent on GPU/CPU and unblocks NPU.

## Test

- Numerical equivalence verified on GPU: output identical to the original implementation.
- Pixtral vision encoder runs successfully on Ascend NPU after this change (via [vllm-ascend](https://github.com/vllm-project/vllm-ascend)).

## Related

- vllm-ascend PR #8152: temporary monkey-patch for the same issue; the complex64 portion can be removed once this PR is merged.
