### PR TITLE
fix(reasoning): force-open poolside_v1 on bare </think>

### DIFF
--- a/tests/reasoning/test_poolside_v1_reasoning_parser.py
+++ b/tests/reasoning/test_poolside_v1_reasoning_parser.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Poolside Laguna force-open reasoning parser tests.
+
+Laguna emits CoT then a bare ``</think>`` with no opening ``<think>``. The
+parser must always force-open (independent of chat_template_kwargs.thinking)
+and must not leak the close tag into content.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.reasoning import ReasoningParserManager
+from vllm.reasoning.deepseek_r1_reasoning_parser import DeepSeekR1ReasoningParser
+from vllm.reasoning.poolside_v1_reasoning_parser import PoolsideV1ReasoningParser
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+class _FakeTok:
+    """Minimal tokenizer with the specials poolside_v1 needs."""
+
+    def __init__(self) -> None:
+        self._vocab = {
+            "<think>": 1,
+            "</think>": 2,
+            "<assistant>": 3,
+        }
+        self.all_special_tokens = list(self._vocab)
+        self.all_special_ids = list(self._vocab.values())
+        self.additional_special_tokens: list[str] = []
+        self.additional_special_tokens_ids: list[int] = []
+
+    def get_vocab(self) -> dict[str, int]:
+        return dict(self._vocab)
+
+    def encode(self, s: str, add_special_tokens: bool = False) -> list[int]:
+        out: list[int] = []
+        i = 0
+        specials = sorted(self._vocab, key=len, reverse=True)
+        while i < len(s):
+            matched = False
+            for t in specials:
+                if s.startswith(t, i):
+                    out.append(self._vocab[t])
+                    i += len(t)
+                    matched = True
+                    break
+            if not matched:
+                out.append(100 + (ord(s[i]) % 50))
+                i += 1
+        return out
+
+    def convert_ids_to_tokens(self, ids: list[int]) -> list[str]:
+        rev = {v: k for k, v in self._vocab.items()}
+        return [rev.get(i, f"t{i}") for i in ids]
+
+    def convert_tokens_to_string(self, tokens: list[str]) -> str:
+        return "".join(tokens)
+
+    def __len__(self) -> int:
+        return len(self._vocab)
+
+
+@pytest.fixture
+def tokenizer() -> _FakeTok:
+    return _FakeTok()
+
+
+@pytest.fixture
+def parser(tokenizer: _FakeTok) -> PoolsideV1ReasoningParser:
+    # No thinking kwargs: must still force-open (this was the Identity leak).
+    return PoolsideV1ReasoningParser(tokenizer)
+
+
+def test_registered_as_poolside_v1():
+    assert (
+        ReasoningParserManager.get_reasoning_parser("poolside_v1")
+        is PoolsideV1ReasoningParser
+    )
+
+
+def test_subclasses_deepseek_r1_not_v3_identity_path(parser):
+    assert isinstance(parser, DeepSeekR1ReasoningParser)
+    assert not hasattr(parser, "_parser")
+
+
+def test_force_open_nonstream_without_thinking_kwargs(parser):
+    request = ChatCompletionRequest(model="test-model", messages=[], temperature=1.0)
+    reasoning, content = parser.extract_reasoning(
+        "reason...</think>answer", request=request
+    )
+    assert reasoning == "reason..."
+    assert content == "answer"
+    assert "</think>" not in (content or "")
+
+
+def test_force_open_with_optional_open_tag(parser):
+    request = ChatCompletionRequest(model="test-model", messages=[], temperature=1.0)
+    reasoning, content = parser.extract_reasoning(
+        "<think>reason...</think>answer", request=request
+    )
+    assert reasoning == "reason..."
+    assert content == "answer"
+
+
+def test_force_open_streaming_without_thinking_kwargs(parser, tokenizer):
+    d1_text = "reason..."
+    d1_ids = tokenizer.encode(d1_text)
+    d1 = parser.extract_reasoning_streaming(
+        "", d1_text, d1_text, [], d1_ids, d1_ids
+    )
+    assert d1 is not None
+    assert d1.reasoning == "reason..."
+    assert not d1.content
+
+    prev = d1_text
+    delta = "</think>answer"
+    curr = prev + delta
+    prev_ids = d1_ids
+    delta_ids = tokenizer.encode(delta)
+    curr_ids = prev_ids + delta_ids
+    d2 = parser.extract_reasoning_streaming(
+        prev, curr, delta, prev_ids, curr_ids, delta_ids
+    )
+    assert d2 is not None
+    assert d2.content == "answer"
+    assert "</think>" not in (d2.content or "")
+
+
+def test_is_reasoning_end_scoped_to_assistant_turn(parser, tokenizer):
+    # Prior turn had </think>; current assistant turn has not closed yet.
+    # Sequence: <assistant> prior ... </think> ... user ... <assistant> reason...
+    prior_close = (
+        tokenizer.encode("<assistant>")
+        + tokenizer.encode("old")
+        + tokenizer.encode("</think>")
+        + tokenizer.encode("<assistant>")
+        + tokenizer.encode("new reason")
+    )
+    assert parser.is_reasoning_end(prior_close) is False
+
+    with_close = prior_close + tokenizer.encode("</think>")
+    assert parser.is_reasoning_end(with_close) is True
+
+
+def test_missing_assistant_token_fails_loud():
+    class NoAssistantTok(_FakeTok):
+        def __init__(self) -> None:
+            super().__init__()
+            del self._vocab["<assistant>"]
+
+    with pytest.raises(ValueError, match="<assistant>"):
+        PoolsideV1ReasoningParser(NoAssistantTok())

