### PR TITLE
[Bugfix][Quantization] Fix fused AutoGPTQ overrides and mixed-group MoE loading

### DIFF
--- a/tests/quantization/test_auto_gptq.py
+++ b/tests/quantization/test_auto_gptq.py
@@ -16,6 +16,7 @@ from vllm.model_executor.layers.quantization.auto_gptq import (
     AutoGPTQConfig,
     AutoGPTQLinearMethod,
     AutoGPTQMoEMethod,
+    _resolve_moe_quant_config,
 )
 
 PROMPT = "On the surface of Mars, we found"
@@ -58,6 +59,151 @@ def test_auto_gptq_quantization_method(vllm_runner, model_id: str, monkeypatch):
 def test_auto_gptq_config_get_name():
     """Test that AutoGPTQConfig.get_name() returns 'auto_gptq'."""
     assert AutoGPTQConfig.get_name() == "auto_gptq"
+
+
+def _make_auto_gptq_config(
+    dynamic: dict[str, dict[str, int | bool]],
+    *,
+    group_size: int = 128,
+    desc_act: bool = False,
+) -> AutoGPTQConfig:
+    full_config = {
+        "bits": 4,
+        "group_size": group_size,
+        "desc_act": desc_act,
+        "sym": True,
+        "quant_method": "gptq",
+        "dynamic": dynamic,
+    }
+    return AutoGPTQConfig(
+        4,
+        group_size,
+        desc_act,
+        True,
+        False,
+        dynamic,
+        full_config,
+    )
+
+
+def _make_routed_experts_stub(num_experts: int = 3) -> SimpleNamespace:
+    return SimpleNamespace(
+        ckpt_gate_proj_name="gate_proj",
+        ckpt_down_proj_name="down_proj",
+        ckpt_up_proj_name="up_proj",
+        moe_config=SimpleNamespace(num_logical_experts=num_experts),
+        expert_map_manager=SimpleNamespace(num_fused_shared_experts=0),
+    )
+
+
+def test_auto_gptq_moe_resolves_mixed_expert_group_sizes():
+    prefix = "model.layers.0.mlp.experts"
+    escaped_prefix = prefix.replace(".", r"\.")
+    dynamic = {
+        rf"+:^{escaped_prefix}\.1\..*_proj$": {
+            "bits": 4,
+            "group_size": 32,
+        },
+        rf"+:^{escaped_prefix}\.2\.down_proj$": {
+            "bits": 4,
+            "group_size": 32,
+        },
+    }
+
+    resolved, source_group_sizes = _resolve_moe_quant_config(
+        _make_auto_gptq_config(dynamic),
+        _make_routed_experts_stub(),
+        prefix,
+    )
+
+    assert resolved is not None
+    assert resolved.group_size == 32
+    assert source_group_sizes[(0, "w1")] == 128
+    assert source_group_sizes[(1, "w1")] == 32
+    assert source_group_sizes[(2, "w1")] == 128
+    assert source_group_sizes[(2, "w2")] == 32
+
+
+def test_auto_gptq_moe_normalizes_larger_group_metadata():
+    method = object.__new__(AutoGPTQMoEMethod)
+    method.quant_config = _make_auto_gptq_config({}, group_size=32)
+    method.source_group_sizes = {(0, "w1"): 128}
+    loaded: dict[str, torch.Tensor] = {}
+
+    def weight_loader(
+        param,
+        loaded_weight,
+        weight_name,
+        shard_id,
+        expert_id,
+        return_success=False,
+    ):
+        loaded[weight_name] = loaded_weight
+        return return_success
+
+    wrapped_loader = method.get_weight_loader(weight_loader)
+    param = torch.nn.Parameter(torch.empty(0), requires_grad=False)
+
+    scales = torch.arange(6, dtype=torch.float16).reshape(2, 3)
+    assert wrapped_loader(
+        param, scales, "experts.w13_scales", "w1", 0, return_success=True
+    )
+    assert torch.equal(
+        loaded["experts.w13_scales"],
+        scales.repeat_interleave(4, dim=0),
+    )
+
+    qzeros = torch.arange(4, dtype=torch.int32).reshape(2, 2)
+    assert wrapped_loader(
+        param, qzeros, "experts.w13_qzeros", "w1", 0, return_success=True
+    )
+    assert torch.equal(
+        loaded["experts.w13_qzeros"],
+        qzeros.repeat_interleave(4, dim=0),
+    )
+
+    g_idx = torch.arange(256, dtype=torch.int32) // 128
+    assert wrapped_loader(
+        param, g_idx, "experts.w13_g_idx", "w1", 0, return_success=True
+    )
+    assert torch.equal(
+        loaded["experts.w13_g_idx"],
+        torch.arange(256, dtype=torch.int32) // 32,
+    )
+
+
+def test_auto_gptq_moe_rejects_mixed_groups_with_desc_act():
+    prefix = "model.layers.0.mlp.experts"
+    escaped_prefix = prefix.replace(".", r"\.")
+    dynamic = {
+        rf"+:^{escaped_prefix}\.1\..*_proj$": {
+            "group_size": 32,
+        }
+    }
+
+    with pytest.raises(ValueError, match="desc_act=True"):
+        _resolve_moe_quant_config(
+            _make_auto_gptq_config(dynamic, desc_act=True),
+            _make_routed_experts_stub(num_experts=2),
+            prefix,
+        )
+
+
+def test_auto_gptq_moe_rejects_incompatible_group_sizes():
+    prefix = "model.layers.0.mlp.experts"
+    escaped_prefix = prefix.replace(".", r"\.")
+    dynamic = {
+        rf"+:^{escaped_prefix}\.1\..*_proj$": {
+            "group_size": 96,
+        }
+    }
+
+    with pytest.raises(ValueError, match="incompatible group sizes"):
+        _resolve_moe_quant_config(
+            _make_auto_gptq_config(dynamic),
+            _make_routed_experts_stub(num_experts=2),
+            prefix,
+        )
 
 
 def test_auto_gptq_moe_creates_zero_initialized_expert_biases():

--- a/tests/quantization/test_auto_gptq.py
+++ b/tests/quantization/test_auto_gptq.py
@@ -25,6 +25,9 @@ MODELS = [
     "TheBloke/TinyLlama-1.1B-Chat-v1.0-GPTQ",
 ]
 
+_MOE_PREFIX = "model.layers.0.mlp.experts"
+_ESCAPED_MOE_PREFIX = _MOE_PREFIX.replace(".", r"\.")
+
 
 @pytest.mark.skipif(
     not is_quant_method_supported("auto_gptq"),
@@ -75,15 +78,7 @@ def _make_auto_gptq_config(
         "quant_method": "gptq",
         "dynamic": dynamic,
     }
-    return AutoGPTQConfig(
-        4,
-        group_size,
-        desc_act,
-        True,
-        False,
-        dynamic,
-        full_config,
-    )
+    return AutoGPTQConfig.from_config(full_config)
 
 
 def _make_routed_experts_stub(num_experts: int = 3) -> SimpleNamespace:
@@ -96,35 +91,38 @@ def _make_routed_experts_stub(num_experts: int = 3) -> SimpleNamespace:
     )
 
 
