### PR TITLE
[Bugfix] Give DeepGEMM power-of-two FP32 scale factors for UE8M0 packing

### DIFF
--- a/tests/kernels/moe/test_deepgemm.py
+++ b/tests/kernels/moe/test_deepgemm.py
@@ -395,3 +395,80 @@ def test_deepgemm_fp4_vs_triton(
             f"DeepGEMM FP4 path was not executed during the test. "
             f"Call counter: {call_counter['cnt']}"
         )
+
+
+@pytest.mark.skipif(not is_deep_gemm_supported(), reason="Requires deep_gemm kernels")
+def test_deepgemm_moe_permute_pads_scales_with_valid_ue8m0():
+    """Every row of the permuted FP32 scale buffer must be UE8M0-castable.
+
+    DeepGEMM converts FP32 scale factors to UE8M0 by keeping only the exponent
+    bits, and asserts that the sign and mantissa are zero. It runs that
+    conversion over the whole alignment-padded MN range, so the padding rows
+    ep_scatter never writes have to satisfy the precondition too.
+    """
+    from vllm.model_executor.layers.fused_moe.deep_gemm_utils import (
+        compute_aligned_M_and_alignment,
+        deepgemm_moe_permute,
+    )
+    from vllm.utils.deep_gemm import get_mk_alignment_for_contiguous_layout
+
+    device = "cuda"
+    num_tokens, topk, local_num_experts = 5, 2, 8
+    block_m, block_k = get_mk_alignment_for_contiguous_layout()
+    hidden = block_k * 2
+    sf_k = hidden // block_k
+
+    m_sum, _ = compute_aligned_M_and_alignment(
+        M=num_tokens,
+        num_topk=topk,
+        local_num_experts=local_num_experts,
+        alignment=block_m,
+        expert_tokens_meta=None,
+    )
+    # Only a handful of the m_sum rows carry a token; the rest are padding.
+    assert m_sum > num_tokens * topk
+
+    aq = torch.empty((num_tokens, hidden), device=device, dtype=torch.float8_e4m3fn)
+    aq_scale = torch.full((num_tokens, sf_k), 0.5, device=device)
+    topk_ids = torch.randint(
+        0, local_num_experts, (num_tokens, topk), device=device, dtype=torch.int32
+    )
+
+    def permute():
+        return deepgemm_moe_permute(
+            aq=aq,
+            aq_scale=aq_scale,
+            topk_ids=topk_ids,
+            local_num_experts=local_num_experts,
+            expert_map=None,
+            expert_tokens_meta=None,
+        )
+
+    # Poison the exact block the scale buffer lands in, then release the whole
+    # result set so the identical second call replays the same allocation
+    # sequence over dirty memory. Without this the buffer can come from a
+    # freshly mapped, already-zeroed segment and hide a missing initialization.
+    # The result is kept as a tuple and deleted whole on purpose: binding the
+    # other tensors to names would hold them past the poison and change the
+    # allocation sequence that the second call replays.
+    first = permute()
+    poisoned_ptr = first[1].data_ptr()
+    first[1].fill_(float("nan"))
+    del first
+
+    _, aq_scale_out, _, _, _ = permute()
+
+    # The poison only guards the assertion below if the allocator actually
+    # handed the same block back. Skip rather than pass vacuously when it does
+    # not, e.g. under PYTORCH_NO_CUDA_MEMORY_CACHING or expandable_segments.
+    if aq_scale_out.data_ptr() != poisoned_ptr:
+        pytest.skip("caching allocator did not reuse the poisoned scale block")
+
+    assert aq_scale_out.dtype == torch.float32
+    # Sign bit plus mantissa is zero for an exact positive power of two, and
+    # for 0.0, which packs to a valid UE8M0 code.
+    bad = (aq_scale_out.contiguous().view(torch.int32) & 0x807FFFFF) != 0
+    assert not bad.any(), (
+        f"{int(bad.sum())} of {bad.numel()} scale entries are not UE8M0-castable; "
+        "DeepGEMM's packing kernel asserts on these"
+    )

--- a/vllm/model_executor/layers/fused_moe/deep_gemm_utils.py
+++ b/vllm/model_executor/layers/fused_moe/deep_gemm_utils.py
@@ -505,7 +505,13 @@ def deepgemm_moe_permute(
             dtype=torch.int32,
         )
     else:
-        aq_scale_out = torch.empty((M_sum, sf_k), device=device, dtype=torch.float32)
+        # ep_scatter only writes rows that receive a token, so the per-expert
+        # alignment padding keeps whatever the allocation started with.
+        # DeepGEMM converts FP32 scale factors to UE8M0 by keeping only the
+        # exponent bits and asserts that the sign and mantissa are zero, and
+        # it runs that conversion over the whole padded MN range. Zero is a
+        # valid UE8M0 code, so zero-fill rather than leave padding undefined.
+        aq_scale_out = torch.zeros((M_sum, sf_k), device=device, dtype=torch.float32)
 
     # DeepGEMM uses negative values in m_indices (here expert_ids) to mark
     # completely invalid / padded blocks that should be skipped. We always

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/batched.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/batched.py
@@ -102,7 +102,10 @@ class BatchedPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
                 num_local_experts, self.max_num_tokens, hidden_dim
             )
 
-            b_a1_scale = torch.empty(scale_shape, dtype=torch.float32, device=a1.device)
+            # Experts with no tokens are skipped below and every expert's rows
+            # past its token count stay unwritten, so this has to start out
+            # UE8M0-castable for the same reason b_a1 is zeroed above.
+            b_a1_scale = torch.zeros(scale_shape, dtype=torch.float32, device=a1.device)
         else:
             assert quant_config.a1_scale is None
             b_a1_scale = None

