### PR TITLE
[CI] Shut down EngineCore explicitly in dynamic shapes compilation tests

### DIFF
--- a/tests/compile/test_dynamic_shapes_compilation.py
+++ b/tests/compile/test_dynamic_shapes_compilation.py
@@ -101,6 +101,10 @@ def test_dynamic_shapes_compilation(
         assert len(output.text.strip()) > 0, "Compiled model produced empty output"
         compiled_outputs.append((output.token_ids, output.text, output.logprobs))
 
+    # Shut the EngineCore down explicitly. `del` only drops one reference, so
+    # if anything else still holds the LLM the finalizer never runs and the
+    # compiled engine keeps its KV cache while the eager engine starts.
+    model.llm_engine.engine_core.shutdown()
     del model
     gc.collect()
     torch.accelerator.empty_cache()
@@ -113,6 +117,7 @@ def test_dynamic_shapes_compilation(
         output = eager_model.generate(p, sampling_params)[0].outputs[0]
         assert len(output.text.strip()) > 0, "Eager model produced empty output"
         eager_outputs.append((output.token_ids, output.text, output.logprobs))
+    eager_model.llm_engine.engine_core.shutdown()
     del eager_model
     gc.collect()
     torch.accelerator.empty_cache()
@@ -278,6 +283,7 @@ def test_piecewise_backend_empty_sym_shape_indices():
     result = output[0].outputs[0].text
     assert len(result) > 0, "Should generate non-empty output on second run"
 
+    llm.llm_engine.engine_core.shutdown()
     del llm
     gc.collect()
     torch.accelerator.empty_cache()


### PR DESCRIPTION
Fixes #49772.

`test_dynamic_shapes_compilation` builds a compiled `LLM` and then an eager `LLM` in the same process. Releasing the first one relies on `del` plus `gc.collect()`, but `del` only drops one reference. If anything else still holds the `LLM`, the weakref finalizer that stops `EngineCore` never runs, so the compiled engine keeps its KV cache and the eager engine fails to initialize. This matches the issue report, where no shutdown log appears before the eager core starts.

Calling `engine_core.shutdown()` before dropping each `LLM` stops the engine deterministically, the same pattern #49749 used for the structured output test.

Measured on an H100 by reproducing the failure mode, one extra reference to the `LLM` held while running the test's existing cleanup:

| cleanup | free GPU memory before the eager LLM | eager LLM |
|---|---|---|
| `del` + `gc.collect()` (current) | 5.14 GiB | fails to initialize |
| explicit `engine_core.shutdown()` | 78.66 GiB | starts |

Baseline free memory was 78.66 GiB.

`pytest tests/compile/test_dynamic_shapes_compilation.py -k gpt2` passes on the two collected cases run (2 passed in 114s).