--- a/vllm/reasoning/poolside_v1_reasoning_parser.py
+++ b/vllm/reasoning/poolside_v1_reasoning_parser.py
@@ -3,22 +3,28 @@
 """
 Laguna reasoning parser.
 
-``DeepSeekV3ReasoningParser.is_reasoning_end`` walks the entire
+Poolside Laguna force-opens the thinking block: the model emits chain-of-thought
+then a literal ``</think>`` with no opening ``<think>``. That is the same
+force-open contract as DeepSeek R1, so this parser subclasses
+``DeepSeekR1ReasoningParser`` directly.
+
+Previously this class subclassed ``DeepSeekV3ReasoningParser``, which only
+installs the R1 force-open path when ``chat_template_kwargs.thinking`` /
+``enable_thinking`` is True and otherwise falls back to
+``IdentityReasoningParser`` (passthrough). With the Identity fallback, CoT and
+a bare ``</think>`` land in ``content`` and the reasoning channel stays empty.
+
+Separately, ``DeepSeekR1ReasoningParser.is_reasoning_end`` walks the entire
 token sequence backwards and returns ``True`` on the first ``</think>`` it
 sees. When called on ``prompt_token_ids`` that mistakes any stray
 ``</think>`` in conversation history, few-shot examples or tool descriptions
 for a template-injected "thinking already ended" marker. In the streaming
 path (see ``vllm/entrypoints/openai/chat_completion/serving.py``,
 ``prompt_is_reasoning_end_arr``) that false positive short-circuits the
-reasoning parser for the whole response, so any ``<think>...</think>`` the
-model emits itself ends up in the content field instead of the reasoning
-field.
-
-As we have more flexible templates, we instead scope
-the backward search to the current assistant turn: the
-walk terminates as soon as we hit the ``<assistant>`` start-of-message
-token. A ``</think>`` in a prior user turn or few-shot example is no longer
-visible.
+reasoning parser for the whole response. We therefore scope the backward
+search to the current assistant turn: the walk terminates as soon as we hit
+the ``<assistant>`` start-of-message token. A ``</think>`` in a prior user
+turn or few-shot example is no longer visible.
 """
 
 from collections.abc import Sequence
