### PR TITLE
Fix MTP position-zero embeddings

### DIFF
--- a/tests/kernels/core/test_fused_q_kv_rmsnorm.py
+++ b/tests/kernels/core/test_fused_q_kv_rmsnorm.py
@@ -14,6 +14,7 @@ import pytest
 import torch
 
 from vllm.models.common.ops import fused_q_kv_rmsnorm
+from vllm.models.deepseek_v4.common.ops import fused_mtp_input_rmsnorm
 from vllm.platforms import current_platform
 
 pytestmark = pytest.mark.skipif(
@@ -27,6 +28,39 @@ def _ref_rmsnorm(x: torch.Tensor, w: torch.Tensor, eps: float) -> torch.Tensor:
     variance = x_f32.pow(2).mean(dim=-1, keepdim=True)
     y = x_f32 * torch.rsqrt(variance + eps) * w.to(torch.float32)
     return y.to(x.dtype)
+
+
+def test_fused_mtp_input_rmsnorm_preserves_all_input_rows():
+    torch.manual_seed(0)
+    device = "cuda"
+    dtype = torch.bfloat16
+    num_tokens, hidden_size, hc_mult = 3, 128, 2
+    inputs_embeds = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
+    previous_hidden_states = torch.randn(
+        num_tokens, hc_mult, hidden_size, dtype=dtype, device=device
+    )
+    enorm_weight = torch.randn(hidden_size, dtype=dtype, device=device)
+    hnorm_weight = torch.randn(hidden_size, dtype=dtype, device=device)
+    eps = 1e-6
+
+    enorm_out, hnorm_out = fused_mtp_input_rmsnorm(
+        inputs_embeds,
+        previous_hidden_states,
+        enorm_weight,
+        hnorm_weight,
+        eps,
+        hc_mult,
+    )
+
+    torch.testing.assert_close(
+        enorm_out, _ref_rmsnorm(inputs_embeds, enorm_weight, eps), rtol=1e-2, atol=1e-2
+    )
+    torch.testing.assert_close(
+        hnorm_out,
+        _ref_rmsnorm(previous_hidden_states, hnorm_weight, eps),
+        rtol=1e-2,
+        atol=1e-2,
+    )
 
 
 @pytest.mark.parametrize("num_tokens", [1, 17, 1024, 8192])

--- a/tests/v1/spec_decode/test_mtp.py
+++ b/tests/v1/spec_decode/test_mtp.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 import pytest
 import torch
+from torch import nn
 
 from tests.v1.attention.utils import (
     BatchSpec,
@@ -22,6 +23,9 @@ from vllm.config import (
     VllmConfig,
 )
 from vllm.config.load import LoadConfig
+from vllm.model_executor.models.deepseek_mtp import (
+    DeepSeekMultiTokenPredictorLayer,
+)
 from vllm.model_executor.models.llama import LlamaForCausalLM
 from vllm.platforms import current_platform
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
@@ -113,6 +117,84 @@ def test_mtp_load_model_unified(mock_get_model, mock_get_layers, mock_get_pp_gro
     assert proposer.model.lm_head == target_model.lm_head
     # MTP shares embed_tokens with target model
     assert proposer.model.model.embed_tokens == target_model.model.embed_tokens
+
+
+def test_mtp_first_pass_shifts_tokens_without_shifting_positions():
+    device = torch.device(DEVICE_TYPE)
+    proposer = _create_mtp_proposer(num_speculative_tokens=1)
+    batch_spec = BatchSpec(seq_lens=[3, 2], query_lens=[3, 2])
+    common_attn_metadata = create_common_attn_metadata(
+        batch_spec, block_size=16, device=device
+    )
+    target_token_ids = torch.tensor([10, 11, 12, 20, 21], device=device)
+    target_positions = torch.tensor([0, 1, 2, 0, 1], device=device)
+    target_hidden_states = torch.zeros(
+        (5, proposer.hidden_size), dtype=proposer.dtype, device=device
+    )
+    next_token_ids = torch.tensor([13, 22], dtype=torch.int32, device=device)
+
+    num_tokens, _, _ = proposer.set_inputs_first_pass(
+        target_token_ids=target_token_ids,
+        next_token_ids=next_token_ids,
+        target_positions=target_positions,
+        target_hidden_states=target_hidden_states,
+        token_indices_to_sample=None,
+        cad=common_attn_metadata,
+        num_rejected_tokens_gpu=None,
+    )
+
+    assert num_tokens == 5
+    torch.testing.assert_close(
+        proposer.input_ids[:num_tokens],
+        torch.tensor([11, 12, 13, 21, 22], dtype=torch.int32, device=device),
+    )
+    torch.testing.assert_close(proposer.positions[:num_tokens], target_positions)
+
+
+def test_mtp_layer_preserves_position_zero_embedding():
+    class CaptureProjection(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.inputs: torch.Tensor | None = None
+
+        def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+            self.inputs = inputs
+            return inputs
+
+    class IdentityMTPBlock(nn.Module):
+        use_sequence_parallel_moe = False
+
+        def forward(
+            self,
+            *,
+            positions: torch.Tensor,
+            hidden_states: torch.Tensor,
+            residual: torch.Tensor | None,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            return hidden_states, torch.zeros_like(hidden_states)
+
+    layer = DeepSeekMultiTokenPredictorLayer.__new__(DeepSeekMultiTokenPredictorLayer)
+    nn.Module.__init__(layer)
+    projection = CaptureProjection()
+    layer.enorm = nn.Identity()
+    layer.hnorm = nn.Identity()
+    layer.eh_proj = projection
+    layer.mtp_block = IdentityMTPBlock()
+    layer.shared_head = nn.Identity()
+
+    inputs_embeds = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    positions = torch.tensor([0, 1])
+    previous_hidden_states = torch.zeros_like(inputs_embeds)
+
+    layer(
+        input_ids=torch.tensor([1, 2]),
+        positions=positions,
+        previous_hidden_states=previous_hidden_states,
+        inputs_embeds=inputs_embeds,
+    )
+
+    assert projection.inputs is not None
+    torch.testing.assert_close(projection.inputs[:, :2], inputs_embeds)
 
 
 @pytest.mark.parametrize("num_speculative_tokens", [1])

--- a/vllm/model_executor/models/bailing_moe_mtp.py
+++ b/vllm/model_executor/models/bailing_moe_mtp.py
@@ -111,7 +111,6 @@ class BailingMoeV25MultiTokenPredictorLayer(nn.Module):
         spec_step_index: int = 0,
     ) -> torch.Tensor:
         assert inputs_embeds is not None
-        inputs_embeds = torch.where(positions.unsqueeze(-1) == 0, 0, inputs_embeds)
         inputs_embeds = self.enorm(inputs_embeds)
         previous_hidden_states = self.hnorm(previous_hidden_states)
 

--- a/vllm/model_executor/models/deepseek_mtp.py
+++ b/vllm/model_executor/models/deepseek_mtp.py
@@ -109,8 +109,6 @@ class DeepSeekMultiTokenPredictorLayer(nn.Module):
         spec_step_index: int = 0,
     ) -> torch.Tensor:
         assert inputs_embeds is not None
-        # masking inputs at position 0, as not needed by MTP
-        inputs_embeds = torch.where(positions.unsqueeze(-1) == 0, 0, inputs_embeds)
         inputs_embeds = self.enorm(inputs_embeds)
         previous_hidden_states = self.hnorm(previous_hidden_states)
 

--- a/vllm/model_executor/models/ernie_mtp.py
+++ b/vllm/model_executor/models/ernie_mtp.py
@@ -65,8 +65,6 @@ class ErnieMultiTokenPredictorLayer(nn.Module):
         spec_step_index: int = 0,
     ) -> torch.Tensor:
         assert inputs_embeds is not None
-        # masking inputs at position 0, as not needed by MTP
-        inputs_embeds[positions == 0] = 0
 
         inputs_embeds = self.mtp_emb_norm(inputs_embeds)
         previous_hidden_states = self.mtp_hidden_norm(previous_hidden_states)

--- a/vllm/model_executor/models/glm4_moe_lite_mtp.py
+++ b/vllm/model_executor/models/glm4_moe_lite_mtp.py
@@ -124,8 +124,6 @@ class Glm4MoeLiteMultiTokenPredictorLayer(nn.Module):
         spec_step_index: int = 0,
     ) -> torch.Tensor:
         assert inputs_embeds is not None
-        # masking inputs at position 0, as not needed by MTP
-        inputs_embeds[positions == 0] = 0
         inputs_embeds = self.enorm(inputs_embeds)
         previous_hidden_states = self.hnorm(previous_hidden_states)
 

--- a/vllm/model_executor/models/glm4_moe_mtp.py
+++ b/vllm/model_executor/models/glm4_moe_mtp.py
@@ -109,8 +109,6 @@ class Glm4MoeMultiTokenPredictorLayer(nn.Module):
         spec_step_index: int = 0,
     ) -> torch.Tensor:
         assert inputs_embeds is not None
