### PR TITLE
[ROCm][Docker] Drop MORI_GPU_ARCHS so MoRI autodetects the device arch

### DIFF
--- a/docker/Dockerfile.rocm_base
+++ b/docker/Dockerfile.rocm_base
@@ -30,7 +30,7 @@ ENV LD_LIBRARY_PATH=/opt/rocm/lib:/usr/local/lib:
 ARG PYTORCH_ROCM_ARCH=gfx90a;gfx942;gfx950;gfx1100;gfx1101;gfx1200;gfx1201;gfx1150;gfx1151
 ENV PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH}
 ENV AITER_ROCM_ARCH=gfx942;gfx950
-ENV MORI_GPU_ARCHS=gfx942;gfx950
+# Note: Do not set MORI_GPU_ARCHS here, it is automatically inferred at runtime
 
 # Required for RCCL in ROCm7.1
 ENV HSA_NO_SCRATCH_RECLAIM=1


### PR DESCRIPTION
Remove `ENV MORI_GPU_ARCHS=gfx942;gfx950` from `Dockerfile.rocm_base`.

MoRI JIT-compiles at runtime and autodetects the GPU arch, but
`mori.jit.config.detect_gpu_arch()` treats `MORI_GPU_ARCHS` as an override that
returns the first entry of its `_SUPPORTED_ARCHS` (`gfx942`). So on a gfx950
(MI350) host it builds a gfx942 code object → `device kernel image is invalid`,
crashing MoRI at startup.

```
[2026-07-24 01:23:31.021] [17068] [shmem] [error] Failed to load shmem module from /root/.mori/jit/gfx942_ionic/d4ce9156baa6/shmem_kernels.hsaco: device kernel image is invalid
```

#44374 fixes this but also tried to switch to the MoRI wheels, which are unsupported on the current ub22.04+py312 base image combination. Opening this smaller PR so we can get this fix in asap.

 AI assistance was used; the submitter reviewed the change.
