### PR TITLE
[Core] Add KV event state snapshots

### DIFF
--- a/tests/distributed/conftest.py
+++ b/tests/distributed/conftest.py
@@ -9,7 +9,7 @@ import pytest
 import zmq
 
 from vllm.config.kv_events import KVEventsConfig
-from vllm.distributed.kv_events import EventPublisherFactory
+from vllm.distributed.kv_events import EventPublisherFactory, ZmqEventPublisher
 
 from .test_events import SampleBatch
 
@@ -135,6 +135,17 @@ class MockSubscriber:
 
         self.replay_sockets[socket_idx].send_multipart(
             [b"", start_seq.to_bytes(8, "big")]
+        )
+
+    def request_snapshot(self, socket_idx: int = 0) -> None:
+        """Request a complete KV cache state snapshot."""
+        if not self.replay_sockets:
+            raise ValueError("Replay sockets not initialized")
+        if socket_idx >= len(self.replay_sockets):
+            raise ValueError(f"Invalid socket index {socket_idx}")
+
+        self.replay_sockets[socket_idx].send_multipart(
+            [b"", ZmqEventPublisher.SNAPSHOT_REQUEST]
         )
 
     def receive_replay(self, socket_idx: int = 0) -> list[tuple[int, SampleBatch]]:

--- a/tests/distributed/test_events.py
+++ b/tests/distributed/test_events.py
@@ -7,9 +7,16 @@ import msgspec
 import pytest
 
 from vllm.distributed.kv_events import (
+    MEDIUM_CPU,
+    MEDIUM_GPU,
+    AllBlocksCleared,
+    BlockRemoved,
+    BlockStored,
     EventBatch,
     EventPublisherFactory,
+    KVEventBatch,
     NullEventPublisher,
+    ZmqEventPublisher,
 )
 
 DP_RANK = 0
@@ -36,6 +43,25 @@ def create_test_events(count: int) -> SampleBatch:
     """Create a batch of test events"""
     events = [EventSample(id=i, value=f"test-{i}") for i in range(count)]
     return SampleBatch(ts=time.time(), events=events)
+
+
+def create_stored_event(
+    block_hashes: list[int],
+    *,
+    medium: str = MEDIUM_GPU,
+    group_idx: int = 0,
+) -> BlockStored:
+    block_size = 4
+    return BlockStored(
+        block_hashes=block_hashes,
+        parent_block_hash=None,
+        token_ids=list(range(len(block_hashes) * block_size)),
+        block_size=block_size,
+        lora_id=None,
+        medium=medium,
+        lora_name=None,
+        group_idx=group_idx,
+    )
 
 
 def test_basic_publishing(publisher, subscriber):
@@ -112,6 +138,138 @@ def test_replay_includes_topic(publisher, subscriber, publisher_config):
     assert len(replayed) == 5, f"Expected 5 replayed messages, got {len(replayed)}"
     seqs = [seq for seq, _ in replayed]
     assert seqs == list(range(5)), "Replayed sequences should be 0-4"
+
+
+def test_snapshot_recovers_state_after_replay_buffer_expires(publisher_config):
+    publisher_config.buffer_steps = 2
+    publisher = EventPublisherFactory.create(publisher_config, DP_RANK)
+    assert isinstance(publisher, ZmqEventPublisher)
+    publisher.SNAPSHOT_BATCH_SIZE = 2
+
+    from .conftest import MockSubscriber
+
+    subscriber = MockSubscriber(
+        publisher_config.endpoint,
+        publisher_config.replay_endpoint,
+        publisher_config.topic,
+        decode_type=KVEventBatch,
+    )
+
+    try:
+        time.sleep(0.1)
+        batches = [
+            KVEventBatch(
+                ts=time.time(),
+                events=[create_stored_event([101, 102, 103])],
+            ),
+            KVEventBatch(
+                ts=time.time(),
+                events=[
+                    BlockRemoved(
+                        block_hashes=[102],
+                        medium=MEDIUM_GPU,
+                        group_idx=0,
+                    )
+                ],
+            ),
+            KVEventBatch(
+                ts=time.time(),
+                events=[create_stored_event([104])],
+            ),
+            KVEventBatch(ts=time.time(), events=[]),
+            KVEventBatch(ts=time.time(), events=[]),
+        ]
+        for batch in batches:
+            publisher.publish(batch)
+            assert subscriber.receive_one(timeout=1000) is not None
+
+        subscriber.request_replay(0)
+        assert [seq for seq, _ in subscriber.receive_replay()] == [3, 4]
+
+        subscriber.request_snapshot()
+        snapshot = subscriber.receive_replay()
+        assert snapshot
+        assert len(snapshot) == 2
+        assert {seq for seq, _ in snapshot} == {5}
+        assert all(batch.data_parallel_rank == DP_RANK for _, batch in snapshot)
+
+        active_blocks: set[int] = set()
+        snapshot_events = [event for _, batch in snapshot for event in batch.events]
+        assert isinstance(snapshot_events[0], AllBlocksCleared)
+        for event in snapshot_events:
+            if isinstance(event, AllBlocksCleared):
+                active_blocks.clear()
+            elif isinstance(event, BlockStored):
+                active_blocks.update(event.block_hashes)
+            elif isinstance(event, BlockRemoved):
+                active_blocks.difference_update(event.block_hashes)
+        assert active_blocks == {101, 103, 104}
+
+        publisher.publish(KVEventBatch(ts=time.time(), events=[AllBlocksCleared()]))
+        assert subscriber.receive_one(timeout=1000) is not None
+        subscriber.request_snapshot()
+        cleared_snapshot = subscriber.receive_replay()
+        cleared_events = [
+            event for _, batch in cleared_snapshot for event in batch.events
+        ]
+        assert len(cleared_events) == 1
+        assert isinstance(cleared_events[0], AllBlocksCleared)
+    finally:
+        publisher.shutdown()
+        subscriber.close()
+
+
+def test_snapshot_tracks_blocks_by_medium(publisher_config):
+    publisher = EventPublisherFactory.create(publisher_config, DP_RANK)
+    assert isinstance(publisher, ZmqEventPublisher)
+
+    from .conftest import MockSubscriber
+
+    subscriber = MockSubscriber(
+        publisher_config.endpoint,
+        publisher_config.replay_endpoint,
+        publisher_config.topic,
+        decode_type=KVEventBatch,
+    )
+
+    try:
+        time.sleep(0.1)
+        publisher.publish(
+            KVEventBatch(
+                ts=time.time(),
+                events=[
+                    create_stored_event([101], medium=MEDIUM_GPU),
+                    create_stored_event([101], medium=MEDIUM_CPU),
+                ],
+            )
+        )
+        assert subscriber.receive_one(timeout=1000) is not None
+        publisher.publish(
+            KVEventBatch(
+                ts=time.time(),
+                events=[
+                    BlockRemoved(
+                        block_hashes=[101],
+                        medium=MEDIUM_GPU,
+                        group_idx=0,
+                    )
+                ],
+            )
+        )
+        assert subscriber.receive_one(timeout=1000) is not None
+
+        subscriber.request_snapshot()
+        snapshot_events = [
+            event for _, batch in subscriber.receive_replay() for event in batch.events
+        ]
+        stored_events = [
+            event for event in snapshot_events if isinstance(event, BlockStored)
+        ]
+        assert len(stored_events) == 1
+        assert stored_events[0].medium == MEDIUM_CPU
+    finally:
+        publisher.shutdown()
+        subscriber.close()
 
 
 def test_buffer_limit(publisher, subscriber, publisher_config):

