### PR TITLE
[Core] Support classical hybrid draft models (short_conv + attention) for speculative decoding

### DIFF
--- a/vllm/model_executor/layers/mamba/abstract.py
+++ b/vllm/model_executor/layers/mamba/abstract.py
@@ -2,11 +2,13 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from abc import abstractmethod
 from collections.abc import Iterable
+from math import prod
 
 import torch
 
 from vllm.config import VllmConfig
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+from vllm.utils.torch_utils import get_dtype_size
 from vllm.v1.attention.backend import AttentionBackend
 from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
 from vllm.v1.attention.selector import get_mamba_attn_backend
@@ -45,9 +47,21 @@ class MambaBase(AttentionLayerBase):
         mamba_block_size = vllm_config.cache_config.mamba_block_size
         assert mamba_block_size is not None
         page_size_padded = vllm_config.cache_config.mamba_page_size_padded
+        shapes = tuple(self.get_state_shape())
+        dtypes = self.get_state_dtype()
+        # mamba_page_size_padded may be computed before num_speculative_tokens
+        # changes the state shape; discard it if it would fail the assertion
+        # inside page_size_bytes.
+        if page_size_padded is not None:
+            actual_page = sum(
+                prod(shape) * get_dtype_size(dtype)
+                for shape, dtype in zip(shapes, dtypes)
+            )
+            if page_size_padded < actual_page:
+                page_size_padded = None
         return MambaSpec(
-            shapes=tuple(self.get_state_shape()),
-            dtypes=self.get_state_dtype(),
+            shapes=shapes,
+            dtypes=dtypes,
             block_size=mamba_block_size,
             page_size_padded=page_size_padded,
             mamba_type=self.mamba_type,

--- a/vllm/model_executor/layers/mamba/mamba_utils.py
+++ b/vllm/model_executor/layers/mamba/mamba_utils.py
@@ -192,9 +192,14 @@ class MambaStateShapeCalculator:
         tp_world_size: int,
         intermediate_size: int,
         conv_kernel: int,
+        num_spec: int = 0,
     ) -> tuple[tuple[int, int]]:
         conv_dim = divide(intermediate_size, tp_world_size)
-        conv_state_shape = cls._orient_conv_shape(conv_dim, conv_kernel - 1)
+        # Speculative decode needs a wider conv state so the spec-aware
+        # causal_conv1d_update sliding window has room to roll back rejected
+        # tokens (kernel uses state_len = width-1 + (seqlen-1)). Mirror
+        # mamba2_state_shape, which adds num_spec for the same reason.
+        conv_state_shape = cls._orient_conv_shape(conv_dim, conv_kernel - 1 + num_spec)
         return (conv_state_shape,)
 
     @classmethod

--- a/vllm/model_executor/layers/mamba/short_conv.py
+++ b/vllm/model_executor/layers/mamba/short_conv.py
@@ -76,7 +76,11 @@ class ShortConv(MambaBase, CustomOp):
             prefix=f"{prefix}.out_proj",
         )
 
-        compilation_config = get_current_vllm_config().compilation_config
+        vllm_config = get_current_vllm_config()
+        # Capture here (config context is set during model build); get_state_shape
+        # runs later outside that context. Widens conv state for spec-decode rollback.
+        self.num_spec = vllm_config.num_speculative_tokens
+        compilation_config = vllm_config.compilation_config
         if prefix in compilation_config.static_forward_context:
             raise ValueError(f"Duplicate layer name: {prefix}")
         compilation_config.static_forward_context[prefix] = self
@@ -217,6 +221,11 @@ class ShortConv(MambaBase, CustomOp):
             state_indices_tensor_d = attn_metadata.state_indices_tensor_d
             has_initial_states_p = attn_metadata.has_initial_states_p
             query_start_loc_p = attn_metadata.query_start_loc_p
+            # Speculative-decode metadata (verify step has >1 query token per
+            # decode request). Provided by BaseMambaAttentionMetadata; None /
+            # trivial when spec decoding is off. Mirrors mamba_mixer2.
+            num_accepted_tokens = attn_metadata.num_accepted_tokens
+            query_start_loc_d = attn_metadata.query_start_loc_d
 
         BCx, _ = self.in_proj(hidden_states)
 
@@ -279,14 +288,32 @@ class ShortConv(MambaBase, CustomOp):
 
         if has_decode:
             Bx_d = (B_d * x_d).contiguous()
-            Bx = causal_conv1d_update(
-                Bx_d,
-                conv_state,
-                conv_weights,
-                self.conv.bias,
-                activation=None,
-                conv_state_indices=state_indices_tensor_d,
-            )
+            if num_accepted_tokens is not None:
+                # Speculative decode: the verify step feeds >1 query token per
+                # decode request, so use the spec-aware conv update path
+                # (mirrors mamba_mixer2). state_indices_tensor_d is
+                # (num_decodes, 1 + num_spec_tokens) here.
+                Bx = causal_conv1d_update(
+                    Bx_d,
+                    conv_state,
+                    conv_weights,
+                    self.conv.bias,
+                    activation=None,
+                    conv_state_indices=state_indices_tensor_d,
+                    num_accepted_tokens=num_accepted_tokens,
+                    query_start_loc=query_start_loc_d,
+                    max_query_len=state_indices_tensor_d.size(-1),
+                )
+            else:
+                # Non-spec decode (1 token/request): unchanged original path.
+                Bx = causal_conv1d_update(
+                    Bx_d,
+                    conv_state,
+                    conv_weights,
+                    self.conv.bias,
+                    activation=None,
+                    conv_state_indices=state_indices_tensor_d,
+                )
             y = C_d * Bx
             conv_output_list.insert(0, y)
 
