### PR TITLE
[Bugfix] Forward SwiGLU alpha/beta to the Marlin NVFP4 MoE quant config

### DIFF
--- a/tests/kernels/moe/test_marlin_nvfp4_moe.py
+++ b/tests/kernels/moe/test_marlin_nvfp4_moe.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Marlin NVFP4 MoE (w4a16) coverage.
+
+This is the kernel path `modelopt` NVFP4 MoE checkpoints serve through on
+GPUs without native FP4 (e.g. SM120 workstation Blackwell); it previously had
+no unit coverage (`test_nvfp4_moe.py` covers the CUTLASS experts only), which
+let a wrong-activation config-plumbing bug ship undetected for SwiGLU-OAI
+models such as MiniMax-M3.
+"""
+
+import pytest
+import torch
+
+from tests.kernels.utils import torch_moe
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.model_executor.layers.fused_moe.experts.marlin_moe import fused_marlin_moe
+from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
+    NvFp4MoeBackend,
+    make_nvfp4_moe_quant_config,
+)
+from vllm.model_executor.layers.quantization.utils.marlin_utils_fp4 import (
+    rand_marlin_weight_nvfp4_like,
+)
+from vllm.platforms import current_platform
+from vllm.scalar_type import scalar_types
+
+NVFP4_GROUP_SIZE = 16
+
+
+def test_marlin_quant_config_forwards_swiglu_params():
+    """The MARLIN branch must forward alpha/beta/clamp — MarlinExperts
+    silently defaults to alpha=1.0 / beta=0.0 otherwise, which runs the
+    wrong activation in every expert of SwiGLU-OAI models."""
+    e, n_groups = 4, 8
+    cfg = make_nvfp4_moe_quant_config(
+        backend=NvFp4MoeBackend.MARLIN,
+        w13_scale=torch.empty(e, 16, n_groups),
+        w2_scale=torch.empty(e, 16, n_groups),
+        w13_scale_2=torch.empty(e),
+        w2_scale_2=torch.empty(e),
+        a13_scale=torch.empty(e),
+        a2_scale=torch.empty(e),
+        swiglu_limit=7.0,
+        swiglu_alpha=1.702,
+        swiglu_beta=1.0,
+    )
+    assert cfg.gemm1_clamp_limit == 7.0
+    assert cfg.gemm1_alpha == 1.702
+    assert cfg.gemm1_beta == 1.0
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="requires CUDA")
+@pytest.mark.parametrize("m", [17, 257])
+@pytest.mark.parametrize("n,k", [(256, 512), (512, 1024)])
+@pytest.mark.parametrize("e,topk", [(8, 2), (1, 1)])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.half])
+@torch.inference_mode()
+def test_marlin_nvfp4_moe(m, n, k, e, topk, dtype):
+    torch.manual_seed(7)
+    a = torch.randn((m, k), device="cuda", dtype=dtype) / 10
+    w13 = torch.randn((e, 2 * n, k), device="cuda", dtype=dtype) / 10
+    w2 = torch.randn((e, k, n), device="cuda", dtype=dtype) / 10
+    score = torch.randn((m, e), device="cuda", dtype=dtype)
+
+    w13_ref, w13_q, w13_s, w13_gs = [], [], [], []
+    w2_ref, w2_q, w2_s, w2_gs = [], [], [], []
+    for i in range(e):
+        ref, q, s, gs = rand_marlin_weight_nvfp4_like(w13[i], NVFP4_GROUP_SIZE)
+        w13_ref.append(ref.T)
+        w13_q.append(q)
+        w13_s.append(s)
+        w13_gs.append(gs)
+        ref, q, s, gs = rand_marlin_weight_nvfp4_like(w2[i], NVFP4_GROUP_SIZE)
+        w2_ref.append(ref.T)
+        w2_q.append(q)
+        w2_s.append(s)
+        w2_gs.append(gs)
+
+    w13_ref = torch.stack(w13_ref)
+    w2_ref = torch.stack(w2_ref)
+    w13_q = torch.stack(w13_q)
+    w2_q = torch.stack(w2_q)
+    w13_s = torch.stack(w13_s)
+    w2_s = torch.stack(w2_s)
+    w13_gs = torch.stack(w13_gs).view(e)
+    w2_gs = torch.stack(w2_gs).view(e)
+
+    with set_current_vllm_config(VllmConfig()):
+        torch_output = torch_moe(a, w13_ref, w2_ref, score, topk)
+
+        # Match torch_moe exactly: softmax over all experts, topk, no renorm.
+        score_soft = torch.softmax(score.float(), dim=-1)
+        topk_weights, topk_ids = torch.topk(score_soft, topk)
+        topk_ids = topk_ids.to(torch.int32)
+
+        marlin_output = fused_marlin_moe(
+            hidden_states=a,
+            w1=w13_q,
+            w2=w2_q,
+            bias1=None,
+            bias2=None,
+            w1_scale=w13_s,
+            w2_scale=w2_s,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            quant_type_id=scalar_types.float4_e2m1f.id,
+            global_num_experts=e,
+            expert_map=None,
+            global_scale1=w13_gs,
+            global_scale2=w2_gs,
+            g_idx1=None,
+            g_idx2=None,
+            input_global_scale1=None,
+            input_global_scale2=None,
+            sort_indices1=None,
+            sort_indices2=None,
+            w1_zeros=None,
+            w2_zeros=None,
+            input_dtype=dtype,
+            is_k_full=True,
+        )
+
+    rel = (marlin_output - torch_output).abs().sum() / torch_output.abs().sum()
+    assert rel.item() < 0.05, f"relative error {rel.item():.5f}"

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -861,6 +861,8 @@ def nvfp4_w4a16_moe_quant_config(
     g2_alphas: torch.Tensor,
     w1_scale: torch.Tensor,
     w2_scale: torch.Tensor,
+    gemm1_alpha: float | None = None,
+    gemm1_beta: float | None = None,
     gemm1_clamp_limit: float | None = None,
 ) -> FusedMoEQuantConfig:
     """
