### PR TITLE
[BugFix] Stop dummy runs from writing mamba state through stale block-table rows

### DIFF
--- a/tests/v1/worker/test_gpu_block_table.py
+++ b/tests/v1/worker/test_gpu_block_table.py
@@ -130,3 +130,66 @@ def test_block_tables_apply_staged_writes_single_group():
         block_tables.block_tables[0].gpu[0, :2],
         torch.tensor([1, 2], dtype=torch.int32, device=device),
     )
+
+
+def test_v1_block_table_move_row_clears_vacated_row():
+    """condense() moves the last row into a freed slot; the vacated row must
+    not keep stale block ids. Padded dummy-run batches dereference stale rows
+    as mamba state slots (bypassing the NULL_BLOCK_ID fill of real decode
+    padding) and write state in place there — corrupting the blocks' new
+    owner once they are reallocated, e.g. to an in-flight NIXL load."""
+    from vllm.v1.worker.block_table import BlockTable
+
+    block_table = BlockTable(
+        block_size=16,
+        max_num_reqs=4,
+        max_num_blocks_per_req=8,
+        max_num_batched_tokens=64,
+        pin_memory=False,
+        device=torch.device("cuda"),
+        kernel_block_size=16,
+        cp_kv_cache_interleave_size=1,
+    )
+    block_table.add_row([7, 8, 9], row_idx=0)
+    block_table.add_row([4, 5], row_idx=1)
+
+    block_table.move_row(1, 0)
+
+    assert block_table.block_table.np[0, :2].tolist() == [4, 5]
+    assert block_table.num_blocks_per_row[0] == 2
+    # The vacated source row routes to the reserved null block.
+    assert block_table.num_blocks_per_row[1] == 0
+    assert (block_table.block_table.np[1] == 0).all()
+
+
+def test_get_dummy_block_tables_returns_zeroed_rows():
+    """Dummy runs bypass the gather, so the persistent input_block_tables
+    hold the previous real step's rows. Mamba/GDN metadata routes in-place
+    state writes through block_table[:, 0] (dummy slot mappings are
+    PAD-filled, state indices are not), so stale rows would direct dummy
+    state writes at freed — possibly reallocated — blocks.
+    get_dummy_block_tables must hand out zeroed (null block) rows while
+    preserving the persistent storage address for CUDA graphs."""
+    device = torch.device("cuda")
+    block_tables = BlockTables(
+        block_sizes=[16],
+        max_num_reqs=4,
+        max_num_batched_tokens=64,
+        max_num_blocks_per_group=[8],
+        device=device,
+        kernel_block_sizes=[16],
+    )
+    # Simulate a real step: stage a request's blocks and gather them into
+    # the persistent input block tables.
+    block_tables.append_block_ids(req_index=0, new_block_ids=([1, 2],), overwrite=True)
+    block_tables.apply_staged_writes()
+    idx_mapping = torch.zeros(1, dtype=torch.int32, device=device)
+    block_tables.gather_block_tables(idx_mapping, num_reqs_padded=1)
+    torch.accelerator.synchronize()
+    assert block_tables.input_block_tables[0][0, 0].item() == 1
+
+    dummy = block_tables.get_dummy_block_tables(num_reqs=1)
+    torch.accelerator.synchronize()
+    assert (dummy[0] == 0).all()
+    # CUDA graph invariant: same persistent tensor, not a fresh allocation.
+    assert dummy[0].data_ptr() == block_tables.input_block_tables[0].data_ptr()

--- a/vllm/v1/worker/block_table.py
+++ b/vllm/v1/worker/block_table.py
@@ -144,6 +144,11 @@ class BlockTable:
         block_table_np = self.block_table.np
         block_table_np[tgt, :num_blocks] = block_table_np[src, :num_blocks]
         self.num_blocks_per_row[tgt] = num_blocks
+        # Clear the vacated source row: dummy-run batches dereference stale
+        # rows as mamba state slots and write state in place there, possibly
+        # after the blocks have been freed and reallocated.
+        block_table_np[src, :num_blocks] = 0
+        self.num_blocks_per_row[src] = 0
 
     def swap_row(self, src: int, tgt: int) -> None:
         src_tgt, tgt_src = [src, tgt], [tgt, src]

--- a/vllm/v1/worker/gpu/block_table.py
+++ b/vllm/v1/worker/gpu/block_table.py
@@ -163,7 +163,13 @@ class BlockTables:
         # Therefore, this method must return the persistent tensor
         # with the same memory address as that used during the model's forward pass,
         # rather than allocating a new tensor.
-        return tuple(block_table[:num_reqs] for block_table in self.input_block_tables)
+        #
+        # Zero the rows so dummy runs write mamba state to the reserved null
+        # block rather than through the previous real step's (stale) block
+        # ids, which may point at blocks since freed and reallocated.
+        return tuple(
+            block_table[:num_reqs].zero_() for block_table in self.input_block_tables
+        )
 
     def compute_slot_mappings(
         self,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1290,6 +1290,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 slot_mappings,
                 self.attn_groups,
                 self.kv_cache_config,
+                # FULL replay reads capture-time metadata buffers. Re-stage them
+                # from the zeroed dummy block tables instead of retaining state
+                # indices from the previous real batch.
+                for_capture=dummy_run and batch_desc.cg_mode == CUDAGraphMode.FULL,
             )
 
         input_ids = input_batch.input_ids

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6057,7 +6057,13 @@ class GPUModelRunner(
                     num_reqs=num_reqs_padded,
                     max_query_len=max_query_len,
                     ubatch_slices=(ubatch_slices_padded if pad_attn else ubatch_slices),
-                    for_cudagraph_capture=is_graph_capturing,
+                    # FULL replay reads capture-time metadata buffers. Re-stage them
+                    # from the zeroed dummy block tables instead of retaining state
+                    # indices from the previous real batch.
+                    for_cudagraph_capture=(
+                        is_graph_capturing
+                        or cudagraph_runtime_mode == CUDAGraphMode.FULL
+                    ),
                     slot_mappings=slot_mappings_by_group,
                     use_spec_decode=self.speculative_config is not None,
                 )


