### PR TITLE
[Frontend][Rust] Support truncate_prompt_tokens

### DIFF
--- a/rust/src/chat/src/lib.rs
+++ b/rust/src/chat/src/lib.rs
@@ -166,6 +166,8 @@ impl ChatRequestProcessor {
             priority: request.priority,
             cache_salt: request.cache_salt,
             add_special_tokens: request.add_special_tokens,
+            truncate_prompt_tokens: request.truncate_prompt_tokens,
+            truncation_side: request.truncation_side,
             data_parallel_rank: request.data_parallel_rank,
             reasoning_parser_kwargs,
             lora_request: request.lora_request,

--- a/rust/src/chat/src/request.rs
+++ b/rust/src/chat/src/request.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 use vllm_engine_core_client::protocol::lora::LoraRequest;
 pub use vllm_parser::tool::Tool as ChatTool;
 pub use vllm_text::SamplingParams;
-use vllm_text::TextDecodeOptions;
+use vllm_text::{TextDecodeOptions, TruncationSide};
 
 use crate::AssistantMessageExt;
 use crate::error::{Error, Result};
@@ -483,6 +483,14 @@ pub struct ChatRequest {
     pub cache_salt: Option<String>,
     /// Whether to add special tokens (e.g. BOS) during prompt tokenization.
     pub add_special_tokens: bool,
+    /// Number of prompt tokens to keep after rendering:
+    /// - `None` means no truncation.
+    /// - `-1` maps to the model context length.
+    #[serde(default)]
+    pub truncate_prompt_tokens: Option<i64>,
+    /// Which side to truncate from when `truncate_prompt_tokens` is active.
+    #[serde(default)]
+    pub truncation_side: Option<TruncationSide>,
     /// Override data parallel rank.
     #[serde(default)]
     pub data_parallel_rank: Option<u32>,
@@ -508,6 +516,8 @@ impl ChatRequest {
             documents: None,
             cache_salt: None,
             add_special_tokens: false,
+            truncate_prompt_tokens: None,
+            truncation_side: None,
             data_parallel_rank: None,
             lora_request: None,
         }

--- a/rust/src/server/src/error.rs
+++ b/rust/src/server/src/error.rs
@@ -126,6 +126,21 @@ mod tests {
     }
 
     #[test]
+    fn truncate_prompt_tokens_too_large_maps_to_invalid_request() {
+        let api_error = text_submit_error(
+            "failed to submit completion request",
+            vllm_text::Error::TruncatePromptTokensTooLarge {
+                max_model_len: 8,
+                truncate_prompt_tokens: 9,
+            },
+        );
+        assert_eq!(api_error.status_code(), StatusCode::BAD_REQUEST);
+        let response = api_error.to_error_response();
+        assert_eq!(response.error.error_type, "invalid_request_error");
+        assert!(response.error.message.contains("truncate_prompt_tokens"));
+    }
+
+    #[test]
     fn min_tokens_above_max_tokens_maps_to_invalid_request() {
         let api_error = text_submit_error(
             "failed to submit completion request",

--- a/rust/src/server/src/grpc/convert.rs
+++ b/rust/src/server/src/grpc/convert.rs
@@ -36,12 +36,6 @@ pub fn to_text_request(
         )));
     }
 
-    if req.truncate_prompt_tokens != 0 {
-        return Err(Status::invalid_argument(
-            "truncate_prompt_tokens is not supported",
-        ));
-    }
-
     let prompt = match req.prompt {
         Some(pb::generate_request::Prompt::Text(text)) => Prompt::Text(text),
         Some(pb::generate_request::Prompt::TokenIds(ids)) => Prompt::TokenIds(ids.ids),
@@ -99,6 +93,12 @@ pub fn to_text_request(
         priority: req.priority,
         cache_salt: kv.map(|k| &k.cache_salt).filter(|s| !s.is_empty()).cloned(),
         add_special_tokens: true,
+        // The proto uses 0 as "unset", so it cannot express Python's -1
+        // (truncate to the model context length).
+        truncate_prompt_tokens: (req.truncate_prompt_tokens != 0)
+            .then_some(req.truncate_prompt_tokens.into()),
+        // TODO: expose `truncation_side` in the proto once a caller needs it.
+        truncation_side: None,
         data_parallel_rank: None,
         reasoning_parser_kwargs: None,
         lora_request: None,

--- a/rust/src/server/src/routes/inference/generate/convert.rs
+++ b/rust/src/server/src/routes/inference/generate/convert.rs
@@ -74,6 +74,10 @@ pub(super) fn prepare_generate_request(
         priority: request.priority,
         cache_salt: request.cache_salt,
         add_special_tokens: false,
+        // TODO: accept `truncate_prompt_tokens` on the internal generate route
+        // once a caller needs it; the prompt arrives pre-tokenized here.
+        truncate_prompt_tokens: None,
+        truncation_side: None,
         data_parallel_rank: ctx.data_parallel_rank,
         reasoning_parser_kwargs: None,
         lora_request: lora_resolution.lora_request.clone(),

--- a/rust/src/server/src/routes/openai/chat_completions/convert.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/convert.rs
@@ -163,6 +163,8 @@ pub(super) fn prepare_chat_request(
         documents: request.documents,
         cache_salt: request.cache_salt,
         add_special_tokens: request.add_special_tokens,
+        truncate_prompt_tokens: request.truncate_prompt_tokens,
+        truncation_side: request.truncation_side,
         data_parallel_rank: ctx.data_parallel_rank,
         lora_request: lora_resolution.lora_request.clone(),
     };
@@ -406,6 +408,7 @@ mod tests {
         ChatTool as VllmChatTool, ChatToolChoice, GenerationPromptMode,
         SamplingParams as VllmSamplingParams,
     };
+    use vllm_text::TruncationSide;
     use vllm_text::output::TextDecodeOptions;
 
     use super::prepare_chat_request;
@@ -640,6 +643,25 @@ mod tests {
             ..VllmSamplingParams::default()
         };
         assert_eq!(prepared.chat_request.sampling_params, expected);
+    }
+
+    #[test]
+    fn prepare_chat_request_forwards_prompt_truncation() {
+        let prepared = prepare_chat_request(
+            ChatCompletionRequest {
+                truncate_prompt_tokens: Some(8),
+                truncation_side: Some(TruncationSide::Left),
+                ..base_request()
+            },
+            &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
+            ResolvedRequestContext::default(),
+        )
+        .expect("request is valid")
+        .chat_request;
+
+        // Truncation itself runs after chat rendering, in `vllm_text`.
+        assert_eq!(prepared.truncate_prompt_tokens, Some(8));
+        assert_eq!(prepared.truncation_side, Some(TruncationSide::Left));
     }
 
     #[test]

--- a/rust/src/server/src/routes/openai/chat_completions/types.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/types.rs
@@ -10,6 +10,7 @@ use serde_with::SerializeDisplay;
 use validator::Validate;
 use vllm_chat::ReasoningEffort;
 use vllm_engine_core_client::protocol::sampling::RepetitionDetectionParams;
+use vllm_text::TruncationSide;
 
 use crate::routes::openai::utils::structured_outputs::ResponseFormat;
 use crate::routes::openai::utils::types::{
@@ -158,6 +159,9 @@ pub struct ChatCompletionRequest {
 
     /// Truncate prompt tokens to this length
     pub truncate_prompt_tokens: Option<i64>,
+    /// Which side to truncate from when `truncate_prompt_tokens` is active.
+    /// `"right"` keeps the first N tokens, `"left"` keeps the last N.
+    pub truncation_side: Option<TruncationSide>,
 
     /// Number of prompt logprobs to return
     pub prompt_logprobs: Option<i32>,
@@ -286,6 +290,7 @@ impl Default for ChatCompletionRequest {
             skip_special_tokens: true,
             spaces_between_special_tokens: true,
             truncate_prompt_tokens: None,
+            truncation_side: None,
             prompt_logprobs: None,
             allowed_token_ids: None,
             bad_words: None,

--- a/rust/src/server/src/routes/openai/chat_completions/validate.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/validate.rs
@@ -83,11 +83,6 @@ pub(super) fn validate_request_compat(
         );
     }
     reject_non_default(
-        request.truncate_prompt_tokens.as_ref(),
-        "truncate_prompt_tokens",
-        "truncate_prompt_tokens is not supported.",
-    )?;
-    reject_non_default(
         request.media_io_kwargs.as_ref(),
         "media_io_kwargs",
         "media_io_kwargs is not supported.",

--- a/rust/src/server/src/routes/openai/completions/convert.rs
+++ b/rust/src/server/src/routes/openai/completions/convert.rs
@@ -146,6 +146,8 @@ pub(super) fn prepare_completion_request(
         priority: request.priority.unwrap_or(0),
         cache_salt: request.cache_salt,
         add_special_tokens: request.add_special_tokens,
+        truncate_prompt_tokens: request.truncate_prompt_tokens,
+        truncation_side: request.truncation_side,
         data_parallel_rank: ctx.data_parallel_rank,
         reasoning_parser_kwargs: None,
         lora_request: lora_resolution.lora_request.clone(),
@@ -200,7 +202,7 @@ fn completion_echo_text(
 mod tests {
     use axum::http::HeaderMap;
     use serde_json::json;
-    use vllm_text::Prompt;
+    use vllm_text::{Prompt, TruncationSide};
     use vllm_tokenizer::test_utils::TestTokenizer;
 
     use super::prepare_completion_request;
@@ -331,6 +333,28 @@ mod tests {
         );
         assert!(prepared.text_request.sampling_params.ignore_eos);
         assert!(!prepared.text_request.decode_options.skip_special_tokens);
+    }
+
+    #[test]
+    fn prepare_completion_request_forwards_prompt_truncation() {
+        let request: CompletionRequest = serde_json::from_value(json!({
+            "model": "Qwen/Qwen1.5-0.5B-Chat",
+            "prompt": "hello",
+            "truncate_prompt_tokens": 8,
+            "truncation_side": "left",
+        }))
+        .expect("parse request");
+        let prepared = prepare_completion_request(
+            request,
+            &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
+            ResolvedRequestContext::default(),
+            &test_tokenizer(),
+        )
+        .expect("prepare")
+        .text_request;
+
+        assert_eq!(prepared.truncate_prompt_tokens, Some(8));
+        assert_eq!(prepared.truncation_side, Some(TruncationSide::Left));
     }
 
     #[test]

--- a/rust/src/server/src/routes/openai/completions/types.rs
+++ b/rust/src/server/src/routes/openai/completions/types.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use validator::Validate;
 use vllm_engine_core_client::protocol::sampling::RepetitionDetectionParams;
-use vllm_text::Prompt;
+use vllm_text::{Prompt, TruncationSide};
 
 use crate::routes::openai::utils::types::{
     LogProbs, Normalizable, StreamOptions, StringOrArray, Usage, default_true, validate_stop,
@@ -134,6 +134,9 @@ pub struct CompletionRequest {
 
     /// Truncate prompt tokens to this length
     pub truncate_prompt_tokens: Option<i64>,
+    /// Which side to truncate from when `truncate_prompt_tokens` is active.
+    /// `"right"` keeps the first N tokens, `"left"` keeps the last N.
+    pub truncation_side: Option<TruncationSide>,
 
     /// Restrict output to these token IDs only
     pub allowed_token_ids: Option<Vec<u32>>,

--- a/rust/src/server/src/routes/openai/completions/validate.rs
+++ b/rust/src/server/src/routes/openai/completions/validate.rs
@@ -82,13 +82,6 @@ pub(super) fn validate_request_compat(
             "spaces_between_special_tokens is not supported."
         );
     }
-    if request.truncate_prompt_tokens.is_some() {
-        bail_invalid_request!(
-            param = "truncate_prompt_tokens",
-            "truncate_prompt_tokens is not supported."
-        );
-    }
-
     Ok(())
 }
 

--- a/rust/src/server/src/routes/tokenize/types.rs
+++ b/rust/src/server/src/routes/tokenize/types.rs
@@ -93,6 +93,10 @@ impl TokenizeChatRequest {
             documents: None,
             cache_salt: None,
             add_special_tokens: self.add_special_tokens,
+            // /tokenize reports what the prompt tokenizes to, so it must not
+            // silently drop tokens.
+            truncate_prompt_tokens: None,
+            truncation_side: None,
             data_parallel_rank: None,
             lora_request: None,
         })

--- a/rust/src/text/src/error.rs
+++ b/rust/src/text/src/error.rs
@@ -30,6 +30,15 @@ pub enum Error {
     MinTokensExceedsMaxTokens { min_tokens: u32, max_tokens: u32 },
     #[error("`thinking_token_budget` must be a non-negative integer or -1 for unlimited.")]
     InvalidThinkingTokenBudget,
+    #[error(
+        "`truncate_prompt_tokens`={truncate_prompt_tokens} cannot be greater than \
+         this model's maximum context length {max_model_len}. \
+         Please request a smaller truncation size."
+    )]
+    TruncatePromptTokensTooLarge {
+        max_model_len: u32,
+        truncate_prompt_tokens: i64,
+    },
     #[error("invalid repetition detection params: {message}")]
     InvalidRepetitionDetection { message: String },
     #[error("text request stream `{request_id}` closed before terminal output")]
@@ -52,6 +61,7 @@ impl Error {
             | Self::TokenIds(_)
             | Self::MinTokensExceedsMaxTokens { .. }
             | Self::InvalidThinkingTokenBudget
+            | Self::TruncatePromptTokensTooLarge { .. }
             | Self::InvalidRepetitionDetection { .. }
             // An empty tokenized prompt detected later, at request prepare
             // time, surfaces through the transparent Llm wrapper.

--- a/rust/src/text/src/lib.rs
+++ b/rust/src/text/src/lib.rs
@@ -19,7 +19,7 @@ pub use output::{
     CollectedTextOutput, DecodedLogprobs, DecodedPositionLogprobs, DecodedPromptLogprobs,
     DecodedTextEvent, DecodedTokenLogprob, Finished, TextDecodeOptions, TextOutputStreamExt,
 };
-pub use request::{Prompt, SamplingParams, TextRequest};
+pub use request::{Prompt, SamplingParams, TextRequest, TruncationSide};
 use trait_set::trait_set;
 use vllm_engine_core_client::EngineCoreClient;
 pub use vllm_llm::FinishReason;
@@ -93,6 +93,12 @@ impl TextRequestProcessor {
             // and infra workloads bypass chat rendering and tokenizer overhead entirely.
             Prompt::TokenIds(token_ids) => token_ids,
         };
+        let prompt_token_ids = truncate_prompt_token_ids(
+            prompt_token_ids,
+            request.truncate_prompt_tokens,
+            request.truncation_side,
+            self.max_model_len,
+        )?;
         let sampling_hints = self.backend.sampling_hints()?;
         let sampling_limits = SamplingLimits {
             max_model_len: self.max_model_len,
@@ -109,6 +115,46 @@ impl TextRequestProcessor {
             tokenizer.as_ref(),
         )
     }
+}
+
+/// Apply `truncate_prompt_tokens` to a tokenized prompt.
+///
+/// `None` means no truncation, `-1` maps to the model context length, and any
+/// other value keeps that many tokens from the side named by `truncation_side`.
+/// Truncation runs after tokenization so pre-tokenized prompts are covered too,
+/// and before length validation so a truncated prompt is measured at its final
+/// length.
+fn truncate_prompt_token_ids(
+    mut prompt_token_ids: Vec<u32>,
+    truncate_prompt_tokens: Option<i64>,
+    truncation_side: Option<TruncationSide>,
+    max_model_len: u32,
+) -> Result<Vec<u32>> {
+    let Some(truncate_prompt_tokens) = truncate_prompt_tokens else {
+        return Ok(prompt_token_ids);
+    };
+
+    let keep = match truncate_prompt_tokens {
+        -1 => max_model_len as usize,
+        n if (0..=i64::from(max_model_len)).contains(&n) => n as usize,
+        n => {
+            return Err(Error::TruncatePromptTokensTooLarge {
+                max_model_len,
+                truncate_prompt_tokens: n,
+            });
+        }
+    };
+
+    if prompt_token_ids.len() > keep {
+        match truncation_side.unwrap_or_default() {
+            TruncationSide::Right => prompt_token_ids.truncate(keep),
+            TruncationSide::Left => {
+                prompt_token_ids.drain(..prompt_token_ids.len() - keep);
+            }
+        }
+    }
+
+    Ok(prompt_token_ids)
 }
 
 /// Raw text facade above [`Llm`].
@@ -216,5 +262,69 @@ impl TextLlm {
     pub async fn shutdown(self) -> Result<()> {
         self.llm.shutdown().await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MAX_MODEL_LEN: u32 = 8;
+
+    fn truncate(
+        ids: &[u32],
+        truncate_prompt_tokens: Option<i64>,
+        truncation_side: Option<TruncationSide>,
+    ) -> Result<Vec<u32>> {
+        truncate_prompt_token_ids(
+            ids.to_vec(),
+            truncate_prompt_tokens,
+            truncation_side,
+            MAX_MODEL_LEN,
+        )
+    }
+
+    #[test]
+    fn truncate_prompt_token_ids_keeps_prompt_without_truncation() {
+        assert_eq!(truncate(&[1, 2, 3], None, None).unwrap(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn truncate_prompt_token_ids_defaults_to_keeping_the_first_tokens() {
+        assert_eq!(truncate(&[1, 2, 3, 4], Some(2), None).unwrap(), vec![1, 2]);
+        assert_eq!(
+            truncate(&[1, 2, 3, 4], Some(2), Some(TruncationSide::Right)).unwrap(),
+            vec![1, 2]
+        );
+    }
+
+    #[test]
+    fn truncate_prompt_token_ids_keeps_the_last_tokens_when_truncating_left() {
+        assert_eq!(
+            truncate(&[1, 2, 3, 4], Some(2), Some(TruncationSide::Left)).unwrap(),
+            vec![3, 4]
+        );
+    }
+
+    #[test]
+    fn truncate_prompt_token_ids_leaves_shorter_prompts_alone() {
+        assert_eq!(truncate(&[1, 2], Some(4), None).unwrap(), vec![1, 2]);
+    }
+
+    #[test]
+    fn truncate_prompt_token_ids_maps_negative_one_to_the_context_length() {
+        let ids: Vec<u32> = (0..12).collect();
+        let truncated = truncate(&ids, Some(-1), None).unwrap();
+        assert_eq!(truncated.len(), MAX_MODEL_LEN as usize);
+        assert_eq!(truncated.first(), Some(&0));
+    }
+
+    #[test]
+    fn truncate_prompt_token_ids_rejects_sizes_above_the_context_length() {
+        let err = truncate(&[1, 2, 3], Some(i64::from(MAX_MODEL_LEN) + 1), None).unwrap_err();
+        assert!(
+            matches!(err, Error::TruncatePromptTokensTooLarge { .. }),
+            "unexpected error: {err:?}"
+        );
     }
 }

--- a/rust/src/text/src/request.rs
+++ b/rust/src/text/src/request.rs
@@ -36,6 +36,26 @@ impl Default for Prompt {
     }
 }
 
+/// Which side to truncate from when `truncate_prompt_tokens` is active.
+///
+/// Original Python definition:
+/// <https://github.com/vllm-project/vllm/blob/main/vllm/renderers/params.py>
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TruncationSide {
+    /// Keep the first N tokens, truncating from the end.
+    ///
+    /// This is the default because it matches the Hugging Face tokenizer
+    /// default that Python falls back to when the request leaves
+    /// `truncation_side` unset.
+    // TODO: read the tokenizer's own configured `truncation_side` so models
+    // that ship a non-default value keep parity with Python.
+    #[default]
+    Right,
+    /// Keep the last N tokens, truncating from the start.
+    Left,
+}
+
 /// User-facing sampling parameters accepted by `vllm-text`.
 ///
 /// This intentionally keeps only the subset that the current Rust text layer
@@ -180,6 +200,15 @@ pub struct TextRequest {
     pub cache_salt: Option<String>,
     /// Whether to add special tokens (e.g. BOS) during prompt tokenization.
     pub add_special_tokens: bool,
+    /// Number of prompt tokens to keep:
+    /// - `None` means no truncation.
+    /// - `-1` maps to the model context length.
+    #[serde(default)]
+    pub truncate_prompt_tokens: Option<i64>,
+    /// Which side to truncate from when `truncate_prompt_tokens` is active.
+    /// `None` falls back to [`TruncationSide::Right`].
+    #[serde(default)]
+    pub truncation_side: Option<TruncationSide>,
     /// Override data parallel rank.
     #[serde(default)]
     pub data_parallel_rank: Option<u32>,
@@ -211,6 +240,8 @@ impl TextRequest {
             priority: 0,
             cache_salt: None,
             add_special_tokens: false,
+            truncate_prompt_tokens: None,
+            truncation_side: None,
             data_parallel_rank: None,
             reasoning_parser_kwargs: None,
             lora_request: None,


### PR DESCRIPTION
## Purpose

Roadmap item from #44280: `truncate_prompt_tokens`.

The Rust frontend rejected it with `truncate_prompt_tokens is not supported` on `/v1/completions` and `/v1/chat/completions`, and with `InvalidArgument` over gRPC. This accepts it.

## Implementation

Truncation is applied once, in `TextRequestProcessor::prepare`, right after tokenization and before length validation. Chat, completions and the pre-tokenized prompt path all flow through there, so there is one implementation rather than one per route, and a truncated prompt is measured at its final length.

Semantics follow `vllm/renderers/params.py`:

- `None` means no truncation.
- `-1` maps to the model context length.
- `truncation_side="right"` keeps the first N tokens, `"left"` keeps the last N.
- A value above the context length is a request validation error, so it surfaces as HTTP 400 rather than a 500.

Two notes for review:

- `truncation_side` defaults to `right`, matching the Hugging Face tokenizer default that Python falls back to when the request leaves it unset. Reading the tokenizer's own configured `truncation_side` is left as a TODO in the code, since `DynTokenizer` does not expose it today.
- The gRPC field is `uint32` where 0 means unset, so it cannot express `-1`. Non-zero values pass through and 0 stays "no truncation". `/tokenize` and the internal `/generate` route keep `None`, with TODOs, since the first must not silently drop tokens and the second receives prompts already tokenized.

## Test

```
cargo test -p vllm-text -p vllm-chat -p vllm-server
```

All green (313 server, 76 text, plus the chat suites). New tests:

- `vllm-text`: no truncation, default side, explicit left and right, prompt shorter than the limit, `-1` mapping, and the over-limit error.
- `vllm-server`: both convert layers forward the two fields, and `TruncatePromptTokensTooLarge` maps to `invalid_request_error` with HTTP 400.

`cargo clippy -p vllm-text -p vllm-server --all-targets` is clean and `cargo fmt` applied.

AI assistance was used for this change.
