### PR TITLE
fix(tracing): preserve temperature=0.0 and top_p=0.0 in OTel span attributes (#49589) 

### DIFF
--- a/tests/v1/tracing/test_tracing.py
+++ b/tests/v1/tracing/test_tracing.py
@@ -31,8 +31,8 @@ def test_traces(
         m.setenv("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
 
         sampling_params = SamplingParams(
-            temperature=0.01,
-            top_p=0.1,
+            temperature=0.0,
+            top_p=1.0,
             max_tokens=256,
         )
         model = "facebook/opt-125m"

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -765,13 +765,13 @@ class OutputProcessor:
         }
 
         # Add optional request parameters
-        if req_state.top_p:
+        if req_state.top_p is not None:
             attributes[SpanAttributes.GEN_AI_REQUEST_TOP_P] = req_state.top_p
         if req_state.max_tokens_param:
             attributes[SpanAttributes.GEN_AI_REQUEST_MAX_TOKENS] = (
                 req_state.max_tokens_param
             )
-        if req_state.temperature:
+        if req_state.temperature is not None:
             attributes[SpanAttributes.GEN_AI_REQUEST_TEMPERATURE] = (
                 req_state.temperature
             )


### PR DESCRIPTION


## Purpose

Fixes #49589.

In `vllm/v1/engine/output_processor.py`, optional request parameters like `top_p` and `temperature` were checked using implicit boolean truthiness:

```python
if req_state.temperature:
    attributes[SpanAttributes.GEN_AI_REQUEST_TEMPERATURE] = req_state.temperature
```

In Python, `bool(0.0)` evaluates to `False`. When a client sends a request with greedy decoding (`temperature=0.0`), `if req_state.temperature:` evaluates to `False`, causing `GEN_AI_REQUEST_TEMPERATURE` to be omitted from OpenTelemetry trace span attributes.

This PR changes the checks to explicit `is not None` conditions (`if req_state.temperature is not None:` and `if req_state.top_p is not None:`) so that valid `0.0` values are preserved in telemetry spans.

---

## Test Plan

1. **Unit Test Execution**

   Run the OpenTelemetry tracing integration test with `temperature=0.0` and `top_p=1.0`:

   ```bash
   PATH=.venv/bin:$PATH .venv/bin/python -m pytest tests/v1/tracing/test_tracing.py -v
   ```

2. **Linter Execution**

   Run Ruff on the modified files:

   ```bash
   .venv/bin/ruff check vllm/v1/engine/output_processor.py tests/v1/tracing/test_tracing.py
   ```

---

## Test Results

1. **Unit Test Result**

   ```text
   ============================= test session starts ==============================
   platform linux -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0
   rootdir: /media/nikki/Data/Projects/OpenSource/vllm_project/vllm
   configfile: pyproject.toml
   collected 1 item

   tests/v1/tracing/test_tracing.py::test_traces PASSED [100%]

   ================== 1 passed, 15 warnings in 77.84s (0:01:17) ==================
   ```

2. **Linter Result**

   ```text
   All checks passed!
   ```

---

## Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)."
- [x] The test plan, such as providing test commands.
- [x] The test results, such as pasting the results or e2e output.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and examples for a new model.

---

### Summary of Work

- Filled out the vLLM GitHub Pull Request template (`PULL_REQUEST_TEMPLATE.md`) with the Purpose, Test Plan, Test Results, and checklist.