### PR TITLE
[DSv4 Perf] Adaptive topk width, 1.0% E2E throughput improvement

### DIFF
--- a/tests/kernels/attention/test_flashmla_sparse.py
+++ b/tests/kernels/attention/test_flashmla_sparse.py
@@ -4,6 +4,43 @@ import pytest
 import torch
 
 
+def test_deepseek_v4_c128a_dynamic_topk_packed_buffers():
+    from vllm.models.deepseek_v4.sparse_mla import build_c128a_topk_metadata
+
+    device = torch.device("cuda")
+    capacity_width = 256
+    active_width = 128
+    global_decode_buffer = torch.empty(
+        (2, capacity_width), dtype=torch.int32, device=device
+    )
+    decode_lens_buffer = torch.empty(2, dtype=torch.int32, device=device)
+    prefill_buffer = torch.empty((2, capacity_width), dtype=torch.int32, device=device)
+
+    global_decode, decode_lens, prefill_local = build_c128a_topk_metadata(
+        positions=torch.tensor([255, 511], dtype=torch.int64, device=device),
+        compress_ratio=128,
+        num_decode_tokens=1,
+        token_to_req_indices=torch.tensor([0, 0], dtype=torch.int32, device=device),
+        block_table=torch.tensor([[3]], dtype=torch.int32, device=device),
+        block_size=capacity_width,
+        slot_mapping=torch.tensor([0, 1], dtype=torch.int64, device=device),
+        global_decode_buffer=global_decode_buffer,
+        decode_lens_buffer=decode_lens_buffer,
+        prefill_buffer=prefill_buffer,
+        max_compressed_tokens=active_width,
+    )
+
+    assert global_decode.shape == (1, active_width)
+    assert prefill_local.shape == (1, active_width)
+    assert global_decode.stride() == (active_width, 1)
+    assert prefill_local.stride() == (active_width, 1)
+    assert global_decode[0, :2].cpu().tolist() == [768, 769]
+    assert decode_lens.cpu().tolist() == [2]
+    assert prefill_local[0, :4].cpu().tolist() == list(range(4))
+    assert torch.all(global_decode[0, 2:] == -1)
+    assert torch.all(prefill_local[0, 4:] == -1)
+
+
 def test_sparse_flashmla_metadata_smoke():
     import vllm.v1.attention.ops.flashmla as fm
 

