### PR TITLE
[tracing] Use explicit is not None checks for optional span parameter…

### DIFF
--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -765,9 +765,9 @@ class OutputProcessor:
         }
 
         # Add optional request parameters
-        if req_state.top_p:
+        if req_state.top_p is not None:
             attributes[SpanAttributes.GEN_AI_REQUEST_TOP_P] = req_state.top_p
-        if req_state.max_tokens_param:
+        if req_state.max_tokens_param is not None:
             attributes[SpanAttributes.GEN_AI_REQUEST_MAX_TOKENS] = (
                 req_state.max_tokens_param
             )
@@ -775,7 +775,7 @@ class OutputProcessor:
             attributes[SpanAttributes.GEN_AI_REQUEST_TEMPERATURE] = (
                 req_state.temperature
             )
-        if req_state.n:
+        if req_state.n is not None:
             attributes[SpanAttributes.GEN_AI_REQUEST_N] = req_state.n
 
         instrument_manual(


### PR DESCRIPTION


## Purpose

Refactors optional request parameter checks in `vllm/v1/engine/output_processor.py` (`top_p`, `max_tokens_param`, and `n`) to use explicit `is not None` type guards for consistent handling of optional request parameters.

> **Note on `temperature`:** `temperature` is intentionally left unchanged in this PR to avoid overlapping with or duplicating PR #49605 by @nightcityblade.

---

## Test Plan

1. **Unit Test Execution**

   ```bash
   PATH=.venv/bin:$PATH .venv/bin/python -m pytest tests/v1/tracing/test_tracing.py -v
   ```

2. **Linter Execution**

   ```bash
   .venv/bin/ruff check vllm/v1/engine/output_processor.py tests/v1/tracing/test_tracing.py
   ```

---

## Test Results

1. **Unit Test Result**

   ```text
   tests/v1/tracing/test_tracing.py::test_traces PASSED [100%]
   ================== 1 passed, 15 warnings in 31.61s ==================
   ```

2. **Linter Result**

   ```text
   All checks passed!
   ```

---

## Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)."
- [x] The test plan, such as providing test commands.
- [x] The test results, such as pasting the results comparison before and after, or end-to-end results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and examples for a new model.

**Note:** The `temperature` fix for #49589 is handled separately in PR #49605 by @nightcityblade.

---

### Summary of Work

- Refactored optional request parameter checks (`top_p`, `max_tokens_param`, and `n`) to use explicit `is not None` type guards.
- Left `temperature` unchanged to avoid conflicting with PR #49605.
- Completed the vLLM GitHub Pull Request template with the Purpose, Test Plan, Test Results, and checklist.