### PR TITLE
[Helion] Improve fused QK config selection

### DIFF
--- a/tests/kernels/helion/test_fused_qk_norm_rope.py
+++ b/tests/kernels/helion/test_fused_qk_norm_rope.py
@@ -33,10 +33,9 @@ if not has_helion():
 
 @default_vllm_config()
 def _generate_fake_input(
-    num_tokens: int, num_q_heads: int, num_kv_heads: int
+    num_tokens: int, num_q_heads: int, num_kv_heads: int, head_dim: int = 128
 ) -> tuple[Any, ...]:
     with FakeTensorMode():
-        head_dim = 128
         eps = 1e-6
         is_neox = True
         rotary_ratio = 1.0
@@ -125,6 +124,17 @@ class TestFusedQkNormRopeConfigPicker:
         assert selected_key == CaseKey(
             {"q_heads": 2048, "kv_heads": 64, "num_tokens": 32}
         )
+
+    def test_config_picker_prefers_exact_head_dim(self):
+        generic = CaseKey({"q_heads": 64, "kv_heads": 8, "num_tokens": 32})
+        head_dim_256 = CaseKey(
+            {"q_heads": 64, "kv_heads": 8, "num_tokens": 256, "head_dim": 256}
+        )
+
+        args = _generate_fake_input(32, 64, 8, head_dim=256)
+        selected_key = pick_config(args, [generic, head_dim_256])
+
+        assert selected_key == head_dim_256
 
     def test_config_picker_no_configs(self):
         config_keys: list[dict] = []

--- a/tests/kernels/helion/test_fused_qk_norm_rope.py
+++ b/tests/kernels/helion/test_fused_qk_norm_rope.py
@@ -122,7 +122,19 @@ class TestFusedQkNormRopeConfigPicker:
         args = _generate_fake_input(20, 3000, 70)
         selected_key = pick_config(args, config_keys)
         assert selected_key == CaseKey(
-            {"q_heads": 2048, "kv_heads": 64, "num_tokens": 32}
+            {"q_heads": 2048, "kv_heads": 64, "num_tokens": 16}
+        )
+
+    def test_config_picker_head_mismatch_uses_lower_token_bucket(self):
+        config_keys = [
+            CaseKey({"q_heads": 16, "kv_heads": 8, "num_tokens": 256}),
+            CaseKey({"q_heads": 16, "kv_heads": 8, "num_tokens": 512}),
+        ]
+
+        args = _generate_fake_input(512, 8, 4)
+        selected_key = pick_config(args, config_keys)
+        assert selected_key == CaseKey(
+            {"q_heads": 16, "kv_heads": 8, "num_tokens": 256}
         )
 
     def test_config_picker_prefers_exact_head_dim(self):

--- a/vllm/kernels/helion/configs/fused_qk_norm_rope/nvidia_b200.json
+++ b/vllm/kernels/helion/configs/fused_qk_norm_rope/nvidia_b200.json
@@ -2131,5 +2131,473 @@
       "num_sm_multiplier": 128,
       "maxnreg": 64
     }
