### PR TITLE
[CI] Fix MXFP8 MOE backend selection tests on gfx942

### DIFF
--- a/tests/kernels/moe/test_mxfp8_aiter_backend_selection.py
+++ b/tests/kernels/moe/test_mxfp8_aiter_backend_selection.py
@@ -27,8 +27,8 @@ from vllm.model_executor.layers.fused_moe.experts.aiter_mxfp8_moe import (  # no
     _AITER_SWIGLU_BETA,
     AiterMxfp8Experts,
 )
-from vllm.model_executor.layers.fused_moe.experts.mxfp8_native_moe import (  # noqa: E402
-    Mxfp8NativeTritonExperts,
+from vllm.model_executor.layers.fused_moe.experts.mxfp8_emulation_moe import (  # noqa: E402
+    Mxfp8EmulationTritonExperts,
 )
 from vllm.model_executor.layers.fused_moe.modular_kernel import (  # noqa: E402
     FusedMoEActivationFormat,
@@ -150,16 +150,20 @@ def test_explicit_moe_backend_aiter():
 
 def test_gfx950_picks_aiter():
     """Auto-select on real ROCm hardware with flydsl usable -> FlyDSL wins."""
-    with _flydsl_installed(True):
+    # NOTE: Fp8MoeBackend.AITER_MXFP8 does not require VLLM_ROCM_USE_AITER=1
+    with (
+        patch(f"{_AITER_MOD}.current_platform.supports_mx", return_value=True),
+        _flydsl_installed(True),
+    ):
         backend, experts_cls = select_mxfp8_moe_backend(_config())
     assert backend is Fp8MoeBackend.AITER_MXFP8
     assert experts_cls is AiterMxfp8Experts
 
 
-def test_gfx942_picks_triton():
+def test_gfx942_picks_emulation():
     """flydsl unusable (e.g. gfx942, no FlyDSL support) -> native Triton
     dot_scaled backend wins instead."""
-    with _flydsl_installed(False):
+    with patch(f"{_AITER_MOD}.current_platform.supports_mx", return_value=False):
         backend, experts_cls = select_mxfp8_moe_backend(_config())
-    assert backend is Fp8MoeBackend.TRITON_MXFP8
-    assert experts_cls is Mxfp8NativeTritonExperts
+    assert backend is Fp8MoeBackend.EMULATION
+    assert experts_cls is Mxfp8EmulationTritonExperts


### PR DESCRIPTION
## Purpose

As reported by @jikunshang (https://github.com/vllm-project/vllm/pull/49747#issuecomment-5114449319), #49747 includes two new failing tests, fixing in this PR. These failures were overlooked as local testing of #49747 was done on MI350 and not on MI300, apologies.

Two tests in https://github.com/vllm-project/vllm/pull/49747 were wrongfully implemented when running on gfx942:

- `test_gfx950_picks_aiter` needs to patch `current_platform.supports_mx()` to pass https://github.com/vllm-project/vllm/blob/65a1a16594995bdc8b8feae2bf2ecf208d585be8/vllm/model_executor/layers/fused_moe/experts/aiter_mxfp8_moe.py#L79-L83
- `test_gfx942_picks_triton` is now renamed to `test_gfx942_picks_emulation`, as `Mxfp8NativeTritonExperts` is only supported on gfx950, including prior to https://github.com/vllm-project/vllm/pull/49747 (see the condition on `supports_mx()`: https://github.com/vllm-project/vllm/blob/d891b9bd51ce726a1bff24a72d03090057718789/vllm/model_executor/layers/fused_moe/oracle/mxfp8.py#L67-L75)

## Test Plan

- `pytest tests/kernels/moe/test_mxfp8_aiter_backend_selection.py -s -vvvvv -k "test_gfx942_picks_triton"`
- `pytest tests/kernels/moe/test_mxfp8_aiter_backend_selection.py -s -vvvvv -k "test_gfx942_picks_triton"`

## Test Result

Passing on MI300.

Other PR to track: https://github.com/vllm-project/vllm/pull/46123
