### PR TITLE
[Bugfix][Rust Frontend] Select earliest-completing stop string

### DIFF
--- a/rust/src/text/src/output/decoded.rs
+++ b/rust/src/text/src/output/decoded.rs
@@ -306,6 +306,12 @@ pub async fn decoded_text_event_stream(
 /// If stop string matches, returns tuple
 /// (index into stop string vec, byte index of first byte of stop string in
 /// output)
+///
+/// When several stop strings match within the newly generated text (for example
+/// when a step appends multiple tokens, or one token decodes to several
+/// characters), the stop string that completes earliest in the text is selected,
+/// so the result matches appending one character at a time. Ties are broken by
+/// stop-list order.
 fn matches_stop_string(stops: &[String], output: &str, new_bytes: usize) -> Option<(usize, usize)> {
     // We compare byte subslices to avoid utf8 boundary problem
     let output = output.as_bytes();
@@ -314,12 +320,15 @@ fn matches_stop_string(stops: &[String], output: &str, new_bytes: usize) -> Opti
         .iter()
         .map(|ss| (ss.as_bytes(), ss.len(), next_off.saturating_sub(ss.len())))
         .enumerate()
-        .find_map(|(ss_idx, (ss, len, start_off))| {
+        .filter_map(|(ss_idx, (ss, len, start_off))| {
             output[start_off..]
                 .windows(len)
                 .position(|w| w == ss)
-                .map(|pos| (ss_idx, start_off + pos))
+                .map(|pos| (ss_idx, start_off + pos, start_off + pos + len))
         })
+        // `min_by_key` keeps the first minimum, so ties fall back to stop-list order.
+        .min_by_key(|&(_, _, end)| end)
+        .map(|(ss_idx, start, _)| (ss_idx, start))
 }
 
 #[cfg(test)]
@@ -524,9 +533,47 @@ mod tests {
     #[test]
     fn stop_string_matches_first_of_multiple() {
         let stops = vec!["wor".to_string(), "say".to_string()];
-        // "say" appears earlier but "wor" is checked first (index 0)
+        // Only "wor" can complete in the 1-new-byte window; the "say" at index 0
+        // is behind the window start and is not a candidate.
         let result = matches_stop_string(&stops, "say wor", 1);
         assert_eq!(result, Some((0, 4)));
+    }
+
+    /// Several stop strings can land in the same window when a step appends
+    /// multiple tokens (speculative decoding) or when one token decodes to
+    /// several characters. The earliest-completing one must win over stop-list
+    /// order, so that a batched step agrees with character-at-a-time appending.
+    #[test]
+    fn stop_string_earliest_completing_wins_regardless_of_list_order() {
+        // " The user is a": " is a" (5 bytes) was appended in one step. Both
+        // "is" (index 10, completes at 12) and " a" (index 12, completes at 14)
+        // land in the window. "is" completes earlier, so it wins either order.
+        for stops in [vec!["a", "is"], vec!["is", "a"]] {
+            let owned: Vec<String> = stops.iter().map(|s| s.to_string()).collect();
+            let is_idx = stops.iter().position(|s| *s == "is").unwrap();
+            let result = matches_stop_string(&owned, " The user is a", " is a".len());
+            assert_eq!(result, Some((is_idx, 10)), "stop list order {stops:?}");
+        }
+    }
+
+    /// Both stops complete at the same offset, so stop-list order decides. This
+    /// pins `min_by_key`'s first-minimum behavior, which is what implements the
+    /// tie-break.
+    #[test]
+    fn stop_string_ties_broken_by_list_order() {
+        for (stops, expected) in [(vec!["ab", "b"], (0, 0)), (vec!["b", "ab"], (0, 1))] {
+            let owned: Vec<String> = stops.iter().map(|s| s.to_string()).collect();
+            let result = matches_stop_string(&owned, "ab", "ab".len());
+            assert_eq!(result, Some(expected), "stop list order {stops:?}");
+        }
+    }
+
+    #[test]
+    fn stop_string_completion_position_not_start_position() {
+        // "b" starts later than "abc" but completes earlier, so it must win.
+        let stops = vec!["abc".to_string(), "b".to_string()];
+        let result = matches_stop_string(&stops, "abc", 3);
+        assert_eq!(result, Some((1, 1)));
     }
 
     #[test]


### PR DESCRIPTION


## Purpose

`matches_stop_string` in the Rust frontend selects the **first stop string in
list order** that matches in the search window. Python selects the one that
**completes earliest in the text**, ties broken by list order — fixed
deliberately in #49391 and pinned by `tests/detokenizer/test_check_stop_strings.py`. 
The Rust frontend still has the pre-#49391 logic, so the two frontends disagree on the same request.

Repro, using the case pinned by that Python test (`matches_stop_string` compiled standalone):

```
text = " The user is a", new_bytes = len(" is a") = 5
"is" completes at 12, " a" completes at 14 -> "is" must win regardless of list order

stop=["a", "is"]  ->  Rust: "a" at 13   | Python: "is" at 10   << DIVERGES
stop=["is", "a"]  ->  Rust: "is" at 10  | Python: "is" at 10   | agrees
```

With `include_stop_str_in_output=false` the Rust output still *contains* a stop
string, and `stop_reason` is wrong.

Unlike the Python bug this does not need speculative decoding: the Rust caller
pushes tokens one at a time, but a single BPE token often decodes to several
characters, which is enough for two stops to complete in one window
(`stop=["lo","ell"]`, one token `"hello"` → old code truncates to `"hel"`
instead of `"h"`).

Fix: replace the `find_map` short-circuit with min-by-completion-offset.
`min_by_key` keeps the first minimum, giving the list-order tie-break for free.
Window arithmetic and both `include_stop_str_in_output` branches are unchanged,
so single-stop behavior is preserved exactly. Part of #44280 (Rust Frontend
Feature Parity).

**Not a duplicate:** #49391 is the Python-side fix and did not touch `rust/`;
this is the parity follow-up. #47616 trims `token_ids`/`logprobs` past an
*already-selected* stop string, so its logic never engages here. #45636 (token
splitting on truncation) and #45846 (stops inside `<think>`, draft) are
different failures.

## Test Plan

```bash
cd rust
cargo fmt -p vllm-text -- --check
cargo clippy -p vllm-text --lib --all-targets
cargo test -p vllm-text --lib
cargo test -p vllm-server --lib stop_string
```

`matches_stop_string` is private to `decoded.rs`, so `vllm-server` is included
for the only multi-stop assertion outside `vllm-text`
(`non_stream_completions_stop_string_array_matches_first_occurrence`).

## Test Result

```
cargo fmt                                       clean
cargo clippy                                    no warnings
cargo test -p vllm-text --lib                   76 passed; 0 failed; 1 ignored
cargo test -p vllm-server --lib stop_string      8 passed; 0 failed
```

Three tests added. The two behavioral ones were confirmed to fail against the
pre-fix logic by temporarily reverting `min_by_key` to `next()`:

```
earliest_completing_wins_regardless_of_list_order  before: Some((0,13))  after: Some((1,10))
completion_position_not_start_position             before: Some((0,0))   after: Some((1,1))
```

All pre-existing stop-string tests pass unchanged. (`ties_broken_by_list_order`
passes both ways by construction — on a tie, first-in-list and first-minimum
agree; it guards the comparator rather than this bug.)

No eval results: this is a deterministic selection fix with exact unit coverage,
and an accuracy benchmark cannot distinguish which of two user-supplied stop
strings terminates a request. #49391 also shipped without evals. Not covered:
e2e against a real model with spec decode (needs a GPU).

AI assistance (Claude) was used for the investigation, fix, tests, and this
description; I have reviewed every changed line and run every command above. The
commit carries a `Co-authored-by:` trailer.
