### PR TITLE
[Kernel] FlashInfer CuTe-DSL NVFP4 Quantization

### DIFF
--- a/benchmarks/kernels/benchmark_nvfp4_quant.py
+++ b/benchmarks/kernels/benchmark_nvfp4_quant.py
@@ -11,7 +11,7 @@ Two comparisons are reported:
   (vLLM does not dispatch to it for these layouts) called directly for
   comparison, as this benchmark has done since it was first added.
 - 8x4 small-M plot: the TRTLLM 8x4 scale layout, CUDA versus CuTe-DSL. Both are
-  production paths; scaled_fp4_quant selects this layout only when the backend
+  production paths; scaled_fp4_quant selects this layout only when gemm_backend
   contains "trtllm" and M <= 32.
 """
 
@@ -65,11 +65,13 @@ PROVIDER_CFGS = {
 }
 
 # Small-M comparison: the TRTLLM 8x4 scale layout only, CUDA vs CuTe-DSL kernel.
-# scaled_fp4_quant selects the 8x4 layout when the backend contains "trtllm" and
+# scaled_fp4_quant selects the 8x4 layout when gemm_backend contains "trtllm" and
 # M <= 32, so this runs on a separate small-M axis (see benchmark_8x4).
 PROVIDER_CFGS_8X4 = {
-    "flashinfer-cuda-8x4": dict(cutedsl=False, enabled=_flashinfer_ok),
-    "flashinfer-cutedsl-8x4": dict(cutedsl=True, enabled=_flashinfer_cutedsl_ok),
+    "flashinfer-cuda-8x4": dict(quant_backend="auto", enabled=_flashinfer_ok),
+    "flashinfer-cutedsl-8x4": dict(
+        quant_backend="flashinfer_cutedsl", enabled=_flashinfer_cutedsl_ok
+    ),
 }
 
 _enabled = [k for k, v in PROVIDER_CFGS.items() if v["enabled"]]
@@ -132,7 +134,7 @@ def benchmark(batch_size, provider, N, K):
             a,
             a_global_scale,
             is_sf_swizzled_layout=cfg["swizzle"],
-            flashinfer_cutedsl=True,
+            quant_backend="flashinfer_cutedsl",
         )
     else:
         raise ValueError(f"unknown provider backend: {cfg['backend']}")
@@ -166,13 +168,13 @@ def benchmark_8x4(batch_size, provider, N, K):
     a_global_scale = compute_global_scale(a)
 
     cfg = PROVIDER_CFGS_8X4[provider]
-    # backend="trtllm" with M <= 32 selects the 8x4 scale layout; flashinfer_cutedsl
+    # gemm_backend="trtllm" with M <= 32 selects the 8x4 scale layout; quant_backend
     # picks the CuTe-DSL kernel over the CUDA one.
     fn = lambda: ops.scaled_fp4_quant(
         a,
         a_global_scale,
-        backend="trtllm",
-        flashinfer_cutedsl=cfg["cutedsl"],
+        gemm_backend="trtllm",
+        quant_backend=cfg["quant_backend"],
     )
     return _bench_quant(fn)
 

--- a/benchmarks/kernels/benchmark_nvfp4_quant.py
+++ b/benchmarks/kernels/benchmark_nvfp4_quant.py
@@ -1,8 +1,24 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Benchmark NVFP4 input quantization kernels.
+
+Two comparisons are reported:
+
+- Main plot: vLLM's built-in C++ kernel versus FlashInfer's CUDA and CuTe-DSL
+  kernels, for the linear and 128x4 swizzled scale layouts. The vLLM and
+  FlashInfer CuTe-DSL lines are the production paths reachable through
+  scaled_fp4_quant; the FlashInfer CUDA line is an external reference kernel
+  (vLLM does not dispatch to it for these layouts) called directly for
+  comparison, as this benchmark has done since it was first added.
+- 8x4 small-M plot: the TRTLLM 8x4 scale layout, CUDA versus CuTe-DSL. Both are
+  production paths; scaled_fp4_quant selects this layout only when the backend
+  contains "trtllm" and M <= 32.
+"""
+
 import argparse
 import copy
 import itertools
+import os
 
 import torch
 from weight_shapes import WEIGHT_SHAPES
@@ -11,7 +27,11 @@ from vllm import _custom_ops as ops
 from vllm.platforms import current_platform
 from vllm.scalar_type import scalar_types
 from vllm.triton_utils import triton
-from vllm.utils.flashinfer import flashinfer_fp4_quantize
+from vllm.utils.flashinfer import (
+    flashinfer_fp4_quantize,
+    has_flashinfer,
+    has_flashinfer_cutedsl_nvfp4_quant,
+)
 
 if not current_platform.has_device_capability(100):
     raise RuntimeError("NVFP4 requires compute capability of 10.0 (Blackwell)")
@@ -19,22 +39,56 @@ if not current_platform.has_device_capability(100):
 FLOAT4_E2M1_MAX = scalar_types.float4_e2m1f.max()
 FLOAT8_E4M3_MAX = torch.finfo(torch.float8_e4m3fn).max
 
+_flashinfer_ok = has_flashinfer()
+_flashinfer_cutedsl_ok = has_flashinfer_cutedsl_nvfp4_quant()
+
+# Main comparison: three NVFP4 quant implementations across the linear and 128x4
+# swizzled scale layouts. ``backend`` selects the implementation and ``swizzle``
+# selects the 128x4 layout. ``vllm`` and ``flashinfer-cutedsl`` are the production
+# paths reachable through scaled_fp4_quant; ``flashinfer-cuda`` is FlashInfer's
+# standalone CUDA kernel, kept as an external reference (see module docstring).
 PROVIDER_CFGS = {
-    "vllm": dict(backend="vllm", is_sf_swizzled_layout=False, enabled=True),
-    "vllm-swizzle": dict(backend="vllm", is_sf_swizzled_layout=True, enabled=True),
-    "flashinfer": dict(backend="flashinfer", is_sf_swizzled_layout=False, enabled=True),
-    "flashinfer-swizzle": dict(
-        backend="flashinfer", is_sf_swizzled_layout=True, enabled=True
+    "vllm-linear": dict(backend="vllm", swizzle=False, enabled=True),
+    "vllm-swizzle": dict(backend="vllm", swizzle=True, enabled=True),
+    "flashinfer-cuda-linear": dict(
+        backend="flashinfer-cuda", swizzle=False, enabled=_flashinfer_ok
+    ),
+    "flashinfer-cuda-swizzle": dict(
+        backend="flashinfer-cuda", swizzle=True, enabled=_flashinfer_ok
+    ),
+    "flashinfer-cutedsl-linear": dict(
+        backend="flashinfer-cutedsl", swizzle=False, enabled=_flashinfer_cutedsl_ok
+    ),
+    "flashinfer-cutedsl-swizzle": dict(
+        backend="flashinfer-cutedsl", swizzle=True, enabled=_flashinfer_cutedsl_ok
     ),
 }
 
+# Small-M comparison: the TRTLLM 8x4 scale layout only, CUDA vs CuTe-DSL kernel.
+# scaled_fp4_quant selects the 8x4 layout when the backend contains "trtllm" and
+# M <= 32, so this runs on a separate small-M axis (see benchmark_8x4).
+PROVIDER_CFGS_8X4 = {
+    "flashinfer-cuda-8x4": dict(cutedsl=False, enabled=_flashinfer_ok),
+    "flashinfer-cutedsl-8x4": dict(cutedsl=True, enabled=_flashinfer_cutedsl_ok),
+}
+
 _enabled = [k for k, v in PROVIDER_CFGS.items() if v["enabled"]]
+_enabled_8x4 = [k for k, v in PROVIDER_CFGS_8X4.items() if v["enabled"]]
 
 
 def compute_global_scale(tensor: torch.Tensor) -> torch.Tensor:
     """Compute global scale for FP4 quantization."""
     amax = torch.abs(tensor).max().to(torch.float32)
     return FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / amax
+
+
+def _bench_quant(fn):
+    """Time a quantization callable, returning (median, hi, lo) in us."""
+    quantiles = [0.5, 0.2, 0.8]
+    ms, min_ms, max_ms = triton.testing.do_bench_cudagraph(fn, quantiles=quantiles)
+    # Convert ms to us for better readability at small batch sizes
+    to_us = lambda t_ms: t_ms * 1000
+    return to_us(ms), to_us(max_ms), to_us(min_ms)
 
 
 @triton.testing.perf_report(
@@ -46,7 +100,7 @@ def compute_global_scale(tensor: torch.Tensor) -> torch.Tensor:
         line_vals=_enabled,
         line_names=_enabled,
         ylabel="us (lower is better)",
-        plot_name="NVFP4 Input Quantization Latency (us)",
+        plot_name="nvfp4-input-quant",
         args={},
     )
 )
@@ -61,46 +115,66 @@ def benchmark(batch_size, provider, N, K):
     # Compute global scale for activation
     a_global_scale = compute_global_scale(a)
 
-    quantiles = [0.5, 0.2, 0.8]
-
     cfg = PROVIDER_CFGS[provider]
-
     if cfg["backend"] == "vllm":
-        # vLLM's FP4 quantization
-        if cfg["is_sf_swizzled_layout"]:
-            ms, min_ms, max_ms = triton.testing.do_bench_cudagraph(
-                lambda: ops.scaled_fp4_quant(
-                    a, a_global_scale, is_sf_swizzled_layout=True
-                ),
-                quantiles=quantiles,
-            )
-        else:
-            ms, min_ms, max_ms = triton.testing.do_bench_cudagraph(
-                lambda: ops.scaled_fp4_quant(
-                    a, a_global_scale, is_sf_swizzled_layout=False
-                ),
-                quantiles=quantiles,
-            )
-    elif cfg["backend"] == "flashinfer":
-        # FlashInfer's FP4 quantization
-        if cfg["is_sf_swizzled_layout"]:
-            ms, min_ms, max_ms = triton.testing.do_bench_cudagraph(
-                lambda: flashinfer_fp4_quantize(
-                    a, a_global_scale, is_sf_swizzled_layout=True
-                ),
-                quantiles=quantiles,
-            )
-        else:
-            ms, min_ms, max_ms = triton.testing.do_bench_cudagraph(
-                lambda: flashinfer_fp4_quantize(
-                    a, a_global_scale, is_sf_swizzled_layout=False
-                ),
-                quantiles=quantiles,
-            )
+        fn = lambda: ops.scaled_fp4_quant(
+            a, a_global_scale, is_sf_swizzled_layout=cfg["swizzle"]
+        )
+    elif cfg["backend"] == "flashinfer-cuda":
+        # FlashInfer's standalone CUDA kernel, called directly (vLLM does not
+        # dispatch to it for the linear and 128x4 layouts); kept as an external
+        # reference.
+        fn = lambda: flashinfer_fp4_quantize(
+            a, a_global_scale, is_sf_swizzled_layout=cfg["swizzle"]
+        )
+    elif cfg["backend"] == "flashinfer-cutedsl":
+        fn = lambda: ops.scaled_fp4_quant(
+            a,
+            a_global_scale,
+            is_sf_swizzled_layout=cfg["swizzle"],
+            flashinfer_cutedsl=True,
+        )
+    else:
+        raise ValueError(f"unknown provider backend: {cfg['backend']}")
+    return _bench_quant(fn)
 
-    # Convert ms to us for better readability at small batch sizes
-    to_us = lambda t_ms: t_ms * 1000
-    return to_us(ms), to_us(max_ms), to_us(min_ms)
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["batch_size"],
+        # The 8x4 scale layout is only selected for M <= 32, so restrict the axis
+        # to that regime instead of reporting values production never uses.
+        x_vals=[1, 4, 8, 16, 32],
+        x_log=False,
+        line_arg="provider",
+        line_vals=_enabled_8x4,
+        line_names=_enabled_8x4,
+        ylabel="us (lower is better)",
+        plot_name="nvfp4-8x4-small-m-quant",
+        args={},
+    )
+)
+def benchmark_8x4(batch_size, provider, N, K):
+    M = batch_size
+    device = "cuda"
+    dtype = torch.bfloat16
+
+    # Create input tensor
+    a = torch.randn((M, K), device=device, dtype=dtype)
+
+    # Compute global scale for activation
+    a_global_scale = compute_global_scale(a)
+
+    cfg = PROVIDER_CFGS_8X4[provider]
+    # backend="trtllm" with M <= 32 selects the 8x4 scale layout; flashinfer_cutedsl
+    # picks the CuTe-DSL kernel over the CUDA one.
+    fn = lambda: ops.scaled_fp4_quant(
+        a,
+        a_global_scale,
+        backend="trtllm",
+        flashinfer_cutedsl=cfg["cutedsl"],
+    )
+    return _bench_quant(fn)
 
 
 def prepare_shapes(args):
@@ -116,7 +190,11 @@ def prepare_shapes(args):
 def _test_accuracy_once(
     M: int, K: int, dtype: torch.dtype, device: str, is_sf_swizzled_layout: bool
 ):
-    """Test accuracy between vLLM and FlashInfer FP4 quantization."""
+    """Test accuracy between vLLM and FlashInfer's CUDA FP4 quantization."""
+    if not has_flashinfer():
+        print("FlashInfer unavailable; skipping accuracy test.")
+        return
+
     # Create input tensor
     a = torch.randn((M, K), device=device, dtype=dtype)
 
