### PR TITLE
[Bugfix][Responses] FunctionTool to ChatCompletionToolsParam Rendering Parity

### DIFF
--- a/tests/entrypoints/openai/responses/test_responses_utils.py
+++ b/tests/entrypoints/openai/responses/test_responses_utils.py
@@ -15,12 +15,15 @@ from openai.types.responses.response_reasoning_item import (
     ResponseReasoningItem,
     Summary,
 )
+from openai.types.responses.tool import FunctionTool
 
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionToolsParam
+from vllm.entrypoints.openai.engine.protocol import FunctionDefinition
 from vllm.entrypoints.openai.responses.utils import (
     _construct_message_from_response_item,
     construct_chat_messages_with_tool_call,
     construct_input_messages,
-    convert_tool_responses_to_completions_format,
+    construct_tool_dicts,
     should_continue_final_message,
 )
 
@@ -116,27 +119,35 @@ def make_function_call_output(
 
 
 class TestResponsesUtils:
-    """Tests for convert_tool_responses_to_completions_format function."""
+    """Tests for Responses API utils."""
 
     def test_convert_tool_responses_to_completions_format(self):
         """Test basic conversion of a flat tool schema to nested format."""
-        input_tool = {
-            "type": "function",
-            "name": "get_weather",
-            "description": "Get the current weather in a given location",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "location": {"type": "string"},
-                    "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
-                },
-                "required": ["location", "unit"],
-            },
+        parameters = {
+            "type": "object",
+            "properties": {"location": {"type": "string"}},
+            "required": ["location"],
         }
-
-        result = convert_tool_responses_to_completions_format(input_tool)
-
-        assert result == {"type": "function", "function": input_tool}
+        assert construct_tool_dicts(
+            [
+                FunctionTool(
+                    type="function",
+                    name="get_weather",
+                    description="Get weather",
+                    parameters=parameters,
+                )
+            ],
+            tool_choice="auto",
+        ) == [
+            ChatCompletionToolsParam(
+                type="function",
+                function=FunctionDefinition(
+                    name="get_weather",
+                    description="Get weather",
+                    parameters=parameters,
+                ),
+            ).model_dump()
+        ]
 
     def test_construct_chat_messages_with_tool_call(self):
         """Test construction of chat messages with tool calls."""

--- a/tests/entrypoints/openai/responses/test_responses_utils.py
+++ b/tests/entrypoints/openai/responses/test_responses_utils.py
@@ -121,33 +121,45 @@ def make_function_call_output(
 class TestResponsesUtils:
     """Tests for Responses API utils."""
 
-    def test_convert_tool_responses_to_completions_format(self):
-        """Test basic conversion of a flat tool schema to nested format."""
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            pytest.param({}, id="basic"),
+            pytest.param({"strict": True}, id="strict_true"),
+            pytest.param({"strict": False}, id="strict_false"),
+            pytest.param({"defer_loading": True}, id="defer_loading_true"),
+            pytest.param({"defer_loading": False}, id="defer_loading_false"),
+            pytest.param(
+                {"unrelated_extra": "should_be_ignored"},
+                id="unrelated_extra_ignored",
+            ),
+        ],
+    )
+    def test_convert_tool_responses_to_completions_format(self, overrides: dict):
+        """Flat Responses tools convert to nested Completions tool_dicts."""
         parameters = {
             "type": "object",
             "properties": {"location": {"type": "string"}},
             "required": ["location"],
         }
