### PR TITLE
[ROCm] Add VLLM_ROCM_CLONE_MMAP_WEIGHTS to avoid slow H2D copies from mapped weights

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -125,6 +125,7 @@ if TYPE_CHECKING:
     VLLM_DISABLE_PYNCCL: bool = False
     VLLM_USE_OINK_OPS: bool = False
     VLLM_MXFP8_EMULATION_DEQUANT_AT_LOAD: bool = True
+    VLLM_ROCM_CLONE_MMAP_WEIGHTS: bool = False
     VLLM_ROCM_USE_AITER: bool = False
     VLLM_ROCM_USE_AITER_CUSTOM_AR: bool = True
     VLLM_ROCM_USE_AITER_LINEAR: bool = True
@@ -1183,6 +1184,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_MXFP8_EMULATION_DEQUANT_AT_LOAD": lambda: (
         os.getenv("VLLM_MXFP8_EMULATION_DEQUANT_AT_LOAD", "True").lower()
         in ("true", "1")
+    ),
+    # Materialise each safetensors tensor into anonymous memory before the
+    # host-to-device copy. Works around a ROCm slow path in which a copy from
+    # a writable MAP_PRIVATE file mapping whose pages are resident runs at
+    # ~2 MiB/s (ROCm/ROCm#6523). Costs one extra host copy per tensor.
+    "VLLM_ROCM_CLONE_MMAP_WEIGHTS": lambda: (
+        os.getenv("VLLM_ROCM_CLONE_MMAP_WEIGHTS", "False").lower() in ("true", "1")
     ),
     "VLLM_ROCM_USE_AITER": lambda: (
         os.getenv("VLLM_ROCM_USE_AITER", "False").lower() in ("true", "1")

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1186,9 +1186,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
         in ("true", "1")
     ),
     # Materialise each safetensors tensor into anonymous memory before the
