### PR TITLE
[Kernel] Add support for Flashinfer Mamba SSU algorithm selection

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -4,12 +4,21 @@
 import json
 from argparse import ArgumentError
 from contextlib import AbstractContextManager, nullcontext
+from pathlib import Path
 from typing import Annotated, Literal
 
 import pytest
 from pydantic import Field
+from transformers import OPTConfig
 
-from vllm.config import AttentionConfig, CompilationConfig, ModelConfig, config
+from vllm.config import (
+    AttentionConfig,
+    CompilationConfig,
+    MambaConfig,
+    ModelConfig,
+    config,
+)
+from vllm.config.mamba import MambaBackendEnum
 from vllm.engine.arg_utils import (
     EngineArgs,
     _expand_json_human_readable_numbers,
@@ -466,6 +475,80 @@ def test_attention_config():
     assert args is not None
     engine_args = EngineArgs.from_cli_args(args)
     with pytest.raises(ValueError, match="mutually exclusive"):
+        engine_args.create_engine_config()
+
+
+def test_mamba_ssu_algorithm_defaults_to_auto():
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+
+    args = parser.parse_args([])
+    engine_args = EngineArgs.from_cli_args(args)
+    assert engine_args.mamba_ssu_algorithm == "auto"
+
+
+def test_mamba_ssu_algorithm_preserves_positional_config_compatibility():
+    mamba_config = MambaConfig(MambaBackendEnum.FLASHINFER, False, 5)
+
+    assert mamba_config.enable_stochastic_rounding is False
+    assert mamba_config.stochastic_rounding_philox_rounds == 5
+    assert mamba_config.ssu_algorithm == "auto"
+
+
+def test_mamba_ssu_algorithm_cli_reaches_config(tmp_path: Path):
+    OPTConfig(
+        architectures=["OPTForCausalLM"],
+        hidden_size=32,
+        ffn_dim=64,
+        num_attention_heads=4,
+        num_hidden_layers=1,
+        max_position_embeddings=128,
+        vocab_size=128,
+    ).save_pretrained(tmp_path)
+
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+    args = parser.parse_args(
+        [
+            "--model",
+            str(tmp_path),
+            "--mamba-backend",
+            "flashinfer",
+            "--mamba-ssu-algorithm",
+            "horizontal",
+        ]
+    )
+    engine_args = EngineArgs.from_cli_args(args)
+    vllm_config = engine_args.create_engine_config()
+    assert vllm_config.mamba_config.backend == MambaBackendEnum.FLASHINFER
+    assert vllm_config.mamba_config.ssu_algorithm == "horizontal"
+
+
+def test_mamba_ssu_algorithm_requires_flashinfer():
+    with pytest.raises(ValueError, match="only supported.*FlashInfer"):
+        MambaConfig(ssu_algorithm="horizontal")
+
+
+def test_mamba_ssu_algorithm_cli_requires_flashinfer(tmp_path: Path):
+    OPTConfig(
+        architectures=["OPTForCausalLM"],
+        hidden_size=32,
+        ffn_dim=64,
+        num_attention_heads=4,
+        num_hidden_layers=1,
+        max_position_embeddings=128,
+        vocab_size=128,
+    ).save_pretrained(tmp_path)
+
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+    args = parser.parse_args(
+        [
+            "--model",
+            str(tmp_path),
+            "--mamba-ssu-algorithm",
+            "horizontal",
+        ]
+    )
+    engine_args = EngineArgs.from_cli_args(args)
+    with pytest.raises(ValueError, match="only supported.*FlashInfer"):
         engine_args.create_engine_config()
 
 

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -14,7 +14,6 @@ from transformers import OPTConfig
 from vllm.config import (
     AttentionConfig,
     CompilationConfig,
-    MambaConfig,
     ModelConfig,
     config,
 )
@@ -490,26 +489,6 @@ def _save_minimal_opt_config(path: Path) -> None:
     ).save_pretrained(path)
 
 
