### PR TITLE
[CI] Fix speech correctness check rejecting improved WER

### DIFF
--- a/tests/entrypoints/speech_to_text/correctness/test_transcription_api_correctness.py
+++ b/tests/entrypoints/speech_to_text/correctness/test_transcription_api_correctness.py
@@ -356,7 +356,12 @@ def test_wer_correctness(
         print(f"Expected WER: {expected_wer}, Actual WER: {wer}")
 
         if expected_wer:
-            torch.testing.assert_close(wer, expected_wer, atol=1e-1, rtol=1e-2)
+            wer_atol, wer_rtol = 1e-1, 1e-2
+            max_wer = expected_wer + wer_atol + wer_rtol * abs(expected_wer)
+            assert wer <= max_wer, (
+                f"WER {wer:.6f} exceeds maximum allowed {max_wer:.6f} "
+                f"(baseline {expected_wer:.6f})"
+            )
 
 
 # 14-22mins of 6 audio samples of total ~115 mins and just 37MB.


### PR DESCRIPTION
## Purpose

The short-form speech correctness test uses a symmetric closeness check for WER, even though lower WER is better. In Buildkite build #80224, Cohere produced a WER of 11.698929 versus the 11.92 baseline. The result was better, but it fell
just below the symmetric accepted interval of `[11.7008, 12.1392]` and failed CI.

This change makes the short-form check one-sided while preserving the existing upper regression limit exactly. It does not change the baseline, tolerance, WER calculation, long-form test, model behavior, or Cohere dithering. The long-form check is intentionally unchanged because this PR is limited to the observed short-form failure and avoids changing an unobserved test path.

CI Failure:
https://buildkite.com/vllm/ci/builds/80224#019f9a94-79b2-4aa5-af1c-32476de56e5c

## Relevant PR

#49773 fixed the separate `evaluate.load("wer")` dependency failure and is now merged. It fixes the separate HfFolder failure by replacing `evaluate.load("wer")` with `jiwer.wer`. However, it does not change the symmetric WER assertion. Build #80224 reached that assertion and failed because a lower, improved Cohere WER fell outside its lower bound. This PR addresses that remaining assertion-semantic issue. 

## Reproducer

```bash
.venv/bin/python -c 'import torch; actual=11.698929902609114; baseline=11.92; torch.testing.assert_close(actual, baseline, atol=1e-1, rtol=1e-2)'
```

## Output on main

```text
AssertionError: Scalars are not close!

Expected 11.92 but got 11.698929902609114.
Absolute difference: 0.22107009739088568 (up to 0.1 allowed)
Relative difference: 0.018546149109973632 (up to 0.01 allowed)
```

## Output on branch

```text
actual=11.698930, max_wer=12.139200: PASS
```

The maximum permitted WER remains 12.1392, identical to the previous upper boundary.

## Test Plan

```bash
.venv/bin/pre-commit run --files tests/entrypoints/speech_to_text/correctness/test_transcription_api_correctness.py
```

`Passed`

## AI assistance

OpenAI Codex (GPT-5) assisted with diagnosis, the code change, validation, and drafting this description.