### PR TITLE
[Bugfix][NIXL] Release a dead peer's NIXL state without waiting for TTL

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -42,6 +42,8 @@ from vllm.distributed.kv_transfer.kv_connector.v1.nixl import (
     NixlKVConnectorStats,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+    RemoteMeta,
+    ReqMeta,
     compute_nixl_compatibility_hash,
 )
 from vllm.distributed.kv_transfer.kv_transfer_state import (
@@ -2109,7 +2111,8 @@ def test_shutdown_cleans_up_resources(default_vllm_config, dist_init):
         worker.shutdown()
         worker.shutdown()
 
-        mock_exec.shutdown.assert_called_with(wait=False)
+        # cancel_futures: a queued release must not run after teardown.
+        mock_exec.shutdown.assert_called_with(wait=False, cancel_futures=True)
 
         # Same sequence on scheduler.shutdown()
         scheduler.shutdown()
@@ -2175,6 +2178,7 @@ def test_engine_ttl_eviction(default_vllm_config, dist_init):
         worker._engine_last_active[engine_id] = time.perf_counter() - 20.0
 
         worker._evict_stale_engines()
+        _wait_for_released_engines(worker)
 
         assert engine_id not in worker._remote_agents
         assert engine_id not in worker.dst_xfer_side_handles
@@ -2209,6 +2213,220 @@ def test_engine_ttl_disabled(default_vllm_config, dist_init):
     # Nothing should be evicted.
     assert engine_id in worker._remote_agents
     assert engine_id in worker.dst_xfer_side_handles
+
+
+def _make_recv_meta(engine_id: str) -> ReqMeta:
+    return ReqMeta(
+        local_block_ids=[[1, 2]],
+        local_physical_block_ids=[[1, 2]],
+        tp_size=1,
+        remote=RemoteMeta(
+            block_ids=[[1, 2]],
+            host="localhost",
+            port=1234,
+            engine_id=engine_id,
+            request_id="remote-req",
+        ),
+    )
+
+
+def _fail_transfers(worker) -> None:
+    """Make every in-flight transfer report failure to get_finished()."""
+    worker.nixl_wrapper.check_xfer_state = lambda handle: "ERR"
+
+
+def _start_recv(worker, req_id: str, engine_id: str) -> None:
+    worker._recving_metadata[req_id] = _make_recv_meta(engine_id)
+    worker._recving_transfers[req_id] = [1234]
+
+
+def _wait_for_released_engines(worker) -> None:
+    """Block until releases queued on the handshake executor have run."""
+    worker._handshake_initiation_executor.submit(lambda: None).result(timeout=5)
+
+
+@patch(
+    "vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker.NixlWrapper",
+    FakeNixlWrapper,
+)
+def test_failed_transfer_releases_remote_engine(default_vllm_config, dist_init):
+    """A step whose transfer fails drops that peer's agents.
+
+    A crashed peer is only observable through failing transfers, so holding
+    its agents until the (1h default) TTL leaves dead endpoints registered
+    in NIXL.
+    """
+    worker, engine_id = _setup_worker_with_remote_engine(engine_ttl=3600.0)
+    _fail_transfers(worker)
+
+    with patch.object(worker.nixl_wrapper, "remove_remote_agent") as mock_rem:
+        _start_recv(worker, "req1", engine_id)
+
+        worker.get_finished()
+        _wait_for_released_engines(worker)
+
+        assert engine_id not in worker._remote_agents
+        assert engine_id not in worker.dst_xfer_side_handles
+        assert engine_id not in worker._engine_last_active
+        assert {call.args[0] for call in mock_rem.call_args_list} == {
+            "agent_0",
+            "agent_1",
+        }
+
+
+@patch(
+    "vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker.NixlWrapper",
+    FakeNixlWrapper,
+)
+def test_failed_transfer_keeps_healthy_engines(default_vllm_config, dist_init):
+    """Only the peer whose transfer failed is released.
+
+    A decode instance usually pulls from several prefill instances.
+    """
+    worker, failing_engine = _setup_worker_with_remote_engine(engine_ttl=3600.0)
+    healthy_engine = "remote-engine-2"
+    worker._remote_agents[healthy_engine] = {(0, 0): "healthy_agent"}
+    worker._engine_last_active[healthy_engine] = time.perf_counter()
+    _fail_transfers(worker)
+
+    _start_recv(worker, "req1", failing_engine)
+
+    worker.get_finished()
+    _wait_for_released_engines(worker)
+
+    assert failing_engine not in worker._remote_agents
+    assert worker._remote_agents[healthy_engine] == {(0, 0): "healthy_agent"}
+
+
+@patch(
+    "vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker.NixlWrapper",
+    FakeNixlWrapper,
+)
+def test_failed_transfer_keeps_engine_serving_other_requests(
+    default_vllm_config, dist_init
+):
+    """Releasing agents under a live transfer would break it, so it waits."""
+    worker, engine_id = _setup_worker_with_remote_engine(engine_ttl=3600.0)
+    _fail_transfers(worker)
+
+    _start_recv(worker, "req1", engine_id)
+    # req2 is still waiting for its KV; get_finished() leaves it untouched.
+    worker._recving_metadata["req2"] = _make_recv_meta(engine_id)
+
+    worker.get_finished()
+    _wait_for_released_engines(worker)
+
+    assert engine_id in worker._remote_agents
+
+    del worker._recving_metadata["req2"]
+    _start_recv(worker, "req3", engine_id)
+
+    worker.get_finished()
+    _wait_for_released_engines(worker)
+
+    assert engine_id not in worker._remote_agents
+
+
+@patch(
+    "vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker.NixlWrapper",
+    FakeNixlWrapper,
+)
+def test_peer_restart_releases_previous_engine_at_same_address(
+    default_vllm_config, dist_init
+):
+    """A peer that restarts comes back under a new engine id at its address.
+
+    Nothing fails a transfer in that sequence, so the dead engine's endpoints
+    would otherwise stay registered in NIXL until the TTL expires.
+    """
+    worker, restarted_engine = _setup_worker_with_remote_engine(engine_ttl=3600.0)
+    worker._engine_address[restarted_engine] = ("localhost", 1234)
+    agents_removed_before_handshake = []
+
+    def record_handshake(*args, **kwargs):
+        agents_removed_before_handshake.append(mock_rem.call_count)
+        return {}
+
+    with (
+        patch.object(worker.nixl_wrapper, "remove_remote_agent") as mock_rem,
+        patch.object(worker, "_nixl_handshake", side_effect=record_handshake),
+    ):
+        expected_agents = len(worker._remote_agents[restarted_engine])
+
+        worker._ensure_handshake("new-engine-after-restart", "localhost", 1234, 1)
+        _wait_for_released_engines(worker)
+
+        assert restarted_engine not in worker._remote_agents
+        assert restarted_engine not in worker._engine_address
+        # NIXL is not thread-safe: release must precede the replacement's load.
+        assert agents_removed_before_handshake == [expected_agents]
+
+
+@patch(
+    "vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker.NixlWrapper",
+    FakeNixlWrapper,
+)
+def test_engine_being_handshaked_is_not_released(default_vllm_config, dist_init):
+    """A pending handshake is about to repopulate the state a release drops."""
+    worker, engine_id = _setup_worker_with_remote_engine(engine_ttl=3600.0)
+    worker._handshake_futures[engine_id] = MagicMock()
+    _fail_transfers(worker)
+
+    _start_recv(worker, "req1", engine_id)
+
+    worker.get_finished()
+    _wait_for_released_engines(worker)
+
+    assert engine_id in worker._remote_agents
+
+
+@patch(
+    "vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker.NixlWrapper",
+    FakeNixlWrapper,
+)
+def test_push_target_engine_is_not_released(default_vllm_config, dist_init):
+    """Pushes are tracked per request, so nothing here sees one in flight.
+
+    Releasing a push target's handles could pull them out from under the
+    writer thread mid-send.
+    """
+    worker, engine_id = _setup_worker_with_remote_engine(engine_ttl=3600.0)
+    worker._push_target_engines.add(engine_id)
+    _fail_transfers(worker)
+
+    _start_recv(worker, "req1", engine_id)
+
+    worker.get_finished()
+    _wait_for_released_engines(worker)
+
+    assert engine_id in worker._remote_agents
+
+
+@patch(
+    "vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker.NixlWrapper",
+    FakeNixlWrapper,
+)
+def test_shutdown_releases_engines_dropped_before_teardown(
+    default_vllm_config, dist_init
+):
+    """Shutdown cancels queued releases, so it must free them itself.
+
+    The engine is already out of _remote_agents by then, so shutdown's own
+    sweep would not otherwise see its agents.
+    """
+    worker, engine_id = _setup_worker_with_remote_engine(engine_ttl=3600.0)
+
+    with patch.object(worker.nixl_wrapper, "remove_remote_agent") as mock_rem:
+        # Drop the engine without letting the executor drain the release.
+        worker._pop_remote_engine_state(engine_id)
+        assert mock_rem.call_count == 0
+
+        worker.shutdown()
+
+        assert {call.args[0] for call in mock_rem.call_args_list} == {
+            "agent_0",
+            "agent_1",
+        }
 
 
 def test_transfer_topology_unregister():

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -9,7 +9,7 @@ import queue
 import threading
 import time
 import uuid
-from collections import defaultdict
+from collections import defaultdict, deque
 from collections.abc import Iterator
 from concurrent.futures import Future, ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, cast
@@ -489,6 +489,14 @@ class NixlBaseConnectorWorker:
         self._engine_ttl: float = vllm_config.kv_transfer_config.get_from_extra_config(
             "engine_ttl", 3600.0
         )
+        # Detects a restarted peer coming back under a new engine id.
+        self._engine_address: dict[EngineId, tuple[str, int]] = {}
+        # Queue: failures are also reported from background threads.
+        self._failed_engines: queue.Queue[EngineId] = queue.Queue()
+        # Never released: their sends are tracked per request, not per engine.
+        self._push_target_engines: set[EngineId] = set()
+        # Outlives a drain cancelled at shutdown. deque ops are atomic, no lock.
+        self._pending_releases: deque[tuple[list[int], list[str]]] = deque()
 
         self.block_size = vllm_config.cache_config.block_size
         self.model_config = vllm_config.model_config
@@ -844,6 +852,7 @@ class NixlBaseConnectorWorker:
         tp_size: int,
         pp_size: int = 1,
         notif_agents_only: bool = False,
+        push_target: bool = False,
     ) -> Future[tuple[dict[tuple[int, int], str], float]] | None:
         """
         Ensure a handshake is in-flight (or already done) for *engine_id*.
@@ -861,6 +870,10 @@ class NixlBaseConnectorWorker:
             fut = self._handshake_futures.get(engine_id)
             if fut is not None:
                 return fut
+            # Single-worker executor: the dead peer is removed before this load.
+            readdressed = self._engines_at_address(host, port, exclude=engine_id)
+            if readdressed:
+                self._release_remote_engines(readdressed, "it was replaced")
             fut = self._handshake_initiation_executor.submit(
                 self._nixl_handshake,
                 host,
@@ -883,6 +896,9 @@ class NixlBaseConnectorWorker:
                         self._remote_agents[eid] = remote_agents
                         self._engine_clock_offset[eid] = clock_offset
                         self._engine_last_active[eid] = time.perf_counter()
+                        self._engine_address[eid] = (host, port)
+                        if push_target:
+                            self._push_target_engines.add(eid)
                     except Exception as e:
                         self._log_failure(
                             failure_type="handshake_setup_failed",
@@ -2022,6 +2038,8 @@ class NixlBaseConnectorWorker:
 
         self._sync_device_after_mamba_recv(done_recving, failed_recv_reqs)
 
+        self._release_failed_engines()
+
         # Handle timeout to avoid stranding blocks on remote.
         now = time.perf_counter()
         while self._reqs_to_send:
@@ -2144,9 +2162,12 @@ class NixlBaseConnectorWorker:
             handle: The transfer handle.
         """
         # Use .get() here as the metadata cleanup is handled by get_finished()
