### PR TITLE
[Bugfix] Skip generic required/named tool grammar for parsers that set supports_required_and_named

### DIFF
--- a/tests/tool_parsers/test_structural_tag_registry.py
+++ b/tests/tool_parsers/test_structural_tag_registry.py
@@ -228,6 +228,42 @@ def test_non_structural_tag_parser_uses_schema_constraints(
     assert out.structured_outputs.structural_tag is None
 
 
+@pytest.mark.parametrize(
+    "tool_choice",
+    [
+        "required",
+        {"type": "function", "function": {"name": "get_weather"}},
+    ],
+    ids=["required", "named"],
+)
+def test_parser_without_required_and_named_support_skips_schema_constraints(
+    tool_choice: str | dict[str, object],
+    sample_tools: list[ChatCompletionToolsParam],
+):
+    """``supports_required_and_named=False`` parsers must not get the tool
+    JSON schema installed as a decoding constraint.
+
+    Their models emit a native, non-JSON tool-call syntax (GLM's XML tags,
+    thinking special tokens), which the JSON grammar rejects: the FSM fails
+    to advance and the request 500s or hangs forever when ``max_tokens`` is
+    unset. The serving layer already falls back to auto parsing here, so the
+    request must stay unconstrained.
+    """
+    parser = Glm47MoeModelToolParser(MagicMock(), tools=sample_tools)
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [],
+            "model": "m",
+            "tools": [tool.model_dump() for tool in sample_tools],
+            "tool_choice": tool_choice,
+        }
+    )
+
+    out = parser.adjust_request(request)
+
+    assert out.structured_outputs is None
+
+
 def test_get_structural_tag_disables_reasoning(
     monkeypatch: pytest.MonkeyPatch,
     sample_tools_strict: list[ChatCompletionToolsParam],

--- a/vllm/tool_parsers/abstract_tool_parser.py
+++ b/vllm/tool_parsers/abstract_tool_parser.py
@@ -11,11 +11,13 @@ from typing import Any
 from openai.types.responses import (
     ResponseFormatTextJSONSchemaConfig,
     ResponseTextConfig,
+    ToolChoiceFunction,
 )
 from openai.types.responses.function_tool import FunctionTool
 
 import vllm.envs as envs
 from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionNamedToolChoiceParam,
     ChatCompletionRequest,
     ChatCompletionToolsParam,
 )
@@ -131,6 +133,20 @@ class ToolParser:
         if (
             structured_outputs is not None
             and structured_outputs.structural_tag is not None
+        ):
+            return request
+
+        # Parsers that opt out of the standard JSON-based required/named
+        # handling emit a native, non-JSON tool-call syntax. Forcing the tool
+        # JSON schema would constrain decoding to output their
+        # extract_tool_calls cannot read, so leave the request unconstrained
+        # and let the serving layer fall back to auto parsing.
+        if not self.supports_required_and_named and (
+            request.tool_choice == "required"
+            or isinstance(
+                request.tool_choice,
+                (ChatCompletionNamedToolChoiceParam, ToolChoiceFunction),
+            )
         ):
             return request
 


### PR DESCRIPTION
# Issue #49981 — `tool_choice: "required"` xgrammar FSM crash / infinite hang (GLM-5.2)

## 1. Root cause

`ToolParser.supports_required_and_named` is the flag a tool parser sets to say
*"my model does not emit the standard tool-call JSON; do not use the generic
JSON-based `required`/named handling for me."* GLM parsers
(`Glm47MoeModelToolParser`, used for `--tool-call-parser glm45/glm47`, i.e. the
GLM-4.5/4.7/5.x family) set `supports_required_and_named = False` because those
models emit XML-ish tool calls plus thinking special tokens.

The **parsing** side honoured that flag — `DelegatingParser.parse` treats
`required`/named as `auto` and routes through the parser's `extract_tool_calls`
(`vllm/parser/abstract_parser.py:433-447`).

The **constraint** side did not. `ToolParser.adjust_request` unconditionally
called `get_json_schema_from_tools()` and installed the resulting
`{"type": "array", "minItems": 1, "items": {"anyOf": [...]}}` schema as
`request.structured_outputs.json`, i.e. as a hard xgrammar decoding constraint.

So for GLM with `tool_choice: "required"` the two halves disagreed: decoding was
forced into a JSON grammar the model never produces, while the output was then
handed to the XML parser that could not have read that JSON anyway. The failure
modes reported in the issue follow directly:

- **500 / `Failed to advance FSM ... grammar rejected tokens [..., 154842, ...]`** —
  GLM's first tokens are its native thinking/tool special tokens (154842 is one
  of them). The JSON grammar has no transition for them, so the FSM cannot
  advance and the request is terminated.
- **Infinite hang with no `max_tokens`** — the array schema only reaches an
  accepting state once a valid JSON array is closed. With several tools the
  model keeps being pushed into a grammar it cannot satisfy and never emits a
  legal stop, so generation runs until the length cap. With no `max_tokens` set
  there is no cap.
- **`auto` works** — no JSON schema is installed for `auto`.
- **A specific named function "works"** in the reporter's environment because
  the single-function schema is small enough that the model can sometimes be
  coerced into it; it is broken for the same reason.