--- a/vllm/model_executor/warmup/deep_gemm_warmup.py
+++ b/vllm/model_executor/warmup/deep_gemm_warmup.py
@@ -234,7 +234,9 @@ def _deepgemm_fp8_gemm_nt_warmup(
 
     device = w.device
     a1q = torch.empty((max_tokens, k), device=device, dtype=torch.float8_e4m3fn)
-    a1q_scales = torch.empty(
+    # Dummy scales must be exact powers of two: DeepGEMM's UE8M0 conversion
+    # keeps only the exponent bits and asserts the sign and mantissa are zero.
+    a1q_scales = torch.ones(
         (max_tokens, k // block_m), device=device, dtype=torch.float32
     )
     out = torch.empty((max_tokens, n), device=device, dtype=torch.bfloat16)
@@ -336,7 +338,10 @@ def _deepgemm_grouped_fp8_gemm_nt_contiguous_warmup(
     def _warmup(w: torch.Tensor, w_scale: torch.Tensor):
         _, n, k = w.size()
         a1q = torch.empty((MAX_M, k), device=device, dtype=torch.float8_e4m3fn)
-        a1q_scales = torch.empty(
+        # Dummy scales must be exact powers of two: DeepGEMM's UE8M0
+        # conversion keeps only the exponent bits and asserts the sign and
+        # mantissa are zero.
+        a1q_scales = torch.ones(
             (MAX_M, k // block_m), device=device, dtype=torch.float32
         )
         out = torch.empty((MAX_M, n), device=device, dtype=torch.bfloat16)

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -3,6 +3,15 @@
 """Compatibility wrapper for DeepGEMM API changes.
 
 Users of vLLM should always import **only** these wrappers.
+
+Scale-factor contract: the entry points below pass
+``disable_ue8m0_cast=not is_deep_gemm_e8m0_used()``. When that cast is enabled,
+DeepGEMM converts FP32 scale factors to UE8M0 by keeping only each value's
+exponent bits and asserts that the sign and mantissa are zero, so every FP32
+scale tensor handed to them must hold exact positive powers of two (or 0.0)
+across its whole extent. That includes alignment padding rows which a scatter
+or quantization kernel never writes, because the layout transform runs over
+the full padded range and cannot see which rows are live.
 """
 
 import contextlib


### PR DESCRIPTION
## Purpose

Fixes #49783.

DeepGEMM converts FP32 scale factors to UE8M0 by keeping only each value's exponent byte, so
it requires every value it is given to be an exact positive power of two. DeepGEMM commit
`54e2261` ("Multiple updates and refactorings", deepseek-ai/DeepGEMM#364), shipped in 2.6.x,
added a device-side assert enforcing that in `transpose_and_pack_fp32_into_ue8m0` and
`pack_fp32_into_ue8m0`:

```
DG_DEVICE_ASSERT((values[j] & 0x807fffffu) == 0)
```

2.5.0, the version vendored at `vllm/third_party/deep_gemm`, had no assert and silently
truncated the mantissa, so the violations below were invisible. With a pip-installed 2.6.x
(which `vllm/utils/deep_gemm.py` deliberately prefers over the vendored copy, with no version
gate) the kernel traps instead, and it comes back as
`CUDA driver error ... 719 (CUDA_ERROR_LAUNCH_FAILED)`.

vLLM breaks the precondition in four places. All four are buffers sized for alignment padding
that only the live rows ever get written:

1. `deepgemm_moe_permute` allocates the FP32 activation-scale buffer with `torch.empty` at the
   padded height `M_sum`, but the triton `ep_scatter` kernel writes `output_tensor_scale` only
   at `dest_token_index` for topk pairs with `expert_id >= 0`. Per-expert alignment padding
   rows keep the recycled allocation's contents.

   Initializing `expert_ids` to -1 does not cover this. That makes DeepGEMM's GEMM scheduler
   skip padded blocks, but the scale-factor layout transform runs *before* the GEMM, over the
   whole padded MN range, and never sees `m_indices`. DeepGEMM 2.6.x added an optional
   `psum_layout` argument to `get_mn_major_tma_aligned_packed_ue8m0_tensor` precisely to skip
   uninitialized per-group MN gaps; we do not pass it, so `is_valid_mn` degenerates to
   `global_mn_idx < mn` and every padding row is read and asserted on.

2. and 3. `deep_gemm_warmup` builds dummy `a1q_scales` with `torch.empty`, uninitialized by
   construction. This part is not DSv4-specific: it affects any model whose warmup exercises
   the DeepGEMM path with `VLLM_USE_DEEP_GEMM_E8M0` enabled.

4. `BatchedPrepareAndFinalize` allocates `b_a1_scale` with `torch.empty` while the activation
   buffer beside it is already `torch.zeros`. Experts with no tokens are skipped and rows past
   each expert's token count stay unwritten. Reached from tests today, so this one is a
   latent trap rather than a live crash.

Zero and one are both valid UE8M0 codes, so the scale buffers are zero-filled and the warmup
scales use ones. The padding rows are still discarded downstream; they are now merely
representable. The caller contract is written down once in the `vllm/utils/deep_gemm.py`
module docstring, which is where `disable_ue8m0_cast` is computed for every entry point.

The zero-fill in item 1 is on the per-MoE-layer path. It covers the scale buffer only
(`M_sum x hidden_size/block_k` floats, ~3.7 MB for a 2048-token DSv4 prefill step), not the
much larger activation buffer beside it, which the scatter kernel fully writes and which stays
`torch.empty`. That is a few microseconds of memset against the two grouped GEMMs that consume
it.

## Test Plan

New regression test `test_deepgemm_moe_permute_pads_scales_with_valid_ue8m0` in
`tests/kernels/moe/test_deepgemm.py` asserts that every entry of the permuted FP32 scale
buffer is UE8M0-castable (`value & 0x807fffff == 0`, true for exact positive powers of two and
for 0.0), not just the rows holding real tokens.

Uninitialized-memory bugs do not reproduce against a freshly mapped allocation, since new
pages read as zero and zero passes the check. The test therefore drives `deepgemm_moe_permute`
once, fills the scale buffer it returns with NaN, releases the whole result tuple, and repeats
the identical call so the caching allocator replays the same allocation sequence over the
dirty block. It compares `data_ptr()` and skips with a clear reason if the allocator did not
hand the block back, so it cannot pass vacuously under
`PYTORCH_NO_CUDA_MEMORY_CACHING` or `expandable_segments`.

```
pytest tests/kernels/moe/test_deepgemm.py -k ue8m0
```

End-to-end check: serve `deepseek-ai/DeepSeek-V4-Flash` on 2x RTX PRO 6000 (SM120) with
`--moe-backend deep_gemm --kv-cache-dtype fp8 -tp 2 --enable-expert-parallel` against a
pip-installed DeepGEMM 2.6.1.

## Test Result

Regression test, DeepGEMM 2.6.1 on SM120:

- Without the fix: `AssertionError: 1132 of 1152 scale entries are not UE8M0-castable`. The 20
  valid entries are exactly the real token rows (5 tokens x topk 2 x 2 scale groups).
- With the fix: passes, and the `data_ptr()` guard did not skip, so the poison was live.

End-to-end, same box and DeepGEMM version:

- Before: dies in `profile_run` with
  `RuntimeError: CUDA driver error ... 719 (CUDA_ERROR_LAUNCH_FAILED)` plus
  `Assertion failed: .../smxx_layout.cuh:131, condition: (values[j] & 0x807fffffu) == 0`.
- With item 1 only: gets past `profile_run` and sizes the KV cache, then dies the same way in
  `kernel_warmup` via `deep_gemm_warmup`.
- With all fixes: `DeepGEMM warmup: 100%|##########| 677/677`, CUDA graphs captured
  (PIECEWISE 15/15, FULL 7/7), `init engine ... took 37.49 s`,
  `Application startup complete`, and the model serves.

`ruff check` and `ruff format` clean (pinned v0.14.0) on all five touched files.
