### PR TITLE
[Bugfix][MLA] Fix fp8 KV cache prefill query quantization selection for Kimi-K3

### DIFF
--- a/tests/v1/attention/test_mla_prefill_selector.py
+++ b/tests/v1/attention/test_mla_prefill_selector.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 
-from vllm.config import AttentionConfig, ModelConfig, VllmConfig
+from vllm.config import AttentionConfig, CacheConfig, ModelConfig, VllmConfig
 from vllm.platforms import current_platform
 from vllm.platforms.interface import DeviceCapability
 from vllm.v1.attention.backends.mla.prefill.base import MLADimensions
@@ -44,14 +44,20 @@ def _make_mock_model_config(
 def _make_vllm_config(
     model_config: ModelConfig | None = None,
     mla_prefill_backend: MLAPrefillBackendEnum | None = None,
+    use_prefill_query_quantization: bool = False,
+    kv_cache_dtype: str = "auto",
 ) -> VllmConfig:
     if model_config is None:
         model_config = _make_mock_model_config()
 
-    attention_config = AttentionConfig(mla_prefill_backend=mla_prefill_backend)
+    attention_config = AttentionConfig(
+        mla_prefill_backend=mla_prefill_backend,
+        use_prefill_query_quantization=use_prefill_query_quantization,
+    )
     mock_vllm_config = MagicMock(spec=VllmConfig)
     mock_vllm_config.model_config = model_config
     mock_vllm_config.attention_config = attention_config
+    mock_vllm_config.cache_config = CacheConfig(cache_dtype=kv_cache_dtype)
     return mock_vllm_config
 
 
@@ -158,6 +164,106 @@ class TestGetMLAPrefillBackend:
             mock_platform.is_rocm.return_value = False
 
             backend = get_mla_prefill_backend(vllm_config)
+            assert backend.get_name() == "FLASH_ATTN"
+
+
+def _mock_get_class(backend_enum: MLAPrefillBackendEnum):
+    """Stand in for every backend so selection is decided by priority alone."""
+    cls = MagicMock()
+    cls.get_name.return_value = backend_enum.name
+    cls.validate_configuration.return_value = []
+    cls.supports_query_quantization = backend_enum in (
+        MLAPrefillBackendEnum.TRTLLM_RAGGED,
+        MLAPrefillBackendEnum.FLASHINFER,
+        MLAPrefillBackendEnum.TOKENSPEED_MLA,
+    )
+    return cls
+
+
+class TestPrefillQueryQuantizationSelection:
+    """`use_prefill_query_quantization` must steer auto-selection.
+
+    Regression test for gh-50056: on Blackwell FLASH_ATTN is the default
+    first choice but cannot consume an FP8 query, so an explicit request for
+    FP8 prefill attention was silently dropped.
+    """
+
+    @staticmethod
+    def _blackwell_priorities(prefer_query_quantization: bool):
+        with patch("vllm.platforms.current_platform") as mock_platform:
+            mock_platform.is_rocm.return_value = False
+            return _get_mla_prefill_backend_priorities(
+                DeviceCapability(major=10, minor=0),
+                MLADimensions(
+                    qk_nope_head_dim=128,
+                    qk_rope_head_dim=64,
+                    v_head_dim=128,
+                ),
+                prefer_query_quantization,
+            )
+
+    def test_flash_attn_stays_first_when_not_requested(self):
+        priorities = self._blackwell_priorities(prefer_query_quantization=False)
+        assert priorities[0] == MLAPrefillBackendEnum.FLASH_ATTN
+
+    def test_quantization_capable_backends_come_first_when_requested(self):
+        priorities = self._blackwell_priorities(prefer_query_quantization=True)
+
+        assert priorities == [
+            MLAPrefillBackendEnum.TRTLLM_RAGGED,
+            MLAPrefillBackendEnum.FLASHINFER,
+            MLAPrefillBackendEnum.TOKENSPEED_MLA,
+            MLAPrefillBackendEnum.FLASH_ATTN,
+        ]
+
+    @pytest.mark.parametrize(
+        ("kv_cache_dtype", "expected_backend"),
+        # Without an FP8 KV cache the flag is a no-op, so the default
+        # priority must be left untouched.
+        [("fp8", "TRTLLM_RAGGED"), ("auto", "FLASH_ATTN")],
+    )
+    def test_selection_honours_flag_only_with_quantized_kv_cache(
+        self, kv_cache_dtype: str, expected_backend: str
+    ):
+        with (
+            patch("vllm.platforms.current_platform") as mock_platform,
+            patch.object(MLAPrefillBackendEnum, "get_class", _mock_get_class),
+        ):
+            mock_platform.is_rocm.return_value = False
+            mock_platform.get_device_capability.return_value = DeviceCapability(
+                major=10, minor=0
+            )
+
+            backend = get_mla_prefill_backend(
+                _make_vllm_config(
+                    use_prefill_query_quantization=True,
+                    kv_cache_dtype=kv_cache_dtype,
+                )
+            )
+            assert backend.get_name() == expected_backend
+
+    def test_falls_back_to_flash_attn_when_no_capable_backend_is_valid(self):
+        def mock_get_class(backend_enum):
+            cls = _mock_get_class(backend_enum)
+            if cls.supports_query_quantization:
+                cls.validate_configuration.return_value = ["deps not available"]
+            return cls
+
+        with (
+            patch("vllm.platforms.current_platform") as mock_platform,
+            patch.object(MLAPrefillBackendEnum, "get_class", mock_get_class),
+        ):
+            mock_platform.is_rocm.return_value = False
+            mock_platform.get_device_capability.return_value = DeviceCapability(
+                major=10, minor=0
+            )
+
+            backend = get_mla_prefill_backend(
+                _make_vllm_config(
+                    use_prefill_query_quantization=True,
+                    kv_cache_dtype="fp8",
+                )
+            )
             assert backend.get_name() == "FLASH_ATTN"
 
 

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -199,7 +199,6 @@ for chunk_idx in range(cdiv(C, W)):
 return curr_o @ W_O
 """
 
-import functools
 import itertools
 import math
 from abc import abstractmethod
@@ -1567,33 +1566,30 @@ def _use_masked_mha(
     return False
 
 
-@functools.cache
-def backend_supports_prefill_query_quantization() -> bool:
-    """Check if the selected MLA prefill backend supports query quantization.
+def prefill_query_quantization_blockers(vllm_config: VllmConfig) -> list[str]:
+    """Reasons the MLA prefill query cannot be quantized to FP8.
 
-    Currently supported backends:
-    - FlashInfer
-    - TRT-LLM Ragged
-
-    Not supported:
-    - FlashAttention (FA3/FA4)
-    - Non-GB200 devices (FP8 prefill requires device capability 100)
+    An empty list means FP8 prefill queries are supported for this config.
     """
-    # FP8 prefill query quantization requires GB200 (device capability 100)
-    # for the necessary FP8 kernels at the moment.
+    # The FP8 prefill kernels currently only exist for the compute capability
+    # 10.x (Blackwell) family.
     if not current_platform.is_device_capability_family(100):
-        return False
+        capability = current_platform.get_device_capability()
+        detected = capability.as_version_str() if capability is not None else "unknown"
+        return [
+            "FP8 prefill queries require a compute capability 10.x device, "
+            f"detected {detected}"
+        ]
 
-    from vllm.config import get_current_vllm_config
     from vllm.v1.attention.backends.mla.prefill import get_mla_prefill_backend
 
-    vllm_config = get_current_vllm_config()
     backend_cls = get_mla_prefill_backend(vllm_config)
-    return backend_cls.get_name() in (
-        "FLASHINFER",
-        "TRTLLM_RAGGED",
-        "TOKENSPEED_MLA",
-    )
+    if not backend_cls.supports_query_quantization:
+        return [
+            f"MLA prefill backend {backend_cls.get_name()} cannot consume an FP8 query"
+        ]
+
+    return []
 
 
 @dataclass
@@ -1966,27 +1962,33 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
         Return FP8 dtype if cache is FP8 and prefill query quantization
         is enabled, else model dtype.
         """
-        use_fp8 = (
-            is_quantized_kv_cache(vllm_config.cache_config.cache_dtype)
-            and vllm_config.attention_config.use_prefill_query_quantization
-            and backend_supports_prefill_query_quantization()
-        )
+        cache_is_quantized = is_quantized_kv_cache(vllm_config.cache_config.cache_dtype)
+        requested = vllm_config.attention_config.use_prefill_query_quantization
 
-        if use_fp8:
-            fp8_dtype = current_platform.fp8_dtype()
-            logger.info_once("FP8 prefill attention enabled: query data type is FP8")
-            return fp8_dtype
-        elif vllm_config.attention_config.use_prefill_query_quantization:
-            logger.info_once(
-                "Unable to perform FP8 prefill attention when"
-                " use_prefill_query_quantization is enabled. Please"
-                " ensure that --kv-cache-dtype is set to fp8 and your prefill"
-                " backend is compatible with FP8 attention.",
+        if requested and not cache_is_quantized:
+            logger.warning_once(
+                "use_prefill_query_quantization is enabled but the KV cache is"
+                " not quantized. Please set --kv-cache-dtype to fp8 to enable"
+                " FP8 prefill attention.",
             )
             return model_dtype
-        elif (
-            is_quantized_kv_cache(vllm_config.cache_config.cache_dtype)
-            and backend_supports_prefill_query_quantization()
+        elif requested:
+            blockers = prefill_query_quantization_blockers(vllm_config)
+            if not blockers:
+                logger.info_once(
+                    "FP8 prefill attention enabled: query data type is FP8"
+                )
+                return current_platform.fp8_dtype()
+            logger.warning_once(
+                "Unable to perform FP8 prefill attention even though"
+                " use_prefill_query_quantization is enabled: %s. Prefill"
+                " queries will use %s.",
+                "; ".join(blockers),
+                model_dtype,
+            )
+            return model_dtype
+        elif cache_is_quantized and not prefill_query_quantization_blockers(
+            vllm_config
         ):
             logger.warning_once(
                 "FP8 KV cache is enabled but prefill queries are not "

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -187,7 +187,6 @@ for chunk_idx in range(cdiv(C, MCC)):
 return curr_o @ W_O
 """
 
-import functools
 from abc import abstractmethod
 from dataclasses import dataclass
 from enum import Enum
@@ -1563,33 +1562,30 @@ def _use_masked_mha(
     return False
 
 
-@functools.cache
-def backend_supports_prefill_query_quantization() -> bool:
-    """Check if the selected MLA prefill backend supports query quantization.
+def prefill_query_quantization_blockers(vllm_config: VllmConfig) -> list[str]:
+    """Reasons the MLA prefill query cannot be quantized to FP8.
 
-    Currently supported backends:
-    - FlashInfer
-    - TRT-LLM Ragged
-
-    Not supported:
-    - FlashAttention (FA3/FA4)
-    - Non-GB200 devices (FP8 prefill requires device capability 100)
+    An empty list means FP8 prefill queries are supported for this config.
     """
-    # FP8 prefill query quantization requires GB200 (device capability 100)
-    # for the necessary FP8 kernels at the moment.
+    # The FP8 prefill kernels currently only exist for the compute capability
+    # 10.x (Blackwell) family.
     if not current_platform.is_device_capability_family(100):
-        return False
+        capability = current_platform.get_device_capability()
+        detected = capability.as_version_str() if capability is not None else "unknown"
+        return [
+            "FP8 prefill queries require a compute capability 10.x device, "
+            f"detected {detected}"
+        ]
 
-    from vllm.config import get_current_vllm_config
     from vllm.v1.attention.backends.mla.prefill import get_mla_prefill_backend
 
-    vllm_config = get_current_vllm_config()
     backend_cls = get_mla_prefill_backend(vllm_config)
-    return backend_cls.get_name() in (
-        "FLASHINFER",
-        "TRTLLM_RAGGED",
-        "TOKENSPEED_MLA",
-    )
+    if not backend_cls.supports_query_quantization:
+        return [
+            f"MLA prefill backend {backend_cls.get_name()} cannot consume an FP8 query"
+        ]
+
+    return []
 
 
 def build_mla_chunked_context_metadata(
@@ -1840,27 +1836,33 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
         Return FP8 dtype if cache is FP8 and prefill query quantization
         is enabled, else model dtype.
         """
-        use_fp8 = (
-            is_quantized_kv_cache(vllm_config.cache_config.cache_dtype)
-            and vllm_config.attention_config.use_prefill_query_quantization
-            and backend_supports_prefill_query_quantization()
-        )
+        cache_is_quantized = is_quantized_kv_cache(vllm_config.cache_config.cache_dtype)
+        requested = vllm_config.attention_config.use_prefill_query_quantization
 
-        if use_fp8:
-            fp8_dtype = current_platform.fp8_dtype()
-            logger.info_once("FP8 prefill attention enabled: query data type is FP8")
-            return fp8_dtype
-        elif vllm_config.attention_config.use_prefill_query_quantization:
-            logger.info_once(
-                "Unable to perform FP8 prefill attention when"
-                " use_prefill_query_quantization is enabled. Please"
-                " ensure that --kv-cache-dtype is set to fp8 and your prefill"
-                " backend is compatible with FP8 attention.",
+        if requested and not cache_is_quantized:
+            logger.warning_once(
+                "use_prefill_query_quantization is enabled but the KV cache is"
+                " not quantized. Please set --kv-cache-dtype to fp8 to enable"
+                " FP8 prefill attention.",
             )
             return model_dtype
-        elif (
-            is_quantized_kv_cache(vllm_config.cache_config.cache_dtype)
-            and backend_supports_prefill_query_quantization()
+        elif requested:
+            blockers = prefill_query_quantization_blockers(vllm_config)
+            if not blockers:
+                logger.info_once(
+                    "FP8 prefill attention enabled: query data type is FP8"
+                )
+                return current_platform.fp8_dtype()
+            logger.warning_once(
+                "Unable to perform FP8 prefill attention even though"
+                " use_prefill_query_quantization is enabled: %s. Prefill"
+                " queries will use %s.",
+                "; ".join(blockers),
+                model_dtype,
+            )
+            return model_dtype
+        elif cache_is_quantized and not prefill_query_quantization_blockers(
+            vllm_config
         ):
             logger.warning_once(
                 "FP8 KV cache is enabled but prefill queries are not "

--- a/vllm/v1/attention/backends/mla/prefill/base.py
+++ b/vllm/v1/attention/backends/mla/prefill/base.py
@@ -42,6 +42,9 @@ class MLAPrefillBackend(ABC):
         torch.bfloat16,
     ]
     supported_mla_dimensions: ClassVar[list[MLADimensions]] = []
+    # Whether the backend can consume an FP8-quantized query, i.e. whether
+    # `AttentionConfig.use_prefill_query_quantization` can be honoured.
+    supports_query_quantization: ClassVar[bool] = False
 
     @staticmethod
     @abstractmethod

--- a/vllm/v1/attention/backends/mla/prefill/flashinfer.py
+++ b/vllm/v1/attention/backends/mla/prefill/flashinfer.py
@@ -43,6 +43,7 @@ class FlashInferPrefillBackend(MLAPrefillBackend):
             v_head_dim=128,
         ),
     ]
+    supports_query_quantization: ClassVar[bool] = True
 
     @staticmethod
     def get_name() -> str:

--- a/vllm/v1/attention/backends/mla/prefill/selector.py
+++ b/vllm/v1/attention/backends/mla/prefill/selector.py
@@ -13,6 +13,7 @@ import torch
 
 from vllm.logger import init_logger
 from vllm.platforms.interface import DeviceCapability
+from vllm.utils.torch_utils import is_quantized_kv_cache
 from vllm.v1.attention.backends.mla.prefill.base import MLADimensions
 from vllm.v1.attention.backends.mla.prefill.registry import MLAPrefillBackendEnum
 
@@ -45,15 +46,25 @@ class MLAPrefillSelectorConfig(NamedTuple):
         )
 
 
+def _supports_query_quantization(backend: MLAPrefillBackendEnum) -> bool:
+    try:
+        return backend.get_class().supports_query_quantization
+    except (ImportError, ValueError):
+        return False
+
+
 def _get_mla_prefill_backend_priorities(
     device_capability: DeviceCapability,
     mla_dimensions: MLADimensions,
+    prefer_query_quantization: bool = False,
 ) -> list[MLAPrefillBackendEnum]:
     """Get MLA prefill backend priorities based on device capability.
 
     Args:
         device_capability: The device's compute capability.
         mla_dimensions: The model's MLA head dimensions.
+        prefer_query_quantization: Whether to prioritize backends that can
+            consume an FP8-quantized query.
 
     Returns:
         List of backends in priority order (highest priority first).
@@ -61,33 +72,40 @@ def _get_mla_prefill_backend_priorities(
     from vllm.platforms import current_platform
 
     if current_platform.is_rocm():
-        return [
+        priorities = [
             MLAPrefillBackendEnum.ROCM_AITER_FA,
             MLAPrefillBackendEnum.FLASH_ATTN,
         ]
-
-    if device_capability.major == 10:  # Blackwell
+    elif device_capability.major == 10:  # Blackwell
         if mla_dimensions == MLADimensions(
             qk_nope_head_dim=192,
             qk_rope_head_dim=64,
             v_head_dim=256,
         ):
-            return [
+            priorities = [
                 MLAPrefillBackendEnum.TRTLLM_RAGGED,
                 MLAPrefillBackendEnum.FLASH_ATTN,
                 MLAPrefillBackendEnum.FLASHINFER,
                 MLAPrefillBackendEnum.TOKENSPEED_MLA,
             ]
-        return [
-            MLAPrefillBackendEnum.FLASH_ATTN,
-            MLAPrefillBackendEnum.TRTLLM_RAGGED,
-            MLAPrefillBackendEnum.FLASHINFER,
-            MLAPrefillBackendEnum.TOKENSPEED_MLA,
-        ]
+        else:
+            priorities = [
+                MLAPrefillBackendEnum.FLASH_ATTN,
+                MLAPrefillBackendEnum.TRTLLM_RAGGED,
+                MLAPrefillBackendEnum.FLASHINFER,
+                MLAPrefillBackendEnum.TOKENSPEED_MLA,
+            ]
     else:  # Hopper (SM90) and older
-        return [
+        priorities = [
             MLAPrefillBackendEnum.FLASH_ATTN,
         ]
+
+    if prefer_query_quantization:
+        # Stable partition: backends that can consume an FP8 query first,
+        # otherwise the request for FP8 prefill attention is silently dropped.
+        priorities.sort(key=lambda backend: not _supports_query_quantization(backend))
+
+    return priorities
 
 
 def get_mla_prefill_backend(
@@ -115,6 +133,12 @@ def get_mla_prefill_backend(
         return MLAPrefillBackendEnum.FLASH_ATTN.get_class()
 
     attention_config = vllm_config.attention_config
+    cache_config = vllm_config.cache_config
+    prefer_query_quantization = (
+        attention_config.use_prefill_query_quantization
+        and cache_config is not None
+        and is_quantized_kv_cache(cache_config.cache_dtype)
+    )
 
     model_config = vllm_config.model_config
     if model_config is None:
@@ -153,6 +177,7 @@ def get_mla_prefill_backend(
     return _auto_select_mla_prefill_backend(
         device_capability,
         selector_config,
+        prefer_query_quantization,
     )
 
 
@@ -160,12 +185,15 @@ def get_mla_prefill_backend(
 def _auto_select_mla_prefill_backend(
     device_capability: DeviceCapability,
     selector_config: MLAPrefillSelectorConfig,
+    prefer_query_quantization: bool = False,
 ) -> "type[MLAPrefillBackend]":
     """Auto-select the best available MLA prefill backend.
 
     Args:
         device_capability: The device's compute capability.
         selector_config: Hashable configuration for backend selection.
+        prefer_query_quantization: Whether to prioritize backends that can
+            consume an FP8-quantized query.
 
     Returns:
         The selected prefill backend class.
@@ -173,6 +201,7 @@ def _auto_select_mla_prefill_backend(
     priorities = _get_mla_prefill_backend_priorities(
         device_capability,
         selector_config.mla_dimensions,
+        prefer_query_quantization,
     )
     all_invalid_reasons: dict[str, list[str]] = {}
 

--- a/vllm/v1/attention/backends/mla/prefill/tokenspeed_mla.py
+++ b/vllm/v1/attention/backends/mla/prefill/tokenspeed_mla.py
@@ -29,6 +29,7 @@ class TokenspeedMLAPrefillBackend(MLAPrefillBackend):
             v_head_dim=128,
         ),
     ]