--- a/tests/distributed/test_events.py
+++ b/tests/distributed/test_events.py
@@ -471,6 +471,26 @@ def test_snapshot_scopes_removal_by_ownership():
     assert stores[0].ownership == "secondary"
 
 
+def test_snapshot_treats_none_ownership_as_primary():
+    state = _KVCacheState()
+    state.update(
+        [
+            create_stored_event([101]),
+            create_stored_event([101], ownership="secondary"),
+            BlockRemoved(
+                block_hashes=[101],
+                medium=MEDIUM_GPU,
+                group_idx=0,
+            ),
+        ]
+    )
+
+    stores = snapshot_stores(state)
+
+    assert len(stores) == 1
+    assert stores[0].ownership == "secondary"
+
+
 def test_snapshot_preserves_session_id():
     state = _KVCacheState()
     state.update([create_stored_event([101], session_id="session-1")])

--- a/tests/distributed/test_events.py
+++ b/tests/distributed/test_events.py
@@ -310,11 +310,15 @@ def test_snapshot_retains_removed_parent_for_active_child():
         [
             create_stored_event([101]),
             create_stored_event([102], parent_block_hash=101),
+        ]
+    )
+    state.update(
+        [
             BlockRemoved(
                 block_hashes=[101],
                 medium=MEDIUM_GPU,
                 group_idx=0,
-            ),
+            )
         ]
     )
 
@@ -336,6 +340,71 @@ def test_snapshot_retains_removed_parent_for_active_child():
     )
 
     assert parent_idx < child_idx < remove_parent_idx
+
+
+def test_snapshot_does_not_remove_restored_part_of_multiblock_store():
+    state = _KVCacheState()
+    state.update(
+        [
+            create_stored_event([101, 102]),
+            create_stored_event([101], session_id="restored"),
+        ]
+    )
+
+    events = state.snapshot_events()
+    removed_hashes = {
+        block_hash
+        for event in events
+        if isinstance(event, BlockRemoved)
+        for block_hash in event.block_hashes
+    }
+
+    assert 101 not in removed_hashes
+
+
+def test_snapshot_discards_fully_removed_dependency_chain():
+    state = _KVCacheState()
+    state.update(
+        [
+            create_stored_event([101]),
+            create_stored_event([102], parent_block_hash=101),
+        ]
+    )
+    state.update(
+        [
+            BlockRemoved(
+                block_hashes=[101, 102],
+                medium=MEDIUM_GPU,
+                group_idx=0,
+            )
+        ]
+    )
+
+    events = state.snapshot_events()
+
+    assert len(events) == 1
+    assert isinstance(events[0], AllBlocksCleared)
+
+
+def test_snapshot_rejects_missing_parent():
+    state = _KVCacheState()
+    state.update([create_stored_event([102], parent_block_hash=101)])
+
+    with pytest.raises(ValueError, match="parent block 101 is unavailable"):
+        state.snapshot_events()
+
+
+def test_snapshot_rejects_dependency_cycle():
+    state = _KVCacheState()
+    state.update(
+        [
+            create_stored_event([101], parent_block_hash=102),
+            create_stored_event([102], parent_block_hash=101),
+        ]
+    )
+
+    with pytest.raises(ValueError, match="cyclic dependencies"):
+        state.snapshot_events()
 
 
 def test_snapshot_scopes_removal_by_ownership():

--- a/tests/distributed/test_events.py
+++ b/tests/distributed/test_events.py
@@ -17,6 +17,7 @@ from vllm.distributed.kv_events import (
     KVEventBatch,
     NullEventPublisher,
     ZmqEventPublisher,
+    _KVCacheState,
 )
 
 DP_RANK = 0
@@ -48,20 +49,33 @@ def create_test_events(count: int) -> SampleBatch:
 def create_stored_event(
     block_hashes: list[int],
     *,
+    parent_block_hash: int | None = None,
     medium: str = MEDIUM_GPU,
     group_idx: int = 0,
+    locality: str | None = None,
+    ownership: str | None = None,
+    session_id: str | None = None,
 ) -> BlockStored:
     block_size = 4
     return BlockStored(
         block_hashes=block_hashes,
-        parent_block_hash=None,
+        parent_block_hash=parent_block_hash,
         token_ids=list(range(len(block_hashes) * block_size)),
         block_size=block_size,
         lora_id=None,
         medium=medium,
         lora_name=None,
         group_idx=group_idx,
+        locality=locality,
+        ownership=ownership,
+        session_id=session_id,
     )
+
+
+def snapshot_stores(state: _KVCacheState) -> list[BlockStored]:
+    return [
+        event for event in state.snapshot_events() if isinstance(event, BlockStored)
+    ]
 
 
 def test_basic_publishing(publisher, subscriber):
@@ -270,6 +284,88 @@ def test_snapshot_tracks_blocks_by_medium(publisher_config):
     finally:
         publisher.shutdown()
         subscriber.close()
