### PR TITLE
[Refactor] reuse GateLinear eligibility for ll_bf16 router warmup

### DIFF
--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -57,14 +57,10 @@ def _ll_bf16_router_shapes_from_model(
     for module in model.modules():
         if not isinstance(module, GateLinear):
             continue
-        weight = getattr(module, "weight", None)
-        if not isinstance(weight, torch.Tensor):
+        if not module.allow_ll_bf16_gemm:
             continue
-        if weight.dim() != 2 or weight.dtype != torch.bfloat16:
-            continue
-        n, k = weight.shape
-        if k % 8 == 0:
-            shapes.add((int(k), int(n)))
+        n, k = module.weight.shape
+        shapes.add((int(k), int(n)))
     return tuple(sorted(shapes))
 
 
@@ -75,9 +71,6 @@ def _warmup_ll_bf16_router_gemm(model: torch.nn.Module) -> None:
     from vllm.model_executor.kernels.linear.cute_dsl.ll_bf16 import (
         ll_bf16_gemm_kernel,
     )
-
-    if not is_ll_bf16_gemm_available():
-        return
 
     shapes = _ll_bf16_router_shapes_from_model(model)
     if not shapes:


### PR DESCRIPTION
### Summary

This PR refactors the ll_bf16 router GEMM warmup to reuse the runtime eligibility logic provided by `GateLinear`.

Previously, the warmup path maintained its own shape filtering logic, including a `k % 8 == 0` restriction and an explicit `is_ll_bf16_gemm_available()` check.

Since `GateLinear.allow_ll_bf16_gemm` already represents the runtime eligibility for the ll_bf16 router GEMM, the warmup path can reuse it directly instead of maintaining separate conditions.

This also keeps the warmup behavior consistent with the runtime kernel eligibility, where ll_bf16 GEMM supports arbitrary dimensions.

### Changes
- Reuse `GateLinear.allow_ll_bf16_gemm` when collecting ll_bf16 router warmup shapes.
- Remove the warmup-only `k % 8` shape restriction.
- Remove the redundant `is_ll_bf16_gemm_available()` check from the warmup path.

### Benefits
- Uses `GateLinear` as the single source of truth for ll_bf16 eligibility.
- Keeps warmup behavior aligned with runtime kernel selection.
- Prevents future divergence if the eligibility logic in `GateLinear` evolves.
- Simplifies the warmup implementation by removing duplicated checks.

### Notes

This change does not modify runtime kernel dispatch. It only refactors how warmup determines which ll_bf16 router GEMM shapes should be compiled.