### PR TITLE
[CI/Build] Refresh tags before building macOS wheel

### DIFF
--- a/.buildkite/scripts/build-macos-wheel.sh
+++ b/.buildkite/scripts/build-macos-wheel.sh
@@ -7,6 +7,9 @@
 
 set -euo pipefail
 
+# The macmini queue uses persistent checkouts, so refresh tags for setuptools-scm.
+git fetch --tags --force origin
+
 # The Rust frontend build needs protoc.
 if ! command -v protoc >/dev/null 2>&1; then
   brew install protobuf


### PR DESCRIPTION
## Purpose

Refresh Git tags before building the native macOS arm64 CPU wheel.

The macOS wheel job runs on a persistent Mac mini checkout. Buildkite fetched the requested commit for [release-v2 build 4253](https://buildkite.com/vllm/release-v2/builds/4253), but did not refresh tag refs. As a result, `setuptools-scm` used the stale `v0.23.1rc0` tag and produced `0.23.1rc1.dev1290+gf2654939e.cpu` even though the commit was tagged `v0.26.0`.

The Linux wheel jobs use fresh autoscaled checkouts and correctly produced `0.26.0`.

## Change

Run `git fetch --tags --force origin` at the start of `.buildkite/scripts/build-macos-wheel.sh`, before `setuptools-scm` determines the package version. This also handles moved release tags consistently with the existing ROCm release-wheel path.

Nightly builds remain supported because the script does not require HEAD to have an exact tag.

## Duplicate-work check

This does not duplicate an existing PR. Open PR searches for `macOS arm64 wheel version`, `build-macos-wheel`, and `setuptools_scm tags release wheel` found no overlapping fix. The open macOS-related results concern contributor documentation and Apple Silicon platform detection, not release version generation. No matching open issue was found.

## Validation

- `bash -n .buildkite/scripts/build-macos-wheel.sh` — passed
- `git diff --check` — passed
- `uvx pre-commit run --files .buildkite/scripts/build-macos-wheel.sh` — passed, including shell lint
- `git fetch --tags --force origin` followed by `git describe --tags --exact-match f2654939e69b4069b13977e9aef3e31d4dcaf051` — returned `v0.26.0`

No model evaluation is applicable because this only changes release-build tag discovery.

## AI assistance

AI assistance was used to diagnose the Buildkite failure, prepare this draft change, and run the checks above. The human submitter must review every changed line and the validation evidence before marking this PR ready for review.
