### PR TITLE
[CI] Allow comment-triggered builds past pipeline filters

### DIFF
--- a/.github/workflows/scripts/run_ci_command.py
+++ b/.github/workflows/scripts/run_ci_command.py
@@ -381,6 +381,7 @@ def create_build_payload(
         "pull_request_base_branch": pr["base"]["ref"],
         "pull_request_repository": pr["head"]["repo"]["clone_url"],
         "pull_request_labels": [label["name"] for label in pr["labels"]],
+        "ignore_pipeline_branch_filters": True,
         "env": {
             "VLLM_CI_GITHUB_COMMENT_ID": str(comment_id),
             "VLLM_CI_TRIGGERED_BY": actor,

--- a/.github/workflows/scripts/test_run_ci_command.py
+++ b/.github/workflows/scripts/test_run_ci_command.py
@@ -280,6 +280,7 @@ class RunCiCommandTest(unittest.TestCase):
                 "pull_request_base_branch": "main",
                 "pull_request_repository": ("https://github.com/contributor/vllm.git"),
                 "pull_request_labels": ["ready", "v1"],
+                "ignore_pipeline_branch_filters": True,
                 "env": {
                     "VLLM_CI_GITHUB_COMMENT_ID": "99",
                     "VLLM_CI_TRIGGERED_BY": "reviewer",


### PR DESCRIPTION
## Summary

- Set `ignore_pipeline_branch_filters` on Buildkite builds created by `/ci run`.
- Extend the build-payload contract test to require the override.

## Root cause

The live `/ci run` test reached Buildkite after the API token was corrected, but Buildkite rejected build creation with:

```
422: Build does not match the pipeline's filter condition
```

The pipeline provider filter only accepts `main` or PRs labeled `ready`/`ready-run-all-tests`. That conflicts with the intended reviewer workflow, where `/ci run` requests CI before a PR is ready. The Buildkite create-build API supports bypassing pipeline filters explicitly.

Failed live test: https://github.com/vllm-project/vllm/actions/runs/30415499683

## Duplicate-work check

Searched open PRs for the comment-based CI commands, Buildkite filter handling, and `ignore_pipeline_branch_filters`. No open PR addresses this follow-up to #50132.

## Tests

```bash
UV_CACHE_DIR=/private/tmp/vllm-ci-filter-uv-cache \
UV_PYTHON_INSTALL_DIR=/private/tmp/vllm-ci-filter-uv-python \
uv run --no-project --python 3.12 \
  .github/workflows/scripts/test_run_ci_command.py
```

Result: 15 tests passed.

```bash
uvx pre-commit run --files \
  .github/workflows/scripts/run_ci_command.py \
  .github/workflows/scripts/test_run_ci_command.py
```

Result: all applicable hooks passed.

No model evaluation is required because this only changes CI control-plane behavior.

## AI assistance

OpenAI Codex assisted with the diagnosis, implementation, tests, and PR preparation. The human submitter must review every changed line and validate the live comment-trigger flow before merge.