### PR TITLE
[Bugfix][KV Connector] Clip DCP block lists by effective span

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -2579,6 +2579,38 @@ def test_emit_cached_block_events_zero_cached():
     assert pool.take_events() == []
 
 
+def test_computed_block_ids_use_dcp_effective_block_size():
+    block_size = 16
+    dcp_world_size = 2
+    manager = KVCacheManager(
+        make_kv_cache_config(block_size, num_blocks=8),
+        max_model_len=8192,
+        scheduler_block_size=block_size * dcp_world_size,
+        hash_block_size=block_size * dcp_world_size,
+        enable_caching=False,
+        dcp_world_size=dcp_world_size,
+    )
+    req = make_request(
+        "dcp_lookahead",
+        prompt_token_ids=list(range(2 * block_size)),
+        block_size=block_size * dcp_world_size,
+        hash_fn=sha256,
+    )
+    blocks = manager.allocate_slots(
+        req,
+        num_new_tokens=block_size * dcp_world_size,
+        num_lookahead_tokens=block_size * dcp_world_size,
+    )
+    assert blocks is not None
+    assert len(blocks.blocks[0]) == 2
+
+    computed = manager.get_block_ids_for_computed_tokens(
+        req.request_id, block_size * dcp_world_size
+    )
+
+    assert computed == ([blocks.blocks[0][0].block_id],)
+
+
 def test_eagle_enabled_removes_last_block():
     """Verify Eagle does NOT remove blocks when request
     length is divisible by block size."""

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -702,7 +702,12 @@ class KVCacheManager:
         """Get block ids covering the request's computed tokens."""
         block_ids = self.get_block_ids(request_id)
         clipped_block_ids: list[list[int]] = []
-        for group, ids in zip(self.kv_cache_config.kv_cache_groups, block_ids):
+        for group, manager, ids in zip(
+            self.kv_cache_config.kv_cache_groups,
+            self.coordinator.single_type_managers,
+            block_ids,
+            strict=True,
+        ):
             spec = group.kv_cache_spec
             if not isinstance(spec, AttentionSpec) or isinstance(
                 spec, (CrossAttentionSpec, EncoderOnlyAttentionSpec)
@@ -710,7 +715,7 @@ class KVCacheManager:
                 clipped_block_ids.append(ids)
                 continue
 
-            num_valid_blocks = cdiv(num_computed_tokens, spec.block_size)
+            num_valid_blocks = cdiv(num_computed_tokens, manager.block_size)
             clipped_block_ids.append(ids[:num_valid_blocks])
         return tuple(clipped_block_ids)
 


### PR DESCRIPTION

## Purpose

Before calling a KV connector's `request_finished` hook, `KVCacheManager.get_block_ids_for_computed_tokens()` removes blocks that were allocated for lookahead but never computed. The method currently converts computed tokens to blocks with the cache spec's physical page size, even though DCP attention blocks span `block_size * dcp_world_size` global tokens.

With a 16-token attention page and DCP=2, allocating 32 computed tokens plus 32 lookahead tokens produces two logical block IDs. The current code returns both IDs as computed, although the second block contains only lookahead capacity and has no computed KV. NIXL and Mooncake consume these finish time lists; NIXL's prefix-cache trimming can then select the unwritten tail block instead of the valid prefix block.

This change clips each cache group's block IDs using its manager block size, which is the allocator's source of truth and already includes DCP scaling for attention.

### Duplicate-work check

I searched open and closed issues and PRs for DCP with NIXL or Mooncake, speculative lookahead, connector finish metadata, and `get_block_ids_for_computed_tokens`.
I found no matching report or fix. #49889 uses the same helper but fixes an unrelated aborted native-offloading request crash.

## Test plan

```bash
tests/v1/core/test_prefix_caching.py
```

## Test results

- Before the fix, the focused DCP reproduction returns block IDs `[1, 2]` for 32 computed tokens and one unwritten lookahead block.
- After the fix, it returns only the computed block ID `[1]`.
- `tests/v1/core/test_prefix_caching.py`: `91 passed`.

## AI Assistance

OpenAI Codex was used to assist with investigation, implementation, testing, and PR preparation. The human submitter must review every changed line and be prepared to explain and defend the change end-to-end.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

