### PR TITLE
Fix/granitemoe fp8 split experts rebased

### DIFF
--- a/tests/models/test_granitemoe.py
+++ b/tests/models/test_granitemoe.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm.model_executor.models.granitemoe import GraniteMoeModel
+
+
+class _StubModel(torch.nn.Module):
+    """Minimal stand-in for `get_expert_mapping`.
+
+    The mapping only reads `config.num_local_experts` and scans
+    `named_parameters()` for a LoRA `base_layer.` prefix, so no real weights
+    or CUDA are needed.
+    """
+
+    def __init__(self, num_local_experts: int):
+        super().__init__()
+        self.config = SimpleNamespace(num_local_experts=num_local_experts)
+
+    def named_parameters(self, *args, **kwargs):
+        return iter([])
+
+
+def test_granitemoe_expert_mapping_split_experts():
+    """Split per-expert checkpoint names map onto the fused FusedMoE slots.
+
+    Regression guard for the FP8 split-experts KeyError: each
+    `experts.{e}.{gate,up,down}_proj.` name must route to the right
+    `w13`/`w2` shard for its expert. gate->w1 and up->w3 land in `w13_`;
+    down->w2 lands in `w2_`.
+    """
+    mapping = GraniteMoeModel.get_expert_mapping(_StubModel(2))
+
+    assert mapping == [
+        ("experts.routed_experts.w13_", "experts.0.gate_proj.", 0, "w1"),
+        ("experts.routed_experts.w2_", "experts.0.down_proj.", 0, "w2"),
+        ("experts.routed_experts.w13_", "experts.0.up_proj.", 0, "w3"),
+        ("experts.routed_experts.w13_", "experts.1.gate_proj.", 1, "w1"),
+        ("experts.routed_experts.w2_", "experts.1.down_proj.", 1, "w2"),
+        ("experts.routed_experts.w13_", "experts.1.up_proj.", 1, "w3"),
+    ]

--- a/vllm/model_executor/models/granitemoe.py
+++ b/vllm/model_executor/models/granitemoe.py
@@ -344,6 +344,9 @@ class GraniteMoeModel(nn.Module):
         This function is copied from `MixtralModel.load_weights`, mainly to
         decouple from mixtral, avoiding impact on support like BNB
         quantization.
