### PR TITLE
[Bugfix][Attention] Size FlashInfer paged-KV buffers for local attention

### DIFF
--- a/tests/v1/attention/test_chunked_local_attention.py
+++ b/tests/v1/attention/test_chunked_local_attention.py
@@ -8,7 +8,11 @@ import torch
 
 from tests.v1.attention.utils import BatchSpec, create_common_attn_metadata
 from vllm.platforms import current_platform
-from vllm.v1.attention.backends.utils import make_local_attention_virtual_batches
+from vllm.utils.math_utils import cdiv
+from vllm.v1.attention.backends.utils import (
+    make_local_attention_virtual_batches,
+    max_local_attention_virtual_batches,
+)
 
 
 @dataclass
@@ -202,3 +206,57 @@ def test_local_attention_virtual_batches(test_data: LocalAttentionTestData):
     print(f"Actual block table:\n{result.block_table_tensor}")
 
     torch.testing.assert_close(result.block_table_tensor, expected_block_table_tensor)
+
+
+@pytest.mark.parametrize(
+    "query_lens,seq_lens,attn_chunk_size,max_num_seqs,expected_num_reqs",
+    [
+        # A single prefill longer than the chunk size, with max_num_seqs=1:
+        # the condition that overflowed FlashInfer's per-request buffers in
+        # https://github.com/vllm-project/vllm/issues/49980.
+        ([1000], [1000], 256, 1, 4),
+        # Partially computed context, so the first local block is partial.
+        ([1000], [1255], 256, 1, 5),
+        # Several requests, each spanning several chunks.
+        ([300, 700, 90], [300, 1400, 90], 128, 4, 10),
+        # Chunk size larger than every sequence: no extra virtual batches.
+        ([64, 64], [64, 64], 256, 2, 2),
+        # Decodes: one virtual batch each, so the token-count cap binds exactly.
+        ([1, 1, 1, 1], [16, 32, 48, 64], 16, 4, 4),
+    ],
+)
+def test_max_local_attention_virtual_batches_bounds_num_reqs(
+    query_lens: list[int],
+    seq_lens: list[int],
+    attn_chunk_size: int,
+    max_num_seqs: int,
+    expected_num_reqs: int,
+):
+    """The virtual batch count must never exceed the advertised upper bound.
+
+    Attention backends preallocate per-request buffers from this bound, so an
+    underestimate overflows or silently truncates them. `expected_num_reqs`
+    pins the split itself, so a bound that collapsed back to `max_num_seqs`
+    fails here rather than passing vacuously.
+    """
+    block_size = 16
+    common_attn_metadata = create_common_attn_metadata(
+        BatchSpec(query_lens=query_lens, seq_lens=seq_lens),
+        block_size,
+        torch.device("cpu"),
+    )
+    result, _ = make_local_attention_virtual_batches(
+        attn_chunk_size, common_attn_metadata, block_size
+    )
+    assert result.num_reqs == expected_num_reqs
+
+    bound = max_local_attention_virtual_batches(
+        attn_chunk_size, max_num_seqs, sum(query_lens)
+    )
+    assert result.num_reqs <= bound
+
+    # Total pages must also fit `bound * pages_per_virtual_batch`, which is how
+    # the FlashInfer builder sizes `paged_kv_indices`.
+    pages_per_virtual_batch = cdiv(attn_chunk_size, block_size)
+    num_pages = sum(cdiv(int(k), block_size) for k in result.seq_lens)
+    assert num_pages <= bound * pages_per_virtual_batch

