### PR TITLE
[Perf][GLM-5.2] Reuse Sparse Physical Indices via Attention Metadata （throughput +3.76%）

### DIFF
--- a/tests/v1/attention/test_sparse_mla_backends.py
+++ b/tests/v1/attention/test_sparse_mla_backends.py
@@ -809,30 +809,48 @@ def test_flashmla_forward_bf16_kv_slices_req_id_to_mqa_tokens():
         ),
         block_table=torch.arange(40, dtype=torch.int32, device=device).view(4, 10),
         block_size=block_size,
+        physical_topk_indices=torch.empty(
+            num_mqa_tokens,
+            num_topk_tokens,
+            dtype=torch.int32,
+            device=device,
+        ),
+        physical_topk_valid_counts=torch.empty(
+            num_mqa_tokens, dtype=torch.int32, device=device
+        ),
+        physical_topk_is_valid=False,
     )
     assert attn_metadata.req_id_per_token.shape[0] == num_batch_tokens
 
     q = torch.zeros(num_mqa_tokens, 4, 576, dtype=torch.bfloat16, device=device)
     kv_cache = torch.zeros(40, block_size, 576, dtype=torch.bfloat16, device=device)
-    topk_indices = torch.randint(
-        0,
-        block_size * 10,
-        (num_mqa_tokens, num_topk_tokens),
+    topk_indices = torch.arange(
+        num_mqa_tokens * num_topk_tokens,
         dtype=torch.int32,
         device=device,
-    )
+    ).view(num_mqa_tokens, num_topk_tokens)
 
     captured = {}
 
     def _stub_kernel(q, kv, indices, lengths):
         captured["indices"] = indices
-        return torch.zeros(q.shape[0], q.shape[1], 512, dtype=q.dtype, device=q.device)
+        return (
+            torch.zeros(q.shape[0], q.shape[1], 512, dtype=q.dtype, device=q.device),
+            None,
+        )
 
-    stub_impl = SimpleNamespace(_bf16_flash_mla_kernel=_stub_kernel)
-
-    out = FlashMLASparseImpl._forward_bf16_kv(
-        stub_impl, q, kv_cache, topk_indices, attn_metadata
+    stub_impl = SimpleNamespace(
+        _bf16_flash_mla_kernel=_stub_kernel,
+        kv_cache_dtype="auto",
+        topk_indices_buffer=topk_indices,
+        dcp_world_size=1,
+        need_to_return_lse_for_decode=False,
     )
+    stub_impl._forward_bf16_kv = MethodType(
+        FlashMLASparseImpl._forward_bf16_kv, stub_impl
+    )
+
+    out, _ = FlashMLASparseImpl.forward_mqa(stub_impl, q, kv_cache, attn_metadata, None)
 
     assert out.shape[0] == num_mqa_tokens
     assert captured["indices"].shape[0] == num_mqa_tokens
@@ -843,6 +861,10 @@ def test_flashmla_forward_bf16_kv_slices_req_id_to_mqa_tokens():
         block_size,
         num_topk_tokens,
     )
+    torch.testing.assert_close(captured["indices"], reference, rtol=0, atol=0)
+
+    topk_indices.zero_()
+    FlashMLASparseImpl.forward_mqa(stub_impl, q, kv_cache, attn_metadata, None)
     torch.testing.assert_close(captured["indices"], reference, rtol=0, atol=0)
 
 
@@ -1302,6 +1324,25 @@ def test_triton_convert_returns_valid_counts(num_topk_tokens: int):
 
     torch.testing.assert_close(valid_counts, expected_valid_tensor, rtol=0, atol=0)
 
+    output_buffer = torch.empty_like(token_indices)
+    valid_counts_buffer = torch.full_like(expected_valid_tensor, -1)
+    buffered_result, buffered_valid_counts = triton_convert_req_index_to_global_index(
+        req_id,
+        block_table,
+        token_indices,
+        BLOCK_SIZE=block_size,
+        NUM_TOPK_TOKENS=num_topk_tokens,
+        return_valid_counts=True,
+        output=output_buffer,
+        valid_counts_out=valid_counts_buffer,
+    )
+    assert buffered_result.data_ptr() == output_buffer.data_ptr()
+    assert buffered_valid_counts.data_ptr() == valid_counts_buffer.data_ptr()
+    torch.testing.assert_close(buffered_result, result, rtol=0, atol=0)
+    torch.testing.assert_close(
+        buffered_valid_counts, expected_valid_tensor, rtol=0, atol=0
+    )
+
     # Test that return_valid_counts=False returns only the indices
     result_only = triton_convert_req_index_to_global_index(
         req_id,
@@ -1487,6 +1528,11 @@ def test_flashmla_fp8_paths_accept_decode_subset(monkeypatch, use_mixed_batch: b
         ),
         block_table=torch.empty(1, 1, dtype=torch.int32, device=DEVICE_TYPE),
         block_size=64,
+        physical_topk_indices=torch.empty_like(topk_indices),
+        physical_topk_valid_counts=torch.empty(
+            num_decode_tokens, dtype=torch.int32, device=DEVICE_TYPE
+        ),
+        physical_topk_is_valid=False,
     )
     impl = SimpleNamespace(
         kv_cache_dtype="fp8_ds_mla",

--- a/tests/v1/attention/test_sparse_mla_backends.py
+++ b/tests/v1/attention/test_sparse_mla_backends.py
@@ -804,18 +804,26 @@ def test_flashmla_forward_bf16_kv_slices_req_id_to_mqa_tokens():
         ),
         block_table=torch.arange(40, dtype=torch.int32, device=device).view(4, 10),
         block_size=block_size,
