### PR TITLE
[Perf][Elastic EP] Remove duplicate cudagraph capture during scale-up

### DIFF
--- a/vllm/distributed/elastic_ep/elastic_execute.py
+++ b/vllm/distributed/elastic_ep/elastic_execute.py
@@ -351,7 +351,7 @@ class ElasticEPScalingExecutor:
         self._release_cuda_graphs()
         _replace_active_groups(world=None, dp=None, ep=None, eplb=None, node_count=None)
 
-    def switch_and_prepare(self) -> None:
+    def switch_and_prepare(self, defer_cudagraph_capture: bool = False) -> None:
         old_dp_size = get_dp_group().world_size
         old_ep_size = get_ep_group().world_size
 
@@ -499,6 +499,13 @@ class ElasticEPScalingExecutor:
             )
             compilation_counter.stock_torch_compile_count += 1
             self.worker.model_runner.model.compile(fullgraph=True, backend=backend)
+
+        if defer_cudagraph_capture:
+            # rewarm_workspace() will recapture after the EPLB reshuffle
+            # with the properly-sized MoE workspace.
+            if new_dp_size < old_dp_size:
+                self._set_eplb_suppressed(False)
+            return
 
         multi_block_table = self.worker.model_runner.input_batch.block_table
         saved_block_tables: list[tuple[torch.Tensor, torch.Tensor]] = []

--- a/vllm/distributed/elastic_ep/elastic_state.py
+++ b/vllm/distributed/elastic_ep/elastic_state.py
@@ -278,7 +278,9 @@ class ElasticEPScalingState:
             return True
 
         elif state == ScaleUpExistingEngineState.SWITCH_AND_PREPARE:
-            self._switch_and_prepare()
+            # rewarm_workspace() recaptures with the correct workspace
+            # size after the EPLB reshuffle; capture here would be wasted.
+            self._switch_and_prepare(defer_cudagraph_capture=True)
             self.state = ScaleUpExistingEngineState.EPLB_RESHUFFLE
             assert self.new_dp_store is not None
             self.new_dp_store.add("eep_barrier_engine_count", 1)
@@ -502,9 +504,13 @@ class ElasticEPScalingState:
         if self.old_dp_group.rank() == 0:
             logger.info("[Elastic EP] Synced KV cache memory size to new workers")
 
-    def _switch_and_prepare(self):
+    def _switch_and_prepare(self, defer_cudagraph_capture: bool = False):
         self.model_executor.collective_rpc(
-            "elastic_ep_execute", args=("switch_and_prepare",)
+            "elastic_ep_execute",
+            args=(
+                "switch_and_prepare",
+                defer_cudagraph_capture,
+            ),
         )
         old_dp_group = self.old_dp_group
         stateless_destroy_torch_distributed_process_group(old_dp_group)


### PR DESCRIPTION
## Problem

During scale-up, existing engines perform two cudagraph captures
back-to-back. The first happens in `switch_and_prepare()` before the
EPLB reshuffle; the second in `rewarm_workspace()` after the reshuffle,
where it drops the first set of graphs via `_release_cuda_graphs()` and
recaptures with the properly-sized MoE workspace. The first capture is
discarded before serving a single request.

This was introduced when #41792 added `rewarm_workspace()` to fix
workspace sizing after the EPLB reshuffle. The follow-up issue #42107
tracks removing the now-redundant capture.

## Fix

Add a `defer_cudagraph_capture` parameter to `switch_and_prepare()`.
When `True`, the method performs reconfiguration and state setup but
skips the cudagraph capture step. `rewarm_workspace()` remains the
single capture point for scale-up.

### Files changed

- `elastic_execute.py`: `switch_and_prepare()` accepts
  `defer_cudagraph_capture: bool = False`. When `True`, returns early
  after reconfiguration, before the block-table save/capture/restore
  section.
- `elastic_state.py`: `_switch_and_prepare()` forwards the parameter
  to the executor RPC. The scale-up `SWITCH_AND_PREPARE` state passes
  `True`; the scale-down `EPLB_RESHUFFLE` state uses the default
  `False`.

### Capture count per path

| Path | Before | After |
|------|--------|-------|
| Scale-up existing engines | 2 | **1** |
| Scale-up new engines | 1 | 1 |
| Scale-down remaining engines | 1 | 1 |
| Scale-down removing engines | 0 | 0 |

## Testing

The existing `test_elastic_ep.py` integration tests cover scale-up
(2→4, 2→3) and scale-down paths end-to-end, verifying GSM8K accuracy
after each transition. This change does not alter inference behavior —
it only removes a superseded capture, so the tests remain valid as-is.

```
tests/distributed/test_elastic_ep.py::test_elastic_ep_scaling
tests/distributed/test_elastic_ep.py::test_elastic_ep_scaling_uneven
```

Fixes #42107.