@@ -305,10 +332,13 @@ class ShortConv(MambaBase, CustomOp):
         )
 
     def get_state_shape(self) -> tuple[tuple[int, ...]]:
+        # num_spec widens the conv state for speculative-decode rollback
+        # (see short_conv_state_shape / mamba2 parity). Captured in __init__.
         return MambaStateShapeCalculator.short_conv_state_shape(
             tp_world_size=get_tensor_model_parallel_world_size(),
             intermediate_size=self.conv_dim,
             conv_kernel=self.L_cache,
+            num_spec=self.num_spec,
         )
 
     @property

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -94,6 +94,26 @@ def kernel_warmup(worker: "Worker"):
     elif has_flashinfer() and current_platform.has_device_capability(90):
         flashinfer_autotune(worker.model_runner)
 
+    # Hybrid/Mamba model (HasInnerState protocol) warmup.
+    # Run a small dummy forward pass to compile all Triton kernels
+    # (causal_conv1d, zero_kv_blocks, batch_memcpy) before graph capture.
+    from vllm.model_executor.models.interfaces import HasInnerState
+
+    model = worker.get_model()
+    is_hybrid_or_mamba = isinstance(model, HasInnerState)
+
+    if is_hybrid_or_mamba and not worker.model_runner.is_pooling_model:
+        logger.info("Warming up hybrid/Mamba Triton kernels.")
+        # Running a dummy pass with mixed batch to JIT compile both prefill and decode
+        # kernels for Mamba/ShortConv layers.
+        worker.model_runner._dummy_run(
+            num_tokens=16,
+            skip_eplb=True,
+            is_profile=True,
+            force_attention=True,
+            create_mixed_batch=True,
+        )
+
     # FlashInfer attention warmup
     # Only warmup if the model has FlashInfer attention groups
     # and is not a pooling model

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1177,6 +1177,33 @@ def _get_kv_cache_groups_uniform_page_size(
     for layer_name, layer_spec in kv_cache_spec.items():
         same_type_layers[layer_spec].append(layer_name)
 
+    # Separate speculator layers into their own group before the heuristic
+    # below runs, so drafter layers don't get scattered across groups.
+    # Separate speculator (drafter) layers into their own dedicated group(s),
+    # one per KV cache spec type. A hybrid draft model (e.g. LFM2.5: short_conv +
+    # attention) has multiple spec types among its layers; they must NOT be merged
+    # into a single group (a KV cache group must be spec-uniform), so we keep one
+    # dedicated group per spec type. A non-hybrid (EAGLE-style) drafter simply
+    # yields a single group.
+    speculator_groups_by_spec: dict[KVCacheSpec, list[str]] = {}
+    if speculator_layers:
+        for spec in list(same_type_layers.keys()):
+            layers = same_type_layers[spec]
+            spec_in_group = [n for n in layers if n in speculator_layers]
+            if spec_in_group:
+                non_spec = [n for n in layers if n not in speculator_layers]
+                if non_spec:
+                    same_type_layers[spec] = non_spec
+                else:
+                    del same_type_layers[spec]
+                speculator_groups_by_spec[spec] = spec_in_group
+        if speculator_groups_by_spec:
+            logger.info(
+                "Separated %d speculator layers into %d dedicated KV cache group(s)",
+                sum(len(v) for v in speculator_groups_by_spec.values()),
+                len(speculator_groups_by_spec),
+            )
+
     # Split each group into smaller groups, to make the number of layers in each
     # group identical. Add padding to the last group of each type if necessary.
     # E.g., (full.0, full.1), (sw.0, sw.1, sw.2)
@@ -1224,6 +1251,10 @@ def _get_kv_cache_groups_uniform_page_size(
         # instead of layers[i * group_size: (i + 1) * group_size]
         for i in range(num_groups):
             grouped_layers.append(layers[i::num_groups])
+    # Prepend speculator layers as their own dedicated group(s), one per spec type
+    for spec_layers in speculator_groups_by_spec.values():
+        grouped_layers.insert(0, spec_layers)
+
     return create_kv_cache_group_specs(kv_cache_spec, grouped_layers)
 
 
@@ -1692,6 +1723,53 @@ def _annotate_eagle_groups_deepseek_v4(
         if last_layer in group.layer_names:
             group.is_eagle_group = True
             break
+
+
+def _identify_speculator_layers(
+    vllm_config: VllmConfig, all_layer_names: list[str]
+) -> set[str] | None:
+    """Identify speculator (drafter) attention layers by finding layers
+    whose index exceeds the target model's total layer count.
+
+    For EAGLE-style drafters, drafter layers are appended after the target
+    model's layers (e.g., model.layers.24-27 for a 24-layer target model).
+    Layer names use global indices even under pipeline parallelism
+    (see make_layers() in model_executor/models/utils.py).
+    """
+    from vllm.model_executor.models.utils import extract_layer_index
+
+    spec_config = vllm_config.speculative_config
+    if spec_config is None:
+        return None
+
+    # Global count -- layer names use global indices under PP.
+    target_num_layers = vllm_config.model_config.get_total_num_hidden_layers()
+
+    speculator_layers: set[str] = set()
+    for name in all_layer_names:
+        # Classical separate draft model: layers are loaded with prefix
+        # "draft_model" (see spec_decode/draft_model.py). Their local layer
+        # indices do NOT exceed the target's layer count, so the index
+        # heuristic below misses them; detect them by prefix instead.
+        if "draft_model" in name:
+            speculator_layers.add(name)
+            continue
+        try:
+            layer_idx = extract_layer_index(name)
+            if layer_idx >= target_num_layers:
+                speculator_layers.add(name)
+        except (AssertionError, ValueError):
+            # Fallback for non-standard naming
+            if "drafter" in name.lower() or "eagle" in name.lower():
+                speculator_layers.add(name)
+
+    if speculator_layers:
+        logger.debug(
+            "Identified %d speculator layers for KV cache grouping: %s",
+            len(speculator_layers),
+            sorted(speculator_layers),
+        )
+    return speculator_layers if speculator_layers else None
 
 
 def get_kv_cache_groups(

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -964,8 +964,10 @@ def _pool_bytes_per_block(
         # buckets = {page_size: [[layer_names], [layer_names], ...]}
         buckets = _bucket_layers_by_page_size(kv_cache_groups)
         return sum(ps * len(slots) for ps, slots in buckets.items())
+    page_size = get_uniform_page_size(
+        [group.kv_cache_spec for group in kv_cache_groups]
+    )
     group_size = max(len(g.layer_names) for g in kv_cache_groups)
-    page_size = get_uniform_page_size([g.kv_cache_spec for g in kv_cache_groups])
     return page_size * group_size
 
 
@@ -987,6 +989,22 @@ def get_num_blocks(
     num_blocks = int(available_memory // page_size // num_layers)
     num_blocks = max(num_blocks, 0)
     return may_override_num_blocks(vllm_config, num_blocks)
+
+
+def _exclude_draft_groups(
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> list[KVCacheGroupSpec]:
+    """Filter out groups belonging to the draft model.
+
+    Draft groups have a fundamentally different page size (Mamba state vs
+    attention KV), so they must not participate in page-size unification.
+    If the result is empty (all-draft worker), return the original list so
+    the caller's assertion gives a clear error instead of a silent skip.
+    """
+    filtered = [
+        g for g in kv_cache_groups if not any("draft_model" in n for n in g.layer_names)
+    ]
+    return filtered if filtered else kv_cache_groups
 
 
 def get_uniform_page_size(kv_cache_specs: Iterable[KVCacheSpec]) -> int:
@@ -1082,9 +1100,9 @@ def unify_kv_cache_spec_page_size(
                 ratio = max_page_size // layer_page_size
                 new_block_size = layer_spec.block_size * ratio
                 new_spec = replace(layer_spec, block_size=new_block_size)
-            elif (
-                isinstance(layer_spec, AttentionSpec)
-                and layer_spec.indexes_kv_by_block_stride
+            elif isinstance(layer_spec, (AttentionSpec, MambaSpec)) and (
+                not isinstance(layer_spec, AttentionSpec)
+                or layer_spec.indexes_kv_by_block_stride
             ):
                 new_spec = replace(layer_spec, page_size_padded=max_page_size)
             else:
@@ -1409,7 +1427,7 @@ def get_kv_cache_config_from_groups(
         group_size = max(len(group.layer_names) for group in kv_cache_groups)
 
         page_size = get_uniform_page_size(
-            [group.kv_cache_spec for group in kv_cache_groups]
+            [group.kv_cache_spec for group in _exclude_draft_groups(kv_cache_groups)]
         )
         assert group_size > 0, "group_size must be greater than 0"
         num_blocks = get_num_blocks(
@@ -1828,14 +1846,16 @@ def get_kv_cache_groups(
     # Classical draft models are detected by the 'draft_model' name prefix;
     # EAGLE-style drafters are detected by layer index >= target layer count.
     speculator_layers = _identify_speculator_layers(
-        vllm_config, list(filtered_spec.keys()))
+        vllm_config, list(filtered_spec.keys())
+    )
 
     # As KVCacheManager can only allocate memory of one size, we need to unify
-    # the page size of the layers. For cases cannot be unified, this function
-    # will raise an error.
+    # the page size of ALL layers (target + draft). unify_kv_cache_spec_page_size
+    # now handles MambaSpec via page_size_padded.
     filtered_spec = unify_kv_cache_spec_page_size(filtered_spec)
     groups = _get_kv_cache_groups_uniform_page_size(
-        filtered_spec, speculator_layers=speculator_layers)
+        filtered_spec, speculator_layers=speculator_layers
+    )
 
     # Add hidden-state layers back with page aligned to the common page.
     if hidden_specs:
@@ -1935,7 +1955,9 @@ def _max_memory_usage_bytes_from_groups(
 
     # General case: group_size pools, each shared by one layer per group
     # Memory = group_size * page_size * blocks_for_max_len
-    group_size = max(len(group.layer_names) for group in kv_cache_groups)
+    group_size = max(
+        len(group.layer_names) for group in _exclude_draft_groups(kv_cache_groups)
+    )
     page_size = get_uniform_page_size(
         [group.kv_cache_spec for group in kv_cache_groups]
     )

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1107,6 +1107,7 @@ def is_kv_cache_type_attention_free(kv_cache_spec: dict[str, KVCacheSpec]) -> bo
 
 def _get_kv_cache_groups_uniform_page_size(
     kv_cache_spec: dict[str, KVCacheSpec],
+    speculator_layers: set[str] | None = None,
 ) -> list[KVCacheGroupSpec]:
     """
     Generates the KV cache groups for hybrid models with multiple
@@ -1823,11 +1824,18 @@ def get_kv_cache_groups(
         if not isinstance(v, HiddenStateCacheSpec)
     }
 
+    # Identify speculator layers for KV cache grouping.
+    # Classical draft models are detected by the 'draft_model' name prefix;
+    # EAGLE-style drafters are detected by layer index >= target layer count.
+    speculator_layers = _identify_speculator_layers(
+        vllm_config, list(filtered_spec.keys()))
+
     # As KVCacheManager can only allocate memory of one size, we need to unify
     # the page size of the layers. For cases cannot be unified, this function
     # will raise an error.
     filtered_spec = unify_kv_cache_spec_page_size(filtered_spec)
-    groups = _get_kv_cache_groups_uniform_page_size(filtered_spec)
+    groups = _get_kv_cache_groups_uniform_page_size(
+        filtered_spec, speculator_layers=speculator_layers)
 
     # Add hidden-state layers back with page aligned to the common page.
     if hidden_specs:

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -24,6 +24,7 @@ from vllm.distributed.parallel_state import get_pp_group
 from vllm.forward_context import set_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+from vllm.model_executor.layers.mamba.abstract import MambaBase
 from vllm.model_executor.model_loader import get_model
 from vllm.model_executor.models import supports_multimodal
 from vllm.model_executor.models.deepseek_eagle3 import Eagle3DeepseekV2ForCausalLM
@@ -38,8 +39,13 @@ from vllm.utils.torch_utils import PIN_MEMORY, async_tensor_h2d
 from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.attention.backends.triton_attn import TritonAttentionMetadata
+from vllm.v1.attention.backends.utils import mamba_get_block_table_tensor
 from vllm.v1.cudagraph_dispatcher import CudagraphDispatcher
-from vllm.v1.kv_cache_interface import KVCacheConfig, UniformTypeKVCacheSpecs
+from vllm.v1.kv_cache_interface import (
+    KVCacheConfig,
+    MambaSpec,
+    UniformTypeKVCacheSpecs,
+)
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.ops.topk_topp_sampler import (
     empty_exponential_noise_like,
@@ -151,6 +157,29 @@ class SpecDecodeBaseProposer:
 
         self.draft_attn_groups: list[AttentionGroup] = []
         self.kv_cache_gid: int = -1
+        # Per-group block tables and slot mappings for draft models whose
+        # layers span more than one KV cache group (e.g. a hybrid attention +
+        # short_conv draft). The model runner populates these via
+        # set_per_group_attn_metadata; they stay empty for single-group
+        # drafters, so the per-group swap below is a no-op for them.
+        self._per_group_block_tables: dict[int, torch.Tensor] = {}
+        self._per_group_slot_mappings: dict[int, torch.Tensor] = {}
+        # Per-group slot-mapping buffers for the non-primary groups. The
+        # primary group reuses self._slot_mapping_buffer.
+        self._per_group_slot_mapping_buffers: dict[int, torch.Tensor] = {}
+        # Drafter short_conv (Mamba) layers and their KV cache spec, populated
+        # in initialize_attn_backend. A hybrid draft advances these recurrent
+        # conv-state buffers in place across the multi-step draft loop with no
+        # rollback, so propose() snapshots the touched blocks after step 0 and
+        # restores them after the loop. Empty for non-Mamba drafters (EAGLE,
+        # plain draft models), which skip the snapshot/restore entirely.
+        self._draft_mamba_layers: dict[str, MambaBase] = {}
+        self._draft_mamba_spec: MambaSpec | None = None
+        self._draft_mamba_gid: int = -1
+        # Reused across propose() calls to hold the post-step-0 conv-state
+        # snapshot; keyed by layer name. Lazily sized to the touched-block
+        # count so we never clone the whole cache.
+        self._mamba_state_snapshot: dict[str, torch.Tensor] = {}
         self.eagle3_use_aux_hidden_state: bool = (
             self._get_eagle3_use_aux_hidden_state_from_config()
         )
@@ -679,6 +708,13 @@ class SpecDecodeBaseProposer:
 
         block_size = self.block_size
         assert block_size > 0, "block_size has not been initialized."
+
+        # Snapshot the drafter's short_conv recurrent state before the draft
+        # loop advances it in place. The loop has no rollback, so without this
+        # the next iteration's step 0 would read a state corrupted by rejected
+        # draft tokens. No-op for non-Mamba drafters (empty layer set).
+        mamba_snapshot_blocks = self._snapshot_draft_mamba_state(common_attn_metadata)
+
         for token_index in range(self.num_speculative_tokens - 1):
             # Update the inputs.
             # cast to int32 is crucial when eagle model is compiled.
@@ -759,6 +795,12 @@ class SpecDecodeBaseProposer:
                 assert draft_probs_list is not None
                 draft_probs_list.append(draft_probs)
             draft_token_ids_list.append(draft_token_ids)
+
+        # Restore the drafter's short_conv state to the post-step-0 (committed)
+        # snapshot, undoing the in-place advance the draft loop applied with
+        # speculative tokens. The next iteration's step 0 then reads the correct
+        # anchor. No-op for non-Mamba drafters.
+        self._restore_draft_mamba_state(mamba_snapshot_blocks)
 
         # [batch_size, num_speculative_tokens]
         draft_token_ids = torch.stack(draft_token_ids_list, dim=1)
@@ -1020,6 +1062,78 @@ class SpecDecodeBaseProposer:
             for layer_name in attn_group.layer_names:
                 per_layer_attn_metadata[layer_name] = attn_metadata
         return per_group_attn_metadata, per_layer_attn_metadata
+
+    def _snapshot_draft_mamba_state(
+        self, common_attn_metadata: CommonAttentionMetadata
+    ) -> torch.Tensor | None:
+        """Snapshot the drafter's short_conv conv-state blocks the draft loop
+        overwrites in place.
+
+        Each short_conv layer advances its recurrent conv state one token per
+        draft step with no rollback, so without this snapshot the next
+        propose() iteration's step 0 would read a state corrupted by rejected
+        draft tokens. Returns the gathered block indices for
+        _restore_draft_mamba_state, or None when there is nothing to snapshot
+        (non-Mamba drafter, or the group's block table is unset).
+
+        Args:
+            common_attn_metadata: The drafter's metadata after the rejected-
+                token correction, so seq_lens reflects the committed length.
+
+        Returns:
+            The int64 block indices captured, or None to skip the restore.
+        """
+        if not self._draft_mamba_layers:
+            return None
+        assert self._draft_mamba_spec is not None
+        block_table = self._per_group_block_tables.get(self._draft_mamba_gid)
+        if block_table is None:
+            return None
+        num_reqs = common_attn_metadata.num_reqs
+        mode = self.vllm_config.cache_config.mamba_cache_mode
+        seq_lens = common_attn_metadata.seq_lens[:num_reqs]
+        bt = block_table[:num_reqs]
+        # The metadata builder selects each step's blocks from
+        # mamba_get_block_table_tensor(block_table, seq_lens, ...). The loop
+        # grows seq_lens by one per step, so its window can slide forward by a
+        # block when the committed length is within num_speculative_tokens of a
+        # block boundary. Snapshot the union of the committed window and the
+        # forward-most window (seq_lens + num_speculative_tokens - 1) so the
+        # captured set is a superset of every block any step can write. The
+        # windows overlap heavily, but the union keeps a fixed shape (so the
+        # snapshot buffer is reused) and the restore is idempotent where they do.
+        ahead = max(self.num_speculative_tokens - 1, 0)
+        committed = mamba_get_block_table_tensor(
+            bt, seq_lens, self._draft_mamba_spec, mode
+        )
+        forward = mamba_get_block_table_tensor(
+            bt, seq_lens + ahead, self._draft_mamba_spec, mode
+        )
+        block_ids = torch.cat([committed.reshape(-1), forward.reshape(-1)])
+        for layer_name, layer in self._draft_mamba_layers.items():
+            gathered = layer.kv_cache[0][block_ids]
+            snap = self._mamba_state_snapshot.get(layer_name)
+            if snap is None or snap.shape != gathered.shape:
+                self._mamba_state_snapshot[layer_name] = gathered.clone()
+            else:
+                snap.copy_(gathered)
+        return block_ids
+
+    def _restore_draft_mamba_state(self, block_ids: torch.Tensor | None) -> None:
+        """Restore the conv-state blocks captured by
+        _snapshot_draft_mamba_state, undoing the draft loop's in-place advance
+        so the next iteration starts from the committed (post-step-0) state.
+
+        Args:
+            block_ids: The indices returned by _snapshot_draft_mamba_state, or
+                None to skip.
+        """
+        if block_ids is None:
+            return
+        for layer_name, layer in self._draft_mamba_layers.items():
+            snap = self._mamba_state_snapshot.get(layer_name)
+            if snap is not None:
+                layer.kv_cache[0][block_ids] = snap
 
     def model_returns_tuple(self) -> bool:
         if self.method == "mtp":
@@ -1795,6 +1909,28 @@ class SpecDecodeBaseProposer:
             self.draft_attn_groups[0].get_metadata_builder().kv_cache_spec.block_size
         )
         logger.debug("Using block size %d for drafting layers", self.block_size)
+
+        # Collect the drafter's short_conv (Mamba) layers so propose() can
+        # snapshot and restore their recurrent conv-state across the draft loop.
+        # These layers advance their state in place with no rollback, so a
+        # partially-rejected iteration would leave the next iteration's step 0
+        # reading a corrupted anchor. Empty for non-Mamba drafters.
+        self._draft_mamba_layers = {}
+        self._draft_mamba_spec = None
+        self._draft_mamba_gid = -1
+        all_layers = get_layers_from_vllm_config(
+            self.vllm_config,
+            AttentionLayerBase,  # type: ignore[type-abstract]
+        )
+        for attn_group in self.draft_attn_groups:
+            if not isinstance(attn_group.kv_cache_spec, MambaSpec):
+                continue
+            self._draft_mamba_spec = attn_group.kv_cache_spec
+            self._draft_mamba_gid = attn_group.kv_cache_group_id
+            for layer_name in attn_group.layer_names:
+                layer = all_layers.get(layer_name)
+                if isinstance(layer, MambaBase):
+                    self._draft_mamba_layers[layer_name] = layer
 
     def _determine_batch_execution_and_padding(
         self,

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -1681,26 +1681,36 @@ class SpecDecodeBaseProposer:
 
     def validate_same_kv_cache_group(self, kv_cache_config: KVCacheConfig) -> None:
         """
-        Validate that all drafting layers belong to the same KVCacheGroup.
-        Need this assumption to ensure all drafting layers can use the
-        same AttentionMetadata.
-        May extend to multiple AttentionMetadata in the future.
+        Validate that draft layers sharing an attention backend belong to the
+        same KVCacheGroup, so each AttentionGroup maps to a single
+        kv_cache_group_id / AttentionMetadata.
+
+        A hybrid draft model (e.g. LFM2/LFM2.5: short_conv + attention) has
+        draft layers of different backends that legitimately live in different
+        KV cache groups; that is supported (metadata is routed per-layer). What
+        is NOT supported is a single backend's draft layers being split across
+        groups.
         """
-        kv_cache_groups: dict[str, int] = {}
+        all_attn_layers = get_layers_from_vllm_config(
+            self.vllm_config,
+            AttentionLayerBase,  # type: ignore[type-abstract]
+        )
+        layer_to_group: dict[str, int] = {}
         for id, kv_cache_group in enumerate(kv_cache_config.kv_cache_groups):
             for layer_name in kv_cache_group.layer_names:
-                kv_cache_groups[layer_name] = id
-        assert (
-            len(
-                set(
-                    [
-                        kv_cache_groups[layer_name]
-                        for layer_name in self._draft_attn_layer_names
-                    ]
-                )
+                layer_to_group[layer_name] = id
+        backend_to_groups: dict[str, set[int]] = {}
+        for layer_name in self._draft_attn_layer_names:
+            backend_key = all_attn_layers[layer_name].get_attn_backend().full_cls_name()
+            backend_to_groups.setdefault(backend_key, set()).add(
+                layer_to_group[layer_name]
             )
-            == 1
-        ), "All drafting layers should belong to the same kv cache group"
+        for backend_key, gids in backend_to_groups.items():
+            assert len(gids) == 1, (
+                f"Draft layers with attention backend {backend_key} span multiple "
+                f"KV cache groups {sorted(gids)}; each backend's draft layers must "
+                "belong to a single KV cache group."
+            )
 
     def initialize_attn_backend(
         self,
@@ -1716,47 +1726,52 @@ class SpecDecodeBaseProposer:
             AttentionLayerBase,  # type: ignore[type-abstract]
         )
 
-        # Find which kv_cache_group the draft layers belong to
+        # Map each draft layer to its own KV cache group. A hybrid draft model
+        # (short_conv + attention) has layers spanning multiple groups, so we
+        # resolve the (group id, group) per layer instead of assuming one group.
         self.validate_same_kv_cache_group(kv_cache_config)
-        kv_cache_spec = None
+        layer_to_group: dict[str, tuple[int, KVCacheGroupSpec]] = {}
         for gid, group in enumerate(kv_cache_config.kv_cache_groups):
-            if self._draft_attn_layer_names & set(group.layer_names):
-                self.kv_cache_gid = gid
-                kv_cache_spec = group.kv_cache_spec
-                break
+            for layer_name in group.layer_names:
+                if layer_name in self._draft_attn_layer_names:
+                    layer_to_group[layer_name] = (gid, group)
+        # Primary group id, retained for cudagraph / buffer paths.
+        self.kv_cache_gid = (
+            next(iter(layer_to_group.values()))[0] if layer_to_group else -1
+        )
 
         attention_groups: dict[tuple[str, str], AttentionGroup] = {}
-        if kv_cache_spec is not None:
-            for layer_name in self._draft_attn_layer_names:
-                attn_backend = all_attn_layers[layer_name].get_attn_backend()
-                backend_key = attn_backend.full_cls_name()
-                if backend_key not in attention_groups:
-                    layer_kv_cache_spec = kv_cache_spec
-                    if isinstance(layer_kv_cache_spec, UniformTypeKVCacheSpecs):
-                        layer_kv_cache_spec = layer_kv_cache_spec.kv_cache_specs[
-                            layer_name
-                        ]
+        for layer_name in self._draft_attn_layer_names:
+            gid, group = layer_to_group[layer_name]
+            attn_backend = all_attn_layers[layer_name].get_attn_backend()
+            backend_key = attn_backend.full_cls_name()
+            if backend_key not in attention_groups:
+                layer_kv_cache_spec = group.kv_cache_spec
+                if isinstance(layer_kv_cache_spec, UniformTypeKVCacheSpecs):
+                    layer_kv_cache_spec = layer_kv_cache_spec.kv_cache_specs[
+                        layer_name
+                    ]
 
-                    kernel_block_size = (
-                        kernel_block_sizes[self.kv_cache_gid]
-                        if kernel_block_sizes is not None
-                        and self.kv_cache_gid < len(kernel_block_sizes)
-                        else None
-                    )
-                    attn_group = AttentionGroup(
-                        backend=attn_backend,
-                        layer_names=[layer_name],
-                        kv_cache_spec=layer_kv_cache_spec,
-                        kv_cache_group_id=self.kv_cache_gid,
-                    )
-                    attn_group.create_metadata_builders(
-                        self.vllm_config,
-                        self.device,
-                        kernel_block_size=kernel_block_size,
-                    )
-                    attention_groups[backend_key] = attn_group
-                else:
-                    attention_groups[backend_key].layer_names.append(layer_name)
+                kernel_block_size = (
+                    kernel_block_sizes[gid]
+                    if kernel_block_sizes is not None
+                    and gid < len(kernel_block_sizes)
+                    else None
+                )
+                attn_group = AttentionGroup(
+                    backend=attn_backend,
+                    layer_names=[layer_name],
+                    kv_cache_spec=layer_kv_cache_spec,
+                    kv_cache_group_id=gid,
+                )
+                attn_group.create_metadata_builders(
+                    self.vllm_config,
+                    self.device,
+                    kernel_block_size=kernel_block_size,
+                )
+                attention_groups[backend_key] = attn_group
+            else:
+                attention_groups[backend_key].layer_names.append(layer_name)
 
         self.draft_attn_groups = list(attention_groups.values())
         self.block_size = (

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -993,6 +993,23 @@ class SpecDecodeBaseProposer:
     def build_per_group_and_layer_attn_metadata(
         self, common_attn_metadata: CommonAttentionMetadata, draft_index: int = 0
     ) -> tuple[list[object], dict[str, object]]:
+        # A hybrid draft's short_conv (Mamba) metadata builder needs fields the
+        # drafter's common_attn_metadata leaves unset (EAGLE drafters don't need
+        # them): is_prefilling and seq_lens_cpu_upper_bound. Populate them for
+        # decode-phase drafting; attention draft groups ignore them. Draft-side
+        # state errors cannot corrupt output (the target verifies every token),
+        # so this affects acceptance, not correctness.
+        mamba_field_defaults: dict[str, torch.Tensor] = {}
+        if common_attn_metadata.is_prefilling is None:
+            mamba_field_defaults["is_prefilling"] = torch.zeros(
+                common_attn_metadata.num_reqs, dtype=torch.bool
+            )
+        if common_attn_metadata.seq_lens_cpu_upper_bound is None:
+            mamba_field_defaults["seq_lens_cpu_upper_bound"] = (
+                common_attn_metadata.seq_lens_cpu
+            )
+        if mamba_field_defaults:
+            common_attn_metadata = common_attn_metadata.replace(**mamba_field_defaults)
         per_group_attn_metadata: list[object] = []
         per_layer_attn_metadata: dict[str, object] = {}
         for attn_group in self.draft_attn_groups:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -136,6 +136,7 @@ from vllm.v1.attention.backends.linear_attn import (
     BailingLinearAttentionMetadataBuilder,
 )
 from vllm.v1.attention.backends.mamba2_attn import Mamba2AttentionMetadataBuilder
+from vllm.v1.attention.backends.short_conv_attn import ShortConvAttentionMetadataBuilder
 from vllm.v1.attention.backends.utils import (
     NULL_BLOCK_ID,
     create_fast_prefill_custom_backend,
@@ -2451,6 +2452,7 @@ class GPUModelRunner(
                     Mamba2AttentionMetadataBuilder,
                     GDNAttentionMetadataBuilder,
                     BailingLinearAttentionMetadataBuilder,
+                    ShortConvAttentionMetadataBuilder,
                 ),
             ):
                 assert ubid is None, (

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -7174,7 +7174,13 @@ class GPUModelRunner(
                     _, blk_stride = packing
                     num_blocks = raw_tensor.numel() // blk_stride
                 else:
-                    assert raw_tensor.numel() % kv_cache_spec.page_size_bytes == 0
+                    assert (
+                        raw_tensor.numel() % kv_cache_spec.page_size_bytes == 0
+                        or isinstance(kv_cache_spec, MambaSpec)
+                    ), (
+                        f"raw_tensor.numel()={raw_tensor.numel()} not divisible by"
+                        f" page_size_bytes={kv_cache_spec.page_size_bytes}"
+                    )
                     num_blocks = raw_tensor.numel() // kv_cache_spec.page_size_bytes
                 if isinstance(kv_cache_spec, AttentionSpec):
                     has_attn = True

--- a/vllm/v1/worker/mamba_utils.py
+++ b/vllm/v1/worker/mamba_utils.py
@@ -417,8 +417,23 @@ def get_mamba_groups(kv_cache_config: KVCacheConfig) -> tuple[list[int], MambaSp
             mamba_group_ids.append(i)
             mamba_specs.append(kv_cache_spec)
     assert len(mamba_group_ids) > 0, "no mamba layers in the model"
-    assert all(mamba_specs[0] == spec for spec in mamba_specs)
-    return mamba_group_ids, mamba_specs[0]
+    # A hybrid draft model adds mamba group(s) whose per-layer state shapes
+    # differ from the target's. Only the scalar fields consumed downstream
+    # (block_size, num_speculative_blocks) must match across groups; the actual
+    # state copies are driven per-layer from the real cache tensors (see
+    # collect_mamba_copy_meta / MambaSpecDecodeGPUContext), not from this spec.
+    # Requiring full spec equality here needlessly rejects a hybrid draft.
+    ref = mamba_specs[0]
+    for spec in mamba_specs:
+        assert (
+            spec.block_size == ref.block_size
+            and spec.num_speculative_blocks == ref.num_speculative_blocks
+        ), (
+            "Mamba groups must share block_size and num_speculative_blocks; got "
+            f"{(spec.block_size, spec.num_speculative_blocks)} vs "
+            f"{(ref.block_size, ref.num_speculative_blocks)}"
+        )
+    return mamba_group_ids, ref
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Enables speculative decoding with a **classical, separate, hybrid draft model** (e.g. `LiquidAI/LFM2.5-350M`, containing both `short_conv` and `attention` layers) drafting for a hybrid target model (`LiquidAI/LFM2.5-1.2B-Instruct`).

This consolidates and extends several prior/parallel efforts to remove 7 blockers that previously prevented hybrid speculative decoding from initializing and running correctly.

Closes #49112.

### Wall 1: Target-side `short_conv` state corruption (builds on #44296)
Previously, whenever a speculative token was rejected, greedy speculative decoding diverged from the non-spec baseline because the `short_conv` sliding window had no room for rollback.
- Widens the target's `short_conv` state by `num_spec`.
- Routes `num_accepted_tokens` into `ShortConvAttentionMetadataBuilder`.

### Wall 2 & 3: Multi-group speculator KV cache (builds on #35062, #49138)
EAGLE / separate speculator layers were previously collapsed into a single KV cache group, but a hybrid draft has both attention and `short_conv` layers that cannot share one spec-uniform KV group.
- Detects classical draft layers via the `"draft_model"` prefix (index heuristic fails under local indexing).
- Separates speculator layers into dedicated KV cache groups, one per spec type.
- Relaxes `validate_same_kv_cache_group` to assert single group per attention backend (not globally).

### Wall 4, 5 & 6: Drafter metadata initialization
The draft-side metadata builder crashed on the first propose step due to missing fields and an overly strict mamba-spec equality check.
- Relaxes `mamba_utils.get_mamba_groups` full spec-equality check down to invariant fields only (`block_size`, `num_speculative_blocks`).
- Defaults `is_prefilling` to all-`False` for draft-step metadata.
- Populates `seq_lens_cpu_upper_bound` from `seq_lens_cpu` for the draft Mamba metadata builder.

### Wall 7: Drafter-side `short_conv` state rollback leakage
The hybrid drafter's `short_conv` recurrent state was advanced in place with no rollback across the multi-step draft loop, so rejected speculative tokens permanently polluted the state — capping acceptance rate at ~6%.
- Snapshots the draft state after step 0 of the loop.
- Restores the snapshot after verification, undoing speculative advances. Raises acceptance rate back to ~70%.

## Changes

- `vllm/model_executor/layers/mamba/mamba_utils.py`: widen `short_conv_state_shape` to support `conv_kernel - 1 + num_spec`.
- `vllm/model_executor/layers/mamba/short_conv.py`: expose `self.num_spec`; implement spec-aware `causal_conv1d_update` path in `forward_cuda` using `num_accepted_tokens` / `query_start_loc_d`.
- `vllm/v1/core/kv_cache_utils.py`: identify classical separate draft models by `"draft_model"` in layer name (`_identify_speculator_layers`); group speculator layers into dedicated groups dynamically by `KVCacheSpec` (`_get_kv_cache_groups_uniform_page_size`).
- `vllm/v1/worker/mamba_utils.py`: relax `get_mamba_groups` draft-spec equality check to `block_size` + `num_speculative_blocks`.
- `vllm/v1/spec_decode/llm_base_proposer.py`: resolve `(gid, group)` per draft layer dynamically instead of assuming a single target group; add `_snapshot_draft_mamba_state` / `_restore_draft_mamba_state`; default `is_prefilling=False` and fill `seq_lens_cpu_upper_bound` dynamically for Mamba draft groups.

## Test Plan

Validated locally with:
- **Target**: `LiquidAI/LFM2.5-1.2B-Instruct`
- **Draft**: `LiquidAI/LFM2.5-350M`

1. **Greedy equivalence test** — compare greedy speculative-decoding output token-by-token against the non-spec baseline for the same prompts.
2. **Serving/performance test** — start the server with speculative decoding enabled, confirm successful multi-step draft/verify loops, and measure TPOT before/after.

<!-- TODO: add exact commands, e.g.
```bash
vllm serve LiquidAI/LFM2.5-1.2B-Instruct \
  --speculative-config '{"model": "LiquidAI/LFM2.5-350M", "num_speculative_tokens": <N>}'
```
-->

## Test Result

- Greedy speculative decoding output is **identical** to the non-spec baseline (greedy equivalence holds).
- Server starts and completes draft/verify loops successfully with a hybrid draft + hybrid target.
- Acceptance rate for the drafter's `short_conv` state: **~6% → ~70%** after adding the snapshot/restore rollback (Wall 7).
- TPOT: significant reduction observed vs. no-spec baseline.

<!-- TODO: paste actual before/after numbers (TPOT, acceptance rate, throughput) here -->

## Co-authors

This PR consolidates work from multiple contributors/forks:

- Tonoken3 <sakamakismile@gmail.com>
- Jaime Campos Salas <jaime.campos.salas@gmail.com>
- dac quang <quangng9112@gmail.com>
- minhnguyent546 <minhnguyent546@gmail.com>
- qtris123 <triv@nvidia.com>

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

</details>