-        # masking inputs at position 0, as not needed by MTP
-        inputs_embeds = torch.where(positions.unsqueeze(-1) == 0, 0, inputs_embeds)
         inputs_embeds = self.enorm(inputs_embeds)
         previous_hidden_states = self.hnorm(previous_hidden_states)
 

--- a/vllm/model_executor/models/glm_ocr_mtp.py
+++ b/vllm/model_executor/models/glm_ocr_mtp.py
@@ -83,8 +83,6 @@ class GlmOcrMultiTokenPredictorLayer(nn.Module):
         spec_step_index: int = 0,
     ) -> torch.Tensor:
         assert inputs_embeds is not None
-        # masking inputs at position 0, as not needed by MTP
-        inputs_embeds[positions[0] == 0] = 0
 
         inputs_embeds = self.enorm(inputs_embeds)
         previous_hidden_states = self.hnorm(previous_hidden_states)

--- a/vllm/model_executor/models/hy_v3_mtp.py
+++ b/vllm/model_executor/models/hy_v3_mtp.py
@@ -124,8 +124,6 @@ class HYV3MultiTokenPredictorLayer(nn.Module):
         spec_step_index: int = 0,
     ) -> torch.Tensor:
         assert inputs_embeds is not None
-        # masking inputs at position 0, as not needed by MTP
-        inputs_embeds[positions == 0] = 0
         inputs_embeds = self.enorm(inputs_embeds)
         previous_hidden_states = self.hnorm(previous_hidden_states)
 

