### PR TITLE
[Bugfix] Fix llama3_json parser dropping parallel and prose-adjacent tool calls

### DIFF
--- a/tests/tool_parsers/test_llama3_json_tool_parser.py
+++ b/tests/tool_parsers/test_llama3_json_tool_parser.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -249,6 +250,72 @@ def test_extract_tool_calls_missing_parameters_and_arguments_key(parser):
     assert result.tools_called is False
     assert len(result.tool_calls) == 0
     assert result.content == model_output
+
+
+def test_extract_tool_calls_brace_in_trailing_text(parser):
+    # A brace in trailing prose must not discard the valid tool call
+    model_output = (
+        '{"name": "searchTool", "parameters": {"query": "test"}} '
+        "I used {searchTool} for this."
+    )
+    result = parser.extract_tool_calls(model_output, None)
+
+    assert result.tools_called is True
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0].function.name == "searchTool"
+
+
+def test_extract_tool_calls_json_fragment_in_trailing_text(parser):
+    # A JSON object without a "name" key in trailing prose (e.g. the model
+    # quoting its arguments) must not discard the valid tool call
+    model_output = (
+        '{"name": "searchTool", "parameters": {"query": "test"}} '
+        'The arguments I passed were {"query": "test"}'
+    )
+    result = parser.extract_tool_calls(model_output, None)
+
+    assert result.tools_called is True
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0].function.name == "searchTool"
+
+
+def _stream_chunks(parser, model_output, chunk_size=7):
+    """Drive extract_tool_calls_streaming with character chunks and collect
+    the streamed tool calls as (name, arguments) tuples."""
+    names: dict[int, str] = {}
+    args: dict[int, str] = {}
+    previous_text = ""
+    for i in range(0, len(model_output), chunk_size):
+        delta_text = model_output[i : i + chunk_size]
+        current_text = previous_text + delta_text
+        delta = parser.extract_tool_calls_streaming(
+            previous_text, current_text, delta_text, [], [], [], None
+        )
+        if delta is not None and delta.tool_calls:
+            for tool_call in delta.tool_calls:
+                if tool_call.function.name:
+                    names[tool_call.index] = tool_call.function.name
+                if tool_call.function.arguments:
+                    args[tool_call.index] = (
+                        args.get(tool_call.index, "") + tool_call.function.arguments
+                    )
+        previous_text = current_text
+    return [(names[i], args.get(i, "")) for i in sorted(names)]
+
+
+@pytest.mark.parametrize("separator", ["; ", ";", ";\n", "\n"])
+def test_extract_tool_calls_streaming_parallel_separators(parser, separator):
+    # Parallel tool calls may be separated by "; ", a bare ";", or a newline;
+    # every variant must stream both calls intact
+    model_output = (
+        '{"name": "searchTool", "parameters": {"query": "test1"}}'
+        + separator
+        + '{"name": "getOpenIncidentsTool", "parameters": {}}'
+    )
+    streamed = _stream_chunks(parser, model_output)
+
+    assert [name for name, _ in streamed] == ["searchTool", "getOpenIncidentsTool"]
+    assert json.loads(streamed[0][1]) == {"query": "test1"}
 
 
 def test_regex_timeout_handling(parser):

--- a/vllm/tool_parsers/llama_tool_parser.py
+++ b/vllm/tool_parsers/llama_tool_parser.py
@@ -127,17 +127,18 @@ class Llama3JsonToolParser(ToolParser):
                         )
                     )
                 except KeyError as e:
-                    # Missing required key
+                    # A JSON object without the required keys is surrounding
+                    # text (e.g. the model quoting arguments), not a tool call
                     missing_key = str(e).strip("'\"")
-                    logger.exception(
-                        "Couldn't extract tool call from JSON response. "
-                        "Required key '%s' not present. "
-                        "Returning output in content with empty tool calls.",
+                    logger.debug(
+                        "Skipping JSON object without required key '%s'.",
                         missing_key,
                     )
-                    return ExtractedToolCallInformation(
-                        tools_called=False, tool_calls=[], content=model_output
-                    )
+                    continue
+                except json.JSONDecodeError:
+                    # A brace in surrounding text that doesn't start a JSON
+                    # object; keep any tool calls already extracted
+                    continue
                 except Exception:
                     # Any other error during parsing
                     logger.exception(
@@ -203,7 +204,14 @@ class Llama3JsonToolParser(ToolParser):
                     is_complete.append(
                         is_complete_json(current_text[start_idx : start_idx + end_idx])
                     )
-                    start_idx += end_idx + len("; ")
+                    start_idx += end_idx
+                    # the model may separate parallel calls with ";", "; ",
+                    # or a newline; skip whatever separator is present
+                    while (
+                        start_idx < len(current_text)
+                        and current_text[start_idx] in "; \t\n"
+                    ):
+                        start_idx += 1
                     # depending on the prompt Llama can use
                     # either arguments or parameters
                     if "parameters" in obj:


### PR DESCRIPTION
## Purpose

Two silent tool-call drops in `Llama3JsonToolParser`:

**Bug 1 — streaming: separator arithmetic.** The streaming loop advances with a hardcoded `start_idx += end_idx + len("; ")`, assuming parallel calls are always separated by exactly `"; "`. When the model emits a bare `;` or a newline instead, the two-char skip lands mid-way into the next JSON object, `partial_json_loads` ingests the bare string `"name"` as a "tool call", and the second call is corrupted or dropped. `"; "` and `";\n"` only worked because they happen to be 2 characters.

**Bug 2 — non-streaming: all-or-nothing extraction.** `extract_tool_calls` returns the entire output as content when any brace region *after* a valid tool call fails to parse. Trailing prose like `I used {searchTool} for this` (JSONDecodeError) or the model quoting its arguments (`the args were {"query": "x"}`, KeyError on `name`) discards already-extracted valid calls — even though surrounding text is explicitly supported (see `test_extract_tool_calls_multiple_json_with_surrounding_text`).

## Fix

- Streaming: advance past `end_idx`, then skip any run of `; \t\n` separator characters.
- Non-streaming: `continue` past unparseable/keyless brace regions instead of returning early; behavior when *no* valid call exists is unchanged (still returns content).

## Not a duplicate

Checked open PRs touching this area: #49320 (logprob validation), #48171 / #46708 (`make_valid_python`, different parsers), #48295 (whole-call-in-single-delta for llama3_json — different bug, no overlap in changed lines beyond the same file).

## Test Plan

New tests: 2 non-streaming (brace / JSON fragment in trailing prose) + 4 parametrized streaming separator variants (`"; "`, `";"`, `";\n"`, `"\n"`) driven through `extract_tool_calls_streaming` in character chunks.

```
python -m pytest tests/tool_parsers/test_llama3_json_tool_parser.py -q
21 passed   (with fix)
4 failed, 17 passed   (new tests on unfixed main — the two 2-char separators pass by luck)
```

Run locally on a CPU build (macOS) with the tokenizer swapped for the ungated `unsloth/Llama-3.2-1B-Instruct` mirror (the committed test keeps `meta-llama/Llama-3.2-1B-Instruct`); logic additionally verified standalone against a verbatim copy of the loop for all five separator variants. `pre-commit run` (ruff, ruff-format, mypy, typos, SPDX) passes on both changed files.

No model-quality impact: parsing only; no request/response schema changes.

## Disclosure

This fix was developed with AI assistance (Claude). I found the bugs through an audit of the parser, reviewed every changed line, and ran the tests above myself.