### PR TITLE
[Bugfix][Parser] gemma4: seed non-streaming parsing from the prompt

### DIFF
--- a/tests/parser/engine/test_gemma4_streaming_reasoning.py
+++ b/tests/parser/engine/test_gemma4_streaming_reasoning.py
@@ -18,6 +18,11 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
 )
 from vllm.entrypoints.openai.engine.protocol import DeltaMessage
+from vllm.parser.abstract_parser import DelegatingParser
+from vllm.parser.engine.registered_adapters import (
+    Gemma4ParserReasoningAdapter,
+    Gemma4ParserToolAdapter,
+)
 from vllm.parser.gemma4 import Gemma4Parser
 
 # ── Special token IDs (arbitrary but consistent) ─────────────────────
@@ -533,6 +538,157 @@ class TestGemma4ChannelLessOutputConsistency:
 
         assert (stream_reasoning or None) == reasoning
         assert (stream_content or None) == content
+
+
+# ── Prompt leaves reasoning half-open and the model never closes it ───
+
+_HALF_OPEN_TEXT = "The user wants the number of business days between the dates"
+_HALF_OPEN_TOKENS: list[tuple[int, str]] = [
+    (7100 + _i, (" " if _i else "") + _word)
+    for _i, _word in enumerate(_HALF_OPEN_TEXT.split(" "))
+]
+
+# Prompt tails. Only the trailing special token matters for detection.
+_OPEN_CHANNEL_PROMPT = [CHANNEL_START_ID, 3000, 3001]  # ...<|channel>thought\n
+_NEW_TURN_PROMPT = [NEW_TURN_ID, 9100, 9101]  # ...<|turn>model\n
+
+
+class _Gemma4DelegatingParser(DelegatingParser):
+    """The parser shape the serving layer actually builds: two separate
+    ``Gemma4Parser`` engines behind the reasoning and tool adapters.
+    """
+
+    reasoning_parser_cls = Gemma4ParserReasoningAdapter
+    tool_parser_cls = Gemma4ParserToolAdapter
+
+
+def _parse_both_ways(make_parser, tokenizer, request, tokens, prompt_token_ids):
+    """Parse the same generation both ways.
+
+    Returns ``((reasoning, content), (reasoning, content))``, empty strings
+    normalised to ``None`` so the two are directly comparable.
+    """
+    text = "".join(token_text for _, token_text in tokens)
+    token_ids = [token_id for token_id, _ in tokens]
+
+    reasoning, content, _ = make_parser().parse(
+        text,
+        request,
+        enable_auto_tools=True,
+        model_output_token_ids=token_ids,
+        prompt_token_ids=prompt_token_ids,
+    )
+
+    results = _stream_tokens_batched(
+        make_parser(),
+        tokenizer,
+        request,
+        batch_size=1,
+        prompt_token_ids=prompt_token_ids,
+    )
+    stream_reasoning, stream_content, _ = _collect_fields(results)
+
+    return (reasoning or None, content or None), (
+        stream_reasoning or None,
+        stream_content or None,
+    )
+
+
+class TestGemma4HalfOpenReasoningParity:
+    """The non-streaming path must honour a prompt that ends inside an open
+    ``<|channel>`` block, exactly as streaming already does.
+
+    When the model stops before emitting ``<channel|>``, streaming called
+    the whole generation ``reasoning`` while non-streaming, which never saw
+    the prompt, returned it as ``content``.
+
+    Regression test for vllm-project/vllm#49717.
+    """
+
+    @pytest.fixture
+    def half_open_tokenizer(self):
+        return _make_tokenizer(_HALF_OPEN_TOKENS)
+
+    def test_delegating_parser_matches_streaming(
+        self, half_open_tokenizer, request_obj
+    ):
+        """The serving shape: ``DelegatingParser`` over the adapters."""
+        non_streaming, streaming = _parse_both_ways(
+            lambda: _Gemma4DelegatingParser(half_open_tokenizer, None),
+            half_open_tokenizer,
+            request_obj,
+            _HALF_OPEN_TOKENS,
+            _OPEN_CHANNEL_PROMPT,
+        )
+
+        assert non_streaming == streaming, (
+            f"Same generation classified differently: "
+            f"non-streaming={non_streaming!r} streaming={streaming!r}"
+        )
+        assert non_streaming == (_HALF_OPEN_TEXT, None)
+
+    def test_engine_parse_matches_streaming(self, half_open_tokenizer, request_obj):
+        """The direct-engine shape, bypassing ``DelegatingParser``."""
+        non_streaming, streaming = _parse_both_ways(
+            lambda: Gemma4Parser(half_open_tokenizer),
+            half_open_tokenizer,
+            request_obj,
+            _HALF_OPEN_TOKENS,
+            _OPEN_CHANNEL_PROMPT,
+        )
+
+        assert non_streaming == streaming
+        assert non_streaming == (_HALF_OPEN_TEXT, None)
+
+    def test_new_turn_prompt_stays_content(self, half_open_tokenizer, request_obj):
+        """A prompt that merely starts a new model turn must not seed
+        reasoning — the same narrowing #48217 required for streaming.
+        """
+        non_streaming, streaming = _parse_both_ways(
+            lambda: _Gemma4DelegatingParser(half_open_tokenizer, None),
+            half_open_tokenizer,
+            request_obj,
+            _HALF_OPEN_TOKENS,
+            _NEW_TURN_PROMPT,
+        )
+
+        assert non_streaming == streaming
+        assert non_streaming == (None, _HALF_OPEN_TEXT)
+
+    def test_model_opens_own_channel_after_new_turn(self, request_obj):
+        """New-turn prompt, model emits its own ``<|channel>thought\\n`` and
+        closes it: the prefix is stripped, reasoning captured, post-channel
+        text is content — identically on both paths.
+        """
+        tokenizer = _make_tokenizer(_PRE_INIT_THOUGHT_GEN_SEQUENCE)
+        non_streaming, streaming = _parse_both_ways(
+            lambda: _Gemma4DelegatingParser(tokenizer, None),
+            tokenizer,
+            request_obj,
+            _PRE_INIT_THOUGHT_GEN_SEQUENCE,
+            _NEW_TURN_PROMPT,
+        )
+
+        assert non_streaming == streaming
+        assert non_streaming == ("Reasoning body", "Final content")
+
+    def test_omitting_prompt_token_ids_is_unchanged(
+        self, half_open_tokenizer, request_obj
+    ):
+        """Callers that do not pass the prompt keep today's behaviour."""
+        text = "".join(token_text for _, token_text in _HALF_OPEN_TOKENS)
+        token_ids = [token_id for token_id, _ in _HALF_OPEN_TOKENS]
+
+        reasoning, content, _ = _Gemma4DelegatingParser(
+            half_open_tokenizer, None
+        ).parse(
+            text,
+            request_obj,
+            enable_auto_tools=True,
+            model_output_token_ids=token_ids,
+        )
+
+        assert (reasoning, content) == (None, _HALF_OPEN_TEXT)
 
 
 # ── Second model output: two tool calls with holdback ────────────────

