### PR TITLE
[KV Offload] Move CPUOffloadingSpec onto SharedOffloadRegion

### DIFF
--- a/tests/v1/kv_offload/test_factory.py
+++ b/tests/v1/kv_offload/test_factory.py
@@ -136,8 +136,12 @@ def test_create_cpu_offloading_spec():
 
 
 def test_cpu_spec_sizes_normalized_worker_layout():
+    # The CPU spec now rounds the offloaded row up to the mmap page size
+    # (matching the shared region), so kv_bytes_per_chunk picks up padding
+    # while cpu_page_size_per_worker stays the un-padded per-worker slot.
+    alignment = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
     spec = _create_spec(
-        cpu_bytes_to_use=1920,
+        cpu_bytes_to_use=alignment * 3,
         worker_kv_bytes_per_block=16,
         blocks_per_chunk=2,
         world_size=6,
@@ -147,8 +151,8 @@ def test_cpu_spec_sizes_normalized_worker_layout():
 
     assert isinstance(spec, CPUOffloadingSpec)
     assert spec.cpu_page_size_per_worker == 32
-    assert spec.kv_bytes_per_chunk == 192
-    assert spec.num_blocks == 10
+    assert spec.kv_bytes_per_chunk == alignment
+    assert spec.num_blocks == 3
 
 
 def test_cpu_spec_zero_worker_bytes_produces_empty_cache():
@@ -267,7 +271,9 @@ def test_tiering_spec_create_worker_folds_device_index_for_sharded_layout(monkey
 
 @pytest.mark.parametrize("world_size", [2, 4, 8])
 def test_cpu_spec_replicated_config_preserves_per_rank_sizing(world_size: int):
-    worker_kv_bytes_per_block = 4096
+    # Use a page-multiple per-worker block so the row size is unaffected by the
+    # page-alignment rounding regardless of the host mmap page size.
+    worker_kv_bytes_per_block = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
     spec = _create_spec(
         cpu_bytes_to_use=worker_kv_bytes_per_block * world_size * 2,
         worker_kv_bytes_per_block=worker_kv_bytes_per_block,
@@ -280,6 +286,107 @@ def test_cpu_spec_replicated_config_preserves_per_rank_sizing(world_size: int):
     assert spec.cpu_page_size_per_worker == worker_kv_bytes_per_block
     assert spec.kv_bytes_per_chunk == worker_kv_bytes_per_block * world_size
     assert spec.num_blocks == 2
+
+
+def test_cpu_spec_create_worker_uses_mmap_on_cuda_alike(monkeypatch):
+    import vllm.v1.kv_offload.cpu.spec as cpu_spec_module
+
+    worker_kv_bytes_per_block = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
+    spec = _create_spec(
+        cpu_bytes_to_use=worker_kv_bytes_per_block * 8,
+        worker_kv_bytes_per_block=worker_kv_bytes_per_block,
+        world_size=4,
+    )
+    assert isinstance(spec, CPUOffloadingSpec)
+
+    region = MagicMock()
+    region_calls: list[dict[str, Any]] = []
+    worker_calls: list[dict[str, Any]] = []
+
+    def fake_region_ctor(**kwargs):
+        region_calls.append(kwargs)
+        return region
+
+    def fake_worker_ctor(**kwargs):
+        worker_calls.append(kwargs)
+        return MagicMock()
+
+    monkeypatch.setattr(cpu_spec_module.current_platform, "is_cuda_alike", lambda: True)
+    monkeypatch.setattr(cpu_spec_module, "SharedOffloadRegion", fake_region_ctor)
+    monkeypatch.setattr(cpu_spec_module, "CPUOffloadingWorker", fake_worker_ctor)
+    monkeypatch.setattr(
+        cpu_spec_module.torch.accelerator, "current_device_index", lambda: 5
+    )
+
+    kv_caches = MagicMock()
+    spec.create_worker(kv_caches)
+
+    # rank folds the physical device index into [0, world_size): 5 % 4 == 1.
+    assert region_calls[0]["rank"] == 1
+    assert region_calls[0]["engine_id"] == "test-engine"
+    assert region_calls[0]["kv_bytes_per_block"] == worker_kv_bytes_per_block * 4
+    assert worker_calls[0]["kv_caches"] is kv_caches
+    assert worker_calls[0]["mmap_region"] is region
+
+
+def test_cpu_spec_create_worker_uses_tensor_path_off_cuda_alike(monkeypatch):
+    import vllm.v1.kv_offload.cpu.spec as cpu_spec_module
+
+    spec = _create_spec(worker_kv_bytes_per_block=4096, world_size=4)
+    assert isinstance(spec, CPUOffloadingSpec)
+
+    region_calls: list[dict[str, Any]] = []
+    worker_calls: list[dict[str, Any]] = []
+
+    def fake_region_ctor(**kwargs):
+        region_calls.append(kwargs)
+        return MagicMock()
+
+    def fake_worker_ctor(**kwargs):
+        worker_calls.append(kwargs)
+        return MagicMock()
+
+    monkeypatch.setattr(
+        cpu_spec_module.current_platform, "is_cuda_alike", lambda: False
+    )
+    monkeypatch.setattr(cpu_spec_module, "SharedOffloadRegion", fake_region_ctor)
+    monkeypatch.setattr(cpu_spec_module, "CPUOffloadingWorker", fake_worker_ctor)
+
+    spec.create_worker(MagicMock())
+
+    # Non-CUDA-alike platforms keep the per-rank pinned-tensor path.
+    assert region_calls == []
+    assert worker_calls[0]["mmap_region"] is None
+
+
+def test_cpu_spec_create_worker_skips_mmap_for_empty_cache(monkeypatch):
+    import vllm.v1.kv_offload.cpu.spec as cpu_spec_module
+
+    # worker_kv_bytes_per_block=0 yields num_blocks=0; a zero-byte region cannot
+    # be mmap'd, so even on CUDA-alike this must fall back to the tensor path.
+    spec = _create_spec(worker_kv_bytes_per_block=0, world_size=4)
+    assert isinstance(spec, CPUOffloadingSpec)
+    assert spec.num_blocks == 0
+
+    region_calls: list[dict[str, Any]] = []
+    worker_calls: list[dict[str, Any]] = []
+
+    monkeypatch.setattr(cpu_spec_module.current_platform, "is_cuda_alike", lambda: True)
+    monkeypatch.setattr(
+        cpu_spec_module,
+        "SharedOffloadRegion",
+        lambda **kwargs: region_calls.append(kwargs),
+    )
+    monkeypatch.setattr(
+        cpu_spec_module,
+        "CPUOffloadingWorker",
+        lambda **kwargs: worker_calls.append(kwargs),
+    )
+
+    spec.create_worker(MagicMock())
+
+    assert region_calls == []
+    assert worker_calls[0]["mmap_region"] is None
 
 
 def test_offloading_spec_has_replicated_layout_default():

--- a/vllm/v1/kv_offload/cpu/spec.py
+++ b/vllm/v1/kv_offload/cpu/spec.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from typing import Any
 
+import torch
 from typing_extensions import override
 
 from vllm.platforms import current_platform
@@ -20,10 +21,11 @@ from vllm.v1.kv_offload.config import OffloadingConfig
 from vllm.v1.kv_offload.cpu.common import CPUOffloadingMetrics
 from vllm.v1.kv_offload.cpu.gpu_worker import CPUOffloadingWorker
 from vllm.v1.kv_offload.cpu.manager import CPUOffloadingManager
+from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
 
 
 class CPUOffloadingSpec(OffloadingSpec):
-    BLOCK_SIZE_ALIGNMENT = 1
+    BLOCK_SIZE_ALIGNMENT = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
     SUPPORTS_REPLICATED_LAYOUT = False
 
     @classmethod
@@ -139,10 +141,28 @@ class CPUOffloadingSpec(OffloadingSpec):
         return self._manager
 
     def create_worker(self, kv_caches: CanonicalKVCaches) -> CPUOffloadingWorker:
+        mmap_region: SharedOffloadRegion | None = None
+        # num_blocks == 0 would size the region to zero bytes, which cannot be
+        # mmap'd; fall back to the tensor path (empty tensors) as before.
+        if current_platform.is_cuda_alike() and self.num_blocks > 0:
+            # Back each worker's CPU buffer with a private slot in a single
+            # shared mmap region instead of a per-rank pinned tensor. Fold the
+            # global physical device index into this replica's
+            # [0, world_size) slot range.
+            world_size = self.config.parallel.world_size
+            rank = torch.accelerator.current_device_index() % world_size
+            mmap_region = SharedOffloadRegion(
+                engine_id=self.config.engine_id,
+                num_blocks=self.num_blocks,
+                rank=rank,
+                kv_bytes_per_block=self.kv_bytes_per_chunk,
+                cpu_page_size=self.cpu_page_size_per_worker,
+            )
         return CPUOffloadingWorker(
             kv_caches=kv_caches,
             blocks_per_chunk=self.blocks_per_chunk,
             num_cpu_blocks=self.num_blocks,
+            mmap_region=mmap_region,
         )
 
     @override


### PR DESCRIPTION
## Purpose

Move the default KV-offload backend `CPUOffloadingSpec`'s worker-side CPU buffer from a per-rank private pinned `torch` tensor onto the existing shared `SharedOffloadRegion` mmap, on CUDA/ROCm. This is the allocation-swap prerequisite for the TP-deduplication feature requested in #47929; it introduces **no** deduplication semantics on its own.

Maintainer authorization (upstream reviewers do not see the issue thread, so the requests are linked directly):

- @orozery confirmed this should land as an independent PR: https://github.com/vllm-project/vllm/issues/47929#issuecomment-4921375612
- @orozery's plan to supersede the #48436 allocation fix with this refactor ("quite small", "should land in the near future"): https://github.com/vllm-project/vllm/pull/48436#issuecomment-4965045368 , https://github.com/vllm-project/vllm/pull/48436#issuecomment-4979791667
- The two-PR plan (this allocation swap, then the dedup) proposed and +1'd by @orozery: https://github.com/vllm-project/vllm/issues/47929#issuecomment-5096162285

### What changes

- `CPUOffloadingSpec.create_worker` now builds a `SharedOffloadRegion` and passes it to `CPUOffloadingWorker` when running on CUDA/ROCm (`current_platform.is_cuda_alike()`), folding the physical device index into this replica's `[0, world_size)` slot range. This is the same allocation `TieringOffloadingSpec.create_worker` already performs. The mmap is host registered (pinned) only when `PIN_MEMORY` is set and `cudaHostRegister` succeeds; a failed registration falls back to unpinned DMA with a warning. A degenerate empty cache (`num_blocks == 0`) keeps the tensor path, since a zero-byte region cannot be mmap'd.
- `CPUOffloadingSpec.BLOCK_SIZE_ALIGNMENT` moves from `1` to the region's page size (`SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT`), so block accounting rounds each offloaded row up to the mmap page size. This is applied unconditionally (scheduler and worker) because the scheduler computes `num_blocks` without knowing the worker platform; both sides must agree on the count.

### Behavior changes

- CUDA/ROCm default backend: the worker CPU buffer is the shared mmap region instead of a private pinned tensor. This takes PyTorch's `CUDACachingHostAllocator` off the allocation path; its power-of-2 rounding of large pinned allocations is the root cause of the host-memory blow-up diagnosed in #48436. Credit to @procr1337 for that diagnosis.
- Block accounting picks up the region's page-size alignment, so `num_blocks` can be marginally lower when an offloaded row is not already a page multiple.
- Non-CUDA-alike platforms (currently XPU) keep the existing per-rank pinned tensor path — unchanged.
- `TieringOffloadingSpec` (a subclass) is unchanged: it already used the shared region and page-size alignment.
- KV data is byte-identical to the previous path (the same bytes are copied, only the destination buffer differs), so model output is unaffected. The per-worker memory semantics are also unchanged: this PR keeps one private slot per worker (no dedup), and the region is node-local (`/dev/shm`).

### Not in this PR (planned follow-up)

- No deduplication / single-copy layout: `SUPPORTS_REPLICATED_LAYOUT` stays `False`. The TP-dedup itself (the #47929 feature) is a separate follow-up.
- No scheduler-side mmap: the default backend has no secondary tier that reads KV data from the scheduler process.
- No change to `pin_mmap_region`, `TieringOffloadingSpec`, or XPU pinning.

### Duplicate-work check

Searched open PRs (`47929 in:body`, `CPUOffloadingSpec`, `SharedOffloadRegion`, pinned-host-memory keywords) and the history of the touched paths. No open PR performs this default-backend allocation swap. Nearest non-duplicates:

- **#48436** (@procr1337) works around the `CUDACachingHostAllocator` power-of-2 rounding *inside* the private-tensor path (touches only `cpu/gpu_worker.py`, allocating unpinned then `cudaHostRegister`). This PR instead removes that tensor for the default backend on CUDA/ROCm, taking the caching host allocator off the path entirely, so it addresses the same symptom at the root and supersedes #48436. The author has indicated they lack a GPU environment to continue; whether to close #48436 is left to the maintainers.
- **#48414** (@Etelis) adds a parallelism-agnostic *canonical* CPU layout (`sharding.py`, and changes to `tiering/spec.py` and `shared_offload_region.py`). That is complementary layout infrastructure, not the default-backend allocation swap; the only file it shares with this PR is `tests/v1/kv_offload/test_factory.py`.

## Test Plan

Run on a CUDA host:

```bash
# Unit tests (offloading spec + worker; the worker suite already exercises the
# mmap-backed path via use_shared_memory=True).
.venv/bin/python -m pytest tests/v1/kv_offload/ -q

# Lint / type checks as in CI.
pre-commit run --files vllm/v1/kv_offload/cpu/spec.py tests/v1/kv_offload/test_factory.py
pre-commit run mypy-3.12 --all-files --hook-stage manual
```

Host-memory reproduction of the #48436 symptom (TP=2, single node). Serve with the CPU offload tier sized to straddle a per-worker power-of-2 boundary and record per-worker RSS before/after this change:

```bash
# cpu_bytes_to_use is the TOTAL across workers. With TP=2:
#   64 GiB total -> 32 GiB/worker (already a power of two: control)
#   80 GiB total -> 40 GiB/worker (rounds up to 64 GiB under the old allocator)
vllm serve <model> --tensor-parallel-size 2 \
  --kv-transfer-config '{
    "kv_connector": "OffloadingConnector",
    "kv_role": "kv_both",
    "kv_connector_extra_config": {"cpu_bytes_to_use": 68719476736}
  }'
# repeat with "cpu_bytes_to_use": 85899345920, recording per-worker RSS
# (e.g. `ps -o rss= -p <worker_pid>`) for each run.
```

## Test Result

Verified on an NVIDIA L4 host (torch 2.13.0+cu130, CUDA 13.0, Python 3.12.3).

**Unit tests** — `pytest tests/v1/kv_offload/test_factory.py tests/v1/kv_offload/cpu/`: `116 passed, 1 skipped`. Covers the new `create_worker` platform-split and empty-cache/sizing tests, plus the existing worker suite whose `test_transfer[use_shared_memory=True]` cases perform byte-exact GPU↔mmap round-trips.

**Lint / type** — `pre-commit run --files vllm/v1/kv_offload/cpu/spec.py tests/v1/kv_offload/test_factory.py`: ruff, ruff-format, mypy, SPDX-header check, and the `torch.cuda`-API guard all pass.

**Allocation behavior (the #48436 mechanism), measured directly** — resident-set (VmRSS) delta of one host allocation of the given size, per path:

| Requested | `torch.zeros(pin_memory=True)` (old tensor path) | mmap + `cudaHostRegister` (this PR's path) |
|---|---|---|
| 6 GiB | 8.00 GiB | 6.00 GiB |
| 10 GiB | 16.00 GiB | 10.00 GiB |
| 12 GiB | 16.00 GiB | 12.00 GiB |

The pinned-tensor path rounds each allocation up to the next power of two (PyTorch's `CUDACachingHostAllocator`); the shared-region path tracks the requested size. This is the same rounding #48436 reports at production sizes (e.g. an 80 GiB-per-worker request rounding up to 128 GiB).

The change has no GPU-architecture-specific path — the `current_platform.is_cuda_alike()` branch is identical across CUDA/ROCm GPUs — so this L4 micro-benchmark isolates the per-allocation rounding. The A100 TP=2 results below measure the end-to-end host-memory effect at scale (where the right metric is total physical memory, not per-worker RSS — see the note there).

**A100 TP=2 E2E.** 2× A100-SXM4-80GB, image `vllm/vllm-openai:nightly-d223c900d8` (vLLM `0.26.1rc1.dev18+gd223c900d`, whose `v1/kv_offload/` is byte-identical to this PR's base — only `cpu/spec.py` is swapped between the baseline and branch runs), `-tp 2 --load-format dummy --enforce-eager`, Qwen3-0.6B.

Total host memory for the CPU offload tier (cgroup `memory.current`, cross-checked with summed PSS — both count the shared region once):

| `cpu_bytes_to_use` | Baseline (per-rank pinned tensors) | Branch (shared mmap) |
|---|---|---|
| 64 GiB | 117.7 GiB | 69.7 GiB |
| 80 GiB | 117.7 GiB | 85.8 GiB |

The default backend allocates one pinned `torch.zeros` per layer (28 for this model); `CUDACachingHostAllocator` rounds each to the next power of two, so a 64 GiB budget resides as ~118 GiB (and an 80 GiB budget lands at ~118 GiB too — both per-tensor sizes fall in the same 2 GiB bucket). The shared-region path packs all layers and workers into one page-aligned `/dev/shm` region and stays at roughly the configured budget plus fixed runtime overhead. (Per-worker RSS is not the right metric here: the region is shared across workers, so summed RSS double-counts it — cgroup/PSS count it once.)

Correctness (TP=2, greedy, 4 prompts sharing a long prefix; the connector offloaded blocks — ~45 MB stored, 72% prefix-cache hit): generated text is identical with offloading on (shared-mmap path) vs off.

---

This PR was developed with AI assistance (implementation and tests). The unit tests, lint/type checks, and the allocation micro-benchmark were run on the submitter's NVIDIA L4 workstation; the A100 TP=2 memory and correctness results were measured on 2× A100-80GB (nightly image noted above).
