### PR TITLE
[Bugfix][CuMem] Make KV-cache wake cleanup tag-safe

### DIFF
--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -291,13 +291,8 @@ class CuMemAllocator:
                 back to GPU memory. If None, all memory allocation will be loaded
                 back to GPU memory.
         """
-        # KV-cache allocations without a CPU backup contain undefined data after
-        # their physical pages are recreated.  Release PyTorch's transient
-        # cached blocks before remapping them, including for an unfiltered wake.
-        is_kv_cache_wake = tags is None or "kv_cache" in tags
-        if is_kv_cache_wake:
-            gc.collect()
-            torch.accelerator.empty_cache()
+        gc.collect()
+        torch.accelerator.empty_cache()
 
         for ptr, data in self.pointer_to_data.items():
             if tags is None or data.tag in tags:

--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -291,11 +291,21 @@ class CuMemAllocator:
                 back to GPU memory. If None, all memory allocation will be loaded
                 back to GPU memory.
         """
+        # KV-cache allocations without a CPU backup contain undefined data after
+        # their physical pages are recreated.  Release PyTorch's transient
+        # cached blocks before remapping them, including for an unfiltered wake.
+        is_kv_cache_wake = tags is None or "kv_cache" in tags
+        if is_kv_cache_wake:
+            gc.collect()
+            torch.cuda.empty_cache()
+
         for ptr, data in self.pointer_to_data.items():
             if tags is None or data.tag in tags:
                 handle = data.handle
                 create_and_map(handle)
                 data.is_asleep = False
+                if data.tag == "kv_cache" and data.cpu_backup_tensor is None:
+                    libcudart.cudaMemset(ptr, 0, handle[1])
                 if data.cpu_backup_tensor is not None:
                     cpu_backup_tensor = data.cpu_backup_tensor
                     if cpu_backup_tensor is not None:

--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -304,8 +304,6 @@ class CuMemAllocator:
                 handle = data.handle
                 create_and_map(handle)
                 data.is_asleep = False
-                if data.tag == "kv_cache" and data.cpu_backup_tensor is None:
-                    libcudart.cudaMemset(ptr, 0, handle[1])
                 if data.cpu_backup_tensor is not None:
                     cpu_backup_tensor = data.cpu_backup_tensor
                     if cpu_backup_tensor is not None:

--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -297,7 +297,7 @@ class CuMemAllocator:
         is_kv_cache_wake = tags is None or "kv_cache" in tags
         if is_kv_cache_wake:
             gc.collect()
-            torch.cuda.empty_cache()
+            torch.accelerator.empty_cache()
 
         for ptr, data in self.pointer_to_data.items():
             if tags is None or data.tag in tags:


### PR DESCRIPTION
## Summary

Release transient Python and accelerator allocator memory before CuMem wake remaps sleeping allocations.

## Problem

The weight-update lifecycle can create temporary CUDA tensors during tensor conversion, copying, and post-load processing. After those operations finish, PyTorch's caching allocator may still retain a large amount of memory as `reserved` but not currently `allocated`.

This creates a mismatch between two views of memory:

1. PyTorch still owns a large cached reservation.
2. The accelerator driver has very little immediately available memory for a new mapping.

The subsequent CuMem wake operation needs to recreate physical mappings for sleeping allocations. Even though the allocator reports substantial reserved capacity, those cached blocks are not automatically available to the CuMem mapping path. Wake can therefore fail with an out-of-memory error before the lifecycle can resume.

The failure is timing-dependent: the memory pressure is accumulated during weight update, but becomes visible at the later wake boundary when CuMem requests physical memory again.

## Change

At the beginning of `CuMemAllocator.wake_up()`, before remapping any sleeping allocation, perform:

```python
gc.collect()
torch.accelerator.empty_cache()
```

`gc.collect()` releases unreachable Python objects that may still hold CUDA tensors. `torch.accelerator.empty_cache()` then returns unused cached allocator blocks to the accelerator runtime, making that memory available to the CuMem remapping operation.

The change intentionally contains no allocation-specific initialization, tensor rewriting, or model-layer logic. It is limited to releasing transient memory before the wake operation.

## Relation to existing work

This is a focused follow-up to the CuMem wake memory-pressure behavior discussed in [vLLM issue #48312](https://github.com/vllm-project/vllm/issues/48312). It does not duplicate the existing open reload PRs: the scope is limited to pre-wake transient-memory release in `CuMemAllocator.wake_up()`.

## Validation

- `git diff --check`
- `uv run --no-project python -m py_compile vllm/device_allocator/cumem.py`

GPU lifecycle/evaluation tests were not run in this environment.

AI assistance was used; the human submitter should review every changed line.