### PR TITLE
[UX] DCP Topology Validation

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1256,27 +1256,33 @@ class ModelConfig:
         decode_context_parallel_size = parallel_config.decode_context_parallel_size
         if decode_context_parallel_size > 1 and not self.use_mla:
             total_num_kv_heads = self.get_total_num_kv_heads()
-            assert tensor_parallel_size > total_num_kv_heads, (
-                f"tensor parallel size {tensor_parallel_size} must be greater "
-                f"than total num kv heads {total_num_kv_heads} when enable "
-                f"decode context parallel for GQA/MQA"
-            )
+            if tensor_parallel_size <= total_num_kv_heads:
+                raise ValueError(
+                    "Decode context parallelism for GQA/MQA requires "
+                    f"`--tensor-parallel-size` ({tensor_parallel_size}) to be "
+                    "greater than the model's total number of KV heads "
+                    f"({total_num_kv_heads}). Increase `--tensor-parallel-size` "
+                    "or set `--decode-context-parallel-size 1`."
+                )
 
             max_dcp_size = tensor_parallel_size // total_num_kv_heads
-            assert decode_context_parallel_size <= max_dcp_size, (
-                f"decode context parallel size must less than or equal to "
-                f"(tensor parallel size {tensor_parallel_size} // total "
-                f"num kv heads {total_num_kv_heads}) = {max_dcp_size}, "
-                f"but got {decode_context_parallel_size}"
-            )
+            if decode_context_parallel_size > max_dcp_size:
+                raise ValueError(
+                    f"`--decode-context-parallel-size` "
+                    f"({decode_context_parallel_size}) must be at most "
+                    f"`--tensor-parallel-size` ({tensor_parallel_size}) divided "
+                    "by the model's total number of KV heads "
+                    f"({total_num_kv_heads}), which is {max_dcp_size}."
+                )
 
             num_q_per_kv = total_num_attention_heads // total_num_kv_heads
-            assert num_q_per_kv % decode_context_parallel_size == 0, (
-                f"Total number of q per kv attn heads ({num_q_per_kv})"
-                " must be divisible by dcp world size when enable "
-                "decode context parallel for GQA "
-                f"({parallel_config.decode_context_parallel_size})."
-            )
+            if num_q_per_kv % decode_context_parallel_size != 0:
+                raise ValueError(
+                    "The model's number of query heads per KV head "
+                    f"({num_q_per_kv}) must be divisible by "
+                    "`--decode-context-parallel-size` "
+                    f"({decode_context_parallel_size}) for GQA/MQA."
+                )
 
         # torch_shm uses a single IPC queue to rank 0; DP>1 is
         # incompatible because API servers can't know which

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1268,11 +1268,11 @@ class ModelConfig:
             max_dcp_size = tensor_parallel_size // total_num_kv_heads
             if decode_context_parallel_size > max_dcp_size:
                 raise ValueError(
-                    f"`--decode-context-parallel-size` "
-                    f"({decode_context_parallel_size}) must be at most "
-                    f"`--tensor-parallel-size` ({tensor_parallel_size}) divided "
-                    "by the model's total number of KV heads "
-                    f"({total_num_kv_heads}), which is {max_dcp_size}."
+                    "`--decode-context-parallel-size` "
+                    f"({decode_context_parallel_size}) exceeds the maximum "
+                    f"supported value ({max_dcp_size}) for "
+                    f"`--tensor-parallel-size` ({tensor_parallel_size}) and "
+                    f"{total_num_kv_heads} model KV heads."
                 )
 
             num_q_per_kv = total_num_attention_heads // total_num_kv_heads


### PR DESCRIPTION
## Purpose

`ModelConfig.verify_with_parallel_config()` validates three model-specific decode-context-parallel constraints for non-MLA GQA/MQA models with `assert`. Invalid user-provided `--tensor-parallel-size` and `--decode-context-parallel-size` combinations therefore raise `AssertionError`, and the validation disappears entirely under `python -O`, allowing invalid topologies into engine initialization. This replaces only those assertions with actionable `ValueError`s that identify the relevant flags and model head counts.

