### PR TITLE
[Bugfix] Wait for the linear bias before layerwise online processing

### DIFF
--- a/tests/model_executor/model_loader/test_reload.py
+++ b/tests/model_executor/model_loader/test_reload.py
@@ -10,9 +10,11 @@ from torch.nn.parameter import UninitializedParameter
 
 import vllm.model_executor.model_loader.reload.meta as reload_meta
 from vllm.model_executor.layers.linear import QKVParallelLinear
+from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
 from vllm.model_executor.model_loader.reload.layerwise import (
     finalize_layerwise_reload,
     initialize_layerwise_reload,
+    initialize_online_processing,
     record_metadata_for_reloading,
 )
 from vllm.model_executor.model_loader.reload.meta import (
@@ -276,6 +278,58 @@ def test_layerwise_reload_composed_loader_does_not_drop_params(monkeypatch):
     assert torch.equal(layer.A, -torch.exp(loaded["A"]))
     assert torch.equal(layer.dt_bias, loaded["dt_bias"])
     assert torch.equal(layer.D, loaded["D"])
+
+
+class _RecordingQuantMethod(QuantizeMethodBase):
+    """Records the layer's bias at the moment processing runs."""
+
+    uses_meta_device = True
+
+    def __init__(self):
+        self.bias_at_process = None
+
+    def create_weights(self, layer, *weight_args, **extra_weight_attrs):
+        pass
+
+    def apply(self, layer, *args, **kwargs):
+        raise NotImplementedError
+
+    def process_weights_after_loading(self, layer):
+        self.bias_at_process = layer.bias.detach().clone()
+
+
+class _LateBiasLayer(torch.nn.Module):
+    """Mimics an online-quantized linear: `weight` is created on meta by
+    `create_weights()`, which wraps the loaders, and the linear base registers
+    `bias` afterwards."""
+
+    def __init__(self, quant_method):
+        super().__init__()
+        self.quant_method = quant_method
+        weight = torch.nn.Parameter(torch.empty(4, 2, device="meta"))
+        weight.weight_loader = default_weight_loader
+        self.register_parameter("weight", weight)
+        initialize_online_processing(self)
+        bias = torch.nn.Parameter(torch.zeros(4))
+        bias.weight_loader = default_weight_loader
+        self.register_parameter("bias", bias)
+
+
+def test_online_processing_waits_for_late_registered_bias():
+    # Regression test: `bias` is skipped by the meta device paths, but it is
+    # still loaded by a weight loader. Excluding it from the processing trigger
+    # finalized the layer one load early, so the trailing bias was written into
+    # an already-processed layer (e.g. over FP8 Marlin's permuted bias).
+    quant_method = _RecordingQuantMethod()
+    layer = _LateBiasLayer(quant_method)
+    loaded_bias = torch.full((4,), 3.0)
+
+    layer.weight.weight_loader(layer.weight, torch.full((4, 2), 2.0))
+    assert quant_method.bias_at_process is None
+
+    layer.bias.weight_loader(layer.bias, loaded_bias)
+    assert quant_method.bias_at_process is not None
+    assert torch.equal(quant_method.bias_at_process, loaded_bias)
 
 
 def test_layerwise_reload_skips_non_persistent_parameter_alias_buffers(monkeypatch):

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -14,7 +14,7 @@ from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBa
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 
 from .meta import (
-    SKIP_TENSORS,
+    SKIP_LOAD_TENSORS,
     capture_layer_to_meta,
     get_numel_loaded,
     materialize_layer,
@@ -140,7 +140,7 @@ def _wrap_parameters_weight_loader(layer: torch.nn.Module) -> None:
     """Wrap each parameter's weight loader."""
     # Note that nested wrapping will occur for shared tensors
     for name, tensor in get_layer_tensors(layer).items():
-        if name in SKIP_TENSORS:
+        if name in SKIP_LOAD_TENSORS:
             continue
         if _get_weight_loader(tensor).__name__ != "online_process_loader":
             tensor.weight_loader = make_online_process_loader(layer, name)

--- a/vllm/model_executor/model_loader/reload/meta.py
+++ b/vllm/model_executor/model_loader/reload/meta.py
@@ -22,6 +22,7 @@ __all__ = [
 
 SKIP_MODULES: set[str] = {"HadamardTransform"}
 
+# Tensors which are never moved to, or materialized from, the meta device
 SKIP_TENSORS: set[str] = {
     "_expert_map",
     "expert_mask",
@@ -29,10 +30,17 @@ SKIP_TENSORS: set[str] = {
     "expert_physical_to_global",
     "expert_local_to_global",
     "e_score_correction_bias",
-    # Built after create_weights(), so it is not tracked by the layerwise-reload
-    # trigger and would be re-materialized into uninitialized memory. Skip it.
+    # Built after create_weights(), so it is already loaded and on device by the
+    # time layerwise processing starts. Re-materializing it would replace the
+    # loaded values with uninitialized memory.
     "bias",
 }
+
+# Tensors which are never loaded by a weight loader, and so must not be counted
+# by the layerwise processing trigger. `bias` is loaded like any other weight,
+# so processing must wait for it (e.g. FP8 Marlin permutes the bias in
+# `process_weights_after_loading`, which a later bias load would corrupt).
+SKIP_LOAD_TENSORS: set[str] = SKIP_TENSORS - {"bias"}
 
 
 def to_meta_tensor(tensor: torch.Tensor) -> torch.Tensor:

--- a/vllm/model_executor/model_loader/reload/meta.py
+++ b/vllm/model_executor/model_loader/reload/meta.py
@@ -20,27 +20,22 @@ __all__ = [
     "get_numel_loaded",
 ]
 
+# Modules whose tensors are never moved to, or materialized from, the meta device.
 SKIP_MODULES: set[str] = {"HadamardTransform"}
 
-# Tensors which are never moved to, or materialized from, the meta device
-SKIP_TENSORS: set[str] = {
+# Tensors never loaded by a weight loader, so the layerwise trigger ignores them.
+SKIP_LOAD_TENSORS: set[str] = {
     "_expert_map",
     "expert_mask",
     "expert_global_to_physical",
     "expert_physical_to_global",
     "expert_local_to_global",
     "e_score_correction_bias",
-    # Built after create_weights(), so it is already loaded and on device by the
-    # time layerwise processing starts. Re-materializing it would replace the
-    # loaded values with uninitialized memory.
-    "bias",
 }
 
-# Tensors which are never loaded by a weight loader, and so must not be counted
-# by the layerwise processing trigger. `bias` is loaded like any other weight,
-# so processing must wait for it (e.g. FP8 Marlin permutes the bias in
-# `process_weights_after_loading`, which a later bias load would corrupt).
-SKIP_LOAD_TENSORS: set[str] = SKIP_TENSORS - {"bias"}
+# Tensors which are never moved to, or materialized from, the meta device.
+# `bias` is built after create_weights(), so it is never on meta to begin with.
+SKIP_TENSORS: set[str] = SKIP_LOAD_TENSORS | {"bias"}
 
 
 def to_meta_tensor(tensor: torch.Tensor) -> torch.Tensor:

--- a/vllm/model_executor/model_loader/reload/utils.py
+++ b/vllm/model_executor/model_loader/reload/utils.py
@@ -33,15 +33,15 @@ def get_layer_params_buffers(layer: torch.nn.Module) -> LayerTensors:
 def get_layer_size(layer: torch.nn.Module) -> int:
     """Calculate total number of elements across loadable tensors in a layer.
 
-    Excludes SKIP_TENSORS (e.g. _expert_map) which are never moved to meta
-    device and never loaded via weight_loader during layerwise reload.
+    Excludes SKIP_LOAD_TENSORS (e.g. _expert_map) which are never loaded via
+    weight_loader during layerwise reload.
     """
-    from .meta import SKIP_TENSORS
+    from .meta import SKIP_LOAD_TENSORS
 
     return sum(
         tensor.numel()
         for name, tensor in get_layer_tensors(layer).items()
-        if name not in SKIP_TENSORS
+        if name not in SKIP_LOAD_TENSORS
     )
 
 


### PR DESCRIPTION
## Purpose

Fixes the `test_fp8.py::test_online_quantization[*-True-*]` failures currently on main (e.g. [build 80095](https://buildkite.com/vllm/ci/builds/80095), Quantization job), which fail with:

```
WARNING [linear.py:1392] Loading a weight without `output_dim` attribute in QKVParallelLinear, assume the weight is the same for all partitions.
ERROR   [core.py:1330]   File "vllm/model_executor/layers/linear.py", line 1398, in weight_loader
ERROR   [core.py:1330]     assert param_data.shape == loaded_weight.shape
ERROR   [core.py:1330] AssertionError
```

**Root cause.** #49586 added `"bias"` to `SKIP_TENSORS`, but that set is consumed for two unrelated purposes:

1. keeping tensors off the meta device (`capture_layer_to_meta` / `restore_layer_on_meta` / `materialize_layer`) — what #49586 needed, and
2. deciding which tensors the layerwise processing trigger counts (`get_layer_size`) and wraps (`_wrap_parameters_weight_loader`).

Excluding `bias` from (2) made `load_numel_total` cover `weight` only. OPT's checkpoint interleaves weight and bias per projection (`k.weight, k.bias, v.weight, v.bias, q.weight, q.bias`), so the weight budget is exhausted at `q.weight` and the layer is processed one load early:

```
QKVParallelLinear: 589824 / 1769472     <- k.weight   (k.bias uncounted)
QKVParallelLinear: 1179648 / 1769472    <- v.weight   (v.bias uncounted)
QKVParallelLinear: 1769472 / 1769472    <- q.weight
marlin_utils_fp8.py:112 Your GPU does not have native support for FP8 computation...
QKVParallelLinear: Processed            <- fires before q.bias is loaded
Loaded shard q ... into ...qkv_proj.weight
linear.py:1392 Loading a weight without `output_dim` attribute      <- q.bias
AssertionError
```

FP8 Marlin is the only backend that rewrites the bias during processing — `prepare_fp8_layer_for_marlin()` ends with `marlin_permute_bias(marlin_pad_dim(layer.bias, ...))` + `replace_parameter(layer, "bias", bias)`. That swaps in a plain `Parameter` with no `output_dim`, so the trailing `q_proj.bias` load takes the "same for all partitions" fallback and asserts `(2304,) == (768,)`. Other backends leave the bias alone, so they only silently mis-order the load instead of crashing — which is why only `force_marlin=True` fails.

**Fix.** Split the two roles. `SKIP_TENSORS` keeps `bias` off the meta device (preserving #49586's fix); the processing trigger uses the new `SKIP_LOAD_TENSORS`, which only excludes tensors that are never loaded by a weight loader. Counting `bias` again can only *delay* processing, and layers that never reach their total are already handled by the delayed-processing branch in `finalize_layerwise_processing`.

Not a duplicate: no open PR or issue covers this (checked `49586 in:body`, `SKIP_TENSORS`, `layerwise bias`, `test_online_quantization`). #49586 is merged, and this keeps its behaviour rather than reverting it.

One note for the reviewer: #49586's stated mechanism ("`bias`'s weight loader is never wrapped ... `load_numel_total` counts only `weight`") no longer holds on main — `online_process_loader` re-wraps late-registered params and refreshes `load_numel_total` on every load, added in #44589. The defect it actually fixed was `materialize_layer()` re-allocating an already-loaded, non-meta `bias`, and that is exactly what this PR preserves.

## Test Plan

```bash
pytest tests/quantization/test_fp8.py::test_online_quantization -q       # the failing CI test
pytest tests/quantization/test_online.py -q
pytest tests/model_executor/model_loader/test_reload.py -q
```

Adds `test_online_processing_waits_for_late_registered_bias` to `test_reload.py`: a CPU-only test that mimics an online-quantized linear (meta `weight` created by `create_weights()`, `bias` registered afterwards) and asserts the layer is not processed until the bias has been loaded.

## Test Result

H100, `VLLM_TEST_FORCE_FP8_MARLIN` covered by the test's `force_marlin` parametrization.

| Suite | Before (main) | After |
| --- | --- | --- |
| `test_fp8.py::test_online_quantization` | 2 failed, 2 passed | **4 passed** |
| `test_online.py` | 6 passed, 1 skipped | 6 passed, 1 skipped |
| `test_reload.py` | 10 failed, 13 passed, 10 skipped, 1 xfailed | 10 failed, **14 passed**, 10 skipped, 1 xfailed |

The 10 `test_reload.py` failures are pre-existing on unmodified `main` in this environment (identical set, verified by running the same file on `main` at `0b1a8bb1f6`); they are unrelated to this change, which only adds a passing test to that file.

The new regression test was confirmed to catch the bug: with `SKIP_LOAD_TENSORS = SKIP_TENSORS` (i.e. the current main behaviour) it fails with `assert tensor([0., 0., 0., 0.]) is None` — processing ran while the bias was still unloaded.

`pre-commit run --files <changed files>` passes.

## AI assistance

AI assistance (Claude Code) was used for this change: log triage, root-cause reduction, and drafting the patch and test. Every changed line has been reviewed, and the test commands above were run locally with the results shown.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

</details>
