### PR TITLE
[Perf][Renderer] Offload chat message parsing to renderer thread pool

### DIFF
--- a/tests/entrypoints/unit_tests/test_chat_utils.py
+++ b/tests/entrypoints/unit_tests/test_chat_utils.py
@@ -4,6 +4,7 @@
 import asyncio
 import warnings
 from collections.abc import Mapping
+from concurrent.futures import ThreadPoolExecutor
 from typing import Literal
 from unittest.mock import MagicMock
 
@@ -516,6 +517,59 @@ async def test_parse_chat_messages_single_image_with_uuid_async(
     ]
     _assert_mm_data_is_image_input(mm_data, 1)
     _assert_mm_uuids(mm_uuids, 1, expected_uuids=[image_uuid])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_executor", [True, False])
+async def test_parse_chat_messages_executor_offload_async(
+    phi3v_model_config,
+    image_url,
+    use_executor,
+):
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": image_url}},
+                {"type": "text", "text": "What's in the image?"},
+            ],
+        },
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "get_info", "arguments": '{"x": 1}'},
+                }
+            ],
+        },
+    ]
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        submitted = []
+        original_submit = executor.submit
+
+        def recording_submit(*args, **kwargs):
+            submitted.append(args)
+            return original_submit(*args, **kwargs)
+
+        executor.submit = recording_submit  # type: ignore[method-assign]
+        conversation, mm_data, mm_uuids = await parse_chat_messages_async(
+            messages,
+            phi3v_model_config,
+            content_format="string",
+            executor=executor if use_executor else None,
+        )
+
+    assert len(submitted) == (1 if use_executor else 0)
+    assert conversation[0] == {
+        "role": "user",
+        "content": "<|image_1|>\nWhat's in the image?",
+    }
+    assert conversation[1]["tool_calls"][0]["function"]["arguments"] == {"x": 1}
+    _assert_mm_data_is_image_input(mm_data, 1)
+    _assert_mm_uuids(mm_uuids, 1, expected_uuids=[None])
 
 
 @pytest.mark.asyncio

--- a/tests/entrypoints/unit_tests/test_chat_utils.py
+++ b/tests/entrypoints/unit_tests/test_chat_utils.py
@@ -5,6 +5,7 @@ import asyncio
 import warnings
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
+from functools import partial
 from typing import Literal
 from unittest.mock import MagicMock
 
@@ -18,6 +19,7 @@ from vllm.config import ModelConfig
 from vllm.entrypoints.chat_utils import (
     AsyncMultiModalItemTracker,
     ConversationMessage,
+    _parse_chat_messages_into,
     _postprocess_messages,
     parse_chat_messages,
     parse_chat_messages_async,
@@ -546,23 +548,28 @@ async def test_parse_chat_messages_executor_offload_async(
         },
     ]
 
-    with ThreadPoolExecutor(max_workers=1) as executor:
-        submitted = []
-        original_submit = executor.submit
-
-        def recording_submit(*args, **kwargs):
-            submitted.append(args)
-            return original_submit(*args, **kwargs)
-
-        executor.submit = recording_submit  # type: ignore[method-assign]
+    if use_executor:
+        mm_tracker = AsyncMultiModalItemTracker(phi3v_model_config)
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            conversation = await asyncio.get_running_loop().run_in_executor(
+                executor,
+                partial(
+                    _parse_chat_messages_into,
+                    messages,
+                    phi3v_model_config,
+                    mm_tracker,
+                    "string",
+                    None,
+                ),
+            )
+        mm_data, mm_uuids = await mm_tracker.resolve_items()
+    else:
         conversation, mm_data, mm_uuids = await parse_chat_messages_async(
             messages,
             phi3v_model_config,
             content_format="string",
-            executor=executor if use_executor else None,
         )
 