-        assert construct_tool_dicts(
-            [
-                FunctionTool(
-                    type="function",
-                    name="get_weather",
-                    description="Get weather",
-                    parameters=parameters,
-                )
-            ],
+        function_data = {
+            "name": "get_weather",
+            "description": "Get weather",
+            "parameters": parameters,
+            **overrides,
+        }
+
+        result = construct_tool_dicts(
+            [FunctionTool.model_validate({"type": "function", **function_data})],
             tool_choice="auto",
-        ) == [
+        )
+        assert result == [
             ChatCompletionToolsParam(
                 type="function",
-                function=FunctionDefinition(
-                    name="get_weather",
-                    description="Get weather",
-                    parameters=parameters,
-                ),
+                function=FunctionDefinition(**function_data),
             ).model_dump()
         ]
+        assert "unrelated_extra" not in result[0]["function"]
 
     def test_construct_chat_messages_with_tool_call(self):
         """Test construction of chat messages with tool calls."""

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -179,6 +179,7 @@ class ChatCompletionToolsParam(OpenAIBaseModel):
     @model_serializer(mode="wrap")
     def _serialize(self, handler):
         data = handler(self)
+        data = {k: v for k, v in data.items() if k in type(self).model_fields}
         if self.defer_loading is None:
             data.pop("defer_loading", None)
         return data

--- a/vllm/entrypoints/openai/engine/protocol.py
+++ b/vllm/entrypoints/openai/engine/protocol.py
@@ -296,6 +296,7 @@ class FunctionDefinition(OpenAIBaseModel):
     @model_serializer(mode="wrap")
     def _serialize(self, handler):
         data = handler(self)
+        data = {k: v for k, v in data.items() if k in type(self).model_fields}
         if self.strict is None:
             data.pop("strict", None)
         if self.defer_loading is None:

--- a/vllm/entrypoints/openai/responses/utils.py
+++ b/vllm/entrypoints/openai/responses/utils.py
@@ -376,12 +376,8 @@ def convert_tool_responses_to_completions_format(
     """
     return ChatCompletionToolsParam(
         type="function",
-        function=FunctionDefinition(
-            name=tool["name"],
-            description=tool.get("description"),
-            parameters=tool.get("parameters"),
-            strict=tool.get("strict"),
-            defer_loading=tool.get("defer_loading"),
+        function=FunctionDefinition.model_validate(
+            {k: v for k, v in tool.items() if k != "type"}
         ),
     )
 

--- a/vllm/entrypoints/openai/responses/utils.py
+++ b/vllm/entrypoints/openai/responses/utils.py
@@ -31,8 +31,11 @@ from openai.types.responses.tool import Tool
 
 from vllm import envs
 from vllm.entrypoints.chat_utils import make_tool_call_id
-from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionMessageParam
-from vllm.entrypoints.openai.engine.protocol import FunctionCall
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionMessageParam,
+    ChatCompletionToolsParam,
+)
+from vllm.entrypoints.openai.engine.protocol import FunctionCall, FunctionDefinition
 from vllm.entrypoints.openai.responses.protocol import ResponseInputOutputItem
 from vllm.logger import init_logger
 from vllm.tool_parsers.utils import (
@@ -363,27 +366,32 @@ def extract_tool_types(tools: list[Tool]) -> set[str]:
     return tool_types
 
 
-def convert_tool_responses_to_completions_format(tool: dict) -> dict:
+def convert_tool_responses_to_completions_format(
+    tool: dict,
+) -> ChatCompletionToolsParam:
     """
-    Convert a flat tool schema:
+    Convert a flat Responses tool schema:
         {"type": "function", "name": "...", "description": "...", "parameters": {...}}
-    into:
-        {"type": "function", "function": {...}}
+    into a Chat Completions tool param for chat-template rendering.
     """
-    return {
-        "type": "function",
-        "function": tool,
-    }
+    return ChatCompletionToolsParam(
+        type="function",
+        function=FunctionDefinition(
+            name=tool["name"],
+            description=tool.get("description"),
+            parameters=tool.get("parameters"),
+            strict=tool.get("strict"),
+            defer_loading=tool.get("defer_loading"),
+        ),
+    )
 
 
 def construct_tool_dicts(
     tools: list[Tool], tool_choice: ToolChoice
 ) -> list[dict[str, Any]] | None:
     if not tools or (tool_choice == "none"):
-        tool_dicts = None
-    else:
-        tool_dicts = [
-            convert_tool_responses_to_completions_format(tool)
-            for tool in iter_response_function_tool_dicts(tools)
-        ]
-    return tool_dicts
+        return None
+    return [
+        convert_tool_responses_to_completions_format(tool).model_dump()
+        for tool in iter_response_function_tool_dicts(tools)
+    ]

--- a/vllm/tool_parsers/utils.py
+++ b/vllm/tool_parsers/utils.py
@@ -215,7 +215,7 @@ def iter_response_function_tool_dicts(
                     namespace, namespaced_tool.name
                 )
                 function_tools.append(tool_dict)
-        else:
+        elif isinstance(tool, FunctionTool):
             function_tools.append(tool.model_dump())
     return function_tools
 


### PR DESCRIPTION
## Purpose

Ensure `FunctionTool` in Responses API gets rendered the same as Chat Completions `ChatCompletionToolsParam`.

Behavioral change: `extra` fields on `ChatCompletionToolsParam` are now also ignored.

Affects models like Qwen and Nemontron on Responses API path

## Test Plan

`tests/entrypoints/openai/responses/test_responses_utils.py`

https://gist.github.com/yzong-rh/bbeda081335e0bb8bf8b4ee45c76e969

## Test Result

```
46 passed, 14 warnings in 15.87s
```

Repro script:
```
Chat tools: [{'type': 'function', 'function': {'name': 'get_weather', 'description': 'Get the currentweather for a city.', 'parameters': {'type': 'object', 'properties': {'city': {'type': 'string', 'description': 'City name'}}, 'required': ['city']}}}]
Responses tools: [{'type': 'function', 'function': {'name': 'get_weather', 'parameters': {'type': 'object', 'properties': {'city': {'type': 'string', 'description': 'City name'}}, 'required': ['city']}, 'strict': None, 'type': 'function', 'defer_loading': None, 'description': 'Get the current weather fora city.'}}]

Chat tokens:      166
Responses tokens: 183
Delta:            17
```
vs
```
Chat tools: [{'type': 'function', 'function': {'name': 'get_weather', 'description': 'Get the current weather for a city.', 'parameters': {'type': 'object', 'properties': {'city': {'type': 'string', 'description': 'City name'}}, 'required': ['city']}}}]
Responses tools: [{'type': 'function', 'function': {'name': 'get_weather', 'description': 'Get the current weather for a city.', 'parameters': {'type': 'object', 'properties': {'city': {'type': 'string', 'description': 'City name'}}, 'required': ['city']}}}]
Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.

Chat tokens:      166
Responses tokens: 166
Delta:            0
```


| Run | multi_turn_base | multi_turn_long_context | multi_turn_miss_func | multi_turn_miss_param |
|---|---|---|---|---|
| chat | 68.00% | 58.00% | 57.00% | 47.50% |
| responses (before) | 67.50% | 62.00% | 55.00% | 45.00% |
| responses (after) | 69.50% | 62.50% | 56.00% | 47.00% |

Mostly within run-to-run variance. Can't confirm improvement, but probably not regression.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

