### PR TITLE
[Bugfix] Zero non-uniform KV page sizes in KVBlockZeroer

### DIFF
--- a/tests/v1/worker/test_kv_block_zeroer.py
+++ b/tests/v1/worker/test_kv_block_zeroer.py
@@ -18,12 +18,14 @@ def test_block_ids_are_not_overwritten_while_copy_is_in_flight():
     # in-flight copy behavior without constructing model attention groups.
     zeroer = KVBlockZeroer.__new__(KVBlockZeroer)
     zeroer.device = device
-    zeroer._meta = (
-        torch.tensor([storage.data_ptr()], dtype=torch.uint64, device=device),
-        page_size_el,
-        page_size_el,
-        1,
-    )
+    zeroer._metas = [
+        (
+            torch.tensor([storage.data_ptr()], dtype=torch.uint64, device=device),
+            page_size_el,
+            page_size_el,
+            1,
+        )
+    ]
 
     stream = torch.cuda.Stream()
     with torch.cuda.stream(stream):
@@ -39,3 +41,42 @@ def test_block_ids_are_not_overwritten_while_copy_is_in_flight():
     assert torch.all(storage[1] == 0)
     assert torch.all(storage[2] == 0)
     assert torch.all(storage[3] == 1)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_zeroing_across_non_uniform_page_sizes():
+    # Layers within one KV-cache group can share a block-id space while having
+    # different page sizes (e.g. DeepSeek-V3.2's main MLA cache and sparse
+    # indexer cache). Each page size must be zeroed against its own storage.
+    device = torch.device("cuda")
+    num_blocks = 4
+    small_page_el = 4
+    large_page_el = 16
+    small = torch.ones((num_blocks, small_page_el), dtype=torch.int32, device=device)
+    large = torch.ones((num_blocks, large_page_el), dtype=torch.int32, device=device)
+
+    zeroer = KVBlockZeroer.__new__(KVBlockZeroer)
+    zeroer.device = device
+    zeroer._metas = [
+        (
+            torch.tensor([small.data_ptr()], dtype=torch.uint64, device=device),
+            small_page_el,
+            small_page_el,
+            1,
+        ),
+        (
+            torch.tensor([large.data_ptr()], dtype=torch.uint64, device=device),
+            large_page_el,
+            large_page_el,
+            1,
+        ),
+    ]
+
+    zeroer.zero_block_ids([1, 3])
+    torch.accelerator.synchronize()
+
+    for storage in (small, large):
+        assert torch.all(storage[0] == 1)
+        assert torch.all(storage[1] == 0)
+        assert torch.all(storage[2] == 1)
+        assert torch.all(storage[3] == 0)

--- a/vllm/model_executor/warmup/qwen_triton_warmup.py
+++ b/vllm/model_executor/warmup/qwen_triton_warmup.py
@@ -154,18 +154,20 @@ def _get_kv_block_zeroer(runner: object) -> object | None:
     return zeroer
 
 
-def _zero_kv_warmup_config(runner: object) -> _ZeroKvWarmupConfig | None:
+def _zero_kv_warmup_configs(runner: object) -> list[_ZeroKvWarmupConfig]:
     zeroer = _get_kv_block_zeroer(runner)
-    meta = getattr(zeroer, "_meta", None)
-    if meta is None:
-        return None
+    metas = getattr(zeroer, "_metas", None)
+    if not metas:
+        return []
 
-    _, page_size_el, block_size, n_segs = meta
-    return _ZeroKvWarmupConfig(
-        page_size_el=int(page_size_el),
-        block_size=int(block_size),
-        n_segs=int(n_segs),
-    )
+    return [
+        _ZeroKvWarmupConfig(
+            page_size_el=int(page_size_el),
+            block_size=int(block_size),
+            n_segs=int(n_segs),
+        )
+        for _, page_size_el, block_size, n_segs in metas
+    ]
 
 
 def _warm_zero_kv_blocks_with_runner_zeroer(runner: object) -> bool:
@@ -369,10 +371,11 @@ def qwen_triton_warmup(
     device = getattr(runner, "device", torch.device("cuda"))
     logger.info("Warming up Qwen Triton kernels for model_type=%s.", model_type)
 
-    zero_config = _zero_kv_warmup_config(runner)
+    zero_configs = _zero_kv_warmup_configs(runner)
     warmed_zeroer = _warm_zero_kv_blocks_with_runner_zeroer(runner)
-    if zero_config is not None:
-        _warm_zero_kv_blocks_kernel(device, zero_config)
+    if zero_configs:
+        for zero_config in zero_configs:
+            _warm_zero_kv_blocks_kernel(device, zero_config)
     elif not warmed_zeroer:
         logger.info("Skipping Qwen zero-kv warmup: no KVBlockZeroer metadata.")
 

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -107,16 +107,21 @@ class KVBlockZeroer:
         PAGE_SIZE_EL accounts for this ratio so that
         ``block_id * PAGE_SIZE_EL`` lands at the correct offset.
 
+        Layers within one KV-cache group share a block-id space but may have
+        different page sizes (e.g. DeepSeek-V3.2 groups the main MLA cache and
+        the sparse indexer cache under one ``UniformTypeKVCacheSpecs`` group).
+        Segments are therefore bucketed by page size and zeroed with one kernel
+        launch per distinct page size.
+
         Only AttentionSpec layers are processed; Mamba layers are skipped.
         """
         self.device = device
-        self._meta: tuple[torch.Tensor, int, int, int] | None = None
+        self._metas: list[tuple[torch.Tensor, int, int, int]] = []
 
         if runner_only_attn_layers is None:
             runner_only_attn_layers = set()
         seen_ptrs: set[int] = set()
-        seg_addrs: list[int] = []
-        page_size_el: int | None = None
+        seg_addrs_by_page: dict[int, list[int]] = defaultdict(list)
 
         for group in attn_groups_iter:
             spec = group.kv_cache_spec
@@ -149,12 +154,6 @@ class KVBlockZeroer:
                 assert cur_bytes % 4 == 0
                 kernel_block_el = cur_bytes // 4
                 cur_page_el = kernel_block_el * ratio
-                if page_size_el is None:
-                    page_size_el = cur_page_el
-                else:
-                    assert page_size_el == cur_page_el, (
-                        f"Non-uniform page sizes: {page_size_el} vs {cur_page_el}"
-                    )
 
                 block_stride_bytes = cur_bytes
                 outer_dims = [
@@ -165,36 +164,35 @@ class KVBlockZeroer:
                 outer_strides = [kv.stride(d) * el for d in outer_dims]
                 for outer in iprod(*(range(kv.shape[d]) for d in outer_dims)):
                     off_bytes = sum(i * s for i, s in zip(outer, outer_strides))
-                    seg_addrs.append(dp + off_bytes)
+                    seg_addrs_by_page[cur_page_el].append(dp + off_bytes)
 
-        if not seg_addrs or page_size_el is None:
-            self._meta = None
-            return
-
-        blk_size = min(largest_power_of_2_divisor(page_size_el), 1024)
-        self._meta = (
-            torch.tensor(seg_addrs, dtype=torch.uint64, device=self.device),
-            page_size_el,
-            blk_size,
-            len(seg_addrs),
-        )
+        for page_size_el, seg_addrs in seg_addrs_by_page.items():
+            blk_size = min(largest_power_of_2_divisor(page_size_el), 1024)
+            self._metas.append(
+                (
+                    torch.tensor(seg_addrs, dtype=torch.uint64, device=self.device),
+                    page_size_el,
+                    blk_size,
+                    len(seg_addrs),
+                )
+            )
 
     def zero_block_ids(self, block_ids: list[int]) -> None:
         """Zero the KV cache memory for the given block IDs."""
-        if not block_ids or self._meta is None:
+        if not block_ids or not self._metas:
             return
-        seg_addrs, page_size_el, blk_size, n_segs = self._meta
         n_blocks = len(block_ids)
         idx = async_tensor_h2d(block_ids, device=self.device, dtype=torch.int64)
-        grid = (n_blocks * n_segs * (page_size_el // blk_size),)
-        _zero_kv_blocks_kernel[grid](
-            seg_addrs,
-            idx,
-            n_blocks,
-            N_SEGS=n_segs,
-            PAGE_SIZE_EL=page_size_el,
-            BLOCK_SIZE=blk_size,
-        )
+        for seg_addrs, page_size_el, blk_size, n_segs in self._metas:
+            grid = (n_blocks * n_segs * (page_size_el // blk_size),)
+            _zero_kv_blocks_kernel[grid](
+                seg_addrs,
+                idx,
+                n_blocks,
+                N_SEGS=n_segs,
+                PAGE_SIZE_EL=page_size_el,
+                BLOCK_SIZE=blk_size,
+            )
 
 
 @dataclass


### PR DESCRIPTION
DeepSeek-V3.2 groups the main MLA cache and the sparse DSA indexer cache under a single UniformTypeKVCacheSpecs group. The two caches share one block-id space but have different page sizes (bf16 head_size=576 vs uint8 head_size=132), which tripped KVBlockZeroer's uniform-page-size assertion during engine init:

    AssertionError: Non-uniform page sizes: 2112 vs 18432

introduced by https://github.com/vllm-project/vllm/pull/47574
This surfaced as `tests/compile/h100/test_startup.py::test_model_startup[deepseek_v3.2]` failing with "Cold-start child failed".

Bucket the zeroing segments by page size and launch the Triton zeroing kernel once per distinct page size; the shared block-id list applies to each bucket. Behavior is unchanged for the uniform (single-bucket) case.

Tests run (H200, offline):
  pytest tests/v1/worker/test_kv_block_zeroer.py            -> 2 passed
  pytest ".../test_startup.py::test_model_startup[deepseek_v3.2]" -> 1 passed
  (cold: saved=9/loaded=0; warm start passed)



## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

