### PR TITLE
[Kimi-K3] MoRIIO KV transfer of hybrid mamba/KDA (conv+ssm) recurrent state (READ + WRITE)

### DIFF
--- a/examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py
+++ b/examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py
@@ -348,10 +348,6 @@ async def handle_request(api: str, request: Request):
                 "remote_block_ids"
             ]
             req_data["kv_transfer_params"]["transfer_id"] = prefill_kv["transfer_id"]
-            if prefill_kv.get("remote_mamba_block_ids"):
-                req_data["kv_transfer_params"]["remote_mamba_block_ids"] = prefill_kv[
-                    "remote_mamba_block_ids"
-                ]
             if prefill_kv.get("tp_size") is not None:
                 req_data["kv_transfer_params"]["tp_size"] = prefill_kv["tp_size"]
 

--- a/examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py
+++ b/examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py
@@ -348,6 +348,12 @@ async def handle_request(api: str, request: Request):
                 "remote_block_ids"
             ]
             req_data["kv_transfer_params"]["transfer_id"] = prefill_kv["transfer_id"]
+            if prefill_kv.get("remote_mamba_block_ids"):
+                req_data["kv_transfer_params"]["remote_mamba_block_ids"] = prefill_kv[
+                    "remote_mamba_block_ids"
+                ]
+            if prefill_kv.get("tp_size") is not None:
+                req_data["kv_transfer_params"]["tp_size"] = prefill_kv["tp_size"]
 
         req_data["kv_transfer_params"]["remote_dp_size"] = prefill_instance_endpoint[
             "dp_size"

--- a/tests/v1/kv_connector/unit/test_moriio_hma_scheduler.py
+++ b/tests/v1/kv_connector/unit/test_moriio_hma_scheduler.py
@@ -41,6 +41,10 @@ ssm_conv_transfer_utils = importlib.import_module(
 )
 MambaConvSplitInfo = ssm_conv_transfer_utils.MambaConvSplitInfo
 MoRIIOMode = moriio_connector.MoRIIOMode
+moriio_common = importlib.import_module(
+    "vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common"
+)
+as_attn_mamba = moriio_common.as_attn_mamba
 
 
 class _FakeScheduler(moriio_connector.MoRIIOConnectorScheduler):
@@ -117,7 +121,7 @@ def test_split_block_groups_no_mamba_reduces_to_prior_behavior():
 # --------------------------------------------------------------------------
 # request_finished_all_groups
 # --------------------------------------------------------------------------
-def test_request_finished_all_groups_routes_attn_and_mamba_ids():
+def test_request_finished_all_groups_carries_attn_and_mamba_in_one_field():
     seen = {}
 
     def _fake_request_finished(request, attn_block_ids):
@@ -133,13 +137,17 @@ def test_request_finished_all_groups_routes_attn_and_mamba_ids():
     delay_free, params = conn.request_finished_all_groups(request, block_ids)
 
     assert delay_free is True
-    # attention ids went to request_finished; mamba slot attached separately.
+    # Attention ids drive request_finished; the mamba slot rides the SAME
+    # remote_block_ids channel as [attn, mamba] -- no separate wire field, so
+    # the proxy/router need no KDA-specific field.
     assert seen["attn"] == [10, 11]
-    assert params["remote_block_ids"] == [10, 11]
-    assert params["remote_mamba_block_ids"] == [42]
+    assert params["remote_block_ids"] == [[10, 11], [42]]
+    assert "remote_mamba_block_ids" not in params
+    # Round-trips through the consumer-side unpacker.
+    assert as_attn_mamba(params["remote_block_ids"]) == ([10, 11], [42])
 
 
-def test_request_finished_all_groups_no_mamba_omits_mamba_ids():
+def test_request_finished_all_groups_pure_attention_stays_flat():
     def _fake_request_finished(request, attn_block_ids):
         return True, {"remote_block_ids": attn_block_ids}
 
@@ -150,8 +158,25 @@ def test_request_finished_all_groups_no_mamba_omits_mamba_ids():
     delay_free, params = conn.request_finished_all_groups(
         SimpleNamespace(request_id="r1"), ([7, 8],)
     )
+    # Pure attention: remote_block_ids stays a flat list; no KDA field added.
     assert params["remote_block_ids"] == [7, 8]
     assert "remote_mamba_block_ids" not in params
+    assert as_attn_mamba(params["remote_block_ids"]) == ([7, 8], [])
+
+
+# --------------------------------------------------------------------------
+# as_attn_mamba (carried block-ids unpacker)
+# --------------------------------------------------------------------------
+def test_as_attn_mamba_unpacks_flat_and_paired():
+    # Empty / None -> no blocks.
+    assert as_attn_mamba(None) == ([], [])
+    assert as_attn_mamba([]) == ([], [])
+    # Flat list (attention-only / legacy) -> all attention, no mamba.
+    assert as_attn_mamba([1, 2, 3]) == ([1, 2, 3], [])
+    # [attn, mamba] pair (hybrid) unpacks both halves.
+    assert as_attn_mamba([[1, 2], [9]]) == ([1, 2], [9])
+    # Tuple form with empty mamba half.
+    assert as_attn_mamba(([4, 5], [])) == ([4, 5], [])
 
 
 # --------------------------------------------------------------------------

--- a/tests/v1/kv_connector/unit/test_moriio_hma_scheduler.py
+++ b/tests/v1/kv_connector/unit/test_moriio_hma_scheduler.py
@@ -1,0 +1,304 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Pure-CPU unit tests for the MoRIIO hybrid (attention + mamba/KDA) scheduler
+and the KDA offset-template cache.
+
+These exercise the highest-risk, otherwise-untested scheduler logic without a
+GPU or the ``mori`` runtime: per-group block-id splitting, the READ/WRITE
+``N-1`` token accounting, P-side prompt truncation, and the C2 offset-cache
+equivalence (cached offsets must be byte-identical to freshly computed ones).
+
+Like ``test_moriio_kv_layout.py`` the whole module is skipped unless it is
+running on ROCm with ``mori`` installed (importing the connector pulls in
+``mori``). The authoritative run happens on the MIA recipe image.
+"""
+
+import importlib
+import importlib.util
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+
+mori_available = importlib.util.find_spec("mori") is not None
+
+if not (current_platform.is_rocm() and mori_available):
+    pytest.skip(
+        "MoRIIOs are only available on ROCm with mori package installed",
+        allow_module_level=True,
+    )
+
+moriio_connector = importlib.import_module(
+    "vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_connector"
+)
+moriio_layout = importlib.import_module(
+    "vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_layout"
+)
+ssm_conv_transfer_utils = importlib.import_module(
+    "vllm.distributed.kv_transfer.kv_connector.v1.ssm_conv_transfer_utils"
+)
+MambaConvSplitInfo = ssm_conv_transfer_utils.MambaConvSplitInfo
+MoRIIOMode = moriio_connector.MoRIIOMode
+
+
+class _FakeScheduler(moriio_connector.MoRIIOConnectorScheduler):
+    """Constructs a scheduler without the heavy real ``__init__``; only the
+    attributes read by the method under test are set."""
+
+    def __init__(self, **attrs):
+        for k, v in attrs.items():
+            setattr(self, k, v)
+
+
+class _FakeConnector(moriio_connector.MoRIIOConnector):
+    def __init__(self, connector_scheduler):
+        self.connector_scheduler = connector_scheduler
+
+
+class _FakeWorker(moriio_connector.MoRIIOConnectorWorker):
+    def __init__(self, **attrs):
+        for k, v in attrs.items():
+            setattr(self, k, v)
+
+
+def _slot_strided(num_slots, per_slot_shape, slot_stride, dtype=torch.bfloat16):
+    inner = 1
+    for d in per_slot_shape:
+        inner *= d
+    assert slot_stride >= inner
+    backing = torch.zeros(num_slots * slot_stride, dtype=dtype)
+    inner_strides = []
+    acc = 1
+    for d in reversed(per_slot_shape):
+        inner_strides.insert(0, acc)
+        acc *= d
+    return backing.as_strided((num_slots, *per_slot_shape), (slot_stride, *inner_strides))
+
+
+def _gdn_split_info(conv_rows=3, key_dim=4, value_dim=8, dtype_size=2):
+    conv_dim = 2 * key_dim + value_dim
+    conv_state_bytes = conv_dim * conv_rows * dtype_size
+    ssm_state_bytes = 64
+    return MambaConvSplitInfo(
+        conv_rows=conv_rows,
+        local_proj_dims=(key_dim, key_dim, value_dim),
+        conv_dtype_size=dtype_size,
+        ssm_sizes=(conv_state_bytes, ssm_state_bytes),
+    )
+
+
+# --------------------------------------------------------------------------
+# split_block_groups
+# --------------------------------------------------------------------------
+def test_split_block_groups_separates_attention_and_mamba():
+    sched = _FakeScheduler(_has_mamba=True, _mamba_group_ids={2})
+    # groups 0,1 = attention; group 2 = mamba recurrent-state slot.
+    block_ids = ([1, 2], [3, 4], [99])
+    attn, mamba = sched.split_block_groups(block_ids)
+    assert attn == [1, 2, 3, 4]
+    assert mamba == [99]
+
+
+def test_split_block_groups_no_mamba_reduces_to_prior_behavior():
+    sched = _FakeScheduler(_has_mamba=False, _mamba_group_ids=set())
+    block_ids = ([5, 6, 7],)
+    attn, mamba = sched.split_block_groups(block_ids)
+    # Pure-attention model: mamba empty, attention == block_ids[0].
+    assert attn == [5, 6, 7]
+    assert mamba == []
+    # Empty input is tolerated.
+    assert _FakeScheduler(_has_mamba=False, _mamba_group_ids=set()).split_block_groups(
+        ()
+    ) == ([], [])
+
+
+# --------------------------------------------------------------------------
+# request_finished_all_groups
+# --------------------------------------------------------------------------
+def test_request_finished_all_groups_routes_attn_and_mamba_ids():
+    seen = {}
+
+    def _fake_request_finished(request, attn_block_ids):
+        seen["attn"] = list(attn_block_ids)
+        return True, {"do_remote_prefill": True, "remote_block_ids": attn_block_ids}
+
+    sched = _FakeScheduler(_has_mamba=True, _mamba_group_ids={1})
+    sched.request_finished = _fake_request_finished
+    conn = _FakeConnector(sched)
+
+    request = SimpleNamespace(request_id="r0")
+    block_ids = ([10, 11], [42])
+    delay_free, params = conn.request_finished_all_groups(request, block_ids)
+
+    assert delay_free is True
+    # attention ids went to request_finished; mamba slot attached separately.
+    assert seen["attn"] == [10, 11]
+    assert params["remote_block_ids"] == [10, 11]
+    assert params["remote_mamba_block_ids"] == [42]
+
+
+def test_request_finished_all_groups_no_mamba_omits_mamba_ids():
+    def _fake_request_finished(request, attn_block_ids):
+        return True, {"remote_block_ids": attn_block_ids}
+
+    sched = _FakeScheduler(_has_mamba=False, _mamba_group_ids=set())
+    sched.request_finished = _fake_request_finished
+    conn = _FakeConnector(sched)
+
+    delay_free, params = conn.request_finished_all_groups(
+        SimpleNamespace(request_id="r1"), ([7, 8],)
+    )
+    assert params["remote_block_ids"] == [7, 8]
+    assert "remote_mamba_block_ids" not in params
+
+
+# --------------------------------------------------------------------------
+# _truncate_mamba_request_for_prefill
+# --------------------------------------------------------------------------
+def _mk_request(prompt, max_tokens=64, params=None):
+    return SimpleNamespace(
+        kv_transfer_params={} if params is None else params,
+        num_prompt_tokens=len(prompt),
+        prompt_token_ids=list(prompt),
+        prompt_embeds=None,
+        _all_token_ids=list(prompt),
+        max_tokens=max_tokens,
+    )
+
+
+def test_truncate_mamba_request_pops_last_token_and_caps_tokens():
+    sched = _FakeScheduler()
+    req = _mk_request([10, 11, 12, 13, 14])
+    sched._truncate_mamba_request_for_prefill(req)
+
+    assert req.prompt_token_ids == [10, 11, 12, 13]  # last token popped
+    assert req._all_token_ids == [10, 11, 12, 13]
+    assert req.num_prompt_tokens == 4  # N-1 accounting
+    assert req.max_tokens == 1
+    assert req.kv_transfer_params["_p_side_truncated"] is True
+
+
+def test_truncate_mamba_request_is_idempotent_across_reschedule():
+    sched = _FakeScheduler()
+    req = _mk_request([10, 11, 12])
+    sched._truncate_mamba_request_for_prefill(req)
+    assert req.num_prompt_tokens == 2
+    # A second call (e.g. after a preemption) must not truncate again.
+    sched._truncate_mamba_request_for_prefill(req)
+    assert req.num_prompt_tokens == 2
+    assert req.prompt_token_ids == [10, 11]
+
+
+def test_truncate_mamba_request_noop_for_single_token_prompt():
+    sched = _FakeScheduler()
+    req = _mk_request([10])
+    sched._truncate_mamba_request_for_prefill(req)
+    assert req.num_prompt_tokens == 1
+    assert req.prompt_token_ids == [10]
+    assert "_p_side_truncated" not in req.kv_transfer_params
+
+
+# --------------------------------------------------------------------------
+# get_num_new_matched_tokens  (hybrid N-1 accounting)
+# --------------------------------------------------------------------------
+def test_get_num_new_matched_tokens_read_recomputes_last_token():
+    sched = _FakeScheduler(is_producer=False, mode=MoRIIOMode.READ, _has_mamba=True)
+    req = SimpleNamespace(prompt_token_ids=list(range(10)), kv_transfer_params=None)
+    n, is_async = sched.get_num_new_matched_tokens(req, num_computed_tokens=0)
+    # READ always recomputes the final token locally: N-1 - computed.
+    assert n == 9
+    assert is_async is False
+
+
+def test_get_num_new_matched_tokens_write_hybrid_drops_last_token():
+    sched = _FakeScheduler(is_producer=False, mode=MoRIIOMode.WRITE, _has_mamba=True)
+    req = SimpleNamespace(prompt_token_ids=list(range(10)), kv_transfer_params=None)
+    n, is_async = sched.get_num_new_matched_tokens(req, num_computed_tokens=0)
+    # Hybrid WRITE: decoder recomputes final token from pushed KDA state -> N-1.
+    assert n == 9
+    assert is_async is True
+
+
+def test_get_num_new_matched_tokens_write_plain_keeps_all_tokens():
+    sched = _FakeScheduler(is_producer=False, mode=MoRIIOMode.WRITE, _has_mamba=False)
+    req = SimpleNamespace(prompt_token_ids=list(range(10)), kv_transfer_params=None)
+    n, is_async = sched.get_num_new_matched_tokens(req, num_computed_tokens=2)
+    # Pure-attention WRITE: no N-1 drop; full length minus already-computed.
+    assert n == 8
+    assert is_async is True
+
+
+def test_get_num_new_matched_tokens_producer_truncates_and_returns_zero():
+    sched = _FakeScheduler(is_producer=True, mode=MoRIIOMode.WRITE, _has_mamba=True)
+    req = _mk_request(list(range(5)), params={"do_remote_decode": True})
+    n, is_async = sched.get_num_new_matched_tokens(req, num_computed_tokens=0)
+    assert (n, is_async) == (0, False)
+    # Producer stops at h(N-1): the last prompt token was dropped.
+    assert req.num_prompt_tokens == 4
+    assert req.max_tokens == 1
+    assert req.kv_transfer_params["_p_side_truncated"] is True
+
+
+# --------------------------------------------------------------------------
+# C2: cached offset template == freshly recomputed (byte-exactness)
+# --------------------------------------------------------------------------
+_SAMPLE_SLOT_SETS = [
+    ([1, 2], [1, 2]),
+    ([0], [3]),
+    ([3, 0, 2], [3, 0, 2]),
+    ([2, 2], [5, 5]),
+    ([], []),
+]
+
+
+@pytest.mark.parametrize("local_slots,remote_slots", _SAMPLE_SLOT_SETS)
+def test_offset_template_apply_matches_direct_compute(local_slots, remote_slots):
+    split = _gdn_split_info()
+    conv_dim = sum(split.local_proj_dims)
+    conv = _slot_strided(8, (conv_dim, split.conv_rows), slot_stride=200)
+    ssm = _slot_strided(8, (2, 4, 4), slot_stride=64)
+
+    template = moriio_layout.build_mamba_offset_template(
+        "kda.0", conv, ssm, {}, split, tp_ratio=1, tp_rank=0, world_size=1
+    )
+    cached = moriio_layout.apply_mamba_offset_template(
+        template, local_slots, remote_slots
+    )
+    fresh = moriio_layout.compute_mamba_conv_ssm_offsets(
+        "kda.0", conv, ssm, {}, local_slots, remote_slots, split,
+        tp_ratio=1, tp_rank=0, world_size=1,
+    )
+    assert cached == fresh
+
+
+def test_worker_compute_mamba_offsets_caches_and_matches_recompute():
+    split = _gdn_split_info()
+    conv_dim = sum(split.local_proj_dims)
+    conv = _slot_strided(8, (conv_dim, split.conv_rows), slot_stride=200)
+    ssm = _slot_strided(8, (2, 4, 4), slot_stride=64)
+
+    worker = _FakeWorker(
+        kv_caches={"kda.0": (conv, ssm)},
+        layer_to_spec={},
+        _conv_decomp=split,
+        tp_rank=0,
+        world_size=1,
+    )
+
+    for local_slots, remote_slots in _SAMPLE_SLOT_SETS:
+        lo, ro, sz, n_conv = worker._compute_mamba_transfer_offsets(
+            "kda.0", local_slots, remote_slots
+        )
+        fresh = moriio_layout.compute_mamba_conv_ssm_offsets(
+            "kda.0", conv, ssm, {}, local_slots, remote_slots, split,
+            tp_ratio=1, tp_rank=0, world_size=1,
+        )
+        assert (lo, ro, sz) == fresh
+        assert n_conv == moriio_layout.compute_mamba_conv_split_count(
+            local_slots, split
+        )
+
+    # The per-(layer, tp_ratio) template is cached after the first call.
+    assert ("kda.0", 1) in worker._mamba_offset_templates

--- a/tests/v1/kv_connector/unit/test_moriio_kv_layout.py
+++ b/tests/v1/kv_connector/unit/test_moriio_kv_layout.py
@@ -33,6 +33,10 @@ moriio_layout = importlib.import_module(
     "vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_layout"
 )
 msgpack = importlib.import_module("msgpack")
+ssm_conv_transfer_utils = importlib.import_module(
+    "vllm.distributed.kv_transfer.kv_connector.v1.ssm_conv_transfer_utils"
+)
+MambaConvSplitInfo = ssm_conv_transfer_utils.MambaConvSplitInfo
 
 ROLE = moriio_common.ROLE
 MoRIIOError = moriio_common.MoRIIOError
@@ -349,6 +353,12 @@ def test_write_transfer_plan_caches_offsets_per_geometry():
     class FakeWorker:
         kv_caches: dict[str, torch.Tensor]
         layer_name_to_local_kv_cache_metadata: dict[str, list[Any]]
+
+        def _is_mamba_layer(self, layer_name):
+            return False
+
+        def _region_session_indices(self, layer_name):
+            return [list(self.kv_caches).index(layer_name)]
 
         def _compute_block_transfer_offsets(
             self, layer_name, local_block_ids, remote_block_ids, remote_moriio_meta
@@ -750,3 +760,114 @@ def test_unsupported_shape_raises_value_error():
 
     with pytest.raises(ValueError, match="Unsupported MoRIIO K/V cache shape"):
         moriio_layout.get_layer_transfer_geometry("layer", cache, worker.layer_to_spec)
+
+
+# ---------------------------------------------------------------------------
+# Mamba/KDA (conv + ssm) transfer geometry
+# ---------------------------------------------------------------------------
+
+
+def _slot_strided(num_slots, per_slot_shape, slot_stride, dtype=torch.bfloat16):
+    """Build a slot-strided view: shape (num_slots, *per_slot_shape) whose slot
+    stride (dim 0) exceeds the per-slot element count, mimicking the K3 KDA
+    conv/ssm cache tensors."""
+    inner = 1
+    for d in per_slot_shape:
+        inner *= d
+    assert slot_stride >= inner
+    backing = torch.zeros(num_slots * slot_stride, dtype=dtype)
+    inner_strides = []
+    acc = 1
+    for d in reversed(per_slot_shape):
+        inner_strides.insert(0, acc)
+        acc *= d
+    return backing.as_strided((num_slots, *per_slot_shape), (slot_stride, *inner_strides))
+
+
+def _gdn_split_info(conv_rows=3, key_dim=4, value_dim=8, dtype_size=2):
+    """A GDN-style conv split: sub-projections (key, key, value)."""
+    conv_dim = 2 * key_dim + value_dim
+    conv_state_bytes = conv_dim * conv_rows * dtype_size
+    ssm_state_bytes = 64  # opaque here; ssm size is taken from the tensor
+    return MambaConvSplitInfo(
+        conv_rows=conv_rows,
+        local_proj_dims=(key_dim, key_dim, value_dim),
+        conv_dtype_size=dtype_size,
+        ssm_sizes=(conv_state_bytes, ssm_state_bytes),
+    )
+
+
+def test_mamba_transfer_geometry_is_slot_strided():
+    split = _gdn_split_info()
+    conv_dim = sum(split.local_proj_dims)
+    conv = _slot_strided(5, (conv_dim, split.conv_rows), slot_stride=200)
+    ssm = _slot_strided(5, (2, 4, 4), slot_stride=64)
+
+    geom = moriio_layout.get_mamba_transfer_geometry("kda.0", conv, ssm, {})
+
+    assert geom.num_slots == 5
+    assert geom.conv_slot_stride == 200
+    assert geom.ssm_slot_stride == 64
+    assert geom.conv_slot_bytes == conv_dim * split.conv_rows * conv.element_size()
+    assert geom.ssm_slot_bytes == (2 * 4 * 4) * ssm.element_size()
+    # Region spans the full slot-strided extent (shape[0] * stride(0)), not just
+    # numel(), so the highest-slot transfers stay in-bounds.
+    assert geom.conv_region_len == conv.shape[0] * conv.stride(0) * conv.element_size()
+    assert geom.ssm_region_len == ssm.shape[0] * ssm.stride(0) * ssm.element_size()
+
+
+def test_mamba_conv_ssm_offsets_homogeneous_tp():
+    split = _gdn_split_info()
+    conv_dim = sum(split.local_proj_dims)
+    conv = _slot_strided(6, (conv_dim, split.conv_rows), slot_stride=200)
+    ssm = _slot_strided(6, (2, 4, 4), slot_stride=64)
+    geom = moriio_layout.get_mamba_transfer_geometry("kda.0", conv, ssm, {})
+
+    local_slots = [1, 2]
+    remote_slots = [1, 2]
+    local_offs, remote_offs, sizes = moriio_layout.compute_mamba_conv_ssm_offsets(
+        "kda.0", conv, ssm, {}, local_slots, remote_slots, split,
+        tp_ratio=1, tp_rank=0, world_size=1,
+    )
+
+    n_conv = moriio_layout.compute_mamba_conv_split_count(local_slots, split)
+    assert n_conv == len(local_slots) * len(split.local_proj_dims)
+    assert len(local_offs) == n_conv + len(local_slots)
+
+    # Homogeneous TP: remote conv slices equal local slices; since local==remote
+    # slots, conv local and remote offsets coincide.
+    loc_co = split.local_conv_offsets
+    rem_co = split.remote_conv_offsets(0, 1)
+    k = 0
+    esz = conv.element_size()
+    for ls, rs in zip(local_slots, remote_slots):
+        lbase = ls * geom.conv_slot_stride * esz
+        rbase = rs * geom.conv_slot_stride * esz
+        for (loff, _), (roff, rsz) in zip(loc_co, rem_co):
+            assert local_offs[k] == lbase + loff
+            assert remote_offs[k] == rbase + roff
+            assert sizes[k] == rsz
+            k += 1
+
+    # SSM: whole per-slot block, no head sharding at tp_ratio == 1.
+    essz = ssm.element_size()
+    for j, (ls, rs) in enumerate(zip(local_slots, remote_slots)):
+        assert local_offs[n_conv + j] == ls * geom.ssm_slot_stride * essz
+        assert remote_offs[n_conv + j] == rs * geom.ssm_slot_stride * essz
+        assert sizes[n_conv + j] == geom.ssm_slot_bytes
+
+
+def test_mamba_conv_ssm_offsets_heterogeneous_tp_is_gated():
+    # Heterogeneous-TP mamba transfer is a documented follow-up (remote slot
+    # stride + multi-rank fan-in gather). Until then the offset helper must fail
+    # loudly rather than silently transfer wrong bytes, since the mamba path
+    # bypasses the attention KV-head validator.
+    split = _gdn_split_info()
+    conv_dim = sum(split.local_proj_dims)
+    conv = _slot_strided(4, (conv_dim, split.conv_rows), slot_stride=200)
+    ssm = _slot_strided(4, (2, 4, 4), slot_stride=64)
+    with pytest.raises(NotImplementedError):
+        moriio_layout.compute_mamba_conv_ssm_offsets(
+            "kda.0", conv, ssm, {}, [0], [3], split,
+            tp_ratio=2, tp_rank=1, world_size=1,
+        )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
@@ -61,11 +61,19 @@ class WriteTask:
     remote_ip: str
     enqueue_time: float = field(default_factory=time.perf_counter)
     retried: int = 0
+    # Local KDA recurrent-state slot ids for this write (empty for attention).
+    local_mamba_block_ids: list[int] = field(default_factory=list)
 
 
 @dataclass
 class LayerTransferPlan:
-    """Plan for transferring a single layer."""
+    """Plan for transferring a single layer.
+
+    For attention layers ``sess_idx`` + ``transfer_*`` describe the one
+    transfer. For KDA layers the conv state uses ``sess_idx`` / ``transfer_*``
+    and the ssm state uses ``ssm_sess_idx`` / ``ssm_*`` (two registered regions
+    per layer, hence two sessions), issued as one scheduled write.
+    """
 
     request_id: ReqId
     transfer_id: TransferId
@@ -75,6 +83,11 @@ class LayerTransferPlan:
     transfer_remote_offsets: list[int]
     transfer_sizes: list[int]
     use_batch: bool = True
+    is_mamba: bool = False
+    ssm_sess_idx: int | None = None
+    ssm_local_offsets: list[int] = field(default_factory=list)
+    ssm_remote_offsets: list[int] = field(default_factory=list)
+    ssm_sizes: list[int] = field(default_factory=list)
 
 
 @dataclass
@@ -82,6 +95,9 @@ class RemoteAllocInfo:
     """Information about remote block allocation."""
 
     block_ids: list[int]
+    # Remote KDA recurrent-state slot ids sent by the decoder (empty for
+    # attention-only models).
+    mamba_block_ids: list[int] = field(default_factory=list)
     writes_done: int = 0
     writes_expected: int | None = None
     decode_dp_rank: int = 0
@@ -422,6 +438,10 @@ class ReqMeta:
     remote_engine_id: str
     tp_size: int
     remote_dp_size: int
+    # Hybrid (mamba/KDA) per-request recurrent-state slot ids; one logical
+    # slot per request. Empty for attention-only models.
+    mamba_local_block_ids: list[int] = field(default_factory=list)
+    mamba_remote_block_ids: list[int] = field(default_factory=list)
 
 
 class MoRIIOConnectorMetadata(KVConnectorMetadata):
@@ -445,6 +465,7 @@ class MoRIIOConnectorMetadata(KVConnectorMetadata):
         local_block_ids: list[int],
         kv_transfer_params: dict[str, Any],
         write_mode=False,
+        local_mamba_block_ids: list[int] | None = None,
     ):
         transfer_id = kv_transfer_params["transfer_id"]
 
@@ -473,8 +494,15 @@ class MoRIIOConnectorMetadata(KVConnectorMetadata):
             remote_port=int(remote_handshake_port),
             remote_handshake_port=int(remote_handshake_port),
             remote_notify_port=int(remote_notify_port),
-            tp_size=kv_transfer_params.get("tp_size", 1),
+            tp_size=kv_transfer_params.get(
+                "remote_tp_size", kv_transfer_params.get("tp_size", 1)
+            ),
             remote_dp_size=kv_transfer_params.get("remote_dp_size", 1),
+            mamba_local_block_ids=local_mamba_block_ids or [],
+            mamba_remote_block_ids=kv_transfer_params.get(
+                "remote_mamba_block_ids", []
+            )
+            or [],
         )
         if write_mode:
             self.reqs_to_save[request_id] = _req

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
@@ -48,6 +48,28 @@ class MoRIIOTransferAck(NamedTuple):
     consumer_tp_size: int = 1
 
 
+def as_attn_mamba(
+    block_ids: "list[int] | tuple | list | None",
+) -> "tuple[list[int], list[int]]":
+    """Unpack a carried block-ids value into (attention, mamba) block ids.
+
+    Hybrid (mamba/KDA) requests carry both halves in the SAME block-ids
+    channel as ``[attn_block_ids, mamba_block_ids]`` (a ``tuple[list[int],
+    ...]``), so the mamba recurrent-state slot rides the existing
+    ``remote_block_ids`` / notify / ReqMeta plumbing instead of a separate
+    wire field. A plain ``list[int]`` (attention-only / legacy) unpacks to
+    ``(that_list, [])``. Consumers on the worker/engine side split at the
+    point of use rather than threading a parallel mamba field through.
+    """
+    if not block_ids:
+        return [], []
+    if isinstance(block_ids[0], (list, tuple)):
+        attn = list(block_ids[0])
+        mamba = list(block_ids[1]) if len(block_ids) > 1 else []
+        return attn, mamba
+    return list(block_ids), []
+
+
 @dataclass
 class WriteTask:
     request_id: ReqId
@@ -61,8 +83,6 @@ class WriteTask:
     remote_ip: str
     enqueue_time: float = field(default_factory=time.perf_counter)
     retried: int = 0
-    # Local KDA recurrent-state slot ids for this write (empty for attention).
-    local_mamba_block_ids: list[int] = field(default_factory=list)
 
 
 @dataclass
@@ -94,10 +114,10 @@ class LayerTransferPlan:
 class RemoteAllocInfo:
     """Information about remote block allocation."""
 
-    block_ids: list[int]
-    # Remote KDA recurrent-state slot ids sent by the decoder (empty for
-    # attention-only models).
-    mamba_block_ids: list[int] = field(default_factory=list)
+    # Carried block ids: attention-only requests hold a flat ``list[int]``;
+    # hybrid requests hold ``[attn_block_ids, mamba_block_ids]`` (unpack with
+    # ``as_attn_mamba``), so the decoder's KDA slot rides this same field.
+    block_ids: list
     writes_done: int = 0
     writes_expected: int | None = None
     decode_dp_rank: int = 0
@@ -438,10 +458,6 @@ class ReqMeta:
     remote_engine_id: str
     tp_size: int
     remote_dp_size: int
-    # Hybrid (mamba/KDA) per-request recurrent-state slot ids; one logical
-    # slot per request. Empty for attention-only models.
-    mamba_local_block_ids: list[int] = field(default_factory=list)
-    mamba_remote_block_ids: list[int] = field(default_factory=list)
 
 
 class MoRIIOConnectorMetadata(KVConnectorMetadata):
@@ -465,7 +481,6 @@ class MoRIIOConnectorMetadata(KVConnectorMetadata):
         local_block_ids: list[int],
         kv_transfer_params: dict[str, Any],
         write_mode=False,
-        local_mamba_block_ids: list[int] | None = None,
     ):
         transfer_id = kv_transfer_params["transfer_id"]
 
@@ -494,15 +509,15 @@ class MoRIIOConnectorMetadata(KVConnectorMetadata):
             remote_port=int(remote_handshake_port),
             remote_handshake_port=int(remote_handshake_port),
             remote_notify_port=int(remote_notify_port),
+            # Use the REMOTE tp size for producer<->consumer rank mapping: the
+            # decode side must know the prefiller's TP degree to map producer
+            # ranks onto the correct decode rank (and vice versa). The old plain
+            # "tp_size" key defaulted to 1, collapsing every producer rank onto
+            # decode rank 0 and corrupting the transfer; prefer "remote_tp_size".
             tp_size=kv_transfer_params.get(
                 "remote_tp_size", kv_transfer_params.get("tp_size", 1)
             ),
             remote_dp_size=kv_transfer_params.get("remote_dp_size", 1),
-            mamba_local_block_ids=local_mamba_block_ids or [],
-            mamba_remote_block_ids=kv_transfer_params.get(
-                "remote_mamba_block_ids", []
-            )
-            or [],
         )
         if write_mode:
             self.reqs_to_save[request_id] = _req

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -21,6 +21,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorMetadata,
     KVConnectorRole,
+    SupportsHMA,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common import (
     ROLE,
@@ -50,12 +51,21 @@ from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_engine import (
     MoRIIOWriter,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_layout import (
+    kda_conv_ssm,
     LayerTransferGeometry,
+    apply_mamba_offset_template,
     build_layer_to_spec,
+    build_mamba_offset_template,
     compute_block_transfer_offsets,
+    compute_mamba_conv_split_count,
     get_layer_transfer_geometry,
     is_mla_cache_layer,
     iter_layer_registration_regions,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.ssm_conv_transfer_utils import (
+    MambaConvSplitInfo,
+    compute_physical_blocks_per_logical,
+    derive_mamba_conv_split,
 )
 from vllm.distributed.parallel_state import (
     get_tensor_model_parallel_world_size,
@@ -70,6 +80,7 @@ from vllm.utils.network_utils import (
 )
 from vllm.v1.attention.selector import get_attn_backend
 from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.kv_cache_interface import MambaSpec
 from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import RequestStatus
 
@@ -186,7 +197,7 @@ def resolve_moriio_transfer_ack(
     return transfer_id
 
 
-class MoRIIOConnector(KVConnectorBase_V1):
+class MoRIIOConnector(KVConnectorBase_V1, SupportsHMA):
     def __init__(
         self,
         vllm_config: VllmConfig,
@@ -209,7 +220,9 @@ class MoRIIOConnector(KVConnectorBase_V1):
         self.mode = get_moriio_mode(self.kv_transfer_config)
         if role == KVConnectorRole.SCHEDULER:
             self.connector_scheduler: MoRIIOConnectorScheduler | None = (
-                MoRIIOConnectorScheduler(vllm_config, self.engine_id)
+                MoRIIOConnectorScheduler(
+                    vllm_config, self.engine_id, kv_cache_config
+                )
             )
             self.connector_worker: MoRIIOConnectorWorker | None = None
         elif role == KVConnectorRole.WORKER:
@@ -271,6 +284,29 @@ class MoRIIOConnector(KVConnectorBase_V1):
         assert self.connector_scheduler is not None
         return self.connector_scheduler.request_finished(request, block_ids)
 
+    def request_finished_all_groups(
+        self,
+        request: "Request",
+        block_ids: tuple[list[int], ...],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        """SupportsHMA hook for hybrid (attention + mamba) models.
+
+        Receives per-KV-cache-group block ids. Splits them into attention
+        blocks and the mamba recurrent-state slot, runs the normal attention
+        completion path, then attaches the mamba slot to the returned
+        kv_transfer_params so the decoder can pull/receive the KDA state.
+        """
+        assert self.connector_scheduler is not None
+        attn_block_ids, mamba_block_ids = (
+            self.connector_scheduler.split_block_groups(block_ids)
+        )
+        delay_free, params = self.connector_scheduler.request_finished(
+            request, attn_block_ids
+        )
+        if params is not None and mamba_block_ids:
+            params["remote_mamba_block_ids"] = mamba_block_ids
+        return delay_free, params
+
     def update_connector_output(self, connector_output: KVConnectorOutput) -> None:
         assert self.connector_scheduler is not None
         self.connector_scheduler.update_connector_output(connector_output)
@@ -330,6 +366,17 @@ class MoRIIOConnector(KVConnectorBase_V1):
         )
         self.connector_worker.wait_for_save(self._connector_metadata)
 
+    def has_pending_push_work(self) -> bool:
+        """True while the WRITE-mode writer still has outstanding transfers.
+
+        KDA conv+ssm writes are scheduled from wait_for_save (not the per-layer
+        save_kv_layer hook), so the engine must keep stepping until every
+        scheduled write is finalized.
+        """
+        if self.connector_worker is not None:
+            return self.connector_worker.has_pending_push_work()
+        return False
+
     def shutdown(self):
         if self.connector_worker is not None:
             self.connector_worker.shutdown()
@@ -348,11 +395,41 @@ class MoRIIOConnector(KVConnectorBase_V1):
             return False
 
 
+def _split_kv_cache_group_kinds(
+    kv_cache_config: "KVCacheConfig | None",
+) -> tuple[list[int], list[int]]:
+    """Classify kv_cache_groups into (attention_group_indices,
+    mamba_group_indices) by whether each group's spec is a MambaSpec.
+    Returns empty lists when kv_cache_config is None (e.g. worker side).
+    """
+    attn: list[int] = []
+    mamba: list[int] = []
+    if kv_cache_config is not None:
+        from vllm.v1.kv_cache_interface import MambaSpec
+
+        for gi, group in enumerate(kv_cache_config.kv_cache_groups):
+            if isinstance(group.kv_cache_spec, MambaSpec):
+                mamba.append(gi)
+            else:
+                attn.append(gi)
+    return attn, mamba
+
+
 class MoRIIOConnectorScheduler:
     """Implementation of Scheduler side methods"""
 
-    def __init__(self, vllm_config: VllmConfig, engine_id: str):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        engine_id: str,
+        kv_cache_config: "KVCacheConfig | None" = None,
+    ):
         self.vllm_config = vllm_config
+        self.kv_cache_config = kv_cache_config
+        self._attn_group_ids, self._mamba_group_ids = (
+            _split_kv_cache_group_kinds(kv_cache_config)
+        )
+        self._has_mamba = bool(self._mamba_group_ids)
 
         assert vllm_config.kv_transfer_config is not None, (
             "kv_transfer_config must be set for MoRIIOConnector"
@@ -380,6 +457,10 @@ class MoRIIOConnectorScheduler:
         # the scheduler. Used to make metadata passed to Worker.
         self._reqs_need_recv: dict[ReqId, tuple[Request, list[int]]] = {}
         self._reqs_need_save: dict[ReqId, tuple[Request, list[int]]] = {}
+        # Per-request local mamba/KDA recurrent-state slot (one logical slot),
+        # kept alongside the attention block ids until the request is finalized
+        # into ReqMeta. Empty for attention-only models.
+        self._reqs_mamba_blocks: dict[ReqId, list[int]] = {}
 
         # For chunked prefill, we perform layer-wise access within the final chunk.
         # TODO: Perform transfer at end chunk.
@@ -448,15 +529,54 @@ class MoRIIOConnectorScheduler:
               asynchronously (between scheduler steps).
         """
         if self.is_producer:
+            # P side: for hybrid models the prefiller must stop at h(N-1) so
+            # the decoder can recompute the final token from the transferred
+            # recurrent state (reconciles with the READ len-1 accounting below).
+            if self._has_mamba:
+                params = request.kv_transfer_params
+                if params is not None and params.get("do_remote_decode"):
+                    self._truncate_mamba_request_for_prefill(request)
             return 0, False
 
         token_ids = request.prompt_token_ids or []
         if self.mode == MoRIIOMode.WRITE:
-            # MoriiO in write mode, no remote prefill
+            # MoriiO in write mode, no remote prefill.
+            num_tokens = len(token_ids)
+            if self._has_mamba and num_tokens > 0:
+                # Hybrid: the decoder recomputes the final token locally from
+                # the pushed KDA state, so only N-1 tokens come from remote.
+                num_tokens -= 1
+            return num_tokens - num_computed_tokens, True
 
-            return len(token_ids) - num_computed_tokens, True
-
+        # READ mode always recomputes the last token locally on the decoder.
         return len(token_ids) - 1 - num_computed_tokens, False
+
+    def _truncate_mamba_request_for_prefill(self, request: "Request") -> None:
+        """P-side only: drop the last prompt token so the prefiller computes
+        h(N-1) instead of h(N).
+
+        The decoder recomputes the last token locally to derive h(N) correctly
+        (see the READ len-1 accounting in get_num_new_matched_tokens). Guarded
+        by ``_p_side_truncated`` to avoid repeated truncation across a
+        preemption/reschedule. Mirrors the NIXL scheduler.
+        """
+        params = request.kv_transfer_params
+        if (
+            params is not None
+            and not params.get("_p_side_truncated")
+            and request.num_prompt_tokens > 1
+        ):
+            if request.prompt_token_ids is not None:
+                request.prompt_token_ids.pop()
+            elif request.prompt_embeds is not None:
+                request.prompt_embeds = request.prompt_embeds[:-1]
+            else:
+                return
+
+            request._all_token_ids.pop()
+            request.num_prompt_tokens -= 1
+            request.max_tokens = 1
+            params["_p_side_truncated"] = True
 
     def send_notify_block(
         self,
@@ -465,6 +585,7 @@ class MoRIIOConnectorScheduler:
         block_notify_list: list[int],
         host=None,
         port=None,
+        mamba_block_notify_list: list[int] | None = None,
     ):
         path = make_zmq_path("tcp", host, port)
         if path not in self.paths:
@@ -478,6 +599,7 @@ class MoRIIOConnectorScheduler:
             "req_id": req_id,
             "transfer_id": transfer_id,
             "block_notify_list": block_notify_list or [],
+            "mamba_block_notify_list": mamba_block_notify_list or [],
             "decode_rank": self.dp_rank,
             "type": "remote_blocks",
         }
