### PR TITLE
[Core][PCP] Select MRV2 when PCP is enabled

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -557,6 +557,10 @@ class VllmConfig:
         if use_v2_model_runner is not None:
             return use_v2_model_runner
 
+        # PCP runtime support is implemented only by the V2 model runner.
+        if self.parallel_config.prefill_context_parallel_size > 1:
+            return True
+
         # DSpark is implemented only by the V2 GPU model runner, and DeepSeek-V4
         # is not otherwise a default-V2 architecture, so force V2 for it. If V2
         # is unsupported for the rest of the config, _validate_v2_model_runner
@@ -1460,6 +1464,11 @@ class VllmConfig:
 
         if self.use_v2_model_runner:
             self._validate_v2_model_runner()
+        elif self.parallel_config.prefill_context_parallel_size > 1:
+            raise ValueError(
+                "Prefill context parallelism requires Model Runner V2. "
+                "Remove VLLM_USE_V2_MODEL_RUNNER=0."
+            )
 
         # Re-compute compile ranges after platform-specific config updates
         # (e.g., XPU may lower max_num_batched_tokens when MLA is enabled)


### PR DESCRIPTION
## Summary

- select Model Runner V2 automatically when prefill context parallelism is enabled
- reject an explicit V1 model-runner override with a clear configuration error

Related to #49810.

## AI assistance

OpenAI Codex assisted with investigation, implementation, and PR preparation. Reviewed by the submitter.