### PR TITLE
[Bugfix][NIXL] Guard heartbeat loop against concurrent agent registration

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_heartbeat.py
+++ b/tests/v1/kv_connector/unit/test_nixl_heartbeat.py
@@ -163,3 +163,49 @@ def test_handle_heartbeat():
     assert w._reqs_to_send["req-b"] >= far_future
     # req-unknown: not added.
     assert "req-unknown" not in w._reqs_to_send
+
+
+# ===================================================================
+# Worker: _send_heartbeats concurrent-registration race
+# ===================================================================
+
+
+def test_send_heartbeats_tolerates_concurrent_agent_registration():
+    """A handshake completing mid-iteration must not crash the worker.
+
+    Handshakes run on a background executor whose done-callback assigns
+    ``self._remote_agents[eid] = ...``. If that lands while _send_heartbeats
+    is iterating ``self._remote_agents[engine_id].values()``, Python raises
+    "RuntimeError: dictionary changed size during iteration", which kills the
+    decode EngineCore. Snapshotting the values before iterating closes the race.
+    """
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker import (
+        NixlBaseConnectorWorker,
+    )
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+        HeartbeatInfo,
+        NixlConnectorMetadata,
+    )
+
+    engine_id = "my-engine-id"
+    w = object.__new__(NixlBaseConnectorWorker)
+    w._remote_agents = {engine_id: {0: "agent-0", 1: "agent-1"}}
+    w._ensure_handshake = MagicMock(return_value=None)
+
+    def _mutating_send_notif(agent_name, notif_msg):
+        del agent_name, notif_msg
+        # Simulate a handshake done-callback registering a new agent mid-loop.
+        idx = len(w._remote_agents[engine_id])
+        w._remote_agents[engine_id][idx] = f"agent-{idx}"
+
+    w.nixl_wrapper = MagicMock()
+    w.nixl_wrapper.send_notif.side_effect = _mutating_send_notif
+
+    metadata = NixlConnectorMetadata()
+    metadata.heartbeat_by_engine[engine_id] = HeartbeatInfo(
+        req_ids={"req-1"}, host="localhost", port=1234, tp_size=1
+    )
+
+    # Must not raise "dictionary changed size during iteration".
+    w._send_heartbeats(metadata)
+    assert w.nixl_wrapper.send_notif.call_count >= 1

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -2174,7 +2174,11 @@ class NixlBaseConnectorWorker:
 
             # Build the heartbeat message: "HB:req1,req2,..."
             hb_msg = ("HB:" + ",".join(hb_info.req_ids)).encode()
-            for agent_name in self._remote_agents[engine_id].values():
+            # Snapshot the agents: handshakes run on a background executor whose
+            # done-callback assigns ``self._remote_agents[eid] = ...``, so one
+            # completing mid-iteration would raise "dictionary changed size
+            # during iteration". A just-registered agent is picked up next cycle.
+            for agent_name in list(self._remote_agents[engine_id].values()):
                 try:
                     self.nixl_wrapper.send_notif(agent_name, notif_msg=hb_msg)
                 except Exception:


### PR DESCRIPTION
## Purpose

`NixlBaseConnectorWorker._send_heartbeats` iterates
`self._remote_agents[engine_id].values()` directly. NIXL handshakes run on a
background `_handshake_initiation_executor` thread whose done-callback assigns
`self._remote_agents[eid] = f.result()`. When a handshake completes while the
decode worker is mid-iteration in `_send_heartbeats`, Python raises:

```
RuntimeError: dictionary changed size during iteration
```

That exception kills the decode `EngineCore`, which surfaces to the client as an
`EngineDeadError` → HTTP 500. Downstream, a proxy retrying against a now-dead
server exhausts its retries and the request fails.

Because this is a thread-timing race it is **flaky** — it is most likely with
wide remote-TP producers (large remote-agent fan-out, so more `send_notif`
iterations per heartbeat and a bigger window for a concurrent handshake to
land). We first hit it on a disaggregated-prefill topology with a wide remote TP,
and it struck a different worker on each run.


