### PR TITLE
[Bugfix] cumem_allocator: return None via Py_IncRef, not Py_RETURN_NONE

### DIFF
--- a/csrc/cumem_allocator.cpp
+++ b/csrc/cumem_allocator.cpp
@@ -593,7 +593,16 @@ static PyObject* py_init_module(PyObject* self, PyObject* args) {
   g_python_malloc_callback = malloc_callback;
   g_python_free_callback = free_callback;
 
-  Py_RETURN_NONE;
+  // Return None via Py_IncRef(Py_None) instead of Py_RETURN_NONE. cumem is an
+  // abi3 extension (USE_SABI 3.8), so Py_RETURN_NONE's inlined Py_INCREF is
+  // compiled against whatever Python.h is on the include path. When the wheel
+  // is built against 3.12+ headers (immortal None, PEP 683) but loaded by an
+  // older interpreter, that increment can be dropped; sleep()/wake_up() call
+  // these every cycle, so the leak eventually crashes with "none_dealloc".
+  // Py_IncRef is out-of-line and uses the running interpreter's semantics, so
+  // it is immune to this compile/runtime header skew.
+  Py_IncRef(Py_None);
+  return Py_None;
 }
 
 static PyObject* python_unmap_and_release(PyObject* self, PyObject* args) {
@@ -714,7 +723,10 @@ static PyObject* python_unmap_and_release(PyObject* self, PyObject* args) {
     return nullptr;
   }
 
-  Py_RETURN_NONE;
+  // See py_init_module: Py_IncRef instead of Py_RETURN_NONE avoids a dropped
+  // None reference under abi3 header/runtime skew. Called on every sleep().
+  Py_IncRef(Py_None);
+  return Py_None;
 }
 
 static PyObject* python_create_and_map(PyObject* self, PyObject* args) {
@@ -782,7 +794,10 @@ static PyObject* python_create_and_map(PyObject* self, PyObject* args) {
     return nullptr;
   }
 
-  Py_RETURN_NONE;
+  // See py_init_module: Py_IncRef instead of Py_RETURN_NONE avoids a dropped
+  // None reference under abi3 header/runtime skew. Called on every wake_up().
+  Py_IncRef(Py_None);
+  return Py_None;
 }
 
 static PyMethodDef module_methods[] = {


### PR DESCRIPTION
cumem_allocator is an abi3 extension (USE_SABI 3.8), so Py_RETURN_NONE's inlined Py_INCREF is compiled against whatever Python.h is on the include path. When the wheel is built against 3.12+ headers (immortal None, PEP 683) but loaded by an older interpreter, that increment can be dropped. sleep()/ wake_up() hit these functions every cycle, so the leaked reference eventually crashes with "Fatal Python error: none_dealloc: deallocating None".

Py_IncRef is out-of-line and uses the running interpreter's semantics, so it is immune to this compile/runtime header skew. A matched build is unaffected.



## Purpose

`cumem_allocator` is an abi3 extension (`USE_SABI 3.8`), so `Py_RETURN_NONE`'s
inlined `Py_INCREF` is compiled against whatever `Python.h` is on the include
path. When the wheel is built against 3.12+ headers (immortal `None`, PEP 683)
but loaded by an older interpreter, that increment can be dropped. `sleep()` /
`wake_up()` hit `python_create_and_map` / `python_unmap_and_release` every
cycle, so the leaked reference on `None` eventually crashes with
`Fatal Python error: none_dealloc: deallocating None`.

`Py_IncRef` is out-of-line and uses the running interpreter's semantics, so it
is immune to this compile/runtime header skew. A matched build is unaffected
(on 3.12+ `None` is immortal and the dropped incref is a no-op).

This is a real, reproducible issue in a released wheel: the official
`vllm-0.22.0+cu129-cp38-abi3-manylinux_2_28_x86_64.whl` ships
`vllm/cumem_allocator.abi3.so` (BuildID `9761c4bd8afc9a83c41bc02b873b5515df1ebb69`)
whose `python_create_and_map` / `python_unmap_and_release` success paths return
`&_Py_NoneStruct` with no refcount increment and no `Py_IncRef` symbol at all —
so running that abi3 wheel under CPython <= 3.11 with sleep mode deterministically
crashes in `none_dealloc`.

Note: this is distinct from #23477 (which keeps a strong Python-side reference to
the malloc callback); this PR fixes the dropped `None` reference on return.

## Test Plan

- `pytest tests/basic_correctness/test_cumem.py` (sleep / wake_up paths).
- Repro of the crash: on CPython <= 3.11 (mortal `None`), run an
  `enable_sleep_mode=True` engine through many `sleep()` / `wake_up()` cycles
  (a tight churn loop) and watch for `none_dealloc`.
- Sanity-check the built artifact: disassemble `cumem_allocator.abi3.so` and
  confirm the `None`-return paths now perform the increment via the out-of-line
  `Py_IncRef` symbol (present in the dynamic symbol table) instead of an inlined
  (and potentially folded-away) `Py_INCREF`.

## Test Result

- Before: with the released/inlined build on CPython 3.10, the sleep/wake churn
  crashes deterministically with
  `Fatal Python error: none_dealloc: deallocating None` (in our environment
  around ~820 cycles, scaling with handle count).
- After: with `Py_IncRef(Py_None); return Py_None;`, the same workload runs well
  past the original crash point (1250+ cycles, >50% beyond) with zero
  `none_dealloc`. `Py_IncRef` now appears as an imported symbol in the `.so`.
- On CPython 3.12+ the behavior is unchanged (immortal `None`), confirming the
  fix is safe for matched builds.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>