### PR TITLE
[Bugfix][Backport v0.24] Bump FlashInfer to 0.6.14

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -792,7 +792,7 @@ RUN --mount=type=cache,target=/opt/uv/cache \
 # Install FlashInfer JIT cache (requires CUDA-version-specific index URL)
 # https://docs.flashinfer.ai/installation.html
 # From versions.json: .flashinfer.version
-ARG FLASHINFER_VERSION=0.6.12
+ARG FLASHINFER_VERSION=0.6.14
 RUN --mount=type=cache,target=/opt/uv/cache \
     uv pip install --system flashinfer-jit-cache==${FLASHINFER_VERSION} \
         --index-url https://flashinfer.ai/whl/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d '.')

--- a/docker/versions.json
+++ b/docker/versions.json
@@ -68,7 +68,7 @@
       "default": "true"
     },
     "FLASHINFER_VERSION": {
-      "default": "0.6.12"
+      "default": "0.6.14"
     },
     "GDRCOPY_CUDA_VERSION": {
       "default": "12.8"

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -9,8 +9,11 @@ torchaudio==2.11.0
 # These must be updated alongside torch
 torchvision==0.26.0 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
 # FlashInfer should be updated together with the Dockerfile
-flashinfer-python==0.6.12
-flashinfer-cubin==0.6.12
+# flashinfer-cubin is not on PyPI since 0.6.14; setup.py excludes it from
+# install_requires so the published wheel does not carry an unresolvable pin
+--extra-index-url https://flashinfer.ai/whl/
+flashinfer-python==0.6.14
+flashinfer-cubin==0.6.14
 apache-tvm-ffi==0.1.9
 tilelang==0.1.9
 nvidia-cudnn-frontend>=1.19.1

--- a/setup.py
+++ b/setup.py
@@ -1074,6 +1074,11 @@ def get_requirements() -> list[str]:
                 # vllm-flash-attn is built only for CUDA 12.x.
                 # Skip for other versions.
                 continue
+            if "flashinfer-cubin" in req:
+                # Not on PyPI since 0.6.14 (only https://flashinfer.ai/whl), so
+                # it cannot be a wheel dependency; flashinfer falls back to
+                # fetching cubins at runtime when the package is absent.
+                continue
             if "nvidia-cutlass-dsl[cu13]" in req and cuda_major == "12":
                 # [cu13] extra is the default; strip it on CUDA 12 builds.
                 req = req.replace("nvidia-cutlass-dsl[cu13]", "nvidia-cutlass-dsl")


### PR DESCRIPTION
## Purpose

Backport the FlashInfer 0.6.14 dependency and packaging changes from #47669
to the `releases/v0.24.0` branch.

v0.24.0 pins FlashInfer 0.6.12. On Blackwell, that version's
`gated_delta_net_chunked` prefill kernel can remain resident forever when a
state-bearing prefill has at least five rows and any row length is not aligned
to 128 tokens. The resulting signature is 100% reported GPU utilization with
near-zero memory traffic and low power, while EngineCore stops making progress
and the API process remains healthy. This is the Blackwell/GDN cohort tracked
in #37729.

Malformed or truncated video input can make the incident appear video-specific:
loading fewer frames changes the multimodal prompt length and can produce a
tile-misaligned remainder row. The OpenCV warning is therefore a plausible
trigger, not the deadlocked component.

FlashInfer fixed the kernel in
[flashinfer#3581](https://github.com/flashinfer-ai/flashinfer/pull/3581) and
[flashinfer#3536](https://github.com/flashinfer-ai/flashinfer/pull/3536), first
released in 0.6.14.

## Changes

- Pin `flashinfer-python`, `flashinfer-cubin`, and the Docker JIT cache to
  0.6.14.
- Add the FlashInfer wheel index needed to resolve `flashinfer-cubin`.
- Exclude `flashinfer-cubin` from published wheel metadata because it is not on
  PyPI; FlashInfer downloads cubins at runtime when that package is absent.

## Duplicate-work check

This does not duplicate an open PR against `releases/v0.24.0`; searches for
`FlashInfer`, `0.6.14`, and `37729` found no release-branch backport. #47669
already fixed `main`, while this PR is limited to the still-vulnerable v0.24.0
release line. The open #46342 targets unrelated structured-output handling on
`main` and does not update FlashInfer.

## Test plan and results

- `uv pip install --dry-run --python ... --python-platform
  x86_64-manylinux_2_31 --python-version 3.12 --torch-backend cu130 -r
  requirements/cuda.txt`
  - Passed: resolved 188 packages, including `flashinfer-python==0.6.14` and
    `flashinfer-cubin==0.6.14`.
- `SKIP=update-dockerfile-graph .venv/bin/pre-commit run`
  - Passed all applicable hooks, including Ruff, typos, pip-compile, mypy,
    SPDX, and Dockerfile/version consistency.
  - The Docker dependency-graph hook was skipped after its amd64-only helper
    image failed to return the generated PNG on this arm64 host.
- `git diff --cached --check`
  - Passed.

The GPU hang regression was not rerun locally because this host has no NVIDIA
GPU. The kernel fix and version boundary were validated upstream, and this
backports the dependency change already merged in #47669.

## AI assistance

Codex was used for diagnosis, backport implementation, validation, and drafting
this PR. The human submitter must review every changed line and be able to
understand and defend the change end to end before marking this ready.
