### PR TITLE
[Bugfix] Gate MiniMax M3 warmup imports by model and platform

### DIFF
--- a/tests/model_executor/test_minimax_m3_msa_warmup.py
+++ b/tests/model_executor/test_minimax_m3_msa_warmup.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import importlib
+import sys
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from vllm.model_executor.warmup import minimax_m3_msa_warmup as warmup
+
+_MINIMAX_MODEL_MODULE = "vllm.models.minimax_m3.nvidia.model"
+
+
+def test_warmup_module_does_not_import_minimax_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delitem(sys.modules, warmup.__name__)
+    monkeypatch.setitem(sys.modules, _MINIMAX_MODEL_MODULE, None)
+
+    importlib.import_module(warmup.__name__)
+
+
+@pytest.mark.parametrize(
+    ("architecture", "is_blackwell", "should_run"),
+    [
+        ("DiffusionGemmaForBlockDiffusion", True, False),
+        ("MiniMaxM3SparseForCausalLM", False, False),
+        ("MiniMaxM3SparseForCausalLM", True, True),
+    ],
+)
+def test_warmup_requires_supported_model_and_platform(
+    monkeypatch: pytest.MonkeyPatch,
+    architecture: str,
+    is_blackwell: bool,
+    should_run: bool,
+) -> None:
+    class SparseAttention:
+        pass
+
+    monkeypatch.setitem(
+        sys.modules,
+        _MINIMAX_MODEL_MODULE,
+        SimpleNamespace(MiniMaxM3SparseAttention=SparseAttention),
+    )
+    monkeypatch.setattr(warmup.current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(
+        warmup.current_platform,
+        "is_device_capability_family",
+        lambda capability: is_blackwell and capability == 100,
+    )
+    get_model = Mock(return_value=SimpleNamespace(modules=lambda: [SparseAttention()]))
+    dummy_run = Mock()
+    worker = SimpleNamespace(
+        get_model=get_model,
+        model_runner=SimpleNamespace(_dummy_run=dummy_run),
+        vllm_config=SimpleNamespace(
+            model_config=SimpleNamespace(architecture=architecture)
+        ),
+    )
+
+    warmup.minimax_m3_msa_warmup(worker)
+
+    assert get_model.called is should_run
+    assert dummy_run.called is should_run

--- a/vllm/model_executor/warmup/minimax_m3_msa_warmup.py
+++ b/vllm/model_executor/warmup/minimax_m3_msa_warmup.py
@@ -4,7 +4,6 @@
 from typing import TYPE_CHECKING
 
 from vllm.logger import init_logger
-from vllm.models.minimax_m3.nvidia.model import MiniMaxM3SparseAttention
 from vllm.platforms import current_platform
 from vllm.tracing import instrument
 
@@ -13,9 +12,26 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
+_MINIMAX_M3_ARCHITECTURES = frozenset(
+    {
+        "MiniMaxM3MTP",
+        "MiniMaxM3SparseForCausalLM",
+        "MiniMaxM3SparseForConditionalGeneration",
+    }
+)
+
 
 @instrument(span_name="MiniMax M3 MSA warmup")
 def minimax_m3_msa_warmup(worker: "Worker") -> None:
+    if worker.vllm_config.model_config.architecture not in _MINIMAX_M3_ARCHITECTURES:
+        return
+    if not (
+        current_platform.is_cuda() and current_platform.is_device_capability_family(100)
+    ):
+        return
+
+    from vllm.models.minimax_m3.nvidia.model import MiniMaxM3SparseAttention
+
     sparse_module = next(
         (
             module
@@ -25,10 +41,6 @@ def minimax_m3_msa_warmup(worker: "Worker") -> None:
         None,
     )
     if sparse_module is None:
-        return
-    if not (
-        current_platform.is_cuda() and current_platform.is_device_capability_family(100)
-    ):
         return
 
     logger.info("Warming up MiniMax M3 MSA kernels.")


### PR DESCRIPTION
## Purpose

Fixes #49920.

`kernel_warmup()` runs for every model, but
`minimax_m3_msa_warmup.py` previously imported the MiniMax M3 NVIDIA model at
module load time. That import reaches MiniMax-specific Triton kernels before
the warmup can check either the loaded architecture or GPU capability. As
reported in #49920, an import failure in that chain can abort engine startup
for an unrelated model such as DiffusionGemma.

This change checks that the resolved architecture is a MiniMax M3 architecture
and the worker is running on CUDA SM100 before importing MiniMax M3 model code.
The supported MiniMax M3 path keeps its existing module scan and dummy run.
Exceptions from a real MiniMax warmup are not suppressed.

### Duplicate-work check

There is no open PR referencing #49920 or matching the DiffusionGemma warmup
import failure. #48807 is related to general warmup error handling, but it
wraps the call to `minimax_m3_msa_warmup()`; the failure here occurs while
importing that function, before its proposed `try` block. It does not change
this module or test the import boundary, so this PR is not duplicating it.

### AI assistance

This PR was prepared with OpenAI Codex assistance. I reviewed every changed
line and remain responsible for the implementation and validation. The commit
includes both `Co-authored-by` attribution and my DCO `Signed-off-by` trailer.

## Test Plan

- Verify that importing the warmup module does not import the MiniMax model.
- Verify that non-MiniMax architectures and non-SM100 GPUs skip the warmup
  before model access.
- Verify that MiniMax M3 on SM100 still executes the existing dummy run.
- Run the neighboring model-executor warmup tests.
- Run pre-commit and CI mypy hooks.

Commands:

```bash
.venv/bin/python -m pytest \
  tests/model_executor/test_minimax_m3_msa_warmup.py \
  tests/model_executor/test_jit_warmup.py -v

.venv/bin/pre-commit run --files \
  vllm/model_executor/warmup/minimax_m3_msa_warmup.py \
  tests/model_executor/test_minimax_m3_msa_warmup.py

SKIP=shellcheck,test-nonroot-entrypoint \
  .venv/bin/pre-commit run --all-files

.venv/bin/pre-commit run mypy-3.11 --all-files --hook-stage manual
.venv/bin/pre-commit run mypy-3.12 --all-files --hook-stage manual
```

## Test Result

- Before the fix, the new test fails during collection because importing the
  warmup module enters the MiniMax model import chain.
- After the fix: `14 passed`.
- Changed-file pre-commit hooks: passed without exclusions.
- Full pre-commit: passed with two host-only hooks skipped:
  - `shellcheck` is not installed on the macOS development host.
  - `test-nonroot-entrypoint` compares the equivalent macOS paths `/var/...`
    and `/private/var/...` as different strings.
- Full mypy for Python 3.10, 3.11, and 3.12: passed.

Model evaluation was not run because this change does not modify model
execution, outputs, or accuracy. An end-to-end CUDA SM100 run is not available
on the macOS development host; the regression tests cover the import boundary,
both eligibility gates, and the supported warmup path.
