### PR TITLE
[DCP][Kernel] Add Shared-DCP consumer-direct Top-K

### DIFF
--- a/tests/distributed/test_cuda_vmm.py
+++ b/tests/distributed/test_cuda_vmm.py
@@ -1,0 +1,464 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import array
+import importlib.util
+import os
+import socket
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from vllm.distributed.device_communicators import cuda_vmm
+from vllm.distributed.device_communicators.cuda_vmm import (
+    RankMajorPeerView,
+    create_rank_major_peer_view,
+)
+from vllm.platforms import current_platform
+from vllm.utils.network_utils import get_open_port
+
+
+class _FakeDriver:
+    CUresult = SimpleNamespace(CUDA_SUCCESS=0)
+    CUmemAllocationHandleType = SimpleNamespace(
+        CU_MEM_HANDLE_TYPE_FABRIC=1,
+        CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR=2,
+    )
+
+    def __init__(self) -> None:
+        self.unmapped: list[tuple[int, int]] = []
+        self.freed: list[tuple[int, int]] = []
+
+    def cuMemUnmap(self, address: int, size: int):
+        self.unmapped.append((address, size))
+        return (0,)
+
+    def cuMemAddressFree(self, address: int, size: int):
+        self.freed.append((address, size))
+        return (0,)
+
+
+def test_allocation_property_preserves_typed_handle() -> None:
+    driver = SimpleNamespace(
+        CUmemAllocationProp=lambda: SimpleNamespace(),
+        CUmemAllocationType=SimpleNamespace(CU_MEM_ALLOCATION_TYPE_PINNED=1),
+        CUmemLocation=lambda: SimpleNamespace(),
+        CUmemLocationType=SimpleNamespace(CU_MEM_LOCATION_TYPE_DEVICE=2),
+    )
+
+    handle_type = SimpleNamespace(value=1)
+    prop = cuda_vmm._make_allocation_property(
+        driver, device_id=3, handle_types=handle_type
+    )
+
+    assert prop.requestedHandleTypes is handle_type
+    assert prop.location.id == 3
+
+
+def test_aligned_local_shape_honors_granularity_and_row_multiple() -> None:
+    shape, size = cuda_vmm._aligned_local_shape(
+        (7, 3), torch.float16, granularity=64, first_dim_multiple=5
+    )
+
+    assert shape == (160, 3)
+    assert size == 960
+    assert size % 64 == 0
+    assert shape[0] % 5 == 0
+
+
+def test_handle_export_uses_posix_collectively(monkeypatch) -> None:
+    driver = _FakeDriver()
+    local_fd = os.open(os.devnull, os.O_RDONLY)
+
+    def export(_handle, handle_type, _flags):
+        assert (
+            handle_type
+            == driver.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+        )
+        return (0, local_fd)
+
+    driver.cuMemExportToShareableHandle = export
+    monkeypatch.setattr(cuda_vmm, "_driver", driver)
+    monkeypatch.setattr(cuda_vmm.dist, "get_world_size", lambda _group: 2)
+
+    def all_gather(output, value, *, group):
+        assert group == "cpu-group"
+        output[:] = [value, value]
+
+    monkeypatch.setattr(cuda_vmm.dist, "all_gather_object", all_gather)
+
+    try:
+        transport, exported = cuda_vmm._export_local_handle(
+            driver, "cpu-group", rank=0, local_handle=19
+        )
+        assert transport == "posix_fd"
+        assert exported == local_fd
+    finally:
+        os.close(local_fd)
+
+
+def test_fd_message_transfers_descriptor_ownership() -> None:
+    sender, receiver = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+    local_fd = os.open(os.devnull, os.O_RDONLY)
+    received_fd = None
+    try:
+        cuda_vmm._send_fd(sender, rank=3, fd=local_fd)
+        message = cuda_vmm._recv_fd(receiver)
+        assert message is not None
+        rank, received_fd = message
+        assert rank == 3
+        assert os.fstat(received_fd).st_mode == os.fstat(local_fd).st_mode
+    finally:
+        sender.close()
+        receiver.close()
+        os.close(local_fd)
+        if received_fd is not None:
+            os.close(received_fd)
+
+
+def test_fd_message_accepts_partial_stream_header() -> None:
+    sender, receiver = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+    local_fd = os.open(os.devnull, os.O_RDONLY)
+    received_fd = None
+    try:
+        payload = cuda_vmm._FD_HEADER.pack(5)
+        fds = array.array("i", [local_fd])
+        assert (
+            sender.sendmsg(
+                [payload[:1]],
+                [(socket.SOL_SOCKET, socket.SCM_RIGHTS, fds.tobytes())],
+            )
+            == 1
+        )
+        sender.sendall(payload[1:])
+
+        message = cuda_vmm._recv_fd(receiver)
+        assert message is not None
+        rank, received_fd = message
+        assert rank == 5
+        assert os.fstat(received_fd).st_mode == os.fstat(local_fd).st_mode
+    finally:
+        sender.close()
+        receiver.close()
+        os.close(local_fd)
+        if received_fd is not None:
+            os.close(received_fd)
+
+
+def test_fd_exchange_timeout_joins_receiver_before_cleanup(monkeypatch) -> None:
+    local_fd = os.open(os.devnull, os.O_RDONLY)
+    gather_count = 0
+
+    def all_gather(output, value, *, group):
+        nonlocal gather_count
+        assert group == "cpu-group"
+        if gather_count == 0:  # socket setup errors
+            output[:] = [None, None]
+        elif gather_count == 1:  # socket paths; peer path is unreachable
+            output[:] = [value, "/missing/vllm-vmm-peer.sock"]
+        else:  # transfer errors
+            output[:] = [value, value]
+        gather_count += 1
+
+    monkeypatch.setattr(cuda_vmm, "_FD_EXCHANGE_TIMEOUT_S", 0.01)
+    monkeypatch.setattr(cuda_vmm.dist, "get_world_size", lambda _group: 2)
+    monkeypatch.setattr(cuda_vmm.dist, "all_gather_object", all_gather)
+    try:
+        with pytest.raises(RuntimeError, match="POSIX FD transfer failed"):
+            cuda_vmm._exchange_posix_fds(
+                "cpu-group", rank=0, world_size=2, local_fd=local_fd
+            )
+    finally:
+        os.close(local_fd)
+
+    assert not any(
+        thread.name == "vllm-vmm-fd-rank-0" and thread.is_alive()
+        for thread in cuda_vmm.threading.enumerate()
+    )
+
+
+def test_request_rejects_a_multi_host_group(monkeypatch) -> None:
+    group = MagicMock(spec=dist.ProcessGroup)
+    request = ((8, 4), torch.float16, 1, False, False)
+    gathered = [[None, None], [request, request], ["host-a", "host-b"]]
+
+    monkeypatch.setattr(cuda_vmm.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(cuda_vmm.dist, "get_backend", lambda _group: "gloo")
+    monkeypatch.setattr(cuda_vmm.dist, "get_rank", lambda _group: 0)
+    monkeypatch.setattr(cuda_vmm.dist, "get_world_size", lambda _group: 2)
+
+    def all_gather(output, _value, *, group):
+        assert group is not None
+        output[:] = gathered.pop(0)
+
+    monkeypatch.setattr(cuda_vmm.dist, "all_gather_object", all_gather)
+
+    with pytest.raises(ValueError, match="every group rank on one host"):
+        cuda_vmm._validate_request(group, *request)
+
+
+def test_peer_capability_rejects_missing_native_atomics(monkeypatch) -> None:
+    driver = SimpleNamespace(
+        CUresult=SimpleNamespace(CUDA_SUCCESS=0),
+        CUdevice_P2PAttribute=SimpleNamespace(
+            CU_DEVICE_P2P_ATTRIBUTE_NATIVE_ATOMIC_SUPPORTED=7
+        ),
+        cuDeviceGet=lambda device_id: (0, device_id),
+        cuDeviceCanAccessPeer=lambda _source, _peer: (0, 1),
+        cuDeviceGetP2PAttribute=lambda _attribute, _source, _peer: (0, 0),
+    )
+    monkeypatch.setattr(cuda_vmm, "_driver", driver)
+    monkeypatch.setattr(cuda_vmm.dist, "get_world_size", lambda _group: 2)
+
+    gather_count = 0
+
+    def all_gather(output, value, *, group):
+        nonlocal gather_count
+        assert group == "cpu-group"
+        if gather_count == 0:
+            output[:] = [0, 1]
+        else:
+            output[:] = [value, value]
+        gather_count += 1
+
+    monkeypatch.setattr(cuda_vmm.dist, "all_gather_object", all_gather)
+
+    with pytest.raises(RuntimeError, match="requires native peer atomics"):
+        cuda_vmm._validate_peer_capabilities(
+            driver,
+            "cpu-group",
+            rank=0,
+            device_id=0,
+            require_native_atomics=True,
+        )
+
+
+def test_mapping_rollback_unmaps_in_reverse_order(monkeypatch) -> None:
+    driver = _FakeDriver()
+    monkeypatch.setattr(cuda_vmm, "_driver", driver)
+    mappings = [100, 164, 228]
+
+    cuda_vmm._rollback_mapping(driver, 100, 192, mappings, 64)
+
+    assert mappings == []
+    assert driver.unmapped == [(228, 64), (164, 64), (100, 64)]
+    assert driver.freed == [(100, 192)]
+
+
+def test_close_is_idempotent_and_keeps_dlpack_callbacks_alive(monkeypatch) -> None:
+    driver = _FakeDriver()
+    monkeypatch.setattr(cuda_vmm, "_driver", driver)
+    synchronize = MagicMock()
+    monkeypatch.setattr(cuda_vmm.torch.cuda, "synchronize", synchronize)
+    refs = [object()]
+    retired_count = len(cuda_vmm._RETIRED_DLPACK_REFS)
+    view = RankMajorPeerView(
+        global_view=MagicMock(),
+        rank_local_view=MagicMock(),
+        local_view=MagicMock(),
+        requested_shape=(2, 4),
+        aligned_local_shape=(8, 4),
+        rows_per_rank=8,
+        bytes_per_rank=64,
+        rank=0,
+        world_size=2,
+        device=torch.device("cuda:0"),
+        transport="fabric",
+        _global_base_va=100,
+        _rank_local_base_va=300,
+        _total_bytes=128,
+        _global_mappings=[100, 164],
+        _rank_local_mappings=[300, 364],
+        _dlpack_refs=refs,
+    )
+
+    view.close()
+    view.close()
+
+    synchronize.assert_called_once_with(torch.device("cuda:0"))
+    assert driver.unmapped == [(164, 64), (100, 64), (364, 64), (300, 64)]
+    assert driver.freed == [(100, 128), (300, 128)]
+    assert view.closed
+    assert view.global_view is None
+    assert view.rank_local_view is None
+    assert view.local_view is None
+    assert cuda_vmm._RETIRED_DLPACK_REFS[retired_count] is refs
+    cuda_vmm._RETIRED_DLPACK_REFS.pop()
+
+
+def test_close_can_retry_a_failed_unmap(monkeypatch) -> None:
+    driver = _FakeDriver()
+    attempts = 0
+
+    def unmap(address: int, size: int):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return (1,)
+        driver.unmapped.append((address, size))
+        return (0,)
+
+    driver.cuMemUnmap = unmap
+    monkeypatch.setattr(cuda_vmm, "_driver", driver)
+    monkeypatch.setattr(cuda_vmm.torch.cuda, "synchronize", lambda _device: None)
+    view = RankMajorPeerView(
+        global_view=MagicMock(),
+        rank_local_view=None,
+        local_view=MagicMock(),
+        requested_shape=(1,),
+        aligned_local_shape=(64,),
+        rows_per_rank=64,
+        bytes_per_rank=64,
+        rank=0,
+        world_size=1,
+        device=torch.device("cuda:0"),
+        transport="posix_fd",
+        _global_base_va=100,
+        _rank_local_base_va=None,
+        _total_bytes=64,
+        _global_mappings=[100],
+        _rank_local_mappings=[],
+        _dlpack_refs=[],
+    )
+
+    with pytest.raises(RuntimeError, match="CUDA VMM close failed"):
+        view.close()
+    assert not view.closed
+
+    view.close()
+    assert view.closed
+    assert driver.unmapped == [(100, 64)]
+    assert driver.freed == [(100, 64)]
+    cuda_vmm._RETIRED_DLPACK_REFS.pop()
+
+
+def _rank_major_peer_worker(rank: int, world_size: int, port: int) -> None:
+    os.environ.update(
+        MASTER_ADDR="127.0.0.1",
+        MASTER_PORT=str(port),
+        RANK=str(rank),
+        WORLD_SIZE=str(world_size),
+    )
+    torch.cuda.set_device(rank)
+    dist.init_process_group("gloo", rank=rank, world_size=world_size)
+    try:
+        module_path = (
+            Path(__file__).parents[2]
+            / "vllm/distributed/device_communicators/peer_memory.py"
+        )
+        spec = importlib.util.spec_from_file_location("_test_peer_memory", module_path)
+        assert spec is not None and spec.loader is not None
+        peer_memory = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(peer_memory)
+
+        view = create_rank_major_peer_view(
+            (7, 4),
+            dtype=torch.uint8,
+            group=dist.group.WORLD,
+            first_dim_multiple=8,
+            map_rank_local=True,
+            require_native_atomics=True,
+        )
+        fence = peer_memory.PeerMemoryFence(dist.group.WORLD, torch.device("cuda"))
+        assert view.global_view is not None
+        assert view.local_view is not None
+        assert view.rank_local_view is not None
+        assert (
+            view.local_view.untyped_storage().data_ptr() == view.local_view.data_ptr()
+        )
+        assert view.local_view.untyped_storage().nbytes() == view.bytes_per_rank
+        view.local_view.fill_(rank + 1)
+        fence()
+
+        for owner_rank in range(world_size):
+            start = owner_rank * view.rows_per_rank
+            canonical = view.global_view.narrow(0, start, 7)
+            assert torch.all(canonical == owner_rank + 1).item(), (
+                rank,
+                owner_rank,
+                canonical[:, 0].tolist(),
+            )
+
+            local_segment = (owner_rank - rank) % world_size
+            start = local_segment * view.rows_per_rank
+            rotated = view.rank_local_view.narrow(0, start, 7)
+            assert torch.all(rotated == owner_rank + 1).item(), (
+                rank,
+                owner_rank,
+                rotated[:, 0].tolist(),
+            )
+        dist.barrier()
+
+        # Model producer kernels use the canonical mapping to store directly
+        # into every rank's cache. Give each producer a disjoint row in every
+        # owner segment so all directed peer-store paths are covered.
+        for owner_rank in range(world_size):
+            start = owner_rank * view.rows_per_rank
+            view.global_view[start + rank].fill_(101 + rank)
+        fence()
+
+        expected = torch.arange(
+            101,
+            101 + world_size,
+            dtype=torch.uint8,
+            device=view.local_view.device,
+        )
+        assert torch.equal(view.local_view[:world_size, 0], expected)
+        dist.barrier()
+
+        # Exercise alternating epochs and skewed producers. Each rank writes a
+        # disjoint byte in every owner segment, then the system-scope fence
+        # must make all producers visible in every local allocation.
+        for epoch in range(1_000 if world_size == 4 else 10):
+            if epoch % 97 == rank:
+                time.sleep(rank * 0.001)
+            for owner_rank in range(world_size):
+                start = owner_rank * view.rows_per_rank
+                view.global_view[start + rank, 1].fill_((epoch + rank) % 251)
+            fence()
+            expected = torch.tensor(
+                [(epoch + source_rank) % 251 for source_rank in range(world_size)],
+                dtype=torch.uint8,
+                device=view.local_view.device,
+            )
+            assert torch.equal(view.local_view[:world_size, 1], expected)
+            dist.barrier()
+
+        # Closing an owner allocation while a peer is still reading it is
+        # invalid. Quiesce this multi-process stress test before teardown.
+        dist.barrier()
+        fence.close()
+        view.close()
+        view.close()
+        dist.barrier()
+    finally:
+        dist.destroy_process_group()
+
+
+def _peer_access_available(world_size: int) -> bool:
+    if not current_platform.is_cuda() or torch.cuda.device_count() < world_size:
+        return False
+    return all(
+        src == dst or torch.cuda.can_device_access_peer(src, dst)
+        for src in range(world_size)
+        for dst in range(world_size)
+    )
+
+
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_rank_major_peer_reads_writes_and_repeated_close(world_size: int) -> None:
+    if not _peer_access_available(world_size):
+        pytest.skip(f"CUDA VMM peer view requires {world_size} peer-accessible GPUs")
+    mp.spawn(
+        _rank_major_peer_worker,
+        args=(world_size, get_open_port()),
+        nprocs=world_size,
+    )

--- a/tests/distributed/test_cuda_vmm.py
+++ b/tests/distributed/test_cuda_vmm.py
@@ -85,7 +85,7 @@ def test_handle_export_uses_posix_collectively(monkeypatch) -> None:
         )
         return (0, local_fd)
 
