### PR TITLE
[ROCm][CI] Handle transformers 5.15 gemma4 schema

### DIFF
--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -209,19 +209,31 @@ class Gemma4Config(VerifyAndUpdateConfig):
         uniform kernel path and avoiding the mixed FA3+FA4 penalty.
         When FA4 is not available we fall back to Triton.
         """
-        hf_text_config = vllm_config.model_config.hf_text_config
-        head_dim = getattr(hf_text_config, "head_dim", None)
-        global_head_dim = getattr(hf_text_config, "global_head_dim", None)
+        from vllm.transformers_utils.config import get_gemma4_head_dim_range
 
-        if head_dim is None or global_head_dim is None or head_dim == global_head_dim:
+        hf_config = vllm_config.model_config.hf_config
+        hf_text_config = vllm_config.model_config.hf_text_config
+
+        # transformers 5.15+ makes Gemma4's per-layer head_dim raise when read
+        # globally (e.g. via the config's bugged auto-generated __eq__), which breaks
+        # later config comparisons at model-load time. vLLM handles the
+        # heterogeneous head dims explicitly (see gemma4_head_dim /
+        # get_gemma4_head_dim_range), so opt into global access on both the
+        # top-level and text configs to avoid the __eq__ bug.
+        # TODO remove when fixed on transformers side.
+        for cfg in (hf_config, hf_text_config):
+            if getattr(cfg, "is_heterogeneous", False):
+                cfg.allow_global_per_layer_attribute_access = True
+
+        min_dim, max_dim = get_gemma4_head_dim_range(hf_text_config)
+
+        if not min_dim or not max_dim or min_dim == max_dim:
             return
 
         from vllm.v1.attention.backends.fa_utils import is_fa_version_supported
         from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
-        max_head_dim = max(head_dim, global_head_dim)
-
-        if is_fa_version_supported(4) and max_head_dim <= 512:
+        if is_fa_version_supported(4) and max_dim <= 512:
             if (
                 vllm_config.attention_config.flash_attn_version is None
                 and vllm_config.attention_config.backend
@@ -232,8 +244,8 @@ class Gemma4Config(VerifyAndUpdateConfig):
                     "Gemma4 model has heterogeneous head dimensions "
                     "(head_dim=%d, global_head_dim=%d). Using FA4 for "
                     "all layers to avoid mixed FA3/FA4 penalty.",
-                    head_dim,
-                    global_head_dim,
+                    min_dim,
+                    max_dim,
                 )
         elif vllm_config.attention_config.backend is None:
             vllm_config.attention_config.backend = AttentionBackendEnum.TRITON_ATTN
@@ -241,8 +253,8 @@ class Gemma4Config(VerifyAndUpdateConfig):
                 "Gemma4 model has heterogeneous head dimensions "
                 "(head_dim=%d, global_head_dim=%d). FA4 not available, "
                 "forcing TRITON_ATTN backend.",
-                head_dim,
-                global_head_dim,
+                min_dim,
+                max_dim,
             )
 
 

--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -84,6 +84,21 @@ from .utils import (
 
 logger = init_logger(__name__)
 
+
+def gemma4_head_dim(config, layer_idx: int) -> int:
+    """Handles both the transformers <=5.14 schema (two named global
+    scalars: head_dim/global_head_dim) and the transformers >=5.15 schema
+    (head_dim lives in per_layer_config).
+    The schema is detected via ``is_heterogeneous`` so the result is independent of
+    whether global per-layer attribute access has been enabled on the config.
+    """
+    if getattr(config, "is_heterogeneous", False):
+        return config.per_layer_config[layer_idx].head_dim
+    is_full = config.layer_types[layer_idx] == "full_attention"
+    head_dim = config.head_dim
+    return getattr(config, "global_head_dim", head_dim) if is_full else head_dim
+
+
 _GEMMA4_EXPERT_PARENT_MAPPER = WeightsMapper(
     orig_to_new_regex={
         re.compile(r"(?<!\.moe)\.experts$"): ".moe.experts",
@@ -572,10 +587,7 @@ class Gemma4DecoderLayer(nn.Module):
         # Gemma4 uses different head dimensions for sliding vs full attention
         layer_type = config.layer_types[layer_idx]
         self.is_full_attention = layer_type == "full_attention"
-        if self.is_full_attention:
-            head_dim = getattr(config, "global_head_dim", config.head_dim)
-        else:
-            head_dim = config.head_dim
+        head_dim = gemma4_head_dim(config, layer_idx)
 
         # Determine if this full-attention layer uses k_eq_v
         # (laptop variant: no v_proj, K reused as V on full attention layers)

--- a/vllm/model_executor/models/gemma4_dspark.py
+++ b/vllm/model_executor/models/gemma4_dspark.py
@@ -21,6 +21,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 )
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 
+from .gemma4 import gemma4_head_dim
 from .gemma4_mtp import Gemma4MTPAttention, Gemma4MTPDecoderLayer
 from .qwen3_dflash import DFlashQwen3Model
 from .qwen3_dspark import DSparkMarkovHead, Qwen3DSparkForCausalLM
@@ -37,12 +38,9 @@ class Gemma4DSparkAttention(Gemma4MTPAttention):
         quant_config: QuantizationConfig | None,
         prefix: str,
     ) -> None:
-        is_full = config.layer_types[extract_layer_index(prefix)] == "full_attention"
-        head_dim = (
-            getattr(config, "global_head_dim", config.head_dim)
-            if is_full
-            else config.head_dim
-        )
+        layer_idx = extract_layer_index(prefix)
+        is_full = config.layer_types[layer_idx] == "full_attention"
+        head_dim = gemma4_head_dim(config, layer_idx)
         use_k_eq_v = is_full and getattr(config, "attention_k_eq_v", False)
         num_kv_heads = (
             getattr(config, "num_global_key_value_heads", config.num_key_value_heads)

--- a/vllm/model_executor/models/gemma4_mtp.py
+++ b/vllm/model_executor/models/gemma4_mtp.py
@@ -46,7 +46,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 )
 from vllm.sequence import IntermediateTensors
 
-from .gemma4 import Gemma4MLP, _get_text_config
+from .gemma4 import Gemma4MLP, _get_text_config, gemma4_head_dim
 from .utils import (
     AutoWeightsLoader,
     WeightsMapper,
@@ -273,11 +273,7 @@ class Gemma4MTPDecoderLayer(nn.Module):
         layer_idx = extract_layer_index(prefix)
         layer_type = config.layer_types[layer_idx]
         is_full_attention = layer_type == "full_attention"
-        head_dim = (
-            getattr(config, "global_head_dim", config.head_dim)
-            if is_full_attention
-            else config.head_dim
-        )
+        head_dim = gemma4_head_dim(config, layer_idx)
 
         use_k_eq_v = is_full_attention and getattr(config, "attention_k_eq_v", False)
         if use_k_eq_v:

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -59,6 +59,24 @@ if Version(version("transformers")) < Version("5.0.0"):
     )
 
 
+def get_gemma4_head_dim_range(config: PretrainedConfig) -> tuple[int, int]:
+    """Handles both the transformers <=5.14 schema (two named global
+    scalars: head_dim/global_head_dim) and the transformers >=5.15 schema
+    (head_dim lives in per_layer_config).
+    The schema is detected via ``is_heterogeneous`` so the result is independent of
+    whether global per-layer attribute access has been enabled on the config.
+    """
+    if getattr(config, "is_heterogeneous", False):
+        num_layers = getattr(config, "num_hidden_layers", 0)
+        dims = [config.per_layer_config[i].head_dim for i in range(num_layers)]
+        return (min(dims), max(dims)) if dims else (0, 0)
+    head_dim = getattr(config, "head_dim", 0) or 0
+    global_head_dim = getattr(config, "global_head_dim", 0) or 0
+    min_head_dim = min(head_dim, global_head_dim) if global_head_dim else head_dim
+    max_head_dim = max(head_dim, global_head_dim)
+    return (min_head_dim, max_head_dim)
+
+
 class LazyConfigDict(dict):
     def __getitem__(self, key):
         if isinstance(value := super().__getitem__(key), type):

--- a/vllm/transformers_utils/model_arch_config_convertor.py
+++ b/vllm/transformers_utils/model_arch_config_convertor.py
@@ -15,6 +15,7 @@ from vllm.config.utils import getattr_iter
 from vllm.logger import init_logger
 from vllm.transformers_utils.config import (
     ConfigFormat,
+    get_gemma4_head_dim_range,
     get_safetensors_params_metadata,
 )
 from vllm.utils.torch_utils import common_broadcastable_dtype
@@ -590,6 +591,11 @@ class Gemma4MTPModelArchConfigConvertor(ModelArchConfigConvertorBase):
     def get_num_hidden_layers(self) -> int:
         return getattr(self.hf_text_config, "num_hidden_layers", 0)
 
+    def get_head_size(self) -> int:
+        return get_gemma4_head_dim_range(self.hf_text_config)[1] or (
+            super().get_head_size()
+        )
+
 
 class Gemma4ModelArchConfigConvertor(ModelArchConfigConvertorBase):
     def is_mm_prefix_lm(self, supports_multimodal: bool = True) -> bool:
@@ -604,9 +610,9 @@ class Gemma4ModelArchConfigConvertor(ModelArchConfigConvertorBase):
         # Gemma4 uses dual head dimensions: head_dim (sliding attention)
         # and global_head_dim (full attention).  Return the largest so
         # that attention backends allocate buffers large enough for both.
-        head_dim = getattr(self.hf_text_config, "head_dim", 0)
-        global_head_dim = getattr(self.hf_text_config, "global_head_dim", 0)
-        return max(head_dim, global_head_dim) or super().get_head_size()
+        return get_gemma4_head_dim_range(self.hf_text_config)[1] or (
+            super().get_head_size()
+        )
 
 
 class MossAudioModelArchConfigConvertor(ModelArchConfigConvertorBase):


### PR DESCRIPTION
## Purpose
The following TGs fail all tests that use Gemma4 on CI:
- Transformers Nightly Models (Initialization) 
- Transformers Nightly Models (Processing) 

Both TGs upgrade the transformers package before running the tests( from .buildkite/test-amd.yaml):
```
commands:
  - pip install --upgrade git+https://github.com/huggingface/transformers
  - pytest -v -s tests/models/test_initialization.py --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
```
Transformers get upgraded to version `transformers-5.15.0.dev0` where Gemma4 switches to using a per-layer stored head_dim instead of using the global head_dim/global_head_dim scalars, which leads to Gemma4 tests failing with the following error:
```
raise AmbiguousGlobalPerLayerAttributeError(
transformers.integrations.heterogeneity.configuration_utils.AmbiguousGlobalPerLayerAttributeError: 
'head_dim' is a per-layer attribute and may vary across layers. Access it via the individual layer configs instead (e.g. config.per_layer_config[i].head_dim). 
To read the global config value from config.head_dim anyway, set `allow_global_per_layer_attribute_access` to `True` on the config. 
Warning: only do this if the caller can safely handle heterogeneous configs; code that assumes a homogeneous model may use the global value incorrectly.
```
In addition, the attribute global_head_dim is removed.

The PR updates Gemma4 config handling to handle both the new and old schemas. 
There is a bug in the `__eq__` method of `Gemma4TextConfig` in transformers (it tries to access the global head_size which raises the previously mentioned error), so enabling `allow_global_per_layer_attribute_access` in `Gemma4Config` in vllm is a workaround until it's fixed on the transformers end.
## Test Plan
```
pip install --upgrade git+https://github.com/huggingface/transformers
pytest -s -v "tests/models/multimodal/processing/test_gemma4.py::test_compute_num_soft_tokens_does_not_exceed_max_soft_tokens[google/gemma-4-E2B-it-3-900-280]" \
"tests/models/multimodal/processing/test_gemma4.py::test_get_mm_max_tokens_per_item_respects_configured_max_soft_tokens[google/gemma-4-E2B-it-mm_processor_kwargs1-70]" \
"tests/models/multimodal/processing/test_gemma4.py::test_get_mm_max_tokens_per_item_respects_configured_max_soft_tokens[google/gemma-4-E2B-it-mm_processor_kwargs5-280]" \
"tests/models/multimodal/processing/test_gemma4.py::test_get_mm_max_tokens_per_item_respects_configured_video_num_frames[google/gemma-4-E2B-it-limit_mm_per_prompt1-2496]" \
"tests/models/multimodal/processing/test_gemma4.py::test_get_mm_max_tokens_per_item_respects_configured_video_num_frames[google/gemma-4-E2B-it-limit_mm_per_prompt4-2496]" \
"tests/models/multimodal/processing/test_common.py::test_processing_correctness[1.0-32-0.3-google/gemma-4-E2B-it]" \
"tests/models/multimodal/processing/test_gemma4.py::test_compute_num_soft_tokens_does_not_exceed_max_soft_tokens[google/gemma-4-E2B-it-900-3-280]" \
"tests/models/multimodal/processing/test_gemma4.py::test_get_mm_max_tokens_per_item_respects_configured_max_soft_tokens[google/gemma-4-E2B-it-mm_processor_kwargs2-280]" \
"tests/models/multimodal/processing/test_gemma4.py::test_get_mm_max_tokens_per_item_respects_configured_video_num_frames[google/gemma-4-E2B-it-limit_mm_per_prompt3-624]" \
"tests/models/multimodal/processing/test_tensor_schema.py::test_model_tensor_schema[google/gemma-4-E2B-it]" \
"tests/models/multimodal/processing/test_common.py::test_processing_correctness[1.0-32-0.5-google/gemma-4-E2B-it]" \
"tests/models/multimodal/processing/test_common.py::test_processing_correctness[1.0-32-1.0-google/gemma-4-E2B-it]" \
"tests/models/multimodal/processing/test_gemma4.py::test_compute_num_soft_tokens_does_not_exceed_max_soft_tokens[google/gemma-4-E2B-it-900-3-70]" \
"tests/models/multimodal/processing/test_gemma4.py::test_get_mm_max_tokens_per_item_respects_configured_max_soft_tokens[google/gemma-4-E2B-it-mm_processor_kwargs0-280]" \
"tests/models/multimodal/processing/test_gemma4.py::test_get_mm_max_tokens_per_item_respects_configured_max_soft_tokens[google/gemma-4-E2B-it-mm_processor_kwargs4-560]" \
"tests/models/multimodal/processing/test_gemma4.py::test_get_mm_max_tokens_per_item_respects_configured_video_num_frames[google/gemma-4-E2B-it-limit_mm_per_prompt0-2496]" \
"tests/models/multimodal/processing/test_gemma4.py::test_get_mm_max_tokens_per_item_respects_configured_video_num_frames[google/gemma-4-E2B-it-limit_mm_per_prompt2-78]" \
"tests/models/multimodal/processing/test_gemma4.py::test_get_mm_max_tokens_per_item_respects_configured_video_num_frames[google/gemma-4-E2B-it-limit_mm_per_prompt5-2496]" \
"tests/models/multimodal/processing/test_gemma4.py::test_get_prompt_updates_respects_nested_max_soft_tokens[google/gemma-4-E2B-it]" \
"tests/models/multimodal/processing/test_gemma4.py::test_limit_mm_per_prompt[google/gemma-4-E2B-it]" \
"tests/models/multimodal/processing/test_gemma4.py::test_compute_num_soft_tokens_does_not_exceed_max_soft_tokens[google/gemma-4-E2B-it-4000-2-1120]" \
"tests/models/multimodal/processing/test_gemma4.py::test_get_mm_max_tokens_per_item_respects_configured_max_soft_tokens[google/gemma-4-E2B-it-mm_processor_kwargs3-1120]" \
"tests/models/multimodal/processing/test_gemma4.py::test_get_mm_max_tokens_per_item_respects_configured_max_soft_tokens[google/gemma-4-E2B-it-mm_processor_kwargs6-280]"
```
```
pip install --upgrade git+https://github.com/huggingface/transformers
pytest -s -v "tests/models/test_initialization.py::test_can_initialize_large_subset[Gemma4ForCausalLM]" \
"tests/models/test_initialization.py::test_can_initialize_large_subset[Gemma4ForConditionalGeneration]" \
"tests/models/test_initialization.py::test_can_initialize_large_subset[Gemma4MTPModel]"
```
## Test Result
Previously all tests failed while raising the aforementioned AmbiguousGlobalPerLayerAttributeError. 
With the fix, all tests pass.
