### PR TITLE
[Bugfix][CI/Build] Honor VLLM_PRECOMPILED_WHEEL_COMMIT=nightly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -657,8 +657,8 @@ class precompiled_wheel_utils:
         3. the default variant from nightly repo
 
         If downloading from the nightly repo, the commit can be specified via
-        VLLM_PRECOMPILED_WHEEL_COMMIT; otherwise, the head commit in the main branch
-        is used.
+        VLLM_PRECOMPILED_WHEEL_COMMIT. The special value ``nightly`` selects the
+        latest built wheel; otherwise, the head commit in the main branch is used.
         """
         wheel_location = os.getenv("VLLM_PRECOMPILED_WHEEL_LOCATION", None)
         if wheel_location is not None:
@@ -679,7 +679,7 @@ class precompiled_wheel_utils:
             if variant is None:
                 variant = precompiled_wheel_utils.detect_system_cuda_variant()
             commit = os.getenv("VLLM_PRECOMPILED_WHEEL_COMMIT", "").lower()
-            if not commit or len(commit) != 40:
+            if commit != "nightly" and (not commit or len(commit) != 40):
                 print(
                     f"VLLM_PRECOMPILED_WHEEL_COMMIT not valid: {commit}"
                     ", trying to fetch base commit in main branch"


### PR DESCRIPTION
## Purpose
`VLLM_PRECOMPILED_WHEEL_COMMIT=nightly` is documented as selecting the latest already-built wheel. However, `setup.py` currently rejects `nightly` because it only accepts 40-character commit hashes.

This causes installation to fall back to a recent main-branch commit. If that commit's wheel has not been built yet, the documented installation command fails with HTTP 404.

This change preserves the special `nightly` value while retaining the existing fallback behavior for empty or invalid commit values.

Fixes #50215

I searched open PRs for `VLLM_PRECOMPILED_WHEEL_COMMIT`, `nightly`, and `precompiled wheel` and found no matching fix. PR #41659 addresses detached HEAD handling rather than validation of the `nightly` alias.

## Test Plan
- Run the documented editable installation with `VLLM_PRECOMPILED_WHEEL_COMMIT=nightly`.
- Run pre-commit checks on `setup.py`.
- Compile `setup.py` with Python 3.12.
- Check the diff for whitespace errors.

## Test Result

Before the change:

`VLLM_PRECOMPILED_WHEEL_COMMIT` not valid: nightly

The installation then selected a recent main-branch commit and failed with HTTP 404 because its wheel was unavailable.

After the change:

```bash
env VLLM_USE_PRECOMPILED=1 \
    VLLM_PRECOMPILED_WHEEL_COMMIT=nightly \
    uv pip install --python .venv/bin/python \
    --editable . \
    --torch-backend=auto
```

The editable build and installation completed successfully.

The following checks passed:

```bash
.venv/bin/pre-commit run --files setup.py
.venv/bin/python -m py_compile setup.py
git diff --check
  ```

Model evaluation is not applicable because this change only affects build-time wheel selection.

The existing documentation already describes the `nightly` behavior, so no additional documentation update is required.
---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

