### PR TITLE
[ROCm][Perf] Speed up large MoE ReLU-squared on gfx90a

### DIFF
--- a/tests/kernels/moe/test_triton_moe_no_act_mul.py
+++ b/tests/kernels/moe/test_triton_moe_no_act_mul.py
@@ -11,12 +11,21 @@ import pytest
 import torch
 
 from tests.kernels.moe.utils import make_dummy_moe_config
-from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.activation import (
+    MoEActivation,
+    apply_moe_activation,
+)
 from vllm.model_executor.layers.fused_moe.config import (
     FUSED_MOE_UNQUANTIZED_CONFIG,
 )
 from vllm.model_executor.layers.fused_moe.experts.triton_moe import TritonExperts
 from vllm.platforms import current_platform
+
+_ON_GFX90A = False
+if current_platform.is_rocm():
+    from vllm.platforms.rocm import on_gfx90a
+
+    _ON_GFX90A = on_gfx90a()
 
 # Test parameters
 M_SIZES = [1, 16, 64]
@@ -209,3 +218,37 @@ def test_adjust_n_for_activation():
     assert experts.adjust_N_for_activation(N, MoEActivation.SILU_NO_MUL) == N
     assert experts.adjust_N_for_activation(N, MoEActivation.GELU_NO_MUL) == N
     assert experts.adjust_N_for_activation(N, MoEActivation.RELU2_NO_MUL) == N
+
+
+@pytest.mark.skipif(not _ON_GFX90A, reason="Requires AMD gfx90a")
+@torch.inference_mode()
+def test_gfx90a_fused_relu2() -> None:
+    # Exercise the production dispatch with Nemotron-3's intermediate width.
+    # This size is above the measured crossover in can_use_fused_relu2.
+    input = torch.randn(11264, 2688, dtype=torch.bfloat16, device="cuda")
+    expected_input = torch.relu(input)
+    expected_output = torch.square(expected_input)
+    output = torch.empty_like(input)
+
+    apply_moe_activation(MoEActivation.RELU2_NO_MUL, output, input)
+
+    torch.testing.assert_close(input, expected_input, rtol=0, atol=0)
+    torch.testing.assert_close(output, expected_output, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not _ON_GFX90A, reason="Requires AMD gfx90a")
+@torch.inference_mode()
+def test_gfx90a_fused_relu2_supports_only_measured_layout() -> None:
+    from vllm.model_executor.layers.fused_moe.rocm_gfx90a_activation import (
+        _MIN_RELU2_ELEMENTS,
+        can_use_fused_relu2,
+    )
+
+    input = torch.empty(_MIN_RELU2_ELEMENTS, dtype=torch.bfloat16, device="cuda")
+    output = torch.empty_like(input)
+
+    assert can_use_fused_relu2(output, input)
+    assert not can_use_fused_relu2(input, input)
+    assert not can_use_fused_relu2(output, input.float())
+    assert not can_use_fused_relu2(output, input[::2])
+    assert not can_use_fused_relu2(output, input[: _MIN_RELU2_ELEMENTS - 1])

--- a/vllm/model_executor/layers/fused_moe/activation.py
+++ b/vllm/model_executor/layers/fused_moe/activation.py
@@ -7,6 +7,19 @@ from enum import Enum
 import torch
 import torch.nn.functional as F
 
+from vllm.platforms import current_platform
+
+_ON_GFX90A = False
+if current_platform.is_rocm():
+    from vllm.platforms.rocm import on_gfx90a
+
+    _ON_GFX90A = on_gfx90a()
+    if _ON_GFX90A:
+        from .rocm_gfx90a_activation import (
+            can_use_fused_relu2,
+            fused_relu2,
+        )
+
 
 class MoEActivation(Enum):
     """Activation functions for MoE layers."""