+  },
+  {
+    "key": {
+      "q_heads": 16,
+      "kv_heads": 8,
+      "num_tokens": 2,
+      "head_dim": 256
+    },
+    "config": {
+      "block_sizes": [
+        1
+      ],
+      "loop_orders": [
+        [
+          0,
+          2,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 32,
+      "kv_heads": 8,
+      "num_tokens": 2,
+      "head_dim": 256
+    },
+    "config": {
+      "block_sizes": [
+        1
+      ],
+      "loop_orders": [
+        [
+          0,
+          2,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 64,
+      "kv_heads": 8,
+      "num_tokens": 2,
+      "head_dim": 256
+    },
+    "config": {
+      "block_sizes": [
+        1
+      ],
+      "loop_orders": [
+        [
+          0,
+          2,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 16,
+      "kv_heads": 8,
+      "num_tokens": 256,
+      "head_dim": 256
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 32,
+      "kv_heads": 8,
+      "num_tokens": 256,
+      "head_dim": 256
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 64,
+      "kv_heads": 8,
+      "num_tokens": 256,
+      "head_dim": 256
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 16,
+      "kv_heads": 8,
+      "num_tokens": 8192,
+      "head_dim": 256
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          2,
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 32,
+      "kv_heads": 8,
+      "num_tokens": 8192,
+      "head_dim": 256
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          2,
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 64,
+      "kv_heads": 8,
+      "num_tokens": 8192,
+      "head_dim": 256
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          2,
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
   }
 ]

--- a/vllm/kernels/helion/configs/fused_qk_norm_rope/nvidia_b200.json
+++ b/vllm/kernels/helion/configs/fused_qk_norm_rope/nvidia_b200.json
@@ -7,17 +7,17 @@
     },
     "config": {
       "block_sizes": [
-        4
+        1
       ],
       "loop_orders": [
         [
+          0,
           2,
-          1,
-          0
+          1
         ]
       ],
       "l2_groupings": [
-        8
+        1
       ],
       "range_unroll_factors": [
         0
@@ -33,30 +33,19 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "first",
-        "",
         "last",
-        "first",
-        "",
         "last",
-        "first"
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
       ],
       "num_warps": 1,
-      "num_stages": 5,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
+      "num_stages": 1,
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -69,79 +58,17 @@
     },
     "config": {
       "block_sizes": [
-        4
+        1
       ],
       "loop_orders": [
         [
           0,
-          1,
-          2
-        ]
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        null
-      ],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "",
-        "last",
-        "last",
-        "first",
-        "first",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 3,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 64,
-      "kv_heads": 8,
-      "num_tokens": 1
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
           2,
-          1,
-          0
+          1
         ]
       ],
       "l2_groupings": [
-        32
+        1
       ],
       "range_unroll_factors": [
         0
@@ -158,115 +85,41 @@
       ],
       "load_eviction_policies": [
         "last",
-        "first",
-        "",
-        "first",
         "last",
-        "first",
-        "first",
-        "first"
-      ],
-      "num_warps": 1,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 16,
-      "kv_heads": 8,
-      "num_tokens": 2
-    },
-    "config": {
-      "block_sizes": [
-        1
-      ],
-      "loop_orders": [
-        [
-          1,
-          2,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        64
-      ],
-      "range_unroll_factors": [
-        1
-      ],
-      "range_warp_specializes": [
-        false
-      ],
-      "range_multi_buffers": [
-        true
-      ],
-      "range_flattens": [
-        true
-      ],
-      "load_eviction_policies": [
         "last",
-        "first",
-        "",
         "last",
-        "first",
         "last",
-        "",
+        "last",
+        "last",
+        "last",
         "last"
       ],
       "num_warps": 1,
       "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
+      "indexing": "pointer",
       "atomic_indexing": [],
-      "pid_type": "persistent_interleaved",
-      "num_sm_multiplier": 4,
-      "maxnreg": 128
+      "pid_type": "flat"
     }
   },
   {
     "key": {
-      "q_heads": 32,
+      "q_heads": 64,
       "kv_heads": 8,
-      "num_tokens": 2
+      "num_tokens": 1
     },
     "config": {
       "block_sizes": [
-        4
+        1
       ],
       "loop_orders": [
         [
+          0,
           2,
-          1,
-          0
+          1
         ]
       ],
       "l2_groupings": [
-        32
+        1
       ],
       "range_unroll_factors": [
         0
@@ -283,29 +136,120 @@
       ],
       "load_eviction_policies": [
         "last",
-        "first",
-        "",
-        "first",
         "last",
-        "first",
-        "first",
-        "first"
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
       ],
       "num_warps": 1,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 16,
+      "kv_heads": 8,
+      "num_tokens": 2
+    },
+    "config": {
+      "block_sizes": [
+        1
       ],
+      "loop_orders": [
+        [
+          0,
+          2,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 32,
+      "kv_heads": 8,
+      "num_tokens": 2
+    },
+    "config": {
+      "block_sizes": [
+        1
+      ],
+      "loop_orders": [
+        [
+          0,
+          2,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -318,17 +262,17 @@
     },
     "config": {
       "block_sizes": [
-        4
+        1
       ],
       "loop_orders": [
         [
+          0,
           2,
-          1,
-          0
+          1
         ]
       ],
       "l2_groupings": [
-        32
+        1
       ],
       "range_unroll_factors": [
         0
@@ -345,29 +289,18 @@
       ],
       "load_eviction_policies": [
         "last",
-        "first",
-        "",
-        "first",
         "last",
-        "first",
-        "first",
-        "first"
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
       ],
       "num_warps": 1,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
+      "num_stages": 1,
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -380,81 +313,18 @@
     },
     "config": {
       "block_sizes": [
-        8
-      ],
-      "loop_orders": [
-        [
-          2,
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        64
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        false
-      ],
-      "range_multi_buffers": [
-        true
-      ],
-      "range_flattens": [
-        false
-      ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "last",
-        "last",
-        "first",
-        "last",
-        "",
-        "last"
-      ],
-      "num_warps": 8,
-      "num_stages": 2,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "persistent_blocked",
-      "num_sm_multiplier": 4,
-      "maxnreg": 128
-    }
-  },
-  {
-    "key": {
-      "q_heads": 32,
-      "kv_heads": 8,
-      "num_tokens": 4
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          0,
-          1,
-          2
-        ]
-      ],
-      "l2_groupings": [
         2
       ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
       "range_unroll_factors": [
         0
       ],
@@ -469,30 +339,70 @@
         null
       ],
       "load_eviction_policies": [
-        "",
         "last",
         "last",
-        "first",
-        "first",
-        "first",
-        "",
-        "first"
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
       ],
       "num_warps": 1,
-      "num_stages": 3,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor"
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 32,
+      "kv_heads": 8,
+      "num_tokens": 4
+    },
+    "config": {
+      "block_sizes": [
+        2
       ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -505,198 +415,12 @@
     },
     "config": {
       "block_sizes": [
-        4
+        2
       ],
       "loop_orders": [
         [
-          2,
           1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        32
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        null
-      ],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "",
-        "first",
-        "last",
-        "first",
-        "first",
-        "first"
-      ],
-      "num_warps": 1,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 16,
-      "kv_heads": 8,
-      "num_tokens": 8
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          0,
           2,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        null
-      ],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "",
-        "",
-        "",
-        "last",
-        "last",
-        "first",
-        "first"
-      ],
-      "num_warps": 4,
-      "num_stages": 3,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 32,
-      "kv_heads": 8,
-      "num_tokens": 8
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          2,
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        32
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        null
-      ],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "",
-        "first",
-        "last",
-        "first",
-        "first",
-        "first"
-      ],
-      "num_warps": 1,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 64,
-      "kv_heads": 8,
-      "num_tokens": 8
-    },
-    "config": {
-      "block_sizes": [
-        8
-      ],
-      "loop_orders": [
-        [
-          2,
-          1,
           0
         ]
       ],
@@ -718,29 +442,171 @@
       ],
       "load_eviction_policies": [
         "last",
-        "first",
-        "first",
-        "first",
+        "last",
+        "last",
+        "last",
+        "last",
         "last",
         "last",
         "last",
         "last"
       ],
-      "num_warps": 8,
-      "num_stages": 3,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 16,
+      "kv_heads": 8,
+      "num_tokens": 8
+    },
+    "config": {
+      "block_sizes": [
+        2
       ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 32,
+      "kv_heads": 8,
+      "num_tokens": 8
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 64,
+      "kv_heads": 8,
+      "num_tokens": 8
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -753,7 +619,7 @@
     },
     "config": {
       "block_sizes": [
-        4
+        2
       ],
       "loop_orders": [
         [
@@ -763,7 +629,7 @@
         ]
       ],
       "l2_groupings": [
-        4
+        1
       ],
       "range_unroll_factors": [
         0
@@ -779,30 +645,19 @@
         null
       ],
       "load_eviction_policies": [
-        "",
         "last",
-        "first",
-        "",
-        "first",
-        "",
-        "",
-        "first"
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
       ],
-      "num_warps": 2,
-      "num_stages": 8,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -815,12 +670,12 @@
     },
     "config": {
       "block_sizes": [
-        4
+        2
       ],
       "loop_orders": [
         [
-          2,
           1,
+          2,
           0
         ]
       ],
@@ -841,30 +696,19 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
         "last",
-        "first",
-        "",
-        "first",
-        "first",
-        "",
-        "first"
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
       ],
-      "num_warps": 2,
-      "num_stages": 4,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor"
-      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -877,694 +721,12 @@
     },
     "config": {
       "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          0,
-          2,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        null
-      ],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "",
-        "",
-        "",
-        "last",
-        "last",
-        "first",
-        "first"
-      ],
-      "num_warps": 4,
-      "num_stages": 3,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 16,
-      "kv_heads": 8,
-      "num_tokens": 32
-    },
-    "config": {
-      "block_sizes": [
-        4
+        2
       ],
       "loop_orders": [
         [
           1,
           2,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        null
-      ],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "first",
-        "",
-        "first",
-        "",
-        "",
-        "first"
-      ],
-      "num_warps": 2,
-      "num_stages": 8,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 32,
-      "kv_heads": 8,
-      "num_tokens": 32
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          2,
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        32
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        null
-      ],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "last",
-        "last",
-        "",
-        "last",
-        "last",
-        "",
-        "first"
-      ],
-      "num_warps": 1,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 64,
-      "kv_heads": 8,
-      "num_tokens": 32
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          1,
-          2,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        null
-      ],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "first",
-        "",
-        "first",
-        "",
-        "",
-        "first"
-      ],
-      "num_warps": 2,
-      "num_stages": 8,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 16,
-      "kv_heads": 8,
-      "num_tokens": 64
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          1,
-          2,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        null
-      ],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "first",
-        "",
-        "first",
-        "",
-        "",
-        "first"
-      ],
-      "num_warps": 2,
-      "num_stages": 8,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 32,
-      "kv_heads": 8,
-      "num_tokens": 64
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          2,
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        32
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        null
-      ],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "",
-        "first",
-        "last",
-        "first",
-        "first",
-        "first"
-      ],
-      "num_warps": 1,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 64,
-      "kv_heads": 8,
-      "num_tokens": 64
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          0,
-          2,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        null
-      ],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "last",
-        "first",
-        "",
-        "last",
-        "first",
-        "first",
-        "first"
-      ],
-      "num_warps": 2,
-      "num_stages": 7,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 16,
-      "kv_heads": 8,
-      "num_tokens": 128
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          1,
-          2,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        null
-      ],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "first",
-        "",
-        "first",
-        "",
-        "",
-        "first"
-      ],
-      "num_warps": 2,
-      "num_stages": 8,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 32,
-      "kv_heads": 8,
-      "num_tokens": 128
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          2,
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        8
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        null
-      ],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "",
-        "",
-        "last",
-        "last",
-        "first",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 7,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 64,
-      "kv_heads": 8,
-      "num_tokens": 128
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          2,
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        8
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        null
-      ],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "",
-        "last",
-        "first",
-        "",
-        "last",
-        "first"
-      ],
-      "num_warps": 1,
-      "num_stages": 5,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 16,
-      "kv_heads": 8,
-      "num_tokens": 256
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          1,
-          2,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        null
-      ],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "first",
-        "",
-        "first",
-        "",
-        "",
-        "first"
-      ],
-      "num_warps": 2,
-      "num_stages": 8,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 32,
-      "kv_heads": 8,
-      "num_tokens": 256
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          2,
-          1,
           0
         ]
       ],
