### PR TITLE
[Core][Kernel] Support dynamic activation scaling for ModelOpt NVFP4

### DIFF
--- a/docs/features/quantization/modelopt.md
+++ b/docs/features/quantization/modelopt.md
@@ -33,6 +33,36 @@ following `quantization.quant_algo` values:
     [Engine Arguments](../../configuration/engine_args.md) page and shown by
     `vllm serve --help=KernelConfig`.
 
+### Dynamic NVFP4 global activation scaling
+
+Serialized `NVFP4` checkpoints may set
+`quantization.activation_scheme: dynamic` in `hf_quant_config.json`. For dense
+linear layers, vLLM then derives one FP32 global activation scale from the
+current invocation instead of using the checkpoint's `input_scale`. Per-block
+activation scales remain part of the normal NVFP4 quantization.
+
+This mode currently:
+
+- accepts FP16 or BF16 activations;
+- requires an NVIDIA Blackwell GPU and the FlashInfer CUTLASS NVFP4 backend;
+- does not support `VLLM_BATCH_INVARIANT` or FusedMoE layers; and
+- requires fused output partitions to share the same `weight_scale_2`.
+
+The checkpoint must still include all standard serialized NVFP4 metadata:
+
+```json
+{
+  "producer": {"name": "modelopt"},
+  "quantization": {
+    "quant_algo": "NVFP4",
+    "activation_scheme": "dynamic",
+    "group_size": 16,
+    "kv_cache_quant_algo": null,
+    "exclude_modules": []
+  }
+}
+```
+
 ## Quantizing HuggingFace Models with PTQ
 
 You can quantize HuggingFace models using the example scripts provided in the Model Optimizer repository. The primary script for LLM PTQ is typically found within the `examples/llm_ptq` directory.

