### PR TITLE
[CI] Allow PR comment acknowledgements

### DIFF
--- a/.github/workflows/run-ci-command.yml
+++ b/.github/workflows/run-ci-command.yml
@@ -11,7 +11,7 @@ concurrency:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   run-ci-command:


### PR DESCRIPTION
## Summary

Grant the comment-trigger workflow explicit `pull-requests: write` permission so it can acknowledge commands and add reactions on pull request conversations.

## Root cause

The live `/ci run` test successfully created and completed Buildkite build #80923, but the workflow failed when it tried to add the acknowledgement comment:

```
ApiError: API returned 403: Resource not accessible by integration
```

The eyes, rocket, and fallback confused reactions failed with the same response. The workflow currently grants `issues: write` but only `pull-requests: read`. GitHub's issue-comment API supports regular PR timeline comments with either Issues write or Pull requests write; this change explicitly grants the PR-side permission for these PR-scoped interactions.

Failed acknowledgement run: https://github.com/vllm-project/vllm/actions/runs/30417187108  
Successful Buildkite trigger: https://buildkite.com/vllm/ci/builds/80923  
GitHub API permission reference: https://docs.github.com/en/rest/issues/comments#create-an-issue-comment

## Duplicate-work check

Searched open PRs for the comment-trigger workflow, GitHubClient acknowledgements, reactions, and PR write permissions. No open PR addresses this failure.

## Tests

```bash
pre-commit run --files .github/workflows/run-ci-command.yml
```

Result: all applicable hooks passed, including actionlint and the sign-off check during commit.

No model evaluation is required because this only changes GitHub Actions permissions.

## Residual validation

The definitive validation is a fresh `/ci run` after merge, because `issue_comment` workflows execute the workflow from the default branch.

## AI assistance

OpenAI Codex assisted with the live failure diagnosis, implementation, validation, and PR preparation. The human submitter must review the permission change and validate the acknowledgement after merge.