-def test_auto_gptq_moe_resolves_mixed_expert_group_sizes():
-    prefix = "model.layers.0.mlp.experts"
-    escaped_prefix = prefix.replace(".", r"\.")
+def test_auto_gptq_moe_resolves_mixed_expert_group_sizes() -> None:
+    """Choose the smallest compatible group while retaining source metadata."""
     dynamic = {
-        rf"+:^{escaped_prefix}\.1\..*_proj$": {
+        rf"+:^{_ESCAPED_MOE_PREFIX}\.1\..*_proj$": {
             "bits": 4,
             "group_size": 32,
         },
-        rf"+:^{escaped_prefix}\.2\.down_proj$": {
+        rf"+:^{_ESCAPED_MOE_PREFIX}\.2\.down_proj$": {
             "bits": 4,
             "group_size": 32,
         },
     }
 
+    config = _make_auto_gptq_config(dynamic)
     resolved, source_group_sizes = _resolve_moe_quant_config(
-        _make_auto_gptq_config(dynamic),
+        config,
         _make_routed_experts_stub(),
-        prefix,
+        _MOE_PREFIX,
     )
 
     assert resolved is not None
     assert resolved.group_size == 32
+    assert resolved.full_config["group_size"] == 32
+    assert config.full_config["group_size"] == 128
     assert source_group_sizes[(0, "w1")] == 128
     assert source_group_sizes[(1, "w1")] == 32
     assert source_group_sizes[(2, "w1")] == 128
     assert source_group_sizes[(2, "w2")] == 32
 
 
-def test_auto_gptq_moe_normalizes_larger_group_metadata():
+def test_auto_gptq_moe_normalizes_larger_group_metadata() -> None:
+    """Expand scales, zero points, and sequential group indices losslessly."""
     method = object.__new__(AutoGPTQMoEMethod)
     method.quant_config = _make_auto_gptq_config({}, group_size=32)
     method.source_group_sizes = {(0, "w1"): 128}
@@ -172,11 +170,25 @@ def test_auto_gptq_moe_normalizes_larger_group_metadata():
     )
 
 
-def test_auto_gptq_moe_rejects_mixed_groups_with_desc_act():
-    prefix = "model.layers.0.mlp.experts"
-    escaped_prefix = prefix.replace(".", r"\.")
+def test_auto_gptq_moe_rejects_non_sequential_group_indices() -> None:
+    """Only the standard non-act-order g_idx layout can be normalized."""
+    method = object.__new__(AutoGPTQMoEMethod)
+    method.quant_config = _make_auto_gptq_config({}, group_size=32)
+    method.source_group_sizes = {(0, "w1"): 128}
+
+    with pytest.raises(ValueError, match="non-sequential g_idx"):
+        method._normalize_group_metadata(
+            torch.zeros(256, dtype=torch.int32),
+            "experts.w13_g_idx",
+            "w1",
+            0,
+        )
+
+
+def test_auto_gptq_moe_rejects_mixed_groups_with_desc_act() -> None:
+    """Activation-order metadata cannot be expanded losslessly."""
     dynamic = {
-        rf"+:^{escaped_prefix}\.1\..*_proj$": {
+        rf"+:^{_ESCAPED_MOE_PREFIX}\.1\..*_proj$": {
             "group_size": 32,
         }
     }
@@ -185,15 +197,28 @@ def test_auto_gptq_moe_rejects_mixed_groups_with_desc_act():
         _resolve_moe_quant_config(
             _make_auto_gptq_config(dynamic, desc_act=True),
             _make_routed_experts_stub(num_experts=2),
-            prefix,
+            _MOE_PREFIX,
         )
 
 
-def test_auto_gptq_moe_rejects_incompatible_group_sizes():
-    prefix = "model.layers.0.mlp.experts"
-    escaped_prefix = prefix.replace(".", r"\.")
+def test_auto_gptq_moe_rejects_partially_unquantized_shards() -> None:
+    """A fused MoE layer cannot mix quantized and unquantized shards."""
     dynamic = {
-        rf"+:^{escaped_prefix}\.1\..*_proj$": {
+        rf"-:^{_ESCAPED_MOE_PREFIX}\.1\.down_proj$": {},
+    }
+
+    with pytest.raises(ValueError, match="excludes only some expert shards"):
+        _resolve_moe_quant_config(
+            _make_auto_gptq_config(dynamic),
+            _make_routed_experts_stub(num_experts=2),
+            _MOE_PREFIX,
+        )
+
+
+def test_auto_gptq_moe_rejects_incompatible_group_sizes() -> None:
+    """Only divisible group sizes have a lossless common representation."""
+    dynamic = {
+        rf"+:^{_ESCAPED_MOE_PREFIX}\.1\..*_proj$": {
             "group_size": 96,
         }
     }
@@ -202,7 +227,7 @@ def test_auto_gptq_moe_rejects_incompatible_group_sizes():
         _resolve_moe_quant_config(
             _make_auto_gptq_config(dynamic),
             _make_routed_experts_stub(num_experts=2),
-            prefix,
+            _MOE_PREFIX,
         )
 
 

--- a/tests/quantization/test_gptq_dynamic.py
+++ b/tests/quantization/test_gptq_dynamic.py
@@ -7,16 +7,19 @@ Run `pytest tests/quantization/test_gptq_dynamic.py --forked`.
 Note: Only symmetric GPTQ models are supported after consolidation to Marlin.
 """
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
-from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
 from vllm.model_executor.layers.quantization.auto_gptq import (
     AutoGPTQConfig,
     AutoGPTQLinearMethod,
 )
 from vllm.model_executor.layers.quantization.utils.gptq_utils import (
     get_dynamic_override,
+    get_linear_quant_method,
 )
 
 PROMPT = "On the surface of Mars, we found"
@@ -39,7 +42,24 @@ def _make_dynamic_config(
     return config
 
 
-def test_dynamic_override_resolves_fused_qkv_shards():
+@pytest.mark.parametrize(
+    "packed_modules_mapping",
+    [
+        {"qkv_proj": ["q_proj", "k_proj", "v_proj"]},
+        {
+            "self_attn.qkv_proj": [
+                "self_attn.q_proj",
+                "self_attn.k_proj",
+                "self_attn.v_proj",
+            ]
+        },
+    ],
+    ids=["module-name", "dotted-module-name"],
+)
+def test_dynamic_override_resolves_fused_qkv_shards(
+    packed_modules_mapping: dict[str, list[str]],
+) -> None:
+    """Resolve unfused checkpoint rules for either fused mapping format."""
     dynamic = {
         rf"+:^model\.layers\.0\.self_attn\.{projection}$": {
             "bits": 4,
@@ -47,10 +67,8 @@ def test_dynamic_override_resolves_fused_qkv_shards():
         }
         for projection in ("q_proj", "k_proj", "v_proj")
     }
-    config = _make_dynamic_config(
-        dynamic,
-        {"qkv_proj": ["q_proj", "k_proj", "v_proj"]},
-    )
+    dynamic[r"+:^model\.layers\.0\.self_attn\.notq_proj$"] = {"group_size": 64}
+    config = _make_dynamic_config(dynamic, packed_modules_mapping)
 
     assert (
         get_dynamic_override(
@@ -70,36 +88,53 @@ def test_dynamic_override_resolves_fused_qkv_shards():
         )
         == 128
     )
+    assert (
+        get_dynamic_override(
+            config,
+            "model.layers.0.self_attn.notqkv_proj",
+            "group_size",
+            config.group_size,
+        )
+        == 128
+    )
 
 
-def test_dynamic_override_resolves_dotted_fused_mapping():
+def test_dynamic_override_skips_fused_layer_when_all_shards_are_excluded() -> None:
+    """A fused layer is skipped when every checkpoint shard is excluded."""
     dynamic = {
-        rf"+:^model\.layers\.0\.self_attn\.{projection}$": {"group_size": 32}
+        rf"-:^model\.layers\.0\.self_attn\.{projection}$": {}
         for projection in ("q_proj", "k_proj", "v_proj")
     }
     config = _make_dynamic_config(
         dynamic,
-        {
-            "self_attn.qkv_proj": [
-                "self_attn.q_proj",
-                "self_attn.k_proj",
-                "self_attn.v_proj",
-            ]
-        },
+        {"qkv_proj": ["q_proj", "k_proj", "v_proj"]},
     )
 
     assert (
         get_dynamic_override(
             config,
             "model.layers.0.self_attn.qkv_proj",
-            "group_size",
-            config.group_size,
         )
-        == 32
+        is False
     )
 
 
-def test_dynamic_override_rejects_mixed_fused_shards():
+def test_dynamic_override_rejects_partially_excluded_fused_layer() -> None:
+    """A fused layer cannot contain both skipped and quantized shards."""
+    config = _make_dynamic_config(
+        {r"-:^model\.layers\.0\.self_attn\.q_proj$": {}},
+        {"qkv_proj": ["q_proj", "k_proj", "v_proj"]},
+    )
+
+    with pytest.raises(ValueError, match="does not match across shards"):
+        get_dynamic_override(
+            config,
+            "model.layers.0.self_attn.qkv_proj",
+        )
+
+
+def test_dynamic_override_rejects_mixed_fused_shards() -> None:
+    """Reject fused shards whose effective settings differ."""
     config = _make_dynamic_config(
         {r"+:^model\.layers\.0\.self_attn\.q_proj$": {"group_size": 32}},
         {"qkv_proj": ["q_proj", "k_proj", "v_proj"]},
@@ -133,7 +168,8 @@ def test_dynamic_override_rejects_mixed_fused_shards():
         ),
     ],
 )
-def test_dynamic_override_preserves_first_match_order(dynamic, expected):
+def test_dynamic_override_preserves_first_match_order(dynamic, expected) -> None:
+    """The exact-rule index must retain dict insertion order semantics."""
     config = _make_dynamic_config(dynamic, {})
 
     assert (
@@ -145,6 +181,27 @@ def test_dynamic_override_preserves_first_match_order(dynamic, expected):
         )
         == expected
     )
+
+
+def test_linear_dynamic_override_does_not_mutate_base_config() -> None:
+    """Per-layer overrides must leave the shared model config unchanged."""
+    config = _make_dynamic_config(
+        {r"+:^model\.layers\.0\.q_proj$": {"group_size": 32}},
+        {},
+    )
+    config.modules_in_block_to_quantize = ["q_proj"]
+    layer = object.__new__(LinearBase)
+
+    method = get_linear_quant_method(
+        config,
+        layer,
+        "model.layers.0.q_proj",
+        lambda quant_config: SimpleNamespace(quant_config=quant_config),
+    )
+
+    assert method.quant_config.group_size == 32
+    assert method.quant_config.full_config is not config.full_config
+    assert config.group_size == 128
 
 
 @pytest.mark.parametrize("model_id", MODELS)

--- a/tests/quantization/test_gptq_dynamic.py
+++ b/tests/quantization/test_gptq_dynamic.py
@@ -11,7 +11,10 @@ import pytest
 import torch
 
 from vllm.model_executor.layers.linear import UnquantizedLinearMethod
-from vllm.model_executor.layers.quantization.auto_gptq import AutoGPTQLinearMethod
+from vllm.model_executor.layers.quantization.auto_gptq import (
+    AutoGPTQConfig,
+    AutoGPTQLinearMethod,
+)
 from vllm.model_executor.layers.quantization.utils.gptq_utils import (
     get_dynamic_override,
 )
@@ -25,6 +28,123 @@ PROMPT = "On the surface of Mars, we found"
 MODELS = [
     "ModelCloud/Qwen1.5-1.8B-Chat-GPTQ-4bits-dynamic-cfg-with-lm_head-symTrue",
 ]
+
+
+def _make_dynamic_config(
+    dynamic: dict[str, dict[str, int | bool]],
+    packed_modules_mapping: dict[str, list[str]],
+) -> AutoGPTQConfig:
+    config = AutoGPTQConfig(4, 128, False, True, False, dynamic, {})
+    config.packed_modules_mapping = packed_modules_mapping
+    return config
+
+
+def test_dynamic_override_resolves_fused_qkv_shards():
+    dynamic = {
+        rf"+:^model\.layers\.0\.self_attn\.{projection}$": {
+            "bits": 4,
+            "group_size": 32,
+        }
+        for projection in ("q_proj", "k_proj", "v_proj")
+    }
+    config = _make_dynamic_config(
+        dynamic,
+        {"qkv_proj": ["q_proj", "k_proj", "v_proj"]},
+    )
+
+    assert (
+        get_dynamic_override(
+            config,
+            "model.layers.0.self_attn.qkv_proj",
+            "group_size",
+            config.group_size,
+        )
+        == 32
+    )
+    assert (
+        get_dynamic_override(
+            config,
+            "model.layers.1.self_attn.qkv_proj",
+            "group_size",
+            config.group_size,
+        )
+        == 128
+    )
+
+
+def test_dynamic_override_resolves_dotted_fused_mapping():
+    dynamic = {
+        rf"+:^model\.layers\.0\.self_attn\.{projection}$": {"group_size": 32}
+        for projection in ("q_proj", "k_proj", "v_proj")
+    }
+    config = _make_dynamic_config(
+        dynamic,
+        {
+            "self_attn.qkv_proj": [
+                "self_attn.q_proj",
+                "self_attn.k_proj",
+                "self_attn.v_proj",
+            ]
+        },
+    )
+
+    assert (
+        get_dynamic_override(
+            config,
+            "model.layers.0.self_attn.qkv_proj",
+            "group_size",
+            config.group_size,
+        )
+        == 32
+    )
+
+
+def test_dynamic_override_rejects_mixed_fused_shards():
+    config = _make_dynamic_config(
+        {r"+:^model\.layers\.0\.self_attn\.q_proj$": {"group_size": 32}},
+        {"qkv_proj": ["q_proj", "k_proj", "v_proj"]},
+    )
+
+    with pytest.raises(ValueError, match="does not match across shards"):
+        get_dynamic_override(
+            config,
+            "model.layers.0.self_attn.qkv_proj",
+            "group_size",
+            config.group_size,
+        )
+
+
+@pytest.mark.parametrize(
+    ("dynamic", "expected"),
+    [
+        (
+            {
+                r"+:^model\.layers\..*\.q_proj$": {"group_size": 64},
+                r"+:^model\.layers\.0\.q_proj$": {"group_size": 32},
+            },
+            64,
+        ),
+        (
+            {
+                r"+:^model\.layers\.0\.q_proj$": {"group_size": 32},
+                r"+:^model\.layers\..*\.q_proj$": {"group_size": 64},
+            },
+            32,
+        ),
+    ],
+)
+def test_dynamic_override_preserves_first_match_order(dynamic, expected):
+    config = _make_dynamic_config(dynamic, {})
+
+    assert (
+        get_dynamic_override(
+            config,
+            "model.layers.0.q_proj",
+            "group_size",
+            config.group_size,
+        )
+        == expected
+    )
 
 
 @pytest.mark.parametrize("model_id", MODELS)

--- a/vllm/model_executor/layers/quantization/auto_gptq.py
+++ b/vllm/model_executor/layers/quantization/auto_gptq.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from copy import deepcopy
+from dataclasses import dataclass
 from typing import Any
 
 import torch
@@ -40,7 +41,6 @@ from vllm.model_executor.layers.quantization.utils import replace_parameter
 from vllm.model_executor.layers.quantization.utils.gptq_utils import (
     get_dynamic_override,
     get_linear_quant_method,
-    override_config,
 )
 from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     check_moe_marlin_supports_layer,
@@ -51,6 +51,7 @@ from vllm.model_executor.layers.quantization.utils.marlin_utils import (
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
+    kInt4Static32GroupScale,
     kInt4StaticGroupScale,
     kInt8StaticGroupScale,
 )
@@ -68,30 +69,174 @@ from vllm.utils.collection_utils import is_list_of
 logger = init_logger(__name__)
 
 
-def get_moe_quant_method(
+@dataclass(frozen=True)
+class _GPTQQuantConfigValues:
+    weight_bits: int
+    group_size: int
+    desc_act: bool
+    is_sym: bool
+
+
+def _apply_dynamic_override(
+    values: _GPTQQuantConfigValues,
+    override: dict[str, int | bool] | None,
+) -> _GPTQQuantConfigValues:
+    if override is None:
+        return values
+    return _GPTQQuantConfigValues(
+        weight_bits=int(override.get("bits", values.weight_bits)),
+        group_size=int(override.get("group_size", values.group_size)),
+        desc_act=bool(override.get("desc_act", values.desc_act)),
+        is_sym=bool(override.get("sym", values.is_sym)),
+    )
+
+
+def _clone_quant_config(
+    config: "AutoGPTQConfig",
+    values: _GPTQQuantConfigValues,
+) -> "AutoGPTQConfig":
+    cloned_config = deepcopy(config)
+    cloned_config.weight_bits = values.weight_bits
+    cloned_config.group_size = values.group_size
+    cloned_config.desc_act = values.desc_act
+    cloned_config.is_sym = values.is_sym
+    cloned_config.pack_factor = 32 // values.weight_bits
+
+    if (values.weight_bits, values.is_sym) not in cloned_config.TYPE_MAP:
+        raise ValueError(
+            "Unsupported quantization config: "
+            f"bits={values.weight_bits}, sym={values.is_sym}"
+        )
+    cloned_config.quant_type = cloned_config.TYPE_MAP[
+        (values.weight_bits, values.is_sym)
+    ]
+    cloned_config.full_config.update(
+        {
+            "bits": values.weight_bits,
+            "group_size": values.group_size,
+            "desc_act": values.desc_act,
+            "sym": values.is_sym,
+        }
+    )
+    return cloned_config
+
+
+def _resolve_moe_quant_config(
     config: "AutoGPTQConfig",
     layer: RoutedExperts,
     prefix: str,
-    moe_method_cls: type,
-):
-    cloned_config = deepcopy(config)
+) -> tuple["AutoGPTQConfig | None", dict[tuple[int, str], int]]:
+    """Resolve dynamic GPTQ settings for every logical MoE weight shard.
 
-    assert isinstance(layer, RoutedExperts)
-    # False = skip module, None = no override, else = Positive match
-    if (
-        get_dynamic_override(  # noqa: E712
-            cloned_config,  # noqa: E712
-            layer_name=prefix,
+    Fused MoE kernels require one quantization scheme for the whole layer. A
+    smaller group size can represent a larger-group checkpoint losslessly by
+    repeating its scale and zero-point metadata. Other mixed settings cannot be
+    represented by the current kernels and are rejected explicitly.
+    """
+    base_values = _GPTQQuantConfigValues(
+        weight_bits=config.weight_bits,
+        group_size=config.group_size,
+        desc_act=config.desc_act,
+        is_sym=config.is_sym,
+    )
+
+    layer_override = get_dynamic_override(config, layer_name=prefix)
+    if layer_override is False:
+        return None, {}
+    assert layer_override is None or isinstance(layer_override, dict)
+    layer_values = _apply_dynamic_override(base_values, layer_override)
+
+    shard_projections = {
+        "w1": layer.ckpt_gate_proj_name,
+        "w2": layer.ckpt_down_proj_name,
+        "w3": layer.ckpt_up_proj_name,
+    }
+    num_checkpoint_experts = (
+        layer.moe_config.num_logical_experts
+        + layer.expert_map_manager.num_fused_shared_experts
+    )
+    shard_values: dict[tuple[int, str], _GPTQQuantConfigValues | None] = {}
+    for expert_id in range(num_checkpoint_experts):
+        for shard_id, projection_name in shard_projections.items():
+            shard_prefix = f"{prefix}.{expert_id}.{projection_name}"
+            dynamic_override = get_dynamic_override(config, layer_name=shard_prefix)
+            if dynamic_override is False:
+                shard_values[(expert_id, shard_id)] = None
+                continue
+            assert dynamic_override is None or isinstance(dynamic_override, dict)
+            shard_values[(expert_id, shard_id)] = _apply_dynamic_override(
+                layer_values, dynamic_override
+            )
+
+    quantized_values = [value for value in shard_values.values() if value is not None]
+    if not quantized_values:
+        return None, {}
+    if len(quantized_values) != len(shard_values):
+        skipped_shards = [
+            f"expert {expert_id} {shard_id}"
+            for (expert_id, shard_id), value in shard_values.items()
+            if value is None
+        ]
+        raise ValueError(
+            f"AutoGPTQ FusedMoE layer '{prefix}' excludes only some expert "
+            f"shards from quantization: {skipped_shards}"
         )
-        == False
-    ):  # noqa: E712
-        return UnquantizedFusedMoEMethod(layer.moe_config)
 
-    if prefix:
-        # Dynamic per module/layer rules may override base config
-        override_config(cloned_config, prefix=prefix)
+    def get_uniform_value(name: str) -> int | bool:
+        values = {getattr(value, name) for value in quantized_values}
+        if len(values) != 1:
+            raise ValueError(
+                f"AutoGPTQ FusedMoE layer '{prefix}' has mixed {name}: "
+                f"{sorted(values)}. Only group_size may differ between experts."
+            )
+        return next(iter(values))
 
-    return moe_method_cls(cloned_config, layer.moe_config)
+    weight_bits = int(get_uniform_value("weight_bits"))
+    desc_act = bool(get_uniform_value("desc_act"))
+    is_sym = bool(get_uniform_value("is_sym"))
+    source_group_sizes = {
+        shard: value.group_size
+        for shard, value in shard_values.items()
+        if value is not None
+    }
+    unique_group_sizes = set(source_group_sizes.values())
+
+    if len(unique_group_sizes) == 1:
+        group_size = next(iter(unique_group_sizes))
+    else:
+        if desc_act:
+            raise ValueError(
+                f"AutoGPTQ FusedMoE layer '{prefix}' has mixed group_size "
+                f"{sorted(unique_group_sizes)} with desc_act=True, which cannot "
+                "be normalized losslessly."
+            )
+        if any(group_size <= 0 for group_size in unique_group_sizes):
+            raise ValueError(
+                f"AutoGPTQ FusedMoE layer '{prefix}' cannot mix channelwise and "
+                f"group quantization: {sorted(unique_group_sizes)}"
+            )
+        group_size = min(unique_group_sizes)
+        if any(
+            source_group_size % group_size for source_group_size in unique_group_sizes
+        ):
+            raise ValueError(
+                f"AutoGPTQ FusedMoE layer '{prefix}' has incompatible group "
+                f"sizes: {sorted(unique_group_sizes)}"
+            )
+        logger.info_once(
+            "AutoGPTQ FusedMoE checkpoint uses mixed group sizes %s; "
+            "normalizing quantization metadata to group_size=%d.",
+            tuple(sorted(unique_group_sizes)),
+            group_size,
+        )
+
+    resolved_values = _GPTQQuantConfigValues(
+        weight_bits=weight_bits,
+        group_size=group_size,
+        desc_act=desc_act,
+        is_sym=is_sym,
+    )
+    return _clone_quant_config(config, resolved_values), source_group_sizes
 
 
 class AutoGPTQConfig(QuantizationConfig):
@@ -243,21 +388,38 @@ class AutoGPTQConfig(QuantizationConfig):
         if isinstance(layer, RoutedExperts):
             from vllm.model_executor.layers.quantization.moe_wna16 import MoeWNA16Config
 
+            resolved_config, source_group_sizes = _resolve_moe_quant_config(
+                self, layer, prefix
+            )
+            if resolved_config is None:
+                return UnquantizedFusedMoEMethod(layer.moe_config)
+
+            has_mixed_group_sizes = len(set(source_group_sizes.values())) > 1
             if not check_moe_marlin_supports_layer(
-                layer, self.group_size, allow_tile_padding=not self.desc_act
+                layer,
+                resolved_config.group_size,
+                allow_tile_padding=not resolved_config.desc_act,
             ):
+                if has_mixed_group_sizes:
+                    raise ValueError(
+                        f"Layer '{prefix}' uses mixed AutoGPTQ group sizes "
+                        f"{sorted(set(source_group_sizes.values()))}, but their "
+                        f"normalized group_size={resolved_config.group_size} is "
+                        "not supported by GPTQMoeMarlin. Moe WNA16 fallback "
+                        "cannot represent per-expert group sizes."
+                    )
                 logger.warning_once(
                     f"Layer '{prefix}' is not supported by GPTQMoeMarlin. "
                     "Falling back to Moe WNA16 kernels."
                 )
-                return MoeWNA16Config.from_config(self.full_config).get_quant_method(
-                    layer, prefix
-                )
-            moe_quant_method = get_moe_quant_method(
-                self, layer, prefix, AutoGPTQMoEMethod
+                return MoeWNA16Config.from_config(
+                    resolved_config.full_config
+                ).get_quant_method(layer, prefix)
+            moe_quant_method = AutoGPTQMoEMethod(
+                resolved_config,
+                layer.moe_config,
+                source_group_sizes if has_mixed_group_sizes else None,
             )
-            if moe_quant_method is None:
-                return None
             moe_quant_method.input_dtype = get_marlin_input_dtype(prefix)
             return moe_quant_method
 
@@ -471,12 +633,18 @@ class AutoGPTQMoEMethod(FusedMoEMethodBase):
         self,
         quant_config: AutoGPTQConfig,
         moe: FusedMoEConfig,
+        source_group_sizes: dict[tuple[int, str], int] | None = None,
     ) -> None:
         super().__init__(moe)
         self.quant_config = quant_config
+        self.source_group_sizes = source_group_sizes or {}
         if self.quant_config.quant_type.size_bits == 4:
             quant_type = scalar_types.uint4b8
-            scale = kInt4StaticGroupScale
+            scale = (
+                kInt4Static32GroupScale
+                if self.quant_config.group_size == 32
+                else kInt4StaticGroupScale
+            )
         elif self.quant_config.quant_type.size_bits == 8:
             quant_type = scalar_types.uint8b128
             scale = kInt8StaticGroupScale
@@ -507,15 +675,22 @@ class AutoGPTQMoEMethod(FusedMoEMethodBase):
         is_a_8bit = self.input_dtype is not None and self.input_dtype.itemsize == 1
 
         if is_a_8bit:
-            assert self.quant_config.quant_type.size_bits == 8, (
-                "W8A8-INT8 is not supported by marlin kernel."
-            )
+            assert (
+                self.quant_config.quant_type.size_bits == 8
+            ), "W8A8-INT8 is not supported by marlin kernel."
 
         intermediate_size_full = extra_weight_attrs.pop("intermediate_size_full")
 
         self.is_k_full = (not self.quant_config.desc_act) or (
             intermediate_size_per_partition == intermediate_size_full
         )
+
+        source_group_sizes = getattr(self, "source_group_sizes", {})
+        if source_group_sizes:
+            assert "weight_loader" in extra_weight_attrs
+            extra_weight_attrs["weight_loader"] = self.get_weight_loader(
+                extra_weight_attrs["weight_loader"]
+            )
 
         if self.quant_config.group_size != -1:
             scales_size13 = hidden_size // self.quant_config.group_size
@@ -673,6 +848,91 @@ class AutoGPTQMoEMethod(FusedMoEMethodBase):
             device = layer.w13_qweight.device
             layer.workspace = marlin_make_workspace_new(device, 4)
 
+    def _normalize_group_metadata(
+        self,
+        loaded_weight: torch.Tensor,
+        weight_name: str,
+        shard_id: str,
+        expert_id: int,
+    ) -> torch.Tensor:
+        source_group_sizes = getattr(self, "source_group_sizes", {})
+        source_group_size = source_group_sizes.get((expert_id, shard_id))
+        if source_group_size is None:
+            raise ValueError(
+                "Missing source group_size for AutoGPTQ FusedMoE "
+                f"expert {expert_id} shard {shard_id}."
+            )
+
+        target_group_size = self.quant_config.group_size
+        if source_group_size == target_group_size:
+            return loaded_weight
+
+        if (
+            source_group_size <= 0
+            or target_group_size <= 0
+            or source_group_size % target_group_size
+        ):
+            raise ValueError(
+                "Cannot normalize AutoGPTQ FusedMoE group_size "
+                f"{source_group_size} to {target_group_size} for expert "
+                f"{expert_id} shard {shard_id}."
+            )
+
+        repeat_factor = source_group_size // target_group_size
+        if weight_name.endswith(("scales", "qzeros")):
+            return loaded_weight.repeat_interleave(repeat_factor, dim=0)
+
+        if weight_name.endswith("g_idx"):
+            expected_g_idx = (
+                torch.arange(
+                    loaded_weight.numel(),
+                    dtype=loaded_weight.dtype,
+                    device=loaded_weight.device,
+                )
+                // source_group_size
+            ).reshape_as(loaded_weight)
+            if not torch.equal(loaded_weight, expected_g_idx):
+                raise ValueError(
+                    "Cannot normalize non-sequential g_idx for mixed-group "
+                    f"AutoGPTQ FusedMoE expert {expert_id} shard {shard_id}."
+                )
+            return (
+                torch.arange(
+                    loaded_weight.numel(),
+                    dtype=loaded_weight.dtype,
+                    device=loaded_weight.device,
+                )
+                // target_group_size
+            ).reshape_as(loaded_weight)
+
+        return loaded_weight
+
+    def get_weight_loader(self, weight_loader):
+        def mixed_group_weight_loader(
+            param: torch.nn.Parameter,
+            loaded_weight: torch.Tensor,
+            weight_name: str,
+            shard_id: str,
+            expert_id: int,
+            return_success: bool = False,
+        ):
+            loaded_weight = self._normalize_group_metadata(
+                loaded_weight,
+                weight_name,
+                shard_id,
+                expert_id,
+            )
+            return weight_loader(
+                param,
+                loaded_weight,
+                weight_name,
+                shard_id,
+                expert_id,
+                return_success=return_success,
+            )
+
+        return mixed_group_weight_loader
+
     def process_weights_after_loading(self, layer: RoutedExperts) -> None:
         def replace_or_register(name: str, val: torch.Tensor | None):
             if val is None:
@@ -687,9 +947,9 @@ class AutoGPTQMoEMethod(FusedMoEMethodBase):
 
         is_a_8bit = self.input_dtype is not None and self.input_dtype.itemsize == 1
 
-        assert not is_a_8bit or self.quant_config.quant_type.size_bits == 8, (
-            "W8A8-INT8 is not supported by marlin kernel."
-        )
+        assert (
+            not is_a_8bit or self.quant_config.quant_type.size_bits == 8
+        ), "W8A8-INT8 is not supported by marlin kernel."
 
         w13_bias = getattr(layer, "w13_bias", None)
         if "w13_bias" not in layer._loaded_expert_biases:

--- a/vllm/model_executor/layers/quantization/auto_gptq.py
+++ b/vllm/model_executor/layers/quantization/auto_gptq.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any
 
@@ -39,6 +38,7 @@ from vllm.model_executor.layers.quantization.base_config import (
 )
 from vllm.model_executor.layers.quantization.utils import replace_parameter
 from vllm.model_executor.layers.quantization.utils.gptq_utils import (
+    _clone_config,
     get_dynamic_override,
     get_linear_quant_method,
 )
@@ -95,21 +95,20 @@ def _clone_quant_config(
     config: "AutoGPTQConfig",
     values: _GPTQQuantConfigValues,
 ) -> "AutoGPTQConfig":
-    cloned_config = deepcopy(config)
+    quant_type = config.TYPE_MAP.get((values.weight_bits, values.is_sym))
+    if quant_type is None:
+        raise ValueError(
+            "Unsupported quantization config: "
+            f"bits={values.weight_bits}, sym={values.is_sym}"
+        )
+
+    cloned_config = _clone_config(config)
     cloned_config.weight_bits = values.weight_bits
     cloned_config.group_size = values.group_size
     cloned_config.desc_act = values.desc_act
     cloned_config.is_sym = values.is_sym
     cloned_config.pack_factor = 32 // values.weight_bits
-
-    if (values.weight_bits, values.is_sym) not in cloned_config.TYPE_MAP:
-        raise ValueError(
-            "Unsupported quantization config: "
-            f"bits={values.weight_bits}, sym={values.is_sym}"
-        )
-    cloned_config.quant_type = cloned_config.TYPE_MAP[
-        (values.weight_bits, values.is_sym)
-    ]
+    cloned_config.quant_type = quant_type
     cloned_config.full_config.update(
         {
             "bits": values.weight_bits,
@@ -215,6 +214,7 @@ def _resolve_moe_quant_config(
                 f"AutoGPTQ FusedMoE layer '{prefix}' cannot mix channelwise and "
                 f"group quantization: {sorted(unique_group_sizes)}"
             )
+        # Larger groups can be represented by repeating their metadata rows.
         group_size = min(unique_group_sizes)
         if any(
             source_group_size % group_size for source_group_size in unique_group_sizes
@@ -685,6 +685,7 @@ class AutoGPTQMoEMethod(FusedMoEMethodBase):
             intermediate_size_per_partition == intermediate_size_full
         )
 
+        # Normalize metadata before the generic MoE loader validates its shape.
         source_group_sizes = getattr(self, "source_group_sizes", {})
         if source_group_sizes:
             assert "weight_loader" in extra_weight_attrs
@@ -855,6 +856,9 @@ class AutoGPTQMoEMethod(FusedMoEMethodBase):
         shard_id: str,
         expert_id: int,
     ) -> torch.Tensor:
+        if not weight_name.endswith(("scales", "qzeros", "g_idx")):
+            return loaded_weight
+
         source_group_sizes = getattr(self, "source_group_sizes", {})
         source_group_size = source_group_sizes.get((expert_id, shard_id))
         if source_group_size is None:
@@ -879,31 +883,23 @@ class AutoGPTQMoEMethod(FusedMoEMethodBase):
             )
 
         repeat_factor = source_group_size // target_group_size
+        # Repeating metadata rows preserves the dequantized qweight values.
         if weight_name.endswith(("scales", "qzeros")):
             return loaded_weight.repeat_interleave(repeat_factor, dim=0)
 
         if weight_name.endswith("g_idx"):
-            expected_g_idx = (
-                torch.arange(
-                    loaded_weight.numel(),
-                    dtype=loaded_weight.dtype,
-                    device=loaded_weight.device,
-                )
-                // source_group_size
-            ).reshape_as(loaded_weight)
+            positions = torch.arange(
+                loaded_weight.numel(),
+                dtype=loaded_weight.dtype,
+                device=loaded_weight.device,
+            )
+            expected_g_idx = (positions // source_group_size).reshape_as(loaded_weight)
             if not torch.equal(loaded_weight, expected_g_idx):
                 raise ValueError(
                     "Cannot normalize non-sequential g_idx for mixed-group "
                     f"AutoGPTQ FusedMoE expert {expert_id} shard {shard_id}."
                 )
-            return (
-                torch.arange(
-                    loaded_weight.numel(),
-                    dtype=loaded_weight.dtype,
-                    device=loaded_weight.device,
-                )
-                // target_group_size
-            ).reshape_as(loaded_weight)
+            return (positions // target_group_size).reshape_as(loaded_weight)
 
         return loaded_weight
 

--- a/vllm/model_executor/layers/quantization/utils/gptq_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/gptq_utils.py
@@ -48,24 +48,104 @@ def override_config(config: AutoGPTQConfig, prefix: str):
     config.quant_type = config.TYPE_MAP[(config.weight_bits, config.is_sym)]
 
 
+_REGEX_META_CHARACTERS = frozenset(r".^$*+?{}[]()|")
+
+
+def _get_literal_pattern(pattern: str) -> str | None:
+    """Return the literal matched by an anchored regex, when it has one."""
+    if not pattern.startswith("^") or not pattern.endswith("$"):
+        return None
+
+    literal = []
+    index = 1
+    end = len(pattern) - 1
+    while index < end:
+        character = pattern[index]
+        if character == "\\":
+            index += 1
+            if index >= end or pattern[index].isalnum():
+                return None
+            literal.append(pattern[index])
+        elif character in _REGEX_META_CHARACTERS:
+            return None
+        else:
+            literal.append(character)
+        index += 1
+    return "".join(literal)
+
+
+def _get_dynamic_rule_matcher(config: AutoGPTQConfig) -> dict[str, Any]:
+    cache = getattr(config, "_dynamic_rule_matcher", None)
+    if (
+        cache is not None
+        and cache["dynamic"] is config.dynamic
+        and cache["size"] == len(config.dynamic)
+    ):
+        return cache
+
+    exact_rules: dict[str, tuple[int, bool, dict]] = {}
+    regex_rules: list[tuple[int, Any, bool, dict]] = []
+    for index, (pattern, pattern_dict) in enumerate(config.dynamic.items()):
+        is_negative = pattern.startswith("-:")
+        regex_pattern = pattern.removeprefix("-:").removeprefix("+:")
+        literal_pattern = _get_literal_pattern(regex_pattern)
+        if literal_pattern is not None:
+            exact_rules.setdefault(
+                literal_pattern,
+                (index, is_negative, pattern_dict),
+            )
+        else:
+            regex_rules.append(
+                (index, re.compile(regex_pattern), is_negative, pattern_dict)
+            )
+
+    cache = {
+        "dynamic": config.dynamic,
+        "size": len(config.dynamic),
+        "exact_rules": exact_rules,
+        "regex_rules": regex_rules,
+    }
+    config._dynamic_rule_matcher = cache
+    return cache
+
+
+def _find_dynamic_rule(
+    config: AutoGPTQConfig,
+    layer_name: str,
+) -> tuple[bool, bool, dict]:
+    matcher = _get_dynamic_rule_matcher(config)
+    exact_rule = matcher["exact_rules"].get(layer_name)
+    exact_rule_index = exact_rule[0] if exact_rule is not None else None
+
+    for index, pattern, is_negative, pattern_dict in matcher["regex_rules"]:
+        if exact_rule_index is not None and index > exact_rule_index:
+            break
+        if pattern.match(layer_name):
+            return True, is_negative, pattern_dict
+
+    if exact_rule is not None:
+        _, is_negative, pattern_dict = exact_rule
+        return True, is_negative, pattern_dict
+    return False, False, {}
+
+
 def _match_dynamic_override(
     config: AutoGPTQConfig,
     layer_name: str,
     key: str | None,
     default_value: int | bool | None,
 ) -> tuple[bool, dict | int | bool | None]:
-    for pattern, pattern_dict in config.dynamic.items():
-        # Negative match: matched modules are excluded from quantized init
-        if pattern.startswith("-:"):
-            if re.match(pattern.removeprefix("-:"), layer_name):
-                return True, False
-        # Positive match: matched modules have quant properties overrides
-        # base quant config
-        elif re.match(pattern.removeprefix("+:"), layer_name):
-            if key is None:
-                return True, pattern_dict
-            return True, pattern_dict.get(key, default_value)
-    return False, default_value
+    matched, is_negative, pattern_dict = _find_dynamic_rule(config, layer_name)
+    if not matched:
+        return False, default_value
+    # Negative match: matched modules are excluded from quantized init
+    if is_negative:
+        return True, False
+    # Positive match: matched modules have quant properties overrides
+    # base quant config
+    if key is None:
+        return True, pattern_dict
+    return True, pattern_dict.get(key, default_value)
 
 
 def _format_shard_values(
@@ -75,24 +155,37 @@ def _format_shard_values(
     return dict(zip(shard_proj_names, shard_values, strict=True))
 
 
+def _get_fused_shard_names(
+    layer_name: str,
+    fused_mapping: Mapping[str, list[str]],
+) -> tuple[str | None, list[str] | None]:
+    fused_name = max(
+        (name for name in fused_mapping if layer_name.endswith(name)),
+        key=len,
+        default=None,
+    )
+    if fused_name is None:
+        return None, None
+    return fused_name, fused_mapping[fused_name]
+
+
 def get_dynamic_override(
     config: AutoGPTQConfig,
     layer_name: str,
     key: str | None = None,
     default_value: int | bool | None = None,
 ) -> dict | int | bool | None:
-    matched, value = _match_dynamic_override(
-        config, layer_name, key, default_value
-    )
+    matched, value = _match_dynamic_override(config, layer_name, key, default_value)
     if matched:
         return value
 
-    proj_name = layer_name.rsplit(".", 1)[-1]
-    shard_proj_names = config.packed_modules_mapping.get(proj_name)
-    if not shard_proj_names:
+    fused_name, shard_proj_names = _get_fused_shard_names(
+        layer_name, config.packed_modules_mapping
+    )
+    if fused_name is None or shard_proj_names is None:
         return default_value
 
-    layer_prefix = layer_name.removesuffix(proj_name)
+    layer_prefix = layer_name.removesuffix(fused_name)
     shard_matches = [
         _match_dynamic_override(
             config,
@@ -111,8 +204,7 @@ def get_dynamic_override(
             if all(negative_matches):
                 return False
             shard_values = [
-                value if matched else default_value
-                for matched, value in shard_matches
+                value if matched else default_value for matched, value in shard_matches
             ]
             raise ValueError(
                 f"Dynamic quantization config for fused layer {layer_name} "
@@ -163,19 +255,16 @@ def is_layer_gptq_quantized(
     # Substr: ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"]
     # Full prefix ["model.layers.0.self_attn.q_proj"]
 
-    proj_name = prefix.split(".")[-1]
-
     quantized_layers = flatten_list(quantized_layers)
 
     # Fused layers like gate_up_proj or qkv_proj will not be fused
     # in the safetensors checkpoint. So, we convert the name
     # from the fused version to unfused + check to make sure that
     # each shard of the fused layer has the same scheme.
-    if proj_name in fused_mapping:
-        shard_prefixes = [
-            prefix.replace(proj_name, shard_proj_name)
-            for shard_proj_name in fused_mapping[proj_name]
-        ]
+    fused_name, shard_names = _get_fused_shard_names(prefix, fused_mapping)
+    if fused_name is not None and shard_names is not None:
+        layer_prefix = prefix.removesuffix(fused_name)
+        shard_prefixes = [f"{layer_prefix}{shard_name}" for shard_name in shard_names]
 
         is_quantized = None
         for shard_prefix in shard_prefixes:

--- a/vllm/model_executor/layers/quantization/utils/gptq_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/gptq_utils.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from collections.abc import Mapping
-from copy import deepcopy
+from copy import copy
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
 
@@ -18,6 +18,13 @@ if TYPE_CHECKING:
     from ..auto_gptq import AutoGPTQConfig
 else:
     AutoGPTQConfig = object
+
+
+def _clone_config(config: AutoGPTQConfig) -> AutoGPTQConfig:
+    # Per-layer overrides only mutate scalar fields; large rule tables are shared.
+    cloned_config = copy(config)
+    cloned_config.full_config = config.full_config.copy()
+    return cloned_config
 
 
 # Match dynamic rules with module name (prefix) and override quantize
@@ -86,6 +93,8 @@ def _get_dynamic_rule_matcher(config: AutoGPTQConfig) -> dict[str, Any]:
     exact_rules: dict[str, tuple[int, bool, dict]] = {}
     regex_rules: list[tuple[int, Any, bool, dict]] = []
     for index, (pattern, pattern_dict) in enumerate(config.dynamic.items()):
+        # GPTQModel often emits thousands of exact rules. Index those rules
+        # while preserving the original first-match order for real regexes.
         is_negative = pattern.startswith("-:")
         regex_pattern = pattern.removeprefix("-:").removeprefix("+:")
         literal_pattern = _get_literal_pattern(regex_pattern)
@@ -155,18 +164,22 @@ def _format_shard_values(
     return dict(zip(shard_proj_names, shard_values, strict=True))
 
 
-def _get_fused_shard_names(
+def _get_fused_shards(
     layer_name: str,
     fused_mapping: Mapping[str, list[str]],
-) -> tuple[str | None, list[str] | None]:
+) -> tuple[str, list[str]] | None:
+    def is_module_suffix(module_name: str) -> bool:
+        suffix = module_name if module_name.startswith(".") else f".{module_name}"
+        return layer_name == module_name or layer_name.endswith(suffix)
+
     fused_name = max(
-        (name for name in fused_mapping if layer_name.endswith(name)),
+        (name for name in fused_mapping if is_module_suffix(name)),
         key=len,
         default=None,
     )
     if fused_name is None:
-        return None, None
-    return fused_name, fused_mapping[fused_name]
+        return None
+    return (fused_name, fused_mapping[fused_name])
 
 
 def get_dynamic_override(
@@ -179,12 +192,12 @@ def get_dynamic_override(
     if matched:
         return value
 
-    fused_name, shard_proj_names = _get_fused_shard_names(
-        layer_name, config.packed_modules_mapping
-    )
-    if fused_name is None or shard_proj_names is None:
+    fused_shards = _get_fused_shards(layer_name, config.packed_modules_mapping)
+    if fused_shards is None:
         return default_value
 
+    # Dynamic rules use unfused checkpoint names, so retry each logical shard.
+    fused_name, shard_proj_names = fused_shards
     layer_prefix = layer_name.removesuffix(fused_name)
     shard_matches = [
         _match_dynamic_override(
@@ -261,8 +274,9 @@ def is_layer_gptq_quantized(
     # in the safetensors checkpoint. So, we convert the name
     # from the fused version to unfused + check to make sure that
     # each shard of the fused layer has the same scheme.
-    fused_name, shard_names = _get_fused_shard_names(prefix, fused_mapping)
-    if fused_name is not None and shard_names is not None:
+    fused_shards = _get_fused_shards(prefix, fused_mapping)
+    if fused_shards is not None:
+        fused_name, shard_names = fused_shards
         layer_prefix = prefix.removesuffix(fused_name)
         shard_prefixes = [f"{layer_prefix}{shard_name}" for shard_name in shard_names]
 
@@ -293,7 +307,7 @@ def get_linear_quant_method(
     prefix: str,
     linear_method_cls: type,
 ):
-    cloned_config = deepcopy(config)
+    cloned_config = _clone_config(config)
     parallel_lm_head_quantized = (
         isinstance(layer, ParallelLMHead) and cloned_config.lm_head_quantized
     )

--- a/vllm/model_executor/layers/quantization/utils/gptq_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/gptq_utils.py
@@ -48,25 +48,93 @@ def override_config(config: AutoGPTQConfig, prefix: str):
     config.quant_type = config.TYPE_MAP[(config.weight_bits, config.is_sym)]
 
 
+def _match_dynamic_override(
+    config: AutoGPTQConfig,
+    layer_name: str,
+    key: str | None,
+    default_value: int | bool | None,
+) -> tuple[bool, dict | int | bool | None]:
+    for pattern, pattern_dict in config.dynamic.items():
+        # Negative match: matched modules are excluded from quantized init
+        if pattern.startswith("-:"):
+            if re.match(pattern.removeprefix("-:"), layer_name):
+                return True, False
+        # Positive match: matched modules have quant properties overrides
+        # base quant config
+        elif re.match(pattern.removeprefix("+:"), layer_name):
+            if key is None:
+                return True, pattern_dict
+            return True, pattern_dict.get(key, default_value)
+    return False, default_value
+
+
+def _format_shard_values(
+    shard_proj_names: list[str],
+    shard_values: list[dict | int | bool | None],
+) -> dict[str, dict | int | bool | None]:
+    return dict(zip(shard_proj_names, shard_values, strict=True))
+
+
 def get_dynamic_override(
     config: AutoGPTQConfig,
     layer_name: str,
     key: str | None = None,
     default_value: int | bool | None = None,
 ) -> dict | int | bool | None:
-    for pattern, pattern_dict in config.dynamic.items():
-        # Negative match: matched modules are excluded from quantized init
-        if pattern.startswith("-:"):
-            if re.match(pattern.removeprefix("-:"), layer_name):
+    matched, value = _match_dynamic_override(
+        config, layer_name, key, default_value
+    )
+    if matched:
+        return value
+
+    proj_name = layer_name.rsplit(".", 1)[-1]
+    shard_proj_names = config.packed_modules_mapping.get(proj_name)
+    if not shard_proj_names:
+        return default_value
+
+    layer_prefix = layer_name.removesuffix(proj_name)
+    shard_matches = [
+        _match_dynamic_override(
+            config,
+            f"{layer_prefix}{shard_proj_name}",
+            key,
+            default_value,
+        )
+        for shard_proj_name in shard_proj_names
+    ]
+
+    if key is None:
+        negative_matches = [
+            matched and value is False for matched, value in shard_matches
+        ]
+        if any(negative_matches):
+            if all(negative_matches):
                 return False
-        # Positive match: matched modules have quant properties overrides
-        # base quant config
-        elif re.match(pattern.removeprefix("+:"), layer_name):
-            if key is None:
-                return pattern_dict
-            else:
-                return pattern_dict.get(key, default_value)
-    return default_value
+            shard_values = [
+                value if matched else default_value
+                for matched, value in shard_matches
+            ]
+            raise ValueError(
+                f"Dynamic quantization config for fused layer {layer_name} "
+                "does not match across shards: "
+                f"{_format_shard_values(shard_proj_names, shard_values)}"
+            )
+
+        for matched, value in shard_matches:
+            if matched:
+                return value
+        return default_value
+
+    shard_values = [
+        value if matched else default_value for matched, value in shard_matches
+    ]
+    if any(value != shard_values[0] for value in shard_values[1:]):
+        raise ValueError(
+            f"Dynamic quantization config for fused layer {layer_name} "
+            f"does not match across shards for {key}: "
+            f"{_format_shard_values(shard_proj_names, shard_values)}"
+        )
+    return shard_values[0]
 
 
 def flatten_list(lst: list[Any]) -> list[Any]:

--- a/vllm/model_executor/models/laguna.py
+++ b/vllm/model_executor/models/laguna.py
@@ -175,18 +175,18 @@ class LagunaMoE(nn.Module):
         )
 
         # Shared expert (optional) - passed to FusedMoE for overlap optimization
-        self.shared_expert: LagunaMLP | None
+        self.shared_experts: LagunaMLP | None
         if config.shared_expert_intermediate_size > 0:
-            self.shared_expert = LagunaMLP(
+            self.shared_experts = LagunaMLP(
                 hidden_size=config.hidden_size,
                 intermediate_size=config.shared_expert_intermediate_size,
                 hidden_act=config.hidden_act,
                 quant_config=quant_config,
                 reduce_results=False,  # Reduce after shared+routed combine
-                prefix=f"{prefix}.shared_expert",
+                prefix=f"{prefix}.shared_experts",
             )
         else:
-            self.shared_expert = None
+            self.shared_experts = None
 
         # Auxiliary-loss-free load-balancing bias (arXiv:2408.15664). The
         # checkpoint stores one [num_experts] tensor per MoE layer at
@@ -205,7 +205,7 @@ class LagunaMoE(nn.Module):
         # routed_scaling_factor, shared+routed combine, and TP all-reduce
         # internally, so forward() just returns the final hidden states.
         self.experts = FusedMoE(
-            shared_experts=self.shared_expert,
+            shared_experts=self.shared_experts,
             num_experts=config.num_experts,
             top_k=config.num_experts_per_tok,
             hidden_size=config.hidden_size,

--- a/vllm/model_executor/models/laguna.py
+++ b/vllm/model_executor/models/laguna.py
@@ -175,6 +175,7 @@ class LagunaMoE(nn.Module):
         )
 
         # Shared expert (optional) - passed to FusedMoE for overlap optimization
+        # Keep this name aligned with the HF module and checkpoint prefix.
         self.shared_experts: LagunaMLP | None
         if config.shared_expert_intermediate_size > 0:
             self.shared_experts = LagunaMLP(


### PR DESCRIPTION
  <!-- markdownlint-disable -->

  ## Purpose

  This PR fixes two related AutoGPTQ loading failures caused by the difference between logical checkpoint module names and fused runtime modules.

  Previously, `get_dynamic_override()` only queried fused names such as `qkv_proj` and `gate_up_proj`. Dynamic rules written for the underlying checkpoint projections could therefore be missed, causing vLLM to fall back to the
  global quantization configuration. For example, a fused QKV layer could be initialized with `group_size=128` even though all of its checkpoint shards use `group_size=32`, eventually causing a weight shape assertion during
  loading.

  FusedMoE had a similar issue: dynamic quantization settings were not resolved for every expert and logical `w1`/`w2`/`w3` shard before allocating the fused parameters. A checkpoint containing compatible mixed group sizes, such
  as 32 and 128, could not be represented by the existing single-group FusedMoE allocation.

  This PR:

  - resolves fused modules through `packed_modules_mapping` and queries the dynamic configuration of each logical shard;
  - preserves dynamic-rule ordering, exact-match behavior, and negative/exclusion semantics;
  - rejects inconsistent fused linear shard configurations instead of silently selecting an incorrect value;
  - caches parsed exact and regex dynamic rules to avoid repeatedly scanning large dynamic configurations;
  - resolves AutoGPTQ settings for every FusedMoE expert and logical weight shard;
  - losslessly normalizes compatible mixed group sizes to the smallest group size by repeating `scales` and `qzeros` and rebuilding sequential `g_idx`, while leaving `qweight` unchanged;
  - rejects unsupported combinations, including partial expert exclusions, mixed bit widths or symmetry settings, mixed groups with `desc_act=True`, channelwise/groupwise mixtures, incompatible group sizes, and unsupported WNA16
  fallback;
  - selects the group-32 Marlin scale type when the resolved group size is 32;
  - aligns Laguna's optional shared-expert module and checkpoint prefix with `shared_experts`, matching the Hugging Face model and checkpoint naming.

  Mixed-group normalization is only performed when every source group size is positive, each larger group size is divisible by the target group size, and `desc_act=False`. Unsupported configurations fail with an actionable
  error.

  These changes are kept together because both loading failures originate at the logical-checkpoint-to-fused-runtime boundary and are required for the affected Laguna checkpoint to load end-to-end.

  Duplicate check: searches of open vLLM PRs for `AutoGPTQ FusedMoE dynamic`, `mixed group GPTQ MoE`, and `GPTQ fused dynamic quantization` found no PR covering this issue. The nearest results concern other models or
  quantization backends, such as AutoRound and Quark.

  No documentation update is required because this fixes checkpoint compatibility without changing the public API or CLI.

  ## Test Plan

  ```bash
  python -m pytest \
    tests/quantization/test_gptq_dynamic.py 

  python -m pytest \
    tests/quantization/test_auto_gptq.py
  ```

  The tests cover:

  - normal and dotted fused-module mappings;
  - module-boundary matching;
  - first-match dynamic-rule semantics;
  - complete and partial exclusions;
  - inconsistent fused-shard overrides;
  - mixed FusedMoE group-size resolution;
  - `scales`, `qzeros`, and `g_idx` normalization;
  - incompatible group sizes and non-sequential `g_idx`;
  - mixed-group configurations with `desc_act=True`;
  - partially unquantized expert shards;
  - independent cloned configuration state.

  An end-to-end one-token generation smoke test was also run with the affected Laguna-S-2.1 GPTQ checkpoint using `max_model_len=512` and `enforce_eager=True`.

  ## Test Result
  - Dynamic GPTQ tests: `8 passed, 1 deselected`.
  - AutoGPTQ tests: `9 passed, 1 skipped`. The skipped test requires a GPU in the targeted unit-test environment.
  - End-to-end GPU smoke test: all 15 checkpoint shards loaded successfully, Marlin/FusedMoE initialization completed, the KV cache was initialized, and the model generated `Paris` for the prompt `The capital of France is`.
  - Before this change, loading failed at:

    ```text
    vllm/model_executor/parameter.py:200
    assert param_data.shape == loaded_weight.shape
    ```

  ## AI Assistance

  AI assistance was used for debugging, implementation, and test drafting. I reviewed and understand every changed line and am prepared to maintain this change.

  ---
  <details>
  <summary> Essential Elements of an Effective PR Description Checklist </summary>

  - [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
  - [x] The test plan, such as providing test command.
  - [x] The test results, such as pasting the results comparison before and after, or e2e results.
  - [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. No documentation update is required for this fix.
  </details>

  