### PR TITLE
[Bugfix][CI] Fix stale Mooncake lookup expectation broken by a merge race

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -1905,13 +1905,15 @@ def test_lookup_rejects_boundary_missing_one_mamba_shard():
     )
     _refresh_group_tp_replication_factors(worker)
 
+    # 33 tokens for two 16-token blocks: the hit stops below the request end,
+    # so the full-hit re-derivation stays out of the shard accounting.
     worker.store.batch_is_exist.side_effect = lambda keys: [1] * len(keys)
-    assert worker.lookup(32, [b"h0", b"h1"]) == 32
+    assert worker.lookup(33, [b"h0", b"h1"]) == 32
 
     worker.store.batch_is_exist.side_effect = lambda keys: [
         0 if "tp_rank:1" in k and "group:1" in k else 1 for k in keys
     ]
-    assert worker.lookup(32, [b"h0", b"h1"]) == 0
+    assert worker.lookup(33, [b"h0", b"h1"]) == 0
 
 
 def test_lookup_requires_all_dcp_rank_namespaces():


### PR DESCRIPTION
## Purpose

`tests/v1/kv_connector/unit/test_mooncake_store_worker.py::test_lookup_rejects_boundary_missing_one_mamba_shard` fails on `main`, breaking the `V1 Core + KV + Metrics` step for every unrelated PR (e.g. [build 80149](https://buildkite.com/vllm/ci/builds/80149)):

```
FAILED v1/kv_connector/unit/test_mooncake_store_worker.py::test_lookup_rejects_boundary_missing_one_mamba_shard
AssertionError: assert 16 == 32
  where 16 = lookup(32, [b'h0', b'h1'])
```

This is a merge race between two Mooncake PRs, not a functional regression:

- #49481 (a76df87) changed `MooncakeStoreWorker.lookup` so a hit covering the whole request is re-derived below the request end, keeping the last token for sampling. With `block_size=16`, a full 2-block hit therefore returns 16, and #49481 added `test_lookup_full_hit_reuses_existing_boundary` asserting exactly `worker.lookup(32, [b"h0", b"h1"]) == 16`.
- #49499 (70052fb) was branched from `f83de6d`, which predates #49481 by ~3 hours, and its new test asserts `worker.lookup(32, [b"h0", b"h1"]) == 32`. Its CI ran green on that base, there was no textual conflict, and it merged a day later without a rebase — leaving `main` with two contradictory expectations for the same call.

The production code from both PRs is correct; only the test expectation is stale.

## Fix

Ask for 33 tokens instead of 32 so the hit stops below the request end and the full-hit re-derivation does not fire. This preserves the test's original intent (all shards present ⇒ full 32-token hit; one Mamba shard missing ⇒ 0) instead of weakening the assertion to `== 16`, and matches the idiom #49481 used elsewhere in the file (`lookup(65, ...) == 64`).

It also keeps the test's discriminating power for the bug #49499 fixed: without that fix, group 1 collapses to a single `tp_rank:0` namespace, the missing shard goes unnoticed, and the second assertion returns 32 instead of 0.

## Test Plan / Result

```
pytest tests/v1/kv_connector/unit/test_mooncake_store_worker.py
```

- Before this change (`main` @ dbcc1cdd0a): `test_lookup_rejects_boundary_missing_one_mamba_shard` fails with `assert 16 == 32`.
- After: **84 passed** in 19.5s, including #49481's `test_lookup_full_hit_reuses_existing_boundary`, which asserts the opposite value for the `lookup(32, ...)` call.
- `pre-commit run --files tests/v1/kv_connector/unit/test_mooncake_store_worker.py`: all hooks pass.

No model evaluation is included: the change is confined to a unit-test expectation and touches no runtime code, so serving behaviour and accuracy are unaffected.

## Not a duplicate

Checked open PRs matching the failing test name and the Mooncake lookup area (`gh pr list --search ...`); no open PR addresses this failure.

## AI assistance

AI assistance (Claude Code) was used to diagnose the CI failure and prepare this change. I have reviewed every changed line and run the tests above.