### PR TITLE
[CUDA] Keep host registration and error drain on one runtime handle

### DIFF
--- a/tests/v1/kv_offload/test_pin_mmap_cuda_error_clear.py
+++ b/tests/v1/kv_offload/test_pin_mmap_cuda_error_clear.py
@@ -1,0 +1,357 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Hermetic same-handle cudaHostRegister/drain/unregister tests.
+
+No live CUDA calls.  CudaRTLibrary instances via object.__new__ + fake
+funcs; caller sites via monkeypatched fake classes.
+"""
+
+import pytest
+
+from vllm.distributed.device_communicators.cuda_wrapper import (
+    CudaRTLibrary,
+    cudaError_t,
+)
+from vllm.distributed.ec_transfer.ec_connector.cpu.ec_shared_region import (
+    ECSharedRegion,
+)
+from vllm.v1.kv_offload.cpu import gpu_worker
+from vllm.v1.kv_offload.cpu import shared_offload_region as sor
+from vllm.v1.kv_offload.cpu.gpu_worker import pin_mmap_region
+from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
+
+EC_MOD = "vllm.distributed.ec_transfer.ec_connector.cpu.ec_shared_region"
+GP_MOD = "vllm.v1.kv_offload.cpu.gpu_worker"
+
+
+def _lib(funcs):
+    lib = object.__new__(CudaRTLibrary)
+    lib.funcs = funcs
+    lib.CUDART_CHECK = CudaRTLibrary.CUDART_CHECK.__get__(lib, CudaRTLibrary)
+    return lib
+
+
+class _Region:
+    rank = 0
+
+    class _Base:
+        def data_ptr(self):
+            return 1234
+
+    _base = _Base()
+    total_size_bytes = 65536
+    is_pinned = False
+    _cudart_lib = None
+
+
+def _kv_obj():
+    obj = object.__new__(SharedOffloadRegion)
+    for a in (
+        "is_pinned",
+        "_cudart_lib",
+        "_base",
+        "mmap_obj",
+        "fd",
+        "_creator",
+        "_views",
+        "mmap_path",
+    ):
+        setattr(obj, a, None)
+    obj.rank = 0
+    return obj
+
+
+def _ec_stub():
+    s = ECSharedRegion.__new__(ECSharedRegion)
+    for a in (
+        "_blocks_ptr",
+        "_blocks_nbytes",
+        "_is_pinned",
+        "_cudart_lib",
+        "_is_creator",
+        "_fd",
+        "_mmap_obj",
+        "_mmap_path",
+    ):
+        setattr(s, a, None)
+    s._blocks_ptr = 1234
+    s._blocks_nbytes = 65536
+    s._is_pinned = False
+    s._cudart_lib = None
+    s._is_creator = False
+    s._fd = None
+    s._mmap_obj = None
+    s._mmap_path = "/dev/shm/_t"
+    return s
+
+
+# -- CudaRTLibrary wrapper + drain -----------------------------------------
+
+
+class TestWrappers:
+    def test_register_no_raise(self):
+        r = _lib({"cudaHostRegister": lambda p, s, f: 1}).cudaHostRegister(0, 0, 0)
+        assert r == 1
+
+    def test_unregister_no_raise(self):
+        r = _lib({"cudaHostUnregister": lambda p: 0}).cudaHostUnregister(0)
+        assert r == 0
+
+    def test_drain_returns_int(self):
+        r = _lib({"cudaGetLastError": lambda: 7}).drain_pending_error()
+        assert r == 7
+
+    def test_drain_zero_after_success(self):
+        r = _lib({"cudaGetLastError": lambda: 0}).drain_pending_error()
+        assert r == 0
+
+
+# -- CUDART_CHECK ----------------------------------------------------------
+
+
+class TestCUDARTCheck:
+    def test_nonzero_drains_then_raises(self):
+        seen = []
+        lib = _lib(
+            {
+                "cudaGetErrorString": lambda e: b"err",
+                "cudaGetLastError": lambda: (seen.append(1), 99)[1],
+            }
+        )
+        with pytest.raises(RuntimeError, match="CUDART error: err"):
+            lib.CUDART_CHECK(1)
+        assert seen == [1]
+
+    def test_preserves_original_error(self):
+        lib = _lib(
+            {
+                "cudaGetErrorString": lambda e: f"code_{e}".encode(),
+                "cudaGetLastError": lambda: 99,
+            }
+        )
+        with pytest.raises(RuntimeError) as exc:
+            lib.CUDART_CHECK(7)
+        assert "code_7" in str(exc.value)
+
+    def test_zero_noop(self):
+        _lib({}).CUDART_CHECK(0)
+
+
+# -- pin_mmap_region (CPU-KV) ----------------------------------------------
+
+
+class TestGPUWorkerPinMmap:
+    def test_failure_drains_unpinned(self, monkeypatch):
+        events = []
+
+        class F:
+            def cudaHostRegister(self, p, s, f):
+                events.append("reg")
+                return 1
+
+            def drain_pending_error(self):
+                events.append("drain")
+                return 1
+
+        monkeypatch.setattr(gpu_worker.current_platform, "is_cuda_alike", lambda: True)
+        monkeypatch.setattr(f"{GP_MOD}.CudaRTLibrary", lambda: F())
+        r = _Region()
+        pin_mmap_region(r)
+        assert events == ["reg", "drain"]
+        assert not r.is_pinned and r._cudart_lib is None
+
+    def test_success_pins_stores(self, monkeypatch):
+        fake = type(
+            "Fake",
+            (),
+            {
+                "cudaHostRegister": lambda s, p, sz, f: 0,
+                "drain_pending_error": lambda s: 0,
+            },
+        )()
+        monkeypatch.setattr(gpu_worker.current_platform, "is_cuda_alike", lambda: True)
+        monkeypatch.setattr(f"{GP_MOD}.CudaRTLibrary", lambda: fake)
+        r = _Region()
+        pin_mmap_region(r)
+        assert r.is_pinned and r._cudart_lib is fake
+
+    def test_non_cuda_skips(self, monkeypatch):
+        monkeypatch.setattr(gpu_worker.current_platform, "is_cuda_alike", lambda: False)
+        r = _Region()
+        pin_mmap_region(r)
+        assert not r.is_pinned
+
+
+# -- SharedOffloadRegion.cleanup (CPU-KV) ----------------------------------
+
+
+class TestKVOffloadCleanup:
+    def _setup(self, is_pinned=True, handle=None):
+        obj = _kv_obj()
+        obj.is_pinned = is_pinned
+        obj._cudart_lib = handle
+        obj._base = type("B", (), {"data_ptr": lambda s: 42})() if is_pinned else None
+        return obj
+
+    def test_cleanup_unregisters_through_stored_handle(self, monkeypatch):
+        monkeypatch.setattr(sor.current_platform, "is_cuda_alike", lambda: True)
+        events = []
+
+        class F:
+            def cudaHostUnregister(self, p):
+                events.append("unreg")
+                return 0
+
+        obj = self._setup(handle=F())
+        obj.cleanup()
+        assert events == ["unreg"] and not obj.is_pinned and obj._cudart_lib is None
+
+    def test_cleanup_idempotent(self, monkeypatch):
+        monkeypatch.setattr(sor.current_platform, "is_cuda_alike", lambda: True)
+        n = [0]
+
+        class F:
+            def cudaHostUnregister(self, p):
+                n[0] += 1
+                return 0
+
+        obj = self._setup(handle=F())
+        obj.cleanup()
+        obj.cleanup()
+        assert n[0] == 1
+
+    def test_cleanup_missing_handle_no_crash(self, monkeypatch):
+        monkeypatch.setattr(sor.current_platform, "is_cuda_alike", lambda: True)
+        obj = self._setup(handle=None)
+        obj.cleanup()  # no exception
+
+
+# -- ECSharedRegion.pin_memory + cleanup -----------------------------------
+
+
+class TestECRegion:
+    def test_failure_drains_and_no_unregister(self, monkeypatch):
+        events = []
+
+        class F:
+            def cudaHostRegister(self, p, s, f):
+                events.append("reg")
+                return 1
+
+            def drain_pending_error(self):
+                events.append("drain")
+                return 1
+
+            def cudaHostUnregister(self, p):
+                events.append("unreg")
+                return 0
+
+        monkeypatch.setattr(f"{EC_MOD}.CudaRTLibrary", lambda: F())
+        monkeypatch.setattr("torch.cuda.is_available", lambda: True)
+        s = _ec_stub()
+        s.pin_memory()
+        assert events == ["reg", "drain"] and not s._is_pinned and s._cudart_lib is None
+        events.clear()
+        s.cleanup()
+        assert "unreg" not in events
+
+    def test_success_stores_handle(self, monkeypatch):
+        fake = type(
+            "Fake",
+            (),
+            {
+                "cudaHostRegister": lambda s, p, sz, f: 0,
+                "drain_pending_error": lambda s: 0,
+                "cudaHostUnregister": lambda s, p: 0,
+            },
+        )()
+        monkeypatch.setattr(f"{EC_MOD}.CudaRTLibrary", lambda: fake)
+        monkeypatch.setattr("torch.cuda.is_available", lambda: True)
+        s = _ec_stub()
+        s.pin_memory()
+        assert s._is_pinned and s._cudart_lib is fake
+
+    def test_register_then_unregister_same_instance(self, monkeypatch):
+        events = []
+
+        class F:
+            def cudaHostRegister(self, p, s, f):
+                events.append("reg")
+                return 0
+
+            def drain_pending_error(self):
+                events.append("drain")
+                return 0
+
+            def cudaHostUnregister(self, p):
+                events.append("unreg")
+                return 0
+
+        monkeypatch.setattr(f"{EC_MOD}.CudaRTLibrary", lambda: F())
+        monkeypatch.setattr("torch.cuda.is_available", lambda: True)
+        s = _ec_stub()
+        s.pin_memory()
+        events.clear()
+        s.cleanup()
+        assert events == ["unreg"] and not s._is_pinned and s._cudart_lib is None
+
+    def test_cleanup_idempotent(self, monkeypatch):
+        n = [0]
+
+        class F:
+            def cudaHostRegister(self, p, s, f):
+                return 0
+
+            def drain_pending_error(self):
+                return 0
+
+            def cudaHostUnregister(self, p):
+                n[0] += 1
+                return 0
+
+        monkeypatch.setattr(f"{EC_MOD}.CudaRTLibrary", lambda: F())
+        monkeypatch.setattr("torch.cuda.is_available", lambda: True)
+        s = _ec_stub()
+        s.pin_memory()
+        s.cleanup()
+        s.cleanup()
+        assert n[0] == 1
+
+    def test_no_cuda_skips(self, monkeypatch):
+        monkeypatch.setattr("torch.cuda.is_available", lambda: False)
+        s = _ec_stub()
+        s.pin_memory()
+        assert not s._is_pinned
+
+
+# -- ROCm mapping + argtypes ----------------------------------------------
+
+ROCM_PAIRS = [
+    ("cudaHostRegister", "hipHostRegister"),
+    ("cudaHostUnregister", "hipHostUnregister"),
+    ("cudaGetLastError", "hipGetLastError"),
+]
+
+
+class TestStruct:
+    @pytest.mark.parametrize("cuda_n,hip_n", ROCM_PAIRS)
+    def test_roc_mapping(self, cuda_n, hip_n):
+        assert CudaRTLibrary.cuda_to_hip_mapping[cuda_n] == hip_n
+
+    def test_both_exported(self):
+        names = {f.name for f in CudaRTLibrary.exported_functions}
+        assert "cudaHostRegister" in names and "cudaHostUnregister" in names
+
+    def test_register_argtypes(self):
+        for f in CudaRTLibrary.exported_functions:
+            if f.name == "cudaHostRegister":
+                assert f.restype == cudaError_t and len(f.argtypes) == 3
+                return
+        pytest.fail("cudaHostRegister missing")
+
+    def test_unregister_argtypes(self):
+        for f in CudaRTLibrary.exported_functions:
+            if f.name == "cudaHostUnregister":
+                assert f.restype == cudaError_t and len(f.argtypes) == 1
+                return
+        pytest.fail("cudaHostUnregister missing")

--- a/vllm/distributed/device_communicators/cuda_wrapper.py
+++ b/vllm/distributed/device_communicators/cuda_wrapper.py
@@ -78,6 +78,20 @@ class CudaRTLibrary:
             cudaError_t,
             [ctypes.POINTER(ctypes.c_void_p), cudaIpcMemHandle_t, ctypes.c_uint],
         ),
+        # ​cudaError_t cudaGetLastError ( void )
+        Function("cudaGetLastError", cudaError_t, []),
+        # cudaError_t cudaHostRegister ( void* ptr, size_t size, unsigned int flags )
+        Function(
+            "cudaHostRegister",
+            cudaError_t,
+            [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_uint],
+        ),
+        # cudaError_t cudaHostUnregister ( void* ptr )
+        Function(
+            "cudaHostUnregister",
+            cudaError_t,
+            [ctypes.c_void_p],
+        ),
     ]
 
     # https://rocm.docs.amd.com/projects/HIPIFY/en/latest/tables/CUDA_Runtime_API_functions_supported_by_HIP.html # noqa
@@ -92,6 +106,9 @@ class CudaRTLibrary:
         "cudaMemcpy": "hipMemcpy",
         "cudaIpcGetMemHandle": "hipIpcGetMemHandle",
         "cudaIpcOpenMemHandle": "hipIpcOpenMemHandle",
+        "cudaGetLastError": "hipGetLastError",
+        "cudaHostRegister": "hipHostRegister",
+        "cudaHostUnregister": "hipHostUnregister",
     }
 
     # class attribute to store the mapping from the path to the library
@@ -137,6 +154,10 @@ class CudaRTLibrary:
     def CUDART_CHECK(self, result: cudaError_t) -> None:
         if result != 0:
             error_str = self.cudaGetErrorString(result)
+            # Drain any thread-local pending CUDA error so subsequent API
+            # calls are not poisoned by a stale error (e.g. from a previous
+            # best-effort cudaHostRegister that deliberately did not raise).
+            self.drain_pending_error()
             raise RuntimeError(f"CUDART error: {error_str}")
 
     def cudaGetErrorString(self, error: cudaError_t) -> str:
@@ -185,3 +206,42 @@ class CudaRTLibrary:
             )
         )
         return devPtr
+
+    def cudaGetLastError(self) -> int:
+        """Return (and clear) the thread-local pending CUDA runtime error.
+
+        Unlike other methods this deliberately does **not** call
+        ``CUDART_CHECK`` because a nonzero value is the expected/consumed
+        state (e.g. consuming a stale error left by a failed best-effort
+        ``cudaHostRegister``).  Returns the prior error code as a plain
+        Python int.
+        """
+        return int(self.funcs["cudaGetLastError"]())
+
+    def drain_pending_error(self) -> int:
+        """Canonical same-handle drain helper.
+
+        Drains and returns the thread-local pending CUDA runtime error
+        through this library handle.  Unlike ``CUDART_CHECK``, does not
+        raise — a nonzero return is the expected consumed state for
+        best-effort paths (e.g. after a failed ``cudaHostRegister``).
+        """
+        return self.cudaGetLastError()
+
+    def cudaHostRegister(self, ptr: int, size: int, flags: int = 0) -> int:
+        """Register host memory for CUDA DMA access (best-effort safe).
+
+        Returns the raw ``cudaError_t`` as a plain Python int — does
+        **not** call ``CUDART_CHECK`` so callers on best-effort paths
+        can inspect the result without raising.  Use ``drain_pending_error``
+        on the same instance to consume any thread-local pending error
+        after a nonzero return.
+        """
+        return int(self.funcs["cudaHostRegister"](ctypes.c_void_p(ptr), size, flags))
+
+    def cudaHostUnregister(self, ptr: int) -> int:
+        """Unregister host memory previously registered with cudaHostRegister.
+
+        Returns the raw ``cudaError_t`` as a plain Python int.
+        """
+        return int(self.funcs["cudaHostUnregister"](ctypes.c_void_p(ptr)))

--- a/vllm/distributed/ec_transfer/ec_connector/cpu/ec_shared_region.py
+++ b/vllm/distributed/ec_transfer/ec_connector/cpu/ec_shared_region.py
@@ -13,6 +13,7 @@ import time
 
 import torch
 
+from vllm.distributed.device_communicators.cuda_wrapper import CudaRTLibrary
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
@@ -61,6 +62,9 @@ class ECSharedRegion:
         self._is_creator = False
         # True after successful cudaHostRegister (cleanup must unregister).
         self._is_pinned = False
+        # Retained CudaRTLibrary handle; set by pin_memory on success, None
+        # on failure.  cleanup reads this exact instance for unregister.
+        self._cudart_lib: CudaRTLibrary | None = None
 
         # File descriptor for the shared memory backing file.
         try:
@@ -113,18 +117,21 @@ class ECSharedRegion:
         """
         if self._is_pinned or not torch.cuda.is_available():
             return
