### PR TITLE
[AMD][Bugfix] Disable MXFP4 Triton backend on gfx950

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/gpt_oss_triton_kernels_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/gpt_oss_triton_kernels_moe.py
@@ -47,15 +47,12 @@ def _triton_kernel_moe_supports_current_device() -> bool:
         # range was not validated.
         return cap is not None and (9, 0) <= (cap.major, cap.minor) < (11, 0)
     if p.is_rocm():
-        from vllm.platforms.rocm import on_gfx1x, on_gfx9, on_gfx950
+        from vllm.platforms.rocm import on_gfx1x, on_gfx9
 
         # gfx9 family: gfx90a (MI200), gfx942/gfx950 (MI3xx);
         # on_gfx9() already excludes gfx906/gfx908.
         # gfx1x family: gfx11xx (RDNA3/3.5) and gfx12xx (RDNA4);
         # on_gfx1x() excludes gfx10xx (RDNA1/RDNA2).
-        # Exclude gfx950 due to shared memory constraints in matmul_ogs kernel.
-        if on_gfx950() and triton.__version__ == "3.7.1":
-            return False
         return on_gfx9() or on_gfx1x()
     return False
 

--- a/vllm/model_executor/layers/fused_moe/experts/gpt_oss_triton_kernels_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/gpt_oss_triton_kernels_moe.py
@@ -47,12 +47,15 @@ def _triton_kernel_moe_supports_current_device() -> bool:
         # range was not validated.
         return cap is not None and (9, 0) <= (cap.major, cap.minor) < (11, 0)
     if p.is_rocm():
-        from vllm.platforms.rocm import on_gfx1x, on_gfx9
+        from vllm.platforms.rocm import on_gfx1x, on_gfx9, on_gfx950
 
         # gfx9 family: gfx90a (MI200), gfx942/gfx950 (MI3xx);
         # on_gfx9() already excludes gfx906/gfx908.
         # gfx1x family: gfx11xx (RDNA3/3.5) and gfx12xx (RDNA4);
         # on_gfx1x() excludes gfx10xx (RDNA1/RDNA2).
+        # Exclude gfx950 due to shared memory constraints in matmul_ogs kernel.
+        if on_gfx950() and triton.__version__ == "3.7.1":
+            return False
         return on_gfx9() or on_gfx1x()
     return False
 

--- a/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
@@ -72,6 +72,13 @@ def _swizzle_mxfp4(quant_tensor, scale, num_warps=8):
                 scale_layout = CDNA4MXScaleLayout
         else:
             scale_layout = StridedLayout
+        constraints = {
+            "block_m": 64,
+            "block_n": 512,
+            "block_k": 256,
+            "split_k": 1,
+        }
+        opt_flags.update_opt_flags_constraints(constraints)
     else:
         value_layout, value_layout_opts = layout.make_default_matmul_mxfp4_w_layout(
             mx_axis=1


### PR DESCRIPTION
## Purpose
ROCm will soon update to 7.14, which ships with Triton 3.7.1.

Running `gpt-oss-120b` on `gfx950` with Triton 3.7.1
```bash
vllm serve openai/gpt-oss-120b \
  --enable-expert-parallel \
  --tensor-parallel-size 4
```
results in
> triton.runtime.errors.OutOfResources: out of resource: shared memory, Required: 165888, Hardware limit: 163840. Reducing block sizes or `num_stages` may help.

This is because Triton 3.7.1 and triton_kernels 3.5.1 generate kernels that exceed the shared memory limit on `gfx950`. With this PR, an emulation backend is selected instead of Triton. Alternatively, the Aiter backend can be selected with the env var `VLLM_ROCM_USE_AITER=1`.

Resolves #49778 

## Test Plan
The below test groups are currently affected.
+ mi355_1: Entrypoints Integration (API Server Generate)
+ mi355_1: Entrypoints Integration (API Server OpenAI - Part 2)
+ mi355_2: GPQA Eval (GPT-OSS) (2xB200-2xMI355)
+ mi355_1: V1 Spec Decode

An isolated test case is
+ `pytest -v -s entrypoints/tool_parsers/test_openai_tool_parser.py::test_calculator_tool_call_and_argument_accuracy`

## Test Result
The affected tests now pass on `gfx950` with Triton 3.7.1.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