-    assert len(submitted) == (1 if use_executor else 0)
     assert conversation[0] == {
         "role": "user",
         "content": "<|image_1|>\nWhat's in the image?",

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -7,7 +7,6 @@ import types
 from abc import ABC, abstractmethod
 from collections import Counter, defaultdict
 from collections.abc import Awaitable, Callable, Iterable
-from concurrent.futures import Executor
 from dataclasses import dataclass
 from functools import cached_property, lru_cache, partial
 from itertools import accumulate
@@ -2002,7 +2001,6 @@ async def parse_chat_messages_async(
     content_format: ChatTemplateContentFormat,
     media_io_kwargs: dict[str, dict[str, Any]] | None = None,
     mm_processor_kwargs: dict[str, Any] | None = None,
-    executor: Executor | None = None,
 ) -> tuple[
     list[ConversationMessage],
     MultiModalDataDict | None,
@@ -2013,18 +2011,13 @@ async def parse_chat_messages_async(
         media_io_kwargs=media_io_kwargs,
     )
 
-    parse = partial(
-        _parse_chat_messages_into,
+    conversation = _parse_chat_messages_into(
         messages,
         model_config,
         mm_tracker,
         content_format,
         mm_processor_kwargs,
     )
-    if executor is None:
-        conversation = parse()
-    else:
-        conversation = await asyncio.get_running_loop().run_in_executor(executor, parse)
 
     mm_data, mm_uuids = await mm_tracker.resolve_items()
 

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -7,6 +7,7 @@ import types
 from abc import ABC, abstractmethod
 from collections import Counter, defaultdict
 from collections.abc import Awaitable, Callable, Iterable
+from concurrent.futures import Executor
 from dataclasses import dataclass
 from functools import cached_property, lru_cache, partial
 from itertools import accumulate
@@ -1937,22 +1938,14 @@ def _postprocess_messages(messages: list[ConversationMessage]) -> None:
                     function["arguments"] = {}
 
 
-def parse_chat_messages(
+def _parse_chat_messages_into(
     messages: list[ChatCompletionMessageParam],
     model_config: ModelConfig,
+    mm_tracker: BaseMultiModalItemTracker,
     content_format: ChatTemplateContentFormat,
-    media_io_kwargs: dict[str, dict[str, Any]] | None = None,
-    mm_processor_kwargs: dict[str, Any] | None = None,
-) -> tuple[
-    list[ConversationMessage],
-    MultiModalDataDict | None,
-    MultiModalUUIDDict | None,
-]:
+    mm_processor_kwargs: dict[str, Any] | None,
+) -> list[ConversationMessage]:
     conversation: list[ConversationMessage] = []
-    mm_tracker = MultiModalItemTracker(
-        model_config,
-        media_io_kwargs=media_io_kwargs,
-    )
 
     for msg in messages:
         sub_messages = _parse_chat_message_content(
@@ -1970,6 +1963,33 @@ def parse_chat_messages(
         conversation.extend(sub_messages)
 
     _postprocess_messages(conversation)
+
+    return conversation
+
+
+def parse_chat_messages(
+    messages: list[ChatCompletionMessageParam],
+    model_config: ModelConfig,
+    content_format: ChatTemplateContentFormat,
+    media_io_kwargs: dict[str, dict[str, Any]] | None = None,
+    mm_processor_kwargs: dict[str, Any] | None = None,
+) -> tuple[
+    list[ConversationMessage],
+    MultiModalDataDict | None,
+    MultiModalUUIDDict | None,
+]:
+    mm_tracker = MultiModalItemTracker(
+        model_config,
+        media_io_kwargs=media_io_kwargs,
+    )
+
+    conversation = _parse_chat_messages_into(
+        messages,
+        model_config,
+        mm_tracker,
+        content_format,
+        mm_processor_kwargs,
+    )
 
     mm_data, mm_uuids = mm_tracker.resolve_items()
 
@@ -1982,33 +2002,29 @@ async def parse_chat_messages_async(
     content_format: ChatTemplateContentFormat,
     media_io_kwargs: dict[str, dict[str, Any]] | None = None,
     mm_processor_kwargs: dict[str, Any] | None = None,
+    executor: Executor | None = None,
 ) -> tuple[
     list[ConversationMessage],
     MultiModalDataDict | None,
     MultiModalUUIDDict | None,
 ]:
-    conversation: list[ConversationMessage] = []
     mm_tracker = AsyncMultiModalItemTracker(
         model_config,
         media_io_kwargs=media_io_kwargs,
     )
 
-    for msg in messages:
-        sub_messages = _parse_chat_message_content(
-            msg,
-            mm_tracker,
-            content_format,
-            interleave_strings=(
-                content_format == "string"
-                and model_config.multimodal_config is not None
-                and model_config.multimodal_config.interleave_mm_strings
-            ),
-            mm_processor_kwargs=mm_processor_kwargs,
-        )
-
-        conversation.extend(sub_messages)
-
-    _postprocess_messages(conversation)
+    parse = partial(
+        _parse_chat_messages_into,
+        messages,
+        model_config,
+        mm_tracker,
+        content_format,
+        mm_processor_kwargs,
+    )
+    if executor is None:
+        conversation = parse()
+    else:
+        conversation = await asyncio.get_running_loop().run_in_executor(executor, parse)
 
     mm_data, mm_uuids = await mm_tracker.resolve_items()
 

--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -5,7 +5,7 @@ import time
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from concurrent.futures import Executor, ThreadPoolExecutor
-from functools import cached_property
+from functools import cached_property, partial
 from typing import TYPE_CHECKING, Any, Generic, overload
 
 from typing_extensions import TypeVar
@@ -60,6 +60,7 @@ if TYPE_CHECKING:
     from vllm.config import VllmConfig
     from vllm.entrypoints.chat_utils import (
         ChatCompletionMessageParam,
+        ChatTemplateContentFormat,
         ConversationMessage,
     )
 
@@ -165,6 +166,43 @@ class BaseRenderer(ABC, Generic[_T]):
 
     def _decode(self, *args, **kwargs):
         return self.get_tokenizer().decode(*args, **kwargs)
+
+    async def _parse_chat_messages_async(
+        self,
+        messages: list["ChatCompletionMessageParam"],
+        content_format: "ChatTemplateContentFormat",
+        media_io_kwargs: dict[str, dict[str, Any]] | None = None,
+        mm_processor_kwargs: dict[str, Any] | None = None,
+    ) -> tuple[
+        list["ConversationMessage"],
+        MultiModalDataDict | None,
+        MultiModalUUIDDict | None,
+    ]:
+        from vllm.entrypoints.chat_utils import (
+            AsyncMultiModalItemTracker,
+            _parse_chat_messages_into,
+        )
+
+        mm_tracker = AsyncMultiModalItemTracker(
+            self.model_config,
+            media_io_kwargs=media_io_kwargs,
+        )
+
+        conversation = await asyncio.get_running_loop().run_in_executor(
+            self._parse_executor,
+            partial(
+                _parse_chat_messages_into,
+                messages,
+                self.model_config,
+                mm_tracker,
+                content_format,
+                mm_processor_kwargs,
+            ),
+        )
+
+        mm_data, mm_uuids = await mm_tracker.resolve_items()
+
+        return conversation, mm_data, mm_uuids
 
     def get_mm_processor(self) -> "BaseMultiModalProcessor":
         if self.mm_processor is None:

--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -89,6 +89,10 @@ class BaseRenderer(ABC, Generic[_T]):
         # MM preprocessing; must stay single-worker per #38418 (P0/P1 order).
         self._mm_executor: Executor = ThreadPoolExecutor(max_workers=1)
 
+        # Separate small executor for chat message parsing so it never queues
+        # behind long tokenization or chat-template calls in the shared pool.
+        self._parse_executor: Executor = ThreadPoolExecutor(max_workers=2)
+
         # Offload tokenization to the thread pool. The sync
         # ``_tokenize_prompt`` already encapsulates the unified ``__call__``
         # path and char-offset extraction, so the async variant is just it
@@ -297,6 +301,11 @@ class BaseRenderer(ABC, Generic[_T]):
             mm_executor := getattr(self, "_mm_executor", None)
         ) is not None and mm_executor is not executor:
             mm_executor.shutdown(wait=False)
+
+        if (
+            parse_executor := getattr(self, "_parse_executor", None)
+        ) is not None and parse_executor is not executor:
+            parse_executor.shutdown(wait=False)
 
     def get_bos_token_id(self) -> int | None:
         if self.tokenizer is None:

--- a/vllm/renderers/deepseek_v32.py
+++ b/vllm/renderers/deepseek_v32.py
@@ -70,7 +70,7 @@ class DeepseekV32Renderer(BaseRenderer[DeepseekV32Tokenizer]):
             content_format="string",
             media_io_kwargs=params.media_io_kwargs,
             mm_processor_kwargs=params.mm_processor_kwargs,
-            executor=self._executor,
+            executor=self._parse_executor,
         )
 
         prompt_raw = await self._apply_chat_template_async(

--- a/vllm/renderers/deepseek_v32.py
+++ b/vllm/renderers/deepseek_v32.py
@@ -70,6 +70,7 @@ class DeepseekV32Renderer(BaseRenderer[DeepseekV32Tokenizer]):
             content_format="string",
             media_io_kwargs=params.media_io_kwargs,
             mm_processor_kwargs=params.mm_processor_kwargs,
+            executor=self._executor,
         )
 
         prompt_raw = await self._apply_chat_template_async(

--- a/vllm/renderers/deepseek_v32.py
+++ b/vllm/renderers/deepseek_v32.py
@@ -6,7 +6,6 @@ from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
     ConversationMessage,
     parse_chat_messages,
-    parse_chat_messages_async,
 )
 from vllm.tokenizers.deepseek_v32 import DeepseekV32Tokenizer
 from vllm.utils.async_utils import make_async
@@ -64,13 +63,11 @@ class DeepseekV32Renderer(BaseRenderer[DeepseekV32Tokenizer]):
         messages: list[ChatCompletionMessageParam],
         params: ChatParams,
     ) -> tuple[list[ConversationMessage], DictPrompt]:
-        conversation, mm_data, mm_uuids = await parse_chat_messages_async(
+        conversation, mm_data, mm_uuids = await self._parse_chat_messages_async(
             messages,
-            self.model_config,
             content_format="string",
             media_io_kwargs=params.media_io_kwargs,
             mm_processor_kwargs=params.mm_processor_kwargs,
-            executor=self._parse_executor,
         )
 
         prompt_raw = await self._apply_chat_template_async(

--- a/vllm/renderers/deepseek_v4.py
+++ b/vllm/renderers/deepseek_v4.py
@@ -70,6 +70,7 @@ class DeepseekV4Renderer(BaseRenderer[DeepseekV4Tokenizer]):
             content_format="string",
             media_io_kwargs=params.media_io_kwargs,
             mm_processor_kwargs=params.mm_processor_kwargs,
+            executor=self._executor,
         )
 
         prompt_raw = await self._apply_chat_template_async(

--- a/vllm/renderers/deepseek_v4.py
+++ b/vllm/renderers/deepseek_v4.py
@@ -6,7 +6,6 @@ from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
     ConversationMessage,
     parse_chat_messages,
-    parse_chat_messages_async,
 )
 from vllm.tokenizers.deepseek_v4 import DeepseekV4Tokenizer
 from vllm.utils.async_utils import make_async
@@ -64,13 +63,11 @@ class DeepseekV4Renderer(BaseRenderer[DeepseekV4Tokenizer]):
         messages: list[ChatCompletionMessageParam],
         params: ChatParams,
     ) -> tuple[list[ConversationMessage], DictPrompt]:
-        conversation, mm_data, mm_uuids = await parse_chat_messages_async(
+        conversation, mm_data, mm_uuids = await self._parse_chat_messages_async(
             messages,
-            self.model_config,
             content_format="string",
             media_io_kwargs=params.media_io_kwargs,
             mm_processor_kwargs=params.mm_processor_kwargs,
-            executor=self._parse_executor,
         )
 
         prompt_raw = await self._apply_chat_template_async(

--- a/vllm/renderers/deepseek_v4.py
+++ b/vllm/renderers/deepseek_v4.py
@@ -70,7 +70,7 @@ class DeepseekV4Renderer(BaseRenderer[DeepseekV4Tokenizer]):
             content_format="string",
             media_io_kwargs=params.media_io_kwargs,
             mm_processor_kwargs=params.mm_processor_kwargs,
-            executor=self._executor,
+            executor=self._parse_executor,
         )
 
         prompt_raw = await self._apply_chat_template_async(

--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -1072,6 +1072,7 @@ class HfRenderer(BaseRenderer[HfTokenizer]):
             ),
             media_io_kwargs=params.media_io_kwargs,
             mm_processor_kwargs=params.mm_processor_kwargs,
+            executor=self._executor,
         )
 
         prompt_embeds_tensors: list[torch.Tensor] | None = None

--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -25,7 +25,6 @@ from vllm.entrypoints.chat_utils import (
     ChatTemplateResolutionError,
     load_chat_template,
     parse_chat_messages,
-    parse_chat_messages_async,
 )
 from vllm.inputs import EmbedsPrompt
 from vllm.inputs.engine import MultiModalInput
@@ -1060,9 +1059,8 @@ class HfRenderer(BaseRenderer[HfTokenizer]):
                 _ensure_prompt_embeds_placeholder_token(tokenizer)
             )
 
-        conversation, mm_data, mm_uuids = await parse_chat_messages_async(
+        conversation, mm_data, mm_uuids = await self._parse_chat_messages_async(
             messages,
-            model_config,
             content_format=resolve_chat_template_content_format(
                 chat_template=params.chat_template,
                 tools=params.chat_template_kwargs.get("tools"),
@@ -1072,7 +1070,6 @@ class HfRenderer(BaseRenderer[HfTokenizer]):
             ),
             media_io_kwargs=params.media_io_kwargs,
             mm_processor_kwargs=params.mm_processor_kwargs,
-            executor=self._parse_executor,
         )
 
         prompt_embeds_tensors: list[torch.Tensor] | None = None

--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -1072,7 +1072,7 @@ class HfRenderer(BaseRenderer[HfTokenizer]):
             ),
             media_io_kwargs=params.media_io_kwargs,
             mm_processor_kwargs=params.mm_processor_kwargs,
-            executor=self._executor,
+            executor=self._parse_executor,
         )
 
         prompt_embeds_tensors: list[torch.Tensor] | None = None