@@ -1585,53 +747,42 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
         "last",
-        "first",
-        "",
-        "first",
-        "first",
-        "",
-        "first"
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
       ],
-      "num_warps": 2,
-      "num_stages": 4,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor"
-      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "flat"
     }
   },
   {
     "key": {
-      "q_heads": 64,
+      "q_heads": 16,
       "kv_heads": 8,
-      "num_tokens": 256
+      "num_tokens": 32
     },
     "config": {
       "block_sizes": [
-        4
+        2
       ],
       "loop_orders": [
         [
-          2,
           1,
+          2,
           0
         ]
       ],
       "l2_groupings": [
-        32
+        1
       ],
       "range_unroll_factors": [
         0
@@ -1647,30 +798,580 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
         "last",
         "last",
-        "",
         "last",
         "last",
-        "",
-        "first"
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
       ],
       "num_warps": 1,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 32,
+      "kv_heads": 8,
+      "num_tokens": 32
+    },
+    "config": {
+      "block_sizes": [
+        2
       ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 64,
+      "kv_heads": 8,
+      "num_tokens": 32
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 16,
+      "kv_heads": 8,
+      "num_tokens": 64
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 32,
+      "kv_heads": 8,
+      "num_tokens": 64
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 64,
+      "kv_heads": 8,
+      "num_tokens": 64
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 16,
+      "kv_heads": 8,
+      "num_tokens": 128
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 32,
+      "kv_heads": 8,
+      "num_tokens": 128
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 64,
+      "kv_heads": 8,
+      "num_tokens": 128
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 16,
+      "kv_heads": 8,
+      "num_tokens": 256
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 32,
+      "kv_heads": 8,
+      "num_tokens": 256
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 64,
+      "kv_heads": 8,
+      "num_tokens": 256
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -1718,19 +1419,7 @@
       ],
       "num_warps": 1,
       "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -1777,19 +1466,7 @@
       ],
       "num_warps": 1,
       "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 32,
@@ -1840,19 +1517,7 @@
       ],
       "num_warps": 1,
       "num_stages": 1,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 32
