### PR TITLE
[Core] Zero KV cache when NaN logits detected

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1635,6 +1635,46 @@ class Scheduler(SchedulerInterface):
         kv_connector_output = model_runner_output.kv_connector_output
         cudagraph_stats = model_runner_output.cudagraph_stats
 
+        if num_nans_in_logits and any(
+            v > 0 for v in num_nans_in_logits.values()
+        ):
+            total = sum(num_nans_in_logits.values())
+            affected = sum(
+                1 for v in num_nans_in_logits.values() if v > 0)
+            logger.warning(
+                "Detected %d NaN logit(s) across %d request(s). "
+                "Aborting all requests and resetting KV cache.",
+                total, affected)
+
+            aborted = self.finish_requests(
+                None, RequestStatus.FINISHED_ABORTED)
+            self.kv_cache_manager.reset_prefix_cache()
+
+            outputs: dict[int, list[EngineCoreOutput]] = defaultdict(
+                list)
+            for request in aborted:
+                outputs[request.client_index].append(
+                    EngineCoreOutput(
+                        request_id=request.request_id,
+                        new_token_ids=[],
+                        finish_reason=request.get_finished_reason(),
+                    ))
+
+            engine_core_outputs = {
+                ci: EngineCoreOutputs(outputs=outs)
+                for ci, outs in outputs.items()
+            }
+            finished_req_ids = self.finished_req_ids_dict
+            if finished_req_ids:
+                for ci, fset in finished_req_ids.items():
+                    if (eco := engine_core_outputs.get(ci)) is not None:
+                        eco.finished_requests = fset
+                    else:
+                        engine_core_outputs[ci] = EngineCoreOutputs(
+                            finished_requests=fset)
+                finished_req_ids.clear()
+            return engine_core_outputs
+
         # Every GPU write enqueued by this and earlier steps has completed, so it is
         # safe to return deferred-free blocks to the pool.
         if self.defer_block_free and scheduler_output.total_num_scheduled_tokens > 0:

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1467,6 +1467,18 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             hidden_states, input_batch, grammar_output
         )
 
+        if (sampler_output.num_nans is not None
+                and sampler_output.num_nans.any()
+                and self.kv_block_zeroer is not None):
+            total = sampler_output.num_nans.sum().item()
+            affected = (sampler_output.num_nans > 0).sum().item()
+            num_blocks = self.kv_cache_config.num_blocks
+            logger.warning(
+                "Detected %d NaN logit(s) across %d request(s). "
+                "Zeroing all %d KV cache blocks.",
+                total, affected, num_blocks)
+            self.kv_block_zeroer.zero_block_ids(list(range(num_blocks)))
+
         if self.pp_handler is not None:
             # Broadcast to non-last PP ranks (handles spec decode multi-token).
             self.pp_handler.broadcast(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5735,6 +5735,17 @@ class GPUModelRunner(
                     if num_nans_for_index is not None and req_index < logits.shape[0]
                     else 0
                 )
+
+            if any(v > 0 for v in num_nans_in_logits.values()):
+                affected = sum(1 for v in num_nans_in_logits.values() if v > 0)
+                total = sum(num_nans_in_logits.values())
+                logger.warning(
+                    "Detected %d NaN logit(s) across %d request(s). "
+                    "Zeroing all %d KV cache blocks.",
+                    total, affected, self.kv_cache_config.num_blocks)
+                self._zero_block_ids(
+                    list(range(self.kv_cache_config.num_blocks)))
+
             return num_nans_in_logits
         except IndexError:
             return {}

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -669,7 +669,8 @@ class Worker(WorkerBase):
         # Build KV-zero metadata outside the CuMem pool so the bookkeeping
         # GPU tensors (seg_addrs, block-id buffers) use the standard PyTorch
         # allocator and are not discarded during sleep/wake cycles.
-        if kv_cache_config.needs_kv_cache_zeroing and hasattr(
+        if (kv_cache_config.needs_kv_cache_zeroing
+                or envs.VLLM_COMPUTE_NANS_IN_LOGITS) and hasattr(
             self.model_runner, "_init_kv_zero_meta"
         ):
             self.model_runner._init_kv_zero_meta()


### PR DESCRIPTION
When `VLLM_COMPUTE_NANS_IN_LOGITS=1` and NaN values are detected in logits, abort all in-flight requests, zero all KV cache blocks, and reset the prefix cache. Covers both MRV1 and MRV2 model runners.

**Limitation:** GPU-side KV cache zeroing only runs on the rank that computes logits (driver / last PP rank). Other TP/PP ranks are not explicitly zeroed. This is safe because aborted requests free all blocks, and fresh allocations go through `new_block_ids_to_zero` which zeros on all ranks — but the cleanup is implicit, not explicit.