@@ -541,8 +663,12 @@ class MoRIIOConnectorScheduler:
         request_id = request.request_id
         self.map_request_id(request_id, transfer_id)
         if params.get("do_remote_decode"):
-            local_block_ids = blocks.get_block_ids()[0]
-            self._reqs_need_save[request.request_id] = (request, local_block_ids)
+            attn_block_ids, mamba_block_ids = self.split_block_groups(
+                blocks.get_block_ids()
+            )
+            self._reqs_need_save[request.request_id] = (request, attn_block_ids)
+            if mamba_block_ids:
+                self._reqs_mamba_blocks[request.request_id] = mamba_block_ids
 
         if params is not None and params.get("do_remote_prefill"):
             if self.mode == MoRIIOMode.READ:
@@ -552,12 +678,19 @@ class MoRIIOConnectorScheduler:
                     if "remote_engine_id" in params:
                         if num_external_tokens > 0:
                             # Get unhashed blocks to pull from remote.
-                            local_block_ids = blocks.get_block_ids()[0]
+                            attn_block_ids, mamba_block_ids = self.split_block_groups(
+                                blocks.get_block_ids()
+                            )
+                            local_block_ids = attn_block_ids
                             assert len(local_block_ids) <= len(remote_block_ids)
                             if len(local_block_ids) != len(remote_block_ids):
                                 local_block_ids = remote_block_ids[
                                     -len(local_block_ids) :
                                 ]
