### PR TITLE
[ROCm][Kimi-K3] Model enablement - aiter moe environment variable cleanup

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -1441,6 +1441,7 @@ class rocm_aiter_ops:
         VLLM_ROCM_USE_AITER_FP4_ASM_GEMM: Controls FP4 assembly GEMM.
         VLLM_ROCM_USE_AITER_TRITON_ROPE: Controls Triton rotary embeddings.
         VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: Controls shared expert fusion.
+        VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4: Controls a8w4 SiTU fused MoE variant.
         VLLM_ROCM_USE_AITER_TRITON_GEMM: Controls Triton unquantized GEMM.
 
     Note:
@@ -1509,6 +1510,7 @@ class rocm_aiter_ops:
     # TODO: Consolidate under VLLM_ROCM_USE_AITER_ROPE
     _TRITON_ROTARY_EMBED = envs.VLLM_ROCM_USE_AITER_TRITON_ROPE
     _MOE_SHARED_EXPERTS_ENABLED = envs.VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS
+    _MOE_SITUV2_A8W4 = envs.VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4
     # TODO: Consolidate under _LINEAR_ENABLED
     _TRITON_UNQUANT_GEMM = envs.VLLM_ROCM_USE_AITER_TRITON_GEMM
     # Lazily probed: whether aiter.topk_softmax supports the
@@ -1538,6 +1540,7 @@ class rocm_aiter_ops:
         cls._FP4_GEMM_DYNAMIC_QUANT_ASM = envs.VLLM_ROCM_USE_AITER_FP4_ASM_GEMM
         cls._TRITON_ROTARY_EMBED = envs.VLLM_ROCM_USE_AITER_TRITON_ROPE
         cls._MOE_SHARED_EXPERTS_ENABLED = envs.VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS
+        cls._MOE_SITUV2_A8W4 = envs.VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4
         cls._TRITON_UNQUANT_GEMM = envs.VLLM_ROCM_USE_AITER_TRITON_GEMM
 
     @staticmethod
@@ -1629,6 +1632,13 @@ class rocm_aiter_ops:
     @if_aiter_supported
     def is_fusion_moe_shared_experts_enabled(cls) -> bool:
         return cls.is_fused_moe_enabled() and cls._MOE_SHARED_EXPERTS_ENABLED
+
+    @classmethod
+    @if_aiter_supported
+    def is_fused_moe_situv2_a8w4_enabled(cls) -> bool:
+        # _MOE_SITUV2_A8W4 is a variant of aiter fused moe, so aiter
+        # fused moe must be enabled as well.
+        return cls.is_fused_moe_enabled() and cls._MOE_SITUV2_A8W4
 
     @classmethod
     @if_aiter_supported

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -131,7 +131,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_LINEAR_HIPBMM: bool = False
     VLLM_ROCM_USE_AITER_MOE: bool = True
     VLLM_ROCM_AITER_MOE_DISPATCH_POLICY: int = 0
-    AITER_SITUV2_A8W4: bool = False
+    VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4: bool = False
     VLLM_ROCM_USE_AITER_RMSNORM: bool = True
     VLLM_ROCM_USE_AITER_MLA: bool = True
     VLLM_ROCM_USE_AITER_MHA: bool = True
@@ -1212,9 +1212,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # Route K3 SiTU MXFP4 MoE through the a8w4 (fp8 activation) gate/up-
     # interleaved flydsl kernels instead of the default a16w4 separated path.
