### PR TITLE
[Bugfix][KV Offload][P2P] Fix EngineCore crash reconnecting to a reaped peer

### DIFF
--- a/tests/v1/kv_offload/tiering/p2p/test_zmq_transport.py
+++ b/tests/v1/kv_offload/tiering/p2p/test_zmq_transport.py
@@ -219,6 +219,7 @@ class TestZmqTransportConnectivity:
             # Pruning is synchronous within poll().
             transport_a.poll()
             assert len(transport_a._connections) == 0
+            assert new_conns[0]._sockets.dealer.closed
         finally:
             transport_a.close()
             transport_b.close()
@@ -228,3 +229,110 @@ class TestZmqTransportConnectivity:
         transport, _ = _make_transport()
         transport.close()
         transport.close()  # should not raise
+
+
+class TestZmqReconnect:
+    """Reconnecting to a peer whose connection died (real ZMQ sockets).
+
+    A session marks its connection dead while handling messages, which happens
+    after the transport's own sweep has run for that tick — so a dead
+    connection stays registered until the next poll(). Reconnecting in that
+    window must succeed, and the retired connection must release its sockets.
+    Real sockets are required: a mock reports every attribute as closed.
+    """
+
+    def test_close_after_mark_dead_releases_sockets(self):
+        """close() releases sockets even when mark_dead() ran first.
+
+        mark_dead() must not set the flag close() guards on, or every peer
+        disconnect leaks a DEALER and a monitor socket.
+        """
+        transport, _ = _make_transport()
+        try:
+            conn = transport.connect(f"127.0.0.1:{_free_port()}")
+            dealer, monitor = conn._sockets.dealer, conn._sockets.monitor
+
+            conn.mark_dead()
+            assert not conn.alive
+            assert not dealer.closed
+
+            conn.close()
+            assert dealer.closed
+            assert monitor.closed
+        finally:
+            transport.close()
+
+    def test_connect_retires_dead_connection(self):
+        """connect() replaces a registered-but-dead connection."""
+        transport, _ = _make_transport()
+        try:
+            # The peer port is never bound — only the peer id matters here.
+            peer_id = f"127.0.0.1:{_free_port()}"
+            dead = transport.connect(peer_id)
+            dead.mark_dead()
+
+            conn = transport.connect(peer_id)
+
+            assert conn is not dead
+            assert conn.alive
+            assert transport._connections[peer_id] is conn
+            assert dead._sockets.dealer.closed
+        finally:
+            transport.close()
+
+    def test_repeated_reconnect_to_same_peer(self):
+        """A flapping peer stays reconnectable.
+
+        Monitor endpoints are inproc addresses that libzmq releases
+        asynchronously, so deriving one from peer_id alone makes each
+        reconnect race the previous teardown and fail with EADDRINUSE.
+        """
+        transport, _ = _make_transport()
+        try:
+            peer_id = f"127.0.0.1:{_free_port()}"
+            for _ in range(10):
+                conn = transport.connect(peer_id)
+                conn.mark_dead()
+                transport.poll()
+                assert conn._sockets.dealer.closed
+
+            assert not transport._connections
+        finally:
+            transport.close()
+
+    def test_inbound_message_survives_dead_registration(self):
+        """A reconnecting peer's first message is not dropped.
+
+        poll() must retire connections killed by their session before routing
+        traffic, otherwise the message is enqueued into the dead connection and
+        discarded when it is swept — and a session announces itself only once.
+        Covers only that between-polls window: a peer dying while poll() runs,
+        or dying silently until the heartbeat expires, is out of scope.
+        """
+        transport_a, port_a = _make_transport()
+        transport_b, _ = _make_transport()
+
+        try:
+            conn_b = transport_b.connect(f"127.0.0.1:{port_a}")
+            conn_b.send({"type": "connect", "seq": 1})
+
+            inbound = _wait_for_inbound(transport_a)[0]
+            _wait_for_messages(transport_a, inbound, 1)
+
+            inbound.mark_dead()
+            conn_b.send({"type": "connect", "seq": 2})
+
+            # Wait until the frame is readable on the ROUTER, so the message is
+            # known to have arrived rather than merely being slow.
+            poller = zmq.Poller()
+            poller.register(transport_a._router, zmq.POLLIN)
+            assert poller.poll(2000), "message never reached the ROUTER"
+
+            new_conns = _wait_for_inbound(transport_a)
+            assert len(new_conns) == 1
+            assert new_conns[0] is not inbound
+            msgs = _wait_for_messages(transport_a, new_conns[0], 1)
+            assert msgs == [{"type": "connect", "seq": 2}]
+        finally:
+            transport_a.close()
+            transport_b.close()