-        # TODO (NickLucche) handle failed transfer for HMA.
-        if (meta := self._recving_metadata.get(req_id)) and not self._is_hma_required:
-            self._invalid_block_ids.put(set(meta.local_block_ids[0]))
+        if (meta := self._recving_metadata.get(req_id)) is not None:
+            # TODO (NickLucche) handle failed transfer for HMA.
+            if not self._is_hma_required:
+                self._invalid_block_ids.put(set(meta.local_block_ids[0]))
+            if meta.remote is not None:
+                self._failed_engines.put(meta.remote.engine_id)
         self._failed_recv_reqs.put(req_id)
         if handle is not None:
             self.nixl_wrapper.release_xfer_handle(handle)
@@ -2174,7 +2195,7 @@ class NixlBaseConnectorWorker:
 
             # Build the heartbeat message: "HB:req1,req2,..."
             hb_msg = ("HB:" + ",".join(hb_info.req_ids)).encode()
-            for agent_name in self._remote_agents[engine_id].values():
+            for agent_name in self._remote_agents.get(engine_id, {}).values():
                 try:
                     self.nixl_wrapper.send_notif(agent_name, notif_msg=hb_msg)
                 except Exception:
@@ -2362,28 +2383,96 @@ class NixlBaseConnectorWorker:
             if now - last_active > self._engine_ttl:
                 self._cleanup_remote_engine(eid)
 
