### PR TITLE
[Bugfix] Fix missing f-string in Keye smart_resize aspect-ratio error message

### DIFF
--- a/vllm/model_executor/models/keye.py
+++ b/vllm/model_executor/models/keye.py
@@ -107,7 +107,7 @@ def smart_resize(
     if max(height, width) / min(height, width) > 200:
         raise ValueError(
             "absolute aspect ratio must be smaller than 200, got "
-            "{max(height, width) / min(height, width)}"
+            f"{max(height, width) / min(height, width)}"
         )
     h_bar = round(height / factor) * factor
     w_bar = round(width / factor) * factor


### PR DESCRIPTION
## Purpose

The aspect-ratio guard in `smart_resize` (`vllm/model_executor/models/keye.py`) builds its error message from two implicitly-concatenated string literals, but the second one contains a `{...}` expression without an `f` prefix:

```python
if max(height, width) / min(height, width) > 200:
    raise ValueError(
        "absolute aspect ratio must be smaller than 200, got "
        "{max(height, width) / min(height, width)}"
    )
```

So when this guard trips, the `ValueError` is raised with the literal text `{max(height, width) / min(height, width)}` instead of the actual ratio — i.e. the one number the message exists to report is never shown. This adds the missing `f` prefix.

`keye_vl1_5.py` imports `smart_resize` from `keye`, so both Keye variants are covered by the single fix.

## Test Plan / Result

Pure string-formatting fix, no behavior change on the success path. Confirmed the module still byte-compiles (`python -m py_compile`), and the message now interpolates the computed ratio rather than emitting literal braces.