### PR TITLE
[Bugfix] Only pad transformers backend `value` when it is narrower

### DIFF
--- a/vllm/model_executor/models/transformers/__init__.py
+++ b/vllm/model_executor/models/transformers/__init__.py
@@ -64,12 +64,15 @@ def vllm_attention_forward(
     head_dim_v = value.shape[-1]
     query, key, value = (x.transpose(1, 2) for x in (query, key, value))
     query, key, value = (x.reshape(hidden, -1) for x in (query, key, value))
-    # Pad `value` up to the query/key head size when they differ (expanded MLA).
-    if head_dim_v != head_dim_qk:
+    # Pad `value` up to the query/key head size when it is smaller (expanded
+    # MLA). A larger last dim just means `value` isn't split per head, e.g.
+    # packed grouped/multi-query projections, and needs no padding.
+    pad_value = head_dim_v < head_dim_qk
+    if pad_value:
         value = F.pad(value.view(-1, head_dim_v), (0, head_dim_qk - head_dim_v))
         value = value.reshape(hidden, -1)
     attn_output = self_attn.forward(query, key, value)
-    if head_dim_v != head_dim_qk:
+    if pad_value:
         attn_output = attn_output.view(-1, head_dim_qk)[..., :head_dim_v]
         attn_output = attn_output.reshape(hidden, -1)
     return attn_output, None


### PR DESCRIPTION
#49982 added padding of `value` up to the query/key head size in `vllm_attention_forward` for expanded MLA, guarded on `head_dim_v != head_dim_qk`. #49987 then added support for packed grouped/multi-query QKV projections, whose attention modules keep `key`/`value` packed rather than split per head, so `value.shape[-1]` is `kv_heads * head_dim` - i.e. *larger* than the query head size whenever `kv_heads > 1`.

The pad amount is then negative, and `F.pad` silently truncates rather than pads: `value` is narrowed to the query head size while `key` keeps its full width, so attention is handed mismatched key/value widths.

    RuntimeError: The size of tensor a (16) must match the size of
                  tensor b (8) at non-singleton dimension 1

Only pad when `value` is genuinely narrower. A wider last dimension just means `value` is not split per head, which needs no padding; skipping it restores the pre-#49982 behaviour for those layouts and leaves the MLA path unchanged.

Neither PR is wrong alone, and neither CI run could have caught this: #49987 was tested ~30 minutes before #49982 merged, and the packed QKV module that trips the branch did not exist when #49982 was tested. They only interact once both are on main, which is why
`test_detects_and_rewrites_packed_qkv[2]` passed in #49987's own CI (build 80569) and has failed on every build from 80627 onwards.