### PR TITLE
fix: Add fp8 einsum warmup

### DIFF
--- a/tests/model_executor/test_deep_gemm_warmup.py
+++ b/tests/model_executor/test_deep_gemm_warmup.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import vllm.model_executor.warmup.deep_gemm_warmup as deep_gemm_warmup
+
+
+@pytest.fixture(autouse=True)
+def clear_fp8_einsum_warmup_cache() -> None:
+    deep_gemm_warmup.FP8_EINSUM_WARMUP_CACHE.clear()
+
+
+def test_fp8_einsum_relax_warmup_covers_exact_small_shapes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VLLM_DEEP_GEMM_WARMUP", "relax")
+    monkeypatch.setattr(
+        deep_gemm_warmup,
+        "_generate_optimal_warmup_m_values",
+        lambda max_tokens, n, device: [1, 16, 64],
+    )
+    weight = torch.empty((2, 128, 256), dtype=torch.float8_e4m3fn)
+
+    assert deep_gemm_warmup._get_fp8_einsum_m_values(weight, 64) == [
+        *range(1, 33),
+        64,
+    ]
+
+
+def test_fp8_einsum_full_warmup_covers_every_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VLLM_DEEP_GEMM_WARMUP", "full")
+    weight = torch.empty((2, 128, 256), dtype=torch.float8_e4m3fn)
+
+    assert deep_gemm_warmup._get_fp8_einsum_m_values(weight, 5) == [1, 2, 3, 4, 5]
+
+
+@pytest.mark.parametrize(
+    ("tma_aligned_scales", "expected_scale_dtype", "expected_scale_inner"),
+    [
+        (False, torch.float32, 2),
+        (True, torch.int32, 1),
+    ],
+)
+def test_fp8_einsum_warmup_matches_runtime_layout(
+    monkeypatch: pytest.MonkeyPatch,
+    tma_aligned_scales: bool,
+    expected_scale_dtype: torch.dtype,
+    expected_scale_inner: int,
+) -> None:
+    monkeypatch.setattr(
+        deep_gemm_warmup,
+        "_get_fp8_einsum_m_values",
+        lambda weight, max_tokens: [1, 3],
+    )
+    monkeypatch.setattr(
+        deep_gemm_warmup,
+        "get_tma_aligned_size",
+        lambda size, element_size: (size + 3) // 4 * 4,
+    )
+
+    calls = []
+
+    def record_fp8_einsum(equation, a, b, out, *, recipe):
+        calls.append((equation, a, b, out, recipe))
+
+    monkeypatch.setattr(deep_gemm_warmup, "fp8_einsum", record_fp8_einsum)
+
+    weight = torch.empty((2, 128, 256), dtype=torch.float8_e4m3fn)
+    weight_scale = torch.empty((2, 1, 2), dtype=expected_scale_dtype)
+    recipe = (1, 1, 128)
+
+    deep_gemm_warmup._deepgemm_fp8_einsum_warmup(
+        weight,
+        weight_scale,
+        recipe,
+        tma_aligned_scales,
+        max_tokens=3,
+    )
+
+    assert len(calls) == 2
+    for num_tokens, (equation, a, b, out, actual_recipe) in zip([1, 3], calls):
+        aq, aq_scale = a
+        assert equation == "bhr,hdr->bhd"
+        assert aq.shape == (num_tokens, 2, 256)
+        assert aq.stride() == (256, num_tokens * 256, 1)
+        assert aq_scale.shape == (num_tokens, 2, expected_scale_inner)
+        assert aq_scale.dtype == expected_scale_dtype
+        assert b[0] is weight
+        assert b[1] is weight_scale
+        assert out.shape == (num_tokens, 2, 128)
+        assert actual_recipe == recipe
+
+    assert {
+        (weight.size(), recipe, tma_aligned_scales)
+    } == deep_gemm_warmup.FP8_EINSUM_WARMUP_CACHE
+
+
+def test_count_warmup_iterations_includes_unique_fp8_einsum_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = torch.nn.Module()
+    target = torch.nn.Module()
+    target.wo_a = SimpleNamespace(
+        weight=torch.empty((2, 128, 256), dtype=torch.float8_e4m3fn)
+    )
+    target._einsum_recipe = (1, 1, 128)
+    target._tma_aligned_scales = True
+    model.add_module("target", target)
+
+    monkeypatch.setattr(
+        deep_gemm_warmup,
+        "_fp8_linear_may_use_deep_gemm",
+        lambda module: False,
+    )
+    monkeypatch.setattr(
+        deep_gemm_warmup,
+        "_fp8_einsum_may_use_deep_gemm",
+        lambda module: module is target,
+    )
+    monkeypatch.setattr(
+        deep_gemm_warmup,
+        "_fused_moe_grouped_gemm_may_use_deep_gemm",
+        lambda module: False,
+    )
+    monkeypatch.setattr(
+        deep_gemm_warmup,
+        "_get_fp8_einsum_m_values",
+        lambda weight, max_tokens: [1, 2, 3],
+    )
+
+    assert deep_gemm_warmup._count_warmup_iterations(model, 3) == 3