+                            if mamba_block_ids:
+                                self._reqs_mamba_blocks[request.request_id] = (
+                                    mamba_block_ids
+                                )
                         else:
                             # If remote_blocks and num_external_tokens = 0, we have
                             # a full prefix cache hit on the D worker. We need to call
@@ -597,9 +730,12 @@ class MoRIIOConnectorScheduler:
 
                 # num_external_tokens == 0: nothing to push, so don't tell the
                 # producer to write into these blocks.
-                block_notify_list = (
-                    blocks.get_block_ids()[0] if num_external_tokens > 0 else []
-                )
+                if num_external_tokens > 0:
+                    block_notify_list, mamba_block_notify_list = (
+                        self.split_block_groups(blocks.get_block_ids())
+                    )
+                else:
+                    block_notify_list, mamba_block_notify_list = [], []
 
                 for tp_index in range(self.tp_size):
                     target_port = remote_notify_port + get_port_offset(
@@ -612,6 +748,7 @@ class MoRIIOConnectorScheduler:
                         block_notify_list=block_notify_list,
                         host=remote_host,
                         port=target_port,
+                        mamba_block_notify_list=mamba_block_notify_list,
                     )
 
             # Only trigger 1 KV transfer per request.
@@ -634,11 +771,14 @@ class MoRIIOConnectorScheduler:
                 new_block_ids = scheduler_output.scheduled_cached_reqs.new_block_ids[i]
 
                 if new_block_ids is not None:
-                    block_ids = new_block_ids[0]
-                    # TODO : hybrid attn, etc
+                    attn_block_ids, mamba_block_ids = self.split_block_groups(
+                        new_block_ids
+                    )
                     req, existing_blocks = self._reqs_need_pending_save[req_id]
-                    updated_blocks = list(existing_blocks) + (block_ids)
+                    updated_blocks = list(existing_blocks) + attn_block_ids
                     self._reqs_need_pending_save[req_id] = (req, updated_blocks)
+                    if mamba_block_ids:
+                        self._reqs_mamba_blocks[req_id] = mamba_block_ids
                     if (
                         len(self._reqs_need_pending_save[req_id][1]) * self.block_size
                         >= req.num_prompt_tokens
@@ -648,6 +788,9 @@ class MoRIIOConnectorScheduler:
                             local_block_ids=self._reqs_need_pending_save[req_id][1],
                             kv_transfer_params=req.kv_transfer_params or {},
                             write_mode=True,
+                            local_mamba_block_ids=self._reqs_mamba_blocks.pop(
+                                req_id, None
+                            ),
                         )
                         del self._reqs_need_pending_save[req_id]
 
@@ -658,12 +801,13 @@ class MoRIIOConnectorScheduler:
                 request_id=req_id,
                 local_block_ids=block_ids,
                 kv_transfer_params=req.kv_transfer_params,
+                local_mamba_block_ids=self._reqs_mamba_blocks.pop(req_id, None),
             )
 
         for req_id, (req, block_ids) in self._reqs_need_save.items():
             assert req.kv_transfer_params is not None
             if req.num_prompt_tokens > len(block_ids) * self.block_size:
-                # not last chunk prefill
+                # not last chunk prefill; keep the mamba slot for the final chunk
                 self._reqs_need_pending_save[req_id] = (req, block_ids)
                 continue
             meta.add_new_req(
@@ -671,6 +815,7 @@ class MoRIIOConnectorScheduler:
                 local_block_ids=block_ids,
                 kv_transfer_params=req.kv_transfer_params,
                 write_mode=True,
+                local_mamba_block_ids=self._reqs_mamba_blocks.pop(req_id, None),
             )
         # Clear the list once workers start the transfers
 
@@ -690,6 +835,28 @@ class MoRIIOConnectorScheduler:
             except Exception as e:
                 logger.warning("Error closing ZMQ socket for path %s: %s", path, e)
         self.paths.clear()