--- a/tests/parser/engine/test_inkling.py
+++ b/tests/parser/engine/test_inkling.py
@@ -413,6 +413,24 @@ class TestPromptSeededState:
         )
         assert parser._engine.state == ParserState.MESSAGE_HEADER
 
+    def test_non_streaming_prompt_seeding_is_deliberately_unchanged(
+        self, mock_tokenizer, mock_request
+    ):
+        """Inkling overrides ``adjust_initial_state_from_prompt`` rather than
+        ``initial_state_from_prompt``, so it does not opt in to the
+        non-streaming prompt seeding added in #49717.
+        """
+        text = f"{TEXT_START}hello world{END_MESSAGE}"
+        prompt_ids = [200001, _TML_VOCAB[THINK_START]]
+
+        with_prompt = InklingParser(mock_tokenizer).parse(
+            text, mock_request, prompt_token_ids=prompt_ids
+        )
+        without_prompt = InklingParser(mock_tokenizer).parse(text, mock_request)
+
+        assert with_prompt == without_prompt
+        assert with_prompt[:2] == (None, "hello world")
+
     def test_generation_prompt_header_hides_tool_name(self, parser, mock_request):
         text = "get_weather" + _tool_block("get_weather", '{"city":"SF"}')
         delta = parser.parse_delta(

--- a/tests/parser/engine/test_qwen3_reasoning.py
+++ b/tests/parser/engine/test_qwen3_reasoning.py
@@ -211,6 +211,28 @@ class TestDelegatingPromptDetection:
         assert delta.reasoning == "thinking"
         assert delta.content is None
 
+    def test_prompt_token_ids_do_not_change_non_streaming(
+        self, mock_tokenizer, mock_request
+    ):
+        """Parsers that do not override ``initial_state_from_prompt`` must
+        parse identically with and without the prompt (#49717).
+        """
+        text = "A direct answer with no reasoning markers."
+        # Prompt tail leaves reasoning open, so the hook is reached; the
+        # base predicate returns None, so nothing is seeded.
+        prompt_ids = [_TEXT_ID, _THINK_START_ID]
+
+        with_prompt = _Qwen3DelegatingParser(mock_tokenizer).parse(
+            text, mock_request, prompt_token_ids=prompt_ids
+        )
+        without_prompt = _Qwen3DelegatingParser(mock_tokenizer).parse(
+            text, mock_request
+        )
+
+        assert with_prompt == without_prompt
+        # Qwen3's configured initial state still governs.
+        assert with_prompt[:2] == (text, None)
+
 
 class TestStreaming:
     def test_basic_streaming(self, parser):

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -895,6 +895,7 @@ class OpenAIServingChat(GenerateBaseServing):
                     request,
                     enable_auto_tools=self.enable_auto_tools,
                     model_output_token_ids=token_ids,
+                    prompt_token_ids=final_res.prompt_token_ids,
                 )
                 suppress_metadata = not request.include_reasoning and parser is not None
                 if not request.include_reasoning:

--- a/vllm/entrypoints/openai/responses/context.py
+++ b/vllm/entrypoints/openai/responses/context.py
@@ -352,6 +352,7 @@ class ParsableContext(ConversationContext):
                 self.request,
                 enable_auto_tools=self.enable_auto_tools,
                 model_output_token_ids=completion.token_ids,
+                prompt_token_ids=output.prompt_token_ids,
             )
             if not self.request.include_reasoning:
                 reasoning = None

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -865,6 +865,7 @@ class OpenAIServingResponses(GenerateBaseServing):
                 final_output,
                 tokenizer,
                 parser=context.response_parser,
+                prompt_token_ids=final_res.prompt_token_ids,
             )
 
             if request.enable_response_messages:
@@ -1039,6 +1040,7 @@ class OpenAIServingResponses(GenerateBaseServing):
         final_output: CompletionOutput,
         tokenizer: TokenizerLike,
         parser: Parser | None = None,
+        prompt_token_ids: list[int] | None = None,
     ) -> list[ResponseOutputItem]:
         # Log complete response if output logging is enabled
         if self.enable_log_outputs and self.request_logger:
@@ -1068,6 +1070,7 @@ class OpenAIServingResponses(GenerateBaseServing):
                 request,
                 enable_auto_tools=self.enable_auto_tools,
                 model_output_token_ids=final_output.token_ids,
+                prompt_token_ids=prompt_token_ids,
             )
             if not request.include_reasoning:
                 reasoning = None

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -340,6 +340,7 @@ class Parser:
         request: ChatCompletionRequest | ResponsesRequest,
         enable_auto_tools: bool = False,
         model_output_token_ids: Sequence[int] = (),
