### PR TITLE
[Doc] Add compile cache volume example to the Docker deployment page

### DIFF
--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -8,6 +8,26 @@ toc_depth: 2
 
 --8<-- "docs/getting_started/installation/gpu.md:pre-built-images"
 
+## Persist the compile cache across containers
+
+Mounting the Hugging Face cache keeps model weights across containers, but each
+new container still starts with an empty `VLLM_CACHE_ROOT` (default
+`~/.cache/vllm`) and recompiles the model's `torch.compile` artifacts. Mount a
+named volume at that path to reuse the inductor, Triton, and AOT artifacts from
+the second container onward:
+
+```bash
+docker run --rm --gpus all \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    -v vllm-cache:/root/.cache/vllm \
+    -p 8000:8000 \
+    vllm/vllm-openai:latest \
+    meta-llama/Llama-3.1-8B-Instruct
+```
+
+See [Faster Startup](../configuration/optimization.md#faster-startup) for the
+mechanism and for what invalidates the cache.
+
 ## Run as a non-root user
 
 The CUDA `vllm/vllm-openai` image runs as root by default for backward


### PR DESCRIPTION
## Purpose

The Docker page shows how to persist the Hugging Face cache across containers but has no example for the compile cache, so a fresh container recompiles the model's `torch.compile` artifacts even when the weights are mounted. The mechanism is already documented in [Faster Startup](https://docs.vllm.ai/en/latest/configuration/optimization.html#faster-startup) (#47374): `VLLM_CACHE_ROOT` can be persisted or baked into an image. This adds the concrete docker recipe next to the existing Hugging Face cache example: one named volume at `~/.cache/vllm`.

Motivating measurement, single A10 with Qwen/Qwen3-0.6B on an image built from the 2026-07-23 nightly (upstream `dd72658e7`) with unrelated local patches, n=1 per arm: a fresh container whose `/root/.cache/vllm/torch_compile_cache` volume was already populated reached `/v1/models` in about 48s, versus about 79s with that directory empty, so roughly 31s (about 40% of the boot) came from reusing the inductor, Triton, and AOT artifacts. Model weights sat on a shared warm Hugging Face cache volume in both arms, so this is compile-cache reuse only. The two boots ran back to back, so the warm arm read artifacts still in host page cache. The documented example mounts the whole cache root, a superset of what was measured. The saving applies from the second container onward; the first container with the volume pays the normal compile cost and populates it.

## Test Plan

Docs-only change. Checked that the relative link target `docs/configuration/optimization.md` and its `Faster Startup` anchor exist on main.

## Test Result

N/A (docs render via the readthedocs preview).
