### PR TITLE
[XPU] Track block weight-scale layout to fix MLA dequant

### DIFF
--- a/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
@@ -5,6 +5,10 @@ from collections.abc import Sequence
 
 import torch
 
+from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+    BlockScaleLayout,
+    set_weight_scale_layout,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8DynamicTensorSym,
     kFp8DynamicTokenSym,
@@ -207,6 +211,11 @@ class XPUFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
         # oneDNN expected layout [K/128, N/128] at load time (one-time cost).
         scale_t = scale.data.t().contiguous()
         replace_parameter(layer, scale_attr, scale_t)
+        # Record the new layout so downstream consumers that expect the
+        # checkpoint [N/128, K/128] layout (e.g. get_and_maybe_dequant_weights,
+        # used by MLA to dequantize kv_b_proj) can detect the transpose instead
+        # of silently misreading the scale.
+        set_weight_scale_layout(layer, BlockScaleLayout.KN)
 
         # For BMM layers (e.g. wo_a), precompute 3D scale and weight:
         # [K/bs, N/bs] -> [batch, K/bs, N_per_batch/bs]

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -6,6 +6,7 @@ import functools
 import json
 import os
 from collections.abc import Callable, Sequence
+from enum import Enum
 from typing import Any
 
 import torch
@@ -36,6 +37,54 @@ from vllm.utils.deep_gemm import (
 from vllm.utils.platform_utils import get_device_name_as_file_name
 
 logger = init_logger(__name__)
+
+
+class BlockScaleLayout(str, Enum):
+    """Layout of a block-quantized weight scale tensor.
+
+    Block-FP8 checkpoints store the weight scale as ``[N/block_n, K/block_k]``
+    (``NK``). Some backends transpose it in ``process_weights_after_loading``
+    to ``[K/block_k, N/block_n]`` (``KN``) to match their kernel's expected
+    layout. Because the transpose happens in place on ``weight_scale``/
+    ``weight_scale_inv``, downstream consumers cannot tell the current layout
+    from the tensor alone. This enum, together with
+    :func:`set_weight_scale_layout` / :func:`get_weight_scale_layout`, makes the
+    layout explicit so other modules can branch correctly.
+    """
+
+    # Checkpoint layout: [N/block_n, K/block_k].
+    NK = "NK"
+    # Transposed layout: [K/block_k, N/block_n] (e.g. oneDNN fp8_gemm on XPU).
+    KN = "KN"
+
+
+# Attribute stamped onto a layer to record its current weight-scale layout.
+WEIGHT_SCALE_LAYOUT_ATTR = "_weight_scale_layout"
+
+
+def set_weight_scale_layout(layer: torch.nn.Module, layout: BlockScaleLayout) -> None:
+    """Record the current layout of ``layer``'s block weight scale.
+
+    Kernels that transpose the weight scale in
+    ``process_weights_after_loading`` should call this so downstream consumers
+    can query the layout via :func:`get_weight_scale_layout`.
+    """
+    setattr(layer, WEIGHT_SCALE_LAYOUT_ATTR, BlockScaleLayout(layout))
+
+
+def get_weight_scale_layout(layer: torch.nn.Module) -> BlockScaleLayout:
+    """Return the layout of ``layer``'s block weight scale.
+
+    Defaults to :attr:`BlockScaleLayout.NK` (checkpoint layout) when no layout
+    has been recorded, so layers and backends that never transpose the scale
+    require no changes.
+    """
+    return getattr(layer, WEIGHT_SCALE_LAYOUT_ATTR, BlockScaleLayout.NK)
+
+
+def is_weight_scale_transposed(layer: torch.nn.Module) -> bool:
+    """Return ``True`` if ``layer``'s block weight scale is in ``KN`` layout."""
+    return get_weight_scale_layout(layer) == BlockScaleLayout.KN
 
 
 def is_fp8(x: torch.dtype | torch.Tensor) -> bool:

--- a/vllm/model_executor/layers/quantization/utils/quant_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/quant_utils.py
@@ -440,6 +440,17 @@ def get_and_maybe_dequant_weights(
         weight_scales = get_attribute_fallback(
             layer, ["weight_scale", "weight_scale_inv"]
         )
+        # Some backends (e.g. XPU oneDNN) transpose the block weight scale from
+        # checkpoint layout [N/block_n, K/block_k] to [K/block_k, N/block_n] in
+        # `process_weights_after_loading`. `scaled_dequantize` expects the
+        # checkpoint layout, so transpose it back when the layer is tagged.
+        if layer.quant_method.block_quant:
+            from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+                is_weight_scale_transposed,
+            )
+
+            if is_weight_scale_transposed(layer):
+                weight_scales = weight_scales.t()
         dequant_weights = scaled_dequantize(
             weight,
             weight_scales,


### PR DESCRIPTION
## Purpose

On XPU, `XPUFp8BlockScaledMMKernel.process_weights_after_loading` transposes a block-FP8 linear layer's weight scale **in place** from the checkpoint layout `[N/128, K/128]` to the oneDNN `fp8_gemm` layout `[K/128, N/128]`. After that, any other code path that reads `weight_scale_inv` / `weight_scale` and assumes the checkpoint layout silently gets the wrong tensor.

The concrete victim is `get_and_maybe_dequant_weights` (used by MLA `process_weights_after_loading` to dequantize `kv_b_proj`): it feeds the scale to `scaled_dequantize`, which requires checkpoint layout. For non-square weights this trips the shape asserts; for square weights it silently produces numerically wrong dequantized weights.

There was previously **no way** for a consumer to tell whether a layer's scale had already been transposed.

## Changes

- **`fp8_utils.py`**: add a tiny layout-tag interface:
  - `BlockScaleLayout(str, Enum)` with `NK` (checkpoint `[N/block_n, K/block_k]`) and `KN` (transposed `[K/block_k, N/block_n]`).
  - `set_weight_scale_layout(layer, layout)`, `get_weight_scale_layout(layer)` (defaults to `NK`), and `is_weight_scale_transposed(layer)`.
- **`scaled_mm/xpu.py`**: `XPUFp8BlockScaledMMKernel` stamps `BlockScaleLayout.KN` right after transposing the scale.
- **`quant_utils.py`**: `get_and_maybe_dequant_weights` transposes the scale back to `NK` when `is_weight_scale_transposed(layer)` is true, before calling `scaled_dequantize`.

`get_weight_scale_layout` defaults to `NK`, so all existing layers and non-XPU backends are unaffected (no behavior change off the XPU block-FP8 path).

## Test Plan

- New interface unit-checked: fresh module reports `NK` / `is_weight_scale_transposed is False`; after `set_weight_scale_layout(..., KN)` reports `KN` / `True`; setter accepts the raw string form too.
- Numerical equivalence: dequantizing with a `KN` scale transposed back to `NK` reproduces the `NK` reference bit-for-bit (`torch.equal`).

## Test Result

Both checks pass; `pre-commit` (ruff, typos, mypy, SPDX, etc.) is green on the changed files.
