### PR TITLE
[Bugfix][NVFP4] Write linear V block scales on SM120/SM121 KV cache

### DIFF
--- a/csrc/libtorch_stable/nvfp4_kv_cache_kernels.cu
+++ b/csrc/libtorch_stable/nvfp4_kv_cache_kernels.cu
@@ -153,12 +153,19 @@ __global__ void reshape_and_cache_nvfp4_kernel(
 #endif
 
       // Write block scale to scale cache.
-      // K (kv==0): linear layout (no swizzle).
-      // V (kv==1): swizzled layout for SM100 trtllm-gen MHA kernel.
+      // SM100 trtllm-gen requires swizzled V scales. SM120 XQA consumes
+      // ordinary tensor strides for both K and V scales, so both must be
+      // linear there.
       if (sf_out_ptr != nullptr) {
         int scale_idx = group_in_head;
         uint8_t* __restrict__ scale_dst;
-        if (kv == 0) {
+#if defined(__CUDA_ARCH__) && \
+    (__CUDA_ARCH__ == 1200 || __CUDA_ARCH__ == 1210)
+        constexpr bool swizzle_v_scale = false;
+#else
+        constexpr bool swizzle_v_scale = true;
+#endif
+        if (kv == 0 || !swizzle_v_scale) {
           scale_dst = scale_block + head * scale_head_stride +
                       block_offset * scale_block_offset_stride + scale_idx;
         } else {

--- a/tests/kernels/attention/test_cache.py
+++ b/tests/kernels/attention/test_cache.py
@@ -354,28 +354,57 @@ def test_reshape_and_cache_flash(
             dequant_nvfp4_kv_cache,
         )
 
-        def dequant_nvfp4_cache_nhd(data_cache, scale_cache, global_scale):
+        def dequant_nvfp4_cache_nhd(
+            data_cache,
+            scale_cache,
+            global_scale,
+            scales_are_swizzled,
+        ):
             # data_cache:  [N, T, H, data_dim]  NHD (contiguous inner dims)
             # scale_cache: [N, T, H, scale_dim] NHD (contiguous inner dims)
             # Permute to HND layout for the dequant utility.
             data_hnd = data_cache.permute(0, 2, 1, 3)
             scale_hnd = scale_cache.permute(0, 2, 1, 3)
             result_hnd = dequant_nvfp4_kv_cache(
-                data_hnd, scale_hnd, global_scale, head_size, block_size
+                data_hnd,
+                scale_hnd,
+                global_scale,
+                head_size,
+                block_size,
+                scales_are_swizzled=scales_are_swizzled,
             )
             return result_hnd.permute(0, 2, 1, 3)  # back to [N, T, H, D]
 
         result_key_cache = dequant_nvfp4_cache_nhd(
-            nvfp4_key_data, key_scale_cache, k_scale.item()
+            nvfp4_key_data,
+            key_scale_cache,
+            k_scale.item(),
+            scales_are_swizzled=False,
         )
         result_value_cache = dequant_nvfp4_cache_nhd(
-            nvfp4_value_data, value_scale_cache, v_scale.item()
+            nvfp4_value_data,
+            value_scale_cache,
+            v_scale.item(),
+            scales_are_swizzled=not current_platform.is_device_capability(120),
         )
 
         # Flatten [num_blocks, block_size] → [num_slots] and index by slot_mapping.
         num_slots = num_blocks * block_size
         result_key_flat = result_key_cache.reshape(num_slots, num_heads, head_size)
         result_value_flat = result_value_cache.reshape(num_slots, num_heads, head_size)
+
+        # A loose assert_close can hide structurally wrong scale ordering.
+        # Normal NVFP4 loss is about 0.1 relative L2 for these inputs.
+        for name, actual, expected in (
+            ("key", result_key_flat[slot_mapping], key.float()),
+            ("value", result_value_flat[slot_mapping], value.float()),
+        ):
+            rel_l2 = torch.linalg.vector_norm(
+                actual - expected
+            ) / torch.linalg.vector_norm(
+                expected,
+            )
+            assert rel_l2 < 0.15, f"{name} NVFP4 relative L2 error: {rel_l2}"
 
         torch.testing.assert_close(
             result_key_flat[slot_mapping], key.float(), atol=1.5, rtol=0.5

--- a/tests/kernels/attention/test_flashinfer_trtllm_attention.py
+++ b/tests/kernels/attention/test_flashinfer_trtllm_attention.py
@@ -117,10 +117,20 @@ def make_nvfp4_kv_cache(
 
     # Dequantize for the FA2 reference baseline.
     ref_k = dequant_nvfp4_kv_cache(
-        k_data, k_scales, kv_scale_val, head_size, block_size
+        k_data,
+        k_scales,
+        kv_scale_val,
+        head_size,
+        block_size,
+        scales_are_swizzled=False,
     ).to(torch.bfloat16)
     ref_v = dequant_nvfp4_kv_cache(
-        v_data, v_scales, kv_scale_val, head_size, block_size
+        v_data,
+        v_scales,
+        kv_scale_val,
+        head_size,
+        block_size,
+        scales_are_swizzled=not current_platform.is_device_capability(120),
     ).to(torch.bfloat16)
     ref_kv_bf16 = torch.stack([ref_k, ref_v], dim=1)  # [N, 2, H, T, D]
 

--- a/tests/kernels/quantization/nvfp4_utils.py
+++ b/tests/kernels/quantization/nvfp4_utils.py
@@ -94,8 +94,9 @@ def dequant_nvfp4_kv_cache(
     global_scale: float,
     head_size: int,
     block_size: int,
+    scales_are_swizzled: bool = True,
 ) -> torch.Tensor:
-    """Dequantize an NVFP4 KV cache with 4x4-swizzled block scales.
+    """Dequantize an NVFP4 KV cache.
 
     The input must be in HND layout so that the last two dims are
     (block_size, last_dim).  For NHD caches, permute to HND first.
@@ -107,6 +108,7 @@ def dequant_nvfp4_kv_cache(
         global_scale: checkpoint dequant scale (k_scale or v_scale).
         head_size: head dimension.
         block_size: page size.
+        scales_are_swizzled: Whether block scales use TRT-LLM's 4x4 layout.
 
     Returns:
         [..., num_heads, block_size, head_size] float32.
@@ -115,18 +117,22 @@ def dequant_nvfp4_kv_cache(
     scale_dim = head_size // 16
 
     fp4_packed = fp4_data
-    sf_swizzled = block_scale.view(torch.uint8)
-
-    # Unswizzle 4x4 block scales on (block_size, scale_dim) plane.
-    # [..., T, S] → [..., T//4, 4, sg, 4] → permute → [..., T, S]
-    batch_shape = sf_swizzled.shape[:-2]
-    T, S = block_size, scale_dim
-    sg = S // 4
-    sf_reshape = sf_swizzled.reshape(*batch_shape, T // 4, 4, sg, 4)
-    ndim = sf_reshape.ndim
-    # Swap the last four dims: (..., T//4, 4, sg, 4) → (..., T//4, 4, 4, sg)
-    perm = list(range(ndim - 4)) + [ndim - 4, ndim - 1, ndim - 3, ndim - 2]
-    sf_linear = sf_reshape.permute(*perm).reshape(*batch_shape, T, S)
+    sf_linear = block_scale.view(torch.uint8)
+    if scales_are_swizzled:
+        # Unswizzle 4x4 block scales on (block_size, scale_dim) plane.
+        # [..., T, S] → [..., T//4, 4, sg, 4] → permute → [..., T, S]
+        batch_shape = sf_linear.shape[:-2]
+        T, S = block_size, scale_dim
+        sg = S // 4
+        sf_reshape = sf_linear.reshape(*batch_shape, T // 4, 4, sg, 4)
+        ndim = sf_reshape.ndim
+        perm = list(range(ndim - 4)) + [
+            ndim - 4,
+            ndim - 1,
+            ndim - 3,
+            ndim - 2,
+        ]
+        sf_linear = sf_reshape.permute(*perm).reshape(*batch_shape, T, S)
     sf_f32 = sf_linear.view(torch.float8_e4m3fn).to(torch.float32)
 
     # Unpack fp4


### PR DESCRIPTION
## Purpose

Fixes #50084.

`reshape_and_cache_nvfp4_kernel` writes **K** block scales linearly but writes **V** block scales in the 4×4 swizzle required by the SM100 `trtllm-gen` MHA kernel — unconditionally, on every architecture.

On SM120/SM121 the NVFP4 KV route (FA2 prefill + FlashInfer **XQA** decode) consumes K and V scale tensors through ordinary NHD tensor strides. The XQA wrapper receives `[pages, page_size, kv_heads, head_dim/16]` scale tensors with the real strides, and the XQA CUDA code contains **no V-scale de-swizzle**. FlashInfer's own paged-NVFP4 quantizer documents its V-scale swizzle as being *for `trtllm-gen` MHA*; that is not the XQA layout.

The result is a swizzled producer feeding a linear consumer. Every tensor has the correct shape, dtype, offset and alignment, and there is no error path — V scales are simply read in the wrong order and the model degrades silently.

This PR gates the swizzle on architecture: **retain it for SM100/SM103, write linear V scales for SM120/SM121.** K-scale layout is untouched. The gate is `constexpr` on `__CUDA_ARCH__`, so there is no runtime branch cost and no behavior change for datacenter Blackwell.

To be clear about scope: this is **below** the read-side routing work in #49011 / #44851 (which selects kernels and binds views) and unrelated to #43562 (no sm_120 `trtllm-gen` FMHA build). It is the layout the data was written in to begin with.

## Test plan

Model-free probes: deterministic BF16 inputs written through the installed `reshape_and_cache_flash` binding, then independently unpacked and dequantized. Direct XQA exercised with 2 pages, page size 16, non-trivial block table `[1, 0]`, sequence length 23 — so page metadata and indexing are covered — across KV heads 1/2/4/8 and Q heads 8/16/24/48, head_dim 256.

This PR also tightens the existing kernel tests. `tests/kernels/attention/test_cache.py` previously passed with `assert_close(atol=1.5, rtol=0.5)`, which a structurally wrong scale ordering slips straight through. The tests now select the expected V-scale layout by device capability and assert a relative-L2 bound; `dequant_nvfp4_kv_cache` grows a `scales_are_swizzled` parameter (defaulting to `True`, preserving current callers).

## Test result

Normal NVFP4 loss for these inputs is ≈0.095 relative L2, which is what K shows. Before the fix, V is far outside that band, and linearizing *only* the V scales restores it:

| KV heads / Q heads | K rel-L2 | V rel-L2 (before) | V rel-L2 (scales linearized) |
|---:|---:|---:|---:|
| 1 / 8 | 0.0952 | 0.7625 | 0.0953 |
| 2 / 16 | 0.0954 | 0.7615 | 0.0949 |
| 4 / 24 | 0.0948 | 0.7876 | 0.0957 |
| 8 / 48 | 0.0946 | 0.7649 | 0.0953 |

Direct XQA, before the fix, reproduces almost exactly a reference that *deliberately applies the wrong V-scale order* — which localizes the fault to the layout contract rather than the XQA math:

| KV heads / Q heads | vs correct ref | vs deliberately-wrong-scale ref | linear-V vs correct ref |
|---:|---:|---:|---:|
| 1 / 8 | 0.8222 | 0.00211 | 0.00213 |
| 2 / 16 | 0.7861 | 0.00218 | 0.00219 |
| 4 / 24 | 0.7769 | 0.00216 | 0.00216 |
| 8 / 48 | 0.7453 | 0.00214 | 0.00212 |

After rebuilding the corrected writer, stored V relative L2 matches K exactly, and applying the *old* inverse transform now damages it (0.026317 → 0.592983) — confirming the layout genuinely flipped:

| KV heads | K rel-L2 | patched V rel-L2 | XQA vs ref | strided vs contiguous |
|---:|---:|---:|---:|---:|
| 1 | 0.09517 | 0.09530 | 0.002135 | 0 |
| 2 | 0.09542 | 0.09493 | 0.002194 | 0 |
| 4 | 0.09478 | 0.09568 | 0.002159 | 0 |
| 8 | 0.09457 | 0.09533 | 0.002121 | 0 |

Two controls worth stating explicitly:

- **Not a striding/contiguity artifact.** Copying the four split views into explicit contiguous buffers changed direct-XQA output by exactly zero for every head count. Only changing V scale values from swizzled to linear corrected it.
- **Not KV-head-count specific.** 2 and 4 KV heads fail the same structural test and both recover. A checkpoint that appeared healthy on this route was not evidence the layout was valid.

**End-to-end.** 150-scenario agentic/quality suites on a Qwen3.6-derived 27B NVFP4 checkpoint over the SM120 NVFP4-KV route, thinking-on, two draws per arm. Matched comparison — same night, same image, 131,072 context / 8 GiB pinned KV / 6 sequences, changing only `--kv-cache-dtype`:

| KV dtype (post-fix writer) | draws | mean |
|---|---|--:|
| FP8 E4M3 (control) | 121, 122 | 121.5 / 150 |
| NVFP4 | 121, 124 | **122.5 / 150** |

Post-fix, FP4 KV lands on top of its FP8 control instead of below it. The same checkpoint on the pre-fix writer averaged 116/150 — though that run used a 262,144 context envelope, so it is not a matched arm and I'm not claiming the delta as a clean measurement, only as direction.

Worth emphasizing for reviewers: pre-fix, this configuration passed every smoke test, needle-in-a-haystack retrieval to 246,660 prompt tokens, and 1h40m of continuous load with zero errors. There is no failure signature to grep for — which is why the tightened test bound matters as much as the kernel change.

## Environment

RTX 5090 (SM120), driver 610.62, CUDA 13.0, WSL2. vLLM v0.25.1 (`752a3a5`), FlashInfer 0.6.15.post1, PyTorch 2.11.0+cu130. I do not have SM100/SM103 hardware, so the datacenter path is verified by construction (`constexpr` gate, unchanged branch) rather than by execution — that arm would benefit from a reviewer with B200 access.