@@ -182,8 +195,11 @@ def apply_moe_activation(
     elif activation == MoEActivation.GELU_TANH_NO_MUL:
         output.copy_(F.gelu(input, approximate="tanh"))
     elif activation == MoEActivation.RELU2_NO_MUL:
-        F.relu(input, inplace=True)
-        torch.square(input, out=output)
+        if _ON_GFX90A and can_use_fused_relu2(output, input):
+            fused_relu2(output, input)
+        else:
+            F.relu(input, inplace=True)
+            torch.square(input, out=output)
     else:
         raise ValueError(f"Unsupported FusedMoe activation: {activation}")
 

--- a/vllm/model_executor/layers/fused_moe/rocm_gfx90a_activation.py
+++ b/vllm/model_executor/layers/fused_moe/rocm_gfx90a_activation.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fused MoE activations tuned for AMD gfx90a."""
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+# The fused kernel becomes faster than separate ReLU and square kernels once
+# the activation is large enough to amortize its additional store. Triton uses
+# 32-bit offsets here, so retain the eager implementation for larger tensors.
+_MIN_RELU2_ELEMENTS = 30_000_000
+_MAX_RELU2_ELEMENTS = torch.iinfo(torch.int32).max
+
+
+@triton.jit
+def _relu2_kernel(
+    input_ptr,
+    output_ptr,
+    elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < elements
+    values = tl.load(input_ptr + offsets, mask=mask)
+    activated = tl.maximum(values, 0.0)
+    tl.store(input_ptr + offsets, activated, mask=mask)
+    tl.store(output_ptr + offsets, activated * activated, mask=mask)
+
+
+def can_use_fused_relu2(output: torch.Tensor, input: torch.Tensor) -> bool:
+    """Return whether the gfx90a fused ReLU-squared kernel supports the tensors."""
+    elements = input.numel()
+    return (
+        input.dtype == torch.bfloat16
+        and output.dtype == input.dtype
+        and output.shape == input.shape
+        and input.is_cuda
+        and input.is_contiguous()
+        and output.is_contiguous()
+        and input.device == output.device
+        and input.data_ptr() != output.data_ptr()
+        and _MIN_RELU2_ELEMENTS <= elements <= _MAX_RELU2_ELEMENTS
+    )
+
+
+def fused_relu2(output: torch.Tensor, input: torch.Tensor) -> None:
+    """Compute ReLU-squared while preserving the eager path in-place ReLU."""
+    elements = input.numel()
+    _relu2_kernel[(triton.cdiv(elements, 1024),)](
+        input,
+        output,
+        elements,
+        BLOCK_SIZE=1024,
+        num_warps=4,
+    )


### PR DESCRIPTION
## Summary

The MoE ReLU-squared code now runs two GPU operations. The first operation
writes ReLU back to the input. The second operation writes the square to the
output.

This PR uses one Triton kernel for both results on gfx90a. gfx90a is the GPU
architecture used by the AMD Instinct MI250X. The new kernel keeps the current
input mutation.

The new kernel runs only when all these conditions are true:

- the GPU is gfx90a;
- the input and output use BF16;
- both tensors are contiguous, have the same shape, and do not alias; and
- the input has at least 30 million elements and at most `INT32_MAX` elements.

All other cases keep the current code.

## Duplicate check

I searched open vLLM PRs for ReLU-squared, ReLU2, gfx90a activation, and ROCm
MoE activation. I found no PR with this change.

## Performance

I tested one AMD Instinct MI250X with BF16 data. The width was 2,688, which is
the NVIDIA-Nemotron-3-Super-120B-A12B-BF16 MoE width.

| Rows | Elements | Current code | This PR | Speedup |
|---:|---:|---:|---:|---:|
| 11,264 | 30.3M | 0.1954 ms | 0.1666 ms | 1.17x |
| 90,112 | 242.2M | 1.4337 ms | 1.1060 ms | 1.30x |
| 180,224 | 484.4M | 2.8460 ms | 2.1521 ms | 1.32x |

The new kernel was slower for a small input of 176 rows. The 30-million-element
limit keeps small inputs on the current code.

These tests use the same kernel and launch settings as the model code. This PR
does not claim a separate end-to-end speedup.

## Correctness and tests

- Model smoke check: the baseline and this PR each completed seven TP8
  prompts with NVIDIA-Nemotron-3-Super-120B-A12B-BF16. Both runs answered
  the 3,624-token control prompt with `READY`.
- gfx90a tests: `2 passed, 74 deselected`.
- Full pre-commit checks passed for all three changed files.

The GPU test calls `apply_moe_activation`, which is the model dispatch
function. It checks exact output values and exact input mutation. A second test
checks the type, layout, alias, and size limits.

## AI assistance

OpenAI Codex helped with profiling, implementation, test runs, and this
description. The human submitter reviewed every changed line and confirmed the
reported results. The submitter understands the change and takes responsibility
for it.
