### PR TITLE
[Model] Support native Transformers ERNIE 4.5 VL

### DIFF
--- a/tests/model_executor/test_ernie45_vl_config.py
+++ b/tests/model_executor/test_ernie45_vl_config.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from transformers import PretrainedConfig
+from transformers.models.ernie4_5_vl_moe.configuration_ernie4_5_vl_moe import (
+    Ernie4_5_VLMoeConfig,
+)
+
+from vllm.model_executor.models.ernie45_vl_config import (
+    get_ernie4_5_vl_config,
+    get_ernie4_5_vl_vision_norm_eps,
+)
+from vllm.model_executor.models.ernie45_vl_moe import _is_moe_layer
+
+
+def test_native_config_view_preserves_ernie_semantics():
+    layer_types = ["dense", "sparse", "dense", "sparse"]
+    hf_config = Ernie4_5_VLMoeConfig(
+        image_token_id=101,
+        video_token_id=102,
+        text_config={
+            "hidden_size": 64,
+            "intermediate_size": 128,
+            "num_hidden_layers": len(layer_types),
+            "moe_num_experts": 8,
+            "mlp_layer_types": layer_types,
+            "rms_norm_eps": 1e-5,
+        },
+        vision_config={
+            "hidden_size": 32,
+            "intermediate_size": 128,
+            "spatial_merge_size": 2,
+            "temporal_merge_size": 3,
+            "rms_norm_eps": 1e-6,
+        },
+    )
+
+    config = get_ernie4_5_vl_config(hf_config)
+
+    assert config.hidden_size == 64
+    assert config.im_patch_id == 101
+    assert config.video_token_id == 102
+    assert config.spatial_conv_size == 2
+    assert config.temporal_conv_size == 3
+    assert config.moe_num_experts == [8, 8]
+    assert get_ernie4_5_vl_vision_norm_eps(config) == 1e-6
+    assert config.vision_config is hf_config.vision_config
+    assert [_is_moe_layer(config, index) for index in range(4)] == [
+        False,
+        True,
+        False,
+        True,
+    ]
+    assert not hasattr(hf_config, "hidden_size")
+    assert hf_config.text_config.moe_num_experts == 8
+
+
+def test_legacy_flat_config_is_unchanged():
+    hf_config = PretrainedConfig()
+    hf_config.hidden_size = 64
+    hf_config.im_patch_id = 101
+    hf_config.rms_norm_eps = 2e-6
+    hf_config.vision_config = PretrainedConfig()
+
+    assert get_ernie4_5_vl_config(hf_config) is hf_config
+    assert get_ernie4_5_vl_vision_norm_eps(hf_config) == 2e-6

