### PR TITLE
Fix KV event aggregation across workers

### DIFF
--- a/tests/distributed/test_kv_cache_events.py
+++ b/tests/distributed/test_kv_cache_events.py
@@ -6,7 +6,12 @@ from typing import Any
 import msgspec
 import pytest
 
-from vllm.distributed.kv_events import BlockRemoved, BlockStored
+from vllm.distributed.kv_events import (
+    AllBlocksCleared,
+    BlockRemoved,
+    BlockStored,
+    KVEventAggregator,
+)
 
 # Minimal ExternalBlockHash for testing (bytes are a valid ExternalBlockHash).
 _FAKE_HASH: bytes = b"\xab" * 32
@@ -183,3 +188,46 @@ def test_block_removed_locality_is_wire_compatible():
     new_payload = msgspec.msgpack.encode(_make_block_removed(locality="REMOTE"))
     assert msgspec.msgpack.decode(new_payload)["locality"] == "REMOTE"
     assert msgspec.msgpack.decode(new_payload, type=_LegacyBlockRemoved).medium == "GPU"
+
+
+def test_aggregator_intersects_worker_event_multiplicities():
+    event = _make_block_stored()
+    aggregator = KVEventAggregator(num_workers=2)
+
+    aggregator.add_events([event, event])
+    aggregator.add_events([event])
+
+    assert aggregator.get_common_events() == [event]
+    assert aggregator.get_all_events() == [event, event, event]
+
+
+def test_duplicate_events_cannot_substitute_for_a_worker_batch():
+    event = _make_block_stored()
+    aggregator = KVEventAggregator(num_workers=2)
+
+    aggregator.add_events([event, event])
+
+    assert aggregator.get_common_events() == []
+
+
+def test_aggregator_merge_preserves_worker_event_batches():
+    event = _make_block_stored()
+    first_worker = KVEventAggregator(num_workers=1)
+    second_worker = KVEventAggregator(num_workers=1)
+    first_worker.add_events([event, event])
+    second_worker.add_events([event])
+
+    first_worker.merge(second_worker)
+
+    assert first_worker.get_number_of_workers() == 2
+    assert first_worker.get_common_events() == [event]
+
+
+def test_all_blocks_cleared_can_be_aggregated():
+    event = AllBlocksCleared()
+    aggregator = KVEventAggregator(num_workers=2)
+
+    aggregator.add_events([event])
+    aggregator.add_events([event])
+
+    assert aggregator.get_common_events() == [event]

--- a/tests/v1/kv_connector/unit/test_lmcache_connector.py
+++ b/tests/v1/kv_connector/unit/test_lmcache_connector.py
@@ -461,13 +461,10 @@ class TestTakeEvents:
             lora_name=None,
         )
 
-        # All 3 workers report common_event
+        # All 3 workers report common_event, but only one reports uncommon_event
+        kv_events.add_events([common_event, uncommon_event])
         kv_events.add_events([common_event])
         kv_events.add_events([common_event])
-        kv_events.add_events([common_event])
-
-        # Only 1 worker reports uncommon_event
-        kv_events.add_events([uncommon_event])
 
         mock_connector._kv_cache_events = kv_events
 

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -114,7 +114,8 @@ class BlockRemoved(KVCacheEvent):
 
 
 class AllBlocksCleared(KVCacheEvent):
-    pass
+    def __hash__(self) -> int:
+        return hash(AllBlocksCleared)
 
 
 class KVEventBatch(EventBatch):
@@ -124,16 +125,22 @@ class KVEventBatch(EventBatch):
 class KVEventAggregator:
     """
     Aggregates KV events across multiple workers.
-    Tracks how many times each event appears and returns only those
-    that were emitted by all workers.
+    Treats each worker's events as a multiset and returns their intersection.
     """
 
-    __slots__ = ("_event_counter", "_num_workers")
+    __slots__ = (
+        "_common_event_counter",
+        "_event_counter",
+        "_num_event_batches",
+        "_num_workers",
+    )
 
     def __init__(self, num_workers: int) -> None:
         if num_workers <= 0:
             raise ValueError("num_workers must be greater than zero.")
+        self._common_event_counter: Counter[KVCacheEvent] = Counter()
         self._event_counter: Counter[KVCacheEvent] = Counter()
+        self._num_event_batches = 0
         self._num_workers: int = num_workers
 
     def add_events(self, events: list[KVCacheEvent]) -> None:
@@ -145,7 +152,13 @@ class KVEventAggregator:
         """
         if not isinstance(events, list):
             raise TypeError("events must be a list of KVCacheEvent.")
-        self._event_counter.update(events)
+        worker_event_counter = Counter(events)
+        self._event_counter.update(worker_event_counter)
+        if self._num_event_batches == 0:
+            self._common_event_counter = worker_event_counter.copy()
+        else:
+            self._common_event_counter &= worker_event_counter
+        self._num_event_batches += 1
 
     def get_common_events(self) -> list[KVCacheEvent]:
         """
@@ -154,11 +167,9 @@ class KVEventAggregator:
         Returns:
             List of events present in all workers.
         """
-        return [
-            event
-            for event, count in self._event_counter.items()
-            if count == self._num_workers
-        ]
+        if self._num_event_batches != self._num_workers:
+            return []
+        return list(self._common_event_counter.elements())
 
     def get_all_events(self) -> list[KVCacheEvent]:
         """
