### PR TITLE
[Kernel] Guard A8 Marlin repack K alignment

### DIFF
--- a/csrc/libtorch_stable/quantization/marlin/awq_marlin_repack.cu
+++ b/csrc/libtorch_stable/quantization/marlin/awq_marlin_repack.cu
@@ -232,7 +232,6 @@ torch::stable::Tensor awq_marlin_repack(torch::stable::Tensor& b_q_weight,
   int64_t const target_tile_k_size = marlin::tile_k_size * (is_a_8bit ? 2 : 1);
   STD_TORCH_CHECK(size_k % target_tile_k_size == 0, "size_k = ", size_k,
                   " is not divisible by tile_k_size = ", target_tile_k_size);
-  // Keep the stricter N alignment required by Marlin GEMM.
   STD_TORCH_CHECK(size_n % marlin::tile_n_size == 0, "size_n = ", size_n,
                   " is not divisible by tile_n_size = ", marlin::tile_n_size);
 

--- a/csrc/libtorch_stable/quantization/marlin/awq_marlin_repack.cu
+++ b/csrc/libtorch_stable/quantization/marlin/awq_marlin_repack.cu
@@ -228,9 +228,11 @@ __global__ void awq_marlin_repack_kernel(
 torch::stable::Tensor awq_marlin_repack(torch::stable::Tensor& b_q_weight,
                                         int64_t size_k, int64_t size_n,
                                         int64_t num_bits, bool is_a_8bit) {
-  // Verify compatibility with marlin tile of 16x64
-  STD_TORCH_CHECK(size_k % marlin::tile_k_size == 0, "size_k = ", size_k,
-                  " is not divisible by tile_k_size = ", marlin::tile_k_size);
+  // Verify compatibility with Marlin tiles
+  int64_t const target_tile_k_size = marlin::tile_k_size * (is_a_8bit ? 2 : 1);
+  STD_TORCH_CHECK(size_k % target_tile_k_size == 0, "size_k = ", size_k,
+                  " is not divisible by tile_k_size = ", target_tile_k_size);
+  // Keep the stricter N alignment required by Marlin GEMM.
   STD_TORCH_CHECK(size_n % marlin::tile_n_size == 0, "size_n = ", size_n,
                   " is not divisible by tile_n_size = ", marlin::tile_n_size);
 

--- a/csrc/libtorch_stable/quantization/marlin/gptq_marlin_repack.cu
+++ b/csrc/libtorch_stable/quantization/marlin/gptq_marlin_repack.cu
@@ -290,7 +290,6 @@ torch::stable::Tensor gptq_marlin_repack(torch::stable::Tensor& b_q_weight,
   int64_t const target_tile_k_size = marlin::tile_k_size * (is_a_8bit ? 2 : 1);
   STD_TORCH_CHECK(size_k % target_tile_k_size == 0, "size_k = ", size_k,
                   " is not divisible by tile_k_size = ", target_tile_k_size);
-  // Keep the stricter N alignment required by Marlin GEMM.
   STD_TORCH_CHECK(size_n % marlin::tile_n_size == 0, "size_n = ", size_n,
                   " is not divisible by tile_n_size = ", marlin::tile_n_size);
 

--- a/csrc/libtorch_stable/quantization/marlin/gptq_marlin_repack.cu
+++ b/csrc/libtorch_stable/quantization/marlin/gptq_marlin_repack.cu
@@ -286,9 +286,11 @@ torch::stable::Tensor gptq_marlin_repack(torch::stable::Tensor& b_q_weight,
                                          torch::stable::Tensor& perm,
                                          int64_t size_k, int64_t size_n,
                                          int64_t num_bits, bool is_a_8bit) {
-  // Verify compatibility with marlin tile of 16x64
-  STD_TORCH_CHECK(size_k % marlin::tile_k_size == 0, "size_k = ", size_k,
-                  " is not divisible by tile_k_size = ", marlin::tile_k_size);
+  // Verify compatibility with Marlin tiles
+  int64_t const target_tile_k_size = marlin::tile_k_size * (is_a_8bit ? 2 : 1);
+  STD_TORCH_CHECK(size_k % target_tile_k_size == 0, "size_k = ", size_k,
+                  " is not divisible by tile_k_size = ", target_tile_k_size);
+  // Keep the stricter N alignment required by Marlin GEMM.
   STD_TORCH_CHECK(size_n % marlin::tile_n_size == 0, "size_n = ", size_n,
                   " is not divisible by tile_n_size = ", marlin::tile_n_size);
 

--- a/tests/kernels/quantization/test_marlin_gemm.py
+++ b/tests/kernels/quantization/test_marlin_gemm.py
@@ -324,12 +324,13 @@ def test_awq_marlin_repack(k_chunk, n_chunk, quant_type, is_a_8bit, nk_factors):
     [
         (16, True, True),
         (48, True, True),
+        # The A16 contract is unchanged, so the 16-element boundary stays legal.
         (16, False, False),
-        (32, True, False),
     ],
 )
 def test_marlin_repack_k_alignment(repack_type, size_k, is_a_8bit, should_reject):
     size_n, num_bits = 64, 4
+    pack_factor = 32 // num_bits
     q_weight_unpacked = torch.randint(
         0,
         1 << num_bits,
@@ -352,33 +353,22 @@ def test_marlin_repack_k_alignment(repack_type, size_k, is_a_8bit, should_reject
         def repack():
             return ops.awq_marlin_repack(q_weight, size_k, size_n, num_bits, is_a_8bit)
 
-    weight_perm = get_weight_perm(num_bits, is_a_8bit)
     if should_reject:
         error_match = rf"size_k = {size_k}.*tile_k_size = 32"
+        with pytest.raises(RuntimeError, match=error_match):
+            repack()
         with pytest.raises(AssertionError, match=error_match):
             marlin_weights(
                 q_weight_unpacked,
                 size_k,
                 size_n,
                 num_bits,
-                weight_perm,
+                get_weight_perm(num_bits, is_a_8bit),
                 is_a_8bit,
             )
-        with pytest.raises(RuntimeError, match=error_match):
-            repack()
         return
 
-    output_ref = marlin_weights(
-        q_weight_unpacked,
-        size_k,
-        size_n,
-        num_bits,
-        weight_perm,
-        is_a_8bit,
-    )
-    output = repack()
-    torch.accelerator.synchronize()
-    torch.testing.assert_close(output, output_ref)
+    assert repack().shape == (size_k // 16, size_n * 16 // pack_factor)
 
 
 @pytest.mark.skipif(

--- a/tests/kernels/quantization/test_marlin_gemm.py
+++ b/tests/kernels/quantization/test_marlin_gemm.py
@@ -9,6 +9,7 @@ import itertools
 
 import pytest
 import torch
+from torch._subclasses.fake_tensor import FakeTensorMode
 
 from tests.kernels.utils import opcheck
 from tests.quantization.utils import is_quant_method_supported
@@ -311,6 +312,124 @@ def test_awq_marlin_repack(k_chunk, n_chunk, quant_type, is_a_8bit, nk_factors):
     torch.accelerator.synchronize()
 
     torch.testing.assert_close(marlin_q_w_1, marlin_q_w_2)
+
+
+@pytest.mark.skipif(
+    not is_quant_method_supported("gptq_marlin"),
+    reason="Marlin is not supported on this GPU type.",
+)
+@pytest.mark.parametrize("repack_type", ["gptq", "awq"])
+@pytest.mark.parametrize(
+    ("size_k", "is_a_8bit", "should_reject"),
+    [
+        (16, True, True),
+        (48, True, True),
+        (16, False, False),
+        (32, True, False),
+    ],
+)
+def test_marlin_repack_k_alignment(repack_type, size_k, is_a_8bit, should_reject):
+    size_n, num_bits = 64, 4
+    q_weight_unpacked = torch.randint(
+        0,
+        1 << num_bits,
+        (size_k, size_n),
+        dtype=torch.int,
+        device="cuda",
+    )
+    if repack_type == "gptq":
+        q_weight = gptq_pack(q_weight_unpacked, num_bits, size_k, size_n)
+        perm = torch.empty(0, dtype=torch.int, device="cuda")
+
+        def repack():
+            return ops.gptq_marlin_repack(
+                q_weight, perm, size_k, size_n, num_bits, is_a_8bit
+            )
+
+    else:
+        q_weight = awq_pack(q_weight_unpacked, num_bits, size_k, size_n)
+
+        def repack():
+            return ops.awq_marlin_repack(q_weight, size_k, size_n, num_bits, is_a_8bit)
+
+    weight_perm = get_weight_perm(num_bits, is_a_8bit)
+    if should_reject:
+        error_match = rf"size_k = {size_k}.*tile_k_size = 32"
+        with pytest.raises(AssertionError, match=error_match):
+            marlin_weights(
+                q_weight_unpacked,
+                size_k,
+                size_n,
+                num_bits,
+                weight_perm,
+                is_a_8bit,
+            )
+        with pytest.raises(RuntimeError, match=error_match):
+            repack()
+        return
+
+    output_ref = marlin_weights(
+        q_weight_unpacked,
+        size_k,
+        size_n,
+        num_bits,
+        weight_perm,
+        is_a_8bit,
+    )
+    output = repack()
+    torch.accelerator.synchronize()
+    torch.testing.assert_close(output, output_ref)
+
+
+@pytest.mark.skipif(
+    not is_quant_method_supported("gptq_marlin"),
+    reason="Marlin is not supported on this GPU type.",
+)
+@pytest.mark.parametrize("repack_type", ["gptq", "awq"])
+def test_marlin_repack_fake_rejects_misaligned_8bit_k(repack_type):
+    with FakeTensorMode():
+        if repack_type == "gptq":
+            q_weight = torch.empty((2, 64), dtype=torch.int, device="cuda")
+            perm = torch.empty(0, dtype=torch.int, device="cuda")
+
+            def repack():
+                return torch.ops._C.gptq_marlin_repack(q_weight, perm, 16, 64, 4, True)
+
+        else:
+            q_weight = torch.empty((16, 8), dtype=torch.int, device="cuda")
+
+            def repack():
+                return torch.ops._C.awq_marlin_repack(q_weight, 16, 64, 4, True)
+
+        with pytest.raises(RuntimeError, match="size_k = 16.*tile_k_size = 32"):
+            repack()
+
+
+# No GPU gate: the wrapper asserts before touching the device.
+@pytest.mark.parametrize("repack_type", ["gptq", "awq"])
+def test_marlin_moe_repack_rejects_misaligned_8bit_k(repack_type):
+    size_k, size_n, num_bits = 16, 64, 4
+    pack_factor = 32 // num_bits
+    perm = torch.empty((1, 0), dtype=torch.int)
+
+    if repack_type == "gptq":
+        q_weight = torch.empty((1, size_k // pack_factor, size_n), dtype=torch.int)
+
+        def repack():
+            ops.gptq_marlin_moe_repack(
+                q_weight, perm, size_k, size_n, num_bits, is_a_8bit=True
+            )
+
+    else:
+        q_weight = torch.empty((1, size_k, size_n // pack_factor), dtype=torch.int)
+
+        def repack():
+            ops.awq_marlin_moe_repack(
+                q_weight, perm, size_k, size_n, num_bits, is_a_8bit=True
+            )
+
+    with pytest.raises(AssertionError, match="size_k = 16.*tile_k_size = 32"):
+        repack()
 
 
 def marlin_generate_valid_test_cases():

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1170,12 +1170,13 @@ def gptq_marlin_moe_repack(
     is_a_8bit: bool = False,
 ) -> torch.Tensor:
     num_experts = b_q_weight.shape[0]
-    target_tile_k_size = 32 if is_a_8bit else 16
+    marlin_tile_size = 16
+    target_tile_k_size = marlin_tile_size * (2 if is_a_8bit else 1)
     assert size_k % target_tile_k_size == 0, (
         f"size_k = {size_k} is not divisible by tile_k_size = {target_tile_k_size}"
     )
     output = torch.empty(
-        (num_experts, size_k // 16, size_n * (num_bits // 2)),
+        (num_experts, size_k // marlin_tile_size, size_n * (num_bits // 2)),
         device=b_q_weight.device,
         dtype=b_q_weight.dtype,
     )
@@ -1195,12 +1196,13 @@ def awq_marlin_moe_repack(
     is_a_8bit: bool = False,
 ) -> torch.Tensor:
     num_experts = b_q_weight.shape[0]
-    target_tile_k_size = 32 if is_a_8bit else 16
+    marlin_tile_size = 16
+    target_tile_k_size = marlin_tile_size * (2 if is_a_8bit else 1)
     assert size_k % target_tile_k_size == 0, (
         f"size_k = {size_k} is not divisible by tile_k_size = {target_tile_k_size}"
     )
     output = torch.empty(
-        (num_experts, size_k // 16, size_n * (num_bits // 2)),
+        (num_experts, size_k // marlin_tile_size, size_n * (num_bits // 2)),
         device=b_q_weight.device,
         dtype=b_q_weight.dtype,
     )

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1106,6 +1106,14 @@ if hasattr(torch.ops._C, "gptq_marlin_repack"):
     ) -> torch.Tensor:
         pack_factor = 32 // num_bits
         marlin_tile_size = 16
+        target_tile_k_size = marlin_tile_size * (2 if is_a_8bit else 1)
+        torch._check(
+            size_k % target_tile_k_size == 0,
+            lambda: (
+                f"size_k = {size_k} is not divisible by "
+                f"tile_k_size = {target_tile_k_size}"
+            ),
+        )
         return torch.empty(
             (size_k // marlin_tile_size, size_n * marlin_tile_size // pack_factor),
             dtype=b_q_weight.dtype,
@@ -1138,6 +1146,14 @@ if hasattr(torch.ops._C, "awq_marlin_repack"):
     ) -> torch.Tensor:
         pack_factor = 32 // num_bits
         marlin_tile_size = 16
+        target_tile_k_size = marlin_tile_size * (2 if is_a_8bit else 1)
+        torch._check(
+            size_k % target_tile_k_size == 0,
+            lambda: (
+                f"size_k = {size_k} is not divisible by "
+                f"tile_k_size = {target_tile_k_size}"
+            ),
+        )
         return torch.empty(
             (size_k // marlin_tile_size, size_n * marlin_tile_size // pack_factor),
             dtype=b_q_weight.dtype,
@@ -1154,7 +1170,10 @@ def gptq_marlin_moe_repack(
     is_a_8bit: bool = False,
 ) -> torch.Tensor:
     num_experts = b_q_weight.shape[0]
-    assert size_k % 16 == 0
+    target_tile_k_size = 32 if is_a_8bit else 16
+    assert size_k % target_tile_k_size == 0, (
+        f"size_k = {size_k} is not divisible by tile_k_size = {target_tile_k_size}"
+    )
     output = torch.empty(
         (num_experts, size_k // 16, size_n * (num_bits // 2)),
         device=b_q_weight.device,
@@ -1176,7 +1195,10 @@ def awq_marlin_moe_repack(
     is_a_8bit: bool = False,
 ) -> torch.Tensor:
     num_experts = b_q_weight.shape[0]
-    assert size_k % 16 == 0
+    target_tile_k_size = 32 if is_a_8bit else 16
+    assert size_k % target_tile_k_size == 0, (
+        f"size_k = {size_k} is not divisible by tile_k_size = {target_tile_k_size}"
+    )
     output = torch.empty(
         (num_experts, size_k // 16, size_n * (num_bits // 2)),
         device=b_q_weight.device,

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_test.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_test.py
@@ -34,8 +34,11 @@ def marlin_permute_weights(
     q_w, size_k, size_n, perm, tile=GPTQ_MARLIN_TILE, is_a_8bit=False
 ):
     assert q_w.shape == (size_k, size_n)
-    assert size_k % tile == 0, f"size_k = {size_k}, tile = {tile}"
-    assert size_n % tile == 0, f"size_k = {size_n}, tile = {tile}"
+    target_tile_k_size = tile * (2 if is_a_8bit else 1)
+    assert size_k % target_tile_k_size == 0, (
+        f"size_k = {size_k}, tile_k_size = {target_tile_k_size}"
+    )
+    assert size_n % tile == 0, f"size_n = {size_n}, tile = {tile}"
 
     if is_a_8bit:
         # Permute weights to 32x32 marlin tiles


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

The GPTQ and AWQ Marlin repack operations validate a K contract that does not
match the one their kernels implement.

With `is_a_8bit=True` the kernels consume K in 32-element tiles
(`k_tiles = size_k / (tile_k_size * 2)`), but both entry points allocate the
output with `size_k / tile_size` (16) rows and check only the base 16-element
Marlin alignment. A K dimension congruent to 16 modulo 32 therefore passes
validation while integer division truncates the K tile count, and the operation
returns a tensor with unwritten rows: `size_k = 48` allocates three output rows
and writes two.

These are directly callable custom operations, so the validation should match
the kernel contract rather than depend on callers padding K. The A8 repack path
is also actively being extended — #38066 broadens the accepted weight types on
the same `is_a_8bit` branch that calls `gptq_marlin_repack`.

This PR makes invalid inputs fail closed by:

- requiring 32-element K alignment when `is_a_8bit=True` in the GPTQ and AWQ
  CUDA entry points;
- applying the same contract, with the same diagnostic, to the FakeTensor
  implementations, the MoE wrappers, and the reference repack helper; and
- covering the rejected A8 K=16 and K=48 boundaries across all three surfaces,
  plus the unchanged A16 K=16 boundary.

Marlin GEMM needs no matching guard. `min_thread_k` is 64, and `is_valid_config`
rejects both a K thread tile below that minimum and any K not divisible by the
selected thread tile, for the dense and the MoE path alike; the
caller-specified-config path additionally checks `prob_k % thread_k` outright,
and dispatch fails closed when no compiled kernel matches. Every executable A8
GEMM is therefore already K%64-aligned, which is stricter than the 32-element
requirement of the A8 MMA, so no unwritten-output equivalent exists there.

The existing N alignment requirement is unchanged. Current internal
model-preparation paths pad K to larger multiples, so valid serving shapes and
outputs are unchanged.

## Duplicate Work Check

I searched open PRs for Marlin repack, A8/8-bit repack, and GPTQ/AWQ alignment.
The related open PRs do not modify this operation contract:

- #38066 adds W4A8-INT model support.
- #36807 pads FP8 MoE weight dimensions.
- #37296 pads an FP4 N dimension.
- #49615 guarded a different MXFP4 converter operation.

None of these changes the GPTQ/AWQ A8 repack entry-point validation or covers
these boundary cases.

## Test Plan

```bash
.venv/bin/python -m pytest -q \
  tests/kernels/quantization/test_marlin_gemm.py::test_marlin_repack_k_alignment \
  tests/kernels/quantization/test_marlin_gemm.py::test_marlin_repack_fake_rejects_misaligned_8bit_k \
  tests/kernels/quantization/test_marlin_gemm.py::test_marlin_moe_repack_rejects_misaligned_8bit_k

.venv/bin/python -m pytest -q \
  tests/kernels/quantization/test_marlin_gemm.py::test_gptq_marlin_repack \
  tests/kernels/quantization/test_marlin_gemm.py::test_awq_marlin_repack

pre-commit run --files \
  csrc/libtorch_stable/quantization/marlin/awq_marlin_repack.cu \
  csrc/libtorch_stable/quantization/marlin/gptq_marlin_repack.cu \
  tests/kernels/quantization/test_marlin_gemm.py \
  vllm/_custom_ops.py \
  vllm/model_executor/layers/quantization/utils/marlin_utils_test.py
```

## Test Result

Tested on a single NVIDIA RTX PRO 6000 Blackwell Server Edition (`sm_120`) with
CUDA 13.0 and torch 2.13.0+cu130, against a `_C_stable_libtorch` CUDA build of
this guard (73/73 build steps passed).

- New alignment, FakeTensor, and MoE boundary tests: 10 passed.
- Existing GPTQ/AWQ repack tests: 60 passed.
- Pre-commit checks for all changed files: passed (ruff check, ruff format,
  clang-format, mypy, typos, SPDX headers, forbidden imports).

Total pytest result: 70 passed.

No model evaluation or documentation update is needed because this change only
rejects invalid shapes; valid-shape kernel output, model behavior, and public
API signatures are unchanged.

## AI Assistance

AI assistance from Claude Opus 5 and OpenAI Codex (GPT-5.6-SOL) was used during
investigation, implementation review, and test preparation. The submitter
reviewed the generated changes and test results, verified the kernel tile
arithmetic, and completed a final line-by-line review.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR.
- [x] The test plan with commands.
- [x] The test results.
- [x] Documentation and model-evaluation applicability considered.

</details>