--- a/tests/models/multimodal/processing/test_ernie45_vl.py
+++ b/tests/models/multimodal/processing/test_ernie45_vl.py
@@ -1,0 +1,371 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from copy import deepcopy
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+from transformers.video_utils import VideoMetadata
+
+from vllm.model_executor.models.ernie45_vl import Ernie4_5VLMultiModalProcessor
+from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.cache import MultiModalProcessorOnlyCache
+from vllm.multimodal.processing import TimingContext
+from vllm.multimodal.processing.inputs import ProcessorInputs
+
+from ...utils import build_model_context
+
+MODEL_ID = "baidu/ERNIE-4.5-VL-28B-A3B-PT"
+
+
+def _make_video(num_frames: int) -> np.ndarray:
+    frame, row, column = np.indices((num_frames, 56, 56))
+    return np.stack(
+        (
+            (17 * frame + 3 * column) % 256,
+            (29 * frame + 5 * row) % 256,
+            (11 * frame + row + column) % 256,
+        ),
+        axis=-1,
+    ).astype(np.uint8)
+
+
+def _metadata(
+    frame_indices: list[int],
+    total_num_frames: int,
+    do_sample_frames: bool | None = None,
+) -> dict[str, object]:
+    metadata: dict[str, object] = {
+        "total_num_frames": total_num_frames,
+        "fps": 7.5,
+        "duration": total_num_frames / 7.5,
+        "video_backend": "opencv",
+        "frames_indices": frame_indices,
+    }
+    if do_sample_frames is not None:
+        metadata["do_sample_frames"] = do_sample_frames
+    return metadata
+
+
+def _clone_video(video: np.ndarray | torch.Tensor):
+    return video.copy() if isinstance(video, np.ndarray) else video.clone()
+
+
+def _video_hash(prompt: str, mm_items) -> str:
+    inputs = ProcessorInputs(prompt=prompt, mm_data_items=mm_items)
+    return inputs.get_mm_hashes(MODEL_ID)["video"][0]
+
+
+@pytest.fixture(scope="module")
+def ernie_context():
+    return build_model_context(
+        MODEL_ID,
+        limit_mm_per_prompt={"image": 2, "video": 2},
+        mm_processor_cache_gb=1,
+    )
+
+
+@pytest.mark.parametrize(
+    ("modality", "legacy_marker"),
+    [
+        ("image", "<|image@placeholder|>"),
+        ("video", "<|video@placeholder|>"),
+    ],
+)
+def test_native_and_legacy_markers_on_cache_miss_and_hit(
+    ernie_context,
+    modality: str,
+    legacy_marker: str,
+):
+    cache = MultiModalProcessorOnlyCache(ernie_context.model_config)
+    processor = MULTIMODAL_REGISTRY.create_processor(
+        ernie_context.model_config,
+        tokenizer=ernie_context.tokenizer,
+        cache=cache,
+    )
+    hf_processor = processor.info.get_hf_processor()
+    native_marker = getattr(hf_processor, f"{modality}_token")
+    native_prompt = f"{native_marker} Describe this input."
+    legacy_prompt = native_prompt.replace(native_marker, legacy_marker)
+
+    if modality == "image":
+        mm_data = {"image": Image.new("RGB", (56, 56), "white")}
+    else:
+        video = _make_video(2)
+        mm_data = {"video": (video, _metadata([0, 1], 2, False))}
+    mm_items = processor.info.parse_mm_data(mm_data)
+
+    results = [
+        processor(legacy_prompt, mm_items=mm_items),
+        processor(native_prompt, mm_items=mm_items),
+        processor(native_prompt, mm_items=mm_items),
+    ]
+    expected = results[0]
+    for result in results[1:]:
+        assert result["prompt_token_ids"] == expected["prompt_token_ids"]
+        assert result["mm_placeholders"] == expected["mm_placeholders"]
+
+    (placeholder,) = expected["mm_placeholders"][modality]
+    placeholder_ids = expected["prompt_token_ids"][
+        placeholder.offset : placeholder.offset + placeholder.length
+    ]
+    token_id = getattr(processor.info.get_hf_config(), f"{modality}_token_id")
+    assert placeholder_ids == [token_id] * placeholder.length
+    assert len(cache._cache) == 1
+
+
+@pytest.mark.parametrize("prompt_type", ["text", "tokens"])
+def test_mixed_native_and_legacy_image_markers_preserve_item_order(
+    ernie_context,
+    prompt_type: str,
+):
+    cache = MultiModalProcessorOnlyCache(ernie_context.model_config)
+    processor = MULTIMODAL_REGISTRY.create_processor(
+        ernie_context.model_config,
+        tokenizer=ernie_context.tokenizer,
+        cache=cache,
+    )
+    native_marker = processor.info.get_hf_processor().image_token
+    legacy_marker = "<|image@placeholder|>"
+    mm_items = processor.info.parse_mm_data(
+        {
+            "image": [
+                Image.new("RGB", (56, 56), "white"),
+                Image.new("RGB", (112, 56), "black"),
+            ]
+        }
+    )
+    prompt = f"{native_marker} A {legacy_marker}"
+
+    def run_processor():
+        if prompt_type == "text":
+            return processor(prompt, mm_items=mm_items)
+        prompt_tokens = ernie_context.tokenizer.encode(prompt, add_special_tokens=False)
+        return processor.apply(
+            ProcessorInputs(prompt_tokens, mm_items),
+            TimingContext(enabled=False),
+        )
+
+    cache_miss = run_processor()
+    cache_hit = run_processor()
+    assert cache_hit["prompt_token_ids"] == cache_miss["prompt_token_ids"]
+    assert cache_hit["mm_placeholders"] == cache_miss["mm_placeholders"]
+    assert len(cache._cache) == 2
+
+    placeholders = cache_miss["mm_placeholders"]["image"]
+    image_grids = cache_miss["mm_kwargs"].get_data()["image_grid_thw"]
+    merge_length = processor.info.get_hf_config().spatial_conv_size ** 2
+    assert len(placeholders) == 2
+    assert placeholders[0].offset < placeholders[1].offset
+    assert [placeholder.length for placeholder in placeholders] == [
+        int(grid.prod()) // merge_length for grid in image_grids
+    ]
+
+
+def test_native_processor_size_layout_ignores_trust_permission(
+    ernie_context,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(ernie_context.model_config, "trust_remote_code", True)
+    processor = MULTIMODAL_REGISTRY.create_processor(
+        ernie_context.model_config,
+        tokenizer=ernie_context.tokenizer,
+    )
+
+    assert processor.info.get_max_image_tokens() > 0
+
+
+@pytest.mark.parametrize(
+    ("configured_max_pixels", "runtime_max_pixels", "expected_grid"),
+    [
+        (None, 12544, 8),
+        (12544, None, 8),
+        (12544, 50176, 16),
+    ],
+)
+def test_native_pixel_aliases_match_processor_size(
+    ernie_context,
+    monkeypatch: pytest.MonkeyPatch,
+    configured_max_pixels: int | None,
+    runtime_max_pixels: int | None,
+    expected_grid: int,
+):
+    runtime_kwargs = {}
+    if configured_max_pixels is not None:
+        mm_config = ernie_context.model_config.get_multimodal_config()
+        monkeypatch.setattr(
+            mm_config,
+            "mm_processor_kwargs",
+            {"min_pixels": 3136, "max_pixels": configured_max_pixels},
+        )
+    if runtime_max_pixels is not None:
+        runtime_kwargs = {
+            "min_pixels": 3136,
+            "max_pixels": runtime_max_pixels,
+        }
+
+    processor = MULTIMODAL_REGISTRY.create_processor(
+        ernie_context.model_config,
+        tokenizer=ernie_context.tokenizer,
+    )
+    mm_items = processor.info.parse_mm_data(
+        {"image": Image.new("RGB", (500, 500), "white")}
+    )
+    result = processor(
+        "<|image@placeholder|>",
+        mm_items=mm_items,
+        hf_processor_mm_kwargs=runtime_kwargs,
+    )
+
+    image_grid = result["mm_kwargs"].get_data()["image_grid_thw"]
+    assert image_grid.tolist() == [[1, expected_grid, expected_grid]]
+    expected_tokens = processor.info.get_num_image_tokens(
+        image_width=500,
+        image_height=500,
+        image_processor=processor.info.get_image_processor(),
+        mm_kwargs=runtime_kwargs,
+    )
+    assert expected_tokens == int(image_grid.prod()) // (
+        processor.info.get_hf_config().spatial_conv_size ** 2
+    )
+
+
+def test_native_video_dummy_matches_profiled_tokens(ernie_context):
+    processor = MULTIMODAL_REGISTRY.create_processor(
+        ernie_context.model_config,
+        tokenizer=ernie_context.tokenizer,
+    )
+    seq_len = 8192
+    mm_counts = {"image": 0, "video": 1}
+    dummy_inputs = processor.dummy_inputs.get_dummy_processor_inputs(
+        seq_len, mm_counts, {}
+    )
+    video, _ = dummy_inputs.mm_data_items["video"][0]
+    target_size = processor.info.get_video_size_with_most_features()
+
+    assert video.shape[1:3] == (target_size.width, target_size.height)
+
+    result = processor(
+        dummy_inputs.prompt,
+        mm_items=dummy_inputs.mm_data_items,
+    )
+    (placeholder,) = result["mm_placeholders"]["video"]
+    assert placeholder.length == processor.info.get_max_video_tokens(seq_len, mm_counts)
+
+
+@pytest.mark.parametrize(
+    ("video_type", "do_sample_frames"),
+    [("numpy", False), ("torch", True)],
+)
+def test_native_video_matches_hf_and_preserves_cache_inputs(
+    ernie_context,
+    video_type: str,
+    do_sample_frames: bool,
+):
+    cache = MultiModalProcessorOnlyCache(ernie_context.model_config)
+    processor = MULTIMODAL_REGISTRY.create_processor(
+        ernie_context.model_config,
+        tokenizer=ernie_context.tokenizer,
+        cache=cache,
+    )
+    hf_processor = processor.info.get_hf_processor()
+    prompt = f"{hf_processor.video_token} Describe this input."
+
+    num_frames = 24 if do_sample_frames else 16
+    total_num_frames = num_frames if do_sample_frames else 32
+    frame_indices = (
+        list(range(num_frames))
+        if do_sample_frames
+        else np.linspace(0, total_num_frames - 1, num_frames, dtype=int).tolist()
+    )
+    video_array = np.transpose(_make_video(num_frames), (0, 3, 1, 2)).copy()
+    video = (
+        torch.from_numpy(video_array.copy()) if video_type == "torch" else video_array
+    )
+    video_before = _clone_video(video)
+    metadata = _metadata(frame_indices, total_num_frames, do_sample_frames)
+    metadata_before = deepcopy(metadata)
+    frame_indices_before = metadata["frames_indices"]
+    mm_items = processor.info.parse_mm_data({"video": (video, metadata)})
+    hash_before = _video_hash(prompt, mm_items)
+    processor_kwargs = {"num_frames": 16} if do_sample_frames else {}
+
+    hf_metadata = VideoMetadata(
+        **{key: value for key, value in metadata.items() if key != "do_sample_frames"}
+    )
+    direct_hf = hf_processor(
+        text=[prompt],
+        videos=[_clone_video(video)],
+        video_metadata=[hf_metadata],
+        do_sample_frames=do_sample_frames,
+        return_tensors="pt",
+        **processor_kwargs,
+    )
+
+    def run_processor():
+        return processor(
+            prompt,
+            mm_items=mm_items,
+            hf_processor_mm_kwargs=processor_kwargs,
+        )
+
+    cache_miss = run_processor()
+    hash_after_miss = _video_hash(prompt, mm_items)
+    cache_hit = run_processor()
+
+    if isinstance(video, np.ndarray):
+        assert np.array_equal(video, video_before)
+    else:
+        assert torch.equal(video, video_before)
+    assert metadata == metadata_before
+    assert metadata["frames_indices"] is frame_indices_before
+    assert hash_before == hash_after_miss == _video_hash(prompt, mm_items)
+    assert len(cache._cache) == 1
+
+    expected_ids = direct_hf["input_ids"][0].tolist()
+    expected_grid = direct_hf["video_grid_thw"]
+    expected_pixels = direct_hf["pixel_values_videos"].to(
+        ernie_context.model_config.dtype
+    )
+    for result in (cache_miss, cache_hit):
+        assert result["prompt_token_ids"] == expected_ids
+        mm_kwargs = result["mm_kwargs"].get_data()
+        assert torch.equal(mm_kwargs["video_grid_thw"], expected_grid)
+        assert torch.equal(mm_kwargs["pixel_values_videos"], expected_pixels)
+
+
+def test_native_video_sampling_policy_resolution():
+    processor = object.__new__(Ernie4_5VLMultiModalProcessor)
+    configured_kwargs = {"do_sample_frames": False}
+    processor.info = SimpleNamespace(
+        ctx=SimpleNamespace(
+            get_merged_mm_kwargs=lambda kwargs: configured_kwargs | dict(kwargs)
+        )
+    )
+    hf_processor = SimpleNamespace(
+        video_processor=SimpleNamespace(do_sample_frames=True)
+    )
+    video = _make_video(2)
+
+    _, kwargs = processor._prepare_native_video_inputs(
+        hf_processor,
+        {"videos": [(video, _metadata([0, 1], 2))]},
+        {},
+    )
+    assert kwargs["do_sample_frames"] is False
+
+    configured_kwargs.clear()
+    with pytest.raises(ValueError, match="same do_sample_frames policy"):
+        processor._prepare_native_video_inputs(
+            hf_processor,
+            {
+                "videos": [
+                    (video, _metadata([0, 1], 2, False)),
+                    (video, _metadata([0, 1], 2, True)),
+                ]
+            },
+            {},
+        )

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -842,8 +842,7 @@ _MULTIMODAL_EXAMPLE_MODELS = {
     "Emu3ForConditionalGeneration": _HfExamplesInfo("BAAI/Emu3-Chat-hf"),
     "Ernie4_5_VLMoeForConditionalGeneration": _HfExamplesInfo(
         "baidu/ERNIE-4.5-VL-28B-A3B-PT",
-        trust_remote_code=True,
-        revision="refs/pr/17",
+        revision="db17d8724f9bd48b288e1a15b33aa6af70416af8",
     ),
     "Exaone4_5_ForConditionalGeneration": _HfExamplesInfo(
         "LGAI-EXAONE/EXAONE-4.5-33B",

--- a/vllm/model_executor/models/ernie45_vl.py
+++ b/vllm/model_executor/models/ernie45_vl.py
@@ -25,6 +25,7 @@
 
 import math
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+from copy import deepcopy
 from functools import partial
 from typing import Annotated, Any, Literal
 
@@ -34,6 +35,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from einops import rearrange
 from transformers import BaseImageProcessor, BatchFeature
+from transformers.video_utils import VideoMetadata
 
 from vllm.config import VllmConfig
 from vllm.config.multimodal import BaseDummyOptions, VideoDummyOptions
@@ -74,6 +76,10 @@ from vllm.sequence import IntermediateTensors
 from vllm.utils.tensor_schema import TensorSchema, TensorShape
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
+from .ernie45_vl_config import (
+    get_ernie4_5_vl_config,
+    get_ernie4_5_vl_vision_norm_eps,
+)
 from .ernie45_vl_moe import Ernie4_5_VLMoeForCausalLM
 from .interfaces import (
     MultiModalEmbeddings,
@@ -359,10 +365,12 @@ class Ernie4_5_VisionTransformer(nn.Module):
         spatial_merge_size = vision_config.spatial_merge_size
         in_channels = vision_config.in_channels
         hidden_size = vision_config.hidden_size
-        embed_dim = vision_config.embed_dim
+        embed_dim = getattr(vision_config, "embed_dim", hidden_size)
         depth = vision_config.depth
         num_heads = vision_config.num_heads
-        mlp_ratio = vision_config.mlp_ratio
+        mlp_ratio = getattr(vision_config, "mlp_ratio", None)
+        if mlp_ratio is None:
+            mlp_ratio = vision_config.intermediate_size / hidden_size
 
         self.spatial_merge_size = spatial_merge_size
         self.num_heads = num_heads
@@ -615,7 +623,7 @@ class VariableResolutionResamplerModel(nn.Module):
         self.config = config
         self.spatial_conv_size = spatial_conv_size
         self.temporal_conv_size = temporal_conv_size
-        self.use_temporal_conv = config.use_temporal_conv
+        self.use_temporal_conv = getattr(config, "use_temporal_conv", True)
 
         # compress 2d conv(picture) to 1d
         self.spatial_dim = self.in_dim * self.spatial_conv_size * self.spatial_conv_size
@@ -785,13 +793,38 @@ class VariableResolutionResamplerModel(nn.Module):
 
 class Ernie4_5_VLProcessingInfo(BaseProcessingInfo):
     def get_hf_config(self):
-        return self.ctx.model_config.hf_config
+        return get_ernie4_5_vl_config(self.ctx.model_config.hf_config)
+
+    def uses_native_hf_config(self) -> bool:
+        return getattr(self.ctx.model_config.hf_config, "text_config", None) is not None
 
     def get_hf_processor(self, **kwargs: object):
         return self.ctx.get_hf_processor(use_fast=True, **kwargs)
 
     def get_image_processor(self, **kwargs: object):
         return self.get_hf_processor(**kwargs).image_processor
+
+    def get_video_processor(self, **kwargs: object):
+        hf_processor = self.get_hf_processor(**kwargs)
+        return getattr(hf_processor, "video_processor", hf_processor.image_processor)
+
+    def normalize_mm_kwargs(self, mm_kwargs: Mapping[str, object]) -> dict[str, object]:
+        normalized = dict(mm_kwargs)
+        if not self.uses_native_hf_config():
+            return normalized
+
+        size = dict(normalized.get("size", {}))  # type: ignore[arg-type]
+        for alias, native_key in (
+            ("min_pixels", "shortest_edge"),
+            ("max_pixels", "longest_edge"),
+        ):
+            if alias in normalized:
+                value = normalized.pop(alias)
+                if value is not None:
+                    size[native_key] = value
+        if size:
+            normalized["size"] = size
+        return normalized
 
     def get_data_parser(self):
         return MultiModalDataParser(
@@ -828,16 +861,16 @@ class Ernie4_5_VLProcessingInfo(BaseProcessingInfo):
         spatial_conv_size = hf_config.spatial_conv_size
         temporal_conv_size = hf_config.temporal_conv_size
 
-        if self.ctx.model_config.trust_remote_code:
-            # Defined in HF Hub repo
-            min_pixels_key = "min_pixels"
-            max_pixels_key = "max_pixels"
-        else:
+        if self.uses_native_hf_config():
             # Defined in Transformers library (requires v5.0 or above)
             min_pixels_key = "shortest_edge"
             max_pixels_key = "longest_edge"
+        else:
+            # Defined in HF Hub repo
+            min_pixels_key = "min_pixels"
+            max_pixels_key = "max_pixels"
 
-        mm_kwargs = self.ctx.get_merged_mm_kwargs(mm_kwargs)
+        mm_kwargs = self.normalize_mm_kwargs(self.ctx.get_merged_mm_kwargs(mm_kwargs))
         size = image_processor.size
         if override_size := mm_kwargs.get("size"):
             size = size | override_size
@@ -901,16 +934,22 @@ class Ernie4_5_VLProcessingInfo(BaseProcessingInfo):
         )
         return num_video_tokens
 
-    def get_image_size_with_most_features(self) -> ImageSize:
-        image_processor = self.get_image_processor()
-
-        max_image_size, _ = self._get_vision_info(
+    def _get_size_with_most_features(
+        self, image_processor: BaseImageProcessor
+    ) -> ImageSize:
+        max_size, _ = self._get_vision_info(
             image_width=9999999,
             image_height=9999999,
             image_processor=image_processor,
             mm_kwargs={},
         )
-        return max_image_size
+        return max_size
+
+    def get_image_size_with_most_features(self) -> ImageSize:
+        return self._get_size_with_most_features(self.get_image_processor())
+
+    def get_video_size_with_most_features(self) -> ImageSize:
+        return self._get_size_with_most_features(self.get_video_processor())
 
     def get_max_image_tokens(self) -> int:
         image_processor = self.get_image_processor()
@@ -925,8 +964,8 @@ class Ernie4_5_VLProcessingInfo(BaseProcessingInfo):
         return num_image_tokens
 
     def _get_max_video_frames(self, max_tokens: int) -> int:
-        image_processor = self.get_image_processor()
-        target_width, target_height = self.get_image_size_with_most_features()
+        video_processor = self.get_video_processor()
+        target_width, target_height = self.get_video_size_with_most_features()
 
         num_frames = 0
 
@@ -936,7 +975,7 @@ class Ernie4_5_VLProcessingInfo(BaseProcessingInfo):
                 image_width=target_width,
                 image_height=target_height,
                 num_frames=next_num_frames,
-                image_processor=image_processor,
+                image_processor=video_processor,
                 mm_kwargs={},
             )
 
@@ -970,19 +1009,111 @@ class Ernie4_5_VLProcessingInfo(BaseProcessingInfo):
         seq_len: int,
         mm_counts: Mapping[str, int],
     ) -> int:
-        image_processor = self.get_image_processor()
-        target_width, target_height = self.get_image_size_with_most_features()
+        video_processor = self.get_video_processor()
+        target_width, target_height = self.get_video_size_with_most_features()
 
         return self.get_num_video_tokens(
             image_width=target_width,
             image_height=target_height,
             num_frames=self.get_num_frames_with_most_features(seq_len, mm_counts),
-            image_processor=image_processor,
+            image_processor=video_processor,
             mm_kwargs={},
         )
 
 
 class Ernie4_5VLMultiModalProcessor(BaseMultiModalProcessor[Ernie4_5_VLProcessingInfo]):
+    @staticmethod
+    def _clone_native_video_data(video: object) -> object:
+        """Copy mutable buffers before the native processor draws timestamps."""
+        if isinstance(video, np.ndarray):
+            return video.copy()
+        if isinstance(video, torch.Tensor):
+            return video.clone()
+        if isinstance(video, list):
+            return [
+                Ernie4_5VLMultiModalProcessor._clone_native_video_data(item)
+                for item in video
+            ]
+        if isinstance(video, tuple):
+            return tuple(
+                Ernie4_5VLMultiModalProcessor._clone_native_video_data(item)
+                for item in video
+            )
+        return video
+
+    def _prepare_native_video_inputs(
+        self,
+        hf_processor: Any,
+        mm_data: Mapping[str, object],
+        mm_kwargs: Mapping[str, object],
+    ) -> tuple[dict[str, object], dict[str, object]]:
+        prepared_data = dict(mm_data)
+        prepared_kwargs = dict(mm_kwargs)
+        videos = prepared_data.get("videos")
+        if not isinstance(videos, list) or not videos:
+            return prepared_data, prepared_kwargs
+
+        effective_kwargs = self.info.ctx.get_merged_mm_kwargs(mm_kwargs)
+        global_policy = effective_kwargs.get("do_sample_frames")
+        has_global_policy = global_policy is not None
+        if not has_global_policy:
+            global_policy = getattr(
+                hf_processor.video_processor, "do_sample_frames", True
+            )
+        if not isinstance(global_policy, bool):
+            raise TypeError(
+                "ERNIE video do_sample_frames must be a bool, "
+                f"got {type(global_policy)}"
+            )
+
+        hf_videos = []
+        hf_video_metadata = []
+        sampling_policies = []
+        for item_idx, item in enumerate(videos):
+            if not isinstance(item, tuple) or len(item) != 2:
+                raise TypeError("ERNIE video input must include metadata")
+            video, metadata = item
+            if not isinstance(metadata, Mapping):
+                raise TypeError(
+                    "ERNIE video metadata must be a mapping, "
+                    f"got {type(metadata)} for item {item_idx}"
+                )
+
+            item_policy = global_policy
+            metadata_fields = deepcopy(dict(metadata))
+            metadata_policy = metadata_fields.pop("do_sample_frames", None)
+            if metadata_policy is not None:
+                if not isinstance(metadata_policy, bool):
+                    raise TypeError(
+                        "ERNIE video metadata do_sample_frames must be a bool, "
+                        f"got {type(metadata_policy)} for item {item_idx}"
+                    )
+                if has_global_policy and metadata_policy != global_policy:
+                    raise ValueError(
+                        "Conflicting ERNIE video sampling policies for item "
+                        f"{item_idx}: processor kwargs specify {global_policy} "
+                        f"but metadata specifies {metadata_policy}"
+                    )
+                item_policy = metadata_policy
+
+            hf_videos.append(
+                Ernie4_5VLMultiModalProcessor._clone_native_video_data(video)
+            )
+            sampling_policies.append(item_policy)
+            hf_video_metadata.append(VideoMetadata(**metadata_fields))
+
+        if len(set(sampling_policies)) != 1:
+            raise ValueError(
+                "All videos in one ERNIE request must use the same "
+                "do_sample_frames policy; got "
+                f"{sampling_policies}"
+            )
+
+        prepared_data["videos"] = hf_videos
+        prepared_data["video_metadata"] = hf_video_metadata
+        prepared_kwargs["do_sample_frames"] = sampling_policies[0]
+        return prepared_data, prepared_kwargs
+
     def _pixel_values_norm(
         self,
         pixel_values: torch.Tensor,
@@ -1027,6 +1158,14 @@ class Ernie4_5VLMultiModalProcessor(BaseMultiModalProcessor[Ernie4_5_VLProcessin
         mm_kwargs: Mapping[str, object],
         tok_kwargs: Mapping[str, object],
     ) -> BatchFeature:
+        hf_processor = self.info.get_hf_processor(
+            **self.info.normalize_mm_kwargs(mm_kwargs)
+        )
+        if self.info.uses_native_hf_config():
+            prompt = prompt.replace(
+                "<|image@placeholder|>", hf_processor.image_token
+            ).replace("<|video@placeholder|>", hf_processor.video_token)
+
         # when the prompt is not empty but the multimodal data is empty,
         # directly invoke the tokenizer.
         if "images" not in mm_data and "videos" not in mm_data and prompt != "":
@@ -1037,35 +1176,47 @@ class Ernie4_5VLMultiModalProcessor(BaseMultiModalProcessor[Ernie4_5_VLProcessin
             )
             return tokenizer_output
 
-        if "images" not in mm_data:
-            mm_data["images"] = []
-        if "videos" not in mm_data:
-            mm_data["videos"] = []
+        processor_mm_data = dict(mm_data)
+        processor_mm_kwargs = dict(mm_kwargs)
 
-        # Check if HF processor supports video metadata
-        hf_processor = self.info.get_hf_processor(**mm_kwargs)
-        supports_video_metadata = getattr(
-            hf_processor, "supports_video_metadata", False
-        )
+        if not self.info.uses_native_hf_config():
+            # The remote processor requires both modality fields.
+            processor_mm_data.setdefault("images", [])
+            processor_mm_data.setdefault("videos", [])
 
-        if mm_data["videos"] and not supports_video_metadata:
-            # Old HF processor, unwrap tuple to pure frames
-            logger.warning_once(
-                "HF processor doesn't support video metadata. "
-                "Timestamps will NOT be rendered. Please upgrade the model."
+            supports_video_metadata = getattr(
+                hf_processor, "supports_video_metadata", False
             )
-            mm_data["videos"] = [
-                v[0] if isinstance(v, tuple) else v for v in mm_data["videos"]
-            ]
+            if processor_mm_data.get("videos") and not supports_video_metadata:
+                logger.warning_once(
+                    "HF processor doesn't support video metadata. "
+                    "Timestamps will NOT be rendered. Please upgrade the model."
+                )
+                processor_mm_data["videos"] = [
+                    video[0] if isinstance(video, tuple) else video
+                    for video in processor_mm_data["videos"]  # type: ignore[union-attr]
+                ]
+        else:
+            processor_mm_data, processor_mm_kwargs = self._prepare_native_video_inputs(
+                hf_processor,
+                processor_mm_data,
+                processor_mm_kwargs,
+            )
+
+        processor_callable = hf_processor
+        if self.info.uses_native_hf_config():
+
+            def processor_callable(**kwargs):
+                return hf_processor(**self.info.normalize_mm_kwargs(kwargs))
 
         processor_output = self.info.ctx.call_hf_processor(
-            hf_processor,
-            dict(text=[prompt], images=mm_data["images"], videos=mm_data["videos"]),
-            dict(**mm_kwargs, **tok_kwargs),
+            processor_callable,
+            dict(text=[prompt], **processor_mm_data),
+            dict(**processor_mm_kwargs, **tok_kwargs),
         )
 
-        # Divide the processor_output into two modalities: image and video.
-        if processor_output is not None:
+        # The remote processor combines image and video patches under ``images``.
+        if processor_output is not None and "images" in processor_output:
             pixel_values = processor_output["images"]
             if pixel_values is not None:
                 processor_output["images"] = self._pixel_values_norm(
@@ -1097,6 +1248,23 @@ class Ernie4_5VLMultiModalProcessor(BaseMultiModalProcessor[Ernie4_5_VLProcessin
 
         return processor_output
 
+    def _apply_hf_processor_tokens_only(
+        self,
+        prompt_tokens: list[int],
+    ) -> list[int]:
+        if not self.info.uses_native_hf_config():
+            return prompt_tokens
+
+        tokenizer = self.info.get_tokenizer()
+        hf_processor = self.info.get_hf_processor()
+        prompt = tokenizer.decode(prompt_tokens)
+        normalized_prompt = prompt.replace(
+            "<|image@placeholder|>", hf_processor.image_token
+        ).replace("<|video@placeholder|>", hf_processor.video_token)
+        if normalized_prompt == prompt:
+            return prompt_tokens
+        return tokenizer.encode(normalized_prompt, add_special_tokens=False)
+
     def _get_prompt_updates(
         self,
         mm_items: MultiModalDataItems,
@@ -1104,6 +1272,7 @@ class Ernie4_5VLMultiModalProcessor(BaseMultiModalProcessor[Ernie4_5_VLProcessin
         out_mm_kwargs: MultiModalKwargsItems,
     ) -> Sequence[PromptUpdate]:
         hf_processor = self.info.get_hf_processor(**hf_processor_mm_kwargs)
+        hf_config = self.info.get_hf_config()
 
         before_placeholder = {
             "image": "<|image@placeholder|>",
@@ -1111,12 +1280,18 @@ class Ernie4_5VLMultiModalProcessor(BaseMultiModalProcessor[Ernie4_5_VLProcessin
         }
 
         after_placeholder = {
-            # image and video have same placeholder
-            "image": "<|IMAGE_PLACEHOLDER|>",
-            "video": "<|IMAGE_PLACEHOLDER|>",
+            "image": getattr(hf_processor, "image_token", "<|IMAGE_PLACEHOLDER|>"),
+            # Only the native processor has a dedicated video patch token.
+            "video": getattr(hf_processor, "video_token", "<|IMAGE_PLACEHOLDER|>"),
         }
 
-        merge_length = hf_processor.spatial_conv_size**2
+        target_placeholders = (
+            after_placeholder
+            if self.info.uses_native_hf_config()
+            else before_placeholder
+        )
+
+        merge_length = hf_config.spatial_conv_size**2
 
         def get_replacement_ernie45vl(item_idx: int, modality: str):
             out_item = out_mm_kwargs[modality][item_idx]
@@ -1124,9 +1299,7 @@ class Ernie4_5VLMultiModalProcessor(BaseMultiModalProcessor[Ernie4_5_VLProcessin
             assert isinstance(grid_thw, torch.Tensor)
             if modality == "video":
                 num_tokens = (
-                    int(grid_thw.prod())
-                    // hf_processor.temporal_conv_size
-                    // merge_length
+                    int(grid_thw.prod()) // hf_config.temporal_conv_size // merge_length
                 )
             else:
                 num_tokens = int(grid_thw.prod()) // merge_length
@@ -1135,7 +1308,7 @@ class Ernie4_5VLMultiModalProcessor(BaseMultiModalProcessor[Ernie4_5_VLProcessin
         return [
             PromptReplacement(
                 modality=modality,
-                target=before_placeholder[modality],
+                target=target_placeholders[modality],
                 replacement=partial(get_replacement_ernie45vl, modality=modality),
             )
             for modality in ("image", "video")
@@ -1187,7 +1360,8 @@ class Ernie4_5_VLDummyInputsBuilder(BaseDummyInputsBuilder[Ernie4_5_VLProcessing
         num_images = mm_counts.get("image", 0)
         num_videos = mm_counts.get("video", 0)
 
-        target_width, target_height = self.info.get_image_size_with_most_features()
+        image_width, image_height = self.info.get_image_size_with_most_features()
+        video_width, video_height = self.info.get_video_size_with_most_features()
         target_num_frames = self.info.get_num_frames_with_most_features(
             seq_len, mm_counts
         )
@@ -1197,14 +1371,14 @@ class Ernie4_5_VLDummyInputsBuilder(BaseDummyInputsBuilder[Ernie4_5_VLProcessing
 
         return {
             "image": self._get_dummy_images(
-                width=target_width,
-                height=target_height,
+                width=image_width,
+                height=image_height,
                 num_images=num_images,
                 overrides=image_overrides,
             ),
             "video": self._get_dummy_videos(
-                width=target_width,
-                height=target_height,
+                width=video_width,
+                height=video_height,
                 num_frames=target_num_frames,
                 num_videos=num_videos,
                 overrides=video_overrides,
@@ -1301,7 +1475,7 @@ class Ernie4_5_VLMoeForConditionalGeneration(
 
     def __init__(self, vllm_config: VllmConfig, prefix: str = "") -> None:
         super().__init__()
-        config = vllm_config.model_config.hf_config
+        config = get_ernie4_5_vl_config(vllm_config.model_config.hf_config)
         quant_config = vllm_config.quant_config
         multimodal_config = vllm_config.model_config.multimodal_config
 
@@ -1311,12 +1485,12 @@ class Ernie4_5_VLMoeForConditionalGeneration(
         with self._mark_tower_model(vllm_config, {"image", "video"}):
             self.vision_model = Ernie4_5_VisionTransformer(
                 config.vision_config,
-                norm_eps=getattr(config, "rms_norm_eps", 1e-6),
+                norm_eps=get_ernie4_5_vl_vision_norm_eps(config),
                 quant_config=quant_config,
                 prefix=maybe_prefix(prefix, "vision_model"),
             )
             self.resampler_model = VariableResolutionResamplerModel(
-                self.config.pixel_hidden_size,
+                self.config.vision_config.hidden_size,
                 self.config.hidden_size,
                 self.config.spatial_conv_size,
                 self.config.temporal_conv_size,
@@ -1339,6 +1513,7 @@ class Ernie4_5_VLMoeForConditionalGeneration(
                 token_id
                 for token_id in [
                     self.config.im_patch_id,
+                    getattr(self.config, "video_token_id", None),
                     getattr(self.config, "image_start_token_id", None),
                     getattr(self.config, "image_end_token_id", None),
                     getattr(self.config, "video_start_token_id", None),

--- a/vllm/model_executor/models/ernie45_vl_config.py
+++ b/vllm/model_executor/models/ernie45_vl_config.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Compatibility accessors for ERNIE 4.5 VL configuration layouts."""
+
+from typing import Any
+
+from transformers import PretrainedConfig
+
+
+def _as_modality_pair(value: int | list[int] | tuple[int, ...]) -> list[int]:
+    if isinstance(value, int):
+        return [value, value]
+    return list(value)
+
+
+class _Ernie4_5VLConfigView:
+    """Read-only flat view of the native Transformers composite config."""
+
+    def __init__(self, config: PretrainedConfig) -> None:
+        self._config = config
+        self._text_config = config.text_config
+
+    @property
+    def im_patch_id(self) -> int:
+        return self._config.image_token_id
+
+    @property
+    def spatial_conv_size(self) -> int:
+        return self._config.vision_config.spatial_merge_size
+
+    @property
+    def temporal_conv_size(self) -> int:
+        return self._config.vision_config.temporal_merge_size
+
+    @property
+    def moe_num_experts(self) -> list[int]:
+        return _as_modality_pair(self._text_config.moe_num_experts)
+
+    def __getattr__(self, name: str) -> Any:
+        try:
+            return getattr(self._config, name)
+        except AttributeError:
+            return getattr(self._text_config, name)
+
+
+def get_ernie4_5_vl_config(config: PretrainedConfig) -> PretrainedConfig:
+    """Return a model-facing view for native composite ERNIE configs."""
+    if getattr(config, "text_config", None) is None:
+        return config
+    return _Ernie4_5VLConfigView(config)  # type: ignore[return-value]
+
+
+def get_ernie4_5_vl_vision_norm_eps(config: PretrainedConfig) -> float:
+    """Select the vision norm epsilon, with legacy flat-config fallback."""
+    vision_config = config.vision_config
+    return getattr(
+        vision_config,
+        "rms_norm_eps",
+        getattr(config, "rms_norm_eps", 1e-6),
+    )

--- a/vllm/model_executor/models/ernie45_vl_moe.py
+++ b/vllm/model_executor/models/ernie45_vl_moe.py
@@ -63,6 +63,7 @@ from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.config import set_default_rope_theta
 
 from .ernie45_moe import Ernie4_5_MoeMLP
+from .ernie45_vl_config import get_ernie4_5_vl_config
 from .interfaces import SupportsPP
 from .utils import (
     PPMissingLayer,
@@ -213,24 +214,29 @@ class Ernie4_5_VLMoeMoE(nn.Module):
                 f"the number of experts {moe_num_experts}."
             )
 
-        moe_layer_start_index = config.moe_layer_start_index
-        text_moe_layer_start_index = moe_layer_start_index[0]
-        vision_moe_layer_start_index = moe_layer_start_index[1]
-        moe_layer_end_index = config.moe_layer_end_index
-        moe_layer_end_index = getattr(
-            config,
-            "moe_layer_end_index",
-            [config.num_hidden_layers - 1, config.num_hidden_layers - 1],
-        )
-        text_moe_layer_end_index = moe_layer_end_index[0]
-        vision_moe_layer_end_index = moe_layer_end_index[1]
+        mlp_layer_types = getattr(config, "mlp_layer_types", None)
+        if mlp_layer_types is not None:
+            text_uses_moe = vision_uses_moe = True
+        else:
+            moe_layer_start_index = config.moe_layer_start_index
+            moe_layer_end_index = getattr(
+                config,
+                "moe_layer_end_index",
+                [config.num_hidden_layers - 1, config.num_hidden_layers - 1],
+            )
+            assert moe_layer_start_index[0] <= moe_layer_end_index[0]
+            assert moe_layer_start_index[1] <= moe_layer_end_index[1]
+            text_uses_moe = (
+                moe_layer_start_index[0] <= layer_idx <= moe_layer_end_index[0]
+            )
+            vision_uses_moe = (
+                moe_layer_start_index[1] <= layer_idx <= moe_layer_end_index[1]
+            )
 
         assert config.moe_num_experts[0] == config.moe_num_experts[1]
         self.e_score_correction_bias = nn.Parameter(
             torch.empty(2, config.moe_num_experts[0], dtype=torch.float32)
         )
-
-        assert text_moe_layer_start_index <= text_moe_layer_end_index
 
         if self.has_shared_experts:
             intermediate_size = (
@@ -247,10 +253,7 @@ class Ernie4_5_VLMoeMoE(nn.Module):
         else:
             self.shared_experts = None
 
-        if (
-            layer_idx >= text_moe_layer_start_index
-            and layer_idx <= text_moe_layer_end_index
-        ):
+        if text_uses_moe:
             self.text_experts_gate = ReplicatedLinear(
                 config.hidden_size,
                 config.moe_num_experts[0],
@@ -283,11 +286,7 @@ class Ernie4_5_VLMoeMoE(nn.Module):
                 prefix=f"{prefix}.mlp",
             )
 
-        assert vision_moe_layer_start_index <= vision_moe_layer_end_index
-        if (
-            layer_idx >= vision_moe_layer_start_index
-            and layer_idx <= vision_moe_layer_end_index
-        ):
+        if vision_uses_moe:
             self.vision_experts_gate = ReplicatedLinear(
                 config.hidden_size,
                 config.moe_num_experts[1],
@@ -381,6 +380,32 @@ class Ernie4_5_VLMoeMoE(nn.Module):
         return final_hidden_states.view(orig_shape)
 
 
+def _is_moe_layer(config: PretrainedConfig, layer_idx: int) -> bool:
+    mlp_layer_types = getattr(config, "mlp_layer_types", None)
+    if mlp_layer_types is not None:
+        if layer_idx >= len(mlp_layer_types):
+            raise ValueError(
+                "ERNIE 4.5 VL config has fewer MLP layer types "
+                f"({len(mlp_layer_types)}) than decoder layers "
+                f"(requested layer {layer_idx})"
+            )
+        return mlp_layer_types[layer_idx] == "sparse"
+
+    start = min(config.moe_layer_start_index)
+    end = max(
+        getattr(
+            config,
+            "moe_layer_end_index",
+            [config.num_hidden_layers - 1, config.num_hidden_layers - 1],
+        )
+    )
+    return (
+        getattr(config, "use_moe", max(config.moe_num_experts) > 0)
+        and (layer_idx + 1) % getattr(config, "moe_layer_interval", 1) == 0
+        and start <= layer_idx <= end
+    )
+
+
 class Ernie4_5_VLMoeDecoderLayer(nn.Module):
     def __init__(
         self,
@@ -413,27 +438,7 @@ class Ernie4_5_VLMoeDecoderLayer(nn.Module):
         layer_idx = extract_layer_index(prefix)
         self.layer_idx = layer_idx
 
-        # MoE
-        moe_layer_start_index = config.moe_layer_start_index
-        min_moe_layer_start_index = min(moe_layer_start_index)
-        moe_layer_end_index = getattr(
-            config,
-            "moe_layer_end_index",
-            [config.num_hidden_layers - 1, config.num_hidden_layers - 1],
-        )
-        max_moe_layer_end_index = max(moe_layer_end_index)
-        assert min_moe_layer_start_index <= max_moe_layer_end_index
-        moe_num_experts = config.moe_num_experts
-        max_moe_num_experts = max(moe_num_experts)
-        moe_layer_interval = getattr(config, "moe_layer_interval", 1)
-        use_moe = getattr(config, "use_moe", max_moe_num_experts > 0)
-
-        if (
-            use_moe
-            and ((layer_idx + 1) % moe_layer_interval == 0)
-            and layer_idx >= min_moe_layer_start_index
-            and layer_idx <= max_moe_layer_end_index
-        ):
+        if _is_moe_layer(config, layer_idx):
             self.mlp = Ernie4_5_VLMoeMoE(
                 config=config, quant_config=quant_config, prefix=f"{prefix}.mlp"
             )
@@ -497,7 +502,7 @@ class Ernie4_5_VLMoeModel(nn.Module):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
 
-        config = vllm_config.model_config.hf_config
+        config = get_ernie4_5_vl_config(vllm_config.model_config.hf_config)
         cache_config = vllm_config.cache_config
         quant_config = vllm_config.quant_config
 
@@ -592,7 +597,7 @@ class Ernie4_5_VLMoeForCausalLM(nn.Module, SupportsPP):
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
-        config = vllm_config.model_config.hf_config
+        config = get_ernie4_5_vl_config(vllm_config.model_config.hf_config)
         quant_config = vllm_config.quant_config
         self.config = config
         self.quant_config = quant_config


### PR DESCRIPTION
## Summary
- Pin the immutable native Transformers snapshot instead of mutable remote code that performs an unbounded font download during import.
- Bridge the native composite text, vision, MoE, image, and video contracts while retaining legacy flat-config behavior.
- Preserve native image/video token identity, metadata, sizing, cache inputs, and caller-owned video buffers.

The Buildkite child failed before EngineCore startup while importing the remote processor. A separate job captured the exact network error at its timeout-free font request.

## Validation
- Config, M-RoPE, and processor contracts: 17 passed.
- Exact native architecture initialization: 1 passed on MI355.
- Real-model evaluation verified all 12 BF16 shard checksums; image output was `5`, text output was `42`, all log probabilities were finite, and shutdown returned the GPU to baseline.
- Changed-file pre-commit passed.

Buildkite: [Extra Initialization 4](https://buildkite.com/vllm/amd-ci/builds/11196/list?jid=019f90f8-af24-4243-8388-74e8f6c103d7&tab=output)

Duplicate check: no open PR was found for native Transformers ERNIE 4.5 VL compatibility.

AI assistance: Codex assisted with investigation, implementation, and validation; Andreas directed the compatibility design and reviewed the resulting changes.