### PR TITLE
[CI] Add trusted /ci policy and catalog metadata

### DIFF
--- a/.buildkite/ci_control.toml
+++ b/.buildkite/ci_control.toml
@@ -1,0 +1,33 @@
+api_version = 1
+
+[catalog]
+groups = ["upstream", "cpu", "amd"]
+# Record reviewed stable-key renames and removals here.
+aliases = {}
+tombstones = []
+# Area names are public selectors too; preserve renames and removals.
+area_aliases = {}
+area_tombstones = []
+# Native AMD is an opaque whole-lane selector until its generated pipeline
+# publishes stable per-job metadata. Do not infer native AMD areas from labels.
+native_amd_selection = "whole_lane"
+
+[authorization]
+minimum_compute_permission = "write"
+minimum_refresh_permission = "write"
+minimum_credit_grant_permission = "maintain"
+committer_teams = ["vllm-committers"]
+credit_admin_teams = []
+
+[credits]
+initial_grant = 300
+reset = "none"
+
+[retry]
+failures_limit = "inf"
+include_states = ["failed", "timed_out", "expired"]
+
+[main_status]
+confirmation_distinct_shas = 2
+resolution_clean_distinct_shas = 3
+evidence_max_age_hours = 72

--- a/.buildkite/hardware_tests/cpu.yaml
+++ b/.buildkite/hardware_tests/cpu.yaml
@@ -2,6 +2,9 @@ group: CPU
 depends_on: []
 steps:
 - label: CPU-Kernel Tests
+  key: cpu-kernel-tests
+  ci_control:
+    areas: [kernels]
   depends_on: []
   device: intel_cpu
   no_plugin: true
@@ -49,6 +52,9 @@ steps:
 #       bash .buildkite/scripts/hardware_ci/run-cpu-compatibility-test.sh"
 
 - label: CPU-Language Generation and Pooling Model Tests
+  key: cpu-language-generation-pooling-model-tests
+  ci_control:
+    areas: [models]
   depends_on: []
   device: intel_cpu
   no_plugin: true
@@ -64,6 +70,9 @@ steps:
       pytest -x -v -s tests/models/language/pooling -m cpu_model"
 
 - label: CPU-ModelRunnerV2 Tests
+  key: cpu-model-runner-v2-tests
+  ci_control:
+    areas: [model-runner-v2]
   depends_on: []
   device: intel_cpu
   no_plugin: true
@@ -85,6 +94,9 @@ steps:
       pytest -x -v -s tests/v1/e2e/test_cpu_linear_attn_chunked_prefix.py"
 
 - label: CPU-Quantization Model Tests
+  key: cpu-quantization-model-tests
+  ci_control:
+    areas: [quantization]
   depends_on: []
   device: intel_cpu
   no_plugin: true
@@ -106,6 +118,9 @@ steps:
       pytest -x -v -s tests/quantization/test_cpu_w8a8.py"
       
 - label: CPU-Distributed Tests (PP+TP)
+  key: cpu-distributed-pp-tp
+  ci_control:
+    areas: [distributed]
   depends_on: []
   device: intel_cpu
   no_plugin: true
@@ -125,6 +140,9 @@ steps:
       bash .buildkite/scripts/hardware_ci/run-cpu-distributed-smoke-test.sh tp_pp"
 
 - label: CPU-Distributed Tests (DP+TP)
+  key: cpu-distributed-dp-tp
+  ci_control:
+    areas: [distributed]
   depends_on: []
   device: intel_cpu
   no_plugin: true
@@ -135,6 +153,9 @@ steps:
       bash .buildkite/scripts/hardware_ci/run-cpu-distributed-smoke-test.sh dp_tp"
 
 - label: CPU-Multi-Modal Model Tests %N
+  key: cpu-multimodal-model-tests
+  ci_control:
+    areas: [models]
   depends_on: []
   device: intel_cpu
   no_plugin: true
@@ -149,6 +170,9 @@ steps:
   parallelism: 4
 
 - label: CPU-Qwen2.5-VL Multimodal Tests
+  key: cpu-qwen2-5-vl-multimodal-tests
+  ci_control:
+    areas: [models]
   depends_on: []
   device: intel_cpu
   no_plugin: true
@@ -162,6 +186,9 @@ steps:
       VLLM_CI_ENV=0 pytest -x -v -s tests/models/multimodal/generation/test_qwen2_5_vl.py"
 
 - label: "Arm CPU Test"
+  key: arm-cpu-test
+  ci_control:
+    areas: [smoke]
   depends_on: []
   soft_fail: false
   device: arm_cpu

