### PR TITLE
[Bugfix] Reject whitespace-only bad_words in SamplingParams

### DIFF
--- a/tests/test_sampling_params.py
+++ b/tests/test_sampling_params.py
@@ -48,3 +48,10 @@ def test_diffusion_accepts_top_k_top_p():
 def test_non_diffusion_models_unaffected():
     params = SamplingParams(temperature=0.7, top_k=10, seed=42)
     params.verify(MockModelConfig(), None, None, None)
+
+
+def test_bad_words_rejects_whitespace_only():
+    # A whitespace-only bad word tokenizes to an empty list, which later crashes
+    # update_from_tokenizer with an IndexError; reject it up front with a clear error.
+    with pytest.raises(ValueError, match="empty or whitespace-only"):
+        SamplingParams(bad_words=[" "])

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -616,9 +616,9 @@ class SamplingParams(
                 "Set detokenize=True to use stop."
             )
         assert isinstance(self.bad_words, list)
-        if any(not bad_word for bad_word in self.bad_words):
+        if any(not bad_word.strip() for bad_word in self.bad_words):
             raise ValueError(
-                f"bad_words cannot contain an empty string. "
+                f"bad_words cannot contain an empty or whitespace-only string. "
                 f"Got bad_words={self.bad_words}"
             )
 


### PR DESCRIPTION
## Purpose

`SamplingParams` already rejects an empty `bad_words` entry (`""`), but a whitespace-only entry
(e.g. `" "`, `"\t"`) slips through the check. Such a string tokenizes to an empty token list, which
later crashes `update_from_tokenizer` / `_bad_words_token_ids` handling with an `IndexError` instead
of a clear validation error.

## Fix

Treat whitespace-only strings the same as empty ones in the up-front validation
(`not bad_word.strip()`), and update the error message accordingly ("empty or whitespace-only
string").

## Test

Added `test_bad_words_rejects_whitespace_only`, asserting `SamplingParams(bad_words=[" "])` raises
`ValueError` matching `empty or whitespace-only`. Without the fix this input passes validation and
crashes later during tokenization.
