### PR TITLE
[Bugfix][Quantization] Match draft model quant targets under its root prefix

### DIFF
--- a/tests/quantization/test_compressed_tensors.py
+++ b/tests/quantization/test_compressed_tensors.py
@@ -22,6 +22,10 @@ from vllm.model_executor.kernels.linear import (
     Fp8BlockScaledMMLinearKernel,
 )
 from vllm.model_executor.layers.fused_moe import UnquantizedFusedMoEMethod
+from vllm.model_executor.layers.linear import (
+    RowParallelLinear,
+    UnquantizedLinearMethod,
+)
 from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import (  # noqa: E501
     CompressedTensorsConfig,
     CompressedTensorsLinearMethod,
@@ -653,6 +657,47 @@ def test_get_quant_method_returns_none_for_unmatched_parallel_lm_head():
     assert method is None, (
         f"Expected None for unmatched ParallelLMHead, got {type(method).__name__}"
     )
+
+
+def _make_draft_linear() -> Mock:
+    mock_layer = Mock(spec=RowParallelLinear)
+    mock_layer.__class__ = RowParallelLinear
+    return mock_layer
+
+
+@pytest.mark.parametrize(
+    "target",
+    ["model.layers.0.mlp.down_proj", r"re:model\.layers\.\d+\.mlp\.down_proj"],
+)
+def test_get_quant_method_matches_targets_under_model_root_prefix(target):
+    """Layer-name targets must match when the model loads under a root prefix.
+
+    Speculative drafters load under a synthetic `draft_model` root, but their
+    checkpoint's targets are relative to the checkpoint. Without stripping the
+    root, only `Linear`-style class-name targets match, so mixed-precision
+    `config_groups` checkpoints load unquantized and fail on `weight_packed`.
+    """
+    config = _make_ct_config(target=target)
+    config.model_root_prefix = "draft_model"
+
+    method = config.get_quant_method(
+        _make_draft_linear(), prefix="draft_model.model.layers.0.mlp.down_proj"
+    )
+
+    assert isinstance(method, CompressedTensorsLinearMethod)
+
+
+def test_get_quant_method_honors_ignore_under_model_root_prefix():
+    """The ignore list is checkpoint-relative too, so it must survive the root."""
+    config = _make_ct_config(target="Linear")
+    config.ignore = ["model.layers.0.mlp.down_proj"]
+    config.model_root_prefix = "draft_model"
+
+    method = config.get_quant_method(
+        _make_draft_linear(), prefix="draft_model.model.layers.0.mlp.down_proj"
+    )
+
+    assert isinstance(method, UnquantizedLinearMethod)
 
 
 def test_find_matched_target_returns_none_on_no_match():

--- a/tests/quantization/test_compressed_tensors.py
+++ b/tests/quantization/test_compressed_tensors.py
@@ -700,6 +700,47 @@ def test_get_quant_method_honors_ignore_under_model_root_prefix():
     assert isinstance(method, UnquantizedLinearMethod)
 
 
+def test_get_quant_method_selects_per_group_scheme_under_model_root_prefix():
+    """Mixed config_groups must keep per-layer scheme selection under the root.
+
+    The #49893 checkpoint quantizes different layer ranges at different
+    bit-widths. Each layer must receive the scheme of the group whose
+    checkpoint-relative target names it, not just any matching scheme.
+    """
+
+    def group(num_bits: int) -> dict:
+        return {
+            "weights": QuantizationArgs(
+                num_bits=num_bits,
+                type=QuantizationType.INT,
+                strategy=QuantizationStrategy.GROUP,
+                group_size=128,
+                symmetric=True,
+                dynamic=False,
+            ),
+            "input_activations": None,
+            "format": "pack-quantized",
+        }
+
+    config = CompressedTensorsConfig(
+        target_scheme_map={
+            "model.layers.0.mlp.down_proj": group(4),
+            "model.layers.1.mlp.down_proj": group(8),
+        },
+        ignore=[],
+        quant_format="pack-quantized",
+    )
+    config.model_root_prefix = "draft_model"
+
+    for layer_idx, num_bits in ((0, 4), (1, 8)):
+        layer = _make_draft_linear()
+        method = config.get_quant_method(
+            layer, prefix=f"draft_model.model.layers.{layer_idx}.mlp.down_proj"
+        )
+        assert isinstance(method, CompressedTensorsLinearMethod)
+        assert layer.scheme.quant_type.size_bits == num_bits
+
+
 def test_find_matched_target_returns_none_on_no_match():
     result = find_matched_target(
         layer_name="model.layers.0.self_attn.qkv_proj",

--- a/tests/quantization/test_compressed_tensors.py
+++ b/tests/quantization/test_compressed_tensors.py
@@ -30,6 +30,11 @@ from vllm.model_executor.kernels.linear.scaled_mm import (
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import UnquantizedFusedMoEMethod
 from vllm.model_executor.layers.fused_moe.oracle.fp8 import Fp8MoeBackend
+from vllm.model_executor.layers.linear import (
+    RowParallelLinear,
+    UnquantizedLinearMethod,
+)
+from vllm.model_executor.layers.quantization import resolve_quant_method
 from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import (  # noqa: E501
     CompressedTensorsConfig,
     CompressedTensorsLinearMethod,
@@ -706,6 +711,102 @@ def test_get_quant_method_returns_none_for_unmatched_parallel_lm_head():
     assert method is None, (
         f"Expected None for unmatched ParallelLMHead, got {type(method).__name__}"
     )
+
+
+def _make_draft_linear() -> Mock:
+    mock_layer = Mock(spec=RowParallelLinear)
+    mock_layer.__class__ = RowParallelLinear
+    return mock_layer
+
+
+@pytest.mark.parametrize(
+    "target",
+    ["model.layers.0.mlp.down_proj", r"re:model\.layers\.\d+\.mlp\.down_proj"],
+)
+def test_resolve_quant_method_matches_targets_under_model_root_prefix(target):
+    """Layer-name targets must match when the model loads under a root prefix.
+
+    Speculative drafters load under a synthetic `draft_model` root, but their
+    checkpoint's targets are relative to the checkpoint. Without stripping the
+    root, only `Linear`-style class-name targets match, so mixed-precision
+    `config_groups` checkpoints load unquantized and fail on `weight_packed`.
+    """
+    config = _make_ct_config(target=target)
+    config.model_root_prefix = "draft_model"
+
+    method = resolve_quant_method(
+        config, _make_draft_linear(), prefix="draft_model.model.layers.0.mlp.down_proj"
+    )
+
+    assert isinstance(method, CompressedTensorsLinearMethod)
+
+
+def test_strip_model_root_prefix_only_strips_a_whole_root_segment():
+    """A root strip must not truncate names that merely share its spelling."""
+    config = _make_ct_config(target="Linear")
+    config.model_root_prefix = "draft_model"
+
+    assert config.strip_model_root_prefix("draft_model.mlp.gate") == "mlp.gate"
+    assert config.strip_model_root_prefix("draft_model") == ""
+    assert config.strip_model_root_prefix("draft_modelish.x") == "draft_modelish.x"
+    assert config.strip_model_root_prefix("other.x") == "other.x"
+
+    unrooted = _make_ct_config(target="Linear")
+    assert unrooted.strip_model_root_prefix("draft_model.x") == "draft_model.x"
+
+
+def test_resolve_quant_method_honors_ignore_under_model_root_prefix():
+    """The ignore list is checkpoint-relative too, so it must survive the root."""
+    config = _make_ct_config(target="Linear")
+    config.ignore = ["model.layers.0.mlp.down_proj"]
+    config.model_root_prefix = "draft_model"
+
+    method = resolve_quant_method(
+        config, _make_draft_linear(), prefix="draft_model.model.layers.0.mlp.down_proj"
+    )
+
+    assert isinstance(method, UnquantizedLinearMethod)
+
+
+def test_resolve_quant_method_selects_per_group_scheme_under_model_root_prefix():
+    """Mixed config_groups must keep per-layer scheme selection under the root.
+
+    The #49893 checkpoint quantizes different layer ranges at different
+    bit-widths. Each layer must receive the scheme of the group whose
+    checkpoint-relative target names it, not just any matching scheme.
+    """
+
+    def group(num_bits: int) -> dict:
+        return {
+            "weights": QuantizationArgs(
+                num_bits=num_bits,
+                type=QuantizationType.INT,
+                strategy=QuantizationStrategy.GROUP,
+                group_size=128,
+                symmetric=True,
+                dynamic=False,
+            ),
+            "input_activations": None,
+            "format": "pack-quantized",
+        }
+
+    config = CompressedTensorsConfig(
+        target_scheme_map={
+            "model.layers.0.mlp.down_proj": group(4),
+            "model.layers.1.mlp.down_proj": group(8),
+        },
+        ignore=[],
+        quant_format="pack-quantized",
+    )
+    config.model_root_prefix = "draft_model"
+
+    for layer_idx, num_bits in ((0, 4), (1, 8)):
+        layer = _make_draft_linear()
+        method = resolve_quant_method(
+            config, layer, prefix=f"draft_model.model.layers.{layer_idx}.mlp.down_proj"
+        )
+        assert isinstance(method, CompressedTensorsLinearMethod)
+        assert layer.scheme.quant_type.size_bits == num_bits
 
 
 def test_find_matched_target_returns_none_on_no_match():

--- a/tests/quantization/test_fp8.py
+++ b/tests/quantization/test_fp8.py
@@ -7,6 +7,7 @@ Run `pytest tests/quantization/test_fp8.py --forked`.
 
 import logging
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 import regex as re
@@ -30,6 +31,11 @@ from vllm.model_executor.layers.attention.attention import (
     set_default_quant_scales,
 )
 from vllm.model_executor.layers.fused_moe import FusedMoEFactory
+from vllm.model_executor.layers.linear import (
+    RowParallelLinear,
+    UnquantizedLinearMethod,
+)
+from vllm.model_executor.layers.quantization import resolve_quant_method
 from vllm.model_executor.layers.quantization.fp8 import (
     Fp8Config,
     Fp8KVCacheMethod,
@@ -560,3 +566,24 @@ def test_kv_cache_dtype_skip_layers(monkeypatch, dist_init, workspace_init):
     for i, layer in enumerate(model.model.decoder.layers):
         expected = "auto" if str(i) in ["0", "2"] else "fp8"
         assert layer.self_attn.attn.kv_cache_dtype == expected
+
+
+def test_resolve_quant_method_honors_ignored_layers_under_model_root_prefix():
+    """The root strip must apply to every backend, not just compressed-tensors.
+
+    FP8 matches `ignored_layers` by exact name, so a drafter loaded under a
+    synthetic root would quantize layers its checkpoint asks to skip.
+    """
+    config = Fp8Config(
+        is_checkpoint_fp8_serialized=True,
+        ignored_layers=["model.layers.0.mlp.down_proj"],
+    )
+    config.model_root_prefix = "draft_model"
+
+    layer = Mock(spec=RowParallelLinear)
+    layer.__class__ = RowParallelLinear
+    method = resolve_quant_method(
+        config, layer, prefix="draft_model.model.layers.0.mlp.down_proj"
+    )
+
+    assert isinstance(method, UnquantizedLinearMethod)

--- a/tests/v1/spec_decode/test_draft_model_quantization.py
+++ b/tests/v1/spec_decode/test_draft_model_quantization.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from vllm.v1.spec_decode.draft_model import DraftModelProposer
+
+
+def test_draft_model_declares_the_root_it_loads_under():
+    """The root given to the quant config must be the one the model loads under.
+
+    Draft layer names carry a synthetic root that the draft checkpoint's
+    quantization config knows nothing about. If the two drift apart, layer-name
+    targets silently stop matching and the drafter loads unquantized.
+    """
+    proposer = DraftModelProposer.__new__(DraftModelProposer)
+    quant_config = SimpleNamespace(model_root_prefix="")
+    draft_vllm_config = Mock(quant_config=quant_config)
+
+    with (
+        patch.object(
+            DraftModelProposer,
+            "_create_draft_vllm_config",
+            return_value=draft_vllm_config,
+        ),
+        patch("vllm.v1.spec_decode.draft_model.get_model") as mock_get_model,
+    ):
+        proposer._get_model()
+
+    assert quant_config.model_root_prefix == mock_get_model.call_args.kwargs["prefix"]

--- a/vllm/model_executor/layers/quantization/base_config.py
+++ b/vllm/model_executor/layers/quantization/base_config.py
@@ -99,6 +99,12 @@ class QuantizationConfig(ABC):
     not in the model, and should be ignored if unexpected during loading. These are used
     after remapping, so should be in vLLM format (e.g. .q_scale, not .q.scale)."""
 
+    model_root_prefix: str = ""
+    """Prefix the model is loaded under when it is not the top-level model, e.g.
+    `"draft_model"` for a speculative drafter. Runtime layer prefixes include it,
+    but the checkpoint's quantization config does not, so it must be stripped
+    before layer names are matched against targets."""
+
     def __init__(self):
         super().__init__()
         # mapping is updated by models as they initialize
@@ -225,6 +231,21 @@ class QuantizationConfig(ABC):
             re.compile(r"(?<!\.attn)\.([qkv])_zero_point$"): r".attn.\1_zero_point",
         }
         return WeightsMapper(orig_to_new_regex=orig_to_new_regex)
+
+    def strip_model_root_prefix(self, prefix: str) -> str:
+        """Convert a runtime layer prefix into a checkpoint-relative layer name.
+
+        Args:
+            prefix: the layer's runtime prefix, which is rooted at
+                `model_root_prefix`.
+
+        Returns:
+            The layer name as the checkpoint's quantization config refers to it.
+        """
+        root = self.model_root_prefix
+        if root and prefix.startswith(f"{root}."):
+            return prefix[len(root) + 1 :]
+        return prefix
 
     def apply_vllm_mapper(  # noqa: B027
         self, hf_to_vllm_mapper: "WeightsMapper"

--- a/vllm/model_executor/layers/quantization/base_config.py
+++ b/vllm/model_executor/layers/quantization/base_config.py
@@ -113,6 +113,12 @@ class QuantizationConfig(ABC):
     after remapping, so should be in vLLM format (e.g. .q_scale, not .q.scale)."""
     online_quantization_config: "OnlineQuantizationConfig | None" = None
 
+    model_root_prefix: str = ""
+    """Prefix the model is loaded under when it is not the top-level model, e.g.
+    `"draft_model"` for a speculative drafter. Runtime layer prefixes include it,
+    but the checkpoint's quantization config does not, so it must be stripped
+    before layer names are matched against targets."""
+
     def __init__(self):
         super().__init__()
         # mapping is updated by models as they initialize
@@ -248,6 +254,25 @@ class QuantizationConfig(ABC):
 
         return WeightsMapper(orig_to_new_suffix={".g_idx": None})
 
+    def strip_model_root_prefix(self, prefix: str) -> str:
+        """Convert a runtime layer prefix into a checkpoint-relative layer name.
+
+        Args:
+            prefix: the layer's runtime prefix, which is rooted at
+                `model_root_prefix`.
+
+        Returns:
+            The layer name as the checkpoint's quantization config refers to it.
+        """
+        root = self.model_root_prefix
+        if not root:
+            return prefix
+        if prefix == root:
+            return ""
+        if prefix.startswith(f"{root}."):
+            return prefix[len(root) + 1 :]
+        return prefix
+
     def apply_vllm_mapper(  # noqa: B027
         self, hf_to_vllm_mapper: "WeightsMapper"
     ):
@@ -295,6 +320,7 @@ def resolve_quant_method(
         UnquantizedLinearMethod,
     )
 
+    prefix = quant_config.strip_model_root_prefix(prefix)
     base_quant_method = quant_config.get_quant_method(layer, prefix)
     if quant_config.online_quantization_config is None:
         return base_quant_method

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -155,6 +155,8 @@ class CompressedTensorsConfig(QuantizationConfig):
         layer: torch.nn.Module,
         prefix: str,
     ) -> "QuantizeMethodBase | None":
+        prefix = self.strip_model_root_prefix(prefix)
+
         if isinstance(layer, LinearBase):
             # collect schemes
             quant_scheme = self.get_scheme(layer=layer, layer_name=prefix)

--- a/vllm/model_executor/models/bailing_moe_v3.py
+++ b/vllm/model_executor/models/bailing_moe_v3.py
@@ -277,7 +277,7 @@ def _is_fp8_module_excluded(
         return False
 
     return is_layer_skipped(
-        prefix=prefix,
+        prefix=quant_config.strip_model_root_prefix(prefix),
         ignored_layers=quant_config.ignored_layers,
         fused_mapping=quant_config.packed_modules_mapping,
         match_mode=quant_config.ignored_layers_match_mode,

--- a/vllm/model_executor/models/bailing_moe_v3_vl.py
+++ b/vllm/model_executor/models/bailing_moe_v3_vl.py
@@ -211,7 +211,8 @@ class BailingMoeV3VisionTransformer(Qwen3_VisionTransformer):
         # Honor whole-tower exclusions before the parent creates linear layers.
         if (
             isinstance(quant_config, Fp8Config)
-            and prefix in quant_config.ignored_layers
+            and quant_config.strip_model_root_prefix(prefix)
+            in quant_config.ignored_layers
         ):
             quant_config = None
 
@@ -251,7 +252,8 @@ class BailingMoeV3VLProjector(nn.Module):
         super().__init__()
         if (
             isinstance(quant_config, Fp8Config)
-            and prefix in quant_config.ignored_layers
+            and quant_config.strip_model_root_prefix(prefix)
+            in quant_config.ignored_layers
         ):
             quant_config = None
 

--- a/vllm/models/kimi_k3/nvidia/kda.py
+++ b/vllm/models/kimi_k3/nvidia/kda.py
@@ -620,7 +620,10 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
         alignment = (
             128
             if isinstance(self.quant_config, ModelOptMixedPrecisionConfig)
-            and self.quant_config._resolve_quant_algo(in_proj_prefix) == "FP8_PB_WO"
+            and self.quant_config._resolve_quant_algo(
+                self.quant_config.strip_model_root_prefix(in_proj_prefix)
+            )
+            == "FP8_PB_WO"
             else 16
         )
         self.in_proj_padding = -local_output_size % alignment

--- a/vllm/models/qwen4_exp/nvidia/ngram_embedding.py
+++ b/vllm/models/qwen4_exp/nvidia/ngram_embedding.py
@@ -175,6 +175,7 @@ class Qwen4ExpPLEEmbeddingMethod(QuantizeMethodBase):
             return Qwen4ExpPLEFp8EmbeddingMethod()
         if quant_config is None:
             return Qwen4ExpPLEUnquantizedEmbeddingMethod()
+        prefix = quant_config.strip_model_root_prefix(prefix)
         if isinstance(quant_config, ModelOptMixedPrecisionConfig):
             if quant_config._resolve_quant_algo(prefix) == "FP8":
                 return Qwen4ExpPLEFp8EmbeddingMethod()

--- a/vllm/v1/spec_decode/draft_model.py
+++ b/vllm/v1/spec_decode/draft_model.py
@@ -15,6 +15,10 @@ from vllm.v1.spec_decode.vocab_mapping import VocabMapping
 
 logger = init_logger(__name__)
 
+DRAFT_MODEL_PREFIX = "draft_model"
+"""Synthetic root the drafter loads under, so its layer names cannot collide
+with the target model's in the shared static forward context."""
+
 
 class DraftModelProposer(SpecDecodeBaseProposer):
     def __init__(
@@ -97,10 +101,15 @@ class DraftModelProposer(SpecDecodeBaseProposer):
         from vllm.compilation.backends import set_model_tag
 
         draft_vllm_config = self._create_draft_vllm_config()
-        with set_model_tag("draft_model"):
+        # The draft checkpoint's quantization config names layers relative to
+        # itself, so the root has to be declared for target matching. Unlike
+        # e.g. "language_model", this root is not part of the checkpoint.
+        if draft_vllm_config.quant_config is not None:
+            draft_vllm_config.quant_config.model_root_prefix = DRAFT_MODEL_PREFIX
+        with set_model_tag(DRAFT_MODEL_PREFIX):
             model = get_model(
                 vllm_config=draft_vllm_config,
-                prefix="draft_model",
+                prefix=DRAFT_MODEL_PREFIX,
             )
         return model
 

--- a/vllm/v1/spec_decode/draft_model.py
+++ b/vllm/v1/spec_decode/draft_model.py
@@ -106,7 +106,7 @@ class DraftModelProposer(SpecDecodeBaseProposer):
         # e.g. "language_model", this root is not part of the checkpoint.
         if draft_vllm_config.quant_config is not None:
             draft_vllm_config.quant_config.model_root_prefix = DRAFT_MODEL_PREFIX
-        with set_model_tag("draft_model"):
+        with set_model_tag(DRAFT_MODEL_PREFIX):
             model = get_model(
                 vllm_config=draft_vllm_config,
                 prefix=DRAFT_MODEL_PREFIX,

--- a/vllm/v1/spec_decode/draft_model.py
+++ b/vllm/v1/spec_decode/draft_model.py
@@ -15,6 +15,10 @@ from vllm.v1.spec_decode.vocab_mapping import VocabMapping
 
 logger = init_logger(__name__)
 
+DRAFT_MODEL_PREFIX = "draft_model"
+"""Synthetic root the drafter loads under, so its layer names cannot collide
+with the target model's in the shared static forward context."""
+
 
 class DraftModelProposer(SpecDecodeBaseProposer):
     def __init__(
@@ -97,10 +101,15 @@ class DraftModelProposer(SpecDecodeBaseProposer):
         from vllm.compilation.backends import set_model_tag
 
         draft_vllm_config = self._create_draft_vllm_config()
+        # The draft checkpoint's quantization config names layers relative to
+        # itself, so the root has to be declared for target matching. Unlike
+        # e.g. "language_model", this root is not part of the checkpoint.
+        if draft_vllm_config.quant_config is not None:
+            draft_vllm_config.quant_config.model_root_prefix = DRAFT_MODEL_PREFIX
         with set_model_tag("draft_model"):
             model = get_model(
                 vllm_config=draft_vllm_config,
-                prefix="draft_model",
+                prefix=DRAFT_MODEL_PREFIX,
             )
         return model
 


### PR DESCRIPTION
## Purpose

Addresses #49893 (the target-matching failure; a separate checkpoint packing-layout issue remains — see Validation status below).

A mixed-precision compressed-tensors checkpoint (`GPTQModifier(config_groups={...})`) crashes when used as a `method="draft_model"` drafter, while a single-scheme `scheme="W4A16"` checkpoint of the same model loads fine.

```
ValueError: There is no module or parameter named 'layers.0.mlp.down_proj.weight_packed'
in Qwen3Model. The available parameters belonging to layers.0.mlp.down_proj
(RowParallelLinear) are: {'layers.0.mlp.down_proj.weight'}
```

**Root cause.** `DraftModelProposer._get_model` loads the drafter under a synthetic root, `prefix="draft_model"` (`vllm/v1/spec_decode/draft_model.py`), so the prefix reaching quantization matching is `draft_model.model.layers.0.mlp.down_proj`. The checkpoint's targets are relative to the checkpoint and contain no `draft_model` component, so exact-name and start-anchored regex targets fail to match; only class-name targets (`"Linear"`) still match because that path is a substring check. That's exactly why the reporter's single-scheme checkpoint works and the `config_groups` one does not.

### Revision history on this PR

An earlier version of this fix stripped the root inside `CompressedTensorsConfig.get_quant_method` only. @benchislett requested changes: *"I don't recall exactly, but I think we've encountered similar issues before and this does not look like the right solution. I think this can be done more cleanly."*

I got two independent second opinions on the redesign (one from a different Claude model, one from GPT-5.6 at max reasoning effort), each asked to verify every claim against the source and to defend the original approach if they thought it was actually fine. Both converged on the same fix, described below, and both confirmed the CT-only approach under-covered the bug: fp8 (exact `ignored_layers` matching), ModelOpt (`exclude_modules` / `quantized_layers`), quark, and gptq's anchored `dynamic` regexes are all broken by a synthetic root the same way — only compressed-tensors was fixed.

**Fix.** Record the root on the quantization config (`QuantizationConfig.model_root_prefix`) and strip it in the module-level `resolve_quant_method` (`base_config.py`) before it delegates to `get_quant_method`. Since #51392, that function is already the single entry point every core layer uses to select its quant method (`linear.py`, `vocab_parallel_embedding.py`, `attention.py`, `mla_attention.py`, `fused_moe/routed_experts.py`, `models/kimi_k3/nvidia/mla.py`), so a one-line strip there fixes every quantization backend at once with no call-site changes. The abstract `get_quant_method` is untouched, so out-of-tree quantization configs are unaffected. Model-side matchers that bypass `get_quant_method` entirely and compare a runtime prefix against the checkpoint config directly are updated to strip the root too: `bailing_moe_v3._is_fp8_module_excluded`, the two `ignored_layers` checks in `bailing_moe_v3_vl.py`, the `_resolve_quant_algo` alignment probe in `kimi_k3/nvidia/kda.py`, and `Qwen4ExpPLEEmbeddingMethod.from_quant_config`. Without that, the Kimi-K3 fused projection would pick a 16-byte alignment in the constructor while the dispatcher later selects `FP8_PB_WO`, which needs 128.

*Rebased 2026-09-10 onto #51392, which moved `resolve_quant_method` from a method I had added on `QuantizationConfig` to a module-level function; the fix now lives in that function and the per-call-site edits from the previous revision are gone. Behavior is unchanged.*

Rewriting the checkpoint's targets with `apply_vllm_mapper` instead (map `"" -> "draft_model."` before construction) was considered and rejected: `CompressedTensorsConfig.apply_vllm_mapper` deliberately preserves targets that aren't layer paths (`"Linear"`, no `.`) and `re:`-prefixed targets, since a broad prefix map is known to be unsafe for those (see the docstring on that method). `re:` targets are also anchored (`re.match`), so a checkpoint's `ignore=["lm_head"]` or any `re:` target would silently stop matching after the root is added, regardless of the mapper. Stripping the runtime name instead of rewriting the checkpoint's targets avoids all three failure modes and matches how the codebase already handles two other synthetic/legacy roots ad hoc: `ModelOptConfig` already strips `language_model.` for older checkpoints, and the Transformers backend already strips its own synthetic `model.` root for Eagle3 layer names.

Only `draft_model.py` sets `model_root_prefix`, because only it invents a root that is absent from the checkpoint. Multimodal inner models load under `prefix="language_model"` too, but that prefix *is* part of the checkpoint, so it must keep matching as-is and is deliberately untouched.

### Why this is not a duplicate

Checked before starting, and no PR touches this:

- `gh pr list -R vllm-project/vllm --state all --search "49893 in:body"` → no results
- keyword searches for `draft_model` / `config_groups` / speculative + compressed-tensors quantization → no PR covering this path
- issue participants are the reporter only, no assignee, no cross-referenced PRs, no informal claim in comments

The nearest open PRs are adjacent but different problems: #40849 (inherit *online* quantization for draft models) and #43319 (skip `quant_config` for a BF16 MTP drafter). #49553 ("Qwen3.5 MTP: honor checkpoint per-layer quantization config for draft layers") is the closest-sounding one but fixes `hf_to_vllm_mapper` propagation for the **MTP** path, where draft layers live inside the target model's own naming — a mapper can't fix a root that has no checkpoint-side name to map to, which is what this PR addresses.

## Test Plan

The failing decision is reachable without a GPU or a checkpoint, so the tests drive the real entry points directly with configs built in-process, matching the existing CPU-only unit tests already in these files.

`tests/quantization/test_compressed_tensors.py` (call `resolve_quant_method`, the entry point layers use, plus one addition):
- `test_resolve_quant_method_matches_targets_under_model_root_prefix` — parametrized over an exact-name target and a start-anchored regex target
- `test_resolve_quant_method_honors_ignore_under_model_root_prefix`
- `test_resolve_quant_method_selects_per_group_scheme_under_model_root_prefix` — two `config_groups` at different bit-widths (W4/W8)
- `test_strip_model_root_prefix_only_strips_a_whole_root_segment` (new) — boundary cases: `prefix == root`, a name that merely starts with the same characters (`draft_modelish`), and an unrooted config leaving names untouched

`tests/quantization/test_fp8.py` (new):
- `test_resolve_quant_method_honors_ignored_layers_under_model_root_prefix` — proves the fix is now general, not compressed-tensors-only. Red on the old `get_quant_method` path (falls through to constructing `Fp8LinearMethod`, i.e. quantizes a layer the checkpoint says to ignore), green on `resolve_quant_method`.

`tests/v1/spec_decode/test_draft_model_quantization.py`:
- `test_draft_model_declares_the_root_it_loads_under` — the root handed to the quant config must equal the prefix the model is actually loaded under

```bash
.venv/bin/python -m pytest tests/quantization/test_compressed_tensors.py \
       tests/quantization/test_fp8.py \
       tests/v1/spec_decode/test_draft_model_quantization.py \
       -k "model_root_prefix or parallel_lm_head or draft_model or strip_model_root"
# 10 passed
```

Full regression sweep, `tests/quantization/` (excludes `--forked` GPU/download-only tests not runnable on this CPU-only machine), run identically on this branch and on unmodified `origin/main`:

```
main (unmodified):  42 failed, 285 passed, 211 skipped
this branch:        42 failed, 287 passed, 211 skipped   (+2 = the new tests above)
```

The two failure sets are identical (`comm` diff is empty both ways) — zero regressions, two new passing tests. The 42 failures are pre-existing on main and need a GPU or network access to a real model repo (e.g. `test_compressed_tensors_fp8`, `test_lm_head[...GPTQ...]`), not a fixture problem introduced here.

Lint: `pre-commit run --files <the changed files>` — all hooks pass, including `ruff check`, `ruff format`, and `mypy`.

Built and tested locally via the CPU path (`requirements/build/cpu.txt` + `requirements/cpu.txt`, `uv pip install -e . --no-build-isolation`), the same sequence `.github/workflows/macos-smoke-test.yml` uses, on Apple Silicon.

### Validation status (updated 2026-07-29, unchanged by this revision)

The reporter built an earlier version of this branch from source and confirmed the original `weight_packed` `ValueError` is gone — the target-matching fix works ([validation comment](https://github.com/vllm-project/vllm/issues/49893#issuecomment-5087852033)).

Their mixed W4/W3 checkpoint then fails later, in weight loading (`parameter.py` shape assert, param `[3072, 96]` vs checkpoint `[3072, 103]` on a W3-group `gate_up_proj`). That is a packing-layout mismatch independent of this PR: vLLM sizes W3 packed weights densely (`ceil(1024·3/32) = 96` int32 columns, matching current compressed-tensors `pack_to_int32`), while the checkpoint's 3-bit tensors are packed whole-values-per-int32 (`ceil(1024/⌊32/3⌋) = 103`) — a layout predating the dense arbitrary-bit packing added in compressed-tensors 0.17.0 (vllm-project/compressed-tensors@3f01c78). The two layouts coincide for 4-bit (32/4 is exact), which is why the reporter's W4 layers load fine.

This is why the PR still says *Addresses* rather than *Fixes*: the issue stays open until the W3 checkpoint question is resolved. This revision does not change the target-matching fix's behavior for their checkpoint, just where and how broadly it's applied.

### Limits worth stating

- **No GPU on my machine.** The reporter's GPU validation above covers the target-matching fix directly; I have no model eval numbers for this revision specifically, but the underlying decision (which quant method a layer resolves to) is identical to what they validated — only the code path that computes it moved.
- I did not touch `prefix="draft_model"` itself. It is load-bearing: the draft `VllmConfig` shares the target's `compilation_config`, so dropping the root would collide draft and target attention layer names in `static_forward_context` (`Attention.__init__`, "Duplicate layer name").

---

AI assistance was used for this change (Claude, with independent second opinions from a second Claude model and GPT-5.6 for the redesign). I have reviewed every changed line, verified the root cause and the redesign against the source myself, and run the tests and results shown above myself.