+    supports_query_quantization: ClassVar[bool] = True
 
     @staticmethod
     def get_name() -> str:

--- a/vllm/v1/attention/backends/mla/prefill/trtllm_ragged.py
+++ b/vllm/v1/attention/backends/mla/prefill/trtllm_ragged.py
@@ -36,6 +36,7 @@ class TrtllmRaggedPrefillBackend(MLAPrefillBackend):
             v_head_dim=256,
         ),
     ]
+    supports_query_quantization: ClassVar[bool] = True
 
     @staticmethod
     def get_name() -> str:


### PR DESCRIPTION
# Issue #50056 — `kimi-k3 --kv-cache-dtype fp8` fails despite `use_prefill_query_quantization`

Reported error:

```
Worker failed with error 'Kimi-K3 fp8 KV cache requires an fp8 prefill query;
enable --attention-config '{"use_prefill_query_quantization": true}'.'
```

…while the reporter already passed both
`--attention-config '{"use_prefill_query_quantization":true}'` and
`--kv-cache-dtype fp8`.

## 1. Root cause

The flag was being silently dropped by MLA prefill backend selection.

`MLACommonMetadataBuilder.determine_prefill_query_data_type()`
(`vllm/model_executor/layers/attention/mla_attention.py`) only returns the FP8
query dtype when **all three** of these hold:

1. the KV cache is quantized,
2. `attention_config.use_prefill_query_quantization` is set,
3. the *already selected* MLA prefill backend can consume an FP8 query
   (`FLASHINFER`, `TRTLLM_RAGGED`, `TOKENSPEED_MLA` — not `FLASH_ATTN`).

Condition 3 is evaluated **after** the backend has been chosen, but
`get_mla_prefill_backend()` /
`_get_mla_prefill_backend_priorities()`
(`vllm/v1/attention/backends/mla/prefill/selector.py`) never looked at
`use_prefill_query_quantization`. On Blackwell the default priority for the
common MLA shape is:

```python
[FLASH_ATTN, TRTLLM_RAGGED, FLASHINFER, TOKENSPEED_MLA]
```

so `FLASH_ATTN` wins, condition 3 is false, and the query stays in the model
dtype — even though the user explicitly asked for FP8 prefill queries and every
capable backend was available. A model that hard-requires an FP8 prefill query
under an FP8 KV cache then aborts with a message telling the user to enable the
flag they had already enabled. That contradiction is exactly what #50056
reports.

Two things made this invisible:

- the "unable to perform FP8 prefill attention" path logged at `info` level and
  gave a generic hint (`ensure --kv-cache-dtype is fp8 and your prefill backend
  is compatible`) rather than naming the actual blocker;
