### PR TITLE
[MoE] Latent-MoE runner, fused MoE tail, SituGLU activation and single-group top-k routing

### DIFF
--- a/benchmarks/kernels/benchmark_kimi_k3_latent_moe_tail.py
+++ b/benchmarks/kernels/benchmark_kimi_k3_latent_moe_tail.py
@@ -1,0 +1,806 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Benchmark the Kimi K3 latent-MoE tail and its up-projection kernels.
+
+The ``up-projection`` subcommand isolates the TP-local dynamic and static-M
+skinny GEMMs. It rotates weights through a working set larger than L2 to model
+successive model layers.
+
+The ``whole-tail`` subcommand measures the distributed operator. Its reference
+path includes two AllReduces, RMSNorm, the replicated up-projection, and the
+final add. CUDA-event samples report the slowest rank so cross-rank skew is
+included.
+
+Examples:
+
+.. code-block:: console
+
+    .venv/bin/python \
+      benchmarks/kernels/benchmark_kimi_k3_latent_moe_tail.py up-projection
+
+    torchrun --nproc-per-node=8 \
+      benchmarks/kernels/benchmark_kimi_k3_latent_moe_tail.py whole-tail
+
+For multi-node runs, launch one ``torchrun`` agent per node and use a shared
+rendezvous endpoint.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import statistics
+from collections.abc import Callable, Sequence
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import cutlass
+import cutlass.utils as utils
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from cuda.bindings import driver as cuda
+
+from vllm.distributed import get_tp_group
+from vllm.distributed.parallel_state import (
+    init_distributed_environment,
+    initialize_model_parallel,
+    set_custom_all_reduce,
+)
+from vllm.model_executor.warmup.cutedsl_warmup import cutedsl_warmup
+from vllm.models.kimi_k3.nvidia.ops import latent_moe_tail
+from vllm.models.kimi_k3.nvidia.ops.cute_dsl.latent_moe_tail import (
+    fused_add_multicast_gemm,
+    fused_add_multicast_skinny_gemm,
+)
+
+HIDDEN_SIZE = 7168
+LATENT_SIZE = 3584
+RMS_EPS = 0.1
+MAX_NUM_TOKENS = 16
+MMA_TILER_MN = (64, 32)
+CLUSTER_SHAPE_MN = (1, 8)
+B_PRIME_STAGES = 2
+
+
+def parse_up_projection_config(
+    value: str,
+) -> fused_add_multicast_skinny_gemm.SkinnyConfig:
+    try:
+        values = [int(part) for part in value.split(",")]
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(
+            "config must be BLOCK,OUTPUTS,K_UNROLL[,VECTOR_WIDTH[,PREFETCH_B]]"
+        ) from error
+    if len(values) in (3, 4):
+        return fused_add_multicast_skinny_gemm.SkinnyConfig(*values)
+    if len(values) == 5 and values[4] in (0, 1):
+        return fused_add_multicast_skinny_gemm.SkinnyConfig(
+            *values[:4],
+            prefetch_b_before_pdl=bool(values[4]),
+        )
+    raise argparse.ArgumentTypeError(
+        "config must be BLOCK,OUTPUTS,K_UNROLL"
+        "[,VECTOR_WIDTH[,PREFETCH_B]], where PREFETCH_B is 0 or 1"
+    )
+
+
+def parse_tail_skinny_config(
+    value: str,
+) -> tuple[int, fused_add_multicast_skinny_gemm.SkinnyConfig]:
+    try:
+        values = [int(part) for part in value.split(",")]
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(
+            "config must be M,BLOCK,OUTPUTS,K_UNROLL[,VECTOR_WIDTH[,PREFETCH_B]]"
+        ) from error
+    if len(values) == 4:
+        num_tokens, *config = values
+        return num_tokens, fused_add_multicast_skinny_gemm.SkinnyConfig(*config)
+    if len(values) == 5:
+        num_tokens, *config = values
+        return num_tokens, fused_add_multicast_skinny_gemm.SkinnyConfig(*config)
+    if len(values) == 6 and values[5] in (0, 1):
+        num_tokens, block, outputs, unroll, vector_width, prefetch = values
+        return num_tokens, fused_add_multicast_skinny_gemm.SkinnyConfig(
+            block,
+            outputs,
+            unroll,
+            vector_width,
+            bool(prefetch),
+        )
+    raise argparse.ArgumentTypeError(
+        "config must be M,BLOCK,OUTPUTS,K_UNROLL"
+        "[,VECTOR_WIDTH[,PREFETCH_B]], where PREFETCH_B is 0 or 1"
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="scope", required=True)
+
+    up_projection = subparsers.add_parser(
+        "up-projection",
+        help="Benchmark the isolated TP-local up-projection kernels.",
+    )
+    up_projection.add_argument(
+        "--backend",
+        choices=("dynamic", "skinny", "both"),
+        default="both",
+    )
+    up_projection.add_argument("--tp-size", type=int, default=16)
+    up_projection.add_argument(
+        "--num-tokens",
+        type=int,
+        nargs="+",
+        default=[*range(1, 9), 16],
+    )
+    up_projection.add_argument(
+        "--skinny-config",
+        type=parse_up_projection_config,
+        action="append",
+        help="Benchmark a static-M config for every selected token count.",
+    )
+    up_projection.add_argument("--cache-multiplier", type=float, default=2.0)
+    up_projection.add_argument("--max-weights", type=int, default=64)
+    up_projection.add_argument("--warmup-replays", type=int, default=10)
+    up_projection.add_argument("--samples", type=int, default=31)
+    up_projection.add_argument("--output", type=Path)
+
+    whole_tail = subparsers.add_parser(
+        "whole-tail",
+        help="Benchmark the distributed latent-MoE tail operator.",
+    )
+    whole_tail.add_argument(
+        "--backend",
+        choices=("reference", "fused", "both"),
+        default="both",
+    )
+    whole_tail.add_argument(
+        "--num-tokens",
+        type=int,
+        nargs="+",
+        default=[1, 5, 8, 16],
+    )
+    whole_tail.add_argument("--warmup-replays", type=int, default=20)
+    whole_tail.add_argument("--samples", type=int, default=51)
+    whole_tail.add_argument(
+        "--skinny-max-num-tokens",
+        type=int,
+        nargs="+",
+        help="Override the fused operator's static-M cutoff; use 0 for dynamic-only.",
+    )
+    whole_tail.add_argument(
+        "--skinny-config",
+        type=parse_tail_skinny_config,
+        action="append",
+        help="Override one static-M config for tuning.",
+    )
+    whole_tail.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def percentile(samples: Sequence[float], fraction: float) -> float:
+    ordered = sorted(samples)
+    position = fraction * (len(ordered) - 1)
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    upper_weight = position - lower
+    return ordered[lower] * (1.0 - upper_weight) + ordered[upper] * upper_weight
+
+
+def summarize(samples_us: Sequence[float]) -> dict[str, Any]:
+    mean_us = statistics.mean(samples_us)
+    return {
+        "median_us": statistics.median(samples_us),
+        "p10_us": percentile(samples_us, 0.1),
+        "p90_us": percentile(samples_us, 0.9),
+        "mean_us": mean_us,
+        "cv_pct": statistics.pstdev(samples_us) / mean_us * 100.0,
+        "samples_us": list(samples_us),
+    }
+
+
+def rotating_weight_count(
+    shard_size: int,
+    cache_multiplier: float,
+    limit: int,
+) -> int:
+    properties = torch.cuda.get_device_properties(
+        torch.accelerator.current_device_index()
+    )
+    weight_bytes = shard_size * LATENT_SIZE * 2
+    target_bytes = math.ceil(properties.L2_cache_size * cache_multiplier)
+    return max(2, min(limit, math.ceil(target_bytes / weight_bytes)))
+
+
+def capture_up_projection_graph(
+    launches: Sequence[Callable[[], None]],
+) -> torch.cuda.CUDAGraph:
+    for launch in launches:
+        launch()
+    torch.accelerator.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        for launch in launches:
+            launch()
+    torch.accelerator.synchronize()
+    return graph
+
+
+def benchmark_up_projection_graph(
+    graph: torch.cuda.CUDAGraph,
+    *,
+    operations_per_replay: int,
+    warmup_replays: int,
+    samples: int,
+) -> dict[str, Any]:
+    for _ in range(warmup_replays):
+        graph.replay()
+    torch.accelerator.synchronize()
+
+    samples_us = []
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    for _ in range(samples):
+        start.record()
+        graph.replay()
+        end.record()
+        end.synchronize()
+        samples_us.append(start.elapsed_time(end) * 1000.0 / operations_per_replay)
+    return summarize(samples_us)
+
+
+class DynamicKernel:
+    def __init__(
+        self,
+        shard_size: int,
+        mailbox: torch.Tensor,
+        shared_shard: torch.Tensor,
+    ) -> None:
+        self.shard_size = shard_size
+        self.mailbox = mailbox
+        self.mailbox_c = fused_add_multicast_gemm._as_cute(mailbox)
+        compile_latent = torch.empty(
+            (1, MAX_NUM_TOKENS, LATENT_SIZE),
+            dtype=torch.bfloat16,
+            device=mailbox.device,
+        )
+        compile_weight = torch.empty(
+            (1, shard_size, LATENT_SIZE),
+            dtype=torch.bfloat16,
+            device=mailbox.device,
+        )
+        cluster_size = math.prod(CLUSTER_SHAPE_MN)
+        max_active_clusters = utils.HardwareInfo().get_max_active_clusters(cluster_size)
+        self.compiled = fused_add_multicast_gemm.compile_kernel(
+            (MAX_NUM_TOKENS, shard_size, LATENT_SIZE, 1),
+            fused_add_multicast_gemm._as_cute(
+                compile_latent,
+                dynamic_m=True,
+            ),
+            fused_add_multicast_gemm._as_cute(compile_weight),
+            self.mailbox_c,
+            fused_add_multicast_gemm._as_cute(shared_shard),
+            HIDDEN_SIZE,
+            shard_size,
+            MMA_TILER_MN,
+            CLUSTER_SHAPE_MN,
+            max_active_clusters,
+            B_PRIME_STAGES,
+        )
+
+    def launch(
+        self,
+        latent: torch.Tensor,
+        weight: torch.Tensor,
+        shared_shard: torch.Tensor,
+    ) -> None:
+        stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+        self.compiled(
+            fused_add_multicast_gemm._as_cute(
+                latent.unsqueeze(0),
+                dynamic_m=True,
+            ),
+            fused_add_multicast_gemm._as_cute(weight.unsqueeze(0)),
+            self.mailbox_c,
+            fused_add_multicast_gemm._as_cute(shared_shard),
+            cutlass.Int64(latent.shape[0]),
+            cutlass.Int64(self.mailbox.data_ptr()),
+            stream,
+        )
+
+
+class SkinnyKernel:
+    def __init__(
+        self,
+        num_tokens: int,
+        shard_size: int,
+        config: fused_add_multicast_skinny_gemm.SkinnyConfig,
+    ) -> None:
+        self.compiled = fused_add_multicast_skinny_gemm.compile_kernel(
+            num_rows=num_tokens,
+            latent_dim=LATENT_SIZE,
+            hidden_dim=HIDDEN_SIZE,
+            shard_dim=shard_size,
+            config=config,
+        )
+
+    def launch(
+        self,
+        latent: torch.Tensor,
+        weight: torch.Tensor,
+        shared_shard: torch.Tensor,
+        mailbox: torch.Tensor,
+    ) -> None:
+        self.compiled(
+            fused_add_multicast_skinny_gemm._as_cute(latent),
+            fused_add_multicast_skinny_gemm._as_cute(weight),
+            fused_add_multicast_skinny_gemm._as_cute(shared_shard),
+            cutlass.Int64(mailbox.data_ptr()),
+            cuda.CUstream(torch.cuda.current_stream().cuda_stream),
+        )
+
+
+def check_up_projection_output(
+    actual: torch.Tensor,
+    latent: torch.Tensor,
+    weight: torch.Tensor,
+    shared_shard: torch.Tensor,
+) -> None:
+    gemm = F.linear(latent.float(), weight.float()).to(torch.bfloat16)
+    expected = (gemm.float() + shared_shard.float()).to(torch.bfloat16)
+    torch.testing.assert_close(actual, expected, atol=8e-2, rtol=3e-2)
+
+
+def make_up_projection_launches(
+    launch: Callable[[torch.Tensor, torch.Tensor, torch.Tensor], None],
+    latent: torch.Tensor,
+    weights: Sequence[torch.Tensor],
+    shared_shard: torch.Tensor,
+) -> list[Callable[[], None]]:
+    return [
+        lambda weight=weight: launch(latent, weight, shared_shard) for weight in weights
+    ]
+
+
+def benchmark_up_projection(args: argparse.Namespace) -> None:
+    if args.tp_size <= 0 or HIDDEN_SIZE % args.tp_size:
+        raise ValueError("TP size must be positive and divide the hidden size")
+    if any(not 1 <= num_tokens <= MAX_NUM_TOKENS for num_tokens in args.num_tokens):
+        raise ValueError("--num-tokens values must be in [1, 16]")
+    if args.cache_multiplier <= 0 or args.max_weights <= 0:
+        raise ValueError("cache multiplier and max weights must be positive")
+    if args.warmup_replays < 0 or args.samples <= 0:
+        raise ValueError("warmup replays must be nonnegative and samples positive")
+
+    torch.accelerator.set_device_index(0)
+    device = torch.device("cuda", 0)
+    if torch.cuda.get_device_capability(device)[0] != 10:
+        raise RuntimeError("Kimi K3 latent-MoE tail requires SM100")
+
+    shard_size = HIDDEN_SIZE // args.tp_size
+    weight_count = rotating_weight_count(
+        shard_size,
+        args.cache_multiplier,
+        args.max_weights,
+    )
+    torch.manual_seed(20260726)
+    weights = [
+        torch.randn(
+            (shard_size, LATENT_SIZE),
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        / LATENT_SIZE**0.5
+        for _ in range(weight_count)
+    ]
+    mailbox = torch.empty(
+        (1, MAX_NUM_TOKENS, HIDDEN_SIZE),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    shared = torch.randn(
+        (MAX_NUM_TOKENS, HIDDEN_SIZE),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    shared_shard = shared[:, :shard_size]
+    use_dynamic = args.backend in ("dynamic", "both")
+    use_skinny = args.backend in ("skinny", "both")
+    dynamic_kernel = (
+        DynamicKernel(shard_size, mailbox, shared_shard) if use_dynamic else None
+    )
+
+    results = []
+    for num_tokens in args.num_tokens:
+        latent = torch.randn(
+            (num_tokens, LATENT_SIZE),
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        result: dict[str, Any] = {"num_tokens": num_tokens}
+        if dynamic_kernel is not None:
+            launches = make_up_projection_launches(
+                dynamic_kernel.launch,
+                latent,
+                weights,
+                shared_shard,
+            )
+            graph = capture_up_projection_graph(launches)
+            result["dynamic"] = benchmark_up_projection_graph(
+                graph,
+                operations_per_replay=len(launches),
+                warmup_replays=args.warmup_replays,
+                samples=args.samples,
+            )
+            check_up_projection_output(
+                mailbox[0, :num_tokens, :shard_size],
+                latent,
+                weights[-1],
+                shared_shard[:num_tokens],
+            )
+        if use_skinny:
+            configs = args.skinny_config or [
+                fused_add_multicast_skinny_gemm.config_for_m(
+                    num_tokens,
+                    shard_size,
+                )
+            ]
+            skinny_results = []
+            for config in configs:
+                skinny_kernel = SkinnyKernel(num_tokens, shard_size, config)
+
+                def launch_skinny(
+                    latent: torch.Tensor,
+                    weight: torch.Tensor,
+                    shared_shard: torch.Tensor,
+                    *,
+                    skinny_kernel: SkinnyKernel = skinny_kernel,
+                    num_tokens: int = num_tokens,
+                ) -> None:
+                    skinny_kernel.launch(
+                        latent,
+                        weight,
+                        shared_shard[:num_tokens],
+                        mailbox,
+                    )
+
+                launches = make_up_projection_launches(
+                    launch_skinny,
+                    latent,
+                    weights,
+                    shared_shard,
+                )
+                graph = capture_up_projection_graph(launches)
+                timing = benchmark_up_projection_graph(
+                    graph,
+                    operations_per_replay=len(launches),
+                    warmup_replays=args.warmup_replays,
+                    samples=args.samples,
+                )
+                check_up_projection_output(
+                    mailbox[0, :num_tokens, :shard_size],
+                    latent,
+                    weights[-1],
+                    shared_shard[:num_tokens],
+                )
+                skinny_results.append(
+                    {
+                        "config": asdict(config),
+                        **timing,
+                    }
+                )
+            result["skinny"] = skinny_results
+        results.append(result)
+
+    properties = torch.cuda.get_device_properties(device)
+    report = {
+        "scope": "up-projection",
+        "device": properties.name,
+        "compute_capability": list(torch.cuda.get_device_capability(device)),
+        "tp_size": args.tp_size,
+        "shard_size": shard_size,
+        "weight_count": weight_count,
+        "cache_multiplier": args.cache_multiplier,
+        "warmup_replays": args.warmup_replays,
+        "samples": args.samples,
+        "results": results,
+    }
+    rendered = json.dumps(report, indent=2)
+    print(rendered, flush=True)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+
+
+def capture_tail_graph(
+    operation: Callable[[], torch.Tensor],
+    cpu_group: dist.ProcessGroup,
+) -> tuple[torch.cuda.CUDAGraph, torch.Tensor]:
+    for _ in range(3):
+        dist.barrier(group=cpu_group)
+        output = operation()
+    torch.accelerator.synchronize()
+
+    dist.barrier(group=cpu_group)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        output = operation()
+    torch.accelerator.synchronize()
+    return graph, output
+
+
+def benchmark_tail_graph(
+    graph: torch.cuda.CUDAGraph,
+    *,
+    warmup_replays: int,
+    samples: int,
+    device_group: dist.ProcessGroup,
+    cpu_group: dist.ProcessGroup,
+) -> dict[str, Any]:
+    for _ in range(warmup_replays):
+        graph.replay()
+    torch.accelerator.synchronize()
+
+    dist.barrier(group=cpu_group)
+    starts = [torch.cuda.Event(enable_timing=True) for _ in range(samples + 1)]
+    ends = [torch.cuda.Event(enable_timing=True) for _ in range(samples + 1)]
+    for start, end in zip(starts, ends):
+        start.record()
+        graph.replay()
+        end.record()
+    torch.accelerator.synchronize()
+
+    samples_us = torch.tensor(
+        [start.elapsed_time(end) * 1000.0 for start, end in zip(starts, ends)],
+        dtype=torch.float64,
+        device=torch.accelerator.current_device_index(),
+    )
+    dist.all_reduce(samples_us, op=dist.ReduceOp.MAX, group=device_group)
+    return summarize(samples_us[1:].tolist())
+
+
+def make_inputs(
+    num_tokens: int,
+    rank: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    torch.manual_seed(20260726 + 100 * num_tokens + rank)
+    routed = torch.randn(
+        (num_tokens, LATENT_SIZE),
+        dtype=torch.bfloat16,
+        device=device,
+    ).mul_(0.01)
+    shared = torch.randn(
+        (num_tokens, HIDDEN_SIZE),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    return routed, shared
+
+
+def make_reference(
+    routed: torch.Tensor,
+    shared: torch.Tensor,
+    rms_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    device_group: dist.ProcessGroup,
+) -> Callable[[], torch.Tensor]:
+    routed_workspace = torch.empty_like(routed)
+    shared_workspace = torch.empty_like(shared)
+
+    def reference() -> torch.Tensor:
+        routed_workspace.copy_(routed)
+        dist.all_reduce(routed_workspace, group=device_group)
+        normalized = F.rms_norm(
+            routed_workspace,
+            (LATENT_SIZE,),
+            rms_weight,
+            RMS_EPS,
+        )
+        projected = F.linear(normalized, up_weight)
+        shared_workspace.copy_(shared)
+        dist.all_reduce(shared_workspace, group=device_group)
+        return projected.add(shared_workspace)
+
+    return reference
+
+
+def check_fused_output(
+    fused_output: torch.Tensor,
+    reference: Callable[[], torch.Tensor],
+    cpu_group: dist.ProcessGroup,
+) -> None:
+    dist.barrier(group=cpu_group)
+    expected = reference()
+    torch.testing.assert_close(fused_output, expected, atol=8e-2, rtol=3e-2)
+
+
+def benchmark_whole_tail(args: argparse.Namespace) -> None:
+    if any(not 1 <= num_tokens <= 16 for num_tokens in args.num_tokens):
+        raise ValueError("--num-tokens values must be in [1, 16]")
+    if args.warmup_replays < 0 or args.samples <= 0:
+        raise ValueError("warmup replays must be nonnegative and samples positive")
+    if args.skinny_max_num_tokens is not None and any(
+        not 0 <= cutoff <= 8 for cutoff in args.skinny_max_num_tokens
+    ):
+        raise ValueError("--skinny-max-num-tokens must be in [0, 8]")
+    skinny_configs = dict(args.skinny_config or ())
+    if len(skinny_configs) != len(args.skinny_config or ()):
+        raise ValueError("--skinny-config must not repeat an M value")
+    if any(not 1 <= num_tokens <= 8 for num_tokens in skinny_configs):
+        raise ValueError("--skinny-config M values must be in [1, 8]")
+    if not {"RANK", "WORLD_SIZE", "LOCAL_RANK"} <= os.environ.keys():
+        raise RuntimeError("launch this benchmark with torchrun")
+
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    local_rank = int(os.environ["LOCAL_RANK"])
+    device = torch.device("cuda", local_rank)
+    torch.accelerator.set_device_index(device)
+    init_distributed_environment()
+    if world_size > 8:
+        set_custom_all_reduce(False)
+    initialize_model_parallel(tensor_model_parallel_size=world_size)
+    device_group = get_tp_group().device_group
+    cpu_group = dist.new_group(backend="gloo")
+
+    if torch.cuda.get_device_capability(device)[0] != 10:
+        raise RuntimeError("Kimi K3 latent-MoE tail requires SM100")
+
+    torch.manual_seed(20260726)
+    rms_weight = 1 + 0.1 * torch.randn(
+        LATENT_SIZE,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    up_weight = (
+        torch.randn(
+            (HIDDEN_SIZE, LATENT_SIZE),
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        / LATENT_SIZE**0.5
+    )
+
+    use_reference = args.backend in ("reference", "both")
+    use_fused = args.backend in ("fused", "both")
+    fused_ops = []
+    if use_fused:
+        production_config_for_m = fused_add_multicast_skinny_gemm.config_for_m
+
+        def config_for_m(
+            num_rows: int,
+            shard_dim: int = 896,
+        ) -> fused_add_multicast_skinny_gemm.SkinnyConfig:
+            config = skinny_configs.get(num_rows)
+            if config is not None:
+                return config
+            return production_config_for_m(num_rows, shard_dim)
+
+        fused_add_multicast_skinny_gemm.config_for_m = config_for_m
+        cutoffs = args.skinny_max_num_tokens or [latent_moe_tail._SKINNY_MAX_NUM_TOKENS]
+        for cutoff in cutoffs:
+            latent_moe_tail._SKINNY_MAX_NUM_TOKENS = cutoff
+            latent_moe_tail.KimiK3LatentMoETailOp._instances.clear()
+            fused_ops.append(
+                (
+                    cutoff,
+                    latent_moe_tail.KimiK3LatentMoETailOp.initialize(
+                        hidden_size=HIDDEN_SIZE,
+                        latent_size=LATENT_SIZE,
+                        dtype=torch.bfloat16,
+                        device=device,
+                        rms_eps=RMS_EPS,
+                    ),
+                )
+            )
+        cutedsl_warmup()
+
+    results = []
+    for num_tokens in args.num_tokens:
+        routed, shared = make_inputs(num_tokens, rank, device)
+        reference = make_reference(
+            routed,
+            shared,
+            rms_weight,
+            up_weight,
+            device_group,
+        )
+        result: dict[str, Any] = {"num_tokens": num_tokens}
+        if use_reference:
+            reference_graph, _ = capture_tail_graph(reference, cpu_group)
+            result["reference"] = benchmark_tail_graph(
+                reference_graph,
+                warmup_replays=args.warmup_replays,
+                samples=args.samples,
+                device_group=device_group,
+                cpu_group=cpu_group,
+            )
+        for cutoff, fused_op in fused_ops:
+
+            def fused(
+                routed: torch.Tensor = routed,
+                shared: torch.Tensor = shared,
+                fused_op: latent_moe_tail.KimiK3LatentMoETailOp = fused_op,
+            ) -> torch.Tensor:
+                return fused_op(routed, shared, rms_weight, up_weight)
+
+            fused_graph, fused_output = capture_tail_graph(fused, cpu_group)
+            fused_key = "fused" if len(fused_ops) == 1 else f"fused_skinny_max_{cutoff}"
+            result[fused_key] = benchmark_tail_graph(
+                fused_graph,
+                warmup_replays=args.warmup_replays,
+                samples=args.samples,
+                device_group=device_group,
+                cpu_group=cpu_group,
+            )
+            check_fused_output(fused_output, reference, cpu_group)
+            if "reference" in result:
+                speedup = (
+                    result["reference"]["median_us"] / result[fused_key]["median_us"]
+                )
+                if len(fused_ops) == 1:
+                    result["speedup"] = speedup
+                else:
+                    result[f"{fused_key}_speedup"] = speedup
+        results.append(result)
+
+    properties = torch.cuda.get_device_properties(device)
+    report = {
+        "scope": "whole-tail",
+        "device": properties.name,
+        "compute_capability": list(torch.cuda.get_device_capability(device)),
+        "world_size": world_size,
+        "torch_version": torch.__version__,
+        "cuda_version": torch.version.cuda,
+        "warmup_replays": args.warmup_replays,
+        "samples": args.samples,
+        "skinny_max_num_tokens": [cutoff for cutoff, _ in fused_ops],
+        "skinny_configs": {
+            str(num_tokens): asdict(config)
+            for num_tokens, config in skinny_configs.items()
+        },
+        "timing_scope": {
+            "reference": (
+                "two input copies, two AllReduces, RMSNorm, full replicated "
+                "up-projection GEMM, and final add"
+            ),
+            "fused": (
+                "routed AllReduce/RMSNorm plus shared ReduceScatter, sharded "
+                "up-projection/multicast, and Lamport copy"
+            ),
+        },
+        "results": results,
+    }
+    if rank == 0:
+        rendered = json.dumps(report, indent=2)
+        print(rendered, flush=True)
+        if args.output is not None:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(rendered + "\n", encoding="utf-8")
+
+    dist.barrier(group=cpu_group)
+
+
+def main() -> None:
+    args = parse_args()
+    if args.scope == "up-projection":
+        benchmark_up_projection(args)
+        return
+
+    from vllm.config import VllmConfig, set_current_vllm_config
+
+    with set_current_vllm_config(VllmConfig()):
+        benchmark_whole_tail(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/csrc/libtorch_stable/activation_kernels.cu
+++ b/csrc/libtorch_stable/activation_kernels.cu
@@ -464,6 +464,66 @@ __global__ void swigluoai_and_mul_kernel(
   }
 }
 
+// SITU (Kimi SituGLU) gated activation. Non-interleaved layout:
+// input = [gate(d), up(d)] per token.
+//   gate_out = beta * tanh(gate / beta) * sigmoid(gate)
+//   up_out   = (linear_beta > 0) ? linear_beta * tanh(up / linear_beta) : up
+//   out      = gate_out * up_out
+// Compute is done in fp32 and written straight to `out` -- no intermediate
+// tensors and no full-tensor fp32 upcast (the pure-torch forward_native
+// allocated ~8 fp32 temporaries per call, which blows up MoE profiling).
+template <typename scalar_t>
+__global__ void situ_and_mul_kernel(
+    scalar_t* __restrict__ out,          // [..., d]
+    const scalar_t* __restrict__ input,  // [..., 2, d]
+    const int d, const float beta, const float linear_beta) {
+  const int64_t row = blockIdx.x;
+  const scalar_t* gate_ptr = input + row * 2 * d;
+  const scalar_t* up_ptr = gate_ptr + d;
+  scalar_t* out_ptr = out + row * d;
+  const bool clamp_up = linear_beta > 0.0f;
+  const float inv_beta = 1.0f / beta;
+  const float inv_linear_beta = clamp_up ? 1.0f / linear_beta : 0.0f;
+  for (int64_t idx = threadIdx.x; idx < d; idx += blockDim.x) {
+    const float g = (float)VLLM_LDG(&gate_ptr[idx]);
+    const float u = (float)VLLM_LDG(&up_ptr[idx]);
+    const float gate_out = beta * tanhf(g * inv_beta) / (1.0f + expf(-g));
+    const float up_out =
+        clamp_up ? linear_beta * tanhf(u * inv_linear_beta) : u;
+    out_ptr[idx] = (scalar_t)(gate_out * up_out);
+  }
+}
+
+template <typename scalar_t>
+__global__ void masked_situ_and_mul_kernel(
+    scalar_t* __restrict__ out, const scalar_t* __restrict__ input,
+    const int* __restrict__ expert_num_tokens, const int max_num_tokens,
+    const int d, const float beta, const float linear_beta) {
+  const int expert = blockIdx.y;
+  const int num_tokens = expert_num_tokens[expert];
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= d || num_tokens == 0) {
+    return;
+  }
+
+  const bool clamp_up = linear_beta > 0.0f;
+  const float inv_beta = 1.0f / beta;
+  const float inv_linear_beta = clamp_up ? 1.0f / linear_beta : 0.0f;
+  const int64_t expert_row = static_cast<int64_t>(expert) * max_num_tokens;
+  for (int token = 0; token < num_tokens; ++token) {
+    const int64_t row = expert_row + token;
+    const scalar_t* gate_ptr = input + row * 2 * d;
+    const scalar_t* up_ptr = gate_ptr + d;
+    scalar_t* out_ptr = out + row * d;
+    const float g = (float)VLLM_LDG(&gate_ptr[idx]);
+    const float u = (float)VLLM_LDG(&up_ptr[idx]);
+    const float gate_out = beta * tanhf(g * inv_beta) / (1.0f + expf(-g));
+    const float up_out =
+        clamp_up ? linear_beta * tanhf(u * inv_linear_beta) : u;
+    out_ptr[idx] = (scalar_t)(gate_out * up_out);
+  }
+}
+
 }  // namespace vllm
 
 #define LAUNCH_ACTIVATION_GATE_KERNEL_WITH_PARAM(KERNEL, PACKED_KERNEL, PARAM) \
@@ -552,6 +612,54 @@ void swigluoai_and_mul(torch::stable::Tensor& out,    // [..., d]
                        torch::stable::Tensor& input,  // [..., 2 * d]
                        double alpha, double limit) {
   LAUNCH_SIGLUOAI_AND_MUL(vllm::swigluoai_and_mul, alpha, limit);
+}
+
+// Kimi SITU gated activation. `linear_beta <= 0` means "unset" (up passed
+// through), matching SituAndMul(linear_beta=None) on the Python side.
+void situ_and_mul(torch::stable::Tensor& out,    // [..., d]
+                  torch::stable::Tensor& input,  // [..., 2 * d]
+                  double beta, double linear_beta) {
+  int d = input.size(-1) / 2;
+  int64_t num_tokens = input.numel() / input.size(-1);
+  if (num_tokens == 0) {
+    return;
+  }
+  dim3 grid(num_tokens);
+  dim3 block(std::min(d, 1024));
+  const torch::stable::accelerator::DeviceGuard device_guard(
+      input.get_device_index());
+  const cudaStream_t stream = get_current_cuda_stream();
+  VLLM_STABLE_DISPATCH_FLOATING_TYPES(
+      input.scalar_type(), "situ_and_mul_kernel", [&] {
+        vllm::situ_and_mul_kernel<scalar_t><<<grid, block, 0, stream>>>(
+            out.mutable_data_ptr<scalar_t>(), input.const_data_ptr<scalar_t>(),
+            d, (float)beta, (float)linear_beta);
+      });
+}
+
+void masked_situ_and_mul(torch::stable::Tensor& out,    // [E, T, d]
+                         torch::stable::Tensor& input,  // [E, T, 2 * d]
+                         const torch::stable::Tensor& expert_num_tokens,
+                         double beta, double linear_beta) {
+  int num_experts = input.size(0);
+  int max_num_tokens = input.size(1);
+  int d = input.size(2) / 2;
+  if (num_experts == 0 || max_num_tokens == 0) {
+    return;
+  }
+  constexpr int block_size = 256;
+  dim3 grid((d + block_size - 1) / block_size, num_experts);
+  dim3 block(block_size);
+  const torch::stable::accelerator::DeviceGuard device_guard(
+      input.get_device_index());
+  const cudaStream_t stream = get_current_cuda_stream();
+  VLLM_STABLE_DISPATCH_FLOATING_TYPES(
+      input.scalar_type(), "masked_situ_and_mul_kernel", [&] {
+        vllm::masked_situ_and_mul_kernel<scalar_t><<<grid, block, 0, stream>>>(
+            out.mutable_data_ptr<scalar_t>(), input.const_data_ptr<scalar_t>(),
+            expert_num_tokens.const_data_ptr<int>(), max_num_tokens, d,
+            (float)beta, (float)linear_beta);
+      });
 }
 namespace vllm {
 

--- a/csrc/libtorch_stable/moe/grouped_topk_kernels.cu
+++ b/csrc/libtorch_stable/moe/grouped_topk_kernels.cu
@@ -25,6 +25,7 @@
 #include "libtorch_stable/torch_utils.h"
 
 #include <cmath>
+#include <cstdint>
 #include <tuple>
 #include <cuda_fp16.h>
 #include <cuda_bf16.h>
@@ -448,7 +449,8 @@ enum ScoringFunc {
   SCORING_SIGMOID = 1  // apply sigmoid
 };
 
-// Efficient sigmoid approximation from TensorRT-LLM
+// Adapted from
+// https://github.com/NVIDIA/TensorRT-LLM/blob/v1.3.0rc2/cpp/tensorrt_llm/kernels/noAuxTcKernels.cu
 __device__ inline float sigmoid_accurate(float x) {
   return 0.5f * tanhf(0.5f * x) + 0.5f;
 }
@@ -890,6 +892,434 @@ __global__ void grouped_topk_fused_small_expert_count_kernel(
 #endif
 }
 
+// Adapted from
+// https://github.com/flashinfer-ai/flashinfer/blob/06400d062a2d51564bbe781f6f811d0b75ca593e/include/flashinfer/trtllm/fused_moe/RoutingKernelTopK.cuh
+namespace single_group_topk {
+namespace detail {
+
+static constexpr int BlockDim = 256;
+static constexpr uint32_t FullWarpMask = 0xffffffffU;
+static constexpr float InvalidScore = -INFINITY;
+
+// TopK-only tuning: use wider workers and keep these tiers on the block path.
+template <int MaxNumExperts, int MaxNumTopExperts>
+static constexpr bool UseTunedBlockPath =
+    MaxNumTopExperts == 16 && (MaxNumExperts == 896 || MaxNumExperts == 1024);
+
+template <typename T, typename BiasT, ScoringFunc SF>
+__device__ __forceinline__ void preprocess_score(T input, BiasT correction_bias,
+                                                 float& unbiased_score,
+                                                 float& selection_score) {
+  unbiased_score = 0.0F;
+  selection_score = InvalidScore;
+  float const input_float = cuda_cast<float, T>(input);
+  float const bias = cuda_cast<float, BiasT>(correction_bias);
+  if (!is_finite(input_float) || !is_finite(bias)) {
+    return;
+  }
+
+  float const unbiased = apply_scoring<SF>(input_float);
+  float const biased = unbiased + bias;
+  if constexpr (SF == SCORING_NONE) {
+    if (!is_finite(biased)) {
+      return;
+    }
+  }
+  unbiased_score = unbiased;
+  selection_score = biased == 0.0F ? 0.0F : biased;
+}
+
+template <typename IdxT>
+__device__ __forceinline__ void write_outputs(
+    cg::thread_block_tile<WARP_SIZE> const& warp, float lane_selection_score,
+    float lane_unbiased, int32_t lane_expert, int32_t lane, int32_t token,
+    int32_t topk, float* topk_values, IdxT* topk_indices, bool renormalize,
+    float routed_scaling_factor) {
+  bool const finite_selection =
+      lane < topk && lane_selection_score != InvalidScore;
+  lane_unbiased = finite_selection ? lane_unbiased : 0.0F;
+  unsigned const finite_mask = __ballot_sync(FullWarpMask, finite_selection);
+  float const sum = cg::reduce(warp, lane_unbiased, cg::plus<float>{});
+
+  if (lane < topk) {
+    float output = 0.0F;
+    if (finite_mask == 0) {
+      if (renormalize) {
+        output = 1.0F / static_cast<float>(topk);
+      }
+    } else if (finite_selection) {
+      float scale = routed_scaling_factor;
+      if (renormalize) {
+        scale /= sum + 1e-20F;
+      }
+      output = lane_unbiased * scale;
+    }
+
+    int64_t const output_index = int64_t{token} * topk + lane;
+    topk_values[output_index] = output;
+    topk_indices[output_index] = static_cast<IdxT>(lane_expert);
+  }
+}
+
+template <typename T, typename BiasT, typename IdxT, ScoringFunc SF,
+          int MaxNumExperts, int MaxNumTopExperts>
+__global__ void __launch_bounds__(BlockDim)
+    single_group_topk_block_kernel(T const* scores, float* topk_values,
+                                   IdxT* topk_indices, BiasT const* bias,
+                                   int64_t num_experts, int64_t topk,
+                                   bool renormalize,
+                                   float routed_scaling_factor,
+                                   bool enable_pdl) {
+  static constexpr int NumChunks = (MaxNumExperts + WARP_SIZE - 1) / WARP_SIZE;
+  static constexpr int WorkerValuesPerLane =
+      UseTunedBlockPath<MaxNumExperts, MaxNumTopExperts> ? 8 : 4;
+  static constexpr int ExpertsPerWorkerWarp = WorkerValuesPerLane * WARP_SIZE;
+  using LaneOwnedRange =
+      reduce_topk::HighExpertLaneOwnedTopKRange<MaxNumExperts,
+                                                MaxNumTopExperts>;
+  static constexpr int NumWorkerWarps =
+      (MaxNumExperts + ExpertsPerWorkerWarp - 1) / ExpertsPerWorkerWarp;
+  static constexpr int NumIntermediate = NumWorkerWarps * MaxNumTopExperts;
+  static constexpr int MergeValuesPerLane =
+      (NumIntermediate + WARP_SIZE - 1) / WARP_SIZE;
+  static constexpr bool LaneOwnedResourcesFit =
+      NumWorkerWarps <= BlockDim / WARP_SIZE && MergeValuesPerLane <= 64;
+  static constexpr bool UseHierarchicalLaneTopK =
+      LaneOwnedRange::kEnabled && LaneOwnedResourcesFit;
+
+  static_assert(NumChunks <= 64);
+  static_assert(MaxNumTopExperts <= WARP_SIZE);
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  if (enable_pdl) {
+    cudaGridDependencySynchronize();
+  }
+#endif
+
+  __shared__ float __attribute((aligned(128))) biased_scores[MaxNumExperts];
+  __shared__ float __attribute((aligned(128))) unbiased_scores[MaxNumExperts];
+
+  int32_t const token = static_cast<int32_t>(blockIdx.x);
+  int32_t const lane = static_cast<int32_t>(threadIdx.x) % WARP_SIZE;
+  int32_t const warp_id = static_cast<int32_t>(threadIdx.x) / WARP_SIZE;
+  int32_t const num_experts_i32 = static_cast<int32_t>(num_experts);
+  int32_t const topk_i32 = static_cast<int32_t>(topk);
+  T const* token_scores = scores + int64_t{token} * num_experts;
+
+  for (int32_t expert = static_cast<int32_t>(threadIdx.x);
+       expert < num_experts_i32; expert += BlockDim) {
+    preprocess_score<T, BiasT, SF>(token_scores[expert], bias[expert],
+                                   unbiased_scores[expert],
+                                   biased_scores[expert]);
+  }
+  __syncthreads();
+
+  auto warp = cg::tiled_partition<WARP_SIZE>(cg::this_thread_block());
+
+  if constexpr (UseHierarchicalLaneTopK) {
+    __shared__ float
+        __attribute((aligned(128))) intermediate_scores[NumIntermediate];
+    __shared__ int32_t
+        __attribute((aligned(128))) intermediate_indices[NumIntermediate];
+
+    if (warp_id < NumWorkerWarps) {
+      float local_scores[WorkerValuesPerLane];
+      int32_t local_indices[WorkerValuesPerLane];
+#pragma unroll
+      for (int index = 0; index < WorkerValuesPerLane; ++index) {
+        int32_t const expert =
+            warp_id * ExpertsPerWorkerWarp + index * WARP_SIZE + lane;
+        local_scores[index] =
+            expert < num_experts_i32 ? biased_scores[expert] : InvalidScore;
+        local_indices[index] = expert;
+      }
+
+      float lane_score;
+      int32_t lane_expert;
+      reduce_topk::reduceTopKForLane<MaxNumTopExperts>(
+          warp, lane_score, lane_expert, local_scores, local_indices,
+          InvalidScore, lane);
+      if (lane < MaxNumTopExperts) {
+        int32_t const intermediate = warp_id * MaxNumTopExperts + lane;
+        bool const active = lane < topk_i32;
+        intermediate_scores[intermediate] = active ? lane_score : InvalidScore;
+        intermediate_indices[intermediate] =
+            active ? lane_expert : MaxNumExperts;
+      }
+    }
+    __syncthreads();
+
+    if (warp_id != 0) {
+      return;
+    }
+
+    float merge_scores[MergeValuesPerLane];
+    int32_t merge_indices[MergeValuesPerLane];
+#pragma unroll
+    for (int index = 0; index < MergeValuesPerLane; ++index) {
+      int32_t const intermediate = index * WARP_SIZE + lane;
+      bool const active = intermediate < NumIntermediate;
+      merge_scores[index] =
+          active ? intermediate_scores[intermediate] : InvalidScore;
+      merge_indices[index] =
+          active ? intermediate_indices[intermediate] : MaxNumExperts;
+    }
+
+    float lane_score;
+    int32_t lane_expert;
+    reduce_topk::reduceTopKForLane<MaxNumTopExperts>(
+        warp, lane_score, lane_expert, merge_scores, merge_indices,
+        InvalidScore, lane);
+    float const lane_unbiased =
+        lane < topk_i32 && lane_expert >= 0 && lane_expert < num_experts_i32
+            ? unbiased_scores[lane_expert]
+            : 0.0F;
+    write_outputs(warp, lane_score, lane_unbiased, lane_expert, lane, token,
+                  topk_i32, topk_values, topk_indices, renormalize,
+                  routed_scaling_factor);
+  } else {
+    if (warp_id != 0) {
+      return;
+    }
+
+    float local_scores[NumChunks];
+    int32_t local_indices[NumChunks];
+#pragma unroll
+    for (int index = 0; index < NumChunks; ++index) {
+      int32_t const expert = index * WARP_SIZE + lane;
+      local_scores[index] =
+          expert < num_experts_i32 ? biased_scores[expert] : InvalidScore;
+      local_indices[index] = expert;
+    }
+
+    float top_scores[MaxNumTopExperts];
+    int32_t top_experts[MaxNumTopExperts];
+    reduce_topk::reduceTopK(warp, top_scores, top_experts, local_scores,
+                            local_indices, InvalidScore, topk_i32);
+    float const lane_score = lane < topk_i32 ? top_scores[lane] : InvalidScore;
+    int32_t const lane_expert = lane < topk_i32 ? top_experts[lane] : -1;
+    float const lane_unbiased =
+        lane < topk_i32 && lane_expert >= 0 && lane_expert < num_experts_i32
+            ? unbiased_scores[lane_expert]
+            : 0.0F;
+    write_outputs(warp, lane_score, lane_unbiased, lane_expert, lane, token,
+                  topk_i32, topk_values, topk_indices, renormalize,
+                  routed_scaling_factor);
+  }
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  if (enable_pdl) {
+    cudaTriggerProgrammaticLaunchCompletion();
+  }
+#endif
+}
+
+template <int MaxNumExperts>
+struct WarpTopKLaunchConfig {
+  static constexpr int DefaultBlockDim =
+      MaxNumExperts <= 1024 ? MaxNumExperts : 1024;
+  static constexpr int BlockDim = DefaultBlockDim > 256 ? 256 : DefaultBlockDim;
+  static constexpr int NumWarps = BlockDim / WARP_SIZE;
+  static constexpr int MaxBlockScale =
+      (DefaultBlockDim + BlockDim - 1) / BlockDim;
+  static constexpr int MaxBlocks = 1024 * MaxBlockScale;
+
+  static_assert(BlockDim % WARP_SIZE == 0);
+
+  static uint32_t grid_dim(int64_t num_tokens) {
+    int64_t const token_blocks = (num_tokens + NumWarps - 1) / NumWarps;
+    int64_t const selected =
+        token_blocks < MaxBlocks ? token_blocks : MaxBlocks;
+    return static_cast<uint32_t>(selected > 0 ? selected : 1);
+  }
+};
+
+template <typename T, typename BiasT, typename IdxT, ScoringFunc SF,
+          int MaxNumExperts, int MaxNumTopExperts>
+__global__ void __launch_bounds__(WarpTopKLaunchConfig<MaxNumExperts>::BlockDim)
+    single_group_topk_warp_kernel(T const* scores, float* topk_values,
+                                  IdxT* topk_indices, BiasT const* bias,
+                                  int64_t num_tokens, int64_t num_experts,
+                                  int64_t topk, bool renormalize,
+                                  float routed_scaling_factor,
+                                  bool enable_pdl) {
+  static constexpr int NumChunks = (MaxNumExperts + WARP_SIZE - 1) / WARP_SIZE;
+  static constexpr int WarpBlockDim =
+      WarpTopKLaunchConfig<MaxNumExperts>::BlockDim;
+  using LaneOwnedRange =
+      reduce_topk::HighExpertLaneOwnedTopKRange<MaxNumExperts,
+                                                MaxNumTopExperts>;
+
+  static_assert(NumChunks <= 64);
+  static_assert(MaxNumTopExperts <= WARP_SIZE);
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  if (enable_pdl) {
+    cudaGridDependencySynchronize();
+  }
+#endif
+
+  int32_t const lane = static_cast<int32_t>(threadIdx.x) % WARP_SIZE;
+  int32_t const warp_id = static_cast<int32_t>(threadIdx.x) / WARP_SIZE;
+  int32_t const global_warp =
+      static_cast<int32_t>(blockIdx.x) * WarpBlockDim / WARP_SIZE + warp_id;
+  int32_t const global_warp_stride =
+      static_cast<int32_t>(gridDim.x) * WarpBlockDim / WARP_SIZE;
+  int32_t const num_experts_i32 = static_cast<int32_t>(num_experts);
+  int32_t const topk_i32 = static_cast<int32_t>(topk);
+  auto warp = cg::tiled_partition<WARP_SIZE>(cg::this_thread_block());
+
+  for (int32_t token = global_warp; token < num_tokens;
+       token += global_warp_stride) {
+    T const* token_scores = scores + int64_t{token} * num_experts;
+    float local_scores[NumChunks];
+    int32_t local_indices[NumChunks];
+#pragma unroll
+    for (int index = 0; index < NumChunks; ++index) {
+      int32_t const expert = index * WARP_SIZE + lane;
+      float unbiased;
+      float selection;
+      if (expert < num_experts_i32) {
+        preprocess_score<T, BiasT, SF>(token_scores[expert], bias[expert],
+                                       unbiased, selection);
+      } else {
+        selection = InvalidScore;
+      }
+      local_scores[index] = selection;
+      local_indices[index] = expert;
+    }
+
+    float lane_score;
+    int32_t lane_expert;
+    if constexpr (LaneOwnedRange::kEnabled) {
+      reduce_topk::reduceTopKForLane<MaxNumTopExperts>(
+          warp, lane_score, lane_expert, local_scores, local_indices,
+          InvalidScore, lane);
+    } else {
+      float top_scores[MaxNumTopExperts];
+      int32_t top_experts[MaxNumTopExperts];
+      reduce_topk::reduceTopK(warp, top_scores, top_experts, local_scores,
+                              local_indices, InvalidScore, topk_i32);
+      lane_score = lane < topk_i32 ? top_scores[lane] : InvalidScore;
+      lane_expert = lane < topk_i32 ? top_experts[lane] : -1;
+    }
+
+    float lane_unbiased = 0.0F;
+    if (lane < topk_i32 && lane_expert >= 0 && lane_expert < num_experts_i32) {
+      lane_unbiased = lane_score - cuda_cast<float, BiasT>(bias[lane_expert]);
+    }
+    write_outputs(warp, lane_score, lane_unbiased, lane_expert, lane, token,
+                  topk_i32, topk_values, topk_indices, renormalize,
+                  routed_scaling_factor);
+  }
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  if (enable_pdl) {
+    cudaTriggerProgrammaticLaunchCompletion();
+  }
+#endif
+}
+
+template <int Experts, int TopK>
+struct Tier {
+  static constexpr int kExperts = Experts;
+  static constexpr int kTopK = TopK;
+};
+
+template <typename... Tiers>
+struct TierList {};
+
+using SigmoidBiasTiers =
+    TierList<Tier<128, 8>, Tier<256, 8>, Tier<384, 8>, Tier<512, 8>,
+             Tier<512, 22>, Tier<768, 16>, Tier<896, 16>, Tier<1024, 16>>;
+
+using PrecomputedSoftmaxBiasTiers =
+    TierList<Tier<128, 4>, Tier<128, 8>, Tier<160, 8>, Tier<256, 8>,
+             Tier<256, 16>, Tier<512, 8>, Tier<512, 16>, Tier<512, 22>,
+             Tier<512, 32>, Tier<576, 8>, Tier<768, 16>, Tier<896, 16>,
+             Tier<1024, 16>>;
+
+template <typename T, typename BiasT, typename IdxT, ScoringFunc SF,
+          int MaxNumExperts, int MaxNumTopExperts>
+void launch(T* scores, float* topk_values, IdxT* topk_indices,
+            BiasT const* bias, int64_t num_tokens, int64_t num_experts,
+            int64_t topk, bool renormalize, double routed_scaling_factor,
+            bool enable_pdl, cudaLaunchConfig_t& config) {
+  config.dynamicSmemBytes = 0;
+  bool const use_block_kernel =
+      UseTunedBlockPath<MaxNumExperts, MaxNumTopExperts> ||
+      MaxNumExperts > 1024 || num_experts >= 1024 ||
+      (num_experts >= 256 && num_tokens <= 1024);
+  if (use_block_kernel) {
+    config.gridDim = static_cast<uint32_t>(num_tokens);
+    config.blockDim = BlockDim;
+    cudaLaunchKernelEx(
+        &config,
+        &single_group_topk_block_kernel<T, BiasT, IdxT, SF, MaxNumExperts,
+                                        MaxNumTopExperts>,
+        scores, topk_values, topk_indices, bias, num_experts, topk, renormalize,
+        static_cast<float>(routed_scaling_factor), enable_pdl);
+  } else {
+    using WarpConfig = WarpTopKLaunchConfig<MaxNumExperts>;
+    config.gridDim = WarpConfig::grid_dim(num_tokens);
+    config.blockDim = WarpConfig::BlockDim;
+    cudaLaunchKernelEx(
+        &config,
+        &single_group_topk_warp_kernel<T, BiasT, IdxT, SF, MaxNumExperts,
+                                       MaxNumTopExperts>,
+        scores, topk_values, topk_indices, bias, num_tokens, num_experts, topk,
+        renormalize, static_cast<float>(routed_scaling_factor), enable_pdl);
+  }
+}
+
+template <typename T, typename BiasT, typename IdxT, ScoringFunc SF>
+bool dispatch(TierList<>*, T*, float*, IdxT*, BiasT const*, int64_t, int64_t,
+              int64_t, bool, double, bool, cudaLaunchConfig_t&) {
+  return false;
+}
+
+template <typename T, typename BiasT, typename IdxT, ScoringFunc SF,
+          typename First, typename... Rest>
+bool dispatch(TierList<First, Rest...>*, T* scores, float* topk_values,
+              IdxT* topk_indices, BiasT const* bias, int64_t num_tokens,
+              int64_t num_experts, int64_t topk, bool renormalize,
+              double routed_scaling_factor, bool enable_pdl,
+              cudaLaunchConfig_t& config) {
+  if (num_experts <= First::kExperts && topk <= First::kTopK) {
+    launch<T, BiasT, IdxT, SF, First::kExperts, First::kTopK>(
+        scores, topk_values, topk_indices, bias, num_tokens, num_experts, topk,
+        renormalize, routed_scaling_factor, enable_pdl, config);
+    return true;
+  }
+  return dispatch<T, BiasT, IdxT, SF>(
+      static_cast<TierList<Rest...>*>(nullptr), scores, topk_values,
+      topk_indices, bias, num_tokens, num_experts, topk, renormalize,
+      routed_scaling_factor, enable_pdl, config);
+}
+
+}  // namespace detail
+
+template <typename T, typename BiasT, typename IdxT, ScoringFunc SF>
+bool invoke(T* scores, float* topk_values, IdxT* topk_indices,
+            BiasT const* bias, int64_t num_tokens, int64_t num_experts,
+            int64_t topk, bool renormalize, double routed_scaling_factor,
+            bool enable_pdl, cudaLaunchConfig_t& config) {
+  static_assert(SF == SCORING_NONE || SF == SCORING_SIGMOID);
+  if constexpr (SF == SCORING_SIGMOID) {
+    return detail::dispatch<T, BiasT, IdxT, SF>(
+        static_cast<detail::SigmoidBiasTiers*>(nullptr), scores, topk_values,
+        topk_indices, bias, num_tokens, num_experts, topk, renormalize,
+        routed_scaling_factor, enable_pdl, config);
+  } else {
+    return detail::dispatch<T, BiasT, IdxT, SF>(
+        static_cast<detail::PrecomputedSoftmaxBiasTiers*>(nullptr), scores,
+        topk_values, topk_indices, bias, num_tokens, num_experts, topk,
+        renormalize, routed_scaling_factor, enable_pdl, config);
+  }
+}
+
+}  // namespace single_group_topk
+
 template <typename T, typename BiasT, typename IdxT, ScoringFunc SF>
 void invokeNoAuxTc(T* scores, float* topk_values, IdxT* topk_indices,
                    BiasT const* bias, int64_t const num_tokens,
@@ -905,6 +1335,12 @@ void invokeNoAuxTc(T* scores, float* topk_values, IdxT* topk_indices,
   attrs[0].val.programmaticStreamSerializationAllowed = enable_pdl;
   config.numAttrs = 1;
   config.attrs = attrs;
+  if (n_group == 1 && topk_group == 1 &&
+      single_group_topk::invoke<T, BiasT, IdxT, SF>(
+          scores, topk_values, topk_indices, bias, num_tokens, num_experts,
+          topk, renormalize, routed_scaling_factor, enable_pdl, config)) {
+    return;
+  }
 
   // Check if we can use the optimized
   // grouped_topk_fused_small_expert_count_kernel

--- a/csrc/libtorch_stable/moe/moeTopKFuncs.cuh
+++ b/csrc/libtorch_stable/moe/moeTopKFuncs.cuh
@@ -1,6 +1,7 @@
 /*
  * Adapted from
  * https://github.com/NVIDIA/TensorRT-LLM/blob/v1.3.0rc2/cpp/tensorrt_llm/kernels/moeTopKFuncs.cuh
+ * https://github.com/flashinfer-ai/flashinfer/blob/06400d062a2d51564bbe781f6f811d0b75ca593e/include/flashinfer/trtllm/fused_moe/RoutingKernelTopK.cuh
  * Copyright (c) 2026, The vLLM team.
  * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION. All rights
  * reserved. SPDX-License-Identifier: Apache-2.0
@@ -23,6 +24,9 @@
 #include <cooperative_groups/reduce.h>
 #include <cub/cub.cuh>
 
+#include <cstdint>
+#include <type_traits>
+
 namespace vllm {
 namespace moe {
 namespace reduce_topk {
@@ -38,11 +42,10 @@ struct TopKRedType {
       "Top K reduction only implemented for int, float, float16 and bfloat16");
 
   using TypeCmp = std::conditional_t<sizeof(T) == 4, uint64_t, uint32_t>;
-  using IdxT = std::conditional_t<sizeof(T) == 4, int32_t, int16_t>;
 
   static constexpr int kMoveBits = (sizeof(T) == 4) ? 32 : 16;
   static constexpr int kMaxIdx = 65535;
-  TypeCmp compValIdx;
+  TypeCmp compVal;
 
   static __host__ __device__ inline TypeCmp makeCmpVal(T val, int32_t idx = 0) {
     auto valueBits = cub::Traits<T>::TwiddleIn(
@@ -69,69 +72,175 @@ struct TopKRedType {
   __host__ __device__ TopKRedType() = default;
 
   __host__ __device__ TopKRedType(T val, int32_t idx)
-      : compValIdx(makeCmpVal(val, idx)) {}
+      : compVal(makeCmpVal(val, idx)) {}
 
-  __host__ __device__ operator TypeCmp() const noexcept { return compValIdx; }
+  __host__ __device__ operator TypeCmp() const noexcept { return compVal; }
 
   __device__ inline TypeCmp reduce(
       cg::thread_block_tile<kWARP_SIZE> const& warp) {
-    return cg::reduce(warp, compValIdx, cg::greater<TypeCmp>{});
+#ifdef __CUDA_ARCH__
+    static constexpr bool kHAS_FAST_REDUX = (__CUDA_ARCH__ / 100) >= 10;
+#else
+    static constexpr bool kHAS_FAST_REDUX = false;
+#endif
+    if constexpr (!kHAS_FAST_REDUX) {
+      return cg::reduce(warp, compVal, cg::greater<TypeCmp>{});
+    } else if constexpr (sizeof(TypeCmp) == 8) {
+      uint32_t hi = static_cast<uint32_t>(compVal >> 32);
+      uint32_t lo = static_cast<uint32_t>(compVal & 0xffffffffu);
+      uint32_t maxHi;
+      asm volatile("redux.sync.max.u32 %0, %1, 0xffffffff;\n"
+                   : "=r"(maxHi)
+                   : "r"(hi));
+      uint32_t loContrib = hi == maxHi ? lo : 0u;
+      uint32_t maxLo;
+      asm volatile("redux.sync.max.u32 %0, %1, 0xffffffff;\n"
+                   : "=r"(maxLo)
+                   : "r"(loContrib));
+      return (static_cast<TypeCmp>(maxHi) << 32) | static_cast<TypeCmp>(maxLo);
+    } else {
+      TypeCmp result;
+      asm volatile("redux.sync.max.u32 %0, %1, 0xffffffff;\n"
+                   : "=r"(result)
+                   : "r"(compVal));
+      return result;
+    }
   }
 };
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-template <int K_, bool Enable_>
-struct TopKIdx {
-  // by default, empty
+template <int N>
+struct IsPowerOf2 {
+  static constexpr bool value = N > 0 && (N & (N - 1)) == 0;
 };
 
-template <int K_>
-struct TopKIdx<K_, true> {
-  static constexpr int K = K_;
-  int32_t val[K];
+template <int N>
+struct NextPow2 {
+ private:
+  static constexpr unsigned u = static_cast<unsigned>(N - 1);
+  static constexpr unsigned s1 = u | (u >> 1);
+  static constexpr unsigned s2 = s1 | (s1 >> 2);
+  static constexpr unsigned s3 = s2 | (s2 >> 4);
+  static constexpr unsigned s4 = s3 | (s3 >> 8);
+  static constexpr unsigned s5 = s4 | (s4 >> 16);
+
+ public:
+  static constexpr int value = N <= 1 ? 1 : static_cast<int>(s5 + 1);
 };
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-#define TOPK_SWAP(I, J)                                         \
-  {                                                             \
-    auto pairMin = min(topK[I].compValIdx, topK[J].compValIdx); \
-    auto pairMax = max(topK[I].compValIdx, topK[J].compValIdx); \
-    topK[I].compValIdx = pairMax;                               \
-    topK[J].compValIdx = pairMin;                               \
+template <int A, int B, int Size, typename T>
+__device__ __forceinline__ void topkCompareSwap(T* a) {
+  if constexpr (A < Size && B < Size) {
+    if (a[A] < a[B]) {
+      T tmp = a[A];
+      a[A] = a[B];
+      a[B] = tmp;
+    }
+  } else {
+    (void)a;
   }
+}
+
+template <int I, int End, int Step, int PairStride, int Size, typename T>
+__device__ __forceinline__ void topkMergePairs(T* a) {
+  if constexpr (I + Step < End) {
+    topkCompareSwap<I, I + Step, Size, T>(a);
+    topkMergePairs<I + PairStride, End, Step, PairStride, Size, T>(a);
+  } else {
+    (void)a;
+  }
+}
+
+template <int Lo, int N, int R, int Size, typename T>
+__device__ __forceinline__ void topkOEM(T* a) {
+  constexpr int M = R * 2;
+  if constexpr (M < N) {
+    topkOEM<Lo, N, M, Size, T>(a);
+    topkOEM<Lo + R, N - R, M, Size, T>(a);
+    topkMergePairs<Lo + R, Lo + N, R, M, Size, T>(a);
+  } else if constexpr (R < N) {
+    topkCompareSwap<Lo, Lo + R, Size, T>(a);
+  } else {
+    (void)a;
+  }
+}
+
+template <int Lo, int N, int Size, typename T>
+__device__ __forceinline__ void topkSortBatcher(T* a) {
+  if constexpr (N > 1) {
+    constexpr int Half = N / 2;
+    topkSortBatcher<Lo, Half, Size, T>(a);
+    topkSortBatcher<Lo + Half, N - Half, Size, T>(a);
+    topkOEM<Lo, N, 1, Size, T>(a);
+  } else {
+    (void)a;
+  }
+}
 
 template <int N, typename RedType>
-struct Sort;
+struct Sort {
+  static_assert(N > 0 && N <= 64, "Sort only supports N in range [1, 64]");
+
+  static __device__ void run(RedType* topK) {
+    if constexpr (IsPowerOf2<N>::value) {
+#pragma unroll
+      for (int k = 2; k <= N; k *= 2) {
+#pragma unroll
+        for (int j = k / 2; j > 0; j /= 2) {
+#pragma unroll
+          for (int i = 0; i < N; ++i) {
+            int ixj = i ^ j;
+            if (ixj > i) {
+              if ((i & k) == 0) {
+                if (topK[i].compVal < topK[ixj].compVal) {
+                  auto tmp = topK[i].compVal;
+                  topK[i].compVal = topK[ixj].compVal;
+                  topK[ixj].compVal = tmp;
+                }
+              } else {
+                if (topK[i].compVal > topK[ixj].compVal) {
+                  auto tmp = topK[i].compVal;
+                  topK[i].compVal = topK[ixj].compVal;
+                  topK[ixj].compVal = tmp;
+                }
+              }
+            }
+          }
+        }
+      }
+    } else {
+      constexpr int P = NextPow2<N>::value;
+      topkSortBatcher<0, P, N, RedType>(topK);
+    }
+  }
+};
 
 template <typename RedType>
 struct Sort<1, RedType> {
-  static __device__ void run(RedType* topK) {}
+  static __device__ void run(RedType*) {}
 };
 
 template <typename RedType>
 struct Sort<2, RedType> {
-  static __device__ void run(RedType* topK) { TOPK_SWAP(0, 1); }
+  static __device__ void run(RedType* topK) { topkCompareSwap<0, 1, 2>(topK); }
 };
 
 template <typename RedType>
 struct Sort<3, RedType> {
   static __device__ void run(RedType* topK) {
-    TOPK_SWAP(0, 1);
-    TOPK_SWAP(1, 2);
-    TOPK_SWAP(0, 1);
+    topkCompareSwap<0, 1, 3>(topK);
+    topkCompareSwap<1, 2, 3>(topK);
+    topkCompareSwap<0, 1, 3>(topK);
   }
 };
 
 template <typename RedType>
 struct Sort<4, RedType> {
   static __device__ void run(RedType* topK) {
-    TOPK_SWAP(0, 2);
-    TOPK_SWAP(1, 3);
-    TOPK_SWAP(0, 1);
-    TOPK_SWAP(2, 3);
-    TOPK_SWAP(1, 2);
+    topkCompareSwap<0, 2, 4>(topK);
+    topkCompareSwap<1, 3, 4>(topK);
+    topkCompareSwap<0, 1, 4>(topK);
+    topkCompareSwap<2, 3, 4>(topK);
+    topkCompareSwap<1, 2, 4>(topK);
   }
 };
 
@@ -147,46 +256,8 @@ __forceinline__ __device__ void reduceTopK(
   typename RedType::TypeCmp packedMax{};
 #pragma unroll
   for (int kk = 0; kk < actualK; ++kk) {
-    topK =
-        kk > 0 && packedMax == topK.compValIdx ? RedType{minValue, idx} : topK;
-    // get the next largest value
+    topK = kk > 0 && packedMax == topK.compVal ? RedType{minValue, idx} : topK;
     packedMax = topK.reduce(warp);
-    RedType::unpack(out[kk], outIdx[kk], packedMax);
-  }
-};
-
-template <int K, typename Type, int N, bool IsSorted = false>
-__device__ void reduceTopKFunc(cg::thread_block_tile<kWARP_SIZE> const& warp,
-                               Type (&out)[K], int32_t (&outIdx)[K],
-                               Type (&value)[N], int32_t (&idx)[N],
-                               Type minValue, int actualK = K) {
-  static_assert(K > 0, "Top K must have K > 0");
-  static_assert(K < kWARP_SIZE, "Top K must have K < kWARP_SIZE");
-  static_assert(N > 0, "Top K must have N > 0");
-  static_assert(N < 5,
-                "Only support candidates number less than or equal to 128");
-  using RedType = TopKRedType<Type>;
-  RedType topK[N];
-#pragma unroll
-  for (int nn = 0; nn < N; ++nn) {
-    topK[nn] = RedType{value[nn], idx[nn]};
-  }
-
-  if constexpr (!IsSorted) {
-    Sort<N, RedType>::run(topK);
-  }
-  typename RedType::TypeCmp packedMax{};
-#pragma unroll
-  for (int kk = 0; kk < actualK; ++kk) {
-    bool update = kk > 0 && packedMax == topK[0].compValIdx;
-#pragma unroll
-    for (int nn = 0; nn < N; ++nn) {
-      topK[nn] = update && nn == N - 1 ? RedType{minValue, idx[nn]}
-                 : update              ? topK[nn + 1]
-                                       : topK[nn];
-    }
-    // get the next largest value
-    packedMax = topK[0].reduce(warp);
     RedType::unpack(out[kk], outIdx[kk], packedMax);
   }
 };
@@ -197,60 +268,100 @@ __forceinline__ __device__ void reduceTopK(
     int32_t (&outIdx)[K], Type (&value)[N], int32_t (&idx)[N],
     Type const minValue, int actualK = K) {
   static_assert(K > 0, "Top K must have K > 0");
-  static_assert(K < kWARP_SIZE, "Top K must have K < kWARP_SIZE");
+  static_assert(K <= kWARP_SIZE, "Top K must have K <= kWARP_SIZE");
   static_assert(N > 0, "Top K must have N > 0");
-  static_assert(
-      N <= 16,
-      "Only support candidates number less than or equal to 16*32=512");
-  static_assert(N <= 4 || N % 4 == 0,
-                "Only support candidates number is a multiple of 4*32=128 or "
-                "less than or equal to 4");
+  static_assert(N <= 64,
+                "Only support candidates number less than or equal to "
+                "64*32=2048");
   using RedType = TopKRedType<Type>;
+  RedType topK[N];
+#pragma unroll
+  for (int nn = 0; nn < N; ++nn) {
+    topK[nn] = RedType{value[nn], idx[nn]};
+  }
 
-  if constexpr (N <= 4) {
-    reduceTopKFunc<K, Type, N>(warp, out, outIdx, value, idx, minValue,
-                               actualK);
-  } else {
-    constexpr int numLoops = N / 4;
-    constexpr int numResults = (numLoops * K - 1) / kWARP_SIZE + 1;
+  Sort<N, RedType>::run(topK);
 
-    Type topKBufferValue[numResults];
-    int32_t topKBufferIdx[numResults];
-    int32_t laneIdx = threadIdx.x % kWARP_SIZE;
-
-    for (int ii = 0; ii < numResults; ++ii) {
-      topKBufferValue[ii] = minValue;
-      topKBufferIdx[ii] = ii * kWARP_SIZE - 1;
+  typename RedType::TypeCmp packedMax{};
+  for (int kk = 0; kk < actualK; ++kk) {
+    bool update = kk > 0 && packedMax == topK[0].compVal;
+#pragma unroll
+    for (int nn = 0; nn < N; ++nn) {
+      topK[nn] = update && nn == N - 1 ? RedType{minValue, idx[nn]}
+                 : update              ? topK[nn + 1]
+                                       : topK[nn];
     }
-    for (int loop = 0; loop < numLoops; ++loop) {
-      int start = loop * 4;
-      Type topKValue[K];
-      int32_t topKIdx[K];
-      Type inValue[4];
-      int32_t inIdx[4];
-      for (int i = 0; i < 4; ++i) {
-        inValue[i] = value[start + i];
-        inIdx[i] = idx[start + i];
-      }
-      reduceTopKFunc<K, Type, 4>(warp, topKValue, topKIdx, inValue, inIdx,
-                                 minValue, actualK);
-      int inOffset = laneIdx % K;
-      if (laneIdx >= loop * K && laneIdx < (loop + 1) * K) {
-        topKBufferValue[0] = topKValue[inOffset];
-        topKBufferIdx[0] = topKIdx[inOffset];
-      }
-      if (loop == numLoops - 1 && (laneIdx < (numLoops * K - kWARP_SIZE))) {
-        topKBufferValue[1] = topKValue[inOffset];
-        topKBufferIdx[1] = topKIdx[inOffset];
-      }
-    }
-
-    reduceTopKFunc<K, Type, numResults>(warp, out, outIdx, topKBufferValue,
-                                        topKBufferIdx, minValue, actualK);
+    packedMax = topK[0].reduce(warp);
+    RedType::unpack(out[kk], outIdx[kk], packedMax);
   }
 };
 
-#undef TOPK_SWAP
+template <int NumExperts, int NumTopExperts, int MinExperts, int MaxExperts,
+          int MinTopExperts, int MaxTopExperts>
+struct LaneOwnedTopKRange {
+  static_assert(MinExperts > 0 && MinExperts <= MaxExperts);
+  static_assert(MinTopExperts > 0 && MinTopExperts <= MaxTopExperts);
+  static constexpr bool kEnabled =
+      NumExperts >= MinExperts && NumExperts <= MaxExperts &&
+      NumTopExperts >= MinTopExperts && NumTopExperts <= MaxTopExperts;
+};
+
+static constexpr int kHIGH_EXPERT_LANE_OWNED_TOPK_MIN_EXPERTS = 512;
+static constexpr int kHIGH_EXPERT_LANE_OWNED_TOPK_MAX_EXPERTS = 1024;
+static constexpr int kHIGH_EXPERT_LANE_OWNED_TOPK_MIN_TOP_EXPERTS = 9;
+static constexpr int kHIGH_EXPERT_LANE_OWNED_TOPK_MAX_TOP_EXPERTS = 16;
+
+template <int NumExperts, int NumTopExperts>
+using HighExpertLaneOwnedTopKRange =
+    LaneOwnedTopKRange<NumExperts, NumTopExperts,
+                       kHIGH_EXPERT_LANE_OWNED_TOPK_MIN_EXPERTS,
+                       kHIGH_EXPERT_LANE_OWNED_TOPK_MAX_EXPERTS,
+                       kHIGH_EXPERT_LANE_OWNED_TOPK_MIN_TOP_EXPERTS,
+                       kHIGH_EXPERT_LANE_OWNED_TOPK_MAX_TOP_EXPERTS>;
+
+template <int K, typename Type, int N>
+__forceinline__ __device__ void reduceTopKForLane(
+    cg::thread_block_tile<kWARP_SIZE> const& warp, Type& out, int32_t& outIdx,
+    Type (&value)[N], int32_t (&idx)[N], Type const minValue, int32_t laneIdx) {
+  static_assert(K > 0, "Top K must have K > 0");
+  static_assert(K <= kWARP_SIZE, "Top K must have K <= kWARP_SIZE");
+  static_assert(N > 0, "Top K must have N > 0");
+  static_assert(N <= 64,
+                "Only support candidates number less than or equal to "
+                "64*32=2048");
+  using RedType = TopKRedType<Type>;
+  RedType topK[N];
+#pragma unroll
+  for (int nn = 0; nn < N; ++nn) {
+    topK[nn] = RedType{value[nn], idx[nn]};
+  }
+
+  Sort<N, RedType>::run(topK);
+
+  typename RedType::TypeCmp packedMax{};
+  typename RedType::TypeCmp lanePacked{};
+#pragma unroll
+  for (int kk = 0; kk < K; ++kk) {
+    bool update = kk > 0 && packedMax == topK[0].compVal;
+#pragma unroll
+    for (int nn = 0; nn < N; ++nn) {
+      topK[nn] = update && nn == N - 1 ? RedType{minValue, idx[nn]}
+                 : update              ? topK[nn + 1]
+                                       : topK[nn];
+    }
+    packedMax = topK[0].reduce(warp);
+    if (laneIdx == kk) {
+      lanePacked = packedMax;
+    }
+  }
+
+  if (laneIdx < K) {
+    RedType::unpack(out, outIdx, lanePacked);
+  } else {
+    out = minValue;
+    outIdx = -1;
+  }
+}
 
 }  // namespace reduce_topk
 }  // namespace moe

--- a/csrc/libtorch_stable/ops.h
+++ b/csrc/libtorch_stable/ops.h
@@ -410,6 +410,12 @@ void fatrelu_and_mul(torch::stable::Tensor& out, torch::stable::Tensor& input,
                      double threshold);
 void swigluoai_and_mul(torch::stable::Tensor& out, torch::stable::Tensor& input,
                        double alpha = 1.702, double limit = 7.0);
+void situ_and_mul(torch::stable::Tensor& out, torch::stable::Tensor& input,
+                  double beta = 1.0, double linear_beta = -1.0);
+void masked_situ_and_mul(torch::stable::Tensor& out,
+                         torch::stable::Tensor& input,
+                         const torch::stable::Tensor& expert_num_tokens,
+                         double beta = 1.0, double linear_beta = -1.0);
 void gelu_new(torch::stable::Tensor& out, torch::stable::Tensor& input);
 void gelu_fast(torch::stable::Tensor& out, torch::stable::Tensor& input);
 void gelu_quick(torch::stable::Tensor& out, torch::stable::Tensor& input);

--- a/csrc/libtorch_stable/torch_bindings.cpp
+++ b/csrc/libtorch_stable/torch_bindings.cpp
@@ -530,6 +530,14 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C, ops) {
       "limit=7.0) "
       "-> ()");
 
+  // SituGLU implementation used in Kimi models.
+  ops.def(
+      "situ_and_mul(Tensor! out, Tensor input, float beta=1.0, float "
+      "linear_beta=-1.0) -> ()");
+  ops.def(
+      "masked_situ_and_mul(Tensor! out, Tensor input, Tensor "
+      "expert_num_tokens, float beta=1.0, float linear_beta=-1.0) -> ()");
+
   // GELU implementation used in GPT-2.
   ops.def("gelu_new(Tensor! out, Tensor input) -> ()");
 
@@ -715,6 +723,8 @@ STABLE_TORCH_LIBRARY_IMPL(_C, CUDA, ops) {
   ops.impl("gelu_tanh_and_mul", TORCH_BOX(&gelu_tanh_and_mul));
   ops.impl("fatrelu_and_mul", TORCH_BOX(&fatrelu_and_mul));
   ops.impl("swigluoai_and_mul", TORCH_BOX(&swigluoai_and_mul));
+  ops.impl("situ_and_mul", TORCH_BOX(&situ_and_mul));
+  ops.impl("masked_situ_and_mul", TORCH_BOX(&masked_situ_and_mul));
   ops.impl("gelu_new", TORCH_BOX(&gelu_new));
   ops.impl("gelu_fast", TORCH_BOX(&gelu_fast));
   ops.impl("gelu_quick", TORCH_BOX(&gelu_quick));

--- a/tests/kernels/core/test_activation.py
+++ b/tests/kernels/core/test_activation.py
@@ -197,6 +197,46 @@ def test_silu_and_mul_with_clamp(
     opcheck(torch.ops._C.silu_and_mul_with_clamp, (out_buf, x, swiglu_limit))
 
 
+@pytest.mark.parametrize("linear_beta", [-1.0, 2.0])
+@pytest.mark.parametrize("dtype", [torch.half, torch.bfloat16])
+@torch.inference_mode()
+def test_masked_situ_and_mul(
+    default_vllm_config,
+    linear_beta: float,
+    dtype: torch.dtype,
+) -> None:
+    """Masked SITU computes valid expert rows and preserves padded zeros."""
+    device = CUDA_DEVICES[0]
+    num_experts, max_num_tokens, d = 4, 7, 512
+    beta = 1.5
+    input = torch.randn(num_experts, max_num_tokens, 2 * d, dtype=dtype, device=device)
+    expert_num_tokens = torch.tensor([0, 1, 4, 7], dtype=torch.int32, device=device)
+    output = torch.zeros(num_experts, max_num_tokens, d, dtype=dtype, device=device)
+
+    torch.ops._C.masked_situ_and_mul(
+        output, input, expert_num_tokens, beta, linear_beta
+    )
+
+    gate, up = input.float().chunk(2, dim=-1)
+    expected = beta * torch.tanh(gate / beta) * torch.sigmoid(gate)
+    if linear_beta > 0:
+        up = linear_beta * torch.tanh(up / linear_beta)
+    expected = (expected * up).to(dtype)
+    for expert, num_tokens in enumerate(expert_num_tokens.cpu().tolist()):
+        torch.testing.assert_close(
+            output[expert, :num_tokens],
+            expected[expert, :num_tokens],
+            atol=get_default_atol(output),
+            rtol=get_default_rtol(output),
+        )
+        assert torch.count_nonzero(output[expert, num_tokens:]) == 0
+
+    opcheck(
+        torch.ops._C.masked_situ_and_mul,
+        (output, input, expert_num_tokens, beta, linear_beta),
+    )
+
+
 @pytest.mark.parametrize(
     "activation",
     [

--- a/tests/kernels/moe/test_grouped_topk.py
+++ b/tests/kernels/moe/test_grouped_topk.py
@@ -23,6 +23,53 @@ from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
 
+def _run_single_group_topk(
+    logits: torch.Tensor,
+    bias: torch.Tensor,
+    topk: int,
+    *,
+    scoring_func: str,
+    renormalize: bool,
+    routed_scaling_factor: float = 1.0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return fused_grouped_topk(
+        hidden_states=torch.empty(
+            (logits.shape[0], 0), dtype=logits.dtype, device=logits.device
+        ),
+        gating_output=logits,
+        topk=topk,
+        renormalize=renormalize,
+        e_score_correction_bias=bias,
+        num_expert_group=1,
+        topk_group=1,
+        scoring_func=scoring_func,
+        routed_scaling_factor=routed_scaling_factor,
+    )
+
+
+def _single_group_reference(
+    logits: torch.Tensor,
+    bias: torch.Tensor,
+    topk: int,
+    *,
+    scoring_func: str,
+    renormalize: bool,
+    routed_scaling_factor: float = 1.0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if scoring_func == "sigmoid":
+        scores = 0.5 * torch.tanh(0.5 * logits.float()) + 0.5
+    else:
+        scores = torch.softmax(logits, dim=-1).float()
+    indices = torch.argsort(
+        scores + bias.float(), dim=-1, descending=True, stable=True
+    )[:, :topk]
+    values = scores.gather(1, indices)
+    if renormalize:
+        values /= values.sum(dim=-1, keepdim=True) + 1e-20
+    values *= routed_scaling_factor
+    return values, indices.to(torch.int32)
+
+
 @pytest.mark.skipif(
     not current_platform.is_cuda(), reason="This test is skipped on non-CUDA platform."
 )
@@ -101,3 +148,222 @@ def test_grouped_topk(
             baseline_topk_weights, test_topk_weights, atol=2e-2, rtol=0
         )
         torch.testing.assert_close(baseline_topk_ids, test_topk_ids, atol=0, rtol=0)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="This test is skipped on non-CUDA platform."
+)
+def test_grouped_topk_single_group_large_batch():
+    set_random_seed(0)
+    logits = torch.randn((1536, 896), dtype=torch.bfloat16, device="cuda")
+    bias = torch.randn((896,), dtype=torch.float32, device="cuda")
+
+    expected_values, expected_ids = _single_group_reference(
+        logits, bias, 16, scoring_func="sigmoid", renormalize=True
+    )
+    actual_values, actual_ids = _run_single_group_topk(
+        logits, bias, 16, scoring_func="sigmoid", renormalize=True
+    )
+
+    torch.testing.assert_close(actual_ids, expected_ids)
+    torch.testing.assert_close(actual_values, expected_values, atol=2e-5, rtol=0)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="This test is skipped on non-CUDA platform."
+)
+@pytest.mark.parametrize(
+    "num_experts,topk,input_dtype,bias_dtype",
+    [
+        (512, 9, torch.bfloat16, torch.float32),
+        (512, 16, torch.float16, torch.float16),
+        (513, 9, torch.float32, torch.bfloat16),
+        (513, 16, torch.bfloat16, torch.float32),
+        (895, 9, torch.float16, torch.bfloat16),
+        (896, 16, torch.float32, torch.float16),
+        (897, 9, torch.bfloat16, torch.bfloat16),
+        (897, 16, torch.float16, torch.float32),
+        (1024, 9, torch.float32, torch.bfloat16),
+        (1024, 16, torch.bfloat16, torch.float16),
+    ],
+)
+@pytest.mark.parametrize(
+    "scoring_func,renormalize,routed_scaling_factor",
+    [
+        ("sigmoid", True, 1.0),
+        ("sigmoid", False, 2.5),
+        ("softmax", True, 2.5),
+        ("softmax", False, 1.0),
+    ],
+)
+def test_grouped_topk_single_group_tiers(
+    num_experts: int,
+    topk: int,
+    input_dtype: torch.dtype,
+    bias_dtype: torch.dtype,
+    scoring_func: str,
+    renormalize: bool,
+    routed_scaling_factor: float,
+):
+    set_random_seed(7)
+    logits = torch.randn((17, num_experts), dtype=input_dtype, device="cuda")
+    bias = torch.randn((num_experts,), dtype=bias_dtype, device="cuda")
+
+    expected_values, expected_ids = _single_group_reference(
+        logits,
+        bias,
+        topk,
+        scoring_func=scoring_func,
+        renormalize=renormalize,
+        routed_scaling_factor=routed_scaling_factor,
+    )
+    actual_values, actual_ids = _run_single_group_topk(
+        logits,
+        bias,
+        topk,
+        scoring_func=scoring_func,
+        renormalize=renormalize,
+        routed_scaling_factor=routed_scaling_factor,
+    )
+
+    torch.testing.assert_close(actual_ids, expected_ids)
+    torch.testing.assert_close(actual_values, expected_values, atol=2e-5, rtol=0)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="This test is skipped on non-CUDA platform."
+)
+@pytest.mark.parametrize(
+    "num_experts,topk,scoring_func",
+    [
+        (128, 8, "sigmoid"),
+        (129, 8, "sigmoid"),
+        (257, 8, "sigmoid"),
+        (385, 8, "sigmoid"),
+        (512, 9, "sigmoid"),
+        (513, 9, "sigmoid"),
+        (769, 9, "sigmoid"),
+        (897, 16, "sigmoid"),
+        (1024, 16, "sigmoid"),
+        (128, 4, "softmax"),
+        (128, 5, "softmax"),
+        (129, 8, "softmax"),
+        (161, 8, "softmax"),
+        (256, 9, "softmax"),
+        (257, 8, "softmax"),
+        (512, 9, "softmax"),
+        (512, 17, "softmax"),
+        (512, 23, "softmax"),
+        (513, 8, "softmax"),
+        (577, 9, "softmax"),
+        (769, 9, "softmax"),
+        (897, 9, "softmax"),
+        (1024, 16, "softmax"),
+    ],
+)
+def test_grouped_topk_single_group_capacity_tiers(
+    num_experts: int,
+    topk: int,
+    scoring_func: str,
+):
+    set_random_seed(11)
+    logits = torch.randn((3, num_experts), dtype=torch.bfloat16, device="cuda")
+    bias = torch.randn((num_experts,), dtype=torch.float32, device="cuda")
+    expected_values, expected_ids = _single_group_reference(
+        logits,
+        bias,
+        topk,
+        scoring_func=scoring_func,
+        renormalize=True,
+        routed_scaling_factor=2.5,
+    )
+    actual_values, actual_ids = _run_single_group_topk(
+        logits,
+        bias,
+        topk,
+        scoring_func=scoring_func,
+        renormalize=True,
+        routed_scaling_factor=2.5,
+    )
+
+    torch.testing.assert_close(actual_ids, expected_ids)
+    torch.testing.assert_close(actual_values, expected_values, atol=2e-5, rtol=0)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="This test is skipped on non-CUDA platform."
+)
+@pytest.mark.parametrize("num_experts", [512, 896, 1024])
+def test_grouped_topk_single_group_stable_ties(num_experts: int):
+    logits = torch.zeros((1, num_experts), dtype=torch.bfloat16, device="cuda")
+    bias = torch.zeros((num_experts,), dtype=torch.float32, device="cuda")
+
+    actual_values, actual_ids = _run_single_group_topk(
+        logits,
+        bias,
+        16,
+        scoring_func="sigmoid",
+        renormalize=True,
+        routed_scaling_factor=2.5,
+    )
+
+    expected_ids = torch.arange(16, dtype=torch.int32, device="cuda")[None]
+    expected_values = torch.full((1, 16), 2.5 / 16, dtype=torch.float32, device="cuda")
+    torch.testing.assert_close(actual_ids, expected_ids)
+    torch.testing.assert_close(actual_values, expected_values, atol=2e-5, rtol=0)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="This test is skipped on non-CUDA platform."
+)
+@pytest.mark.parametrize("num_experts", [512, 896, 1024])
+@pytest.mark.parametrize("num_finite", [0, 15])
+@pytest.mark.parametrize("renormalize", [False, True])
+def test_grouped_topk_single_group_nonfinite_scores(
+    num_experts: int, num_finite: int, renormalize: bool
+):
+    logits = torch.full(
+        (1, num_experts), float("nan"), dtype=torch.bfloat16, device="cuda"
+    )
+    if num_finite:
+        logits[0, :num_finite] = torch.arange(
+            num_finite, dtype=torch.bfloat16, device="cuda"
+        )
+    logits[0, num_finite] = torch.inf
+    logits[0, num_finite + 1] = -torch.inf
+    bias = torch.zeros((num_experts,), dtype=torch.float32, device="cuda")
+
+    actual_values, actual_ids = _run_single_group_topk(
+        logits,
+        bias,
+        16,
+        scoring_func="sigmoid",
+        renormalize=renormalize,
+        routed_scaling_factor=2.5,
+    )
+
+    if num_finite == 0:
+        expected_ids = torch.arange(16, dtype=torch.int32, device="cuda")[None]
+        if renormalize:
+            expected_values = torch.full(
+                (1, 16), 1 / 16, dtype=torch.float32, device="cuda"
+            )
+        else:
+            expected_values = torch.zeros((1, 16), dtype=torch.float32, device="cuda")
+    else:
+        expected_ids = torch.cat(
+            (
+                torch.arange(num_finite - 1, -1, -1, dtype=torch.int32, device="cuda"),
+                torch.tensor([num_finite], dtype=torch.int32, device="cuda"),
+            )
+        )[None]
+        finite_values = logits[0, :num_finite].float().sigmoid().flip(0)
+        if renormalize:
+            finite_values /= finite_values.sum()
+        finite_values *= 2.5
+        expected_values = torch.cat(
+            (finite_values, torch.zeros(1, dtype=torch.float32, device="cuda"))
+        )[None]
+
+    torch.testing.assert_close(actual_ids, expected_ids)
+    torch.testing.assert_close(actual_values, expected_values, atol=2e-5, rtol=0)

--- a/tests/models/kimi_k3/test_latent_moe_tail.py
+++ b/tests/models/kimi_k3/test_latent_moe_tail.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import ray
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+
+from tests.utils import (
+    init_test_distributed_environment,
+    multi_gpu_test,
+    multi_process_parallel,
+)
+from vllm.distributed import get_tp_group
+from vllm.model_executor.warmup.cutedsl_warmup import cutedsl_warmup
+from vllm.models.kimi_k3.nvidia.ops.latent_moe_tail import KimiK3LatentMoETailOp
+from vllm.platforms import current_platform
+
+HIDDEN_SIZE = 7168
+LATENT_SIZE = 3584
+EPS = 0.1
+
+
+@ray.remote(num_gpus=1, max_calls=1)
+def _test_latent_moe_tail_worker(
+    monkeypatch: pytest.MonkeyPatch,
+    tp_size: int,
+    pp_size: int,
+    rank: int,
+    distributed_init_port: str,
+) -> None:
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    device = torch.device(f"cuda:{rank}")
+    torch.accelerator.set_device_index(device)
+    init_test_distributed_environment(
+        tp_size,
+        pp_size,
+        rank,
+        distributed_init_port,
+    )
+
+    torch.manual_seed(0)
+    rms_weight = 1 + 0.1 * torch.randn(
+        LATENT_SIZE,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    up_weight = (
+        torch.randn(
+            HIDDEN_SIZE,
+            LATENT_SIZE,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        / LATENT_SIZE**0.5
+    )
+
+    group = get_tp_group().device_group
+    op = KimiK3LatentMoETailOp.initialize(
+        hidden_size=HIDDEN_SIZE,
+        latent_size=LATENT_SIZE,
+        dtype=torch.bfloat16,
+        device=device,
+        rms_eps=EPS,
+    )
+    cutedsl_warmup()
+
+    for iteration, num_tokens in enumerate((1, 5, 8, 16, 5)):
+        torch.manual_seed(100 * iteration + rank + 1)
+        routed_output = torch.randn(
+            num_tokens,
+            LATENT_SIZE,
+            device=device,
+            dtype=torch.bfloat16,
+        ).mul_(0.01)
+        shared_output = torch.randn(
+            num_tokens,
+            HIDDEN_SIZE,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+
+        routed_reference = routed_output.clone()
+        shared_reference = shared_output.clone()
+        dist.all_reduce(routed_reference, group=group)
+        dist.all_reduce(shared_reference, group=group)
+        expected = F.linear(
+            F.rms_norm(
+                routed_reference,
+                (LATENT_SIZE,),
+                rms_weight,
+                EPS,
+            ),
+            up_weight,
+        )
+        expected.add_(shared_reference)
+
+        actual = op(
+            routed_output,
+            shared_output,
+            rms_weight,
+            up_weight,
+        )
+        torch.testing.assert_close(actual, expected, atol=8e-2, rtol=3e-2)
+        assert actual.is_contiguous()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graph_output = op(
+            routed_output,
+            shared_output,
+            rms_weight,
+            up_weight,
+        )
+    graph.replay()
+    torch.testing.assert_close(graph_output, expected, atol=8e-2, rtol=3e-2)
+
+
+def _run_latent_moe_tail_test(
+    monkeypatch: pytest.MonkeyPatch,
+    tp_size: int,
+) -> None:
+    if not current_platform.is_device_capability_family(100):
+        pytest.skip("K3 latent-MoE tail fusion requires SM100")
+    multi_process_parallel(
+        monkeypatch,
+        tp_size,
+        1,
+        _test_latent_moe_tail_worker,
+    )
+
+
+@multi_gpu_test(num_gpus=8)
+def test_latent_moe_tail_tp8_matches_native_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _run_latent_moe_tail_test(monkeypatch, 8)
+
+
+@multi_gpu_test(num_gpus=16)
+def test_latent_moe_tail_tp16_matches_native_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _run_latent_moe_tail_test(monkeypatch, 16)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -268,6 +268,7 @@ if TYPE_CHECKING:
     VLLM_NCCL_INCLUDE_PATH: str | None = None
     VLLM_GC_DEBUG: str = ""
     VLLM_DEBUG_WORKSPACE: bool = False
+    VLLM_ENABLE_K3_LATENT_MOE_TAIL_FUSION: bool = False
     VLLM_DISABLE_SHARED_EXPERTS_STREAM: bool = False
     VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD: int = 256
     VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD: int = 1024
@@ -1889,6 +1890,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Debug workspace allocations.
     # logging of workspace resize operations.
     "VLLM_DEBUG_WORKSPACE": lambda: bool(int(os.getenv("VLLM_DEBUG_WORKSPACE", "0"))),
+    # Enable the experimental Kimi K3 latent-MoE tail fusion.
+    # Currently supported only on SM100 with TP=8/16 and BF16.
+    "VLLM_ENABLE_K3_LATENT_MOE_TAIL_FUSION": lambda: bool(
+        int(os.getenv("VLLM_ENABLE_K3_LATENT_MOE_TAIL_FUSION", "0"))
+    ),
     # Disables parallel execution of shared_experts via separate cuda stream
     "VLLM_DISABLE_SHARED_EXPERTS_STREAM": lambda: bool(
         int(os.getenv("VLLM_DISABLE_SHARED_EXPERTS_STREAM", "0"))

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -158,6 +158,51 @@ class SiluAndMul(CustomOp):
         return self.forward_native(x)
 
 
+@CustomOp.register("situ_and_mul")
+class SituAndMul(CustomOp):
+    """SituGLU activation used by Kimi models.
+
+    Computes beta * tanh(gate / beta) * sigmoid(gate) * up.  When
+    ``linear_beta`` is set, the up projection is also softly clipped with
+    linear_beta * tanh(up / linear_beta).
+    """
+
+    def __init__(
+        self,
+        beta: float = 1.0,
+        linear_beta: float | None = None,
+        *,
+        compile_native: bool = True,
+    ):
+        super().__init__(compile_native=compile_native)
+        self.beta = float(beta)
+        self.linear_beta = None if linear_beta is None else float(linear_beta)
+        if current_platform.is_cuda_alike():
+            self.op = torch.ops._C.situ_and_mul
+
+    def forward_native(self, x: torch.Tensor) -> torch.Tensor:
+        d = x.shape[-1] // 2
+        gate = x[..., :d].float()
+        up = x[..., d:].float()
+        gate = self.beta * torch.tanh(gate / self.beta) * torch.sigmoid(gate)
+        if self.linear_beta is not None:
+            up = self.linear_beta * torch.tanh(up / self.linear_beta)
+        return (gate * up).to(x.dtype)
+
+    def forward_cuda(self, x: torch.Tensor) -> torch.Tensor:
+        # Fused CUDA kernel: writes straight to `out`, no fp32 temporaries.
+        # linear_beta<=0 signals "unset" to the kernel (up passed through).
+        d = x.shape[-1] // 2
+        out = torch.empty(x.shape[:-1] + (d,), dtype=x.dtype, device=x.device)
+        self.op(
+            out, x, self.beta, -1.0 if self.linear_beta is None else self.linear_beta
+        )
+        return out
+
+    def forward_xpu(self, x: torch.Tensor) -> torch.Tensor:
+        return self.forward_native(x)
+
+
 @CustomOp.register("silu_and_mul_with_clamp")
 class SiluAndMulWithClamp(CustomOp):
     """SwiGLU activation with input clamping (used by some MoE shared experts).

--- a/vllm/model_executor/layers/fused_moe/activation.py
+++ b/vllm/model_executor/layers/fused_moe/activation.py
@@ -22,6 +22,7 @@ class MoEActivation(Enum):
     # expects the *packed* layout ([all gates; all ups]), as produced by a
     # MergedColumnParallelLinear gate_up_proj (e.g. MiniMax-M3).
     SWIGLUOAI = "swigluoai"
+    SITU = "situ"
     SWIGLUOAI_UNINTERLEAVE = "swigluoai_uninterleave"
     SWIGLUSTEP = "swiglustep"
 
@@ -77,6 +78,7 @@ _CUSTOM_OP_NAMES: dict[MoEActivation, str] = {
     MoEActivation.SILU: "silu_and_mul",
     MoEActivation.GELU: "gelu_and_mul",
     MoEActivation.GELU_TANH: "gelu_tanh_and_mul",
+    MoEActivation.SITU: "situ_and_mul",
     MoEActivation.SWIGLUOAI: "swigluoai_and_mul",
     MoEActivation.SWIGLUOAI_UNINTERLEAVE: "silu_and_mul_with_clamp",
     MoEActivation.SWIGLUSTEP: "swiglustep_and_mul",
@@ -133,6 +135,8 @@ def apply_moe_activation(
     beta: float = 0.0,
     topk_ids: torch.Tensor | None = None,
     expert_map: torch.Tensor | None = None,
+    activation_situ_beta: float | None = None,
+    activation_situ_linear_beta: float | None = None,
 ) -> torch.Tensor:
     """Apply MoE activation function.
 
@@ -163,6 +167,25 @@ def apply_moe_activation(
         torch.ops._C.gelu_and_mul(output, input)
     elif activation == MoEActivation.GELU_TANH:
         torch.ops._C.gelu_tanh_and_mul(output, input)
+    elif activation == MoEActivation.SITU:
+        # Fused CUDA kernel: writes straight to `output`, no fp32 temporaries.
+        # (The pure-torch fallback below upcast both halves to fp32 and
+        # allocated ~8 temporaries per call, blowing up MoE memory.)
+        # Both betas come from FusedMoEConfig; a missing beta means the caller
+        # bypassed the config plumbing, so fail rather than silently use 1.0.
+        # linear_beta is genuinely optional: <= 0 signals "unset" to the kernel
+        # (up passed through), matching SituAndMul(linear_beta=None).
+        assert activation_situ_beta is not None, (
+            "SITU requires activation_situ_beta from FusedMoEConfig"
+        )
+        torch.ops._C.situ_and_mul(
+            output,
+            input,
+            activation_situ_beta,
+            -1.0
+            if activation_situ_linear_beta is None
+            else activation_situ_linear_beta,
+        )
     elif activation == MoEActivation.SWIGLUOAI:
         torch.ops._C.swigluoai_and_mul(output, input)
     elif activation == MoEActivation.SWIGLUOAI_UNINTERLEAVE:

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -1314,6 +1314,10 @@ class FusedMoEConfig:
     swiglu_alpha: float | None = None
     swiglu_beta: float | None = None
 
+    # SituGLU parameters used by Kimi sit(u/v2) activations.
+    activation_situ_beta: float | None = None
+    activation_situ_linear_beta: float | None = None
+
     max_capture_size: int = 0
 
     # Set by __post_init__

--- a/vllm/model_executor/layers/fused_moe/experts/deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/deep_gemm_moe.py
@@ -444,7 +444,14 @@ class DeepGemmFP4Experts(mk.FusedMoEExpertsModular):
 
     @staticmethod
     def _supports_activation(activation: MoEActivation) -> bool:
-        return activation in [MoEActivation.SILU, MoEActivation.SWIGLUSTEP]
+        # SILU has fused gate+mul+quant kernels; SWIGLUSTEP/SITU take the
+        # general path (activation applied via self.activation, which forwards
+        # the situ betas, then FP8 requant).
+        return activation in [
+            MoEActivation.SILU,
+            MoEActivation.SWIGLUSTEP,
+            MoEActivation.SITU,
+        ]
 
     @staticmethod
     def _supports_parallel_config(moe_parallel_config: FusedMoEParallelConfig) -> bool:
@@ -488,16 +495,15 @@ class DeepGemmFP4Experts(mk.FusedMoEExpertsModular):
         M_sum, N = input.size()
         activation_out_dim = self.adjust_N_for_activation(N, activation)
 
-        if scale_fmt == DeepGemmQuantScaleFMT.UE8M0:
-            assert activation == MoEActivation.SILU
-            return fused_silu_mul_fp8_quant_packed(
-                input=input,
-                output_q=output,
-                group_size=block_k,
-                clamp_limit=self.gemm1_clamp_limit,
-            )
-
         if activation == MoEActivation.SILU:
+            # Fused gate+mul+quant kernels for the common SILU case.
+            if scale_fmt == DeepGemmQuantScaleFMT.UE8M0:
+                return fused_silu_mul_fp8_quant_packed(
+                    input=input,
+                    output_q=output,
+                    group_size=block_k,
+                    clamp_limit=self.gemm1_clamp_limit,
+                )
             use_ue8m0 = scale_fmt == DeepGemmQuantScaleFMT.FLOAT32_CEIL_UE8M0
             return silu_mul_per_token_group_quant_fp8_colmajor(
                 input=input,
@@ -506,12 +512,24 @@ class DeepGemmFP4Experts(mk.FusedMoEExpertsModular):
                 clamp_limit=self.gemm1_clamp_limit,
             )
 
+        # General gated activations (SWIGLUSTEP, SITU): apply the activation
+        # (self.activation forwards the situ betas from moe_config) then
+        # FP8-requant into the layout DeepGEMM expects for this scale format.
         act_out = torch.empty(
             (M_sum, activation_out_dim), dtype=input.dtype, device=input.device
         )
         self.activation(activation, act_out, input)
+        if scale_fmt == DeepGemmQuantScaleFMT.UE8M0:
+            return per_token_group_quant_fp8_packed_for_deepgemm(
+                act_out, block_k, use_ue8m0=True, out_q=output
+            )
+        use_ue8m0 = scale_fmt == DeepGemmQuantScaleFMT.FLOAT32_CEIL_UE8M0
         return per_token_group_quant_fp8(
-            act_out, block_k, column_major_scales=True, out_q=output
+            act_out,
+            block_k,
+            column_major_scales=True,
+            out_q=output,
+            use_ue8m0=use_ue8m0,
         )
 
     def apply(

--- a/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
@@ -93,6 +93,8 @@ def _fused_marlin_moe(
     clamp_limit: float | None = None,
     gemm1_alpha: float = 1.0,
     gemm1_beta: float = 0.0,
+    activation_situ_beta: float | None = None,
+    activation_situ_linear_beta: float | None = None,
 ) -> torch.Tensor:
     assert hidden_states.ndim == 2
     M, K = hidden_states.size()
@@ -171,6 +173,8 @@ def _fused_marlin_moe(
         beta=gemm1_beta,
         topk_ids=topk_ids,
         expert_map=expert_map,
+        activation_situ_beta=activation_situ_beta,
+        activation_situ_linear_beta=activation_situ_linear_beta,
     )
 
     if output is None:
@@ -256,6 +260,8 @@ def fused_marlin_moe(
     clamp_limit: float | None = None,
     gemm1_alpha: float = 1.0,
     gemm1_beta: float = 0.0,
+    activation_situ_beta: float | None = None,
+    activation_situ_linear_beta: float | None = None,
 ) -> torch.Tensor:
     """
     This function computes a Mixture of Experts (MoE) layer using two sets of
@@ -357,6 +363,8 @@ def fused_marlin_moe(
         num_tokens_post_padded=num_tokens_post_padded,
         activation=activation,
         activation_func=activation_func,
+        activation_situ_beta=activation_situ_beta,
+        activation_situ_linear_beta=activation_situ_linear_beta,
         input_global_scale1=input_global_scale1,
         input_global_scale2=input_global_scale2,
         global_scale1=global_scale1,
@@ -423,6 +431,9 @@ def batched_fused_marlin_moe(
     clamp_limit: float | None = None,
     gemm1_alpha: float = 1.0,
     gemm1_beta: float = 0.0,
+    activation_func: Callable[..., None] = apply_moe_activation,
+    activation_situ_beta: float | None = None,
+    activation_situ_linear_beta: float | None = None,
 ) -> torch.Tensor:
     """
     This function massages the inputs so the batched hidden_states can be
@@ -530,6 +541,9 @@ def batched_fused_marlin_moe(
         quant_type=quant_type,
         apply_router_weight_on_input=apply_router_weight_on_input,
         activation=activation,
+        activation_func=activation_func,
+        activation_situ_beta=activation_situ_beta,
+        activation_situ_linear_beta=activation_situ_linear_beta,
         expert_map=expert_map,
         block_size_m=block_size_m,
         sorted_token_ids=sorted_token_ids,
@@ -645,6 +659,7 @@ class MarlinExpertsBase(mk.FusedMoEExpertsModular):
             MoEActivation.SILU,
             MoEActivation.GELU,
             MoEActivation.GELU_TANH,
+            MoEActivation.SITU,
             MoEActivation.SWIGLUOAI,
             MoEActivation.SWIGLUOAI_UNINTERLEAVE,
             MoEActivation.SWIGLUSTEP,
@@ -793,6 +808,10 @@ class MarlinExperts(LoRAExpertsMixin, MarlinExpertsBase):
                 global_num_experts=global_num_experts,
                 activation=activation,
                 activation_func=self.activation,
+                activation_situ_beta=self.moe_config.activation_situ_beta,
+                activation_situ_linear_beta=(
+                    self.moe_config.activation_situ_linear_beta
+                ),
                 moe_sum=self.moe_sum,
                 expert_map=expert_map,
                 output=output,
@@ -833,6 +852,8 @@ class MarlinExperts(LoRAExpertsMixin, MarlinExpertsBase):
             beta: float = 0.0,
             topk_ids: torch.Tensor | None = None,
             expert_map: torch.Tensor | None = None,
+            activation_situ_beta: float | None = None,
+            activation_situ_linear_beta: float | None = None,
         ) -> None:
             # act_input  = intermediate_cache1 (M*topk, 2N for gated)
             # act_output = intermediate_cache2 (M*topk, N)
@@ -871,6 +892,8 @@ class MarlinExperts(LoRAExpertsMixin, MarlinExpertsBase):
                 beta=beta,
                 topk_ids=topk_ids,
                 expert_map=expert_map,
+                activation_situ_beta=activation_situ_beta,
+                activation_situ_linear_beta=activation_situ_linear_beta,
             )
             lora_state["cache2"] = act_output
 
@@ -918,6 +941,8 @@ class MarlinExperts(LoRAExpertsMixin, MarlinExpertsBase):
             global_num_experts=global_num_experts,
             activation=activation,
             activation_func=activation_with_lora,
+            activation_situ_beta=self.moe_config.activation_situ_beta,
+            activation_situ_linear_beta=self.moe_config.activation_situ_linear_beta,
             moe_sum=moe_sum_with_lora,
             expert_map=expert_map,
             output=output,
@@ -1021,6 +1046,41 @@ class BatchedMarlinExperts(MarlinExpertsBase):
         apply_router_weight_on_input: bool,
     ):
         assert expert_tokens_meta is not None, "Num valid tokens per batch is required"
+
+        def activation_func(
+            act: MoEActivation,
+            act_output: torch.Tensor,
+            act_input: torch.Tensor,
+            *,
+            activation_situ_beta: float | None = None,
+            activation_situ_linear_beta: float | None = None,
+            **kwargs,
+        ) -> None:
+            if act != MoEActivation.SITU:
+                self.activation(
+                    act,
+                    act_output,
+                    act_input,
+                    activation_situ_beta=activation_situ_beta,
+                    activation_situ_linear_beta=activation_situ_linear_beta,
+                    **kwargs,
+                )
+                return
+
+            num_experts, max_num_tokens = hidden_states.shape[:2]
+            beta = activation_situ_beta
+            linear_beta = activation_situ_linear_beta
+            assert beta is not None, (
+                "SITU requires activation_situ_beta from FusedMoEConfig"
+            )
+            torch.ops._C.masked_situ_and_mul(
+                act_output.view(num_experts, max_num_tokens, -1),
+                act_input.view(num_experts, max_num_tokens, -1),
+                expert_tokens_meta.expert_num_tokens,
+                beta,
+                -1.0 if linear_beta is None else linear_beta,
+            )
+
         return batched_fused_marlin_moe(
             hidden_states=hidden_states,
             expert_num_tokens=expert_tokens_meta.expert_num_tokens,
@@ -1051,4 +1111,7 @@ class BatchedMarlinExperts(MarlinExpertsBase):
             clamp_limit=self.gemm1_clamp_limit,
             gemm1_alpha=self.gemm1_alpha,
             gemm1_beta=self.gemm1_beta,
+            activation_func=activation_func,
+            activation_situ_beta=self.moe_config.activation_situ_beta,
+            activation_situ_linear_beta=self.moe_config.activation_situ_linear_beta,
         )

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_mxfp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_mxfp4_moe.py
@@ -142,6 +142,7 @@ class TrtLlmMxfp4ExpertsMonolithic(
         activation_key: QuantKey | None,
     ) -> bool:
         return routing_method in [
+            RoutingMethodType.DeepSeekV3,
             RoutingMethodType.Renormalize,
             RoutingMethodType.RenormalizeNaive,
         ]
@@ -192,8 +193,8 @@ class TrtLlmMxfp4ExpertsMonolithic(
             device=hidden_states.device,
         )
         trtllm_fp4_block_scale_moe(
-            routing_logits=router_logits.to(torch.bfloat16),
-            routing_bias=None,
+            routing_logits=router_logits,
+            routing_bias=e_score_correction_bias,
             hidden_states=x_quant,
             hidden_states_scale=x_scale,
             gemm1_weights=w1,
@@ -210,12 +211,12 @@ class TrtLlmMxfp4ExpertsMonolithic(
             output2_scale_scalar=None,
             num_experts=global_num_experts,
             top_k=self.topk,
-            n_group=None,
-            topk_group=None,
+            n_group=(num_expert_group or 0),
+            topk_group=(topk_group or 0),
             intermediate_size=self.intermediate_size_per_partition,
             local_expert_offset=self.ep_rank * self.local_num_experts,
             local_num_experts=self.local_num_experts,
-            routed_scaling_factor=None,
+            routed_scaling_factor=routed_scaling_factor,
             routing_method_type=self.routing_method_type,
             do_finalize=True,
             tune_max_num_tokens=max(self.max_capture_size, 1),

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_mxfp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_mxfp4_moe.py
@@ -79,6 +79,36 @@ class TrtLlmMxfp4ExpertsBase:
         else:
             self.gemm1_clamp_limit = None
 
+        # SITU (SituGLU) TRTLLM-Gen kernel computes
+        #   left  = alpha * tanh(x0 / alpha) * sigmoid(x0)   # gate (x0)
+        #   right = beta  * tanh(x1 / beta)                  # up   (x1)
+        # which matches vLLM's situ_and_mul with (beta, linear_beta), so map
+        # situ beta -> gatedActAlpha (gemm1_alpha) and situ linear_beta ->
+        # gatedActBeta (gemm1_beta). Both must be > 0.
+        if moe_config.activation == MoEActivation.SITU:
+            situ_beta = moe_config.activation_situ_beta
+            situ_linear_beta = moe_config.activation_situ_linear_beta
+            assert situ_beta is not None and situ_beta > 0, (
+                "SITU requires activation_situ_beta > 0"
+            )
+            assert situ_linear_beta is not None and situ_linear_beta > 0, (
+                "TRTLLM SiTuGlu requires activation_situ_linear_beta > 0 "
+                "(the private cubin has no up-passthrough path)"
+            )
+            self.gemm1_alpha = torch.full(
+                (self.local_num_experts,),
+                float(situ_beta),
+                dtype=torch.float32,
+                device=device,
+            )
+            self.gemm1_beta = torch.full(
+                (self.local_num_experts,),
+                float(situ_linear_beta),
+                dtype=torch.float32,
+                device=device,
+            )
+            self.gemm1_clamp_limit = None
+
         self.max_capture_size = moe_config.max_capture_size
 
     @staticmethod
@@ -103,7 +133,19 @@ class TrtLlmMxfp4ExpertsBase:
 
     @staticmethod
     def _supports_activation(activation: MoEActivation) -> bool:
-        return activation in (MoEActivation.SWIGLUOAI, MoEActivation.SILU)
+        return activation in (
+            MoEActivation.SWIGLUOAI,
+            MoEActivation.SILU,
+            MoEActivation.SITU,
+        )
+
+    @staticmethod
+    def _flashinfer_activation_type(activation: MoEActivation) -> int:
+        from flashinfer.fused_moe.core import ActivationType
+
+        if activation == MoEActivation.SITU:
+            return ActivationType.Situ.value
+        return ActivationType.Swiglu.value
 
     @staticmethod
     def activation_format() -> mk.FusedMoEActivationFormat:
@@ -219,6 +261,8 @@ class TrtLlmMxfp4ExpertsMonolithic(
             routed_scaling_factor=routed_scaling_factor,
             routing_method_type=self.routing_method_type,
             do_finalize=True,
+            activation_type=self._flashinfer_activation_type(activation),
+            is_private=True,
             tune_max_num_tokens=max(self.max_capture_size, 1),
             output=output,
             routing_replay_out=routing_replay_out,
@@ -339,6 +383,8 @@ class TrtLlmMxfp4ExpertsModular(TrtLlmMxfp4ExpertsBase, mk.FusedMoEExpertsModula
             "routing_method_type": RoutingMethodType.Renormalize,
             "do_finalize": True,
             "enable_pdl": True,
+            "activation_type": self._flashinfer_activation_type(activation),
+            "is_private": True,
             "output": output,
             "tune_max_num_tokens": max(self.max_capture_size, 1),
         }

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
@@ -110,6 +110,27 @@ class TrtLlmNvFp4ExpertsBase:
             self.gemm1_alpha = None
             self.gemm1_beta = None
 
+        # SITU (Kimi SituGLU) TRTLLM-Gen kernel computes
+        # left=alpha*tanh(x0/alpha)*sigmoid(x0), right=beta*tanh(x1/beta),
+        # matching vLLM's situ_and_mul, so map situ beta -> gatedActAlpha
+        # (gemm1_alpha) and situ linear_beta -> gatedActBeta (gemm1_beta).
+        # These operate on the dequantized gate/up, so they are NOT folded by
+        # g1_alphas in process_weights_after_loading.
+        self.is_situ = moe_config.activation == MoEActivation.SITU
+        if self.is_situ:
+            situ_beta = moe_config.activation_situ_beta
+            situ_linear_beta = moe_config.activation_situ_linear_beta
+            assert situ_beta is not None and situ_beta > 0, (
+                "SITU requires activation_situ_beta > 0"
+            )
+            assert situ_linear_beta is not None and situ_linear_beta > 0, (
+                "TRTLLM SiTuGlu requires activation_situ_linear_beta > 0 "
+                "(the private cubin has no up-passthrough path)"
+            )
+            self.gemm1_alpha = _per_expert(situ_beta)
+            self.gemm1_beta = _per_expert(situ_linear_beta)
+            self.gemm1_clamp_limit = None
+
         logger.debug_once(
             "activation=%s, gemm1_alpha=%s, gemm1_beta=%s, gemm1_clamp_limit=%s",
             moe_config.activation,
@@ -142,7 +163,10 @@ class TrtLlmNvFp4ExpertsBase:
         # (via the in-place mul above) and never changes again, so this is a
         # static, per-expert constant. Register on the layer so EPLB
         # rearranges it alongside the other expert tensors.
-        if self.gemm1_clamp_limit is not None:
+        # SITU alpha/beta act on the dequantized gate/up (tanh clamps), not the
+        # raw GEMM1 accumulator, so they are registered as-is without the
+        # g1_alphas fold used by the SwiGLU-OAI clamp/beta below.
+        if self.gemm1_clamp_limit is not None and not self.is_situ:
             gemm1_clamp_limit = self.gemm1_clamp_limit / self.quant_config.g1_alphas
             layer.register_parameter(
                 "gemm1_clamp_limit",
@@ -155,7 +179,11 @@ class TrtLlmNvFp4ExpertsBase:
         # raw. Register both on the layer so EPLB rearranges them with the
         # other per-expert tensors.
         if self.gemm1_beta is not None:
-            gemm1_beta = self.gemm1_beta / self.quant_config.g1_alphas
+            gemm1_beta = (
+                self.gemm1_beta
+                if self.is_situ
+                else self.gemm1_beta / self.quant_config.g1_alphas
+            )
             layer.register_parameter(
                 "gemm1_beta",
                 torch.nn.Parameter(gemm1_beta, requires_grad=False),
@@ -197,13 +225,15 @@ class TrtLlmNvFp4ExpertsBase:
 
     @staticmethod
     def _supports_activation(activation: MoEActivation) -> bool:
-        """Supports SiLU, RELU^2 non-gated, GELU, and clamped SwiGLU-OAI."""
+        """Supports SiLU, RELU^2 non-gated, GELU, clamped SwiGLU-OAI, and the
+        private SituGLU (SITU) cubin."""
         return activation in [
             MoEActivation.SILU,
             MoEActivation.RELU2_NO_MUL,
             MoEActivation.GELU,
             MoEActivation.GELU_TANH,
             MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+            MoEActivation.SITU,
         ]
 
     @staticmethod
@@ -368,6 +398,7 @@ class TrtLlmNvFp4ExpertsModular(TrtLlmNvFp4ExpertsBase, mk.FusedMoEExpertsModula
             routing_method_type=1,  # not used
             do_finalize=True,
             activation_type=activation_to_flashinfer_int(activation),
+            is_private=True,
             per_token_scale=per_token_scale,
             output=output,
             tune_max_num_tokens=min(
@@ -549,6 +580,7 @@ class TrtLlmNvFp4ExpertsMonolithic(
             routing_method_type=self.routing_method_type,
             do_finalize=True,
             activation_type=activation_to_flashinfer_int(activation),
+            is_private=True,
             per_token_scale=per_token_scale,
             tune_max_num_tokens=fi_moe_largest_bucket(self.moe_config),
             routing_replay_out=routing_replay_out,

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -120,6 +120,8 @@ def FusedMoE(
     swiglu_limit: float | None = None,
     swiglu_alpha: float | None = None,
     swiglu_beta: float | None = None,
+    activation_situ_beta: float | None = None,
+    activation_situ_linear_beta: float | None = None,
     e_score_correction_bias: torch.Tensor | None = None,
     apply_router_weight_on_input: bool = False,
     activation: str = "silu",
@@ -178,6 +180,8 @@ def FusedMoE(
         scoring_func: Scoring function for routing ("softmax" or others)
         routed_scaling_factor: Scaling factor applied to topk_weights or output
         swiglu_limit: SwiGLU activation limit
+        activation_situ_beta: SituGLU activation beta
+        activation_situ_linear_beta: SituGLU linear beta
         e_score_correction_bias: Expert score correction bias tensor
         apply_router_weight_on_input: Whether to apply router weights on input
         activation: Activation function name ("silu", "gelu", etc.)
@@ -352,6 +356,8 @@ def FusedMoE(
         swiglu_limit=swiglu_limit,
         swiglu_alpha=swiglu_alpha,
         swiglu_beta=swiglu_beta,
+        activation_situ_beta=activation_situ_beta,
+        activation_situ_linear_beta=activation_situ_linear_beta,
         max_capture_size=vllm_config.compilation_config.max_cudagraph_capture_size,
         skip_final_all_reduce=skip_final_all_reduce,
     )

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -890,6 +890,8 @@ class FusedMoEExpertsModular(FusedMoEExperts):
         beta: float = 0.0,
         topk_ids: torch.Tensor | None = None,
         expert_map: torch.Tensor | None = None,
+        activation_situ_beta: float | None = None,
+        activation_situ_linear_beta: float | None = None,
     ) -> None:
         apply_moe_activation(
             activation,
@@ -900,6 +902,16 @@ class FusedMoEExpertsModular(FusedMoEExperts):
             beta=beta,
             topk_ids=topk_ids,
             expert_map=expert_map,
+            activation_situ_beta=(
+                self.moe_config.activation_situ_beta
+                if activation_situ_beta is None
+                else activation_situ_beta
+            ),
+            activation_situ_linear_beta=(
+                self.moe_config.activation_situ_linear_beta
+                if activation_situ_linear_beta is None
+                else activation_situ_linear_beta
+            ),
         )
 
     @abstractmethod

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -1319,6 +1319,14 @@ class FusedMoEKernelModularImpl:
             activation,
         )
 
+        use_output_alias = (
+            output_alias is not None
+            and output_alias.shape == fused_out.shape
+            and output_alias.dtype == fused_out.dtype
+            and output_alias.device == fused_out.device
+            and output_alias.is_contiguous()
+        )
+
         # If caller's output buffer already matches fused_out shape/dtype, alias
         # to skip the redundant copy in TopKWeightAndReduceNoOP.apply downstream.
         # This eliminates ~94% of __amd_rocclr_copyBuffer events (Copy 2 of the
@@ -1326,15 +1334,10 @@ class FusedMoEKernelModularImpl:
         if current_platform.is_rocm():
             from vllm._aiter_ops import rocm_aiter_ops
 
-            if (
-                rocm_aiter_ops.is_fused_moe_enabled()
-                and output_alias is not None
-                and output_alias.shape == fused_out.shape
-                and output_alias.dtype == fused_out.dtype
-                and output_alias.device == fused_out.device
-                and output_alias.is_contiguous()
-            ):
+            if use_output_alias and rocm_aiter_ops.is_fused_moe_enabled():
                 fused_out = output_alias
+        elif use_output_alias:
+            fused_out = output_alias
 
         self.fused_experts.apply(
             output=fused_out,

--- a/vllm/model_executor/layers/fused_moe/runner/latent_moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/latent_moe_runner.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import torch
+
+import vllm.envs as envs
+from vllm.config import get_current_vllm_config
+from vllm.distributed import tensor_model_parallel_all_reduce
+from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_allreduce_gemma_rms_norm import (
+    _AR_RESIDUAL_RMS_NORM,
+    _can_use_flashinfer,
+    flashinfer_trtllm_fused_allreduce_norm,
+)
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.utils.torch_utils import aux_stream, current_stream
+
+from .moe_runner import MoERunner, _unpack
+
+logger = init_logger(__name__)
+
+
+class LatentMoERunner(MoERunner):
+    """MoE runner for latent MoE with a replicated routed up-projection.
+
+    Fused path (tp>1, un-reduced combine output, shared expert, no SP):
+    concatenates the un-reduced latent partial (dim d) and the un-reduced
+    shared partial (dim D) into one contiguous buffer, all-reduces once, then
+    splits. The latent half is normed and up-projected locally (replicated
+    up-proj -> full hidden), and the shared add folds into the GEMM epilogue
+    (``torch.addmm``). One collective total, no post-reduction communication.
+
+    Native path: the replicated up-proj produces the full hidden dim on every
+    rank, so the base runner combines routed + shared correctly at any TP size
+    (using two collectives instead of the fused path's one).
+    """
+
+    def __init__(
+        self,
+        *args,
+        enable_k3_latent_moe_tail_fusion: bool = False,
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.enable_k3_latent_moe_tail_fusion = enable_k3_latent_moe_tail_fusion
+        use_fused_path = self._use_fused_path()
+        if (
+            self.enable_k3_latent_moe_tail_fusion
+            and use_fused_path
+            and self.moe_config.tp_size not in (8, 16)
+        ):
+            logger.warning_once(
+                "K3 latent-MoE tail fusion currently supports TP=8 and TP=16, "
+                "but TP=%d is configured. Falling back to the default path.",
+                self.moe_config.tp_size,
+            )
+            self.enable_k3_latent_moe_tail_fusion = False
+
+        if self.enable_k3_latent_moe_tail_fusion and use_fused_path:
+            vllm_config = get_current_vllm_config()
+            if vllm_config.parallel_config.use_ubatching:
+                raise ValueError(
+                    "K3 latent-MoE tail fusion does not support DBO or ubatching."
+                )
+            if vllm_config.model_config.enable_sleep_mode:
+                raise ValueError(
+                    "K3 latent-MoE tail fusion does not support sleep mode."
+                )
+            transform = self.routed_output_transform
+            assert transform is not None
+            norm = transform.norm
+            assert norm is not None
+            from vllm.models.kimi_k3.nvidia.ops.latent_moe_tail import (
+                KimiK3LatentMoETailOp,
+            )
+
+            op = KimiK3LatentMoETailOp.initialize(
+                hidden_size=transform.up_proj.weight.shape[0],
+                latent_size=norm.weight.shape[0],
+                dtype=norm.weight.dtype,
+                device=norm.weight.device,
+                rms_eps=norm.variance_epsilon,
+            )
+            self._k3_latent_moe_tail_op = op
+
+    def _get_zero_residual(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Read-only zero ``residual_in`` for the fused AR+RMSNorm kernel.
+
+        flashinfer requires a residual buffer even when there is no residual to
+        add.
+        """
+        numel = hidden_states.numel()
+        buf = getattr(self, "_zero_residual", None)
+        if (
+            buf is None
+            or buf.dtype != hidden_states.dtype
+            or buf.device != hidden_states.device
+            or buf.numel() < numel
+        ):
+            buf = torch.zeros(
+                numel, dtype=hidden_states.dtype, device=hidden_states.device
+            )
+            self._zero_residual = buf
+        return buf[:numel].view_as(hidden_states)
+
+    def _use_fused_path(self) -> bool:
+        # The fused path merges the latent and shared reductions into one
+        # all-reduce, so it needs actual TP parallelism, a shared expert (to
+        # concat), an un-reduced combine output, and no sequence parallelism.
+        return (
+            self.moe_config.tp_size > 1
+            and self._shared_experts is not None
+            and not self._fused_output_is_reduced
+            and not self.moe_config.is_sequence_parallel
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+        input_ids: torch.Tensor | None = None,
+        shared_experts_input: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if self._use_fused_path():
+            return self._fused_forward(
+                hidden_states, router_logits, input_ids, shared_experts_input
+            )
+        return super().forward(
+            hidden_states, router_logits, input_ids, shared_experts_input
+        )
+
+    def _fused_forward(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+        input_ids: torch.Tensor | None = None,
+        shared_experts_input: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        # When the caller pre-applies the routed input transform outside the
+        # runner (e.g. to overlap it on a separate stream), it passes the
+        # already-transformed routed input as ``hidden_states`` and the original
+        # hidden states as ``shared_experts_input``; skip the transform then.
+        if shared_experts_input is None:
+            hidden_states, shared_experts_input = self.apply_routed_input_transform(
+                hidden_states
+            )
+        hidden_states, og_hidden_dim_pre_xform, og_hidden_dim_post_xform = (
+            self._maybe_pad_hidden_states(
+                shared_experts_input,
+                hidden_states,
+            )
+        )
+
+        result = self._forward_entry(
+            hidden_states,
+            router_logits,
+            shared_experts_input,
+            input_ids,
+            self._encode_layer_name(),
+            self.moe_config.hidden_dim_unpadded
+            if self._quant_method.has_unpadded_output
+            else 0,
+        )
+
+        shared_output, fused_output = _unpack(result)
+        assert shared_output is not None
+
+        if og_hidden_dim_pre_xform is not None:
+            fused_output = fused_output[..., :og_hidden_dim_pre_xform]
+
+        transform = self.routed_output_transform
+        assert transform is not None
+
+        if self.enable_k3_latent_moe_tail_fusion:
+            op = self._k3_latent_moe_tail_op
+            if 0 < fused_output.shape[0] <= op.contract.max_num_tokens:
+                norm = transform.norm
+                assert norm is not None
+                result = op(
+                    fused_output,
+                    shared_output,
+                    norm.weight,
+                    transform.up_proj.weight,
+                )
+                result = self._maybe_reduce_final_output(
+                    result, og_hidden_dim_post_xform, output_is_reduced=True
+                )
+                return self._maybe_add_zero_expert_output(result)
+
+        fused_latent = None
+        if transform.norm is not None:
+            fused_latent = self.allreduce_norm_latent_out(fused_output, transform.norm)
+        else:
+            fused_latent = tensor_model_parallel_all_reduce(fused_output)
+
+        shared_expert_stream = (
+            aux_stream()
+            if shared_output.size(0) <= envs.VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD
+            else None
+        )
+        if shared_expert_stream is not None:
+            # overlap shared expert allreduce with latent up_proj
+            main = current_stream()
+            shared_output.record_stream(shared_expert_stream)
+            shared_expert_stream.wait_stream(main)
+            with torch.cuda.stream(shared_expert_stream):
+                shared_output = tensor_model_parallel_all_reduce(shared_output)
+            result = torch.mm(fused_latent, transform.up_proj.weight.t())
+            main.wait_stream(shared_expert_stream)
+        else:
+            shared_output = tensor_model_parallel_all_reduce(shared_output)
+            result = torch.mm(fused_latent, transform.up_proj.weight.t())
+        result.add_(shared_output)
+
+        # Output is already fully reduced; this only strips padding.
+        result = self._maybe_reduce_final_output(
+            result, og_hidden_dim_post_xform, output_is_reduced=True
+        )
+
+        return self._maybe_add_zero_expert_output(result)
+
+    def allreduce_norm_latent_out(
+        self,
+        hidden_states: torch.Tensor,
+        norm: RMSNorm,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """All-reduce + add residual + (standard) RMSNorm, fused via flashinfer."""
+        if self.moe_config.tp_size == 1:
+            return norm(hidden_states)
+
+        if flashinfer_trtllm_fused_allreduce_norm is not None:
+            ok, max_token_num = _can_use_flashinfer(
+                hidden_states, self.moe_config.tp_size
+            )
+            if ok:
+                norm_out = torch.empty_like(hidden_states)
+                # With norm_out provided, the kernel writes the new residual
+                # (all_reduce(hidden_states) + residual) into the hidden_states
+                # buffer and the normalized result into norm_out.
+                flashinfer_trtllm_fused_allreduce_norm(
+                    allreduce_in=hidden_states,
+                    residual=self._get_zero_residual(hidden_states),
+                    rms_gamma=norm.weight,
+                    rms_eps=norm.variance_epsilon,
+                    world_size=self.moe_config.tp_size,
+                    weight_bias=0.0,
+                    launch_with_pdl=True,
+                    fp32_acc=True,
+                    max_token_num=max_token_num,
+                    pattern_code=_AR_RESIDUAL_RMS_NORM,
+                    norm_out=norm_out,
+                )
+                return norm_out
+
+        reduced = tensor_model_parallel_all_reduce(hidden_states)
+        return norm(reduced)

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -348,7 +348,8 @@ class MoERunner(MoERunnerInterface):
         return self.routed_experts.quant_method
 
     def apply_routed_input_transform(
-        self, hidden_states: torch.Tensor
+        self,
+        hidden_states: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """Apply transform for routed experts (e.g., latent projection).
 
@@ -416,6 +417,7 @@ class MoERunner(MoERunnerInterface):
     def _maybe_reduce_shared_expert_output(
         self,
         shared_output: torch.Tensor | None,
+        fused_output_is_reduced: bool | None = None,
     ) -> torch.Tensor | None:
         """All-reduce shared expert output when the combine kernel already
         reduced fused output.
@@ -425,18 +427,43 @@ class MoERunner(MoERunnerInterface):
         * If we have SP (TP=N, DP=M, EP), there is a separate AG step handled
           in the model.
         """
+        if fused_output_is_reduced is None:
+            fused_output_is_reduced = self._fused_output_is_reduced
+
         if (
             shared_output is not None
             and not self.moe_config.is_sequence_parallel
-            and self._fused_output_is_reduced
+            and fused_output_is_reduced
         ):
             shared_output = tensor_model_parallel_all_reduce(shared_output)
         return shared_output
+
+    def _maybe_reduce_routed_output_before_transform(
+        self,
+        fused_output: torch.Tensor,
+        fused_output_is_reduced: bool,
+    ) -> tuple[torch.Tensor, bool]:
+        """All-reduce latent routed output before its output transform.
+
+        Latent MoE output transforms may contain non-linear ops, e.g. RMSNorm.
+        TP partial routed outputs must be summed in latent space before such
+        transforms are applied.
+        """
+        if (
+            self.routed_output_transform is not None
+            and not self.moe_config.is_sequence_parallel
+            and (self.moe_config.tp_size > 1 or self.moe_config.ep_size > 1)
+            and not fused_output_is_reduced
+        ):
+            fused_output = tensor_model_parallel_all_reduce(fused_output)
+            fused_output_is_reduced = True
+        return fused_output, fused_output_is_reduced
 
     def _maybe_reduce_final_output(
         self,
         states: torch.Tensor,
         trunc_size: int | None,
+        output_is_reduced: bool | None = None,
     ) -> torch.Tensor:
         """All-reduce the combined output if needed.
 
@@ -455,11 +482,14 @@ class MoERunner(MoERunnerInterface):
         # We don't need to reduce the final output if:
         # - We are not running with TP or DP
         # - The MK already reduced the fused output itself.
+        if output_is_reduced is None:
+            output_is_reduced = self._fused_output_is_reduced
+
         if (
             not self.moe_config.is_sequence_parallel
             and not self.moe_config.skip_final_all_reduce
             and (self.moe_config.tp_size > 1 or self.moe_config.ep_size > 1)
-            and not self._fused_output_is_reduced
+            and not output_is_reduced
         ):
             states = tensor_model_parallel_all_reduce(states)
 
@@ -643,6 +673,7 @@ class MoERunner(MoERunnerInterface):
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
         input_ids: torch.Tensor | None = None,
+        shared_experts_input: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Invoke the fused moe layer.
 
@@ -664,11 +695,16 @@ class MoERunner(MoERunnerInterface):
            _moe_forward and _moe_forward_shared must be split.
         """
 
-        # Apply transform for routed experts (e.g., latent projection
-        # for latent MoE)
-        hidden_states, shared_experts_input = self.apply_routed_input_transform(
-            hidden_states
-        )
+        # Apply transform for routed experts (e.g., latent projection for
+        # latent MoE). When the caller pre-applies the routed input transform
+        # outside the runner (e.g. to overlap it on a separate stream), it
+        # passes the already-transformed routed input as ``hidden_states`` and
+        # the original hidden states as ``shared_experts_input``; skip the
+        # transform in that case so shared experts still see the original input.
+        if shared_experts_input is None:
+            hidden_states, shared_experts_input = self.apply_routed_input_transform(
+                hidden_states
+            )
 
         # Record before `_maybe_pad_hidden_states` pads activations to match
         # `moe_config.hidden_dim`, e.g. after `align_trtllm_fp4_moe_hidden_dim_for_fi`
@@ -708,9 +744,22 @@ class MoERunner(MoERunnerInterface):
         if og_hidden_dim_pre_xform is not None:
             fused_output = fused_output[..., :og_hidden_dim_pre_xform]
 
-        # If combine kernel already reduced fused, reduce shared to match.
+        fused_output_is_reduced = self._fused_output_is_reduced
+
+        # Latent routed output has to be reduced before output transform,
+        # because the transform may include non-linear normalization.
+        fused_output, fused_output_is_reduced = (
+            self._maybe_reduce_routed_output_before_transform(
+                fused_output,
+                fused_output_is_reduced,
+            )
+        )
+
+        # If routed output is already reduced, reduce shared to match.
         # See note above re: the two all-reduce points.
-        shared_output = self._maybe_reduce_shared_expert_output(shared_output)
+        shared_output = self._maybe_reduce_shared_expert_output(
+            shared_output, fused_output_is_reduced
+        )
 
         shared_output, fused_output = self._maybe_apply_routed_scale_to_output(
             shared_output, fused_output
@@ -724,7 +773,9 @@ class MoERunner(MoERunnerInterface):
         else:
             result = fused_output
 
-        result = self._maybe_reduce_final_output(result, og_hidden_dim_post_xform)
+        result = self._maybe_reduce_final_output(
+            result, og_hidden_dim_post_xform, fused_output_is_reduced
+        )
 
         return self._maybe_add_zero_expert_output(result)
 

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner_interface.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner_interface.py
@@ -36,6 +36,7 @@ class MoERunnerInterface(PluggableLayer, ABC):
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
         input_ids: torch.Tensor | None = None,
+        shared_experts_input: torch.Tensor | None = None,
     ) -> torch.Tensor:
         raise NotImplementedError
 

--- a/vllm/models/kimi_k3/__init__.py
+++ b/vllm/models/kimi_k3/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/models/kimi_k3/nvidia/__init__.py
+++ b/vllm/models/kimi_k3/nvidia/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/models/kimi_k3/nvidia/ops/__init__.py
+++ b/vllm/models/kimi_k3/nvidia/ops/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/models/kimi_k3/nvidia/ops/cute_dsl/__init__.py
+++ b/vllm/models/kimi_k3/nvidia/ops/cute_dsl/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/models/kimi_k3/nvidia/ops/cute_dsl/latent_moe_tail/__init__.py
+++ b/vllm/models/kimi_k3/nvidia/ops/cute_dsl/latent_moe_tail/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""CuTe DSL kernels for KimiK3LatentMoETailOp."""
+
+from .allreduce_rmsnorm_reduce_scatter_early_exit import CollectiveKernel
+from .fused_add_multicast_gemm import AdaptiveUpProjectionKernel
+from .lamport_copy import LamportCopyKernel
+
+__all__ = [
+    "AdaptiveUpProjectionKernel",
+    "CollectiveKernel",
+    "LamportCopyKernel",
+]

--- a/vllm/models/kimi_k3/nvidia/ops/cute_dsl/latent_moe_tail/allreduce_rmsnorm_reduce_scatter_early_exit.py
+++ b/vllm/models/kimi_k3/nvidia/ops/cute_dsl/latent_moe_tail/allreduce_rmsnorm_reduce_scatter_early_exit.py
@@ -1,0 +1,1012 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Specialized from FlashInfer's oneshotAllreduceFusionKernel.
+
+"""Routed AllReduce/RMSNorm with CTA-specialized ReduceScatter early exit."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+from cutlass import BFloat16, Float32, Int32, Int64, Uint32
+
+from .primitives import (
+    NUM_LAMPORT_BUFFERS,
+    PACKED_BYTES,
+    VEC_BF16,
+    bf16x8_to_packed_u32x4,
+    block_sum_specialized,
+    fragment_is_dirty,
+    load_global_u32x4,
+    load_volatile_u32,
+    map_shared_to_peer,
+    packed_u32x4_to_bf16x8,
+    red_async_release_gpu_add_u32,
+    sanitize_negative_zero,
+    store_global_u32x4,
+    store_lamport_sentinel_128,
+    store_shared_cluster_f32,
+    to_cute,
+    to_cute_dynamic_m,
+)
+
+
+def _mapping(
+    tp_size: int,
+    latent_dim: int,
+    hidden_dim: int,
+) -> tuple[int, int, int, int]:
+    shard_dim = hidden_dim // tp_size
+    cluster_ctas = latent_dim // shard_dim
+    threads = shard_dim // VEC_BF16
+    shared_roles = tp_size // cluster_ctas
+    return shard_dim, cluster_ctas, threads, shared_roles
+
+
+def validate_shape(*, tp_size: int, latent_dim: int, hidden_dim: int) -> None:
+    """Validate constraints imposed by the fused collective mapping."""
+
+    if tp_size <= 0 or latent_dim <= 0 or hidden_dim <= 0:
+        raise ValueError("collective dimensions must be positive")
+    if hidden_dim % tp_size:
+        raise ValueError("hidden_dim must be divisible by tp_size")
+    shard, cluster, threads, _ = _mapping(tp_size, latent_dim, hidden_dim)
+    if shard % VEC_BF16:
+        raise ValueError("hidden_dim / tp_size must be divisible by 8")
+    if latent_dim % shard:
+        raise ValueError("latent_dim must be an integer multiple of shard_dim")
+    if cluster > 16 or cluster & (cluster - 1):
+        raise ValueError("collective cluster width must be a power of two <= 16")
+    if tp_size % cluster:
+        raise ValueError("tp_size must be divisible by collective cluster width")
+    if not 32 <= threads <= 1024:
+        raise ValueError("collective threads per CTA must be in [32, 1024]")
+    if threads < cluster:
+        raise ValueError("collective threads must cover every cluster CTA")
+
+
+def _select_routed_schedule(
+    tp_size: int,
+    latent_dim: int,
+    hidden_dim: int,
+    max_m: int,
+) -> tuple[int, int]:
+    """Match upstream MNNVL's one-cluster-per-token occupancy policy."""
+
+    _, cluster_ctas, threads, _ = _mapping(tp_size, latent_dim, hidden_dim)
+    sm_count = torch.cuda.get_device_properties(
+        torch.accelerator.current_device_index()
+    ).multi_processor_count
+    while max_m * cluster_ctas > sm_count and cluster_ctas > 1 and threads <= 512:
+        cluster_ctas //= 2
+        threads *= 2
+    return threads, cluster_ctas
+
+
+class AllReduceRMSNormWithReduceScatterEarlyExit:
+    """One routed role plus one ReduceScatter role per destination group."""
+
+    def __init__(
+        self,
+        *,
+        rank: int,
+        tp_size: int,
+        latent_dim: int,
+        hidden_dim: int,
+        max_m: int,
+        max_token_ctas: int,
+        fp32_internal: bool = False,
+        include_reduce_scatter: bool = True,
+        include_routed: bool = True,
+    ):
+        validate_shape(
+            tp_size=tp_size,
+            latent_dim=latent_dim,
+            hidden_dim=hidden_dim,
+        )
+        if not 0 <= rank < tp_size:
+            raise ValueError(f"rank must be in [0,{tp_size}), got {rank}")
+        if not include_routed and not include_reduce_scatter:
+            raise ValueError("at least one collective role must be enabled")
+        self.rank = rank
+        self.tp_size = tp_size
+        self.latent_dim = latent_dim
+        self.hidden_dim = hidden_dim
+        (
+            self.shard_dim,
+            mapped_cluster,
+            mapped_threads,
+            shared_roles,
+        ) = _mapping(tp_size, latent_dim, hidden_dim)
+        if include_reduce_scatter:
+            self.cluster_ctas = mapped_cluster
+            self.threads = mapped_threads
+        else:
+            self.threads, self.cluster_ctas = _select_routed_schedule(
+                tp_size, latent_dim, hidden_dim, max_m
+            )
+        # Diagnostic specialization: a one-role grid executes only the routed
+        # AllReduce/RMSNorm path.  Keep this compile-time so the production
+        # fused path is unchanged when include_reduce_scatter=True.
+        if include_routed and include_reduce_scatter:
+            self.roles = 1 + shared_roles
+        elif include_routed:
+            self.roles = 1
+        else:
+            self.roles = shared_roles
+        self.warps = (self.threads + 31) // 32
+        self.last_warp_lanes = self.threads - (self.warps - 1) * 32
+        self.last_warp_mask = (1 << self.last_warp_lanes) - 1
+        # The upstream MNNVL oneshot protocol assigns one cluster to each
+        # token.  Keep that exact ownership in the routed-only diagnostic;
+        # reusing a cluster for multiple token waves allows the Lamport
+        # generation metadata to change between waves.
+        self.token_ctas = (
+            min(max_m, max_token_ctas) if include_reduce_scatter else max_m
+        )
+        self.fp32_internal = fp32_internal
+        self.include_reduce_scatter = include_reduce_scatter
+        self.include_routed = include_routed
+
+    @cute.jit
+    def __call__(
+        self,
+        latent_source: cute.Tensor,
+        gamma: cute.Tensor,
+        latent_output: cute.Tensor,
+        routed_workspace: cute.Tensor,
+        latent_flags: cute.Tensor,
+        latent_multicast_ptr: Int64,
+        shared_source: cute.Tensor,
+        shared_output: cute.Tensor,
+        shared_workspace: cute.Tensor,
+        shared_flags: cute.Tensor,
+        shared_peer_ptrs: cute.Tensor,
+        m: Int32,
+        epsilon: Float32,
+        stream: cuda.CUstream,
+    ):
+        self.kernel(
+            latent_source,
+            gamma,
+            latent_output,
+            routed_workspace,
+            latent_flags,
+            latent_multicast_ptr,
+            shared_source,
+            shared_output,
+            shared_workspace,
+            shared_flags,
+            shared_peer_ptrs,
+            m,
+            epsilon,
+        ).launch(
+            grid=(self.token_ctas, self.cluster_ctas, self.roles),
+            block=(self.threads, 1, 1),
+            cluster=(1, self.cluster_ctas, 1),
+            smem=(self.warps + self.cluster_ctas) * 4,
+            stream=stream,
+            use_pdl=True,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        latent_source: cute.Tensor,
+        gamma: cute.Tensor,
+        latent_output: cute.Tensor,
+        routed_workspace: cute.Tensor,
+        latent_flags: cute.Tensor,
+        latent_multicast_ptr: Int64,
+        shared_source: cute.Tensor,
+        shared_output: cute.Tensor,
+        shared_workspace: cute.Tensor,
+        shared_flags: cute.Tensor,
+        shared_peer_ptrs: cute.Tensor,
+        m: Int32,
+        epsilon: Float32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        token_cta, cta_y, role = cute.arch.block_idx()
+        logical_role = role
+        if cutlass.const_expr(not self.include_routed):
+            # A shared-only grid starts at z=0, while _token_device reserves
+            # logical role 0 for the routed collective.
+            logical_role = role + Int32(1)
+        cluster_rank = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+
+        cute.arch.griddepcontrol_wait()
+        token = token_cta
+        while token < m:
+            self._token_device(
+                latent_source,
+                gamma,
+                latent_output,
+                routed_workspace,
+                latent_flags,
+                latent_multicast_ptr,
+                shared_source,
+                shared_output,
+                shared_workspace,
+                shared_flags,
+                shared_peer_ptrs,
+                m,
+                epsilon,
+                token,
+                token_cta,
+                cta_y,
+                logical_role,
+                cluster_rank,
+                tidx,
+            )
+            token = token + self.token_ctas
+
+    @cute.jit
+    def _token_device(
+        self,
+        latent_source: cute.Tensor,
+        gamma: cute.Tensor,
+        latent_output: cute.Tensor,
+        routed_workspace: cute.Tensor,
+        latent_flags: cute.Tensor,
+        latent_multicast_ptr: Int64,
+        shared_source: cute.Tensor,
+        shared_output: cute.Tensor,
+        shared_workspace: cute.Tensor,
+        shared_flags: cute.Tensor,
+        shared_peer_ptrs: cute.Tensor,
+        m: Int32,
+        epsilon: Float32,
+        token: Int32,
+        token_cta: Int32,
+        cta_y: Int32,
+        role: Int32,
+        cluster_rank: Int32,
+        tidx: Int32,
+    ):
+        if role == 0:
+            # ---------------- routed AllReduce + RMSNorm ----------------
+            packed_idx = cluster_rank * self.threads + tidx
+            element_offset = (
+                Int64(token) * self.latent_dim + Int64(packed_idx) * VEC_BF16
+            )
+            current_index = cute.arch.load((latent_flags.iterator + 0).llvm_ptr, Uint32)
+            dirty_index = cute.arch.load((latent_flags.iterator + 1).llvm_ptr, Uint32)
+            bytes_per_buffer = cute.arch.load(
+                (latent_flags.iterator + 2).llvm_ptr, Uint32
+            )
+            dirty_num_stages = cute.arch.load(
+                (latent_flags.iterator + 3).llvm_ptr, Uint32
+            )
+            bytes_to_clear = cute.arch.load(
+                (latent_flags.iterator + 4).llvm_ptr, Uint32
+            )
+            current_elements = Int64(current_index) * (
+                Int64(bytes_per_buffer) // Int64(2)
+            )
+            dirty_elements = Int64(dirty_index) * (Int64(bytes_per_buffer) // Int64(2))
+
+            local_ptr = cute.make_ptr(
+                BFloat16,
+                (latent_source.iterator + element_offset).llvm_ptr,
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            )
+            local_packed = sanitize_negative_zero(
+                load_global_u32x4(local_ptr, volatile=False)
+            )
+            multicast_offset = (
+                Int64(current_index) * Int64(bytes_per_buffer)
+                + (
+                    (Int64(token) * self.tp_size + self.rank) * self.latent_dim
+                    + Int64(packed_idx) * VEC_BF16
+                )
+                * 2
+            )
+            store_global_u32x4(
+                latent_multicast_ptr + multicast_offset,
+                local_packed,
+                volatile=False,
+            )
+
+            cute.arch.cluster_arrive()
+            if cluster_rank == 0 and tidx < 32:
+                cute.arch.cluster_wait()
+                if tidx == 0:
+                    red_async_release_gpu_add_u32(latent_flags.iterator + 8, Uint32(1))
+
+            global_tid = (
+                Int64(token) * self.cluster_ctas + Int64(cta_y)
+            ) * self.threads + Int64(tidx)
+            total_threads = Int64(m) * self.cluster_ctas * self.threads
+            clear_fragments = (Int64(bytes_to_clear) + PACKED_BYTES - 1) // PACKED_BYTES
+            clear_idx = global_tid
+            if dirty_num_stages > Uint32(0):
+                while clear_idx < clear_fragments:
+                    clear_ptr = cute.make_ptr(
+                        BFloat16,
+                        (
+                            routed_workspace.iterator
+                            + dirty_elements
+                            + clear_idx * VEC_BF16
+                        ).llvm_ptr,
+                        cute.AddressSpace.gmem,
+                        assumed_align=16,
+                    )
+                    store_lamport_sentinel_128(clear_ptr)
+                    clear_idx = clear_idx + total_threads
+
+            rank_words = cute.make_rmem_tensor(
+                cute.make_layout((self.tp_size, 4), stride=(4, 1)), Uint32
+            )
+            for word in cutlass.range_constexpr(4):
+                rank_words[self.rank, word] = local_packed[word]
+            valid = False
+            while not valid:
+                valid = True
+                for source_rank in cutlass.range_constexpr(self.tp_size):
+                    if cutlass.const_expr(source_rank != self.rank):
+                        remote_element = current_elements + (
+                            (Int64(token) * self.tp_size + source_rank)
+                            * self.latent_dim
+                            + Int64(packed_idx) * VEC_BF16
+                        )
+                        remote_ptr = cute.make_ptr(
+                            BFloat16,
+                            (routed_workspace.iterator + remote_element).llvm_ptr,
+                            cute.AddressSpace.gmem,
+                            assumed_align=16,
+                        )
+                        remote = load_global_u32x4(remote_ptr, volatile=True)
+                        for word in cutlass.range_constexpr(4):
+                            rank_words[source_rank, word] = remote[word]
+                        valid = valid & (not fragment_is_dirty(remote))
+
+            accum = cute.make_rmem_tensor(cute.make_layout((VEC_BF16,)), Float32)
+            for element in cutlass.range_constexpr(VEC_BF16):
+                accum[element] = Float32(0.0)
+            for source_rank in cutlass.range_constexpr(self.tp_size):
+                values = packed_u32x4_to_bf16x8(
+                    rank_words[source_rank, None].load()
+                ).to(Float32)
+                for element in cutlass.range_constexpr(VEC_BF16):
+                    accum[element] = accum[element] + values[element]
+
+            # Preserve the original early PDL point before RMSNorm.
+            cute.arch.griddepcontrol_launch_dependents()
+
+            if cutlass.const_expr(self.fp32_internal):
+                # High-precision fused mode: retain the rank reduction in
+                # FP32 through the RMS square and row reduction.
+                norm_input = accum.load()
+                norm_square = norm_input * norm_input
+            else:
+                norm_input_bf16 = accum.load().to(BFloat16)
+                norm_input = norm_input_bf16.to(Float32)
+                # Upstream-compatible mode: FlashInfer evaluates BF16 *
+                # BF16 first, then promotes the rounded square to FP32.
+                norm_square = (norm_input_bf16 * norm_input_bf16).to(Float32)
+            thread_sum = norm_square.reduce(
+                cute.ReductionOp.ADD,
+                init_val=Float32(0.0),
+                reduction_profile=0,
+            )
+            smem = cutlass.utils.SmemAllocator()
+            warp_sums = smem.allocate_tensor(
+                Float32, cute.make_layout((self.warps,)), byte_alignment=4
+            )
+            cluster_sums = smem.allocate_tensor(
+                Float32,
+                cute.make_layout((self.cluster_ctas,)),
+                byte_alignment=4,
+            )
+            block_sum = block_sum_specialized(
+                thread_sum,
+                warp_sums,
+                tidx,
+                self.warps,
+                self.last_warp_lanes,
+                self.last_warp_mask,
+            )
+            if tidx < self.cluster_ctas:
+                local_slot = cluster_sums.iterator + cluster_rank
+                remote_slot = map_shared_to_peer(local_slot, Int32(tidx))
+                store_shared_cluster_f32(remote_slot, block_sum)
+            cute.arch.cluster_arrive()
+            cute.arch.cluster_wait()
+
+            full_sum = Float32(0.0)
+            for peer in cutlass.range_constexpr(self.cluster_ctas):
+                full_sum = full_sum + cluster_sums[peer]
+            inv_rms = cute.math.rsqrt(
+                full_sum / Float32(self.latent_dim) + epsilon, fastmath=True
+            )
+            gamma_ptr = cute.make_ptr(
+                BFloat16,
+                (gamma.iterator + Int64(packed_idx) * VEC_BF16).llvm_ptr,
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            )
+            gamma_values = packed_u32x4_to_bf16x8(
+                load_global_u32x4(gamma_ptr, volatile=False)
+            )
+            result = (norm_input * inv_rms * gamma_values.to(Float32)).to(BFloat16)
+            store_global_u32x4(
+                Int64((latent_output.iterator + element_offset).toint()),
+                bf16x8_to_packed_u32x4(result),
+                volatile=False,
+            )
+
+            # The x=0 CTA rotates only after reaching its final token wave.
+            # Waiting for all M arrivals then guarantees every token-wave CTA
+            # loaded the current generation before the metadata is advanced.
+            if (
+                token_cta == 0
+                and token + self.token_ctas >= m
+                and cta_y == 0
+                and tidx == 0
+            ):
+                access_counter = latent_flags.iterator + 8
+                arrived = load_volatile_u32(access_counter)
+                while arrived < Uint32(m):
+                    arrived = load_volatile_u32(access_counter)
+                next_index = (current_index + Uint32(1)) % Uint32(NUM_LAMPORT_BUFFERS)
+                actual_bytes = Uint32(m) * Uint32(self.tp_size * self.latent_dim * 2)
+                cute.arch.store((latent_flags.iterator + 0).llvm_ptr, next_index)
+                cute.arch.store((latent_flags.iterator + 1).llvm_ptr, current_index)
+                cute.arch.store(
+                    (latent_flags.iterator + 2).llvm_ptr,
+                    bytes_per_buffer,
+                )
+                cute.arch.store((latent_flags.iterator + 3).llvm_ptr, Uint32(1))
+                cute.arch.store((latent_flags.iterator + 4).llvm_ptr, actual_bytes)
+                for index in cutlass.range_constexpr(5, 8):
+                    cute.arch.store(
+                        (latent_flags.iterator + index).llvm_ptr,
+                        Uint32(0),
+                    )
+                cute.arch.store(access_counter.llvm_ptr, Uint32(0))
+
+        else:
+            # ---------------- shared ReduceScatter ----------------
+            shared_group = role - 1
+            destination = shared_group * self.cluster_ctas + cluster_rank
+            current_index = cute.arch.load((shared_flags.iterator + 0).llvm_ptr, Uint32)
+            dirty_index = cute.arch.load((shared_flags.iterator + 1).llvm_ptr, Uint32)
+            bytes_per_buffer = cute.arch.load(
+                (shared_flags.iterator + 2).llvm_ptr, Uint32
+            )
+            dirty_num_stages = cute.arch.load(
+                (shared_flags.iterator + 3).llvm_ptr, Uint32
+            )
+            bytes_to_clear = cute.arch.load(
+                (shared_flags.iterator + 4).llvm_ptr, Uint32
+            )
+            current_elements = Int64(current_index) * (
+                Int64(bytes_per_buffer) // Int64(2)
+            )
+            dirty_elements = Int64(dirty_index) * (Int64(bytes_per_buffer) // Int64(2))
+
+            source_element = (
+                Int64(token) * self.hidden_dim
+                + Int64(destination) * self.shard_dim
+                + Int64(tidx) * VEC_BF16
+            )
+            source_ptr = cute.make_ptr(
+                BFloat16,
+                (shared_source.iterator + source_element).llvm_ptr,
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            )
+            local_packed = sanitize_negative_zero(
+                load_global_u32x4(source_ptr, volatile=False)
+            )
+            peer_base = cute.arch.load(
+                (shared_peer_ptrs.iterator + destination).llvm_ptr,
+                Int64,
+            )
+            destination_element = current_elements + (
+                (Int64(token) * self.tp_size + self.rank) * self.shard_dim
+                + Int64(tidx) * VEC_BF16
+            )
+            store_global_u32x4(
+                peer_base + destination_element * 2,
+                local_packed,
+                volatile=False,
+            )
+
+            # One arrival per shared destination group and token.
+            cute.arch.cluster_arrive()
+            if cluster_rank == 0 and tidx < 32:
+                cute.arch.cluster_wait()
+                if tidx == 0:
+                    red_async_release_gpu_add_u32(shared_flags.iterator + 8, Uint32(1))
+
+            global_tid = (
+                Int64(token) * self.tp_size + Int64(destination)
+            ) * self.threads + Int64(tidx)
+            total_threads = Int64(m) * self.tp_size * self.threads
+            clear_fragments = (Int64(bytes_to_clear) + PACKED_BYTES - 1) // PACKED_BYTES
+            clear_idx = global_tid
+            if dirty_num_stages > Uint32(0):
+                while clear_idx < clear_fragments:
+                    clear_ptr = cute.make_ptr(
+                        BFloat16,
+                        (
+                            shared_workspace.iterator
+                            + dirty_elements
+                            + clear_idx * VEC_BF16
+                        ).llvm_ptr,
+                        cute.AddressSpace.gmem,
+                        assumed_align=16,
+                    )
+                    store_lamport_sentinel_128(clear_ptr)
+                    clear_idx = clear_idx + total_threads
+
+            if destination == self.rank:
+                rank_words = cute.make_rmem_tensor(
+                    cute.make_layout((self.tp_size, 4), stride=(4, 1)), Uint32
+                )
+                valid = False
+                while not valid:
+                    valid = True
+                    for source_rank in cutlass.range_constexpr(self.tp_size):
+                        remote_element = current_elements + (
+                            (Int64(token) * self.tp_size + source_rank) * self.shard_dim
+                            + Int64(tidx) * VEC_BF16
+                        )
+                        remote_ptr = cute.make_ptr(
+                            BFloat16,
+                            (shared_workspace.iterator + remote_element).llvm_ptr,
+                            cute.AddressSpace.gmem,
+                            assumed_align=16,
+                        )
+                        remote = load_global_u32x4(remote_ptr, volatile=True)
+                        for word in cutlass.range_constexpr(4):
+                            rank_words[source_rank, word] = remote[word]
+                        valid = valid & (not fragment_is_dirty(remote))
+
+                accum = cute.make_rmem_tensor(cute.make_layout((VEC_BF16,)), Float32)
+                for element in cutlass.range_constexpr(VEC_BF16):
+                    accum[element] = Float32(0.0)
+                for source_rank in cutlass.range_constexpr(self.tp_size):
+                    values = packed_u32x4_to_bf16x8(
+                        rank_words[source_rank, None].load()
+                    ).to(Float32)
+                    for element in cutlass.range_constexpr(VEC_BF16):
+                        accum[element] = accum[element] + values[element]
+                result = accum.load().to(BFloat16)
+                output_element = (
+                    Int64(token) * self.hidden_dim
+                    + self.rank * self.shard_dim
+                    + Int64(tidx) * VEC_BF16
+                )
+                store_global_u32x4(
+                    Int64((shared_output.iterator + output_element).toint()),
+                    bf16x8_to_packed_u32x4(result),
+                    volatile=False,
+                )
+
+            if destination == self.rank:
+                cute.arch.barrier()
+
+            cute.arch.griddepcontrol_launch_dependents()
+
+            if (
+                token_cta == 0
+                and token + self.token_ctas >= m
+                and shared_group == 0
+                and cluster_rank == 0
+                and tidx == 0
+            ):
+                access_counter = shared_flags.iterator + 8
+                arrived = load_volatile_u32(access_counter)
+                target = Uint32(m) * Uint32(self.tp_size // self.cluster_ctas)
+                while arrived < target:
+                    arrived = load_volatile_u32(access_counter)
+                next_index = (current_index + Uint32(1)) % Uint32(NUM_LAMPORT_BUFFERS)
+                actual_bytes = Uint32(m) * Uint32(self.tp_size * self.shard_dim * 2)
+                cute.arch.store((shared_flags.iterator + 0).llvm_ptr, next_index)
+                cute.arch.store((shared_flags.iterator + 1).llvm_ptr, current_index)
+                cute.arch.store(
+                    (shared_flags.iterator + 2).llvm_ptr,
+                    bytes_per_buffer,
+                )
+                cute.arch.store((shared_flags.iterator + 3).llvm_ptr, Uint32(1))
+                cute.arch.store((shared_flags.iterator + 4).llvm_ptr, actual_bytes)
+                for index in cutlass.range_constexpr(5, 8):
+                    cute.arch.store(
+                        (shared_flags.iterator + index).llvm_ptr,
+                        Uint32(0),
+                    )
+                cute.arch.store(access_counter.llvm_ptr, Uint32(0))
+
+
+_COMPILED: dict[tuple[object, ...], Any] = {}
+
+
+def _routed_workspace_cute(workspace: torch.Tensor):
+    return to_cute(workspace.view(torch.bfloat16), 16)
+
+
+def _compile_key(
+    rank: int,
+    tp_size: int,
+    latent_dim: int,
+    hidden_dim: int,
+    max_m: int,
+    max_token_ctas: int,
+    fp32_internal: bool,
+    include_reduce_scatter: bool,
+    include_routed: bool,
+):
+    return (
+        torch.accelerator.current_device_index(),
+        rank,
+        tp_size,
+        latent_dim,
+        hidden_dim,
+        max_m,
+        max_token_ctas,
+        fp32_internal,
+        include_reduce_scatter,
+        include_routed,
+    )
+
+
+def _runtime_args(
+    latent_source: torch.Tensor,
+    gamma: torch.Tensor,
+    latent_output: torch.Tensor,
+    routed_workspace: torch.Tensor,
+    routed_flags: torch.Tensor,
+    routed_multicast_ptr: int,
+    shared_source: torch.Tensor,
+    shared_output: torch.Tensor,
+    shared_workspace: torch.Tensor,
+    shared_flags: torch.Tensor,
+    shared_peer_ptrs: torch.Tensor,
+    rms_eps: float,
+):
+    return (
+        to_cute_dynamic_m(latent_source, mode=0, assumed_align=16),
+        to_cute(gamma, 16),
+        to_cute(latent_output, 16),
+        _routed_workspace_cute(routed_workspace),
+        to_cute(routed_flags, 16),
+        Int64(routed_multicast_ptr),
+        to_cute_dynamic_m(shared_source, mode=0, assumed_align=16),
+        to_cute(shared_output, 16),
+        to_cute(shared_workspace, 16),
+        to_cute(shared_flags, 16),
+        to_cute(shared_peer_ptrs, 16),
+        Int32(latent_source.shape[0]),
+        Float32(rms_eps),
+        cuda.CUstream(torch.cuda.current_stream(latent_source.device).cuda_stream),
+    )
+
+
+def compile_kernel(
+    *,
+    rank: int,
+    tp_size: int,
+    latent_dim: int,
+    hidden_dim: int,
+    max_m: int,
+    max_token_ctas: int,
+    latent_output: torch.Tensor,
+    routed_workspace: torch.Tensor,
+    routed_flags: torch.Tensor,
+    routed_multicast_ptr: int,
+    shared_output: torch.Tensor,
+    shared_workspace: torch.Tensor,
+    shared_flags: torch.Tensor,
+    shared_peer_ptrs: torch.Tensor,
+    rms_eps: float,
+    fp32_internal: bool,
+    include_reduce_scatter: bool = True,
+    include_routed: bool = True,
+) -> None:
+    """Compile the rank/M specialization without retaining caller tensors."""
+
+    key = _compile_key(
+        rank,
+        tp_size,
+        latent_dim,
+        hidden_dim,
+        max_m,
+        max_token_ctas,
+        fp32_internal,
+        include_reduce_scatter,
+        include_routed,
+    )
+    if key in _COMPILED:
+        return
+    device = latent_output.device
+    latent = torch.empty((max_m, latent_dim), dtype=torch.bfloat16, device=device)
+    gamma = torch.empty((latent_dim,), dtype=torch.bfloat16, device=device)
+    shared = torch.empty((max_m, hidden_dim), dtype=torch.bfloat16, device=device)
+    kernel = AllReduceRMSNormWithReduceScatterEarlyExit(
+        rank=rank,
+        tp_size=tp_size,
+        latent_dim=latent_dim,
+        hidden_dim=hidden_dim,
+        max_m=max_m,
+        max_token_ctas=max_token_ctas,
+        fp32_internal=fp32_internal,
+        include_reduce_scatter=include_reduce_scatter,
+        include_routed=include_routed,
+    )
+    _COMPILED[key] = cute.compile(
+        kernel,
+        *_runtime_args(
+            latent,
+            gamma,
+            latent_output,
+            routed_workspace,
+            routed_flags,
+            routed_multicast_ptr,
+            shared,
+            shared_output,
+            shared_workspace,
+            shared_flags,
+            shared_peer_ptrs,
+            rms_eps,
+        ),
+    )
+
+
+def launch(
+    latent_source: torch.Tensor,
+    gamma: torch.Tensor,
+    latent_output: torch.Tensor,
+    routed_workspace: torch.Tensor,
+    routed_flags: torch.Tensor,
+    routed_multicast_ptr: int,
+    shared_source: torch.Tensor,
+    shared_output: torch.Tensor,
+    shared_workspace: torch.Tensor,
+    shared_flags: torch.Tensor,
+    shared_peer_ptrs: torch.Tensor,
+    rms_eps: float,
+    *,
+    rank: int,
+    tp_size: int,
+    latent_dim: int,
+    hidden_dim: int,
+    max_m: int,
+    max_token_ctas: int,
+    fp32_internal: bool,
+    include_reduce_scatter: bool = True,
+    include_routed: bool = True,
+) -> None:
+    compile_kernel(
+        rank=rank,
+        tp_size=tp_size,
+        latent_dim=latent_dim,
+        hidden_dim=hidden_dim,
+        max_m=max_m,
+        max_token_ctas=max_token_ctas,
+        latent_output=latent_output,
+        routed_workspace=routed_workspace,
+        routed_flags=routed_flags,
+        routed_multicast_ptr=routed_multicast_ptr,
+        shared_output=shared_output,
+        shared_workspace=shared_workspace,
+        shared_flags=shared_flags,
+        shared_peer_ptrs=shared_peer_ptrs,
+        rms_eps=rms_eps,
+        fp32_internal=fp32_internal,
+        include_reduce_scatter=include_reduce_scatter,
+        include_routed=include_routed,
+    )
+    _COMPILED[
+        _compile_key(
+            rank,
+            tp_size,
+            latent_dim,
+            hidden_dim,
+            max_m,
+            max_token_ctas,
+            fp32_internal,
+            include_reduce_scatter,
+            include_routed,
+        )
+    ](
+        *_runtime_args(
+            latent_source,
+            gamma,
+            latent_output,
+            routed_workspace,
+            routed_flags,
+            routed_multicast_ptr,
+            shared_source,
+            shared_output,
+            shared_workspace,
+            shared_flags,
+            shared_peer_ptrs,
+            rms_eps,
+        )
+    )
+
+
+class CollectiveKernel:
+    """Own and launch the routed AllReduce/RMSNorm plus shared ReduceScatter."""
+
+    def __init__(
+        self,
+        *,
+        group: dist.ProcessGroup,
+        rank: int,
+        tp_size: int,
+        latent_dim: int,
+        hidden_dim: int,
+        max_m: int,
+        max_token_ctas: int,
+        rms_eps: float,
+        fp32_internal: bool,
+    ) -> None:
+        validate_shape(
+            tp_size=tp_size,
+            latent_dim=latent_dim,
+            hidden_dim=hidden_dim,
+        )
+        self.rank = rank
+        self.tp_size = tp_size
+        self.latent_dim = latent_dim
+        self.hidden_dim = hidden_dim
+        self.shard_dim = hidden_dim // tp_size
+        self.max_m = max_m
+        self.max_token_ctas = max_token_ctas
+        self.rms_eps = float(rms_eps)
+        self.fp32_internal = fp32_internal
+        device = torch.device("cuda", torch.accelerator.current_device_index())
+
+        bytes_per_routed_buffer = max_m * tp_size * latent_dim * 2
+        routed_bytes = NUM_LAMPORT_BUFFERS * bytes_per_routed_buffer
+        self._routed_workspace = symm_mem.empty(
+            routed_bytes // 4,
+            dtype=torch.float32,
+            device=device,
+        )
+        self._routed_symm_mem = symm_mem.rendezvous(self._routed_workspace, group)
+        self._routed_workspace.fill_(-0.0)
+        actual_bytes_per_buffer = (
+            self._routed_symm_mem.buffer_size // NUM_LAMPORT_BUFFERS // 16 * 16
+        )
+        if actual_bytes_per_buffer < bytes_per_routed_buffer:
+            raise RuntimeError("routed symmetric workspace is too small")
+        self._routed_flags = torch.tensor(
+            [0, 2, actual_bytes_per_buffer, 0, 0, 0, 0, 0, 0],
+            dtype=torch.uint32,
+            device=device,
+        )
+        routed_multicast_ptr = self._routed_symm_mem.multicast_ptr
+        if routed_multicast_ptr is None or routed_multicast_ptr == 0:
+            raise RuntimeError("routed NVLS multicast mapping is unavailable")
+        self._routed_multicast_ptr = int(routed_multicast_ptr)
+
+        self._latent_output = torch.empty(
+            (max_m, latent_dim), dtype=torch.bfloat16, device=device
+        )
+        self._shared_output = torch.empty(
+            (max_m, hidden_dim), dtype=torch.bfloat16, device=device
+        )
+        shard_start = rank * self.shard_dim
+        shard_end = shard_start + self.shard_dim
+        self._shared_shard = self._shared_output[:, shard_start:shard_end]
+
+        self._shared_workspace = symm_mem.empty(
+            (NUM_LAMPORT_BUFFERS, max_m, tp_size, self.shard_dim),
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        self._shared_symm_mem = symm_mem.rendezvous(self._shared_workspace, group)
+        self._shared_workspace.view(torch.int32).fill_(-0x80000000)
+        self._shared_flags = torch.zeros(12, dtype=torch.int32, device=device)
+        self._shared_flags[1] = 1
+        self._shared_flags[2] = max_m * tp_size * self.shard_dim * 2
+        peer_ptrs = [
+            self._shared_symm_mem.get_buffer(
+                peer,
+                self._shared_workspace.shape,
+                torch.bfloat16,
+            ).data_ptr()
+            for peer in range(tp_size)
+        ]
+        if any(pointer == 0 for pointer in peer_ptrs):
+            raise RuntimeError("shared LSA peer mapping is unavailable")
+        self._shared_peer_ptrs = torch.tensor(
+            peer_ptrs, dtype=torch.int64, device=device
+        )
+
+        torch.accelerator.synchronize(device)
+        dist.barrier(group=group, device_ids=[device.index])
+        for owner in range(tp_size):
+            if rank == owner:
+                compile_kernel(
+                    rank=rank,
+                    tp_size=tp_size,
+                    latent_dim=latent_dim,
+                    hidden_dim=hidden_dim,
+                    max_m=max_m,
+                    max_token_ctas=max_token_ctas,
+                    latent_output=self._latent_output,
+                    routed_workspace=self._routed_workspace,
+                    routed_flags=self._routed_flags,
+                    routed_multicast_ptr=self._routed_multicast_ptr,
+                    shared_output=self._shared_output,
+                    shared_workspace=self._shared_workspace,
+                    shared_flags=self._shared_flags,
+                    shared_peer_ptrs=self._shared_peer_ptrs,
+                    rms_eps=self.rms_eps,
+                    fp32_internal=fp32_internal,
+                )
+            dist.barrier(group=group, device_ids=[device.index])
+
+    def __call__(
+        self,
+        latent_source: torch.Tensor,
+        shared_source: torch.Tensor,
+        gamma: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if latent_source.ndim != 2 or shared_source.ndim != 2:
+            raise ValueError("latent_source and shared_source must be rank-2")
+        m = latent_source.shape[0]
+        device = self._routed_workspace.device
+        expected = (
+            (latent_source, (m, self.latent_dim), "latent_source"),
+            (shared_source, (m, self.hidden_dim), "shared_source"),
+            (gamma, (self.latent_dim,), "gamma"),
+        )
+        for tensor, shape, name in expected:
+            if (
+                tensor.shape != shape
+                or tensor.dtype != torch.bfloat16
+                or tensor.device != device
+                or not tensor.is_contiguous()
+            ):
+                raise ValueError(f"{name} must be contiguous CUDA BF16 {list(shape)}")
+        if not 1 <= m <= self.max_m:
+            raise ValueError(f"runtime M={m} must be in [1, {self.max_m}]")
+
+        with torch.accelerator.device_index(device.index):
+            launch(
+                latent_source,
+                gamma,
+                self._latent_output,
+                self._routed_workspace,
+                self._routed_flags,
+                self._routed_multicast_ptr,
+                shared_source,
+                self._shared_output,
+                self._shared_workspace,
+                self._shared_flags,
+                self._shared_peer_ptrs,
+                self.rms_eps,
+                rank=self.rank,
+                tp_size=self.tp_size,
+                latent_dim=self.latent_dim,
+                hidden_dim=self.hidden_dim,
+                max_m=self.max_m,
+                max_token_ctas=self.max_token_ctas,
+                fp32_internal=self.fp32_internal,
+            )
+        return (
+            self._latent_output[:m],
+            self._shared_shard,
+        )
+
+    @property
+    def latent_output(self) -> torch.Tensor:
+        return self._latent_output
+
+    @property
+    def shared_output(self) -> torch.Tensor:
+        return self._shared_output

--- a/vllm/models/kimi_k3/nvidia/ops/cute_dsl/latent_moe_tail/fused_add_multicast_gemm.py
+++ b/vllm/models/kimi_k3/nvidia/ops/cute_dsl/latent_moe_tail/fused_add_multicast_gemm.py
@@ -1,0 +1,1291 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Blackwell GEMM with a fused shared-shard add and multicast epilogue.
+
+Modified from the original CUTLASS CuTe DSL SM100 persistent GEMM tutorial.
+The PDL wait before A loading orders the up-projection and shared-expert
+inputs after the producer collective.
+"""
+
+import math
+from typing import Any
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+import cutlass.utils as utils
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+from cutlass.cute.nvgpu import cpasync, tcgen05
+from cutlass.cute.nvgpu.common import CacheEvictionPriority
+from cutlass.cute.runtime import from_dlpack
+from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
+
+from .fused_add_multicast_skinny_gemm import (
+    FusedAddMulticastSkinnyGemmKernel,
+)
+from .primitives import CUDAGraphCompatibleWrapper
+
+
+def _as_cute(tensor: torch.Tensor, *, dynamic_m: bool = False):
+    converted = from_dlpack(
+        CUDAGraphCompatibleWrapper(tensor.detach()), assumed_align=16
+    )
+    if dynamic_m:
+        converted = converted.mark_compact_shape_dynamic(
+            mode=1,
+            stride_order=tensor.dim_order(),
+        )
+    return converted
+
+
+def validate_configuration(
+    *,
+    latent_dim: int,
+    shard_dim: int,
+    mma_tiler_mn: tuple[int, int],
+    cluster_shape_mn: tuple[int, int],
+    b_prime_stages: int,
+) -> None:
+    """Validate constraints imposed by this BF16 SM100 GEMM."""
+
+    if latent_dim <= 0 or shard_dim <= 0:
+        raise ValueError("GEMM K and N must be positive")
+    if latent_dim % 8 or shard_dim % 8:
+        raise ValueError("GEMM K and N must be divisible by 8 BF16 values")
+    if mma_tiler_mn[0] not in (64, 128):
+        raise ValueError("MMA M tile must be 64 or 128")
+    if mma_tiler_mn[1] not in range(32, 257, 32):
+        raise ValueError("MMA N tile must be a multiple of 32 in [32, 256]")
+    if (
+        len(cluster_shape_mn) != 2
+        or any(value <= 0 or value & (value - 1) for value in cluster_shape_mn)
+        or math.prod(cluster_shape_mn) > 16
+    ):
+        raise ValueError("cluster dimensions must be powers of two with product <= 16")
+    if not 0 <= b_prime_stages <= math.ceil(latent_dim / 128):
+        raise ValueError("b_prime_stages exceeds the GEMM K-tile count")
+
+
+@cute.jit
+def _epilogue_tma_store_add_shared(
+    gemm_kernel,
+    epi_tidx: cutlass.Int32,
+    warp_idx: cutlass.Int32,
+    tma_atom_c: cute.CopyAtom,
+    tCtAcc_base: cute.Tensor,
+    sC: cute.Tensor,
+    tCgC_base: cute.Tensor,
+    tCgShared_base: cute.Tensor,
+    tCcC_base: cute.Tensor,
+    mC_mnl: cute.Tensor,
+    mShared_mnl: cute.Tensor,
+    epi_tile: cute.Tile,
+    num_tiles_executed: cutlass.Int32,
+    mma_tile_coord_mnl,
+    acc_consumer_state: pipeline.PipelineState,
+    acc_pipeline: pipeline.PipelineAsync,
+    c_pipeline: pipeline.PipelineTmaStore,
+) -> pipeline.PipelineState:
+    """BF16 GEMM rounding + BF16 shared shard addition, then swizzled S2G TMA."""
+    sm100 = utils.gemm.sm100
+    tCgC = sm100.transform_partitioned_tensor_layout(tCgC_base)
+    tCgShared = sm100.transform_partitioned_tensor_layout(tCgShared_base)
+    tCcC = sm100.transform_partitioned_tensor_layout(tCcC_base)
+    tCtAcc = sm100.transform_partitioned_tensor_layout(tCtAcc_base)
+
+    tiled_copy_t2r, tTR_tAcc_base, tTR_rAcc = sm100.epilogue_tmem_copy_and_partition(
+        gemm_kernel,
+        epi_tidx,
+        tCtAcc,
+        tCgC,
+        epi_tile,
+        False,
+    )
+    tTR_rC = cute.make_rmem_tensor(tTR_rAcc.shape, gemm_kernel.c_dtype)
+    tTR_rShared = cute.make_rmem_tensor(tTR_rAcc.shape, gemm_kernel.c_dtype)
+    tiled_copy_r2s, tRS_rC, tRS_sC = sm100.epilogue_smem_copy_and_partition(
+        gemm_kernel, tiled_copy_t2r, tTR_rC, epi_tidx, sC
+    )
+
+    tCgC_epi = cute.flat_divide(tCgC, epi_tile)
+    bSG_sC, bSG_gC_partitioned = cpasync.tma_partition(
+        tma_atom_c,
+        0,
+        cute.make_layout(1),
+        cute.group_modes(sC, 0, 2),
+        cute.group_modes(tCgC_epi, 0, 2),
+    )
+    epilog_sync_barrier = pipeline.NamedBarrier(
+        barrier_id=gemm_kernel.epilog_sync_bar_id,
+        num_threads=32 * len(gemm_kernel.epilogue_warp_id),
+    )
+
+    bSG_gC = bSG_gC_partitioned[(None, None, None, *mma_tile_coord_mnl)]
+    tTR_tAcc = tTR_tAcc_base[(None, None, None, None, None, acc_consumer_state.index)]
+    thr_copy_t2r = tiled_copy_t2r.get_slice(epi_tidx)
+    tTR_gShared_partitioned = thr_copy_t2r.partition_D(
+        cute.flat_divide(tCgShared, epi_tile)
+    )
+    tTR_cC_partitioned = thr_copy_t2r.partition_D(cute.flat_divide(tCcC, epi_tile))
+    tTR_gShared = tTR_gShared_partitioned[
+        (None, None, None, None, None, *mma_tile_coord_mnl)
+    ]
+    tTR_cC = tTR_cC_partitioned[(None, None, None, None, None, *mma_tile_coord_mnl)]
+
+    exemplar = tTR_gShared_partitioned[(None, None, None, 0, 0, 0, 0, 0)]
+    mcl_r = cute.max_common_layout(tTR_rShared.layout, exemplar.layout)
+    shared_copy_bits = min(
+        exemplar.iterator.alignment * 8,
+        cute.size(mcl_r) * gemm_kernel.c_dtype.width,
+        128,
+    )
+    shared_g2r_atom = cute.make_copy_atom(
+        cute.nvgpu.CopyG2ROp(),
+        gemm_kernel.c_dtype,
+        num_bits_per_copy=shared_copy_bits,
+        l1c_evict_priority=CacheEvictionPriority.NO_ALLOCATE,
+    )
+
+    tTR_tAcc = cute.group_modes(tTR_tAcc, 3, cute.rank(tTR_tAcc))
+    tTR_gShared = cute.group_modes(tTR_gShared, 3, cute.rank(tTR_gShared))
+    tTR_cC = cute.group_modes(tTR_cC, 3, cute.rank(tTR_cC))
+    bSG_gC = cute.group_modes(bSG_gC, 1, cute.rank(bSG_gC))
+
+    subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
+    previous_subtile_count = num_tiles_executed * subtile_cnt
+    cute.arch.griddepcontrol_wait()
+    for subtile_idx in range(subtile_cnt):
+        tTR_gShared_subtile = tTR_gShared[(None, None, None, subtile_idx)]
+        tTR_cC_subtile = tTR_cC[(None, None, None, subtile_idx)]
+        pred_shape = (1, *tTR_cC_subtile.shape[1:])
+        pred = cute.make_rmem_tensor(pred_shape, cutlass.Boolean)
+        for m_idx in range(tTR_cC_subtile.shape[1]):
+            for n_idx in range(tTR_cC_subtile.shape[2]):
+                pred[(0, m_idx, n_idx)] = cute.elem_less(
+                    tTR_cC_subtile[(0, m_idx, n_idx)], mC_mnl.shape
+                )
+        tTR_rShared.store(cute.zeros_like(tTR_rShared, dtype=gemm_kernel.c_dtype))
+        cute.copy(
+            shared_g2r_atom,
+            tTR_gShared_subtile,
+            tTR_rShared,
+            pred=pred,
+        )
+
+        # Load the shared addend before waiting for the accumulator.
+        if subtile_idx == 0:
+            acc_pipeline.consumer_wait(acc_consumer_state)
+        tTR_tAcc_mn = tTR_tAcc[(None, None, None, subtile_idx)]
+        cute.copy(tiled_copy_t2r, tTR_tAcc_mn, tTR_rAcc)
+
+        gemm_vec = tiled_copy_r2s.retile(tTR_rAcc).load().to(gemm_kernel.c_dtype)
+        shared_vec = tiled_copy_r2s.retile(tTR_rShared).load()
+        fused_vec = (gemm_vec.to(cutlass.Float32) + shared_vec.to(cutlass.Float32)).to(
+            gemm_kernel.c_dtype
+        )
+        # The symmetric output is an in-band Lamport mailbox whose empty
+        # marker contains BF16 -0. Normalize either signed zero to +0 so a
+        # legitimate result can never be mistaken for an unwritten fragment.
+        fused_vec = cute.where(
+            fused_vec == cute.zeros_like(fused_vec),
+            cute.zeros_like(fused_vec),
+            fused_vec,
+        )
+        tRS_rC.store(fused_vec)
+
+        c_buffer = (previous_subtile_count + subtile_idx) % gemm_kernel.num_c_stage
+        cute.copy(tiled_copy_r2s, tRS_rC, tRS_sC[(None, None, None, c_buffer)])
+        cute.arch.fence_proxy("async.shared", space="cta")
+        epilog_sync_barrier.arrive_and_wait()
+        if warp_idx == gemm_kernel.epilogue_warp_id[0]:
+            cute.copy(
+                tma_atom_c,
+                bSG_sC[(None, c_buffer)],
+                bSG_gC[(None, subtile_idx)],
+            )
+            c_pipeline.producer_commit()
+            c_pipeline.producer_acquire()
+        epilog_sync_barrier.arrive_and_wait()
+
+    epilog_sync_barrier.arrive_and_wait()
+    with cute.arch.elect_one():
+        acc_pipeline.consumer_release(acc_consumer_state)
+    acc_consumer_state.advance()
+    return acc_consumer_state
+
+
+def _compute_stages(
+    tiled_mma: cute.TiledMma,
+    mma_tiler_mnk: tuple[int, int, int],
+    a_dtype,
+    b_dtype,
+    c_dtype,
+    smem_capacity: int,
+    c_smem_layout,
+) -> tuple[int, int, int]:
+    """Choose accumulator, mainloop, and epilogue stage counts."""
+    num_acc_stage = 2
+    num_c_stage = 2
+    a_smem_layout_stage_one = utils.sm100.make_smem_layout_a(
+        tiled_mma, mma_tiler_mnk, a_dtype, 1
+    )
+    b_smem_layout_staged_one = utils.sm100.make_smem_layout_b(
+        tiled_mma, mma_tiler_mnk, b_dtype, 1
+    )
+
+    ab_bytes_per_stage = cute.size_in_bytes(
+        a_dtype, a_smem_layout_stage_one
+    ) + cute.size_in_bytes(b_dtype, b_smem_layout_staged_one)
+    mbar_helpers_bytes = 1024
+
+    c_bytes_per_stage = cute.size_in_bytes(c_dtype, c_smem_layout)
+    c_bytes = c_bytes_per_stage * num_c_stage
+    num_ab_stage = (
+        smem_capacity - (mbar_helpers_bytes + c_bytes)
+    ) // ab_bytes_per_stage
+    num_c_stage += (
+        smem_capacity
+        - ab_bytes_per_stage * num_ab_stage
+        - (mbar_helpers_bytes + c_bytes)
+    ) // c_bytes_per_stage
+    return num_acc_stage, num_ab_stage, num_c_stage
+
+
+class FusedAddMulticastGemm:
+    """Persistent Blackwell GEMM with a shared-add epilogue.
+
+    B priming may overlap the producer collective. The PDL wait before A
+    loading orders both inputs before the shared-add epilogue.
+    """
+
+    def __init__(
+        self,
+        mma_tiler_mn: tuple[int, int],
+        cluster_shape_mn: tuple[int, int],
+        b_prime_stages: int = 2,
+    ):
+        self.acc_dtype = cutlass.Float32
+        self.cluster_shape_mn = cluster_shape_mn
+        self.mma_tiler = (*mma_tiler_mn, 1)
+        # B primes the combined A+B pipeline before the PDL wait.
+        self.b_prime_stages = b_prime_stages
+        self.cta_group = tcgen05.CtaGroup.ONE
+        self.epilogue_warp_id = (0, 1, 2, 3)
+        self.mma_warp_id = 4
+        self.tma_warp_id = 5
+        self.threads_per_cta = 32 * len(
+            (self.mma_warp_id, self.tma_warp_id, *self.epilogue_warp_id)
+        )
+        self.epilog_sync_bar_id = 1
+        self.tmem_alloc_sync_bar_id = 2
+
+    def _create_tiled_mma(self):
+        return utils.sm100.make_trivial_tiled_mma(
+            self.a_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.acc_dtype,
+            self.cta_group,
+            self.mma_tiler[:2],
+        )
+
+    def _setup_attributes(self):
+        """Derive layouts and stage counts from the compiled tensor shapes."""
+        tiled_mma = self._create_tiled_mma()
+
+        mma_inst_shape_k = cute.size(tiled_mma.shape_mnk, mode=[2])
+        mma_inst_tile_k = 4
+        self.mma_tiler = (
+            self.mma_tiler[0],
+            self.mma_tiler[1],
+            mma_inst_shape_k * mma_inst_tile_k,
+        )
+        self.cta_tile_shape_mnk = (
+            self.mma_tiler[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler[1],
+            self.mma_tiler[2],
+        )
+
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma.thr_id.shape,),
+        )
+
+        self.num_mcast_ctas_a = cute.size(self.cluster_layout_vmnk.shape[2])
+        self.num_mcast_ctas_b = cute.size(self.cluster_layout_vmnk.shape[1])
+        self.is_a_mcast = self.num_mcast_ctas_a > 1
+        self.is_b_mcast = self.num_mcast_ctas_b > 1
+
+        self.epi_tile = utils.sm100.compute_epilogue_tile_shape(
+            self.cta_tile_shape_mnk,
+            False,
+            self.c_layout,
+            self.c_dtype,
+        )
+        c_smem_layout = utils.sm100.make_smem_layout_epi(
+            self.c_dtype, self.c_layout, self.epi_tile, 1
+        )
+
+        self.num_acc_stage, self.num_ab_stage, self.num_c_stage = _compute_stages(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.b_dtype,
+            self.c_dtype,
+            utils.get_smem_capacity_in_bytes(),
+            c_smem_layout,
+        )
+
+        self.a_smem_layout_staged = utils.sm100.make_smem_layout_a(
+            tiled_mma, self.mma_tiler, self.a_dtype, self.num_ab_stage
+        )
+        self.b_smem_layout_staged = utils.sm100.make_smem_layout_b(
+            tiled_mma, self.mma_tiler, self.b_dtype, self.num_ab_stage
+        )
+
+        self.c_smem_layout_staged = utils.sm100.make_smem_layout_epi(
+            self.c_dtype, self.c_layout, self.epi_tile, self.num_c_stage
+        )
+
+        self.num_tmem_alloc_cols = self._compute_num_tmem_alloc_cols(
+            tiled_mma, self.mma_tiler, self.num_acc_stage, "sm_100"
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        a: cute.Tensor,
+        b: cute.Tensor,
+        c: cute.Tensor,
+        shared_shard: cute.Tensor,
+        c_multicast_i64: cutlass.Int64,
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+    ):
+        """Launch the persistent GEMM."""
+        # Preserve C's logical strided layout but point the TMA descriptor at
+        # this rank's shard inside the LSA multicast mapping.  One TMA store is
+        # therefore replicated into the same shard on all eight ranks.
+        c = cute.make_tensor(
+            cute.make_ptr(
+                c.element_type,
+                c_multicast_i64,
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+            c.layout,
+        )
+
+        self.a_dtype: type[cutlass.Numeric] = a.element_type
+        self.b_dtype: type[cutlass.Numeric] = b.element_type
+        self.c_dtype: type[cutlass.Numeric] = c.element_type
+        self.a_major_mode = utils.LayoutEnum.from_tensor(a).mma_major_mode()
+        self.b_major_mode = utils.LayoutEnum.from_tensor(b).mma_major_mode()
+        self.c_layout = utils.LayoutEnum.from_tensor(c)
+
+        if cutlass.const_expr(self.a_dtype != self.b_dtype):
+            raise TypeError(f"Type must match: {self.a_dtype} != {self.b_dtype}")
+
+        tiled_mma = self._create_tiled_mma()
+
+        self._setup_attributes()
+        if cutlass.const_expr(self.b_prime_stages > self.num_ab_stage):
+            raise ValueError(
+                "b_prime_stages exceeds the compiled A/B pipeline stage count"
+            )
+
+        atom_thr_size = cute.size(tiled_mma.thr_id.shape)
+
+        a_op = utils.sm100.cluster_shape_to_tma_atom_A(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        a_smem_layout = cute.slice_(self.a_smem_layout_staged, (None, None, None, 0))
+        tma_atom_a, tma_tensor_a = cute.nvgpu.make_tiled_tma_atom_A(
+            a_op,
+            a,
+            a_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+            internal_type=(
+                cutlass.TFloat32 if a.element_type is cutlass.Float32 else None
+            ),
+        )
+
+        b_op = utils.sm100.cluster_shape_to_tma_atom_B(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        b_smem_layout = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
+        tma_atom_b, tma_tensor_b = cute.nvgpu.make_tiled_tma_atom_B(
+            b_op,
+            b,
+            b_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+            internal_type=(
+                cutlass.TFloat32 if b.element_type is cutlass.Float32 else None
+            ),
+        )
+
+        a_copy_size = cute.size_in_bytes(self.a_dtype, a_smem_layout)
+        b_copy_size = cute.size_in_bytes(self.b_dtype, b_smem_layout)
+        self.num_tma_load_bytes = (a_copy_size + b_copy_size) * atom_thr_size
+
+        epi_smem_layout = cute.select(self.c_smem_layout_staged, mode=[0, 1])
+        tma_atom_c, tma_tensor_c = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileS2GOp(), c, epi_smem_layout, self.epi_tile
+        )
+
+        tile_sched_params, grid = self._compute_grid(
+            c, self.cta_tile_shape_mnk, self.cluster_shape_mn, max_active_clusters
+        )
+        self.kernel(
+            tiled_mma,
+            tma_atom_a,
+            tma_tensor_a,
+            tma_atom_b,
+            tma_tensor_b,
+            tma_atom_c,
+            tma_tensor_c,
+            self.cluster_layout_vmnk,
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.c_smem_layout_staged,
+            self.epi_tile,
+            tile_sched_params,
+            shared_shard,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=(*self.cluster_shape_mn, 1),
+            stream=stream,
+            use_pdl=True,
+        )
+        return
+
+    @cute.kernel
+    def kernel(
+        self,
+        tiled_mma: cute.TiledMma,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        mC_mnl: cute.Tensor,
+        cluster_layout_vmnk: cute.Layout,
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        c_smem_layout_staged: cute.Layout | cute.ComposedLayout,
+        epi_tile: cute.Tile,
+        tile_sched_params: utils.PersistentTileSchedulerParams,
+        shared_shard: cute.Tensor,
+    ):
+        self._gemm_device(
+            tiled_mma,
+            tma_atom_a,
+            mA_mkl,
+            tma_atom_b,
+            mB_nkl,
+            tma_atom_c,
+            mC_mnl,
+            cluster_layout_vmnk,
+            a_smem_layout_staged,
+            b_smem_layout_staged,
+            c_smem_layout_staged,
+            epi_tile,
+            tile_sched_params,
+            shared_shard,
+        )
+
+    @cute.jit
+    def _gemm_device(
+        self,
+        tiled_mma: cute.TiledMma,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        mC_mnl: cute.Tensor,
+        cluster_layout_vmnk: cute.Layout,
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        c_smem_layout_staged: cute.Layout | cute.ComposedLayout,
+        epi_tile: cute.Tile,
+        tile_sched_params: utils.PersistentTileSchedulerParams,
+        shared_shard: cute.Tensor,
+    ):
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+
+        if warp_idx == self.tma_warp_id:
+            cpasync.prefetch_descriptor(tma_atom_a)
+            cpasync.prefetch_descriptor(tma_atom_b)
+            cpasync.prefetch_descriptor(tma_atom_c)
+
+        bidx, bidy, bidz = cute.arch.block_idx()
+        mma_tile_coord_v = bidx % cute.size(tiled_mma.thr_id.shape)
+        is_leader_cta = mma_tile_coord_v == 0
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(
+            cute.arch.block_idx_in_cluster()
+        )
+        block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(
+            cta_rank_in_cluster
+        )
+        tidx, _, _ = cute.arch.thread_idx()
+
+        @cute.struct
+        class SharedStorage:
+            ab_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage * 2]
+            acc_full_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.num_acc_stage * 2
+            ]
+            tmem_dealloc_mbar_ptr: cutlass.Int64
+            tmem_holding_buf: cutlass.Int32
+
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+
+        ab_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_tma_producer = self.num_mcast_ctas_a + self.num_mcast_ctas_b - 1
+        ab_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, num_tma_producer
+        )
+        ab_pipeline = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.ab_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_ab_stage,
+            producer_group=ab_pipeline_producer_group,
+            consumer_group=ab_pipeline_consumer_group,
+            tx_count=self.num_tma_load_bytes,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+        ab_producer, ab_consumer = ab_pipeline.make_participants()
+
+        acc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_acc_consumer_threads = len(self.epilogue_warp_id)
+        acc_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, num_acc_consumer_threads
+        )
+        acc_pipeline = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.acc_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_acc_stage,
+            producer_group=acc_pipeline_producer_group,
+            consumer_group=acc_pipeline_consumer_group,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+
+        tmem_alloc_barrier = pipeline.NamedBarrier(
+            barrier_id=self.tmem_alloc_sync_bar_id,
+            num_threads=32 * len((self.mma_warp_id, *self.epilogue_warp_id)),
+        )
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf,
+            barrier_for_retrieve=tmem_alloc_barrier,
+            allocator_warp_id=self.epilogue_warp_id[0],
+            is_two_cta=False,
+            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr,
+        )
+
+        pipeline_init_arrive(cluster_shape_mn=cluster_layout_vmnk, is_relaxed=True)
+
+        sA = smem.allocate_tensor(
+            element_type=self.a_dtype,
+            layout=a_smem_layout_staged.outer,
+            byte_alignment=128,
+            swizzle=a_smem_layout_staged.inner,
+        )
+        sB = smem.allocate_tensor(
+            element_type=self.b_dtype,
+            layout=b_smem_layout_staged.outer,
+            byte_alignment=128,
+            swizzle=b_smem_layout_staged.inner,
+        )
+
+        a_full_mcast_mask = None
+        b_full_mcast_mask = None
+        if cutlass.const_expr(self.is_a_mcast or self.is_b_mcast):
+            a_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2
+            )
+            b_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=1
+            )
+
+        gA_mkl = cute.local_tile(
+            mA_mkl, cute.slice_(self.mma_tiler, (None, 0, None)), (None, None, None)
+        )
+        gB_nkl = cute.local_tile(
+            mB_nkl, cute.slice_(self.mma_tiler, (0, None, None)), (None, None, None)
+        )
+        gC_mnl = cute.local_tile(
+            mC_mnl, cute.slice_(self.mma_tiler, (None, None, 0)), (None, None, None)
+        )
+        # Shared shard is physically [M, shard_dim]. Give it the same logical MNL
+        # view as C so its epilogue partition is coordinate-identical.
+        mShared_mnl = cute.make_tensor(
+            shared_shard.iterator,
+            cute.append(shared_shard.layout, cute.make_layout((1,), stride=(0,))),
+        )
+        gShared_mnl = cute.local_tile(
+            mShared_mnl,
+            cute.slice_(self.mma_tiler, (None, None, 0)),
+            (None, None, None),
+        )
+        k_tile_cnt = cute.size(gA_mkl, mode=[3])
+
+        thr_mma = tiled_mma.get_slice(mma_tile_coord_v)
+        tCgA = thr_mma.partition_A(gA_mkl)
+        tCgB = thr_mma.partition_B(gB_nkl)
+        tCgC = thr_mma.partition_C(gC_mnl)
+        tCgShared = thr_mma.partition_C(gShared_mnl)
+
+        # Predicate the partial M tile when M is smaller than the MMA tile.
+        idC = cute.make_identity_tensor(mC_mnl.shape)
+        cC_mnl = cute.local_tile(
+            idC, cute.slice_(self.mma_tiler, (None, None, 0)), (None, None, None)
+        )
+        tCcC = thr_mma.partition_C(cC_mnl)
+
+        a_cta_layout = cute.make_layout(
+            cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape
+        )
+        tAsA, tAgA = cpasync.tma_partition(
+            tma_atom_a,
+            block_in_cluster_coord_vmnk[2],
+            a_cta_layout,
+            cute.group_modes(sA, 0, 3),
+            cute.group_modes(tCgA, 0, 3),
+        )
+        b_cta_layout = cute.make_layout(
+            cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape
+        )
+        tBsB, tBgB = cpasync.tma_partition(
+            tma_atom_b,
+            block_in_cluster_coord_vmnk[1],
+            b_cta_layout,
+            cute.group_modes(sB, 0, 3),
+            cute.group_modes(tCgB, 0, 3),
+        )
+
+        tCrA = tiled_mma.make_fragment_A(sA)
+        tCrB = tiled_mma.make_fragment_B(sB)
+        acc_shape = tiled_mma.partition_shape_C(self.mma_tiler[:2])
+        tCtAcc_fake = tiled_mma.make_fragment_C(
+            cute.append(acc_shape, self.num_acc_stage)
+        )
+
+        pipeline_init_wait(cluster_shape_mn=cluster_layout_vmnk)
+
+        gemm_grid_z = cute.arch.grid_dim()[2]
+        tile_sched = utils.StaticPersistentTileScheduler.create(
+            tile_sched_params,
+            cute.arch.block_idx(),
+            (
+                cute.arch.grid_dim()[0],
+                cute.arch.grid_dim()[1],
+                gemm_grid_z,
+            ),
+        )
+        work_tile = tile_sched.initial_work_tile_info()
+
+        if warp_idx == self.tma_warp_id:
+            while work_tile.is_valid_tile:
+                cur_tile_coord = work_tile.tile_idx
+                mma_tile_coord_mnl = (
+                    cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape),
+                    cur_tile_coord[1],
+                    cur_tile_coord[2],
+                )
+
+                tAgA_slice = tAgA[
+                    (None, mma_tile_coord_mnl[0], None, mma_tile_coord_mnl[2])
+                ]
+                tBgB_slice = tBgB[
+                    (None, mma_tile_coord_mnl[1], None, mma_tile_coord_mnl[2])
+                ]
+
+                # Prime a short prefix of the existing combined A+B ring with
+                # B only.  Its barrier still expects A+B bytes, so the MMA
+                # consumer cannot observe a half-filled stage.
+                ab_producer.reset()
+                peek_ab_empty_status = ab_producer.try_acquire()
+
+                for k_tile in cutlass.range(0, self.b_prime_stages, 1, unroll=1):
+                    handle = ab_producer.acquire_and_advance(peek_ab_empty_status)
+                    cute.copy(
+                        tma_atom_b,
+                        tBgB_slice[(None, handle.count)],
+                        tBsB[(None, handle.index)],
+                        tma_bar_ptr=handle.barrier,
+                        mcast_mask=b_full_mcast_mask,
+                    )
+                    peek_ab_empty_status = cutlass.Boolean(1)
+                    if handle.count + 1 < self.b_prime_stages:
+                        peek_ab_empty_status = ab_producer.try_acquire()
+
+                cute.arch.griddepcontrol_wait()
+
+                # Supply A to the very same stages after the producer AR has
+                # programmatically released this dependent kernel.
+                a_fill_state = pipeline.make_pipeline_state(
+                    pipeline.PipelineUserType.Producer, self.num_ab_stage
+                )
+                for k_tile in cutlass.range(0, self.b_prime_stages, 1, unroll=1):
+                    a_barrier = ab_pipeline.producer_get_barrier(a_fill_state)
+                    cute.copy(
+                        tma_atom_a,
+                        tAgA_slice[(None, k_tile)],
+                        tAsA[(None, a_fill_state.index)],
+                        tma_bar_ptr=a_barrier,
+                        mcast_mask=a_full_mcast_mask,
+                    )
+                    a_fill_state.advance()
+
+                peek_ab_empty_status = ab_producer.try_acquire()
+
+                for k_tile in cutlass.range(
+                    self.b_prime_stages, k_tile_cnt, 1, unroll=1
+                ):
+                    handle = ab_producer.acquire_and_advance(peek_ab_empty_status)
+
+                    cute.copy(
+                        tma_atom_a,
+                        tAgA_slice[(None, handle.count)],
+                        tAsA[(None, handle.index)],
+                        tma_bar_ptr=handle.barrier,
+                        mcast_mask=a_full_mcast_mask,
+                    )
+                    cute.copy(
+                        tma_atom_b,
+                        tBgB_slice[(None, handle.count)],
+                        tBsB[(None, handle.index)],
+                        tma_bar_ptr=handle.barrier,
+                        mcast_mask=b_full_mcast_mask,
+                    )
+
+                    peek_ab_empty_status = cutlass.Boolean(1)
+                    if handle.count + 1 < k_tile_cnt:
+                        peek_ab_empty_status = ab_producer.try_acquire()
+
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+            ab_producer.tail()
+
+        if warp_idx == self.mma_warp_id:
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            tCtAcc_base = cute.make_tensor(tmem_ptr, tCtAcc_fake.layout)
+
+            acc_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.num_acc_stage
+            )
+
+            while work_tile.is_valid_tile:
+                cur_tile_coord = work_tile.tile_idx
+                mma_tile_coord_mnl = (
+                    cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape),
+                    cur_tile_coord[1],
+                    cur_tile_coord[2],
+                )
+
+                tCtAcc = tCtAcc_base[(None, None, None, acc_producer_state.index)]
+
+                ab_consumer.reset()
+                peek_ab_full_status = cutlass.Boolean(1)
+                if is_leader_cta:
+                    peek_ab_full_status = ab_consumer.try_wait()
+
+                if is_leader_cta:
+                    acc_pipeline.producer_acquire(acc_producer_state)
+
+                tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+
+                for k_tile in range(k_tile_cnt):
+                    if is_leader_cta:
+                        handle = ab_consumer.wait_and_advance(peek_ab_full_status)
+
+                        num_kblocks = cute.size(tCrA, mode=[2])
+                        for kblk_idx in cutlass.range(num_kblocks, unroll_full=True):
+                            kblk_crd = (None, None, kblk_idx, handle.index)
+
+                            cute.gemm(
+                                tiled_mma,
+                                tCtAcc,
+                                tCrA[kblk_crd],
+                                tCrB[kblk_crd],
+                                tCtAcc,
+                            )
+                            tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+
+                        handle.release()
+
+                        peek_ab_full_status = cutlass.Boolean(1)
+                        if handle.count + 1 < k_tile_cnt:
+                            peek_ab_full_status = ab_consumer.try_wait()
+
+                if is_leader_cta:
+                    acc_pipeline.producer_commit(acc_producer_state)
+                acc_producer_state.advance()
+
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+            acc_pipeline.producer_tail(acc_producer_state)
+
+        sC = smem.allocate_tensor(
+            element_type=self.c_dtype,
+            layout=c_smem_layout_staged.outer,
+            byte_alignment=128,
+            swizzle=c_smem_layout_staged.inner,
+        )
+
+        if warp_idx < self.mma_warp_id:
+            tmem.allocate(self.num_tmem_alloc_cols)
+
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            tCtAcc_base = cute.make_tensor(tmem_ptr, tCtAcc_fake.layout)
+
+            acc_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.num_acc_stage
+            )
+            c_producer_group = pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                32 * len(self.epilogue_warp_id),
+            )
+            c_pipeline = pipeline.PipelineTmaStore.create(
+                num_stages=self.num_c_stage, producer_group=c_producer_group
+            )
+            while work_tile.is_valid_tile:
+                cur_tile_coord = work_tile.tile_idx
+                mma_tile_coord_mnl = (
+                    cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape),
+                    cur_tile_coord[1],
+                    cur_tile_coord[2],
+                )
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+                num_tiles_executed = tile_sched.num_tiles_executed
+                acc_consumer_state = _epilogue_tma_store_add_shared(
+                    self,
+                    tidx,
+                    warp_idx,
+                    tma_atom_c,
+                    tCtAcc_base,
+                    sC,
+                    tCgC,
+                    tCgShared,
+                    tCcC,
+                    mC_mnl,
+                    mShared_mnl,
+                    epi_tile,
+                    num_tiles_executed,
+                    mma_tile_coord_mnl,
+                    acc_consumer_state,
+                    acc_pipeline,
+                    c_pipeline,
+                )
+
+            c_pipeline.producer_tail()
+
+            tmem.relinquish_alloc_permit()
+            tmem.free(tmem_ptr)
+
+        # Allow the Lamport copy to become resident before this grid
+        # fully retires. Its griddepcontrol.wait still enforces complete
+        # producer-grid ordering before mailbox inspection.
+        cute.arch.griddepcontrol_launch_dependents()
+
+    @staticmethod
+    def _compute_grid(
+        c: cute.Tensor,
+        cta_tile_shape_mnk: tuple[int, int, int],
+        cluster_shape_mn: tuple[int, int],
+        max_active_clusters: cutlass.Constexpr,
+    ) -> tuple[utils.PersistentTileSchedulerParams, tuple[int, int, int]]:
+        """Build the static persistent schedule."""
+        c_shape = cute.slice_(cta_tile_shape_mnk, (None, None, 0))
+        gc = cute.zipped_divide(c, tiler=c_shape)
+        num_ctas_mnl = gc[(0, (None, None, None))].shape
+        cluster_shape_mnl = (*cluster_shape_mn, 1)
+
+        tile_sched_params = utils.PersistentTileSchedulerParams(
+            num_ctas_mnl, cluster_shape_mnl
+        )
+        grid = utils.StaticPersistentTileScheduler.get_grid_shape(
+            tile_sched_params, max_active_clusters
+        )
+
+        return tile_sched_params, grid
+
+    @staticmethod
+    def _compute_num_tmem_alloc_cols(
+        tiled_mma: cute.TiledMma,
+        mma_tiler: tuple[int, int, int],
+        num_acc_stage: int,
+        arch: str,
+    ) -> int:
+        """Return the required tensor-memory column count."""
+        acc_shape = tiled_mma.partition_shape_C(mma_tiler[:2])
+        tCtAcc_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, num_acc_stage))
+        num_tmem_alloc_cols = utils.get_num_tmem_alloc_cols(tCtAcc_fake, arch=arch)
+
+        return num_tmem_alloc_cols
+
+
+@cute.jit
+def launch_kernel(
+    gemm_op: cutlass.Constexpr,
+    a: cute.Tensor,  # (l, m, k)
+    b: cute.Tensor,  # (l, n, k)
+    c: cute.Tensor,  # (l, m, n)
+    shared_shard: cute.Tensor,  # (m, shard_dim), private TP shard
+    rows: cutlass.Int64,
+    c_multicast_i64: cutlass.Int64,
+    full_hidden_dim: cutlass.Constexpr,
+    shard_dim: cutlass.Constexpr,
+    max_active_clusters: cutlass.Constexpr,
+    stream: cuda.CUstream,
+):
+    """Launch the fused-add multicast GEMM using PyTorch BMM tensor order."""
+    # C is passed as the fixed-capacity [1,max_m,H] symmetric mailbox. Only M
+    # is runtime-variable; construct this rank's logical [1,M,S] view here so
+    # H and S remain compile-time constants and no dynamic strided host view is
+    # needed on every call. __call__ later replaces the local base pointer with
+    # the already rank-offset multicast address.
+    c = cute.make_tensor(
+        c.iterator,
+        cute.make_layout(
+            (1, rows, shard_dim),
+            stride=(0, full_hidden_dim, 1),
+        ),
+    )
+    # (l,m,k) -> (m,k,l)
+    a = cute.make_tensor(a.iterator, cute.select(a.layout, mode=[1, 2, 0]))
+    # (l,n,k) -> (n,k,l)
+    b = cute.make_tensor(b.iterator, cute.select(b.layout, mode=[1, 2, 0]))
+    # (l,m,n) -> (m,n,l)
+    c = cute.make_tensor(c.iterator, cute.select(c.layout, mode=[1, 2, 0]))
+
+    gemm_op(
+        a,
+        b,
+        c,
+        shared_shard,
+        c_multicast_i64,
+        max_active_clusters,
+        stream,
+    )
+
+
+_COMPILED: dict[tuple[object, ...], object] = {}
+
+
+def compile_kernel(
+    mnkl: tuple[int, int, int, int],
+    a: cute.Tensor,
+    b: cute.Tensor,
+    c: cute.Tensor,
+    shared_shard: cute.Tensor,
+    full_hidden_dim: int,
+    shard_dim: int,
+    mma_tiler_mn: tuple[int, int] = (64, 32),
+    cluster_shape_mn: tuple[int, int] = (1, 8),
+    max_active_clusters: cutlass.Constexpr = None,
+    b_prime_stages: int = 2,
+):
+    key = (
+        torch.accelerator.current_device_index(),
+        mnkl,
+        full_hidden_dim,
+        shard_dim,
+        mma_tiler_mn,
+        cluster_shape_mn,
+        max_active_clusters,
+        b_prime_stages,
+    )
+    if key in _COMPILED:
+        return _COMPILED[key]
+
+    from cutlass.cute.runtime import make_fake_stream, make_fake_tensor
+
+    gemm = FusedAddMulticastGemm(
+        mma_tiler_mn,
+        cluster_shape_mn,
+        b_prime_stages,
+    )
+    validate_configuration(
+        latent_dim=mnkl[2],
+        shard_dim=mnkl[1],
+        mma_tiler_mn=mma_tiler_mn,
+        cluster_shape_mn=cluster_shape_mn,
+        b_prime_stages=b_prime_stages,
+    )
+    if any(tensor.element_type is not cutlass.BFloat16 for tensor in (a, b, c)):
+        raise ValueError("up-projection tensors must be BF16")
+
+    # The producer writes [M, full_hidden_dim]. GEMM receives a rank-local
+    # [M, shard_dim] view: contiguous within a row, with full_hidden_dim as
+    # its leading dimension.
+    shared_shard_compile = make_fake_tensor(
+        shared_shard.element_type,
+        (mnkl[0], shard_dim),
+        stride=(full_hidden_dim, 1),
+        assumed_align=16,
+    )
+    stream = make_fake_stream()
+    compiled = cute.compile(
+        launch_kernel,
+        gemm,
+        a,
+        b,
+        c,
+        shared_shard_compile,
+        cutlass.Int64(mnkl[0]),
+        cutlass.Int64(0),
+        full_hidden_dim,
+        shard_dim,
+        max_active_clusters,
+        stream,
+    )
+    _COMPILED[key] = compiled
+    return compiled
+
+
+class AdaptiveUpProjectionKernel:
+    """Dispatch static-M Skinny or dynamic-M WGMMA into one mailbox."""
+
+    def __init__(
+        self,
+        *,
+        group: dist.ProcessGroup,
+        rank: int,
+        tp_size: int,
+        latent_dim: int,
+        hidden_dim: int,
+        max_m: int,
+        skinny_max_m: int,
+        mma_tiler_mn: tuple[int, int],
+        cluster_shape_mn: tuple[int, int],
+        b_prime_stages: int,
+    ) -> None:
+        if hidden_dim % tp_size:
+            raise ValueError("hidden_dim must be divisible by TP size")
+        if not 0 <= skinny_max_m <= min(8, max_m):
+            raise ValueError("skinny_max_m must be in [0, min(8, max_m)]")
+        self.rank = rank
+        self.tp_size = tp_size
+        self.latent_dim = latent_dim
+        self.hidden_dim = hidden_dim
+        self.shard_dim = hidden_dim // tp_size
+        self.max_m = max_m
+        self.skinny_max_m = skinny_max_m
+        self.mma_tiler_mn = mma_tiler_mn
+        self.cluster_shape_mn = cluster_shape_mn
+        self.b_prime_stages = b_prime_stages
+        device = torch.device("cuda", torch.accelerator.current_device_index())
+        self._device = device
+        self._dynamic: Any | None = None
+        self._skinny_by_m: dict[int, FusedAddMulticastSkinnyGemmKernel] = {}
+        validate_configuration(
+            latent_dim=latent_dim,
+            shard_dim=self.shard_dim,
+            mma_tiler_mn=mma_tiler_mn,
+            cluster_shape_mn=cluster_shape_mn,
+            b_prime_stages=b_prime_stages,
+        )
+        if skinny_max_m and self.latent_dim % (224 * 8):
+            raise ValueError(
+                "Skinny up-projection requires latent_dim divisible by 1792."
+            )
+
+        self._mailbox = symm_mem.empty(
+            (1, max_m, hidden_dim),
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        self._mailbox_symm_mem = symm_mem.rendezvous(self._mailbox, group)
+        self._mailbox.view(torch.int32).fill_(-0x80000000)
+        multicast_ptr = self._mailbox_symm_mem.multicast_ptr
+        if multicast_ptr is None or multicast_ptr == 0:
+            raise RuntimeError("mailbox NVLS multicast mapping is unavailable")
+        self._mailbox_multicast_ptr = int(multicast_ptr)
+
+        cluster_size = math.prod(cluster_shape_mn)
+        self._max_active_clusters = utils.HardwareInfo().get_max_active_clusters(
+            cluster_size
+        )
+        self._mailbox_c = _as_cute(self._mailbox)
+
+    def compile_dynamic(self) -> None:
+        if self._dynamic is not None:
+            return
+        device = self._device
+        with torch.accelerator.device_index(device.index):
+            compile_latent = torch.empty(
+                (1, self.max_m, self.latent_dim),
+                dtype=torch.bfloat16,
+                device=device,
+            )
+            compile_weight = torch.empty(
+                (self.shard_dim, self.latent_dim),
+                dtype=torch.bfloat16,
+                device=device,
+            )
+            compile_shared = torch.empty(
+                (self.max_m, self.hidden_dim),
+                dtype=torch.bfloat16,
+                device=device,
+            )[
+                :,
+                self.rank * self.shard_dim : (self.rank + 1) * self.shard_dim,
+            ]
+            compile_latent_c = _as_cute(compile_latent, dynamic_m=True)
+            compile_weight_c = _as_cute(compile_weight.unsqueeze(0))
+            compile_shared_c = _as_cute(compile_shared)
+
+            self._dynamic = compile_kernel(
+                (self.max_m, self.shard_dim, self.latent_dim, 1),
+                compile_latent_c,
+                compile_weight_c,
+                self._mailbox_c,
+                compile_shared_c,
+                self.hidden_dim,
+                self.shard_dim,
+                self.mma_tiler_mn,
+                self.cluster_shape_mn,
+                self._max_active_clusters,
+                self.b_prime_stages,
+            )
+
+    def compile_skinny(self, m: int) -> None:
+        if not 1 <= m <= self.skinny_max_m:
+            raise ValueError(
+                f"Skinny up-projection requires M in [1, {self.skinny_max_m}]."
+            )
+        if m in self._skinny_by_m:
+            return
+        with torch.accelerator.device_index(self._device.index):
+            self._skinny_by_m[m] = FusedAddMulticastSkinnyGemmKernel(
+                rank=self.rank,
+                tp_size=self.tp_size,
+                latent_dim=self.latent_dim,
+                hidden_dim=self.hidden_dim,
+                num_rows=m,
+            )
+
+    def ensure_compiled(self, m: int) -> None:
+        if not 1 <= m <= self.max_m:
+            raise ValueError(f"runtime M={m} must be in [1, {self.max_m}]")
+        if m <= self.skinny_max_m:
+            self.compile_skinny(m)
+        else:
+            self.compile_dynamic()
+
+    def __call__(
+        self,
+        latent: torch.Tensor,
+        weight: torch.Tensor,
+        shared_shard: torch.Tensor,
+    ) -> torch.Tensor:
+        if latent.ndim != 2:
+            raise ValueError("latent must be rank-2")
+        m = latent.shape[0]
+        device = self._mailbox.device
+        expected = (
+            (latent, (m, self.latent_dim), "latent"),
+            (
+                weight,
+                (self.shard_dim, self.latent_dim),
+                "weight",
+            ),
+            (
+                shared_shard,
+                (self.max_m, self.shard_dim),
+                "shared_shard",
+            ),
+        )
+        for tensor, shape, name in expected:
+            if (
+                tensor.shape != shape
+                or tensor.dtype != torch.bfloat16
+                or tensor.device != device
+            ):
+                raise ValueError(f"{name} must be CUDA torch.bfloat16 {list(shape)}")
+        if (
+            not latent.is_contiguous()
+            or not weight.is_contiguous()
+            or shared_shard.stride() != (self.hidden_dim, 1)
+        ):
+            raise ValueError("up-projection inputs have unsupported strides")
+        if not 1 <= m <= self.max_m:
+            raise ValueError(f"runtime M={m} must be in [1, {self.max_m}]")
+
+        if m <= self.skinny_max_m:
+            skinny = self._skinny_by_m.get(m)
+            if skinny is None:
+                raise RuntimeError(
+                    f"Skinny up-projection M={m} was not compiled before launch."
+                )
+            return skinny(
+                latent,
+                weight,
+                shared_shard,
+                self._mailbox,
+                self._mailbox_multicast_ptr,
+            )
+
+        if self._dynamic is None:
+            raise RuntimeError("Dynamic up-projection was not compiled before launch.")
+        with torch.accelerator.device_index(device.index):
+            stream = cuda.CUstream(torch.cuda.current_stream(device).cuda_stream)
+            self._dynamic(
+                _as_cute(latent.unsqueeze(0), dynamic_m=True),
+                _as_cute(weight.unsqueeze(0)),
+                self._mailbox_c,
+                _as_cute(shared_shard),
+                cutlass.Int64(m),
+                cutlass.Int64(
+                    self._mailbox_multicast_ptr + self.rank * self.shard_dim * 2
+                ),
+                stream,
+            )
+        return self._mailbox

--- a/vllm/models/kimi_k3/nvidia/ops/cute_dsl/latent_moe_tail/fused_add_multicast_skinny_gemm.py
+++ b/vllm/models/kimi_k3/nvidia/ops/cute_dsl/latent_moe_tail/fused_add_multicast_skinny_gemm.py
@@ -1,0 +1,438 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Static-M SIMT skinny GEMM with a shared-add multicast epilogue."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import torch
+from cutlass import BFloat16, Float32, Int64, const_expr
+from cutlass.cute.runtime import from_dlpack
+
+from .primitives import (
+    CUDAGraphCompatibleWrapper,
+    bf16x2_to_u32,
+    bf16x4_to_packed_u32x2,
+    bf16x8_to_packed_u32x4,
+    sanitize_negative_zero,
+    sanitize_negative_zero_u32,
+    sanitize_negative_zero_u32x2,
+    store_global_u32,
+    store_global_u32x2,
+    store_global_u32x4,
+)
+
+
+@dataclass(frozen=True)
+class SkinnyConfig:
+    block_size: int = 224
+    outputs_per_block: int = 2
+    k_unroll: int = 2
+    vector_width: int = 8
+    prefetch_b_before_pdl: bool = True
+
+
+def config_for_m(num_rows: int, shard_dim: int = 896) -> SkinnyConfig:
+    if shard_dim == 448:
+        if num_rows >= 6:
+            return SkinnyConfig(
+                block_size=224,
+                outputs_per_block=2,
+                k_unroll=1,
+            )
+        outputs_per_block = 2 if num_rows <= 3 else 4
+        return SkinnyConfig(
+            block_size=448,
+            outputs_per_block=outputs_per_block,
+            k_unroll=1,
+        )
+    if num_rows == 1:
+        return SkinnyConfig(outputs_per_block=8, k_unroll=1)
+    return SkinnyConfig(outputs_per_block=4)
+
+
+def _as_cute(tensor: torch.Tensor):
+    return from_dlpack(
+        CUDAGraphCompatibleWrapper(tensor.detach()),
+        assumed_align=16,
+    )
+
+
+class FusedAddMulticastSkinnyGemm:
+    """SIMT GEMM adapted from the existing Skinny GEMM."""
+
+    def __init__(
+        self,
+        *,
+        num_rows: int,
+        hidden_dim: int,
+        config: SkinnyConfig,
+    ) -> None:
+        if config.block_size % 32:
+            raise ValueError("skinny block_size must be a multiple of 32")
+        self.num_rows = num_rows
+        self.hidden_dim = hidden_dim
+        self.block_size = config.block_size
+        self.outputs_per_block = config.outputs_per_block
+        self.k_unroll = config.k_unroll
+        self.vector_width = config.vector_width
+        self.prefetch_b_before_pdl = config.prefetch_b_before_pdl
+        self.num_warps = config.block_size // 32
+
+    @cute.jit
+    def __call__(
+        self,
+        gA: cute.Tensor,
+        gB: cute.Tensor,
+        gShared: cute.Tensor,
+        output_multicast_ptr: Int64,
+        stream: cuda.CUstream,
+    ) -> None:
+        n = cute.size(gB, mode=[0])
+        k = cute.size(gA, mode=[1])
+        copy_a = cute.make_copy_atom(
+            cute.nvgpu.CopyG2ROp(),
+            BFloat16,
+            num_bits_per_copy=self.vector_width * BFloat16.width,
+            load_cache_mode=cute.nvgpu.LoadCacheMode.ALWAYS,
+        )
+        copy_b = cute.make_copy_atom(
+            cute.nvgpu.CopyG2ROp(),
+            BFloat16,
+            num_bits_per_copy=self.vector_width * BFloat16.width,
+            load_cache_mode=cute.nvgpu.LoadCacheMode.STREAMING,
+        )
+        self.kernel(
+            gA,
+            gB,
+            gShared,
+            output_multicast_ptr,
+            k,
+            copy_a,
+            copy_b,
+        ).launch(
+            grid=[cute.ceil_div(n, self.outputs_per_block), 1, 1],
+            block=[self.block_size, 1, 1],
+            smem=(self.num_rows * self.outputs_per_block * self.num_warps * 4),
+            stream=stream,
+            use_pdl=True,
+            min_blocks_per_mp=1,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        gA: cute.Tensor,
+        gB: cute.Tensor,
+        gShared: cute.Tensor,
+        output_multicast_ptr: Int64,
+        k_extent: cutlass.Int32,
+        copy_a: cute.CopyAtom,
+        copy_b: cute.CopyAtom,
+    ) -> None:
+        tidx, _, _ = cute.arch.thread_idx()
+        block_idx, _, _ = cute.arch.block_idx()
+        warp_idx = cute.arch.warp_idx()
+
+        outputs_per_block: cutlass.Constexpr = self.outputs_per_block
+        vector_width: cutlass.Constexpr = self.vector_width
+        block_size: cutlass.Constexpr = self.block_size
+        num_warps: cutlass.Constexpr = self.num_warps
+        num_rows: cutlass.Constexpr = self.num_rows
+
+        acc = cute.make_rmem_tensor(
+            cute.make_layout(
+                (num_rows, outputs_per_block),
+                stride=(outputs_per_block, 1),
+            ),
+            Float32,
+        )
+        acc.fill(0.0)
+
+        n_base = block_idx * outputs_per_block
+        k_tile_size: cutlass.Constexpr = block_size * vector_width
+        num_k_tiles = k_extent // k_tile_size
+        gA_vec = cute.logical_divide(gA, (None, vector_width))
+        gB_vec = cute.logical_divide(gB, (None, vector_width))
+        tA_all = cute.logical_divide(gA_vec, (None, (None, block_size)))
+        tB_all = cute.logical_divide(gB_vec, (None, (None, block_size)))
+        tA = tA_all[None, (None, (tidx, None))]
+
+        a_regs = cute.make_rmem_tensor(
+            cute.make_layout(
+                (num_rows, vector_width),
+                stride=(vector_width, 1),
+            ),
+            BFloat16,
+        )
+        b_regs = cute.make_rmem_tensor(
+            cute.make_layout(
+                (outputs_per_block, vector_width),
+                stride=(vector_width, 1),
+            ),
+            BFloat16,
+        )
+
+        if const_expr(self.prefetch_b_before_pdl):
+            for ni in cutlass.range_constexpr(outputs_per_block):
+                tB = tB_all[n_base + ni, (None, (tidx, None))]
+                cute.copy(copy_b, tB[None, 0], b_regs[ni, None])
+
+        cute.arch.griddepcontrol_wait()
+
+        for mi in cutlass.range_constexpr(num_rows):
+            cute.copy(copy_a, tA[mi, None, 0], a_regs[mi, None])
+        if const_expr(not self.prefetch_b_before_pdl):
+            for ni in cutlass.range_constexpr(outputs_per_block):
+                tB = tB_all[n_base + ni, (None, (tidx, None))]
+                cute.copy(copy_b, tB[None, 0], b_regs[ni, None])
+        for vi in cutlass.range_constexpr(vector_width):
+            for mi in cutlass.range_constexpr(num_rows):
+                for ni in cutlass.range_constexpr(outputs_per_block):
+                    acc[mi, ni] = acc[mi, ni] + a_regs[mi, vi].to(Float32) * b_regs[
+                        ni, vi
+                    ].to(Float32)
+
+        for k_tile in cutlass.range(1, num_k_tiles, unroll=self.k_unroll):
+            for mi in cutlass.range_constexpr(num_rows):
+                cute.copy(
+                    copy_a,
+                    tA[mi, None, k_tile],
+                    a_regs[mi, None],
+                )
+            for ni in cutlass.range_constexpr(outputs_per_block):
+                tB = tB_all[n_base + ni, (None, (tidx, None))]
+                cute.copy(copy_b, tB[None, k_tile], b_regs[ni, None])
+            for vi in cutlass.range_constexpr(vector_width):
+                for mi in cutlass.range_constexpr(num_rows):
+                    for ni in cutlass.range_constexpr(outputs_per_block):
+                        acc[mi, ni] = acc[mi, ni] + a_regs[mi, vi].to(Float32) * b_regs[
+                            ni, vi
+                        ].to(Float32)
+
+        for mi in cutlass.range_constexpr(num_rows):
+            for ni in cutlass.range_constexpr(outputs_per_block):
+                acc[mi, ni] = cute.arch.warp_reduction_sum(acc[mi, ni])
+
+        smem_layout = cute.make_layout(
+            (num_rows, outputs_per_block, num_warps),
+            stride=(outputs_per_block * num_warps, num_warps, 1),
+        )
+        smem = cutlass.utils.SmemAllocator()
+        partials = smem.allocate_tensor(
+            Float32,
+            smem_layout,
+            byte_alignment=16,
+        )
+        with cute.arch.elect_one():
+            for mi in cutlass.range_constexpr(num_rows):
+                for ni in cutlass.range_constexpr(outputs_per_block):
+                    partials[mi, ni, warp_idx] = acc[mi, ni]
+
+        cute.arch.sync_threads()
+        if tidx == 0:
+            fused = cute.make_rmem_tensor(
+                cute.make_layout((outputs_per_block,)),
+                BFloat16,
+            )
+            for mi in cutlass.range_constexpr(num_rows):
+                for ni in cutlass.range_constexpr(outputs_per_block):
+                    total = (
+                        partials[mi, ni, None]
+                        .load()
+                        .reduce(
+                            cute.ReductionOp.ADD,
+                            init_val=Float32(0.0),
+                            reduction_profile=0,
+                        )
+                    )
+                    gemm_value = Float32(total).to(BFloat16)
+                    fused[ni] = (
+                        gemm_value.to(Float32) + gShared[mi, n_base + ni].to(Float32)
+                    ).to(BFloat16)
+                output_offset = Int64((mi * self.hidden_dim + n_base) * 2)
+                if const_expr(outputs_per_block == 2):
+                    packed = sanitize_negative_zero_u32(bf16x2_to_u32(fused.load()))
+                    store_global_u32(
+                        output_multicast_ptr + output_offset,
+                        packed,
+                    )
+                elif const_expr(outputs_per_block == 4):
+                    packed = sanitize_negative_zero_u32x2(
+                        bf16x4_to_packed_u32x2(fused.load())
+                    )
+                    store_global_u32x2(
+                        output_multicast_ptr + output_offset,
+                        packed,
+                    )
+                else:
+                    packed = sanitize_negative_zero(
+                        bf16x8_to_packed_u32x4(fused.load())
+                    )
+                    store_global_u32x4(
+                        output_multicast_ptr + output_offset,
+                        packed,
+                    )
+
+        cute.arch.griddepcontrol_launch_dependents()
+
+
+_COMPILED: dict[tuple[object, ...], object] = {}
+
+
+def compile_kernel(
+    *,
+    num_rows: int,
+    latent_dim: int,
+    hidden_dim: int,
+    shard_dim: int,
+    config: SkinnyConfig,
+):
+    key = (
+        torch.accelerator.current_device_index(),
+        num_rows,
+        latent_dim,
+        hidden_dim,
+        shard_dim,
+        config,
+    )
+    if key in _COMPILED:
+        return _COMPILED[key]
+
+    from cutlass.cute.runtime import make_fake_stream, make_fake_tensor
+
+    if shard_dim % config.outputs_per_block:
+        raise ValueError("shard_dim must be divisible by outputs_per_block")
+    if latent_dim % (config.block_size * config.vector_width):
+        raise ValueError("latent_dim must be divisible by block_size * vector_width")
+
+    a = make_fake_tensor(
+        BFloat16,
+        (num_rows, latent_dim),
+        stride=(latent_dim, 1),
+        assumed_align=16,
+    )
+    b = make_fake_tensor(
+        BFloat16,
+        (shard_dim, latent_dim),
+        stride=(latent_dim, 1),
+        assumed_align=16,
+    )
+    shared = make_fake_tensor(
+        BFloat16,
+        (num_rows, shard_dim),
+        stride=(hidden_dim, 1),
+        assumed_align=16,
+    )
+    compiled = cute.compile(
+        FusedAddMulticastSkinnyGemm(
+            num_rows=num_rows,
+            hidden_dim=hidden_dim,
+            config=config,
+        ),
+        a,
+        b,
+        shared,
+        Int64(0),
+        make_fake_stream(),
+        options="--ptxas-options -maxrregcount=128",
+    )
+    _COMPILED[key] = compiled
+    return compiled
+
+
+class FusedAddMulticastSkinnyGemmKernel:
+    """Buffer-free compiled launcher for one static M."""
+
+    def __init__(
+        self,
+        *,
+        rank: int,
+        tp_size: int,
+        latent_dim: int,
+        hidden_dim: int,
+        num_rows: int,
+    ) -> None:
+        if not 1 <= num_rows <= 8:
+            raise ValueError("skinny backend requires static M in [1, 8]")
+        if hidden_dim % tp_size:
+            raise ValueError("hidden_dim must be divisible by TP size")
+        self.rank = rank
+        self.latent_dim = latent_dim
+        self.hidden_dim = hidden_dim
+        self.shard_dim = hidden_dim // tp_size
+        self.num_rows = num_rows
+        self._skinny = compile_kernel(
+            num_rows=num_rows,
+            latent_dim=latent_dim,
+            hidden_dim=hidden_dim,
+            shard_dim=self.shard_dim,
+            config=config_for_m(num_rows, self.shard_dim),
+        )
+
+    def __call__(
+        self,
+        latent: torch.Tensor,
+        weight: torch.Tensor,
+        shared_shard: torch.Tensor,
+        mailbox: torch.Tensor,
+        mailbox_multicast_ptr: int,
+    ) -> torch.Tensor:
+        device = mailbox.device
+        expected = (
+            (
+                latent,
+                (self.num_rows, self.latent_dim),
+                torch.bfloat16,
+                "latent",
+            ),
+            (
+                weight,
+                (self.shard_dim, self.latent_dim),
+                torch.bfloat16,
+                "weight",
+            ),
+            (
+                shared_shard,
+                (mailbox.shape[1], self.shard_dim),
+                torch.bfloat16,
+                "shared_shard",
+            ),
+            (
+                mailbox,
+                (1, mailbox.shape[1], self.hidden_dim),
+                torch.bfloat16,
+                "mailbox",
+            ),
+        )
+        for tensor, shape, dtype, name in expected:
+            if (
+                tensor.shape != shape
+                or tensor.dtype != dtype
+                or tensor.device != device
+            ):
+                raise ValueError(f"{name} must be CUDA {dtype} {list(shape)}")
+        if (
+            not latent.is_contiguous()
+            or not weight.is_contiguous()
+            or shared_shard.stride() != (self.hidden_dim, 1)
+            or not mailbox.is_contiguous()
+        ):
+            raise ValueError("skinny up-projection inputs have unsupported strides")
+        if mailbox.shape[1] < self.num_rows:
+            raise ValueError("mailbox capacity is smaller than runtime M")
+
+        with torch.accelerator.device_index(device.index):
+            self._skinny(
+                _as_cute(latent),
+                _as_cute(weight),
+                _as_cute(shared_shard[: self.num_rows]),
+                Int64(mailbox_multicast_ptr + self.rank * self.shard_dim * 2),
+                cuda.CUstream(torch.cuda.current_stream(device).cuda_stream),
+            )
+        return mailbox

--- a/vllm/models/kimi_k3/nvidia/ops/cute_dsl/latent_moe_tail/lamport_copy.py
+++ b/vllm/models/kimi_k3/nvidia/ops/cute_dsl/latent_moe_tail/lamport_copy.py
@@ -1,0 +1,226 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Lamport mailbox-to-local copy and reset."""
+
+from __future__ import annotations
+
+import functools
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import torch
+from cutlass.cute.runtime import make_fake_compact_tensor, make_fake_stream
+
+from .primitives import (
+    VEC_BF16,
+    fragment_is_dirty,
+    load_global_u32x4,
+    store_global_u32x4,
+    store_lamport_sentinel_128,
+    to_cute,
+    to_cute_dynamic_m,
+)
+
+
+class LamportCopy:
+    """Consume the local physical copy of an NVLS-multicast mailbox."""
+
+    def __init__(self, hidden_dim: int, ctas: int, threads: int):
+        self.hidden_dim = hidden_dim
+        self.ctas = ctas
+        self.threads = threads
+
+    @cute.jit
+    def __call__(
+        self,
+        symmetric_mailbox: cute.Tensor,
+        local_output: cute.Tensor,
+        m: cutlass.Int32,
+        stream: cuda.CUstream,
+    ):
+        self.kernel(symmetric_mailbox, local_output, m).launch(
+            grid=(self.ctas, 1, 1),
+            block=(self.threads, 1, 1),
+            stream=stream,
+            use_pdl=True,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        symmetric_mailbox: cute.Tensor,
+        local_output: cute.Tensor,
+        m: cutlass.Int32,
+    ):
+        # The CTA may be scheduled early, but mailbox inspection must not pass
+        # the producer GEMM's programmatic completion point.
+        cute.arch.griddepcontrol_wait()
+
+        tidx, _, _ = cute.arch.thread_idx()
+        block, _, _ = cute.arch.block_idx()
+        thread = cutlass.Int64(block * self.threads + tidx)
+        stride = cutlass.Int64(self.ctas * self.threads)
+        fragments = cutlass.Int64(m) * cutlass.Int64(self.hidden_dim // VEC_BF16)
+
+        fragment = thread
+        while fragment < fragments:
+            element = fragment * VEC_BF16
+            source = cute.make_ptr(
+                cutlass.BFloat16,
+                (symmetric_mailbox.iterator + element).llvm_ptr,
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            )
+            packed = load_global_u32x4(source, volatile=True)
+            while fragment_is_dirty(packed):
+                packed = load_global_u32x4(source, volatile=True)
+
+            destination = cutlass.Int64((local_output.iterator + element).toint())
+            store_global_u32x4(destination, packed, volatile=False)
+            fragment = fragment + stride
+
+        # The returned ordinary tensor is complete. A same-stream successor
+        # may overlap the mailbox cleanup below.
+        cute.arch.griddepcontrol_launch_dependents()
+
+        fragment = thread
+        while fragment < fragments:
+            element = fragment * VEC_BF16
+            source = cute.make_ptr(
+                cutlass.BFloat16,
+                (symmetric_mailbox.iterator + element).llvm_ptr,
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            )
+            store_lamport_sentinel_128(source)
+            fragment = fragment + stride
+
+
+@functools.cache
+def compile_kernel(
+    hidden_dim: int,
+    max_m: int,
+    ctas: int,
+    threads: int,
+    device_index: int,
+):
+    if hidden_dim <= 0 or hidden_dim % VEC_BF16:
+        raise ValueError("hidden_dim must be a positive multiple of 8")
+    if max_m <= 0:
+        raise ValueError("max_m must be positive")
+    if ctas <= 0:
+        raise ValueError("Lamport copy ctas must be positive")
+    if not 1 <= threads <= 1024:
+        raise ValueError("Lamport copy threads must be in [1, 1024]")
+    with torch.accelerator.device_index(device_index):
+        mailbox = make_fake_compact_tensor(
+            cutlass.BFloat16, (max_m * hidden_dim,), assumed_align=16
+        )
+        output = make_fake_compact_tensor(
+            cutlass.BFloat16,
+            (cute.sym_int32(divisibility=VEC_BF16),),
+            assumed_align=16,
+        )
+        return cute.compile(
+            LamportCopy(hidden_dim, ctas, threads),
+            mailbox,
+            output,
+            cutlass.Int32(max_m),
+            make_fake_stream(),
+        )
+
+
+def launch(
+    symmetric_mailbox: torch.Tensor,
+    local_output: torch.Tensor,
+    *,
+    m: int,
+    hidden_dim: int,
+    max_m: int,
+    ctas: int,
+    threads: int,
+) -> None:
+    if not 1 <= m <= max_m:
+        raise ValueError(f"runtime M={m} must be in [1, {max_m}]")
+    if (
+        symmetric_mailbox.ndim != 3
+        or symmetric_mailbox.dtype != torch.bfloat16
+        or not symmetric_mailbox.is_cuda
+        or not symmetric_mailbox.is_contiguous()
+        or symmetric_mailbox.shape[0] != 1
+        or symmetric_mailbox.shape[2] != hidden_dim
+    ):
+        raise ValueError(
+            f"symmetric_mailbox must be contiguous CUDA BF16 [1,M,{hidden_dim}]"
+        )
+    if symmetric_mailbox.shape[1] != max_m:
+        raise ValueError("symmetric mailbox must retain its full max_m capacity")
+    if (
+        local_output.shape != (1, m, hidden_dim)
+        or local_output.dtype != torch.bfloat16
+        or local_output.device != symmetric_mailbox.device
+        or not local_output.is_contiguous()
+    ):
+        raise ValueError("local_output must be contiguous CUDA BF16 [1,M,H]")
+
+    device_index = symmetric_mailbox.device.index
+    stream = cuda.CUstream(
+        torch.cuda.current_stream(symmetric_mailbox.device).cuda_stream
+    )
+    compile_kernel(hidden_dim, max_m, ctas, threads, device_index)(
+        to_cute(symmetric_mailbox.flatten(), 16),
+        to_cute_dynamic_m(
+            local_output.flatten(),
+            mode=0,
+            assumed_align=16,
+        ),
+        cutlass.Int32(m),
+        stream,
+    )
+
+
+class LamportCopyKernel:
+    """Copy a borrowed symmetric mailbox into a fresh local tensor."""
+
+    def __init__(
+        self,
+        *,
+        hidden_dim: int,
+        max_m: int,
+        ctas: int,
+        threads: int,
+    ) -> None:
+        self.hidden_dim = hidden_dim
+        self.max_m = max_m
+        self.ctas = ctas
+        self.threads = threads
+        compile_kernel(
+            hidden_dim,
+            max_m,
+            ctas,
+            threads,
+            torch.accelerator.current_device_index(),
+        )
+
+    def __call__(self, symmetric_mailbox: torch.Tensor, *, m: int) -> torch.Tensor:
+        if not symmetric_mailbox.is_cuda:
+            raise ValueError("symmetric_mailbox must be a CUDA tensor")
+        device = symmetric_mailbox.device
+        with torch.accelerator.device_index(device.index):
+            output = torch.empty(
+                (1, m, self.hidden_dim),
+                dtype=torch.bfloat16,
+                device=device,
+            )
+            launch(
+                symmetric_mailbox,
+                output,
+                m=m,
+                hidden_dim=self.hidden_dim,
+                max_m=self.max_m,
+                ctas=self.ctas,
+                threads=self.threads,
+            )
+        return output

--- a/vllm/models/kimi_k3/nvidia/ops/cute_dsl/latent_moe_tail/primitives.py
+++ b/vllm/models/kimi_k3/nvidia/ops/cute_dsl/latent_moe_tail/primitives.py
@@ -1,0 +1,437 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Shared CuTe DSL primitives; this module does not define a CUDA kernel."""
+
+from __future__ import annotations
+
+import cutlass
+import cutlass.cute as cute
+import torch
+from cutlass import BFloat16, Float32, Int32, Int64, Uint16, Uint32
+from cutlass._mlir import ir
+from cutlass._mlir.dialects import llvm, vector
+from cutlass.cute.runtime import from_dlpack
+from cutlass.cutlass_dsl import T, dsl_user_op
+
+VEC_BF16 = 8
+PACKED_BYTES = 16
+NUM_LAMPORT_BUFFERS = 3
+NEG_ZERO_F32_BITS = 0x80000000
+NEG_ZERO_BF16_BITS = 0x8000
+
+
+class CUDAGraphCompatibleWrapper:
+    """DLPack view that does not synchronize with the producer stream."""
+
+    def __init__(self, tensor: torch.Tensor):
+        self.tensor = tensor
+
+    def __dlpack__(self, stream=None):
+        return self.tensor.__dlpack__(stream=-1)
+
+    def __dlpack_device__(self):
+        return self.tensor.__dlpack_device__()
+
+
+def to_cute(tensor: torch.Tensor, assumed_align: int = 16) -> cute.Tensor:
+    return from_dlpack(
+        CUDAGraphCompatibleWrapper(tensor.detach()), assumed_align=assumed_align
+    )
+
+
+def to_cute_dynamic_m(
+    tensor: torch.Tensor,
+    *,
+    mode: int,
+    assumed_align: int = 16,
+) -> cute.Tensor:
+    """Expose exactly one compact tensor mode as a runtime shape.
+
+    Model dimensions remain part of the compiled tensor type. Only the token
+    mode is symbolic, so changing M within an Op's capacity reuses the same
+    compiled kernel.
+    """
+
+    return to_cute(tensor, assumed_align).mark_compact_shape_dynamic(
+        mode=mode,
+        stride_order=tensor.dim_order(),
+    )
+
+
+@dsl_user_op
+def load_global_u32x4(
+    pointer: cute.Pointer,
+    *,
+    volatile: cutlass.Constexpr[bool] = False,
+    loc=None,
+    ip=None,
+):
+    """Load one 128-bit fragment as four u32 registers.
+
+    The volatile form is the Lamport polling load.  Marking the asm
+    side-effecting prevents loop-invariant motion and common-subexpression
+    elimination across polling iterations.
+    """
+
+    address = pointer.toint(loc=loc, ip=ip)
+    opcode = "ld.volatile.global.v4.u32" if volatile else "ld.global.v4.u32"
+    out = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32()] * 4),
+        [address.ir_value(loc=loc, ip=ip)],
+        f"{opcode} {{$0, $1, $2, $3}}, [$4];",
+        "=r,=r,=r,=r,l",
+        has_side_effects=volatile,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    packed = vector.from_elements(
+        ir.VectorType.get([4], T.i32(), loc=loc),
+        [llvm.extractvalue(T.i32(), out, [i], loc=loc, ip=ip) for i in range(4)],
+        loc=loc,
+        ip=ip,
+    )
+    return cute.TensorSSA(packed, 4, Uint32)
+
+
+@dsl_user_op
+def store_global_u32x4(
+    address: Int64,
+    packed,
+    *,
+    volatile: cutlass.Constexpr[bool] = False,
+    loc=None,
+    ip=None,
+) -> None:
+    """Store four packed words to an ordinary or NVLS multicast global VA."""
+
+    words = [packed[i].ir_value(loc=loc, ip=ip) for i in range(4)]
+    opcode = "st.volatile.global.v4.u32" if volatile else "st.global.v4.u32"
+    llvm.inline_asm(
+        None,
+        [address.ir_value(loc=loc, ip=ip), *words],
+        f"{opcode} [$0], {{$1, $2, $3, $4}};",
+        "l,r,r,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def store_global_u32x2(
+    address: Int64,
+    packed,
+    *,
+    loc=None,
+    ip=None,
+) -> None:
+    words = [packed[i].ir_value(loc=loc, ip=ip) for i in range(2)]
+    llvm.inline_asm(
+        None,
+        [address.ir_value(loc=loc, ip=ip), *words],
+        "st.global.v2.u32 [$0], {$1, $2};",
+        "l,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def store_global_u32(
+    address: Int64,
+    word: Uint32,
+    *,
+    loc=None,
+    ip=None,
+) -> None:
+    llvm.inline_asm(
+        None,
+        [
+            address.ir_value(loc=loc, ip=ip),
+            word.ir_value(loc=loc, ip=ip),
+        ],
+        "st.global.u32 [$0], $1;",
+        "l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def store_lamport_sentinel_128(pointer: cute.Pointer, *, loc=None, ip=None) -> None:
+    """Reset one Lamport fragment to four FP32 negative-zero bit patterns."""
+
+    address = pointer.toint(loc=loc, ip=ip)
+    value = Uint32(NEG_ZERO_F32_BITS).ir_value(loc=loc, ip=ip)
+    llvm.inline_asm(
+        None,
+        [address.ir_value(loc=loc, ip=ip), value, value, value, value],
+        "st.global.v4.u32 [$0], {$1, $2, $3, $4};",
+        "l,r,r,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def red_async_release_gpu_add_u32(
+    pointer: cute.Pointer, value: Uint32, *, loc=None, ip=None
+) -> None:
+    """The exact SM100 arrival primitive used by upstream LamportFlags."""
+
+    address = pointer.toint(loc=loc, ip=ip)
+    llvm.inline_asm(
+        None,
+        [
+            address.ir_value(loc=loc, ip=ip),
+            value.ir_value(loc=loc, ip=ip),
+        ],
+        "red.async.release.global.gpu.add.u32 [$0], $1;",
+        "l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def load_volatile_u32(pointer: cute.Pointer, *, loc=None, ip=None) -> Uint32:
+    address = pointer.toint(loc=loc, ip=ip)
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [address.ir_value(loc=loc, ip=ip)],
+            "ld.volatile.global.u32 $0, [$1];",
+            "=r,l",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def map_shared_to_peer(
+    smem_ptr: cute.Pointer,
+    peer_rank: Int32,
+    *,
+    loc=None,
+    ip=None,
+) -> Int32:
+    """Map a local shared-memory slot to the same slot in a peer CTA."""
+
+    smem_address = smem_ptr.toint(loc=loc, ip=ip).ir_value()
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [smem_address, peer_rank.ir_value(loc=loc, ip=ip)],
+            "mapa.shared::cluster.u32 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def store_shared_cluster_f32(
+    remote_address: Int32,
+    value: Float32,
+    *,
+    loc=None,
+    ip=None,
+) -> None:
+    llvm.inline_asm(
+        None,
+        [
+            remote_address.ir_value(loc=loc, ip=ip),
+            value.ir_value(loc=loc, ip=ip),
+        ],
+        "st.shared::cluster.f32 [$0], $1;",
+        "r,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def packed_u32x4_to_bf16x8(packed, *, loc=None, ip=None):
+    target_type = ir.VectorType.get([VEC_BF16], BFloat16.mlir_type, loc=loc)
+    values = llvm.bitcast(
+        target_type,
+        packed.ir_value(loc=loc, ip=ip),
+        loc=loc,
+        ip=ip,
+    )
+    return cute.TensorSSA(values, VEC_BF16, BFloat16)
+
+
+@dsl_user_op
+def bf16x8_to_packed_u32x4(values, *, loc=None, ip=None):
+    target_type = ir.VectorType.get([4], T.i32(), loc=loc)
+    packed = llvm.bitcast(
+        target_type,
+        values.ir_value(loc=loc, ip=ip),
+        loc=loc,
+        ip=ip,
+    )
+    return cute.TensorSSA(packed, 4, Uint32)
+
+
+@dsl_user_op
+def bf16x4_to_packed_u32x2(values, *, loc=None, ip=None):
+    target_type = ir.VectorType.get([2], T.i32(), loc=loc)
+    packed = llvm.bitcast(
+        target_type,
+        values.ir_value(loc=loc, ip=ip),
+        loc=loc,
+        ip=ip,
+    )
+    return cute.TensorSSA(packed, 2, Uint32)
+
+
+@dsl_user_op
+def bf16x2_to_u32(values, *, loc=None, ip=None):
+    packed = llvm.bitcast(
+        T.i32(),
+        values.ir_value(loc=loc, ip=ip),
+        loc=loc,
+        ip=ip,
+    )
+    return Uint32(packed)
+
+
+@cute.jit
+def sanitize_negative_zero_u32(word):
+    low = Uint16(word & Uint32(0xFFFF))
+    high = Uint16(word >> Uint32(16))
+    if low == Uint16(NEG_ZERO_BF16_BITS):
+        word = word & Uint32(0xFFFF0000)
+    if high == Uint16(NEG_ZERO_BF16_BITS):
+        word = word & Uint32(0x0000FFFF)
+    return word
+
+
+@cute.jit
+def sanitize_negative_zero_u32x2(packed):
+    result = cute.make_rmem_tensor(cute.make_layout((2,)), Uint32)
+    for i in cutlass.range_constexpr(2):
+        result[i] = sanitize_negative_zero_u32(packed[i])
+    return result.load()
+
+
+@cute.jit
+def sanitize_negative_zero(packed):
+    """Turn real BF16 -0 into +0 so it cannot equal the empty sentinel."""
+
+    result = cute.make_rmem_tensor(cute.make_layout((4,)), Uint32)
+    for i in cutlass.range_constexpr(4):
+        word = packed[i]
+        low = Uint16(word & Uint32(0xFFFF))
+        high = Uint16(word >> Uint32(16))
+        if low == Uint16(NEG_ZERO_BF16_BITS):
+            word = word & Uint32(0xFFFF0000)
+        if high == Uint16(NEG_ZERO_BF16_BITS):
+            word = word & Uint32(0x0000FFFF)
+        result[i] = word
+    return result.load()
+
+
+@cute.jit
+def fragment_is_dirty(packed):
+    """Bit-exact upstream sentinel check: one comparison per 32-bit word."""
+
+    dirty = packed[0] == Uint32(NEG_ZERO_F32_BITS)
+    for i in cutlass.range_constexpr(1, 4):
+        dirty = dirty | (packed[i] == Uint32(NEG_ZERO_F32_BITS))
+    return dirty
+
+
+@cute.jit
+def warp_sum_specialized(
+    value: Float32,
+    warp_idx: Int32,
+    lane: Int32,
+    warps: cutlass.Constexpr[int],
+    last_warp_lanes: cutlass.Constexpr[int],
+    last_warp_mask: cutlass.Constexpr[int],
+) -> Float32:
+    """Warp sum supporting a compile-time partial final warp."""
+
+    if warp_idx == Int32(warps - 1) and cutlass.const_expr(last_warp_lanes < 32):
+        for offset in cutlass.range_constexpr(16, 0, -1):
+            # range_constexpr does not provide powers-of-two stepping.
+            if cutlass.const_expr(offset in (16, 8, 4, 2, 1)):
+                other = cute.arch.shuffle_sync_bfly(
+                    value,
+                    offset=offset,
+                    mask=last_warp_mask,
+                    mask_and_clamp=31,
+                )
+                if (lane ^ Int32(offset)) < Int32(last_warp_lanes):
+                    value = value + other
+    else:
+        for offset in cutlass.range_constexpr(16, 0, -1):
+            if cutlass.const_expr(offset in (16, 8, 4, 2, 1)):
+                value = value + cute.arch.shuffle_sync_bfly(
+                    value,
+                    offset=offset,
+                    mask=-1,
+                    mask_and_clamp=31,
+                )
+    return value
+
+
+@cute.jit
+def block_sum_specialized(
+    value: Float32,
+    warp_sums: cute.Tensor,
+    tidx: Int32,
+    warps: cutlass.Constexpr[int],
+    last_warp_lanes: cutlass.Constexpr[int],
+    last_warp_mask: cutlass.Constexpr[int],
+) -> Float32:
+    """Upstream-equivalent FP32 block reduction."""
+
+    lane = cute.arch.lane_idx()
+    warp_idx = cute.arch.warp_idx()
+    value = warp_sum_specialized(
+        value, warp_idx, lane, warps, last_warp_lanes, last_warp_mask
+    )
+    if lane == 0:
+        warp_sums[warp_idx] = value
+    cute.arch.barrier()
+
+    block_sum = Float32(0.0)
+    if warp_idx == 0:
+        if lane < Int32(warps):
+            block_sum = warp_sums[lane]
+        block_sum = cute.arch.warp_reduction_sum(block_sum)
+        if lane == 0:
+            warp_sums[0] = block_sum
+    cute.arch.barrier()
+    return warp_sums[0]

--- a/vllm/models/kimi_k3/nvidia/ops/latent_moe_tail.py
+++ b/vllm/models/kimi_k3/nvidia/ops/latent_moe_tail.py
@@ -1,0 +1,265 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from dataclasses import dataclass
+from functools import partial
+from typing import ClassVar
+
+import torch
+import torch.distributed as dist
+
+from vllm.distributed import get_tp_group
+from vllm.model_executor.warmup.cutedsl_warmup import (
+    CuTeDSLCompileUnit,
+    register_cutedsl_warmup_provider,
+)
+
+_MAX_NUM_TOKENS = 16
+_SKINNY_MAX_NUM_TOKENS = 5
+_MMA_TILER_MN = (64, 32)
+_GEMM_CLUSTER_MN = (1, 8)
+_B_PRIME_STAGES = 2
+_COLLECTIVE_TOKEN_CTAS = 8
+_LAMPORT_COPY_CTAS = 32
+_LAMPORT_COPY_THREADS = 224
+_SUPPORTED_TP_SIZES = (8, 16)
+
+
+@dataclass(frozen=True)
+class KimiK3LatentMoETailContract:
+    tp_group_id: int
+    tp_size: int
+    device: torch.device
+    dtype: torch.dtype
+    hidden_size: int
+    latent_size: int
+    max_num_tokens: int
+    rms_eps: float
+
+
+class KimiK3LatentMoETailOp:
+    """Process-wide cached K3 latent-MoE tail implementation."""
+
+    _instances: ClassVar[
+        dict[KimiK3LatentMoETailContract, "KimiK3LatentMoETailOp"]
+    ] = {}
+
+    @classmethod
+    def _contract_and_group(
+        cls,
+        *,
+        hidden_size: int,
+        latent_size: int,
+        dtype: torch.dtype,
+        device: torch.device,
+        rms_eps: float,
+    ) -> tuple[KimiK3LatentMoETailContract, dist.ProcessGroup]:
+        tp = get_tp_group()
+        group = tp.device_group
+        device = torch.device(device)
+        tp_device = torch.device(tp.device)
+        if device != tp_device:
+            raise ValueError(
+                f"Input device {device} does not match TP device {tp_device}."
+            )
+        return (
+            KimiK3LatentMoETailContract(
+                tp_group_id=id(group),
+                tp_size=dist.get_world_size(group),
+                device=device,
+                dtype=dtype,
+                hidden_size=hidden_size,
+                latent_size=latent_size,
+                max_num_tokens=_MAX_NUM_TOKENS,
+                rms_eps=float(rms_eps),
+            ),
+            group,
+        )
+
+    @classmethod
+    def initialize(
+        cls,
+        *,
+        hidden_size: int,
+        latent_size: int,
+        dtype: torch.dtype,
+        device: torch.device,
+        rms_eps: float,
+    ) -> "KimiK3LatentMoETailOp":
+        contract, group = cls._contract_and_group(
+            hidden_size=hidden_size,
+            latent_size=latent_size,
+            dtype=dtype,
+            device=device,
+            rms_eps=rms_eps,
+        )
+        op = cls._instances.get(contract)
+        if op is None:
+            op = cls(contract, group)
+            cls._instances[contract] = op
+        return op
+
+    def __init__(
+        self,
+        contract: KimiK3LatentMoETailContract,
+        group: dist.ProcessGroup,
+    ) -> None:
+        if contract.tp_size not in _SUPPORTED_TP_SIZES:
+            raise ValueError(
+                "K3 latent-MoE tail fusion requires TP in "
+                f"{_SUPPORTED_TP_SIZES}, got {contract.tp_size}."
+            )
+        if contract.device.type != "cuda":
+            raise ValueError("K3 latent-MoE tail fusion requires a CUDA device.")
+        if torch.cuda.get_device_capability(contract.device)[0] != 10:
+            raise ValueError("K3 latent-MoE tail fusion requires SM100.")
+        if contract.dtype != torch.bfloat16:
+            raise ValueError("K3 latent-MoE tail fusion requires bfloat16.")
+        if (contract.hidden_size, contract.latent_size) != (7168, 3584):
+            raise ValueError(
+                "K3 latent-MoE tail fusion requires hidden_size=7168 and "
+                "latent_size=3584."
+            )
+
+        self.contract = contract
+        self.rank = dist.get_rank(group)
+        from .cute_dsl.latent_moe_tail import (
+            AdaptiveUpProjectionKernel,
+            CollectiveKernel,
+            LamportCopyKernel,
+        )
+
+        with torch.accelerator.device_index(contract.device.index):
+            self._collective = CollectiveKernel(
+                group=group,
+                rank=self.rank,
+                tp_size=contract.tp_size,
+                latent_dim=contract.latent_size,
+                hidden_dim=contract.hidden_size,
+                max_m=contract.max_num_tokens,
+                max_token_ctas=_COLLECTIVE_TOKEN_CTAS,
+                rms_eps=contract.rms_eps,
+                fp32_internal=False,
+            )
+            self._up_projection = AdaptiveUpProjectionKernel(
+                group=group,
+                rank=self.rank,
+                tp_size=contract.tp_size,
+                latent_dim=contract.latent_size,
+                hidden_dim=contract.hidden_size,
+                max_m=contract.max_num_tokens,
+                skinny_max_m=_SKINNY_MAX_NUM_TOKENS,
+                mma_tiler_mn=_MMA_TILER_MN,
+                cluster_shape_mn=_GEMM_CLUSTER_MN,
+                b_prime_stages=_B_PRIME_STAGES,
+            )
+            self._lamport_copy = LamportCopyKernel(
+                hidden_dim=contract.hidden_size,
+                max_m=contract.max_num_tokens,
+                ctas=_LAMPORT_COPY_CTAS,
+                threads=_LAMPORT_COPY_THREADS,
+            )
+        register_cutedsl_warmup_provider(self)
+
+    def get_cutedsl_warmup_compile_units(self) -> tuple[CuTeDSLCompileUnit, ...]:
+        contract = self.contract
+        skinny_units = tuple(
+            CuTeDSLCompileUnit(
+                name="K3 latent MoE tail Skinny up-projection",
+                key=(
+                    "k3-latent-moe-tail-skinny-up-projection",
+                    contract,
+                    m,
+                ),
+                compile=partial(self._up_projection.compile_skinny, m),
+            )
+            for m in range(1, self._up_projection.skinny_max_m + 1)
+        )
+        return skinny_units + (
+            CuTeDSLCompileUnit(
+                name="K3 latent MoE tail dynamic up-projection",
+                key=(
+                    "k3-latent-moe-tail-dynamic-up-projection",
+                    contract,
+                    _MMA_TILER_MN,
+                    _GEMM_CLUSTER_MN,
+                    _B_PRIME_STAGES,
+                ),
+                compile=self._up_projection.compile_dynamic,
+            ),
+        )
+
+    def __call__(
+        self,
+        routed_output: torch.Tensor,
+        shared_output: torch.Tensor,
+        rms_weight: torch.Tensor,
+        up_weight: torch.Tensor,
+    ) -> torch.Tensor:
+        self._validate_inputs(
+            routed_output,
+            shared_output,
+            rms_weight,
+            up_weight,
+        )
+        self._up_projection.ensure_compiled(routed_output.shape[0])
+        latent, shared_shard = self._collective(
+            routed_output,
+            shared_output,
+            rms_weight,
+        )
+        local_hidden_size = self.contract.hidden_size // self.contract.tp_size
+        local_up_weight = up_weight.narrow(
+            0,
+            self.rank * local_hidden_size,
+            local_hidden_size,
+        )
+        mailbox = self._up_projection(
+            latent,
+            local_up_weight,
+            shared_shard,
+        )
+        return self._lamport_copy(
+            mailbox,
+            m=routed_output.shape[0],
+        ).squeeze(0)
+
+    def _validate_inputs(
+        self,
+        routed_output: torch.Tensor,
+        shared_output: torch.Tensor,
+        rms_weight: torch.Tensor,
+        up_weight: torch.Tensor,
+    ) -> None:
+        contract = self.contract
+        if routed_output.ndim != 2:
+            raise ValueError("routed_output must be a 2D tensor.")
+        num_tokens = routed_output.shape[0]
+        if routed_output.shape != (num_tokens, contract.latent_size):
+            raise ValueError(
+                f"routed_output must have shape [M, {contract.latent_size}]."
+            )
+        if shared_output.shape != (num_tokens, contract.hidden_size):
+            raise ValueError(
+                f"shared_output must have shape [M, {contract.hidden_size}]."
+            )
+        if rms_weight.shape != (contract.latent_size,):
+            raise ValueError(f"rms_weight must have shape [{contract.latent_size}].")
+        if up_weight.shape != (contract.hidden_size, contract.latent_size):
+            raise ValueError(
+                "up_weight must have shape "
+                f"[{contract.hidden_size}, {contract.latent_size}]."
+            )
+        if not 1 <= num_tokens <= contract.max_num_tokens:
+            raise ValueError(
+                "K3 latent-MoE tail fusion requires between 1 and "
+                f"{contract.max_num_tokens} tokens."
+            )
+
+        tensors = (routed_output, shared_output, rms_weight, up_weight)
+        if any(tensor.device != contract.device for tensor in tensors):
+            raise ValueError("All inputs must be on the contract device.")
+        if any(tensor.dtype != contract.dtype for tensor in tensors):
+            raise ValueError("All inputs must use the contract dtype.")
+        if any(not tensor.is_contiguous() for tensor in tensors):
+            raise ValueError("All inputs must be contiguous.")


### PR DESCRIPTION
## Purpose

Extends the existing fused-MoE stack with the pieces needed by latent-MoE
models, split out of the much larger Kimi K3 model PR
(https://github.com/vllm-project/vllm/pull/50000) so the MoE work can be
reviewed independently of the model, attention, tokenizer and parser changes.

Nothing here registers a new model. Every addition is either a new kernel, a
new opt-in code path, or plumbing for a new activation/routing mode; default
execution paths are unchanged.

### What's in it

Seven self-contained commits, reviewable in order:

1. **`[Kernel][MoE]` fused single-group top-k routing** — adds a dedicated
   path for the degenerate grouped-topk case (`n_group == 1 && topk_group == 1`),
   which is plain top-k over all experts. `invokeNoAuxTc` tries it first and
   falls back to the existing grouped kernels. Two kernels are dispatched from a
   compile-time `(num_experts, topk)` tier list: a block-per-token kernel with a
   hierarchical per-warp reduction for high expert counts, and a warp-per-token
   kernel for the large-batch case. `moeTopKFuncs.cuh` gains a generalized
   bitonic / odd-even-merge `Sort<N>` for any `N` in `[1, 64]` (was `N <= 4`, or
   a multiple of 4 up to 16), a `reduceTopKForLane` that leaves the k-th result
   in lane k instead of replicating all K results in every lane, and a
   `redux.sync.max.u32` warp reduction on SM100+.

2. **`[Kernel]` SituGLU (`situ_and_mul`)** — the gated activation used by Kimi
   models:

   ```
   gate_out = beta * tanh(gate / beta) * sigmoid(gate)
   up_out   = linear_beta * tanh(up / linear_beta)   # if linear_beta > 0
   out      = gate_out * up_out
   ```

   Adds the `SituAndMul` CustomOp plus two CUDA kernels: `situ_and_mul` for the
   dense `[..., 2 * d]` layout and `masked_situ_and_mul` for the batched
   `[E, T, 2 * d]` MoE layout, which reads `expert_num_tokens` and leaves padded
   rows untouched. Both accumulate in fp32 and write straight to the output
   buffer — the pure-torch fallback allocates ~8 fp32 temporaries per call,
   which is prohibitive inside a MoE layer.

3. **`[MoE]` wire SituGLU through fused MoE** — `MoEActivation.SITU` plus the
   `activation_situ_beta` / `activation_situ_linear_beta` parameters, plumbed
   from `FusedMoE(...)` through `FusedMoEConfig` to the experts.

   Declared supported on Marlin and DeepGEMM FP4 only (plus the TRTLLM-Gen
   backends in commit 5). Both betas reach the kernel from `FusedMoEConfig` on
   every one of those paths:

   - The Marlin helpers (`fused_marlin_moe`, `batched_fused_marlin_moe`,
     `_fused_marlin_moe`) take the two betas as explicit arguments and forward
     them to their activation callback, alongside the existing `clamp_limit` /
     `gemm1_alpha` / `gemm1_beta` quant-config parameters. This keeps the
     module-level `apply_moe_activation` default correct instead of depending on
     the caller supplying a config-aware callback.
   - `FusedMoEExpertsModular.activation` accepts the betas as well, preferring
     an explicit value and falling back to `self.moe_config`, so it stays
     interchangeable with the module-level function as a callback.
   - Batched Marlin's callback routes SITU to `masked_situ_and_mul`, which
     respects `expert_num_tokens` instead of running over padded rows.
   - DeepGEMM FP4 calls `self.activation`. SILU keeps its fused gate+mul+quant
     kernels, while the general gated activations apply the activation then
     FP8-requant into the layout matching the active scale format.

   `beta` is required rather than defaulted — a missing value means the caller
   bypassed the config plumbing, so both the generic path and the batched
   Marlin callback assert instead of silently substituting 1.0. `linear_beta`
   stays optional: `<= 0` signals "unset" to the kernel and passes `up`
   through, matching `SituAndMul(linear_beta=None)`.

4. **`[MoE]` DeepSeekV3 routing on the TRTLLM-Gen MXFP4 monolithic path** —
   `TrtLlmMxfp4ExpertsMonolithic` hardcoded the routing arguments to the
   renormalize case: logits cast to BF16, and bias / group counts / routed
   scaling factor all passed as `None`. That silently excluded sigmoid +
   grouped-topk routing even though the TRTLLM-Gen kernel implements it and the
   caller already threads all four values into `apply`. Forwards them and stops
   downcasting the logits (DeepSeekV3 routing wants FP32; the renormalize path
   still receives BF16 from the caller).

5. **`[MoE]` SituGLU for the TRTLLM-Gen MXFP4/NVFP4 backends** — the TRTLLM-Gen
   SituGLU cubin computes exactly `situ_and_mul`, so `activation_situ_beta` maps
   to `gatedActAlpha` and `activation_situ_linear_beta` to `gatedActBeta`.
   Unlike the SwiGLU-OAI clamp/beta these act on the dequantized gate/up rather
   than the raw GEMM1 accumulator, so on the NVFP4 path they are registered
   as-is instead of being folded by `g1_alphas`.

   > **Dependency:** needs a FlashInfer build exposing `ActivationType.Situ` and
   > the `is_private` kernel selector (flashinfer-ai/flashinfer#4180). The
   > currently pinned `flashinfer-python==0.6.15.post1` does not have it. This
   > commit is isolated so it can be dropped or held if reviewers prefer to
   > land the rest first.

6. **`[Kernel]` CuTe DSL fused latent-MoE tail** — `KimiK3LatentMoETailOp`.
   Given the TP-partial latent routed output and the TP-partial shared-expert
   output, it produces the fully reduced hidden-size result in one fused
   sequence instead of two NCCL all-reduces plus a separate up projection.
   Three kernels back it, all over symmetric memory: `CollectiveKernel`
   (all-reduce + RMSNorm + reduce-scatter with a Lamport-flag early exit, so
   ranks proceed as their peers' data lands), `AdaptiveUpProjectionKernel`
   (multicast GEMM for the replicated latent up projection, folding the
   shared-expert add into its epilogue) and `LamportCopyKernel`. The op is
   process-wide cached on a contract (TP group, dtype, shapes, eps) and
   registers a CuTe DSL warmup provider so the JIT compile happens during warmup
   rather than on the first forward.

   Decode-shaped only: TP 8 or 16, BF16, SM100, up to 16 tokens per call. Gated
   behind `VLLM_ENABLE_K3_LATENT_MOE_TAIL_FUSION` (default off).

7. **`[MoE]` `LatentMoERunner`** — latent MoE keeps the routed experts in a
   lower-dimensional latent space and projects back to hidden size afterwards,
   so the runner must reduce the routed output *before* the output transform:
   that transform contains an RMSNorm, and normalizing TP-partial values then
   summing is not the same as summing then normalizing. `MoERunner` gains
   `_maybe_reduce_routed_output_before_transform` for this, and the two
   downstream reduction helpers now take the resulting "already reduced" flag
   explicitly instead of always reading `_fused_output_is_reduced`.

   `LatentMoERunner` adds a fused path for the common case (TP > 1, shared
   expert present, un-reduced combine output, no sequence parallelism): the up
   projection is replicated, so the latent partial can be all-reduced and
   RMSNormed in one FlashInfer fused collective then up-projected locally, with
   the shared-expert all-reduce overlapped on the aux stream at decode batch
   sizes. It optionally dispatches to the commit-6 CuTe DSL tail. The base path
   stays correct at any TP size, just with two collectives instead of one.

   Also generalizes the modular-kernel `output_alias` fast path to CUDA. It was
   gated on ROCm + AITER, but the redundant write-back copy it avoids is
   platform-independent; ROCm behavior is unchanged.

## Not duplicating an existing PR

Checked per `AGENTS.md`:

```bash
gh pr list --repo vllm-project/vllm --state open --search "grouped topk routing kernel"
gh pr list --repo vllm-project/vllm --state open --search "single group topk"
gh pr list --repo vllm-project/vllm --state open --search "situ activation"
gh pr list --repo vllm-project/vllm --state open --search "SituGLU"
gh pr list --repo vllm-project/vllm --state open --search "latent moe runner"
gh pr list --repo vllm-project/vllm --state open --search "moe tail fusion"
```

- No open PR touches SituGLU/SITU, the latent-MoE tail, or a single-group top-k
  fast path.
- #46869 (group scoring `max` vs `top2` for bias-free models) and #45120 (fusing
  softmax into `grouped_topk`) also edit `grouped_topk_kernels.cu`, but for
  different features — neither adds an `n_group == 1 && topk_group == 1` fast
  path. Textual conflicts are likely; happy to rebase behind whichever lands
  first.
- #45452 (opt-in two-stream Kimi-K2.6 decode) and #46077 (latent-MoE
  internal-router crash fix) also edit `moe_runner.py`, but neither overlaps
  with the reduce-before-transform change or `LatentMoERunner`.
- This PR is a subset of #50000 (Kimi K3), split out at reviewer-friendly size.
  #50000 will be rebased onto whatever lands here.

## Test plan

> **Not yet run — this is why the PR is a draft.** Filling these in before
> marking it ready for review.

Intended commands:

```bash
pytest tests/kernels/moe/test_grouped_topk.py -v
pytest tests/kernels/core/test_activation.py -v -k situ
pytest tests/models/kimi_k3/test_latent_moe_tail.py -v   # needs 8x SM100
```

Kernel performance for the latent-MoE tail is measured with the benchmark added
in this PR:

```bash
python benchmarks/kernels/benchmark_kimi_k3_latent_moe_tail.py
```

## Test results

To be added.

## Model evaluation results

To be added. Commits 3–5 and 7 can affect model output, so accuracy numbers are
required before this is ready for review.

## AI assistance

AI assistance (Claude Code) was used to extract these changes from #50000 into a
reviewable commit series and to write the commit messages and this description.
The underlying implementation is from #50000. A human submitter is reviewing
every changed line and will run the tests and evals above before marking this
ready for review.
