### PR TITLE
experiment: force Preshuffle=True for decode paged MQA-logits

### DIFF
--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -439,7 +439,7 @@ def rocm_fp8_paged_mqa_logits(
                 block_tables,
                 max_model_len,
                 ChunkK=256,
-                Preshuffle=block_size > 1,
+                Preshuffle=True,
                 KVBlockSize=block_size,
                 WavePerEU=2,
             )


### PR DESCRIPTION
## Summary

Changes the decode paged MQA-logits call in `rocm_fp8_paged_mqa_logits` (`vllm/v1/attention/ops/rocm_aiter_mla_sparse.py`) to pass `Preshuffle=True` unconditionally instead of gating on `block_size > 1`.

This is an experimental A/B to exercise the preshuffle paged-logits kernel path independent of the KV-cache block size.

## Change

```diff
-                Preshuffle=block_size > 1,
+                Preshuffle=True,
```

## Scope / caveats

- Affects only the decode paged path (`deepgemm_fp8_paged_mqa_logits`).
- The aiter kernel asserts `KVBlockSize % 16 == 0` when `Preshuffle=True`; with `KVBlockSize=block_size`, this requires the KV-cache block size to be 16-aligned. With `block_size=1` (per-token page table) the preshuffle contract is not satisfied, so this is intended for block-size-16-aligned KV cache configs only.
- Draft / experimental: for benchmarking, not for merge as-is.

## Test plan

- [ ] Verify server starts with a 16-aligned KV cache block size and the preshuffle kernel is selected.
- [ ] Compare decode correctness and perf vs baseline (`Preshuffle=block_size > 1`).