Note this is only reachable when the xgrammar structural-tag path is *not* taken.
With the default `VLLM_ENFORCE_STRICT_TOOL_CALLING=1`, `_apply_structural_tag`
installs the `glm_4_7` builtin structural tag first and `adjust_request` returns
early. Setting `VLLM_ENFORCE_STRICT_TOOL_CALLING=0` (or using any
`supports_required_and_named = False` parser with no structural tag wired up,
e.g. `InklingEngineToolParser`) drops into the broken JSON-schema path.

This is the same defect class already fixed one-parser-at-a-time for Gemma4
(`Gemma4EngineToolParser.adjust_request`, regression after #45588), Poolside
(`PoolsideV1ToolParser.adjust_request`) and the Rust bridge
(`RustToolParser.adjust_request`) — each carries its own copy of the skip. GLM
and Inkling never got one.

## 2. The fix

`vllm/tool_parsers/abstract_tool_parser.py` — in `ToolParser.adjust_request`,
return the request unchanged when `supports_required_and_named` is `False` and
`tool_choice` is `"required"` or a named function, before the JSON schema is
built and installed.

Why in the base class rather than adding a fourth per-parser override: the flag
already *means* "the generic JSON required/named path does not apply to me", and
the parsing side reads it that way. Enforcing it in one place makes the two
halves consistent, fixes GLM and Inkling together, and stops the next
`supports_required_and_named = False` parser from re-introducing the bug. The
existing per-parser overrides are left alone — they also flip
`skip_special_tokens`, and they have their own regression tests.

Behaviour after the fix: `required`/named on these parsers is unconstrained and
parsed as `auto`, which is exactly what the serving layer already assumed. GLM
still gets `skip_special_tokens = False` from
`ParserEngineToolAdapter.adjust_request` → `ParserEngine.adjust_request`, so its
native delimiters still reach the extractor.

## 3. Files changed

| File | Change |
|---|---|
| `vllm/tool_parsers/abstract_tool_parser.py` | Skip the forced tool JSON schema for `required`/named when `supports_required_and_named` is `False`; import `ChatCompletionNamedToolChoiceParam` and `ToolChoiceFunction`. |
| `tests/tool_parsers/test_structural_tag_registry.py` | Added `test_parser_without_required_and_named_support_skips_schema_constraints` (parametrized `required` / named), next to the existing `test_non_structural_tag_parser_uses_schema_constraints` that pins the opposite case. |
| `NOTES.md` | This file. |

## 4. Risk / uncertainty

- **Behaviour change:** `required` on these parsers is no longer grammar-forced.
  It was never actually enforcing anything useful there — it was producing
  output the model's own parser rejects — but a caller who relied on the
  constraint existing will now see an unconstrained generation. This matches
  what Gemma4/Poolside/Rust already do, and the default strict-tool-calling path
  (structural tag) is untouched and still enforces `required` properly.
- **Mistral:** `MistralParser` flips `supports_required_and_named` to `False` on
  the *instance*, but only inside `parse`/`parse_delta`, which run after
  `adjust_request`; the parser is constructed per request in the renderer, so
  the new branch never fires for Mistral. Verified by
  `tests/tool_parsers/test_mistral_tool_parser.py` passing unchanged.
- **Unverified:** I could not run GLM-5.2-NVFP4 end-to-end — no GPU in this
  environment. The 500/hang reproduction and its disappearance are argued from
  the code path and the reporter's token IDs, not observed on hardware. Since
  the change only removes a decoding constraint (never adds one) and does not
  touch model code, no model-quality eval is implicated; the on-GPU check worth
  doing before merge is a GLM-5.2 request with `tool_choice: "required"`, 4+
  tools, `enable_thinking: false` and no `max_tokens`, under
  `VLLM_ENFORCE_STRICT_TOOL_CALLING=0`.

## 5. How I verified it

Environment: CPU-only venv (`uv venv --python 3.12`, CPU torch 2.13 + test
deps); no GPU, so only the non-GPU unit suites are runnable.

```
.venv/bin/python -m pytest tests/tool_parsers/test_structural_tag_registry.py -q
→ 54 passed
```

Confirmed the new test actually catches the bug — with the
`abstract_tool_parser.py` change stashed and the test kept:

```
FAILED ...::test_parser_without_required_and_named_support_skips_schema_constraints[required]
FAILED ...::test_parser_without_required_and_named_support_skips_schema_constraints[named]
2 failed, 52 passed
```

Regression sweep over every suite that touches tool parsing / request
adjustment:

```
.venv/bin/python -m pytest tests/tool_parsers/ tests/parser/ \
    tests/tool_use/test_gemma4_responses_adjust_request.py -q
→ 4710 passed, 3 skipped, 34 xfailed, 15 errors

.venv/bin/python -m pytest \
    tests/entrypoints/openai/responses/test_parsable_context_unit.py \
    tests/tool_use/test_chat_completion_request_validations.py \
    tests/tool_use/test_responses_request_validations.py -q
→ 40 passed
```

The 15 errors are all in `tests/tool_parsers/test_llama3_json_tool_parser.py`
and are environment-only: fixture setup gets HTTP 401 fetching the gated
`meta-llama/Llama-3.2-1B-Instruct` config from Hugging Face (no HF token here).
They fail identically before and after the change.

Lint:

```
ruff check <changed files>   → All checks passed!
ruff format --diff <changed files> → 2 files already formatted
```

AI assistance was used for this investigation and patch.
