### PR TITLE
[Bugfix][KV Offload][OBJ] Preserve job completion during cleanup

### DIFF
--- a/tests/v1/kv_offload/tiering/test_obj_tier.py
+++ b/tests/v1/kv_offload/tiering/test_obj_tier.py
@@ -464,7 +464,7 @@ class TestMockObjTierFailures:
         assert len(results) == 1
         assert results[0].job_id == 1
         assert not results[0].success
-        agent.check_xfer_state.assert_called_once()
+        assert agent.check_xfer_state.call_count == 2
         assert release_xfer.call_count == 2
         assert not tier._transfers
         assert list(tier.get_finished_jobs()) == []
@@ -539,7 +539,7 @@ class TestMockObjTierFailures:
         assert block.ref_cnt == 0
         assert obj_tier._transfers == {}
         assert not manager.has_pending_work()
-        agent.check_xfer_state.assert_called_once()
+        assert agent.check_xfer_state.call_count == 2
         assert release_xfer.call_count == 2
 
 

--- a/tests/v1/kv_offload/tiering/test_obj_tier.py
+++ b/tests/v1/kv_offload/tiering/test_obj_tier.py
@@ -34,6 +34,10 @@ from vllm.v1.kv_offload.config import (
     OffloadingParallelConfig,
 )
 from vllm.v1.kv_offload.tiering.base import JobMetadata, JobResult
+from vllm.v1.kv_offload.tiering.manager import (
+    CPUPrimaryTierOffloadingManager,
+    TieringOffloadingManager,
+)
 from vllm.v1.kv_offload.tiering.obj.config import ObjStoreConfig
 from vllm.v1.kv_offload.tiering.obj.manager import ObjectStoreSecondaryTierManager
 
@@ -208,12 +212,14 @@ def _make_events_spec(enable_kv_cache_events: bool) -> SimpleNamespace:
 def _make_tier(
     num_blocks: int = 4,
     offloading_spec: SimpleNamespace = _OFFLOADING_SPEC,
+    primary_kv_view: memoryview | None = None,
     **tier_kwargs,
 ) -> tuple[ObjectStoreSecondaryTierManager, MockNixlAgent]:
     """Create a tier backed by a fresh MockNixlAgent."""
     mock_agent = MockNixlAgent()
