### PR TITLE
[Bugfix] Coordinate scheduler with process checkpoint hooks

### DIFF
--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -944,10 +944,10 @@ class AsyncLLM(EngineClient):
             self.logger_manager.record_sleep_state(0, 0)
 
     async def checkpoint_prepare(self) -> None:
-        await self.collective_rpc("checkpoint_prepare")
+        await self.engine_core.checkpoint_prepare_async()
 
     async def checkpoint_restore(self) -> None:
-        await self.collective_rpc("checkpoint_restore")
+        await self.engine_core.checkpoint_restore_async()
 
     async def is_sleeping(self) -> bool:
         return await self.engine_core.is_sleeping_async()

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -234,6 +234,7 @@ class EngineCore:
         self.aborts_queue = queue.Queue[list[str]]()
 
         self._idle_state_callbacks: list[Callable] = []
+        self._process_checkpoint_active = False
 
         # Mark the startup heap as static so that it's ignored by GC.
         # Reduces pause times of oldest generation collections.
@@ -862,6 +863,34 @@ class EngineCore:
         """Return whether the scheduler is in any pause state."""
         return self.scheduler.pause_state != PauseState.UNPAUSED
 
+    def checkpoint_prepare(self) -> None | Future:
+        """Pause scheduling, then prepare worker communicators."""
+        pause_future = None if self.is_scheduler_paused() else self.pause_scheduler()
+        if pause_future is None:
+            self._process_checkpoint_active = True
+            self.collective_rpc("checkpoint_prepare")
+            return None
+
+        future = Future[Any]()
+
+        def pause_complete(f: Future):
+            try:
+                f.result()
+                self._process_checkpoint_active = True
+                self.collective_rpc("checkpoint_prepare")
+            except Exception as e:
+                future.set_exception(e)
+            else:
+                future.set_result(None)
+
+        pause_future.add_done_callback(pause_complete)
+        return future
+
+    def checkpoint_restore(self) -> None:
+        """Restore worker communicators without resuming scheduling."""
+        self.collective_rpc("checkpoint_restore")
+        self._process_checkpoint_active = False
+
     def sleep(self, level: int = 1, mode: PauseMode = "abort") -> None | Future:
         """Put the engine to sleep at the specified level.
 
@@ -874,6 +903,12 @@ class EngineCore:
             mode: Pause mode - how to deal with any existing requests, see
                 documentation of pause_scheduler method.
         """
+
+        if self._process_checkpoint_active:
+            if level >= 1:
+                self._reset_caches()
+                self.model_executor.sleep(level)
+            return None
 
         # Pause scheduler before sleeping.
         clear_prefix_cache = level >= 1
@@ -912,6 +947,9 @@ class EngineCore:
 
         if tags is None or tags:
             self.model_executor.wake_up(tags)
+
+        if self._process_checkpoint_active:
+            return
 
         # Partial wakes intentionally keep the remaining allocations asleep.
         # Resume scheduling only once all executor memory is resident again.

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -247,6 +247,12 @@ class EngineCoreClient(ABC):
     async def wake_up_async(self, tags: list[str] | None = None) -> None:
         raise NotImplementedError
 
+    async def checkpoint_prepare_async(self) -> None:
+        raise NotImplementedError
+
+    async def checkpoint_restore_async(self) -> None:
+        raise NotImplementedError
+
     async def is_sleeping_async(self) -> bool:
         raise NotImplementedError
 
@@ -1192,6 +1198,12 @@ class AsyncMPClient(MPClient):
 
     async def wake_up_async(self, tags: list[str] | None = None) -> None:
         await self.call_utility_async("wake_up", tags)
+
+    async def checkpoint_prepare_async(self) -> None:
+        await self.call_utility_async("checkpoint_prepare")
+
+    async def checkpoint_restore_async(self) -> None:
+        await self.call_utility_async("checkpoint_restore")
 
     async def is_sleeping_async(self) -> bool:
         return await self.call_utility_async("is_sleeping")


### PR DESCRIPTION
## Summary

- pause generation before preparing process-checkpoint communicator state
- keep scheduling paused while checkpoint sleep/wake manages GPU memory
- restore communicators without automatically resuming generation
- allow an already-paused scheduler to be reused without starting another
  pause

The intended serialized sequence is:

```python
await engine.checkpoint_prepare()
await engine.sleep()
# external CUDA/CRIU checkpoint and restore
await engine.wake_up()
await engine.checkpoint_restore()
await engine.resume_generation()
```

Callers may optionally pause first:

```python
await engine.pause_generation()
await engine.checkpoint_prepare()
```

Because the calls are awaited and serialized, `checkpoint_prepare()` reuses the
existing pause and does not initiate a second DP pause wave.

## Original symptoms

The communicator checkpoint hooks and scheduler sleep lifecycle were previously
independent:

1. `checkpoint_prepare()` called workers directly without coordinating the
   scheduler.
2. `sleep()` always requested its own scheduler pause.
3. `wake_up()` automatically resumed scheduling once executor memory was awake.

For an orchestrator using:

```text
pause_generation
checkpoint_prepare
sleep
external checkpoint/restore
wake_up
checkpoint_restore
resume_generation
```

this caused two failures:

- `sleep()` could restart DP pause consensus and dummy execution after the
  caller had already quiesced generation;
- `wake_up()` could resume scheduling before `checkpoint_restore()` rebuilt
  communicator state.

The latter could schedule work while communicator state was still unavailable
after process restore.

## Root cause

`AsyncLLM.checkpoint_prepare()` and `checkpoint_restore()` forwarded directly to
worker collective RPCs. `EngineCore` therefore could not distinguish ordinary
memory sleep/wake from sleep/wake inside a process checkpoint.

Making pause/resume independently idempotent is insufficient: the resume from
`wake_up()` is the first resume in the sequence, so it is not redundant.

## Fix

The checkpoint hooks now route through `EngineCore`, the layer that owns both
the scheduler and model executor:

- `checkpoint_prepare()` reuses an existing scheduler pause or waits for the
  normal pause Future before invoking worker communicator preparation.
- One private boolean records that process-checkpoint preparation is active.
- While active, `sleep()` and `wake_up()` retain their cache/memory behavior but
  do not pause or resume the scheduler.
- `checkpoint_restore()` restores worker communicators, clears the boolean, and
  leaves scheduling paused.
- The existing explicit `resume_generation()` resumes serving after restore.

This intentionally trusts the orchestrator to issue the lifecycle calls in the
serialized order above. It does not add a public flag, checkpoint state machine,
pause-owner abstraction, retry protocol, or implicit communicator handling in
generic sleep/wake.

When checkpoint hooks are not used, ordinary pause/resume/sleep/wake behavior
is unchanged.

## Duplicate-work check

This builds on merged PR #46877, which added communicator-owned
`checkpoint_prepare`/`checkpoint_restore` hooks. It does not duplicate the
following open work:

- #37925 adds a separate CUDA-checkpoint `suspend()`/`resume()` API and REST
  integration.
- #35934 tears down and rebuilds distributed state for CRIU snapshots.
- #47500 refuses unsupported sleep backends based on communicator-preservation
  capabilities.

This PR only coordinates the already-merged communicator hooks with the
existing scheduler sleep/wake lifecycle.

## AI assistance and submitter accountability

AI assistance was used to investigate, implement, review, and validate this
change.