### PR TITLE
[Bugfix][Core][Spec Decode] Skip spec-decode block reservation on the external-KV-load step (P/D)

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -859,6 +859,10 @@ class Scheduler(SchedulerInterface):
                         and self.num_sampled_tokens_per_step > 0
                         and num_new_tokens == 1
                         and (scheduled_running_reqs and not prefill_scheduled)
+                        # Not on the initial external-KV-load step: the remote
+                        # sent only prompt KV, so a padded spec block has no
+                        # remote counterpart (connector asserts local<=remote).
+                        and num_external_computed_tokens == 0
                     ):
                         num_new_tokens = 1 + self.num_spec_tokens
                         if (
@@ -915,10 +919,13 @@ class Scheduler(SchedulerInterface):
                     if num_new_tokens == 0:
                         break
 
-                # During async KV load, no forward pass is run yet.
-                # Allocate speculative lookahead slots later to avoid
-                # mismatching local and remote block counts.
-                limit_lookahead_tokens = load_kv_async and self.num_lookahead_tokens > 0
+                # During async KV load, no forward pass is run yet. The same
+                # local/remote block-count mismatch also occurs on the first
+                # step of a synchronous connector read (load_kv_async=False,
+                # num_external_computed_tokens > 0), so limit lookahead there too.
+                limit_lookahead_tokens = (
+                    load_kv_async or num_external_computed_tokens > 0
+                ) and self.num_lookahead_tokens > 0
                 effective_lookahead_tokens = (
                     0 if limit_lookahead_tokens else self.num_lookahead_tokens
                 )


### PR DESCRIPTION
## Summary

Under MTP (spec decode) + P/D disaggregation (Synchronous MoRIIO READ mode), the decode over-allocates KV blocks on a request's initial external-KV-load step and then trips the connector's downstream check:

```python
assert len(local_block_ids) <= len(remote_block_ids)
```

The prefill transfers N prompt blocks, but the scheduler will reserve N+1 (MTP1) blocks on the decode node. However, the prefill should only produce the blocks associated with the prompt, and not the speculation. Two sources over-allocate:

* the lookahead reservation (`num_lookahead_tokens`), and
* `pad_spec_decode`, which pads `num_new_tokens` to `1 + num_spec_tokens` to keep
  a uniform cudagraph shape.

Either can push the decode's block count one past what the prefill sent. The existing lookahead guard only zeroed lookahead for the **async** path (`load_kv_async=True`). This PR implements the same checks for the sync path.

## Fix

Gate **both** the lookahead reservation and `pad_spec_decode` on `num_external_computed_tokens > 0`, so the initial external-load step allocates exactly the prompt blocks (`== remote block count`). Both reservations resume on the next running step (`num_external == 0`), so there is no correctness or spec-decode-throughput change beyond that one step. This mirrors what the async path already does.

## Reproduction

TP8 1P1D, DeepSeek-R1, MTP1 (`num_speculative_tokens=1`), MoRIIO READ mode, `block_size=64`:

```
MORIIO_BLOCK_MISMATCH ... num_external_tokens=958 num_prompt_tokens=959 num_spec_tokens=0 num_preemptions=0 local_count=16 remote_count=15
AssertionError: assert len(local_block_ids) <= len(remote_block_ids)
```

Prefill transferred 15 prompt blocks; decode reserved 16 → assert. Fails deterministically on every request's first external-load step.

## Test commands and results

End-to-end 1P1D TP8:TP8 MTP1 P/D disaggregation (MoRIIO READ mode), gsm8k via `lm_eval`:

```bash
# prefill (node A)
python3 -m vllm.entrypoints.openai.api_server \
    --model /models/models/DeepSeek-R1 \
    --served-model-name DeepSeek-R1-0528 \
    --host 0.0.0.0 \
    --port 8100 \
    --tensor-parallel-size 8 \
    --max-model-len 20480 \
    --max-num-batched-tokens 32768 \
    --gpu-memory-utilization 0.80 \
    --kv-cache-dtype fp8_e4m3 \
    --block-size 64 \
    --no-enable-chunked-prefill \
    --no-enable-prefix-caching \
    --trust-remote-code \
    --distributed-executor-backend mp \
    --speculative-config '{"method":"deepseek_mtp","num_speculative_tokens":1}' \
    --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_producer","kv_connector_extra_config":{"proxy_ip":"<PROXY_HOST>","proxy_port":36367,"http_port":8100,"handshake_port":6301,"notify_port":61005,"read_mode":true}}'

# decode (node B)
python3 -m vllm.entrypoints.openai.api_server \
    --model /models/models/DeepSeek-R1 \
    --served-model-name DeepSeek-R1-0528 \
    --host 0.0.0.0 \
    --port 8100 \
    --tensor-parallel-size 8 \
    --max-model-len 20480 \
    --max-num-batched-tokens 32768 \
    --gpu-memory-utilization 0.80 \
    --kv-cache-dtype fp8_e4m3 \
    --block-size 64 \
    --no-enable-chunked-prefill \
    --no-enable-prefix-caching \
    --trust-remote-code \
    --distributed-executor-backend mp \
    --speculative-config '{"method":"deepseek_mtp","num_speculative_tokens":1}' \
    --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_consumer","kv_connector_extra_config":{"proxy_ip":"<PROXY_HOST>","proxy_port":36367,"http_port":8201,"handshake_port":6301,"notify_port":61005,"read_mode":true}}'

# moriio toy proxy
python3 examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py --port 10001

# accuracy eval
python3 -m lm_eval \
    --model local-chat-completions \
    --apply_chat_template \
    --tasks gsm8k \
    --limit 512 \
    --model_args "model=DeepSeek-R1-0528,base_url=http://<PROXY_HOST>:10001/v1/chat/completions,api_key=EMPTY,num_concurrent=128,timeout=1800,tokenized_requests=False,max_length=20480" \
    --gen_kwargs "max_tokens=16384,temperature=0,top_p=1"

```

Result (512 samples, before fix: 0 completions — crash on first decode step):

| metric | value |
| --- | --- |
| gsm8k flexible-extract | **0.9473** |
| gsm8k strict-match | **0.8496** |
| completions | **512 / 512** |
| block-mismatch asserts | **0** |
| decode container exit | **0** |

## Model evaluation

The change affects scheduling/serving under spec decode. gsm8k accuracy above is in-line with DeepSeek-R1 MTP1 expectations, and the run completed cleanly with zero asserts and a clean decode shutdown, versus a hard crash on the first decode step without the fix.

## AI assistance

AI assistance (Claude) was used to help root-cause and draft this change. The submitter reviewed every changed line, ran the reproduction and the end-to-end gsm8k validation above, and understands and defends the change end-to-end.