### PR TITLE
[Kimi K3] Add KDA kernels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1074,6 +1074,23 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
     set(MLA_ARCHS)
   endif()
 
+  if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 13.0)
+    cuda_archs_loose_intersection(FUSED_KDA_DECODE_ARCHS
+      "9.0a;10.0f;12.0f" "${CUDA_ARCHS}")
+  endif()
+  if(FUSED_KDA_DECODE_ARCHS)
+    set(FUSED_KDA_DECODE_SRC
+      "csrc/libtorch_stable/kimi_k3/fused_kda_decode_kernel.cu")
+    set_gencode_flags_for_srcs(
+      SRCS "${FUSED_KDA_DECODE_SRC}"
+      CUDA_ARCHS "${FUSED_KDA_DECODE_ARCHS}")
+    set_property(SOURCE ${FUSED_KDA_DECODE_SRC} APPEND PROPERTY
+      COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CUDA>:--use_fast_math>")
+    list(APPEND VLLM_STABLE_EXT_SRC "${FUSED_KDA_DECODE_SRC}")
+    message(STATUS
+      "Building fused KDA decode for archs: ${FUSED_KDA_DECODE_ARCHS}")
+  endif()
+
   # Hadacore kernels
   cuda_archs_loose_intersection(HADACORE_ARCHS "8.0+PTX;9.0+PTX" "${CUDA_ARCHS}")
   if(HADACORE_ARCHS)
@@ -1114,6 +1131,10 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
     if(COOPERATIVE_TOPK_ARCHS)
       target_compile_definitions(_C_stable_libtorch PRIVATE
         VLLM_ENABLE_COOPERATIVE_TOPK=1)
+    endif()
+    if(FUSED_KDA_DECODE_ARCHS)
+      target_compile_definitions(_C_stable_libtorch PRIVATE
+        VLLM_ENABLE_FUSED_KDA_DECODE=1)
     endif()
     # Needed by CUTLASS kernels
     target_compile_definitions(_C_stable_libtorch PRIVATE
@@ -1412,6 +1433,7 @@ if (VLLM_GPU_LANG STREQUAL "CUDA")
     include(cmake/external_projects/deepgemm.cmake)
     include(cmake/external_projects/fmha_sm100.cmake)
     include(cmake/external_projects/flashmla.cmake)
+    include(cmake/external_projects/flashkda.cmake)
     include(cmake/external_projects/qutlass.cmake)
     include(cmake/external_projects/tml_fa4.cmake)
 

--- a/cmake/external_projects/flashkda.cmake
+++ b/cmake/external_projects/flashkda.cmake
@@ -1,0 +1,80 @@
+include(FetchContent)
+
+if(DEFINED ENV{FLASH_KDA_SRC_DIR})
+  set(FLASH_KDA_SRC_DIR $ENV{FLASH_KDA_SRC_DIR})
+endif()
+
+if(FLASH_KDA_SRC_DIR)
+  FetchContent_Declare(
+    flashkda
+    SOURCE_DIR ${FLASH_KDA_SRC_DIR}
+  )
+else()
+  FetchContent_Declare(
+    flashkda
+    GIT_REPOSITORY https://github.com/vllm-project/FlashKDA.git
+    GIT_TAG b5d11010ff01c1d4a683c0dde42e76cbeaa8107f
+    GIT_PROGRESS TRUE
+    GIT_SUBMODULES cutlass
+  )
+endif()
+
+FetchContent_MakeAvailable(flashkda)
+message(STATUS "FlashKDA is available at ${flashkda_SOURCE_DIR}")
+
+set(FLASH_KDA_SUPPORT_ARCHS)
+if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.0)
+  list(APPEND FLASH_KDA_SUPPORT_ARCHS "9.0a")
+endif()
+if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 13.0)
+  list(APPEND FLASH_KDA_SUPPORT_ARCHS "10.0f" "12.0f")
+elseif(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.9)
+  list(APPEND FLASH_KDA_SUPPORT_ARCHS "10.0a" "10.3a" "12.0a")
+endif()
+
+cuda_archs_loose_intersection(
+  FLASH_KDA_ARCHS "${FLASH_KDA_SUPPORT_ARCHS}" "${CUDA_ARCHS}")
+
+if(FLASH_KDA_ARCHS)
+  message(STATUS "FlashKDA CUDA architectures: ${FLASH_KDA_ARCHS}")
+
+  set(FLASH_KDA_SOURCES
+    csrc/flashkda_registration.cpp
+    ${flashkda_SOURCE_DIR}/csrc/flash_kda.cpp
+    ${flashkda_SOURCE_DIR}/csrc/smxx/fwd_launch.cu)
+  set(FLASH_KDA_INCLUDES
+    ${flashkda_SOURCE_DIR}/csrc
+    ${flashkda_SOURCE_DIR}/cutlass/include
+    ${flashkda_SOURCE_DIR}/cutlass/examples/common
+    ${flashkda_SOURCE_DIR}/cutlass/tools/util/include)
+
+  set_gencode_flags_for_srcs(
+    SRCS "${FLASH_KDA_SOURCES}"
+    CUDA_ARCHS "${FLASH_KDA_ARCHS}")
+
+  define_extension_target(
+    _flashkda_C
+    DESTINATION vllm
+    LANGUAGE ${VLLM_GPU_LANG}
+    SOURCES ${FLASH_KDA_SOURCES}
+    COMPILE_FLAGS ${VLLM_GPU_FLAGS}
+    ARCHITECTURES ${VLLM_GPU_ARCHES}
+    INCLUDE_DIRECTORIES ${FLASH_KDA_INCLUDES}
+    USE_SABI 3
+    WITH_SOABI)
+
+  target_compile_definitions(_flashkda_C PRIVATE
+    TORCH_TARGET_VERSION=0x020B000000000000ULL)
+  if(VLLM_GPU_LANG STREQUAL "CUDA")
+    target_compile_definitions(_flashkda_C PRIVATE USE_CUDA)
+  endif()
+
+  target_compile_options(_flashkda_C PRIVATE
+    $<$<COMPILE_LANGUAGE:CUDA>:-UPy_LIMITED_API --expt-relaxed-constexpr --expt-extended-lambda --use_fast_math -O3>
+    $<$<COMPILE_LANGUAGE:CXX>:-UPy_LIMITED_API>)
+else()
+  message(STATUS
+    "FlashKDA will not compile: CUDA >=12.0 and a supported architecture "
+    "(SM90, SM10x, or SM12x) are required")
+  add_custom_target(_flashkda_C)
+endif()

--- a/csrc/flashkda_registration.cpp
+++ b/csrc/flashkda_registration.cpp
@@ -1,0 +1,24 @@
+#include "core/registration.h"
+#include "flash_kda.h"
+
+#include <torch/csrc/stable/library.h>
+
+STABLE_TORCH_LIBRARY(_flashkda_C, m) {
+  m.def("get_workspace_size(int T_total, int H, int N=1) -> int");
+  m.def(
+      "fwd(Tensor q, Tensor k, Tensor v, Tensor g, Tensor beta, float scale, "
+      "Tensor(a!) out, Tensor(c!) workspace, Tensor A_log, Tensor dt_bias, "
+      "float lower_bound, "
+      "Tensor? initial_state=None, Tensor(b!)? final_state=None, "
+      "Tensor? cu_seqlens=None) -> ()");
+}
+
+STABLE_TORCH_LIBRARY_IMPL(_flashkda_C, CompositeExplicitAutograd, m) {
+  m.impl("get_workspace_size", TORCH_BOX(&get_workspace_size));
+}
+
+STABLE_TORCH_LIBRARY_IMPL(_flashkda_C, CUDA, m) {
+  m.impl("fwd", TORCH_BOX(&fwd));
+}
+
+REGISTER_EXTENSION(_flashkda_C)

--- a/csrc/libtorch_stable/kimi_k3/fused_kda_decode_kernel.cu
+++ b/csrc/libtorch_stable/kimi_k3/fused_kda_decode_kernel.cu
@@ -1,0 +1,1130 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ */
+
+#include <cstdint>
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <array>
+#include <optional>
+
+#include "../torch_utils.h"
+#include "../../cuda_compat.h"
+
+namespace {
+
+constexpr int kDimK = 128;
+constexpr int kDimV = 128;
+constexpr int kKernelWidth = 4;
+constexpr int kConvStateWidth = kKernelWidth - 1;
+constexpr int kThreads = 256;
+constexpr int kWarps = kThreads / 32;
+constexpr int kChunkV = 32;
+constexpr int kNumChunks = kDimV / kChunkV;
+constexpr int kRowsPerWarp = kChunkV / kWarps;
+
+struct KdaDecodeStrides {
+  int64_t x_row;
+  int64_t beta_row;
+  int64_t onorm_row;
+  int64_t conv_slot;
+  int64_t state_slot;
+};
+
+__device__ __forceinline__ float bf16_load(const __nv_bfloat16* ptr,
+                                           int64_t idx) {
+  return __bfloat162float(ptr[idx]);
+}
+
+__device__ __forceinline__ float bf16_load(const float* ptr, int64_t idx) {
+  return ptr[idx];
+}
+
+template <int kChannels>
+__device__ __forceinline__ float conv_weight_load(const float* ptr, int channel,
+                                                  int width) {
+  return ptr[width * kChannels + channel];
+}
+
+__device__ __forceinline__ __nv_bfloat16 bf16_store(float value) {
+  return __float2bfloat16(value);
+}
+
+template <bool kUseCacheGlobalStore>
+__device__ __forceinline__ void store_state_float4(float* ptr, float4 value) {
+  if constexpr (kUseCacheGlobalStore) {
+    __stcg(reinterpret_cast<float4*>(ptr), value);
+  } else {
+    *reinterpret_cast<float4*>(ptr) = value;
+  }
+}
+
+__device__ __forceinline__ float sigmoid_fast(float x) {
+  return 1.0f / (1.0f + __expf(-x));
+}
+
+__device__ __forceinline__ float silu_fast(float x) {
+  return x * sigmoid_fast(x);
+}
+
+__device__ __forceinline__ float softplus_fast(float x) {
+  return x > 20.0f ? x : log1pf(__expf(x));
+}
+
+__device__ __forceinline__ float warp_reduce_sum(float value) {
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    value += __shfl_xor_sync(0xffffffffu, value, offset);
+  }
+  return value;
+}
+
+__device__ __forceinline__ void cp_async_cg_16b(float* smem_ptr,
+                                                const float* gmem_ptr) {
+  uint32_t smem_addr =
+      static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile("cp.async.cg.shared.global [%0], [%1], 16;\n"
+               :
+               : "r"(smem_addr), "l"(gmem_ptr));
+}
+
+__device__ __forceinline__ void cp_async_commit() {
+  asm volatile("cp.async.commit_group;\n" ::);
+}
+
+__device__ __forceinline__ void cp_async_wait_all() {
+  asm volatile("cp.async.wait_all;\n" ::: "memory");
+}
+
+__device__ __forceinline__ void cp_async_wait_group_1() {
+  asm volatile("cp.async.wait_group 1;\n" ::: "memory");
+}
+
+template <int kCopyThreads>
+__device__ __forceinline__ void cp_async_state_chunk_for(float* s_state,
+                                                         const float* state,
+                                                         int slot, int i_hv,
+                                                         int HV, int chunk) {
+  constexpr int kFloat4PerChunk = kChunkV * kDimK / 4;
+  const int tid = threadIdx.x;
+  const int stage = chunk & 1;
+  const int v_base = chunk * kChunkV;
+  for (int linear4 = tid; linear4 < kFloat4PerChunk; linear4 += kCopyThreads) {
+    const int elem = linear4 * 4;
+    const int row = elem / kDimK;
+    const int k = elem - row * kDimK;
+    float* dst = s_state + (stage * kChunkV + row) * kDimK + k;
+    const float* src =
+        state + ((slot * HV + i_hv) * kDimV + v_base + row) * kDimK + k;
+    cp_async_cg_16b(dst, src);
+  }
+  cp_async_commit();
+}
+
+__device__ __forceinline__ void cp_async_state_chunk(float* s_state,
+                                                     const float* state,
+                                                     int slot, int i_hv, int HV,
+                                                     int chunk) {
+  cp_async_state_chunk_for<kThreads>(s_state, state, slot, i_hv, HV, chunk);
+}
+
+__device__ __forceinline__ float block_reduce_sum(float value, float* scratch) {
+  const int tid = threadIdx.x;
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+
+  float warp_total = warp_reduce_sum(value);
+  if (lane == 0) {
+    scratch[warp] = warp_total;
+  }
+  __syncthreads();
+
+  float block_total = 0.0f;
+  if (warp == 0) {
+    block_total = lane < kWarps ? scratch[lane] : 0.0f;
+    block_total = warp_reduce_sum(block_total);
+    if (lane == 0) {
+      scratch[0] = block_total;
+    }
+  }
+  __syncthreads();
+  return scratch[0];
+}
+
+struct Sum2 {
+  float x;
+  float y;
+};
+
+__device__ __forceinline__ Sum2 warp_reduce_sum_pair(float x, float y) {
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    x += __shfl_xor_sync(0xffffffffu, x, offset);
+    y += __shfl_xor_sync(0xffffffffu, y, offset);
+  }
+  return {x, y};
+}
+
+template <int kReduceWarps>
+__device__ __forceinline__ Sum2 block_reduce_sum2_for(float x, float y,
+                                                      float* scratch) {
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+
+  const float warp_x = warp_reduce_sum(x);
+  const float warp_y = warp_reduce_sum(y);
+  if (lane == 0) {
+    scratch[warp] = warp_x;
+    scratch[kReduceWarps + warp] = warp_y;
+  }
+  __syncthreads();
+
+  float block_x = 0.0f;
+  float block_y = 0.0f;
+  if (warp == 0) {
+    block_x = lane < kReduceWarps ? scratch[lane] : 0.0f;
+    block_y = lane < kReduceWarps ? scratch[kReduceWarps + lane] : 0.0f;
+    block_x = warp_reduce_sum(block_x);
+    block_y = warp_reduce_sum(block_y);
+    if (lane == 0) {
+      scratch[0] = block_x;
+      scratch[1] = block_y;
+    }
+  }
+  __syncthreads();
+  return {scratch[0], scratch[1]};
+}
+
+__device__ __forceinline__ Sum2 block_reduce_sum2(float x, float y,
+                                                  float* scratch) {
+  return block_reduce_sum2_for<kWarps>(x, y, scratch);
+}
+
+template <int kReduceWarps>
+__device__ __forceinline__ float block_reduce_sum_active_for(float value,
+                                                             float* scratch) {
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+
+  float warp_total = 0.0f;
+  if (warp < kReduceWarps) {
+    warp_total = warp_reduce_sum(value);
+  }
+  if (lane == 0 && warp < kReduceWarps) {
+    scratch[warp] = warp_total;
+  }
+  __syncthreads();
+
+  float block_total = 0.0f;
+  if (warp == 0) {
+    block_total = lane < kReduceWarps ? scratch[lane] : 0.0f;
+    block_total = warp_reduce_sum(block_total);
+    if (lane == 0) {
+      scratch[0] = block_total;
+    }
+  }
+  __syncthreads();
+  return scratch[0];
+}
+
+template <int kReduceWarps>
+__device__ __forceinline__ Sum2 block_reduce_sum2_active_for(float x, float y,
+                                                             float* scratch) {
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+
+  float warp_x = 0.0f;
+  float warp_y = 0.0f;
+  if (warp < kReduceWarps) {
+    warp_x = warp_reduce_sum(x);
+    warp_y = warp_reduce_sum(y);
+  }
+  if (lane == 0 && warp < kReduceWarps) {
+    scratch[warp] = warp_x;
+    scratch[kReduceWarps + warp] = warp_y;
+  }
+  __syncthreads();
+
+  float block_x = 0.0f;
+  float block_y = 0.0f;
+  if (warp == 0) {
+    block_x = lane < kReduceWarps ? scratch[lane] : 0.0f;
+    block_y = lane < kReduceWarps ? scratch[kReduceWarps + lane] : 0.0f;
+    block_x = warp_reduce_sum(block_x);
+    block_y = warp_reduce_sum(block_y);
+    if (lane == 0) {
+      scratch[0] = block_x;
+      scratch[1] = block_y;
+    }
+  }
+  __syncthreads();
+  return {scratch[0], scratch[1]};
+}
+
+template <bool kApplyOnorm, bool kUseStaticDecodeLayout = false,
+          int kFixedHeads = 0, int kFixedValueHeads = 0,
+          bool kUseHeadGrid = false, bool kAccumulateOnormSumsq = false,
+          bool kUseActiveQkReduction = false, bool kUseCacheGlobalStore = false,
+          bool kComputeOutputBeforeStore = false, bool kSkipWarpSync = false,
+          bool kPreloadOnormParams = false,
+          bool kPrefetchNextStateChunk = false,
+          bool kUseActiveOnormReduction = false, bool kUpdateConvState = false,
+          bool kUseLowerBound = false, bool kApplyBetaSigmoid = true>
+__global__
+__launch_bounds__(kThreads, 2) void kda_decode_fusion_many_heads_kernel(
+    const __nv_bfloat16* __restrict__ x_q,
+    const __nv_bfloat16* __restrict__ x_k,
+    const __nv_bfloat16* __restrict__ x_v, const float* __restrict__ w_q_t,
+    const float* __restrict__ w_k_t, const float* __restrict__ w_v_t,
+    const float* __restrict__ bias_q, const float* __restrict__ bias_k,
+    const float* __restrict__ bias_v, __nv_bfloat16* __restrict__ cs_q,
+    __nv_bfloat16* __restrict__ cs_k, __nv_bfloat16* __restrict__ cs_v,
+    const float* __restrict__ a_log, const __nv_bfloat16* __restrict__ g,
+    const float* __restrict__ dt_bias, const __nv_bfloat16* __restrict__ beta,
+    const __nv_bfloat16* __restrict__ onorm_g,
+    const float* __restrict__ onorm_weight,
+    const int* __restrict__ ssm_state_indices,
+    const int* __restrict__ cu_seqlens, float* __restrict__ state,
+    __nv_bfloat16* __restrict__ out, int B, int H, int HV, float lower_bound,
+    float scale, float onorm_eps, KdaDecodeStrides strides) {
+  const int tid = threadIdx.x;
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+  int i_n;
+  int i_hv;
+  int i_h;
+  int bos;
+  int slot;
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  cudaGridDependencySynchronize();
+#endif
+  if constexpr (kUseStaticDecodeLayout) {
+    if constexpr (kUseHeadGrid) {
+      i_n = blockIdx.x;
+      i_hv = blockIdx.y;
+    } else {
+      const int nhv = blockIdx.x;
+      i_n = nhv / kFixedValueHeads;
+      i_hv = nhv - i_n * kFixedValueHeads;
+    }
+    i_h = i_hv;
+    bos = i_n;
+    slot = ssm_state_indices == nullptr ? i_n : ssm_state_indices[i_n];
+  } else {
+    const int nhv = blockIdx.x;
+    i_n = nhv / HV;
+    i_hv = nhv - i_n * HV;
+    const int hv_per_h = HV / H;
+    i_h = i_hv / hv_per_h;
+
+    bos = cu_seqlens == nullptr ? i_n : cu_seqlens[i_n];
+    const int eos = cu_seqlens == nullptr ? i_n + 1 : cu_seqlens[i_n + 1];
+    if (eos <= bos) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+      cudaTriggerProgrammaticLaunchCompletion();
+#endif
+      return;
+    }
+    slot = ssm_state_indices == nullptr ? i_n : ssm_state_indices[i_n];
+  }
+
+  constexpr int kLocalDim = kFixedHeads * kDimK;
+  constexpr int kPackedDim = 3 * kLocalDim;
+  const int hk_off = i_h * kDimK;
+  const int hv_off = i_hv * kDimV;
+  constexpr int hv_count = kFixedValueHeads;
+  float* const state_for_slot = state + slot * strides.state_slot;
+  const int64_t conv_slot_offset = slot * strides.conv_slot;
+  __nv_bfloat16* const cs_q_for_slot = cs_q + conv_slot_offset;
+  __nv_bfloat16* const cs_k_for_slot = cs_k + conv_slot_offset;
+  __nv_bfloat16* const cs_v_for_slot = cs_v + conv_slot_offset;
+
+  __shared__ float s_state[2][kChunkV][kDimK];
+  __shared__ float s_q[kDimK];
+  __shared__ float s_k[kDimK];
+  __shared__ float s_decay[kDimK];
+  __shared__ float s_v[kDimV];
+  __shared__ float s_o[kDimV];
+  __shared__ float s_reduce[kThreads];
+  __shared__ float s_beta;
+  float pre_onorm_gate = 0.0f;
+  float pre_onorm_weight = 0.0f;
+
+  cp_async_state_chunk(&s_state[0][0][0], state_for_slot, 0, i_hv, hv_count, 0);
+
+  if constexpr (kUpdateConvState) {
+    if (tid < kDimK) {
+      const int k = tid;
+      const int hk = hk_off + k;
+      const int64_t xq_idx = bos * strides.x_row + i_h * kDimK + k;
+      const float exp_a =
+          __shfl_sync(0xffffffffu, lane == 0 ? __expf(a_log[i_h]) : 0.0f, 0);
+
+      float q_acc = bias_q == nullptr ? 0.0f : bf16_load(bias_q, hk);
+      float k_acc = bias_k == nullptr ? 0.0f : bf16_load(bias_k, hk);
+      __nv_bfloat16 q_shift0 = __float2bfloat16(0.0f);
+      __nv_bfloat16 q_shift1 = __float2bfloat16(0.0f);
+      __nv_bfloat16 k_shift0 = __float2bfloat16(0.0f);
+      __nv_bfloat16 k_shift1 = __float2bfloat16(0.0f);
+#pragma unroll
+      for (int w = 0; w < kConvStateWidth; ++w) {
+        const __nv_bfloat16 q_state = cs_q_for_slot[hk + w * kPackedDim];
+        const __nv_bfloat16 k_state = cs_k_for_slot[hk + w * kPackedDim];
+        q_acc += __bfloat162float(q_state) *
+                 conv_weight_load<kLocalDim>(w_q_t, hk, w);
+        k_acc += __bfloat162float(k_state) *
+                 conv_weight_load<kLocalDim>(w_k_t, hk, w);
+        if (w == 1) {
+          q_shift0 = q_state;
+          k_shift0 = k_state;
+        } else if (w == 2) {
+          q_shift1 = q_state;
+          k_shift1 = k_state;
+        }
+      }
+      const __nv_bfloat16 q_new = x_q[xq_idx];
+      const __nv_bfloat16 k_new = x_k[xq_idx];
+      q_acc += __bfloat162float(q_new) *
+               conv_weight_load<kLocalDim>(w_q_t, hk, kKernelWidth - 1);
+      k_acc += __bfloat162float(k_new) *
+               conv_weight_load<kLocalDim>(w_k_t, hk, kKernelWidth - 1);
+
+      cs_q_for_slot[hk] = q_shift0;
+      cs_q_for_slot[hk + kPackedDim] = q_shift1;
+      cs_q_for_slot[hk + 2 * kPackedDim] = q_new;
+      cs_k_for_slot[hk] = k_shift0;
+      cs_k_for_slot[hk + kPackedDim] = k_shift1;
+      cs_k_for_slot[hk + 2 * kPackedDim] = k_new;
+
+      s_q[k] = silu_fast(q_acc);
+      s_k[k] = silu_fast(k_acc);
+
+      const int64_t gate_idx = bos * kLocalDim + i_hv * kDimK + k;
+      const float g_raw = bf16_load(g, gate_idx) + dt_bias[hk];
+      if constexpr (kUseLowerBound) {
+        s_decay[k] = __expf(lower_bound * sigmoid_fast(exp_a * g_raw));
+      } else {
+        s_decay[k] = __expf(-exp_a * softplus_fast(g_raw));
+      }
+    }
+  } else {
+    if (tid < kDimK) {
+      const int k = tid;
+      const int hk = hk_off + k;
+      const float exp_a =
+          __shfl_sync(0xffffffffu, lane == 0 ? __expf(a_log[i_h]) : 0.0f, 0);
+
+      float q_acc = bias_q == nullptr ? 0.0f : bf16_load(bias_q, hk);
+      float k_acc = bias_k == nullptr ? 0.0f : bf16_load(bias_k, hk);
+#pragma unroll
+      for (int w = 0; w < kConvStateWidth; ++w) {
+        const int cs_idx = hk + w * kPackedDim;
+        q_acc += bf16_load(cs_q_for_slot, cs_idx) *
+                 conv_weight_load<kLocalDim>(w_q_t, hk, w);
+        k_acc += bf16_load(cs_k_for_slot, cs_idx) *
+                 conv_weight_load<kLocalDim>(w_k_t, hk, w);
+      }
+      q_acc += bf16_load(x_q, bos * strides.x_row + i_h * kDimK + k) *
+               conv_weight_load<kLocalDim>(w_q_t, hk, kKernelWidth - 1);
+      k_acc += bf16_load(x_k, bos * strides.x_row + i_h * kDimK + k) *
+               conv_weight_load<kLocalDim>(w_k_t, hk, kKernelWidth - 1);
+
+      s_q[k] = silu_fast(q_acc);
+      s_k[k] = silu_fast(k_acc);
+
+      const int64_t gate_idx = bos * kLocalDim + i_hv * kDimK + k;
+      const float g_raw = bf16_load(g, gate_idx) + dt_bias[hk];
+      if constexpr (kUseLowerBound) {
+        s_decay[k] = __expf(lower_bound * sigmoid_fast(exp_a * g_raw));
+      } else {
+        s_decay[k] = __expf(-exp_a * softplus_fast(g_raw));
+      }
+    }
+  }
+
+  if constexpr (kUpdateConvState) {
+    if (tid < kDimV) {
+      const int v = tid;
+      const int hvv = hv_off + v;
+      const int64_t xv_idx = bos * strides.x_row + i_hv * kDimV + v;
+
+      float v_acc = bias_v == nullptr ? 0.0f : bf16_load(bias_v, hvv);
+      __nv_bfloat16 v_shift0 = __float2bfloat16(0.0f);
+      __nv_bfloat16 v_shift1 = __float2bfloat16(0.0f);
+#pragma unroll
+      for (int w = 0; w < kConvStateWidth; ++w) {
+        const __nv_bfloat16 v_state = cs_v_for_slot[hvv + w * kPackedDim];
+        v_acc += __bfloat162float(v_state) *
+                 conv_weight_load<kLocalDim>(w_v_t, hvv, w);
+        if (w == 1) {
+          v_shift0 = v_state;
+        } else if (w == 2) {
+          v_shift1 = v_state;
+        }
+      }
+      const __nv_bfloat16 v_new = x_v[xv_idx];
+      v_acc += __bfloat162float(v_new) *
+               conv_weight_load<kLocalDim>(w_v_t, hvv, kKernelWidth - 1);
+      cs_v_for_slot[hvv] = v_shift0;
+      cs_v_for_slot[hvv + kPackedDim] = v_shift1;
+      cs_v_for_slot[hvv + 2 * kPackedDim] = v_new;
+      s_v[v] = silu_fast(v_acc);
+
+      if constexpr (kApplyOnorm && kPreloadOnormParams) {
+        const int64_t gate_idx = i_n * strides.onorm_row + i_hv * kDimV + v;
+        pre_onorm_gate = sigmoid_fast(bf16_load(onorm_g, gate_idx));
+        pre_onorm_weight = onorm_weight[v];
+      }
+    }
+  } else {
+    if (tid < kDimV) {
+      const int v = tid;
+      const int hvv = hv_off + v;
+
+      float v_acc = bias_v == nullptr ? 0.0f : bf16_load(bias_v, hvv);
+#pragma unroll
+      for (int w = 0; w < kConvStateWidth; ++w) {
+        const int cs_idx = hvv + w * kPackedDim;
+        v_acc += bf16_load(cs_v_for_slot, cs_idx) *
+                 conv_weight_load<kLocalDim>(w_v_t, hvv, w);
+      }
+      v_acc += bf16_load(x_v, bos * strides.x_row + i_hv * kDimV + v) *
+               conv_weight_load<kLocalDim>(w_v_t, hvv, kKernelWidth - 1);
+      s_v[v] = silu_fast(v_acc);
+
+      if constexpr (kApplyOnorm && kPreloadOnormParams) {
+        const int64_t gate_idx = i_n * strides.onorm_row + i_hv * kDimV + v;
+        pre_onorm_gate = sigmoid_fast(bf16_load(onorm_g, gate_idx));
+        pre_onorm_weight = onorm_weight[v];
+      }
+    }
+  }
+
+  if (tid == 0) {
+    const float beta_raw = bf16_load(beta, bos * strides.beta_row + i_hv);
+    if constexpr (kApplyBetaSigmoid) {
+      s_beta = sigmoid_fast(beta_raw);
+    } else {
+      s_beta = beta_raw;
+    }
+  }
+  __syncthreads();
+
+  if constexpr (kPrefetchNextStateChunk && kNumChunks > 1) {
+    cp_async_state_chunk(&s_state[0][0][0], state_for_slot, 0, i_hv, hv_count,
+                         1);
+  }
+
+  const float q_sq = tid < kDimK ? s_q[tid] * s_q[tid] : 0.0f;
+  const float k_sq = tid < kDimK ? s_k[tid] * s_k[tid] : 0.0f;
+  Sum2 qk_sum;
+  if constexpr (kUseActiveQkReduction) {
+    qk_sum = block_reduce_sum2_active_for<kDimK / 32>(q_sq, k_sq, s_reduce);
+  } else {
+    qk_sum = block_reduce_sum2(q_sq, k_sq, s_reduce);
+  }
+  if (tid < kDimK) {
+    s_q[tid] *= rsqrtf(qk_sum.x + 1.0e-6f) * scale;
+    s_k[tid] *= rsqrtf(qk_sum.y + 1.0e-6f);
+  }
+  __syncthreads();
+
+  const int k_base = lane * 4;
+  const float4 q4 = *reinterpret_cast<const float4*>(s_q + k_base);
+  const float4 k4 = *reinterpret_cast<const float4*>(s_k + k_base);
+  const float4 decay4 = *reinterpret_cast<const float4*>(s_decay + k_base);
+  float r_q[4] = {q4.x, q4.y, q4.z, q4.w};
+  float r_k[4] = {k4.x, k4.y, k4.z, k4.w};
+  float r_decay[4] = {decay4.x, decay4.y, decay4.z, decay4.w};
+  float o_sumsq = 0.0f;
+
+#pragma unroll
+  for (int chunk = 0; chunk < kNumChunks; ++chunk) {
+    if constexpr (kPrefetchNextStateChunk && kNumChunks > 1) {
+      if (chunk + 1 < kNumChunks) {
+        cp_async_wait_group_1();
+      } else {
+        cp_async_wait_all();
+      }
+    } else {
+      cp_async_wait_all();
+    }
+    if constexpr (!kSkipWarpSync) {
+      __syncwarp();
+    }
+
+    if constexpr (!kPrefetchNextStateChunk) {
+      if (chunk + 1 < kNumChunks) {
+        cp_async_state_chunk(&s_state[0][0][0], state_for_slot, 0, i_hv,
+                             hv_count, chunk + 1);
+      }
+    }
+
+#pragma unroll
+    for (int row = 0; row < kRowsPerWarp; row += 2) {
+      const int v_row_a = warp + row * kWarps;
+      const int v_row_b = warp + (row + 1) * kWarps;
+      const int v0 = chunk * kChunkV + v_row_a;
+      const int v1 = chunk * kChunkV + v_row_b;
+      float h_a_vals[4];
+      float h_b_vals[4];
+      float dot_hk_a = 0.0f;
+      float dot_hk_b = 0.0f;
+
+      const float4 raw_h_a = *reinterpret_cast<const float4*>(
+          &s_state[chunk & 1][v_row_a][k_base]);
+      const float4 raw_h_b = *reinterpret_cast<const float4*>(
+          &s_state[chunk & 1][v_row_b][k_base]);
+      h_a_vals[0] = raw_h_a.x * r_decay[0];
+      h_a_vals[1] = raw_h_a.y * r_decay[1];
+      h_a_vals[2] = raw_h_a.z * r_decay[2];
+      h_a_vals[3] = raw_h_a.w * r_decay[3];
+      h_b_vals[0] = raw_h_b.x * r_decay[0];
+      h_b_vals[1] = raw_h_b.y * r_decay[1];
+      h_b_vals[2] = raw_h_b.z * r_decay[2];
+      h_b_vals[3] = raw_h_b.w * r_decay[3];
+      dot_hk_a = h_a_vals[0] * r_k[0] + h_a_vals[1] * r_k[1] +
+                 h_a_vals[2] * r_k[2] + h_a_vals[3] * r_k[3];
+      dot_hk_b = h_b_vals[0] * r_k[0] + h_b_vals[1] * r_k[1] +
+                 h_b_vals[2] * r_k[2] + h_b_vals[3] * r_k[3];
+
+      const Sum2 dot_hk = warp_reduce_sum_pair(dot_hk_a, dot_hk_b);
+      const float v_new0 = (s_v[v0] - dot_hk.x) * s_beta;
+      const float v_new1 = (s_v[v1] - dot_hk.y) * s_beta;
+
+      float dot_hq_a = 0.0f;
+      float dot_hq_b = 0.0f;
+      const int state_idx_a = (i_hv * kDimV + v0) * kDimK + k_base;
+      const int state_idx_b = (i_hv * kDimV + v1) * kDimK + k_base;
+      const float h_a_0 = h_a_vals[0] + r_k[0] * v_new0;
+      const float h_a_1 = h_a_vals[1] + r_k[1] * v_new0;
+      const float h_a_2 = h_a_vals[2] + r_k[2] * v_new0;
+      const float h_a_3 = h_a_vals[3] + r_k[3] * v_new0;
+      const float h_b_0 = h_b_vals[0] + r_k[0] * v_new1;
+      const float h_b_1 = h_b_vals[1] + r_k[1] * v_new1;
+      const float h_b_2 = h_b_vals[2] + r_k[2] * v_new1;
+      const float h_b_3 = h_b_vals[3] + r_k[3] * v_new1;
+      if constexpr (kComputeOutputBeforeStore) {
+        dot_hq_a =
+            h_a_0 * r_q[0] + h_a_1 * r_q[1] + h_a_2 * r_q[2] + h_a_3 * r_q[3];
+        dot_hq_b =
+            h_b_0 * r_q[0] + h_b_1 * r_q[1] + h_b_2 * r_q[2] + h_b_3 * r_q[3];
+        store_state_float4<kUseCacheGlobalStore>(
+            state_for_slot + state_idx_a,
+            make_float4(h_a_0, h_a_1, h_a_2, h_a_3));
+        store_state_float4<kUseCacheGlobalStore>(
+            state_for_slot + state_idx_b,
+            make_float4(h_b_0, h_b_1, h_b_2, h_b_3));
+      } else {
+        store_state_float4<kUseCacheGlobalStore>(
+            state_for_slot + state_idx_a,
+            make_float4(h_a_0, h_a_1, h_a_2, h_a_3));
+        store_state_float4<kUseCacheGlobalStore>(
+            state_for_slot + state_idx_b,
+            make_float4(h_b_0, h_b_1, h_b_2, h_b_3));
+        dot_hq_a =
+            h_a_0 * r_q[0] + h_a_1 * r_q[1] + h_a_2 * r_q[2] + h_a_3 * r_q[3];
+        dot_hq_b =
+            h_b_0 * r_q[0] + h_b_1 * r_q[1] + h_b_2 * r_q[2] + h_b_3 * r_q[3];
+      }
+
+      const Sum2 dot_hq = warp_reduce_sum_pair(dot_hq_a, dot_hq_b);
+      if (lane == 0) {
+        s_o[v0] = dot_hq.x;
+        s_o[v1] = dot_hq.y;
+        if constexpr (kApplyOnorm && kAccumulateOnormSumsq) {
+          o_sumsq += dot_hq.x * dot_hq.x + dot_hq.y * dot_hq.y;
+        }
+      }
+    }
+
+    if constexpr (kPrefetchNextStateChunk) {
+      if (chunk + 2 < kNumChunks) {
+        cp_async_state_chunk(&s_state[0][0][0], state_for_slot, 0, i_hv,
+                             hv_count, chunk + 2);
+      }
+    }
+  }
+  __syncthreads();
+
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  cudaTriggerProgrammaticLaunchCompletion();
+#endif
+
+  if constexpr (kApplyOnorm) {
+    if constexpr (kAccumulateOnormSumsq) {
+      if (lane == 0) {
+        s_reduce[warp] = o_sumsq;
+      }
+      __syncthreads();
+
+      float total_sumsq = 0.0f;
+      if (warp == 0) {
+        total_sumsq = lane < kWarps ? s_reduce[lane] : 0.0f;
+        total_sumsq = warp_reduce_sum(total_sumsq);
+        if (lane == 0) {
+          s_reduce[0] = total_sumsq;
+        }
+      }
+      __syncthreads();
+
+      if (tid < kDimV) {
+        const int64_t out_idx = i_n * kLocalDim + i_hv * kDimV + tid;
+        const float raw_o = s_o[tid];
+        const float rstd =
+            rsqrtf(s_reduce[0] / static_cast<float>(kDimV) + onorm_eps);
+        float gate;
+        float weight;
+        if constexpr (kPreloadOnormParams) {
+          gate = pre_onorm_gate;
+          weight = pre_onorm_weight;
+        } else {
+          const int64_t gate_idx = i_n * strides.onorm_row + i_hv * kDimV + tid;
+          gate = sigmoid_fast(bf16_load(onorm_g, gate_idx));
+          weight = onorm_weight[tid];
+        }
+        const float y = raw_o * rstd * weight * gate;
+        out[out_idx] = bf16_store(y);
+      }
+    } else {
+      const float raw_o = tid < kDimV ? s_o[tid] : 0.0f;
+      const float o_sq = raw_o * raw_o;
+      float sumsq;
+      if constexpr (kUseActiveOnormReduction || kUseActiveQkReduction) {
+        sumsq = block_reduce_sum_active_for<kDimV / 32>(o_sq, s_reduce);
+      } else {
+        sumsq = block_reduce_sum(o_sq, s_reduce);
+      }
+
+      if (tid < kDimV) {
+        const int64_t out_idx = i_n * kLocalDim + i_hv * kDimV + tid;
+        const float rstd =
+            rsqrtf(sumsq / static_cast<float>(kDimV) + onorm_eps);
+        float gate;
+        float weight;
+        if constexpr (kPreloadOnormParams) {
+          gate = pre_onorm_gate;
+          weight = pre_onorm_weight;
+        } else {
+          const int64_t gate_idx = i_n * strides.onorm_row + i_hv * kDimV + tid;
+          gate = sigmoid_fast(bf16_load(onorm_g, gate_idx));
+          weight = onorm_weight[tid];
+        }
+        const float y = raw_o * rstd * weight * gate;
+        out[out_idx] = bf16_store(y);
+      }
+    }
+  } else {
+    if (tid < kDimV) {
+      const int64_t out_idx = i_n * kLocalDim + i_hv * kDimV + tid;
+      out[out_idx] = bf16_store(s_o[tid]);
+    }
+  }
+}
+
+template <int kHeads, bool kApplyOnorm, bool kUpdateConvState,
+          bool kUseLowerBound, bool kApplyBetaSigmoid>
+void launch_kda_decode_many_heads_raw(
+    const void* x_q, const void* x_k, const void* x_v, const void* w_q_t,
+    const void* w_k_t, const void* w_v_t, const void* bias_q,
+    const void* bias_k, const void* bias_v, void* cs_q, void* cs_k, void* cs_v,
+    const float* a_log, const void* g, const float* dt_bias, const void* beta,
+    const void* onorm_g, const float* onorm_weight,
+    const int* ssm_state_indices, const int* cu_seqlens, float* state,
+    void* out, int B, int H, int HV, float lower_bound, float scale,
+    float onorm_eps, KdaDecodeStrides strides, cudaStream_t stream) {
+  auto kernel = &kda_decode_fusion_many_heads_kernel<
+      kApplyOnorm, true, kHeads, kHeads, true, false, false, false, false,
+      false, true, true, true, kUpdateConvState, kUseLowerBound,
+      kApplyBetaSigmoid>;
+  cudaLaunchConfig_t config{};
+  config.gridDim = dim3(B, kHeads);
+  config.blockDim = dim3(kThreads);
+  config.dynamicSmemBytes = 0;
+  config.stream = stream;
+  cudaLaunchAttribute attrs[1];
+  attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+  attrs[0].val.programmaticStreamSerializationAllowed = 1;
+  config.attrs = attrs;
+  config.numAttrs = 1;
+  cudaLaunchKernelEx(&config, kernel,
+                     reinterpret_cast<const __nv_bfloat16*>(x_q),
+                     reinterpret_cast<const __nv_bfloat16*>(x_k),
+                     reinterpret_cast<const __nv_bfloat16*>(x_v),
+                     reinterpret_cast<const float*>(w_q_t),
+                     reinterpret_cast<const float*>(w_k_t),
+                     reinterpret_cast<const float*>(w_v_t),
+                     reinterpret_cast<const float*>(bias_q),
+                     reinterpret_cast<const float*>(bias_k),
+                     reinterpret_cast<const float*>(bias_v),
+                     reinterpret_cast<__nv_bfloat16*>(cs_q),
+                     reinterpret_cast<__nv_bfloat16*>(cs_k),
+                     reinterpret_cast<__nv_bfloat16*>(cs_v), a_log,
+                     reinterpret_cast<const __nv_bfloat16*>(g), dt_bias,
+                     reinterpret_cast<const __nv_bfloat16*>(beta),
+                     reinterpret_cast<const __nv_bfloat16*>(onorm_g),
+                     onorm_weight, ssm_state_indices, cu_seqlens, state,
+                     reinterpret_cast<__nv_bfloat16*>(out), B, H, HV,
+                     lower_bound, scale, onorm_eps, strides);
+}
+
+template <bool kApplyOnorm, bool kUseLowerBound, bool kApplyBetaSigmoid>
+void launch_kda_decode_many_heads_selected(
+    const void* x_q, const void* x_k, const void* x_v, const void* w_q_t,
+    const void* w_k_t, const void* w_v_t, const void* bias_q,
+    const void* bias_k, const void* bias_v, void* cs_q, void* cs_k, void* cs_v,
+    const float* a_log, const void* g, const float* dt_bias, const void* beta,
+    const void* onorm_g, const float* onorm_weight,
+    const int* ssm_state_indices, const int* cu_seqlens, float* state,
+    void* out, int B, int H, int HV, bool update_conv_cache, float lower_bound,
+    float scale, float onorm_eps, KdaDecodeStrides strides,
+    cudaStream_t stream) {
+#define LAUNCH_KDA_DECODE(NUM_HEADS)                                        \
+  do {                                                                      \
+    if (update_conv_cache) {                                                \
+      launch_kda_decode_many_heads_raw<NUM_HEADS, kApplyOnorm, true,        \
+                                       kUseLowerBound, kApplyBetaSigmoid>(  \
+          x_q, x_k, x_v, w_q_t, w_k_t, w_v_t, bias_q, bias_k, bias_v, cs_q, \
+          cs_k, cs_v, a_log, g, dt_bias, beta, onorm_g, onorm_weight,       \
+          ssm_state_indices, cu_seqlens, state, out, B, H, HV, lower_bound, \
+          scale, onorm_eps, strides, stream);                               \
+    } else {                                                                \
+      launch_kda_decode_many_heads_raw<NUM_HEADS, kApplyOnorm, false,       \
+                                       kUseLowerBound, kApplyBetaSigmoid>(  \
+          x_q, x_k, x_v, w_q_t, w_k_t, w_v_t, bias_q, bias_k, bias_v, cs_q, \
+          cs_k, cs_v, a_log, g, dt_bias, beta, onorm_g, onorm_weight,       \
+          ssm_state_indices, cu_seqlens, state, out, B, H, HV, lower_bound, \
+          scale, onorm_eps, strides, stream);                               \
+    }                                                                       \
+  } while (false)
+
+  switch (H) {
+    case 12:
+      LAUNCH_KDA_DECODE(12);
+      break;
+    case 24:
+      LAUNCH_KDA_DECODE(24);
+      break;
+    case 48:
+      LAUNCH_KDA_DECODE(48);
+      break;
+    case 96:
+      LAUNCH_KDA_DECODE(96);
+      break;
+    default:
+      STD_TORCH_CHECK(false, "Unsupported number of heads: ", H);
+  }
+
+#undef LAUNCH_KDA_DECODE
+}
+
+struct KdaDecodeLaunchParams {
+  const void* x_q;
+  const void* x_k;
+  const void* x_v;
+  const void* w_q_t;
+  const void* w_k_t;
+  const void* w_v_t;
+  const void* bias_q;
+  const void* bias_k;
+  const void* bias_v;
+  void* cs_q;
+  void* cs_k;
+  void* cs_v;
+  const float* a_log;
+  const void* g;
+  const float* dt_bias;
+  const void* beta;
+  const void* onorm_g;
+  const float* onorm_weight;
+  const int* ssm_state_indices;
+  const int* cu_seqlens;
+  float* state;
+  void* out;
+  int B;
+  int H;
+  int HV;
+  bool update_conv_cache;
+  float lower_bound;
+  float scale;
+  float onorm_eps;
+  KdaDecodeStrides strides;
+  cudaStream_t stream;
+};
+
+template <bool kApplyOnorm, bool kUseLowerBound, bool kApplyBetaSigmoid>
+void launch_kda_decode_selected_backend(const KdaDecodeLaunchParams& p) {
+  launch_kda_decode_many_heads_selected<kApplyOnorm, kUseLowerBound,
+                                        kApplyBetaSigmoid>(
+      p.x_q, p.x_k, p.x_v, p.w_q_t, p.w_k_t, p.w_v_t, p.bias_q, p.bias_k,
+      p.bias_v, p.cs_q, p.cs_k, p.cs_v, p.a_log, p.g, p.dt_bias, p.beta,
+      p.onorm_g, p.onorm_weight, p.ssm_state_indices, p.cu_seqlens, p.state,
+      p.out, p.B, p.H, p.HV, p.update_conv_cache, p.lower_bound, p.scale,
+      p.onorm_eps, p.strides, p.stream);
+}
+
+template <bool kApplyOnorm, bool kUseLowerBound>
+void dispatch_kda_decode_beta(const KdaDecodeLaunchParams& p,
+                              bool apply_beta_sigmoid) {
+  if (apply_beta_sigmoid) {
+    launch_kda_decode_selected_backend<kApplyOnorm, kUseLowerBound, true>(p);
+  } else {
+    launch_kda_decode_selected_backend<kApplyOnorm, kUseLowerBound, false>(p);
+  }
+}
+
+template <bool kApplyOnorm>
+void dispatch_kda_decode_decay(const KdaDecodeLaunchParams& p,
+                               bool use_lower_bound, bool apply_beta_sigmoid) {
+  if (use_lower_bound) {
+    dispatch_kda_decode_beta<kApplyOnorm, true>(p, apply_beta_sigmoid);
+  } else {
+    dispatch_kda_decode_beta<kApplyOnorm, false>(p, apply_beta_sigmoid);
+  }
+}
+
+void dispatch_kda_decode_features(const KdaDecodeLaunchParams& p,
+                                  bool apply_onorm, bool use_lower_bound,
+                                  bool apply_beta_sigmoid) {
+  if (apply_onorm) {
+    dispatch_kda_decode_decay<true>(p, use_lower_bound, apply_beta_sigmoid);
+  } else {
+    dispatch_kda_decode_decay<false>(p, use_lower_bound, apply_beta_sigmoid);
+  }
+}
+
+}  // namespace
+
+extern "C" void launch_kda_decode_many_heads_cuda(
+    const void* x_q, const void* x_k, const void* x_v, const void* w_q_t,
+    const void* w_k_t, const void* w_v_t, const void* bias_q,
+    const void* bias_k, const void* bias_v, void* cs_q, void* cs_k, void* cs_v,
+    const float* a_log, const void* g, const float* dt_bias, const void* beta,
+    const void* onorm_g, const float* onorm_weight,
+    const int* ssm_state_indices, const int* cu_seqlens, float* state,
+    void* out, int B, int H, int HV, bool apply_onorm, bool update_conv_cache,
+    bool use_lower_bound, bool apply_beta_sigmoid, float lower_bound,
+    float scale, float onorm_eps, const int64_t* raw_strides,
+    cudaStream_t stream) {
+  const KdaDecodeStrides strides{raw_strides[0], raw_strides[1], raw_strides[2],
+                                 raw_strides[3], raw_strides[4]};
+  const KdaDecodeLaunchParams params{x_q,
+                                     x_k,
+                                     x_v,
+                                     w_q_t,
+                                     w_k_t,
+                                     w_v_t,
+                                     bias_q,
+                                     bias_k,
+                                     bias_v,
+                                     cs_q,
+                                     cs_k,
+                                     cs_v,
+                                     a_log,
+                                     g,
+                                     dt_bias,
+                                     beta,
+                                     onorm_g,
+                                     onorm_weight,
+                                     ssm_state_indices,
+                                     cu_seqlens,
+                                     state,
+                                     out,
+                                     B,
+                                     H,
+                                     HV,
+                                     update_conv_cache,
+                                     lower_bound,
+                                     scale,
+                                     onorm_eps,
+                                     strides,
+                                     stream};
+  dispatch_kda_decode_features(params, apply_onorm, use_lower_bound,
+                               apply_beta_sigmoid);
+}
+
+void fused_kda_decode(
+    torch::stable::Tensor const& x, torch::stable::Tensor const& weight,
+    std::optional<torch::stable::Tensor> bias,
+    torch::stable::Tensor& conv_state, torch::stable::Tensor const& raw_g,
+    torch::stable::Tensor const& raw_beta, torch::stable::Tensor const& a_log,
+    torch::stable::Tensor const& dt_bias,
+    torch::stable::Tensor const& state_indices, torch::stable::Tensor& state,
+    torch::stable::Tensor& out, std::optional<double> lower_bound,
+    std::optional<torch::stable::Tensor> output_gate,
+    std::optional<torch::stable::Tensor> norm_weight, double norm_eps) {
+  using torch::headeronly::ScalarType;
+  constexpr int kHeadDim = 128;
+  constexpr int kConvWidth = 4;
+
+  STD_TORCH_CHECK(x.is_cuda() && x.scalar_type() == ScalarType::BFloat16,
+                  "x must be a CUDA bfloat16 tensor");
+  STD_TORCH_CHECK(weight.is_cuda() && weight.scalar_type() == ScalarType::Float,
+                  "weight must be a CUDA float32 tensor");
+  STD_TORCH_CHECK(
+      conv_state.is_cuda() && conv_state.scalar_type() == ScalarType::BFloat16,
+      "conv_state must be a CUDA bfloat16 tensor");
+  STD_TORCH_CHECK(
+      raw_g.is_cuda() && raw_g.scalar_type() == ScalarType::BFloat16,
+      "raw_g must be a CUDA bfloat16 tensor");
+  STD_TORCH_CHECK(
+      raw_beta.is_cuda() && raw_beta.scalar_type() == ScalarType::BFloat16,
+      "raw_beta must be a CUDA bfloat16 tensor");
+  STD_TORCH_CHECK(a_log.is_cuda() && a_log.scalar_type() == ScalarType::Float,
+                  "A_log must be a CUDA float32 tensor");
+  STD_TORCH_CHECK(
+      dt_bias.is_cuda() && dt_bias.scalar_type() == ScalarType::Float,
+      "dt_bias must be a CUDA float32 tensor");
+  STD_TORCH_CHECK(state.is_cuda() && state.scalar_type() == ScalarType::Float,
+                  "state must be a CUDA float32 tensor");
+  STD_TORCH_CHECK(out.is_cuda() && out.scalar_type() == ScalarType::BFloat16,
+                  "out must be a CUDA bfloat16 tensor");
+  STD_TORCH_CHECK(
+      state_indices.is_cuda() && state_indices.scalar_type() == ScalarType::Int,
+      "state_indices must be a CUDA int32 tensor");
+
+  STD_TORCH_CHECK(x.dim() == 2, "x must have shape [B, 3 * H * 128]");
+  int const batch_size = static_cast<int>(x.size(0));
+  int64_t const qkv_width = x.size(1);
+  STD_TORCH_CHECK(qkv_width % (3 * kHeadDim) == 0,
+                  "x must have shape [B, 3 * H * 128]");
+  int64_t const num_heads = qkv_width / (3 * kHeadDim);
+  STD_TORCH_CHECK(
+      num_heads == 12 || num_heads == 24 || num_heads == 48 || num_heads == 96,
+      "H must be 12, 24, 48, or 96, got ", num_heads);
+  STD_TORCH_CHECK(batch_size > 0,
+                  "KDA decode fusion requires at least one row");
+  int const dim = num_heads * kHeadDim;
+
+  STD_TORCH_CHECK(weight.dim() == 3 && weight.is_contiguous() &&
+                      weight.size(0) == 3 && weight.size(1) == kConvWidth &&
+                      weight.size(2) == dim,
+                  "weight must have shape [3, 4, H * 128]");
+  STD_TORCH_CHECK(conv_state.dim() == 3 && conv_state.size(1) == 3 * dim &&
+                      conv_state.size(2) == kConvWidth - 1,
+                  "conv_state must have shape [slots, 3 * H * 128, 3]");
+  STD_TORCH_CHECK(raw_g.dim() == 4 && raw_g.size(0) == 1 &&
+                      raw_g.size(1) == batch_size &&
+                      raw_g.size(2) == num_heads && raw_g.size(3) == kHeadDim,
+                  "raw_g must have shape [1, B, H, 128]");
+  STD_TORCH_CHECK(raw_beta.dim() == 3 && raw_beta.size(0) == 1 &&
+                      raw_beta.size(1) == batch_size &&
+                      raw_beta.size(2) == num_heads,
+                  "raw_beta must have shape [1, B, H]");
+  STD_TORCH_CHECK(a_log.is_contiguous() && a_log.numel() == num_heads,
+                  "A_log must be contiguous with H elements");
+  STD_TORCH_CHECK(dt_bias.is_contiguous() && dt_bias.numel() == dim,
+                  "dt_bias must be contiguous with H * 128 elements");
+  STD_TORCH_CHECK(
+      state_indices.is_contiguous() && state_indices.numel() == batch_size,
+      "state_indices must be contiguous with B elements");
+  STD_TORCH_CHECK(state.dim() == 4 && state.size(1) == num_heads &&
+                      state.size(2) == kHeadDim && state.size(3) == kHeadDim,
+                  "state must have shape [slots, H, 128, 128]");
+  STD_TORCH_CHECK(out.dim() == 4 && out.size(0) == 1 &&
+                      out.size(1) == batch_size && out.size(2) == num_heads &&
+                      out.size(3) == kHeadDim,
+                  "out must have shape [1, B, H, 128]");
+  STD_TORCH_CHECK(x.stride(1) == 1,
+                  "x must be contiguous in its channel dimension");
+  STD_TORCH_CHECK(conv_state.stride(0) >= 3 * dim * (kConvWidth - 1) &&
+                      conv_state.stride(1) == 1 &&
+                      conv_state.stride(2) == 3 * dim,
+                  "conv_state must use the SD cache layout");
+  STD_TORCH_CHECK(state.stride(0) >= num_heads * kHeadDim * kHeadDim &&
+                      state.stride(1) == kHeadDim * kHeadDim &&
+                      state.stride(2) == kHeadDim && state.stride(3) == 1,
+                  "state must have contiguous [H, 128, 128] slot contents");
+  STD_TORCH_CHECK(raw_g.is_contiguous(), "raw_g must be contiguous");
+  STD_TORCH_CHECK(raw_beta.stride(2) == 1,
+                  "raw_beta must be contiguous in its head dimension");
+  STD_TORCH_CHECK(out.is_contiguous(), "out must be contiguous");
+
+  bool const apply_onorm = output_gate.has_value();
+  STD_TORCH_CHECK(apply_onorm == norm_weight.has_value(),
+                  "output_gate and norm_weight must be provided together");
+  void const* output_gate_ptr = nullptr;
+  float const* norm_weight_ptr = nullptr;
+  int64_t output_gate_row_stride = 0;
+  if (apply_onorm) {
+    STD_TORCH_CHECK(output_gate->is_cuda() &&
+                        output_gate->scalar_type() == ScalarType::BFloat16,
+                    "output_gate must be a CUDA bfloat16 tensor");
+    bool const gate_is_3d =
+        output_gate->dim() == 3 && output_gate->size(0) == batch_size &&
+        output_gate->size(1) == num_heads && output_gate->size(2) == kHeadDim;
+    bool const gate_is_4d =
+        output_gate->dim() == 4 && output_gate->size(0) == 1 &&
+        output_gate->size(1) == batch_size &&
+        output_gate->size(2) == num_heads && output_gate->size(3) == kHeadDim;
+    STD_TORCH_CHECK(gate_is_3d || gate_is_4d,
+                    "output_gate must have shape [B, H, 128] or "
+                    "[1, B, H, 128]");
+    int const row_dim = gate_is_3d ? 0 : 1;
+    STD_TORCH_CHECK(output_gate->stride(output_gate->dim() - 1) == 1,
+                    "output_gate must be contiguous in its last dimension");
+    STD_TORCH_CHECK(output_gate->stride(row_dim + 1) == kHeadDim,
+                    "output_gate must have contiguous head rows");
+    STD_TORCH_CHECK(norm_weight->is_cuda() &&
+                        norm_weight->scalar_type() == ScalarType::Float,
+                    "norm_weight must be a CUDA float32 tensor");
+    STD_TORCH_CHECK(
+        norm_weight->is_contiguous() && norm_weight->numel() == kHeadDim,
+        "norm_weight must be contiguous with 128 elements");
+    STD_TORCH_CHECK(norm_eps >= 0.0, "norm_eps must be non-negative");
+    output_gate_ptr = output_gate->data_ptr();
+    norm_weight_ptr = static_cast<float const*>(norm_weight->data_ptr());
+    output_gate_row_stride = output_gate->stride(row_dim);
+  }
+
+  void const* bias_ptr = nullptr;
+  if (bias.has_value()) {
+    STD_TORCH_CHECK(bias->is_cuda() && bias->scalar_type() == ScalarType::Float,
+                    "bias must be a CUDA float32 tensor");
+    STD_TORCH_CHECK(bias->is_contiguous() && bias->numel() == 3 * dim,
+                    "bias must be contiguous with 3 * H * 128 elements");
+    bias_ptr = bias->data_ptr();
+  }
+
+  auto const* x_ptr = static_cast<char const*>(x.data_ptr());
+  auto const* weight_ptr = static_cast<char const*>(weight.data_ptr());
+  auto* conv_ptr = static_cast<char*>(conv_state.data_ptr());
+  auto const* bias_bytes = static_cast<char const*>(bias_ptr);
+  int64_t const segment_bytes = dim * sizeof(__nv_bfloat16);
+  int64_t const weight_segment_bytes =
+      dim * kConvWidth * static_cast<int64_t>(sizeof(float));
+  int64_t const conv_segment_bytes =
+      dim * conv_state.stride(1) * sizeof(__nv_bfloat16);
+  int64_t const bias_segment_bytes = dim * sizeof(float);
+  std::array<int64_t, 5> const strides{
+      x.stride(0),          raw_beta.stride(1), output_gate_row_stride,
+      conv_state.stride(0), state.stride(0),
+  };
+  bool const use_lower_bound = lower_bound.has_value();
+  float const lower_bound_value =
+      use_lower_bound ? static_cast<float>(*lower_bound) : 0.0f;
+
+  torch::stable::accelerator::DeviceGuard const device_guard(
+      x.get_device_index());
+  cudaStream_t const stream = get_current_cuda_stream(x.get_device_index());
+  launch_kda_decode_many_heads_cuda(
+      x_ptr, x_ptr + segment_bytes, x_ptr + 2 * segment_bytes, weight_ptr,
+      weight_ptr + weight_segment_bytes, weight_ptr + 2 * weight_segment_bytes,
+      bias_bytes,
+      bias_bytes == nullptr ? nullptr : bias_bytes + bias_segment_bytes,
+      bias_bytes == nullptr ? nullptr : bias_bytes + 2 * bias_segment_bytes,
+      conv_ptr, conv_ptr + conv_segment_bytes,
+      conv_ptr + 2 * conv_segment_bytes,
+      static_cast<float const*>(a_log.data_ptr()), raw_g.data_ptr(),
+      static_cast<float const*>(dt_bias.data_ptr()), raw_beta.data_ptr(),
+      output_gate_ptr, norm_weight_ptr,
+      static_cast<int const*>(state_indices.data_ptr()), nullptr,
+      static_cast<float*>(state.data_ptr()), out.data_ptr(), batch_size,
+      num_heads, num_heads, apply_onorm, true, use_lower_bound, true,
+      lower_bound_value, 0.08838834764831845f, static_cast<float>(norm_eps),
+      strides.data(), stream);
+  cudaError_t const error = cudaGetLastError();
+  STD_TORCH_CHECK(
+      error == cudaSuccess,
+      "Kimi K3 KDA decode kernel launch failed: ", cudaGetErrorString(error));
+}

--- a/csrc/libtorch_stable/ops.h
+++ b/csrc/libtorch_stable/ops.h
@@ -315,6 +315,19 @@ void fused_minimax_m3_qknorm_rope_kv_insert(
     std::optional<torch::stable::Tensor> index_q_out,
     const std::string& kv_cache_dtype, bool skip_index_branch);
 
+#ifdef VLLM_ENABLE_FUSED_KDA_DECODE
+void fused_kda_decode(
+    torch::stable::Tensor const& x, torch::stable::Tensor const& weight,
+    std::optional<torch::stable::Tensor> bias,
+    torch::stable::Tensor& conv_state, torch::stable::Tensor const& raw_g,
+    torch::stable::Tensor const& raw_beta, torch::stable::Tensor const& a_log,
+    torch::stable::Tensor const& dt_bias,
+    torch::stable::Tensor const& state_indices, torch::stable::Tensor& state,
+    torch::stable::Tensor& out, std::optional<double> lower_bound,
+    std::optional<torch::stable::Tensor> output_gate,
+    std::optional<torch::stable::Tensor> norm_weight, double norm_eps);
+#endif
+
 // Sampler kernels (shared CUDA/ROCm)
 void apply_repetition_penalties_(
     torch::stable::Tensor& logits, const torch::stable::Tensor& prompt_mask,

--- a/csrc/libtorch_stable/torch_bindings.cpp
+++ b/csrc/libtorch_stable/torch_bindings.cpp
@@ -468,6 +468,16 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C, ops) {
       "int block_size, Tensor!? q_out, Tensor!? index_q_out, "
       "str kv_cache_dtype, bool skip_index_branch=False) -> ()");
 
+#ifdef VLLM_ENABLE_FUSED_KDA_DECODE
+  ops.def(
+      "fused_kda_decode("
+      "Tensor x, Tensor weight, Tensor? bias, Tensor! conv_state, "
+      "Tensor raw_g, Tensor raw_beta, Tensor A_log, Tensor dt_bias, "
+      "Tensor state_indices, Tensor! state, Tensor! out, "
+      "float? lower_bound=None, Tensor? output_gate=None, "
+      "Tensor? norm_weight=None, float norm_eps=1e-5) -> ()");
+#endif
+
   // Apply repetition penalties to logits in-place.
   ops.def(
       "apply_repetition_penalties_(Tensor! logits, Tensor prompt_mask, "
@@ -693,6 +703,9 @@ STABLE_TORCH_LIBRARY_IMPL(_C, CUDA, ops) {
 #endif
   ops.impl("fused_minimax_m3_qknorm_rope_kv_insert",
            TORCH_BOX(&fused_minimax_m3_qknorm_rope_kv_insert));
+#ifdef VLLM_ENABLE_FUSED_KDA_DECODE
+  ops.impl("fused_kda_decode", TORCH_BOX(&fused_kda_decode));
+#endif
 
   // Sampler kernels (shared CUDA/ROCm)
   ops.impl("apply_repetition_penalties_",

--- a/setup.py
+++ b/setup.py
@@ -783,6 +783,7 @@ class precompiled_wheel_utils:
                             "vllm/_qutlass_C.abi3.so",
                             "vllm/_flashmla_C.abi3.so",
                             "vllm/_flashmla_extension_C.abi3.so",
+                            "vllm/_flashkda_C.abi3.so",
                             "vllm/_sparse_flashmla_C.abi3.so",
                             "vllm/vllm_flash_attn/_vllm_fa2_C.abi3.so",
                             "vllm/vllm_flash_attn/_vllm_fa3_C.abi3.so",
@@ -1150,6 +1151,10 @@ if _is_cuda():
         ext_modules.append(
             CMakeExtension(name="vllm._flashmla_extension_C", optional=True)
         )
+    if USE_PRECOMPILED_EXTENSIONS or (
+        CUDA_HOME and get_nvcc_cuda_version() >= Version("12.0")
+    ):
+        ext_modules.append(CMakeExtension(name="vllm._flashkda_C", optional=True))
     if envs.VLLM_USE_PRECOMPILED or (
         CUDA_HOME and get_nvcc_cuda_version() >= Version("12.3")
     ):

--- a/tests/models/kimi_k3/test_kda.py
+++ b/tests/models/kimi_k3/test_kda.py
@@ -1,0 +1,772 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Precision tests for vllm's chunk_kda Triton operator.
+
+Compares chunk_kda against a naive recurrent reference (float32).
+Uses torch.rand for q/k/v to match FLA's test pattern.
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from vllm import _custom_ops as ops
+from vllm.model_executor.layers.mamba.ops.causal_conv1d import causal_conv1d_update
+from vllm.model_executor.layers.mamba.ops.gather_initial_states import (
+    gather_initial_states,
+)
+from vllm.models.kimi_k3.nvidia.kda import (
+    is_flashkda_supported,
+    is_fused_kda_decode_supported,
+)
+from vllm.models.kimi_k3.nvidia.ops.third_party.kda import (
+    chunk_kda,
+    chunk_kda_with_fused_gate,
+    fused_kda_gate,
+    fused_recurrent_kda,
+    fused_recurrent_kda_fwd,
+    fused_recurrent_kda_packed_decode,
+)
+from vllm.third_party.flash_linear_attention.ops.l2norm import l2norm_fwd
+
+DEVICE = "cuda"
+
+
+@torch.inference_mode()
+def test_gather_initial_states_correctness():
+    row_size = 8 * 128 * 128
+    storage = torch.randn(5, row_size + 256, dtype=torch.float32, device=DEVICE)
+    state = storage[:, :row_size].view(5, 8, 128, 128)
+    assert not state.is_contiguous()
+    assert state[0].is_contiguous()
+    indices = torch.tensor([4, 1, 3], dtype=torch.int32, device=DEVICE)
+    has_initial_state = torch.tensor([True, False, True], device=DEVICE)
+
+    expected = state[indices].clone()
+    expected[~has_initial_state] = 0
+
+    torch.testing.assert_close(
+        gather_initial_states(state, indices, has_initial_state),
+        expected,
+    )
+
+
+def naive_recurrent_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float | None = None,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Naive recurrent KDA reference, ported from FLA's naive.py."""
+    dtype = v.dtype
+    B, T, H, K = q.shape
+    V = v.shape[-1]
+    if scale is None:
+        scale = K**-0.5
+
+    q, k, v, g, beta = (x.to(torch.float) for x in [q, k, v, g, beta])
+    q = q * scale
+
+    S = k.new_zeros(B, H, K, V).to(q)
+    if initial_state is not None:
+        S += initial_state
+    o = torch.zeros_like(v)
+    for i in range(T):
+        q_i, k_i, v_i, g_i, b_i = q[:, i], k[:, i], v[:, i], g[:, i], beta[:, i]
+        S = S * g_i[..., None].exp()
+        S = S + torch.einsum(
+            "bhk,bhv->bhkv",
+            b_i[..., None] * k_i,
+            v_i - (k_i[..., None] * S).sum(-2),
+        )
+        o[:, i] = torch.einsum("bhk,bhkv->bhv", q_i, S)
+    if not output_final_state:
+        S = None
+    return o.to(dtype), S
+
+
+def assert_close(
+    name: str,
+    ref: torch.Tensor,
+    tri: torch.Tensor,
+    ratio: float,
+    err_atol: float = 1e-6,
+):
+    """RMSE-based relative error comparison."""
+    abs_err = (ref.detach() - tri.detach()).flatten().abs().max().item()
+    rmse_diff = (ref.detach() - tri.detach()).flatten().square().mean().sqrt().item()
+    rmse_base = ref.detach().flatten().square().mean().sqrt().item()
+    rel_err = rmse_diff / (rmse_base + 1e-8)
+    print(f"{name:>4} | abs={abs_err:.6f} | rmse={rel_err:.6f} | thr={ratio}")
+    if abs_err <= err_atol:
+        return
+    assert not torch.isnan(ref).any(), f"{name}: NaN detected in ref"
+    assert not torch.isnan(tri).any(), f"{name}: NaN detected in tri"
+    assert rel_err < ratio, (
+        f"{name}: max abs err {abs_err:.6f}, rmse ratio {rel_err:.6f} >= {ratio}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("H", "D", "cu_seqlens", "dtype"),
+    [
+        pytest.param(
+            *test,
+            id="H{}-D{}-cu{}-{}".format(*test),
+        )
+        for test in [
+            (32, 128, [0, 64], torch.float16),
+            (32, 128, [0, 1024], torch.float16),
+            (32, 128, [0, 15], torch.float16),
+            (32, 128, [0, 256, 512, 768, 1024], torch.float16),
+            (32, 128, [0, 15, 100, 300, 1200], torch.float16),
+            (64, 128, [0, 256, 500, 1000], torch.float16),
+            (32, 128, [0, 8192], torch.float16),
+            (32, 128, [0, 256, 500, 1000], torch.bfloat16),
+        ]
+    ],
+)
+@torch.inference_mode()
+def test_chunk_kda(
+    H: int,
+    D: int,
+    cu_seqlens: list[int],
+    dtype: torch.dtype,
+):
+    T = cu_seqlens[-1]
+    torch.manual_seed(42)
+    B = 1
+    cu_seqlens_t = torch.LongTensor(cu_seqlens).to(DEVICE)
+    N = len(cu_seqlens) - 1
+
+    q = torch.rand(B, T, H, D, dtype=dtype, device=DEVICE)
+    k = torch.rand(B, T, H, D, dtype=dtype, device=DEVICE)
+    v = torch.rand(B, T, H, D, dtype=dtype, device=DEVICE)
+    g = F.logsigmoid(torch.randn(B, T, H, D, dtype=torch.float32, device=DEVICE)).to(
+        dtype
+    )
+    beta = torch.rand(B, T, H, dtype=dtype, device=DEVICE).sigmoid()
+    h0 = torch.randn(N, H, D, D, dtype=torch.float32, device=DEVICE)
+
+    # Naive reference with l2norm_fwd (same kernel as chunk_kda)
+    ref_outputs = []
+    ref_states = []
+    for i in range(N):
+        s, e = cu_seqlens[i], cu_seqlens[i + 1]
+        q_i = l2norm_fwd(q[:, s:e].contiguous())
+        k_i = l2norm_fwd(k[:, s:e].contiguous())
+        o_i, ht_i = naive_recurrent_kda(
+            q_i,
+            k_i,
+            v[:, s:e],
+            g[:, s:e],
+            beta[:, s:e],
+            initial_state=h0[i],
+            output_final_state=True,
+        )
+        ref_outputs.append(o_i)
+        ref_states.append(ht_i)
+    ref_o = torch.cat(ref_outputs, dim=1)
+    ref_ht = torch.cat(ref_states, dim=0)
+
+    # h0 transposed to (V, K) layout for the kernel; naive uses (K, V)
+    tri_o, tri_ht = chunk_kda(
+        q=q.clone(),
+        k=k.clone(),
+        v=v.clone(),
+        g=g.clone(),
+        beta=beta.clone(),
+        initial_state=h0.transpose(-1, -2).contiguous().clone(),
+        output_final_state=True,
+        cu_seqlens=cu_seqlens_t,
+        use_qk_l2norm_in_kernel=True,
+    )
+
+    assert not torch.isnan(tri_o).any(), "Triton output o contains NaN"
+    assert not torch.isnan(tri_ht).any(), "Triton output ht contains NaN"
+    assert_close("o", ref_o, tri_o, 0.005)
+    assert_close("ht", ref_ht, tri_ht.transpose(-1, -2).contiguous(), 0.005)
+
+
+@pytest.mark.parametrize(
+    ("cu_seqlens", "dtype", "lower_bound"),
+    [
+        ([0, 64], torch.float16, None),
+        ([0, 15, 100, 300], torch.bfloat16, None),
+        ([0, 15, 100, 300], torch.bfloat16, -3.0),
+    ],
+)
+@torch.inference_mode()
+def test_chunk_kda_fused_gate_cumsum_matches_unfused(
+    cu_seqlens: list[int],
+    dtype: torch.dtype,
+    lower_bound: float | None,
+):
+    H, D = 8, 64
+    T = cu_seqlens[-1]
+    N = len(cu_seqlens) - 1
+    torch.manual_seed(123)
+
+    cu_seqlens_t = torch.tensor(cu_seqlens, dtype=torch.int32, device=DEVICE)
+    q = torch.randn(1, T, H, D, dtype=dtype, device=DEVICE)
+    k = torch.randn(1, T, H, D, dtype=dtype, device=DEVICE)
+    v = torch.randn(1, T, H, D, dtype=dtype, device=DEVICE)
+    raw_g = torch.randn(1, T, H, D, dtype=dtype, device=DEVICE)
+    beta_storage = torch.randn(1, T, 2 * H + 3, dtype=dtype, device=DEVICE)
+    raw_beta = beta_storage[..., 1 : 2 * H + 1 : 2]
+    beta = raw_beta.float().sigmoid()
+    A_log = (torch.randn(H, dtype=torch.float32, device=DEVICE) * 0.5).contiguous()
+    dt_bias = (
+        torch.randn(H * D, dtype=torch.float32, device=DEVICE) * 0.1
+    ).contiguous()
+    h0 = torch.randn(N, H, D, D, dtype=torch.float32, device=DEVICE)
+    initial_state = h0.transpose(-1, -2).contiguous()
+
+    gate = fused_kda_gate(
+        raw_g.reshape(T, H * D),
+        A_log,
+        D,
+        g_bias=dt_bias,
+        lower_bound=lower_bound,
+    )
+    if lower_bound is not None:
+        expected_gate = lower_bound * torch.sigmoid(
+            A_log.exp()[None, :, None]
+            * (raw_g.float().view(T, H, D) + dt_bias.view(H, D))
+        )
+        torch.testing.assert_close(gate, expected_gate)
+    gate = gate.unsqueeze(0)
+    old_o, old_ht = chunk_kda(
+        q=q.clone(),
+        k=k.clone(),
+        v=v.clone(),
+        g=gate,
+        beta=beta,
+        initial_state=initial_state.clone(),
+        output_final_state=True,
+        cu_seqlens=cu_seqlens_t,
+        use_qk_l2norm_in_kernel=True,
+    )
+    new_o, new_ht = chunk_kda_with_fused_gate(
+        q=q.clone(),
+        k=k.clone(),
+        v=v.clone(),
+        raw_g=raw_g,
+        raw_beta=raw_beta,
+        A_log=A_log,
+        g_bias=dt_bias,
+        lower_bound=lower_bound,
+        initial_state=initial_state.clone(),
+        output_final_state=True,
+        cu_seqlens=cu_seqlens_t,
+        use_qk_l2norm_in_kernel=True,
+    )
+
+    assert_close("o", old_o, new_o, 1e-3, err_atol=1e-3)
+    assert_close("ht", old_ht, new_ht, 1e-3, err_atol=1e-3)
+
+
+@pytest.mark.parametrize("num_seqs", [1, 8, 32])
+@pytest.mark.parametrize("lower_bound", [-5.0, None])
+@pytest.mark.parametrize("state_indices_stride", [1, 8])
+@torch.inference_mode()
+def test_packed_kda_decode_correctness(
+    num_seqs: int,
+    lower_bound: float | None,
+    state_indices_stride: int,
+):
+    H, D = 8, 128
+    torch.manual_seed(321)
+
+    packed_storage = torch.randn(
+        num_seqs,
+        3 * H * D + 1,
+        dtype=torch.bfloat16,
+        device=DEVICE,
+    )
+    mixed_qkv = packed_storage[:, : 3 * H * D]
+    assert mixed_qkv.stride(0) == 3 * H * D + 1
+    q, k, v = (
+        x.contiguous().view(1, num_seqs, H, D) for x in mixed_qkv.split(H * D, dim=-1)
+    )
+    raw_g = torch.randn(
+        1,
+        num_seqs,
+        H,
+        D,
+        dtype=torch.bfloat16,
+        device=DEVICE,
+    )
+    raw_beta = torch.randn(
+        1,
+        num_seqs,
+        H,
+        dtype=torch.bfloat16,
+        device=DEVICE,
+    )
+    beta = raw_beta.float().sigmoid()
+    A_log = torch.randn(H, dtype=torch.float32, device=DEVICE) * 0.5
+    dt_bias = torch.randn(H, D, dtype=torch.float32, device=DEVICE) * 0.1
+    state_storage = torch.randn(
+        num_seqs + 1,
+        H * D * D + 17,
+        dtype=torch.float32,
+        device=DEVICE,
+    )
+    state = state_storage[:, : H * D * D].view(num_seqs + 1, H, D, D)
+    assert not state.is_contiguous()
+    assert state.stride()[1:] == (D * D, D, 1)
+    state_indices_storage = torch.zeros(
+        num_seqs,
+        state_indices_stride,
+        dtype=torch.int32,
+        device=DEVICE,
+    )
+    state_indices = state_indices_storage[:, 0]
+    state_indices.copy_(
+        torch.arange(
+            1,
+            num_seqs + 1,
+            dtype=torch.int32,
+            device=DEVICE,
+        )
+    )
+    gate = fused_kda_gate(
+        raw_g.reshape(num_seqs, H * D),
+        A_log,
+        D,
+        g_bias=dt_bias,
+        lower_bound=lower_bound,
+    ).unsqueeze(0)
+    dense_state = state.clone()
+    dense_out, _ = fused_recurrent_kda_fwd(
+        q=q,
+        k=k,
+        v=v,
+        g=gate,
+        beta=beta,
+        scale=D**-0.5,
+        initial_state=dense_state,
+        inplace_final_state=True,
+        cu_seqlens=torch.arange(
+            num_seqs + 1,
+            dtype=torch.int32,
+            device=DEVICE,
+        ),
+        ssm_state_indices=state_indices,
+        use_qk_l2norm_in_kernel=True,
+    )
+    packed_state = state
+    packed_out, _ = fused_recurrent_kda_packed_decode(
+        mixed_qkv=mixed_qkv,
+        raw_g=raw_g,
+        raw_beta=raw_beta,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        lower_bound=lower_bound,
+        initial_state=packed_state,
+        state_indices=state_indices,
+    )
+
+    assert_close("o", dense_out, packed_out, 1e-3, err_atol=1e-3)
+    assert_close("ht", dense_state, packed_state, 1e-3, err_atol=1e-3)
+
+
+@pytest.mark.parametrize(
+    ("H", "fuse_gate"),
+    [(12, True), (12, False), (12, None), (96, None)],
+)
+@pytest.mark.parametrize("lower_bound", [-5.0, None])
+@torch.inference_mode()
+def test_kda_spec_decode_correctness(
+    H: int,
+    fuse_gate: bool | None,
+    lower_bound: float | None,
+):
+    num_seqs, query_len, D = 3, 3, 128
+    T = num_seqs * query_len
+    torch.manual_seed(1234)
+
+    qkv_storage = torch.randn(
+        1,
+        T,
+        3 * H * D + 7,
+        dtype=torch.bfloat16,
+        device=DEVICE,
+    )
+    packed_qkv = qkv_storage[..., : 3 * H * D]
+    q, k, v = (x.view(1, T, H, D) for x in packed_qkv.split(H * D, dim=-1))
+    gate_storage = torch.randn(
+        1,
+        T,
+        H * D + 5,
+        dtype=torch.bfloat16,
+        device=DEVICE,
+    )
+    raw_g = gate_storage[..., : H * D].view(1, T, H, D)
+    beta_storage = torch.randn(
+        1,
+        T,
+        H + 1,
+        dtype=torch.bfloat16,
+        device=DEVICE,
+    )
+    raw_beta = beta_storage[..., :H]
+    A_log = 0.5 * torch.randn(H, dtype=torch.float32, device=DEVICE)
+    dt_bias = 0.1 * torch.randn(H, D, dtype=torch.float32, device=DEVICE)
+    cu_seqlens = torch.arange(
+        0,
+        T + 1,
+        query_len,
+        dtype=torch.int32,
+        device=DEVICE,
+    )
+    state_indices = torch.arange(
+        1,
+        T + 1,
+        dtype=torch.int32,
+        device=DEVICE,
+    ).view(num_seqs, query_len)
+    num_accepted_tokens = torch.tensor(
+        [1, 2, 3],
+        dtype=torch.int32,
+        device=DEVICE,
+    )
+    state_storage = 0.01 * torch.randn(
+        T + 1,
+        H * D * D + 17,
+        dtype=torch.float32,
+        device=DEVICE,
+    )
+    state = state_storage[:, : H * D * D].view(T + 1, H, D, D)
+    output_storage = torch.full(
+        (1, T, H * D + 11),
+        torch.nan,
+        dtype=torch.bfloat16,
+        device=DEVICE,
+    )
+    output = output_storage[..., : H * D].view(1, T, H, D)
+
+    gate = fused_kda_gate(
+        raw_g.contiguous().view(T, H * D),
+        A_log,
+        D,
+        g_bias=dt_bias,
+        lower_bound=lower_bound,
+    ).unsqueeze(0)
+    beta = raw_beta.float().sigmoid()
+    q_norm = l2norm_fwd(q.contiguous())
+    k_norm = l2norm_fwd(k.contiguous())
+    expected_state = state.clone()
+    expected_outputs = []
+    for seq, accepted in enumerate(num_accepted_tokens.tolist()):
+        recurrent_state = expected_state[state_indices[seq, accepted - 1]].transpose(
+            -1, -2
+        )
+        start = seq * query_len
+        for token in range(query_len):
+            token_slice = slice(start + token, start + token + 1)
+            token_output, recurrent_state = naive_recurrent_kda(
+                q_norm[:, token_slice],
+                k_norm[:, token_slice],
+                v[:, token_slice],
+                gate[:, token_slice],
+                beta[:, token_slice],
+                initial_state=recurrent_state,
+                output_final_state=True,
+            )
+            assert recurrent_state is not None
+            expected_outputs.append(token_output)
+            expected_state[state_indices[seq, token]] = recurrent_state.transpose(
+                -1, -2
+            )
+    expected = torch.cat(expected_outputs, dim=1)
+
+    actual_state = state.clone()
+    actual, _ = fused_recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        raw_g=raw_g,
+        raw_beta=raw_beta,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        lower_bound=lower_bound,
+        initial_state=actual_state,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=state_indices,
+        num_accepted_tokens=num_accepted_tokens,
+        out=output,
+        fuse_gate=fuse_gate,
+    )
+
+    assert actual.data_ptr() == output.data_ptr()
+    assert_close("o", expected, actual, 1e-3, err_atol=1e-3)
+    used_states = state_indices.flatten().long()
+    assert_close(
+        "ht",
+        expected_state[used_states],
+        actual_state[used_states],
+        3e-3,
+        err_atol=3e-3,
+    )
+    assert torch.isnan(output_storage[..., H * D :]).all()
+
+
+@pytest.mark.parametrize(
+    ("num_heads", "num_seqs", "lower_bound", "fuse_output_norm"),
+    [
+        (12, 1, -5.0, True),
+        (12, 4, None, False),
+        (24, 4, None, False),
+        (48, 1, -5.0, True),
+        (96, 1, -5.0, True),
+    ],
+)
+@torch.inference_mode()
+def test_fused_kda_decode_correctness(
+    num_heads: int,
+    num_seqs: int,
+    lower_bound: float | None,
+    fuse_output_norm: bool,
+):
+    D, W = 128, 4
+    if not is_fused_kda_decode_supported(
+        num_heads,
+        D,
+        W,
+        num_spec=0,
+        input_dtype=torch.bfloat16,
+        conv_state_dtype=torch.bfloat16,
+    ):
+        pytest.skip("Fused KDA decode is not supported on this platform")
+    torch.manual_seed(967 + num_heads + num_seqs)
+    dim = num_heads * D
+    slots = num_seqs + 2
+    packed_x_storage = torch.randn(
+        num_seqs, 3 * dim + 17, dtype=torch.bfloat16, device=DEVICE
+    )
+    packed_x = packed_x_storage[:, : 3 * dim]
+    weight = 0.1 * torch.randn(3 * dim, W, dtype=torch.float32, device=DEVICE)
+    conv_seed = 0.1 * torch.randn(
+        slots,
+        W - 1,
+        3 * dim,
+        dtype=torch.bfloat16,
+        device=DEVICE,
+    ).transpose(1, 2)
+    raw_g = torch.randn(
+        1,
+        num_seqs,
+        num_heads,
+        D,
+        dtype=torch.bfloat16,
+        device=DEVICE,
+    )
+    raw_beta_storage = torch.randn(
+        1,
+        num_seqs,
+        num_heads + 1,
+        dtype=torch.bfloat16,
+        device=DEVICE,
+    )
+    raw_beta = raw_beta_storage[:, :, :num_heads]
+    output_gate_storage = torch.randn(
+        num_seqs,
+        dim + 7,
+        dtype=torch.bfloat16,
+        device=DEVICE,
+    )
+    output_gate = output_gate_storage[:, :dim].view(num_seqs, num_heads, D)
+    norm_weight = torch.randn(D, dtype=torch.float32, device=DEVICE)
+    norm_eps = 1e-5
+    A_log = 0.5 * torch.randn(num_heads, dtype=torch.float32, device=DEVICE)
+    dt_bias = 0.1 * torch.randn(dim, dtype=torch.float32, device=DEVICE)
+    state_indices = torch.arange(
+        num_seqs,
+        0,
+        -1,
+        dtype=torch.int32,
+        device=DEVICE,
+    )
+    state_seed = 0.01 * torch.randn(
+        slots,
+        num_heads,
+        D,
+        D,
+        dtype=torch.float32,
+        device=DEVICE,
+    )
+
+    conv_ref = conv_seed.clone()
+    state_ref = state_seed.clone()
+    mixed_qkv = causal_conv1d_update(
+        packed_x,
+        conv_ref,
+        weight,
+        activation="silu",
+        conv_state_indices=state_indices,
+        validate_data=True,
+        out=torch.empty_like(packed_x),
+    )
+    expected, _ = fused_recurrent_kda_packed_decode(
+        mixed_qkv=mixed_qkv,
+        raw_g=raw_g,
+        raw_beta=raw_beta,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        lower_bound=lower_bound,
+        initial_state=state_ref,
+        state_indices=state_indices,
+    )
+    if fuse_output_norm:
+        expected_float = expected.float()
+        expected = (
+            expected_float
+            * torch.rsqrt(expected_float.square().mean(dim=-1, keepdim=True) + norm_eps)
+            * norm_weight
+            * output_gate.float().sigmoid().unsqueeze(0)
+        ).to(expected.dtype)
+
+    conv_slot_elements = 3 * dim * (W - 1)
+    state_slot_elements = num_heads * D * D
+    conv_slot_bytes = conv_slot_elements * torch.bfloat16.itemsize
+    page_bytes = conv_slot_bytes + state_slot_elements * torch.float32.itemsize
+    cache_storage = torch.empty(slots * page_bytes, dtype=torch.uint8, device=DEVICE)
+    conv_actual = torch.as_strided(
+        cache_storage.view(torch.bfloat16),
+        size=(slots, 3 * dim, W - 1),
+        stride=(page_bytes // torch.bfloat16.itemsize, 1, 3 * dim),
+    )
+    state_actual = torch.as_strided(
+        cache_storage.view(torch.float32),
+        size=(slots, num_heads, D, D),
+        stride=(page_bytes // torch.float32.itemsize, D * D, D, 1),
+        storage_offset=conv_slot_bytes // torch.float32.itemsize,
+    )
+    conv_actual.copy_(conv_seed)
+    state_actual.copy_(state_seed)
+    fused_weight = weight.reshape(3, dim, W).transpose(1, 2).contiguous()
+    actual = ops.fused_kda_decode(
+        x=packed_x,
+        weight=fused_weight,
+        bias=None,
+        conv_state=conv_actual,
+        raw_g=raw_g,
+        raw_beta=raw_beta,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        state_indices=state_indices,
+        state=state_actual,
+        lower_bound=lower_bound,
+        output_gate=output_gate if fuse_output_norm else None,
+        norm_weight=norm_weight if fuse_output_norm else None,
+        norm_eps=norm_eps,
+    )
+
+    torch.testing.assert_close(actual, expected, atol=3e-2, rtol=3e-2)
+    torch.testing.assert_close(conv_actual, conv_ref, atol=0, rtol=0)
+    torch.testing.assert_close(state_actual, state_ref, atol=3e-2, rtol=3e-2)
+
+
+def test_fused_kda_decode_rejects_speculative_conv_state():
+    assert not is_fused_kda_decode_supported(
+        num_heads=12,
+        head_dim=128,
+        conv_width=4,
+        num_spec=2,
+        input_dtype=torch.bfloat16,
+        conv_state_dtype=torch.bfloat16,
+    )
+
+
+def test_flashkda_schema_marks_mutable_tensors():
+    if not is_flashkda_supported(128, torch.bfloat16, -3.0):
+        pytest.skip("FlashKDA is not supported on this platform")
+
+    import vllm._flashkda_C  # noqa: F401
+
+    schema = torch.ops._flashkda_C.fwd.default._schema
+    mutable_arguments = {
+        argument.name
+        for argument in schema.arguments
+        if argument.alias_info is not None and argument.alias_info.is_write
+    }
+    assert mutable_arguments == {"out", "workspace", "final_state"}
+
+
+@torch.inference_mode()
+def test_flashkda_correctness():
+    if not is_flashkda_supported(128, torch.bfloat16, -3.0):
+        pytest.skip("FlashKDA is not supported on this platform")
+
+    import vllm._flashkda_C  # noqa: F401
+
+    B, T, H, D = 1, 48, 2, 128
+    torch.manual_seed(11)
+    q, k, v, raw_g = [
+        torch.randn(B, T, H, D, dtype=torch.bfloat16, device=DEVICE) for _ in range(4)
+    ]
+    beta_logits = torch.randn(B, T, H, dtype=torch.bfloat16, device=DEVICE)
+    A_log = torch.randn(H, dtype=torch.float32, device=DEVICE) * 0.5
+    dt_bias = torch.randn(H, D, dtype=torch.float32, device=DEVICE) * 0.1
+    initial_state = torch.randn(2, H, D, D, dtype=torch.float32, device=DEVICE)
+    cu_seqlens = torch.tensor([0, 17, T], dtype=torch.int32, device=DEVICE)
+    lower_bound = -3.0
+
+    gate = lower_bound * torch.sigmoid(
+        A_log.exp()[None, None, :, None] * (raw_g.float() + dt_bias[None, None, :, :])
+    )
+    beta = beta_logits.float().sigmoid()
+    q_norm = l2norm_fwd(q.contiguous())
+    k_norm = l2norm_fwd(k.contiguous())
+
+    expected_outputs = []
+    expected_states = []
+    for i, (start, end) in enumerate(
+        zip(cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist())
+    ):
+        output, final_state = naive_recurrent_kda(
+            q_norm[:, start:end],
+            k_norm[:, start:end],
+            v[:, start:end],
+            gate[:, start:end],
+            beta[:, start:end],
+            initial_state=initial_state[i].transpose(-1, -2),
+            output_final_state=True,
+        )
+        expected_outputs.append(output)
+        expected_states.append(final_state)
+    expected_out = torch.cat(expected_outputs, dim=1)
+    expected_state = torch.cat(expected_states).transpose(-1, -2).contiguous()
+
+    actual_out = torch.empty_like(v)
+    actual_state = torch.empty_like(initial_state)
+    workspace = torch.empty(
+        torch.ops._flashkda_C.get_workspace_size(T, H, cu_seqlens.numel() - 1),
+        dtype=torch.uint8,
+        device=DEVICE,
+    )
+    torch.ops._flashkda_C.fwd(
+        q,
+        k,
+        v,
+        raw_g,
+        beta_logits,
+        D**-0.5,
+        actual_out,
+        workspace,
+        A_log,
+        dt_bias,
+        lower_bound,
+        initial_state,
+        actual_state,
+        cu_seqlens,
+    )
+
+    assert_close("o", expected_out, actual_out, 0.01)
+    assert_close("ht", expected_state, actual_state, 0.01)

--- a/tests/models/kimi_k3/test_kda_metadata.py
+++ b/tests/models/kimi_k3/test_kda_metadata.py
@@ -1,0 +1,411 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from dataclasses import fields
+
+import pytest
+import torch
+
+from tests.v1.attention.utils import (
+    BatchSpec,
+    create_common_attn_metadata,
+    create_vllm_config,
+)
+from vllm.config import SpeculativeConfig
+from vllm.config.compilation import CUDAGraphMode
+from vllm.models.kimi_k3.nvidia.kda_metadata import (
+    KimiK3KDAAttentionBackend,
+    KimiK3KDAMetadata,
+    KimiK3KDAMetadataBuilder,
+    _mamba_get_block_table_tensor,
+    stage_spec_decode_metadata,
+)
+from vllm.v1.attention.backend import AttentionMetadataBuilder
+from vllm.v1.attention.backends.gdn_attn import (
+    GDNAttentionBackend,
+    GDNAttentionMetadata,
+    GDNAttentionMetadataBuilder,
+)
+from vllm.v1.attention.backends.utils import (
+    NULL_BLOCK_ID,
+    mamba_get_block_table_tensor,
+)
+from vllm.v1.kv_cache_interface import MambaSpec
+
+BLOCK_SIZE = 16
+DEVICE = torch.device("cpu")
+PRUNED_METADATA_FIELDS = {
+    "chunk_indices",
+    "chunk_offsets",
+    "prefill_query_start_loc",
+    "prefill_state_indices",
+    "prefill_has_initial_state",
+    "spec_sequence_masks",
+}
+
+
+def _assert_matches_shared_gdn(reference, actual: KimiK3KDAMetadata):
+    for field in fields(KimiK3KDAMetadata):
+        actual_value = getattr(actual, field.name)
+        expected_value = getattr(reference, field.name)
+        if field.name in PRUNED_METADATA_FIELDS:
+            assert actual_value is None
+            continue
+        if (
+            field.name in {"spec_token_indx", "non_spec_token_indx"}
+            and actual.num_spec_decodes > 0
+            and actual.num_prefills == 0
+            and actual.num_decodes == 0
+        ):
+            assert actual_value is None
+            continue
+        if isinstance(actual_value, torch.Tensor):
+            torch.testing.assert_close(actual_value, expected_value)
+        elif field.name == "nums_dict":
+            assert (actual_value is None) == (expected_value is None)
+            if actual_value is not None:
+                assert actual_value[8]["tot"] == expected_value[8]["tot"]
+                torch.testing.assert_close(
+                    actual_value[8]["nums"], expected_value[8]["nums"]
+                )
+        else:
+            assert actual_value == expected_value
+
+
+def _make_builder(
+    builder_cls: type[AttentionMetadataBuilder],
+    num_speculative_tokens: int,
+    full_cuda_graph: bool,
+    device: torch.device = DEVICE,
+    mamba_cache_mode: str = "none",
+) -> AttentionMetadataBuilder:
+    vllm_config = create_vllm_config(
+        model_name="Qwen/Qwen3.5-0.8B",
+        block_size=BLOCK_SIZE,
+    )
+    if num_speculative_tokens:
+        vllm_config.speculative_config = SpeculativeConfig(
+            method="ngram",
+            num_speculative_tokens=num_speculative_tokens,
+        )
+    vllm_config.compilation_config.cudagraph_mode = (
+        CUDAGraphMode.FULL_AND_PIECEWISE if full_cuda_graph else CUDAGraphMode.NONE
+    )
+    vllm_config.cache_config.mamba_cache_mode = mamba_cache_mode
+    return builder_cls(
+        kv_cache_spec=MambaSpec(
+            block_size=BLOCK_SIZE,
+            shapes=((16, 64),),
+            dtypes=(torch.float16,),
+            num_speculative_blocks=num_speculative_tokens,
+        ),
+        layer_names=["layer.0"],
+        vllm_config=vllm_config,
+        device=device,
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        "batch",
+        "num_decode_draft_tokens",
+        "num_speculative_tokens",
+        "full_cuda_graph",
+        "is_prefilling",
+    ),
+    [
+        pytest.param(
+            BatchSpec(seq_lens=[50, 30], query_lens=[3, 3]),
+            [2, 2],
+            2,
+            False,
+            [False, False],
+            id="pure-spec-decode",
+        ),
+        pytest.param(
+            BatchSpec(seq_lens=[100, 65, 20], query_lens=[50, 1, 3]),
+            [-1, -1, 2],
+            2,
+            False,
+            [True, False, False],
+            id="mixed-prefill-and-spec-decode",
+        ),
+        pytest.param(
+            BatchSpec(seq_lens=[40, 30], query_lens=[1, 1]),
+            None,
+            0,
+            False,
+            [False, False],
+            id="regular-decode",
+        ),
+        pytest.param(
+            BatchSpec(seq_lens=[40, 30], query_lens=[1, 1]),
+            [0, 0],
+            2,
+            False,
+            [False, False],
+            id="no-scheduled-draft-tokens",
+        ),
+    ],
+)
+def test_kimi_k3_kda_metadata_matches_shared_gdn(
+    batch: BatchSpec,
+    num_decode_draft_tokens: list[int] | None,
+    num_speculative_tokens: int,
+    full_cuda_graph: bool,
+    is_prefilling: list[bool],
+):
+    kwargs: dict[str, torch.Tensor] = {}
+    if num_decode_draft_tokens is not None:
+        kwargs = {
+            "num_decode_draft_tokens_cpu": torch.tensor(
+                num_decode_draft_tokens, dtype=torch.int32
+            ),
+            "num_accepted_tokens": torch.ones(
+                batch.batch_size, dtype=torch.int32, device=DEVICE
+            ),
+        }
+
+    common_attn_metadata = create_common_attn_metadata(
+        batch, BLOCK_SIZE, DEVICE
+    ).replace(is_prefilling=torch.tensor(is_prefilling, dtype=torch.bool))
+    reference = _make_builder(
+        GDNAttentionMetadataBuilder,
+        num_speculative_tokens,
+        full_cuda_graph,
+    ).build(
+        0,
+        common_attn_metadata,
+        **kwargs,
+    )
+    actual = _make_builder(
+        KimiK3KDAMetadataBuilder,
+        num_speculative_tokens,
+        full_cuda_graph,
+    ).build(0, common_attn_metadata, **kwargs)
+
+    assert isinstance(actual, KimiK3KDAMetadata)
+    _assert_matches_shared_gdn(reference, actual)
+
+
+def test_mixed_regular_and_spec_decode_uses_packed_decode_metadata():
+    batch = BatchSpec(seq_lens=[100, 65, 20], query_lens=[1, 1, 3])
+    common_attn_metadata = create_common_attn_metadata(
+        batch, BLOCK_SIZE, DEVICE
+    ).replace(is_prefilling=torch.tensor([False, False, False]))
+    actual = _make_builder(
+        KimiK3KDAMetadataBuilder,
+        num_speculative_tokens=2,
+        full_cuda_graph=False,
+    ).build(
+        0,
+        common_attn_metadata,
+        num_decode_draft_tokens_cpu=torch.tensor([-1, -1, 2], dtype=torch.int32),
+        num_accepted_tokens=torch.ones(3, dtype=torch.int32, device=DEVICE),
+    )
+
+    # The K3 layer dispatches the non-spec subgroup to packed decode whenever
+    # it contains no prefill request.
+    assert actual.num_decodes == 2
+    assert actual.num_decode_tokens == 2
+    assert actual.num_prefills == 0
+    assert actual.num_prefill_tokens == 0
+    assert actual.has_initial_state is None
+    assert actual.nums_dict is None
+    assert actual.non_spec_query_start_loc is None
+    torch.testing.assert_close(actual.non_spec_token_indx, torch.tensor([0, 1]))
+    torch.testing.assert_close(actual.spec_token_indx, torch.tensor([2, 3, 4]))
+    torch.testing.assert_close(
+        actual.spec_query_start_loc,
+        torch.tensor([0, 3], dtype=torch.int32),
+    )
+
+
+def test_mixed_regular_and_spec_decode_excludes_request_padding():
+    batch = BatchSpec(seq_lens=[16, 65, 20], query_lens=[0, 1, 3])
+    common_attn_metadata = create_common_attn_metadata(
+        batch, BLOCK_SIZE, DEVICE
+    ).replace(is_prefilling=torch.tensor([False, False, False]))
+    actual = _make_builder(
+        KimiK3KDAMetadataBuilder,
+        num_speculative_tokens=2,
+        full_cuda_graph=False,
+    ).build(
+        0,
+        common_attn_metadata,
+        num_decode_draft_tokens_cpu=torch.tensor([-1, -1, 2], dtype=torch.int32),
+        num_accepted_tokens=torch.ones(3, dtype=torch.int32, device=DEVICE),
+    )
+
+    assert actual.num_decodes == 1
+    assert actual.non_spec_state_indices_tensor is not None
+    assert actual.non_spec_state_indices_tensor.shape == (1,)
+    torch.testing.assert_close(actual.non_spec_token_indx, torch.tensor([0]))
+    torch.testing.assert_close(actual.spec_token_indx, torch.tensor([1, 2, 3]))
+
+
+@pytest.mark.parametrize(
+    ("seq_len", "expected_has_initial_state"),
+    [
+        pytest.param(1, False, id="first-token-prefill"),
+        pytest.param(65, True, id="final-one-token-prefill-chunk"),
+    ],
+)
+def test_mixed_one_token_prefill_and_spec_decode_uses_prefill_metadata(
+    seq_len: int,
+    expected_has_initial_state: bool,
+):
+    batch = BatchSpec(seq_lens=[seq_len, 20], query_lens=[1, 3])
+    common_attn_metadata = create_common_attn_metadata(
+        batch, BLOCK_SIZE, DEVICE
+    ).replace(is_prefilling=torch.tensor([True, False]))
+    actual = _make_builder(
+        KimiK3KDAMetadataBuilder,
+        num_speculative_tokens=2,
+        full_cuda_graph=False,
+    ).build(
+        0,
+        common_attn_metadata,
+        num_decode_draft_tokens_cpu=torch.tensor([-1, 2], dtype=torch.int32),
+        num_accepted_tokens=torch.ones(2, dtype=torch.int32, device=DEVICE),
+    )
+
+    assert actual.num_prefills == 1
+    assert actual.num_prefill_tokens == 1
+    assert actual.num_decodes == 0
+    assert actual.num_decode_tokens == 0
+    assert actual.has_initial_state is not None
+    assert actual.has_initial_state.tolist() == [expected_has_initial_state]
+    assert actual.non_spec_query_start_loc is not None
+    torch.testing.assert_close(
+        actual.non_spec_query_start_loc,
+        torch.tensor([0, 1], dtype=torch.int32),
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_kimi_k3_kda_cudagraph_capture_matches_shared_gdn():
+    device = torch.device("cuda")
+    batch = BatchSpec(seq_lens=[50, 30], query_lens=[3, 3])
+    common_attn_metadata = create_common_attn_metadata(
+        batch, BLOCK_SIZE, device
+    ).replace(is_prefilling=torch.tensor([False, False]))
+    reference = _make_builder(
+        GDNAttentionMetadataBuilder,
+        num_speculative_tokens=2,
+        full_cuda_graph=True,
+        device=device,
+    ).build_for_cudagraph_capture(common_attn_metadata)
+    actual = _make_builder(
+        KimiK3KDAMetadataBuilder,
+        num_speculative_tokens=2,
+        full_cuda_graph=True,
+        device=device,
+    ).build_for_cudagraph_capture(common_attn_metadata)
+
+    assert isinstance(actual, KimiK3KDAMetadata)
+    _assert_matches_shared_gdn(reference, actual)
+
+
+def test_kimi_k3_kda_backend_uses_private_metadata_builder():
+    assert KimiK3KDAAttentionBackend.get_builder_cls() is KimiK3KDAMetadataBuilder
+    assert KimiK3KDAAttentionBackend.is_ssm()
+    assert issubclass(KimiK3KDAAttentionBackend, GDNAttentionBackend)
+    assert issubclass(KimiK3KDAMetadata, GDNAttentionMetadata)
+    assert issubclass(KimiK3KDAMetadataBuilder, GDNAttentionMetadataBuilder)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_stage_spec_decode_metadata_matches_pytorch():
+    device = torch.device("cuda")
+    num_spec_decodes = 33
+    batch_size = 65
+    num_state_slots = 3
+    state_indices = torch.arange(
+        num_spec_decodes * 32,
+        dtype=torch.int32,
+        device=device,
+    ).reshape(num_spec_decodes, 32)[:, :num_state_slots]
+    query_start_loc = (
+        torch.arange(num_spec_decodes + 1, dtype=torch.int32, device=device)
+        * num_state_slots
+    )
+    num_accepted_tokens = (
+        torch.arange(num_spec_decodes, dtype=torch.int32, device=device)
+        % num_state_slots
+        + 1
+    )
+
+    staged_state_indices = torch.empty(
+        (batch_size, num_state_slots), dtype=torch.int32, device=device
+    )
+    staged_query_start_loc = torch.empty(
+        batch_size + 1, dtype=torch.int32, device=device
+    )
+    staged_num_accepted_tokens = torch.empty(
+        batch_size, dtype=torch.int32, device=device
+    )
+    stage_spec_decode_metadata(
+        state_indices,
+        query_start_loc,
+        num_accepted_tokens,
+        staged_state_indices,
+        staged_query_start_loc,
+        staged_num_accepted_tokens,
+        num_spec_decodes=num_spec_decodes,
+    )
+
+    expected_state_indices = torch.full_like(staged_state_indices, NULL_BLOCK_ID)
+    expected_state_indices[:num_spec_decodes] = state_indices
+    expected_query_start_loc = torch.full(
+        (batch_size + 1,),
+        query_start_loc[-1],
+        dtype=torch.int32,
+        device=device,
+    )
+    expected_query_start_loc[: num_spec_decodes + 1] = query_start_loc
+    expected_num_accepted_tokens = torch.ones(
+        batch_size, dtype=torch.int32, device=device
+    )
+    expected_num_accepted_tokens[:num_spec_decodes] = num_accepted_tokens
+
+    torch.testing.assert_close(staged_state_indices, expected_state_indices)
+    torch.testing.assert_close(staged_query_start_loc, expected_query_start_loc)
+    torch.testing.assert_close(staged_num_accepted_tokens, expected_num_accepted_tokens)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_aligned_block_table_matches_shared_gdn():
+    device = torch.device("cuda")
+    seq_lens = torch.tensor(
+        [0, 1, 15, 16, 17, 31, 32, 33, 511, 512, 513],
+        dtype=torch.int32,
+        device=device,
+    ).repeat(6)[:65]
+    block_table_storage = torch.arange(
+        seq_lens.numel() * 128,
+        dtype=torch.int32,
+        device=device,
+    ).reshape(seq_lens.numel(), 128)
+    block_table = block_table_storage[:, ::2]
+    kv_cache_spec = MambaSpec(
+        block_size=BLOCK_SIZE,
+        shapes=((16, 64),),
+        dtypes=(torch.float16,),
+        num_speculative_blocks=2,
+    )
+
+    expected = mamba_get_block_table_tensor(
+        block_table,
+        seq_lens,
+        kv_cache_spec,
+        "align",
+    )
+    actual = _mamba_get_block_table_tensor(
+        block_table,
+        seq_lens,
+        kv_cache_spec,
+        "align",
+    )
+
+    torch.testing.assert_close(actual, expected)

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2746,6 +2746,52 @@ def concat_and_cache_mla(
     )
 
 
+def fused_kda_decode(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    conv_state: torch.Tensor,
+    raw_g: torch.Tensor,
+    raw_beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    state_indices: torch.Tensor,
+    state: torch.Tensor,
+    out: torch.Tensor | None = None,
+    lower_bound: float | None = None,
+    output_gate: torch.Tensor | None = None,
+    norm_weight: torch.Tensor | None = None,
+    norm_eps: float = 1e-5,
+) -> torch.Tensor:
+    if out is None:
+        out = torch.empty(
+            1,
+            x.shape[0],
+            raw_g.shape[2],
+            raw_g.shape[3],
+            dtype=x.dtype,
+            device=x.device,
+        )
+    torch.ops._C.fused_kda_decode(
+        x,
+        weight,
+        bias,
+        conv_state,
+        raw_g,
+        raw_beta,
+        A_log,
+        dt_bias,
+        state_indices,
+        state,
+        out,
+        lower_bound,
+        output_gate,
+        norm_weight,
+        norm_eps,
+    )
+    return out
+
+
 def concat_and_cache_mla_rope_fused(
     positions: torch.Tensor,
     q_pe: torch.Tensor,

--- a/vllm/model_executor/layers/mamba/mamba_utils.py
+++ b/vllm/model_executor/layers/mamba/mamba_utils.py
@@ -288,7 +288,7 @@ class MambaStateShapeCalculator:
 
         conv_dim = proj_size + 2 * proj_k_size
         conv_state_shape = cls._orient_conv_shape(
-            divide(conv_dim, tp_world_size), conv_kernel_size - 1
+            divide(conv_dim, tp_world_size), conv_kernel_size - 1 + num_spec
         )
         recurrent_state_shape = (divide(num_heads, tp_world_size), head_dim, head_dim)
         return (conv_state_shape, recurrent_state_shape)

--- a/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
+++ b/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
@@ -8,11 +8,12 @@
 import numpy as np
 import torch
 
+from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backends.utils import NULL_BLOCK_ID, PAD_SLOT_ID
 
 
-@triton.jit()
+@triton.jit(do_not_specialize_on_alignment=["num_cache_lines"])
 def _causal_conv1d_fwd_kernel(  # continuous batching
     # Pointers to matrices
     x_ptr,  # (dim, cu_seqlen) holding `batch` of actual sequences + padded sequences
@@ -33,7 +34,7 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
     o_ptr,  # (dim, seqlen) - actually pointing to x_ptr
     # Matrix dimensions
     dim: tl.constexpr,
-    num_cache_lines: tl.constexpr,  # added to support vLLM larger cache lines
+    num_cache_lines,  # added to support vLLM larger cache lines
     # Strides
     stride_x_dim: tl.constexpr,  # stride to get to next feature-value,
     stride_x_token: tl.int64,  # stride to get to next token (same feature-index, same sequence-index)
@@ -58,6 +59,7 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
     NP2_STATELEN: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
+    launch_pdl: tl.constexpr,
 ):
     conv_states_ptr = initial_states_ptr
     conv_state_indices_ptr = cache_indices_ptr
@@ -67,6 +69,9 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
     state_len = (
         KERNEL_WIDTH - 1
     )  # can be passed via argument if it's not the same as this value
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
 
     # one program handles one chunk in a single sequence
     # rather than mixing sequences - to make updating initial_states across sequences efficiently
@@ -79,6 +84,8 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
     idx_feats = tl.program_id(1) * BLOCK_N + tl.arange(0, BLOCK_N)
 
     if idx_seq == pad_slot_id:
+        if launch_pdl:
+            tl.extra.cuda.gdc_launch_dependents()
         return
 
     sequence_start_index = tl.load(query_start_loc_ptr + idx_seq)
@@ -136,6 +143,8 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
     if HAS_NULL_BLOCK:  # noqa
         if conv_states_input_coord == null_block_id:
             # not processing as this is a null block (padding)
+            if launch_pdl:
+                tl.extra.cuda.gdc_launch_dependents()
             return
     conv_states_base = (
         conv_states_ptr
@@ -408,6 +417,10 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
         w_ptrs = w_base + (3 * stride_w_width)  # [BLOCK_N] tensor
         w_col3 = tl.load(w_ptrs, mask_w, other=0.0)
     mask_x_1d = idx_feats < dim
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_launch_dependents()
+
     for idx_token in range(segment_len):
         acc = acc_preload
 
@@ -741,11 +754,12 @@ def causal_conv1d_fn(
         BLOCK_M=BLOCK_M,
         BLOCK_N=256,
         num_stages=2,
+        launch_pdl=current_platform.is_arch_support_pdl(),
     )
     return out.to(original_x_dtype)
 
 
-@triton.jit()
+@triton.jit(do_not_specialize_on_alignment=["num_cache_lines"])
 def _causal_conv1d_update_kernel(
     # Pointers to matrices
     x_ptr,  # (batch, dim, seqlen)
@@ -763,7 +777,7 @@ def _causal_conv1d_update_kernel(
     dim: tl.constexpr,
     seqlen: tl.constexpr,
     state_len: tl.constexpr,
-    num_cache_lines: tl.constexpr,  # added to support vLLM larger cache lines
+    num_cache_lines,  # added to support vLLM larger cache lines
     # Strides
     stride_x_seq: tl.constexpr,
     stride_x_dim: tl.constexpr,
@@ -789,10 +803,16 @@ def _causal_conv1d_update_kernel(
     NP2_STATELEN: tl.constexpr,
     HAS_NULL_BLOCK: tl.constexpr,
     BLOCK_N: tl.constexpr,
+    launch_pdl: tl.constexpr,
 ):
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+
     # ruff: noqa: E501
     idx_seq = tl.program_id(0)
     if idx_seq >= batch:
+        if launch_pdl:
+            tl.extra.cuda.gdc_launch_dependents()
         return
 
     # [BLOCK_N,] elements along the feature-dimension (channel)
@@ -814,6 +834,8 @@ def _causal_conv1d_update_kernel(
     if HAS_NULL_BLOCK:  # noqa
         if conv_states_input_coord == null_block_id:
             # not processing as this is not the actual sequence
+            if launch_pdl:
+                tl.extra.cuda.gdc_launch_dependents()
             return
 
     if IS_VARLEN:
@@ -831,6 +853,8 @@ def _causal_conv1d_update_kernel(
         o_offset = idx_seq * stride_o_seq
 
     if query_start_index == query_end_index:
+        if launch_pdl:
+            tl.extra.cuda.gdc_launch_dependents()
         return
 
     if IS_SPEC_DECODING:
@@ -969,6 +993,9 @@ def _causal_conv1d_update_kernel(
     mask_x_1d = idx_feats < dim
 
     # STEP 5: compute each token
+    if launch_pdl:
+        tl.extra.cuda.gdc_launch_dependents()
+
     for idx_token in tl.range(seqlen):
         acc = acc_preload
 
@@ -1080,6 +1107,7 @@ def causal_conv1d_update(
     block_idx_last_scheduled_token: torch.Tensor | None = None,
     initial_state_idx: torch.Tensor | None = None,
     validate_data=False,
+    out: torch.Tensor | None = None,
 ):
     """
     x: Input tensor which can take the following shapes:
@@ -1117,7 +1145,8 @@ def causal_conv1d_update(
             for example: conv_state_indices = [null_block_id, 1, 20, null_block_id]
             in this case, the kernel will not process entries at
             indices 0 and 3
-    out: (batch, dim) or (batch, dim, seqlen) or (num_tokens, dim), same shape as `x`
+    out: optional output tensor with the same shape as `x`. When omitted,
+        the input is overwritten.
     """
     if validate_data:
         assert null_block_id is not None
@@ -1129,10 +1158,22 @@ def causal_conv1d_update(
 
     original_x_dtype = x.dtype
     x = x.to(conv_state.dtype)
+    if out is None:
+        out = x
+    else:
+        if out.shape != x.shape:
+            raise ValueError(
+                f"`out` shape {tuple(out.shape)} must match `x` shape {tuple(x.shape)}."
+            )
+        if out.dtype != original_x_dtype or out.device != x.device:
+            raise ValueError(
+                "`out` must have the same dtype and device as the input `x`."
+            )
     unsqueeze = query_start_loc is None and x.dim() == 2
     if unsqueeze:
         # make it (batch, dim, seqlen) with seqlen == 1
         x = x.unsqueeze(-1)
+        out = out.unsqueeze(-1)
     if query_start_loc is None:
         batch, dim, seqlen = x.shape
     else:
@@ -1159,8 +1200,6 @@ def causal_conv1d_update(
         assert num_cache_lines >= batch
         assert weight.stride(1) == 1  # Need this
 
-    # adopt the strategy in vLLM that overwrite on 'x' directly, rather than creating a new tensor 'o'
-    out = x
     stride_w_dim, stride_w_width = weight.stride()
 
     if query_start_loc is None:
@@ -1233,13 +1272,12 @@ def causal_conv1d_update(
         NP2_STATELEN=np2_statelen,
         HAS_NULL_BLOCK=null_block_id is not None,
         BLOCK_N=256,
+        launch_pdl=current_platform.is_arch_support_pdl(),
     )
     if unsqueeze:
         out = out.squeeze(-1)
     return out.to(original_x_dtype)
 
-
-from vllm.platforms import current_platform  # noqa: E402
 
 if current_platform.is_cpu():
     from vllm.model_executor.layers.mamba.ops.cpu.causal_conv1d import (

--- a/vllm/model_executor/layers/mamba/ops/gather_initial_states.py
+++ b/vllm/model_executor/layers/mamba/ops/gather_initial_states.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def _gather_initial_states_kernel(
+    state_ptr,
+    indices_ptr,
+    has_initial_state_ptr,
+    output_ptr,
+    stride_state_batch,
+    stride_indices,
+    stride_has_initial_state,
+    row_size: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    launch_pdl: tl.constexpr,
+):
+    block_idx = tl.program_id(0)
+    batch_idx = tl.program_id(1)
+    offsets = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < row_size
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+        tl.extra.cuda.gdc_launch_dependents()
+
+    has_initial_state = tl.load(
+        has_initial_state_ptr + batch_idx * stride_has_initial_state
+    ).to(tl.int1)
+    state_idx = tl.load(indices_ptr + batch_idx * stride_indices).to(tl.int64)
+    state_idx = tl.where(has_initial_state, state_idx, 0)
+    values = tl.load(
+        state_ptr + state_idx * stride_state_batch + offsets,
+        mask=mask & has_initial_state,
+        other=0.0,
+    )
+    tl.store(output_ptr + batch_idx * row_size + offsets, values, mask=mask)
+
+
+def gather_initial_states(
+    state: torch.Tensor,
+    indices: torch.Tensor,
+    has_initial_state: torch.Tensor,
+) -> torch.Tensor:
+    """Gather dense state rows, replacing uninitialized rows with zeros."""
+    assert state.ndim >= 2
+    assert state.is_cuda
+    assert indices.ndim == 1 and has_initial_state.ndim == 1
+    assert indices.shape == has_initial_state.shape
+    assert indices.device == state.device
+    assert has_initial_state.device == state.device
+    assert indices.dtype in (torch.int32, torch.int64)
+    assert has_initial_state.dtype == torch.bool
+
+    row_size = state[0].numel()
+    # Mamba pages may pad stride(0), but each state row remains dense.
+    assert state[0].is_contiguous()
+    output = torch.empty(
+        (indices.numel(), *state.shape[1:]),
+        dtype=state.dtype,
+        device=state.device,
+    )
+    block_size = min(triton.next_power_of_2(row_size), 1024)
+    grid = (triton.cdiv(row_size, block_size), indices.numel())
+    _gather_initial_states_kernel[grid](
+        state,
+        indices,
+        has_initial_state,
+        output,
+        state.stride(0),
+        indices.stride(0),
+        has_initial_state.stride(0),
+        row_size=row_size,
+        BLOCK_SIZE=block_size,
+        num_warps=8,
+        launch_pdl=current_platform.is_arch_support_pdl(),
+    )
+    return output

--- a/vllm/models/kimi_k3/amd/__init__.py
+++ b/vllm/models/kimi_k3/amd/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/models/kimi_k3/amd/ops/third_party/__init__.py
+++ b/vllm/models/kimi_k3/amd/ops/third_party/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/models/kimi_k3/amd/ops/third_party/kda/__init__.py
+++ b/vllm/models/kimi_k3/amd/ops/third_party/kda/__init__.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# AMD/ROCm vendored copy of the Kimi-K3 KDA triton kernels.
+#
+# Provenance: mirror of vllm/models/kimi_k3/nvidia/ops/third_party/kda at
+# 7adebfcf9 (FLA vendored per PRs #39/#86). Split per-vendor so
+# AMD can carry gfx950-specific kernel changes without touching the NVIDIA copy.
+#
+# fla-org/flash-linear-attention#869 (the unmerged ROCm fixes our earlier
+# amd_fla shim carried against FLA 0.5.0) is covered here by the *newer* vendored
+# FLA rather than the literal patch:
+#   - transpose-state-layout workaround: N/A (kernels rewritten; no
+#     transpose_state_layout path remains),
+#   - AMD autotune configs: present (is_amd num_warps/num_stages branches),
+#   - OOB-mask correctness fix: present (all tl.load use mask=..., other=0).
+# Validated on gfx950: no core-dump, gsm8k 94.1%.
+#
+# AMD-specific deltas remove CUDA PDL operations, use gfx950-tuned recurrent
+# launch parameters, and require contiguous state indices. Keep shared logic in
+# sync with the NVIDIA copy; other divergence should be intentional and
+# documented.
+
+from .chunk import (
+    chunk_kda,
+    chunk_kda_fwd,
+    chunk_kda_with_fused_gate,
+    chunk_kda_with_fused_gate_fwd,
+    fused_kda_gate,
+    fused_kda_gate_chunk_cumsum,
+)
+from .fused_recurrent import (
+    fused_recurrent_kda,
+    fused_recurrent_kda_fwd,
+    fused_recurrent_kda_packed_decode,
+)
+
+__all__ = [
+    "chunk_kda",
+    "chunk_kda_fwd",
+    "chunk_kda_with_fused_gate",
+    "chunk_kda_with_fused_gate_fwd",
+    "fused_kda_gate",
+    "fused_kda_gate_chunk_cumsum",
+    "fused_recurrent_kda",
+    "fused_recurrent_kda_fwd",
+    "fused_recurrent_kda_packed_decode",
+]

--- a/vllm/models/kimi_k3/amd/ops/third_party/kda/chunk.py
+++ b/vllm/models/kimi_k3/amd/ops/third_party/kda/chunk.py
@@ -1,0 +1,936 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This file contains code copied from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+# ruff: noqa: E501
+# mypy: ignore-errors
+
+
+import torch
+
+from vllm.third_party.flash_linear_attention.ops.chunk_delta_h import (
+    chunk_gated_delta_rule_fwd_h,
+)
+from vllm.third_party.flash_linear_attention.ops.cumsum import chunk_local_cumsum
+from vllm.third_party.flash_linear_attention.ops.index import prepare_chunk_indices
+from vllm.third_party.flash_linear_attention.ops.l2norm import l2norm_fwd
+from vllm.third_party.flash_linear_attention.ops.op import exp2, log
+from vllm.third_party.flash_linear_attention.ops.utils import FLA_CHUNK_SIZE, is_amd
+from vllm.triton_utils import tl, triton
+from vllm.utils.math_utils import RCP_LN2, cdiv, next_power_of_2
+
+from .chunk_intra import chunk_kda_fwd_intra
+
+BT_LIST_AUTOTUNE = [32, 64, 128]
+NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if is_amd else [4, 8, 16, 32]
+
+
+@triton.heuristics(
+    {
+        "STORE_QG": lambda args: args["qg"] is not None,
+        "STORE_KG": lambda args: args["kg"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in [2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=["H", "K", "V", "BT", "BK", "BV", "IS_VARLEN"],
+)
+@triton.jit(do_not_specialize=["T"])
+def recompute_w_u_fwd_kernel(
+    q,
+    k,
+    qg,
+    kg,
+    v,
+    beta,
+    w,
+    u,
+    A,
+    gk,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    STORE_QG: tl.constexpr,
+    STORE_KG: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    DOT_PRECISION: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+    p_b = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+    b_b = tl.load(p_b, boundary_check=(0,)).to(tl.float32)
+
+    p_A = tl.make_block_ptr(
+        A + (bos * H + i_h) * BT, (T, BT), (H * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0)
+    )
+    b_A = tl.load(p_A, boundary_check=(0, 1))
+
+    for i_v in range(tl.cdiv(V, BV)):
+        p_v = tl.make_block_ptr(
+            v + (bos * H + i_h) * V,
+            (T, V),
+            (H * V, 1),
+            (i_t * BT, i_v * BV),
+            (BT, BV),
+            (1, 0),
+        )
+        p_u = tl.make_block_ptr(
+            u + (bos * H + i_h) * V,
+            (T, V),
+            (H * V, 1),
+            (i_t * BT, i_v * BV),
+            (BT, BV),
+            (1, 0),
+        )
+        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_vb = (b_v * b_b[:, None]).to(b_v.dtype)
+        b_u = tl.dot(b_A, b_vb, input_precision=DOT_PRECISION)
+        tl.store(p_u, b_u.to(p_u.dtype.element_ty), boundary_check=(0, 1))
+
+    for i_k in range(tl.cdiv(K, BK)):
+        p_w = tl.make_block_ptr(
+            w + (bos * H + i_h) * K,
+            (T, K),
+            (H * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        p_k = tl.make_block_ptr(
+            k + (bos * H + i_h) * K,
+            (T, K),
+            (H * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_kb = b_k * b_b[:, None]
+
+        p_gk = tl.make_block_ptr(
+            gk + (bos * H + i_h) * K,
+            (T, K),
+            (H * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        b_gk = tl.load(p_gk, boundary_check=(0, 1))
+        b_kb *= exp2(b_gk)
+        if STORE_QG:
+            p_q = tl.make_block_ptr(
+                q + (bos * H + i_h) * K,
+                (T, K),
+                (H * K, 1),
+                (i_t * BT, i_k * BK),
+                (BT, BK),
+                (1, 0),
+            )
+            p_qg = tl.make_block_ptr(
+                qg + (bos * H + i_h) * K,
+                (T, K),
+                (H * K, 1),
+                (i_t * BT, i_k * BK),
+                (BT, BK),
+                (1, 0),
+            )
+            b_q = tl.load(p_q, boundary_check=(0, 1))
+            b_qg = b_q * exp2(b_gk)
+            tl.store(p_qg, b_qg.to(p_qg.dtype.element_ty), boundary_check=(0, 1))
+        if STORE_KG:
+            last_idx = min(i_t * BT + BT, T) - 1
+
+            o_k = i_k * BK + tl.arange(0, BK)
+            m_k = o_k < K
+            b_gn = tl.load(
+                gk + ((bos + last_idx) * H + i_h) * K + o_k, mask=m_k, other=0.0
+            )
+            b_kg = b_k * exp2(b_gn - b_gk)
+
+            p_kg = tl.make_block_ptr(
+                kg + (bos * H + i_h) * K,
+                (T, K),
+                (H * K, 1),
+                (i_t * BT, i_k * BK),
+                (BT, BK),
+                (1, 0),
+            )
+            tl.store(p_kg, b_kg.to(p_kg.dtype.element_ty), boundary_check=(0, 1))
+
+        b_w = tl.dot(b_A, b_kb.to(b_k.dtype))
+        tl.store(p_w, b_w.to(p_w.dtype.element_ty), boundary_check=(0, 1))
+
+
+def recompute_w_u_fwd(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    A: torch.Tensor,
+    q: torch.Tensor | None = None,
+    gk: torch.Tensor | None = None,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_indices: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    B, T, H, K, V = *k.shape, v.shape[-1]
+    BT = A.shape[-1]
+    BK = 64
+    BV = 64
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    w = torch.empty_like(k)
+    u = torch.empty_like(v)
+    kg = torch.empty_like(k) if gk is not None else None
+    recompute_w_u_fwd_kernel[(NT, B * H)](
+        q=q,
+        k=k,
+        qg=None,
+        kg=kg,
+        v=v,
+        beta=beta,
+        w=w,
+        u=u,
+        A=A,
+        gk=gk,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        K=K,
+        V=V,
+        BT=BT,
+        BK=BK,
+        BV=BV,
+        DOT_PRECISION="ieee",
+    )
+    return w, u, None, kg
+
+
+@triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
+@triton.autotune(
+    configs=[
+        triton.Config({"BK": BK, "BV": BV}, num_warps=num_warps, num_stages=num_stages)
+        for BK in [32, 64]
+        for BV in [64, 128]
+        for num_warps in [2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=["BT"],
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_gla_fwd_kernel_o(
+    q,
+    v,
+    g,
+    h,
+    o,
+    A,
+    cu_seqlens,
+    chunk_indices,
+    scale,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_tg = i_t
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+    else:
+        NT = tl.cdiv(T, BT)
+        i_tg = i_b * NT + i_t
+        bos, eos = i_b * T, i_b * T + T
+
+    m_s = tl.arange(0, BT)[:, None] >= tl.arange(0, BT)[None, :]
+
+    b_o = tl.zeros([BT, BV], dtype=tl.float32)
+    for i_k in range(tl.cdiv(K, BK)):
+        p_q = tl.make_block_ptr(
+            q + (bos * H + i_h) * K,
+            (T, K),
+            (H * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        p_g = tl.make_block_ptr(
+            g + (bos * H + i_h) * K,
+            (T, K),
+            (H * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        p_h = tl.make_block_ptr(
+            h + (i_tg * H + i_h) * K * V,
+            (V, K),
+            (K, 1),
+            (i_v * BV, i_k * BK),
+            (BV, BK),
+            (1, 0),
+        )
+
+        # [BT, BK]
+        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_q = (b_q * scale).to(b_q.dtype)
+        # [BT, BK]
+        b_g = tl.load(p_g, boundary_check=(0, 1))
+        # [BT, BK]
+        b_qg = (b_q * exp2(b_g)).to(b_q.dtype)
+        # [BV, BK]
+        b_h = tl.load(p_h, boundary_check=(0, 1))
+        # [BT, BV]
+        if i_k >= 0:
+            b_o += tl.dot(b_qg, tl.trans(b_h).to(b_qg.dtype))
+    p_v = tl.make_block_ptr(
+        v + (bos * H + i_h) * V,
+        (T, V),
+        (H * V, 1),
+        (i_t * BT, i_v * BV),
+        (BT, BV),
+        (1, 0),
+    )
+    p_o = tl.make_block_ptr(
+        o + (bos * H + i_h) * V,
+        (T, V),
+        (H * V, 1),
+        (i_t * BT, i_v * BV),
+        (BT, BV),
+        (1, 0),
+    )
+    p_A = tl.make_block_ptr(
+        A + (bos * H + i_h) * BT, (T, BT), (H * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0)
+    )
+    # [BT, BV]
+    b_v = tl.load(p_v, boundary_check=(0, 1))
+    # [BT, BT]
+    b_A = tl.load(p_A, boundary_check=(0, 1))
+    b_A = tl.where(m_s, b_A, 0.0).to(b_v.dtype)
+    b_o += tl.dot(b_A, b_v, allow_tf32=False)
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+
+
+def chunk_gla_fwd_o_gk(
+    q: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    A: torch.Tensor,
+    h: torch.Tensor,
+    o: torch.Tensor,
+    scale: float,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_indices: torch.Tensor | None = None,
+    chunk_size: int = FLA_CHUNK_SIZE,
+):
+    B, T, H, K, V = *q.shape, v.shape[-1]
+    BT = chunk_size
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+    NT = cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    def grid(meta):
+        return (cdiv(V, meta["BV"]), NT, B * H)
+
+    chunk_gla_fwd_kernel_o[grid](
+        q=q,
+        v=v,
+        g=g,
+        h=h,
+        o=o,
+        A=A,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        scale=scale,
+        T=T,
+        H=H,
+        K=K,
+        V=V,
+        BT=BT,
+    )
+    return o
+
+
+@triton.heuristics(
+    {
+        "HAS_BIAS": lambda args: args["g_bias"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({"BS": BS}, num_warps=num_warps)
+        for BS in [32, 64]
+        for num_warps in [2, 4, 8]
+    ],
+    key=["H", "S", "BT", "IS_VARLEN"],
+)
+@triton.jit(do_not_specialize=["T"])
+def kda_gate_chunk_cumsum_vector_kernel(
+    s,
+    raw_beta,
+    A_log,
+    g_bias,
+    o,
+    beta_out,
+    cu_seqlens,
+    chunk_indices,
+    cumsum_scale,
+    lower_bound,
+    beta,
+    threshold,
+    T,
+    stride_beta_batch,
+    stride_beta_token,
+    stride_beta_head,
+    H: tl.constexpr,
+    S: tl.constexpr,
+    BT: tl.constexpr,
+    BS: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    USE_LOWER_BOUND: tl.constexpr,
+):
+    i_s, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+    else:
+        bos = i_b * T
+
+    if i_s == 0:
+        o_beta_t = tl.arange(0, BT)
+        m_beta = i_t * BT + o_beta_t < T
+        if IS_VARLEN:
+            p_beta = (
+                raw_beta
+                + (bos + i_t * BT + o_beta_t) * stride_beta_token
+                + i_h * stride_beta_head
+            )
+        else:
+            p_beta = (
+                raw_beta
+                + i_b * stride_beta_batch
+                + (i_t * BT + o_beta_t) * stride_beta_token
+                + i_h * stride_beta_head
+            )
+        b_beta = tl.load(p_beta, mask=m_beta, other=0.0).to(tl.float32)
+        p_beta_out = beta_out + (bos + i_t * BT + o_beta_t) * H + i_h
+        tl.store(p_beta_out, tl.sigmoid(b_beta), mask=m_beta)
+        return
+
+    i_s -= 1
+
+    p_s = tl.make_block_ptr(
+        s + (bos * H + i_h) * S,
+        (T, S),
+        (H * S, 1),
+        (i_t * BT, i_s * BS),
+        (BT, BS),
+        (1, 0),
+    )
+    p_o = tl.make_block_ptr(
+        o + (bos * H + i_h) * S,
+        (T, S),
+        (H * S, 1),
+        (i_t * BT, i_s * BS),
+        (BT, BS),
+        (1, 0),
+    )
+
+    b_s = tl.load(p_s, boundary_check=(0, 1)).to(tl.float32)
+    if HAS_BIAS:
+        p_bias = tl.make_block_ptr(
+            g_bias + i_h * S,
+            (S,),
+            (1,),
+            (i_s * BS,),
+            (BS,),
+            (0,),
+        )
+        b_bias = tl.load(p_bias, boundary_check=(0,)).to(tl.float32)
+        b_s += b_bias[None, :]
+
+    b_a = tl.exp(tl.load(A_log + i_h).to(tl.float32))
+    if USE_LOWER_BOUND:
+        b_gate = lower_bound * tl.sigmoid(b_a * b_s)
+    else:
+        b_g_scaled = b_s * beta
+        b_softplus = tl.where(
+            b_g_scaled > threshold,
+            b_s,
+            (1.0 / beta) * log(1.0 + tl.exp(b_g_scaled)),
+        )
+        b_gate = -b_a * b_softplus
+
+    # Boundary loads return zero, but bias and gate activation can make padded
+    # rows nonzero. Padding trails valid rows, so it only affects masked stores.
+    b_o = tl.cumsum(b_gate, axis=0) * cumsum_scale
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+
+
+def fused_kda_gate_chunk_cumsum(
+    raw_g: torch.Tensor,
+    raw_beta: torch.Tensor,
+    A_log: torch.Tensor,
+    g_bias: torch.Tensor | None = None,
+    beta: float = 1.0,
+    threshold: float = 20.0,
+    lower_bound: float | None = None,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_indices: torch.Tensor | None = None,
+    chunk_size: int = FLA_CHUNK_SIZE,
+    output_dtype: torch.dtype | None = torch.float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if cu_seqlens is not None:
+        assert raw_g.shape[0] == 1, (
+            "Only batch size 1 is supported when cu_seqlens are provided"
+        )
+    B, T, H, D = raw_g.shape
+    if raw_beta.shape != (B, T, H):
+        raise ValueError(f"Expected raw_beta shape {(B, T, H)}, got {raw_beta.shape}")
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+    NT = cdiv(T, chunk_size) if cu_seqlens is None else len(chunk_indices)
+
+    A_log = A_log.reshape(-1)
+    if g_bias is not None:
+        g_bias = g_bias.reshape(-1)
+    y = torch.empty_like(raw_g, dtype=output_dtype or raw_g.dtype)
+    beta_out = torch.empty(raw_beta.shape, device=raw_beta.device, dtype=torch.float32)
+
+    def grid(meta):
+        # For each (chunk, head), program 0 computes beta without extending a
+        # gate tile's critical path. The remaining programs cover the gate dim.
+        return (cdiv(meta["S"], meta["BS"]) + 1, NT, B * H)
+
+    kda_gate_chunk_cumsum_vector_kernel[grid](
+        s=raw_g,
+        raw_beta=raw_beta,
+        A_log=A_log,
+        g_bias=g_bias,
+        o=y,
+        beta_out=beta_out,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        # RCP_LN2 folds in the natural-log -> log2 conversion so downstream
+        # exp2-based kernels reproduce exp(g). Keep this in sync with the
+        # `use_exp2=True` path in `_chunk_kda_fwd_with_cumulative_g`.
+        cumsum_scale=RCP_LN2,
+        lower_bound=lower_bound or 0.0,
+        beta=beta,
+        threshold=threshold,
+        T=T,
+        stride_beta_batch=raw_beta.stride(0),
+        stride_beta_token=raw_beta.stride(1),
+        stride_beta_head=raw_beta.stride(2),
+        H=H,
+        S=D,
+        BT=chunk_size,
+        USE_LOWER_BOUND=lower_bound is not None,
+    )
+    return y, beta_out
+
+
+def _chunk_kda_fwd_with_cumulative_g(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    initial_state: torch.Tensor,
+    output_final_state: bool,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_indices: torch.Tensor | None = None,
+    chunk_size: int = FLA_CHUNK_SIZE,
+    safe_gate: bool = False,
+):
+    # `g` must already be chunk-local cumulatively-summed AND scaled by
+    # RCP_LN2 (so the downstream exp2-based kernels reproduce exp(g)).
+    # Use `chunk_kda_fwd` or `chunk_kda_with_fused_gate_fwd` instead of
+    # calling this helper directly unless that invariant is upheld.
+    Aqk, A = chunk_kda_fwd_intra(
+        q=q,
+        k=k,
+        gk=g,
+        beta=beta,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        chunk_size=chunk_size,
+        safe_gate=safe_gate,
+    )
+    w, u, _, kg = recompute_w_u_fwd(
+        k=k,
+        v=v,
+        beta=beta,
+        A=A,
+        gk=g,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+    del A
+    h, v_new, final_state = chunk_gated_delta_rule_fwd_h(
+        k=kg,
+        w=w,
+        u=u,
+        gk=g,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        use_exp2=True,
+    )
+    del w, u, kg
+    o = chunk_gla_fwd_o_gk(
+        q=q,
+        v=v_new,
+        g=g,
+        A=Aqk,
+        h=h,
+        o=v,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        chunk_size=chunk_size,
+    )
+    del Aqk, v_new, h
+    return o, final_state
+
+
+def chunk_kda_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    initial_state: torch.Tensor,
+    output_final_state: bool,
+    cu_seqlens: torch.Tensor | None = None,
+):
+    chunk_size = FLA_CHUNK_SIZE
+    chunk_indices = (
+        prepare_chunk_indices(cu_seqlens, chunk_size)
+        if cu_seqlens is not None
+        else None
+    )
+    g = chunk_local_cumsum(
+        g,
+        chunk_size=chunk_size,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+    # KDA evaluates cumulative gate decays with exp2. Convert from natural-log
+    # space so exp(x) is preserved as exp2(x / ln(2)).
+    g = g * RCP_LN2
+    return _chunk_kda_fwd_with_cumulative_g(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        chunk_size=chunk_size,
+    )
+
+
+def chunk_kda_with_fused_gate_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    raw_g: torch.Tensor,
+    raw_beta: torch.Tensor,
+    A_log: torch.Tensor,
+    g_bias: torch.Tensor | None,
+    scale: float,
+    initial_state: torch.Tensor,
+    output_final_state: bool,
+    lower_bound: float | None = None,
+    cu_seqlens: torch.Tensor | None = None,
+):
+    chunk_size = FLA_CHUNK_SIZE
+    chunk_indices = (
+        prepare_chunk_indices(cu_seqlens, chunk_size)
+        if cu_seqlens is not None
+        else None
+    )
+    g, beta = fused_kda_gate_chunk_cumsum(
+        raw_g,
+        raw_beta=raw_beta,
+        A_log=A_log,
+        g_bias=g_bias,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        chunk_size=chunk_size,
+        lower_bound=lower_bound,
+    )
+    return _chunk_kda_fwd_with_cumulative_g(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        chunk_size=chunk_size,
+        safe_gate=lower_bound is not None,
+    )
+
+
+def chunk_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float = None,
+    initial_state: torch.Tensor = None,
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    **kwargs,
+):
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+
+    if use_qk_l2norm_in_kernel:
+        q = l2norm_fwd(q.contiguous())
+        k = l2norm_fwd(k.contiguous())
+
+    o, final_state = chunk_kda_fwd(
+        q=q,
+        k=k,
+        v=v.contiguous(),
+        g=g.contiguous(),
+        beta=beta.contiguous(),
+        scale=scale,
+        initial_state=initial_state.contiguous(),
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+    )
+    return o, final_state
+
+
+def chunk_kda_with_fused_gate(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    raw_g: torch.Tensor,
+    raw_beta: torch.Tensor,
+    A_log: torch.Tensor,
+    g_bias: torch.Tensor | None,
+    scale: float | None = None,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    lower_bound: float | None = None,
+    use_qk_l2norm_in_kernel: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    **kwargs,
+):
+    """Run chunk KDA from raw gate and beta projections."""
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+
+    if use_qk_l2norm_in_kernel:
+        q = l2norm_fwd(q.contiguous())
+        k = l2norm_fwd(k.contiguous())
+
+    o, final_state = chunk_kda_with_fused_gate_fwd(
+        q=q,
+        k=k,
+        v=v.contiguous(),
+        raw_g=raw_g.contiguous(),
+        raw_beta=raw_beta,
+        A_log=A_log,
+        g_bias=g_bias,
+        scale=scale,
+        initial_state=initial_state.contiguous() if initial_state is not None else None,
+        output_final_state=output_final_state,
+        lower_bound=lower_bound,
+        cu_seqlens=cu_seqlens,
+    )
+    return o, final_state
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BT": bt}, num_warps=nw, num_stages=ns)
+        for bt in BT_LIST_AUTOTUNE
+        for nw in NUM_WARPS_AUTOTUNE
+        for ns in [2, 3]
+    ],
+    key=["H", "D"],
+)
+@triton.jit
+def kda_gate_fwd_kernel(
+    g,
+    A,
+    y,
+    g_bias,
+    lower_bound,
+    beta: tl.constexpr,
+    threshold: tl.constexpr,
+    T,
+    H,
+    D: tl.constexpr,
+    BT: tl.constexpr,
+    BD: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+    USE_LOWER_BOUND: tl.constexpr,
+):
+    i_t, i_h = tl.program_id(0), tl.program_id(1)
+    n_t = i_t * BT
+
+    b_a = tl.exp(tl.load(A + i_h).to(tl.float32))
+
+    stride_row = H * D
+    stride_col = 1
+
+    g_ptr = tl.make_block_ptr(
+        base=g + i_h * D,
+        shape=(T, D),
+        strides=(stride_row, stride_col),
+        offsets=(n_t, 0),
+        block_shape=(BT, BD),
+        order=(1, 0),
+    )
+
+    y_ptr = tl.make_block_ptr(
+        base=y + i_h * D,
+        shape=(T, D),
+        strides=(stride_row, stride_col),
+        offsets=(n_t, 0),
+        block_shape=(BT, BD),
+        order=(1, 0),
+    )
+
+    b_g = tl.load(g_ptr, boundary_check=(0, 1)).to(tl.float32)
+
+    if HAS_BIAS:
+        n_d = tl.arange(0, BD)
+        bias_mask = n_d < D
+        b_bias = tl.load(g_bias + i_h * D + n_d, mask=bias_mask, other=0.0).to(
+            tl.float32
+        )
+        b_g = b_g + b_bias[None, :]
+
+    if USE_LOWER_BOUND:
+        b_y = lower_bound * tl.sigmoid(b_a * b_g)
+    else:
+        g_scaled = b_g * beta
+        use_linear = g_scaled > threshold
+        sp = tl.where(use_linear, b_g, (1.0 / beta) * log(1.0 + tl.exp(g_scaled)))
+        b_y = -b_a * sp
+
+    tl.store(y_ptr, b_y.to(y.dtype.element_ty), boundary_check=(0, 1))
+
+
+def fused_kda_gate(
+    g: torch.Tensor,
+    A: torch.Tensor,
+    head_k_dim: int,
+    g_bias: torch.Tensor | None = None,
+    beta: float = 1.0,
+    threshold: float = 20.0,
+    lower_bound: float | None = None,
+) -> torch.Tensor:
+    """
+    Forward pass for KDA gate:
+      input g: [..., H*D]
+      param A: [H] or [1, 1, H, 1]
+      beta: softplus beta parameter
+      threshold: softplus threshold parameter
+      return  : [..., H, D]
+    """
+    orig_shape = g.shape[:-1]
+
+    g = g.view(-1, g.shape[-1])
+    T = g.shape[0]
+    HD = g.shape[1]
+    H = A.numel()
+    assert H * head_k_dim == HD
+
+    y = torch.empty_like(g, dtype=torch.float32)
+
+    def grid(meta):
+        return (cdiv(T, meta["BT"]), H)
+
+    kda_gate_fwd_kernel[grid](
+        g,
+        A,
+        y,
+        g_bias,
+        lower_bound or 0.0,
+        beta,
+        threshold,
+        T,
+        H,
+        head_k_dim,
+        BD=next_power_of_2(head_k_dim),
+        HAS_BIAS=g_bias is not None,
+        USE_LOWER_BOUND=lower_bound is not None,
+    )
+
+    y = y.view(*orig_shape, H, head_k_dim)
+    return y

--- a/vllm/models/kimi_k3/amd/ops/third_party/kda/chunk_intra.py
+++ b/vllm/models/kimi_k3/amd/ops/third_party/kda/chunk_intra.py
@@ -1,0 +1,663 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This file contains code copied from the flash-linear-attention project.
+# The original source was licensed under the MIT license.
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+# Forward-only adaptation of flash-linear-attention 0.5.0.
+# ruff: noqa: E501
+# mypy: ignore-errors
+
+import torch
+
+from vllm.platforms import current_platform
+from vllm.third_party.flash_linear_attention.ops.index import prepare_chunk_indices
+from vllm.third_party.flash_linear_attention.ops.op import exp2, gather
+from vllm.third_party.flash_linear_attention.ops.utils import is_gather_supported
+from vllm.triton_utils import tl, triton
+
+from .chunk_intra_token_parallel import chunk_kda_fwd_intra_token_parallel
+
+################################################################################
+# Fused inter + solve_tril kernel: compute off-diagonal Akk and solve in one pass
+################################################################################
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({"BK": BK}, num_warps=num_warps)
+        for BK in [32, 64]
+        for num_warps in [1, 2, 4]
+    ],
+    key=["H", "HV", "K", "BC"],
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_kda_fwd_kernel_inter_solve_fused(
+    q,
+    k,
+    g,
+    beta,
+    Aqk,
+    Akkd,
+    Akk,
+    scale,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    USE_SAFE_GATE: tl.constexpr,
+    SOLVE_TRIL_DOT_PRECISION: tl.constexpr,
+):
+    """
+    Fused kernel: compute inter-subchunk Akk + solve_tril in one pass.
+    Prerequisite: token_parallel has already computed diagonal Akk blocks in Akkd.
+
+    This kernel:
+    1. Computes off-diagonal Aqk blocks -> writes to global
+    2. Computes off-diagonal Akk blocks -> keeps in registers
+    3. Loads diagonal Akk blocks from Akkd (fp32)
+    4. Does forward substitution on diagonals
+    5. Computes merged Akk_inv
+    6. Writes Akk_inv to Akk
+    """
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_hv = i_bh // HV, i_bh % HV
+    i_h = i_hv // (HV // H)
+
+    if IS_VARLEN:
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    if i_t * BT >= T:
+        return
+
+    i_tc0 = i_t * BT
+    i_tc1 = i_t * BT + BC
+    i_tc2 = i_t * BT + 2 * BC
+    i_tc3 = i_t * BT + 3 * BC
+
+    q += (bos * H + i_h) * K
+    k += (bos * H + i_h) * K
+    g += (bos * HV + i_hv) * K
+    Aqk += (bos * HV + i_hv) * BT
+    Akk += (bos * HV + i_hv) * BT
+    Akkd += (bos * HV + i_hv) * BC
+
+    o_i = tl.arange(0, BC)
+    m_tc1 = (i_tc1 + o_i) < T
+    m_tc2 = (i_tc2 + o_i) < T
+    m_tc3 = (i_tc3 + o_i) < T
+
+    b_Aqk10 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk10 = tl.zeros([BC, BC], dtype=tl.float32)
+
+    b_Aqk20 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk20 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Aqk21 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk21 = tl.zeros([BC, BC], dtype=tl.float32)
+
+    b_Aqk30 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk30 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Aqk31 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk31 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Aqk32 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk32 = tl.zeros([BC, BC], dtype=tl.float32)
+
+    ################################################################################
+    # off-diagonal blocks
+    ################################################################################
+    for i_k in range(tl.cdiv(K, BK)):
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = o_k < K
+
+        p_k0 = tl.make_block_ptr(
+            k, (T, K), (H * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0)
+        )
+        p_g0 = tl.make_block_ptr(
+            g, (T, K), (HV * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0)
+        )
+        b_k0 = tl.load(p_k0, boundary_check=(0, 1)).to(tl.float32)
+        b_g0 = tl.load(p_g0, boundary_check=(0, 1)).to(tl.float32)
+
+        if i_tc1 < T:
+            p_q1 = tl.make_block_ptr(
+                q, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0)
+            )
+            p_k1 = tl.make_block_ptr(
+                k, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0)
+            )
+            p_g1 = tl.make_block_ptr(
+                g, (T, K), (HV * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0)
+            )
+            # [BC, BK]
+            b_q1 = tl.load(p_q1, boundary_check=(0, 1)).to(tl.float32)
+            b_k1 = tl.load(p_k1, boundary_check=(0, 1)).to(tl.float32)
+            b_g1 = tl.load(p_g1, boundary_check=(0, 1)).to(tl.float32)
+            # [BK]
+            b_gn1 = tl.load(g + i_tc1 * HV * K + o_k, mask=m_k, other=0).to(tl.float32)
+            # [BC, BK]
+            b_gqn = tl.where(m_tc1[:, None], exp2(b_g1 - b_gn1[None, :]), 0)
+            # [BK, BC]
+            b_kgt = tl.trans(b_k0 * exp2(b_gn1[None, :] - b_g0))
+            # [BC, BC]
+            b_Aqk10 += tl.dot(b_q1 * b_gqn, b_kgt)
+            b_Akk10 += tl.dot(b_k1 * b_gqn, b_kgt)
+
+            if i_tc2 < T:
+                p_q2 = tl.make_block_ptr(
+                    q, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0)
+                )
+                p_k2 = tl.make_block_ptr(
+                    k, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0)
+                )
+                p_g2 = tl.make_block_ptr(
+                    g, (T, K), (HV * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0)
+                )
+                # [BC, BK]
+                b_q2 = tl.load(p_q2, boundary_check=(0, 1)).to(tl.float32)
+                b_k2 = tl.load(p_k2, boundary_check=(0, 1)).to(tl.float32)
+                b_g2 = tl.load(p_g2, boundary_check=(0, 1)).to(tl.float32)
+                # [BK]
+                b_gn2 = tl.load(g + i_tc2 * HV * K + o_k, mask=m_k, other=0).to(
+                    tl.float32
+                )
+                # [BC, BK]
+                b_gqn2 = tl.where(m_tc2[:, None], exp2(b_g2 - b_gn2[None, :]), 0)
+                b_qg2 = b_q2 * b_gqn2
+                b_kg2 = b_k2 * b_gqn2
+                # [BK, BC]
+                b_kgt = tl.trans(b_k0 * exp2(b_gn2[None, :] - b_g0))
+                b_Aqk20 += tl.dot(b_qg2, b_kgt)
+                b_Akk20 += tl.dot(b_kg2, b_kgt)
+                # [BC, BC]
+                b_kgt = tl.trans(b_k1 * exp2(b_gn2[None, :] - b_g1))
+                # [BC, BC]
+                b_Aqk21 += tl.dot(b_qg2, b_kgt)
+                b_Akk21 += tl.dot(b_kg2, b_kgt)
+
+                if i_tc3 < T:
+                    p_q3 = tl.make_block_ptr(
+                        q, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0)
+                    )
+                    p_k3 = tl.make_block_ptr(
+                        k, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0)
+                    )
+                    p_g3 = tl.make_block_ptr(
+                        g, (T, K), (HV * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0)
+                    )
+                    # [BC, BK]
+                    b_q3 = tl.load(p_q3, boundary_check=(0, 1)).to(tl.float32)
+                    b_k3 = tl.load(p_k3, boundary_check=(0, 1)).to(tl.float32)
+                    b_g3 = tl.load(p_g3, boundary_check=(0, 1)).to(tl.float32)
+                    # [BK]
+                    b_gn3 = tl.load(g + i_tc3 * HV * K + o_k, mask=m_k, other=0).to(
+                        tl.float32
+                    )
+                    # [BC, BK]
+                    b_gqn3 = tl.where(m_tc3[:, None], exp2(b_g3 - b_gn3[None, :]), 0)
+                    b_qg3 = b_q3 * b_gqn3
+                    b_kg3 = b_k3 * b_gqn3
+                    # [BK, BC]
+                    b_kgt = tl.trans(b_k0 * exp2(b_gn3[None, :] - b_g0))
+                    # [BC, BC]
+                    b_Aqk30 += tl.dot(b_qg3, b_kgt)
+                    b_Akk30 += tl.dot(b_kg3, b_kgt)
+                    # [BK, BC]
+                    b_kgt = tl.trans(b_k1 * exp2(b_gn3[None, :] - b_g1))
+                    # [BC, BC]
+                    b_Aqk31 += tl.dot(b_qg3, b_kgt)
+                    b_Akk31 += tl.dot(b_kg3, b_kgt)
+                    # [BK, BC]
+                    b_kgt = tl.trans(b_k2 * exp2(b_gn3[None, :] - b_g2))
+                    # [BC, BC]
+                    b_Aqk32 += tl.dot(b_qg3, b_kgt)
+                    b_Akk32 += tl.dot(b_kg3, b_kgt)
+
+    ################################################################################
+    # save off-diagonal Aqk blocks and prepare Akk
+    ################################################################################
+    if i_tc1 < T:
+        p_Aqk10 = tl.make_block_ptr(
+            Aqk, (T, BT), (HV * BT, 1), (i_tc1, 0), (BC, BC), (1, 0)
+        )
+        tl.store(
+            p_Aqk10, (b_Aqk10 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1)
+        )
+
+        p_b1 = tl.make_block_ptr(
+            beta + bos * HV + i_hv, (T,), (HV,), (i_tc1,), (BC,), (0,)
+        )
+        b_b1 = tl.load(p_b1, boundary_check=(0,)).to(tl.float32)
+        b_Akk10 = b_Akk10 * b_b1[:, None]
+    if i_tc2 < T:
+        p_Aqk20 = tl.make_block_ptr(
+            Aqk, (T, BT), (HV * BT, 1), (i_tc2, 0), (BC, BC), (1, 0)
+        )
+        p_Aqk21 = tl.make_block_ptr(
+            Aqk, (T, BT), (HV * BT, 1), (i_tc2, BC), (BC, BC), (1, 0)
+        )
+        tl.store(
+            p_Aqk20, (b_Aqk20 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1)
+        )
+        tl.store(
+            p_Aqk21, (b_Aqk21 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1)
+        )
+
+        p_b2 = tl.make_block_ptr(
+            beta + bos * HV + i_hv, (T,), (HV,), (i_tc2,), (BC,), (0,)
+        )
+        b_b2 = tl.load(p_b2, boundary_check=(0,)).to(tl.float32)
+        b_Akk20 = b_Akk20 * b_b2[:, None]
+        b_Akk21 = b_Akk21 * b_b2[:, None]
+    if i_tc3 < T:
+        p_Aqk30 = tl.make_block_ptr(
+            Aqk, (T, BT), (HV * BT, 1), (i_tc3, 0), (BC, BC), (1, 0)
+        )
+        p_Aqk31 = tl.make_block_ptr(
+            Aqk, (T, BT), (HV * BT, 1), (i_tc3, BC), (BC, BC), (1, 0)
+        )
+        p_Aqk32 = tl.make_block_ptr(
+            Aqk, (T, BT), (HV * BT, 1), (i_tc3, 2 * BC), (BC, BC), (1, 0)
+        )
+        tl.store(
+            p_Aqk30, (b_Aqk30 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1)
+        )
+        tl.store(
+            p_Aqk31, (b_Aqk31 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1)
+        )
+        tl.store(
+            p_Aqk32, (b_Aqk32 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1)
+        )
+
+        p_b3 = tl.make_block_ptr(
+            beta + bos * HV + i_hv, (T,), (HV,), (i_tc3,), (BC,), (0,)
+        )
+        b_b3 = tl.load(p_b3, boundary_check=(0,)).to(tl.float32)
+        b_Akk30 = b_Akk30 * b_b3[:, None]
+        b_Akk31 = b_Akk31 * b_b3[:, None]
+        b_Akk32 = b_Akk32 * b_b3[:, None]
+
+    p_Akk00 = tl.make_block_ptr(
+        Akkd, (T, BC), (HV * BC, 1), (i_tc0, 0), (BC, BC), (1, 0)
+    )
+    p_Akk11 = tl.make_block_ptr(
+        Akkd, (T, BC), (HV * BC, 1), (i_tc1, 0), (BC, BC), (1, 0)
+    )
+    p_Akk22 = tl.make_block_ptr(
+        Akkd, (T, BC), (HV * BC, 1), (i_tc2, 0), (BC, BC), (1, 0)
+    )
+    p_Akk33 = tl.make_block_ptr(
+        Akkd, (T, BC), (HV * BC, 1), (i_tc3, 0), (BC, BC), (1, 0)
+    )
+    b_Ai00 = tl.load(p_Akk00, boundary_check=(0, 1)).to(tl.float32)
+    b_Ai11 = tl.load(p_Akk11, boundary_check=(0, 1)).to(tl.float32)
+    b_Ai22 = tl.load(p_Akk22, boundary_check=(0, 1)).to(tl.float32)
+    b_Ai33 = tl.load(p_Akk33, boundary_check=(0, 1)).to(tl.float32)
+
+    ################################################################################
+    # forward substitution on diagonals
+    ################################################################################
+
+    if not USE_SAFE_GATE:
+        m_A = o_i[:, None] > o_i[None, :]
+        m_I = o_i[:, None] == o_i[None, :]
+
+        b_Ai00 = -tl.where(m_A, b_Ai00, 0)
+        b_Ai11 = -tl.where(m_A, b_Ai11, 0)
+        b_Ai22 = -tl.where(m_A, b_Ai22, 0)
+        b_Ai33 = -tl.where(m_A, b_Ai33, 0)
+
+        for i in range(2, min(BC, T - i_tc0)):
+            b_a00 = -tl.load(Akkd + (i_tc0 + i) * HV * BC + o_i)
+            b_a00 = tl.where(o_i < i, b_a00, 0.0)
+            b_a00 += tl.sum(b_a00[:, None] * b_Ai00, 0)
+            b_Ai00 = tl.where((o_i == i)[:, None], b_a00, b_Ai00)
+        for i in range(BC + 2, min(2 * BC, T - i_tc0)):
+            b_a11 = -tl.load(Akkd + (i_tc0 + i) * HV * BC + o_i)
+            b_a11 = tl.where(o_i < i - BC, b_a11, 0.0)
+            b_a11 += tl.sum(b_a11[:, None] * b_Ai11, 0)
+            b_Ai11 = tl.where((o_i == i - BC)[:, None], b_a11, b_Ai11)
+        for i in range(2 * BC + 2, min(3 * BC, T - i_tc0)):
+            b_a22 = -tl.load(Akkd + (i_tc0 + i) * HV * BC + o_i)
+            b_a22 = tl.where(o_i < i - 2 * BC, b_a22, 0.0)
+            b_a22 += tl.sum(b_a22[:, None] * b_Ai22, 0)
+            b_Ai22 = tl.where((o_i == i - 2 * BC)[:, None], b_a22, b_Ai22)
+        for i in range(3 * BC + 2, min(4 * BC, T - i_tc0)):
+            b_a33 = -tl.load(Akkd + (i_tc0 + i) * HV * BC + o_i)
+            b_a33 = tl.where(o_i < i - 3 * BC, b_a33, 0.0)
+            b_a33 += tl.sum(b_a33[:, None] * b_Ai33, 0)
+            b_Ai33 = tl.where((o_i == i - 3 * BC)[:, None], b_a33, b_Ai33)
+
+        b_Ai00 += m_I
+        b_Ai11 += m_I
+        b_Ai22 += m_I
+        b_Ai33 += m_I
+
+    ################################################################################
+    # compute merged inverse using off-diagonals
+    ################################################################################
+
+    # we used tf32 to maintain matrix inverse's precision whenever possible.
+    b_Ai10 = -tl.dot(
+        tl.dot(b_Ai11, b_Akk10, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        b_Ai00,
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+    b_Ai21 = -tl.dot(
+        tl.dot(b_Ai22, b_Akk21, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        b_Ai11,
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+    b_Ai32 = -tl.dot(
+        tl.dot(b_Ai33, b_Akk32, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        b_Ai22,
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+
+    b_Ai20 = -tl.dot(
+        b_Ai22,
+        tl.dot(b_Akk20, b_Ai00, input_precision=SOLVE_TRIL_DOT_PRECISION)
+        + tl.dot(b_Akk21, b_Ai10, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+    b_Ai31 = -tl.dot(
+        b_Ai33,
+        tl.dot(b_Akk31, b_Ai11, input_precision=SOLVE_TRIL_DOT_PRECISION)
+        + tl.dot(b_Akk32, b_Ai21, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+    b_Ai30 = -tl.dot(
+        b_Ai33,
+        tl.dot(b_Akk30, b_Ai00, input_precision=SOLVE_TRIL_DOT_PRECISION)
+        + tl.dot(b_Akk31, b_Ai10, input_precision=SOLVE_TRIL_DOT_PRECISION)
+        + tl.dot(b_Akk32, b_Ai20, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+
+    ################################################################################
+    # store full Akk_inv to Akk
+    ################################################################################
+
+    p_Akk00 = tl.make_block_ptr(
+        Akk, (T, BT), (HV * BT, 1), (i_tc0, 0), (BC, BC), (1, 0)
+    )
+    p_Akk10 = tl.make_block_ptr(
+        Akk, (T, BT), (HV * BT, 1), (i_tc1, 0), (BC, BC), (1, 0)
+    )
+    p_Akk11 = tl.make_block_ptr(
+        Akk, (T, BT), (HV * BT, 1), (i_tc1, BC), (BC, BC), (1, 0)
+    )
+    p_Akk20 = tl.make_block_ptr(
+        Akk, (T, BT), (HV * BT, 1), (i_tc2, 0), (BC, BC), (1, 0)
+    )
+    p_Akk21 = tl.make_block_ptr(
+        Akk, (T, BT), (HV * BT, 1), (i_tc2, BC), (BC, BC), (1, 0)
+    )
+    p_Akk22 = tl.make_block_ptr(
+        Akk, (T, BT), (HV * BT, 1), (i_tc2, 2 * BC), (BC, BC), (1, 0)
+    )
+    p_Akk30 = tl.make_block_ptr(
+        Akk, (T, BT), (HV * BT, 1), (i_tc3, 0), (BC, BC), (1, 0)
+    )
+    p_Akk31 = tl.make_block_ptr(
+        Akk, (T, BT), (HV * BT, 1), (i_tc3, BC), (BC, BC), (1, 0)
+    )
+    p_Akk32 = tl.make_block_ptr(
+        Akk, (T, BT), (HV * BT, 1), (i_tc3, 2 * BC), (BC, BC), (1, 0)
+    )
+    p_Akk33 = tl.make_block_ptr(
+        Akk, (T, BT), (HV * BT, 1), (i_tc3, 3 * BC), (BC, BC), (1, 0)
+    )
+
+    tl.store(p_Akk00, b_Ai00.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk10, b_Ai10.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk11, b_Ai11.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk20, b_Ai20.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk21, b_Ai21.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk22, b_Ai22.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk30, b_Ai30.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk31, b_Ai31.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk32, b_Ai32.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk33, b_Ai33.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in [1, 2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=["BK", "NC", "BT", "HV"],
+)
+@triton.jit(do_not_specialize=["B", "T"])
+def chunk_kda_fwd_kernel_intra_sub_chunk(
+    q,
+    k,
+    g,
+    beta,
+    Aqk,
+    Akk,
+    scale,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    USE_GATHER: tl.constexpr,
+):
+    i_t, i_i, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_hv = i_bh // HV, i_bh % HV
+    i_h = i_hv // (HV // H)
+
+    if IS_VARLEN:
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    i_ti = i_t * BT + i_i * BC
+    if i_ti >= T:
+        return
+
+    o_c = i_ti + tl.arange(0, BC)
+    m_c = o_c < T
+
+    q = q + (bos * H + i_h) * K
+    k = k + (bos * H + i_h) * K
+    g = g + (bos * HV + i_hv) * K
+    beta = beta + bos * HV + i_hv
+    Aqk = Aqk + (bos * HV + i_hv) * BT
+    Akk = Akk + (bos * HV + i_hv) * BC
+
+    p_q = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_ti, 0), (BC, BK), (1, 0))
+    p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_ti, 0), (BC, BK), (1, 0))
+    p_g = tl.make_block_ptr(g, (T, K), (HV * K, 1), (i_ti, 0), (BC, BK), (1, 0))
+
+    p_beta = tl.make_block_ptr(beta, (T,), (HV,), (i_ti,), (BC,), (0,))
+
+    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_k = tl.load(p_k, boundary_check=(0, 1))
+    b_g = tl.load(p_g, boundary_check=(0, 1))
+    b_beta = tl.load(p_beta, boundary_check=(0,)).to(tl.float32)
+
+    if USE_GATHER:
+        b_gn = gather(
+            b_g, tl.full([1, BK], min(BC // 2, T - i_ti - 1), dtype=tl.int16), axis=0
+        )
+    else:
+        # calculate offset
+        p_gn = g + (i_ti + min(BC // 2, T - i_ti - 1)) * HV * K + tl.arange(0, BK)
+        b_gn = tl.load(p_gn, mask=tl.arange(0, BK) < K, other=0.0)
+        b_gn = b_gn[None, :]
+
+    # current block, keep numerical stability by subtracting the left boundary
+    # less than 85 to avoid overflow in exp2
+    b_gm = (b_g - b_gn).to(tl.float32)
+
+    b_gq = tl.where(m_c[:, None], exp2(b_gm), 0.0)
+    b_gk = tl.where(m_c[:, None], exp2(-b_gm), 0.0)
+
+    b_kgt = tl.trans(b_k * b_gk)
+
+    b_Aqk = tl.dot(b_q * b_gq, b_kgt) * scale
+    b_Akk = tl.dot(b_k * b_gq, b_kgt) * b_beta[:, None]
+
+    o_i = tl.arange(0, BC)
+    m_Aqk = o_i[:, None] >= o_i[None, :]
+    m_Akk = o_i[:, None] > o_i[None, :]
+    m_I = o_i[:, None] == o_i[None, :]
+
+    b_Aqk = tl.where(m_Aqk, b_Aqk, 0.0)
+    b_Akk = tl.where(m_Akk, b_Akk, 0.0)
+
+    p_Aqk = tl.make_block_ptr(
+        Aqk, (T, BT), (HV * BT, 1), (i_ti, i_i * BC), (BC, BC), (1, 0)
+    )
+    p_Akk = tl.make_block_ptr(Akk, (T, BC), (HV * BC, 1), (i_ti, 0), (BC, BC), (1, 0))
+    tl.store(p_Aqk, b_Aqk.to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk, b_Akk.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+
+    tl.debug_barrier()
+
+    ################################################################################
+    # forward substitution
+    ################################################################################
+
+    b_Ai = -b_Akk
+    for i in range(2, min(BC, T - i_ti)):
+        b_a = -tl.load(Akk + (i_ti + i) * HV * BC + o_i)
+        b_a = tl.where(o_i < i, b_a, 0.0)
+        b_a += tl.sum(b_a[:, None] * b_Ai, 0)
+        b_Ai = tl.where((o_i == i)[:, None], b_a, b_Ai)
+    b_Ai += m_I
+    tl.store(p_Akk, b_Ai.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+
+
+def chunk_kda_fwd_intra(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    gk: torch.Tensor | None = None,
+    beta: torch.Tensor | None = None,
+    scale: float | None = None,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+    safe_gate: bool = False,
+):
+    B, T, H, K, HV = *k.shape, gk.shape[2]
+    BT = chunk_size
+    BC = 16
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    NC = triton.cdiv(BT, BC)
+
+    Aqk = torch.empty(B, T, HV, BT, device=k.device, dtype=k.dtype)
+    # Akk must be zero-initialized - kernel only writes lower triangular
+    Akk = torch.zeros(B, T, HV, BT, device=k.device, dtype=k.dtype)
+    # Separate fp32 buffer for diagonal 16x16 blocks (for precision in solve_tril)
+    Akkd = torch.empty(B, T, HV, BC, device=k.device, dtype=torch.float32)
+
+    # Compute diagonal blocks into Akkd in fp32.
+    if safe_gate:
+        grid = (NT, NC, B * HV)
+        BK = triton.next_power_of_2(K)
+        chunk_kda_fwd_kernel_intra_sub_chunk[grid](
+            q=q,
+            k=k,
+            g=gk,
+            beta=beta,
+            Aqk=Aqk,
+            Akk=Akkd,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            T=T,
+            H=H,
+            HV=HV,
+            K=K,
+            BT=BT,
+            BC=BC,
+            BK=BK,
+            USE_GATHER=is_gather_supported,
+        )
+    else:
+        Aqk, Akkd = chunk_kda_fwd_intra_token_parallel(
+            q=q,
+            k=k,
+            gk=gk,
+            beta=beta,
+            Aqk=Aqk,
+            Akk=Akkd,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            chunk_size=BT,
+            sub_chunk_size=BC,
+        )
+
+    # Step 2: Fused inter + solve_tril (works for both fixed-len and varlen)
+    solve_tril_dot_precision = (
+        "tf32"
+        if current_platform.is_cuda() and current_platform.has_device_capability(80)
+        else "ieee"
+    )
+    grid = (NT, B * HV)
+    chunk_kda_fwd_kernel_inter_solve_fused[grid](
+        q=q,
+        k=k,
+        g=gk,
+        beta=beta,
+        Aqk=Aqk,
+        Akkd=Akkd,
+        Akk=Akk,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        HV=HV,
+        K=K,
+        BT=BT,
+        BC=BC,
+        USE_SAFE_GATE=safe_gate,
+        SOLVE_TRIL_DOT_PRECISION=solve_tril_dot_precision,
+    )
+    return Aqk, Akk

--- a/vllm/models/kimi_k3/amd/ops/third_party/kda/chunk_intra_token_parallel.py
+++ b/vllm/models/kimi_k3/amd/ops/third_party/kda/chunk_intra_token_parallel.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This file contains code copied from the flash-linear-attention project.
+# The original source was licensed under the MIT license.
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+# Forward-only adaptation of flash-linear-attention 0.5.0.
+# ruff: noqa: E501
+# mypy: ignore-errors
+
+# Token-parallel implementation of KDA intra chunk kernel
+
+import torch
+
+from vllm.third_party.flash_linear_attention.ops.op import exp2
+from vllm.triton_utils import tl, triton
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({"BH": BH}, num_warps=num_warps)
+        for BH in [1, 2, 4, 8]
+        for num_warps in [1, 2, 4, 8]
+    ],
+    key=["K", "H", "HV"],
+)
+@triton.jit(do_not_specialize=["T", "N"])
+def chunk_kda_fwd_kernel_intra_token_parallel(
+    q,
+    k,
+    g,
+    beta,
+    Aqk,
+    Akk,
+    scale,
+    cu_seqlens,
+    N,
+    T,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BH: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_tg, i_hg = tl.program_id(0), tl.program_id(1)
+
+    if IS_VARLEN:
+        i_n = 0
+        left, right = 0, N
+
+        # Unrolled binary search (max B=2^32)
+        # We can limit iterations based on expected max batch size if needed
+        # 20 iterations covers B=1M, usually enough
+        for _ in range(20):
+            if left < right:
+                mid = (left + right) // 2
+                if i_tg < tl.load(cu_seqlens + mid + 1).to(tl.int32):
+                    right = mid
+                else:
+                    left = mid + 1
+        i_n = left
+
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+        i_t = i_tg - bos
+    else:
+        bos = (i_tg // T) * T
+        i_t = i_tg % T
+
+    if i_t >= T:
+        return
+
+    i_c = i_t // BT
+    i_s = (i_t % BT) // BC
+    i_tc = i_c * BT
+    i_ts = i_tc + i_s * BC
+
+    G: tl.constexpr = HV // H
+
+    q += bos * H * K
+    k += bos * H * K
+    g += bos * HV * K
+    Aqk += bos * HV * BT
+    Akk += bos * HV * BC
+    beta += bos * HV
+
+    BK: tl.constexpr = triton.next_power_of_2(K)
+    o_hv = i_hg * BH + tl.arange(0, BH)
+    o_h = o_hv // G
+    o_k = tl.arange(0, BK)
+    m_hv = o_hv < HV
+    m_k = o_k < K
+    m_hk = m_hv[:, None] & m_k[None, :]
+
+    # q/k: [B, T, H, K], manual load via mapped qk head index
+    p_qk = o_h[:, None] * K + o_k[None, :]
+    b_q = tl.load(q + i_t * H * K + p_qk, mask=m_hk, other=0).to(tl.float32)
+    b_k = tl.load(k + i_t * H * K + p_qk, mask=m_hk, other=0).to(tl.float32)
+
+    # g: [B, T, HV, K], beta: [B, T, HV]
+    p_g = tl.make_block_ptr(
+        g + i_t * HV * K, (HV, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0)
+    )
+    p_beta = tl.make_block_ptr(beta + i_t * HV, (HV,), (1,), (i_hg * BH,), (BH,), (0,))
+    b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+    b_beta = tl.load(p_beta, boundary_check=(0,)).to(tl.float32)
+    b_k *= b_beta[:, None]
+
+    for j in range(i_ts, min(i_t + 1, min(T, i_ts + BC))):
+        b_kj = tl.load(k + j * H * K + p_qk, mask=m_hk, other=0).to(tl.float32)
+        p_gj = tl.make_block_ptr(
+            g + j * HV * K, (HV, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0)
+        )
+        b_gj = tl.load(p_gj, boundary_check=(0, 1)).to(tl.float32)
+
+        b_kgj = tl.where(m_k[None, :], b_kj * exp2(b_g - b_gj), 0.0)
+        b_Aqk = tl.sum(b_q * b_kgj, axis=1) * scale
+        b_Akk = tl.sum(b_k * b_kgj, axis=1) * tl.where(j < i_t, 1.0, 0.0)
+
+        tl.store(
+            Aqk + i_t * HV * BT + o_hv * BT + j % BT,
+            b_Aqk.to(Aqk.dtype.element_ty),
+            mask=m_hv,
+        )
+        tl.store(
+            Akk + i_t * HV * BC + o_hv * BC + j - i_ts,
+            b_Akk.to(Akk.dtype.element_ty),
+            mask=m_hv,
+        )
+
+
+def chunk_kda_fwd_intra_token_parallel(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    gk: torch.Tensor,
+    beta: torch.Tensor,
+    Aqk: torch.Tensor,
+    Akk: torch.Tensor,
+    scale: float,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    sub_chunk_size: int = 16,
+) -> None:
+    """
+    Token-parallel implementation: each token gets its own thread block.
+    Supports both fixed-length and variable-length sequences.
+    Reduces wasted computation on padding.
+
+    Writes directly to Aqk and Akk tensors (in-place).
+
+    Args:
+        q: [B, T, H, K]
+        k: [B, T, H, K]
+        gk: [B, T, HV, K] cumsum of gates (HV >= H for GVA)
+        beta: [B, T, HV]
+        Aqk: [B, T, HV, BT] output tensor to write to
+        Akk: [B, T, HV, BC] output tensor for diagonal blocks (fp32)
+        scale: attention scale
+        chunk_size: BT (default 64)
+        sub_chunk_size: BC (default 16)
+    """
+    B, T, H, K, HV = *q.shape, gk.shape[2]
+    N = len(cu_seqlens) - 1 if cu_seqlens is not None else B
+    BT = chunk_size
+    BC = sub_chunk_size
+
+    def grid(meta):
+        return (B * T, triton.cdiv(HV, meta["BH"]))
+
+    chunk_kda_fwd_kernel_intra_token_parallel[grid](
+        q=q,
+        k=k,
+        g=gk,
+        beta=beta,
+        Aqk=Aqk,
+        Akk=Akk,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        N=N,
+        T=T,
+        H=H,
+        HV=HV,
+        K=K,
+        BT=BT,
+        BC=BC,
+    )
+    return Aqk, Akk

--- a/vllm/models/kimi_k3/amd/ops/third_party/kda/fused_recurrent.py
+++ b/vllm/models/kimi_k3/amd/ops/third_party/kda/fused_recurrent.py
@@ -1,0 +1,621 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This file contains code adapted from the flash-linear-attention project.
+# The original source was licensed under the MIT license.
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+# ruff: noqa: E501
+
+import torch
+
+from vllm.third_party.flash_linear_attention.ops.op import exp, log
+from vllm.triton_utils import tl, triton
+from vllm.utils.math_utils import cdiv, next_power_of_2
+
+
+@triton.heuristics(
+    {
+        "HAS_DT_BIAS": lambda args: args["dt_bias"] is not None,
+        "USE_LOWER_BOUND": lambda args: args["lower_bound"] is not None,
+    }
+)
+@triton.jit
+def _kda_gate_beta_fwd_kernel(
+    raw_g,
+    raw_beta,
+    A_log,
+    dt_bias,
+    gate,
+    beta_out,
+    lower_bound,
+    softplus_beta: tl.constexpr,
+    softplus_threshold: tl.constexpr,
+    T,
+    stride_g_token: tl.constexpr,
+    stride_beta_token: tl.constexpr,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    BT: tl.constexpr,
+    BD: tl.constexpr,
+    HAS_DT_BIAS: tl.constexpr,
+    USE_LOWER_BOUND: tl.constexpr,
+):
+    i_t, i_h = tl.program_id(0), tl.program_id(1)
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_d = tl.arange(0, BD)
+    m_t = o_t < T
+    m_d = o_d < D
+
+    p_g = raw_g + o_t[:, None] * stride_g_token + i_h * D + o_d[None, :]
+    b_g = tl.load(p_g, mask=m_t[:, None] & m_d[None, :], other=0.0).to(tl.float32)
+    if HAS_DT_BIAS:
+        b_bias = tl.load(
+            dt_bias + i_h * D + o_d,
+            mask=m_d,
+            other=0.0,
+        ).to(tl.float32)
+        b_g += b_bias[None, :]
+
+    b_a = exp(tl.load(A_log + i_h).to(tl.float32))
+    if USE_LOWER_BOUND:
+        b_gate = lower_bound * tl.sigmoid(b_a * b_g)
+    else:
+        b_scaled = b_g * softplus_beta
+        b_softplus = tl.where(
+            b_scaled > softplus_threshold,
+            b_g,
+            log(1.0 + tl.exp(b_scaled)) / softplus_beta,
+        )
+        b_gate = -b_a * b_softplus
+
+    p_gate = gate + (o_t[:, None] * H + i_h) * D + o_d[None, :]
+    tl.store(
+        p_gate,
+        b_gate,
+        mask=m_t[:, None] & m_d[None, :],
+    )
+
+    b_beta = tl.load(
+        raw_beta + o_t * stride_beta_token + i_h,
+        mask=m_t,
+        other=0.0,
+    ).to(tl.float32)
+    tl.store(beta_out + o_t * H + i_h, tl.sigmoid(b_beta), mask=m_t)
+
+
+def _fused_kda_gate_beta(
+    raw_g: torch.Tensor,
+    raw_beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor | None,
+    lower_bound: float | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    B, T, H, D = raw_g.shape
+    assert B == 1
+    assert raw_beta.shape == (B, T, H)
+    assert raw_g.stride()[2:] == (D, 1)
+    assert raw_beta.stride(2) == 1
+    gate = torch.empty((B, T, H, D), dtype=torch.float32, device=raw_g.device)
+    beta = torch.empty((B, T, H), dtype=torch.float32, device=raw_beta.device)
+
+    BT = 16
+    _kda_gate_beta_fwd_kernel[(cdiv(T, BT), H)](
+        raw_g=raw_g,
+        raw_beta=raw_beta,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        gate=gate,
+        beta_out=beta,
+        lower_bound=lower_bound,
+        softplus_beta=1.0,
+        softplus_threshold=20.0,
+        T=T,
+        stride_g_token=raw_g.stride(1),
+        stride_beta_token=raw_beta.stride(1),
+        H=H,
+        D=D,
+        BT=BT,
+        BD=next_power_of_2(D),
+        num_warps=4,
+    )
+    return gate, beta
+
+
+@triton.heuristics(
+    {
+        "IS_SPEC_DECODING": lambda args: args["num_accepted_tokens"] is not None,
+        "HAS_DT_BIAS": lambda args: args["dt_bias"] is not None,
+        "USE_LOWER_BOUND": lambda args: args["lower_bound"] is not None,
+    }
+)
+@triton.jit(do_not_specialize=["N", "T"])
+def fused_recurrent_kda_fwd_kernel(
+    q,
+    k,
+    v,
+    g,
+    beta,
+    A_log,
+    dt_bias,
+    out,
+    state,
+    cu_seqlens,
+    state_indices,
+    num_accepted_tokens,
+    lower_bound,
+    scale: tl.constexpr,
+    N: tl.int64,
+    T: tl.int64,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    stride_qkv_token: tl.constexpr,
+    stride_g_token: tl.constexpr,
+    stride_beta_token: tl.constexpr,
+    stride_out_token: tl.constexpr,
+    stride_state_token: tl.constexpr,
+    stride_indices_seq: tl.constexpr,
+    IS_SPEC_DECODING: tl.constexpr,
+    USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
+    USE_GATE_IN_KERNEL: tl.constexpr,
+    APPLY_BETA_SIGMOID: tl.constexpr,
+    HAS_DT_BIAS: tl.constexpr,
+    USE_LOWER_BOUND: tl.constexpr,
+    num_stages: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    i_v = pid % tl.cdiv(V, BV)
+    i_nh = pid // tl.cdiv(V, BV)
+    i_n, i_h = i_nh // H, i_nh % H
+    bos = tl.load(cu_seqlens + i_n).to(tl.int64)
+    eos = tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+    sequence_length = eos - bos
+    if sequence_length == 0:
+        return
+
+    o_k = tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_k = o_k < K
+    m_v = o_v < V
+    m_state = m_v[:, None] & m_k[None, :]
+
+    if IS_SPEC_DECODING:
+        initial_token = tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1
+    else:
+        initial_token = 0
+    state_index = tl.load(state_indices + i_n * stride_indices_seq + initial_token).to(
+        tl.int64
+    )
+    p_out = out + bos * stride_out_token + i_h * V + o_v
+    if state_index <= 0:
+        tl.store(p_out, tl.zeros([BV], dtype=tl.float32), mask=m_v)
+        return
+
+    p_state = (
+        state
+        + state_index * stride_state_token
+        + i_h * V * K
+        + o_v[:, None] * K
+        + o_k[None, :]
+    )
+    b_state = tl.load(p_state, mask=m_state, other=0.0).to(tl.float32)
+
+    p_q = q + bos * stride_qkv_token + i_h * K + o_k
+    p_k = k + bos * stride_qkv_token + i_h * K + o_k
+    p_v = v + bos * stride_qkv_token + i_h * V + o_v
+    p_g = g + bos * stride_g_token + i_h * K + o_k
+    p_beta = beta + bos * stride_beta_token + i_h
+    for i_t in tl.range(0, sequence_length, num_stages=num_stages):
+        b_q = tl.load(p_q, mask=m_k, other=0.0, eviction_policy="evict_last").to(
+            tl.float32
+        )
+        b_k = tl.load(p_k, mask=m_k, other=0.0, eviction_policy="evict_last").to(
+            tl.float32
+        )
+        b_v = tl.load(p_v, mask=m_v, other=0.0, eviction_policy="evict_first").to(
+            tl.float32
+        )
+        if USE_QK_L2NORM_IN_KERNEL:
+            b_q = b_q / tl.sqrt(tl.sum(b_q * b_q) + 1e-6)
+            b_k = b_k / tl.sqrt(tl.sum(b_k * b_k) + 1e-6)
+        b_q *= scale
+
+        b_gate = tl.load(
+            p_g,
+            mask=m_k,
+            other=0.0,
+            eviction_policy="evict_last",
+        ).to(tl.float32)
+        if USE_GATE_IN_KERNEL:
+            if HAS_DT_BIAS:
+                b_bias = tl.load(
+                    dt_bias + i_h * K + o_k,
+                    mask=m_k,
+                    other=0.0,
+                ).to(tl.float32)
+                b_gate += b_bias
+            b_a = exp(tl.load(A_log + i_h).to(tl.float32))
+            if USE_LOWER_BOUND:
+                b_gate = lower_bound * tl.sigmoid(b_a * b_gate)
+            else:
+                b_softplus = tl.where(
+                    b_gate > 20.0,
+                    b_gate,
+                    log(1.0 + tl.exp(b_gate)),
+                )
+                b_gate = -b_a * b_softplus
+
+        b_state *= exp(b_gate[None, :])
+        b_v -= tl.sum(b_state * b_k[None, :], axis=1)
+        b_beta = tl.load(p_beta, eviction_policy="evict_last").to(tl.float32)
+        if APPLY_BETA_SIGMOID:
+            b_beta = tl.sigmoid(b_beta)
+        b_v *= b_beta
+        b_state += b_v[:, None] * b_k[None, :]
+        b_out = tl.sum(b_state * b_q[None, :], axis=1)
+        tl.store(
+            p_out,
+            b_out.to(p_out.dtype.element_ty),
+            mask=m_v,
+            eviction_policy="evict_first",
+        )
+
+        final_state_index = tl.load(state_indices + i_n * stride_indices_seq + i_t).to(
+            tl.int64
+        )
+        if final_state_index > 0:
+            p_final_state = (
+                state
+                + final_state_index * stride_state_token
+                + i_h * V * K
+                + o_v[:, None] * K
+                + o_k[None, :]
+            )
+            tl.store(
+                p_final_state,
+                b_state.to(p_final_state.dtype.element_ty),
+                mask=m_state,
+            )
+
+        p_q += stride_qkv_token
+        p_k += stride_qkv_token
+        p_v += stride_qkv_token
+        p_g += stride_g_token
+        p_beta += stride_beta_token
+        p_out += stride_out_token
+
+
+def fused_recurrent_kda_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float | None = None,
+    initial_state: torch.Tensor | None = None,
+    inplace_final_state: bool = True,
+    cu_seqlens: torch.Tensor | None = None,
+    ssm_state_indices: torch.Tensor | None = None,
+    num_accepted_tokens: torch.Tensor | None = None,
+    use_qk_l2norm_in_kernel: bool = True,
+    A_log: torch.Tensor | None = None,
+    dt_bias: torch.Tensor | None = None,
+    lower_bound: float | None = None,
+    use_gate_in_kernel: bool = False,
+    use_beta_sigmoid_in_kernel: bool = False,
+    out: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Launch recurrent KDA with dense inner dimensions and row strides."""
+    B, T, H, K = q.shape
+    V = v.shape[-1]
+    assert B == 1 and k.shape == q.shape
+    assert v.shape == (B, T, H, V) and g.shape == (B, T, H, K)
+    assert beta.shape == (B, T, H)
+    assert initial_state is not None
+    assert cu_seqlens is not None
+    assert ssm_state_indices is not None
+    assert inplace_final_state
+    if out is None:
+        out = torch.empty_like(v)
+    assert out.shape == v.shape
+    assert initial_state.shape[1:] == (H, V, K)
+    assert ssm_state_indices.ndim in (1, 2)
+
+    assert q.stride()[2:] == k.stride()[2:] == (K, 1)
+    assert v.stride()[2:] == out.stride()[2:] == (V, 1)
+    assert g.stride()[2:] == (K, 1)
+    assert beta.stride(2) == 1
+    assert q.stride(1) == k.stride(1) == v.stride(1)
+    assert initial_state.stride()[1:] == (V * K, K, 1)
+    N = cu_seqlens.numel() - 1
+    if ssm_state_indices.ndim == 1:
+        assert T == N
+        assert num_accepted_tokens is None
+    else:
+        assert ssm_state_indices.stride(1) == 1
+    assert cu_seqlens.is_contiguous()
+    if use_gate_in_kernel:
+        assert A_log is not None and A_log.is_contiguous()
+        assert dt_bias is None or dt_bias.is_contiguous()
+
+    if scale is None:
+        scale = K**-0.5
+
+    BV = 32 if use_gate_in_kernel else 8
+    num_warps = 4 if use_gate_in_kernel else 1
+    grid = (cdiv(V, BV) * N * H,)
+    fused_recurrent_kda_fwd_kernel[grid](
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        out=out,
+        state=initial_state,
+        cu_seqlens=cu_seqlens,
+        state_indices=ssm_state_indices,
+        num_accepted_tokens=num_accepted_tokens,
+        lower_bound=lower_bound,
+        scale=scale,
+        N=N,
+        T=T,
+        H=H,
+        K=K,
+        V=V,
+        BK=next_power_of_2(K),
+        BV=BV,
+        stride_qkv_token=q.stride(1),
+        stride_g_token=g.stride(1),
+        stride_beta_token=beta.stride(1),
+        stride_out_token=out.stride(1),
+        stride_state_token=initial_state.stride(0),
+        stride_indices_seq=ssm_state_indices.stride(0),
+        IS_SPEC_DECODING=num_accepted_tokens is not None,
+        USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
+        USE_GATE_IN_KERNEL=use_gate_in_kernel,
+        APPLY_BETA_SIGMOID=use_beta_sigmoid_in_kernel,
+        num_warps=num_warps,
+        num_stages=2,
+    )
+    return out, initial_state
+
+
+def fused_recurrent_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    raw_g: torch.Tensor,
+    raw_beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor | None,
+    lower_bound: float | None,
+    initial_state: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    ssm_state_indices: torch.Tensor,
+    num_accepted_tokens: torch.Tensor | None = None,
+    out: torch.Tensor | None = None,
+    fuse_gate: bool | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run recurrent KDA from raw gate and beta inputs.
+
+    This vLLM wrapper applies the gate activation and beta sigmoid, selecting
+    whether to materialize them before launching the recurrent kernel.
+    """
+    if fuse_gate is None:
+        # gfx950: always fuse the gate.
+        fuse_gate = True
+
+    if fuse_gate:
+        gate = raw_g
+        beta = raw_beta
+    else:
+        gate, beta = _fused_kda_gate_beta(
+            raw_g,
+            raw_beta,
+            A_log,
+            dt_bias,
+            lower_bound,
+        )
+    return fused_recurrent_kda_fwd(
+        q=q,
+        k=k,
+        v=v,
+        g=gate,
+        beta=beta,
+        scale=q.shape[-1] ** -0.5,
+        initial_state=initial_state,
+        inplace_final_state=True,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_state_indices,
+        num_accepted_tokens=num_accepted_tokens,
+        use_qk_l2norm_in_kernel=True,
+        A_log=A_log if fuse_gate else None,
+        dt_bias=dt_bias if fuse_gate else None,
+        lower_bound=lower_bound if fuse_gate else None,
+        use_gate_in_kernel=fuse_gate,
+        use_beta_sigmoid_in_kernel=fuse_gate,
+        out=out,
+    )
+
+
+@triton.jit
+def fused_recurrent_kda_packed_decode_kernel(
+    mixed_qkv,
+    raw_g,
+    raw_beta,
+    A_log,
+    dt_bias,
+    out,
+    state,
+    state_indices,
+    lower_bound,
+    scale: tl.constexpr,
+    stride_mixed_token: tl.constexpr,
+    stride_g_token: tl.constexpr,
+    stride_beta_token: tl.constexpr,
+    stride_state_token: tl.constexpr,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    SOFTPLUS_THRESHOLD: tl.constexpr,
+    USE_LOWER_BOUND: tl.constexpr,
+):
+    i_v, i_nh = tl.program_id(0), tl.program_id(1)
+    i_n, i_h = i_nh // H, i_nh % H
+
+    o_k = tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    mask_k = o_k < K
+    mask_v = o_v < V
+    mask_state = mask_v[:, None] & mask_k[None, :]
+
+    state_idx = tl.load(state_indices + i_n).to(tl.int64)
+    p_out = out + (i_n * H + i_h) * V + o_v
+    if state_idx <= 0:
+        tl.store(p_out, tl.zeros([BV], dtype=tl.float32), mask=mask_v)
+        return
+
+    p_state = state + state_idx * stride_state_token
+    p_state += i_h * V * K + o_v[:, None] * K + o_k[None, :]
+    b_state = tl.load(p_state, mask=mask_state, other=0).to(tl.float32)
+
+    # Q, K, and V occupy consecutive channel ranges, while the token stride
+    # may also include the output-gate projection that follows packed QKV.
+    p_mixed = mixed_qkv + i_n * stride_mixed_token
+    b_q = tl.load(p_mixed + i_h * K + o_k, mask=mask_k, other=0).to(tl.float32)
+    b_k = tl.load(
+        p_mixed + H * K + i_h * K + o_k,
+        mask=mask_k,
+        other=0,
+    ).to(tl.float32)
+    b_v = tl.load(
+        p_mixed + 2 * H * K + i_h * V + o_v,
+        mask=mask_v,
+        other=0,
+    ).to(tl.float32)
+
+    b_q /= tl.sqrt(tl.sum(b_q * b_q) + 1e-6)
+    b_k /= tl.sqrt(tl.sum(b_k * b_k) + 1e-6)
+    b_q *= scale
+
+    p_g = raw_g + i_n * stride_g_token + i_h * K + o_k
+    b_g = tl.load(p_g, mask=mask_k, other=0).to(tl.float32)
+    b_bias = tl.load(dt_bias + i_h * K + o_k, mask=mask_k, other=0).to(tl.float32)
+    b_a = exp(tl.load(A_log + i_h).to(tl.float32))
+    b_g += b_bias
+    if USE_LOWER_BOUND:
+        b_gate = lower_bound * tl.sigmoid(b_a * b_g)
+    else:
+        b_softplus = tl.where(
+            b_g > SOFTPLUS_THRESHOLD,
+            b_g,
+            log(1.0 + tl.exp(b_g)),
+        )
+        b_gate = -b_a * b_softplus
+
+    b_state *= exp(b_gate[None, :])
+    b_v -= tl.sum(b_state * b_k[None, :], axis=1)
+    b_beta = tl.sigmoid(
+        tl.load(raw_beta + i_n * stride_beta_token + i_h).to(tl.float32)
+    )
+    b_v *= b_beta
+    b_state += b_v[:, None] * b_k[None, :]
+    b_out = tl.sum(b_state * b_q[None, :], axis=1)
+
+    tl.store(p_out, b_out.to(p_out.dtype.element_ty), mask=mask_v)
+    tl.store(p_state, b_state.to(p_state.dtype.element_ty), mask=mask_state)
+
+
+def fused_recurrent_kda_packed_decode(
+    mixed_qkv: torch.Tensor,
+    raw_g: torch.Tensor,
+    raw_beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    lower_bound: float | None,
+    initial_state: torch.Tensor,
+    state_indices: torch.Tensor,
+    scale: float | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run one-token KDA decode directly from packed post-conv QKV."""
+    if mixed_qkv.ndim != 2 or mixed_qkv.stride(-1) != 1:
+        raise ValueError("`mixed_qkv` must be 2D and contiguous in its last dim.")
+    if raw_g.ndim != 4 or raw_g.shape[0] != 1:
+        raise ValueError("`raw_g` must have shape [1, B, H, K].")
+    if raw_beta.ndim != 3 or raw_beta.shape[0] != 1:
+        raise ValueError("`raw_beta` must have shape [1, B, H].")
+    if initial_state.ndim != 4:
+        raise ValueError("`initial_state` must have shape [cache, H, V, K].")
+    _, H, V, K = initial_state.shape
+    if raw_g.stride()[2:] != (K, 1):
+        raise ValueError("`raw_g` must be contiguous within each token.")
+    if raw_beta.stride(2) != 1:
+        raise ValueError("`raw_beta` heads must be contiguous.")
+    if initial_state.stride()[1:] != (V * K, K, 1):
+        raise ValueError("`initial_state` must be contiguous within each cache slot.")
+    if state_indices.ndim != 1 or state_indices.stride(0) != 1:
+        raise ValueError("`state_indices` must be contiguous and one-dimensional.")
+    if A_log.ndim != 1 or not A_log.is_contiguous():
+        raise ValueError("`A_log` must be contiguous and one-dimensional.")
+    if not dt_bias.is_contiguous():
+        raise ValueError("`dt_bias` must be contiguous.")
+
+    device = mixed_qkv.device
+    if any(
+        x.device != device
+        for x in (raw_g, raw_beta, A_log, dt_bias, initial_state, state_indices)
+    ):
+        raise ValueError("All packed KDA inputs must be on the same device.")
+
+    B = mixed_qkv.shape[0]
+    if raw_g.shape != (1, B, H, K):
+        raise ValueError(f"Unexpected raw gate shape {tuple(raw_g.shape)}.")
+    if raw_beta.shape != (1, B, H):
+        raise ValueError(f"Unexpected raw beta shape {tuple(raw_beta.shape)}.")
+    if mixed_qkv.shape[1] != 2 * H * K + H * V:
+        raise ValueError(f"Unexpected packed QKV shape {tuple(mixed_qkv.shape)}.")
+    if A_log.numel() != H or dt_bias.numel() != H * K:
+        raise ValueError("`A_log` or `dt_bias` has an incompatible shape.")
+    if state_indices.shape[0] != B:
+        raise ValueError("`state_indices` must contain one entry per token.")
+
+    BK = next_power_of_2(K)
+    BV = min(next_power_of_2(V), 32)
+    if scale is None:
+        scale = K**-0.5
+
+    out = torch.empty((1, B, H, V), dtype=mixed_qkv.dtype, device=device)
+    grid = (cdiv(V, BV), B * H)
+    fused_recurrent_kda_packed_decode_kernel[grid](
+        mixed_qkv=mixed_qkv,
+        raw_g=raw_g,
+        raw_beta=raw_beta,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        out=out,
+        state=initial_state,
+        state_indices=state_indices,
+        lower_bound=lower_bound or 0.0,
+        scale=scale,
+        stride_mixed_token=mixed_qkv.stride(0),
+        stride_g_token=raw_g.stride(1),
+        stride_beta_token=raw_beta.stride(1),
+        stride_state_token=initial_state.stride(0),
+        H=H,
+        K=K,
+        V=V,
+        BK=BK,
+        BV=BV,
+        SOFTPLUS_THRESHOLD=20.0,
+        USE_LOWER_BOUND=lower_bound is not None,
+        num_warps=4,
+        num_stages=2,
+    )
+    return out, initial_state

--- a/vllm/models/kimi_k3/nvidia/__init__.py
+++ b/vllm/models/kimi_k3/nvidia/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/models/kimi_k3/nvidia/kda.py
+++ b/vllm/models/kimi_k3/nvidia/kda.py
@@ -1,0 +1,777 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Callable
+
+import torch
+from einops import rearrange
+from torch import nn
+from torch.nn.parameter import Parameter
+
+from vllm import _custom_ops as ops
+from vllm.compilation.breakable_cudagraph import eager_break_during_capture
+from vllm.config import VllmConfig
+from vllm.distributed import divide, get_tensor_model_parallel_rank
+from vllm.forward_context import get_forward_context
+from vllm.logger import init_logger
+from vllm.model_executor.layers.linear import (
+    ColumnParallelLinear,
+    MergedColumnParallelLinear,
+    RowParallelLinear,
+)
+from vllm.model_executor.layers.mamba.gdn.base import GatedDeltaNetAttention
+from vllm.model_executor.layers.mamba.mamba_utils import (
+    MambaStateDtypeCalculator,
+    MambaStateShapeCalculator,
+    is_conv_state_dim_first,
+)
+from vllm.model_executor.layers.mamba.ops.causal_conv1d import (
+    causal_conv1d_fn,
+    causal_conv1d_update,
+)
+from vllm.model_executor.layers.mamba.ops.gather_initial_states import (
+    gather_initial_states,
+)
+from vllm.model_executor.model_loader.weight_utils import (
+    default_weight_loader,
+    sharded_weight_loader,
+)
+from vllm.model_executor.parameter import BasevLLMParameter
+from vllm.model_executor.utils import set_weight_attrs
+from vllm.models.kimi_k3.nvidia.kda_metadata import (
+    KimiK3KDAAttentionBackend,
+    KimiK3KDAMetadata,
+)
+from vllm.platforms import current_platform
+from vllm.third_party.flash_linear_attention.ops.fused_norm_gate import (
+    FusedRMSNormGated,
+)
+from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
+from vllm.v1.attention.backend import AttentionBackend
+
+logger = init_logger(__name__)
+
+_KDA_GATE_LOGBOUND_MIN = -5.0
+
+
+def a_log_weight_loader(
+    shard_axis: int,
+) -> Callable[[torch.Tensor, torch.Tensor], None]:
+    """Load KDA A_log stored as either old 4D or current 1D weights."""
+
+    def loader(param: torch.Tensor, loaded_weight: torch.Tensor) -> None:
+        tp_rank = get_tensor_model_parallel_rank()
+        shard_size = param.data.shape[shard_axis]
+        start_idx = tp_rank * shard_size
+
+        if loaded_weight.dim() == 4:
+            assert loaded_weight.shape[:2] == (1, 1), (
+                f"Expected old A_log shape (1, 1, H, 1), got {loaded_weight.shape}"
+            )
+            assert loaded_weight.shape[-1] == 1, (
+                f"Expected old A_log last dim to be 1, got {loaded_weight.shape}"
+            )
+            loaded_weight = loaded_weight.view(loaded_weight.shape[2])
+
+        loaded_weight = loaded_weight.narrow(shard_axis, start_idx, shard_size)
+        return default_weight_loader(param, loaded_weight)
+
+    return loader
+
+
+class _KimiGDNMergedColumnParallelLinear(MergedColumnParallelLinear):
+    """Merged projection with one output replicated across TP ranks."""
+
+    def __init__(
+        self,
+        input_size: int,
+        output_sizes: list[int],
+        replicated_shard_id: int,
+        tp_size: int,
+        **kwargs,
+    ) -> None:
+        self.replicated_shard_id = replicated_shard_id
+        output_sizes = output_sizes.copy()
+        output_sizes[replicated_shard_id] *= tp_size
+        super().__init__(input_size, output_sizes, **kwargs)
+
+    def weight_loader(
+        self,
+        param: Parameter,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: tuple[int, ...] | int | None = None,
+    ) -> None:
+        tp_rank = self.tp_rank
+        param_tp_rank = getattr(param, "tp_rank", None)
+        if loaded_shard_id == self.replicated_shard_id:
+            self.tp_rank = 0
+            if param_tp_rank is not None:
+                param.tp_rank = 0
+        try:
+            super().weight_loader(param, loaded_weight, loaded_shard_id)
+        finally:
+            self.tp_rank = tp_rank
+            if param_tp_rank is not None:
+                param.tp_rank = param_tp_rank
+
+    def weight_loader_v2(
+        self,
+        param: BasevLLMParameter,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: tuple[int, ...] | int | None = None,
+    ) -> None:
+        tp_rank = self.tp_rank
+        param_tp_rank = getattr(param, "tp_rank", None)
+        if loaded_shard_id == self.replicated_shard_id:
+            self.tp_rank = 0
+            if param_tp_rank is not None:
+                param.tp_rank = 0
+        try:
+            super().weight_loader_v2(param, loaded_weight, loaded_shard_id)
+        finally:
+            self.tp_rank = tp_rank
+            if param_tp_rank is not None:
+                param.tp_rank = param_tp_rank
+
+
+def is_fused_kda_decode_supported(
+    num_heads: int,
+    head_dim: int,
+    conv_width: int,
+    num_spec: int,
+    input_dtype: torch.dtype,
+    conv_state_dtype: torch.dtype,
+) -> bool:
+    if (
+        num_heads not in (12, 24, 48, 96)
+        or head_dim != 128
+        or conv_width != 4
+        or num_spec != 0
+        or input_dtype != torch.bfloat16
+        or conv_state_dtype != torch.bfloat16
+        or is_conv_state_dim_first()
+        or not hasattr(torch.ops._C, "fused_kda_decode")
+    ):
+        return False
+    # SM90 is architecture-specific; SM10x and SM12x use family binaries.
+    return (
+        current_platform.is_device_capability(90)
+        or current_platform.is_device_capability_family(100)
+        or current_platform.is_device_capability_family(120)
+    )
+
+
+def is_flashkda_supported(
+    head_dim: int,
+    dtype: torch.dtype,
+    lower_bound: float | None,
+) -> bool:
+    capability = current_platform.get_device_capability()
+    return (
+        capability is not None
+        and capability.major in (9, 10, 12)
+        and head_dim == 128
+        and dtype == torch.bfloat16
+        and lower_bound is not None
+    )
+
+
+def _flashkda_prefill(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    lower_bound: float,
+    initial_state: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    import vllm._flashkda_C  # noqa: F401
+
+    out = torch.empty(v.shape, dtype=v.dtype, device=v.device)
+    final_state = torch.empty_like(initial_state)
+    workspace = torch.empty(
+        torch.ops._flashkda_C.get_workspace_size(
+            q.shape[0] * q.shape[1],
+            q.shape[2],
+            cu_seqlens.numel() - 1,
+        ),
+        dtype=torch.uint8,
+        device=q.device,
+    )
+    # FlashKDA hardcodes dense Q/K/V/G strides. Beta may be row-strided because
+    # FlashKDA materializes its transposed [H, T] layout internally.
+    # TODO: Teach FlashKDA to consume beta in [T, H] layout directly instead
+    # of transposing it to contiguous [H, T] storage internally.
+    torch.ops._flashkda_C.fwd(
+        q.contiguous(),
+        k.contiguous(),
+        v.contiguous(),
+        g.contiguous(),
+        beta,
+        q.shape[-1] ** -0.5,
+        out,
+        workspace,
+        A_log.contiguous(),
+        dt_bias.view(-1, q.shape[-1]).contiguous(),
+        lower_bound,
+        initial_state.contiguous(),
+        final_state,
+        cu_seqlens.contiguous(),
+    )
+    return out, final_state
+
+
+def resolve_kda_prefill_backend(
+    backend: str,
+    head_dim: int,
+    dtype: torch.dtype,
+    lower_bound: float | None,
+) -> str:
+    if backend not in ("auto", "triton", "flashkda"):
+        raise ValueError(f"Unsupported KDA prefill backend: {backend}")
+    supported = is_flashkda_supported(head_dim, dtype, lower_bound)
+    if backend == "flashkda" and not supported:
+        raise RuntimeError(
+            "FlashKDA requires CUDA SM90/SM10x/SM12x, bfloat16, "
+            "head_dim=128, and a bounded KDA gate."
+        )
+    if supported and backend != "triton":
+        logger.info_once("Using FlashKDA KDA prefill backend.")
+        return "flashkda"
+    return "triton"
+
+
+def _make_decode_conv1d_weight_loader(
+    dims: list[int],
+    tp_size: int,
+    tp_rank: int,
+    decode_conv1d_weight: torch.Tensor | None,
+) -> Callable[..., None]:
+    sharded_dims = [dim // tp_size for dim in dims]
+
+    def weight_loader(
+        param: torch.Tensor,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: int,
+    ) -> None:
+        if loaded_weight.dim() == 2:
+            loaded_weight = loaded_weight.unsqueeze(1)
+        shard_size = sharded_dims[loaded_shard_id]
+        source_start = tp_rank * shard_size
+        target_start = sum(sharded_dims[:loaded_shard_id])
+        loaded_shard = loaded_weight[source_start : source_start + shard_size]
+        param.data[target_start : target_start + shard_size].copy_(loaded_shard)
+        if decode_conv1d_weight is not None and not param.is_meta:
+            decode_conv1d_weight[loaded_shard_id].copy_(
+                loaded_shard.squeeze(1).transpose(0, 1)
+            )
+
+    return weight_loader
+
+
+def _make_decode_norm_weight_loader(
+    decode_norm_weight: torch.Tensor,
+) -> Callable[..., None]:
+    def weight_loader(param: torch.Tensor, loaded_weight: torch.Tensor) -> None:
+        default_weight_loader(param, loaded_weight)
+        if not param.is_meta:
+            decode_norm_weight.copy_(param.data)
+
+    return weight_loader
+
+
+class KimiK3DeltaAttention(GatedDeltaNetAttention):
+    def get_attn_backend(self) -> type[AttentionBackend]:
+        return KimiK3KDAAttentionBackend
+
+    def get_state_dtype(
+        self,
+    ) -> tuple[torch.dtype, torch.dtype]:
+        if self.model_config is None or self.cache_config is None:
+            raise ValueError("model_config and cache_config must be set")
+        return MambaStateDtypeCalculator.kda_state_dtype(
+            self.model_config.dtype, self.cache_config.mamba_cache_dtype
+        )
+
+    def get_state_shape(
+        self,
+    ) -> tuple[tuple[int, ...], tuple[int, ...]]:
+        return MambaStateShapeCalculator.kda_state_shape(
+            self.tp_size,
+            self.num_heads,
+            self.head_dim,
+            conv_kernel_size=self.conv_size,
+            num_spec=self.num_spec,
+        )
+
+    def __init__(
+        self,
+        config: KimiLinearConfig,
+        vllm_config: VllmConfig,
+        prefix: str = "",
+    ) -> None:
+        super().__init__(config, vllm_config, prefix)
+
+        kda_config = config.linear_attn_config  # type: ignore[attr-defined]
+        assert kda_config is not None, "linear_attn_config must be set"
+        self.head_dim = kda_config["head_dim"]
+        self.num_heads = kda_config["num_heads"]
+        assert self.num_heads % self.tp_size == 0
+        self.local_num_heads = divide(self.num_heads, self.tp_size)
+        self.projection_size = self.head_dim * self.num_heads
+        self.local_projection_size = divide(self.projection_size, self.tp_size)
+        self.conv_size = kda_config["short_conv_kernel_size"]
+        assert kda_config.get("use_full_rank_gate", False), (
+            "KimiK3DeltaAttention requires a full-rank gate"
+        )
+
+        # Keep f_a before the narrow beta shard, then pad each TP-local row
+        # to select the aligned BF16 GEMM path.
+        qkvg_output_sizes = [self.projection_size] * 4
+        in_proj_output_sizes = qkvg_output_sizes + [
+            self.head_dim,
+            self.num_heads,
+        ]
+        local_output_size = (
+            4 * self.local_projection_size + self.head_dim + self.local_num_heads
+        )
+        self.in_proj_padding = -local_output_size % 16
+        if self.in_proj_padding:
+            in_proj_output_sizes.append(self.in_proj_padding * self.tp_size)
+        self.in_proj_qkvgfab = _KimiGDNMergedColumnParallelLinear(
+            self.hidden_size,
+            in_proj_output_sizes,
+            replicated_shard_id=4,
+            tp_size=self.tp_size,
+            bias=False,
+            quant_config=self.quant_config,
+            prefix=f"{prefix}.in_proj_qkvgfab",
+        )
+        if self.in_proj_padding:
+            self.in_proj_qkvgfab.weight.data[-self.in_proj_padding :].zero_()
+
+        self.f_b_proj = ColumnParallelLinear(
+            self.head_dim,
+            self.projection_size,
+            bias=False,
+            quant_config=self.quant_config,
+            prefix=f"{prefix}.f_b_proj",
+        )
+        self.dt_bias = nn.Parameter(
+            torch.empty(self.local_projection_size, dtype=torch.float32)
+        )
+        set_weight_attrs(self.dt_bias, {"weight_loader": sharded_weight_loader(0)})
+
+        # One packed parameter and cache let decode run a single conv update.
+        # Prefill slices them back into Q/K/V to obtain dense outputs cheaply.
+        self.conv1d = ColumnParallelLinear(
+            input_size=self.conv_size,
+            output_size=3 * self.projection_size,
+            bias=False,
+            params_dtype=torch.float32,
+            prefix=f"{prefix}.conv1d",
+        )
+        self.conv1d.weight.data = self.conv1d.weight.data.unsqueeze(1)
+        # Keep a width-major copy for fused decode without changing the layout
+        # consumed by the prefill and fallback decode kernels.
+        conv_state_dtype, _ = self.get_state_dtype()
+        decode_conv1d_weight = None
+        if is_fused_kda_decode_supported(
+            self.local_num_heads,
+            self.head_dim,
+            self.conv_size,
+            self.num_spec,
+            vllm_config.model_config.dtype,
+            conv_state_dtype,
+        ):
+            logger.info_once("Fused KDA decode kernel (conv+KDA+norm) is enabled.")
+            decode_conv1d_weight = torch.empty(
+                3,
+                self.conv_size,
+                self.local_projection_size,
+                dtype=self.conv1d.weight.dtype,
+                device=self.conv1d.weight.device,
+            )
+        self.register_buffer(
+            "decode_conv1d_weight", decode_conv1d_weight, persistent=False
+        )
+        delattr(self.conv1d.weight, "weight_loader")
+        set_weight_attrs(
+            self.conv1d.weight,
+            {
+                "weight_loader": _make_decode_conv1d_weight_loader(
+                    [self.projection_size] * 3,
+                    self.tp_size,
+                    self.tp_rank,
+                    decode_conv1d_weight,
+                )
+            },
+        )
+
+        self.A_log = nn.Parameter(
+            torch.empty(self.local_num_heads, dtype=torch.float32)
+        )
+        set_weight_attrs(self.A_log, {"weight_loader": a_log_weight_loader(0)})
+
+        self.gate_lower_bound: float | None = kda_config.get("gate_lower_bound", None)
+        if self.gate_lower_bound is not None:
+            assert _KDA_GATE_LOGBOUND_MIN <= self.gate_lower_bound < 0, (
+                "KDA gate lower bound must be in "
+                f"[{_KDA_GATE_LOGBOUND_MIN}, 0). "
+                f"Got {self.gate_lower_bound}."
+            )
+
+        additional_config = vllm_config.additional_config
+        backend = (
+            additional_config.get("kda_prefill_backend", "auto")
+            if isinstance(additional_config, dict)
+            else "auto"
+        )
+        self.kda_prefill_backend = resolve_kda_prefill_backend(
+            backend,
+            self.head_dim,
+            vllm_config.model_config.dtype,
+            self.gate_lower_bound,
+        )
+
+        self.o_norm = FusedRMSNormGated(self.head_dim, activation="sigmoid")
+        decode_norm_weight = None
+        if decode_conv1d_weight is not None:
+            decode_norm_weight = torch.empty(
+                self.head_dim,
+                dtype=torch.float32,
+                device=self.o_norm.weight.device,
+            )
+        self.register_buffer("decode_norm_weight", decode_norm_weight, persistent=False)
+        if decode_norm_weight is not None:
+            # Upcast once while loading; direct BF16 norm weights slow the
+            # fully fused decode kernel.
+            if hasattr(self.o_norm.weight, "weight_loader"):
+                delattr(self.o_norm.weight, "weight_loader")
+            set_weight_attrs(
+                self.o_norm.weight,
+                {"weight_loader": _make_decode_norm_weight_loader(decode_norm_weight)},
+            )
+        self.o_proj = RowParallelLinear(
+            self.projection_size,
+            self.hidden_size,
+            bias=False,
+            quant_config=self.quant_config,
+            prefix=f"{prefix}.o_proj",
+        )
+
+        compilation_config = vllm_config.compilation_config
+        if prefix in compilation_config.static_forward_context:
+            raise ValueError(f"Duplicate layer name: {prefix}")
+        compilation_config.static_forward_context[prefix] = self
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> torch.Tensor:
+        num_tokens = hidden_states.size(0)
+        projected_qkvgfab = self.in_proj_qkvgfab(hidden_states)[0]
+        split_sizes = [
+            3 * self.local_projection_size,
+            self.local_projection_size,
+            self.head_dim,
+            self.local_num_heads,
+        ]
+        if self.in_proj_padding:
+            split_sizes.append(self.in_proj_padding)
+        projected = projected_qkvgfab.split(split_sizes, dim=-1)
+        mixed_qkv, g_proj_states, f_a, beta = projected[:4]
+
+        g1 = self.f_b_proj(f_a)[0]
+        beta = beta.unsqueeze(0)
+        g1 = rearrange(g1, "n (h d) -> 1 n h d", d=self.head_dim)
+        g2 = rearrange(g_proj_states, "... (h d) -> ... h d", d=self.head_dim)
+        core_attn_out = torch.empty(
+            (1, num_tokens, self.local_num_heads, self.head_dim),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+        self._forward(
+            mixed_qkv=mixed_qkv,
+            g1=g1,
+            g2=g2,
+            beta=beta,
+            core_attn_out=core_attn_out,
+        )
+        core_attn_out = rearrange(core_attn_out, "1 n h d -> n (h d)")
+        return self.o_proj(core_attn_out)[0]
+
+    @eager_break_during_capture
+    def _forward(
+        self,
+        mixed_qkv: torch.Tensor,
+        g1: torch.Tensor,
+        g2: torch.Tensor,
+        beta: torch.Tensor,
+        core_attn_out: torch.Tensor,
+    ) -> None:
+        forward_context = get_forward_context()
+        attn_metadata_raw = forward_context.attn_metadata
+        if attn_metadata_raw is None:
+            return
+
+        from vllm.models.kimi_k3.nvidia.ops.third_party.kda import (
+            chunk_kda_with_fused_gate,
+            fused_recurrent_kda,
+            fused_recurrent_kda_packed_decode,
+        )
+
+        assert isinstance(attn_metadata_raw, dict)
+        attn_metadata_narrowed = attn_metadata_raw[self.prefix]
+        assert isinstance(attn_metadata_narrowed, KimiK3KDAMetadata)
+        m = attn_metadata_narrowed
+        has_initial_state = m.has_initial_state
+        non_spec_query_start_loc = m.non_spec_query_start_loc
+        non_spec_state_indices_tensor = m.non_spec_state_indices_tensor
+        spec_token_indx = m.spec_token_indx
+        non_spec_token_indx = m.non_spec_token_indx
+        spec_state_indices_tensor = m.spec_state_indices_tensor
+        spec_query_start_loc = m.spec_query_start_loc
+        num_accepted_tokens = m.num_accepted_tokens
+        num_actual_tokens = m.num_actual_tokens
+        has_spec_decode = m.num_spec_decodes > 0
+        mixed_qkv = mixed_qkv[:num_actual_tokens]
+        g1 = g1[:, :num_actual_tokens]
+        beta = beta[:, :num_actual_tokens]
+
+        conv_state, recurrent_state = self.kv_cache
+        # The convolution kernels consume (..., dim, width - 1).
+        if not is_conv_state_dim_first():
+            conv_state = conv_state.transpose(-1, -2)
+
+        if (
+            self.decode_conv1d_weight is not None
+            and self.decode_norm_weight is not None
+            and not has_spec_decode
+            and m.num_prefills == 0
+            and m.num_decodes > 0
+        ):
+            assert non_spec_state_indices_tensor is not None
+            ops.fused_kda_decode(
+                x=mixed_qkv,
+                weight=self.decode_conv1d_weight,
+                bias=self.conv1d.bias,
+                conv_state=conv_state,
+                raw_g=g1,
+                raw_beta=beta,
+                A_log=self.A_log,
+                dt_bias=self.dt_bias,
+                state_indices=non_spec_state_indices_tensor[:num_actual_tokens],
+                state=recurrent_state,
+                out=core_attn_out[:, :num_actual_tokens],
+                lower_bound=self.gate_lower_bound,
+                output_gate=g2[:num_actual_tokens],
+                norm_weight=self.decode_norm_weight,
+                norm_eps=self.o_norm.eps,
+            )
+            return
+
+        conv_weights = self.conv1d.weight.view(
+            self.conv1d.weight.size(0), self.conv1d.weight.size(2)
+        )
+        q_conv_weight, k_conv_weight, v_conv_weight = conv_weights.split(
+            self.local_projection_size, dim=0
+        )
+        q_conv_state, k_conv_state, v_conv_state = conv_state.split(
+            self.local_projection_size, dim=-2
+        )
+
+        # Separate multi-query speculative tokens from prefill/plain decode.
+        if has_spec_decode:
+            if m.num_prefills == 0 and m.num_decodes == 0:
+                mixed_qkv_spec = mixed_qkv
+                g1_spec, beta_spec = g1, beta
+                mixed_qkv_ns = g1_ns = beta_ns = None
+            else:
+                assert spec_token_indx is not None
+                assert non_spec_token_indx is not None
+                mixed_qkv_spec = mixed_qkv.index_select(0, spec_token_indx)
+                g1_spec = g1.index_select(1, spec_token_indx)
+                beta_spec = beta.index_select(1, spec_token_indx)
+                mixed_qkv_ns = mixed_qkv.index_select(0, non_spec_token_indx)
+                g1_ns = g1.index_select(1, non_spec_token_indx)
+                beta_ns = beta.index_select(1, non_spec_token_indx)
+        else:
+            mixed_qkv_spec = g1_spec = beta_spec = None
+            mixed_qkv_ns, g1_ns, beta_ns = mixed_qkv, g1, beta
+
+        # Spec-decode multi-query path.
+        core_attn_out_spec = None
+        if has_spec_decode:
+            assert spec_state_indices_tensor is not None
+            assert spec_query_start_loc is not None
+            spec_conv_indices = spec_state_indices_tensor[:, 0][: m.num_spec_decodes]
+            spec_max_query_len = spec_state_indices_tensor.size(-1)
+            spec_conv_out = torch.empty_like(mixed_qkv_spec)
+            mixed_qkv_spec = causal_conv1d_update(
+                mixed_qkv_spec,
+                conv_state,
+                conv_weights,
+                self.conv1d.bias,
+                activation="silu",
+                conv_state_indices=spec_conv_indices,
+                num_accepted_tokens=num_accepted_tokens,
+                query_start_loc=spec_query_start_loc,
+                max_query_len=spec_max_query_len,
+                validate_data=False,
+                out=spec_conv_out,
+            )
+            q_spec, k_spec, v_spec = (
+                rearrange(x, "n (h d) -> 1 n h d", d=self.head_dim)
+                for x in mixed_qkv_spec.split(self.local_projection_size, dim=-1)
+            )
+            spec_cu_seqlens = spec_query_start_loc[: m.num_spec_decodes + 1]
+            spec_out = (
+                core_attn_out[:, : q_spec.shape[1]]
+                if m.num_prefills == 0 and m.num_decodes == 0
+                else None
+            )
+            core_attn_out_spec, _ = fused_recurrent_kda(
+                q=q_spec,
+                k=k_spec,
+                v=v_spec,
+                raw_g=g1_spec,
+                raw_beta=beta_spec,
+                A_log=self.A_log,
+                dt_bias=self.dt_bias,
+                lower_bound=self.gate_lower_bound,
+                initial_state=recurrent_state,
+                cu_seqlens=spec_cu_seqlens,
+                ssm_state_indices=spec_state_indices_tensor,
+                num_accepted_tokens=num_accepted_tokens,
+                out=spec_out,
+            )
+
+        # Prefill or plain-decode path.
+        core_attn_out_non_spec = None
+        if mixed_qkv_ns is not None:
+            assert g1_ns is not None and beta_ns is not None
+            if m.num_prefills > 0:
+                q_ns, k_ns, v_ns = mixed_qkv_ns.split(
+                    self.local_projection_size, dim=-1
+                )
+
+                # Separate convolution calls accept row-strided packed inputs
+                # and produce dense Q/K/V without an additional V copy.
+                def _prefill_conv(
+                    x: torch.Tensor,
+                    state: torch.Tensor,
+                    weight: torch.Tensor,
+                ) -> torch.Tensor:
+                    return causal_conv1d_fn(
+                        x.transpose(0, 1),
+                        weight,
+                        None,
+                        activation="silu",
+                        conv_states=state,
+                        has_initial_state=has_initial_state,
+                        cache_indices=non_spec_state_indices_tensor,
+                        query_start_loc=non_spec_query_start_loc,
+                        metadata=m,
+                    ).transpose(0, 1)
+
+                q_ns = _prefill_conv(q_ns, q_conv_state, q_conv_weight)
+                k_ns = _prefill_conv(k_ns, k_conv_state, k_conv_weight)
+                v_ns = _prefill_conv(v_ns, v_conv_state, v_conv_weight)
+                q_ns, k_ns, v_ns = (
+                    rearrange(x, "n (h d) -> 1 n h d", d=self.head_dim)
+                    for x in (q_ns, k_ns, v_ns)
+                )
+
+                assert non_spec_state_indices_tensor is not None
+                assert has_initial_state is not None
+                initial_state = gather_initial_states(
+                    recurrent_state,
+                    non_spec_state_indices_tensor,
+                    has_initial_state,
+                )
+                if self.kda_prefill_backend == "flashkda":
+                    assert self.gate_lower_bound is not None
+                    (
+                        core_attn_out_non_spec,
+                        last_recurrent_state,
+                    ) = _flashkda_prefill(
+                        q=q_ns,
+                        k=k_ns,
+                        v=v_ns,
+                        g=g1_ns,
+                        beta=beta_ns,
+                        A_log=self.A_log,
+                        dt_bias=self.dt_bias,
+                        lower_bound=self.gate_lower_bound,
+                        initial_state=initial_state,
+                        cu_seqlens=non_spec_query_start_loc,
+                    )
+                else:
+                    (
+                        core_attn_out_non_spec,
+                        last_recurrent_state,
+                    ) = chunk_kda_with_fused_gate(
+                        q=q_ns,
+                        k=k_ns,
+                        v=v_ns,
+                        raw_g=g1_ns,
+                        raw_beta=beta_ns,
+                        A_log=self.A_log,
+                        g_bias=self.dt_bias,
+                        lower_bound=self.gate_lower_bound,
+                        initial_state=initial_state,
+                        output_final_state=True,
+                        use_qk_l2norm_in_kernel=True,
+                        cu_seqlens=non_spec_query_start_loc,
+                    )
+                recurrent_state[non_spec_state_indices_tensor] = last_recurrent_state
+            else:
+                # Pure non-speculative decode.
+                assert non_spec_state_indices_tensor is not None
+                decode_conv_indices = non_spec_state_indices_tensor[
+                    : mixed_qkv_ns.size(0)
+                ]
+                packed_conv_out = torch.empty_like(mixed_qkv_ns)
+                mixed_qkv_ns = causal_conv1d_update(
+                    mixed_qkv_ns,
+                    conv_state,
+                    conv_weights,
+                    self.conv1d.bias,
+                    activation="silu",
+                    conv_state_indices=decode_conv_indices,
+                    validate_data=True,
+                    out=packed_conv_out,
+                )
+                (
+                    core_attn_out_non_spec,
+                    _,
+                ) = fused_recurrent_kda_packed_decode(
+                    mixed_qkv=mixed_qkv_ns,
+                    raw_g=g1_ns,
+                    raw_beta=beta_ns,
+                    A_log=self.A_log,
+                    dt_bias=self.dt_bias,
+                    lower_bound=self.gate_lower_bound,
+                    initial_state=recurrent_state,
+                    state_indices=decode_conv_indices,
+                )
+
+        # Restore the scheduler's original token order for mixed batches.
+        if core_attn_out_spec is not None and core_attn_out_non_spec is not None:
+            core_attn_out.index_copy_(1, spec_token_indx, core_attn_out_spec)
+            core_attn_out.index_copy_(1, non_spec_token_indx, core_attn_out_non_spec)
+        elif core_attn_out_non_spec is not None:
+            # TODO: prefill and decode kernels write directly to core_attn_out
+            core_attn_out[0, :num_actual_tokens] = core_attn_out_non_spec[
+                0, :num_actual_tokens
+            ]
+        else:
+            assert core_attn_out_spec is not None
+        # Triton normalizes in place, so this is a self-copy with no device
+        # work. Keep it for the out-of-place native implementation.
+        core_attn_out.copy_(self.o_norm(core_attn_out, g2))

--- a/vllm/models/kimi_k3/nvidia/kda_metadata.py
+++ b/vllm/models/kimi_k3/nvidia/kda_metadata.py
@@ -1,0 +1,496 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Kimi-K3 specialization of GDN attention metadata.
+
+The request classification and cudagraph staging intentionally mirror
+``GDNAttentionMetadataBuilder``. Kimi-K3 builds the metadata required by its
+prefill KDA kernel internally, so this builder omits the shared FLA chunk
+metadata construction.
+"""
+
+from dataclasses import dataclass
+from functools import cache
+
+import torch
+
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+from vllm.utils.torch_utils import async_tensor_h2d
+from vllm.v1.attention.backend import CommonAttentionMetadata
+from vllm.v1.attention.backends.gdn_attn import (
+    GDNAttentionBackend,
+    GDNAttentionMetadata,
+    GDNAttentionMetadataBuilder,
+)
+from vllm.v1.attention.backends.utils import (
+    NULL_BLOCK_ID,
+    compute_causal_conv1d_metadata,
+    split_decodes_and_prefills,
+)
+from vllm.v1.kv_cache_interface import MambaSpec
+
+
+@cache
+def _metadata_launch_pdl() -> bool:
+    return current_platform.is_arch_support_pdl()
+
+
+@triton.jit(do_not_specialize=["num_requests"])
+def _get_aligned_state_indices_kernel(
+    block_table_ptr,
+    seq_lens_ptr,
+    state_indices_ptr,
+    block_table_stride_0: tl.constexpr,
+    block_table_stride_1: tl.constexpr,
+    seq_lens_stride: tl.constexpr,
+    state_indices_stride_0: tl.constexpr,
+    state_indices_stride_1: tl.constexpr,
+    num_requests,
+    CACHE_BLOCK_SIZE: tl.constexpr,
+    NUM_STATE_SLOTS: tl.constexpr,
+    BLOCK_STATE_SLOTS: tl.constexpr,
+    BLOCK_ROWS: tl.constexpr,
+    launch_pdl: tl.constexpr,
+):
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+        tl.extra.cuda.gdc_launch_dependents()
+
+    rows = tl.program_id(0) * BLOCK_ROWS + tl.arange(0, BLOCK_ROWS)
+    valid_row = rows < num_requests
+    seq_lens = tl.load(
+        seq_lens_ptr + rows * seq_lens_stride,
+        mask=valid_row,
+        other=1,
+    )
+    # Triton truncates signed division toward zero, unlike PyTorch floor
+    # division. Clamping makes both semantics equivalent for seq_lens <= 0.
+    first_state_slot = tl.maximum((seq_lens - 1) // CACHE_BLOCK_SIZE, 0)
+
+    state_slots = tl.arange(0, BLOCK_STATE_SLOTS)
+    valid_state_slot = state_slots < NUM_STATE_SLOTS
+    state_indices = tl.load(
+        block_table_ptr
+        + rows[:, None] * block_table_stride_0
+        + (first_state_slot[:, None] + state_slots[None, :]) * block_table_stride_1,
+        mask=valid_row[:, None] & valid_state_slot[None, :],
+    )
+    tl.store(
+        state_indices_ptr
+        + rows[:, None] * state_indices_stride_0
+        + state_slots[None, :] * state_indices_stride_1,
+        state_indices,
+        mask=valid_row[:, None] & valid_state_slot[None, :],
+    )
+
+
+def _mamba_get_block_table_tensor(
+    block_table: torch.Tensor,
+    seq_lens: torch.Tensor,
+    kv_cache_spec: MambaSpec,
+    mamba_cache_mode: str,
+) -> torch.Tensor:
+    if mamba_cache_mode in ("all", "none"):
+        return block_table
+
+    assert block_table.is_cuda and seq_lens.is_cuda
+    num_requests = block_table.shape[0]
+    num_state_slots = 1 + kv_cache_spec.num_speculative_blocks
+    state_indices = torch.empty(
+        (num_requests, num_state_slots),
+        dtype=block_table.dtype,
+        device=block_table.device,
+    )
+    BLOCK_ROWS = 32
+    grid = (triton.cdiv(num_requests, BLOCK_ROWS),)
+    _get_aligned_state_indices_kernel[grid](
+        block_table,
+        seq_lens,
+        state_indices,
+        block_table.stride(0),
+        block_table.stride(1),
+        seq_lens.stride(0),
+        state_indices.stride(0),
+        state_indices.stride(1),
+        num_requests,
+        CACHE_BLOCK_SIZE=kv_cache_spec.block_size,
+        NUM_STATE_SLOTS=num_state_slots,
+        BLOCK_STATE_SLOTS=triton.next_power_of_2(num_state_slots),
+        BLOCK_ROWS=BLOCK_ROWS,
+        num_warps=1,
+        launch_pdl=_metadata_launch_pdl(),
+    )
+    return state_indices
+
+
+@triton.jit(do_not_specialize=["num_spec_decodes", "batch_size"])
+def _stage_spec_decode_metadata_kernel(
+    state_indices_ptr,
+    query_start_loc_ptr,
+    num_accepted_tokens_ptr,
+    staged_state_indices_ptr,
+    staged_query_start_loc_ptr,
+    staged_num_accepted_tokens_ptr,
+    state_indices_stride_0: tl.constexpr,
+    state_indices_stride_1: tl.constexpr,
+    staged_state_indices_stride_0: tl.constexpr,
+    staged_state_indices_stride_1: tl.constexpr,
+    num_spec_decodes,
+    batch_size,
+    NUM_STATE_SLOTS: tl.constexpr,
+    BLOCK_STATE_SLOTS: tl.constexpr,
+    NULL_STATE_ID: tl.constexpr,
+    BLOCK_ROWS: tl.constexpr,
+    launch_pdl: tl.constexpr,
+):
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+        tl.extra.cuda.gdc_launch_dependents()
+
+    rows = tl.program_id(0) * BLOCK_ROWS + tl.arange(0, BLOCK_ROWS)
+    real_request = rows < num_spec_decodes
+
+    state_slots = tl.arange(0, BLOCK_STATE_SLOTS)
+    valid_state_slot = state_slots < NUM_STATE_SLOTS
+    state_indices = tl.load(
+        state_indices_ptr
+        + rows[:, None] * state_indices_stride_0
+        + state_slots[None, :] * state_indices_stride_1,
+        mask=real_request[:, None] & valid_state_slot[None, :],
+        other=NULL_STATE_ID,
+    )
+    tl.store(
+        staged_state_indices_ptr
+        + rows[:, None] * staged_state_indices_stride_0
+        + state_slots[None, :] * staged_state_indices_stride_1,
+        state_indices,
+        mask=(rows < batch_size)[:, None] & valid_state_slot[None, :],
+    )
+
+    query_row = tl.minimum(rows, num_spec_decodes)
+    query_start_loc = tl.load(
+        query_start_loc_ptr + query_row,
+        mask=rows <= batch_size,
+    )
+    tl.store(
+        staged_query_start_loc_ptr + rows,
+        query_start_loc,
+        mask=rows <= batch_size,
+    )
+
+    num_accepted_tokens = tl.load(
+        num_accepted_tokens_ptr + rows,
+        mask=real_request,
+        other=1,
+    )
+    tl.store(
+        staged_num_accepted_tokens_ptr + rows,
+        num_accepted_tokens,
+        mask=rows < batch_size,
+    )
+
+
+def stage_spec_decode_metadata(
+    state_indices: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    num_accepted_tokens: torch.Tensor,
+    staged_state_indices: torch.Tensor,
+    staged_query_start_loc: torch.Tensor,
+    staged_num_accepted_tokens: torch.Tensor,
+    *,
+    num_spec_decodes: int,
+) -> None:
+    """Stage speculative-decode metadata into CUDA-graph buffers."""
+    assert state_indices.is_cuda
+    assert state_indices.ndim == 2
+    batch_size, num_state_slots = staged_state_indices.shape
+    BLOCK_ROWS = 32
+    grid = (triton.cdiv(batch_size + 1, BLOCK_ROWS),)
+    _stage_spec_decode_metadata_kernel[grid](
+        state_indices,
+        query_start_loc,
+        num_accepted_tokens,
+        staged_state_indices,
+        staged_query_start_loc,
+        staged_num_accepted_tokens,
+        state_indices.stride(0),
+        state_indices.stride(1),
+        staged_state_indices.stride(0),
+        staged_state_indices.stride(1),
+        num_spec_decodes,
+        batch_size,
+        NUM_STATE_SLOTS=num_state_slots,
+        BLOCK_STATE_SLOTS=triton.next_power_of_2(num_state_slots),
+        NULL_STATE_ID=NULL_BLOCK_ID,
+        BLOCK_ROWS=BLOCK_ROWS,
+        num_warps=1,
+        launch_pdl=_metadata_launch_pdl(),
+    )
+
+
+@dataclass
+class KimiK3KDAMetadata(GDNAttentionMetadata):
+    pass
+
+
+class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
+    def build(  # type: ignore[override]
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: CommonAttentionMetadata,
+        num_accepted_tokens: torch.Tensor | None = None,
+        num_decode_draft_tokens_cpu: torch.Tensor | None = None,
+        fast_build: bool = False,
+    ) -> KimiK3KDAMetadata:
+        m = common_attn_metadata
+        query_start_loc = m.query_start_loc
+        query_start_loc_cpu = m.query_start_loc_cpu
+        assert isinstance(self.kv_cache_spec, MambaSpec)
+        # Equivalent PyTorch "align" path:
+        #   start = ((seq_lens - 1) // block_size).clamp_(min=0)
+        #   offsets = torch.arange(1 + num_speculative_blocks, dtype=torch.int32)
+        #   indices = (start[:, None] + offsets).to(torch.int64)
+        #   block_table_tensor = torch.gather(block_table, 1, indices)
+        block_table_tensor = _mamba_get_block_table_tensor(
+            m.block_table_tensor,
+            m.seq_lens,
+            self.kv_cache_spec,
+            self.vllm_config.cache_config.mamba_cache_mode,
+        )
+
+        if not self.use_spec_decode or num_decode_draft_tokens_cpu is None:
+            spec_sequence_masks_cpu = None
+            num_spec_decodes = 0
+        else:
+            spec_sequence_masks_cpu = num_decode_draft_tokens_cpu >= 0
+            # A nonnegative entry identifies a spec request. If no draft token
+            # was scheduled, process the whole batch as non-spec instead.
+            if num_decode_draft_tokens_cpu[spec_sequence_masks_cpu].sum().item() == 0:
+                spec_sequence_masks_cpu = None
+                num_spec_decodes = 0
+            else:
+                num_spec_decodes = spec_sequence_masks_cpu.sum().item()
+
+        if num_spec_decodes == 0:
+            # The runner orders ordinary decodes before prefills.
+            num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
+                split_decodes_and_prefills(m, decode_threshold=1)
+            )
+            num_spec_decode_tokens = 0
+            spec_token_indx = None
+            non_spec_token_indx = None
+            spec_state_indices_tensor = None
+            non_spec_state_indices_tensor = block_table_tensor[:, 0]
+            spec_query_start_loc = None
+            non_spec_query_start_loc = query_start_loc
+            non_spec_query_start_loc_cpu = query_start_loc_cpu
+            num_accepted_tokens = None
+        else:
+            assert spec_sequence_masks_cpu is not None
+            assert num_accepted_tokens is not None
+            query_lens_cpu = query_start_loc_cpu.diff()
+            num_query_tokens = query_start_loc_cpu[-1].item()
+
+            # Exclude zero-length cudagraph padding from request-indexed
+            # non-spec metadata.
+            active_non_spec_mask_cpu = (~spec_sequence_masks_cpu) & (query_lens_cpu > 0)
+            non_spec_query_lens_cpu = query_lens_cpu[active_non_spec_mask_cpu]
+            num_non_spec_requests = non_spec_query_lens_cpu.numel()
+            num_non_spec_tokens = non_spec_query_lens_cpu.sum().item()
+
+            # Query length alone cannot distinguish a true decode from a
+            # one-token prefill chunk. Packed decode is safe only when every
+            # active non-spec request is a true, one-token decode.
+            assert m.is_prefilling is not None
+            assert m.is_prefilling.device.type == "cpu"
+            non_spec_is_prefilling = m.is_prefilling[active_non_spec_mask_cpu]
+            use_prefill = torch.any(
+                non_spec_is_prefilling | (non_spec_query_lens_cpu != 1)
+            ).item()
+            if use_prefill:
+                num_prefills = num_non_spec_requests
+                num_prefill_tokens = num_non_spec_tokens
+                num_decodes = 0
+                num_decode_tokens = 0
+            else:
+                num_prefills = 0
+                num_prefill_tokens = 0
+                num_decodes = num_non_spec_requests
+                num_decode_tokens = num_non_spec_tokens
+
+            num_spec_decode_tokens = num_query_tokens - num_non_spec_tokens
+
+            if num_prefills == 0 and num_decodes == 0:
+                spec_token_indx = None
+                non_spec_token_indx = None
+                # Real requests precede trailing cudagraph padding.
+                spec_state_indices_tensor = block_table_tensor[
+                    :num_spec_decodes, : self.num_spec + 1
+                ]
+                non_spec_state_indices_tensor = None
+                # Padding trails real requests, so this prefix already contains
+                # the correct cumulative token counts.
+                spec_query_start_loc = query_start_loc[: num_spec_decodes + 1]
+                non_spec_query_start_loc = None
+                non_spec_query_start_loc_cpu = None
+                num_accepted_tokens = num_accepted_tokens[:num_spec_decodes]
+            else:
+                query_lens = query_start_loc.diff()
+                spec_sequence_masks_gpu = async_tensor_h2d(
+                    spec_sequence_masks_cpu, device=query_start_loc.device
+                )
+                spec_token_masks = torch.repeat_interleave(
+                    spec_sequence_masks_gpu,
+                    query_lens,
+                    output_size=num_query_tokens,
+                )
+                # Stable partitioning preserves request-local token order in
+                # both subgroup tensors.
+                index = torch.argsort(spec_token_masks, stable=True)
+                num_non_spec_tokens = num_prefill_tokens + num_decode_tokens
+                non_spec_token_indx = index[:num_non_spec_tokens]
+                spec_token_indx = index[num_non_spec_tokens:]
+
+                # Spec requests carry one state slot per speculative step;
+                # non-spec requests use only their current state slot.
+                spec_state_indices_tensor = block_table_tensor[
+                    spec_sequence_masks_cpu, : self.num_spec + 1
+                ]
+                non_spec_state_indices_tensor = block_table_tensor[
+                    active_non_spec_mask_cpu, 0
+                ]
+
+                spec_query_lens = query_lens[spec_sequence_masks_cpu]
+                spec_query_start_loc = torch.zeros(
+                    num_spec_decodes + 1,
+                    dtype=torch.int32,
+                    device=query_start_loc.device,
+                )
+                torch.cumsum(
+                    spec_query_lens,
+                    dim=0,
+                    out=spec_query_start_loc[1:],
+                )
+                if num_prefills > 0:
+                    non_spec_query_lens = query_lens[active_non_spec_mask_cpu]
+                    non_spec_query_start_loc = torch.zeros(
+                        non_spec_query_lens.size(0) + 1,
+                        dtype=torch.int32,
+                        device=query_start_loc.device,
+                    )
+                    torch.cumsum(
+                        non_spec_query_lens,
+                        dim=0,
+                        out=non_spec_query_start_loc[1:],
+                    )
+                    non_spec_query_start_loc_cpu = torch.zeros(
+                        non_spec_query_lens_cpu.size(0) + 1,
+                        dtype=torch.int32,
+                    )
+                    torch.cumsum(
+                        non_spec_query_lens_cpu,
+                        dim=0,
+                        out=non_spec_query_start_loc_cpu[1:],
+                    )
+                else:
+                    # Packed decode consumes one row per request and does not
+                    # use cumulative sequence lengths.
+                    non_spec_query_start_loc = None
+                    non_spec_query_start_loc_cpu = None
+
+                num_accepted_tokens = num_accepted_tokens[spec_sequence_masks_cpu]
+
+        # Unlike the shared GDN layer, Kimi-K3's prefill KDA wrapper prepares
+        # its own chunk indices. Only causal-convolution metadata is needed here.
+        nums_dict, batch_ptr, token_chunk_offset_ptr = None, None, None
+        if num_prefills > 0:
+            has_initial_state = m.compute_num_computed_tokens() > 0
+            if spec_sequence_masks_cpu is not None:
+                has_initial_state = has_initial_state[active_non_spec_mask_cpu]
+                assert non_spec_query_start_loc_cpu is not None
+            nums_dict, batch_ptr, token_chunk_offset_ptr = (
+                compute_causal_conv1d_metadata(
+                    non_spec_query_start_loc_cpu,
+                    device=query_start_loc.device,
+                )
+            )
+        else:
+            has_initial_state = None
+
+        # Prepare per-request tensors for cudagraph replay. num_actual_tokens
+        # may be token-padded, while state/query/acceptance metadata is indexed
+        # by request.
+        batch_size = m.num_reqs
+        if (
+            self.use_full_cuda_graph
+            and num_spec_decodes > 0
+            and num_prefills == 0
+            and num_decodes == 0
+            and num_spec_decodes <= self.decode_cudagraph_max_bs
+            and num_spec_decode_tokens <= self.decode_cudagraph_max_bs
+        ):
+            # Equivalent PyTorch staging:
+            #   state[:N].copy_(state_src); state[N:].fill_(NULL_BLOCK_ID)
+            #   qsl[:N + 1].copy_(qsl_src); qsl[N + 1:].fill_(qsl_src[-1])
+            #   accepted[:N].copy_(accepted_src); accepted[N:].fill_(1)
+            stage_spec_decode_metadata(
+                state_indices=spec_state_indices_tensor,
+                query_start_loc=spec_query_start_loc,
+                num_accepted_tokens=num_accepted_tokens,
+                staged_state_indices=self.spec_state_indices_tensor[:batch_size],
+                staged_query_start_loc=self.spec_query_start_loc[: batch_size + 1],
+                staged_num_accepted_tokens=self.num_accepted_tokens[:batch_size],
+                num_spec_decodes=num_spec_decodes,
+            )
+
+            spec_state_indices_tensor = self.spec_state_indices_tensor[:batch_size]
+            spec_query_start_loc = self.spec_query_start_loc[: batch_size + 1]
+            num_accepted_tokens = self.num_accepted_tokens[:batch_size]
+
+        if (
+            self.use_full_cuda_graph
+            and num_prefills == 0
+            and num_spec_decodes == 0
+            and num_decodes <= self.decode_cudagraph_max_bs
+        ):
+            self.non_spec_state_indices_tensor[:num_decodes].copy_(
+                non_spec_state_indices_tensor, non_blocking=True
+            )
+            self.non_spec_state_indices_tensor[num_decodes:batch_size].fill_(
+                NULL_BLOCK_ID
+            )
+            non_spec_state_indices_tensor = self.non_spec_state_indices_tensor[
+                :batch_size
+            ]
+
+        return KimiK3KDAMetadata(
+            num_prefills=num_prefills,
+            num_prefill_tokens=num_prefill_tokens,
+            num_decodes=num_decodes,
+            num_decode_tokens=num_decode_tokens,
+            num_spec_decodes=num_spec_decodes,
+            num_spec_decode_tokens=num_spec_decode_tokens,
+            num_actual_tokens=m.num_actual_tokens,
+            has_initial_state=has_initial_state,
+            spec_query_start_loc=spec_query_start_loc,
+            non_spec_query_start_loc=non_spec_query_start_loc,
+            spec_state_indices_tensor=spec_state_indices_tensor,
+            non_spec_state_indices_tensor=non_spec_state_indices_tensor,
+            spec_sequence_masks=None,
+            spec_token_indx=spec_token_indx,
+            non_spec_token_indx=non_spec_token_indx,
+            num_accepted_tokens=num_accepted_tokens,
+            nums_dict=nums_dict,
+            batch_ptr=batch_ptr,
+            token_chunk_offset_ptr=token_chunk_offset_ptr,
+        )
+
+
+class KimiK3KDAAttentionBackend(GDNAttentionBackend):
+    @staticmethod
+    def get_name() -> str:
+        return "KIMI_K3_KDA"
+
+    @staticmethod
+    def get_builder_cls() -> type[KimiK3KDAMetadataBuilder]:
+        return KimiK3KDAMetadataBuilder

--- a/vllm/models/kimi_k3/nvidia/ops/third_party/__init__.py
+++ b/vllm/models/kimi_k3/nvidia/ops/third_party/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/models/kimi_k3/nvidia/ops/third_party/kda/__init__.py
+++ b/vllm/models/kimi_k3/nvidia/ops/third_party/kda/__init__.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from .chunk import (
+    chunk_kda,
+    chunk_kda_fwd,
+    chunk_kda_with_fused_gate,
+    chunk_kda_with_fused_gate_fwd,
+    fused_kda_gate,
+    fused_kda_gate_chunk_cumsum,
+)
+from .fused_recurrent import (
+    fused_recurrent_kda,
+    fused_recurrent_kda_fwd,
+    fused_recurrent_kda_packed_decode,
+)
+
+__all__ = [
+    "chunk_kda",
+    "chunk_kda_fwd",
+    "chunk_kda_with_fused_gate",
+    "chunk_kda_with_fused_gate_fwd",
+    "fused_kda_gate",
+    "fused_kda_gate_chunk_cumsum",
+    "fused_recurrent_kda",
+    "fused_recurrent_kda_fwd",
+    "fused_recurrent_kda_packed_decode",
+]

--- a/vllm/models/kimi_k3/nvidia/ops/third_party/kda/chunk.py
+++ b/vllm/models/kimi_k3/nvidia/ops/third_party/kda/chunk.py
@@ -1,0 +1,937 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This file contains code copied from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+# ruff: noqa: E501
+# mypy: ignore-errors
+
+
+import torch
+
+from vllm.third_party.flash_linear_attention.ops.chunk_delta_h import (
+    chunk_gated_delta_rule_fwd_h,
+)
+from vllm.third_party.flash_linear_attention.ops.cumsum import chunk_local_cumsum
+from vllm.third_party.flash_linear_attention.ops.index import prepare_chunk_indices
+from vllm.third_party.flash_linear_attention.ops.l2norm import l2norm_fwd
+from vllm.third_party.flash_linear_attention.ops.op import exp2, log
+from vllm.third_party.flash_linear_attention.ops.utils import FLA_CHUNK_SIZE, is_amd
+from vllm.triton_utils import tl, triton
+from vllm.utils.math_utils import RCP_LN2, cdiv, next_power_of_2
+
+from .chunk_intra import chunk_kda_fwd_intra
+
+BT_LIST_AUTOTUNE = [32, 64, 128]
+NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if is_amd else [4, 8, 16, 32]
+
+
+@triton.heuristics(
+    {
+        "STORE_QG": lambda args: args["qg"] is not None,
+        "STORE_KG": lambda args: args["kg"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in [2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=["H", "K", "V", "BT", "BK", "BV", "IS_VARLEN"],
+)
+@triton.jit(do_not_specialize=["T"])
+def recompute_w_u_fwd_kernel(
+    q,
+    k,
+    qg,
+    kg,
+    v,
+    beta,
+    w,
+    u,
+    A,
+    gk,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    STORE_QG: tl.constexpr,
+    STORE_KG: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    DOT_PRECISION: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+    p_b = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+    b_b = tl.load(p_b, boundary_check=(0,)).to(tl.float32)
+
+    p_A = tl.make_block_ptr(
+        A + (bos * H + i_h) * BT, (T, BT), (H * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0)
+    )
+    b_A = tl.load(p_A, boundary_check=(0, 1))
+
+    for i_v in range(tl.cdiv(V, BV)):
+        p_v = tl.make_block_ptr(
+            v + (bos * H + i_h) * V,
+            (T, V),
+            (H * V, 1),
+            (i_t * BT, i_v * BV),
+            (BT, BV),
+            (1, 0),
+        )
+        p_u = tl.make_block_ptr(
+            u + (bos * H + i_h) * V,
+            (T, V),
+            (H * V, 1),
+            (i_t * BT, i_v * BV),
+            (BT, BV),
+            (1, 0),
+        )
+        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_vb = (b_v * b_b[:, None]).to(b_v.dtype)
+        b_u = tl.dot(b_A, b_vb, input_precision=DOT_PRECISION)
+        tl.store(p_u, b_u.to(p_u.dtype.element_ty), boundary_check=(0, 1))
+
+    for i_k in range(tl.cdiv(K, BK)):
+        p_w = tl.make_block_ptr(
+            w + (bos * H + i_h) * K,
+            (T, K),
+            (H * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        p_k = tl.make_block_ptr(
+            k + (bos * H + i_h) * K,
+            (T, K),
+            (H * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_kb = b_k * b_b[:, None]
+
+        p_gk = tl.make_block_ptr(
+            gk + (bos * H + i_h) * K,
+            (T, K),
+            (H * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        b_gk = tl.load(p_gk, boundary_check=(0, 1))
+        b_kb *= exp2(b_gk)
+        if STORE_QG:
+            p_q = tl.make_block_ptr(
+                q + (bos * H + i_h) * K,
+                (T, K),
+                (H * K, 1),
+                (i_t * BT, i_k * BK),
+                (BT, BK),
+                (1, 0),
+            )
+            p_qg = tl.make_block_ptr(
+                qg + (bos * H + i_h) * K,
+                (T, K),
+                (H * K, 1),
+                (i_t * BT, i_k * BK),
+                (BT, BK),
+                (1, 0),
+            )
+            b_q = tl.load(p_q, boundary_check=(0, 1))
+            b_qg = b_q * exp2(b_gk)
+            tl.store(p_qg, b_qg.to(p_qg.dtype.element_ty), boundary_check=(0, 1))
+        if STORE_KG:
+            last_idx = min(i_t * BT + BT, T) - 1
+
+            o_k = i_k * BK + tl.arange(0, BK)
+            m_k = o_k < K
+            b_gn = tl.load(
+                gk + ((bos + last_idx) * H + i_h) * K + o_k, mask=m_k, other=0.0
+            )
+            b_kg = b_k * exp2(b_gn - b_gk)
+
+            p_kg = tl.make_block_ptr(
+                kg + (bos * H + i_h) * K,
+                (T, K),
+                (H * K, 1),
+                (i_t * BT, i_k * BK),
+                (BT, BK),
+                (1, 0),
+            )
+            tl.store(p_kg, b_kg.to(p_kg.dtype.element_ty), boundary_check=(0, 1))
+
+        b_w = tl.dot(b_A, b_kb.to(b_k.dtype))
+        tl.store(p_w, b_w.to(p_w.dtype.element_ty), boundary_check=(0, 1))
+
+
+def recompute_w_u_fwd(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    A: torch.Tensor,
+    q: torch.Tensor | None = None,
+    gk: torch.Tensor | None = None,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_indices: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    B, T, H, K, V = *k.shape, v.shape[-1]
+    BT = A.shape[-1]
+    BK = 64
+    BV = 64
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    w = torch.empty_like(k)
+    u = torch.empty_like(v)
+    kg = torch.empty_like(k) if gk is not None else None
+    recompute_w_u_fwd_kernel[(NT, B * H)](
+        q=q,
+        k=k,
+        qg=None,
+        kg=kg,
+        v=v,
+        beta=beta,
+        w=w,
+        u=u,
+        A=A,
+        gk=gk,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        K=K,
+        V=V,
+        BT=BT,
+        BK=BK,
+        BV=BV,
+        DOT_PRECISION="ieee",
+    )
+    return w, u, None, kg
+
+
+@triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
+@triton.autotune(
+    configs=[
+        triton.Config({"BK": BK, "BV": BV}, num_warps=num_warps, num_stages=num_stages)
+        for BK in [32, 64]
+        for BV in [64, 128]
+        for num_warps in [2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=["BT"],
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_gla_fwd_kernel_o(
+    q,
+    v,
+    g,
+    h,
+    o,
+    A,
+    cu_seqlens,
+    chunk_indices,
+    scale,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_tg = i_t
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+    else:
+        NT = tl.cdiv(T, BT)
+        i_tg = i_b * NT + i_t
+        bos, eos = i_b * T, i_b * T + T
+
+    m_s = tl.arange(0, BT)[:, None] >= tl.arange(0, BT)[None, :]
+
+    b_o = tl.zeros([BT, BV], dtype=tl.float32)
+    for i_k in range(tl.cdiv(K, BK)):
+        p_q = tl.make_block_ptr(
+            q + (bos * H + i_h) * K,
+            (T, K),
+            (H * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        p_g = tl.make_block_ptr(
+            g + (bos * H + i_h) * K,
+            (T, K),
+            (H * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        p_h = tl.make_block_ptr(
+            h + (i_tg * H + i_h) * K * V,
+            (V, K),
+            (K, 1),
+            (i_v * BV, i_k * BK),
+            (BV, BK),
+            (1, 0),
+        )
+
+        # [BT, BK]
+        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_q = (b_q * scale).to(b_q.dtype)
+        # [BT, BK]
+        b_g = tl.load(p_g, boundary_check=(0, 1))
+        # [BT, BK]
+        b_qg = (b_q * exp2(b_g)).to(b_q.dtype)
+        # [BV, BK]
+        b_h = tl.load(p_h, boundary_check=(0, 1))
+        # [BT, BV]
+        if i_k >= 0:
+            b_o += tl.dot(b_qg, tl.trans(b_h).to(b_qg.dtype))
+    p_v = tl.make_block_ptr(
+        v + (bos * H + i_h) * V,
+        (T, V),
+        (H * V, 1),
+        (i_t * BT, i_v * BV),
+        (BT, BV),
+        (1, 0),
+    )
+    p_o = tl.make_block_ptr(
+        o + (bos * H + i_h) * V,
+        (T, V),
+        (H * V, 1),
+        (i_t * BT, i_v * BV),
+        (BT, BV),
+        (1, 0),
+    )
+    p_A = tl.make_block_ptr(
+        A + (bos * H + i_h) * BT, (T, BT), (H * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0)
+    )
+    # [BT, BV]
+    b_v = tl.load(p_v, boundary_check=(0, 1))
+    # [BT, BT]
+    b_A = tl.load(p_A, boundary_check=(0, 1))
+    b_A = tl.where(m_s, b_A, 0.0).to(b_v.dtype)
+    b_o += tl.dot(b_A, b_v, allow_tf32=False)
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+
+
+def chunk_gla_fwd_o_gk(
+    q: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    A: torch.Tensor,
+    h: torch.Tensor,
+    o: torch.Tensor,
+    scale: float,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_indices: torch.Tensor | None = None,
+    chunk_size: int = FLA_CHUNK_SIZE,
+):
+    B, T, H, K, V = *q.shape, v.shape[-1]
+    BT = chunk_size
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+    NT = cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    def grid(meta):
+        return (cdiv(V, meta["BV"]), NT, B * H)
+
+    chunk_gla_fwd_kernel_o[grid](
+        q=q,
+        v=v,
+        g=g,
+        h=h,
+        o=o,
+        A=A,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        scale=scale,
+        T=T,
+        H=H,
+        K=K,
+        V=V,
+        BT=BT,
+    )
+    return o
+
+
+@triton.heuristics(
+    {
+        "HAS_BIAS": lambda args: args["g_bias"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({"BS": BS}, num_warps=num_warps)
+        for BS in [32, 64]
+        for num_warps in [2, 4, 8]
+    ],
+    key=["H", "S", "BT", "IS_VARLEN"],
+)
+@triton.jit(do_not_specialize=["T"])
+def kda_gate_chunk_cumsum_vector_kernel(
+    s,
+    raw_beta,
+    A_log,
+    g_bias,
+    o,
+    beta_out,
+    cu_seqlens,
+    chunk_indices,
+    cumsum_scale,
+    lower_bound,
+    beta,
+    threshold,
+    T,
+    stride_beta_batch,
+    stride_beta_token,
+    stride_beta_head,
+    H: tl.constexpr,
+    S: tl.constexpr,
+    BT: tl.constexpr,
+    BS: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    USE_LOWER_BOUND: tl.constexpr,
+):
+    i_s, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+    else:
+        bos = i_b * T
+
+    if i_s == 0:
+        o_beta_t = tl.arange(0, BT)
+        m_beta = i_t * BT + o_beta_t < T
+        if IS_VARLEN:
+            p_beta = (
+                raw_beta
+                + (bos + i_t * BT + o_beta_t) * stride_beta_token
+                + i_h * stride_beta_head
+            )
+        else:
+            p_beta = (
+                raw_beta
+                + i_b * stride_beta_batch
+                + (i_t * BT + o_beta_t) * stride_beta_token
+                + i_h * stride_beta_head
+            )
+        b_beta = tl.load(p_beta, mask=m_beta, other=0.0).to(tl.float32)
+        p_beta_out = beta_out + (bos + i_t * BT + o_beta_t) * H + i_h
+        tl.store(p_beta_out, tl.sigmoid(b_beta), mask=m_beta)
+        return
+
+    i_s -= 1
+
+    p_s = tl.make_block_ptr(
+        s + (bos * H + i_h) * S,
+        (T, S),
+        (H * S, 1),
+        (i_t * BT, i_s * BS),
+        (BT, BS),
+        (1, 0),
+    )
+    p_o = tl.make_block_ptr(
+        o + (bos * H + i_h) * S,
+        (T, S),
+        (H * S, 1),
+        (i_t * BT, i_s * BS),
+        (BT, BS),
+        (1, 0),
+    )
+
+    b_s = tl.load(p_s, boundary_check=(0, 1)).to(tl.float32)
+    if HAS_BIAS:
+        p_bias = tl.make_block_ptr(
+            g_bias + i_h * S,
+            (S,),
+            (1,),
+            (i_s * BS,),
+            (BS,),
+            (0,),
+        )
+        b_bias = tl.load(p_bias, boundary_check=(0,)).to(tl.float32)
+        b_s += b_bias[None, :]
+
+    b_a = tl.exp(tl.load(A_log + i_h).to(tl.float32))
+    if USE_LOWER_BOUND:
+        b_gate = lower_bound * tl.sigmoid(b_a * b_s)
+    else:
+        b_g_scaled = b_s * beta
+        b_softplus = tl.where(
+            b_g_scaled > threshold,
+            b_s,
+            (1.0 / beta) * log(1.0 + tl.exp(b_g_scaled)),
+        )
+        b_gate = -b_a * b_softplus
+
+    # Boundary loads return zero, but bias and gate activation can make padded
+    # rows nonzero. Padding trails valid rows, so it only affects masked stores.
+    b_o = tl.cumsum(b_gate, axis=0) * cumsum_scale
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+
+
+def fused_kda_gate_chunk_cumsum(
+    raw_g: torch.Tensor,
+    raw_beta: torch.Tensor,
+    A_log: torch.Tensor,
+    g_bias: torch.Tensor | None = None,
+    beta: float = 1.0,
+    threshold: float = 20.0,
+    lower_bound: float | None = None,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_indices: torch.Tensor | None = None,
+    chunk_size: int = FLA_CHUNK_SIZE,
+    output_dtype: torch.dtype | None = torch.float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if cu_seqlens is not None:
+        assert raw_g.shape[0] == 1, (
+            "Only batch size 1 is supported when cu_seqlens are provided"
+        )
+    B, T, H, D = raw_g.shape
+    if raw_beta.shape != (B, T, H):
+        raise ValueError(f"Expected raw_beta shape {(B, T, H)}, got {raw_beta.shape}")
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+    NT = cdiv(T, chunk_size) if cu_seqlens is None else len(chunk_indices)
+
+    A_log = A_log.reshape(-1)
+    if g_bias is not None:
+        g_bias = g_bias.reshape(-1)
+    y = torch.empty_like(raw_g, dtype=output_dtype or raw_g.dtype)
+    beta_out = torch.empty(raw_beta.shape, device=raw_beta.device, dtype=torch.float32)
+
+    def grid(meta):
+        # For each (chunk, head), program 0 computes beta without extending a
+        # gate tile's critical path. The remaining programs cover the gate dim.
+        return (cdiv(meta["S"], meta["BS"]) + 1, NT, B * H)
+
+    kda_gate_chunk_cumsum_vector_kernel[grid](
+        s=raw_g,
+        raw_beta=raw_beta,
+        A_log=A_log,
+        g_bias=g_bias,
+        o=y,
+        beta_out=beta_out,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        # RCP_LN2 folds in the natural-log -> log2 conversion so downstream
+        # exp2-based kernels reproduce exp(g). Keep this in sync with the
+        # `use_exp2=True` path in `_chunk_kda_fwd_with_cumulative_g`.
+        cumsum_scale=RCP_LN2,
+        lower_bound=lower_bound or 0.0,
+        beta=beta,
+        threshold=threshold,
+        T=T,
+        stride_beta_batch=raw_beta.stride(0),
+        stride_beta_token=raw_beta.stride(1),
+        stride_beta_head=raw_beta.stride(2),
+        H=H,
+        S=D,
+        BT=chunk_size,
+        USE_LOWER_BOUND=lower_bound is not None,
+    )
+    return y, beta_out
+
+
+def _chunk_kda_fwd_with_cumulative_g(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    initial_state: torch.Tensor,
+    output_final_state: bool,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_indices: torch.Tensor | None = None,
+    chunk_size: int = FLA_CHUNK_SIZE,
+    safe_gate: bool = False,
+):
+    # `g` must already be chunk-local cumulatively-summed AND scaled by
+    # RCP_LN2 (so the downstream exp2-based kernels reproduce exp(g)).
+    # Use `chunk_kda_fwd` or `chunk_kda_with_fused_gate_fwd` instead of
+    # calling this helper directly unless that invariant is upheld.
+    Aqk, A = chunk_kda_fwd_intra(
+        q=q,
+        k=k,
+        gk=g,
+        beta=beta,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        chunk_size=chunk_size,
+        safe_gate=safe_gate,
+    )
+    w, u, _, kg = recompute_w_u_fwd(
+        k=k,
+        v=v,
+        beta=beta,
+        A=A,
+        gk=g,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+    del A
+    h, v_new, final_state = chunk_gated_delta_rule_fwd_h(
+        k=kg,
+        w=w,
+        u=u,
+        gk=g,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        use_exp2=True,
+    )
+    del w, u, kg
+    o = chunk_gla_fwd_o_gk(
+        q=q,
+        v=v_new,
+        g=g,
+        A=Aqk,
+        h=h,
+        o=v,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        chunk_size=chunk_size,
+    )
+    del Aqk, v_new, h
+    return o, final_state
+
+
+def chunk_kda_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    initial_state: torch.Tensor,
+    output_final_state: bool,
+    cu_seqlens: torch.Tensor | None = None,
+):
+    chunk_size = FLA_CHUNK_SIZE
+    chunk_indices = (
+        prepare_chunk_indices(cu_seqlens, chunk_size)
+        if cu_seqlens is not None
+        else None
+    )
+    g = chunk_local_cumsum(
+        g,
+        chunk_size=chunk_size,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+    # KDA evaluates cumulative gate decays with exp2. Convert from natural-log
+    # space so exp(x) is preserved as exp2(x / ln(2)).
+    g = g * RCP_LN2
+    return _chunk_kda_fwd_with_cumulative_g(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        chunk_size=chunk_size,
+    )
+
+
+def chunk_kda_with_fused_gate_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    raw_g: torch.Tensor,
+    raw_beta: torch.Tensor,
+    A_log: torch.Tensor,
+    g_bias: torch.Tensor | None,
+    scale: float,
+    initial_state: torch.Tensor,
+    output_final_state: bool,
+    lower_bound: float | None = None,
+    cu_seqlens: torch.Tensor | None = None,
+):
+    chunk_size = FLA_CHUNK_SIZE
+    chunk_indices = (
+        prepare_chunk_indices(cu_seqlens, chunk_size)
+        if cu_seqlens is not None
+        else None
+    )
+    g, beta = fused_kda_gate_chunk_cumsum(
+        raw_g,
+        raw_beta=raw_beta,
+        A_log=A_log,
+        g_bias=g_bias,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        chunk_size=chunk_size,
+        lower_bound=lower_bound,
+    )
+    return _chunk_kda_fwd_with_cumulative_g(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        chunk_size=chunk_size,
+        safe_gate=lower_bound is not None,
+    )
+
+
+def chunk_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float = None,
+    initial_state: torch.Tensor = None,
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    **kwargs,
+):
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+
+    if use_qk_l2norm_in_kernel:
+        q = l2norm_fwd(q.contiguous())
+        k = l2norm_fwd(k.contiguous())
+
+    o, final_state = chunk_kda_fwd(
+        q=q,
+        k=k,
+        v=v.contiguous(),
+        g=g.contiguous(),
+        beta=beta.contiguous(),
+        scale=scale,
+        initial_state=initial_state.contiguous(),
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+    )
+    return o, final_state
+
+
+def chunk_kda_with_fused_gate(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    raw_g: torch.Tensor,
+    raw_beta: torch.Tensor,
+    A_log: torch.Tensor,
+    g_bias: torch.Tensor | None,
+    scale: float | None = None,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    lower_bound: float | None = None,
+    use_qk_l2norm_in_kernel: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    **kwargs,
+):
+    """Run chunk KDA from raw gate and beta projections."""
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+
+    if use_qk_l2norm_in_kernel:
+        q = l2norm_fwd(q.contiguous())
+        k = l2norm_fwd(k.contiguous())
+
+    o, final_state = chunk_kda_with_fused_gate_fwd(
+        q=q,
+        k=k,
+        v=v.contiguous(),
+        raw_g=raw_g.contiguous(),
+        raw_beta=raw_beta,
+        A_log=A_log,
+        g_bias=g_bias,
+        scale=scale,
+        initial_state=initial_state.contiguous() if initial_state is not None else None,
+        output_final_state=output_final_state,
+        lower_bound=lower_bound,
+        cu_seqlens=cu_seqlens,
+    )
+    return o, final_state
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BT": bt}, num_warps=nw, num_stages=ns)
+        for bt in BT_LIST_AUTOTUNE
+        for nw in NUM_WARPS_AUTOTUNE
+        for ns in [2, 3]
+    ],
+    key=["H", "D"],
+)
+@triton.jit
+def kda_gate_fwd_kernel(
+    g,
+    A,
+    y,
+    g_bias,
+    lower_bound,
+    beta: tl.constexpr,
+    threshold: tl.constexpr,
+    T,
+    H,
+    D: tl.constexpr,
+    BT: tl.constexpr,
+    BD: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+    USE_LOWER_BOUND: tl.constexpr,
+):
+    i_t, i_h = tl.program_id(0), tl.program_id(1)
+    n_t = i_t * BT
+
+    b_a = tl.exp(tl.load(A + i_h).to(tl.float32))
+
+    stride_row = H * D
+    stride_col = 1
+
+    g_ptr = tl.make_block_ptr(
+        base=g + i_h * D,
+        shape=(T, D),
+        strides=(stride_row, stride_col),
+        offsets=(n_t, 0),
+        block_shape=(BT, BD),
+        order=(1, 0),
+    )
+
+    y_ptr = tl.make_block_ptr(
+        base=y + i_h * D,
+        shape=(T, D),
+        strides=(stride_row, stride_col),
+        offsets=(n_t, 0),
+        block_shape=(BT, BD),
+        order=(1, 0),
+    )
+
+    b_g = tl.load(g_ptr, boundary_check=(0, 1)).to(tl.float32)
+
+    if HAS_BIAS:
+        n_d = tl.arange(0, BD)
+        bias_mask = n_d < D
+        b_bias = tl.load(g_bias + i_h * D + n_d, mask=bias_mask, other=0.0).to(
+            tl.float32
+        )
+        b_g = b_g + b_bias[None, :]
+
+    if USE_LOWER_BOUND:
+        b_y = lower_bound * tl.sigmoid(b_a * b_g)
+    else:
+        g_scaled = b_g * beta
+        use_linear = g_scaled > threshold
+        sp = tl.where(use_linear, b_g, (1.0 / beta) * log(1.0 + tl.exp(g_scaled)))
+        b_y = -b_a * sp
+
+    tl.store(y_ptr, b_y.to(y.dtype.element_ty), boundary_check=(0, 1))
+
+
+def fused_kda_gate(
+    g: torch.Tensor,
+    A: torch.Tensor,
+    head_k_dim: int,
+    g_bias: torch.Tensor | None = None,
+    beta: float = 1.0,
+    threshold: float = 20.0,
+    lower_bound: float | None = None,
+) -> torch.Tensor:
+    """
+    Forward pass for KDA gate:
+      input g: [..., H*D]
+      param A: [H] or [1, 1, H, 1]
+      beta: softplus beta parameter
+      threshold: softplus threshold parameter
+      return  : [..., H, D]
+    """
+    orig_shape = g.shape[:-1]
+
+    g = g.view(-1, g.shape[-1])
+    T = g.shape[0]
+    HD = g.shape[1]
+    H = A.numel()
+    assert H * head_k_dim == HD
+    assert g.stride() == (HD, 1)
+
+    y = torch.empty_like(g, dtype=torch.float32)
+
+    def grid(meta):
+        return (cdiv(T, meta["BT"]), H)
+
+    kda_gate_fwd_kernel[grid](
+        g,
+        A,
+        y,
+        g_bias,
+        lower_bound or 0.0,
+        beta,
+        threshold,
+        T,
+        H,
+        head_k_dim,
+        BD=next_power_of_2(head_k_dim),
+        HAS_BIAS=g_bias is not None,
+        USE_LOWER_BOUND=lower_bound is not None,
+    )
+
+    y = y.view(*orig_shape, H, head_k_dim)
+    return y

--- a/vllm/models/kimi_k3/nvidia/ops/third_party/kda/chunk_intra.py
+++ b/vllm/models/kimi_k3/nvidia/ops/third_party/kda/chunk_intra.py
@@ -1,0 +1,663 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This file contains code copied from the flash-linear-attention project.
+# The original source was licensed under the MIT license.
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+# Forward-only adaptation of flash-linear-attention 0.5.0.
+# ruff: noqa: E501
+# mypy: ignore-errors
+
+import torch
+
+from vllm.platforms import current_platform
+from vllm.third_party.flash_linear_attention.ops.index import prepare_chunk_indices
+from vllm.third_party.flash_linear_attention.ops.op import exp2, gather
+from vllm.third_party.flash_linear_attention.ops.utils import is_gather_supported
+from vllm.triton_utils import tl, triton
+
+from .chunk_intra_token_parallel import chunk_kda_fwd_intra_token_parallel
+
+################################################################################
+# Fused inter + solve_tril kernel: compute off-diagonal Akk and solve in one pass
+################################################################################
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({"BK": BK}, num_warps=num_warps)
+        for BK in [32, 64]
+        for num_warps in [1, 2, 4]
+    ],
+    key=["H", "HV", "K", "BC"],
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_kda_fwd_kernel_inter_solve_fused(
+    q,
+    k,
+    g,
+    beta,
+    Aqk,
+    Akkd,
+    Akk,
+    scale,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    USE_SAFE_GATE: tl.constexpr,
+    SOLVE_TRIL_DOT_PRECISION: tl.constexpr,
+):
+    """
+    Fused kernel: compute inter-subchunk Akk + solve_tril in one pass.
+    Prerequisite: token_parallel has already computed diagonal Akk blocks in Akkd.
+
+    This kernel:
+    1. Computes off-diagonal Aqk blocks -> writes to global
+    2. Computes off-diagonal Akk blocks -> keeps in registers
+    3. Loads diagonal Akk blocks from Akkd (fp32)
+    4. Does forward substitution on diagonals
+    5. Computes merged Akk_inv
+    6. Writes Akk_inv to Akk
+    """
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_hv = i_bh // HV, i_bh % HV
+    i_h = i_hv // (HV // H)
+
+    if IS_VARLEN:
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    if i_t * BT >= T:
+        return
+
+    i_tc0 = i_t * BT
+    i_tc1 = i_t * BT + BC
+    i_tc2 = i_t * BT + 2 * BC
+    i_tc3 = i_t * BT + 3 * BC
+
+    q += (bos * H + i_h) * K
+    k += (bos * H + i_h) * K
+    g += (bos * HV + i_hv) * K
+    Aqk += (bos * HV + i_hv) * BT
+    Akk += (bos * HV + i_hv) * BT
+    Akkd += (bos * HV + i_hv) * BC
+
+    o_i = tl.arange(0, BC)
+    m_tc1 = (i_tc1 + o_i) < T
+    m_tc2 = (i_tc2 + o_i) < T
+    m_tc3 = (i_tc3 + o_i) < T
+
+    b_Aqk10 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk10 = tl.zeros([BC, BC], dtype=tl.float32)
+
+    b_Aqk20 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk20 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Aqk21 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk21 = tl.zeros([BC, BC], dtype=tl.float32)
+
+    b_Aqk30 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk30 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Aqk31 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk31 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Aqk32 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk32 = tl.zeros([BC, BC], dtype=tl.float32)
+
+    ################################################################################
+    # off-diagonal blocks
+    ################################################################################
+    for i_k in range(tl.cdiv(K, BK)):
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = o_k < K
+
+        p_k0 = tl.make_block_ptr(
+            k, (T, K), (H * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0)
+        )
+        p_g0 = tl.make_block_ptr(
+            g, (T, K), (HV * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0)
+        )
+        b_k0 = tl.load(p_k0, boundary_check=(0, 1)).to(tl.float32)
+        b_g0 = tl.load(p_g0, boundary_check=(0, 1)).to(tl.float32)
+
+        if i_tc1 < T:
+            p_q1 = tl.make_block_ptr(
+                q, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0)
+            )
+            p_k1 = tl.make_block_ptr(
+                k, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0)
+            )
+            p_g1 = tl.make_block_ptr(
+                g, (T, K), (HV * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0)
+            )
+            # [BC, BK]
+            b_q1 = tl.load(p_q1, boundary_check=(0, 1)).to(tl.float32)
+            b_k1 = tl.load(p_k1, boundary_check=(0, 1)).to(tl.float32)
+            b_g1 = tl.load(p_g1, boundary_check=(0, 1)).to(tl.float32)
+            # [BK]
+            b_gn1 = tl.load(g + i_tc1 * HV * K + o_k, mask=m_k, other=0).to(tl.float32)
+            # [BC, BK]
+            b_gqn = tl.where(m_tc1[:, None], exp2(b_g1 - b_gn1[None, :]), 0)
+            # [BK, BC]
+            b_kgt = tl.trans(b_k0 * exp2(b_gn1[None, :] - b_g0))
+            # [BC, BC]
+            b_Aqk10 += tl.dot(b_q1 * b_gqn, b_kgt)
+            b_Akk10 += tl.dot(b_k1 * b_gqn, b_kgt)
+
+            if i_tc2 < T:
+                p_q2 = tl.make_block_ptr(
+                    q, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0)
+                )
+                p_k2 = tl.make_block_ptr(
+                    k, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0)
+                )
+                p_g2 = tl.make_block_ptr(
+                    g, (T, K), (HV * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0)
+                )
+                # [BC, BK]
+                b_q2 = tl.load(p_q2, boundary_check=(0, 1)).to(tl.float32)
+                b_k2 = tl.load(p_k2, boundary_check=(0, 1)).to(tl.float32)
+                b_g2 = tl.load(p_g2, boundary_check=(0, 1)).to(tl.float32)
+                # [BK]
+                b_gn2 = tl.load(g + i_tc2 * HV * K + o_k, mask=m_k, other=0).to(
+                    tl.float32
+                )
+                # [BC, BK]
+                b_gqn2 = tl.where(m_tc2[:, None], exp2(b_g2 - b_gn2[None, :]), 0)
+                b_qg2 = b_q2 * b_gqn2
+                b_kg2 = b_k2 * b_gqn2
+                # [BK, BC]
+                b_kgt = tl.trans(b_k0 * exp2(b_gn2[None, :] - b_g0))
+                b_Aqk20 += tl.dot(b_qg2, b_kgt)
+                b_Akk20 += tl.dot(b_kg2, b_kgt)
+                # [BC, BC]
+                b_kgt = tl.trans(b_k1 * exp2(b_gn2[None, :] - b_g1))
+                # [BC, BC]
+                b_Aqk21 += tl.dot(b_qg2, b_kgt)
+                b_Akk21 += tl.dot(b_kg2, b_kgt)
+
+                if i_tc3 < T:
+                    p_q3 = tl.make_block_ptr(
+                        q, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0)
+                    )
+                    p_k3 = tl.make_block_ptr(
+                        k, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0)
+                    )
+                    p_g3 = tl.make_block_ptr(
+                        g, (T, K), (HV * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0)
+                    )
+                    # [BC, BK]
+                    b_q3 = tl.load(p_q3, boundary_check=(0, 1)).to(tl.float32)
+                    b_k3 = tl.load(p_k3, boundary_check=(0, 1)).to(tl.float32)
+                    b_g3 = tl.load(p_g3, boundary_check=(0, 1)).to(tl.float32)
+                    # [BK]
+                    b_gn3 = tl.load(g + i_tc3 * HV * K + o_k, mask=m_k, other=0).to(
+                        tl.float32
+                    )
+                    # [BC, BK]
+                    b_gqn3 = tl.where(m_tc3[:, None], exp2(b_g3 - b_gn3[None, :]), 0)
+                    b_qg3 = b_q3 * b_gqn3
+                    b_kg3 = b_k3 * b_gqn3
+                    # [BK, BC]
+                    b_kgt = tl.trans(b_k0 * exp2(b_gn3[None, :] - b_g0))
+                    # [BC, BC]
+                    b_Aqk30 += tl.dot(b_qg3, b_kgt)
+                    b_Akk30 += tl.dot(b_kg3, b_kgt)
+                    # [BK, BC]
+                    b_kgt = tl.trans(b_k1 * exp2(b_gn3[None, :] - b_g1))
+                    # [BC, BC]
+                    b_Aqk31 += tl.dot(b_qg3, b_kgt)
+                    b_Akk31 += tl.dot(b_kg3, b_kgt)
+                    # [BK, BC]
+                    b_kgt = tl.trans(b_k2 * exp2(b_gn3[None, :] - b_g2))
+                    # [BC, BC]
+                    b_Aqk32 += tl.dot(b_qg3, b_kgt)
+                    b_Akk32 += tl.dot(b_kg3, b_kgt)
+
+    ################################################################################
+    # save off-diagonal Aqk blocks and prepare Akk
+    ################################################################################
+    if i_tc1 < T:
+        p_Aqk10 = tl.make_block_ptr(
+            Aqk, (T, BT), (HV * BT, 1), (i_tc1, 0), (BC, BC), (1, 0)
+        )
+        tl.store(
+            p_Aqk10, (b_Aqk10 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1)
+        )
+
+        p_b1 = tl.make_block_ptr(
+            beta + bos * HV + i_hv, (T,), (HV,), (i_tc1,), (BC,), (0,)
+        )
+        b_b1 = tl.load(p_b1, boundary_check=(0,)).to(tl.float32)
+        b_Akk10 = b_Akk10 * b_b1[:, None]
+    if i_tc2 < T:
+        p_Aqk20 = tl.make_block_ptr(
+            Aqk, (T, BT), (HV * BT, 1), (i_tc2, 0), (BC, BC), (1, 0)
+        )
+        p_Aqk21 = tl.make_block_ptr(
+            Aqk, (T, BT), (HV * BT, 1), (i_tc2, BC), (BC, BC), (1, 0)
+        )
+        tl.store(
+            p_Aqk20, (b_Aqk20 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1)
+        )
+        tl.store(
+            p_Aqk21, (b_Aqk21 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1)
+        )
+
+        p_b2 = tl.make_block_ptr(
+            beta + bos * HV + i_hv, (T,), (HV,), (i_tc2,), (BC,), (0,)
+        )
+        b_b2 = tl.load(p_b2, boundary_check=(0,)).to(tl.float32)
+        b_Akk20 = b_Akk20 * b_b2[:, None]
+        b_Akk21 = b_Akk21 * b_b2[:, None]
+    if i_tc3 < T:
+        p_Aqk30 = tl.make_block_ptr(
+            Aqk, (T, BT), (HV * BT, 1), (i_tc3, 0), (BC, BC), (1, 0)
+        )
+        p_Aqk31 = tl.make_block_ptr(
+            Aqk, (T, BT), (HV * BT, 1), (i_tc3, BC), (BC, BC), (1, 0)
+        )
+        p_Aqk32 = tl.make_block_ptr(
+            Aqk, (T, BT), (HV * BT, 1), (i_tc3, 2 * BC), (BC, BC), (1, 0)
+        )
+        tl.store(
+            p_Aqk30, (b_Aqk30 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1)
+        )
+        tl.store(
+            p_Aqk31, (b_Aqk31 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1)
+        )
+        tl.store(
+            p_Aqk32, (b_Aqk32 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1)
+        )
+
+        p_b3 = tl.make_block_ptr(
+            beta + bos * HV + i_hv, (T,), (HV,), (i_tc3,), (BC,), (0,)
+        )
+        b_b3 = tl.load(p_b3, boundary_check=(0,)).to(tl.float32)
+        b_Akk30 = b_Akk30 * b_b3[:, None]
+        b_Akk31 = b_Akk31 * b_b3[:, None]
+        b_Akk32 = b_Akk32 * b_b3[:, None]
+
+    p_Akk00 = tl.make_block_ptr(
+        Akkd, (T, BC), (HV * BC, 1), (i_tc0, 0), (BC, BC), (1, 0)
+    )
+    p_Akk11 = tl.make_block_ptr(
+        Akkd, (T, BC), (HV * BC, 1), (i_tc1, 0), (BC, BC), (1, 0)
+    )
+    p_Akk22 = tl.make_block_ptr(
+        Akkd, (T, BC), (HV * BC, 1), (i_tc2, 0), (BC, BC), (1, 0)
+    )
+    p_Akk33 = tl.make_block_ptr(
+        Akkd, (T, BC), (HV * BC, 1), (i_tc3, 0), (BC, BC), (1, 0)
+    )
+    b_Ai00 = tl.load(p_Akk00, boundary_check=(0, 1)).to(tl.float32)
+    b_Ai11 = tl.load(p_Akk11, boundary_check=(0, 1)).to(tl.float32)
+    b_Ai22 = tl.load(p_Akk22, boundary_check=(0, 1)).to(tl.float32)
+    b_Ai33 = tl.load(p_Akk33, boundary_check=(0, 1)).to(tl.float32)
+
+    ################################################################################
+    # forward substitution on diagonals
+    ################################################################################
+
+    if not USE_SAFE_GATE:
+        m_A = o_i[:, None] > o_i[None, :]
+        m_I = o_i[:, None] == o_i[None, :]
+
+        b_Ai00 = -tl.where(m_A, b_Ai00, 0)
+        b_Ai11 = -tl.where(m_A, b_Ai11, 0)
+        b_Ai22 = -tl.where(m_A, b_Ai22, 0)
+        b_Ai33 = -tl.where(m_A, b_Ai33, 0)
+
+        for i in range(2, min(BC, T - i_tc0)):
+            b_a00 = -tl.load(Akkd + (i_tc0 + i) * HV * BC + o_i)
+            b_a00 = tl.where(o_i < i, b_a00, 0.0)
+            b_a00 += tl.sum(b_a00[:, None] * b_Ai00, 0)
+            b_Ai00 = tl.where((o_i == i)[:, None], b_a00, b_Ai00)
+        for i in range(BC + 2, min(2 * BC, T - i_tc0)):
+            b_a11 = -tl.load(Akkd + (i_tc0 + i) * HV * BC + o_i)
+            b_a11 = tl.where(o_i < i - BC, b_a11, 0.0)
+            b_a11 += tl.sum(b_a11[:, None] * b_Ai11, 0)
+            b_Ai11 = tl.where((o_i == i - BC)[:, None], b_a11, b_Ai11)
+        for i in range(2 * BC + 2, min(3 * BC, T - i_tc0)):
+            b_a22 = -tl.load(Akkd + (i_tc0 + i) * HV * BC + o_i)
+            b_a22 = tl.where(o_i < i - 2 * BC, b_a22, 0.0)
+            b_a22 += tl.sum(b_a22[:, None] * b_Ai22, 0)
+            b_Ai22 = tl.where((o_i == i - 2 * BC)[:, None], b_a22, b_Ai22)
+        for i in range(3 * BC + 2, min(4 * BC, T - i_tc0)):
+            b_a33 = -tl.load(Akkd + (i_tc0 + i) * HV * BC + o_i)
+            b_a33 = tl.where(o_i < i - 3 * BC, b_a33, 0.0)
+            b_a33 += tl.sum(b_a33[:, None] * b_Ai33, 0)
+            b_Ai33 = tl.where((o_i == i - 3 * BC)[:, None], b_a33, b_Ai33)
+
+        b_Ai00 += m_I
+        b_Ai11 += m_I
+        b_Ai22 += m_I
+        b_Ai33 += m_I
+
+    ################################################################################
+    # compute merged inverse using off-diagonals
+    ################################################################################
+
+    # we used tf32 to maintain matrix inverse's precision whenever possible.
+    b_Ai10 = -tl.dot(
+        tl.dot(b_Ai11, b_Akk10, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        b_Ai00,
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+    b_Ai21 = -tl.dot(
+        tl.dot(b_Ai22, b_Akk21, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        b_Ai11,
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+    b_Ai32 = -tl.dot(
+        tl.dot(b_Ai33, b_Akk32, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        b_Ai22,
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+
+    b_Ai20 = -tl.dot(
+        b_Ai22,
+        tl.dot(b_Akk20, b_Ai00, input_precision=SOLVE_TRIL_DOT_PRECISION)
+        + tl.dot(b_Akk21, b_Ai10, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+    b_Ai31 = -tl.dot(
+        b_Ai33,
+        tl.dot(b_Akk31, b_Ai11, input_precision=SOLVE_TRIL_DOT_PRECISION)
+        + tl.dot(b_Akk32, b_Ai21, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+    b_Ai30 = -tl.dot(
+        b_Ai33,
+        tl.dot(b_Akk30, b_Ai00, input_precision=SOLVE_TRIL_DOT_PRECISION)
+        + tl.dot(b_Akk31, b_Ai10, input_precision=SOLVE_TRIL_DOT_PRECISION)
+        + tl.dot(b_Akk32, b_Ai20, input_precision=SOLVE_TRIL_DOT_PRECISION),
+        input_precision=SOLVE_TRIL_DOT_PRECISION,
+    )
+
+    ################################################################################
+    # store full Akk_inv to Akk
+    ################################################################################
+
+    p_Akk00 = tl.make_block_ptr(
+        Akk, (T, BT), (HV * BT, 1), (i_tc0, 0), (BC, BC), (1, 0)
+    )
+    p_Akk10 = tl.make_block_ptr(
+        Akk, (T, BT), (HV * BT, 1), (i_tc1, 0), (BC, BC), (1, 0)
+    )
+    p_Akk11 = tl.make_block_ptr(
+        Akk, (T, BT), (HV * BT, 1), (i_tc1, BC), (BC, BC), (1, 0)
+    )
+    p_Akk20 = tl.make_block_ptr(
+        Akk, (T, BT), (HV * BT, 1), (i_tc2, 0), (BC, BC), (1, 0)
+    )
+    p_Akk21 = tl.make_block_ptr(
+        Akk, (T, BT), (HV * BT, 1), (i_tc2, BC), (BC, BC), (1, 0)
+    )
+    p_Akk22 = tl.make_block_ptr(
+        Akk, (T, BT), (HV * BT, 1), (i_tc2, 2 * BC), (BC, BC), (1, 0)
+    )
+    p_Akk30 = tl.make_block_ptr(
+        Akk, (T, BT), (HV * BT, 1), (i_tc3, 0), (BC, BC), (1, 0)
+    )
+    p_Akk31 = tl.make_block_ptr(
+        Akk, (T, BT), (HV * BT, 1), (i_tc3, BC), (BC, BC), (1, 0)
+    )
+    p_Akk32 = tl.make_block_ptr(
+        Akk, (T, BT), (HV * BT, 1), (i_tc3, 2 * BC), (BC, BC), (1, 0)
+    )
+    p_Akk33 = tl.make_block_ptr(
+        Akk, (T, BT), (HV * BT, 1), (i_tc3, 3 * BC), (BC, BC), (1, 0)
+    )
+
+    tl.store(p_Akk00, b_Ai00.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk10, b_Ai10.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk11, b_Ai11.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk20, b_Ai20.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk21, b_Ai21.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk22, b_Ai22.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk30, b_Ai30.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk31, b_Ai31.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk32, b_Ai32.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk33, b_Ai33.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in [1, 2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=["BK", "NC", "BT", "HV"],
+)
+@triton.jit(do_not_specialize=["B", "T"])
+def chunk_kda_fwd_kernel_intra_sub_chunk(
+    q,
+    k,
+    g,
+    beta,
+    Aqk,
+    Akk,
+    scale,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    USE_GATHER: tl.constexpr,
+):
+    i_t, i_i, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_hv = i_bh // HV, i_bh % HV
+    i_h = i_hv // (HV // H)
+
+    if IS_VARLEN:
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    i_ti = i_t * BT + i_i * BC
+    if i_ti >= T:
+        return
+
+    o_c = i_ti + tl.arange(0, BC)
+    m_c = o_c < T
+
+    q = q + (bos * H + i_h) * K
+    k = k + (bos * H + i_h) * K
+    g = g + (bos * HV + i_hv) * K
+    beta = beta + bos * HV + i_hv
+    Aqk = Aqk + (bos * HV + i_hv) * BT
+    Akk = Akk + (bos * HV + i_hv) * BC
+
+    p_q = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_ti, 0), (BC, BK), (1, 0))
+    p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_ti, 0), (BC, BK), (1, 0))
+    p_g = tl.make_block_ptr(g, (T, K), (HV * K, 1), (i_ti, 0), (BC, BK), (1, 0))
+
+    p_beta = tl.make_block_ptr(beta, (T,), (HV,), (i_ti,), (BC,), (0,))
+
+    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_k = tl.load(p_k, boundary_check=(0, 1))
+    b_g = tl.load(p_g, boundary_check=(0, 1))
+    b_beta = tl.load(p_beta, boundary_check=(0,)).to(tl.float32)
+
+    if USE_GATHER:
+        b_gn = gather(
+            b_g, tl.full([1, BK], min(BC // 2, T - i_ti - 1), dtype=tl.int16), axis=0
+        )
+    else:
+        # calculate offset
+        p_gn = g + (i_ti + min(BC // 2, T - i_ti - 1)) * HV * K + tl.arange(0, BK)
+        b_gn = tl.load(p_gn, mask=tl.arange(0, BK) < K, other=0.0)
+        b_gn = b_gn[None, :]
+
+    # current block, keep numerical stability by subtracting the left boundary
+    # less than 85 to avoid overflow in exp2
+    b_gm = (b_g - b_gn).to(tl.float32)
+
+    b_gq = tl.where(m_c[:, None], exp2(b_gm), 0.0)
+    b_gk = tl.where(m_c[:, None], exp2(-b_gm), 0.0)
+
+    b_kgt = tl.trans(b_k * b_gk)
+
+    b_Aqk = tl.dot(b_q * b_gq, b_kgt) * scale
+    b_Akk = tl.dot(b_k * b_gq, b_kgt) * b_beta[:, None]
+
+    o_i = tl.arange(0, BC)
+    m_Aqk = o_i[:, None] >= o_i[None, :]
+    m_Akk = o_i[:, None] > o_i[None, :]
+    m_I = o_i[:, None] == o_i[None, :]
+
+    b_Aqk = tl.where(m_Aqk, b_Aqk, 0.0)
+    b_Akk = tl.where(m_Akk, b_Akk, 0.0)
+
+    p_Aqk = tl.make_block_ptr(
+        Aqk, (T, BT), (HV * BT, 1), (i_ti, i_i * BC), (BC, BC), (1, 0)
+    )
+    p_Akk = tl.make_block_ptr(Akk, (T, BC), (HV * BC, 1), (i_ti, 0), (BC, BC), (1, 0))
+    tl.store(p_Aqk, b_Aqk.to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk, b_Akk.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+
+    tl.debug_barrier()
+
+    ################################################################################
+    # forward substitution
+    ################################################################################
+
+    b_Ai = -b_Akk
+    for i in range(2, min(BC, T - i_ti)):
+        b_a = -tl.load(Akk + (i_ti + i) * HV * BC + o_i)
+        b_a = tl.where(o_i < i, b_a, 0.0)
+        b_a += tl.sum(b_a[:, None] * b_Ai, 0)
+        b_Ai = tl.where((o_i == i)[:, None], b_a, b_Ai)
+    b_Ai += m_I
+    tl.store(p_Akk, b_Ai.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+
+
+def chunk_kda_fwd_intra(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    gk: torch.Tensor | None = None,
+    beta: torch.Tensor | None = None,
+    scale: float | None = None,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+    safe_gate: bool = False,
+):
+    B, T, H, K, HV = *k.shape, gk.shape[2]
+    BT = chunk_size
+    BC = 16
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    NC = triton.cdiv(BT, BC)
+
+    Aqk = torch.empty(B, T, HV, BT, device=k.device, dtype=k.dtype)
+    # Akk must be zero-initialized - kernel only writes lower triangular
+    Akk = torch.zeros(B, T, HV, BT, device=k.device, dtype=k.dtype)
+    # Separate fp32 buffer for diagonal 16x16 blocks (for precision in solve_tril)
+    Akkd = torch.empty(B, T, HV, BC, device=k.device, dtype=torch.float32)
+
+    # Compute diagonal blocks into Akkd in fp32.
+    if safe_gate:
+        grid = (NT, NC, B * HV)
+        BK = triton.next_power_of_2(K)
+        chunk_kda_fwd_kernel_intra_sub_chunk[grid](
+            q=q,
+            k=k,
+            g=gk,
+            beta=beta,
+            Aqk=Aqk,
+            Akk=Akkd,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            T=T,
+            H=H,
+            HV=HV,
+            K=K,
+            BT=BT,
+            BC=BC,
+            BK=BK,
+            USE_GATHER=is_gather_supported,
+        )
+    else:
+        Aqk, Akkd = chunk_kda_fwd_intra_token_parallel(
+            q=q,
+            k=k,
+            gk=gk,
+            beta=beta,
+            Aqk=Aqk,
+            Akk=Akkd,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            chunk_size=BT,
+            sub_chunk_size=BC,
+        )
+
+    # Step 2: Fused inter + solve_tril (works for both fixed-len and varlen)
+    solve_tril_dot_precision = (
+        "tf32"
+        if current_platform.is_cuda() and current_platform.has_device_capability(80)
+        else "ieee"
+    )
+    grid = (NT, B * HV)
+    chunk_kda_fwd_kernel_inter_solve_fused[grid](
+        q=q,
+        k=k,
+        g=gk,
+        beta=beta,
+        Aqk=Aqk,
+        Akkd=Akkd,
+        Akk=Akk,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        HV=HV,
+        K=K,
+        BT=BT,
+        BC=BC,
+        USE_SAFE_GATE=safe_gate,
+        SOLVE_TRIL_DOT_PRECISION=solve_tril_dot_precision,
+    )
+    return Aqk, Akk

--- a/vllm/models/kimi_k3/nvidia/ops/third_party/kda/chunk_intra_token_parallel.py
+++ b/vllm/models/kimi_k3/nvidia/ops/third_party/kda/chunk_intra_token_parallel.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This file contains code copied from the flash-linear-attention project.
+# The original source was licensed under the MIT license.
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+# Forward-only adaptation of flash-linear-attention 0.5.0.
+# ruff: noqa: E501
+# mypy: ignore-errors
+
+# Token-parallel implementation of KDA intra chunk kernel
+
+import torch
+
+from vllm.third_party.flash_linear_attention.ops.op import exp2
+from vllm.triton_utils import tl, triton
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({"BH": BH}, num_warps=num_warps)
+        for BH in [1, 2, 4, 8]
+        for num_warps in [1, 2, 4, 8]
+    ],
+    key=["K", "H", "HV"],
+)
+@triton.jit(do_not_specialize=["T", "N"])
+def chunk_kda_fwd_kernel_intra_token_parallel(
+    q,
+    k,
+    g,
+    beta,
+    Aqk,
+    Akk,
+    scale,
+    cu_seqlens,
+    N,
+    T,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BH: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_tg, i_hg = tl.program_id(0), tl.program_id(1)
+
+    if IS_VARLEN:
+        i_n = 0
+        left, right = 0, N
+
+        # Unrolled binary search (max B=2^32)
+        # We can limit iterations based on expected max batch size if needed
+        # 20 iterations covers B=1M, usually enough
+        for _ in range(20):
+            if left < right:
+                mid = (left + right) // 2
+                if i_tg < tl.load(cu_seqlens + mid + 1).to(tl.int32):
+                    right = mid
+                else:
+                    left = mid + 1
+        i_n = left
+
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+        i_t = i_tg - bos
+    else:
+        bos = (i_tg // T) * T
+        i_t = i_tg % T
+
+    if i_t >= T:
+        return
+
+    i_c = i_t // BT
+    i_s = (i_t % BT) // BC
+    i_tc = i_c * BT
+    i_ts = i_tc + i_s * BC
+
+    G: tl.constexpr = HV // H
+
+    q += bos * H * K
+    k += bos * H * K
+    g += bos * HV * K
+    Aqk += bos * HV * BT
+    Akk += bos * HV * BC
+    beta += bos * HV
+
+    BK: tl.constexpr = triton.next_power_of_2(K)
+    o_hv = i_hg * BH + tl.arange(0, BH)
+    o_h = o_hv // G
+    o_k = tl.arange(0, BK)
+    m_hv = o_hv < HV
+    m_k = o_k < K
+    m_hk = m_hv[:, None] & m_k[None, :]
+
+    # q/k: [B, T, H, K], manual load via mapped qk head index
+    p_qk = o_h[:, None] * K + o_k[None, :]
+    b_q = tl.load(q + i_t * H * K + p_qk, mask=m_hk, other=0).to(tl.float32)
+    b_k = tl.load(k + i_t * H * K + p_qk, mask=m_hk, other=0).to(tl.float32)
+
+    # g: [B, T, HV, K], beta: [B, T, HV]
+    p_g = tl.make_block_ptr(
+        g + i_t * HV * K, (HV, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0)
+    )
+    p_beta = tl.make_block_ptr(beta + i_t * HV, (HV,), (1,), (i_hg * BH,), (BH,), (0,))
+    b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+    b_beta = tl.load(p_beta, boundary_check=(0,)).to(tl.float32)
+    b_k *= b_beta[:, None]
+
+    for j in range(i_ts, min(i_t + 1, min(T, i_ts + BC))):
+        b_kj = tl.load(k + j * H * K + p_qk, mask=m_hk, other=0).to(tl.float32)
+        p_gj = tl.make_block_ptr(
+            g + j * HV * K, (HV, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0)
+        )
+        b_gj = tl.load(p_gj, boundary_check=(0, 1)).to(tl.float32)
+
+        b_kgj = tl.where(m_k[None, :], b_kj * exp2(b_g - b_gj), 0.0)
+        b_Aqk = tl.sum(b_q * b_kgj, axis=1) * scale
+        b_Akk = tl.sum(b_k * b_kgj, axis=1) * tl.where(j < i_t, 1.0, 0.0)
+
+        tl.store(
+            Aqk + i_t * HV * BT + o_hv * BT + j % BT,
+            b_Aqk.to(Aqk.dtype.element_ty),
+            mask=m_hv,
+        )
+        tl.store(
+            Akk + i_t * HV * BC + o_hv * BC + j - i_ts,
+            b_Akk.to(Akk.dtype.element_ty),
+            mask=m_hv,
+        )
+
+
+def chunk_kda_fwd_intra_token_parallel(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    gk: torch.Tensor,
+    beta: torch.Tensor,
+    Aqk: torch.Tensor,
+    Akk: torch.Tensor,
+    scale: float,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    sub_chunk_size: int = 16,
+) -> None:
+    """
+    Token-parallel implementation: each token gets its own thread block.
+    Supports both fixed-length and variable-length sequences.
+    Reduces wasted computation on padding.
+
+    Writes directly to Aqk and Akk tensors (in-place).
+
+    Args:
+        q: [B, T, H, K]
+        k: [B, T, H, K]
+        gk: [B, T, HV, K] cumsum of gates (HV >= H for GVA)
+        beta: [B, T, HV]
+        Aqk: [B, T, HV, BT] output tensor to write to
+        Akk: [B, T, HV, BC] output tensor for diagonal blocks (fp32)
+        scale: attention scale
+        chunk_size: BT (default 64)
+        sub_chunk_size: BC (default 16)
+    """
+    B, T, H, K, HV = *q.shape, gk.shape[2]
+    N = len(cu_seqlens) - 1 if cu_seqlens is not None else B
+    BT = chunk_size
+    BC = sub_chunk_size
+
+    def grid(meta):
+        return (B * T, triton.cdiv(HV, meta["BH"]))
+
+    chunk_kda_fwd_kernel_intra_token_parallel[grid](
+        q=q,
+        k=k,
+        g=gk,
+        beta=beta,
+        Aqk=Aqk,
+        Akk=Akk,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        N=N,
+        T=T,
+        H=H,
+        HV=HV,
+        K=K,
+        BT=BT,
+        BC=BC,
+    )
+    return Aqk, Akk

--- a/vllm/models/kimi_k3/nvidia/ops/third_party/kda/fused_recurrent.py
+++ b/vllm/models/kimi_k3/nvidia/ops/third_party/kda/fused_recurrent.py
@@ -1,0 +1,669 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This file contains code adapted from the flash-linear-attention project.
+# The original source was licensed under the MIT license.
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+# ruff: noqa: E501
+
+import torch
+
+from vllm.platforms import current_platform
+from vllm.third_party.flash_linear_attention.ops.op import exp, log
+from vllm.triton_utils import tl, triton
+from vllm.utils.math_utils import cdiv, next_power_of_2
+
+
+@triton.heuristics(
+    {
+        "HAS_DT_BIAS": lambda args: args["dt_bias"] is not None,
+        "USE_LOWER_BOUND": lambda args: args["lower_bound"] is not None,
+    }
+)
+@triton.jit
+def _kda_gate_beta_fwd_kernel(
+    raw_g,
+    raw_beta,
+    A_log,
+    dt_bias,
+    gate,
+    beta_out,
+    lower_bound,
+    softplus_beta: tl.constexpr,
+    softplus_threshold: tl.constexpr,
+    T,
+    stride_g_token: tl.constexpr,
+    stride_beta_token: tl.constexpr,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    BT: tl.constexpr,
+    BD: tl.constexpr,
+    HAS_DT_BIAS: tl.constexpr,
+    USE_LOWER_BOUND: tl.constexpr,
+    launch_pdl: tl.constexpr,
+):
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+        tl.extra.cuda.gdc_launch_dependents()
+
+    i_t, i_h = tl.program_id(0), tl.program_id(1)
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_d = tl.arange(0, BD)
+    m_t = o_t < T
+    m_d = o_d < D
+
+    p_g = raw_g + o_t[:, None] * stride_g_token + i_h * D + o_d[None, :]
+    b_g = tl.load(p_g, mask=m_t[:, None] & m_d[None, :], other=0.0).to(tl.float32)
+    if HAS_DT_BIAS:
+        b_bias = tl.load(
+            dt_bias + i_h * D + o_d,
+            mask=m_d,
+            other=0.0,
+        ).to(tl.float32)
+        b_g += b_bias[None, :]
+
+    b_a = exp(tl.load(A_log + i_h).to(tl.float32))
+    if USE_LOWER_BOUND:
+        b_gate = lower_bound * tl.sigmoid(b_a * b_g)
+    else:
+        b_scaled = b_g * softplus_beta
+        b_softplus = tl.where(
+            b_scaled > softplus_threshold,
+            b_g,
+            log(1.0 + tl.exp(b_scaled)) / softplus_beta,
+        )
+        b_gate = -b_a * b_softplus
+
+    p_gate = gate + (o_t[:, None] * H + i_h) * D + o_d[None, :]
+    tl.store(
+        p_gate,
+        b_gate,
+        mask=m_t[:, None] & m_d[None, :],
+    )
+
+    b_beta = tl.load(
+        raw_beta + o_t * stride_beta_token + i_h,
+        mask=m_t,
+        other=0.0,
+    ).to(tl.float32)
+    tl.store(beta_out + o_t * H + i_h, tl.sigmoid(b_beta), mask=m_t)
+
+
+def _fused_kda_gate_beta(
+    raw_g: torch.Tensor,
+    raw_beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor | None,
+    lower_bound: float | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    B, T, H, D = raw_g.shape
+    assert B == 1
+    assert raw_beta.shape == (B, T, H)
+    assert raw_g.stride()[2:] == (D, 1)
+    assert raw_beta.stride(2) == 1
+    gate = torch.empty((B, T, H, D), dtype=torch.float32, device=raw_g.device)
+    beta = torch.empty((B, T, H), dtype=torch.float32, device=raw_beta.device)
+
+    BT = 16
+    _kda_gate_beta_fwd_kernel[(cdiv(T, BT), H)](
+        raw_g=raw_g,
+        raw_beta=raw_beta,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        gate=gate,
+        beta_out=beta,
+        lower_bound=lower_bound,
+        softplus_beta=1.0,
+        softplus_threshold=20.0,
+        T=T,
+        stride_g_token=raw_g.stride(1),
+        stride_beta_token=raw_beta.stride(1),
+        H=H,
+        D=D,
+        BT=BT,
+        BD=next_power_of_2(D),
+        num_warps=4,
+        launch_pdl=current_platform.is_arch_support_pdl(),
+    )
+    return gate, beta
+
+
+@triton.heuristics(
+    {
+        "IS_SPEC_DECODING": lambda args: args["num_accepted_tokens"] is not None,
+        "HAS_DT_BIAS": lambda args: args["dt_bias"] is not None,
+        "USE_LOWER_BOUND": lambda args: args["lower_bound"] is not None,
+    }
+)
+@triton.jit(do_not_specialize=["N", "T", "stride_beta_token"])
+def fused_recurrent_kda_fwd_kernel(
+    q,
+    k,
+    v,
+    g,
+    beta,
+    A_log,
+    dt_bias,
+    out,
+    state,
+    cu_seqlens,
+    state_indices,
+    num_accepted_tokens,
+    lower_bound,
+    scale: tl.constexpr,
+    N: tl.int64,
+    T: tl.int64,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    stride_qkv_token: tl.constexpr,
+    stride_g_token: tl.constexpr,
+    stride_beta_token,
+    stride_out_token: tl.constexpr,
+    stride_state_token: tl.constexpr,
+    stride_indices_seq: tl.constexpr,
+    IS_SPEC_DECODING: tl.constexpr,
+    USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
+    USE_GATE_IN_KERNEL: tl.constexpr,
+    APPLY_BETA_SIGMOID: tl.constexpr,
+    HAS_DT_BIAS: tl.constexpr,
+    USE_LOWER_BOUND: tl.constexpr,
+    num_stages: tl.constexpr,
+    launch_pdl: tl.constexpr,
+):
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+
+    pid = tl.program_id(0)
+    i_v = pid % tl.cdiv(V, BV)
+    i_nh = pid // tl.cdiv(V, BV)
+    i_n, i_h = i_nh // H, i_nh % H
+    bos = tl.load(cu_seqlens + i_n).to(tl.int64)
+    eos = tl.load(cu_seqlens + i_n + 1).to(tl.int64)
+    sequence_length = eos - bos
+    if sequence_length == 0:
+        return
+
+    o_k = tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_k = o_k < K
+    m_v = o_v < V
+    m_state = m_v[:, None] & m_k[None, :]
+
+    if IS_SPEC_DECODING:
+        initial_token = tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1
+    else:
+        initial_token = 0
+    state_index = tl.load(state_indices + i_n * stride_indices_seq + initial_token).to(
+        tl.int64
+    )
+    p_out = out + bos * stride_out_token + i_h * V + o_v
+    if state_index <= 0:
+        tl.store(p_out, tl.zeros([BV], dtype=tl.float32), mask=m_v)
+        return
+
+    p_state = (
+        state
+        + state_index * stride_state_token
+        + i_h * V * K
+        + o_v[:, None] * K
+        + o_k[None, :]
+    )
+    b_state = tl.load(p_state, mask=m_state, other=0.0).to(tl.float32)
+
+    p_q = q + bos * stride_qkv_token + i_h * K + o_k
+    p_k = k + bos * stride_qkv_token + i_h * K + o_k
+    p_v = v + bos * stride_qkv_token + i_h * V + o_v
+    p_g = g + bos * stride_g_token + i_h * K + o_k
+    p_beta = beta + bos * stride_beta_token + i_h
+    for i_t in tl.range(0, sequence_length, num_stages=num_stages):
+        b_q = tl.load(p_q, mask=m_k, other=0.0, eviction_policy="evict_last").to(
+            tl.float32
+        )
+        b_k = tl.load(p_k, mask=m_k, other=0.0, eviction_policy="evict_last").to(
+            tl.float32
+        )
+        b_v = tl.load(p_v, mask=m_v, other=0.0, eviction_policy="evict_first").to(
+            tl.float32
+        )
+        if USE_QK_L2NORM_IN_KERNEL:
+            b_q = b_q / tl.sqrt(tl.sum(b_q * b_q) + 1e-6)
+            b_k = b_k / tl.sqrt(tl.sum(b_k * b_k) + 1e-6)
+        b_q *= scale
+
+        b_gate = tl.load(
+            p_g,
+            mask=m_k,
+            other=0.0,
+            eviction_policy="evict_last",
+        ).to(tl.float32)
+        if USE_GATE_IN_KERNEL:
+            if HAS_DT_BIAS:
+                b_bias = tl.load(
+                    dt_bias + i_h * K + o_k,
+                    mask=m_k,
+                    other=0.0,
+                ).to(tl.float32)
+                b_gate += b_bias
+            b_a = exp(tl.load(A_log + i_h).to(tl.float32))
+            if USE_LOWER_BOUND:
+                b_gate = lower_bound * tl.sigmoid(b_a * b_gate)
+            else:
+                b_softplus = tl.where(
+                    b_gate > 20.0,
+                    b_gate,
+                    log(1.0 + tl.exp(b_gate)),
+                )
+                b_gate = -b_a * b_softplus
+
+        b_state *= exp(b_gate[None, :])
+        b_v -= tl.sum(b_state * b_k[None, :], axis=1)
+        b_beta = tl.load(p_beta, eviction_policy="evict_last").to(tl.float32)
+        if APPLY_BETA_SIGMOID:
+            b_beta = tl.sigmoid(b_beta)
+        b_v *= b_beta
+        b_state += b_v[:, None] * b_k[None, :]
+        b_out = tl.sum(b_state * b_q[None, :], axis=1)
+        tl.store(
+            p_out,
+            b_out.to(p_out.dtype.element_ty),
+            mask=m_v,
+            eviction_policy="evict_first",
+        )
+
+        final_state_index = tl.load(state_indices + i_n * stride_indices_seq + i_t).to(
+            tl.int64
+        )
+        if final_state_index > 0:
+            p_final_state = (
+                state
+                + final_state_index * stride_state_token
+                + i_h * V * K
+                + o_v[:, None] * K
+                + o_k[None, :]
+            )
+            tl.store(
+                p_final_state,
+                b_state.to(p_final_state.dtype.element_ty),
+                mask=m_state,
+            )
+
+        p_q += stride_qkv_token
+        p_k += stride_qkv_token
+        p_v += stride_qkv_token
+        p_g += stride_g_token
+        p_beta += stride_beta_token
+        p_out += stride_out_token
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_launch_dependents()
+
+
+# Consumed by kimi_k3_triton_warmup.py during kernel_warmup().
+def get_fused_recurrent_kda_fwd_warmup_profiles(
+    num_heads: int,
+) -> tuple[int, ...]:
+    """Return representative sequence counts for gated launch variants."""
+    # The region above 192 head-sequences reuses the second launch variant.
+    return (
+        1,
+        48 // num_heads + 1,
+        96 // num_heads + 1,
+    )
+
+
+def fused_recurrent_kda_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float | None = None,
+    initial_state: torch.Tensor | None = None,
+    inplace_final_state: bool = True,
+    cu_seqlens: torch.Tensor | None = None,
+    ssm_state_indices: torch.Tensor | None = None,
+    num_accepted_tokens: torch.Tensor | None = None,
+    use_qk_l2norm_in_kernel: bool = True,
+    A_log: torch.Tensor | None = None,
+    dt_bias: torch.Tensor | None = None,
+    lower_bound: float | None = None,
+    use_gate_in_kernel: bool = False,
+    use_beta_sigmoid_in_kernel: bool = False,
+    out: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Launch recurrent KDA with dense inner dimensions and row strides."""
+    B, T, H, K = q.shape
+    V = v.shape[-1]
+    assert B == 1 and k.shape == q.shape
+    assert v.shape == (B, T, H, V) and g.shape == (B, T, H, K)
+    assert beta.shape == (B, T, H)
+    assert initial_state is not None
+    assert cu_seqlens is not None
+    assert ssm_state_indices is not None
+    assert inplace_final_state
+    if out is None:
+        out = torch.empty_like(v)
+    assert out.shape == v.shape
+    assert initial_state.shape[1:] == (H, V, K)
+    assert ssm_state_indices.ndim in (1, 2)
+
+    assert q.stride()[2:] == k.stride()[2:] == (K, 1)
+    assert v.stride()[2:] == out.stride()[2:] == (V, 1)
+    assert g.stride()[2:] == (K, 1)
+    assert beta.stride(2) == 1
+    assert q.stride(1) == k.stride(1) == v.stride(1)
+    assert initial_state.stride()[1:] == (V * K, K, 1)
+    N = cu_seqlens.numel() - 1
+    if ssm_state_indices.ndim == 1:
+        assert T == N
+        assert num_accepted_tokens is None
+    else:
+        assert ssm_state_indices.stride(1) == 1
+    assert cu_seqlens.is_contiguous()
+    if use_gate_in_kernel:
+        assert A_log is not None and A_log.is_contiguous()
+        assert dt_bias is None or dt_bias.is_contiguous()
+
+    if scale is None:
+        scale = K**-0.5
+
+    if use_gate_in_kernel:
+        # Tuned on GB300 for Kimi-K3 shapes. Keep the warmup profiles above in
+        # sync with these boundaries.
+        head_sequences = H * N
+        if head_sequences <= 48:
+            BV, num_stages = 4, 4
+        elif head_sequences <= 96:
+            BV, num_stages = 8, 3
+        elif head_sequences <= 192:
+            BV, num_stages = 16, 3
+        else:
+            BV, num_stages = 8, 3
+        num_warps = 1
+    else:
+        BV, num_warps, num_stages = 8, 1, 2
+    grid = (cdiv(V, BV) * N * H,)
+    fused_recurrent_kda_fwd_kernel[grid](
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        out=out,
+        state=initial_state,
+        cu_seqlens=cu_seqlens,
+        state_indices=ssm_state_indices,
+        num_accepted_tokens=num_accepted_tokens,
+        lower_bound=lower_bound,
+        scale=scale,
+        N=N,
+        T=T,
+        H=H,
+        K=K,
+        V=V,
+        BK=next_power_of_2(K),
+        BV=BV,
+        stride_qkv_token=q.stride(1),
+        stride_g_token=g.stride(1),
+        stride_beta_token=beta.stride(1),
+        stride_out_token=out.stride(1),
+        stride_state_token=initial_state.stride(0),
+        stride_indices_seq=ssm_state_indices.stride(0),
+        IS_SPEC_DECODING=num_accepted_tokens is not None,
+        USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
+        USE_GATE_IN_KERNEL=use_gate_in_kernel,
+        APPLY_BETA_SIGMOID=use_beta_sigmoid_in_kernel,
+        num_warps=num_warps,
+        num_stages=num_stages,
+        launch_pdl=current_platform.is_arch_support_pdl(),
+    )
+    return out, initial_state
+
+
+def fused_recurrent_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    raw_g: torch.Tensor,
+    raw_beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor | None,
+    lower_bound: float | None,
+    initial_state: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    ssm_state_indices: torch.Tensor,
+    num_accepted_tokens: torch.Tensor | None = None,
+    out: torch.Tensor | None = None,
+    fuse_gate: bool | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run recurrent KDA from raw gate and beta inputs.
+
+    This vLLM wrapper applies the gate activation and beta sigmoid, selecting
+    whether to materialize them before launching the recurrent kernel.
+    """
+    if fuse_gate is None:
+        fuse_gate = True
+
+    if fuse_gate:
+        gate = raw_g
+        beta = raw_beta
+    else:
+        gate, beta = _fused_kda_gate_beta(
+            raw_g,
+            raw_beta,
+            A_log,
+            dt_bias,
+            lower_bound,
+        )
+    return fused_recurrent_kda_fwd(
+        q=q,
+        k=k,
+        v=v,
+        g=gate,
+        beta=beta,
+        scale=q.shape[-1] ** -0.5,
+        initial_state=initial_state,
+        inplace_final_state=True,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_state_indices,
+        num_accepted_tokens=num_accepted_tokens,
+        use_qk_l2norm_in_kernel=True,
+        A_log=A_log if fuse_gate else None,
+        dt_bias=dt_bias if fuse_gate else None,
+        lower_bound=lower_bound if fuse_gate else None,
+        use_gate_in_kernel=fuse_gate,
+        use_beta_sigmoid_in_kernel=fuse_gate,
+        out=out,
+    )
+
+
+@triton.jit(do_not_specialize=["stride_beta_token", "stride_state_indices"])
+def fused_recurrent_kda_packed_decode_kernel(
+    mixed_qkv,
+    raw_g,
+    raw_beta,
+    A_log,
+    dt_bias,
+    out,
+    state,
+    state_indices,
+    lower_bound,
+    scale: tl.constexpr,
+    stride_mixed_token: tl.constexpr,
+    stride_g_token: tl.constexpr,
+    stride_beta_token,
+    stride_state_token: tl.constexpr,
+    stride_state_indices,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    SOFTPLUS_THRESHOLD: tl.constexpr,
+    USE_LOWER_BOUND: tl.constexpr,
+    launch_pdl: tl.constexpr,
+):
+    i_v, i_nh = tl.program_id(0), tl.program_id(1)
+    i_n, i_h = i_nh // H, i_nh % H
+
+    o_k = tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    mask_k = o_k < K
+    mask_v = o_v < V
+    mask_state = mask_v[:, None] & mask_k[None, :]
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+        tl.extra.cuda.gdc_launch_dependents()
+
+    state_idx = tl.load(state_indices + i_n * stride_state_indices).to(tl.int64)
+    p_out = out + (i_n * H + i_h) * V + o_v
+    if state_idx <= 0:
+        tl.store(p_out, tl.zeros([BV], dtype=tl.float32), mask=mask_v)
+        return
+
+    p_state = state + state_idx * stride_state_token
+    p_state += i_h * V * K + o_v[:, None] * K + o_k[None, :]
+    b_state = tl.load(p_state, mask=mask_state, other=0).to(tl.float32)
+
+    # Q, K, and V occupy consecutive channel ranges, while the token stride
+    # may also include the output-gate projection that follows packed QKV.
+    p_mixed = mixed_qkv + i_n * stride_mixed_token
+    b_q = tl.load(p_mixed + i_h * K + o_k, mask=mask_k, other=0).to(tl.float32)
+    b_k = tl.load(
+        p_mixed + H * K + i_h * K + o_k,
+        mask=mask_k,
+        other=0,
+    ).to(tl.float32)
+    b_v = tl.load(
+        p_mixed + 2 * H * K + i_h * V + o_v,
+        mask=mask_v,
+        other=0,
+    ).to(tl.float32)
+
+    b_q /= tl.sqrt(tl.sum(b_q * b_q) + 1e-6)
+    b_k /= tl.sqrt(tl.sum(b_k * b_k) + 1e-6)
+    b_q *= scale
+
+    p_g = raw_g + i_n * stride_g_token + i_h * K + o_k
+    b_g = tl.load(p_g, mask=mask_k, other=0).to(tl.float32)
+    b_bias = tl.load(dt_bias + i_h * K + o_k, mask=mask_k, other=0).to(tl.float32)
+    b_a = exp(tl.load(A_log + i_h).to(tl.float32))
+    b_g += b_bias
+    if USE_LOWER_BOUND:
+        b_gate = lower_bound * tl.sigmoid(b_a * b_g)
+    else:
+        b_softplus = tl.where(
+            b_g > SOFTPLUS_THRESHOLD,
+            b_g,
+            log(1.0 + tl.exp(b_g)),
+        )
+        b_gate = -b_a * b_softplus
+
+    b_state *= exp(b_gate[None, :])
+    b_v -= tl.sum(b_state * b_k[None, :], axis=1)
+    b_beta = tl.sigmoid(
+        tl.load(raw_beta + i_n * stride_beta_token + i_h).to(tl.float32)
+    )
+    b_v *= b_beta
+    b_state += b_v[:, None] * b_k[None, :]
+    b_out = tl.sum(b_state * b_q[None, :], axis=1)
+
+    tl.store(p_out, b_out.to(p_out.dtype.element_ty), mask=mask_v)
+    tl.store(p_state, b_state.to(p_state.dtype.element_ty), mask=mask_state)
+
+
+def fused_recurrent_kda_packed_decode(
+    mixed_qkv: torch.Tensor,
+    raw_g: torch.Tensor,
+    raw_beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    lower_bound: float | None,
+    initial_state: torch.Tensor,
+    state_indices: torch.Tensor,
+    scale: float | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run one-token KDA decode directly from packed post-conv QKV."""
+    if mixed_qkv.ndim != 2 or mixed_qkv.stride(-1) != 1:
+        raise ValueError("`mixed_qkv` must be 2D and contiguous in its last dim.")
+    if raw_g.ndim != 4 or raw_g.shape[0] != 1:
+        raise ValueError("`raw_g` must have shape [1, B, H, K].")
+    if raw_beta.ndim != 3 or raw_beta.shape[0] != 1:
+        raise ValueError("`raw_beta` must have shape [1, B, H].")
+    if initial_state.ndim != 4:
+        raise ValueError("`initial_state` must have shape [cache, H, V, K].")
+    _, H, V, K = initial_state.shape
+    if raw_g.stride()[2:] != (K, 1):
+        raise ValueError("`raw_g` must be contiguous within each token.")
+    if raw_beta.stride(2) != 1:
+        raise ValueError("`raw_beta` heads must be contiguous.")
+    if initial_state.stride()[1:] != (V * K, K, 1):
+        raise ValueError("`initial_state` must be contiguous within each cache slot.")
+    if state_indices.ndim != 1:
+        raise ValueError("`state_indices` must be one-dimensional.")
+    if A_log.ndim != 1 or not A_log.is_contiguous():
+        raise ValueError("`A_log` must be contiguous and one-dimensional.")
+    if not dt_bias.is_contiguous():
+        raise ValueError("`dt_bias` must be contiguous.")
+
+    device = mixed_qkv.device
+    if any(
+        x.device != device
+        for x in (raw_g, raw_beta, A_log, dt_bias, initial_state, state_indices)
+    ):
+        raise ValueError("All packed KDA inputs must be on the same device.")
+
+    B = mixed_qkv.shape[0]
+    if raw_g.shape != (1, B, H, K):
+        raise ValueError(f"Unexpected raw gate shape {tuple(raw_g.shape)}.")
+    if raw_beta.shape != (1, B, H):
+        raise ValueError(f"Unexpected raw beta shape {tuple(raw_beta.shape)}.")
+    if mixed_qkv.shape[1] != 2 * H * K + H * V:
+        raise ValueError(f"Unexpected packed QKV shape {tuple(mixed_qkv.shape)}.")
+    if A_log.numel() != H or dt_bias.numel() != H * K:
+        raise ValueError("`A_log` or `dt_bias` has an incompatible shape.")
+    if state_indices.shape[0] != B:
+        raise ValueError("`state_indices` must contain one entry per token.")
+
+    BK = next_power_of_2(K)
+    BV = min(next_power_of_2(V), 32)
+    if scale is None:
+        scale = K**-0.5
+
+    out = torch.empty((1, B, H, V), dtype=mixed_qkv.dtype, device=device)
+    grid = (cdiv(V, BV), B * H)
+    fused_recurrent_kda_packed_decode_kernel[grid](
+        mixed_qkv=mixed_qkv,
+        raw_g=raw_g,
+        raw_beta=raw_beta,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        out=out,
+        state=initial_state,
+        state_indices=state_indices,
+        lower_bound=lower_bound or 0.0,
+        scale=scale,
+        stride_mixed_token=mixed_qkv.stride(0),
+        stride_g_token=raw_g.stride(1),
+        stride_beta_token=raw_beta.stride(1),
+        stride_state_token=initial_state.stride(0),
+        stride_state_indices=state_indices.stride(0),
+        H=H,
+        K=K,
+        V=V,
+        BK=BK,
+        BV=BV,
+        SOFTPLUS_THRESHOLD=20.0,
+        USE_LOWER_BOUND=lower_bound is not None,
+        num_warps=4,
+        num_stages=2,
+        launch_pdl=current_platform.is_arch_support_pdl(),
+    )
+    return out, initial_state

--- a/vllm/third_party/flash_linear_attention/ops/fused_norm_gate.py
+++ b/vllm/third_party/flash_linear_attention/ops/fused_norm_gate.py
@@ -1,0 +1,412 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Songlin Yang, Yu Zhang
+#
+# This file contains code copied from the flash-linear-attention project.
+# The original source was licensed under the MIT license.
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+# ruff: noqa: E501
+
+import torch
+import torch.nn as nn
+
+from vllm.model_executor.custom_op import CustomOp
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+from vllm.utils.math_utils import cdiv, next_power_of_2
+
+@triton.heuristics(
+    {
+        "STORE_RESIDUAL_OUT": lambda args: args["residual_out"] is not None,
+        "HAS_RESIDUAL": lambda args: args["residual"] is not None,
+        "HAS_WEIGHT": lambda args: args["w"] is not None,
+        "HAS_BIAS": lambda args: args["b"] is not None,
+    }
+)
+@triton.jit
+def layer_norm_gated_fwd_kernel(
+    x,  # pointer to the input
+    g,  # pointer to the gate
+    y,  # pointer to the output
+    w,  # pointer to the weights
+    b,  # pointer to the biases
+    residual,  # pointer to the residual
+    residual_out,  # pointer to the residual
+    mean,  # pointer to the mean
+    rstd,  # pointer to the 1/std
+    eps,  # epsilon to avoid division by zero
+    T,  # number of rows in x
+    H: tl.constexpr,  # number of heads
+    g_stride_n,
+    D: tl.constexpr,  # number of columns in x
+    BT: tl.constexpr,
+    BD: tl.constexpr,
+    ACTIVATION: tl.constexpr,
+    IS_RMS_NORM: tl.constexpr,
+    STORE_RESIDUAL_OUT: tl.constexpr,
+    HAS_RESIDUAL: tl.constexpr,
+    HAS_WEIGHT: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+    launch_pdl: tl.constexpr,
+):
+    i_t = tl.program_id(0)
+
+    o_d = tl.arange(0, BD)
+    m_d = o_d < D
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+        tl.extra.cuda.gdc_launch_dependents()
+
+    p_x = tl.make_block_ptr(x, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
+    b_x = tl.load(p_x, boundary_check=(0, 1)).to(tl.float32)
+    if HAS_RESIDUAL:
+        p_res = tl.make_block_ptr(
+            residual, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0)
+        )
+        b_x += tl.load(p_res, boundary_check=(0, 1)).to(tl.float32)
+    if STORE_RESIDUAL_OUT:
+        p_res_out = tl.make_block_ptr(
+            residual_out, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0)
+        )
+        tl.store(p_res_out, b_x.to(p_res_out.dtype.element_ty), boundary_check=(0, 1))
+    if not IS_RMS_NORM:
+        b_mean = tl.sum(b_x, axis=1) / D
+        p_mean = tl.make_block_ptr(mean, (T,), (1,), (i_t * BT,), (BT,), (0,))
+        tl.store(p_mean, b_mean.to(p_mean.dtype.element_ty), boundary_check=(0,))
+        b_xbar = tl.where(m_d[None, :], b_x - b_mean[:, None], 0.0)
+        b_var = tl.sum(b_xbar * b_xbar, axis=1) / D
+    else:
+        b_xbar = tl.where(m_d[None, :], b_x, 0.0)
+        b_var = tl.sum(b_xbar * b_xbar, axis=1) / D
+    b_rstd = 1 / tl.sqrt(b_var + eps)
+
+    p_rstd = tl.make_block_ptr(rstd, (T,), (1,), (i_t * BT,), (BT,), (0,))
+    tl.store(p_rstd, b_rstd.to(p_rstd.dtype.element_ty), boundary_check=(0,))
+
+    if HAS_WEIGHT:
+        b_w = tl.load(w + o_d, mask=m_d).to(tl.float32)
+    if HAS_BIAS:
+        b_b = tl.load(b + o_d, mask=m_d).to(tl.float32)
+    b_x_hat = (
+        (b_x - b_mean[:, None]) * b_rstd[:, None]
+        if not IS_RMS_NORM
+        else b_x * b_rstd[:, None]
+    )
+    b_y = b_x_hat * b_w[None, :] if HAS_WEIGHT else b_x_hat
+    if HAS_BIAS:
+        b_y = b_y + b_b[None, :]
+
+    # swish/sigmoid output gate
+    o_t = i_t * BT + tl.arange(0, BT)
+    o_g = (o_t // H) * g_stride_n + (o_t % H) * D
+    b_g = tl.load(
+        g + o_g[:, None] + o_d[None, :],
+        mask=(o_t[:, None] < T) & m_d[None, :],
+        other=0.0,
+    ).to(tl.float32)
+    if ACTIVATION == "swish" or ACTIVATION == "silu":
+        b_y = b_y * b_g * tl.sigmoid(b_g)
+    elif ACTIVATION == "sigmoid":
+        b_y = b_y * tl.sigmoid(b_g)
+
+    # Write output
+    p_y = tl.make_block_ptr(y, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
+    tl.store(p_y, b_y.to(p_y.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics(
+    {
+        "STORE_RESIDUAL_OUT": lambda args: args["residual_out"] is not None,
+        "HAS_RESIDUAL": lambda args: args["residual"] is not None,
+        "HAS_WEIGHT": lambda args: args["w"] is not None,
+        "HAS_BIAS": lambda args: args["b"] is not None,
+    }
+)
+@triton.jit
+def layer_norm_gated_fwd_kernel1(
+    x,  # pointer to the input
+    g,  # pointer to the gate
+    y,  # pointer to the output
+    w,  # pointer to the weights
+    b,  # pointer to the biases
+    residual,  # pointer to the residual
+    residual_out,  # pointer to the residual
+    mean,  # pointer to the mean
+    rstd,  # pointer to the 1/std
+    eps,  # epsilon to avoid division by zero
+    D: tl.constexpr,  # number of columns in x
+    BD: tl.constexpr,
+    ACTIVATION: tl.constexpr,
+    IS_RMS_NORM: tl.constexpr,
+    STORE_RESIDUAL_OUT: tl.constexpr,
+    HAS_RESIDUAL: tl.constexpr,
+    HAS_WEIGHT: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+    launch_pdl: tl.constexpr,
+):
+    i_t = tl.program_id(0)
+    x += i_t * D
+    y += i_t * D
+    g += i_t * D
+    if HAS_RESIDUAL:
+        residual += i_t * D
+    if STORE_RESIDUAL_OUT:
+        residual_out += i_t * D
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+        tl.extra.cuda.gdc_launch_dependents()
+
+    o_d = tl.arange(0, BD)
+    m_d = o_d < D
+    b_x = tl.load(x + o_d, mask=m_d, other=0.0).to(tl.float32)
+    if HAS_RESIDUAL:
+        b_x += tl.load(residual + o_d, mask=m_d, other=0.0).to(tl.float32)
+    if STORE_RESIDUAL_OUT:
+        tl.store(residual_out + o_d, b_x, mask=m_d)
+    if not IS_RMS_NORM:
+        b_mean = tl.sum(b_x, axis=0) / D
+        tl.store(mean + i_t, b_mean)
+        b_xbar = tl.where(m_d, b_x - b_mean, 0.0)
+        b_var = tl.sum(b_xbar * b_xbar, axis=0) / D
+    else:
+        b_xbar = tl.where(m_d, b_x, 0.0)
+        b_var = tl.sum(b_xbar * b_xbar, axis=0) / D
+    b_rstd = 1 / tl.sqrt(b_var + eps)
+    tl.store(rstd + i_t, b_rstd)
+
+    if HAS_WEIGHT:
+        b_w = tl.load(w + o_d, mask=m_d).to(tl.float32)
+    if HAS_BIAS:
+        b_b = tl.load(b + o_d, mask=m_d).to(tl.float32)
+    b_x_hat = (b_x - b_mean) * b_rstd if not IS_RMS_NORM else b_x * b_rstd
+    b_y = b_x_hat * b_w if HAS_WEIGHT else b_x_hat
+    if HAS_BIAS:
+        b_y = b_y + b_b
+
+    # swish/sigmoid output gate
+    b_g = tl.load(g + o_d, mask=m_d, other=0.0).to(tl.float32)
+    if ACTIVATION == "swish" or ACTIVATION == "silu":
+        b_y = b_y * b_g * tl.sigmoid(b_g)
+    elif ACTIVATION == "sigmoid":
+        b_y = b_y * tl.sigmoid(b_g)
+
+    # Write output
+    tl.store(y + o_d, b_y, mask=m_d)
+
+
+def layer_norm_gated_fwd(
+    x: torch.Tensor,
+    g: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    activation: str = "swish",
+    eps: float = 1e-5,
+    residual: torch.Tensor = None,
+    out_dtype: torch.dtype = None,
+    residual_dtype: torch.dtype = None,
+    is_rms_norm: bool = False,
+    H: int = 1,
+    g_stride_n: int | None = None,
+):
+    if residual is not None:
+        residual_dtype = residual.dtype
+    T, D = x.shape
+    if g_stride_n is None:
+        g_stride_n = D
+    assert T % H == 0
+    if residual is not None:
+        assert residual.shape == (T, D)
+    if weight is not None:
+        assert weight.shape == (D,)
+    if bias is not None:
+        assert bias.shape == (D,)
+    # allocate output
+    y = x if out_dtype is None else torch.empty_like(x, dtype=out_dtype)
+    if residual is not None or (
+        residual_dtype is not None and residual_dtype != x.dtype
+    ):
+        residual_out = torch.empty(T, D, device=x.device, dtype=residual_dtype)
+    else:
+        residual_out = None
+    mean = (
+        torch.empty((T,), dtype=torch.float, device=x.device)
+        if not is_rms_norm
+        else None
+    )
+    rstd = torch.empty((T,), dtype=torch.float, device=x.device)
+    # Less than 64KB per feature: enqueue fused kernel
+    MAX_FUSED_SIZE = 65536 // x.element_size()
+    BD = min(MAX_FUSED_SIZE, next_power_of_2(D))
+    if D > BD:
+        raise RuntimeError("This layer norm doesn't support feature dim >= 64KB.")
+    if D <= 512:
+        BT = 16
+        layer_norm_gated_fwd_kernel[(cdiv(T, BT),)](
+            x=x,
+            g=g,
+            y=y,
+            w=weight,
+            b=bias,
+            residual=residual,
+            residual_out=residual_out,
+            mean=mean,
+            rstd=rstd,
+            eps=eps,
+            T=T,
+            H=H,
+            g_stride_n=g_stride_n,
+            D=D,
+            BD=BD,
+            BT=BT,
+            ACTIVATION=activation,
+            IS_RMS_NORM=is_rms_norm,
+            num_warps=8,
+            launch_pdl=current_platform.is_arch_support_pdl(),
+        )
+    else:
+        layer_norm_gated_fwd_kernel1[(T,)](
+            x=x,
+            g=g,
+            y=y,
+            w=weight,
+            b=bias,
+            residual=residual,
+            residual_out=residual_out,
+            mean=mean,
+            rstd=rstd,
+            eps=eps,
+            D=D,
+            BD=BD,
+            ACTIVATION=activation,
+            IS_RMS_NORM=is_rms_norm,
+            num_warps=4,
+            launch_pdl=current_platform.is_arch_support_pdl(),
+        )
+    # residual_out is None if residual is None and residual_dtype == input_dtype
+    return y, mean, rstd, residual_out if residual_out is not None else x
+
+
+def rms_norm_gated(
+    x: torch.Tensor,
+    g: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    activation: str = "swish",
+    residual: torch.Tensor | None = None,
+    prenorm: bool = False,
+    residual_in_fp32: bool = False,
+    eps: float = 1e-6,
+):
+    x_shape_og = x.shape
+    # reshape input data into 2D tensor
+    x = x.contiguous().reshape(-1, x.shape[-1])
+    D = x.shape[-1]
+    # The tiled kernel supports row-strided gates; kernel1 does not.
+    if D <= 512:
+        H = 1 if g.ndim == 2 else g.shape[-2]
+        g = g.view(-1, H, D)
+        g_stride_n = g.stride(0)
+    else:
+        g = g.contiguous()
+        H = 1
+        g_stride_n = D
+    if residual is not None:
+        assert residual.shape == x_shape_og
+        residual = residual.contiguous().reshape(-1, residual.shape[-1])
+    residual_dtype = (
+        residual.dtype
+        if residual is not None
+        else (torch.float if residual_in_fp32 else None)
+    )
+    y, _, _, residual_out = layer_norm_gated_fwd(
+        x=x,
+        g=g,
+        weight=weight,
+        bias=bias,
+        activation=activation,
+        eps=eps,
+        residual=residual,
+        residual_dtype=residual_dtype,
+        is_rms_norm=True,
+        H=H,
+        g_stride_n=g_stride_n,
+    )
+    y = y.reshape(x_shape_og)
+    return y if not prenorm else (y, residual_out.reshape(x_shape_og))
+
+
+@CustomOp.register("fused_rms_norm_gated")
+class FusedRMSNormGated(CustomOp):
+    def __init__(
+        self,
+        hidden_size: int,
+        elementwise_affine: bool = True,
+        eps: float = 1e-5,
+        activation: str = "swish",
+        device: torch.device | None = None,
+        dtype: torch.dtype | None = None,
+    ) -> None:
+        factory_kwargs = {"device": device, "dtype": dtype}
+        super().__init__()
+
+        self.hidden_size = hidden_size
+        self.elementwise_affine = elementwise_affine
+        self.eps = eps
+        self.activation = activation
+
+        if self.activation not in ["swish", "silu", "sigmoid"]:
+            raise ValueError(f"Unsupported activation: {self.activation}")
+
+        if elementwise_affine:
+            self.weight = nn.Parameter(torch.empty(hidden_size, **factory_kwargs))
+        else:
+            self.register_parameter("weight", None)
+        self.register_parameter("bias", None)
+
+    def forward_native(
+        self,
+        x: torch.Tensor,
+        g: torch.Tensor,
+        residual: torch.Tensor | None = None,
+        prenorm: bool = False,
+        residual_in_fp32: bool = False,
+    ) -> torch.Tensor:
+        """Decomposed PyTorch ops for torch.compile/inductor fusion."""
+        # TODO(https://github.com/vllm-project/vllm/issues/36175): implement
+        # native residual/prenorm path and unify with RMSNormGated.
+        # For now, fall back to the triton kernel.
+        if residual is not None or prenorm:
+            return self.forward_cuda(x, g, residual, prenorm, residual_in_fp32)
+        x_float = x.float()
+        variance = x_float.pow(2).mean(dim=-1, keepdim=True)
+        x_normed = x_float * torch.rsqrt(variance + self.eps)
+        if self.weight is not None:
+            x_normed = x_normed * self.weight.float()
+        g_float = g.float()
+        if self.activation in ("swish", "silu"):
+            out = x_normed * g_float * torch.sigmoid(g_float)
+        else:  # sigmoid
+            out = x_normed * torch.sigmoid(g_float)
+        return out.to(x.dtype)
+
+    def forward_cuda(
+        self,
+        x: torch.Tensor,
+        g: torch.Tensor,
+        residual: torch.Tensor | None = None,
+        prenorm: bool = False,
+        residual_in_fp32: bool = False,
+    ) -> torch.Tensor:
+        return rms_norm_gated(
+            x,
+            g,
+            self.weight,
+            self.bias,
+            self.activation,
+            residual=residual,
+            eps=self.eps,
+            prenorm=prenorm,
+            residual_in_fp32=residual_in_fp32,
+        )

--- a/vllm/v1/worker/mamba_utils.py
+++ b/vllm/v1/worker/mamba_utils.py
@@ -150,7 +150,7 @@ def _copy_mamba_state_block(
     tl.store(tail_dst + tail_off, tail_data, mask=tail_mask)
 
 
-@triton.jit
+@triton.jit(do_not_specialize=["num_reqs"])
 def postprocess_mamba_fused_kernel(
     # Decision inputs (per-request)
     num_accepted_tokens_ptr,
@@ -280,7 +280,7 @@ def postprocess_mamba_fused_kernel(
     )
 
 
-@triton.jit
+@triton.jit(do_not_specialize=["num_reqs"])
 def preprocess_mamba_align_fused_kernel(
     idx_mapping_ptr,
     state_idx_ptr,
@@ -326,7 +326,7 @@ def preprocess_mamba_align_fused_kernel(
     tl.store(num_accepted_tokens_ptr + req_indices, 1, mask=mask & should_reset)
 
 
-@triton.jit
+@triton.jit(do_not_specialize=["num_reqs"])
 def precopy_mamba_align_fused_kernel(
     # Per-request-slot inputs (indexed by req_idx via idx_mapping), produced by
     # the V2 fused align preprocess kernel for the current step:


### PR DESCRIPTION
## Purpose

Add KDA kernels for Kimi-K3 #50000

NVIDIA
- Fully fused KDA decode (conv+KDA+norm)
- Vendor FlashKDA (https://github.com/vllm-project/FlashKDA/tree/dev) with PyTorch stable ABI
- Vendor FLA kernels (`models/kimi_k3/nvidia/third_party/kda`)
- Dedicated KDA layer for Kimi-K3 (`models/kimi_k3/nvidia/kda.py`), with dedicated metadata builder
- Move Gated RMSNorm

AMD
- Vendor FLA kernels (`models/kimi_k3/amd/third_party/kda`)

Other kernels involved in KDA codepath: remove specialization on certain arguments to avoid recompilation, add PDL
- `_causal_conv1d_fwd_kernel`
- `_causal_conv1d_update_kernel`
- `postprocess_mamba_fused_kernel`
- `preprocess_mamba_align_fused_kernel`
- `precopy_mamba_align_fused_kernel`

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