+    def _engines_at_address(
+        self, host: str, port: int, exclude: EngineId
+    ) -> list[EngineId]:
+        """Registered engines previously reached at ``host``:``port``.
+
+        A side-channel address belongs to one engine (the port is derived per
+        DP rank and the handshake rejects a mismatched engine id), so another
+        engine answering there means the first one is gone. Engines still in
+        use are left alone; they fall back to the TTL.
+
+        Called with ``_handshake_lock`` held.
+        """
+        in_use = self._engines_in_use()
+        return [
+            eid
+            for eid, address in self._engine_address.items()
+            if address == (host, port) and eid != exclude and eid not in in_use
+        ]
+
+    def _engines_in_use(self) -> set[EngineId]:
+        """Engines that must not be released yet.
+
+        Engines this worker pushes to are excluded wholesale: those sends are
+        tracked per request rather than per engine, so the writer thread may
+        be using their handles with nothing here to see it.
+        """
+        # Snapshot: the main thread mutates _recving_metadata concurrently.
+        recving = {
+            meta.remote.engine_id
+            for meta in list(self._recving_metadata.values())
+            if meta.remote is not None
+        }
+        return recving | self._push_target_engines
+
+    def _release_failed_engines(self) -> None:
+        """Release NIXL state for remote engines whose transfers failed.
+
+        A crashed peer is only observable through failing transfers, so
+        waiting for the TTL keeps its endpoints registered for up to an hour.
+        An engine still serving requests is skipped; a failure that persists
+        re-reports it on a later step.
+        """
+        failed: set[EngineId] = set()
+        while not self._failed_engines.empty():
+            try:
+                failed.add(self._failed_engines.get_nowait())
+            except queue.Empty:
+                break
+        if not failed:
+            return
+
+        releasable = [
+            eid for eid in failed - self._engines_in_use() if eid in self._remote_agents
+        ]
+        if releasable:
+            self._release_remote_engines(releasable, "its transfers failed")
+
+    def _release_remote_engines(self, engine_ids: list[EngineId], reason: str) -> None:
+        """Drop cached NIXL state so the next request re-handshakes."""
+        for engine_id in engine_ids:
+            with self._handshake_lock:
+                if (
+                    engine_id in self._handshake_futures
+                    or engine_id not in self._remote_agents
+                ):
+                    continue
+                self._cleanup_remote_engine(engine_id, log_eviction=False)
+            logger.info(
+                "Released NIXL state for remote engine %s because %s; "
+                "the next request to it will re-handshake.",
+                engine_id,
+                reason,
+            )
+
     def _cleanup_remote_engine(
         self, engine_id: EngineId, *, log_eviction: bool = True
     ) -> None:
         """Remove all state for a single remote engine.
 
-        Releases NIXL resources (dlist handles, remote agents) and clears
-        all per-engine data structures. Used by both TTL eviction and
-        shutdown.
+        The NIXL resources are released on the handshake executor: NIXL is not
+        thread-safe, so an agent must not be removed while another one is being
+        loaded.
+
+        The bookkeeping is dropped on the calling thread and is not atomic, so
+        callers must already have established that nothing is using the engine
+        -- see ``_engines_in_use`` for the failure and restart paths, and
+        ``_engine_last_active`` for TTL eviction.
         """