+
+    def split_block_groups(
+        self, block_ids: "tuple[list[int], ...]"
+    ) -> tuple[list[int], list[int]]:
+        """Split per-group block ids into (attention_blocks, mamba_slots).
+
+        Attention groups are concatenated into one flat list; mamba groups
+        into the single recurrent-state slot list. For a pure-attention
+        model the mamba list is empty and this reduces to the previous
+        ``block_ids[0]`` behavior.
+        """
+        if not self._has_mamba:
+            first = block_ids[0] if block_ids else []
+            return list(first), []
+        attn: list[int] = []
+        mamba: list[int] = []
+        for gi, group in enumerate(block_ids):
+            if gi in self._mamba_group_ids:
+                mamba.extend(group)
+            else:
+                attn.extend(group)
+        return attn, mamba
 
     def request_finished(
         self,
@@ -1021,6 +1188,15 @@ class MoRIIOConnectorWorker:
 
         self.block_window_per_layer: list[int | None] = []
         self.use_mla = self.model_config.use_mla
+        # Hybrid (mamba/KDA) recurrent-state transfer. Populated in
+        # register_kv_caches when the model has a MambaSpec kv_cache group.
+        self._has_mamba = False
+        self._conv_decomp: MambaConvSplitInfo | None = None
+        self._mamba_ssm_size: tuple[int, int] = (0, 0)
+        self._physical_blocks_per_logical = 1
+        # layer_name -> flat session indices (one per registered region:
+        # 1 for attention, 2 (conv, ssm) for a KDA layer). Built once lazily.
+        self._region_session_index: dict[str, list[int]] | None = None
         self.built_session = False
         self.built_write_session: defaultdict[str, list] = defaultdict(list)
         backend = get_attn_backend(
@@ -1056,6 +1232,7 @@ class MoRIIOConnectorWorker:
         kv_layer: torch.Tensor,
         remote_notify_port: int,
         remote_ip: str,
+        local_mamba_block_ids: list[int] | None = None,
     ) -> None:
         """Schedule a block write operation.
 
@@ -1090,28 +1267,33 @@ class MoRIIOConnectorWorker:
             event=event,
             remote_notify_port=remote_notify_port,
             remote_ip=remote_ip,
+            local_mamba_block_ids=local_mamba_block_ids or [],
         )
         self._writer.schedule_write(task)
 
     def _get_built_session(self, remote_engine_id):
         if remote_engine_id not in self.built_write_session:
             cur_remote_engine_sessions = []
-            for ln, local_meta in self.layer_name_to_local_kv_cache_metadata.items():
-                unpacked_local_memory_meta = (
-                    self.moriio_wrapper.get_unpack_memory_metadata(local_meta[0])
-                )
-                unpacked_remote_memory_meta = (
-                    self.moriio_wrapper.get_unpack_memory_metadata(
-                        self.layer_name_to_remote_kv_cache_metadata[remote_engine_id][
-                            ln
-                        ][0]
+            for ln, local_metas in self.layer_name_to_local_kv_cache_metadata.items():
+                remote_metas = self.layer_name_to_remote_kv_cache_metadata[
+                    remote_engine_id
+                ][ln]
+                # One session per registered region, in registration order:
+                # attention layers have a single region; KDA layers have two
+                # (conv then ssm). This flat layout is indexed via
+                # _region_session_indices(layer_name).
+                for local_meta, remote_meta in zip(local_metas, remote_metas):
+                    unpacked_local_memory_meta = (
+                        self.moriio_wrapper.get_unpack_memory_metadata(local_meta)
                     )
-                )
-                cur_remote_engine_sessions.append(
-                    self.moriio_wrapper.build_session(
-                        unpacked_local_memory_meta, unpacked_remote_memory_meta
+                    unpacked_remote_memory_meta = (
+                        self.moriio_wrapper.get_unpack_memory_metadata(remote_meta)
                     )
-                )
+                    cur_remote_engine_sessions.append(
+                        self.moriio_wrapper.build_session(
+                            unpacked_local_memory_meta, unpacked_remote_memory_meta
+                        )
+                    )
             self.built_write_session[remote_engine_id] = cur_remote_engine_sessions
         return self.built_write_session[remote_engine_id], self.remote_moriio_metadata[
             remote_engine_id
@@ -1393,6 +1575,46 @@ class MoRIIOConnectorWorker:
     def _is_mla_cache_layer(self, layer_name: str) -> bool:
         return is_mla_cache_layer(self.layer_to_spec, layer_name)
 
+    def _is_mamba_layer(self, layer_name: str) -> bool:
+        """True for a hybrid/KDA layer whose cache is a (conv, ssm) tuple."""
+        return isinstance(self.layer_to_spec.get(layer_name), MambaSpec)
+
+    @staticmethod
+    def _contiguous_byte_alias(tensor: torch.Tensor) -> torch.Tensor:
+        """Return a contiguous uint8 view over ``tensor``'s full byte extent.
+
+        KDA conv/ssm caches are slot-strided views (``stride(0)`` may exceed the
+        per-slot element count), so they are non-contiguous and cannot be passed
+        to ``register_torch_tensor``. This aliases the same storage (zero-copy,
+        identical ``data_ptr``) as a flat uint8 tensor spanning
+        ``shape[0] * stride(0)`` elements -- the full slot-strided extent that
+        transfer offsets (``slot * stride(0) * elem``) address.
+        """
+        esz = tensor.element_size()
+        storage_nbytes = tensor.untyped_storage().nbytes()
+        offset_bytes = tensor.storage_offset() * esz
+        extent_bytes = tensor.shape[0] * tensor.stride(0) * esz
+        # Clamp to the bytes remaining from the view's storage offset. A shared
+        # conv+ssm page buffer (dev19253 packed layout) places ssm at a
+        # non-zero intra-buffer offset whose slot-strided extent
+        # (shape[0]*stride(0)) would otherwise run past the buffer end; the
+        # clamp still covers every slot (the last slot ends at the buffer end).
+        # For separate buffers (offset 0, full storage) this is a no-op.
+        extent_bytes = min(extent_bytes, storage_nbytes - offset_bytes)
+        assert extent_bytes > 0, (
+            "KDA byte alias empty: storage_offset="
+            f"{tensor.storage_offset()} * esz={esz} >= "
+            f"storage_nbytes={storage_nbytes}"
+        )
+        alias = torch.empty(0, dtype=torch.uint8, device=tensor.device)
+        alias.set_(
+            tensor.untyped_storage(),
+            tensor.storage_offset() * esz,
+            (extent_bytes,),
+            (1,),
+        )
+        return alias
+
     def _get_layer_transfer_geometry(
         self, layer_name: str, remote_num_blocks: int | None = None
     ) -> LayerTransferGeometry:
@@ -1416,21 +1638,32 @@ class MoRIIOConnectorWorker:
         """Register the KV Cache data in moriio."""
 
         self.kv_caches = kv_caches  # layer name to kv cache
+        # KDA layers store a (conv, ssm) tuple which has no `.shape`; only
+        # record shapes for attention tensors.
         self.kv_cache_shapes = {
-            layer_name: kv_cache.shape for layer_name, kv_cache in kv_caches.items()
+            layer_name: kv_cache.shape
+            for layer_name, kv_cache in kv_caches.items()
+            if not self._is_mamba_layer(layer_name)
         }
 
+        # Geometry selection must pick an attention layer (never a KDA tuple):
+        # prefer a standard 5-D K/V layer, else the first attention layer.
+        attn_items = [
+            (layer_name, kv_cache)
+            for layer_name, kv_cache in kv_caches.items()
+            if not self._is_mamba_layer(layer_name)
+        ]
         first_layer_name, first_kv_cache = next(
             (
                 (layer_name, kv_cache)
-                for layer_name, kv_cache in kv_caches.items()
+                for layer_name, kv_cache in attn_items
                 if (
                     not self._is_mla_cache_layer(layer_name)
                     and len(kv_cache.shape) == 5
                     and (kv_cache.shape[0] == 2 or kv_cache.shape[1] == 2)
                 )
             ),
-            next(iter(kv_caches.items())),
+            attn_items[0] if attn_items else next(iter(kv_caches.items())),
         )
         kv_elem_size = first_kv_cache.element_size()
 
@@ -1461,6 +1694,16 @@ class MoRIIOConnectorWorker:
         caches_data = []
 
         for layer_name in kv_caches:
+            if self._is_mamba_layer(layer_name):
+                # KDA layer: two whole-tensor regions (conv, ssm); no block-size
+                # geometry (recurrent state is per-slot, not paged).
+                for cache, region_len in self._iter_layer_registration_regions(
+                    layer_name
+                ):
+                    base_addr = cache.data_ptr()
+                    caches_data.append((base_addr, region_len, cache.device.index, ""))
+                    kv_caches_base_addr.append(base_addr)
+                continue
             geometry = self._get_layer_transfer_geometry(layer_name)
             if geometry.block_size != self.block_size:
                 raise ValueError(
@@ -1477,18 +1720,74 @@ class MoRIIOConnectorWorker:
             if layer_name not in self.layer_name_to_local_kv_cache_metadata:
                 self.layer_name_to_local_kv_cache_metadata[layer_name] = []
 
-            moriio_mem_metadata = self.moriio_wrapper.register_local_tensor(kv_cache)
-            self.layer_name_to_local_kv_cache_metadata[layer_name].append(
-                moriio_mem_metadata
-            )
-
-            self.local_kv_cache_size.append(
-                kv_cache.nelement() * kv_cache.element_size()
-            )
+            if self._is_mamba_layer(layer_name):
+                # Register conv and ssm as two whole-tensor regions, appending
+                # both metadata blobs (order: conv then ssm) so the session
+                # layout matches iter_layer_registration_regions. conv/ssm are
+                # slot-strided views and are not contiguous, which
+                # register_torch_tensor rejects; register a contiguous uint8
+                # alias over each tensor's full byte extent instead (zero-copy:
+                # same storage and data_ptr).
+                conv, ssm = kda_conv_ssm(kv_cache, self.layer_to_spec.get(layer_name))
+                logger.debug(
+                    "MoRIIO KDA register %s: conv shape=%s stride=%s contig=%s "
+                    "storage_nbytes=%s ; ssm shape=%s stride=%s contig=%s "
+                    "storage_nbytes=%s",
+                    layer_name,
+                    tuple(conv.shape), tuple(conv.stride()),
+                    conv.is_contiguous(), conv.untyped_storage().nbytes(),
+                    tuple(ssm.shape), tuple(ssm.stride()),
+                    ssm.is_contiguous(), ssm.untyped_storage().nbytes(),
+                )
+                for tensor in (conv, ssm):
+                    alias = self._contiguous_byte_alias(tensor)
+                    meta = self.moriio_wrapper.register_local_tensor(alias)
+                    self.layer_name_to_local_kv_cache_metadata[layer_name].append(meta)
+                    self.local_kv_cache_size.append(alias.numel())
+            else:
+                moriio_mem_metadata = self.moriio_wrapper.register_local_tensor(
+                    kv_cache
+                )
+                self.layer_name_to_local_kv_cache_metadata[layer_name].append(
+                    moriio_mem_metadata
+                )
+                self.local_kv_cache_size.append(
+                    kv_cache.nelement() * kv_cache.element_size()
+                )
 
         self.kv_caches_base_addr[self.engine_id] = kv_caches_base_addr
         self.num_regions = len(caches_data)
         self.num_layers = len(self.kv_caches.keys())
+
+        # Derive the KDA conv sub-projection decomposition and ssm sizes once,
+        # shared across all KDA layers (all GDN layers are homogeneous).
+        self._has_mamba = any(
+            self._is_mamba_layer(layer_name) for layer_name in kv_caches
+        )
+        if self._has_mamba:
+            from vllm.model_executor.layers.mamba.mamba_utils import (
+                is_conv_state_dim_first,
+            )
+
+            assert is_conv_state_dim_first(), (
+                "MoRIIO KDA conv transfer requires the DS (dim-first) conv "
+                "state layout; set VLLM_SSM_CONV_STATE_LAYOUT=DS."
+            )
+            mamba_spec = next(
+                spec
+                for spec in self.layer_to_spec.values()
+                if isinstance(spec, MambaSpec)
+            )
+            self._conv_decomp = derive_mamba_conv_split(mamba_spec, self.world_size)
+            self._mamba_ssm_size = self._conv_decomp.ssm_sizes
+            self._physical_blocks_per_logical = compute_physical_blocks_per_logical(
+                self._mamba_ssm_size, self.block_len
+            )
+            logger.info(
+                "MoRIIO registered %d KDA (conv+ssm) layer(s); ssm sizes=%s",
+                sum(1 for ln in kv_caches if self._is_mamba_layer(ln)),
+                self._mamba_ssm_size,
+            )
 
         # Optimization for models with local attention (Llama 4)
         if self.vllm_config.model_config.hf_config.model_type == "llama4":
@@ -1615,6 +1914,10 @@ class MoRIIOConnectorWorker:
             self._unmatched_write_completions -= matched_xfer_ids
 
         return done_sending, done_recving
+
+    def has_pending_push_work(self) -> bool:
+        """True while the WRITE writer has scheduled transfers pending."""
+        return self._writer.has_outstanding_writes()
 
     def _pop_done_transfers(self) -> set[str]:
         done_req_ids: set[str] = set()
@@ -1824,6 +2127,8 @@ class MoRIIOConnectorWorker:
             remote_host=meta.remote_host,
             remote_notify_port=meta.remote_notify_port,
             remote_tp_size=meta.tp_size,
+            local_mamba_block_ids=meta.mamba_local_block_ids,
+            remote_mamba_block_ids=meta.mamba_remote_block_ids,
         )
 
     def _write_blocks_for_req(self, req_id: ReqId, meta: ReqMeta, layer_name, kv_layer):
@@ -1837,6 +2142,7 @@ class MoRIIOConnectorWorker:
             kv_layer=kv_layer,
             remote_notify_port=meta.remote_notify_port,
             remote_ip=meta.remote_host,
+            local_mamba_block_ids=meta.mamba_local_block_ids,
         )
 
     def merge_contiguous_blocks(
@@ -1949,6 +2255,121 @@ class MoRIIOConnectorWorker:
             ),
         )
 
+    def _region_session_indices(self, layer_name: str) -> list[int]:
+        """Flat session indices for a layer's registered regions.
+
+        Sessions are built one per region in registration order (see
+        _get_built_session), so an attention layer maps to a single index and a
+        KDA layer to two indices ([conv, ssm]). Built once and cached.
+        """
+        if self._region_session_index is None:
+            mapping: dict[str, list[int]] = {}
+            idx = 0
+            for ln, metas in self.layer_name_to_local_kv_cache_metadata.items():
+                mapping[ln] = list(range(idx, idx + len(metas)))
+                idx += len(metas)
+            self._region_session_index = mapping
+        return self._region_session_index[layer_name]
+
+    def _mamba_tp_ratio(self, remote_tp_size: int | None) -> int:
+        """Signed conv/ssm TP ratio for KDA recurrent state.
+
+        Mirrors MambaConvSplitInfo.remote_conv_offsets semantics for the READ
+        direction (this decode rank reads from a prefill rank): >= 1 when
+        D_TP >= P_TP (the remote/prefill page is larger and this rank reads its
+        slice), < 0 when P_TP > D_TP. Homogeneous TP yields 1.
+        """
+        remote = remote_tp_size or self.world_size
+        local = self.world_size
+        if local >= remote:
+            return local // remote
+        return -(remote // local)
+
+    def _compute_mamba_transfer_offsets(
+        self,
+        layer_name: str,
+        local_slots: list[int],
+        remote_slots: list[int],
+        remote_tp_size: int | None = None,
+    ) -> tuple[list[int], list[int], list[int], int]:
+        """Compute (local, remote, sizes, n_conv) for a KDA layer.
+
+        Entries [:n_conv] address the conv region/session; entries [n_conv:]
+        address the ssm region/session.
+        """
+        assert self._conv_decomp is not None, "KDA decomposition not derived"
+        conv, ssm = kda_conv_ssm(
+            self.kv_caches[layer_name], self.layer_to_spec.get(layer_name)
+        )
+        tp_ratio = self._mamba_tp_ratio(remote_tp_size)
+        # KDA geometry is homogeneous across the ~69 GDN layers and every
+        # request, so cache the slot-independent offset template per
+        # (layer, tp_ratio) and only apply the per-request slot bases here.
+        # apply_mamba_offset_template is defined so its output is byte-identical
+        # to compute_mamba_conv_ssm_offsets (see the cached==recomputed test).
+        cache = getattr(self, "_mamba_offset_templates", None)
+        if cache is None:
+            cache = {}
+            self._mamba_offset_templates = cache
+        cache_key = (layer_name, tp_ratio)
+        template = cache.get(cache_key)
+        if template is None:
+            template = build_mamba_offset_template(
+                layer_name,
+                conv,
+                ssm,
+                self.layer_to_spec,
+                self._conv_decomp,
+                tp_ratio,
+                self.tp_rank,
+                self.world_size,
+            )
+            cache[cache_key] = template
+        local_offs, remote_offs, sizes = apply_mamba_offset_template(
+            template, local_slots, remote_slots
+        )
+        n_conv = compute_mamba_conv_split_count(local_slots, self._conv_decomp)
+        return local_offs, remote_offs, sizes, n_conv
+
+    def _post_read_with_backoff(
+        self,
+        session,
+        sizes: list[int],
+        local_offsets: list[int],
+        remote_offsets: list[int],
+        request_id: str,
+        layer_name: str,
+        deadline: float,
+    ):
+        """Post one RDMA READ, backing off on transient SQ-full rejection.
+
+        read_remote_data posts synchronously, so a send-queue-full rejection is
+        a Failed() status on return; a separate CQ-poll thread drains
+        completions and frees SQ depth, so we back off and re-post until
+        transfer_timeout, then store the failed status (get_finished notifies
+        prefill and drops the request non-fatally).
+        """
+        _backoff = 0.001
+        while True:
+            transfer_status = self.moriio_wrapper.read_remote_data(
+                sizes, local_offsets, remote_offsets, session
+            )
+            if not self._is_sq_full_status(transfer_status):
+                break
+            if time.monotonic() > deadline:
+                logger.warning(
+                    "MoRIIO READ send queue stayed full past "
+                    "transfer_timeout for req %s layer %s; storing failed "
+                    "status (get_finished notifies prefill and drops the "
+                    "request). Raise qp_per_transfer if frequent.",
+                    request_id,
+                    layer_name,
+                )
+                break
+            time.sleep(_backoff)
+            _backoff = min(_backoff * 2, 0.05)
+        return transfer_status
+
     @staticmethod
     def _is_sq_full_status(status) -> bool:
         """True if a MoRIIO transfer status is a transient RDMA send-queue-full
@@ -1976,6 +2397,8 @@ class MoRIIOConnectorWorker:
         remote_host: str,
         remote_notify_port: int,
         remote_tp_size: int,
+        local_mamba_block_ids: list[int] | None = None,
+        remote_mamba_block_ids: list[int] | None = None,
     ) -> None:
         if self.mode == MoRIIOMode.WRITE:
             return
@@ -1985,49 +2408,67 @@ class MoRIIOConnectorWorker:
 
         # SQ-full backpressure deadline, shared across this request's layers.
         _sq_deadline = time.monotonic() + self.moriio_config.transfer_timeout
+        # TODO : apply multi-session batch-read when moriio support it
         for layer_name in self.layer_name_to_local_kv_cache_metadata:
-            sess_idx = list(self.layer_name_to_local_kv_cache_metadata.keys()).index(
-                layer_name
-            )
-            offs = self._compute_block_transfer_offsets(
-                layer_name,
-                local_block_ids,
-                remote_block_ids,
-                remote_moriio_meta,
-                remote_tp_size=remote_tp_size,
-            )
-            # TODO : apply multi-session batch-read when moriio support it
-            #
-            # SQ-full backpressure: read_remote_data posts the RDMA READ
-            # SYNCHRONOUSLY, so a send-queue-full rejection (per-QP HW cap) comes
-            # back as a Failed() status right here. A SEPARATE CQ-poll thread
-            # drains completions and frees SQ depth, so back off and RE-POST
-            # rather than let a transient rejection abort the request. No
-            # self-deadlock (the drain is off-thread); the reserve is
-            # all-or-nothing (nothing posted on a rejected attempt). Bounded by
-            # transfer_timeout; on sustained overload store the failed status and
-            # let get_finished handle it non-fatally (notify prefill + drop).
-            _backoff = 0.001
-            while True:
-                transfer_status = self.moriio_wrapper.read_remote_data(
-                    offs[2], offs[0], offs[1], sessions[sess_idx]
+            region_sessions = self._region_session_indices(layer_name)
+            statuses = []
+            if self._is_mamba_layer(layer_name):
+                # KDA layer: pull conv (sub-projection offsets) and ssm at the
+                # request's recurrent-state slot. Two regions -> two sessions.
+                if not local_mamba_block_ids or not remote_mamba_block_ids:
+                    continue
+                m_local, m_remote, m_sizes, n_conv = (
+                    self._compute_mamba_transfer_offsets(
+                        layer_name,
+                        local_mamba_block_ids,
+                        remote_mamba_block_ids,
+                        remote_tp_size=remote_tp_size,
+                    )
                 )
-                if not self._is_sq_full_status(transfer_status):
-                    break
-                if time.monotonic() > _sq_deadline:
-                    logger.warning(
-                        "MoRIIO READ send queue stayed full past "
-                        "transfer_timeout for req %s layer %s; storing failed "
-                        "status (get_finished notifies prefill and drops the "
-                        "request). Raise qp_per_transfer if frequent.",
+                region_slices = (
+                    (region_sessions[0], slice(0, n_conv)),
+                    (region_sessions[1], slice(n_conv, None)),
+                )
+                for sess_idx, sl in region_slices:
+                    sizes, local_offs, remote_offs = (
+                        m_sizes[sl],
+                        m_local[sl],
+                        m_remote[sl],
+                    )
+                    if not sizes:
+                        continue
+                    statuses.append(
+                        self._post_read_with_backoff(
+                            sessions[sess_idx],
+                            sizes,
+                            local_offs,
+                            remote_offs,
+                            request_id,
+                            layer_name,
+                            _sq_deadline,
+                        )
+                    )
+            else:
+                offs = self._compute_block_transfer_offsets(
+                    layer_name,
+                    local_block_ids,
+                    remote_block_ids,
+                    remote_moriio_meta,
+                    remote_tp_size=remote_tp_size,
+                )
+                statuses.append(
+                    self._post_read_with_backoff(
+                        sessions[region_sessions[0]],
+                        offs[2],
+                        offs[0],
+                        offs[1],
                         request_id,
                         layer_name,
+                        _sq_deadline,
                     )
-                    break
-                time.sleep(_backoff)
-                _backoff = min(_backoff * 2, 0.05)
+                )
             with self.moriio_wrapper.lock:
-                self._recving_transfers[request_id].append(transfer_status)
+                self._recving_transfers[request_id].extend(statuses)
                 self._recving_transfers_callback_addr[request_id] = (
                     remote_host,
                     str(remote_notify_port + self._remote_tp_rank(remote_tp_size)),

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -31,12 +31,14 @@ from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common import (
     MoRIIOConfig,
     MoRIIOConnectorMetadata,
     MoRIIOConstants,
+    MoRIIOError,
     MoRIIOMode,
     MoRIIOTransferAck,
     ReqId,
     ReqMeta,
     TransferId,
     WriteTask,
+    as_attn_mamba,
     get_moriio_mode,
     get_peer_zmq_from_request_id,
     get_port_offset,
@@ -300,11 +302,15 @@ class MoRIIOConnector(KVConnectorBase_V1, SupportsHMA):
         attn_block_ids, mamba_block_ids = (
             self.connector_scheduler.split_block_groups(block_ids)
         )
+        # Drive the completion path with the attention blocks, but carry the
+        # mamba/KDA recurrent-state slot in the SAME remote_block_ids channel
+        # (as [attn, mamba]) rather than a separate wire field, so the
+        # proxy/router need no KDA-specific field.
         delay_free, params = self.connector_scheduler.request_finished(
             request, attn_block_ids
         )
         if params is not None and mamba_block_ids:
-            params["remote_mamba_block_ids"] = mamba_block_ids
+            params["remote_block_ids"] = [attn_block_ids, mamba_block_ids]
         return delay_free, params
 
     def update_connector_output(self, connector_output: KVConnectorOutput) -> None:
@@ -455,16 +461,16 @@ class MoRIIOConnectorScheduler:
         # Requests that need to start recv/send.
         # New requests are added by update_state_after_alloc in
         # the scheduler. Used to make metadata passed to Worker.
-        self._reqs_need_recv: dict[ReqId, tuple[Request, list[int]]] = {}
-        self._reqs_need_save: dict[ReqId, tuple[Request, list[int]]] = {}
-        # Per-request local mamba/KDA recurrent-state slot (one logical slot),
-        # kept alongside the attention block ids until the request is finalized
-        # into ReqMeta. Empty for attention-only models.
-        self._reqs_mamba_blocks: dict[ReqId, list[int]] = {}
+        # Values carry the request's block ids: a flat list[int] for
+        # attention-only models, or [attn_block_ids, mamba_block_ids] for
+        # hybrid (mamba/KDA) models (unpack with as_attn_mamba). The mamba
+        # recurrent-state slot rides here instead of a parallel dict.
+        self._reqs_need_recv: dict[ReqId, tuple[Request, list]] = {}
+        self._reqs_need_save: dict[ReqId, tuple[Request, list]] = {}
 
         # For chunked prefill, we perform layer-wise access within the final chunk.
         # TODO: Perform transfer at end chunk.
-        self._reqs_need_pending_save: dict[ReqId, tuple[Request, list[int]]] = {}
+        self._reqs_need_pending_save: dict[ReqId, tuple[Request, list]] = {}
 
         if self.is_producer:
             set_role(ROLE.PRODUCER)
@@ -582,10 +588,9 @@ class MoRIIOConnectorScheduler:
         self,
         req_id: ReqId,
         transfer_id: TransferId,
-        block_notify_list: list[int],
+        block_notify_list: list,
         host=None,
         port=None,
-        mamba_block_notify_list: list[int] | None = None,
     ):
         path = make_zmq_path("tcp", host, port)
         if path not in self.paths:
@@ -599,7 +604,6 @@ class MoRIIOConnectorScheduler:
             "req_id": req_id,
             "transfer_id": transfer_id,
             "block_notify_list": block_notify_list or [],
-            "mamba_block_notify_list": mamba_block_notify_list or [],
             "decode_rank": self.dp_rank,
             "type": "remote_blocks",
         }
@@ -666,9 +670,11 @@ class MoRIIOConnectorScheduler:
             attn_block_ids, mamba_block_ids = self.split_block_groups(
                 blocks.get_block_ids()
             )
-            self._reqs_need_save[request.request_id] = (request, attn_block_ids)
-            if mamba_block_ids:
-                self._reqs_mamba_blocks[request.request_id] = mamba_block_ids
+            # Carry attn + mamba together in the single block-ids channel.
+            self._reqs_need_save[request.request_id] = (
+                request,
+                [attn_block_ids, mamba_block_ids],
+            )
 
         if params is not None and params.get("do_remote_prefill"):
             if self.mode == MoRIIOMode.READ:
@@ -676,26 +682,34 @@ class MoRIIOConnectorScheduler:
                     # remote_engine_id is returned by the prefill's request_finished.
                     # host/ports come from the request_id (parsed in add_new_req).
                     if "remote_engine_id" in params:
+                        # remote_block_ids carries [attn, mamba] (hybrid) or a
+                        # flat attn list; compare/trim on the attention half.
+                        remote_attn, _ = as_attn_mamba(remote_block_ids)
                         if num_external_tokens > 0:
                             # Get unhashed blocks to pull from remote.
                             attn_block_ids, mamba_block_ids = self.split_block_groups(
                                 blocks.get_block_ids()
                             )
-                            local_block_ids = attn_block_ids
-                            assert len(local_block_ids) <= len(remote_block_ids)
-                            if len(local_block_ids) != len(remote_block_ids):
-                                local_block_ids = remote_block_ids[
-                                    -len(local_block_ids) :
-                                ]
-                            if mamba_block_ids:
-                                self._reqs_mamba_blocks[request.request_id] = (
-                                    mamba_block_ids
-                                )
+                            local_attn = attn_block_ids
+                            assert len(local_attn) <= len(remote_attn)
+                            if len(local_attn) != len(remote_attn):
+                                local_attn = remote_attn[-len(local_attn) :]
+                            local_block_ids = [local_attn, mamba_block_ids]
                         else:
-                            # If remote_blocks and num_external_tokens = 0, we have
-                            # a full prefix cache hit on the D worker. We need to call
-                            # send_notify in _read_blocks to free the memory on the P.
-                            local_block_ids = []
+                            # Attention needs no pull (full prefix-cache hit, or
+                            # the len-1 READ accounting yields zero external attn
+                            # tokens), but the per-request KDA recurrent (conv+ssm)
+                            # state is NOT prefix-cacheable and must ALWAYS be
+                            # transferred. Carry the mamba slot with an empty
+                            # attention half; only a pure-attention model (no mamba
+                            # group) collapses to []. _read_blocks still notifies P
+                            # to free memory.
+                            _, mamba_block_ids = self.split_block_groups(
+                                blocks.get_block_ids()
+                            )
+                            local_block_ids = (
+                                [[], mamba_block_ids] if mamba_block_ids else []
+                            )
 
                         self._reqs_need_recv[request.request_id] = (
                             request,
@@ -728,14 +742,27 @@ class MoRIIOConnectorScheduler:
                     )
                 remote_notify_port = int(remote_notify_port)
 
-                # num_external_tokens == 0: nothing to push, so don't tell the
-                # producer to write into these blocks.
+                # Attention may need nothing pushed (cache hit / len-1 accounting),
+                # but the per-request KDA recurrent state is not prefix-cacheable
+                # and must still be pushed. With attn tokens, notify [attn, mamba];
+                # otherwise notify just the mamba slot so the producer still writes
+                # the recurrent state into the decoder's blocks.
                 if num_external_tokens > 0:
-                    block_notify_list, mamba_block_notify_list = (
-                        self.split_block_groups(blocks.get_block_ids())
+                    attn_notify, mamba_notify = self.split_block_groups(
+                        blocks.get_block_ids()
+                    )
+                    # One block-ids channel: attn + mamba together (or flat attn
+                    # when there is no mamba group).
+                    block_notify_list = (
+                        [attn_notify, mamba_notify] if mamba_notify else attn_notify
                     )
                 else:
-                    block_notify_list, mamba_block_notify_list = [], []
+                    _, mamba_notify = self.split_block_groups(
+                        blocks.get_block_ids()
+                    )
+                    block_notify_list = (
+                        [[], mamba_notify] if mamba_notify else []
+                    )
 
                 for tp_index in range(self.tp_size):
                     target_port = remote_notify_port + get_port_offset(
@@ -748,7 +775,6 @@ class MoRIIOConnectorScheduler:
                         block_notify_list=block_notify_list,
                         host=remote_host,
                         port=target_port,
-                        mamba_block_notify_list=mamba_block_notify_list,
                     )
 
             # Only trigger 1 KV transfer per request.
@@ -775,22 +801,21 @@ class MoRIIOConnectorScheduler:
                         new_block_ids
                     )
                     req, existing_blocks = self._reqs_need_pending_save[req_id]
-                    updated_blocks = list(existing_blocks) + attn_block_ids
-                    self._reqs_need_pending_save[req_id] = (req, updated_blocks)
-                    if mamba_block_ids:
-                        self._reqs_mamba_blocks[req_id] = mamba_block_ids
-                    if (
-                        len(self._reqs_need_pending_save[req_id][1]) * self.block_size
-                        >= req.num_prompt_tokens
-                    ):
+                    # Accumulate attention blocks across chunks; keep the single
+                    # mamba slot. Both ride the one [attn, mamba] value.
+                    ex_attn, ex_mamba = as_attn_mamba(existing_blocks)
+                    updated_attn = list(ex_attn) + attn_block_ids
+                    updated_mamba = mamba_block_ids or ex_mamba
+                    self._reqs_need_pending_save[req_id] = (
+                        req,
+                        [updated_attn, updated_mamba],
+                    )
+                    if len(updated_attn) * self.block_size >= req.num_prompt_tokens:
                         meta.add_new_req(
                             request_id=req_id,
-                            local_block_ids=self._reqs_need_pending_save[req_id][1],
+                            local_block_ids=[updated_attn, updated_mamba],
                             kv_transfer_params=req.kv_transfer_params or {},
                             write_mode=True,
-                            local_mamba_block_ids=self._reqs_mamba_blocks.pop(
-                                req_id, None
-                            ),
                         )
                         del self._reqs_need_pending_save[req_id]
 
@@ -801,12 +826,12 @@ class MoRIIOConnectorScheduler:
                 request_id=req_id,
                 local_block_ids=block_ids,
                 kv_transfer_params=req.kv_transfer_params,
-                local_mamba_block_ids=self._reqs_mamba_blocks.pop(req_id, None),
             )
 
         for req_id, (req, block_ids) in self._reqs_need_save.items():
             assert req.kv_transfer_params is not None
-            if req.num_prompt_tokens > len(block_ids) * self.block_size:
+            attn_ids, _ = as_attn_mamba(block_ids)
+            if req.num_prompt_tokens > len(attn_ids) * self.block_size:
                 # not last chunk prefill; keep the mamba slot for the final chunk
                 self._reqs_need_pending_save[req_id] = (req, block_ids)
                 continue
@@ -815,7 +840,6 @@ class MoRIIOConnectorScheduler:
                 local_block_ids=block_ids,
                 kv_transfer_params=req.kv_transfer_params,
                 write_mode=True,
-                local_mamba_block_ids=self._reqs_mamba_blocks.pop(req_id, None),
             )
         # Clear the list once workers start the transfers
 
@@ -899,7 +923,18 @@ class MoRIIOConnectorScheduler:
             if self.mode == MoRIIOMode.WRITE:
                 self._release_write_prefill_blocks(request.request_id, params)
             else:
-                self._reqs_need_recv[request.request_id] = (request, [])
+                # Carry the actually-allocated blocks (incl. the per-request KDA
+                # mamba slot) instead of []: a do_remote_prefill request finishing
+                # before update_state_after_alloc still has blocks, and dropping the
+                # mamba slot here would re-trip the KDA guard in _read_blocks.
+                if block_ids:
+                    h_attn, h_mamba = self.split_block_groups(block_ids)
+                    recv_blocks = (
+                        [h_attn, h_mamba] if h_mamba else ([h_attn] if h_attn else [])
+                    )
+                else:
+                    recv_blocks = []
+                self._reqs_need_recv[request.request_id] = (request, recv_blocks)
             params["do_remote_prefill"] = False
             return False, None
 
@@ -1232,7 +1267,6 @@ class MoRIIOConnectorWorker:
         kv_layer: torch.Tensor,
         remote_notify_port: int,
         remote_ip: str,
