### PR TITLE
[Doc] Fix stale script references in CI contributor guides

### DIFF
--- a/docs/contributing/ci/failures.md
+++ b/docs/contributing/ci/failures.md
@@ -83,7 +83,7 @@ To clean an already-downloaded log:
 [.buildkite/scripts/ci-clean-log.sh](../../../.buildkite/scripts/ci-clean-log.sh)
 
 ```bash
-./ci-clean-log.sh ci.log
+.buildkite/scripts/ci-clean-log.sh ci.log
 ```
 
 Use a tool [wl-clipboard](https://github.com/bugaevc/wl-clipboard) for quick copy-pasting:
@@ -106,7 +106,7 @@ CI test failures may be flaky. Use a bash loop to run repeatedly:
 [.buildkite/scripts/rerun-test.sh](../../../.buildkite/scripts/rerun-test.sh)
 
 ```bash
-./rerun-test.sh tests/v1/engine/test_engine_core_client.py::test_kv_cache_events[True-tcp]
+.buildkite/scripts/rerun-test.sh tests/v1/engine/test_engine_core_client.py::test_kv_cache_events[True-tcp]
 ```
 
 ## Submitting a PR

--- a/docs/contributing/ci/nightly_builds.md
+++ b/docs/contributing/ci/nightly_builds.md
@@ -23,7 +23,10 @@ Each build step:
 
 ### Index Generation
 
-After uploading each wheel, the `.buildkite/scripts/upload-wheels.sh` script:
+Wheel upload and index generation run as separate pipeline stages. CUDA, CPU,
+and macOS wheel jobs use `.buildkite/scripts/upload-nightly-wheels.sh` to retag
+Linux wheels when needed and upload them. After the dependent wheel builds
+finish, `.buildkite/scripts/generate-and-upload-nightly-index.sh`:
 
 1. **Lists all existing wheels** in the commit directory from S3
 2. **Generates indices** using `.buildkite/scripts/generate-nightly-index.py`:
@@ -36,7 +39,9 @@ After uploading each wheel, the `.buildkite/scripts/upload-wheels.sh` script:
     - `/{version}/` - Only for release wheels (no `dev` in its version).
 
 !!! tip "Handling Concurrent Builds"
-    The index generation script can handle multiple variants being built concurrently by always listing all wheels in the commit directory before generating indices, avoiding race conditions.
+    Wheel builds can upload concurrently because they do not write indices. A
+    dedicated post-build step lists the uploaded wheels and generates indices,
+    preventing concurrent upload jobs from overwriting partial indices.
 
 ## Directory Structure
 
@@ -159,6 +164,7 @@ _Note: it's users' responsibility to ensure there is no native code (e.g., C++ o
 Key files involved in the nightly wheel mechanism:
 
 - **`.buildkite/release-pipeline.yaml`**: CI pipeline that builds wheels
-- **`.buildkite/scripts/upload-wheels.sh`**: Script that uploads wheels and generates indices
+- **`.buildkite/scripts/upload-nightly-wheels.sh`**: Script that retags Linux wheels when needed and uploads CUDA, CPU, and macOS wheels
+- **`.buildkite/scripts/generate-and-upload-nightly-index.sh`**: Script that generates and uploads indices after wheel builds finish
 - **`.buildkite/scripts/generate-nightly-index.py`**: Python script that generates PyPI-compatible indices
 - **`setup.py`**: Contains `precompiled_wheel_utils` class for fetching and using precompiled wheels

--- a/docs/contributing/ci/update_pytorch_version.md
+++ b/docs/contributing/ci/update_pytorch_version.md
@@ -73,9 +73,11 @@ This complicates the process as we cannot use the out-of-the-box
 | ROCm 6.3 | [https://download.pytorch.org/whl/rocm6.3](https://download.pytorch.org/whl/rocm6.3) |
 | XPU | [https://download.pytorch.org/whl/xpu](https://download.pytorch.org/whl/xpu) |
 
-- Update the below files to match the CUDA version from step 1. This makes sure that the release vLLM wheel is tested on CI.
+- Update the files below to match the CUDA version from step 1. This ensures that
+  CI builds the release vLLM wheel with that CUDA version and points the default
+  variant alias to it.
     - `.buildkite/release-pipeline.yaml`
-    - `.buildkite/scripts/upload-wheels.sh`
+    - `.buildkite/scripts/generate-and-upload-nightly-index.sh`
 
 ## Manually running vLLM builds on BuildKiteCI
 


### PR DESCRIPTION
## Purpose

The CI contributor guides still reference the deleted `.buildkite/scripts/upload-wheels.sh` and describe wheel upload and index generation as one operation. Two CI failure examples also use paths that do not work from the repository root.

This PR:

- Documents wheel upload and index generation as separate pipeline stages.
- Points the PyTorch update guide to the current index-generation script.
- Makes the `ci-clean-log.sh` and `rerun-test.sh` examples runnable from the repository root.

This is a documentation-only change and does not alter CI behavior.

### Duplicate-work check

I searched open PRs using the affected script names and CI documentation keywords. No open PR addresses this scope. PR #38458 adds a general CI overview, while PRs #42917 and #47628 update CUDA installation documentation.

## Test Plan

```bash
pre-commit run --hook-stage manual --files docs/contributing/ci/nightly_builds.md docs/contributing/ci/update_pytorch_version.md docs/contributing/ci/failures.md

API_AUTONAV_EXCLUDE=vllm .venv/bin/mkdocs serve

git diff --check
```

## Test Result

- Targeted pre-commit: Passed, including `typos` and `markdownlint-cli2`.
- Local MkDocs preview: Passed; the three changed pages rendered correctly.
- `git diff --check`: Passed
- Model evaluation: Not applicable; this is a documentation-only change.