### PR DESCRIPTION
Dummy-run batches execute real state-writing kernels, and both model runners mask only the attention side (PAD-filled slot mappings / null routing) while the mamba/GDN/KDA path routes its in-place state writes through `block_table[:, 0]`. Two paths let stale block ids reach those writes:

- V1: `condense()` vacates the moved-from row without clearing it, leaving a duplicate of a live request's block ids at an `index >= num_reqs`. Padded dummy rows are all classified as decodes (split_decodes_and_prefills fast path), so the staged state indices take these stale rows verbatim — the `NULL_BLOCK_ID` fill only covers `[num_decodes:]`, which is empty. `remove_request()` clearing (#37728) does not cover the condense-vacated index.
- V2: `get_dummy_block_tables()` skips the gather and returns the persistent `input_block_tables` slices holding whatever the previous real step's gather wrote, i.e. that batch's block ids.

Once the owning requests finish, those ids point at freed blocks that the pool promptly reallocates. Everything a normal request writes is stream-ordered after the dummy's state writes, but KV-connector-loaded state is written by the NIC outside any stream — so a DP-lockstep dummy run (the only common source of dummy/real interleaving) can overwrite a disaggregated request's freshly received mamba state before its first decode step, corrupting its recurrence from token 0. This matches rare first-token garbage observed with hybrid-model P/D disaggregation under DP+EP decode on both runners.

Fix both at the source: clear the vacated row in `BlockTable.move_row` (covers the GPU and TPU condense paths), and zero the dummy block-table rows in `get_dummy_block_tables` (preserving the persistent storage address required for CUDA graph capture). Cleared rows route dummy state writes to the reserved null block, matching how real decode padding is handled.

## Second commit: restaging the zeroed rows into the persistent metadata buffers

Zeroing the block tables is necessary but not sufficient for spec-decode hybrid models, which hit the same corruption through a second path.

The recurrent metadata builders stage state indices into persistent CUDA-graph-safe buffers such as `spec_state_indices_tensor`. A FULL cudagraph replay reads those buffers — their addresses were baked in at capture — rather than reading the block tables. So the zeros only help if they are actually propagated into the staged buffers.

For a dummy batch they are not. A dummy `InputBatch` has no `num_draft_tokens_per_req`, so the non-capture path computes an all `-1` `num_decode_draft_tokens_cpu`, the builder sees zero spec-decode rows, and it skips the spec staging branch entirely. `spec_state_indices_tensor` therefore keeps the block ids staged by the previous *real* spec batch, and the replayed recurrent kernels write state through those. This is not a CUDA synchronization issue: the replay is dereferencing the wrong state-index values, not racing an unfinished copy.

The second commit builds attention metadata via the capture path for runtime FULL dummy runs on both runners (`for_capture` in V2's `execute_model`, `for_cudagraph_capture` in V1's `_dummy_run`). That path derives the dummy speculative layout and restages the now-zeroed block-table entries, routing recurrent writes to the reserved null block. Real batches, eager execution and piecewise cudagraphs are unchanged, and no CUDA synchronization is added.

The two commits are complementary and ordered: the first zeroes the source rows, the second ensures those zeros reach the buffer the graph replay actually dereferences. Applied alone, the second commit would faithfully restage *stale* ids and fix nothing.

Authored by @majunze2001 

## Relationship to other PRs

- #49995 (`[MRV2] Always build attn metadata at capture time`) touches only `prepare_inputs_to_capture()`, i.e. behaviour during CUDA graph **capture** — it makes PIECEWISE capture build metadata with `for_capture=False`, and leaves FULL capture unchanged. Neither failure mode here is on that path — both are runtime replay — so the two are disjoint and #49995 does not subsume either commit.
- #37728 clears block-table rows in `remove_request()`, which does not cover the condense-vacated index (see above).
- Open-PR searches found nothing else addressing either the condense-vacated row, the dummy block-table rows, or the persistent spec metadata buffers.

## Test plan and results

```bash
pytest tests/v1/worker/test_gpu_block_table.py -q
```

The two new unit tests in this PR cover the first commit's invariants: `move_row` clears the vacated row, and `get_dummy_block_tables` returns zeroed rows while preserving the persistent tensor address required for cudagraph capture.

End-to-end validation of the second commit (contributed by @majunze2001, and the origin of that commit) used Kimi-K3 GSM8K over 10 runs on a `1p1d_tp8_dep16` P/D setup with DSpark:

- Before: 100 garbage responses across 6,595 outputs.
- After: 0 garbage responses across 19,785 outputs.

No throughput benchmark was run. The added work is one `zero_()` over the dummy block-table rows per dummy run plus a numpy row clear in `move_row`, both negligible against the model forward and the existing row copy respectively.

## Follow-ups (not in this PR)

- Both mechanisms could be gated on whether any KV group actually writes state in place through pool block ids, which would skip the zeroing entirely for non-hybrid models. Deliberately left out here to keep the invariant unconditional; if added later it must gate *both* commits from a single shared predicate, since narrowing only the zeroing would silently reintroduce the corruption through the restaging path.
- A composition test — dummy FULL batch after a real spec-decode step, asserting `spec_state_indices_tensor` holds only the null block — would fail if either half regresses. Neither commit asserts this today.

## AI assistance

AI assistance was used for diagnosis, implementation and drafting of this description.