-        local_mamba_block_ids: list[int] | None = None,
     ) -> None:
         """Schedule a block write operation.
 
@@ -1267,7 +1301,6 @@ class MoRIIOConnectorWorker:
             event=event,
             remote_notify_port=remote_notify_port,
             remote_ip=remote_ip,
-            local_mamba_block_ids=local_mamba_block_ids or [],
         )
         self._writer.schedule_write(task)
 
@@ -2127,8 +2160,6 @@ class MoRIIOConnectorWorker:
             remote_host=meta.remote_host,
             remote_notify_port=meta.remote_notify_port,
             remote_tp_size=meta.tp_size,
-            local_mamba_block_ids=meta.mamba_local_block_ids,
-            remote_mamba_block_ids=meta.mamba_remote_block_ids,
         )
 
     def _write_blocks_for_req(self, req_id: ReqId, meta: ReqMeta, layer_name, kv_layer):
@@ -2142,7 +2173,6 @@ class MoRIIOConnectorWorker:
             kv_layer=kv_layer,
             remote_notify_port=meta.remote_notify_port,
             remote_ip=meta.remote_host,
-            local_mamba_block_ids=meta.mamba_local_block_ids,
         )
 
     def merge_contiguous_blocks(
@@ -2397,11 +2427,13 @@ class MoRIIOConnectorWorker:
         remote_host: str,
         remote_notify_port: int,
         remote_tp_size: int,
-        local_mamba_block_ids: list[int] | None = None,
-        remote_mamba_block_ids: list[int] | None = None,
     ) -> None:
         if self.mode == MoRIIOMode.WRITE:
             return
+
+        # Both halves ride the one block-ids channel; split at the point of use.
+        local_attn, local_mamba = as_attn_mamba(local_block_ids)
+        remote_attn, remote_mamba = as_attn_mamba(remote_block_ids)
 
         dp0_engine_id = self.get_engine_name_with_dp(dst_engine_id, 0)
         sessions, remote_moriio_meta = self._get_built_session(dp0_engine_id)
@@ -2415,13 +2447,26 @@ class MoRIIOConnectorWorker:
             if self._is_mamba_layer(layer_name):
                 # KDA layer: pull conv (sub-projection offsets) and ssm at the
                 # request's recurrent-state slot. Two regions -> two sessions.
-                if not local_mamba_block_ids or not remote_mamba_block_ids:
-                    continue
+                if not local_mamba or not remote_mamba:
+                    if not local_attn and not remote_attn:
+                        # Whole-request no-op (e.g. full prefix cache hit):
+                        # nothing to transfer for any layer.
+                        continue
+                    # A KDA layer must have its recurrent-state slot in the
+                    # block-id tuple; missing it (while attention blocks are
+                    # present) means the mamba KV-cache group is absent -> bug.
+                    raise MoRIIOError(
+                        f"KDA layer {layer_name}: missing mamba recurrent-state "
+                        f"block ids (local={local_mamba}, remote={remote_mamba}) "
+                        f"with attention blocks present for request {request_id}; "
+                        "the mamba KV-cache group is absent from the transfer "
+                        "block-id tuple"
+                    )
                 m_local, m_remote, m_sizes, n_conv = (
                     self._compute_mamba_transfer_offsets(
                         layer_name,
-                        local_mamba_block_ids,
-                        remote_mamba_block_ids,
+                        local_mamba,
+                        remote_mamba,
                         remote_tp_size=remote_tp_size,
                     )
                 )
@@ -2451,8 +2496,8 @@ class MoRIIOConnectorWorker:
             else:
                 offs = self._compute_block_transfer_offsets(
                     layer_name,
-                    local_block_ids,
-                    remote_block_ids,
+                    local_attn,
+                    remote_attn,
                     remote_moriio_meta,
                     remote_tp_size=remote_tp_size,
                 )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_engine.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_engine.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from mori.io import BackendType
 
 from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common import (
+    as_attn_mamba,
     ROLE,
     HandshakeError,
     LayerTransferPlan,
@@ -381,10 +382,14 @@ class MoRIIOWriter:
         geometry_key = _get_write_geometry_key(layer_cache)
         offsets = request_info.transfer_offsets.get(geometry_key)
         if offsets is None:
+            # local/remote block ids carry [attn, mamba]; attention layers use
+            # the attention half.
+            local_attn, _ = as_attn_mamba(task.local_block_ids)
+            remote_attn, _ = as_attn_mamba(request_info.block_ids)
             offsets = self.worker._compute_block_transfer_offsets(
                 task.layer_name,
-                task.local_block_ids,
-                request_info.block_ids,
+                local_attn,
+                remote_attn,
                 remote_moriio_meta,
             )
             request_info.transfer_offsets[geometry_key] = offsets
@@ -419,10 +424,13 @@ class MoRIIOWriter:
         per task regardless of how many session writes fire), so no attention-
         layer-count threshold is needed.
         """
