### PR TITLE
[ROCm][CI] Wait for ROCm VRAM to settle between compiled and eager LL…

### DIFF
--- a/tests/compile/test_dynamic_shapes_compilation.py
+++ b/tests/compile/test_dynamic_shapes_compilation.py
@@ -9,6 +9,7 @@ import pytest
 import torch
 
 from tests.models.utils import check_logprobs_close
+from tests.utils import wait_for_rocm_memory_to_settle
 from vllm import LLM, SamplingParams
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CompilationConfig, VllmConfig, set_current_vllm_config
@@ -104,6 +105,7 @@ def test_dynamic_shapes_compilation(
     gc.collect()
     torch.accelerator.empty_cache()
     torch.accelerator.synchronize()
+    wait_for_rocm_memory_to_settle()
 
     eager_model = LLM(model=model_name, enforce_eager=True, max_model_len=1024)
     eager_outputs = []


### PR DESCRIPTION
## Summary

Wait for ROCm VRAM to settle between compiled and eager `LLM` runs in `test_dynamic_shapes_compilation`, fixing `mi300_1: PyTorch Compilation Unit Tests`.

## Problem

Build 11128 failed on:

`test_dynamic_shapes_compilation[False-True-0-backed-Qwen/Qwen2-7B-Instruct]`

After the compiled Qwen2-7B run, starting an eager `LLM` in the same process hit a GPU fault in V2 model runner (`buffer_utils.py` → `states.py` → `model_runner.py`). `gc` + `empty_cache()` alone do not release enough ROCm state before the second init.

## Solution

- Import `wait_for_rocm_memory_to_settle` from `tests.utils`
- Call it after compiled-model teardown and before the eager `LLM`