### PR TITLE
[Docs] Fix ECExampleConnector references in disagg_encoder docs

### DIFF
--- a/docs/features/disagg_encoder.md
+++ b/docs/features/disagg_encoder.md
@@ -32,7 +32,7 @@ Design doc: <https://docs.google.com/document/d/1aed8KtC6XkXtdoV87pWT0a8OJlZ-Cpn
 
 ## 2  Usage Example
 
-The current reference pathway is **ExampleConnector**.  
+The current reference pathway is **ECExampleConnector** (the EC counterpart of `ExampleConnector`, renamed from `ECSharedStorageConnector` in [#30201](https://github.com/vllm-project/vllm/pull/30201)).  
 Below ready-to-run scripts shows the workflow:
 
 1 Encoder instance + 1 PD instance:

--- a/examples/disaggregated/disaggregated_encoder/README.md
+++ b/examples/disaggregated/disaggregated_encoder/README.md
@@ -57,7 +57,7 @@ The vllm instances and `disagg_encoder_proxy` supports local URIs with ```{"url"
 
 ## EC connector and KV transfer
 
-The `ECExampleonnector` is used to store the encoder cache on local disk and facilitate transfer. To enable the encoder disaggregation feature, add the following configuration:
+The `ECExampleConnector` is used to store the encoder cache on local disk and facilitate transfer. To enable the encoder disaggregation feature, add the following configuration:
 
 ```bash
 # Add to encoder instance: 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_integration/vllm_v1_adapter.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_integration/vllm_v1_adapter.py
@@ -1232,7 +1232,7 @@ class LMCacheConnectorV1Impl:
         """
         Update KVConnector state after temporary buffer alloc.
 
-        For SharedStorageConnector, update _request_needs_load
+        For ExampleConnector, update _request_needs_load
         if the CacheManager this allocated blocks for us.
         """
 


### PR DESCRIPTION
## Purpose

#30201 renamed `SharedStorageConnector`/`ECSharedStorageConnector` to `ExampleConnector`/`ECExampleConnector`. Three in-repo references still used the old/wrong name:

- `docs/features/disagg_encoder.md` pointed readers at the generic `ExampleConnector` instead of the actually-registered `ECExampleConnector` (see `vllm/distributed/ec_transfer/ec_connector/factory.py`).
- The `vllm_v1_adapter.py` docstring still said `SharedStorageConnector`.
- `examples/disaggregated/disaggregated_encoder/README.md` had a typo, `ECExampleonnector`.

Note: the same rename also left `docs/features/disagg_prefill.md` out of date, but that file is already being fixed by #49663 (open, reviewed), so this PR intentionally does not touch it to avoid duplicating that work.

Fixes the disagg_encoder-related portion of #49399.

## Test Plan

- `npx --yes markdownlint-cli2@0.21.0 docs/features/disagg_encoder.md examples/disaggregated/disaggregated_encoder/README.md`
- `python3 -c "import ast; ast.parse(open('vllm/distributed/kv_transfer/kv_connector/v1/lmcache_integration/vllm_v1_adapter.py').read())"`
- `git diff --check HEAD~1`
- Manual check against `vllm/distributed/ec_transfer/ec_connector/factory.py` to confirm `ECExampleConnector` is the registered name.

## Test Result

- markdownlint-cli2: `Summary: 0 error(s)` on both files.
- Python syntax check: passes (docstring-only change).
- `git diff --check`: no new whitespace errors introduced by this diff.
- `ECExampleConnector` confirmed as the name registered in `ECConnectorFactory.register_connector(...)`.