+
+
+def test_snapshot_orders_restored_parent_before_existing_child():
+    state = _KVCacheState()
+    state.update(
+        [
+            create_stored_event([101]),
+            create_stored_event([102], parent_block_hash=101),
+            create_stored_event([101], session_id="restored-parent"),
+        ]
+    )
+
+    stores = snapshot_stores(state)
+    parent_idx = next(i for i, event in enumerate(stores) if 101 in event.block_hashes)
+    child_idx = next(i for i, event in enumerate(stores) if 102 in event.block_hashes)
+
+    assert parent_idx < child_idx
+    assert stores[parent_idx].session_id == "restored-parent"
+
+
+def test_snapshot_retains_removed_parent_for_active_child():
+    state = _KVCacheState()
+    state.update(
+        [
+            create_stored_event([101]),
+            create_stored_event([102], parent_block_hash=101),
+            BlockRemoved(
+                block_hashes=[101],
+                medium=MEDIUM_GPU,
+                group_idx=0,
+            ),
+        ]
+    )
+
+    events = state.snapshot_events()
+    parent_idx = next(
+        i
+        for i, event in enumerate(events)
+        if isinstance(event, BlockStored) and 101 in event.block_hashes
+    )
+    child_idx = next(
+        i
+        for i, event in enumerate(events)
+        if isinstance(event, BlockStored) and 102 in event.block_hashes
+    )
+    remove_parent_idx = next(
+        i
+        for i, event in enumerate(events)
+        if isinstance(event, BlockRemoved) and 101 in event.block_hashes
+    )
+
+    assert parent_idx < child_idx < remove_parent_idx
+
+
+def test_snapshot_scopes_removal_by_ownership():
+    state = _KVCacheState()
+    state.update(
+        [
+            create_stored_event([101], ownership="primary"),
+            create_stored_event([101], ownership="secondary"),
+            BlockRemoved(
+                block_hashes=[101],
+                medium=MEDIUM_GPU,
+                group_idx=0,
+                ownership="primary",
+            ),
+        ]
+    )
+
+    stores = snapshot_stores(state)
+
+    assert len(stores) == 1
+    assert stores[0].ownership == "secondary"
+
+
+def test_snapshot_preserves_session_id():
+    state = _KVCacheState()
+    state.update([create_stored_event([101], session_id="session-1")])
+
+    [store] = snapshot_stores(state)
+
+    assert store.session_id == "session-1"
 
 
 def test_buffer_limit(publisher, subscriber, publisher_config):

--- a/tests/distributed/test_events.py
+++ b/tests/distributed/test_events.py
@@ -286,6 +286,49 @@ def test_snapshot_tracks_blocks_by_medium(publisher_config):
         subscriber.close()
 
 