@@ -873,6 +875,8 @@ def nvfp4_w4a16_moe_quant_config(
         g1_alphas=g1_alphas,
         g2_alphas=g2_alphas,
         weight_dtype="nvfp4",
+        gemm1_alpha=gemm1_alpha,
+        gemm1_beta=gemm1_beta,
         gemm1_clamp_limit=gemm1_clamp_limit,
     )
 

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -468,6 +468,8 @@ def make_nvfp4_moe_quant_config(
     a13_scale: torch.Tensor,
     a2_scale: torch.Tensor,
     swiglu_limit: float | None = None,
+    swiglu_alpha: float | None = None,
+    swiglu_beta: float | None = None,
     layer: torch.nn.Module | None = None,
 ) -> FusedMoEQuantConfig:
     if backend == NvFp4MoeBackend.HUMMING:
@@ -479,11 +481,18 @@ def make_nvfp4_moe_quant_config(
         assert isinstance(layer, RoutedExperts)
         return get_humming_moe_quant_config(layer)
     elif backend == NvFp4MoeBackend.MARLIN:
+        # Forward the full gated-activation parameterization, not only the
+        # clamp: SwiGLU-OAI models (e.g. MiniMax-M3) need alpha/beta too.
+        # MarlinExperts silently falls back to alpha=1.0 / beta=0.0 when the
+        # quant config omits them, running the wrong activation in every
+        # expert (see the linked issue for the end-to-end effect).
         return nvfp4_w4a16_moe_quant_config(
             g1_alphas=w13_scale_2,
             g2_alphas=w2_scale_2,
             w1_scale=w13_scale,
             w2_scale=w2_scale,
+            gemm1_alpha=swiglu_alpha,
+            gemm1_beta=swiglu_beta,
             gemm1_clamp_limit=swiglu_limit,
         )
     elif backend == NvFp4MoeBackend.EMULATION:

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -1624,6 +1624,8 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
             a13_scale=layer.w13_input_scale,
             a2_scale=layer.w2_input_scale,
             swiglu_limit=getattr(layer, "swiglu_limit", None),
+            swiglu_alpha=getattr(layer, "swiglu_alpha", None),
+            swiglu_beta=getattr(layer, "swiglu_beta", None),
             layer=layer,
         )
 


