### PR TITLE
[Misc][CI]Fix ci test_linear test failed

### DIFF
--- a/tests/models/transformers/fusers/test_linear.py
+++ b/tests/models/transformers/fusers/test_linear.py
@@ -270,7 +270,10 @@ class PackedQKVAttention(nn.Module):
             .unsqueeze(1)
             .split((self.embed_dim, self.kv_dim, self.kv_dim), dim=3)
         )
-        q = q.view(*input_shape, -1, self.head_dim).transpose(1, 2)
+        q, k, v = (
+            tensor.view(*input_shape, -1, self.head_dim).transpose(1, 2)
+            for tensor in (q, k, v)
+        )
         if past_key_values is not None:
             k, v = past_key_values.update(k, v, self.layer_idx)
         attention_interface = ALL_ATTENTION_FUNCTIONS.get_interface(


### PR DESCRIPTION



## Purpose

Fix: https://buildkite.com/vllm/ci/builds/80700/canvas?jid=019fa77a-f32e-44a1-ae8d-59a0037aa869&tab=output
```
FAILED models/transformers/fusers/test_linear.py::test_detects_and_rewrites_packed_qkv[2] - RuntimeError: The size of tensor a (16) must match the size of tensor b (8) at non-singleton dimension 1
```

This PR [vllm-project/vllm#49987](https://github.com/vllm-project/vllm/pull/49987/)  introduced PackedQKVAttention with the GPTBigCode packed MQA layout, where only Q was reshaped because K and V each contained a single head. The same test also covers kv_heads=2, where leaving K and V flattened exposes the concatenated KV width as head_dim and makes the value-padding path crop V before packed QKV fusion is exercised.
    
Reshape Q, K, and V uniformly so both MQA and multi-KV-head cases use the expected `[batch, heads, sequence, head_dim]` layout.

## Test Plan

```
$ .venv/bin/python -m pytest ./tests/models/transformers/fusers/test_linear.py::test_detects_and_rewrites_packed_qkv
=========================================== test session starts ===========================================
platform linux -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0
rootdir: /home/jovyan/code/vllm
configfile: pyproject.toml
plugins: anyio-4.13.0
collected 2 items                                                                                         

tests/models/transformers/fusers/test_linear.py ..                                                  [100%]

============================================ warnings summary =============================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

.venv/lib/python3.12/site-packages/torch/jit/_script.py:365: 14 warnings
  /home/jovyan/code/vllm/.venv/lib/python3.12/site-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================== 2 passed, 16 warnings in 5.90s ======================================
```

## Test Result

unit test passed

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