-    driver.cuMemExportToShareableHandle = export
+    monkeypatch.setattr(driver, "cuMemExportToShareableHandle", export, raising=False)
     monkeypatch.setattr(cuda_vmm, "_driver", driver)
     monkeypatch.setattr(cuda_vmm.dist, "get_world_size", lambda _group: 2)
 
@@ -306,9 +306,9 @@ def test_close_can_retry_a_failed_unmap(monkeypatch) -> None:
         driver.unmapped.append((address, size))
         return (0,)
 
-    driver.cuMemUnmap = unmap
+    monkeypatch.setattr(driver, "cuMemUnmap", unmap)
     monkeypatch.setattr(cuda_vmm, "_driver", driver)
-    monkeypatch.setattr(cuda_vmm.torch.cuda, "synchronize", lambda _device: None)
+    monkeypatch.setattr(cuda_vmm.torch.accelerator, "synchronize", lambda _device: None)
     view = RankMajorPeerView(
         global_view=MagicMock(),
         rank_local_view=None,
@@ -347,7 +347,7 @@ def _rank_major_peer_worker(rank: int, world_size: int, port: int) -> None:
         RANK=str(rank),
         WORLD_SIZE=str(world_size),
     )
-    torch.cuda.set_device(rank)
+    torch.accelerator.set_device_index(rank)
     dist.init_process_group("gloo", rank=rank, world_size=world_size)
     try:
         module_path = (
@@ -444,7 +444,7 @@ def _rank_major_peer_worker(rank: int, world_size: int, port: int) -> None:
 
 
 def _peer_access_available(world_size: int) -> bool:
-    if not current_platform.is_cuda() or torch.cuda.device_count() < world_size:
+    if not current_platform.is_cuda() or current_platform.device_count() < world_size:
         return False
     return all(
         src == dst or torch.cuda.can_device_access_peer(src, dst)

--- a/tests/distributed/test_dcp_topk_vmm.py
+++ b/tests/distributed/test_dcp_topk_vmm.py
@@ -1,0 +1,302 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Exactness and CUDA-graph tests for owner-local VMM DCP top-k."""
+
+import os
+import socket
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+import vllm.envs as envs
+from vllm.platforms import current_platform
+from vllm.utils.import_utils import has_cutedsl
+
+
+def _get_free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("localhost", 0))
+        return int(sock.getsockname()[1])
+
+
+def _make_inputs(
+    rank: int,
+    rows: int,
+    num_cols: int,
+    topk: int,
+    seed: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    generator = torch.Generator(device=device)
+    generator.manual_seed(seed * 997 + rank)
+    logits = torch.randn(
+        rows,
+        num_cols,
+        generator=generator,
+        device=device,
+    )
+    indices = torch.topk(logits, k=topk, dim=1).indices.to(torch.int32)
+    return logits, indices
+
+
+def _reference_merge(
+    logits: torch.Tensor,
+    indices: torch.Tensor,
+    topk: int,
+    rank: int,
+    world_size: int,
+    row_starts: torch.Tensor | None = None,
+) -> torch.Tensor:
+    from vllm.model_executor.kernels.attention.dsa.dcp_indexer_cutedsl import (
+        pack_dcp_topk_candidates_cutedsl,
+        stable_topk_from_gathered_candidates_cutedsl,
+    )
+
+    rows = indices.shape[0]
+    packed = torch.empty(
+        (rows, topk, 2),
+        dtype=torch.float32,
+        device=logits.device,
+    )
+    pack_dcp_topk_candidates_cutedsl(
+        logits,
+        indices,
+        packed,
+        rank,
+        world_size,
+        1,
+        row_starts,
+    )
+    gathered_flat = torch.empty(
+        (world_size * rows, topk, 2),
+        dtype=torch.float32,
+        device=logits.device,
+    )
+    dist.all_gather_into_tensor(gathered_flat, packed)
+    gathered = (
+        gathered_flat.view(world_size, rows, topk, 2)
+        .permute(1, 0, 2, 3)
+        .reshape(rows, world_size * topk, 2)
+        .contiguous()
+    )
+    stable_topk_from_gathered_candidates_cutedsl(
+        gathered,
+        topk,
+        out=indices,
+    )
+    return indices
+
+
+def _assert_same_ids(actual: torch.Tensor, expected: torch.Tensor) -> None:
+    torch.testing.assert_close(
+        actual.sort(dim=1).values,
+        expected.sort(dim=1).values,
+        rtol=0,
+        atol=0,
+    )
+
+
+def _worker(rank: int, world_size: int, port: int) -> None:
+    os.environ.update(
+        MASTER_ADDR="127.0.0.1",
+        MASTER_PORT=str(port),
+        RANK=str(rank),
+        LOCAL_RANK=str(rank),
+        WORLD_SIZE=str(world_size),
+    )
+    device = torch.device(f"cuda:{rank}")
+    torch.accelerator.set_device_index(device)
+    dist.init_process_group("nccl")
+    cpu_group = dist.new_group(
+        ranks=list(range(world_size)),
+        backend="gloo",
+    )
+    from vllm.model_executor.kernels.attention.dsa.dcp_topk_vmm import (
+        create_dcp_topk_vmm_workspace_for_group,
+    )
+
+    topk = 2048
+    num_cols = 4096
+    max_rows = 96
+    workspace = create_dcp_topk_vmm_workspace_for_group(
+        max_rows,
+        topk,
+        cpu_group,
+        device,
+    )
+    assert workspace.candidate_payload_bytes_per_rank == max_rows * topk * 2 * 4
+    assert workspace.peer_candidates.shape == (
+        world_size,
+        max_rows,
+        topk,
+        2,
+    )
+
+    try:
+        for iteration, rows in enumerate((1, 17, 64, 96)):
+            logits, indices = _make_inputs(
+                rank,
+                rows,
+                num_cols,
+                topk,
+                iteration,
+                device,
+            )
+            expected = _reference_merge(
+                logits,
+                indices.clone(),
+                topk,
+                rank,
+                world_size,
+            )
+            workspace.merge(
+                logits,
+                indices,
+                topk,
+                rank,
+                world_size,
+                1,
+                None,
+            )
+            torch.accelerator.synchronize()
+            _assert_same_ids(indices, expected)
+
+        # Stable selection with ties and one empty owner shard.
+        rows = 8
+        logits = torch.zeros(
+            (rows, num_cols),
+            dtype=torch.float32,
+            device=device,
+        )
+        indices = (
+            torch.arange(topk, dtype=torch.int32, device=device)
+            .expand(rows, -1)
+            .clone()
+        )
+        if rank == world_size - 1:
+            indices.fill_(-1)
+        expected = _reference_merge(
+            logits,
+            indices.clone(),
+            topk,
+            rank,
+            world_size,
+        )
+        workspace.merge(
+            logits,
+            indices,
+            topk,
+            rank,
+            world_size,
+            1,
+            None,
+        )
+        torch.accelerator.synchronize()
+        _assert_same_ids(indices, expected)
+
+        # Prefill-style row-relative candidate indices.
+        rows = 8
+        logits = torch.randn(
+            (rows, num_cols),
+            dtype=torch.float32,
+            device=device,
+        )
+        row_starts = torch.arange(rows, dtype=torch.int32, device=device) * 3
+        indices = torch.stack(
+            [
+                torch.topk(
+                    logits[row, int(row_starts[row].item()) :],
+                    topk,
+                ).indices
+                for row in range(rows)
+            ]
+        ).to(torch.int32)
+        expected = _reference_merge(
+            logits,
+            indices.clone(),
+            topk,
+            rank,
+            world_size,
+            row_starts,
+        )
+        workspace.merge(
+            logits,
+            indices,
+            topk,
+            rank,
+            world_size,
+            1,
+            row_starts,
+        )
+        torch.accelerator.synchronize()
+        _assert_same_ids(indices, expected)
+
+        # Capture once, then replay with two different input tensors. Device
+        # epochs must advance on replay rather than reusing capture-time values.
+        rows = 64
+        logits, source_indices = _make_inputs(
+            rank,
+            rows,
+            num_cols,
+            topk,
+            99,
+            device,
+        )
+        graph_indices = source_indices.clone()
+        dist.barrier()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            graph_indices.copy_(source_indices)
+            workspace.merge(
+                logits,
+                graph_indices,
+                topk,
+                rank,
+                world_size,
+                1,
+                None,
+            )
+
+        for replay in range(2):
+            if replay:
+                logits.neg_()
+                source_indices.copy_(
+                    torch.topk(logits, k=topk, dim=1).indices.to(torch.int32)
+                )
+            expected = _reference_merge(
+                logits,
+                source_indices.clone(),
+                topk,
+                rank,
+                world_size,
+            )
+            dist.barrier()
+            graph.replay()
+            torch.accelerator.synchronize()
+            _assert_same_ids(graph_indices, expected)
+    finally:
+        torch.accelerator.synchronize()
+        dist.barrier(group=cpu_group)
+        workspace.close()
+        dist.barrier(group=cpu_group)
+        dist.destroy_process_group(cpu_group)
+        dist.destroy_process_group()
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="Owner-local DCP top-k requires CUDA.",
+)
+@pytest.mark.skipif(envs.VLLM_TARGET_DEVICE != "cuda", reason="Only test on CUDA")
+@pytest.mark.skipif(not has_cutedsl(), reason="Requires CuTeDSL.")
+def test_dcp_topk_vmm_matches_allgather_and_replays_graph() -> None:
+    world_size = 4
+    if torch.accelerator.device_count() < world_size:
+        pytest.skip(f"Test requires {world_size} GPUs")
+    mp.spawn(
+        _worker,
+        args=(world_size, _get_free_port()),
+        nprocs=world_size,
+    )

--- a/tests/distributed/test_peer_memory.py
+++ b/tests/distributed/test_peer_memory.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.distributed.device_communicators.peer_memory import (
+    PeerMemoryFence,
+    make_rank_major_tensor_view,
+)
+
+
+def test_rank_major_tensor_view_preserves_packed_offset_and_stride() -> None:
+    world_size = 2
+    bytes_per_rank = 64
+    global_view = torch.arange(world_size * bytes_per_rank, dtype=torch.int8)
+    local_view = global_view[bytes_per_rank:]
+    allocation = SimpleNamespace(
+        global_view=global_view,
+        local_view=local_view,
+        bytes_per_rank=bytes_per_rank,
+        world_size=world_size,
+    )
+    local_tensor = local_view.view(4, 16)[:, 4:12]
+
+    peer_tensor = make_rank_major_tensor_view(allocation, local_tensor)
+
+    assert peer_tensor.shape == (world_size, 4, 8)
+    assert peer_tensor.stride() == (bytes_per_rank, 16, 1)
+    torch.testing.assert_close(peer_tensor[1], local_tensor)
+    torch.testing.assert_close(
+        peer_tensor[0], global_view[:bytes_per_rank].view(4, 16)[:, 4:12]
+    )
+
+
+def test_peer_memory_fence_close_quiesces_group_before_unmap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[object] = []
+    allocation = SimpleNamespace(close=lambda: events.append("close"))
+    fence = object.__new__(PeerMemoryFence)
+    fence._group = "pcp-cpu-group"
+    fence._allocation = allocation
+    fence._peer_signals = torch.empty(0)
+    fence._closed = False
+
+    monkeypatch.setattr(
+        torch.accelerator,
+        "synchronize",
+        lambda: events.append("synchronize"),
+    )
+    monkeypatch.setattr(
+        "vllm.distributed.device_communicators.peer_memory.dist.barrier",
+        lambda *, group: events.append(("barrier", group)),
+    )
+
+    fence.close()
+    fence.close()
+
+    assert events == [
+        "synchronize",
+        ("barrier", "pcp-cpu-group"),
+        "close",
+    ]
+    with pytest.raises(RuntimeError, match="is closed"):
+        fence()

--- a/tests/kernels/test_fused_deepseek_v32_norm_rope.py
+++ b/tests/kernels/test_fused_deepseek_v32_norm_rope.py
@@ -235,6 +235,63 @@ def test_fused_norm_rope(num_tokens: int, index_interleave: bool, mla_fp8: bool)
     assert (topk == -1).all(), "topk buffer not cleared on indexer layer"
 
 
+def test_fused_norm_rope_normalizes_query_without_local_cache_slots():
+    """DCP non-owner ranks still need valid query shards for query AllGather."""
+    torch.manual_seed(7)
+    dev = "cuda"
+    num_tokens = 4
+    max_pos = 16
+    pos = torch.arange(num_tokens, device=dev, dtype=torch.int64)
+
+    q_c = torch.randn(num_tokens, Q_LORA, device=dev, dtype=torch.bfloat16)
+    kv_c = torch.randn(num_tokens, KV_LORA, device=dev, dtype=torch.bfloat16)
+    k_pe = torch.randn(num_tokens, ROPE_DIM, device=dev, dtype=torch.bfloat16)
+    qw = torch.randn(Q_LORA, device=dev, dtype=torch.bfloat16)
+    kvw = torch.randn(KV_LORA, device=dev, dtype=torch.bfloat16)
+    ik = torch.randn(num_tokens, INDEX_HEAD_DIM, device=dev, dtype=torch.bfloat16)
+    ikw = torch.randn(INDEX_HEAD_DIM, device=dev, dtype=torch.float32)
+    ikb = torch.randn(INDEX_HEAD_DIM, device=dev, dtype=torch.float32)
+    cos_sin = make_cos_sin(max_pos, ROPE_DIM, dev)
+
+    mla_cache = torch.zeros(
+        1, max_pos, KV_LORA + ROPE_DIM, device=dev, dtype=torch.bfloat16
+    )
+    idx_row = INDEX_HEAD_DIM + INDEX_HEAD_DIM // 128 * 4
+    idx_cache = torch.zeros(1, max_pos, idx_row, device=dev, dtype=torch.uint8)
+    no_local_slots = torch.full((num_tokens,), -1, device=dev, dtype=torch.int64)
+    topk = torch.full((num_tokens, 2048), 7, device=dev, dtype=torch.int32)
+
+    q_out = K.fused_norm_rope(
+        pos,
+        q_c,
+        qw,
+        EPS,
+        kv_c,
+        kvw,
+        EPS,
+        k_pe,
+        cos_sin,
+        ik,
+        ikw,
+        ikb,
+        EPS,
+        cos_sin,
+        topk,
+        slot_mapping=no_local_slots,
+        indexer_k_cache=idx_cache,
+        mla_kv_cache=mla_cache,
+        mla_kv_cache_dtype="auto",
+        mla_k_scale=None,
+        has_indexer=True,
+        index_rope_interleave=True,
+    )
+
+    assert_bf16(q_out, rms_norm(q_c, qw), "q_c rmsnorm without local cache slots")
+    assert not mla_cache.any(), "non-owner rank wrote the MLA KV cache"
+    assert not idx_cache.any(), "non-owner rank wrote the indexer KV cache"
+    assert (topk == -1).all(), "topk buffer not cleared on non-owner rank"
+
+
 @pytest.mark.parametrize("num_tokens", [1, 17, 512])
 def test_fused_norm_rope_no_indexer(num_tokens: int):
     """Shared (no-indexer) layer: q + kv/MLA only; top-k buffer untouched."""

--- a/tests/v1/attention/test_indexer_dcp_localize.py
+++ b/tests/v1/attention/test_indexer_dcp_localize.py
@@ -253,6 +253,145 @@ def _merge_local_topks_global_with_fake_dcp(
         sparse_indexer.get_dcp_group = original_get_dcp_group
 
 
+@pytest.mark.parametrize(
+    ("enabled", "rows", "is_prefill", "expected"),
+    [
+        (False, 32, False, "explicit"),
+        (True, 15, False, "explicit"),
+        (True, 16, False, "vmm"),
+        (True, 32, False, "vmm"),
+        (True, 128, False, "vmm"),
+        (True, 129, False, "explicit"),
+        (True, 32, True, "explicit"),
+    ],
+)
+def test_dcp_topk_vmm_serving_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+    enabled: bool,
+    rows: int,
+    is_prefill: bool,
+    expected: str,
+):
+    from vllm.model_executor.kernels.attention.dsa import (
+        dcp_indexer_cutedsl,
+        dcp_topk_vmm,
+    )
+
+    calls = []
+
+    class FakeVmmWorkspace:
+        def merge(self, *args):
+            calls.append("vmm")
+
+    class FakeDcpGroup:
+        def all_gather(self, input_: torch.Tensor, dim: int) -> torch.Tensor:
+            assert dim == 1
+            calls.append("all_gather")
+            return input_
+
+    def get_vmm_workspace(max_rows: int, candidates: int, world: int):
+        assert max_rows == sparse_indexer.DCP_TOPK_VMM_MAX_DECODE_ROWS
+        assert candidates == 4
+        assert world == 4
+        calls.append("vmm_init")
+        return FakeVmmWorkspace()
+
+    def pack(*args):
+        calls.append("pack")
+
+    def stable_topk(*args, **kwargs):
+        calls.append("stable_topk")
+
+    monkeypatch.setattr(
+        sparse_indexer,
+        "_assert_cutedsl_dcp_merge_supported",
+        lambda *args: None,
+    )
+    monkeypatch.setattr(sparse_indexer.envs, "VLLM_DCP_TOPK_VMM", enabled)
+    monkeypatch.setattr(sparse_indexer, "get_dcp_group", lambda: FakeDcpGroup())
+    monkeypatch.setattr(
+        dcp_topk_vmm,
+        "get_dcp_topk_vmm_workspace",
+        get_vmm_workspace,
+    )
+    monkeypatch.setattr(
+        dcp_indexer_cutedsl,
+        "pack_dcp_topk_candidates_cutedsl",
+        pack,
+    )
+    monkeypatch.setattr(
+        dcp_indexer_cutedsl,
+        "stable_topk_from_gathered_candidates_cutedsl",
+        stable_topk,
+    )
+
+    logits = torch.zeros((rows, 8), dtype=torch.float32)
+    topk_indices = torch.zeros((rows, 4), dtype=torch.int32)
+    row_starts = torch.zeros((rows,), dtype=torch.int32) if is_prefill else None
+    sparse_indexer._merge_dcp_topk_global(
+        logits,
+        topk_indices,
+        topk_tokens=4,
+        dcp_rank=0,
+        dcp_world_size=4,
+        cp_interleave=1,
+        row_starts=row_starts,
+    )
+
+    if expected == "vmm":
+        assert calls == ["vmm_init", "vmm"]
+    else:
+        assert calls == ["pack", "all_gather", "stable_topk"]
+
+
+@pytest.mark.parametrize("failure_stage", ["initialization", "merge"])
+def test_dcp_topk_vmm_failure_is_fatal(
+    monkeypatch: pytest.MonkeyPatch,
+    failure_stage: str,
+):
+    from vllm.model_executor.kernels.attention.dsa import (
+        dcp_topk_vmm,
+    )
+
+    class FailingWorkspace:
+        def merge(self, *args):
+            raise RuntimeError("merge failed")
+
+    def get_vmm_workspace(*args):
+        if failure_stage == "initialization":
+            raise RuntimeError("initialization failed")
+        return FailingWorkspace()
+
+    def unexpected_recovery(*args, **kwargs):
+        raise AssertionError("selected VMM failure must not recover")
+
+    monkeypatch.setattr(
+        sparse_indexer,
+        "_assert_cutedsl_dcp_merge_supported",
+        lambda *args: None,
+    )
+    monkeypatch.setattr(sparse_indexer.envs, "VLLM_DCP_TOPK_VMM", True)
+    monkeypatch.setattr(sparse_indexer, "get_dcp_group", unexpected_recovery)
+    monkeypatch.setattr(
+        dcp_topk_vmm,
+        "get_dcp_topk_vmm_workspace",
+        get_vmm_workspace,
+    )
+
+    logits = torch.zeros((32, 8), dtype=torch.float32)
+    topk_indices = torch.zeros((32, 4), dtype=torch.int32)
+    with pytest.raises(RuntimeError, match=f"{failure_stage} failed"):
+        sparse_indexer._merge_dcp_topk_global(
+            logits,
+            topk_indices,
+            topk_tokens=4,
+            dcp_rank=0,
+            dcp_world_size=4,
+            cp_interleave=1,
+            row_starts=None,
+        )
+
+
 @pytest.mark.parametrize("world", [1, 2, 4])
 @pytest.mark.parametrize("interleave", [1, 2, 4])
 def test_get_dcp_local_seq_lens_matches_naive(world: int, interleave: int):

--- a/vllm/distributed/device_communicators/cuda_vmm.py
+++ b/vllm/distributed/device_communicators/cuda_vmm.py
@@ -1,0 +1,1060 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright 2023-2026 SGLang Team
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Adapted from https://github.com/sgl-project/sglang/pull/31435
+"""CUDA VMM-backed rank-major peer tensor views.
+
+The setup path exchanges allocation handles. Once constructed, the returned
+views use ordinary device loads and stores; they do not issue runtime pulls,
+gets, collectives, or copies.
+"""
+
+from __future__ import annotations
+
+import array
+import ctypes
+import math
+import os
+import socket
+import struct
+import tempfile
+import threading
+from contextlib import suppress
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+_driver: Any | None = None
+_FD_EXCHANGE_TIMEOUT_S = 120.0
+_FD_HEADER = struct.Struct("<Q")
+
+# A PyTorch tensor may be kept alive after its owning peer view is closed. The
+# VMM address is invalid after close, but the DLPack deleter callback must still
+# be callable when such an alias is eventually destroyed.
+_RETIRED_DLPACK_REFS: list[list[Any]] = []
+
+
+def _get_cuda_driver() -> Any:
+    global _driver
+    if _driver is None:
+        try:
+            from cuda.bindings import driver
+        except ModuleNotFoundError as exc:
+            raise RuntimeError(
+                "CUDA VMM peer views require the cuda-bindings package."
+            ) from exc
+        _driver = driver
+    return _driver
+
+
+def _check_driver(result: Any, operation: str) -> Any:
+    """Return a CUDA driver result value or raise an actionable error."""
+    if not isinstance(result, tuple):
+        result = (result,)
+    error = result[0]
+    driver = _get_cuda_driver()
+    if error != driver.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"{operation} failed with {error}")
+    if len(result) == 1:
+        return None
+    if len(result) == 2:
+        return result[1]
+    return result[1:]
+
+
+def _error_text(error: BaseException | None) -> str | None:
+    if error is None:
+        return None
+    return f"{type(error).__name__}: {error}"
+
+
+def _gather_errors(
+    group: ProcessGroup, local_error: BaseException | None
+) -> list[str | None]:
+    errors: list[str | None] = [None] * dist.get_world_size(group)
+    dist.all_gather_object(errors, _error_text(local_error), group=group)
+    return errors
+
+
+def _raise_if_any_rank_failed(
+    group: ProcessGroup,
+    rank: int,
+    stage: str,
+    local_error: BaseException | None,
+) -> None:
+    errors = _gather_errors(group, local_error)
+    for failed_rank, error in enumerate(errors):
+        if error is None:
+            continue
+        message = f"CUDA VMM {stage} failed on group rank {failed_rank}: {error}"
+        if failed_rank == rank:
+            raise RuntimeError(message) from local_error
+        raise RuntimeError(message)
+
+
+def _validate_request(
+    group: ProcessGroup,
+    local_shape: tuple[int, ...],
+    dtype: torch.dtype,
+    first_dim_multiple: int,
+    map_rank_local: bool,
+    require_native_atomics: bool,
+) -> tuple[int, int]:
+    if not isinstance(group, ProcessGroup):
+        raise TypeError("group must be a torch.distributed.ProcessGroup")
+    if not dist.is_initialized():
+        raise RuntimeError("torch.distributed must be initialized")
+    if dist.get_backend(group) == dist.Backend.NCCL:
+        raise ValueError("CUDA VMM setup requires a CPU-capable ProcessGroup, not NCCL")
+
+    rank = dist.get_rank(group)
+    world_size = dist.get_world_size(group)
+    local_error: BaseException | None = None
+    try:
+        if not local_shape:
+            raise ValueError("local_shape must have at least one dimension")
+        if any(not isinstance(dim, int) or dim <= 0 for dim in local_shape):
+            raise ValueError(f"local_shape dimensions must be positive: {local_shape}")
+        if first_dim_multiple <= 0:
+            raise ValueError("first_dim_multiple must be positive")
+        _dtype_to_dlpack(dtype)
+    except BaseException as exc:
+        local_error = exc
+    _raise_if_any_rank_failed(group, rank, "request validation", local_error)
+
+    requests: list[Any] = [None] * world_size
+    request = (
+        local_shape,
+        dtype,
+        first_dim_multiple,
+        map_rank_local,
+        require_native_atomics,
+    )
+    dist.all_gather_object(requests, request, group=group)
+    if any(peer_request != request for peer_request in requests):
+        details = ", ".join(
+            f"rank {peer_rank}={peer_request!r}"
+            for peer_rank, peer_request in enumerate(requests)
+        )
+        raise ValueError(
+            "CUDA VMM peer view arguments must match on every rank; " + details
+        )
+
+    hosts: list[str | None] = [None] * world_size
+    dist.all_gather_object(hosts, socket.gethostname(), group=group)
+    if len(set(hosts)) != 1:
+        details = ", ".join(
+            f"rank {peer_rank}={host!r}" for peer_rank, host in enumerate(hosts)
+        )
+        raise ValueError(
+            "CUDA VMM peer views require every group rank on one host; " + details
+        )
+    return rank, world_size
+
+
+def _validate_peer_capabilities(
+    driver: Any,
+    group: ProcessGroup,
+    rank: int,
+    device_id: int,
+    require_native_atomics: bool,
+) -> None:
+    """Collectively validate directed access from each rank to every peer."""
+    world_size = dist.get_world_size(group)
+    device_ids: list[int | None] = [None] * world_size
+    dist.all_gather_object(device_ids, device_id, group=group)
+
+    local_error: BaseException | None = None
+    try:
+        if any(peer_device is None for peer_device in device_ids):
+            raise RuntimeError("A peer rank did not report its CUDA device.")
+        if len(set(device_ids)) != world_size:
+            raise ValueError(
+                "CUDA VMM peer views require one distinct CUDA device per rank; "
+                f"got {device_ids}."
+            )
+
+        source_device = _check_driver(
+            driver.cuDeviceGet(device_id), f"cuDeviceGet({device_id})"
+        )
+        atomic_attribute = (
+            driver.CUdevice_P2PAttribute.CU_DEVICE_P2P_ATTRIBUTE_NATIVE_ATOMIC_SUPPORTED
+        )
+        for peer_rank, peer_device_id in enumerate(device_ids):
+            if peer_rank == rank:
+                continue
+            assert peer_device_id is not None
+            peer_device = _check_driver(
+                driver.cuDeviceGet(peer_device_id),
+                f"cuDeviceGet({peer_device_id})",
+            )
+            can_access = int(
+                _check_driver(
+                    driver.cuDeviceCanAccessPeer(source_device, peer_device),
+                    f"cuDeviceCanAccessPeer({device_id}, {peer_device_id})",
+                )
+            )
+            if not can_access:
+                raise NotImplementedError(
+                    "CUDA device "
+                    f"{device_id} cannot access PCP rank {peer_rank} device "
+                    f"{peer_device_id}."
+                )
+            if require_native_atomics:
+                native_atomics = int(
+                    _check_driver(
+                        driver.cuDeviceGetP2PAttribute(
+                            atomic_attribute, source_device, peer_device
+                        ),
+                        "cuDeviceGetP2PAttribute(NATIVE_ATOMIC_SUPPORTED, "
+                        f"{device_id}, {peer_device_id})",
+                    )
+                )
+                if not native_atomics:
+                    raise NotImplementedError(
+                        "Peer-memory fencing requires native peer atomics, but CUDA "
+                        f"device {device_id} cannot issue them to PCP rank "
+                        f"{peer_rank} device {peer_device_id}."
+                    )
+    except BaseException as exc:
+        local_error = exc
+    _raise_if_any_rank_failed(group, rank, "peer capability validation", local_error)
+
+
+def _make_allocation_property(driver: Any, device_id: int, handle_types: Any) -> Any:
+    prop = driver.CUmemAllocationProp()
+    prop.type = driver.CUmemAllocationType.CU_MEM_ALLOCATION_TYPE_PINNED
+    prop.location = driver.CUmemLocation()
+    prop.location.type = driver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
+    prop.location.id = device_id
+    prop.requestedHandleTypes = handle_types
+    return prop
+
+
+def _make_rw_access(driver: Any, device_id: int) -> Any:
+    access = driver.CUmemAccessDesc()
+    access.location.type = driver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
+    access.location.id = device_id
+    access.flags = driver.CUmemAccess_flags.CU_MEM_ACCESS_FLAGS_PROT_READWRITE
+    return access
+
+
+def _element_size(dtype: torch.dtype) -> int:
+    return torch.empty((), dtype=dtype, device="cpu").element_size()
+
+
+def _aligned_local_shape(
+    local_shape: tuple[int, ...],
+    dtype: torch.dtype,
+    granularity: int,
+    first_dim_multiple: int,
+) -> tuple[tuple[int, ...], int]:
+    row_bytes = math.prod(local_shape[1:]) * _element_size(dtype)
+    rows_per_granularity = granularity // math.gcd(granularity, row_bytes)
+    row_alignment = math.lcm(rows_per_granularity, first_dim_multiple)
+    rows = math.ceil(local_shape[0] / row_alignment) * row_alignment
+    return (rows, *local_shape[1:]), rows * row_bytes
+
+
+def _release_handle(driver: Any, handle: Any, label: str) -> None:
+    _check_driver(driver.cuMemRelease(handle), label)
+
+
+def _allocate_local_segment(
+    driver: Any,
+    group: ProcessGroup,
+    rank: int,
+    device_id: int,
+    local_shape: tuple[int, ...],
+    dtype: torch.dtype,
+    first_dim_multiple: int,
+) -> tuple[Any, tuple[int, ...], int, int]:
+    posix = driver.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+    granularity_flag = (
+        driver.CUmemAllocationGranularity_flags.CU_MEM_ALLOC_GRANULARITY_RECOMMENDED
+    )
+
+    prop: Any | None = None
+    granularity = 0
+    aligned_shape: tuple[int, ...] = ()
+    segment_bytes = 0
+    local_error: BaseException | None = None
+    try:
+        # The Python CUDA bindings do not consistently accept combined
+        # CUmemAllocationHandleType bitmasks across releases. POSIX FDs are the
+        # portable same-host transport required by this primitive; transport
+        # choice does not affect runtime peer loads or stores after mapping.
+        prop = _make_allocation_property(driver, device_id, posix)
+        granularity = int(
+            _check_driver(
+                driver.cuMemGetAllocationGranularity(prop, granularity_flag),
+                "cuMemGetAllocationGranularity",
+            )
+        )
+        aligned_shape, segment_bytes = _aligned_local_shape(
+            local_shape, dtype, granularity, first_dim_multiple
+        )
+    except BaseException as exc:
+        local_error = exc
+    _raise_if_any_rank_failed(group, rank, "allocation planning", local_error)
+    assert prop is not None
+
+    plan = (aligned_shape, segment_bytes, granularity)
+    plans: list[Any] = [None] * dist.get_world_size(group)
+    dist.all_gather_object(plans, plan, group=group)
+    if any(peer_plan != plan for peer_plan in plans):
+        details = ", ".join(
+            f"rank {peer_rank}={peer_plan!r}"
+            for peer_rank, peer_plan in enumerate(plans)
+        )
+        raise RuntimeError(
+            "CUDA VMM allocation granularity must match on every rank; " + details
+        )
+
+    local_handle: Any | None = None
+    allocation_error: BaseException | None = None
+    try:
+        local_handle = _check_driver(
+            driver.cuMemCreate(segment_bytes, prop, 0),
+            "cuMemCreate(POSIX_FD)",
+        )
+    except BaseException as exc:
+        allocation_error = exc
+    try:
+        _raise_if_any_rank_failed(group, rank, "local allocation", allocation_error)
+    except BaseException:
+        if local_handle is not None:
+            _release_handle(driver, local_handle, "cuMemRelease(failed allocation)")
+        raise
+    return local_handle, aligned_shape, segment_bytes, granularity
+
+
+def _export_local_handle(
+    driver: Any,
+    group: ProcessGroup,
+    rank: int,
+    local_handle: Any,
+) -> tuple[Literal["fabric", "posix_fd"], bytes | int]:
+    posix = driver.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+
+    local_fd: int | None = None
+    posix_error: BaseException | None = None
+    try:
+        local_fd = int(
+            _check_driver(
+                driver.cuMemExportToShareableHandle(local_handle, posix, 0),
+                "cuMemExportToShareableHandle(POSIX_FD)",
+            )
+        )
+    except BaseException as exc:
+        posix_error = exc
+    try:
+        _raise_if_any_rank_failed(group, rank, "handle export", posix_error)
+    except BaseException:
+        if local_fd is not None:
+            os.close(local_fd)
+        raise
+    assert local_fd is not None
+    return "posix_fd", local_fd
+
+
+def _send_fd(sock: socket.socket, rank: int, fd: int) -> None:
+    payload = _FD_HEADER.pack(rank)
+    fds = array.array("i", [fd])
+    sent = sock.sendmsg(
+        [payload],
+        [(socket.SOL_SOCKET, socket.SCM_RIGHTS, fds.tobytes())],
+    )
+    if sent <= 0:
+        raise RuntimeError("sendmsg did not send the FD header")
+    if sent < len(payload):
+        # SOCK_SEQPACKET sends the header atomically. The SOCK_STREAM fallback
+        # may split it; SCM_RIGHTS is already attached to the first byte, so
+        # only the remaining framing bytes are sent here.
+        sock.sendall(payload[sent:])
+
+
+def _recv_fd(sock: socket.socket) -> tuple[int, int] | None:
+    fd_size = array.array("i").itemsize
+    payload = bytearray()
+    received = array.array("i")
+    try:
+        while len(payload) < _FD_HEADER.size:
+            chunk, ancillary, _, _ = sock.recvmsg(
+                _FD_HEADER.size - len(payload), socket.CMSG_SPACE(fd_size)
+            )
+            if not chunk:
+                if not payload and not received:
+                    return None
+                raise RuntimeError(
+                    "peer closed with an incomplete POSIX FD header: "
+                    f"{len(payload)}/{_FD_HEADER.size} bytes"
+                )
+            payload.extend(chunk)
+            for level, message_type, data in ancillary:
+                if level == socket.SOL_SOCKET and message_type == socket.SCM_RIGHTS:
+                    received.frombytes(data[: len(data) - len(data) % fd_size])
+        if len(received) != 1:
+            raise RuntimeError(
+                f"expected one file descriptor, received {len(received)}"
+            )
+        return _FD_HEADER.unpack(payload)[0], int(received[0])
+    except BaseException:
+        for received_fd in received:
+            os.close(received_fd)
+        raise
+
+
+def _exchange_posix_fds(
+    group: ProcessGroup, rank: int, world_size: int, local_fd: int
+) -> dict[int, int]:
+    """Exchange one process-local CUDA allocation FD per group rank."""
+    socket_kind = getattr(socket, "SOCK_SEQPACKET", socket.SOCK_STREAM)
+    socket_dir: str | None = None
+    socket_path: str | None = None
+    server: socket.socket | None = None
+    received: dict[int, int] = {}
+    receive_errors: list[BaseException] = []
+    active_connections: set[socket.socket] = set()
+    connection_lock = threading.Lock()
+
+    def receive_loop() -> None:
+        assert server is not None
+        try:
+            for _ in range(world_size - 1):
+                connection, _ = server.accept()
+                with connection_lock:
+                    active_connections.add(connection)
+                try:
+                    connection.settimeout(_FD_EXCHANGE_TIMEOUT_S)
+                    message = _recv_fd(connection)
+                    if message is None:
+                        raise RuntimeError(
+                            "peer closed its socket before sending an FD"
+                        )
+                    peer_rank, peer_fd = message
+                    if peer_rank in received:
+                        os.close(peer_fd)
+                        raise RuntimeError(f"duplicate FD from group rank {peer_rank}")
+                    received[peer_rank] = peer_fd
+                finally:
+                    with connection_lock:
+                        active_connections.discard(connection)
+                    connection.close()
+        except BaseException as exc:
+            receive_errors.append(exc)
+
+    try:
+        setup_error: BaseException | None = None
+        try:
+            socket_dir = tempfile.mkdtemp(prefix="vllm_vmm_fd_")
+            socket_path = os.path.join(socket_dir, f"rank_{rank}.sock")
+            server = socket.socket(socket.AF_UNIX, socket_kind)
+            server.settimeout(_FD_EXCHANGE_TIMEOUT_S)
+            server.bind(socket_path)
+            server.listen(world_size)
+        except BaseException as exc:
+            setup_error = exc
+        _raise_if_any_rank_failed(group, rank, "POSIX FD socket setup", setup_error)
+
+        socket_paths: list[str | None] = [None] * world_size
+        dist.all_gather_object(socket_paths, socket_path, group=group)
+        thread = threading.Thread(
+            target=receive_loop,
+            name=f"vllm-vmm-fd-rank-{rank}",
+            daemon=True,
+        )
+        thread.start()
+
+        send_error: BaseException | None = None
+        try:
+            for peer_rank, peer_path in enumerate(socket_paths):
+                if peer_rank == rank:
+                    continue
+                assert peer_path is not None
+                with socket.socket(socket.AF_UNIX, socket_kind) as client:
+                    client.settimeout(_FD_EXCHANGE_TIMEOUT_S)
+                    client.connect(peer_path)
+                    _send_fd(client, rank, local_fd)
+        except BaseException as exc:
+            send_error = exc
+        thread.join(_FD_EXCHANGE_TIMEOUT_S)
+        transfer_error = send_error
+        if thread.is_alive():
+            if transfer_error is None:
+                transfer_error = RuntimeError("timed out receiving POSIX FDs")
+            # Stop accept/recv before inspecting or closing ``received`` so a
+            # late SCM_RIGHTS message cannot race cleanup and leak its FD.
+            assert server is not None
+            server.close()
+            with connection_lock:
+                connections = tuple(active_connections)
+            for connection in connections:
+                with suppress(OSError):
+                    connection.shutdown(socket.SHUT_RDWR)
+                connection.close()
+            thread.join()
+        if transfer_error is None and receive_errors:
+            transfer_error = receive_errors[0]
+        expected = set(range(world_size)) - {rank}
+        if transfer_error is None and set(received) != expected:
+            transfer_error = RuntimeError(
+                "FD sender mismatch: "
+                f"missing={sorted(expected - set(received))}, "
+                f"extra={sorted(set(received) - expected)}"
+            )
+        try:
+            _raise_if_any_rank_failed(group, rank, "POSIX FD transfer", transfer_error)
+        except BaseException:
+            for peer_fd in received.values():
+                os.close(peer_fd)
+            received.clear()
+            raise
+        return received
+    finally:
+        if server is not None:
+            server.close()
+        if socket_path is not None:
+            with suppress(FileNotFoundError):
+                os.unlink(socket_path)
+        if socket_dir is not None:
+            with suppress(OSError):
+                os.rmdir(socket_dir)
+
+
+def _import_peer_handle(
+    driver: Any,
+    transport: Literal["fabric", "posix_fd"],
+    exported_handle: bytes | int,
+    peer_rank: int,
+) -> Any:
+    handle_types = driver.CUmemAllocationHandleType
+    if transport == "fabric":
+        handle_type = handle_types.CU_MEM_HANDLE_TYPE_FABRIC
+        return _check_driver(
+            driver.cuMemImportFromShareableHandle(exported_handle, handle_type),
+            f"cuMemImportFromShareableHandle(FABRIC, rank={peer_rank})",
+        )
+
+    handle_type = handle_types.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+    duplicate_fd = os.dup(int(exported_handle))
+    try:
+        return _check_driver(
+            driver.cuMemImportFromShareableHandle(duplicate_fd, handle_type),
+            f"cuMemImportFromShareableHandle(POSIX_FD, rank={peer_rank})",
+        )
+    finally:
+        os.close(duplicate_fd)
+
+
+class _DLDevice(ctypes.Structure):
+    _fields_ = [("device_type", ctypes.c_int), ("device_id", ctypes.c_int)]
+
+
+class _DLDataType(ctypes.Structure):
+    _fields_ = [
+        ("code", ctypes.c_uint8),
+        ("bits", ctypes.c_uint8),
+        ("lanes", ctypes.c_uint16),
+    ]
+
+
+class _DLTensor(ctypes.Structure):
+    _fields_ = [
+        ("data", ctypes.c_void_p),
+        ("device", _DLDevice),
+        ("ndim", ctypes.c_int),
+        ("dtype", _DLDataType),
+        ("shape", ctypes.POINTER(ctypes.c_int64)),
+        ("strides", ctypes.POINTER(ctypes.c_int64)),
+        ("byte_offset", ctypes.c_uint64),
+    ]
+
+
+class _DLManagedTensor(ctypes.Structure):
+    pass
+
+
+_DLPACK_DELETER = ctypes.CFUNCTYPE(None, ctypes.POINTER(_DLManagedTensor))
+_DLManagedTensor._fields_ = [
+    ("dl_tensor", _DLTensor),
+    ("manager_ctx", ctypes.c_void_p),
+    ("deleter", _DLPACK_DELETER),
+]
+
+
+def _dtype_to_dlpack(dtype: torch.dtype) -> tuple[int, int]:
+    types: dict[torch.dtype, tuple[int, int]] = {
+        torch.uint8: (1, 8),
+        torch.int8: (0, 8),
+        torch.int16: (0, 16),
+        torch.int32: (0, 32),
+        torch.int64: (0, 64),
+        torch.float16: (2, 16),
+        torch.bfloat16: (4, 16),
+        torch.float32: (2, 32),
+        torch.float64: (2, 64),
+        torch.bool: (6, 8),
+        torch.complex64: (5, 64),
+        torch.complex128: (5, 128),
+    }
+    optional_types = (
+        ("float8_e4m3fn", 10),
+        ("float8_e4m3fnuz", 11),
+        ("float8_e5m2", 12),
+        ("float8_e5m2fnuz", 13),
+    )
+    for name, code in optional_types:
+        if hasattr(torch, name):
+            types[getattr(torch, name)] = (code, 8)
+    try:
+        return types[dtype]
+    except KeyError as exc:
+        raise TypeError(f"CUDA VMM peer views do not support dtype {dtype}") from exc
+
+
+def _tensor_from_cuda_pointer(
+    pointer: int,
+    shape: tuple[int, ...],
+    dtype: torch.dtype,
+    device_id: int,
+    refs: list[Any],
+) -> torch.Tensor:
+    dtype_code, dtype_bits = _dtype_to_dlpack(dtype)
+    shape_array = (ctypes.c_int64 * len(shape))(*shape)
+    managed = _DLManagedTensor()
+    managed.dl_tensor.data = ctypes.c_void_p(pointer)
+    managed.dl_tensor.device = _DLDevice(2, device_id)
+    managed.dl_tensor.ndim = len(shape)
+    managed.dl_tensor.dtype = _DLDataType(dtype_code, dtype_bits, 1)
+    managed.dl_tensor.shape = shape_array
+    managed.dl_tensor.strides = None
+    managed.dl_tensor.byte_offset = 0
+    managed.manager_ctx = None
+
+    @_DLPACK_DELETER
+    def deleter(_: ctypes.POINTER(_DLManagedTensor)) -> None:
+        return None
+
+    managed.deleter = deleter
+    refs.extend((managed, shape_array, deleter))
+    ctypes.pythonapi.PyCapsule_New.restype = ctypes.py_object
+    ctypes.pythonapi.PyCapsule_New.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_char_p,
+        ctypes.c_void_p,
+    ]
+    capsule = ctypes.pythonapi.PyCapsule_New(ctypes.byref(managed), b"dltensor", None)
+    return torch.from_dlpack(capsule)
+
+
+def _rollback_mapping(
+    driver: Any,
+    base_va: int | None,
+    total_bytes: int,
+    mapped_addresses: list[int],
+    segment_bytes: int,
+) -> None:
+    failed_addresses: list[int] = []
+    while mapped_addresses:
+        address = mapped_addresses.pop()
+        try:
+            _check_driver(
+                driver.cuMemUnmap(address, segment_bytes),
+                "cuMemUnmap(rollback)",
+            )
+        except Exception:
+            logger.exception("Failed to roll back CUDA VMM mapping at %#x", address)
+            failed_addresses.append(address)
+    if base_va is not None and not failed_addresses:
+        try:
+            _check_driver(
+                driver.cuMemAddressFree(base_va, total_bytes),
+                "cuMemAddressFree(rollback)",
+            )
+        except Exception:
+            logger.exception(
+                "Failed to roll back CUDA VMM address range at %#x", base_va
+            )
+
+
+@dataclass
+class RankMajorPeerView:
+    """Rank-segmented CUDA memory exposed through rank-major tensor aliases.
+
+    ``global_view`` stores group-rank ``r`` at rows
+    ``[r * rows_per_rank:(r + 1) * rows_per_rank]``. If requested,
+    ``rank_local_view`` contains the same physical segments rotated so the
+    current rank is first. ``local_view`` is the current rank's owner segment.
+
+    All tensor aliases become invalid when :meth:`close` is called. Callers
+    must arrange any inter-rank write/read synchronization themselves.
+    """
+
+    global_view: torch.Tensor | None
+    rank_local_view: torch.Tensor | None
+    local_view: torch.Tensor | None
+    requested_shape: tuple[int, ...]
+    aligned_local_shape: tuple[int, ...]
+    rows_per_rank: int
+    bytes_per_rank: int
+    rank: int
+    world_size: int
+    device: torch.device
+    transport: Literal["fabric", "posix_fd"]
+    _global_base_va: int | None
+    _rank_local_base_va: int | None
+    _total_bytes: int
+    _global_mappings: list[int] = field(repr=False)
+    _rank_local_mappings: list[int] = field(repr=False)
+    _dlpack_refs: list[Any] = field(repr=False)
+    _refs_retired: bool = field(default=False, init=False, repr=False)
+    _closed: bool = field(default=False, init=False, repr=False)
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def __enter__(self) -> RankMajorPeerView:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        # Tensor views can outlive the allocation wrapper. Keep the ctypes
+        # DLPack metadata and callback callable until process teardown even
+        # when a caller forgot the required explicit close(). CUDA mappings
+        # are intentionally not touched from a Python finalizer.
+        if not self._refs_retired and self._dlpack_refs:
+            _RETIRED_DLPACK_REFS.append(self._dlpack_refs)
+            self._refs_retired = True
+
+    def close(self) -> None:
+        """Synchronize the local device and deterministically release mappings."""
+        if self._closed:
+            return
+        torch.cuda.synchronize(self.device)
+
+        self.local_view = None
+        self.rank_local_view = None
+        self.global_view = None
+        if not self._refs_retired:
+            _RETIRED_DLPACK_REFS.append(self._dlpack_refs)
+            self._refs_retired = True
+
+        driver = _get_cuda_driver()
+        failures: list[str] = []
+        regions = (
+            ("global", "_global_base_va", self._global_mappings),
+            ("rank-local", "_rank_local_base_va", self._rank_local_mappings),
+        )
+        for label, base_attribute, mappings in regions:
+            while mappings:
+                address = mappings[-1]
+                try:
+                    _check_driver(
+                        driver.cuMemUnmap(address, self.bytes_per_rank),
+                        f"cuMemUnmap({label})",
+                    )
+                except BaseException as exc:
+                    failures.append(str(exc))
+                    break
+                mappings.pop()
+            base_va = getattr(self, base_attribute)
+            if base_va is not None and not mappings:
+                try:
+                    _check_driver(
+                        driver.cuMemAddressFree(base_va, self._total_bytes),
+                        f"cuMemAddressFree({label})",
+                    )
+                except BaseException as exc:
+                    failures.append(str(exc))
+                else:
+                    setattr(self, base_attribute, None)
+
+        self._closed = self._global_base_va is None and self._rank_local_base_va is None
+        if failures:
+            raise RuntimeError("CUDA VMM close failed: " + "; ".join(failures))
+
+
+def create_rank_major_peer_view(
+    local_shape: tuple[int, ...],
+    *,
+    dtype: torch.dtype,
+    group: ProcessGroup,
+    first_dim_multiple: int = 1,
+    map_rank_local: bool = False,
+    require_native_atomics: bool = False,
+    device: torch.device | str | int | None = None,
+) -> RankMajorPeerView:
+    """Collectively create a same-host rank-major CUDA peer tensor.
+
+    Each rank owns one physical VMM allocation. Every rank maps all allocations
+    in group-rank order into one contiguous virtual address range. Setup uses
+    same-host POSIX file descriptors to transfer allocation handles.
+
+    Args:
+        local_shape: Requested owner-local tensor shape. Its first dimension is
+            padded to CUDA allocation granularity and ``first_dim_multiple``.
+        dtype: Tensor element type.
+        group: Same-host, CPU-capable process group used for setup collectives.
+        first_dim_multiple: Additional alignment for the padded first dimension.
+        map_rank_local: Also create a rotated alias with the local rank first.
+        require_native_atomics: Require directed native peer-atomic support
+            between every pair of devices in addition to peer load/store access.
+        device: CUDA device. It must be the process's current CUDA device.
+
+    Returns:
+        A peer view whose ``local_view`` is the owner-local allocation.
+
+    Raises:
+        RuntimeError: If CUDA VMM setup fails on any group rank.
+        ValueError: If arguments, topology, or current device are invalid.
+    """
+    local_shape = tuple(local_shape)
+    rank, world_size = _validate_request(
+        group,
+        local_shape,
+        dtype,
+        first_dim_multiple,
+        map_rank_local,
+        require_native_atomics,
+    )
+
+    local_error: BaseException | None = None
+    driver: Any | None = None
+    device_id = -1
+    resolved_device = torch.device("cuda")
+    try:
+        driver = _get_cuda_driver()
+        current_device = torch.cuda.current_device()
+        if device is None:
+            resolved_device = torch.device(f"cuda:{current_device}")
+        elif isinstance(device, int):
+            resolved_device = torch.device(f"cuda:{device}")
+        else:
+            resolved_device = torch.device(device)
+        if resolved_device.type != "cuda":
+            raise ValueError(f"device must be CUDA, got {resolved_device}")
+        device_id = (
+            current_device
+            if resolved_device.index is None
+            else int(resolved_device.index)
+        )
+        if device_id != current_device:
+            raise ValueError(
+                f"device {device_id} is not the current CUDA device {current_device}"
+            )
+        resolved_device = torch.device(f"cuda:{device_id}")
+    except BaseException as exc:
+        local_error = exc
+    _raise_if_any_rank_failed(group, rank, "CUDA initialization", local_error)
+    assert driver is not None
+    _validate_peer_capabilities(driver, group, rank, device_id, require_native_atomics)
+
+    local_handle, aligned_shape, segment_bytes, granularity = _allocate_local_segment(
+        driver,
+        group,
+        rank,
+        device_id,
+        local_shape,
+        dtype,
+        first_dim_multiple,
+    )
+
+    local_fd: int | None = None
+    peer_fds: dict[int, int] = {}
+    imported_handles: list[Any] = []
+    dlpack_refs: list[Any] = []
+    global_base_va: int | None = None
+    rank_local_base_va: int | None = None
+    global_mappings: list[int] = []
+    rank_local_mappings: list[int] = []
+    total_bytes = segment_bytes * world_size
+    transport: Literal["fabric", "posix_fd"] = "posix_fd"
+    try:
+        transport, exported_handle = _export_local_handle(
+            driver, group, rank, local_handle
+        )
+        peer_handles: list[bytes | int | None] = [None] * world_size
+        if transport == "fabric":
+            dist.all_gather_object(peer_handles, exported_handle, group=group)
+        else:
+            local_fd = int(exported_handle)
+            peer_fds = _exchange_posix_fds(group, rank, world_size, local_fd)
+
+        mapping_error: BaseException | None = None
+        try:
+            global_base_va = int(
+                _check_driver(
+                    driver.cuMemAddressReserve(total_bytes, granularity, 0, 0),
+                    "cuMemAddressReserve(global)",
+                )
+            )
+            if map_rank_local:
+                rank_local_base_va = int(
+                    _check_driver(
+                        driver.cuMemAddressReserve(total_bytes, granularity, 0, 0),
+                        "cuMemAddressReserve(rank-local)",
+                    )
+                )
+
+            access = _make_rw_access(driver, device_id)
+            for peer_rank in range(world_size):
+                handle = local_handle
+                if peer_rank != rank:
+                    exported = (
+                        peer_handles[peer_rank]
+                        if transport == "fabric"
+                        else peer_fds[peer_rank]
+                    )
+                    assert exported is not None
+                    handle = _import_peer_handle(driver, transport, exported, peer_rank)
+                    imported_handles.append(handle)
+
+                global_address = global_base_va + peer_rank * segment_bytes
+                _check_driver(
+                    driver.cuMemMap(global_address, segment_bytes, 0, handle, 0),
+                    f"cuMemMap(global, rank={peer_rank})",
+                )
+                global_mappings.append(global_address)
+                _check_driver(
+                    driver.cuMemSetAccess(global_address, segment_bytes, [access], 1),
+                    f"cuMemSetAccess(global, rank={peer_rank})",
+                )
+
+                if rank_local_base_va is not None:
+                    rank_local_segment = (peer_rank - rank) % world_size
+                    rank_local_address = (
+                        rank_local_base_va + rank_local_segment * segment_bytes
+                    )
+                    _check_driver(
+                        driver.cuMemMap(
+                            rank_local_address, segment_bytes, 0, handle, 0
+                        ),
+                        f"cuMemMap(rank-local, rank={peer_rank})",
+                    )
+                    rank_local_mappings.append(rank_local_address)
+                    _check_driver(
+                        driver.cuMemSetAccess(
+                            rank_local_address, segment_bytes, [access], 1
+                        ),
+                        f"cuMemSetAccess(rank-local, rank={peer_rank})",
+                    )
+
+                if peer_rank != rank:
+                    _release_handle(
+                        driver, handle, f"cuMemRelease(imported rank={peer_rank})"
+                    )
+                    imported_handles.pop()
+        except BaseException as exc:
+            mapping_error = exc
+        _raise_if_any_rank_failed(group, rank, "peer mapping", mapping_error)
+
+        release_error: BaseException | None = None
+        try:
+            _release_handle(driver, local_handle, "cuMemRelease(local)")
+            local_handle = None
+        except BaseException as exc:
+            release_error = exc
+        _raise_if_any_rank_failed(
+            group, rank, "allocation handle release", release_error
+        )
+
+        global_view: torch.Tensor | None = None
+        rank_local_view: torch.Tensor | None = None
+        local_view: torch.Tensor | None = None
+        tensor_error: BaseException | None = None
+        try:
+            global_shape = (world_size * aligned_shape[0], *aligned_shape[1:])
+            assert global_base_va is not None
+            global_view = _tensor_from_cuda_pointer(
+                global_base_va, global_shape, dtype, device_id, dlpack_refs
+            )
+            if rank_local_base_va is not None:
+                rank_local_view = _tensor_from_cuda_pointer(
+                    rank_local_base_va,
+                    global_shape,
+                    dtype,
+                    device_id,
+                    dlpack_refs,
+                )
+            local_segment_va = global_base_va + rank * segment_bytes
+            local_view = _tensor_from_cuda_pointer(
+                local_segment_va,
+                aligned_shape,
+                dtype,
+                device_id,
+                dlpack_refs,
+            )
+        except BaseException as exc:
+            tensor_error = exc
+        _raise_if_any_rank_failed(group, rank, "tensor construction", tensor_error)
+        assert global_view is not None and local_view is not None
+
+        return RankMajorPeerView(
+            global_view=global_view,
+            rank_local_view=rank_local_view,
+            local_view=local_view,
+            requested_shape=local_shape,
+            aligned_local_shape=aligned_shape,
+            rows_per_rank=aligned_shape[0],
+            bytes_per_rank=segment_bytes,
+            rank=rank,
+            world_size=world_size,
+            device=resolved_device,
+            transport=transport,
+            _global_base_va=global_base_va,
+            _rank_local_base_va=rank_local_base_va,
+            _total_bytes=total_bytes,
+            _global_mappings=global_mappings,
+            _rank_local_mappings=rank_local_mappings,
+            _dlpack_refs=dlpack_refs,
+        )
+    except BaseException:
+        if dlpack_refs:
+            _RETIRED_DLPACK_REFS.append(dlpack_refs)
+        _rollback_mapping(
+            driver,
+            global_base_va,
+            total_bytes,
+            global_mappings,
+            segment_bytes,
+        )
+        _rollback_mapping(
+            driver,
+            rank_local_base_va,
+            total_bytes,
+            rank_local_mappings,
+            segment_bytes,
+        )
+        for handle in imported_handles:
+            try:
+                _check_driver(
+                    driver.cuMemRelease(handle),
+                    "cuMemRelease(imported rollback)",
+                )
+            except Exception:
+                logger.exception("Failed to release imported CUDA VMM handle")
+        if local_handle is not None:
+            try:
+                _check_driver(
+                    driver.cuMemRelease(local_handle),
+                    "cuMemRelease(local rollback)",
+                )
+            except Exception:
+                logger.exception("Failed to release local CUDA VMM handle")
+        raise
+    finally:
+        if local_fd is not None:
+            os.close(local_fd)
+        for peer_fd in peer_fds.values():
+            os.close(peer_fd)

--- a/vllm/distributed/device_communicators/cuda_vmm.py
+++ b/vllm/distributed/device_communicators/cuda_vmm.py
@@ -640,7 +640,7 @@ def _tensor_from_cuda_pointer(
     managed.manager_ctx = None
 
     @_DLPACK_DELETER
-    def deleter(_: ctypes.POINTER(_DLManagedTensor)) -> None:
+    def deleter(_: Any) -> None:
         return None
 
     managed.deleter = deleter
@@ -741,7 +741,7 @@ class RankMajorPeerView:
         """Synchronize the local device and deterministically release mappings."""
         if self._closed:
             return
-        torch.cuda.synchronize(self.device)
+        torch.accelerator.synchronize(self.device)
 
         self.local_view = None
         self.rank_local_view = None
@@ -835,7 +835,7 @@ def create_rank_major_peer_view(
     resolved_device = torch.device("cuda")
     try:
         driver = _get_cuda_driver()
-        current_device = torch.cuda.current_device()
+        current_device = torch.accelerator.current_device_index()
         if device is None:
             resolved_device = torch.device(f"cuda:{current_device}")
         elif isinstance(device, int):

--- a/vllm/distributed/device_communicators/peer_memory.py
+++ b/vllm/distributed/device_communicators/peer_memory.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Rank-major peer tensor views and system-scope publication fencing."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+
+from vllm.triton_utils import tl, triton
+
+if TYPE_CHECKING:
+    from vllm.distributed.device_communicators.cuda_vmm import RankMajorPeerView
+
+_MAX_FENCE_SPINS = 100_000_000
+
+
+@triton.jit
+def _trap_if_nonzero(value):
+    """Unconditionally compile a device trap when a bounded wait times out."""
+    return tl.inline_asm_elementwise(
+        asm="""
+        {
+            .reg .pred failed;
+            setp.ne.u32 failed, $1, 0;
+            @failed trap;
+            mov.u32 $0, 0;
+        }
+        """,
+        constraints="=r,r",
+        args=[value],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+def make_rank_major_tensor_view(
+    allocation: RankMajorPeerView,
+    local_tensor: torch.Tensor,
+) -> torch.Tensor:
+    """Mirror a tensor view across every rank segment without copying bytes."""
+    element_size = local_tensor.element_size()
+    if allocation.bytes_per_rank % element_size != 0:
+        raise ValueError(
+            "Peer allocation stride is not divisible by the tensor element size: "
+            f"{allocation.bytes_per_rank} bytes vs {element_size}."
+        )
+
+    local_offset_bytes = local_tensor.data_ptr() - allocation.local_view.data_ptr()
+    view_span = 0 if local_tensor.numel() == 0 else 1
+    for size, stride in zip(local_tensor.shape, local_tensor.stride()):
+        if size > 0:
+            view_span += (size - 1) * stride
+    view_span_bytes = view_span * element_size
+    if (
+        local_offset_bytes < 0
+        or local_offset_bytes + view_span_bytes > allocation.bytes_per_rank
+    ):
+        raise ValueError("Tensor view lies outside its local peer allocation.")
+    if local_offset_bytes % element_size != 0:
+        raise ValueError("Tensor view is not aligned to its element size.")
+
+    global_typed = allocation.global_view.view(local_tensor.dtype)
+    rank_stride = allocation.bytes_per_rank // element_size
+    return torch.as_strided(
+        global_typed,
+        size=(allocation.world_size, *local_tensor.shape),
+        stride=(rank_stride, *local_tensor.stride()),
+        storage_offset=local_offset_bytes // element_size,
+    )
+
+
+@triton.jit
+def _publish_fence_kernel(
+    peer_signal_ptr,
+    peer_rank_stride,
+    epoch,
+    parity,
+    source_rank: tl.constexpr,
+    world_size: tl.constexpr,
+):
+    destination_rank = tl.program_id(0)
+    if destination_rank < world_size:
+        signal_ptr = (
+            peer_signal_ptr
+            + destination_rank * peer_rank_stride
+            + parity * world_size
+            + source_rank
+        )
+        tl.atomic_xchg(signal_ptr, epoch, sem="release", scope="sys")
+
+
+@triton.jit
+def _wait_fence_kernel(
+    local_signal_ptr,
+    epoch,
+    parity,
+    world_size: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    MAX_SPINS: tl.constexpr,
+):
+    source_rank = tl.arange(0, BLOCK_SIZE)
+    mask = source_rank < world_size
+    signal_ptr = local_signal_ptr + parity * world_size + source_rank
+    observed = tl.atomic_add(
+        signal_ptr,
+        0,
+        mask=mask,
+        sem="acquire",
+        scope="sys",
+    )
+    pending = tl.max(tl.where(mask & (observed != epoch), 1, 0))
+    spins = 0
+    while (pending != 0) & (spins < MAX_SPINS):
+        observed = tl.atomic_add(
+            signal_ptr,
+            0,
+            mask=mask,
+            sem="acquire",
+            scope="sys",
+        )
+        pending = tl.max(tl.where(mask & (observed != epoch), 1, 0))
+        spins += 1
+    _trap_if_nonzero(pending)
+
+
+class PeerMemoryFence:
+    """Reusable release/acquire fence for one peer-memory process group."""
+
+    def __init__(self, group: ProcessGroup, device: torch.device) -> None:
+        from vllm.distributed.device_communicators.cuda_vmm import (
+            create_rank_major_peer_view,
+        )
+
+        self._group = group
+        self._world_size = group.size()
+        self._rank = group.rank()
+        self._epoch = 0
+        self._closed = False
+        self._allocation = create_rank_major_peer_view(
+            (2, self._world_size),
+            dtype=torch.int32,
+            group=group,
+            require_native_atomics=True,
+            device=device,
+        )
+        self._allocation.local_view.zero_()
+        torch.accelerator.synchronize()
+        dist.barrier(group=group)
+        self._peer_signals = make_rank_major_tensor_view(
+            self._allocation, self._allocation.local_view
+        )
+
+    def __call__(self) -> None:
+        if self._closed:
+            raise RuntimeError("Peer-memory fence is closed.")
+        self._epoch = self._epoch % 0x7FFFFFFE + 1
+        parity = self._epoch & 1
+        _publish_fence_kernel[(self._world_size,)](
+            self._peer_signals,
+            self._peer_signals.stride(0),
+            self._epoch,
+            parity,
+            source_rank=self._rank,
+            world_size=self._world_size,
+        )
+        _wait_fence_kernel[(1,)](
+            self._allocation.local_view,
+            self._epoch,
+            parity,
+            world_size=self._world_size,
+            BLOCK_SIZE=triton.next_power_of_2(self._world_size),
+            MAX_SPINS=_MAX_FENCE_SPINS,
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        # Every rank must stop using peer signals before any rank unmaps them.
+        torch.accelerator.synchronize()
+        dist.barrier(group=self._group)
+        self._peer_signals = None
+        self._allocation.close()
+        self._closed = True

--- a/vllm/distributed/device_communicators/peer_memory.py
+++ b/vllm/distributed/device_communicators/peer_memory.py
@@ -43,6 +43,11 @@ def make_rank_major_tensor_view(
     local_tensor: torch.Tensor,
 ) -> torch.Tensor:
     """Mirror a tensor view across every rank segment without copying bytes."""
+    local_view = allocation.local_view
+    global_view = allocation.global_view
+    if local_view is None or global_view is None:
+        raise RuntimeError("Peer allocation is closed.")
+
     element_size = local_tensor.element_size()
     if allocation.bytes_per_rank % element_size != 0:
         raise ValueError(
@@ -50,7 +55,7 @@ def make_rank_major_tensor_view(
             f"{allocation.bytes_per_rank} bytes vs {element_size}."
         )
 
-    local_offset_bytes = local_tensor.data_ptr() - allocation.local_view.data_ptr()
+    local_offset_bytes = local_tensor.data_ptr() - local_view.data_ptr()
     view_span = 0 if local_tensor.numel() == 0 else 1
     for size, stride in zip(local_tensor.shape, local_tensor.stride()):
         if size > 0:
@@ -64,7 +69,7 @@ def make_rank_major_tensor_view(
     if local_offset_bytes % element_size != 0:
         raise ValueError("Tensor view is not aligned to its element size.")
 
-    global_typed = allocation.global_view.view(local_tensor.dtype)
+    global_typed = global_view.view(local_tensor.dtype)
     rank_stride = allocation.bytes_per_rank // element_size
     return torch.as_strided(
         global_typed,
@@ -148,12 +153,13 @@ class PeerMemoryFence:
             require_native_atomics=True,
             device=device,
         )
-        self._allocation.local_view.zero_()
+        local_view = self._allocation.local_view
+        if local_view is None:
+            raise RuntimeError("Peer-memory fence allocation is closed.")
+        local_view.zero_()
         torch.accelerator.synchronize()
         dist.barrier(group=group)
-        self._peer_signals = make_rank_major_tensor_view(
-            self._allocation, self._allocation.local_view
-        )
+        self._peer_signals = make_rank_major_tensor_view(self._allocation, local_view)
 
     def __call__(self) -> None:
         if self._closed:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -58,6 +58,7 @@ if TYPE_CHECKING:
     VLLM_XLA_CACHE_PATH: str = os.path.join(VLLM_CACHE_ROOT, "xla_cache")
     VLLM_XLA_CHECK_RECOMPILATION: bool = False
     VLLM_SPARSE_INDEXER_MAX_LOGITS_MB: int = 512
+    VLLM_DCP_TOPK_VMM: bool = False
     VLLM_USE_RAY_COMPILED_DAG_CHANNEL_TYPE: Literal["auto", "nccl", "shm"] = "auto"
     VLLM_USE_RAY_COMPILED_DAG_OVERLAP_COMM: bool = False
     VLLM_USE_RAY_WRAPPED_PP_COMM: bool = True
@@ -1048,6 +1049,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SPARSE_INDEXER_MAX_LOGITS_MB": lambda: int(
         os.getenv("VLLM_SPARSE_INDEXER_MAX_LOGITS_MB", "512")
     ),
+    # Experimental owner-local VMM merge for bounded DCP sparse-indexer decode.
+    "VLLM_DCP_TOPK_VMM": lambda: bool(int(os.getenv("VLLM_DCP_TOPK_VMM", "0"))),
     # If set, the OpenAI API server will stay alive even after the underlying
     # AsyncLLMEngine errors and stops serving requests
     "VLLM_KEEP_ALIVE_ON_ENGINE_DEATH": lambda: bool(

--- a/vllm/model_executor/kernels/attention/dsa/dcp_indexer_cutedsl.py
+++ b/vllm/model_executor/kernels/attention/dsa/dcp_indexer_cutedsl.py
@@ -31,6 +31,30 @@ def stable_topk_from_gathered_candidates_cutedsl(
     return out
 
 
+def stable_topk_from_rank_major_candidates_cutedsl(
+    rank_major_candidates: torch.Tensor,
+    topk: int,
+    out: torch.Tensor,
+) -> None:
+    """Select directly from owner-local rank-major candidate storage.
+
+    ``rank_major_candidates`` has shape ``(world, rows, local_candidates, 2)``.
+    Its first-dimension stride may cross CUDA VMM mappings owned by different
+    ranks; this function must not materialize a contiguous gathered tensor.
+    """
+    if rank_major_candidates.ndim != 4 or rank_major_candidates.shape[-1] != 2:
+        raise ValueError(
+            "rank-major candidates must have shape (world, rows, local_candidates, 2)"
+        )
+    world_size = rank_major_candidates.shape[0]
+    local_candidates = rank_major_candidates.shape[2]
+    StableTopKFromRankMajorCandidatesKernel.compile(
+        topk,
+        world_size,
+        local_candidates,
+    )(rank_major_candidates, out)
+
+
 def pack_dcp_topk_candidates_cutedsl(
     logits: torch.Tensor,
     topk_indices: torch.Tensor,
@@ -414,6 +438,113 @@ class StableTopKFromGatheredCandidatesKernel:
         return cute.compile(
             kernel,
             gathered,
+            out,
+            stream,
+            options="--enable-tvm-ffi",
+        )
+
+
+class StableTopKFromRankMajorCandidatesKernel(StableTopKFromGatheredCandidatesKernel):
+    """Stable top-k whose input remains split across VMM owner segments."""
+
+    def __init__(self, topk: int, world_size: int, local_candidates: int):
+        super().__init__(topk, world_size * local_candidates)
+        self.world_size = world_size
+        self.local_candidates = local_candidates
+
+    @cute.jit
+    def __call__(
+        self,
+        rank_major_candidates: cute.Tensor,
+        out: cute.Tensor,
+        stream: CUstream,
+    ):
+        grid = (rank_major_candidates.shape[1], 1, 1)
+        self.kernel(rank_major_candidates, out).launch(
+            grid=grid,
+            block=(self.tb_size, 1, 1),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        input: cute.Tensor,
+        out: cute.Tensor,
+    ):
+        row, _, _ = cute.arch.block_idx()
+        tid, _, _ = cute.arch.thread_idx()
+        output_row = out[row, None]
+        keys = cute.make_rmem_tensor((self.keys_per_thread,), Uint64)
+
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage, 8)
+        committed_count_smem = storage.committed_count.data_ptr()
+        prefix_smem = storage.prefix_s.data_ptr()
+        for i in range(tid, self.topk, self.tb_size):
+            output_row[i] = Int32(-1)
+
+        for key_idx in cutlass.range_constexpr(self.keys_per_thread):
+            col = tid + Int32(key_idx * self.tb_size)
+            owner = col // Int32(self.local_candidates)
+            local_col = col - owner * Int32(self.local_candidates)
+            score = Float32(input[owner, row, local_col, 0])
+            token_id = Int32(input[owner, row, local_col, 1])
+            keys[key_idx] = self._stable_key(score, token_id)
+
+        if tid == Int32(0):
+            committed_count_smem.store(Int32(0))
+            prefix_smem.store(Uint64(0))
+        cute.arch.sync_threads()
+
+        step = Int32(0)
+        finished = Int32(0)
+        while finished == Int32(0) and step < Int32(self.radix_passes - 1):
+            finished = self._radix_pass(
+                keys,
+                output_row,
+                storage,
+                tid,
+                step,
+                self.radix_bits,
+                False,
+            )
+            step += Int32(1)
+
+        if finished == Int32(0):
+            self._radix_pass(
+                keys,
+                output_row,
+                storage,
+                tid,
+                Int32(self.radix_passes - 1),
+                self.final_radix_bits,
+                True,
+            )
+
+    @cache
+    @staticmethod
+    def compile(topk: int, world_size: int, local_candidates: int):
+        num_rows = cute.sym_int()
+        rank_stride = cute.sym_int64(divisibility=2)
+
+        rank_major = cute.runtime.make_fake_tensor(
+            Float32,
+            (world_size, num_rows, local_candidates, 2),
+            stride=(rank_stride, local_candidates * 2, 2, 1),
+            assumed_align=8,
+        )
+        out = make_fake_tensor(Int32, (num_rows, topk), divisibility=1)
+
+        kernel = StableTopKFromRankMajorCandidatesKernel(
+            topk,
+            world_size,
+            local_candidates,
+        )
+        stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
+        return cute.compile(
+            kernel,
+            rank_major,
             out,
             stream,
             options="--enable-tvm-ffi",

--- a/vllm/model_executor/kernels/attention/dsa/dcp_topk_vmm.py
+++ b/vllm/model_executor/kernels/attention/dsa/dcp_topk_vmm.py
@@ -1,0 +1,367 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Consumer-side DCP top-k merge over owner-local CUDA VMM storage.
+
+Each rank owns only its ``(max_rows, local_candidates, 2)`` candidate tensor.
+CUDA VMM maps those owner allocations into every peer process. After each
+producer packs its local candidates, the stable-top-k consumer loads candidates
+directly from the rank-major peer mapping; no rank materializes a full gathered
+candidate inbox.
+
+The two int64 sequence counters in each owner allocation make reuse and
+publication CUDA-graph safe:
+
+1. wait until every consumer has acknowledged the previous owner epoch;
+2. pack candidates into the owner-local allocation;
+3. release-increment ``write_seq`` and acquire-wait for all producers;
+4. consume all owner mappings directly in stable top-k;
+5. release-increment ``read_seq``.
+
+This experimental path is fail-closed. It never falls back to an all-gather or
+to the symmetric-memory full-inbox implementation.
+"""
+
+from dataclasses import dataclass
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+
+from vllm.distributed.device_communicators.cuda_vmm import (
+    RankMajorPeerView,
+    create_rank_major_peer_view,
+)
+from vllm.distributed.device_communicators.peer_memory import (
+    make_rank_major_tensor_view,
+)
+from vllm.logger import init_logger
+from vllm.triton_utils import tl, triton
+
+logger = init_logger(__name__)
+
+_HEADER_BYTES = 256
+_WRITE_SEQ = tl.constexpr(0)
+_READ_SEQ = tl.constexpr(1)
+_MAX_FENCE_SPINS = 100_000_000
+
+
+@triton.jit
+def _trap_if_nonzero(value):
+    return tl.inline_asm_elementwise(
+        asm="""
+        {
+            .reg .pred failed;
+            setp.ne.u32 failed, $1, 0;
+            @failed trap;
+            mov.u32 $0, 0;
+        }
+        """,
+        constraints="=r,r",
+        args=[value],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def _wait_writable_kernel(
+    peer_flags,
+    peer_stride,
+    my_rank: tl.constexpr,
+    world_size: tl.constexpr,
+    block_size: tl.constexpr,
+    max_spins: tl.constexpr,
+):
+    my_write_seq = tl.atomic_add(
+        peer_flags + my_rank * peer_stride + _WRITE_SEQ,
+        0,
+        sem="acquire",
+        scope="sys",
+    )
+    peer = tl.arange(0, block_size)
+    mask = peer < world_size
+    observed = tl.atomic_add(
+        peer_flags + peer * peer_stride + _READ_SEQ,
+        0,
+        mask=mask,
+        sem="acquire",
+        scope="sys",
+    )
+    pending = tl.max(tl.where(mask & (observed < my_write_seq), 1, 0))
+    spins = 0
+    while (pending != 0) & (spins < max_spins):
+        observed = tl.atomic_add(
+            peer_flags + peer * peer_stride + _READ_SEQ,
+            0,
+            mask=mask,
+            sem="acquire",
+            scope="sys",
+        )
+        pending = tl.max(tl.where(mask & (observed < my_write_seq), 1, 0))
+        spins += 1
+    _trap_if_nonzero(pending)
+
+
+@triton.jit
+def _publish_and_wait_kernel(
+    peer_flags,
+    peer_stride,
+    my_rank: tl.constexpr,
+    world_size: tl.constexpr,
+    block_size: tl.constexpr,
+    max_spins: tl.constexpr,
+):
+    epoch = (
+        tl.atomic_add(
+            peer_flags + my_rank * peer_stride + _WRITE_SEQ,
+            1,
+            sem="release",
+            scope="sys",
+        )
+        + 1
+    )
+    peer = tl.arange(0, block_size)
+    mask = peer < world_size
+    observed = tl.atomic_add(
+        peer_flags + peer * peer_stride + _WRITE_SEQ,
+        0,
+        mask=mask,
+        sem="acquire",
+        scope="sys",
+    )
+    pending = tl.max(tl.where(mask & (observed < epoch), 1, 0))
+    spins = 0
+    while (pending != 0) & (spins < max_spins):
+        observed = tl.atomic_add(
+            peer_flags + peer * peer_stride + _WRITE_SEQ,
+            0,
+            mask=mask,
+            sem="acquire",
+            scope="sys",
+        )
+        pending = tl.max(tl.where(mask & (observed < epoch), 1, 0))
+        spins += 1
+    _trap_if_nonzero(pending)
+
+
+@triton.jit
+def _ack_kernel(
+    peer_flags,
+    peer_stride,
+    my_rank: tl.constexpr,
+):
+    tl.atomic_add(
+        peer_flags + my_rank * peer_stride + _READ_SEQ,
+        1,
+        sem="release",
+        scope="sys",
+    )
+
+
+@dataclass
+class DcpTopkVmmWorkspace:
+    my_rank: int
+    world_size: int
+    max_rows: int
+    local_candidates_count: int
+    allocation: RankMajorPeerView
+    local_candidates: torch.Tensor
+    peer_candidates: torch.Tensor
+    peer_flags: torch.Tensor
+
+    @property
+    def physical_bytes_per_rank(self) -> int:
+        return self.allocation.bytes_per_rank
+
+    @property
+    def candidate_payload_bytes_per_rank(self) -> int:
+        return self.max_rows * self.local_candidates_count * 2 * 4
+
+    def merge(
+        self,
+        logits: torch.Tensor,
+        topk_indices: torch.Tensor,
+        topk_tokens: int,
+        dcp_rank: int,
+        dcp_world_size: int,
+        cp_interleave: int,
+        row_starts: torch.Tensor | None,
+    ) -> None:
+        from vllm.model_executor.kernels.attention.dsa.dcp_indexer_cutedsl import (
+            pack_dcp_topk_candidates_cutedsl,
+            stable_topk_from_rank_major_candidates_cutedsl,
+        )
+
+        if dcp_rank != self.my_rank or dcp_world_size != self.world_size:
+            raise RuntimeError(
+                "DCP VMM workspace geometry changed after initialization: "
+                f"workspace=({self.my_rank}, {self.world_size}), "
+                f"request=({dcp_rank}, {dcp_world_size})."
+            )
+        rows = topk_indices.shape[0]
+        if rows > self.max_rows:
+            raise RuntimeError(
+                f"DCP VMM workspace has {self.max_rows} rows, requested {rows}."
+            )
+
+        _wait_writable_kernel[(1,)](
+            self.peer_flags,
+            self.peer_flags.stride(0),
+            my_rank=self.my_rank,
+            world_size=self.world_size,
+            block_size=triton.next_power_of_2(self.world_size),
+            max_spins=_MAX_FENCE_SPINS,
+        )
+        pack_dcp_topk_candidates_cutedsl(
+            logits,
+            topk_indices[:, : self.local_candidates_count],
+            self.local_candidates[:rows],
+            dcp_rank,
+            dcp_world_size,
+            cp_interleave,
+            row_starts,
+        )
+        _publish_and_wait_kernel[(1,)](
+            self.peer_flags,
+            self.peer_flags.stride(0),
+            my_rank=self.my_rank,
+            world_size=self.world_size,
+            block_size=triton.next_power_of_2(self.world_size),
+            max_spins=_MAX_FENCE_SPINS,
+        )
+        stable_topk_from_rank_major_candidates_cutedsl(
+            self.peer_candidates[:, :rows],
+            topk_tokens,
+            out=topk_indices,
+        )
+        _ack_kernel[(1,)](
+            self.peer_flags,
+            self.peer_flags.stride(0),
+            my_rank=self.my_rank,
+        )
+
+    def close(self) -> None:
+        self.peer_flags = None
+        self.peer_candidates = None
+        self.local_candidates = None
+        self.allocation.close()
+
+
+def create_dcp_topk_vmm_workspace_for_group(
+    max_rows: int,
+    local_candidates: int,
+    group: ProcessGroup,
+    device: torch.device,
+) -> DcpTopkVmmWorkspace:
+    """Collectively create an owner-local workspace for a CPU-capable group."""
+    world_size = group.size()
+    rank = group.rank()
+    if world_size <= 1:
+        raise RuntimeError("DCP VMM workspace requires dcp_world_size > 1.")
+    if (world_size * local_candidates) % 512 != 0:
+        raise RuntimeError(
+            "DCP VMM stable-topK requires total candidates to be a multiple "
+            f"of 512; got {world_size} * {local_candidates}."
+        )
+
+    payload_bytes = max_rows * local_candidates * 2 * 4
+    requested_bytes = _HEADER_BYTES + payload_bytes
+    allocation = create_rank_major_peer_view(
+        (requested_bytes,),
+        dtype=torch.uint8,
+        group=group,
+        require_native_atomics=True,
+        device=device,
+    )
+    assert allocation.local_view is not None
+
+    allocation.local_view[:requested_bytes].zero_()
+    torch.accelerator.synchronize()
+    dist.barrier(group=group)
+
+    local_flags = allocation.local_view[: 2 * 8].view(torch.int64)
+    peer_flags = make_rank_major_tensor_view(allocation, local_flags)
+    local_payload = allocation.local_view[_HEADER_BYTES : _HEADER_BYTES + payload_bytes]
+    local_candidate_tensor = local_payload.view(torch.float32).view(
+        max_rows,
+        local_candidates,
+        2,
+    )
+    peer_candidates = make_rank_major_tensor_view(
+        allocation,
+        local_candidate_tensor,
+    )
+    return DcpTopkVmmWorkspace(
+        my_rank=rank,
+        world_size=world_size,
+        max_rows=max_rows,
+        local_candidates_count=local_candidates,
+        allocation=allocation,
+        local_candidates=local_candidate_tensor,
+        peer_candidates=peer_candidates,
+        peer_flags=peer_flags,
+    )
+
+
+def create_dcp_topk_vmm_workspace(
+    max_rows: int,
+    local_candidates: int,
+) -> DcpTopkVmmWorkspace:
+    """Collectively create an owner-local workspace for the DCP group."""
+    from vllm.distributed import get_dcp_group
+
+    dcp_group = get_dcp_group()
+    return create_dcp_topk_vmm_workspace_for_group(
+        max_rows,
+        local_candidates,
+        dcp_group.cpu_group,
+        dcp_group.device,
+    )
+
+
+_workspace: DcpTopkVmmWorkspace | None = None
+_workspace_failed = False
+
+
+def get_dcp_topk_vmm_workspace(
+    max_rows: int,
+    local_candidates: int,
+    dcp_world_size: int,
+) -> DcpTopkVmmWorkspace | None:
+    """Create or fetch the singleton VMM workspace, with no fallback."""
+    global _workspace, _workspace_failed
+    if dcp_world_size <= 1:
+        return None
+    if _workspace_failed:
+        raise RuntimeError("DCP VMM top-k workspace is unavailable.")
+    if _workspace is not None:
+        if (
+            _workspace.max_rows < max_rows
+            or _workspace.local_candidates_count != local_candidates
+            or _workspace.world_size != dcp_world_size
+        ):
+            raise RuntimeError(
+                "DCP VMM workspace shape mismatch: "
+                f"workspace=({_workspace.max_rows}, "
+                f"{_workspace.local_candidates_count}, {_workspace.world_size}), "
+                f"request=({max_rows}, {local_candidates}, {dcp_world_size})."
+            )
+        return _workspace
+
+    try:
+        _workspace = create_dcp_topk_vmm_workspace(max_rows, local_candidates)
+    except Exception as exc:
+        _workspace_failed = True
+        raise RuntimeError(
+            "DCP VMM top-k workspace initialization failed; refusing to "
+            "fall back to another exchange path."
+        ) from exc
+    logger.info_once(
+        "Using owner-local CUDA VMM DCP top-k workspace "
+        "(max_rows=%d, candidates_per_rank=%d, physical_bytes_per_rank=%d).",
+        _workspace.max_rows,
+        _workspace.local_candidates_count,
+        _workspace.physical_bytes_per_rank,
+    )
+    return _workspace

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -127,7 +127,10 @@ def _merge_dcp_topk_global(
             raise RuntimeError(
                 "DCP top-k VMM dispatch selected without a VMM workspace."
             )
-        if rows not in _logged_dcp_topk_vmm_rows:
+        # Keep one rows=32 reachability marker for integration validation, but
+        # do not synchronously log every first-seen dynamic batch size from
+        # the serving hot path.
+        if rows == 32 and rows not in _logged_dcp_topk_vmm_rows:
             _logged_dcp_topk_vmm_rows.add(rows)
             logger.info(
                 "Executing owner-local CUDA VMM DCP top-k merge for decode rows=%d.",

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -40,6 +40,9 @@ from vllm.v1.worker.workspace import current_workspace_manager
 logger = init_logger(__name__)
 
 RADIX_TOPK_WORKSPACE_SIZE = 1024 * 1024
+DCP_TOPK_VMM_MIN_DECODE_ROWS = 16
+DCP_TOPK_VMM_MAX_DECODE_ROWS = 128
+_logged_dcp_topk_vmm_rows: set[int] = set()
 
 # MXFP4 layout: 2 values packed per byte, ue8m0 (1-byte) scale per block of 32.
 MXFP4_BLOCK_SIZE = 32
@@ -104,6 +107,46 @@ def _merge_dcp_topk_global(
         stable_topk_from_gathered_candidates_cutedsl,
     )
 
+    rows = topk_indices.shape[0]
+    use_vmm = (
+        envs.VLLM_DCP_TOPK_VMM
+        and row_starts is None
+        and DCP_TOPK_VMM_MIN_DECODE_ROWS <= rows <= DCP_TOPK_VMM_MAX_DECODE_ROWS
+    )
+    if use_vmm:
+        from vllm.model_executor.kernels.attention.dsa.dcp_topk_vmm import (
+            get_dcp_topk_vmm_workspace,
+        )
+
+        workspace = get_dcp_topk_vmm_workspace(
+            DCP_TOPK_VMM_MAX_DECODE_ROWS,
+            topk_indices.shape[1],
+            dcp_world_size,
+        )
+        if workspace is None:
+            raise RuntimeError(
+                "DCP top-k VMM dispatch selected without a VMM workspace."
+            )
+        if rows not in _logged_dcp_topk_vmm_rows:
+            _logged_dcp_topk_vmm_rows.add(rows)
+            logger.info(
+                "Executing owner-local CUDA VMM DCP top-k merge for decode rows=%d.",
+                rows,
+            )
+        workspace.merge(
+            logits,
+            topk_indices,
+            topk_tokens,
+            dcp_rank,
+            dcp_world_size,
+            cp_interleave,
+            row_starts,
+        )
+        return
+
+    # Flag-off, prefill, and decode shapes outside the bounded VMM policy use
+    # the original explicit candidate exchange. This is deliberate routing,
+    # never error recovery from a selected VMM path.
     packed = torch.empty(
         (*topk_indices.shape, 2),
         dtype=torch.float32,
@@ -752,6 +795,24 @@ class SparseAttnIndexer(CustomOp):
                 "Sparse Attention Indexer CUDA op requires DeepGEMM support in "
                 "the current vLLM environment."
             )
+        if envs.VLLM_DCP_TOPK_VMM and self.dcp_world_size > 1:
+            if not current_platform.is_cuda():
+                raise NotImplementedError(
+                    "DCP top-k VMM is only supported on CUDA platforms."
+                )
+            from vllm.model_executor.kernels.attention.dsa.dcp_topk_vmm import (
+                get_dcp_topk_vmm_workspace,
+            )
+
+            workspace = get_dcp_topk_vmm_workspace(
+                DCP_TOPK_VMM_MAX_DECODE_ROWS,
+                self.topk_tokens,
+                self.dcp_world_size,
+            )
+            if workspace is None:
+                raise RuntimeError(
+                    "DCP top-k VMM was enabled without a usable DCP workspace."
+                )
 
     def forward_native(
         self,

--- a/vllm/models/deepseek_v32/nvidia/attention.py
+++ b/vllm/models/deepseek_v32/nvidia/attention.py
@@ -6,7 +6,7 @@ from transformers import DeepseekV2Config, DeepseekV3Config
 
 from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import CacheConfig, VllmConfig
-from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.distributed import get_dcp_group, get_tensor_model_parallel_world_size
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.attention import MLAAttention
 from vllm.model_executor.layers.layernorm import LayerNorm, RMSNorm
@@ -32,6 +32,7 @@ from vllm.model_executor.models.deepseek_v2 import (
 )
 from vllm.model_executor.models.utils import extract_layer_index
 from vllm.utils.torch_utils import is_quantized_kv_cache
+from vllm.v1.attention.ops.common import cp_lse_ag_out_rs
 
 from .kernels import fused_norm_rope, fused_q
 
@@ -498,6 +499,13 @@ class DeepseekV32Attention(MLAAttention):
                 False,  # use_fp4_cache
                 # fused_norm_rope already cleared the topk buffer this forward.
                 skip_topk_buffer_clear=True,
+                # The fused NVIDIA path bypasses SparseAttnIndexer.forward_cuda,
+                # so forward the run-constant DCP geometry explicitly.
+                dcp_rank=self.indexer.indexer_op.dcp_rank,
+                dcp_world_size=self.indexer.indexer_op.dcp_world_size,
+                cp_kv_cache_interleave_size=(
+                    self.indexer.indexer_op.cp_kv_cache_interleave_size
+                ),
             )
 
         if attn_metadata is None:
@@ -517,9 +525,39 @@ class DeepseekV32Attention(MLAAttention):
             # FlashMLA sparse: bf16 (ql_nope, q_pe) tuple. mqa_q is the RoPE'd
             # q_pe; ql_nope is consumed directly.
             mqa_q_arg = (ql_nope[:num_actual], mqa_q[:num_actual])
-        attn_out, _ = self.impl.forward_mqa(  # type: ignore[attr-defined]
+        if self.impl.dcp_world_size > 1:
+            if self.use_pcp:
+                raise NotImplementedError(
+                    "The NVIDIA DeepSeek-v3.2/GLM-5.2 override does not yet "
+                    "support combined PCP and DCP attention."
+                )
+            if self.dcp_a2a:
+                raise NotImplementedError(
+                    "The NVIDIA DeepSeek-v3.2/GLM-5.2 override currently "
+                    "supports DCP only with dcp_comm_backend='ag_rs'."
+                )
+            if isinstance(mqa_q_arg, tuple):
+                mqa_q_arg = torch.cat(mqa_q_arg, dim=-1)
+            # Each TP/DCP rank projects only its local query-head shard. Every
+            # DCP rank must evaluate all query heads against its owner-local KV
+            # shard before the output/LSE merge below.
+            mqa_q_arg = get_dcp_group().all_gather(mqa_q_arg, dim=1)
+
+        attn_out, lse = self.impl.forward_mqa(  # type: ignore[attr-defined]
             mqa_q_arg, kv_cache, attn_metadata, self
         )
+        if self.impl.dcp_world_size > 1:
+            if lse is None:
+                raise RuntimeError(
+                    "The NVIDIA DCP attention path requires per-head LSE from "
+                    "the sparse MLA backend."
+                )
+            attn_out = cp_lse_ag_out_rs(
+                attn_out,
+                lse,
+                get_dcp_group(),
+                is_lse_base_on_e=self.impl.lse_base_on_e,
+            )
         x = attn_out.view(
             num_actual, self.num_local_heads, self.kv_lora_rank
         ).transpose(0, 1)

--- a/vllm/models/deepseek_v32/nvidia/attention.py
+++ b/vllm/models/deepseek_v32/nvidia/attention.py
@@ -33,6 +33,7 @@ from vllm.model_executor.models.deepseek_v2 import (
 from vllm.model_executor.models.utils import extract_layer_index
 from vllm.utils.torch_utils import is_quantized_kv_cache
 from vllm.v1.attention.ops.common import cp_lse_ag_out_rs
+from vllm.v1.attention.ops.dcp_alltoall import dcp_a2a_lse_reduce
 
 from .kernels import fused_norm_rope, fused_q
 
@@ -531,11 +532,6 @@ class DeepseekV32Attention(MLAAttention):
                     "The NVIDIA DeepSeek-v3.2/GLM-5.2 override does not yet "
                     "support combined PCP and DCP attention."
                 )
-            if self.dcp_a2a:
-                raise NotImplementedError(
-                    "The NVIDIA DeepSeek-v3.2/GLM-5.2 override currently "
-                    "supports DCP only with dcp_comm_backend='ag_rs'."
-                )
             if isinstance(mqa_q_arg, tuple):
                 mqa_q_arg = torch.cat(mqa_q_arg, dim=-1)
             # Each TP/DCP rank projects only its local query-head shard. Every
@@ -552,12 +548,21 @@ class DeepseekV32Attention(MLAAttention):
                     "The NVIDIA DCP attention path requires per-head LSE from "
                     "the sparse MLA backend."
                 )
-            attn_out = cp_lse_ag_out_rs(
-                attn_out,
-                lse,
-                get_dcp_group(),
-                is_lse_base_on_e=self.impl.lse_base_on_e,
-            )
+            dcp_group = get_dcp_group()
+            if self.dcp_a2a:
+                attn_out = dcp_a2a_lse_reduce(
+                    attn_out,
+                    lse,
+                    dcp_group,
+                    is_lse_base_on_e=self.impl.lse_base_on_e,
+                )
+            else:
+                attn_out = cp_lse_ag_out_rs(
+                    attn_out,
+                    lse,
+                    dcp_group,
+                    is_lse_base_on_e=self.impl.lse_base_on_e,
+                )
         x = attn_out.view(
             num_actual, self.num_local_heads, self.kv_lora_rank
         ).transpose(0, 1)

--- a/vllm/models/deepseek_v32/nvidia/kernels.py
+++ b/vllm/models/deepseek_v32/nvidia/kernels.py
@@ -169,20 +169,25 @@ def _fused_norm_rope_kernel(
     if slot_mapping_ptr is None:
         # Memory profiling run.
         return
-    slot_idx = tl.load(slot_mapping_ptr + tok_idx)
-    if slot_idx < 0:
-        # Padding
-        return
 
     if pid == 2:
-        # Q RMS norm
+        # Query normalization is independent of KV-cache ownership. Under DCP,
+        # non-owner ranks have a negative slot mapping but still need a valid
+        # local query shard for the subsequent query-head AllGather.
         q_block = tl.arange(0, Q_BLOCK_SIZE)
         q_mask = q_block < Q_DIM
         q_c = tl.load(q_c_ptr + tok_idx * q_c_stride + q_block, mask=q_mask, other=0.0)
         q_c_rms_w = tl.load(q_rms_norm_w_ptr + q_block, mask=q_mask)
         q_c = _rms_norm(q_c, q_c_rms_w, q_rms_eps, Q_DIM)
         tl.store(q_c_out_ptr + tok_idx * q_c_out_stride + q_block, q_c, mask=q_mask)
-    elif pid == 1:
+        return
+
+    slot_idx = tl.load(slot_mapping_ptr + tok_idx)
+    if slot_idx < 0:
+        # Padding
+        return
+
+    if pid == 1:
         # KV RMS Norm + KV RoPE + MLA concat_and_cache.
         # Merged so the normed kv_c and RoPE'd k_pe can be written
         # to the MLA KV cache directly without a separate kernel.


### PR DESCRIPTION
# [DCP][Kernel] Add Shared-DCP consumer-direct Top-K

Depends on #50005.

## Summary

This is the focused Top-K extraction of Shared-DCP.

DCP already distributes data across ranks. Shared-DCP makes that distributed
data directly addressable as GPU objects with stable physical storage,
explicit ownership, local/peer views, and publish/wait/ack synchronization.

For sparse-indexer candidates, this PR uses an owner-sharded object:

```text
DeepGEMM owner-local scores
  -> local Top-K candidate shard
  -> publish one owner-local CUDA VMM object per rank
  -> stable-TopK consumer directly loads rank-major local/peer shards
  -> global Top-K indices
```

The existing bounded path instead materializes a complete candidate tensor on
every rank:

```text
local Top-K candidate shard
  -> pack
  -> candidate AllGather
  -> complete local candidate tensor
  -> stable-TopK
```

The new path removes that materialization boundary. The data still crosses GPU
boundaries and synchronization is still required, but the consumer reads the
owner-sharded physical layout directly.

DeepGEMM is unchanged.

## Scope and runtime contract

- opt-in `VLLM_DCP_TOPK_VMM=1`, default off;
- bounded decode rows 16 through 128;
- one owner-local candidate allocation per DCP rank;
- rank-major stable-TopK peer consumption;
- device-side publish/wait/ack epochs for CUDA-graph replay;
- eager VMM workspace initialization before memory profiling and capture;
- exact rows=32 activation marker without first-seen-shape logging in the hot
  path.

A selected Shared-DCP Top-K route is fail-closed. Initialization, topology,
identity, capability, or runtime protocol failures do not recover through
NCCL, symmetric memory, or another transport.

Flag-off execution, prefill, and out-of-policy decode shapes use the existing
explicit pack -> AllGather -> stable-TopK path by declared shape routing. That
is not failure fallback from a selected Shared-DCP route.

The validated serving scope is one peer-accessible NVIDIA node,
GLM-5.2-NVFP4, TP4/DCP4/EP4, `FLASHINFER_MLA_SPARSE`, FP8 KV cache, and FULL
CUDA graphs.

## Memory layout

At the current bounded rows=128 serving policy, the owner-local candidate
object physically allocates about 4 MiB/rank.

For a separate full-shape allocation comparison at 4096 rows and 2048
candidates/rank:

| Layout | Physical candidate workspace per rank |
|---|---:|
| #47348 complete producer inbox | about 256 MiB |
| Shared-DCP owner shard | about 66 MiB |
| Reduction | 3.88x |

The current bounded route does not allocate the 66 MiB full-shape workspace.
Peer virtual mappings do not duplicate the owner allocation.

## Validation

Current synchronized stack:

```text
current upstream main: 61ac36802
reviewed correctness PR #50005 head: 42b5b4e20

d0468b4fb Add CUDA peer-memory primitives
b4a9ff696 Fix CUDA VMM pre-commit checks
04569da51 Add consumer-side VMM DCP top-k merge
4e83c6b43 Integrate bounded DCP top-k VMM dispatch
1852773d1 Avoid dynamic Top-K route logging in serving hot path

current synchronized PR head: 5198c756b
```

The focused feature diff is byte-identical across the correctness restack:

```text
old c3803f736..0c9c056d4 SHA-256:
b6989665dd17204af77854b9c03d8ca9d4be5f899dd60fac3af84ea3b494769c

current 42b5b4e20..1852773d1 SHA-256:
b6989665dd17204af77854b9c03d8ca9d4be5f899dd60fac3af84ea3b494769c
```

Merging current `main` introduced no file overlap. The complete PR diff is
also byte-identical:

```text
old 27d7061ef..0c9c056d4 SHA-256:
da1a7c7d0e3facf54b05c78c2532aa70748da0a199a1ce30506231e24aba2e2a

current 61ac36802..5198c756b SHA-256:
da1a7c7d0e3facf54b05c78c2532aa70748da0a199a1ce30506231e24aba2e2a
```

Current-main checks:

```text
full applicable pre-commit suite: passed
git diff --check: passed
```

The exact patch previously passed the focused four-GPU test:

```text
tests/distributed/test_dcp_topk_vmm.py
  -> 1 passed
```

The same Top-K patch was also included in #50009's combined focused GPU run:

```text
query + Top-K + Output/LSE + fused RoPE/FP8
  -> 54 passed
```

Coverage includes:

- stable ties and deterministic rank-major ordering;
- empty candidate shards;
- global index localization and prefill indexing;
- exact four-rank output equivalence;
- changing-input CUDA-graph replay;
- initialization and selected-route fail-closed assertions.

No GPU rerun was required for the current-main synchronization because both the
focused and complete PR diffs are byte-identical and upstream changed none of
the PR files.

## Operator performance

Three independent DCP4 processes measured 200 CUDA-graph replays per case.
Values are median maximum-rank latency:

| Rows | Explicit AllGather | #47348 inbox | Shared-DCP peer consumer | vs explicit | vs #47348 |
|---:|---:|---:|---:|---:|---:|
| 1 | 38.754 us | 41.188 us | 32.596 us | 15.89% faster | 20.73% faster |
| 8 | 44.174 us | 41.198 us | 33.022 us | 25.25% faster | 19.73% faster |
| 32 | 58.523 us | 47.788 us | 39.336 us | 32.79% faster | 17.47% faster |
| 64 | 74.782 us | 53.338 us | 41.138 us | 44.99% faster | 22.87% faster |

This is a 16% to 45% operator improvement over explicit AllGather and a 17% to
23% improvement over #47348 in the matched local benchmark.

## Serving claim boundary

The isolated GLM-5.2 c32 serving contribution was neutral after removing
synchronous first-seen-shape logging from the hot path:

```text
before logging fix: 92.607 ms TPOT, 0.696% worse than Output/LSE control
after logging fix:  92.035 ms TPOT, 0.074% worse than Output/LSE control
```

Each ablation was one fresh run, so it is diagnostic evidence rather than a
repeated serving result. This PR claims:

- direct consumption of physically owner-sharded data;
- lower Top-K operator latency;
- lower full-bound physical workspace.

It does not claim an end-to-end serving win or additive gains with other
Shared-DCP mechanisms.

## Relationship to #50009

#50009 is the Shared-DCP umbrella PR. It contains this entire ten-file
Top-K/VMM feature surface plus Query and Output/LSE mechanisms.

The two PRs must not merge unchanged. They provide two review choices:

1. land this focused Top-K subset first, then remove its overlapping commits
   and files from #50009; or
2. review the complete Shared-DCP design in #50009 and close this PR as
   superseded.

This PR remains useful as the smaller operator/workspace review unit; it is not
presented as independent code from #50009.

## Relationship to #47348

#47348 optimizes the same candidate boundary with producer fanout into a
complete symmetric-memory inbox and retains a recovery fallback. This PR keeps
one physical owner shard per rank, has the stable-TopK consumer read peer
shards directly, and fails closed after route selection.

On the matched local operator benchmark, Shared-DCP is faster and uses less
full-bound physical workspace. #47348 reports an approximately 4% serving
throughput gain on a different GLM-5.1 configuration, while this PR's measured
GLM-5.2 serving contribution is neutral. The results are therefore not treated
as an end-to-end serving comparison.

## Attribution and human review

The core implementation commit carries:

```text
Co-authored-by: taoyuanyuan <linuxty@gmail.com>
```

OpenAI Codex assisted with implementation, validation orchestration,
benchmarking, history cleanup, independent review, and drafting this
description.

- [x] Before publication, the submitter has reviewed every changed line,
  verified the evidence, and can explain and defend VMM allocation and mapping,
  owner-local publication, rank-major peer reads, publish/wait/ack epochs,
  stable tie handling, bounded routing, overlap with #50009, and the absence of
  runtime recovery fallback.

Co-authored with [@taoyuanyuan](https://github.com/taoyuanyuan)
