### PR TITLE
[Bugfix][KV Events] Report DCP cache hits at effective span

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -2579,6 +2579,37 @@ def test_emit_cached_block_events_zero_cached():
     assert pool.take_events() == []
 
 
+def test_full_report_uses_dcp_effective_block_size():
+    block_size = 16
+    dcp_world_size = 2
+    effective_block_size = block_size * dcp_world_size
+    manager = KVCacheManager(
+        make_kv_cache_config(block_size, num_blocks=8),
+        max_model_len=8192,
+        scheduler_block_size=effective_block_size,
+        hash_block_size=effective_block_size,
+        enable_caching=True,
+        enable_kv_cache_events=True,
+        dcp_world_size=dcp_world_size,
+    )
+    token_ids = list(range(2 * effective_block_size))
+    req0 = make_request("dcp_store", token_ids, effective_block_size, sha256)
+    assert manager.allocate_slots(req0, len(token_ids)) is not None
+    manager.take_events()
+    manager.free(req0)
+
+    req1 = make_request("dcp_hit", token_ids, effective_block_size, sha256)
+    req1.kv_cache_report_mode = "full"
+    _, num_computed_tokens, _ = manager.get_computed_blocks(req1)
+    events = manager.take_events()
+
+    assert num_computed_tokens == effective_block_size
+    assert len(events) == 1
+    assert isinstance(events[0], BlockStored)
+    assert events[0].block_size == effective_block_size
+    assert len(events[0].token_ids) == effective_block_size
+
+
 def test_eagle_enabled_removes_last_block():
     """Verify Eagle does NOT remove blocks when request
     length is divisible by block size."""

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -267,15 +267,19 @@ class KVCacheManager:
             and self.enable_kv_cache_events
             and getattr(request, "kv_cache_report_mode", "incremental") == "full"
         ):
-            for group_idx, group_blocks in enumerate(computed_blocks):
+            for group_idx, (manager, group_blocks) in enumerate(
+                zip(
+                    self.coordinator.single_type_managers,
+                    computed_blocks,
+                    strict=True,
+                )
+            ):
                 num_blocks = len(group_blocks)
                 if num_blocks > 0:
-                    group = self.kv_cache_config.kv_cache_groups[group_idx]
-                    block_size = group.kv_cache_spec.block_size
                     self.block_pool.emit_cached_block_events(
                         request,
                         num_blocks,
-                        block_size,
+                        manager.block_size,
                         group_idx,
                     )
 


### PR DESCRIPTION

## Purpose

With KV events enabled, full report mode republishes `BlockStored` events for prefix blocks that were already cached. The current path passes the cache spec's physical page size to the event builder, while the block pool hashes and allocates DCP attention blocks at the effective size `block_size * dcp_world_size`.

With a 16-token attention page and DCP=2, a valid cache hit has a 32-token block hash but is reported with a 16-token event block size. `resolve_block_hashes()` cannot convert a 32-token hash into 16-token hashes and raises an assertion, so scheduling crashes while reporting the cache hit.

This change emits full-report events with each cache group's manager block size. That is the allocator and hash system's source of truth and already includes DCP scaling for attention groups. It also adds a regression test that exercises full event reporting after a DCP cache hit.

### Duplicate-work check

I searched open and closed issues and PRs for KV events, full report mode, DCP, decode context parallelism, prefix-cache hits, and event block sizes.
I found no matching report or fix.

## Test plan

```bash
tests/v1/core/test_prefix_caching.py
```

## Test results

- Before the fix, the focused DCP reproduction fails in `resolve_block_hashes()` with a 32-token hash block size and a 16-token event block size.
- After the fix, the path emits one event with `block_size=32` and 32 token IDs.
- `test_full_report_uses_dcp_effective_block_size` passes.
- tests/v1/core/test_prefix_caching.py: `91 passed`.

## AI Assistance

OpenAI Codex was used to assist with investigation, implementation, testing, and PR preparation. The human submitter must review every changed line and be prepared to explain and defend the change end-to-end.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
