### PR TITLE
[Build] Fix DeepEP CUDA driver stub linking

### DIFF
--- a/tools/ep_kernels/install_python_libraries.sh
+++ b/tools/ep_kernels/install_python_libraries.sh
@@ -197,6 +197,21 @@ do_build() {
 #endif' csrc/kernels/backend/symmetric.hpp
     fi
 
+    if [[ "$name" == "DeepEP" ]]; then
+        # DeepEP links against the CUDA driver API in driverless build images.
+        local cuda_driver_stub
+        local cuda_driver_stub_dir
+        cuda_driver_stub=$(
+            find -H "$CUDA_HOME" -path "*/stubs/libcuda.so" -print -quit
+        )
+        if [[ -z "$cuda_driver_stub" ]]; then
+            echo "CUDA driver stub not found under $CUDA_HOME" >&2
+            exit 1
+        fi
+        cuda_driver_stub_dir=$(dirname "$cuda_driver_stub")
+        export LIBRARY_PATH="${cuda_driver_stub_dir}${LIBRARY_PATH:+:$LIBRARY_PATH}"
+    fi
+
     if [ "$MODE" = "install" ]; then
         echo "Installing $name into environment"
         eval "$extra_env" uv pip install --no-build-isolation -vvv .


### PR DESCRIPTION
## Summary

- discover the CUDA toolkit's `libcuda.so` driver stub before building DeepEP
- prepend its architecture-specific directory to `LIBRARY_PATH`
- fail early with a clear message if the toolkit stub is missing

## Root cause

#45321 updated the pinned DeepEP revision to `d4f41e4e93`. That DeepEP revision adds `-lcuda` when linking its extension, but the manylinux wheel builders do not contain a real NVIDIA driver library in their normal linker search path.

The first observed failure was earlier in compilation because the manylinux headers did not define `SYS_pidfd_open` and `SYS_pidfd_getfd`. #49814 supplied those definitions and allowed all DeepEP sources to compile, but it did not change the final linker search path. The build then advanced to the final link and failed with `ld: cannot find -lcuda`.

This change links against the CUDA toolkit's driver stub during wheel construction. The stub is used only at link time; the built extension resolves the real NVIDIA driver library at runtime.

## Duplicate-work check

I searched open vLLM PRs for `49814`, `DeepEP libcuda wheel`, and `DeepEP CUDA stub`, and open issues for `DeepEP libcuda wheel`. No open PR or issue addresses this release-wheel linker failure. The nearest search results concern unrelated DeepSeek model support.

## Validation

- `bash -n tools/ep_kernels/install_python_libraries.sh`
- `shellcheck tools/ep_kernels/install_python_libraries.sh`
- synthetic symlinked `CUDA_HOME` fixture covering architecture-specific `targets/*/lib/stubs/libcuda.so` discovery
- repository commit hooks, including shell lint, Docker dependency graph validation, and DCO sign-off
- [`release-v2` build #4388](https://buildkite.com/vllm/release-v2/builds/4388), commit `1fca23e6bdf531c8ea71d95e6bd90f841990ae84`:
  - [CUDA 13 x86_64 wheel](https://buildkite.com/vllm/release-v2/builds/4388#019fa7ad-53f3-4a62-b796-46cb28c019cc): passed, exit 0; built the DeepEP wheel and full vLLM wheel
  - [CUDA 13 aarch64 wheel](https://buildkite.com/vllm/release-v2/builds/4388#019fa7ad-53f1-47b7-b9d2-96ff7c358d1b): passed, exit 0; built the DeepEP wheel and full vLLM wheel

Model evaluation is not applicable because this changes only the build-time linker search path and does not change model output or serving behavior.

## AI assistance disclosure

AI assistance was used to investigate the Buildkite regression, prepare this change, run validation, and draft this PR. The human submitter must review every changed line and understand and defend the change before this draft is marked ready for review.