--- a/vllm/model_executor/models/mimo_mtp.py
+++ b/vllm/model_executor/models/mimo_mtp.py
@@ -72,8 +72,6 @@ class MiMoMultiTokenPredictorLayer(nn.Module):
         spec_step_index: int = 0,
     ) -> torch.Tensor:
         assert inputs_embeds is not None
-        # masking inputs at position 0, as not needed by MTP
-        inputs_embeds[positions == 0] = 0
         inputs_embeds = self.token_layernorm(inputs_embeds)
         previous_hidden_states = self.hidden_layernorm(previous_hidden_states)
 

--- a/vllm/models/deepseek_v4/amd/mtp.py
+++ b/vllm/models/deepseek_v4/amd/mtp.py
@@ -142,10 +142,9 @@ class DeepSeekV4MultiTokenPredictorLayer(nn.Module):
         previous_hidden_states = previous_hidden_states.view(
             -1, self.hc_mult, self.config.hidden_size
         )
-        # Fused: mask inputs at position 0 (not needed by MTP), enorm, hnorm.
+        # Fused enorm and hnorm.
         inputs_embeds, previous_hidden_states = fused_mtp_input_rmsnorm(
             inputs_embeds,
-            positions,
             previous_hidden_states,
             self.enorm.weight.data,
             self.hnorm.weight.data,

--- a/vllm/models/deepseek_v4/common/ops/fused_mtp_input_rmsnorm.py
+++ b/vllm/models/deepseek_v4/common/ops/fused_mtp_input_rmsnorm.py
@@ -1,17 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Fused MTP-input RMSNorm: enorm (with mask-zero at position 0) + hnorm.
+"""Fused MTP-input RMSNorm: enorm + hnorm.
 
 Replaces the eager sequence at the top of the MTP draft forward:
-    inputs_embeds = torch.where(positions.unsqueeze(-1) == 0, 0, inputs_embeds)
     inputs_embeds = self.enorm(inputs_embeds)
     previous_hidden_states = previous_hidden_states.view(-1, hc_mult, H)
     previous_hidden_states = self.hnorm(previous_hidden_states)
-
-which lowers to ~6 small kernels (CompareEq, where, Fill, enorm rms_norm,
-hnorm rms_norm, plus aten elementwise helpers) on the breakable-cudagraph
-path. Math is preserved: positions==0 → masked row → zero RMS output
-regardless of weight.
 
 A single grid (T, hc_mult+1) drives both norms: task 0 is enorm on
 inputs_embeds[token, :], task k+1 is hnorm on previous_hidden_states[token, k, :].
@@ -43,7 +37,6 @@ def _rmsnorm_row(
 @triton.jit
 def _fused_mtp_input_rmsnorm_kernel(
     inputs_embeds_ptr,
-    positions_ptr,
     prev_hidden_ptr,
     enorm_weight_ptr,
     hnorm_weight_ptr,
@@ -63,15 +56,10 @@ def _fused_mtp_input_rmsnorm_kernel(
     mask = block < HIDDEN
 
     if pid_task == 0:
-        # enorm path: load inputs_embeds[token, :] then zero-mask at pos==0.
-        # Math is preserved: pos==0 → x=0 → variance=0 → RMSNorm output is 0
-        # regardless of weight, matching torch.where(pos==0, 0, x) + RMSNorm.
-        pos = tl.load(positions_ptr + token_idx)
-        keep = pos != 0
+        # enorm path: load inputs_embeds[token, :].
         x = tl.load(
             inputs_embeds_ptr + token_idx * HIDDEN + block, mask=mask, other=0.0
         )
-        x = tl.where(keep, x, 0.0)
         _rmsnorm_row(
             x,
             enorm_weight_ptr,
@@ -152,7 +140,6 @@ def mtp_shared_head_rmsnorm(
 
 def fused_mtp_input_rmsnorm(
     inputs_embeds: torch.Tensor,
-    positions: torch.Tensor,
     previous_hidden_states: torch.Tensor,
     enorm_weight: torch.Tensor,
     hnorm_weight: torch.Tensor,
@@ -189,7 +176,6 @@ def fused_mtp_input_rmsnorm(
     block_size = triton.next_power_of_2(hidden)
     _fused_mtp_input_rmsnorm_kernel[(num_tokens, hc_mult + 1)](
         inputs_embeds,
-        positions,
         previous_hidden_states,
         enorm_weight,
         hnorm_weight,

--- a/vllm/models/deepseek_v4/nvidia/mtp.py
+++ b/vllm/models/deepseek_v4/nvidia/mtp.py
@@ -148,10 +148,9 @@ class DeepSeekV4MultiTokenPredictorLayer(nn.Module):
         previous_hidden_states = previous_hidden_states.view(
             -1, self.hc_mult, self.config.hidden_size
         )
-        # Fused: mask inputs at position 0 (not needed by MTP), enorm, hnorm.
+        # Fused enorm and hnorm.
         inputs_embeds, previous_hidden_states = fused_mtp_input_rmsnorm(
             inputs_embeds,
-            positions,
             previous_hidden_states,
             self.enorm.weight.data,
             self.hnorm.weight.data,

--- a/vllm/models/deepseek_v4/xpu/mtp.py
+++ b/vllm/models/deepseek_v4/xpu/mtp.py
@@ -145,10 +145,9 @@ class DeepSeekV4MultiTokenPredictorLayer(nn.Module):
         previous_hidden_states = previous_hidden_states.view(
             -1, self.hc_mult, self.config.hidden_size
         )
-        # Fused: mask inputs at position 0 (not needed by MTP), enorm, hnorm.
+        # Fused enorm and hnorm.
         inputs_embeds, previous_hidden_states = fused_mtp_input_rmsnorm(
             inputs_embeds,
-            positions,
             previous_hidden_states,
             self.enorm.weight.data,
             self.hnorm.weight.data,

--- a/vllm/models/minimax_m3/amd/mtp.py
+++ b/vllm/models/minimax_m3/amd/mtp.py
@@ -92,8 +92,6 @@ class MiniMaxM3MultiTokenPredictorLayer(nn.Module):
         spec_step_index: int = 0,
     ) -> torch.Tensor:
         assert inputs_embeds is not None
-        # Mask out inputs at position 0, as not needed by MTP.
-        inputs_embeds = torch.where(positions.unsqueeze(-1) == 0, 0, inputs_embeds)
 
         # Combine the normalized token embeddings with the normalized
         # previous hidden states.

--- a/vllm/models/minimax_m3/nvidia/mtp.py
+++ b/vllm/models/minimax_m3/nvidia/mtp.py
@@ -74,8 +74,6 @@ class MiniMaxM3MultiTokenPredictorLayer(nn.Module):
         spec_step_index: int = 0,
     ) -> torch.Tensor:
         assert inputs_embeds is not None
-        # Mask out inputs at position 0, as not needed by MTP.
-        inputs_embeds = torch.where(positions.unsqueeze(-1) == 0, 0, inputs_embeds)
 
         # Combine the normalized token embeddings with the normalized
         # previous hidden states.


### PR DESCRIPTION
## Summary

Fixes #33299.

MTP first-pass inputs are shifted before the draft forward, so position 0 contains a valid token embedding. Remove the position-0 embedding mask from affected MTP implementations, including the DeepSeek V4 fused input RMSNorm path.

Add regression coverage for the shifted first-pass input contract, an eager MTP layer that preserves the position-0 embedding, and the fused RMSNorm output.

## Duplicate-work check

No open PR references #33299 or implements this fix. #32592 proposed a partial earlier removal but was closed without merging; this change also covers MTP implementations added after it.

## Validation

- `tests/v1/spec_decode/test_mtp.py tests/kernels/core/test_fused_q_kv_rmsnorm.py`: 16 passed
- New eager layer, proposer-contract, and fused-kernel regressions: 3 passed
- `tests/v1/e2e/spec_decode/test_mtp_parallel_load.py::test_deepseek_mtp_load_dp[dp1]`: passed with the repository-default `gpu_memory_utilization=0.85`
- MTP speculative/no-spec greedy A/B: token match ratio `1.000`
- `pre-commit run`, `ruff check`, `ruff format --check`, and `git diff --check`: passed

The multi-GPU TP/EP/PP variants were not run; this validation used single-GPU `dp1`.

## AI assistance

This PR was developed with AI assistance. I reviewed the complete diff, ran the listed validations, and am responsible for the change.