-def test_mamba_ssu_algorithm_defaults_to_auto(tmp_path: Path):
-    _save_minimal_opt_config(tmp_path)
-    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
-
-    args = parser.parse_args(["--model", str(tmp_path)])
-    engine_args = EngineArgs.from_cli_args(args)
-    vllm_config = engine_args.create_engine_config()
-
-    assert engine_args.mamba_ssu_algorithm is None
-    assert vllm_config.mamba_config.ssu_algorithm == "auto"
-
-
-def test_mamba_ssu_algorithm_preserves_positional_config_compatibility():
-    mamba_config = MambaConfig(MambaBackendEnum.FLASHINFER, False, 5)
-
-    assert mamba_config.enable_stochastic_rounding is False
-    assert mamba_config.stochastic_rounding_philox_rounds == 5
-    assert mamba_config.ssu_algorithm == "auto"
-
-
 def test_mamba_ssu_algorithm_cli_reaches_config(tmp_path: Path):
     _save_minimal_opt_config(tmp_path)
 
@@ -528,28 +507,6 @@ def test_mamba_ssu_algorithm_cli_reaches_config(tmp_path: Path):
     vllm_config = engine_args.create_engine_config()
     assert vllm_config.mamba_config.backend == MambaBackendEnum.FLASHINFER
     assert vllm_config.mamba_config.ssu_algorithm == "horizontal"
-
-
-def test_mamba_ssu_algorithm_preserves_explicit_config(tmp_path: Path):
-    _save_minimal_opt_config(tmp_path)
-    mamba_config = MambaConfig(
-        backend=MambaBackendEnum.FLASHINFER,
-        ssu_algorithm="horizontal",
-    )
-    engine_args = EngineArgs(
-        model=str(tmp_path),
-        mamba_backend=MambaBackendEnum.FLASHINFER,
-        mamba_config=mamba_config,
-    )
-
-    vllm_config = engine_args.create_engine_config()
-
-    assert vllm_config.mamba_config.ssu_algorithm == "horizontal"
-
-
-def test_mamba_ssu_algorithm_requires_flashinfer():
-    with pytest.raises(ValueError, match="only supported.*FlashInfer"):
-        MambaConfig(ssu_algorithm="horizontal")
 
 
 def test_mamba_ssu_algorithm_cli_requires_flashinfer(tmp_path: Path):

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -478,12 +478,28 @@ def test_attention_config():
         engine_args.create_engine_config()
 
 
-def test_mamba_ssu_algorithm_defaults_to_auto():
+def _save_minimal_opt_config(path: Path) -> None:
+    OPTConfig(
+        architectures=["OPTForCausalLM"],
+        hidden_size=32,
+        ffn_dim=64,
+        num_attention_heads=4,
+        num_hidden_layers=1,
+        max_position_embeddings=128,
+        vocab_size=128,
+    ).save_pretrained(path)
+
+
+def test_mamba_ssu_algorithm_defaults_to_auto(tmp_path: Path):
+    _save_minimal_opt_config(tmp_path)
     parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
 
-    args = parser.parse_args([])
+    args = parser.parse_args(["--model", str(tmp_path)])
     engine_args = EngineArgs.from_cli_args(args)
-    assert engine_args.mamba_ssu_algorithm == "auto"
+    vllm_config = engine_args.create_engine_config()
+
+    assert engine_args.mamba_ssu_algorithm is None
+    assert vllm_config.mamba_config.ssu_algorithm == "auto"
 
 
 def test_mamba_ssu_algorithm_preserves_positional_config_compatibility():
@@ -495,15 +511,7 @@ def test_mamba_ssu_algorithm_preserves_positional_config_compatibility():
 
 
 def test_mamba_ssu_algorithm_cli_reaches_config(tmp_path: Path):