--- a/tests/fusion/test_quant_activation_contract.py
+++ b/tests/fusion/test_quant_activation_contract.py
@@ -115,6 +115,38 @@ def test_bridge_marks_supporting_and_skips_others():
     assert not hasattr(layer, "input_quant_key")
 
 
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_dynamic_nvfp4_global_scale_skips_bridge_and_handles_empty_input(dtype):
+    kernel = FlashInferCutlassNvFp4LinearKernel.__new__(
+        FlashInferCutlassNvFp4LinearKernel
+    )
+    kernel.config = NvFp4LinearLayerConfig(dynamic_input_global_scale=True)
+    assert kernel.input_quant_key() is None
+
+    layer = torch.nn.Module()
+    layer.output_size_per_partition = 32
+    inputs = torch.empty(0, 16, dtype=dtype)
+    output = kernel.apply_weights(layer, inputs)
+    assert output.shape == (0, 32)
+    assert output.dtype == dtype
+    assert output.device == inputs.device
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float8_e4m3fn])
+def test_dynamic_nvfp4_global_scale_rejects_unsupported_dtype_before_empty_return(
+    dtype,
+):
+    kernel = FlashInferCutlassNvFp4LinearKernel.__new__(
+        FlashInferCutlassNvFp4LinearKernel
+    )
+    kernel.config = NvFp4LinearLayerConfig(dynamic_input_global_scale=True)
+    layer = torch.nn.Module()
+    layer.output_size_per_partition = 32
+
+    with pytest.raises(ValueError, match="requires FP16 or BF16"):
+        kernel.apply_weights(layer, torch.empty(0, 16, dtype=dtype))
+
+
 def test_as_quantized_activation_validates_key():
     qa = QuantizedActivation(
         data=torch.zeros(2, 4, dtype=current_platform.fp8_dtype()),

--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -473,6 +473,134 @@ def test_modelopt_nvfp4_config_dispatches_w4a4_method():
     assert config.quant_method == "NVFP4"
 
 
+def test_modelopt_nvfp4_parses_dynamic_activation_scheme():
+    config = ModelOptNvFp4Config.from_config(
+        {
+            "quant_method": "modelopt",
+            "quantization": {
+                "quant_algo": "NVFP4",
+                "activation_scheme": "dynamic",
+                "group_size": 16,
+                "kv_cache_quant_algo": None,
+                "exclude_modules": [],
+            },
+        }
+    )
+
+    assert config.activation_scheme == "dynamic"
+
+
+def test_modelopt_nvfp4_dynamic_activation_ignores_loaded_input_scale():
+    config = ModelOptNvFp4Config(
+        quant_method="NVFP4",
+        is_checkpoint_nvfp4_serialized=True,
+        kv_cache_quant_algo=None,
+        exclude_modules=[],
+        activation_scheme="dynamic",
+    )
+    kernel = MagicMock()
+    with patch(
+        "vllm.model_executor.layers.quantization.modelopt.init_nvfp4_linear_kernel",
+        return_value=kernel,
+    ) as init_kernel:
+        method = ModelOptNvFp4LinearMethod(config)
+
+    layer = torch.nn.Module()
+    layer.register_parameter(
+        "input_scale",
+        torch.nn.Parameter(torch.tensor([float("nan")]), requires_grad=False),
+    )
+    layer.register_parameter(
+        "weight_scale_2",
+        torch.nn.Parameter(torch.tensor([0.125, 0.125]), requires_grad=False),
+    )
+
+    method.process_weights_after_loading(layer)
+
+    init_kernel.assert_called_once_with(dynamic_input_global_scale=True)
+    assert not hasattr(layer, "input_scale")
+    assert not hasattr(layer, "weight_scale_2")
+    assert layer.weight_global_scale.item() == pytest.approx(0.125)
+    kernel.process_weights_after_loading.assert_called_once_with(layer)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_dynamic_nvfp4_global_scales_use_current_activation_amax(dtype):
+    from vllm.model_executor.kernels.linear.nvfp4.flashinfer import (
+        _dynamic_nvfp4_global_scales,
+    )
+
+    quant_scale, dequant_scale = _dynamic_nvfp4_global_scales(
+        torch.tensor([-1344.0, 672.0], dtype=dtype)
+    )
+
+    assert quant_scale.dtype == torch.float32
+    assert dequant_scale.dtype == torch.float32
+    assert dequant_scale.item() == pytest.approx(0.5)
+    assert quant_scale.item() == pytest.approx(2.0)
+
+
+def test_modelopt_nvfp4_dynamic_activation_validates_before_mutating_layer():
+    config = ModelOptNvFp4Config(
+        quant_method="NVFP4",
+        is_checkpoint_nvfp4_serialized=True,
+        kv_cache_quant_algo=None,
+        exclude_modules=[],
+        activation_scheme="dynamic",
+    )
+    kernel = MagicMock()
+    with patch(
+        "vllm.model_executor.layers.quantization.modelopt.init_nvfp4_linear_kernel",
+        return_value=kernel,
+    ):
+        method = ModelOptNvFp4LinearMethod(config)
+
+    layer = torch.nn.Module()
+    layer.register_parameter(
+        "input_scale",
+        torch.nn.Parameter(torch.tensor([0.25, 0.25]), requires_grad=False),
+    )
+    layer.register_parameter(
+        "weight_scale_2",
+        torch.nn.Parameter(torch.tensor([0.125, 0.25]), requires_grad=False),
+    )
+
+    with pytest.raises(ValueError, match="one shared weight_scale_2"):
+        method.process_weights_after_loading(layer)
+
+    assert hasattr(layer, "input_scale")
+    assert hasattr(layer, "weight_scale_2")
+    kernel.process_weights_after_loading.assert_not_called()
+
+
+def test_modelopt_nvfp4_rejects_invalid_activation_scheme():
+    with pytest.raises(ValueError, match="activation_scheme"):
+        ModelOptNvFp4Config(
+            quant_method="NVFP4",
+            is_checkpoint_nvfp4_serialized=True,
+            kv_cache_quant_algo=None,
+            exclude_modules=[],
+            activation_scheme="per_token",
+        )
+
+
+def test_modelopt_nvfp4_dynamic_activation_rejects_fused_moe():
+    from vllm.model_executor.layers.quantization.modelopt import (
+        ModelOptNvFp4FusedMoE,
+    )
+
+    config = ModelOptNvFp4Config(
+        quant_method="NVFP4",
+        is_checkpoint_nvfp4_serialized=True,
+        kv_cache_quant_algo=None,
+        exclude_modules=[],
+        activation_scheme="dynamic",
+    )
+
+    with pytest.raises(ValueError, match="only for dense linear layers"):
+        ModelOptNvFp4FusedMoE(config, MagicMock())
+
+
 def test_modelopt_nvfp4_config_dispatches_w4a16_method():
     """``quant_method="W4A16_NVFP4"`` routes to
     ``ModelOptNvFp4W4A16LinearMethod`` instead of the W4A4 sibling.

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -976,10 +976,15 @@ def init_wfp8_a16_linear_kernel(
     )
 
 
-def init_nvfp4_linear_kernel(use_a16: bool = False) -> NvFp4LinearKernel:
+def init_nvfp4_linear_kernel(
+    use_a16: bool = False,
+    dynamic_input_global_scale: bool = False,
+) -> NvFp4LinearKernel:
     """Select and instantiate the best NVFP4 linear kernel for the
     current platform."""
-    config = NvFp4LinearLayerConfig()
+    config = NvFp4LinearLayerConfig(
+        dynamic_input_global_scale=dynamic_input_global_scale
+    )
     a16_kernels = (MarlinNvFp4LinearKernel, HummingNvFp4LinearKernel)
 
     # VLLM_BATCH_INVARIANT forces deterministic execution. Prefer the
@@ -987,7 +992,23 @@ def init_nvfp4_linear_kernel(use_a16: bool = False) -> NvFp4LinearKernel:
     # back to emulation. It overrides --linear-backend.
     force_kernel: type[NvFp4LinearKernel] | None = None
     linear_backend = _get_linear_backend()
-    if envs.VLLM_BATCH_INVARIANT:
+    if dynamic_input_global_scale:
+        if use_a16:
+            raise ValueError(
+                "Dynamic NVFP4 activation scaling cannot be combined with A16."
+            )
+        if envs.VLLM_BATCH_INVARIANT:
+            raise ValueError(
+                "Dynamic NVFP4 activation scaling is not compatible with "
+                "VLLM_BATCH_INVARIANT."
+            )
+        if linear_backend not in ("auto", "flashinfer_cutlass"):
+            raise ValueError(
+                "Dynamic NVFP4 activation scaling requires "
+                "--linear-backend=flashinfer_cutlass."
+            )
+        force_kernel = FlashInferCutlassNvFp4LinearKernel
+    elif envs.VLLM_BATCH_INVARIANT:
         bi_supported, reason = CutlassNvFp4LinearKernel.is_supported()
         if bi_supported:
             if linear_backend not in ("auto", "cutlass"):

--- a/vllm/model_executor/kernels/linear/nvfp4/base.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/base.py
@@ -15,10 +15,10 @@ class NvFp4LinearLayerConfig:
 
     All NVFP4 layers share the same structure: packed uint8 weights (2 FP4 values per
     byte), FP8-E4M3 per-block weight scales (group size 16), and scalar global
-    scales for both weights and activations.
+    scales for weights and, when static activation scaling is used, activations.
     """
 
-    pass
+    dynamic_input_global_scale: bool = False
 
 
 class NvFp4LinearKernel(ABC):

--- a/vllm/model_executor/kernels/linear/nvfp4/flashinfer.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/flashinfer.py
@@ -27,6 +27,17 @@ from vllm.utils.flashinfer import (
 
 from .base import NvFp4LinearKernel, NvFp4LinearLayerConfig
 
+_NVFP4_GLOBAL_SCALE_DENOMINATOR = 6.0 * torch.finfo(torch.float8_e4m3fn).max
+
+
+def _dynamic_nvfp4_global_scales(
+    x: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return one quantization/dequantization scale pair for this invocation."""
+    amax = x.abs().amax().to(torch.float32).clamp_min(1.0e-6)
+    input_dequant_scale = amax / _NVFP4_GLOBAL_SCALE_DENOMINATOR
+    return input_dequant_scale.reciprocal(), input_dequant_scale
+
 
 class FlashInferCuteDslNvFp4LinearKernel(NvFp4LinearKernel):
     """NVFP4 GEMM via FlashInfer's cutedsl backend."""
@@ -100,6 +111,8 @@ class FlashInferCutlassNvFp4LinearKernel(NvFp4LinearKernel):
     def input_quant_key(self) -> QuantKey | None:
         """This kernel supports dynamic quantization of the input. By
         convention, pre-quantized blockscales must use the swizzled layout."""
+        if self.config.dynamic_input_global_scale:
+            return None
         return kNvfp4Dynamic
 
     @classmethod
@@ -141,19 +154,35 @@ class FlashInferCutlassNvFp4LinearKernel(NvFp4LinearKernel):
         output_size = layer.output_size_per_partition
         weights_padding_bytes = getattr(layer, "weights_padding_cols", 0)
 
+        if self.config.dynamic_input_global_scale and isinstance(x, torch.Tensor):
+            if x.dtype not in (torch.float16, torch.bfloat16):
+                raise ValueError(
+                    "Dynamic NVFP4 global activation scaling requires FP16 or BF16 "
+                    f"input, got {x.dtype}."
+                )
+            if x.numel() == 0:
+                return x.new_empty((*x.shape[:-1], output_size))
+
         qa = as_quantized_activation(x, self.input_quant_key())
         if qa is not None:
             x_fp4, x_blockscale = qa.data, qa.scale
             x_fp4 = pad_nvfp4_activation_for_cutlass(x_fp4, weights_padding_bytes)
             output_dtype = qa.orig_dtype
             output_shape = [*qa.orig_shape[:-1], output_size]
+            alpha = layer.alpha
         else:
             assert isinstance(x, torch.Tensor)
             output_dtype = x.dtype
             output_shape = [*x.shape[:-1], output_size]
+            if self.config.dynamic_input_global_scale:
+                input_quant_scale, input_dequant_scale = _dynamic_nvfp4_global_scales(x)
+                alpha = input_dequant_scale * layer.weight_global_scale
+            else:
+                input_quant_scale = layer.input_global_scale_inv
+                alpha = layer.alpha
             x_fp4, x_blockscale = scaled_fp4_quant(
                 x,
-                layer.input_global_scale_inv,
+                input_quant_scale,
                 is_sf_swizzled_layout=True,
                 backend="flashinfer-cutlass",
                 padded_n=x.shape[-1] + weights_padding_bytes * 2,
@@ -164,7 +193,7 @@ class FlashInferCutlassNvFp4LinearKernel(NvFp4LinearKernel):
             layer.weight,
             x_blockscale,
             layer.weight_scale,
-            layer.alpha,
+            alpha,
             output_dtype,
             backend="cutlass",
         )
@@ -316,8 +345,10 @@ class FlashInferB12xNvFp4LinearKernel(NvFp4LinearKernel):
             return True, None
         return (
             False,
-            "FlashInfer b12x requires SM120+ and FlashInfer "
-            "with Sm120BlockScaledDenseGemmKernel",
+            (
+                "FlashInfer b12x requires SM120+ and FlashInfer "
+                "with Sm120BlockScaledDenseGemmKernel"
+            ),
         )
 
     @classmethod

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -1009,11 +1009,18 @@ class ModelOptNvFp4Config(ModelOptQuantConfigBase):
         kv_cache_quant_algo: str | None = None,
         exclude_modules: list[str] | None = None,
         group_size: int = 16,
+        activation_scheme: str = "static",
     ) -> None:
         if exclude_modules is None:
             exclude_modules = []
         super().__init__(exclude_modules)
         self.quant_method = quant_method
+        if activation_scheme not in ("static", "dynamic"):
+            raise ValueError(
+                "ModelOpt NVFP4 activation_scheme must be 'static' or "
+                f"'dynamic', got {activation_scheme!r}."
+            )
+        self.activation_scheme = activation_scheme
         self.is_checkpoint_nvfp4_serialized = is_checkpoint_nvfp4_serialized
         if is_checkpoint_nvfp4_serialized:
             logger.warning(
@@ -1043,7 +1050,10 @@ class ModelOptNvFp4Config(ModelOptQuantConfigBase):
         return "modelopt_fp4"
 
     def get_supported_act_dtypes(self) -> list[torch.dtype]:
-        return [torch.bfloat16, torch.half, torch.float8_e4m3fn]
+        dtypes = [torch.bfloat16, torch.half]
+        if self.activation_scheme == "static":
+            dtypes.append(torch.float8_e4m3fn)
+        return dtypes
 
     @classmethod
     def get_min_capability(cls) -> int:
@@ -1073,6 +1083,8 @@ class ModelOptNvFp4Config(ModelOptQuantConfigBase):
 
         if group_size is None:
             group_size = 16  # Default value
+        quant_config = original_config.get("quantization", original_config)
+        activation_scheme = str(quant_config.get("activation_scheme", "static")).lower()
 
         # For FP4, these fields are required
         if is_checkpoint_nvfp4_serialized and "quantization" in original_config:
@@ -1094,6 +1106,7 @@ class ModelOptNvFp4Config(ModelOptQuantConfigBase):
             kv_cache_quant_method,
             exclude_modules,
             group_size,
+            activation_scheme,
         )
 
 
@@ -1111,7 +1124,9 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
     def __init__(self, quant_config: ModelOptNvFp4Config) -> None:
         self.quant_config = quant_config
         self.marlin_input_dtype = None
-        self.kernel = init_nvfp4_linear_kernel()
+        self.kernel = init_nvfp4_linear_kernel(
+            dynamic_input_global_scale=quant_config.activation_scheme == "dynamic"
+        )
 
     def create_weights(
         self,
@@ -1159,7 +1174,8 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
         )
         layer.register_parameter("weight", weight)
 
-        # Input Global Scale
+        # Input Global Scale. Dynamic checkpoints may still contain this key,
+        # so register it for loading and discard it after loading.
         input_global_scale = PerTensorScaleParameter(
             data=torch.empty(len(output_partition_sizes), dtype=torch.float32),
             weight_loader=weight_loader,
@@ -1187,10 +1203,18 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
 
         layer.register_parameter("weight_scale", weight_scale)
 
-        expose_input_quant_key(layer, self.kernel)
+        if self.quant_config.activation_scheme == "static":
+            expose_input_quant_key(layer, self.kernel)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        if (
+        dynamic_global_scale = self.quant_config.activation_scheme == "dynamic"
+        if dynamic_global_scale:
+            if torch.unique(layer.weight_scale_2).numel() != 1:
+                raise ValueError(
+                    "Dynamic NVFP4 activation scaling requires one shared "
+                    "weight_scale_2 across fused output partitions."
+                )
+        elif (
             torch.unique(layer.input_scale).numel() != 1
             or torch.unique(layer.weight_scale_2).numel() != 1
         ):
@@ -1202,22 +1226,30 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
                 " scale for parallel layers."
             )
 
-        # Rename ModelOpt checkpoint names to standardized names
-        input_global_scale = layer.input_scale.max().to(torch.float32)
-        layer.input_global_scale = Parameter(input_global_scale, requires_grad=False)
-        del layer.input_scale
+        if dynamic_global_scale:
+            del layer.input_scale
+        else:
+            input_global_scale = layer.input_scale.max().to(torch.float32)
+            layer.input_global_scale = Parameter(
+                input_global_scale, requires_grad=False
+            )
+            del layer.input_scale
 
+        # Rename the ModelOpt weight-scale key to the kernel-standard name.
         weight_global_scale = layer.weight_scale_2.max().to(torch.float32)
         layer.weight_global_scale = Parameter(weight_global_scale, requires_grad=False)
         del layer.weight_scale_2
 
-        # Pre-compute alpha and inverse for runtime quantization
-        layer.alpha = Parameter(
-            layer.input_global_scale * layer.weight_global_scale, requires_grad=False
-        )
-        layer.input_global_scale_inv = Parameter(
-            (1.0 / layer.input_global_scale).to(torch.float32), requires_grad=False
-        )
+        if not dynamic_global_scale:
+            # Pre-compute alpha and inverse for runtime quantization.
+            layer.alpha = Parameter(
+                layer.input_global_scale * layer.weight_global_scale,
+                requires_grad=False,
+            )
+            layer.input_global_scale_inv = Parameter(
+                (1.0 / layer.input_global_scale).to(torch.float32),
+                requires_grad=False,
+            )
 
         # Convert layer to NVFP4 linear kernel format
         self.kernel.process_weights_after_loading(layer)
@@ -1388,6 +1420,11 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
         quant_config: ModelOptNvFp4Config,
         moe_config: FusedMoEConfig,
     ) -> None:
+        if quant_config.activation_scheme == "dynamic":
+            raise ValueError(
+                "Dynamic ModelOpt NVFP4 global activation scaling is currently "
+                "supported only for dense linear layers, not FusedMoE."
+            )
         super().__init__(moe_config)
         self.quant_config = quant_config
         # W4A16 mode fires for W4A16_NVFP4 on-disk checkpoints. With


### PR DESCRIPTION
## Purpose

### Problem

Some serialized ModelOpt NVFP4 diffusion checkpoints contain packed FP4 weights, per-block weight scales, and `weight_scale_2`, but intentionally omit a calibrated static activation `input_scale`. The existing loader still registers an input-scale placeholder. Treating that uninitialized placeholder as a real scale can collapse W4A4 output even when the GPU and CUTLASS kernel are healthy.

Inferring dynamic behavior merely from a missing tensor would be unsafe. This change therefore adds an explicit checkpoint contract:

```json
{
  "producer": {"name": "modelopt"},
  "quantization": {
    "quant_algo": "NVFP4",
    "activation_scheme": "dynamic",
    "group_size": 16,
    "kv_cache_quant_algo": null,
    "exclude_modules": []
  }
}
```

### Change

- Parse and validate `activation_scheme` as `static` or `dynamic`.
- Preserve `static` as the default for existing checkpoints.
- In dynamic mode, compute one FP32 scale pair per invocation from `amax / (6 * 448)`.
- Select FlashInfer-CUTLASS and bypass the pre-quantized-activation bridge.
- Discard the loader's unused `input_scale` placeholder without reading it.
- Require a shared `weight_scale_2` across fused output partitions.
- Fail closed for A16, unsupported input dtypes, FusedMoE, `VLLM_BATCH_INVARIANT`, and incompatible forced linear backends.
- Document the serialized checkpoint metadata and supported dense-linear scope.

### Evaluation and compatibility boundary

The end-to-end LTX-2.3 run used an experiment-scoped vLLM 0.22.0 prototype equivalent to this PR's dense runtime math and FlashInfer-CUTLASS path. The current source implementation is covered by the unit tests below.

The evaluated transformer was not an untouched official NVFP4 export: packed FP4 nibble/block-scale layout was corrected, 264 padded gate projections remained BF16, and 88 fused Q/K/V groups used harmonized global scales. This PR does not claim to repair an incompatible checkpoint export by itself.

### Duplicate-work check

The nearest open core work, [#42428](https://github.com/vllm-project/vllm/pull/42428), covers W4A16 linear/MoE routing and intentionally avoids activation quantization. This change covers the distinct W4A4 case with per-invocation dynamic activation scaling.

The newer open refactor [#49381](https://github.com/vllm-project/vllm/pull/49381) replaces the ModelOpt linear-method structure, but explicitly preserves a serialized static global `input_scale` for NVFP4 W4A4. This PR adds a separate checkpoint contract for checkpoints that omit that tensor and derives the global activation scale per invocation. If #49381 merges first, this patch must be ported onto its QuantKey-driven structure rather than merged unchanged.

The vLLM-Omni diffusion [RFC #1959](https://github.com/vllm-project/vllm-omni/issues/1959) discusses W4A4 and W4A16 but does not implement this dense-linear checkpoint contract. Searches for `ModelOpt NVFP4 dynamic activation` and `NVFP4 input scale` found no matching open implementation PR.

### AI assistance disclosure

AI tooling assisted with investigation, implementation, tests, experiment orchestration, and this draft. The human submitter must review every changed line, understand and defend the scale/checkpoint contract, rerun the relevant tests, and add their own sign-off before marking the PR ready for review.

## Test Plan

Unit tests:

```bash
.venv/bin/python -m pytest \
  tests/quantization/test_modelopt.py \
  tests/fusion/test_quant_activation_contract.py \
  -k 'dynamic_activation or dynamic_nvfp4' -q

.venv/bin/python -m pytest \
  tests/quantization/test_modelopt.py::test_modelopt_nvfp4_rejects_invalid_activation_scheme \
  -q
```

Lint:

```bash
.venv/bin/ruff check \
  tests/fusion/test_quant_activation_contract.py \
  tests/quantization/test_modelopt.py \
  vllm/model_executor/kernels/linear/__init__.py \
  vllm/model_executor/kernels/linear/nvfp4/base.py \
  vllm/model_executor/kernels/linear/nvfp4/flashinfer.py \
  vllm/model_executor/layers/quantization/modelopt.py

.venv/bin/ruff format --check \
  tests/fusion/test_quant_activation_contract.py \
  tests/quantization/test_modelopt.py \
  vllm/model_executor/kernels/linear/__init__.py \
  vllm/model_executor/kernels/linear/nvfp4/base.py \
  vllm/model_executor/kernels/linear/nvfp4/flashinfer.py \
  vllm/model_executor/layers/quantization/modelopt.py

git diff --check
```

Model evaluation:

- Hardware: one NVIDIA RTX PRO 6000 Blackwell, 96 GB.
- Software: vLLM/vLLM-Omni 0.22.0 experiment runtime; CUDNN attention.
- Workload: official LTX-2.3 felt-birds prompt, seed 10, 1280x704, 121 frames, 24 fps, 30 steps, explicit CFG 3.0, no audio or cache acceleration.
- Matched quality: one BF16 and one corrected dynamic-W4A4 full output.
- Controlled timing: two warmups and three hot full-video measurements per mode. Only experimental order block 1 was completed.

## Test Result

### Unit tests and lint

- Dynamic selector: `10 passed, 25 deselected`.
- Invalid-scheme regression: `1 passed`.
- Ruff check: passed.
- Ruff format check: passed.
- Diff-scoped pre-commit hooks: passed.
- `git diff --check`: passed.

### Official-prompt matched quality

| Metric | Result |
| --- | ---: |
| W4A4 versus BF16 all-frame SSIM | 0.911789 |
| W4A4 versus BF16 all-frame PSNR | 27.2039 dB |
| Final-frame SSIM | 0.922751 |
| BF16 reported peak memory | 61,794 MB |
| W4A4 reported peak memory | 38,492 MB |
| W4A4 peak-memory reduction | 37.71% |

Both outputs contain coherent yellow felt birds, at least two birds, a birdhouse, and stable miniature-set texture. W4A4 shows no noise, monochrome, black-frame, or geometry collapse. The literal worm handoff is only partially readable in both single-stage outputs.

![Official LTX-2.3 felt-birds video contact sheet](https://raw.githubusercontent.com/Qyx5-5/vllm/review/modelopt-dynamic-nvfp4/PR_REVIEW/official_bird_contact_sheet.png)

The middle column is an unmatched two-stage BF16 output included only as absolute-quality context; its pipeline, resolution, duration, and refinement settings differ.

### Controlled hot timing

| Mode | Hot mean | CV | Peak memory | BF16-relative |
| --- | ---: | ---: | ---: | ---: |
| BF16 | 141.884 s | 0.363% | 61,798 MB | 1.0000x |
| Corrected W4A16 | 149.141 s | 0.344% | 38,450 MB | 0.9514x |
| Corrected dynamic W4A4 | 114.568 s | 1.124% | 38,480 MB | 1.2385x |

Corrected W4A4 reduced hot latency by 19.25% in this completed order block. This is descriptive one-block evidence, not the cancelled three-block order-balanced confidence estimate. Fresh official-prompt request times are excluded from the speed claim because they include unequal graph/kernel compilation.

Current-main validation: after resolving the merge conflict, the signed one-commit patch is based on `vllm-project/vllm@92e8518d376c3c9a6979da4d56ee6263ef6af630` with head `c0804ef469c8b7f05a452ce31108d9a7dae4552b`. The targeted selector suite (`10 passed, 25 deselected`), invalid-scheme regression (`1 passed`), Ruff check, Ruff format check, and `git diff --check` pass on that base. `git range-diff` shows no source or test change from the pre-rebase patch; the documentation resolution retains both the upstream NVFP4 backend-selection note and the dynamic-scaling contract added by this PR. The end-to-end model evaluation remains the disclosed vLLM 0.22.0 experiment runtime; it was not rerun on current main. GitHub full test suite currently awaits a maintainer-applied `verified`, `ready`, or `ready-run-all-tests` label.

---

<details>
<summary>Essential elements of an effective PR description</summary>

- [x] Purpose and compatibility boundary are documented.
- [x] Exact unit-test and lint commands are provided.
- [x] Unit, model-evaluation, timing, and memory results are reported.
- [x] User-facing checkpoint metadata documentation is updated.

</details>

**Before marking ready:** read <https://docs.vllm.ai/en/latest/contributing>, review every changed line, rerun validation, and add the human submitter's sign-off.