### PR TITLE
[Bugfix][KV Offload] Reserve primary-tier headroom so speculative promotions don't starve running stores

### DIFF
--- a/tests/v1/kv_offload/tiering/test_tiering_offloading.py
+++ b/tests/v1/kv_offload/tiering/test_tiering_offloading.py
@@ -431,6 +431,37 @@ class TestTieringOffloadingManager:
             "(issue #49902)"
         )
 
+    def test_promotions_leave_room_for_batched_stores(self, manager_setup):
+        """The reserve must cover a whole store batch, not a single block.
+
+        ``prepare_store()`` receives every key a running request offloads in
+        one all-or-nothing call, so leaving one free block is not enough: a
+        two-key store still fails. Once a batch of that size has been seen,
+        promotions must keep that much room free.
+        """
+        running_ctx = ReqContext(req_id="running")
+        self._start_request(running_ctx)
+
+        # Establish the batch size this workload stores in one call.
+        first = self.manager.prepare_store(to_keys([200, 201]), running_ctx)
+        assert first is not None
+        self.manager.complete_store(to_keys([200, 201]), running_ctx, success=True)
+
+        queued_keys = to_keys(range(100, 105))
+        for key in queued_keys:
+            self.secondary_tier1.blocks[key] = True
+        for i, key in enumerate(queued_keys):
+            ctx = ReqContext(req_id=f"queued-{i}")
+            self._start_request(ctx)
+            self.manager.lookup(key, ctx)
+
+        # A store of the same shape must still fit.
+        result = self.manager.prepare_store(to_keys([300, 301]), running_ctx)
+        assert result is not None, (
+            "batched offload store was starved by speculative promotions: the "
+            "reserve must cover a whole store batch (issue #49902)"
+        )
+
     def test_lookup_reports_sync_delay_for_resolved_lookups(self, manager_setup):
         """Resolved lookups report one sync delay sample on allocation."""
         self._start_request()

--- a/tests/v1/kv_offload/tiering/test_tiering_offloading.py
+++ b/tests/v1/kv_offload/tiering/test_tiering_offloading.py
@@ -396,6 +396,41 @@ class TestTieringOffloadingManager:
         # Next lookup should succeed
         assert count_hits(self.manager, blocks) == 3
 
+    def test_speculative_promotions_do_not_starve_running_stores(self, manager_setup):
+        """Promotions for queued requests must leave room for running stores.
+
+        Regression test for issue #49902. The scheduler calls ``lookup()`` for
+        every request in the waiting queue, well before ``allocate_slots()``
+        decides which of them is admitted this step, so a deep queue can
+        reserve the whole primary pool for requests that never run. A running
+        request's offload store then fails to allocate, because the primary
+        tier's ``prepare_write`` *is* ``prepare_store``: promotions and real
+        offloads contend for the same blocks. Promotions must leave headroom
+        instead of consuming the pool speculatively.
+        """
+        # The primary pool holds 5 blocks (see manager_setup).
+        queued_keys = to_keys(range(100, 105))
+        for key in queued_keys:
+            self.secondary_tier1.blocks[key] = True
+
+        # Drain the waiting queue exactly as schedule() does: one lookup per
+        # queued request, each initiating a promotion into the primary tier.
+        for i, key in enumerate(queued_keys):
+            ctx = ReqContext(req_id=f"queued-{i}")
+            self._start_request(ctx)
+            self.manager.lookup(key, ctx)
+
+        # In the same step, a running request offloads a freshly computed block.
+        running_ctx = ReqContext(req_id="running")
+        self._start_request(running_ctx)
+        result = self.manager.prepare_store(to_keys([200]), running_ctx)
+
+        assert result is not None, (
+            "running request's offload store was starved by speculative "
+            "promotions for queued requests that were never scheduled "
+            "(issue #49902)"
+        )
+
     def test_lookup_reports_sync_delay_for_resolved_lookups(self, manager_setup):
         """Resolved lookups report one sync delay sample on allocation."""
         self._start_request()