@@ -26,13 +32,14 @@ from collections.abc import Sequence
 from transformers import PreTrainedTokenizerBase
 
 from vllm.reasoning.deepseek_r1_reasoning_parser import DeepSeekR1ReasoningParser
-from vllm.reasoning.deepseek_v3_reasoning_parser import DeepSeekV3ReasoningParser
-from vllm.reasoning.identity_reasoning_parser import IdentityReasoningParser
 
 
-class PoolsideV1ReasoningParser(DeepSeekV3ReasoningParser):
-    """Drop-in replacement for ``deepseek_v3`` that tolerates ``</think>``
-    tokens appearing anywhere in the prompt other than the generation prefix.
+class PoolsideV1ReasoningParser(DeepSeekR1ReasoningParser):
+    """Force-open ``</think>`` parser for Poolside Laguna.
+
+    Drop-in for ``deepseek_r1`` force-open semantics that also tolerates
+    ``</think>`` tokens appearing in the prompt outside the generation
+    prefix (scoped to the current ``<assistant>`` turn).
     """
 
     _start_of_assistant_message = "<assistant>"
@@ -49,17 +56,12 @@ class PoolsideV1ReasoningParser(DeepSeekV3ReasoningParser):
         ]
 
     def is_reasoning_end(self, input_ids: Sequence[int]) -> bool:
-        # IdentityReasoningParser always returns True: no reasoning to parse.
-        if isinstance(self._parser, IdentityReasoningParser):
-            return True
-
-        assert isinstance(self._parser, DeepSeekR1ReasoningParser)
         for tok_id in reversed(input_ids):
             # <think>: reasoning is not yet ended.
-            if tok_id == self._parser.start_token_id:
+            if tok_id == self.start_token_id:
                 return False
             # </think>: reasoning has ended.
-            if tok_id == self._parser.end_token_id:
+            if tok_id == self.end_token_id:
                 return True
             # <assistant>: reached the start of the current assistant turn
             # without seeing either marker. Anything further back belongs to


### PR DESCRIPTION
## Summary

Poolside Laguna force-opens the thinking block: the model emits chain-of-thought then a literal `</think>` with **no opening `<think>`**. The stock `poolside_v1` reasoning parser previously subclassed `DeepSeekV3ReasoningParser`, which only installs the DeepSeek R1 force-open path when `chat_template_kwargs.thinking` / `enable_thinking` is True and otherwise falls back to `IdentityReasoningParser` (passthrough). With that Identity fallback, CoT and a bare `</think>` land in `content` and the reasoning channel stays empty.

This change subclasses `DeepSeekR1ReasoningParser` directly so force-open is always on (same semantics as `--reasoning-format deepseek` on the llama.cpp side), and keeps the assistant-turn-scoped `is_reasoning_end` walk so a stray `</think>` in prior conversation history does not short-circuit the streaming path.

Related discussion class: #49379 (force-open / asymmetric `</think>` handling for poolside).

## Changes

- `vllm/reasoning/poolside_v1_reasoning_parser.py`: inherit from `DeepSeekR1ReasoningParser`; drop the DeepSeekV3 / Identity delegation path; keep `<assistant>`-scoped `is_reasoning_end`.
- `tests/reasoning/test_poolside_v1_reasoning_parser.py`: force-open non-stream + streaming without thinking kwargs; scoped `is_reasoning_end`; fail-loud on missing `<assistant>` token.

## Test plan

- [x] New unit tests for force-open extract (non-stream + stream) without `thinking` kwargs
- [x] Unit test that `is_reasoning_end` ignores a prior-turn `</think>`
- [x] On-box validation against a native aarch64/sm_121 source build of vLLM serving Laguna: stock path leaked; fixed parser splits `reason...</think>answer` -> reasoning=`reason...`, content=`answer`