-        assert engine_id in self._remote_agents
-
-        # Notif-only engines (push-mode D side) have no descriptor state.
-        for handle in self.dst_xfer_side_handles.pop(engine_id, {}).values():
-            self.nixl_wrapper.release_dlist_handle(handle)
-        for agent_name in self._remote_agents.pop(engine_id).values():
-            self.nixl_wrapper.remove_remote_agent(agent_name)
-
-        self.kv_caches_base_addr.pop(engine_id, None)
-        self.dst_num_blocks.pop(engine_id, None)
-        self.tp_mappings.pop(engine_id, None)
-        if self.transfer_topo is not None:
-            self.transfer_topo.unregister_remote_engine(engine_id)
+        self._pop_remote_engine_state(engine_id)
+        self._handshake_initiation_executor.submit(self._drain_pending_releases)
 
         # Drop the cached clock offset; it is re-measured on the next handshake.
         self._engine_clock_offset.pop(engine_id, None)
@@ -2398,6 +2487,40 @@ class NixlBaseConnectorWorker:
                 time.perf_counter() - last_active,
             )
 
+    def _pop_remote_engine_state(self, engine_id: EngineId) -> None:
+        """Drop cached state for a remote engine.
+
+        What NIXL still holds is queued onto ``_pending_releases`` rather than
+        freed here, so the caller chooses which thread frees it.
+        """
+        # Notif-only engines (push-mode D side) have no descriptor state.
+        handles = list(self.dst_xfer_side_handles.pop(engine_id, {}).values())
+        agent_names = list(self._remote_agents.pop(engine_id, {}).values())
+
+        self.kv_caches_base_addr.pop(engine_id, None)
+        self.dst_num_blocks.pop(engine_id, None)
+        self.tp_mappings.pop(engine_id, None)
+        if self.transfer_topo is not None:
+            self.transfer_topo.unregister_remote_engine(engine_id)
+        # Re-measured on the next handshake.
+        self._engine_clock_offset.pop(engine_id, None)
+        self._engine_address.pop(engine_id, None)
+        self._push_target_engines.discard(engine_id)
+        if handles or agent_names:
+            self._pending_releases.append((handles, agent_names))
+
+    def _drain_pending_releases(self) -> None:
+        """Hand removed engines' resources back to NIXL."""
+        while True:
+            try:
+                handles, agent_names = self._pending_releases.popleft()
+            except IndexError:
+                return
+            for handle in handles:
+                self.nixl_wrapper.release_dlist_handle(handle)
+            for agent_name in agent_names:
+                self.nixl_wrapper.remove_remote_agent(agent_name)
+
     def __del__(self):
         self.shutdown()
 