@@ -128,24 +206,20 @@ def _test_accuracy_once(
         a, a_global_scale, is_sf_swizzled_layout=is_sf_swizzled_layout
     )
 
-    # FlashInfer quantization (with swizzled layout to match vLLM's output)
+    # FlashInfer CUDA quantization (swizzled layout to match vLLM's output)
     flashinfer_fp4, flashinfer_scale = flashinfer_fp4_quantize(
         a, a_global_scale, is_sf_swizzled_layout=is_sf_swizzled_layout
     )
     flashinfer_scale = flashinfer_scale.view(torch.float8_e4m3fn)
 
-    # Compare outputs
-    torch.testing.assert_close(
-        vllm_fp4,
-        flashinfer_fp4,
-    )
-    # Compare scales
-    torch.testing.assert_close(
-        vllm_scale,
-        flashinfer_scale,
-    )
+    # vLLM's built-in kernel and FlashInfer's CUDA kernel both use an exact
+    # reciprocal, so require bit-exact fp4 codes and scales. CuTe-DSL correctness
+    # is covered separately by the kernel tests in tests/kernels/quantization.
+    torch.testing.assert_close(vllm_fp4, flashinfer_fp4)
+    torch.testing.assert_close(vllm_scale, flashinfer_scale)
     print(
-        f"M={M}, K={K}, dtype={dtype}, is_sf_swizzled_layout={is_sf_swizzled_layout}: PASSED"  # noqa: E501
+        f"M={M}, K={K}, dtype={dtype}, "
+        f"is_sf_swizzled_layout={is_sf_swizzled_layout}: PASSED"
     )
 
 
@@ -200,11 +274,23 @@ if __name__ == "__main__":
 
     for K, N, model in prepare_shapes(args):
         print(f"\n{model}, N={N} K={K}")
+        save_path = args.save_path
+        if save_path is not None:
+            save_path = os.path.join(save_path, f"n{N}_k{K}")
+            os.makedirs(save_path, exist_ok=True)
         benchmark.run(
             print_data=True,
-            save_path=args.save_path,
+            save_path=save_path,
             N=N,
             K=K,
         )
+        if _enabled_8x4:
+            print(f"\n{model}, N={N} K={K} (8x4 small-M)")
+            benchmark_8x4.run(
+                print_data=True,
+                save_path=save_path,
+                N=N,
+                K=K,
+            )
 
     print("\nBenchmark finished!")

