### PR TITLE
[Doc]: Update Quickstart documentation with Apple Silicon / Metal execution

### DIFF
--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -142,7 +142,7 @@ sampling_params = SamplingParams(temperature=0.8, top_p=0.95)
 The [LLM][vllm.LLM] class initializes vLLM's engine and the [OPT-125M model](https://arxiv.org/abs/2205.01068) for offline inference. The list of supported models can be found [here](../models/supported_models.md).
 
 ```python
-llm = LLM(model="facebook/opt-125m")
+llm = LLM(model="Qwen/Qwen2.5-0.5B")
 ```
 
 !!! note


### PR DESCRIPTION
This PR fixes the documentation issue reported in #50165: corrects `llm = LLM(model="facebook/opt-125m")` to `llm = LLM(model="Qwen/Qwen2.5-0.5B")` in `docs/getting_started/quickstart.md`.

Fixes #50165



## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

