### PR TITLE
[XPU][INC] Add configurable backend selection for W4A16 on XPU

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -292,6 +292,7 @@ if TYPE_CHECKING:
     VLLM_NIXL_EP_MAX_NUM_RANKS: int = 32
     VLLM_XPU_ENABLE_XPU_GRAPH: bool = False
     VLLM_XPU_USE_SAMPLER_KERNEL: bool = True
+    VLLM_XPU_INC_W4A16_BACKEND: str = "auto"
     VLLM_LORA_ENABLE_DUAL_STREAM: bool = False
     VLLM_GPU_NIC_PCIE_MAPPING: str = ""
     VLLM_NIC_SELECTION_VARS: str = ""
@@ -2000,6 +2001,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_XPU_USE_SAMPLER_KERNEL": lambda: bool(
         int(os.getenv("VLLM_XPU_USE_SAMPLER_KERNEL", "1"))
     ),
+    # Backend selector for INC W4A16 on XPU: auto, ark, or xpu.
+    # auto: prefer ARK when available; otherwise fallback to XPU (except int2).
+    # ark: require ARK availability.
+    # xpu: force the default XPU path (int2 is unsupported and will raise).
+    "VLLM_XPU_INC_W4A16_BACKEND": lambda: os.getenv(
+        "VLLM_XPU_INC_W4A16_BACKEND", "auto"
+    ).strip().lower(),
     # Enable simple KV offload.
     "VLLM_USE_SIMPLE_KV_OFFLOAD": lambda: bool(
         int(os.getenv("VLLM_USE_SIMPLE_KV_OFFLOAD", "0"))

--- a/vllm/model_executor/layers/quantization/inc/schemes/inc_wna16_scheme.py
+++ b/vllm/model_executor/layers/quantization/inc/schemes/inc_wna16_scheme.py
@@ -3,6 +3,7 @@
 
 from typing import TYPE_CHECKING
 
+from vllm import envs
 from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.auto_awq import AutoAWQConfig
 from vllm.model_executor.layers.quantization.auto_gptq import AutoGPTQConfig
@@ -43,6 +44,11 @@ class INCWna16Scheme(INCScheme):
                     INCARKLinearMethod,
                     INCXPULinearMethod,
                 )
+
+                backend = envs.VLLM_XPU_INC_W4A16_BACKEND
+                if backend == "xpu":
+                    logger.debug("Using XPU INC backend for layer %s", prefix)
+                    return INCLinearMethod(INCXPULinearMethod(layer_config))
 
                 is_ark_available, ark_error, _, _ = get_ark_state()
                 if is_ark_available:


### PR DESCRIPTION

Add configurable backend selection for INC W4A16 on XPU.

## Purpose
This PR introduces the VLLM_XPU_INC_W4A16_BACKEND environment variable so XPU W4A16 execution can explicitly select the native XPU INC backend instead of relying only on the existing auto-selection path. This makes backend behavior easier to control for W4A16 deployments and keeps the current fallback behavior intact when ARK is unavailable.

## Test Plan

Before PR command:
```bash
python text_to_image.py \
    --model vllm-project-org/FLUX.1-dev-AutoRound-w4a16 \
    --prompt "A cinematic photo of a lighthouse in a storm" \
    --tensor-parallel-size 2 \
    --num-inference-steps 28 \
    --height 1024 \
    --width 1024 \
    --output outputs/w4a16_ark_backend.png
```

After PR: 
```bash
VLLM_XPU_INC_W4A16_BACKEND=xpu \
python text_to_image.py \
    --model vllm-project-org/FLUX.1-dev-AutoRound-w4a16 \
    --prompt "A cinematic photo of a lighthouse in a storm" \
    --tensor-parallel-size 2 \
    --num-inference-steps 28 \
    --height 1024 \
    --width 1024 \
    --output outputs/w4a16_xpu_backedn.png
```

## Test Result
Generation completed successfully in both cases.

Before PR: Total generation time: 23.6189 seconds (23618.86 ms)

After PR with VLLM_XPU_INC_W4A16_BACKEND=xpu: Total generation time: 21.8331 seconds (21833.11 ms)

This is an improvement of 1.7858 seconds, or about 7.6% faster with XPU backend

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

