### PR TITLE
[Bugfix][KV Connector] Fix HF3FS DCP block span

### DIFF
--- a/tests/v1/kv_connector/unit/test_hf3fs_connector.py
+++ b/tests/v1/kv_connector/unit/test_hf3fs_connector.py
@@ -3,17 +3,26 @@
 """
 Tests for HF3FS KV Connector high-level components:
   - TestHf3fsMockClient      : file-backed mock client I/O correctness
+  - TestHF3FSKVConnector     : connector scheduling and metadata behavior
   - TestHF3FSKVConnectorStats: metric collection, aggregation, serialisation
 """
 
 import os
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 import torch
 
+from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
 from vllm.distributed.kv_transfer.kv_connector.v1.hf3fs.hf3fs_connector import (
+    HF3FSKVConnector,
     HF3FSKVConnectorStats,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.hf3fs.utils.common import (
+    HF3FSConnectorMetadata,
+    HF3FSRequestMetadata,
+    SaveBlockInfo,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.hf3fs.utils.hf3fs_mock_client import (
     Hf3fsClient as MockHf3fsClient,
@@ -35,6 +44,45 @@ def _make_cuda_event():
     if torch.cuda.is_available():
         return torch.cuda.Event()
     return MagicMock()
+
+
+# ===========================================================================
+# TestHF3FSKVConnector
+# ===========================================================================
+
+
+class TestHF3FSKVConnector:
+    """Tests for HF3FSKVConnector scheduling and metadata behavior."""
+
+    @pytest.mark.cpu_test
+    def test_dcp_hashes_one_key_per_allocated_block(self):
+        extra_config = SimpleNamespace(
+            get_from_extra_config=lambda _key, default: default
+        )
+        config = SimpleNamespace(
+            cache_config=SimpleNamespace(block_size=16),
+            model_config=SimpleNamespace(use_mla=False),
+            parallel_config=SimpleNamespace(decode_context_parallel_size=2),
+            kv_transfer_config=extra_config,
+        )
+        connector = HF3FSKVConnector(config, KVConnectorRole.WORKER, SimpleNamespace())
+        connector._async_manager = MagicMock()
+        metadata = HF3FSConnectorMetadata()
+        metadata.add_request(
+            HF3FSRequestMetadata(
+                request_id="r0",
+                token_ids=list(range(32)),
+                block_ids=[7],
+                save_block_op=SaveBlockInfo(skip_leading_blocks=0),
+            )
+        )
+        connector.bind_connector_metadata(metadata)
+
+        connector.wait_for_save()
+
+        args = connector._async_manager.submit_save_operation.call_args.args
+        assert args[1] == [7]
+        assert len(args[2]) == 1
 
 
 # ===========================================================================

--- a/vllm/distributed/kv_transfer/kv_connector/v1/hf3fs/hf3fs_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/hf3fs/hf3fs_connector.py
@@ -482,7 +482,10 @@ class HF3FSKVConnector(KVConnectorBase_V1):
         # Core configuration
         self._vllm_config = vllm_config
         self._role = role
-        self._block_size = vllm_config.cache_config.block_size
+        self._block_size = (
+            vllm_config.cache_config.block_size
+            * vllm_config.parallel_config.decode_context_parallel_size
+        )
         self._use_mla = vllm_config.model_config.use_mla
         self._model_config = vllm_config.model_config
 


### PR DESCRIPTION

## Purpose

The HF3FS KV connector currently hashes, counts, and aligns global token prefixes with the physical cache page size. Under DCP, one scheduler attention block ID spans `cache_config.block_size * dcp_world_size` global tokens, so the connector creates multiple storage keys for each allocated device block.

With a 16-token cache page and DCP=2, a complete 32-token prefix has one block ID. The current code creates two keys, one for tokens 0 through 15 and one for tokens 0 through 31, but provides only one device page. This key-to-page mismatch breaks save accounting, and the same physical-size conversion affects lookup, allocation validation, and load metadata.

This change uses the DCP-effective block size for token hashing and scheduler-side geometry. The worker continues to use `_local_block_size`, derived from the tensor shape, for device addresses and transfer-buffer sizes. It also adds a regression test to the existing HF3FS connector test file for the one-key-per-allocated-block invariant under DCP.

### Duplicate-work check

I searched open and closed issues and PRs for HF3FS, DCP, decode context parallelism, storage-key counts, and block-size mismatches.
I found no matching report or fix. The original HF3FS implementation in #37636 does not discuss DCP.

## Test plan

```bash
tests/v1/kv_connector/unit/test_hf3fs_connector.py
```

## Test results

- Before the fix, the focused reproduction creates two storage keys for one allocated block ID.
- After the fix, it submits one key for one block ID.
- `tests/v1/kv_connector/unit/test_hf3fs_connector.py`: `17 passed`.

## AI Assistance

OpenAI Codex was used to assist with investigation, implementation, testing, and PR preparation. The human submitter must review every changed line and be prepared to explain and defend the change end-to-end.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>