--- a/.buildkite/test_areas/docker.yaml
+++ b/.buildkite/test_areas/docker.yaml
@@ -3,6 +3,7 @@ depends_on:
   - image-build-cpu
 steps:
 - label: Docker Build Metadata
+  key: docker-build-metadata
   timeout_in_minutes: 20
   device: cpu-small
   source_file_dependencies:

--- a/.buildkite/test_areas/kernels.yaml
+++ b/.buildkite/test_areas/kernels.yaml
@@ -215,6 +215,7 @@ steps:
     - pytest -v -s kernels/mamba
 
 - label: Kernels KDA Test
+  key: kernels-kda-test
   timeout_in_minutes: 25
   device: h200_18gb
   source_file_dependencies:

--- a/.buildkite/test_areas/lm_eval.yaml
+++ b/.buildkite/test_areas/lm_eval.yaml
@@ -364,6 +364,7 @@ steps:
   - pytest -s -v evals/gsm8k/test_gsm8k_offloading.py -k "deepseek-v4-flash"
 
 - label: MRCR Eval Small Models
+  key: mrcr-eval-small-models
   device: h200_35gb
   timeout_in_minutes: 25
   source_file_dependencies:

--- a/.buildkite/test_areas/rust_frontend.yaml
+++ b/.buildkite/test_areas/rust_frontend.yaml
@@ -3,6 +3,7 @@ depends_on:
   - image-build
 steps:
 - label: Rust Frontend OpenAI Coverage
+  key: rust-frontend-openai-coverage
   timeout_in_minutes: 30
   device: h200_18gb
   working_dir: "/vllm-workspace/tests"
@@ -38,6 +39,7 @@ steps:
   - pytest -v -s v1/sample/test_logprobs_e2e.py -k "test_prompt_logprobs_e2e_server"
 
 - label: Rust Frontend Serve/Admin Coverage
+  key: rust-frontend-serve-admin-coverage
   timeout_in_minutes: 25
   device: h200_18gb
   working_dir: "/vllm-workspace/tests"
@@ -67,6 +69,7 @@ steps:
   - pytest -v -s entrypoints/serve/tokenize/test_tokenization.py -k "not tokenizer_info"
 
 - label: Rust Frontend Core Correctness
+  key: rust-frontend-core-correctness
   timeout_in_minutes: 20
   device: h200_18gb
   working_dir: "/vllm-workspace/tests"
@@ -81,6 +84,7 @@ steps:
   - pytest -s entrypoints/openai/correctness/test_lmeval.py::test_lm_eval_accuracy_v1_engine
 
 - label: Rust Frontend Tool Use
+  key: rust-frontend-tool-use
   device: h200_35gb
   timeout_in_minutes: 25
   working_dir: "/vllm-workspace/tests"
@@ -96,6 +100,7 @@ steps:
   - pytest -v -s tool_use --ignore=tool_use/mistral --models llama3.2 -k "not test_response_format_with_tool_choice_required and not test_parallel_tool_calls_false and not test_tool_call_and_choice"
 
 - label: Rust Frontend Distributed
+  key: rust-frontend-distributed
   timeout_in_minutes: 25
   num_devices: 4
   working_dir: "/vllm-workspace/tests"

--- a/.buildkite/test_areas/spec_decode.yaml
+++ b/.buildkite/test_areas/spec_decode.yaml
@@ -163,6 +163,7 @@ steps:
     - pytest -v -s v1/spec_decode/test_speculators_correctness.py -m slow_test
 
 - label: Spec Decode MTP hybrid (B200)
+  key: spec-decode-mtp-hybrid-b200
   timeout_in_minutes: 20
   device: b200-k8s
   optional: true

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -86,6 +86,8 @@
 
 # CI & building
 /.buildkite @Harry-Chen @khluu
+/.github/workflows/ci-catalog.yml @Harry-Chen @khluu
+/.github/workflows/run-ci-command.yml @Harry-Chen @khluu
 /docker/Dockerfile @Harry-Chen @khluu
 /pyproject.toml @khluu
 /setup.py @khluu

