### PR TITLE
[Bugfix][KV Connector] Fix MoRIIO DCP block span

### DIFF
--- a/tests/v1/kv_connector/unit/test_moriio_connector.py
+++ b/tests/v1/kv_connector/unit/test_moriio_connector.py
@@ -3,6 +3,7 @@
 import importlib.util
 import socket
 import uuid
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import msgspec
@@ -20,11 +21,13 @@ from vllm.config import (
     set_current_vllm_config,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common import (
+    ROLE,
     MoRIIOAgentMetadata,
     MoRIIOConnectorMetadata,
     MoRIIOConstants,
     MoRIIOMode,
     resolve_host_ip,
+    set_role,
     zmq_ctx,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_connector import (
@@ -38,6 +41,7 @@ from vllm.utils.network_utils import (
     get_ip,
     make_zmq_path,
 )
+from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
@@ -393,6 +397,48 @@ def test_write_mode_with_chunked_prefill_saves_local_block_ids():
         ],
     ):
         assert block_id == block.block_id, f"{block_id} != {block.block_id}"
+
+
+def test_dcp_block_completes_write_prefill():
+    transfer_config = SimpleNamespace(
+        kv_connector_extra_config={
+            "handshake_port": 1,
+            "notify_port": 2,
+            "host_ip": "127.0.0.1",
+        },
+        kv_role="kv_producer",
+    )
+    config = SimpleNamespace(
+        kv_transfer_config=transfer_config,
+        cache_config=SimpleNamespace(block_size=16),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=2,
+            data_parallel_rank=0,
+            tensor_parallel_size=2,
+        ),
+    )
+    scheduler = MoRIIOConnectorScheduler(config, "engine")
+    set_role(ROLE.PRODUCER)
+
+    params = {
+        "transfer_id": "tx",
+        "remote_block_ids": [],
+        "remote_engine_id": "remote",
+        "remote_host": "127.0.0.1",
+        "remote_handshake_port": 1,
+        "remote_notify_port": 2,
+    }
+    request = SimpleNamespace(
+        request_id="r0",
+        num_prompt_tokens=32,
+        kv_transfer_params=params,
+    )
+    scheduler._reqs_need_save["r0"] = (request, [7])
+
+    metadata = scheduler.build_connector_meta(SchedulerOutput.make_empty())
+
+    assert "r0" in metadata.reqs_to_save
+    assert "r0" not in scheduler._reqs_need_pending_save
 
 
 def test_read_mode_loads_remote_block_ids():

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -358,7 +358,10 @@ class MoRIIOConnectorScheduler:
             "kv_transfer_config must be set for MoRIIOConnector"
         )
         self.kv_transfer_config = vllm_config.kv_transfer_config
-        self.block_size = vllm_config.cache_config.block_size
+        self.block_size = (
+            vllm_config.cache_config.block_size
+            * vllm_config.parallel_config.decode_context_parallel_size
+        )
         self.engine_id: EngineId = engine_id
         self.mode = get_moriio_mode(self.kv_transfer_config)
         self.host_ip = resolve_host_ip(


### PR DESCRIPTION

## Purpose

MoRIIO decides whether the final prefill chunk has arrived by multiplying the number of scheduler block IDs by the physical cache page size. Under DCP, one scheduler attention block spans `cache_config.block_size * dcp_world_size` global tokens, so the current calculation undercounts the completed prefix.

With a 16-token cache page and DCP=2, a complete 32-token prompt has one scheduler block ID. The current code counts only 16 completed tokens and leaves the request pending. No later block allocation can make the count reach the prompt length, so the request is never submitted for KV transfer. The same mismatch affects the final chunk of chunked prefill.

This change uses the DCP-effective block size for scheduler-side prompt-completion checks. Worker-side address calculations continue to use the physical cache page size. It also adds a scheduler regression test for a complete 32-token prompt represented by one DCP logical block.

### Duplicate-work check

I searched open and closed issues and PRs for MoRIIO, DCP, decode context parallelism, chunked prefill, pending transfers, and block size mismatches.
I found no matching report or fix.

## Test plan

```bash
tests/v1/kv_connector/unit/test_moriio_connector.py
```

## Test results

- Before the fix, the complete 32-token request remains in the pending map and no save request is emitted.
- After the fix, the scheduler recognizes the final prefill block and emits the request in `reqs_to_save`.
- `test_dcp_block_completes_write_prefill`: `1 passed`.

## AI Assistance

OpenAI Codex was used to assist with investigation, implementation, testing, and PR preparation. The human submitter must review every changed line and be prepared to explain and defend the change end-to-end.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
