### PR TITLE
[CI][ROCm] Keep global GPU memory cleanup opt-in

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1729,13 +1729,9 @@ def disable_deepgemm_ue8m0(monkeypatch):
 
 
 def _should_clean_gpu_memory_between_tests() -> bool:
-    setting = os.getenv("VLLM_TEST_CLEAN_GPU_MEMORY")
-    if setting == "1":
-        return True
-    if setting == "0":
-        return False
-    # ROCm reclaims VRAM lazily; default to waiting between tests on ROCm CI.
-    return current_platform.is_rocm()
+    # This must stay opt-in: a function-scoped fixture cannot distinguish
+    # stale VRAM from allocations owned by longer-lived module/session fixtures.
+    return os.getenv("VLLM_TEST_CLEAN_GPU_MEMORY", "0") == "1"
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
- Require VLLM_TEST_CLEAN_GPU_MEMORY=1 before enabling the global cleanup fixture; function-scoped cleanup cannot release longer-lived fixtures.
- Keep the targeted Qwen-VL and Nixl teardown from #49242.

https://buildkite.com/vllm/amd-ci/builds/11263/list?tab=output&jid=019f9aea-ada5-4312-af96-9b60d26d4ad6#L684