### PR TITLE
[Kernel] Fused QK-Norm + mRoPE for Qwen3-VL-class models

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -400,6 +400,7 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
     "csrc/libtorch_stable/quantization/gptq/q_gemm.cu"
     "csrc/libtorch_stable/pos_encoding_kernels.cu"
     "csrc/libtorch_stable/fused_qknorm_rope_kernel.cu"
+    "csrc/libtorch_stable/fused_qknorm_mrope_kernel.cu"
     "csrc/libtorch_stable/fused_minimax_m3_qknorm_rope_kv_insert_kernel.cu"
     "csrc/libtorch_stable/layernorm_kernels.cu"
     "csrc/libtorch_stable/layernorm_quant_kernels.cu"

--- a/benchmarks/fused_kernels/fused_qk_norm_mrope_benchmark.py
+++ b/benchmarks/fused_kernels/fused_qk_norm_mrope_benchmark.py
@@ -133,7 +133,9 @@ def make_fused(
     return fused
 
 
-def bench_fn(fn: Callable, label: str, sub_label: str, description: str) -> TMeasurement:
+def bench_fn(
+    fn: Callable, label: str, sub_label: str, description: str
+) -> TMeasurement:
     return TBenchmark.Timer(
         stmt="fn()",
         globals={"fn": fn},
@@ -177,9 +179,7 @@ def bench(p: bench_params_t, label: str, sub_label: str) -> Iterable[TMeasuremen
     ]
 
 
-def print_speedups(
-    params: list[bench_params_t], timers: list[TMeasurement]
-) -> None:
+def print_speedups(params: list[bench_params_t], timers: list[TMeasurement]) -> None:
     """Per-config unfused/fused speedup plus summary. timers are laid out as
     [unfused_0, fused_0, unfused_1, fused_1, ...] matching ``params`` order."""
     print("\n" + "=" * 80)

--- a/benchmarks/fused_kernels/fused_qk_norm_mrope_benchmark.py
+++ b/benchmarks/fused_kernels/fused_qk_norm_mrope_benchmark.py
@@ -127,6 +127,7 @@ def make_fused(
             positions,
             ms[0],
             ms[1],
+            False,  # mrope_interleaved (section layout; irrelevant to timing)
         )
 
     return fused

--- a/benchmarks/fused_kernels/fused_qk_norm_mrope_benchmark.py
+++ b/benchmarks/fused_kernels/fused_qk_norm_mrope_benchmark.py
@@ -1,0 +1,223 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Microbenchmark: fused QK-Norm + mRoPE vs. the unfused 3-launch path.
+
+Unfused path (what Qwen3-VL-class models run today):
+    rms_norm(q) -> rms_norm(k) -> mrope(q, k)          # 3 kernel launches
+Fused path (this PR):
+    fused_qk_norm_mrope(qkv, ...)                       # 1 kernel launch
+
+Run:
+    python benchmarks/fused_kernels/fused_qk_norm_mrope_benchmark.py
+"""
+
+import statistics
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from itertools import product
+
+import torch
+import torch.utils.benchmark as TBenchmark
+from torch.utils.benchmark import Measurement as TMeasurement
+from tqdm import tqdm
+
+# Imported for side effects: loading vLLM registers the C ops (torch.ops._C.rms_norm,
+# torch.ops._C.fused_qk_norm_mrope) and the mRoPE custom op (torch.ops.vllm.mrope).
+# The module import is safe; only *instantiating* MRotaryEmbedding needs a vLLM config.
+import vllm.model_executor.layers.rotary_embedding.mrope  # noqa: F401,E402
+
+# mRoPE rotation is always neox-style; the fused kernel is invoked with is_neox=True.
+IS_NEOX = True
+EPS = 1e-6
+
+
+@dataclass
+class bench_params_t:
+    num_tokens: int
+    num_heads: int
+    num_kv_heads: int
+    head_dim: int
+    mrope_section: tuple[int, int, int]
+    dtype: torch.dtype
+
+    def description(self) -> str:
+        return (
+            f"N {self.num_tokens} "
+            f"x Hq {self.num_heads} "
+            f"x Hkv {self.num_kv_heads} "
+            f"x D {self.head_dim} "
+            f"x DT {self.dtype}"
+        )
+
+
+def get_bench_params() -> list[bench_params_t]:
+    """Representative Qwen-VL-class attention geometries.
+
+    mrope_section sums to head_dim // 2 (full rotary). All are non-interleaved.
+    """
+    NUM_TOKENS = [16, 128, 512, 2048, 8192]
+    # (num_heads, num_kv_heads, head_dim, mrope_section)
+    HEAD_CONFIGS = [
+        (16, 2, 128, (16, 24, 24)),  # small VL
+        (28, 4, 128, (16, 24, 24)),  # ~Qwen2.5-VL-7B
+        (40, 8, 128, (16, 24, 24)),  # larger GQA
+    ]
+    DTYPES = [torch.bfloat16, torch.float16]
+
+    params: list[bench_params_t] = []
+    for num_tokens, (nh, nkv, hd, ms), dtype in product(
+        NUM_TOKENS, HEAD_CONFIGS, DTYPES
+    ):
+        params.append(bench_params_t(num_tokens, nh, nkv, hd, ms, dtype))
+    return params
+
+
+def _rmsnorm_cuda(
+    x_flat: torch.Tensor, weight: torch.Tensor, eps: float
+) -> torch.Tensor:
+    out = torch.empty_like(x_flat)
+    torch.ops._C.rms_norm(out, x_flat, weight, eps)
+    return out
+
+
+def make_unfused(
+    qkv, positions, q_weight, k_weight, cos_sin_cache, p: bench_params_t
+) -> Callable:
+    q_size = p.num_heads * p.head_dim
+    kv_size = p.num_kv_heads * p.head_dim
+    ms = p.mrope_section
+
+    def unfused():
+        q, k, _ = qkv.split([q_size, kv_size, kv_size], dim=-1)
+        qn = _rmsnorm_cuda(q.reshape(-1, p.head_dim).contiguous(), q_weight, EPS)
+        kn = _rmsnorm_cuda(k.reshape(-1, p.head_dim).contiguous(), k_weight, EPS)
+        torch.ops.vllm.mrope(
+            positions,
+            qn.view(p.num_tokens, q_size),
+            kn.view(p.num_tokens, kv_size),
+            cos_sin_cache,
+            p.head_dim,
+            p.head_dim,
+            ms[0],
+            ms[1],
+            ms[2],
+            False,
+        )
+
+    return unfused
+
+
+def make_fused(
+    qkv, positions, q_weight, k_weight, cos_sin_cache, p: bench_params_t
+) -> Callable:
+    ms = p.mrope_section
+
+    def fused():
+        torch.ops._C.fused_qk_norm_mrope(
+            qkv,
+            p.num_heads,
+            p.num_kv_heads,
+            p.num_kv_heads,
+            p.head_dim,
+            EPS,
+            q_weight,
+            k_weight,
+            cos_sin_cache,
+            IS_NEOX,
+            positions,
+            ms[0],
+            ms[1],
+        )
+
+    return fused
+
+
+def bench_fn(fn: Callable, label: str, sub_label: str, description: str) -> TMeasurement:
+    return TBenchmark.Timer(
+        stmt="fn()",
+        globals={"fn": fn},
+        label=label,
+        sub_label=sub_label,
+        description=description,
+    ).blocked_autorange(min_run_time=1.0)
+
+
+def bench(p: bench_params_t, label: str, sub_label: str) -> Iterable[TMeasurement]:
+    device = "cuda"
+    q_size = p.num_heads * p.head_dim
+    kv_size = p.num_kv_heads * p.head_dim
+    total = q_size + 2 * kv_size
+
+    qkv = torch.randn(p.num_tokens, total, dtype=p.dtype, device=device)
+    positions = torch.randint(
+        0, 4096, (3, p.num_tokens), dtype=torch.long, device=device
+    )
+    q_weight = torch.randn(p.head_dim, dtype=p.dtype, device=device)
+    k_weight = torch.randn(p.head_dim, dtype=p.dtype, device=device)
+
+    # A random cos/sin cache is sufficient for timing: the kernel's memory
+    # traffic (gather cos_sin_cache[positions]) and FLOPs are identical
+    # regardless of the values, and the benchmark makes no correctness assertion.
+    cos_sin_cache = torch.randn(4096, p.head_dim, dtype=p.dtype, device=device)
+
+    return [
+        bench_fn(
+            make_unfused(qkv.clone(), positions, q_weight, k_weight, cos_sin_cache, p),
+            label,
+            sub_label,
+            "unfused_rmsnorm+mrope",
+        ),
+        bench_fn(
+            make_fused(qkv.clone(), positions, q_weight, k_weight, cos_sin_cache, p),
+            label,
+            sub_label,
+            "fused_qk_norm_mrope",
+        ),
+    ]
+
+
+def print_speedups(
+    params: list[bench_params_t], timers: list[TMeasurement]
+) -> None:
+    """Per-config unfused/fused speedup plus summary. timers are laid out as
+    [unfused_0, fused_0, unfused_1, fused_1, ...] matching ``params`` order."""
+    print("\n" + "=" * 80)
+    print("SPEEDUP (unfused / fused, from median times)")
+    print("=" * 80)
+    print(f"{'config':<50}{'unfused(us)':>13}{'fused(us)':>12}{'speedup':>10}")
+    print("-" * 85)
+    speedups = []
+    for i, p in enumerate(params):
+        unf = timers[2 * i].median * 1e6
+        fus = timers[2 * i + 1].median * 1e6
+        sp = unf / fus
+        speedups.append(sp)
+        print(f"{p.description():<50}{unf:>13.1f}{fus:>12.1f}{sp:>9.2f}x")
+    print("-" * 85)
+    print(
+        f"min {min(speedups):.2f}x | "
+        f"median {statistics.median(speedups):.2f}x | "
+        f"mean {statistics.mean(speedups):.2f}x | "
+        f"max {max(speedups):.2f}x"
+    )
+
+
+def main():
+    torch.set_default_device("cuda")
+    params = get_bench_params()
+    print(f"Running {len(params)} configurations (~2s each)...\n")
+
+    timers: list[TMeasurement] = []
+    for p in tqdm(params):
+        timers.extend(bench(p, "qk-norm-mrope", p.description()))
+
+    print("\n" + "=" * 80)
+    print("FINAL COMPARISON — unfused (3 launches) vs fused (1 launch)")
+    print("=" * 80)
+    TBenchmark.Compare(timers).print()
+
+    print_speedups(params, timers)
+
+
+if __name__ == "__main__":
+    main()

--- a/csrc/libtorch_stable/fused_qknorm_mrope_kernel.cu
+++ b/csrc/libtorch_stable/fused_qknorm_mrope_kernel.cu
@@ -1,0 +1,466 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Fused per-head QK RMSNorm + multimodal RoPE (mRoPE) for Qwen3-VL-class models.
+//
+// This is the mRoPE analogue of fused_qknorm_rope_kernel.cu. The RMSNorm and
+// RoPE-rotation math is identical; the only difference is where cos/sin come
+// from. Standard RoPE uses a single position id per token, so cos/sin for
+// half-dimension d live at cos_sin_cache[pos_id, d]. mRoPE instead has three
+// position streams (time/height/width) in position_ids[3, num_tokens], and the
+// half-dimension d selects which stream to use via the mrope_section [t, h, w]
+// boundaries (with t + h + w == rotary_dim / 2). We therefore look up
+// cos_sin_cache[position_ids[section(d), token], d] per half-dimension, with no
+// pre-gather of the cache.
+//
+// v1 scope: base (one warp per token-head) kernel only, non-interleaved mRoPE
+// section layout (mrope_interleaved == false, the Qwen3-VL default), head dims
+// 64/128/256, both neox and gpt-j (interleaved) rotation styles. The
+// cp.async NTokenHeads throughput variant present in the plain-RoPE kernel is a
+// planned follow-up; the compile-fusion pass only fires for the configurations
+// supported here.
+
+#include <cmath>
+#include <cuda_runtime.h>
+#include <type_traits>
+
+#include "torch_utils.h"
+
+#include "../cuda_compat.h"
+#include "type_convert.cuh"
+#include "dispatch_utils.h"
+
+#define CHECK_TYPE(x, st)                                                  \
+  STD_TORCH_CHECK(x.scalar_type() == st, #x " dtype is ", x.scalar_type(), \
+                  ", while ", st, " is expected")
+#define CHECK_TH_CUDA(x) \
+  STD_TORCH_CHECK(x.is_cuda(), #x " must be a CUDA tensor")
+#define CHECK_CONTIGUOUS(x) \
+  STD_TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
+#define CHECK_INPUT(x) \
+  CHECK_TH_CUDA(x);    \
+  CHECK_CONTIGUOUS(x)
+
+#ifdef USE_ROCM
+  #define FINAL_MASK 0xffffffffffffffffULL
+
+  #if defined(HIP_VERSION) && HIP_VERSION < 70000000
+__device__ inline void __syncwarp() {
+  __builtin_amdgcn_fence(__ATOMIC_RELEASE, "wavefront");
+  __builtin_amdgcn_wave_barrier();
+  __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "wavefront");
+}
+  #endif
+#else
+  #define FINAL_MASK 0xffffffff
+#endif
+
+namespace tensorrt_llm::common {
+template <typename T, int num>
+struct packed_as;
+template <>
+struct packed_as<uint, 1> {
+  using type = uint;
+};
+template <>
+struct packed_as<uint, 2> {
+  using type = uint2;
+};
+template <>
+struct packed_as<uint, 4> {
+  using type = uint4;
+};
+
+template <typename T>
+__inline__ __device__ T warpReduceSum(T val) {
+#pragma unroll
+  for (int mask = 16; mask > 0; mask >>= 1)
+    val += __shfl_xor_sync(FINAL_MASK, val, mask, 32);
+  return val;
+}
+
+template <typename T>
+inline __device__ __host__ T divUp(T m, T n) {
+  return (m + n - 1) / n;
+}
+
+}  // namespace tensorrt_llm::common
+
+namespace tensorrt_llm::kernels {
+
+// Select the mRoPE section (0=time, 1=height, 2=width) that owns half-dimension
+// `half_dim` for the non-interleaved layout, then return the token's position id
+// for that section. position_ids is laid out row-major as [3, num_tokens].
+__device__ __forceinline__ int64_t mropePositionForHalfDim(
+    int64_t const* position_ids, int const num_tokens, int const tokenIdx,
+    int const half_dim, int const mrope_section_t, int const mrope_section_h) {
+  int section;
+  if (half_dim < mrope_section_t) {
+    section = 0;
+  } else if (half_dim < mrope_section_t + mrope_section_h) {
+    section = 1;
+  } else {
+    section = 2;
+  }
+  return position_ids[section * num_tokens + tokenIdx];
+}
+
+// Perform per-head QK Norm and mRoPE in a single kernel.
+// scalar_t_in: data type of QKV and RMSNorm weights
+// scalar_t_cache: data type of cos/sin cache
+// head_dim: the dimension of each head
+// interleave: interleave = !is_neox (rotary rotation style).
+template <typename scalar_t_in, typename scalar_t_cache, int head_dim,
+          bool interleave>
+__global__ void fusedQKNormMRopeKernel(
+    void* qkv_void,                  // Combined QKV tensor
+    int const num_heads_q,           // Number of query heads
+    int const num_heads_k,           // Number of key heads
+    int const num_heads_v,           // Number of value heads
+    float const eps,                 // Epsilon for RMS normalization
+    void const* q_weight_void,       // RMSNorm weights for query
+    void const* k_weight_void,       // RMSNorm weights for key
+    void const* cos_sin_cache_void,  // Pre-computed cos/sin cache
+    int64_t const* position_ids,     // Position IDs for mRoPE [3, num_tokens]
+    int const num_tokens,            // Number of tokens
+    int const rotary_dim,            // Dimension for RoPE
+    int const mrope_section_t,       // mRoPE time-section size (half-dims)
+    int const mrope_section_h        // mRoPE height-section size (half-dims)
+) {
+#if (!defined(__CUDA_ARCH__) || __CUDA_ARCH__ < 800) && !defined(USE_ROCM)
+  if constexpr ((std::is_same_v<scalar_t_in, c10::BFloat16>) ||
+                std::is_same_v<scalar_t_cache, c10::BFloat16>) {
+    return;
+  } else {
+#endif
+
+    using Converter = vllm::_typeConvert<scalar_t_in>;
+    static_assert(Converter::exists,
+                  "Input QKV data type is not supported for this CUDA "
+                  "architecture or toolkit version.");
+    using T_in = typename Converter::hip_type;
+    using T2_in = typename Converter::packed_hip_type;
+
+    using CacheConverter = vllm::_typeConvert<scalar_t_cache>;
+    static_assert(CacheConverter::exists,
+                  "Cache data type is not supported for this CUDA architecture "
+                  "or toolkit version.");
+    using T_cache = typename CacheConverter::hip_type;
+
+    T_in* qkv = reinterpret_cast<T_in*>(qkv_void);
+    T_in const* q_weight = reinterpret_cast<T_in const*>(q_weight_void);
+    T_in const* k_weight = reinterpret_cast<T_in const*>(k_weight_void);
+    T_cache const* cos_sin_cache =
+        reinterpret_cast<T_cache const*>(cos_sin_cache_void);
+
+    int const warpsPerBlock = blockDim.x / 32;
+    int const warpId = threadIdx.x / 32;
+    int const laneId = threadIdx.x % 32;
+
+    int const globalWarpIdx = blockIdx.x * warpsPerBlock + warpId;
+
+    int const total_qk_heads = num_heads_q + num_heads_k;
+
+    int const tokenIdx = globalWarpIdx / total_qk_heads;
+    int const localHeadIdx = globalWarpIdx % total_qk_heads;
+
+    if (tokenIdx >= num_tokens) return;
+
+    bool const isQ = localHeadIdx < num_heads_q;
+    int const headIdx = isQ ? localHeadIdx : localHeadIdx - num_heads_q;
+
+    int const num_heads = num_heads_q + num_heads_k + num_heads_v;
+
+    static_assert(head_dim % (32 * 2) == 0,
+                  "head_dim must be divisible by 64 (each warp processes one "
+                  "head, and each thread gets even number of "
+                  "elements)");
+    constexpr int numElemsPerThread = head_dim / 32;
+    float elements[numElemsPerThread];
+    constexpr int elemSizeBytes = numElemsPerThread * sizeof(__nv_bfloat16);
+    static_assert(elemSizeBytes % 4 == 0,
+                  "numSizeBytes must be a multiple of 4");
+    constexpr int vecSize = elemSizeBytes / 4;
+    using vec_T = typename tensorrt_llm::common::packed_as<uint, vecSize>::type;
+
+    int offsetWarp;
+    if (isQ) {
+      offsetWarp = tokenIdx * num_heads * head_dim + headIdx * head_dim;
+    } else {
+      offsetWarp = tokenIdx * num_heads * head_dim + num_heads_q * head_dim +
+                   headIdx * head_dim;
+    }
+    int offsetThread = offsetWarp + laneId * numElemsPerThread;
+
+    // Sum of squares for RMSNorm
+    float sumOfSquares = 0.0f;
+
+    // Load.
+    {
+      vec_T vec = *reinterpret_cast<vec_T const*>(&qkv[offsetThread]);
+      constexpr int num_packed_elems = elemSizeBytes / sizeof(T2_in);
+#pragma unroll
+      for (int i = 0; i < num_packed_elems; i++) {
+        T2_in packed_val = *(reinterpret_cast<T2_in*>(&vec) + i);
+        float2 vals = Converter::convert(packed_val);
+        sumOfSquares += vals.x * vals.x;
+        sumOfSquares += vals.y * vals.y;
+
+        elements[2 * i] = vals.x;
+        elements[2 * i + 1] = vals.y;
+      }
+    }
+
+    sumOfSquares = tensorrt_llm::common::warpReduceSum(sumOfSquares);
+
+    float rms_rcp = rsqrtf(sumOfSquares / static_cast<float>(head_dim) + eps);
+
+#pragma unroll
+    for (int i = 0; i < numElemsPerThread; i++) {
+      int dim = laneId * numElemsPerThread + i;
+      float weight = isQ ? Converter::convert(q_weight[dim])
+                         : Converter::convert(k_weight[dim]);
+      elements[i] *= rms_rcp * weight;
+    }
+
+    // Apply mRoPE to normalized elements
+    float elements2[numElemsPerThread];  // Additional buffer required for RoPE.
+
+    int const embed_dim = rotary_dim / 2;
+    int const rotary_lanes = rotary_dim / numElemsPerThread;
+    if (laneId < rotary_lanes) {
+      if constexpr (interleave) {
+        // gpt-j / interleaved rotation style.
+#pragma unroll
+        for (int i = 0; i < numElemsPerThread / 2; ++i) {
+          int const idx0 = 2 * i;
+          int const idx1 = 2 * i + 1;
+          int const dim_idx = laneId * numElemsPerThread + idx0;
+
+          float const val0 = elements[idx0];
+          float const val1 = elements[idx1];
+
+          int const half_dim = dim_idx / 2;
+          int64_t const pos_id = mropePositionForHalfDim(
+              position_ids, num_tokens, tokenIdx, half_dim, mrope_section_t,
+              mrope_section_h);
+          T_cache const* cache_ptr = cos_sin_cache + pos_id * rotary_dim;
+          float const cos_val =
+              CacheConverter::convert(VLLM_LDG(cache_ptr + half_dim));
+          float const sin_val = CacheConverter::convert(
+              VLLM_LDG(cache_ptr + embed_dim + half_dim));
+
+          elements[idx0] = val0 * cos_val - val1 * sin_val;
+          elements[idx1] = val0 * sin_val + val1 * cos_val;
+        }
+      } else {
+        // neox rotation style: pair element i with the element rotary_dim/2 away
+        // in the head, exchanged across the warp.
+        __syncwarp();
+        int pairOffset = (rotary_dim / 2) / numElemsPerThread;
+#pragma unroll
+        for (int i = 0; i < numElemsPerThread; i++) {
+          elements2[i] = __shfl_xor_sync(FINAL_MASK, elements[i], pairOffset);
+
+          if (laneId < pairOffset) {
+            elements2[i] = -elements2[i];
+          }
+          int dim_idx = laneId * numElemsPerThread + i;
+
+          dim_idx = (dim_idx * 2) % rotary_dim;
+          int half_dim = dim_idx / 2;
+          int64_t const pos_id = mropePositionForHalfDim(
+              position_ids, num_tokens, tokenIdx, half_dim, mrope_section_t,
+              mrope_section_h);
+          T_cache const* cache_ptr = cos_sin_cache + pos_id * rotary_dim;
+          float cos_val =
+              CacheConverter::convert(VLLM_LDG(cache_ptr + half_dim));
+          float sin_val =
+              CacheConverter::convert(VLLM_LDG(cache_ptr + embed_dim + half_dim));
+
+          elements[i] = elements[i] * cos_val + elements2[i] * sin_val;
+        }
+        __syncwarp();
+      }
+    }
+    // Store.
+    {
+      vec_T vec;
+      constexpr int num_packed_elems = elemSizeBytes / sizeof(T2_in);
+#pragma unroll
+      for (int i = 0; i < num_packed_elems; i++) {
+        T2_in packed_val = Converter::convert(
+            make_float2(elements[2 * i], elements[2 * i + 1]));
+        *(reinterpret_cast<T2_in*>(&vec) + i) = packed_val;
+      }
+      *reinterpret_cast<vec_T*>(&qkv[offsetThread]) = vec;
+    }
+
+#if (!defined(__CUDA_ARCH__) || __CUDA_ARCH__ < 800) && !defined(USE_ROCM)
+  }
+#endif
+}
+
+#define DISPATCH_INTERLEAVE(interleave, INTERLEAVE, ...) \
+  if (interleave) {                                      \
+    const bool INTERLEAVE = true;                        \
+    __VA_ARGS__                                          \
+  } else {                                               \
+    const bool INTERLEAVE = false;                       \
+    __VA_ARGS__                                          \
+  }
+
+template <typename scalar_t_in, typename scalar_t_cache>
+void launchFusedQKNormMRope(void* qkv, int const num_tokens,
+                            int const num_heads_q, int const num_heads_k,
+                            int const num_heads_v, int const head_dim,
+                            int const rotary_dim, float const eps,
+                            void const* q_weight, void const* k_weight,
+                            void const* cos_sin_cache, bool const interleave,
+                            int64_t const* position_ids,
+                            int const mrope_section_t, int const mrope_section_h,
+                            cudaStream_t stream) {
+  constexpr int blockSize = 256;
+  int const warpsPerBlock = blockSize / 32;
+  int const totalQKHeads = num_heads_q + num_heads_k;
+  int const totalWarps = num_tokens * totalQKHeads;
+  int const gridSize = common::divUp(totalWarps, warpsPerBlock);
+  dim3 gridDim(gridSize);
+  dim3 blockDim(blockSize);
+  switch (head_dim) {
+    case 64:
+      DISPATCH_INTERLEAVE(interleave, INTERLEAVE, {
+        fusedQKNormMRopeKernel<scalar_t_in, scalar_t_cache, 64, INTERLEAVE>
+            <<<gridDim, blockDim, 0, stream>>>(
+                qkv, num_heads_q, num_heads_k, num_heads_v, eps, q_weight,
+                k_weight, cos_sin_cache, position_ids, num_tokens, rotary_dim,
+                mrope_section_t, mrope_section_h);
+      });
+      break;
+    case 128:
+      DISPATCH_INTERLEAVE(interleave, INTERLEAVE, {
+        fusedQKNormMRopeKernel<scalar_t_in, scalar_t_cache, 128, INTERLEAVE>
+            <<<gridDim, blockDim, 0, stream>>>(
+                qkv, num_heads_q, num_heads_k, num_heads_v, eps, q_weight,
+                k_weight, cos_sin_cache, position_ids, num_tokens, rotary_dim,
+                mrope_section_t, mrope_section_h);
+      });
+      break;
+    case 256:
+      DISPATCH_INTERLEAVE(interleave, INTERLEAVE, {
+        fusedQKNormMRopeKernel<scalar_t_in, scalar_t_cache, 256, INTERLEAVE>
+            <<<gridDim, blockDim, 0, stream>>>(
+                qkv, num_heads_q, num_heads_k, num_heads_v, eps, q_weight,
+                k_weight, cos_sin_cache, position_ids, num_tokens, rotary_dim,
+                mrope_section_t, mrope_section_h);
+      });
+      break;
+    default:
+      STD_TORCH_CHECK(
+          false, "Unsupported head dimension for fusedQKNormMRope: ", head_dim);
+  }
+}
+
+}  // namespace tensorrt_llm::kernels
+
+void fused_qk_norm_mrope(
+    torch::stable::Tensor&
+        qkv,              // Combined QKV tensor [num_tokens,
+                          // (num_heads_q+num_heads_k+num_heads_v)*head_dim]
+    int64_t num_heads_q,  // Number of query heads
+    int64_t num_heads_k,  // Number of key heads
+    int64_t num_heads_v,  // Number of value heads
+    int64_t head_dim,     // Dimension per head
+    double eps,           // Epsilon for RMS normalization
+    torch::stable::Tensor& q_weight,  // RMSNorm weights for query [head_dim]
+    torch::stable::Tensor& k_weight,  // RMSNorm weights for key [head_dim]
+    torch::stable::Tensor& cos_sin_cache,  // Cos/sin cache [max_position,
+                                           // rotary_dim]
+    bool is_neox,  // Whether RoPE is applied in Neox style
+    torch::stable::Tensor&
+        position_ids,          // mRoPE position IDs [3, num_tokens] (t/h/w)
+    int64_t mrope_section_t,   // mRoPE time-section size (in half-dims)
+    int64_t mrope_section_h    // mRoPE height-section size (in half-dims)
+) {
+  // Input validation
+  CHECK_INPUT(qkv);
+  CHECK_INPUT(position_ids);
+  CHECK_INPUT(q_weight);
+  CHECK_INPUT(k_weight);
+  CHECK_INPUT(cos_sin_cache);
+  CHECK_TYPE(position_ids, torch::headeronly::ScalarType::Long);
+
+  STD_TORCH_CHECK(qkv.dim() == 2,
+                  "QKV tensor must be 2D: [num_tokens, "
+                  "(num_heads_q+num_heads_k+num_heads_v)*head_dim]");
+  STD_TORCH_CHECK(position_ids.dim() == 2 && position_ids.size(0) == 3,
+                  "mRoPE position IDs must be 2D: [3, num_tokens]");
+  STD_TORCH_CHECK(q_weight.dim() == 1, "Query weights must be 1D: [head_dim]");
+  STD_TORCH_CHECK(k_weight.dim() == 1, "Key weights must be 1D: [head_dim]");
+  STD_TORCH_CHECK(cos_sin_cache.dim() == 2,
+                  "Cos/sin cache must be 2D: [max_position, rotary_dim]");
+  STD_TORCH_CHECK(q_weight.size(0) == head_dim,
+                  "Query weights size must match head dimension");
+  STD_TORCH_CHECK(k_weight.size(0) == head_dim,
+                  "Key weights size must match head dimension");
+
+  STD_TORCH_CHECK(cos_sin_cache.size(1) % 2 == 0, "rotary_dim must be even");
+  STD_TORCH_CHECK(cos_sin_cache.size(1) <= head_dim,
+                  "rotary_dim must be less than or equal to head_dim");
+
+  STD_TORCH_CHECK(qkv.scalar_type() == q_weight.scalar_type() &&
+                      qkv.scalar_type() == k_weight.scalar_type(),
+                  "qkv, q_weight and k_weight must have the same dtype");
+
+  int64_t num_tokens = qkv.size(0);
+  STD_TORCH_CHECK(position_ids.size(1) == num_tokens,
+                  "Number of tokens in position_ids must match QKV");
+
+  int64_t total_heads = num_heads_q + num_heads_k + num_heads_v;
+  STD_TORCH_CHECK(
+      qkv.size(1) == total_heads * head_dim,
+      "QKV tensor size must match total number of heads and head dimension");
+
+  int64_t const embed_dim = cos_sin_cache.size(1) / 2;
+  STD_TORCH_CHECK(
+      mrope_section_t >= 0 && mrope_section_h >= 0 &&
+          mrope_section_t + mrope_section_h <= embed_dim,
+      "mrope_section_t + mrope_section_h must be <= rotary_dim/2");
+
+  const torch::stable::accelerator::DeviceGuard device_guard(
+      qkv.get_device_index());
+  auto stream = get_current_cuda_stream(qkv.get_device_index());
+
+  VLLM_STABLE_DISPATCH_HALF_TYPES(
+      qkv.scalar_type(), "fused_qk_norm_mrope_kernel", [&] {
+        using qkv_scalar_t = scalar_t;
+        VLLM_STABLE_DISPATCH_FLOATING_TYPES(
+            cos_sin_cache.scalar_type(), "fused_qk_norm_mrope_kernel", [&] {
+              using cache_scalar_t = scalar_t;
+              tensorrt_llm::kernels::launchFusedQKNormMRope<qkv_scalar_t,
+                                                            cache_scalar_t>(
+                  qkv.data_ptr(), static_cast<int>(num_tokens),
+                  static_cast<int>(num_heads_q), static_cast<int>(num_heads_k),
+                  static_cast<int>(num_heads_v), static_cast<int>(head_dim),
+                  static_cast<int>(cos_sin_cache.size(1)),
+                  static_cast<float>(eps), q_weight.data_ptr(),
+                  k_weight.data_ptr(), cos_sin_cache.data_ptr(), !is_neox,
+                  reinterpret_cast<int64_t const*>(position_ids.data_ptr()),
+                  static_cast<int>(mrope_section_t),
+                  static_cast<int>(mrope_section_h), stream);
+            });
+      });
+}

--- a/csrc/libtorch_stable/fused_qknorm_mrope_kernel.cu
+++ b/csrc/libtorch_stable/fused_qknorm_mrope_kernel.cu
@@ -102,18 +102,34 @@ inline __device__ __host__ T divUp(T m, T n) {
 namespace tensorrt_llm::kernels {
 
 // Select the mRoPE section (0=time, 1=height, 2=width) that owns half-dimension
-// `half_dim` for the non-interleaved layout, then return the token's position id
-// for that section. position_ids is laid out row-major as [3, num_tokens].
+// `half_dim`, then return the token's position id for that section.
+// position_ids is laid out row-major as [3, num_tokens].
+//   - Contiguous layout (mrope_interleaved == false): [T..T H..H W..W].
+//   - Interleaved layout (mrope_interleaved == true, the Qwen3-VL default):
+//     [T H W T H W ... T T] -- half-dim d is H if d%3==1 and d<3*h, W if
+//     d%3==2 and d<3*w, else T. Matches apply_interleaved_rope /
+//     triton_mrope's is_interleaved branch in mrope.py.
 __device__ __forceinline__ int64_t mropePositionForHalfDim(
     int64_t const* position_ids, int const num_tokens, int const tokenIdx,
-    int const half_dim, int const mrope_section_t, int const mrope_section_h) {
+    int const half_dim, int const mrope_section_t, int const mrope_section_h,
+    int const mrope_section_w, bool const mrope_interleaved) {
   int section;
-  if (half_dim < mrope_section_t) {
-    section = 0;
-  } else if (half_dim < mrope_section_t + mrope_section_h) {
-    section = 1;
+  if (mrope_interleaved) {
+    if ((half_dim % 3 == 1) && (half_dim < 3 * mrope_section_h)) {
+      section = 1;
+    } else if ((half_dim % 3 == 2) && (half_dim < 3 * mrope_section_w)) {
+      section = 2;
+    } else {
+      section = 0;
+    }
   } else {
-    section = 2;
+    if (half_dim < mrope_section_t) {
+      section = 0;
+    } else if (half_dim < mrope_section_t + mrope_section_h) {
+      section = 1;
+    } else {
+      section = 2;
+    }
   }
   return position_ids[section * num_tokens + tokenIdx];
 }
@@ -138,7 +154,8 @@ __global__ void fusedQKNormMRopeKernel(
     int const num_tokens,            // Number of tokens
     int const rotary_dim,            // Dimension for RoPE
     int const mrope_section_t,       // mRoPE time-section size (half-dims)
-    int const mrope_section_h        // mRoPE height-section size (half-dims)
+    int const mrope_section_h,       // mRoPE height-section size (half-dims)
+    bool const mrope_interleaved     // Interleaved (Qwen3-VL) vs contiguous
 ) {
 #if (!defined(__CUDA_ARCH__) || __CUDA_ARCH__ < 800) && !defined(USE_ROCM)
   if constexpr ((std::is_same_v<scalar_t_in, c10::BFloat16>) ||
@@ -240,6 +257,7 @@ __global__ void fusedQKNormMRopeKernel(
     float elements2[numElemsPerThread];  // Additional buffer required for RoPE.
 
     int const embed_dim = rotary_dim / 2;
+    int const mrope_section_w = embed_dim - mrope_section_t - mrope_section_h;
     int const rotary_lanes = rotary_dim / numElemsPerThread;
     if (laneId < rotary_lanes) {
       if constexpr (interleave) {
@@ -256,7 +274,7 @@ __global__ void fusedQKNormMRopeKernel(
           int const half_dim = dim_idx / 2;
           int64_t const pos_id = mropePositionForHalfDim(
               position_ids, num_tokens, tokenIdx, half_dim, mrope_section_t,
-              mrope_section_h);
+              mrope_section_h, mrope_section_w, mrope_interleaved);
           T_cache const* cache_ptr = cos_sin_cache + pos_id * rotary_dim;
           float const cos_val =
               CacheConverter::convert(VLLM_LDG(cache_ptr + half_dim));
@@ -284,7 +302,7 @@ __global__ void fusedQKNormMRopeKernel(
           int half_dim = dim_idx / 2;
           int64_t const pos_id = mropePositionForHalfDim(
               position_ids, num_tokens, tokenIdx, half_dim, mrope_section_t,
-              mrope_section_h);
+              mrope_section_h, mrope_section_w, mrope_interleaved);
           T_cache const* cache_ptr = cos_sin_cache + pos_id * rotary_dim;
           float cos_val =
               CacheConverter::convert(VLLM_LDG(cache_ptr + half_dim));
@@ -332,7 +350,7 @@ void launchFusedQKNormMRope(void* qkv, int const num_tokens,
                             void const* cos_sin_cache, bool const interleave,
                             int64_t const* position_ids,
                             int const mrope_section_t, int const mrope_section_h,
-                            cudaStream_t stream) {
+                            bool const mrope_interleaved, cudaStream_t stream) {
   constexpr int blockSize = 256;
   int const warpsPerBlock = blockSize / 32;
   int const totalQKHeads = num_heads_q + num_heads_k;
@@ -347,7 +365,7 @@ void launchFusedQKNormMRope(void* qkv, int const num_tokens,
             <<<gridDim, blockDim, 0, stream>>>(
                 qkv, num_heads_q, num_heads_k, num_heads_v, eps, q_weight,
                 k_weight, cos_sin_cache, position_ids, num_tokens, rotary_dim,
-                mrope_section_t, mrope_section_h);
+                mrope_section_t, mrope_section_h, mrope_interleaved);
       });
       break;
     case 128:
@@ -356,7 +374,7 @@ void launchFusedQKNormMRope(void* qkv, int const num_tokens,
             <<<gridDim, blockDim, 0, stream>>>(
                 qkv, num_heads_q, num_heads_k, num_heads_v, eps, q_weight,
                 k_weight, cos_sin_cache, position_ids, num_tokens, rotary_dim,
-                mrope_section_t, mrope_section_h);
+                mrope_section_t, mrope_section_h, mrope_interleaved);
       });
       break;
     case 256:
@@ -365,7 +383,7 @@ void launchFusedQKNormMRope(void* qkv, int const num_tokens,
             <<<gridDim, blockDim, 0, stream>>>(
                 qkv, num_heads_q, num_heads_k, num_heads_v, eps, q_weight,
                 k_weight, cos_sin_cache, position_ids, num_tokens, rotary_dim,
-                mrope_section_t, mrope_section_h);
+                mrope_section_t, mrope_section_h, mrope_interleaved);
       });
       break;
     default:
@@ -393,7 +411,8 @@ void fused_qk_norm_mrope(
     torch::stable::Tensor&
         position_ids,          // mRoPE position IDs [3, num_tokens] (t/h/w)
     int64_t mrope_section_t,   // mRoPE time-section size (in half-dims)
-    int64_t mrope_section_h    // mRoPE height-section size (in half-dims)
+    int64_t mrope_section_h,   // mRoPE height-section size (in half-dims)
+    bool mrope_interleaved     // Interleaved (Qwen3-VL) vs contiguous layout
 ) {
   // Input validation
   CHECK_INPUT(qkv);
@@ -460,7 +479,7 @@ void fused_qk_norm_mrope(
                   k_weight.data_ptr(), cos_sin_cache.data_ptr(), !is_neox,
                   reinterpret_cast<int64_t const*>(position_ids.data_ptr()),
                   static_cast<int>(mrope_section_t),
-                  static_cast<int>(mrope_section_h), stream);
+                  static_cast<int>(mrope_section_h), mrope_interleaved, stream);
             });
       });
 }

--- a/csrc/libtorch_stable/fused_qknorm_mrope_kernel.cu
+++ b/csrc/libtorch_stable/fused_qknorm_mrope_kernel.cu
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-// Fused per-head QK RMSNorm + multimodal RoPE (mRoPE) for Qwen3-VL-class models.
+// Fused per-head QK RMSNorm + multimodal RoPE (mRoPE) for Qwen3-VL-class
+// models.
 //
 // This is the mRoPE analogue of fused_qknorm_rope_kernel.cu. The RMSNorm and
 // RoPE-rotation math is identical; the only difference is where cos/sin come
@@ -285,8 +286,8 @@ __global__ void fusedQKNormMRopeKernel(
           elements[idx1] = val0 * sin_val + val1 * cos_val;
         }
       } else {
-        // neox rotation style: pair element i with the element rotary_dim/2 away
-        // in the head, exchanged across the warp.
+        // neox rotation style: pair element i with the element rotary_dim/2
+        // away in the head, exchanged across the warp.
         __syncwarp();
         int pairOffset = (rotary_dim / 2) / numElemsPerThread;
 #pragma unroll
@@ -306,8 +307,8 @@ __global__ void fusedQKNormMRopeKernel(
           T_cache const* cache_ptr = cos_sin_cache + pos_id * rotary_dim;
           float cos_val =
               CacheConverter::convert(VLLM_LDG(cache_ptr + half_dim));
-          float sin_val =
-              CacheConverter::convert(VLLM_LDG(cache_ptr + embed_dim + half_dim));
+          float sin_val = CacheConverter::convert(
+              VLLM_LDG(cache_ptr + embed_dim + half_dim));
 
           elements[i] = elements[i] * cos_val + elements2[i] * sin_val;
         }
@@ -349,7 +350,8 @@ void launchFusedQKNormMRope(void* qkv, int const num_tokens,
                             void const* q_weight, void const* k_weight,
                             void const* cos_sin_cache, bool const interleave,
                             int64_t const* position_ids,
-                            int const mrope_section_t, int const mrope_section_h,
+                            int const mrope_section_t,
+                            int const mrope_section_h,
                             bool const mrope_interleaved, cudaStream_t stream) {
   constexpr int blockSize = 256;
   int const warpsPerBlock = blockSize / 32;
@@ -409,10 +411,10 @@ void fused_qk_norm_mrope(
                                            // rotary_dim]
     bool is_neox,  // Whether RoPE is applied in Neox style
     torch::stable::Tensor&
-        position_ids,          // mRoPE position IDs [3, num_tokens] (t/h/w)
-    int64_t mrope_section_t,   // mRoPE time-section size (in half-dims)
-    int64_t mrope_section_h,   // mRoPE height-section size (in half-dims)
-    bool mrope_interleaved     // Interleaved (Qwen3-VL) vs contiguous layout
+        position_ids,         // mRoPE position IDs [3, num_tokens] (t/h/w)
+    int64_t mrope_section_t,  // mRoPE time-section size (in half-dims)
+    int64_t mrope_section_h,  // mRoPE height-section size (in half-dims)
+    bool mrope_interleaved    // Interleaved (Qwen3-VL) vs contiguous layout
 ) {
   // Input validation
   CHECK_INPUT(qkv);
@@ -457,10 +459,9 @@ void fused_qk_norm_mrope(
       "QKV tensor size must match total number of heads and head dimension");
 
   int64_t const embed_dim = cos_sin_cache.size(1) / 2;
-  STD_TORCH_CHECK(
-      mrope_section_t >= 0 && mrope_section_h >= 0 &&
-          mrope_section_t + mrope_section_h <= embed_dim,
-      "mrope_section_t + mrope_section_h must be <= rotary_dim/2");
+  STD_TORCH_CHECK(mrope_section_t >= 0 && mrope_section_h >= 0 &&
+                      mrope_section_t + mrope_section_h <= embed_dim,
+                  "mrope_section_t + mrope_section_h must be <= rotary_dim/2");
 
   const torch::stable::accelerator::DeviceGuard device_guard(
       qkv.get_device_index());
@@ -486,7 +487,8 @@ void fused_qk_norm_mrope(
                   static_cast<int>(cos_sin_cache.size(1)),
                   static_cast<float>(eps), q_weight.data_ptr(),
                   k_weight.data_ptr(), cos_sin_cache.data_ptr(), !is_neox,
-                  reinterpret_cast<int64_t const*>(position_ids_contig.data_ptr()),
+                  reinterpret_cast<int64_t const*>(
+                      position_ids_contig.data_ptr()),
                   static_cast<int>(mrope_section_t),
                   static_cast<int>(mrope_section_h), mrope_interleaved, stream);
             });

--- a/csrc/libtorch_stable/fused_qknorm_mrope_kernel.cu
+++ b/csrc/libtorch_stable/fused_qknorm_mrope_kernel.cu
@@ -26,12 +26,12 @@
 // cos_sin_cache[position_ids[section(d), token], d] per half-dimension, with no
 // pre-gather of the cache.
 //
-// v1 scope: base (one warp per token-head) kernel only, non-interleaved mRoPE
-// section layout (mrope_interleaved == false, the Qwen3-VL default), head dims
-// 64/128/256, both neox and gpt-j (interleaved) rotation styles. The
-// cp.async NTokenHeads throughput variant present in the plain-RoPE kernel is a
-// planned follow-up; the compile-fusion pass only fires for the configurations
-// supported here.
+// v1 scope: base (one warp per token-head) kernel only, head dims 64/128/256,
+// both neox and gpt-j rotation styles, and both mRoPE section layouts --
+// contiguous [T..T H..H W..W] and interleaved [T H W ... T T] (the Qwen3-VL
+// default), selected by mrope_interleaved. The cp.async NTokenHeads throughput
+// variant present in the plain-RoPE kernel is a planned follow-up; the
+// compile-fusion pass only fires for the configurations supported here.
 
 #include <cmath>
 #include <cuda_runtime.h>
@@ -416,7 +416,10 @@ void fused_qk_norm_mrope(
 ) {
   // Input validation
   CHECK_INPUT(qkv);
-  CHECK_INPUT(position_ids);
+  // position_ids may be a non-contiguous view (Qwen3-VL slices [3, N] out of a
+  // larger positions tensor); require only CUDA here and materialize a
+  // contiguous copy below for the row-major kernel index.
+  CHECK_TH_CUDA(position_ids);
   CHECK_INPUT(q_weight);
   CHECK_INPUT(k_weight);
   CHECK_INPUT(cos_sin_cache);
@@ -463,6 +466,12 @@ void fused_qk_norm_mrope(
       qkv.get_device_index());
   auto stream = get_current_cuda_stream(qkv.get_device_index());
 
+  // Materialize a contiguous [3, num_tokens] copy so the kernel's row-major
+  // index (position_ids[section * num_tokens + tokenIdx]) is valid even when
+  // the caller passes a strided view (e.g. Qwen3-VL).
+  torch::stable::Tensor position_ids_contig =
+      torch::stable::contiguous(position_ids);
+
   VLLM_STABLE_DISPATCH_HALF_TYPES(
       qkv.scalar_type(), "fused_qk_norm_mrope_kernel", [&] {
         using qkv_scalar_t = scalar_t;
@@ -477,7 +486,7 @@ void fused_qk_norm_mrope(
                   static_cast<int>(cos_sin_cache.size(1)),
                   static_cast<float>(eps), q_weight.data_ptr(),
                   k_weight.data_ptr(), cos_sin_cache.data_ptr(), !is_neox,
-                  reinterpret_cast<int64_t const*>(position_ids.data_ptr()),
+                  reinterpret_cast<int64_t const*>(position_ids_contig.data_ptr()),
                   static_cast<int>(mrope_section_t),
                   static_cast<int>(mrope_section_h), mrope_interleaved, stream);
             });

--- a/csrc/libtorch_stable/ops.h
+++ b/csrc/libtorch_stable/ops.h
@@ -269,7 +269,8 @@ void fused_qk_norm_mrope(torch::stable::Tensor& qkv, int64_t num_heads_q,
                          torch::stable::Tensor& k_weight,
                          torch::stable::Tensor& cos_sin_cache, bool is_neox,
                          torch::stable::Tensor& position_ids,
-                         int64_t mrope_section_t, int64_t mrope_section_h);
+                         int64_t mrope_section_t, int64_t mrope_section_h,
+                         bool mrope_interleaved);
 
 torch::stable::Tensor fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert(
     torch::stable::Tensor const& q_in, torch::stable::Tensor const& kv,

--- a/csrc/libtorch_stable/ops.h
+++ b/csrc/libtorch_stable/ops.h
@@ -262,6 +262,15 @@ void fused_qk_norm_rope(torch::stable::Tensor& qkv, int64_t num_heads_q,
                         torch::stable::Tensor& position_ids,
                         int64_t forced_token_heads_per_warp);
 
+void fused_qk_norm_mrope(torch::stable::Tensor& qkv, int64_t num_heads_q,
+                         int64_t num_heads_k, int64_t num_heads_v,
+                         int64_t head_dim, double eps,
+                         torch::stable::Tensor& q_weight,
+                         torch::stable::Tensor& k_weight,
+                         torch::stable::Tensor& cos_sin_cache, bool is_neox,
+                         torch::stable::Tensor& position_ids,
+                         int64_t mrope_section_t, int64_t mrope_section_h);
+
 torch::stable::Tensor fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert(
     torch::stable::Tensor const& q_in, torch::stable::Tensor const& kv,
     torch::stable::Tensor& k_cache, torch::stable::Tensor const& slot_mapping,

--- a/csrc/libtorch_stable/torch_bindings.cpp
+++ b/csrc/libtorch_stable/torch_bindings.cpp
@@ -427,6 +427,16 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C, ops) {
       "bool is_neox, Tensor position_ids, "
       "int forced_token_heads_per_warp=-1) -> ()");
 
+  // Fused per-head QK RMSNorm + multimodal RoPE (mRoPE) for Qwen3-VL-class
+  // models. position_ids is [3, num_tokens] (time/height/width streams);
+  // mrope_section_{t,h} are the section sizes in half-dims (w is implied).
+  ops.def(
+      "fused_qk_norm_mrope(Tensor! qkv, int num_heads_q, "
+      "int num_heads_k, int num_heads_v, int head_dim, float eps, "
+      "Tensor q_weight, Tensor k_weight, Tensor cos_sin_cache, "
+      "bool is_neox, Tensor position_ids, "
+      "int mrope_section_t, int mrope_section_h) -> ()");
+
   ops.def(
       "fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert("
       "Tensor q_in, Tensor kv, Tensor! k_cache, "
@@ -680,6 +690,7 @@ STABLE_TORCH_LIBRARY_IMPL(_C, CUDA, ops) {
   // Positional encoding kernels (shared CUDA/ROCm)
   ops.impl("rotary_embedding", TORCH_BOX(&rotary_embedding));
   ops.impl("fused_qk_norm_rope", TORCH_BOX(&fused_qk_norm_rope));
+  ops.impl("fused_qk_norm_mrope", TORCH_BOX(&fused_qk_norm_mrope));
   ops.impl("fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert",
            TORCH_BOX(&fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert));
   ops.impl(

--- a/csrc/libtorch_stable/torch_bindings.cpp
+++ b/csrc/libtorch_stable/torch_bindings.cpp
@@ -435,7 +435,8 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C, ops) {
       "int num_heads_k, int num_heads_v, int head_dim, float eps, "
       "Tensor q_weight, Tensor k_weight, Tensor cos_sin_cache, "
       "bool is_neox, Tensor position_ids, "
-      "int mrope_section_t, int mrope_section_h) -> ()");
+      "int mrope_section_t, int mrope_section_h, "
+      "bool mrope_interleaved) -> ()");
 
   ops.def(
       "fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert("

--- a/docs/design/fusions.md
+++ b/docs/design/fusions.md
@@ -273,12 +273,19 @@ q_rope, k_rope = rotary_embedding(q_norm, k_norm, ...)
 fused_qk_norm_rope(qkv, ...)
 ```
 
+**Multimodal RoPE (mRoPE).** The same pass (under the same `enable_qk_norm_rope_fusion`
+flag) also fuses the mRoPE variant used by Qwen3-VL-class models — per-head Q/K RMSNorm
+followed by 3-section `[t, h, w]` multimodal rotary embedding — into a single
+`fused_qk_norm_mrope` kernel. Both the contiguous `[T..T H..H W..W]` and interleaved
+`[T H W ... T T]` (the Qwen3-VL default) mRoPE section layouts are supported.
+
 Supported hardware: CUDA (sm80+) only, tested only on sm90 and sm100.
 
 **Code locations.**
 
 - Pass: [`vllm/compilation/passes/fusion/qk_norm_rope_fusion.py`](https://github.com/vllm-project/vllm/blob/main/vllm/compilation/passes/fusion/qk_norm_rope_fusion.py)
 - CUDA kernel: [`csrc/ops.h`](https://github.com/vllm-project/vllm/blob/main/csrc/ops.h) (`fused_qk_norm_rope`)
+- mRoPE CUDA kernel: [`csrc/libtorch_stable/fused_qknorm_mrope_kernel.cu`](https://github.com/vllm-project/vllm/blob/main/csrc/libtorch_stable/fused_qknorm_mrope_kernel.cu) (`fused_qk_norm_mrope`)
 
 ### RMSNorm + Quantization (`fuse_norm_quant`)
 

--- a/tests/compile/fusions_e2e/common.py
+++ b/tests/compile/fusions_e2e/common.py
@@ -17,6 +17,7 @@ class Matches(NamedTuple):
     rms_quant_fusion: int = 0
     act_quant_fusion: int = 0
     norm_rope_fusion: int = 0
+    norm_mrope_fusion: int = 0
     attn_quant_fusion: int = 0
     # distributed
     ar_rms_fusion: int = 0
@@ -91,6 +92,9 @@ FUSION_LOG_PATTERNS: dict[str, re.Pattern] = {
     "act_quant_fusion": re.compile(r"act_quant_fusion.py:\d+] Replaced (\d+) patterns"),
     "norm_rope_fusion": re.compile(
         r"qk_norm_rope_fusion.py:\d+] Fused QK Norm\+RoPE on (\d+) sites"
+    ),
+    "norm_mrope_fusion": re.compile(
+        r"qk_norm_rope_fusion.py:\d+] Fused QK Norm\+mRoPE on (\d+) sites"
     ),
     "attn_quant_fusion": re.compile(
         r"attn_quant_fusion.py:\d+] Fused quant onto (\d+) attention nodes"

--- a/tests/compile/fusions_e2e/models.py
+++ b/tests/compile/fusions_e2e/models.py
@@ -155,6 +155,17 @@ qwen3_a3b_fp8 = ModelFusionInfo(
     ),
 )
 
+qwen3_vl_2b = ModelFusionInfo(
+    model_name="Qwen/Qwen3-VL-2B-Instruct",
+    # Qwen3-VL is multimodal; reduce only the text decoder layers. It uses
+    # interleaved mRoPE + QK-norm, so it exercises norm_mrope_fusion.
+    hf_overrides=lambda n_layers: {"text_config": {"num_hidden_layers": n_layers}},
+    matches=lambda n_layers: Matches(
+        # One QK-norm + mRoPE fusion site per text decoder layer.
+        norm_mrope_fusion=n_layers,
+    ),
+)
+
 deepseek_coder_v2_lite_fp8 = ModelFusionInfo(
     model_name="RedHatAI/DeepSeek-Coder-V2-Lite-Instruct-FP8",
     matches=lambda n_layers: Matches(

--- a/tests/compile/fusions_e2e/test_tp1_quant.py
+++ b/tests/compile/fusions_e2e/test_tp1_quant.py
@@ -32,6 +32,7 @@ from .models import (
     llama4_scout_fp4,
     llama4_scout_fp8,
     qwen3_a3b_fp8,
+    qwen3_vl_2b,
 )
 
 
@@ -198,4 +199,52 @@ def test_tp1_fp4_fusions(
         attn_backend,
         compilation_config,
         matches_check,
+    )
+
+
+@pytest.mark.parametrize(
+    "model_name, matches_fn, model_kwargs, hf_overrides",
+    [qwen3_vl_2b],
+)
+@pytest.mark.parametrize("attn_backend", [TRITON_ATTN])
+@pytest.mark.parametrize("n_layers", [2])
+@pytest.mark.parametrize("inductor_graph_partition", INDUCTOR_GRAPH_PARTITION)
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="QK Norm + mRoPE fusion requires CUDA/ROCm",
+)
+def test_tp1_norm_mrope_fusion(
+    model_name: str,
+    matches_fn: Callable[[int], Matches],
+    model_kwargs: dict,
+    hf_overrides: Callable[[int], dict],
+    attn_backend: AttentionBackendCase,
+    n_layers: int,
+    inductor_graph_partition: bool,
+    run_e2e_fusion_test,
+    monkeypatch,
+):
+    """QK-RMSNorm + interleaved mRoPE fusion on a Qwen3-VL-class model (bf16)."""
+    matches = matches_fn(n_layers)
+
+    model_kwargs = dict(model_kwargs)
+    model_kwargs["hf_overrides"] = hf_overrides(n_layers)
+    model_kwargs["load_format"] = "dummy"
+    model_kwargs["max_model_len"] = 1024
+    model_kwargs["kernel_config"] = {"enable_flashinfer_autotune": False}
+
+    compilation_config = dict(
+        use_inductor_graph_partition=inductor_graph_partition,
+        # mRoPE fusion matches the rms_norm + rotary_embedding custom ops.
+        custom_ops=["+rms_norm", "+rotary_embedding"],
+        pass_config=PassConfig(enable_qk_norm_rope_fusion=True),
+    )
+
+    run_e2e_fusion_test(
+        model_name,
+        matches,
+        model_kwargs,
+        attn_backend,
+        compilation_config,
+        matches_check=["norm_mrope_fusion"],
     )

--- a/tests/compile/passes/test_qk_norm_mrope_fusion.py
+++ b/tests/compile/passes/test_qk_norm_mrope_fusion.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+from torch._ops import OpOverload, OpOverloadPacket
+
+import vllm.compilation.passes.fusion.qk_norm_rope_fusion as mrope_fusion_mod
+from tests.compile.backend import TestBackend
+from vllm.compilation.passes.fusion.matcher_utils import MROPE_OP
+from vllm.compilation.passes.fusion.qk_norm_rope_fusion import (
+    FUSED_QK_MROPE_OP,
+    QKNormMRoPEFusionPass,
+)
+from vllm.compilation.passes.utility.noop_elimination import NoOpEliminationPass
+from vllm.compilation.passes.utility.post_cleanup import PostCleanupPass
+from vllm.compilation.passes.utility.split_coalescing import SplitCoalescingPass
+from vllm.config import (
+    CompilationConfig,
+    CompilationMode,
+    ModelConfig,
+    PassConfig,
+    VllmConfig,
+    set_current_vllm_config,
+)
+from vllm.model_executor.layers.attention import Attention
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.rotary_embedding.mrope import MRotaryEmbedding
+from vllm.platforms import current_platform
+from vllm.v1.attention.backend import AttentionType
+
+
+class QKNormMRoPETestModel(torch.nn.Module):
+    def __init__(
+        self,
+        *,
+        num_heads: int,
+        num_kv_heads: int,
+        head_dim: int,
+        eps: float,
+        mrope_section: list[int],
+        vllm_config: VllmConfig,
+        dtype: torch.dtype,
+        prefix: str = "model.layers.0.self_attn.attn",
+    ) -> None:
+        super().__init__()
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = head_dim
+        self.q_size = num_heads * head_dim
+        self.kv_size = num_kv_heads * head_dim
+        self.eps = eps
+        self.dtype = dtype
+
+        # Register layer geometry for the fusion pass via Attention.
+        self.attn = Attention(
+            num_heads=self.num_heads,
+            head_size=self.head_dim,
+            scale=1.0 / self.head_dim**0.5,
+            num_kv_heads=self.num_kv_heads,
+            cache_config=vllm_config.cache_config,
+            prefix=prefix,
+            attn_type=AttentionType.DECODER,
+        )
+
+        self.q_norm = RMSNorm(self.head_dim, eps=self.eps)
+        self.k_norm = RMSNorm(self.head_dim, eps=self.eps)
+        # mRoPE rotation is neox-style; full rotary (rotary_dim == head_dim).
+        self.rotary_emb = MRotaryEmbedding(
+            self.head_dim,
+            rotary_dim=self.head_dim,
+            max_position_embeddings=4096,
+            base=10000,
+            is_neox_style=True,
+            dtype=self.dtype,
+            mrope_section=mrope_section,
+            mrope_interleaved=False,
+        )
+
+    def forward(self, qkv: torch.Tensor, positions: torch.Tensor):
+        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim, self.head_dim)
+        q_by_head = self.q_norm(q_by_head)
+        q = q_by_head.view(q.shape)
+        k_by_head = k.view(*k.shape[:-1], k.shape[-1] // self.head_dim, self.head_dim)
+        k_by_head = self.k_norm(k_by_head)
+        k = k_by_head.view(k.shape)
+        q, k = self.rotary_emb(positions, q, k)
+        return q, k, v
+
+    def ops_in_model_before(self) -> list[OpOverload | OpOverloadPacket]:
+        return [torch.ops.vllm_ir.rms_norm, MROPE_OP]
+
+    def ops_in_model_after(self) -> list[OpOverload | OpOverloadPacket]:
+        return [FUSED_QK_MROPE_OP]
+
+
+@pytest.mark.parametrize("eps", [1e-5, 1e-6])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="Only test on cuda and rocm platform",
+)
+def test_qk_norm_mrope_fusion(monkeypatch, eps, dtype):
+    if not hasattr(torch.ops._C, "fused_qk_norm_mrope"):
+        pytest.skip("fused_qk_norm_mrope custom op not available")
+
+    torch.set_default_device(current_platform.device_type)
+    torch.set_default_dtype(dtype)
+    torch.manual_seed(0)
+
+    num_heads, num_kv_heads, head_dim = 16, 4, 128
+    mrope_section = [16, 24, 24]  # sums to head_dim // 2
+    T = 5
+
+    # The pass reads mrope_section from the model's HF config; a synthetic
+    # ModelConfig has none, so inject it to isolate the pattern-matching logic.
+    monkeypatch.setattr(
+        mrope_fusion_mod,
+        "_discover_mrope_configs",
+        lambda config: ((tuple(mrope_section), False),),
+    )
+
+    vllm_config = VllmConfig(
+        model_config=ModelConfig(dtype=dtype),
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.VLLM_COMPILE,
+            custom_ops=["+rms_norm", "+rotary_embedding"],
+            pass_config=PassConfig(
+                enable_qk_norm_rope_fusion=True,
+                eliminate_noops=True,
+            ),
+        ),
+    )
+
+    with (
+        set_current_vllm_config(vllm_config),
+        vllm_config.kernel_config.ir_op_priority.set_priority(),
+    ):
+        model = QKNormMRoPETestModel(
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            eps=eps,
+            mrope_section=mrope_section,
+            vllm_config=vllm_config,
+            dtype=dtype,
+        )
+
+        noop_pass = NoOpEliminationPass(vllm_config)
+        coalesce_pass = SplitCoalescingPass(vllm_config)
+        fusion_pass = QKNormMRoPEFusionPass(vllm_config)
+        cleanup_pass = PostCleanupPass(vllm_config)
+
+        backend = TestBackend(noop_pass, coalesce_pass, fusion_pass, cleanup_pass)
+        backend_baseline = TestBackend(noop_pass, cleanup_pass)
+
+        qkv = torch.randn(T, model.q_size + 2 * model.kv_size)
+        # mRoPE positions: [3, num_tokens].
+        pos = torch.randint(0, 1000, (3, T), dtype=torch.long, device=qkv.device)
+        qkv_unfused = qkv.clone()
+        pos_unfused = pos.clone()
+
+        torch._dynamo.mark_dynamic(qkv, 0)
+        torch._dynamo.mark_dynamic(pos, 1)
+        model_fused = torch.compile(model, backend=backend)
+        q_fused, k_fused, v_fused = model_fused(qkv, pos)
+
+        torch._dynamo.mark_dynamic(qkv_unfused, 0)
+        torch._dynamo.mark_dynamic(pos_unfused, 1)
+        model_unfused = torch.compile(model, backend=backend_baseline)
+        q_unfused, k_unfused, v_unfused = model_unfused(qkv_unfused, pos_unfused)
+
+        if dtype == torch.float16:
+            ATOL, RTOL = (2e-3, 2e-3)
+        else:
+            ATOL, RTOL = (1e-2, 1e-2)
+
+        torch.testing.assert_close(q_unfused, q_fused, atol=ATOL, rtol=RTOL)
+        torch.testing.assert_close(k_unfused, k_fused, atol=ATOL, rtol=RTOL)
+        torch.testing.assert_close(v_unfused, v_fused, atol=ATOL, rtol=RTOL)
+
+        assert fusion_pass.matched_count == 1
+
+        backend.check_before_ops(model.ops_in_model_before())
+        backend.check_after_ops(model.ops_in_model_after())

--- a/tests/compile/passes/test_qk_norm_mrope_fusion.py
+++ b/tests/compile/passes/test_qk_norm_mrope_fusion.py
@@ -41,6 +41,7 @@ class QKNormMRoPETestModel(torch.nn.Module):
         mrope_section: list[int],
         vllm_config: VllmConfig,
         dtype: torch.dtype,
+        mrope_interleaved: bool = False,
         prefix: str = "model.layers.0.self_attn.attn",
     ) -> None:
         super().__init__()
@@ -74,7 +75,7 @@ class QKNormMRoPETestModel(torch.nn.Module):
             is_neox_style=True,
             dtype=self.dtype,
             mrope_section=mrope_section,
-            mrope_interleaved=False,
+            mrope_interleaved=mrope_interleaved,
         )
 
     def forward(self, qkv: torch.Tensor, positions: torch.Tensor):
@@ -96,12 +97,13 @@ class QKNormMRoPETestModel(torch.nn.Module):
 
 
 @pytest.mark.parametrize("eps", [1e-5, 1e-6])
+@pytest.mark.parametrize("mrope_interleaved", [False, True])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.skipif(
     not current_platform.is_cuda_alike(),
     reason="Only test on cuda and rocm platform",
 )
-def test_qk_norm_mrope_fusion(monkeypatch, eps, dtype):
+def test_qk_norm_mrope_fusion(monkeypatch, eps, mrope_interleaved, dtype):
     if not hasattr(torch.ops._C, "fused_qk_norm_mrope"):
         pytest.skip("fused_qk_norm_mrope custom op not available")
 
@@ -118,7 +120,7 @@ def test_qk_norm_mrope_fusion(monkeypatch, eps, dtype):
     monkeypatch.setattr(
         mrope_fusion_mod,
         "_discover_mrope_configs",
-        lambda config: ((tuple(mrope_section), False),),
+        lambda config: ((tuple(mrope_section), mrope_interleaved),),
     )
 
     vllm_config = VllmConfig(
@@ -145,6 +147,7 @@ def test_qk_norm_mrope_fusion(monkeypatch, eps, dtype):
             mrope_section=mrope_section,
             vllm_config=vllm_config,
             dtype=dtype,
+            mrope_interleaved=mrope_interleaved,
         )
 
         noop_pass = NoOpEliminationPass(vllm_config)

--- a/tests/kernels/core/test_fused_qk_norm_mrope.py
+++ b/tests/kernels/core/test_fused_qk_norm_mrope.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from tests.kernels.utils import opcheck
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.rotary_embedding.mrope import MRotaryEmbedding
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import set_random_seed
+
+DTYPES = [torch.bfloat16, torch.float16]
+IS_NEOX = [True, False]
+EPS_VALUES = [1e-5, 1e-6]
+SEEDS = [13]
+CUDA_DEVICES = ["cuda:0"]
+
+# (num_heads, num_kv_heads, head_dim, mrope_section). mrope_section sums to
+# head_dim // 2 (full rotary).
+HEAD_CONFIGS = [
+    (16, 4, 128, [16, 24, 24]),
+    (16, 2, 64, [8, 12, 12]),
+    (8, 8, 256, [32, 48, 48]),
+]
+
+
+def _apply_qk_norm_mrope(
+    qkv: torch.Tensor,
+    positions: torch.Tensor,
+    q_norm: RMSNorm,
+    k_norm: RMSNorm,
+    rope: MRotaryEmbedding,
+    num_heads_q: int,
+    num_heads_kv: int,
+    head_dim: int,
+) -> torch.Tensor:
+    q_size = num_heads_q * head_dim
+    kv_size = num_heads_kv * head_dim
+
+    q, k, v = qkv.split([q_size, kv_size, kv_size], dim=-1)
+
+    q_by_head = q.view(*q.shape[:-1], q.shape[-1] // head_dim, head_dim)
+    q_by_head = q_norm.forward_native(q_by_head)
+    q = q_by_head.view(q.shape)
+
+    k_by_head = k.view(*k.shape[:-1], k.shape[-1] // head_dim, head_dim)
+    k_by_head = k_norm.forward_native(k_by_head)
+    k = k_by_head.view(k.shape)
+
+    q, k = rope.forward_native(positions, q, k)
+    return torch.cat([q, k, v], dim=-1)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="fused_qk_norm_mrope custom op requires cuda and rocm platform",
+)
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("is_neox", IS_NEOX)
+@pytest.mark.parametrize("eps", EPS_VALUES)
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("num_heads,num_kv_heads,head_dim,mrope_section", HEAD_CONFIGS)
+@torch.inference_mode()
+def test_fused_qk_norm_mrope_matches_reference(
+    default_vllm_config,
+    device: str,
+    dtype: torch.dtype,
+    is_neox: bool,
+    eps: float,
+    seed: int,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    mrope_section: list[int],
+):
+    torch.set_default_device(device)
+    set_random_seed(seed)
+    num_tokens = 7
+
+    total_dim = (num_heads + 2 * num_kv_heads) * head_dim
+    qkv_base = torch.randn(num_tokens, total_dim, dtype=dtype, device=device)
+    qkv_fused = qkv_base.clone()
+    # mRoPE positions: [3, num_tokens] (time/height/width), independent streams.
+    positions = torch.randint(
+        0, 1000, (3, num_tokens), dtype=torch.long, device=device
+    )
+
+    q_norm = RMSNorm(head_dim, eps=eps).to(device=device, dtype=dtype)
+    k_norm = RMSNorm(head_dim, eps=eps).to(device=device, dtype=dtype)
+    q_norm.weight.data.normal_(mean=1.0, std=0.1)
+    k_norm.weight.data.normal_(mean=1.0, std=0.1)
+    q_weight = q_norm.weight.data
+    k_weight = k_norm.weight.data
+
+    rope = MRotaryEmbedding(
+        head_size=head_dim,
+        rotary_dim=head_dim,
+        max_position_embeddings=4096,
+        base=10000.0,
+        is_neox_style=is_neox,
+        dtype=dtype,
+        mrope_section=mrope_section,
+        mrope_interleaved=False,
+    ).to(device)
+
+    ref_result = _apply_qk_norm_mrope(
+        qkv=qkv_base,
+        positions=positions,
+        q_norm=q_norm,
+        k_norm=k_norm,
+        rope=rope,
+        num_heads_q=num_heads,
+        num_heads_kv=num_kv_heads,
+        head_dim=head_dim,
+    )
+
+    opcheck(
+        torch.ops._C.fused_qk_norm_mrope,
+        (
+            qkv_fused.clone(),
+            num_heads,
+            num_kv_heads,
+            num_kv_heads,
+            head_dim,
+            eps,
+            q_weight,
+            k_weight,
+            rope.cos_sin_cache,
+            is_neox,
+            positions,
+            mrope_section[0],
+            mrope_section[1],
+        ),
+    )
+
+    torch.ops._C.fused_qk_norm_mrope(
+        qkv_fused,
+        num_heads,
+        num_kv_heads,
+        num_kv_heads,
+        head_dim,
+        eps,
+        q_weight,
+        k_weight,
+        rope.cos_sin_cache,
+        is_neox,
+        positions,
+        mrope_section[0],
+        mrope_section[1],
+    )
+
+    if dtype == torch.float16:
+        ATOL, RTOL = (2e-3, 2e-3)
+    else:
+        ATOL, RTOL = (1e-2, 1e-2)
+
+    torch.testing.assert_close(
+        qkv_fused,
+        ref_result,
+        atol=ATOL,
+        rtol=RTOL,
+    )

--- a/tests/kernels/core/test_fused_qk_norm_mrope.py
+++ b/tests/kernels/core/test_fused_qk_norm_mrope.py
@@ -154,7 +154,7 @@ def test_fused_qk_norm_mrope_matches_reference(
     if dtype == torch.float16:
         ATOL, RTOL = (2e-3, 2e-3)
     else:
-        ATOL, RTOL = (1e-2, 1e-2)
+        ATOL, RTOL = (4e-2, 4e-2)
 
     torch.testing.assert_close(
         qkv_fused,

--- a/tests/kernels/core/test_fused_qk_norm_mrope.py
+++ b/tests/kernels/core/test_fused_qk_norm_mrope.py
@@ -86,9 +86,11 @@ def test_fused_qk_norm_mrope_matches_reference(
     qkv_base = torch.randn(num_tokens, total_dim, dtype=dtype, device=device)
     qkv_fused = qkv_base.clone()
     # mRoPE positions: [3, num_tokens] (time/height/width), independent streams.
+    # Use a strided (non-contiguous) view like Qwen3-VL passes at runtime, to
+    # also exercise the kernel's internal contiguous() handling.
     positions = torch.randint(
-        0, 1000, (3, num_tokens), dtype=torch.long, device=device
-    )
+        0, 1000, (3, num_tokens * 2), dtype=torch.long, device=device
+    )[:, :num_tokens]
 
     q_norm = RMSNorm(head_dim, eps=eps).to(device=device, dtype=dtype)
     k_norm = RMSNorm(head_dim, eps=eps).to(device=device, dtype=dtype)

--- a/tests/kernels/core/test_fused_qk_norm_mrope.py
+++ b/tests/kernels/core/test_fused_qk_norm_mrope.py
@@ -12,6 +12,7 @@ from vllm.utils.torch_utils import set_random_seed
 
 DTYPES = [torch.bfloat16, torch.float16]
 IS_NEOX = [True, False]
+MROPE_INTERLEAVED = [False, True]  # Qwen3-VL uses interleaved
 EPS_VALUES = [1e-5, 1e-6]
 SEEDS = [13]
 CUDA_DEVICES = ["cuda:0"]
@@ -59,6 +60,7 @@ def _apply_qk_norm_mrope(
 @pytest.mark.parametrize("device", CUDA_DEVICES)
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("is_neox", IS_NEOX)
+@pytest.mark.parametrize("mrope_interleaved", MROPE_INTERLEAVED)
 @pytest.mark.parametrize("eps", EPS_VALUES)
 @pytest.mark.parametrize("seed", SEEDS)
 @pytest.mark.parametrize("num_heads,num_kv_heads,head_dim,mrope_section", HEAD_CONFIGS)
@@ -68,6 +70,7 @@ def test_fused_qk_norm_mrope_matches_reference(
     device: str,
     dtype: torch.dtype,
     is_neox: bool,
+    mrope_interleaved: bool,
     eps: float,
     seed: int,
     num_heads: int,
@@ -102,7 +105,7 @@ def test_fused_qk_norm_mrope_matches_reference(
         is_neox_style=is_neox,
         dtype=dtype,
         mrope_section=mrope_section,
-        mrope_interleaved=False,
+        mrope_interleaved=mrope_interleaved,
     ).to(device)
 
     ref_result = _apply_qk_norm_mrope(
@@ -132,6 +135,7 @@ def test_fused_qk_norm_mrope_matches_reference(
             positions,
             mrope_section[0],
             mrope_section[1],
+            mrope_interleaved,
         ),
     )
 
@@ -149,6 +153,7 @@ def test_fused_qk_norm_mrope_matches_reference(
         positions,
         mrope_section[0],
         mrope_section[1],
+        mrope_interleaved,
     )
 
     if dtype == torch.float16:

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -306,6 +306,43 @@ def fused_qk_norm_rope(
     )
 
 
+def fused_qk_norm_mrope(
+    qkv: torch.Tensor,
+    num_heads_q: int,
+    num_heads_k: int,
+    num_heads_v: int,
+    head_dim: int,
+    eps: float,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    is_neox: bool,
+    position_ids: torch.Tensor,
+    mrope_section_t: int,
+    mrope_section_h: int,
+) -> None:
+    """Fused per-head QK RMSNorm + multimodal RoPE (mRoPE), in-place on qkv.
+
+    position_ids is [3, num_tokens] (time/height/width streams); mrope_section_t
+    and mrope_section_h are the section sizes in half-dims (width is implied).
+    """
+    torch.ops._C.fused_qk_norm_mrope(
+        qkv,
+        num_heads_q,
+        num_heads_k,
+        num_heads_v,
+        head_dim,
+        eps,
+        q_weight,
+        k_weight,
+        cos_sin_cache,
+        is_neox,
+        position_ids,
+        mrope_section_t,
+        mrope_section_h,
+    )
+
+
 def apply_repetition_penalties_torch(
     logits: torch.Tensor,
     prompt_mask: torch.Tensor,

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -320,11 +320,14 @@ def fused_qk_norm_mrope(
     position_ids: torch.Tensor,
     mrope_section_t: int,
     mrope_section_h: int,
+    mrope_interleaved: bool,
 ) -> None:
     """Fused per-head QK RMSNorm + multimodal RoPE (mRoPE), in-place on qkv.
 
     position_ids is [3, num_tokens] (time/height/width streams); mrope_section_t
     and mrope_section_h are the section sizes in half-dims (width is implied).
+    mrope_interleaved selects the [T H W T H W ...] section layout (Qwen3-VL)
+    vs. the contiguous [T..T H..H W..W] layout.
     """
     torch.ops._C.fused_qk_norm_mrope(
         qkv,
@@ -340,6 +343,7 @@ def fused_qk_norm_mrope(
         position_ids,
         mrope_section_t,
         mrope_section_h,
+        mrope_interleaved,
     )
 
 

--- a/vllm/compilation/passes/fusion/matcher_utils.py
+++ b/vllm/compilation/passes/fusion/matcher_utils.py
@@ -31,6 +31,7 @@ from vllm.platforms import current_platform
 
 ROTARY_OP = torch.ops._C.rotary_embedding.default
 FLASHINFER_ROTARY_OP = torch.ops.vllm.flashinfer_rotary_embedding.default
+MROPE_OP = torch.ops.vllm.mrope.default
 
 QUANT_OPS: dict[QuantKey, OpOverload] = {
     kFp8StaticTensorSym: torch.ops._C.static_scaled_fp8_quant.default,  # noqa: E501
@@ -160,6 +161,81 @@ class MatcherRotaryEmbedding(MatcherCustomOp):
             )
         )
         return result
+
+
+class MatcherMRotaryEmbedding(MatcherCustomOp):
+    """Matches the ``torch.ops.vllm.mrope`` custom op (multimodal RoPE).
+
+    mRoPE rotation is always neox-style; ``mrope_interleaved`` only controls the
+    T/H/W section frequency layout. Only the custom-op form is matched (the
+    fusion pass requires the rotary_embedding custom op to be enabled); the
+    native decomposition is not reproduced here.
+    """
+
+    def __init__(
+        self,
+        head_size: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mrope_section: list[int],
+        mrope_interleaved: bool = False,
+        enabled: bool | None = None,
+    ) -> None:
+        if enabled is None:
+            enabled = RotaryEmbedding.enabled()
+
+        super().__init__(enabled)
+        self.head_size = head_size
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.q_size = self.num_heads * self.head_size
+        self.kv_size = self.num_kv_heads * self.head_size
+        self.rotary_dim = head_size
+        self.mrope_section = mrope_section
+        self.mrope_interleaved = mrope_interleaved
+
+    def inputs(self) -> list[torch.Tensor]:
+        positions = self.empty_int64(3, 5)  # [3, num_tokens]
+        query = self.empty(5, self.q_size)
+        key = self.empty(5, self.kv_size)
+        cos_sin_cache = self.empty(4096, self.rotary_dim)
+        return [positions, query, key, cos_sin_cache]
+
+    def forward_custom(
+        self,
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor | None,
+        cos_sin_cache: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        result = auto_functionalized(
+            MROPE_OP,
+            positions=positions,
+            query=query,
+            key=key,
+            cos_sin_cache=cos_sin_cache,
+            head_size=self.head_size,
+            rotary_dim=self.rotary_dim,
+            mrope_section_t=self.mrope_section[0],
+            mrope_section_h=self.mrope_section[1],
+            mrope_section_w=self.mrope_section[2],
+            mrope_interleaved=self.mrope_interleaved,
+        )
+        query_out = result[1]
+        key_out = result[2] if len(result) > 2 else None
+        return query_out, key_out
+
+    def forward_native(
+        self,
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor | None,
+        cos_sin_cache: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        raise NotImplementedError(
+            "MatcherMRotaryEmbedding only supports the custom-op form; the "
+            "mRoPE fusion pass requires the rotary_embedding custom op enabled."
+        )
 
 
 class MatcherRMSNormGated(MatcherCustomOp):

--- a/vllm/compilation/passes/fusion/qk_norm_rope_fusion.py
+++ b/vllm/compilation/passes/fusion/qk_norm_rope_fusion.py
@@ -282,8 +282,8 @@ class QkNormMRopePattern:
     Matches Q/K RMSNorm followed by the multimodal-RoPE custom op
     (torch.ops.vllm.mrope) and replaces the pair with the fused
     fused_qk_norm_mrope op. mRoPE rotation is always neox-style, so the fused op
-    is invoked with is_neox=True. v1 supports the non-interleaved section layout
-    only (mrope_interleaved=False).
+    is invoked with is_neox=True. Both the interleaved (Qwen3-VL) and contiguous
+    section layouts are supported via the mrope_interleaved flag.
     """
 
     def __init__(
@@ -370,6 +370,7 @@ class QkNormMRopePattern:
                 position_ids=positions,
                 mrope_section_t=self.mrope_section[0],
                 mrope_section_h=self.mrope_section[1],
+                mrope_interleaved=self.mrope_interleaved,
             )
             result_qkv = result[1]
             return result_qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)  # type: ignore[no-any-return]
@@ -391,10 +392,10 @@ def _discover_mrope_configs(
 ) -> tuple[tuple[tuple[int, ...], bool], ...]:
     """Extract (mrope_section, mrope_interleaved) from the model's text config.
 
-    Returns an empty tuple when the model does not use mRoPE, uses the
-    interleaved section layout (unsupported in v1), or the config cannot be
-    read — in which case the fusion pass disables itself and the unfused mRoPE
-    path is used.
+    Returns an empty tuple when the model does not use mRoPE or the config
+    cannot be read — in which case the fusion pass disables itself and the
+    unfused mRoPE path is used. Both interleaved (Qwen3-VL) and contiguous
+    section layouts are supported.
     """
     try:
         model_config = config.model_config
@@ -408,12 +409,11 @@ def _discover_mrope_configs(
         )
         if not rope or "mrope_section" not in rope:
             return ()
-        if rope.get("mrope_interleaved", False):
-            return ()  # v1: non-interleaved section layout only
         section = tuple(int(x) for x in rope["mrope_section"])
         if len(section) != 3:
             return ()
-        return ((section, False),)
+        interleaved = bool(rope.get("mrope_interleaved", False))
+        return ((section, interleaved),)
     except Exception:  # noqa: BLE001 - defensive: any failure disables the pass
         return ()
 

--- a/vllm/compilation/passes/fusion/qk_norm_rope_fusion.py
+++ b/vllm/compilation/passes/fusion/qk_norm_rope_fusion.py
@@ -18,12 +18,13 @@ from vllm.model_executor.layers.rotary_embedding import RotaryEmbedding
 
 from ..inductor_pass import enable_fake_mode
 from ..vllm_inductor_pass import VllmInductorPass, VllmPatternMatcherPass
-from .matcher_utils import MatcherRotaryEmbedding
+from .matcher_utils import MatcherMRotaryEmbedding, MatcherRotaryEmbedding
 from .rms_quant_fusion import empty_bf16, empty_fp32, empty_i64
 
 logger = init_logger(__name__)
 
 FUSED_QK_ROPE_OP = torch.ops._C.fused_qk_norm_rope.default
+FUSED_QK_MROPE_OP = torch.ops._C.fused_qk_norm_mrope.default
 
 # Head dimensions supported by csrc/fused_qknorm_rope_kernel.cu's
 # launchFusedQKNormRope and launchFusedQKNormRopeNTokenHeads dispatchers.
@@ -272,4 +273,223 @@ class QKNormRoPEFusionPass(VllmPatternMatcherPass):
     def uuid(self) -> str:
         return VllmInductorPass.hash_source(
             self, QkNormRopePattern, repr(self._attention_geometries)
+        )
+
+
+class QkNormMRopePattern:
+    """mRoPE analogue of QkNormRopePattern for Qwen3-VL-class models.
+
+    Matches Q/K RMSNorm followed by the multimodal-RoPE custom op
+    (torch.ops.vllm.mrope) and replaces the pair with the fused
+    fused_qk_norm_mrope op. mRoPE rotation is always neox-style, so the fused op
+    is invoked with is_neox=True. v1 supports the non-interleaved section layout
+    only (mrope_interleaved=False).
+    """
+
+    def __init__(
+        self,
+        head_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        eps: float,
+        mrope_section: list[int],
+        mrope_interleaved: bool = False,
+    ) -> None:
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = head_dim
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
+        self.eps = eps
+        self.mrope_section = mrope_section
+        self.mrope_interleaved = mrope_interleaved
+        self.rope_matcher = MatcherMRotaryEmbedding(
+            head_size=self.head_dim,
+            num_heads=self.num_heads,
+            num_kv_heads=self.num_kv_heads,
+            mrope_section=mrope_section,
+            mrope_interleaved=mrope_interleaved,
+        )
+
+    def get_inputs(self) -> list[torch.Tensor]:
+        T = 5
+        qkv = empty_bf16(T, self.q_size + 2 * self.kv_size)
+        positions = empty_i64(3, T)  # mRoPE positions [3, num_tokens]
+        q_weight = empty_bf16(1, self.head_dim)
+        k_weight = empty_bf16(1, self.head_dim)
+        cos_sin_cache = empty_bf16(4096, self.head_dim)
+        return [qkv, positions, q_weight, k_weight, cos_sin_cache]
+
+    def register(self, pm_pass: PatternMatcherPass) -> None:
+        def pattern(
+            qkv: torch.Tensor,
+            positions: torch.Tensor,
+            q_weight: torch.Tensor,
+            k_weight: torch.Tensor,
+            cos_sin_cache: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            try:
+                q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+            except ValueError as e:
+                raise RuntimeError from e
+
+            q_by_head = q.view(
+                *q.shape[:-1], q.shape[-1] // self.head_dim, self.head_dim
+            )
+            q_normed_by_head = vllm.ir.ops.rms_norm(q_by_head, q_weight, self.eps)
+            q_flat = q_normed_by_head.view(q.shape)
+
+            k_by_head = k.view(
+                *k.shape[:-1], k.shape[-1] // self.head_dim, self.head_dim
+            )
+            k_normed_by_head = vllm.ir.ops.rms_norm(k_by_head, k_weight, self.eps)
+            k_flat = k_normed_by_head.view(k.shape)
+
+            q_rope, k_rope = self.rope_matcher(positions, q_flat, k_flat, cos_sin_cache)
+            return q_rope, k_rope, v
+
+        def replacement(
+            qkv: torch.Tensor,
+            positions: torch.Tensor,
+            q_weight: torch.Tensor,
+            k_weight: torch.Tensor,
+            cos_sin_cache: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            result = auto_functionalized(
+                FUSED_QK_MROPE_OP,
+                qkv=qkv,
+                num_heads_q=self.num_heads,
+                num_heads_k=self.num_kv_heads,
+                num_heads_v=self.num_kv_heads,
+                head_dim=self.head_dim,
+                eps=self.eps,
+                q_weight=q_weight,
+                k_weight=k_weight,
+                cos_sin_cache=cos_sin_cache,
+                is_neox=True,
+                position_ids=positions,
+                mrope_section_t=self.mrope_section[0],
+                mrope_section_h=self.mrope_section[1],
+            )
+            result_qkv = result[1]
+            return result_qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)  # type: ignore[no-any-return]
+
+        pm.register_replacement(
+            pattern,
+            replacement,
+            self.get_inputs(),
+            QkNormRopePattern.wrap_trace_fn(
+                pm.fwd_only,
+                QkNormRopePattern.fx_view_to_reshape,
+            ),
+            pm_pass,
+        )
+
+
+def _discover_mrope_configs(
+    config: VllmConfig,
+) -> tuple[tuple[tuple[int, ...], bool], ...]:
+    """Extract (mrope_section, mrope_interleaved) from the model's text config.
+
+    Returns an empty tuple when the model does not use mRoPE, uses the
+    interleaved section layout (unsupported in v1), or the config cannot be
+    read — in which case the fusion pass disables itself and the unfused mRoPE
+    path is used.
+    """
+    try:
+        model_config = config.model_config
+        hf_text = getattr(model_config, "hf_text_config", None) or getattr(
+            model_config, "hf_config", None
+        )
+        if hf_text is None:
+            return ()
+        rope = getattr(hf_text, "rope_parameters", None) or getattr(
+            hf_text, "rope_scaling", None
+        )
+        if not rope or "mrope_section" not in rope:
+            return ()
+        if rope.get("mrope_interleaved", False):
+            return ()  # v1: non-interleaved section layout only
+        section = tuple(int(x) for x in rope["mrope_section"])
+        if len(section) != 3:
+            return ()
+        return ((section, False),)
+    except Exception:  # noqa: BLE001 - defensive: any failure disables the pass
+        return ()
+
+
+class QKNormMRoPEFusionPass(VllmPatternMatcherPass):
+    """Fuse Q/K RMSNorm + mRoPE into fused_qk_norm_mrope for Qwen3-VL-class
+    models when the custom op exists and the model uses (non-interleaved)
+    mRoPE."""
+
+    @enable_fake_mode
+    def __init__(self, config: VllmConfig) -> None:
+        super().__init__(config)
+        self.patterns: PatternMatcherPass = PatternMatcherPass(
+            pass_name="qk_norm_mrope_fusion_pass"
+        )
+        self._attention_geometries: tuple[tuple[int, int, int], ...] = ()
+
+        dtype = config.model_config.dtype
+        if dtype not in (torch.bfloat16, torch.float16):
+            logger.warning_once(
+                "QK Norm+mRoPE fusion not enabled: unsupported dtype %s", dtype
+            )
+            return
+
+        mrope_configs = _discover_mrope_configs(config)
+        if not mrope_configs:
+            return
+
+        attn_layers: dict[str, Attention] = get_layers_from_vllm_config(
+            config, Attention
+        )
+        if len(attn_layers) == 0:
+            return
+
+        for layer in attn_layers.values():
+            if layer.head_size not in SUPPORTED_FUSED_QK_NORM_ROPE_HEAD_DIMS:
+                logger.warning_once(
+                    "QK Norm+mRoPE fusion not enabled: layer head_size=%d not "
+                    "supported by fused_qk_norm_mrope kernel (supported: %s).",
+                    layer.head_size,
+                    SUPPORTED_FUSED_QK_NORM_ROPE_HEAD_DIMS,
+                )
+                return
+
+        self._attention_geometries = tuple(
+            sorted(
+                {
+                    (layer.head_size, layer.num_heads, layer.num_kv_heads)
+                    for layer in attn_layers.values()
+                }
+            )
+        )
+
+        for head_dim, num_heads, num_kv_heads in self._attention_geometries:
+            for section, interleaved in mrope_configs:
+                # mRoPE is full-rotary: sum(section) == rotary_dim/2 == head_dim/2.
+                if 2 * sum(section) != head_dim:
+                    continue
+                for epsilon in [1e-5, 1e-6]:
+                    QkNormMRopePattern(
+                        head_dim=head_dim,
+                        num_heads=num_heads,
+                        num_kv_heads=num_kv_heads,
+                        eps=epsilon,
+                        mrope_section=list(section),
+                        mrope_interleaved=interleaved,
+                    ).register(self.patterns)
+
+        self.dump_patterns(config, self.patterns)
+
+    @VllmInductorPass.time_and_log
+    def __call__(self, graph: fx.Graph) -> None:
+        self.matched_count = self.patterns.apply(graph)
+        logger.debug("Fused QK Norm+mRoPE on %s sites", self.matched_count)
+
+    def uuid(self) -> str:
+        return VllmInductorPass.hash_source(
+            self, QkNormMRopePattern, repr(self._attention_geometries)
         )

--- a/vllm/compilation/passes/pass_manager.py
+++ b/vllm/compilation/passes/pass_manager.py
@@ -37,7 +37,7 @@ if current_platform.is_cuda_alike():
     from .fusion.attn_quant_fusion import AttnQuantFusionPass
     from .fusion.mla_attn_quant_fusion import MLAAttnQuantFusionPass
     from .fusion.mla_rope_kvcache_cat_fusion import MLARoPEKVCacheCatFusionPass
-    from .fusion.qk_norm_rope_fusion import QKNormRoPEFusionPass
+    from .fusion.qk_norm_rope_fusion import QKNormMRoPEFusionPass, QKNormRoPEFusionPass
     from .fusion.qk_norm_rope_kvcache_fusion import QkNormRopeKvCacheFusionPass
     from .fusion.rms_quant_fusion import RMSNormQuantFusionPass
     from .fusion.rope_kvcache_fusion import RopeKVCacheFusionPass
@@ -195,6 +195,7 @@ class PostGradPassManager(CustomGraphPass):  # type: ignore[misc]
             if self.pass_config.enable_qk_norm_rope_fusion:
                 self.passes += [SplitCoalescingPass(config)]
                 self.passes += [QKNormRoPEFusionPass(config)]
+                self.passes += [QKNormMRoPEFusionPass(config)]
 
             self.ir_lowering = VllmIRLoweringPass(config)
             self.clone_elimination = UnsafeCloneEliminationPass(config)

--- a/vllm/model_executor/layers/rotary_embedding/mrope.py
+++ b/vllm/model_executor/layers/rotary_embedding/mrope.py
@@ -6,6 +6,7 @@ import numpy as np
 import torch
 
 from vllm.triton_utils import tl, triton
+from vllm.utils.torch_utils import direct_register_custom_op
 
 from .base import RotaryEmbeddingBase
 from .yarn_scaling_rope import YaRNScalingRotaryEmbedding, yarn_get_mscale
@@ -198,6 +199,68 @@ def apply_interleaved_rope(x: torch.Tensor, mrope_section: list[int]) -> torch.T
     return x_t
 
 
+def _mrope_apply(
+    positions: torch.Tensor,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    head_size: int,
+    rotary_dim: int,
+    mrope_section_t: int,
+    mrope_section_h: int,
+    mrope_section_w: int,
+    mrope_interleaved: bool,
+) -> None:
+    """In-place mRoPE application, registered as a custom op so the compile
+    fusion pass can match it as a single node (mirrors the standard
+    ``rotary_embedding`` custom op). Gathers the T/H/W cos/sin streams from
+    ``cos_sin_cache`` (indexed by ``positions`` [3, num_tokens]) and applies the
+    Triton mRoPE kernel to ``query``/``key`` in place.
+    """
+    cos_sin = cos_sin_cache[positions]  # [3, num_tokens, rotary_dim]
+    cos, sin = cos_sin.chunk(2, dim=-1)  # each [3, num_tokens, rotary_dim/2]
+    q, k = triton_mrope(
+        query,
+        key,
+        cos,
+        sin,
+        [mrope_section_t, mrope_section_h, mrope_section_w],
+        head_size,
+        rotary_dim,
+        mrope_interleaved,
+    )
+    # triton_mrope mutates its inputs in place when they are contiguous, but
+    # returns freshly-allocated tensors when it has to make them contiguous.
+    # Copy back in that case so the declared in-place mutation always holds.
+    if q.data_ptr() != query.data_ptr():
+        query.copy_(q.view_as(query))
+    if k.data_ptr() != key.data_ptr():
+        key.copy_(k.view_as(key))
+
+
+def _mrope_apply_fake(
+    positions: torch.Tensor,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    head_size: int,
+    rotary_dim: int,
+    mrope_section_t: int,
+    mrope_section_h: int,
+    mrope_section_w: int,
+    mrope_interleaved: bool,
+) -> None:
+    return
+
+
+direct_register_custom_op(
+    op_name="mrope",
+    op_func=_mrope_apply,
+    mutates_args=["query", "key"],
+    fake_impl=_mrope_apply_fake,
+)
+
+
 class MRotaryEmbedding(RotaryEmbeddingBase):
     """Rotary Embedding with Multimodal Sections."""
 
@@ -333,26 +396,31 @@ class MRotaryEmbedding(RotaryEmbeddingBase):
 
         cos_sin_cache = self._match_cos_sin_cache_dtype(query)
         num_tokens = positions.shape[-1]
-        cos_sin = cos_sin_cache[positions]
-        cos, sin = cos_sin.chunk(2, dim=-1)
         query_shape = query.shape
         key_shape = key.shape
         if positions.ndim == 2:
             assert self.mrope_section
 
-            q, k = triton_mrope(
+            mrope_section = self.mrope_section
+            # In-place via the registered custom op so the compile fusion pass
+            # can match Q/K-norm + mRoPE as a single node.
+            torch.ops.vllm.mrope(
+                positions,
                 query,
                 key,
-                cos,
-                sin,
-                self.mrope_section,
+                cos_sin_cache,
                 self.head_size,
                 self.rotary_dim,
+                mrope_section[0],
+                mrope_section[1],
+                mrope_section[2],
                 self.mrope_interleaved,
             )
 
-            return q.reshape(query_shape), k.reshape(key_shape)
+            return query.reshape(query_shape), key.reshape(key_shape)
 
+        cos_sin = cos_sin_cache[positions]
+        cos, sin = cos_sin.chunk(2, dim=-1)
         query = query.view(num_tokens, -1, self.head_size)
         query_rot = query[..., : self.rotary_dim]
         query_pass = query[..., self.rotary_dim :]


### PR DESCRIPTION
### Purpose

Adds a fused CUDA kernel and a `torch.compile` fusion pass for **QK-RMSNorm + multimodal RoPE (mRoPE)**, the mRoPE analogue of the existing `fused_qk_norm_rope` fusion. For Qwen3-VL-class models (per-head Q/K RMSNorm followed by mRoPE), the attention-input path currently dispatches three separate kernels:

```text
# Unfused (3 launches):
q, k, v = split(qkv)
q_norm  = rms_norm(q.view(heads))
k_norm  = rms_norm(k.view(kv_heads))
q_rope, k_rope = mrope(q_norm, k_norm, positions, ...)

# Fused (1 launch):
fused_qk_norm_mrope(qkv, positions, ...)
```

It runs under the existing `enable_qk_norm_rope_fusion` flag and supports:
- both mRoPE section layouts — contiguous `[T..T H..H W..W]` and interleaved `[T H W ... T T]` (the Qwen3-VL default),
- both neox and gpt-j rotation styles,
- head dims 64 / 128 / 256.

### Test Result

Experiments on **NVIDIA RTX 4070 (12 GB)**, CUDA 13.0, torch 2.12.

**Fused op correctness** — fused kernel vs. `RMSNorm` + `MRotaryEmbedding.forward_native`, across both section layouts, both rotation styles, bf16/fp16, multiple head geometries, with non-contiguous positions:
```
pytest tests/kernels/core/test_fused_qk_norm_mrope.py
...
48 passed
```

**Compile fusion pass** — pattern matches under real `torch.compile`, rewrites to `fused_qk_norm_mrope`, fused vs. unfused numerics preserved:
```
pytest tests/compile/passes/test_qk_norm_mrope_fusion.py
...
8 passed
```

**E2E fusion-count test** — the pass fires the expected number of sites on a real Qwen3-VL model (dummy weights):
```
pytest tests/compile/fusions_e2e/test_tp1_quant.py -k test_tp1_norm_mrope_fusion
...
2 passed
```

**Microbenchmark — isolated op** (`benchmarks/fused_kernels/fused_qk_norm_mrope_benchmark.py`, unfused 3-launch vs. fused 1-launch, swept over token counts × head geometries × dtypes):

| Regime | Unfused (µs) | Fused (µs) | Speedup |
|---|---|---|---|
| N ≤ 2048 (most configs) | ~680 | ~43 | ~14–15× |
| N=8192, 16 heads | 681 | 100 | ~6.8× |
| N=8192, 28–40 heads | 900–1370 | 305–456 | ~3.0× |

Summary across all 30 configs: **min 2.94× · median 13.84× · max 15.23×**. The large speedup at small N is dominated by launch/dispatch overhead the compiler also removes; the **~3× at large batch is the compile-invariant memory-traffic reduction** (one fused pass vs. three).

---

### lm_eval & Benchmarks (E2E)

**Model:** Qwen3-VL-2B-Instruct · **GPU:** RTX 4070 (12 GB)
> Small model due to GPU-memory constraints. norm+RoPE is a small slice of total compute at 2B, so the e2e delta is modest; larger models with wider attention benefit more.

The fusion fires only when enabled — server compile logs show `Fused QK Norm+mRoPE on 1 sites` per attention subgraph with the pass on, and **zero** matches with it off. Both configs use identical settings (`-O3`, `+rms_norm`, `+rotary_embedding`), differing only in `pass_config.enable_qk_norm_rope_fusion`.

**gsm8k (250 questions, 5-shot)**

| Config | Accuracy | Invalid | Questions/s | Output tok/s |
|---|:--:|:--:|:--:|:--:|
| fusion disabled | 0.712 | 0.000 | 25.03 | 2851.0 |
| **fusion enabled** | **0.712** | 0.004 | **26.47** | **3024.8** |

No accuracy change (identical exact-match).

**Serving Benchmark (sonnet, 640 prompts, 128 RPS)**

| Metric | fusion disabled | fusion enabled | Δ |
|---|:--:|:--:|:--:|
| Benchmark duration (s) | 36.37 | 36.05 | −0.9% |
| Request throughput (req/s) | 17.60 | 17.75 | +0.9% |
| Output token throughput (tok/s) | 2639.7 | 2662.8 | +0.9% |
| Total token throughput (tok/s) | 12195.4 | 12302.3 | +0.9% |
| Mean TTFT (ms) | 13713.1 | 13544.1 | −1.2% |
| Mean TPOT (ms) | 30.69 | 30.40 | −0.9% |
| Mean ITL (ms) | 33.38 | 32.22 | −3.5% |

Consistent small improvement across every metric with no accuracy regression.

### Notes

- Kernel: `csrc/libtorch_stable/fused_qknorm_mrope_kernel.cu` (op `fused_qk_norm_mrope`); pass: `vllm/compilation/passes/fusion/qk_norm_rope_fusion.py`.
- The fusion matches the `rotary_embedding` + `rms_norm` custom-op forms, so it requires those custom ops enabled (the default on CUDA); with them disabled the model falls back to the unfused path.
- Docs updated in `docs/design/fusions.md`.
