### PR TITLE
[Bugfix][Frontend] Handle malformed InternLM2 tool output

### DIFF
--- a/tests/tool_parsers/test_internlm2_tool_parser.py
+++ b/tests/tool_parsers/test_internlm2_tool_parser.py
@@ -115,13 +115,25 @@ class TestInternLM2ToolParser(ToolParserTests):
                     "content instead of None - streaming/non-streaming inconsistency"
                 ),
             },
-            xfail_nonstreaming={
-                "test_malformed_input": (
-                    "InternLM2 parser raises JSONDecodeError on malformed JSON "
-                    "instead of gracefully handling it"
-                ),
-            },
         )
+
+
+@pytest.mark.parametrize(
+    "model_output",
+    [
+        '<|action_start|><|plugin|>{"name": "func", "parameters": {',
+        "<|action_start|><|plugin|>not json<|action_end|>",
+        "<|action_start|><|plugin|>",
+    ],
+)
+def test_malformed_nonstreaming_output_is_content(model_output: str) -> None:
+    parser = Internlm2ToolParser(MagicMock())
+
+    result = parser.extract_tool_calls(model_output, request=MagicMock())
+
+    assert not result.tools_called
+    assert result.tool_calls == []
+    assert result.content == model_output
 
 
 def test_streaming_arguments_in_single_delta(default_tokenizer: TokenizerLike) -> None:

--- a/vllm/tool_parsers/internlm2_tool_parser.py
+++ b/vllm/tool_parsers/internlm2_tool_parser.py
@@ -213,7 +213,12 @@ class Internlm2ToolParser(ToolParser):
             text, action = text.split("<|action_start|><|plugin|>")
             action = action.split("<|action_end|>".strip())[0]
             action = action[action.find("{") :]
-            action_dict = json.loads(action)
+            try:
+                action_dict = json.loads(action)
+            except json.JSONDecodeError:
+                return ExtractedToolCallInformation(
+                    tools_called=False, tool_calls=[], content=model_output
+                )
             name, parameters = (
                 action_dict["name"],
                 json.dumps(


### PR DESCRIPTION
## Purpose

Malformed or truncated non-streaming InternLM2 tool output currently raises `JSONDecodeError`, which turns the completion into an internal server error. Treat invalid tool-call JSON as regular assistant content and preserve the original model output.

This is separate from #44140, which handles repeated action markers causing `ValueError`; it does not handle invalid JSON.

Valid tool calls are unchanged. Model evaluation is not applicable because this only changes fallback behavior for malformed parser input.

AI assistance was used to prepare this change; the submitter reviewed the diff and test results.

## Test Plan

Run the InternLM2 tool parser unit tests and Ruff checks for the changed files.

## Test Result

- `.venv/bin/python -m pytest tests/tool_parsers/test_internlm2_tool_parser.py -v`
  - `14 passed, 7 xfailed`
- `.venv/bin/pre-commit run ruff-check --files vllm/tool_parsers/internlm2_tool_parser.py tests/tool_parsers/test_internlm2_tool_parser.py`
  - Passed
- `.venv/bin/pre-commit run ruff-format --files vllm/tool_parsers/internlm2_tool_parser.py tests/tool_parsers/test_internlm2_tool_parser.py`
  - Passed