--- a/.github/workflows/ci-catalog.yml
+++ b/.github/workflows/ci-catalog.yml
@@ -1,0 +1,41 @@
+name: CI catalog
+
+on:
+  pull_request:
+    paths:
+      - ".buildkite/**"
+      - ".github/workflows/ci-catalog.yml"
+  push:
+    branches: [main]
+    paths:
+      - ".buildkite/**"
+      - ".github/workflows/ci-catalog.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out proposed catalog
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - name: Check out base catalog
+        if: >-
+          github.event_name == 'pull_request' ||
+          github.event.before != '0000000000000000000000000000000000000000'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.event.before }}
+          path: .ci-control-baseline
+          persist-credentials: false
+      - name: Validate policy, jobs, and selector compatibility
+        uses: vllm-project/ci-infra/.github/actions/ci-control-validate@11bc2c60ebd2f99f52c8a764655380b844e26c27
+        with:
+          repository-root: .
+          baseline-repository-root: .ci-control-baseline

--- a/.github/workflows/run-ci-command.yml
+++ b/.github/workflows/run-ci-command.yml
@@ -17,6 +17,7 @@ jobs:
   run-ci-command:
     if: >-
       github.event.issue.pull_request &&
+      vars.CI_CONTROL_GATEWAY_MODE != 'active' &&
       (github.event.comment.body == '/ci run' ||
       github.event.comment.body == '/ci retry')
     runs-on: ubuntu-latest

--- a/docs/contributing/ci/ci_control.md
+++ b/docs/contributing/ci/ci_control.md
@@ -1,0 +1,136 @@
+# `/ci` control API
+
+This is the user contract for the new pull-request comment API. The command
+gateway must be deployed from `ci-infra` before these commands take effect.
+Repository-owned policy lives in
+[`.buildkite/ci_control.toml`](../../../.buildkite/ci_control.toml); job commands,
+dependencies, and secrets remain in the existing CI definitions.
+
+The existing exact `/ci run` and `/ci retry` commands remain on the legacy
+workflow during the read-only rollout. At cutover, repository administrators
+set `CI_CONTROL_GATEWAY_MODE=active`, which disables that workflow before the
+new gateway enables mutations. The two mutation paths must never be active at
+the same time because the legacy path has no credit ledger.
+
+Use one exact, lowercase command per PR comment. Editing a processed comment
+does not run it again.
+
+## Commands
+
+| Command | What it does |
+| --- | --- |
+| `/ci help` | Show syntax and valid selectors. |
+| `/ci status` | Summarize the exact current PR HEAD, latest `main` snapshot, and your credits. |
+| `/ci status main [<selection>]` | Show active, recovering, and recently resolved failures on `main`. |
+| `/ci status pr [<selection>]` | Classify each failure from completed CI on the exact current PR HEAD. |
+| `/ci status request:<id>` | Show one run or retry request and its cost. |
+| `/ci status refresh` | Refresh CI evidence without rerunning tests. |
+| `/ci list groups` | List selectable groups. |
+| `/ci list areas` | List stable test areas. |
+| `/ci list jobs` | List stable job keys and their group/area membership. |
+| `/ci plan <selection>` | Show exact jobs, dependencies, and cost without running them. |
+| `/ci run <selection>` | Run selected CI on the exact current PR HEAD. |
+| `/ci retry failures [<selection>]` | Retry each matching current failure once. |
+| `/ci credits` | Show available, reserved, granted, and spent credits. |
+| `/ci credits add @user <amount> <reason>` | Add an audited credit grant; maintainers/admins only. |
+
+Unknown commands or selectors do no work and return help.
+
+## Selectors
+
+```text
+all
+groups:<group>[,<group>...]
+areas:<area>[,<area>...] [groups:<group>[,<group>...]]
+jobs:<stable-job-key>[,<stable-job-key>...]
+```
+
+The initial groups are:
+
+- `upstream`: vLLM-owned upstream tests;
+- `cpu`: CPU-only tests; and
+- `amd`: keyed AMD mirrors plus the native AMD lane.
+
+Comma-separated values are alternatives; different selector types are
+intersected. For example, `groups:upstream,cpu areas:models` selects model tests
+from either catalog. A job selected more than once runs once.
+
+The legacy native AMD pipeline is represented by the single
+`native-amd-lane` job and `native-amd` area. Either name selects the whole
+lane. Its individual jobs cannot be selected by area or job until that
+generated pipeline publishes stable metadata. Keyed AMD mirror jobs remain
+individually selectable, including by their inherited test areas.
+Status for the native lane is correspondingly lane-level, not a claim about
+the identity of an individual native job.
+
+Job keys and area names are public API. The catalog check compares a PR with
+its base checkout; a rename requires an alias and a removal requires a
+tombstone in `ci_control.toml`. Derived AMD mirror keys are checked too.
+
+Examples:
+
+```text
+/ci run groups:cpu
+/ci run groups:upstream areas:attention,models
+/ci run groups:amd
+/ci retry failures groups:cpu
+/ci plan jobs:cpu-kernel-tests
+/ci credits add @alice 100 investigate intermittent AMD failures
+```
+
+## Credits and access
+
+Each eligible GitHub user receives a one-time balance of 300 job credits. One
+credit pays for one executable job attempt or parallel shard accepted by the
+provider. Retries and newly required dependencies cost again. Read commands,
+wait/group nodes, skipped jobs, and ordinary automatic CI are free. There is
+no automatic reset in version 1.
+
+Insufficient credit rejects the complete plan; it never runs an arbitrary
+subset. `/ci retry failures` has no lineage-depth ceiling, but one comment
+still creates at most one new attempt for each current failure and still
+requires credits.
+
+Read-only status and catalog views may be public. Commands that mutate
+authoritative state or request compute require live `write` access or
+membership in the vLLM committer team. Credit grants require
+`maintain` or `admin` access, and the recipient must independently have
+`write` access or committer membership.
+
+## Understanding failures
+
+Buildkite is the source of run facts. Completion webhooks update status
+quickly, while an overlapping scheduled reconciler repairs missed or
+out-of-order events. `/ci status refresh` queues that same reconciliation; it
+does not run tests. An update is conclusive only after every provider page,
+expected shard, and retry predecessor is accounted for.
+
+`/ci status main` reports an immutable evidence snapshot, its per-lane
+watermarks, freshness, and incident state. A group becomes known after
+failures on two distinct canonical `main` SHAs. After a known failure starts
+passing, it remains recovering until three clean distinct SHAs resolve it.
+Retries and rebuilds of one SHA count once. A force-push starts a new main
+epoch, so unconfirmed failure and recovery counters do not cross rewritten
+history. A changed executable test definition also starts fresh confirmation
+counters. Evidence older than 72 hours is stale and cannot prove that a
+failure is PR-only.
+
+`/ci status pr` compares each failure independently with one immutable `main`
+snapshot and reports one of:
+
+- known on `main`;
+- candidate on `main`;
+- seen flaky on `main`;
+- recovering or resolved on `main`;
+- a different failure on `main`;
+- the same group is red but the underlying failure is unverified;
+- not matched on fresh, compatible `main` evidence from the PR base ancestry;
+  or
+- unable to classify because evidence is missing, partial, stale, or
+  incompatible.
+
+A red group on both branches is not enough to call failures equal. The API
+uses exact fingerprints only when the lane produces them and the execution
+profile and test-definition digest match. Otherwise it reports the weaker
+group-level result explicitly. Mixed groups keep each result visible, and all
+classifications are advisory.