Stack trace
```
(Worker_TP0 pid=51621) ERROR 07-25 07:08:54 [multiproc_executor.py:1000] WorkerProc hit an exception.
Traceback (most recent call last):
  File ".../vllm/v1/executor/multiproc_executor.py", line 992, in worker_busy_loop
    output = func(*args, **kwargs)
  File ".../vllm/v1/worker/worker_base.py", line 351, in execute_model
    return self.worker.execute_model(scheduler_output)
  File ".../vllm_neuron/vllm/worker/neuron_worker.py", line 1890, in execute_model
    output = self.model_runner.execute_model(scheduler_output)
  File ".../vllm_neuron/vllm/worker/neuron_model_runner.py", line 5351, in execute_model
    return self.kv_connector_no_forward(scheduler_output, self.vllm_config)
  File ".../vllm/v1/worker/kv_connector_model_runner_mixin.py", line 42, in kv_connector_no_forward
    KVConnectorModelRunnerMixin._get_kv_connector_output(
        scheduler_output, wait_for_save=False
    ) as kv_connector_output,
  File ".../contextlib.py", line 141, in __enter__
    return next(self.gen)
  File ".../vllm/v1/worker/kv_connector_model_runner_mixin.py", line 95, in _get_kv_connector_output
    kv_connector.start_load_kv(get_forward_context())
  File ".../vllm/distributed/kv_transfer/kv_connector/v1/nixl/connector.py", line 346, in start_load_kv
    self.connector_worker.start_load_kv(self._connector_metadata)
  File ".../vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py", line 99, in start_load_kv
    self._send_heartbeats(metadata)
  File ".../vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py", line 2085, in _send_heartbeats
    for agent_name in self._remote_agents[engine_id].values():
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
RuntimeError: dictionary changed size during iteration
```

## Why this is flaky / why it wasn't caught on GPU
The crash is a race inside a single decode worker process (each vLLM worker is one process bound to one device/rank). Two threads in that process touch self._remote_agents[engine_id]:

the model-execution thread, iterating it in _send_heartbeats → for agent_name in self._remote_agents[engine_id].values():
the background _handshake_initiation_executor thread, whose done-callback assigns self._remote_agents[eid] = f.result()
A handshake completing mid-iteration mutates the dict and raises RuntimeError: dictionary changed size during iteration, which kills the EngineCore. Since any one worker dying takes down the whole engine (→ HTTP 500), the run fails if any worker loses the race.

Per-run failure probability scales with two factors, and both grow with device-count-per-node:

Number of decode workers — each worker has its own _remote_agents dict and hits the race independently. TRN2/TRN3 (64+ NeuronCores/node) run up to 64 decode processes; a GPU box runs ≤8. More processes → more independent chances that at least one lands in the window.
Remote-agent fan-out per worker — the loop has one entry per remote (prefill) rank, so a wide producer means (a) a longer loop that stays open longer and (b) more handshakes still completing concurrently during it. tp32_dcp4 (~32 remote agents) has a race window orders of magnitude larger than a tp1/tp2 config, whose 1–2-iteration loop closes before any handshake lands. A single 8-GPU node can't even build a producer that wide.
So the window is roughly (# decode workers) × (per-worker window, which grows with producer TP). GPU CI is small on both axes — near-zero window — while wide-TP DI topologies on TRN are large on both, which is why it reproduces there and effectively never on GPU. This is a genuine race on any backend; it just requires a wide enough fan-out to observe, and TRN makes that the common case (rather than GPUs being structurally immune).

The logs confirm the mechanism: Worker_TP0 crashed at 07:08:54 in the exact second Worker_TP3 was completing a NIXL handshake: add agent, and a separate run (pod 33661c42) hit the identical trace on a different worker — nondeterministic, not topology-deterministic.



## Fix

Snapshot the agent list with `list(...)` before iterating, so a concurrent
insert into `_remote_agents[engine_id]` can no longer corrupt the iteration. A
heartbeat that misses a just-registered agent is simply picked up on the next
heartbeat cycle. A snapshot is preferred over a lock so the per-agent
`send_notif` network calls are not serialized against new handshakes.

```python
for agent_name in list(self._remote_agents[engine_id].values()):
```

## Not a duplicate

Checked open PRs against `vllm-project/vllm` for `nixl heartbeat`,
`dictionary changed size iteration`, and `_send_heartbeats remote_agents` — none
address this race (matches were the EC connector, mooncake HBM leak, sleep-mode
leak, etc.).

## Test

Added `tests/v1/kv_connector/unit/test_nixl_heartbeat.py::test_send_heartbeats_tolerates_concurrent_agent_registration`,
which reproduces the race by mutating `_remote_agents` from inside a `send_notif`
side-effect mid-loop. It fails on the current `.values()` iteration
(`RuntimeError: dictionary changed size during iteration`) and passes with the
`list(...)` snapshot.

```bash
.venv/bin/python -m pytest \
  tests/v1/kv_connector/unit/test_nixl_heartbeat.py \
  -k send_heartbeats -v
```

<!-- Submitter: paste the local pytest output here after running in the vLLM
     dev environment (uv venv + VLLM_USE_PRECOMPILED=1 uv pip install -e .). -->

The isolated race + fix logic was also verified standalone (direct iteration
raises; the `list(...)` snapshot survives with the extra element registered
mid-loop).

