### PR TITLE
[Bugfix] Prevent get_open_port() from spinning forever when VLLM_PORT is in the DP reserved range

### DIFF
--- a/tests/utils_/test_network_utils.py
+++ b/tests/utils_/test_network_utils.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import socket
+from types import SimpleNamespace
 
 import pytest
 import zmq
 
+from vllm.utils import network_utils
 from vllm.utils.network_utils import (
     get_open_port,
     get_open_ports_list,
@@ -27,6 +29,99 @@ def test_get_open_port(monkeypatch: pytest.MonkeyPatch):
                 s2.bind(("localhost", get_open_port()))
                 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s3:
                     s3.bind(("localhost", get_open_port()))
+
+
+def test_get_open_port_skips_dp_reserved_range(monkeypatch: pytest.MonkeyPatch):
+    # VLLM_PORT makes the port scan deterministic, so a candidate landing in
+    # the data parallel reserved range used to loop forever.
+    dp_master_port = 5678
+    reserved_port_range = range(dp_master_port, dp_master_port + 10)
+    with monkeypatch.context() as m:
+        m.setenv("VLLM_PORT", str(dp_master_port))
+        m.setenv("VLLM_DP_MASTER_PORT", str(dp_master_port))
+        port = get_open_port()
+        assert port not in reserved_port_range
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("localhost", port))
+
+
+def test_get_open_port_dp_without_vllm_port(monkeypatch: pytest.MonkeyPatch):
+    dp_master_port = 5678
+    reserved_port_range = range(dp_master_port, dp_master_port + 10)
+    with monkeypatch.context() as m:
+        m.delenv("VLLM_PORT", raising=False)
+        m.setenv("VLLM_DP_MASTER_PORT", str(dp_master_port))
+        port = get_open_port()
+        assert port not in reserved_port_range
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("localhost", port))
+
+
+def test_get_open_port_dp_vllm_port_above_range(monkeypatch: pytest.MonkeyPatch):
+    # The scan only ever counts upward, so a VLLM_PORT above the reserved
+    # range must be honoured as-is rather than pushed higher.
+    dp_master_port = 5678
+    reserved_port_range = range(dp_master_port, dp_master_port + 10)
+    start_port = reserved_port_range.stop + 12
+    with monkeypatch.context() as m:
+        m.setenv("VLLM_PORT", str(start_port))
+        m.setenv("VLLM_DP_MASTER_PORT", str(dp_master_port))
+        port = get_open_port()
+        assert port >= start_port
+        assert port not in reserved_port_range
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("localhost", port))
+
+
+def test_get_open_port_without_dp_master_port(monkeypatch: pytest.MonkeyPatch):
+    start_port = 5678
+    with monkeypatch.context() as m:
+        m.setenv("VLLM_PORT", str(start_port))
+        m.delenv("VLLM_DP_MASTER_PORT", raising=False)
+        port = get_open_port()
+        assert port >= start_port
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("localhost", port))
+
+
+def test_get_open_port_dp_reserved_range_exhausted(monkeypatch: pytest.MonkeyPatch):
+    dp_master_port = 5678
+    reserved_port_range = range(dp_master_port, dp_master_port + 10)
+
+    class OnlyReservedPortsFree:
+        """Socket stub where every port outside the reserved range is taken."""
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc_info):
+            return False
+
+        def bind(self, address):
+            if address[1] not in reserved_port_range:
+                raise OSError("address already in use")
+
+    with monkeypatch.context() as m:
+        m.setenv("VLLM_PORT", str(dp_master_port))
+        m.setenv("VLLM_DP_MASTER_PORT", str(dp_master_port))
+        m.setattr(
+            network_utils,
+            "socket",
+            SimpleNamespace(
+                socket=OnlyReservedPortsFree,
+                AF_INET=socket.AF_INET,
+                AF_INET6=socket.AF_INET6,
+                SOCK_STREAM=socket.SOCK_STREAM,
+            ),
+        )
+        with pytest.raises(
+            RuntimeError,
+            match=f"starting from port {reserved_port_range.stop}",
+        ):
+            get_open_port()
 
 
 def test_get_open_ports_list_with_vllm_port(monkeypatch: pytest.MonkeyPatch):

--- a/vllm/utils/network_utils.py
+++ b/vllm/utils/network_utils.py
@@ -159,6 +159,17 @@ def get_open_port() -> int:
     if "VLLM_DP_MASTER_PORT" in os.environ:
         dp_master_port = envs.VLLM_DP_MASTER_PORT
         reserved_port_range = range(dp_master_port, dp_master_port + 10)
+        if envs.VLLM_PORT is not None:
+            # VLLM_PORT pins where the scan starts, so calling _get_open_port()
+            # again would keep returning the same reserved port forever. Restart
+            # the scan above the range, the same way get_open_ports_list()
+            # advances its start port.
+            port = _get_open_port(start_port=envs.VLLM_PORT, max_attempts=1000)
+            if port in reserved_port_range:
+                port = _get_open_port(
+                    start_port=reserved_port_range.stop, max_attempts=1000
+                )
+            return port
         while True:
             candidate_port = _get_open_port()
             if candidate_port not in reserved_port_range:


### PR DESCRIPTION
## Purpose

Fixes #50024. Completes the fix started in #36191.

`get_open_port()` spins forever when `VLLM_PORT` is set to a value inside the data parallel reserved window, so `vllm serve --data-parallel-size N` hangs at startup with no output. `_get_open_port()` is deterministic when `VLLM_PORT` is set, so the `while True` loop that skips reserved ports keeps regenerating the same excluded port.

#36191 added `start_port` and `max_attempts` to `_get_open_port` and routed `get_open_ports_list` through them, but this caller was left on the bare no-argument call. This change routes it through the same machinery: scan from `VLLM_PORT`, and if the result lands in the reserved window, rescan starting above the window. The scan only counts upward, so a single rescan is enough to guarantee progress, and exhaustion raises the `RuntimeError` `_get_open_port` already produces instead of hanging.

The ephemeral path (`VLLM_PORT` unset) is untouched: each call there returns a fresh OS-assigned port, so that loop does terminate.

## Test Plan

`tests/utils_/test_network_utils.py`:

- `test_get_open_port_skips_dp_reserved_range` â€” the regression case, `VLLM_PORT` inside the window, asserts a bindable port outside it
- `test_get_open_port_dp_without_vllm_port` â€” ephemeral path with the window set
- `test_get_open_port_dp_vllm_port_above_range` â€” `VLLM_PORT` above the window is honored as-is
- `test_get_open_port_without_dp_master_port` â€” no DP env, unchanged
- `test_get_open_port_dp_reserved_range_exhausted` â€” clear `RuntimeError` rather than a spin

## Test Result

All five pass. Against the unfixed function the regression case does not terminate (bounded at 200000 iterations, same port every time); with the fix it returns 29510 in two calls.

Also verified on a live server (released 0.26.0 image, this file mounted over the installed copy): the three configurations that wedged past 120 seconds unpatched all return port 29510 in about 3 seconds patched, 0 of 7 configurations hang, and the unrelated startup paths behave identically before and after.

Note for reviewers: the pre-existing `test_get_open_port` fails on Windows both before and after this change, because Windows allows `bind(("", port))` while `127.0.0.1:port` is bound. Unrelated to this PR and not touched by it.
