### PR TITLE
[Bugfix][CPU] Fall back to torch for unaligned swigluoai on NEON/vec MoE

### DIFF
--- a/vllm/model_executor/layers/fused_moe/cpu_fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/cpu_fused_moe.py
@@ -381,6 +381,12 @@ class CPUFusedMOE:
         if not (w13_output_size % 32 == 0 and w2_output_size % 32 == 0):
             return False, "none"
 
+        if (
+            layer.activation == MoEActivation.SWIGLUOAI
+            and w2_input_size % _MOE_GROUPED_GEMM_N_TILE != 0
+        ):
+            return False, "none"
+
         supports_neon = current_platform.get_cpu_architecture() == CpuArchEnum.ARM
         if supports_neon:
             if (


### PR DESCRIPTION
## Purpose
I found this while triaging CI failures on my own PR #48391. That PR touches `csrc/`, so it triggers the `csrc/`-gated run-all (which includes the **Arm CPU Test**); the Arm CPU Test came back red, and it turned out to be a **pre-existing regression on `main`, not caused by #48391**.   

PR #49591 added the swigluoai grouped-gemm fallback only on the AMX path (raise-on-unaligned) plus a test asserting non-AMX CPUs fall back to the per-expert torch loop, but the pre-existing NEON/vec paths were left unpatched. They select forward_grouped_gemm for swigluoai whenever the inputs pass the relaxed %4 check, even though swigluoai's interleaved gate/up layout can't be zero-padded and needs the intermediate dim tile-aligned. This makes test_cpu_fused_moe_unaligned_intermediate_size_swigluoai fail deterministically on the Arm CPU Test.

Guard swigluoai before the NEON/vec branches: when the intermediate dim isn't a multiple of the grouped-gemm tile, fall back to forward_torch (the AMX path already raises for the same misalignment).

## Test
It added the swigluoai fallback **only on the AMX path** (raise-on-unaligned) plus a new test encoding the intended behavior, but the **pre-existing NEON (ARM) branch** in `check_grouped_gemm` was left unpatched. So the new test fails deterministically on Arm CPU:

```
FAILED tests/kernels/moe/test_cpu_fused_moe.py::test_cpu_fused_moe_unaligned_intermediate_size_swigluoai
E   assert forward_grouped_gemm == forward_torch
tests/kernels/moe/test_cpu_fused_moe.py:478: AssertionError
====== 1 failed, 480 passed, 12 skipped ======
```

(e.g. build https://buildkite.com/vllm/ci/builds/80467)

**Root cause** — the NEON branch never inspects the activation:

```python
supports_neon = current_platform.get_cpu_architecture() == CpuArchEnum.ARM
if supports_neon:
    if dtype == torch.bfloat16 and w13_input_size % 4 == 0 and w2_input_size % 4 == 0:
        return True, "neon"      # <-- selected for SWIGLUOAI too
    return False, "none"
```

For SWIGLUOAI (bf16, `intermediate=176` → `%4==0` but not `%32`) it returns `(True, "neon")` → `forward_grouped_gemm`, whereas the test expects `forward_torch` on non-AMX CPUs.