### PR TITLE
[Bugfix] Only require symm-mem multicast when multimem is the selected algorithm

### DIFF
--- a/tests/distributed/test_symm_mem_allreduce.py
+++ b/tests/distributed/test_symm_mem_allreduce.py
@@ -3,6 +3,7 @@
 
 import queue
 import random
+import types
 import typing
 
 import pytest
@@ -15,6 +16,7 @@ from vllm.config import ParallelConfig, VllmConfig, set_current_vllm_config
 from vllm.distributed import cleanup_dist_env_and_memory
 from vllm.distributed.communication_op import tensor_model_parallel_all_reduce
 from vllm.distributed.device_communicators.cuda_communicator import CudaCommunicator
+from vllm.distributed.device_communicators.symm_mem import SymmMemCommunicator
 from vllm.distributed.parallel_state import (
     get_tp_group,
     init_distributed_environment,
@@ -138,3 +140,79 @@ def test_dp_with_symm_mem_allreduce(monkeypatch: pytest.MonkeyPatch):
         data_parallel_backend="mp",
     )
     LLMEngine.from_engine_args(engine_args)
+
+
+@pytest.mark.parametrize(
+    "capability,world_size,force_multimem,expected",
+    [
+        # Capabilities that list the world size as multimem-capable.
+        ("9.0", 4, None, True),
+        ("9.0", 8, None, True),
+        # Same capability, world size that falls back to two-shot.
+        ("9.0", 2, None, False),
+        ("10.0", 4, None, False),
+        # Unknown capability must not raise; two-shot is the safe default.
+        ("8.0", 2, None, False),
+        ("8.0", 8, None, False),
+        # Explicit override wins either way (used by benchmarks/tests).
+        ("9.0", 2, True, True),
+        ("9.0", 8, False, False),
+    ],
+)
+def test_uses_multimem(capability, world_size, force_multimem, expected):
+    """`_uses_multimem` decides whether a multicast pointer is required.
+
+    Guards against re-introducing a multicast capability check that disables
+    the two-shot path, which never uses multicast.
+    """
+    comm = object.__new__(SymmMemCommunicator)
+    comm.device_capability = capability
+    comm.world_size = world_size
+    assert comm._uses_multimem(force_multimem) is expected
+
+
+@pytest.mark.parametrize(
+    "capability,world_size,expected_op",
+    [
+        # Multimem world size for this capability -> multimem kernel.
+        ("9.0", 4, "multimem_all_reduce_"),
+        # Same capability, world size 2 falls back to two-shot.
+        ("9.0", 2, "two_shot_all_reduce_"),
+        ("10.0", 4, "two_shot_all_reduce_"),
+    ],
+)
+def test_all_reduce_dispatch(monkeypatch, capability, world_size, expected_op):
+    """`all_reduce` must pick the kernel `_uses_multimem` advertises.
+
+    The guard in ``__init__`` and the dispatch here have to agree; they were
+    previously separate expressions and disagreed about whether multicast was
+    required.
+    """
+    called = []
+
+    class _FakeOps:
+        @staticmethod
+        def multimem_all_reduce_(*args, **kwargs):
+            called.append("multimem_all_reduce_")
+
+        @staticmethod
+        def two_shot_all_reduce_(*args, **kwargs):
+            called.append("two_shot_all_reduce_")
+
+    monkeypatch.setattr(torch.ops, "symm_mem", _FakeOps, raising=False)
+
+    comm = object.__new__(SymmMemCommunicator)
+    comm.disabled = False
+    comm.dtype = torch.bfloat16
+    comm.max_size = 1 << 20
+    comm.device_capability = capability
+    comm.world_size = world_size
+    comm.force_multimem = None
+    comm.group = types.SimpleNamespace(group_name="test_group")
+    comm.buffer = torch.zeros(1024, dtype=torch.bfloat16)
+
+    inp = torch.ones(1024, dtype=torch.bfloat16)
+    out = comm.all_reduce(inp)
+
+    assert called == [expected_op]
+    assert out is not None and out.shape == inp.shape

--- a/vllm/distributed/device_communicators/symm_mem.py
+++ b/vllm/distributed/device_communicators/symm_mem.py
@@ -102,16 +102,30 @@ class SymmMemCommunicator:
                 str(e),
             )
             return
-        if handle.multicast_ptr == 0:
+        # Only the multimem kernel needs a multicast pointer; the two-shot
+        # kernel does not. Disable solely when multimem is what would run.
+        if handle.multicast_ptr == 0 and self._uses_multimem(force_multimem):
             logger.warning(
-                "SymmMemCommunicator: symmetric memory "
-                "multicast operations are not supported."
+                "SymmMemCommunicator: symmetric memory multicast operations "
+                "are not supported, and multimem is the configured algorithm "
+                "for device capability %s at world size %d; communicator is "
+                "not available.",
+                self.device_capability,
+                self.world_size,
             )
             return
         self.force_multimem = force_multimem
         self.disabled = False
         if envs.VLLM_BATCH_INVARIANT:
             self.disabled = True
+
+    def _uses_multimem(self, force_multimem: bool | None) -> bool:
+        """Whether `all_reduce` dispatches to the multimem kernel."""
+        if force_multimem is not None:
+            return force_multimem
+        return self.world_size in self._WORLD_SIZES_MULTIMEM.get(
+            self.device_capability, []
+        )
 
     def should_use_symm_mem(self, inp: torch.Tensor):
         if self.disabled:
@@ -132,18 +146,7 @@ class SymmMemCommunicator:
             out = torch.empty_like(inp)
         self.buffer[: inp.numel()].copy_(inp.view(-1))
 
-        # Determine which algorithm to use
-        use_multimem = False
-        if self.force_multimem is not None:
-            # Test override: use forced setting
-            use_multimem = self.force_multimem
-        else:
-            # Normal logic: use multimem for supported world sizes
-            use_multimem = (
-                self.world_size in self._WORLD_SIZES_MULTIMEM[self.device_capability]
-            )
-
-        if use_multimem:
+        if self._uses_multimem(self.force_multimem):
             torch.ops.symm_mem.multimem_all_reduce_(
                 self.buffer[: inp.numel()], "sum", self.group.group_name
             )


### PR DESCRIPTION
## Purpose

Fixes #50179.

`SymmMemCommunicator.__init__` disables the communicator whenever the rendezvous handle has no multicast pointer:

```python
if handle.multicast_ptr == 0:
    logger.warning("SymmMemCommunicator: symmetric memory "
                   "multicast operations are not supported.")
    return
```

Only the multimem kernel needs a multicast pointer. `all_reduce` selects between two kernels, and the two-shot branch never uses multicast:

```python
use_multimem = self.world_size in self._WORLD_SIZES_MULTIMEM[self.device_capability]
if use_multimem:
    torch.ops.symm_mem.multimem_all_reduce_(...)
else:
    torch.ops.symm_mem.two_shot_all_reduce_(...)   # no multicast
```

On a device whose capability is present in `SYMM_MEM_ALL_REDUCE_MAX_SIZES` but which has no NVLS multicast, this leaves a working two-shot path unreachable. `_WORLD_SIZES_MULTIMEM["9.0"] = [4, 6, 8]` selects two-shot at `world_size=2`, so capability 9.0 is affected at that world size.

The underlying cause is that the multimem/two-shot decision was expressed in two places that disagreed: the guard assumed multicast was always required, the dispatch did not. This PR moves that decision into `_uses_multimem()` and has both call sites use it, so the guard and the dispatch cannot drift apart again. The helper reads `_WORLD_SIZES_MULTIMEM` with `.get(capability, [])`, which also removes a latent `KeyError` for capabilities absent from the table.

Behavior is unchanged wherever multicast is available: `_uses_multimem()` returns the same value the inline expression did, and the guard still fires when multimem is selected.

## Test Plan

Two new tests in `tests/distributed/test_symm_mem_allreduce.py`. Both are CPU-only and need no distributed initialization.

`test_uses_multimem` covers the selection helper, parametrized over capabilities that list the world size as multimem-capable, the same capability at a world size that falls back to two-shot, capabilities absent from the table, and the `force_multimem` override.

`test_all_reduce_dispatch` covers the dispatch itself: it stubs `torch.ops.symm_mem`, calls `all_reduce`, and asserts which kernel was invoked.

```
pytest tests/distributed/test_symm_mem_allreduce.py -k "test_uses_multimem or test_all_reduce_dispatch"
```

Separately, a direct check that the guarded kernel is functional on a device where the guard fires: 8x A100-SXM4-80GB with NVSwitch, where `multicast_ptr` is 0, calling `torch.ops.symm_mem.two_shot_all_reduce_` and verifying the reduction.

## Test Result

```text
11 passed, 2 deselected, 15 warnings in 0.95s
```

Both tests are load-bearing. Reverting `.get(capability, [])` to a direct dict index turns 2 of the `test_uses_multimem` cases red:

```text
FAILED tests/distributed/test_symm_mem_allreduce.py::test_uses_multimem[8.0-2-None-False]
FAILED tests/distributed/test_symm_mem_allreduce.py::test_uses_multimem[8.0-8-None-False]
```

Inverting the dispatch condition in `all_reduce` turns all three `test_all_reduce_dispatch` cases red:

```text
FAILED test_all_reduce_dispatch[9.0-4-multimem_all_reduce_]
FAILED test_all_reduce_dispatch[9.0-2-two_shot_all_reduce_]
FAILED test_all_reduce_dispatch[10.0-4-two_shot_all_reduce_]
```

The guard in `__init__` is a single call to `_uses_multimem`, which the unit tests cover directly. Its runtime behavior where multicast is present is exercised by the existing GPU tests in this file, which CI runs on the 4-GPU job.

Kernel check, torch 2.11.0+cu130, 8x A100-SXM4-80GB, `multicast_ptr == 0`:

```text
torch=2.11.0+cu130 world=2 gpu=NVIDIA A100-SXM4-80GB cc=(8, 0)
rendezvous OK multicast_ptr=0
two_shot_all_reduce_ -> PASS  first=[3.0, 3.0] expected=3.0

torch=2.11.0+cu130 world=8 gpu=NVIDIA A100-SXM4-80GB cc=(8, 0)
rendezvous OK multicast_ptr=0
two_shot_all_reduce_ -> PASS  first=[36.0, 36.0] expected=36.0
```

Capability 8.0 stops at the earlier `SYMM_MEM_ALL_REDUCE_MAX_SIZES` check, so A100 does not exercise this guard through vLLM. That earlier check is a separate matter and not addressed here.

## Validation

Rebased onto upstream `main` at `0b6aa3c47`.

```text
git diff --check: pass
ruff check: pass
ruff format --check: pass
final diff: 2 files changed, 96 insertions(+), 15 deletions(-)
```

## Provenance

Developed with AI assistance (Claude Code). Every changed line was reviewed before submission. Attribution is in the commit trailer as `Assisted-by: Claude Code`.