### PR TITLE
[Bugfix] Track token usage for ParsableContext

### DIFF
--- a/tests/entrypoints/openai/responses/test_parsable_context.py
+++ b/tests/entrypoints/openai/responses/test_parsable_context.py
@@ -216,6 +216,11 @@ async def test_mcp_tool_call(client: OpenAI, model_name: str):
     output_types = [getattr(o, "type", None) for o in response.output]
     log_response_diagnostics(response, label="test_mcp_tool_call")
 
+    assert response.usage.input_tokens_details.input_tokens_per_turn
+    assert response.usage.output_tokens_details.output_tokens_per_turn
+    assert response.usage.output_tokens_details.tool_output_tokens > 0
+    assert response.usage.output_tokens_details.tool_output_tokens_per_turn
+
     assert response.status == "completed", (
         f"Response status={response.status} "
         f"(details={getattr(response, 'incomplete_details', None)}). "

--- a/tests/entrypoints/openai/responses/test_parsable_context_unit.py
+++ b/tests/entrypoints/openai/responses/test_parsable_context_unit.py
@@ -162,11 +162,13 @@ def _make_request_output(
     text: str = "Hello, world!",
     token_ids: Sequence[int] = (1, 2, 3),
     finish_reason: str = "stop",
+    prompt_token_ids: Sequence[int] | None = (),
+    num_cached_tokens: int | None = 0,
 ) -> RequestOutput:
     return RequestOutput(
         request_id="test",
         prompt=None,
-        prompt_token_ids=[],
+        prompt_token_ids=(None if prompt_token_ids is None else list(prompt_token_ids)),
         prompt_logprobs=None,
         outputs=[
             CompletionOutput(
@@ -179,6 +181,7 @@ def _make_request_output(
             )
         ],
         finished=True,
+        num_cached_tokens=num_cached_tokens,
     )
 
 
@@ -361,3 +364,60 @@ def test_num_init_messages_offset():
     items = ctx.make_response_output_items()
     assert len(items) == 1
     assert items[0].type == "message"
+
+
+# ---------------------------------------------------------------------------
+# Tests: token usage
+# ---------------------------------------------------------------------------
+
+
+def test_single_turn_token_usage():
+    ctx = _make_context(_NoOpParser)
+
+    ctx.append_output(
+        _make_request_output(
+            prompt_token_ids=(10, 11, 12, 13),
+            token_ids=(20, 21, 22),
+            num_cached_tokens=2,
+        )
+    )
+
+    assert ctx.num_prompt_tokens == 4
+    assert ctx.num_output_tokens == 3
+    assert ctx.num_cached_tokens == 2
+    assert ctx.num_tool_output_tokens == 0
+    assert len(ctx.all_turn_metrics) == 1
+    turn = ctx.all_turn_metrics[0]
+    assert turn.input_tokens == 4
+    assert turn.output_tokens == 3
+    assert turn.cached_input_tokens == 2
+    assert turn.tool_output_tokens == 0
+
+
+def test_multi_turn_token_usage_counts_tool_output():
+    ctx = _make_context(_NoOpParser)
+
+    ctx.append_output(
+        _make_request_output(
+            prompt_token_ids=(10, 11, 12, 13),
+            token_ids=(20, 21),
+            num_cached_tokens=1,
+        )
+    )
+    ctx.append_output(
+        _make_request_output(
+            prompt_token_ids=(10, 11, 12, 13, 20, 21, 30, 31, 32),
+            token_ids=(40, 41, 42),
+            num_cached_tokens=4,
+        )
+    )
+
+    assert ctx.num_prompt_tokens == 13
+    assert ctx.num_output_tokens == 5
+    assert ctx.num_cached_tokens == 5
+    assert ctx.num_tool_output_tokens == 3
+    assert len(ctx.all_turn_metrics) == 2
+    assert [turn.input_tokens for turn in ctx.all_turn_metrics] == [4, 9]
+    assert [turn.output_tokens for turn in ctx.all_turn_metrics] == [2, 3]
+    assert [turn.cached_input_tokens for turn in ctx.all_turn_metrics] == [1, 4]
+    assert [turn.tool_output_tokens for turn in ctx.all_turn_metrics] == [0, 3]

--- a/vllm/entrypoints/openai/responses/context.py
+++ b/vllm/entrypoints/openai/responses/context.py
@@ -305,8 +305,10 @@ class ParsableContext(ConversationContext):
         self.num_output_tokens = 0
         self.num_cached_tokens = 0
         self.num_reasoning_tokens = 0
-        # not implemented yet for ParsableContext
+        self.num_tool_output_tokens = 0
+        self.current_turn_metrics = TurnMetrics()
         self.all_turn_metrics: list[TurnMetrics] = []
+        self.is_first_turn = True
 
         self.response_messages: list[ResponseInputOutputItem] = response_messages
         self.num_init_messages = len(response_messages)
@@ -334,9 +336,11 @@ class ParsableContext(ConversationContext):
         self.ec_transfer_params: dict[str, Any] | None = None
 
     def append_output(self, output: RequestOutput) -> None:
-        self.num_prompt_tokens = len(output.prompt_token_ids or [])
-        self.num_cached_tokens = output.num_cached_tokens or 0
-        self.num_output_tokens += len(output.outputs[0].token_ids or [])
+        self._update_prefill_token_usage(output)
+        self._update_decode_token_usage(output)
+        self.all_turn_metrics.append(self.current_turn_metrics.copy())
+        self.current_turn_metrics.reset()
+
         if output.kv_transfer_params is not None:
             self.kv_transfer_params = output.kv_transfer_params
 
@@ -406,6 +410,42 @@ class ParsableContext(ConversationContext):
                     tokens=completion.token_ids,
                 )
             )
