### PR TITLE
[CI][ROCm] Make hf-xet reconstruction safe on shared NFS

### DIFF
--- a/.buildkite/scripts/hardware_ci/run-amd-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-amd-test.sh
@@ -387,6 +387,7 @@ initialize_native_environment() {
   local job_id="${BUILDKITE_JOB_ID:-${BUILDKITE_PARALLEL_JOB:-local}}"
   local job_id_suffix=""
   local native_root=""
+  local hf_fstype=""
   local hf_mount=""
 
   if [[ "$(id -u)" -ne 0 ]]; then
@@ -431,6 +432,18 @@ initialize_native_environment() {
       echo "Native CI requires a persistent volume mounted at or above ${HF_HOME}" >&2
       return 1
     fi
+  fi
+
+  if command -v findmnt >/dev/null 2>&1; then
+    hf_fstype=$(findmnt -n -T "${HF_HOME}" -o FSTYPE 2>/dev/null || true)
+  fi
+  if [[ "${hf_fstype}" == nfs || "${hf_fstype}" == nfs4 ]]; then
+    # Keep hf-xet state local and avoid vectored writes on shared NFS.
+    export HF_XET_CACHE="${native_root}/cache/hf-xet"
+    export HF_XET_HIGH_PERFORMANCE=0
+    export HF_XET_RECONSTRUCTION_USE_VECTORED_WRITE=0
+    mkdir -p "${HF_XET_CACHE}" || return 1
+    echo "Configured hf-xet for shared ${hf_fstype} cache at ${HF_HOME}"
   fi
 }
 


### PR DESCRIPTION
## Summary
- Detect an NFS-backed `HF_HOME` in the AMD hardware test runner.
- Keep Xet and the persistent Hub cache enabled while moving ephemeral Xet state to local storage and disabling high-performance vectored reconstruction only on NFS.

hf-xet 1.5.1 stalled on the large vectored write after the first tokenizer fragment, and later jobs convoyed behind the Hub lock. Non-NFS jobs are unchanged.

## Validation
- `bash -n .buildkite/scripts/hardware_ci/run-amd-test.sh`
- Changed-file pre-commit passed.
- Local syscall controls reconstructed Apeach and Qwen3-Next with scalar writes. Cold concurrent validation on Buildkite NFS remains pending.

Buildkite: [Entrypoints Integration (Pooling)](https://buildkite.com/vllm/amd-ci/builds/11196/list?jid=019f90f8-af1a-479e-b835-ef3804113f8f&tab=output)

Duplicate check: no open PR was found for `hf-xet NFS`.

AI assistance: Codex assisted with investigation, implementation, and validation; Andreas directed the design and reviewed the resulting changes.