### PR TITLE
[Bugfix] Reject custom tools on non-Harmony Responses routes

### DIFF
--- a/tests/entrypoints/openai/responses/test_responses_utils.py
+++ b/tests/entrypoints/openai/responses/test_responses_utils.py
@@ -15,11 +15,13 @@ from openai.types.responses.response_reasoning_item import (
     ResponseReasoningItem,
     Summary,
 )
+from openai.types.responses.tool import CustomTool, FunctionTool
 
 from vllm.entrypoints.openai.responses.utils import (
     _construct_message_from_response_item,
     construct_chat_messages_with_tool_call,
     construct_input_messages,
+    construct_tool_dicts,
     convert_tool_responses_to_completions_format,
     should_continue_final_message,
 )
@@ -137,6 +139,31 @@ class TestResponsesUtils:
         result = convert_tool_responses_to_completions_format(input_tool)
 
         assert result == {"type": "function", "function": input_tool}
+
+    def test_construct_tool_dicts_skips_custom_tools(self):
+        """A custom tool must not be coerced into a function tool dict."""
+        tools = [
+            FunctionTool(
+                type="function",
+                name="get_weather",
+                parameters={},
+                strict=None,
+            ),
+            CustomTool(
+                type="custom",
+                name="apply_patch",
+                description="Apply a patch",
+            ),
+        ]
+
+        result = construct_tool_dicts(tools, "auto")
+
+        assert result == [
+            {
+                "type": "function",
+                "function": tools[0].model_dump(),
+            }
+        ]
 
     def test_construct_chat_messages_with_tool_call(self):
         """Test construction of chat messages with tool calls."""

--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from contextlib import AsyncExitStack
+from http import HTTPStatus
 from unittest.mock import MagicMock
 
 import pytest
@@ -291,6 +292,69 @@ class TestInitializeToolSessions:
         error = serving_responses_instance._validate_create_responses_input(request)
         assert error is not None
         assert error.error.type == "invalid_request_error"
+
+    @pytest.mark.parametrize(
+        ("use_harmony", "tool_choice", "expect_error"),
+        [
+            (False, "auto", True),
+            (False, "none", False),
+            (True, "auto", False),
+        ],
+    )
+    def test_validates_custom_tools_for_non_harmony(
+        self,
+        serving_responses_instance,
+        use_harmony,
+        tool_choice,
+        expect_error,
+    ):
+        """Custom tools must be rejected on non-Harmony routes instead of
+        being silently coerced into function tools."""
+        serving_responses_instance.use_harmony = use_harmony
+        request = ResponsesRequest(
+            input="please apply a patch",
+            tools=[
+                {
+                    "type": "custom",
+                    "name": "apply_patch",
+                    "description": "Apply a patch",
+                    "format": {
+                        "type": "grammar",
+                        "syntax": "lark",
+                        "definition": "start: /[\\s\\S]+/",
+                    },
+                }
+            ],
+            tool_choice=tool_choice,
+        )
+
+        error = serving_responses_instance._validate_create_responses_input(request)
+
+        if expect_error:
+            assert error is not None
+            assert error.error.type == "invalid_request_error"
+            assert error.error.param == "tools"
+            assert error.error.code == HTTPStatus.BAD_REQUEST
+        else:
+            assert error is None
+
+    def test_validates_function_tools_for_non_harmony(self, serving_responses_instance):
+        """Ordinary function tools remain accepted on non-Harmony routes."""
+        request = ResponsesRequest(
+            input="What is the weather?",
+            tools=[
+                {
+                    "type": "function",
+                    "name": "get_weather",
+                    "parameters": {},
+                }
+            ],
+            tool_choice="auto",
+        )
+
+        error = serving_responses_instance._validate_create_responses_input(request)
+
+        assert error is None
 
 
 class TestValidateGeneratorInput:

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -295,6 +295,21 @@ class OpenAIServingResponses(GenerateBaseServing):
     def _validate_create_responses_input(
         self, request: ResponsesRequest
     ) -> ErrorResponse | None:
+        if (
+            not self.use_harmony
+            and request.tool_choice != "none"
+            and any(tool.type == "custom" for tool in request.tools)
+        ):
+            return self.create_error_response(
+                err_type="invalid_request_error",
+                message=(
+                    "Custom tools are not supported by this model's tool "
+                    "parser. Use a function tool instead, or set "
+                    "`tool_choice='none'`."
+                ),
+                status_code=HTTPStatus.BAD_REQUEST,
+                param="tools",
+            )
         if self.use_harmony and request.is_include_output_logprobs():
             return self.create_error_response(
                 err_type="invalid_request_error",

--- a/vllm/tool_parsers/utils.py
+++ b/vllm/tool_parsers/utils.py
@@ -215,7 +215,7 @@ def iter_response_function_tool_dicts(
                     namespace, namespaced_tool.name
                 )
                 function_tools.append(tool_dict)
-        else:
+        elif isinstance(tool, FunctionTool):
             function_tools.append(tool.model_dump())
     return function_tools
 


### PR DESCRIPTION
## Purpose

Fix #49724: on non-Harmony Responses routes, a `type=custom` tool was silently coerced into a Chat function tool and the response came back as a `function_call`, breaking the custom/freeform tool contract (e.g. Codex CLI rejects the payload with `tool apply_patch invoked with incompatible payload`).

This PR implements the "fail request validation clearly" option from the issue:

1. `_validate_create_responses_input` now rejects requests containing `type=custom` tools when the route is non-Harmony and `tool_choice != "none"`, returning a 400 `invalid_request_error` with `param="tools"` (same pattern as #49785 for unsupported forced `tool_choice`). Harmony/gpt-oss routes are unaffected — they support custom tools natively.
2. `iter_response_function_tool_dicts` now only emits dicts for actual `FunctionTool`s (aligning it with its sibling `iter_response_function_tool_info`), so non-function tools can never be rendered into the chat template as malformed function definitions.

Full custom-tool support for simple parsers (preserving freeform `input` and mapping output to `custom_tool_call`) is a larger effort and intentionally out of scope; rejecting before generation is strictly better than changing the tool kind.

### Not a duplicate

- No open/closed PR references #49724.
- #48885 preserves custom tool *history* on input; it does not address output classification.
- #49824 refactors tool schema rendering parity but still renders a custom tool as a function tool; it neither rejects nor preserves the custom contract. Small textual overlap in `vllm/tool_parsers/utils.py` / `test_responses_utils.py`; happy to rebase on whichever lands first.

## Test Plan

CPU-only (no CUDA required), `VLLM_TARGET_DEVICE=empty` editable install:

```bash
.venv/bin/python -m pytest tests/entrypoints/openai/responses/test_serving_responses.py tests/entrypoints/openai/responses/test_responses_utils.py -q
```

New tests:

- `test_validates_custom_tools_for_non_harmony` — parametrized: non-Harmony + custom tool + `tool_choice=auto` → 400 with `param="tools"`; `tool_choice="none"` → accepted; Harmony route → accepted.
- `test_validates_function_tools_for_non_harmony` — ordinary function tools still accepted.
- `test_construct_tool_dicts_skips_custom_tools` — `construct_tool_dicts` no longer emits a `{"type": "function", "function": {..., "type": "custom"}}` dict for a custom tool.

## Test Result

```
67 passed, 1 xfailed in 6.66s
```

Before the fix, a reproduction of the issue's minimal request produced:

```json
{"type": "function", "function": {"name": "apply_patch", "type": "custom", "format": {...}}}
```

After the fix, the custom tool is rejected at validation (400) and `construct_tool_dicts` only emits the function tool.

`pre-commit run` (ruff, mypy 3.10-3.12, etc.) passes on all changed files.

---

AI assistance was used for this PR (Claude Code); I have reviewed every changed line and the test results.