+        physical_topk_indices=torch.empty(
+            num_mqa_tokens,
+            num_topk_tokens,
+            dtype=torch.int32,
+            device=device,
+        ),
+        physical_topk_valid_counts=torch.empty(
+            num_mqa_tokens, dtype=torch.int32, device=device
+        ),
+        physical_topk_is_valid=False,
     )
     assert attn_metadata.req_id_per_token.shape[0] == num_batch_tokens
 
     q = torch.zeros(num_mqa_tokens, 4, 576, dtype=torch.bfloat16, device=device)
     kv_cache = torch.zeros(40 * block_size, 576, dtype=torch.bfloat16, device=device)
-    topk_indices = torch.randint(
-        0,
-        block_size * 10,
-        (num_mqa_tokens, num_topk_tokens),
+    topk_indices = torch.arange(
+        num_mqa_tokens * num_topk_tokens,
         dtype=torch.int32,
         device=device,
-    )
+    ).view(num_mqa_tokens, num_topk_tokens)
 
     captured = {}
 
@@ -823,12 +831,16 @@ def test_flashmla_forward_bf16_kv_slices_req_id_to_mqa_tokens():
         captured["indices"] = indices
         return torch.zeros(q.shape[0], q.shape[1], 512, dtype=q.dtype, device=q.device)
 
-    stub_impl = SimpleNamespace(_bf16_flash_mla_kernel=_stub_kernel)
-
-    out = FlashMLASparseImpl._forward_bf16_kv(
-        stub_impl, q, kv_cache, topk_indices, attn_metadata
+    stub_impl = SimpleNamespace(
+        _bf16_flash_mla_kernel=_stub_kernel,
+        kv_cache_dtype="auto",
+        topk_indices_buffer=topk_indices,
+    )
+    stub_impl._forward_bf16_kv = MethodType(
+        FlashMLASparseImpl._forward_bf16_kv, stub_impl
     )
 
+    out, _ = FlashMLASparseImpl.forward_mqa(stub_impl, q, kv_cache, attn_metadata, None)
     assert out.shape[0] == num_mqa_tokens
     assert captured["indices"].shape[0] == num_mqa_tokens
     reference = _triton_convert_reference_impl(
@@ -838,6 +850,10 @@ def test_flashmla_forward_bf16_kv_slices_req_id_to_mqa_tokens():
         block_size,
         num_topk_tokens,
     )
+    torch.testing.assert_close(captured["indices"], reference, rtol=0, atol=0)
+
+    topk_indices.zero_()
+    FlashMLASparseImpl.forward_mqa(stub_impl, q, kv_cache, attn_metadata, None)
     torch.testing.assert_close(captured["indices"], reference, rtol=0, atol=0)
 
 
@@ -1240,6 +1256,25 @@ def test_triton_convert_returns_valid_counts():
 
     torch.testing.assert_close(valid_counts, expected_valid_tensor, rtol=0, atol=0)
 
+    output_buffer = torch.empty_like(token_indices)
+    valid_counts_buffer = torch.full_like(expected_valid_tensor, -1)
+    buffered_result, buffered_valid_counts = triton_convert_req_index_to_global_index(
+        req_id,
+        block_table,
+        token_indices,
+        BLOCK_SIZE=block_size,
+        NUM_TOPK_TOKENS=num_topk_tokens,
+        return_valid_counts=True,
+        output=output_buffer,
+        valid_counts_out=valid_counts_buffer,
+    )
+    assert buffered_result.data_ptr() == output_buffer.data_ptr()
+    assert buffered_valid_counts.data_ptr() == valid_counts_buffer.data_ptr()
+    torch.testing.assert_close(buffered_result, result, rtol=0, atol=0)
+    torch.testing.assert_close(
+        buffered_valid_counts, expected_valid_tensor, rtol=0, atol=0
+    )
+
     # Test that return_valid_counts=False returns only the indices
     result_only = triton_convert_req_index_to_global_index(
         req_id,
@@ -1425,6 +1460,11 @@ def test_flashmla_fp8_paths_accept_decode_subset(monkeypatch, use_mixed_batch: b
         ),
         block_table=torch.empty(1, 1, dtype=torch.int32, device=DEVICE_TYPE),
         block_size=64,
+        physical_topk_indices=torch.empty_like(topk_indices),
+        physical_topk_valid_counts=torch.empty(
+            num_decode_tokens, dtype=torch.int32, device=DEVICE_TYPE
+        ),
+        physical_topk_is_valid=False,
     )
     impl = SimpleNamespace(
         kv_cache_dtype="fp8_ds_mla",

--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
@@ -36,6 +36,7 @@ from vllm.v1.kv_cache_interface import AttentionSpec
 
 if TYPE_CHECKING:
     from vllm.model_executor.models.deepseek_v2 import Indexer
+    from vllm.v1.attention.backend import CommonAttentionMetadata
 
 logger = init_logger(__name__)
 
@@ -261,6 +262,9 @@ class FlashInferMLASparseMetadata(AttentionMetadata):
     block_size: int = 64
     topk_tokens: int = 2048
     cp_kv_cache_interleave_size: int = 1
+    physical_topk_indices: torch.Tensor | None = None
+    physical_topk_valid_counts: torch.Tensor | None = None
+    physical_topk_is_valid: bool = False
 
 
 class FlashInferMLASparseMetadataBuilder(
@@ -280,6 +284,18 @@ class FlashInferMLASparseMetadataBuilder(
     ) -> None:
         super().__init__(kv_cache_spec, layer_names, vllm_config, device)
 
+        max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        self.physical_topk_indices = torch.empty(
+            (max_num_tokens, self.topk_tokens),
+            dtype=torch.int32,
+            device=device,
+        )
+        self.physical_topk_valid_counts = torch.empty(
+            max_num_tokens,
+            dtype=torch.int32,
+            device=device,
+        )
+
         num_q_heads = vllm_config.model_config.get_num_attention_heads(
             vllm_config.parallel_config
         )
@@ -291,6 +307,17 @@ class FlashInferMLASparseMetadataBuilder(
             supports_spec_as_decode=True,
             supports_dcp_with_varlen=True,
         )
+
+    def build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: "CommonAttentionMetadata",
+        fast_build: bool = False,
+    ) -> FlashInferMLASparseMetadata:
+        metadata = super().build(common_prefix_len, common_attn_metadata, fast_build)
+        metadata.physical_topk_indices = self.physical_topk_indices
+        metadata.physical_topk_valid_counts = self.physical_topk_valid_counts
+        return metadata
 
 
 # Global workspace buffer (lazily initialized)
@@ -405,14 +432,34 @@ class FlashInferMLASparseImpl(SparseMLACommonImpl[FlashInferMLASparseMetadata]):
                 return_valid_counts=True,
             )
         else:
-            topk_indices_physical, seq_lens = triton_convert_req_index_to_global_index(
-                attn_metadata.req_id_per_token[:num_actual_toks],
-                attn_metadata.block_table,
-                topk_indices,
-                BLOCK_SIZE=attn_metadata.block_size,
-                NUM_TOPK_TOKENS=topk_indices.shape[1],
-                return_valid_counts=True,
-            )
+            assert attn_metadata.physical_topk_indices is not None
+            assert attn_metadata.physical_topk_valid_counts is not None
+            physical_topk_indices = attn_metadata.physical_topk_indices[
+                :num_actual_toks
+            ]
+            physical_topk_valid_counts = attn_metadata.physical_topk_valid_counts[
+                :num_actual_toks
+            ]
+            wrote_fresh_topk = getattr(
+                layer, "indexer", None
+            ) is not None and not getattr(layer, "skip_topk", False)
+            if wrote_fresh_topk or not attn_metadata.physical_topk_is_valid:
+                topk_indices_physical, seq_lens = (
+                    triton_convert_req_index_to_global_index(
+                        attn_metadata.req_id_per_token[:num_actual_toks],
+                        attn_metadata.block_table,
+                        topk_indices,
+                        BLOCK_SIZE=attn_metadata.block_size,
+                        NUM_TOPK_TOKENS=topk_indices.shape[1],
+                        return_valid_counts=True,
+                        output=physical_topk_indices,
+                        valid_counts_out=physical_topk_valid_counts,
+                    )
+                )
+                attn_metadata.physical_topk_is_valid = True
+            else:
+                topk_indices_physical = physical_topk_indices
+                seq_lens = physical_topk_valid_counts
 
         if self._workspace_buffer is None:
             self._workspace_buffer = _get_workspace_buffer(q.device)

--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
@@ -35,6 +35,7 @@ from vllm.v1.kv_cache_interface import AttentionSpec
 
 if TYPE_CHECKING:
     from vllm.model_executor.models.deepseek_v2 import Indexer
+    from vllm.v1.attention.backend import CommonAttentionMetadata
 
 logger = init_logger(__name__)
 
@@ -229,6 +230,9 @@ class FlashInferMLASparseMetadata(AttentionMetadata):
     block_size: int = 64
     topk_tokens: int = 2048
     cp_kv_cache_interleave_size: int = 1
+    physical_topk_indices: torch.Tensor | None = None
+    physical_topk_valid_counts: torch.Tensor | None = None
+    physical_topk_is_valid: bool = False
 
 
 class FlashInferMLASparseMetadataBuilder(
@@ -248,6 +252,14 @@ class FlashInferMLASparseMetadataBuilder(
     ) -> None:
         super().__init__(kv_cache_spec, layer_names, vllm_config, device)
 
+        max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        self.physical_topk_indices = torch.empty(
+            (max_num_tokens, self.topk_tokens), dtype=torch.int32, device=device
+        )
+        self.physical_topk_valid_counts = torch.empty(
+            max_num_tokens, dtype=torch.int32, device=device
+        )
+
         num_q_heads = vllm_config.model_config.get_num_attention_heads(
             vllm_config.parallel_config
         )
@@ -259,6 +271,17 @@ class FlashInferMLASparseMetadataBuilder(
             supports_spec_as_decode=True,
             supports_dcp_with_varlen=True,
         )
+
+    def build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: "CommonAttentionMetadata",
+        fast_build: bool = False,
+    ) -> FlashInferMLASparseMetadata:
+        metadata = super().build(common_prefix_len, common_attn_metadata, fast_build)
+        metadata.physical_topk_indices = self.physical_topk_indices
+        metadata.physical_topk_valid_counts = self.physical_topk_valid_counts
+        return metadata
 
 
 # Global workspace buffer (lazily initialized)
@@ -373,14 +396,30 @@ class FlashInferMLASparseImpl(SparseMLACommonImpl[FlashInferMLASparseMetadata]):
                 return_valid_counts=True,
             )
         else:
-            topk_indices_physical, seq_lens = triton_convert_req_index_to_global_index(
-                attn_metadata.req_id_per_token[:num_actual_toks],
-                attn_metadata.block_table,
-                topk_indices,
-                BLOCK_SIZE=attn_metadata.block_size,
-                NUM_TOPK_TOKENS=topk_indices.shape[1],
-                return_valid_counts=True,
-            )
+            assert attn_metadata.physical_topk_indices is not None
+            assert attn_metadata.physical_topk_valid_counts is not None
+            physical_indices = attn_metadata.physical_topk_indices[:num_actual_toks]
+            valid_counts = attn_metadata.physical_topk_valid_counts[:num_actual_toks]
+            wrote_fresh_topk = getattr(
+                layer, "indexer", None
+            ) is not None and not getattr(layer, "skip_topk", False)
+            if wrote_fresh_topk or not attn_metadata.physical_topk_is_valid:
+                topk_indices_physical, seq_lens = (
+                    triton_convert_req_index_to_global_index(
+                        attn_metadata.req_id_per_token[:num_actual_toks],
+                        attn_metadata.block_table,
+                        topk_indices,
+                        BLOCK_SIZE=attn_metadata.block_size,
+                        NUM_TOPK_TOKENS=topk_indices.shape[1],
+                        return_valid_counts=True,
+                        output=physical_indices,
+                        valid_counts_out=valid_counts,
+                    )
+                )
+                attn_metadata.physical_topk_is_valid = True
+            else:
+                topk_indices_physical = physical_indices
+                seq_lens = valid_counts
 
         if self._workspace_buffer is None:
             self._workspace_buffer = _get_workspace_buffer(q.device)