-    OPTConfig(
-        architectures=["OPTForCausalLM"],
-        hidden_size=32,
-        ffn_dim=64,
-        num_attention_heads=4,
-        num_hidden_layers=1,
-        max_position_embeddings=128,
-        vocab_size=128,
-    ).save_pretrained(tmp_path)
+    _save_minimal_opt_config(tmp_path)
 
     parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
     args = parser.parse_args(
@@ -522,21 +530,30 @@ def test_mamba_ssu_algorithm_cli_reaches_config(tmp_path: Path):
     assert vllm_config.mamba_config.ssu_algorithm == "horizontal"
 
 
+def test_mamba_ssu_algorithm_preserves_explicit_config(tmp_path: Path):
+    _save_minimal_opt_config(tmp_path)
+    mamba_config = MambaConfig(
+        backend=MambaBackendEnum.FLASHINFER,
+        ssu_algorithm="horizontal",
+    )
+    engine_args = EngineArgs(
+        model=str(tmp_path),
+        mamba_backend=MambaBackendEnum.FLASHINFER,
+        mamba_config=mamba_config,
+    )
+
+    vllm_config = engine_args.create_engine_config()
+
+    assert vllm_config.mamba_config.ssu_algorithm == "horizontal"
+
+
 def test_mamba_ssu_algorithm_requires_flashinfer():
     with pytest.raises(ValueError, match="only supported.*FlashInfer"):
         MambaConfig(ssu_algorithm="horizontal")
 
 
 def test_mamba_ssu_algorithm_cli_requires_flashinfer(tmp_path: Path):
-    OPTConfig(
-        architectures=["OPTForCausalLM"],
-        hidden_size=32,
-        ffn_dim=64,
-        num_attention_heads=4,
-        num_hidden_layers=1,
-        max_position_embeddings=128,
-        vocab_size=128,
-    ).save_pretrained(tmp_path)
+    _save_minimal_opt_config(tmp_path)
 
     parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
     args = parser.parse_args(

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -4,20 +4,12 @@
 import json
 from argparse import ArgumentError
 from contextlib import AbstractContextManager, nullcontext
-from pathlib import Path
 from typing import Annotated, Literal
 
 import pytest
 from pydantic import Field
-from transformers import OPTConfig
 
-from vllm.config import (
-    AttentionConfig,
-    CompilationConfig,
-    ModelConfig,
-    config,
-)
-from vllm.config.mamba import MambaBackendEnum
+from vllm.config import AttentionConfig, CompilationConfig, ModelConfig, config
 from vllm.engine.arg_utils import (
     EngineArgs,
     _expand_json_human_readable_numbers,
@@ -474,55 +466,6 @@ def test_attention_config():
     assert args is not None
     engine_args = EngineArgs.from_cli_args(args)
     with pytest.raises(ValueError, match="mutually exclusive"):
-        engine_args.create_engine_config()
-
-
-def _save_minimal_opt_config(path: Path) -> None:
-    OPTConfig(
-        architectures=["OPTForCausalLM"],
-        hidden_size=32,
-        ffn_dim=64,
-        num_attention_heads=4,
-        num_hidden_layers=1,
-        max_position_embeddings=128,
-        vocab_size=128,
-    ).save_pretrained(path)
-
-
-def test_mamba_ssu_algorithm_cli_reaches_config(tmp_path: Path):
-    _save_minimal_opt_config(tmp_path)
-
-    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
-    args = parser.parse_args(
-        [
-            "--model",
-            str(tmp_path),
-            "--mamba-backend",
-            "flashinfer",
-            "--mamba-ssu-algorithm",
-            "horizontal",
-        ]
-    )
-    engine_args = EngineArgs.from_cli_args(args)
-    vllm_config = engine_args.create_engine_config()
-    assert vllm_config.mamba_config.backend == MambaBackendEnum.FLASHINFER
-    assert vllm_config.mamba_config.ssu_algorithm == "horizontal"
-
-
-def test_mamba_ssu_algorithm_cli_requires_flashinfer(tmp_path: Path):
-    _save_minimal_opt_config(tmp_path)
-
-    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
-    args = parser.parse_args(
-        [
-            "--model",
-            str(tmp_path),
-            "--mamba-ssu-algorithm",
-            "horizontal",
-        ]
-    )
-    engine_args = EngineArgs.from_cli_args(args)
-    with pytest.raises(ValueError, match="only supported.*FlashInfer"):
         engine_args.create_engine_config()
 
 

--- a/tests/kernels/mamba/test_ssu_dispatch.py
+++ b/tests/kernels/mamba/test_ssu_dispatch.py
@@ -97,11 +97,7 @@ def test_flashinfer_forwards_ssu_algorithm(algorithm: str, monkeypatch):
         tensor,
     )
 
-    kwargs = kernel.call_args.kwargs
-    if algorithm == "auto":
-        assert "algorithm" not in kwargs
-    else:
-        assert kwargs["algorithm"] == algorithm
+    assert kernel.call_args.kwargs["algorithm"] == algorithm
 
 
 def test_uninitialized_backend_raises():

--- a/tests/kernels/mamba/test_ssu_dispatch.py
+++ b/tests/kernels/mamba/test_ssu_dispatch.py
@@ -72,8 +72,19 @@ def test_flashinfer_backend_init():
 
 
 @pytest.mark.skipif(not HAS_FLASHINFER, reason="flashinfer not installed")
-@pytest.mark.parametrize("algorithm", ["auto", "simple", "vertical", "horizontal"])
-def test_flashinfer_forwards_ssu_algorithm(algorithm: str, monkeypatch):
+@pytest.mark.parametrize(
+    ("algorithm", "expected"),
+    [
+        (None, "auto"),
+        ("auto", "auto"),
+        ("simple", "simple"),
+        ("vertical", "vertical"),
+        ("horizontal", "horizontal"),
+    ],
+)
+def test_flashinfer_forwards_ssu_algorithm(
+    algorithm: str | None, expected: str, monkeypatch
+):
     import flashinfer.mamba
 
     kernel = Mock()
@@ -97,7 +108,7 @@ def test_flashinfer_forwards_ssu_algorithm(algorithm: str, monkeypatch):
         tensor,
     )
 
-    assert kernel.call_args.kwargs["algorithm"] == algorithm
+    assert kernel.call_args.kwargs["algorithm"] == expected
 
 
 def test_uninitialized_backend_raises():

--- a/tests/kernels/mamba/test_ssu_dispatch.py
+++ b/tests/kernels/mamba/test_ssu_dispatch.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock
 import pytest
 import torch
 
-from vllm.config.mamba import MambaBackendEnum, MambaConfig
+from vllm.config.mamba import MambaBackendEnum, MambaConfig, MambaSSUAlgorithm
 from vllm.model_executor.layers.mamba.ops.ssu_dispatch import (
     FlashInferSSUBackend,
     TritonSSUBackend,
@@ -83,7 +83,9 @@ def test_flashinfer_backend_init():
     ],
 )
 def test_flashinfer_forwards_ssu_algorithm(
-    algorithm: str | None, expected: str, monkeypatch
+    algorithm: MambaSSUAlgorithm | None,
+    expected: MambaSSUAlgorithm,
+    monkeypatch,
 ):
     import flashinfer.mamba
 

