### PR TITLE
fix(responses): reject code_interpreter tool call missing "code" field

### DIFF
--- a/tests/entrypoints/openai/responses/test_parsable_context_unit.py
+++ b/tests/entrypoints/openai/responses/test_parsable_context_unit.py
@@ -6,6 +6,7 @@ These tests verify that ParsableContext correctly delegates to the unified
 Parser (via parse) and properly builds response output items.
 """
 
+import asyncio
 from collections.abc import Sequence
 from unittest.mock import MagicMock
 
@@ -361,3 +362,15 @@ def test_num_init_messages_offset():
     items = ctx.make_response_output_items()
     assert len(items) == 1
     assert items[0].type == "message"
+
+
+def test_call_python_tool_missing_code_raises_value_error():
+    """code_interpreter args that omit 'code' must raise a controlled
+    ValueError, not an uncaught KeyError -> HTTP 500 (issue #49954)."""
+    ctx = _make_context(None)
+    # Valid JSON, but no required "code" field.
+    last_msg = FunctionCall(
+        id="call_1", name="code_interpreter", arguments='{"language": "python"}'
+    )
+    with pytest.raises(ValueError, match="code"):
+        asyncio.run(ctx.call_python_tool(MagicMock(), last_msg))

--- a/vllm/entrypoints/openai/responses/context.py
+++ b/vllm/entrypoints/openai/responses/context.py
@@ -431,6 +431,10 @@ class ParsableContext(ConversationContext):
         if isinstance(tool_session, Tool):
             return await tool_session.get_result_parsable_context(self)
         args = json.loads(last_msg.arguments)
+        if "code" not in args:
+            raise ValueError(
+                "code_interpreter tool call is missing the required 'code' field."
+            )
         param = {
             "code": args["code"],
         }


### PR DESCRIPTION
Fixes #49954.

With `VLLM_USE_EXPERIMENTAL_PARSER_CONTEXT=1`, the Responses API `code_interpreter` path in `ParsableContext.call_python_tool()` parsed the tool-call arguments and then accessed `args["code"]` directly. If the arguments are valid JSON but omit the required `code` field, that raised an uncaught `KeyError: 'code'` → HTTP 500.

Validate the field first and raise a descriptive `ValueError` (matching the `raise ValueError(...)` convention already used for tool-argument problems elsewhere in this file) so the caller sees a controlled error instead of a raw 500.

## Test
Added `tests/entrypoints/openai/responses/test_parsable_context_unit.py::test_call_python_tool_missing_code_raises_value_error` — valid JSON without `code` now raises `ValueError`, not `KeyError`. Verified the present-`code` path still reaches the tool call.