### PR TITLE
[ROCm] Support AITER paged attention on gfx90a

### DIFF
--- a/tests/v1/attention/test_rocm_attention_backends_selection.py
+++ b/tests/v1/attention/test_rocm_attention_backends_selection.py
@@ -304,13 +304,13 @@ def test_mla_backend_selection(
             assert backend_path == expected_backend_path
 
 
-def test_aiter_fa_requires_mi3xx(mock_vllm_config):
-    """Test that ROCM_AITER_FA requires mi3xx architecture."""
+def test_aiter_fa_requires_supported_architecture(mock_vllm_config):
+    """Test that ROCM_AITER_FA rejects unsupported architectures."""
     from vllm.platforms.rocm import RocmPlatform
 
-    # Mock on_mi3xx to return False (used by supports_compute_capability)
     with (
         patch("vllm.platforms.rocm.on_mi3xx", return_value=False),
+        patch("vllm.platforms.rocm.on_gfx90a", return_value=False),
         pytest.raises(
             ValueError,
             match="compute capability not supported",
@@ -330,6 +330,51 @@ def test_aiter_fa_requires_mi3xx(mock_vllm_config):
             selected_backend=AttentionBackendEnum.ROCM_AITER_FA,
             attn_selector_config=attn_selector_config,
         )
+
+
+def test_aiter_fa_supports_gfx90a(mock_vllm_config):
+    """Test explicit ROCM_AITER_FA selection on gfx90a."""
+    from vllm.platforms.rocm import RocmPlatform
+
+    with (
+        patch("vllm.platforms.rocm.on_mi3xx", return_value=False),
+        patch("vllm.platforms.rocm.on_gfx90a", return_value=True),
+    ):
+        attn_selector_config = AttentionSelectorConfig(
+            head_size=128,
+            dtype=torch.bfloat16,
+            kv_cache_dtype="auto",
+            block_size=2048,
+            use_mla=False,
+            has_sink=False,
+            use_sparse=False,
+        )
+
+        backend_path = RocmPlatform.get_attn_backend_cls(
+            selected_backend=AttentionBackendEnum.ROCM_AITER_FA,
+            attn_selector_config=attn_selector_config,
+        )
+
+    assert backend_path == AttentionBackendEnum.ROCM_AITER_FA.get_path()
+
+
+def test_aiter_fa_adds_large_pages_only_on_gfx90a():
+    from vllm.v1.attention.backends.rocm_aiter_fa import (
+        AiterFlashAttentionBackend,
+    )
+
+    with patch("vllm.platforms.rocm.on_gfx90a", return_value=False):
+        assert AiterFlashAttentionBackend.get_supported_kernel_block_sizes() == [
+            16,
+            32,
+        ]
+
+    with patch("vllm.platforms.rocm.on_gfx90a", return_value=True):
+        assert AiterFlashAttentionBackend.get_supported_kernel_block_sizes() == [
+            16,
+            32,
+            2048,
+        ]
 
 
 def test_sparse_not_supported(mock_vllm_config):

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -110,6 +110,21 @@ def if_aiter_supported(func: Callable) -> Callable:
     return wrapper
 
 
+def if_aiter_attention_supported(func: Callable) -> Callable:
+    """Allow AITER attention on gfx90a and the existing MI3xx targets."""
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        if current_platform.is_rocm() and IS_AITER_FOUND:
+            from vllm.platforms.rocm import on_gfx90a, on_mi3xx
+
+            if on_gfx90a() or on_mi3xx():
+                return func(*args, **kwargs)
+        return None
+
+    return wrapper
+
+
 def _rocm_aiter_fused_moe_impl(
     hidden_states: torch.Tensor,
     w1: torch.Tensor,
@@ -1443,10 +1458,11 @@ class rocm_aiter_ops:
         after monkey patching the env variables in the unit test.
 
     Check Functions:
-        All check functions (is_*_enabled) are decorated with @if_aiter_supported,
-        which verifies: (1) platform is ROCm, (2) device arch is gfx9, and
-        (3) aiter library is installed. The check function then also verifies
-        the corresponding environment variable is enabled.
+        Check functions (is_*_enabled) use architecture decorators which verify
+        the ROCm platform, supported device target, and AITER installation.
+        Most use @if_aiter_supported. Shuffled attention also supports gfx90a
+        through @if_aiter_attention_supported. Each check then verifies its
+        corresponding environment variable.
         i.e.                                             ___
         is_enabled() == current_platform.is_rocm() and      |     checked by
                         current_platform.is_on_gfx9() and   | @if_aiter_supported
@@ -1681,7 +1697,7 @@ class rocm_aiter_ops:
         return cls._AITER_ENABLED and cls._CUSTOM_ALL_REDUCE_ENABLED
 
     @classmethod
-    @if_aiter_supported
+    @if_aiter_attention_supported
     def is_shuffle_kv_cache_enabled(cls) -> bool:
         return cls._SHUFFLE_KV_CACHE_ENABLED
 
@@ -2828,6 +2844,40 @@ class rocm_aiter_ops:
             return_lse=return_lse,
             out=out,
             sink_ptr=sink_ptr,
+        )
+
+    @staticmethod
+    def mha_batch_prefill_func(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        kv_indptr: torch.Tensor,
+        kv_page_indices: torch.Tensor,
+        max_seqlen_q: int,
+        max_seqlen_k: int,
+        softmax_scale: float,
+        causal: bool,
+        out: torch.Tensor,
+        block_table: torch.Tensor,
+        seqlen_k: torch.Tensor,
+    ):
+        from aiter import mha_batch_prefill_func
+
+        return mha_batch_prefill_func(
+            q,
+            k,
+            v,
+            cu_seqlens_q,
+            kv_indptr,
+            kv_page_indices,
+            max_seqlen_q,
+            max_seqlen_k,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            out=out,
+            block_table=block_table,
+            seqlen_k=seqlen_k,
         )
 
     @staticmethod

--- a/vllm/v1/attention/backends/rocm_aiter_fa.py
+++ b/vllm/v1/attention/backends/rocm_aiter_fa.py
@@ -737,6 +737,10 @@ class AiterFlashAttentionBackend(AttentionBackend):
 
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
+        from vllm.platforms.rocm import on_gfx90a
+
+        if on_gfx90a():
+            return [16, 32, 2048]
         return [16, 32]
 
     @classmethod
@@ -776,12 +780,12 @@ class AiterFlashAttentionBackend(AttentionBackend):
 
     @classmethod
     def supports_compute_capability(cls, capability: DeviceCapability) -> bool:
-        from vllm.platforms.rocm import on_mi3xx
+        from vllm.platforms.rocm import on_gfx90a, on_mi3xx
 
         # DeviceCapability is currently created using torch.cuda.get_device_capability()
-        # which is known to be buggy on rocm systems. on_mi3xx uses amd-smi which is
-        # more reliable.
-        return on_mi3xx()
+        # which is known to be buggy on ROCm systems. Use the detected target
+        # architecture instead.
+        return on_gfx90a() or on_mi3xx()
 
     @classmethod
     def supports_non_causal(cls) -> bool:
@@ -928,6 +932,27 @@ class AiterFlashAttentionImpl(AttentionImpl):
                 v_scale,
             )
             return
+        if self._can_use_paged_batch_prefill(
+            attn_metadata,
+            query,
+            key_cache,
+            value_cache,
+            output,
+            cu_seqlens_q,
+            block_table,
+        ):
+            self._paged_batch_prefill(
+                attn_metadata,
+                query,
+                key_cache,
+                value_cache,
+                output,
+                cu_seqlens_q,
+                max_seqlen_q,
+                max_seqlen_k,
+                block_table,
+            )
+            return
         out, lse = rocm_aiter_ops.flash_attn_varlen_func(
             q=query,
             k=key,
@@ -1016,6 +1041,91 @@ class AiterFlashAttentionImpl(AttentionImpl):
             prefix_lse=chunked_lse,
             suffix_output=out,
             suffix_lse=lse,
+        )
+
+    def _can_use_paged_batch_prefill(
+        self,
+        attn_metadata: AiterFlashAttentionMetadata,
+        query: torch.Tensor,
+        key_cache: torch.Tensor,
+        value_cache: torch.Tensor,
+        output: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        block_table: torch.Tensor,
+    ) -> bool:
+        from vllm.platforms.rocm import on_gfx90a
+
+        return (
+            on_gfx90a()
+            and rocm_aiter_ops.is_shuffle_kv_cache_enabled()
+            and self.kv_cache_dtype in ("auto", "float16", "bfloat16")
+            and self.alibi_slopes is None
+            and self.logits_soft_cap == 0.0
+            and self.sinks is None
+            and attn_metadata.causal
+            and query.dtype in (torch.float16, torch.bfloat16)
+            and output.dtype == query.dtype
+            and key_cache.dtype == query.dtype
+            and value_cache.dtype == query.dtype
+            and query.ndim == 3
+            and output.shape == query.shape
+            and key_cache.ndim == 4
+            and value_cache.shape == key_cache.shape
+            and key_cache.shape[1] == 2048
+            and key_cache.shape[2] == self.num_kv_heads
+            and key_cache.shape[3] == self.head_size
+            and cu_seqlens_q.dtype == torch.int32
+            and cu_seqlens_q.ndim == 1
+            and block_table.dtype == torch.int32
+            and block_table.ndim == 2
+            and block_table.stride(-1) == 1
+        )
+
+    def _paged_batch_prefill(
+        self,
+        attn_metadata: AiterFlashAttentionMetadata,
+        query: torch.Tensor,
+        key_cache: torch.Tensor,
+        value_cache: torch.Tensor,
+        output: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        max_seqlen_q: int,
+        max_seqlen_k: int,
+        block_table: torch.Tensor,
+    ) -> None:
+        vector_size = 16 // key_cache.element_size()
+        num_blocks, block_size, num_kv_heads, head_size = key_cache.shape
+        vector_key_cache = key_cache.reshape(
+            num_blocks,
+            num_kv_heads,
+            head_size // vector_size,
+            block_size,
+            vector_size,
+        )
+        vector_value_cache = value_cache.reshape(
+            num_blocks,
+            num_kv_heads,
+            block_size // vector_size,
+            head_size,
+            vector_size,
+        )
+        start = attn_metadata.num_decodes
+        stop = start + attn_metadata.num_extends
+        seq_lens = attn_metadata.seq_lens[start:stop]
+        rocm_aiter_ops.mha_batch_prefill_func(
+            q=query,
+            k=vector_key_cache,
+            v=vector_value_cache,
+            cu_seqlens_q=cu_seqlens_q,
+            kv_indptr=cu_seqlens_q,
+            kv_page_indices=block_table,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+            softmax_scale=self.scale,
+            causal=True,
+            out=output,
+            block_table=block_table,
+            seqlen_k=seq_lens,
         )
 
     def forward(


### PR DESCRIPTION
## What this changes

Add gfx90a support to the existing `ROCM_AITER_FA` backend:

- Accept explicit AITER attention selection on gfx90a.
- Advertise 2048-token cache pages on gfx90a for hybrid models with large
  state-alignment requirements.
- Use AITER/CK batch prefill directly for supported BF16 and FP16 shuffled
  caches instead of gathering each long prefix into a temporary buffer.
- Keep the existing fallback for quantized caches, other page sizes, sliding
  windows, attention sinks, ALiBi, and soft caps.

Only the attention-specific AITER gate is extended. MoE, GEMM, normalization,
and other AITER features keep their existing architecture checks and remain
opt-in. Existing behavior on every other GPU architecture is unchanged.

This draft depends on:

- ROCm/aiter#4387
- ROCm/aiter#4388
- ROCm/composable_kernel#3760

## Performance

NVIDIA Nemotron 3 Super 120B-A12B, MI250X, TP8, BF16, 128K prompts at
concurrency 8:

| Metric | Existing configuration | This stack | Change |
| --- | ---: | ---: | ---: |
| Total throughput | 5,561 tok/s | 8,590 tok/s | 1.545x |
| Mean time to first token | 90.73 s | 60.05 s | 1.51x |
| Mean time per output token | 190.7 ms | 120.7 ms | 1.58x |

Isolated kernel comparisons:

- AITER HIP paged decode was 3.94x faster at 128K and 3.81x faster at 256K
  than the tuned Triton path.
- CK batch prefill was 1.70x faster at 128K and 1.69x faster at 256K than
  Triton. Outputs matched at `rtol=2e-2, atol=2e-2`; maximum absolute
  difference was 0.000244 at 128K.

## Validation

```text
python -m pytest -q \
  tests/v1/attention/test_rocm_attention_backends_selection.py \
  -k aiter_fa
# 4 passed, 18 deselected

pre-commit run ruff-check --files \
  vllm/_aiter_ops.py \
  vllm/v1/attention/backends/rocm_aiter_fa.py \
  tests/v1/attention/test_rocm_attention_backends_selection.py
# passed

pre-commit run ruff-format --files <same files>
# passed

pre-commit run typos --files <same files>
# passed
```

The end-to-end smoke covered 1K and 8K first prefills plus a 40K prompt that
requires a 32K initial prefill followed by an 8K paged continuation. All three
requests returned HTTP 200 and the server completed full decode graph capture.

I searched open vLLM PRs for gfx90a AITER attention, 2048-token AITER pages, and
paged batch prefill and found no duplicate. #36317 changes hybrid-cache
alignment policy but does not add this backend or these kernels; this change is
compatible with it.

This change was prepared with AI assistance. The submitter reviewed every
changed line and ran the tests and benchmarks above.