-    # host-to-device copy. Works around a ROCm slow path in which a copy from
-    # a writable MAP_PRIVATE file mapping whose pages are resident runs at
-    # ~2 MiB/s (ROCm/ROCm#6523). Costs one extra host copy per tensor.
+    # host-to-device copy. safetensors maps checkpoints writable, and KFD takes
+    # the fault permission from the VMA rather than from the copy, so the copy
+    # breaks copy-on-write on every resident page and leaves the checkpoint as
+    # anonymous memory instead of evictable page cache (ROCm/ROCm#6523). Costs
+    # one extra host copy per tensor, which does not pay for itself when the
+    # tensors are small.
     "VLLM_ROCM_CLONE_MMAP_WEIGHTS": lambda: (
         os.getenv("VLLM_ROCM_CLONE_MMAP_WEIGHTS", "False").lower() in ("true", "1")
     ),

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -852,6 +852,12 @@ def safetensors_weights_iterator(
     this rank are skipped **before** reading from disk, which drastically
     reduces storage I/O for MoE models under EP.
     """
+    # See VLLM_ROCM_CLONE_MMAP_WEIGHTS in vllm/envs.py. On affected ROCm
+    # platforms the host-to-device copy out of safetensors' writable mapping
+    # is pathologically slow, and materialising each tensor into anonymous
+    # memory first avoids it.
+    clone_mmap = envs.VLLM_ROCM_CLONE_MMAP_WEIGHTS and current_platform.is_rocm()
+
     loading_desc = "Loading safetensors checkpoint shards"
     if safetensors_load_strategy == "eager":
         loading_desc += " (eager)"
@@ -971,6 +977,8 @@ def safetensors_weights_iterator(
                     if should_skip_weight(name, local_expert_ids):
                         continue
                     param = f.get_tensor(name)
+                    if clone_mmap:
+                        param = param.clone()
                     yield name, param
 
 

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -852,10 +852,10 @@ def safetensors_weights_iterator(
     this rank are skipped **before** reading from disk, which drastically
     reduces storage I/O for MoE models under EP.
     """
-    # See VLLM_ROCM_CLONE_MMAP_WEIGHTS in vllm/envs.py. On affected ROCm
-    # platforms the host-to-device copy out of safetensors' writable mapping
-    # is pathologically slow, and materialising each tensor into anonymous
-    # memory first avoids it.
+    # See VLLM_ROCM_CLONE_MMAP_WEIGHTS in vllm/envs.py. On ROCm the
+    # host-to-device copy out of safetensors' writable mapping breaks
+    # copy-on-write on every resident page, and materialising each tensor into
+    # anonymous memory first avoids it.
     clone_mmap = envs.VLLM_ROCM_CLONE_MMAP_WEIGHTS and current_platform.is_rocm()
 
     loading_desc = "Loading safetensors checkpoint shards"


### PR DESCRIPTION
## Purpose

Adds `VLLM_ROCM_CLONE_MMAP_WEIGHTS`, off by default and gated on ROCm, which materialises each safetensors tensor into anonymous memory before the host-to-device copy.

**The kernel regression this PR was opened against has since been fixed, and the numbers it was opened with are superseded.** Ubuntu shipped `7.0.0-30.30~24.04.1` on 2026-08-20, and on 2026-08-23 I verified it on the same machine: the 32 MiB reproducer goes from 16 019.3 ms to 15.3 ms across that upgrade, with the two control cases unmoved. Everything below is re-measured on `-30`. The three tables this PR used to carry are in the edit history. They were taken on a kernel nobody runs now, with no control over page cache, and they do not reproduce; I would rather replace them than leave them standing.

What remains is why the flag is still worth having. safetensors maps a read-only checkpoint `rw-p`, because its PyTorch path calls `torch.UntypedStorage.from_file(filename, shared=False, nbytes=size)` ([lib.rs:783-795](https://github.com/huggingface/safetensors/blob/main/bindings/python/src/lib.rs)) and PyTorch maps that writable. KFD then takes the fault permission from the VMA rather than from what the copy will do — `readonly = !(vma->vm_flags & VM_WRITE)` in `kfd_svm.c`, which sets `HMM_PFN_REQ_WRITE` and breaks copy-on-write on every resident page, even though a host-to-device copy only reads the source. AMD confirmed the mechanism and named that line in [ROCm#6523](https://github.com/ROCm/ROCm/issues/6523), and said it predates both kernels. Nothing upstream addresses it.

## The mechanism is visible in the resident set, not just on the clock

This is the part I did not have when I opened the PR, and it is a better argument than the timings. `VmHWM` cannot tell an anonymous page from a mapped file page, so sampling `RssAnon` and `RssFile` during the load says directly what the checkpoint becomes. gemma-4-31B, 21.67 GiB in one shard:

| | peak `RssAnon` | peak `RssFile` |
|---|---:|---:|
| default | **21 390 MiB** | 782 MiB |
| `VLLM_ROCM_CLONE_MMAP_WEIGHTS=1` | 843 MiB | 21 479 MiB |

The default path converts the entire checkpoint into anonymous memory. Those pages are no longer evictable, so on a host where the checkpoint is a large fraction of RAM the loader drives itself into swap. With the flag the same bytes stay file-backed and clean. The clone is not buying bandwidth; it is stopping the loader from turning a page-cache-resident checkpoint into private dirty memory.

That is also why this is not a constant ratio, and why sharding matters. Qwen3-8B is 15.26 GiB in five shards, safetensors unmaps each shard as the iterator leaves it, and its peak `RssAnon` is 4 535 MiB rather than 15 GiB. Single-shard checkpoints are the worst case.

## Test Plan

One script iterates the checkpoint through `safetensors_weights_iterator` and copies every tensor to device 0, run four ways, each cell a fresh process so the process is the replication unit. **Page cache is a controlled variable**: every cell is preceded either by `drop_caches` (cold) or by `drop_caches` plus a full read of the checkpoint (warm). Not controlling it is what made the first version of this PR wrong.

```bash
python3 loadbench.py /models/Qwen3-8B baseline
python3 loadbench.py /models/Qwen3-8B eager     # --safetensors-load-strategy eager
python3 loadbench.py /models/Qwen3-8B flag      # VLLM_ROCM_CLONE_MMAP_WEIGHTS=1
python3 loadbench.py /models/Qwen3-8B pread     # safe_open(backend="pread"), for comparison
```

Then the same thing through a real server startup, reading the loader's own line:

```bash
vllm serve /models/gemma-4-12B --max-model-len 2048 --gpu-memory-utilization 0.90 --enforce-eager
```

## Test Result

2x Radeon RX 7900 XT (gfx1100), ROCm 7.14, PyTorch 2.11, vLLM 0.23.1.dev, safetensors 0.8.0, TP=1, kernel `7.0.0-30.30~24.04.1`, 23.4 GiB RAM, ext4 that reads 1 931 to 2 114 MiB/s cold sequential. Loader-path seconds, median of n:

| checkpoint | cache | default | `eager` | flag | `pread` |
|---|---|---:|---:|---:|---:|
| gemma-4-12B, 9.56 GiB, 1 shard | warm | 4.96 | 10.23 | **2.51** | 4.79 |
| gemma-4-12B | cold | 8.15 | 11.46 | **4.71** | 7.16 |
| Qwen3-8B, 15.26 GiB, 5 shards | warm | 6.78 | 15.93 | **4.49** | 10.48 |
| Qwen3-8B | cold | 13.36 | 18.26 | **7.43** | 13.03 |
| gemma-4-31B, 21.67 GiB, 1 shard | cold | 88.52 | did not fit | **11.75** | 17.08 |
| gemma-4-26B-A4B MoE, 35 743 tensors | cold | **19.17** | not run | 19.95 | 15.87 |

n=5 for the 8B and 12B default and flag cells, n=3 for `eager` and for the 31B, n=2 elsewhere, n=1 for 31B `pread`. Spread is tight: the 12B flag cells span 2.46 to 2.69 s across five processes.

`vllm serve` on the 12B, two startups per cell, reading `Loading weights took`:

| | default | flag |
|---|---:|---:|
| warm | 4.59, 4.60 | **2.55, 2.58** |
| cold | 7.32, 7.90 | **4.93, 5.11** |

That tracks the loader-path figures, so the isolated harness is not flattering itself.

**On a current kernel the flag is worth 1.5x to 2.0x while the checkpoint fits in RAM comfortably, and 7.5x when it does not.** The 31B is 21.67 GiB on a 23.4 GiB host: the default runs at 251 MiB/s and dips into swap, the flag runs at 1 889 MiB/s, which is this array's disk speed. **The flat 3.9x to 5.6x I claimed before is withdrawn** — it was an artefact of an uncontrolled page cache.

**The flag is not free, and I was wrong to say it was.** The earlier description said cloning was faster than the mapping in every configuration measured and that switching it on by default for ROCm looked sensible. On a 128-expert MoE checkpoint whose tensors are mostly small it is no better than doing nothing and possibly slightly worse, 19.95 against 19.17 with overlapping ranges: almost nothing there is large enough to pay the copy-on-write cost, so the extra host copy is pure overhead. Default-on would be a regression for that shape of checkpoint. Off by default is the right setting and I am no longer proposing to change it.

**`eager` is now the worst of the four everywhere I measured**, 1.4x to 2.4x slower than doing nothing at roughly twice the peak RSS. On `-28` it was the second-best option. Its peak is the `bytes` buffer plus the tensors deserialised out of it, which on a single-shard checkpoint is twice the model, and that is why the 31B cannot be run with it at all.

## safetensors has a `pread` backend, and it is a different trade

`safe_open(..., backend="pread")` is in the shipped safetensors 0.8.0 — absent from the Python docstring, which is why I missed it, but named in the [v0.8.0 release notes](https://github.com/huggingface/safetensors/releases/tag/v0.8.0) as "useful for specific archs/platforms". It never maps the file, so the trigger cannot arise, and it returned byte-identical tensors for all 1334 tensors of a 12B shard. Its peak resident set is 2.4 to 3.9 GiB against 4.9 to 21.8 GiB for every other path.

It is slower than the clone on every checkpoint here except the MoE one, where it is the fastest of the four, because a syscall per tensor costs more than the mapping does when tensors are large and the data is already in page cache. I am not proposing it in this PR and I have not tried to plumb it through `safetensors_load_strategy`, but it looks like the better answer for memory-constrained hosts and for many-small-tensor checkpoints, and a reviewer should know it exists before judging this one.

## Scope

Only `safetensors_weights_iterator`, the default path. The torchao branch and `multi_thread_safetensors_weights_iterator` are untouched. With the variable unset there is no behaviour change on any platform, and it is gated on `current_platform.is_rocm()` as well, so it does nothing on CUDA.

I have one machine, a VFIO guest with two gfx1100 cards. CDNA is untested, and nothing here says what this is worth on a host whose RAM dwarfs the checkpoint, which is the case that matters most in production. That is why it defaults to off.

## Notes

Not a duplicate of [#50794](https://github.com/vllm-project/vllm/pull/50794), which clones the same call sites unconditionally to fix an Ascend NPU DMA hang: that is a correctness fix on a different accelerator and needs no opt-in, this is opt-in and ROCm-gated. If a reviewer would rather have one mechanism than two, I am happy for this to be closed in favour of a shared one.

Every number here was produced on hardware I own, and I can re-run any of it on request.

cc @hongxiayang @tjtanaa @vllmellm

## AI assistance

The measurements, the analysis and this description were produced with an AI agent; I reviewed the change and the measurement design, and every run was executed on my own hardware. The commits carry a `Co-authored-by:` trailer, added on 2026-08-28 — the branch predates my reading of the project's AI policy and the trailer was missing until then, which is on me rather than on the tooling.
