### PR TITLE
[Bugfix] Handle non-text frames in realtime speech WebSocket

### DIFF
--- a/tests/entrypoints/speech_to_text/realtime/test_realtime_connection_unit.py
+++ b/tests/entrypoints/speech_to_text/realtime/test_realtime_connection_unit.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the realtime WebSocket connection loop."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from starlette.websockets import WebSocketDisconnect
+
+from vllm.entrypoints.speech_to_text.realtime.connection import RealtimeConnection
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+class _FakeWebSocket:
+    """Minimal WebSocket that mirrors Starlette's frame semantics.
+
+    ``receive`` returns raw ASGI messages; ``receive_text`` reproduces
+    Starlette's behavior of indexing ``message["text"]`` (which raises
+    ``KeyError`` on a binary frame). This lets the same test exercise both the
+    old ``receive_text`` path and the new ``receive`` path faithfully.
+    """
+
+    def __init__(self, frames: list[dict]):
+        self._frames = iter([*frames, {"type": "websocket.disconnect", "code": 1000}])
+        self.accept = AsyncMock()
+        self.send_text = AsyncMock()
+
+    async def receive(self) -> dict:
+        return next(self._frames)
+
+    async def receive_text(self) -> str:
+        message = await self.receive()
+        if message["type"] == "websocket.disconnect":
+            raise WebSocketDisconnect(message.get("code", 1000))
+        return message["text"]
+
+    def sent_error_codes(self) -> list[str]:
+        codes = []
+        for call in self.send_text.await_args_list:
+            payload = json.loads(call.args[0])
+            if payload.get("type") == "error":
+                codes.append(payload.get("code"))
+        return codes
+
+
+def _make_connection(frames: list[dict]):
+    websocket = _FakeWebSocket(frames)
+    conn = RealtimeConnection(websocket=websocket, serving=MagicMock())
+    return conn, websocket
+
+
+@pytest.mark.asyncio
+async def test_binary_frame_reports_error_and_keeps_session_open():
+    """A binary frame must not crash the session; the client gets a clean
+    error event and the loop continues to the next frame.
+
+    Previously ``receive_text()`` raised ``KeyError`` on the missing ``text``
+    key, which propagated past the per-event handler and killed the session
+    without ever sending an error to the client.
+    """
+    conn, websocket = _make_connection(
+        [{"type": "websocket.receive", "bytes": b"\x00\x01\x02\x03"}]
+    )
+
+    await conn.handle_connection()
+
+    assert "invalid_frame" in websocket.sent_error_codes()
+
+
+@pytest.mark.asyncio
+async def test_text_frame_is_routed_to_handle_event():
+    """A normal text frame is decoded and dispatched to handle_event."""
+    conn, websocket = _make_connection(
+        [{"type": "websocket.receive", "text": '{"type": "input_audio_buffer.append"}'}]
+    )
+    conn.handle_event = AsyncMock()
+
+    await conn.handle_connection()
+
+    conn.handle_event.assert_awaited_once_with({"type": "input_audio_buffer.append"})
+
+
+@pytest.mark.asyncio
+async def test_disconnect_frame_ends_loop_cleanly():
+    """A disconnect frame ends the loop without emitting an error event."""
+    conn, websocket = _make_connection([])
+
+    await conn.handle_connection()
+
+    assert conn._is_connected is False
+    assert websocket.sent_error_codes() == []

--- a/vllm/entrypoints/speech_to_text/realtime/connection.py
+++ b/vllm/entrypoints/speech_to_text/realtime/connection.py
@@ -65,7 +65,18 @@ class RealtimeConnection:
 
         try:
             while True:
-                message = await self.websocket.receive_text()
+                message = await self._receive_text_frame()
+                if message is None:
+                    # A non-text frame (e.g. raw binary audio) was received.
+                    # Realtime events must be JSON text frames, so report the
+                    # error and keep the session open instead of letting the
+                    # missing "text" key crash the connection.
+                    await self.send_error(
+                        "Expected a text frame containing a JSON event; "
+                        "binary frames are not supported.",
+                        "invalid_frame",
+                    )
+                    continue
                 try:
                     event = json.loads(message)
                     await self.handle_event(event)
@@ -81,6 +92,19 @@ class RealtimeConnection:
             logger.exception("Unexpected error in connection: %s", e)
         finally:
             await self.cleanup()
+
+    async def _receive_text_frame(self) -> str | None:
+        """Receive one frame, returning its text payload.
+
+        Unlike ``WebSocket.receive_text``, which raises ``KeyError`` on a
+        binary frame, this returns ``None`` so the caller can reject it
+        gracefully. Disconnects are surfaced as ``WebSocketDisconnect`` to
+        match the existing handling.
+        """
+        message = await self.websocket.receive()
+        if message["type"] == "websocket.disconnect":
+            raise WebSocketDisconnect(message.get("code", 1000))
+        return message.get("text")
 
     def _check_model(self, model: str | None) -> None | ErrorResponse:
         if self.serving._is_model_supported(model):


### PR DESCRIPTION
## Purpose

Fix a crash in the realtime speech-to-text WebSocket that silently kills the session when a client sends a binary frame.

`RealtimeConnection.handle_connection` reads every frame with `websocket.receive_text()`:

```python
while True:
    message = await self.websocket.receive_text()
    try:
        event = json.loads(message)
        await self.handle_event(event)
    ...
```

Starlette's `receive_text` does `return cast(str, message["text"])`. For a binary frame the ASGI message is `{"type": "websocket.receive", "bytes": b"..."}` — there is no `"text"` key, so it raises `KeyError`. That `KeyError` is raised **outside** the inner `try`, so it propagates to the connection-level `except Exception` (`connection.py:80`), which logs and runs `cleanup()` — the session is torn down and the socket closes with a bare `1000`, with **no error event ever sent to the client**.

Sending raw PCM as a binary frame instead of base64-in-JSON is the natural mistake on a realtime **audio** endpoint (every OpenAI-realtime-style client exposes `ws.send(bytes)`), so this is easy to trigger by accident.

### Fix

Receive frames via `websocket.receive()` and reject non-text frames with a clean `invalid_frame` error event, keeping the session open. Disconnects are still surfaced as `WebSocketDisconnect` so the existing handling is unchanged:

```python
async def _receive_text_frame(self) -> str | None:
    message = await self.websocket.receive()
    if message["type"] == "websocket.disconnect":
        raise WebSocketDisconnect(message.get("code", 1000))
    return message.get("text")
```

## Test Plan

New unit tests in `tests/entrypoints/speech_to_text/realtime/test_realtime_connection_unit.py` drive `handle_connection` with a fake WebSocket that mirrors Starlette's frame semantics (so `receive_text` really raises `KeyError` on a binary frame):

```
pytest tests/entrypoints/speech_to_text/realtime/test_realtime_connection_unit.py
```

- `test_binary_frame_reports_error_and_keeps_session_open` — a binary frame yields an `invalid_frame` error event instead of crashing.
- `test_text_frame_is_routed_to_handle_event` — normal text frames still dispatch.
- `test_disconnect_frame_ends_loop_cleanly` — disconnect ends the loop with no error event.

## Test Result

With the fix: `3 passed`. Against the current code the binary-frame test fails with the original `KeyError: 'text'` logged at `connection.py` (session dies, no `invalid_frame` emitted), confirming the test reproduces the bug. `pre-commit run` passes on both files (ruff, ruff-format, typos, mypy).
