### PR TITLE
[ROCm] Make vllm_c RMSNorm output contiguous

### DIFF
--- a/tests/kernels/ir/test_layernorm.py
+++ b/tests/kernels/ir/test_layernorm.py
@@ -176,6 +176,29 @@ def test_vllm_c_rms_norm_accepts_nd_input():
     assert_close(ir.ops.rms_norm, output, ref_output)
 
 
+@pytest.mark.skipif(
+    not current_platform.is_rocm(),
+    reason="ROCm vllm_c RMSNorm needs a contiguous output for strided inputs",
+)
+def test_vllm_c_rms_norm_accepts_transposed_input():
+    impl = ir.ops.rms_norm.impls["vllm_c"]
+    if not impl.supported:
+        pytest.skip("vllm_c impl not supported on this platform")
+
+    x = torch.randn(
+        1, 320, 120, dtype=torch.float16, device=current_platform.device_type
+    ).transpose(1, 2)
+    assert x.reshape(-1, x.shape[-1]).stride(-1) != 1
+    weight = torch.randn(320, dtype=torch.float16, device=current_platform.device_type)
+    epsilon = 1e-5
+
+    output = impl.impl_fn(x, weight, epsilon)
+    ref_output = rms_norm_native(x, weight, epsilon)
+
+    assert output.shape == x.shape
+    assert_close(ir.ops.rms_norm, output, ref_output)
+
+
 fused_add_rms_norm_native = ir.ops.fused_add_rms_norm.impls["native"].impl_fn
 
 

--- a/vllm/kernels/vllm_c.py
+++ b/vllm/kernels/vllm_c.py
@@ -32,7 +32,9 @@ def rms_norm(
     if IS_ROCM and (x.dim() > 2 or not x.is_contiguous()):
         original_shape = x.shape
         x = x.reshape(-1, original_shape[-1])
-        output = torch.empty_like(x)
+        # empty_like preserves the strides of transposed inputs, but the
+        # libtorch-stable kernel requires a contiguous output tensor.
+        output = torch.empty(x.shape, device=x.device, dtype=x.dtype)
         torch.ops._C.rms_norm(output, x, weight, epsilon)
         return output.reshape(original_shape)
 


### PR DESCRIPTION
- Allocate contiguous ROCm vllm_c RMSNorm output when the input has transposed strides.
- Cover the singleton-batch VibeVoice layout with an IR regression case.

https://buildkite.com/vllm/amd-ci/builds/11266/list?tab=output&jid=019f9c06-9a43-42d8-a972-5eac4371b598#L3072