-    # Shared with the AITER runtime, which reads the same env var directly.
-    "AITER_SITUV2_A8W4": lambda: (
-        os.getenv("AITER_SITUV2_A8W4", "0").lower() in ("true", "1")
+    # This is the only flag users need: vLLM picks the kernels by passing
+    # gate_mode to AITER and sets the AITER-side workaround env at init.
+    "VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4": lambda: (
+        os.getenv("VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4", "0").lower() in ("true", "1")
     ),
     # MoE sorting dispatch policy for AITER fused MoE kernels.
     #   0 = auto (default): single-pass for small batches, multi-pass

--- a/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
@@ -5,7 +5,6 @@ from functools import lru_cache
 
 import torch
 
-import vllm.envs as envs
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
@@ -376,11 +375,12 @@ def rocm_aiter_fused_experts(
 
         gate_mode = ""
         if activation == MoEActivation.SITU:
-            # a8w4 (AITER_SITUV2_A8W4=1) uses the gate/up-interleaved (_gui_)
-            # fp8 flydsl kernels; default a16w4 SiTU stays separated.
+            # a8w4 (VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4=1) uses the gate/up-
+            # interleaved (_gui_) fp8 flydsl kernels; default a16w4 SiTU stays
+            # separated.
             gate_mode = (
                 GateMode.INTERLEAVE.value
-                if envs.AITER_SITUV2_A8W4
+                if rocm_aiter_ops.is_fused_moe_situv2_a8w4_enabled()
                 else GateMode.SEPARATED.value
             )
         elif quant_config.use_mxfp4_w4a16:

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -14,6 +14,7 @@ from vllm.model_executor.layers.fused_moe import (
     FusedMoEConfig,
     RoutedExperts,
 )
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.all2all_utils import (
     maybe_make_prepare_finalize,
 )
@@ -633,10 +634,18 @@ def select_deepseek_v4_mxfp4_moe_backend(
 
 
 def mxfp4_round_up_hidden_size_and_intermediate_size(
-    backend: Mxfp4MoeBackend, hidden_size: int, intermediate_size: int
+    backend: Mxfp4MoeBackend,
+    hidden_size: int,
+    intermediate_size: int,
+    activation: MoEActivation | None = None,
 ) -> tuple[int, int]:
     """Round up hidden_size and intermediate_size based on backend requirements."""
-    if backend == Mxfp4MoeBackend.EMULATION:
+    if backend == Mxfp4MoeBackend.AITER_MXFP4_BF16 and activation == MoEActivation.SITU:
+        # K3's AITER A16W4 SiTU kernel handles K3's native intermediate size
+        # (moe_intermediate 3072; e.g. 384/partition at TP8); the generic
+        # ROCm 256 round-up would inflate weights and OOM.
+        pass
+    elif backend == Mxfp4MoeBackend.EMULATION:
         # Emulation has no kernel tile; it only needs OCP MX block alignment so the
         # per-block scale buffers (`dim // OCP_MX_BLOCK_SIZE`) aren't floor-truncated
         # by a non-block-aligned TP/DP shard (e.g. 2880 // 4 = 720).

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -642,9 +642,11 @@ def mxfp4_round_up_hidden_size_and_intermediate_size(
     """Round up hidden_size and intermediate_size based on backend requirements."""
     if backend == Mxfp4MoeBackend.AITER_MXFP4_BF16 and activation == MoEActivation.SITU:
         # K3's AITER A16W4 SiTU kernel handles K3's native intermediate size
-        # (moe_intermediate 3072; e.g. 384/partition at TP8); the generic
-        # ROCm 256 round-up would inflate weights and OOM.
-        pass
+        # (moe_intermediate 3072; e.g. 384/partition at TP8). Align to 128 (a
+        # no-op for K3's shapes) rather than the generic ROCm 256 round-up,
+        # which would inflate weights and OOM.
+        intermediate_size = round_up(intermediate_size, 128)
+        hidden_size = round_up(hidden_size, 128)
     elif backend == Mxfp4MoeBackend.EMULATION:
         # Emulation has no kernel tile; it only needs OCP MX block alignment so the
         # per-block scale buffers (`dim // OCP_MX_BLOCK_SIZE`) aren't floor-truncated

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
+
 import torch
 
-import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import (
@@ -518,6 +519,14 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             self.mxfp4_backend = Mxfp4MoeBackend.AITER_MXFP4_BF16
             self.experts_cls = backend_to_kernel_cls(self.mxfp4_backend)[0]
             logger.info_once("Using AITER_MXFP4_BF16 for Kimi-K3 SiTU MXFP4 MoE.")
+            from vllm._aiter_ops import rocm_aiter_ops
+
+            if rocm_aiter_ops.is_fused_moe_situv2_a8w4_enabled():
+                # AITER keeps bf16 activations below this token count, which
+                # would not match the fp8 a8w4 kernels the interleaved SiTU
+                # path is tuned for. The a16w4 path never reads it.
+                # TODO: Remove once AITER takes this as a kernel argument.
+                os.environ["AITER_BF16_FP8_MOE_BOUND"] = "0"
         else:
             self.mxfp4_backend, self.experts_cls = select_deepseek_v4_mxfp4_moe_backend(
                 moe
@@ -563,13 +572,11 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             act_dtype=act_dtype,
             moe_parallel_config=moe_parallel_config,
         )
-        if self.is_k3_situ_aiter:
-            # K3's AITER A16W4 kernel handles K3's native intermediate size
-            # (moe_intermediate 3072; e.g. 384/partition at TP8); the generic
-            # 256 round-up would inflate weights and OOM.
-            return hidden_size, intermediate_size_per_partition
         return mxfp4_round_up_hidden_size_and_intermediate_size(
-            self.mxfp4_backend, hidden_size, intermediate_size_per_partition
+            self.mxfp4_backend,
+            hidden_size,
+            intermediate_size_per_partition,
+            activation=self.moe.activation,
         )
 
     def create_weights(
@@ -719,19 +726,24 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             )
 
         # Convert weights to kernel format
-        w13, w2, w13_scale, w2_scale, w13_bias, w2_bias = (
-            convert_weight_to_mxfp4_moe_kernel_format(
-                mxfp4_backend=self.mxfp4_backend,
-                layer=layer,
-                w13_weight=w13,
-                w2_weight=w2,
-                w13_weight_scale=w13_scale,
-                w2_weight_scale=w2_scale,
-                w13_bias=w13_bias,
-                w2_bias=w2_bias,
-                _cache_permute_indices=self._cache_permute_indices,
+        if self.is_k3_situ_aiter:
+            w13, w2, w13_scale, w2_scale = (
+                self._convert_k3_situ_weight_to_kernel_format(layer)
             )
-        )
+        else:
+            w13, w2, w13_scale, w2_scale, w13_bias, w2_bias = (
+                convert_weight_to_mxfp4_moe_kernel_format(
+                    mxfp4_backend=self.mxfp4_backend,
+                    layer=layer,
+                    w13_weight=w13,
+                    w2_weight=w2,
+                    w13_weight_scale=w13_scale,
+                    w2_weight_scale=w2_scale,
+                    w13_bias=w13_bias,
+                    w2_bias=w2_bias,
+                    _cache_permute_indices=self._cache_permute_indices,
+                )
+            )
 
         # For TRITON backends, weights are wrapped tensors from triton_kernels
         # that don't support .detach(). Manually assign parameters.
@@ -769,7 +781,9 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 layer=layer,
             )
 
-    def _setup_kernel_k3_situ(self, layer: RoutedExperts) -> None:
+    def _convert_k3_situ_weight_to_kernel_format(
+        self, layer: RoutedExperts
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         # K3's AITER A16W4 kernel wants the separated ([gate_all, up_all])
         # stage-1 layout, unlike the interleaved gpt-oss/DeepSeek path in
         # convert_weight_to_mxfp4_moe_kernel_format. Preshuffle once here.
@@ -781,10 +795,10 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         e8m0_dtype = torch.float8_e8m0fnu
         num_experts = layer.w13_weight.shape[0]
 
-        # a8w4 (AITER_SITUV2_A8W4=1) uses the gate/up-interleaved (_gui_) fp8
-        # flydsl kernels, which need w13 weight+scale in interleave layout.
-        # Default a16w4 keeps the separated layout.
-        guinterleave = envs.AITER_SITUV2_A8W4
+        # a8w4 (VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4=1) uses the gate/up-
+        # interleaved (_gui_) fp8 flydsl kernels, which need w13 weight+scale
+        # in interleave layout. Default a16w4 keeps the separated layout.
+        guinterleave = rocm_aiter_ops.is_fused_moe_situv2_a8w4_enabled()
         w13 = rocm_aiter_ops.shuffle_weight_a16w4(
             layer.w13_weight.data.view(fp4_dtype), 16, guinterleave
         )
@@ -797,30 +811,9 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             w13_scale_raw.view(-1, w13_scale_raw.shape[-1]), num_experts, guinterleave
         )
         w2_scale = e8m0_shuffle(w2_scale_raw.view(-1, w2_scale_raw.shape[-1]))
-
-        replace_parameter(layer, "w13_weight", w13)
-        replace_parameter(layer, "w2_weight", w2)
-        replace_parameter(layer, "w13_weight_scale", w13_scale)
-        replace_parameter(layer, "w2_weight_scale", w2_scale)
-        layer.w13_weight.is_shuffled = True
-        layer.w2_weight.is_shuffled = True
-
-        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
-        if self.moe_quant_config is not None and self.experts_cls is not None:
-            self.moe_kernel = make_mxfp4_moe_kernel(
-                moe_quant_config=self.moe_quant_config,
-                moe_config=self.moe,
-                mxfp4_backend=self.mxfp4_backend,
-                experts_cls=self.experts_cls,
-                routing_tables=layer._expert_routing_tables(),
-                layer=layer,
-            )
+        return w13, w2, w13_scale, w2_scale
 
     def process_weights_after_loading(self, layer):
-        if self.is_k3_situ_aiter:
-            self._setup_kernel_k3_situ(layer)
-            return
-
         w13 = layer.w13_weight
         w2 = layer.w2_weight
         w13_scale = layer.w13_weight_scale


### PR DESCRIPTION



## Purpose
Based on Day 0 code enablement on ROCm, this PR is to address review comment on vLLM master PR for Kimi-k3 Enablement. It also intends to clean up/minimze environment variables as well.

[[New model] Kimi K3 by ZJY0516 · Pull Request #50000 · vllm-project/vllm](https://github.com/vllm-project/vllm/pull/50000),

Changes (addresses @tjtanaa and @BowenBao review comments on #50000):

Env rename + hot-path caching — AITER_SITUV2_A8W4 → VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4, following vLLM naming. Cached in rocm_aiter_ops as _MOE_SITUV2_A8W4 with is_fused_moe_situv2_a8w4_enabled() (requires is_fused_moe_enabled()) and wired into refresh_env_variables(). Removes per-forward envs. reads in rocm_aiter_moe.py per #17067. (_aiter_ops.py, envs.py, rocm_aiter_moe.py, mxfp4.py)

No raw AITER flags for users — vLLM sets AITER_BF16_FP8_MOE_BOUND=0 itself at MoE-method init (not in the forward pass), scoped to the a8w4 branch with a TODO to remove once AITER fixes it. The recipe no longer needs it. Also deleted a dead AITER_SITUV2_A8W4 export: AITER reads that var only in its SEPARATED branch, which vLLM reaches only when a8w4 is off, so GateMode.INTERLEAVE alone selects the fp8 kernels. (mxfp4.py)

Backend logic into the oracle — the K3 SiTU "skip round-up" case moved from Mxfp4MoEMethod.maybe_roundup_sizes into mxfp4_round_up_hidden_size_and_intermediate_size() via a new optional activation arg. (oracle/mxfp4.py, mxfp4.py)

K3 setup folded into _setup_kernel — dropped the separate _setup_kernel_k3_situ early-return; K3 now shares the common shape assertions, parameter replacement, quant-config and kernel build, with only the preshuffle isolated in _convert_k3_situ_weight_to_kernel_format. (mxfp4.py)

## Test Plan
Test both a8w4 and a16w4 path.

Common envs:
```
export VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_MOE=1 VLLM_ROCM_USE_AITER_MLA=1
export VLLM_USE_BREAKABLE_CUDAGRAPH=0
export SAFETENSORS_FAST_GPU=1
MODEL=/data/Kimi-K3-public
```
(1) a8w4 MoE (fp8 activations, gate/up-interleaved flydsl kernels — the faster path):

```
VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4=1 \
vllm serve $MODEL --trust-remote-code --host 127.0.0.1 --port 8005 \
  --gpu-memory-utilization 0.95 --tensor-parallel-size 8 --mm-encoder-tp-mode data \
  --max-model-len 10240 --max-num-batched-tokens 4096 --max-num-seqs 128 \
  --reasoning-parser kimi_k3
```

(2) a16w4 MoE (bf16 activations, separated layout — the default): (TODO - update a8w4 as default)

```
VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4=0 \
vllm serve $MODEL --trust-remote-code --host 127.0.0.1 --port 8005 \
  --gpu-memory-utilization 0.95 --tensor-parallel-size 8 --mm-encoder-tp-mode data \
  --max-model-len 10240 --max-num-batched-tokens 4096 --max-num-seqs 128 \
  --reasoning-parser kimi_k3
```

## Test Result

benchmarking to ensure no regression. (e.g., 8k/1k con64: a8w4 has 3.5% perf above a16w4)
eval test to ensure accuracy pass. (GSM8K 1319q within noise)


Path | GSM8K 1319q, 5-shot
-- | --
a8w4 (VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4=1) | 94.62% 
a16w4 (default) | 95.00% 

the other benchmarks (kvv, eg: OCRBench)  was run on a8w4 on Day 0 image and all passed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

