### PR TITLE
[ROCm][Perf] Add MI250X selective state update tuning

### DIFF
--- a/vllm/model_executor/layers/mamba/ops/configs/selective_state_update/headdim=64,dstate=128,device_name=AMD_Instinct_MI250X,cache_dtype=float32.json
+++ b/vllm/model_executor/layers/mamba/ops/configs/selective_state_update/headdim=64,dstate=128,device_name=AMD_Instinct_MI250X,cache_dtype=float32.json
@@ -1,0 +1,31 @@
+{
+  "triton_version": "3.7.1",
+  "16": {
+    "BLOCK_SIZE_M": 16,
+    "num_warps": 4
+  },
+  "32": {
+    "BLOCK_SIZE_M": 16,
+    "num_warps": 4
+  },
+  "64": {
+    "BLOCK_SIZE_M": 16,
+    "num_warps": 4
+  },
+  "128": {
+    "BLOCK_SIZE_M": 8,
+    "num_warps": 2
+  },
+  "256": {
+    "BLOCK_SIZE_M": 16,
+    "num_warps": 4
+  },
+  "512": {
+    "BLOCK_SIZE_M": 16,
+    "num_warps": 1
+  },
+  "1024": {
+    "BLOCK_SIZE_M": 32,
+    "num_warps": 2
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds measured launch settings for selective state update on the AMD
Instinct MI250X.

The settings apply to head size 64, state size 128, and a float32 state cache.
This is a data-only change. The loader matches the exact GPU name, sizes, and
cache type. Other GPUs and other shapes keep the current settings.

## Duplicate check

I searched open vLLM PRs for MI250X, gfx90a, Mamba, selective state update, and
related tuning files. I found no PR for this device and shape.

## Performance

I tested each setting on one AMD Instinct MI250X. I compared the output with
the current fallback before I measured time. The tuning file records Triton
3.7.1, which was the tested version.

| Effective batch | Selected setting | Speedup |
|---:|---:|---:|
| 16 | block 16, 4 warps | 1.08x |
| 32 | block 16, 4 warps | 1.14x |
| 64 | block 16, 4 warps | 1.32x |
| 128 | block 8, 2 warps | 1.43x |
| 256 | block 16, 4 warps | 1.34x |
| 512 | block 16, 1 warp | 1.21x |
| 1,024 | block 32, 2 warps | 1.19x |

In an earlier TP8 NVIDIA-Nemotron-3-Super-120B-A12B-BF16 run, selective state
update fell from 6.566 ms to 6.059 ms (-7.7%). The full step fell from
37.038 ms to 36.868 ms (-0.46%).

That run also had other long-context changes. The table above is the isolated
result for this PR.

## Correctness and tests

- Model smoke check: the baseline and this PR each completed seven TP8
  prompts with NVIDIA-Nemotron-3-Super-120B-A12B-BF16. Both runs answered
  the 3,624-token control prompt with `READY`.
- Each selected setting matched the fallback output before timing.
- The JSON file is valid.
- The current loader selected all seven entries for an MI250X.
- Full pre-commit checks passed for the changed file.

The committed file is identical to the file used in the model run.

## AI assistance

OpenAI Codex helped with profiling, test runs, and this description. The human
submitter reviewed the changed file and confirmed the reported results. The
submitter understands the change and takes responsibility for it.