+def test_snapshot_orders_dependencies_across_batches(publisher_config):
+    publisher = EventPublisherFactory.create(publisher_config, DP_RANK)
+    assert isinstance(publisher, ZmqEventPublisher)
+    publisher.SNAPSHOT_BATCH_SIZE = 1
+
+    from .conftest import MockSubscriber
+
+    subscriber = MockSubscriber(
+        publisher_config.endpoint,
+        publisher_config.replay_endpoint,
+        publisher_config.topic,
+        decode_type=KVEventBatch,
+    )
+
+    try:
+        time.sleep(0.1)
+        publisher.publish(
+            KVEventBatch(
+                ts=time.time(),
+                events=[
+                    create_stored_event([101]),
+                    create_stored_event([102], parent_block_hash=101),
+                    create_stored_event([101], session_id="restored-parent"),
+                ],
+            )
+        )
+        assert subscriber.receive_one(timeout=1000) is not None
+
+        subscriber.request_snapshot()
+        snapshot = subscriber.receive_replay()
+        assert len(snapshot) == 3
+        snapshot_events = [event for _, batch in snapshot for event in batch.events]
+
+        assert isinstance(snapshot_events[0], AllBlocksCleared)
+        assert isinstance(snapshot_events[1], BlockStored)
+        assert snapshot_events[1].block_hashes == [101]
+        assert isinstance(snapshot_events[2], BlockStored)
+        assert snapshot_events[2].block_hashes == [102]
+    finally:
+        publisher.shutdown()
+        subscriber.close()
+
+
 def test_snapshot_orders_restored_parent_before_existing_child():
     state = _KVCacheState()
     state.update(

--- a/vllm/config/kv_events.py
+++ b/vllm/config/kv_events.py
@@ -25,7 +25,11 @@ class KVEventsConfig:
     """
 
     replay_endpoint: str | None = None
-    """The zmq endpoint to use for replaying kv events.
+    """The zmq endpoint to use for replaying KV events.
+
+    In addition to sequence-based replay, consumers can send ``b"snapshot"``
+    to stream the current KV cache state. Snapshot frames carry the next live
+    sequence number from which replay should resume.
     """
 
     buffer_steps: int = 10_000

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -7,8 +7,7 @@ import time
 from abc import ABC, abstractmethod
 from collections import Counter, deque
 from collections.abc import Callable
-from dataclasses import asdict
-from itertools import count
+from dataclasses import asdict, dataclass
 from queue import Queue
 from typing import Any
 
@@ -118,6 +117,127 @@ class AllBlocksCleared(KVCacheEvent):
 
 class KVEventBatch(EventBatch):
     events: list[BlockStored | BlockRemoved | AllBlocksCleared]
+
+
+_BlockKey = tuple[ExternalBlockHash, str | None, int | None, str | None]
+
+
+@dataclass(slots=True)
+class _StoredBlocks:
+    event: BlockStored
+    keys: tuple[_BlockKey, ...]
+    active_keys: set[_BlockKey]
+
+
+class _KVCacheState:
+    """Tracks active blocks while retaining their original store metadata."""
+
+    def __init__(self) -> None:
+        self._next_store_id = 0
+        self._stores: dict[int, _StoredBlocks] = {}
+        self._active_stores: dict[_BlockKey, int] = {}
+        self._keys_by_hash: dict[ExternalBlockHash, set[_BlockKey]] = {}
+
+    @staticmethod
+    def _key(
+        block_hash: ExternalBlockHash,
+        medium: str | None,
+        group_idx: int | None,
+        locality: str | None,
+    ) -> _BlockKey:
+        return block_hash, medium, group_idx, locality
+
+    def update(
+        self,
+        events: list[BlockStored | BlockRemoved | AllBlocksCleared],
+    ) -> None:
+        for event in events:
+            if isinstance(event, AllBlocksCleared):
+                self.clear()
+            elif isinstance(event, BlockStored):
+                self._store(event)
+            elif isinstance(event, BlockRemoved):
+                self._remove(event)
+
+    def clear(self) -> None:
+        self._next_store_id = 0
+        self._stores.clear()
+        self._active_stores.clear()
+        self._keys_by_hash.clear()
+
+    def snapshot_events(
+        self,
+    ) -> list[BlockStored | BlockRemoved | AllBlocksCleared]:
+        events: list[BlockStored | BlockRemoved | AllBlocksCleared] = [
+            AllBlocksCleared()
+        ]
+        for stored in self._stores.values():
+            events.append(stored.event)
+            removed_hashes = [
+                key[0] for key in stored.keys if key not in stored.active_keys
+            ]
+            if removed_hashes:
+                event = stored.event
+                events.append(
+                    BlockRemoved(
+                        block_hashes=removed_hashes,
+                        medium=event.medium,
+                        group_idx=event.group_idx,
+                        locality=event.locality,
+                    )
+                )
+        return events
+
+    def _store(self, event: BlockStored) -> None:
+        keys = tuple(
+            self._key(
+                block_hash,
+                event.medium,
+                event.group_idx,
+                event.locality,
+            )
+            for block_hash in event.block_hashes
+        )
+        if not keys:
+            return
+
+        for key in keys:
+            self._deactivate(key)
+
+        store_id = self._next_store_id
+        self._next_store_id += 1
+        stored = _StoredBlocks(event, keys, set(keys))
+        self._stores[store_id] = stored
+        for key in keys:
+            self._active_stores[key] = store_id
+            self._keys_by_hash.setdefault(key[0], set()).add(key)
+
+    def _remove(self, event: BlockRemoved) -> None:
+        for block_hash in event.block_hashes:
+            for key in tuple(self._keys_by_hash.get(block_hash, ())):
+                _, medium, group_idx, locality = key
+                if event.medium is not None and medium != event.medium:
+                    continue
+                if event.group_idx is not None and group_idx != event.group_idx:
+                    continue
+                if event.locality is not None and locality != event.locality:
+                    continue
+                self._deactivate(key)
+
+    def _deactivate(self, key: _BlockKey) -> None:
+        store_id = self._active_stores.pop(key, None)
+        if store_id is None:
+            return
+
+        hash_keys = self._keys_by_hash[key[0]]
+        hash_keys.remove(key)
+        if not hash_keys:
+            del self._keys_by_hash[key[0]]
+
+        stored = self._stores[store_id]
+        stored.active_keys.remove(key)
+        if not stored.active_keys:
+            del self._stores[store_id]
 
 
 class KVEventAggregator:
@@ -296,7 +416,9 @@ class ZmqEventPublisher(EventPublisher):
     replay_endpoint:
         Optional ROUTER address for replay requests. When given, subscribers can
         request missed batches by sending the starting sequence number as an
-        8-byte big-endian integer.
+        8-byte big-endian integer, or request a complete cache snapshot by
+        sending ``b"snapshot"``. Snapshot response frames carry the next live
+        sequence number from which replay should resume.
     buffer_steps:
         Number of past batches to keep for replay.
     hwm:
@@ -309,6 +431,8 @@ class ZmqEventPublisher(EventPublisher):
 
     SHUTDOWN_TIMEOUT: float = 1.0
     END_SEQ = (-1).to_bytes(8, "big", signed=True)
+    SNAPSHOT_REQUEST = b"snapshot"
+    SNAPSHOT_BATCH_SIZE = 1_000
 
     def __init__(
         self,
@@ -339,8 +463,9 @@ class ZmqEventPublisher(EventPublisher):
         self._socket_setup()
 
         # Payload
-        self._seq_gen = count()
+        self._next_seq = 0
         self._topic_bytes = topic.encode("utf-8")
+        self._kv_cache_state = _KVCacheState() if self._replay is not None else None
 
         # Thread
         self._running = True
@@ -439,9 +564,12 @@ class ZmqEventPublisher(EventPublisher):
                 continue
 
             try:
-                seq = next(self._seq_gen)
+                seq = self._next_seq
+                self._next_seq += 1
 
                 payload = self._pack.encode(event)
+                if self._kv_cache_state is not None and isinstance(event, KVEventBatch):
+                    self._kv_cache_state.update(event.events)
                 seq_bytes = seq.to_bytes(8, "big")
                 self._pub.send_multipart((self._topic_bytes, seq_bytes, payload))
 
@@ -461,7 +589,12 @@ class ZmqEventPublisher(EventPublisher):
         if len(frame) != 3:
             logger.warning("Invalid replay request: %s", frame)
             return
-        client_id, _, start_seq_bytes = frame
+        client_id, _, request = frame
+        if request == self.SNAPSHOT_REQUEST:
+            self._service_snapshot(client_id)
+            return
+
+        start_seq_bytes = request
         start_seq = int.from_bytes(start_seq_bytes, "big")
 
         for seq, buf in self._buffer:
@@ -471,6 +604,31 @@ class ZmqEventPublisher(EventPublisher):
                     (client_id, b"", self._topic_bytes, seq.to_bytes(8, "big"), buf)
                 )
         # Send end of sequence marker
+        self._replay.send_multipart((client_id, b"", b"", self.END_SEQ, b""))
+
+    def _service_snapshot(self, client_id: bytes) -> None:
+        """Send cache state and the sequence from which replay should resume."""
+        assert self._replay is not None
+        assert self._kv_cache_state is not None
+
+        events = self._kv_cache_state.snapshot_events()
+        resume_seq = self._next_seq.to_bytes(8, "big")
+        timestamp = time.time()
+        for start in range(0, len(events), self.SNAPSHOT_BATCH_SIZE):
+            batch = KVEventBatch(
+                ts=timestamp,
+                events=events[start : start + self.SNAPSHOT_BATCH_SIZE],
+                data_parallel_rank=self._data_parallel_rank,
+            )
+            self._replay.send_multipart(
+                (
+                    client_id,
+                    b"",
+                    self._topic_bytes,
+                    resume_seq,
+                    self._pack.encode(batch),
+                )
+            )
         self._replay.send_multipart((client_id, b"", b"", self.END_SEQ, b""))
 
     @staticmethod

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -7,8 +7,7 @@ import time
 from abc import ABC, abstractmethod
 from collections import Counter, deque
 from collections.abc import Callable
-from dataclasses import asdict
-from itertools import count
+from dataclasses import asdict, dataclass
 from queue import Queue
 from typing import Any
 
@@ -132,6 +131,127 @@ class AllBlocksCleared(KVCacheEvent):
 
 class KVEventBatch(EventBatch):
     events: list[BlockStored | BlockRemoved | AllBlocksCleared]
+
+
+_BlockKey = tuple[ExternalBlockHash, str | None, int | None, str | None]
+
+
+@dataclass(slots=True)
+class _StoredBlocks:
+    event: BlockStored
+    keys: tuple[_BlockKey, ...]
+    active_keys: set[_BlockKey]
+
+
+class _KVCacheState:
+    """Tracks active blocks while retaining their original store metadata."""
+
+    def __init__(self) -> None:
+        self._next_store_id = 0
+        self._stores: dict[int, _StoredBlocks] = {}
+        self._active_stores: dict[_BlockKey, int] = {}
+        self._keys_by_hash: dict[ExternalBlockHash, set[_BlockKey]] = {}
+
+    @staticmethod
+    def _key(
+        block_hash: ExternalBlockHash,
+        medium: str | None,
+        group_idx: int | None,
+        locality: str | None,
+    ) -> _BlockKey:
+        return block_hash, medium, group_idx, locality
+
+    def update(
+        self,
+        events: list[BlockStored | BlockRemoved | AllBlocksCleared],
+    ) -> None:
+        for event in events:
+            if isinstance(event, AllBlocksCleared):
+                self.clear()
+            elif isinstance(event, BlockStored):
+                self._store(event)
+            elif isinstance(event, BlockRemoved):
+                self._remove(event)
+
+    def clear(self) -> None:
+        self._next_store_id = 0
+        self._stores.clear()
+        self._active_stores.clear()
+        self._keys_by_hash.clear()
+
+    def snapshot_events(
+        self,
+    ) -> list[BlockStored | BlockRemoved | AllBlocksCleared]:
+        events: list[BlockStored | BlockRemoved | AllBlocksCleared] = [
+            AllBlocksCleared()
+        ]
+        for stored in self._stores.values():
+            events.append(stored.event)
+            removed_hashes = [
+                key[0] for key in stored.keys if key not in stored.active_keys
+            ]
+            if removed_hashes:
+                event = stored.event
+                events.append(
+                    BlockRemoved(
+                        block_hashes=removed_hashes,
+                        medium=event.medium,
+                        group_idx=event.group_idx,
+                        locality=event.locality,
+                    )
+                )
+        return events
+
+    def _store(self, event: BlockStored) -> None:
+        keys = tuple(
+            self._key(
+                block_hash,
+                event.medium,
+                event.group_idx,
+                event.locality,
+            )
+            for block_hash in event.block_hashes
+        )
+        if not keys:
+            return
+
+        for key in keys:
+            self._deactivate(key)
+
+        store_id = self._next_store_id
+        self._next_store_id += 1
+        stored = _StoredBlocks(event, keys, set(keys))
+        self._stores[store_id] = stored
+        for key in keys:
+            self._active_stores[key] = store_id
+            self._keys_by_hash.setdefault(key[0], set()).add(key)
+
+    def _remove(self, event: BlockRemoved) -> None:
+        for block_hash in event.block_hashes:
+            for key in tuple(self._keys_by_hash.get(block_hash, ())):
+                _, medium, group_idx, locality = key
+                if event.medium is not None and medium != event.medium:
+                    continue
+                if event.group_idx is not None and group_idx != event.group_idx:
+                    continue
+                if event.locality is not None and locality != event.locality:
+                    continue
+                self._deactivate(key)
+
+    def _deactivate(self, key: _BlockKey) -> None:
+        store_id = self._active_stores.pop(key, None)
+        if store_id is None:
+            return
+
+        hash_keys = self._keys_by_hash[key[0]]
+        hash_keys.remove(key)
+        if not hash_keys:
+            del self._keys_by_hash[key[0]]
+
+        stored = self._stores[store_id]
+        stored.active_keys.remove(key)
+        if not stored.active_keys:
+            del self._stores[store_id]
 
 
 class KVEventAggregator:
@@ -314,7 +434,9 @@ class ZmqEventPublisher(EventPublisher):
     replay_endpoint:
         Optional ROUTER address for replay requests. When given, subscribers can
         request missed batches by sending the starting sequence number as an
-        8-byte big-endian integer.
+        8-byte big-endian integer, or request a complete cache snapshot by
+        sending ``b"snapshot"``. Snapshot response frames carry the next live
+        sequence number from which replay should resume.
     buffer_steps:
         Number of past batches to keep for replay.
     hwm:
@@ -327,6 +449,8 @@ class ZmqEventPublisher(EventPublisher):
 
     SHUTDOWN_TIMEOUT: float = 1.0
     END_SEQ = (-1).to_bytes(8, "big", signed=True)
+    SNAPSHOT_REQUEST = b"snapshot"
+    SNAPSHOT_BATCH_SIZE = 1_000
 
     def __init__(
         self,
@@ -368,8 +492,9 @@ class ZmqEventPublisher(EventPublisher):
         self._socket_setup()
 
         # Payload
-        self._seq_gen = count()
+        self._next_seq = 0
         self._topic_bytes = topic.encode("utf-8")
+        self._kv_cache_state = _KVCacheState() if self._replay is not None else None
 
         # Thread
         self._running = True
@@ -471,9 +596,12 @@ class ZmqEventPublisher(EventPublisher):
                 continue
 
             try:
-                seq = next(self._seq_gen)
+                seq = self._next_seq
+                self._next_seq += 1
 
                 payload = self._pack.encode(event)
+                if self._kv_cache_state is not None and isinstance(event, KVEventBatch):
+                    self._kv_cache_state.update(event.events)
                 seq_bytes = seq.to_bytes(8, "big")
                 self._pub.send_multipart((self._topic_bytes, seq_bytes, payload))
 
@@ -493,7 +621,12 @@ class ZmqEventPublisher(EventPublisher):
         if len(frame) != 3:
             logger.warning("Invalid replay request: %s", frame)
             return
-        client_id, _, start_seq_bytes = frame
+        client_id, _, request = frame
+        if request == self.SNAPSHOT_REQUEST:
+            self._service_snapshot(client_id)
+            return
+
+        start_seq_bytes = request
         start_seq = int.from_bytes(start_seq_bytes, "big")
 
         for seq, buf in self._buffer:
@@ -503,6 +636,31 @@ class ZmqEventPublisher(EventPublisher):
                     (client_id, b"", self._topic_bytes, seq.to_bytes(8, "big"), buf)
                 )
         # Send end of sequence marker
+        self._replay.send_multipart((client_id, b"", b"", self.END_SEQ, b""))
+
+    def _service_snapshot(self, client_id: bytes) -> None:
+        """Send cache state and the sequence from which replay should resume."""
+        assert self._replay is not None
+        assert self._kv_cache_state is not None
+
+        events = self._kv_cache_state.snapshot_events()
+        resume_seq = self._next_seq.to_bytes(8, "big")
+        timestamp = time.time()
+        for start in range(0, len(events), self.SNAPSHOT_BATCH_SIZE):
+            batch = KVEventBatch(
+                ts=timestamp,
+                events=events[start : start + self.SNAPSHOT_BATCH_SIZE],
+                data_parallel_rank=self._data_parallel_rank,
+            )
+            self._replay.send_multipart(
+                (
+                    client_id,
+                    b"",
+                    self._topic_bytes,
+                    resume_seq,
+                    self._pack.encode(batch),
+                )
+            )
         self._replay.send_multipart((client_id, b"", b"", self.END_SEQ, b""))
 
     @staticmethod

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -272,7 +272,7 @@ class _KVCacheState:
                     continue
                 if event.locality is not None and locality != event.locality:
                     continue
-                if event.ownership is not None and ownership != event.ownership:
+                if ownership != event.ownership:
                     continue
                 self._deactivate(key)
 

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -133,7 +133,13 @@ class KVEventBatch(EventBatch):
     events: list[BlockStored | BlockRemoved | AllBlocksCleared]
 
 
-_BlockKey = tuple[ExternalBlockHash, str | None, int | None, str | None]
+_BlockKey = tuple[
+    ExternalBlockHash,
+    str | None,
+    int | None,
+    str | None,
+    str | None,
+]
 
 
 @dataclass(slots=True)
@@ -150,6 +156,7 @@ class _KVCacheState:
         self._next_store_id = 0
         self._stores: dict[int, _StoredBlocks] = {}
         self._active_stores: dict[_BlockKey, int] = {}
+        self._latest_stores: dict[_BlockKey, int] = {}
         self._keys_by_hash: dict[ExternalBlockHash, set[_BlockKey]] = {}
 
     @staticmethod
@@ -158,8 +165,9 @@ class _KVCacheState:
         medium: str | None,
         group_idx: int | None,
         locality: str | None,
+        ownership: str | None,
     ) -> _BlockKey:
-        return block_hash, medium, group_idx, locality
+        return block_hash, medium, group_idx, locality, ownership
 
     def update(
         self,
@@ -172,32 +180,36 @@ class _KVCacheState:
                 self._store(event)
             elif isinstance(event, BlockRemoved):
                 self._remove(event)
+        self._collect_unused_stores()
 
     def clear(self) -> None:
         self._next_store_id = 0
         self._stores.clear()
         self._active_stores.clear()
+        self._latest_stores.clear()
         self._keys_by_hash.clear()
 
     def snapshot_events(
         self,
     ) -> list[BlockStored | BlockRemoved | AllBlocksCleared]:
+        ordered_stores = self._ordered_stores()
         events: list[BlockStored | BlockRemoved | AllBlocksCleared] = [
             AllBlocksCleared()
         ]
-        for stored in self._stores.values():
-            events.append(stored.event)
+        events.extend(stored.event for stored in ordered_stores)
+        for stored in ordered_stores:
+            event = stored.event
             removed_hashes = [
                 key[0] for key in stored.keys if key not in stored.active_keys
             ]
             if removed_hashes:
-                event = stored.event
                 events.append(
                     BlockRemoved(
                         block_hashes=removed_hashes,
                         medium=event.medium,
                         group_idx=event.group_idx,
                         locality=event.locality,
+                        ownership=event.ownership,
                     )
                 )
         return events
@@ -209,6 +221,7 @@ class _KVCacheState:
                 event.medium,
                 event.group_idx,
                 event.locality,
+                event.ownership,
             )
             for block_hash in event.block_hashes
         )
