### PR TITLE
[Bugfix] Fix ModelOpt NVFP4 TP shard alignment

### DIFF
--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
@@ -494,14 +494,19 @@ class RoutedExperts(PluggableLayer):
             shard_size = expert_data.shape[shard_dim]
         # Only narrow if the loaded_weight is not a scalar (0-dim tensor)
         # and we're not loading the full weight
+        shard_alignment = getattr(
+            self.quant_method, "intermediate_size_per_partition_alignment", 1
+        )
         if not load_full and loaded_weight.ndim > 0:
-            # When the parameter has been padded (e.g. MXFP4 rounding up
-            # intermediate_size_per_partition), shard_size is the padded
-            # size.  Compute the offset into the checkpoint weight using
-            # the *unpadded* per-rank size so that every TP rank lands at
-            # the correct slice.
-            tp_size = self.moe_config.moe_parallel_config.tp_size
-            loaded_per_rank = loaded_weight.shape[shard_dim] // tp_size
+            if shard_alignment > 1:
+                loaded_per_rank = shard_size
+            else:
+                # When the parameter has been padded (e.g. MXFP4 rounding up
+                # intermediate_size_per_partition), shard_size is the padded
+                # size. Compute the offset into the checkpoint weight using
+                # the unpadded per-rank size.
+                tp_size = self.moe_config.moe_parallel_config.tp_size
+                loaded_per_rank = loaded_weight.shape[shard_dim] // tp_size
             start_offset = loaded_per_rank * tp_rank
             available = loaded_weight.shape[shard_dim] - start_offset
             if available <= 0:
@@ -519,6 +524,11 @@ class RoutedExperts(PluggableLayer):
         else:
             assert shard_id == "w3"
             expert_data = expert_data.narrow(shard_dim, shard_size, shard_size)