+        prompt_token_ids: list[int] | None = None,
     ) -> tuple[str | None, str | None, list[FunctionCall] | None]:
         """Parse a complete model output, extracting reasoning and tool calls.
 
@@ -348,6 +349,9 @@ class Parser:
             request: The request object used to generate the output.
             enable_auto_tools: Whether to enable automatic tool call parsing.
             model_output_token_ids: The generated raw output token IDs.
+            prompt_token_ids: The prompt token IDs, when available. Mirrors
+                the argument :meth:`parse_delta` takes, so a prompt ending
+                mid-reasoning seeds both paths alike (issue #49717).
 
         Returns:
             A tuple of (reasoning, content, tool_calls).
@@ -788,8 +792,19 @@ class DelegatingParser(Parser):
         request: ChatCompletionRequest | ResponsesRequest,
         enable_auto_tools: bool = False,
         model_output_token_ids: Sequence[int] = (),
+        prompt_token_ids: list[int] | None = None,
     ) -> tuple[str | None, str | None, list[FunctionCall] | None]:
         self._initialize_history_tool_call_cnt(request)
+
+        if (
+            prompt_token_ids is not None
+            and self._reasoning_parser is not None
+            and not self.is_reasoning_end(prompt_token_ids)
+        ):
+            # Reasoning is still open at the end of the prompt. Mirrors the
+            # same check in ``parse_delta`` (issue #49717).
+            self._reasoning_parser.adjust_initial_state_from_prompt(prompt_token_ids)
+
         reasoning, content = self.extract_reasoning(model_output, request)
         tool_calls, content = self._extract_tool_calls(
             content=content,

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -117,6 +117,7 @@ class ParserEngine(Parser):
         self._reasoning_ended: bool = not self._has_reasoning
         self._streaming_initialized: bool = False
         self._prompt_streaming_prepared: bool = False
+        self._prompt_initial_state: ParserState | None = None
 
         self._tool_slots: list[ToolCallSlot] = []
         self._deferred_content: str = ""
@@ -182,9 +183,30 @@ class ParserEngine(Parser):
             self._streaming_initialized = True
             self._reset(initial_state=initial_state)
 
+    def initial_state_from_prompt(
+        self, prompt_token_ids: Sequence[int]
+    ) -> ParserState | None:
+        """The state to start in given the prompt, or ``None`` for the
+        configured default.
+
+        Shared by the streaming and non-streaming entry points so both
+        classify a generation alike (issue #49717). Default is a no-op;
+        override in subclasses as needed.
+        """
+        return None
+
     def adjust_initial_state_from_prompt(self, prompt_token_ids: Sequence[int]) -> None:
         """See :meth:`ReasoningParser.adjust_initial_state_from_prompt`."""
-        return
+        state = self.initial_state_from_prompt(prompt_token_ids)
+        if state is None:
+            return
+        # Remembered because the non-streaming entry points open with a
+        # ``_reset()`` that would otherwise restore the configured default.
+        self._prompt_initial_state = state
+        self._engine.reset(initial_state=state)
+        # Prevent a later default ``initialize_streaming()`` from clobbering
+        # this with the configured initial state.
+        self._streaming_initialized = True
 
     def finish_streaming(self) -> DeltaMessage | None:
         events = self._engine.finish()
@@ -193,6 +215,8 @@ class ParserEngine(Parser):
         return None
 
     def _reset(self, initial_state: ParserState | None = None) -> None:
+        if initial_state is None:
+            initial_state = self._prompt_initial_state
         self._engine.reset(initial_state=initial_state)
         self._reasoning_ended = not self._has_reasoning
         self._tool_slots.clear()
@@ -680,8 +704,12 @@ class ParserEngine(Parser):
         request: ChatCompletionRequest | ResponsesRequest,
         enable_auto_tools: bool = False,
         model_output_token_ids: Sequence[int] = (),
+        prompt_token_ids: list[int] | None = None,
     ) -> tuple[str | None, str | None, list[FunctionCall] | None]:
         self._initialize_history_tool_call_cnt(request)
+        if prompt_token_ids is not None:
+            # Mirrors ``parse_delta`` (issue #49717).
+            self.adjust_initial_state_from_prompt(prompt_token_ids)
         self._check_skip_tool_parsing(request)
         reasoning, content, tool_call_info = self._single_pass_parse(
             model_output,

--- a/vllm/parser/gemma4.py
+++ b/vllm/parser/gemma4.py
@@ -505,27 +505,25 @@ class Gemma4Parser(ParserEngine):
                 return False
         return False
 
-    def adjust_initial_state_from_prompt(self, prompt_token_ids: Sequence[int]) -> None:
-        """Pre-initialise the engine to ``REASONING`` when the prompt ends
-        inside an open ``<|channel>`` block.
+    def initial_state_from_prompt(
+        self, prompt_token_ids: Sequence[int]
+    ) -> ParserState | None:
+        """Start in ``REASONING`` when the prompt ends inside an open
+        ``<|channel>`` block.
 
         This covers the post-tool-response continuation case where the chat
         template leaves the prompt ending with ``<|channel>thought\n``
         (issue #45834). A prompt that merely starts a new model turn must
         not pre-initialise reasoning: the model may answer directly without
-        emitting any channel markers, and the non-streaming path classifies
-        such output as content (issue #48217). When the model does open its
-        own ``<|channel>``, the ``(CONTENT, THINK_START)`` transition
-        handles it, and the ``thought\n`` prefix in the first reasoning
-        chunk is stripped by ``_events_to_delta`` as in the default flow.
+        emitting any channel markers, and such output is content
+        (issue #48217). When the model does open its own ``<|channel>``,
+        the ``(CONTENT, THINK_START)`` transition handles it, and the
+        ``thought\n`` prefix in the first reasoning chunk is stripped by
+        ``_events_to_delta`` as in the default flow.
         """
         if not self._prompt_ends_in_open_reasoning(prompt_token_ids):
-            return
-        self._engine.reset(initial_state=ParserState.REASONING)
-        # Prevent a later default ``initialize_streaming()`` (e.g. from
-        # ``ParserEngineReasoningAdapter.extract_reasoning_streaming``) from
-        # clobbering this with ``CONTENT``.
-        self._streaming_initialized = True
+            return None
+        return ParserState.REASONING
 
     def _events_to_delta(
         self,

--- a/vllm/parser/harmony.py
+++ b/vllm/parser/harmony.py
@@ -159,11 +159,15 @@ class HarmonyParser(DelegatingParser):
         request: ChatCompletionRequest | ResponsesRequest,
         enable_auto_tools: bool = False,
         model_output_token_ids: Sequence[int] = (),
+        prompt_token_ids: list[int] | None = None,
     ) -> tuple[str | None, str | None, list[FunctionCall] | None]:
         """Parse Harmony output from token IDs.
 
         Tool calls are always extracted regardless of ``enable_auto_tools``.
         Callers must decide whether to surface them.
+
+        ``prompt_token_ids`` is ignored: Harmony tracks channel state from
+        the output token stream.
         """
         result = self.process_chunk(model_output_token_ids)
         flushed_segments = self.flush()

--- a/vllm/parser/mistral.py
+++ b/vllm/parser/mistral.py
@@ -45,6 +45,7 @@ class MistralParser(DelegatingParser):
         request: ChatCompletionRequest | ResponsesRequest,
         enable_auto_tools: bool = False,
         model_output_token_ids: Sequence[int] = (),
+        prompt_token_ids: list[int] | None = None,
     ) -> tuple[str | None, str | None, list[FunctionCall] | None]:
         self._maybe_force_auto_tool_parsing(request)
         reasoning, content, tool_calls = super().parse(
@@ -52,6 +53,7 @@ class MistralParser(DelegatingParser):
             request,
             enable_auto_tools,
             model_output_token_ids,
+            prompt_token_ids,
         )
         if tool_calls:
             from vllm.tool_parsers.mistral_tool_parser import MistralToolCall