- `backend_supports_prefill_query_quantization()` was `@functools.cache`d with
  no arguments while reading `get_current_vllm_config()` inside, so its result
  was pinned to whatever config happened to be current on the first call.

Note: the Kimi-K3 model itself is not in `main` yet (PRs #49999/#50000 are still
open), so the model-side `raise` is not in this tree. The defect that produces
it — the ignored flag — is, and it affects every MLA model with an FP8 KV cache,
not just K3.

## 2. The fix and why

Make the requested query quantization an *input* to backend selection instead of
a property discovered after the fact, and tell the truth when it still cannot be
honoured.

- `MLAPrefillBackend.supports_query_quantization` (new `ClassVar`, default
  `False`; `True` on `FLASHINFER`, `TRTLLM_RAGGED`, `TOKENSPEED_MLA`). This
  replaces a hard-coded list of backend name strings in `mla_attention.py` with
  a property the backends declare themselves — the same shape as the existing
  `supported_dtypes` / `supported_mla_dimensions` capability declarations.
- `_get_mla_prefill_backend_priorities()` takes `prefer_query_quantization` and,
  when set, does a **stable partition** putting quantization-capable backends
  first. Relative order is otherwise preserved, and if none of them validate
  (missing FlashInfer, unsupported MLA dims, …) selection still falls back to
  `FLASH_ATTN` exactly as before.
