### PR TITLE
Add timeout enforcement to wait_for_engine_startup

### DIFF
--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -4,6 +4,7 @@
 import contextlib
 import os
 import threading
+import time
 import weakref
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
@@ -1239,6 +1240,7 @@ def wait_for_engine_startup(
     conn_pending, start_pending = [local_count, remote_count], [0, 0]
     poller = zmq.Poller()
     poller.register(handshake_socket, zmq.POLLIN)
+    deadline = time.monotonic() + envs.VLLM_ENGINE_READY_TIMEOUT_S
 
     remote_should_be_headless = (
         not parallel_config.data_parallel_hybrid_lb
@@ -1251,7 +1253,16 @@ def wait_for_engine_startup(
     if coord_process is not None:
         poller.register(coord_process.sentinel, zmq.POLLIN)
     while any(conn_pending) or any(start_pending):
-        events = poller.poll(STARTUP_POLL_PERIOD_MS)
+        remaining_s = deadline - time.monotonic()
+        if remaining_s <= 0:
+            raise TimeoutError(
+                f"Timed out after {envs.VLLM_ENGINE_READY_TIMEOUT_S}s waiting "
+                f"for engine core process(es) to start. This may be due "
+                f"to slow model loading or first-time kernel compilation "
+                f"on new hardware. To increase the timeout, set the "
+                f"environment variable: VLLM_ENGINE_READY_TIMEOUT_S=<seconds>"
+            )
+        events = poller.poll(min(STARTUP_POLL_PERIOD_MS, remaining_s * 1000))
         if not events:
             if any(conn_pending):
                 logger.debug(


### PR DESCRIPTION
## Purpose

`wait_for_engine_startup` in `vllm/v1/engine/utils.py` previously polled indefinitely with no deadline, relying on external mechanisms (e.g. container health checks) to kill hung engine core processes. This adds a `VLLM_ENGINE_READY_TIMEOUT_S`-based deadline with a clear error message, matching the pattern already used in `core_client.py` and `gather_actual_addresses`.

Related to #48031. That issue reports `wait_for_engine_startup` catching a process exit with no context on *why* the process died, producing an unhelpful `Failed core proc(s): {}` message. Tracing the code, this specific function had no internal timeout at all — so an external timeout (e.g. a Docker healthcheck) is likely what kills the process in that scenario, and this function just reported the aftermath without explanation. This change adds real timeout enforcement here, so vLLM itself can detect and explain a startup timeout rather than relying on an external killer.

I also checked both call sites of `launch_core_engines` (`core_client.py`, `entrypoints/cli/serve.py`) to confirm neither wraps this call in exception handling that assumes `RuntimeError` specifically — both let exceptions propagate naturally, so this change is safe.

I was not able to reproduce the original cold-start JIT compilation timeout described in #48031 in my environment. This PR addresses the underlying missing-timeout gap in this code path.

## Test Plan

Manually forced a short timeout to trigger the new code path:

​```
VLLM_ENGINE_READY_TIMEOUT_S=5 vllm serve facebook/opt-125m
​```

## Test Result

​```
(APIServer pid=2508909)   File ".../vllm/v1/engine/utils.py", line 1214, in launch_core_engines
(APIServer pid=2508909)     wait_for_engine_startup(
(APIServer pid=2508909)   File ".../vllm/v1/engine/utils.py", line 1258, in wait_for_engine_startup
(APIServer pid=2508909)     raise TimeoutError(
(APIServer pid=2508909) TimeoutError: Timed out after 5s waiting for engine core process(es) to start. This may be due to slow model loading or first-time kernel compilation on new hardware. To increase the timeout, set the environment variable: VLLM_ENGINE_READY_TIMEOUT_S=<seconds>
​```

Confirms the new error message fires correctly and replaces the previous 
unhelpful `Failed core proc(s): {}` output.

---
*Portions of this code, investigation, and PR description were assisted by Claude (Anthropic).*