@@ -2406,7 +2529,7 @@ class NixlBaseConnectorWorker:
         if not hasattr(self, "_handshake_initiation_executor"):
             # error happens during init, no need to shutdown
             return
-        self._handshake_initiation_executor.shutdown(wait=False)
+        self._handshake_initiation_executor.shutdown(wait=False, cancel_futures=True)
         for handles in self._recving_transfers.values():
             for handle in handles:
                 self.nixl_wrapper.release_xfer_handle(handle)
@@ -2419,7 +2542,9 @@ class NixlBaseConnectorWorker:
                 self.nixl_wrapper.release_dlist_handle(handle)
         self.src_xfer_handles_by_tp_ratio.clear()
         for engine_id in list(self._remote_agents):
-            self._cleanup_remote_engine(engine_id, log_eviction=False)
+            self._pop_remote_engine_state(engine_id)
+        # Also frees anything a release cancelled above never got to.
+        self._drain_pending_releases()
         for desc in self._registered_descs:
             self.nixl_wrapper.deregister_memory(desc)
         self._registered_descs.clear()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
@@ -207,7 +207,7 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
             # ..but we still need to notify the other remote ranks that we
             # have the blocks we need so they can update the request state.
             notif_id = f"{meta.remote.request_id}:{self.world_size}".encode()
-            remote_agents = self._remote_agents[meta.remote.engine_id]
+            remote_agents = self._remote_agents.get(meta.remote.engine_id, {})
             for rank_to_notify, agent in remote_agents.items():
                 if rank_to_notify != (0, read_specs[0].remote_rank):
                     self.nixl_wrapper.send_notif(agent, notif_msg=notif_id)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -419,6 +419,7 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
             registration_data["decode_host"],
             registration_data["decode_port"],
             registration_data["decode_tp_size"],
+            push_target=True,
         )
         if fut is not None:
 


### PR DESCRIPTION
## Purpose

When a pull-mode prefiller restarts with a new engine ID at the same host and port, the decoder can keep the previous peer's NIXL resources and cached metadata until TTL cleanup.

This PR detects the replacement after a successful handshake and marks the old peer for cleanup. It waits for requests using the old peer and pending handshakes to finish before releasing the old state. This avoids removing resources that are still in use and allows cleanup without restarting the decoder or waiting for TTL eviction.

## Test Plan

```bash
.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_nixl_connector.py 
143 passed
```

Also ran a GPU test on two RTX PRO 4500 GPUs using Qwen3-0.6B, with one GPU for P and one for D. P was restarted twice normally and once after a forced shutdown while D stayed running. Each time, P returned with a new engine ID at the same address and D cleared the old peer state.

All new requests after the restarts succeeded and matched the outputs from the original P/D setup. Requests interrupted by the forced shutdown failed and were not resumed.