### PR TITLE
[CI] Compute speech WER directly with jiwer

### DIFF
--- a/tests/entrypoints/speech_to_text/correctness/test_transcription_api_correctness.py
+++ b/tests/entrypoints/speech_to_text/correctness/test_transcription_api_correctness.py
@@ -17,7 +17,7 @@ import pytest
 import soundfile
 import torch
 from datasets import Audio, load_dataset
-from evaluate import load
+from jiwer import wer
 from transformers.models.whisper.english_normalizer import EnglishTextNormalizer
 
 from vllm.benchmarks.datasets.datasets import ASRDataset
@@ -202,8 +202,7 @@ def run_evaluation(
     # Compute WER
     predictions = [res[2] for res in results]
     references = [res[3] for res in results]
-    wer = load("wer")
-    wer_score = 100 * wer.compute(references=references, predictions=predictions)
+    wer_score = 100 * wer(references, predictions)
     print("WER:", wer_score)
     return wer_score
 
@@ -302,8 +301,7 @@ def run_longform_evaluation(
 
     predictions = [res[2] for res in results]
     references = [res[3] for res in results]
-    wer = load("wer")
-    wer_score = 100 * wer.compute(references=references, predictions=predictions)
+    wer_score = 100 * wer(references, predictions)
     print("WER:", wer_score)
     return wer_score
 


### PR DESCRIPTION
## Purpose

Closes #49771.

The speech correctness tests use `evaluate.load("wer")`. With the current test dependencies, `evaluate==0.4.3` calls the removed `huggingface_hub.hf_api.HfFolder` API and fails after inference completes.

This change computes WER directly with `jiwer`, which is already a test dependency and the backend used by the Hugging Face WER metric. It preserves the existing per-sample alignment and global error aggregation while removing the runtime metric download.

## Duplicate work

This does not duplicate another open fix. Searches for `speech-to-text evaluate jiwer`, `HfFolder huggingface_hub evaluate`, and `speech transcription WER CI` found no matching open issue or PR.

## Test results

- `jiwer==3.0.5`: the existing Hugging Face aggregation and direct `jiwer.wer` matched exactly for the canonical example and 1,900 randomized non-empty-reference batches.
- `pre-commit run --files tests/entrypoints/speech_to_text/correctness/test_transcription_api_correctness.py`: passed.
- Full speech correctness suite: not run locally because it downloads and serves multiple speech models; the existing Buildkite job covers it.
- Model evaluation: not applicable; this only changes test-side WER calculation.

AI assistance was used for CI diagnosis, implementation, and test planning.
