### PR TITLE
[Bugfix][CLI] Include inherited field docstrings in get_attr_docs

### DIFF
--- a/tests/config/test_config_utils.py
+++ b/tests/config/test_config_utils.py
@@ -7,7 +7,12 @@ from enum import Enum
 import pytest
 
 from vllm.config.cache import CacheConfig
-from vllm.config.utils import get_hash_factors, hash_factors, normalize_value
+from vllm.config.utils import (
+    get_attr_docs,
+    get_hash_factors,
+    hash_factors,
+    normalize_value,
+)
 
 # Helpers
 
@@ -165,6 +170,50 @@ def test_classes_are_types():
         pass
 
     assert endswith_fqname(LocalDummy, ".LocalDummy")
+
+
+def test_get_attr_docs_includes_inherited_fields():
+    """get_attr_docs must collect attribute docstrings inherited from base
+    classes, not just those declared in the class's own body.
+
+    dataclasses.fields() exposes inherited fields as CLI arguments, so their
+    docstrings must also reach the generated help output (issue #49817).
+    """
+
+    @dataclass
+    class Base:
+        inherited: object = None
+        """doc for inherited (base)."""
+        overridden: object = None
+        """base version of overridden."""
+
+    @dataclass
+    class Derived(Base):
+        own: object = None
+        """doc for own (derived)."""
+        overridden: object = None
+        """derived override of overridden."""
+
+    docs = get_attr_docs(Derived)
+
+    # Own field.
+    assert docs["own"] == "doc for own (derived)."
+    # Inherited field's docstring is picked up from the base class.
+    assert docs["inherited"] == "doc for inherited (base)."
+    # A field redefined on the subclass keeps the subclass docstring.
+    assert docs["overridden"] == "derived override of overridden."
+
+
+def test_get_attr_docs_handles_object_in_mro():
+    """Walking the MRO must not crash on classes without retrievable source
+    (e.g. ``object``)."""
+
+    class Plain:
+        x: int = 1
+        """doc for x."""
+
+    docs = get_attr_docs(Plain)
+    assert docs == {"x": "doc for x."}
 
 
 def test_envs_compile_factors_stable():

--- a/vllm/config/utils.py
+++ b/vllm/config/utils.py
@@ -157,19 +157,17 @@ def getattr_iter(
     return default_factory() if default_factory is not None else default
 
 
-def get_attr_docs(cls: type[Any]) -> dict[str, str]:
-    """
-    Get any docstrings placed after attribute assignments in a class body.
+def _get_own_attr_docs(cls: type[Any], out: dict[str, str]) -> None:
+    """Collect attribute docstrings declared directly in ``cls``'s own body."""
+    try:
+        source = inspect.getsource(cls)
+    except (OSError, TypeError):
+        # ``object`` and classes without retrievable source (e.g. builtins).
+        return
 
-    https://davidism.com/mit-license/
-    """
-
-    cls_node = ast.parse(textwrap.dedent(inspect.getsource(cls))).body[0]
-
+    cls_node = ast.parse(textwrap.dedent(source)).body[0]
     if not isinstance(cls_node, ast.ClassDef):
-        raise TypeError("Given object was not a class.")
-
-    out = {}
+        return
 
     # Consider each pair of nodes.
     for a, b in pairwise(cls_node.body):
@@ -194,6 +192,25 @@ def get_attr_docs(cls: type[Any]) -> dict[str, str]:
                 continue
 
             out[target.id] = doc
+
+
+def get_attr_docs(cls: type[Any]) -> dict[str, str]:
+    """
+    Get any docstrings placed after attribute assignments in a class body.
+
+    Also includes docstrings for attributes inherited from base classes, since
+    ``dataclasses.fields()`` exposes inherited fields as CLI arguments too.
+    Docstrings on ``cls`` take precedence over those from its base classes.
+
+    https://davidism.com/mit-license/
+    """
+
+    out: dict[str, str] = {}
+
+    # Walk the MRO from the most-base class to ``cls`` so that a docstring
+    # redefined on a subclass overrides the one inherited from a base class.
+    for klass in reversed(cls.__mro__):
+        _get_own_attr_docs(klass, out)
 
     return out
 


### PR DESCRIPTION
Fixes #49817.

`get_attr_docs(cls)` only AST-parses `inspect.getsource(cls)` — the class's own body — so attribute docstrings inherited from a base dataclass are dropped. But `dataclasses.fields()` exposes inherited fields, so those args still get registered; the net effect is CLI args like `--chat-template` / `--lora-modules` (inherited by `FrontendArgs` from `BaseFrontendArgs`) show up in `vllm serve --help=Frontend` with no docs.

Fix: walk `cls.__mro__` base→derived and merge per-class attr docs, so inherited docstrings are picked up and a docstring redefined on a subclass still wins. Classes without retrievable source (e.g. `object`) are skipped.

## Test
Added `tests/config/test_config_utils.py::test_get_attr_docs_includes_inherited_fields` (base + derived + override) and `::test_get_attr_docs_handles_object_in_mro`.

```
$ pytest tests/config/test_config_utils.py -q
24 passed
```