### PR TITLE
[rocm] perf: drop redundant -inf prefill of decode paged MQA-logits buffer

### DIFF
--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -429,7 +429,6 @@ def rocm_fp8_paged_mqa_logits(
             (out_logits,) = current_workspace_manager().get_simultaneous(
                 ((batch_size * next_n, max_model_len), torch.float32),
             )
-            out_logits.fill_(float("-inf"))
             deepgemm_fp8_paged_mqa_logits(
                 q_fp8,
                 kv_cache_fp8,


### PR DESCRIPTION
## Summary

Removes the full-width `out_logits.fill_(float("-inf"))` before the decode paged MQA-logits kernel in `rocm_fp8_paged_mqa_logits` (`vllm/v1/attention/ops/rocm_aiter_mla_sparse.py`).

The decode consumer, `top_k_per_row_decode`, bounds its per-row scan by `seq_lens` (it reads only `[0, rowEnd)` where `rowEnd = seq_len - next_n + next_n_idx + 1`) and pads short rows (`rowLen <= topK`) with `-1` internally. The paged MQA-logits kernels write every in-causal column that top-k reads:
- Gluon `deepgemm_fp8_paged_mqa_logits` writes `-inf` into masked in-tile positions itself.
- FlyDSL `flydsl_fp8_paged_mqa_logits` writes exactly `col <= q_limit` (== the columns top-k reads).

So the out-of-window `[rowEnd, max_model_len)` region initialized by this `fill_` is never consumed on the decode path, making the prefill redundant. Dropping it saves a `rows x max_model_len` fp32 HBM write every decode step.

## Why it's safe (decode path)

`q_limit` (kernel write extent) and `rowEnd` (top-k read extent) are both derived from the same context length and `next_n`, so every column top-k reads is freshly written; nothing reads the untouched tail.

## Scope / caveats

- Only affects the **decode** paged path (`rocm_fp8_paged_mqa_logits`).
- The prefill top-k path and the `topk_indices_buffer[...] = -1` init are untouched.
- The FlyDSL kernel documents a `-inf`-prefill contract; this change relies on the consumer's `seq_lens` bounding rather than the kernel self-initializing, so it should be validated numerically.

## Test plan

- [ ] Compare decode top-k indices with/without the fill across short / long / padded batches (Gluon and FlyDSL paths) on gfx942/gfx950.
- [ ] Run existing `tests/kernels/test_top_k_per_row.py` and sparse-indexer tests.
- [ ] Sanity-check end-to-end GLM-5.2 sparse-MLA decode output.