### PR TITLE
[Docs] Validate SmolLM2 batch invariance

### DIFF
--- a/docs/features/batch_invariance.md
+++ b/docs/features/batch_invariance.md
@@ -108,6 +108,7 @@ Batch invariance has been tested and verified on the following models:
 - **GPT-OSS**: `openai/gpt-oss-20b`, `openai/gpt-oss-120b`
 - **Mistral**: `mistralai/Mistral-7B-v0.3`
 - **Phi series**: `microsoft/Phi-3.5-mini-instruct`
+- **SmolLM2**: `HuggingFaceTB/SmolLM2-360M-Instruct`
 
 Other models may also work, but these have been explicitly validated. If you encounter issues with a specific model, please report them on the [GitHub issue tracker](https://github.com/vllm-project/vllm/issues/new/choose).
 


### PR DESCRIPTION
## Summary

Add `HuggingFaceTB/SmolLM2-360M-Instruct` to the batch-invariance tested-models
list after validating it with vLLM's determinism tests.

Fixes #49708

## Why this is not duplicate work

Before validation, searches of open and closed issues and PRs found no existing
claim or validation for `HuggingFaceTB/SmolLM2-360M-Instruct`. This is separate
from the already claimed TinyLlama validation under the #27433 tracker.

## Validation environment

- vLLM commit: `163ecba37766e22036d8456a64d9122520647ab7`
- GPU: NVIDIA GeForce RTX 3050 Ti Laptop GPU, 4 GiB, SM 8.6
- OS: Ubuntu 22.04 under WSL2
- Model runner: default V2 runner
- `VLLM_BATCH_INVARIANT=1`
- `VLLM_WSL2_ENABLE_PIN_MEMORY=1`
- `VLLM_USE_FLASHINFER_SAMPLER=0`

## Model evaluation

Official needle-in-batch test, unchanged, batch size 8 and 5 trials per
backend:

```text
FLASH_ATTN     5/5 matched
FLEX_ATTENTION 5/5 matched
TRITON_ATTN    5/5 matched
3 passed
```

The bitwise BS=1 versus BS=32 token/logprob test also passed across all three
backends and both block configurations:

```text
6 passed
```

Because the local GPU has 4 GiB, that second test used the same test function
and assertions with only two resource parameters reduced:
`gpu_memory_utilization=0.75` and `max_num_seqs=32`. The original hardcoded
`0.9` reservation failed before model loading because only 3.21 of 4.0 GiB was
free; it did not produce a model correctness failure.

## Documentation checks

- `pre-commit run markdownlint-cli2 --files docs/features/batch_invariance.md`
  - passed
- `git diff --check`
  - passed

## AI assistance

OpenAI Codex was used to research existing claims, prepare the validation
environment, run the tests, and draft this documentation update.

- [x] I have reviewed and understand the change and validation results and can
  defend them during review.
