### PR TITLE
[Bugfix][Parser] Confirm reasoning end when an Inkling content block opens

### DIFF
--- a/tests/parser/engine/test_inkling.py
+++ b/tests/parser/engine/test_inkling.py
@@ -166,9 +166,13 @@ def _delegating(mock_tokenizer, tools=None):
 
 def _stream_delegating(parser, request, text, chunk_size, prompt_token_ids):
     """Stream ``text`` through ``DelegatingParser.parse_delta``, ``chunk_size``
-    tokens per delta; return ``(content, reasoning, ordered tool names)``."""
+    tokens per delta; return ``(content, reasoning, ordered tool names,
+    ordered tool arguments)``. Arguments arrive in fragments, so they are
+    concatenated per tool index."""
     tokens = _tokenize(text)
-    content, reasoning, tools = "", "", {}
+    content, reasoning = "", ""
+    tools: dict[int, str] = {}
+    args: dict[int, str] = {}
     for start in range(0, len(tokens), chunk_size):
         batch = tokens[start : start + chunk_size]
         delta = parser.parse_delta(
@@ -186,7 +190,14 @@ def _stream_delegating(parser, request, text, chunk_size, prompt_token_ids):
             for tc in delta.tool_calls:
                 if tc.function and tc.function.name:
                     tools[tc.index] = tc.function.name
-    return content, reasoning, [tools[k] for k in sorted(tools)]
+                if tc.function and tc.function.arguments:
+                    args[tc.index] = args.get(tc.index, "") + tc.function.arguments
+    return (
+        content,
+        reasoning,
+        [tools[k] for k in sorted(tools)],
+        [args.get(k, "") for k in sorted(tools)],
+    )
 
 
 class TestArgConverter:
@@ -615,7 +626,7 @@ class TestDelegatingTwoPass:
     def test_plain_text_streaming(self, mock_tokenizer, mock_request, chunk_size):
         tools = [_function_tool()]
         mock_request.tools = tools
-        content, _, calls = _stream_delegating(
+        content, _, calls, _ = _stream_delegating(
             _delegating(mock_tokenizer, tools),
             mock_request,
             f"{TEXT_START}The answer is 42.{END_MESSAGE}",
@@ -734,7 +745,7 @@ class TestDelegatingTwoPass:
     def test_reasoning_then_tool_streaming(
         self, mock_tokenizer, mock_request, chunk_size
     ):
-        content, _, tools = _stream_delegating(
+        content, _, tools, _ = _stream_delegating(
             _delegating(mock_tokenizer),
             mock_request,
             f"{THINK_START}plan{END_MESSAGE}{MSG_MODEL}"
@@ -743,5 +754,35 @@ class TestDelegatingTwoPass:
             self.GEN_PROMPT,
         )
         assert tools == ["get_weather"]
+        assert TOOL_JSON not in content
+        assert END_MESSAGE not in content
+
+    @pytest.mark.parametrize("opener", [TEXT_START, TOOL_TEXT, TOOL_ERROR])
+    @pytest.mark.parametrize("chunk_size", [1, 3, 64])
+    def test_visible_text_then_tool_streaming(
+        self, mock_tokenizer, mock_request, chunk_size, opener
+    ):
+        """Visible content before a tool call, with no thinking block.
+
+        The reasoning pass leaves its reasoning phase only on an explicit
+        reasoning-end event. A response that opens with visible content never
+        emitted one, so the tool pass never ran: the entire tool block came
+        back as assistant content and no tool call was parsed. Every opener
+        that starts a visible block has to confirm the boundary, which is why
+        ``TOOL_TEXT`` and ``TOOL_ERROR`` are covered alongside ``TEXT_START``.
+        """
+        tools = [_function_tool()]
+        mock_request.tools = tools
+        content, _, names, args = _stream_delegating(
+            _delegating(mock_tokenizer, tools),
+            mock_request,
+            f"{opener}let me check{END_MESSAGE}{MSG_MODEL}"
+            + _tool_block("get_weather", '{"city":"SF"}'),
+            chunk_size,
+            self.GEN_PROMPT,
+        )
+        assert content == "let me check"
+        assert names == ["get_weather"]
+        assert json.loads(args[0]) == {"city": "SF"}
         assert TOOL_JSON not in content
         assert END_MESSAGE not in content

--- a/vllm/parser/inkling.py
+++ b/vllm/parser/inkling.py
@@ -189,9 +189,14 @@ def inkling_config() -> ParserEngineConfig:
             ParserState.MESSAGE_HEADER,
             (),
         ),
+        # Opening a block that renders as visible content proves no reasoning
+        # is still open. Confirming that here is what lets DelegatingParser
+        # hand the following blocks to the tool pass: the reasoning pass only
+        # leaves its reasoning phase on an explicit reasoning-end event, and a
+        # response with no thinking block never emits one otherwise.
         (ParserState.CONTENT, "TEXT_START"): Transition(
             ParserState.CONTENT,
-            (),
+            (EventType.REASONING_END,),
         ),
         (ParserState.CONTENT, "THINK_START"): Transition(
             ParserState.REASONING,
@@ -204,11 +209,11 @@ def inkling_config() -> ParserEngineConfig:
         # Raw / error tool blocks render as visible text.
         (ParserState.CONTENT, "TOOL_TEXT"): Transition(
             ParserState.CONTENT,
-            (),
+            (EventType.REASONING_END,),
         ),
         (ParserState.CONTENT, "TOOL_ERROR"): Transition(
             ParserState.CONTENT,
-            (),
+            (EventType.REASONING_END,),
         ),
         # The optional function name between the model-role and content-kind
         # markers is metadata, not visible assistant content.
@@ -218,7 +223,7 @@ def inkling_config() -> ParserEngineConfig:
         ),
         (ParserState.MESSAGE_HEADER, "TEXT_START"): Transition(
             ParserState.CONTENT,
-            (),
+            (EventType.REASONING_END,),
         ),
         (ParserState.MESSAGE_HEADER, "THINK_START"): Transition(
             ParserState.REASONING,
@@ -230,11 +235,11 @@ def inkling_config() -> ParserEngineConfig:
         ),
         (ParserState.MESSAGE_HEADER, "TOOL_TEXT"): Transition(
             ParserState.CONTENT,
-            (),
+            (EventType.REASONING_END,),
         ),
         (ParserState.MESSAGE_HEADER, "TOOL_ERROR"): Transition(
             ParserState.CONTENT,
-            (),
+            (EventType.REASONING_END,),
         ),
         # ── Inside a thinking block ───────────────────────────────────
         (ParserState.REASONING, "THINK_START"): Transition(


### PR DESCRIPTION
Fixes the streaming text-then-tool half of #49865.

Rebased onto current `main` (including #51391) and narrowed to that one bug,
per @bbrowning's review.

## Purpose

Inkling's reasoning pass leaves its reasoning phase only on an explicit
reasoning-end event. A response that opens with visible content and no thinking
block never emitted one, so `DelegatingParser` never entered its tool phase and
the tool pass never ran.

#51391 fixed marker ownership inside the reasoning pass, but not this phase
gating. With both Inkling parsers enabled, tools declared, and
`tool_choice="auto"`, this still fails on current main:

```
<|content_text|>let me check<|end_message|>
<|message_model|>
<|content_invoke_tool_json|>{"name":"get_weather","args":{"city":"SF"}}<|end_message|>
```

Content comes back as

```
let me check<|content_invoke_tool_json|>{"name":"get_weather","args":{"city":"SF"}}<|end_message|>
```

and no tool call is parsed.

## Fix

Emit `REASONING_END` from every transition that opens a block rendering as
visible content — `TEXT_START`, `TOOL_TEXT` and `TOOL_ERROR`, from both
`CONTENT` and `MESSAGE_HEADER`. Six one-line changes in `inkling_config()`;
nothing else in the parser or engine is touched.

These openers are not tool terminals, so they do not interact with the
forwarded-tool-span tracking added in #51391.

## Scope

Narrowed from the original PR, per review:

- `passthrough_terminal_when_skipping_tools` and its engine/config plumbing are
  **dropped** — #51391 owns shared block-closer handling now, and that plumbing
  was the source of the rebase conflict.
- The generic `_extract_tool_calls` cleaned-content fallback is **dropped**.
  #51391's own `test_plain_text_non_streaming` covers the non-streaming
  plain-text-with-tools case on current main, so there is no separate
  post-#51391 reproduction for it.
- The no-tools plain-text work is **split out** into a follow-up PR. Final
  content is correct on main; what remains there is the streaming-latency
  issue, which wants its own tests.
- The tool-first / no-thinking case is left to #50528, which owns the
  `TOOL_START` → `REASONING_END` transition.

## Test Plan

`TestDelegatingTwoPass::test_visible_text_then_tool_streaming` in
`tests/parser/engine/test_inkling.py` drives the served two-pass
`DelegatingParser.parse_delta` path with a real function tool declared and
`tool_choice="auto"`, and asserts:

- visible content is exactly `let me check`
- the tool call is parsed as `get_weather` with arguments `{"city": "SF"}`
- neither `<|content_invoke_tool_json|>` nor `<|end_message|>` appears in content

Parameterized over chunk sizes `1 / 3 / 64` and over all three visible-content
openers (`TEXT_START`, `TOOL_TEXT`, `TOOL_ERROR`), since the same change lands
on all of them — nine cases.

`_stream_delegating` now also returns accumulated tool-call arguments so the
argument assertion is possible; its two existing callers are updated for the
extra return value.

## Test Result

All nine cases fail on current main and pass with this change. On main the
content assertion fails as:

```
- let me check
+ let me check<|content_invoke_tool_json|>{"name":"get_weather","args":{"city":"SF"}}<|end_message|>
```

`tests/parser/engine`: **3767 passed** (main reports 3758 in #51391; the
difference is exactly the nine cases added here).

`ruff check` and `ruff format --check` clean on both changed files.

Note for anyone reproducing locally: `pytest tests/parser tests/reasoning`
segfaults on current main in this environment, in the autouse `cleanup_fixture`
teardown after
`tests/parser/mistral/test_reasoning.py::test_mistral_reasoning_v13[v13_basic]`
(`cleanup_dist_env_and_memory` → `torch.accelerator.empty_host_cache`). It
reproduces identically with and without this change, so it is unrelated —
`tests/parser/engine` runs clean.

No live model evaluation was run; this is a parser-only change with
deterministic CPU-only coverage, and an Inkling model was not available.

## AI assistance

The human submitter selected and claimed the underlying issue, controlled the
scope, reviewed the root cause and implementation, reviewed every changed line,
and approved publication. AI-assisted tooling supported implementation,
regression-test authoring, and validation orchestration.
