### PR TITLE
[Bugfix] Reject stream and tools in batch chat completions instead of returning empty output

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_chat_error.py
+++ b/tests/entrypoints/openai/chat_completion/test_chat_error.py
@@ -503,6 +503,68 @@ def test_batch_structural_tag_response_format_invalid(format_value):
         )
 
 
+@pytest.mark.parametrize(
+    "streaming_kwargs",
+    [
+        {"stream": True},
+        {"stream_options": {"include_usage": True}},
+    ],
+)
+def test_batch_streaming_rejected(streaming_kwargs):
+    """Batch chat has no streaming path. `stream` is not a declared field on the
+    batch model, so without an explicit check it survives as an extra and is
+    forwarded to ChatCompletionRequest, which truncates the response to the last
+    delta instead of failing."""
+    with pytest.raises(
+        ValidationError,
+        match="do not support streaming",
+    ):
+        BatchChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[[{"role": "user", "content": "hello"}]],
+            **streaming_kwargs,
+        )
+
+
+def test_batch_tool_use_rejected():
+    """Batch chat never passes tool definitions to the renderer, so a request
+    carrying them must fail rather than silently drop them."""
+    with pytest.raises(
+        ValidationError,
+        match="do not support tool use",
+    ):
+        BatchChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[[{"role": "user", "content": "hello"}]],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+        )
+
+
+def test_batch_without_streaming_or_tools_accepted():
+    """Control case: the explicit off values stay valid and do not leak a
+    streaming or tool-calling request into the per-conversation requests."""
+    request = BatchChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[[{"role": "user", "content": "hello"}]],
+        stream=False,
+        tools=None,
+        tool_choice="none",
+    )
+
+    single = request.to_chat_completion_request(request.messages[0])
+    assert single.stream is False
+    assert single.tools is None
+    assert single.tool_choice == "none"
+
+
 @pytest.mark.parametrize("structural_tag", ["not json", ""])
 def test_structured_outputs_structural_tag_invalid(structural_tag):
     """Malformed direct structured_outputs structural tags should be rejected."""

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -1086,6 +1086,23 @@ class BatchChatCompletionRequest(OpenAIBaseModel):
     def check_batch_mode(cls, data: Any) -> Any:
         if isinstance(data, BatchChatCompletionRequest):
             data = data.model_dump(exclude_unset=True)
+        if data.get("stream"):
+            raise VLLMValidationError(
+                "Batch chat completions do not support streaming. "
+                "Please set `stream` to False.",
+                parameter="stream",
+            )
+        if data.get("stream_options"):
+            raise VLLMValidationError(
+                "Batch chat completions do not support streaming. "
+                "Please omit `stream_options`.",
+                parameter="stream_options",
+            )
+        if data.get("tools"):
+            raise VLLMValidationError(
+                "Batch chat completions do not support tool use. Please omit `tools`.",
+                parameter="tools",
+            )
         if data.get("use_beam_search"):
             raise VLLMValidationError(
                 "Batch chat completions do not support beam search. "


### PR DESCRIPTION
## Purpose

Fixes #50026.

`check_batch_mode` guards the batch chat endpoint against options it cannot honor, but `stream` and `tools` were missing. Since `OpenAIBaseModel` permits extra fields, both reached `to_chat_completion_request` and were forwarded to a real `ChatCompletionRequest`. `stream` switched the request to `DELTA` output, and because the collector assigns rather than accumulates (`batch_serving.py:225`), the client received empty choices with HTTP 200 and `finish_reason: "stop"`. `tools` was dropped at `batch_serving.py:129`, which passes `None` for tools, so the model answered without ever seeing them.

This adds the missing checks, in the same shape as the existing ones in that validator. `stream_options` is included with `stream` since it is meaningless without it and would otherwise fail later, deeper in request handling. The docstrings in `protocol.py` and `batch_serving.py` already described this contract, so no doc changes were needed.

## Test Plan

`tests/entrypoints/openai/chat_completion/test_chat_error.py`, next to the existing `test_batch_structural_tag_response_format_invalid` and following its style:

- `test_batch_streaming_rejected` â€” `stream: true` and `stream_options`
- `test_batch_tool_use_rejected` â€” a `tools` array
- `test_batch_without_streaming_or_tools_accepted` â€” control, explicit off values still build a valid per-conversation request

Also verified against a live server (released 0.26.0 image, RTX 5090, Qwen2.5-0.5B-Instruct), unpatched vs patched with only this change applied.

## Test Result

Unit tests pass. Live server, unpatched:

```
batch, no stream       HTTP 200  completion_tokens=76   full answers
batch, stream=true     HTTP 200  completion_tokens=2    every choice ''  finish_reason 'stop'
batch, tools array     HTTP 200  prompt_tokens=38 (single endpoint: 212) - tools never rendered
```

Live server, patched:

```
batch, stream=true     HTTP 400  param='stream'
batch, stream_options  HTTP 400  param='stream_options'
batch, tools array     HTTP 400  param='tools'
smoke: normal batch, normal single, explicit stream=False/tools=None - correct full answers;
       single endpoint with tools + tool_choice='auto' still emits real tool_calls
```
