### PR TITLE
[XPU] [SP] Support mxfp4 Sequence Parallelism on XPU

### DIFF
--- a/.buildkite/intel_jobs/test-intel.yaml
+++ b/.buildkite/intel_jobs/test-intel.yaml
@@ -225,3 +225,28 @@ steps:
         python3 examples/basic/offline_inference/generate.py --model INCModel/Qwen3-30B-A3B-Instruct-2507-MXFP4-CT-AutoRound --max-model-len 4096'
       # Temporarily disabled (multi-GPU/MXFP8 not yet supported with XPU Graph):
       # python3 examples/basic/offline_inference/generate.py --model INCModel/Qwen3-30B-A3B-Instruct-2507-MXFP8-CT-AutoRound -tp 2 --max-model-len 4096
+  - label: "XPU compile distributed passes"
+    depends_on:
+      - image-build-xpu
+    timeout_in_minutes: 60
+    device: intel_gpu
+    agent_tags:
+      label: production
+      gpu: 2+
+      mem: 16+
+    no_plugin: true
+    env:
+      REGISTRY: "public.ecr.aws/q9t5s3a7"
+      REPO: "vllm-ci-test-repo"
+      VLLM_TEST_DEVICE: "xpu"
+    source_file_dependencies:
+      - vllm/compilation/
+      - vllm/model_executor/layers/quantization/
+      - tests/compile/passes/distributed/test_sequence_parallelism.py
+      - tests/utils.py
+      - .buildkite/intel_jobs/test-intel.yaml
+    commands:
+      - >-
+        bash .buildkite/scripts/hardware_ci/run-intel-test.sh
+        'cd tests &&
+        pytest -v -s compile/passes/distributed/test_sequence_parallelism.py::test_sequence_parallelism_pass_xpu_mxfp4'

--- a/.buildkite/intel_jobs/test-intel.yaml
+++ b/.buildkite/intel_jobs/test-intel.yaml
@@ -204,3 +204,28 @@ steps:
         python3 examples/basic/offline_inference/generate.py --model INCModel/Qwen3-30B-A3B-Instruct-2507-MXFP4-CT-AutoRound --max-model-len 4096'
       # Temporarily disabled (multi-GPU/MXFP8 not yet supported with XPU Graph):
       # python3 examples/basic/offline_inference/generate.py --model INCModel/Qwen3-30B-A3B-Instruct-2507-MXFP8-CT-AutoRound -tp 2 --max-model-len 4096
+  - label: "XPU compile distributed passes"
+    depends_on:
+      - image-build-xpu
+    timeout_in_minutes: 60
+    device: intel_gpu
+    agent_tags:
+      label: production
+      gpu: 2+
+      mem: 16+
+    no_plugin: true
+    env:
+      REGISTRY: "public.ecr.aws/q9t5s3a7"
+      REPO: "vllm-ci-test-repo"
+      VLLM_TEST_DEVICE: "xpu"
+    source_file_dependencies:
+      - vllm/compilation/
+      - vllm/model_executor/layers/quantization/
+      - tests/compile/passes/distributed/test_sequence_parallelism.py
+      - tests/utils.py
+      - .buildkite/intel_jobs/test-intel.yaml
+    commands:
+      - >-
+        bash .buildkite/scripts/hardware_ci/run-intel-test.sh
+        'cd tests &&
+        pytest -v -s compile/passes/distributed/test_sequence_parallelism.py::test_sequence_parallelism_pass_xpu_mxfp4'

--- a/.buildkite/intel_jobs/test-intel.yaml
+++ b/.buildkite/intel_jobs/test-intel.yaml
@@ -228,4 +228,5 @@ steps:
       - >-
         bash .buildkite/scripts/hardware_ci/run-intel-test.sh
         'cd tests &&
-        pytest -v -s compile/passes/distributed/test_sequence_parallelism.py::test_sequence_parallelism_pass_xpu_mxfp4'
+        pytest -v -s compile/passes/distributed/test_sequence_parallelism.py::test_sequence_parallelism_pass_xpu_mxfp4 &&
+        pytest -v -s compile/correctness_e2e/test_sequence_parallel.py::test_tp_sp_mxfp4_generation'

--- a/tests/compile/correctness_e2e/test_sequence_parallel.py
+++ b/tests/compile/correctness_e2e/test_sequence_parallel.py
@@ -29,6 +29,8 @@ logger = init_logger("test_sequence_parallel")
 VLLM_MULTI_NODE = os.getenv("VLLM_MULTI_NODE", "0") == "1"
 NVFP4_MODEL_ID = "nvidia/Llama-3.1-8B-Instruct-NVFP4"
 NVFP4_MODEL_INFO = _HfExamplesInfo(NVFP4_MODEL_ID)
+MXFP4_MODEL_ID = "INCModel/Qwen3-32B-MXFP4-CT-AutoRound"
+MXFP4_MODEL_INFO = _HfExamplesInfo(MXFP4_MODEL_ID)
 
 
 class ParallelSetup(NamedTuple):
