### PR TITLE
[Bugfix][KV Offload] Fix hybrid DCP block geometry

### DIFF
--- a/tests/v1/simple_kv_offload/test_scheduler.py
+++ b/tests/v1/simple_kv_offload/test_scheduler.py
@@ -39,6 +39,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheTensor,
+    MambaSpec,
 )
 from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import Request
@@ -1580,6 +1581,90 @@ def _make_cp_scheduler(
         vllm_config=vllm_config,
         kv_cache_config=kv_cache_config,
     )
+
+
+def _make_hybrid_dcp_scheduler() -> SchedulerFixture:
+    num_gpu_blocks = 16
+    full = FullAttentionSpec(
+        block_size=BLOCK_SIZE,
+        num_kv_heads=NUM_KV_HEADS,
+        head_size=HEAD_SIZE,
+        dtype=DTYPE,
+    )
+    mamba = MambaSpec(
+        block_size=BLOCK_SIZE,
+        shapes=((1, 1),),
+        dtypes=(DTYPE,),
+        mamba_cache_mode="align",
+    )
+    groups = [
+        KVCacheGroupSpec(["full_layer"], full),
+        KVCacheGroupSpec(["mamba_layer"], mamba),
+    ]
+    tensors = [
+        KVCacheTensor(
+            size=spec.page_size_bytes * num_gpu_blocks,
+            shared_by=group.layer_names,
+        )
+        for group, spec in zip(groups, (full, mamba), strict=True)
+    ]
+    kv_cache_config = KVCacheConfig(
+        num_blocks=num_gpu_blocks,
+        kv_cache_tensors=tensors,
+        kv_cache_groups=groups,
+    )
+    vllm_config = _make_cp_vllm_config(dcp_world_size=2)
+    bytes_per_block = sum(t.size for t in tensors) // num_gpu_blocks
+    sched = SimpleCPUOffloadScheduler(
+        vllm_config=vllm_config,
+        kv_cache_config=kv_cache_config,
+        cpu_capacity_bytes=bytes_per_block * 16,
+        scheduler_block_size=BLOCK_SIZE * 2,
+        hash_block_size=BLOCK_SIZE,
+        lazy_offload=False,
+    )
+    gpu_block_pool = BlockPool(
+        num_gpu_blocks=num_gpu_blocks,
+        enable_caching=True,
+        hash_block_size=BLOCK_SIZE,
+    )
+    sched.bind_gpu_block_pool(gpu_block_pool)
+    return SchedulerFixture(
+        scheduler=sched,
+        gpu_block_pool=gpu_block_pool,
+        vllm_config=vllm_config,
+        kv_cache_config=kv_cache_config,
+        num_groups=2,
+    )
+
+
+def test_hybrid_dcp_store_uses_unscaled_mamba_block_size() -> None:
+    fix = _make_hybrid_dcp_scheduler()
+    req = make_request(num_blocks=4)
+    req.num_computed_tokens = 4 * BLOCK_SIZE
+
+    full_blocks = fix.gpu_block_pool.get_new_blocks(2)
+    mamba_blocks = fix.gpu_block_pool.get_new_blocks(4)
+    for idx, block in enumerate(full_blocks):
+        block._block_hash = make_block_hash_with_group_id(
+            req.block_hashes[2 * idx + 1], 0
+        )
+    for idx, block in enumerate(mamba_blocks):
+        block._block_hash = make_block_hash_with_group_id(req.block_hashes[idx], 1)
+
+    blocks = KVCacheBlocks(blocks=(full_blocks, mamba_blocks))
+    fix.scheduler.update_state_after_alloc(req, blocks, num_external_tokens=0)
+    meta = fix.scheduler.build_connector_meta(
+        make_scheduler_output(
+            {req.request_id: 4 * BLOCK_SIZE},
+            new_reqs={req.request_id: blocks.get_block_ids()},
+        )
+    )
+
+    assert meta.store_gpu_blocks == [
+        *(block.block_id for block in full_blocks),
+        *(block.block_id for block in mamba_blocks),
+    ]
 
 
 def _make_cp_request(

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -19,7 +19,9 @@ from vllm.v1.core.kv_cache_coordinator import (
 )
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
     FullAttentionSpec,
+    KVCacheSpec,
     MambaSpec,
     SlidingWindowSpec,
 )
@@ -36,6 +38,10 @@ if TYPE_CHECKING:
     from vllm.v1.request import Request
 
 logger = init_logger(__name__)
+
+
+def _effective_group_block_size(spec: KVCacheSpec, dcp_world_size: int) -> int:
+    return spec.block_size * (dcp_world_size if isinstance(spec, AttentionSpec) else 1)
 
 
 @dataclass
@@ -84,11 +90,11 @@ class SimpleCPUOffloadScheduler:
         )
         dcp_world_size = vllm_config.parallel_config.decode_context_parallel_size
         self.cp_world_size = dcp_world_size
