### PR TITLE
[Build] Fix CUDA arch detection producing kernel-less builds on SM121

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,10 +219,8 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
   # the set of architectures we want to compile for and remove the from the
   # CMAKE_CUDA_FLAGS so that they are not applied globally.
   #
-  # `+PTX` in TORCH_CUDA_ARCH_LIST is not preserved here. It is emitted by torch
-  # as `code=compute_*`, while extract_unique_cuda_archs_ascending() records only
-  # `arch=compute_*`. If a kernel really needs PTX, add `+PTX` to that kernel's
-  # component-specific arch list below.
+  # `+PTX` in TORCH_CUDA_ARCH_LIST is not preserved here. If a kernel really
+  # needs PTX, add `+PTX` to that kernel's component-specific arch list below.
   #
   clear_cuda_arches(CUDA_ARCH_FLAGS)
   extract_unique_cuda_archs_ascending(CUDA_ARCHS "${CUDA_ARCH_FLAGS}")
@@ -232,6 +230,13 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
   cuda_archs_loose_intersection(CUDA_ARCHS
     "${CUDA_SUPPORTED_ARCHS}" "${CUDA_ARCHS}")
   message(STATUS "CUDA supported target architectures: ${CUDA_ARCHS}")
+  if(NOT CUDA_ARCHS)
+    message(FATAL_ERROR
+      "No supported CUDA architectures; the build would produce a binary "
+      "with no usable kernels. Detected gencode flags: ${CUDA_ARCH_FLAGS}; "
+      "supported: ${CUDA_SUPPORTED_ARCHS}. "
+      "Set TORCH_CUDA_ARCH_LIST for your GPU (e.g. 12.0).")
+  endif()
 else()
   #
   # For other GPU targets override the GPU architectures detected by cmake/torch

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -241,14 +241,15 @@ endmacro()
 # `<major>.<minor>`, dedupes them and then sorts them in ascending order and 
 # stores them in `OUT_ARCHES`.
 #
-# Example:
-#   CUDA_ARCH_FLAGS="-gencode arch=compute_75,code=sm_75;...;-gencode arch=compute_90a,code=sm_90a" 
-#   extract_unique_cuda_archs_ascending(OUT_ARCHES CUDA_ARCH_FLAGS)
-#   OUT_ARCHES="7.5;...;9.0"
+# Prefer `code=sm_*`; fall back to `arch=compute_*` for PTX-only flags.
+# This handles mismatches such as `arch=compute_20,code=sm_121`.
 function(extract_unique_cuda_archs_ascending OUT_ARCHES CUDA_ARCH_FLAGS)
   set(_CUDA_ARCHES)
   foreach(_ARCH ${CUDA_ARCH_FLAGS})
-    string(REGEX MATCH "arch=compute_\([0-9]+[af]?\)" _COMPUTE ${_ARCH})
+    string(REGEX MATCH "code=sm_\([0-9]+[af]?\)" _COMPUTE ${_ARCH})
+    if (NOT _COMPUTE)
+      string(REGEX MATCH "arch=compute_\([0-9]+[af]?\)" _COMPUTE ${_ARCH})
+    endif()
     if (_COMPUTE)
       set(_COMPUTE ${CMAKE_MATCH_1})
     endif()

--- a/tests/test_cmake_utils.py
+++ b/tests/test_cmake_utils.py
@@ -21,3 +21,28 @@ endif()
     )
 
     subprocess.run(["cmake", "-P", script], check=True)
+
+
+def test_extract_archs_prefers_sass_target_over_corrupted_virtual_arch(
+    tmp_path: Path,
+):
+    """torch's autodetection can emit a bogus arch=compute_* half (e.g.
+    capability 12.1 corrupted to arch=compute_20,code=sm_121); the SASS
+    target must win, while PTX-only entries keep the virtual arch."""
+    repo_root = Path(__file__).parents[1]
+    script = tmp_path / "test_extract_archs.cmake"
+    script.write_text(
+        f"""
+cmake_minimum_required(VERSION 3.26)
+include("{repo_root / "cmake" / "utils.cmake"}")
+extract_unique_cuda_archs_ascending(actual
+  "-gencode arch=compute_20,code=sm_121;\
+-gencode arch=compute_80,code=sm_80;\
+-gencode arch=compute_80,code=compute_80")
+if(NOT "${{actual}}" STREQUAL "8.0;12.1")
+  message(FATAL_ERROR "Expected '8.0;12.1', got '${{actual}}'")
+endif()
+"""
+    )
+
+    subprocess.run(["cmake", "-P", script], check=True)