### PR DESCRIPTION
FIX #34694 (for ModelOpt NVFP4 MoE / Marlin-fallback configurations of SwiGLU-OAI models)

## Purpose

`nvidia/MiniMax-M3-NVFP4` (and by construction any SwiGLU-OAI MoE model served via ModelOpt NVFP4 on the Marlin fallback, i.e. GPUs without native FP4) produces prompt-unrelated token noise. The root cause is not the Marlin kernel: the modelopt → `NvFp4MoeBackend.MARLIN` quant-config bridge forwards only `gemm1_clamp_limit` and drops `swiglu_alpha` / `swiglu_beta`, and `MarlinExperts` silently defaults them to `alpha=1.0` / `beta=0.0` — the wrong activation in every expert of every MoE layer, compounding across depth into noise.

All three values are present on the layer (`RoutedExperts` stores `swiglu_alpha/beta/limit`), and the neighboring MXFP8 site in `modelopt.py` already forwards them with the identical `getattr` pattern; the NVFP4 site never did. The fix threads them through the three-hop chain (`modelopt.py` → `make_nvfp4_moe_quant_config` → `nvfp4_w4a16_moe_quant_config`).

This also reattributes part of #34694 for MoE checkpoints: we initially reproduced that issue's symptom with this model and (like #47315) suspected the Marlin FP4 BF16 scale dequant. Direct kernel unit testing (below) shows the Marlin NVFP4 MoE kernel + scale-prep pair is numerically correct as-is (bf16 ≈0.8% rel err, fp16 ≈0.08% vs torch reference); only the activation parameterization was wrong. Detailed investigation notes in https://github.com/vllm-project/vllm/pull/47315#issuecomment-5086481909 and follow-ups.

## Changes

- `nvfp4_w4a16_moe_quant_config`: accept and forward `gemm1_alpha` / `gemm1_beta`.
- `make_nvfp4_moe_quant_config`: accept `swiglu_alpha` / `swiglu_beta`, forward on the MARLIN branch.
- `modelopt.py` (`ModelOptNvFp4FusedMoE.get_fused_moe_quant_config`): pass `getattr(layer, "swiglu_alpha"/"swiglu_beta", None)`, mirroring the MXFP8 site.
- New `tests/kernels/moe/test_marlin_nvfp4_moe.py`:
  - a config-plumbing test that pins this regression (fails on the old code with a `TypeError` / missing params);
  - Marlin NVFP4 MoE kernel-vs-torch-reference coverage (bf16 + fp16, multiple shapes, incl. single-expert) — this path had no unit coverage at all (`test_nvfp4_moe.py` covers the CUTLASS experts only), which is how the bug shipped silently.

Note: the sibling FP8 MoE call site in `modelopt.py` (`make_fp8_moe_quant_config`) has the same omission and likely wants the same one-line treatment; left out here because it was not exercised by the model we validated with.

## Test Plan

- New tests: 17/17 pass on 4× RTX PRO 6000 Blackwell (SM120), CUDA 13.0, torch 2.11.0+cu130. The kernel-correctness cases pass identically with and without the fix (the kernel was never the problem).
- End-to-end serving A/B on `nvidia/MiniMax-M3-NVFP4` (TP=4, `quantization=modelopt_mixed`, `Using 'MARLIN' NvFp4 MoE backend`), only variable = this patch:

Before — output has no relationship to the prompt:
```
prompt: "What is 17 * 23? Reply with just the number."
output: '</\n\n</\n\n | &](\n\nX\n\n\n\n德里\n\nBid</\n\n</.\n\n\n\n",</</ …'
```
After — correct, with clean reasoning, including 2K/4.5K-token needle retrieval:
```
[math  ] '391'
[prose ] "The sky appears blue because Earth's atmosphere scatters shorter-wavelength blue light …"
[needle] 'BLUEBERRY'
```

(Separately from this fix, we observe an illegal-memory-access crash under highly concurrent load on this SM120 setup; single-stream and moderate-concurrency serving is coherent. That appears to be an orthogonal platform issue and is not addressed here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