@@ -224,17 +237,20 @@ class _KVCacheState:
         self._stores[store_id] = stored
         for key in keys:
             self._active_stores[key] = store_id
+            self._latest_stores[key] = store_id
             self._keys_by_hash.setdefault(key[0], set()).add(key)
 
     def _remove(self, event: BlockRemoved) -> None:
         for block_hash in event.block_hashes:
             for key in tuple(self._keys_by_hash.get(block_hash, ())):
-                _, medium, group_idx, locality = key
+                _, medium, group_idx, locality, ownership = key
                 if event.medium is not None and medium != event.medium:
                     continue
                 if event.group_idx is not None and group_idx != event.group_idx:
                     continue
                 if event.locality is not None and locality != event.locality:
+                    continue
+                if event.ownership is not None and ownership != event.ownership:
                     continue
                 self._deactivate(key)
 
@@ -250,8 +266,64 @@ class _KVCacheState:
 
         stored = self._stores[store_id]
         stored.active_keys.remove(key)
-        if not stored.active_keys:
-            del self._stores[store_id]
+
+    def _parent_store_id(self, stored: _StoredBlocks) -> int | None:
+        event = stored.event
+        if event.parent_block_hash is None:
+            return None
+        parent_key = self._key(
+            event.parent_block_hash,
+            event.medium,
+            event.group_idx,
+            event.locality,
+            event.ownership,
+        )
+        return self._latest_stores.get(parent_key)
+
+    def _collect_unused_stores(self) -> None:
+        required = set(self._active_stores.values())
+        pending = list(required)
+        while pending:
+            store_id = pending.pop()
+            parent_id = self._parent_store_id(self._stores[store_id])
+            if parent_id is not None and parent_id not in required:
+                required.add(parent_id)
+                pending.append(parent_id)
+
+        for store_id in tuple(self._stores):
+            if store_id in required:
+                continue
+            stored = self._stores.pop(store_id)
+            for key in stored.keys:
+                if self._latest_stores.get(key) == store_id:
+                    del self._latest_stores[key]
+
+    def _ordered_stores(self) -> list[_StoredBlocks]:
+        roots: deque[int] = deque()
+        children: dict[int, list[int]] = {}
+        for store_id, stored in self._stores.items():
+            parent_id = self._parent_store_id(stored)
+            if stored.event.parent_block_hash is None:
+                roots.append(store_id)
+            elif parent_id is None:
+                raise ValueError(
+                    "Cannot build KV cache snapshot: parent block "
+                    f"{stored.event.parent_block_hash!r} is unavailable"
+                )
+            elif parent_id == store_id:
+                raise ValueError("Cannot build KV cache snapshot: self dependency")
+            else:
+                children.setdefault(parent_id, []).append(store_id)
+
+        ordered_ids: list[int] = []
+        while roots:
+            store_id = roots.popleft()
+            ordered_ids.append(store_id)
+            roots.extend(children.get(store_id, ()))
+
+        if len(ordered_ids) != len(self._stores):
+            raise ValueError("Cannot build KV cache snapshot: cyclic dependencies")
+        return [self._stores[store_id] for store_id in ordered_ids]
 
 
 class KVEventAggregator:

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -147,6 +147,7 @@ class _StoredBlocks:
     event: BlockStored
     keys: tuple[_BlockKey, ...]
     active_keys: set[_BlockKey]
