### PR TITLE
fix(entrypoints): reject stream=True and tools in BatchChatCompletionRequest

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -1114,6 +1114,16 @@ class BatchChatCompletionRequest(OpenAIBaseModel):
                 parameter="n",
                 value=n,
             )
+        if data.get("stream"):
+            raise VLLMValidationError(
+                "Batch chat completions do not support `stream=True`.",
+                parameter="stream",
+            )
+        if data.get("tools"):
+            raise VLLMValidationError(
+                "Batch chat completions do not support `tools`.",
+                parameter="tools",
+            )
         return data
 
     def to_chat_completion_request(


### PR DESCRIPTION
## Description
This PR resolves issue #50026 by adding validation checks for `stream` and `tools` in `BatchChatCompletionRequest.check_batch_mode()` in `vllm/entrypoints/openai/chat_completion/protocol.py`.

## Details
- Raises `VLLMValidationError` when `stream=True` or `tools` are passed to `/v1/chat/completions/batch` instead of returning empty outputs or silently dropping tools.