### PR TITLE
[Bugfix] Count reasoning tokens when the start token is absent

### DIFF
--- a/tests/reasoning/test_base_thinking_reasoning_parser.py
+++ b/tests/reasoning/test_base_thinking_reasoning_parser.py
@@ -184,6 +184,21 @@ class TestBaseThinkingReasoningParserMethods:
         # Tokens 1,2,3 are inside reasoning (depth>0) => 3 tokens
         assert parser.count_reasoning_tokens(token_ids) == 3
 
+    def test_count_reasoning_tokens_without_start_token(self, test_tokenizer):
+        """Count leading reasoning tokens when the start token is absent.
+
+        Some models (e.g. DeepSeek-R1) use a chat template that emits the
+        opening think token into the prompt, so the generated output starts
+        with reasoning and only contains the end token. The tokens before the
+        end token are reasoning content (matching ``extract_reasoning``) and
+        must be counted.
+        """
+        parser = TestThinkingReasoningParser(test_tokenizer)
+        end = parser.end_token_id
+        # No start token id anywhere; reasoning is the leading run before `end`.
+        token_ids = [11, 12, end, 99]
+        assert parser.count_reasoning_tokens(token_ids) == 2
+
     def test_extract_content_ids(self, test_tokenizer):
         """Test the extract_content_ids method."""
         parser = TestThinkingReasoningParser(test_tokenizer)

--- a/vllm/reasoning/basic_parsers.py
+++ b/vllm/reasoning/basic_parsers.py
@@ -185,9 +185,20 @@ class BaseThinkingReasoningParser(ReasoningParser):
 
         Uses a depth counter so nested spans are handled safely and stray end
         tokens do not drive the counter negative.
+
+        Some models (e.g. DeepSeek-R1) use a chat template that emits the
+        opening start token into the prompt rather than into the generated
+        output. In that case the output begins directly with reasoning and
+        only contains the end token, so the reasoning span is opened
+        implicitly at the beginning to match ``extract_reasoning``.
         """
         count = 0
         depth = 0
+        # Handle models that begin reasoning without emitting a start token:
+        # when an end token is present but no start token is, the leading
+        # tokens up to the first end token are reasoning content.
+        if self.start_token_id not in token_ids and self.end_token_id in token_ids:
+            depth = 1
         for token_id in token_ids:
             if token_id == self.start_token_id:
                 depth += 1


### PR DESCRIPTION
## Purpose

`BaseThinkingReasoningParser.count_reasoning_tokens()` counts reasoning tokens with a depth counter that is only incremented by a **start** token (e.g. `<think>`). However, the base parser explicitly supports models whose chat template emits the opening think token into the **prompt** rather than into the generated output — most notably **DeepSeek-R1**. For those models the generated `output_token_ids` begin directly with reasoning content and contain only the **end** token (`</think>`):

```text
[reasoning_token, reasoning_token, ..., </think>, content_token, ...]
```

Because there is no start token in the output, the depth counter never leaves `0` and `count_reasoning_tokens()` returns **0**, even though `extract_reasoning()` / `extract_reasoning_streaming()` correctly treat the leading tokens as reasoning content.

This value populates the `reasoning_tokens` field of the response usage object (via `count_reasoning_tokens` in `vllm/entrypoints/openai/responses/serving.py`), so the reported reasoning-token usage is `0` for DeepSeek-R1 and any other model that relies on an implicit, prompt-injected start token.

### Fix

Open the reasoning span implicitly at the beginning when the token sequence contains an end token but no start token, matching the behavior of `extract_reasoning()`. The normal (explicit start token) and nested-span cases are unchanged.

## Test Plan

Added a regression test `test_count_reasoning_tokens_without_start_token` in `tests/reasoning/test_base_thinking_reasoning_parser.py` that feeds a token sequence with an end token but no start token and asserts the leading tokens are counted as reasoning.

```bash
pytest tests/reasoning/test_base_thinking_reasoning_parser.py \
       tests/reasoning/test_deepseekr1_reasoning_parser.py
```

## Test Result

- The new test **fails** on `main` (returns `0`, expected `2`) and **passes** with this change.
- `tests/reasoning/test_base_thinking_reasoning_parser.py` → **25 passed**
- `tests/reasoning/test_deepseekr1_reasoning_parser.py` → **24 passed** (no regression in the explicit-start-token path)
- `ruff check` and `ruff format --check` are clean on both changed files.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
