### PR TITLE
[Attention] Enable NVFP4 KV cache on SM120 (consumer Blackwell)

### DIFF
--- a/tests/kernels/attention/test_nvfp4_kv_cache_layout.py
+++ b/tests/kernels/attention/test_nvfp4_kv_cache_layout.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test for the NVFP4 KV-cache layout on SM120.
+
+#44455 ("[2/N][KV-Cache Layout Refactor]") folded K/V into the content dim for
+all dtypes. That is a pure reindex when the last dim is `head_size`, but NVFP4
+stores `full_dim = [fp4 data | fp8 block scales]`, so a `2 * num_kv_heads`
+head-group slice no longer yields the contiguous `[data-block | scale-block]`
+region that `nvfp4_split_data_scale()` reconstructs its views from. On SM120
+(fa2 prefill / XQA decode) attention then dequantises against the wrong scales
+and every generation collapses to token id 0.
+
+These are pure-CPU shape/stride contract checks — no GPU required — and they
+would have failed the moment the shape changed without the NVFP4 consumers
+being updated.
+"""
+import pytest
+
+from vllm.v1.attention.backends.flashinfer import FlashInferBackend
+
+NUM_BLOCKS, BLOCK_SIZE, NUM_KV_HEADS, HEAD_SIZE = 8, 16, 4, 256
+
+
+def _shape(dtype):
+    return FlashInferBackend.get_kv_cache_shape(
+        NUM_BLOCKS, BLOCK_SIZE, NUM_KV_HEADS, HEAD_SIZE, cache_dtype_str=dtype
+    )
+
+
+def _stride_order(dtype):
+    try:
+        return FlashInferBackend.get_kv_cache_stride_order(cache_dtype_str=dtype)
+    except TypeError:  # backend predating the cache_dtype_str kwarg
+        return FlashInferBackend.get_kv_cache_stride_order()
+
+
+@pytest.mark.parametrize("dtype", ["auto", "fp8_e4m3", "nvfp4"])
+def test_stride_order_rank_matches_shape_rank(dtype):
+    """The allocator asserts these agree; a mismatch aborts engine start."""
+    assert len(_stride_order(dtype)) == len(_shape(dtype)), (
+        f"stride order rank {len(_stride_order(dtype))} != shape rank "
+        f"{len(_shape(dtype))} for cache_dtype_str={dtype!r}"
+    )
+
+
+@pytest.mark.parametrize("dtype", ["auto", "fp8_e4m3", "nvfp4"])
+def test_stride_order_is_a_permutation(dtype):
+    order = _stride_order(dtype)
+    assert sorted(order) == list(range(len(order))), (
+        f"stride order {order} is not a permutation for cache_dtype_str={dtype!r}"
+    )
+
+
+def test_nvfp4_last_dim_carries_data_and_scale():
+    """full_dim must be data + scale, i.e. 9/8 of the fp4 data width."""
+    shape = _shape("nvfp4")
+    full_dim = shape[-1]
+    assert full_dim == HEAD_SIZE // 2 + HEAD_SIZE // 16
+    assert full_dim * 8 % 9 == 0, "full_dim must split cleanly into data|scale"
+
+
+def test_nvfp4_kv_sides_are_separable_without_head_group_slicing():
+    """
+    The NVFP4 consumers (`nvfp4_split_data_scale`) require each K/V side to be a
+    single contiguous [data | scale] region. On SM120 that means the layout must
+    expose K and V on a dedicated leading axis rather than folding them into a
+    2*num_kv_heads head-group dim.
+    """
+    from vllm.platforms import current_platform
+
+    shape = _shape("nvfp4")
+    if current_platform.is_device_capability_family(120):
+        assert len(shape) == 5 and shape[1] == 2, (
+            "SM120 NVFP4 must keep the (num_blocks, 2, block_size, num_kv_heads,"
+            f" full_dim) layout; got {shape}"
+        )
+    else:
+        # SM100/trtllm-gen keeps the packed layout introduced by #44455.
+        assert len(shape) == 4 and shape[1] == 2 * NUM_KV_HEADS, (
+            f"non-SM120 NVFP4 should keep the packed layout; got {shape}"
+        )

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -391,7 +391,12 @@ def supports_trtllm_attention(is_prefill: bool = False) -> bool:
         return not is_prefill
 
     # SM100/SM103 has both prefill and decode TRTLLM kernels.
-    return current_platform.is_device_capability_family(100)
+    if current_platform.is_device_capability_family(100):
+        return True
+    # SM120: XQA decode only; prefill uses fa2 (trtllm-gen FMHA is SM100-only).
+    if current_platform.is_device_capability_family(120):
+        return not is_prefill
+    return False
 
 
 def force_use_trtllm_attention() -> bool | None:

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -403,6 +403,16 @@ class FlashInferBackend(AttentionBackend):
     ) -> tuple[int, ...]:
         if cache_dtype_str == "nvfp4":
             full_dim = nvfp4_kv_cache_full_dim(head_size)
+            if current_platform.is_device_capability_family(120):
+                # SM120 reads paged NVFP4 KV with fa2 prefill / XQA decode, which
+                # need the per-head split layout. #44455 folded K/V into the
+                # content dim for trtllm-gen (SM100); for NVFP4 the last dim is
+                # [data | scale], so a 2*num_kv_heads head-group slice no longer
+                # yields the contiguous [data-block | scale-block] region that
+                # nvfp4_split_data_scale() reconstructs its views from, and
+                # attention dequantises against wrong scales (argmax collapses to
+                # token id 0). Keep SM120 on the pre-#44455 5-D layout.
+                return (num_blocks, 2, block_size, num_kv_heads, full_dim)
             return (num_blocks, 2 * num_kv_heads, block_size, full_dim)
         # Pack K and V in the content dim (B, H, N, 2*hs).
         return (num_blocks, num_kv_heads, block_size, 2 * head_size)
@@ -410,11 +420,29 @@ class FlashInferBackend(AttentionBackend):
     @staticmethod
     def get_kv_cache_stride_order(
         include_num_layers_dimension: bool = False,
+        cache_dtype_str: str = "auto",
     ) -> tuple[int, ...]:
         # `stride_order` indicates the permutation that gets us from
         # `get_kv_cache_shape` (logical (B, H, N, 2*hs)) to the actual memory
         # layout we want.
         cache_layout = get_kv_cache_layout()
+        if cache_dtype_str == "nvfp4" and current_platform.is_device_capability_family(
+            120
+        ):
+            # Matches the 5-D SM120 NVFP4 shape returned above.
+            if cache_layout == "NHD":
+                return (
+                    (1, 0, 2, 3, 4, 5)
+                    if include_num_layers_dimension
+                    else (0, 1, 2, 3, 4)
+                )
+            if cache_layout == "HND":
+                return (
+                    (1, 2, 4, 0, 3, 5)
+                    if include_num_layers_dimension
+                    else (0, 1, 3, 2, 4)
+                )
+            raise ValueError(f"Unknown cache layout format {cache_layout}.")
         if cache_layout == "NHD" and include_num_layers_dimension:
             # (num_blocks, num_layers, block_size, num_kv_heads, 2*head_size)
             return (1, 0, 3, 2, 4)
@@ -1823,10 +1851,13 @@ class FlashInferImpl(AttentionImpl):
             assert attn_metadata.cascade_wrapper is not None
             stride_order = FlashInferBackend.get_kv_cache_stride_order()
             if self.is_kvcache_nvfp4:
-                kv_cache_views = tuple(
-                    cache.permute(*stride_order)
-                    for cache in kv_cache.split(self.num_kv_heads, dim=1)
-                )
+                if current_platform.is_device_capability_family(120):
+                    kv_cache_views = (kv_cache[:, 0], kv_cache[:, 1])
+                else:
+                    kv_cache_views = tuple(
+                        cache.permute(*stride_order)
+                        for cache in kv_cache.split(self.num_kv_heads, dim=1)
+                    )
             else:
                 kv_perm = kv_cache.permute(*stride_order)
                 kv_cache_views = kv_perm.split(self.head_size, dim=-1)
@@ -1841,8 +1872,17 @@ class FlashInferImpl(AttentionImpl):
         num_decode_tokens = attn_metadata.num_decode_tokens
         num_prefill_tokens = attn_metadata.num_prefill_tokens
 
-        stride_order = FlashInferBackend.get_kv_cache_stride_order()
-        kv_cache_permute = kv_cache.permute(*stride_order)  # HND and contiguous
+        stride_order = FlashInferBackend.get_kv_cache_stride_order(
+            cache_dtype_str=self.kv_cache_dtype
+        )
+        nvfp4_sm120 = self.is_kvcache_nvfp4 and current_platform.is_device_capability_family(
+            120
+        )
+        if nvfp4_sm120:
+            # 5-D (B, 2, N, H, full_dim): K/V are taken on the leading axis.
+            kv_cache_permute = kv_cache
+        else:
+            kv_cache_permute = kv_cache.permute(*stride_order)  # HND and contiguous
         # Fix degenerate strides on any size-1 dimension (e.g. num_kv_heads=1
         # with TP=8).  PyTorch permits non-canonical strides on size-1 dims;
         # CUDA TMA requires ≥16-byte alignment on all non-outermost strides.
@@ -1865,11 +1905,17 @@ class FlashInferImpl(AttentionImpl):
         nvfp4_kv_data = None
         nvfp4_kv_block_scales = None
         if self.is_kvcache_nvfp4:
-            k_cache, v_cache = kv_cache.split(self.num_kv_heads, dim=1)
-            kv_cache_tuple = (
-                canonicalize_singleton_dim_strides(k_cache.permute(*stride_order)),
-                canonicalize_singleton_dim_strides(v_cache.permute(*stride_order)),
-            )
+            if nvfp4_sm120:
+                kv_cache_tuple = (
+                    canonicalize_singleton_dim_strides(kv_cache[:, 0]),
+                    canonicalize_singleton_dim_strides(kv_cache[:, 1]),
+                )
+            else:
+                k_cache, v_cache = kv_cache.split(self.num_kv_heads, dim=1)
+                kv_cache_tuple = (
+                    canonicalize_singleton_dim_strides(k_cache.permute(*stride_order)),
+                    canonicalize_singleton_dim_strides(v_cache.permute(*stride_order)),
+                )
             k_data, k_sf = nvfp4_split_data_scale(kv_cache_tuple[0])
             v_data, v_sf = nvfp4_split_data_scale(kv_cache_tuple[1])
             nvfp4_kv_data = (k_data, v_data)
@@ -2305,7 +2351,13 @@ class FlashInferImpl(AttentionImpl):
             # and value[:num_actual_tokens] because the reshape_and_cache_flash
             # op uses the slot_mapping's shape to determine the number of
             # actual tokens.
-            if self.is_kvcache_nvfp4:
+            if self.is_kvcache_nvfp4 and current_platform.is_device_capability_family(
+                120
+            ):
+                # SM120 5-D (B, 2, N, H, full_dim): K/V on the leading axis.
+                k_cache = kv_cache[:, 0]
+                v_cache = kv_cache[:, 1]
+            elif self.is_kvcache_nvfp4:
                 # (B, 2*H, N, full_dim) -> ((B, N, H, full_dim),
                 #                            (B, N, H, full_dim));
                 # K heads first, then V heads.

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -445,6 +445,9 @@ class FlashInferBackend(AttentionBackend):
     @classmethod
     def supports_kv_cache_dtype(cls, kv_cache_dtype: CacheDType | None) -> bool:
         if kv_cache_dtype == "nvfp4":
+            if current_platform.is_device_capability_family(120):
+                # SM120: XQA decode (native nvfp4-KV) + fa2 prefill.
+                return supports_trtllm_attention(is_prefill=False)
             return (
                 current_platform.is_device_capability_family(100)
                 and supports_trtllm_attention(is_prefill=True)
@@ -709,7 +712,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             # storage dtype may not be the same as the op dtype (uint8 vs fp8_e4m3)
             self.is_kvcache_nvfp4 = self.cache_dtype == "nvfp4"
             if self.is_kvcache_nvfp4:
-                if (
+                if current_platform.is_device_capability_family(120):
+                    pass  # SM120: XQA decode + fa2 prefill.
+                elif (
                     force_use_trtllm_attention() is False
                     or not supports_trtllm_attention(is_prefill=True)
                     or not supports_trtllm_attention(is_prefill=False)
@@ -874,6 +879,10 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 return FlashInferBackend.get_dtype_for_flashinfer(cache_dtype)
             return self.model_config.dtype
         if cache_dtype == "nvfp4":
+            if current_platform.is_device_capability_family(120):
+                # SM120: fa2 prefill cannot take FP8-Q, and XQA decode requires
+                # output dtype == q dtype, so Q/O stay model dtype (bf16).
+                return self.model_config.dtype
             return FlashInferBackend.get_dtype_for_flashinfer("fp8_e4m3")
         return self.kv_cache_spec.dtype
 
@@ -965,6 +974,8 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
     def _get_flashinfer_trtllm_api_decode_kernel() -> FlashInferDecodeKernel:
         if current_platform.is_device_capability(90):
             return FlashInferDecodeKernel.XQA
+        if current_platform.is_device_capability_family(120):
+            return FlashInferDecodeKernel.XQA
         assert current_platform.is_device_capability_family(100)
         return FlashInferDecodeKernel.TRTLLM_GEN
 
@@ -998,8 +1009,17 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 )
             else:
                 # NVFP4 KV cache requires the trtllm-gen backend inside
-                # the wrapper; fa2/fa3 do not support nvfp4.
-                backend = "trtllm-gen" if self.is_kvcache_nvfp4 else "auto"
+                # the wrapper; fa2/fa3 do not support nvfp4. SM120 has no
+                # trtllm-gen FMHA, so it uses fa2 prefill (FlashInfer >= 0.6.15
+                # handles the strided nvfp4 KV views natively).
+                if self.is_kvcache_nvfp4:
+                    backend = (
+                        "fa2"
+                        if current_platform.is_device_capability_family(120)
+                        else "trtllm-gen"
+                    )
+                else:
+                    backend = "auto"
                 self._prefill_wrapper = BatchPrefillWithPagedKVCacheWrapper(
                     self._get_workspace_buffer(),
                     get_kv_cache_layout(),
@@ -1425,7 +1445,10 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     # use FP8 o_data_type so the wrapper matches the
                     # FP8 output buffer allocated in forward().
                     o_dtype = (
-                        FP8_DTYPE if self.is_kvcache_nvfp4 else self.model_config.dtype
+                        FP8_DTYPE
+                        if self.is_kvcache_nvfp4
+                        and not current_platform.is_device_capability_family(120)
+                        else self.model_config.dtype
                     )
                     prefill_wrapper.plan(
                         qo_indptr=qo_indptr_prefill_cpu,
@@ -1441,7 +1464,11 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                         window_left=self.window_left,
                         logits_soft_cap=self.logits_soft_cap,
                         q_data_type=self.q_data_type_prefill,
-                        kv_data_type=self.kv_cache_dtype,
+                        kv_data_type=(
+                            torch.uint8
+                            if self.is_kvcache_nvfp4
+                            else self.kv_cache_dtype
+                        ),
                         o_data_type=o_dtype,
                         fixed_split_size=self.prefill_fixed_split_size,
                         disable_split_kv=self.disable_split_kv,
@@ -1915,7 +1942,9 @@ class FlashInferImpl(AttentionImpl):
                     # Use a pre-allocated FP8 buffer and dequantize
                     # afterwards.
                     needs_fp8_out_prefill = (
-                        self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                        self.is_kvcache_nvfp4
+                        and output.dtype != FP8_DTYPE
+                        and not current_platform.is_device_capability_family(120)
                     )
                     if needs_fp8_out_prefill:
                         out_prefill = self._nvfp4_fp8_out[:num_prefill_tokens]
@@ -1969,7 +1998,11 @@ class FlashInferImpl(AttentionImpl):
 
                 # NVFP4 trtllm kernel only supports FP8 output.
                 # Use a pre-allocated FP8 buffer and dequantize afterwards.
-                needs_fp8_out = self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                needs_fp8_out = (
+                    self.is_kvcache_nvfp4
+                    and output.dtype != FP8_DTYPE
+                    and not current_platform.is_device_capability_family(120)
+                )
                 if needs_fp8_out:
                     out = self._nvfp4_fp8_out[:num_prefill_tokens]
 
@@ -2072,7 +2105,11 @@ class FlashInferImpl(AttentionImpl):
 
                 # NVFP4 kernel only supports FP8 output.
                 # Use a pre-allocated FP8 buffer and dequantize afterwards.
-                needs_fp8_out = self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                needs_fp8_out = (
+                    self.is_kvcache_nvfp4
+                    and output.dtype != FP8_DTYPE
+                    and not current_platform.is_device_capability_family(120)
+                )
                 if needs_fp8_out:
                     out_decode = self._nvfp4_fp8_out[:num_decode_tokens]
                 else:
@@ -2174,7 +2211,11 @@ class FlashInferImpl(AttentionImpl):
 
                 # NVFP4 trtllm kernel only supports FP8 output.
                 # Use a pre-allocated FP8 buffer and dequantize afterwards.
-                needs_fp8_out = self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                needs_fp8_out = (
+                    self.is_kvcache_nvfp4
+                    and output.dtype != FP8_DTYPE
+                    and not current_platform.is_device_capability_family(120)
+                )
                 if needs_fp8_out:
                     out = self._nvfp4_fp8_out[:num_decode_tokens]
 

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -325,7 +325,17 @@ def _reshape_kv_cache(
 
                 # FIXME(woosuk): Add kv_cache_stride_order to all attention backends.
                 try:
-                    kv_cache_stride_order = group.backend.get_kv_cache_stride_order()
+                    try:
+                        kv_cache_stride_order = (
+                            group.backend.get_kv_cache_stride_order(
+                                cache_dtype_str=layer_cache_dtype
+                            )
+                        )
+                    except TypeError:
+                        # backend predates the cache_dtype_str kwarg
+                        kv_cache_stride_order = (
+                            group.backend.get_kv_cache_stride_order()
+                        )
                     assert len(kv_cache_stride_order) == len(kv_cache_shape)
                 except (AttributeError, NotImplementedError):
                     kv_cache_stride_order = tuple(range(len(kv_cache_shape)))

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -7412,7 +7412,17 @@ class GPUModelRunner(
                         cache_dtype_str=layer_cache_dtype_str,
                     )
                     try:
-                        kv_cache_stride_order = attn_backend.get_kv_cache_stride_order()
+                        try:
+                            kv_cache_stride_order = (
+                                attn_backend.get_kv_cache_stride_order(
+                                    cache_dtype_str=layer_cache_dtype_str
+                                )
+                            )
+                        except TypeError:
+                            # backend predates the cache_dtype_str kwarg
+                            kv_cache_stride_order = (
+                                attn_backend.get_kv_cache_stride_order()
+                            )
                         assert len(kv_cache_stride_order) == len(kv_cache_shape)
                     except (AttributeError, NotImplementedError):
                         kv_cache_stride_order = tuple(range(len(kv_cache_shape)))


### PR DESCRIPTION
## What this does

Stock vLLM gates NVFP4 KV cache to SM100 (datacenter Blackwell) only. That path requires trtllm-gen for both prefill and decode, which SM120 (consumer/prosumer Blackwell: RTX 5090, RTX PRO 6000, 5060 Ti) does not have, so on SM120 you hit:

```
ValueError: Selected backend FLASHINFER is not valid for this configuration.
Reason: ['kv_cache_dtype not supported']
```

This enables the path in two parts:

1. **Dispatch gates** - route SM120 through **XQA decode + fa2 prefill** instead of trtllm-gen. Q/O stay in model dtype (bf16) rather than the SM100 FP8 staging, and the FP8 output buffer path is skipped on SM120.
2. **KV cache layout** - keep SM120 NVFP4 on the pre-#44455 5-D `(num_blocks, 2, block_size, num_kv_heads, full_dim)` layout. #44455 folded K/V into the content dim (`2*num_kv_heads`) for all dtypes; for NVFP4 the last dim packs `[data | scale]`, so a head-group slice no longer yields the contiguous `[data-block | scale-block]` region `nvfp4_split_data_scale()` rebuilds its views from, and SM120 fa2/XQA dequantise against the wrong scales (every generation collapses to token id 0). Gating the shape + stride order on NVFP4 **and** SM120 restores the correct layout; SM100 trtllm-gen keeps the packed layout it was built for and is not reached.

## Requirements

- **FlashInfer >= 0.6.15.** Handles the strided nvfp4 scale-factor / packed-KV views on the 5-D layout (flashinfer-ai/flashinfer#3748, #3608, which closed #4044). No copy shim is needed because SM120 retains the 5-D `[data | scale]`-contiguous layout the NVFP4 consumers require, rather than the post-#44455 packed layout.
- **PIECEWISE cudagraph.** XQA decode silently corrupts under FULL cudagraph capture (#49010): launch with `--compilation-config '{"cudagraph_mode":"PIECEWISE"}'`.

## Concurrency

There is a known pitfall in this route: if the fa2 prefill branch rebinds the shared `kv_cache_permute` name to the `nvfp4_kv_data` tuple, the first **mixed prefill+decode batch** crashes EngineCore (`'tuple' object has no attribute 'shape'` in the decode stride check). It does not appear under single-stream or prefill-only / decode-only traffic. Root-caused with a 32-way repro by @seanyourhighness.

**This PR is clean here** - the fa2 prefill path binds a local and leaves `kv_cache_permute` a Tensor for the decode path. @seanyourhighness confirmed 8/8-way concurrency on a from-main build with `errors=[]`.

## Validation

Gates-only on current main produced **corrupted NVFP4 output** (token-0 collapse) due to the #44455 layout regression above; FP8 on the identical build was clean. @seanyourhighness isolated it causally - reverting only the NVFP4 layout to 5-D, changing nothing else, flipped 5/5 garbage to 5/5 correct - then built and validated the layout fix in this PR.

From-main validation (nightly `0ba2aa35` + these gates + the layout fix, FlashInfer 0.6.15.post1, RTX 5090 / SM120, greedy `temperature=0`):

- **NVFP4 correctness: 5/5 correct**, output hashes identical to the ungated variant.
- **Concurrency: 8/8**, `errors=[]`, 13,158-token needle correct.
- **FP8 regression: 5/5 output byte-identical to pre-fix** - the SM100 path is provably unreached (static audit: every non-SM120 branch preserved verbatim).
- **Density: 1.60x** KV pool over fp8 (428,168 vs 267,605 tokens at 9.39 GiB), needle-verified at 246,660 prompt tokens.

Earlier end-to-end coherence was also confirmed on the equivalent 0.25.1 gates by @heungwing (RTX PRO 6000, Hermes Agent / Claude Code) - exact 0.25.1 diff: https://gist.github.com/0xdespot/42600bc72d4623812142c09efcf0e2c9.

## Credit

- @seanyourhighness - **co-author.** Concurrency root-cause + fix, causal proof of the #44455 layout regression, and the SM120-gated layout fix, all validated on SM120 hardware.
- @hikarioyama - the explicit scale-factor-stride / split-buffer kernel approach behind the FlashInfer fix.
- @Njuapp - prior art in #44851.
- Reproductions/confirmations: @gtrak (dual 5060 Ti), hebo1221 (SM121 FlashInfer verification), @heungwing (RTX PRO 6000), @stevenmoto (RTX PRO 6000, TP=4).

Related: #49011, #49010, #44851, flashinfer-ai/flashinfer#3748 / #3608 / #4044.