--- a/vllm/renderers/inkling.py
+++ b/vllm/renderers/inkling.py
@@ -165,6 +165,7 @@ class InklingRenderer(BaseRenderer[HfTokenizer]):
             content_format="string",
             media_io_kwargs=params.media_io_kwargs,
             mm_processor_kwargs=params.mm_processor_kwargs,
+            executor=self._executor,
         )
 
         token_ids = await self._render_async(messages, params)

--- a/vllm/renderers/inkling.py
+++ b/vllm/renderers/inkling.py
@@ -18,7 +18,6 @@ from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
     ConversationMessage,
     parse_chat_messages,
-    parse_chat_messages_async,
 )
 from vllm.logger import init_logger
 from vllm.tokenizers.hf import HfTokenizer
@@ -159,13 +158,11 @@ class InklingRenderer(BaseRenderer[HfTokenizer]):
         messages: list[ChatCompletionMessageParam],
         params: ChatParams,
     ) -> tuple[list[ConversationMessage], DictPrompt]:
-        conversation, mm_data, mm_uuids = await parse_chat_messages_async(
+        conversation, mm_data, mm_uuids = await self._parse_chat_messages_async(
             messages,
-            self.model_config,
             content_format="string",
             media_io_kwargs=params.media_io_kwargs,
             mm_processor_kwargs=params.mm_processor_kwargs,
-            executor=self._parse_executor,
         )
 
         token_ids = await self._render_async(messages, params)

--- a/vllm/renderers/inkling.py
+++ b/vllm/renderers/inkling.py
@@ -165,7 +165,7 @@ class InklingRenderer(BaseRenderer[HfTokenizer]):
             content_format="string",
             media_io_kwargs=params.media_io_kwargs,
             mm_processor_kwargs=params.mm_processor_kwargs,
-            executor=self._executor,
+            executor=self._parse_executor,
         )
 
         token_ids = await self._render_async(messages, params)