@@ -1900,19 +1565,7 @@
       ],
       "num_warps": 1,
       "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 32,
@@ -1937,48 +1590,37 @@
         ]
       ],
       "l2_groupings": [
-        64
+        1
       ],
       "range_unroll_factors": [
-        2
+        0
       ],
       "range_warp_specializes": [
-        false
+        null
       ],
+      "range_num_stages": [],
       "range_multi_buffers": [
-        true
+        null
       ],
       "range_flattens": [
-        false
+        null
       ],
       "load_eviction_policies": [
-        "",
-        "last",
-        "",
-        "",
         "last",
         "last",
-        "first",
-        ""
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
       ],
       "num_warps": 1,
-      "num_stages": 7,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
+      "num_stages": 1,
+      "indexing": "pointer",
       "atomic_indexing": [],
-      "pid_type": "persistent_interleaved",
-      "num_sm_multiplier": 32
+      "pid_type": "flat"
     }
   },
   {
@@ -2025,19 +1667,7 @@
       ],
       "num_warps": 1,
       "num_stages": 6,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,
@@ -2062,48 +1692,37 @@
         ]
       ],
       "l2_groupings": [
-        64
+        1
       ],
       "range_unroll_factors": [
-        2
+        0
       ],
       "range_warp_specializes": [
-        false
+        null
       ],