-        result = torch.cuda.cudart().cudaHostRegister(
-            self._blocks_ptr, self._blocks_nbytes, 0
-        )
-        if result.value != 0:
+        cudart_lib = CudaRTLibrary()
+        result = cudart_lib.cudaHostRegister(self._blocks_ptr, self._blocks_nbytes, 0)
+        if result != 0:
+            # Drain the thread-local pending CUDA error so subsequent
+            # API calls are not poisoned by this stale error.
+            cudart_lib.drain_pending_error()
             logger.warning(
                 "cudaHostRegister failed (code=%d) — "
                 "transfers will still work but may be slower (unpinned DMA)",
-                result.value,
+                result,
             )
         else:
             logger.debug("cudaHostRegister %.2f MB", self._blocks_nbytes / 1e6)
             self._is_pinned = True
+            self._cudart_lib = cudart_lib
 
     def cleanup(self) -> None:
         """Tear down the region. Lifecycle method; no concurrent access."""
@@ -139,10 +146,17 @@ class ECSharedRegion:
                 )
             self._is_creator = False
         if self._is_pinned:
-            result = torch.cuda.cudart().cudaHostUnregister(self._blocks_ptr)
-            if result.value != 0:
-                logger.warning("cudaHostUnregister failed (code=%d)", result)
+            if self._cudart_lib is None:
+                logger.warning(
+                    "cudaHostUnregister: _is_pinned=True but no retained "
+                    "CudaRTLibrary handle; skipping unregister"
+                )
+            else:
+                result = self._cudart_lib.cudaHostUnregister(self._blocks_ptr)
+                if result != 0:
+                    logger.warning("cudaHostUnregister failed (code=%d)", result)
             self._is_pinned = False
