### PR TITLE
fix: add TQFullAttentionSpec guard in v1 _reshape_kv_cache_tensors

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -165,6 +165,7 @@ from vllm.v1.kv_cache_interface import (
     KVQuantMode,
     MambaSpec,
     SlidingWindowSpec,
+    TQFullAttentionSpec,
     UniformTypeKVCacheSpecs,
     get_kv_cache_spec_kind,
 )
@@ -7396,7 +7397,10 @@ class GPUModelRunner(
                     # the unquantized shape.
                     layer_cache_dtype_str = (
                         "auto"
-                        if kv_cache_spec.kv_quant_mode == KVQuantMode.NONE
+                        if (
+                            kv_cache_spec.kv_quant_mode == KVQuantMode.NONE
+                            and not isinstance(kv_cache_spec, TQFullAttentionSpec)
+                        )
                         else getattr(
                             kv_cache_spec,
                             "cache_dtype_str",


### PR DESCRIPTION
## Problem

vLLM v1 engine crashes with `ValueError: Unknown TurboQuant cache dtype: 'auto'` when using `--kv-cache-dtype turboquant_*` with hybrid Mamba+Attention models (e.g. Qwen3.5-MoE / Qwen3.6-35B-A3B-AWQ).

## Root Cause

`_reshape_kv_cache_tensors` in `v1/worker/gpu_model_runner.py:7397` sets `layer_cache_dtype_str = "auto"` for any layer with `kv_quant_mode == KVQuantMode.NONE`. This `"auto"` string is then passed to `TurboQuantConfig.from_cache_dtype()` which only accepts explicit presets (`turboquant_4bit_nc`, etc.).

The non-v1 path (`v1/worker/gpu/attn_utils.py:312-315`) already guards against this:

```python
layer_cache_dtype = (
    "auto"
    if kv_cache_spec.kv_quant_mode == KVQuantMode.NONE
    and not isinstance(kv_cache_spec, TQFullAttentionSpec)  # <-- this guard exists here
    else cache_dtype
)
```

The v1 engine path is missing the same guard.

## Fix

Add the same `TQFullAttentionSpec` guard to the v1 engine path:

1. Import `TQFullAttentionSpec` from `vllm.v1.kv_cache_interface`
2. Add `and not isinstance(kv_cache_spec, TQFullAttentionSpec)` to the condition in `gpu_model_runner.py`

This ensures TurboQuant layers always receive the correct cache dtype string, while genuinely unquantized layers (skipped via `--kv-cache-dtype-skip-layers`) still get `"auto"`.

## Reproduction

```bash
vllm serve QuantTrio/Qwen3.6-35B-A3B-AWQ   --kv-cache-dtype turboquant_4bit_nc   --tensor-parallel-size 2   --enforce-eager
```

Without fix: `ValueError: Unknown TurboQuant cache dtype: 'auto'. Valid presets: turboquant_k8v4, turboquant_4bit_nc, ...`

With fix: server starts successfully.

## Tested

Verified on 2x RTX 3060 12GB with Qwen3.6-35B-A3B-AWQ (hybrid MoE, 35B/3B active, 256 experts, 8 active).