### PR TITLE
[CI] Initialize DeepEP FP8 test weights

### DIFF
--- a/tests/kernels/moe/test_deepep_moe.py
+++ b/tests/kernels/moe/test_deepep_moe.py
@@ -66,8 +66,14 @@ def make_weights(
 
     # per-out-channel weight quantization
     assert dtype == current_platform.fp8_dtype()
-    w1 = torch.empty((e, 2 * n, k), device="cuda", dtype=torch.float16)
-    w2 = torch.empty((e, k, n), device="cuda", dtype=torch.float16)
+    # Keep FP8 inputs finite and bounded. torch.empty made this test depend on
+    # allocator contents, while larger values exceed its fixed W8A8 tolerance.
+    w1 = torch.randn(
+        (e, 2 * n, k), device=current_platform.device_type, dtype=torch.float16
+    ).div_(100)
+    w2 = torch.randn(
+        (e, k, n), device=current_platform.device_type, dtype=torch.float16
+    ).div_(100)
 
     n_b_scales = 2 * n
     k_b_scales = k


### PR DESCRIPTION
- Replace allocator-dependent FP8 source weights with small bounded random values.
- Allocate through current_platform.device_type while preserving the buffer-reuse and tolerance fixes from #46758.

https://buildkite.com/vllm/amd-ci/builds/11266/list?sid=019f9c06-9989-45bd-9353-9a349d807bdc&tab=output