### PR TITLE
[Bugfix][V1] Free _re_block_ids on aborted requests with enable_return_routed_experts

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2199,6 +2199,13 @@ class Scheduler(SchedulerInterface):
         assert request.is_finished()
 
         self._inflight_prefills.discard(request)
+        if self.enable_return_routed_experts:
+            # Drop the schedule-time block-ID snapshot. update_from_output only
+            # pops _re_block_ids on the token-emitting path; a request aborted or
+            # finished while in flight takes the `request is None or
+            # request.is_finished(): continue` branch before that pop, so clean
+            # it up here on the common finish/abort funnel to avoid a leak.
+            self._re_block_ids.pop(request.request_id, None)
         connector_delay_free_blocks, kv_xfer_params = self._connector_finished(request)
 
         # EC Connector: mirror the KV hook. The contract requires firing


### PR DESCRIPTION
## Purpose

`_re_block_ids` (in `vllm/v1/core/sched/scheduler.py`) snapshots each scheduled request's attention block IDs so `update_from_output` can read routed-expert data even if a later `schedule()` frees the blocks. It leaks on the abort path.

The asymmetry:

- **Populate** — `_update_after_schedule` adds an entry for **every** scheduled request, every step, unconditionally:
  ```python
  if self.enable_return_routed_experts:
      self._re_block_ids.update({rid: ... for rid in num_scheduled_tokens})
  ```
- **Free** — the only `pop` is in `update_from_output`, guarded by `enable_return_routed_experts and routing_data is not None and new_token_ids`.

A request aborted or finished while in flight takes this branch first:

```python
if request is None or request.is_finished():
    # aborted while the model is executing it (async scheduling / PP)
    continue
```

so it never reaches the pop, and `_free_request` — the common finish/abort funnel — never touches `_re_block_ids` either. Result: one orphaned dict entry per aborted-in-flight request, growing unbounded over the server's lifetime. The window is narrow under synchronous scheduling but routinely reachable with async scheduling / PP>1, which the code's own comment calls out.

## Fix

Free the entry in `_free_request`, mirroring the adjacent `_inflight_prefills.discard(request)`. Guarded on `enable_return_routed_experts` since the dict is only created then, and safe for the normal path: a finished request is never rescheduled, and the token-emitting pop already ran (a redundant `pop(..., None)` is a no-op).

## Test Plan

Bookkeeping-only change, verifiable by reading. A unit test that schedules a request, aborts it while its `_re_block_ids` entry is live, and asserts the dict is empty after `_free_request` would cover it; no GPU needed. Confirmed the module byte-compiles.