### PR TITLE
[Bugfix] Clean distributed state after worker initialization failure

### DIFF
--- a/tests/v1/executor/test_executor.py
+++ b/tests/v1/executor/test_executor.py
@@ -5,6 +5,7 @@ import asyncio
 import os
 from collections.abc import Callable
 from concurrent.futures import Future
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -86,6 +87,54 @@ def test_multiproc_executor_worker_termination_timeout(
     proc = _FakeProcess(clock, exits_at=exits_at)
     executor._ensure_worker_termination([proc])
     assert proc.terminate_called is expected_terminate
+
+
+def test_worker_init_failure_cleans_distributed_environment(monkeypatch):
+    worker_main = multiproc_executor_module.WorkerProc.worker_main
+    cleanup_calls = []
+
+    class _ReadyPipe:
+        closed = False
+
+        def close(self):
+            self.closed = True
+
+    def fail_worker_init(*args, **kwargs):
+        raise RuntimeError("worker initialization failed")
+
+    monkeypatch.setattr(multiproc_executor_module, "WorkerProc", fail_worker_init)
+    monkeypatch.setattr(multiproc_executor_module.signal, "signal", lambda *args: None)
+    monkeypatch.setattr(
+        multiproc_executor_module, "set_worker_net_device", lambda *args: None
+    )
+    monkeypatch.setattr(
+        multiproc_executor_module, "maybe_init_worker_tracer", lambda **kwargs: None
+    )
+    monkeypatch.setattr(
+        multiproc_executor_module,
+        "destroy_model_parallel",
+        lambda: cleanup_calls.append("model_parallel"),
+    )
+    monkeypatch.setattr(
+        multiproc_executor_module,
+        "destroy_distributed_environment",
+        lambda: cleanup_calls.append("distributed"),
+    )
+
+    ready_pipe = _ReadyPipe()
+    worker_main(
+        vllm_config=SimpleNamespace(
+            parallel_config=SimpleNamespace(assigned_physical_gpu_ids=None)
+        ),
+        local_rank=0,
+        rank=0,
+        ready_pipe=ready_pipe,
+        death_pipe=None,
+        inherited_fds=[],
+    )
+
+    assert ready_pipe.closed
+    assert cleanup_calls == ["model_parallel", "distributed"]
 
 
 class CustomMultiprocExecutor(MultiprocExecutor):

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -942,6 +942,11 @@ class WorkerProc:
             # Clean up once worker exits busy loop
             if worker is not None:
                 worker.shutdown()
+            else:
+                try:
+                    destroy_model_parallel()
+                finally:
+                    destroy_distributed_environment()
 
     class ResponseStatus(Enum):
         SUCCESS = auto()


### PR DESCRIPTION
## Summary
- Tear down model-parallel and distributed state when a spawned worker fails before `WorkerProc` construction completes.
- Add a focused regression for cleanup order on the partial-initialization path.

With `spawn`, constructor failure can occur after global groups and their shared-memory queue are initialized but before a `WorkerProc` exists to own normal shutdown.

## Validation
- Focused worker cleanup regression: 1 passed.
- Two-GPU invalid Tensorizer shard path: 1 passed in 24.89 seconds, with no surviving worker or GPU allocation in the lifecycle control.
- Changed-file pre-commit passed.

Buildkite: [Model Executor](https://buildkite.com/vllm/amd-ci/builds/11196/list?jid=019f90f8-af22-4c9f-848c-07675a6588cd&tab=output)

Duplicate check: #34816 handles parent-death signals, not constructor failure; no open PR addresses this ownership path.

AI assistance: Codex assisted with investigation, implementation, and validation; Andreas directed the ownership design and reviewed the resulting changes.