### PR TITLE
[Test] Add a Hugging Face cache artifact verifier

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,7 @@ from transformers import (
 )
 from transformers.models.auto.auto_factory import _BaseAutoModelClass
 
+from tests.hf_cache_utils import HfCacheVerifier
 from tests.models.utils import (
     TokensTextLogprobs,
     TokensTextLogprobsPromptLogprobs,
@@ -79,6 +80,12 @@ if TYPE_CHECKING:
 
 
 logger = init_logger(__name__)
+
+
+@pytest.fixture(scope="session")
+def verify_hf_cache_artifacts():
+    verifier = HfCacheVerifier()
+    return verifier.verify
 
 
 @pytest.fixture

--- a/tests/hf_cache_utils.py
+++ b/tests/hf_cache_utils.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Integrity checks for materialized Hugging Face Hub cache artifacts."""
+
+import os
+from pathlib import Path
+
+import regex as re
+from huggingface_hub._tree_cache import TreeCacheEntry, read_tree_cache
+from huggingface_hub.utils._verification import compute_file_hash
+
+_COMMIT_RE = re.compile(r"[0-9a-f]{40}\Z")
+FileIdentity = tuple[int, int, int, int, int]
+VerificationKey = tuple[str, str, FileIdentity]
+
+
+class HfCacheIntegrityError(RuntimeError):
+    pass
+
+
+class HfCacheVerifier:
+    """Verify a Hub snapshot or one materialized file beneath it."""
+
+    def __init__(self) -> None:
+        self._verified: set[VerificationKey] = set()
+
+    def verify(self, artifact: str | os.PathLike[str]) -> Path:
+        path = Path(os.path.abspath(os.fspath(artifact)))
+        snapshot = next(
+            (item for item in (path, *path.parents) if item.parent.name == "snapshots"),
+            None,
+        )
+        if snapshot is None or not _COMMIT_RE.fullmatch(snapshot.name):
+            raise HfCacheIntegrityError(f"Not a snapshots/<commit> path: {path}")
+        if not snapshot.is_dir():
+            raise HfCacheIntegrityError(f"Cached snapshot does not exist: {snapshot}")
+
+        entries = [path]
+        if path == snapshot:
+            entries = sorted(
+                (
+                    entry
+                    for entry in snapshot.rglob("*")
+                    if entry.is_symlink() or entry.is_file()
+                ),
+                key=os.fspath,
+            )
+        if not entries:
+            raise HfCacheIntegrityError(f"Cached snapshot is empty: {snapshot}")
+
+        tree = self._read_tree(snapshot)
+        for entry in entries:
+            self._verify_entry(entry, snapshot, tree)
+        return path
+
+    @staticmethod
+    def _read_tree(snapshot: Path) -> dict[str, TreeCacheEntry] | None:
+        repo = snapshot.parent.parent
+        tree_path = repo / "trees" / f"{snapshot.name}.json"
+        tree = read_tree_cache(str(repo), snapshot.name)
+        if tree_path.exists() and tree is None:
+            raise HfCacheIntegrityError(f"Invalid Hub tree metadata: {tree_path}")
+        return tree
+
+    @staticmethod
+    def _expected(
+        entry: Path,
+        snapshot: Path,
+        tree: dict[str, TreeCacheEntry] | None,
+    ) -> tuple[str, str, int | None]:
+        if tree is None:
+            if not entry.is_symlink():
+                raise HfCacheIntegrityError(f"No tree metadata: {entry}")
+            try:
+                target = entry.resolve(strict=True)
+                blobs = (snapshot.parent.parent / "blobs").resolve(strict=True)
+            except OSError as error:
+                raise HfCacheIntegrityError(f"Unreadable link: {entry}") from error
+            if target.parent != blobs:
+                raise HfCacheIntegrityError(f"Cache link escapes blobs: {entry}")
+            expected = target.name
+            algorithm = "sha256" if len(expected) == 64 else "git-sha1"
+            expected_size = None
+        else:
+            metadata = tree.get(entry.relative_to(snapshot).as_posix())
+            if metadata is None:
+                raise HfCacheIntegrityError(f"Tree metadata has no entry for {entry}")
+            if metadata.lfs_sha256 is not None:
+                algorithm, expected = "sha256", metadata.lfs_sha256
+                expected_size = metadata.lfs_size
+            else:
+                algorithm, expected = "git-sha1", metadata.blob_id
+                expected_size = metadata.size
+            if expected_size is None or expected_size < 0:
+                raise HfCacheIntegrityError(f"Invalid cached size for {entry}")
+
+        digest_length = 64 if algorithm == "sha256" else 40
+        if not re.fullmatch(rf"[0-9a-f]{{{digest_length}}}", expected):
+            raise HfCacheIntegrityError(f"Invalid cached digest for {entry}")
+        return algorithm, expected, expected_size
+
+    def _verify_entry(
+        self,
+        entry: Path,
+        snapshot: Path,
+        tree: dict[str, TreeCacheEntry] | None,
+    ) -> None:
+        algorithm, expected, expected_size = self._expected(entry, snapshot, tree)
+        identity = self._identity(entry.stat())
+        if expected_size is not None and identity[2] != expected_size:
+            raise HfCacheIntegrityError(f"Wrong cached size for {entry}")
+
+        key = (algorithm, expected, identity)
+        if key not in self._verified:
+            actual = compute_file_hash(entry, algorithm)  # type: ignore[arg-type]
+            if self._identity(entry.stat()) != identity:
+                raise HfCacheIntegrityError(f"Cache changed while hashing: {entry}")
+            if actual != expected:
+                raise HfCacheIntegrityError(f"Cache checksum mismatch for {entry}")
+            self._verified.add(key)
+
+    @staticmethod
+    def _identity(file_stat: os.stat_result) -> FileIdentity:
+        return (
+            file_stat.st_dev,
+            file_stat.st_ino,
+            file_stat.st_size,
+            file_stat.st_mtime_ns,
+            file_stat.st_ctime_ns,
+        )

--- a/tests/utils_/test_hf_cache.py
+++ b/tests/utils_/test_hf_cache.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import hashlib
+import os
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+from huggingface_hub._tree_cache import TreeCacheEntry, write_tree_cache
+from huggingface_hub.utils.sha import git_hash
+
+import tests.hf_cache_utils as cache_utils
+from tests.hf_cache_utils import HfCacheIntegrityError, HfCacheVerifier
+
+_COMMIT = "a" * 40
+
+
+def _make_snapshot(tmp_path: Path) -> tuple[Path, Path, Path]:
+    repo = tmp_path / "models--org--model"
+    blobs = repo / "blobs"
+    snapshot = repo / "snapshots" / _COMMIT
+    blobs.mkdir(parents=True)
+    snapshot.mkdir(parents=True)
+    return repo, blobs, snapshot
+
+
+def _add_file(
+    snapshot: Path,
+    blobs: Path,
+    name: str,
+    data: bytes,
+    *,
+    lfs: bool,
+) -> tuple[Path, Path, TreeCacheEntry]:
+    digest = hashlib.sha256(data).hexdigest() if lfs else git_hash(data)
+    blob = blobs / digest
+    blob.write_bytes(data)
+    entry = snapshot / name
+    entry.parent.mkdir(parents=True, exist_ok=True)
+    entry.symlink_to(os.path.relpath(blob, entry.parent))
+    metadata = TreeCacheEntry(
+        size=len(data),
+        blob_id=git_hash(data),
+        lfs_sha256=digest if lfs else None,
+        lfs_size=len(data) if lfs else None,
+    )
+    return entry, blob, metadata
+
+
+def _write_tree(repo: Path, files: dict[str, TreeCacheEntry]) -> None:
+    write_tree_cache(str(repo), _COMMIT, files)
+
+
+def test_fixture_verifies_partial_git_and_lfs_snapshot(
+    tmp_path: Path, verify_hf_cache_artifacts
+) -> None:
+    repo, blobs, snapshot = _make_snapshot(tmp_path)
+    _, _, config = _add_file(snapshot, blobs, "config.json", b"config", lfs=False)
+    _, _, weights = _add_file(
+        snapshot, blobs, "weights/model.safetensors", b"weights", lfs=True
+    )
+    _write_tree(
+        repo,
+        {
+            "config.json": config,
+            "weights/model.safetensors": weights,
+            "not-materialized.json": TreeCacheEntry(1, "f" * 40),
+        },
+    )
+    assert verify_hf_cache_artifacts(snapshot) == snapshot
+
+
+@pytest.mark.parametrize("lfs", [False, True])
+def test_corrupt_blob_fails_checksum(tmp_path: Path, lfs: bool) -> None:
+    repo, blobs, snapshot = _make_snapshot(tmp_path)
+    entry, blob, metadata = _add_file(snapshot, blobs, "artifact.bin", b"good", lfs=lfs)
+    _write_tree(repo, {"artifact.bin": metadata})
+    blob.write_bytes(b"evil")
+    with pytest.raises(HfCacheIntegrityError, match="checksum mismatch"):
+        HfCacheVerifier().verify(entry)
+
+
+@pytest.mark.parametrize("failure", ["invalid-tree", "missing-entry", "wrong-size"])
+def test_invalid_tree_metadata_fails_closed(tmp_path: Path, failure: str) -> None:
+    repo, blobs, snapshot = _make_snapshot(tmp_path)
+    entry, _, metadata = _add_file(snapshot, blobs, "artifact.bin", b"data", lfs=False)
+    if failure == "missing-entry":
+        _write_tree(repo, {})
+    elif failure == "wrong-size":
+        _write_tree(repo, {"artifact.bin": replace(metadata, size=99)})
+    else:
+        trees = repo / "trees"
+        trees.mkdir()
+        (trees / f"{_COMMIT}.json").write_text('{"format_version": 2, "files": {}}')
+
+    with pytest.raises(HfCacheIntegrityError):
+        HfCacheVerifier().verify(entry)
+
+
+def test_tree_less_content_address_fallback(tmp_path: Path) -> None:
+    _, blobs, snapshot = _make_snapshot(tmp_path)
+    entry, _, _ = _add_file(snapshot, blobs, "config.json", b"config", lfs=False)
+    assert HfCacheVerifier().verify(entry) == entry
+
+    regular_file = snapshot / "copied.json"
+    regular_file.write_bytes(b"copy")
+    with pytest.raises(HfCacheIntegrityError, match="No tree metadata"):
+        HfCacheVerifier().verify(regular_file)
+
+
+def test_stable_identity_is_memoized_and_replacement_rehashed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo, blobs, snapshot = _make_snapshot(tmp_path)
+    entry, blob, metadata = _add_file(
+        snapshot, blobs, "model.safetensors", b"weights", lfs=True
+    )
+    _write_tree(repo, {"model.safetensors": metadata})
+    original_hash = cache_utils.compute_file_hash
+    calls = 0
+
+    def counted_hash(path: Path, algorithm: str) -> str:
+        nonlocal calls
+        calls += 1
+        return original_hash(path, algorithm)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(cache_utils, "compute_file_hash", counted_hash)
+    verifier = HfCacheVerifier()
+    verifier.verify(entry)
+    verifier.verify(entry)
+    assert calls == 1
+
+    replacement = blob.with_suffix(".replacement")
+    replacement.write_bytes(b"corrupt")
+    os.replace(replacement, blob)
+    with pytest.raises(HfCacheIntegrityError, match="checksum mismatch"):
+        verifier.verify(entry)
+    assert calls == 2


### PR DESCRIPTION
## Summary
- Add the requested opt-in session fixture for verifying a materialized Hub snapshot or one file beneath it.
- Check Git and LFS content addresses and recorded sizes, and memoize a digest only while the file identity is unchanged.

The fixture is explicit: it does not intercept, repair, or claim to verify every model load.

## Validation
- `VLLM_TEST_CLEAN_GPU_MEMORY=0 .venv/bin/python -m pytest -q tests/utils_/test_hf_cache.py` — 8 passed.
- The same 8 tests passed with the CI-pinned Hugging Face Hub 1.22 implementation.
- Changed-file pre-commit passed.

Buildkite motivation: [Multimodal Standard (Qwen2)](https://buildkite.com/vllm/amd-ci/builds/11196/list?jid=019f90f8-af27-4284-b344-6f02469902aa&tab=output)

Duplicate check: no open PR was found for a Hugging Face cache artifact verifier.

AI assistance: Codex assisted with investigation, implementation, and validation; Andreas directed the design and reviewed the resulting changes.