+        if (
+            shard_alignment > 1
+            and expert_data.shape[shard_dim] > loaded_weight.shape[shard_dim]
+        ):
+            expert_data.zero_()
         hidden_dim = self._get_hidden_dim(shard_dim, expert_data.ndim)
         expert_data = self._narrow_expert_data_for_padding(
             expert_data,
@@ -540,10 +550,16 @@ class RoutedExperts(PluggableLayer):
         # down_proj: "RowParallel" so tp sharding on input_dim
         # Only narrow if the loaded_weight is not a scalar (0-dim tensor)
         # and we're not loading the full weight
+        shard_alignment = getattr(
+            self.quant_method, "intermediate_size_per_partition_alignment", 1
+        )
         if not load_full and loaded_weight.ndim > 0:
-            # Same padding fix as _load_w13: use unpadded per-rank size.
-            tp_size = self.moe_config.moe_parallel_config.tp_size
-            loaded_per_rank = loaded_weight.shape[shard_dim] // tp_size
+            if shard_alignment > 1:
+                loaded_per_rank = expert_data.shape[shard_dim]
+            else:
+                # Same padding fix as _load_w13: use unpadded per-rank size.
+                tp_size = self.moe_config.moe_parallel_config.tp_size
+                loaded_per_rank = loaded_weight.shape[shard_dim] // tp_size
             start_offset = loaded_per_rank * tp_rank
             available = loaded_weight.shape[shard_dim] - start_offset
             if available <= 0:
@@ -554,6 +570,11 @@ class RoutedExperts(PluggableLayer):
             narrow_size = min(loaded_per_rank, available)
             loaded_weight = loaded_weight.narrow(shard_dim, start_offset, narrow_size)
         # w2, down_proj: Load into only logical weight of w2.
+        if (
+            shard_alignment > 1
+            and expert_data.shape[shard_dim] > loaded_weight.shape[shard_dim]
+        ):
+            expert_data.zero_()
         hidden_dim = self._get_hidden_dim(shard_dim, expert_data.ndim)
         expert_data = self._narrow_expert_data_for_padding(
             expert_data,

--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
@@ -473,14 +473,19 @@ class RoutedExperts(PluggableLayer):
             shard_size = expert_data.shape[shard_dim]
         # Only narrow if the loaded_weight is not a scalar (0-dim tensor)
         # and we're not loading the full weight
+        shard_alignment = getattr(
+            self.quant_method, "intermediate_size_per_partition_alignment", 1
+        )
         if not load_full and loaded_weight.ndim > 0:
-            # When the parameter has been padded (e.g. MXFP4 rounding up
-            # intermediate_size_per_partition), shard_size is the padded
-            # size.  Compute the offset into the checkpoint weight using
-            # the *unpadded* per-rank size so that every TP rank lands at
-            # the correct slice.
-            tp_size = self.moe_config.moe_parallel_config.tp_size
-            loaded_per_rank = loaded_weight.shape[shard_dim] // tp_size
+            if shard_alignment > 1:
+                loaded_per_rank = shard_size
+            else:
+                # When the parameter has been padded (e.g. MXFP4 rounding up
+                # intermediate_size_per_partition), shard_size is the padded
+                # size. Compute the offset into the checkpoint weight using
+                # the unpadded per-rank size.
+                tp_size = self.moe_config.moe_parallel_config.tp_size
+                loaded_per_rank = loaded_weight.shape[shard_dim] // tp_size
             start_offset = loaded_per_rank * tp_rank
             available = loaded_weight.shape[shard_dim] - start_offset
             if available <= 0:
@@ -498,6 +503,11 @@ class RoutedExperts(PluggableLayer):
         else:
             assert shard_id == "w3"
             expert_data = expert_data.narrow(shard_dim, shard_size, shard_size)
+        if (
+            shard_alignment > 1
+            and expert_data.shape[shard_dim] > loaded_weight.shape[shard_dim]
+        ):
+            expert_data.zero_()
         hidden_dim = self._get_hidden_dim(shard_dim, expert_data.ndim)
         expert_data = self._narrow_expert_data_for_padding(
             expert_data,
@@ -517,10 +527,16 @@ class RoutedExperts(PluggableLayer):
         # Index the loaded weight for tp sharding.
         # down_proj: "RowParallel" so tp sharding on input_dim
         # Only narrow if the loaded_weight is not a scalar (0-dim tensor).
+        shard_alignment = getattr(
+            self.quant_method, "intermediate_size_per_partition_alignment", 1
+        )
         if loaded_weight.ndim > 0:
-            # Same padding fix as _load_w13: use unpadded per-rank size.
-            tp_size = self.moe_config.moe_parallel_config.tp_size
-            loaded_per_rank = loaded_weight.shape[shard_dim] // tp_size
+            if shard_alignment > 1:
+                loaded_per_rank = expert_data.shape[shard_dim]
+            else:
+                # Same padding fix as _load_w13: use unpadded per-rank size.
+                tp_size = self.moe_config.moe_parallel_config.tp_size
+                loaded_per_rank = loaded_weight.shape[shard_dim] // tp_size
             start_offset = loaded_per_rank * tp_rank
             available = loaded_weight.shape[shard_dim] - start_offset
             if available <= 0:
@@ -531,6 +547,11 @@ class RoutedExperts(PluggableLayer):
             narrow_size = min(loaded_per_rank, available)
             loaded_weight = loaded_weight.narrow(shard_dim, start_offset, narrow_size)
         # w2, down_proj: Load into only logical weight of w2.
+        if (
+            shard_alignment > 1
+            and expert_data.shape[shard_dim] > loaded_weight.shape[shard_dim]
+        ):
+            expert_data.zero_()
         hidden_dim = self._get_hidden_dim(shard_dim, expert_data.ndim)
         expert_data = self._narrow_expert_data_for_padding(
             expert_data,

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -20,6 +20,7 @@ from vllm.model_executor.layers.attention import Attention, MLAAttention
 from vllm.model_executor.layers.fused_moe import (
     FusedMoEConfig,
     FusedMoEMethodBase,
+    FusedMoEParallelConfig,
     FusedMoEQuantConfig,
     FusedMoeWeightScaleSupported,
     RoutedExperts,
@@ -1390,6 +1391,7 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
     ) -> None:
         super().__init__(moe_config)
         self.quant_config = quant_config
+        self.intermediate_size_per_partition_alignment = quant_config.group_size
         # W4A16 mode fires for W4A16_NVFP4 on-disk checkpoints. With
         # activation_key=None every W4A4 backend's _supports_quant_scheme
         # rejects itself (they all require (kNvfp4Static, kNvfp4Dynamic)
@@ -1406,6 +1408,25 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
         self.use_global_sf = is_global_sf_supported_for_nvfp4_backend(
             self.nvfp4_backend
         )
+
+    def maybe_roundup_sizes(
+        self,
+        hidden_size: int,
+        intermediate_size_per_partition: int,
+        act_dtype: torch.dtype,
+        moe_parallel_config: FusedMoEParallelConfig,
+    ) -> tuple[int, int]:
+        hidden_size, intermediate_size_per_partition = super().maybe_roundup_sizes(
+            hidden_size,
+            intermediate_size_per_partition,
+            act_dtype,
+            moe_parallel_config,
+        )
+        alignment = self.intermediate_size_per_partition_alignment
+        intermediate_size_per_partition = (
+            (intermediate_size_per_partition + alignment - 1) // alignment * alignment
+        )
+        return hidden_size, intermediate_size_per_partition
 
     def maybe_make_prepare_finalize(
         self,

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -23,6 +23,7 @@ from vllm.model_executor.layers.attention import Attention, MLAAttention
 from vllm.model_executor.layers.fused_moe import (
     FusedMoEConfig,
     FusedMoEMethodBase,
+    FusedMoEParallelConfig,
     FusedMoEQuantConfig,
     FusedMoeWeightScaleSupported,
     RoutedExperts,
@@ -833,6 +834,7 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
     ) -> None:
         super().__init__(moe_config)
         self.quant_config = quant_config
+        self.intermediate_size_per_partition_alignment = quant_config.group_size
         # W4A16 mode fires for W4A16_NVFP4 on-disk checkpoints. With
         # activation_key=None every W4A4 backend's _supports_quant_scheme
         # rejects itself (they all require (kNvfp4Static, kNvfp4Dynamic)
@@ -849,6 +851,25 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
         self.use_global_sf = is_global_sf_supported_for_nvfp4_backend(
             self.nvfp4_backend
         )
+
+    def maybe_roundup_sizes(
+        self,
+        hidden_size: int,
+        intermediate_size_per_partition: int,
+        act_dtype: torch.dtype,
+        moe_parallel_config: FusedMoEParallelConfig,
+    ) -> tuple[int, int]:
+        hidden_size, intermediate_size_per_partition = super().maybe_roundup_sizes(
+            hidden_size=hidden_size,
+            intermediate_size_per_partition=intermediate_size_per_partition,
+            act_dtype=act_dtype,
+            moe_parallel_config=moe_parallel_config,
+        )
+        alignment = self.intermediate_size_per_partition_alignment
+        intermediate_size_per_partition = (
+            (intermediate_size_per_partition + alignment - 1) // alignment * alignment
+        )
+        return hidden_size, intermediate_size_per_partition
 
     def uses_weight_scale_2_pattern(self) -> bool:
         """


### PR DESCRIPTION
## Purpose

Fixes https://github.com/vllm-project/vllm/issues/49949.

ModelOpt NVFP4 MoE loading fails when tensor parallelism divides an expert intermediate dimension at a boundary that is not aligned to the checkpoint's quantization group. *In other words, we slice an avfp4 group across shards.*

`nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4` provides a compact reproducer. Its routed-expert intermediate size is 1,856, so TP8 currently assigns 232 logical values to each rank. ModelOpt NVFP4 uses groups of 16 values, and 232 is not divisible by 16.

The existing loader independently partitions each checkpoint representation:

- Logical weights: 232 values per rank
- Packed FP4 weights: 116 bytes per rank
- NVFP4 scales: `232 // 16 = 14` groups per rank

### Sliced and distributed NVFP4 group, and Why reported as scale error first. 

Once the NVFP4 group has been sliced and partitioned between multiple shards, the loader proceeds to partition the scales.  This in turn triggers inconsistencies because the slices groups across shards have no rational associated  scale.

Marlin subsequently pads the local weight extent from 232 to 256 values. The scale tensor receives only one additional group, producing 15 scale groups for 256 values and failing during startup:

```text
RuntimeError: moe_wna16_marlin_gemm,
/workspace/csrc/libtorch_stable/moe/marlin_moe_wna16/ops.cu:768,
size_k = 256, is not divisible by b_scales.size(1) = 15
```

Appending another scale would only remove the immediate shape error. The original TP boundaries occur at `0, 232, 464, 696, ...`; after rank 0, those boundaries split NVFP4 groups and associate weights with the wrong source scales.

### This fix: align shards with nvfp4 groups at multiples of 16

This PR rounds the ModelOpt NVFP4 intermediate partition from 232 to 240 before allocating its weights and scales. Each representation then uses corresponding aligned boundaries:

- Logical weights: 240 values
- Packed FP4 weights: 120 bytes
- NVFP4 scales: 15 groups

The final TP rank loads the checkpoint remainder and zero-fills its padded tail.

The PR also replaces a ModelOpt-specific Boolean with the numeric `intermediate_size_per_partition_alignment` contract:

- If the attribute is absent, its effective value is `1`.
- Alignment `1` preserves the existing checkpoint cuts for all other quantization methods.
- ModelOpt NVFP4 sets the alignment from `quant_config.group_size`, currently 16.
- When the alignment is greater than 1, the generic loader calculates source offsets from the aligned destination shard width. This works for logical weights, packed weights, and scale tensors because each destination expresses the same aligned partition in its own storage units.

MXFP4 can opt into the same loader behavior in a follow-up change by setting:

```python
intermediate_size_per_partition_alignment = 32
```

on `GptOssMxfp4MoEMethod` and `Mxfp4MoEMethod`. Their existing `maybe_roundup_sizes()` path already rounds local intermediate dimensions to backend-specific multiples of 32. Setting the attribute would make their checkpoint slicing use those aligned partitions without another generic-loader change.

MXFP4 is not opted in by this PR because this change and its reproducer cover ModelOpt NVFP4.

## Test Plan

Reproduce the failure on eight H100 GPUs with unpatched vLLM 0.26.0:

```bash
vllm serve nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4 \
  --served-model-name nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4 \
  --tensor-parallel-size 8 \
  --max-num-seqs 512 \
  --max-model-len 2200 \
  --kv-cache-dtype fp8 \
  --gpu-memory-utilization 0.90 \
  --block-size 128 \
  --no-enable-prefix-caching \
  --trust-remote-code
```

Apply this PR and run the identical command:

```bash
vllm serve nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4 \
  --served-model-name nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4 \
  --tensor-parallel-size 8 \
  --max-num-seqs 512 \
  --max-model-len 2200 \
  --kv-cache-dtype fp8 \
  --gpu-memory-utilization 0.90 \
  --block-size 128 \
  --no-enable-prefix-caching \
  --trust-remote-code
```

After the patched server reports ready, verify a completion:

```bash
curl -s http://localhost:8000/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4",
    "messages": [
      {
        "role": "user",
        "content": "What is the capital city of France? Answer with one word."
      }
    ],
    "temperature": 0
  }'
```

## Test Result

### Before

The unpatched vLLM 0.26.0 command loads the checkpoint but fails during the startup profile run on every TP rank:

```text
RuntimeError: moe_wna16_marlin_gemm,
/workspace/csrc/libtorch_stable/moe/marlin_moe_wna16/ops.cu:768,
size_k = 256, is not divisible by b_scales.size(1) = 15
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, including the issue it fixes.
- [x] The test plan, including the standalone reproduction command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] Documentation impact was considered. No user documentation change is required because this changes an internal weight-loading contract.
</details>