--- a/vllm/model_executor/warmup/deep_gemm_warmup.py
+++ b/vllm/model_executor/warmup/deep_gemm_warmup.py
@@ -27,8 +27,10 @@ from vllm.model_executor.layers.quantization.fp8 import Fp8LinearMethod
 from vllm.model_executor.layers.quantization.online.mxfp8 import Mxfp8OnlineLinearMethod
 from vllm.tracing import instrument
 from vllm.utils.deep_gemm import (
+    fp8_einsum,
     fp8_gemm_nt,
     get_mk_alignment_for_contiguous_layout,
+    get_tma_aligned_size,
     m_grouped_fp8_gemm_nt_contiguous,
     mk_alignment_scope,
 )
@@ -199,6 +201,28 @@ def _fused_moe_grouped_gemm_may_use_deep_gemm(module: torch.nn.Module) -> bool:
     return isinstance(fused_experts, (DeepGemmExperts, TritonOrDeepGemmExperts))
 
 
+def _fp8_einsum_may_use_deep_gemm(module: torch.nn.Module) -> bool:
+    wo_a = getattr(module, "wo_a", None)
+    weight = getattr(wo_a, "weight", None)
+    weight_scale = getattr(
+        wo_a,
+        "weight_scale",
+        getattr(wo_a, "weight_scale_inv", None),
+    )
+    recipe = getattr(module, "_einsum_recipe", None)
+    return (
+        isinstance(wo_a, LinearBase)
+        and getattr(wo_a, "is_bmm", False)
+        and isinstance(weight, torch.Tensor)
+        and weight.dtype == torch.float8_e4m3fn
+        and weight.ndim == 3
+        and isinstance(weight_scale, torch.Tensor)
+        and isinstance(recipe, tuple)
+        and len(recipe) == 3
+        and isinstance(getattr(module, "_tma_aligned_scales", None), bool)
+    )
+
+
 FP8_GEMM_NT_WARMUP_CACHE: set[torch.Size] = set()
 
 
