### PR TITLE
[XPU] WA topk_sigmoid argument mismatch for XPU platform

### DIFF
--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2423,6 +2423,18 @@ def topk_sigmoid(
     routed_scaling_factor: float = 1.0,
     is_padding: torch.Tensor | None = None,
 ) -> None:
+    if current_platform.is_xpu():
+        # TODO: Remove after vllm-xpu-kernels supports is_padding.
+        torch.ops._moe_C.topk_sigmoid(
+            topk_weights,
+            topk_ids,
+            token_expert_indices,
+            gating_output,
+            renormalize,
+            e_score_correction_bias,
+            routed_scaling_factor,
+        )
+        return
     torch.ops._moe_C.topk_sigmoid(
         topk_weights,
         topk_ids,


### PR DESCRIPTION



## Purpose
Similar to #49395 for `topk_softmax`, PR #48979 also added the `is_padding` argument to `_moe_C.topk_sigmoid`, but the current XPU kernel does not yet support it.

This PR adds the same workaround to fall back to the old interface for XPU. This will be removed once vllm-xpu-kernels is updated.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

