### PR TITLE
Support Voxtral audio generation in the Transformers backend

### DIFF
--- a/tests/models/multimodal/generation/test_transformers_audio.py
+++ b/tests/models/multimodal/generation/test_transformers_audio.py
@@ -40,6 +40,9 @@ AUDIO_MODEL_SETTINGS: dict[str, dict[str, Any]] = {
             "gpu_memory_utilization": 0.85,
         },
     },
+    "mistralai/Voxtral-Mini-3B-2507": {
+        "prompt": ("[INST][AUDIO]What can you tell me about this audio?[/INST]"),
+    },
     "microsoft/VibeVoice-ASR-HF": {
         "prompt": (
             "<|im_start|>system\n"

--- a/tests/models/multimodal/processing/test_transformers_audio.py
+++ b/tests/models/multimodal/processing/test_transformers_audio.py
@@ -58,18 +58,7 @@ AUDIO_MODEL_SETTINGS = {
     [
         "ibm-granite/granite-speech-3.3-2b",
         "nvidia/audio-flamingo-3-hf",
-        pytest.param(
-            "mistralai/Voxtral-Mini-3B-2507",
-            marks=pytest.mark.xfail(
-                reason="MistralCommonBackend.encode does not produce the audio "
-                "placeholder token (ID 24) from raw text. apply_chat_template "
-                "yields token IDs with placeholders, but MultiModalProcessor."
-                "apply() decodes the prompt back to text and re-tokenizes, at "
-                "which point the placeholders are lost. Fix belongs in "
-                "mistral_common or in the Voxtral-specific path.",
-                strict=False,
-            ),
-        ),
+        "mistralai/Voxtral-Mini-3B-2507",
         "microsoft/VibeVoice-ASR-HF",
         "zai-org/GLM-ASR-Nano-2512",
     ],

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -560,6 +560,10 @@ class ModelConfig:
         ):
             raise ValueError("cumem allocator is not supported on current platform.")
 
+        # The Transformers backend needs the HF config, not Mistral's params.json
+        if self.model_impl == "transformers" and self.config_format == "auto":
+            self.config_format = "hf"
+
         hf_config = get_config(
             self.hf_config_path or self.model,
             self.trust_remote_code,

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -560,7 +560,7 @@ class ModelConfig:
         ):
             raise ValueError("cumem allocator is not supported on current platform.")
 
-        # The Transformers backend needs the HF config, not Mistral's params.json
+        # AutoModel.from_config resolves by class, needs typed HF config not params.json
         if self.model_impl == "transformers" and self.config_format == "auto":
             self.config_format = "hf"
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2080,6 +2080,13 @@ class VllmConfig:
                     f"Model: {self.model_config.model}"
                 )
 
+        # The Transformers backend needs HF weights, not Mistral's consolidated
+        if (
+            self.model_config.model_impl == "transformers"
+            and self.load_config.load_format == "auto"
+        ):
+            self.load_config.load_format = "hf"
+
     def compile_debug_dump_path(self) -> Path | None:
         """Returns a rank-aware path for dumping
         torch.compile debug information.

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2080,7 +2080,7 @@ class VllmConfig:
                     f"Model: {self.model_config.model}"
                 )
 
-        # The Transformers backend needs HF weights, not Mistral's consolidated
+        # Mistral's consolidated weight names don't map to HF modules; use HF weights
         if (
             self.model_config.model_impl == "transformers"
             and self.load_config.load_format == "auto"

--- a/vllm/multimodal/processing/context.py
+++ b/vllm/multimodal/processing/context.py
@@ -195,17 +195,21 @@ class InputProcessingContext:
 
             typ = ProcessorMixin
 
-        tokenizer = self.tokenizer
-        if is_mistral_tokenizer(tokenizer):
-            tokenizer = tokenizer.transformers_tokenizer  # type: ignore[union-attr]
+        from transformers import MistralCommonBackend
 
+        tokenizer = self.tokenizer
         merged_kwargs = self.get_merged_mm_kwargs(kwargs)
         merged_kwargs.pop("tokenizer", None)
+
+        # `MistralCommonBackend` rejects a forwarded `tokenizer` kwarg
+        if not is_mistral_tokenizer(tokenizer) and not isinstance(
+            tokenizer, MistralCommonBackend
+        ):
+            merged_kwargs["tokenizer"] = tokenizer
 
         return cached_processor_from_config(
             self.model_config,
             processor_cls=typ,
-            tokenizer=tokenizer,
             **merged_kwargs,
         )
 


### PR DESCRIPTION
### What does this PR do?

→ [Blocked by the companion Transformers PR](https://github.com/huggingface/transformers/pull/47588) making `VoxtralProcessor.__call__` audio-capable.
→ Enables Voxtral audio generation through the Transformers backend (`--model-impl transformers`) currently <ins>XFAILed</ins>. Stops forwarding `tokenizer` to `MistralCommonBackend` (rejects the kwarg), and forces the HF config and weights (not Mistral's `params.json` / consolidated) when the backend is explicitly requested. 
→ <ins>Verified no regressions on the vLLM-side</ins> with `tests/models/multimodal/processing/test_transformers_audio.py` (Voxtral un-XFAILed) and `tests/models/multimodal/generation/test_transformers_audio.py` (Voxtral added, matches HF via `check_logprobs_close`); full audio suite green.
→ I've tried to explain why each non-trivial change was made in a one-line comment given much of this involved unwrapping failure modes layer by layer and uncovering deeper issues in the call chain :)

cc: @hmellor

**Before (vLLM Voxtral Generation)**

<img src="https://github.com/user-attachments/assets/1b4c6223-e079-4d03-b661-596721d1be86" /><br>

**After (vLLM Voxtral Generation)**

<img src="https://github.com/user-attachments/assets/3fdb3f56-5f70-453b-9e3c-c59ea4a0417b" /><br>

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary><br>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>