-    tensor = torch.zeros((num_blocks, _BLOCK_ELEMENTS), dtype=_DTYPE)
-    view = memoryview(tensor.numpy())
+    if primary_kv_view is None:
+        tensor = torch.zeros((num_blocks, _BLOCK_ELEMENTS), dtype=_DTYPE)
+        primary_kv_view = memoryview(tensor.numpy())
     with (
         patch("vllm.v1.kv_offload.tiering.obj.manager.nixl_agent_config"),
         patch(
@@ -223,7 +229,7 @@ def _make_tier(
     ):
         tier = ObjectStoreSecondaryTierManager(
             offloading_spec=offloading_spec,
-            primary_kv_view=view,
+            primary_kv_view=primary_kv_view,
             tier_type="obj",
             store_config=_STORE_CONFIG,
             prefix=_RUN_PREFIX,
@@ -436,6 +442,105 @@ class TestMockObjTierFailures:
         by_id = {r.job_id: r for r in results}
         assert not by_id[1].success
         assert by_id[2].success
+
+    def test_release_xfer_failure_retries_without_losing_result(self, monkeypatch):
+        tier, agent = _make_tier(num_blocks=4)
+        agent.check_xfer_state = MagicMock(side_effect=RuntimeError("poll failed"))
+        release_xfer = MagicMock(
+            side_effect=[RuntimeError("transfer is still active"), None]
+        )
+        monkeypatch.setattr(agent, "release_xfer_handle", release_xfer)
+
+        tier.submit_store(make_job(1, [key(1)], [0]))
+
+        # The transfer handle could not be released safely, so the job must
+        # remain tracked and must not be finalized yet.
+        assert list(tier.get_finished_jobs()) == []
+        assert 1 in tier._transfers
+
+        # Cleanup is retried without polling again or changing the failure
+        # verdict. The completion is then returned exactly once.
+        results = list(tier.get_finished_jobs())
+        assert len(results) == 1
+        assert results[0].job_id == 1
+        assert not results[0].success
+        agent.check_xfer_state.assert_called_once()
+        assert release_xfer.call_count == 2
+        assert not tier._transfers
+        assert list(tier.get_finished_jobs()) == []
+
+    @pytest.mark.parametrize(
+        "cleanup_method", ["release_dlist_handle", "deregister_memory"]
+    )
+    def test_post_transfer_cleanup_failure_does_not_lose_result(
+        self, monkeypatch, cleanup_method
+    ):
+        tier, agent = _make_tier(num_blocks=4)
+        monkeypatch.setattr(
+            agent,
+            cleanup_method,
+            MagicMock(side_effect=RuntimeError("cleanup failed")),
+        )
+
+        tier.submit_store(make_job(1, [key(1)], [0]))
+        results = list(tier.get_finished_jobs())
+
+        assert len(results) == 1
+        assert results[0].job_id == 1
+        assert results[0].success
+        assert not tier._transfers
+        assert list(tier.get_finished_jobs()) == []
+
+    def test_xfer_cleanup_retry_finalizes_parent_job_and_primary_pin(self, monkeypatch):
+        num_blocks = 4
+        tensor = torch.zeros((num_blocks, _BLOCK_ELEMENTS), dtype=_DTYPE)
+        primary_kv_view = memoryview(tensor.numpy())
+        mmap_region = MagicMock()
+        mmap_region.create_kv_memoryview.return_value = primary_kv_view
+        primary_tier = CPUPrimaryTierOffloadingManager(
+            num_blocks=num_blocks, mmap_region=mmap_region
+        )
+        obj_tier, agent = _make_tier(
+            num_blocks=num_blocks, primary_kv_view=primary_kv_view
+        )
+        manager = TieringOffloadingManager(
+            primary_tier=primary_tier, secondary_tiers=[obj_tier]
+        )
+
+        keys = [key(1)]
+        primary_result = primary_tier.prepare_store(keys, _CTX)
+        assert primary_result is not None
+        primary_tier.complete_store(keys, _CTX, success=True)
+        job = manager.create_store_job(keys, _CTX)
+        obj_tier.submit_store(job)
+
+        block = primary_tier._policy.get(keys[0])
+        assert block is not None
+        assert block.ref_cnt == 1
+        assert len(manager._transfer_jobs) == 1
+
+        agent.check_xfer_state = MagicMock(side_effect=RuntimeError("poll failed"))
+        release_xfer = MagicMock(
+            side_effect=[RuntimeError("transfer is still active"), None]
+        )
+        monkeypatch.setattr(agent, "release_xfer_handle", release_xfer)
+        schedule_context = ScheduleEndContext(new_req_ids=[], preempted_req_ids=())
+
+        manager.on_schedule_end(schedule_context)
+
+        assert len(manager._transfer_jobs) == 1
+        assert block.ref_cnt == 1
+        assert len(obj_tier._transfers) == 1
+        assert manager.has_pending_work()
+
+        manager.on_schedule_end(schedule_context)
+
+        assert manager._transfer_jobs == {}
+        assert block.ref_cnt == 0
+        assert obj_tier._transfers == {}
+        assert not manager.has_pending_work()
+        agent.check_xfer_state.assert_called_once()
+        assert release_xfer.call_count == 2
 
 
 class TestMockObjTierShutdown:

--- a/vllm/v1/kv_offload/tiering/obj/manager.py
+++ b/vllm/v1/kv_offload/tiering/obj/manager.py
@@ -58,7 +58,6 @@ class TransferEntry(NamedTuple):
     xfer_handle: "nixl_xfer_handle"
     files_desc: object
     obj_handle: "nixl_prepped_dlist_handle"
-    success: bool | None = None
 
 
 class ObjAsyncLookupManager(AsyncLookupManager):
@@ -300,27 +299,20 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
         """Poll all in-flight transfers once; move newly-completed (success or
         failure) into ``_pending_results`` and release their NIXL handles."""
         for job_id, entry in list(self._transfers.items()):
-            if entry.success is None:
-                try:
-                    state = self._agent.check_xfer_state(entry.xfer_handle)
-                except Exception as exc:
-                    success = False
-                    logger.warning(
-                        "check_xfer_state raised for job %d: %s", job_id, exc
-                    )
+            try:
+                state = self._agent.check_xfer_state(entry.xfer_handle)
+            except Exception as exc:
+                success = False
+                logger.warning("check_xfer_state raised for job %d: %s", job_id, exc)
+            else:
+                if state == NIXL_PROC:
+                    continue
+                if state == NIXL_DONE:
+                    success = True
                 else:
-                    if state == NIXL_PROC:
-                        continue
-                    if state == NIXL_DONE:
-                        success = True
-                    else:
-                        success = False
-                        logger.warning("transfer failed job=%d state=%s", job_id, state)
-                entry = entry._replace(success=success)
-                self._transfers[job_id] = entry
+                    success = False
+                    logger.warning("transfer failed job=%d state=%s", job_id, state)
 
-            final_success = entry.success
-            assert final_success is not None
             try:
                 self._agent.release_xfer_handle(entry.xfer_handle)
             except Exception as exc:
@@ -345,9 +337,7 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
                 logger.warning("deregister_memory failed for job %d: %s", job_id, exc)
 
             del self._transfers[job_id]
-            self._pending_results.append(
-                JobResult(job_id=job_id, success=final_success)
-            )
+            self._pending_results.append(JobResult(job_id=job_id, success=success))
 
     def get_finished_jobs(self) -> Iterable[JobResult]:
         """Poll in-flight transfers; return completed (job_id, success) pairs."""

--- a/vllm/v1/kv_offload/tiering/obj/manager.py
+++ b/vllm/v1/kv_offload/tiering/obj/manager.py
@@ -58,6 +58,7 @@ class TransferEntry(NamedTuple):
     xfer_handle: "nixl_xfer_handle"
     files_desc: object
     obj_handle: "nixl_prepped_dlist_handle"
+    success: bool | None = None
 
 
 class ObjAsyncLookupManager(AsyncLookupManager):
@@ -299,24 +300,54 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
         """Poll all in-flight transfers once; move newly-completed (success or
         failure) into ``_pending_results`` and release their NIXL handles."""
         for job_id, entry in list(self._transfers.items()):
-            try:
-                state = self._agent.check_xfer_state(entry.xfer_handle)
-            except Exception as exc:
-                success = False
-                logger.warning("check_xfer_state raised for job %d: %s", job_id, exc)
-            else:
-                if state == NIXL_PROC:
-                    continue
-                elif state == NIXL_DONE:
-                    success = True
-                else:
+            if entry.success is None:
+                try:
+                    state = self._agent.check_xfer_state(entry.xfer_handle)
+                except Exception as exc:
                     success = False
-                    logger.warning("transfer failed job=%d state=%s", job_id, state)
+                    logger.warning(
+                        "check_xfer_state raised for job %d: %s", job_id, exc
+                    )
+                else:
+                    if state == NIXL_PROC:
+                        continue
+                    if state == NIXL_DONE:
+                        success = True
+                    else:
+                        success = False
+                        logger.warning("transfer failed job=%d state=%s", job_id, state)
+                entry = entry._replace(success=success)
+                self._transfers[job_id] = entry
+
+            final_success = entry.success
+            assert final_success is not None
+            try:
+                self._agent.release_xfer_handle(entry.xfer_handle)
+            except Exception as exc:
+                # Keep the entry until NIXL confirms that the transfer handle
+                # can be released. The transfer may still access primary-tier
+                # memory, so publishing its result would allow unsafe reuse.
+                logger.warning("release_xfer_handle failed for job %d: %s", job_id, exc)
+                continue
+
+            # Once the transfer handle is released, these remaining cleanup
+            # failures must not suppress the job completion. They can leak
+            # NIXL metadata, but cannot leave an active data transfer behind.
+            try:
+                self._agent.release_dlist_handle(entry.obj_handle)
+            except Exception as exc:
+                logger.warning(
+                    "release_dlist_handle failed for job %d: %s", job_id, exc
+                )
+            try:
+                self._agent.deregister_memory(entry.files_desc)
+            except Exception as exc:
+                logger.warning("deregister_memory failed for job %d: %s", job_id, exc)
+
             del self._transfers[job_id]
-            self._agent.release_xfer_handle(entry.xfer_handle)
-            self._agent.release_dlist_handle(entry.obj_handle)
-            self._agent.deregister_memory(entry.files_desc)
-            self._pending_results.append(JobResult(job_id=job_id, success=success))
+            self._pending_results.append(
+                JobResult(job_id=job_id, success=final_success)
+            )
 
     def get_finished_jobs(self) -> Iterable[JobResult]:
         """Poll in-flight transfers; return completed (job_id, success) pairs."""


### PR DESCRIPTION
## Purpose

The OBJ secondary tier removes a transfer from `_transfers` before releasing its NIXL resources. If `release_xfer_handle()` raises, no `JobResult` is published and the OBJ tier has already discarded the only state needed to retry cleanup.

The parent `TieringOffloadingManager` therefore cannot pop the corresponding `_transfer_jobs` entry or call `primary.complete_read()`. For a primary-to-OBJ store, the CPU cache block remains pinned and `has_pending_work()` remains true.

NIXL documents that releasing an active transfer can fail when the transfer cannot be cancelled; in that case the handle is not freed:
https://github.com/ai-dynamo/nixl/blob/main/src/api/python/_api.py#L705-L714

## Fix

- Keep each transfer entry in `_transfers` until `release_xfer_handle()` succeeds.
- If releasing the transfer handle raises, continue polling and retry cleanup on the next scheduler step.
- After the transfer handle is released, treat descriptor-list and OBJ registration cleanup as best effort so those exceptions cannot suppress the job completion.
- Publish each `JobResult` exactly once.

This preserves the safety boundary: the parent is not allowed to reuse primary-tier memory while a NIXL transfer may still be active.

## Regression proof

The regression test connects the real `TieringOffloadingManager`, CPU primary tier, and OBJ secondary tier, and drives the public `on_schedule_end()` path. It injects:

1. an exception from `check_xfer_state()`, leaving the transfer state unknown; and
2. one failure from `release_xfer_handle()`, representing an active transfer that NIXL cannot cancel yet.

On unmodified `main`, the same test fails with `RuntimeError: transfer is still active`. A diagnostic assertion immediately after that failure observes:

```
parent_jobs=1
block_ref_cnt=1
has_pending_work=True
obj_transfers=0
```

The parent job and CPU pin remain, but the OBJ tier no longer has the transfer entry needed to finish them.

With this change, the first scheduler poll retains all of that state safely. The next poll retries cleanup, after which the test observes an empty parent job map, `ref_cnt == 0`, no OBJ transfer, and `has_pending_work() == False`.

## Live NIXL/OBJ validation

In addition to the mock-based failure injection, I ran the real `ObjectStoreSecondaryTierManager` with NIXL 1.3.1's OBJ backend against a local S3-compatible Moto server:

1. The startup connectivity probe reached the test bucket.
2. NIXL asynchronously wrote one 1,024-byte CPU DRAM block to an actual S3 object.
3. The CPU block was zeroed locally.
4. NIXL read the object back into the same CPU block.
5. The restored tensor matched the original byte-for-byte.
6. S3 listing confirmed one `.bin` object with size 1,024 bytes.
7. Manager shutdown completed normally.

Observed output:

```
NIXL is available
Backend OBJ was instantiated
Object store tier connectivity probe succeeded
LIVE_OBJ_PASS restored_bytes=1024
LIVE_S3_OBJECT ...0000000000000065.bin size=1024
```

This validates the normal live WRITE/READ and cleanup path without a GPU. The cleanup exceptions themselves remain deterministic fault injection because reproducing a real transport cancellation failure on demand is not reliable.

## Duplicate-work check

No open issue or PR found for lost OBJ job completion during NIXL cleanup.

Related work is not a duplicate:

- #49561 handles a `check_xfer_state()` exception in the P2P `NixlTransport` inflight map. It does not touch the OBJ secondary-tier manager or parent job completion.
- #49328 invalidates cached lookup verdicts after failed promotions and hardens the FS tier. Its OBJ change concerns failed-load lookup invalidation, not cleanup retry or completion delivery.
- #49850 bounds request-level waiting on leaked `HIT_PENDING` entries. It mitigates a downstream symptom and does not repair stalled transfer bookkeeping.

Searches run:

```
gh pr list --repo vllm-project/vllm --state open --search '"ObjectStoreSecondaryTierManager"'
gh pr list --repo vllm-project/vllm --state open --search '"release_xfer_handle" OBJ'
gh pr list --repo vllm-project/vllm --state open --search '"cleanup" "JobResult" "KV Offload"'
```

## Test plan

```bash
.venv/bin/python -m pytest -q tests/v1/kv_offload/tiering/test_obj_tier.py
# 36 passed

pre-commit run --files \
  vllm/v1/kv_offload/tiering/obj/manager.py \
  tests/v1/kv_offload/tiering/test_obj_tier.py
# all applicable hooks passed

.venv/bin/python tools/pre_commit/mypy.py 3.10 vllm/v1/kv_offload/tiering/obj/manager.py tests/v1/kv_offload/tiering/test_obj_tier.py
.venv/bin/python tools/pre_commit/mypy.py 3.11 vllm/v1/kv_offload/tiering/obj/manager.py tests/v1/kv_offload/tiering/test_obj_tier.py
.venv/bin/python tools/pre_commit/mypy.py 3.12 vllm/v1/kv_offload/tiering/obj/manager.py tests/v1/kv_offload/tiering/test_obj_tier.py
.venv/bin/python tools/pre_commit/mypy.py 3.13 vllm/v1/kv_offload/tiering/obj/manager.py tests/v1/kv_offload/tiering/test_obj_tier.py
# all passed
```

Model evaluation: N/A. This changes transfer cleanup and bookkeeping only; it does not affect model output or accuracy.

## AI assistance

This PR includes AI-assisted code and analysis from OpenAI Codex. I reviewed every changed line, understand the failure mode and fix, and take responsibility for the contribution.
