### PR TITLE
[Core][Perf] Skip no-op block-hasher calls between full-block boundaries

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -698,6 +698,50 @@ def test_request_block_hasher(hash_fn):
     assert block_hashes[1] == hash_fn((block_hashes[0], (3, 4, 5), (("hash2", 0),)))
 
 
+def test_request_skips_block_hasher_between_full_blocks():
+    block_size = 4
+    block_hasher = get_request_block_hasher(block_size, sha256)
+
+    class CountingBlockHasher:
+        def __init__(self) -> None:
+            self.hash_block_size = block_hasher.hash_block_size
+            self.num_calls = 0
+
+        def __call__(self, request: Request) -> list[BlockHash]:
+            self.num_calls += 1
+            return block_hasher(request)
+
+    counting_hasher = CountingBlockHasher()
+    sampling_params = SamplingParams(max_tokens=16)
+    sampling_params.update_from_generation_config({}, eos_token_id=100)
+    request = Request(
+        request_id="0",
+        prompt_token_ids=[0],
+        sampling_params=sampling_params,
+        pooling_params=None,
+        block_hasher=counting_hasher,
+    )
+
+    assert counting_hasher.num_calls == 0
+    request.append_output_token_ids([1, 2])
+    assert counting_hasher.num_calls == 0
+
+    request.append_output_token_ids(3)
+    assert counting_hasher.num_calls == 1
+    assert len(request.block_hashes) == 1
+
+    # A single update can cross multiple block boundaries.
+    request.append_output_token_ids([4, 5, 6, 7, 8])
+    assert counting_hasher.num_calls == 2
+    assert len(request.block_hashes) == 2
+
+    request.append_output_token_ids([9, 10])
+    assert counting_hasher.num_calls == 2
+    request.append_output_token_ids(11)
+    assert counting_hasher.num_calls == 3
+    assert len(request.block_hashes) == 3
+
+
 @pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor])
 def test_hash_tokens_different_mm_input(hash_fn):
     request1 = make_request(

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass, replace
 from functools import partial
-from typing import Any, NamedTuple, NewType, TypeAlias, cast, overload
+from typing import Any, NamedTuple, NewType, Protocol, TypeAlias, cast, overload
 
 from vllm import envs
 from vllm.config import VllmConfig
@@ -688,12 +688,20 @@ def resolve_kv_cache_block_sizes(
     return scheduler_block_size, hash_block_size
 
 
+class RequestBlockHasher(Protocol):
+    """Callable that incrementally computes block hashes for a request."""
+
+    hash_block_size: int
+
+    def __call__(self, request: Request) -> list[BlockHash]: ...
+
+
 def get_request_block_hasher(
     hash_block_size: int,
     caching_hash_fn: Callable[[Any], bytes],
-) -> Callable[[Request], list[BlockHash]]:
+) -> RequestBlockHasher:
     """
-    Returns a function which computes the list of un-computed block hashes
+    Returns a callable which computes the list of un-computed block hashes
     of a request.
 
     Hashes are computed at ``hash_block_size`` granularity and chained over the
@@ -705,10 +713,6 @@ def get_request_block_hasher(
     def request_block_hasher(request: Request) -> list[BlockHash]:
         start_token_idx = len(request.block_hashes) * hash_block_size
         num_tokens = request.num_tokens
-
-        if start_token_idx + hash_block_size > num_tokens:
-            # Early stop when there no new full blocks created.
-            return []
 
         curr_mm_idx = 0
         if start_token_idx > 0:
@@ -745,7 +749,9 @@ def get_request_block_hasher(
 
         return new_block_hashes
 
-    return request_block_hasher
+    block_hasher = cast(RequestBlockHasher, request_block_hasher)
+    block_hasher.hash_block_size = hash_block_size
+    return block_hasher
 
 
 def _check_enough_kv_cache_memory(

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -201,6 +201,13 @@ class Request:
         # reference cycle (Request -> partial -> Request) that prevents
         # immediate garbage collection via reference counting.
         self._block_hasher: Callable[[Request], list[BlockHash]] | None = block_hasher
+        hash_block_size = getattr(block_hasher, "hash_block_size", None)
+        # Only sizes greater than 1 have incomplete-token updates to skip.
+        self._hash_block_size: int | None = (
+            hash_block_size
+            if isinstance(hash_block_size, int) and hash_block_size > 1
+            else None
+        )
         self.update_block_hashes()
 
         self.skip_reading_prefix_cache = self.get_skip_reading_prefix_cache()
@@ -256,8 +263,18 @@ class Request:
 
     def update_block_hashes(self) -> None:
         """Compute block hashes for any new full blocks and append them."""
-        if self._block_hasher is not None:
-            self.block_hashes.extend(self._block_hasher(self))
+        block_hasher = self._block_hasher
+        if block_hasher is None:
+            return
+
+        block_size = self._hash_block_size
+        if (
+            block_size is not None
+            and (len(self.block_hashes) + 1) * block_size > self.num_tokens
+        ):
+            return
+
+        self.block_hashes.extend(block_hasher(self))
 
     @property
     def use_structured_output(self) -> bool:


### PR DESCRIPTION
## Purpose

`Request.append_output_token_ids()` updates block hashes after every generated
token. The request block hasher therefore runs on every decode update even
though it can only produce a hash when the token count reaches the next full
hash block. Between boundaries, the call always returns an empty list.

An existing priority-scheduler stress test produced about 1.2 million
`request_block_hasher` calls, which made this repeated empty-call path visible
in CPU profiling.

This change:

- exposes the hash granularity on the request block-hasher callable;
- lets `Request` skip hasher calls until the next complete block exists;
- preserves the original path for block size 1 and custom hash callables that
  do not expose a hash block size;
- adds a regression test for incomplete updates, exact boundaries, and a
  multi-token update crossing more than one boundary.

The generated block hashes and model outputs are unchanged.

## Duplicate-work check

I searched open and closed PRs for `block hasher`, `block hashing`,
`append_output_token_ids`, `incomplete block hash`, and related decode
performance terms. I found no PR implementing this optimization.

Related open PRs #49448 and #49619 address correctness when streaming-session
updates replace already-hashed tokens. They do not avoid the per-token empty
hasher calls addressed here.

## Test Plan

```bash
pytest -q tests/v1/core/test_kv_cache_utils.py

pytest -q \
  tests/v1/core/test_scheduler.py \
  tests/v1/core/test_prefix_caching.py \
  tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py \
  tests/v1/streaming_input/test_scheduler_streaming.py

pytest -q \
  'tests/v1/core/test_priority_scheduler_random.py::test_priority_scheduling_blast[standard-None-True]'

pre-commit run --files \
  vllm/v1/core/kv_cache_utils.py \
  vllm/v1/request.py \
  tests/v1/core/test_kv_cache_utils.py
```

The microbenchmark compared `origin/main` at `88402a41c` with this change. Each
trial appended 500,000 tokens one at a time to a `Request` using SHA-256 block
hashing. The table reports the median of nine trials.

## Test Result

- KV-cache utility tests: `74 passed`
- Scheduler, prefix-cache, partial-prefix-cache, and streaming-input tests:
  `244 passed`
- Priority scheduler stress test: `1 passed`
- Relevant pre-commit hooks, including Ruff and mypy: passed

| Hash block size | `main` | This PR | Change |
| ---: | ---: | ---: | ---: |
| 1 | 1.1053 s | 1.1030 s | 0.2% faster |
| 16 | 0.2263 s | 0.2021 s | 10.7% faster |
| 32 | 0.1935 s | 0.1614 s | 16.6% faster |

No GPU or model evaluation was run because this change only gates a Python
control-plane hash call and does not affect model execution or output.

## AI assistance

AI assistance was used for profiling and test execution.