+      "range_num_stages": [],
       "range_multi_buffers": [
-        true
+        null
       ],
       "range_flattens": [
-        false
+        null
       ],
       "load_eviction_policies": [
-        "",
-        "last",
-        "",
-        "",
         "last",
         "last",
-        "first",
-        ""
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
       ],
       "num_warps": 1,
-      "num_stages": 7,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
+      "num_stages": 1,
+      "indexing": "pointer",
       "atomic_indexing": [],
-      "pid_type": "persistent_interleaved",
-      "num_sm_multiplier": 32
+      "pid_type": "flat"
     }
   },
   {
@@ -2150,19 +1769,7 @@
       ],
       "num_warps": 1,
       "num_stages": 8,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "persistent_interleaved",
       "num_sm_multiplier": 32
@@ -2212,19 +1819,7 @@
       ],
       "num_warps": 1,
       "num_stages": 6,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,
@@ -2275,19 +1870,7 @@
       ],
       "num_warps": 1,
       "num_stages": 6,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,
@@ -2338,19 +1921,7 @@
       ],
       "num_warps": 1,
       "num_stages": 6,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,
@@ -2401,19 +1972,7 @@
       ],
       "num_warps": 1,
       "num_stages": 6,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,
@@ -2464,19 +2023,7 @@
       ],
       "num_warps": 1,
       "num_stages": 6,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,
@@ -2527,19 +2074,7 @@
       ],
       "num_warps": 1,
       "num_stages": 6,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,
@@ -2590,19 +2125,7 @@
       ],
       "num_warps": 1,
       "num_stages": 6,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,