### PR DESCRIPTION
## Purpose

On GB10 / DGX Spark (compute capability 12.1, CUDA 13), this shows up on the default source-build path from the docs, `uv pip install -e .` with `TORCH_CUDA_ARCH_LIST` unset. No special flags or custom arch list needed. The build looks fine but has no CUTLASS kernels in it. The `.so` only contains `sm_75` cubins. Serving any FP8 model then fails at startup:

```
RuntimeError: cutlass_scaled_mm, csrc/.../scaled_mm_entry.cu:265,
NotImplementedError: No compiled cutlass_scaled_mm for a compute capability
less than CUDA device capability: 121
```

The cause is an old line in torch's vendored `select_compute_arch.cmake`:

```cmake
string(REPLACE "2.1" "2.1(2.0)" compute_capabilities "${compute_capabilities}")
```

It was written for Fermi . The string `12.1` contains `2.1`, so torch rewrites it to `12.1(2.0)` and emits `-gencode arch=compute_20,code=sm_121`.

vLLM's `extract_unique_cuda_archs_ascending()` reads the `arch=compute_*` part of that flag, so it sees arch `2.0`. Nothing in `CUDA_SUPPORTED_ARCHS` matches `2.0`, so every arch-gated kernel is skipped. The rest of the sources build at nvcc's default `sm_75`, and the build reports success.

There is an upstream fix in progress (pytorch/pytorch#185993), but every torch release up to 2.11 has the bug so there should be a fix in vLLM as well.

### Changes

- `cmake/utils.cmake`: read the `code=sm_*` part of each gencode flag instead of `arch=compute_*`, since that is the real SASS target. Fall back to `arch=compute_*` for PTX-only entries. This gets `12.1` back, and `cuda_archs_loose_intersection()` maps it to the `12.0f` family target.
- `CMakeLists.txt`: if no supported arch matches, stop with an error instead of building a binary with no kernels.

### Not a duplicate

- #47149 scopes kernel feature macros per source file and warns when a prebuilt wheel lacks the device's arch. It does not touch arch autodetection, and it does not catch the empty-arch case at configure time.
- #43003 (closed) added 12.1 to the supported arch list. Review there showed the `12.0f` family fallback already handles SM121. The bug here happens before that logic runs.
- #38484 changes which archs the published wheels target, not source builds.

### AI assistance disclosure

AI assistance was used for root-cause analysis, and drafting this description. The code changes were made and tested by me, reviewed with AI.

## Test Plan

```bash
.venv/bin/python -m pytest tests/test_cmake_utils.py -v
```

On GB10: rebuild with `TORCH_CUDA_ARCH_LIST` unset, check the compiled archs with `cuobjdump --list-elf`, then serve the FP8 model from the issue.

## Test Result

GB10 (aarch64, CUDA 13.0.88, torch 2.11.0+cu130), `uv pip install -e .`, no `TORCH_CUDA_ARCH_LIST` set.

**Before:**
```
-- Autodetected CUDA architecture(s):  12.1(2.0)
-- Added CUDA NVCC flags for: -gencode;arch=compute_20,code=sm_121
-- CUDA target architectures: 2.0
-- CUDA supported target architectures:
-- Not building scaled_mm_c3x_120 as no compatible archs found ...
```
`_C_stable_libtorch.abi3.so` has only `sm_75` cubins. `vllm serve RedHatAI/gemma-4-31B-it-FP8-block` crashes in `profile_run`.

**After:**
```
-- CUDA target architectures: 12.1
-- CUDA supported target architectures: 12.0
-- Building scaled_mm_c3x_sm120 for archs: 12.0f
```
The rebuild works and the same model serves fine (`Application startup
complete`).

I am attaching the full `vllm serve` startup logs for both cases, the crash before the fix and the clean startup after it.

[FP8_SM121_bug_startup_logs.md](https://github.com/user-attachments/files/30393977/FP8_SM121_bug_startup_logs.md)
[FP8_SM121_bugfix_startup_logs.md](https://github.com/user-attachments/files/30393978/FP8_SM121_bugfix_startup_logs.md)

```text
tests/test_cmake_utils.py::test_exact_family_arch_precedes_generic_family_fallback PASSED
tests/test_cmake_utils.py::test_extract_archs_prefers_sass_target_over_corrupted_virtual_arch PASSED

2 passed in 0.26s
```
This only changes the build system and touches no numerics, so I did not run evals.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and examples for a new model. No documentation update is required for this build-only fix.
</details>