### PR TITLE
[Docs] Add SharedStorageConnector->ExampleConnector migration note to disagg prefill docs

### DIFF
--- a/docs/features/disagg_prefill.md
+++ b/docs/features/disagg_prefill.md
@@ -17,7 +17,19 @@ Two main reasons:
 
 ## Usage example
 
-Now supports 9 types of connectors:
+!!! note "Migration: `SharedStorageConnector` was renamed to `ExampleConnector`"
+    The host-directory debug connector previously named `SharedStorageConnector`
+    was renamed to `ExampleConnector` in [#30201](https://github.com/vllm-project/vllm/pull/30201)
+    to make clear it is a debug/example connector, not a production shared-storage
+    backend. If you are following an older tutorial or blog post that sets
+    `kv_connector="SharedStorageConnector"`, use `kv_connector="ExampleConnector"`
+    instead (the `shared_storage_path` extra config still applies). Using the old
+    name on current vLLM fails with
+    `Unsupported connector type: SharedStorageConnector`. For production
+    disaggregated prefilling, prefer a production-grade connector such as
+    `NixlConnector` or `MooncakeConnector` rather than the example connector.
+
+vLLM ships the following KV connectors:
 
 - **ExampleConnector**: refer to [examples/disaggregated/example_connector/run.sh](../../examples/disaggregated/example_connector/run.sh) for the example usage of ExampleConnector disaggregated prefilling.
 - **LMCacheConnectorV1**: refer to [examples/disaggregated/lmcache/disagg_prefill_lmcache_v1/disagg_example_nixl.sh](../../examples/disaggregated/lmcache/disagg_prefill_lmcache_v1/disagg_example_nixl.sh) for the example usage of LMCacheConnectorV1 disaggregated prefilling which uses NIXL as the underlying KV transmission. LMCache also offers a multi-process (MP) mode via `LMCacheMPConnector`, where a standalone `lmcache server` holds the KV cache shared by one or more vLLM instances; see the [LMCache examples](../../examples/disaggregated/lmcache/README.md) and the [LMCache docs](https://docs.lmcache.ai) for setup.


### PR DESCRIPTION
## Purpose

Addresses the docs subset of #49399. After #30201 renamed `SharedStorageConnector` -> `ExampleConnector`, `docs/features/disagg_prefill.md` still had no migration note, so users following older tutorials / the anatomy blog snippet (`kv_connector="SharedStorageConnector"`) hit `Unsupported connector type: SharedStorageConnector` on current `main` with no in-repo guidance on what to use instead.

## Changes

- Add a migration note to `docs/features/disagg_prefill.md`: the debug connector was renamed to `ExampleConnector` (see #30201), `shared_storage_path` still applies, it is debug/example-only, and production PD should use a production connector (`NixlConnector` / `MooncakeConnector`).
- Replace the inaccurate `Now supports 9 types of connectors` line with a count-free phrasing, since the listed set (8) and the registry in `vllm/distributed/kv_transfer/kv_connector/factory.py` had already drifted from that number.

## Scope / notes

Docs-only change; no code paths touched. This intentionally covers the in-repo docs gap from #49399. The external blog snippet and the optional deprecated-alias idea in that issue are out of scope for this PR.
