### PR TITLE
[Bugfix][Spec Decode] Fix misspelled EAGLE3 aux-hidden-state layer method overrides

### DIFF
--- a/tests/model_executor/test_eagle3_aux_layers_method_name.py
+++ b/tests/model_executor/test_eagle3_aux_layers_method_name.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Guard against the EAGLE3 aux-hidden-state method-name typo.
+
+``SupportsEagle3`` declares ``get_eagle3_default_aux_hidden_state_layers`` and
+every runtime caller (``gpu_model_runner`` / eagle3 utils) invokes exactly that
+name. Several models historically overrode a misspelled
+``get_eagle3_aux_hidden_state_layers`` (missing ``default``); because nothing
+calls that name, those overrides were silently dead code. This test fails if the
+misspelled name reappears anywhere under ``vllm/model_executor/models``.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+import vllm.model_executor.models as models_pkg
+from vllm.model_executor.models.interfaces import SupportsEagle3
+
+CORRECT_NAME = "get_eagle3_default_aux_hidden_state_layers"
+MISSPELLED_NAME = "get_eagle3_aux_hidden_state_layers"
+
+
+@pytest.mark.cpu_test
+def test_interface_uses_correct_method_name():
+    assert hasattr(SupportsEagle3, CORRECT_NAME)
+    assert not hasattr(SupportsEagle3, MISSPELLED_NAME)
+
+
+@pytest.mark.cpu_test
+def test_no_model_defines_misspelled_eagle3_aux_layers_method():
+    models_dir = Path(models_pkg.__file__).parent
+    offenders = []
+    for path in sorted(models_dir.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.FunctionDef)
+                and node.name == MISSPELLED_NAME
+            ):
+                offenders.append(f"{path.name}:{node.lineno}")
+
+    assert not offenders, (
+        f"Found method(s) named {MISSPELLED_NAME!r} (missing 'default'). The "
+        f"EAGLE3 runtime only ever calls {CORRECT_NAME!r}, so such overrides are "
+        f"dead code. Rename them. Offenders: {offenders}"
+    )

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -1884,7 +1884,7 @@ class DeepseekV2ForCausalLM(
     def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
         self.model.aux_hidden_state_layers = layers
 
-    def get_eagle3_aux_hidden_state_layers(self) -> tuple[int, ...]:
+    def get_eagle3_default_aux_hidden_state_layers(self) -> tuple[int, ...]:
         num_layers = len(self.model.layers)
         return (2, num_layers // 2, num_layers - 3)
 

--- a/vllm/model_executor/models/kimi_k25.py
+++ b/vllm/model_executor/models/kimi_k25.py
@@ -467,8 +467,8 @@ class KimiK25ForConditionalGeneration(
     def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
         self.language_model.set_aux_hidden_state_layers(layers)
 
-    def get_eagle3_aux_hidden_state_layers(self) -> tuple[int, ...]:
-        return self.language_model.get_eagle3_aux_hidden_state_layers()
+    def get_eagle3_default_aux_hidden_state_layers(self) -> tuple[int, ...]:
+        return self.language_model.get_eagle3_default_aux_hidden_state_layers()
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
         loader = AutoWeightsLoader(self)

--- a/vllm/model_executor/models/pixtral.py
+++ b/vllm/model_executor/models/pixtral.py
@@ -451,9 +451,9 @@ class PixtralForConditionalGeneration(
         self._require_language_model_eagle3()
         self.language_model.set_aux_hidden_state_layers(layers)
 
-    def get_eagle3_aux_hidden_state_layers(self) -> tuple[int, ...]:
+    def get_eagle3_default_aux_hidden_state_layers(self) -> tuple[int, ...]:
         self._require_language_model_eagle3()
-        return self.language_model.get_eagle3_aux_hidden_state_layers()
+        return self.language_model.get_eagle3_default_aux_hidden_state_layers()
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
         _vision_encoder_stacked_params = [

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -343,7 +343,7 @@ class Qwen3_5ForCausalLMBase(
     def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
         self.model.aux_hidden_state_layers = layers
 
-    def get_eagle3_aux_hidden_state_layers(self) -> tuple[int, ...]:
+    def get_eagle3_default_aux_hidden_state_layers(self) -> tuple[int, ...]:
         num_layers = len(self.model.layers)
         return (2, num_layers // 2, num_layers - 3)
 


### PR DESCRIPTION
`SupportsEagle3` declares `get_eagle3_default_aux_hidden_state_layers`, and the runtime (gpu_model_runner, eagle3 utils) only ever calls that name. However deepseek_v2, qwen3_5, pixtral, and kimi_k25 overrode a misspelled `get_eagle3_aux_hidden_state_layers` (missing `default`), so those overrides were never invoked (dead code).

- deepseek_v2 / qwen3_5: the override duplicated the base default, so behavior is unchanged after renaming.
- pixtral / kimi_k25: the override delegates to self.language_model; the wrong name meant delegation silently fell back to the interface default. Rename the method and the inner call so delegation works (matching mllama4).

Add a regression test that fails if the misspelled name reappears under vllm/model_executor/models.

Signed-off-by: huang cheng <chenghuang1990@gmail.com>