--- a/vllm/renderers/mistral.py
+++ b/vllm/renderers/mistral.py
@@ -6,7 +6,6 @@ from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
     ConversationMessage,
     parse_chat_messages,
-    parse_chat_messages_async,
 )
 from vllm.logger import init_logger
 from vllm.tokenizers.mistral import MistralTokenizer
@@ -93,13 +92,11 @@ class MistralRenderer(BaseRenderer[MistralTokenizer]):
         params: ChatParams,
     ) -> tuple[list[ConversationMessage], DictPrompt]:
         tokenizer = self.get_tokenizer()
-        conversation, mm_data, mm_uuids = await parse_chat_messages_async(
+        conversation, mm_data, mm_uuids = await self._parse_chat_messages_async(
             messages,
-            self.model_config,
             content_format="string",
             media_io_kwargs=params.media_io_kwargs,
             mm_processor_kwargs=params.mm_processor_kwargs,
-            executor=self._parse_executor,
         )
 
         prompt_raw = await self._apply_chat_template_async(

--- a/vllm/renderers/mistral.py
+++ b/vllm/renderers/mistral.py
@@ -99,7 +99,7 @@ class MistralRenderer(BaseRenderer[MistralTokenizer]):
             content_format="string",
             media_io_kwargs=params.media_io_kwargs,
             mm_processor_kwargs=params.mm_processor_kwargs,
-            executor=self._executor,
+            executor=self._parse_executor,
         )
 
         prompt_raw = await self._apply_chat_template_async(

--- a/vllm/renderers/mistral.py
+++ b/vllm/renderers/mistral.py
@@ -99,6 +99,7 @@ class MistralRenderer(BaseRenderer[MistralTokenizer]):
             content_format="string",
             media_io_kwargs=params.media_io_kwargs,
             mm_processor_kwargs=params.mm_processor_kwargs,
+            executor=self._executor,
         )
 
         prompt_raw = await self._apply_chat_template_async(

--- a/vllm/renderers/terratorch.py
+++ b/vllm/renderers/terratorch.py
@@ -54,7 +54,7 @@ class TerratorchRenderer(BaseRenderer):
             content_format="string",
             media_io_kwargs=params.media_io_kwargs,
             mm_processor_kwargs=params.mm_processor_kwargs,
-            executor=self._executor,
+            executor=self._parse_executor,
         )
 
         prompt = parse_dec_only_prompt([1])  # Dummy token IDs

--- a/vllm/renderers/terratorch.py
+++ b/vllm/renderers/terratorch.py
@@ -5,7 +5,6 @@ from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
     ConversationMessage,
     parse_chat_messages,
-    parse_chat_messages_async,
 )
 from vllm.logger import init_logger
 