@@ -249,6 +273,85 @@ def _deepgemm_fp8_gemm_nt_warmup(
             pbar.update(1)
 
     FP8_GEMM_NT_WARMUP_CACHE.add(w.size())
+
+
+FP8_EINSUM_WARMUP_CACHE: set[tuple[torch.Size, tuple[int, int, int], bool]] = set()
+
+
+def _get_fp8_einsum_m_values(
+    w: torch.Tensor,
+    max_tokens: int,
+) -> list[int]:
+    if envs.VLLM_DEEP_GEMM_WARMUP == "full":
+        return list(range(1, max_tokens + 1))
+
+    assert envs.VLLM_DEEP_GEMM_WARMUP == "relax", (
+        "Expected "
+        'VLLM_DEEP_GEMM_WARMUP env to be set to "relax" or "full" but got '
+        f"{envs.VLLM_DEEP_GEMM_WARMUP}"
+    )
+    _, n, _ = w.size()
+    m_values = _generate_optimal_warmup_m_values(max_tokens, n, w.device)
+
+    # DeepGEMM swaps A/B for small-M fp8_einsum on SM120, making the
+    # original token count a compiled N dimension. Warm every exact small
+    # shape so requests such as M=18 cannot load a new module at runtime.
+    m_values.extend(range(1, min(max_tokens, 32) + 1))
+    return sorted({m for m in m_values if m <= max_tokens})
+
+
+def _deepgemm_fp8_einsum_warmup(
+    w: torch.Tensor,
+    ws: torch.Tensor,
+    recipe: tuple[int, int, int],
+    tma_aligned_scales: bool,
+    max_tokens: int,
+    pbar: tqdm | None = None,
+) -> None:
+    cache_key = (w.size(), recipe, tma_aligned_scales)
+    if cache_key in FP8_EINSUM_WARMUP_CACHE:
+        return
+
+    h, n, k = w.size()
+    scale_blocks = cdiv(k, recipe[2])
+    scale_inner = cdiv(scale_blocks, 4) if tma_aligned_scales else scale_blocks
+    scale_dtype = torch.int32 if tma_aligned_scales else torch.float32
+
+    for num_tokens in _get_fp8_einsum_m_values(w, max_tokens):
+        tma_aligned_tokens = get_tma_aligned_size(num_tokens, 4)
+        aq = torch.empty(
+            (h, num_tokens, k),
+            device=w.device,
+            dtype=torch.float8_e4m3fn,
+        ).transpose(0, 1)
+        aq_scales = (
+            torch.empty(
+                h * scale_inner * tma_aligned_tokens,
+                device=w.device,
+                dtype=scale_dtype,
+            )
+            .as_strided(
+                (h, num_tokens, scale_inner),
+                (scale_inner * tma_aligned_tokens, 1, tma_aligned_tokens),
+            )
+            .transpose(0, 1)
+        )
+        out = torch.empty(
+            (num_tokens, h, n),
+            device=w.device,
+            dtype=torch.bfloat16,
+        )
+        fp8_einsum(
+            "bhr,hdr->bhd",
+            (aq, aq_scales),
+            (w, ws),
+            out,
+            recipe=recipe,
+        )
+        if pbar is not None:
+            pbar.update(1)
+
+    FP8_EINSUM_WARMUP_CACHE.add(cache_key)
 
 
 GROUPED_FP8_GEMM_NT_CONTIGUOUS_WARMUP_CACHE: set[torch.Size] = set()
@@ -368,6 +471,31 @@ def deepgemm_fp8_gemm_nt_warmup(
         _deepgemm_fp8_gemm_nt_warmup(w=w, ws=ws, max_tokens=max_tokens, pbar=pbar)
 
 
+def deepgemm_fp8_einsum_warmup(
+    model: torch.nn.Module,
+    max_tokens: int,
+    pbar: tqdm | None = None,
+) -> None:
+    for module in model.modules():
+        if not _fp8_einsum_may_use_deep_gemm(module):
+            continue
+
+        wo_a = module.wo_a
+        weight_scale = (
+            wo_a.weight_scale
+            if hasattr(wo_a, "weight_scale")
+            else wo_a.weight_scale_inv
+        )
+        _deepgemm_fp8_einsum_warmup(
+            w=wo_a.weight,
+            ws=weight_scale,
+            recipe=module._einsum_recipe,
+            tma_aligned_scales=module._tma_aligned_scales,
+            max_tokens=max_tokens,
+            pbar=pbar,
+        )
+
+
 def deepgemm_grouped_fp8_gemm_nt_contiguous_warmup(
     model: torch.nn.Module, max_tokens: int, pbar: tqdm | None = None
 ):
@@ -386,6 +514,7 @@ def deepgemm_grouped_fp8_gemm_nt_contiguous_warmup(
 
 def _count_warmup_iterations(model: torch.nn.Module, max_tokens: int) -> int:
     seen_fp8_sizes: set[torch.Size] = set(FP8_GEMM_NT_WARMUP_CACHE)
+    seen_einsum_keys = set(FP8_EINSUM_WARMUP_CACHE)
     seen_grouped_sizes: set[torch.Size] = set(
         GROUPED_FP8_GEMM_NT_CONTIGUOUS_WARMUP_CACHE
     )
@@ -397,6 +526,12 @@ def _count_warmup_iterations(model: torch.nn.Module, max_tokens: int) -> int:
             if w.size() not in seen_fp8_sizes:
                 total += len(_get_fp8_gemm_nt_m_values(w, max_tokens))
                 seen_fp8_sizes.add(w.size())
+        elif _fp8_einsum_may_use_deep_gemm(m):
+            w = m.wo_a.weight
+            cache_key = (w.size(), m._einsum_recipe, m._tma_aligned_scales)
+            if cache_key not in seen_einsum_keys:
+                total += len(_get_fp8_einsum_m_values(w, max_tokens))
+                seen_einsum_keys.add(cache_key)
         elif _fused_moe_grouped_gemm_may_use_deep_gemm(m):
             w13, _, w2, _, num_topk = _extract_data_from_fused_moe_module(m)
             if w13.size() in seen_grouped_sizes and w2.size() in seen_grouped_sizes:
@@ -422,7 +557,9 @@ def deep_gemm_warmup(model: torch.nn.Module, max_tokens: int):
     if is_global_first_rank():
         with tqdm(total=total, desc="DeepGEMM warmup") as pbar:
             deepgemm_fp8_gemm_nt_warmup(model, max_tokens, pbar)
+            deepgemm_fp8_einsum_warmup(model, max_tokens, pbar)
             deepgemm_grouped_fp8_gemm_nt_contiguous_warmup(model, max_tokens, pbar)
     else:
         deepgemm_fp8_gemm_nt_warmup(model, max_tokens, None)
+        deepgemm_fp8_einsum_warmup(model, max_tokens, None)
         deepgemm_grouped_fp8_gemm_nt_contiguous_warmup(model, max_tokens, None)


### PR DESCRIPTION
## Purpose
Fixes #49905.

DeepGEMM warmup currently misses the fp8_einsum path, so its kernels may be JIT-compiled during the first real requests, causing an avoidable latency spike. This change adds fp8_einsum to the existing warmup flow and covers the shape/layout handling with unit tests.

Currently, I found no existing PR that addresses this issue, and the current main branch does not contain an equivalent fix.

## Test Plan
I will test on a platform with NVIDIA H20, launch the affected FP8 model with:
DG_JIT_DEBUG=1 DG_JIT_PRINT_LOAD_TIME=1

Verify that:
- fp8_einsum kernels are compiled or loaded during model warmup.
- The first inference request does not trigger additional fp8_einsum JIT compilation.
- Inference output remains consistent with the current main branch.

## Test Result
### H20 cluster A/B validation
Tested revision: 4fffa0c0e49b10cec59a483e27017f7b810cfbb9
Environment:
- 8 x NVIDIA H20 (SM90), PP=2 and TP=4.
- DeepSeek-V4-Flash checkpoint with real FP8 E4M3 wo_a weights.
- DeepGEMM enabled for the attention FP8 einsum path.
- Fresh /tmp/dg-jit-cache for both baseline and patched processes.
- DG_JIT_DEBUG=1 and DG_JIT_PRINT_LOAD_TIME=1.

Baseline:
- DeepGEMM warmup iterations: 1360.
- Batched FP8 CUBINs at Ready: 3.
- Batched FP8 CUBINs after M=1/18/32 requests: 6.
- Three target fp8_einsum CUBINs were loaded after Ready.

Patched:
- DeepGEMM warmup iterations: 1585.
- Batched FP8 CUBINs at Ready: 13.
- Batched FP8 CUBINs after M=1/18/32 requests: 13.
- Post-Ready target CUBIN loads: 0.

The patched startup log contains the same three target CUBIN hashes that the baseline loaded during the M=1, M=18, and M=32 request windows. This confirms that their compilation/loading moved from serving time into startup warmup.
 
### Inference output check 
Both variants used the same prompt, seed 49930, temperature 0, output length, and per-request cache salts. All 102 requests returned HTTP 200:
- M=1: exact output match.
- M=32: output multisets matched exactly.
- M=18: every response produced the same answer (42). The only observed difference was a one-response punctuation-frequency shift after the answer token, consistent with batching order.

No correctness regression was observed.

A separate model-quality evaluation was not run because this change only adds discarded startup warmup calls and does not change the serving computation or model numerics.

### Remaining coverage
The runtime A/B validation was performed on H20/SM90. The SM120 scale layout is covered by unit tests, but the SM120-specific small-M operand-swap behavior has not been directly validated on Blackwell hardware.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

