### PR TITLE
[Rust frontend] treat stream_interval as no-op instead of unsupported

### DIFF
--- a/rust/src/cmd/src/cli/unsupported.rs
+++ b/rust/src/cmd/src/cli/unsupported.rs
@@ -334,8 +334,10 @@ pub struct EngineUnsupportedArgs {
     pub collect_detailed_traces: Option<Unsupported>,
 
     /// The interval (or buffer size) for streaming in terms of token length.
-    #[arg(long)]
-    pub stream_interval: Option<Unsupported>,
+    /// Accepted as a no-op: the Rust frontend manages its own SSE batching
+    /// independently and does not use this Python engine-side knob.
+    #[arg(long, hide = true)]
+    pub stream_interval: Option<Noop>,
 
     /// Structured outputs configuration.
     #[arg(long)]


### PR DESCRIPTION
stream_interval controls how many tokens the Python engine batches before flushing an SSE event. The Rust frontend manages its own SSE batching independently, so it does not need this knob, but crashing with exit code 2 when it is present prevents users who set stream_interval in their vllm serve config from using the Rust frontend at all.

Change stream_interval from Unsupported (hard error) to Noop (warn and ignore), matching the treatment of structured_outputs_config and enable_auto_tool_choice.

## Test Plan
- Existing unsupported-arg tests in `rust/src/cmd/src/cli/tests.rs` pass
- `vllm serve <model> --stream-interval 10` no longer crashes the Rust frontend