### PR TITLE
[Feat][ROCm] Implement get_all_gpu_pci_bus_ids for ROCm platform

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -29,6 +29,7 @@ try:
         AmdSmiException,
         AmdSmiMemoryType,
         amdsmi_get_gpu_asic_info,
+        amdsmi_get_gpu_device_bdf,
         amdsmi_get_gpu_device_uuid,
         amdsmi_get_gpu_memory_total,
         amdsmi_get_processor_handles,
@@ -1064,3 +1065,15 @@ class RocmPlatform(Platform):
         except Exception as e:
             logger.warning("Failed to get NUMA nodes for GPUs: %s", e)
             return None
+
+    @classmethod
+    @with_amdsmi_context
+    def get_all_gpu_pci_bus_ids(cls) -> dict[int, str]:
+        """Query amdsmi for GPU index -> PCI bus ID mapping."""
+        handles = amdsmi_get_processor_handles()
+        if not handles:
+            raise RuntimeError("amdsmi returned no GPU processor handles")
+        out: dict[int, str] = {}
+        for idx, handle in enumerate(handles):
+            out[idx] = amdsmi_get_gpu_device_bdf(handle)
+        return out


### PR DESCRIPTION
## Purpose

Extend the per-worker RDMA NIC selection feature (#42083) to AMD GPUs by implementing `Platform.get_all_gpu_pci_bus_ids()` for `RocmPlatform`.

#42083 introduced `VLLM_GPU_NIC_PCIE_MAPPING` and `VLLM_NIC_SELECTION_VARS` to control which RDMA NIC each GPU worker uses, but only implemented the GPU PCI discovery for CUDA (via pynvml). On ROCm, calling this method raises `NotImplementedError`. This PR adds the ROCm implementation using `amdsmi_get_gpu_device_bdf`, which returns the PCI Bus/Device/Function string for each physical GPU without initializing a HIP context.

**Changes:**
- Import `amdsmi_get_gpu_device_bdf` in the existing amdsmi import block
- Implement `get_all_gpu_pci_bus_ids()` on `RocmPlatform` using `@with_amdsmi_context` (consistent with other amdsmi methods in the class)

## Test Plan

**Unit validation** and **integration testing** performed on an 8xMI300X node (physical BCM57608 RDMA NICs present but RDMA networking not enabled -- drivers not bound, no `/sys/class/infiniband/` entries). End-to-end RDMA transfer testing will be performed on a cluster with fully operational InfiniBand/RoCE networking.

### 1. Unit validation

Verified `amdsmi_get_gpu_device_bdf` output matches `rocm-smi --showbus` for all 8 GPUs and that the strings pass through `normalize_pci()` correctly:
```
GPU 0: 0000:1b:00.0
GPU 1: 0000:3d:00.0
GPU 2: 0000:4e:00.0
GPU 3: 0000:5f:00.0
GPU 4: 0000:9d:00.0
GPU 5: 0000:bd:00.0
GPU 6: 0000:cd:00.0
GPU 7: 0000:dd:00.0
```

### 2. Integration test (TP=8, multiproc executor)

Launched vLLM with TP=8 and `VLLM_GPU_NIC_PCIE_MAPPING` set. Each worker correctly:
1. Called `get_all_gpu_pci_bus_ids()` (our new ROCm implementation)
2. Resolved its physical GPU index via `device_id_to_physical_device_id()`
3. Looked up the correct paired NIC from the PCIe mapping

Workers failed at `rdma_name_for_nic_pci()` as expected (no RDMA devices on this node), but the error messages confirm correct GPU-to-NIC resolution for all 8 workers:
```
Worker 0 -> NIC PCI (0, 28, 0, 0)  = 0000:1c:00.0 ✓
Worker 1 -> NIC PCI (0, 62, 0, 0)  = 0000:3e:00.0 ✓
Worker 2 -> NIC PCI (0, 79, 0, 0)  = 0000:4f:00.0 ✓
Worker 3 -> NIC PCI (0, 96, 0, 0)  = 0000:60:00.0 ✓
Worker 4 -> NIC PCI (0, 158, 0, 0) = 0000:9e:00.0 ✓
Worker 5 -> NIC PCI (0, 190, 0, 0) = 0000:be:00.0 ✓
Worker 6 -> NIC PCI (0, 206, 0, 0) = 0000:ce:00.0 ✓
Worker 7 -> NIC PCI (0, 222, 0, 0) = 0000:de:00.0 ✓
```

### 3. End-to-end RDMA test (pending)

Will validate full NIC selection and RDMA transfers on a multi-node MI300X cluster with operational RoCE/InfiniBand networking. Results will be posted as a follow-up comment.

## Test Result

GPU PCI discovery and NIC mapping verified on 8xMI300X. Full RDMA results to follow.

---

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results