### PR TITLE
[Bugfix] Fix Marlin MoE W13 scale permutation under tensor parallelism

### DIFF
--- a/tests/quantization/test_moe_wna16.py
+++ b/tests/quantization/test_moe_wna16.py
@@ -12,10 +12,13 @@ from compressed_tensors.quantization import (
     QuantizationType,
 )
 
+from vllm.model_executor.layers.fused_moe.oracle import int_wna16
 from vllm.model_executor.layers.fused_moe.oracle.int_wna16 import (
     WNA16MoEBackend,
     _backend_incompatibility_reason,
     _convert_moe_wna16_humming_tensors,
+    _process_awq_weights_marlin,
+    _process_weights_marlin,
     convert_to_wna16_moe_kernel_format,
     map_wna16_backend,
 )
@@ -196,3 +199,142 @@ def test_moe_wna16_uses_humming_quant_config(monkeypatch):
     )
 
     assert method.get_fused_moe_quant_config(layer) is quant_config
+
+
+@pytest.mark.parametrize("quant_method", ["awq", "gptq"])
+@pytest.mark.parametrize(
+    ("tp_size", "intermediate_size"), [(2, 512), (4, 256), (8, 128)]
+)
+def test_marlin_moe_w13_scale_permutation_uses_weight_k(
+    monkeypatch, quant_method, tp_size, intermediate_size
+):
+    hidden_size = 4096
+    group_size = 128
+    pack_factor = 8
+    num_experts = 1
+    w13_scales = torch.arange(
+        num_experts * (hidden_size // group_size) * (2 * intermediate_size),
+        dtype=torch.float32,
+    ).reshape(num_experts, hidden_size // group_size, 2 * intermediate_size)
+    w2_scales = torch.arange(
+        num_experts * (intermediate_size // group_size) * hidden_size,
+        dtype=torch.float32,
+    ).reshape(num_experts, intermediate_size // group_size, hidden_size)
+    layer = SimpleNamespace(
+        intermediate_size_per_partition=intermediate_size,
+        num_groups_w13=hidden_size // group_size,
+        num_groups_w2=intermediate_size // group_size,
+    )
+
+    permute_scales = int_wna16.marlin_moe_permute_scales
+    observed_size_ks = []
+
+    def capture_size_k(*, s, size_k, size_n, group_size, is_a_8bit=False):
+        observed_size_ks.append(size_k)
+        return permute_scales(
+            s=s,
+            size_k=size_k,
+            size_n=size_n,
+            group_size=group_size,
+            is_a_8bit=is_a_8bit,
+        )
+
+    monkeypatch.setattr(int_wna16, "marlin_moe_permute_scales", capture_size_k)
+
+    if quant_method == "awq":
+        monkeypatch.setattr(
+            int_wna16.ops,
+            "awq_marlin_moe_repack",
+            lambda qweight, *_args, **_kwargs: qweight,
+        )
+        monkeypatch.setattr(
+            int_wna16,
+            "moe_awq_to_marlin_zero_points",
+            lambda qzeros, **_kwargs: qzeros,
+        )
+        w13_qweight = torch.empty(
+            num_experts,
+            hidden_size,
+            2 * intermediate_size // pack_factor,
+            dtype=torch.int32,
+        )
+        w2_qweight = torch.empty(
+            num_experts,
+            intermediate_size,
+            hidden_size // pack_factor,
+            dtype=torch.int32,
+        )
+        w13_qzeros = torch.empty(
+            num_experts,
+            hidden_size // group_size,
+            2 * intermediate_size // pack_factor,
+            dtype=torch.int32,
+        )
+        w2_qzeros = torch.empty(
+            num_experts,
+            intermediate_size // group_size,
+            hidden_size // pack_factor,
+            dtype=torch.int32,
+        )
+        converted = _process_awq_weights_marlin(
+            layer,
+            4,
+            pack_factor,
+            group_size,
+            None,
+            w13_qweight,
+            w2_qweight,
+            w13_scales,
+            w2_scales,
+            w13_qzeros,
+            w2_qzeros,
+        )
+    else:
+        monkeypatch.setattr(
+            int_wna16.ops,
+            "gptq_marlin_moe_repack",
+            lambda qweight, *_args, **_kwargs: qweight,
+        )
+        w13_qweight = torch.empty(
+            num_experts,
+            hidden_size // pack_factor,
+            2 * intermediate_size,
+            dtype=torch.int32,
+        )
+        w2_qweight = torch.empty(
+            num_experts,
+            intermediate_size // pack_factor,
+            hidden_size,
+            dtype=torch.int32,
+        )
+        converted = _process_weights_marlin(
+            layer,
+            None,
+            4,
+            pack_factor,
+            group_size,
+            None,
+            w13_qweight,
+            w2_qweight,
+            w13_scales,
+            w2_scales,
+            torch.empty(num_experts, hidden_size, dtype=torch.int32),
+            torch.empty(num_experts, intermediate_size, dtype=torch.int32),
+        )
+
+    correctly_permuted_w13 = permute_scales(
+        s=w13_scales,
+        size_k=hidden_size,
+        size_n=w13_scales.shape[2],
+        group_size=group_size,
+    )
+    old_w13_permutation = permute_scales(
+        s=w13_scales,
+        size_k=intermediate_size,
+        size_n=w13_scales.shape[2],
+        group_size=group_size,
+    )
+
+    assert observed_size_ks == [hidden_size, intermediate_size]
+    assert torch.equal(converted[2], correctly_permuted_w13)
+    assert torch.equal(old_w13_permutation, correctly_permuted_w13) == (tp_size < 8)

--- a/vllm/model_executor/layers/fused_moe/oracle/int_wna16.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/int_wna16.py
@@ -651,7 +651,7 @@ def _process_weights_marlin(
     # --- Permute scales ---
     marlin_w13_scales = marlin_moe_permute_scales(
         s=marlin_w13_scales,
-        size_k=layer.intermediate_size_per_partition,
+        size_k=w13_qweight.shape[1] * pack_factor,
         size_n=marlin_w13_scales.shape[2],
         group_size=group_size,
         is_a_8bit=is_a_8bit,
@@ -820,7 +820,7 @@ def _process_awq_weights_marlin(
 
     marlin_w13_scales = marlin_moe_permute_scales(
         s=w13_scales,
-        size_k=layer.intermediate_size_per_partition,
+        size_k=w13_qweight.shape[1],
         size_n=w13_scales.shape[2],
         group_size=group_size,
         is_a_8bit=is_a_8bit,


### PR DESCRIPTION
## Purpose

Fix the W13 scale permutation used when converting GPTQ/AWQ MoE weights to
Marlin format.

`marlin_moe_permute_scales` expects the GEMM K dimension. For W13, K is the
full hidden/input dimension, but both conversion paths passed
`intermediate_size_per_partition`, which is W13's rank-local N dimension (and
W2's K dimension). At TP=8 for the model used below, that meant passing
`size_k=128` instead of `size_k=4096`. With group size 128, the incorrect value
selects the single-group scale layout even though W13 has 32 groups along K.

The corrected K is derived from the actual W13 tensor layout:

- GPTQ stores packed K in `w13_qweight.shape[1]`, so K is
  `shape[1] * pack_factor`.
- AWQ stores unpacked K in `w13_qweight.shape[1]`.

W2 behavior is unchanged. There are no public API, configuration,
checkpoint-format, or kernel changes.

### Why this does not duplicate an existing PR

I searched open issues and PRs immediately before submission for combinations
of `Marlin`, `MoE`, `W13`, `int_wna16`, `size_k`, `scale permutation`, `AWQ`,
and `GPTQ`; no PR or issue contains this fix.

The closest open PRs address different problems:

- #48028: non-gated MoE allocation and FP8 Marlin tile padding.
- #44563: legal `BLOCK_SIZE_K // group_size` values in the WNA16 CUDA kernel.
- #36807: FP8 MoE tile alignment under TP.
- #37296: FP4 kernel N-dimension alignment.

None changes the W13 K argument passed to `marlin_moe_permute_scales`.

## Test Plan

```bash
.venv/bin/python -m pytest tests/quantization/test_moe_wna16.py -q
.venv/bin/pre-commit run ruff-check --files \
  vllm/model_executor/layers/fused_moe/oracle/int_wna16.py \
  tests/quantization/test_moe_wna16.py
.venv/bin/pre-commit run ruff-format --files \
  vllm/model_executor/layers/fused_moe/oracle/int_wna16.py \
  tests/quantization/test_moe_wna16.py
```

The regression test covers AWQ and GPTQ at TP=2, TP=4, and TP=8 using
hidden K=4096, group size=128, and rank-local intermediate sizes 512, 256, and
128. It verifies:

- W13 receives K=4096.
- W2 continues to receive rank-local K.
- TP=8 changes from the incorrect single-group permutation to the correct
  multi-group permutation.
- TP=2 and TP=4 output remains byte-identical because both old and corrected
  values already selected the multi-group path.

## Test Result

### Deterministic tests and lint

- Negative control with the production fix reverted: 6/6 new parameter cases
  failed. Observed W13/W2 K pairs were `[512, 512]`, `[256, 256]`, and
  `[128, 128]`; W13 should be 4096 in every case.
- Patched parameter cases: 6/6 passed.
- Full `tests/quantization/test_moe_wna16.py`: 16 passed.
- `ruff-check`: passed.
- `ruff-format`: passed.

### Eight-GPU model validation

Environment:

- 8 x NVIDIA A100-SXM4-80GB
- TP=8, PP=1, expert parallelism disabled
- Python 3.12.11
- PyTorch 2.13.0+cu129, CUDA 12.9, NCCL 2.29.7
- Model: `QuantTrio/Qwen3.5-397B-A17B-AWQ`
- Model revision: `536f95520cb5202283f828e76fdc86afda581e43`
- Upstream source/wheel commit used for the A/B:
  `bb3b61f2fd2333ab165ebaba13f133db4210b9f2`
- Sampling: temperature 0.6, top-p 0.95, top-k 20, min-p 0,
  repetition penalty 1, seed 20260721, max tokens 8192

The A/B replayed three frozen private evaluation inputs with identical
requests. Their text and raw outputs are intentionally omitted.

| Case | Unpatched | Patched |
| --- | --- | --- |
| A | `stop`, 2708 tokens, strict JSON | `stop`, 6075 tokens, strict JSON |
| B | `length`, 8192 tokens, empty content | `stop`, 2606 tokens, strict JSON |
| C | `length`, 8192 tokens, empty content | `stop`, 2834 tokens, strict JSON |

Both Slurm jobs completed successfully. The unpatched and patched runs took
16:31 and 17:29 respectively, including checkpoint loading, compilation, and
warmup.

### Public synthetic reproduction

The same A/B was also run with this non-sensitive request:

```json
{
  "messages": [
    {
      "role": "system",
      "content": "You are a JSON-only evaluator. Return one JSON object and no prose."
    },
    {
      "role": "user",
      "content": "Evaluate the candidate answer. Question: Is 2 + 2 equal to 4? Candidate answer: Yes, 2 + 2 = 4. Return exactly two keys: \"verdict\" (true or false) and \"reason\" (one short string)."
    }
  ],
  "temperature": 0.6,
  "top_p": 0.95,
  "top_k": 20,
  "max_tokens": 8192,
  "seed": 20260721
}
```

- Unpatched: `finish_reason=length`, 8192 completion tokens, empty content,
  invalid JSON.
- Patched: `finish_reason=stop`, 591 completion tokens, strict JSON:
  `{"verdict": true, "reason": "The answer is mathematically correct."}`.

The A/B was launched when `bb3b61f2f` was current `main`. This PR was rebased
onto current `main` immediately before submission; neither changed file had
upstream drift.

## AI assistance disclosure

OpenAI Codex assisted with implementation, test construction, validation, and
PR preparation. The human submitter reviewed the changed lines, validated the
behavior end-to-end, and can defend the change.