@@ -255,6 +257,7 @@ def _compare_sp_settings(
     settings: list[tuple[list[str], list[str]]],
     *,
     method: Literal["generate", "encode"],
+    max_wait_seconds: float | None = None,
 ) -> None:
     if not settings:
         pytest.skip("No supported sequence-parallel configurations")
@@ -271,6 +274,7 @@ def _compare_sp_settings(
             [None] * len(all_args),
             method=method,
             force_v1_runner=True,
+            max_wait_seconds=max_wait_seconds,
         )
 
 
@@ -407,4 +411,38 @@ def test_tp_sp_nvfp4_generation(num_gpus_available: int):
         NVFP4_MODEL_ID,
         [] if comparison is None else [comparison],
         method="generate",
+    )
+
+
+@create_new_process_for_each_test()
+def test_tp_sp_mxfp4_generation(num_gpus_available: int):
+    if not current_platform.is_xpu():
+        pytest.skip("MXFP4 SP is only supported on XPU")
+
+    comparison = _build_sp_args(
+        MXFP4_MODEL_ID,
+        ParallelSetup(
+            tp_size=2,
+            pp_size=1,
+            fuse_norm_quant=False,
+            fuse_act_quant=False,
+            eager_mode=False,
+        ),
+        "mp",
+        "auto",
+        SPTestOptions(
+            multi_node_only=False,
+            model_info=MXFP4_MODEL_INFO,
+        ),
+        num_gpus_available,
+        use_inductor_graph_partition=True,
+        fuse_gemm_comms=False,
+        enable_prompt_embeds=False,
+        is_multimodal=False,
+    )
+    _compare_sp_settings(
+        MXFP4_MODEL_ID,
+        [] if comparison is None else [comparison],
+        method="generate",
+        max_wait_seconds=960,
     )

--- a/tests/compile/passes/distributed/test_sequence_parallelism.py
+++ b/tests/compile/passes/distributed/test_sequence_parallelism.py
@@ -6,7 +6,7 @@ import torch
 
 import vllm.envs as envs
 from tests.compile.backend import TestBackend
-from tests.utils import TestFP8Layer, multi_gpu_test
+from tests.utils import TestFP8Layer, TestMXFP4Layer, multi_gpu_test
 from vllm.compilation.passes.fusion.rms_quant_fusion import RMSNormQuantFusionPass
 from vllm.compilation.passes.fusion.sequence_parallelism import SequenceParallelismPass
 from vllm.compilation.passes.utility.noop_elimination import NoOpEliminationPass
@@ -38,7 +38,10 @@ from vllm.utils.torch_utils import set_random_seed
 
 DEVICE_TYPE = current_platform.device_type
 