--- a/vllm/v1/kv_offload/cpu/manager.py
+++ b/vllm/v1/kv_offload/cpu/manager.py
@@ -84,6 +84,10 @@ class CPUOffloadingManager(OffloadingManager):
     def _get_num_free_blocks(self) -> int:
         return len(self._free_list) + self._num_blocks - self._num_allocated_blocks
 
+    def get_num_allocatable_blocks(self) -> int:
+        """Blocks a store could take right now: free plus evictable ones."""
+        return self._get_num_free_blocks() + self._num_evictable_cache_blocks
+
     def _allocate_blocks(self, keys: list[OffloadKey]) -> list[BlockStatus]:
         num_fresh = min(len(keys), self._num_blocks - self._num_allocated_blocks)
         num_reused = len(keys) - num_fresh

--- a/vllm/v1/kv_offload/tiering/manager.py
+++ b/vllm/v1/kv_offload/tiering/manager.py
@@ -56,11 +56,13 @@ from vllm.v1.kv_offload.tiering.base import (
 
 logger = init_logger(__name__)
 
-# Primary blocks kept out of reach of in-flight promotions, as headroom for
-# GPU->primary offloads of requests that are actually running. The primary tier
-# serves both through the same allocator, so without a reserve the promotions
-# of a deep waiting queue can make real offloads fail to allocate.
-PROMOTION_HEADROOM_BLOCKS = 1
+# Lower bound on the primary blocks kept out of reach of in-flight promotions,
+# used until a GPU->primary store has been seen. The primary tier serves
+# promotions and stores through the same allocator, so without a reserve the
+# promotions of a deep waiting queue can make real offloads fail to allocate.
+# prepare_store() is all-or-nothing over a whole batch of keys, so the reserve
+# grows to the largest batch observed (see _store_headroom_blocks).
+MIN_PROMOTION_HEADROOM_BLOCKS = 1
 
 
 @dataclass
@@ -214,10 +216,12 @@ class TieringOffloadingManager(OffloadingManager):
         self._processed_jobs_this_step: bool = False
 
         # Primary blocks reserved by promotions that have not completed yet.
-        # Used to keep speculative promotions from claiming the last of the
-        # pool while still letting a request promote into an empty one
-        # (see _promotion_budget_exhausted).
         self._num_inflight_promotion_blocks: int = 0
+
+        # Largest GPU->primary store batch seen so far. prepare_store() is
+        # all-or-nothing, so this is how much room a running request may need
+        # in one call, and hence how much promotions must leave free.
+        self._max_store_batch_blocks: int = 0
 
         # Per-request state for prepared GPU->primary stores and finalization.
         # Secondary tiers are finalized only after pending primary stores reach
@@ -443,22 +447,41 @@ class TieringOffloadingManager(OffloadingManager):
         entry.block_ids.extend(store_spec.block_ids)
         return True
 
+    def _store_headroom_blocks(self) -> int:
+        """Blocks to keep available for one GPU->primary store call.
+
+        Capped at half the pool so a large store batch cannot reserve so much
+        that promotions stop happening altogether on a small primary tier.
+        """
+        headroom = max(self._max_store_batch_blocks, MIN_PROMOTION_HEADROOM_BLOCKS)
+        return min(headroom, max(self.primary_tier._num_blocks // 2, 1))
+
     def _promotion_budget_exhausted(self) -> bool:
-        """Whether a promotion would eat into the store headroom.
+        """Whether promoting one more block would eat into the store headroom.
 
         The scheduler looks up every queued request before deciding which ones
         it admits, so without a reserve the promotions of a deep waiting queue
         can claim the whole primary tier for requests that never run this step,
-        starving offloads of the requests that do. Promotions are speculative,
-        so they yield the last blocks; a request whose prefix misses here simply
-        recomputes it.
+        starving the offloads of the requests that do. Promotions are
+        speculative, so they yield: a prefix that misses here is recomputed,
+        whereas a store that cannot allocate drops KV that was already
+        computed.
         """
-        if self._num_inflight_promotion_blocks == 0:
-            # Never block the first promotion: a request must be able to make
-            # progress even when the pool is otherwise fully committed.
-            return False
+        headroom = self._store_headroom_blocks()
+
+        # Never let promotions alone occupy the room a store batch needs, even
+        # when the pool is otherwise empty.
+        budget = max(self.primary_tier._num_blocks - headroom, 1)
+        if self._num_inflight_promotion_blocks >= budget:
+            return True
+
+        # Blocks held by running requests are not the promotions' doing, so
+        # only yield once this promotion would itself consume the last of the
+        # room a store batch needs.
         allocatable = self.primary_tier.get_num_allocatable_blocks()
-        return allocatable <= PROMOTION_HEADROOM_BLOCKS
+        return (
+            self._num_inflight_promotion_blocks > 0 and allocatable - 1 < headroom
+        )
 
     def _flush_pending_promotions(self) -> None:
         """Submit one batched submit_load() per (tier, request).
@@ -566,6 +589,11 @@ class TieringOffloadingManager(OffloadingManager):
         #    making it evictable for the first time.
         # Both must be accounted for before the eviction decision below.
         self._maybe_process_finished_jobs()
+
+        # Remember how much room a store call asks for, so promotions leave
+        # that much free. Recorded before the attempt below, so a store that
+        # fails to allocate still widens the reserve that protects the next one.
+        self._max_store_batch_blocks = max(self._max_store_batch_blocks, len(keys))
 
         # Step 2: Store to primary tier (new blocks only).
         # Cascading of these newly-stored blocks to ALL secondary tiers

--- a/vllm/v1/kv_offload/tiering/manager.py
+++ b/vllm/v1/kv_offload/tiering/manager.py
@@ -56,6 +56,12 @@ from vllm.v1.kv_offload.tiering.base import (
 
 logger = init_logger(__name__)
 
+# Primary blocks kept out of reach of in-flight promotions, as headroom for
+# GPU->primary offloads of requests that are actually running. The primary tier
+# serves both through the same allocator, so without a reserve the promotions
+# of a deep waiting queue can make real offloads fail to allocate.
+PROMOTION_HEADROOM_BLOCKS = 1
+
 
 @dataclass
 class PendingPromotion:
@@ -207,6 +213,12 @@ class TieringOffloadingManager(OffloadingManager):
         # Reset at the end of each step in on_schedule_end().
         self._processed_jobs_this_step: bool = False
 
+        # Primary blocks reserved by promotions that have not completed yet.
+        # Used to keep speculative promotions from claiming the last of the
+        # pool while still letting a request promote into an empty one
+        # (see _promotion_budget_exhausted).
+        self._num_inflight_promotion_blocks: int = 0
+
         # Per-request state for prepared GPU->primary stores and finalization.
         # Secondary tiers are finalized only after pending primary stores reach
         # complete_store(), since complete_store() can still submit cascades.
@@ -264,6 +276,8 @@ class TieringOffloadingManager(OffloadingManager):
                 if job_metadata.is_promotion:
                     # secondary→primary transfer (promotion) completed.
                     # Make blocks available in primary tier.
+                    self._num_inflight_promotion_blocks -= len(job_metadata.keys)
+                    assert self._num_inflight_promotion_blocks >= 0
                     self.primary_tier.complete_write(
                         job_metadata.keys,
                         job_metadata.req_context,
@@ -394,8 +408,13 @@ class TieringOffloadingManager(OffloadingManager):
             req_context: Per-request context forwarded to primary.prepare_write().
 
         Returns:
-            True if promotion was initiated, False if primary tier is full.
+            True if promotion was initiated, False if the promotion budget is
+            exhausted or the primary tier is full.
         """
+        if self._promotion_budget_exhausted():
+            # Leave the rest of the pool for offloads of running requests.
+            return False
+
         # Allocate space in primary tier for promoted block.
         # Must happen immediately so primary.lookup() returns None (in-flight)
         # for this key on any subsequent lookup() call within the same step,
@@ -406,6 +425,8 @@ class TieringOffloadingManager(OffloadingManager):
             # Primary tier is full; caller should treat the block as unavailable
             # rather than retrying indefinitely.
             return False
+
+        self._num_inflight_promotion_blocks += len(primary_write_result.keys_to_store)
 
         store_spec = primary_write_result.store_spec
         assert isinstance(store_spec, CPULoadStoreSpec)
@@ -421,6 +442,23 @@ class TieringOffloadingManager(OffloadingManager):
         entry.keys.extend(primary_write_result.keys_to_store)
         entry.block_ids.extend(store_spec.block_ids)
         return True
+
+    def _promotion_budget_exhausted(self) -> bool:
+        """Whether a promotion would eat into the store headroom.
+
+        The scheduler looks up every queued request before deciding which ones
+        it admits, so without a reserve the promotions of a deep waiting queue
+        can claim the whole primary tier for requests that never run this step,
+        starving offloads of the requests that do. Promotions are speculative,
+        so they yield the last blocks; a request whose prefix misses here simply
+        recomputes it.
+        """
+        if self._num_inflight_promotion_blocks == 0:
+            # Never block the first promotion: a request must be able to make
+            # progress even when the pool is otherwise fully committed.
+            return False
+        allocatable = self.primary_tier.get_num_allocatable_blocks()
+        return allocatable <= PROMOTION_HEADROOM_BLOCKS
 
     def _flush_pending_promotions(self) -> None:
         """Submit one batched submit_load() per (tier, request).
@@ -796,6 +834,9 @@ class TieringOffloadingManager(OffloadingManager):
         # reset below invalidates; their submit_load() has not yet been
         # called so no tier I/O is touching that memory.
         self._pending_load_submissions.clear()
+        # Those reservations will never reach complete_write(), so drop their
+        # share of the promotion budget along with the slots themselves.
+        self._num_inflight_promotion_blocks = 0
 
         finished_req_ids = []
         for req_id, state in self._req_state.items():


### PR DESCRIPTION
## Purpose

Fixes #49902. With tiered KV offload, promotions from a secondary tier could claim every block of the primary (CPU/DRAM) pool on behalf of requests that were still queued, so offloads of the requests actually running failed to allocate. This adds a small headroom reserve so speculative promotions yield the last blocks.

## Root cause

`OffloadingConnectorScheduler` calls `lookup()` from the scheduler's **waiting** loop, once per queued request. A request whose lookup defers is skipped with `continue` (not `break`), so a single `schedule()` pass walks the whole waiting queue and issues a promotion for every secondary-tier hit — roughly 175 lines before `allocate_slots()` decides which of those requests is actually admitted this step. Each promotion reserves a primary block immediately (`prepare_write` → `ref_cnt = -1`) so that subsequent lookups in the same step see it in flight.

The primary tier serves promotions and GPU→CPU offloads through the *same* allocator (`prepare_write` is `prepare_store`), and nothing reserved capacity for the latter. With a deep queue the pool ends up fully committed to requests that never run, and a running request's `prepare_store` returns `None` (`ALLOCATION_FAILURE`). Separately, once a promotion completes, `complete_store` marks the block evictable before the promoting request has been scheduled, and `evict()` only protects the keys of the *current* store call — so promoted-but-unused blocks get evicted and re-promoted on later steps.

### Note on the report's proposed mechanism

The issue hypothesised that the pool is left permanently with no free blocks. That part does not hold: `prepare_store` refuses to over-subscribe (`num_blocks_to_evict > _num_evictable_cache_blocks → None`), so a saturated pool degrades a promotion to a cache `MISS` rather than deadlocking. The defect is the absence of *back-pressure* — promotions are admitted until the pool is exhausted, which starves concurrent stores and burns secondary-tier read bandwidth on promotions that get evicted before use. The observed symptom (thrash under queue depth + memory pressure) is the same.

## Fix

- `CPUOffloadingManager.get_num_allocatable_blocks()` — blocks a store could take right now (free + evictable), mirroring the allocator's own arithmetic.
- `TieringOffloadingManager._store_headroom_blocks()` — how much room to keep for one store call: the largest GPU→primary store batch seen so far, since `prepare_store()` is all-or-nothing over a batch. Recorded before the allocation attempt, so a store that fails to allocate still widens the reserve protecting the next one. There is no static bound on the batch size (it depends on tokens per step, KV cache groups and chunk size), so it is learned rather than a constant, and capped at half the pool so a large batch cannot stop promotions altogether on a small primary tier.
- `TieringOffloadingManager._promotion_budget_exhausted()` — refuse a promotion when in-flight promotions already hold everything outside that reserve, or when this promotion would itself consume the last of it. Both conditions are needed: bounding only the promotions' own footprint lets them take whatever the pool has left, while requiring free space outright would block promotion whenever the pool is merely busy with in-flight cascades. Promotions are the right side to yield — a refused lookup is a cache miss whose prefix is recomputed, whereas a store that cannot allocate drops KV that was already computed.
- `_num_inflight_promotion_blocks` tracks reserved-but-incomplete promotion blocks: incremented in `_initiate_promotion`, decremented when the promotion job completes, and zeroed in `reset_cache()` (which drops deferred submissions whose `submit_load()` never fired, so those reservations would otherwise leak).

## Testing

```
pytest -q tests/v1/kv_offload/
# 434 passed in 535.10s
```

Two regression tests, both driving the real call order (one `lookup()` per queued request, as `schedule()` does, then a running request's `prepare_store`):

- `test_speculative_promotions_do_not_starve_running_stores` — a single-block store must still allocate. Fails on unpatched code with `AssertionError: running request's offload store was starved by speculative promotions for queued requests that were never scheduled (issue #49902)`.
- `test_promotions_leave_room_for_batched_stores` — a multi-key store must still allocate, since `prepare_store()` is all-or-nothing over the batch.

Mutation-checked, so neither test is vacuously green:

- Disabling the reserve fails both tests.
- Keeping the reserve but ignoring the observed batch size fails only the batched-store test, so the sizing is independently covered.

`pre-commit run --files ...` clean (ruff, ruff-format, mypy, SPDX).

Earlier iterations of the reserve were caught by the existing suite, which is why it ended up as it is: capping promotions at a fraction of the pool wrongly refused a single request's legitimate multi-block promotion, and requiring free space outright blocked promotion whenever the pool was merely busy with in-flight cascades.

## Not a duplicate

No other open PR addresses #49902 — it has no other linked PR, and no open PR touches promotion admission or the primary-tier reserve in `vllm/v1/kv_offload/tiering/manager.py`. The other in-flight KV-offload PRs are orthogonal: #49889 (abort mid-transfer) and #49947 (job completion during cleanup) concern transfer-job lifecycle rather than whether a promotion is admitted, and #41790 / #49307 (metrics), #45693 (hugepages), #48436 (block rounding) and #49644 (disk offloading) are unrelated areas.

## Model evaluation

N/A — no change to model outputs or sampling. The change affects only admission of speculative KV-offload promotions; a refused promotion is a cache miss whose tokens are recomputed.

## AI assistance

AI assistance (Claude Code) was used to trace the promotion path, write the regression test, and draft this description. I reviewed every changed line, ran the tests and the mutation check myself, and verified the results above.
