### PR TITLE
[Perf] Fuse mul_+moe_sum in TopKWeightAndReduceContiguous for large reductions

### DIFF
--- a/tests/kernels/moe/test_topk_weight_and_reduce.py
+++ b/tests/kernels/moe/test_topk_weight_and_reduce.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for TopKWeightAndReduceContiguous.
+
+Covers both the eager (``mul_`` + ``moe_sum``) path and the fused
+``moe_fused_mul_sum`` path, which is selected by tensor size, so the shapes
+below straddle the ``_FUSED_MUL_SUM_MIN_NUMEL`` threshold.
+"""
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
+    _FUSED_MUL_SUM_MIN_NUMEL,
+    TopKWeightAndReduceContiguous,
+)
+from vllm.platforms import current_platform
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="requires CUDA")
+# num_tokens=8 stays under the fused threshold; 512 crosses it for top_k=8.
+@pytest.mark.parametrize("num_tokens", [8, 512])
+@pytest.mark.parametrize("hidden", [2048, 7168])
+@pytest.mark.parametrize("top_k", [2, 8])
+@pytest.mark.parametrize("apply_router_weight_on_input", [False, True])
+@pytest.mark.parametrize("preallocated_output", [False, True])
+def test_topk_weight_and_reduce_contiguous(
+    num_tokens: int,
+    hidden: int,
+    top_k: int,
+    apply_router_weight_on_input: bool,
+    preallocated_output: bool,
+):
+    device = "cuda"
+    dtype = torch.bfloat16
+    torch.manual_seed(0)
+
+    fused_expert_output = torch.randn(
+        num_tokens, top_k, hidden, device=device, dtype=dtype
+    )
+    topk_weights = torch.rand(num_tokens, top_k, device=device, dtype=dtype)
+    topk_ids = torch.randint(
+        0, 64, (num_tokens, top_k), device=device, dtype=torch.int64
+    )
+
+    output = None
+    if preallocated_output:
+        output = torch.empty(num_tokens, hidden, device=device, dtype=dtype)
+
+    if apply_router_weight_on_input:
+        # Weights are assumed already applied upstream: reduce is a plain sum.
+        ref = fused_expert_output.float().sum(dim=1)
+    else:
+        ref = (fused_expert_output.float() * topk_weights.float().unsqueeze(-1)).sum(
+            dim=1
+        )
+
+    result = TopKWeightAndReduceContiguous().apply(
+        output=output,
+        # apply() may mutate the input in the eager branch; pass a copy.
+        fused_expert_output=fused_expert_output.clone(),
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        apply_router_weight_on_input=apply_router_weight_on_input,
+    )
+
+    assert result.shape == (num_tokens, hidden)
+    if preallocated_output:
+        assert result.data_ptr() == output.data_ptr()
+    # Tolerance accommodates bf16 rounding; a wrong reduction/weighting would
+    # miss by ~O(weight * value), far outside this band.
+    torch.testing.assert_close(result.float(), ref, atol=1e-1, rtol=5e-2)
+
+
+def test_fused_threshold_is_reachable():
+    # Guard against a regression that sets the gate so high the fused path is
+    # effectively dead for realistic high-throughput EP shapes.
+    assert _FUSED_MUL_SUM_MIN_NUMEL <= 512 * 8 * 4096

--- a/vllm/model_executor/layers/fused_moe/topk_weight_and_reduce.py
+++ b/vllm/model_executor/layers/fused_moe/topk_weight_and_reduce.py
@@ -6,6 +6,14 @@ import torch
 
 import vllm._custom_ops as ops
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm.model_executor.layers.fused_moe.moe_fused_mul_sum import moe_fused_mul_sum
+
+# Minimum number of elements in the (num_tokens, top_k, hidden) expert-output
+# tensor for the fused mul+sum Triton kernel to beat the eager
+# ``mul_`` + ``moe_sum`` path. Below this the kernel's fixed launch cost
+# dominates; above it the single fused pass is ~1.1-4.7x faster. Measured to be
+# stable across A100/H100 and hidden sizes.
+_FUSED_MUL_SUM_MIN_NUMEL = 8 * 1024 * 1024
 
 
 class TopKWeightAndReduceDelegate(mk.TopKWeightAndReduce):
@@ -104,9 +112,6 @@ class TopKWeightAndReduceContiguous(mk.TopKWeightAndReduce):
             f"{fused_expert_output.size()}"
         )
 
-        if not apply_router_weight_on_input:
-            fused_expert_output.mul_(topk_weights.view(m, -1, 1))
-
         if output is None:
             output = torch.empty(
                 (m, k),
@@ -116,6 +121,20 @@ class TopKWeightAndReduceContiguous(mk.TopKWeightAndReduce):
         assert output.size() == (m, k), (
             f"Expected output size {(m, k)}. But got {output.size()}"
         )
+
+        # For large reductions, fuse the weight multiply and the top-k sum into
+        # a single Triton pass instead of an in-place ``mul_`` (an extra
+        # read+write over the (m, top_k, k) tensor) followed by ``moe_sum``.
+        # Gated on tensor size because the kernel's fixed launch cost only pays
+        # off past the threshold.
+        if (
+            not apply_router_weight_on_input
+            and fused_expert_output.numel() >= _FUSED_MUL_SUM_MIN_NUMEL
+        ):
+            return moe_fused_mul_sum(fused_expert_output, topk_weights, output)
+
+        if not apply_router_weight_on_input:
+            fused_expert_output.mul_(topk_weights.view(m, -1, 1))
 
         ops.moe_sum(fused_expert_output, output)
         return output


### PR DESCRIPTION
## Purpose

`TopKWeightAndReduceContiguous.apply` is the EP combine-side reduction. It runs
an in-place `mul_` (a full extra read+write pass over the
`(num_tokens, top_k, hidden)` expert output) followed by `ops.moe_sum`:

```python
if not apply_router_weight_on_input:
    fused_expert_output.mul_(topk_weights.view(m, -1, 1))
ops.moe_sum(fused_expert_output, output)
```

The in-tree `moe_fused_mul_sum` Triton kernel (already used by
`fused_humming_moe.py`) does the weight multiply and the top-k reduction in a
single pass, removing that extra pass over the largest MoE tensor. It also
accumulates the product in fp32, where the eager `mul_` rounds to bf16, so it is
marginally more accurate.

The kernel has a fixed launch cost that loses to `moe_sum` on small tensors, so
the fused path is gated on `numel()` — below the threshold the eager path is
retained, making this a strict win/neutral. All four call sites (`deepep_ht`,
`deepep_v2`, `naive_dp_ep`, `no_dp_ep`) are high-throughput / prefill EP paths
that run at large token counts. The `apply_router_weight_on_input=True` branch is
unchanged and never takes the fused path.

## Changes

- `topk_weight_and_reduce.py`: in `TopKWeightAndReduceContiguous.apply`, dispatch
  to `moe_fused_mul_sum` when `fused_expert_output.numel() >= 8 * 1024 * 1024`,
  otherwise keep `mul_` + `moe_sum`.
- Add `tests/kernels/moe/test_topk_weight_and_reduce.py` covering both branches,
  both `apply_router_weight_on_input` values, and pre-allocated vs new output.

## Test Plan

```
pytest tests/kernels/moe/test_topk_weight_and_reduce.py -v
```

Kernel microbenchmark: `mul_ + ops.moe_sum` vs `moe_fused_mul_sum`, bf16,
top_k=8, swept over `num_tokens` / `hidden` on H100 and A100.

## Test Result

Correctness (H100, real `ops.moe_sum`): all parametrized cases pass; the fused
output is closer to the fp32 reference than the eager path (max|err| 0.0298 vs
0.0364 at DeepSeek shapes).

Throughput, hidden=7168, top_k=8 (DeepSeek-V3):

| tokens | numel | `mul_`+`moe_sum` | fused | speedup |
|-------:|------:|-----------------:|------:|:-------:|
| 32   | 1.8M  | 10.6 µs  | 16.7 µs | 0.63× (eager kept) |
| 128  | 7.3M  | 23.7 µs  | 18.3 µs | 1.29× |
| 256  | 14.7M | 47.4 µs  | 16.9 µs | 2.81× |
| 512  | 29.4M | 110.6 µs | 25.9 µs | 4.26× |
| 1024 | 58.7M | 219.8 µs | 46.9 µs | 4.69× |

The crossover (first numel where fused ≥ 1.1×) is identical on H100 and A100
(~8M elements) and roughly hidden-size independent, so a single `numel` gate is
GPU-portable. End-to-end multi-GPU DeepEP throughput numbers to follow.

## Non-duplication, dependency, and current validation

- #43250 is complementary rather than a duplicate: it adds a new sum-oriented
  Triton kernel for `top_k > 4` and wires it into decode and
  `TritonExperts`; this PR reuses the existing `moe_fused_mul_sum` kernel to
  eliminate the separate router-weight multiply pass for large prefill/EP
  tensors.
- #44452 changes output-buffer allocation around the same component but is
  otherwise orthogonal to this reduction change.
- Safety dependency: #50220 fixes int32 row-offset overflow in
  `moe_fused_mul_sum`. Because this PR expands that kernel's use, it should
  not merge until #50220 (or an equivalent int64-offset fix) is on `main`.

Validation after rebasing:

```
uvx ruff check tests/kernels/moe/test_topk_weight_and_reduce.py \
  vllm/model_executor/layers/fused_moe/topk_weight_and_reduce.py
uvx ruff format --check tests/kernels/moe/test_topk_weight_and_reduce.py \
  vllm/model_executor/layers/fused_moe/topk_weight_and_reduce.py
pytest tests/kernels/moe/test_topk_weight_and_reduce.py -v
```

Ruff lint and format checks passed. The targeted pytest suite passed on an H100:
33 passed, 14 warnings in 14.48s.

AI assistance (Claude Code and OpenAI Codex) was used to author, rebase, and
validate this change. The human submitter must still review every changed line
before treating the PR as ready for maintainer review.