+        assert kv_cache_config is not None
         self.block_size = scheduler_block_size
         self.hash_block_size = hash_block_size
         assert self.block_size % self.hash_block_size == 0
         # Derive a CPU KVCacheConfig from the GPU config and build a coordinator
-        assert kv_cache_config is not None
         self.cpu_kv_cache_config = self._derive_cpu_config(
             kv_cache_config, cpu_capacity_bytes
         )
@@ -102,11 +108,9 @@ class SimpleCPUOffloadScheduler:
         assert 0 <= self.fa_gidx < len(self.cpu_kv_cache_config.kv_cache_groups)
         # FA group's own block_size; divides scheduler_block_size (the LCM)
         # but is NOT assumed to equal it.
-        self.fa_block_size: int = (
-            self.cpu_kv_cache_config.kv_cache_groups[
-                self.fa_gidx
-            ].kv_cache_spec.block_size
-            * self.cp_world_size
+        self.fa_block_size = _effective_group_block_size(
+            self.cpu_kv_cache_config.kv_cache_groups[self.fa_gidx].kv_cache_spec,
+            self.cp_world_size,
         )
         assert self.block_size % self.fa_block_size == 0
 
@@ -225,7 +229,7 @@ class SimpleCPUOffloadScheduler:
         target = 0
         for g in kv_cache_config.kv_cache_groups:
             spec = g.kv_cache_spec
-            block_size = spec.block_size * cp_world_size
+            block_size = _effective_group_block_size(spec, cp_world_size)
             if isinstance(spec, MambaSpec):
                 target += 2
             elif isinstance(spec, SlidingWindowSpec):
@@ -348,8 +352,8 @@ class SimpleCPUOffloadScheduler:
         # the rest will be released along with the temp pin below.
         cpu_hit_blocks: list[list[KVCacheBlock]] = []
         for g in range(num_groups):
-            g_block_size = (
-                kv_cache_groups[g].kv_cache_spec.block_size * self.cp_world_size
+            g_block_size = _effective_group_block_size(
+                kv_cache_groups[g].kv_cache_spec, self.cp_world_size
             )
             assert num_external_tokens % g_block_size == 0, (
                 f"num_external_tokens={num_external_tokens} not aligned to "
@@ -369,8 +373,8 @@ class SimpleCPUOffloadScheduler:
                 continue
 
             # Number of blocks in the computed range for this group.
-            g_block_size = (
-                kv_cache_groups[g].kv_cache_spec.block_size * self.cp_world_size
+            g_block_size = _effective_group_block_size(
+                kv_cache_groups[g].kv_cache_spec, self.cp_world_size
             )
             n_computed_g = cdiv(total_computed_tokens, g_block_size)
 
@@ -588,8 +592,8 @@ class SimpleCPUOffloadScheduler:
                 already_stored_g = state.num_stored_blocks[g]
                 group_gpu_ids = block_ids_by_group[g]
 
-                g_block_size = (
-                    kv_cache_groups[g].kv_cache_spec.block_size * self.cp_world_size
+                g_block_size = _effective_group_block_size(
+                    kv_cache_groups[g].kv_cache_spec, self.cp_world_size
                 )
                 ready_blocks_g = aligned_tokens // g_block_size
                 scannable = group_gpu_ids[already_stored_g:ready_blocks_g]


### PR DESCRIPTION

## Purpose

`SimpleCPUOffloadConnector` currently multiplies every cache group's block size by the decode context parallelism world size. This is correct for attention KV, which is sharded across DCP ranks, but Mamba state is replicated and keeps its original block size.

With 16 token attention and Mamba blocks under DCP=2, a confirmed 64 token prefix contains two effective attention blocks and four Mamba state blocks. The current store plan selects only two Mamba blocks because it treats each one as spanning 32 tokens. The same incorrect geometry affects CPU hit truncation and load range selection.

This change introduces an effective block size (aware of cache spec) and applies it consistently to eager store selection, CPU hit truncation, GPU load range selection, full-attention bookkeeping, and lazy target estimation. DCP scaling is applied only to `AttentionSpec`.

### Duplicate-work check

I searched open and closed issues and PRs for `SimpleCPUOffloadConnector`, hybrid KV cache, DCP, Mamba, and block size mismatches.
I found no matching report or fix.

## Test plan

```bash
tests/v1/simple_kv_offload/test_scheduler.py
```

## Test results

- Before the fix, a 64 token hybrid prefix under DCP=2 selects two attention blocks and only two Mamba blocks.
- After the fix, the same prefix selects two attention blocks and all four Mamba blocks.
- `tests/v1/simple_kv_offload/test_scheduler.py`: `30 passed`.

## AI Assistance

OpenAI Codex was used to assist with investigation, implementation, testing, and PR preparation. The human submitter must review every changed line and be prepared to explain and defend the change end-to-end.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