## Reproducer

```python
import warnings
from types import SimpleNamespace

warnings.filterwarnings("ignore", message="Can't initialize NVML")

from vllm.config import ModelConfig, ParallelConfig


CASES = {
    "insufficient_tp": (16, 8, 2, 2),
    "dcp_exceeds_max": (16, 2, 4, 4),
    "uneven_query_heads": (6, 2, 6, 2),
}


def main() -> None:
    print(f"optimized={not __debug__}")
    for name, (query_heads, kv_heads, tp_size, dcp_size) in CASES.items():
        model_config = SimpleNamespace(
            model_arch_config=SimpleNamespace(
                total_num_attention_heads=query_heads,
            ),
            use_mla=False,
            multimodal_config=None,
            get_total_num_kv_heads=lambda kv_heads=kv_heads: kv_heads,
        )
        parallel_config = ParallelConfig(
            tensor_parallel_size=tp_size,
            decode_context_parallel_size=dcp_size,
        )

        try:
            ModelConfig.verify_with_parallel_config(model_config, parallel_config)
        except Exception as exc:
            print(f"{name}: {type(exc).__name__}: {exc}")
        else:
            print(f"{name}: invalid topology accepted")


if __name__ == "__main__":
    main()
```

```bash
VLLM_LOGGING_LEVEL=ERROR .venv/bin/python repro.py
VLLM_LOGGING_LEVEL=ERROR .venv/bin/python -O repro.py
```

## Output on main

```text
optimized=False
insufficient_tp: AssertionError: tensor parallel size 2 must be greater than total num kv heads 8 when enable decode context parallel for GQA/MQA
dcp_exceeds_max: AssertionError: decode context parallel size must less than or equal to (tensor parallel size 4 // total num kv heads 2) = 2, but got 4
uneven_query_heads: AssertionError: Total number of q per kv attn heads (3) must be divisible by dcp world size when enable decode context parallel for GQA (2).
```

```text
optimized=True
insufficient_tp: invalid topology accepted
dcp_exceeds_max: invalid topology accepted
uneven_query_heads: invalid topology accepted
```

## Output on this branch

```text
optimized=False
insufficient_tp: ValueError: Decode context parallelism for GQA/MQA requires `--tensor-parallel-size` (2) to be greater than the model's total number of KV heads (8). Increase `--tensor-parallel-size` or set `--decode-context-parallel-size 1`.
dcp_exceeds_max: ValueError: `--decode-context-parallel-size` (4) exceeds the maximum supported value (2) for `--tensor-parallel-size` (4) and 2 model KV heads.
uneven_query_heads: ValueError: The model's number of query heads per KV head (3) must be divisible by `--decode-context-parallel-size` (2) for GQA/MQA.
```

```text
optimized=True
insufficient_tp: ValueError: Decode context parallelism for GQA/MQA requires `--tensor-parallel-size` (2) to be greater than the model's total number of KV heads (8). Increase `--tensor-parallel-size` or set `--decode-context-parallel-size 1`.
dcp_exceeds_max: ValueError: `--decode-context-parallel-size` (4) exceeds the maximum supported value (2) for `--tensor-parallel-size` (4) and 2 model KV heads.
uneven_query_heads: ValueError: The model's number of query heads per KV head (3) must be divisible by `--decode-context-parallel-size` (2) for GQA/MQA.
```

## Test Plan

```bash
FLASHINFER_DISABLE_VERSION_CHECK=1 PATH="$PWD/.venv/bin:$PATH" \
  .venv/bin/python -m pytest \
  tests/test_config.py::test_async_scheduling_with_pipeline_parallelism_is_allowed -q
# 1 passed

```

## AI assistance

OpenAI Codex assisted with drafting the change and PR description. I reviewed every changed line and ran and verified the commands above.