### PR TITLE
[Bugfix][Structured Output] Stage V2 grammar bitmask copies through preallocated pinned buffers

### DIFF
--- a/tests/v1/worker/test_structured_outputs_staging.py
+++ b/tests/v1/worker/test_structured_outputs_staging.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the V2 worker's structured-output staging buffers.
+
+`StructuredOutputsWorker.apply_grammar_bitmask` runs on every decode step of
+every batch containing structured-output requests, so the host->device staging
+must not allocate per step. These tests pin down both the buffer reuse and the
+resulting bitmask/mapping values.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from vllm.utils.math_utils import cdiv
+from vllm.v1.worker.gpu.structured_outputs import StructuredOutputsWorker
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="StructuredOutputsWorker requires CUDA"
+)
+
+VOCAB_SIZE = 64
+BITMASK_WIDTH = cdiv(VOCAB_SIZE, 32)
+
+
+class _FakeInputBatch:
+    """Minimal stand-in exposing only what apply_grammar_bitmask reads."""
+
+    def __init__(self, req_ids: list[str], cu_num_logits: list[int]):
+        self.req_ids = req_ids
+        self.cu_num_logits_np = np.array(cu_num_logits, dtype=np.int32)
+
+
+def _make_worker(max_num_logits: int = 4) -> StructuredOutputsWorker:
+    return StructuredOutputsWorker(
+        max_num_logits=max_num_logits,
+        vocab_size=VOCAB_SIZE,
+        device=torch.device("cuda"),
+    )
+
+
+def test_staging_buffers_are_preallocated():
+    """Staging memory is allocated once, sized to the batch upper bound."""
+    worker = _make_worker(max_num_logits=8)
+
+    assert worker.grammar_bitmask.cpu.shape == (8, BITMASK_WIDTH)
+    assert worker.logits_indices.cpu.shape == (8,)
+    # The numpy views alias the staging tensors, so writes land in pinned memory
+    # rather than in a fresh per-step allocation.
+    assert worker.grammar_bitmask.np.base is not None
+    assert worker.logits_indices.np.base is not None
+
+
+def test_no_reallocation_across_steps():
+    """Repeated calls must reuse the same host and device buffers."""
+    worker = _make_worker(max_num_logits=4)
+    input_batch = _FakeInputBatch(req_ids=["a", "b"], cu_num_logits=[0, 1, 2])
+
+    ptrs = (
+        worker.grammar_bitmask.cpu.data_ptr(),
+        worker.grammar_bitmask.gpu.data_ptr(),
+        worker.logits_indices.cpu.data_ptr(),
+        worker.logits_indices.gpu.data_ptr(),
+    )
+
+    for step in range(4):
+        num_masks = 1 + step % 2
+        logits = torch.zeros((2, VOCAB_SIZE), dtype=torch.float32, device="cuda")
+        bitmask = np.full((num_masks, BITMASK_WIDTH), -1, dtype=np.int32)
+        worker.apply_grammar_bitmask(
+            logits, input_batch, ["a", "b"][:num_masks], bitmask
+        )
+        torch.accelerator.synchronize()
+
+        assert ptrs == (
+            worker.grammar_bitmask.cpu.data_ptr(),
+            worker.grammar_bitmask.gpu.data_ptr(),
+            worker.logits_indices.cpu.data_ptr(),
+            worker.logits_indices.gpu.data_ptr(),
+        )
+
+
+def test_apply_grammar_bitmask_masks_expected_tokens():
+    """End-to-end: the staged bitmask masks exactly the disallowed token ids."""
+    worker = _make_worker()
+    # Two requests, one logits row each.
+    input_batch = _FakeInputBatch(req_ids=["a", "b"], cu_num_logits=[0, 1, 2])
+    logits = torch.zeros((2, VOCAB_SIZE), dtype=torch.float32, device="cuda")
+
+    # Allow only token 0 for req "a" and only token 1 for req "b".
+    bitmask = np.zeros((2, BITMASK_WIDTH), dtype=np.int32)
+    bitmask[0, 0] = 1 << 0
+    bitmask[1, 0] = 1 << 1
+
+    worker.apply_grammar_bitmask(logits, input_batch, ["a", "b"], bitmask)
+    torch.accelerator.synchronize()
+
+    assert torch.isfinite(logits[0, 0])
+    assert torch.isneginf(logits[0, 1])
+    assert torch.isneginf(logits[1, 0])
+    assert torch.isfinite(logits[1, 1])
+    # Every token past the single allowed bit is masked for both rows.
+    assert torch.isneginf(logits[:, 2:]).all()
+
+
+def test_stale_staging_rows_do_not_leak_between_steps():
+    """A wide step followed by a narrow one must not reuse the stale rows."""
+    worker = _make_worker()
+    input_batch = _FakeInputBatch(req_ids=["a", "b"], cu_num_logits=[0, 1, 2])
+
+    # Step 1: two requests, everything masked.
+    logits = torch.zeros((2, VOCAB_SIZE), dtype=torch.float32, device="cuda")
+    worker.apply_grammar_bitmask(
+        logits, input_batch, ["a", "b"], np.zeros((2, BITMASK_WIDTH), dtype=np.int32)
+    )
+    torch.accelerator.synchronize()
+    assert torch.isneginf(logits).all()
+
+    # Step 2: only req "b", allowing every token in the low word.
+    logits = torch.zeros((2, VOCAB_SIZE), dtype=torch.float32, device="cuda")
+    bitmask = np.full((1, BITMASK_WIDTH), -1, dtype=np.int32)
+    worker.apply_grammar_bitmask(logits, input_batch, ["b"], bitmask)
+    torch.accelerator.synchronize()
+
+    # Row 1 (req "b") is unmasked; row 0 was not scheduled and is untouched.
+    assert torch.isfinite(logits[1]).all()
+    assert torch.isfinite(logits[0]).all()
+
+
+def test_apply_grammar_bitmask_is_noop_without_requests():
+    worker = _make_worker()
+    input_batch = _FakeInputBatch(req_ids=["a"], cu_num_logits=[0, 1])
+    logits = torch.zeros((1, VOCAB_SIZE), dtype=torch.float32, device="cuda")
+
+    worker.apply_grammar_bitmask(
+        logits, input_batch, [], np.zeros((0, BITMASK_WIDTH), dtype=np.int32)
+    )
+    torch.accelerator.synchronize()
+    assert torch.isfinite(logits).all()

