### PR TITLE
fix(metrics): add graceful fallback for MultiProcessCollector initialization failure

### DIFF
--- a/vllm/v1/metrics/prometheus.py
+++ b/vllm/v1/metrics/prometheus.py
@@ -46,7 +46,15 @@ def get_prometheus_registry() -> CollectorRegistry:
     if os.getenv("PROMETHEUS_MULTIPROC_DIR") is not None:
         logger.debug("Using multiprocess registry for prometheus metrics")
         registry = CollectorRegistry()
-        multiprocess.MultiProcessCollector(registry)
+        try:
+            multiprocess.MultiProcessCollector(registry)
+        except Exception as e:
+            logger.warning(
+                "Failed to initialize MultiProcessCollector for prometheus metrics (%s). "
+                "Falling back to global registry.",
+                e,
+            )
+            return REGISTRY
         return registry
 
     return REGISTRY


### PR DESCRIPTION
## Description
This PR resolves issue #49983 by adding a try-except fallback to `REGISTRY` if `multiprocess.MultiProcessCollector(registry)` fails in `vllm/v1/metrics/prometheus.py`.

## Details
- Prevents HTTP 500 crashes on `GET /metrics` when `PROMETHEUS_MULTIPROC_DIR` is backed by a non-local or network-mounted filesystem.