--- a/tests/kernels/mamba/test_ssu_dispatch.py
+++ b/tests/kernels/mamba/test_ssu_dispatch.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from unittest.mock import Mock
+
 import pytest
 import torch
 
@@ -67,6 +69,39 @@ def test_flashinfer_backend_init():
     backend = get_mamba_ssu_backend()
     assert isinstance(backend, FlashInferSSUBackend)
     assert backend.name == "flashinfer"
+
+
+@pytest.mark.skipif(not HAS_FLASHINFER, reason="flashinfer not installed")
+@pytest.mark.parametrize("algorithm", ["auto", "simple", "vertical", "horizontal"])
+def test_flashinfer_forwards_ssu_algorithm(algorithm: str, monkeypatch):
+    import flashinfer.mamba
+
+    kernel = Mock()
+    monkeypatch.setattr(flashinfer.mamba, "selective_state_update", kernel)
+    backend = FlashInferSSUBackend(
+        MambaConfig(
+            backend=MambaBackendEnum.FLASHINFER,
+            ssu_algorithm=algorithm,
+        )
+    )
+
+    tensor = torch.empty(1)
+    backend(
+        tensor,
+        tensor,
+        tensor,
+        tensor,
+        tensor,
+        tensor,
+        tensor,
+        tensor,
+    )
+
+    kwargs = kernel.call_args.kwargs
+    if algorithm == "auto":
+        assert "algorithm" not in kwargs
+    else:
+        assert kwargs["algorithm"] == algorithm
 
 
 def test_uninitialized_backend_raises():

--- a/vllm/config/mamba.py
+++ b/vllm/config/mamba.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from enum import Enum, EnumMeta
-from typing import Any
+from typing import Any, Literal, get_args
 
 from pydantic import field_validator
 
@@ -30,6 +30,9 @@ class MambaBackendEnum(Enum, metaclass=_MambaBackendEnumMeta):
     CPU = "cpu"
 
 
+MambaSSUAlgorithm = Literal["auto", "simple", "vertical", "horizontal"]
+
+
 @config
 class MambaConfig:
     """Configuration for Mamba SSM backends."""
