### PR TITLE
[ROCm][CI] Fix XPASS(strict) on mixed audio embeds test

### DIFF
--- a/tests/entrypoints/multimodal/openai/chat_completion/test_chat_completion_with_mixed_audio_embeds.py
+++ b/tests/entrypoints/multimodal/openai/chat_completion/test_chat_completion_with_mixed_audio_embeds.py
@@ -16,6 +16,7 @@ from huggingface_hub import hf_hub_download
 from transformers import AutoConfig, AutoTokenizer
 
 from tests.utils import RemoteOpenAIServer
+from vllm.platforms import current_platform
 from vllm.utils.serial_utils import tensor2base64
 
 QWEN2AUDIO_MODEL = "Qwen/Qwen2-Audio-7B-Instruct"
@@ -148,6 +149,10 @@ def qwen2audio_aligned_content_and_embeds_b64() -> tuple[str, str]:
             False,
             id="text-then-audio_embeds",
             marks=pytest.mark.xfail(
+                # On ROCm the outputs coincide and the test passes, so scope
+                # the strict xfail to non-ROCm to avoid an XPASS(strict)
+                # failure on AMD CI.
+                condition=not current_platform.is_rocm(),
                 reason="torch 2.12 regression: prompt_embeds output diverges "
                 "from raw-text when text precedes audio; "
                 "https://github.com/pytorch/pytorch/issues/184431",

--- a/tests/entrypoints/multimodal/openai/chat_completion/test_chat_completion_with_mixed_audio_embeds.py
+++ b/tests/entrypoints/multimodal/openai/chat_completion/test_chat_completion_with_mixed_audio_embeds.py
@@ -16,8 +16,8 @@ from huggingface_hub import hf_hub_download
 from transformers import AutoConfig, AutoTokenizer
 
 from tests.utils import RemoteOpenAIServer
-from vllm.platforms import current_platform
 from vllm.utils.serial_utils import tensor2base64
+from vllm.utils.torch_utils import is_torch_equal_or_newer
 
 QWEN2AUDIO_MODEL = "Qwen/Qwen2-Audio-7B-Instruct"
 
@@ -149,10 +149,7 @@ def qwen2audio_aligned_content_and_embeds_b64() -> tuple[str, str]:
             False,
             id="text-then-audio_embeds",
             marks=pytest.mark.xfail(
-                # On ROCm the outputs coincide and the test passes, so scope
-                # the strict xfail to non-ROCm to avoid an XPASS(strict)
-                # failure on AMD CI.
-                condition=not current_platform.is_rocm(),
+                condition=is_torch_equal_or_newer("2.12.0"),
                 reason="torch 2.12 regression: prompt_embeds output diverges "
                 "from raw-text when text precedes audio; "
                 "https://github.com/pytorch/pytorch/issues/184431",


### PR DESCRIPTION
## Purpose

The `text-then-audio_embeds` test is expected to fail with PyTorch 2.12 and newer, so it is marked `xfail(strict=True)`. Current ROCm CI still uses PyTorch 2.11, where the test passes; an unconditional strict xfail therefore becomes `XPASS(strict)` and fails the job.

Apply the strict xfail only when `is_torch_equal_or_newer("2.12.0")`. PyTorch versions below 2.12 continue to run the test normally, while affected versions retain the expected-failure marker. This also covers the pending ROCm PyTorch 2.12 upgrade, where the failure reproduces.

This is not a duplicate: searches for the linked upstream issue and mixed-audio xfail work found no other open vLLM PR.

## Test Plan

- `.venv/bin/python -m pytest tests/entrypoints/multimodal/openai/chat_completion/test_chat_completion_with_mixed_audio_embeds.py --collect-only -q`
- `uvx --from pre-commit pre-commit run --files tests/entrypoints/multimodal/openai/chat_completion/test_chat_completion_with_mixed_audio_embeds.py`
- GPU E2E command: `pytest tests/entrypoints/multimodal/openai/chat_completion/test_chat_completion_with_mixed_audio_embeds.py -v -rA`

## Test Result

- Focused collection: 3 tests collected successfully on PyTorch 2.12.0+rocm7.2.
- All applicable pre-commit hooks passed.
- Existing ROCm 2.11 result after disabling the strict xfail: PASSED. Before: `[XPASS(strict)] torch 2.12 regression: prompt_embeds output diverges from raw-text when text precedes audio`.
- The full GPU E2E test was not rerun for this follow-up commit; the change only updates marker selection.

## Model Evaluation

Not applicable; this changes test metadata only and does not affect model behavior or serving.

## AI Assistance

OpenAI Codex was used to analyze the review feedback, update the condition, and run focused validation.