### PR TITLE
[Bugfix] Bound accepted-token state lookups in GDN/KDA spec decode

### DIFF
--- a/tests/kernels/mamba/test_causal_conv1d.py
+++ b/tests/kernels/mamba/test_causal_conv1d.py
@@ -392,3 +392,32 @@ def test_causal_conv1d_varlen(
     )
     unpadded_out = out[:, : out_ref_tensor.shape[-1]]
     assert torch.allclose(unpadded_out, out_ref_tensor, rtol=rtol, atol=atol)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("num_accepted", [0, 4])
+def test_causal_conv1d_update_invalid_accepted_count_is_fail_closed(
+    num_accepted: int,
+):
+    """An invalid speculative offset must not read or update adjacent state."""
+    device = DEVICE
+    batch, dim, seqlen, width = 1, 64, 3, 4
+    x = torch.randn(batch, dim, seqlen, device=device)
+    weight = torch.randn(dim, width, device=device)
+    conv_state = torch.randn(3, dim, width - 1 + seqlen - 1, device=device)
+    state_before = conv_state.clone()
+    state_indices = torch.tensor([1], dtype=torch.int32, device=device)
+    accepted = torch.tensor([num_accepted], dtype=torch.int32, device=device)
+    out = torch.full_like(x, torch.nan)
+
+    result = causal_conv1d_update(
+        x,
+        conv_state,
+        weight,
+        conv_state_indices=state_indices,
+        num_accepted_tokens=accepted,
+        out=out,
+    )
+
+    torch.testing.assert_close(result, torch.zeros_like(result))
+    torch.testing.assert_close(conv_state, state_before)

