### PR TITLE
[Cleanup] Remove orphaned output_text_buffer_length and stale spec-decode startup warning after V0 removal

### DIFF
--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -313,7 +313,6 @@ class SamplingParams(
 
     # The below fields are not supposed to be used as an input.
     # They are set in post_init.
-    output_text_buffer_length: int = 0
     _eos_token_id: int | None = None
     _all_stop_token_ids: set[int] = msgspec.field(default_factory=set)
 
@@ -488,11 +487,6 @@ class SamplingParams(
 
         if self.prompt_logprobs is True:
             self.prompt_logprobs = 1
-
-        # Number of characters to hold back for stop string evaluation
-        # until sequence is finished.
-        if self.stop and not self.include_stop_str_in_output:
-            self.output_text_buffer_length = max(len(s) for s in self.stop) - 1
 
         self._verify_args()
 

--- a/vllm/v1/sample/logits_processor/__init__.py
+++ b/vllm/v1/sample/logits_processor/__init__.py
@@ -202,9 +202,6 @@ def build_logitsprocs(
     if vllm_config.speculative_config:
         if custom_logitsprocs:
             raise ValueError(STR_SPEC_DEC_REJECTS_LOGITSPROCS)
-        logger.warning(
-            "min_p and logit_bias parameters won't work with speculative decoding."
-        )
         return LogitsProcessors(
             [MinTokensLogitsProcessor(vllm_config, device, is_pin_memory)]
         )


### PR DESCRIPTION
## Summary

Fixes #50217

Two dead items left behind after the V0 deprecation (#25330):

### 1. Removed orphaned `SamplingParams.output_text_buffer_length`

**File:** `vllm/sampling_params.py`

The field was introduced in #3672 to track stop-string buffer length for the V0 streaming path. After V0 was removed, no code path reads this value — V1 recomputes it locally as `stop_buffer_length` in `vllm/v1/engine/detokenizer.py:88`.

Changes:
- Removed the field declaration `output_text_buffer_length: int = 0`
- Removed the `__post_init__` computation block (stop-string buffer calculation)

### 2. Removed stale `logger.warning` in `build_logitsprocs`

**File:** `vllm/v1/sample/logits_processor/__init__.py`

The warning claimed `min_p` and `logit_bias` silently break with spec decode, but `_validate_spec_decode` (in `sampling_params.py:887`) now raises a hard `VLLMValidationError` per-request. The warning fired on every server startup with spec decode enabled, creating noise and incorrectly suggesting degraded behavior.

Changes:
- Removed the stale `logger.warning` call

## Verification

```bash
# Confirm no remaining consumers of output_text_buffer_length:
grep -rn "output_text_buffer_length" vllm/ --include="*.py"
# (should return nothing)

# Confirm V1 independently computes stop_buffer_length:
grep -n "stop_buffer_length" vllm/v1/engine/detokenizer.py

# Confirm per-request validation exists:
grep -n "_validate_spec_decode" vllm/sampling_params.py
```

## Related

- Closes #50217
- V0 removal: #25330
- Original output_text_buffer_length: #3672

🤖 Generated with [Claude Code](https://claude.com/claude-code)