### PR TITLE
fix(dp): avoid get_open_port() infinite loop when VLLM_PORT is DP-reserved

### DIFF
--- a/tests/utils_/test_network_utils.py
+++ b/tests/utils_/test_network_utils.py
@@ -29,6 +29,20 @@ def test_get_open_port(monkeypatch: pytest.MonkeyPatch):
                     s3.bind(("localhost", get_open_port()))
 
 
+def test_get_open_port_vllm_port_in_dp_reserved_range(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # VLLM_PORT falling inside the data-parallel reserved window used to make
+    # get_open_port() loop forever (issue #50024). It must instead return a
+    # port outside the reserved range.
+    with monkeypatch.context() as m:
+        m.setenv("VLLM_DP_MASTER_PORT", "5680")
+        # 5682 is inside [5680, 5690).
+        m.setenv("VLLM_PORT", "5682")
+        port = get_open_port()
+        assert port not in range(5680, 5690)
+
+
 def test_get_open_ports_list_with_vllm_port(monkeypatch: pytest.MonkeyPatch):
     with monkeypatch.context() as m:
         m.setenv("VLLM_PORT", "5678")

--- a/vllm/utils/network_utils.py
+++ b/vllm/utils/network_utils.py
@@ -159,10 +159,17 @@ def get_open_port() -> int:
     if "VLLM_DP_MASTER_PORT" in os.environ:
         dp_master_port = envs.VLLM_DP_MASTER_PORT
         reserved_port_range = range(dp_master_port, dp_master_port + 10)
+        # Start scanning from VLLM_PORT when set (via _get_open_port's default).
+        start_port = envs.VLLM_PORT
         while True:
-            candidate_port = _get_open_port()
+            candidate_port = _get_open_port(start_port=start_port)
             if candidate_port not in reserved_port_range:
                 return candidate_port
+            # The candidate fell inside the DP-reserved range. Resume the
+            # search just past the range instead of retrying the same port
+            # forever (which happens when VLLM_PORT itself is reserved, since
+            # _get_open_port would keep returning it).
+            start_port = reserved_port_range.stop
     return _get_open_port()
 
 


### PR DESCRIPTION
Fixes #50024.

With `--data-parallel-size N`, `get_open_port()` avoids the reserved `[VLLM_DP_MASTER_PORT, +10)` window. It called `_get_open_port()` with no `start_port`, so when `VLLM_PORT` was set to a value inside that window, `_get_open_port()` kept returning that same reserved port and the `while True` loop spun forever — DP startup hung with no log output or error.

Fix: when a candidate lands in the reserved range, advance the scan start just past the range so the search makes progress instead of retrying the same port.

## Test
Added `tests/utils_/test_network_utils.py::test_get_open_port_vllm_port_in_dp_reserved_range` — sets `VLLM_DP_MASTER_PORT`/`VLLM_PORT` so `VLLM_PORT` is inside the reserved window and asserts `get_open_port()` returns a port outside it (previously hung).

```
$ pytest tests/utils_/test_network_utils.py -q
16 passed
```