+
+    def _update_prefill_token_usage(self, output: RequestOutput) -> None:
+        if output.prompt_token_ids is None:
+            input_tokens = 0
+            logger.error("RequestOutput appended contains no prompt_token_ids.")
+        else:
+            input_tokens = len(output.prompt_token_ids)
+
+        self.current_turn_metrics.input_tokens = input_tokens
+        self.num_prompt_tokens += input_tokens
+
+        if self.is_first_turn:
+            self.is_first_turn = False
+        else:
+            previous_turn = self.all_turn_metrics[-1]
+            tool_output_tokens = (
+                input_tokens - previous_turn.input_tokens - previous_turn.output_tokens
+            )
+            if tool_output_tokens < 0:
+                logger.error(
+                    "Negative tool output tokens calculated: %d. Setting to 0.",
+                    tool_output_tokens,
+                )
+                tool_output_tokens = 0
+
+            self.num_tool_output_tokens += tool_output_tokens
+            self.current_turn_metrics.tool_output_tokens = tool_output_tokens
+
+        cached_input_tokens = output.num_cached_tokens or 0
+        self.num_cached_tokens += cached_input_tokens
+        self.current_turn_metrics.cached_input_tokens = cached_input_tokens
+
+    def _update_decode_token_usage(self, output: RequestOutput) -> None:
+        output_tokens = sum(len(item.token_ids) for item in output.outputs)
+        self.num_output_tokens += output_tokens
+        self.current_turn_metrics.output_tokens = output_tokens
 
     def append_tool_output(self, output: list[ResponseInputOutputItem]) -> None:
         self.response_messages.extend(output)

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -838,9 +838,7 @@ class OpenAIServingResponses(GenerateBaseServing):
                 input_messages = context.input_messages
                 output_messages = context.output_messages
 
-            # TODO: Calculate usage.
-            # assert final_res.prompt_token_ids is not None
-            num_tool_output_tokens = 0
+            num_tool_output_tokens = context.num_tool_output_tokens
 
             # Check finish reason from the parser
             if context.finish_reason == "length":


### PR DESCRIPTION
## Summary

Track per-turn and aggregate token usage for `ParsableContext`, including
prompt, cached, generated, and tool-output tokens. Use the resulting tool token
count in non-streaming Responses API usage instead of always returning zero.

This also extends the existing MCP end-to-end test with public response usage
assertions.

## Why this is not duplicate work

This completes the remaining non-streaming `ParsableContext` accounting work
from #30759. That issue was closed by the stale bot rather than by a completed
fix.

The earlier #31094 is closed and attempted a substantially larger streaming
parser refactor. Reviewer feedback asked for the non-streaming token accounting
to be split into a focused PR; this change implements only that smaller scope.
No open PR matching #30759 or `ParsableContext` token usage was found before
starting this work.

## Tests

- `.venv/bin/python -m pytest tests/entrypoints/openai/responses/test_parsable_context_unit.py -v`
  - `12 passed`
- `pre-commit run ruff-check --files <changed Python files>`
  - passed
- `pre-commit run ruff-format --files <changed Python files>`
  - passed
- `git diff --check`
  - passed

The existing `test_mcp_tool_call` end-to-end test now also checks per-turn and
tool-output usage through the public response schema. It was not run locally
because its Qwen3-8B fixture does not fit the available 4 GiB GPU; it is left to
the existing GPU CI job.

## Model evaluation

Not applicable. This changes response accounting only and does not alter model
inputs, sampling, or generated outputs.

## AI assistance

OpenAI Codex was used to research the issue history, implement the change, and
run the tests.

- [x] I have reviewed and understand every changed line and can defend the
  implementation and test scope.
