### PR TITLE
[CI][ROCm] Soft-fail Python-only installation mirror

### DIFF
--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -295,6 +295,7 @@ steps:
     amd:
       device: mi250_1
       timeout_in_minutes: 55
+      soft_fail: true
       depends_on:
       - image-build-amd
       source_file_dependencies:


### PR DESCRIPTION
Soft failing the Python-only installation mirror to regate fast.