### PR TITLE
[Bugfix][CI/Build] Fix InternViT load crash on transformers v5 (missing all_tied_weights_keys)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,8 +39,16 @@ from transformers import (
     AutoTokenizer,
     BatchEncoding,
     BatchFeature,
+    PreTrainedModel,
 )
 from transformers.models.auto.auto_factory import _BaseAutoModelClass
+
+# Transformers v5 sets ``all_tied_weights_keys`` only in ``post_init``, which some
+# custom remote-code models never call, so loading them raises AttributeError in
+# ``_move_missing_keys_from_meta_to_device``. Provide a safe empty default; models
+# that call ``post_init`` override it per-instance.
+if not hasattr(PreTrainedModel, "all_tied_weights_keys"):
+    PreTrainedModel.all_tied_weights_keys = {}
 
 from tests.models.utils import (
     TokensTextLogprobs,

--- a/tests/models/multimodal/pooling/test_intern_vit.py
+++ b/tests/models/multimodal/pooling/test_intern_vit.py
@@ -12,11 +12,6 @@ from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
 
 from ....conftest import ImageTestAssets
 
-pytestmark = pytest.mark.skip(
-    reason="InternVisionModel's custom code is incompatible with "
-    "transformers v5 (missing all_tied_weights_keys)"
-)
-
 # we use snapshot_download to prevent conflicts between
 # dynamic_module and trust_remote_code for hf_runner
 DOWNLOAD_PATTERN = ["*.json", "*.py", "*.safetensors", "*.txt", "*.model"]


### PR DESCRIPTION
## Purpose

`tests/models/multimodal/pooling/test_intern_vit.py` is skipped under transformers v5.
Loading the `InternVisionModel` reference crashes with `AttributeError: 'InternVisionModel' object has no attribute 'all_tied_weights_keys'`.
Transformers v5 reads `all_tied_weights_keys` at `modeling_utils.py:4736` but sets it only in `PreTrainedModel.post_init()` (line 1394).
InternViT's remote `InternVisionModel.__init__` never calls `post_init()`, so the attribute is missing.
Transformers is itself inconsistent here: line 4829 reads it defensively with `getattr(...)`, line 4736 does not.
This seeds a safe empty default on `PreTrainedModel` in the test conftest, matching what `post_init()` would set.
It removes the skip on `test_intern_vit.py`.
No open PR addresses this.

## Test Plan

Remove the skip.
Run `.venv/bin/python -m pytest tests/models/multimodal/pooling/test_intern_vit.py -v`.

## Test Result

InternViT-300M passes with cosine similarity mean = 1.0 against the HF reference, no `AttributeError`.
Validated on an RTX 4060 (WSL2), transformers 5.9.0.
InternViT-6B needs more VRAM than that box has, so it runs in CI.
`ruff-check`, `ruff-format`, and `mypy` pass.

## Notes

AI assistance was used.
This is a deterministic test-infrastructure fix, so model evals do not apply.
The root fix belongs upstream: make `modeling_utils.py:4736` defensive like line 4829. I will file that with transformers separately.