--- a/tests/v1/attention/test_flashinfer_chunked_local_attention.py
+++ b/tests/v1/attention/test_flashinfer_chunked_local_attention.py
@@ -71,10 +71,9 @@ def _build_builder(vllm_config, kv_cache_spec):
 def _make_specs(vllm_config):
     """Both specs a chunked-local layer can reach a builder with.
 
-    With the hybrid KV cache manager enabled the builder sees a
-    `ChunkedLocalAttentionSpec`; by default vLLM disables it for chunked local
-    attention, which promotes the spec to a `FullAttentionSpec` that keeps
-    `attention_chunk_size` set.
+    With the hybrid KV cache manager enabled (the default on CUDA) the builder
+    sees a `ChunkedLocalAttentionSpec`. When it is disabled, the spec is promoted
+    to a `FullAttentionSpec` that keeps `attention_chunk_size` set.
     """
     common = dict(
         block_size=BLOCK_SIZE,

--- a/tests/v1/attention/test_flashinfer_chunked_local_attention.py
+++ b/tests/v1/attention/test_flashinfer_chunked_local_attention.py
@@ -1,0 +1,202 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""FlashInfer paged-KV buffer sizing under chunked local attention."""
+
+import unittest.mock
+
+import numpy as np
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+
+if not current_platform.is_cuda():
+    pytest.skip("FlashInfer backend requires a CUDA platform.", allow_module_level=True)
+
+from tests.v1.attention.utils import (  # noqa: E402
+    BatchSpec,
+    create_common_attn_metadata,
+    create_vllm_config,
+)
+from vllm.config import set_current_vllm_config  # noqa: E402
+from vllm.model_executor.layers.attention.chunked_local_attention import (  # noqa: E402
+    create_chunked_local_attention_backend,
+)
+from vllm.v1.attention.backends.flashinfer import FlashInferBackend  # noqa: E402
+from vllm.v1.attention.backends.utils import (  # noqa: E402
+    PerLayerParameters,
+    make_local_attention_virtual_batches,
+)
+from vllm.v1.kv_cache_interface import (  # noqa: E402
+    ChunkedLocalAttentionSpec,
+    FullAttentionSpec,
+)
+
+ATTN_CHUNK_SIZE = 256
+BLOCK_SIZE = 16
+# Longer than ATTN_CHUNK_SIZE, so the request is split into several virtual
+# batches; with max_num_seqs=1 that is what overflowed the buffers.
+QUERY_LEN = 1000
+MAX_NUM_SEQS = 1
+
+
+def _mock_get_per_layer_parameters(vllm_config, layer_names, impl_cls):
+    head_size = vllm_config.model_config.get_head_size()
+    return {
+        name: PerLayerParameters(
+            window_left=-1,
+            logits_soft_cap=0.0,
+            sm_scale=1.0 / (head_size**0.5),
+        )
+        for name in layer_names
+    }
+
+
+def _build_builder(vllm_config, kv_cache_spec):
+    backend = create_chunked_local_attention_backend(FlashInferBackend, ATTN_CHUNK_SIZE)
+    with (
+        set_current_vllm_config(vllm_config),
+        unittest.mock.patch(
+            "vllm.v1.attention.backends.flashinfer.get_per_layer_parameters",
+            _mock_get_per_layer_parameters,
+        ),
+    ):
+        # Buffer sizing happens in __init__ and is device-independent, so the
+        # test stays on CPU and needs no particular GPU.
+        return backend.get_builder_cls()(
+            kv_cache_spec, ["layer.0"], vllm_config, torch.device("cpu")
+        )
+
+
+def _make_specs(vllm_config):
+    """Both specs a chunked-local layer can reach a builder with.
+
+    With the hybrid KV cache manager enabled the builder sees a
+    `ChunkedLocalAttentionSpec`; by default vLLM disables it for chunked local
+    attention, which promotes the spec to a `FullAttentionSpec` that keeps
+    `attention_chunk_size` set.
+    """
+    common = dict(
+        block_size=BLOCK_SIZE,
+        num_kv_heads=vllm_config.model_config.get_num_kv_heads(
+            vllm_config.parallel_config
+        ),
+        head_size=vllm_config.model_config.get_head_size(),
+        dtype=vllm_config.model_config.dtype,
+    )
+    return {
+        "chunked_local": ChunkedLocalAttentionSpec(
+            attention_chunk_size=ATTN_CHUNK_SIZE, **common
+        ),
+        "promoted_full": FullAttentionSpec(
+            attention_chunk_size=ATTN_CHUNK_SIZE, **common
+        ),
+    }
+
+
+@pytest.mark.parametrize("spec_name", ["chunked_local", "promoted_full"])
+def test_paged_kv_buffers_fit_local_attention_virtual_batches(spec_name: str):
+    """Regression test for https://github.com/vllm-project/vllm/issues/49980.
+
+    `make_local_attention_virtual_batches` reports a `num_reqs` equal to the
+    virtual batch count, which is decoupled from `max_num_seqs`. Sizing the
+    paged-KV buffers from `max_num_seqs` made the cumsum in
+    `_compute_flashinfer_kv_metadata` raise "provided out is the wrong size for
+    the accumulation" whenever a prefill exceeded `attention_chunk_size`.
+    """
+    vllm_config = create_vllm_config(
+        max_model_len=2048,
+        block_size=BLOCK_SIZE,
+        max_num_seqs=MAX_NUM_SEQS,
+        max_num_batched_tokens=2048,
+    )
+    builder = _build_builder(vllm_config, _make_specs(vllm_config)[spec_name])
+
+    common_attn_metadata = create_common_attn_metadata(
+        BatchSpec(query_lens=[QUERY_LEN], seq_lens=[QUERY_LEN]),
+        BLOCK_SIZE,
+        torch.device("cpu"),
+    )
+    local_metadata, _ = make_local_attention_virtual_batches(
+        ATTN_CHUNK_SIZE, common_attn_metadata, BLOCK_SIZE
+    )
+    num_reqs = local_metadata.num_reqs
+    # Guard against the test passing vacuously if the split ever stops
+    # inflating the request count.
+    assert num_reqs > MAX_NUM_SEQS
+
+    # The exact operation that raised before the fix.
+    seq_lens_np = local_metadata.seq_lens.numpy()
+    num_blocks_np = (seq_lens_np + BLOCK_SIZE - 1) // BLOCK_SIZE
+    np.cumsum(
+        num_blocks_np,
+        dtype=np.int32,
+        out=builder.paged_kv_indptr.np[1 : num_reqs + 1],
+    )
+
+    assert builder.paged_kv_last_page_len.np.shape[0] >= num_reqs
+    num_actual_pages = int(builder.paged_kv_indptr.np[num_reqs])
+    assert builder.paged_kv_indices.np.shape[0] >= num_actual_pages
+
+
+def test_chunked_local_sizing_never_shrinks_full_attention_capacity():
+    """`attention_chunk_size` on a merged spec must not shrink the allocation.
+
+    When the hybrid KV cache manager is disabled, every Llama-4 layer becomes a
+    `FullAttentionSpec` and they merge into one KV cache group whose spec keeps
+    `attention_chunk_size`. The global attention layers form their own attention
+    group but share that spec, and they attend over the whole sequence, so
+    `paged_kv_indices` must still cover `max_num_seqs * max_num_pages_per_req`.
+    """
+    max_num_seqs = 4
+    max_model_len = 8192
+    vllm_config = create_vllm_config(
+        max_model_len=max_model_len,
+        block_size=BLOCK_SIZE,
+        max_num_seqs=max_num_seqs,
+        max_num_batched_tokens=max_model_len,
+    )
+    kv_cache_spec = FullAttentionSpec(
+        block_size=BLOCK_SIZE,
+        num_kv_heads=vllm_config.model_config.get_num_kv_heads(
+            vllm_config.parallel_config
+        ),
+        head_size=vllm_config.model_config.get_head_size(),
+        dtype=vllm_config.model_config.dtype,
+        attention_chunk_size=ATTN_CHUNK_SIZE,
+    )
+    builder = _build_builder(vllm_config, kv_cache_spec)
+
+    full_attention_pages = max_num_seqs * -(-max_model_len // BLOCK_SIZE)
+    assert builder.paged_kv_indices.np.shape[0] >= full_attention_pages
+
+
+def test_full_attention_buffer_sizing_is_unchanged():
+    """A spec without `attention_chunk_size` must keep the original sizing."""
+    vllm_config = create_vllm_config(
+        max_model_len=2048, block_size=BLOCK_SIZE, max_num_seqs=8
+    )
+    kv_cache_spec = FullAttentionSpec(
+        block_size=BLOCK_SIZE,
+        num_kv_heads=vllm_config.model_config.get_num_kv_heads(
+            vllm_config.parallel_config
+        ),
+        head_size=vllm_config.model_config.get_head_size(),
+        dtype=vllm_config.model_config.dtype,
+    )
+    backend = create_chunked_local_attention_backend(FlashInferBackend, ATTN_CHUNK_SIZE)
+    with (
+        set_current_vllm_config(vllm_config),
+        unittest.mock.patch(
+            "vllm.v1.attention.backends.flashinfer.get_per_layer_parameters",
+            _mock_get_per_layer_parameters,
+        ),
+    ):
+        builder = backend.get_builder_cls()(
+            kv_cache_spec, ["layer.0"], vllm_config, torch.device("cpu")
+        )
+
+    max_num_pages_per_req = -(-2048 // BLOCK_SIZE)
+    assert builder.paged_kv_indptr.np.shape[0] == 8 + 1
+    assert builder.paged_kv_last_page_len.np.shape[0] == 8
+    assert builder.paged_kv_indices.np.shape[0] == 8 * max_num_pages_per_req

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -69,6 +69,7 @@ from vllm.v1.attention.backends.utils import (
     get_num_attention_heads_from_layers,
     get_per_layer_parameters,
     infer_global_hyperparameters,
+    max_local_attention_virtual_batches,
     split_decodes_and_prefills,
 )
 from vllm.v1.attention.ops.common import cp_lse_ag_out_rs
@@ -657,6 +658,25 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         )
         max_num_reqs = vllm_config.scheduler_config.max_num_seqs
         max_num_pages = max_num_reqs * max_num_pages_per_req
+        # Chunked local attention emits one virtual batch per local attention
+        # block, so `build()` sees a `num_reqs` far above `max_num_seqs`. These
+        # buffers back fixed-address CUDA graph buffers, so size for that worst
+        # case rather than reallocating on overflow. A merged spec can carry
+        # `attention_chunk_size` for a group whose layers use full attention,
+        # so only ever grow the allocation.
+        attn_chunk_size = getattr(self.kv_cache_spec, "attention_chunk_size", None)
+        if attn_chunk_size is None:
+            self.max_buffer_reqs = max_num_reqs
+        else:
+            self.max_buffer_reqs = max_local_attention_virtual_batches(
+                attn_chunk_size, max_num_reqs, self.max_num_batched_tokens
+            )
+            # Each virtual batch attends to at most `attn_chunk_size` KV tokens.
+            max_num_pages = max(
+                max_num_pages,
+                self.max_buffer_reqs
+                * cdiv(attn_chunk_size, self.kv_cache_spec.block_size),
+            )
         speculative_config = vllm_config.speculative_config
         num_spec_tokens = (
             speculative_config.num_speculative_tokens
@@ -833,12 +853,12 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         # reused CPU buffers to avoid a race condition between step N async copies to
         # GPU and step N+1 buffer updates.
         self.pin_memory = not vllm_config.use_v2_model_runner and PIN_MEMORY
-        self.paged_kv_indptr = self._make_buffer(max_num_reqs + 1)
+        self.paged_kv_indptr = self._make_buffer(self.max_buffer_reqs + 1)
         self.paged_kv_indptr_cpu_buffer = torch.zeros_like(
             self.paged_kv_indptr.cpu, pin_memory=self.pin_memory
         )  # Extra buffer for mutable paged_kv_indptr.cpu in cuda graph mode
         self.paged_kv_indices = self._make_buffer(max_num_pages)
-        self.paged_kv_last_page_len = self._make_buffer(max_num_reqs)
+        self.paged_kv_last_page_len = self._make_buffer(self.max_buffer_reqs)
 
     # Keep SM90 prefill/decode Q dtype selection in one place.
     def get_q_data_type(self, is_prefill: bool) -> torch.dtype:
@@ -1055,6 +1075,36 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             )
         return self._cascade_wrapper
 
+    def _ensure_paged_kv_capacity(self, num_reqs: int, num_pages: int = 0) -> None:
+        """Grow the persistent paged-KV buffers if the batch outgrows them.
+
+        A backstop; `__init__` already sizes for chunked local attention. It
+        cannot run under decode CUDA graphs, where `_get_decode_wrapper` has
+        handed the `.gpu` tensors to FlashInfer as fixed-address buffers and
+        `fast_plan_decode` skips the indices copy on that basis. Rebinding them
+        updates no wrapper, so those plans would read stale storage.
+        """
+        grow_reqs = num_reqs > self.max_buffer_reqs
+        grow_pages = num_pages > self.paged_kv_indices.np.shape[0]
+        if not grow_reqs and not grow_pages:
+            return
+        if self.enable_cuda_graph:
+            raise ValueError(
+                f"FlashInfer paged-KV buffers hold {self.max_buffer_reqs} "
+                f"requests / {self.paged_kv_indices.np.shape[0]} pages but the "
+                f"batch needs {num_reqs} / {num_pages}, and they cannot be "
+                "grown while captured decode CUDA graphs hold their addresses."
+            )
+        if grow_reqs:
+            self.max_buffer_reqs = num_reqs
+            self.paged_kv_indptr = self._make_buffer(num_reqs + 1)
+            self.paged_kv_indptr_cpu_buffer = torch.zeros_like(
+                self.paged_kv_indptr.cpu, pin_memory=self.pin_memory
+            )
+            self.paged_kv_last_page_len = self._make_buffer(num_reqs)
+        if grow_pages:
+            self.paged_kv_indices = self._make_buffer(num_pages)
+
     def _compute_flashinfer_kv_metadata(
         self,
         num_blocks_np: np.ndarray,
@@ -1091,6 +1141,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
 
         # write self.paged_kv_indices inplace
         num_actual_pages = self.paged_kv_indptr.np[num_reqs]
+        self._ensure_paged_kv_capacity(num_reqs, int(num_actual_pages))
         paged_kv_indices = self.paged_kv_indices.gpu[:num_actual_pages]
         _copy_page_indices_kernel[(num_reqs,)](
             paged_kv_indices,
@@ -1119,6 +1170,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         fast_build: bool = False,
     ) -> FlashInferMetadata:
         num_reqs = common_attn_metadata.num_reqs
+        self._ensure_paged_kv_capacity(num_reqs)
         num_actual_tokens = common_attn_metadata.num_actual_tokens
         causal = common_attn_metadata.causal
         if causal:

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -222,6 +222,38 @@ def infer_global_hyperparameters(
     return global_params
 
 
+def max_local_attention_virtual_batches(
+    attn_chunk_size: int,
+    max_num_reqs: int,
+    max_num_batched_tokens: int,
+) -> int:
+    """Upper bound on the ``num_reqs`` that local attention can produce.
+
+    `make_local_attention_virtual_batches` emits one virtual batch per local
+    attention block, so the ``num_reqs`` it reports is decoupled from
+    `max_num_seqs`. Backends that preallocate per-request buffers must size them
+    from this bound instead.
+
+    Each request contributes ``1 + cdiv(q_i - f_i, c)`` blocks with
+    ``f_i = q_tokens_in_first_block >= 1``, summing to at most
+    ``2 * max_num_reqs + cdiv(max_num_batched_tokens, attn_chunk_size)``; the
+    ``2 *`` term is required, not slack. Every virtual batch also owns at least
+    one query token, capping the count at ``max_num_batched_tokens``.
+
+    Args:
+        attn_chunk_size: Local attention chunk size.
+        max_num_reqs: Maximum number of real requests in a batch.
+        max_num_batched_tokens: Maximum number of query tokens in a batch.
+
+    Returns:
+        Maximum number of virtual batches.
+    """
+    return min(
+        2 * max_num_reqs + cdiv(max_num_batched_tokens, attn_chunk_size),
+        max_num_batched_tokens,
+    )
+
+
 #
 # Take in `query_start_loc_np` and `seq_lens_np` and break the sequences into
 # local attention blocks, where each block is passed to the attention kernel


### PR DESCRIPTION
## Purpose

Fixes #49980.

Under chunked local attention, `make_local_attention_virtual_batches` turns `N` requests into `M > N` virtual batches and passes `M` to the builder as `num_reqs`. `FlashInferMetadataBuilder` sized `paged_kv_indptr`, `paged_kv_last_page_len` and `paged_kv_indices` from `max_num_seqs`, so they overflow whenever `M > max_num_seqs`. The reporter (`max_num_seqs=1`) hit `ValueError: provided out is the wrong size for the accumulation` from the `np.cumsum` in `_compute_flashinfer_kv_metadata`.

This PR sizes those buffers in `__init__` from an upper bound on the virtual batch count, `min(2 * max_num_seqs + cdiv(max_num_batched_tokens, c), max_num_batched_tokens)` (new helper `max_local_attention_virtual_batches`).

- **Detected with `getattr(spec, "attention_chunk_size", None)`.** The builder gets a `ChunkedLocalAttentionSpec` when the hybrid KV cache manager is on (the CUDA default). When it is off (e.g. EAGLE, `--disable-hybrid-kv-cache-manager`) it gets a `FullAttentionSpec(attention_chunk_size=...)`, which an `isinstance` check would miss. The test covers both.
- **Sized up front, not grown on overflow.** When a whole batch runs on trtllm-gen (SM100), `build()` skips `_compute_flashinfer_kv_metadata` and runs a `torch.cumsum` into an out-of-range slice of `paged_kv_indptr.gpu`. The only signal is a warning, and the kernel gets a `cum_seq_lens_kv` that is too short. The issue's grow-on-overflow check lives in `_compute_flashinfer_kv_metadata`, so it would never see this path. Rebinding the buffers is also unsafe: CUDA-graph decode wrappers alias them, and `fast_decode_plan` does not copy into them.
- **Backstop.** `_ensure_paged_kv_capacity` runs at the top of `build()` and again once the page count is known. If the bound is ever wrong, it grows the buffers, or raises when `enable_cuda_graph` is set.
- **Page count only grows (`max`, not `min`).** With the hybrid manager off, all Llama-4 layers merge into one KV cache group whose `FullAttentionSpec` keeps `attention_chunk_size`. The global-attention layers read that spec but attend over the whole sequence, so capping pages at the chunk size would under-size them (2250 → 512 pages in the reporter's config).
- **XQA draft mask (third commit).** #49718, merged after this PR was opened, added `_decode_mask_cache`, also sized from `max_num_seqs`. With XQA speculative decoding, a verify window split evenly by a chunk boundary can produce more uniform decodes than that. XQA indexes the mask per request without a shape check, so it reads past the end. The cache now uses the same bound. Reaching this needs Llama-4 with FlashInfer on SM90/SM12x and speculative decoding (any method) with an odd `k >= 3`.

<details>
<summary>Why the bound holds, and what it allocates</summary>

With `c = attention_chunk_size`, `N = max_num_seqs` and `T = max_num_batched_tokens`, each request contributes `1 + cdiv(q_i - f_i, c)` virtual batches, where `f_i = min(c - ((s_i - q_i) mod c), q_i) >= 1`. Summing gives `V <= 2N + cdiv(T, c)`. The `2N` term is needed: `q_i = 2` with `f_i = 1` gives `V = 2N`. Every virtual batch holds at least one query token, so `V <= T`. Every virtual batch sees at most `c` KV tokens, so pages `<= V * cdiv(c, block_size)`. A brute-force check over 2.7M configurations found no violations. Zero-length padded requests only occur in FULL CUDA-graph mode, which chunked-local rules out (`AttentionCGSupport.NEVER`).

| config | `paged_kv_indptr` | `paged_kv_indices` |
| --- | --- | --- |
| reporter's (`max_model_len=36000`, `T=36000`, `N=1`, `c=8192`, block 16) | 2 → 8 | 2250 → 3584 |
| `max_model_len=131072`, `T=8192`, `N=256`, `c=8192`, block 16 | 257 → 514 | unchanged |
| spec without `attention_chunk_size` | unchanged | unchanged |

</details>

**Question for reviewers:** `FullAttentionSpec.merge` keeps `attention_chunk_size`, but its consistency assert only checks `fields(AttentionSpec)`, which excludes it. Is that intended? If not, the `max()` above can go. I left it as out of scope.

## Test Plan

```bash
pytest -q tests/v1/attention/test_chunked_local_attention.py             # CPU only
pytest -q tests/v1/attention/test_flashinfer_chunked_local_attention.py  # CUDA + flashinfer, no Llama-4 weights
```

To see the failures, revert `vllm/v1/attention/backends/flashinfer.py` to `origin/main` and re-run the second file. `create_vllm_config` fetches `config.json` from the gated `meta-llama/Meta-Llama-3-8B`, so an HF token is needed.

## Test Result

- **Rebased onto current `main`, CPU only.** The only conflict was #56888's buffer-type refactor; the fix was ported with its logic unchanged. `test_chunked_local_attention.py`: 11 passed. `test_flashinfer_chunked_local_attention.py`: 5 passed, on a copy with the CUDA-only skip removed and a locally cached Qwen config. With `flashinfer.py` reverted to `origin/main`: 3 failed. Both paged-KV cases fail with the #49980 `ValueError`, and the mask case fails with `assert 1 == 2`.
- **Before the rebase, on an RTX 4090.** The FlashInfer test file: 4 passed; with the fix reverted, 2 failed with the #49980 `ValueError`. `pytest tests/v1/attention/ -k flashinfer`: 13 passed, 844 skipped.
- **Independent end-to-end.** @janbernloehr [reported](https://github.com/vllm-project/vllm/pull/50022#issuecomment-5233944543) that the original patch, cherry-picked onto `0.26.1rc1.dev528+gf8d03e774`, passes their previously fatal 32k-prefix Llama-4 Scout scenario on DGX H100 (ISL avg 34,000.80 tok, 108.23 output tok/s). Thank you! It covers only the #49980 native-prefill path: that build predates #56888, MRV2 becoming the default and SM90 XQA decode.
- **Still open.** A GPU run of the rebased branch. The XQA mask fix is CPU-verified only, and no run has exercised the SM100 trtllm-gen path.
- **Lint.** After the rebase, `pre-commit` (including manual-stage mypy 3.10–3.13) passes on Windows, except `update-dockerfile-graph`, which needs `/bin/bash`.

## AGENTS.md

- **Not a duplicate.** Re-ran the duplicate-work checks on 2026-09-18. This is the only open PR referencing #49980, and no other open PR resizes these buffers.
- **Model evaluation.** N/A. Only buffer sizes change; no kernel or attention math is touched.
- **AI assistance.** Written with AI assistance (Claude). I reviewed every changed line and verified the original fix on GPU myself.
