### PR TITLE
[Perf][Multimodal] Speed up special mm token check

### DIFF
--- a/tests/transformers_utils/test_processor.py
+++ b/tests/transformers_utils/test_processor.py
@@ -65,3 +65,33 @@ def test_get_processor_kwargs_from_processor_module_scan_returns_full_union():
     proc = _ProcWithoutUnpack()
     keys = get_processor_kwargs_keys(get_processor_kwargs_type(proc))
     _assert_has_all_expected(keys)
+
+
+# ---- _check_special_mm_tokens patch ----
+
+
+class _FakeMMProcessor:
+    image_token = "<image>"
+    image_token_id = 7
+
+
+def test_check_special_mm_tokens_patched_and_equivalent():
+    import pytest
+    import torch
+    from transformers import BatchFeature
+    from transformers.processing_utils import ProcessorMixin
+
+    check = ProcessorMixin._check_special_mm_tokens
+    assert check._vllm_patched is True
+
+    proc = _FakeMMProcessor()
+    text = ["a <image> b <image>"]
+    ok_ids = BatchFeature({"input_ids": torch.tensor([[1, 7, 2, 7]])})
+    check(proc, text, ok_ids, modalities=["image"])
+
+    bad_ids = BatchFeature({"input_ids": torch.tensor([[1, 7, 2, 3]])})
+    with pytest.raises(ValueError, match="Mismatch in `image` token count"):
+        check(proc, text, bad_ids, modalities=["image"])
+
+    list_ids = BatchFeature({"input_ids": [[1, 7, 2, 7]]})
+    check(proc, text, list_ids, modalities=["image"])

--- a/vllm/transformers_utils/processor.py
+++ b/vllm/transformers_utils/processor.py
@@ -3,7 +3,7 @@
 
 import importlib
 import inspect
-from functools import lru_cache
+from functools import lru_cache, wraps
 from typing import TYPE_CHECKING, Any, cast, get_args, get_type_hints
 
 from transformers import (
@@ -77,8 +77,27 @@ def _transformers_v4_compatibility_init() -> Any:
         ProcessorMixin.__init__ = __init__
 
 
+def _patch_check_special_mm_tokens() -> None:
+    """Avoid tensor path in `_check_special_mm_tokens`; drop once fixed upstream."""
+    original = ProcessorMixin._check_special_mm_tokens
+    if hasattr(original, "_vllm_patched"):
+        return
+
+    @wraps(original)
+    def _check_special_mm_tokens(self, text, text_inputs, modalities):
+        input_ids = text_inputs.get("input_ids")
+        if input_ids is not None and hasattr(input_ids, "tolist"):
+            text_inputs = BatchFeature({**text_inputs, "input_ids": input_ids.tolist()})
+        return original(self, text, text_inputs, modalities)
+
+    if not hasattr(ProcessorMixin, "_mock_name"):
+        _check_special_mm_tokens._vllm_patched = True  # type: ignore[attr-defined]
+        ProcessorMixin._check_special_mm_tokens = _check_special_mm_tokens
+
+
 _transformers_v4_compatibility_import()
 _transformers_v4_compatibility_init()
+_patch_check_special_mm_tokens()
 
 _P = TypeVar("_P", bound=ProcessorMixin, default=ProcessorMixin)
 _I = TypeVar("_I", bound=BaseImageProcessor, default=BaseImageProcessor)


### PR DESCRIPTION
## Purpose

- `_check_special_mm_tokens` does `list(tensor).count()` — 3-67 ms per image request, 19-35% of MM processing CPU
- Shim converts `input_ids` to lists once, then delegates; semantics unchanged
- Mirrors existing `ProcessorMixin` shims; upstream fix huggingface/transformers#47580 is merged; shim is removable once the pinned Transformers includes it
- Not a duplicate: searched both repos

## Test Plan

- `pytest tests/transformers_utils/test_processor.py` — patch applied, mismatch still raises, list input unaffected
- Isolated microbench: 4k-token prompt, 3 modalities
- `_process_multimodal` timing: Qwen2.5-VL-3B, 20 iters/size, single-threaded (Modal T4)
- E2E serving: `vllm bench serve` (random-mm, `--probe-request-rate 1`), Qwen2.5-VL-3B on RTX 5090

## Test Result

- 3 passed
- Microbench: 15.0 → 0.16 ms/call (94x)

| image | process ms/req base → fix | check ms/req base → fix |
|---|---|---|
| 512px | 17.4 → 13.4 (-23%) | 3.37 → 0.07 |
| 1024px | 72.3 → 47.4 (-34%) | 25.20 → 0.17 |
| 2048px | 247.0 → 185.2 (-25%) | 66.91 → 0.57 |

E2E serving at moderate load (2×1092px images + 4k-token text per request, 4 req/s, concurrency 8, 120 requests, 3 runs averaged):

| metric (ms) | base | fix | Δ |
|---|---|---|---|
| TTFT median | 1172 [1133, 1191, 1192] | 1067 [1076, 1050, 1074] | -8.9% |
| TTFT p99 | 2274 | 2157 | -5.2% |
| E2E p99 | 4992 | 4787 | -4.1% |
| probe median | 888 [710, 927, 1027] | 657 [645, 651, 675] | -26.0% |
| probe p99 | 2053 [1785, 2238, 2134] | 1786 [1788, 1781, 1787] | -13.0% |

Probe (1-token text request) tail variance collapses (p99 σ ~190 ms → ~3 ms), i.e. less GIL interference on the API event loop from MM preprocessing threads. At full GPU saturation (request rate inf, concurrency 16) all serving metrics are flat — prefill dominates; the win there is MM preprocessing CPU and its single-worker throughput ceiling (13.9 → 21 req/s at 1024px).

---

AI assistance was used for this change (Claude); every line was reviewed by the submitter.