--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """SM120 implementation variant for ``FLASHINFER_MLA_SPARSE_SM120``."""
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 import torch
 
@@ -118,16 +118,22 @@ class FlashInferMLASparseSM120Impl(MLAAttentionImpl[FlashInferMLASparseMetadata]
         assert self.topk_indices_buffer is not None
         topk_indices = self.topk_indices_buffer[:num_actual_toks]
 
-        topk_indices_physical = cast(
-            torch.Tensor,
-            triton_convert_req_index_to_global_index(
+        assert attn_metadata.physical_topk_indices is not None
+        topk_indices_physical = attn_metadata.physical_topk_indices[:num_actual_toks]
+        wrote_fresh_topk = getattr(layer, "indexer", None) is not None and not getattr(
+            layer, "skip_topk", False
+        )
+        if wrote_fresh_topk or not attn_metadata.physical_topk_is_valid:
+            topk_indices_physical = triton_convert_req_index_to_global_index(
                 attn_metadata.req_id_per_token[:num_actual_toks],
                 attn_metadata.block_table,
                 topk_indices,
                 BLOCK_SIZE=attn_metadata.block_size,
                 NUM_TOPK_TOKENS=topk_indices.shape[1],
-            ),
-        )
+                output=topk_indices_physical,
+            )
+            assert isinstance(topk_indices_physical, torch.Tensor)
+            attn_metadata.physical_topk_is_valid = True
 
         output = q.new_empty(
             (num_actual_toks, self.num_heads, self.kv_lora_rank),

--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """SM120 implementation variant for ``FLASHINFER_MLA_SPARSE_SM120``."""
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 import torch
 
@@ -117,16 +117,22 @@ class FlashInferMLASparseSM120Impl(MLAAttentionImpl[FlashInferMLASparseMetadata]
         assert self.topk_indices_buffer is not None
         topk_indices = self.topk_indices_buffer[:num_actual_toks]
 
-        topk_indices_physical = cast(
-            torch.Tensor,
-            triton_convert_req_index_to_global_index(
+        assert attn_metadata.physical_topk_indices is not None
+        topk_indices_physical = attn_metadata.physical_topk_indices[:num_actual_toks]
+        wrote_fresh_topk = getattr(layer, "indexer", None) is not None and not getattr(
+            layer, "skip_topk", False
+        )
+        if wrote_fresh_topk or not attn_metadata.physical_topk_is_valid:
+            topk_indices_physical = triton_convert_req_index_to_global_index(
                 attn_metadata.req_id_per_token[:num_actual_toks],
                 attn_metadata.block_table,
                 topk_indices,
                 BLOCK_SIZE=attn_metadata.block_size,
                 NUM_TOPK_TOKENS=topk_indices.shape[1],
-            ),
-        )
+                output=topk_indices_physical,
+            )
+            assert isinstance(topk_indices_physical, torch.Tensor)
+            attn_metadata.physical_topk_is_valid = True
 
         output = q.new_empty(
             (num_actual_toks, self.num_heads, self.kv_lora_rank),

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -205,6 +205,9 @@ class FlashMLASparseMetadata(AttentionMetadata):
 
     fp8_extra_metadata: FP8SeparatePrefillDecode | FP8KernelMetadata | None = None
     fp8_use_mixed_batch: bool = False
+    physical_topk_indices: torch.Tensor | None = None
+    physical_topk_valid_counts: torch.Tensor | None = None
+    physical_topk_is_valid: bool = False
 
 
 def get_prefill_workspace_size(max_model_len: int):
@@ -234,6 +237,14 @@ class FlashMLASparseMetadataBuilder(
         super().__init__(kv_cache_spec, layer_names, vllm_config, device)
         cache_config = vllm_config.cache_config
         parallel_config = vllm_config.parallel_config
+
+        max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        self.physical_topk_indices = torch.empty(
+            (max_num_tokens, self.topk_tokens), dtype=torch.int32, device=device
+        )
+        self.physical_topk_valid_counts = torch.empty(
+            max_num_tokens, dtype=torch.int32, device=device
+        )
 
         num_q_heads = self.model_config.get_num_attention_heads(parallel_config)
         if current_platform.is_device_capability_family(100):
@@ -522,6 +533,8 @@ class FlashMLASparseMetadataBuilder(
         fast_build: bool = False,
     ) -> FlashMLASparseMetadata:
         metadata = super().build(common_prefix_len, common_attn_metadata, fast_build)
+        metadata.physical_topk_indices = self.physical_topk_indices
+        metadata.physical_topk_valid_counts = self.physical_topk_valid_counts
 
         metadata.fp8_use_mixed_batch = self.fp8_use_mixed_batch
         if self.use_fp8_kv_cache:
@@ -625,23 +638,10 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
         q: torch.Tensor,
         kv_c_and_k_pe_cache: torch.Tensor,
         topk_indices: torch.Tensor,
-        attn_metadata: FlashMLASparseMetadata,
+        topk_length: torch.Tensor,
+        block_size: int,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        # Convert per-request indices to global slots (decode) or workspace
-        # offsets (prefill). req_id_per_token covers the whole batch; slice it
-        # to the MQA tokens (q may exclude prefill tokens routed to dense MHA).
-        kv_rows, block_stride_rows = flat_kv_row_view(
-            kv_c_and_k_pe_cache, attn_metadata.block_size
-        )
-        topk_indices, topk_length = triton_convert_req_index_to_global_index(
-            attn_metadata.req_id_per_token[: topk_indices.shape[0]],
-            attn_metadata.block_table,
-            topk_indices,
-            BLOCK_SIZE=attn_metadata.block_size,
-            BLOCK_STRIDE_ROWS=block_stride_rows,
-            NUM_TOPK_TOKENS=topk_indices.shape[1],
-            return_valid_counts=True,
-        )
+        kv_rows, _ = flat_kv_row_view(kv_c_and_k_pe_cache, block_size)
 
         return self._bf16_flash_mla_kernel(
             q,
@@ -655,6 +655,7 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
         q: torch.Tensor,
         kv_c_and_k_pe_cache: torch.Tensor,
         topk_indices: torch.Tensor,
+        topk_length: torch.Tensor,
         attn_metadata: FlashMLASparseMetadata,
     ) -> torch.Tensor:
         fp8_metadata = attn_metadata.fp8_extra_metadata
@@ -666,36 +667,6 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
         assert num_prefill_tokens in (0, fp8_metadata.num_prefill_tokens), (
             "FP8 sparse MLA expects either the decode subset or the full batch"
         )
-
-        prefill_request_ids = None
-        prefill_workspace_starts = None
-        has_prefill_workspace = False
-        if num_prefill_tokens > 0:
-            assert fp8_metadata.prefill is not None
-            prefill_request_ids = fp8_metadata.prefill.request_ids
-            prefill_workspace_starts = fp8_metadata.prefill.workspace_starts
-            has_prefill_workspace = True
-
-        # Convert per-request indices to global slots (decode) or workspace
-        # offsets (prefill).
-        # For FP8 cache: prefill uses workspace mapping (upconverted to BF16)
-        # For BF16 cache: always use global cache slots (no workspace)
-        # prefill_workspace_starts has been adjusted in-place per chunk so
-        # prefill indices automatically come out chunk-local
-        topk_indices, topk_length = triton_convert_req_index_to_global_index(
-            attn_metadata.req_id_per_token[: topk_indices.shape[0]],
-            attn_metadata.block_table,
-            topk_indices,
-            BLOCK_SIZE=attn_metadata.block_size,
-            NUM_TOPK_TOKENS=topk_indices.shape[1],
-            HAS_PREFILL_WORKSPACE=has_prefill_workspace,
-            prefill_workspace_request_ids=prefill_request_ids,
-            prefill_workspace_starts=prefill_workspace_starts,
-            return_valid_counts=True,
-        )
-
-        fp8_metadata = attn_metadata.fp8_extra_metadata
-        assert isinstance(fp8_metadata, FlashMLASparseMetadata.FP8SeparatePrefillDecode)
 
         def _fp8_decode(
             q: torch.Tensor,
@@ -793,17 +764,6 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
                 NUM_TOPK_TOKENS=topk_indices.shape[1],
                 compact_valid_to_front=False,
             )
-        else:
-            # Convert per-request indices to global slots (decode) or workspace
-            # offsets (prefill).
-            topk_indices = triton_convert_req_index_to_global_index(
-                attn_metadata.req_id_per_token[: topk_indices.shape[0]],
-                attn_metadata.block_table,
-                topk_indices,
-                BLOCK_SIZE=attn_metadata.block_size,
-                NUM_TOPK_TOKENS=topk_indices.shape[1],
-            )
-
         assert attn_metadata.fp8_extra_metadata is not None
         assert isinstance(
             attn_metadata.fp8_extra_metadata, FlashMLASparseMetadata.FP8KernelMetadata
@@ -940,22 +900,86 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
         topk_indices = self.topk_indices_buffer[:num_actual_toks]
 
         use_fp8_cache = self.kv_cache_dtype == "fp8_ds_mla"
+        fp8_use_mixed_batch = use_fp8_cache and attn_metadata.fp8_use_mixed_batch
+        refresh_physical_topk = getattr(
+            layer, "indexer", None
+        ) is not None and not getattr(layer, "skip_topk", False)
+
+        if self.dcp_world_size > 1:
+            topk_length = None
+        else:
+            assert attn_metadata.physical_topk_indices is not None
+            physical_indices = attn_metadata.physical_topk_indices[:num_actual_toks]
+            topk_length = None
+            if not fp8_use_mixed_batch:
+                assert attn_metadata.physical_topk_valid_counts is not None
+                topk_length = attn_metadata.physical_topk_valid_counts[:num_actual_toks]
+
+            if refresh_physical_topk or not attn_metadata.physical_topk_is_valid:
+                prefill_request_ids = None
+                prefill_workspace_starts = None
+                has_prefill_workspace = False
+                if use_fp8_cache and not fp8_use_mixed_batch:
+                    fp8_metadata = attn_metadata.fp8_extra_metadata
+                    assert isinstance(
+                        fp8_metadata, FlashMLASparseMetadata.FP8SeparatePrefillDecode
+                    )
+                    if num_actual_toks > fp8_metadata.num_decode_tokens:
+                        assert fp8_metadata.prefill is not None
+                        prefill_request_ids = fp8_metadata.prefill.request_ids
+                        prefill_workspace_starts = fp8_metadata.prefill.workspace_starts
+                        has_prefill_workspace = True
+
+                block_stride_rows = None
+                if not use_fp8_cache:
+                    _, block_stride_rows = flat_kv_row_view(
+                        kv_c_and_k_pe_cache, attn_metadata.block_size
+                    )
+                converted = triton_convert_req_index_to_global_index(
+                    attn_metadata.req_id_per_token[:num_actual_toks],
+                    attn_metadata.block_table,
+                    topk_indices,
+                    BLOCK_SIZE=attn_metadata.block_size,
+                    BLOCK_STRIDE_ROWS=block_stride_rows,
+                    NUM_TOPK_TOKENS=topk_indices.shape[1],
+                    HAS_PREFILL_WORKSPACE=has_prefill_workspace,
+                    prefill_workspace_request_ids=prefill_request_ids,
+                    prefill_workspace_starts=prefill_workspace_starts,
+                    return_valid_counts=not fp8_use_mixed_batch,
+                    output=physical_indices,
+                    valid_counts_out=topk_length,
+                )
+                if fp8_use_mixed_batch:
+                    assert isinstance(converted, torch.Tensor)
+                    topk_indices = converted
+                else:
+                    assert isinstance(converted, tuple)
+                    topk_indices, topk_length = converted
+                attn_metadata.physical_topk_is_valid = True
+            else:
+                topk_indices = physical_indices
 
         lse: torch.Tensor | None = None
 
         if not use_fp8_cache:
+            assert topk_length is not None
             attn_out, bf16_lse = self._forward_bf16_kv(
-                q, kv_c_and_k_pe_cache, topk_indices, attn_metadata
+                q,
+                kv_c_and_k_pe_cache,
+                topk_indices,
+                topk_length,
+                attn_metadata.block_size,
             )
             if self.need_to_return_lse_for_decode:
                 lse = bf16_lse
-        elif attn_metadata.fp8_use_mixed_batch:
+        elif fp8_use_mixed_batch:
             attn_out, lse = self._forward_fp8_kv_mixed_batch(
                 q, kv_c_and_k_pe_cache, topk_indices, attn_metadata
             )
         else:
+            assert topk_length is not None
             attn_out = self._forward_fp8_kv_separate_prefill_decode(
-                q, kv_c_and_k_pe_cache, topk_indices, attn_metadata
+                q, kv_c_and_k_pe_cache, topk_indices, topk_length, attn_metadata
             )
 
         return attn_out, lse

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -217,6 +217,9 @@ class FlashMLASparseMetadata(AttentionMetadata):
 
     fp8_extra_metadata: FP8SeparatePrefillDecode | FP8KernelMetadata | None = None
     fp8_use_mixed_batch: bool = False
+    physical_topk_indices: torch.Tensor | None = None
+    physical_topk_valid_counts: torch.Tensor | None = None
+    physical_topk_is_valid: bool = False
 
 
 def get_prefill_workspace_size(max_model_len: int):
@@ -246,6 +249,18 @@ class FlashMLASparseMetadataBuilder(
         super().__init__(kv_cache_spec, layer_names, vllm_config, device)
         cache_config = vllm_config.cache_config
         parallel_config = vllm_config.parallel_config
+
+        max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        self.physical_topk_indices = torch.empty(
+            (max_num_tokens, self.topk_tokens),
+            dtype=torch.int32,
+            device=device,
+        )
+        self.physical_topk_valid_counts = torch.empty(
+            max_num_tokens,
+            dtype=torch.int32,
+            device=device,
+        )
 
         num_q_heads = self.model_config.get_num_attention_heads(parallel_config)
         if current_platform.is_device_capability_family(100):
@@ -495,6 +510,8 @@ class FlashMLASparseMetadataBuilder(
         fast_build: bool = False,
     ) -> FlashMLASparseMetadata:
         metadata = super().build(common_prefix_len, common_attn_metadata, fast_build)
+        metadata.physical_topk_indices = self.physical_topk_indices
+        metadata.physical_topk_valid_counts = self.physical_topk_valid_counts
 
         fp8_use_mixed_batch = self.num_heads < MIN_HEADS_FOR_BF16_PREFILL
         metadata.fp8_use_mixed_batch = fp8_use_mixed_batch
@@ -589,20 +606,8 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
         q: torch.Tensor,
         kv_c_and_k_pe_cache: torch.Tensor,
         topk_indices: torch.Tensor,
-        attn_metadata: FlashMLASparseMetadata,
+        topk_length: torch.Tensor,
     ) -> torch.Tensor:
-        # Convert per-request indices to global slots (decode) or workspace
-        # offsets (prefill). req_id_per_token covers the whole batch; slice it
-        # to the MQA tokens (q may exclude prefill tokens routed to dense MHA).
-        topk_indices, topk_length = triton_convert_req_index_to_global_index(
-            attn_metadata.req_id_per_token[: topk_indices.shape[0]],
-            attn_metadata.block_table,
-            topk_indices,
-            BLOCK_SIZE=attn_metadata.block_size,
-            NUM_TOPK_TOKENS=topk_indices.shape[1],
-            return_valid_counts=True,
-        )
-
         return self._bf16_flash_mla_kernel(
             q,
             kv_c_and_k_pe_cache,
@@ -615,6 +620,7 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
         q: torch.Tensor,
         kv_c_and_k_pe_cache: torch.Tensor,
         topk_indices: torch.Tensor,
+        topk_length: torch.Tensor,
         attn_metadata: FlashMLASparseMetadata,
     ) -> torch.Tensor:
         fp8_metadata = attn_metadata.fp8_extra_metadata
@@ -625,33 +631,6 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
         num_prefill_tokens = num_mqa_tokens - num_decode_tokens
         assert num_prefill_tokens in (0, fp8_metadata.num_prefill_tokens), (
             "FP8 sparse MLA expects either the decode subset or the full batch"
-        )
-
-        prefill_request_ids = None
-        prefill_workspace_starts = None
-        has_prefill_workspace = False
-        if num_prefill_tokens > 0:
-            assert fp8_metadata.prefill is not None
-            prefill_request_ids = fp8_metadata.prefill.request_ids
-            prefill_workspace_starts = fp8_metadata.prefill.workspace_starts
-            has_prefill_workspace = True
-
-        # Convert per-request indices to global slots (decode) or workspace
-        # offsets (prefill).
-        # For FP8 cache: prefill uses workspace mapping (upconverted to BF16)
-        # For BF16 cache: always use global cache slots (no workspace)
-        # prefill_workspace_starts has been adjusted in-place per chunk so
-        # prefill indices automatically come out chunk-local
-        topk_indices, topk_length = triton_convert_req_index_to_global_index(
-            attn_metadata.req_id_per_token[: topk_indices.shape[0]],
-            attn_metadata.block_table,
-            topk_indices,
-            BLOCK_SIZE=attn_metadata.block_size,
-            NUM_TOPK_TOKENS=topk_indices.shape[1],
-            HAS_PREFILL_WORKSPACE=has_prefill_workspace,
-            prefill_workspace_request_ids=prefill_request_ids,
-            prefill_workspace_starts=prefill_workspace_starts,
-            return_valid_counts=True,
         )
 
         fp8_metadata = attn_metadata.fp8_extra_metadata
@@ -734,16 +713,6 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
         prefill kernel which has head padding overhead when num_heads is small.
         Used when use_mixed_batch is True.
         """
-        # Convert per-request indices to global slots (decode) or workspace
-        # offsets (prefill).
-        topk_indices = triton_convert_req_index_to_global_index(
-            attn_metadata.req_id_per_token[: topk_indices.shape[0]],
-            attn_metadata.block_table,
-            topk_indices,
-            BLOCK_SIZE=attn_metadata.block_size,
-            NUM_TOPK_TOKENS=topk_indices.shape[1],
-        )
-
         assert attn_metadata.fp8_extra_metadata is not None
         assert isinstance(
             attn_metadata.fp8_extra_metadata, FlashMLASparseMetadata.FP8KernelMetadata
@@ -858,18 +827,73 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
         topk_indices = self.topk_indices_buffer[:num_actual_toks]
 
         use_fp8_cache = self.kv_cache_dtype == "fp8_ds_mla"
+        fp8_use_mixed_batch = use_fp8_cache and attn_metadata.fp8_use_mixed_batch
+        refresh_physical_topk = getattr(
+            layer, "indexer", None
+        ) is not None and not getattr(layer, "skip_topk", False)
+
+        assert attn_metadata.physical_topk_indices is not None
+        physical_topk_indices = attn_metadata.physical_topk_indices[:num_actual_toks]
+        topk_length = None
+        if not fp8_use_mixed_batch:
+            assert attn_metadata.physical_topk_valid_counts is not None
+            topk_length = attn_metadata.physical_topk_valid_counts[:num_actual_toks]
+
+        if refresh_physical_topk or not attn_metadata.physical_topk_is_valid:
+            prefill_request_ids = None
+            prefill_workspace_starts = None
+            has_prefill_workspace = False
+            if use_fp8_cache and not fp8_use_mixed_batch:
+                fp8_metadata = attn_metadata.fp8_extra_metadata
+                assert isinstance(
+                    fp8_metadata, FlashMLASparseMetadata.FP8SeparatePrefillDecode
+                )
+                if num_actual_toks > fp8_metadata.num_decode_tokens:
+                    assert fp8_metadata.prefill is not None
+                    prefill_request_ids = fp8_metadata.prefill.request_ids
+                    prefill_workspace_starts = fp8_metadata.prefill.workspace_starts
+                    has_prefill_workspace = True
+
+            converted = triton_convert_req_index_to_global_index(
+                attn_metadata.req_id_per_token[:num_actual_toks],
+                attn_metadata.block_table,
+                topk_indices,
+                BLOCK_SIZE=attn_metadata.block_size,
+                NUM_TOPK_TOKENS=topk_indices.shape[1],
+                HAS_PREFILL_WORKSPACE=has_prefill_workspace,
+                prefill_workspace_request_ids=prefill_request_ids,
+                prefill_workspace_starts=prefill_workspace_starts,
+                return_valid_counts=not fp8_use_mixed_batch,
+                output=physical_topk_indices,
+                valid_counts_out=topk_length,
+            )
+            if fp8_use_mixed_batch:
+                assert isinstance(converted, torch.Tensor)
+                topk_indices = converted
+            else:
+                assert isinstance(converted, tuple)
+                topk_indices, topk_length = converted
+            attn_metadata.physical_topk_is_valid = True
+        else:
+            topk_indices = physical_topk_indices
 
         if not use_fp8_cache:
+            assert topk_length is not None
             attn_out = self._forward_bf16_kv(
-                q, kv_c_and_k_pe_cache, topk_indices, attn_metadata
+                q, kv_c_and_k_pe_cache, topk_indices, topk_length
             )
-        elif attn_metadata.fp8_use_mixed_batch:
+        elif fp8_use_mixed_batch:
             attn_out = self._forward_fp8_kv_mixed_batch(
                 q, kv_c_and_k_pe_cache, topk_indices, attn_metadata
             )
         else:
+            assert topk_length is not None
             attn_out = self._forward_fp8_kv_separate_prefill_decode(
-                q, kv_c_and_k_pe_cache, topk_indices, attn_metadata
+                q,
+                kv_c_and_k_pe_cache,
+                topk_indices,
+                topk_length,
+                attn_metadata,
             )
 
         return attn_out, None

--- a/vllm/v1/attention/backends/mla/sparse_utils.py
+++ b/vllm/v1/attention/backends/mla/sparse_utils.py
@@ -128,6 +128,8 @@ def triton_convert_req_index_to_global_index(
     prefill_workspace_request_ids: torch.Tensor | None = None,
     prefill_workspace_starts: torch.Tensor | None = None,
     return_valid_counts: bool = False,
+    output: torch.Tensor | None = None,
+    valid_counts_out: torch.Tensor | None = None,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     """
     out[token_id, indice_id] =
@@ -150,6 +152,7 @@ def triton_convert_req_index_to_global_index(
 
     When return_valid_counts is True, also returns the count of valid (non -1)
     indices per row, computed during the same kernel pass (no extra overhead).
+    Callers may provide output and valid_counts_out to reuse existing buffers.
     """
     assert req_id.dtype == torch.int32
     assert block_table.dtype == torch.int32
@@ -178,14 +181,29 @@ def triton_convert_req_index_to_global_index(
     req_id_c = req_id.contiguous()
     block_table_c = block_table.contiguous()
     token_indices_c = token_indices.contiguous()
-    out = torch.empty_like(token_indices_c)
+    if output is None:
+        out = torch.empty_like(token_indices_c)
+    else:
+        assert output.shape == token_indices.shape
+        assert output.dtype == torch.int32
+        assert output.device == token_indices.device
+        out = output
 
     # Allocate valid count buffer if needed (must be zero-initialized for atomics)
     valid_counts: torch.Tensor | None = None
     if return_valid_counts:
-        valid_counts = torch.zeros(
-            num_tokens, dtype=torch.int32, device=token_indices.device
-        )
+        if valid_counts_out is None:
+            valid_counts = torch.zeros(
+                num_tokens, dtype=torch.int32, device=token_indices.device
+            )
+        else:
+            assert valid_counts_out.shape == (num_tokens,)
+            assert valid_counts_out.dtype == torch.int32
+            assert valid_counts_out.device == token_indices.device
+            valid_counts = valid_counts_out
+            valid_counts.zero_()
+    else:
+        assert valid_counts_out is None
 
     # Strides in elements
     bt_stride0, bt_stride1 = block_table_c.stride()

--- a/vllm/v1/attention/backends/mla/sparse_utils.py
+++ b/vllm/v1/attention/backends/mla/sparse_utils.py
@@ -186,6 +186,8 @@ def triton_convert_req_index_to_global_index(
     prefill_workspace_request_ids: torch.Tensor | None = None,
     prefill_workspace_starts: torch.Tensor | None = None,
     return_valid_counts: bool = False,
+    output: torch.Tensor | None = None,
+    valid_counts_out: torch.Tensor | None = None,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     """
     out[token_id, indice_id] =
@@ -208,6 +210,7 @@ def triton_convert_req_index_to_global_index(
 
     When return_valid_counts is True, also returns the count of valid (non -1)
     indices per row, computed during the same kernel pass (no extra overhead).
+    Callers may provide output and valid_counts_out to reuse existing buffers.
     """
     assert req_id.dtype == torch.int32
     assert block_table.dtype == torch.int32
@@ -239,13 +242,31 @@ def triton_convert_req_index_to_global_index(
     req_id_c = req_id.contiguous()
     block_table_c = block_table.contiguous()
     token_indices_c = token_indices.contiguous()
-    out = torch.empty_like(token_indices_c)
+    if output is None:
+        out = torch.empty_like(token_indices_c)
+    else:
+        assert output.shape == token_indices.shape
+        assert output.dtype == torch.int32
+        assert output.device == token_indices.device
+        out = output
 
     valid_counts: torch.Tensor | None = None
     if return_valid_counts:
         # Zero-init only matters for the atomic accumulation path.
-        alloc = torch.empty if single_tile else torch.zeros
-        valid_counts = alloc(num_tokens, dtype=torch.int32, device=token_indices.device)
+        if valid_counts_out is None:
+            alloc = torch.empty if single_tile else torch.zeros
+            valid_counts = alloc(
+                num_tokens, dtype=torch.int32, device=token_indices.device
+            )
+        else:
+            assert valid_counts_out.shape == (num_tokens,)
+            assert valid_counts_out.dtype == torch.int32
+            assert valid_counts_out.device == token_indices.device
+            valid_counts = valid_counts_out
+            if not single_tile:
+                valid_counts.zero_()
+    else:
+        assert valid_counts_out is None
 
     # Strides in elements
     bt_stride0, bt_stride1 = block_table_c.stride()


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm/pull/48597#discussion_r3586833876

## Purpose
The optimization caches the converted sparse physical indices in attention metadata, allowing subsequent layers that reuse the same top-k indices to skip calling `triton_convert_req_index_to_global_index`.

  The conversion is performed only when a layer produces fresh top-k indices. Layers using IndexCache directly reuse the cached physical indices and valid counts.
## Test Plan

### Test Environment

- GPUs: 8 x NVIDIA H20-3e
- Model: `zai-org/GLM-5.2-FP8`
- Tensor parallel size: 8
- Attention backend: `FLASHMLA_SPARSE`
- Model configuration: `index_topk_freq=4`, `index_topk=2048`
- Input/output length: 8,000 / 1,024 tokens
- Number of prompts: 128
- Maximum concurrency: 32



### Server Command

```bash
 vllm serve \
  ZhipuAI/GLM-5.2-FP8 \
  --load-format instanttensor \
  --tensor-parallel-size 8 \
  --max-model-len 16384 \
  --gpu-memory-utilization 0.9 \
  --trust-remote-code \
  --attention-backend FLASHMLA_SPARSE \
  --port 8000
```

### Benchmark Command

```bash
vllm bench serve \
  --backend openai \
  --modelZhipuAI/GLM-5.2-FP8 \
  --endpoint /v1/completions \
  --dataset-name random \
  --random-input-len 8000 \
  --random-output-len 1024 \
  --num-prompts 128 \
  --request-rate inf \
  --max-concurrency 32 \
  --seed 1234 \
  --port 8000
```

### Results

All 128 requests completed successfully, and both runs generated 131,072
output tokens.

| Metric | Before | After | Change |
|---|---:|---:|---:|
| Benchmark duration | 372.98 s | 359.46 s | **-3.62%** |
| Request throughput | 0.343 req/s | 0.356 req/s | **+3.76%** |
| Output throughput | 351.42 tok/s | 364.64 tok/s | **+3.76%** |
| Total token throughput | 3,096.91 tok/s | 3,213.37 tok/s | **+3.76%** |
| Mean TTFT | 13,470.43 ms | 13,281.72 ms | **-1.40%** |
| Mean TPOT | 77.88 ms | 74.76 ms | **-4.00%** |
| Mean ITL | 77.88 ms | 74.76 ms | **-4.00%** |
| P99 TPOT | 88.92 ms | 85.62 ms | **-3.71%** |
| P99 ITL | 1,975.12 ms | 1,961.67 ms | **-0.68%** |

 In this pr, output throughput increased by 3.76% and mean TPOT
decreased by 4.00%.

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