--- a/vllm/v1/kv_offload/tiering/p2p/control/base.py
+++ b/vllm/v1/kv_offload/tiering/p2p/control/base.py
@@ -97,6 +97,7 @@ class ControlConnection(ABC):
 
         After this call, alive returns False. The session should
         stop using this connection and the transport will clean it up.
+        Resources are not released here — close() must still run.
         """
         ...
 
@@ -134,6 +135,10 @@ class ControlTransport(ABC):
 
         The connection's send queue is live immediately — messages
         sent before the remote peer's poll() will be buffered.
+
+        A connection to peer_id that is registered but no longer alive is
+        retired and replaced; a live one is a duplicate and must not be
+        replaced.
         """
         ...
 

--- a/vllm/v1/kv_offload/tiering/p2p/control/zmq.py
+++ b/vllm/v1/kv_offload/tiering/p2p/control/zmq.py
@@ -55,12 +55,16 @@ class ZmqConnection(ControlConnection):
     def __init__(self, peer_id: str, sockets: _Sockets) -> None:
         super().__init__(peer_id)
         self._sockets = sockets
+        # _dead: the peer is gone. _closed: the sockets have been released.
+        # Distinct, so mark_dead() cannot turn close() into a no-op and leak
+        # the DEALER and its monitor socket.
+        self._dead = False
         self._closed = False
         self._inbox: list[dict] = []
 
     def send(self, msg: dict) -> None:
         """Send a msgpack-encoded message to this peer."""
-        if self._closed:
+        if not self.alive:
             raise RuntimeError(
                 f"ZmqConnection: send on closed connection to {self.peer_id}"
             )
@@ -77,12 +81,13 @@ class ZmqConnection(ControlConnection):
 
     @property
     def alive(self) -> bool:
-        return not self._closed
+        return not (self._dead or self._closed)
 
     def close(self) -> None:
         if self._closed:
             return
         self._closed = True
+        self._dead = True
         logger.info("ZmqConnection: closing connection to %s", self.peer_id)
         self._sockets.monitor.close()
         self._sockets.dealer.close()
@@ -92,8 +97,12 @@ class ZmqConnection(ControlConnection):
         self._inbox.append(msg)
 
     def mark_dead(self) -> None:
-        """Mark connection as disconnected."""
-        self._closed = True
+        """Mark connection as disconnected.
+
+        Only flips liveness: the sockets stay open until close() releases
+        them, so the owner can still drain recv() before tearing down.
+        """
+        self._dead = True
 
     @property
     def monitor_socket(self) -> zmq.Socket:
@@ -114,6 +123,9 @@ class ZmqTransport(ControlTransport):
 
         self._connections: dict[str, ZmqConnection] = {}
         self._pending_inbound: list[tuple[str, dict]] = []
+        # Monotonic suffix for inproc monitor endpoints — see
+        # _open_connection() for why peer_id alone is not enough.
+        self._monitor_seq = 0
 
         self._zmq_ctx = zmq.Context()
         self._router: zmq.Socket = self._zmq_ctx.socket(zmq.ROUTER)
@@ -127,10 +139,23 @@ class ZmqTransport(ControlTransport):
     # ------------------------------------------------------------------
 
     def connect(self, peer_id: str) -> ZmqConnection:
-        """Open an outbound connection to a remote peer."""
-        assert peer_id not in self._connections, (
-            f"ZmqConnection to {peer_id} already exists"
-        )
+        """Open an outbound connection to a remote peer.
+
+        A dead connection can still be registered: its owning session may mark
+        it dead after this tick's sweep already ran, and poll() only
+        unregisters it on the next pass. Retire such an entry instead of
+        asserting, so a reconnect landing in that window succeeds. A live
+        entry is still a genuine duplicate.
+        """
+        existing = self._connections.get(peer_id)
+        if existing is not None:
+            assert not existing.alive, f"ZmqConnection to {peer_id} already exists"
+            logger.info(
+                "ZmqTransport %s: retiring dead connection to %s before reconnect",
+                self._local_id,
+                peer_id,
+            )
+            self._connections.pop(peer_id).close()
         logger.info(
             "ZmqTransport %s: opening OUTBOUND connection to %s",
             self._local_id,
@@ -146,8 +171,18 @@ class ZmqTransport(ControlTransport):
         - Checks monitors for disconnections
         - Removes and closes dead connections
         """
+        # Retire connections a session killed since the last poll() before
+        # routing traffic: otherwise a reconnecting peer's first message is
+        # enqueued into the dead connection and discarded along with it.
+        # This closes only that between-polls window. A peer that dies while
+        # poll() is running is not seen until the next _check_monitors(), and
+        # one that dies silently not until the ZMQ heartbeat expires; both
+        # still take a message into a doomed connection and are out of scope.
+        self._sweep_dead_connections()
+
         self._recv_router()
         self._check_monitors()
+        self._sweep_dead_connections()
 
         # Create connections for new inbound peers
         new_connections: list[ControlConnection] | None = None
@@ -165,10 +200,6 @@ class ZmqTransport(ControlTransport):
                 new_connections.append(conn)
             conn.enqueue(msg)
         self._pending_inbound.clear()
-
-        # Remove dead connections
-        for pid in [p for p, c in self._connections.items() if not c.alive]:
-            self._connections.pop(pid).close()
 
         return (
             new_connections if new_connections is not None else _EMPTY_NEW_CONNECTIONS
@@ -210,8 +241,13 @@ class ZmqTransport(ControlTransport):
         _apply_heartbeat(dealer)
         dealer.identity = self._local_id.encode()
 
+        # Unique per connection, not per peer: libzmq releases an inproc
+        # endpoint on its reaper thread after the DEALER's close() has already
+        # returned, so reusing the peer-derived address on a reconnect races
+        # that teardown and fails with EADDRINUSE.
         safe_id = peer_id.replace(":", "-").replace("/", "-")
-        monitor_addr = f"inproc://p2p-monitor-{safe_id}"
+        monitor_addr = f"inproc://p2p-monitor-{safe_id}-{self._monitor_seq}"
+        self._monitor_seq += 1
         dealer.monitor(monitor_addr, zmq.EVENT_DISCONNECTED)
 
         monitor_sock = self._zmq_ctx.socket(zmq.PAIR)
@@ -230,6 +266,11 @@ class ZmqTransport(ControlTransport):
             len(self._connections),
         )
         return conn
+
+    def _sweep_dead_connections(self) -> None:
+        """Unregister and release every connection that is no longer alive."""
+        for pid in [p for p, c in self._connections.items() if not c.alive]:
+            self._connections.pop(pid).close()
 
     def _recv_router(self) -> None:
         """Non-blocking: receive all pending messages from ROUTER."""


### PR DESCRIPTION
## Purpose

Fixes #49809. With the `OffloadingConnector` P2P secondary tier, `EngineCore` dies with
`AssertionError: ZmqConnection to <peer>:7777 already exists` when a request reconnects to a peer
whose session was just reaped.

Relaxing that assertion is not sufficient. Three distinct defects sit on the same path, and fixing
any one of them alone converts the crash into a different crash.

## Root cause

### Defect 1 — a dead connection stays registered in the transport

`P2PSession` calls `mark_dead()` on its `ControlConnection` from `session.poll()`, which
`P2PSecondaryTierManager._poll_once()` runs *after* `ZmqTransport.poll()` has already swept dead
connections for that tick. `_reap_dead_sessions()` then drops the session from `_sessions` but
never touches `ZmqTransport._connections`, so the dead entry stays registered until the next
transport poll.

This has two consequences:

- An `on_new_request()` landing in that gap calls `_control.connect(peer_id)`, trips
  `assert peer_id not in self._connections`, and the `AssertionError` escapes into the engine
  loop. **This is the reported crash.**
- `poll()` swept dead connections *last*, after `_recv_router()`. A reconnecting peer's first
  message was therefore enqueued into the still-registered dead connection and discarded when it
  was swept. `P2PSession.attach_connection()` announces itself exactly once, so that `ConnectMsg`
  was lost rather than retried.

### Defect 2 — `mark_dead()` and `close()` shared one flag, so `close()` leaked both sockets

`mark_dead()` set `self._closed`, the same flag `close()` guards on. A `close()` following a
`mark_dead()` therefore returned early and never released the DEALER or its monitor socket. That
leaks two ZMQ sockets per peer death and contradicts the lifecycle documented in `control/base.py`,
where `close()` is specified as *"Release all resources (sockets, monitors)"*. It also keeps the
never-closed DEALER owning `inproc://p2p-monitor-<peer>`, so the reconnect fails with `EADDRINUSE`.

### Defect 3 — the monitor endpoint was derived from `peer_id` alone

libzmq unregisters an `inproc` endpoint on its reaper thread *after* `zmq_close()` has returned.
So even with a correct `close()`, an immediate reconnect to the same peer races that teardown and
intermittently fails with `EADDRINUSE`.

## Reproduction

Measured in-tree against the branch base `26d725c`, `N = 50` fresh transports each doing
`connect` → `mark_dead` → `connect`:

| variant | code under test | result |
|---|---|---|
| base as-is | `26d725c` unmodified | `AssertionError` **50 / 50** |
| assertion relaxed only | `26d725c` + `connect()` pops and closes the stale entry instead of asserting; nothing else changed | `ZMQError(EADDRINUSE)` **50 / 50** |
| this PR | this branch | clean reconnect **50 / 50** |

The middle row is a **synthetic variant built for diagnosis** — it is not the state of any branch,
and checking out `26d725c` will not reproduce it. It exists only to show that removing the
assertion by itself does not fix anything; it just moves the failure onto defect 2.

Defect 3 in isolation — 5 rounds × 20 same-peer reconnects:

| arm | code under test | `EADDRINUSE` per round (of 20) |
|---|---|---|
| peer-derived endpoint | this branch, with the monitor endpoint reverted to peer-derived | `10, 9, 6, 5, 11` → **25–55 %** |
| per-connection endpoint | this branch | `0, 0, 0, 0, 0` → **0 %** |

Both arms carry the corrected `close()` from defect 2, so the monitor endpoint is the only
variable between them. The first arm is likewise a synthetic variant of this branch, not a state
of `main`. It is a race, so the range is what matters rather than any single figure.

Environment: Linux, Python 3.12.3, pyzmq 27.1.0, libzmq 4.3.5.

## Changes

All in `vllm/v1/kv_offload/tiering/p2p/control/zmq.py`, plus two docstring clarifications in
`control/base.py`:

- Separate `_dead` from `_closed`; `alive` is `not (_dead or _closed)`, `mark_dead()` only flips
  liveness, and `close()` always releases the sockets. `send()` now guards on `not self.alive` so
  it still raises after `mark_dead()`. *(defect 2)*
- `connect()` retires a registered *dead* connection before opening the replacement. A *live*
  registered connection is still a genuine duplicate and still asserts. *(defect 1)*
- The `inproc` monitor endpoint is unique per connection via a monotonic `_monitor_seq`, which
  never resets. *(defect 3)*
- `poll()` sweeps dead connections *before* routing traffic, extracted as
  `_sweep_dead_connections()` and also run after `_check_monitors()`. The old trailing sweep is
  gone, so no connection is left registered after being marked dead. *(defect 1, second
  consequence)*

## Test plan

Extended the existing `tests/v1/kv_offload/tiering/p2p/test_zmq_transport.py` rather than adding a
new file: a new `TestZmqReconnect` class, plus one assertion added to
`test_dead_connection_removed_on_poll`. All CPU-only — the transport binds a loopback ROUTER and
opens DEALERs toward an unbound port, so no model, GPU, or second process is needed.

```bash
pytest -v tests/v1/kv_offload/tiering/p2p/test_zmq_transport.py
```

**Each new case fails without the fix.** With `control/` reverted to the branch base and the new
tests kept in place:

```text
$ git checkout 26d725c -- vllm/v1/kv_offload/tiering/p2p/control/
$ python -m pytest -q tests/v1/kv_offload/tiering/p2p/test_zmq_transport.py

______ TestZmqTransportConnectivity.test_dead_connection_removed_on_poll _______
>           assert new_conns[0]._sockets.dealer.closed
E           assert False
E            +  where False = <zmq.Socket(zmq.DEALER) at 0x7659751815c0>.closed
_________ TestZmqReconnect.test_close_after_mark_dead_releases_sockets _________
>           assert dealer.closed
E           assert False
E            +  where False = <zmq.Socket(zmq.DEALER) at 0x765975181080>.closed
____________ TestZmqReconnect.test_connect_retires_dead_connection _____________
>       assert peer_id not in self._connections, (
E       AssertionError: ZmqConnection to 127.0.0.1:60207 already exists
vllm/v1/kv_offload/tiering/p2p/control/zmq.py:131: AssertionError
____________ TestZmqReconnect.test_repeated_reconnect_to_same_peer _____________
>               assert conn._sockets.dealer.closed
E               assert False
_______ TestZmqReconnect.test_inbound_message_survives_dead_registration _______
>       raise AssertionError(f"no inbound connection within {deadline}s")
E       AssertionError: no inbound connection within 2.0s

5 failed, 11 passed in 6.72s
```

The four new cases map onto the defects above:

- `test_close_after_mark_dead_releases_sockets` — defect 2, the socket leak. Uses real sockets
  deliberately: a `MagicMock` reports `.closed` as truthy, so a mock-based version false-passes.
- `test_connect_retires_dead_connection` — defect 1, the reported `AssertionError`.
- `test_repeated_reconnect_to_same_peer` — defect 3; 10 reconnects catch the `EADDRINUSE` race.
- `test_inbound_message_survives_dead_registration` — defect 1's second consequence. Waits on a
  `zmq.Poller` over the ROUTER so the arrival is deterministic rather than timing-dependent.

**With this PR**, the full file is green, and stays green across 10 consecutive runs:

```text
$ for i in $(seq 1 10); do python -m pytest -q tests/v1/kv_offload/tiering/p2p/test_zmq_transport.py; done

16 passed in 4.35s      16 passed in 4.80s
16 passed in 4.08s      16 passed in 4.95s
16 passed in 4.62s      16 passed in 4.49s
16 passed in 4.10s      16 passed in 4.99s
16 passed in 4.16s      16 passed in 3.80s

runs with nonzero exit: 0 / 10
```

The four pre-existing cases touched by the `_dead`/`_closed` split — `test_mark_dead`,
`test_send_raises_when_closed`, `test_duplicate_connect_asserts` and
`test_dead_connection_removed_on_poll` — are inside those 16. `test_send_raises_when_closed` still
matches the "closed connection" message, and `test_duplicate_connect_asserts` still gets an
`AssertionError` for a *live* duplicate, since that assertion was kept.

### Committed tests vs. the manual stress runs

Two figures quoted in the [issue thread](https://github.com/vllm-project/vllm/issues/49809#issuecomment-5079077078)
came from manual stress runs, not from committed tests. Separating them so the test file is not
read as doing more than it does:

**Committed:** `test_repeated_reconnect_to_same_peer` loops **10** reconnects. That is what CI runs,
and 10 is enough to catch the defect-3 race at the rate measured in the 5 × 20 table above.

**Manual, not committed — "300 flapping reconnects":** the patched transport driven 300 times
through `connect(peer)` → `mark_dead()` → teardown, once per teardown path, counting DEALERs left
open and entries left registered:

```text
reap path: mark_dead + close(): 300/300 ok | leaked dealers 0 | residual _connections 1 | errors NONE
poll path: mark_dead + poll(): 300/300 ok | leaked dealers 0 | residual _connections 0 | errors NONE
```

`residual _connections 1` on the reap path is expected — that arm never polls, so the final
connection is still registered when the loop ends.

**Manual, not committed — "27/300 (~9%) `EADDRINUSE`":** a standalone libzmq loop (a DEALER plus
`monitor()` on a fixed `inproc` address, 300 rounds), isolating defect 3 without the transport:

```text
same addr, dealer closed   : 27/300 EADDRINUSE   iter33: Address in use
unique addr, dealer closed : 0/300 EADDRINUSE
same addr, dealer LEAKED   : 299/300 EADDRINUSE  iter1: Address in use
```

Both stress runs were done on a Windows host (CPython 3.13.11, pyzmq 27.1.0, libzmq 4.3.5) against
the real `control/{zmq,base}.py` with only `vllm.logger` and `msgspec` stubbed — a different
environment from the Linux in-tree figures earlier in this PR, which are the ones to rely on. The
in-tree equivalent of the second run is the 5 × 20 defect-3 table.

Lint:

```text
$ pre-commit run --files vllm/v1/kv_offload/tiering/p2p/control/zmq.py \
    vllm/v1/kv_offload/tiering/p2p/control/base.py \
    tests/v1/kv_offload/tiering/p2p/test_zmq_transport.py
ruff check ..... Passed
ruff format .... Passed
typos .......... Passed
Run mypy for Python 3.10 ... Passed
(all other hooks Passed or Skipped — no files to check)
[pre-commit exit=0]   # and no hook rewrote anything
```

No model evaluation is included: this touches only control-plane connection lifecycle and cannot
affect model output, accuracy, or sampling.

## Known remaining window

The sweep added to the top of `poll()` closes the window this bug actually occurs in: a session
calls `mark_dead()` during `session.poll()`, i.e. after `ZmqTransport.poll()` has already swept for
that tick, so the entry survives exactly until the next transport poll. That between-polls window
is where the reported crash lives, and it is now closed.

Two narrower windows remain open and are deliberately **not** addressed here:

- **Death observed mid-poll.** A peer that dies while `poll()` is running is not seen until the
  next `_check_monitors()`. Its connection reads as alive for the remainder of that tick, so a
  message can still be routed into a connection that is already doomed.
- **Silent death.** A peer that disappears without a TCP FIN — host loss, network partition — is
  not detected until the ZMQ heartbeat expires, up to `HEARTBEAT_TIMEOUT` = 10 s with the current
  settings. For that interval the connection is indistinguishable from a healthy one, and a
  `connect()` to that peer still hits the live-duplicate assertion.

Both are limits on how quickly death is *detected*, not defects in how a dead connection is
*retired*, and closing them would mean changing the detection mechanism rather than the lifecycle.
Neither is a regression: both behave exactly as they do on main today. The code comments in
`poll()` and in `test_inbound_message_survives_dead_registration` state this scope explicitly so
the next reader does not over-read the guarantee.

## Relationship to #48021

Not a duplicate. As of 2026-07-25, `gh pr list --state open --search "49809 in:body"` returns
nothing, and no open PR touches `p2p/control/`. #48021 (open, unmerged, last updated 2026-07-24)
is the only adjacent work.

**No file overlap with #48021**, and this fix is orthogonal to any rewrite of
`_reap_dead_sessions`: the socket leak and the `inproc` endpoint reuse are transport-layer
problems, independent of manager-side cleanup ordering. #48021 touches `p2p/manager.py` and
`p2p/session/*` and does not modify `control/` at all; it rewrites `_reap_dead_sessions` but does
not detach the connection from the control transport — it adds no `_control.` reference anywhere.

Worth noting for sequencing: #48021 *adds* a `self._conn.mark_dead()` call in the exception path of
`P2PSession._do_send`, so once it lands, any send failure produces this same dead-but-registered
state on an ordinary request path — widening this crash's window. The two changes compose cleanly
in either merge order.

This is also why the fix belongs in the transport rather than in `_reap_dead_sessions`: the reap is
not the only producer of a stale entry. `_accept_new_peers()` rejects a duplicate peer by calling
`conn.close()` on the fresh inbound connection while leaving it registered until the next poll,
which reaches the same assertion. Fixing `connect()` covers both; detaching from the manager would
cover only one, and would need a new `ControlTransport` abstract method.

## Out of scope / follow-up

`P2PSecondaryTierManager._poll_once()` runs `_accept_new_peers()` *before* `_reap_dead_sessions()`,
and `_accept_new_peers()` rejects a peer that still has a session with `duplicate connection from
…`. That ordering looks wrong, but I could not construct a reachable path: a session is always
reaped in the same tick its connection dies, so `_accept_new_peers()` never observes a stale one.
Left untouched deliberately — it is latent, and `_poll_once`/`_reap_dead_sessions` are being
rewritten in #48021, so changing the order here would collide for no present benefit.

## AI assistance

AI assistance (Claude) was used for the investigation, the patch, and the tests.

I have reviewed every changed line myself and reproduced the failures before and after: the five
failing cases on the unpatched base, the 50/50 `AssertionError` → `EADDRINUSE` → clean progression
in the table above, the full file green across 10 consecutive runs, and `pre-commit` clean with no
hook rewrites. All figures quoted in this PR come from those in-tree runs on the branch as it
stands, rebased onto `26d725c`.

