### PR TITLE
trtllm fp8 moe sm100 compatibility

### DIFF
--- a/tests/kernels/moe/test_flashinfer.py
+++ b/tests/kernels/moe/test_flashinfer.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from dataclasses import dataclass
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -22,6 +23,7 @@ from vllm.model_executor.layers.fused_moe.experts.flashinfer_cutlass_moe import 
     FlashInferExperts,
 )
 from vllm.model_executor.layers.fused_moe.experts.trtllm_fp8_moe import (
+    TrtLlmFp8ExpertsModular,
     TrtLlmFp8ExpertsMonolithic,
 )
 from vllm.model_executor.layers.fused_moe.fused_moe import fused_experts
@@ -422,3 +424,103 @@ def test_convert_moe_weights_to_flashinfer_trtllm_block_layout(
 
     assert w13_converted.shape[0] == num_experts
     assert w2_converted.shape[0] == num_experts
+
+
+@pytest.mark.parametrize("block_shape,is_mxfp8", [([1, 32], True), ([128, 128], False)])
+def test_trtllm_fp8_moe_forwards_swiglu_params_only_for_mxfp8(
+    block_shape, is_mxfp8, monkeypatch
+):
+    """gemm1_alpha/beta/clamp_limit are MXFP8 + SwiGLU per-expert params.
+
+    They must reach flashinfer only on the MXFP8 path: newer flashinfer rejects
+    them on the DeepSeekFp8 path. Verified for both the modular (pre-routed)
+    and monolithic block-scale entry points by capturing the forwarded kwargs.
+    """
+    import flashinfer
+
+    e, m, k, intermediate, topk = 4, 8, 128, 16, 2
+
+    def make_quant_config():
+        gemm1 = 1.0 if is_mxfp8 else None
+        return SimpleNamespace(
+            block_shape=block_shape,
+            is_per_tensor=False,
+            w1_scale=torch.ones(e, device="cuda"),
+            w2_scale=torch.ones(e, device="cuda"),
+            gemm1_alpha=gemm1,
+            gemm1_beta=gemm1,
+            gemm1_clamp_limit=gemm1,
+        )
+
+    def make_moe_config():
+        return SimpleNamespace(
+            routing_method=None,
+            experts_per_token=topk,
+            intermediate_size_per_partition=intermediate,
+            hidden_dim=k,
+            num_local_experts=e,
+            max_num_tokens=128,
+            dp_size=1,
+            is_act_and_mul=True,
+            moe_parallel_config=SimpleNamespace(ep_rank=0),
+        )
+
+    captured: dict = {}
+
+    def capture(**kwargs):
+        captured.update(kwargs)
+        return torch.zeros(1)
+
+    swiglu_keys = ("gemm1_alpha", "gemm1_beta", "gemm1_clamp_limit")
+    expected = list(swiglu_keys) if is_mxfp8 else []
+    a1q_scale = torch.ones(k // 128, m, device="cuda")
+    w1 = torch.zeros(e, 2 * intermediate, k, dtype=torch.float8_e4m3fn, device="cuda")
+    w2 = torch.zeros(e, k, intermediate, dtype=torch.float8_e4m3fn, device="cuda")
+
+    # Modular (pre-routed) path.
+    captured.clear()
+    monkeypatch.setattr(
+        flashinfer.fused_moe, "trtllm_fp8_block_scale_routed_moe", capture
+    )
+    TrtLlmFp8ExpertsModular(make_moe_config(), make_quant_config()).apply(
+        output=torch.zeros(m, k, device="cuda"),
+        hidden_states=torch.randn(m, k, device="cuda"),
+        w1=w1,
+        w2=w2,
+        topk_weights=torch.zeros(m, topk, device="cuda"),
+        topk_ids=torch.zeros(m, topk, dtype=torch.int32, device="cuda"),
+        activation=MoEActivation.SILU,
+        global_num_experts=e,
+        expert_map=None,
+        a1q_scale=a1q_scale,
+        a2_scale=None,
+        workspace13=None,
+        workspace2=None,
+        expert_tokens_meta=None,
+        apply_router_weight_on_input=False,
+    )
+    forwarded = [key for key in swiglu_keys if key in captured]
+    assert forwarded == expected, (
+        f"modular path: expected {expected} gemm1 kwargs, got {forwarded}"
+    )
+
+    # Monolithic block-scale path.
+    captured.clear()
+    monkeypatch.setattr(flashinfer.fused_moe, "trtllm_fp8_block_scale_moe", capture)
+    TrtLlmFp8ExpertsMonolithic(
+        make_moe_config(), make_quant_config()
+    )._apply_block_scale(
+        hidden_states=torch.randn(m, k, device="cuda"),
+        w1=w1,
+        w2=w2,
+        router_logits=torch.randn(m, e, device="cuda"),
+        activation=MoEActivation.SILU,
+        global_num_experts=e,
+        expert_map=None,
+        a1q_scale=a1q_scale,
+        apply_router_weight_on_input=False,
+    )
+    forwarded = [key for key in swiglu_keys if key in captured]
+    assert forwarded == expected, (
+        f"monolithic path: expected {expected} gemm1 kwargs, got {forwarded}"
+    )

--- a/tests/kernels/moe/test_flashinfer.py
+++ b/tests/kernels/moe/test_flashinfer.py
@@ -45,6 +45,19 @@ except ImportError:
             "flashinfer not supported for vLLM on ROCm", allow_module_level=True
         )
 
+try:
+    from vllm.utils.flashinfer import has_flashinfer_trtllm_fused_moe
+except ImportError:
+    has_flashinfer_trtllm_fused_moe = lambda: False
+
+requires_trtllm_fp8_moe = pytest.mark.skipif(
+    not current_platform.is_cuda()
+    or not current_platform.has_device_capability(100)
+    or not has_flashinfer_trtllm_fused_moe(),
+    reason="trtllm fp8 moe experts require CUDA, sm100 (Blackwell), and a "
+    "flashinfer build with the trtllm fused moe kernels",
+)
+
 if not has_flashinfer_cutlass_fused_moe() or not current_platform.has_device_capability(
     90
 ):
@@ -426,30 +439,41 @@ def test_convert_moe_weights_to_flashinfer_trtllm_block_layout(
     assert w2_converted.shape[0] == num_experts
 
 
+@requires_trtllm_fp8_moe
 @pytest.mark.parametrize("block_shape,is_mxfp8", [([1, 32], True), ([128, 128], False)])
-def test_trtllm_fp8_moe_forwards_swiglu_params_only_for_mxfp8(
+def test_trtllm_fp8_moe_gemm1_swiglu_params_only_forwarded_for_mxfp8(
     block_shape, is_mxfp8, monkeypatch
 ):
-    """gemm1_alpha/beta/clamp_limit are MXFP8 + SwiGLU per-expert params.
+    """gemm1_alpha/beta/clamp_limit must reach flashinfer only on the MXFP8 path.
 
-    They must reach flashinfer only on the MXFP8 path: newer flashinfer rejects
-    them on the DeepSeekFp8 path. Verified for both the modular (pre-routed)
-    and monolithic block-scale entry points by capturing the forwarded kwargs.
+    These are MXFP8 + SwiGLU per-expert parameters. flashinfer 0.6.15+ rejects
+    them on the DeepSeekFp8 path (``Fp8QuantizationType != MxFp8``) via
+    ``_validate_fp8_block_scale_gemm1_activation_params``. A SwiGLU-OAI model
+    sets them (``layer.swiglu_alpha`` -> ``gemm1_alpha`` in fp8.py) even while
+    running the DeepSeekFp8 block-scale path, so vLLM must drop them there.
+
+    This is a forwarding-invariant check: the flashinfer entry points are
+    replaced with a capture stub, so no kernel runs and the result is stable
+    across flashinfer versions. gemm1_alpha/beta/clamp_limit are kept non-None
+    on *both* paths -- the DeepSeekFp8 case only exercises the fix when they
+    are present, since flashinfer short-circuits when all three are None.
     """
     import flashinfer
 
     e, m, k, intermediate, topk = 4, 8, 128, 16, 2
+    swiglu_keys = ("gemm1_alpha", "gemm1_beta", "gemm1_clamp_limit")
+    expected = list(swiglu_keys) if is_mxfp8 else []
 
     def make_quant_config():
-        gemm1 = 1.0 if is_mxfp8 else None
+        # Non-None on both paths: the DeepSeekFp8 case is the real trigger.
         return SimpleNamespace(
             block_shape=block_shape,
             is_per_tensor=False,
             w1_scale=torch.ones(e, device="cuda"),
             w2_scale=torch.ones(e, device="cuda"),
-            gemm1_alpha=gemm1,
-            gemm1_beta=gemm1,
-            gemm1_clamp_limit=gemm1,
+            gemm1_alpha=1.0,
+            gemm1_beta=1.0,
+            gemm1_clamp_limit=10.0,
         )
 
     def make_moe_config():
@@ -471,8 +495,6 @@ def test_trtllm_fp8_moe_forwards_swiglu_params_only_for_mxfp8(
         captured.update(kwargs)
         return torch.zeros(1)
 
-    swiglu_keys = ("gemm1_alpha", "gemm1_beta", "gemm1_clamp_limit")
-    expected = list(swiglu_keys) if is_mxfp8 else []
     a1q_scale = torch.ones(k // 128, m, device="cuda")
     w1 = torch.zeros(e, 2 * intermediate, k, dtype=torch.float8_e4m3fn, device="cuda")
     w2 = torch.zeros(e, k, intermediate, dtype=torch.float8_e4m3fn, device="cuda")

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
@@ -231,16 +231,16 @@ class TrtLlmFp8ExpertsModular(TrtLlmFp8ExpertsBase, mk.FusedMoEExpertsModular):
             weight_layout = WeightLayout.BlockMajorK
             hidden_states_scale = a1q_scale.t().contiguous()
 
-        flashinfer.fused_moe.trtllm_fp8_block_scale_routed_moe(
+        # gemm1_alpha/beta/clamp_limit are MXFP8 + SwiGLU per-expert params;
+        # only forward them in the MXFP8 path (newer flashinfer rejects them on
+        # the DeepSeekFp8 path).
+        kwargs = dict(
             topk_ids=packed_topk_ids,
             routing_bias=None,
             hidden_states=hidden_states,
             hidden_states_scale=hidden_states_scale,
             gemm1_weights=w1,
             gemm1_weights_scale=self.quant_config.w1_scale,
-            gemm1_alpha=self.gemm1_alpha,
-            gemm1_beta=self.gemm1_beta,
-            gemm1_clamp_limit=self.gemm1_clamp_limit,
             gemm2_weights=w2,
             gemm2_weights_scale=self.quant_config.w2_scale,
             num_experts=global_num_experts,
@@ -258,6 +258,11 @@ class TrtLlmFp8ExpertsModular(TrtLlmFp8ExpertsBase, mk.FusedMoEExpertsModular):
             output=output,
             tune_max_num_tokens=fi_moe_largest_bucket(self.moe_config),
         )
+        if is_mxfp8:
+            kwargs["gemm1_alpha"] = self.gemm1_alpha
+            kwargs["gemm1_beta"] = self.gemm1_beta
+            kwargs["gemm1_clamp_limit"] = self.gemm1_clamp_limit
+        flashinfer.fused_moe.trtllm_fp8_block_scale_routed_moe(**kwargs)
 
 
 class TrtLlmFp8ExpertsMonolithic(TrtLlmFp8ExpertsBase, mk.FusedMoEExpertsMonolithic):
@@ -418,9 +423,6 @@ class TrtLlmFp8ExpertsMonolithic(TrtLlmFp8ExpertsBase, mk.FusedMoEExpertsMonolit
             hidden_states_scale=hidden_states_scale,
             gemm1_weights=w1,
             gemm1_weights_scale=self.quant_config.w1_scale,
-            gemm1_alpha=self.gemm1_alpha,
-            gemm1_beta=self.gemm1_beta,
-            gemm1_clamp_limit=self.gemm1_clamp_limit,
             gemm2_weights=w2,
             gemm2_weights_scale=self.quant_config.w2_scale,
             num_experts=global_num_experts,
@@ -438,6 +440,13 @@ class TrtLlmFp8ExpertsMonolithic(TrtLlmFp8ExpertsBase, mk.FusedMoEExpertsMonolit
             routing_replay_out=routing_replay_out,
             tune_max_num_tokens=fi_moe_largest_bucket(self.moe_config),
         )
+        # gemm1_alpha/beta/clamp_limit are MXFP8 + SwiGLU per-expert params;
+        # only forward them in the MXFP8 path (newer flashinfer rejects them on
+        # the DeepSeekFp8 path).
+        if is_mxfp8:
+            kwargs["gemm1_alpha"] = self.gemm1_alpha
+            kwargs["gemm1_beta"] = self.gemm1_beta
+            kwargs["gemm1_clamp_limit"] = self.gemm1_clamp_limit
         if is_mxfp8 or activation == MoEActivation.RELU2_NO_MUL:
             kwargs["activation_type"] = activation_type
         result = flashinfer.fused_moe.trtllm_fp8_block_scale_moe(**kwargs)


### PR DESCRIPTION
## Purpose
for flashinfer >= 0.6.14 compatibility

`_validate_fp8_block_scale_gemm1_activation_params` funciton requires `fp8_quantization_type == MxFp8` and `ActivationType.Swiglu`
introduced by this [PR](https://github.com/flashinfer-ai/flashinfer/pull/3504)
and went public in [releases 0.6.14](https://github.com/flashinfer-ai/flashinfer/releases?q=3504&expanded=true#:~:text=Add%20MXFP8%20MoE%20SwiGLU%20OA%20parameters%20by%20%40ruoqianguo%20in%20%233504)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