- `get_mla_prefill_backend()` derives that argument from
  `use_prefill_query_quantization and is_quantized_kv_cache(cache_dtype)`. The
  gate on the KV cache dtype matters: without an FP8 cache the flag is a no-op,
  so the default priority must not be perturbed.
- `backend_supports_prefill_query_quantization()` →
  `prefill_query_quantization_blockers(vllm_config)`, returning the list of
  reasons instead of a bare bool. Dropping `@functools.cache` and taking the
  config explicitly removes the stale-cache hazard;
  `determine_prefill_query_data_type()` now `warning_once`s the concrete blocker
  ("device capability 10.x", or the named backend that cannot consume an FP8
  query) instead of a generic info line, and separately calls out the
  "flag set but KV cache not quantized" case.

Deliberately *not* changed: an explicitly requested `mla_prefill_backend` still
wins over the preference — the user's explicit choice is not overridden, they
just now get a warning naming that backend as the blocker.

## 3. Files changed

| File | Change |
| --- | --- |
| `vllm/v1/attention/backends/mla/prefill/base.py` | new `supports_query_quantization` classvar (default `False`) |
| `vllm/v1/attention/backends/mla/prefill/flashinfer.py` | declares `supports_query_quantization = True` |
| `vllm/v1/attention/backends/mla/prefill/trtllm_ragged.py` | declares `supports_query_quantization = True` |
| `vllm/v1/attention/backends/mla/prefill/tokenspeed_mla.py` | declares `supports_query_quantization = True` |
| `vllm/v1/attention/backends/mla/prefill/selector.py` | priority reorder + `prefer_query_quantization` plumbing |
| `vllm/model_executor/layers/attention/mla_attention.py` | `prefill_query_quantization_blockers()`; actionable warnings; cache removal |
| `tests/v1/attention/test_mla_prefill_selector.py` | `TestPrefillQueryQuantizationSelection` regression tests |