@@ -173,7 +184,29 @@ class KVEventAggregator:
         """
         Clear all tracked events.
         """
+        self._common_event_counter.clear()
         self._event_counter.clear()
+        self._num_event_batches = 0
+
+    def merge(self, other: "KVEventAggregator") -> None:
+        """
+        Merge worker event batches from another aggregator.
+
+        Args:
+            other: Aggregator whose workers and events should be merged.
+        """
+        other_common_events = other._common_event_counter.copy()
+        other_events = other._event_counter.copy()
+        other_num_event_batches = other._num_event_batches
+        other_num_workers = other._num_workers
+
+        if self._num_event_batches == 0:
+            self._common_event_counter = other_common_events
+        elif other_num_event_batches:
+            self._common_event_counter &= other_common_events
+        self._event_counter.update(other_events)
+        self._num_event_batches += other_num_event_batches
+        self._num_workers += other_num_workers
 
     def increment_workers(self, count: int = 1) -> None:
         """
@@ -204,7 +237,8 @@ class KVEventAggregator:
     def __repr__(self) -> str:
         return (
             f"<KVEventAggregator workers={self._num_workers}, "
-            f"events={len(self._event_counter)}>"
+            f"event_batches={self._num_event_batches}, "
+            f"events={sum(self._event_counter.values())}>"
         )
 
 
@@ -240,6 +274,7 @@ class KVConnectorKVEvents(ABC):
 
     def merge(self, other: "KVConnectorKVEvents") -> "KVConnectorKVEvents":
         self.add_events(other.get_all_events())
+        self.increment_workers(other.get_number_of_workers())
         return self
 
 

--- a/vllm/distributed/kv_transfer/kv_connector/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/utils.py
@@ -150,9 +150,7 @@ class KVOutputAggregator:
                     combined_kv_cache_events,
                     type(kv_cache_events),
                 )
-                worker_kv_cache_events = kv_cache_events.get_all_events()
-                combined_kv_cache_events.add_events(worker_kv_cache_events)
-                combined_kv_cache_events.increment_workers(1)
+                combined_kv_cache_events.merge(kv_cache_events)
 
             invalid_block_ids |= kv_output.invalid_block_ids
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_connector.py
@@ -55,6 +55,12 @@ class LMCacheKVEvents(KVConnectorKVEvents):
     def increment_workers(self, count: int = 1) -> None:
         self._aggregator.increment_workers(count)
 
+    def merge(self, other: KVConnectorKVEvents) -> "LMCacheKVEvents":
+        if not isinstance(other, LMCacheKVEvents):
+            raise TypeError("Can only merge LMCacheKVEvents.")
+        self._aggregator.merge(other._aggregator)
+        return self
+
     def get_all_events(self) -> list[KVCacheEvent]:
         return self._aggregator.get_all_events()
 
@@ -316,10 +322,7 @@ class LMCacheConnectorV1(KVConnectorBase_V1):
         if self._kv_cache_events is None:
             self._kv_cache_events = kv_cache_events
         else:
-            self._kv_cache_events.add_events(kv_cache_events.get_all_events())
-            self._kv_cache_events.increment_workers(
-                kv_cache_events.get_number_of_workers()
-            )
+            self._kv_cache_events.merge(kv_cache_events)
         return
 
     def request_finished(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
@@ -70,6 +70,12 @@ class MooncakeStoreKVEvents(KVConnectorKVEvents):
     def increment_workers(self, count: int = 1) -> None:
         self._aggregator.increment_workers(count)
 
+    def merge(self, other: KVConnectorKVEvents) -> "MooncakeStoreKVEvents":
+        if not isinstance(other, MooncakeStoreKVEvents):
+            raise TypeError("Can only merge MooncakeStoreKVEvents.")
+        self._aggregator.merge(other._aggregator)
+        return self
+
     def get_all_events(self) -> list[KVCacheEvent]:
         return self._aggregator.get_all_events()
 
@@ -242,10 +248,7 @@ class MooncakeStoreConnector(KVConnectorBase_V1, SupportsHMA):
         if self._kv_cache_events is None:
             self._kv_cache_events = kv_cache_events
         else:
-            self._kv_cache_events.add_events(kv_cache_events.get_all_events())
-            self._kv_cache_events.increment_workers(
-                kv_cache_events.get_number_of_workers()
-            )
+            self._kv_cache_events.merge(kv_cache_events)
 
     def take_events(self) -> Iterable[KVCacheEvent]:
         if self._kv_cache_events is not None:


### PR DESCRIPTION
## Purpose

Fix incorrect KV event aggregation when workers emit duplicate events.

The previous implementation counted events globally. As a result, duplicate
events from one worker could be mistaken for events reported by multiple
workers, while valid common events could be dropped when their total count
exceeded the worker count.

This change:

- Computes a multiset intersection across individual worker batches.
- Preserves worker boundaries when LMCache and Mooncake events are merged.
- Makes `AllBlocksCleared` hashable.
- Adds regression tests for duplicate, missing, merged, and clear events.

I searched existing issues and PRs and did not find an open change implementing
this fix. No public API, configuration, or wire-format changes are introduced.

## Test Plan

```bash
.venv/bin/python -m pytest -q \
  tests/distributed/test_kv_cache_events.py \
  tests/v1/kv_connector/unit/test_lmcache_connector.py

## Test Result
42 passed in 17.90s
Ruff check: passed
Ruff format: passed
Mypy: passed