@@ -46,6 +49,12 @@ class MambaConfig:
     generation. 0 uses the Triton default. Higher values improve randomness
     quality at the cost of compute."""
 
+    ssu_algorithm: MambaSSUAlgorithm = "auto"
+    """Selective state update algorithm to use with the FlashInfer backend.
+    "auto" preserves FlashInfer's automatic algorithm selection. Forced
+    algorithms must be supported by FlashInfer for the active GPU, state
+    dtype, and decoding mode."""
+
     @field_validator("backend", mode="before")
     @classmethod
     def validate_backend_before(cls, value: Any) -> Any:
@@ -54,7 +63,26 @@ class MambaConfig:
             return MambaBackendEnum[value.upper()]
         return value
 
+    def validate_ssu_algorithm(self) -> None:
+        valid_algorithms = get_args(MambaSSUAlgorithm)
+        if self.ssu_algorithm not in valid_algorithms:
+            valid = ", ".join(valid_algorithms)
+            raise ValueError(
+                f"Unknown Mamba SSU algorithm: '{self.ssu_algorithm}'. "
+                f"Valid options are: {valid}"
+            )
+        if (
+            self.ssu_algorithm != "auto"
+            and self.backend != MambaBackendEnum.FLASHINFER
+        ):
+            raise ValueError(
+                "Mamba SSU algorithm selection is only supported with the "
+                "FlashInfer backend. Please set `--mamba-backend flashinfer`, "
+                "or leave `--mamba-ssu-algorithm` as `auto`."
+            )
+
     def __post_init__(self):
+        self.validate_ssu_algorithm()
         if self.enable_stochastic_rounding:
             from vllm.platforms import current_platform
 

--- a/vllm/config/mamba.py
+++ b/vllm/config/mamba.py
@@ -71,10 +71,7 @@ class MambaConfig:
                 f"Unknown Mamba SSU algorithm: '{self.ssu_algorithm}'. "
                 f"Valid options are: {valid}"
             )
-        if (
-            self.ssu_algorithm != "auto"
-            and self.backend != MambaBackendEnum.FLASHINFER
-        ):
+        if self.ssu_algorithm != "auto" and self.backend != MambaBackendEnum.FLASHINFER:
             raise ValueError(
                 "Mamba SSU algorithm selection is only supported with the "
                 "FlashInfer backend. Please set `--mamba-backend flashinfer`, "

--- a/vllm/config/mamba.py
+++ b/vllm/config/mamba.py
@@ -49,11 +49,11 @@ class MambaConfig:
     generation. 0 uses the Triton default. Higher values improve randomness
     quality at the cost of compute."""
 
