### PR TITLE
[CI][NIXL] Fix flaky DP+EP test port conflict

### DIFF
--- a/tests/v1/kv_connector/nixl_integration/run_accuracy_test.sh
+++ b/tests/v1/kv_connector/nixl_integration/run_accuracy_test.sh
@@ -227,9 +227,12 @@ run_tests_for_model() {
     # Calculate side channel port
     SIDE_CHANNEL_PORT=$((5659 + i * $DECODER_TP_SIZE))
     INTERNAL_PORT=$((DECODER_INTERNAL_PORT_BASE + i * INTERNAL_PORT_STRIDE))
-    DECODER_INTERNAL_PORT_ENV=
+    # For non-DP mode, set VLLM_PORT to pin the internal port;
+    # For DP mode, set VLLM_DP_MASTER_PORT instead to avoid race condition.
     if [[ -z "${DP_EP:-}" ]]; then
       DECODER_INTERNAL_PORT_ENV="VLLM_PORT=$INTERNAL_PORT"
+    else
+      DECODER_INTERNAL_PORT_ENV="VLLM_DP_MASTER_PORT=$INTERNAL_PORT"
     fi
 
     echo "Starting decode instance $i on GPU $GPU_ID, port $PORT"


### PR DESCRIPTION
This PR fixes flaky NIXL accuracy test timeout in DP+EP mode by setting `VLLM_DP_MASTER_PORT` for the decode instance.

Without this PR, the DP_EP case for decode instance has tendency to fall into race-condition as the ports are not explicitly set for this case. They might end up inheriting the same fixed base port and might compete with the prefill instance's port range.

Fix: Set `VLLM_DP_MASTER_PORT` instead of `VLLM_PORT` for DP mode. This reserves a port range for DP process group coordination. This allows each EngineCore to independently allocate other ports and isolates decode's DP ports from prefill's ports.