### PR TITLE
[KV Offload] Per-request store strategy hook (covers #42050 + admission seam)

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import time
-from abc import ABC, abstractmethod
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from itertools import chain, islice
@@ -65,70 +64,6 @@ logger = init_logger(__name__)
 KV_LOAD_TIERS_KEY = "kv_load_tiers"
 MATCHER_MEDIUM_KEY = "medium"
 MATCHER_LOCALITY_KEY = "locality"
-
-
-class StoreStrategy(ABC):
-    """Per-request store policy. Stateful: one instance per request.
-
-    The instance lives on ``RequestOffloadState._store_strategy`` (set
-    in ``__post_init__`` from ``offloading_context.store_policy``).
-    State, counters, and per-request config belong on the strategy
-    instance, not on ``RequestOffloadState`` -- the latter is for KV
-    bookkeeping (cursors, block_ids, in-flight jobs). The strategy only
-    answers the single "what's the per-group store boundary this step?"
-    question; reachability filtering and packing are architectural
-    invariants owned by the scheduler and must remain so.
-
-    Two deliberate choices vs #42050's ``OffloadPolicy``:
-      * progress ownership: #42050 stores cursors on the policy
-        (``self._stored_idx: dict[req_id, list[int]]``); this design
-        keeps cursors in ``RequestOffloadState`` and lets the strategy
-        hold only *non-progress* per-request state, so the scheduler's
-        cursor invariants stay in one place.
-      * strategy lifetime: #42050 uses a scheduler-singleton policy
-        with cross-request dict state; this design uses a per-request
-        instance selected from ``offloading_context.store_policy``, so
-        each request can run a different policy.
-    """
-
-    @abstractmethod
-    def store_extent(
-        self,
-        req_status: RequestOffloadState,
-        num_offloadable_tokens: int,
-    ) -> list[int]:
-        """Per-group exclusive chunk boundary for this step.
-
-        Returned in ``config.kv_group_configs`` order; returning
-        ``group_state.next_stored_chunk_idx`` for a group means "defer this
-        step" (no new chunks offered, cursor stays put). The eager default is
-        the eligible boundary computed by ``req_status.storable_chunks``.
-        """
-        ...
-
-
-class EagerStoreStrategy(StoreStrategy):
-    """Default: every group's eligible chunk boundary."""
-
-    def store_extent(self, req_status, num_offloadable_tokens):
-        return req_status.storable_chunks_for_each_group(num_offloadable_tokens)
-
-
-class DeferUntilFinishStoreStrategy(StoreStrategy):
-    """Defer every group until the request reaches a terminal state.
-
-    Related: #42050 introduces ``request_finished`` on
-    ``OffloadingManager``, which lets the manager react when a request
-    ends (e.g. flush a deferred last-block transfer). This strategy is
-    the scheduler-side mirror: deferring all stores until
-    ``req.is_finished()`` so no incremental chunks hit the offload tier
-    during decode. See the #49413 RFC thread for context.
-    """
-
-    def store_extent(self, req_status, num_offloadable_tokens):
-        if req_status.req.is_finished():
-            return req_status.storable_chunks_for_each_group(num_offloadable_tokens)
-        return req_status.store_frontiers()
 
 
 @dataclass(slots=True)
@@ -430,12 +365,11 @@ class RequestOffloadState:
     deferred_lookup_start_time: float | None = None
     # True once on_request_finished has been signaled to the manager.
     finished_signaled: bool = False
-    # Per-request store strategy. Translated from
-    # ``offloading_context.store_policy`` in ``__post_init__``; the
-    # scheduler reads it via ``store_extent`` on every step. The mapping
-    # is a small closed dispatch (see ``__post_init__``) -- new policies
-    # add a branch there, not a registry.
-    _store_strategy: StoreStrategy = field(init=False, repr=False)
+    # Per-request store policy is held in
+    # ``offloading_context.store_policy`` (a ``StorePolicy`` enum set by
+    # the tier's ``on_new_request``). The two built-in policies are
+    # dispatched inline in ``_store_extent`` via a small closed
+    # ``match``.
 
     def __post_init__(self) -> None:
         self.group_states = tuple(
@@ -458,17 +392,9 @@ class RequestOffloadState:
                 "max_offload_tokens must be a non-negative int, got %r; ignoring", raw
             )
 
-        # Translate the tier's ``offloading_context.store_policy`` choice
-        # into a concrete ``StoreStrategy`` instance. The tier does not
-        # know about ``StoreStrategy`` (it returns an enum in its
-        # ``on_new_request`` hook); this dispatch is the only place
-        # external intent becomes a scheduler-internal object. New
-        # ``StorePolicy`` values add a branch here.
-        match self.offloading_context.store_policy:
-            case StorePolicy.ON_COMPUTE:
-                self._store_strategy = EagerStoreStrategy()
-            case StorePolicy.ON_FINISH:
-                self._store_strategy = DeferUntilFinishStoreStrategy()
+        # (No strategy instance to construct -- the two built-in policies
+        # are dispatched inline in ``_store_extent`` via a small closed
+        # ``match`` on ``self.offloading_context.store_policy``.)
 
     def update_offload_keys(self) -> None:
         for group_config, group_state in zip(
@@ -527,23 +453,28 @@ class RequestOffloadState:
     def _store_extent(self, num_offloadable_tokens: int) -> list[int]:
         """Resolve this step's per-group store boundary from the store policy.
 
-        Delegates to the per-request ``StoreStrategy`` instance set in
-        ``__post_init__`` from ``offloading_context.store_policy``. The
-        strategy is *not* a singleton -- each request holds its own
-        instance so per-request state (counters, accumulators, ...) can
-        live on the strategy itself.
+        Dispatches inline on ``offloading_context.store_policy``:
+
+          * ``ON_COMPUTE``: the eager per-group eligible boundary
+            (``storable_chunks_for_each_group``).
+          * ``ON_FINISH``: defer every group until the request
+            reaches a terminal state; once ``req.is_finished()``,
+            fall back to the eager boundary.
 
         Each entry is the exclusive end index of the leading chunks to
-        store for that group this step; returning
-        ``group_state.next_stored_chunk_idx`` for a group means "defer"
-        (no new chunks offered, cursor stays put). The eager default is
-        identical to ``storable_chunks`` for every group.
-
-        Internal: the per-group list is cached in ``_step_extents``
-        and consumed by ``finalize_store_step`` via
-        ``_consume_step_extents``. Callers never see the list.
+        store for that group this step; the per-group store frontier
+        (``group_state.next_stored_chunk_idx``) signals "defer this
+        step" (no new chunks offered, cursor stays put). Callers (the
+        store path) pass ``num_offloadable_tokens``; the per-group
+        extent list is resolved here and never exposed.
         """
-        return self._store_strategy.store_extent(self, num_offloadable_tokens)
+        match self.offloading_context.store_policy:
+            case StorePolicy.ON_COMPUTE:
+                return self.storable_chunks_for_each_group(num_offloadable_tokens)
+            case StorePolicy.ON_FINISH:
+                if self.req.is_finished():
+                    return self.storable_chunks_for_each_group(num_offloadable_tokens)
+                return self.store_frontiers()
 
     def _advance_to_extent(self, ends: list[int]) -> None:
         """Advance each group's store cursor to ``ends[i]``.
@@ -562,20 +493,18 @@ class RequestOffloadState:
     def store_frontiers(self) -> list[int]:
         """Per-group store frontiers (``RequestGroupState.next_stored_chunk_idx``).
 
-        Consulted by ``DeferUntilFinishStoreStrategy`` to report its
-        deferred extent ("stay where you are"). Bulk accessor so
-        strategies don't iterate ``group_states`` directly.
+        Used by the inline ``ON_FINISH`` branch of ``_store_extent``
+        to report its deferred extent ("stay where you are").
         """
         return [gs.next_stored_chunk_idx for gs in self.group_states]
 
     def storable_chunks_for_each_group(self, num_offloadable_tokens: int) -> list[int]:
         """Per-group eligible storable-chunk count.
 
-        Used by ``EagerStoreStrategy.store_extent``: the eager
-        strategy's per-group boundary is "the eligible boundary
-        computed from ``num_offloadable_tokens`` and the per-group
-        chunk size". Bulk accessor so strategies don't iterate
-        ``group_states`` directly.
+        Used by the inline ``ON_COMPUTE`` / finished-``ON_FINISH``
+        branches of ``_store_extent``: the eager boundary is "the
+        eligible boundary computed from ``num_offloadable_tokens``
+        and the per-group chunk size".
         """
         return [
             self.storable_chunks(gc, gs, num_offloadable_tokens)
@@ -1387,12 +1316,23 @@ class OffloadingConnectorScheduler:
             store_output = self.manager.prepare_store(
                 new_offload_keys, req_status.req_context
             )
-            if store_output is None or not store_output.keys_to_store:
-                if store_output is None:
-                    self._connector_stats.increase_counter(
-                        _ConnectorMetricName.ALLOCATION_FAILURE
-                    )
-                    logger.warning("Request %s: cannot store chunks", req_id)
+            if store_output is None:
+                # Allocation failure: keep the per-group store cursors so
+                # the next step re-offers the same candidates (the
+                # manager might recover). This matches the pre-refactor
+                # semantics where prepare_store failure skipped the
+                # advance_to_extent.
+                self._connector_stats.increase_counter(
+                    _ConnectorMetricName.ALLOCATION_FAILURE
+                )
+                logger.warning("Request %s: cannot store chunks", req_id)
+                continue
+
+            if not store_output.keys_to_store:
+                # Manager rejected all candidates -- nothing to store
+                # this step; advance the cursors so next step's
+                # ``ends`` reflects today's eligibility, not stale
+                # state.
                 req_status.finalize_store_step(num_offloadable_tokens)
                 continue
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -1,10 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
 import time
-from collections.abc import Iterable, Sequence
+from abc import ABC, abstractmethod
+from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass, field
 from itertools import chain, islice
-from typing import Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from vllm.config import VllmConfig
 from vllm.distributed.kv_events import KVCacheEvent
@@ -49,6 +52,7 @@ from vllm.v1.kv_offload.base import (
     ReqContext,
     RequestOffloadingContext,
     ScheduleEndContext,
+    StorePolicy,
     TierFilter,
     TierMatcher,
     make_offload_key,
@@ -61,6 +65,87 @@ logger = init_logger(__name__)
 KV_LOAD_TIERS_KEY = "kv_load_tiers"
 MATCHER_MEDIUM_KEY = "medium"
 MATCHER_LOCALITY_KEY = "locality"
+
+
+if TYPE_CHECKING:
+    # Forward reference defined in the per-candidate admission follow-up
+    # (Decision A of #49413). See
+    # ``RequestOffloadState.iterate_candidates_for_store`` for the seam.
+    _StoreCandidate = Any
+
+
+class StoreStrategy(ABC):
+    """Per-request store policy. Stateful: one instance per request.
+
+    The instance lives on ``RequestOffloadState._store_strategy`` (set
+    in ``__post_init__`` from ``offloading_context.store_policy``).
+    State, counters, and per-request config belong on the strategy
+    instance, not on ``RequestOffloadState`` -- the latter is for KV
+    bookkeeping (cursors, block_ids, in-flight jobs). The strategy only
+    answers the single "what's the per-group store boundary this step?"
+    question; reachability filtering and packing are architectural
+    invariants owned by the scheduler and must remain so.
+
+    Two deliberate choices vs #42050's ``OffloadPolicy``:
+      * progress ownership: #42050 stores cursors on the policy
+        (``self._stored_idx: dict[req_id, list[int]]``); this design
+        keeps cursors in ``RequestOffloadState`` and lets the strategy
+        hold only *non-progress* per-request state, so the scheduler's
+        cursor invariants stay in one place.
+      * strategy lifetime: #42050 uses a scheduler-singleton policy
+        with cross-request dict state; this design uses a per-request
+        instance selected from ``offloading_context.store_policy``, so
+        each request can run a different policy.
+    """
+
+    @abstractmethod
+    def store_extent(
+        self,
+        req_status: RequestOffloadState,
+        num_offloadable_tokens: int,
+    ) -> list[int]:
+        """Per-group exclusive chunk boundary for this step.
+
+        Returned in ``config.kv_group_configs`` order; returning
+        ``group_state.next_stored_chunk_idx`` for a group means "defer this
+        step" (no new chunks offered, cursor stays put). The eager default is
+        the eligible boundary computed by ``req_status.storable_chunks``.
+        """
+        ...
+
+
+class EagerStoreStrategy(StoreStrategy):
+    """Default: every group's eligible chunk boundary."""
+
+    def store_extent(self, req_status, num_offloadable_tokens):
+        return [
+            req_status.storable_chunks(gc, gs, num_offloadable_tokens)
+            for gc, gs in zip(
+                req_status.config.kv_group_configs, req_status.group_states
+            )
+        ]
+
+
+class DeferUntilFinishStoreStrategy(StoreStrategy):
+    """Defer every group until the request reaches a terminal state.
+
+    Related: #42050 introduces ``request_finished`` on
+    ``OffloadingManager``, which lets the manager react when a request
+    ends (e.g. flush a deferred last-block transfer). This strategy is
+    the scheduler-side mirror: deferring all stores until
+    ``req.is_finished()`` so no incremental chunks hit the offload tier
+    during decode. See the #49413 RFC thread for context.
+    """
+
+    def store_extent(self, req_status, num_offloadable_tokens):
+        if req_status.req.is_finished():
+            return [
+                req_status.storable_chunks(gc, gs, num_offloadable_tokens)
+                for gc, gs in zip(
+                    req_status.config.kv_group_configs, req_status.group_states
+                )
+            ]
+        return [gs.next_stored_chunk_idx for gs in req_status.group_states]
 
 
 @dataclass(slots=True)
@@ -140,7 +225,7 @@ def is_store_reachable_swa_chunk(
 
 
 def resolve_mamba_align_size(
-    spec: "OffloadingSpec", kv_cache_config: KVCacheConfig
+    spec: OffloadingSpec, kv_cache_config: KVCacheConfig
 ) -> int | None:
     """Scan all KV cache groups in *spec* and return the single mamba alignment
     size, or None if no group requires mamba alignment.
@@ -171,7 +256,7 @@ class SchedulerOffloadConfig(NamedTuple):
         spec: OffloadingSpec,
         vllm_config: VllmConfig,
         kv_cache_config: KVCacheConfig,
-    ) -> "SchedulerOffloadConfig":
+    ) -> SchedulerOffloadConfig:
         # Determine the alignment token count from the full-attention group(s).
         # This is the tokens_per_chunk of the full-attention group; load
         # hits are always aligned to this boundary, so SWA blocks earlier in
@@ -288,6 +373,12 @@ class RequestOffloadState:
     deferred_lookup_start_time: float | None = None
     # True once on_request_finished has been signaled to the manager.
     finished_signaled: bool = False
+    # Per-request store strategy. Translated from
+    # ``offloading_context.store_policy`` in ``__post_init__``; the
+    # scheduler reads it via ``store_extent`` on every step. The mapping
+    # is a small closed dispatch (see ``__post_init__``) -- new policies
+    # add a branch there, not a registry.
+    _store_strategy: StoreStrategy = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
         self.group_states = tuple(
@@ -308,6 +399,18 @@ class RequestOffloadState:
             logger.warning(
                 "max_offload_tokens must be a non-negative int, got %r; ignoring", raw
             )
+
+        # Translate the tier's ``offloading_context.store_policy`` choice
+        # into a concrete ``StoreStrategy`` instance. The tier does not
+        # know about ``StoreStrategy`` (it returns an enum in its
+        # ``on_new_request`` hook); this dispatch is the only place
+        # external intent becomes a scheduler-internal object. New
+        # ``StorePolicy`` values add a branch here.
+        match self.offloading_context.store_policy:
+            case StorePolicy.ON_COMPUTE:
+                self._store_strategy = EagerStoreStrategy()
+            case StorePolicy.ON_FINISH:
+                self._store_strategy = DeferUntilFinishStoreStrategy()
 
     def update_offload_keys(self) -> None:
         for group_config, group_state in zip(
@@ -337,7 +440,7 @@ class RequestOffloadState:
 
     def storable_chunks(
         self,
-        group_config: "GroupOffloadConfig",
+        group_config: GroupOffloadConfig,
         group_state: RequestGroupState,
         num_offloadable_tokens: int,
     ) -> int:
@@ -363,17 +466,59 @@ class RequestOffloadState:
         )
         return min(num_chunks, num_allocated_chunks)
 
-    def advance_stored_idx(self, num_offloadable_tokens: int) -> None:
-        # max(): at the prefill->decode transition of a chunk-aligned prompt,
-        # storable_chunks drops by one (the eagle exclusion kicks in), and the
-        # index must not move backwards past already-stored chunks.
-        for group_config, group_state in zip(
-            self.config.kv_group_configs, self.group_states
-        ):
+    def store_extent(self, num_offloadable_tokens: int) -> list[int]:
+        """Resolve this step's per-group store boundary from the store policy.
+
+        Delegates to the per-request ``StoreStrategy`` instance set in
+        ``__post_init__`` from ``offloading_context.store_policy``. The
+        strategy is *not* a singleton -- each request holds its own
+        instance so per-request state (counters, accumulators, ...) can
+        live on the strategy itself.
+
+        Each entry is the exclusive end index of the leading chunks to
+        store for that group this step; returning
+        ``group_state.next_stored_chunk_idx`` for a group means "defer"
+        (no new chunks offered, cursor stays put). The eager default is
+        identical to ``storable_chunks`` for every group.
+
+        Call once per step. The returned list is the **single source of
+        truth** for what the store loop should offer -- the per-group loop
+        uses ``ends[group_idx]`` instead of recomputing
+        ``storable_chunks(...)``, and cursor advance uses
+        ``advance_to_extent(ends)`` instead of recomputing
+        ``storable_chunks`` again. This keeps selection and advance
+        consistent so a deferred group's cursor can never jump past
+        chunks that were not offered.
+        """
+        return self._store_strategy.store_extent(self, num_offloadable_tokens)
+
+    def advance_to_extent(self, ends: list[int]) -> None:
+        """Advance each group's store cursor to ``ends[i]``.
+
+        ``ends`` is what ``store_extent`` (or the eager equivalent) just
+        produced for this step. ``max()`` guards the eagle prefill->decode
+        transition where the eligible boundary momentarily drops by one.
+        """
+        assert len(ends) == len(self.group_states)
+        for group_state, end in zip(self.group_states, ends):
             group_state.next_stored_chunk_idx = max(
-                group_state.next_stored_chunk_idx,
-                self.storable_chunks(group_config, group_state, num_offloadable_tokens),
+                group_state.next_stored_chunk_idx, end
             )
+
+    def iterate_candidates_for_store(
+        self, num_offloadable_tokens: int
+    ) -> Iterator[_StoreCandidate] | None:
+        """Seam for the per-candidate admission follow-up (Decision A of #49413).
+
+        Default returns ``None``, opting in to the per-group dispatch in
+        ``_build_store_jobs``. The per-candidate admission follow-up
+        (after #49506 lands) overrides this to return an iterator that
+        yields ``_StoreCandidate`` tuples in cross-group ending-token
+        order; the scheduler's per-candidate dispatch then consumes the
+        iterator to call ``manager.prepare_store`` once per admitted key
+        with prefix-transactional failure semantics.
+        """
+        return None
 
     def update_num_hit_chunks(self, num_cached_tokens: int) -> None:
         for group_config, group_state in zip(
@@ -1049,13 +1194,14 @@ class OffloadingConnectorScheduler:
 
             # Filter out chunks skipped due to sliding window attention / SSM
             # or unreachable by the load path's alignment constraints.
+            # ``ends`` is the policy-adjusted per-group store boundary; see
+            # ``RequestOffloadState.store_extent``.
+            ends = req_status.store_extent(num_offloadable_tokens)
             new_offload_keys: list[OffloadKey] = []
-            for group_config, group_state in zip(
-                self.config.kv_group_configs, req_status.group_states
+            for group_idx, (group_config, group_state) in enumerate(
+                zip(self.config.kv_group_configs, req_status.group_states)
             ):
-                num_chunks = req_status.storable_chunks(
-                    group_config, group_state, num_offloadable_tokens
-                )
+                num_chunks = ends[group_idx]
 
                 start_chunk_idx = group_state.next_stored_chunk_idx
                 if num_chunks <= start_chunk_idx:
@@ -1095,7 +1241,7 @@ class OffloadingConnectorScheduler:
                     new_offload_keys.append(offload_key)
 
             if not new_offload_keys:
-                req_status.advance_stored_idx(num_offloadable_tokens)
+                req_status.advance_to_extent(ends)
                 continue
 
             store_output = self.manager.prepare_store(
@@ -1109,7 +1255,7 @@ class OffloadingConnectorScheduler:
                 continue
 
             if not store_output.keys_to_store:
-                req_status.advance_stored_idx(num_offloadable_tokens)
+                req_status.advance_to_extent(ends)
                 continue
 
             self._touch(req_status)
@@ -1121,15 +1267,13 @@ class OffloadingConnectorScheduler:
             src_block_ids: list[int] = []
             sliding_window_block_ids: list[int] = []
             non_sliding_window_block_ids: list[int] = []
-            for group_config, group_state in zip(
-                self.config.kv_group_configs, req_status.group_states
+            for group_idx, (group_config, group_state) in enumerate(
+                zip(self.config.kv_group_configs, req_status.group_states)
             ):
                 is_sliding_window = (
                     group_config.sliding_window_size_in_chunks is not None
                 )
-                num_chunks = req_status.storable_chunks(
-                    group_config, group_state, num_offloadable_tokens
-                )
+                num_chunks = ends[group_idx]
                 start_chunk_idx = group_state.next_stored_chunk_idx
                 block_ids = group_state.block_ids
                 num_group_blocks = 0
@@ -1162,9 +1306,8 @@ class OffloadingConnectorScheduler:
 
                 group_sizes.append(num_group_blocks)
                 block_indices.append(start_gpu_block_idx or 0)
-                group_state.next_stored_chunk_idx = max(
-                    group_state.next_stored_chunk_idx, num_chunks
-                )
+
+            req_status.advance_to_extent(ends)
 
             src_spec = GPULoadStoreSpec(
                 src_block_ids, group_sizes=group_sizes, block_indices=block_indices

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -111,12 +111,7 @@ class EagerStoreStrategy(StoreStrategy):
     """Default: every group's eligible chunk boundary."""
 
     def store_extent(self, req_status, num_offloadable_tokens):
-        return [
-            req_status.storable_chunks(gc, gs, num_offloadable_tokens)
-            for gc, gs in zip(
-                req_status.config.kv_group_configs, req_status.group_states
-            )
-        ]
+        return req_status.storable_chunks_for_each_group(num_offloadable_tokens)
 
 
 class DeferUntilFinishStoreStrategy(StoreStrategy):
@@ -132,13 +127,8 @@ class DeferUntilFinishStoreStrategy(StoreStrategy):
 
     def store_extent(self, req_status, num_offloadable_tokens):
         if req_status.req.is_finished():
-            return [
-                req_status.storable_chunks(gc, gs, num_offloadable_tokens)
-                for gc, gs in zip(
-                    req_status.config.kv_group_configs, req_status.group_states
-                )
-            ]
-        return [gs.next_stored_chunk_idx for gs in req_status.group_states]
+            return req_status.storable_chunks_for_each_group(num_offloadable_tokens)
+        return req_status.store_frontiers()
 
 
 @dataclass(slots=True)
@@ -534,7 +524,7 @@ class RequestOffloadState:
         )
         return min(num_chunks, num_allocated_chunks)
 
-    def store_extent(self, num_offloadable_tokens: int) -> list[int]:
+    def _store_extent(self, num_offloadable_tokens: int) -> list[int]:
         """Resolve this step's per-group store boundary from the store policy.
 
         Delegates to the per-request ``StoreStrategy`` instance set in
@@ -549,29 +539,151 @@ class RequestOffloadState:
         (no new chunks offered, cursor stays put). The eager default is
         identical to ``storable_chunks`` for every group.
 
-        Call once per step. The returned list is the **single source of
-        truth** for what the store loop should offer -- the per-group loop
-        uses ``ends[group_idx]`` instead of recomputing
-        ``storable_chunks(...)``, and cursor advance uses
-        ``advance_to_extent(ends)`` instead of recomputing
-        ``storable_chunks`` again. This keeps selection and advance
-        consistent so a deferred group's cursor can never jump past
-        chunks that were not offered.
+        Internal: the per-group list is cached in ``_step_extents``
+        and consumed by ``finalize_store_step`` via
+        ``_consume_step_extents``. Callers never see the list.
         """
         return self._store_strategy.store_extent(self, num_offloadable_tokens)
 
-    def advance_to_extent(self, ends: list[int]) -> None:
+    def _advance_to_extent(self, ends: list[int]) -> None:
         """Advance each group's store cursor to ``ends[i]``.
 
-        ``ends`` is what ``store_extent`` (or the eager equivalent) just
-        produced for this step. ``max()`` guards the eagle prefill->decode
-        transition where the eligible boundary momentarily drops by one.
+        Internal. Called from ``finalize_store_step`` after the payload
+        is collected (or as the only action on the skip path).
+        ``max()`` guards the eagle prefill->decode transition where the
+        eligible boundary momentarily drops by one.
         """
         assert len(ends) == len(self.group_states)
         for group_state, end in zip(self.group_states, ends):
             group_state.next_stored_chunk_idx = max(
                 group_state.next_stored_chunk_idx, end
             )
+
+    def store_frontiers(self) -> list[int]:
+        """Per-group store frontiers (``RequestGroupState.next_stored_chunk_idx``).
+
+        Consulted by ``DeferUntilFinishStoreStrategy`` to report its
+        deferred extent ("stay where you are"). Bulk accessor so
+        strategies don't iterate ``group_states`` directly.
+        """
+        return [gs.next_stored_chunk_idx for gs in self.group_states]
+
+    def storable_chunks_for_each_group(self, num_offloadable_tokens: int) -> list[int]:
+        """Per-group eligible storable-chunk count.
+
+        Used by ``EagerStoreStrategy.store_extent``: the eager
+        strategy's per-group boundary is "the eligible boundary
+        computed from ``num_offloadable_tokens`` and the per-group
+        chunk size". Bulk accessor so strategies don't iterate
+        ``group_states`` directly.
+        """
+        return [
+            self.storable_chunks(gc, gs, num_offloadable_tokens)
+            for gc, gs in zip(self.config.kv_group_configs, self.group_states)
+        ]
+
+    def iter_reachable_offloads(
+        self, num_offloadable_tokens: int
+    ) -> Iterable[OffloadKey]:
+        """Yield every eligible reachable offload key for this step.
+
+        The per-group store boundary is queried internally; the caller
+        (the store loop) never sees the ``ends`` list. This is the
+        token-sort-friendly shape: callers pass in tokens, the state
+        resolves the policy and per-group boundaries internally.
+
+        Per-group iteration and per-group reachability filtering live
+        inside ``RequestGroupState.iter_reachable_offloads``.
+        """
+        extents = self._store_extent(num_offloadable_tokens)
+        for group_idx, group_state in enumerate(self.group_states):
+            group_config = self.config.kv_group_configs[group_idx]
+            for offload_key, _last_block_id in group_state.iter_reachable_offloads(
+                group_config, extents[group_idx]
+            ):
+                yield offload_key
+
+    def finalize_store_step(
+        self,
+        num_offloadable_tokens: int,
+        keys_to_store: set[OffloadKey] | None = None,
+        req: Request | None = None,
+        events_tracker: OffloadingEventsTracker | None = None,
+    ) -> tuple[
+        list[int],
+        list[int],
+        list[int],
+        list[int],
+        list[int],
+    ]:
+        """Finalize the current store step.
+
+        Skip path: ``finalize_store_step(num_offloadable_tokens)`` --
+        no payload collection, just advance every per-group store
+        cursor to the strategy's boundary.
+
+        Pack path: ``finalize_store_step(num_offloadable_tokens,
+        keys_to_store=..., req=..., events_tracker=...)`` -- collect
+        the 5-tuple payload AND advance cursors in one call.
+
+        The boundary is queried internally via ``_step_extents``; the
+        caller doesn't see ``ends``. Per-group iteration,
+        ``keys_to_store`` filtering, events recording, and the
+        deferred-group skip are all done internally.
+
+        Returns 5 empty lists for the skip path (callers ignore them).
+        """
+        extents = self._store_extent(num_offloadable_tokens)
+        if keys_to_store is None:
+            self._advance_to_extent(extents)
+            return [], [], [], [], []
+        src_block_ids: list[int] = []
+        sliding_window_block_ids: list[int] = []
+        non_sliding_window_block_ids: list[int] = []
+        group_sizes: list[int] = []
+        block_indices: list[int] = []
+        store_frontiers = self.store_frontiers()
+        bpc = self.config.blocks_per_chunk
+        for group_idx, group_config in enumerate(self.config.kv_group_configs):
+            is_sliding_window = group_config.sliding_window_size_in_chunks is not None
+            if extents[group_idx] <= store_frontiers[group_idx]:
+                group_sizes.append(0)
+                block_indices.append(0)
+                continue
+            start_gpu_block_idx: int | None = None
+            num_group_blocks = 0
+            group_state = self.group_states[group_idx]
+            for chunk_idx, chunk_block_ids in group_state.iter_paired_offloads(
+                group_config, extents[group_idx]
+            ):
+                offload_key = group_state.offload_keys[chunk_idx]
+                if offload_key not in keys_to_store:
+                    continue
+                assert events_tracker is not None
+                assert req is not None
+                events_tracker.record_store(req, group_config, chunk_idx, offload_key)
+                base = chunk_idx * bpc
+                for i, block_id in enumerate(chunk_block_ids):
+                    if block_id == 0:
+                        continue
+                    if start_gpu_block_idx is None:
+                        start_gpu_block_idx = base + i
+                    src_block_ids.append(block_id)
+                    num_group_blocks += 1
+                    if is_sliding_window:
+                        sliding_window_block_ids.append(block_id)
+                    else:
+                        non_sliding_window_block_ids.append(block_id)
+            group_sizes.append(num_group_blocks)
+            block_indices.append(start_gpu_block_idx or 0)
+        self._advance_to_extent(extents)
+        return (
+            src_block_ids,
+            sliding_window_block_ids,
+            non_sliding_window_block_ids,
+            group_sizes,
+            block_indices,
+        )
 
     def update_num_hit_chunks(self, num_cached_tokens: int) -> None:
         for group_config, group_state in zip(
@@ -1256,91 +1368,50 @@ class OffloadingConnectorScheduler:
 
             # Filter out chunks skipped due to sliding window attention / SSM
             # or unreachable by the load path's alignment constraints.
-            # ``ends`` is the policy-adjusted per-group store boundary; see
-            # ``RequestOffloadState.store_extent``. The per-group flat
-            # addressing math and the SWA reachability filter live inside
-            # ``RequestGroupState.iter_reachable_offloads``; this loop never
-            # reconstructs an absolute chunk index. ``range(start, ends_upper)``
-            # is empty when a deferred group's cursor has already reached
-            # its extent, so the helper naturally yields nothing for that
-            # group -- no caller-side skip is required.
-            ends = req_status.store_extent(num_offloadable_tokens)
-            new_offload_keys: list[OffloadKey] = []
-            for group_idx, (group_config, group_state) in enumerate(
-                zip(self.config.kv_group_configs, req_status.group_states)
-            ):
-                for offload_key, _last_block_id in group_state.iter_reachable_offloads(
-                    group_config, ends[group_idx]
-                ):
-                    new_offload_keys.append(offload_key)
+            # The per-group flat addressing math and the SWA reachability
+            # filter live inside ``RequestGroupState.iter_reachable_offloads``;
+            # this loop never reconstructs an absolute chunk index.
+            # ``store_extent`` (the per-group boundary) is queried
+            # internally by every ``RequestOffloadState`` helper the
+            # scheduler calls -- the scheduler never sees ``ends``. This
+            # keeps the store loop forward-compatible with a token-sort
+            # dispatch (where ``ends`` no longer exists).
+            new_offload_keys: list[OffloadKey] = list(
+                req_status.iter_reachable_offloads(num_offloadable_tokens)
+            )
 
             if not new_offload_keys:
-                req_status.advance_to_extent(ends)
+                req_status.finalize_store_step(num_offloadable_tokens)
                 continue
 
             store_output = self.manager.prepare_store(
                 new_offload_keys, req_status.req_context
             )
-            if store_output is None:
-                self._connector_stats.increase_counter(
-                    _ConnectorMetricName.ALLOCATION_FAILURE
-                )
-                logger.warning("Request %s: cannot store chunks", req_id)
-                continue
-
-            if not store_output.keys_to_store:
-                req_status.advance_to_extent(ends)
+            if store_output is None or not store_output.keys_to_store:
+                if store_output is None:
+                    self._connector_stats.increase_counter(
+                        _ConnectorMetricName.ALLOCATION_FAILURE
+                    )
+                    logger.warning("Request %s: cannot store chunks", req_id)
+                req_status.finalize_store_step(num_offloadable_tokens)
                 continue
 
             self._touch(req_status)
 
             keys_to_store = set(store_output.keys_to_store)
 
-            group_sizes: list[int] = []
-            block_indices: list[int] = []
-            src_block_ids: list[int] = []
-            sliding_window_block_ids: list[int] = []
-            non_sliding_window_block_ids: list[int] = []
-            for group_idx, (group_config, group_state) in enumerate(
-                zip(self.config.kv_group_configs, req_status.group_states)
-            ):
-                is_sliding_window = (
-                    group_config.sliding_window_size_in_chunks is not None
-                )
-                if ends[group_idx] <= group_state.next_stored_chunk_idx:
-                    group_sizes.append(0)
-                    block_indices.append(0)
-                    continue
-                num_group_blocks = 0
-                start_gpu_block_idx: int | None = None
-                for chunk_idx, chunk_block_ids in group_state.iter_paired_offloads(
-                    group_config, ends[group_idx]
-                ):
-                    offload_key = group_state.offload_keys[chunk_idx]
-                    if offload_key not in keys_to_store:
-                        continue
-
-                    self._events_tracker.record_store(
-                        req, group_config, chunk_idx, offload_key
-                    )
-
-                    base = chunk_idx * group_state.blocks_per_chunk
-                    for i, block_id in enumerate(chunk_block_ids):
-                        if block_id == 0:
-                            continue
-                        if start_gpu_block_idx is None:
-                            start_gpu_block_idx = base + i
-                        src_block_ids.append(block_id)
-                        num_group_blocks += 1
-                        if is_sliding_window:
-                            sliding_window_block_ids.append(block_id)
-                        else:
-                            non_sliding_window_block_ids.append(block_id)
-
-                group_sizes.append(num_group_blocks)
-                block_indices.append(start_gpu_block_idx or 0)
-
-            req_status.advance_to_extent(ends)
+            (
+                src_block_ids,
+                sliding_window_block_ids,
+                non_sliding_window_block_ids,
+                group_sizes,
+                block_indices,
+            ) = req_status.finalize_store_step(
+                num_offloadable_tokens=num_offloadable_tokens,
+                keys_to_store=keys_to_store,
+                req=req,
+                events_tracker=self._events_tracker,
+            )
 
             src_spec = GPULoadStoreSpec(
                 src_block_ids, group_sizes=group_sizes, block_indices=block_indices

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import time
 from abc import ABC, abstractmethod
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from itertools import chain, islice
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import Any, NamedTuple
 
 from vllm.config import VllmConfig
 from vllm.distributed.kv_events import KVCacheEvent
@@ -65,13 +65,6 @@ logger = init_logger(__name__)
 KV_LOAD_TIERS_KEY = "kv_load_tiers"
 MATCHER_MEDIUM_KEY = "medium"
 MATCHER_LOCALITY_KEY = "locality"
-
-
-if TYPE_CHECKING:
-    # Forward reference defined in the per-candidate admission follow-up
-    # (Decision A of #49413). See
-    # ``RequestOffloadState.iterate_candidates_for_store`` for the seam.
-    _StoreCandidate = Any
 
 
 class StoreStrategy(ABC):
@@ -352,6 +345,80 @@ class RequestGroupState:
     # Number of offloaded chunks hit (including GPU prefix cache)
     # when the request first started
     num_hit_chunks: int = 0
+    # Per-group block count per offload chunk. Set by
+    # ``RequestOffloadState.__post_init__`` from the connector's
+    # ``SchedulerOffloadConfig.blocks_per_chunk``; per-connector
+    # invariant, identical across all groups on this scheduler instance.
+    # Held on each group state so ``iter_*`` helpers can address
+    # ``block_ids`` without a parent backref.
+    blocks_per_chunk: int = 0
+
+    def iter_reachable_offloads(
+        self,
+        group_config: GroupOffloadConfig,
+        ends_upper: int,
+    ) -> Iterable[tuple[OffloadKey, int]]:
+        """Yield ``(offload_key, last_block_id)`` for each eligible reachable
+        chunk in ``[self.next_stored_chunk_idx, ends_upper)``.
+
+        Encapsulates the per-group flat addressing
+        (``chunk K -> self.block_ids[K*blocks_per_chunk : (K+1)*blocks_per_chunk]``)
+        and the SWA reachability filter. The caller never reconstructs an
+        absolute chunk index -- the iterator handles the
+        ``abs_chunk_idx = next_stored_chunk_idx + key_idx`` step internally.
+
+        Skips:
+          * chunks whose LAST block is 0 (sliding-window / SSM skip or
+            stale; matches the pre-refactor ``offload_block_ids`` slicing);
+          * chunks where ``is_store_reachable_swa_chunk`` returns False.
+        """
+        start = self.next_stored_chunk_idx
+        bpc = self.blocks_per_chunk
+        for abs_chunk_idx in range(start, ends_upper):
+            chunk_block_ids = self.block_ids[
+                abs_chunk_idx * bpc : (abs_chunk_idx + 1) * bpc
+            ]
+            last_block_id = chunk_block_ids[-1]
+            if last_block_id == 0:
+                continue
+            if not is_store_reachable_swa_chunk(
+                abs_chunk_idx,
+                ends_upper,
+                group_config.alignment_chunk_count,
+                group_config.sliding_window_size_in_chunks,
+                group_config.is_eagle_group,
+            ):
+                continue
+            yield self.offload_keys[abs_chunk_idx], last_block_id
+
+    def iter_paired_offloads(
+        self,
+        group_config: GroupOffloadConfig,  # accepted for signature symmetry
+        ends_upper: int,
+    ) -> Iterable[tuple[int, list[int]]]:
+        """Yield ``(chunk_idx, all_block_ids)`` for each chunk in
+        ``[self.next_stored_chunk_idx, ends_upper)``.
+
+        ``chunk_idx`` is absolute (consumed by
+        ``_events_tracker.record_store`` for slicing ``req.block_hashes``
+        and ``req.all_token_ids``). Yields zero-only chunks too -- the
+        caller's ``if offload_key not in keys_to_store`` filter drops them
+        (preserving pre-refactor semantics where the second per-group
+        loop recorded events for any chunk whose key survived
+        ``prepare_store``).
+
+        ``group_config`` is accepted but unused; keeping the signature
+        symmetric with ``iter_reachable_offloads`` lets callers swap
+        helpers without branching.
+        """
+        del group_config  # explicitly unused
+        start = self.next_stored_chunk_idx
+        bpc = self.blocks_per_chunk
+        for abs_chunk_idx in range(start, ends_upper):
+            yield (
+                abs_chunk_idx,
+                self.block_ids[abs_chunk_idx * bpc : (abs_chunk_idx + 1) * bpc],
+            )
 
 
 @dataclass(slots=True)
@@ -382,7 +449,8 @@ class RequestOffloadState:
 
     def __post_init__(self) -> None:
         self.group_states = tuple(
-            RequestGroupState() for _ in self.config.kv_group_configs
+            RequestGroupState(blocks_per_chunk=self.config.blocks_per_chunk)
+            for _ in self.config.kv_group_configs
         )
         params = self.req.kv_transfer_params
 
@@ -504,21 +572,6 @@ class RequestOffloadState:
             group_state.next_stored_chunk_idx = max(
                 group_state.next_stored_chunk_idx, end
             )
-
-    def iterate_candidates_for_store(
-        self, num_offloadable_tokens: int
-    ) -> Iterator[_StoreCandidate] | None:
-        """Seam for the per-candidate admission follow-up (Decision A of #49413).
-
-        Default returns ``None``, opting in to the per-group dispatch in
-        ``_build_store_jobs``. The per-candidate admission follow-up
-        (after #49506 lands) overrides this to return an iterator that
-        yields ``_StoreCandidate`` tuples in cross-group ending-token
-        order; the scheduler's per-candidate dispatch then consumes the
-        iterator to call ``manager.prepare_store`` once per admitted key
-        with prefix-transactional failure semantics.
-        """
-        return None
 
     def update_num_hit_chunks(self, num_cached_tokens: int) -> None:
         for group_config, group_state in zip(
@@ -956,6 +1009,16 @@ class OffloadingConnectorScheduler:
             req_context=req_context,
             offloading_context=offloading_context,
         )
+        # Publish the scheduler's chosen store policy to tiers via
+        # ``req_context._state``. Tiers read it via
+        # ``req_context.get_state(StorePolicy)`` in later hooks
+        # (``prepare_store``, ``submit_store``, ``lookup`` ...). The write
+        # is intentionally placed AFTER ``RequestOffloadState`` construction
+        # (so ``__post_init__``'s enum-to-strategy translation has run)
+        # and BEFORE ``self._req_status[...]`` publication (so the
+        # ``req_status`` is fully initialized before any downstream
+        # observer can race in).
+        req_context.set_state(offloading_context.store_policy)
         self._req_status[request.request_id] = req_status
 
     def get_num_new_matched_tokens(
@@ -1169,7 +1232,6 @@ class OffloadingConnectorScheduler:
         self,
         scheduler_output: SchedulerOutput,
     ) -> dict[int, TransferJob]:
-        blocks_per_chunk = self.config.blocks_per_chunk
         store_jobs: dict[int, TransferJob] = {}
         for req_id in chain(
             scheduler_output.num_scheduled_tokens,
@@ -1195,49 +1257,21 @@ class OffloadingConnectorScheduler:
             # Filter out chunks skipped due to sliding window attention / SSM
             # or unreachable by the load path's alignment constraints.
             # ``ends`` is the policy-adjusted per-group store boundary; see
-            # ``RequestOffloadState.store_extent``.
+            # ``RequestOffloadState.store_extent``. The per-group flat
+            # addressing math and the SWA reachability filter live inside
+            # ``RequestGroupState.iter_reachable_offloads``; this loop never
+            # reconstructs an absolute chunk index. ``range(start, ends_upper)``
+            # is empty when a deferred group's cursor has already reached
+            # its extent, so the helper naturally yields nothing for that
+            # group -- no caller-side skip is required.
             ends = req_status.store_extent(num_offloadable_tokens)
             new_offload_keys: list[OffloadKey] = []
             for group_idx, (group_config, group_state) in enumerate(
                 zip(self.config.kv_group_configs, req_status.group_states)
             ):
-                num_chunks = ends[group_idx]
-
-                start_chunk_idx = group_state.next_stored_chunk_idx
-                if num_chunks <= start_chunk_idx:
-                    continue
-                offload_keys = group_state.offload_keys[start_chunk_idx:num_chunks]
-                # For each chunk, take the last corresponding GPU block. For
-                # blocks_per_chunk=3 and GPU block IDs 1 5 6 7 2 4 9 3 8,
-                # this selects GPU blocks 6 4 8.
-                # A block_id of 0 means either a sliding window / SSM skip
-                # or a stale entry that was zeroed out — skip it either way.
-                offload_block_ids = group_state.block_ids[
-                    start_chunk_idx * blocks_per_chunk
-                    + blocks_per_chunk
-                    - 1 : num_chunks * blocks_per_chunk : blocks_per_chunk
-                ]
-                assert len(offload_keys) == len(offload_block_ids)
-
-                for key_idx, (offload_key, block_id) in enumerate(
-                    zip(offload_keys, offload_block_ids)
+                for offload_key, _last_block_id in group_state.iter_reachable_offloads(
+                    group_config, ends[group_idx]
                 ):
-                    if block_id == 0:
-                        continue
-                    # Skip SWA chunks that can never serve a load hit:
-                    # within each full-attention alignment segment, only the
-                    # trailing chunks queried by _sliding_window_lookup are
-                    # reachable. EAGLE/MTP requires one additional chunk that
-                    # lookup later drops as its volatile draft tail.
-                    abs_chunk_idx = start_chunk_idx + key_idx
-                    if not is_store_reachable_swa_chunk(
-                        abs_chunk_idx,
-                        num_chunks,
-                        group_config.alignment_chunk_count,
-                        group_config.sliding_window_size_in_chunks,
-                        group_config.is_eagle_group,
-                    ):
-                        continue
                     new_offload_keys.append(offload_key)
 
             if not new_offload_keys:
@@ -1273,30 +1307,29 @@ class OffloadingConnectorScheduler:
                 is_sliding_window = (
                     group_config.sliding_window_size_in_chunks is not None
                 )
-                num_chunks = ends[group_idx]
-                start_chunk_idx = group_state.next_stored_chunk_idx
-                block_ids = group_state.block_ids
+                if ends[group_idx] <= group_state.next_stored_chunk_idx:
+                    group_sizes.append(0)
+                    block_indices.append(0)
+                    continue
                 num_group_blocks = 0
                 start_gpu_block_idx: int | None = None
-                for idx, offload_key in enumerate(
-                    group_state.offload_keys[start_chunk_idx:num_chunks]
+                for chunk_idx, chunk_block_ids in group_state.iter_paired_offloads(
+                    group_config, ends[group_idx]
                 ):
+                    offload_key = group_state.offload_keys[chunk_idx]
                     if offload_key not in keys_to_store:
                         continue
-
-                    chunk_idx = start_chunk_idx + idx
 
                     self._events_tracker.record_store(
                         req, group_config, chunk_idx, offload_key
                     )
 
-                    gpu_block_idx = chunk_idx * blocks_per_chunk
-                    for i in range(blocks_per_chunk):
-                        block_id = block_ids[gpu_block_idx + i]
+                    base = chunk_idx * group_state.blocks_per_chunk
+                    for i, block_id in enumerate(chunk_block_ids):
                         if block_id == 0:
                             continue
                         if start_gpu_block_idx is None:
-                            start_gpu_block_idx = gpu_block_idx + i
+                            start_gpu_block_idx = base + i
                         src_block_ids.append(block_id)
                         num_group_blocks += 1
                         if is_sliding_window:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -318,7 +318,6 @@ class RequestGroupState:
 
     def iter_paired_offloads(
         self,
-        group_config: GroupOffloadConfig,  # accepted for signature symmetry
         ends_upper: int,
     ) -> Iterable[tuple[int, list[int]]]:
         """Yield ``(chunk_idx, all_block_ids)`` for each chunk in
@@ -331,12 +330,7 @@ class RequestGroupState:
         (preserving pre-refactor semantics where the second per-group
         loop recorded events for any chunk whose key survived
         ``prepare_store``).
-
-        ``group_config`` is accepted but unused; keeping the signature
-        symmetric with ``iter_reachable_offloads`` lets callers swap
-        helpers without branching.
         """
-        del group_config  # explicitly unused
         start = self.next_stored_chunk_idx
         bpc = self.blocks_per_chunk
         for abs_chunk_idx in range(start, ends_upper):
@@ -583,7 +577,7 @@ class RequestOffloadState:
             num_group_blocks = 0
             group_state = self.group_states[group_idx]
             for chunk_idx, chunk_block_ids in group_state.iter_paired_offloads(
-                group_config, extents[group_idx]
+                extents[group_idx]
             ):
                 offload_key = group_state.offload_keys[chunk_idx]
                 if offload_key not in keys_to_store:

--- a/vllm/v1/kv_offload/base.py
+++ b/vllm/v1/kv_offload/base.py
@@ -99,9 +99,21 @@ class ReqContext:
     # Per-request scratch space keyed by value type, so a tier can parse
     # kv_transfer_params once (in on_new_request) and read the result back
     # on later calls for the same request.
+    #
+    # The scheduler also writes the per-request ``StorePolicy`` here (in
+    # ``KVOffloadingConnector.on_new_request`` after the enum-to-strategy
+    # translation runs) so tiers can read back the scheduler's chosen
+    # store policy via ``get_state(StorePolicy)``. The scheduler owns that
+    # key; tiers should treat it as read-only.
     _state: dict[type, Any] = field(default_factory=dict, repr=False, init=False)
 
     def set_state(self, val: Any) -> None:
+        """Set a per-request scratch value keyed by ``type(val)``.
+
+        The scheduler owns the ``StorePolicy`` key (written from
+        ``KVOffloadingConnector.on_new_request``); tiers should treat
+        that key as read-only and rely on ``get_state`` to observe it.
+        """
         self._state[type(val)] = val
 
     def get_state(self, cls: type[_T]) -> _T | None:
@@ -134,6 +146,17 @@ class StorePolicy(Enum):
     ``RequestOffloadingContext(store_policy=...)`` from its
     ``on_new_request`` hook; the scheduler translates it into a
     ``StoreStrategy`` instance in ``RequestOffloadState.__post_init__``.
+
+    Read-back: ``KVOffloadingConnector.on_new_request`` writes the
+    scheduler's chosen ``StorePolicy`` value into ``req_context._state``
+    via ``set_state``. A tier that needs to observe the scheduler's
+    choice in later hooks (``prepare_store``, ``submit_store``,
+    ``lookup``, ...) can call
+    ``req_context.get_state(StorePolicy) -> StorePolicy | None``.
+
+    Note: the write happens AFTER the tier's own ``on_new_request``
+    returns, so a tier cannot read back its just-chosen policy inside
+    its own ``on_new_request`` callback -- only in subsequent hooks.
     """
 
     # Main behavior: every eligible chunk is offered as soon as it is

--- a/vllm/v1/kv_offload/base.py
+++ b/vllm/v1/kv_offload/base.py
@@ -126,9 +126,29 @@ class OffloadPolicy(Enum):
     REQUEST_LEVEL = "request_level"
 
 
+class StorePolicy(Enum):
+    """When eligible offloaded chunks are offered to the offload tier.
+
+    Independent of ``OffloadPolicy`` (which selects *which* blocks to
+    offload); ``StorePolicy`` selects the *timing*. A tier returns
+    ``RequestOffloadingContext(store_policy=...)`` from its
+    ``on_new_request`` hook; the scheduler translates it into a
+    ``StoreStrategy`` instance in ``RequestOffloadState.__post_init__``.
+    """
+
+    # Main behavior: every eligible chunk is offered as soon as it is
+    # allocated. Mirrors the pre-``StoreStrategy`` inline behavior.
+    ON_COMPUTE = "on_compute"
+    # Hold off all stores until the request reaches a terminal state
+    # (e.g. abort, finish). The strategy flushes everything in the
+    # ``req.is_finished()`` step; before that no chunks are offered.
+    ON_FINISH = "on_finish"
+
+
 @dataclass
 class RequestOffloadingContext:
     policy: OffloadPolicy = OffloadPolicy.BLOCK_LEVEL
+    store_policy: StorePolicy = StorePolicy.ON_COMPUTE
 
 
 class ScheduleEndContext(NamedTuple):


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Introduces a per-request store policy on the KV offloading connector that **covers the scope of #42050** and removes the per-chunk index / per-group extent concept from the scheduler, in preparation for the per-candidate admission follow-up (#49413 Decision A, after #49506 lands).

The data flow that lands here:

```
StorePolicy enum (vllm/v1/kv_offload/base.py)
    │
    │   tier returns RequestOffloadingContext(store_policy=ON_COMPUTE|ON_FINISH)
    │   from on_new_request
    ▼
RequestOffloadState._store_extent
    │   inline match on offloading_context.store_policy:
    │     ON_COMPUTE → storable_chunks_for_each_group(num_offloadable_tokens)
    │     ON_FINISH  → req.is_finished() ? same : store_frontiers()
    ▼
RequestGroupState.iter_reachable_offloads / iter_paired_offloads
    │   encapsulate per-group flat addressing
    │   (chunk K → block_ids[K*bpc:(K+1)*bpc]) + SWA reachability
    ▼
RequestOffloadState.iter_reachable_offloads(num_offloadable_tokens)
    │   yields flat list of offload_keys (no group_idx, no chunk_idx)
    ▼   (scheduler calls manager.prepare_store)
RequestOffloadState.finalize_store_step(num_offloadable_tokens, keys_to_store=..., ...)
    │   collect 5-tuple payload + advance cursors; scheduler never sees 'ends'
```

Three things land here:

1. **Per-request `StorePolicy` selection.** #42050's `OffloadPolicy` is a scheduler-singleton policy (created once in `__init__`); every request on a scheduler runs the same policy. This PR lets a tier pick a different `StorePolicy` per request via the existing `on_new_request → RequestOffloadingContext` hook, so (e.g.) a tier can defer stores for one request while staying eager for another.
2. **The store loop (`_build_store_jobs`) no longer touches `chunk_idx`, `ends`, `group_idx`, or `RequestGroupState` internals directly.** All per-chunk addressing math, SWA reachability filtering, and per-group payload packing live on `RequestOffloadState` / `RequestGroupState` helpers. The store loop passes only `num_offloadable_tokens` and receives a flat list of `offload_key`s plus the 5-tuple worker payload; it never reconstructs an absolute chunk index. See the "Layer separation" section below for what this PR does and does not claim about group-awareness.
3. **`StorePolicy` read-back for tiers.** `KVOffloadingConnector.on_new_request` writes the scheduler's chosen policy to `req_context._state` via `set_state`. Tiers observe it in later hooks via `req_context.get_state(StorePolicy)`.

### Layer separation

This PR refactors three layers with different group-awareness properties:

| Layer | What's exposed | group-aware? | Why |
|---|---|---|---|
| **Store loop** (`OffloadingConnectorScheduler._build_store_jobs`) | `(offload_key, last_block_id)` pairs, plus the constructed `GPULoadStoreSpec` | **No** at the call sites — never sees `chunk_idx`, `ends`, `group_idx`, or `RequestGroupState` | Refactor target of this PR |
| **State internals** (`RequestOffloadState` methods, `RequestGroupState` helpers) | `_store_extent()` returns `list[int]` (per-group extents); `finalize_store_step()` iterates `for group_idx, group_config in enumerate(...)` to pack `group_sizes` / `block_indices` | **Yes** — group-major decision + group-major packing | Internal to state; not part of the scheduler ↔ state boundary this PR tightens |
| **Worker protocol** (`GPULoadStoreSpec`) | `block_ids` flat + `group_sizes` / `block_indices` per-group | **Yes** — by physical necessity | GPU KV tensors are per-group; the worker uses `group_sizes` to slice `block_ids` and route each segment to the correct group tensor. Cannot be made group-agnostic without a different worker-side API (see #44865) |
| **State → manager** (`manager.prepare_store(flat_key_list, ctx)`) | flat `list[OffloadKey]` | **No** at the API level | Manager does not need to know about groups |

What this PR claims:

- The **store-loop ↔ state boundary** is group-agnostic. Adding candidate-major admission (#49413 Decision A) can change `RequestOffloadState` internals (replace `_store_extent` with a candidate iterator, replace `_advance_to_extent` with per-candidate advance) without re-touching `_build_store_jobs`.

What this PR does NOT claim:

- `RequestOffloadState` internals are group-agnostic. `_store_extent` still returns a per-group `list[int]`; `finalize_store_step` still iterates groups to pack the worker payload. Decision A will still need to rewrite these methods — the seam for that rewrite is the store-loop boundary, not the state internals.
- `GPULoadStoreSpec` is group-agnostic. It is per-group by physical necessity (see "Worker protocol" row above). Decision A's candidate-major dispatch produces the same `GPULoadStoreSpec` shape; only the **construction path** inside `finalize_store_step` changes.

### Refactor rationale

- The store loop's per-chunk addressing math (chunk K → `block_ids[K*blocks_per_chunk : (K+1)*blocks_per_chunk]` + SWA reachability filter) lives on `RequestGroupState.iter_reachable_offloads` / `iter_paired_offloads`. The store loop consumes `(offload_key, block_id)` pairs without reconstructing `chunk_idx`.
- `RequestOffloadState._store_extent` / `_advance_to_extent` are private (only state internals touch the per-group extent list). The scheduler passes only `num_offloadable_tokens`; the state resolves the policy inline via a small closed `match` on `offloading_context.store_policy`.
- The two built-in policies (`ON_COMPUTE`, `ON_FINISH`) are dispatched inline in `_store_extent`. The previous `StoreStrategy` ABC + per-request strategy instances were removed — the policy only needs `is_finished()` and the per-group extents to decide, so passing `req_status` through a strategy was unnecessary coupling.
- `finalize_store_step(num_offloadable_tokens)` advances cursors for skip paths (empty reachable keys, manager rejected all keys). For the prepare-store-allocation-failure path the cursors are deliberately *not* advanced — the candidates are re-offered next step. `test_stale_sliding_window_block_after_prepare_store_failure` exercises this branch.
- `StorePolicy` is written to `req_context._state` (under the `StorePolicy` key) by `KVOffloadingConnector.on_new_request` after `RequestOffloadState` construction. Tiers read it via `req_context.get_state(StorePolicy)` in later hooks.
- See "Layer separation" above for the precise scope of what this PR refactors. The store loop ↔ state boundary is group-agnostic; `RequestOffloadState` internals are still group-major (this is #49413 Decision A's seam); `GPULoadStoreSpec` is per-group by physical necessity.

### Relationship to related work

| # | Status | Relationship |
|---|---|---|
| #42050 (hickeyma) | DRAFT, needs feedback | **Covers its scope (different API shape).** #42050's `OffloadPolicy(ABC).get_blocks_to_store` owns per-request progress in `dict[req_id, list[int]]` on a scheduler-singleton policy. This PR keeps per-request progress on `RequestOffloadState` (where cursors already live) and uses a `StorePolicy` enum + inline dispatch — same scope, different API. hickeyma noted on #49413 (2026-07-22) that #42050 is "ready to push on" but waiting on feedback (see #44865 thread); #50087 does not depend on that feedback landing. **This PR has not been reviewed by @orozery**; do not infer approval from hickeyma's reference. |
| #44865 (hickeyma) | OPEN, needs-rebase | **Directionally aligned, but unrelated.** orozery's review on #44865 stated the following direction (paraphrased): `OffloadingManager` should not be group-aware; the scheduler should do per-group splitting; the manager should expose a more general `get_spec` (not strongly bound to `BlockIDsLoadStoreSpec`; GDS backend will map blocks to files instead of block IDs). #50087's scheduler-side encapsulation (encapsulating the per-group flat addressing math + the per-group store extent list inside `RequestOffloadState`, leaving the store loop group-agnostic) is consistent with that direction, but #44865 is not merged and its eventual API may further reshape the `OffloadingManager` / `OffloadingSpec` / `LoadStoreSpec` design. This PR does not preempt that work; the read-back path on `req_context._state` (used to publish the scheduler's chosen `StorePolicy`) draws from the same maintainer thread. |
| #49413 (Change72) | OPEN, feedback | This PR lands the store-loop changes the per-candidate admission follow-up needs: the per-group extent list / per-chunk cursor math is now internal to `RequestOffloadState`. The follow-up will define its own per-candidate seam (likely a `StoreCandidate` NamedTuple) and add per-candidate dispatch without re-touching `_build_store_jobs`. |
| #49506 (Change72) | OPEN, merge conflict | No conflict; lands independently. This PR does **not** depend on #49506. |

**Not a duplicate** of #49506. #49506's body adds `chunk_idx` to `OffloadKey`; this PR hides `chunk_idx` / `ends` from the scheduler and encapsulates the per-chunk addressing math on `RequestGroupState`. Different slices.

## Test Plan

```bash
.venv/bin/python -m pytest tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py tests/v1/kv_offload/tiering/test_tiering_offloading.py -v
pre-commit run ruff-check ruff-format mypy-3.12 --files vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py vllm/v1/kv_offload/base.py
```

## Test Result

- `pytest`: **160 passed** in ~116s. The default `ON_COMPUTE` policy is observationally identical to the prior inline eager path; both the offloading-scheduler tests (116) and the P2P tiering tests (44) pass unchanged.
- `ruff check` / `ruff format`: clean.
- `mypy` (3.12): clean — no `# type: ignore` needed.

The offloading scheduler tests cover the key invariants directly:

- `test_two_groups_different_block_sizes` — direct exercise of the per-group flat addressing math.
- `test_offloading_connector` — the canonical store-loop path; checks per-step `src_spec.block_ids`, `group_sizes`, `block_indices`.
- `test_two_groups_full_and_sliding_window` — SWA path.
- `test_stale_sliding_window_block_after_prepare_store_failure` — prepare-store-failure path (cursors deliberately *not* advanced so the candidates are re-offered next step).
- `test_is_store_reachable_swa_chunk` — the reachability predicate.

`_store_extent` is covered by the existing scheduler tests for `ON_COMPUTE`. **`ON_FINISH` has no direct test coverage in this PR** — it is exercised only through the same cursor-advance path (since the strategy branch is one line of `match`).

## Out of scope (deliberately)

- **This PR is store-path only.** The load path still touches `req_status.group_states[i]` and `group_state.offload_keys` / `group_state.block_ids` directly from `OffloadingConnectorScheduler` (e.g. `update_state_after_alloc`, `_update_req_states`, stale sliding window block check). A follow-up PR can apply the same helper-encapsulation pattern (`RequestOffloadState.collect_load_keys(...)`, `RequestOffloadState.ingest_new_block_id_groups(...)`, `RequestOffloadState.zero_stale_sliding_window_blocks(...)`) to fully retire direct `group_states` access from the scheduler. This PR deliberately does not bundle that refactor — it is independent of Decision A and can land separately.
- **Per-candidate admission** (#49413 Decision A) — the per-chunk addressing math is now encapsulated on `RequestGroupState`; the follow-up will define its own per-candidate seam and wire it into `RequestOffloadState` without re-touching `_build_store_jobs`. The follow-up depends on #49506 landing `chunk_idx` in `OffloadKey`.
- **New tests for the read-back path / `ON_FINISH` policy** — the read-back path's primary user would be a custom tier; tier tests are left to the tier owner. `ON_FINISH` would be best covered by a follow-up that adds a fixture tier returning it.
- **Custom `StorePolicy` values** — the inline `match` in `_store_extent` is the seam. Adding a new value is one branch in the `match`.
- **`Co-authored-by:` trailer** — to be added by the human submitter at sign-off time.

---

<details>
<summary> Checklist </summary>

- [x] Purpose stated; relationship to #42050 / #44865 / #49413 / #49506 documented.
- [x] Test plan + test result included.
- [x] AI assistance: yes (design exploration, refactor, doc draft). Human author reviewed every changed line and ran the tests.
- [ ] (N/A) Documentation update: not a model addition.
- [ ] (N/A) Issue link: this is an experimental refactor PR; no specific issue.

</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>**