+            self._cudart_lib = None
         if hasattr(self, "blocks"):
             del self.blocks
         if self._mmap_obj:

--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
+++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
@@ -9,6 +9,7 @@ import numpy as np
 import torch
 
 from vllm import _custom_ops as ops
+from vllm.distributed.device_communicators.cuda_wrapper import CudaRTLibrary
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.triton_utils import HAS_TRITON, triton
@@ -132,9 +133,15 @@ def pin_mmap_region(region: SharedOffloadRegion) -> None:
 
     rank = region.rank
 
+    cudart_lib = CudaRTLibrary()
     base_ptr = region._base.data_ptr()
-    result = torch.cuda.cudart().cudaHostRegister(base_ptr, region.total_size_bytes, 0)
-    if result.value != 0:
+    result = cudart_lib.cudaHostRegister(base_ptr, region.total_size_bytes, 0)
+    if result != 0:
+        # Drain the thread-local pending CUDA runtime error left by
+        # the failed cudaHostRegister.  Without this explicit drain the
+        # stale error code causes the *next* unrelated CUDA runtime API
+        # call to fail with cudaErrorInvalidValue.
+        cudart_lib.drain_pending_error()
         logger.warning(
             "cudaHostRegister failed for rank=%d (code=%d) — "
             "transfers will still work but may be slower (unpinned DMA)",
@@ -148,6 +155,7 @@ def pin_mmap_region(region: SharedOffloadRegion) -> None:
             region.total_size_bytes / 1e9,
         )
         region.is_pinned = True