## 4. Risk / uncertainty

- **The reporter's exact stack trace could not be reproduced.** The Kimi-K3
  model is not merged into `main`, so the `raise` that produced their message
  lives in an unmerged branch. The diagnosis is from the shared MLA path the K3
  model consumes; I could not confirm K3's MLA head dims, which decide whether
  the reporter hit the generic Blackwell priority list (`FLASH_ATTN` first —
  always broken) or the `(192, 64, 256)` list (`TRTLLM_RAGGED` first — broken
  only when FlashInfer is unavailable and it falls back to `FLASH_ATTN`). Both
  are fixed by this change, but a maintainer with K3 access should confirm the
  runtime error actually clears.
- **Behaviour change:** with `--kv-cache-dtype fp8` *and*
  `use_prefill_query_quantization`, auto-selection can now pick a different
  prefill backend than before (e.g. `TRTLLM_RAGGED` instead of `FLASH_ATTN`).
  That is the point of the flag, and it is opt-in, but a user who set the flag
  on Blackwell and was silently getting FA prefill will now get a different
  kernel and different perf. Anyone who set neither flag, or the flag without an
  FP8 cache, is unaffected — priorities are byte-identical.
- **Not benchmarked.** No GPU in this environment, so the FP8 prefill path was
  not executed end-to-end and no accuracy/throughput numbers were collected.
  This change only routes to a kernel path that already existed and is already
  used when the backend is selected explicitly, so it should not alter output
  for any configuration that was previously *working*; still, a Blackwell +
  fp8-KV eval run is warranted before merge.
