### PR TITLE
[Bugfix][Model] Inkling sm_12x (GB10) boot + memory-safety fixes

### DIFF
--- a/vllm/models/inkling/nvidia/ops/fa4_rel_attention.py
+++ b/vllm/models/inkling/nvidia/ops/fa4_rel_attention.py
@@ -50,7 +50,16 @@ def _get_score_mod(rel_extent: int) -> Callable:
         rel_idx = rel_dist_0 if rel_dist_0 >= 0 else 0
         rel_idx = rel_idx if rel_idx < rel_extent else (rel_extent - 1)
 
-        rel_bias = rel_logits[global_q_idx[0], h_idx[0], rel_idx]
+        # Clamp the q-row symmetrically with the kv index above: score_mod
+        # evaluates on ALL tile coordinates before masking, and an out-of-range
+        # global_q_idx wraps the 64-bit gather address (deterministic illegal
+        # access on sm_121a warmup; see #49049). Bit-identical in-range.
+        n_rows = rel_logits.shape[0]
+        g_row_0 = global_q_idx[0]
+        g_row = g_row_0 if g_row_0 >= 0 else 0
+        g_row = g_row if g_row < n_rows else (n_rows - 1)
+
+        rel_bias = rel_logits[g_row, h_idx[0], rel_idx]
         rel_bias = Float32(rel_bias) if rel_dist_0 == rel_idx else Float32(0.0)
         return scores + rel_bias
 
@@ -69,6 +78,12 @@ def inkling_fa4_num_splits(
     """Return the split-KV cap for Inkling relative attention."""
     capability = current_platform.get_device_capability()
     if capability is not None and capability.major == 9:
+        return 1
+    # SM12x takes the vllm_flash_attn cute SM120 forward (the sheared-bias
+    # path is SM100/SM110-only), which supports neither split-KV nor paged
+    # KV in current vllm-flash-attn (ed4b7342: "SM120 forward only supports
+    # num_splits=1"). Cap at 1 to avoid an AssertionError in cutedsl_warmup.
+    if capability is not None and capability.major >= 12:
         return 1
     if is_local:
         return 1

--- a/vllm/models/inkling/nvidia/ops/qkvr_prep.py
+++ b/vllm/models/inkling/nvidia/ops/qkvr_prep.py
@@ -4,7 +4,6 @@
 import torch
 
 from vllm.triton_utils import tl, triton
-from vllm.utils.torch_utils import aux_stream
 
 LOW_BLOCK_M = 32
 LOW_BLOCK_N = 64
@@ -867,33 +866,33 @@ def fused_qkvr_prep(
         )
         return q_out, rel_out
 
-    kv_stream = aux_stream()
-    assert kv_stream is not None
-    current_stream = torch.cuda.current_stream()
-    kv_stream.wait_stream(current_stream)
-    with torch.cuda.stream(kv_stream):
-        _run_tiled_kv(
+    # Run the KV write on the main stream: the aux-stream fork races the
+    # attention read under un-serialized execution / CUDA graph capture
+    # (#49049, fault surfaces downstream and is easily misattributed).
+    # Write-before-read by program order; measured ~0 prefill cost (937 vs
+    # 943 t/s on 8xGB10 TP=8).
+    _run_tiled_kv(
             qkvr,
             k_weight,
             v_weight,
             k_norm_weight,
-            conv_cache,
-            key_cache,
-            value_cache,
-            positions,
-            seq_idx,
-            conv_slot_mapping,
-            conv_block_table,
-            query_start,
-            attention_slot_mapping,
-            eps=eps,
-            num_q_heads=num_q_heads,
-            num_kv_heads=num_kv_heads,
-            head_dim=head_dim,
-            off_k=off_k,
-            off_v=off_v,
-            conv_block_size=conv_block_size,
-        )
+        conv_cache,
+        key_cache,
+        value_cache,
+        positions,
+        seq_idx,
+        conv_slot_mapping,
+        conv_block_table,
+        query_start,
+        attention_slot_mapping,
+        eps=eps,
+        num_q_heads=num_q_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        off_k=off_k,
+        off_v=off_v,
+        conv_block_size=conv_block_size,
+    )
     _run_tiled_q(
         qkvr,
         q_norm_weight,
@@ -914,5 +913,4 @@ def fused_qkvr_prep(
         head_dim=head_dim,
         d_rel=d_rel,
     )
-    current_stream.wait_stream(kv_stream)
     return q_out, rel_out


### PR DESCRIPTION
## Summary

Three small fixes for **Inkling on consumer Blackwell (sm_120/sm_121, DGX Spark / GB10)**. Without them the model cannot boot on sm_121: every rank dies in `cutedsl_warmup`, and (with an SM120-paged flash-attn build) two latent memory-safety bugs remain.

### 1. `inkling_fa4_num_splits`: cap at 1 for `capability.major >= 12`
SM12x routes Inkling relative attention to the `vllm.vllm_flash_attn.cute` SM120 forward (`_use_sheared_bias()` is SM100/SM110-only). The current vllm-flash-attn pin (`ed4b7342`) asserts `num_splits == 1` there ("SM120 forward only supports num_splits=1"), so the computed splits crash all ranks in warmup with `AssertionError`. Same shape as the existing Hopper (`major == 9`) guard. (Split-KV on SM120 exists upstream as Dao-AILab/flash-attention#2336 — the cap can be relaxed once vllm-flash-attn picks that up.)

### 2. score_mod rel-bias gather: clamp the q-row (from #49049 bug 1, validated fix)
`apply_score_mod` evaluates on **all** tile coordinates before masking; the kv index is clamped but the q-row (`global_q_idx`) is not, and an out-of-range row wraps the 64-bit gather address → deterministic illegal memory access in `_initialize_kv_caches` warmup on sm_121a (GPU coredump evidence in #49049: warp illegal address in `FlashAttentionForwardSm120`, byte-identical fault state on two ranks). Clamp is bit-identical for in-range traffic (md5-verified by the #49049 author).

### 3. `qkvr_prep`: KV-cache write on the main stream (from #49049 bug 2, validated fix)
The tiled path (tokens ≥ 128) forks the KV write onto `aux_stream()`, which races the attention read under un-serialized execution / CUDA graph capture — the fault surfaces at the next downstream sync point and is easily misattributed. Moving the write to the main stream removes the hazard; the aux overlap is a prefill-only optimization and costs ~0 when removed (937 vs 943 t/s A/B on 8xGB10 TP=8, per #49049).

## Validation

With these three fixes (plus an SM120 paged-KV flash-attn build — see note), **Inkling-NVFP4 boots and serves on 8× DGX Spark (GB10, sm_121a), TP=8/EP=8**: 34/34 shards load, `CuTeDSL warmup compiled 28 units`, KV profiled ~18 GiB/rank, and the full endpoint suite passes — OpenAI + Anthropic APIs, SSE streaming, tool calls, multi-turn reasoning replay with clean `reasoning_content` splits, and **vision inputs** (1873 image tokens through the multimodal tower).

Note on the remaining sm_121 gap: vllm-flash-attn's SM120 forward still rejects **paged KV** ("Paged KV not supported on SM 12.0 in this PR"), which vLLM requires. We run a flash-attn branch with Dao-AILab/flash-attention#2348 (+#2336) integrated onto the vllm-flash-attn fork — integration notes at [ianlevesque/flash-attention@inkling-sm120-paged](https://github.com/ianlevesque/flash-attention/tree/inkling-sm120-paged) (includes one merge-artifact fix: `mDynamicCausal` threading through the SM80-base kernel signature, which whoever merges #2348 into the fork will also need).

Ref #49049.