--- a/docs/contributing/ci/failures.md
+++ b/docs/contributing/ci/failures.md
@@ -3,11 +3,15 @@
 What should I do when a CI job fails on my PR, but I don't think my PR caused
 the failure?
 
+For current-HEAD diagnosis and targeted retries, see the
+[`/ci` control API](ci_control.md).
+
 - Check the dashboard of current CI test failures:  
   👉 [CI Failures Dashboard](https://github.com/orgs/vllm-project/projects/20)
 
-- If your failure **is already listed**, it's likely unrelated to your PR.
-  Help fixing it is always welcome!
+- If your failure **is already listed**, compare its exact fingerprint with
+  `/ci status pr`; a red test group alone does not prove it is the same failure.
+  Help fixing a matching failure is always welcome!
     - Leave comments with links to additional instances of the failure.
     - React with a 👍 to signal how many are affected.
 


### PR DESCRIPTION
This rebuilds the existing PR from current `main` as the repository-owned half of the modular `/ci` design in vllm-project/ci-infra#437.

- Add `.buildkite/ci_control.toml` for trusted authorization, credit, retry, selector, and main-incident policy.
- Add stable keys and semantic areas to existing upstream and CPU jobs without moving their execution logic.
- Validate the proposed catalog against the exact PR base with a read-only, secretless action pinned to the reviewed ci-infra commit.
- Document the command API, 300-credit default, `inf` retries, administrative top-ups, status refresh/reconciliation, incident recovery, and PR-vs-main classifications.
- Gate the legacy mutation workflow so it cannot overlap an activated control-plane gateway.

All stateful command, accounting, provider, evidence, incident, and validation logic remains in ci-infra. This repository contains no controller service, database, credentials, or duplicated provider code. New mutation commands remain disabled until the durable runtime is deployed.

Depends on vllm-project/ci-infra#437; merge the ci-infra foundation first.