+
+        Used by GraniteMoeShared, which pre-splits the fused expert weights
+        into ``experts.{e}.w{1,2,3}`` before calling this.
         """
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
@@ -431,10 +434,115 @@ class GraniteMoeModel(nn.Module):
             loaded_params.add(name)
         return loaded_params
 
+    def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
+        """Build the checkpoint->FusedMoE translation table for split experts.
+
+        The split per-expert layout (from llm-compressor FP8 quantization)
+        stores one tensor per expert per projection, named
+        ``experts.{e}.{gate,up,down}_proj.{weight,weight_scale}``. The fused
+        ``FusedMoE`` module instead exposes a single stacked parameter per
+        layer (``experts.w13_*`` for gate+up, ``experts.w2_*`` for down).
+
+        Each returned tuple is
+        ``(param_name, weight_name, expert_id, shard_id)``:
+          - ``weight_name``  is the checkpoint substring to match, e.g.
+            ``experts.3.gate_proj.``.
+          - ``param_name``   is the FusedMoE parameter it maps onto, e.g.
+            ``experts.w13_``.
+          - ``expert_id``    selects the slice within that stacked param.
+          - ``shard_id``     (``w1``/``w2``/``w3``) tells the FusedMoE weight
+            loader which half of ``w13`` (gate vs up) or that it is ``w2``.
+
+        ``load_weights`` iterates this table in ``_load_quant_expert`` to route
+        each split tensor (both ``weight`` and ``weight_scale``) to the right
+        expert slot. The mapping is suffix-agnostic, so weight and scale share
+        one path.
+        """
+        # (param_name, weight_name, expert_id, shard_id)
+        return fused_moe_make_expert_params_mapping(
+            self,
+            ckpt_gate_proj_name="gate_proj",
+            ckpt_down_proj_name="down_proj",
+            ckpt_up_proj_name="up_proj",
+            num_experts=self.config.num_local_experts,
+        )
+
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        new_weights = {}
+        stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            (".qkv_proj", ".q_proj", "q"),
+            (".qkv_proj", ".k_proj", "k"),
+            (".qkv_proj", ".v_proj", "v"),
+        ]
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+        expert_params_mapping = self.get_expert_mapping()
+
+        def _load(n, p):
+            if n.endswith("scale"):
+                n = maybe_remap_kv_scale_name(n, params_dict)
+                if n is None:
+                    return
+            if is_pp_missing_parameter(n, self):
+                return
+            param = params_dict[n]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, p)
+            loaded_params.add(n)
+
+        def _load_shard(n, p, shard_id):
+            if is_pp_missing_parameter(n, self):
+                return
+            param = params_dict[n]
+            weight_loader = param.weight_loader
+            weight_loader(param, p, shard_id)
+            loaded_params.add(n)
+
+        def _load_expert(n, p, name, shard_id, expert_id):
+            if is_pp_missing_parameter(n, self):
+                return
+            param = params_dict[n]
+            weight_loader = param.weight_loader
+            weight_loader(param, p, name, shard_id=shard_id, expert_id=expert_id)
+            loaded_params.add(n)
+
+        def _load_quant_expert(name, loaded_weight):
+            # Handles the split per-expert checkpoint layout
+            # (``experts.{e}.{gate,up,down}_proj.{weight,weight_scale}``), e.g.
+            # produced by llm-compressor FP8 quantization.
+            for param_name, weight_name, expert_id, shard_id in expert_params_mapping:
+                if weight_name not in name:
+                    continue
+                name_mapped = name.replace(weight_name, param_name)
+                if is_pp_missing_parameter(name_mapped, self):
+                    continue
+                param = params_dict[name_mapped]
+                weight_loader = param.weight_loader
+                success = weight_loader(
+                    param,
+                    loaded_weight,
+                    name_mapped,
+                    shard_id=shard_id,
+                    expert_id=expert_id,
+                    return_success=True,
+                )
+                if success:
+                    loaded_params.add(name_mapped)
+                    return name_mapped
+            return None
+
         for n, p in weights:
-            if n.endswith(".block_sparse_moe.input_linear.weight"):
+            if _load_quant_expert(n, p):
+                continue
+
+            # Map the fused expert layout of the unquantized base checkpoint
+            #  from HF (input_linear, output_linear, router)
+            #  to vLLM (experts.routed_experts.{w13_,w2_}, gate).
+            # The renaming and loading logic is identical for weight and
+            # weight_scale tensors, so both suffixes are handled here.
+            if n.endswith(".block_sparse_moe.input_linear.weight") or n.endswith(
+                ".block_sparse_moe.input_linear.weight_scale"
+            ):
                 for e in range(p.size(0)):
                     w1_name = n.replace(
                         ".block_sparse_moe.input_linear.weight",
@@ -445,29 +553,53 @@ class GraniteMoeModel(nn.Module):
                         f".block_sparse_moe.experts.{e}.w3.weight",
                     )
                     w1_param, w3_param = p[e].chunk(2, dim=0)
-                    assert w1_name not in new_weights
-                    assert w3_name not in new_weights
-                    new_weights[w1_name] = w1_param
-                    new_weights[w3_name] = w3_param
-            elif n.endswith(".block_sparse_moe.output_linear.weight"):
+                    _load_expert(
+                        n.replace(".input_linear.", ".experts.routed_experts.w13_"),
+                        w1_param,
+                        w1_name,
+                        shard_id="w1",
+                        expert_id=e,
+                    )
+                    _load_expert(
+                        n.replace(".input_linear.", ".experts.routed_experts.w13_"),
+                        w3_param,
+                        w3_name,
+                        shard_id="w3",
+                        expert_id=e,
+                    )
+            elif n.endswith(".block_sparse_moe.output_linear.weight") or n.endswith(
+                ".block_sparse_moe.output_linear.weight_scale"
+            ):
                 for e in range(p.size(0)):
                     w2_name = n.replace(
                         ".block_sparse_moe.output_linear.weight",
                         f".block_sparse_moe.experts.{e}.w2.weight",
                     )
-                    w2_param = p[e]
-                    assert w2_name not in new_weights
-                    new_weights[w2_name] = w2_param
+                    _load_expert(
+                        n.replace(".output_linear.", ".experts.routed_experts.w2_"),
+                        p[e],
+                        w2_name,
+                        shard_id="w2",
+                        expert_id=e,
+                    )
             elif n.endswith(".block_sparse_moe.router.layer.weight"):
                 gate_name = n.replace(
                     ".block_sparse_moe.router.layer.weight",
                     ".block_sparse_moe.gate.weight",
                 )
-                assert gate_name not in new_weights
-                new_weights[gate_name] = p
+                _load(gate_name, p)
             else:
-                new_weights[n] = p
-        return self._load_weights(new_weights.items())
+                loaded = False
+                for param_name, weight_name, shard_id in stacked_params_mapping:
+                    if weight_name in n:
+                        _load_shard(
+                            n.replace(weight_name, param_name), p, shard_id=shard_id
+                        )
+                        loaded = True
+                        break
+                if not loaded:
+                    _load(n, p)
+        return loaded_params
 
 
 class GraniteMoeForCausalLM(nn.Module, SupportsLoRA, SupportsPP):

--- a/vllm/model_executor/models/granitemoe.py
+++ b/vllm/model_executor/models/granitemoe.py
@@ -453,7 +453,7 @@ class GraniteMoeModel(nn.Module):
           - ``shard_id``     (``w1``/``w2``/``w3``) tells the FusedMoE weight
             loader which half of ``w13`` (gate vs up) or that it is ``w2``.
 
-        ``load_weights`` iterates this table in ``_load_quant_expert`` to route
+        ``load_weights`` iterates this table in ``_load_unfused_expert`` to route
         each split tensor (both ``weight`` and ``weight_scale``) to the right
         expert slot. The mapping is suffix-agnostic, so weight and scale share
         one path.
@@ -506,7 +506,7 @@ class GraniteMoeModel(nn.Module):
             weight_loader(param, p, name, shard_id=shard_id, expert_id=expert_id)
             loaded_params.add(n)
 
-        def _load_quant_expert(name, loaded_weight):
+        def _load_unfused_expert(name, loaded_weight):
             # Handles the split per-expert checkpoint layout
             # (``experts.{e}.{gate,up,down}_proj.{weight,weight_scale}``), e.g.
             # produced by llm-compressor FP8 quantization.
@@ -532,7 +532,7 @@ class GraniteMoeModel(nn.Module):
             return None
 
         for n, p in weights:
-            if _load_quant_expert(n, p):
+            if _load_unfused_expert(n, p):
                 continue
 
             # Map the fused expert layout of the unquantized base checkpoint


### PR DESCRIPTION
# [Bugfix] Load GraniteMoE FP8 checkpoints with split per-expert weights

Fixes #42463 (in combination with #44739 for the fused layout).

## Purpose

GraniteMoE FP8 checkpoints ship in two distinct on-disk expert layouts, and
`GraniteMoeModel.load_weights` handles only the fused one today:

1. **Fused layout** (`input_linear`/`output_linear`, as in the base BF16
   checkpoint). The existing loader chunks `input_linear` into gate/up and
   copies `output_linear` to `w2`, but only for `.weight` — it drops the
   `.weight_scale` tensors, triggering a `KeyError` on FP8 checkpoints. This
   is the bug reported in #42463 and fixed by #44739.

2. **Split per-expert layout** (produced by current `llm-compressor` FP8
   quantization): one tensor per expert per projection, named
   `...block_sparse_moe.experts.{e}.{gate,up,down}_proj.{weight,weight_scale}`.
   Neither the current loader nor #44739 understands these names, so loading
   raises `KeyError` on e.g. `...experts.0.down_proj.weight`.

This PR reworks `load_weights` to route **both** layouts through the
`FusedMoE` weight loader, carrying `weight_scale` alongside `weight` on every
path — with the split per-expert layout as the primary addition.

## Relationship to existing work / not a duplicate

Duplicate-work checks (AGENTS.md):

```bash
gh issue view 42463 --repo vllm-project/vllm --comments
gh pr list --repo vllm-project/vllm --state open --search "42463 in:body"
gh pr list --repo vllm-project/vllm --state open --search "granitemoe fp8"
```

- **Issue #42463** (filed by this submitter): GraniteMoE loader drops
  `.weight_scale` on the fused layout → `KeyError` for FP8_DYNAMIC.
- **PR #44739** (`@javierdejesusda`, open): fixes exactly the fused-layout
  scale case from #42463 by extending the load guards to match
  `.weight_scale`. It does **not** handle the split per-expert layout.

This PR is **not a duplicate of #44739**: its new, non-overlapping
contribution is the **split per-expert layout** path
(`experts.{e}.{gate,up,down}_proj.`), which #44739 does not cover. It also
reworks the fused path to go through the FusedMoE `weight_loader` (carrying
scales), so the two PRs overlap on the fused-layout scale fix.

Suggested resolution to avoid stepping on #44739: if #44739 merges first,
this PR can be rebased and narrowed to just the split per-expert path
(`get_expert_mapping` + `_load_quant_expert`) on top of it. If maintainers
prefer a single loader rewrite covering both layouts, this PR already does
that and #44739 can be closed in its favor. Deferring to maintainer
preference.