### PR TITLE
[Bugfix][AsyncScheduler] Reset num_output_placeholders after discarding stale async frames

### DIFF
--- a/vllm/v1/core/sched/async_scheduler.py
+++ b/vllm/v1/core/sched/async_scheduler.py
@@ -56,6 +56,16 @@ class AsyncScheduler(Scheduler):
             # stale in-flight async output frame per call until the counter
             # is drained.
             request.async_tokens_to_discard -= 1
+            if request.async_tokens_to_discard == 0:
+                # All stale frames have been drained. Reset the output
+                # placeholder count to zero: the frames that inflated it
+                # during the discard period (via _update_after_schedule)
+                # were never consumed, so keeping them would artificially
+                # inflate num_output_placeholders and cause the scheduling
+                # guard (num_computed_tokens + 2 - num_output_placeholders
+                # >= max_tokens) to fire conservatively, delaying the
+                # request's final stop by 1-2 steps.
+                request.num_output_placeholders = 0
             return [], False
 
         status_before_update = request.status


### PR DESCRIPTION
## Summary

Fix a subtle scheduling delay introduced when stale async output frames (from `reset_prefix_cache` force-preemption) are discarded without consuming their corresponding `num_output_placeholders`.

## Root Cause

When `reset_prefix_cache` force-preempts a request, it sets `async_tokens_to_discard` to drain stale in-flight async frames. During the drain period (1 frame per scheduling step):

1. `_update_after_schedule` **adds** `num_output_placeholders` for each step (line 39-41)
2. The discard path short-circuits: `return [], False` — the placeholders are **never consumed**
3. After all stale frames drain, `num_output_placeholders` is artificially inflated

This inflated count causes the scheduling guard (`num_computed_tokens + 2 - num_output_placeholders >= max_tokens`) to fire conservatively, delaying the request's final stop by 1-2 decode steps.

## Fix

Reset `num_output_placeholders = 0` when `async_tokens_to_discard` reaches 0 (all stale frames have drained).

## Related

- PR #48245 fixes `num_output_placeholders` underflow in the KV-pressure preemption path (`_preempt_request`). This fix addresses a complementary issue in the `reset_prefix_cache` preemption path (`async_tokens_to_discard`).

<sup>AI assistance was used in the analysis and implementation of this fix. Every line was reviewed by a human.</sup>