--- a/tests/kernels/mamba/test_mamba_ssm.py
+++ b/tests/kernels/mamba/test_mamba_ssm.py
@@ -1152,3 +1152,60 @@ def test_selective_state_update_varlen_with_num_accepted(
             state_ref = state_ref_intermediate[(seq_idx, token_idx)].squeeze(0)
 
             assert torch.allclose(state[dst_slot], state_ref, rtol=rtol, atol=atol)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@torch.inference_mode()
+def test_selective_state_update_rejects_accepted_count_past_state_row():
+    """An invalid accepted count must not select an adjacent state row."""
+    dim, dstate, seq_len = 64, 16, 3
+    total_state_slots = 12
+    set_random_seed(2026)
+
+    state = torch.randn(
+        total_state_slots, dim, dstate, dtype=torch.float32, device=DEVICE
+    )
+    state_before = state.clone()
+
+    state_indices_storage = torch.full(
+        (3, seq_len), NULL_BLOCK_ID, dtype=torch.int32, device=DEVICE
+    )
+    state_indices_storage[1, 0] = 1
+    # Keep the old out-of-row access inside allocated storage so this is a
+    # deterministic semantic regression rather than an illegal-address probe.
+    state_indices_storage[2, 0] = 2
+    state_batch_indices = state_indices_storage[1:2]
+    dst_state_batch_indices = torch.tensor(
+        [[3, 4, 5]], dtype=torch.int32, device=DEVICE
+    )
+
+    x = torch.randn(seq_len, dim, device=DEVICE)
+    dt = torch.randn_like(x)
+    A = -torch.rand(dim, dstate, device=DEVICE) - 1.0
+    B = torch.randn(seq_len, dstate, device=DEVICE)
+    C = torch.randn_like(B)
+    D = torch.randn(dim, device=DEVICE)
+    dt_bias = torch.rand(dim, device=DEVICE) - 4.0
+    out = torch.full_like(x, torch.nan)
+
+    selective_state_update(
+        state,
+        x,
+        dt,
+        A,
+        B,
+        C,
+        D=D,
+        dt_bias=dt_bias,
+        dt_softplus=True,
+        state_batch_indices=state_batch_indices,
+        dst_state_batch_indices=dst_state_batch_indices,
+        out=out,
+        num_accepted_tokens=torch.tensor(
+            [seq_len + 1], dtype=torch.int32, device=DEVICE
+        ),
+        cu_seqlens=torch.tensor([0, seq_len], dtype=torch.int32, device=DEVICE),
+    )
+
+    torch.testing.assert_close(out, torch.zeros_like(out))
+    torch.testing.assert_close(state, state_before)

--- a/tests/kernels/mamba/test_mamba_ssm.py
+++ b/tests/kernels/mamba/test_mamba_ssm.py
@@ -1209,3 +1209,72 @@ def test_selective_state_update_rejects_accepted_count_past_state_row():
 
     torch.testing.assert_close(out, torch.zeros_like(out))
     torch.testing.assert_close(state, state_before)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@torch.inference_mode()
+def test_selective_state_update_accepts_valid_accepted_count_within_row():
+    """A VALID accepted count > 1 must still compute, not fail closed.
+
+    Discriminating half of the bounds regression above: the first version of
+    the bound compared against stride(1) (== 1 when contiguous), which
+    rejected every accepted count > 1 and zeroed legitimate speculative
+    decode output while leaving state untouched. Guarding only the invalid
+    side cannot catch that (an oversized count fails closed under both the
+    right and the wrong bound), so this test pins the valid side: real
+    output, state mutation.
+    """
+    dim, dstate, seq_len = 64, 16, 3
+    total_state_slots = 12
+    set_random_seed(2026)
+
+    state = torch.randn(
+        total_state_slots, dim, dstate, dtype=torch.float32, device=DEVICE
+    )
+    state_before = state.clone()
+
+    state_indices_storage = torch.full(
+        (3, seq_len), NULL_BLOCK_ID, dtype=torch.int32, device=DEVICE
+    )
+    # Column 1 (init_token_idx for num_accepted == 2) selects state row 1.
+    state_indices_storage[1, 0] = 6
+    state_indices_storage[1, 1] = 1
+    state_indices_storage[1, 2] = 7
+    state_batch_indices = state_indices_storage[1:2]
+    dst_state_batch_indices = torch.tensor(
+        [[3, 4, 5]], dtype=torch.int32, device=DEVICE
+    )
+
+    x = torch.randn(seq_len, dim, device=DEVICE)
+    dt = torch.randn_like(x)
+    A = -torch.rand(dim, dstate, device=DEVICE) - 1.0
+    B = torch.randn(seq_len, dstate, device=DEVICE)
+    C = torch.randn_like(B)
+    D = torch.randn(dim, device=DEVICE)
+    dt_bias = torch.rand(dim, device=DEVICE) - 4.0
+    out = torch.full_like(x, torch.nan)
+
+    selective_state_update(
+        state,
+        x,
+        dt,
+        A,
+        B,
+        C,
+        D=D,
+        dt_bias=dt_bias,
+        dt_softplus=True,
+        state_batch_indices=state_batch_indices,
+        dst_state_batch_indices=dst_state_batch_indices,
+        out=out,
+        num_accepted_tokens=torch.tensor([2], dtype=torch.int32, device=DEVICE),
+        cu_seqlens=torch.tensor([0, seq_len], dtype=torch.int32, device=DEVICE),
+    )
+
+    assert not torch.isnan(out).any(), "output was never written"
+    assert not torch.equal(out, torch.zeros_like(out)), (
+        "valid accepted count was wrongly failed closed to zero output"
+    )
+    assert not torch.equal(state, state_before), (
+        "valid accepted count wrongly skipped the state update"
+    )

--- a/tests/kernels/test_fused_sigmoid_gating_delta_rule.py
+++ b/tests/kernels/test_fused_sigmoid_gating_delta_rule.py
@@ -197,3 +197,73 @@ def test_fused_sigmoid_gating_delta_rule_update_spec(
     torch.testing.assert_close(
         last_recurrent_state, last_recurrent_state_ref, atol=1e-2, rtol=1e-2
     )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("num_accepted", [0, 5])
+def test_spec_invalid_accepted_count_zeroes_output(num_accepted: int) -> None:
+    """Invalid active-request state selection must not expose empty output."""
+    torch.set_default_device(DEVICE)
+    set_random_seed(0)
+
+    num_tokens, num_k_heads, num_v_heads = 4, 2, 4
+    head_k_dim = head_v_dim = 16
+    query = torch.rand(1, num_tokens, num_k_heads, head_k_dim)
+    key = torch.rand_like(query)
+    value = torch.rand(1, num_tokens, num_v_heads, head_v_dim)
+    a = torch.rand(num_tokens, num_v_heads)
+    b = torch.rand_like(a)
+    A_log = torch.rand(num_v_heads)
+    dt_bias = torch.rand_like(A_log)
+    initial_state = torch.rand(num_tokens + 1, num_v_heads, head_v_dim, head_k_dim)
+    state_indices = torch.arange(1, num_tokens + 1, dtype=torch.int32).view(
+        1, num_tokens
+    )
+    cu_seqlens = torch.tensor([0, num_tokens], dtype=torch.int32)
+    accepted = torch.tensor([num_accepted], dtype=torch.int32)
+
+    previous_deterministic = torch.are_deterministic_algorithms_enabled()
+    previous_warn_only = torch.is_deterministic_algorithms_warn_only_enabled()
+    previous_fill = torch.utils.deterministic.fill_uninitialized_memory
+    torch.use_deterministic_algorithms(True)
+    torch.utils.deterministic.fill_uninitialized_memory = True
+    try:
+        recurrent_state = initial_state.clone()
+        recurrent_out, recurrent_state = fused_recurrent_gated_delta_rule(
+            q=query,
+            k=key,
+            v=value,
+            g=torch.rand(1, num_tokens, num_v_heads),
+            beta=torch.rand(1, num_tokens, num_v_heads),
+            initial_state=recurrent_state,
+            inplace_final_state=True,
+            ssm_state_indices=state_indices,
+            cu_seqlens=cu_seqlens,
+            num_accepted_tokens=accepted,
+        )
+
+        sigmoid_state = initial_state.clone()
+        sigmoid_out, sigmoid_state = fused_sigmoid_gating_delta_rule_update(
+            A_log=A_log,
+            a=a,
+            b=b,
+            dt_bias=dt_bias,
+            q=query,
+            k=key,
+            v=value,
+            initial_state=sigmoid_state,
+            inplace_final_state=True,
+            ssm_state_indices=state_indices,
+            cu_seqlens=cu_seqlens,
+            num_accepted_tokens=accepted,
+        )
+    finally:
+        torch.utils.deterministic.fill_uninitialized_memory = previous_fill
+        torch.use_deterministic_algorithms(
+            previous_deterministic, warn_only=previous_warn_only
+        )
+
+    torch.testing.assert_close(recurrent_out, torch.zeros_like(recurrent_out))
+    torch.testing.assert_close(sigmoid_out, torch.zeros_like(sigmoid_out))
+    torch.testing.assert_close(recurrent_state, initial_state)
+    torch.testing.assert_close(sigmoid_state, initial_state)

--- a/tests/models/kimi_k3/test_kda.py
+++ b/tests/models/kimi_k3/test_kda.py
@@ -18,6 +18,9 @@ from vllm.model_executor.layers.mamba.ops.gather_initial_states import (
     gather_initial_states,
 )
 from vllm.models.kimi_k3.amd.ops.third_party.kda import (
+    fused_recurrent_kda_fwd as fused_recurrent_kda_fwd_amd,
+)
+from vllm.models.kimi_k3.amd.ops.third_party.kda import (
     fused_recurrent_kda_packed_decode as fused_recurrent_kda_packed_decode_amd,
 )
 from vllm.models.kimi_k3.nvidia.kda import (
@@ -53,6 +56,10 @@ pytestmark = pytest.mark.skipif(
 PACKED_DECODE_IMPLS = {
     "nvidia": fused_recurrent_kda_packed_decode,
     "amd": fused_recurrent_kda_packed_decode_amd,
+}
+SPEC_DECODE_IMPLS = {
+    "nvidia": fused_recurrent_kda_fwd,
+    "amd": fused_recurrent_kda_fwd_amd,
 }
 
 
@@ -573,6 +580,55 @@ def test_kda_spec_decode_correctness(
         err_atol=3e-3,
     )
     assert torch.isnan(output_storage[..., H * D :]).all()
+
+
+@pytest.mark.parametrize("impl", SPEC_DECODE_IMPLS.keys())
+@pytest.mark.parametrize("num_accepted", [0, 4])
+@torch.inference_mode()
+def test_kda_spec_invalid_accepted_count_is_fail_closed(
+    impl: str,
+    num_accepted: int,
+):
+    """Invalid accepted counts must not select an adjacent KDA state row."""
+    H, D, T = 2, 128, 3
+    torch.manual_seed(2026)
+
+    q = torch.randn(1, T, H, D, dtype=torch.bfloat16, device=DEVICE)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+    gate = -torch.rand_like(q)
+    beta = torch.rand(1, T, H, dtype=torch.float32, device=DEVICE)
+    cu_seqlens = torch.tensor([0, T], dtype=torch.int32, device=DEVICE)
+
+    state_indices_storage = torch.zeros(3, T, dtype=torch.int32, device=DEVICE)
+    state_indices_storage[1] = torch.arange(1, T + 1, dtype=torch.int32, device=DEVICE)
+    # Keep the old out-of-row accesses inside allocated storage so this test
+    # is a deterministic semantic regression rather than an illegal-address probe.
+    state_indices_storage[0, -1] = 4
+    state_indices_storage[2, 0] = 5
+    state_indices = state_indices_storage[1:2]
+
+    state = torch.randn(T + 3, H, D, D, dtype=torch.float32, device=DEVICE)
+    state_before = state.clone()
+    output = torch.full_like(v, torch.nan)
+    accepted = torch.tensor([num_accepted], dtype=torch.int32, device=DEVICE)
+
+    actual, actual_state = SPEC_DECODE_IMPLS[impl](
+        q=q,
+        k=k,
+        v=v,
+        g=gate,
+        beta=beta,
+        initial_state=state,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=state_indices,
+        num_accepted_tokens=accepted,
+        out=output,
+    )
+
+    assert actual.data_ptr() == output.data_ptr()
+    torch.testing.assert_close(actual, torch.zeros_like(actual))
+    torch.testing.assert_close(actual_state, state_before)
 
 
 @pytest.mark.parametrize(

--- a/tests/v1/worker/test_mamba_utils.py
+++ b/tests/v1/worker/test_mamba_utils.py
@@ -790,6 +790,75 @@ class TestPostprocessMambaFusedKernel:
         torch.testing.assert_close(conv_state, conv_state_orig)
         torch.testing.assert_close(temporal_state, temporal_state_orig)
 
+    @pytest.mark.parametrize(
+        ("num_computed", "source_col", "destination_col", "conv_unchanged"),
+        [
+            (60, 1, 3, True),  # destination is an in-row NULL_BLOCK_ID
+            (76, 1, 4, True),  # destination is the next row's first column
+            (60, 4, 3, True),  # source is the next row's first column
+            (60, 3, 3, False),  # temporal bias crosses into the next row
+        ],
+    )
+    def test_invalid_block_table_lookup_does_not_copy_state(
+        self,
+        device,
+        num_computed,
+        source_col,
+        destination_col,
+        conv_unchanged,
+    ):
+        """Invalid columns and NULL_BLOCK_ID must not reach state address math."""
+        cfg = _TestConfig(num_blocks=8)
+        layer_names = ["layer_0"]
+        kv_cache_config = _make_kv_cache_config(cfg, layer_names)
+        conv_state = torch.randn(
+            cfg.num_blocks,
+            cfg.conv_width,
+            cfg.conv_inner_dim,
+            dtype=cfg.dtype,
+            device=device,
+        )
+        temporal_state = torch.randn(
+            cfg.num_blocks,
+            cfg.temporal_state_dim,
+            dtype=cfg.dtype,
+            device=device,
+        )
+        conv_before = conv_state.clone()
+        temporal_before = temporal_state.clone()
+        forward_context = {"layer_0": _make_mock_attention(conv_state, temporal_state)}
+        gpu_ctx = _make_gpu_ctx(cfg, kv_cache_config, device)
+
+        block_table_storage = torch.zeros(2, 4, dtype=torch.int32, device=device)
+        block_table_storage[0, 1] = 1
+        if destination_col < block_table_storage.stride(0):
+            is_null_destination = (
+                destination_col == 3 and num_computed == 60 and source_col == 1
+            )
+            block_table_storage[0, destination_col] = 0 if is_null_destination else 3
+        block_table_storage[1, 0] = 2
+
+        _run_gpu_postprocess(
+            gpu_ctx,
+            kv_cache_config=kv_cache_config,
+            forward_context=forward_context,
+            copy_funcs=_COPY_FUNCS,
+            block_table=block_table_storage[:1],
+            req_ids=["req_0"],
+            num_accepted_tokens=[3],
+            mamba_state_idx=[source_col],
+            num_scheduled_tokens={"req_0": 3},
+            num_computed_tokens=[num_computed],
+            num_draft_tokens={},
+            device=device,
+        )
+
+        expected_destination = (num_computed + 3 + 3 - 1) // cfg.block_size - 1
+        assert expected_destination == destination_col
+        if conv_unchanged:
+            torch.testing.assert_close(conv_state, conv_before)
+        torch.testing.assert_close(temporal_state, temporal_before)
+
     @pytest.mark.parametrize("num_reqs", [1, 2, 8, 16])
     def test_various_batch_sizes(self, device, test_config, num_reqs):
         """Verify kernel works correctly with different batch sizes."""

--- a/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
+++ b/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
@@ -871,9 +871,21 @@ def _causal_conv1d_update_kernel(
         # - accept 1 tokens: [history2, ..., historyM, draft1]
         # - accept 2 tokens: [history3, ..., historyM, draft1, draft2]
         # - and so on.
-        conv_state_token_offset = (
-            tl.load(num_accepted_tokens_ptr + idx_seq).to(tl.int64) - 1
-        )
+        num_accepted = tl.load(num_accepted_tokens_ptr + idx_seq).to(tl.int64)
+        if (num_accepted < 1) | (num_accepted > seqlen):
+            zero = tl.zeros((BLOCK_N,), dtype=tl.float32)
+            for idx_token in tl.range(seqlen):
+                o_ptrs = (
+                    o_ptr
+                    + o_offset
+                    + idx_token * stride_o_token
+                    + idx_feats * stride_o_dim
+                )
+                tl.store(o_ptrs, zero, mask=idx_feats < dim)
+            if launch_pdl:
+                tl.extra.cuda.gdc_launch_dependents()
+            return
+        conv_state_token_offset = num_accepted - 1
     else:
         conv_state_token_offset = 0
 

--- a/vllm/model_executor/layers/mamba/ops/mamba_ssm.py
+++ b/vllm/model_executor/layers/mamba/ops/mamba_ssm.py
@@ -335,8 +335,13 @@ def _selective_scan_update_kernel(
             num_accepted = tl.load(num_accepted_tokens_ptr + pid_b).to(tl.int64)
             # Preserve the existing zero-count clamp while bounding the
             # accepted-token-derived state lookup to this request's row.
+            # The bound is the ROW stride (elements per batch row), matching
+            # fused_recurrent.py's i_t < stride_indices_seq: for a contiguous
+            # [batch, T] tensor stride(0) == T. stride(1) would be 1 there,
+            # which rejects every accepted count > 1 (and a padded row keeps
+            # any overshoot inside this request's allocated slack).
             init_token_idx = tl.maximum(num_accepted - 1, 0)
-            valid_initial_token = init_token_idx < stride_state_indices_T
+            valid_initial_token = init_token_idx < stride_state_indices_batch
         else:
             init_token_idx = 0
 

--- a/vllm/model_executor/layers/mamba/ops/mamba_ssm.py
+++ b/vllm/model_executor/layers/mamba/ops/mamba_ssm.py
@@ -333,7 +333,10 @@ def _selective_scan_update_kernel(
     if HAS_STATE_BATCH_INDICES:
         if IS_SPEC_DECODING:
             num_accepted = tl.load(num_accepted_tokens_ptr + pid_b).to(tl.int64)
+            # Preserve the existing zero-count clamp while bounding the
+            # accepted-token-derived state lookup to this request's row.
             init_token_idx = tl.maximum(num_accepted - 1, 0)
+            valid_initial_token = init_token_idx < stride_state_indices_T
         else:
             init_token_idx = 0
 
@@ -347,9 +350,17 @@ def _selective_scan_update_kernel(
                 dst_state_batch_idx * stride_state_batch + pid_h * stride_state_head
             )
 
-        state_batch_indices_ptr += (
-            pid_b * stride_state_indices_batch + init_token_idx * stride_state_indices_T
-        )
+        state_batch_indices_ptr += pid_b * stride_state_indices_batch
+        if IS_SPEC_DECODING and not valid_initial_token:
+            offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+            zero = tl.zeros([BLOCK_SIZE_M], dtype=tl.float32)
+            out_ptr += bos * stride_out_batch + pid_h * stride_out_head
+            for _ in range(seq_len):
+                tl.store(out_ptr + offs_m * stride_out_dim, zero, mask=offs_m < dim)
+                out_ptr += stride_out_batch
+            return
+
+        state_batch_indices_ptr += init_token_idx * stride_state_indices_T
         state_batch_idx = tl.load(state_batch_indices_ptr).to(tl.int64)
         state_ptr += state_batch_idx * stride_state_batch + pid_h * stride_state_head
     else:

--- a/vllm/models/kimi_k3/amd/ops/third_party/kda/fused_recurrent.py
+++ b/vllm/models/kimi_k3/amd/ops/third_party/kda/fused_recurrent.py
@@ -186,12 +186,20 @@ def fused_recurrent_kda_fwd_kernel(
         initial_token = tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1
     else:
         initial_token = 0
-    state_index = tl.load(state_indices + i_n * stride_indices_seq + initial_token).to(
-        tl.int64
+    initial_token_in_row = (initial_token >= 0) & (
+        initial_token < stride_indices_seq
     )
+    state_index = tl.load(
+        state_indices + i_n * stride_indices_seq + initial_token,
+        mask=initial_token_in_row,
+        other=0,
+    ).to(tl.int64)
     p_out = out + bos * stride_out_token + i_h * V + o_v
     if state_index <= 0:
-        tl.store(p_out, tl.zeros([BV], dtype=tl.float32), mask=m_v)
+        zero = tl.zeros([BV], dtype=tl.float32).to(p_out.dtype.element_ty)
+        for _ in range(0, sequence_length):
+            tl.store(p_out, zero, mask=m_v)
+            p_out += stride_out_token
         return
 
     p_state = (

--- a/vllm/models/kimi_k3/nvidia/ops/third_party/kda/fused_recurrent.py
+++ b/vllm/models/kimi_k3/nvidia/ops/third_party/kda/fused_recurrent.py
@@ -185,6 +185,8 @@ def fused_recurrent_kda_fwd_kernel(
     eos = tl.load(cu_seqlens + i_n + 1).to(tl.int64)
     sequence_length = eos - bos
     if sequence_length == 0:
+        if launch_pdl:
+            tl.extra.cuda.gdc_launch_dependents()
         return
 
     o_k = tl.arange(0, BK)
@@ -197,12 +199,22 @@ def fused_recurrent_kda_fwd_kernel(
         initial_token = tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1
     else:
         initial_token = 0
-    state_index = tl.load(state_indices + i_n * stride_indices_seq + initial_token).to(
-        tl.int64
+    initial_token_in_row = (initial_token >= 0) & (
+        initial_token < stride_indices_seq
     )
+    state_index = tl.load(
+        state_indices + i_n * stride_indices_seq + initial_token,
+        mask=initial_token_in_row,
+        other=0,
+    ).to(tl.int64)
     p_out = out + bos * stride_out_token + i_h * V + o_v
     if state_index <= 0:
-        tl.store(p_out, tl.zeros([BV], dtype=tl.float32), mask=m_v)
+        zero = tl.zeros([BV], dtype=tl.float32).to(p_out.dtype.element_ty)
+        for _ in range(0, sequence_length):
+            tl.store(p_out, zero, mask=m_v)
+            p_out += stride_out_token
+        if launch_pdl:
+            tl.extra.cuda.gdc_launch_dependents()
         return
 
     p_state = (

--- a/vllm/third_party/flash_linear_attention/ops/fused_recurrent.py
+++ b/vllm/third_party/flash_linear_attention/ops/fused_recurrent.py
@@ -107,9 +107,23 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
             else:
                 i_t = 0
             # Load state index and check for invalid entries
-            state_idx = tl.load(ssm_state_indices + i_n * stride_indices_seq + i_t).to(
-                tl.int64
-            )
+            # ``i_t`` is ``num_accepted_tokens - 1`` and is otherwise
+            # unbounded, while ``ssm_state_indices`` has only
+            # ``stride_indices_seq`` columns per request. A zero accepted
+            # count gives ``i_t == -1`` (a read before this request's row,
+            # and before the tensor for ``i_n == 0``); a stale or too-large
+            # count reads past the row. The ``state_idx <= 0`` guard below
+            # only rejects non-positive values, so an out-of-range read that
+            # returns a garbage positive int32 flows into
+            # ``h0 + state_idx * stride_init_state_token`` and is
+            # dereferenced, faulting the SM. Mask the load to the row and let
+            # ``other=0`` fall into the existing invalid-state path.
+            idx_in_row = (i_t >= 0) & (i_t < stride_indices_seq)
+            state_idx = tl.load(
+                ssm_state_indices + i_n * stride_indices_seq + i_t,
+                mask=idx_in_row,
+                other=0,
+            ).to(tl.int64)
             # Skip if state index is invalid (NULL_BLOCK_ID=0)
             if state_idx <= 0:
                 return

--- a/vllm/third_party/flash_linear_attention/ops/fused_recurrent.py
+++ b/vllm/third_party/flash_linear_attention/ops/fused_recurrent.py
@@ -124,8 +124,12 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
                 mask=idx_in_row,
                 other=0,
             ).to(tl.int64)
-            # Skip if state index is invalid (NULL_BLOCK_ID=0)
+            # Skip invalid state indices without exposing uninitialized output.
             if state_idx <= 0:
+                zero = tl.zeros([BV], dtype=tl.float32).to(p_o.dtype.element_ty)
+                for _ in range(0, T):
+                    tl.store(p_o, zero, mask=mask_v)
+                    p_o += HV * V
                 return
             p_h0 = h0 + state_idx * stride_init_state_token
         else:

--- a/vllm/third_party/flash_linear_attention/ops/fused_sigmoid_gating.py
+++ b/vllm/third_party/flash_linear_attention/ops/fused_sigmoid_gating.py
@@ -106,10 +106,23 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
                 i_t = tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1
             else:
                 i_t = 0
-            # Load state index and check for invalid entries
-            state_idx = tl.load(ssm_state_indices + i_n * stride_indices_seq + i_t).to(
-                tl.int64
-            )
+            # Load state index and check for invalid entries.
+            # ``i_t`` is ``num_accepted_tokens - 1`` and is otherwise unbounded
+            # against a ``stride_indices_seq``-column tensor: a zero accepted
+            # count gives ``i_t == -1`` (a read before this request's row, and
+            # before the tensor for ``i_n == 0``); a stale or too-large count
+            # reads past the row. The ``state_idx <= 0`` guard below only rejects
+            # non-positive values, so an out-of-range read returning a garbage
+            # positive int flows into ``h0 + state_idx * stride_init_state_token``
+            # and faults the SM. Mask the load to the row; ``other=0`` falls into
+            # the invalid-state path below, which also returns before the
+            # ``final_state_idx`` load later.
+            idx_in_row = (i_t >= 0) & (i_t < stride_indices_seq)
+            state_idx = tl.load(
+                ssm_state_indices + i_n * stride_indices_seq + i_t,
+                mask=idx_in_row,
+                other=0,
+            ).to(tl.int64)
             # Skip if state index is invalid (NULL_BLOCK_ID=0)
             if state_idx <= 0:
                 return

--- a/vllm/third_party/flash_linear_attention/ops/fused_sigmoid_gating.py
+++ b/vllm/third_party/flash_linear_attention/ops/fused_sigmoid_gating.py
@@ -123,8 +123,12 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
                 mask=idx_in_row,
                 other=0,
             ).to(tl.int64)
-            # Skip if state index is invalid (NULL_BLOCK_ID=0)
+            # Skip invalid state indices without exposing uninitialized output.
             if state_idx <= 0:
+                zero = tl.zeros([BV], dtype=tl.float32).to(p_o.dtype.element_ty)
+                for _ in range(0, T):
+                    tl.store(p_o, zero, mask=mask_v)
+                    p_o += HV * V
                 return
             p_h0 = h0 + state_idx * stride_init_state_token
         else:

--- a/vllm/v1/worker/mamba_utils.py
+++ b/vllm/v1/worker/mamba_utils.py
@@ -79,14 +79,15 @@ def _copy_mamba_state_block(
     # accepted-token counts. A wrong count walks the read past this request's
     # row; the loaded int32 is then multiplied by state_block_stride and
     # dereferenced, so an out-of-range column becomes a wild (and possibly
-    # misaligned) address rather than merely a wrong copy. Bound the columns
-    # to the row and treat a negative id as "no block", matching the
-    # convention used elsewhere for unallocated slots.
+    # misaligned) address rather than merely a wrong copy. Bound the columns to
+    # the row: an out-of-range column loads the ``other=-1`` sentinel, and the
+    # ``<= 0`` guards below reject both that sentinel and ``NULL_BLOCK_ID`` (0,
+    # the unallocated-slot marker), so neither reaches the address math.
     dst_col_ok = (dst_col >= 0) & (dst_col < block_table_stride_req)
     dest_block_id = tl.load(
         block_table_base + dst_col, mask=dst_col_ok, other=-1
     ).to(tl.int64)
-    if dest_block_id < 0:
+    if dest_block_id <= 0:
         return
     dst_addr = state_base_addr + dest_block_id * state_block_stride
 
@@ -98,7 +99,7 @@ def _copy_mamba_state_block(
         src_block_id = tl.load(
             block_table_base + src_col, mask=src_col_ok, other=-1
         ).to(tl.int64)
-        if src_block_id < 0:
+        if src_block_id <= 0:
             return
         dim_rows = tl.load(state_dim_row_count_ptr + state_idx)
         row_stride = tl.load(state_dim_row_stride_ptr + state_idx)
@@ -125,7 +126,7 @@ def _copy_mamba_state_block(
         src_block_id = tl.load(
             block_table_base + src_col, mask=src_col_ok, other=-1
         ).to(tl.int64)
-        if src_block_id < 0:
+        if src_block_id <= 0:
             return
         src_offset = token_bias.to(tl.int64) * state_inner_size * state_elem_size
         src_addr = state_base_addr + src_block_id * state_block_stride + src_offset
@@ -146,7 +147,7 @@ def _copy_mamba_state_block(
     actual_src_block_id = tl.load(
         block_table_base + tmp_col, mask=tmp_col_ok, other=-1
     ).to(tl.int64)
-    if actual_src_block_id < 0:
+    if actual_src_block_id <= 0:
         return
     src_addr = state_base_addr + actual_src_block_id * state_block_stride
     # Use natural block data size (inner_size * elem_size), NOT

--- a/vllm/v1/worker/mamba_utils.py
+++ b/vllm/v1/worker/mamba_utils.py
@@ -179,14 +179,15 @@ def _copy_mamba_state_block(
     # accepted-token counts. A wrong count walks the read past this request's
     # row; the loaded int32 is then multiplied by state_block_stride and
     # dereferenced, so an out-of-range column becomes a wild (and possibly
-    # misaligned) address rather than merely a wrong copy. Bound the columns
-    # to the row and treat a negative id as "no block", matching the
-    # convention used elsewhere for unallocated slots.
+    # misaligned) address rather than merely a wrong copy. Bound the columns to
+    # the row: an out-of-range column loads the ``other=-1`` sentinel, and the
+    # ``<= 0`` guards below reject both that sentinel and ``NULL_BLOCK_ID`` (0,
+    # the unallocated-slot marker), so neither reaches the address math.
     dst_col_ok = (dst_col >= 0) & (dst_col < block_table_stride_req)
-    dest_block_id = tl.load(
-        block_table_base + dst_col, mask=dst_col_ok, other=-1
-    ).to(tl.int64)
-    if dest_block_id < 0:
+    dest_block_id = tl.load(block_table_base + dst_col, mask=dst_col_ok, other=-1).to(
+        tl.int64
+    )
+    if dest_block_id <= 0:
         return
     dst_addr = state_base_addr + dest_block_id * state_block_stride
 
@@ -202,7 +203,7 @@ def _copy_mamba_state_block(
         src_block_id = tl.load(
             block_table_base + src_col, mask=src_col_ok, other=-1
         ).to(tl.int64)
-        if src_block_id < 0:
+        if src_block_id <= 0:
             return
         dim_rows = tl.load(state_dim_row_count_ptr + state_idx)
         row_stride = tl.load(state_dim_row_stride_ptr + state_idx)
@@ -258,7 +259,7 @@ def _copy_mamba_state_block(
         src_block_id = tl.load(
             block_table_base + src_col, mask=src_col_ok, other=-1
         ).to(tl.int64)
-        if src_block_id < 0:
+        if src_block_id <= 0:
             return
         src_block_addr = state_base_addr + src_block_id * state_block_stride
         token_bytes = state_inner_size * state_elem_size
@@ -303,7 +304,7 @@ def _copy_mamba_state_block(
     actual_src_block_id = tl.load(
         block_table_base + tmp_col, mask=tmp_col_ok, other=-1
     ).to(tl.int64)
-    if actual_src_block_id < 0:
+    if actual_src_block_id <= 0:
         return
     src_addr = state_base_addr + actual_src_block_id * state_block_stride
     # Use natural block data size (inner_size * elem_size), NOT

--- a/vllm/v1/worker/mamba_utils.py
+++ b/vllm/v1/worker/mamba_utils.py
@@ -75,14 +75,31 @@ def _copy_mamba_state_block(
     # Widen block ids to int64 before they reach `block_id * state_block_stride`
     # below: state_block_stride can exceed 2**31 bytes for large mamba caches,
     # and Triton would otherwise do the multiply in int32 and wrap.
-    dest_block_id = tl.load(block_table_base + dst_col).to(tl.int64)
+    # FIX I: the block-table columns below are derived from per-request
+    # accepted-token counts. A wrong count walks the read past this request's
+    # row; the loaded int32 is then multiplied by state_block_stride and
+    # dereferenced, so an out-of-range column becomes a wild (and possibly
+    # misaligned) address rather than merely a wrong copy. Bound the columns
+    # to the row and treat a negative id as "no block", matching the
+    # convention used elsewhere for unallocated slots.
+    dst_col_ok = (dst_col >= 0) & (dst_col < block_table_stride_req)
+    dest_block_id = tl.load(
+        block_table_base + dst_col, mask=dst_col_ok, other=-1
+    ).to(tl.int64)
+    if dest_block_id < 0:
+        return
     dst_addr = state_base_addr + dest_block_id * state_block_stride
 
     is_conv_state = conv_width > 0
 
     if CONV_STATE_DIM_FIRST and is_conv_state:
         # DS conv layout: state_len is the slide axis; copy per dim row.
-        src_block_id = tl.load(block_table_base + src_col).to(tl.int64)
+        src_col_ok = (src_col >= 0) & (src_col < block_table_stride_req)
+        src_block_id = tl.load(
+            block_table_base + src_col, mask=src_col_ok, other=-1
+        ).to(tl.int64)
+        if src_block_id < 0:
+            return
         dim_rows = tl.load(state_dim_row_count_ptr + state_idx)
         row_stride = tl.load(state_dim_row_stride_ptr + state_idx)
         per_row_bytes = (conv_width - token_bias).to(tl.int64) * state_elem_size
@@ -104,7 +121,12 @@ def _copy_mamba_state_block(
         # SD conv: copy
         #   state[bt[src_col], token_bias:] ->
         #   state[bt[dst_col], :conv_width - token_bias]
-        src_block_id = tl.load(block_table_base + src_col).to(tl.int64)
+        src_col_ok = (src_col >= 0) & (src_col < block_table_stride_req)
+        src_block_id = tl.load(
+            block_table_base + src_col, mask=src_col_ok, other=-1
+        ).to(tl.int64)
+        if src_block_id < 0:
+            return
         src_offset = token_bias.to(tl.int64) * state_inner_size * state_elem_size
         src_addr = state_base_addr + src_block_id * state_block_stride + src_offset
         num_elems_to_copy = (conv_width - token_bias).to(tl.int64) * state_inner_size
@@ -119,7 +141,13 @@ def _copy_mamba_state_block(
         return
 
     # Temporal state: copy state[bt[src_col + token_bias]] -> state[bt[dst_col]]
-    actual_src_block_id = tl.load(block_table_base + src_col + token_bias).to(tl.int64)
+    tmp_col = src_col + token_bias
+    tmp_col_ok = (tmp_col >= 0) & (tmp_col < block_table_stride_req)
+    actual_src_block_id = tl.load(
+        block_table_base + tmp_col, mask=tmp_col_ok, other=-1
+    ).to(tl.int64)
+    if actual_src_block_id < 0:
+        return
     src_addr = state_base_addr + actual_src_block_id * state_block_stride
     # Use natural block data size (inner_size * elem_size), NOT
     # state_block_stride which is the page stride and can exceed the

--- a/vllm/v1/worker/mamba_utils.py
+++ b/vllm/v1/worker/mamba_utils.py
@@ -175,7 +175,19 @@ def _copy_mamba_state_block(
     # Widen block ids to int64 before they reach `block_id * state_block_stride`
     # below: state_block_stride can exceed 2**31 bytes for large mamba caches,
     # and Triton would otherwise do the multiply in int32 and wrap.
-    dest_block_id = tl.load(block_table_base + dst_col).to(tl.int64)
+    # FIX I: the block-table columns below are derived from per-request
+    # accepted-token counts. A wrong count walks the read past this request's
+    # row; the loaded int32 is then multiplied by state_block_stride and
+    # dereferenced, so an out-of-range column becomes a wild (and possibly
+    # misaligned) address rather than merely a wrong copy. Bound the columns
+    # to the row and treat a negative id as "no block", matching the
+    # convention used elsewhere for unallocated slots.
+    dst_col_ok = (dst_col >= 0) & (dst_col < block_table_stride_req)
+    dest_block_id = tl.load(
+        block_table_base + dst_col, mask=dst_col_ok, other=-1
+    ).to(tl.int64)
+    if dest_block_id < 0:
+        return
     dst_addr = state_base_addr + dest_block_id * state_block_stride
 
     is_conv_state = conv_width > 0
@@ -186,7 +198,12 @@ def _copy_mamba_state_block(
         if tile_idx > 0:
             return
         # DS conv layout: state_len is the slide axis; copy per dim row.
-        src_block_id = tl.load(block_table_base + src_col).to(tl.int64)
+        src_col_ok = (src_col >= 0) & (src_col < block_table_stride_req)
+        src_block_id = tl.load(
+            block_table_base + src_col, mask=src_col_ok, other=-1
+        ).to(tl.int64)
+        if src_block_id < 0:
+            return
         dim_rows = tl.load(state_dim_row_count_ptr + state_idx)
         row_stride = tl.load(state_dim_row_stride_ptr + state_idx)
         src_block_addr = state_base_addr + src_block_id * state_block_stride
@@ -237,7 +254,12 @@ def _copy_mamba_state_block(
         # SD conv: copy
         #   state[bt[src_col], token_bias:] ->
         #   state[bt[dst_col], :conv_width - token_bias]
-        src_block_id = tl.load(block_table_base + src_col).to(tl.int64)
+        src_col_ok = (src_col >= 0) & (src_col < block_table_stride_req)
+        src_block_id = tl.load(
+            block_table_base + src_col, mask=src_col_ok, other=-1
+        ).to(tl.int64)
+        if src_block_id < 0:
+            return
         src_block_addr = state_base_addr + src_block_id * state_block_stride
         token_bytes = state_inner_size * state_elem_size
         num_dst_tokens = conv_width - token_bias
@@ -276,7 +298,13 @@ def _copy_mamba_state_block(
     # Temporal state: copy state[bt[src_col + token_bias]] -> state[bt[dst_col]]
     # Body u64 range is partitioned across TEMPORAL_TILES CTAs to keep the
     # SMs filled at small batch.
-    actual_src_block_id = tl.load(block_table_base + src_col + token_bias).to(tl.int64)
+    tmp_col = src_col + token_bias
+    tmp_col_ok = (tmp_col >= 0) & (tmp_col < block_table_stride_req)
+    actual_src_block_id = tl.load(
+        block_table_base + tmp_col, mask=tmp_col_ok, other=-1
+    ).to(tl.int64)
+    if actual_src_block_id < 0:
+        return
     src_addr = state_base_addr + actual_src_block_id * state_block_stride
     # Use natural block data size (inner_size * elem_size), NOT
     # state_block_stride which is the page stride and can exceed the


### PR DESCRIPTION
## Summary

On a hybrid GDN model (Qwen3.5 / Qwen3.6) with MTP speculative decoding and prefix caching (`--mamba-cache-mode align`), the engine dies with `CUDA error: unspecified launch failure` within 7-10 requests of agent-shaped traffic. The GPU faults, not the runtime: the signature is an SM address exception (`Xid 13`, `ESR 0x404000`) or an MMU fault (`Xid 31`), depending on whether the wild address happens to be mapped.

> **Validation scope (added 2026-08-19).** Everything below was developed and validated with
> `--mamba-cache-mode align` and `--enforce-eager`. That matters: `align` is the only branch in
> which `gpu_model_runner` still calls `num_accepted_tokens_event.synchronize()` (the wait is
> skipped when `use_async_scheduling and mamba_cache_mode != "align"`), and eager mode removes
> CUDA-graph stream structure. So this PR addresses accepted-count-derived indices that are
> **correctly synchronized but out of range**. It does **not** address the separate cross-stream
> race reported by @noonghunna under async scheduling with the default (non-`align`) mamba cache
> mode, where the accepted-count value itself arrives unsynchronized — in-kernel bounds cannot
> repair a value that arrives wrong. See the discussion in this thread; that path needs stream
> ordering, not bounds. Note `mamba_cache_mode` resolves per-model: with prefix caching and no
> explicit flag it is `"all"` (sync skipped) when `model_config.supports_mamba_prefix_caching`,
> else `"align"` (sync kept).

This is the crash half of the problems reported around hybrid-Mamba + MTP. It is distinct from the prefix-cache corruption in #43559 (the coordinator-level EAGLE cache-peek gating for Mamba), which is already handled on current `main`. This PR does not touch that path and does not claim to fix #43559; it fixes a separate GPU fault in two kernels downstream.

## Root cause: unchecked accepted-count-derived indices

Speculative decoding produces a per-request accepted-token count. Multiple GPU state consumers turn that count into an array index without bounding it, so a count that is stale, zero, or too large indexes outside its tensor and yields a wild address the GPU then dereferences.

**Site 1** `fused_recurrent_gated_delta_rule_fwd_kernel` (`fused_recurrent.py`):

```python
i_t = tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1        # unbounded
state_idx = tl.load(ssm_state_indices + i_n * stride_indices_seq + i_t)
if state_idx <= 0: return                                        # positive garbage passes
p_h0 = h0 + state_idx * stride_init_state_token                  # dereferenced
```

`i_t` (= count - 1) is unbounded against a `stride_indices_seq`-column tensor. A zero accepted count gives `i_t == -1`, a read before this request's row (before the tensor for `i_n == 0`); a stale or too-large count reads past the row. The `state_idx <= 0` guard only rejects non-positive values, so an out-of-range read that returns a garbage positive int flows into the address math and faults the SM.

**Site 2** `_copy_mamba_state_block` (`mamba_utils.py`): the block-table columns derive from the same count and index the per-request block-table row unbounded; the loaded block id becomes `state_base_addr + block_id * state_block_stride`, which is then read and written.

The two sites fire under different loads. A light decode load exercises only Site 1; a heavy cache-transition load (long prefills, A->B->A prefix reuse) also drives Site 2. Both must be bounded.

## The fix

Both loads are masked to the valid range, so an out-of-range index falls into the existing invalid-state path instead of producing an address. No stream-ordering change, no device sync, no measurable throughput cost.

## Test plan

RTX 5090 (sm_120), Qwen3.6-27B NVFP4, TP=1, `--enforce-eager --max-model-len 16384`, MTP 3 (`qwen3_5_mtp`), prefix caching on, `align` mode.

| build | crash (Xid) | corruption (A->B->A probe) |
|---|---|---|
| stock | dies at 7-10 requests, Xid every run | 0/N reproduced (already fixed on main) |
| Site 1 fix alone | survives light load; still crashes on the first heavy probe (`Xid 31`) | 0/N reproduced |
| **both fixes** | **68 heavy probes + a 39-minute soak, 0 new Xid** | **0/68 reproduced** |

The A->B->A probe issues an agent-shaped sequence (long prefill, prefix reuse, 20 tool schemas) and reports whether a poisoned prefix reappears; 68/68 returned a clean verdict, which also confirms the out-of-range early-return does not drop a needed state copy. Warm throughput and MTP acceptance length (3.98-4.00 of 4) are unchanged.

## Note: a separate, still-open livelock (#49203)

Independently of this crash, the same stack can occasionally hang: engine alive, `/v1/models` answering, but the in-flight request stuck at 0% GPU util with no Xid. It is rare and timing-variable (seen once, then not across the 68 probes here) and matches open issue #49203. This PR does not address it and does not claim to; the 68/68 clean-verdict result rules out this change as a cause.


## Follow-up bounds audit

A follow-up audit expanded the same fail-closed rule to the remaining consumers in this path:

- Both FLA wrappers now zero rejected output deterministically instead of returning with new_empty storage visible downstream.
- _causal_conv1d_update_kernel now bounds the accepted-count offset before state address math; invalid active rows produce zero output and leave state unchanged.
- GPU regressions cover too-small/too-large accepted counts, NULL block IDs, source/destination columns crossing the block-table row, and temporal-bias overflow.

Validation after this follow-up: full pre-commit passed; on an RTX 5090, 186 FLA/causal-conv kernel tests and all 21 fused Mamba postprocess tests passed (207 total).

## Kimi K3 KDA expansion

The same accepted-count-derived state selection pattern also existed in Kimi K3 KDA fused recurrent decode, in both the NVIDIA and AMD vendored kernels. This PR now masks that initial state-index load to the request row, zeroes all invalid-count output tokens, preserves state on invalid counts, and releases NVIDIA PDL dependents before the new empty/invalid early returns.

Additional validation on an RTX 5090:

- Patched KDA invalid-count test: 4/4 passed across NVIDIA and AMD implementations (`num_accepted` 0 and 4).
- Existing KDA spec-decode correctness plus the new invalid-count target: 12/12 passed.
- Negative control at previous PR head `e7f66b199` with only the new test added: 4/4 failed on old KDA for NVIDIA and AMD, proving the regression is non-vacuous.

## AI assistance disclosure

OpenAI Codex assisted with the follow-up bounds audit, implementation, and regression-test generation. The submitter owns the conclusions and final review.

## Mamba2 selective-state expansion

The Mamba2 selective-state-update kernel also derives its initial state-slot lookup from `num_accepted_tokens - 1`. It already clamps the lower side, but had no upper row bound. This update preserves that zero-count behavior and makes an oversized count fail closed: it writes zero output and returns before reading or writing state.

RTX 5090 red/green regression: a count one past a three-column state row made the prior source select an adjacent row and emit nonzero output; the new kernel passes by emitting zero output and preserving the complete state tensor. Pre-commit passes for both changed files.