+        # KDA layers use the mamba half of the carried [attn, mamba] block ids.
+        _, local_mamba = as_attn_mamba(task.local_block_ids)
+        _, remote_mamba = as_attn_mamba(request_info.block_ids)
         local, remote, sizes, n_conv = self.worker._compute_mamba_transfer_offsets(
             task.layer_name,
-            task.local_mamba_block_ids,
-            request_info.mamba_block_ids,
+            local_mamba,
+            remote_mamba,
         )
         region_sessions = self.worker._region_session_indices(task.layer_name)
         return LayerTransferPlan(
@@ -829,7 +837,6 @@ class MoRIIOWrapper:
         assert get_role() == ROLE.PRODUCER, "Only prefill can get block messages"
         transfer_id = data["transfer_id"]
         block_notify_list = data.get("block_notify_list", [])
-        mamba_block_notify_list = data.get("mamba_block_notify_list", [])
         decode_dp_rank = data.get("decode_rank", 0)
         if not block_notify_list:
             raise MoRIIOError(
@@ -845,7 +852,6 @@ class MoRIIOWrapper:
                 return
             self.done_remote_allocate_req_dict[transfer_id] = RemoteAllocInfo(
                 block_ids=block_notify_list,
-                mamba_block_ids=mamba_block_notify_list,
                 decode_dp_rank=decode_dp_rank,
             )
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_engine.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_engine.py
@@ -176,6 +176,14 @@ class MoRIIOWriter:
         for transfer_id, request_info in pending:
             self._finalize_if_complete(transfer_id, request_info)
 
+    def has_outstanding_writes(self) -> bool:
+        """True while any transfer still has scheduled writes that have not
+        been finalized/cleared. Drives MoRIIOConnector.has_pending_push_work so
+        the engine keeps stepping until all WRITE transfers (including KDA
+        conv+ssm, which fire only from wait_for_save) complete."""
+        with self._write_state_lock:
+            return bool(self._scheduled_writes)
+
     def _write_worker_loop(self) -> None:
         """Main loop for the write worker thread."""
 
@@ -366,6 +374,9 @@ class MoRIIOWriter:
         Returns:
             The transfer plan
         """
+        if self.worker._is_mamba_layer(task.layer_name):
+            return self._prepare_mamba_transfer_plan(task, request_info)
+
         layer_cache = self.worker.kv_caches[task.layer_name]
         geometry_key = _get_write_geometry_key(layer_cache)
         offsets = request_info.transfer_offsets.get(geometry_key)
@@ -378,9 +389,9 @@ class MoRIIOWriter:
             )
             request_info.transfer_offsets[geometry_key] = offsets
 
-        # Get session index
-        layer_names = list(self.worker.layer_name_to_local_kv_cache_metadata.keys())
-        sess_idx = layer_names.index(task.layer_name)
+        # One session per registered region; attention layers map to a single
+        # index (see MoRIIOConnectorWorker._region_session_indices).
+        sess_idx = self.worker._region_session_indices(task.layer_name)[0]
 
         local_off, remote_off, sizes = offsets
 
@@ -395,6 +406,41 @@ class MoRIIOWriter:
             use_batch=True,
         )
 
+    def _prepare_mamba_transfer_plan(
+        self,
+        task: WriteTask,
+        request_info: RemoteAllocInfo,
+    ) -> LayerTransferPlan:
+        """Build a conv+ssm write plan for a KDA layer.
+
+        The layer has two registered regions (conv, ssm) -> two sessions. Both
+        are issued as one scheduled write (seal_pending_transfers counts one
+        write per (transfer_id, layer_name), and writes_done is incremented once
+        per task regardless of how many session writes fire), so no attention-
+        layer-count threshold is needed.
+        """
+        local, remote, sizes, n_conv = self.worker._compute_mamba_transfer_offsets(
+            task.layer_name,
+            task.local_mamba_block_ids,
+            request_info.mamba_block_ids,
+        )
+        region_sessions = self.worker._region_session_indices(task.layer_name)
+        return LayerTransferPlan(
+            request_id=task.request_id,
+            transfer_id=task.transfer_id,
+            layer_name=task.layer_name,
+            sess_idx=region_sessions[0],
+            transfer_local_offsets=local[:n_conv],
+            transfer_remote_offsets=remote[:n_conv],
+            transfer_sizes=sizes[:n_conv],
+            use_batch=True,
+            is_mamba=True,
+            ssm_sess_idx=region_sessions[1],
+            ssm_local_offsets=local[n_conv:],
+            ssm_remote_offsets=remote[n_conv:],
+            ssm_sizes=sizes[n_conv:],
+        )
+
     def _do_layer_write(self, plan: LayerTransferPlan, sessions: list) -> list[Any]:
         """Perform the actual layer write.
 
@@ -402,6 +448,32 @@ class MoRIIOWriter:
             plan: The transfer plan
             sessions: List of transfer sessions
         """
+        if plan.is_mamba:
+            # KDA layer: batched conv write on the conv session and batched ssm
+            # write on the ssm session (two regions), collected as this task's
+            # transfer statuses.
+            mamba_statuses: list[Any] = []
+            if plan.transfer_sizes:
+                mamba_statuses.append(
+                    self.worker.moriio_wrapper.write_remote_data(
+                        plan.transfer_sizes,
+                        plan.transfer_local_offsets,
+                        plan.transfer_remote_offsets,
+                        sessions[plan.sess_idx],
+                    )
+                )
+            if plan.ssm_sizes:
+                assert plan.ssm_sess_idx is not None
+                mamba_statuses.append(
+                    self.worker.moriio_wrapper.write_remote_data(
+                        plan.ssm_sizes,
+                        plan.ssm_local_offsets,
+                        plan.ssm_remote_offsets,
+                        sessions[plan.ssm_sess_idx],
+                    )
+                )
+            return mamba_statuses
+
         if plan.use_batch:
             return [
                 self.worker.moriio_wrapper.write_remote_data(
@@ -757,6 +829,7 @@ class MoRIIOWrapper:
         assert get_role() == ROLE.PRODUCER, "Only prefill can get block messages"
         transfer_id = data["transfer_id"]
         block_notify_list = data.get("block_notify_list", [])
+        mamba_block_notify_list = data.get("mamba_block_notify_list", [])
         decode_dp_rank = data.get("decode_rank", 0)
         if not block_notify_list:
             raise MoRIIOError(
@@ -771,7 +844,9 @@ class MoRIIOWrapper:
                 )
                 return
             self.done_remote_allocate_req_dict[transfer_id] = RemoteAllocInfo(
-                block_ids=block_notify_list, decode_dp_rank=decode_dp_rank
+                block_ids=block_notify_list,
+                mamba_block_ids=mamba_block_notify_list,
+                decode_dp_rank=decode_dp_rank,
             )
 
     def _handle_write_done_message(self, data: dict):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_layout.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_layout.py
@@ -533,6 +533,11 @@ def build_mamba_offset_template(
             f"(tp_ratio={tp_ratio}); use equal prefill/decode TP for "
             "hybrid models"
         )
+    # Past the gate above this is always the homogeneous path (the reviewer's
+    # "is tp_ratio always 1 here?"): make that invariant explicit.
+    assert tp_ratio == 1, (
+        f"homogeneous KDA offset path requires tp_ratio == 1, got {tp_ratio}"
+    )
     geom = get_mamba_transfer_geometry(layer_name, conv, ssm, layer_to_spec)
     local_offset = tp_rank % max(tp_ratio, 1)
     conv_local_offsets = split_info.local_conv_offsets

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_layout.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_layout.py
@@ -6,10 +6,14 @@ from typing import NamedTuple
 
 import torch
 
+from vllm.distributed.kv_transfer.kv_connector.v1.ssm_conv_transfer_utils import (
+    MambaConvSplitInfo,
+)
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     KVCacheConfig,
     KVCacheSpec,
+    MambaSpec,
     MLAAttentionSpec,
     SlidingWindowMLASpec,
     UniformTypeKVCacheSpecs,
@@ -27,6 +31,70 @@ class LayerTransferGeometry(NamedTuple):
     transfers_per_block: int
     regions_per_block: int
     split_kv_regions: bool
+
+
+class MambaTransferGeometry(NamedTuple):
+    """Geometry of a hybrid (mamba/KDA) layer's recurrent state.
+
+    A KDA layer's cache is a ``(conv_state, ssm_state)`` tuple; each is a
+    slot-strided view whose slot stride (``stride(0)``) is larger than the
+    per-slot element count, so a slot's bytes live at
+    ``slot * slot_stride * element_size`` and span ``slot_bytes``. The two
+    tensors are registered as two separate MoRIIO regions per layer.
+    """
+
+    num_slots: int
+    conv_slot_stride: int
+    ssm_slot_stride: int
+    conv_slot_bytes: int
+    ssm_slot_bytes: int
+    conv_element_size: int
+    ssm_element_size: int
+    conv_region_len: int
+    ssm_region_len: int
+
+
+def get_mamba_transfer_geometry(
+    layer_name: str,
+    conv: torch.Tensor,
+    ssm: torch.Tensor,
+    layer_to_spec: Mapping[str, KVCacheSpec],
+) -> MambaTransferGeometry:
+    """Derive the slot-strided geometry of a KDA layer's conv + ssm state.
+
+    ``conv``/``ssm`` are the two tensors of the layer's ``(conv, ssm)`` cache
+    tuple. Slot byte offset is ``slot * slot_stride * element_size`` and each
+    slot spans ``subtensor[0].numel() * element_size`` bytes; the whole tensor
+    is registered as one region (``*_region_len`` bytes).
+    """
+    return MambaTransferGeometry(
+        num_slots=conv.shape[0],
+        conv_slot_stride=conv.stride(0),
+        ssm_slot_stride=ssm.stride(0),
+        conv_slot_bytes=conv[0].numel() * conv.element_size(),
+        ssm_slot_bytes=ssm[0].numel() * ssm.element_size(),
+        conv_element_size=conv.element_size(),
+        ssm_element_size=ssm.element_size(),
+        # Registered region must span the full slot-strided extent: stride(0)
+        # may exceed the per-slot element count, so numel() would under-size the
+        # region and truncate the highest-slot transfers. shape[0]*stride(0)
+        # covers every byte a ``slot * slot_stride * elem`` offset can address.
+        # Cap at the bytes remaining from each view's storage offset so a
+        # shared conv+ssm page buffer (dev19253 packed layout: ssm sits at
+        # a non-zero intra-buffer offset) is not registered past the buffer
+        # end; for separate buffers (offset 0, full storage) it is the same
+        # slot-strided extent as before.
+        conv_region_len=min(
+            conv.shape[0] * conv.stride(0) * conv.element_size(),
+            conv.untyped_storage().nbytes()
+            - conv.storage_offset() * conv.element_size(),
+        ),
+        ssm_region_len=min(
+            ssm.shape[0] * ssm.stride(0) * ssm.element_size(),
+            ssm.untyped_storage().nbytes()
+            - ssm.storage_offset() * ssm.element_size(),
+        ),
+    )
 
 
 def build_layer_to_spec(kv_cache_config: KVCacheConfig) -> dict[str, KVCacheSpec]:
@@ -103,11 +171,16 @@ def get_layer_transfer_geometry(
     kv_cache: torch.Tensor,
     layer_to_spec: Mapping[str, KVCacheSpec],
     remote_num_blocks: int | None = None,
-) -> LayerTransferGeometry:
+) -> LayerTransferGeometry | MambaTransferGeometry:
+    spec = layer_to_spec[layer_name]
+    if isinstance(spec, MambaSpec):
+        # Hybrid/KDA layer: cache is a ``(conv, ssm)`` tuple, which has no
+        # ``.shape``; handle it before touching the attention-only shape logic.
+        conv, ssm = kda_conv_ssm(kv_cache, spec)
+        return get_mamba_transfer_geometry(layer_name, conv, ssm, layer_to_spec)
     shape = kv_cache.shape
     stride = kv_cache.stride()
     element_size = kv_cache.element_size()
-    spec = layer_to_spec[layer_name]
     is_mla_cache = is_mla_cache_layer(layer_to_spec, layer_name)
 
     if is_mla_cache and len(shape) == 3:
@@ -260,11 +333,73 @@ def get_layer_transfer_geometry(
     )
 
 
+def kda_conv_ssm(
+    kv_cache: "torch.Tensor | tuple | list",
+    spec: "KVCacheSpec | None" = None,
+) -> "tuple[torch.Tensor, torch.Tensor]":
+    """Return (conv_state, ssm_state) for a KDA/Mamba layer, version-robustly.
+
+    Two vLLM kv-cache layouts are supported:
+      * legacy k3-release (e.g. dev19033): ``kv_cache`` is a ``(conv, ssm)``
+        tuple/list of separate slot-strided tensors -> returned as-is (``spec``
+        unused, so callers on this path may pass ``None``).
+      * dev19253+: ``kv_cache`` is a single ``[num_blocks, 1, 1, page_bytes]``
+        int8 page view holding both states packed per block. Slice the conv
+        and ssm byte sub-ranges and reinterpret per ``spec.shapes``/``dtypes``,
+        mirroring ``MambaBase.bind_kv_cache`` so the returned views are
+        byte-identical to what the model reads/writes: slot stride == page
+        bytes, per-slot span == that state's bytes, conv/ssm sharing one
+        backing buffer (handled by the connector's single-region + ssm
+        intra-buffer offset path). Byte-exact for homogeneous P/D attn-TP.
+
+    NOTE: the packed page interleaves conv+ssm per block, so the hetero-TP
+    conv sub-projection split cannot be expressed by slicing this layout
+    alone; hetero-TP GDN remains a documented follow-up (as with the legacy
+    layout's whole-item transfer).
+    """
+    if isinstance(kv_cache, (tuple, list)):
+        if len(kv_cache) != 2:
+            raise ValueError(
+                "Expected a 2-tuple (conv, ssm) KDA kv-cache, got "
+                f"len={len(kv_cache)}"
+            )
+        return kv_cache[0], kv_cache[1]
+    if spec is None:
+        raise ValueError("kda_conv_ssm needs the MambaSpec to unpack a packed page tensor")
+    from math import prod
+
+    from vllm.utils.torch_utils import get_dtype_size
+
+    shapes = list(spec.shapes)
+    dtypes = list(spec.dtypes)
+    if len(dtypes) == 1 and len(shapes) > 1:
+        dtypes = dtypes * len(shapes)
+    pages = kv_cache.reshape(kv_cache.shape[0], -1)  # [num_blocks, page_bytes]
+    states: list[torch.Tensor] = []
+    offset = 0
+    for shp, dt in zip(shapes, dtypes):
+        nbytes = prod(shp) * get_dtype_size(dt)
+        state = pages[:, offset : offset + nbytes].view(dt)
+        states.append(state.view(-1, *shp))
+        offset += nbytes
+    if len(states) < 2:
+        raise ValueError(f"KDA page unpack expected >=2 states, got {len(states)}")
+    return states[0], states[1]
+
+
 def iter_layer_registration_regions(
     layer_name: str,
     kv_cache: torch.Tensor,
     layer_to_spec: Mapping[str, KVCacheSpec],
 ) -> list[tuple[torch.Tensor, int]]:
+    spec = layer_to_spec[layer_name]
+    if isinstance(spec, MambaSpec):
+        # KDA layer: register the conv and ssm tensors as two whole-tensor
+        # regions (the conv 3-subprojection split is expressed as transfer
+        # offset triples, not extra registrations).
+        conv, ssm = kda_conv_ssm(kv_cache, spec)
+        geom = get_mamba_transfer_geometry(layer_name, conv, ssm, layer_to_spec)
+        return [(conv, geom.conv_region_len), (ssm, geom.ssm_region_len)]
     geometry = get_layer_transfer_geometry(layer_name, kv_cache, layer_to_spec)
     region_len = geometry.num_blocks * geometry.regions_per_block * geometry.block_len
     if geometry.split_kv_regions:
@@ -351,3 +486,168 @@ def compute_block_transfer_offsets(
             w += 1
 
     return merge_fn(offset_local, offset_remote, sizes)
+
+
+class MambaOffsetTemplate(NamedTuple):
+    """Slot-independent conv+ssm offset decomposition for a KDA layer.
+
+    Homogeneous-TP geometry (conv/ssm slot strides, conv sub-projection
+    offsets, ssm per-slot size) is identical across requests and across the
+    homogeneous GDN layers, so it is computed once and reused; only the
+    per-request slot bases vary (see ``apply_mamba_offset_template``).
+    """
+
+    conv_slot_stride_bytes: int
+    ssm_slot_stride_bytes: int
+    ssm_read_bytes: int
+    ssm_remote_extra: int
+    conv_subprojs: tuple[tuple[int, int, int], ...]
+
+
+def build_mamba_offset_template(
+    layer_name: str,
+    conv: torch.Tensor,
+    ssm: torch.Tensor,
+    layer_to_spec: Mapping[str, KVCacheSpec],
+    split_info: MambaConvSplitInfo,
+    tp_ratio: int,
+    tp_rank: int,
+    world_size: int,
+) -> MambaOffsetTemplate:
+    """Precompute the slot-independent conv+ssm offset decomposition.
+
+    Only homogeneous TP (``tp_ratio == 1``) is supported; heterogeneous TP is
+    gated with ``NotImplementedError`` (see the design doc). The returned
+    template is a pure function of the layer geometry and ``split_info``, so it
+    can be cached and reused across requests without recomputation.
+    """
+    if tp_ratio != 1:
+        # Heterogeneous-TP recurrent-state transfer needs the remote page's
+        # slot stride (which differs from the local page) and, for
+        # P_TP > D_TP, a multi-rank gather of conv/ssm slices. Both are
+        # follow-ups (see docs/design/moriio_kda_transfer.md). The mamba path
+        # bypasses the attention KV-head validator, so fail loudly here
+        # instead of silently transferring wrong bytes.
+        raise NotImplementedError(
+            "heterogeneous-TP mamba/KDA transfer is not supported yet "
+            f"(tp_ratio={tp_ratio}); use equal prefill/decode TP for "
+            "hybrid models"
+        )
+    geom = get_mamba_transfer_geometry(layer_name, conv, ssm, layer_to_spec)
+    local_offset = tp_rank % max(tp_ratio, 1)
+    conv_local_offsets = split_info.local_conv_offsets
+    conv_remote_offsets = split_info.remote_conv_offsets(local_offset, tp_ratio)
+    ssm_read_bytes = geom.ssm_slot_bytes
+    conv_subprojs = tuple(
+        (loff, roff, rsz)
+        for (loff, _lsz), (roff, rsz) in zip(conv_local_offsets, conv_remote_offsets)
+    )
+    return MambaOffsetTemplate(
+        conv_slot_stride_bytes=geom.conv_slot_stride * geom.conv_element_size,
+        ssm_slot_stride_bytes=geom.ssm_slot_stride * geom.ssm_element_size,
+        ssm_read_bytes=ssm_read_bytes,
+        ssm_remote_extra=local_offset * ssm_read_bytes,
+        conv_subprojs=conv_subprojs,
+    )
+
+
+def apply_mamba_offset_template(
+    template: MambaOffsetTemplate,
+    local_slots: list[int],
+    remote_slots: list[int],
+) -> tuple[list[int], list[int], list[int]]:
+    """Apply per-request slot bases to a cached ``MambaOffsetTemplate``.
+
+    Produces byte-identical output to computing the offsets from scratch:
+    ``compute_mamba_conv_ssm_offsets`` is defined in terms of this function, so
+    the cached fast path and the fresh path share one arithmetic definition.
+    Conv sub-projection entries (all slots) come first, followed by one ssm
+    entry per slot.
+    """
+    if len(local_slots) > len(remote_slots):
+        raise ValueError(
+            "local_slots longer than remote_slots: "
+            f"{len(local_slots)} > {len(remote_slots)}"
+        )
+    local_offs: list[int] = []
+    remote_offs: list[int] = []
+    sizes: list[int] = []
+
+    # Conv sub-projections (region 0), all slots first.
+    conv_slot_stride_bytes = template.conv_slot_stride_bytes
+    for ls, rs in zip(local_slots, remote_slots):
+        lbase = ls * conv_slot_stride_bytes
+        rbase = rs * conv_slot_stride_bytes
+        for loff, roff, rsz in template.conv_subprojs:
+            local_offs.append(lbase + loff)
+            remote_offs.append(rbase + roff)
+            sizes.append(rsz)
+
+    # SSM temporal state (region 1), one entry per slot.
+    ssm_slot_stride_bytes = template.ssm_slot_stride_bytes
+    ssm_read_bytes = template.ssm_read_bytes
+    ssm_remote_extra = template.ssm_remote_extra
+    for ls, rs in zip(local_slots, remote_slots):
+        local_offs.append(ls * ssm_slot_stride_bytes)
+        remote_offs.append(rs * ssm_slot_stride_bytes + ssm_remote_extra)
+        sizes.append(ssm_read_bytes)
+
+    return local_offs, remote_offs, sizes
+
+
+def compute_mamba_conv_ssm_offsets(
+    layer_name: str,
+    conv: torch.Tensor,
+    ssm: torch.Tensor,
+    layer_to_spec: Mapping[str, KVCacheSpec],
+    local_slots: list[int],
+    remote_slots: list[int],
+    split_info: MambaConvSplitInfo,
+    tp_ratio: int,
+    tp_rank: int,
+    world_size: int,
+) -> tuple[list[int], list[int], list[int]]:
+    """Compute conv + ssm byte offsets for a KDA layer's state transfer.
+
+    Returns ``(local_offsets, remote_offsets, sizes)`` where the conv
+    sub-projection entries come first (``len(local_slots) *
+    len(split_info.local_conv_offsets)`` of them) followed by one ssm entry
+    per slot. Conv and ssm live in two separate registered regions, so the
+    caller must route the conv slice to the conv session and the ssm slice to
+    the ssm session (``compute_mamba_conv_split_count`` gives the boundary).
+
+    Offsets are region-relative byte offsets. Each slot's base is
+    ``slot * slot_stride * element_size`` (slot-strided view); conv
+    sub-projections are placed at ``slot_base + local_conv_offsets`` locally
+    and ``slot_base + remote_conv_offsets(local_offset, tp_ratio)`` remotely,
+    while the ssm state uses the whole per-slot block (heads TP-sharded via
+    ``local_offset`` for heterogeneous TP).
+    """
+    if len(local_slots) > len(remote_slots):
+        raise ValueError(
+            "local_slots longer than remote_slots: "
+            f"{len(local_slots)} > {len(remote_slots)}"
+        )
+    template = build_mamba_offset_template(
+        layer_name,
+        conv,
+        ssm,
+        layer_to_spec,
+        split_info,
+        tp_ratio,
+        tp_rank,
+        world_size,
+    )
+    return apply_mamba_offset_template(template, local_slots, remote_slots)
+
+
+def compute_mamba_conv_split_count(
+    local_slots: list[int],
+    split_info: MambaConvSplitInfo,
+) -> int:
+    """Number of leading conv entries in ``compute_mamba_conv_ssm_offsets``.
+
+    Entries ``[:count]`` are conv sub-projections (conv region/session);
+    entries ``[count:]`` are the per-slot ssm state (ssm region/session).
+    """
+    return len(local_slots) * len(split_info.local_conv_offsets)


### PR DESCRIPTION
## Summary
- Adds MoRIIO KV-connector support for transferring Kimi-K3's hybrid KDA (Kimi Delta Attention / GDN linear-attention) conv+ssm recurrent state in 1P1D disaggregated serving, alongside the existing attention/MLA KV transfer.
- Implements both READ (decode pulls) and WRITE (prefill pushes) of the conv+ssm state. Generalizes the connector from "1 layer = 1 region = 1 session" to per-region sessions so a KDA layer registers its conv and ssm regions.
- Scheduler-side hybrid handling: attention/mamba block-group split (`SupportsHMA`), plus producer-side N-1 prompt truncation so the decoder recomputes the final token from the transferred recurrent state. The per-request conv+ssm slot is always transferred (it is not prefix-cacheable), including on a full prefix-cache hit.
- Version-robust KDA kv-cache unpack (`kda_conv_ssm`) supporting both the legacy `(conv, ssm)` tuple and the newer packed single-page layout; storage-offset-aware region/alias registration.
- **Router-agnostic:** the per-request KDA recurrent-state slot rides the existing `remote_block_ids` channel as `[attn, mamba]` (no separate wire field), so **the disaggregation router/proxy needs no KDA-specific changes.**

## Validation (MI355X / gfx950, ROCm + AITER)
- Unit: moriio layout geometry + HMA scheduler split / N-1 accounting / offset-cache equivalence + `as_attn_mamba` round-trips.
- E2E, real Kimi-K3 weights, TP8, 1P1D cross-node over RDMA, validated through **both front-ends with no router-side code changes**:
  - the production vLLM router (`vllm-router --kv-connector moriio`, ZMQ service discovery), and
  - the bundled `moriio_toy_proxy_server.py` example.
- READ and WRITE both round-trip coherently. GSM8K (200 questions) via the vLLM router: **READ 199/200, WRITE 199/200**.

## Test plan
- [x] `pytest tests/v1/kv_connector/unit/test_moriio_kv_layout.py tests/v1/kv_connector/unit/test_moriio_hma_scheduler.py`
- [x] real-weights READ 1P1D coherent (toy proxy + vLLM router)
- [x] real-weights WRITE 1P1D coherent (toy proxy + vLLM router)
- [x] GSM8K 200 via vLLM router: READ 199/200, WRITE 199/200