--- a/tests/kernels/quantization/test_flashinfer_nvfp4_scaled_mm.py
+++ b/tests/kernels/quantization/test_flashinfer_nvfp4_scaled_mm.py
@@ -114,7 +114,7 @@ def test_flashinfer_nvfp4_gemm(
     # from checkpoints are in linear scales.
     # cutlass and b12x use swizzled scales directly; trtllm needs them unswizzled.
     a_fp4, a_scale_interleaved = ops.scaled_fp4_quant(
-        a_dtype, a_global_scale, is_sf_swizzled_layout=True, backend=backend
+        a_dtype, a_global_scale, is_sf_swizzled_layout=True, gemm_backend=backend
     )
     is_sf_128x4_layout = not (backend == "trtllm" and m <= 32)
 

--- a/tests/kernels/quantization/test_nvfp4_quant.py
+++ b/tests/kernels/quantization/test_nvfp4_quant.py
@@ -359,7 +359,7 @@ def test_flashinfer_nvfp4_quant_128x4_matches_vllm(
     )
     # FlashInfer CuTe-DSL 128x4.
     fi_out, fi_scale = ops.scaled_fp4_quant(
-        x, global_scale, is_sf_swizzled_layout=True, flashinfer_cutedsl=True
+        x, global_scale, is_sf_swizzled_layout=True, quant_backend="flashinfer_cutedsl"
     )
 
     assert fi_out.shape == ref_out.shape
@@ -412,10 +412,10 @@ def test_flashinfer_nvfp4_quant_128x4_padded_output(
         global_scale,
         is_sf_swizzled_layout=True,
         padded_n=padded_n,
-        flashinfer_cutedsl=True,
+        quant_backend="flashinfer_cutedsl",
     )
     unpadded_out, unpadded_scale = ops.scaled_fp4_quant(
-        x, global_scale, is_sf_swizzled_layout=True, flashinfer_cutedsl=True
+        x, global_scale, is_sf_swizzled_layout=True, quant_backend="flashinfer_cutedsl"
     )
 
     assert padded_out.shape == (m, padded_n // 2)
@@ -458,7 +458,7 @@ def test_flashinfer_nvfp4_quant_128x4_zeros_scale_padding(
     )
 
     _, scale = ops.scaled_fp4_quant(
-        x, global_scale, is_sf_swizzled_layout=True, flashinfer_cutedsl=True
+        x, global_scale, is_sf_swizzled_layout=True, quant_backend="flashinfer_cutedsl"
     )
 
     # Un-swizzle the full padded buffer; the padded rows [m:padded_m) must be zero.
@@ -495,7 +495,7 @@ def test_flashinfer_nvfp4_quant_linear_matches_vllm(
     )
     # FlashInfer CuTe-DSL linear.
     fi_out, fi_scale = ops.scaled_fp4_quant(
-        x, global_scale, is_sf_swizzled_layout=False, flashinfer_cutedsl=True
+        x, global_scale, is_sf_swizzled_layout=False, quant_backend="flashinfer_cutedsl"
     )
 
     assert fi_out.shape == ref_out.shape
@@ -526,7 +526,8 @@ def test_flashinfer_nvfp4_quant_linear_matches_vllm(
 def test_nvfp4_quant_trtllm_8x4_layout_selection() -> None:
     """For the TRTLLM backend the SF layout is chosen by M: 8x4 at m <= 32 and
     128x4 above (distinguished by the scale row count). This holds with
-    flashinfer_cutedsl, which routes to the cute-dsl 8x4 / 128x4 kernels."""
+    quant_backend="flashinfer_cutedsl", which routes to the cute-dsl 8x4 / 128x4
+    kernels."""
     set_random_seed(42)
     torch.set_default_device("cuda:0")
     n = 64
@@ -536,7 +537,7 @@ def test_nvfp4_quant_trtllm_8x4_layout_selection() -> None:
     x = torch.randn((m_small, n), dtype=torch.bfloat16)
     gs = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / torch.abs(x).max().to(torch.float32)
     _, scale = ops.scaled_fp4_quant(
-        x, gs, backend="flashinfer-trtllm", flashinfer_cutedsl=True
+        x, gs, gemm_backend="flashinfer-trtllm", quant_backend="flashinfer_cutedsl"
     )
     assert scale.shape[0] == round_up(m_small, 8)
 
@@ -546,7 +547,7 @@ def test_nvfp4_quant_trtllm_8x4_layout_selection() -> None:
     x = torch.randn((m_large, n), dtype=torch.bfloat16)
     gs = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / torch.abs(x).max().to(torch.float32)
     _, scale = ops.scaled_fp4_quant(
-        x, gs, backend="flashinfer-trtllm", flashinfer_cutedsl=True
+        x, gs, gemm_backend="flashinfer-trtllm", quant_backend="flashinfer_cutedsl"
     )
     assert scale.shape[0] == round_up(m_large, 128)
 
@@ -570,10 +571,10 @@ def test_flashinfer_cutedsl_nvfp4_quant_8x4_matches_cuda(dtype: torch.dtype) -> 
         x = torch.randn((m, n), dtype=dtype)
         gs = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / torch.abs(x).max().to(torch.float32)
         cuda_out, cuda_scale = ops.scaled_fp4_quant(
-            x, gs, backend="flashinfer-trtllm", flashinfer_cutedsl=False
+            x, gs, gemm_backend="flashinfer-trtllm", quant_backend="auto"
         )
         fi_out, fi_scale = ops.scaled_fp4_quant(
-            x, gs, backend="flashinfer-trtllm", flashinfer_cutedsl=True
+            x, gs, gemm_backend="flashinfer-trtllm", quant_backend="flashinfer_cutedsl"
         )
 
         # Both use the 8x4 layout (scale rows rounded up to 8).

--- a/tests/kernels/quantization/test_nvfp4_quant.py
+++ b/tests/kernels/quantization/test_nvfp4_quant.py
@@ -3,9 +3,11 @@
 import pytest
 import torch
 
+from tests.kernels.quantization.nvfp4_utils import break_fp4_bytes
 from vllm import _custom_ops as ops
 from vllm.platforms import current_platform
 from vllm.scalar_type import scalar_types
+from vllm.utils.flashinfer import has_flashinfer_cutedsl_nvfp4_quant
 from vllm.utils.torch_utils import set_random_seed
 
 if not current_platform.has_device_capability(100):
@@ -133,6 +135,25 @@ def recover_swizzled_scales(scale, m, n):
 
 def round_up(x: int, y: int) -> int:
     return (x + y - 1) // y * y
+
+
+# Signed FP4 (E2M1) levels in ascending order; an index gap of 1 between two
+# decoded values is a single representable-level (rounding-boundary) step.
+_FP4_LEVELS_ASC = sorted(set(E2M1_TO_FLOAT32))
+
+
+def assert_fp4_within_one_level(packed_a: torch.Tensor, packed_b: torch.Tensor) -> None:
+    """Assert two packed-FP4 tensors decode to values differing by at most one FP4
+    level per element. Unlike a packed-byte mismatch fraction this is size- and
+    nibble-independent and bounds every element to a single level, so a larger
+    systematic difference is still caught while an approximate-reciprocal boundary
+    flip is tolerated."""
+    a = break_fp4_bytes(packed_a, torch.float32).flatten()
+    b = break_fp4_bytes(packed_b, torch.float32).flatten()
+    levels = torch.tensor(_FP4_LEVELS_ASC, dtype=torch.float32, device=a.device)
+    gap = (torch.searchsorted(levels, a) - torch.searchsorted(levels, b)).abs()
+    max_gap = int(gap.max())
+    assert max_gap <= 1, f"fp4 codes differ by up to {max_gap} levels"
 
 
 @pytest.mark.parametrize("dtype", DTYPES)
@@ -306,3 +327,262 @@ def test_quantize_to_fp4_padded_no_sf_swizzled(pad_shape: tuple[int, int]) -> No
     out_ans = cast_from_fp4(out, m, n)
     torch.testing.assert_close(out_ans, out_ref)
     torch.testing.assert_close(scale_ans, scale_ref)
+
+
+@pytest.mark.skipif(
+    not has_flashinfer_cutedsl_nvfp4_quant(),
+    reason="FlashInfer NVFP4 quantization is not available.",
+)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("shape", SHAPES + PAD_SHAPES)
+@torch.inference_mode()
+def test_flashinfer_nvfp4_quant_128x4_matches_vllm(
+    dtype: torch.dtype,
+    shape: tuple[int, int],
+) -> None:
+    """FlashInfer CuTe-DSL 128x4 quant must match the vLLM C++ kernel it replaces
+    (including M not a multiple of 128). CuTe-DSL uses an approximate reciprocal,
+    so assert equivalence (at most one FP4 level per element + aggregate dequant
+    error), not bit-exactness."""
+    set_random_seed(42)
+    torch.set_default_device("cuda:0")
+
+    m, n = shape
+    x = torch.randn((m, n), dtype=dtype)
+    global_scale = (
+        FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / torch.abs(x).max().to(torch.float32)
+    )
+
+    # vLLM C++ 128x4 (the path FlashInfer replaces).
+    ref_out, ref_scale = ops.scaled_fp4_quant(
+        x, global_scale, is_sf_swizzled_layout=True
+    )
+    # FlashInfer CuTe-DSL 128x4.
+    fi_out, fi_scale = ops.scaled_fp4_quant(
+        x, global_scale, is_sf_swizzled_layout=True, flashinfer_cutedsl=True
+    )
+
+    assert fi_out.shape == ref_out.shape
+    assert fi_scale.shape == ref_scale.shape
+
+    # An approximate reciprocal may flip a value to an adjacent FP4 level, but no
+    # element may differ by more than one level.
+    assert_fp4_within_one_level(fi_out, ref_out)
+
+    # Aggregate dequant error catches systematic (scale/layout) errors while
+    # tolerating those isolated single-level boundary flips.
+    n_blocks = n // BLOCK_SIZE
+    fi_s = recover_swizzled_scales(fi_scale, m, n)
+    ref_s = recover_swizzled_scales(ref_scale, m, n)
+    fi_fp4 = break_fp4_bytes(fi_out, torch.float32).reshape(m, n_blocks, BLOCK_SIZE)
+    ref_fp4 = break_fp4_bytes(ref_out, torch.float32).reshape(m, n_blocks, BLOCK_SIZE)
+    fi_deq = fi_fp4 * fi_s.unsqueeze(-1) / global_scale
+    ref_deq = ref_fp4 * ref_s.unsqueeze(-1) / global_scale
+    agg_rel_err = (fi_deq - ref_deq).abs().sum() / ref_deq.abs().sum().clamp_min(1e-6)
+    assert agg_rel_err < 1e-2, f"aggregate rel err {float(agg_rel_err):.4f}"
+
+
+@pytest.mark.skipif(
+    not has_flashinfer_cutedsl_nvfp4_quant(),
+    reason="FlashInfer NVFP4 quantization is not available.",
+)
+@pytest.mark.parametrize("shape", PADDED_OUTPUT_SHAPES)
+@torch.inference_mode()
+def test_flashinfer_nvfp4_quant_128x4_padded_output(
+    shape: tuple[int, int],
+) -> None:
+    """The FlashInfer route emulates padded_n by zero-padding the input. The
+    data region must equal the unpadded FlashInfer output and the padded
+    columns (fp4 and scale) must be exactly zero."""
+    dtype = torch.float16
+    set_random_seed(42)
+    torch.set_default_device("cuda:0")
+
+    m, n = shape
+    padded_n = round_up(n, 32)
+    assert padded_n > n
+
+    x = torch.randn((m, n), dtype=dtype)
+    global_scale = (
+        FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / torch.abs(x).max().to(torch.float32)
+    )
+
+    padded_out, padded_scale = ops.scaled_fp4_quant(
+        x,
+        global_scale,
+        is_sf_swizzled_layout=True,
+        padded_n=padded_n,
+        flashinfer_cutedsl=True,
+    )
+    unpadded_out, unpadded_scale = ops.scaled_fp4_quant(
+        x, global_scale, is_sf_swizzled_layout=True, flashinfer_cutedsl=True
+    )
+
+    assert padded_out.shape == (m, padded_n // 2)
+
+    # Padding whole zero blocks leaves the real blocks unchanged.
+    torch.testing.assert_close(padded_out[:, : n // 2], unpadded_out)
+    assert torch.count_nonzero(padded_out[:, n // 2 :]) == 0
+
+    padded_s = recover_swizzled_scales(padded_scale, m, padded_n)
+    unpadded_s = recover_swizzled_scales(unpadded_scale, m, n)
+    torch.testing.assert_close(padded_s[:, : n // BLOCK_SIZE], unpadded_s)
+    assert torch.count_nonzero(padded_s[:, n // BLOCK_SIZE :]) == 0
+
+
+@pytest.mark.skipif(
+    not has_flashinfer_cutedsl_nvfp4_quant(),
+    reason="FlashInfer NVFP4 quantization is not available.",
+)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("shape", [(90, 64), (150, 64), (90, 128), (150, 128)])
+@torch.inference_mode()
+def test_flashinfer_nvfp4_quant_128x4_zeros_scale_padding(
+    dtype: torch.dtype,
+    shape: tuple[int, int],
+) -> None:
+    """The swizzled scale buffer is padded to round_up(m, 128) rows. This CuTe-DSL
+    path bypasses create_fp4_scale_tensor's zero-init, so it relies on the
+    FlashInfer kernel zeroing those padded rows itself. Guards against a FlashInfer
+    change reintroducing the uninitialized-scale corruption fixed in PR #45739."""
+    set_random_seed(42)
+    torch.set_default_device("cuda:0")
+
+    m, n = shape
+    padded_m = round_up(m, 128)
+    assert padded_m > m and (n // BLOCK_SIZE) % 4 == 0  # row padding only
+
+    x = torch.randn((m, n), dtype=dtype)
+    global_scale = (
+        FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / torch.abs(x).max().to(torch.float32)
+    )
+
+    _, scale = ops.scaled_fp4_quant(
+        x, global_scale, is_sf_swizzled_layout=True, flashinfer_cutedsl=True
+    )
+
+    # Un-swizzle the full padded buffer; the padded rows [m:padded_m) must be zero.
+    full = recover_swizzled_scales(scale, padded_m, n)
+    assert torch.count_nonzero(full[m:]) == 0
+
+
+@pytest.mark.skipif(
+    not has_flashinfer_cutedsl_nvfp4_quant(),
+    reason="FlashInfer NVFP4 quantization is not available.",
+)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("shape", SHAPES + PAD_SHAPES)
+@torch.inference_mode()
+def test_flashinfer_nvfp4_quant_linear_matches_vllm(
+    dtype: torch.dtype,
+    shape: tuple[int, int],
+) -> None:
+    """FlashInfer CuTe-DSL linear quant must match the vLLM C++ kernel it
+    mirrors. Same approximate-reciprocal tolerance as the 128x4 test; the linear
+    scale is a plain [m, n // 16] tensor, compared directly (no unswizzle)."""
+    set_random_seed(42)
+    torch.set_default_device("cuda:0")
+
+    m, n = shape
+    x = torch.randn((m, n), dtype=dtype)
+    global_scale = (
+        FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / torch.abs(x).max().to(torch.float32)
+    )
+
+    # vLLM C++ linear (the path FlashInfer mirrors).
+    ref_out, ref_scale = ops.scaled_fp4_quant(
+        x, global_scale, is_sf_swizzled_layout=False
+    )
+    # FlashInfer CuTe-DSL linear.
+    fi_out, fi_scale = ops.scaled_fp4_quant(
+        x, global_scale, is_sf_swizzled_layout=False, flashinfer_cutedsl=True
+    )
+
+    assert fi_out.shape == ref_out.shape
+    assert fi_scale.shape == ref_scale.shape
+
+    # An approximate reciprocal may flip a value to an adjacent FP4 level, but no
+    # element may differ by more than one level.
+    assert_fp4_within_one_level(fi_out, ref_out)
+
+    # Aggregate dequant error catches systematic (scale/layout) errors while
+    # tolerating those isolated single-level boundary flips.
+    n_blocks = n // BLOCK_SIZE
+    fi_s = fi_scale.to(torch.float32)
+    ref_s = ref_scale.to(torch.float32)
+    fi_fp4 = break_fp4_bytes(fi_out, torch.float32).reshape(m, n_blocks, BLOCK_SIZE)
+    ref_fp4 = break_fp4_bytes(ref_out, torch.float32).reshape(m, n_blocks, BLOCK_SIZE)
+    fi_deq = fi_fp4 * fi_s.unsqueeze(-1) / global_scale
+    ref_deq = ref_fp4 * ref_s.unsqueeze(-1) / global_scale
+    agg_rel_err = (fi_deq - ref_deq).abs().sum() / ref_deq.abs().sum().clamp_min(1e-6)
+    assert agg_rel_err < 1e-2, f"aggregate rel err {float(agg_rel_err):.4f}"
+
+
+@pytest.mark.skipif(
+    not has_flashinfer_cutedsl_nvfp4_quant(),
+    reason="FlashInfer NVFP4 quantization is not available.",
+)
+@torch.inference_mode()
+def test_nvfp4_quant_trtllm_8x4_layout_selection() -> None:
+    """For the TRTLLM backend the SF layout is chosen by M: 8x4 at m <= 32 and
+    128x4 above (distinguished by the scale row count). This holds with
+    flashinfer_cutedsl, which routes to the cute-dsl 8x4 / 128x4 kernels."""
+    set_random_seed(42)
+    torch.set_default_device("cuda:0")
+    n = 64
+
+    # m <= 32 with the TRTLLM backend: 8x4 layout (cute-dsl 8x4 here).
+    m_small = 16
+    x = torch.randn((m_small, n), dtype=torch.bfloat16)
+    gs = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / torch.abs(x).max().to(torch.float32)
+    _, scale = ops.scaled_fp4_quant(
+        x, gs, backend="flashinfer-trtllm", flashinfer_cutedsl=True
+    )
+    assert scale.shape[0] == round_up(m_small, 8)
+
+    # m > 32: the 8x4 path no longer applies, so it routes to the 128x4 CuTe-DSL
+    # kernel.
+    m_large = 64
+    x = torch.randn((m_large, n), dtype=torch.bfloat16)
+    gs = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / torch.abs(x).max().to(torch.float32)
+    _, scale = ops.scaled_fp4_quant(
+        x, gs, backend="flashinfer-trtllm", flashinfer_cutedsl=True
+    )
+    assert scale.shape[0] == round_up(m_large, 128)
+
+
+@pytest.mark.skipif(
+    not has_flashinfer_cutedsl_nvfp4_quant(),
+    reason="FlashInfer NVFP4 quantization is not available.",
+)
+@pytest.mark.parametrize("dtype", DTYPES)
+@torch.inference_mode()
+def test_flashinfer_cutedsl_nvfp4_quant_8x4_matches_cuda(dtype: torch.dtype) -> None:
+    """FlashInfer CuTe-DSL 8x4 quant (TRTLLM small-M) must match the CUDA 8x4
+    kernel. There is no vLLM C++ 8x4 kernel, so both sides are FlashInfer; assert
+    at most one FP4 level (and one e4m3 scale step) per element, not
+    bit-exactness."""
+    set_random_seed(42)
+    torch.set_default_device("cuda:0")
+    n = 128
+
+    for m in (1, 16, 32):
+        x = torch.randn((m, n), dtype=dtype)
+        gs = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / torch.abs(x).max().to(torch.float32)
+        cuda_out, cuda_scale = ops.scaled_fp4_quant(
+            x, gs, backend="flashinfer-trtllm", flashinfer_cutedsl=False
+        )
+        fi_out, fi_scale = ops.scaled_fp4_quant(
+            x, gs, backend="flashinfer-trtllm", flashinfer_cutedsl=True
+        )
+
+        # Both use the 8x4 layout (scale rows rounded up to 8).
+        assert fi_out.shape == cuda_out.shape
+        assert fi_scale.shape == cuda_scale.shape
+        assert fi_scale.shape[0] == round_up(m, 8)
+
+        # At most one FP4 level and one e4m3 scale step may differ per element.
+        assert_fp4_within_one_level(fi_out, cuda_out)
+        fi_s = fi_scale.view(torch.float8_e4m3fn).to(torch.float32)
+        cuda_s = cuda_scale.view(torch.float8_e4m3fn).to(torch.float32)
+        torch.testing.assert_close(fi_s, cuda_s, rtol=0.13, atol=2**-9)

--- a/tests/kernels/quantization/test_nvfp4_quant_backend.py
+++ b/tests/kernels/quantization/test_nvfp4_quant_backend.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Tests for ``KernelConfig.nvfp4_input_quant_backend`` routing into the NVFP4 linear
-kernels (opt-in FlashInfer CuTe-DSL activation quantization)."""
+kernels (FlashInfer CuTe-DSL activation quantization, default on Blackwell)."""
 
 import pytest
 
@@ -36,10 +36,11 @@ def _config(nvfp4_input_quant_backend: str) -> VllmConfig:
 )
 def test_nvfp4_input_quant_backend_routes_only_flashinfer_kernels() -> None:
     """A FlashInfer NVFP4 linear kernel resolves its activation quant to CuTe-DSL
-    when ``nvfp4_input_quant_backend=flashinfer_cutedsl``. A non-FlashInfer kernel
-    cannot honor the request and raises (matching linear_backend's convention for
-    an unsatisfiable explicit backend). Under the default ("auto"), no kernel opts
-    in."""
+    under the default ("auto", when CuTe-DSL is available) and under an explicit
+    "flashinfer_cutedsl"; "cuda" forces the built-in kernel. A non-FlashInfer
+    kernel never routes through CuTe-DSL: it stays on the CUDA kernel under "auto"
+    and raises for an explicit "flashinfer_cutedsl" (matching linear_backend's
+    convention for an unsatisfiable explicit backend)."""
     layer_config = NvFp4LinearLayerConfig()
 
     with set_current_vllm_config(_config("flashinfer_cutedsl")):
@@ -51,6 +52,15 @@ def test_nvfp4_input_quant_backend_routes_only_flashinfer_kernels() -> None:
             CutlassNvFp4LinearKernel(layer_config)
 
     with set_current_vllm_config(_config("auto")):
+        # Default prefers CuTe-DSL for FlashInfer kernels when it is available.
+        fi_kernel = FlashInferCutlassNvFp4LinearKernel(layer_config)
+        assert fi_kernel.input_quant_backend == "flashinfer_cutedsl"
+        # Non-FlashInfer kernels keep the built-in CUDA kernel under "auto".
+        cutlass_kernel = CutlassNvFp4LinearKernel(layer_config)
+        assert cutlass_kernel.input_quant_backend == "auto"
+
+    with set_current_vllm_config(_config("cuda")):
+        # Explicit opt-out keeps the built-in CUDA kernel even for FlashInfer.
         fi_kernel = FlashInferCutlassNvFp4LinearKernel(layer_config)
         assert fi_kernel.input_quant_backend == "auto"
 
@@ -83,20 +93,22 @@ def test_nvfp4_input_quant_backend_requires_flashinfer(monkeypatch) -> None:
     reason="FlashInfer CuTe-DSL NVFP4 quantization is not available.",
 )
 def test_flashinfer_cutedsl_disables_input_prequant() -> None:
-    """Guards the fused-MLP path: under flashinfer_cutedsl the CUTLASS NVFP4
-    kernel must not advertise a pre-quantized input key (a producer would
-    pre-quantize with the C++ kernel and bypass cute-dsl). So input_quant_key()
-    is None under flashinfer_cutedsl and kNvfp4Dynamic under the default."""
+    """Guards the fused-MLP path: whenever the CUTLASS NVFP4 kernel resolves to
+    CuTe-DSL (the default "auto" when available, or an explicit "flashinfer_cutedsl")
+    it must not advertise a pre-quantized input key, or a producer would
+    pre-quantize with the C++ kernel and bypass cute-dsl. So input_quant_key() is
+    None there and kNvfp4Dynamic only under an explicit "cuda"."""
     from vllm.model_executor.layers.quantization.utils.quant_utils import (
         kNvfp4Dynamic,
     )
 
     layer_config = NvFp4LinearLayerConfig()
 
-    with set_current_vllm_config(_config("flashinfer_cutedsl")):
-        kernel = FlashInferCutlassNvFp4LinearKernel(layer_config)
-        assert kernel.input_quant_key() is None
+    for backend in ("auto", "flashinfer_cutedsl"):
+        with set_current_vllm_config(_config(backend)):
+            kernel = FlashInferCutlassNvFp4LinearKernel(layer_config)
+            assert kernel.input_quant_key() is None
 
-    with set_current_vllm_config(_config("auto")):
+    with set_current_vllm_config(_config("cuda")):
         kernel = FlashInferCutlassNvFp4LinearKernel(layer_config)
         assert kernel.input_quant_key() == kNvfp4Dynamic

--- a/tests/kernels/quantization/test_nvfp4_quant_backend.py
+++ b/tests/kernels/quantization/test_nvfp4_quant_backend.py
@@ -44,7 +44,7 @@ def test_nvfp4_input_quant_backend_routes_only_flashinfer_kernels() -> None:
 
     with set_current_vllm_config(_config("flashinfer_cutedsl")):
         fi_kernel = FlashInferCutlassNvFp4LinearKernel(layer_config)
-        assert fi_kernel.use_flashinfer_cutedsl_input_quant is True
+        assert fi_kernel.input_quant_backend == "flashinfer_cutedsl"
 
         # A non-FlashInfer NVFP4 linear kernel cannot honor the knob and raises.
         with pytest.raises(ValueError, match="does not route activation quant"):
@@ -52,7 +52,7 @@ def test_nvfp4_input_quant_backend_routes_only_flashinfer_kernels() -> None:
 
     with set_current_vllm_config(_config("auto")):
         fi_kernel = FlashInferCutlassNvFp4LinearKernel(layer_config)
-        assert fi_kernel.use_flashinfer_cutedsl_input_quant is False
+        assert fi_kernel.input_quant_backend == "auto"
 
 
 @pytest.mark.skipif(

--- a/tests/kernels/quantization/test_nvfp4_quant_backend.py
+++ b/tests/kernels/quantization/test_nvfp4_quant_backend.py
@@ -68,14 +68,14 @@ def test_nvfp4_input_quant_backend_requires_flashinfer(monkeypatch) -> None:
 
     # base.py imports has_flashinfer_cutedsl_nvfp4_quant at module scope, so patch
     # it there (where the resolver looks it up), not on vllm.utils.flashinfer.
-    monkeypatch.setattr(
-        nvfp4_base, "has_flashinfer_cutedsl_nvfp4_quant", lambda: False
-    )
+    monkeypatch.setattr(nvfp4_base, "has_flashinfer_cutedsl_nvfp4_quant", lambda: False)
     layer_config = NvFp4LinearLayerConfig()
 
-    with set_current_vllm_config(_config("flashinfer_cutedsl")):
-        with pytest.raises(ValueError, match="requires SM100"):
-            FlashInferCutlassNvFp4LinearKernel(layer_config)
+    with (
+        set_current_vllm_config(_config("flashinfer_cutedsl")),
+        pytest.raises(ValueError, match="requires SM100"),
+    ):
+        FlashInferCutlassNvFp4LinearKernel(layer_config)
 
 
 @pytest.mark.skipif(

--- a/tests/kernels/quantization/test_nvfp4_quant_backend.py
+++ b/tests/kernels/quantization/test_nvfp4_quant_backend.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for ``KernelConfig.nvfp4_input_quant_backend`` routing into the NVFP4 linear
+kernels (opt-in FlashInfer CuTe-DSL activation quantization)."""
+
+import pytest
+
+from vllm.config import KernelConfig, VllmConfig, set_current_vllm_config
+from vllm.model_executor.kernels.linear.nvfp4.base import NvFp4LinearLayerConfig
+from vllm.model_executor.kernels.linear.nvfp4.cutlass import CutlassNvFp4LinearKernel
+from vllm.model_executor.kernels.linear.nvfp4.flashinfer import (
+    FlashInferCutlassNvFp4LinearKernel,
+)
+from vllm.platforms import current_platform
+from vllm.utils.flashinfer import (
+    has_flashinfer,
+    has_flashinfer_cutedsl_nvfp4_quant,
+)
+
+if not current_platform.has_device_capability(100):
+    pytest.skip(
+        reason="Nvfp4 requires compute capability of 10 or above.",
+        allow_module_level=True,
+    )
+
+
+def _config(nvfp4_input_quant_backend: str) -> VllmConfig:
+    return VllmConfig(
+        kernel_config=KernelConfig(nvfp4_input_quant_backend=nvfp4_input_quant_backend)
+    )
+
+
+@pytest.mark.skipif(
+    not has_flashinfer_cutedsl_nvfp4_quant(),
+    reason="FlashInfer CuTe-DSL NVFP4 quantization is not available.",
+)
+def test_nvfp4_input_quant_backend_routes_only_flashinfer_kernels() -> None:
+    """A FlashInfer NVFP4 linear kernel resolves its activation quant to CuTe-DSL
+    when ``nvfp4_input_quant_backend=flashinfer_cutedsl``. A non-FlashInfer kernel
+    cannot honor the request and raises (matching linear_backend's convention for
+    an unsatisfiable explicit backend). Under the default ("auto"), no kernel opts
+    in."""
+    layer_config = NvFp4LinearLayerConfig()
+
+    with set_current_vllm_config(_config("flashinfer_cutedsl")):
+        fi_kernel = FlashInferCutlassNvFp4LinearKernel(layer_config)
+        assert fi_kernel.use_flashinfer_cutedsl_input_quant is True
+
+        # A non-FlashInfer NVFP4 linear kernel cannot honor the knob and raises.
+        with pytest.raises(ValueError, match="does not route activation quant"):
+            CutlassNvFp4LinearKernel(layer_config)
+
+    with set_current_vllm_config(_config("auto")):
+        fi_kernel = FlashInferCutlassNvFp4LinearKernel(layer_config)
+        assert fi_kernel.use_flashinfer_cutedsl_input_quant is False
+
+
+@pytest.mark.skipif(
+    not has_flashinfer(),
+    reason="FlashInfer (needed to construct the kernel) is not available.",
+)
+def test_nvfp4_input_quant_backend_requires_flashinfer(monkeypatch) -> None:
+    """Selecting flashinfer_cutedsl for a FlashInfer kernel without CuTe-DSL
+    nvfp4_quantize available fails at kernel setup. Gated on has_flashinfer()
+    (not the CuTe-DSL check) so it also runs where CuTe-DSL is genuinely
+    unavailable; the monkeypatch forces the unavailable branch either way."""
+    import vllm.model_executor.kernels.linear.nvfp4.base as nvfp4_base
+
+    # base.py imports has_flashinfer_cutedsl_nvfp4_quant at module scope, so patch
+    # it there (where the resolver looks it up), not on vllm.utils.flashinfer.
+    monkeypatch.setattr(
+        nvfp4_base, "has_flashinfer_cutedsl_nvfp4_quant", lambda: False
+    )
+    layer_config = NvFp4LinearLayerConfig()
+
+    with set_current_vllm_config(_config("flashinfer_cutedsl")):
+        with pytest.raises(ValueError, match="requires SM100"):
+            FlashInferCutlassNvFp4LinearKernel(layer_config)
+
+
+@pytest.mark.skipif(
+    not has_flashinfer_cutedsl_nvfp4_quant(),
+    reason="FlashInfer CuTe-DSL NVFP4 quantization is not available.",
+)
+def test_flashinfer_cutedsl_disables_input_prequant() -> None:
+    """Guards the fused-MLP path: under flashinfer_cutedsl the CUTLASS NVFP4
+    kernel must not advertise a pre-quantized input key (a producer would
+    pre-quantize with the C++ kernel and bypass cute-dsl). So input_quant_key()
+    is None under flashinfer_cutedsl and kNvfp4Dynamic under the default."""
+    from vllm.model_executor.layers.quantization.utils.quant_utils import (
+        kNvfp4Dynamic,
+    )
+
+    layer_config = NvFp4LinearLayerConfig()
+
+    with set_current_vllm_config(_config("flashinfer_cutedsl")):
+        kernel = FlashInferCutlassNvFp4LinearKernel(layer_config)
+        assert kernel.input_quant_key() is None
+
+    with set_current_vllm_config(_config("auto")):
+        kernel = FlashInferCutlassNvFp4LinearKernel(layer_config)
+        assert kernel.input_quant_key() == kNvfp4Dynamic

--- a/tests/models/quantization/test_nvfp4.py
+++ b/tests/models/quantization/test_nvfp4.py
@@ -15,6 +15,7 @@ from tests.quantization.utils import is_quant_method_supported
 from vllm import LLM, SamplingParams
 
 from vllm.platforms import current_platform
+from vllm.utils.flashinfer import has_flashinfer_cutedsl_nvfp4_quant
 
 os.environ["TOKENIZERS_PARALLELISM"] = "true"
 
@@ -124,6 +125,26 @@ def test_nvfp4(vllm_runner, model, eager, backend):
         )
 
     with vllm_runner(model, enforce_eager=eager, linear_backend=backend) as llm:
+        output = llm.generate_greedy(["1 2 3 4 5"], max_tokens=2)
+    assert output[0][1] == "1 2 3 4 5 6"
+
+
+@pytest.mark.skipif(
+    not has_flashinfer_cutedsl_nvfp4_quant(),
+    reason="FlashInfer CuTe-DSL NVFP4 activation quant requires SM10x and a "
+    "FlashInfer build with CuTe-DSL",
+)
+@pytest.mark.parametrize("model", ["nvidia/Llama-3.1-8B-Instruct-NVFP4"])
+@pytest.mark.parametrize("eager", EAGER)
+def test_nvfp4_input_quant_backend_cutedsl(vllm_runner, model, eager):
+    """End-to-end check that the FlashInfer CuTe-DSL activation-quant backend
+    (kernel_config.nvfp4_input_quant_backend) drives the NVFP4 linear kernels'
+    apply_weights path correctly, independently of the GEMM backend."""
+    with vllm_runner(
+        model,
+        enforce_eager=eager,
+        kernel_config={"nvfp4_input_quant_backend": "flashinfer_cutedsl"},
+    ) as llm:
         output = llm.generate_greedy(["1 2 3 4 5"], max_tokens=2)
     assert output[0][1] == "1 2 3 4 5 6"
 

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1524,9 +1524,9 @@ def scaled_fp4_quant(
     input: torch.Tensor,
     input_global_scale: torch.Tensor,
     is_sf_swizzled_layout: bool = True,
-    backend: str = "none",
+    gemm_backend: str = "none",
     padded_n: int | None = None,
-    flashinfer_cutedsl: bool = False,
+    quant_backend: Literal["auto", "flashinfer_cutedsl"] = "auto",
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Quantize input tensor to FP4 and return quantized tensor and scale.
@@ -1542,17 +1542,19 @@ def scaled_fp4_quant(
         input_global_scale: A scalar scaling factor for the entire tensor.
         is_sf_swizzled_layout: Whether to store the scaling factors in the
             swizzled layout (default `True`).
-        backend: Quantization kernel backend to dispatch to. For `"trtllm"`
-            backends the 8x4 scale-factor layout is selected for small
-            batches (m <= 32) instead of the 128x4 layout.
+        gemm_backend: Backend of the GEMM that consumes the quantized output.
+            Only affects the scale-factor layout: `"trtllm"` backends take the
+            8x4 layout for small batches (m <= 32) instead of the 128x4 layout.
         padded_n: Optional padded K dimension. When provided, the quantized
             output and scale tensors are allocated for ``padded_n``
-        flashinfer_cutedsl: Internal; normally set by the NVFP4 linear kernels,
-            which validate availability. When ``True`` quantize via FlashInfer's
-            CuTe-DSL ``nvfp4_quantize`` (128x4, linear, or 8x4 layout) instead of
-            the built-in kernel. There is no availability check here (to stay
-            torch.compile-safe), so direct callers must first ensure
-            has_flashinfer_cutedsl_nvfp4_quant(). ``False`` is the default.
+        quant_backend: Which kernel performs the quantization, mirroring
+            ``KernelConfig.nvfp4_input_quant_backend``. ``"auto"`` (the default)
+            uses the built-in kernel; ``"flashinfer_cutedsl"`` uses FlashInfer's
+            CuTe-DSL ``nvfp4_quantize`` (128x4, linear, or 8x4 layout). Normally
+            set by the NVFP4 linear kernels, which validate availability. There
+            is no availability check here (to stay torch.compile-safe), so
+            direct callers must first ensure
+            has_flashinfer_cutedsl_nvfp4_quant().
 
     Returns:
         tuple[torch.Tensor, torch.Tensor]: The output tensor in FP4 but every
@@ -1560,6 +1562,8 @@ def scaled_fp4_quant(
             in the sizzled layout.
     """
     assert not current_platform.is_rocm()
+    if quant_backend not in ("auto", "flashinfer_cutedsl"):
+        raise ValueError(f"Unknown quant_backend: {quant_backend}.")
     assert input.ndim >= 1, f"input.ndim needs to be >= 1, but got {input.ndim}."
     other_dims = 1 if input.ndim == 1 else -1
     input = input.reshape(other_dims, input.shape[-1])
@@ -1576,14 +1580,14 @@ def scaled_fp4_quant(
             f"padded_n has to be a multiple of {block_size}, but got {padded_n}."
         )
 
-    use_8x4_sf_layout = "trtllm" in backend and m <= 32
+    use_8x4_sf_layout = "trtllm" in gemm_backend and m <= 32
     if use_8x4_sf_layout and padded_n is not None and padded_n != n:
         # TODO: support this case
         raise ValueError("padded_n is not supported with TRTLLM 8x4 scale layout.")
     if use_8x4_sf_layout:
         # 8x4 layout (TRTLLM small-M). CuTe-DSL supports it, so honor
-        # flashinfer_cutedsl instead of always using the CUDA kernel.
-        if flashinfer_cutedsl:
+        # quant_backend instead of always using the CUDA kernel.
+        if quant_backend == "flashinfer_cutedsl":
             output, output_scale = torch.ops.vllm.flashinfer_cutedsl_nvfp4_quantize(
                 input, input_global_scale, "8x4"
             )
@@ -1591,7 +1595,7 @@ def scaled_fp4_quant(
             output, output_scale = flashinfer_quant_nvfp4_8x4_sf_layout(
                 input, input_global_scale
             )
-    elif flashinfer_cutedsl:
+    elif quant_backend == "flashinfer_cutedsl":
         # CuTe-DSL 128x4 or linear quant; output uses the same packed layout as
         # the vLLM C++ kernel (drop-in replaceable) and is numerically equivalent
         # aside from occasional adjacent-FP4 rounding from CuTe-DSL's approximate

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1526,6 +1526,7 @@ def scaled_fp4_quant(
     is_sf_swizzled_layout: bool = True,
     backend: str = "none",
     padded_n: int | None = None,
+    flashinfer_cutedsl: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Quantize input tensor to FP4 and return quantized tensor and scale.
@@ -1546,6 +1547,12 @@ def scaled_fp4_quant(
             batches (m <= 32) instead of the 128x4 layout.
         padded_n: Optional padded K dimension. When provided, the quantized
             output and scale tensors are allocated for ``padded_n``
+        flashinfer_cutedsl: Internal; normally set by the NVFP4 linear kernels,
+            which validate availability. When ``True`` quantize via FlashInfer's
+            CuTe-DSL ``nvfp4_quantize`` (128x4, linear, or 8x4 layout) instead of
+            the built-in kernel. There is no availability check here (to stay
+            torch.compile-safe), so direct callers must first ensure
+            has_flashinfer_cutedsl_nvfp4_quant(). ``False`` is the default.
 
     Returns:
         tuple[torch.Tensor, torch.Tensor]: The output tensor in FP4 but every
@@ -1569,14 +1576,40 @@ def scaled_fp4_quant(
             f"padded_n has to be a multiple of {block_size}, but got {padded_n}."
         )
 
-    use_8x4_sf_layout = True if "trtllm" in backend and m <= 32 else False  # noqa: SIM210
+    use_8x4_sf_layout = "trtllm" in backend and m <= 32
     if use_8x4_sf_layout and padded_n is not None and padded_n != n:
         # TODO: support this case
         raise ValueError("padded_n is not supported with TRTLLM 8x4 scale layout.")
     if use_8x4_sf_layout:
-        output, output_scale = flashinfer_quant_nvfp4_8x4_sf_layout(
-            input, input_global_scale
-        )
+        # 8x4 layout (TRTLLM small-M). CuTe-DSL supports it, so honor
+        # flashinfer_cutedsl instead of always using the CUDA kernel.
+        if flashinfer_cutedsl:
+            output, output_scale = torch.ops.vllm.flashinfer_cutedsl_nvfp4_quantize(
+                input, input_global_scale, "8x4"
+            )
+        else:
+            output, output_scale = flashinfer_quant_nvfp4_8x4_sf_layout(
+                input, input_global_scale
+            )
+    elif flashinfer_cutedsl:
+        # CuTe-DSL 128x4 or linear quant; output uses the same packed layout as
+        # the vLLM C++ kernel (drop-in replaceable) and is numerically equivalent
+        # aside from occasional adjacent-FP4 rounding from CuTe-DSL's approximate
+        # reciprocal. It zero-fills padded scale factors itself (unlike the C++
+        # kernel), so create_fp4_scale_tensor's zero-init is skipped here.
+        # FlashInfer has no padded_n, so zero-pad the width first (zero blocks
+        # quantize to zero, matching the C++ padded output).
+        quant_input = input
+        if padded_n is not None and padded_n != n:
+            quant_input = torch.nn.functional.pad(input, (0, padded_n - n))
+        if is_sf_swizzled_layout:
+            output, output_scale = torch.ops.vllm.flashinfer_cutedsl_nvfp4_quantize(
+                quant_input, input_global_scale, "128x4"
+            )
+        else:
+            output, output_scale = torch.ops.vllm.flashinfer_cutedsl_nvfp4_quantize(
+                quant_input, input_global_scale, "linear"
+            )
     else:
         # Pre-allocate and call .out variant (same behavior as old in-place API)
         output, output_scale = create_fp4_output_tensors(

--- a/vllm/config/kernel.py
+++ b/vllm/config/kernel.py
@@ -163,6 +163,7 @@ LinearBackend = Literal[
 
 NvFp4InputQuantBackend = Literal[
     "auto",
+    "cuda",
     "flashinfer_cutedsl",
 ]
 
@@ -240,15 +241,16 @@ class KernelConfig:
     """
 
     nvfp4_input_quant_backend: NvFp4InputQuantBackend = "auto"
-    """Backend for the NVFP4 activation (input) quantization used by NVFP4 dense
-    linear layers. Available options:
+    """Backend for the NVFP4 activation (input) quantization in NVFP4 dense linear
+    layers. Only the FlashInfer NVFP4 linear kernels honor this; other kernels
+    always use the built-in CUDA kernel. Available options:
 
-    - "auto": Use vLLM's built-in CUDA kernel (default; no behavior change)
-    - "flashinfer_cutedsl": Use FlashInfer's CuTe-DSL nvfp4_quantize kernel
-
-    "flashinfer_cutedsl" requires a Blackwell (SM100+) device and a FlashInfer
-    build exposing the CuTe-DSL nvfp4_quantize backend; it is only honored by the
-    FlashInfer NVFP4 linear kernels.
+    - "auto": Use FlashInfer's CuTe-DSL nvfp4_quantize when available (Blackwell
+      SM100+ with a CuTe-DSL FlashInfer build), else the built-in CUDA kernel
+      (default)
+    - "cuda": Always use the built-in CUDA kernel
+    - "flashinfer_cutedsl": Force the CuTe-DSL kernel; errors at setup if it is
+      unavailable
     """
 
     @field_validator("moe_backend", mode="before")

--- a/vllm/config/kernel.py
+++ b/vllm/config/kernel.py
@@ -161,6 +161,11 @@ LinearBackend = Literal[
     "xpu_woq",
 ]
 
+NvFp4InputQuantBackend = Literal[
+    "auto",
+    "flashinfer_cutedsl",
+]
+
 
 @config
 class KernelConfig:
@@ -234,6 +239,18 @@ class KernelConfig:
     - "xpu_woq": Use XPU kernels for weight-only quantization (e.g. W8A16)
     """
 
+    nvfp4_input_quant_backend: NvFp4InputQuantBackend = "auto"
+    """Backend for the NVFP4 activation (input) quantization used by NVFP4 dense
+    linear layers. Available options:
+
+    - "auto": Use vLLM's built-in CUDA kernel (default; no behavior change)
+    - "flashinfer_cutedsl": Use FlashInfer's CuTe-DSL nvfp4_quantize kernel
+
+    "flashinfer_cutedsl" requires a Blackwell (SM100+) device and a FlashInfer
+    build exposing the CuTe-DSL nvfp4_quantize backend; it is only honored by the
+    FlashInfer NVFP4 linear kernels.
+    """
+
     @field_validator("moe_backend", mode="before")
     @classmethod
     def _normalize_moe_backend(cls, value: Any) -> Any:
@@ -244,6 +261,13 @@ class KernelConfig:
     @field_validator("linear_backend", mode="before")
     @classmethod
     def _normalize_linear_backend(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            return value.lower().replace("-", "_")
+        return value
+
+    @field_validator("nvfp4_input_quant_backend", mode="before")
+    @classmethod
+    def _normalize_nvfp4_input_quant_backend(cls, value: Any) -> Any:
         if isinstance(value, str):
             return value.lower().replace("-", "_")
         return value

--- a/vllm/model_executor/kernels/linear/nvfp4/base.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/base.py
@@ -3,15 +3,17 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import Literal
 
 import torch
 
 from vllm.model_executor.layers.quantization.utils.quant_utils import QuantKey
 from vllm.utils.flashinfer import has_flashinfer_cutedsl_nvfp4_quant
 
-if TYPE_CHECKING:
-    from vllm.config.kernel import NvFp4InputQuantBackend
+# Backend actually used by a kernel after resolving KernelConfig.
+# nvfp4_input_quant_backend; the config's "cuda" opt-out resolves to "auto"
+# (the built-in CUDA path), so a resolved value is only ever one of these.
+ResolvedNvFp4InputQuantBackend = Literal["auto", "flashinfer_cutedsl"]
 
 
 @dataclass
@@ -41,7 +43,7 @@ class NvFp4LinearKernel(ABC):
 
     # Resolved per instance in __init__; the class-level default keeps
     # input_quant_key() safe on instances probed without running __init__.
-    input_quant_backend: "NvFp4InputQuantBackend" = "auto"
+    input_quant_backend: ResolvedNvFp4InputQuantBackend = "auto"
 
     def __init__(self, config: NvFp4LinearLayerConfig) -> None:
         assert self.can_implement(config)[0]
@@ -49,19 +51,28 @@ class NvFp4LinearKernel(ABC):
         self.config = config
         self.input_quant_backend = self._resolve_input_quant_backend()
 
-    def _resolve_input_quant_backend(self) -> "NvFp4InputQuantBackend":
+    def _resolve_input_quant_backend(self) -> ResolvedNvFp4InputQuantBackend:
         """Resolve once at setup which backend performs this kernel's activation
-        quant, so apply_weights only reads a plain attribute."""
+        quant, so apply_weights only reads a plain attribute. "auto" defaults to
+        the FlashInfer CuTe-DSL quant where this kernel supports it and it is
+        available, else the built-in CUDA kernel; "cuda" forces the CUDA kernel;
+        "flashinfer_cutedsl" forces CuTe-DSL and errors if it is unavailable."""
         from vllm.config import get_current_vllm_config_or_none
 
         config = get_current_vllm_config_or_none()
         if config is None:
             return "auto"
         backend = config.kernel_config.nvfp4_input_quant_backend
-        if backend != "flashinfer_cutedsl":
-            return backend
-        # An explicit backend request that cannot be honored is an error, matching
-        # how linear_backend rejects unsatisfiable selections.
+        if backend == "cuda":
+            return "auto"
+        if backend == "auto":
+            use_cutedsl = (
+                self.uses_flashinfer_input_quant
+                and has_flashinfer_cutedsl_nvfp4_quant()
+            )
+            return "flashinfer_cutedsl" if use_cutedsl else "auto"
+        # Explicit flashinfer_cutedsl request that cannot be honored is an error,
+        # matching how linear_backend rejects unsatisfiable selections.
         if not self.uses_flashinfer_input_quant:
             raise ValueError(
                 f"nvfp4_input_quant_backend=flashinfer_cutedsl was requested but "
@@ -75,7 +86,7 @@ class NvFp4LinearKernel(ABC):
                 "FlashInfer build with CuTe-DSL available "
                 "(flashinfer.cute_dsl.is_cute_dsl_available())."
             )
-        return backend
+        return "flashinfer_cutedsl"
 
     def input_quant_key(self) -> QuantKey | None:
         """Return the input quantization key supported by this kernel. If the kernel

--- a/vllm/model_executor/kernels/linear/nvfp4/base.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/base.py
@@ -3,11 +3,15 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import torch
 
 from vllm.model_executor.layers.quantization.utils.quant_utils import QuantKey
 from vllm.utils.flashinfer import has_flashinfer_cutedsl_nvfp4_quant
+
+if TYPE_CHECKING:
+    from vllm.config.kernel import NvFp4InputQuantBackend
 
 
 @dataclass
@@ -37,26 +41,25 @@ class NvFp4LinearKernel(ABC):
 
     # Resolved per instance in __init__; the class-level default keeps
     # input_quant_key() safe on instances probed without running __init__.
-    use_flashinfer_cutedsl_input_quant: bool = False
+    input_quant_backend: "NvFp4InputQuantBackend" = "auto"
 
     def __init__(self, config: NvFp4LinearLayerConfig) -> None:
         assert self.can_implement(config)[0]
         assert self.is_supported()[0]
         self.config = config
-        self.use_flashinfer_cutedsl_input_quant = (
-            self._resolve_use_flashinfer_cutedsl_input_quant()
-        )
+        self.input_quant_backend = self._resolve_input_quant_backend()
 
-    def _resolve_use_flashinfer_cutedsl_input_quant(self) -> bool:
-        """Resolve once at setup whether this kernel's activation quant uses
-        FlashInfer CuTe-DSL, so apply_weights only reads a plain attribute."""
+    def _resolve_input_quant_backend(self) -> "NvFp4InputQuantBackend":
+        """Resolve once at setup which backend performs this kernel's activation
+        quant, so apply_weights only reads a plain attribute."""
         from vllm.config import get_current_vllm_config_or_none
 
         config = get_current_vllm_config_or_none()
         if config is None:
-            return False
-        if config.kernel_config.nvfp4_input_quant_backend != "flashinfer_cutedsl":
-            return False
+            return "auto"
+        backend = config.kernel_config.nvfp4_input_quant_backend
+        if backend != "flashinfer_cutedsl":
+            return backend
         # An explicit backend request that cannot be honored is an error, matching
         # how linear_backend rejects unsatisfiable selections.
         if not self.uses_flashinfer_input_quant:
@@ -72,7 +75,7 @@ class NvFp4LinearKernel(ABC):
                 "FlashInfer build with CuTe-DSL available "
                 "(flashinfer.cute_dsl.is_cute_dsl_available())."
             )
-        return True
+        return backend
 
     def input_quant_key(self) -> QuantKey | None:
         """Return the input quantization key supported by this kernel. If the kernel

--- a/vllm/model_executor/kernels/linear/nvfp4/base.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/base.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 import torch
 
 from vllm.model_executor.layers.quantization.utils.quant_utils import QuantKey
+from vllm.utils.flashinfer import has_flashinfer_cutedsl_nvfp4_quant
 
 
 @dataclass
@@ -30,10 +31,48 @@ class NvFp4LinearKernel(ABC):
     match for the current hardware.
     """
 
+    # Subclasses that route their NVFP4 activation quantization through
+    # FlashInfer (see ``KernelConfig.nvfp4_input_quant_backend``) set this to True.
+    uses_flashinfer_input_quant: bool = False
+
+    # Resolved per instance in __init__; the class-level default keeps
+    # input_quant_key() safe on instances probed without running __init__.
+    use_flashinfer_cutedsl_input_quant: bool = False
+
     def __init__(self, config: NvFp4LinearLayerConfig) -> None:
         assert self.can_implement(config)[0]
         assert self.is_supported()[0]
         self.config = config
+        self.use_flashinfer_cutedsl_input_quant = (
+            self._resolve_use_flashinfer_cutedsl_input_quant()
+        )
+
+    def _resolve_use_flashinfer_cutedsl_input_quant(self) -> bool:
+        """Resolve once at setup whether this kernel's activation quant uses
+        FlashInfer CuTe-DSL, so apply_weights only reads a plain attribute."""
+        from vllm.config import get_current_vllm_config_or_none
+
+        config = get_current_vllm_config_or_none()
+        if config is None:
+            return False
+        if config.kernel_config.nvfp4_input_quant_backend != "flashinfer_cutedsl":
+            return False
+        # An explicit backend request that cannot be honored is an error, matching
+        # how linear_backend rejects unsatisfiable selections.
+        if not self.uses_flashinfer_input_quant:
+            raise ValueError(
+                f"nvfp4_input_quant_backend=flashinfer_cutedsl was requested but "
+                f"{type(self).__name__} does not route activation quant through "
+                f"FlashInfer. Select a FlashInfer NVFP4 linear backend (e.g. "
+                f"flashinfer_cutlass) or set nvfp4_input_quant_backend=auto."
+            )
+        if not has_flashinfer_cutedsl_nvfp4_quant():
+            raise ValueError(
+                "nvfp4_input_quant_backend=flashinfer_cutedsl requires SM100+ and a "
+                "FlashInfer build with CuTe-DSL available "
+                "(flashinfer.cute_dsl.is_cute_dsl_available())."
+            )
+        return True
 
     def input_quant_key(self) -> QuantKey | None:
         """Return the input quantization key supported by this kernel. If the kernel

--- a/vllm/model_executor/kernels/linear/nvfp4/cutlass.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/cutlass.py
@@ -57,7 +57,7 @@ class CutlassNvFp4LinearKernel(NvFp4LinearKernel):
             x,
             layer.input_global_scale_inv,
             is_sf_swizzled_layout=True,
-            backend="cutlass",
+            gemm_backend="cutlass",
             padded_n=x.shape[-1] + weights_padding_bytes * 2,
         )
 

--- a/vllm/model_executor/kernels/linear/nvfp4/fbgemm.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/fbgemm.py
@@ -50,7 +50,7 @@ class FbgemmNvFp4LinearKernel(NvFp4LinearKernel):
             x,
             layer.input_global_scale_inv,
             is_sf_swizzled_layout=True,
-            backend="fbgemm",
+            gemm_backend="fbgemm",
         )
 
         out = torch.ops.fbgemm.f4f4bf16(

--- a/vllm/model_executor/kernels/linear/nvfp4/flashinfer.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/flashinfer.py
@@ -77,8 +77,8 @@ class FlashInferCuteDslNvFp4LinearKernel(_FlashInferNvFp4LinearKernel):
             x,
             layer.input_global_scale_inv,
             is_sf_swizzled_layout=True,
-            backend="flashinfer-cutedsl",
-            flashinfer_cutedsl=self.use_flashinfer_cutedsl_input_quant,
+            gemm_backend="flashinfer-cutedsl",
+            quant_backend=self.input_quant_backend,
         )
 
         x_fp4 = pad_nvfp4_activation_for_cutlass(
@@ -110,7 +110,7 @@ class FlashInferCutlassNvFp4LinearKernel(_FlashInferNvFp4LinearKernel):
         activation quant), except under FlashInfer CuTe-DSL: producers quantize
         with the C++ kernel, so a pre-quantized input would bypass the selected
         backend. Returning None keeps the quant in apply_weights."""
-        if self.use_flashinfer_cutedsl_input_quant:
+        if self.input_quant_backend != "auto":
             return None
         return kNvfp4Dynamic
 
@@ -167,9 +167,9 @@ class FlashInferCutlassNvFp4LinearKernel(_FlashInferNvFp4LinearKernel):
                 x,
                 layer.input_global_scale_inv,
                 is_sf_swizzled_layout=True,
-                backend="flashinfer-cutlass",
+                gemm_backend="flashinfer-cutlass",
                 padded_n=x.shape[-1] + weights_padding_bytes * 2,
-                flashinfer_cutedsl=self.use_flashinfer_cutedsl_input_quant,
+                quant_backend=self.input_quant_backend,
             )
 
         out = flashinfer_scaled_fp4_mm(
@@ -236,8 +236,8 @@ class FlashInferTrtllmNvFp4LinearKernel(_FlashInferNvFp4LinearKernel):
             x,
             layer.input_global_scale_inv,
             is_sf_swizzled_layout=True,
-            backend="flashinfer-trtllm",
-            flashinfer_cutedsl=self.use_flashinfer_cutedsl_input_quant,
+            gemm_backend="flashinfer-trtllm",
+            quant_backend=self.input_quant_backend,
         )
 
         out = flashinfer_scaled_fp4_mm(
@@ -298,9 +298,9 @@ class FlashInferCudnnNvFp4LinearKernel(_FlashInferNvFp4LinearKernel):
             x,
             layer.input_global_scale_inv,
             is_sf_swizzled_layout=True,
-            backend="flashinfer-cudnn",
+            gemm_backend="flashinfer-cudnn",
             padded_n=x.shape[-1] + weights_padding_bytes * 2,
-            flashinfer_cutedsl=self.use_flashinfer_cutedsl_input_quant,
+            quant_backend=self.input_quant_backend,
         )
 
         out = flashinfer_scaled_fp4_mm(
@@ -363,8 +363,8 @@ class FlashInferB12xNvFp4LinearKernel(_FlashInferNvFp4LinearKernel):
             x,
             layer.input_global_scale_inv,
             is_sf_swizzled_layout=True,
-            backend="b12x",
-            flashinfer_cutedsl=self.use_flashinfer_cutedsl_input_quant,
+            gemm_backend="b12x",
+            quant_backend=self.input_quant_backend,
         )
 
         x_fp4 = pad_nvfp4_activation_for_cutlass(

--- a/vllm/model_executor/kernels/linear/nvfp4/flashinfer.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/flashinfer.py
@@ -28,7 +28,14 @@ from vllm.utils.flashinfer import (
 from .base import NvFp4LinearKernel, NvFp4LinearLayerConfig
 
 
-class FlashInferCuteDslNvFp4LinearKernel(NvFp4LinearKernel):
+class _FlashInferNvFp4LinearKernel(NvFp4LinearKernel):
+    """Base for NVFP4 linear kernels that can route activation quant through
+    FlashInfer (see ``KernelConfig.nvfp4_input_quant_backend``)."""
+
+    uses_flashinfer_input_quant = True
+
+
+class FlashInferCuteDslNvFp4LinearKernel(_FlashInferNvFp4LinearKernel):
     """NVFP4 GEMM via FlashInfer's cutedsl backend."""
 
     @classmethod
@@ -71,6 +78,7 @@ class FlashInferCuteDslNvFp4LinearKernel(NvFp4LinearKernel):
             layer.input_global_scale_inv,
             is_sf_swizzled_layout=True,
             backend="flashinfer-cutedsl",
+            flashinfer_cutedsl=self.use_flashinfer_cutedsl_input_quant,
         )
 
         x_fp4 = pad_nvfp4_activation_for_cutlass(
@@ -94,12 +102,16 @@ class FlashInferCuteDslNvFp4LinearKernel(NvFp4LinearKernel):
         return out.view(*output_shape)
 
 
-class FlashInferCutlassNvFp4LinearKernel(NvFp4LinearKernel):
+class FlashInferCutlassNvFp4LinearKernel(_FlashInferNvFp4LinearKernel):
     """NVFP4 GEMM via FlashInfer's CUTLASS wrapper."""
 
     def input_quant_key(self) -> QuantKey | None:
-        """This kernel supports dynamic quantization of the input. By
-        convention, pre-quantized blockscales must use the swizzled layout."""
+        """Advertise dynamic input pre-quantization (lets producers fuse the
+        activation quant), except under FlashInfer CuTe-DSL: producers quantize
+        with the C++ kernel, so a pre-quantized input would bypass the selected
+        backend. Returning None keeps the quant in apply_weights."""
+        if self.use_flashinfer_cutedsl_input_quant:
+            return None
         return kNvfp4Dynamic
 
     @classmethod
@@ -157,6 +169,7 @@ class FlashInferCutlassNvFp4LinearKernel(NvFp4LinearKernel):
                 is_sf_swizzled_layout=True,
                 backend="flashinfer-cutlass",
                 padded_n=x.shape[-1] + weights_padding_bytes * 2,
+                flashinfer_cutedsl=self.use_flashinfer_cutedsl_input_quant,
             )
 
         out = flashinfer_scaled_fp4_mm(
@@ -176,7 +189,7 @@ class FlashInferCutlassNvFp4LinearKernel(NvFp4LinearKernel):
         return out.view(*output_shape)
 
 
-class FlashInferTrtllmNvFp4LinearKernel(NvFp4LinearKernel):
+class FlashInferTrtllmNvFp4LinearKernel(_FlashInferNvFp4LinearKernel):
     """NVFP4 GEMM via FlashInfer's TensorRT-LLM wrapper."""
 
     @classmethod
@@ -224,6 +237,7 @@ class FlashInferTrtllmNvFp4LinearKernel(NvFp4LinearKernel):
             layer.input_global_scale_inv,
             is_sf_swizzled_layout=True,
             backend="flashinfer-trtllm",
+            flashinfer_cutedsl=self.use_flashinfer_cutedsl_input_quant,
         )
 
         out = flashinfer_scaled_fp4_mm(
@@ -243,7 +257,7 @@ class FlashInferTrtllmNvFp4LinearKernel(NvFp4LinearKernel):
         return out.view(*output_shape)
 
 
-class FlashInferCudnnNvFp4LinearKernel(NvFp4LinearKernel):
+class FlashInferCudnnNvFp4LinearKernel(_FlashInferNvFp4LinearKernel):
     """NVFP4 GEMM via FlashInfer's cuDNN wrapper."""
 
     @classmethod
@@ -286,6 +300,7 @@ class FlashInferCudnnNvFp4LinearKernel(NvFp4LinearKernel):
             is_sf_swizzled_layout=True,
             backend="flashinfer-cudnn",
             padded_n=x.shape[-1] + weights_padding_bytes * 2,
+            flashinfer_cutedsl=self.use_flashinfer_cutedsl_input_quant,
         )
 
         out = flashinfer_scaled_fp4_mm(
@@ -305,7 +320,7 @@ class FlashInferCudnnNvFp4LinearKernel(NvFp4LinearKernel):
         return out.view(*output_shape)
 
 
-class FlashInferB12xNvFp4LinearKernel(NvFp4LinearKernel):
+class FlashInferB12xNvFp4LinearKernel(_FlashInferNvFp4LinearKernel):
     """NVFP4 GEMM via FlashInfer's b12x CuTe DSL warp-level MMA kernel (SM120+)."""
 
     @classmethod
@@ -349,6 +364,7 @@ class FlashInferB12xNvFp4LinearKernel(NvFp4LinearKernel):
             layer.input_global_scale_inv,
             is_sf_swizzled_layout=True,
             backend="b12x",
+            flashinfer_cutedsl=self.use_flashinfer_cutedsl_input_quant,
         )
 
         x_fp4 = pad_nvfp4_activation_for_cutlass(

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -343,6 +343,29 @@ def has_flashinfer_b12x_moe() -> bool:
 
 
 @functools.cache
+def has_flashinfer_cutedsl_nvfp4_quant() -> bool:
+    """Return ``True`` if FlashInfer's CuTe-DSL ``nvfp4_quantize`` backend is
+    usable (Blackwell SM100+).
+
+    ``nvfp4_quantize`` is exposed even without CuTe-DSL, so this also checks
+    ``flashinfer.cute_dsl.is_cute_dsl_available()`` to avoid a runtime failure on
+    the first ``backend="cute-dsl"`` call.
+    """
+    if not has_flashinfer() or not current_platform.has_device_capability(100):
+        return False
+    mod = _get_submodule("flashinfer")
+    if mod is None or not hasattr(mod, "nvfp4_quantize"):
+        return False
+    cute_dsl = _get_submodule("flashinfer.cute_dsl")
+    if cute_dsl is None or not hasattr(cute_dsl, "is_cute_dsl_available"):
+        return False
+    try:
+        return bool(cute_dsl.is_cute_dsl_available())
+    except Exception:
+        return False
+
+
+@functools.cache
 def has_nvidia_artifactory() -> bool:
     """Return `True` if NVIDIA's artifactory is accessible.
 
@@ -704,6 +727,54 @@ if has_flashinfer():
         )
 
     @torch.library.custom_op(
+        "vllm::flashinfer_cutedsl_nvfp4_quantize",
+        mutates_args=[],
+        device_types="cuda",
+    )
+    def flashinfer_cutedsl_nvfp4_quantize(
+        a: torch.Tensor, a_global_sf: torch.Tensor, sf_layout: str
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # CuTe-DSL NVFP4 quant; sf_layout is "128x4", "8x4", or "linear".
+        from flashinfer import SfLayout
+        from flashinfer import nvfp4_quantize as nvfp4_quantize_
+
+        layouts = {
+            "128x4": SfLayout.layout_128x4,
+            "8x4": SfLayout.layout_8x4,
+            "linear": SfLayout.layout_linear,
+        }
+        return nvfp4_quantize_(
+            a,
+            a_global_sf,
+            sfLayout=layouts[sf_layout],
+            do_shuffle=False,
+            backend="cute-dsl",
+        )
+
+    @torch.library.register_fake(
+        "vllm::flashinfer_cutedsl_nvfp4_quantize",
+    )
+    def flashinfer_cutedsl_nvfp4_quantize_fake(
+        a: torch.Tensor, a_global_sf: torch.Tensor, sf_layout: str
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        m, n = a.shape
+        round_up = lambda x, y: (x + y - 1) // y * y
+        scale_n = n // 16
+        if sf_layout == "linear":
+            # Linear: row-major [m, n // 16] scale, no swizzle padding.
+            scale = torch.empty(m, scale_n, dtype=torch.uint8, device=a.device)
+        else:
+            # 128x4 / 8x4 swizzled: pad rows to the tile and cols to 4.
+            row_tile = 8 if sf_layout == "8x4" else 128
+            scale = torch.empty(
+                round_up(m, row_tile),
+                round_up(scale_n, 4),
+                dtype=torch.uint8,
+                device=a.device,
+            )
+        return torch.empty(m, n // 2, dtype=torch.uint8, device=a.device), scale
+
+    @torch.library.custom_op(
         "vllm::mm_mxfp8",
         mutates_args=[],
         device_types="cuda",
@@ -1046,6 +1117,7 @@ __all__ = [
     "has_flashinfer_cutedsl_moe_nvfp4",
     "has_flashinfer_b12x_moe",
     "has_flashinfer_b12x_gemm",
+    "has_flashinfer_cutedsl_nvfp4_quant",
     "has_flashinfer_fp8_blockscale_gemm",
     "has_nvidia_artifactory",
     "supports_trtllm_attention",


### PR DESCRIPTION
## Purpose

Adds a FlashInfer CuTe-DSL backend for NVFP4 activation quantization and makes it the preferred backend when available.

The default `auto` setting selects FlashInfer CuTe-DSL for FlashInfer NVFP4 linear kernels on Blackwell when the required FlashInfer support is available. It falls back to vLLM's built-in CUDA kernel otherwise. Non-FlashInfer NVFP4 linear kernels continue to use the built-in kernel.

The change:

- Supports linear, 128x4, and TRTLLM small-M 8x4 scale layouts.
- Adds `cuda` as an explicit opt-out that always selects the built-in kernel.
- Allows `flashinfer_cutedsl` to force CuTe-DSL and report an error during setup when it is unavailable.
- Validates hardware and FlashInfer CuTe-DSL availability during kernel setup.
- Handles padded outputs.
- Prevents fused input pre-quantization from bypassing the selected backend.
- Extends correctness tests and the NVFP4 quantization benchmark.

## Test Plan

```bash
pre-commit run --all-files

python -m pytest -v \
  tests/kernels/quantization/test_nvfp4_quant.py \
  tests/kernels/quantization/test_nvfp4_quant_backend.py

python -m pytest -v \
  tests/models/quantization/test_nvfp4.py \
  -k input_quant_backend_cutedsl

python benchmarks/kernels/benchmark_nvfp4_quant.py \
  --tp-sizes 1 4 8
```

## Test Result

All results in this section are collected on an NVIDIA GB200 system (SM100 Blackwell).

The NVFP4 kernel correctness and backend-routing tests pass with FlashInfer CuTe-DSL enabled.

### Kernel microbenchmark

The benchmark uses BF16 inputs and CUDA graph timing. It covers the Llama 3.3 70B linear shapes at tensor-parallel sizes 1, 4, and 8. Speedup is the baseline latency divided by the FlashInfer CuTe-DSL latency.

For the linear and 128x4 layouts, the baseline is vLLM's built-in kernel. For the TRTLLM 8x4 layout, the baseline is the existing FlashInfer CUDA production path.

| Shape | Linear geometric mean speedup | Linear wins | 128x4 geometric mean speedup | 128x4 wins | 8x4 geometric mean speedup |
|---|---:|---:|---:|---:|---:|
| `K=1024, N=8192` | 1.270x | 11/11 | 1.863x | 11/11 | 1.184x |
| `K=2048, N=8192` | 1.156x | 11/11 | 1.711x | 11/11 | 1.157x |
| `K=3584, N=8192` | 1.024x | 7/11 | 1.506x | 11/11 | 1.167x |
| `K=7168, N=8192` | 1.057x | 9/11 | 1.436x | 9/11 | 1.249x |
| `K=8192, N=1280` | 1.097x | 9/11 | 1.495x | 9/11 | 1.254x |
| `K=8192, N=2560` | 1.098x | 9/11 | 1.490x | 9/11 | 1.254x |
| `K=8192, N=7168` | 1.103x | 9/11 | 1.494x | 9/11 | 1.251x |
| `K=8192, N=8192` | 1.102x | 9/11 | 1.493x | 9/11 | 1.250x |
| `K=8192, N=10240` | 1.207x | 9/11 | 1.629x | 11/11 | 1.252x |
| `K=8192, N=14336` | 1.103x | 9/11 | 1.487x | 9/11 | 1.256x |
| `K=8192, N=57344` | 1.098x | 9/11 | 1.493x | 9/11 | 1.235x |
| `K=28672, N=8192` | 1.049x | 8/11 | 1.092x | 8/11 | 1.174x |
| **All shapes** | **1.112x** | **109/132** | **1.505x** | **115/132** | **1.223x** |

CuTe-DSL wins all 60 measured TRTLLM 8x4 points.

The linear and 128x4 regressions primarily occur at large `M`. The largest measured regressions are:

- Linear, `K=8192, N=57344, M=4096`: 9.094 us to 11.619 us
- 128x4, `K=28672, N=8192, M=2048`: 24.675 us to 27.860 us

<details>
<summary>Full linear and 128x4 results</summary>

All values are latency in us.

| K | N | M | vLLM linear | CuTe-DSL linear | vLLM 128x4 | CuTe-DSL 128x4 |
|---:|---:|---:|---:|---:|---:|---:|
| 1024 | 8192 | 1 | 1.106 | 0.910 | 2.004 | 0.959 |
| 1024 | 8192 | 16 | 1.183 | 1.122 | 2.010 | 1.194 |
| 1024 | 8192 | 32 | 1.179 | 1.107 | 2.010 | 1.190 |
| 1024 | 8192 | 64 | 1.214 | 1.107 | 2.028 | 1.214 |
| 1024 | 8192 | 128 | 1.237 | 1.178 | 2.125 | 1.265 |
| 1024 | 8192 | 256 | 1.300 | 1.184 | 2.253 | 1.277 |
| 1024 | 8192 | 512 | 1.400 | 1.191 | 2.282 | 1.297 |
| 1024 | 8192 | 1024 | 1.746 | 1.253 | 2.819 | 1.337 |
| 1024 | 8192 | 2048 | 2.396 | 1.557 | 3.593 | 1.713 |
| 1024 | 8192 | 4096 | 3.565 | 2.087 | 4.825 | 2.374 |
| 1024 | 8192 | 8192 | 6.007 | 3.234 | 7.486 | 3.709 |
| 2048 | 8192 | 1 | 1.108 | 0.921 | 2.086 | 0.967 |
| 2048 | 8192 | 16 | 1.182 | 1.107 | 2.010 | 1.207 |
| 2048 | 8192 | 32 | 1.188 | 1.105 | 2.034 | 1.217 |
| 2048 | 8192 | 64 | 1.214 | 1.189 | 2.069 | 1.212 |
| 2048 | 8192 | 128 | 1.246 | 1.176 | 2.260 | 1.318 |
| 2048 | 8192 | 256 | 1.331 | 1.203 | 2.281 | 1.327 |
| 2048 | 8192 | 512 | 1.463 | 1.237 | 2.488 | 1.347 |
| 2048 | 8192 | 1024 | 1.911 | 1.568 | 3.094 | 1.733 |
| 2048 | 8192 | 2048 | 2.670 | 2.099 | 3.982 | 2.373 |
| 2048 | 8192 | 4096 | 4.027 | 3.250 | 5.516 | 3.716 |
| 2048 | 8192 | 8192 | 6.686 | 5.094 | 8.744 | 5.888 |
| 3584 | 8192 | 1 | 1.168 | 1.088 | 2.072 | 1.139 |
| 3584 | 8192 | 16 | 1.234 | 1.231 | 2.105 | 1.229 |
| 3584 | 8192 | 32 | 1.242 | 1.282 | 2.084 | 1.243 |
| 3584 | 8192 | 64 | 1.256 | 1.300 | 2.144 | 1.239 |
| 3584 | 8192 | 128 | 1.294 | 1.308 | 2.279 | 1.374 |
| 3584 | 8192 | 256 | 1.455 | 1.377 | 2.552 | 1.361 |
| 3584 | 8192 | 512 | 1.697 | 1.641 | 2.798 | 1.695 |
| 3584 | 8192 | 1024 | 2.189 | 1.929 | 3.406 | 2.429 |
| 3584 | 8192 | 2048 | 2.956 | 2.879 | 4.456 | 3.686 |
| 3584 | 8192 | 4096 | 4.933 | 4.607 | 6.587 | 5.807 |
| 3584 | 8192 | 8192 | 8.547 | 8.929 | 10.712 | 10.559 |
| 7168 | 8192 | 1 | 1.297 | 1.219 | 2.276 | 1.244 |
| 7168 | 8192 | 16 | 1.375 | 1.291 | 2.448 | 1.261 |
| 7168 | 8192 | 32 | 1.382 | 1.304 | 2.319 | 1.265 |
| 7168 | 8192 | 64 | 1.409 | 1.307 | 2.457 | 1.270 |
| 7168 | 8192 | 128 | 1.463 | 1.371 | 2.537 | 1.495 |
| 7168 | 8192 | 256 | 1.709 | 1.648 | 2.815 | 1.799 |
| 7168 | 8192 | 512 | 2.323 | 1.931 | 3.249 | 2.449 |
| 7168 | 8192 | 1024 | 3.357 | 2.874 | 4.414 | 3.683 |
| 7168 | 8192 | 2048 | 4.790 | 4.601 | 6.222 | 5.812 |
| 7168 | 8192 | 4096 | 8.241 | 8.859 | 10.118 | 10.601 |
| 7168 | 8192 | 8192 | 23.049 | 24.500 | 24.428 | 24.740 |
| 8192 | 1280 | 1 | 1.297 | 1.107 | 2.379 | 1.209 |
| 8192 | 1280 | 16 | 1.381 | 1.177 | 2.454 | 1.257 |
| 8192 | 1280 | 32 | 1.389 | 1.173 | 2.451 | 1.264 |
| 8192 | 1280 | 64 | 1.409 | 1.198 | 2.446 | 1.268 |
| 8192 | 1280 | 128 | 1.481 | 1.238 | 2.543 | 1.444 |
| 8192 | 1280 | 256 | 1.778 | 1.561 | 2.883 | 1.787 |
| 8192 | 1280 | 512 | 2.528 | 2.092 | 3.428 | 2.385 |
| 8192 | 1280 | 1024 | 3.655 | 3.242 | 4.700 | 3.680 |
| 8192 | 1280 | 2048 | 5.246 | 5.107 | 6.694 | 5.891 |
| 8192 | 1280 | 4096 | 9.291 | 11.476 | 11.376 | 11.462 |
| 8192 | 1280 | 8192 | 25.651 | 27.307 | 27.061 | 27.504 |
| 8192 | 2560 | 1 | 1.299 | 1.101 | 2.389 | 1.209 |
| 8192 | 2560 | 16 | 1.382 | 1.181 | 2.444 | 1.245 |
| 8192 | 2560 | 32 | 1.389 | 1.173 | 2.458 | 1.263 |
| 8192 | 2560 | 64 | 1.411 | 1.191 | 2.446 | 1.278 |
| 8192 | 2560 | 128 | 1.484 | 1.244 | 2.534 | 1.444 |
| 8192 | 2560 | 256 | 1.784 | 1.560 | 2.889 | 1.783 |
| 8192 | 2560 | 512 | 2.531 | 2.091 | 3.430 | 2.374 |
| 8192 | 2560 | 1024 | 3.663 | 3.250 | 4.703 | 3.670 |
| 8192 | 2560 | 2048 | 5.233 | 5.095 | 6.879 | 6.248 |
| 8192 | 2560 | 4096 | 9.072 | 11.417 | 11.101 | 11.465 |
| 8192 | 2560 | 8192 | 25.763 | 27.084 | 27.180 | 27.452 |
| 8192 | 7168 | 1 | 1.296 | 1.085 | 2.385 | 1.204 |
| 8192 | 7168 | 16 | 1.381 | 1.183 | 2.450 | 1.251 |
| 8192 | 7168 | 32 | 1.392 | 1.184 | 2.454 | 1.270 |
| 8192 | 7168 | 64 | 1.412 | 1.203 | 2.448 | 1.272 |
| 8192 | 7168 | 128 | 1.482 | 1.253 | 2.537 | 1.447 |
| 8192 | 7168 | 256 | 1.783 | 1.558 | 2.887 | 1.786 |
| 8192 | 7168 | 512 | 2.535 | 2.089 | 3.428 | 2.383 |
| 8192 | 7168 | 1024 | 3.659 | 3.251 | 4.698 | 3.683 |
| 8192 | 7168 | 2048 | 5.244 | 5.111 | 6.694 | 5.916 |
| 8192 | 7168 | 4096 | 9.294 | 10.874 | 11.306 | 11.445 |
| 8192 | 7168 | 8192 | 25.649 | 27.290 | 27.078 | 27.498 |
| 8192 | 8192 | 1 | 1.296 | 1.102 | 2.385 | 1.210 |
| 8192 | 8192 | 16 | 1.380 | 1.182 | 2.441 | 1.249 |
| 8192 | 8192 | 32 | 1.391 | 1.179 | 2.459 | 1.275 |
| 8192 | 8192 | 64 | 1.412 | 1.192 | 2.445 | 1.272 |
| 8192 | 8192 | 128 | 1.481 | 1.237 | 2.539 | 1.443 |
| 8192 | 8192 | 256 | 1.780 | 1.563 | 2.885 | 1.787 |
| 8192 | 8192 | 512 | 2.532 | 2.098 | 3.430 | 2.376 |
| 8192 | 8192 | 1024 | 3.660 | 3.255 | 4.697 | 3.666 |
| 8192 | 8192 | 2048 | 5.243 | 5.104 | 6.694 | 5.903 |
| 8192 | 8192 | 4096 | 9.106 | 10.820 | 11.096 | 11.381 |
| 8192 | 8192 | 8192 | 25.753 | 27.093 | 27.173 | 27.452 |
| 8192 | 10240 | 1 | 1.507 | 1.098 | 2.384 | 1.211 |
| 8192 | 10240 | 16 | 1.588 | 1.186 | 2.868 | 1.258 |
| 8192 | 10240 | 32 | 1.599 | 1.179 | 2.871 | 1.274 |
| 8192 | 10240 | 64 | 1.620 | 1.204 | 2.871 | 1.278 |
| 8192 | 10240 | 128 | 1.692 | 1.273 | 2.955 | 1.450 |
| 8192 | 10240 | 256 | 1.992 | 1.557 | 2.886 | 1.787 |
| 8192 | 10240 | 512 | 2.743 | 2.114 | 3.856 | 2.383 |
| 8192 | 10240 | 1024 | 3.879 | 3.265 | 5.127 | 3.695 |
| 8192 | 10240 | 2048 | 5.471 | 5.075 | 7.136 | 5.820 |
| 8192 | 10240 | 4096 | 9.350 | 10.803 | 11.627 | 11.372 |
| 8192 | 10240 | 8192 | 26.140 | 27.087 | 27.950 | 27.458 |
| 8192 | 14336 | 1 | 1.296 | 1.090 | 2.383 | 1.222 |
| 8192 | 14336 | 16 | 1.380 | 1.192 | 2.446 | 1.262 |
| 8192 | 14336 | 32 | 1.391 | 1.180 | 2.458 | 1.277 |
| 8192 | 14336 | 64 | 1.413 | 1.192 | 2.446 | 1.274 |
| 8192 | 14336 | 128 | 1.481 | 1.246 | 2.540 | 1.449 |
| 8192 | 14336 | 256 | 1.785 | 1.561 | 2.887 | 1.789 |
| 8192 | 14336 | 512 | 2.532 | 2.097 | 3.431 | 2.380 |
| 8192 | 14336 | 1024 | 3.664 | 3.239 | 4.702 | 3.667 |
| 8192 | 14336 | 2048 | 5.243 | 5.108 | 6.694 | 5.904 |
| 8192 | 14336 | 4096 | 9.094 | 10.812 | 11.074 | 11.553 |
| 8192 | 14336 | 8192 | 25.747 | 27.073 | 27.183 | 27.446 |
| 8192 | 57344 | 1 | 1.300 | 1.086 | 2.386 | 1.201 |
| 8192 | 57344 | 16 | 1.379 | 1.180 | 2.450 | 1.262 |
| 8192 | 57344 | 32 | 1.389 | 1.172 | 2.455 | 1.269 |
| 8192 | 57344 | 64 | 1.411 | 1.199 | 2.441 | 1.272 |
| 8192 | 57344 | 128 | 1.482 | 1.238 | 2.537 | 1.449 |
| 8192 | 57344 | 256 | 1.781 | 1.561 | 2.882 | 1.788 |
| 8192 | 57344 | 512 | 2.535 | 2.097 | 3.438 | 2.375 |
| 8192 | 57344 | 1024 | 3.656 | 3.231 | 4.703 | 3.672 |
| 8192 | 57344 | 2048 | 5.237 | 5.107 | 6.696 | 5.907 |
| 8192 | 57344 | 4096 | 9.094 | 11.619 | 11.099 | 11.366 |
| 8192 | 57344 | 8192 | 25.754 | 27.081 | 27.188 | 27.451 |
| 28672 | 8192 | 1 | 1.326 | 1.243 | 3.133 | 2.379 |
| 28672 | 8192 | 16 | 1.416 | 1.307 | 3.132 | 2.655 |
| 28672 | 8192 | 32 | 1.480 | 1.383 | 3.197 | 2.833 |
| 28672 | 8192 | 64 | 1.698 | 1.650 | 3.411 | 2.975 |
| 28672 | 8192 | 128 | 2.399 | 1.936 | 3.305 | 3.111 |
| 28672 | 8192 | 256 | 3.549 | 2.893 | 4.576 | 4.000 |
| 28672 | 8192 | 512 | 5.514 | 4.598 | 6.828 | 5.633 |
| 28672 | 8192 | 1024 | 8.986 | 8.732 | 10.791 | 10.102 |
| 28672 | 8192 | 2048 | 23.434 | 27.837 | 24.675 | 27.860 |
| 28672 | 8192 | 4096 | 44.547 | 48.064 | 46.590 | 47.717 |
| 28672 | 8192 | 8192 | 86.808 | 95.797 | 90.676 | 94.242 |

</details>

<details>
<summary>Full TRTLLM 8x4 results</summary>

All values are latency in us.

| K | N | M | FlashInfer CUDA 8x4 | FlashInfer CuTe-DSL 8x4 |
|---:|---:|---:|---:|---:|
| 1024 | 8192 | 1 | 1.250 | 0.938 |
| 1024 | 8192 | 4 | 1.126 | 0.981 |
| 1024 | 8192 | 8 | 1.220 | 1.104 |
| 1024 | 8192 | 16 | 1.301 | 1.114 |
| 1024 | 8192 | 32 | 1.307 | 1.110 |
| 2048 | 8192 | 1 | 1.264 | 0.940 |
| 2048 | 8192 | 4 | 1.137 | 1.099 |
| 2048 | 8192 | 8 | 1.226 | 1.131 |
| 2048 | 8192 | 16 | 1.316 | 1.131 |
| 2048 | 8192 | 32 | 1.328 | 1.125 |
| 3584 | 8192 | 1 | 1.308 | 1.067 |
| 3584 | 8192 | 4 | 1.306 | 1.148 |
| 3584 | 8192 | 8 | 1.304 | 1.147 |
| 3584 | 8192 | 16 | 1.378 | 1.150 |
| 3584 | 8192 | 32 | 1.379 | 1.211 |
| 7168 | 8192 | 1 | 1.388 | 1.137 |
| 7168 | 8192 | 4 | 1.520 | 1.119 |
| 7168 | 8192 | 8 | 1.470 | 1.120 |
| 7168 | 8192 | 16 | 1.392 | 1.189 |
| 7168 | 8192 | 32 | 1.427 | 1.198 |
| 8192 | 1280 | 1 | 1.386 | 1.107 |
| 8192 | 1280 | 4 | 1.394 | 1.113 |
| 8192 | 1280 | 8 | 1.401 | 1.130 |
| 8192 | 1280 | 16 | 1.494 | 1.186 |
| 8192 | 1280 | 32 | 1.507 | 1.193 |
| 8192 | 2560 | 1 | 1.357 | 1.113 |
| 8192 | 2560 | 4 | 1.418 | 1.121 |
| 8192 | 2560 | 8 | 1.421 | 1.116 |
| 8192 | 2560 | 16 | 1.489 | 1.187 |
| 8192 | 2560 | 32 | 1.497 | 1.191 |
| 8192 | 7168 | 1 | 1.402 | 1.109 |
| 8192 | 7168 | 4 | 1.414 | 1.125 |
| 8192 | 7168 | 8 | 1.425 | 1.134 |
| 8192 | 7168 | 16 | 1.461 | 1.194 |
| 8192 | 7168 | 32 | 1.500 | 1.194 |
| 8192 | 8192 | 1 | 1.385 | 1.115 |
| 8192 | 8192 | 4 | 1.387 | 1.120 |
| 8192 | 8192 | 8 | 1.408 | 1.118 |
| 8192 | 8192 | 16 | 1.484 | 1.188 |
| 8192 | 8192 | 32 | 1.500 | 1.190 |
| 8192 | 10240 | 1 | 1.456 | 1.117 |
| 8192 | 10240 | 4 | 1.391 | 1.134 |
| 8192 | 10240 | 8 | 1.395 | 1.132 |
| 8192 | 10240 | 16 | 1.476 | 1.190 |
| 8192 | 10240 | 32 | 1.501 | 1.190 |
| 8192 | 14336 | 1 | 1.380 | 1.116 |
| 8192 | 14336 | 4 | 1.427 | 1.112 |
| 8192 | 14336 | 8 | 1.405 | 1.112 |
| 8192 | 14336 | 16 | 1.470 | 1.189 |
| 8192 | 14336 | 32 | 1.505 | 1.194 |
| 8192 | 57344 | 1 | 1.366 | 1.114 |
| 8192 | 57344 | 4 | 1.435 | 1.121 |
| 8192 | 57344 | 8 | 1.407 | 1.186 |
| 8192 | 57344 | 16 | 1.459 | 1.192 |
| 8192 | 57344 | 32 | 1.504 | 1.194 |
| 28672 | 8192 | 1 | 2.768 | 2.254 |
| 28672 | 8192 | 4 | 2.858 | 2.337 |
| 28672 | 8192 | 8 | 2.871 | 2.429 |
| 28672 | 8192 | 16 | 2.796 | 2.493 |
| 28672 | 8192 | 32 | 2.833 | 2.526 |

</details>

### End-to-end latency

Base configuration: `nvidia/Llama-3.1-8B-Instruct-NVFP4`, batch size 1, input/output lengths 10/1000, full model architecture with dummy weights.

Results:

- Built-in CUDA baseline: 2195.31 ms mean, 1.11 ms standard deviation
- FlashInfer CuTe-DSL: 2124.54 ms mean, 5.96 ms standard deviation
- Paired speedup: `1.0333x +/- 0.0017` (95% confidence interval)
- CuTe-DSL is reliably 3.33% faster

On GB200, the default `nvfp4_input_quant_backend=auto` selects the FlashInfer CuTe-DSL configuration. The built-in baseline corresponds to `nvfp4_input_quant_backend=cuda`.

<details>
<summary>Full end-to-end benchmark configuration</summary>

- `max_model_len=2048`
- GPU memory utilization: 0.9
- `enforce_eager=False`
- Temperature/top-p: 1.0/1.0
- EOS ignored and detokenization disabled
- Seed: 0
- Eight interleaved paired rounds
- Five warmups and 20 timed `generate()` calls per configuration per round
- Each configuration runs in a separate subprocess
- Execution order alternates between rounds
- Per-round medians are compared using the baseline/CuTe-DSL ratio and a 95% confidence interval

</details>

---
<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR is documented.
- [x] The test commands and benchmark methodology are provided.
- [x] Correctness and performance results are provided.
- [x] Documentation updates are considered; none are required for this kernel configuration option.

</details>