### PR DESCRIPTION
Fixes https://github.com/vllm-project/vllm/issues/49717.

## Purpose

With `--reasoning-parser gemma4 --tool-call-parser gemma4` and `enable_thinking=true`, the **same generation** is classified as `reasoning` when streamed and as `content` when not.

After a tool response the Gemma4 chat template leaves the prompt ending in a half-open `<|channel>thought\n`. "The model is currently inside a reasoning channel" is therefore a fact about the **prompt**, not about the generated text. `Parser.parse_delta()` receives `prompt_token_ids` and seeds the engine via `adjust_initial_state_from_prompt()` (added in
#45852, narrowed in #48262); `Parser.parse()` has no such parameter, so the non-streaming path starts from the configured default (`CONTENT`). When the model stops before emitting `<channel|>` — natural EOS or a `max_tokens` cut — the two paths disagree.

Worth flagging for reviewers, because it is easy to get wrong: the non-streaming serving path does **not** go through `ParserEngine.parse()`. `ParserManager.get_parser()` always returns a `DelegatingParser`, so it runs `DelegatingParser.parse()` → `extract_reasoning()` → the reasoning adapter → `ParserEngine.extract_reasoning()`, which is a separate implementation from `_single_pass_parse()`. Both entry points are covered here.

### What this changes

`ParserEngine` gains a pure query, `initial_state_from_prompt(prompt_token_ids) -> ParserState | None`, and the existing streaming hook `adjust_initial_state_from_prompt()` is rewritten to use it — so streaming and non-streaming share **one predicate** rather than two parallel checks. The resolved state is remembered in `_prompt_initial_state` because the non-streaming entry points open with a `_reset()` that would otherwise restore the configured default.

`Parser.parse()` gains `prompt_token_ids: list[int] | None = None`. This completes the symmetry with `parse_delta()`, which has taken the same argument since #45852 — it is not a new API concept. Wired at the non-streaming call sites of both APIs whose streaming counterpart already passes it: `chat_completion/serving.py`, `responses/context.py`, `responses/serving.py`.

`Gemma4Parser` moves its existing `_prompt_ends_in_open_reasoning()` check into `initial_state_from_prompt()`. That predicate itself is **unchanged**: #48262 deliberately narrowed to it, and widening it to `is_reasoning_end()` would regress that fix.

### Blast radius

- The base `initial_state_from_prompt()` returns `None`, so `_prompt_initial_state` stays `None` and `_reset()` behaves exactly as before for every parser that does not override it.
- `ReasoningParser.adjust_initial_state_from_prompt()` is a no-op on the legacy base, so calling it from `DelegatingParser.parse()` is inert for all non-engine parsers. That is why no `_engine_based` guard is needed here, unlike #47562.
- Callers that do not pass `prompt_token_ids` are byte-identical to today.
- `InklingParser` also overrides `adjust_initial_state_from_prompt` — gemma4 is not the only one. It is left on the old hook deliberately, so it never records `_prompt_initial_state` and its non-streaming path is unchanged: inkling can seed `MESSAGE_HEADER` as well as `REASONING`/`CONTENT`, and I cannot validate that behaviour change without an inkling
  checkpoint. There is a test pinning that it stays unchanged.

### Direction of the fix

The bug reporter expected `content` to win. This makes both paths report **reasoning**, on the #48262 principle of classifying according to what actually happened — the model was genuinely still mid-thought when it stopped. The question of which side should give was raised upstream and never answered. If the other direction is preferred, the parity machinery here is the same and only the predicate changes; happy to flip it.

## Why this is not duplicating an existing PR

```
gh pr list --repo vllm-project/vllm --state all  --search "<bug report number> in:body"   # empty
gh pr list --repo vllm-project/vllm --state open --search "parser prompt_token_ids"
gh pr list --repo vllm-project/vllm --state open --search "gemma4 parser reasoning"
gh pr list --repo vllm-project/vllm --state open --search "streaming non-streaming parser parity"
```

No open or closed PR addresses this divergence. The nearest open work touches different methods:
#49426 (whitespace at tool-call boundaries in `parser_engine.py`), #47562 (`_extract_tool_calls` in `abstract_parser.py`), #45787 (`count_reasoning_tokens`), #46663 (`is_reasoning_end` prompt-tail check in `serving.py`), #42105 (`batch_serving.py` `adjust_request` plumbing — which is why `batch_serving.py` is deliberately not touched here). #46225 was closed in favour of #46875, and neither opposes prompt token IDs reaching the engine.

## Test Plan

```
pytest tests/parser/engine/test_gemma4_streaming_reasoning.py::TestGemma4HalfOpenReasoningParity
pytest tests/parser/engine/test_qwen3_reasoning.py::TestDelegatingPromptDetection
pytest tests/parser/engine/test_inkling.py::TestPromptSeededState
pytest tests/parser/ tests/reasoning/
pytest tests/tool_parsers/test_gemma4_tool_parser.py tests/tool_use/test_gemma4_responses_adjust_request.py
pytest tests/entrypoints/openai/responses/test_parsable_context_unit.py
pre-commit run --files <changed files>
```

New tests in `tests/parser/engine/test_gemma4_streaming_reasoning.py`
(`TestGemma4HalfOpenReasoningParity`) assert that streaming and non-streaming produce the same
`(reasoning, content)` split for one generation and one prompt, covering:

1. the `DelegatingParser` shape the serving layer actually builds,
2. the direct `ParserEngine` shape,
3. a new-turn prompt still yielding content (guards #48262),
4. a new-turn prompt where the model opens and closes its own `<|channel>` — the permutation bbrowning asked for in the #45852 review,
5. omitting `prompt_token_ids` reproducing today's output exactly.

Plus `qwen3` and `inkling` tests pinning that parsers which do not override the predicate parse identically with and without the prompt.

Note: the existing `tests/reasoning/` suites drive `run_reasoning_extraction` → `extract_reasoning_streaming`, which never passes prompt token ids, so this hook had no coverage there. The new tests drive `parse()` / `parse_delta()` directly.

## Test Result

**Before the fix** — the five new parity tests fail, and the divergence reproduces through the
real `DelegatingParser` path:

```
open <|channel>   non-streaming(r=None c='Sure, the answer is 42')  streaming(r='Sure, the answer is 42' c=None)   DIVERGE
```

```
FAILED tests/parser/engine/test_gemma4_streaming_reasoning.py::TestGemma4HalfOpenReasoningParity::test_delegating_parser_matches_streaming
FAILED tests/parser/engine/test_gemma4_streaming_reasoning.py::TestGemma4HalfOpenReasoningParity::test_engine_parse_matches_streaming
FAILED tests/parser/engine/test_gemma4_streaming_reasoning.py::TestGemma4HalfOpenReasoningParity::test_new_turn_prompt_stays_content
FAILED tests/parser/engine/test_gemma4_streaming_reasoning.py::TestGemma4HalfOpenReasoningParity::test_model_opens_own_channel_after_new_turn
FAILED tests/parser/engine/test_qwen3_reasoning.py::TestDelegatingPromptDetection::test_prompt_token_ids_do_not_change_non_streaming
5 failed, 1 passed in 3.84s
```

(The one that passes is `test_omitting_prompt_token_ids_is_unchanged`, which does not use the new argument — it is the unchanged-behaviour baseline.)

**After the fix** — all three cases agree:

```
open <|channel>       non-streaming(r='Sure, the answer is 42' c=None)  streaming(same)  MATCH
new turn              non-streaming(r=None c='Sure, the answer is 42')  streaming(same)  MATCH
no prompt token ids   non-streaming(r=None c='Sure, the answer is 42')  streaming(same)  MATCH
```

Full suites:

```
pytest tests/parser/ tests/reasoning/
  4278 passed, 3 warnings in 354.19s

pytest tests/tool_parsers/test_gemma4_tool_parser.py tests/tool_use/test_gemma4_responses_adjust_request.py
  62 passed, 14 warnings in 20.68s

pytest tests/entrypoints/openai/responses/test_parsable_context_unit.py
  10 passed, 14 warnings in 1.76s
```

`tests/reasoning/test_cohere_command_reasoning_parser.py` is excluded — it fails to collect on an
unmodified tree too (`ImportError: The Cohere reasoning parser requires the cohere_melody
package`), unrelated to this change.

Lint — `pre-commit run --files <changed files>`:

```
ruff check / ruff format / typos ................ Passed
Run mypy for Python 3.10 ........................ Passed
Check SPDX headers .............................. Passed
Check root lazy imports ......................... Passed
Check for forbidden imports ..................... Passed
Prevent new 'torch.cuda' APIs call .............. Passed
Validate configuration .......................... Passed
Check attention backend documentation ........... Passed
Check for boolean ops in with-statements ........ Passed
```

`tools/pre_commit/mypy.py 3.12` also run directly: `Success: no issues found`.

Run on Ubuntu (WSL2) with a CPU-only build, torch 2.13.0+cpu, Python 3.12.

**Still outstanding, which is why this is a draft:** no model eval yet. This change affects serving output, so per AGENTS.md it needs one before it is ready for review; I do not have the hardware to run Gemma 4 locally and will add BFCL / eval numbers before marking it ready.

## AI assistance

This PR includes AI-assisted code (Claude). I reviewed and understand every changed line, reproduced the original failure and verified the fix myself, and take responsibility for this change.
