### PR TITLE
[CI][ROCm] Reduce kernel test runtime

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -1577,11 +1577,12 @@ steps:
   commands:
   - pytest -v -s kernels/attention --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
 
-- label: Kernels Core Operation Test # TBD
+- label: Kernels Core Operation Test %N # TBD
   timeout_in_minutes: 180
   mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
   dind: false
   agent_pool: mi300_1
+  parallelism: 3
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:
   - csrc/
@@ -1592,7 +1593,7 @@ steps:
   - vllm/_aiter_ops.py
   - vllm/platforms/rocm.py
   commands:
-  - pytest -v -s kernels/core --ignore=kernels/core/test_minimax_reduce_rms.py  kernels/test_concat_mla_q.py kernels/test_top_k_per_row.py
+  - pytest -v -s kernels/core --ignore=kernels/core/test_minimax_reduce_rms.py kernels/test_concat_mla_q.py kernels/test_top_k_per_row.py --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
 
 - label: Kernels KDA Test # TBD
   timeout_in_minutes: 180
@@ -2161,7 +2162,7 @@ steps:
   mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
   dind: false
   agent_pool: mi300_1
-  parallelism: 4
+  parallelism: 8
   optional: true
   working_dir: "/vllm-workspace/"
   source_file_dependencies:

--- a/tests/kernels/core/test_fused_quant_layernorm.py
+++ b/tests/kernels/core/test_fused_quant_layernorm.py
@@ -31,7 +31,7 @@ NUM_TOKENS_HIDDEN_SIZES = [
 
 ADD_RESIDUAL = [False, True]
 SCALE_UBS = [True, False]
-GROUP_SIZES = [None, [1, 64], [1, 128]]
+GROUP_SIZES = [[1, 64], [1, 128]]
 TMA_ALIGNMENTS = [0, 4]
 SEEDS = [0]
 CUDA_DEVICES = [
@@ -39,6 +39,86 @@ CUDA_DEVICES = [
 ]
 
 EPS = 1e-6
+
+
+def _is_valid_config(
+    hidden_size: int,
+    has_scale_ub: bool,
+    quant_dtype: torch.dtype,
+    group_size: list[int] | None,
+    tma_alignment: int,
+) -> bool:
+    if group_size is not None and hidden_size % group_size[1] != 0:
+        return False
+    if group_size is not None and has_scale_ub:
+        return False
+    if (
+        group_size is None or quant_dtype != current_platform.fp8_dtype()
+    ) and tma_alignment != 0:
+        return False
+    if (
+        group_size is not None
+        and tma_alignment != 0
+        and hidden_size // group_size[1] % tma_alignment == 0
+    ):
+        return False
+    return not (has_scale_ub and quant_dtype != current_platform.fp8_dtype())
+
+
+def _config_id(
+    num_tokens: int,
+    hidden_size: int,
+    has_scale_ub: bool,
+    quant_dtype: torch.dtype,
+    group_size: list[int] | None,
+    tma_alignment: int,
+) -> str:
+    quant = str(quant_dtype).removeprefix("torch.")
+    group = "per-token" if group_size is None else f"group-{group_size[1]}"
+    return (
+        f"{num_tokens}x{hidden_size}-{quant}-{group}-"
+        f"tma-{tma_alignment}-scale-ub-{has_scale_ub}"
+    )
+
+
+# Filter unsupported combinations during collection. Letting each case call
+# pytest.skip still runs the global per-test teardown and dominates this suite.
+RMS_NORM_CONFIGS = [
+    pytest.param(
+        num_tokens,
+        hidden_size,
+        has_scale_ub,
+        quant_dtype,
+        group_size,
+        tma_alignment,
+        id=_config_id(
+            num_tokens,
+            hidden_size,
+            has_scale_ub,
+            quant_dtype,
+            group_size,
+            tma_alignment,
+        ),
+    )
+    for (
+        (num_tokens, hidden_size),
+        has_scale_ub,
+        quant_dtype,
+        (group_size, tma_alignment),
+    ) in itertools.product(
+        NUM_TOKENS_HIDDEN_SIZES,
+        SCALE_UBS,
+        QUANT_DTYPES,
+        [(None, 0), *itertools.product(GROUP_SIZES, TMA_ALIGNMENTS)],
+    )
+    if _is_valid_config(
+        hidden_size,
+        has_scale_ub,
+        quant_dtype,
+        group_size,
+        tma_alignment,
+    )
+]
 
 ## Helpers
 
@@ -154,15 +234,19 @@ def ops_impl(
     )
 
 
-@pytest.mark.parametrize("num_tokens, hidden_size", NUM_TOKENS_HIDDEN_SIZES)
-@pytest.mark.parametrize("add_residual", ADD_RESIDUAL)
-@pytest.mark.parametrize("has_scale_ub", SCALE_UBS)
-@pytest.mark.parametrize("dtype", DTYPES)
-@pytest.mark.parametrize("quant_dtype", QUANT_DTYPES)
 @pytest.mark.parametrize(
-    "group_size, tma_alignment",
-    [(None, 0), *itertools.product(GROUP_SIZES, TMA_ALIGNMENTS)],
+    (
+        "num_tokens",
+        "hidden_size",
+        "has_scale_ub",
+        "quant_dtype",
+        "group_size",
+        "tma_alignment",
+    ),
+    RMS_NORM_CONFIGS,
 )
+@pytest.mark.parametrize("add_residual", ADD_RESIDUAL)
+@pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("seed", SEEDS)
 @pytest.mark.parametrize("device", CUDA_DEVICES)
 @pytest.mark.parametrize("strided_input", [False, True])
@@ -184,32 +268,6 @@ def test_rms_norm(
     set_random_seed(seed)
     torch.set_default_device(device)
     torch.accelerator.set_device_index(device)
-
-    if group_size is not None and hidden_size % group_size[1] != 0:
-        # skip
-        pytest.skip("Skip non-divisible group sizes")
-
-    if group_size is not None and has_scale_ub:
-        # blockwise baseline doesn't support scale_ub
-        pytest.skip("scale_ub not supported for blockwise/group quantization")
-
-    if (
-        group_size is None or quant_dtype != current_platform.fp8_dtype()
-    ) and tma_alignment != 0:
-        # TMA alignment is only supported for groupwise fp8 kernels
-        pytest.skip("tma alignment not supported for per-token or int8 quantization")
-
-    if (
-        group_size is not None
-        and tma_alignment != 0
-        and hidden_size // group_size[1] % tma_alignment == 0
-    ):
-        # Skip tests where TMA alignment doesn't create extra padding to save time
-        pytest.skip("Skip TMA alignment cases where no extra padding is added")
-
-    if has_scale_ub and quant_dtype != current_platform.fp8_dtype():
-        # skip
-        pytest.skip("scale_ub only supported for fp8 quantization")
 
     layer = RMSNorm(hidden_size, EPS).to(dtype=dtype)
 

--- a/tests/kernels/core/test_vit_fp8_scaling.py
+++ b/tests/kernels/core/test_vit_fp8_scaling.py
@@ -18,6 +18,11 @@ from vllm.utils.flashinfer import (
     is_flashinfer_cudnn_fp8_prefill_attn_supported,
 )
 
+pytestmark = pytest.mark.skipif(
+    not is_flashinfer_cudnn_fp8_prefill_attn_supported(),
+    reason="FlashInfer cuDNN FP8 prefill attention not supported",
+)
+
 LAYER_0 = "visual.blocks.0.attn.attn"
 LAYER_1 = "visual.blocks.1.attn.attn"
 NUM_HEADS = 16


### PR DESCRIPTION
- Filter unsupported fused RMSNorm parameters during collection and skip the unsupported FP8 scaling module before GPU setup.
- Shard MI300 kernel-core coverage three ways and increase Transformers Processing parallelism from four to eight.

https://buildkite.com/vllm/amd-ci/builds/11266/list?sid=019f9c06-9985-4ea9-9b04-4dfa7ec3eea3&tab=output