-pytestmark = pytest.mark.skipif(not current_platform.is_cuda(), reason="Only test CUDA")
+pytestmark = pytest.mark.skipif(
+    not (current_platform.is_cuda() or current_platform.is_xpu()),
+    reason="Only test on CUDA or XPU",
+)
 
 FP8_DTYPE = current_platform.fp8_dtype()
 prompts = [
@@ -80,6 +83,9 @@ class TestAllReduceRMSNormModel(torch.nn.Module):
 
     def ops_in_model_before(self):
         return [torch.ops.vllm.all_reduce.default]
+
+    def ops_count_after(self, op) -> int:
+        return 4
 
     def ops_in_model_after(self):
         return [
@@ -140,6 +146,9 @@ class TestAllReduceRMSNormStaticQuantFP8Model(torch.nn.Module):
             torch.ops.vllm.reduce_scatter.default,
         ]
 
+    def ops_count_after(self, op) -> int:
+        return 4
+
     def ops_in_model_before(self):
         return [
             torch.ops.vllm.all_reduce.default,
@@ -159,6 +168,110 @@ class TestAllReduceRMSNormStaticQuantFP8Model(torch.nn.Module):
                 torch.ops.vllm_ir.fused_add_rms_norm,
                 *quant_ops,
             ]
+
+
+class TestAllReduceRMSNormXPUMxFP4Model(torch.nn.Module):
+    """Model with all_reduce → rms_norm/fused_add_rms_norm → xpu_mxfp4_quantize.
+
+    Tests FirstAllReduceRMSNormXPUMxFP4Pattern (layer 0) and
+    MiddleAllReduceRMSNormXPUMxFP4Pattern (layers 1-3).
+    hidden_size must be divisible by 32 (MXFP4 block size).
+    """
+
+    def __init__(self, hidden_size=32, eps=1e-6):
+        super().__init__()
+        self.vllm_config = get_current_vllm_config()
+        self.hidden_size = hidden_size
+        self.eps = eps
+        self.dtype = torch.bfloat16
+        self.norm = [RMSNorm(hidden_size, eps) for _ in range(4)]
+        self.mxfp4_linear_layers = [
+            TestMXFP4Layer(
+                hidden_size=hidden_size,
+            )
+            for _ in range(4)
+        ]
+
+    def forward(self, hidden_states):
+        z = torch.relu(hidden_states)
+        x = resid = tensor_model_parallel_all_reduce(z)
+        y = self.norm[0](x)
+        # First pattern: rms_norm → xpu_mxfp4_quantize
+        z2 = self.mxfp4_linear_layers[0](y)
+
+        x2 = tensor_model_parallel_all_reduce(z2)
+        y2, resid = self.norm[1](x2, resid)
+        # Middle pattern 1
+        z3 = self.mxfp4_linear_layers[1](y2)
+
+        x3 = tensor_model_parallel_all_reduce(z3)
+        y3, resid = self.norm[2](x3, resid)
+        # Middle pattern 2
+        z4 = self.mxfp4_linear_layers[2](y3)
+
+        x4 = tensor_model_parallel_all_reduce(z4)
+        y4, resid = self.norm[3](x4, resid)
+        # Middle pattern 3: fp4_gemm uses both fp4 and scale; return resid so
+        # residual_out has a consumer → full 3-tuple pattern matches (2 all_gathers)
+        z5 = self.mxfp4_linear_layers[3](y4)
+        return z5, resid
+
+    def ops_in_model_after(self):
+        return [
+            torch.ops.vllm.all_gather.default,
+            torch.ops.vllm.reduce_scatter.default,
+        ]
+
+    def ops_count_after(self, op) -> int:
+        # After SP pass: reduce_scatter × 4, all_gather × 8 (fp4 + scale per layer,
+        # all 4 layers match the full 3-tuple pattern variant)
+        if op == torch.ops.vllm.all_gather.default:
+            return 8
+        return 4
+
+    def ops_in_model_before(self):
+        return [
+            torch.ops.vllm.all_reduce.default,
+        ]
+
+    def ops_in_model(self):
+        return [
+            torch.ops.vllm_ir.rms_norm,
+            torch.ops.vllm_ir.fused_add_rms_norm,
+            torch.ops.vllm.xpu_mxfp4_quantize.default,
+        ]
+
+
+def _run_sequence_parallelism_pass_test(
+    test_model_cls: type[torch.nn.Module],
+    custom_ops: str,
+    batch_size: int,
+    seq_len: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+    fuse_norm_quant: bool,
+    dynamic: bool,
+    model_name: str,
+):
+    # need to use torch.mp.spawn otherwise will have problems with
+    # torch.distributed and cuda
+    num_processes = 2
+    torch.multiprocessing.spawn(
+        sequence_parallelism_pass_on_test_model,
+        args=(
+            num_processes,
+            test_model_cls,
+            custom_ops,
+            batch_size,
+            seq_len,
+            hidden_size,
+            dtype,
+            fuse_norm_quant,
+            dynamic,
+            model_name,
+        ),
+        nprocs=num_processes,
+    )
 
 
 @multi_gpu_test(num_gpus=2)
@@ -190,28 +303,61 @@ def test_sequence_parallelism_pass(
     fuse_norm_quant: bool,
     dynamic: bool,
 ):
-    num_processes = 2
+    _run_sequence_parallelism_pass_test(
+        test_model_cls,
+        custom_ops,
+        batch_size,
+        seq_len,
+        hidden_size,
+        dtype,
+        fuse_norm_quant,
+        dynamic,
+        "RedHatAI/Llama-3.2-1B-Instruct-FP8",
+    )
 
-    def run_torch_spawn(fn, nprocs):
-        # need to use torch.mp.spawn otherwise will have problems with
-        # torch.distributed and cuda
-        torch.multiprocessing.spawn(
-            fn,
-            args=(
-                num_processes,
-                test_model_cls,
-                custom_ops,
-                batch_size,
-                seq_len,
-                hidden_size,
-                dtype,
-                fuse_norm_quant,
-                dynamic,
-            ),
-            nprocs=nprocs,
-        )
 
-    run_torch_spawn(sequence_parallelism_pass_on_test_model, num_processes)
+@multi_gpu_test(num_gpus=2)
+@pytest.mark.parametrize(
+    "test_model_cls, custom_ops",
+    [
+        (
+            TestAllReduceRMSNormXPUMxFP4Model,
+            "+rms_norm",
+        ),
+        (
+            TestAllReduceRMSNormXPUMxFP4Model,
+            "-rms_norm",
+        ),
+    ],
+)
+@pytest.mark.parametrize("batch_size", [8])
+@pytest.mark.parametrize("seq_len", [16])
+@pytest.mark.parametrize("hidden_size", [32])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dynamic", [False, True])
+@pytest.mark.skipif(envs.VLLM_TARGET_DEVICE not in ["xpu"], reason="Only test on XPU")
+def test_sequence_parallelism_pass_xpu_mxfp4(
+    test_model_cls: type[torch.nn.Module],
+    custom_ops: str,
+    batch_size: int,
+    seq_len: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+    dynamic: bool,
+):
+    # MXFP4 has no fused rms_norm+quant kernel yet, so fuse_norm_quant
+    # doesn't change the traced graph; keep it fixed at False.
+    _run_sequence_parallelism_pass_test(
+        test_model_cls,
+        custom_ops,
+        batch_size,
+        seq_len,
+        hidden_size,
+        dtype,
+        False,
+        dynamic,
+        "INCModel/Qwen3-30B-A3B-Instruct-2507-MXFP4-CT-AutoRound",
+    )
 
 
 def test_sequence_parallelism_pass_requires_full_graph_compilation():
@@ -243,6 +389,7 @@ def sequence_parallelism_pass_on_test_model(
     dtype: torch.dtype,
     fuse_norm_quant: bool,
     dynamic: bool,
+    model_name: str,
 ):
     set_random_seed(0)
 
@@ -262,7 +409,7 @@ def sequence_parallelism_pass_on_test_model(
     )
 
     # initialize distributed
-    init_distributed_environment()
+    init_distributed_environment(backend=current_platform.dist_backend)
 
     # configure vllm config for SequenceParallelismPass
     custom_ops_list = custom_ops.split(",") if custom_ops else []
@@ -280,7 +427,6 @@ def sequence_parallelism_pass_on_test_model(
 
     # this is a fake model name to construct the model config
     # in the vllm_config, it's not really used.
-    model_name = "RedHatAI/Llama-3.2-1B-Instruct-FP8"
     model_config = ModelConfig(
         model=model_name, trust_remote_code=True, dtype=dtype, seed=42
     )
@@ -337,7 +483,7 @@ def sequence_parallelism_pass_on_test_model(
         # In post-nodes, reduce scatter and all gather should be there,
         # all reduce should not
         for op in model.ops_in_model_after():
-            assert backend.op_count(op, before=False) == 4
+            assert backend.op_count(op, before=False) == model.ops_count_after(op)
 
         for op in model.ops_in_model():
             assert backend.op_count(op, before=False) > 0

--- a/tests/compile/passes/distributed/test_sequence_parallelism.py
+++ b/tests/compile/passes/distributed/test_sequence_parallelism.py
@@ -171,13 +171,6 @@ class TestAllReduceRMSNormStaticQuantFP8Model(torch.nn.Module):
 
 
 class TestAllReduceRMSNormXPUMxFP4Model(torch.nn.Module):
-    """Model with all_reduce → rms_norm/fused_add_rms_norm → xpu_mxfp4_quantize.
-
-    Tests FirstAllReduceRMSNormXPUMxFP4Pattern (layer 0) and
-    MiddleAllReduceRMSNormXPUMxFP4Pattern (layers 1-3).
-    hidden_size must be divisible by 32 (MXFP4 block size).
-    """
-
     def __init__(self, hidden_size=32, eps=1e-6):
         super().__init__()
         self.vllm_config = get_current_vllm_config()
@@ -242,38 +235,6 @@ class TestAllReduceRMSNormXPUMxFP4Model(torch.nn.Module):
         ]
 
 
-def _run_sequence_parallelism_pass_test(
-    test_model_cls: type[torch.nn.Module],
-    custom_ops: str,
-    batch_size: int,
-    seq_len: int,
-    hidden_size: int,
-    dtype: torch.dtype,
-    fuse_norm_quant: bool,
-    dynamic: bool,
-    model_name: str,
-):
-    # need to use torch.mp.spawn otherwise will have problems with
-    # torch.distributed and cuda
-    num_processes = 2
-    torch.multiprocessing.spawn(
-        sequence_parallelism_pass_on_test_model,
-        args=(
-            num_processes,
-            test_model_cls,
-            custom_ops,
-            batch_size,
-            seq_len,
-            hidden_size,
-            dtype,
-            fuse_norm_quant,
-            dynamic,
-            model_name,
-        ),
-        nprocs=num_processes,
-    )
-
-
 @multi_gpu_test(num_gpus=2)
 @pytest.mark.parametrize(
     "test_model_cls, custom_ops",
@@ -303,17 +264,28 @@ def test_sequence_parallelism_pass(
     fuse_norm_quant: bool,
     dynamic: bool,
 ):
-    _run_sequence_parallelism_pass_test(
-        test_model_cls,
-        custom_ops,
-        batch_size,
-        seq_len,
-        hidden_size,
-        dtype,
-        fuse_norm_quant,
-        dynamic,
-        "RedHatAI/Llama-3.2-1B-Instruct-FP8",
-    )
+    num_processes = 2
+
+    def run_torch_spawn(fn, nprocs):
+        # need to use torch.mp.spawn otherwise will have problems with
+        # torch.distributed and cuda
+        torch.multiprocessing.spawn(
+            fn,
+            args=(
+                num_processes,
+                test_model_cls,
+                custom_ops,
+                batch_size,
+                seq_len,
+                hidden_size,
+                dtype,
+                fuse_norm_quant,
+                dynamic,
+            ),
+            nprocs=nprocs,
+        )
+
+    run_torch_spawn(sequence_parallelism_pass_on_test_model, num_processes)
 
 
 @multi_gpu_test(num_gpus=2)
@@ -345,19 +317,27 @@ def test_sequence_parallelism_pass_xpu_mxfp4(
     dtype: torch.dtype,
     dynamic: bool,
 ):
-    # MXFP4 has no fused rms_norm+quant kernel yet, so fuse_norm_quant
-    # doesn't change the traced graph; keep it fixed at False.
-    _run_sequence_parallelism_pass_test(
-        test_model_cls,
-        custom_ops,
-        batch_size,
-        seq_len,
-        hidden_size,
-        dtype,
-        False,
-        dynamic,
-        "INCModel/Qwen3-30B-A3B-Instruct-2507-MXFP4-CT-AutoRound",
-    )
+    num_processes = 2
+
+    def run_torch_spawn(fn, nprocs):
+        # need to use torch.mp.spawn otherwise will have problems with
+        # torch.distributed and cuda
+        torch.multiprocessing.spawn(
+            fn,
+            args=(
+                num_processes,
+                test_model_cls,
+                custom_ops,
+                batch_size,
+                seq_len,
+                hidden_size,
+                dtype,
+                dynamic,
+            ),
+            nprocs=nprocs,
+        )
+
+    run_torch_spawn(sequence_parallelism_pass_on_test_model, num_processes)
 
 
 def test_sequence_parallelism_pass_requires_full_graph_compilation():
@@ -389,7 +369,6 @@ def sequence_parallelism_pass_on_test_model(
     dtype: torch.dtype,
     fuse_norm_quant: bool,
     dynamic: bool,
-    model_name: str,
 ):
     set_random_seed(0)
 
@@ -427,6 +406,7 @@ def sequence_parallelism_pass_on_test_model(
 
     # this is a fake model name to construct the model config
     # in the vllm_config, it's not really used.
+    model_name = "RedHatAI/Llama-3.2-1B-Instruct-FP8"
     model_config = ModelConfig(
         model=model_name, trust_remote_code=True, dtype=dtype, seed=42
     )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -49,6 +49,7 @@ from vllm.logger import init_logger
 from vllm.model_executor.kernels.linear import (
     _KernelT,
     init_fp8_linear_kernel,
+    init_mxfp4_linear_kernel,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
@@ -2385,6 +2386,58 @@ class TestFP8Layer(torch.nn.Module):
 
     def is_quant_fp8_enabled(self) -> bool:
         return self.kernel.quant_fp8.enabled()
+
+    def forward(
+        self, y: torch.Tensor, bias: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        return self.kernel.apply_weights(self, y, bias)
+
+
+MXFP4_BLOCK_SIZE = 32
+
+
+class TestMXFP4Layer(torch.nn.Module):
+    """
+    Test helper for MXFP4 W4A4 linear operations (weight: packed FP4 +
+    e8m0 block scale; activation: quantized on the fly to packed FP4 +
+    e8m0 block scale by the kernel via xpu_mxfp4_quantize).
+
+    Args:
+        hidden_size: Both in_features and out_features of the (square)
+            weight matrix.
+        block_size: MXFP4 scale group size (default 32).
+        scale_exp_range: Range of raw e8m0 scale byte values to sample
+            from (interpreted as float8_e8m0fnu after process_weights_
+            after_loading).
+        device: Device to allocate tensors on.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        block_size: int = MXFP4_BLOCK_SIZE,
+        scale_exp_range: tuple[int, int] = (118, 138),
+        device: torch.device | None = None,
+    ):
+        super().__init__()
+        # Packed FP4: two 4-bit values per uint8 byte, so the last
+        # dimension is halved relative to the logical (unpacked) weight.
+        self.weight = torch.randint(
+            0,
+            256,
+            (hidden_size, hidden_size // 2),
+            dtype=torch.uint8,
+            device=device,
+        )
+        self.weight_scale = torch.randint(
+            scale_exp_range[0],
+            scale_exp_range[1],
+            (hidden_size, hidden_size // block_size),
+            dtype=torch.uint8,
+            device=device,
+        )
+        self.kernel = init_mxfp4_linear_kernel()
+        self.kernel.process_weights_after_loading(self)
 
     def forward(
         self, y: torch.Tensor, bias: torch.Tensor | None = None

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -53,6 +53,7 @@ from vllm.model_executor.kernels.linear import (
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
+    kMxfp4Dynamic,
 )
 from vllm.model_executor.model_loader import get_model_loader
 from vllm.platforms import current_platform
@@ -2455,7 +2456,7 @@ class TestMXFP4Layer(torch.nn.Module):
             dtype=torch.uint8,
             device=device,
         )
-        self.kernel = init_mxfp4_linear_kernel()
+        self.kernel = init_mxfp4_linear_kernel(activation_quant_key=kMxfp4Dynamic)
         self.kernel.process_weights_after_loading(self)
 
     def forward(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -49,6 +49,7 @@ from vllm.logger import init_logger
 from vllm.model_executor.kernels.linear import (
     _KernelT,
     init_fp8_linear_kernel,
+    init_mxfp4_linear_kernel,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
@@ -2404,6 +2405,58 @@ class TestFP8Layer(torch.nn.Module):
 
     def is_quant_fp8_enabled(self) -> bool:
         return self.kernel.quant_fp8.enabled()
+
+    def forward(
+        self, y: torch.Tensor, bias: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        return self.kernel.apply_weights(self, y, bias)
+
+
+MXFP4_BLOCK_SIZE = 32
+
+
+class TestMXFP4Layer(torch.nn.Module):
+    """
+    Test helper for MXFP4 W4A4 linear operations (weight: packed FP4 +
+    e8m0 block scale; activation: quantized on the fly to packed FP4 +
+    e8m0 block scale by the kernel via xpu_mxfp4_quantize).
+
+    Args:
+        hidden_size: Both in_features and out_features of the (square)
+            weight matrix.
+        block_size: MXFP4 scale group size (default 32).
+        scale_exp_range: Range of raw e8m0 scale byte values to sample
+            from (interpreted as float8_e8m0fnu after process_weights_
+            after_loading).
+        device: Device to allocate tensors on.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        block_size: int = MXFP4_BLOCK_SIZE,
+        scale_exp_range: tuple[int, int] = (118, 138),
+        device: torch.device | None = None,
+    ):
+        super().__init__()
+        # Packed FP4: two 4-bit values per uint8 byte, so the last
+        # dimension is halved relative to the logical (unpacked) weight.
+        self.weight = torch.randint(
+            0,
+            256,
+            (hidden_size, hidden_size // 2),
+            dtype=torch.uint8,
+            device=device,
+        )
+        self.weight_scale = torch.randint(
+            scale_exp_range[0],
+            scale_exp_range[1],
+            (hidden_size, hidden_size // block_size),
+            dtype=torch.uint8,
+            device=device,
+        )
+        self.kernel = init_mxfp4_linear_kernel()
+        self.kernel.process_weights_after_loading(self)
 
     def forward(
         self, y: torch.Tensor, bias: torch.Tensor | None = None

--- a/vllm/compilation/passes/fusion/sequence_parallelism.py
+++ b/vllm/compilation/passes/fusion/sequence_parallelism.py
@@ -495,6 +495,118 @@ class MiddleAllReduceRMSNormStaticNVFP4Pattern(_SequenceParallelPatternHelper):
         )
 
 
+class FirstAllReduceRMSNormXPUMxFP4Pattern(_SequenceParallelPatternHelper):
+    def get_inputs(self) -> list[torch.Tensor]:
+        # Input width must be >= 32 (MXFP4 block size) so the scale tensor
+        # [tokens, width//32] is non-degenerate during pattern tracing.
+        return [self.empty([8, 32]), self.empty([32])]
+
+    def register(self, pm_pass: PatternMatcherPass) -> None:
+        def pattern(
+            input: torch.Tensor,
+            weight: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+            all_reduce = self._all_reduce(input)
+            rms = vllm.ir.ops.rms_norm(all_reduce, weight, self.epsilon)
+            quant = torch.ops.vllm.xpu_mxfp4_quantize(rms)
+            # `rms` (a plain bf16/fp16 tensor) is returned first so torch's
+            # PatternMatcherPass anchors this MultiOutputPattern on the
+            # rms_norm node, for the same reason documented in
+            # FirstAllReduceRMSNormXPUMxFP8Pattern above: anchoring on the
+            # getitem unpacking xpu_mxfp4_quantize's tuple output would make
+            # PatternMatcherPass.apply() skip this pattern entirely, since
+            # the scale output is torch.float8_e8m0fnu and operator.getitem
+            # is never in the small OpOverload whitelist that bypasses that
+            # check.
+            return rms, all_reduce, quant[0], quant[1]
+
+        def replacement(
+            input: torch.Tensor,
+            weight: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+            reduce_scatter = self._reduce_scatter(input)
+            rms = vllm.ir.ops.rms_norm(reduce_scatter, weight, self.epsilon)
+            quant = torch.ops.vllm.xpu_mxfp4_quantize(rms)
+            # XCCL supports neither float4_e2m1fn_x2 nor float8_e8m0fnu. Reinterpret
+            # both as uint8 (they share the same 8-bit width) during collectives,
+            # then convert back to the original dtypes after gathering.
+            all_gather_fp4 = self._all_gather(quant[0].view(torch.uint8)).view(
+                torch.float4_e2m1fn_x2
+            )
+            all_gather_scales = self._all_gather(quant[1].view(torch.uint8)).view(
+                torch.float8_e8m0fnu
+            )
+            return (
+                rms,
+                reduce_scatter,
+                all_gather_fp4,
+                all_gather_scales,
+            )
+
+        pm.register_replacement(
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+        )
+
+
+class MiddleAllReduceRMSNormXPUMxFP4Pattern(_SequenceParallelPatternHelper):
+    def get_inputs(self) -> list[torch.Tensor]:
+        mm_1 = torch.empty([8, 32])
+        residual = torch.empty([8, 32])
+        rms_norm_weights = torch.empty([32])
+        return [residual, mm_1, rms_norm_weights]
+
+    def register(self, pm_pass: PatternMatcherPass) -> None:
+        def pattern(
+            residual: torch.Tensor,
+            mm_1: torch.Tensor,
+            rms_norm_weights: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+            all_reduce = self._all_reduce(mm_1)
+            rms, residual_out = vllm.ir.ops.fused_add_rms_norm(
+                all_reduce, residual, rms_norm_weights, self.epsilon
+            )
+            quant = torch.ops.vllm.xpu_mxfp4_quantize(rms)
+            # Same reasoning as in FirstAllReduceRMSNormXPUMxFP4Pattern
+            # above: `rms`/`residual_out` must come first in the returned
+            # tuple so the pattern is anchored on the fused_add_rms_norm
+            # node (bf16/fp16 output) rather than on the getitem unpacking
+            # fp4/scale from xpu_mxfp4_quantize.
+            return rms, residual_out, quant[0], quant[1]
+
+        def replacement(
+            residual: torch.Tensor,
+            mm_1: torch.Tensor,
+            rms_norm_weights: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+            # Keep this slice in sync with the non-quantized SP replacement:
+            # once the previous SP pattern fires, it becomes a no-op.
+            reduce_scatter = self._reduce_scatter(mm_1)
+            residual = residual[0 : reduce_scatter.size(0), ...]
+            rms, residual_out = vllm.ir.ops.fused_add_rms_norm(
+                reduce_scatter, residual, rms_norm_weights, self.epsilon
+            )
+            quant = torch.ops.vllm.xpu_mxfp4_quantize(rms)
+            # XCCL supports neither float4_e2m1fn_x2 nor float8_e8m0fnu. Reinterpret
+            # both as uint8 (they share the same 8-bit width) during collectives,
+            # then convert back to the original dtypes after gathering.
+            all_gather_fp4 = self._all_gather(quant[0].view(torch.uint8)).view(
+                torch.float4_e2m1fn_x2
+            )
+            all_gather_scales = self._all_gather(quant[1].view(torch.uint8)).view(
+                torch.float8_e8m0fnu
+            )
+            return (
+                rms,
+                residual_out,
+                all_gather_fp4,
+                all_gather_scales,
+            )
+
+        pm.register_replacement(
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+        )
+
+
 class SequenceParallelismPass(VllmPatternMatcherPass):
     """
     This pass enables sequence parallelism for models.
@@ -575,6 +687,14 @@ class SequenceParallelismPass(VllmPatternMatcherPass):
                     epsilon, self.model_dtype, self.device
                 ).register(self.patterns)
                 MiddleAllReduceRMSNormStaticNVFP4Pattern(
+                    epsilon, self.model_dtype, self.device
+                ).register(self.patterns)
+
+            if hasattr(torch.ops.vllm, "xpu_mxfp4_quantize"):
+                FirstAllReduceRMSNormXPUMxFP4Pattern(
+                    epsilon, self.model_dtype, self.device
+                ).register(self.patterns)
+                MiddleAllReduceRMSNormXPUMxFP4Pattern(
                     epsilon, self.model_dtype, self.device
                 ).register(self.patterns)
 

--- a/vllm/compilation/passes/fusion/sequence_parallelism.py
+++ b/vllm/compilation/passes/fusion/sequence_parallelism.py
@@ -23,6 +23,7 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8StaticTensorSym,
 )
+from vllm.platforms import current_platform
 
 from ..inductor_pass import enable_fake_mode
 from ..utility.noop_elimination import NoOpEliminationPass
@@ -690,7 +691,7 @@ class SequenceParallelismPass(VllmPatternMatcherPass):
                     epsilon, self.model_dtype, self.device
                 ).register(self.patterns)
 
-            if hasattr(torch.ops.vllm, "xpu_mxfp4_quantize"):
+            if current_platform.is_xpu():
                 FirstAllReduceRMSNormXPUMxFP4Pattern(
                     epsilon, self.model_dtype, self.device
                 ).register(self.patterns)


### PR DESCRIPTION

## Purpose

Evaluate sequence parallelism (SP) on XPU for a W4A4 MXFP4 dense model.

SP is enabled with:

```json
{"pass_config":{"enable_sp":true},"use_inductor_graph_partition":true}
```
 

## Test Plan

Model: `INCModel/Qwen3-32B-MXFP4-CT-AutoRound` (dense, W4A4 MXFP4), tp=4.

### Server (one of the three, per case)

```bash
# sp_on
VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 VLLM_WORKER_MULTIPROC_METHOD=spawn \
python3 -m vllm.entrypoints.openai.api_server \
    --model INCModel/Qwen3-32B-MXFP4-CT-AutoRound --port 8072 --host 0.0.0.0 \
    --trust-remote-code --gpu-memory-util=0.90 --max-num-batched-tokens=16384 \
    --max-model-len=8448 --no-enable-prefix-caching --block-size 64 \
    -tp=4 \
    --compilation-config '{"pass_config":{"enable_sp":true},"use_inductor_graph_partition":true}'

# sp_off
VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 VLLM_WORKER_MULTIPROC_METHOD=spawn \
python3 -m vllm.entrypoints.openai.api_server \
    --model INCModel/Qwen3-32B-MXFP4-CT-AutoRound --port 8072 --host 0.0.0.0 \
    --trust-remote-code --gpu-memory-util=0.90 --max-num-batched-tokens=16384 \
    --max-model-len=8448 --no-enable-prefix-caching --block-size 64 \
    -tp=4

# eager
VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 VLLM_WORKER_MULTIPROC_METHOD=spawn \
python3 -m vllm.entrypoints.openai.api_server \
    --model INCModel/Qwen3-32B-MXFP4-CT-AutoRound --port 8072 --host 0.0.0.0 \
    --trust-remote-code --gpu-memory-util=0.90 --max-num-batched-tokens=16384 \
    --max-model-len=8448 --no-enable-prefix-caching --block-size 64 \
    -tp=4 --enforce-eager
```

### Client (bench serve, run twice per shape; better of the two reported)

```bash
python3 -m vllm.entrypoints.cli.main bench serve \
    --model INCModel/Qwen3-32B-MXFP4-CT-AutoRound \
    --ready-check-timeout-sec 1 --temperature=0 \
    --dataset-name random \
    --random-input-len=${input_len} \
    --random-output-len=${output_len} \
    --ignore-eos \
    --port=8072 --host 0.0.0.0 \
    --num-prompts ${num_prompts} \
    --request-rate inf --backend vllm \
    --trust-remote-code
```

Shapes: pure prefill `16:8192:1`, `16:4096:1`; mixed `16:256:128`, `32:128:64`.

## Test Result

### Accuracy (GSM8K, 5-shot, 250 questions)

| Case | Accuracy | Invalid rate |
|------|----------|--------------|
| eager (baseline) | 0.0 | 1.0 |
| sp_off | 0.0 | 1.0 |
| sp_on | 0.0 | 1.0 |


### Benchmark: sp_on vs sp_off (direct comparison)

Positive % = improvement (higher throughput / lower latency). Best of two runs.

#### Pure prefill 16:8192:1

| Metric | sp_off | sp_on | Improvement |
|--------|--------|-------|-------------|
| Benchmark duration (s) | 248.14 | 236.59 | **+4.65% ↑** |
| Mean TTFT (ms) | 133854 | 127932 | **+4.42% ↑** |
| Median TTFT (ms) | 133206 | 127118 | **+4.57% ↑** |
| P99 TTFT (ms) | 245627 | 234194 | **+4.65% ↑** |

#### Pure prefill 16:4096:1

| Metric | sp_off | sp_on | Improvement |
|--------|--------|-------|-------------|
| Benchmark duration (s) | 128.69 | 123.20 | **+4.27% ↑** |
| Mean TTFT (ms) | 77913 | 74448 | **+4.45% ↑** |
| Median TTFT (ms) | 70945 | 67767 | **+4.48% ↑** |
| P99 TTFT (ms) | 128675 | 123195 | **+4.26% ↑** |

#### Mixed prefill+decode 16:256:128

| Metric | sp_off | sp_on | Improvement |
|--------|--------|-------|-------------|
| Output throughput (tok/s) | 107.35 | 108.86 | **+1.41% ↑** |
| Mean TTFT (ms) | 7152 | 6912 | **+3.35% ↑** |
| Median TTFT (ms) | 7597 | 7342 | **+3.36% ↑** |
| Mean TPOT (ms) | 93.77 | 93.27 | **+0.53% ↑** |

#### Mixed prefill+decode 32:128:64

| Metric | sp_off | sp_on | Improvement |
|--------|--------|-------|-------------|
| Output throughput (tok/s) | 162.29 | 168.53 | **+3.84% ↑** |
| Mean TTFT (ms) | 6701 | 6365 | **+5.01% ↑** |
| Median TTFT (ms) | 6912 | 6564 | **+5.04% ↑** |
| Mean TPOT (ms) | 93.67 | 91.61 | **+2.20% ↑** |

### Benchmark: all configurations vs eager baseline

Pure prefill `16:4096:1`:

| Case | Mean TTFT (ms) | Median TTFT (ms) | P99 TTFT (ms) |
|------|----------------|-------------------|----------------|
| eager (baseline) | 78750 | 71733 | 129431 |
| sp_off (compile, no SP) | 77913 (+1.06%) | 70945 (+1.10%) | 128675 (+0.58%) |
| sp_on (compile + SP) | 74448 (+5.46%) | 67767 (+5.53%) | 123195 (+4.82%) |

Mixed `32:128:64`:

| Case | Output throughput (tok/s) | Mean TTFT (ms) | Mean TPOT (ms) |
|------|---------------------------|----------------|-----------------|
| eager (baseline) | 156.96 | 6970 | 96.22 |
| sp_off (compile, no SP) | 162.29 (+3.40%) | 6701 (+3.86%) | 93.67 (+2.65%) |
| sp_on (compile + SP) | 168.53 (+7.37%) | 6365 (+8.68%) | 91.61 (+4.79%) |

## Summary

- SP delivers a consistent **+4.3–4.7% TTFT / duration** gain on pure prefill and **+3.8–5.0% TTFT with +1.4–3.8% output throughput** on mixed workloads.

- Accuracy is unchanged across all three arms and orthogonal to SP; the 0.0  GSM8K score is caused by a numeric NaN bug in oneDNN's mxfp4 GEMM `autoTypeConversions()` forcing F4 operand compute type to f16 regardless of dst dtype  
