### PR TITLE
[CI] Add kimi and k3 auto-labeling rules

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -233,6 +233,31 @@ pull_request_rules:
       add:
         - gpt-oss
 
+- name: label-kimi
+  description: Automatically apply kimi label
+  conditions:
+    - label != stale
+    - or:
+      - files~=(?i)kimi
+      - files~=(?i)moonshot
+      - title~=(?i)(?:kimi|moonshot)
+  actions:
+    label:
+      add:
+        - kimi
+
+- name: label-k3
+  description: Automatically apply k3 label (launch triage; retire after ramp-down)
+  conditions:
+    - label != stale
+    - or:
+      - files~=(?i)kimi[-_]?k3
+      - title~=(?i)(?:kimi[-\s]?k3|\bk3\b)
+  actions:
+    label:
+      add:
+        - k3
+
 - name: label-nvidia
   description: Automatically apply nvidia label
   conditions:

--- a/.github/workflows/issue_autolabel.yml
+++ b/.github/workflows/issue_autolabel.yml
@@ -130,6 +130,25 @@ jobs:
                   },
                 ],
               },
+              kimi: {
+                keywords: [
+                  { term: "Kimi",     searchIn: "both" },
+                  { term: "Moonshot", searchIn: "both" },
+                ],
+                substrings: [
+                  { term: "moonshotai/", searchIn: "both" },
+                  { term: "kimi",        searchIn: "title" },
+                ],
+              },
+              k3: {
+                keywords: [
+                  { term: "Kimi K3", searchIn: "both" },
+                  { term: "K3",      searchIn: "title" },
+                ],
+                substrings: [
+                  { term: "moonshotai/kimi-k3", searchIn: "both" },
+                ],
+              },
               quantization: {
                 keywords: [
                   {


### PR DESCRIPTION
## Purpose

Adds auto-labeling for Moonshot's Kimi model family, in both places vLLM does labeling:

- **`.github/mergify.yml`** — a `label-kimi` rule for PRs, plus a temporary `label-k3` rule for K3 launch triage.
- **`.github/workflows/issue_autolabel.yml`** — matching `kimi` and `k3` entries in `labelConfig` for issues.

Kimi is now a sizable surface in the tree (22 files across `vllm/model_executor/models/`, `vllm/parser/`, `vllm/tokenizers/`, `vllm/reasoning/`, `vllm/tool_parsers/`, `vllm/transformers_utils/`, and `rust/src/parser/`), but has no labeling coverage, unlike `gpt-oss`, `rocm`, `nvidia`, etc.

> [!IMPORTANT]
> This adds auto-labeling rules referencing two new labels, `kimi` (Moonshot Kimi family) and `k3` (temporary K3 launch-triage tag). Neither exists yet — a maintainer will need to create them for the rules to take effect.

`label-k3` is deliberately temporary; its `description` field records that it should be retired after launch ramp-down.

### On the path patterns

The `files~=` conditions match the vendor name anywhere in the path (`(?i)kimi`, `(?i)moonshot`) rather than enumerating directories and extensions. This was a deliberate choice over the dir-scoped style used by `label-gpt-oss`:

- A dir-scoped, `.py`-only pattern list missed 7 of the 22 Kimi files — the three `rust/src/parser/**/kimi_*.rs` files, `vllm/parser/kimi_k2.py`, `vllm/tokenizers/kimi_audio.py`, `vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py`, and `vllm/transformers_utils/chat_templates/template_kimi_audio.jinja`.
- Two of those gaps exist because the directory list would have predated the `vllm/parser/` and `vllm/tokenizers/` split, so the enumerated form rots as parsers move.

`label-k3` uses `(?i)kimi[-_]?k3` rather than a bare `k3` substring specifically so it cannot collide with the many `*topk*` files in this repo (e.g. a future `tests/kernels/test_topk3.py`).

## Test plan and results

These are config files with no existing test suite, so verification was done by evaluating the patterns against the actual tree at `7154856f3`.

**1. `pre-commit run` on the staged files — all pass, nothing reformatted.** Notably `actionlint`:

```
typos ............................................. Passed
Lint GitHub Actions workflow files ................ Passed
Check for spaces in all filenames ................. Passed
Update Dockerfile dependency graph ................ Passed
Validate configuration has default values ......... Passed
(remaining hooks: no files to check / Skipped)
```

**2. Mergify rules parse; no duplicate rule names.**

```
YAML parses OK; rules: 34 | duplicate names: False
new rules present: ['label-kimi', 'label-k3']
```

**3. `label-kimi` file conditions evaluated against `git ls-files` — 22/22 Kimi files matched, zero false positives.**

```
label-kimi: 22 files matched
  false positives (non-kimi paths): none
  kimi surface coverage: 22/22; missed: none
```

**4. `label-k3` matches 0 files today, as expected (no K3 files exist yet).** Checked against hypothetical future paths to confirm it fires where intended and not where it shouldn't:

```
  MATCH  vllm/model_executor/models/kimi_k3.py
  MATCH  vllm/parser/kimi_k3.py
  MATCH  rust/src/parser/src/tool/kimi_k3.rs
  MATCH  tests/models/test_kimi-k3.py
  no     tests/kernels/test_topk3.py
  no     tests/kernels/moe/test_grouped_topk.py
```

**5. `issue_autolabel.yml` inline script — valid JS, entries parse as intended.** Checked with `node --check` (wrapped in an `async` function, as `actions/github-script` runs it), then evaluating `labelConfig`:

```
node --check (async-wrapped): OK
labelConfig keys (6): rocm, cpu, kimi, k3, quantization, intel-gpu
duplicate keys: false
order around insert: cpu -> kimi -> k3 -> quantization
```

The `ccConfig` step is untouched.

**Model evaluation:** not applicable. This change only touches GitHub repository automation — no vLLM runtime code, no effect on model output, accuracy, or serving.

## Not a duplicate

Checked before opening:

```
gh pr list --repo vllm-project/vllm --state open --search "kimi"
gh pr list --repo vllm-project/vllm --state open --search "mergify in:title"
gh pr list --repo vllm-project/vllm --state open --search "autolabel in:title"
gh pr list --repo vllm-project/vllm --state open --search "label in:title kimi"
```

The 20 open Kimi PRs are all model, kernel, parser, or CI-accuracy work — none touch labeling config. No open PR has `mergify`, `autolabel`, or `labeling` in its title, and none modifies `.github/mergify.yml` or `.github/workflows/issue_autolabel.yml`.

## AI assistance disclosure

AI assistance (Claude Code) was used to author this change and to run the verification above. The submitter has reviewed every changed line and reviewed the verification output.