+    parent_key: _BlockKey | None
 
 
 class _KVCacheState:
@@ -158,6 +159,7 @@ class _KVCacheState:
         self._active_stores: dict[_BlockKey, int] = {}
         self._latest_stores: dict[_BlockKey, int] = {}
         self._keys_by_hash: dict[ExternalBlockHash, set[_BlockKey]] = {}
+        self._dependents: dict[_BlockKey, set[int]] = {}
 
     @staticmethod
     def _key(
@@ -180,7 +182,6 @@ class _KVCacheState:
                 self._store(event)
             elif isinstance(event, BlockRemoved):
                 self._remove(event)
-        self._collect_unused_stores()
 
     def clear(self) -> None:
         self._next_store_id = 0
@@ -188,6 +189,7 @@ class _KVCacheState:
         self._active_stores.clear()
         self._latest_stores.clear()
         self._keys_by_hash.clear()
+        self._dependents.clear()
 
     def snapshot_events(
         self,
@@ -200,7 +202,7 @@ class _KVCacheState:
         for stored in ordered_stores:
             event = stored.event
             removed_hashes = [
-                key[0] for key in stored.keys if key not in stored.active_keys
+                key[0] for key in stored.keys if key not in self._active_stores
             ]
             if removed_hashes:
                 events.append(
@@ -228,17 +230,37 @@ class _KVCacheState:
         if not keys:
             return
 
+        replaced_store_ids = {
+            store_id
+            for key in keys
+            if (store_id := self._latest_stores.get(key)) is not None
+        }
         for key in keys:
-            self._deactivate(key)
+            self._deactivate(key, collect=False)
 
         store_id = self._next_store_id
         self._next_store_id += 1
-        stored = _StoredBlocks(event, keys, set(keys))
+        parent_key = (
+            self._key(
+                event.parent_block_hash,
+                event.medium,
+                event.group_idx,
+                event.locality,
+                event.ownership,
+            )
+            if event.parent_block_hash is not None
+            else None
+        )
+        stored = _StoredBlocks(event, keys, set(keys), parent_key)
         self._stores[store_id] = stored
         for key in keys:
             self._active_stores[key] = store_id
             self._latest_stores[key] = store_id
             self._keys_by_hash.setdefault(key[0], set()).add(key)
+        if parent_key is not None:
+            self._dependents.setdefault(parent_key, set()).add(store_id)
+        for replaced_store_id in replaced_store_ids:
+            self._collect_store(replaced_store_id)
 
     def _remove(self, event: BlockRemoved) -> None:
         for block_hash in event.block_hashes:
@@ -254,7 +276,7 @@ class _KVCacheState:
                     continue
                 self._deactivate(key)
 
-    def _deactivate(self, key: _BlockKey) -> None:
+    def _deactivate(self, key: _BlockKey, *, collect: bool = True) -> None:
         store_id = self._active_stores.pop(key, None)
         if store_id is None:
             return
@@ -266,37 +288,39 @@ class _KVCacheState:
 
         stored = self._stores[store_id]
         stored.active_keys.remove(key)
+        if collect:
+            self._collect_store(store_id)
 
     def _parent_store_id(self, stored: _StoredBlocks) -> int | None:
-        event = stored.event
-        if event.parent_block_hash is None:
+        if stored.parent_key is None:
             return None
-        parent_key = self._key(
-            event.parent_block_hash,
-            event.medium,
-            event.group_idx,
-            event.locality,
-            event.ownership,
-        )
-        return self._latest_stores.get(parent_key)
+        return self._latest_stores.get(stored.parent_key)
 
-    def _collect_unused_stores(self) -> None:
-        required = set(self._active_stores.values())
-        pending = list(required)
+    def _collect_store(self, store_id: int) -> None:
+        pending = [store_id]
         while pending:
             store_id = pending.pop()
-            parent_id = self._parent_store_id(self._stores[store_id])
-            if parent_id is not None and parent_id not in required:
-                required.add(parent_id)
-                pending.append(parent_id)
-
-        for store_id in tuple(self._stores):
-            if store_id in required:
+            stored = self._stores.get(store_id)
+            if stored is None or stored.active_keys:
                 continue
-            stored = self._stores.pop(store_id)
+            if any(
+                self._latest_stores.get(key) == store_id and self._dependents.get(key)
+                for key in stored.keys
+            ):
+                continue
+
+            del self._stores[store_id]
             for key in stored.keys:
                 if self._latest_stores.get(key) == store_id:
                     del self._latest_stores[key]
+            if stored.parent_key is not None:
+                dependents = self._dependents[stored.parent_key]
+                dependents.remove(store_id)
+                if not dependents:
+                    del self._dependents[stored.parent_key]
+                parent_id = self._latest_stores.get(stored.parent_key)
+                if parent_id is not None:
+                    pending.append(parent_id)
 
     def _ordered_stores(self) -> list[_StoredBlocks]:
         roots: deque[int] = deque()

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -156,7 +156,7 @@ class _KVCacheState:
     def __init__(self) -> None:
         self._next_store_id = 0
         self._stores: dict[int, _StoredBlocks] = {}
-        self._active_stores: dict[_BlockKey, int] = {}
+        self._active_keys: set[_BlockKey] = set()
         self._latest_stores: dict[_BlockKey, int] = {}
         self._keys_by_hash: dict[ExternalBlockHash, set[_BlockKey]] = {}
         self._dependents: dict[_BlockKey, set[int]] = {}
@@ -186,7 +186,7 @@ class _KVCacheState:
     def clear(self) -> None:
         self._next_store_id = 0
         self._stores.clear()
-        self._active_stores.clear()
+        self._active_keys.clear()
         self._latest_stores.clear()
         self._keys_by_hash.clear()
         self._dependents.clear()
@@ -202,7 +202,7 @@ class _KVCacheState:
         for stored in ordered_stores:
             event = stored.event
             removed_hashes = [
-                key[0] for key in stored.keys if key not in self._active_stores
+                key[0] for key in stored.keys if key not in self._active_keys
             ]
             if removed_hashes:
                 events.append(
@@ -254,7 +254,7 @@ class _KVCacheState:
         stored = _StoredBlocks(event, keys, set(keys), parent_key)
         self._stores[store_id] = stored
         for key in keys:
-            self._active_stores[key] = store_id
+            self._active_keys.add(key)
             self._latest_stores[key] = store_id
             self._keys_by_hash.setdefault(key[0], set()).add(key)
         if parent_key is not None:
@@ -277,16 +277,18 @@ class _KVCacheState:
                 self._deactivate(key)
 
     def _deactivate(self, key: _BlockKey, *, collect: bool = True) -> None:
-        store_id = self._active_stores.pop(key, None)
-        if store_id is None:
+        if key not in self._active_keys:
             return
+        store_id = self._latest_stores.get(key)
+        assert store_id is not None
+        stored = self._stores[store_id]
+        self._active_keys.remove(key)
 
         hash_keys = self._keys_by_hash[key[0]]
         hash_keys.remove(key)
         if not hash_keys:
             del self._keys_by_hash[key[0]]
 
-        stored = self._stores[store_id]
         stored.active_keys.remove(key)
         if collect:
             self._collect_store(store_id)


### PR DESCRIPTION
## Purpose

Addresses #40363.

The replay buffer only covers transient KV event gaps. Once it expires, a newly started or recovering router has no way to reconstruct the worker's current cache state.

This change adds an explicit `b"snapshot"` request to the existing ZMQ replay endpoint. The publisher tracks active blocks from `BlockStored`, `BlockRemoved`, and `AllBlocksCleared` events, then streams a snapshot using the existing topic/sequence/payload framing and end marker. Snapshot frames carry the next live sequence as the resume point, while numeric replay requests remain unchanged.

No open PR was found for #40363 or for the same KV event snapshot/BlockPool state-dump scope before submission.

AI assistance was used for implementation, test development, and review follow-up. The commits include the corresponding attribution trailers.

## Correctness

- Snapshot stores are emitted in stable parent-before-child topological order, including across snapshot frames.
- Inactive ancestors required by active children are retained for reconstruction, then removed only after all stores have been emitted.
- The complete snapshot plan is validated before `AllBlocksCleared` is sent; missing parents, self-dependencies, and cycles fail closed.
- Multi-block stores, exact ownership matching (including primary `ownership=None`), and existing wire metadata such as `session_id` are preserved.
- Dependency cleanup is incremental during normal event processing rather than scanning the complete cache state on every update.

## Performance characteristics

Snapshot construction and sending run synchronously on the dedicated `zmq-publisher` thread, not directly on the engine thread. Live KV-event publication pauses while a snapshot is served, so a full 100,000-item publisher queue can indirectly backpressure the engine.

Local CPU measurements on macOS arm64 / Python 3.12.13 used chained stores with 64 blocks per event and three independent runs (median shown):

| Active blocks | State update | Snapshot plan | Msgpack encode | Plan + encode | Payload |
|---:|---:|---:|---:|---:|---:|
| 10K | 7.30 ms | 0.45 ms | 0.51 ms | 0.96 ms | 0.47 MB |
| 100K | 88.65 ms | 7.44 ms | 5.16 ms | 12.59 ms | 4.76 MB |
| 1M | 2.212 s | 127.81 ms | 58.41 ms | 186.22 ms | 48.80 MB |

The 1M state update added a median approximately 395 MiB RSS after source events were built. Measurements exclude actual ROUTER transport time. The synchronous design is retained in this revision because it provides a fixed, consistent resume sequence.

## Test plan

- Recover cache state after the replay buffer expires.
- Verify parent-before-child reconstruction, including re-stored parents, inactive ancestors, and cross-frame ordering.
- Cover partial multi-block removals, dependency cleanup, clears, missing parents, self-dependencies, and cycles.
- Verify medium, group, locality, named/primary ownership, topic metadata, DP rank, and `session_id` behavior.
- Run existing replay and KV event wire-compatibility suites.

## Test results

- `.venv/bin/python -m pytest tests/distributed/test_events.py -v --confcutdir=tests/distributed`: 22 passed.
- `.venv/bin/python -m pytest tests/distributed/test_kv_cache_events.py -v --confcutdir=tests/distributed`: 17 passed.
- `.venv/bin/pre-commit run --files vllm/distributed/kv_events.py tests/distributed/test_events.py`: all hooks passed.
- `.venv/bin/pre-commit run mypy-3.12 --files vllm/distributed/kv_events.py tests/distributed/test_events.py --hook-stage manual`: passed.
- Randomized state-machine diagnostic: 100 trials x 500 legal updates passed.
- Coverage: local `pytest-cov`/coverage runs exit 139 while loading the test configuration, before tests start, on the project's PyTorch 2.13.0 environment; no coverage percentage is reported.
- Model evaluation: not applicable; this does not affect model execution or output.
