### PR TITLE
perf(rocm): fuse Kimi-K3 KDA decode gate

### DIFF
--- a/tests/kernels/core/test_fused_rms_norm_gated.py
+++ b/tests/kernels/core/test_fused_rms_norm_gated.py
@@ -7,6 +7,8 @@ matching the eager triton kernel output."""
 import pytest
 import torch
 
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.platforms import current_platform
 from vllm.third_party.flash_linear_attention.ops.fused_norm_gate import (
     FusedRMSNormGated,
 )
@@ -103,3 +105,43 @@ def test_compiled_vs_eager_multidim(
     native_out = compiled_native(x.clone(), g.clone())
 
     torch.testing.assert_close(native_out, cuda_out, atol=1e-3, rtol=1e-2)
+
+
+@pytest.mark.skipif(not current_platform.is_rocm(), reason="ROCm only")
+@pytest.mark.parametrize("num_tokens", [1, 8, 64])
+@torch.inference_mode()
+def test_kimi_k3_gate_uses_fused_rocm_kernel(num_tokens: int) -> None:
+    """Kimi-K3's packed gate selects the fused ROCm implementation."""
+    set_random_seed(0)
+    device = torch.device("cuda:0")
+    config = VllmConfig()
+    config.compilation_config.custom_ops = ["none"]
+    with set_current_vllm_config(config):
+        module = FusedRMSNormGated(
+            hidden_size=128,
+            activation="sigmoid",
+            device=device,
+            dtype=torch.bfloat16,
+            enforce_enable=True,
+        )
+    module.weight.data.normal_()
+
+    x = torch.randn((1, num_tokens, 12, 128), dtype=torch.bfloat16, device=device)
+    packed_gate = torch.randn((num_tokens, 6288), dtype=torch.bfloat16, device=device)
+    gate = packed_gate[:, 4608:6144].view(num_tokens, 12, 128)
+    assert gate.stride()[-2:] == (128, 1)
+
+    x_float = x.float()
+    variance = x_float.pow(2).mean(dim=-1, keepdim=True)
+    reference = (
+        x_float
+        * torch.rsqrt(variance + module.eps)
+        * module.weight.float()
+        * torch.sigmoid(gate.float())
+    ).to(x.dtype)
+
+    output = module(x, gate)
+
+    assert module._forward_method.__name__ == "forward_hip"
+    assert output.data_ptr() == x.data_ptr()
+    torch.testing.assert_close(output, reference, atol=1e-3, rtol=1e-2)

--- a/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
@@ -302,7 +302,11 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                 quant_config=self.quant_config,
                 prefix=f"{prefix}.g_b_proj",
             )
