### PR TITLE
[Docs] Fix confusing docstring indentation in nemotron_h.py

### DIFF
--- a/vllm/model_executor/models/nemotron_h.py
+++ b/vllm/model_executor/models/nemotron_h.py
@@ -771,8 +771,7 @@ class NemotronHForCausalLM(
             Tuple containing:
             - conv_state_shape: Shape for convolutional state cache
             - temporal_state_shape: Shape for state space model cache
-            - (when use_replayssm is enabled) the x_cache/dt_cache/B_cache
-              ring-buffer shapes
+            - x_cache/dt_cache/B_cache ring-buffer shapes (use_replayssm only)
         """
         parallel_config = vllm_config.parallel_config
         cache_config = vllm_config.cache_config


### PR DESCRIPTION
## Purpose

Follow-up to #48018, requested by @hmellor: a docstring it added fails the docs build on main.

```
WARNING -  griffe: vllm/model_executor/models/nemotron_h.py:775: Confusing indentation for continuation line 11 in docstring, should be 4 * 2 = 8 spaces, not 6
```

The wrapped bullet sat at 6 spaces, between griffe's item indent (4) and continuation indent (8). `.readthedocs.yaml` sets `fail_on_warning: true`, so that single warning aborts the build (RTD 33746915 on `866fea2b9`). This collapses the bullet onto one line. Docstring text only.

No other PR addresses this warning, and main still carries the line as of `318b527cc`.

## Test Plan

```bash
uv venv --python 3.12 .venv-docs
uv pip install --python .venv-docs/bin/python -r requirements/docs.txt
.venv-docs/bin/python -m mkdocs build --strict --config-file mkdocs.yaml
pre-commit run --files vllm/model_executor/models/nemotron_h.py
```

The mkdocs invocation is the one RTD runs, against the same pinned `requirements/docs.txt`.

## Test Result

The strict build aborts on main and passes with this change. pre-commit is clean.

No model evaluation applies: docstring text only.

Could a maintainer add the `build-docs` label? `docs/pre_run_check.sh` skips RTD builds on PRs without it. cc @hmellor @tomeras91
