### PR TITLE
[Bugfix] Terminate background stream consumers when producer exits early

### DIFF
--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import asyncio
+import contextlib
+from collections import deque
 from contextlib import AsyncExitStack
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -347,6 +351,151 @@ class TestValidateGeneratorInput:
         # Should return an ErrorResponse
         assert result is not None
         assert isinstance(result, ErrorResponse)
+
+
+class TestBackgroundStreamTermination:
+    """Tests for responses_background_stream_generator termination.
+
+    The consumer must terminate not only on a `response.completed` event but
+    also when the producer exits without one (cancellation, generation error,
+    or an unexpected exception). Before the producer-done signal existed, the
+    consumer would block forever on `new_event_signal.wait()` in those cases.
+    """
+
+    @pytest_asyncio.fixture
+    async def serving_responses_instance(self):
+        engine_client = MagicMock()
+
+        model_config = MagicMock()
+        model_config.max_model_len = 100
+        model_config.hf_config.model_type = "test"
+        model_config.get_diff_sampling_param.return_value = {}
+        engine_client.model_config = model_config
+
+        engine_client.input_processor = MagicMock()
+        engine_client.renderer = MagicMock()
+
+        return OpenAIServingResponses(
+            engine_client=engine_client,
+            models=MagicMock(),
+            online_renderer=MagicMock(),
+            request_logger=None,
+            chat_template=None,
+            chat_template_content_format="auto",
+        )
+
+    @staticmethod
+    async def _collect(serving, response_id):
+        return [
+            event
+            async for event in serving.responses_background_stream_generator(
+                response_id
+            )
+        ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.skip_global_cleanup
+    async def test_terminates_when_producer_exits_without_terminal_event(
+        self, serving_responses_instance
+    ):
+        """A dead producer without `response.completed` must not hang the
+        consumer; buffered events are still flushed."""
+        serving = serving_responses_instance
+        response_id = "resp_producer_died"
+        done_signal = asyncio.Event()
+        done_signal.set()
+        serving.event_store[response_id] = (
+            deque(
+                [
+                    SimpleNamespace(type="response.created"),
+                    SimpleNamespace(type="response.in_progress"),
+                ]
+            ),
+            asyncio.Event(),
+            done_signal,
+        )
+
+        events = await asyncio.wait_for(
+            self._collect(serving, response_id), timeout=1.0
+        )
+
+        assert [event.type for event in events] == [
+            "response.created",
+            "response.in_progress",
+        ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.skip_global_cleanup
+    async def test_terminates_when_background_producer_is_cancelled(
+        self, serving_responses_instance, monkeypatch
+    ):
+        """Cancelling the background task must terminate stream consumers."""
+        serving = serving_responses_instance
+        response_id = "resp_cancelled"
+        request = MagicMock()
+        request.request_id = response_id
+        blocked = asyncio.Event()
+
+        async def fake_stream_generator(request, *args, **kwargs):
+            yield SimpleNamespace(type="response.created")
+            yield SimpleNamespace(type="response.in_progress")
+            await blocked.wait()
+
+        monkeypatch.setattr(
+            serving, "responses_stream_generator", fake_stream_generator
+        )
+        task = asyncio.create_task(serving._run_background_request_stream(request))
+
+        async def wait_for_events():
+            while (
+                response_id not in serving.event_store
+                or len(serving.event_store[response_id][0]) < 2
+            ):
+                await asyncio.sleep(0)
+
+        await asyncio.wait_for(wait_for_events(), timeout=1.0)
+
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+        events = await asyncio.wait_for(
+            self._collect(serving, response_id), timeout=1.0
+        )
+
+        assert [event.type for event in events] == [
+            "response.created",
+            "response.in_progress",
+        ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.skip_global_cleanup
+    async def test_still_terminates_on_completed_event(
+        self, serving_responses_instance
+    ):
+        """The normal `response.completed` path keeps working even while the
+        producer is still alive (done signal unset)."""
+        serving = serving_responses_instance
+        response_id = "resp_completed"
+        serving.event_store[response_id] = (
+            deque(
+                [
+                    SimpleNamespace(type="response.created"),
+                    SimpleNamespace(type="response.completed"),
+                ]
+            ),
+            asyncio.Event(),
+            asyncio.Event(),
+        )
+
+        events = await asyncio.wait_for(
+            self._collect(serving, response_id), timeout=1.0
+        )
+
+        assert [event.type for event in events] == [
+            "response.created",
+            "response.completed",
+        ]
 
 
 @pytest.mark.asyncio

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -234,8 +234,10 @@ class OpenAIServingResponses(GenerateBaseServing):
         # HACK(wuhang): This is a hack. We should use a better store.
         # FIXME: If enable_store=True, this may cause a memory leak since we
         # never remove events from the store.
+        # Each entry is (events, new_event_signal, producer_done_signal).
         self.event_store: dict[
-            str, tuple[deque[StreamingResponsesResponse], asyncio.Event]
+            str,
+            tuple[deque[StreamingResponsesResponse], asyncio.Event, asyncio.Event],
         ] = {}
 
         self.background_tasks: dict[str, asyncio.Task] = {}
@@ -1215,13 +1217,22 @@ class OpenAIServingResponses(GenerateBaseServing):
     ):
         event_deque: deque[StreamingResponsesResponse] = deque()
         new_event_signal = asyncio.Event()
-        self.event_store[request.request_id] = (event_deque, new_event_signal)
+        done_signal = asyncio.Event()
+        self.event_store[request.request_id] = (
+            event_deque,
+            new_event_signal,
+            done_signal,
+        )
         generator = self.responses_stream_generator(request, *args, **kwargs)
         try:
             async for event in generator:
                 event_deque.append(event)
                 new_event_signal.set()  # Signal new event available
         finally:
+            # Mark the producer as finished before waking consumers so they
+            # can terminate even when no terminal event was emitted
+            # (cancellation, generation error, or an unexpected exception).
+            done_signal.set()
             new_event_signal.set()
 
     async def _run_background_request(
@@ -1253,7 +1264,7 @@ class OpenAIServingResponses(GenerateBaseServing):
                 value=response_id,
             )
 
-        event_deque, new_event_signal = self.event_store[response_id]
+        event_deque, new_event_signal, done_signal = self.event_store[response_id]
         start_index = 0 if starting_after is None else starting_after + 1
         current_index = start_index
 
@@ -1267,6 +1278,16 @@ class OpenAIServingResponses(GenerateBaseServing):
                 if getattr(event, "type", "unknown") == "response.completed":
                     return
                 current_index += 1
+
+            if done_signal.is_set():
+                # The producer exited without a terminal event (cancellation,
+                # generation error, or an unexpected exception). Flush any
+                # events appended just before the done signal, then stop
+                # instead of waiting on a signal that will never fire again.
+                while current_index < len(event_deque):
+                    yield event_deque[current_index]
+                    current_index += 1
+                return
 
             await new_event_signal.wait()
 


### PR DESCRIPTION
## Purpose

Fix a hang in the Responses API background streaming path: stream consumers block forever when the background producer exits without emitting a terminal event.

`responses_background_stream_generator` only terminates when it sees a `response.completed` event:

```python
while True:
    new_event_signal.clear()
    while current_index < len(event_deque):
        event = event_deque[current_index]
        yield event
        if getattr(event, "type", "unknown") == "response.completed":
            return
        current_index += 1
    await new_event_signal.wait()
```

But the producer does not always emit one:

- **Cancellation** — `cancel_responses` calls `task.cancel()`; `CancelledError` unwinds `_run_background_request_stream` and the final `response.completed` emit is never reached.
- **Generation error** — the `except GenerationError` branch returns early. (It also tries to yield an `ErrorResponse`-shaped payload through `TypeAdapter(StreamingResponsesResponse)`, which has no error member, so `validate_json` raises — the foreground flavor of this is #22341.)
- **Any unexpected exception** — propagates out of the producer.

In all three cases the producer's `finally` sets `new_event_signal` exactly once. The consumer wakes, drains the queue, finds no terminal event, and re-enters `new_event_signal.wait()` — which nothing will ever set again. The generator is wrapped in a FastAPI `StreamingResponse` at both entry points (POST create with `stream=true`+`background=true`, and GET retrieve with `?stream=true`), so the SSE stream never closes and the client hangs until its own timeout.

This never surfaced in CI because no test exercises `responses_background_stream_generator` — the existing e2e background tests (`test_stateful.py`) poll via non-streaming retrieve only.

### Fix

Add a producer-done signal to the event store entry (`(events, new_event_signal, done_signal)`). The producer sets it in its `finally` before the final wakeup; the consumer, after draining, terminates cleanly when the producer is done instead of waiting on a signal that will never fire:

```python
if done_signal.is_set():
    # flush any events appended just before the done signal, then stop
    while current_index < len(event_deque):
        yield event_deque[current_index]
        current_index += 1
    return
```

Because `done_signal.set()` runs strictly after the last `event_deque.append`, checking it after draining (and re-draining before returning) closes the append/wakeup race. This single change covers all three early-exit paths without depending on constructing a valid terminal event at cancel/failure time; emitting an explicit `response.cancelled`/`response.failed` SSE frame can be layered on later if desired, but requires new protocol event types.

## Test Plan

New unit tests in `tests/entrypoints/openai/responses/test_serving_responses.py` (`TestBackgroundStreamTermination`), using the file's existing mock-engine fixture pattern — no real engine needed:

```
pytest tests/entrypoints/openai/responses/test_serving_responses.py::TestBackgroundStreamTermination
```

- `test_terminates_when_producer_exits_without_terminal_event` — dead producer, no terminal event: consumer flushes buffered events and stops.
- `test_terminates_when_background_producer_is_cancelled` — end-to-end through the real `_run_background_request_stream`: cancel the background task, then consume.
- `test_still_terminates_on_completed_event` — the normal `response.completed` path still works while the producer is alive.

## Test Result

With the fix: `3 passed`. Against the previous code, the cancellation test reproduces the hang exactly — the consumer blocks and the test fails with `TimeoutError` from `asyncio.wait_for`. Full file: `24 passed, 2 xfailed` (remaining errors are the known macOS MPS teardown issue in tests without `skip_global_cleanup`, unrelated to this change).

`pre-commit run` passes on both files (ruff, ruff-format, typos, mypy).
