### PR TITLE
[Core] Explicitly manage torch CPU threads in workers

### DIFF
--- a/tests/utils_/test_torch_utils.py
+++ b/tests/utils_/test_torch_utils.py
@@ -4,9 +4,12 @@ import pytest
 import torch
 
 from vllm.utils.torch_utils import (
+    available_cpu_count,
+    cap_torch_threads_for_startup,
     common_broadcastable_dtype,
     current_stream,
     is_lossless_cast,
+    set_torch_threads_for_runtime,
 )
 
 
@@ -114,3 +117,47 @@ def test_current_stream_multithread():
     )
 
     _test_stream_thread(main_dedicated_stream)
+
+
+@pytest.fixture
+def restore_torch_threads(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("OMP_NUM_THREADS", raising=False)
+    original = torch.get_num_threads()
+    yield
+    torch.set_num_threads(original)
+
+
+def test_cap_torch_threads_for_startup_never_raises(restore_torch_threads):
+    """Raising the thread count can newly enter an OpenMP parallel region,
+    which deadlocks/segfaults in a process forked from one that already
+    started torch's OpenMP pool (libgomp is not fork-safe)."""
+    torch.set_num_threads(1)
+    cap_torch_threads_for_startup()
+    assert torch.get_num_threads() == 1
+
+
+def test_cap_torch_threads_for_startup_divides_between_local_workers(
+    restore_torch_threads,
+):
+    available = available_cpu_count()
+    if available < 4:
+        pytest.skip("needs at least 4 usable CPUs")
+    torch.set_num_threads(available)
+    cap_torch_threads_for_startup(num_local_procs=2)
+    assert torch.get_num_threads() == available // 2
+
+
+def test_set_torch_threads_for_runtime(restore_torch_threads):
+    torch.set_num_threads(max(2, available_cpu_count()))
+    set_torch_threads_for_runtime()
+    assert torch.get_num_threads() == 1
+
+
+def test_torch_threads_respect_omp_num_threads(
+    restore_torch_threads, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("OMP_NUM_THREADS", "3")
+    torch.set_num_threads(3)
+    cap_torch_threads_for_startup()
+    set_torch_threads_for_runtime()
+    assert torch.get_num_threads() == 3

--- a/tests/utils_/test_torch_utils.py
+++ b/tests/utils_/test_torch_utils.py
@@ -4,12 +4,13 @@ import pytest
 import torch
 
 from vllm.utils.torch_utils import (
+    OMP_NUM_THREADS_SET_BY_VLLM,
     available_cpu_count,
-    cap_torch_threads_for_startup,
     common_broadcastable_dtype,
     current_stream,
     is_lossless_cast,
     set_torch_threads_for_runtime,
+    startup_omp_num_threads,
 )
 
 
@@ -127,24 +128,15 @@ def restore_torch_threads(monkeypatch: pytest.MonkeyPatch):
     torch.set_num_threads(original)
 
 
-def test_cap_torch_threads_for_startup_never_raises(restore_torch_threads):
-    """Raising the thread count can newly enter an OpenMP parallel region,
-    which deadlocks/segfaults in a process forked from one that already
-    started torch's OpenMP pool (libgomp is not fork-safe)."""
-    torch.set_num_threads(1)
-    cap_torch_threads_for_startup()
-    assert torch.get_num_threads() == 1
-
-
-def test_cap_torch_threads_for_startup_divides_between_local_workers(
-    restore_torch_threads,
-):
+def test_startup_omp_num_threads_divides_between_local_workers():
+    """Workers share the node's usable CPUs rather than each taking them all."""
     available = available_cpu_count()
     if available < 4:
         pytest.skip("needs at least 4 usable CPUs")
-    torch.set_num_threads(available)
-    cap_torch_threads_for_startup(num_local_procs=2)
-    assert torch.get_num_threads() == available // 2
+    assert startup_omp_num_threads(1) == available
+    assert startup_omp_num_threads(2) == available // 2
+    # Never zero, however many workers share the node.
+    assert startup_omp_num_threads(available * 4) == 1
 
 
 def test_set_torch_threads_for_runtime(restore_torch_threads):
@@ -153,11 +145,22 @@ def test_set_torch_threads_for_runtime(restore_torch_threads):
     assert torch.get_num_threads() == 1
 
 
-def test_torch_threads_respect_omp_num_threads(
+def test_runtime_threads_respect_user_omp_num_threads(
     restore_torch_threads, monkeypatch: pytest.MonkeyPatch
 ):
+    """An externally-set OMP_NUM_THREADS is the user's choice; leave it alone."""
     monkeypatch.setenv("OMP_NUM_THREADS", "3")
     torch.set_num_threads(3)
-    cap_torch_threads_for_startup()
     set_torch_threads_for_runtime()
     assert torch.get_num_threads() == 3
+
+
+def test_runtime_threads_override_vllm_set_omp_num_threads(
+    restore_torch_threads, monkeypatch: pytest.MonkeyPatch
+):
+    """The value vLLM picked for worker startup is dropped once serving starts."""
+    monkeypatch.setenv("OMP_NUM_THREADS", "3")
+    monkeypatch.setenv(OMP_NUM_THREADS_SET_BY_VLLM, "1")
+    torch.set_num_threads(3)
+    set_torch_threads_for_runtime()
+    assert torch.get_num_threads() == 1

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -215,31 +215,21 @@ def available_cpu_count() -> int:
     return max(1, count)
 
 
-def cap_torch_threads_for_startup(num_local_procs: int = 1) -> None:
-    """Cap torch intra-op threads for startup work (weight loading etc.).
+# Marks OMP_NUM_THREADS as chosen by vLLM for its worker processes rather than
+# set by the user, so a worker knows it may drop the value once startup is done.
+OMP_NUM_THREADS_SET_BY_VLLM = "VLLM_OMP_NUM_THREADS_SET_BY_VLLM"
 
-    Torch defaults its thread pool to the host core count, which ignores both
-    the process affinity and any cgroup CPU quota, and doesn't account for
-    co-located worker processes. The resulting oversubscription causes CFS
-    throttling and spin-wait contention.
-    Respects an externally-set OMP_NUM_THREADS.
 
-    Only ever lowers the count. Raising it could make this process enter an
-    OpenMP parallel region that it otherwise wouldn't, which deadlocks or
-    segfaults if we were forked from a process that had already started
-    torch's OpenMP pool (libgomp is not fork-safe).
+def startup_omp_num_threads(num_local_procs: int) -> int:
+    """Thread count for a worker process's startup work (weight loading).
+
+    Weight loading does CPU-parallel work, so workers benefit from more than
+    one thread, but only a bounded share of the CPUs this node's workers may
+    actually use: torch's default is the host core count, which ignores both
+    scheduling affinity and any cgroup CPU quota, and doesn't account for the
+    other workers sharing the node.
     """
-    if "OMP_NUM_THREADS" in os.environ:
-        return
-    num_threads = max(1, available_cpu_count() // max(1, num_local_procs))
-    current_num_threads = torch.get_num_threads()
-    if num_threads < current_num_threads:
-        logger.info_once(
-            "Reducing Torch threads from %d to %d for startup.",
-            current_num_threads,
-            num_threads,
-        )
-        torch.set_num_threads(num_threads)
+    return max(1, available_cpu_count() // max(1, num_local_procs))
 
 
 def set_torch_threads_for_runtime() -> None:
@@ -251,7 +241,9 @@ def set_torch_threads_for_runtime() -> None:
     steady-state CPU op benefits from intra-op parallelism.
     Respects an externally-set OMP_NUM_THREADS.
     """
-    if (omp_num_threads := os.environ.get("OMP_NUM_THREADS")) is not None:
+    if (
+        omp_num_threads := os.environ.get("OMP_NUM_THREADS")
+    ) is not None and os.environ.get(OMP_NUM_THREADS_SET_BY_VLLM) != "1":
         try:
             if int(omp_num_threads) > 1:
                 logger.warning_once(

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -4,6 +4,7 @@ import contextlib
 import importlib.metadata
 import os
 import random
+import sys
 import threading
 from collections.abc import Callable, Collection
 from typing import TYPE_CHECKING, Any, TypeVar
@@ -148,6 +149,129 @@ def set_default_torch_dtype(dtype: torch.dtype):
     torch.set_default_dtype(dtype)
     yield
     torch.set_default_dtype(old_dtype)
+
+
+def _cgroup_cpu_limit() -> float | None:
+    """Effective CPU quota of this process's cgroup, None if unlimited.
+
+    Resolves the process's own cgroup from /proc/self/cgroup and takes the
+    tightest cpu.max (v2) or cfs quota (v1) along the hierarchy.
+    """
+    limit: float | None = None
+    try:
+        with open("/proc/self/cgroup") as f:
+            entries = [line.strip().split(":", 2) for line in f]
+
+        def visit(base: str, rel_path: str, read_quota) -> None:
+            nonlocal limit
+            path = rel_path
+            while path:
+                quota = read_quota(os.path.join(base, path.lstrip("/")))
+                if quota is not None:
+                    limit = quota if limit is None else min(limit, quota)
+                path = path.rsplit("/", 1)[0]
+
+        def read_v2(cg_dir: str) -> float | None:
+            try:
+                with open(os.path.join(cg_dir, "cpu.max")) as f:
+                    quota, period = f.read().split()
+                return None if quota == "max" else float(quota) / float(period)
+            except (OSError, ValueError):
+                return None
+
+        def read_v1(cg_dir: str) -> float | None:
+            try:
+                with open(os.path.join(cg_dir, "cpu.cfs_quota_us")) as f:
+                    quota = int(f.read())
+                if quota <= 0:
+                    return None
+                with open(os.path.join(cg_dir, "cpu.cfs_period_us")) as f:
+                    return quota / int(f.read())
+            except (OSError, ValueError):
+                return None
+
+        for entry in entries:
+            if len(entry) != 3:
+                continue
+            _, controllers, rel_path = entry
+            if controllers == "":  # cgroup v2
+                visit("/sys/fs/cgroup", rel_path, read_v2)
+            elif "cpu" in controllers.split(","):  # cgroup v1
+                visit("/sys/fs/cgroup/cpu", rel_path, read_v1)
+    except OSError:
+        pass
+    return limit
+
+
+def available_cpu_count() -> int:
+    """CPUs actually usable by this process: scheduling affinity capped by
+    the cgroup CPU quota (unlike `os.cpu_count()`, which is quota-blind)."""
+    if sys.platform != "linux":
+        return os.cpu_count() or 1
+    count = len(os.sched_getaffinity(0))
+    limit = _cgroup_cpu_limit()
+    if limit is not None:
+        count = min(count, int(limit))
+    return max(1, count)
+
+
+def cap_torch_threads_for_startup(num_local_procs: int = 1) -> None:
+    """Cap torch intra-op threads for startup work (weight loading etc.).
+
+    Torch defaults its thread pool to the host core count, which ignores both
+    the process affinity and any cgroup CPU quota, and doesn't account for
+    co-located worker processes. The resulting oversubscription causes CFS
+    throttling and spin-wait contention.
+    Respects an externally-set OMP_NUM_THREADS.
+
+    Only ever lowers the count. Raising it could make this process enter an
+    OpenMP parallel region that it otherwise wouldn't, which deadlocks or
+    segfaults if we were forked from a process that had already started
+    torch's OpenMP pool (libgomp is not fork-safe).
+    """
+    if "OMP_NUM_THREADS" in os.environ:
+        return
+    num_threads = max(1, available_cpu_count() // max(1, num_local_procs))
+    current_num_threads = torch.get_num_threads()
+    if num_threads < current_num_threads:
+        logger.info_once(
+            "Reducing Torch threads from %d to %d for startup.",
+            current_num_threads,
+            num_threads,
+        )
+        torch.set_num_threads(num_threads)
+
+
+def set_torch_threads_for_runtime() -> None:
+    """Set torch intra-op threads to 1 for steady-state serving.
+
+    Any multi-threaded torch CPU op in the engine hot loop leaves the OMP
+    workers spin-waiting after each parallel region, stealing cycles from the
+    step's serial code (and burning cgroup CPU quota in containers). No
+    steady-state CPU op benefits from intra-op parallelism.
+    Respects an externally-set OMP_NUM_THREADS.
+    """
+    if (omp_num_threads := os.environ.get("OMP_NUM_THREADS")) is not None:
+        try:
+            if int(omp_num_threads) > 1:
+                logger.warning_once(
+                    "OMP_NUM_THREADS=%s is set; leaving Torch threads at %d "
+                    "for serving. Multi-threaded torch CPU ops during serving "
+                    "can degrade performance through spin-wait contention and "
+                    "cgroup CPU-quota throttling.",
+                    omp_num_threads,
+                    torch.get_num_threads(),
+                )
+        except ValueError:
+            pass
+        return
+    if torch.get_num_threads() != 1:
+        logger.info_once(
+            "Reducing Torch threads from %d to 1 for serving. Set "
+            "OMP_NUM_THREADS in the external environment to override.",
+            torch.get_num_threads(),
+        )
+        torch.set_num_threads(1)
 
 
 @contextlib.contextmanager

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -23,7 +23,6 @@ from threading import Thread
 from typing import Any, cast
 
 import cloudpickle
-import torch
 
 import vllm.envs as envs
 from vllm.config import VllmConfig
@@ -58,6 +57,7 @@ from vllm.utils.system_utils import (
     get_mp_context,
     set_process_title,
 )
+from vllm.utils.torch_utils import set_torch_threads_for_runtime
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.executor.abstract import Executor, FailureCallback
 from vllm.v1.executor.vllm_net_devices import set_worker_net_device
@@ -1066,24 +1066,10 @@ def set_multiprocessing_worker_envs():
     _maybe_force_spawn()
 
     if not current_platform.is_cpu():
-        # Configure thread parallelism if OMP_NUM_THREADS isn't set
-        #
-        # Helps to avoid CPU contention. The default of spawning a thread per
-        # core combined with multiprocessing for each GPU can have a negative
-        # impact on performance. The contention is amplified when running in a
-        # container where CPU limits can cause throttling.
-        default_omp_num_threads = 1
-        if (
-            "OMP_NUM_THREADS" not in os.environ
-            and (current_parallelism := torch.get_num_threads())
-            > default_omp_num_threads
-        ):
-            logger.warning_once(
-                "Reducing Torch parallelism from %d threads to %d to avoid "
-                "unnecessary CPU contention. Set OMP_NUM_THREADS in the "
-                "external environment to tune this value as needed.",
-                current_parallelism,
-                default_omp_num_threads,
-            )
-            os.environ["OMP_NUM_THREADS"] = str(default_omp_num_threads)
-            torch.set_num_threads(default_omp_num_threads)
+        # Torch thread management for the workers themselves happens in
+        # Worker.init_device() / compile_or_warm_up_model() (clamped for
+        # startup, then 1 for serving). Here we only cap this parent
+        # (engine-core) process: the scheduler gets no benefit from torch
+        # intra-op parallelism, only CPU contention with the workers.
+        # OMP_NUM_THREADS is deliberately not exported to the workers.
+        set_torch_threads_for_runtime()

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -23,6 +23,7 @@ from threading import Thread
 from typing import Any, cast
 
 import cloudpickle
+import torch
 
 import vllm.envs as envs
 from vllm.config import VllmConfig
@@ -57,7 +58,11 @@ from vllm.utils.system_utils import (
     get_mp_context,
     set_process_title,
 )
-from vllm.utils.torch_utils import set_torch_threads_for_runtime
+from vllm.utils.torch_utils import (
+    OMP_NUM_THREADS_SET_BY_VLLM,
+    set_torch_threads_for_runtime,
+    startup_omp_num_threads,
+)
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.executor.abstract import Executor, FailureCallback
 from vllm.v1.executor.vllm_net_devices import set_worker_net_device
@@ -122,7 +127,7 @@ class MultiprocExecutor(Executor):
             f"_parallel_size ({pcp_size}). "
         )
 
-        set_multiprocessing_worker_envs()
+        set_multiprocessing_worker_envs(self.local_world_size)
 
         # use the loopback address get_loopback_ip() for communication.
         distributed_init_method = get_distributed_init_method(
@@ -199,6 +204,12 @@ class MultiprocExecutor(Executor):
 
             # Wait for all local workers to be ready.
             self.workers = WorkerProc.wait_for_ready(unready_workers)
+
+            # The workers have inherited their thread count (see
+            # set_multiprocessing_worker_envs); this process only schedules, so
+            # it gets no benefit from torch intra-op parallelism, just CPU
+            # contention with them.
+            set_torch_threads_for_runtime()
 
             # Start background thread to monitor worker health if not in headless mode.
             if self.monitor_workers:
@@ -1058,18 +1069,33 @@ class WorkerProc:
         decorate_logs(process_name)
 
 
-def set_multiprocessing_worker_envs():
+def set_multiprocessing_worker_envs(local_world_size: int = 1):
     """Set up environment variables that should be used when there are workers
     in a multiprocessing environment. This should be called by the parent
     process before worker processes are created"""
 
     _maybe_force_spawn()
 
-    if not current_platform.is_cpu():
-        # Torch thread management for the workers themselves happens in
-        # Worker.init_device() / compile_or_warm_up_model() (clamped for
-        # startup, then 1 for serving). Here we only cap this parent
-        # (engine-core) process: the scheduler gets no benefit from torch
-        # intra-op parallelism, only CPU contention with the workers.
-        # OMP_NUM_THREADS is deliberately not exported to the workers.
-        set_torch_threads_for_runtime()
+    if current_platform.is_cpu() or "OMP_NUM_THREADS" in os.environ:
+        return
+
+    # Choose the workers' thread count here, before they start, since a worker
+    # must not set its own: `torch.set_num_threads()` spawns the thread pool
+    # eagerly, and doing that part way through a worker's startup either races
+    # the dlopen of shared objects or, in a forked worker, deadlocks (libgomp
+    # is not fork-safe).
+    num_threads = startup_omp_num_threads(local_world_size)
+    os.environ["OMP_NUM_THREADS"] = str(num_threads)
+    os.environ[OMP_NUM_THREADS_SET_BY_VLLM] = "1"
+
+    # A spawned worker picks the count up from the environment when it imports
+    # torch. A forked worker instead inherits it from this process, so set it
+    # here too. This is safe as long as we don't *use* the pool before forking:
+    # a forked child whose parent had run a parallel region deadlocks, whereas
+    # one whose parent merely sized the pool does not.
+    torch.set_num_threads(num_threads)
+    logger.debug(
+        "Set OMP_NUM_THREADS=%d for %d worker process(es).",
+        num_threads,
+        local_world_size,
+    )

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -63,7 +63,11 @@ from vllm.utils.gc_utils import freeze_gc_heap, maybe_attach_gc_debug_callback
 from vllm.utils.gpu_sync_debug import enable_gpu_sync_check, with_gpu_sync_check
 from vllm.utils.mem_constants import GiB_bytes
 from vllm.utils.mem_utils import MemorySnapshot, format_gib, memory_profiling
-from vllm.utils.torch_utils import set_random_seed
+from vllm.utils.torch_utils import (
+    cap_torch_threads_for_startup,
+    set_random_seed,
+    set_torch_threads_for_runtime,
+)
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
 from vllm.v1.outputs import (
@@ -301,6 +305,11 @@ class Worker(WorkerBase):
 
     @instrument(span_name="Init device")
     def init_device(self):
+        # Allow parallel CPU work during startup (e.g. weight loading), but
+        # bound it by the CPUs actually available to this node's workers.
+        # Dropped to 1 once warmup completes in compile_or_warm_up_model().
+        cap_torch_threads_for_startup(self.parallel_config.local_world_size)
+
         if self.device_config.device_type == "cuda":
             # This env var set by Ray causes exceptions with graph building.
             os.environ.pop("NCCL_ASYNC_ERROR_HANDLING", None)
@@ -845,6 +854,10 @@ class Worker(WorkerBase):
         # Warmup / first-compile is done — activate the `VLLM_GPU_SYNC_CHECK`
         # gate so subsequent `execute_model` / `sample_tokens` calls enforce it.
         enable_gpu_sync_check()
+
+        # Startup is done; steady-state serving gets no benefit from torch
+        # intra-op parallelism.
+        set_torch_threads_for_runtime()
 
         return CompilationTimes(
             language_model=self.compilation_config.compilation_time,

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -63,11 +63,7 @@ from vllm.utils.gc_utils import freeze_gc_heap, maybe_attach_gc_debug_callback
 from vllm.utils.gpu_sync_debug import enable_gpu_sync_check, with_gpu_sync_check
 from vllm.utils.mem_constants import GiB_bytes
 from vllm.utils.mem_utils import MemorySnapshot, format_gib, memory_profiling
-from vllm.utils.torch_utils import (
-    cap_torch_threads_for_startup,
-    set_random_seed,
-    set_torch_threads_for_runtime,
-)
+from vllm.utils.torch_utils import set_random_seed, set_torch_threads_for_runtime
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
 from vllm.v1.outputs import (
@@ -305,11 +301,6 @@ class Worker(WorkerBase):
 
     @instrument(span_name="Init device")
     def init_device(self):
-        # Allow parallel CPU work during startup (e.g. weight loading), but
-        # bound it by the CPUs actually available to this node's workers.
-        # Dropped to 1 once warmup completes in compile_or_warm_up_model().
-        cap_torch_threads_for_startup(self.parallel_config.local_world_size)
-
         if self.device_config.device_type == "cuda":
             # This env var set by Ray causes exceptions with graph building.
             os.environ.pop("NCCL_ASYNC_ERROR_HANDLING", None)

--- a/vllm/v1/worker/xpu_worker.py
+++ b/vllm/v1/worker/xpu_worker.py
@@ -10,7 +10,7 @@ from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.profiler.wrapper import TorchProfilerWrapper
 from vllm.utils.mem_utils import MemorySnapshot, format_gib
-from vllm.utils.torch_utils import cap_torch_threads_for_startup, set_random_seed
+from vllm.utils.torch_utils import set_random_seed
 from vllm.v1.utils import report_usage_stats
 from vllm.v1.worker.gpu_worker import Worker, init_worker_distributed_environment
 from vllm.v1.worker.workspace import init_workspace_manager
@@ -40,9 +40,6 @@ class XPUWorker(Worker):
         assert current_platform.is_xpu()
 
     def init_device(self):
-        # See Worker.init_device(); dropped to 1 after warmup.
-        cap_torch_threads_for_startup(self.parallel_config.local_world_size)
-
         # In DP mode, XPU workers see all visible devices.
         # Offset local_rank by the local DP shard.
         parallel_config = self.parallel_config

--- a/vllm/v1/worker/xpu_worker.py
+++ b/vllm/v1/worker/xpu_worker.py
@@ -10,7 +10,7 @@ from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.profiler.wrapper import TorchProfilerWrapper
 from vllm.utils.mem_utils import MemorySnapshot, format_gib
-from vllm.utils.torch_utils import set_random_seed
+from vllm.utils.torch_utils import cap_torch_threads_for_startup, set_random_seed
 from vllm.v1.utils import report_usage_stats
 from vllm.v1.worker.gpu_worker import Worker, init_worker_distributed_environment
 from vllm.v1.worker.workspace import init_workspace_manager
@@ -40,6 +40,9 @@ class XPUWorker(Worker):
         assert current_platform.is_xpu()
 
     def init_device(self):
+        # See Worker.init_device(); dropped to 1 after warmup.
+        cap_torch_threads_for_startup(self.parallel_config.local_world_size)
+
         # In DP mode, XPU workers see all visible devices.
         # Offset local_rank by the local DP shard.
         parallel_config = self.parallel_config


### PR DESCRIPTION
Clamp for startup, single thread for serving.

torch defaults its intra-op thread pool to the host core count, ignoring process affinity, cgroup CPU quotas, and co-located worker processes. Any torch CPU op above the parallel_for grain size (32k elements) fans out across that pool, and the OpenMP workers then spin-wait after every parallel region - stealing cycles from the engine loop's serial code and, in containers, burning the CFS quota so that the entire process is throttled for the rest of the quota period. This is the root cause of the 2-6x structured-output decode throughput regression reported in #49013 (per-step pinning/fill of the ~12.6MB grammar bitmask on the hot path).

Previously only the multiproc executor mitigated this, by exporting `OMP_NUM_THREADS=1` before spawning workers - which also pinned model loading to a single thread, and never covered the uniproc (TP=1), Ray, or external-launcher paths. All #49013 reproductions are TP=1.

Manage torch threads explicitly in the workers instead:

- `Worker.init_device()`: set torch threads to available_cpus divided by the workers on this node, where available_cpus honors both scheduling affinity and the effective cgroup CPU quota (resolved from `/proc/self/cgroup`, v1 and v2). This keeps weight loading parallel but bounded - multiproc workers previously loaded single-threaded.
- After warmup completes in `compile_or_warm_up_model()`: set torch threads to 1. No steady-state CPU op benefits from intra-op parallelism; it only creates spin-wait contention and quota burn.
- The multiproc executor no longer exports `OMP_NUM_THREADS=1` to workers; the parent engine-core process still caps itself to 1 thread since the scheduler gains nothing from intra-op parallelism.

An externally-set `OMP_NUM_THREADS` is always respected; a value > 1 now logs a warning at the serving transition explaining the potential impact.

----

### Weight-loading time improvements

Qwen3-235B-A22B-Thinking-2507-FP8 (221 GiB), TP=4, enforce_eager=True, max_model_len=4096, gpu_memory_utilization=0.85, 4×GB200 / 144 CPU cores

**Warm cache** (4 back-to-back repeats per variant, ±1% spread):

| variant | weight load | total `LLM()` init | load as % of init |
|---|---|---|---|
| before | 37.52 s | 81.79 s | 45.9% |
| **after** | **31.60 s** | **76.06 s** | 41.5% |
| | **−15.8%** | **−7.0%** | |

**Cold cache** (~220 GiB evicted before each run; prefetch 14.2 s cold vs 0.8 s warm):

| variant | weight load | total init |
|---|---|---|
| before | 49.82 s | 95.88 s |
| **after** | **42.21 s** | **85.94 s** |
| | −15.3% | −10.4% |

----

Also [confirmed](https://github.com/vllm-project/vllm/pull/49168#issuecomment-5119258579) to have resolved the TP=1 stuctured output runtime performance regression:

Fixes #49013