### PR TITLE
[CI] Stabilize Pooling Rerank Equivalence Test

### DIFF
--- a/tests/entrypoints/pooling/scoring/test_cross_encoder_online_vision.py
+++ b/tests/entrypoints/pooling/scoring/test_cross_encoder_online_vision.py
@@ -473,7 +473,7 @@ async def test_rerank_api_instruction_field(
 async def test_rerank_api_instruction_field_matches_chat_template_kwargs(
     server: tuple[RemoteOpenAIServer, str],
 ):
-    remote_server, _ = server
+    remote_server, backend = server
 
     doc_list = [
         document,
@@ -514,4 +514,6 @@ async def test_rerank_api_instruction_field_matches_chat_template_kwargs(
     kwargs_scores = [
         r.relevance_score for r in sorted(kwargs_rerank.results, key=lambda x: x.index)
     ]
-    assert field_scores == pytest.approx(kwargs_scores)
+    assert field_scores == pytest.approx(
+        kwargs_scores, rel=get_tol(backend), abs=get_abs_tol(backend)
+    )


### PR DESCRIPTION
## Purpose
This fixes a recurring numerical flake in `test_rerank_api_instruction_field_matches_chat_template_kwargs`, observed on main in Buildkite failures in [#80147](https://buildkite.com/vllm/ci/builds/80147#019f97dd-5540-4624-92f7-eed31f4b3fcd), [#80164](https://buildkite.com/vllm/ci/builds/80164#019f98af-c8db-4c8c-a342-4bd26604c7e7), and [#80202](https://buildkite.com/vllm/ci/builds/80202#019f99f8-7957-4ba1-b748-b7e022dbe1ef).

## Reproducer

```bash
pytest -v -s \
tests/entrypoints/pooling/scoring/test_cross_encoder_online_vision.py::test_rerank_api_instruction_field_matches_chat_template_kwargs
```

### Output on main:

```text
1 failed, 309 passed
Max absolute difference: 0.0023747682571411133
```

### Output on this branch:

```text 
1 passed, 14 warnings in 196.71s
```

