### PR TITLE
[Bugfix] Finalize streaming requests at terminal sentinel

### DIFF
--- a/tests/v1/streaming_input/test_scheduler_streaming.py
+++ b/tests/v1/streaming_input/test_scheduler_streaming.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import unittest
+from collections import deque
 from unittest.mock import MagicMock
 
 import torch
@@ -275,6 +276,26 @@ class TestStreamingScheduler(unittest.TestCase):
         _ = scheduler.schedule()
 
         assert session.status == RequestStatus.RUNNING
+
+    def test_handle_stopped_request_finalizes_streaming_session(self):
+        scheduler = create_scheduler()
+        request = DummyRequest(request_id="session", resumable=True)
+        request.status = RequestStatus.FINISHED_STOPPED
+        request.streaming_queue = deque([None])
+
+        assert scheduler._handle_stopped_request(request) is True
+        assert request.resumable is False
+        assert not request.streaming_queue
+
+    def test_handle_stopped_request_waits_for_more_streaming_input(self):
+        scheduler = create_scheduler()
+        request = DummyRequest(request_id="session", resumable=True)
+        request.status = RequestStatus.FINISHED_STOPPED
+
+        assert scheduler._handle_stopped_request(request) is False
+        assert request.resumable is True
+        assert request.status == RequestStatus.WAITING_FOR_STREAMING_REQ
+        assert scheduler.num_waiting_for_streaming_input == 1
 
     def test_update_request_as_session_with_output_tokens(self):
         scheduler = create_scheduler()

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1987,6 +1987,7 @@ class Scheduler(SchedulerInterface):
             update = request.streaming_queue.popleft()
             if update is None:
                 # Streaming request finished.
+                request.resumable = False
                 return True
             self._update_request_as_session(request, update)
         else:


### PR DESCRIPTION
## Purpose

A resumable request uses `None` in `streaming_queue` as the terminal sentinel. `_handle_stopped_request()` consumes that sentinel and returns `True`, but leaves `request.resumable` set to `True`. The request is finished, yet teardown code and request-finished hooks still receive state that says another streaming chunk is possible.

**What broke:** the terminal-sentinel path returned a finished result without finalizing the request lifecycle flag.

**Root cause:** the `None` branch returned immediately after popping the sentinel and never cleared `resumable`.

**Fix:** set `request.resumable = False` when the terminal sentinel is consumed. A paired regression test keeps the empty-queue behavior unchanged: a resumable request with no queued update still waits for more input.

To reproduce the failure against the parent commit while keeping the new test:

```bash
git checkout HEAD^ -- vllm/v1/core/sched/scheduler.py
.venv/bin/python -m pytest -q tests/v1/streaming_input/test_scheduler_streaming.py -k handle_stopped_request
git restore --source=HEAD --staged --worktree vllm/v1/core/sched/scheduler.py
```

### Why this is not a duplicate

I searched the open vLLM PRs for `streaming_queue`, terminal sentinels, and resumable-request finalization. #42502 addresses `max_model_len` overflow across later streaming segments, while #43683 clears stale speculative-decoding state. Neither changes the `None` sentinel path or finalizes the `resumable` flag.

AI assistance: OpenAI Codex helped inspect the scheduler lifecycle, prepare the focused tests, and draft this PR. This is a draft so I can review every changed line and reproduce the test result before marking it ready.

Model evaluation is not applicable because this does not change model execution, sampling, or generated output.

## Test Plan

```bash
.venv/bin/python -m pytest -q tests/v1/streaming_input/test_scheduler_streaming.py
.venv/bin/pre-commit run --files vllm/v1/core/sched/scheduler.py tests/v1/streaming_input/test_scheduler_streaming.py
```

## Test Result

Before the fix, the focused tests reported `1 failed, 1 passed`; the terminal case failed with `assert True is False` for `request.resumable`.

After the fix:

```text
10 passed, 17 warnings in 1.40s
```

All configured pre-commit hooks passed on the two changed files, including Ruff, formatting, typos, mypy, SPDX, and repository policy checks.