### PR TITLE
LUT-B quantization accuracy prototype

### DIFF
--- a/docs/features/quantization/llm_compressor/README.md
+++ b/docs/features/quantization/llm_compressor/README.md
@@ -29,3 +29,52 @@ Also includes support for QuIP and SpinQuant-style transforms as well as KV cach
 
 - [LLM Compressor examples](https://github.com/vllm-project/llm-compressor/tree/main/examples)
 - [GitHub Repository](https://github.com/vllm-project/llm-compressor)
+
+## Experimental Rubin LUT-B evaluation
+
+The `lut_b` linear backend is a calibration-free accuracy prototype for dense
+NVFP4 linear layers. During checkpoint loading, it dequantizes each NVFP4
+weight, fits an eight-entry E4M3 codebook for every 8x64 tile, and packs one
+3-bit index per weight. The resulting representation uses 3.125 bits per
+weight.
+
+The reference forward fully reconstructs the BF16/FP16 weight before
+`torch.nn.functional.linear`. It does not use the Rubin MMA and is intended
+only for accuracy evaluation:
+
+```bash
+vllm serve RedHatAI/Qwen3-8B-NVFP4 \
+  --linear-backend lut_b \
+  --enforce-eager \
+  --port 8000
+```
+
+For a useful GSM8K comparison, run these four configurations:
+
+| Input checkpoint | Options | Measurement |
+| ---------------- | ------- | ----------- |
+| `Qwen/Qwen3-8B` | `--quantization lut_b --enforce-eager` | Direct BF16-to-LUT-B weight-only loss |
+| `RedHatAI/Qwen3-8B-NVFP4` | Default options | NVFP4 weight-and-activation quantization |
+| `RedHatAI/Qwen3-8B-NVFP4` | `--linear-backend marlin` | Existing NVFP4 weights with unquantized activations |
+| `RedHatAI/Qwen3-8B-NVFP4` | `--linear-backend lut_b --enforce-eager` | NVFP4-to-LUT-B weight-only conversion |
+
+Run the default case on hardware with a native NVFP4 W4A4 backend and confirm
+the selected backend in the server log. On older hardware, automatic selection
+can fall back to Marlin and duplicate the explicit weight-only measurement.
+
+Run the internal GSM8K harness against each server, changing the result
+filename:
+
+```bash
+.venv/bin/python tests/evals/gsm8k/gsm8k_eval.py \
+  --port 8000 \
+  --num-questions 1319 \
+  --num-shots 5 \
+  --temperature 0 \
+  --max-concurrency 32 \
+  --save-results lut-b-qwen3-8b.json
+```
+
+The prototype supports dense NVFP4 linear weights whose sharded K dimension
+is divisible by 64 and whose logical output widths are divisible by 8. MoE
+weights and the hardware-specific GMEM/SMEM/TMEM layouts are not included.

--- a/docs/features/quantization/online.md
+++ b/docs/features/quantization/online.md
@@ -3,7 +3,7 @@
 Online quantization lets you take a BF16/FP16 model and quantize its Linear
 and MoE weights to lower precision (such as FP8) at load time, without needing
 a pre-quantized checkpoint or calibration data. Weights are converted during
-model loading and activations are dynamically scaled during each forward pass.
+model loading. Activation handling depends on the selected scheme.
 
 ## Quick Start
 
@@ -20,6 +20,9 @@ llm = LLM("meta-llama/Llama-3.1-8B", quantization="fp8_per_block")
 
 # MXFP8 quantization for weights and activations
 llm = LLM("meta-llama/Llama-3.1-8B", quantization="mxfp8")
+
+# Rubin LUT-B reference weight quantization
+llm = LLM("Qwen/Qwen3-8B", quantization="lut_b", enforce_eager=True)
 ```
 
 Or with the CLI:
@@ -28,6 +31,7 @@ Or with the CLI:
 vllm serve meta-llama/Llama-3.1-8B --quantization fp8_per_tensor
 vllm serve meta-llama/Llama-3.1-8B --quantization fp8_per_block
 vllm serve meta-llama/Llama-3.1-8B --quantization mxfp8
+vllm serve Qwen/Qwen3-8B --quantization lut_b --enforce-eager
 ```
 
 ## Supported Schemes
@@ -37,6 +41,33 @@ vllm serve meta-llama/Llama-3.1-8B --quantization mxfp8
 | `fp8_per_tensor` | fp8_e4m3 data, fp32 per-tensor scale | fp8_e4m3 data, fp32 per-tensor scale | On some GPUs (Ada, Hopper) linear activations use per-token scaling for better performance |
 | `fp8_per_block` | fp8_e4m3 data, fp32 per-128x128-block scale | fp8_e4m3 data, fp32 per-1x128-block scale | |
 | `mxfp8` | fp8_e4m3 data, e8m0 per-1x32-block scale | fp8_e4m3 data, e8m0 per-1x32-block scale | Requires SM 100+ (Blackwell or newer) for w8a8, other GPUs use a w8a16 fallback |
+| `lut_b` | 3-bit indices, eight E4M3 values per 8x64 tile | Unquantized | Reference accuracy path; fully reconstructs weights before each linear |
+
+### Rubin LUT-B reference
+
+The calibration-free `lut_b` path fits each BF16/FP16 dense linear weight
+during model loading. Its persistent representation is 3.125 bits per weight:
+192 bytes of packed indices and an eight-byte E4M3 codebook for every 8x64
+tile.
+
+This is an accuracy prototype. It fully reconstructs the weight and calls
+`torch.nn.functional.linear` on every forward rather than executing the Rubin
+MMA. MoE weights and the hardware-specific memory layouts are not included.
+
+Calibration-free fitting ablations are available through
+`quantization_config.linear.algorithm`. The supported values are `multistart`,
+`scaled`, `residual_{1,2,4,8}`, and `scaled_residual_{1,2,4,8}`:
+
+```bash
+vllm serve Qwen/Qwen3-8B \
+  --quantization online \
+  --quantization-config.linear.weight lut_b \
+  --quantization-config.linear.algorithm residual_1 \
+  --enforce-eager
+```
+
+The residual algorithms add logical sparse correction sidecars for accuracy
+experiments. These sidecars are not consumed by the Rubin LUT MMA.
 
 ## Advanced Configuration
 
@@ -49,6 +80,7 @@ quantization_config:
   linear:
     weight: <name>      # see QUANT_KEY_NAMES in vllm/config/quantization.py
     activation: <name>
+    algorithm: <name>   # optional online fitting algorithm
   moe:
     weight: <name>
     activation: <name>

--- a/tests/kernels/quantization/test_nvfp4_lut_b.py
+++ b/tests/kernels/quantization/test_nvfp4_lut_b.py
@@ -1,0 +1,262 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.config.kernel import KernelConfig
+from vllm.model_executor.kernels.linear import _LINEAR_BACKEND_KERNEL_MAP
+from vllm.model_executor.kernels.linear.nvfp4.base import NvFp4LinearLayerConfig
+from vllm.model_executor.kernels.linear.nvfp4.lut_b import (
+    LUT_B_PACKED_TILE_BYTES,
+    LutBNvFp4LinearKernel,
+    dequantize_lut_b,
+    dequantize_nvfp4_weight,
+    pack_lut_b_indices,
+    quantize_lut_b,
+    quantize_lut_b_calibration_free,
+    unpack_lut_b_indices,
+)
+from vllm.model_executor.layers.quantization import modelopt
+from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
+    compressed_tensors_w4a4_nvfp4 as ct_nvfp4,
+)
+from vllm.model_executor.layers.quantization.quark.schemes import quark_nvfp4
+
+
+def _make_nvfp4_layer(global_scales: torch.Tensor) -> torch.nn.Module:
+    layer = torch.nn.Module()
+    layer.weight = torch.nn.Parameter(
+        torch.full((16, 32), 0x42, dtype=torch.uint8),
+        requires_grad=False,
+    )
+    layer.weight_scale = torch.nn.Parameter(
+        torch.ones((16, 4), dtype=torch.float8_e4m3fn),
+        requires_grad=False,
+    )
+    layer.weight_global_scale = torch.nn.Parameter(
+        global_scales,
+        requires_grad=False,
+    )
+    layer.logical_widths = [8, 8]
+    layer.output_size_per_partition = 16
+    return layer
+
+
+def test_lut_b_index_pack_round_trip() -> None:
+    indices = torch.randint(0, 8, (7, 512), dtype=torch.uint8)
+
+    packed = pack_lut_b_indices(indices)
+    reconstructed = unpack_lut_b_indices(packed)
+
+    assert packed.shape == (7, LUT_B_PACKED_TILE_BYTES)
+    torch.testing.assert_close(reconstructed, indices)
+
+
+def test_lut_b_tile_layout_has_3_125_bits_per_weight() -> None:
+    weight = torch.empty(16, 128, dtype=torch.float32)
+    expected_values = ((0.5, 1.0), (2.0, 4.0))
+    for n_tile in range(2):
+        for k_tile in range(2):
+            weight[
+                n_tile * 8 : (n_tile + 1) * 8,
+                k_tile * 64 : (k_tile + 1) * 64,
+            ] = expected_values[n_tile][k_tile]
+
+    packed, codebooks = quantize_lut_b(weight)
+    reconstructed = dequantize_lut_b(
+        packed,
+        codebooks,
+        out_dtype=weight.dtype,
+    )
+
+    assert packed.shape == (2, 2, 192)
+    assert codebooks.shape == (2, 2, 8)
+    assert codebooks.dtype == torch.float8_e4m3fn
+    assert packed.numel() + codebooks.numel() == 4 * 200
+    torch.testing.assert_close(reconstructed, weight)
+
+
+def test_lut_b_multistart_does_not_increase_reconstruction_error() -> None:
+    torch.manual_seed(4)
+    weight = torch.randn(8, 64, dtype=torch.float32)
+    baseline_packed, baseline_codebooks = quantize_lut_b(weight)
+    multistart_packed, multistart_codebooks, _, _, _ = quantize_lut_b_calibration_free(
+        weight, algorithm="multistart"
+    )
+
+    baseline = dequantize_lut_b(
+        baseline_packed,
+        baseline_codebooks,
+        out_dtype=torch.float32,
+    )
+    multistart = dequantize_lut_b(
+        multistart_packed,
+        multistart_codebooks,
+        out_dtype=torch.float32,
+    )
+    assert torch.mean((multistart - weight).square()) <= torch.mean(
+        (baseline - weight).square()
+    )
+
+
+def test_lut_b_sparse_residual_reduces_reconstruction_error() -> None:
+    torch.manual_seed(5)
+    weight = torch.randn(8, 64, dtype=torch.float32)
+    packed, codebooks, scale, position, residual = quantize_lut_b_calibration_free(
+        weight, algorithm="residual_1"
+    )
+    baseline = dequantize_lut_b(
+        packed,
+        codebooks,
+        out_dtype=torch.float32,
+        output_scale=scale,
+    )
+    corrected = dequantize_lut_b(
+        packed,
+        codebooks,
+        out_dtype=torch.float32,
+        output_scale=scale,
+        residual_position=position,
+        residual_value=residual,
+    )
+
+    assert position is not None and position.shape == (1, 1)
+    assert residual is not None and residual.shape == (1, 1)
+    assert torch.mean((corrected - weight).square()) < torch.mean(
+        (baseline - weight).square()
+    )
+
+
+def test_lut_b_multiple_sparse_residuals() -> None:
+    torch.manual_seed(6)
+    weight = torch.randn(8, 64, dtype=torch.float32)
+    packed, codebooks, scale, position, residual = quantize_lut_b_calibration_free(
+        weight, algorithm="scaled_residual_4"
+    )
+    corrected = dequantize_lut_b(
+        packed,
+        codebooks,
+        out_dtype=torch.float32,
+        output_scale=scale,
+        residual_position=position,
+        residual_value=residual,
+    )
+
+    assert position is not None and position.shape == (1, 1, 4)
+    assert residual is not None and residual.shape == (1, 1, 4)
+    assert torch.isfinite(corrected).all()
+
+
+def test_nvfp4_decode_preserves_fused_partition_scales() -> None:
+    layer = _make_nvfp4_layer(torch.tensor([0.5, 0.25], dtype=torch.float32))
+
+    weight = dequantize_nvfp4_weight(
+        layer.weight,
+        layer.weight_scale,
+        layer.weight_global_scale,
+        layer.logical_widths,
+        out_dtype=torch.float32,
+    )
+
+    expected = torch.tensor([0.5, 1.0], dtype=torch.float32).repeat(16, 32)
+    expected[8:] *= 0.5
+    torch.testing.assert_close(weight, expected)
+
+
+def test_lut_b_backend_repacks_and_uses_reference_linear() -> None:
+    layer = _make_nvfp4_layer(torch.tensor([0.5, 0.25], dtype=torch.float32))
+    source_weight = dequantize_nvfp4_weight(
+        layer.weight,
+        layer.weight_scale,
+        layer.weight_global_scale,
+        layer.logical_widths,
+        out_dtype=torch.float32,
+    )
+    kernel = LutBNvFp4LinearKernel(NvFp4LinearLayerConfig())
+
+    kernel.process_weights_after_loading(layer)
+
+    assert layer.weight.shape == (2, 1, 192)
+    assert layer.weight_codebook.shape == (2, 1, 8)
+    assert not hasattr(layer, "weight_scale")
+    assert not hasattr(layer, "weight_global_scale")
+    reconstructed = dequantize_lut_b(
+        layer.weight,
+        layer.weight_codebook,
+        out_dtype=torch.float32,
+    )
+    torch.testing.assert_close(reconstructed, source_weight)
+
+    x = torch.randn(3, 64, dtype=torch.float32)
+    bias = torch.randn(16, dtype=torch.float32)
+    actual = kernel.apply_weights(layer, x, bias)
+    expected = torch.nn.functional.linear(x, reconstructed, bias)
+    torch.testing.assert_close(actual, expected)
+
+
+def test_compressed_tensors_passes_distinct_scales_to_lut_b() -> None:
+    layer = _make_nvfp4_layer(torch.tensor([2.0, 4.0], dtype=torch.float32))
+    layer.weight_packed = layer.weight
+    del layer.weight
+    layer.input_global_scale = torch.nn.Parameter(
+        torch.ones(2, dtype=torch.float32),
+        requires_grad=False,
+    )
+    scheme = ct_nvfp4.CompressedTensorsW4A4Fp4.__new__(
+        ct_nvfp4.CompressedTensorsW4A4Fp4
+    )
+    scheme.kernel = LutBNvFp4LinearKernel(NvFp4LinearLayerConfig())
+
+    scheme.process_weights_after_loading(layer)
+
+    reconstructed = dequantize_lut_b(
+        layer.weight,
+        layer.weight_codebook,
+        out_dtype=torch.float32,
+    )
+    expected = torch.tensor([0.5, 1.0], dtype=torch.float32).repeat(16, 32)
+    expected[8:] *= 0.5
+    torch.testing.assert_close(reconstructed, expected)
+
+
+@pytest.mark.parametrize(
+    ("method_cls", "input_scale_name"),
+    [
+        (modelopt.ModelOptNvFp4LinearMethod, "input_scale"),
+        (quark_nvfp4.QuarkNVFP4, "input_scale_2"),
+    ],
+)
+def test_nvfp4_loaders_pass_distinct_scales_to_lut_b(
+    method_cls: type,
+    input_scale_name: str,
+) -> None:
+    layer = _make_nvfp4_layer(torch.tensor([0.5, 0.25], dtype=torch.float32))
+    del layer.weight_global_scale
+    layer.weight_scale_2 = torch.nn.Parameter(
+        torch.tensor([0.5, 0.25], dtype=torch.float32),
+        requires_grad=False,
+    )
+    setattr(
+        layer,
+        input_scale_name,
+        torch.nn.Parameter(torch.ones(2, dtype=torch.float32), requires_grad=False),
+    )
+    method = method_cls.__new__(method_cls)  # type: ignore[call-overload]
+    method.kernel = LutBNvFp4LinearKernel(NvFp4LinearLayerConfig())
+
+    method.process_weights_after_loading(layer)
+
+    reconstructed = dequantize_lut_b(
+        layer.weight,
+        layer.weight_codebook,
+        out_dtype=torch.float32,
+    )
+    expected = torch.tensor([0.5, 1.0], dtype=torch.float32).repeat(16, 32)
+    expected[8:] *= 0.5
+    torch.testing.assert_close(reconstructed, expected)
+
+
+def test_lut_b_linear_backend_registration() -> None:
+    assert _LINEAR_BACKEND_KERNEL_MAP["lut_b"] == {LutBNvFp4LinearKernel}
+    assert KernelConfig(linear_backend="lut-b").linear_backend == "lut_b"

--- a/tests/quantization/test_online.py
+++ b/tests/quantization/test_online.py
@@ -9,18 +9,124 @@ from tests.quantization.utils import (
     _test_online_quant_peak_mem_impl,
     is_quant_method_supported,
 )
-from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+from vllm.config.quantization import QuantizationConfigArgs
+from vllm.model_executor.kernels.linear.nvfp4.lut_b import dequantize_lut_b
+from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
+from vllm.model_executor.layers.quantization.online.base import (
+    OnlineQuantizationConfig,
+)
 from vllm.model_executor.layers.quantization.online.fp8 import (
     Fp8PerBlockOnlineLinearMethod,
     Fp8PerBlockOnlineMoEMethod,
     Fp8PerTensorOnlineLinearMethod,
     Fp8PerTensorOnlineMoEMethod,
 )
+from vllm.model_executor.layers.quantization.online.lut_b import (
+    LutBOnlineLinearMethod,
+)
 from vllm.model_executor.layers.quantization.online.nvfp4 import (
     Nvfp4OnlineMoEMethod,
 )
 from vllm.platforms import current_platform
 from vllm.utils.flashinfer import has_flashinfer_trtllm_fused_moe
+
+
+def test_online_lut_b_dispatches_dense_linear(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = OnlineQuantizationConfig(
+        QuantizationConfigArgs(
+            linear="lut_b",
+        )
+    )
+    layer = LinearBase(
+        64,
+        8,
+        params_dtype=torch.bfloat16,
+        quant_config=config,
+        prefix="proj",
+        tp_rank=0,
+        tp_size=1,
+    )
+
+    assert isinstance(layer.quant_method, LutBOnlineLinearMethod)
+    monkeypatch.setattr(
+        "vllm.model_executor.parameter.get_tensor_model_parallel_rank", lambda: 0
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.parameter.get_tensor_model_parallel_world_size",
+        lambda: 1,
+    )
+    loaded_layer = torch.nn.Module()
+    layer.quant_method.create_weights(
+        loaded_layer,
+        input_size_per_partition=64,
+        output_partition_sizes=[8],
+        input_size=64,
+        output_size=8,
+        params_dtype=torch.bfloat16,
+    )
+    assert loaded_layer.weight.shape == (8, 64)
+    assert loaded_layer.weight.device.type == "meta"
+
+
+def test_online_lut_b_repacks_and_uses_reference_linear() -> None:
+    torch.manual_seed(0)
+    weight = torch.randn(8, 64, dtype=torch.float32) * 0.1
+    x = torch.randn(3, 64, dtype=torch.float32)
+    bias = torch.randn(8, dtype=torch.float32)
+    layer = torch.nn.Module()
+    layer.weight = torch.nn.Parameter(weight, requires_grad=False)
+    method = LutBOnlineLinearMethod()
+
+    method.process_weights_after_loading(layer)
+    actual = method.apply(layer, x, bias)
+
+    reconstructed = dequantize_lut_b(
+        layer.weight,
+        layer.weight_codebook,
+        out_dtype=x.dtype,
+    )
+    expected = torch.nn.functional.linear(x, reconstructed, bias)
+    assert layer.weight.shape == (1, 1, 192)
+    assert layer.weight_codebook.shape == (1, 1, 8)
+    torch.testing.assert_close(actual, expected)
+
+
+@pytest.mark.parametrize(
+    ("algorithm", "has_scale", "has_residual"),
+    [
+        ("multistart", False, False),
+        ("scaled", True, False),
+        ("residual_1", False, True),
+        ("scaled_residual_1", True, True),
+    ],
+)
+def test_online_lut_b_calibration_free_algorithms(
+    algorithm: str,
+    has_scale: bool,
+    has_residual: bool,
+) -> None:
+    torch.manual_seed(1)
+    weight = torch.randn(8, 64, dtype=torch.float32) * 0.1
+    x = torch.randn(2, 64, dtype=torch.float32)
+    layer = torch.nn.Module()
+    layer.weight = torch.nn.Parameter(weight, requires_grad=False)
+    method = LutBOnlineLinearMethod(algorithm=algorithm)
+
+    method.process_weights_after_loading(layer)
+    actual = method.apply(layer, x)
+
+    assert hasattr(layer, "weight_output_scale") is has_scale
+    assert hasattr(layer, "weight_residual_position") is has_residual
+    assert hasattr(layer, "weight_residual_value") is has_residual
+    expected_weight = dequantize_lut_b(
+        layer.weight,
+        layer.weight_codebook,
+        out_dtype=x.dtype,
+        output_scale=getattr(layer, "weight_output_scale", None),
+        residual_position=getattr(layer, "weight_residual_position", None),
+        residual_value=getattr(layer, "weight_residual_value", None),
+    )
+    torch.testing.assert_close(actual, torch.nn.functional.linear(x, expected_weight))
 
 
 @pytest.mark.skipif(

--- a/tests/quantization/test_quantization_config_args.py
+++ b/tests/quantization/test_quantization_config_args.py
@@ -16,6 +16,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8Static128BlockSym,
     kFp8StaticTensorSym,
     kInt8StaticChannelSym,
+    kLutBStatic,
     kMxfp8Dynamic,
 )
 
@@ -85,6 +86,17 @@ def test_resolve_int8_shorthand_leaves_linear_unset():
     args = resolve_quantization_config("int8_per_channel_weight_only", None)
     assert args.linear is None
     assert args.moe == QuantSpec(weight=kInt8StaticChannelSym)
+
+
+def test_resolve_lut_b_shorthand_is_linear_weight_only():
+    args = resolve_quantization_config("lut_b", None)
+    assert args.linear == QuantSpec(weight=kLutBStatic)
+    assert args.moe is None
+
+
+def test_lut_b_algorithm_config():
+    args = QuantizationConfigArgs(linear={"weight": "lut_b", "algorithm": "residual_1"})
+    assert args.linear == QuantSpec(weight=kLutBStatic, algorithm="residual_1")
 
 
 def test_resolve_quantization_config_only():

--- a/vllm/config/kernel.py
+++ b/vllm/config/kernel.py
@@ -149,6 +149,7 @@ LinearBackend = Literal[
     "flashinfer_b12x",
     "marlin",
     "humming",
+    "lut_b",
     "triton",
     "deep_gemm",
     "torch",
@@ -224,6 +225,7 @@ class KernelConfig:
     - "flashinfer_cudnn": Use FlashInfer with cuDNN kernels
     - "flashinfer_b12x": Use FlashInfer b12x CuteDSL NVFP4 GEMM (SM120+)
     - "marlin": Use Marlin kernels
+    - "lut_b": Repack NVFP4 weights to the experimental Rubin LUT-B format
     - "triton": Use Triton-based kernels
     - "deep_gemm": Use DeepGEMM kernels
     - "torch": Use PyTorch native scaled_mm kernels

--- a/vllm/config/quantization.py
+++ b/vllm/config/quantization.py
@@ -16,6 +16,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8StaticChannelSym,
     kFp8StaticTensorSym,
     kInt8StaticChannelSym,
+    kLutBStatic,
     kMxfp4Dynamic,
     kMxfp8Dynamic,
     kNvfp4Static,
@@ -32,6 +33,7 @@ QUANT_KEY_NAMES: dict[str, QuantKey] = {
     "mxfp8": kMxfp8Dynamic,
     "mxfp4": kMxfp4Dynamic,
     "int8_per_channel_static": kInt8StaticChannelSym,
+    "lut_b": kLutBStatic,
 }
 
 
@@ -74,6 +76,9 @@ class QuantSpec:
 
     activation: QuantKeyField = None
     """Activation quantization key, or a name from QUANT_KEY_NAMES."""
+
+    algorithm: str | None = None
+    """Optional online fitting algorithm. Currently used by LUT-B."""
 
 
 @config
@@ -139,6 +144,11 @@ _ONLINE_SHORTHANDS: dict[str, QuantizationConfigArgs] = {
     # FlashInfer TRTLLM only); linear stays unquantized (no `linear` field).
     "nvfp4_per_token": QuantizationConfigArgs(
         moe=QuantSpec(weight=kNvfp4Static),
+    ),
+    # Rubin LUT-B reference: 3-bit weight indices into per-8x64-tile E4M3
+    # codebooks. Activations remain in the model dtype.
+    "lut_b": QuantizationConfigArgs(
+        linear=QuantSpec(weight=kLutBStatic),
     ),
 }
 

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -135,6 +135,9 @@ from vllm.model_executor.kernels.linear.nvfp4.flashinfer import (
 from vllm.model_executor.kernels.linear.nvfp4.humming import (
     HummingNvFp4LinearKernel,
 )
+from vllm.model_executor.kernels.linear.nvfp4.lut_b import (
+    LutBNvFp4LinearKernel,
+)
 from vllm.model_executor.kernels.linear.nvfp4.marlin import (
     MarlinNvFp4LinearKernel,
 )
@@ -251,6 +254,9 @@ _LINEAR_BACKEND_KERNEL_MAP: dict[str, set[type]] = {
         HummingMxfp8LinearKernel,
         HummingMxFp4LinearKernel,
         HummingNvFp4LinearKernel,
+    },
+    "lut_b": {
+        LutBNvFp4LinearKernel,
     },
     "marlin": {
         MarlinFP8ScaledMMLinearKernel,
@@ -461,9 +467,11 @@ _POSSIBLE_NVFP4_KERNELS: dict[PlatformEnum, list[type[NvFp4LinearKernel]]] = {
         FbgemmNvFp4LinearKernel,
         EmulationNvFp4LinearKernel,
         HummingNvFp4LinearKernel,
+        LutBNvFp4LinearKernel,
     ],
     PlatformEnum.ROCM: [
         EmulationNvFp4LinearKernel,
+        LutBNvFp4LinearKernel,
     ],
 }
 
@@ -1102,6 +1110,7 @@ __all__ = [
     "FlashInferCutlassNvFp4LinearKernel",
     "FlashInferTrtllmNvFp4LinearKernel",
     "FlashInferCudnnNvFp4LinearKernel",
+    "LutBNvFp4LinearKernel",
     "MarlinNvFp4LinearKernel",
     "_KernelT",
     "DeepGemmFp8BlockScaledMMKernel",

--- a/vllm/model_executor/kernels/linear/nvfp4/base.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/base.py
@@ -41,6 +41,10 @@ class NvFp4LinearKernel(ABC):
         """
         return None
 
+    def supports_per_partition_weight_global_scale(self) -> bool:
+        """Return whether fused logical weights may retain distinct global scales."""
+        return False
+
     @classmethod
     @abstractmethod
     def is_supported(

--- a/vllm/model_executor/kernels/linear/nvfp4/lut_b.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/lut_b.py
@@ -1,0 +1,524 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+import torch.nn.functional as F
+
+from vllm.model_executor.layers.quantization.utils.nvfp4_emulation_utils import (
+    dequantize_to_dtype,
+)
+from vllm.model_executor.utils import replace_parameter
+
+from .base import NvFp4LinearKernel, NvFp4LinearLayerConfig
+
+LUT_B_BLOCK_N = 8
+LUT_B_BLOCK_K = 64
+LUT_B_CODEBOOK_SIZE = 8
+LUT_B_PACKED_TILE_BYTES = LUT_B_BLOCK_N * LUT_B_BLOCK_K * 3 // 8
+LUT_B_LLOYD_ITERATIONS = 4
+LUT_B_MULTISTART_ITERATIONS = 16
+LUT_B_MAX_TILES_PER_CHUNK = 4096
+_LUT_B_CALIBRATION_FREE_ALGORITHMS: dict[str, tuple[bool, int]] = {
+    "multistart": (False, 0),
+    "scaled": (True, 0),
+    "residual_1": (False, 1),
+    "residual_2": (False, 2),
+    "residual_4": (False, 4),
+    "residual_8": (False, 8),
+    "scaled_residual_1": (True, 1),
+    "scaled_residual_2": (True, 2),
+    "scaled_residual_4": (True, 4),
+    "scaled_residual_8": (True, 8),
+}
+
+
+def pack_lut_b_indices(indices: torch.Tensor) -> torch.Tensor:
+    """Pack eight 3-bit LUT indices into three bytes."""
+    if indices.shape[-1] % 8 != 0:
+        raise ValueError("The number of LUT indices must be divisible by 8")
+
+    index_groups = indices.reshape(*indices.shape[:-1], -1, 8).to(torch.int32)
+    words = torch.zeros(
+        index_groups.shape[:-1],
+        dtype=torch.int32,
+        device=indices.device,
+    )
+    for index in range(8):
+        words |= index_groups[..., index] << (3 * index)
+
+    return (
+        torch.stack(
+            (
+                words & 0xFF,
+                (words >> 8) & 0xFF,
+                (words >> 16) & 0xFF,
+            ),
+            dim=-1,
+        )
+        .to(torch.uint8)
+        .flatten(start_dim=-2)
+    )
+
+
+def unpack_lut_b_indices(packed: torch.Tensor) -> torch.Tensor:
+    """Unpack three-byte groups into eight 3-bit LUT indices."""
+    if packed.shape[-1] % 3 != 0:
+        raise ValueError("The number of packed bytes must be divisible by 3")
+
+    byte_groups = packed.reshape(*packed.shape[:-1], -1, 3).to(torch.int32)
+    words = (
+        byte_groups[..., 0] | (byte_groups[..., 1] << 8) | (byte_groups[..., 2] << 16)
+    )
+    return (
+        torch.stack(
+            tuple((words >> (3 * index)) & 0x7 for index in range(8)),
+            dim=-1,
+        )
+        .to(torch.uint8)
+        .flatten(start_dim=-2)
+    )
+
+
+def _snap_to_e4m3(values: torch.Tensor) -> torch.Tensor:
+    finfo = torch.finfo(torch.float8_e4m3fn)
+    values = values.clamp(min=finfo.min, max=finfo.max)
+    return values.to(torch.float8_e4m3fn).to(torch.float32)
+
+
+def _assign_lut_indices(values: torch.Tensor, centers: torch.Tensor) -> torch.Tensor:
+    boundaries = ((centers[:, :-1] + centers[:, 1:]) * 0.5).contiguous()
+    return torch.searchsorted(boundaries, values.contiguous()).to(torch.int64)
+
+
+def _initialize_lut_centers(values: torch.Tensor) -> torch.Tensor:
+    centers = torch.empty(
+        values.shape[0],
+        LUT_B_CODEBOOK_SIZE,
+        dtype=torch.float32,
+        device=values.device,
+    )
+    centers[:, 0] = values.mean(dim=1)
+    minimum_distance = (values - centers[:, :1]).square()
+    for center_index in range(1, LUT_B_CODEBOOK_SIZE):
+        farthest = minimum_distance.argmax(dim=1, keepdim=True)
+        new_center = torch.gather(values, 1, farthest).squeeze(1)
+        centers[:, center_index] = new_center
+        distance = (values - new_center[:, None]).square()
+        minimum_distance = torch.minimum(minimum_distance, distance)
+    return _snap_to_e4m3(centers).sort(dim=1).values
+
+
+def _initialize_quantile_lut_centers(values: torch.Tensor) -> torch.Tensor:
+    sorted_values = values.sort(dim=1).values
+    ranks = (
+        (torch.arange(LUT_B_CODEBOOK_SIZE, device=values.device) + 0.5)
+        * values.shape[1]
+        / LUT_B_CODEBOOK_SIZE
+    ).to(torch.int64)
+    ranks.clamp_max_(values.shape[1] - 1)
+    return sorted_values[:, ranks]
+
+
+def _initialize_uniform_lut_centers(values: torch.Tensor) -> torch.Tensor:
+    fractions = torch.linspace(
+        0,
+        1,
+        LUT_B_CODEBOOK_SIZE,
+        dtype=torch.float32,
+        device=values.device,
+    )
+    minimum = values.amin(dim=1, keepdim=True)
+    maximum = values.amax(dim=1, keepdim=True)
+    return minimum + (maximum - minimum) * fractions
+
+
+def _fit_lut_b_tiles_from_centers(
+    values: torch.Tensor,
+    centers: torch.Tensor,
+    num_iterations: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    centers = _snap_to_e4m3(centers).sort(dim=1).values
+
+    for _ in range(num_iterations):
+        indices = _assign_lut_indices(values, centers)
+        sums = torch.zeros_like(centers)
+        counts = torch.zeros_like(centers)
+        sums.scatter_add_(1, indices, values)
+        counts.scatter_add_(1, indices, torch.ones_like(values))
+        updated = sums / counts.clamp_min(1)
+        centers = torch.where(counts > 0, updated, centers)
+        centers = _snap_to_e4m3(centers).sort(dim=1).values
+
+    indices = _assign_lut_indices(values, centers)
+    return indices.to(torch.uint8), centers.to(torch.float8_e4m3fn)
+
+
+def _fit_lut_b_tiles(
+    values: torch.Tensor,
+    num_iterations: int = LUT_B_LLOYD_ITERATIONS,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    values = values.to(torch.float32)
+    centers = _initialize_lut_centers(values)
+    return _fit_lut_b_tiles_from_centers(values, centers, num_iterations)
+
+
+def _fit_lut_b_tiles_multistart(
+    values: torch.Tensor,
+    num_iterations: int = LUT_B_MULTISTART_ITERATIONS,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    values = values.to(torch.float32)
+    initializers = (
+        _initialize_lut_centers,
+        _initialize_quantile_lut_centers,
+        _initialize_uniform_lut_centers,
+    )
+    best_loss = torch.full(
+        (values.shape[0],),
+        torch.inf,
+        dtype=torch.float32,
+        device=values.device,
+    )
+    best_indices = torch.empty_like(values, dtype=torch.uint8)
+    best_centers = torch.empty(
+        values.shape[0],
+        LUT_B_CODEBOOK_SIZE,
+        dtype=torch.float8_e4m3fn,
+        device=values.device,
+    )
+
+    for initializer in initializers:
+        indices, centers = _fit_lut_b_tiles_from_centers(
+            values,
+            initializer(values),
+            num_iterations,
+        )
+        reconstructed = torch.gather(
+            centers.to(torch.float32),
+            1,
+            indices.to(torch.int64),
+        )
+        loss = (reconstructed - values).square().sum(dim=1)
+        selected = loss < best_loss
+        best_loss[selected] = loss[selected]
+        best_indices[selected] = indices[selected]
+        best_centers[selected] = centers[selected]
+
+    return best_indices, best_centers
+
+
+def _weight_to_lut_b_tiles(weight: torch.Tensor) -> torch.Tensor:
+    n, k = weight.shape
+    return (
+        weight.reshape(
+            n // LUT_B_BLOCK_N,
+            LUT_B_BLOCK_N,
+            k // LUT_B_BLOCK_K,
+            LUT_B_BLOCK_K,
+        )
+        .permute(0, 2, 1, 3)
+        .reshape(-1, LUT_B_BLOCK_N * LUT_B_BLOCK_K)
+    )
+
+
+@torch.no_grad()
+def quantize_lut_b(
+    weight: torch.Tensor,
+    *,
+    max_tiles_per_chunk: int = LUT_B_MAX_TILES_PER_CHUNK,
+    num_iterations: int = LUT_B_LLOYD_ITERATIONS,
+    multistart: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fit the canonical LUT-B representation for a logical ``[N, K]`` weight."""
+    if weight.ndim != 2:
+        raise ValueError(f"LUT-B expects a 2D weight, got shape {weight.shape}")
+    n, k = weight.shape
+    if n % LUT_B_BLOCK_N != 0 or k % LUT_B_BLOCK_K != 0:
+        raise ValueError(
+            "LUT-B requires weight dimensions divisible by "
+            f"({LUT_B_BLOCK_N}, {LUT_B_BLOCK_K}), got ({n}, {k})"
+        )
+
+    n_tiles = n // LUT_B_BLOCK_N
+    k_tiles = k // LUT_B_BLOCK_K
+    packed = torch.empty(
+        n_tiles,
+        k_tiles,
+        LUT_B_PACKED_TILE_BYTES,
+        dtype=torch.uint8,
+        device=weight.device,
+    )
+    codebooks = torch.empty(
+        n_tiles,
+        k_tiles,
+        LUT_B_CODEBOOK_SIZE,
+        dtype=torch.float8_e4m3fn,
+        device=weight.device,
+    )
+
+    n_tiles_per_chunk = max(1, max_tiles_per_chunk // k_tiles)
+    for n_tile_start in range(0, n_tiles, n_tiles_per_chunk):
+        n_tile_end = min(n_tile_start + n_tiles_per_chunk, n_tiles)
+        row_start = n_tile_start * LUT_B_BLOCK_N
+        row_end = n_tile_end * LUT_B_BLOCK_N
+        tiles = (
+            weight[row_start:row_end]
+            .reshape(
+                n_tile_end - n_tile_start,
+                LUT_B_BLOCK_N,
+                k_tiles,
+                LUT_B_BLOCK_K,
+            )
+            .permute(0, 2, 1, 3)
+            .reshape(-1, LUT_B_BLOCK_N * LUT_B_BLOCK_K)
+        )
+        fit_tiles = _fit_lut_b_tiles_multistart if multistart else _fit_lut_b_tiles
+        indices, fitted_codebooks = fit_tiles(tiles, num_iterations=num_iterations)
+        packed[n_tile_start:n_tile_end] = pack_lut_b_indices(indices).reshape(
+            n_tile_end - n_tile_start,
+            k_tiles,
+            LUT_B_PACKED_TILE_BYTES,
+        )
+        codebooks[n_tile_start:n_tile_end] = fitted_codebooks.reshape(
+            n_tile_end - n_tile_start,
+            k_tiles,
+            LUT_B_CODEBOOK_SIZE,
+        )
+
+    return packed, codebooks
+
+
+@torch.no_grad()
+def quantize_lut_b_calibration_free(
+    weight: torch.Tensor,
+    *,
+    algorithm: str,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor | None,
+    torch.Tensor | None,
+    torch.Tensor | None,
+]:
+    """Quantize a weight with a selectable calibration-free LUT-B algorithm."""
+    try:
+        use_output_scale, residual_count = _LUT_B_CALIBRATION_FREE_ALGORITHMS[algorithm]
+    except KeyError:
+        raise ValueError(
+            f"Unknown LUT-B algorithm {algorithm!r}; "
+            f"expected one of {sorted(_LUT_B_CALIBRATION_FREE_ALGORITHMS)}"
+        ) from None
+
+    output_scale = None
+    normalized_weight = weight
+    if use_output_scale:
+        output_scale = (
+            weight.to(torch.float32).square().mean(dim=1).sqrt() / 32.0
+        ).clamp_min_(torch.finfo(torch.float32).tiny)
+        normalized_weight = weight.to(torch.float32) / output_scale[:, None]
+
+    packed, codebooks = quantize_lut_b(
+        normalized_weight,
+        num_iterations=LUT_B_MULTISTART_ITERATIONS,
+        multistart=True,
+    )
+    if residual_count == 0:
+        return packed, codebooks, output_scale, None, None
+
+    reconstructed = dequantize_lut_b(
+        packed,
+        codebooks,
+        out_dtype=torch.float32,
+        output_scale=output_scale,
+    )
+    errors = _weight_to_lut_b_tiles(weight.to(torch.float32)) - (
+        _weight_to_lut_b_tiles(reconstructed)
+    )
+    residual_position = errors.abs().topk(residual_count, dim=1).indices.to(torch.int16)
+    residual_value = torch.gather(
+        errors,
+        1,
+        residual_position.to(torch.int64),
+    )
+    n_tiles, k_tiles = packed.shape[:2]
+    residual_shape: tuple[int, ...] = (n_tiles, k_tiles)
+    if residual_count > 1:
+        residual_shape = (*residual_shape, residual_count)
+    return (
+        packed,
+        codebooks,
+        output_scale,
+        residual_position.reshape(residual_shape),
+        residual_value.to(torch.bfloat16).reshape(residual_shape),
+    )
+
+
+def dequantize_lut_b(
+    packed: torch.Tensor,
+    codebooks: torch.Tensor,
+    *,
+    out_dtype: torch.dtype,
+    output_scale: torch.Tensor | None = None,
+    residual_position: torch.Tensor | None = None,
+    residual_value: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Fully reconstruct a logical ``[N, K]`` weight from LUT-B tiles."""
+    if packed.ndim != 3 or packed.shape[-1] != LUT_B_PACKED_TILE_BYTES:
+        raise ValueError(f"Unexpected packed LUT-B shape {packed.shape}")
+    if codebooks.shape != (*packed.shape[:2], LUT_B_CODEBOOK_SIZE):
+        raise ValueError(
+            f"Codebook shape {codebooks.shape} does not match {packed.shape}"
+        )
+
+    n_tiles, k_tiles = packed.shape[:2]
+    indices = unpack_lut_b_indices(packed).reshape(-1, LUT_B_BLOCK_N * LUT_B_BLOCK_K)
+    values = torch.gather(
+        codebooks.reshape(-1, LUT_B_CODEBOOK_SIZE).to(out_dtype),
+        1,
+        indices.to(torch.int64),
+    ).reshape(
+        n_tiles,
+        k_tiles,
+        LUT_B_BLOCK_N,
+        LUT_B_BLOCK_K,
+    )
+    if output_scale is not None:
+        if output_scale.shape != (n_tiles * LUT_B_BLOCK_N,):
+            raise ValueError(
+                f"Unexpected LUT-B output scale shape {output_scale.shape}"
+            )
+        values *= output_scale.to(out_dtype).reshape(
+            n_tiles,
+            1,
+            LUT_B_BLOCK_N,
+            1,
+        )
+
+    if (residual_position is None) != (residual_value is None):
+        raise ValueError("LUT-B residual position and value must be provided together")
+    if residual_position is not None and residual_value is not None:
+        expected_prefix = (n_tiles, k_tiles)
+        if residual_position.shape[:2] != expected_prefix:
+            raise ValueError(
+                f"Unexpected LUT-B residual position shape {residual_position.shape}"
+            )
+        if residual_value.shape != residual_position.shape:
+            raise ValueError(
+                f"Unexpected LUT-B residual value shape {residual_value.shape}"
+            )
+        if residual_position.ndim == 2:
+            residual_position = residual_position.unsqueeze(-1)
+            residual_value = residual_value.unsqueeze(-1)
+        elif residual_position.ndim != 3:
+            raise ValueError(f"Unexpected LUT-B residual rank {residual_position.ndim}")
+        values = values.reshape(n_tiles, k_tiles, -1)
+        values.scatter_add_(
+            2,
+            residual_position.to(torch.int64),
+            residual_value.to(out_dtype),
+        )
+        values = values.reshape(
+            n_tiles,
+            k_tiles,
+            LUT_B_BLOCK_N,
+            LUT_B_BLOCK_K,
+        )
+
+    return values.permute(0, 2, 1, 3).reshape(
+        n_tiles * LUT_B_BLOCK_N, k_tiles * LUT_B_BLOCK_K
+    )
+
+
+def dequantize_nvfp4_weight(
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    weight_global_scale: torch.Tensor,
+    logical_widths: list[int],
+    *,
+    out_dtype: torch.dtype,
+) -> torch.Tensor:
+    """Decode standardized NVFP4 tensors while preserving fused-layer scales."""
+    global_scales = weight_global_scale.flatten()
+    if global_scales.numel() == 1:
+        global_scales = global_scales.expand(len(logical_widths))
+    if global_scales.numel() != len(logical_widths):
+        raise ValueError(
+            f"Expected {len(logical_widths)} NVFP4 global scales, "
+            f"got {global_scales.numel()}"
+        )
+
+    decoded = []
+    row_start = 0
+    for width, global_scale in zip(logical_widths, global_scales):
+        row_end = row_start + width
+        decoded.append(
+            dequantize_to_dtype(
+                weight[row_start:row_end],
+                weight_scale[row_start:row_end],
+                global_scale,
+                out_dtype,
+                block_size=16,
+                swizzle=False,
+            )
+        )
+        row_start = row_end
+    if row_start != weight.shape[0]:
+        raise ValueError(
+            f"Logical widths cover {row_start} rows, but the weight has "
+            f"{weight.shape[0]}"
+        )
+    return torch.cat(decoded, dim=0)
+
+
+class LutBNvFp4LinearKernel(NvFp4LinearKernel):
+    """Calibration-free LUT-B repacking with an unfused reference forward."""
+
+    @classmethod
+    def is_supported(
+        cls, compute_capability: int | None = None
+    ) -> tuple[bool, str | None]:
+        return True, None
+
+    @classmethod
+    def can_implement(cls, config: NvFp4LinearLayerConfig) -> tuple[bool, str | None]:
+        return True, None
+
+    def supports_per_partition_weight_global_scale(self) -> bool:
+        return True
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        source_weight = dequantize_nvfp4_weight(
+            layer.weight,
+            layer.weight_scale,
+            layer.weight_global_scale,
+            layer.logical_widths,
+            out_dtype=torch.float32,
+        )
+        packed, codebooks = quantize_lut_b(source_weight)
+        replace_parameter(layer, "weight", packed)
+        replace_parameter(layer, "weight_codebook", codebooks)
+
+        for name in (
+            "weight_scale",
+            "weight_global_scale",
+            "weight_scale_2",
+            "input_scale",
+            "input_scale_2",
+            "input_global_scale",
+            "input_global_scale_inv",
+            "alpha",
+        ):
+            if hasattr(layer, name):
+                delattr(layer, name)
+
+    def apply_weights(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        weight = dequantize_lut_b(
+            layer.weight,
+            layer.weight_codebook,
+            out_dtype=x.dtype,
+        )
+        return F.linear(x, weight, bias)

--- a/vllm/model_executor/layers/quantization/__init__.py
+++ b/vllm/model_executor/layers/quantization/__init__.py
@@ -43,6 +43,7 @@ QuantizationMethods = Literal[
     "fp8_per_channel",
     "int8_per_channel_weight_only",
     "nvfp4_per_token",
+    "lut_b",
     "mxfp8",
 ]
 QUANTIZATION_METHODS: list[str] = list(get_args(QuantizationMethods))

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -97,6 +97,14 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
         layer.weight = layer.weight_packed
         del layer.weight_packed
 
+        if self.kernel.supports_per_partition_weight_global_scale():
+            layer.weight_global_scale = Parameter(
+                1.0 / layer.weight_global_scale.to(torch.float32),
+                requires_grad=False,
+            )
+            self.kernel.process_weights_after_loading(layer)
+            return
+
         # Check for mismatched weight global scales
         if torch.unique(layer.weight_global_scale).numel() != 1:
             logger.warning_once(

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -1202,6 +1202,15 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
         expose_input_quant_key(layer, self.kernel)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if self.kernel.supports_per_partition_weight_global_scale():
+            layer.weight_global_scale = Parameter(
+                layer.weight_scale_2.to(torch.float32),
+                requires_grad=False,
+            )
+            del layer.weight_scale_2
+            self.kernel.process_weights_after_loading(layer)
+            return
+
         if (
             torch.unique(layer.input_scale).numel() != 1
             or torch.unique(layer.weight_scale_2).numel() != 1

--- a/vllm/model_executor/layers/quantization/online/base.py
+++ b/vllm/model_executor/layers/quantization/online/base.py
@@ -36,6 +36,9 @@ from vllm.model_executor.layers.quantization.online.fp8 import (
 from vllm.model_executor.layers.quantization.online.int8 import (
     Int8OnlineMoEMethod,
 )
+from vllm.model_executor.layers.quantization.online.lut_b import (
+    LutBOnlineLinearMethod,
+)
 from vllm.model_executor.layers.quantization.online.mxfp8 import (
     Mxfp8OnlineLinearMethod,
     Mxfp8OnlineMoEMethod,
@@ -49,6 +52,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8StaticChannelSym,
     kFp8StaticTensorSym,
     kInt8StaticChannelSym,
+    kLutBStatic,
     kMxfp8Dynamic,
     kNvfp4Static,
 )
@@ -64,6 +68,7 @@ _ONLINE_LINEAR_METHODS: dict[QuantKey, type] = {
     kFp8Static128BlockSym: Fp8PerBlockOnlineLinearMethod,
     kFp8StaticChannelSym: Fp8PtpcOnlineLinearMethod,
     kMxfp8Dynamic: Mxfp8OnlineLinearMethod,
+    kLutBStatic: LutBOnlineLinearMethod,
 }
 
 _ONLINE_MOE_METHODS: dict[QuantKey, type] = {
@@ -142,6 +147,13 @@ class OnlineQuantizationConfig(QuantizationConfig):
             raise ValueError(
                 f"activation override (activation={spec.activation}) is not "
                 f"yet supported for online {cls.__name__}"
+            )
+        if cls is LutBOnlineLinearMethod:
+            return cls(algorithm=spec.algorithm)
+        if spec.algorithm is not None:
+            raise ValueError(
+                f"algorithm={spec.algorithm!r} is not supported for "
+                f"online {cls.__name__}"
             )
         if isinstance(layer, RoutedExperts):
             return cls(layer=layer)

--- a/vllm/model_executor/layers/quantization/online/lut_b.py
+++ b/vllm/model_executor/layers/quantization/online/lut_b.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+import torch.nn.functional as F
+
+from vllm.model_executor.kernels.linear.nvfp4.lut_b import (
+    LUT_B_BLOCK_K,
+    LUT_B_BLOCK_N,
+    dequantize_lut_b,
+    quantize_lut_b,
+    quantize_lut_b_calibration_free,
+)
+from vllm.model_executor.layers.linear import LinearMethodBase
+from vllm.model_executor.model_loader.reload.layerwise import (
+    initialize_online_processing,
+)
+from vllm.model_executor.parameter import ModelWeightParameter
+from vllm.model_executor.utils import replace_parameter
+
+
+class LutBOnlineLinearMethod(LinearMethodBase):
+    """Online calibration-free LUT-B weight quantization."""
+
+    uses_meta_device: bool = True
+
+    def __init__(self, algorithm: str | None = None) -> None:
+        self.algorithm = algorithm
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        output_size_per_partition = sum(output_partition_sizes)
+        if output_size_per_partition % LUT_B_BLOCK_N != 0:
+            raise ValueError(
+                "The sharded LUT-B output width must be divisible by "
+                f"{LUT_B_BLOCK_N}, got {output_size_per_partition}"
+            )
+        if input_size_per_partition % LUT_B_BLOCK_K != 0:
+            raise ValueError(
+                "The sharded LUT-B input width must be divisible by "
+                f"{LUT_B_BLOCK_K}, got {input_size_per_partition}"
+            )
+
+        layer.logical_widths = output_partition_sizes
+        layer.input_size_per_partition = input_size_per_partition
+        layer.output_size_per_partition = output_size_per_partition
+        weight = ModelWeightParameter(
+            data=torch.empty(
+                output_size_per_partition,
+                input_size_per_partition,
+                device="meta",
+                dtype=params_dtype,
+            ),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=extra_weight_attrs.get("weight_loader"),
+        )
+        layer.register_parameter("weight", weight)
+        initialize_online_processing(layer)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if getattr(layer, "_already_called_process_weights_after_loading", False):
+            return
+
+        if self.algorithm is None:
+            packed, codebooks = quantize_lut_b(layer.weight)
+            output_scale = None
+            residual_position = None
+            residual_value = None
+        else:
+            (
+                packed,
+                codebooks,
+                output_scale,
+                residual_position,
+                residual_value,
+            ) = quantize_lut_b_calibration_free(
+                layer.weight,
+                algorithm=self.algorithm,
+            )
+        replace_parameter(layer, "weight", packed)
+        replace_parameter(layer, "weight_codebook", codebooks)
+        if output_scale is not None:
+            replace_parameter(layer, "weight_output_scale", output_scale)
+        if residual_position is not None and residual_value is not None:
+            replace_parameter(layer, "weight_residual_position", residual_position)
+            replace_parameter(layer, "weight_residual_value", residual_value)
+        layer._already_called_process_weights_after_loading = True
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        weight = dequantize_lut_b(
+            layer.weight,
+            layer.weight_codebook,
+            out_dtype=x.dtype,
+            output_scale=getattr(layer, "weight_output_scale", None),
+            residual_position=getattr(layer, "weight_residual_position", None),
+            residual_value=getattr(layer, "weight_residual_value", None),
+        )
+        return F.linear(x, weight, bias)

--- a/vllm/model_executor/layers/quantization/quark/schemes/quark_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/quark_nvfp4.py
@@ -11,6 +11,9 @@ from vllm.model_executor.kernels.linear import init_nvfp4_linear_kernel
 from vllm.model_executor.kernels.linear.nvfp4.emulation import (
     EmulationNvFp4LinearKernel,
 )
+from vllm.model_executor.kernels.linear.nvfp4.lut_b import (
+    LutBNvFp4LinearKernel,
+)
 from vllm.model_executor.layers.quantization.quark.schemes.quark_scheme import (
     QuarkScheme,
 )
@@ -42,7 +45,10 @@ class QuarkNVFP4(QuarkScheme):
         self.kernel = init_nvfp4_linear_kernel()
         self.group_size = 16
 
-        if not isinstance(self.kernel, EmulationNvFp4LinearKernel):
+        if not isinstance(
+            self.kernel,
+            (EmulationNvFp4LinearKernel, LutBNvFp4LinearKernel),
+        ):
             logger.warning_once(
                 "Only EmulationNvFp4LinearKernel NVFP4 dense implementation is "
                 "tested with QuarkNVFP4, got kernel=%s. Correctness is not validated.",
@@ -115,6 +121,15 @@ class QuarkNVFP4(QuarkScheme):
         layer.register_parameter("input_scale_2", input_scale_2)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if self.kernel.supports_per_partition_weight_global_scale():
+            layer.weight_global_scale = Parameter(
+                layer.weight_scale_2.to(torch.float32),
+                requires_grad=False,
+            )
+            del layer.weight_scale_2
+            self.kernel.process_weights_after_loading(layer)
+            return
+
         input_global_scale = layer.input_scale_2.max().to(torch.float32)
         layer.input_global_scale = Parameter(input_global_scale, requires_grad=False)
         del layer.input_scale_2

--- a/vllm/model_executor/layers/quantization/utils/quant_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/quant_utils.py
@@ -193,6 +193,13 @@ kInt8DynamicTokenSym = QuantKey(torch.int8, kDynamicTokenScale, symmetric=True)
 kInt8StaticTensorSym = QuantKey(torch.int8, kStaticTensorScale, symmetric=True)
 kInt8DynamicTensorSym = QuantKey(torch.int8, kDynamicTensorScale, symmetric=True)
 
+kLutBStaticCodebook = ScaleDesc(
+    torch.float8_e4m3fn,
+    True,
+    GroupShape(8, 64),
+)
+kLutBStatic = QuantKey(torch.uint8, kLutBStaticCodebook, symmetric=True)
+
 # INT4 W4A8 quantization keys
 
 # For group-wise quantization (e.g., group_size=128)


### PR DESCRIPTION
## Summary

This draft adds reference infrastructure for evaluating NVIDIA Rubin LUT-B
weight compression before a fused kernel is available.

- Defines a canonical logical LUT-B tile as 512 3-bit indices plus an
  eight-entry E4M3 codebook: 200 bytes per 8x64 tile, or 3.125 bits/weight.
- Adds online BF16/FP16 weight quantization for dense linear layers.
- Adds an NVFP4 linear backend that repacks loaded ModelOpt, Quark, and
  compressed-tensors checkpoints in `process_weights_after_loading`.
- Adds selectable calibration-free fitting experiments through
  `quantization_config.linear.algorithm`.
- Uses a deliberately unfused reference forward that reconstructs the weight
  before `torch.nn.functional.linear`.

The persistent representation is intentionally logical and easy to inspect.
An eventual Rubin kernel can swizzle it into the required GMEM/SMEM/TMEM
layout during checkpoint load.

## Motivation

Rubin PTX exposes LUT decompression for the MMA B operand using 3-bit indices
into per-tile E4M3 codebooks. This prototype answers two questions before
kernel work begins:

1. What accuracy is retained by calibration-free BF16-to-LUT-B fitting?
2. Can existing NVFP4 checkpoints be repacked after model load?

Public specification:
https://docs.nvidia.com/cuda/developer-preview/13.4/parallel-thread-execution/index.html#tcgen05-decompress-inp-mat

## Usage

Baseline online BF16-to-LUT-B:

```bash
vllm serve Qwen/Qwen3-8B \
  --quantization lut_b \
  --enforce-eager
```

Calibration-free fitting experiment:

```bash
vllm serve Qwen/Qwen3-8B \
  --quantization online \
  --quantization-config.linear.weight lut_b \
  --quantization-config.linear.algorithm residual_1 \
  --enforce-eager
```

Repack an existing NVFP4 checkpoint:

```bash
vllm serve RedHatAI/Qwen3-8B-NVFP4 \
  --linear-backend lut_b \
  --enforce-eager
```

## Calibration-free GSM8K results

Methodology:

- Model: `Qwen/Qwen3-8B`
- Internal `tests/evals/gsm8k/gsm8k_eval.py` harness
- 1,319 questions, 5-shot
- `max_tokens=256`, `temperature=0`, `seed=42`
- 32 concurrent requests
- B300, eager mode, max model length 8192
- All runs completed 1,319/1,319 HTTP requests successfully

| Algorithm | Row scale | Residuals/tile | Logical bpw | Accuracy |
| --- | ---: | ---: | ---: | ---: |
| baseline | no | 0 | 3.125 | 52.08% |
| `multistart` | no | 0 | 3.125 | 57.62% |
| `scaled` | yes | 0 | 3.131 | 25.78% |
| `residual_1` | no | 1 | 3.174 | 69.83% |
| `scaled_residual_1` | yes | 1 | 3.180 | 66.11% |
| `residual_2` | no | 2 | 3.223 | 72.93% |
| `scaled_residual_2` | yes | 2 | 3.229 | 69.14% |
| `residual_4` | no | 4 | 3.320 | 74.45% |
| `scaled_residual_4` | yes | 4 | 3.327 | 70.13% |
| `residual_8` | no | 8 | 3.516 | 75.51% |
| `scaled_residual_8` | yes | 8 | 3.522 | 74.83% |

Reference checkpoint paths from the same harness:

| Model/path | Activation path | Accuracy |
| --- | --- | ---: |
| BF16 to online LUT-B | BF16 | 52.08% |
| NVFP4 to LUT-B backend | BF16 | 61.03% |
| NVFP4 default | NVFP4 | 86.05% |
| NVFP4 Marlin | BF16 | 87.72% |

The main findings are:

- Deterministic multistart fitting adds 5.54 accuracy points without changing
  the native 3.125-bit representation.
- Weight-space RMS scaling reduced sampled reconstruction error but badly
  regressed model accuracy.
- Preserving one largest-error weight per tile is the best observed
  accuracy/storage knee: 69.83% at 3.174 logical bits/weight.
- Unscaled residual variants win at every matched residual count.

Residual logical accounting uses a 9-bit tile position and BF16 correction.
The reference implementation currently stores the position as `int16`, so its
resident prototype size is slightly larger than the logical checkpoint size.

## Scope and limitations

- This does not execute the Rubin LUT MMA and makes no performance claim.
- Hardware-specific swizzles are intentionally excluded.
- Multistart remains a native 3.125-bit LUT-B representation.
- Per-output scales require an output epilogue.
- Sparse residual sidecars require a separate correction path and are not
  consumed by the LUT MMA.
- MoE weights are not included.

## Validation

```bash
.venv/bin/python -m pytest \
  tests/kernels/quantization/test_nvfp4_lut_b.py \
  tests/quantization/test_online.py \
  tests/quantization/test_quantization_config_args.py -q
```

Result: 33 passed, 7 hardware-gated skips.

Targeted pre-commit hooks, including Ruff, formatting, mypy, markdownlint,
configuration validation, and forbidden-import checks, all pass on the 17
changed files.

## Duplicate-work check

No open `vllm-project/vllm` PR matched searches for `LUT-B`,
`Rubin LUT quantization`, or `tcgen05 decompress`.

## AI assistance disclosure

OpenAI Codex was used to implement, test, evaluate, and prepare this draft.
The human submitter must review every changed line and be able to explain and
defend the implementation and evaluation results before marking it ready for
review.
