### PR TITLE
[CI] fix compile test | refactor VLLM_DISABLE_COMPILE_CACHE for tests

### DIFF
--- a/tests/compile/passes/test_fusion_attn.py
+++ b/tests/compile/passes/test_fusion_attn.py
@@ -290,12 +290,9 @@ def test_attention_quant_pattern(
     model_class: type[AttentionQuantPatternModel],
     backend: AttentionBackendEnum,
     dist_init,
-    monkeypatch,
-    use_fresh_inductor_cache,
+    disable_vllm_compile_cache,
 ):
     """Test AttentionStaticQuantPattern fusion pass"""
-    monkeypatch.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
-
     if backend == AttentionBackendEnum.FLASHINFER and (
         not current_platform.is_device_capability((10, 0)) or not has_flashinfer()
     ):

--- a/tests/compile/passes/test_mla_attn_quant_fusion.py
+++ b/tests/compile/passes/test_mla_attn_quant_fusion.py
@@ -419,8 +419,7 @@ def test_mla_attention_quant_pattern(
     model_class: type[MLAAttentionQuantPatternModel],
     backend: AttentionBackendEnum,
     dist_init,
-    monkeypatch,
-    use_fresh_inductor_cache,
+    disable_vllm_compile_cache,
 ):
     """Test MLA AttentionQuantPattern fusion pass"""
     if (
@@ -428,8 +427,6 @@ def test_mla_attention_quant_pattern(
         and not is_nvfp4_supported()
     ):
         pytest.skip("NVFP4 is not supported on this GPU (requires SM 100+).")
-
-    monkeypatch.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
 
     custom_ops_list = custom_ops.split(",") if custom_ops else []
 

--- a/tests/compile/test_compile_ranges.py
+++ b/tests/compile/test_compile_ranges.py
@@ -66,7 +66,7 @@ class PostGradRangeChecker(InductorPass):
         return InductorPass.hash_dict(state)
 
 
-def test_compile_ranges(use_fresh_inductor_cache):
+def test_compile_ranges(disable_vllm_compile_cache):
     post_grad_range_checker = PostGradRangeChecker(
         [
             Range(start=1, end=8),
@@ -168,7 +168,7 @@ class PostGradStaticShapeChecker(InductorPass):
         return InductorPass.hash_dict(state)
 
 
-def test_compile_sizes_produce_static_shapes(use_fresh_inductor_cache):
+def test_compile_sizes_produce_static_shapes(disable_vllm_compile_cache):
     """Verify that compile_sizes entries are compiled with fully concrete
     shapes (no SymInts), while compile_ranges entries retain dynamic shapes."""
     checker = PostGradStaticShapeChecker()
@@ -209,10 +209,9 @@ def test_compile_sizes_produce_static_shapes(use_fresh_inductor_cache):
     )
 
 
-def test_inductor_cache_compile_ranges(monkeypatch, use_fresh_inductor_cache):
-    # To force multiple compilations, we disable the compile cache
-    monkeypatch.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
-
+def test_inductor_cache_compile_ranges(disable_vllm_compile_cache):
+    # disable_vllm_compile_cache sets VLLM_DISABLE_COMPILE_CACHE=1 to force
+    # multiple compilations by disabling vLLM's on-disk compile cache.
     post_grad_range_checker = PostGradRangeChecker(
         ranges=[
             Range(start=1, end=8),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1769,6 +1769,22 @@ def use_fresh_inductor_cache():
 
 
 @pytest.fixture
+def disable_vllm_compile_cache(monkeypatch, use_fresh_inductor_cache):
+    """
+    Use a fresh inductor cache AND disable vLLM's on-disk torch.compile cache.
+
+    This forces compilation (and any custom compile passes) to actually run
+    instead of being served from a warm cache left behind by previous runs
+    (e.g. on persistent CI agents). Use this for tests that inspect what
+    happens during compilation; use ``use_fresh_inductor_cache`` (or
+    ``fresh_vllm_cache``) instead when the vLLM compile cache must stay
+    enabled (e.g. cache save/load tests).
+    """
+    monkeypatch.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
+    yield
+
+
+@pytest.fixture
 def fresh_vllm_cache(monkeypatch, use_fresh_inductor_cache):
     """Temporary VLLM_CACHE_ROOT combined with a fresh inductor cache."""
     with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
Fixes `tests/compile/test_compile_ranges.py` tests that flakily failed on persistent CI agents when a warm vLLM compile cache caused graphs to load from disk, skipping the custom post-grad passes the tests count. 

Adds a new `disable_vllm_compile_cache` fixture (fresh Inductor cache + `VLLM_DISABLE_COMPILE_CACHE=1`) so compilation always runs, and migrates the compile-ranges and attention-fusion tests to it—de-duplicating their manual env-var setup while leaving cache save/load tests (`fresh_vllm_cache`) untouched.