--- a/vllm/models/deepseek_v4/sparse_mla.py
+++ b/vllm/models/deepseek_v4/sparse_mla.py
@@ -261,6 +261,13 @@ class DeepseekV4FlashMLAMetadataBuilder(
         assert cm.positions is not None, (
             "positions is required for C128A metadata build"
         )
+        active_topk_width = min(
+            max(
+                triton.next_power_of_2(max(cm.max_seq_len // self.compress_ratio, 1)),
+                _C128A_TOPK_ALIGNMENT,
+            ),
+            self.c128a_max_compressed,
+        )
         block_size = self.kv_cache_spec.block_size // self.compress_ratio
         global_decode, decode_lens, prefill_local = build_c128a_topk_metadata(
             cm.positions[:num_total],
@@ -273,7 +280,7 @@ class DeepseekV4FlashMLAMetadataBuilder(
             self.c128a_global_decode_buffer,
             self.c128a_decode_lens_buffer,
             self.c128a_prefill_buffer,
-            max_compressed_tokens=self.c128a_max_compressed,
+            max_compressed_tokens=active_topk_width,
         )
 
         result: dict[str, torch.Tensor | None] = {}
@@ -305,25 +312,30 @@ def build_c128a_topk_metadata(
     Decode tokens: position → block_table lookup → global slot ids + topk_lens.
     Prefill tokens: position → local indices [0, ..., n-1, -1, ...].
 
-    Writes into pre-allocated buffers for CUDA graph address stability.
-    Returns slices of the buffers.
+    Writes into packed views of pre-allocated buffers for CUDA graph stability.
     """
     num_tokens = positions.shape[0]
     num_prefill_tokens = num_tokens - num_decode_tokens
 
-    global_decode = global_decode_buffer[:num_decode_tokens]
+    # view(-1) as 1-d array and then expanded to
+    # [num_decode_tokens, max_compressed_tokens]
+    global_decode = global_decode_buffer.view(-1)[
+        : num_decode_tokens * max_compressed_tokens
+    ].view(num_decode_tokens, max_compressed_tokens)
     decode_lens = decode_lens_buffer[:num_decode_tokens]
-    prefill_local = prefill_buffer[:num_prefill_tokens]
+    prefill_local = prefill_buffer.view(-1)[
+        : num_prefill_tokens * max_compressed_tokens
+    ].view(num_prefill_tokens, max_compressed_tokens)
 
     if num_tokens == 0:
         return global_decode, decode_lens, prefill_local
 
     _build_c128a_topk_metadata_kernel[(num_tokens,)](
         global_decode_buffer,
-        global_decode_buffer.stride(0),
+        max_compressed_tokens,
         decode_lens_buffer,
         prefill_buffer,
-        prefill_buffer.stride(0),
+        max_compressed_tokens,
         positions,
         compress_ratio,
         max_compressed_tokens,


### PR DESCRIPTION
## Purpose

Let's assume token num = 2

Originally: Always use maximum length

```bash
c128a_max_compressed
→ 1,048,576 / 128
→ 8,192

So buffer

global_decode_buffer[:2]
→ shape = [2, 8192]
→ stride = 8192

kernel loop for 8192 times
```

Now based on current context

```bash
32,768 / 128
→ 256
→ active_topk_width = 256

buffer.view(-1)[: 2 × 256]
→ view(2, 256)
→ shape = [2, 256]
→ stride = 256

Kernel only loops for 256 times
```

## Test

```bash
cd /home/yewentao256/vllm-source
source /home/yewentao256/wt_env.sh
export MODEL=deepseek-ai/DeepSeek-V4-Pro

CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
/home/yewentao256/.venv/bin/python -m vllm.entrypoints.cli.main serve "$MODEL" \
  --served-model-name dsv4-pro \
  --tensor-parallel-size 8 \
  --enable-expert-parallel \
  --max-model-len 1048576 \
  --max-num-batched-tokens 8192 \
  --max-num-seqs 512 \
  --gpu-memory-utilization 0.95 \
  --kv-cache-dtype fp8_ds_mla \
  --no-enable-prefix-caching \
  --trust-remote-code \
  --port 8000 \
  2>&1 | tee /home/yewentao256/dsv4-c128a-prefill-results/diff-server.log
```

### Acc

```bash
lm_eval run \
  --model local-completions \
  --model_args model="$MODEL",base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=100,tokenized_requests=False \
  --tasks gsm8k \
  --num_fewshot 5 \
  --output_path /home/yewentao256/dsv4-c128a-lm-eval-results/results \
  --log_samples \
  --seed 0 \
  2>&1 | tee /home/yewentao256/dsv4-c128a-lm-eval-results/lm-eval.log

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9492|±  |0.0060|
|     |       |strict-match    |     5|exact_match|↑  |0.9484|±  |0.0061|

```

### Perf

```bash
vllm bench serve \
  --backend openai \
  --base-url http://127.0.0.1:8000 \
  --endpoint /v1/completions \
  --model "$MODEL" \
  --served-model-name dsv4-pro \
  --dataset-name random \
  --random-input-len 8192 \
  --random-output-len 1 \
  --random-range-ratio 0 \
  --num-prompts 32 \
  --num-warmups 4 \
  --request-rate inf \
  --max-concurrency 1 \
  --ignore-eos \
```

```bash
# now
============ Serving Benchmark Result ============
Successful requests:                     32        
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  11.84     
Total input tokens:                      262144    
Total generated tokens:                  32        
Request throughput (req/s):              2.70      
Output token throughput (tok/s):         2.70      
Peak output token throughput (tok/s):    3.00      
Peak concurrent requests:                4.00      
Total token throughput (tok/s):          22151.38  
---------------Time to First Token----------------
Mean TTFT (ms):                          369.74    
Median TTFT (ms):                        369.99    
P99 TTFT (ms):                           374.28    
----------------End-to-end Latency----------------
Mean E2EL (ms):                          369.74    
Median E2EL (ms):                        369.99    
P99 E2EL (ms):                           374.28    
==================================================

============ Serving Benchmark Result ============
Successful requests:                     32        
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  11.82     
Total input tokens:                      262144    
Total generated tokens:                  32        
Request throughput (req/s):              2.71      
Output token throughput (tok/s):         2.71      
Peak output token throughput (tok/s):    3.00      
Peak concurrent requests:                4.00      
Total token throughput (tok/s):          22186.10  
---------------Time to First Token----------------
Mean TTFT (ms):                          369.17    
Median TTFT (ms):                        369.42    
P99 TTFT (ms):                           372.82    
----------------End-to-end Latency----------------
Mean E2EL (ms):                          369.17    
Median E2EL (ms):                        369.42    
P99 E2EL (ms):                           372.82    
==================================================

# main
============ Serving Benchmark Result ============
Successful requests:                     32        
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  11.94     
Total input tokens:                      262144    
Total generated tokens:                  32        
Request throughput (req/s):              2.68      
Output token throughput (tok/s):         2.68      
Peak output token throughput (tok/s):    3.00      
Peak concurrent requests:                4.00      
Total token throughput (tok/s):          21959.34  
---------------Time to First Token----------------
Mean TTFT (ms):                          372.97    
Median TTFT (ms):                        373.45    
P99 TTFT (ms):                           377.40    
----------------End-to-end Latency----------------
Mean E2EL (ms):                          372.97    
Median E2EL (ms):                        373.45    
P99 E2EL (ms):                           377.40    
==================================================
============ Serving Benchmark Result ============
Successful requests:                     32        
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  11.95     
Total input tokens:                      262144    
Total generated tokens:                  32        
Request throughput (req/s):              2.68      
Output token throughput (tok/s):         2.68      
Peak output token throughput (tok/s):    3.00      
Peak concurrent requests:                4.00      
Total token throughput (tok/s):          21945.26  
---------------Time to First Token----------------
Mean TTFT (ms):                          373.21    
Median TTFT (ms):                        373.45    
P99 TTFT (ms):                           377.10    
----------------End-to-end Latency----------------
Mean E2EL (ms):                          373.21    
Median E2EL (ms):                        373.45    
P99 E2EL (ms):                           377.10    
==================================================
```