-    ssu_algorithm: MambaSSUAlgorithm = "auto"
+    ssu_algorithm: MambaSSUAlgorithm | None = None
     """Selective state update algorithm to use with the FlashInfer backend.
-    "auto" preserves FlashInfer's automatic algorithm selection. Forced
-    algorithms must be supported by FlashInfer for the active GPU, state
-    dtype, and decoding mode."""
+    None defaults to FlashInfer's "auto" algorithm. Forced algorithms must
+    be supported by FlashInfer for the active GPU, state dtype, and decoding
+    mode."""
 
     @field_validator("backend", mode="before")
     @classmethod
@@ -64,6 +64,8 @@ class MambaConfig:
         return value
 
     def validate_ssu_algorithm(self) -> None:
+        if self.ssu_algorithm is None:
+            return
         valid_algorithms = get_args(MambaSSUAlgorithm)
         if self.ssu_algorithm not in valid_algorithms:
             valid = ", ".join(valid_algorithms)
@@ -71,11 +73,11 @@ class MambaConfig:
                 f"Unknown Mamba SSU algorithm: '{self.ssu_algorithm}'. "
                 f"Valid options are: {valid}"
             )
-        if self.ssu_algorithm != "auto" and self.backend != MambaBackendEnum.FLASHINFER:
+        if self.backend != MambaBackendEnum.FLASHINFER:
             raise ValueError(
                 "Mamba SSU algorithm selection is only supported with the "
                 "FlashInfer backend. Please set `--mamba-backend flashinfer`, "
-                "or leave `--mamba-ssu-algorithm` as `auto`."
+                "or omit `--mamba-ssu-algorithm`."
             )
 
     def __post_init__(self):

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -707,7 +707,7 @@ class EngineArgs:
     use_replayssm: bool = CacheConfig.use_replayssm
 
     mamba_backend: MambaBackendEnum = MambaBackendEnum.TRITON
-    mamba_ssu_algorithm: MambaSSUAlgorithm = MambaConfig.ssu_algorithm
+    mamba_ssu_algorithm: MambaSSUAlgorithm | None = None
     enable_mamba_cache_stochastic_rounding: bool = (
         MambaConfig.enable_stochastic_rounding
     )
@@ -962,8 +962,10 @@ class EngineArgs:
             description=MambaConfig.__doc__,
         )
         mamba_group.add_argument("--mamba-backend", **mamba_kwargs["backend"])
+        mamba_ssu_algorithm_kwargs = mamba_kwargs["ssu_algorithm"]
+        mamba_ssu_algorithm_kwargs["default"] = None
         mamba_group.add_argument(
-            "--mamba-ssu-algorithm", **mamba_kwargs["ssu_algorithm"]
+            "--mamba-ssu-algorithm", **mamba_ssu_algorithm_kwargs
         )
         mamba_group.add_argument(
             "--enable-mamba-cache-stochastic-rounding",
@@ -2360,7 +2362,8 @@ class EngineArgs:
             mamba_config.backend = MambaBackendEnum[self.mamba_backend.upper()]
         else:
             mamba_config.backend = self.mamba_backend
-        mamba_config.ssu_algorithm = self.mamba_ssu_algorithm
+        if self.mamba_ssu_algorithm is not None:
+            mamba_config.ssu_algorithm = self.mamba_ssu_algorithm
         if self.enable_mamba_cache_stochastic_rounding:
             mamba_config.enable_stochastic_rounding = (
                 self.enable_mamba_cache_stochastic_rounding

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -962,9 +962,9 @@ class EngineArgs:
             description=MambaConfig.__doc__,
         )
         mamba_group.add_argument("--mamba-backend", **mamba_kwargs["backend"])
-        mamba_ssu_algorithm_kwargs = mamba_kwargs["ssu_algorithm"]
-        mamba_ssu_algorithm_kwargs["default"] = None
-        mamba_group.add_argument("--mamba-ssu-algorithm", **mamba_ssu_algorithm_kwargs)
+        mamba_group.add_argument(
+            "--mamba-ssu-algorithm", **mamba_kwargs["ssu_algorithm"]
+        )
         mamba_group.add_argument(
             "--enable-mamba-cache-stochastic-rounding",
             **mamba_kwargs["enable_stochastic_rounding"],

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -964,9 +964,7 @@ class EngineArgs:
         mamba_group.add_argument("--mamba-backend", **mamba_kwargs["backend"])
         mamba_ssu_algorithm_kwargs = mamba_kwargs["ssu_algorithm"]
         mamba_ssu_algorithm_kwargs["default"] = None
-        mamba_group.add_argument(
-            "--mamba-ssu-algorithm", **mamba_ssu_algorithm_kwargs
-        )
+        mamba_group.add_argument("--mamba-ssu-algorithm", **mamba_ssu_algorithm_kwargs)
         mamba_group.add_argument(
             "--enable-mamba-cache-stochastic-rounding",
             **mamba_kwargs["enable_stochastic_rounding"],

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -77,7 +77,7 @@ from vllm.config.device import Device
 from vllm.config.kernel import IrOpPriorityConfig, LinearBackend, MoEBackend
 from vllm.config.load import SafetensorsLoadStrategy
 from vllm.config.lora import MaxLoRARanks
-from vllm.config.mamba import MambaBackendEnum
+from vllm.config.mamba import MambaBackendEnum, MambaSSUAlgorithm
 from vllm.config.model import (
     ConvertOption,
     HfOverrides,
@@ -707,6 +707,7 @@ class EngineArgs:
     use_replayssm: bool = CacheConfig.use_replayssm
 
     mamba_backend: MambaBackendEnum = MambaBackendEnum.TRITON
+    mamba_ssu_algorithm: MambaSSUAlgorithm = MambaConfig.ssu_algorithm
     enable_mamba_cache_stochastic_rounding: bool = (
         MambaConfig.enable_stochastic_rounding
     )
@@ -961,6 +962,9 @@ class EngineArgs:
             description=MambaConfig.__doc__,
         )
         mamba_group.add_argument("--mamba-backend", **mamba_kwargs["backend"])
+        mamba_group.add_argument(
+            "--mamba-ssu-algorithm", **mamba_kwargs["ssu_algorithm"]
+        )
         mamba_group.add_argument(
             "--enable-mamba-cache-stochastic-rounding",
             **mamba_kwargs["enable_stochastic_rounding"],
@@ -2356,6 +2360,7 @@ class EngineArgs:
             mamba_config.backend = MambaBackendEnum[self.mamba_backend.upper()]
         else:
             mamba_config.backend = self.mamba_backend
+        mamba_config.ssu_algorithm = self.mamba_ssu_algorithm
         if self.enable_mamba_cache_stochastic_rounding:
             mamba_config.enable_stochastic_rounding = (
                 self.enable_mamba_cache_stochastic_rounding
@@ -2364,6 +2369,7 @@ class EngineArgs:
             mamba_config.stochastic_rounding_philox_rounds = (
                 self.mamba_cache_philox_rounds
             )
+        mamba_config.validate_ssu_algorithm()
 
         # Kernel config overrides
         kernel_config = copy.deepcopy(self.kernel_config)

--- a/vllm/model_executor/layers/mamba/ops/ssu_dispatch.py
+++ b/vllm/model_executor/layers/mamba/ops/ssu_dispatch.py
@@ -127,14 +127,7 @@ class FlashInferSSUBackend(MambaSSUBackend):
                 "Please install flashinfer (>= 0.6.4): "
                 "pip install flashinfer-python"
             ) from e
-        # Keep the default call identical to the pre-selector path, including
-        # compatibility with manually installed FlashInfer 0.6.4. Bind an
-        # explicit selection once instead of adding work to every SSU call.
-        self._kernel = (
-            partial(_fi_ssu, algorithm=mamba_config.ssu_algorithm)
-            if mamba_config.ssu_algorithm != "auto"
-            else _fi_ssu
-        )
+        self._kernel = partial(_fi_ssu, algorithm=mamba_config.ssu_algorithm)
 
     @property
     def name(self) -> str:

--- a/vllm/model_executor/layers/mamba/ops/ssu_dispatch.py
+++ b/vllm/model_executor/layers/mamba/ops/ssu_dispatch.py
@@ -10,6 +10,7 @@ the backend defaults to 'cpu'.
 """
 
 from abc import ABC, abstractmethod