--- a/vllm/v1/worker/gpu/structured_outputs.py
+++ b/vllm/v1/worker/gpu/structured_outputs.py
@@ -5,17 +5,21 @@ import torch
 
 from vllm.triton_utils import tl, triton
 from vllm.utils.math_utils import cdiv
-from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
+from vllm.v1.utils import CpuGpuBuffer
 from vllm.v1.worker.gpu.input_batch import InputBatch
 
 
 class StructuredOutputsWorker:
     def __init__(self, max_num_logits: int, vocab_size: int, device: torch.device):
-        self.logits_indices = torch.zeros(
+        # Persistent host staging buffers paired with their device tensors.
+        # Both copies below run on every decode step of every batch that
+        # contains structured-output requests, so the staging memory is
+        # allocated once here rather than per step.
+        self.logits_indices = CpuGpuBuffer(
             max_num_logits, dtype=torch.int32, device=device
         )
-        self.grammar_bitmask = torch.zeros(
-            (max_num_logits, cdiv(vocab_size, 32)), dtype=torch.int32, device=device
+        self.grammar_bitmask = CpuGpuBuffer(
+            max_num_logits, cdiv(vocab_size, 32), dtype=torch.int32, device=device
         )
         self.device = device
         self.copy_stream = torch.cuda.Stream()
@@ -30,11 +34,11 @@ class StructuredOutputsWorker:
         if not grammar_req_ids:
             return
 
-        # Asynchronously copy the bitmask to GPU.
+        # Stage the bitmask into pinned memory, then copy it asynchronously.
+        num_masks = grammar_bitmask.shape[0]
+        self.grammar_bitmask.np[:num_masks] = grammar_bitmask
         with torch.cuda.stream(self.copy_stream):
-            bitmask = async_copy_to_gpu(
-                grammar_bitmask, out=self.grammar_bitmask[: grammar_bitmask.shape[0]]
-            )
+            bitmask = self.grammar_bitmask.copy_to_gpu(num_masks)
 
         # Construct bitmask -> logits mapping
         mapping: list[int] = []
@@ -47,21 +51,17 @@ class StructuredOutputsWorker:
             logits_end_idx = cu_num_logits[req_idx + 1]
             mapping.extend(range(logits_start_idx, logits_end_idx))
 
-        # Asynchronously copy the mapping to GPU.
+        # Stage the mapping into pinned memory, then copy it asynchronously.
+        num_logits = len(mapping)
+        self.logits_indices.np[:num_logits] = mapping
         with torch.cuda.stream(self.copy_stream):
-            logits_indices = torch.tensor(
-                mapping, dtype=torch.int32, device="cpu", pin_memory=True
-            )
-            logits_indices = self.logits_indices[: len(mapping)].copy_(
-                logits_indices, non_blocking=True
-            )
+            logits_indices = self.logits_indices.copy_to_gpu(num_logits)
 
         # Ensure all async copies are complete before launching the kernel.
         current_stream = torch.cuda.current_stream()
         current_stream.wait_stream(self.copy_stream)
 
-        num_masks = bitmask.shape[0]
-        assert num_masks == len(mapping)
+        assert num_masks == num_logits
         vocab_size = logits.shape[-1]
         BLOCK_SIZE = 8192
         grid = (num_masks, triton.cdiv(vocab_size, BLOCK_SIZE))


### PR DESCRIPTION
## Purpose

`StructuredOutputsWorker.apply_grammar_bitmask` (V2 runner) allocates pinned host memory **twice on every decode step** of every batch that contains structured-output requests:

- `async_copy_to_gpu(grammar_bitmask, ...)` calls `x.pin_memory()`. `grammar_bitmask` is a fresh `np.ndarray` built by the scheduler each step, so the `# pin_memory() is no-op if the memory is already pinned` assumption never holds on this path — it is a real allocation plus copy per step.
- the bitmask → logits mapping is materialized with `torch.tensor(mapping, ..., pin_memory=True)`.

Allocating pinned memory serializes on the CUDA driver's host allocator, so under concurrency the cost lands on the engine loop rather than the GPU (GPU sits mostly idle while inter-token latency inflates).

This is the **V2-runner counterpart** of the regression reported in #49013 and bisected there to #45424. The two open PRs for that issue (#49150, #49168) only change `vllm/v1/structured_output/utils.py`, i.e. the V1 path, so dense models — which move V1 → V2 across that version window — are not covered by either.

Note also that on this path the `pin_memory()` call reinstates exactly what #37006 (*"[V1] Remove pin_memory() in async_copy_to_gpu to fix sporadic stalls"*, merged) had deliberately removed, together with its comment:

```python
# Copy directly to GPU — explicit pin_memory() causes sporadic stalls
# under high concurrency due to CUDA driver contention. The driver
# handles the transfer efficiently without manual pinning.
```

## Changes

Stage both copies through `CpuGpuBuffer`s sized to `max_num_logits`, allocated once in `__init__`. This keeps #45424's property that the source of an async h2d copy is pinned, while removing the per-step allocation. `CpuGpuBuffer` is already used the same way elsewhere in the V2 worker (e.g. `model_states/mamba_hybrid.py`).

Buffer reuse follows the same pattern as the rest of the V2 input pipeline: host writes for step N+1 are ordered after step N's copies by the existing sampler synchronization, and only the rows in use (`[:num_masks]`, `[:num_logits]`) are written and copied.

## Test Result

Measured on 1×B300, `google/gemma-4-12B-it`, 172-core host with a 12-CPU cgroup quota, 80 requests at concurrency 8, every request guided-JSON (xgrammar), identical args otherwise:

| build | guided p50 | decode throughput |
|---|---|---|
| v0.25.1 | 7.49 s | 115 tok/s |
| v0.25.1 + this patch | **1.07 s** | **740 tok/s** |
| v0.25.1 + this patch (2nd run, warm) | 1.06 s | 806 tok/s |

Guided decoding returns to parity with unguided on the same build (1.07 s vs 1.11 s p50). Unguided throughput is unchanged, as expected — `apply_grammar_bitmask` returns early on `if not grammar_req_ids`.

Verified by mounting the patched file into an otherwise unmodified `vllm/vllm-openai:v0.25.1` container, so the only delta is this diff.

Added `tests/v1/worker/test_structured_outputs_staging.py` covering: staging buffers are preallocated at the batch upper bound, host/device pointers are stable across steps, the staged bitmask masks exactly the disallowed token ids, stale rows from a wider previous step do not leak, and the no-request path is a no-op.

## Related

- #49013 — the umbrella perf issue (V1 path bisect)
- #49150, #49168 — V1-path fixes; this PR is complementary, not overlapping
- #45424 — the commit that introduced the per-step pinning
- #37006 — the earlier fix this silently reverted on the V2 path