-        self.o_norm = FusedRMSNormGated(self.head_dim, activation="sigmoid")
+        self.o_norm = FusedRMSNormGated(
+            self.head_dim,
+            activation="sigmoid",
+            enforce_enable=current_platform.is_rocm(),
+        )
         self.o_proj = RowParallelLinear(
             self.projection_size,
             self.hidden_size,

--- a/vllm/third_party/flash_linear_attention/ops/fused_norm_gate.py
+++ b/vllm/third_party/flash_linear_attention/ops/fused_norm_gate.py
@@ -15,6 +15,7 @@ from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.math_utils import cdiv, next_power_of_2
 
+
 @triton.heuristics(
     {
         "STORE_RESIDUAL_OUT": lambda args: args["residual_out"] is not None,
@@ -347,9 +348,10 @@ class FusedRMSNormGated(CustomOp):
         activation: str = "swish",
         device: torch.device | None = None,
         dtype: torch.dtype | None = None,
+        enforce_enable: bool = False,
     ) -> None:
         factory_kwargs = {"device": device, "dtype": dtype}
-        super().__init__()
+        super().__init__(enforce_enable=enforce_enable)
 
         self.hidden_size = hidden_size
         self.elementwise_affine = elementwise_affine


### PR DESCRIPTION
# perf(rocm): fuse Kimi-K3 KDA decode gate

## Stack and dependency

This is a focused ROCm performance PR stacked on
https://github.com/vllm-project/vllm/pull/50000. Its base branch should be
`vllm-project/vllm:kimi-k3` until PR #50000 merges.

The combined result also depends on the companion ROCm/AITER MLA split
optimization prepared as commit `249f5f7ac2`
(`perf(mla): split Kimi-K3 graph decode workgroups`). Add that PR URL here
before submission.

## What

Route Kimi-K3's KDA output gate through the existing fused ROCm Triton
RMSNorm+sigmoid implementation when global custom ops are disabled.

`FusedRMSNormGated` now exposes the `enforce_enable` option already provided
by `CustomOp`. The Kimi GDN layer enables it on ROCm at construction time.
This keeps model policy out of the shared operator's data path:

- `forward_native` remains a generic decomposition.
- Other users retain the existing default, `enforce_enable=False`.
- NVIDIA is unchanged because the Kimi layer enables the override only when
  `current_platform.is_rocm()` is true.

## Why

Kimi-K3 runs with `custom_ops=none` under full-graph compilation, so
`FusedRMSNormGated` dispatches `forward_native`. At B1 decode this decomposition
costs 23.8 us per layer, while the existing fused ROCm kernel costs 3.8 us.

The previous prototype recognized one production trace with a long
shape/dtype/stride predicate in `forward_native`. That encoded model-specific
policy and an incidental singleton stride in a shared operator. Construction-
time dispatch uses vLLM's intended `CustomOp` mechanism and also covers
multi-token and batched Kimi execution.

## Performance

Hardware: 8x AMD Instinct MI355X (`gfx950`), ROCm 7.2.3, TP8, no speculative
decoding.

Kernel-level:

| Metric | Native | Fused |
|---|---:|---:|
| Graph median | 23.80 us | 3.80 us |
| Speedup | 1.00x | 6.26x |
| rocprofv3 device median | — | 4.24 us |

rocprofv3 captured 4,112 `layer_norm_gated_fwd_kernel` calls. The kernel used
16 VGPRs, 48 SGPRs, and a 512-thread workgroup.

End-to-end, 8,192 input / 1,024 output tokens:

| Configuration | Decode tok/s | Median ITL |
|---|---:|---:|
| PR #50000 baseline | 33.275 | 30.007 ms |
| MLA split32 only, two-run midpoint | 40.285 | 24.745 ms |
| MLA + KDA, run 1 | 45.818 | 21.731 ms |
| MLA + KDA, run 2 | 45.983 | 21.712 ms |
| MLA + redesigned KDA dispatch | 45.835 | 21.752 ms |

The KDA change adds 13.9% decode throughput and reduces median ITL by 12.2%
over MLA split32 alone. Combined versus the original PR #50000 baseline,
decode throughput improves by 37.9% and median ITL falls by 27.6%.

## Accuracy and tests

Focused ROCm regression:

```bash
.venv/bin/python -m pytest \
  tests/kernels/core/test_fused_rms_norm_gated.py::test_kimi_k3_gate_uses_fused_rocm_kernel \
  -v
```

Result: `3 passed`, covering 1, 8, and 64 tokens from the 6,288-wide packed
gate projection.

Numerical comparison against the PyTorch decomposition:

- 1 token: max difference 0, SNR 999 dB
- 8 tokens: max difference 0, SNR 999 dB
- 64 tokens: max difference `0.0001220703125`, SNR 122.47 dB
- graph median: 3.774 us

The companion MLA kernel passed against its reference at 52.01 dB SNR with a
maximum BF16 difference of `0.00390625`.

Model-level evaluation used vLLM's isolated GSM8K evaluator against the live
combined endpoint:

```python
evaluate_gsm8k(
    num_questions=100,
    num_shots=5,
    max_tokens=256,
    model="moonshotai/Kimi-K3",
    use_chat_completions=True,
    temperature=0.0,
    seed=42,
    max_concurrency=8,
)
```

Result:

- Accuracy: 0.88
- Invalid response rate: 0.00
- Questions: 100
- Output tokens: 18,509

Formatting and static checks:

```bash
uvx ruff check \
  vllm/third_party/flash_linear_attention/ops/fused_norm_gate.py \
  vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py \
  tests/kernels/core/test_fused_rms_norm_gated.py
uvx ruff format --check \
  vllm/third_party/flash_linear_attention/ops/fused_norm_gate.py \
  vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py \
  tests/kernels/core/test_fused_rms_norm_gated.py
git diff --check
```

All passed.

## Duplicate and assistance disclosure

I searched open vLLM pull requests and issues for `FusedRMSNormGated`,
`fused_norm_gate`, Kimi-K3 KDA gating, and ROCm sigmoid gate fusion. PR #36469
is a broader cleanup on the older FLA module paths; it neither touches PR
#50000's current `third_party` implementation nor adds this ROCm production
shape specialization. PR #50000 adds Kimi-K3 support but does not contain this
KDA optimization, so this is a focused stacked performance change rather than
a duplicate.

OpenAI Codex assisted with profiling, benchmark orchestration, test
implementation, and preparing this change and description. The human
submitter must review every changed line and be able to explain and defend the
change before submission.