+from functools import partial
 
 import torch
 
@@ -126,7 +127,14 @@ class FlashInferSSUBackend(MambaSSUBackend):
                 "Please install flashinfer (>= 0.6.4): "
                 "pip install flashinfer-python"
             ) from e
-        self._kernel = _fi_ssu
+        # Keep the default call identical to the pre-selector path, including
+        # compatibility with manually installed FlashInfer 0.6.4. Bind an
+        # explicit selection once instead of adding work to every SSU call.
+        self._kernel = (
+            partial(_fi_ssu, algorithm=mamba_config.ssu_algorithm)
+            if mamba_config.ssu_algorithm != "auto"
+            else _fi_ssu
+        )
 
     @property
     def name(self) -> str:
@@ -157,7 +165,6 @@ class FlashInferSSUBackend(MambaSSUBackend):
             if self._mamba_config.enable_stochastic_rounding
             else None
         )
-
         self._kernel(
             state,
             x,

--- a/vllm/model_executor/layers/mamba/ops/ssu_dispatch.py
+++ b/vllm/model_executor/layers/mamba/ops/ssu_dispatch.py
@@ -10,11 +10,10 @@ the backend defaults to 'cpu'.
 """
 
 from abc import ABC, abstractmethod
-from functools import partial
 
 import torch
 
-from vllm.config.mamba import MambaBackendEnum, MambaConfig
+from vllm.config.mamba import MambaBackendEnum, MambaConfig, MambaSSUAlgorithm
 from vllm.logger import init_logger
 from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
 from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
@@ -127,7 +126,12 @@ class FlashInferSSUBackend(MambaSSUBackend):
                 "Please install flashinfer (>= 0.6.4): "
                 "pip install flashinfer-python"
             ) from e
-        self._kernel = partial(_fi_ssu, algorithm=mamba_config.ssu_algorithm)
+        logger.info_once("Using FlashInfer Mamba SSU algorithm: %s", self._algorithm)
+        self._kernel = _fi_ssu
+
+    @property
+    def _algorithm(self) -> MambaSSUAlgorithm:
+        return self._mamba_config.ssu_algorithm or "auto"
 
     @property
     def name(self) -> str:
@@ -180,6 +184,7 @@ class FlashInferSSUBackend(MambaSSUBackend):
             out=out,
             rand_seed=rand_seed,
             philox_rounds=self._mamba_config.stochastic_rounding_philox_rounds or 10,
+            algorithm=self._algorithm,
         )
 
 


### PR DESCRIPTION
## Purpose
Allow choosing the Flashinfer Mamba SSU algorithm.
The new command line argument is `--mamba-ssu-algorithm`.

On some use-cases of Nemotron 3 Nano NVFP4 (like ISL/OSL=1k/8k), using "horizontal" instead of "auto" (which eventually chooses "vertical") improves throughput.

## Test Plan
On Nemotron 3 Nano NVFP4 with & without `--mamba-ssu-algorithm horizontal`:
* Throughput benchmark with aiperf (3 runs to account for variance), on a single H100 GPU
* Accuracy test with GSM8K, on TP=2

## Test Result

### Accuracy test

vLLM command:
```
MODEL=nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4
vllm serve "$MODEL" \
  --served-model-name "$MODEL" \
  --trust-remote-code \
  --tensor-parallel-size 2 \
  --max-model-len 8192 \
  --mamba-backend flashinfer \
  --host 0.0.0.0 \
  --port 8000
```
To run with "horizontal", add:
```
--mamba-ssu-algorithm horizontal
```

`lm_eval` command:
```
MODEL=nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4

lm_eval \
  --model local-completions \
  --model_args "base_url=http://127.0.0.1:8000/v1/completions,model=$MODEL,tokenized_requests=False,tokenizer_backend=None,num_concurrent=512,timeout=120,max_retries=5,max_length=8192" \
  --tasks gsm8k \
  --num_fewshot 5 \
  --batch_size auto \
  --seed 42 \
  --output_path "$RESULT_DIR"
```

Results:

Without `--mamba-ssu-algorithm horizontal`:
```
local-completions ({'base_url': 'http://127.0.0.1:37524/v1/completions', 'model': 'nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4', 'tokenized_requests': False, 'tokenizer_backend': None, 'num_concurrent': 512, 'timeout': 120, 'max_retries': 5, 'max_length': 8192}), gen_kwargs: ({}), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.4390|±  |0.0137|
|     |       |strict-match    |     5|exact_match|↑  |0.8423|±  |0.0100|
```

With `--mamba-ssu-algorithm horizontal`:
```
local-completions ({'base_url': 'http://127.0.0.1:37525/v1/completions', 'model': 'nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4', 'tokenized_requests': False, 'tokenizer_backend': None, 'num_concurrent': 512, 'timeout': 120, 'max_retries': 5, 'max_length': 8192}), gen_kwargs: ({}), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.4261|±  |0.0136|
|     |       |strict-match    |     5|exact_match|↑  |0.8438|±  |0.0100|
```


### Throughput benchmark

vLLM command without horizontal:
```
MODEL=nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4

VLLM_MOE_ROUTING_SIMULATION_STRATEGY=uniform_random \
vllm serve "$MODEL" \
  --served-model-name "$MODEL" \
  --max-num-seqs 512 \
  --trust-remote-code \
  --max-model-len 52000 \
  --max-num-batched-tokens 32768 \
  --enable-prefix-caching \
  --async-scheduling \
  --quantization modelopt_fp4 \
  --mamba-backend flashinfer \
  --mamba-cache-mode align \
  --mamba-ssm-cache-dtype float16 \
  --enable-mamba-cache-stochastic-rounding \
  --mamba-cache-philox-rounds 5 \
  --host 0.0.0.0 \
  --port 8000
```

To run with "horizontal", add:
```
--mamba-ssu-algorithm horizontal
```

AIPerf command:
```
MODEL=nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4

aiperf profile \
  --model "$MODEL" \
  --tokenizer "$MODEL" \
  --url http://127.0.0.1:8000 \
  --endpoint-type chat \
  --ui-type None \
  --streaming \
  --concurrency 512 \
  --request-count 1024 \
  --warmup-request-count 16 \
  --isl 1024 \
  --isl-stddev 0 \
  --osl 8192 \
  --osl-stddev 0 \
  --random-seed 42 \
  --use-server-token-count \
  --tokenizer-trust-remote-code \
  --extra-inputs temperature:0 \
  --extra-inputs ignore_eos:true \
  --artifact-dir "$RESULT_DIR"
```

Results (on 1xH100):
| Configuration | Run 1 | Run 2 | Run 3 | Mean output TPS/GPU |
|---|---:|---:|---:|---:|
| FlashInfer default | 13,061.091 | 13,078.941 | 13,087.962 | **13,075.998** |
| FlashInfer horizontal | 13,914.585 | 13,790.473 | 13,902.849 | **13,869.302** |
| Improvement | +6.535% | +5.440% | +6.226% | **+6.067%** |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