--- a/vllm/kernels/helion/ops/fused_qk_norm_rope.py
+++ b/vllm/kernels/helion/ops/fused_qk_norm_rope.py
@@ -290,6 +290,8 @@ def fused_qk_norm_rope(
             x1_offset = hl.arange(embed_dim) * 2
             x2_offset = x1_offset + 1
 
+        # Partial RoPE still requires RMSNorm over the full head, including the
+        # unrotated tail, so retain the full-head normalization path.
         if rotary_dim < head_dim:
             x_blk = qkv[tile_m, tile_gn, tile_n].to(dtype=torch.float32)
             rms = torch.rsqrt(x_blk.pow(2).sum(dim=-1) * (1.0 / head_dim) + eps)
@@ -303,6 +305,8 @@ def fused_qk_norm_rope(
             x1_blk = qkv[tile_m, tile_gn, x1_offset]
             x2_blk = qkv[tile_m, tile_gn, x2_offset]
         else:
+            # Full RoPE covers the entire head. Keep both rotary halves in
+            # registers through RMSNorm and RoPE to avoid a store/reload round trip.
             x1_blk = qkv[tile_m, tile_gn, x1_offset].to(dtype=torch.float32)
             x2_blk = qkv[tile_m, tile_gn, x2_offset].to(dtype=torch.float32)
             rms = x1_blk.pow(2).sum(dim=-1) + x2_blk.pow(2).sum(dim=-1)

--- a/vllm/kernels/helion/ops/fused_qk_norm_rope.py
+++ b/vllm/kernels/helion/ops/fused_qk_norm_rope.py
@@ -281,23 +281,7 @@ def fused_qk_norm_rope(
     for tile_m, tile_gn, tile_n in hl.tile(
         [num_tokens, qk_heads, head_dim], block_size=[1, None, head_dim]
     ):
-        x_blk = qkv[tile_m, tile_gn, tile_n].to(dtype=torch.float32)
-
-        rms = x_blk.pow(2).sum(dim=-1)
-        rms = torch.rsqrt(rms * (1.0 / head_dim) + eps)
-
         use_q_weight = (tile_gn.index < num_heads_q)[None, :, None]
-        w_blk = torch.where(
-            use_q_weight, q_weight[None, None, tile_n], k_weight[None, None, tile_n]
-        )
-
-        x_blk = (x_blk * rms[:, :, None]).to(qkv.dtype) * w_blk
-
-        qkv[tile_m, tile_gn, tile_n] = x_blk
-
-        pos_id = position_ids[tile_m]
-        cos_blk = cos_sin_cache[pos_id, hl.arange(embed_dim)]
-        sin_blk = cos_sin_cache[pos_id, hl.arange(embed_dim) + embed_dim]
 
         if is_neox:
             x1_offset = hl.arange(embed_dim)
@@ -306,8 +290,39 @@ def fused_qk_norm_rope(
             x1_offset = hl.arange(embed_dim) * 2
             x2_offset = x1_offset + 1
 
-        x1_blk = qkv[tile_m, tile_gn, x1_offset]
-        x2_blk = qkv[tile_m, tile_gn, x2_offset]
+        if rotary_dim < head_dim:
+            x_blk = qkv[tile_m, tile_gn, tile_n].to(dtype=torch.float32)
+            rms = torch.rsqrt(x_blk.pow(2).sum(dim=-1) * (1.0 / head_dim) + eps)
+            weight = torch.where(
+                use_q_weight,
+                q_weight[None, None, tile_n],
+                k_weight[None, None, tile_n],
+            )
+            x_blk = (x_blk * rms[:, :, None]).to(qkv.dtype) * weight
+            qkv[tile_m, tile_gn, tile_n] = x_blk
+            x1_blk = qkv[tile_m, tile_gn, x1_offset]
+            x2_blk = qkv[tile_m, tile_gn, x2_offset]
+        else:
+            x1_blk = qkv[tile_m, tile_gn, x1_offset].to(dtype=torch.float32)
+            x2_blk = qkv[tile_m, tile_gn, x2_offset].to(dtype=torch.float32)
+            rms = x1_blk.pow(2).sum(dim=-1) + x2_blk.pow(2).sum(dim=-1)
+            rms = torch.rsqrt(rms * (1.0 / head_dim) + eps)
+            x1_weight = torch.where(
+                use_q_weight,
+                q_weight[None, None, x1_offset],
+                k_weight[None, None, x1_offset],
+            )
+            x2_weight = torch.where(
+                use_q_weight,
+                q_weight[None, None, x2_offset],
+                k_weight[None, None, x2_offset],
+            )
+            x1_blk = (x1_blk * rms[:, :, None]).to(qkv.dtype) * x1_weight
+            x2_blk = (x2_blk * rms[:, :, None]).to(qkv.dtype) * x2_weight
+
+        pos_id = position_ids[tile_m]
+        cos_blk = cos_sin_cache[pos_id, hl.arange(embed_dim)]
+        sin_blk = cos_sin_cache[pos_id, hl.arange(embed_dim) + embed_dim]
 
         o1_blk = x1_blk * cos_blk[:, None, :] - x2_blk * sin_blk[:, None, :]
         o2_blk = x2_blk * cos_blk[:, None, :] + x1_blk * sin_blk[:, None, :]

--- a/vllm/kernels/helion/ops/fused_qk_norm_rope.py
+++ b/vllm/kernels/helion/ops/fused_qk_norm_rope.py
@@ -53,7 +53,7 @@ def generate_inputs() -> dict[CaseKey, tuple[Any, ...]]:
         (32, 8),
         (64, 8),
     ]
-    head_dim = 128
+    head_dim_list = [64, 128, 256]
     in_dtype: torch.dtype = torch.bfloat16
     rotary_ratio = 1.0
     is_neox = True
@@ -61,8 +61,8 @@ def generate_inputs() -> dict[CaseKey, tuple[Any, ...]]:
     device = "cuda"
     inputs = {}
 
-    for num_tokens, (num_q_heads, num_kv_heads) in product(
-        num_tokens_list, num_heads_pair
+    for num_tokens, (num_q_heads, num_kv_heads), head_dim in product(
+        num_tokens_list, num_heads_pair, head_dim_list
     ):
         total_dim = (num_q_heads + 2 * num_kv_heads) * head_dim
         qkv = torch.empty(
@@ -84,6 +84,7 @@ def generate_inputs() -> dict[CaseKey, tuple[Any, ...]]:
                 "q_heads": num_q_heads,
                 "kv_heads": num_kv_heads,
                 "num_tokens": num_tokens,
+                "head_dim": head_dim,
             }
         )
         inputs[config_key] = (

--- a/vllm/kernels/helion/ops/fused_qk_norm_rope.py
+++ b/vllm/kernels/helion/ops/fused_qk_norm_rope.py
@@ -117,9 +117,9 @@ def pick_config(args: tuple[Any, ...], config_keys: list[CaseKey]) -> CaseKey | 
          (exact match preferred).
       3. Find the closest kv_heads among available configs
          (exact match preferred).
-      4. Among the num_tokens values tuned for that q_heads and kv_heads, pick
-         the smallest num_tokens >= the input's num_tokens. If the input is
-         larger than all available num_tokens, fall back to the largest.
+      4. Use an exact token config only when the Q/KV head tuple also matches.
+         Otherwise, pick the largest token config below the input size. If no
+         smaller token config exists, fall back to the smallest.
     """
 
     if not config_keys:
@@ -160,9 +160,14 @@ def pick_config(args: tuple[Any, ...], config_keys: list[CaseKey]) -> CaseKey | 
     best_q_heads = min(configs, key=lambda s: abs(s - q_heads))
     best_kv_heads = min(configs[best_q_heads], key=lambda s: abs(s - kv_heads))
     available_num_tokens = sorted(configs[best_q_heads][best_kv_heads])
-    best_num_tokens = next(
-        (n for n in available_num_tokens if n >= num_tokens), available_num_tokens[-1]
-    )
+    head_shape_exact = best_q_heads == q_heads and best_kv_heads == kv_heads
+    if head_shape_exact and num_tokens in available_num_tokens:
+        best_num_tokens = num_tokens
+    else:
+        smaller_num_tokens = [n for n in available_num_tokens if n < num_tokens]
+        best_num_tokens = (
+            smaller_num_tokens[-1] if smaller_num_tokens else available_num_tokens[0]
+        )
 
     result = next(
         key

--- a/vllm/kernels/helion/ops/fused_qk_norm_rope.py
+++ b/vllm/kernels/helion/ops/fused_qk_norm_rope.py
@@ -104,18 +104,20 @@ def generate_inputs() -> dict[CaseKey, tuple[Any, ...]]:
     return inputs
 
 
-_pick_cache: dict[tuple[int, int, int], CaseKey | None] = {}
+_pick_cache: dict[tuple[int, int, int, int], CaseKey | None] = {}
 
 
 def pick_config(args: tuple[Any, ...], config_keys: list[CaseKey]) -> CaseKey | None:
     """Pick the best pre-tuned config for the given input shape.
 
     Selection strategy:
-      1. Find the closest q_heads among available configs
+      1. Prefer configs tuned for the exact head_dim. If none exist, use
+         configs without a head_dim key, then fall back to the closest head_dim.
+      2. Find the closest q_heads among available configs
          (exact match preferred).
-      2. Find the closest kv_heads among available configs
+      3. Find the closest kv_heads among available configs
          (exact match preferred).
-      3. Among the num_tokens values tuned for that q_heads and q_heads, pick
+      4. Among the num_tokens values tuned for that q_heads and kv_heads, pick
          the smallest num_tokens >= the input's num_tokens. If the input is
          larger than all available num_tokens, fall back to the largest.
     """
@@ -123,18 +125,31 @@ def pick_config(args: tuple[Any, ...], config_keys: list[CaseKey]) -> CaseKey | 
     if not config_keys:
         return None
 
-    qkv, q_heads, kv_heads, *_ = args
+    qkv, q_heads, kv_heads, _, head_dim, *_ = args
     num_tokens = qkv.shape[0]
 
-    cache_key = (num_tokens, q_heads, kv_heads)
+    cache_key = (num_tokens, q_heads, kv_heads, head_dim)
     cached = _pick_cache.get(cache_key)
     if cached is not None:
         return cached
 
+    non_default_keys = [key for key in config_keys if not key.is_default()]
+    candidate_keys = [
+        key for key in non_default_keys if key.get("head_dim") == head_dim
+    ]
+    if not candidate_keys:
+        candidate_keys = [key for key in non_default_keys if "head_dim" not in key]
+    if not candidate_keys and non_default_keys:
+        best_head_dim = min(
+            {key["head_dim"] for key in non_default_keys},
+            key=lambda value: abs(value - head_dim),
+        )
+        candidate_keys = [
+            key for key in non_default_keys if key["head_dim"] == best_head_dim
+        ]
+
     configs: dict[int, dict[int, list[int]]] = {}
-    for key in config_keys:
-        if key.is_default():
-            continue
+    for key in candidate_keys:
         configs.setdefault(key["q_heads"], {}).setdefault(key["kv_heads"], []).append(
             key["num_tokens"]
         )
@@ -149,12 +164,12 @@ def pick_config(args: tuple[Any, ...], config_keys: list[CaseKey]) -> CaseKey | 
         (n for n in available_num_tokens if n >= num_tokens), available_num_tokens[-1]
     )
 
-    result = CaseKey(
-        {
-            "q_heads": best_q_heads,
-            "kv_heads": best_kv_heads,
-            "num_tokens": best_num_tokens,
-        }
+    result = next(
+        key
+        for key in candidate_keys
+        if key["q_heads"] == best_q_heads
+        and key["kv_heads"] == best_kv_heads
+        and key["num_tokens"] == best_num_tokens
     )
     _pick_cache[cache_key] = result
     return result


### PR DESCRIPTION
# Improve Out-of-Config Helion QK Schedule Selection

<!--
Before opening this PR, rerun the mandatory duplicate-work checks from an
environment with GitHub access:

gh pr list --repo vllm-project/vllm --state open \
  --search "fused qk config picker"
gh pr list --repo vllm-project/vllm --state open --search "Helion QK"

The Codex environment attempted both searches, but access to api.github.com
was blocked by its network policy.
-->

## Summary

This PR improves the deterministic config picker for Helion's
`fused_qk_norm_rope` kernel on out-of-config shapes.

The picker still selects configs by `head_dim`, then the closest Q-head and
KV-head tuple. It now uses an exact token config only when the head tuple is
also exact. Otherwise, it selects the largest lower token bucket, falling back
to the smallest bucket when no lower one exists.

This avoids applying highly specialized upper-bucket schedules to different
head shapes. It does not add runtime benchmarking or a measured per-shape map.

## Motivation

The previous ceiling-bucket policy performed well on average but had a poor
tail in a 1,326-shape B200 sweep. Out-of-config head tuples above 256 tokens
were often mapped to specialized 512-token schedules, producing speedups as
low as `0.378x` relative to the native kernel.

The revised policy preserves exact tuned cases while using a more robust
schedule for unmatched shapes.

## B200 Results

The model-backed sweep covers 51 token counts through 512 and 26 physical
`(Q heads, KV heads, head dim)` tuples derived from public model configs and
tensor-parallel sizes 1, 2, 4, and 8.

| Picker | Correctness | Geomean | Median | Faster | More than 5% slower | Worst |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Ceiling token bucket | 1,326/1,326 | 1.172x | 1.241x | 1,032 | 229 | 0.378x |
| Exact tuple, otherwise lower bucket | 1,326/1,326 | 1.264x | 1.262x | 1,324 | 0 | 0.980x |

For token counts above 256, geometric-mean speedup improves from `0.991x` to
`1.227x`, and the number of cases faster than native improves from 170/416 to
415/416. The two revised-picker cases below native are both within 2%.

These measurements validate the picker policy against the pre-stack B200 QK
config set identified by SHA-256
`1c92a8918b6134adeb6a842e06cbe867bc528b437da239ba789c24479a4f8b4d`.
This branch is stacked on the `head_dim`-aware configs from #50466, so the
model-backed sweep should be repeated on the final branch before requesting
review.

Environment:

- NVIDIA B200
- Helion 1.4.0
- Torch 2.11.0+cu130
- Triton 3.6.0
- BF16 inputs
- Cold-L2 CUDA-graph timing

## Correctness And Tests

The picker-only branch was validated with:

```bash
.venv/bin/python -m pytest \
  tests/kernels/helion/test_fused_qk_norm_rope.py::TestFusedQkNormRopeConfigPicker \
  -v

.venv/bin/python -m pre_commit run ruff-check --files \
  vllm/kernels/helion/ops/fused_qk_norm_rope.py \
  tests/kernels/helion/test_fused_qk_norm_rope.py

.venv/bin/python -m pre_commit run ruff-format --files \
  vllm/kernels/helion/ops/fused_qk_norm_rope.py \
  tests/kernels/helion/test_fused_qk_norm_rope.py
```

Results:

- Picker tests: 6 passed
- Ruff check: passed
- Ruff format: passed
- Model-backed correctness sweep: 1,326/1,326 passed with `atol=rtol=5e-2`

No model evaluation was run because this change only selects among existing
numerics-equivalent kernel schedules and does not change model outputs.

## Related Work And Duplicate Check

This is intended as a stacked change on #50466. That PR optimizes the kernel
dataflow, adds `head_dim`-aware selection, and retunes B200 configs. This PR
changes the token-bucket policy used after the head dimension and closest head
tuple have been selected.

It therefore does not duplicate #50466. The required repository-wide open-PR
keyword searches must still be rerun before opening because GitHub API access
was blocked in the environment used to prepare this description.

## Artifacts


- [Baseline results](https://gist.githubusercontent.com/yushangdi/357a0fbda53554edf0681edd5ce635e3/raw/b200_qk_picker_baseline_results.json)
- [Revised-picker results](https://gist.githubusercontent.com/yushangdi/357a0fbda53554edf0681edd5ce635e3/raw/b200_qk_picker_revised_results.json)
- [Picker implementation](https://gist.githubusercontent.com/yushangdi/357a0fbda53554edf0681edd5ce635e3/raw/fused_qk_norm_rope.py)
- [Picker tests](https://gist.githubusercontent.com/yushangdi/357a0fbda53554edf0681edd5ce635e3/raw/test_fused_qk_norm_rope.py)
## AI Assistance

AI assistance was used to analyze benchmark results, implement and test the
picker change, and draft this PR description. The human submitter must review
every changed line, rerun the duplicate-work checks, and validate the final
branch before requesting review.