+        region._cudart_lib = cudart_lib
 
 
 def _new_descriptor_buffers(

--- a/vllm/v1/kv_offload/cpu/shared_offload_region.py
+++ b/vllm/v1/kv_offload/cpu/shared_offload_region.py
@@ -6,6 +6,7 @@ import time
 
 import torch
 
+from vllm.distributed.device_communicators.cuda_wrapper import CudaRTLibrary
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 
@@ -116,6 +117,7 @@ class SharedOffloadRegion:
         self._base = torch.frombuffer(memoryview(self.mmap_obj), dtype=torch.int8)
         self._views: list[torch.Tensor] = []
         self.is_pinned: bool = False
+        self._cudart_lib: CudaRTLibrary | None = None
 
     def create_next_view(self, tensor_page_size: int) -> torch.Tensor:
         """Allocate a strided int8 view for this worker, one canonical tensor.
@@ -173,15 +175,22 @@ class SharedOffloadRegion:
     def cleanup(self) -> None:
         if self.is_pinned and self._base is not None:
             if current_platform.is_cuda_alike():
-                base_ptr = self._base.data_ptr()
-                result = torch.cuda.cudart().cudaHostUnregister(base_ptr)
-                if result.value != 0:
+                if self._cudart_lib is None:
                     logger.warning(
-                        "cudaHostUnregister failed for rank=%d (code=%d)",
-                        self.rank,
-                        result,
+                        "cudaHostUnregister: is_pinned=True but no retained "
+                        "CudaRTLibrary handle; skipping unregister"
                     )
+                else:
+                    base_ptr = self._base.data_ptr()
+                    result = self._cudart_lib.cudaHostUnregister(base_ptr)
+                    if result != 0:
+                        logger.warning(
+                            "cudaHostUnregister failed for rank=%d (code=%d)",
+                            self.rank,
+                            result,
+                        )
             self.is_pinned = False
+            self._cudart_lib = None
         # Release views before _base: each view holds a _base reference and a
         # direct StorageImpl reference.  Freeing views first lets both refcounts
         # drop so the storage (which holds the mmap_obj buffer export) is freed


### PR DESCRIPTION
## Purpose

A failed best-effort `cudaHostRegister()` leaves a pending thread-local CUDA runtime error. If the fallback continues without draining that error, the next unrelated CUDA operation can fail even though pageable transfers remain valid.

The original revision mixed `torch.cuda.cudart()` for registration with a separately resolved `CudaRTLibrary` for draining. In a process with multiple CUDA runtime instances, those handles may not identify the same runtime.

This revision keeps each registration lifecycle on one `CudaRTLibrary` instance:

1. expose raw `cudaHostRegister`, `cudaHostUnregister`, and `drain_pending_error` operations on `CudaRTLibrary`;
2. make `CUDART_CHECK` drain through its own handle before raising;
3. use one handle for register and failed-register drain in CPU KV offload and EC shared regions;
4. retain that exact handle after successful registration so cleanup unregisters through the same instance.

A failed registration still falls back to pageable transfers. This PR does not claim to explain or fix why registration may fail. It also does not add Portable registration flags, retries, or runtime-path ranking.

## Test Plan

- Verify the raw wrapper methods do not raise on nonzero registration results.
- Verify `CUDART_CHECK` drains through the same wrapper instance before raising while preserving the original error.
- Exercise failed and successful registration through the production CPU KV and EC shared-region methods.
- Verify failed registration drains and remains unpinned.
- Verify successful registration retains the handle and cleanup unregisters through that same instance exactly once.
- Verify non-CUDA paths skip registration.
- Verify CUDA/ROCm symbol mappings and ctypes signatures.

## Test Result

- Focused hermetic source tests: **24 passed**.
- `py_compile`: passed for all five changed files.
- Ruff lint: passed.
- Ruff format check: passed.
- `git diff --check`: passed.

Hardware evidence for the earlier revision used one TP=2 host with 2x RTX PRO 6000 Blackwell GPUs and a 240 GiB shared CPU-KV mapping. A deterministic full-server canary forced one registration failure per TP process. Both ranks completed warmup, admitted the full 1M-token GPU KV configuration, remained healthy, and served requests without CUDA errors or restarts. An exact 52,173-token store → GPU-only reset → CPU reload gate restored 51,968 external tokens, recomputed 205 tokens, transferred 431,169,920 aggregate CPU-to-GPU bytes, and reproduced the control output exactly.

That canary established that draining the pending error preserves the pageable fallback. The final same-handle revision was then verified through the 24 focused production-seam tests above; it has not been rerun in that full-server canary. The underlying intermittent registration failure remains separate and unresolved.

---
<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR.
- [x] The test plan.
- [x] The test results.
- [x] Documentation update is not required for this runtime/fallback bugfix.
</details>
