### PR TITLE
[Test][ROCm] Account for gfx950 FP8 RMSNorm rounding

### DIFF
--- a/tests/kernels/core/test_fused_quant_layernorm.py
+++ b/tests/kernels/core/test_fused_quant_layernorm.py
@@ -8,7 +8,7 @@ import pytest
 import torch
 
 import vllm._custom_ops as ops
-from tests.kernels.utils import fp8_ulp_distance, opcheck
+from tests.kernels.utils import fp8_allclose, fp8_ulp_distance, opcheck
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     per_token_group_quant_fp8,
@@ -18,6 +18,9 @@ from vllm.model_executor.layers.quantization.utils.int8_utils import (
 )
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
+
+if current_platform.is_rocm():
+    from vllm.platforms.rocm import on_gfx950
 
 DTYPES = [torch.bfloat16, torch.float]
 QUANT_DTYPES = [torch.int8, current_platform.fp8_dtype()]
@@ -259,6 +262,13 @@ def test_rms_norm(
         and dtype == torch.bfloat16
         and current_platform.is_rocm()
     )
+    use_gfx950_fp8_allclose = (
+        current_platform.is_rocm()
+        and on_gfx950()
+        and group_size is None
+        and dtype == torch.bfloat16
+        and quant_dtype == current_platform.fp8_dtype()
+    )
 
     def scales_close(rtol: float, atol: float) -> bool:
         if torch.allclose(ref_scales, ops_scales, rtol=rtol, atol=atol):
@@ -283,6 +293,10 @@ def test_rms_norm(
                 ulp = fp8_ulp_distance(ref_out, ops_out)
                 max_outliers = ulp.numel() // 100_000 + 8
                 ok = int((ulp > 0).sum().item()) <= max_outliers
+            elif use_gfx950_fp8_allclose:
+                # Valid gfx950 reduction trees can straddle an E4M3 boundary.
+                ok = fp8_allclose(ops_out, ref_out, rtol=0.125, atol=2e-3)
+                ok = ok and int(fp8_ulp_distance(ops_out, ref_out).max()) <= 1
             else:
                 # CUDA (& non-bf16): compare dequantized values with relaxed tolerance.
                 if group_size is None:

--- a/tests/kernels/core/test_layernorm.py
+++ b/tests/kernels/core/test_layernorm.py
@@ -5,14 +5,14 @@ import pytest
 import torch
 
 from tests.kernels.quant_utils import FP8_DTYPE
-from tests.kernels.utils import fp8_ulp_distance, opcheck
+from tests.kernels.utils import fp8_allclose, fp8_ulp_distance, opcheck
 from vllm import ir
 from vllm.model_executor.layers.layernorm import GemmaRMSNorm, RMSNorm
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
 if current_platform.is_rocm():
-    from vllm.platforms.rocm import on_gfx90a
+    from vllm.platforms.rocm import on_gfx90a, on_gfx950
 
     on_mi250 = on_gfx90a()
 else:
@@ -205,14 +205,20 @@ def test_fused_rms_norm_quant(
         )
 
     if current_platform.is_rocm():
-        # Fused and unfused FP8 paths can land on opposite sides of an E4M3 tie;
-        # tolerate a tiny number of isolated fp8 outliers on ROCm.
-        ulp = fp8_ulp_distance(out_quant, out_quant_fused)
-        max_outliers = ulp.numel() // 100_000 + 8
-        num_outliers = int((ulp > 0).sum().item())
-        assert num_outliers <= max_outliers, (
-            f"FP8 quant mismatch: {num_outliers} fp8 outliers (allowed {max_outliers})"
-        )
+        if on_gfx950() and dtype == torch.float16 and not add_residual:
+            # Fusion may round normalized FP16 across an E4M3 boundary on gfx950.
+            assert fp8_allclose(out_quant_fused, out_quant, rtol=0.125, atol=2e-3)
+            assert int(fp8_ulp_distance(out_quant_fused, out_quant).max()) <= 1
+        else:
+            # Fused and unfused FP8 paths can land on opposite sides of an E4M3
+            # tie; tolerate a tiny number of isolated fp8 outliers on ROCm.
+            ulp = fp8_ulp_distance(out_quant, out_quant_fused)
+            max_outliers = ulp.numel() // 100_000 + 8
+            num_outliers = int((ulp > 0).sum().item())
+            assert num_outliers <= max_outliers, (
+                f"FP8 quant mismatch: {num_outliers} fp8 outliers "
+                f"(allowed {max_outliers})"
+            )
     else:
         torch.testing.assert_close(
             out_quant.to(dtype=torch.float32),


### PR DESCRIPTION
## Summary
- Use the shared FP8 `allclose` contract only for the measured gfx950 fused RMSNorm cases.
- Bound every accepted difference to one FP8 ULP while leaving scales, residuals, other dtypes, other architectures, and other ROCm checks unchanged.

E4M3 adjacent codes can differ by 12.5%, and its minimum subnormal step is approximately 0.002. Fused and unfused gfx950 reductions selected adjacent codes at those boundaries; no production kernel changed.

## Validation
- Original Buildkite failures: 39 passed.
- Final changed scope: 162 static cases passed; dynamic scope had 304 passed and 152 expected parameter skips.
- Earlier complete matrices passed 648 static and 1,128 dynamic cases; changed-file pre-commit passed.

Buildkite: [Kernels Core Operation](https://buildkite.com/vllm/amd-ci/builds/11196/list?jid=019f90f8-af1f-4348-9ebf-44f8f83c692b&tab=output)

Duplicate check: no open PR covers these tests; #49621 changes separate per-group quantization files.

AI assistance: Codex assisted with investigation, implementation, and validation; Andreas directed the numerical contract and reviewed the resulting changes.