### PR TITLE
[Docs] Add SharedStorageConnector→ExampleConnector migration note and fix connector inventory

### DIFF
--- a/docs/features/disagg_prefill.md
+++ b/docs/features/disagg_prefill.md
@@ -17,7 +17,21 @@ Two main reasons:
 
 ## Usage example
 
-Now supports 9 types of connectors:
+!!! note "Migration note: SharedStorageConnector renamed to ExampleConnector"
+    As of PR [#30201](https://github.com/vllm-project/vllm/pull/30201),
+    `SharedStorageConnector` has been renamed to `ExampleConnector`.
+    This connector is intended for **debug and example purposes only** — it is
+    **not suitable for production** PD deployments.
+
+    If you were using `SharedStorageConnector` in your configuration, update
+    `kv_connector` to `ExampleConnector`. The `shared_storage_path`
+    configuration key remains unchanged.
+
+    For production disaggregated prefilling, use one of the production-grade
+    connectors such as **NixlConnector**, **MooncakeConnector**, or
+    **FlexKVConnectorV1**.
+
+Now supports the following connectors (see [`factory.py`](https://github.com/vllm-project/vllm/blob/main/vllm/distributed/kv_transfer/kv_connector/factory.py) for the complete registry):
 
 - **ExampleConnector**: refer to [examples/disaggregated/example_connector/run.sh](../../examples/disaggregated/example_connector/run.sh) for the example usage of ExampleConnector disaggregated prefilling.
 - **LMCacheConnectorV1**: refer to [examples/disaggregated/lmcache/disagg_prefill_lmcache_v1/disagg_example_nixl.sh](../../examples/disaggregated/lmcache/disagg_prefill_lmcache_v1/disagg_example_nixl.sh) for the example usage of LMCacheConnectorV1 disaggregated prefilling which uses NIXL as the underlying KV transmission. LMCache also offers a multi-process (MP) mode via `LMCacheMPConnector`, where a standalone `lmcache server` holds the KV cache shared by one or more vLLM instances; see the [LMCache examples](../../examples/disaggregated/lmcache/README.md) and the [LMCache docs](https://docs.lmcache.ai) for setup.


### PR DESCRIPTION
## Summary

Fixes #49399

## Changes

This PR adds documentation to address the gap left by PR #30201 (SharedStorageConnector → ExampleConnector rename):

1. **Added migration note** — A callout box in `docs/features/disagg_prefill.md` explaining:
   - That `SharedStorageConnector` was renamed to `ExampleConnector` in #30201
   - That `ExampleConnector` is for **debug/example purposes only**, not production
   - How to update configurations (change `kv_connector` value, keep `shared_storage_path`)
   - Pointers to production-grade alternatives (NixlConnector, MooncakeConnector, FlexKVConnectorV1)

2. **Fixed connector count** — Changed the stale "9 types of connectors" to a dynamic reference pointing to `factory.py` as the authoritative registry, avoiding future drift.

## Related

- Closes #49399
- Related: #30201 (the rename)
- Related: #38524 (broader PD docs rewrite — this is a focused, actionable subset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)