### PR TITLE
[Bugfix] Check only prompt tail for reasoning end in DelegatingParser

### DIFF
--- a/tests/parser/engine/test_prompt_reasoning_end.py
+++ b/tests/parser/engine/test_prompt_reasoning_end.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Prompt-level reasoning-end detection must only look at the prompt tail."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm.parser.abstract_parser import DelegatingParser
+from vllm.reasoning.minimax_m3_reasoning_parser import MiniMaxM3ReasoningParser
+
+THINK_START = "<mm:think>"
+THINK_END = "</mm:think>"
+START_ID = 100
+END_ID = 101
+
+
+def _tokenizer():
+    """Mock tokenizer where each marker is a single vocabulary token.
+
+    NOTE: tests.parser.engine.conftest.make_mock_tokenizer cannot be used here
+    because it stubs encode() with a constant return value, which would make
+    both markers encode to the same ids and silently void these assertions.
+    """
+    vocab = {THINK_START: START_ID, THINK_END: END_ID}
+    id_to_text = {v: k for k, v in vocab.items()}
+
+    def encode(text, add_special_tokens=False):
+        if text in vocab:
+            return [vocab[text]]
+        return [ord(c) for c in text]
+
+    def decode(ids, skip_special_tokens=False):
+        return "".join(id_to_text.get(i, chr(i) if i < 128 else f"<{i}>") for i in ids)
+
+    tokenizer = MagicMock()
+    tokenizer.get_vocab.return_value = dict(vocab)
+    tokenizer.all_special_tokens = list(vocab)
+    tokenizer.all_special_ids = list(vocab.values())
+    tokenizer.encode.side_effect = encode
+    tokenizer.decode.side_effect = decode
+    return tokenizer
+
+
+@pytest.fixture
+def reasoning_parser():
+    return MiniMaxM3ReasoningParser(_tokenizer())
+
+
+@pytest.fixture
+def parser(reasoning_parser):
+    obj = DelegatingParser.__new__(DelegatingParser)
+    obj._reasoning_parser = reasoning_parser
+    obj._tool_parser = None
+    return obj
+
+
+def test_mock_encodes_markers_as_single_tokens(reasoning_parser):
+    """Guard the fixture itself: if the markers do not encode to the ids used
+    below, every other assertion in this file becomes vacuous."""
+    assert reasoning_parser._start_token_ids == (START_ID,)
+    assert reasoning_parser._end_token_ids == (END_ID,)
+
+
+def test_marker_pair_inside_prompt_does_not_end_reasoning(parser):
+    """A <mm:think></mm:think> pair coming from the chat template must not be
+    mistaken for a completed reasoning block."""
+    # instructions ... <mm:think></mm:think> ... </mm:think> ... user turn
+    prompt = [1, 2, START_ID, END_ID, 3, 4, END_ID, 5, 6]
+    assert parser._prompt_ends_reasoning(prompt) is False
+
+
+def test_unpaired_end_marker_inside_prompt_does_not_end_reasoning(parser):
+    prompt = [1, 2, END_ID, 3, 4, 5]
+    assert parser._prompt_ends_reasoning(prompt) is False
+
+
+def test_prompt_ending_with_end_marker_ends_reasoning(parser):
+    prompt = [1, 2, START_ID, 3, 4, END_ID]
+    assert parser._prompt_ends_reasoning(prompt) is True
+
+
+def test_no_reasoning_parser_ends_reasoning(parser):
+    parser._reasoning_parser = None
+    assert parser._prompt_ends_reasoning([1, 2, 3]) is True

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -798,6 +798,21 @@ class DelegatingParser(Parser):
         )
         return reasoning, content, tool_calls
 
+    def _prompt_ends_reasoning(self, prompt_token_ids: Sequence[int]) -> bool:
+        """Whether the prompt itself leaves reasoning already closed.
+
+        Only the tail of the prompt can close a reasoning block. Scanning the
+        whole prompt returns True whenever the end marker appears anywhere in
+        it -- chat-template instructions, few-shot examples, or an earlier
+        assistant turn -- which silently skips the reasoning phase for the
+        entire generation (see #46042).
+        """
+        if self._reasoning_parser is None:
+            return True
+        end_token_ids = getattr(self._reasoning_parser, "_end_token_ids", None)
+        tail_len = len(end_token_ids) if end_token_ids else 1
+        return self.is_reasoning_end(list(prompt_token_ids)[-tail_len:])
+
     def parse_delta(
         self,
         delta_text: str,
@@ -812,7 +827,7 @@ class DelegatingParser(Parser):
 
         if not state.prompt_reasoning_checked and prompt_token_ids is not None:
             state.prompt_reasoning_checked = True
-            if self._reasoning_parser is None or self.is_reasoning_end(
+            if self._reasoning_parser is None or self._prompt_ends_reasoning(
                 prompt_token_ids
             ):
                 state.reasoning_ended = True


### PR DESCRIPTION
DelegatingParser.parse_delta scanned the entire prompt with is_reasoning_end(), so any reasoning marker inside the chat template or an earlier turn marked reasoning as already finished and the whole generation was emitted as content.

Check only the last tokens of the prompt instead, sized to the parser's end marker.




## Purpose

`DelegatingParser.parse_delta` calls `is_reasoning_end(prompt_token_ids)` over the
**entire** prompt. Any reasoning marker present in the prompt -- from chat-template
instructions, few-shot examples, or an earlier assistant turn -- makes it conclude
reasoning already ended, so `state.reasoning_ended` is set before the first
generated token and the whole response is emitted as `content`.

Reproduced with MiniMax-M3 (`--reasoning-parser minimax_m3`) on v0.25.1 and still
present on main. The rendered prompt contains three markers from the model's own
`<thinking_instructions>` block, at offsets 394 (`<mm:think>`), 404 and 509
(`</mm:think>`). `rfind(end) > rfind(start)` -> True -> reasoning phase skipped.

Related: #46042 (same symptom). #46663 fixes the equivalent check in
`OpenAIServingChat`, but that fix alone is not sufficient: `parse_delta`
recomputes the value independently. Verified on a deployment already carrying
#46663 -- the bug persisted until this second site was fixed.

## Test Plan

Added `tests/parser/engine/test_prompt_reasoning_end.py`:

    pytest tests/parser/engine/test_prompt_reasoning_end.py -v

End-to-end: MiniMax-M3-NVFP4, 4x H200, TP=4, streaming chat completions.

## Test Result

Unit tests: 5 passed with the fix; 4 fail without it.

End-to-end before the fix: every streamed response emitted a literal `<mm:think>`
delta inside `content` and no `reasoning_content` field was present.
After the fix: reasoning is correctly separated into `reasoning_content`.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

