### PR TITLE
[Bugfix] Fix DFlash/MTP crash on non-CUDA backends: graceful page_size_padded fallback

### DIFF
--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1076,11 +1076,11 @@ def unify_kv_cache_spec_page_size(
     size by increasing the block size of layers with smaller page size. Two
     cases cannot be unified by block size alone and pad their physical page to
     the maximum instead: Mamba layers, whose page size comes from state shapes
-    and is independent of block size; and attention layers whose page does not
-    evenly divide the maximum and whose backend opts in via
-    ``AttentionSpec.indexes_kv_by_block_stride`` (the padded page is read through
-    a strided view, which not every backend handles). Raise NotImplementedError
-    if failed to unify the page size.
+    and is independent of block size; and attention layers, which set
+    ``page_size_padded`` (the padded page is read through a strided view when
+    ``indexes_kv_by_block_stride`` is True, or read physically when False).
+    Raise NotImplementedError only for non-attention layers that cannot be
+    unified.
 
     Args:
         kv_cache_spec: The KVCacheSpec of each attention layer in the model
@@ -1118,6 +1118,8 @@ def unify_kv_cache_spec_page_size(
                 isinstance(layer_spec, AttentionSpec)
                 and layer_spec.indexes_kv_by_block_stride
             ):
+                new_spec = replace(layer_spec, page_size_padded=max_page_size)
+            elif isinstance(layer_spec, AttentionSpec):
                 new_spec = replace(layer_spec, page_size_padded=max_page_size)
             else:
                 raise NotImplementedError(


### PR DESCRIPTION
## Problem

Speculative decoding (DFlash/MTP) crashes on non-CUDA backends (e.g., Ascend NPU) when the draft model has different attention dimensions than the target model.

**Root cause**: `unify_kv_cache_spec_page_size()` in `vllm/v1/core/kv_cache_utils.py` raises `NotImplementedError` for backends that do not implement `indexes_kv_by_block_stride = True`.

On CUDA/H20, FlashAttention supports strided KV indexing, so the code falls through to `page_size_padded`. Ascend and other backends default to `False`, hitting the raise.

## Fix

Add an `elif isinstance(layer_spec, AttentionSpec)` fallback before the `raise NotImplementedError`:

```python
# Before:
else:
    raise NotImplementedError(...)

# After:
elif isinstance(layer_spec, AttentionSpec):
    new_spec = replace(layer_spec, page_size_padded=max_page_size)
else:
    raise NotImplementedError(...)
```

Same pattern already used for `MambaSpec` (line 1108) and strided `AttentionSpec` (line 1121).

## Safety

- `page_size_padded` only affects memory allocation — kernels compute layout from `num_kv_heads × head_size` independently
- Identical to CUDA path behavior (line 1121), just without strided view
- Minimal memory overhead: only draft model layers get padded

## Tested

- [x] Qwen3.5-35B-A3B + DFlash on Ascend 910C — previously crashed, now works
- [x] MTP on same model — no regression
- [x] Multi-concurrency (con=1,4,8) — TPOT stable

## Changes

| File | +/- |
|------|-----|
| `vllm/v1/core/kv_cache_utils.py` | +7 / −5 |

---
*AI assistance used.*