### PR TITLE
[Kernel] ReplaySSM: cache SSM inputs for faster Gated DeltaNet speculative decode

### DIFF
--- a/benchmarks/replayssm/e2e_spec_decode_throughput.py
+++ b/benchmarks/replayssm/e2e_spec_decode_throughput.py
@@ -1,0 +1,336 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""End-to-end speculative-decode throughput: standard vs native spec vs ReplaySSM spec.
+
+Real GSM8K prompts (chat-formatted) at a fixed batch size, CUDA graphs on, with
+ignore_eos so every mode emits exactly --max-tokens tokens per sequence, making
+tokens/s directly comparable. Reports throughput, mean acceptance length, and
+the ReplaySSM-spec speedup over both baselines.
+
+  standard : no speculative decoding
+  spec     : vLLM native spec decoding (one recurrent state per draft token)
+  cache    : ReplaySSM cached spec decoding (use_replayssm_spec)
+
+Each mode runs in its own subprocess for a clean CUDA context.
+
+The FlashInfer FP4-MoE autotuner is disabled by default (it is unstable under
+CUDA-graph capture on the pre-release Blackwell FP4 path); pass
+--no-disable-flashinfer-autotune for non-FP4 models.
+
+Example (B300):
+    python e2e_spec_decode_throughput.py --batch-size 512 \
+        --model-id nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+
+MODE_LABEL = {"standard": "standard", "spec": "native-spec", "cache": "ReplaySSM-spec"}
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="E2E spec-decode throughput: standard vs native spec vs ReplaySSM."
+    )
+    p.add_argument(
+        "--model-id", default="nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4"
+    )
+    p.add_argument("--tensor-parallel-size", type=int, default=1)
+    p.add_argument("--batch-size", type=int, default=512)
+    p.add_argument(
+        "--num-spec",
+        type=int,
+        default=3,
+        help="Draft tokens per step (spec window = num_spec + 1).",
+    )
+    p.add_argument("--spec-method", default="mtp")
+    p.add_argument(
+        "--buffer-len",
+        type=int,
+        default=16,
+        help="ReplaySSM buffer length (power of two, >= 1 + num_spec).",
+    )
+    p.add_argument("--max-tokens", type=int, default=256)
+    p.add_argument("--max-model-len", type=int, default=2048)
+    p.add_argument("--dtype", default="auto")
+    p.add_argument("--kv-cache-dtype", default="auto")
+    p.add_argument("--gpu-memory-utilization", type=float, default=0.9)
+    p.add_argument(
+        "--warmup-s",
+        type=float,
+        default=30.0,
+        help="Sustained full-batch decode before timing, to ramp the "
+        "GPU SM clock to its steady-state boost.",
+    )
+    p.add_argument(
+        "--enable-thinking",
+        action="store_true",
+        help="Keep reasoning mode on (default off for short outputs).",
+    )
+    p.add_argument(
+        "--disable-flashinfer-autotune",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Disable the FlashInfer FP4-MoE autotuner (default: on). "
+        "It is unstable under CUDA-graph capture on the "
+        "pre-release Blackwell FP4 path; pass "
+        "--no-disable-flashinfer-autotune for non-FP4 models.",
+    )
+    p.add_argument(
+        "--modes",
+        default="standard,spec,cache",
+        help="Comma-separated subset of {standard,spec,cache}.",
+    )
+    p.add_argument(
+        "--moe-backend",
+        default=None,
+        help="Override the draft-model MoE backend (e.g. triton). On "
+        "Blackwell the draft's bf16 MoE hangs on flashinfer_trtllm; "
+        "pass triton. Main-model MoE is left at auto.",
+    )
+    p.add_argument(
+        "--worker",
+        choices=["standard", "spec", "cache"],
+        default=None,
+        help=argparse.SUPPRESS,
+    )
+    return p.parse_args()
+
+
+def gsm8k_messages(batch_size):
+    from datasets import load_dataset
+
+    questions = [
+        r["question"] for r in load_dataset("openai/gsm8k", "main", split="test")
+    ]
+    return [
+        [{"role": "user", "content": questions[i % len(questions)]}]
+        for i in range(batch_size)
+    ]
+
+
+def _sum_counter(metrics, name):
+    return sum(
+        m.value
+        for m in metrics
+        if getattr(m, "name", None) == name and hasattr(m, "value")
+    )
+
+
+def run_worker(args):
+    import torch
+
+    from vllm import LLM, SamplingParams
+
+    mode = args.worker
+    spec_window = 1 if mode == "standard" else 1 + args.num_spec
+
+    llm_kwargs = dict(
+        model=args.model_id,
+        tensor_parallel_size=args.tensor_parallel_size,
+        dtype=args.dtype,
+        kv_cache_dtype=args.kv_cache_dtype,
+        max_model_len=args.max_model_len,
+        max_num_seqs=args.batch_size,
+        trust_remote_code=True,
+        enable_prefix_caching=False,
+        enforce_eager=False,
+        disable_log_stats=False,
+        gpu_memory_utilization=args.gpu_memory_utilization,
+        seed=0,
+        # Ladder of spec_window multiples: covers the baseline spec path's
+        # <= max_concurrency sub-batches when bs > cap, and fixes the
+        # bs=1,T=6 "cudagraph size must be a multiple of T" abort.
+        compilation_config={
+            "cudagraph_capture_sizes": sorted(
+                {
+                    min(r, args.batch_size) * spec_window
+                    for r in (
+                        1,
+                        2,
+                        4,
+                        8,
+                        16,
+                        24,
+                        32,
+                        48,
+                        64,
+                        96,
+                        128,
+                        192,
+                        256,
+                        384,
+                        512,
+                    )
+                }
+            ),
+            "max_cudagraph_capture_size": args.batch_size * spec_window,
+        },
+    )
+    if args.disable_flashinfer_autotune:
+        # FP4-MoE autotuner is unstable under CUDA-graph capture on Blackwell;
+        # re-enable (--no-disable-flashinfer-autotune) only for non-FP4 models.
+        llm_kwargs["kernel_config"] = {"enable_flashinfer_autotune": False}
+    if mode != "standard":
+        spec_cfg = {
+            "method": args.spec_method,
+            "num_speculative_tokens": args.num_spec,
+        }
+        # Override only the draft MoE backend (the trtllm hang is in the draft).
+        if args.moe_backend:
+            spec_cfg["moe_backend"] = args.moe_backend
+        llm_kwargs["speculative_config"] = spec_cfg
+    if mode == "cache":
+        llm_kwargs["use_replayssm_spec"] = True
+        llm_kwargs["replayssm_buffer_len"] = args.buffer_len
+
+    llm = LLM(**llm_kwargs)
+    messages = gsm8k_messages(args.batch_size)
+    chat_kwargs = {"enable_thinking": args.enable_thinking}
+    sp = SamplingParams(
+        n=1, temperature=0.0, max_tokens=args.max_tokens, ignore_eos=True, seed=0
+    )
+
+    def timed_chat():
+        torch.accelerator.synchronize()
+        t0 = time.perf_counter()
+        outs = llm.chat(messages, sp, chat_template_kwargs=chat_kwargs, use_tqdm=False)
+        torch.accelerator.synchronize()
+        return time.perf_counter() - t0, outs
+
+    deadline = time.perf_counter() + args.warmup_s
+    while time.perf_counter() < deadline:
+        timed_chat()
+
+    pre_acc = _sum_counter(llm.get_metrics(), "vllm:spec_decode_num_accepted_tokens")
+    pre_dft = _sum_counter(llm.get_metrics(), "vllm:spec_decode_num_drafts")
+
+    elapsed, outs = timed_chat()
+    produced = min(len(o.outputs[0].token_ids) for o in outs)
+    assert produced == args.max_tokens, f"expected {args.max_tokens}, got {produced}"
+    tok_s = args.batch_size * args.max_tokens / elapsed
+
+    accept_len = None
+    if mode != "standard":
+        drafts = (
+            _sum_counter(llm.get_metrics(), "vllm:spec_decode_num_drafts") - pre_dft
+        )
+        accepted = (
+            _sum_counter(llm.get_metrics(), "vllm:spec_decode_num_accepted_tokens")
+            - pre_acc
+        )
+        accept_len = 1.0 + accepted / drafts if drafts else None
+
+    result = {
+        "mode": mode,
+        "elapsed_s": elapsed,
+        "tok_s": tok_s,
+        "accept_len": accept_len,
+    }
+    print(
+        f"[{mode}] {elapsed:.2f}s  {tok_s:,.0f} tok/s"
+        + (f"  accept_len={accept_len:.2f}" if accept_len else ""),
+        flush=True,
+    )
+    print("RESULT_JSON " + json.dumps(result), flush=True)
+
+
+def run_one_mode(args, mode):
+    cmd = [
+        sys.executable,
+        __file__,
+        "--worker",
+        mode,
+        "--model-id",
+        args.model_id,
+        "--tensor-parallel-size",
+        str(args.tensor_parallel_size),
+        "--batch-size",
+        str(args.batch_size),
+        "--num-spec",
+        str(args.num_spec),
+        "--spec-method",
+        args.spec_method,
+        "--buffer-len",
+        str(args.buffer_len),
+        "--max-tokens",
+        str(args.max_tokens),
+        "--max-model-len",
+        str(args.max_model_len),
+        "--dtype",
+        args.dtype,
+        "--kv-cache-dtype",
+        args.kv_cache_dtype,
+        "--gpu-memory-utilization",
+        str(args.gpu_memory_utilization),
+        "--warmup-s",
+        str(args.warmup_s),
+    ]
+    if args.enable_thinking:
+        cmd.append("--enable-thinking")
+    if args.moe_backend:
+        cmd += ["--moe-backend", args.moe_backend]
+    cmd.append(
+        "--disable-flashinfer-autotune"
+        if args.disable_flashinfer_autotune
+        else "--no-disable-flashinfer-autotune"
+    )
+
+    result = None
+    proc = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1
+    )
+    for line in proc.stdout:
+        sys.stdout.write(line)
+        sys.stdout.flush()
+        if line.startswith("RESULT_JSON "):
+            result = json.loads(line[len("RESULT_JSON ") :])
+    proc.wait()
+    if proc.returncode != 0:
+        raise RuntimeError(f"mode '{mode}' worker exited with {proc.returncode}")
+    if result is None:
+        raise RuntimeError(f"mode '{mode}' produced no RESULT_JSON line")
+    return result
+
+
+def main():
+    args = parse_args()
+    if args.worker is not None:
+        run_worker(args)
+        return
+
+    print(
+        f"model={args.model_id}  tp={args.tensor_parallel_size}  "
+        f"batch_size={args.batch_size}  num_spec={args.num_spec}  "
+        f"buffer_len={args.buffer_len}  max_tokens={args.max_tokens}"
+    )
+
+    modes = [m for m in args.modes.split(",") if m]
+    results = {m: run_one_mode(args, m) for m in modes}
+
+    print()
+    header = f"{'mode':<16}{'tok/s':>14}{'accept_len':>12}{'wall (s)':>12}"
+    print(header)
+    print("-" * len(header))
+    for m in modes:
+        r = results[m]
+        al = f"{r['accept_len']:.2f}" if r["accept_len"] else "-"
+        print(f"{MODE_LABEL[m]:<16}{r['tok_s']:>14,.0f}{al:>12}{r['elapsed_s']:>12.2f}")
+    print("-" * len(header))
+    if "cache" in results and "spec" in results:
+        print(
+            f"ReplaySSM / native-spec : "
+            f"{results['cache']['tok_s'] / results['spec']['tok_s']:.2f}x"
+        )
+    if "cache" in results and "standard" in results:
+        print(
+            f"ReplaySSM / standard    : "
+            f"{results['cache']['tok_s'] / results['standard']['tok_s']:.2f}x"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/replayssm/e2e_spec_decode_throughput.py
+++ b/benchmarks/replayssm/e2e_spec_decode_throughput.py
@@ -17,9 +17,11 @@ The FlashInfer FP4-MoE autotuner is disabled by default (it is unstable under
 CUDA-graph capture on the pre-release Blackwell FP4 path); pass
 --no-disable-flashinfer-autotune for non-FP4 models.
 
-Example (B300):
+Examples (B300):
     python e2e_spec_decode_throughput.py --batch-size 512 \
         --model-id nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4
+    python e2e_spec_decode_throughput.py --batch-size 512 \
+        --model-id nvidia/Qwen3.5-122B-A10B-NVFP4 --moe-backend triton
 """
 
 import argparse
@@ -141,6 +143,9 @@ def run_worker(args):
         disable_log_stats=False,
         gpu_memory_utilization=args.gpu_memory_utilization,
         seed=0,
+        # FlashInfer's GDN prefill kernel JIT-compiles on first use and stalls
+        # on Blackwell; the Triton prefill leaves decode speed unchanged.
+        additional_config={"gdn_prefill_backend": "triton"},
         # Ladder of spec_window multiples: covers the baseline spec path's
         # <= max_concurrency sub-batches when bs > cap, and fixes the
         # bs=1,T=6 "cudagraph size must be a multiple of T" abort.

--- a/tests/kernels/mamba/test_replayssm_spec_decode_mamba2.py
+++ b/tests/kernels/mamba/test_replayssm_spec_decode_mamba2.py
@@ -1,0 +1,845 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Speculative-decode correctness for the Mamba2 ReplaySSM kernels.
+
+A spec/verify step takes the checkpoint state ``S_0`` + the committed ring buffer
++ a window of ``max_spec_len = 1 + num_speculative_tokens`` draft tokens, and
+computes the recurrence OUTPUT at each window position (causal: draft ``s`` reads
+the buffer up to its own position). It does NOT write the state per draft -- only
+a flush step folds the *committed* history into the checkpoint, so unaccepted
+drafts can be rolled back.
+
+The history window is ``L = B + max_spec_len`` (block ``B`` = ``buffer_len``): the
+physical circular buffer is ``next_pow2(L)`` and ``max_cache_len`` passed to the
+kernel is the logical ``L``. Verify launches the non-flush kernel; flush launches
+the reconstruct kernel; both run every step with device-side row routing.
+
+Oracle (no separate spec reference needed): the already-verified ReplaySSM
+STANDARD decode kernel (``selective_state_update_replayssm_output_only``) stepped
+one token at a time over the SAME window from the SAME checkpoint+buffer, with
+``is_flush=False`` so it reads the SAME fixed checkpoint at every window position.
+Its per-position output must equal the spec kernel's. For the multi-step rollback
+the ground truth is the baseline ``selective_state_update`` decode of the accepted
+token stream (it writes the full state every step).
+
+Three checks per (precision, geometry, base_block, max_spec_len):
+  * single spec step output == standard-decode-of-window, swept over the buffer
+    fill level up to the max non-flush fill C = B - max_spec_len,
+  * a 40-step rollback with a random accepted count k per step: accepted-position
+    outputs track the baseline decode, and the committed checkpoint at each flush
+    matches the baseline state at the matching folded-token count,
+  * continuous-batching realism: sparse state slots via state_batch_indices with
+    NULL padding rows and per-row buffer fill levels.
+
+Precision: the checkpoint-readout dot is keyed on the activation dtype -- tf32x3
+(~fp32 parity, 3-pass) for fp32 activations, single-pass tf32 for bf16 -- and the
+cache GEMM uses tf32x3, so fp32 is near-exact (rel ~1e-6, tight tolerance). At bf16
+activations the bf16 ``C``/``x``/``B`` operands dominate (rel ~5e-3), a small
+EXPECTED gap that is bounded per step and non-accumulating across the decode.
+"""
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.mamba.ops.mamba_ssm import selective_state_update
+from vllm.model_executor.layers.mamba.ops.selective_state_update_replayssm_output_only import (  # noqa: E501
+    selective_state_update_replayssm_output_only,
+)
+from vllm.model_executor.layers.mamba.ops.selective_state_update_replayssm_spec import (  # noqa: E501
+    commit_replayssm_spec,
+    reset_replayssm_spec_cursors,
+    selective_state_update_replayssm_spec,
+)
+from vllm.utils.torch_utils import set_random_seed
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
+
+DEV = "cuda"
+
+
+def _lbt(base_block: int, max_spec_len: int) -> tuple[int, int]:
+    """Logical flush threshold L = B + max_spec_len and physical pow2 buffer."""
+    L = base_block + max_spec_len
+    buf = 1 << (L - 1).bit_length()
+    return L, buf
+
+
+def _tolerances(both_fp32: bool) -> tuple[float, float]:
+    # fp32 activations use the tf32x3 checkpoint dot, matching the standard-decode
+    # oracle to ~1e-6; atol=1e-3 still flags a regression to single-pass tf32. bf16
+    # stays loose: the bf16 C/x/B operands dominate (rel ~5e-3), unaffected by the
+    # checkpoint dot's precision.
+    if both_fp32:
+        return 1e-4, 1e-3
+    return 6e-2, 2e-1
+
+
+def _tied_A(nheads: int, headdim: int, dstate: int) -> torch.Tensor:
+    # TIE_HDIM: A is scalar per head (stride(-1)==stride(-2)==0).
+    A = -torch.rand(nheads, device=DEV) - 1.0
+    return A.view(nheads, 1, 1).expand(nheads, headdim, dstate)
+
+
+def _scatter_packed_history(
+    post_conv_cache: torch.Tensor,
+    dt_cache: torch.Tensor,
+    slot: int,
+    x_hist: torch.Tensor,  # (wp, H, P)
+    B_hist: torch.Tensor,  # (wp, G, N)
+    dt_hist_raw: torch.Tensor,  # (wp, H) raw dt
+    d_inner: int,
+    ngroups: int,
+    dstate: int,
+) -> None:
+    """Fill the committed history [0, wp) into the packed circular caches at
+    post_origin=0 (so logical pos == physical pos). Channel map matches the
+    kernel's x_view/B_view: x[h,d]->h*P+d, B[g,n]->d_inner+g*N+n (C is not
+    cached; the kernel reads it fresh from conv_out). dt_cache stores RAW dt
+    (the kernel applies bias+softplus on read)."""
+    wp, H, P = x_hist.shape
+    G, N = ngroups, dstate
+    for p in range(wp):
+        post_conv_cache[slot, p, :d_inner] = x_hist[p].reshape(d_inner)
+        post_conv_cache[slot, p, d_inner : d_inner + G * N] = B_hist[p].reshape(G * N)
+        # C not cached; only x|B seeded.
+        dt_cache[slot, :, p] = dt_hist_raw[p].float()
+
+
+def _pack_window_conv_out(
+    x_w: torch.Tensor,  # (S, H, P)
+    B_w: torch.Tensor,  # (S, G, N)
+    C_w: torch.Tensor,  # (S, G, N)
+    d_inner: int,
+    ngroups: int,
+    dstate: int,
+    act_dtype: torch.dtype,
+) -> torch.Tensor:
+    S = x_w.shape[0]
+    G, N = ngroups, dstate
+    conv_dim = d_inner + 2 * G * N
+    conv_out = torch.zeros(S, conv_dim, device=DEV, dtype=act_dtype)
+    conv_out[:, :d_inner] = x_w.reshape(S, d_inner)
+    conv_out[:, d_inner : d_inner + G * N] = B_w.reshape(S, G * N)
+    conv_out[:, d_inner + G * N :] = C_w.reshape(S, G * N)
+    return conv_out
+
+
+def _standard_window_oracle(
+    *,
+    S0_slot: torch.Tensor,  # (H, P, N) checkpoint for the row
+    x_all,
+    dt_all,
+    B_all,
+    C_all,
+    z_all,  # (T_tot, ...) history+window raw inputs
+    A,
+    D,
+    dt_bias,
+    dt_softplus,
+    wp: int,
+    spec_len: int,
+    buffer_len: int,
+    act_dtype: torch.dtype,
+) -> torch.Tensor:
+    """Step the standard output_only decode over history+window (is_flush=False
+    throughout, so the checkpoint stays fixed). Return the window outputs
+    (spec_len, H, P)."""
+    H, P, N = S0_slot.shape
+    G = B_all.shape[1]
+    state = S0_slot[None].clone()  # (1, H, P, N)
+    x_cache = torch.zeros(1, H, buffer_len, P, device=DEV, dtype=act_dtype)
+    dt_cache = torch.zeros(1, H, buffer_len, device=DEV, dtype=torch.float32)
+    B_cache = torch.zeros(1, G, buffer_len, N, device=DEV, dtype=act_dtype)
+    bc_pre = torch.empty(1, G, buffer_len, device=DEV, dtype=torch.float32)
+    no_flush = torch.zeros(1, device=DEV, dtype=torch.int8)
+    win = []
+    for t in range(wp + spec_len):
+        out_t = torch.empty(1, H, P, device=DEV, dtype=act_dtype)
+        selective_state_update_replayssm_output_only(
+            state,
+            x_all[t : t + 1],
+            dt_all[t : t + 1, :, None].expand(1, H, P),
+            A,
+            B_all[t : t + 1],
+            C_all[t : t + 1],
+            D=D,
+            z=z_all[t : t + 1] if z_all is not None else None,
+            dt_bias=dt_bias[:, None].expand(H, P),
+            dt_softplus=dt_softplus,
+            x_cache=x_cache,
+            dt_cache=dt_cache,
+            B_cache=B_cache,
+            write_pos=torch.tensor([t], device=DEV, dtype=torch.int32),
+            is_flush=no_flush,
+            max_cache_len=buffer_len,
+            bc_pre=bc_pre,
+            out=out_t,
+        )
+        if t >= wp:
+            win.append(out_t.clone())
+    return torch.cat(win, dim=0)
+
+
+def _run_single_step(
+    *,
+    state_dtype,
+    act_dtype,
+    nheads,
+    headdim,
+    dstate,
+    ngroups,
+    buffer_len,  # history block B
+    max_spec_len,
+    wp,
+    has_z,
+    dt_softplus=True,
+    seed=0,
+    perturb=False,
+):
+    set_random_seed(seed)
+    H, P, N, G = nheads, headdim, dstate, ngroups
+    d_inner = H * P
+    spec_len = max_spec_len
+    L, buf = _lbt(buffer_len, max_spec_len)
+    both_fp32 = state_dtype == torch.float32 and act_dtype == torch.float32
+    rtol, atol = _tolerances(both_fp32)
+
+    A = _tied_A(H, P, N)
+    dt_bias = torch.rand(H, device=DEV) - 4.0
+    D = torch.randn(H, P, device=DEV)
+
+    T_tot = wp + spec_len
+    x = torch.randn(T_tot, H, P, device=DEV, dtype=act_dtype)
+    dt = torch.randn(T_tot, H, device=DEV, dtype=act_dtype)
+    B = torch.randn(T_tot, G, N, device=DEV, dtype=act_dtype)
+    C = torch.randn(T_tot, G, N, device=DEV, dtype=act_dtype)
+    z = torch.randn(T_tot, H, P, device=DEV, dtype=act_dtype) if has_z else None
+
+    num_blocks = 2
+    S0 = torch.randn(num_blocks, H, P, N, device=DEV, dtype=state_dtype) * 0.1
+
+    oracle = _standard_window_oracle(
+        S0_slot=S0[1],
+        x_all=x,
+        dt_all=dt,
+        B_all=B,
+        C_all=C,
+        z_all=z,
+        A=A,
+        D=D,
+        dt_bias=dt_bias,
+        dt_softplus=dt_softplus,
+        wp=wp,
+        spec_len=spec_len,
+        buffer_len=buf,
+        act_dtype=act_dtype,
+    )
+
+    # spec path: prefill packed history, one verify call (non-flush).
+    state_spec = S0.clone()
+    cache_conv_dim = d_inner + G * N  # x|B only (no C)
+    post_conv_cache = torch.zeros(
+        num_blocks, buf, cache_conv_dim, device=DEV, dtype=act_dtype
+    )
+    dt_cache = torch.zeros(num_blocks, H, buf, device=DEV, dtype=torch.float32)
+    _scatter_packed_history(
+        post_conv_cache, dt_cache, 1, x[:wp], B[:wp], dt[:wp], d_inner, G, N
+    )
+    if perturb:
+        # teeth: corrupt one history slot -> outputs must diverge from the oracle.
+        post_conv_cache[1, max(0, wp - 1), 0] += 5.0
+
+    conv_out = _pack_window_conv_out(x[wp:], B[wp:], C[wp:], d_inner, G, N, act_dtype)
+    dt_spec = dt[wp:].float()
+    z_spec = z[wp:] if z is not None else None
+    write_pos = torch.zeros(num_blocks, dtype=torch.int32, device=DEV)
+    write_pos[1] = wp
+    post_origin = torch.zeros(num_blocks, dtype=torch.int32, device=DEV)
+    is_flush = torch.zeros(num_blocks, dtype=torch.int8, device=DEV)
+    qsl = torch.tensor([0, spec_len], device=DEV, dtype=torch.int32)
+    sbi = torch.tensor([1], device=DEV, dtype=torch.int32)
+    out_spec = torch.empty(spec_len, H, P, device=DEV, dtype=act_dtype)
+    selective_state_update_replayssm_spec(
+        state_spec,
+        post_conv_cache,
+        dt_cache,
+        conv_out,
+        dt_spec,
+        A,
+        write_pos=write_pos,
+        post_conv_state_pos=post_origin,
+        is_flush=is_flush,
+        query_start_loc=qsl,
+        state_batch_indices=sbi,
+        max_cache_len=L,
+        max_spec_len=max_spec_len,
+        d_inner=d_inner,
+        ngroups=G,
+        dstate=N,
+        D=D,
+        z=z_spec,
+        dt_bias=dt_bias,
+        dt_softplus=dt_softplus,
+        out=out_spec,
+    )
+
+    torch.testing.assert_close(out_spec, oracle, rtol=rtol, atol=atol)
+    # non-flush verify must not touch the checkpoint.
+    torch.testing.assert_close(state_spec, S0, rtol=0, atol=0)
+
+
+def _wp_set(base_block: int, max_spec_len: int) -> list[int]:
+    # Verify-path fills: 0 (empty buffer = pure checkpoint readout), the max
+    # non-flush fill C = B - max_spec_len (the tightest edge), and a midpoint.
+    C = base_block - max_spec_len
+    return sorted({0, max(0, C // 2), max(0, C)})
+
+
+_PRECISIONS = [
+    pytest.param((torch.float32, torch.float32), id="s32_a32"),
+    pytest.param((torch.float32, torch.bfloat16), id="s32_a16"),
+    pytest.param((torch.bfloat16, torch.bfloat16), id="s16_a16"),
+]
+# (nheads, headdim, dstate, ngroups). The full precision x block x max_spec_len
+# sweep runs on the small shapes (cheap compiles); the production Nemotron-3
+# Mamba2 shapes are exercised by test_spec_step_real_geometry.
+_SMALL = pytest.param((8, 64, 64, 4), id="small")
+_TINY = pytest.param((4, 64, 16, 1), id="tiny")
+_REAL_GEOMETRIES = [
+    pytest.param((96, 80, 128, 8), id="nano4b"),
+    pytest.param((128, 64, 128, 8), id="super120b"),
+    pytest.param((256, 64, 128, 8), id="ultra550b"),
+]
+_BASE_BLOCKS = [16, 32]  # history block B (replayssm_buffer_len)
+_MAX_SPEC_LENS = [2, 4, 6, 8]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA device")
+@pytest.mark.parametrize("precision", _PRECISIONS)
+@pytest.mark.parametrize("geometry", [_SMALL, _TINY])
+@pytest.mark.parametrize("base_block", _BASE_BLOCKS)
+@pytest.mark.parametrize("max_spec_len", _MAX_SPEC_LENS)
+@pytest.mark.parametrize("has_z", [False, True])
+def test_spec_step_matches_standard_decode(
+    precision, geometry, base_block, max_spec_len, has_z
+):
+    # base_block >= max_spec_len always holds here. Sweep the non-flush fill level.
+    state_dtype, act_dtype = precision
+    nheads, headdim, dstate, ngroups = geometry
+    for wp in _wp_set(base_block, max_spec_len):
+        _run_single_step(
+            state_dtype=state_dtype,
+            act_dtype=act_dtype,
+            nheads=nheads,
+            headdim=headdim,
+            dstate=dstate,
+            ngroups=ngroups,
+            buffer_len=base_block,
+            max_spec_len=max_spec_len,
+            wp=wp,
+            has_z=has_z,
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA device")
+@pytest.mark.parametrize("precision", _PRECISIONS)
+@pytest.mark.parametrize("geometry", _REAL_GEOMETRIES)
+@pytest.mark.parametrize("max_spec_len", [2, 8])
+def test_spec_step_real_geometry(precision, geometry, max_spec_len):
+    # Production Nemotron-3 Mamba2 shapes (Nano-4B / Super-120B / Ultra-550B) at
+    # the deployable block B=16, both ends of the max_spec_len range.
+    state_dtype, act_dtype = precision
+    nheads, headdim, dstate, ngroups = geometry
+    for wp in _wp_set(16, max_spec_len):
+        _run_single_step(
+            state_dtype=state_dtype,
+            act_dtype=act_dtype,
+            nheads=nheads,
+            headdim=headdim,
+            dstate=dstate,
+            ngroups=ngroups,
+            buffer_len=16,
+            max_spec_len=max_spec_len,
+            wp=wp,
+            has_z=True,
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA device")
+def test_spec_step_teeth():
+    # A correct run passes; corrupting one cached history value must break the
+    # output match (guards against a vacuous oracle).
+    _run_single_step(
+        state_dtype=torch.float32,
+        act_dtype=torch.float32,
+        nheads=8,
+        headdim=64,
+        dstate=64,
+        ngroups=4,
+        buffer_len=16,
+        max_spec_len=4,
+        wp=5,
+        has_z=True,
+    )
+    with pytest.raises(AssertionError):
+        _run_single_step(
+            state_dtype=torch.float32,
+            act_dtype=torch.float32,
+            nheads=8,
+            headdim=64,
+            dstate=64,
+            ngroups=4,
+            buffer_len=16,
+            max_spec_len=4,
+            wp=5,
+            has_z=True,
+            perturb=True,
+        )
+
+
+def _run_rollback(
+    *,
+    state_dtype,
+    act_dtype,
+    nheads,
+    headdim,
+    dstate,
+    ngroups,
+    buffer_len,  # history block B
+    max_spec_len,
+    num_steps=40,
+    has_z=True,
+    seed=0,
+):
+    """Drive the verify+commit loop from an empty buffer; accept a random k each
+    step. The baseline ``selective_state_update`` decode of the accepted stream is
+    the ground truth for outputs; the committed checkpoint at each flush must match
+    the baseline state at the matching folded-token count (n_folded bookkeeping)."""
+    set_random_seed(seed)
+    H, P, N, G = nheads, headdim, dstate, ngroups
+    d_inner = H * P
+    L, buf = _lbt(buffer_len, max_spec_len)
+    both_fp32 = state_dtype == torch.float32 and act_dtype == torch.float32
+    rtol, atol = _tolerances(both_fp32)
+
+    A = _tied_A(H, P, N)
+    dt_bias = torch.rand(H, device=DEV) - 4.0
+    D = torch.randn(H, P, device=DEV)
+
+    num_blocks = 2
+    S0 = torch.randn(num_blocks, H, P, N, device=DEV, dtype=state_dtype) * 0.1
+    state_spec = S0.clone()
+    state_base = S0.clone()  # full pool; row in slot 1
+
+    cache_conv_dim = d_inner + G * N  # x|B only (no C)
+    post_conv_cache = torch.zeros(
+        num_blocks, buf, cache_conv_dim, device=DEV, dtype=act_dtype
+    )
+    dt_cache = torch.zeros(num_blocks, H, buf, device=DEV, dtype=torch.float32)
+    write_pos = torch.zeros(num_blocks, dtype=torch.int32, device=DEV)
+    post_origin = torch.zeros(num_blocks, dtype=torch.int32, device=DEV)
+    is_flush = torch.zeros(num_blocks, dtype=torch.int8, device=DEV)
+    sbi = torch.tensor([1], device=DEV, dtype=torch.int32)
+    reset_replayssm_spec_cursors(
+        write_pos,
+        post_origin,
+        is_flush,
+        torch.ones(1, dtype=torch.int8, device=DEV),
+        sbi,
+        L,
+        max_spec_len,
+    )
+
+    n_folded = 0
+    snapshots = {0: state_base[1].clone()}
+    total_accepted = 0
+    g = torch.Generator(device="cpu").manual_seed(seed + 1)
+
+    for _ in range(num_steps):
+        spec_len = max_spec_len
+        x = torch.randn(spec_len, H, P, device=DEV, dtype=act_dtype)
+        dt = torch.randn(spec_len, H, device=DEV, dtype=act_dtype)
+        Bw = torch.randn(spec_len, G, N, device=DEV, dtype=act_dtype)
+        Cw = torch.randn(spec_len, G, N, device=DEV, dtype=act_dtype)
+        zw = torch.randn(spec_len, H, P, device=DEV, dtype=act_dtype) if has_z else None
+
+        conv_out = _pack_window_conv_out(x, Bw, Cw, d_inner, G, N, act_dtype)
+        dt_spec = dt.float()
+        qsl = torch.tensor([0, spec_len], device=DEV, dtype=torch.int32)
+        out_spec = torch.empty(spec_len, H, P, device=DEV, dtype=act_dtype)
+
+        wp_before = int(write_pos[1].item())
+        flush_before = int(is_flush[1].item())
+        selective_state_update_replayssm_spec(
+            state_spec,
+            post_conv_cache,
+            dt_cache,
+            conv_out,
+            dt_spec,
+            A,
+            write_pos=write_pos,
+            post_conv_state_pos=post_origin,
+            is_flush=is_flush,
+            query_start_loc=qsl,
+            state_batch_indices=sbi,
+            max_cache_len=L,
+            max_spec_len=max_spec_len,
+            d_inner=d_inner,
+            ngroups=G,
+            dstate=N,
+            D=D,
+            z=zw,
+            dt_bias=dt_bias,
+            dt_softplus=True,
+            out=out_spec,
+        )
+        # a flush verify folds the committed history [0, wp_before) into S_0.
+        if flush_before and wp_before > 0:
+            n_folded += wp_before
+
+        k = int(torch.randint(1, spec_len + 1, (1,), generator=g).item())
+
+        base_out = []
+        for s in range(k):
+            out_t = torch.empty(1, H, P, device=DEV, dtype=act_dtype)
+            selective_state_update(
+                state_base,
+                x[s : s + 1],
+                dt[s : s + 1, :, None].expand(1, H, P),
+                A,
+                Bw[s : s + 1],
+                Cw[s : s + 1],
+                D=D,
+                z=zw[s : s + 1] if zw is not None else None,
+                dt_bias=dt_bias[:, None].expand(H, P),
+                dt_softplus=True,
+                state_batch_indices=sbi,
+                out=out_t,
+            )
+            base_out.append(out_t.clone())
+            total_accepted += 1
+            snapshots[total_accepted] = state_base[1].clone()
+        base_out = torch.cat(base_out, dim=0)
+
+        # (a) accepted-position outputs track the baseline decode.
+        torch.testing.assert_close(out_spec[:k], base_out, rtol=rtol, atol=atol)
+
+        commit_replayssm_spec(
+            write_pos,
+            post_origin,
+            is_flush,
+            torch.tensor([k], device=DEV, dtype=torch.int32),
+            sbi,
+            L,
+            max_spec_len,
+        )
+
+        # (b) committed checkpoint == baseline state at the folded-token count.
+        if n_folded in snapshots:
+            torch.testing.assert_close(
+                state_spec[1], snapshots[n_folded], rtol=rtol, atol=atol
+            )
+
+    # The buffer must have flushed at least once over 40 steps (else the state
+    # check above never ran) -- otherwise the test is vacuous.
+    assert n_folded > 0
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA device")
+@pytest.mark.parametrize("precision", _PRECISIONS)
+@pytest.mark.parametrize("base_block", _BASE_BLOCKS)
+@pytest.mark.parametrize("max_spec_len", _MAX_SPEC_LENS)
+def test_spec_rollback_tracks_baseline(precision, base_block, max_spec_len):
+    state_dtype, act_dtype = precision
+    _run_rollback(
+        state_dtype=state_dtype,
+        act_dtype=act_dtype,
+        nheads=8,
+        headdim=64,
+        dstate=64,
+        ngroups=4,
+        buffer_len=base_block,
+        max_spec_len=max_spec_len,
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA device")
+@pytest.mark.parametrize("precision", _PRECISIONS)
+@pytest.mark.parametrize("with_padding", [False, True])
+def test_spec_continuous_batching(precision, with_padding):
+    """Sparse state slots via state_batch_indices with NULL padding rows and a
+    DIFFERENT buffer fill level per row, in a single verify call. Each active
+    row is checked against its own standard-decode window oracle; padding-row
+    outputs and unused state slots are left untouched."""
+    state_dtype, act_dtype = precision
+    set_random_seed(0)
+    H, P, N, G = 4, 64, 16, 2
+    d_inner = H * P
+    conv_dim = d_inner + 2 * G * N
+    base_block = 16
+    max_spec_len = 4
+    spec_len = max_spec_len
+    L, buf = _lbt(base_block, max_spec_len)
+    both_fp32 = state_dtype == torch.float32 and act_dtype == torch.float32
+    rtol, atol = _tolerances(both_fp32)
+
+    batch = 3
+    padding = 2 if with_padding else 0
+    padded_batch = batch + padding
+    total_slots = 12
+    C = base_block - max_spec_len
+    wps = [0, C // 2, C]  # staggered non-flush fills incl. the tight edge
+
+    A = _tied_A(H, P, N)
+    dt_bias = torch.rand(H, device=DEV) - 4.0
+    D = torch.randn(H, P, device=DEV)
+
+    state_indices = (torch.randperm(total_slots - 1, device=DEV)[:batch] + 1).to(
+        torch.int32
+    )
+    sbi = torch.cat(
+        [
+            state_indices,
+            torch.full((padding,), NULL_BLOCK_ID, dtype=torch.int32, device=DEV),
+        ]
+    )
+    unused = torch.ones(total_slots, dtype=torch.bool, device=DEV)
+    unused[state_indices] = False
+
+    S0 = torch.randn(total_slots, H, P, N, device=DEV, dtype=state_dtype) * 0.1
+    state_spec = S0.clone()
+    post_conv_cache = torch.zeros(
+        total_slots, buf, d_inner + G * N, device=DEV, dtype=act_dtype
+    )
+    dt_cache = torch.zeros(total_slots, H, buf, device=DEV, dtype=torch.float32)
+    write_pos = torch.zeros(total_slots, dtype=torch.int32, device=DEV)
+    post_origin = torch.zeros(total_slots, dtype=torch.int32, device=DEV)
+    is_flush = torch.zeros(total_slots, dtype=torch.int8, device=DEV)
+
+    # per-row raw inputs (history + window); build the per-row oracle.
+    oracles = []
+    conv_out = torch.zeros(
+        padded_batch * spec_len, conv_dim, device=DEV, dtype=act_dtype
+    )
+    dt_spec = torch.zeros(padded_batch * spec_len, H, device=DEV, dtype=torch.float32)
+    z_pack = torch.zeros(padded_batch * spec_len, H, P, device=DEV, dtype=act_dtype)
+    for r in range(batch):
+        wp = wps[r]
+        slot = int(state_indices[r].item())
+        T_tot = wp + spec_len
+        x = torch.randn(T_tot, H, P, device=DEV, dtype=act_dtype)
+        dt = torch.randn(T_tot, H, device=DEV, dtype=act_dtype)
+        Bv = torch.randn(T_tot, G, N, device=DEV, dtype=act_dtype)
+        Cv = torch.randn(T_tot, G, N, device=DEV, dtype=act_dtype)
+        zv = torch.randn(T_tot, H, P, device=DEV, dtype=act_dtype)
+        oracles.append(
+            _standard_window_oracle(
+                S0_slot=S0[slot],
+                x_all=x,
+                dt_all=dt,
+                B_all=Bv,
+                C_all=Cv,
+                z_all=zv,
+                A=A,
+                D=D,
+                dt_bias=dt_bias,
+                dt_softplus=True,
+                wp=wp,
+                spec_len=spec_len,
+                buffer_len=buf,
+                act_dtype=act_dtype,
+            )
+        )
+        _scatter_packed_history(
+            post_conv_cache,
+            dt_cache,
+            slot,
+            x[:wp],
+            Bv[:wp],
+            dt[:wp],
+            d_inner,
+            G,
+            N,
+        )
+        write_pos[slot] = wp
+        seg = slice(r * spec_len, (r + 1) * spec_len)
+        conv_out[seg] = _pack_window_conv_out(
+            x[wp:], Bv[wp:], Cv[wp:], d_inner, G, N, act_dtype
+        )
+        dt_spec[seg] = dt[wp:].float()
+        z_pack[seg] = zv[wp:]
+
+    qsl = torch.arange(
+        0, (padded_batch + 1) * spec_len, spec_len, device=DEV, dtype=torch.int32
+    )
+    out_spec = torch.full(
+        (padded_batch * spec_len, H, P), 42.0, device=DEV, dtype=act_dtype
+    )
+    selective_state_update_replayssm_spec(
+        state_spec,
+        post_conv_cache,
+        dt_cache,
+        conv_out,
+        dt_spec,
+        A,
+        write_pos=write_pos,
+        post_conv_state_pos=post_origin,
+        is_flush=is_flush,
+        query_start_loc=qsl,
+        state_batch_indices=sbi,
+        max_cache_len=L,
+        max_spec_len=max_spec_len,
+        d_inner=d_inner,
+        ngroups=G,
+        dstate=N,
+        D=D,
+        z=z_pack,
+        dt_bias=dt_bias,
+        dt_softplus=True,
+        out=out_spec,
+    )
+
+    for r in range(batch):
+        seg = slice(r * spec_len, (r + 1) * spec_len)
+        torch.testing.assert_close(out_spec[seg], oracles[r], rtol=rtol, atol=atol)
+    if with_padding:
+        pad = slice(batch * spec_len, padded_batch * spec_len)
+        assert torch.equal(out_spec[pad], torch.full_like(out_spec[pad], 42.0))
+    # non-flush verify leaves every state slot untouched.
+    assert torch.equal(state_spec[unused], S0[unused])
+    torch.testing.assert_close(state_spec, S0, rtol=0, atol=0)
+
+
+_TP_SHARD_GEOMETRIES = [
+    pytest.param((32, 64, 128, 2), id="super120b_tp4"),
+    pytest.param((16, 64, 128, 1), id="super120b_tp8"),
+]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA device")
+@pytest.mark.parametrize(
+    "precision",
+    [
+        pytest.param((torch.float32, torch.float32), id="s32_a32"),
+        pytest.param((torch.float32, torch.bfloat16), id="s32_a16"),
+    ],
+)
+@pytest.mark.parametrize("geometry", _TP_SHARD_GEOMETRIES)
+def test_spec_external_bc_pre_builder_shape(precision, geometry):
+    """Multi-row verify with an externally allocated bc_pre scratch, as the
+    engine provides it (fp32, oversized batch dim sliced to the batch), at
+    the TP4/TP8 per-rank shards of Super-120B. Each row's outputs must match
+    its standard-decode oracle; the checkpoint stays untouched."""
+    state_dtype, act_dtype = precision
+    set_random_seed(0)
+    H, P, N, G = geometry
+    d_inner = H * P
+    base_block = 16
+    max_spec_len = 4
+    spec_len = max_spec_len
+    L, buf = _lbt(base_block, max_spec_len)
+    both_fp32 = state_dtype == torch.float32 and act_dtype == torch.float32
+    rtol, atol = _tolerances(both_fp32)
+
+    batch = 3
+    total_slots = 8
+    C = base_block - max_spec_len
+    wps = [C, C // 2, C]  # per-row non-flush fills incl. the tight edge
+
+    A = _tied_A(H, P, N)
+    dt_bias = torch.rand(H, device=DEV) - 4.0
+    D = torch.randn(H, P, device=DEV)
+    sbi = torch.arange(1, 1 + batch, device=DEV, dtype=torch.int32)
+
+    S0 = torch.randn(total_slots, H, P, N, device=DEV, dtype=state_dtype) * 0.1
+    state_spec = S0.clone()
+    post_conv_cache = torch.zeros(
+        total_slots, buf, d_inner + G * N, device=DEV, dtype=act_dtype
+    )
+    dt_cache = torch.zeros(total_slots, H, buf, device=DEV, dtype=torch.float32)
+    write_pos = torch.zeros(total_slots, dtype=torch.int32, device=DEV)
+    post_origin = torch.zeros(total_slots, dtype=torch.int32, device=DEV)
+    is_flush = torch.zeros(total_slots, dtype=torch.int8, device=DEV)
+
+    oracles = []
+    conv_dim = d_inner + 2 * G * N
+    conv_out = torch.zeros(batch * spec_len, conv_dim, device=DEV, dtype=act_dtype)
+    dt_spec = torch.zeros(batch * spec_len, H, device=DEV, dtype=torch.float32)
+    for r in range(batch):
+        wp = wps[r]
+        slot = int(sbi[r].item())
+        T_tot = wp + spec_len
+        x = torch.randn(T_tot, H, P, device=DEV, dtype=act_dtype)
+        dt = torch.randn(T_tot, H, device=DEV, dtype=act_dtype)
+        Bv = torch.randn(T_tot, G, N, device=DEV, dtype=act_dtype)
+        Cv = torch.randn(T_tot, G, N, device=DEV, dtype=act_dtype)
+        oracles.append(
+            _standard_window_oracle(
+                S0_slot=S0[slot],
+                x_all=x,
+                dt_all=dt,
+                B_all=Bv,
+                C_all=Cv,
+                z_all=None,
+                A=A,
+                D=D,
+                dt_bias=dt_bias,
+                dt_softplus=True,
+                wp=wp,
+                spec_len=spec_len,
+                buffer_len=buf,
+                act_dtype=act_dtype,
+            )
+        )
+        _scatter_packed_history(
+            post_conv_cache, dt_cache, slot, x[:wp], Bv[:wp], dt[:wp], d_inner, G, N
+        )
+        write_pos[slot] = wp
+        seg = slice(r * spec_len, (r + 1) * spec_len)
+        conv_out[seg] = _pack_window_conv_out(
+            x[wp:], Bv[wp:], Cv[wp:], d_inner, G, N, act_dtype
+        )
+        dt_spec[seg] = dt[wp:].float()
+
+    # Engine-style external scratch: fp32, oversized batch dim sliced to the
+    # batch, NaN-filled so an unwritten-but-read cell fails loudly.
+    block_spec = 1 << (max_spec_len - 1).bit_length()
+    scratch = torch.full(
+        (batch + 5, G, buf, block_spec),
+        float("nan"),
+        device=DEV,
+        dtype=torch.float32,
+    )
+
+    qsl = torch.arange(
+        0, (batch + 1) * spec_len, spec_len, device=DEV, dtype=torch.int32
+    )
+    out_spec = torch.empty(batch * spec_len, H, P, device=DEV, dtype=act_dtype)
+    selective_state_update_replayssm_spec(
+        state_spec,
+        post_conv_cache,
+        dt_cache,
+        conv_out,
+        dt_spec,
+        A,
+        write_pos=write_pos,
+        post_conv_state_pos=post_origin,
+        is_flush=is_flush,
+        query_start_loc=qsl,
+        state_batch_indices=sbi,
+        max_cache_len=L,
+        max_spec_len=max_spec_len,
+        d_inner=d_inner,
+        ngroups=G,
+        dstate=N,
+        D=D,
+        z=None,
+        dt_bias=dt_bias,
+        dt_softplus=True,
+        out=out_spec,
+        bc_pre=scratch[:batch],
+    )
+
+    for r in range(batch):
+        seg = slice(r * spec_len, (r + 1) * spec_len)
+        torch.testing.assert_close(out_spec[seg], oracles[r], rtol=rtol, atol=atol)
+    torch.testing.assert_close(state_spec, S0, rtol=0, atol=0)

--- a/tests/kernels/test_replayssm_spec_decode_gdn.py
+++ b/tests/kernels/test_replayssm_spec_decode_gdn.py
@@ -1,0 +1,667 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Speculative-decode correctness for the GDN (Gated DeltaNet) ReplaySSM kernel.
+
+A spec/verify step takes the checkpoint state + the committed ring buffer (the
+per-step delta-rule ``d``/``k``/``g`` caches) + a window of ``max_spec_len =
+1 + num_speculative_tokens`` draft tokens, and computes the recurrence OUTPUT at
+each window position (causal). It does NOT write the state per draft -- only a
+flush step folds the *committed* history into the checkpoint, so unaccepted
+drafts can be rolled back.
+
+The history window is ``L = B + max_spec_len`` (block ``B`` = ``buffer_len``): the
+physical circular buffer is ``next_pow2(L)`` and ``max_cache_len`` passed to the
+kernel is the logical ``L`` (the history block ``BC = next_pow2(B)`` is derived
+inside the kernel).
+
+Every case is anchored on the upstream baseline
+``fused_recurrent_gated_delta_rule_packed_decode``:
+  * build the committed history by running the spec kernel for ``wp`` draft-less
+    (T=1) steps, which fills the ring and leaves the checkpoint fixed,
+  * spec: one verify call over the window reading those very caches,
+  * oracle: the baseline stepped one token at a time from the checkpoint through
+    the history and then the window.
+The multi-step rollback case uses the same baseline over the accepted stream.
+
+Precision: the spec kernel uses a chunked UT-transform whereas the standard /
+packed kernels use the sequential recurrence, so even at fp32 they differ by
+~1e-3 (an arithmetic-ordering difference, not a bug). bf16 adds the usual rounding
+(rel ~1e-2), bounded per step and non-accumulating across the decode.
+"""
+
+import pytest
+import torch
+
+from vllm.third_party.flash_linear_attention.ops import (
+    fused_recurrent_gated_delta_rule_packed_decode,
+)
+from vllm.third_party.flash_linear_attention.ops.gdn_replayssm_spec_decode import (
+    commit_gdn_replayssm_spec,
+    gdn_replayssm_spec_decode,
+    reset_gdn_replayssm_spec_cursors,
+)
+from vllm.utils.torch_utils import set_random_seed
+
+DEV = "cuda"
+PAD_SLOT_ID = -1
+
+
+def _lbt(base_block: int, max_spec_len: int) -> tuple[int, int]:
+    """Logical flush threshold L = B + max_spec_len and physical pow2 buffer."""
+    L = base_block + max_spec_len
+    buf = 1 << (L - 1).bit_length()
+    return L, buf
+
+
+def _output_tol(both_fp32: bool) -> tuple[float, float]:
+    # Spec (chunked) vs standard/baseline (sequential): fp32 differs ~1.7e-3
+    # by arithmetic ordering; bf16 adds rounding (~1e-2). atol is a small floor.
+    if both_fp32:
+        return 5e-3, 2e-3
+    return 4e-2, 1e-2
+
+
+def _state_tol(both_fp32: bool) -> tuple[float, float]:
+    if both_fp32:
+        return 5e-3, 3e-3
+    return 4e-2, 2e-2
+
+
+def _build_history(
+    *,
+    mqkv,
+    a,
+    b,
+    A_log,
+    dt_bias,
+    scale,
+    state,
+    d_cache,
+    k_cache,
+    g_cache,
+    slot: int,
+    wp: int,
+    L: int,
+    max_spec_len: int,
+):
+    """Fill the ring with the first ``wp`` tokens as draft-less (T=1) spec steps.
+
+    wp <= B - max_spec_len, so no step flushes and the checkpoint is unchanged.
+    """
+    sbi = torch.tensor([slot], device=DEV, dtype=torch.int32)
+    qsl = torch.tensor([0, 1], device=DEV, dtype=torch.int32)
+    num_slots = state.shape[0]
+    cache_base = torch.zeros(num_slots, dtype=torch.int32, device=DEV)
+    is_flush = torch.zeros(num_slots, dtype=torch.int8, device=DEV)
+    write_pos = torch.zeros(num_slots, dtype=torch.int32, device=DEV)
+    for t in range(wp):
+        write_pos[slot] = t
+        out_t = torch.empty(1, *state.shape[1:3], device=DEV, dtype=mqkv.dtype)
+        gdn_replayssm_spec_decode(
+            mixed_qkv=mqkv[t : t + 1],
+            a=a[t : t + 1],
+            b=b[t : t + 1],
+            A_log=A_log,
+            dt_bias=dt_bias,
+            checkpoint_state=state,
+            d_cache=d_cache,
+            k_cache=k_cache,
+            g_cache=g_cache,
+            out=out_t,
+            query_start_loc=qsl,
+            ssm_state_indices=sbi,
+            write_pos=write_pos,
+            cache_base=cache_base,
+            is_flush=is_flush,
+            max_cache_len=L,
+            max_spec_len=max_spec_len,
+            scale=scale,
+            use_qk_l2norm_in_kernel=True,
+        )
+
+
+def _standard_window_oracle(
+    *,
+    mqkv,
+    a,
+    b,
+    A_log,
+    dt_bias,
+    scale,
+    state,
+    slot: int,
+    wp: int,
+    spec_len: int,
+    HV: int,
+    V: int,
+) -> torch.Tensor:
+    """Window outputs from the upstream baseline decode, one token at a time.
+
+    Runs on a clone from the checkpoint through the history and then the window,
+    so it is independent of the ring and of the kernel under test.
+    """
+    st = state.clone()
+    sbi = torch.tensor([slot], device=DEV, dtype=torch.int32)
+    win = []
+    for t in range(wp + spec_len):
+        out_t = torch.empty(1, 1, HV, V, device=DEV, dtype=mqkv.dtype)
+        fused_recurrent_gated_delta_rule_packed_decode(
+            mixed_qkv=mqkv[t : t + 1],
+            a=a[t : t + 1],
+            b=b[t : t + 1],
+            A_log=A_log,
+            dt_bias=dt_bias,
+            scale=scale,
+            initial_state=st,
+            out=out_t,
+            ssm_state_indices=sbi,
+            use_qk_l2norm_in_kernel=True,
+        )
+        if t >= wp:
+            win.append(out_t.reshape(1, HV, V).clone())
+    return torch.cat(win, dim=0)
+
+
+def _run_single_step(
+    *,
+    state_dtype,
+    act_dtype,
+    HQ,
+    HV,
+    K,
+    V,
+    buffer_len,  # history block B
+    max_spec_len,
+    wp,
+    seed=0,
+    perturb=False,
+):
+    set_random_seed(seed)
+    H = HQ
+    spec_len = max_spec_len
+    scale = K**-0.5
+    qkv_dim = 2 * H * K + HV * V
+    L, buf = _lbt(buffer_len, max_spec_len)
+    both_fp32 = state_dtype == torch.float32 and act_dtype == torch.float32
+    rtol, atol = _output_tol(both_fp32)
+
+    num_slots = 2
+    slot = 1
+    A_log = torch.randn(HV, device=DEV, dtype=torch.float32)
+    dt_bias = torch.randn(HV, device=DEV, dtype=torch.float32)
+
+    T_tot = wp + spec_len
+    mqkv = torch.randn(T_tot, qkv_dim, device=DEV, dtype=act_dtype)
+    a = torch.randn(T_tot, HV, device=DEV, dtype=act_dtype)
+    b = torch.randn(T_tot, HV, device=DEV, dtype=act_dtype)
+    S0 = torch.randn(num_slots, HV, V, K, device=DEV, dtype=state_dtype) * 0.1
+
+    d_cache = torch.zeros(num_slots, HV, buf, V, device=DEV, dtype=act_dtype)
+    k_cache = torch.zeros(num_slots, H, buf, K, device=DEV, dtype=act_dtype)
+    g_cache = torch.zeros(num_slots, HV, buf, device=DEV, dtype=torch.float32)
+
+    state = S0.clone()
+    _build_history(
+        mqkv=mqkv,
+        a=a,
+        b=b,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        scale=scale,
+        state=state,
+        d_cache=d_cache,
+        k_cache=k_cache,
+        g_cache=g_cache,
+        slot=slot,
+        wp=wp,
+        L=L,
+        max_spec_len=max_spec_len,
+    )
+    # history build must not have touched the checkpoint (no flush).
+    torch.testing.assert_close(state, S0, rtol=0, atol=0)
+
+    oracle = _standard_window_oracle(
+        mqkv=mqkv,
+        a=a,
+        b=b,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        scale=scale,
+        state=state,
+        slot=slot,
+        wp=wp,
+        spec_len=spec_len,
+        HV=HV,
+        V=V,
+    )
+
+    if perturb:
+        # teeth: corrupt one cached history key -> outputs must diverge.
+        k_cache[slot, 0, max(0, wp - 1), 0] += 5.0
+
+    state_spec = state.clone()
+    write_pos = torch.zeros(num_slots, dtype=torch.int32, device=DEV)
+    write_pos[slot] = wp
+    cache_base = torch.zeros(num_slots, dtype=torch.int32, device=DEV)
+    is_flush = torch.zeros(num_slots, dtype=torch.int8, device=DEV)
+    qsl = torch.tensor([0, spec_len], device=DEV, dtype=torch.int32)
+    sbi = torch.tensor([slot], device=DEV, dtype=torch.int32)
+    out_spec = torch.empty(spec_len, HV, V, device=DEV, dtype=act_dtype)
+    gdn_replayssm_spec_decode(
+        mixed_qkv=mqkv[wp:],
+        a=a[wp:],
+        b=b[wp:],
+        A_log=A_log,
+        dt_bias=dt_bias,
+        checkpoint_state=state_spec,
+        d_cache=d_cache,
+        k_cache=k_cache,
+        g_cache=g_cache,
+        out=out_spec,
+        query_start_loc=qsl,
+        ssm_state_indices=sbi,
+        write_pos=write_pos,
+        cache_base=cache_base,
+        is_flush=is_flush,
+        max_cache_len=L,
+        max_spec_len=max_spec_len,
+        scale=scale,
+        use_qk_l2norm_in_kernel=True,
+    )
+
+    torch.testing.assert_close(out_spec, oracle, rtol=rtol, atol=atol)
+    # non-flush verify must not touch the checkpoint.
+    torch.testing.assert_close(state_spec, S0, rtol=0, atol=0)
+
+
+def _wp_set(base_block: int, max_spec_len: int) -> list[int]:
+    # Verify-path fills up to the max non-flush fill C = B - max_spec_len.
+    C = base_block - max_spec_len
+    return sorted({0, max(0, C // 2), max(0, C)})
+
+
+_PRECISIONS = [
+    pytest.param((torch.float32, torch.float32), id="s32_a32"),
+    pytest.param((torch.float32, torch.bfloat16), id="s32_a16"),
+    pytest.param((torch.bfloat16, torch.bfloat16), id="s16_a16"),
+]
+# (num_q_heads, num_v_heads, head_k_dim, head_v_dim). The full sweep runs on the
+# small shape; the production Qwen3.5 GDN shapes are exercised by
+# test_spec_step_real_geometry.
+_SMALL = pytest.param((2, 4, 64, 64), id="small")
+_REAL_GEOMETRIES = [
+    pytest.param((16, 32, 128, 128), id="qwen4b"),
+    pytest.param((16, 64, 128, 128), id="qwen122b"),
+]
+_BASE_BLOCKS = [16, 32]  # history block B (replayssm_buffer_len)
+_MAX_SPEC_LENS = [2, 4, 6, 8]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA device")
+@pytest.mark.parametrize("precision", _PRECISIONS)
+@pytest.mark.parametrize("geometry", [_SMALL])
+@pytest.mark.parametrize("base_block", _BASE_BLOCKS)
+@pytest.mark.parametrize("max_spec_len", _MAX_SPEC_LENS)
+def test_spec_step_matches_standard_decode(
+    precision, geometry, base_block, max_spec_len
+):
+    state_dtype, act_dtype = precision
+    HQ, HV, K, V = geometry
+    for wp in _wp_set(base_block, max_spec_len):
+        _run_single_step(
+            state_dtype=state_dtype,
+            act_dtype=act_dtype,
+            HQ=HQ,
+            HV=HV,
+            K=K,
+            V=V,
+            buffer_len=base_block,
+            max_spec_len=max_spec_len,
+            wp=wp,
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA device")
+@pytest.mark.parametrize("precision", _PRECISIONS)
+@pytest.mark.parametrize("geometry", _REAL_GEOMETRIES)
+@pytest.mark.parametrize("max_spec_len", [2, 8])
+def test_spec_step_real_geometry(precision, geometry, max_spec_len):
+    # Production Qwen3.5 GDN shapes (4B v_heads=32 / 122B-A10B v_heads=64) at the
+    # deployable block B=16, both ends of the max_spec_len range.
+    state_dtype, act_dtype = precision
+    HQ, HV, K, V = geometry
+    for wp in _wp_set(16, max_spec_len):
+        _run_single_step(
+            state_dtype=state_dtype,
+            act_dtype=act_dtype,
+            HQ=HQ,
+            HV=HV,
+            K=K,
+            V=V,
+            buffer_len=16,
+            max_spec_len=max_spec_len,
+            wp=wp,
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA device")
+def test_spec_step_teeth():
+    _run_single_step(
+        state_dtype=torch.float32,
+        act_dtype=torch.float32,
+        HQ=2,
+        HV=4,
+        K=64,
+        V=64,
+        buffer_len=16,
+        max_spec_len=4,
+        wp=5,
+    )
+    with pytest.raises(AssertionError):
+        _run_single_step(
+            state_dtype=torch.float32,
+            act_dtype=torch.float32,
+            HQ=2,
+            HV=4,
+            K=64,
+            V=64,
+            buffer_len=16,
+            max_spec_len=4,
+            wp=5,
+            perturb=True,
+        )
+
+
+def _run_rollback(
+    *,
+    state_dtype,
+    act_dtype,
+    HQ,
+    HV,
+    K,
+    V,
+    buffer_len,  # history block B
+    max_spec_len,
+    num_steps=40,
+    seed=0,
+):
+    """Drive the verify+commit loop from an empty buffer; accept a random k each
+    step. Baseline packed decode of the accepted stream is the output ground
+    truth; the committed checkpoint at each flush must match the baseline state at
+    the matching folded-token count (n_folded bookkeeping)."""
+    set_random_seed(seed)
+    H = HQ
+    scale = K**-0.5
+    qkv_dim = 2 * H * K + HV * V
+    L, buf = _lbt(buffer_len, max_spec_len)
+    both_fp32 = state_dtype == torch.float32 and act_dtype == torch.float32
+    o_rtol, o_atol = _output_tol(both_fp32)
+    s_rtol, s_atol = _state_tol(both_fp32)
+
+    num_slots = 2
+    slot = 1
+    A_log = torch.randn(HV, device=DEV, dtype=torch.float32)
+    dt_bias = torch.randn(HV, device=DEV, dtype=torch.float32)
+    S0 = torch.randn(num_slots, HV, V, K, device=DEV, dtype=state_dtype) * 0.1
+    state_spec = S0.clone()
+    state_base = S0.clone()  # full pool; row in slot 1
+
+    d_cache = torch.zeros(num_slots, HV, buf, V, device=DEV, dtype=act_dtype)
+    k_cache = torch.zeros(num_slots, H, buf, K, device=DEV, dtype=act_dtype)
+    g_cache = torch.zeros(num_slots, HV, buf, device=DEV, dtype=torch.float32)
+
+    write_pos = torch.zeros(num_slots, dtype=torch.int32, device=DEV)
+    cache_base = torch.zeros(num_slots, dtype=torch.int32, device=DEV)
+    is_flush = torch.zeros(num_slots, dtype=torch.int8, device=DEV)
+    sbi = torch.tensor([slot], device=DEV, dtype=torch.int32)
+    reset_gdn_replayssm_spec_cursors(
+        write_pos,
+        cache_base,
+        is_flush,
+        torch.ones(1, dtype=torch.int32, device=DEV),
+        sbi,
+        L,
+        max_spec_len,
+    )
+
+    n_folded = 0
+    snapshots = {0: state_base[slot].clone()}
+    total_accepted = 0
+    g = torch.Generator(device="cpu").manual_seed(seed + 1)
+
+    for _ in range(num_steps):
+        spec_len = max_spec_len
+        mqkv = torch.randn(spec_len, qkv_dim, device=DEV, dtype=act_dtype)
+        a = torch.randn(spec_len, HV, device=DEV, dtype=act_dtype)
+        b = torch.randn(spec_len, HV, device=DEV, dtype=act_dtype)
+        qsl = torch.tensor([0, spec_len], device=DEV, dtype=torch.int32)
+        out_spec = torch.empty(spec_len, HV, V, device=DEV, dtype=act_dtype)
+
+        wp_before = int(write_pos[slot].item())
+        flush_before = int(is_flush[slot].item())
+        gdn_replayssm_spec_decode(
+            mixed_qkv=mqkv,
+            a=a,
+            b=b,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            checkpoint_state=state_spec,
+            d_cache=d_cache,
+            k_cache=k_cache,
+            g_cache=g_cache,
+            out=out_spec,
+            query_start_loc=qsl,
+            ssm_state_indices=sbi,
+            write_pos=write_pos,
+            cache_base=cache_base,
+            is_flush=is_flush,
+            max_cache_len=L,
+            max_spec_len=max_spec_len,
+            scale=scale,
+            use_qk_l2norm_in_kernel=True,
+        )
+        if flush_before and wp_before > 0:
+            n_folded += wp_before
+
+        k = int(torch.randint(1, spec_len + 1, (1,), generator=g).item())
+        base_out = []
+        for s in range(k):
+            out_t = torch.empty(1, 1, HV, V, device=DEV, dtype=act_dtype)
+            fused_recurrent_gated_delta_rule_packed_decode(
+                mixed_qkv=mqkv[s : s + 1],
+                a=a[s : s + 1],
+                b=b[s : s + 1],
+                A_log=A_log,
+                dt_bias=dt_bias,
+                scale=scale,
+                initial_state=state_base,
+                out=out_t,
+                ssm_state_indices=sbi,
+                use_qk_l2norm_in_kernel=True,
+            )
+            base_out.append(out_t.reshape(1, HV, V).clone())
+            total_accepted += 1
+            snapshots[total_accepted] = state_base[slot].clone()
+        base_out = torch.cat(base_out, dim=0)
+
+        # (a) accepted-position outputs track the baseline decode.
+        torch.testing.assert_close(out_spec[:k], base_out, rtol=o_rtol, atol=o_atol)
+
+        commit_gdn_replayssm_spec(
+            write_pos,
+            cache_base,
+            is_flush,
+            torch.tensor([k], device=DEV, dtype=torch.int32),
+            sbi,
+            L,
+            max_spec_len,
+        )
+
+        # (b) committed checkpoint == baseline state at the folded-token count.
+        if n_folded in snapshots:
+            torch.testing.assert_close(
+                state_spec[slot], snapshots[n_folded], rtol=s_rtol, atol=s_atol
+            )
+
+    assert n_folded > 0
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA device")
+@pytest.mark.parametrize("precision", _PRECISIONS)
+@pytest.mark.parametrize("base_block", _BASE_BLOCKS)
+@pytest.mark.parametrize("max_spec_len", _MAX_SPEC_LENS)
+def test_spec_rollback_tracks_baseline(precision, base_block, max_spec_len):
+    state_dtype, act_dtype = precision
+    _run_rollback(
+        state_dtype=state_dtype,
+        act_dtype=act_dtype,
+        HQ=2,
+        HV=4,
+        K=64,
+        V=64,
+        buffer_len=base_block,
+        max_spec_len=max_spec_len,
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA device")
+@pytest.mark.parametrize("precision", _PRECISIONS)
+@pytest.mark.parametrize("with_padding", [False, True])
+def test_spec_continuous_batching(precision, with_padding):
+    """Sparse state slots via ssm_state_indices with PAD(-1) padding rows and a
+    DIFFERENT buffer fill per row, in one verify call. Each active row is checked
+    against its own standard-decode window oracle; padding rows are zeroed and
+    unused state slots are left untouched."""
+    state_dtype, act_dtype = precision
+    set_random_seed(0)
+    HQ, HV, K, V = 2, 4, 64, 64
+    H = HQ
+    scale = K**-0.5
+    qkv_dim = 2 * H * K + HV * V
+    base_block = 16
+    max_spec_len = 4
+    spec_len = max_spec_len
+    L, buf = _lbt(base_block, max_spec_len)
+    both_fp32 = state_dtype == torch.float32 and act_dtype == torch.float32
+    rtol, atol = _output_tol(both_fp32)
+
+    batch = 3
+    padding = 2 if with_padding else 0
+    padded_batch = batch + padding
+    total_slots = 12
+    C = base_block - max_spec_len
+    wps = [0, C // 2, C]
+
+    A_log = torch.randn(HV, device=DEV, dtype=torch.float32)
+    dt_bias = torch.randn(HV, device=DEV, dtype=torch.float32)
+    state_indices = (torch.randperm(total_slots - 1, device=DEV)[:batch] + 1).to(
+        torch.int32
+    )
+    sbi = torch.cat(
+        [
+            state_indices,
+            torch.full((padding,), PAD_SLOT_ID, dtype=torch.int32, device=DEV),
+        ]
+    )
+    unused = torch.ones(total_slots, dtype=torch.bool, device=DEV)
+    unused[state_indices] = False
+
+    S0 = torch.randn(total_slots, HV, V, K, device=DEV, dtype=state_dtype) * 0.1
+    state_spec = S0.clone()
+    d_cache = torch.zeros(total_slots, HV, buf, V, device=DEV, dtype=act_dtype)
+    k_cache = torch.zeros(total_slots, H, buf, K, device=DEV, dtype=act_dtype)
+    g_cache = torch.zeros(total_slots, HV, buf, device=DEV, dtype=torch.float32)
+
+    write_pos = torch.zeros(total_slots, dtype=torch.int32, device=DEV)
+    cache_base = torch.zeros(total_slots, dtype=torch.int32, device=DEV)
+    is_flush = torch.zeros(total_slots, dtype=torch.int8, device=DEV)
+
+    oracles = []
+    mqkv_pack = torch.zeros(
+        padded_batch * spec_len, qkv_dim, device=DEV, dtype=act_dtype
+    )
+    a_pack = torch.zeros(padded_batch * spec_len, HV, device=DEV, dtype=act_dtype)
+    b_pack = torch.zeros(padded_batch * spec_len, HV, device=DEV, dtype=act_dtype)
+    for r in range(batch):
+        wp = wps[r]
+        slot = int(state_indices[r].item())
+        T_tot = wp + spec_len
+        mqkv = torch.randn(T_tot, qkv_dim, device=DEV, dtype=act_dtype)
+        a = torch.randn(T_tot, HV, device=DEV, dtype=act_dtype)
+        b = torch.randn(T_tot, HV, device=DEV, dtype=act_dtype)
+        _build_history(
+            mqkv=mqkv,
+            a=a,
+            b=b,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            scale=scale,
+            state=state_spec,
+            d_cache=d_cache,
+            k_cache=k_cache,
+            g_cache=g_cache,
+            slot=slot,
+            wp=wp,
+            L=L,
+            max_spec_len=max_spec_len,
+        )
+        oracles.append(
+            _standard_window_oracle(
+                mqkv=mqkv,
+                a=a,
+                b=b,
+                A_log=A_log,
+                dt_bias=dt_bias,
+                scale=scale,
+                state=state_spec,
+                slot=slot,
+                wp=wp,
+                spec_len=spec_len,
+                HV=HV,
+                V=V,
+            )
+        )
+        write_pos[slot] = wp
+        seg = slice(r * spec_len, (r + 1) * spec_len)
+        mqkv_pack[seg] = mqkv[wp:]
+        a_pack[seg] = a[wp:]
+        b_pack[seg] = b[wp:]
+
+    state_before = state_spec.clone()
+    qsl = torch.arange(
+        0, (padded_batch + 1) * spec_len, spec_len, device=DEV, dtype=torch.int32
+    )
+    out_spec = torch.full(
+        (padded_batch * spec_len, HV, V), 42.0, device=DEV, dtype=act_dtype
+    )
+    gdn_replayssm_spec_decode(
+        mixed_qkv=mqkv_pack,
+        a=a_pack,
+        b=b_pack,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        checkpoint_state=state_spec,
+        d_cache=d_cache,
+        k_cache=k_cache,
+        g_cache=g_cache,
+        out=out_spec,
+        query_start_loc=qsl,
+        ssm_state_indices=sbi,
+        write_pos=write_pos,
+        cache_base=cache_base,
+        is_flush=is_flush,
+        max_cache_len=L,
+        max_spec_len=max_spec_len,
+        scale=scale,
+        use_qk_l2norm_in_kernel=True,
+    )
+
+    for r in range(batch):
+        seg = slice(r * spec_len, (r + 1) * spec_len)
+        torch.testing.assert_close(out_spec[seg], oracles[r], rtol=rtol, atol=atol)
+    if with_padding:
+        pad = slice(batch * spec_len, padded_batch * spec_len)
+        assert torch.equal(out_spec[pad], torch.zeros_like(out_spec[pad]))
+    # non-flush verify leaves every state slot untouched.
+    torch.testing.assert_close(state_spec, state_before, rtol=0, atol=0)
+    assert torch.equal(state_spec[unused], S0[unused])

--- a/tests/v1/attention/test_gdn_spec_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_spec_metadata_builder.py
@@ -1,0 +1,324 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""ReplaySSM speculative-decode ring cursors in GDNAttentionMetadataBuilder.
+
+The cursors are block-keyed and advanced on-device by commit_gdn_replayssm_spec,
+so these tests drive builder.build() and read the resulting buffers back. Each
+case builds one CommonAttentionMetadata and reuses it, because
+create_common_attn_metadata draws fresh block ids on every call.
+"""
+
+import pytest
+import torch
+
+from tests.v1.attention.utils import (
+    BatchSpec,
+    create_common_attn_metadata,
+    create_vllm_config,
+)
+from vllm.config import SpeculativeConfig
+from vllm.config.compilation import CUDAGraphMode
+from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
+from vllm.v1.kv_cache_interface import MambaSpec
+
+BLOCK_SIZE = 16
+NUM_SPEC = 3
+MAX_SPEC_LEN = 1 + NUM_SPEC
+BUFFER_LEN = 8
+FLUSH_THRESHOLD = BUFFER_LEN + MAX_SPEC_LEN
+RING_LEN = 16
+DEVICE = torch.device("cuda")
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="ReplaySSM spec cursors are Triton kernels"
+)
+
+
+def _create_spec_builder(
+    buffer_len: int = BUFFER_LEN,
+    full_cuda_graph: bool = False,
+) -> GDNAttentionMetadataBuilder:
+    vllm_config = create_vllm_config(
+        model_name="Qwen/Qwen3.5-0.8B",
+        block_size=BLOCK_SIZE,
+        num_gpu_blocks=1024,
+    )
+    vllm_config.speculative_config = SpeculativeConfig(
+        method="ngram", num_speculative_tokens=NUM_SPEC
+    )
+    if full_cuda_graph:
+        vllm_config.compilation_config.cudagraph_mode = CUDAGraphMode.FULL_AND_PIECEWISE
+    # Set after construction so validate_mamba_cached_spec_kernel (Triton only)
+    # does not run against the mock model.
+    vllm_config.cache_config.use_replayssm_spec = True
+    vllm_config.cache_config.replayssm_buffer_len = buffer_len
+    mamba_spec = MambaSpec(
+        block_size=BLOCK_SIZE,
+        shapes=((16, 64),),
+        dtypes=(torch.float16,),
+    )
+    return GDNAttentionMetadataBuilder(
+        kv_cache_spec=mamba_spec,
+        layer_names=["layer.0"],
+        vllm_config=vllm_config,
+        device=DEVICE,
+    )
+
+
+def _make_common(seq_lens: list[int], decode_base: list[int], query_lens: list[int]):
+    batch = BatchSpec(seq_lens=seq_lens, query_lens=query_lens)
+    return create_common_attn_metadata(batch, BLOCK_SIZE, DEVICE).replace(
+        is_prefilling=torch.tensor([False] * len(seq_lens), dtype=torch.bool),
+        replayssm_decode_base_cpu=torch.tensor(decode_base, dtype=torch.int32),
+    )
+
+
+def _build(builder, common, num_accepted: list[int]):
+    n = len(num_accepted)
+    return builder.build(
+        common_prefix_len=0,
+        common_attn_metadata=common,
+        num_accepted_tokens=torch.tensor(
+            num_accepted, dtype=torch.int32, device=DEVICE
+        ),
+        num_decode_draft_tokens_cpu=torch.full((n,), NUM_SPEC, dtype=torch.int32),
+    )
+
+
+def _cursors(builder, blocks: list[int]):
+    idx = torch.tensor(blocks, device=DEVICE)
+    return (
+        builder.spec_write_pos[idx].tolist(),
+        builder.spec_cache_base[idx].tolist(),
+        builder.spec_is_flush[idx].tolist(),
+    )
+
+
+def _seed(builder, blocks: list[int], write_pos: int, is_flush: int):
+    for block in blocks:
+        builder.spec_write_pos[block] = write_pos
+        builder.spec_cache_base[block] = 0
+        builder.spec_is_flush[block] = is_flush
+
+
+def _prime(builder, common) -> list[int]:
+    """Allocate the cursor buffers and return this batch's physical block ids."""
+    meta = _build(builder, common, [1] * common.num_reqs)
+    return meta.spec_state_indices_tensor[: common.num_reqs, 0].tolist()
+
+
+def _spec_window(n: int = 1):
+    return [MAX_SPEC_LEN] * n
+
+
+def test_commit_advances_write_pos_by_accepted():
+    builder = _create_spec_builder()
+    # num_computed = 120 - 4 = 116 > decode_base, so no reset fires.
+    common = _make_common([120], [100], _spec_window())
+    blocks = _prime(builder, common)
+    _seed(builder, blocks, write_pos=2, is_flush=0)
+
+    _build(builder, common, [3])
+
+    write_pos, cache_base, _ = _cursors(builder, blocks)
+    assert write_pos == [5]
+    assert cache_base == [0]
+
+
+def test_rejected_drafts_are_not_committed():
+    """Rollback: only accepted tokens advance the cursor, the rest are dropped."""
+    builder = _create_spec_builder()
+    common = _make_common([120], [100], _spec_window())
+    blocks = _prime(builder, common)
+    _seed(builder, blocks, write_pos=2, is_flush=0)
+
+    _build(builder, common, [1])
+
+    assert _cursors(builder, blocks)[0] == [3]
+
+
+def test_flush_advances_base_and_restarts_write_pos():
+    builder = _create_spec_builder()
+    common = _make_common([120], [100], _spec_window())
+    blocks = _prime(builder, common)
+    _seed(builder, blocks, write_pos=5, is_flush=1)
+
+    _build(builder, common, [2])
+
+    write_pos, cache_base, _ = _cursors(builder, blocks)
+    # The flush consumed the 5 committed history tokens, so the ring restarts
+    # past them and only the freshly accepted tokens remain.
+    assert cache_base == [5]
+    assert write_pos == [2]
+
+
+def test_early_flush_keeps_room_for_a_full_window():
+    """is_flush is set one window early: write_pos + 2 * max_spec_len > L."""
+    builder = _create_spec_builder()
+    common = _make_common([120], [100], _spec_window())
+    blocks = _prime(builder, common)
+
+    # write_pos 3 -> +1 = 4; 4 + 8 = 12 is not > 12, so no flush yet.
+    _seed(builder, blocks, write_pos=3, is_flush=0)
+    _build(builder, common, [1])
+    assert _cursors(builder, blocks)[2] == [0]
+
+    # write_pos 4 -> +1 = 5; 5 + 8 = 13 > 12, so the next step must flush.
+    _seed(builder, blocks, write_pos=4, is_flush=0)
+    _build(builder, common, [1])
+    assert _cursors(builder, blocks)[2] == [1]
+
+
+def test_first_decode_resets_a_recycled_block():
+    builder = _create_spec_builder()
+    # num_computed == decode_base marks the request's first verify step.
+    common = _make_common([104], [100], _spec_window())
+    blocks = _prime(builder, common)
+    # Stale cursors left behind by whoever held this block before.
+    _seed(builder, blocks, write_pos=6, is_flush=1)
+
+    _build(builder, common, [1])
+
+    assert _cursors(builder, blocks) == ([0], [0], [0])
+
+
+def test_resumed_request_reanchors_on_decode_base():
+    """Preemption: decode_base moves to the resume point, which re-fires the
+    reset so the recomputed request does not inherit its old cursors."""
+    builder = _create_spec_builder()
+    common = _make_common([120], [116], _spec_window())
+    blocks = _prime(builder, common)
+    _seed(builder, blocks, write_pos=7, is_flush=1)
+
+    _build(builder, common, [1])
+
+    write_pos, cache_base, _ = _cursors(builder, blocks)
+    assert (write_pos, cache_base) == ([0], [0])
+
+
+def test_steady_state_row_is_not_reset():
+    builder = _create_spec_builder()
+    common = _make_common([120], [100], _spec_window())
+    blocks = _prime(builder, common)
+    _seed(builder, blocks, write_pos=2, is_flush=0)
+
+    _build(builder, common, [1])
+
+    assert _cursors(builder, blocks)[0] == [3]
+
+
+def test_mixed_batch_resets_only_the_entering_rows():
+    builder = _create_spec_builder()
+    # Row 0 steady state, row 1 first decode, row 2 steady state.
+    common = _make_common([120, 104, 124], [100, 100, 100], _spec_window(3))
+    blocks = _prime(builder, common)
+    _seed(builder, blocks, write_pos=4, is_flush=0)
+
+    _build(builder, common, [2, 2, 2])
+
+    assert _cursors(builder, blocks)[0] == [6, 0, 6]
+
+
+def test_draft_less_rows_route_through_the_spec_kernel():
+    """A row with no drafts is a T=1 window, not a baseline decode. Routing it
+    to the baseline path would read a checkpoint the ring has moved past."""
+    builder = _create_spec_builder()
+    common = _make_common([120, 120], [100, 100], query_lens=[1, 1])
+    meta = builder.build(
+        common_prefix_len=0,
+        common_attn_metadata=common,
+        num_accepted_tokens=torch.tensor([1, 1], dtype=torch.int32, device=DEVICE),
+        # Stale on draft-less steps, so it must not drive the routing mask.
+        num_decode_draft_tokens_cpu=torch.tensor([-1, -1], dtype=torch.int32),
+    )
+
+    assert meta.num_spec_decodes == 2
+    assert meta.num_decodes == 0
+    assert meta.spec_write_pos_d is not None
+
+
+def test_prefilling_rows_stay_on_the_prefill_path():
+    """A still-prefilling chunk is excluded from the spec mask. It cannot reach
+    a captured decode graph either: _is_uniform_decode needs every row to be
+    exactly 1 + num_spec tokens wide, which a 1-token chunk breaks."""
+    builder = _create_spec_builder()
+    batch = BatchSpec(seq_lens=[120, 100], query_lens=[MAX_SPEC_LEN, 1])
+    common = create_common_attn_metadata(batch, BLOCK_SIZE, DEVICE).replace(
+        is_prefilling=torch.tensor([False, True], dtype=torch.bool),
+        replayssm_decode_base_cpu=torch.tensor([100, 100], dtype=torch.int32),
+    )
+    meta = builder.build(
+        common_prefix_len=0,
+        common_attn_metadata=common,
+        num_accepted_tokens=torch.tensor([1, 1], dtype=torch.int32, device=DEVICE),
+        num_decode_draft_tokens_cpu=torch.tensor([NUM_SPEC, -1], dtype=torch.int32),
+    )
+
+    assert meta.num_spec_decodes == 1
+    assert meta.num_prefills == 1
+
+
+def test_ring_geometry_matches_the_page():
+    builder = _create_spec_builder()
+
+    assert builder.max_spec_len == MAX_SPEC_LEN
+    assert builder.spec_flush_threshold == FLUSH_THRESHOLD
+    assert builder.spec_ring_len == RING_LEN
+
+
+def test_cursors_are_the_persistent_block_keyed_buffers():
+    builder = _create_spec_builder(full_cuda_graph=True)
+    common = _make_common([120, 120], [100, 100], _spec_window(2))
+    meta = _build(builder, common, [1, 1])
+
+    # Block-keyed and full-length, so a captured graph replays against a fixed
+    # address rather than a per-step slice.
+    assert meta.spec_write_pos_d.data_ptr() == builder.spec_write_pos.data_ptr()
+    assert meta.spec_cache_base_d.data_ptr() == builder.spec_cache_base.data_ptr()
+    assert meta.spec_is_flush_d.data_ptr() == builder.spec_is_flush.data_ptr()
+    assert meta.spec_write_pos_d.shape[0] == 1024
+
+
+def test_layer_and_config_pages_agree():
+    """The layer sizes its kv_cache from get_state_shape/get_state_dtype while
+    the engine sizes the page from the config classmethods. If the two disagree
+    the page silently truncates, because abstract.py zips shapes with dtypes.
+    """
+    from vllm.model_executor.layers.mamba.mamba_utils import (
+        MambaStateDtypeCalculator,
+        MambaStateShapeCalculator,
+    )
+
+    vllm_config = create_vllm_config(model_name="Qwen/Qwen3.5-0.8B")
+    vllm_config.cache_config.use_replayssm_spec = True
+    vllm_config.cache_config.replayssm_buffer_len = BUFFER_LEN
+    hf = vllm_config.model_config.hf_text_config
+
+    base_shape = MambaStateShapeCalculator.gated_delta_net_state_shape(
+        1,
+        hf.linear_num_key_heads,
+        hf.linear_num_value_heads,
+        hf.linear_key_head_dim,
+        hf.linear_value_head_dim,
+        hf.linear_conv_kernel_dim,
+        NUM_SPEC,
+    )
+    shapes = MambaStateShapeCalculator.append_gated_delta_net_replayssm_spec_ring(
+        base_shape,
+        hf.linear_num_key_heads,
+        hf.linear_num_value_heads,
+        hf.linear_key_head_dim,
+        hf.linear_value_head_dim,
+        1,
+        BUFFER_LEN,
+        NUM_SPEC,
+    )
+    base_dtype = MambaStateDtypeCalculator.gated_delta_net_state_dtype(
+        vllm_config.model_config.dtype, "auto", "auto"
+    )
+    dtypes = MambaStateDtypeCalculator.append_gated_delta_net_replayssm_spec_ring(
+        base_dtype, vllm_config.model_config.dtype
+    )
+
+    assert len(shapes) == 5
+    assert len(shapes) == len(dtypes)

--- a/tests/v1/attention/test_mamba_update_block_table.py
+++ b/tests/v1/attention/test_mamba_update_block_table.py
@@ -43,6 +43,7 @@ def _make_vllm_config(
             block_size=block_size,
             mamba_cache_mode="all",
             use_replayssm=False,
+            use_replayssm_spec=False,
             replayssm_buffer_len=16,
         ),
         compilation_config=SimpleNamespace(

--- a/tests/v1/attention/test_replayssm_spec_metadata_builder.py
+++ b/tests/v1/attention/test_replayssm_spec_metadata_builder.py
@@ -1,0 +1,320 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""ReplaySSM speculative-decode ring cursors in BaseMambaAttentionMetadataBuilder.
+
+The cursors are block-keyed and advanced on-device by commit_replayssm_spec, so
+these tests drive builder.build() and read the resulting buffers back. Each case
+builds one CommonAttentionMetadata and reuses it, because
+create_common_attn_metadata draws fresh block ids on every call.
+"""
+
+import pytest
+import torch
+
+from tests.v1.attention.utils import (
+    BatchSpec,
+    MockMambaBuilder,
+    create_common_attn_metadata,
+    create_vllm_config,
+)
+from vllm.config import SpeculativeConfig
+from vllm.config.compilation import CUDAGraphMode
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
+from vllm.v1.kv_cache_interface import MambaSpec
+
+BLOCK_SIZE = 16
+NUM_SPEC = 3
+MAX_SPEC_LEN = 1 + NUM_SPEC
+BUFFER_LEN = 8
+# L = B + max_spec_len; physical ring is next_pow2(B + num_spec).
+FLUSH_THRESHOLD = BUFFER_LEN + MAX_SPEC_LEN
+RING_LEN = 16
+
+NHEADS, HEAD_DIM, DSTATE, NGROUPS = 2, 4, 8, 1
+CONV_DIM = NHEADS * HEAD_DIM + NGROUPS * DSTATE
+DEVICE = torch.device("cuda")
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="ReplaySSM spec cursors are Triton kernels"
+)
+
+
+def _make_spec_mamba_spec() -> MambaSpec:
+    # Four-tensor spec page: (conv, ssm, post_conv_cache, dt_cache).
+    return MambaSpec(
+        block_size=BLOCK_SIZE,
+        shapes=(
+            (CONV_DIM, 3),
+            (NHEADS, HEAD_DIM, DSTATE),
+            (RING_LEN, CONV_DIM),
+            (NHEADS, RING_LEN),
+        ),
+        dtypes=(torch.float32,),
+    )
+
+
+def _create_spec_builder(
+    buffer_len: int = BUFFER_LEN,
+    full_cuda_graph: bool = False,
+) -> MockMambaBuilder:
+    vllm_config = create_vllm_config(
+        model_name="Qwen/Qwen3.5-0.8B",
+        block_size=BLOCK_SIZE,
+        num_gpu_blocks=1024,
+    )
+    vllm_config.speculative_config = SpeculativeConfig(
+        method="ngram", num_speculative_tokens=NUM_SPEC
+    )
+    if full_cuda_graph:
+        vllm_config.compilation_config.cudagraph_mode = CUDAGraphMode.FULL_AND_PIECEWISE
+    # Set after construction so validate_mamba_cached_spec_kernel (Triton only)
+    # does not run against the mock model.
+    vllm_config.cache_config.use_replayssm_spec = True
+    vllm_config.cache_config.replayssm_buffer_len = buffer_len
+    return MockMambaBuilder(_make_spec_mamba_spec(), ["layer0"], vllm_config, DEVICE)
+
+
+def _make_common(
+    seq_lens: list[int],
+    decode_base: list[int],
+    query_lens: list[int] | None = None,
+):
+    n = len(seq_lens)
+    query_lens = query_lens if query_lens is not None else [MAX_SPEC_LEN] * n
+    batch = BatchSpec(seq_lens=seq_lens, query_lens=query_lens)
+    return create_common_attn_metadata(batch, BLOCK_SIZE, DEVICE).replace(
+        is_prefilling=torch.tensor([False] * n, dtype=torch.bool),
+        replayssm_decode_base_cpu=torch.tensor(decode_base, dtype=torch.int32),
+    )
+
+
+def _build(builder: MockMambaBuilder, common, num_accepted: list[int]):
+    return builder.build(
+        0,
+        common,
+        num_accepted_tokens=torch.tensor(
+            num_accepted, dtype=torch.int32, device=DEVICE
+        ),
+    )
+
+
+def _cursors(builder: MockMambaBuilder, blocks: list[int]):
+    idx = torch.tensor(blocks, device=DEVICE)
+    return (
+        builder.spec_write_pos[idx].tolist(),
+        builder.spec_post_origin[idx].tolist(),
+        builder.spec_is_flush[idx].tolist(),
+    )
+
+
+def _seed(builder: MockMambaBuilder, blocks: list[int], write_pos: int, is_flush: int):
+    for block in blocks:
+        builder.spec_write_pos[block] = write_pos
+        builder.spec_post_origin[block] = 0
+        builder.spec_is_flush[block] = is_flush
+
+
+def _prime(builder: MockMambaBuilder, common) -> list[int]:
+    """Allocate the cursor buffers and return this batch's physical block ids."""
+    meta = _build(builder, common, [1] * common.num_reqs)
+    return meta.state_indices_tensor_d[:, 0].tolist()
+
+
+def test_commit_advances_write_pos_by_accepted():
+    builder = _create_spec_builder()
+    # num_computed = 120 - 4 = 116 > decode_base, so no reset fires.
+    common = _make_common([120], [100])
+    blocks = _prime(builder, common)
+    _seed(builder, blocks, write_pos=2, is_flush=0)
+
+    _build(builder, common, [3])
+
+    write_pos, post_origin, _ = _cursors(builder, blocks)
+    assert write_pos == [5]
+    assert post_origin == [0]
+
+
+def test_rejected_drafts_are_not_committed():
+    """Rollback: only accepted tokens advance the cursor, the rest are dropped."""
+    builder = _create_spec_builder()
+    common = _make_common([120], [100])
+    blocks = _prime(builder, common)
+    _seed(builder, blocks, write_pos=2, is_flush=0)
+
+    # One accepted out of a 4-token window.
+    _build(builder, common, [1])
+
+    assert _cursors(builder, blocks)[0] == [3]
+
+
+def test_flush_advances_origin_and_restarts_write_pos():
+    builder = _create_spec_builder()
+    common = _make_common([120], [100])
+    blocks = _prime(builder, common)
+    _seed(builder, blocks, write_pos=5, is_flush=1)
+
+    _build(builder, common, [2])
+
+    write_pos, post_origin, _ = _cursors(builder, blocks)
+    # The flush consumed the 5 committed history tokens, so the ring restarts
+    # past them and only the freshly accepted tokens remain.
+    assert post_origin == [5]
+    assert write_pos == [2]
+
+
+def test_early_flush_keeps_room_for_a_full_window():
+    """is_flush is set one window early: write_pos + 2 * max_spec_len > L."""
+    builder = _create_spec_builder()
+    common = _make_common([120], [100])
+    blocks = _prime(builder, common)
+
+    # write_pos 3 -> +1 = 4; 4 + 8 = 12 is not > 12, so no flush yet.
+    _seed(builder, blocks, write_pos=3, is_flush=0)
+    _build(builder, common, [1])
+    assert _cursors(builder, blocks)[2] == [0]
+
+    # write_pos 4 -> +1 = 5; 5 + 8 = 13 > 12, so the next step must flush.
+    _seed(builder, blocks, write_pos=4, is_flush=0)
+    _build(builder, common, [1])
+    assert _cursors(builder, blocks)[2] == [1]
+
+
+def test_first_decode_resets_a_recycled_block():
+    builder = _create_spec_builder()
+    # num_computed == decode_base marks the request's first verify step.
+    common = _make_common([104], [100])
+    blocks = _prime(builder, common)
+    # Stale cursors left behind by whoever held this block before.
+    _seed(builder, blocks, write_pos=6, is_flush=1)
+
+    _build(builder, common, [1])
+
+    assert _cursors(builder, blocks) == ([0], [0], [0])
+
+
+def test_resumed_request_reanchors_on_decode_base():
+    """Preemption: decode_base moves to the resume point, which re-fires the
+    reset so the recomputed request does not inherit its old cursors."""
+    builder = _create_spec_builder()
+    # Resumed at 116 tokens of context: num_computed == decode_base again.
+    common = _make_common([120], [116])
+    blocks = _prime(builder, common)
+    _seed(builder, blocks, write_pos=7, is_flush=1)
+
+    _build(builder, common, [1])
+
+    write_pos, post_origin, _ = _cursors(builder, blocks)
+    assert (write_pos, post_origin) == ([0], [0])
+
+
+def test_steady_state_row_is_not_reset():
+    builder = _create_spec_builder()
+    # num_computed (116) > decode_base (100): mid-generation, keep the ring.
+    common = _make_common([120], [100])
+    blocks = _prime(builder, common)
+    _seed(builder, blocks, write_pos=2, is_flush=0)
+
+    _build(builder, common, [1])
+
+    assert _cursors(builder, blocks)[0] == [3]
+
+
+def test_leftover_prompt_chunk_resets_and_forces_a_flush():
+    """A final single-token prompt chunk is reclassified as a decode, so it runs
+    the spec kernel one token short of decode_base. It must reset the ring and
+    flush, or the checkpoint never advances past that token and the next step's
+    reset drops it."""
+    builder = _create_spec_builder()
+    # num_computed = 100 - 1 = 99, one short of decode_base.
+    common = _make_common([100], [100], query_lens=[1])
+    blocks = _prime(builder, common)
+    _seed(builder, blocks, write_pos=6, is_flush=0)
+
+    _build(builder, common, [1])
+
+    write_pos, post_origin, is_flush = _cursors(builder, blocks)
+    assert (write_pos, post_origin) == ([0], [0])
+    assert is_flush == [1]
+
+
+def test_mixed_batch_resets_only_the_entering_rows():
+    builder = _create_spec_builder()
+    # Row 0 steady state, row 1 first decode, row 2 steady state.
+    common = _make_common([120, 104, 124], [100, 100, 100])
+    blocks = _prime(builder, common)
+    _seed(builder, blocks, write_pos=4, is_flush=0)
+
+    _build(builder, common, [2, 2, 2])
+
+    assert _cursors(builder, blocks)[0] == [6, 0, 6]
+
+
+def test_zero_accept_row_commits_nothing():
+    builder = _create_spec_builder()
+    common = _make_common([120], [100])
+    blocks = _prime(builder, common)
+    _seed(builder, blocks, write_pos=3, is_flush=0)
+
+    _build(builder, common, [0])
+
+    assert _cursors(builder, blocks)[0] == [3]
+
+
+def test_null_block_rows_are_skipped():
+    builder = _create_spec_builder()
+    common = _make_common([120, 120], [100, 100])
+    blocks = _prime(builder, common)
+    _seed(builder, blocks, write_pos=3, is_flush=0)
+    # Mark row 1 as padding, the way cudagraph padding does.
+    common.block_table_tensor[1, :] = NULL_BLOCK_ID
+
+    _build(builder, common, [2, 2])
+
+    write_pos, _, _ = _cursors(builder, blocks)
+    assert write_pos[0] == 5
+    assert write_pos[1] == 3
+
+
+def test_cudagraph_scratch_widens_to_the_padded_batch():
+    builder = _create_spec_builder(full_cuda_graph=True)
+    common = _make_common([120, 120], [100, 100])
+    meta = _build(builder, common, [1, 1])
+
+    assert meta.spec_bc_pre_scratch is not None
+    assert meta.spec_bc_pre_scratch.shape[0] == meta.num_reqs
+    # It must be the persistent buffer, not a fresh allocation, or the captured
+    # graph would replay against a dangling pointer.
+    assert meta.spec_bc_pre_scratch.data_ptr() == builder.decode_spec_bc_pre.data_ptr()
+    # The cursors are block-keyed and full-length, so they are handed through
+    # whole rather than sliced to the batch.
+    assert meta.spec_write_pos_d.shape[0] == builder.spec_write_pos.shape[0]
+    assert meta.spec_write_pos_d.data_ptr() == builder.spec_write_pos.data_ptr()
+
+
+def test_ring_geometry_matches_the_page():
+    builder = _create_spec_builder()
+
+    assert builder.max_spec_len == MAX_SPEC_LEN
+    assert builder.spec_flush_threshold == FLUSH_THRESHOLD
+    assert builder.spec_ring_len == RING_LEN
+    # ngroups is recovered from the page width: (conv_dim - d_inner) / dstate.
+    assert builder.decode_spec_bc_pre.shape[1] == NGROUPS
+    assert builder.decode_spec_bc_pre.shape[2] == RING_LEN
+
+
+def test_spec_page_shape_is_validated():
+    vllm_config = create_vllm_config(
+        model_name="Qwen/Qwen3.5-0.8B", block_size=BLOCK_SIZE
+    )
+    vllm_config.speculative_config = SpeculativeConfig(
+        method="ngram", num_speculative_tokens=NUM_SPEC
+    )
+    vllm_config.cache_config.use_replayssm_spec = True
+    # Five-tensor standard page instead of the four-tensor spec page.
+    bad_spec = MambaSpec(
+        block_size=BLOCK_SIZE,
+        shapes=((1, 1), (1, 1, 1), (1, 8, 1), (1, 8), (1, 8, 1)),
+        dtypes=(torch.float32,),
+    )
+    with pytest.raises(ValueError, match="4-tensor Mamba2 page"):
+        MockMambaBuilder(bad_spec, ["layer0"], vllm_config, DEVICE)

--- a/tests/v1/e2e/test_replayssm_decode.py
+++ b/tests/v1/e2e/test_replayssm_decode.py
@@ -9,10 +9,15 @@ from vllm.v1.metrics.reader import Counter
 from ...models.utils import check_logprobs_close
 from ...utils import large_gpu_mark, multi_gpu_test
 
-# Mamba2 (Nemotron-3) hybrid.
+# Mamba2 (Nemotron-3) and GDN (Qwen3.5) hybrids.
 MAMBA2_MODEL = "nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16"
+GDN_MODEL = "Qwen/Qwen3.5-4B"
 MODELS = [
     pytest.param(MAMBA2_MODEL, marks=large_gpu_mark(min_gb=40)),
+]
+SPEC_MODELS = [
+    pytest.param(MAMBA2_MODEL, marks=large_gpu_mark(min_gb=40)),
+    pytest.param(GDN_MODEL, marks=large_gpu_mark(min_gb=40)),
 ]
 
 PROMPTS = [
@@ -169,6 +174,6 @@ def _check_replayssm_spec_parity(vllm_runner, model_name, *, num_spec_tokens=3):
     )
 
 
-@pytest.mark.parametrize("model_name", MODELS)
+@pytest.mark.parametrize("model_name", SPEC_MODELS)
 def test_replayssm_spec_decode_matches_baseline(vllm_runner, model_name):
     _check_replayssm_spec_parity(vllm_runner, model_name)

--- a/tests/v1/e2e/test_replayssm_decode.py
+++ b/tests/v1/e2e/test_replayssm_decode.py
@@ -136,3 +136,39 @@ def test_replayssm_prefix_caching_matches_baseline_tp2(vllm_runner, model_name):
     _check_replayssm_prefix_caching_parity(
         vllm_runner, model_name, tensor_parallel_size=2
     )
+
+
+def _check_replayssm_spec_parity(vllm_runner, model_name, *, num_spec_tokens=3):
+    # Speculative verify must reproduce the baseline spec path token for token:
+    # the ring replays the same recurrence the per-draft snapshots would have.
+    # Exercises the block-keyed cursors, the commit/rollback, the flush cadence
+    # and CUDA-graph capture of the fixed two-launch decode sequence.
+    common = dict(
+        max_model_len=1024,
+        trust_remote_code=True,
+        enable_prefix_caching=False,
+        mamba_cache_mode="none",
+        speculative_config={
+            "method": "ngram",
+            "num_speculative_tokens": num_spec_tokens,
+            "prompt_lookup_max": 3,
+        },
+    )
+    with vllm_runner(model_name, **common) as llm:
+        baseline = llm.generate_greedy_logprobs(PROMPTS, max_tokens=32, num_logprobs=5)
+    with vllm_runner(
+        model_name, use_replayssm_spec=True, replayssm_buffer_len=16, **common
+    ) as llm:
+        replay = llm.generate_greedy_logprobs(PROMPTS, max_tokens=32, num_logprobs=5)
+
+    check_logprobs_close(
+        outputs_0_lst=baseline,
+        outputs_1_lst=replay,
+        name_0="baseline_spec",
+        name_1="replayssm_spec",
+    )
+
+
+@pytest.mark.parametrize("model_name", MODELS)
+def test_replayssm_spec_decode_matches_baseline(vllm_runner, model_name):
+    _check_replayssm_spec_parity(vllm_runner, model_name)

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -148,7 +148,9 @@ class CacheConfig:
     replayssm_buffer_len: int = Field(default=16, gt=0)
     """ReplaySSM history buffer length B: with use_replayssm, standard decode
     caches recent SSM inputs in a size-B ring buffer and flushes the checkpoint
-    state to HBM every B steps. Default 16."""
+    state to HBM every B steps. With use_replayssm_spec, B is the maximum history
+    the ring carries into a verify step, so the flush rule is
+    history + 1 + num_speculative_tokens > B. Default 16."""
     use_replayssm: bool = False
     """Use the ReplaySSM Mamba2 decode kernel: cache recent SSM inputs and skip
     the per-step full-state store, writing the checkpoint back only on flush.
@@ -156,6 +158,13 @@ class CacheConfig:
     mamba backend; standard (non-speculative) decode only. In align mode flushes
     are most efficient when mamba_block_size is a multiple of replayssm_buffer_len,
     but this is not required."""
+    use_replayssm_spec: bool = False
+    """Use the ReplaySSM Mamba2 speculative-decode kernel: verify a whole draft
+    window against one checkpoint plus a circular input ring, so rollback is a
+    cursor move instead of a per-draft state snapshot. Requires speculative
+    decoding, mamba_cache_mode 'none' and the Triton mamba backend; mutually
+    exclusive with use_replayssm. replayssm_buffer_len must be at least
+    1 + num_speculative_tokens."""
 
     # Will be set after profiling.
     num_gpu_blocks: int | None = field(default=None, init=False)

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2350,7 +2350,8 @@ class VllmConfig:
             )
         if self.model_config is not None and not self.model_config.supports_replayssm:
             raise ValueError(
-                "--use-replayssm-spec is only supported for Nemotron-H models "
+                "--use-replayssm-spec is only supported for models that declare "
+                "ReplaySSM support via the SupportsReplaySSM interface "
                 f"(got architecture {self.model_config.architecture!r})"
             )
         # Inverted against --use-replayssm, which forbids speculative decoding.

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2339,6 +2339,56 @@ class VllmConfig:
             )
         return self
 
+    @model_validator(mode="after")
+    def validate_mamba_cached_spec_kernel(self) -> "VllmConfig":
+        if not self.cache_config.use_replayssm_spec:
+            return self
+        if self.cache_config.use_replayssm:
+            raise ValueError(
+                "--use-replayssm-spec is mutually exclusive with --use-replayssm "
+                "(different page shapes and decode paths)"
+            )
+        if self.model_config is not None and not self.model_config.supports_replayssm:
+            raise ValueError(
+                "--use-replayssm-spec is only supported for Nemotron-H models "
+                f"(got architecture {self.model_config.architecture!r})"
+            )
+        # Inverted against --use-replayssm, which forbids speculative decoding.
+        if self.num_speculative_tokens <= 0:
+            raise ValueError(
+                "--use-replayssm-spec requires speculative decoding "
+                "(num_speculative_tokens > 0)"
+            )
+        if self.cache_config.mamba_cache_mode != "none":
+            raise ValueError(
+                "--use-replayssm-spec does not support prefix caching; "
+                "pass --mamba-cache-mode none"
+            )
+        if self.mamba_config.backend != MambaBackendEnum.TRITON:
+            raise ValueError("--use-replayssm-spec requires --mamba-backend triton")
+        if self.mamba_config.enable_stochastic_rounding:
+            raise ValueError(
+                "--use-replayssm-spec does not support Mamba cache stochastic rounding"
+            )
+        if (
+            self.kv_transfer_config is not None
+            and self.kv_transfer_config.is_kv_transfer_instance
+        ):
+            raise ValueError(
+                "--use-replayssm-spec is incompatible with KV connectors "
+                "(P/D disaggregation, KV cache offload)"
+            )
+        # The ring holds L = B + max_spec_len slots and flushes once the next
+        # window would not fit, so B below max_spec_len can never seat a window.
+        max_spec_len = 1 + self.num_speculative_tokens
+        if self.cache_config.replayssm_buffer_len < max_spec_len:
+            raise ValueError(
+                "--use-replayssm-spec requires --replayssm-buffer-len >= "
+                f"1 + num_speculative_tokens ({max_spec_len}); got "
+                f"{self.cache_config.replayssm_buffer_len}"
+            )
+        return self
+
 
 _current_vllm_config: VllmConfig | None = None
 _current_prefix: str | None = None

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -697,6 +697,7 @@ class EngineArgs:
     mamba_cache_mode: MambaCacheMode = CacheConfig.mamba_cache_mode
     replayssm_buffer_len: int = CacheConfig.replayssm_buffer_len
     use_replayssm: bool = CacheConfig.use_replayssm
+    use_replayssm_spec: bool = CacheConfig.use_replayssm_spec
 
     mamba_backend: MambaBackendEnum = MambaBackendEnum.TRITON
     enable_mamba_cache_stochastic_rounding: bool = (
@@ -1228,6 +1229,9 @@ class EngineArgs:
             "--replayssm-buffer-len", **cache_kwargs["replayssm_buffer_len"]
         )
         cache_group.add_argument("--use-replayssm", **cache_kwargs["use_replayssm"])
+        cache_group.add_argument(
+            "--use-replayssm-spec", **cache_kwargs["use_replayssm_spec"]
+        )
         cache_group.add_argument(
             "--kv-offloading-size", **cache_kwargs["kv_offloading_size"]
         )
@@ -1941,6 +1945,7 @@ class EngineArgs:
             mamba_cache_mode=self.mamba_cache_mode,
             replayssm_buffer_len=self.replayssm_buffer_len,
             use_replayssm=self.use_replayssm,
+            use_replayssm_spec=self.use_replayssm_spec,
             kv_offloading_size=self.kv_offloading_size,
             kv_offloading_backend=self.kv_offloading_backend,
         )

--- a/vllm/model_executor/layers/mamba/abstract.py
+++ b/vllm/model_executor/layers/mamba/abstract.py
@@ -71,10 +71,16 @@ class MambaBase(AttentionLayerBase):
             page_size_padded=page_size_padded,
             mamba_type=self.mamba_type,
             mamba_cache_mode=vllm_config.cache_config.mamba_cache_mode,
+            # ReplaySSM-spec verifies the whole window off one checkpoint, so it
+            # never writes the baseline's per-draft-token state slots.
             num_speculative_blocks=(
-                vllm_config.speculative_config.num_speculative_tokens
-                if vllm_config.speculative_config
-                else 0
+                0
+                if vllm_config.cache_config.use_replayssm_spec
+                else (
+                    vllm_config.speculative_config.num_speculative_tokens
+                    if vllm_config.speculative_config
+                    else 0
+                )
             ),
         )
 

--- a/vllm/model_executor/layers/mamba/gdn/base.py
+++ b/vllm/model_executor/layers/mamba/gdn/base.py
@@ -51,8 +51,13 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         return MambaAttentionBackendEnum.GDN_ATTN
 
     def get_state_dtype(self) -> tuple[torch.dtype, ...]:
-        return MambaStateDtypeCalculator.gated_delta_net_state_dtype(
+        base_dtype = MambaStateDtypeCalculator.gated_delta_net_state_dtype(
             self.model_config.dtype,
             self.cache_config.mamba_cache_dtype,
             self.cache_config.mamba_ssm_cache_dtype,
         )
+        if self.cache_config.use_replayssm_spec:
+            return MambaStateDtypeCalculator.append_gated_delta_net_replayssm_spec_ring(
+                base_dtype, self.model_config.dtype
+            )
+        return base_dtype

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -340,10 +340,8 @@ class ChunkGatedDeltaRule(CustomOp):
 
 @PluggableLayer.register("qwen_gated_delta_net_attention")
 class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
-    def get_state_shape(
-        self,
-    ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
-        return MambaStateShapeCalculator.gated_delta_net_state_shape(
+    def get_state_shape(self) -> tuple[tuple[int, ...], ...]:
+        base_shape = MambaStateShapeCalculator.gated_delta_net_state_shape(
             self.tp_size,
             self.num_k_heads,
             self.num_v_heads,
@@ -352,6 +350,18 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             self.conv_kernel_size,
             self.num_spec,
         )
+        if self.cache_config.use_replayssm_spec:
+            return MambaStateShapeCalculator.append_gated_delta_net_replayssm_spec_ring(
+                base_shape,
+                self.num_k_heads,
+                self.num_v_heads,
+                self.head_k_dim,
+                self.head_v_dim,
+                self.tp_size,
+                self.cache_config.replayssm_buffer_len,
+                self.num_spec,
+            )
+        return base_shape
 
     def __init__(
         self,
@@ -371,6 +381,9 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         self.key_dim = self.head_k_dim * self.num_k_heads
         self.value_dim = self.head_v_dim * self.num_v_heads
         self.gqa_interleaved_layout = gqa_interleaved_layout
+        self.use_replayssm_spec = self.cache_config.use_replayssm_spec
+        self.replayssm_buffer_len = self.cache_config.replayssm_buffer_len
+        self.max_spec_len = 1 + self.num_spec
         if current_platform.is_xpu():
             self._forward_method = self.forward_xpu
         elif current_platform.is_cpu():
@@ -1018,7 +1031,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         dtype = qkv_or_qkvz.dtype
         num_k_heads = self.num_k_heads // self.tp_size
         num_v_heads = self.num_v_heads // self.tp_size
-        _, state_dtype = self.get_state_dtype()
+        # get_state_dtype() is (conv, ssm[, d, k, g]); only the ssm dtype is needed.
+        state_dtype = self.get_state_dtype()[1]
 
         # All kernels use BT = chunk_size, so a single pass with T = chunk_size
         # is sufficient to populate every autotuner cache. Mirror the real
@@ -1272,7 +1286,11 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 ],
                 num_accepted_tokens=num_accepted_tokens,
                 query_start_loc=spec_query_start_loc,
-                max_query_len=spec_state_indices_tensor.size(-1),
+                max_query_len=(
+                    self.max_spec_len
+                    if self.use_replayssm_spec
+                    else spec_state_indices_tensor.size(-1)
+                ),
                 validate_data=False,
             )
 
@@ -1309,7 +1327,10 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         else:
             mixed_qkv_non_spec = None
 
-        query_spec, key_spec, value_spec = self.rearrange_mixed_qkv(mixed_qkv_spec)
+        if spec_sequence_masks is not None and self.use_replayssm_spec:
+            query_spec, key_spec, value_spec = None, None, None
+        else:
+            query_spec, key_spec, value_spec = self.rearrange_mixed_qkv(mixed_qkv_spec)
 
         # Split mixed non-spec-decode+prefill to process independently
         split_non_spec = (
@@ -1372,7 +1393,49 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         # 2. Recurrent attention
 
         # 2.1: Process the multi-query part
-        if spec_sequence_masks is not None:
+        if spec_sequence_masks is not None and self.use_replayssm_spec:
+            from vllm.third_party.flash_linear_attention.ops.gdn_replayssm_spec_decode import (  # noqa: E501
+                gdn_replayssm_spec_decode,
+            )
+
+            assert mixed_qkv_spec is not None
+            num_spec_decodes = attn_metadata.num_spec_decodes
+            d_cache, k_cache, g_cache = self_kv_cache[2:5]
+            cs_out = torch.empty(
+                mixed_qkv_spec.shape[0],
+                self.num_v_heads // self.tp_size,
+                self.head_v_dim,
+                dtype=mixed_qkv_spec.dtype,
+                device=mixed_qkv_spec.device,
+            )
+            gdn_replayssm_spec_decode(
+                mixed_qkv=mixed_qkv_spec,
+                a=a,
+                b=b,
+                A_log=self.A_log,
+                dt_bias=self.dt_bias,
+                checkpoint_state=ssm_state,
+                d_cache=d_cache,
+                k_cache=k_cache,
+                g_cache=g_cache,
+                out=cs_out,
+                query_start_loc=spec_query_start_loc[  # type: ignore[index]
+                    : num_spec_decodes + 1
+                ],
+                ssm_state_indices=spec_state_indices_tensor[  # type: ignore[index]
+                    :num_spec_decodes, 0
+                ],
+                write_pos=attn_metadata.spec_write_pos_d,
+                cache_base=attn_metadata.spec_cache_base_d,
+                is_flush=attn_metadata.spec_is_flush_d,
+                max_cache_len=self.replayssm_buffer_len + self.max_spec_len,
+                max_spec_len=self.max_spec_len,
+                scale=self.head_k_dim**-0.5,
+                use_qk_l2norm_in_kernel=True,
+            )
+            core_attn_out_spec = cs_out.unsqueeze(0)
+            last_recurrent_state = None
+        elif spec_sequence_masks is not None:
             core_attn_out_spec, last_recurrent_state = (
                 fused_sigmoid_gating_delta_rule_update(
                     A_log=self.A_log,

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -35,6 +35,9 @@ from vllm.model_executor.layers.mamba.ops.layernorm_gated import rms_norm_gated
 from vllm.model_executor.layers.mamba.ops.selective_state_update_replayssm_output_only import (  # noqa: E501
     selective_state_update_replayssm_output_only,
 )
+from vllm.model_executor.layers.mamba.ops.selective_state_update_replayssm_spec import (
+    selective_state_update_replayssm_spec,
+)
 from vllm.model_executor.layers.mamba.ops.ssd_combined import (
     mamba_chunk_scan_combined_varlen,
 )
@@ -504,22 +507,36 @@ class MambaMixer2(MambaBase, PluggableLayer):
         self.use_replayssm = (
             cache_config.use_replayssm if cache_config is not None else False
         )
+        self.use_replayssm_spec = (
+            cache_config.use_replayssm_spec if cache_config is not None else False
+        )
         self.replayssm_buffer_len = (
             cache_config.replayssm_buffer_len
-            if cache_config is not None and cache_config.use_replayssm
+            if cache_config is not None
+            and (cache_config.use_replayssm or cache_config.use_replayssm_spec)
             else None
         )
         self.mamba_config = vllm_config.mamba_config
-        if self.use_replayssm and self.num_heads % self.tp_size != 0:
+        if (
+            self.use_replayssm or self.use_replayssm_spec
+        ) and self.num_heads % self.tp_size != 0:
             raise ValueError(
-                "--use-replayssm requires tensor-parallel heads to divide evenly"
+                "ReplaySSM requires tensor-parallel heads to divide evenly"
             )
         # The tuple is (conv_state, ssm_state); with the cached (ReplaySSM) decode
-        # kernel enabled it is (conv_state, ssm_state, x_cache, dt_cache, B_cache).
-        _n_state = 5 if self.use_replayssm else 2
+        # kernel enabled it is (conv_state, ssm_state, x_cache, dt_cache, B_cache),
+        # and with the cached-spec kernel (conv_state, ssm_state, post_conv_cache,
+        # dt_cache).
+        if self.use_replayssm_spec:
+            _n_state = 4
+        elif self.use_replayssm:
+            _n_state = 5
+        else:
+            _n_state = 2
         self.kv_cache = tuple(torch.tensor([]) for _ in range(_n_state))
 
         self.num_spec = vllm_config.num_speculative_tokens
+        self.max_spec_len = 1 + self.num_spec
         if self.num_spec > 0:
             self.register_buffer(
                 "_decode_state_offsets",
@@ -720,10 +737,12 @@ class MambaMixer2(MambaBase, PluggableLayer):
                 else self.kv_cache[0].transpose(-1, -2)
             )
             ssm_state = self.kv_cache[1]
-            if self.use_replayssm:
+            spec_post_conv_cache = spec_dt_cache = None
+            x_cache = dt_cache = B_cache = None
+            if self.use_replayssm_spec:
+                spec_post_conv_cache, spec_dt_cache = self.kv_cache[2:]
+            elif self.use_replayssm:
                 x_cache, dt_cache, B_cache = self.kv_cache[2:]
-            else:
-                x_cache = dt_cache = B_cache = None
             has_initial_states_p = attn_metadata.has_initial_states_p
             prep_initial_states = attn_metadata.prep_initial_states
             chunk_size = attn_metadata.chunk_size
@@ -1021,8 +1040,17 @@ class MambaMixer2(MambaBase, PluggableLayer):
                 initial_state_idx=block_idx_last_computed_token_d,
                 num_accepted_tokens=num_accepted_tokens,
                 query_start_loc=query_start_loc_d,
-                max_query_len=state_indices_tensor_d.size(-1),
+                max_query_len=(
+                    self.max_spec_len
+                    if self.use_replayssm_spec
+                    else state_indices_tensor_d.size(-1)
+                ),
             )
+
+            # The spec kernel consumes the full channel-last post-conv output and
+            # the raw dt; capture both before the split reshapes them.
+            conv_out_spec = hidden_states_B_C_d
+            dt_d_raw = dt_d
 
             hidden_states_d, B_d, C_d = self.split_hidden_states_B_C_fn(
                 hidden_states_B_C_d
@@ -1052,7 +1080,37 @@ class MambaMixer2(MambaBase, PluggableLayer):
             preallocated_ssm_out_d = preallocated_ssm_out_d.view(
                 num_decode_tokens, -1, self.head_dim
             )
-            if self.use_replayssm:
+            if self.use_replayssm_spec:
+                assert self.replayssm_buffer_len is not None
+                assert spec_post_conv_cache is not None
+                assert spec_dt_cache is not None
+                assert query_start_loc_d is not None
+                assert attn_metadata.spec_write_pos_d is not None
+                selective_state_update_replayssm_spec(
+                    ssm_state,
+                    spec_post_conv_cache,
+                    spec_dt_cache,
+                    conv_out_spec,
+                    dt_d_raw,
+                    A_d,
+                    write_pos=attn_metadata.spec_write_pos_d,
+                    post_conv_state_pos=attn_metadata.spec_post_origin_d,
+                    is_flush=attn_metadata.spec_is_flush_d,
+                    query_start_loc=query_start_loc_d,
+                    state_batch_indices=state_indices_tensor_d_input[:, 0],
+                    max_cache_len=self.replayssm_buffer_len + self.max_spec_len,
+                    max_spec_len=self.max_spec_len,
+                    d_inner=self.intermediate_size // self.tp_size,
+                    ngroups=n_groups,
+                    dstate=self.ssm_state_size,
+                    D=D_d,
+                    z=None,
+                    dt_bias=dt_bias,
+                    dt_softplus=True,
+                    out=preallocated_ssm_out_d,
+                    bc_pre=attn_metadata.spec_bc_pre_scratch,
+                )
+            elif self.use_replayssm:
                 assert self.replayssm_buffer_len is not None
                 selective_state_update_replayssm_output_only(
                     ssm_state,
@@ -1110,6 +1168,10 @@ class MambaMixer2(MambaBase, PluggableLayer):
             self.cache_config.mamba_cache_dtype,
             self.cache_config.mamba_ssm_cache_dtype,
         )
+        if self.use_replayssm_spec:
+            return MambaStateDtypeCalculator.append_replayssm_spec_ring(
+                base_dtype, self.model_config.dtype
+            )
         if self.use_replayssm:
             return MambaStateDtypeCalculator.append_replayssm_ring(
                 base_dtype, self.model_config.dtype
@@ -1128,6 +1190,16 @@ class MambaMixer2(MambaBase, PluggableLayer):
             conv_kernel=self.conv_kernel_size,
             num_spec=self.num_spec,
         )
+        if self.use_replayssm_spec:
+            assert self.replayssm_buffer_len is not None
+            return MambaStateShapeCalculator.append_replayssm_spec_ring(
+                base_shape,
+                self.intermediate_size,
+                self.n_groups,
+                tp_world_size,
+                self.replayssm_buffer_len,
+                self.num_spec,
+            )
         if self.use_replayssm:
             assert self.replayssm_buffer_len is not None
             return MambaStateShapeCalculator.append_replayssm_ring(

--- a/vllm/model_executor/layers/mamba/mamba_utils.py
+++ b/vllm/model_executor/layers/mamba/mamba_utils.py
@@ -106,6 +106,23 @@ class MambaStateDtypeCalculator:
         return (*base_dtypes, activation_dtype, torch.float32)
 
     @classmethod
+    def append_gated_delta_net_replayssm_spec_ring(
+        cls,
+        base_dtypes: tuple[torch.dtype, ...],
+        model_dtype: ModelDType | torch.dtype,
+    ) -> tuple[torch.dtype, ...]:
+        """Append the GDN ReplaySSM spec ring dtypes to a base ``(conv, ssm)``
+        tuple: ``(d_cache, k_cache, g_cache)``. The d/k caches use fp16 for bf16
+        activations, which reconstructs the state more accurately at the same
+        width; ``g`` drives the cumulative decay replay and stays fp32.
+        """
+        activation_dtype = get_kv_cache_torch_dtype("auto", model_dtype)
+        ring_dtype = (
+            torch.float16 if activation_dtype == torch.bfloat16 else activation_dtype
+        )
+        return (*base_dtypes, ring_dtype, ring_dtype, torch.float32)
+
+    @classmethod
     def _mamba_state_dtype(
         cls,
         model_dtype: ModelDType | torch.dtype,
@@ -316,6 +333,32 @@ class MambaStateShapeCalculator:
             head_k_dim,
         )
         return conv_state_shape, temporal_state_shape
+
+    @classmethod
+    def append_gated_delta_net_replayssm_spec_ring(
+        cls,
+        base_shapes: tuple[tuple[int, ...], ...],
+        num_k_heads: int,
+        num_v_heads: int,
+        head_k_dim: int,
+        head_v_dim: int,
+        tp_world_size: int,
+        replayssm_buffer_len: int,
+        num_spec: int,
+    ) -> tuple[tuple[int, ...], ...]:
+        """Append the GDN ReplaySSM spec ring shapes (d_cache, k_cache, g_cache)
+        to a base ``(conv, ssm)`` tuple. ``base_shapes`` must already carry the
+        spec conv window (``gated_delta_net_state_shape(..., num_spec)``).
+        """
+        ring_len = cls.replayssm_spec_ring_len(replayssm_buffer_len, num_spec)
+        local_v_heads = divide(num_v_heads, tp_world_size)
+        local_k_heads = divide(num_k_heads, tp_world_size)
+        return (
+            *base_shapes,
+            (local_v_heads, ring_len, head_v_dim),
+            (local_k_heads, ring_len, head_k_dim),
+            (local_v_heads, ring_len),
+        )
 
     @classmethod
     def kda_state_shape(

--- a/vllm/model_executor/layers/mamba/mamba_utils.py
+++ b/vllm/model_executor/layers/mamba/mamba_utils.py
@@ -93,6 +93,19 @@ class MambaStateDtypeCalculator:
         return (*base_dtypes, activation_dtype, torch.float32, activation_dtype)
 
     @classmethod
+    def append_replayssm_spec_ring(
+        cls,
+        base_dtypes: tuple[torch.dtype, ...],
+        model_dtype: ModelDType | torch.dtype,
+    ) -> tuple[torch.dtype, ...]:
+        """Append the ReplaySSM spec ring dtypes to a base ``(conv, ssm)`` tuple:
+        ``(post_conv_cache, dt_cache)`` = ``(activation, fp32)``. ``dt`` drives
+        the cumulative decay replay and stays fp32 regardless of state dtype.
+        """
+        activation_dtype = get_kv_cache_torch_dtype("auto", model_dtype)
+        return (*base_dtypes, activation_dtype, torch.float32)
+
+    @classmethod
     def _mamba_state_dtype(
         cls,
         model_dtype: ModelDType | torch.dtype,
@@ -218,6 +231,43 @@ class MambaStateShapeCalculator:
             (local_nheads, replayssm_buffer_len, head_dim),
             (local_nheads, replayssm_buffer_len),
             (local_ngroups, replayssm_buffer_len, state_size),
+        )
+
+    @classmethod
+    def replayssm_spec_ring_len(cls, replayssm_buffer_len: int, num_spec: int) -> int:
+        """Physical ring length: next_pow2 of the L = B + 1 + num_spec window,
+        so wraparound indexing is a bit-mask instead of a modulo.
+        """
+        return 1 << (replayssm_buffer_len + num_spec).bit_length()
+
+    @classmethod
+    def append_replayssm_spec_ring(
+        cls,
+        base_shapes: tuple[tuple[int, ...], ...],
+        intermediate_size: int,
+        n_groups: int,
+        tp_world_size: int,
+        replayssm_buffer_len: int,
+        num_spec: int,
+    ) -> tuple[tuple[int, ...], ...]:
+        """Append the ReplaySSM spec ring shapes (post_conv_cache, dt_cache) to a
+        base ``(conv, ssm)`` tuple. ``post_conv_cache`` holds x|B only; C is read
+        fresh from conv_out, so its width excludes one n_groups * state_size
+        block of the conv width. ``base_shapes`` must already carry the spec conv
+        window (``mamba2_state_shape(..., num_spec=num_spec)``).
+        """
+        local_nheads, _head_dim, state_size = base_shapes[1]
+        n_groups_ext = n_groups + cls.extra_groups_for_head_shards(
+            n_groups, tp_world_size
+        )
+        conv_dim_local = divide(
+            intermediate_size + n_groups_ext * state_size, tp_world_size
+        )
+        ring_len = cls.replayssm_spec_ring_len(replayssm_buffer_len, num_spec)
+        return (
+            *base_shapes,
+            (ring_len, conv_dim_local),
+            (local_nheads, ring_len),
         )
 
     @classmethod

--- a/vllm/model_executor/layers/mamba/ops/replayssm_config.py
+++ b/vllm/model_executor/layers/mamba/ops/replayssm_config.py
@@ -66,12 +66,51 @@ def _mamba2_spec_flush(dstate, base_block, is_blackwell):
     return 32, 1, _dstate_tile(dstate, 128), 2
 
 
+# GDN spec configs are (block_v, num_warps, block_s, num_stages), swept on
+# B300 at the Qwen3.5 geometry. The head_k_dim gate matters: these tuples
+# regress badly at K=64, which the default covers instead.
+_GDN_SPEC_VERIFY_BLACKWELL = {
+    2: (128, 2, 4, 3),
+    4: (128, 2, 4, 3),
+    6: (128, 2, 8, 4),
+    8: (128, 2, 8, 4),
+}
+_GDN_SPEC_FLUSH_BLACKWELL = {
+    2: (64, 1, 8, 4),
+    4: (64, 1, 8, 4),
+    6: (64, 1, 8, 2),
+    8: (64, 1, 8, 2),
+}
+
+
+def _gdn_spec_default(max_spec_len):
+    return 64, 1, (4 if max_spec_len >= 6 else 2), 2
+
+
+def _gdn_spec_verify(max_spec_len, head_k_dim, is_blackwell):
+    if is_blackwell and head_k_dim == 128:
+        return _GDN_SPEC_VERIFY_BLACKWELL.get(
+            max_spec_len, _gdn_spec_default(max_spec_len)
+        )
+    return _gdn_spec_default(max_spec_len)
+
+
+def _gdn_spec_flush(max_spec_len, head_k_dim, is_blackwell):
+    if is_blackwell and head_k_dim == 128:
+        return _GDN_SPEC_FLUSH_BLACKWELL.get(
+            max_spec_len, _gdn_spec_default(max_spec_len)
+        )
+    return _gdn_spec_default(max_spec_len)
+
+
 def get_replayssm_config(kernel: str, **shape) -> tuple:
     """Return the launch config for ``kernel`` (override > tuned default).
 
-    kernel: "mamba2_output_only", "mamba2_spec_verify" or "mamba2_spec_flush".
-    ``shape`` carries the keying dims (dstate; ``L`` for the buffer length,
-    default 16; ``base_block`` for spec); hardware is auto-detected.
+    kernel: "mamba2_output_only", "mamba2_spec_verify", "mamba2_spec_flush",
+    "gdn_spec_verify" or "gdn_spec_flush". ``shape`` carries the keying dims
+    (dstate; ``L`` for the buffer length, default 16; ``base_block`` for Mamba2
+    spec; ``max_spec_len`` and ``head_k_dim`` for GDN spec); hardware is
+    auto-detected.
     """
     if kernel in _overrides:
         return _overrides[kernel]
@@ -82,4 +121,8 @@ def get_replayssm_config(kernel: str, **shape) -> tuple:
         return _mamba2_spec_verify(shape["dstate"], shape["base_block"], bw)
     if kernel == "mamba2_spec_flush":
         return _mamba2_spec_flush(shape["dstate"], shape["base_block"], bw)
+    if kernel == "gdn_spec_verify":
+        return _gdn_spec_verify(shape["max_spec_len"], shape["head_k_dim"], bw)
+    if kernel == "gdn_spec_flush":
+        return _gdn_spec_flush(shape["max_spec_len"], shape["head_k_dim"], bw)
     raise ValueError(f"unknown ReplaySSM kernel config key: {kernel}")

--- a/vllm/model_executor/layers/mamba/ops/replayssm_config.py
+++ b/vllm/model_executor/layers/mamba/ops/replayssm_config.py
@@ -52,15 +52,34 @@ def _mamba2_output_only(dstate, L, is_blackwell):
     return 16, 1, _dstate_tile(dstate, 64), _dstate_tile(dstate, 128), 2
 
 
+def _mamba2_spec_verify(dstate, base_block, is_blackwell):
+    # (block_size_m, num_warps, dstate_tile, num_stages)
+    bsm = 64 if (is_blackwell or base_block <= 16) else 32
+    return bsm, 2, _dstate_tile(dstate, 64), 2
+
+
+def _mamba2_spec_flush(dstate, base_block, is_blackwell):
+    if base_block <= 16:
+        return 32, 2, _dstate_tile(dstate, 64), 2
+    if is_blackwell:
+        return 64, 2, _dstate_tile(dstate, 128), 2
+    return 32, 1, _dstate_tile(dstate, 128), 2
+
+
 def get_replayssm_config(kernel: str, **shape) -> tuple:
     """Return the launch config for ``kernel`` (override > tuned default).
 
-    kernel: "mamba2_output_only". ``shape`` carries the keying dims (dstate;
-    ``L`` for the buffer length, default 16); hardware is auto-detected.
+    kernel: "mamba2_output_only", "mamba2_spec_verify" or "mamba2_spec_flush".
+    ``shape`` carries the keying dims (dstate; ``L`` for the buffer length,
+    default 16; ``base_block`` for spec); hardware is auto-detected.
     """
     if kernel in _overrides:
         return _overrides[kernel]
     bw = _is_blackwell()
     if kernel == "mamba2_output_only":
         return _mamba2_output_only(shape["dstate"], shape.get("L", 16), bw)
+    if kernel == "mamba2_spec_verify":
+        return _mamba2_spec_verify(shape["dstate"], shape["base_block"], bw)
+    if kernel == "mamba2_spec_flush":
+        return _mamba2_spec_flush(shape["dstate"], shape["base_block"], bw)
     raise ValueError(f"unknown ReplaySSM kernel config key: {kernel}")

--- a/vllm/model_executor/layers/mamba/ops/selective_state_update_replayssm_spec.py
+++ b/vllm/model_executor/layers/mamba/ops/selective_state_update_replayssm_spec.py
@@ -1,0 +1,1162 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# ruff: noqa: E501
+
+import torch
+
+from vllm.model_executor.layers.mamba.ops.mamba_ssm import softplus
+from vllm.model_executor.layers.mamba.ops.replayssm_config import get_replayssm_config
+from vllm.triton_utils import tl, triton
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
+
+
+# ======================================================================
+# Fused scatter + precompute  (grid: (batch, ngroups))
+#
+# Scatters all conv_dim channels (x|B|C, partitioned by group) + dt of the
+# fresh spec tokens into the circular post-conv / dt caches at
+# ``(origin + write_pos + s) % buf``, and computes ``bc[k, s] = B_full[k] . C[s]``
+# over the window (history B from the cache + fresh spec B, no read-back).
+# ======================================================================
+@triton.heuristics(
+    {"BLOCK_SIZE_DSTATE": lambda args: triton.next_power_of_2(args["dstate"])}
+)
+@triton.jit
+def _fused_scatter_precompute_kernel(
+    conv_out_ptr,  # (total_tokens, conv_dim) packed channel-last conv output
+    dt_spec_ptr,  # (total_tokens, nheads) packed raw dt
+    post_conv_cache_ptr,  # (num_blocks, buf, conv_dim) circular paged
+    dt_cache_ptr,  # (num_blocks, nheads, buf) circular paged
+    write_pos_ptr,  # (num_state_slots,) block-keyed
+    post_origin_ptr,  # (num_state_slots,) block-keyed
+    bc_pre_ptr,  # (max_bs, ngroups, max_cache_len, block_spec) dense per-row scratch
+    state_batch_indices_ptr,  # (batch,) physical block per dense decode row
+    query_start_loc_ptr,  # (batch + 1,) packed token offsets
+    null_block_id,
+    batch,
+    ngroups,
+    nheads,
+    dstate,
+    d_inner,
+    conv_dim,
+    max_cache_len,
+    stride_conv_out_tok,
+    stride_conv_out_c,
+    stride_dt_spec_tok,
+    stride_dt_spec_h,
+    stride_post_conv_cache_b,
+    stride_post_conv_cache_pos,
+    stride_post_conv_cache_c,
+    stride_dt_cache_b,
+    stride_dt_cache_h,
+    stride_dt_cache_pos,
+    stride_bc_pre_batch,
+    stride_bc_pre_group,
+    stride_bc_pre_pos,
+    stride_bc_pre_spec,
+    stride_state_indices_batch,
+    RATIO: tl.constexpr,
+    RATIO_P: tl.constexpr,
+    NCX: tl.constexpr,
+    BLOCK_CX: tl.constexpr,
+    CACHE_BUF_LEN: tl.constexpr,
+    BLOCK_SIZE_CACHE: tl.constexpr,
+    BLOCK_SIZE_SPEC: tl.constexpr,
+    BLOCK_HL: tl.constexpr,
+    BLOCK_SIZE_DSTATE: tl.constexpr,
+):
+    pid_b = tl.program_id(0)
+    pid_g = tl.program_id(1)
+    state_batch_idx = tl.load(
+        state_batch_indices_ptr + pid_b * stride_state_indices_batch
+    ).to(tl.int64)
+    if state_batch_idx == null_block_id:
+        return
+    bos = tl.load(query_start_loc_ptr + pid_b).to(tl.int64)
+    eos = tl.load(query_start_loc_ptr + pid_b + 1).to(tl.int64)
+    spec_len = (eos - bos).to(tl.int32)
+    write_pos = tl.load(write_pos_ptr + state_batch_idx).to(tl.int32)
+    post_origin = tl.load(post_origin_ptr + state_batch_idx).to(tl.int32)
+
+    offs_s = tl.arange(0, BLOCK_SIZE_SPEC)
+    offs_n = tl.arange(0, BLOCK_SIZE_DSTATE)
+    spec_valid = offs_s < spec_len
+    nmask = offs_n < dstate
+    phys_spec = (post_origin + write_pos + offs_s) & (CACHE_BUF_LEN - 1)
+
+    b_c0 = d_inner + pid_g * dstate
+    c_c0 = d_inner + ngroups * dstate + pid_g * dstate
+
+    src_base = conv_out_ptr + bos * stride_conv_out_tok
+    # fresh spec B / C  [S, N]
+    B_spec = tl.load(
+        src_base
+        + (b_c0 + offs_n[None, :]) * stride_conv_out_c
+        + offs_s[:, None] * stride_conv_out_tok,
+        mask=spec_valid[:, None] & nmask[None, :],
+        other=0.0,
+    )
+    C_spec = tl.load(
+        src_base
+        + (c_c0 + offs_n[None, :]) * stride_conv_out_c
+        + offs_s[:, None] * stride_conv_out_tok,
+        mask=spec_valid[:, None] & nmask[None, :],
+        other=0.0,
+    )
+    cache_base = post_conv_cache_ptr + state_batch_idx * stride_post_conv_cache_b
+    # scatter B (C is not cached; read fresh from conv_out)
+    tl.store(
+        cache_base
+        + phys_spec[:, None] * stride_post_conv_cache_pos
+        + (b_c0 + offs_n[None, :]) * stride_post_conv_cache_c,
+        B_spec,
+        mask=spec_valid[:, None] & nmask[None, :],
+    )
+
+    # scatter x channels owned by this group: [g*RATIO_P, (g+1)*RATIO_P)
+    gx0 = pid_g * RATIO_P
+    for i in tl.static_range(NCX):
+        offs_cx = i * BLOCK_CX + tl.arange(0, BLOCK_CX)
+        cxm = offs_cx < RATIO_P
+        gx = gx0 + offs_cx
+        xv = tl.load(
+            src_base
+            + gx[None, :] * stride_conv_out_c
+            + offs_s[:, None] * stride_conv_out_tok,
+            mask=spec_valid[:, None] & cxm[None, :],
+            other=0.0,
+        )
+        tl.store(
+            cache_base
+            + phys_spec[:, None] * stride_post_conv_cache_pos
+            + gx[None, :] * stride_post_conv_cache_c,
+            xv,
+            mask=spec_valid[:, None] & cxm[None, :],
+        )
+
+    # scatter dt for this group's heads
+    offs_hl = tl.arange(0, BLOCK_HL)
+    hlm = offs_hl < RATIO
+    gh = pid_g * RATIO + offs_hl
+    dt_base = dt_spec_ptr + bos * stride_dt_spec_tok
+    dtv = tl.load(
+        dt_base + offs_s[:, None] * stride_dt_spec_tok + gh[None, :] * stride_dt_spec_h,
+        mask=spec_valid[:, None] & hlm[None, :],
+        other=0.0,
+    )
+    dtc_base = dt_cache_ptr + state_batch_idx * stride_dt_cache_b
+    tl.store(
+        dtc_base
+        + gh[None, :] * stride_dt_cache_h
+        + phys_spec[:, None] * stride_dt_cache_pos,
+        dtv,
+        mask=spec_valid[:, None] & hlm[None, :],
+    )
+
+    # bc: history B from cache + fresh spec B  (no read-back of spec B)
+    offs_k = tl.arange(0, BLOCK_SIZE_CACHE)
+    hist_mask = offs_k < write_pos
+    cache_valid = (offs_k < max_cache_len) & (offs_k < (write_pos + spec_len))
+    spec_tok = (offs_k >= write_pos) & (offs_k < (write_pos + spec_len))
+    spec_off = offs_k - write_pos
+    phys_k = (post_origin + offs_k) & (CACHE_BUF_LEN - 1)
+    B_hist = tl.load(
+        cache_base
+        + phys_k[:, None] * stride_post_conv_cache_pos
+        + (b_c0 + offs_n[None, :]) * stride_post_conv_cache_c,
+        mask=hist_mask[:, None] & nmask[None, :],
+        other=0.0,
+    )
+    B_specrows = tl.load(
+        src_base
+        + (b_c0 + offs_n[None, :]) * stride_conv_out_c
+        + spec_off[:, None] * stride_conv_out_tok,
+        mask=spec_tok[:, None] & nmask[None, :],
+        other=0.0,
+    )
+    B_full = tl.where(spec_tok[:, None], B_specrows, B_hist)
+    B_full = tl.where(cache_valid[:, None], B_full.to(tl.float32), 0.0).to(
+        conv_out_ptr.dtype.element_ty
+    )
+    bc = tl.dot(
+        B_full,
+        tl.trans(C_spec.to(conv_out_ptr.dtype.element_ty)),
+        input_precision="tf32x3",
+    ).to(tl.float32)
+    bc_ptrs = (
+        bc_pre_ptr
+        + pid_b * stride_bc_pre_batch
+        + pid_g * stride_bc_pre_group
+        + offs_k[:, None] * stride_bc_pre_pos
+        + offs_s[None, :] * stride_bc_pre_spec
+    )
+    tl.store(
+        bc_ptrs,
+        bc.to(bc_pre_ptr.dtype.element_ty),
+        mask=cache_valid[:, None] & spec_valid[None, :],
+    )
+
+
+# ======================================================================
+# Verify launch (non-flush rows): per-draft output from the fixed checkpoint
+# S_0, no state write. dstate-tiled. Flush rows early-exit.
+# ======================================================================
+@triton.heuristics({"HAS_DT_BIAS": lambda args: args["dt_bias_ptr"] is not None})
+@triton.heuristics({"HAS_D": lambda args: args["D_ptr"] is not None})
+@triton.heuristics({"HAS_Z": lambda args: args["z_ptr"] is not None})
+@triton.heuristics(
+    {"BLOCK_SIZE_DSTATE": lambda args: triton.next_power_of_2(args["dstate"])}
+)
+@triton.jit
+def _replayssm_spec_nf_kernel(
+    state_ptr,
+    x_cache_ptr,
+    dt_cache_ptr,
+    B_cache_ptr,
+    C_src_ptr,
+    bc_pre_ptr,
+    D_ptr,
+    z_ptr,
+    dt_bias_ptr,
+    A_ptr,
+    out_ptr,
+    is_flush_flags_ptr,
+    write_pos_ptr,
+    post_origin_ptr,
+    state_batch_indices_ptr,
+    query_start_loc_ptr,
+    null_block_id,
+    batch,
+    nheads,
+    dim,
+    dstate,
+    max_cache_len,
+    nheads_ngroups_ratio,
+    stride_state_batch,
+    stride_state_head,
+    stride_state_dim,
+    stride_state_dstate,
+    stride_x_cache_batch,
+    stride_x_cache_head,
+    stride_x_cache_dim,
+    stride_x_cache_pos,
+    stride_dt_cache_batch,
+    stride_dt_cache_head,
+    stride_dt_cache_pos,
+    stride_B_cache_batch,
+    stride_B_cache_group,
+    stride_B_cache_dstate,
+    stride_B_cache_pos,
+    stride_C_src_tok,
+    stride_C_src_c,
+    stride_bc_pre_batch,
+    stride_bc_pre_group,
+    stride_bc_pre_pos,
+    stride_bc_pre_spec,
+    stride_D_head,
+    stride_D_dim,
+    stride_z_tok,
+    stride_z_head,
+    stride_z_dim,
+    stride_dt_bias_head,
+    stride_A_head,
+    stride_out_tok,
+    stride_out_head,
+    stride_out_dim,
+    stride_state_indices_batch,
+    DT_SOFTPLUS: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_CACHE: tl.constexpr,
+    BLOCK_SIZE_SPEC: tl.constexpr,
+    HAS_DT_BIAS: tl.constexpr,
+    HAS_D: tl.constexpr,
+    HAS_Z: tl.constexpr,
+    CACHE_BUF_LEN: tl.constexpr,
+    DSTATE_TILE: tl.constexpr,
+    NDS: tl.constexpr,
+    BLOCK_SIZE_DSTATE: tl.constexpr,
+):
+    pid_m = tl.program_id(axis=0)
+    pid_b = tl.program_id(axis=1)
+    pid_h = tl.program_id(axis=2)
+    state_batch_idx = tl.load(
+        state_batch_indices_ptr + pid_b * stride_state_indices_batch
+    ).to(tl.int64)
+    if state_batch_idx == null_block_id:
+        return
+    if tl.load(is_flush_flags_ptr + state_batch_idx) != 0:
+        return
+    bos = tl.load(query_start_loc_ptr + pid_b).to(tl.int64)
+    eos = tl.load(query_start_loc_ptr + pid_b + 1).to(tl.int64)
+    spec_len = (eos - bos).to(tl.int32)
+    write_pos = tl.load(write_pos_ptr + state_batch_idx).to(tl.int32)
+    post_origin = tl.load(post_origin_ptr + state_batch_idx).to(tl.int32)
+
+    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_k = tl.arange(0, BLOCK_SIZE_CACHE)
+    offs_s = tl.arange(0, BLOCK_SIZE_SPEC)
+    offs_nt = tl.arange(0, DSTATE_TILE)
+    spec_valid_mask = offs_s < spec_len
+    hist_mask = offs_k < write_pos
+    cache_valid_mask = (offs_k < max_cache_len) & (offs_k < (write_pos + spec_len))
+    spec_token_mask = (offs_k >= write_pos) & (offs_k < (write_pos + spec_len))
+    spec_cache_pos = write_pos + offs_s
+    spec_prefix_mask = (
+        spec_valid_mask[:, None]
+        & spec_token_mask[None, :]
+        & (offs_k[None, :] <= spec_cache_pos[:, None])
+    )
+    phys_k = (post_origin + offs_k) & (CACHE_BUF_LEN - 1)
+    phys_spec = (post_origin + spec_cache_pos) & (CACHE_BUF_LEN - 1)
+
+    state_ptr += state_batch_idx * stride_state_batch + pid_h * stride_state_head
+    x_cache_ptr += state_batch_idx * stride_x_cache_batch + pid_h * stride_x_cache_head
+    dt_cache_ptr += (
+        state_batch_idx * stride_dt_cache_batch + pid_h * stride_dt_cache_head
+    )
+    C_src_ptr += (
+        bos * stride_C_src_tok
+        + (pid_h // nheads_ngroups_ratio) * dstate * stride_C_src_c
+    )
+    bc_pre_ptr += (
+        pid_b * stride_bc_pre_batch
+        + (pid_h // nheads_ngroups_ratio) * stride_bc_pre_group
+    )
+    if HAS_D:
+        D_ptr += pid_h * stride_D_head
+    if HAS_Z:
+        z_ptr += bos * stride_z_tok + pid_h * stride_z_head
+    if HAS_DT_BIAS:
+        dt_bias_ptr += pid_h * stride_dt_bias_head
+    A_ptr += pid_h * stride_A_head
+    out_ptr += bos * stride_out_tok + pid_h * stride_out_head
+    A_val = tl.load(A_ptr).to(tl.float32)
+    dt_bias_val = tl.load(dt_bias_ptr).to(tl.float32) if HAS_DT_BIAS else 0.0
+
+    # dt over the window (+ bias / softplus), then the per-draft decay weights.
+    dt_blk = tl.load(
+        dt_cache_ptr + phys_k * stride_dt_cache_pos, mask=cache_valid_mask, other=0.0
+    ).to(tl.float32)
+    dt_blk = tl.where(cache_valid_mask, dt_blk, 0.0)
+    if HAS_DT_BIAS:
+        dt_blk = tl.where(cache_valid_mask, dt_blk + dt_bias_val, 0.0)
+    if DT_SOFTPLUS:
+        dt_blk = tl.where(
+            cache_valid_mask, tl.where(dt_blk <= 20.0, softplus(dt_blk), dt_blk), 0.0
+        )
+    dt_cum = tl.cumsum(dt_blk, axis=0)
+    hist_total = tl.sum(tl.where(hist_mask, dt_blk, 0.0), axis=0)
+    spec_cum = tl.sum(tl.where(spec_prefix_mask, dt_blk[None, :], 0.0), axis=1)
+    spec_cum = tl.where(spec_valid_mask, spec_cum, 0.0)
+    spec_total = hist_total + spec_cum
+    checkpoint_decay = tl.where(
+        spec_valid_mask, tl.exp(tl.minimum(A_val * spec_total, 0.0)), 0.0
+    )
+
+    # Causal weighted sum over cached values: spec_contrib = x_cache @ factor.
+    x_blk = tl.load(
+        x_cache_ptr
+        + phys_k[None, :] * stride_x_cache_pos
+        + offs_m[:, None] * stride_x_cache_dim,
+        mask=(offs_m[:, None] < dim) & cache_valid_mask[None, :],
+        other=0.0,
+    )
+    x_ty = x_blk.to(x_cache_ptr.dtype.element_ty)
+    bc = tl.load(
+        bc_pre_ptr
+        + offs_k[:, None] * stride_bc_pre_pos
+        + offs_s[None, :] * stride_bc_pre_spec,
+        mask=cache_valid_mask[:, None] & spec_valid_mask[None, :],
+        other=0.0,
+    ).to(tl.float32)
+    spec_scale = dt_blk[:, None] * tl.exp(
+        tl.minimum(A_val * (spec_total[None, :] - dt_cum[:, None]), 0.0)
+    )
+    causal = (
+        spec_valid_mask[None, :]
+        & cache_valid_mask[:, None]
+        & (offs_k[:, None] <= spec_cache_pos[None, :])
+    )
+    factor = tl.where(causal, bc * spec_scale, 0.0)
+    spec_contrib = tl.dot(
+        x_ty, factor.to(x_cache_ptr.dtype.element_ty), input_precision="tf32x3"
+    ).to(tl.float32)
+
+    # Decayed checkpoint readout S_0 @ C, dstate-tiled. tf32x3 keeps fp32-act
+    # parity; bf16 act uses single-pass tf32 (the flag is a no-op on bf16 inputs).
+    checkpoint_out = tl.zeros([BLOCK_SIZE_M, BLOCK_SIZE_SPEC], dtype=tl.float32)
+    for i in tl.static_range(NDS):
+        offs_n = i * DSTATE_TILE + offs_nt
+        nmask = offs_n < dstate
+        st = tl.load(
+            state_ptr
+            + offs_m[:, None] * stride_state_dim
+            + offs_n[None, :] * stride_state_dstate,
+            mask=(offs_m[:, None] < dim) & nmask[None, :],
+            other=0.0,
+        ).to(tl.float32)
+        c_mask = spec_valid_mask[:, None] & nmask[None, :]
+        c_chunk = tl.load(
+            C_src_ptr
+            + offs_s[:, None] * stride_C_src_tok
+            + offs_n[None, :] * stride_C_src_c,
+            mask=c_mask,
+            other=0.0,
+        ).to(tl.float32)
+        if x_cache_ptr.dtype.element_ty == tl.float32:
+            checkpoint_out += tl.dot(
+                st, tl.trans(c_chunk), input_precision="tf32x3"
+            ).to(tl.float32)
+        else:
+            checkpoint_out += tl.dot(st, tl.trans(c_chunk), input_precision="tf32").to(
+                tl.float32
+            )
+    checkpoint_out *= checkpoint_decay[None, :]
+    out = tl.trans(checkpoint_out + spec_contrib)
+
+    if HAS_D:
+        x_spec_sm = tl.load(
+            x_cache_ptr
+            + offs_m[None, :] * stride_x_cache_dim
+            + phys_spec[:, None] * stride_x_cache_pos,
+            mask=spec_valid_mask[:, None] & (offs_m[None, :] < dim),
+            other=0.0,
+        ).to(tl.float32)
+        D_val = tl.load(D_ptr + offs_m * stride_D_dim, mask=offs_m < dim, other=0.0).to(
+            tl.float32
+        )
+        out += x_spec_sm * D_val[None, :]
+    if HAS_Z:
+        z_val = tl.load(
+            z_ptr + offs_s[:, None] * stride_z_tok + offs_m[None, :] * stride_z_dim,
+            mask=spec_valid_mask[:, None] & (offs_m[None, :] < dim),
+            other=0.0,
+        ).to(tl.float32)
+        out *= z_val * tl.sigmoid(z_val)
+    out = tl.where(spec_valid_mask[:, None], out, 0.0)
+    tl.store(
+        out_ptr + offs_s[:, None] * stride_out_tok + offs_m[None, :] * stride_out_dim,
+        out,
+        mask=spec_valid_mask[:, None] & (offs_m[None, :] < dim),
+    )
+
+
+# ======================================================================
+# Flush launch (flush rows): reconstruct the committed-history state S_1, store
+# it as the checkpoint, and read the output via S_1 + the intra-spec window.
+# Non-flush rows early-exit. dstate-tiled.
+# ======================================================================
+@triton.heuristics({"HAS_DT_BIAS": lambda args: args["dt_bias_ptr"] is not None})
+@triton.heuristics({"HAS_D": lambda args: args["D_ptr"] is not None})
+@triton.heuristics({"HAS_Z": lambda args: args["z_ptr"] is not None})
+@triton.heuristics(
+    {"BLOCK_SIZE_DSTATE": lambda args: triton.next_power_of_2(args["dstate"])}
+)
+@triton.jit
+def _replayssm_spec_fl_kernel(
+    state_ptr,
+    x_cache_ptr,
+    dt_cache_ptr,
+    B_cache_ptr,
+    C_src_ptr,
+    bc_pre_ptr,
+    D_ptr,
+    z_ptr,
+    dt_bias_ptr,
+    A_ptr,
+    out_ptr,
+    is_flush_flags_ptr,
+    write_pos_ptr,
+    post_origin_ptr,
+    state_batch_indices_ptr,
+    query_start_loc_ptr,
+    null_block_id,
+    batch,
+    nheads,
+    dim,
+    dstate,
+    max_cache_len,
+    nheads_ngroups_ratio,
+    stride_state_batch,
+    stride_state_head,
+    stride_state_dim,
+    stride_state_dstate,
+    stride_x_cache_batch,
+    stride_x_cache_head,
+    stride_x_cache_dim,
+    stride_x_cache_pos,
+    stride_dt_cache_batch,
+    stride_dt_cache_head,
+    stride_dt_cache_pos,
+    stride_B_cache_batch,
+    stride_B_cache_group,
+    stride_B_cache_dstate,
+    stride_B_cache_pos,
+    stride_C_src_tok,
+    stride_C_src_c,
+    stride_bc_pre_batch,
+    stride_bc_pre_group,
+    stride_bc_pre_pos,
+    stride_bc_pre_spec,
+    stride_D_head,
+    stride_D_dim,
+    stride_z_tok,
+    stride_z_head,
+    stride_z_dim,
+    stride_dt_bias_head,
+    stride_A_head,
+    stride_out_tok,
+    stride_out_head,
+    stride_out_dim,
+    stride_state_indices_batch,
+    DT_SOFTPLUS: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_CACHE: tl.constexpr,
+    BLOCK_SIZE_SPEC: tl.constexpr,
+    HAS_DT_BIAS: tl.constexpr,
+    HAS_D: tl.constexpr,
+    HAS_Z: tl.constexpr,
+    CACHE_BUF_LEN: tl.constexpr,
+    DSTATE_TILE: tl.constexpr,
+    NDS: tl.constexpr,
+    BLOCK_SIZE_DSTATE: tl.constexpr,
+):
+    pid_m = tl.program_id(axis=0)
+    pid_b = tl.program_id(axis=1)
+    pid_h = tl.program_id(axis=2)
+    state_batch_idx = tl.load(
+        state_batch_indices_ptr + pid_b * stride_state_indices_batch
+    ).to(tl.int64)
+    if state_batch_idx == null_block_id:
+        return
+    if tl.load(is_flush_flags_ptr + state_batch_idx) == 0:
+        return
+    bos = tl.load(query_start_loc_ptr + pid_b).to(tl.int64)
+    eos = tl.load(query_start_loc_ptr + pid_b + 1).to(tl.int64)
+    spec_len = (eos - bos).to(tl.int32)
+    write_pos = tl.load(write_pos_ptr + state_batch_idx).to(tl.int32)
+    post_origin = tl.load(post_origin_ptr + state_batch_idx).to(tl.int32)
+
+    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_k = tl.arange(0, BLOCK_SIZE_CACHE)
+    offs_s = tl.arange(0, BLOCK_SIZE_SPEC)
+    offs_nt = tl.arange(0, DSTATE_TILE)
+    spec_valid_mask = offs_s < spec_len
+    spec_cache_pos = write_pos + offs_s
+    phys_spec = (post_origin + spec_cache_pos) & (CACHE_BUF_LEN - 1)
+    hist_mask = offs_k < write_pos
+    phys_h = (post_origin + offs_k) & (CACHE_BUF_LEN - 1)
+
+    state_ptr += state_batch_idx * stride_state_batch + pid_h * stride_state_head
+    x_cache_ptr += state_batch_idx * stride_x_cache_batch + pid_h * stride_x_cache_head
+    dt_cache_ptr += (
+        state_batch_idx * stride_dt_cache_batch + pid_h * stride_dt_cache_head
+    )
+    B_cache_ptr += (
+        state_batch_idx * stride_B_cache_batch
+        + (pid_h // nheads_ngroups_ratio) * stride_B_cache_group
+    )
+    C_src_ptr += (
+        bos * stride_C_src_tok
+        + (pid_h // nheads_ngroups_ratio) * dstate * stride_C_src_c
+    )
+    bc_pre_ptr += (
+        pid_b * stride_bc_pre_batch
+        + (pid_h // nheads_ngroups_ratio) * stride_bc_pre_group
+    )
+    if HAS_D:
+        D_ptr += pid_h * stride_D_head
+    if HAS_Z:
+        z_ptr += bos * stride_z_tok + pid_h * stride_z_head
+    if HAS_DT_BIAS:
+        dt_bias_ptr += pid_h * stride_dt_bias_head
+    A_ptr += pid_h * stride_A_head
+    out_ptr += bos * stride_out_tok + pid_h * stride_out_head
+    A_val = tl.load(A_ptr).to(tl.float32)
+    dt_bias_val = tl.load(dt_bias_ptr).to(tl.float32) if HAS_DT_BIAS else 0.0
+
+    # History decay (for the S_1 reconstruction) and spec-prefix decay (output).
+    dt_h = tl.load(
+        dt_cache_ptr + phys_h * stride_dt_cache_pos, mask=hist_mask, other=0.0
+    ).to(tl.float32)
+    dt_h = tl.where(hist_mask, dt_h, 0.0)
+    if HAS_DT_BIAS:
+        dt_h = tl.where(hist_mask, dt_h + dt_bias_val, 0.0)
+    if DT_SOFTPLUS:
+        dt_h = tl.where(hist_mask, tl.where(dt_h <= 20.0, softplus(dt_h), dt_h), 0.0)
+    hist_cum = tl.cumsum(dt_h, axis=0)
+    hist_total = tl.sum(dt_h, axis=0)
+    hist_decay = tl.exp(tl.minimum(A_val * hist_total, 0.0))
+    hist_scale = tl.where(
+        hist_mask, dt_h * tl.exp(tl.minimum(A_val * (hist_total - hist_cum), 0.0)), 0.0
+    )
+    dt_s = tl.load(
+        dt_cache_ptr + phys_spec * stride_dt_cache_pos, mask=spec_valid_mask, other=0.0
+    ).to(tl.float32)
+    dt_s = tl.where(spec_valid_mask, dt_s, 0.0)
+    if HAS_DT_BIAS:
+        dt_s = tl.where(spec_valid_mask, dt_s + dt_bias_val, 0.0)
+    if DT_SOFTPLUS:
+        dt_s = tl.where(
+            spec_valid_mask, tl.where(dt_s <= 20.0, softplus(dt_s), dt_s), 0.0
+        )
+    spec_cum = tl.cumsum(dt_s, axis=0)
+    spec_decay = tl.where(
+        spec_valid_mask, tl.exp(tl.minimum(A_val * spec_cum, 0.0)), 0.0
+    )
+    x_hist = tl.load(
+        x_cache_ptr
+        + phys_h[None, :] * stride_x_cache_pos
+        + offs_m[:, None] * stride_x_cache_dim,
+        mask=(offs_m[:, None] < dim) & hist_mask[None, :],
+        other=0.0,
+    )
+    x_hist_ty = x_hist.to(x_cache_ptr.dtype.element_ty)
+
+    # Reconstruct S_1 = S_0 * hist_decay + (x_hist @ scaled B_hist), store it, and
+    # accumulate the checkpoint readout S_1 @ C. dstate-tiled.
+    checkpoint_out = tl.zeros([BLOCK_SIZE_M, BLOCK_SIZE_SPEC], dtype=tl.float32)
+    for i in tl.static_range(NDS):
+        offs_n = i * DSTATE_TILE + offs_nt
+        nmask = offs_n < dstate
+        B_block = tl.load(
+            B_cache_ptr
+            + phys_h[:, None] * stride_B_cache_pos
+            + offs_n[None, :] * stride_B_cache_dstate,
+            mask=hist_mask[:, None] & nmask[None, :],
+            other=0.0,
+        )
+        B_hist_scaled = (
+            tl.where(hist_mask[:, None], B_block.to(tl.float32), 0.0)
+            * hist_scale[:, None]
+        ).to(x_cache_ptr.dtype.element_ty)
+        delta = tl.dot(x_hist_ty, B_hist_scaled, input_precision="tf32x3").to(
+            tl.float32
+        )
+        st_ptrs = (
+            state_ptr
+            + offs_m[:, None] * stride_state_dim
+            + offs_n[None, :] * stride_state_dstate
+        )
+        st = tl.load(st_ptrs, mask=(offs_m[:, None] < dim) & nmask[None, :], other=0.0)
+        S1 = st.to(tl.float32) * hist_decay + delta
+        if write_pos > 0:
+            tl.store(
+                st_ptrs, S1.to(st.dtype), mask=(offs_m[:, None] < dim) & nmask[None, :]
+            )
+        c_mask = spec_valid_mask[:, None] & nmask[None, :]
+        c_chunk = tl.load(
+            C_src_ptr
+            + offs_s[:, None] * stride_C_src_tok
+            + offs_n[None, :] * stride_C_src_c,
+            mask=c_mask,
+            other=0.0,
+        ).to(tl.float32)
+        if x_cache_ptr.dtype.element_ty == tl.float32:
+            checkpoint_out += tl.dot(
+                S1, tl.trans(c_chunk), input_precision="tf32x3"
+            ).to(tl.float32)
+        else:
+            checkpoint_out += tl.dot(S1, tl.trans(c_chunk), input_precision="tf32").to(
+                tl.float32
+            )
+    checkpoint_out *= spec_decay[None, :]
+
+    # Intra-spec window contribution: intra = x_spec @ factor_intra (causal T x T).
+    bc_spec = tl.load(
+        bc_pre_ptr
+        + (write_pos + offs_k)[:, None] * stride_bc_pre_pos
+        + offs_s[None, :] * stride_bc_pre_spec,
+        mask=(offs_k[:, None] < spec_len) & spec_valid_mask[None, :],
+        other=0.0,
+    ).to(tl.float32)
+    dt_k = tl.load(
+        dt_cache_ptr
+        + ((post_origin + write_pos + offs_k) & (CACHE_BUF_LEN - 1))
+        * stride_dt_cache_pos,
+        mask=offs_k < spec_len,
+        other=0.0,
+    ).to(tl.float32)
+    dt_k = tl.where(offs_k < spec_len, dt_k, 0.0)
+    if HAS_DT_BIAS:
+        dt_k = tl.where(offs_k < spec_len, dt_k + dt_bias_val, 0.0)
+    if DT_SOFTPLUS:
+        dt_k = tl.where(
+            offs_k < spec_len, tl.where(dt_k <= 20.0, softplus(dt_k), dt_k), 0.0
+        )
+    speccum_k = tl.cumsum(dt_k, axis=0)
+    causal = (
+        (offs_k[:, None] < spec_len)
+        & spec_valid_mask[None, :]
+        & (offs_k[:, None] <= offs_s[None, :])
+    )
+    decay_ks = tl.exp(tl.minimum(A_val * (spec_cum[None, :] - speccum_k[:, None]), 0.0))
+    factor_intra = tl.where(causal, bc_spec * dt_k[:, None] * decay_ks, 0.0)
+    x_src = tl.load(
+        x_cache_ptr
+        + ((post_origin + write_pos + offs_k)[None, :] & (CACHE_BUF_LEN - 1))
+        * stride_x_cache_pos
+        + offs_m[:, None] * stride_x_cache_dim,
+        mask=(offs_m[:, None] < dim) & (offs_k[None, :] < spec_len),
+        other=0.0,
+    ).to(x_cache_ptr.dtype.element_ty)
+    intra = tl.dot(
+        x_src, factor_intra.to(x_cache_ptr.dtype.element_ty), input_precision="tf32x3"
+    ).to(tl.float32)
+    out = tl.trans(checkpoint_out + intra)
+
+    if HAS_D:
+        x_spec_sm = tl.load(
+            x_cache_ptr
+            + offs_m[None, :] * stride_x_cache_dim
+            + phys_spec[:, None] * stride_x_cache_pos,
+            mask=spec_valid_mask[:, None] & (offs_m[None, :] < dim),
+            other=0.0,
+        ).to(tl.float32)
+        D_val = tl.load(D_ptr + offs_m * stride_D_dim, mask=offs_m < dim, other=0.0).to(
+            tl.float32
+        )
+        out += x_spec_sm * D_val[None, :]
+    if HAS_Z:
+        z_val = tl.load(
+            z_ptr + offs_s[:, None] * stride_z_tok + offs_m[None, :] * stride_z_dim,
+            mask=spec_valid_mask[:, None] & (offs_m[None, :] < dim),
+            other=0.0,
+        ).to(tl.float32)
+        out *= z_val * tl.sigmoid(z_val)
+    out = tl.where(spec_valid_mask[:, None], out, 0.0)
+    tl.store(
+        out_ptr + offs_s[:, None] * stride_out_tok + offs_m[None, :] * stride_out_dim,
+        out,
+        mask=spec_valid_mask[:, None] & (offs_m[None, :] < dim),
+    )
+
+
+@triton.jit
+def _advance_write_pos_origin_kernel(
+    write_pos_ptr,
+    post_origin_ptr,
+    is_flush_ptr,
+    num_accepted_ptr,
+    state_batch_indices_ptr,
+    null_block_id,
+    batch,
+    stride_state_indices_batch,
+    MAX_CACHE_LEN: tl.constexpr,
+    MAX_SPEC_LEN: tl.constexpr,
+    CACHE_BUF_LEN: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offs = tl.arange(0, BLOCK_SIZE)
+    row_mask = offs < batch
+    state_batch_idx = tl.load(
+        state_batch_indices_ptr + offs * stride_state_indices_batch,
+        mask=row_mask,
+        other=null_block_id,
+    ).to(tl.int64)
+    valid = row_mask & (state_batch_idx != null_block_id)
+    write_pos = tl.load(write_pos_ptr + state_batch_idx, mask=valid, other=0).to(
+        tl.int32
+    )
+    post_origin = tl.load(post_origin_ptr + state_batch_idx, mask=valid, other=0).to(
+        tl.int32
+    )
+    is_flush_cur = tl.load(is_flush_ptr + state_batch_idx, mask=valid, other=0).to(
+        tl.int32
+    )
+    num_accepted = tl.load(num_accepted_ptr + offs, mask=valid, other=0).to(tl.int32)
+    total_commit = tl.where(valid, num_accepted, 0).to(tl.int32)
+    flush_now = (total_commit > 0) & (is_flush_cur != 0)
+    new_origin = tl.where(
+        flush_now, (post_origin + write_pos) & (CACHE_BUF_LEN - 1), post_origin
+    ).to(tl.int32)
+    new_wp = tl.where(
+        total_commit <= 0,
+        write_pos,
+        tl.where(is_flush_cur != 0, total_commit, write_pos + total_commit),
+    ).to(tl.int32)
+    # Early-flush one window early so every verify step satisfies
+    # write_pos + spec_len <= max_cache_len (the spec window never overflows).
+    next_is_flush = ((new_wp + 2 * MAX_SPEC_LEN) > MAX_CACHE_LEN).to(tl.int8)
+    tl.store(post_origin_ptr + state_batch_idx, new_origin, mask=valid)
+    tl.store(write_pos_ptr + state_batch_idx, new_wp, mask=valid)
+    tl.store(is_flush_ptr + state_batch_idx, next_is_flush, mask=valid)
+
+
+@triton.jit
+def _reset_replayssm_spec_cursors_kernel(
+    write_pos_ptr,
+    post_origin_ptr,
+    is_flush_ptr,
+    first_decode_ptr,  # (batch,) int8 mask
+    force_flush_ptr,  # (batch,) int8 mask, subset of first_decode
+    state_batch_indices_ptr,
+    null_block_id,
+    batch,
+    stride_state_indices_batch,
+    INIT_IS_FLUSH: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offs = tl.arange(0, BLOCK_SIZE)
+    row_mask = offs < batch
+    state_batch_idx = tl.load(
+        state_batch_indices_ptr + offs * stride_state_indices_batch,
+        mask=row_mask,
+        other=null_block_id,
+    ).to(tl.int64)
+    first = tl.load(first_decode_ptr + offs, mask=row_mask, other=0).to(tl.int32)
+    force_flush = tl.load(force_flush_ptr + offs, mask=row_mask, other=0).to(tl.int32)
+    do_reset = row_mask & (state_batch_idx != null_block_id) & (first != 0)
+    tl.store(
+        write_pos_ptr + state_batch_idx,
+        tl.zeros_like(state_batch_idx).to(tl.int32),
+        mask=do_reset,
+    )
+    tl.store(
+        post_origin_ptr + state_batch_idx,
+        tl.zeros_like(state_batch_idx).to(tl.int32),
+        mask=do_reset,
+    )
+    # A leftover single-token prompt chunk must flush this step: it appends one
+    # token to a freshly emptied ring, and without the flush the checkpoint never
+    # advances past it, so the next step's reset would drop that token.
+    init_flag = tl.zeros_like(state_batch_idx).to(tl.int32) + INIT_IS_FLUSH
+    tl.store(
+        is_flush_ptr + state_batch_idx,
+        tl.where(force_flush != 0, 1, init_flag).to(tl.int8),
+        mask=do_reset,
+    )
+
+
+def selective_state_update_replayssm_spec(
+    state_checkpoint: torch.Tensor,  # (num_blocks, H, P, N) checkpoint (flush updates in place)
+    post_conv_cache: torch.Tensor,  # (num_blocks, cache_buf_len, conv_dim) circular
+    dt_cache: torch.Tensor,  # (num_blocks, H, cache_buf_len) circular
+    conv_out: torch.Tensor,  # (total_tokens, conv_dim) packed channel-last post-conv
+    dt_spec: torch.Tensor,  # (total_tokens, H) packed raw dt
+    A: torch.Tensor,  # (H, P, N) TIE_HDIM (A.stride(-1)==A.stride(-2)==0)
+    write_pos: torch.Tensor,  # (num_state_slots,) int32 block-keyed cursor
+    post_conv_state_pos: torch.Tensor,  # (num_state_slots,) int32 circular origin
+    is_flush: torch.Tensor,  # (num_state_slots,) int8 block-keyed flag
+    query_start_loc: torch.Tensor,  # (batch + 1,) int32 packed offsets
+    state_batch_indices: torch.Tensor,  # (batch,) int32 physical block per row
+    max_cache_len: int,  # logical flush threshold L = B + max_spec_len
+    max_spec_len: int,
+    d_inner: int,
+    ngroups: int,
+    dstate: int,
+    D: torch.Tensor | None = None,
+    z: torch.Tensor | None = None,
+    dt_bias: torch.Tensor | None = None,
+    dt_softplus: bool = True,
+    out: torch.Tensor | None = None,
+    bc_pre: torch.Tensor | None = None,
+    null_block_id: int = NULL_BLOCK_ID,
+) -> torch.Tensor:
+    """One Mamba2 speculative verify step on the paged CIRCULAR post-conv cache.
+
+    Hybrid conv variant: ``conv_out`` is the post-conv output of vLLM's
+    ``causal_conv1d_update`` (packed channel-last ``[total_tokens, conv_dim]``).
+    ``max_cache_len`` is the logical flush threshold L = B + max_spec_len; the
+    physical pow2 buffer (= ``post_conv_cache.shape[1]`` = ``next_pow2(L)``) wraps
+    the ring, while the history/cache tile is ``next_pow2(L - max_spec_len)``.
+    Fuses scatter + bc-precompute in one ``(batch, ngroups)`` launch, then runs
+    two dedicated launches (verify + flush) with device-side row routing. Cursors
+    are block-keyed and advanced once per step by ``commit_replayssm_spec``.
+    """
+    num_blocks, nheads, dim, n_state = state_checkpoint.shape
+    assert n_state == dstate
+    total_tokens, conv_dim = conv_out.shape
+    buf = post_conv_cache.shape[1]
+    cache_buf_len = buf
+    assert cache_buf_len & (cache_buf_len - 1) == 0, (
+        "cache_buf_len must be a power of two"
+    )
+    assert d_inner == nheads * dim
+    cache_conv_dim = d_inner + ngroups * dstate  # x|B only (no C)
+    assert post_conv_cache.shape == (num_blocks, buf, cache_conv_dim)
+    assert dt_cache.shape == (num_blocks, nheads, buf)
+    assert dt_spec.shape == (total_tokens, nheads)
+    assert A.shape == (nheads, dim, dstate) and A.stride(-1) == 0 and A.stride(-2) == 0
+    batch = state_batch_indices.shape[0]
+    assert query_start_loc.shape[0] == batch + 1
+
+    if out is None:
+        out = torch.empty(
+            total_tokens, nheads, dim, device=conv_out.device, dtype=conv_out.dtype
+        )
+    if total_tokens == 0:
+        return out
+
+    L = max_cache_len
+    base_block = max(1, L - max_spec_len)
+    main_block = max(16, triton.next_power_of_2(base_block))  # history/cache tile
+    block_spec = max(1, triton.next_power_of_2(max_spec_len))
+    pre_block = max(16, triton.next_power_of_2(L))  # precompute window tile
+    block_dstate = triton.next_power_of_2(dstate)
+
+    bsm_v, nw_v, dt_v, ns_v = get_replayssm_config(
+        "mamba2_spec_verify", dstate=dstate, base_block=base_block
+    )
+    bsm_f, nw_f, dt_f, ns_f = get_replayssm_config(
+        "mamba2_spec_flush", dstate=dstate, base_block=base_block
+    )
+    dt_v = max(16, min(dt_v, block_dstate))
+    nds_v = triton.cdiv(block_dstate, dt_v)
+    dt_f = max(16, min(dt_f, block_dstate))
+    nds_f = triton.cdiv(block_dstate, dt_f)
+
+    if bc_pre is None:
+        bc_pre = torch.empty(
+            batch,
+            ngroups,
+            buf,
+            block_spec,
+            device=conv_out.device,
+            dtype=conv_out.dtype,
+        )
+    else:
+        # The kernels index bc_pre with its raw strides on a (batch, ngroups)
+        # grid; an under-sized group dim aliases across rows (races / OOB).
+        assert (
+            bc_pre.shape[0] >= batch
+            and bc_pre.shape[1] == ngroups
+            and bc_pre.shape[2] >= L
+            and bc_pre.shape[3] >= block_spec
+        ), (
+            f"bc_pre shape {tuple(bc_pre.shape)} incompatible with "
+            f"(batch={batch}, ngroups={ngroups}, L={L}, block_spec={block_spec})"
+        )
+    sis = state_batch_indices.stride(0)
+
+    # --- fused scatter + precompute (full-window bc over [0, L)) ---
+    ratio = nheads // ngroups
+    ratio_p = ratio * dim
+    BLOCK_CX = 256
+    NCX = triton.cdiv(ratio_p, BLOCK_CX)
+    block_hl = max(1, triton.next_power_of_2(ratio))
+    with torch.accelerator.device_index(conv_out.device.index):
+        _fused_scatter_precompute_kernel[(batch, ngroups)](
+            conv_out,
+            dt_spec,
+            post_conv_cache,
+            dt_cache,
+            write_pos,
+            post_conv_state_pos,
+            bc_pre,
+            state_batch_indices,
+            query_start_loc,
+            null_block_id,
+            batch,
+            ngroups,
+            nheads,
+            dstate,
+            d_inner,
+            conv_dim,
+            L,
+            conv_out.stride(0),
+            conv_out.stride(1),
+            dt_spec.stride(0),
+            dt_spec.stride(1),
+            post_conv_cache.stride(0),
+            post_conv_cache.stride(1),
+            post_conv_cache.stride(2),
+            dt_cache.stride(0),
+            dt_cache.stride(1),
+            dt_cache.stride(2),
+            bc_pre.stride(0),
+            bc_pre.stride(1),
+            bc_pre.stride(2),
+            bc_pre.stride(3),
+            sis,
+            RATIO=ratio,
+            RATIO_P=ratio_p,
+            NCX=NCX,
+            BLOCK_CX=BLOCK_CX,
+            CACHE_BUF_LEN=cache_buf_len,
+            BLOCK_SIZE_CACHE=pre_block,
+            BLOCK_SIZE_SPEC=block_spec,
+            BLOCK_HL=block_hl,
+            num_warps=4,
+        )
+
+    # views into the paged circular post-conv cache: x | B | C on the channel axis
+    x_view = (
+        post_conv_cache[:, :, :d_inner]
+        .view(num_blocks, buf, nheads, dim)
+        .permute(0, 2, 1, 3)
+    )
+    B_view = (
+        post_conv_cache[:, :, d_inner : d_inner + ngroups * dstate]
+        .view(num_blocks, buf, ngroups, dstate)
+        .permute(0, 2, 1, 3)
+    )
+    # C is not cached; the kernels read it fresh from this conv_out slice.
+    C_src = conv_out[:, d_inner + ngroups * dstate :]
+    z_strides = (z.stride(0), z.stride(1), z.stride(2)) if z is not None else (0, 0, 0)
+
+    def _args(bsm):
+        grid = lambda META: (triton.cdiv(dim, META["BLOCK_SIZE_M"]), batch, nheads)
+        return grid, (
+            state_checkpoint,
+            x_view,
+            dt_cache,
+            B_view,
+            C_src,
+            bc_pre,
+            D,
+            z,
+            dt_bias,
+            A,
+            out,
+            is_flush,
+            write_pos,
+            post_conv_state_pos,
+            state_batch_indices,
+            query_start_loc,
+            null_block_id,
+            batch,
+            nheads,
+            dim,
+            dstate,
+            L,
+            ratio,
+            state_checkpoint.stride(0),
+            state_checkpoint.stride(1),
+            state_checkpoint.stride(2),
+            state_checkpoint.stride(3),
+            x_view.stride(0),
+            x_view.stride(1),
+            x_view.stride(3),
+            x_view.stride(2),
+            dt_cache.stride(0),
+            dt_cache.stride(1),
+            dt_cache.stride(2),
+            B_view.stride(0),
+            B_view.stride(1),
+            B_view.stride(3),
+            B_view.stride(2),
+            C_src.stride(0),
+            C_src.stride(1),
+            bc_pre.stride(0),
+            bc_pre.stride(1),
+            bc_pre.stride(2),
+            bc_pre.stride(3),
+            D.stride(0) if D is not None else 0,
+            D.stride(1) if D is not None else 0,
+            z_strides[0],
+            z_strides[1],
+            z_strides[2],
+            dt_bias.stride(0) if dt_bias is not None else 0,
+            A.stride(0),
+            out.stride(0),
+            out.stride(1),
+            out.stride(2),
+            sis,
+            dt_softplus,
+            bsm,
+        )
+
+    with torch.accelerator.device_index(state_checkpoint.device.index):
+        grid, base = _args(bsm_v)
+        _replayssm_spec_nf_kernel[grid](
+            *base,
+            main_block,
+            block_spec,
+            CACHE_BUF_LEN=cache_buf_len,
+            DSTATE_TILE=dt_v,
+            NDS=nds_v,
+            num_warps=nw_v,
+            num_stages=ns_v,
+        )
+        grid, base = _args(bsm_f)
+        _replayssm_spec_fl_kernel[grid](
+            *base,
+            main_block,
+            block_spec,
+            CACHE_BUF_LEN=cache_buf_len,
+            DSTATE_TILE=dt_f,
+            NDS=nds_f,
+            num_warps=nw_f,
+            num_stages=ns_f,
+        )
+    return out
+
+
+def commit_replayssm_spec(
+    write_pos: torch.Tensor,
+    post_conv_state_pos: torch.Tensor,
+    is_flush: torch.Tensor,
+    num_accepted_tokens: torch.Tensor,  # (batch,) int32, INCLUDES bonus (min 1)
+    state_batch_indices: torch.Tensor,  # (batch,) int32
+    max_cache_len: int,  # logical flush threshold L
+    max_spec_len: int,
+    cache_buf_len: int | None = None,  # physical pow2 buffer next_pow2(L)
+    null_block_id: int = NULL_BLOCK_ID,
+) -> None:
+    """CUDA-graph-safe block-keyed commit. Advances ``write_pos`` and the circular
+    origin (flush = O(1) bump) per decode row, and precomputes next-step
+    ``is_flush``. Maps vLLM ``num_accepted_tokens`` (incl. bonus) to the commit."""
+    batch = state_batch_indices.shape[0]
+    if cache_buf_len is None:
+        cache_buf_len = max(1, triton.next_power_of_2(max_cache_len))
+    BLOCK = max(1, triton.next_power_of_2(batch))
+    with torch.accelerator.device_index(write_pos.device.index):
+        _advance_write_pos_origin_kernel[(1,)](
+            write_pos,
+            post_conv_state_pos,
+            is_flush,
+            num_accepted_tokens,
+            state_batch_indices,
+            null_block_id,
+            batch,
+            state_batch_indices.stride(0),
+            MAX_CACHE_LEN=max_cache_len,
+            MAX_SPEC_LEN=max_spec_len,
+            CACHE_BUF_LEN=cache_buf_len,
+            BLOCK_SIZE=BLOCK,
+            num_warps=1,
+        )
+
+
+def reset_replayssm_spec_cursors(
+    write_pos: torch.Tensor,
+    post_conv_state_pos: torch.Tensor,
+    is_flush: torch.Tensor,
+    first_decode_mask: torch.Tensor,  # (batch,) int8
+    state_batch_indices: torch.Tensor,  # (batch,) int32
+    max_cache_len: int,  # logical flush threshold L
+    max_spec_len: int,
+    force_flush_mask: torch.Tensor | None = None,  # (batch,) int8, subset of first
+    null_block_id: int = NULL_BLOCK_ID,
+) -> None:
+    """Prefill->decode reset for first-decode rows (block-keyed). Seeds the
+    initial ``is_flush`` to match the steady-state early-flush cadence, or to 1
+    for rows in ``force_flush_mask``."""
+    batch = state_batch_indices.shape[0]
+    BLOCK = max(1, triton.next_power_of_2(batch))
+    init_is_flush = 1 if 2 * max_spec_len > max_cache_len else 0
+    if force_flush_mask is None:
+        force_flush_mask = torch.zeros_like(first_decode_mask)
+    with torch.accelerator.device_index(write_pos.device.index):
+        _reset_replayssm_spec_cursors_kernel[(1,)](
+            write_pos,
+            post_conv_state_pos,
+            is_flush,
+            first_decode_mask,
+            force_flush_mask,
+            state_batch_indices,
+            null_block_id,
+            batch,
+            state_batch_indices.stride(0),
+            INIT_IS_FLUSH=init_is_flush,
+            BLOCK_SIZE=BLOCK,
+            num_warps=1,
+        )
+
+
+__all__ = [
+    "selective_state_update_replayssm_spec",
+    "commit_replayssm_spec",
+    "reset_replayssm_spec_cursors",
+]

--- a/vllm/model_executor/models/nemotron_h.py
+++ b/vllm/model_executor/models/nemotron_h.py
@@ -751,6 +751,10 @@ class NemotronHForCausalLM(
             cache_config.mamba_cache_dtype,
             cache_config.mamba_ssm_cache_dtype,
         )
+        if cache_config.use_replayssm_spec:
+            return MambaStateDtypeCalculator.append_replayssm_spec_ring(
+                base_dtype, vllm_config.model_config.dtype
+            )
         if cache_config.use_replayssm:
             return MambaStateDtypeCalculator.append_replayssm_ring(
                 base_dtype, vllm_config.model_config.dtype
@@ -772,6 +776,8 @@ class NemotronHForCausalLM(
             - conv_state_shape: Shape for convolutional state cache
             - temporal_state_shape: Shape for state space model cache
             - x_cache/dt_cache/B_cache ring-buffer shapes (use_replayssm only)
+            - post_conv_cache/dt_cache circular ring shapes
+              (use_replayssm_spec only)
         """
         parallel_config = vllm_config.parallel_config
         cache_config = vllm_config.cache_config
@@ -788,6 +794,15 @@ class NemotronHForCausalLM(
             conv_kernel=hf_config.conv_kernel,
             num_spec=vllm_config.num_speculative_tokens,
         )
+        if cache_config.use_replayssm_spec:
+            return MambaStateShapeCalculator.append_replayssm_spec_ring(
+                base_shape,
+                intermediate_size,
+                hf_config.n_groups,
+                parallel_config.tensor_parallel_size,
+                cache_config.replayssm_buffer_len,
+                vllm_config.num_speculative_tokens,
+            )
         if cache_config.use_replayssm:
             return MambaStateShapeCalculator.append_replayssm_ring(
                 base_shape,

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -67,6 +67,7 @@ from .interfaces import (
     SupportsEagle3,
     SupportsLoRA,
     SupportsPP,
+    SupportsReplaySSM,
     _require_is_multimodal,
 )
 from .qwen2_moe import Qwen2MoeMLP as Qwen3NextMLP
@@ -396,7 +397,9 @@ class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLMBase, QwenNextMixtureOfExperts):
     info=Qwen3_5ProcessingInfo,
     dummy_inputs=Qwen3VLDummyInputsBuilder,
 )
-class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid):
+class Qwen3_5ForConditionalGeneration(
+    Qwen3VLForConditionalGeneration, IsHybrid, SupportsReplaySSM
+):
     # Qwen3.5 does not support multimodal pruning (EVS).
     supports_multimodal_pruning = False
 
@@ -523,18 +526,24 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
     def get_mamba_state_dtype_from_config(
         cls,
         vllm_config: "VllmConfig",
-    ) -> tuple[torch.dtype, torch.dtype]:
-        return MambaStateDtypeCalculator.gated_delta_net_state_dtype(
+    ) -> tuple[torch.dtype, ...]:
+        base_dtype = MambaStateDtypeCalculator.gated_delta_net_state_dtype(
             vllm_config.model_config.dtype,
             vllm_config.cache_config.mamba_cache_dtype,
             vllm_config.cache_config.mamba_ssm_cache_dtype,
         )
+        if vllm_config.cache_config.use_replayssm_spec:
+            return MambaStateDtypeCalculator.append_gated_delta_net_replayssm_spec_ring(
+                base_dtype, vllm_config.model_config.dtype
+            )
+        return base_dtype
 
     @classmethod
     def get_mamba_state_shape_from_config(
         cls, vllm_config: "VllmConfig"
-    ) -> tuple[tuple[int, int], tuple[int, int]]:
+    ) -> tuple[tuple[int, ...], ...]:
         parallel_config = vllm_config.parallel_config
+        cache_config = vllm_config.cache_config
         hf_config = vllm_config.model_config.hf_text_config
         tp_size = parallel_config.tensor_parallel_size
         num_spec = (
@@ -542,7 +551,7 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
             if vllm_config.speculative_config
             else 0
         )
-        return MambaStateShapeCalculator.gated_delta_net_state_shape(
+        base_shape = MambaStateShapeCalculator.gated_delta_net_state_shape(
             tp_size,
             hf_config.linear_num_key_heads,
             hf_config.linear_num_value_heads,
@@ -551,6 +560,18 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
             hf_config.linear_conv_kernel_dim,
             num_spec,
         )
+        if cache_config.use_replayssm_spec:
+            return MambaStateShapeCalculator.append_gated_delta_net_replayssm_spec_ring(
+                base_shape,
+                hf_config.linear_num_key_heads,
+                hf_config.linear_num_value_heads,
+                hf_config.linear_key_head_dim,
+                hf_config.linear_value_head_dim,
+                tp_size,
+                cache_config.replayssm_buffer_len,
+                num_spec,
+            )
+        return base_shape
 
     @classmethod
     def get_mamba_state_copy_func(cls) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:

--- a/vllm/third_party/flash_linear_attention/ops/gdn_replayssm_spec_decode.py
+++ b/vllm/third_party/flash_linear_attention/ops/gdn_replayssm_spec_decode.py
@@ -1,0 +1,716 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# ruff: noqa: E501
+
+from __future__ import annotations
+
+import torch
+
+from vllm.model_executor.layers.mamba.ops.replayssm_config import get_replayssm_config
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def gdn_replayssm_spec_circular_kernel(
+    mixed_qkv,  # [total_tokens, qkv_dim]  packed, channel-last (q|k|v)
+    a,  # [total_tokens, HV]
+    b,  # [total_tokens, HV]
+    A_log,  # [HV] fp32
+    dt_bias,  # [HV] fp32
+    o,  # [total_tokens, HV, V]  preallocated output
+    h0,  # [num_slots, HV, V, K]  checkpoint state (== ht, in-place)
+    ht,  # [num_slots, HV, V, K]
+    d_cache,  # [num_slots, HV, L, V]
+    k_cache,  # [num_slots, H, L, K]
+    g_cache,  # [num_slots, HV, L]  fp32
+    query_start_loc,  # [B+1] int  packed cu_seqlens
+    ssm_state_indices,  # [B] int  physical block per request
+    write_pos,  # [num_slots] int32  block-keyed
+    cache_base,  # [num_slots] int32  block-keyed circular origin
+    is_flush_flags,  # [num_slots] int8  block-keyed
+    scale,
+    stride_mqkv_t: tl.constexpr,  # per-token stride of mixed_qkv
+    stride_a_t: tl.constexpr,
+    stride_b_t: tl.constexpr,
+    stride_o_t: tl.constexpr,  # per-token stride of o (= HV*V)
+    stride_state_slot: tl.constexpr,
+    stride_d_slot: tl.constexpr,
+    stride_k_slot: tl.constexpr,
+    stride_g_slot: tl.constexpr,
+    stride_qsl: tl.constexpr,
+    stride_indices: tl.constexpr,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    BS: tl.constexpr,
+    BC: tl.constexpr,
+    NK: tl.constexpr,
+    BKT: tl.constexpr,
+    MAX_CACHE_LEN: tl.constexpr,
+    SOFTPLUS_THRESHOLD: tl.constexpr,
+    USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
+    IS_FLUSH: tl.constexpr,
+    NULL_BLOCK_ID: tl.constexpr,
+    DOT_PRECISION: tl.constexpr,
+):
+    i_v = tl.program_id(0)
+    i_n = tl.program_id(1)
+    i_hv = tl.program_id(2)
+    i_h = i_hv // (HV // H)
+
+    o_v = i_v * BV + tl.arange(0, BV)
+    o_s = tl.arange(0, BS)
+    o_c = tl.arange(0, BC)
+    mask_v = o_v < V
+
+    # --- per-request packed window ---
+    bos = tl.load(query_start_loc + i_n * stride_qsl).to(tl.int64)
+    eos = tl.load(query_start_loc + (i_n + 1) * stride_qsl).to(tl.int64)
+    spec_len = eos - bos  # full window length
+
+    state_idx = tl.load(ssm_state_indices + i_n * stride_indices).to(tl.int64)
+
+    # output pointer (packed): token (bos + o_s), value-head i_hv, dim o_v
+    p_o = o + (bos + o_s[:, None]) * stride_o_t + i_hv * V + o_v[None, :]
+
+    if IS_FLUSH:
+        if state_idx <= NULL_BLOCK_ID:
+            return
+        b_is_flush = tl.load(is_flush_flags + state_idx) != 0
+        if not b_is_flush:
+            return
+    else:
+        if state_idx <= NULL_BLOCK_ID:
+            full_mask = (o_s < spec_len)[:, None] & mask_v[None, :]
+            tl.store(
+                p_o,
+                tl.zeros([BS, BV], dtype=tl.float32).to(p_o.dtype.element_ty),
+                mask=full_mask,
+            )
+            return
+        b_is_flush = tl.load(is_flush_flags + state_idx) != 0
+        if b_is_flush:
+            return
+
+    b_write_pos = tl.load(write_pos + state_idx).to(tl.int64)
+    b_cache_base = tl.load(cache_base + state_idx).to(tl.int32)
+
+    mask_s = o_s < spec_len
+    out_mask = mask_s[:, None] & mask_v[None, :]
+
+    b_wp_i = b_write_pos.to(tl.int32)
+    cache_valid = o_c < b_write_pos
+
+    # CIRCULAR physical slots (addresses only; masks/cumsums stay logical).
+    phys_c = (b_cache_base + o_c) & (MAX_CACHE_LEN - 1)  # [BC] history
+    phys_spec = (b_cache_base + b_wp_i + o_s) & (MAX_CACHE_LEN - 1)  # [BS] spec
+
+    # ------------------------------------------------------------------
+    # Block 0: gates / beta / local cumsum + committed-history replay decay.
+    # ------------------------------------------------------------------
+    A_log_val = tl.load(A_log + i_hv).to(tl.float32)
+    dt_bias_val = tl.load(dt_bias + i_hv).to(tl.float32)
+    a_s = tl.load(a + (bos + o_s) * stride_a_t + i_hv, mask=mask_s, other=0.0).to(
+        tl.float32
+    )
+    b_s = tl.load(b + (bos + o_s) * stride_b_t + i_hv, mask=mask_s, other=0.0).to(
+        tl.float32
+    )
+    x = a_s + dt_bias_val
+    softplus_x = tl.where(x <= SOFTPLUS_THRESHOLD, tl.log(1.0 + tl.exp(x)), x)
+    g_s = tl.where(mask_s, -tl.exp(A_log_val) * softplus_x, 0.0)
+    beta_s = tl.where(mask_s, tl.sigmoid(b_s), 0.0)
+    G_s = tl.cumsum(g_s, axis=0)
+    expG_s = tl.exp(G_s)
+
+    # committed-history replay decay from cached g (history loads -> phys_c)
+    p_g_main = g_cache + state_idx * stride_g_slot + i_hv * MAX_CACHE_LEN + phys_c
+    b_g_all = tl.load(p_g_main, mask=cache_valid, other=0.0).to(tl.float32)
+    b_g_prefix = tl.cumsum(b_g_all, axis=0)
+    b_g_total = tl.sum(b_g_all, axis=0)
+    b_replay_decay = tl.where(cache_valid, tl.exp(b_g_total - b_g_prefix), 0.0)
+    b_total_decay = tl.exp(b_g_total)
+
+    p_d_main = d_cache + (
+        state_idx * stride_d_slot
+        + (i_hv * MAX_CACHE_LEN + phys_c[None, :]) * V
+        + o_v[:, None]
+    )
+    b_d_all = tl.load(
+        p_d_main, mask=mask_v[:, None] & cache_valid[None, :], other=0.0
+    ).to(tl.float32)
+    b_d_scaled = b_d_all * b_replay_decay[None, :]
+
+    if USE_QK_L2NORM_IN_KERNEL:
+        qnorm_acc = tl.zeros([BS], dtype=tl.float32)
+        knorm_acc = tl.zeros([BS], dtype=tl.float32)
+        for kk in range(NK):
+            o_kt = kk * BKT + tl.arange(0, BKT)
+            mask_kt = o_kt < K
+            ld = mask_s[:, None] & mask_kt[None, :]
+            qn = tl.load(
+                mixed_qkv
+                + (bos + o_s[:, None]) * stride_mqkv_t
+                + i_h * K
+                + o_kt[None, :],
+                mask=ld,
+                other=0.0,
+            ).to(tl.float32)
+            knn = tl.load(
+                mixed_qkv
+                + (bos + o_s[:, None]) * stride_mqkv_t
+                + H * K
+                + i_h * K
+                + o_kt[None, :],
+                mask=ld,
+                other=0.0,
+            ).to(tl.float32)
+            qnorm_acc += tl.sum(qn * qn, axis=1)
+            knorm_acc += tl.sum(knn * knn, axis=1)
+        q_rnorm = tl.where(mask_s, 1.0 / tl.sqrt(qnorm_acc + 1e-6), 0.0)
+        k_rnorm = tl.where(mask_s, 1.0 / tl.sqrt(knorm_acc + 1e-6), 0.0)
+    else:
+        q_rnorm = tl.where(mask_s, 1.0, 0.0)
+        k_rnorm = tl.where(mask_s, 1.0, 0.0)
+
+    # ------------------------------------------------------------------
+    # K-Tiled Fused Projection and Intra-Spec Matrices (+ flush)
+    # ------------------------------------------------------------------
+    hw_q = tl.zeros([BV, BS], dtype=tl.float32)
+    hw_k = tl.zeros([BV, BS], dtype=tl.float32)
+    if not IS_FLUSH:
+        scores_q = tl.zeros([BC, BS], dtype=tl.float32)
+        scores_k = tl.zeros([BC, BS], dtype=tl.float32)
+    kk_mat = tl.zeros([BS, BS], dtype=tl.float32)
+    kq_mat = tl.zeros([BS, BS], dtype=tl.float32)
+
+    write_k = (i_v == 0) and (i_hv == i_h * (HV // H))
+
+    for kk in range(NK):
+        o_kt = kk * BKT + tl.arange(0, BKT)
+        mask_kt = o_kt < K
+        ld_s = mask_s[:, None] & mask_kt[None, :]
+        q_tile = tl.load(
+            mixed_qkv + (bos + o_s[:, None]) * stride_mqkv_t + i_h * K + o_kt[None, :],
+            mask=ld_s,
+            other=0.0,
+        ).to(tl.float32)
+        k_tile = tl.load(
+            mixed_qkv
+            + (bos + o_s[:, None]) * stride_mqkv_t
+            + H * K
+            + i_h * K
+            + o_kt[None, :],
+            mask=ld_s,
+            other=0.0,
+        ).to(tl.float32)
+        q_tile = q_tile * (q_rnorm * scale)[:, None]
+        k_tile = k_tile * k_rnorm[:, None]
+
+        p_h0 = (
+            h0
+            + state_idx * stride_state_slot
+            + i_hv * V * K
+            + o_v[:, None] * K
+            + o_kt[None, :]
+        )
+        sc_tile = tl.load(p_h0, mask=mask_v[:, None] & mask_kt[None, :], other=0.0).to(
+            tl.float32
+        )
+        # cached-key history load -> phys_c
+        p_k = k_cache + (
+            state_idx * stride_k_slot
+            + (i_h * MAX_CACHE_LEN + phys_c[:, None]) * K
+            + o_kt[None, :]
+        )
+        khist_tile = tl.load(
+            p_k, mask=cache_valid[:, None] & mask_kt[None, :], other=0.0
+        ).to(tl.float32)
+
+        qT = tl.trans(q_tile)
+        kT = tl.trans(k_tile)
+        kk_mat += tl.dot(k_tile, kT, input_precision=DOT_PRECISION)
+        kq_mat += tl.dot(k_tile, qT, input_precision=DOT_PRECISION)
+
+        if IS_FLUSH:
+            sw_f = tl.dot(
+                b_d_scaled,
+                khist_tile,
+                acc=b_total_decay * sc_tile,
+                input_precision=DOT_PRECISION,
+            )
+            hw_q += tl.dot(sw_f, qT, input_precision=DOT_PRECISION)
+            hw_k += tl.dot(sw_f, kT, input_precision=DOT_PRECISION)
+            p_ht = (
+                ht
+                + state_idx * stride_state_slot
+                + i_hv * V * K
+                + o_v[:, None] * K
+                + o_kt[None, :]
+            )
+            # fp32 store to the fp32 checkpoint page
+            tl.store(
+                p_ht,
+                sw_f.to(p_ht.dtype.element_ty),
+                mask=mask_v[:, None] & mask_kt[None, :],
+            )
+        else:
+            hw_q += tl.dot(sc_tile, qT, input_precision=DOT_PRECISION)
+            hw_k += tl.dot(sc_tile, kT, input_precision=DOT_PRECISION)
+            scores_q += tl.dot(khist_tile, qT, input_precision=DOT_PRECISION)
+            scores_k += tl.dot(khist_tile, kT, input_precision=DOT_PRECISION)
+
+        if write_k:
+            # spec key store -> phys_spec (circular)
+            p_cur_k = k_cache + (
+                state_idx * stride_k_slot
+                + (i_h * MAX_CACHE_LEN + phys_spec[:, None]) * K
+                + o_kt[None, :]
+            )
+            tl.store(
+                p_cur_k,
+                k_tile.to(p_cur_k.dtype.element_ty),
+                mask=mask_s[:, None]
+                & mask_kt[None, :]
+                & ((b_write_pos + o_s[:, None]) < MAX_CACHE_LEN),
+            )
+
+    if not IS_FLUSH:
+        hw_q = b_total_decay * hw_q + tl.dot(
+            b_d_scaled, scores_q, input_precision=DOT_PRECISION
+        )
+        hw_k = b_total_decay * hw_k + tl.dot(
+            b_d_scaled, scores_k, input_precision=DOT_PRECISION
+        )
+
+    # ------------------------------------------------------------------
+    # strictly-lower A and T = (I + A)^{-1}.
+    # ------------------------------------------------------------------
+    lower = (o_s[:, None] > o_s[None, :]) & mask_s[:, None] & mask_s[None, :]
+    diff_ij = G_s[:, None] - G_s[None, :]
+    A_mat = tl.where(lower, beta_s[:, None] * tl.exp(diff_ij) * kk_mat, 0.0)
+
+    b_Ai = -A_mat
+    for ii in range(2, BS):
+        row = tl.sum(tl.where((o_s == ii)[:, None], -A_mat, 0.0), axis=0)
+        row = tl.where(o_s < ii, row, 0.0)
+        row = row + tl.sum(row[:, None] * b_Ai, axis=0)
+        b_Ai = tl.where((o_s == ii)[:, None], row, b_Ai)
+    T_mat = b_Ai + (o_s[:, None] == o_s[None, :]).to(tl.float32)
+
+    # ------------------------------------------------------------------
+    # R and D_spec = R @ T^T.
+    # ------------------------------------------------------------------
+    p_v = (
+        mixed_qkv
+        + (bos + o_s[None, :]) * stride_mqkv_t
+        + 2 * H * K
+        + i_hv * V
+        + o_v[:, None]
+    )
+    v_tile = tl.load(p_v, mask=mask_v[:, None] & mask_s[None, :], other=0.0).to(
+        tl.float32
+    )
+    R_mat = beta_s[None, :] * (v_tile - expG_s[None, :] * hw_k)
+    D_spec = tl.zeros([BV, BS], dtype=tl.float32)
+    for j in tl.static_range(BS):
+        Rj = tl.sum(tl.where((o_s == j)[None, :], R_mat, 0.0), axis=1)
+        Tj = tl.sum(tl.where((o_s == j)[None, :], T_mat, 0.0), axis=1)
+        D_spec += Rj[:, None] * Tj[None, :]
+
+    # ------------------------------------------------------------------
+    # outputs.
+    # ------------------------------------------------------------------
+    causalF = (o_s[:, None] <= o_s[None, :]) & mask_s[:, None] & mask_s[None, :]
+    diff_ji = G_s[None, :] - G_s[:, None]
+    F_mat = tl.where(causalF, tl.exp(diff_ji) * kq_mat, 0.0)
+    DF = tl.zeros([BV, BS], dtype=tl.float32)
+    for j in tl.static_range(BS):
+        Dj = tl.sum(tl.where((o_s == j)[None, :], D_spec, 0.0), axis=1)
+        Fj = tl.sum(tl.where((o_s == j)[:, None], F_mat, 0.0), axis=0)
+        DF += Dj[:, None] * Fj[None, :]
+    O_tile = expG_s[None, :] * hw_q + DF
+
+    tl.store(p_o, tl.trans(O_tile).to(p_o.dtype.element_ty), mask=out_mask)
+
+    # ------------------------------------------------------------------
+    # write speculative d / g at circular positions (phys_spec).
+    # ------------------------------------------------------------------
+    spec_pos = b_write_pos + o_s
+    spec_store_mask = mask_s & (spec_pos < MAX_CACHE_LEN)
+    p_cur_d = d_cache + (
+        state_idx * stride_d_slot
+        + (i_hv * MAX_CACHE_LEN + phys_spec[None, :]) * V
+        + o_v[:, None]
+    )
+    tl.store(
+        p_cur_d,
+        D_spec.to(p_cur_d.dtype.element_ty),
+        mask=mask_v[:, None] & spec_store_mask[None, :],
+    )
+    if i_v == 0:
+        p_cur_g = g_cache + state_idx * stride_g_slot + i_hv * MAX_CACHE_LEN + phys_spec
+        tl.store(p_cur_g, g_s, mask=spec_store_mask)
+
+
+@triton.jit
+def _advance_gdn_spec_cursors_kernel(
+    write_pos_ptr,
+    cache_base_ptr,
+    is_flush_ptr,
+    num_accepted_ptr,
+    state_batch_indices_ptr,
+    n_rows,
+    stride_sbi: tl.constexpr,
+    stride_na: tl.constexpr,
+    MAX_CACHE_LEN: tl.constexpr,
+    MAX_SPEC_LEN: tl.constexpr,
+    CACHE_BUF_LEN: tl.constexpr,
+    BLOCK: tl.constexpr,
+    NULL_BLOCK_ID: tl.constexpr,
+):
+    offs = tl.arange(0, BLOCK)
+    row_mask = offs < n_rows
+    blk = tl.load(
+        state_batch_indices_ptr + offs * stride_sbi, mask=row_mask, other=NULL_BLOCK_ID
+    ).to(tl.int64)
+    valid = row_mask & (blk > NULL_BLOCK_ID)
+
+    write_pos = tl.load(write_pos_ptr + blk, mask=valid, other=0).to(tl.int32)
+    cache_base = tl.load(cache_base_ptr + blk, mask=valid, other=0).to(tl.int32)
+    is_flush_cur = tl.load(is_flush_ptr + blk, mask=valid, other=0).to(tl.int32)
+    num_acc = tl.load(num_accepted_ptr + offs * stride_na, mask=valid, other=0).to(
+        tl.int32
+    )
+
+    total_commit = num_acc
+    flush_now = (total_commit > 0) & (is_flush_cur != 0)
+
+    new_base = tl.where(
+        flush_now, (cache_base + write_pos) & (CACHE_BUF_LEN - 1), cache_base
+    )
+    new_wp = tl.where(is_flush_cur != 0, total_commit, write_pos + total_commit).to(
+        tl.int32
+    )
+    # Early-flush one window early so every verify step satisfies
+    # write_pos + spec_len <= max_cache_len (the spec window never overflows).
+    next_is_flush = ((new_wp + 2 * MAX_SPEC_LEN) > MAX_CACHE_LEN).to(tl.int8)
+
+    tl.store(write_pos_ptr + blk, new_wp, mask=valid)
+    tl.store(cache_base_ptr + blk, new_base, mask=valid)
+    tl.store(is_flush_ptr + blk, next_is_flush, mask=valid)
+
+
+@triton.jit
+def _reset_gdn_replayssm_spec_cursors_kernel(
+    write_pos_ptr,
+    cache_base_ptr,
+    is_flush_ptr,
+    do_reset_ptr,
+    state_batch_indices_ptr,
+    n_rows,
+    stride_sbi: tl.constexpr,
+    stride_reset: tl.constexpr,
+    INIT_FLUSH: tl.constexpr,
+    BLOCK: tl.constexpr,
+    NULL_BLOCK_ID: tl.constexpr,
+):
+    offs = tl.arange(0, BLOCK)
+    row_mask = offs < n_rows
+    blk = tl.load(
+        state_batch_indices_ptr + offs * stride_sbi, mask=row_mask, other=NULL_BLOCK_ID
+    ).to(tl.int64)
+    do_reset = tl.load(do_reset_ptr + offs * stride_reset, mask=row_mask, other=0).to(
+        tl.int32
+    )
+    do = row_mask & (blk > NULL_BLOCK_ID) & (do_reset != 0)
+
+    tl.store(write_pos_ptr + blk, tl.zeros_like(blk).to(tl.int32), mask=do)
+    tl.store(cache_base_ptr + blk, tl.zeros_like(blk).to(tl.int32), mask=do)
+    tl.store(
+        is_flush_ptr + blk,
+        tl.full([BLOCK], INIT_FLUSH, dtype=tl.int8),
+        mask=do,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Python wrappers.
+# ---------------------------------------------------------------------------
+def _launch_gdn_spec(
+    mixed_qkv,
+    a,
+    b,
+    A_log,
+    dt_bias,
+    out,
+    checkpoint_state,
+    d_cache,
+    k_cache,
+    g_cache,
+    query_start_loc,
+    ssm_state_indices,
+    write_pos,
+    cache_base,
+    is_flush,
+    scale,
+    max_cache_len,
+    max_spec_len,
+    use_qk_l2norm_in_kernel,
+    is_flush_kernel,
+    block_v,
+    num_warps,
+    num_stages,
+    nk,
+    null_block_id,
+    dot_precision,
+):
+    num_slots, HV, V, K = checkpoint_state.shape
+    qkv_dim = mixed_qkv.shape[1]
+    q_dim = (qkv_dim - HV * V) // 2
+    H = q_dim // K
+    B = query_start_loc.shape[0] - 1
+    # max_cache_len is the logical flush threshold L; the physical pow2 ring is
+    # d_cache.shape[2] = next_pow2(L) and wraps addresses / per-head strides.
+    buf = d_cache.shape[2]
+    assert buf & (buf - 1) == 0, "circular cache requires power-of-two buffer"
+
+    BK = triton.next_power_of_2(K)
+    if triton.cdiv(K, BK) != 1:
+        raise ValueError(f"only NK_global=1 supported (K={K}, BK={BK}).")
+    if BK % nk != 0:
+        raise ValueError(f"nk={nk} must divide BK={BK}.")
+    BKT = BK // nk
+    if BKT < 16:
+        raise ValueError(f"BKT={BKT} must be >=16 for tl.dot.")
+    BV = block_v if block_v is not None else min(triton.next_power_of_2(V), 64)
+    BS = max(4, triton.next_power_of_2(max_spec_len))
+    # History block decoupled from the physical buffer: with L = B + max_spec_len
+    # committed history never exceeds L - max_spec_len, so BC covers it while
+    # staying small (the L=B+T win).
+    BC = max(16, triton.next_power_of_2(max(1, max_cache_len - max_spec_len)))
+
+    grid = (triton.cdiv(V, BV), B, HV)
+    gdn_replayssm_spec_circular_kernel[grid](
+        mixed_qkv,
+        a,
+        b,
+        A_log,
+        dt_bias,
+        out,
+        checkpoint_state,
+        checkpoint_state,
+        d_cache,
+        k_cache,
+        g_cache,
+        query_start_loc,
+        ssm_state_indices,
+        write_pos,
+        cache_base,
+        is_flush,
+        scale,
+        mixed_qkv.stride(0),
+        a.stride(0),
+        b.stride(0),
+        out.stride(0),
+        checkpoint_state.stride(0),
+        d_cache.stride(0),
+        k_cache.stride(0),
+        g_cache.stride(0),
+        query_start_loc.stride(0),
+        ssm_state_indices.stride(0),
+        H=H,
+        HV=HV,
+        K=K,
+        V=V,
+        BK=BK,
+        BV=BV,
+        BS=BS,
+        BC=BC,
+        NK=nk,
+        BKT=BKT,
+        MAX_CACHE_LEN=buf,
+        SOFTPLUS_THRESHOLD=20.0,
+        USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
+        IS_FLUSH=is_flush_kernel,
+        NULL_BLOCK_ID=null_block_id,
+        DOT_PRECISION=dot_precision,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+
+
+def gdn_replayssm_spec_decode(
+    mixed_qkv: torch.Tensor,  # [total_tokens, qkv_dim]  post-conv packed (q|k|v)
+    a: torch.Tensor,  # [total_tokens, HV]
+    b: torch.Tensor,  # [total_tokens, HV]
+    A_log: torch.Tensor,  # [HV] fp32
+    dt_bias: torch.Tensor,  # [HV] fp32
+    checkpoint_state: torch.Tensor,  # [num_slots, HV, V, K]  (in-place h0==ht)
+    d_cache: torch.Tensor,  # [num_slots, HV, buf, V]
+    k_cache: torch.Tensor,  # [num_slots, H, buf, K]
+    g_cache: torch.Tensor,  # [num_slots, HV, buf]  fp32
+    out: torch.Tensor,  # [total_tokens, HV, V]  preallocated
+    query_start_loc: torch.Tensor,  # [B+1] int
+    ssm_state_indices: torch.Tensor,  # [B] int  physical block per request
+    write_pos: torch.Tensor,  # [num_slots] int32  block-keyed
+    cache_base: torch.Tensor,  # [num_slots] int32  block-keyed
+    is_flush: torch.Tensor,  # [num_slots] int8  block-keyed
+    max_cache_len: int,  # logical flush threshold L = B + max_spec_len
+    max_spec_len: int,
+    scale: float | None = None,
+    use_qk_l2norm_in_kernel: bool = True,
+    null_block_id: int = 0,
+    launch_mode: str = "both",
+    dot_precision: str = "tf32",
+    dot_precision_flush: str | None = None,
+):
+    """GDN cached speculative-decode on a CIRCULAR d/k/g cache (vLLM packed varlen).
+
+    ``max_cache_len`` is the logical flush threshold L = B + max_spec_len; the
+    physical pow2 buffer is ``d_cache.shape[2]`` = ``next_pow2(L)`` and the history
+    block ``BC = next_pow2(L - max_spec_len)``. Two launches (verify + flush
+    ``IS_FLUSH`` specializations) with device-side per-row routing keep the step
+    CUDA-graph capturable. Cursors are advanced by ``commit_gdn_replayssm_spec``.
+    """
+    if scale is None:
+        scale = checkpoint_state.shape[-1] ** -0.5
+    if is_flush.dtype != torch.int8:
+        is_flush = is_flush.to(torch.int8)
+    if dot_precision_flush is None:
+        dot_precision_flush = dot_precision
+    vb, vw, vnk, vns = get_replayssm_config(
+        "gdn_spec_verify",
+        max_spec_len=max_spec_len,
+        head_k_dim=checkpoint_state.shape[-1],
+    )
+    fb, fw, fnk, fns = get_replayssm_config(
+        "gdn_spec_flush",
+        max_spec_len=max_spec_len,
+        head_k_dim=checkpoint_state.shape[-1],
+    )
+
+    if launch_mode in ("both", "verify"):
+        _launch_gdn_spec(
+            mixed_qkv,
+            a,
+            b,
+            A_log,
+            dt_bias,
+            out,
+            checkpoint_state,
+            d_cache,
+            k_cache,
+            g_cache,
+            query_start_loc,
+            ssm_state_indices,
+            write_pos,
+            cache_base,
+            is_flush,
+            scale,
+            max_cache_len,
+            max_spec_len,
+            use_qk_l2norm_in_kernel,
+            False,
+            vb,
+            vw,
+            vns,
+            vnk,
+            null_block_id,
+            dot_precision,
+        )
+    if launch_mode in ("both", "flush"):
+        _launch_gdn_spec(
+            mixed_qkv,
+            a,
+            b,
+            A_log,
+            dt_bias,
+            out,
+            checkpoint_state,
+            d_cache,
+            k_cache,
+            g_cache,
+            query_start_loc,
+            ssm_state_indices,
+            write_pos,
+            cache_base,
+            is_flush,
+            scale,
+            max_cache_len,
+            max_spec_len,
+            use_qk_l2norm_in_kernel,
+            True,
+            fb,
+            fw,
+            fns,
+            fnk,
+            null_block_id,
+            dot_precision_flush,
+        )
+    return out
+
+
+def commit_gdn_replayssm_spec(
+    write_pos: torch.Tensor,
+    cache_base: torch.Tensor,
+    is_flush: torch.Tensor,
+    num_accepted: torch.Tensor,  # [n_rows] int  (already includes the bonus token)
+    state_batch_indices: torch.Tensor,  # [n_rows] int  physical block per row
+    max_cache_len: int,  # logical flush threshold L
+    max_spec_len: int,
+    cache_buf_len: int | None = None,  # physical pow2 buffer next_pow2(L)
+    null_block_id: int = 0,
+):
+    """Advance the block-keyed cursors once per decode step (device-only)."""
+    if cache_buf_len is None:
+        cache_buf_len = triton.next_power_of_2(max_cache_len)
+    n_rows = state_batch_indices.shape[0]
+    BLOCK = triton.next_power_of_2(max(1, n_rows))
+    _advance_gdn_spec_cursors_kernel[(1,)](
+        write_pos,
+        cache_base,
+        is_flush,
+        num_accepted,
+        state_batch_indices,
+        n_rows,
+        stride_sbi=state_batch_indices.stride(0),
+        stride_na=num_accepted.stride(0),
+        MAX_CACHE_LEN=max_cache_len,
+        MAX_SPEC_LEN=max_spec_len,
+        CACHE_BUF_LEN=cache_buf_len,
+        BLOCK=BLOCK,
+        NULL_BLOCK_ID=null_block_id,
+    )
+
+
+def reset_gdn_replayssm_spec_cursors(
+    write_pos: torch.Tensor,
+    cache_base: torch.Tensor,
+    is_flush: torch.Tensor,
+    do_reset: torch.Tensor,  # [n_rows] int/bool  1 for first-decode rows
+    state_batch_indices: torch.Tensor,  # [n_rows] int
+    max_cache_len: int,
+    max_spec_len: int,
+    null_block_id: int = 0,
+):
+    """Reset the cursors of first-decode rows (prefill->decode handoff)."""
+    n_rows = state_batch_indices.shape[0]
+    BLOCK = triton.next_power_of_2(max(1, n_rows))
+    init_flush = 1 if 2 * max_spec_len > max_cache_len else 0
+    _reset_gdn_replayssm_spec_cursors_kernel[(1,)](
+        write_pos,
+        cache_base,
+        is_flush,
+        do_reset,
+        state_batch_indices,
+        n_rows,
+        stride_sbi=state_batch_indices.stride(0),
+        stride_reset=do_reset.stride(0),
+        INIT_FLUSH=init_flush,
+        BLOCK=BLOCK,
+        NULL_BLOCK_ID=null_block_id,
+    )

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -8,6 +8,7 @@ from typing import Literal
 import torch
 
 from vllm.config import VllmConfig
+from vllm.model_executor.layers.mamba.mamba_utils import MambaStateShapeCalculator
 from vllm.utils.torch_utils import async_tensor_h2d
 from vllm.v1.attention.backend import (
     AttentionBackend,
@@ -65,6 +66,13 @@ class GDNAttentionMetadata:
 
     num_accepted_tokens: torch.Tensor | None = None  # shape: [batch,]
 
+    # ReplaySSM spec ring cursors: block-keyed (num_blocks,) buffers indexed by
+    # spec_state_indices_tensor[:, 0], advanced on-device once per step by
+    # commit_gdn_replayssm_spec. None unless use_replayssm_spec is enabled.
+    spec_write_pos_d: torch.Tensor | None = None
+    spec_cache_base_d: torch.Tensor | None = None
+    spec_is_flush_d: torch.Tensor | None = None
+
     # Pre-computed FLA chunk metadata (avoids GPU->CPU sync in prepare_chunk_indices)
     chunk_indices: torch.Tensor | None = None
     chunk_offsets: torch.Tensor | None = None
@@ -110,6 +118,20 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             self.num_spec = 0
         self.use_spec_decode: bool = self.num_spec > 0
         self._init_reorder_batch_threshold(1, self.use_spec_decode)
+
+        self.use_replayssm_spec: bool = vllm_config.cache_config.use_replayssm_spec
+        self.replayssm_buffer_len: int = vllm_config.cache_config.replayssm_buffer_len
+        self.max_spec_len: int = 1 + self.num_spec
+        # Flush once the next window would not fit: threshold L = B + max_spec_len,
+        # physical ring next_pow2(L). Cursors are sized from num_gpu_blocks, which
+        # is only known after profiling, so they are allocated on the first build.
+        self.spec_flush_threshold = self.replayssm_buffer_len + self.max_spec_len
+        self.spec_ring_len = MambaStateShapeCalculator.replayssm_spec_ring_len(
+            self.replayssm_buffer_len, self.num_spec
+        )
+        self.spec_write_pos: torch.Tensor | None = None
+        self.spec_cache_base: torch.Tensor | None = None
+        self.spec_is_flush: torch.Tensor | None = None
 
         self.use_full_cuda_graph: bool = (
             self.compilation_config.cudagraph_mode.has_full_cudagraphs()
@@ -187,7 +209,32 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         )
 
         spec_sequence_masks_cpu: torch.Tensor | None = None
-        if (
+        if self.use_replayssm_spec and num_accepted_tokens is not None:
+            # Every post-prefill row runs the spec kernel, a draft-less row as a
+            # T=1 window. The baseline decode path reads the checkpoint page,
+            # which lags the committed ring, so routing a decode row there
+            # corrupts the state. num_decode_draft_tokens_cpu cannot drive this
+            # mask: it is stale on draft-less steps and -1 for decode rows whose
+            # drafts were dropped.
+            is_prefilling_cpu = m.is_prefilling
+            assert is_prefilling_cpu is not None
+            query_lens_cpu_all = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
+            spec_sequence_masks_cpu = (
+                ~is_prefilling_cpu[: query_lens_cpu_all.shape[0]]
+            ) & (query_lens_cpu_all > 0)
+            num_spec_decodes = int(spec_sequence_masks_cpu.sum().item())
+            if num_spec_decodes == 0:
+                spec_sequence_masks = None
+                spec_sequence_masks_cpu = None
+            else:
+                assert (
+                    int(query_lens_cpu_all[spec_sequence_masks_cpu].max().item())
+                    <= self.max_spec_len
+                ), "ReplaySSM-spec decode row wider than the spec window"
+                spec_sequence_masks = async_tensor_h2d(
+                    spec_sequence_masks_cpu, device=query_start_loc.device
+                )
+        elif (
             not self.use_spec_decode
             or num_decode_draft_tokens_cpu is None
             or num_decode_draft_tokens_cpu[num_decode_draft_tokens_cpu >= 0]
@@ -412,6 +459,23 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             f"num_decodes: {num_decodes}, num_spec_decodes: {num_spec_decodes}"
         )
 
+        spec_write_pos_d = None
+        spec_cache_base_d = None
+        spec_is_flush_d = None
+        if self.use_replayssm_spec and num_spec_decodes > 0:
+            assert spec_state_indices_tensor is not None
+            assert num_accepted_tokens is not None
+            assert spec_sequence_masks_cpu is not None
+            spec_write_pos_d, spec_cache_base_d, spec_is_flush_d = (
+                self._commit_replayssm_spec_cursors(
+                    m,
+                    spec_state_indices_tensor,
+                    num_accepted_tokens,
+                    spec_sequence_masks_cpu,
+                    context_lens_tensor,
+                )
+            )
+
         # Prepare per-request tensors for cudagraph. m.num_actual_tokens is
         # token-padded for FULL graph replay, but the GDN state/query/accepted
         # metadata below is indexed by request.
@@ -506,11 +570,95 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             spec_token_indx=spec_token_indx,
             non_spec_token_indx=non_spec_token_indx,
             num_accepted_tokens=num_accepted_tokens,
+            spec_write_pos_d=spec_write_pos_d,
+            spec_cache_base_d=spec_cache_base_d,
+            spec_is_flush_d=spec_is_flush_d,
             nums_dict=nums_dict,
             batch_ptr=batch_ptr,
             token_chunk_offset_ptr=token_chunk_offset_ptr,
         )
         return attn_metadata
+
+    def _commit_replayssm_spec_cursors(
+        self,
+        m: CommonAttentionMetadata,
+        spec_state_indices_tensor: torch.Tensor,
+        num_accepted_tokens: torch.Tensor,
+        spec_sequence_masks_cpu: torch.Tensor,
+        context_lens_tensor: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Advance the block-keyed spec ring cursors for this step.
+
+        Commits the previous step's accepted tokens and decides this step's
+        is_flush on-device, then resets rows entering decode. Both run as fixed
+        launches so the captured graph is identical every step.
+        """
+        from vllm.third_party.flash_linear_attention.ops.gdn_replayssm_spec_decode import (  # noqa: E501
+            commit_gdn_replayssm_spec,
+            reset_gdn_replayssm_spec_cursors,
+        )
+
+        device = spec_state_indices_tensor.device
+        if self.spec_write_pos is None:
+            num_gpu_blocks = self.vllm_config.cache_config.num_gpu_blocks
+            if not num_gpu_blocks:
+                raise ValueError(
+                    "--use-replayssm-spec needs num_gpu_blocks at build time to "
+                    "size the block-keyed cursor buffers"
+                )
+            self.spec_write_pos = torch.zeros(
+                num_gpu_blocks, dtype=torch.int32, device=device
+            )
+            self.spec_cache_base = torch.zeros(
+                num_gpu_blocks, dtype=torch.int32, device=device
+            )
+            self.spec_is_flush = torch.zeros(
+                num_gpu_blocks, dtype=torch.int8, device=device
+            )
+        assert self.spec_cache_base is not None and self.spec_is_flush is not None
+
+        block_ids = spec_state_indices_tensor[:, 0]
+        # Commit first: acceptance is only known after the previous step's
+        # sampling, so folding it into this build keeps every cursor update
+        # on-device and avoids a device-to-host sync on num_accepted_tokens.
+        commit_gdn_replayssm_spec(
+            self.spec_write_pos,
+            self.spec_cache_base,
+            self.spec_is_flush,
+            num_accepted_tokens.to(torch.int32),
+            block_ids,
+            max_cache_len=self.spec_flush_threshold,
+            max_spec_len=self.max_spec_len,
+            cache_buf_len=self.spec_ring_len,
+        )
+
+        decode_base_cpu = m.replayssm_decode_base_cpu
+        if decode_base_cpu is None:
+            raise ValueError(
+                "--use-replayssm-spec requires the CPU decode-base counts to "
+                "reset the ring on entry to decode"
+            )
+        # decode_base is the context at (re)admission, so a request's first
+        # verify and a resumed request both land exactly on it.
+        decode_base_d = decode_base_cpu.to(
+            context_lens_tensor.device, non_blocking=True
+        )
+        first_decode_full = (
+            context_lens_tensor[: decode_base_d.shape[0]] == decode_base_d
+        ).to(torch.int8)
+        spec_row_idx = spec_sequence_masks_cpu.nonzero(as_tuple=True)[0].to(
+            device, non_blocking=True
+        )
+        reset_gdn_replayssm_spec_cursors(
+            self.spec_write_pos,
+            self.spec_cache_base,
+            self.spec_is_flush,
+            first_decode_full.index_select(0, spec_row_idx),
+            block_ids,
+            max_cache_len=self.spec_flush_threshold,
+            max_spec_len=self.max_spec_len,
+        )
+        return self.spec_write_pos, self.spec_cache_base, self.spec_is_flush
 
     def build_for_cudagraph_capture(
         self, common_attn_metadata: CommonAttentionMetadata

--- a/vllm/v1/attention/backends/mamba_attn.py
+++ b/vllm/v1/attention/backends/mamba_attn.py
@@ -8,6 +8,7 @@ from typing import Any, ClassVar, TypeVar
 import torch
 
 from vllm.config import VllmConfig
+from vllm.model_executor.layers.mamba.mamba_utils import MambaStateShapeCalculator
 from vllm.utils.math_utils import cdiv
 from vllm.utils.torch_utils import async_tensor_h2d
 from vllm.v1.attention.backend import (
@@ -80,6 +81,15 @@ class BaseMambaAttentionMetadata:
     write_pos_d: torch.Tensor | None = None
     is_flush_d: torch.Tensor | None = None
     bc_pre_scratch: torch.Tensor | None = None
+    # ReplaySSM speculative decode: block-keyed ring cursors, shaped
+    # (num_gpu_blocks,) and indexed by physical SSM block id, plus the per-step
+    # (decode_rows, ngroups, ring_len, block_spec) fp32 scratch. The cursors are
+    # advanced on-device once per step by commit_replayssm_spec. All None when
+    # use_replayssm_spec is disabled.
+    spec_write_pos_d: torch.Tensor | None = None
+    spec_post_origin_d: torch.Tensor | None = None
+    spec_is_flush_d: torch.Tensor | None = None
+    spec_bc_pre_scratch: torch.Tensor | None = None
 
 
 class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
@@ -106,6 +116,14 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
         self.use_spec_decode = self.num_spec_tokens > 0
         self.use_replayssm = vllm_config.cache_config.use_replayssm
         self.replayssm_buffer_len = vllm_config.cache_config.replayssm_buffer_len
+        self.use_replayssm_spec = vllm_config.cache_config.use_replayssm_spec
+        self.max_spec_len = 1 + self.num_spec_tokens
+        # A verify step consumes a whole window, so flush once the next window
+        # would not fit: threshold L = B + max_spec_len, physical ring next_pow2(L).
+        self.spec_flush_threshold = self.replayssm_buffer_len + self.max_spec_len
+        self.spec_ring_len = MambaStateShapeCalculator.replayssm_spec_ring_len(
+            self.replayssm_buffer_len, self.num_spec_tokens
+        )
 
         assert isinstance(kv_cache_spec, MambaSpec)
         scheduler_config = vllm_config.scheduler_config
@@ -196,6 +214,43 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
             )
         else:
             self.decode_bc_pre_scratch = None
+
+        # ReplaySSM speculative decode. The cursors are block-keyed and sized
+        # from num_gpu_blocks, which is only known after profiling, so they are
+        # allocated lazily on the first build.
+        self.spec_write_pos: torch.Tensor | None = None
+        self.spec_post_origin: torch.Tensor | None = None
+        self.spec_is_flush: torch.Tensor | None = None
+        self.decode_spec_bc_pre: torch.Tensor | None = None
+        if self.use_replayssm_spec:
+            if len(kv_cache_spec.shapes) != 4:
+                raise ValueError(
+                    "the cached-spec kernel requires the 4-tensor Mamba2 page "
+                    "(conv, ssm, post_conv_cache, dt_cache)"
+                )
+            local_nheads, head_dim, dstate = kv_cache_spec.shapes[1]
+            conv_dim_local = kv_cache_spec.shapes[2][1]
+            # post_conv_cache holds x|B only, so the width past d_inner is
+            # ngroups_local * dstate (one B block, no C).
+            ngroups_local = (conv_dim_local - local_nheads * head_dim) // dstate
+            if ngroups_local < 1:
+                raise ValueError(
+                    f"invalid ngroups_local={ngroups_local} derived from spec page "
+                    f"width {conv_dim_local} (dstate {dstate})"
+                )
+            block_spec = 1 << (max(1, self.max_spec_len) - 1).bit_length()
+            # Consumed by the scatter on every decode step, eager and captured
+            # alike, and indexed by pid_b in [0, num_decodes). Size it by
+            # max_num_seqs, not decode_cudagraph_max_bs, which is 0 under
+            # enforce_eager and would leave the scatter writing out of bounds.
+            spec_scratch_bs = max(
+                self.decode_cudagraph_max_bs, scheduler_config.max_num_seqs
+            )
+            self.decode_spec_bc_pre = torch.empty(
+                (spec_scratch_bs, ngroups_local, self.spec_ring_len, block_spec),
+                dtype=torch.float32,
+                device=device,
+            )
 
         self._init_reorder_batch_threshold(1, self.use_spec_decode)
         if self.use_spec_decode:
@@ -645,6 +700,26 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
         ):
             bc_pre_scratch = self.decode_bc_pre_scratch[:num_decodes]
 
+        spec_write_pos_d = None
+        spec_post_origin_d = None
+        spec_is_flush_d = None
+        spec_bc_pre_scratch = None
+        if (
+            self.use_replayssm_spec
+            and num_decodes > 0
+            and num_accepted_tokens is not None
+        ):
+            spec_write_pos_d, spec_post_origin_d, spec_is_flush_d = (
+                self._commit_replayssm_spec_cursors(
+                    common_attn_metadata,
+                    state_indices_tensor_d,
+                    num_accepted_tokens,
+                    num_decodes,
+                )
+            )
+            if self.decode_spec_bc_pre is not None:
+                spec_bc_pre_scratch = self.decode_spec_bc_pre[:num_decodes]
+
         metadata = self.metadata_cls(
             num_prefills=num_prefills,
             num_prefill_tokens=num_prefill_tokens,
@@ -657,6 +732,10 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
             write_pos_d=write_pos_d,
             is_flush_d=is_flush_d,
             bc_pre_scratch=bc_pre_scratch,
+            spec_write_pos_d=spec_write_pos_d,
+            spec_post_origin_d=spec_post_origin_d,
+            spec_is_flush_d=spec_is_flush_d,
+            spec_bc_pre_scratch=spec_bc_pre_scratch,
             num_accepted_tokens=num_accepted_tokens,
             query_start_loc_d=query_start_loc_d,
             block_idx_last_scheduled_token=block_idx_last_scheduled_token,
@@ -674,6 +753,92 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
         )
 
         return self._update_metadata_for_cudagraph_capture(metadata)
+
+    def _commit_replayssm_spec_cursors(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        state_indices_tensor_d: torch.Tensor,
+        num_accepted_tokens: torch.Tensor,
+        num_decodes: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Advance the block-keyed spec ring cursors for this step.
+
+        Commits the previous step's accepted tokens and decides this step's
+        is_flush on-device, then resets rows that are entering decode. Both run
+        as fixed launches so the captured graph is identical every step.
+        """
+        from vllm.model_executor.layers.mamba.ops.selective_state_update_replayssm_spec import (  # noqa: E501
+            commit_replayssm_spec,
+            reset_replayssm_spec_cursors,
+        )
+
+        device = common_attn_metadata.query_start_loc.device
+        if self.spec_write_pos is None:
+            num_gpu_blocks = self.vllm_config.cache_config.num_gpu_blocks
+            if not num_gpu_blocks:
+                raise ValueError(
+                    "--use-replayssm-spec needs num_gpu_blocks at build time to "
+                    "size the block-keyed cursor buffers"
+                )
+            self.spec_write_pos = torch.zeros(
+                num_gpu_blocks, dtype=torch.int32, device=device
+            )
+            self.spec_post_origin = torch.zeros(
+                num_gpu_blocks, dtype=torch.int32, device=device
+            )
+            self.spec_is_flush = torch.zeros(
+                num_gpu_blocks, dtype=torch.int8, device=device
+            )
+        assert self.spec_post_origin is not None and self.spec_is_flush is not None
+
+        block_ids = state_indices_tensor_d[:, 0]
+        # Commit first: acceptance is only known after the previous step's
+        # sampling, so folding it into this build keeps every cursor update
+        # on-device and avoids a device-to-host sync on num_accepted_tokens.
+        commit_replayssm_spec(
+            self.spec_write_pos,
+            self.spec_post_origin,
+            self.spec_is_flush,
+            num_accepted_tokens.to(torch.int32),
+            block_ids,
+            max_cache_len=self.spec_flush_threshold,
+            max_spec_len=self.max_spec_len,
+            cache_buf_len=self.spec_ring_len,
+        )
+
+        decode_base_cpu = common_attn_metadata.replayssm_decode_base_cpu
+        num_computed_tokens_cpu = common_attn_metadata._num_computed_tokens_cpu
+        if decode_base_cpu is None or num_computed_tokens_cpu is None:
+            raise ValueError(
+                "--use-replayssm-spec requires CPU decode-base and computed-token "
+                "counts to reset the ring on entry to decode"
+            )
+        num_computed_d = num_computed_tokens_cpu[:num_decodes]
+        decode_base_d = decode_base_cpu[:num_decodes]
+        # decode_base is the context at (re)admission, so a request's first
+        # verify and a resumed request both land exactly on it. A final
+        # single-token prompt chunk reclassified as a decode sits one token
+        # short; reset it too and force it to flush, or it would append to a
+        # recycled block's stale cursors.
+        force_flush_cpu = num_computed_d < decode_base_d
+        first_decode_cpu = (num_computed_d <= decode_base_d).to(torch.int8)
+        first_decode_d = async_tensor_h2d(
+            first_decode_cpu.tolist(), dtype=torch.int8, device=device
+        )
+        force_flush_d = async_tensor_h2d(
+            force_flush_cpu.to(torch.int8).tolist(), dtype=torch.int8, device=device
+        )
+        reset_replayssm_spec_cursors(
+            self.spec_write_pos,
+            self.spec_post_origin,
+            self.spec_is_flush,
+            first_decode_d,
+            block_ids,
+            max_cache_len=self.spec_flush_threshold,
+            max_spec_len=self.max_spec_len,
+            force_flush_mask=force_flush_d,
+        )
+        return self.spec_write_pos, self.spec_post_origin, self.spec_is_flush
 
     def _update_metadata_for_cudagraph_capture(
         self,
@@ -694,6 +859,7 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
         write_pos_d = metadata.write_pos_d
         is_flush_d = metadata.is_flush_d
         bc_pre_scratch = metadata.bc_pre_scratch
+        spec_bc_pre_scratch = metadata.spec_bc_pre_scratch
         if (
             metadata.num_prefills == 0
             and metadata.num_decodes <= self.decode_cudagraph_max_bs
@@ -775,6 +941,11 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
                 if self.decode_bc_pre_scratch is not None:
                     bc_pre_scratch = self.decode_bc_pre_scratch[:padded_bs]
 
+            # The spec cursors are block-keyed and full-length, so only the
+            # dense per-row scratch needs widening to the padded batch.
+            if self.use_replayssm_spec and self.decode_spec_bc_pre is not None:
+                spec_bc_pre_scratch = self.decode_spec_bc_pre[:padded_bs]
+
         return replace(
             metadata,
             state_indices_tensor_d=state_indices_tensor_d,
@@ -783,6 +954,7 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
             write_pos_d=write_pos_d,
             is_flush_d=is_flush_d,
             bc_pre_scratch=bc_pre_scratch,
+            spec_bc_pre_scratch=spec_bc_pre_scratch,
             block_idx_last_scheduled_token=block_idx_last_scheduled_token,
             block_idx_last_computed_token=block_idx_last_computed_token,
             block_idx_last_scheduled_token_prev_step=(

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -172,7 +172,7 @@ class InputBatch:
         self.num_computed_tokens_cpu = self.num_computed_tokens_cpu_tensor.numpy()
 
         # Mamba2 ReplaySSM decode ring origin (num_computed at each request's
-        # last full-state write); populated only when the feature is on.
+        # last full-state write); populated only when a ReplaySSM mode is on.
         self.use_replayssm = use_replayssm
         self.replayssm_decode_base_cpu_tensor = torch.zeros(
             (max_num_reqs,),

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2499,7 +2499,10 @@ class GPUModelRunner(
             needs_replayssm_spec_args = (
                 self.cache_config.use_replayssm_spec
                 and self.speculative_config is not None
-                and isinstance(builder, Mamba2AttentionMetadataBuilder)
+                and isinstance(
+                    builder,
+                    (Mamba2AttentionMetadataBuilder, GDNAttentionMetadataBuilder),
+                )
             )
             if (use_spec_decode or needs_replayssm_spec_args) and isinstance(
                 builder,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -727,7 +727,8 @@ class GPUModelRunner(
             is_pooling_model=self.is_pooling_model,
             cp_kv_cache_interleave_size=self.parallel_config.cp_kv_cache_interleave_size,
             reasoning_config=self.vllm_config.reasoning_config,
-            use_replayssm=self.cache_config.use_replayssm,
+            use_replayssm=self.cache_config.use_replayssm
+            or self.cache_config.use_replayssm_spec,
         )
 
         # Separate cuda stream for overlapping transfer of sampled token ids from
@@ -2415,7 +2416,7 @@ class GPUModelRunner(
             rswa_prefix_lens = num_prompt_tokens_cpu
 
         replayssm_decode_base_cpu = None
-        if self.cache_config.use_replayssm:
+        if self.cache_config.use_replayssm or self.cache_config.use_replayssm_spec:
             replayssm_decode_base_cpu = (
                 self.input_batch.replayssm_decode_base_cpu_tensor[:num_reqs_padded]
             )
@@ -2491,7 +2492,16 @@ class GPUModelRunner(
             )
 
             extra_attn_metadata_args = {}
-            if use_spec_decode and isinstance(
+            # use_spec_decode is step-level: it is False whenever the drafter
+            # proposed nothing anywhere in the batch. ReplaySSM-spec still needs
+            # the cursors on those steps, or the rows fall through to the
+            # baseline kernel and advance a checkpoint the ring has moved past.
+            needs_replayssm_spec_args = (
+                self.cache_config.use_replayssm_spec
+                and self.speculative_config is not None
+                and isinstance(builder, Mamba2AttentionMetadataBuilder)
+            )
+            if (use_spec_decode or needs_replayssm_spec_args) and isinstance(
                 builder,
                 (
                     Mamba2AttentionMetadataBuilder,
@@ -7270,7 +7280,8 @@ class GPUModelRunner(
                 is_pooling_model=self.is_pooling_model,
                 cp_kv_cache_interleave_size=self.parallel_config.cp_kv_cache_interleave_size,
                 reasoning_config=self.vllm_config.reasoning_config,
-                use_replayssm=self.cache_config.use_replayssm,
+                use_replayssm=self.cache_config.use_replayssm
+                or self.cache_config.use_replayssm_spec,
                 slot_mapping_modes=slot_mapping_modes,
             )
 


### PR DESCRIPTION
> **Review order.** This PR is stacked on [#49847](https://github.com/vllm-project/vllm/pull/49847) (Mamba2 speculative decode). Because it targets `main`, the diff also includes that PR's commits. Please review this PR after #49847 is reviewed and merged.

## Background

This is the fourth sub-PR split from the larger ReplaySSM draft PR [#47576](https://github.com/vllm-project/vllm/pull/47576), which contains the complete Mamba2 and Gated DeltaNet implementation for both standard and speculative decode. Mamba2 standard decode landed as `866fea2b9` ([#48018](https://github.com/vllm-project/vllm/pull/48018)); GDN standard decode is [#48792](https://github.com/vllm-project/vllm/pull/48792), and Mamba2 speculative decode is [#49847](https://github.com/vllm-project/vllm/pull/49847). This PR adds GDN speculative decode. It is a collaboration between Dao AI Lab and NVIDIA, and the full derivation and figures are in the [blog post](https://dao-lab.ai/blog/2026/replayssm/). AI assistance was used for parts of this work, and the authors have reviewed every changed line.

## Core concept

To roll back rejected drafts, vLLM's native GDN spec path keeps a separate recurrent state snapshot for every draft token, so a step with `T = 1 + num_speculative_tokens` tokens writes `T` full `head_v x head_k` states per value head. Cost grows linearly in `T`.

ReplaySSM replaces the snapshots with one checkpoint plus a small circular buffer of the per-step inputs. For GDN the buffer holds `(d, k, g)`, where `d = beta * (v - S k)` is the per-token delta-rule update and `S` is the decayed state before the rank-one update. The spec kernel computes these updates for the whole window as `D_spec` and writes them to `d_cache`. The name `d` is deliberate: GDN prefill already uses `U` for its chunk-transformed value tensor in the WY representation. Caching `d` rather than `v` removes the serial state dependency during replay. This changes three things:

- Rollback is a cursor move.
- Every draft output is computed from the same checkpoint.
- The full state is materialized only on a periodic flush.

## What this PR adds

Everything is behind the flag added in #49847. With ReplaySSM disabled, the GDN decode path is unchanged.

- The GDN cached spec kernel `gdn_replayssm_spec_decode`, its device-side cursor helpers `commit_gdn_replayssm_spec` and `reset_gdn_replayssm_spec_cursors`, and the swept Blackwell launch configs.
- Integration. The Qwen3.5 GDN mixer dispatches to the kernel under `--use-replayssm-spec`, the GDN metadata builder owns the block-keyed ring cursors, and the state-shape and state-dtype calculators size the `d`/`k`/`g` ring on the paged state. Qwen3.5 declares `SupportsReplaySSM`. The conv path reuses vLLM's `causal_conv1d_update` unchanged.
- One benchmark change: the spec throughput benchmark routes GDN prefill through Triton instead of FlashInfer.

## Design notes

The flush rule, cache sizing, on-device commit, and fixed verify-plus-flush launch pair are inherited from #49847. Three details are GDN-specific.

### Paged cache layout

The ring and checkpoint live inside the paged KV block, appended as `d_cache`, `k_cache`, and `g_cache` on the baseline `(conv, ssm)` state for five tensors total. `d_cache` stores the delta-rule update defined above. **The `d` and `k` caches use fp16 when activations are bf16**, which reconstructs the state more accurately at the same width. `g` is always fp32 because it drives the cumulative decay replay.

Only the small per-block cursors live outside the page: `write_pos`, `cache_base`, and `is_flush`, all shaped `(num_gpu_blocks,)` and indexed by physical block id.

### Routing every post-prefill row

Under the flag, the builder marks every post-prefill row as a spec row, so a draft-less row runs as a `T=1` window. `num_decode_draft_tokens_cpu` cannot drive that mask: it is stale on steps where the drafter proposed nothing and is `-1` for decode rows whose drafts were dropped. Sending either row to the baseline decode path would read the checkpoint page, which lags the committed ring.

### Prefill chunks and captured graphs

A final single-token prompt chunk stays on the prefill path. This differs from GDN standard decode, where leaving it as a prefill lets a shape-uniform batch replay a decode graph against a stale cursor.

That batch is not uniform on the spec path. `_is_uniform_decode` requires both `max_num_scheduled_tokens == 1 + num_speculative_tokens` and `num_tokens == max * num_reqs`. A draft-less step fails the first condition because every row is one token wide, and a mixed batch fails the second because the prompt chunk is shorter than the window. Standard decode has `uniform_decode_query_len == 1`, so the same batch is uniform there. A builder test covers the classification.

## Results

Qwen3.5-122B-A10B-NVFP4 on one B300, TP1, fp32 SSM state, `B=16`, in-checkpoint MTP drafter.

### Kernel-level

Isolated per-layer-step CUDA-graph latency on B300. The baseline is `fused_sigmoid_gating_delta_rule_update`; ReplaySSM is the full step (verify plus flush) amortized over the exact steady-state flush cadence `f = a/(B-T+a)`, at a mean acceptance of 2 tokens for `T=2` and 3 for `T=4,6,8`. At `B=16`:

| bs | T=2 | T=4 | T=6 | T=8 |
|---:|---|---|---|---|
| 128 | 1.79x | 2.86x | 3.30x | 3.86x |
| 256 | 2.02x | 3.05x | 3.49x | 4.22x |
| 512 | 2.16x | 3.24x | 3.56x | 4.46x |

The ratio grows with `T` because the baseline writes `T` states per step while ReplaySSM's traffic is flat in `T`.

### End-to-end throughput

GSM8K, greedy, `ignore_eos`, 256 output tokens, `max_model_len` 2048, CUDA graphs on. Produced with `benchmarks/replayssm/e2e_spec_decode_throughput.py`.

ReplaySSM spec over native spec:

| bs | T=2 | T=4 | T=6 | T=8 |
|---:|---|---|---|---|
| 1 | 1.00x | 1.12x | 0.87x | 0.96x |
| 32 | 1.05x | 1.22x | 1.17x | 1.12x |
| 128 | 1.35x | 1.43x | 1.42x | 1.84x |
| 256 | 1.36x | 1.79x | 1.99x | 2.09x |
| 512 | 1.73x | 2.10x | OOM | OOM |

ReplaySSM spec over standard (no-spec) decode:

| bs | T=2 | T=4 | T=6 | T=8 |
|---:|---|---|---|---|
| 1 | 1.37x | 1.97x | 1.76x | 1.77x |
| 32 | 1.44x | 2.08x | 2.07x | 1.94x |
| 128 | 1.56x | 1.87x | 1.86x | 1.83x |
| 256 | 1.45x | 1.84x | 1.87x | 1.76x |
| 512 | 1.53x | 1.90x | OOM | OOM |

Compared with native spec, the gain grows with batch size, where its `T` state writes per step cost the most. Compared with standard decode, ReplaySSM is 1.4x to 2.1x faster at every batch size. At bs512, native spec reaches 9,223 tok/s at T=2 and 9,395 tok/s at T=4, below standard decode at 10,398 tok/s. ReplaySSM spec reaches 19,707 tok/s.

The two bs512 runs at T=6 and T=8 fail to start. The failure happens in `_init_minimal_kv_cache_for_profiling`, which allocates a temporary KV cache before vLLM determines the size of the real one. This isn't a ReplaySSM memory regression. The temporary cache is block-based, so it charges the larger ReplaySSM page size without accounting for the reduced per-request footprint when `num_speculative_blocks = 0`.

### Acceptance length

At bs256:

| T | native spec | ReplaySSM |
|---:|---:|---:|
| 2 | 1.95 | 1.95 |
| 4 | 3.56 | 3.57 |
| 6 | 4.73 | 4.76 |
| 8 | 5.52 | 5.53 |

### Serving capacity

Native spec holds `1 + num_speculative_tokens` recurrent states per request for rollback. ReplaySSM holds one checkpoint plus the input ring. Maximum decode concurrency at `max_model_len` 2048, `(B, T) = (16, 4)`, one B300:

| native spec | ReplaySSM | ratio |
|---:|---:|---:|
| 233.2 | 656.5 | 2.81x |

These are worst-case caps at the full request length.

### Accuracy

Official model-card presets with paired seeds. Qwen3.5-122B-A10B-NVFP4 on one B300 with CUDA graphs (FP32 state, d/k cache in FP16 instead of BF16 for precision purpose):

| dataset | standard | native spec | ReplaySSM spec |
|---|---:|---:|---:|
| gsm8k | 0.9606 | 0.9621 | 0.9575 |
| mmlu_pro | 0.8590 | 0.8590 | 0.8550 |
| gpqa | 0.8510 | 0.8460 | 0.8422 |
| hmmt | 0.8729 | 0.8708 | 0.8771 |

Every ReplaySSM result is within 0.9 percentage points of the baseline, and degenerate-loop counts stay within the baseline range. Qwen3.5-35B-A3B on 2xH100 TP2 shows the same parity. Native spec scores 85.8% on MMLU-Pro against a model-card value of 85.3%, and 87.9% on HMMT against 89.0%.

Acceptance length is only comparable between runs with identical settings. With the model-card presets, native spec and ReplaySSM both average 2.6 to 2.8 accepted tokens; the greedy throughput runs average about 3.4 on the same model.

## Tests

Per-step kernel correctness is covered by `tests/kernels/test_replayssm_spec_decode_gdn.py`. A `T`-window verify step is checked against decoding the same window one token at a time, across three state and activation precision combinations, the production geometries (small, Qwen3.5-4B, Qwen3.5-122B), `B` in {16, 32}, and `T` in {2, 4, 6, 8}. It also covers rollback across a flush and continuous batching with per-row cursors and null-padded slots. The reference is the upstream `fused_recurrent_gated_delta_rule_packed_decode`, run on a clone from the checkpoint through the history and then the window. The committed history is built with draft-less `T=1` spec steps. One case corrupts a cached history key and asserts that the output changes.

Metadata builder unit tests are in `tests/v1/attention/test_gdn_spec_metadata_builder.py`. They cover commit and flush cursor updates, the early-flush boundary, rejected drafts, recycled blocks, resume after preemption, mixed batches, draft-less rows, final prefill chunks, persistent block-keyed cursor buffers under graph capture, and matching page sizes from the layer and config paths. The last check guards against silent truncation when those paths are zipped.

Engine-level parity lives in `tests/v1/e2e/test_replayssm_decode.py`, which compares native spec against ReplaySSM spec with greedy decode and `check_logprobs_close` on Qwen3.5-4B.

Results: the GDN kernel file is 67 passed (131 seconds on one A100), and the GDN builder file is 13 passed. Together with the Mamba2 suites inherited from #49847, the combined run is 273 passed. Engine parity on Qwen3.5-4B passes on one H100.

```
pytest tests/kernels/test_replayssm_spec_decode_gdn.py \
       tests/v1/attention/test_gdn_spec_metadata_builder.py \
       tests/v1/e2e/test_replayssm_decode.py -q
```

## Duplicate check

No open PR addresses ReplaySSM GDN speculative decode. This PR is split from the large draft PR [#47576](https://github.com/vllm-project/vllm/pull/47576), which stays open as the full design. The related prior ReplaySSM PRs we are aware of cover standard decode only:

- [#43102](https://github.com/vllm-project/vllm/pull/43102) and [#43439](https://github.com/vllm-project/vllm/pull/43439), earlier PRs from our collaborator on the same ReplaySSM effort. This is the newer, more complete version.
- [#46239](https://github.com/vllm-project/vllm/pull/46239), opened by another contributor based on our original fork. We have since made substantial changes, intend to land the feature ourselves, and have notified the author.

## Out of scope

- Prefix caching. Rejected by the validator added in #49847.
- P/D disaggregation and KV connectors. Rejected by the validator.
- Stochastic rounding. Rejected by the validator.
- Low-precision state. The code handles fp16 and bf16 state, but only fp32 state is evaluated here.