- `_supports_query_quantization()` calls `get_class()`, which imports the
  backend module. Auto-selection already does this for every candidate, so no
  new import cost beyond the reordering pass.

## 5. How this was verified

Environment: no GPU and no built `vllm._C` here; a CPU-only torch venv from a
sibling checkout was used to run the pure-Python selector tests against this
tree.

```
python -m pytest tests/v1/attention/test_mla_prefill_selector.py -q
```

- New `TestPrefillQueryQuantizationSelection`: **5 passed**.
- Whole file: **27 passed, 6 skipped, 2 failed**. The 2 failures
  (`test_no_device_capability_returns_flash_attn`,
  `test_supports_compute_capability_on_rocm`) reproduce identically on the
  unmodified tree (`git stash` baseline: same 2 failures) — they are CPU-only
  environment artifacts, not regressions. The teardown `ERROR`s come from
  `tests/conftest.py::cleanup_fixture` calling
  `torch.accelerator.empty_cache()` with no accelerator present, and likewise
  affect every test in the file before and after the change.
- **Regression check:** neutralising the fix (forcing the reorder branch off)
  turns 2 of the 5 new tests red —
  `test_quantization_capable_backends_come_first_when_requested` and
  `test_selection_honours_flag_only_with_quantized_kv_cache[fp8-TRTLLM_RAGGED]`
  — confirming they actually pin the fixed behaviour.
- Import smoke test of the changed modules: capability classvars resolve to
  `False / True / True / True` for base / TRTLLM / FlashInfer / Tokenspeed.
- `ruff check vllm/` → all checks passed; `ruff format --check` clean on all
  changed files. `mypy` was not available in this environment.
