### PR TITLE
docs: clarify NIXL transfer metrics aggregation

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
@@ -51,6 +51,15 @@ class KVConnectorStats:
 
 
 class KVConnectorLogging:
+    """Collect and log KV connector stats for one logging interval.
+
+    The logging path is observe() -> aggregate() -> reduce() -> log().
+    observe() receives stats that are already aggregated across workers for a
+    scheduler sync. Additional observe() calls in the same logging interval are
+    accumulated with aggregate(), and reduce() converts the accumulated
+    observations into the single ``KV Transfer metrics`` log line.
+    """
+
     def __init__(self, kv_transfer_config: KVTransferConfig | None):
         # Instantiate the connector's stats class.
         if kv_transfer_config and kv_transfer_config.kv_connector:
@@ -69,6 +78,8 @@ class KVConnectorLogging:
         # Note that this is not the same as the logging interval.
         # We expect transfer_stats_data to be aggregated across all workers and
         # consist of observations from a single connector or a MultiConnector.
+        # Connector-specific reduce() implementations should document how those
+        # pre-aggregated observations are summarized for logging.
         transfer_stats = self.connector_cls.build_kv_connector_stats(
             transfer_stats_data
         )
@@ -85,7 +96,8 @@ class KVConnectorLogging:
         if self.transfer_stats_accumulator is None:
             self.transfer_stats_accumulator = transfer_stats
         else:
-            # Accumulate last interval stats.
+            # Accumulate already worker-aggregated stats for this logging
+            # interval.
             self.transfer_stats_accumulator = self.transfer_stats_accumulator.aggregate(
                 transfer_stats
             )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py
@@ -23,7 +23,14 @@ if TYPE_CHECKING:
 
 @dataclass
 class NixlKVConnectorStats(KVConnectorStats):
-    """Container for transfer performance metrics"""
+    """Container for NIXL transfer performance metrics.
+
+    Each successful transfer is recorded as one rank-local observation. When
+    tensor parallelism is enabled, aggregation concatenates the observations
+    from all ranks into one combined pool before CLI logging. The reduced
+    count, averages, percentiles, and throughput therefore describe rank-level
+    transfers observed during the logging interval, not per-request totals.
+    """
 
     def __post_init__(self):
         if not self.data:
@@ -80,11 +87,14 @@ class NixlKVConnectorStats(KVConnectorStats):
             for k, v in other.data.items():
                 accumulator = self.data[k]
                 assert isinstance(accumulator, list)
+                # Preserve each worker/rank observation for reduce() to
+                # summarize over the combined observation pool.
                 accumulator.extend(v)
         return self
 
     def reduce(self) -> dict[str, int | float]:
-        # Compute compact representative stats suitable for CLI logging
+        # Compute compact representative stats suitable for CLI logging over
+        # the combined pool of worker/rank observations.
         if self.num_successful_transfers == 0:
             # CLI logging only reports successful transfers stats. If all requests in
             # the interval were unsuccessful, Prom will report failures stats instead.
@@ -108,9 +118,14 @@ class NixlKVConnectorStats(KVConnectorStats):
         assert n == self.num_successful_transfers
 
         total_mb = mb.sum()
+        # This is the average rank-local payload size, not the total bytes for
+        # one logical KV transfer across all ranks.
         avg_mb = total_mb / n
 
         total_time_seconds = xfer_time.sum()
+        # This is total rank-local MB divided by total rank-local transfer
+        # time, so it is an average over observations rather than aggregate
+        # system throughput across tensor-parallel ranks.
         throughput_mb_s = total_mb / total_time_seconds
 
         return {


### PR DESCRIPTION
## Summary

- document that NIXL transfer metrics are aggregated from rank-local observations
- explain the `observe() -> aggregate() -> reduce() -> log()` pipeline
- clarify that average MB and throughput are summaries over rank-level observations, not per-request totals or aggregate system throughput

## Why

The current log labels can be interpreted as request-level or system-wide values when tensor parallelism is enabled. These comments make the aggregation semantics explicit for maintainers and users reading the metrics implementation.

Addresses #41230.

## Validation

- `python3 -m py_compile vllm/distributed/kv_transfer/kv_connector/v1/metrics.py vllm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py`
- `git diff --check HEAD^ HEAD`
