### PR TITLE
[Bugfix] Restore truncate_prompt_tokens for Jina rerank/score online

### DIFF
--- a/tests/entrypoints/pooling/scoring/test_jina_ranking_io_processor_unit.py
+++ b/tests/entrypoints/pooling/scoring/test_jina_ranking_io_processor_unit.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for JinaRankingIOProcessor online request building."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm.entrypoints.pooling.base.io_processor import PoolingIOProcessor
+from vllm.entrypoints.pooling.scoring.io_processor import JinaRankingIOProcessor
+from vllm.entrypoints.pooling.scoring.protocol import RerankRequest
+from vllm.entrypoints.pooling.scoring.typing import ScoringData
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+def test_online_forwards_truncate_prompt_tokens_to_proxy(monkeypatch):
+    """The proxy request handed to the base factory must carry
+    truncate_prompt_tokens/truncation_side from the real request.
+
+    JinaRankingIOProcessor swaps ctx.request for a proxy
+    PoolingCompletionRequest before delegating to the base factory, which
+    reads truncation off ctx.request. Dropping the fields on the proxy
+    silently disables truncate_prompt_tokens for Jina rerank/score.
+    """
+    proc = JinaRankingIOProcessor.__new__(JinaRankingIOProcessor)
+    proc.valid_inputs_online = MagicMock(
+        return_value=ScoringData(data_1=["query"], data_2=["doc"])
+    )
+    proc._get_token_limits = MagicMock(return_value=(0, 0))
+    proc.ensure_str = MagicMock(side_effect=lambda data: list(data))
+    proc.format_docs_prompts_func = MagicMock(return_value="formatted prompt")
+
+    captured: dict[str, object] = {}
+
+    def _spy_base(self, ctx):
+        captured["truncate_prompt_tokens"] = ctx.request.truncate_prompt_tokens
+        captured["truncation_side"] = ctx.request.truncation_side
+        return []
+
+    monkeypatch.setattr(PoolingIOProcessor, "get_request_factory_online", _spy_base)
+
+    request = RerankRequest(
+        model="m",
+        query="query",
+        documents=["doc"],
+        truncate_prompt_tokens=512,
+        truncation_side="left",
+    )
+    ctx = MagicMock()
+    ctx.request = request
+    ctx.prompt_extras = None
+
+    proc.get_request_factory_online(ctx)
+
+    assert captured["truncate_prompt_tokens"] == 512
+    assert captured["truncation_side"] == "left"
+    # The real request is restored after delegating.
+    assert ctx.request is request

--- a/vllm/entrypoints/pooling/scoring/io_processor.py
+++ b/vllm/entrypoints/pooling/scoring/io_processor.py
@@ -820,7 +820,16 @@ class JinaRankingIOProcessor(LateInteractionIOProcessor, JinaRankingIOProcessorM
                 for q, d in zip(queries, docs)
             ]
 
-        ctx.request = PoolingCompletionRequest(task="token_embed", input=prompts)
+        # Forward truncation from the real request: the base factory reads
+        # these off ctx.request, so omitting them here silently drops
+        # truncate_prompt_tokens for Jina rerank/score (unlike the embed and
+        # bi/cross-encoder paths, which read them from the real request).
+        ctx.request = PoolingCompletionRequest(
+            task="token_embed",
+            input=prompts,
+            truncate_prompt_tokens=request.truncate_prompt_tokens,
+            truncation_side=request.truncation_side,
+        )
         requests = PoolingIOProcessor.get_request_factory_online(self, ctx)
         ctx.request = request
         return requests


### PR DESCRIPTION
## Purpose

Fix a regression where `truncate_prompt_tokens` (and `truncation_side`) is silently dropped on the **Jina rerank/score online** path, so a request that asked to truncate is instead rejected with HTTP 400.

`JinaRankingIOProcessor.get_request_factory_online` swaps `ctx.request` for a proxy `PoolingCompletionRequest` and delegates to the base factory, which reads truncation off `ctx.request`:

```python
# base factory: vllm/entrypoints/pooling/base/io_processor.py
tok_params = request.build_tok_params(model_config)   # request == ctx.request (the proxy)
```

The proxy was built with only `task` and `input`:

```python
ctx.request = PoolingCompletionRequest(task="token_embed", input=prompts)
```

`PoolingCompletionRequest` inherits `truncate_prompt_tokens`/`truncation_side` from `PoolingBasicRequestMixin` with default `None`, so both are `None` on the proxy and the real `RerankRequest`/`ScoreRequest` value is never consulted. With `truncate_prompt_tokens=None`, the renderer's `_token_truncation` is a no-op and `_token_len_check` raises `VLLMValidationError` → 400 once the formatted Jina prompt exceeds `max_model_len`.

Per the field's own documentation this is wrong — the `max_tokens_per_doc` description states: *"0 means no document-level truncation is applied (only truncate_prompt_tokens applies to the combined query+document)."* Jina's own `_truncate_scoring_data` only applies `max_tokens_per_query`/`max_tokens_per_doc`, so nothing else recovers the dropped value.

### Regression

This is a regression from #49153. Before that PR, `JinaRankingIOProcessor` did not define `get_request_factory_online` and inherited `BiEncoderIOProcessor.pre_process_online`, which built `tok_params` from the **real** request and passed them through Jina's `_pre_process` — truncation was honored. #49153 refactored to the proxy pattern; the embed proxies in the same PR forward `truncate_prompt_tokens`/`truncation_side`, but the Jina scoring proxy was missed. The bi/cross-encoder online paths read `tok_params` off the real request and are unaffected — this is the only affected site.

### Fix

Forward the two fields from the real request into the proxy, mirroring the embed path:

```python
ctx.request = PoolingCompletionRequest(
    task="token_embed",
    input=prompts,
    truncate_prompt_tokens=request.truncate_prompt_tokens,
    truncation_side=request.truncation_side,
)
```

## Test Plan

Added `tests/entrypoints/pooling/scoring/test_jina_ranking_io_processor_unit.py`, which drives `get_request_factory_online` with a real `RerankRequest(truncate_prompt_tokens=512, truncation_side="left")` and spies on the base factory to capture what the proxy carried:

```
pytest tests/entrypoints/pooling/scoring/test_jina_ranking_io_processor_unit.py
```

## Test Result

With the fix: `1 passed`. Against the current code the test fails with `assert None == 512` — the proxy carries `None`, reproducing the drop exactly. `pre-commit run` passes on both files (ruff, ruff-format, typos, mypy).

The existing end-to-end truncation tests in `tests/entrypoints/pooling/scoring/test_cross_encoder_online.py` cover the bi/cross-encoder paths (`--max-model-len 100` + `truncate_prompt_tokens`); the equivalent coverage for the Jina path needs `jinaai/jina-reranker-v3` in CI, so it isn't included here.