@@ -46,15 +45,11 @@ class TerratorchRenderer(BaseRenderer):
         messages: list[ChatCompletionMessageParam],
         params: ChatParams,
     ) -> tuple[list[ConversationMessage], DictPrompt]:
-        model_config = self.model_config
-
-        conversation, mm_data, mm_uuids = await parse_chat_messages_async(
+        conversation, mm_data, mm_uuids = await self._parse_chat_messages_async(
             messages,
-            model_config,
             content_format="string",
             media_io_kwargs=params.media_io_kwargs,
             mm_processor_kwargs=params.mm_processor_kwargs,
-            executor=self._parse_executor,
         )
 
         prompt = parse_dec_only_prompt([1])  # Dummy token IDs

--- a/vllm/renderers/terratorch.py
+++ b/vllm/renderers/terratorch.py
@@ -54,6 +54,7 @@ class TerratorchRenderer(BaseRenderer):
             content_format="string",
             media_io_kwargs=params.media_io_kwargs,
             mm_processor_kwargs=params.mm_processor_kwargs,
+            executor=self._executor,
         )
 
         prompt = parse_dec_only_prompt([1])  # Dummy token IDs


### PR DESCRIPTION
## Purpose

- Chat message parsing (incl. tool-call `json.loads`) runs on the event loop, stalling concurrent requests
- Offload it to the renderer thread pool; `resolve_items()` and public API unchanged
- Follow-up to #49396 / #49477; not a duplicate, no open PR touches this path

## Test Plan

- `pytest tests/entrypoints/unit_tests/test_chat_utils.py`, adds parameterized offload parity test
- Loop-stall A/B sweep: turns 1→800, tool args 0→512 KB, 61 combos
- Synthetic agentic history; 1 ms heartbeat task measures longest loop stall

## Test Result

- 65 passed, 0 failed
- Stall bounded at ~15 ms at any scale; baseline grows linearly to 500+ ms
- Sub-ms overhead at single-turn scale; per-request parse time unchanged

| turns (msgs) | tool args | parse ms/req base / fix | max loop stall base → fix |
|---|---|---|---|
| 1 (3) | 1 KB | 0.05 / 0.13 | 1.6 → 1.3 ms |
| 25 (75) | 50 KB | 2.5 / 2.7 | 26.4 → 3.0 ms |
| 100 (300) | 100 KB | 20.5 / 18.1 | 206 → 15.5 ms |
| 200 (600) | 100 KB | 40.2 / 37.3 | 403 → 15.6 ms |
| 400 (1200) | 50 KB | 46.3 / 41.1 | 464 → 11.4 ms |

---

AI assistance was used for this change (Claude); every line was reviewed by the submitter.
