### PR TITLE
[Kernel] Optimize SM103 GDN causal-conv prefills

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -448,10 +448,14 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
   if(VLLM_GPU_LANG STREQUAL "CUDA")
     if(DEFINED CMAKE_CUDA_COMPILER_VERSION AND
        CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0)
-      list(APPEND VLLM_STABLE_EXT_SRC
-        "csrc/libtorch_stable/mamba/gdn_causal_conv1d_sm103.cu")
-      list(APPEND VLLM_GPU_FLAGS "-DVLLM_ENABLE_GDN_CONV_SM103=1")
-      set(VLLM_ENABLE_GDN_CONV_SM103 ON)
+      cuda_archs_loose_intersection(GDN_CONV_SM103_ARCHS
+        "10.3a" "${CUDA_ARCHS}")
+      if(GDN_CONV_SM103_ARCHS)
+        list(APPEND VLLM_STABLE_EXT_SRC
+          "csrc/libtorch_stable/mamba/gdn_causal_conv1d_sm103.cu")
+        list(APPEND VLLM_GPU_FLAGS "-DVLLM_ENABLE_GDN_CONV_SM103=1")
+        set(VLLM_ENABLE_GDN_CONV_SM103 ON)
+      endif()
     endif()
 
     SET(CUTLASS_ENABLE_HEADERS_ONLY ON CACHE BOOL "Enable only the header library")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -446,6 +446,14 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
   endif()
 
   if(VLLM_GPU_LANG STREQUAL "CUDA")
+    if(DEFINED CMAKE_CUDA_COMPILER_VERSION AND
+       CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0)
+      list(APPEND VLLM_STABLE_EXT_SRC
+        "csrc/libtorch_stable/mamba/gdn_causal_conv1d_sm103.cu")
+      list(APPEND VLLM_GPU_FLAGS "-DVLLM_ENABLE_GDN_CONV_SM103=1")
+      set(VLLM_ENABLE_GDN_CONV_SM103 ON)
+    endif()
+
     SET(CUTLASS_ENABLE_HEADERS_ONLY ON CACHE BOOL "Enable only the header library")
 
     # Set CUTLASS_REVISION. Used for FetchContent. Also fixes some bogus messages when building.
@@ -558,6 +566,14 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
     set_gencode_flags_for_srcs(
       SRCS "${VLLM_STABLE_EXT_SRC}"
       CUDA_ARCHS "${CUDA_ARCHS}")
+
+    if(VLLM_ENABLE_GDN_CONV_SM103)
+      set_property(
+        SOURCE "csrc/libtorch_stable/mamba/gdn_causal_conv1d_sm103.cu"
+        PROPERTY COMPILE_OPTIONS
+        "$<$<COMPILE_LANGUAGE:CUDA>:-gencode>"
+        "$<$<COMPILE_LANGUAGE:CUDA>:arch=compute_103,code=sm_103>")
+    endif()
 
     if(COOPERATIVE_TOPK_ARCHS)
       list(APPEND VLLM_STABLE_EXT_SRC

--- a/benchmarks/kernels/benchmark_gdn_causal_conv1d.py
+++ b/benchmarks/kernels/benchmark_gdn_causal_conv1d.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Benchmark optimized GDN causal-conv paths against the current operator."""
+
+import argparse
+from collections.abc import Callable
+
+import torch
+
+from tests.kernels.mamba.causal_conv1d_contract import ContractCase, build_case
+from vllm.model_executor.layers.mamba.ops.causal_conv1d import (
+    causal_conv1d_fn as official,
+)
+from vllm.model_executor.layers.mamba.ops.gdn_causal_conv1d import (
+    causal_conv1d_fn as optimized,
+)
+from vllm.triton_utils import triton
+
+CASES = (
+    ContractCase(
+        "single_none", (4096,), dim=4096, activation=None, initial_mask=(True,)
+    ),
+    ContractCase(
+        "varlen",
+        (1000, 1200, 896, 1000),
+        dim=4096,
+        initial_mask=(True, False, True, False),
+    ),
+    ContractCase(
+        "fp32",
+        (1024,),
+        dim=2048,
+        dtype=torch.float32,
+        initial_mask=(True,),
+    ),
+    ContractCase("width3", (4096,), dim=4096, width=3, initial_mask=(True,)),
+)
+
+
+def _bench_pair(
+    name: str,
+    official_call: Callable[[], torch.Tensor],
+    optimized_call: Callable[[], torch.Tensor],
+) -> None:
+    official_call()
+    optimized_call()
+    torch.accelerator.synchronize()
+    official_us = (
+        triton.testing.do_bench(official_call, warmup=20, rep=50, return_mode="median")
+        * 1000
+    )
+    optimized_us = (
+        triton.testing.do_bench(optimized_call, warmup=20, rep=50, return_mode="median")
+        * 1000
+    )
+    print(
+        f"{name:16s} official={official_us:8.2f} us "
+        f"optimized={optimized_us:8.2f} us "
+        f"speedup={official_us / optimized_us:5.2f}x"
+    )
+
+
+def _call_contract(fn, inputs):
+    return fn(
+        inputs["x"],
+        inputs["weight"],
+        inputs["bias"],
+        inputs["conv_states"],
+        inputs["query_start_loc"],
+        cache_indices=inputs["cache_indices"],
+        has_initial_state=inputs["has_initial_state"],
+        activation=inputs["activation"],
+    )
+
+
+def benchmark_contract_cases() -> None:
+    for case in CASES:
+        inputs = build_case(case, torch.device("cuda"))
+        _bench_pair(
+            case.name,
+            lambda inputs=inputs: _call_contract(official, inputs),
+            lambda inputs=inputs: _call_contract(optimized, inputs),
+        )
+
+
+def benchmark_production_shape() -> None:
+    torch.manual_seed(0)
+    dim, tokens = 12288, 16384
+    projected = torch.randn(tokens, dim + 8192, device="cuda", dtype=torch.bfloat16)
+    x = projected[:, :dim].T
+    weight = torch.randn(dim, 4, device="cuda", dtype=torch.bfloat16) * 0.1
+    states = torch.randn(2, dim, 3, device="cuda", dtype=torch.bfloat16) * 0.1
+    query_start_loc = torch.tensor([0, tokens], device="cuda", dtype=torch.int32)
+    cache_indices = torch.tensor([1], device="cuda", dtype=torch.int32)
+    has_initial_state = torch.tensor([False], device="cuda")
+
+    def call(fn):
+        return fn(
+            x,
+            weight,
+            None,
+            states,
+            query_start_loc,
+            cache_indices=cache_indices,
+            has_initial_state=has_initial_state,
+        )
+
+    reference = call(official)
+    actual = call(optimized)
+    relative_l2 = torch.linalg.vector_norm(
+        (actual.float() - reference.float()).double()
+    ) / torch.linalg.vector_norm(reference.float().double())
+    print(f"production relative_l2={relative_l2.item():.6g}")
+    _bench_pair(
+        "sm103_production",
+        lambda: call(official),
+        lambda: call(optimized),
+    )
+
+
+def benchmark_apc() -> None:
+    torch.manual_seed(0)
+    dim, tokens, width = 4096, 4096, 4
+    projected = torch.randn(tokens, dim + 64, device="cuda", dtype=torch.bfloat16)
+    x = projected[:, :dim].T
+    weight = torch.randn(dim, width, device="cuda", dtype=torch.bfloat16)
+    bias = torch.randn(dim, device="cuda", dtype=torch.bfloat16)
+    states = torch.randn(
+        8, width - 1, dim, device="cuda", dtype=torch.bfloat16
+    ).transpose(1, 2)
+    query_start_loc = torch.tensor([0, tokens], device="cuda", dtype=torch.int32)
+    cache_indices = torch.tensor([[1, 2, 3, 4]], device="cuda", dtype=torch.int32)
+    has_initial_state = torch.tensor([True], device="cuda")
+    first = torch.tensor([1], device="cuda", dtype=torch.int32)
+    last = torch.tensor([3], device="cuda", dtype=torch.int32)
+    initial = torch.tensor([0], device="cuda", dtype=torch.int32)
+    computed = torch.tensor([0], device="cuda", dtype=torch.int32)
+
+    def call(fn):
+        return fn(
+            x,
+            weight,
+            bias,
+            states,
+            query_start_loc,
+            cache_indices=cache_indices,
+            has_initial_state=has_initial_state,
+            block_idx_first_scheduled_token=first,
+            block_idx_last_scheduled_token=last,
+            initial_state_idx=initial,
+            num_computed_tokens=computed,
+            block_size_to_align=128,
+        )
+
+    _bench_pair("apc", lambda: call(official), lambda: call(optimized))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--production-shape", action="store_true")
+    parser.add_argument("--apc", action="store_true")
+    args = parser.parse_args()
+
+    benchmark_contract_cases()
+    if args.production_shape:
+        benchmark_production_shape()
+    if args.apc:
+        benchmark_apc()
+
+
+if __name__ == "__main__":
+    main()

--- a/csrc/libtorch_stable/mamba/gdn_causal_conv1d_sm103.cu
+++ b/csrc/libtorch_stable/mamba/gdn_causal_conv1d_sm103.cu
@@ -1,0 +1,218 @@
+#include "../torch_utils.h"
+#include "../ops.h"
+
+#include <cuda_bf16.h>
+#include <cuda_pipeline.h>
+
+__device__ __forceinline__ float silu_approx(float x) {
+  float t;
+  asm("tanh.approx.f32 %0,%1;" : "=f"(t) : "f"(0.5f * x));
+  return 0.5f * x * (1.f + t);
+}
+
+template <int V, int BLOCK, int CHUNK, int DEPTH, int MIN_BLOCKS, bool HAS_BIAS>
+__global__ void __launch_bounds__(BLOCK, MIN_BLOCKS)
+    conv_fwd(const __nv_bfloat16* __restrict__ x,
+             const __nv_bfloat16* __restrict__ weight,
+             const __nv_bfloat16* __restrict__ bias,
+             __nv_bfloat16* __restrict__ states,
+             const int* __restrict__ state_indices,
+             const bool* __restrict__ has_initial_state,
+             __nv_bfloat16* __restrict__ output, int dim, int tokens,
+             long stride_x_token, long stride_output_token,
+             long stride_state_seq, long stride_state_dim,
+             long stride_state_token) {
+  using Vec = float2;
+  constexpr int LANES = V / 2;
+  const int channel_groups = dim / V;
+  const int token_chunks = (tokens + CHUNK - 1) / CHUNK;
+  const long linear = static_cast<long>(blockIdx.x) * BLOCK + threadIdx.x;
+  const int channel_group = linear % channel_groups;
+  const int chunk = linear / channel_groups;
+  if (chunk >= token_chunks) return;
+
+  const int channel = channel_group * V;
+  const int token_start = chunk * CHUNK;
+  const int token_end = min(token_start + CHUNK, tokens);
+  const int state_index = state_indices[0];
+  const bool use_initial_state = has_initial_state[0];
+  if (state_index <= 0) return;
+
+  extern __shared__ __nv_bfloat16 ring[];
+  __nv_bfloat16* thread_ring =
+      ring + static_cast<long>(threadIdx.x) * DEPTH * V;
+  __nv_bfloat162 weights[4][LANES];
+  __nv_bfloat162 biases[LANES];
+#pragma unroll
+  for (int lane = 0; lane < LANES; ++lane) {
+#pragma unroll
+    for (int tap = 0; tap < 4; ++tap) {
+      weights[tap][lane] =
+          __halves2bfloat162(weight[(channel + 2 * lane) * 4 + tap],
+                             weight[(channel + 2 * lane + 1) * 4 + tap]);
+    }
+    if constexpr (HAS_BIAS) {
+      biases[lane] = __halves2bfloat162(bias[channel + 2 * lane],
+                                        bias[channel + 2 * lane + 1]);
+    } else {
+      biases[lane] = __float2bfloat162_rn(0.f);
+    }
+  }
+
+  __nv_bfloat162 tap0[LANES], tap1[LANES], tap2[LANES];
+  auto load_x = [&](int token, __nv_bfloat162* destination) {
+    Vec packed = *reinterpret_cast<const Vec*>(
+        x + static_cast<long>(token) * stride_x_token + channel);
+    const auto* halves = reinterpret_cast<const __nv_bfloat162*>(&packed);
+#pragma unroll
+    for (int lane = 0; lane < LANES; ++lane) destination[lane] = halves[lane];
+  };
+  auto load_state = [&](int token, __nv_bfloat162* destination) {
+#pragma unroll
+    for (int lane = 0; lane < LANES; ++lane) {
+      long base = static_cast<long>(state_index) * stride_state_seq +
+                  static_cast<long>(channel + 2 * lane) * stride_state_dim +
+                  static_cast<long>(token) * stride_state_token;
+      destination[lane] =
+          __halves2bfloat162(states[base], states[base + stride_state_dim]);
+    }
+  };
+  auto zero = [&](__nv_bfloat162* destination) {
+#pragma unroll
+    for (int lane = 0; lane < LANES; ++lane) {
+      destination[lane] = __float2bfloat162_rn(0.f);
+    }
+  };
+
+  if (token_start == 0) {
+    if (use_initial_state) {
+      load_state(0, tap0);
+      load_state(1, tap1);
+      load_state(2, tap2);
+    } else {
+      zero(tap0);
+      zero(tap1);
+      zero(tap2);
+    }
+  } else {
+    load_x(token_start - 3, tap0);
+    load_x(token_start - 2, tap1);
+    load_x(token_start - 1, tap2);
+  }
+
+#pragma unroll
+  for (int stage = 0; stage < DEPTH; ++stage) {
+    int token = token_start + stage;
+    if (token < token_end) {
+      __pipeline_memcpy_async(
+          thread_ring + stage * V,
+          x + static_cast<long>(token) * stride_x_token + channel,
+          V * sizeof(__nv_bfloat16));
+    }
+    __pipeline_commit();
+  }
+
+  for (int token = token_start; token < token_end; ++token) {
+    int slot = (token - token_start) % DEPTH;
+    __pipeline_wait_prior(DEPTH - 1);
+    __nv_bfloat162 current[LANES];
+    Vec packed = *reinterpret_cast<const Vec*>(thread_ring + slot * V);
+    const auto* halves = reinterpret_cast<const __nv_bfloat162*>(&packed);
+#pragma unroll
+    for (int lane = 0; lane < LANES; ++lane) current[lane] = halves[lane];
+
+    int next_token = token + DEPTH;
+    if (next_token < token_end) {
+      __pipeline_memcpy_async(
+          thread_ring + slot * V,
+          x + static_cast<long>(next_token) * stride_x_token + channel,
+          V * sizeof(__nv_bfloat16));
+    }
+    __pipeline_commit();
+
+    Vec packed_output;
+    auto* output_halves = reinterpret_cast<__nv_bfloat162*>(&packed_output);
+#pragma unroll
+    for (int lane = 0; lane < LANES; ++lane) {
+      __nv_bfloat162 acc =
+          __hfma2(weights[0][lane], tap0[lane],
+                  __hfma2(weights[1][lane], tap1[lane],
+                          __hfma2(weights[2][lane], tap2[lane],
+                                  __hmul2(weights[3][lane], current[lane]))));
+      acc = __hadd2(acc, biases[lane]);
+      output_halves[lane] =
+          __halves2bfloat162(__float2bfloat16(silu_approx(__low2float(acc))),
+                             __float2bfloat16(silu_approx(__high2float(acc))));
+      tap0[lane] = tap1[lane];
+      tap1[lane] = tap2[lane];
+      tap2[lane] = current[lane];
+    }
+    *reinterpret_cast<Vec*>(
+        output + static_cast<long>(token) * stride_output_token + channel) =
+        packed_output;
+  }
+
+  if (chunk == token_chunks - 1) {
+#pragma unroll
+    for (int state_token = 0; state_token < 3; ++state_token) {
+      int source_token = tokens - 3 + state_token;
+#pragma unroll
+      for (int lane = 0; lane < V; ++lane) {
+        long state_offset =
+            static_cast<long>(state_index) * stride_state_seq +
+            static_cast<long>(channel + lane) * stride_state_dim +
+            static_cast<long>(state_token) * stride_state_token;
+        states[state_offset] =
+            x[static_cast<long>(source_token) * stride_x_token + channel +
+              lane];
+      }
+    }
+  }
+}
+
+torch::stable::Tensor gdn_causal_conv1d_sm103(
+    const torch::stable::Tensor& x, const torch::stable::Tensor& weight,
+    const torch::stable::Tensor& bias, torch::stable::Tensor& states,
+    const torch::stable::Tensor& state_indices,
+    const torch::stable::Tensor& has_initial_state, bool has_bias) {
+  const int dim = static_cast<int>(x.size(0));
+  const int tokens = static_cast<int>(x.size(1));
+  auto output = torch::stable::empty_like(x);
+  constexpr int V = 4;
+  constexpr int BLOCK = 128;
+  constexpr int CHUNK = 64;
+  constexpr int DEPTH = 6;
+  const int64_t threads =
+      static_cast<int64_t>(dim / V) * ((tokens + CHUNK - 1) / CHUNK);
+  const int64_t grid = (threads + BLOCK - 1) / BLOCK;
+  const size_t shared =
+      static_cast<size_t>(BLOCK) * DEPTH * V * sizeof(__nv_bfloat16);
+  const torch::stable::accelerator::DeviceGuard device_guard(
+      x.get_device_index());
+  const cudaStream_t stream = get_current_cuda_stream();
+
+  if (has_bias) {
+    conv_fwd<V, BLOCK, CHUNK, DEPTH, 8, true><<<grid, BLOCK, shared, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x.const_data_ptr()),
+        reinterpret_cast<const __nv_bfloat16*>(weight.const_data_ptr()),
+        reinterpret_cast<const __nv_bfloat16*>(bias.const_data_ptr()),
+        reinterpret_cast<__nv_bfloat16*>(states.mutable_data_ptr()),
+        reinterpret_cast<const int*>(state_indices.const_data_ptr()),
+        reinterpret_cast<const bool*>(has_initial_state.const_data_ptr()),
+        reinterpret_cast<__nv_bfloat16*>(output.mutable_data_ptr()), dim,
+        tokens, x.stride(1), output.stride(1), states.stride(0),
+        states.stride(1), states.stride(2));
+  } else {
+    conv_fwd<V, BLOCK, CHUNK, DEPTH, 8, false><<<grid, BLOCK, shared, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x.const_data_ptr()),
+        reinterpret_cast<const __nv_bfloat16*>(weight.const_data_ptr()),
+        reinterpret_cast<const __nv_bfloat16*>(bias.const_data_ptr()),
+        reinterpret_cast<__nv_bfloat16*>(states.mutable_data_ptr()),
+        reinterpret_cast<const int*>(state_indices.const_data_ptr()),
+        reinterpret_cast<const bool*>(has_initial_state.const_data_ptr()),
+        reinterpret_cast<__nv_bfloat16*>(output.mutable_data_ptr()), dim,
+        tokens, x.stride(1), output.stride(1), states.stride(0),
+        states.stride(1), states.stride(2));
+  }
+  return output;
+}

--- a/csrc/libtorch_stable/ops.h
+++ b/csrc/libtorch_stable/ops.h
@@ -47,6 +47,14 @@ torch::stable::Tensor permute_cols(torch::stable::Tensor const& A,
                                    torch::stable::Tensor const& perm);
 
 #ifndef USE_ROCM
+  #ifdef VLLM_ENABLE_GDN_CONV_SM103
+torch::stable::Tensor gdn_causal_conv1d_sm103(
+    const torch::stable::Tensor& x, const torch::stable::Tensor& weight,
+    const torch::stable::Tensor& bias, torch::stable::Tensor& states,
+    const torch::stable::Tensor& state_indices,
+    const torch::stable::Tensor& has_initial_state, bool has_bias);
+  #endif
+
 bool cutlass_scaled_mm_supports_fp8(int64_t cuda_device_capability);
 bool cutlass_scaled_mm_supports_block_fp8(int64_t cuda_device_capability);
 bool cutlass_group_gemm_supported(int64_t cuda_device_capability);

--- a/csrc/libtorch_stable/torch_bindings.cpp
+++ b/csrc/libtorch_stable/torch_bindings.cpp
@@ -33,6 +33,13 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C, ops) {
 
 #ifndef USE_ROCM
 
+  #ifdef VLLM_ENABLE_GDN_CONV_SM103
+  ops.def(
+      "gdn_causal_conv1d_sm103(Tensor x, Tensor weight, Tensor bias, "
+      "Tensor(a!) states, Tensor state_indices, Tensor has_initial_state, "
+      "bool has_bias) -> Tensor");
+  #endif
+
   // Note about marlin kernel 'workspace' arguments:
   // Technically these should be mutable since they are modified by the kernel.
   // But since they are set back to zero once the kernel is finished we can
@@ -701,6 +708,10 @@ STABLE_TORCH_LIBRARY_IMPL(_C, CUDA, ops) {
   ops.impl("permute_cols", TORCH_BOX(&permute_cols));
 
 #ifndef USE_ROCM
+  #ifdef VLLM_ENABLE_GDN_CONV_SM103
+  ops.impl("gdn_causal_conv1d_sm103", TORCH_BOX(&gdn_causal_conv1d_sm103));
+  #endif
+
   // CUTLASS scaled_mm ops
   ops.impl("cutlass_scaled_mm", TORCH_BOX(&cutlass_scaled_mm));
   ops.impl("cutlass_scaled_mm_azp", TORCH_BOX(&cutlass_scaled_mm_azp));

--- a/tests/kernels/mamba/causal_conv1d_contract.py
+++ b/tests/kernels/mamba/causal_conv1d_contract.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F
+
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
+
+
+@dataclass(frozen=True)
+class ContractCase:
+    name: str
+    lengths: tuple[int, ...]
+    dim: int = 256
+    width: int = 4
+    dtype: torch.dtype = torch.bfloat16
+    activation: str | None = "silu"
+    has_bias: bool = True
+    channel_contiguous: bool = True
+    initial_mask: tuple[bool, ...] | None = None
+    padded_sequences: int = 0
+    family: str = "generic"
+
+    @property
+    def active_sequences(self) -> int:
+        return len(self.lengths) - self.padded_sequences
+
+
+CONTRACT_CASES = (
+    ContractCase("main_bf16_w4", (1024,), initial_mask=(False,), family="fast"),
+    ContractCase("main_bf16_w4_initial", (1024,), initial_mask=(True,), family="fast"),
+    ContractCase("biasless", (127,), has_bias=False, initial_mask=(True,)),
+    ContractCase("activation_none", (127,), activation=None, initial_mask=(True,)),
+    ContractCase("width2", (127,), width=2, initial_mask=(True,)),
+    ContractCase("width3", (127,), width=3, initial_mask=(True,)),
+    ContractCase("width5", (127,), width=5, initial_mask=(True,)),
+    ContractCase("fp32", (127,), dtype=torch.float32, initial_mask=(True,)),
+    ContractCase("shorter_than_state", (2,), width=5, initial_mask=(True,)),
+    ContractCase(
+        "token_contiguous",
+        (127,),
+        channel_contiguous=False,
+        initial_mask=(True,),
+    ),
+    ContractCase(
+        "varlen",
+        (17, 31, 9),
+        initial_mask=(True, False, True),
+        family="varlen",
+    ),
+    ContractCase(
+        "varlen_with_null_padding",
+        (17, 31, 9, 13),
+        initial_mask=(True, False, True, False),
+        padded_sequences=1,
+        family="varlen",
+    ),
+)
+
+REQUIRED_FEATURE_FAMILIES = {
+    "fast",
+    "generic",
+    "varlen",
+    "continuous_batching",
+    "pad_null",
+    "apc_prefix_cache",
+}
+
+
+def build_case(case: ContractCase, device: torch.device) -> dict[str, object]:
+    torch.manual_seed(0)
+    total_tokens = sum(case.lengths)
+    if case.channel_contiguous:
+        backing = torch.randn(
+            total_tokens,
+            case.dim + 64,
+            dtype=case.dtype,
+            device=device,
+        )
+        x = backing[:, : case.dim].transpose(0, 1)
+    else:
+        x = torch.randn(
+            case.dim, total_tokens, dtype=case.dtype, device=device
+        ).contiguous()
+
+    weight = torch.randn(case.dim, case.width, dtype=case.dtype, device=device)
+    bias = (
+        torch.randn(case.dim, dtype=case.dtype, device=device)
+        if case.has_bias
+        else None
+    )
+    pool_size = case.active_sequences + 4
+    states = torch.randn(
+        pool_size,
+        case.width - 1,
+        case.dim,
+        dtype=case.dtype,
+        device=device,
+    ).transpose(1, 2)
+    active_indices = torch.arange(
+        1, case.active_sequences + 1, dtype=torch.int32, device=device
+    )
+    if case.padded_sequences:
+        padding = torch.full(
+            (case.padded_sequences,),
+            NULL_BLOCK_ID,
+            dtype=torch.int32,
+            device=device,
+        )
+        indices = torch.cat((active_indices, padding))
+    else:
+        indices = active_indices
+
+    initial_mask = case.initial_mask or tuple(False for _ in case.lengths)
+    has_initial_state = torch.tensor(initial_mask, dtype=torch.bool, device=device)
+    query_start_loc = torch.tensor(
+        (0, *torch.tensor(case.lengths).cumsum(0).tolist()),
+        dtype=torch.int32,
+        device=device,
+    )
+    return {
+        "x": x,
+        "weight": weight,
+        "bias": bias,
+        "conv_states": states,
+        "query_start_loc": query_start_loc,
+        "cache_indices": indices,
+        "has_initial_state": has_initial_state,
+        "activation": case.activation,
+    }
+
+
+def reference_output_and_state(
+    case: ContractCase, inputs: dict[str, object]
+) -> tuple[torch.Tensor, torch.Tensor]:
+    x = inputs["x"]
+    weight = inputs["weight"]
+    bias = inputs["bias"]
+    states = inputs["conv_states"]
+    indices = inputs["cache_indices"]
+    has_initial_state = inputs["has_initial_state"]
+    assert isinstance(x, torch.Tensor)
+    assert isinstance(weight, torch.Tensor)
+    assert bias is None or isinstance(bias, torch.Tensor)
+    assert isinstance(states, torch.Tensor)
+    states = states.clone()
+    assert isinstance(indices, torch.Tensor)
+    assert isinstance(has_initial_state, torch.Tensor)
+
+    outputs: list[torch.Tensor] = []
+    token_offset = 0
+    state_len = case.width - 1
+    for sequence, length in enumerate(case.lengths):
+        sequence_x = x[:, token_offset : token_offset + length]
+        token_offset += length
+        state_index = int(indices[sequence].item())
+        if state_index == NULL_BLOCK_ID:
+            continue
+        initial = (
+            states[state_index]
+            if bool(has_initial_state[sequence].item())
+            else torch.zeros_like(states[state_index])
+        )
+        full_input = torch.cat((initial, sequence_x), dim=1)
+        output = F.conv1d(
+            full_input.unsqueeze(0).float(),
+            weight.unsqueeze(1).float(),
+            bias.float() if bias is not None else None,
+            groups=case.dim,
+        ).squeeze(0)
+        if case.activation in ("silu", "swish"):
+            output = F.silu(output)
+        outputs.append(output.to(case.dtype))
+        states[state_index] = full_input[:, -state_len:]
+
+    return torch.cat(outputs, dim=1), states
+
+
+def active_output(case: ContractCase, output: torch.Tensor) -> torch.Tensor:
+    if case.padded_sequences == 0:
+        return output
+    active_tokens = sum(case.lengths[: case.active_sequences])
+    return output[:, :active_tokens]

--- a/tests/kernels/mamba/test_gdn_causal_conv1d_apc.py
+++ b/tests/kernels/mamba/test_gdn_causal_conv1d_apc.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.mamba.ops.causal_conv1d import (
+    causal_conv1d_fn as official_causal_conv1d_fn,
+)
+from vllm.model_executor.layers.mamba.ops.gdn_causal_conv1d import (
+    causal_conv1d_fn as replacement_causal_conv1d_fn,
+)
+
+
+@pytest.mark.parametrize("has_initial", [False, True])
+@pytest.mark.parametrize(
+    "tokens,computed,first,last,block_size",
+    [(1024, 0, 1, 3, 128), (1021, 3, 1, 2, 128)],
+)
+def test_apc_output_and_all_cache_writes_match_official(
+    has_initial: bool,
+    tokens: int,
+    computed: int,
+    first: int,
+    last: int,
+    block_size: int,
+) -> None:
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    dim = 256
+    width = 4
+    backing = torch.randn(tokens, dim + 64, device=device, dtype=torch.bfloat16)
+    x = backing[:, :dim].transpose(0, 1)
+    weight = torch.randn(dim, width, device=device, dtype=torch.bfloat16)
+    bias = torch.randn(dim, device=device, dtype=torch.bfloat16)
+    states = torch.randn(8, width - 1, dim, device=device, dtype=torch.bfloat16)
+    states = states.transpose(1, 2)
+    cache_indices = torch.tensor([[1, 2, 3, 4]], device=device, dtype=torch.int32)
+    query_start_loc = torch.tensor([0, tokens], device=device, dtype=torch.int32)
+    has_initial_state = torch.tensor([has_initial], device=device)
+    first_tensor = torch.tensor([first], device=device, dtype=torch.int32)
+    last_tensor = torch.tensor([last], device=device, dtype=torch.int32)
+    initial_state_idx = torch.tensor([0], device=device, dtype=torch.int32)
+    num_computed_tokens = torch.tensor([computed], device=device, dtype=torch.int32)
+
+    def run(fn, state_pool):
+        return fn(
+            x,
+            weight,
+            bias,
+            state_pool,
+            query_start_loc,
+            cache_indices=cache_indices,
+            has_initial_state=has_initial_state,
+            activation="silu",
+            block_idx_first_scheduled_token=first_tensor,
+            block_idx_last_scheduled_token=last_tensor,
+            initial_state_idx=initial_state_idx,
+            num_computed_tokens=num_computed_tokens,
+            block_size_to_align=block_size,
+        )
+
+    official_states = states.clone()
+    expected = run(official_causal_conv1d_fn, official_states)
+    replacement_states = states.clone()
+    actual = run(replacement_causal_conv1d_fn, replacement_states)
+
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=5e-2)
+    torch.testing.assert_close(replacement_states, official_states, rtol=0, atol=0)
+
+
+def test_apc_multi_sequence_cache_rows_match_official() -> None:
+    torch.manual_seed(1)
+    device = torch.device("cuda")
+    dim = 256
+    width = 4
+    lengths = (512, 512)
+    total_tokens = sum(lengths)
+    x = torch.randn(total_tokens, dim + 64, device=device, dtype=torch.bfloat16)
+    x = x[:, :dim].transpose(0, 1)
+    weight = torch.randn(dim, width, device=device, dtype=torch.bfloat16)
+    states = torch.randn(12, width - 1, dim, device=device, dtype=torch.bfloat16)
+    states = states.transpose(1, 2)
+    query_start_loc = torch.tensor([0, 512, 1024], device=device, dtype=torch.int32)
+    cache_indices = torch.tensor(
+        [[1, 2, 3, 4], [5, 6, 7, 8]], device=device, dtype=torch.int32
+    )
+    has_initial_state = torch.tensor([True, False], device=device)
+    first = torch.tensor([1, 1], device=device, dtype=torch.int32)
+    last = torch.tensor([3, 2], device=device, dtype=torch.int32)
+    initial = torch.tensor([0, 0], device=device, dtype=torch.int32)
+    computed = torch.tensor([0, 3], device=device, dtype=torch.int32)
+
+    def run(fn, state_pool):
+        return fn(
+            x,
+            weight,
+            None,
+            state_pool,
+            query_start_loc,
+            cache_indices=cache_indices,
+            has_initial_state=has_initial_state,
+            activation=None,
+            block_idx_first_scheduled_token=first,
+            block_idx_last_scheduled_token=last,
+            initial_state_idx=initial,
+            num_computed_tokens=computed,
+            block_size_to_align=128,
+        )
+
+    official_states = states.clone()
+    expected = run(official_causal_conv1d_fn, official_states)
+    replacement_states = states.clone()
+    actual = run(replacement_causal_conv1d_fn, replacement_states)
+
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=5e-2)
+    torch.testing.assert_close(replacement_states, official_states, rtol=0, atol=0)

--- a/tests/kernels/mamba/test_gdn_causal_conv1d_contract.py
+++ b/tests/kernels/mamba/test_gdn_causal_conv1d_contract.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.mamba.ops.causal_conv1d import (
+    causal_conv1d_fn as official_causal_conv1d_fn,
+)
+from vllm.model_executor.layers.mamba.ops.gdn_causal_conv1d import (
+    causal_conv1d_fn,
+)
+
+from .causal_conv1d_contract import (
+    CONTRACT_CASES,
+    REQUIRED_FEATURE_FAMILIES,
+    ContractCase,
+    active_output,
+    build_case,
+    reference_output_and_state,
+)
+
+
+def tolerances(dtype: torch.dtype) -> tuple[float, float]:
+    if dtype == torch.bfloat16:
+        return 1e-2, 5e-2
+    return 3e-4, 1e-3
+
+
+@pytest.mark.parametrize("case", CONTRACT_CASES, ids=lambda case: case.name)
+def test_official_operator_matches_contract_reference(case: ContractCase) -> None:
+    if case.width == 5:
+        pytest.xfail(
+            "official prefill kernel has width-5 branches but fails its PyTorch "
+            "reference; the replacement must implement the intended semantics"
+        )
+    inputs = build_case(case, torch.device("cuda"))
+    expected_output, expected_states = reference_output_and_state(case, inputs)
+    actual_states = inputs["conv_states"]
+    assert isinstance(actual_states, torch.Tensor)
+    actual_states = actual_states.clone()
+    actual = official_causal_conv1d_fn(
+        inputs["x"],
+        inputs["weight"],
+        inputs["bias"],
+        actual_states,
+        inputs["query_start_loc"],
+        cache_indices=inputs["cache_indices"],
+        has_initial_state=inputs["has_initial_state"],
+        activation=inputs["activation"],
+    )
+    rtol, atol = tolerances(case.dtype)
+    torch.testing.assert_close(
+        active_output(case, actual), expected_output, rtol=rtol, atol=atol
+    )
+    torch.testing.assert_close(actual_states, expected_states, rtol=rtol, atol=atol)
+
+
+@pytest.mark.parametrize("case", CONTRACT_CASES, ids=lambda case: case.name)
+def test_current_replacement_against_contract(case: ContractCase) -> None:
+    if case.width == 5:
+        pytest.xfail("width-5 inputs retain the existing official fallback")
+    inputs = build_case(case, torch.device("cuda"))
+    expected_output, expected_states = reference_output_and_state(case, inputs)
+    actual_states = inputs["conv_states"]
+    assert isinstance(actual_states, torch.Tensor)
+    actual_states = actual_states.clone()
+    actual = causal_conv1d_fn(
+        inputs["x"],
+        inputs["weight"],
+        inputs["bias"],
+        actual_states,
+        inputs["query_start_loc"],
+        cache_indices=inputs["cache_indices"],
+        has_initial_state=inputs["has_initial_state"],
+        activation=inputs["activation"],
+    )
+    rtol, atol = tolerances(case.dtype)
+    torch.testing.assert_close(
+        active_output(case, actual), expected_output, rtol=rtol, atol=atol
+    )
+    torch.testing.assert_close(actual_states, expected_states, rtol=rtol, atol=atol)
+
+
+def test_contract_tracks_all_required_feature_families() -> None:
+    represented = {case.family for case in CONTRACT_CASES}
+    implemented_later = {
+        "continuous_batching",
+        "pad_null",
+        "apc_prefix_cache",
+    }
+    assert represented | implemented_later == REQUIRED_FEATURE_FAMILIES

--- a/tests/kernels/mamba/test_gdn_causal_conv1d_contract.py
+++ b/tests/kernels/mamba/test_gdn_causal_conv1d_contract.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from typing import cast
+
 import pytest
 import torch
 
@@ -47,7 +49,7 @@ def test_official_operator_matches_contract_reference(case: ContractCase) -> Non
         inputs["query_start_loc"],
         cache_indices=inputs["cache_indices"],
         has_initial_state=inputs["has_initial_state"],
-        activation=inputs["activation"],
+        activation=cast(str | None, inputs["activation"]),
     )
     rtol, atol = tolerances(case.dtype)
     torch.testing.assert_close(
@@ -73,7 +75,7 @@ def test_current_replacement_against_contract(case: ContractCase) -> None:
         inputs["query_start_loc"],
         cache_indices=inputs["cache_indices"],
         has_initial_state=inputs["has_initial_state"],
-        activation=inputs["activation"],
+        activation=cast(str | None, inputs["activation"]),
     )
     rtol, atol = tolerances(case.dtype)
     torch.testing.assert_close(

--- a/tests/kernels/mamba/test_gdn_causal_conv1d_fast.py
+++ b/tests/kernels/mamba/test_gdn_causal_conv1d_fast.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from vllm.model_executor.layers.mamba.ops.gdn_causal_conv1d import (
+    fast_causal_conv1d,
+)
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() != (10, 3),
+    reason="SM103 causal-conv specialization requires compute capability 10.3",
+)
+
+
+@pytest.mark.parametrize("has_bias", [False, True])
+@pytest.mark.parametrize("has_initial", [False, True])
+@pytest.mark.parametrize("tokens,dim", [(256, 4096), (8192, 12288)])
+def test_fast_causal_conv_matches_stock_and_state(
+    has_bias: bool, has_initial: bool, tokens: int, dim: int
+) -> None:
+    torch.manual_seed(0)
+    projected = (
+        torch.randn(tokens, dim + 8192, device="cuda", dtype=torch.bfloat16) * 0.1
+    )
+    x = projected[:, :dim].transpose(0, 1)
+    weight = torch.randn(dim, 4, device="cuda", dtype=torch.bfloat16) * 0.1
+    bias = (
+        torch.randn(dim, device="cuda", dtype=torch.bfloat16) * 0.1
+        if has_bias
+        else None
+    )
+    state = (
+        torch.randn(2, 3, dim, device="cuda", dtype=torch.bfloat16) * 0.1
+    ).transpose(1, 2)
+    indices = torch.tensor([1], device="cuda", dtype=torch.int32)
+    has_initial_state = torch.tensor([has_initial], device="cuda")
+
+    prefix = state[1] if has_initial else torch.zeros_like(state[1])
+    sequence = torch.cat((prefix, x), dim=1).unsqueeze(0).float()
+    expected = (
+        F.silu(
+            F.conv1d(
+                sequence,
+                weight.unsqueeze(1).float(),
+                bias.float() if bias is not None else None,
+                groups=dim,
+            )
+        )
+        .squeeze(0)
+        .to(torch.bfloat16)
+    )
+    expected_state = state.clone()
+    expected_state[1] = x[:, -3:]
+    actual_state = state.clone()
+    actual = fast_causal_conv1d(
+        x, weight, bias, actual_state, indices, has_initial_state
+    )
+
+    assert actual is not None
+    diff = actual.float() - expected.float()
+    rel_l2 = torch.linalg.vector_norm(diff) / torch.linalg.vector_norm(expected.float())
+    assert rel_l2.item() <= 1e-2
+    torch.testing.assert_close(actual_state, expected_state, atol=0, rtol=0)
+
+
+def test_fast_causal_conv_preserves_null_state_slot() -> None:
+    x = torch.empty(256, 4096, device="cuda", dtype=torch.bfloat16).T
+    weight = torch.empty(4096, 4, device="cuda", dtype=torch.bfloat16)
+    state = torch.randn(1, 4096, 3, device="cuda", dtype=torch.bfloat16)
+    expected_state = state.clone()
+    indices = torch.tensor([0], device="cuda", dtype=torch.int32)
+    has_initial_state = torch.tensor([False], device="cuda")
+
+    fast_causal_conv1d(x, weight, None, state, indices, has_initial_state)
+    torch.accelerator.synchronize()
+
+    torch.testing.assert_close(state, expected_state, atol=0, rtol=0)
+
+
+def test_fast_causal_conv_rejects_token_contiguous_input() -> None:
+    x = torch.empty(4096, 256, device="cuda", dtype=torch.bfloat16).contiguous()
+    weight = torch.empty(4096, 4, device="cuda", dtype=torch.bfloat16)
+    bias = torch.empty(4096, device="cuda", dtype=torch.bfloat16)
+    state = torch.empty(2, 4096, 3, device="cuda", dtype=torch.bfloat16)
+    indices = torch.tensor([1], device="cuda", dtype=torch.int32)
+    has_initial_state = torch.tensor([False], device="cuda")
+
+    assert (
+        fast_causal_conv1d(x, weight, bias, state, indices, has_initial_state) is None
+    )

--- a/tests/kernels/mamba/test_gdn_causal_conv1d_fast.py
+++ b/tests/kernels/mamba/test_gdn_causal_conv1d_fast.py
@@ -80,6 +80,56 @@ def test_fast_causal_conv_preserves_null_state_slot() -> None:
     torch.testing.assert_close(state, expected_state, atol=0, rtol=0)
 
 
+def test_fast_causal_conv_rejects_misaligned_token_stride(monkeypatch) -> None:
+    dim, tokens = 4096, 256
+    backing = torch.empty(tokens, dim + 1, device="cuda", dtype=torch.bfloat16)
+    x = backing[:, :dim].T
+    weight = torch.empty(dim, 4, device="cuda", dtype=torch.bfloat16)
+    state = torch.empty(2, dim, 3, device="cuda", dtype=torch.bfloat16)
+    indices = torch.tensor([1], device="cuda", dtype=torch.int32)
+    has_initial_state = torch.tensor([False], device="cuda")
+    called = False
+
+    def fail_if_called(*args, **kwargs):
+        nonlocal called
+        called = True
+        return torch.empty_like(x)
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.mamba.ops.gdn_causal_conv1d.ops."
+        "gdn_causal_conv1d_sm103",
+        fail_if_called,
+    )
+
+    assert x.stride(1) % 4 != 0
+    assert (
+        fast_causal_conv1d(x, weight, None, state, indices, has_initial_state) is None
+    )
+    assert not called
+
+
+def test_fast_causal_conv_rejects_cpu_input(monkeypatch) -> None:
+    from vllm.model_executor.layers.mamba.ops import gdn_causal_conv1d
+
+    monkeypatch.setattr(gdn_causal_conv1d, "_IS_SM103", True)
+    monkeypatch.setattr(gdn_causal_conv1d, "_HAS_SM103_KERNEL", True)
+    monkeypatch.setattr(
+        gdn_causal_conv1d.ops,
+        "gdn_causal_conv1d_sm103",
+        lambda *args, **kwargs: torch.empty_like(args[0]),
+    )
+    dim, tokens = 4096, 256
+    x = torch.empty(tokens, dim, dtype=torch.bfloat16).T
+    weight = torch.empty(dim, 4, dtype=torch.bfloat16)
+    state = torch.empty(2, dim, 3, dtype=torch.bfloat16)
+    indices = torch.tensor([1], dtype=torch.int32)
+    has_initial_state = torch.tensor([False])
+
+    assert (
+        fast_causal_conv1d(x, weight, None, state, indices, has_initial_state) is None
+    )
+
+
 def test_fast_causal_conv_rejects_token_contiguous_input() -> None:
     x = torch.empty(4096, 256, device="cuda", dtype=torch.bfloat16).contiguous()
     weight = torch.empty(4096, 4, device="cuda", dtype=torch.bfloat16)

--- a/tests/kernels/mamba/test_gdn_causal_conv1d_interface.py
+++ b/tests/kernels/mamba/test_gdn_causal_conv1d_interface.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import inspect
+from unittest.mock import patch
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from vllm.model_executor.layers.mamba.ops import gdn_causal_conv1d
+from vllm.model_executor.layers.mamba.ops.causal_conv1d import (
+    causal_conv1d_fn as official_causal_conv1d_fn,
+)
+from vllm.model_executor.layers.mamba.ops.gdn_causal_conv1d import (
+    causal_conv1d_fn,
+)
+
+from .causal_conv1d_contract import (
+    CONTRACT_CASES,
+    ContractCase,
+    build_case,
+    reference_output_and_state,
+)
+
+
+def test_replacement_interface_matches_official_parameters() -> None:
+    official = inspect.signature(official_causal_conv1d_fn)
+    replacement = inspect.signature(causal_conv1d_fn)
+    assert tuple(replacement.parameters) == tuple(official.parameters)
+    for name, parameter in official.parameters.items():
+        assert replacement.parameters[name].default == parameter.default
+
+
+def test_short_prefill_uses_official_fallback() -> None:
+    case = next(case for case in CONTRACT_CASES if case.name == "activation_none")
+    inputs = build_case(case, torch.device("cuda"))
+    with patch.object(
+        gdn_causal_conv1d,
+        "official_causal_conv1d_fn",
+        wraps=official_causal_conv1d_fn,
+    ) as fallback:
+        causal_conv1d_fn(
+            inputs["x"],
+            inputs["weight"],
+            inputs["bias"],
+            inputs["conv_states"],
+            inputs["query_start_loc"],
+            cache_indices=inputs["cache_indices"],
+            has_initial_state=inputs["has_initial_state"],
+            activation=inputs["activation"],
+        )
+    fallback.assert_called_once()
+
+
+def test_replacement_interface_runs_current_fast_variant() -> None:
+    case = next(case for case in CONTRACT_CASES if case.name == "main_bf16_w4")
+    inputs = build_case(case, torch.device("cuda"))
+    expected_output, expected_states = reference_output_and_state(case, inputs)
+    actual_states = inputs["conv_states"]
+    assert isinstance(actual_states, torch.Tensor)
+    actual_states = actual_states.clone()
+
+    actual = causal_conv1d_fn(
+        inputs["x"],
+        inputs["weight"],
+        inputs["bias"],
+        actual_states,
+        inputs["query_start_loc"],
+        cache_indices=inputs["cache_indices"],
+        has_initial_state=inputs["has_initial_state"],
+        activation=inputs["activation"],
+    )
+
+    torch.testing.assert_close(actual, expected_output, rtol=1e-2, atol=5e-2)
+    torch.testing.assert_close(actual_states, expected_states, rtol=0, atol=0)
+
+
+def test_replacement_preserves_input_dtype_with_bf16_cache() -> None:
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    dim = 128
+    tokens = 31
+    x = torch.randn(tokens, dim, device=device, dtype=torch.float32).transpose(0, 1)
+    weight = torch.randn(dim, 4, device=device, dtype=torch.bfloat16)
+    states = torch.randn(2, 3, dim, device=device, dtype=torch.bfloat16).transpose(1, 2)
+    indices = torch.tensor([1], device=device, dtype=torch.int32)
+    has_initial = torch.tensor([True], device=device)
+    query_start = torch.tensor([0, tokens], device=device, dtype=torch.int32)
+
+    x_bf16 = x.to(torch.bfloat16)
+    full_input = torch.cat((states[1], x_bf16), dim=1)
+    expected = (
+        F.silu(
+            F.conv1d(
+                full_input.unsqueeze(0).float(),
+                weight.unsqueeze(1).float(),
+                groups=dim,
+            )
+        )
+        .squeeze(0)
+        .to(torch.bfloat16)
+        .float()
+    )
+    expected_states = states.clone()
+    expected_states[1] = full_input[:, -3:]
+    actual_states = states.clone()
+    actual = causal_conv1d_fn(
+        x,
+        weight,
+        None,
+        actual_states,
+        query_start,
+        cache_indices=indices,
+        has_initial_state=has_initial,
+    )
+
+    assert actual.dtype == torch.float32
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=5e-2)
+    torch.testing.assert_close(actual_states, expected_states, rtol=0, atol=0)
+
+
+def test_replacement_validate_data_rejects_unsupported_layout() -> None:
+    base = torch.empty(64, 64, device="cuda", dtype=torch.bfloat16)
+    x = base[::2, ::2]
+    weight = torch.empty(32, 4, device="cuda", dtype=torch.bfloat16)
+    states = torch.empty(1, 32, 3, device="cuda", dtype=torch.bfloat16)
+    query_start = torch.tensor([0, 32], device="cuda", dtype=torch.int32)
+    with pytest.raises(AssertionError):
+        causal_conv1d_fn(
+            x,
+            weight,
+            None,
+            states,
+            query_start,
+            validate_data=True,
+        )
+
+
+def test_replacement_interface_runs_generic_variant() -> None:
+    case = ContractCase(
+        "long_activation_none",
+        (1024,),
+        activation=None,
+        initial_mask=(True,),
+    )
+    inputs = build_case(case, torch.device("cuda"))
+    expected_output, expected_states = reference_output_and_state(case, inputs)
+    actual_states = inputs["conv_states"]
+    assert isinstance(actual_states, torch.Tensor)
+    actual_states = actual_states.clone()
+    actual = causal_conv1d_fn(
+        inputs["x"],
+        inputs["weight"],
+        inputs["bias"],
+        actual_states,
+        inputs["query_start_loc"],
+        cache_indices=inputs["cache_indices"],
+        has_initial_state=inputs["has_initial_state"],
+        activation=inputs["activation"],
+    )
+    torch.testing.assert_close(actual, expected_output, rtol=1e-2, atol=5e-2)
+    torch.testing.assert_close(actual_states, expected_states, rtol=0, atol=0)

--- a/tests/kernels/mamba/test_gdn_causal_conv1d_interface.py
+++ b/tests/kernels/mamba/test_gdn_causal_conv1d_interface.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import inspect
+from typing import cast
 from unittest.mock import patch
 
 import pytest
@@ -48,7 +49,7 @@ def test_short_prefill_uses_official_fallback() -> None:
             inputs["query_start_loc"],
             cache_indices=inputs["cache_indices"],
             has_initial_state=inputs["has_initial_state"],
-            activation=inputs["activation"],
+            activation=cast(str | None, inputs["activation"]),
         )
     fallback.assert_called_once()
 
@@ -69,7 +70,7 @@ def test_replacement_interface_runs_current_fast_variant() -> None:
         inputs["query_start_loc"],
         cache_indices=inputs["cache_indices"],
         has_initial_state=inputs["has_initial_state"],
-        activation=inputs["activation"],
+        activation=cast(str | None, inputs["activation"]),
     )
 
     torch.testing.assert_close(actual, expected_output, rtol=1e-2, atol=5e-2)
@@ -137,6 +138,41 @@ def test_replacement_validate_data_rejects_unsupported_layout() -> None:
         )
 
 
+def test_long_cpu_input_uses_official_fallback(monkeypatch) -> None:
+    dim, tokens = 128, 1024
+    x = torch.empty(tokens, dim, dtype=torch.bfloat16).T
+    weight = torch.empty(dim, 4, dtype=torch.bfloat16)
+    states = torch.empty(2, dim, 3, dtype=torch.bfloat16)
+    query_start = torch.tensor([0, tokens], dtype=torch.int32)
+    indices = torch.tensor([1], dtype=torch.int32)
+    has_initial = torch.tensor([False])
+    expected = torch.empty_like(x)
+
+    monkeypatch.setattr(gdn_causal_conv1d, "_IS_SM103", True)
+    monkeypatch.setattr(
+        gdn_causal_conv1d,
+        "generic_causal_conv1d",
+        lambda *args, **kwargs: pytest.fail("CPU input reached the Triton path"),
+    )
+    with patch.object(
+        gdn_causal_conv1d,
+        "official_causal_conv1d_fn",
+        return_value=expected,
+    ) as fallback:
+        actual = causal_conv1d_fn(
+            x,
+            weight,
+            None,
+            states,
+            query_start,
+            cache_indices=indices,
+            has_initial_state=has_initial,
+        )
+
+    assert actual is expected
+    fallback.assert_called_once()
+
+
 def test_replacement_interface_runs_generic_variant() -> None:
     case = ContractCase(
         "long_activation_none",
@@ -157,7 +193,7 @@ def test_replacement_interface_runs_generic_variant() -> None:
         inputs["query_start_loc"],
         cache_indices=inputs["cache_indices"],
         has_initial_state=inputs["has_initial_state"],
-        activation=inputs["activation"],
+        activation=cast(str | None, inputs["activation"]),
     )
     torch.testing.assert_close(actual, expected_output, rtol=1e-2, atol=5e-2)
     torch.testing.assert_close(actual_states, expected_states, rtol=0, atol=0)

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2070,6 +2070,41 @@ def selective_scan_fwd(
     )
 
 
+if hasattr(torch.ops, "_C") and hasattr(torch.ops._C, "gdn_causal_conv1d_sm103"):
+
+    @register_fake("_C::gdn_causal_conv1d_sm103")
+    def _gdn_causal_conv1d_sm103_fake(
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor,
+        states: torch.Tensor,
+        state_indices: torch.Tensor,
+        has_initial_state: torch.Tensor,
+        has_bias: bool,
+    ) -> torch.Tensor:
+        return torch.empty_like(x)
+
+
+def gdn_causal_conv1d_sm103(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    states: torch.Tensor,
+    state_indices: torch.Tensor,
+    has_initial_state: torch.Tensor,
+    has_bias: bool,
+) -> torch.Tensor:
+    return torch.ops._C.gdn_causal_conv1d_sm103(
+        x,
+        weight,
+        bias,
+        states,
+        state_indices,
+        has_initial_state,
+        has_bias,
+    )
+
+
 def causal_conv1d_update_cpu_vec(
     x: torch.Tensor,
     conv_state: torch.Tensor,

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -32,9 +32,9 @@ from vllm.model_executor.layers.mamba.mamba_utils import (
     MambaStateShapeCalculator,
     is_conv_state_dim_first,
 )
-from vllm.model_executor.layers.mamba.ops.causal_conv1d import (
+from vllm.model_executor.layers.mamba.ops.causal_conv1d import causal_conv1d_update
+from vllm.model_executor.layers.mamba.ops.gdn_causal_conv1d import (
     causal_conv1d_fn,
-    causal_conv1d_update,
 )
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.quantization.auto_awq import AutoAWQConfig

--- a/vllm/model_executor/layers/mamba/ops/gdn_causal_conv1d.py
+++ b/vllm/model_executor/layers/mamba/ops/gdn_causal_conv1d.py
@@ -1,0 +1,225 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+import vllm._custom_ops as ops
+from vllm.model_executor.layers.mamba.ops.causal_conv1d import (
+    causal_conv1d_fn as official_causal_conv1d_fn,
+)
+from vllm.model_executor.layers.mamba.ops.gdn_causal_conv1d_apc import (
+    apc_causal_conv1d,
+)
+from vllm.model_executor.layers.mamba.ops.gdn_causal_conv1d_generic import (
+    generic_causal_conv1d,
+)
+from vllm.platforms import current_platform
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID, PAD_SLOT_ID
+
+_IS_SM103 = current_platform.get_device_capability() == (10, 3)
+_HAS_SM103_KERNEL = hasattr(torch.ops, "_C") and hasattr(
+    torch.ops._C, "gdn_causal_conv1d_sm103"
+)
+
+
+def fast_causal_conv1d(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    conv_states: torch.Tensor,
+    cache_indices: torch.Tensor,
+    has_initial_state: torch.Tensor,
+) -> torch.Tensor | None:
+    """Run the guarded SM103 single-sequence kernel, or return ``None``."""
+    eligible = (
+        _IS_SM103
+        and _HAS_SM103_KERNEL
+        and x.dtype == torch.bfloat16
+        and x.ndim == 2
+        and x.stride(0) == 1
+        and x.stride(1) >= x.shape[0]
+        and x.storage_offset() % 4 == 0
+        and x.shape[0] % 4 == 0
+        and x.shape[1] >= 3
+        and weight.dtype == x.dtype
+        and weight.device == x.device
+        and weight.shape == (x.shape[0], 4)
+        and weight.stride(1) == 1
+        and (
+            bias is None
+            or (
+                bias.dtype == x.dtype
+                and bias.device == x.device
+                and bias.shape == (x.shape[0],)
+                and bias.stride(0) == 1
+            )
+        )
+        and conv_states.dtype == x.dtype
+        and conv_states.device == x.device
+        and conv_states.ndim == 3
+        and conv_states.shape[1:] == (x.shape[0], 3)
+        and cache_indices.dtype == torch.int32
+        and cache_indices.device == x.device
+        and cache_indices.numel() == 1
+        and has_initial_state.dtype == torch.bool
+        and has_initial_state.device == x.device
+        and has_initial_state.numel() == 1
+    )
+    if not eligible:
+        return None
+    has_bias = bias is not None
+    bias_arg = (
+        bias if bias is not None else torch.empty(1, device=x.device, dtype=x.dtype)
+    )
+    return ops.gdn_causal_conv1d_sm103(
+        x,
+        weight,
+        bias_arg,
+        conv_states,
+        cache_indices,
+        has_initial_state,
+        has_bias,
+    )
+
+
+def causal_conv1d_fn(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    conv_states: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    cache_indices: torch.Tensor | None = None,
+    has_initial_state: torch.Tensor | None = None,
+    activation: str | None = "silu",
+    pad_slot_id: int = PAD_SLOT_ID,
+    null_block_id: int = NULL_BLOCK_ID,
+    block_idx_first_scheduled_token: torch.Tensor | None = None,
+    block_idx_last_scheduled_token: torch.Tensor | None = None,
+    initial_state_idx: torch.Tensor | None = None,
+    num_computed_tokens: torch.Tensor | None = None,
+    block_size_to_align=0,
+    metadata=None,
+    validate_data=False,
+):
+    """Dispatch profitable long GDN prefills to optimized kernels."""
+    if isinstance(activation, bool) and activation:
+        activation = "silu"
+
+    if validate_data:
+        assert x.dim() == 2
+        assert query_start_loc.dim() == 1
+        assert x.stride(0) == 1 or x.stride(1) == 1
+        if bias is not None:
+            assert bias.dim() == 1 and bias.size(0) == x.size(0)
+        if cache_indices is not None:
+            assert cache_indices.dim() in (1, 2)
+        if has_initial_state is not None:
+            assert has_initial_state.size(0) == query_start_loc.size(0) - 1
+        assert weight.stride(1) == 1
+        assert weight.size(0) == x.size(0)
+        if block_size_to_align is not None and block_size_to_align > 0:
+            assert block_size_to_align % 8 == 0
+
+    original_x_dtype = x.dtype
+    conv_x = x.to(conv_states.dtype)
+    simple = (
+        cache_indices is not None
+        and has_initial_state is not None
+        and query_start_loc.numel() == 2
+        and block_idx_first_scheduled_token is None
+        and block_idx_last_scheduled_token is None
+        and activation in ("silu", "swish")
+        and conv_x.shape[1] >= 1024
+    )
+    if simple:
+        output = fast_causal_conv1d(
+            conv_x,
+            weight,
+            bias,
+            conv_states,
+            cache_indices,
+            has_initial_state,
+        )
+        if output is not None:
+            return output.to(original_x_dtype)
+
+    apc_requested = any(
+        value is not None
+        for value in (
+            block_idx_first_scheduled_token,
+            block_idx_last_scheduled_token,
+            initial_state_idx,
+            num_computed_tokens,
+        )
+    )
+    batch = query_start_loc.numel() - 1
+    use_tiled = (
+        _IS_SM103
+        and conv_x.shape[1] >= 1024
+        and conv_x.shape[0] <= 4096
+        and batch <= 32
+        and conv_x.shape[1] // max(batch, 1) >= 128
+    )
+    if not apc_requested and use_tiled:
+        generated_cache_indices = cache_indices is None
+        if cache_indices is None:
+            cache_indices = torch.arange(batch, dtype=torch.int32, device=x.device)
+        if has_initial_state is None:
+            has_initial_state = torch.zeros(batch, dtype=torch.bool, device=x.device)
+        return generic_causal_conv1d(
+            conv_x,
+            weight,
+            bias,
+            conv_states,
+            query_start_loc,
+            cache_indices,
+            has_initial_state,
+            activation,
+            pad_slot_id,
+            pad_slot_id - 1 if generated_cache_indices else null_block_id,
+        ).to(original_x_dtype)
+
+    if not apc_requested or not use_tiled:
+        return official_causal_conv1d_fn(
+            x,
+            weight,
+            bias,
+            conv_states,
+            query_start_loc,
+            cache_indices=cache_indices,
+            has_initial_state=has_initial_state,
+            activation=activation,
+            pad_slot_id=pad_slot_id,
+            null_block_id=null_block_id,
+            block_idx_first_scheduled_token=block_idx_first_scheduled_token,
+            block_idx_last_scheduled_token=block_idx_last_scheduled_token,
+            initial_state_idx=initial_state_idx,
+            num_computed_tokens=num_computed_tokens,
+            block_size_to_align=block_size_to_align,
+            metadata=metadata,
+            validate_data=validate_data,
+        )
+
+    assert cache_indices is not None
+    assert has_initial_state is not None
+    assert block_idx_first_scheduled_token is not None
+    assert block_idx_last_scheduled_token is not None
+    assert initial_state_idx is not None
+    assert num_computed_tokens is not None
+    return apc_causal_conv1d(
+        conv_x,
+        weight,
+        bias,
+        conv_states,
+        query_start_loc,
+        cache_indices,
+        has_initial_state,
+        activation,
+        pad_slot_id,
+        null_block_id,
+        block_idx_first_scheduled_token,
+        block_idx_last_scheduled_token,
+        initial_state_idx,
+        num_computed_tokens,
+        block_size_to_align,
+    ).to(original_x_dtype)

--- a/vllm/model_executor/layers/mamba/ops/gdn_causal_conv1d.py
+++ b/vllm/model_executor/layers/mamba/ops/gdn_causal_conv1d.py
@@ -34,10 +34,12 @@ def fast_causal_conv1d(
     eligible = (
         _IS_SM103
         and _HAS_SM103_KERNEL
+        and x.is_cuda
         and x.dtype == torch.bfloat16
         and x.ndim == 2
         and x.stride(0) == 1
         and x.stride(1) >= x.shape[0]
+        and x.stride(1) % 4 == 0
         and x.storage_offset() % 4 == 0
         and x.shape[0] % 4 == 0
         and x.shape[1] >= 3
@@ -155,6 +157,7 @@ def causal_conv1d_fn(
     batch = query_start_loc.numel() - 1
     use_tiled = (
         _IS_SM103
+        and conv_x.is_cuda
         and conv_x.shape[1] >= 1024
         and conv_x.shape[0] <= 4096
         and batch <= 32

--- a/vllm/model_executor/layers/mamba/ops/gdn_causal_conv1d_apc.py
+++ b/vllm/model_executor/layers/mamba/ops/gdn_causal_conv1d_apc.py
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.model_executor.layers.mamba.ops.gdn_causal_conv1d_generic import (
+    generic_causal_conv1d,
+)
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def _resolve_apc_state_indices_kernel(
+    cache_indices_ptr,
+    initial_state_idx_ptr,
+    last_scheduled_ptr,
+    input_indices_ptr,
+    output_indices_ptr,
+    batch,
+    stride_cache_batch,
+    BLOCK: tl.constexpr,
+):
+    sequence = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = sequence < batch
+    initial_offset = tl.load(initial_state_idx_ptr + sequence, mask=mask, other=0)
+    final_offset = tl.load(last_scheduled_ptr + sequence, mask=mask, other=0)
+    input_index = tl.load(
+        cache_indices_ptr + sequence * stride_cache_batch + initial_offset,
+        mask=mask,
+        other=0,
+    )
+    output_index = tl.load(
+        cache_indices_ptr + sequence * stride_cache_batch + final_offset,
+        mask=mask,
+        other=0,
+    )
+    tl.store(input_indices_ptr + sequence, input_index, mask=mask)
+    tl.store(output_indices_ptr + sequence, output_index, mask=mask)
+
+
+@triton.jit
+def _store_apc_intermediate_states_kernel(
+    x_ptr,
+    states_ptr,
+    query_start_ptr,
+    cache_indices_ptr,
+    first_scheduled_ptr,
+    last_scheduled_ptr,
+    num_computed_ptr,
+    batch,
+    dim,
+    max_blocks,
+    block_size,
+    stride_x_dim,
+    stride_x_token,
+    stride_state_seq,
+    stride_state_dim,
+    stride_state_token,
+    stride_cache_batch,
+    pad_slot_id,
+    null_block_id,
+    STATE_LEN: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BLOCK_STATE: tl.constexpr,
+):
+    sequence = tl.program_id(0)
+    block_offset = tl.program_id(1)
+    channel = tl.program_id(2) * BLOCK_D + tl.arange(0, BLOCK_D)
+    state_token = tl.arange(0, BLOCK_STATE)
+    channel_mask = channel < dim
+    state_mask = state_token < STATE_LEN
+
+    sequence_start = tl.load(query_start_ptr + sequence)
+    sequence_end = tl.load(query_start_ptr + sequence + 1)
+    sequence_length = sequence_end - sequence_start
+    first = tl.load(first_scheduled_ptr + sequence)
+    last = tl.load(last_scheduled_ptr + sequence)
+    blocks_to_fill = last - first
+    computed = tl.load(num_computed_ptr + sequence)
+    active_block = block_offset < blocks_to_fill
+
+    completed_offset = block_size - (computed % block_size)
+    end_offset = (sequence_length - completed_offset) % block_size
+    last_full = sequence_end - end_offset
+    last_full = tl.where(end_offset == 0, last_full - block_size, last_full)
+    boundary = last_full - (blocks_to_fill - block_offset - 1) * block_size
+    input_token = boundary - STATE_LEN + state_token
+
+    cache_index = tl.load(
+        cache_indices_ptr + sequence * stride_cache_batch + first + block_offset
+    ).to(tl.int64)
+    active = (
+        active_block
+        & (block_offset < max_blocks)
+        & (cache_index != pad_slot_id)
+        & (cache_index != null_block_id)
+        & channel_mask[:, None]
+        & state_mask[None, :]
+        & (input_token[None, :] >= sequence_start)
+        & (input_token[None, :] < sequence_end)
+    )
+    source = input_token[None, :] * stride_x_token + channel[:, None] * stride_x_dim
+    destination = (
+        cache_index * stride_state_seq
+        + channel[:, None] * stride_state_dim
+        + state_token[None, :] * stride_state_token
+    )
+    value = tl.load(x_ptr + source, mask=active, other=0.0)
+    tl.store(states_ptr + destination, value, mask=active)
+
+
+def apc_causal_conv1d(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    conv_states: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    cache_indices: torch.Tensor,
+    has_initial_state: torch.Tensor,
+    activation: str | bool | None,
+    pad_slot_id: int,
+    null_block_id: int,
+    block_idx_first_scheduled_token: torch.Tensor,
+    block_idx_last_scheduled_token: torch.Tensor,
+    initial_state_idx: torch.Tensor,
+    num_computed_tokens: torch.Tensor,
+    block_size_to_align: int,
+) -> torch.Tensor:
+    """Self-owned prefix-cache/APC causal-conv implementation."""
+    assert cache_indices.ndim == 2
+    assert block_size_to_align > 0
+    batch = query_start_loc.numel() - 1
+    input_indices = torch.empty(batch, dtype=torch.int32, device=x.device)
+    output_indices = torch.empty_like(input_indices)
+    block = 128
+    _resolve_apc_state_indices_kernel[(triton.cdiv(batch, block),)](
+        cache_indices,
+        initial_state_idx,
+        block_idx_last_scheduled_token,
+        input_indices,
+        output_indices,
+        batch,
+        cache_indices.stride(0),
+        BLOCK=block,
+        num_warps=4,
+    )
+    output = generic_causal_conv1d(
+        x,
+        weight,
+        bias,
+        conv_states,
+        query_start_loc,
+        input_indices,
+        has_initial_state,
+        activation,
+        pad_slot_id,
+        null_block_id,
+        output_cache_indices=output_indices,
+    )
+
+    state_len = weight.shape[1] - 1
+    max_blocks = cache_indices.shape[1]
+    block_d = 32
+    _store_apc_intermediate_states_kernel[
+        (batch, max_blocks, triton.cdiv(x.shape[0], block_d))
+    ](
+        x,
+        conv_states,
+        query_start_loc,
+        cache_indices,
+        block_idx_first_scheduled_token,
+        block_idx_last_scheduled_token,
+        num_computed_tokens,
+        batch,
+        x.shape[0],
+        max_blocks,
+        block_size_to_align,
+        x.stride(0),
+        x.stride(1),
+        conv_states.stride(0),
+        conv_states.stride(1),
+        conv_states.stride(2),
+        cache_indices.stride(0),
+        pad_slot_id,
+        null_block_id,
+        STATE_LEN=state_len,
+        BLOCK_D=block_d,
+        BLOCK_STATE=triton.next_power_of_2(state_len),
+        num_warps=4,
+    )
+    return output

--- a/vllm/model_executor/layers/mamba/ops/gdn_causal_conv1d_generic.py
+++ b/vllm/model_executor/layers/mamba/ops/gdn_causal_conv1d_generic.py
@@ -1,0 +1,346 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def _causal_conv1d_varlen_kernel(
+    x_ptr,
+    weight_ptr,
+    bias_ptr,
+    states_ptr,
+    query_start_ptr,
+    state_indices_ptr,
+    has_initial_ptr,
+    output_ptr,
+    total_tokens,
+    dim,
+    stride_x_dim,
+    stride_x_token,
+    stride_weight_dim,
+    stride_weight_width,
+    stride_state_seq,
+    stride_state_dim,
+    stride_state_token,
+    stride_output_dim,
+    stride_output_token,
+    pad_slot_id,
+    null_block_id,
+    BATCH: tl.constexpr,
+    WIDTH: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+    ACTIVATION: tl.constexpr,
+    BLOCK_T: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    token = tl.program_id(0) * BLOCK_T + tl.arange(0, BLOCK_T)
+    channel = tl.program_id(1) * BLOCK_D + tl.arange(0, BLOCK_D)
+    token_mask = token < total_tokens
+    channel_mask = channel < dim
+
+    sequence = tl.zeros((BLOCK_T,), dtype=tl.int32)
+    for seq in tl.static_range(1, BATCH):
+        start = tl.load(query_start_ptr + seq)
+        sequence += (token >= start).to(tl.int32)
+
+    sequence_start = tl.load(query_start_ptr + sequence, mask=token_mask, other=0)
+    sequence_end = tl.load(query_start_ptr + sequence + 1, mask=token_mask, other=0)
+    local_token = token - sequence_start
+    sequence_length = sequence_end - sequence_start
+    state_index = tl.load(
+        state_indices_ptr + sequence, mask=token_mask, other=null_block_id
+    ).to(tl.int64)
+    has_initial = tl.load(has_initial_ptr + sequence, mask=token_mask, other=0).to(
+        tl.int1
+    )
+    active = (
+        token_mask
+        & (local_token >= 0)
+        & (local_token < sequence_length)
+        & (state_index != pad_slot_id)
+        & (state_index != null_block_id)
+    )
+
+    accumulator = tl.zeros((BLOCK_T, BLOCK_D), dtype=tl.float32)
+    state_len: tl.constexpr = WIDTH - 1
+    for tap in tl.static_range(WIDTH):
+        source_local = local_token - state_len + tap
+        from_input = source_local >= 0
+        input_token = sequence_start + source_local
+        input_offsets = (
+            input_token[:, None] * stride_x_token + channel[None, :] * stride_x_dim
+        )
+        input_value = tl.load(
+            x_ptr + input_offsets,
+            mask=active[:, None] & from_input[:, None] & channel_mask[None, :],
+            other=0.0,
+        ).to(tl.float32)
+
+        state_token = source_local + state_len
+        state_offsets = (
+            state_index[:, None] * stride_state_seq
+            + channel[None, :] * stride_state_dim
+            + state_token[:, None] * stride_state_token
+        )
+        state_value = tl.load(
+            states_ptr + state_offsets,
+            mask=(
+                active[:, None]
+                & (~from_input[:, None])
+                & has_initial[:, None]
+                & channel_mask[None, :]
+            ),
+            other=0.0,
+        ).to(tl.float32)
+        value = tl.where(from_input[:, None], input_value, state_value)
+        weight = tl.load(
+            weight_ptr + channel * stride_weight_dim + tap * stride_weight_width,
+            mask=channel_mask,
+            other=0.0,
+        ).to(tl.float32)
+        accumulator += value * weight[None, :]
+
+    if HAS_BIAS:
+        bias = tl.load(bias_ptr + channel, mask=channel_mask, other=0.0)
+        accumulator += bias[None, :].to(tl.float32)
+    if ACTIVATION:
+        accumulator *= tl.sigmoid(accumulator)
+
+    output_offsets = (
+        token[:, None] * stride_output_token + channel[None, :] * stride_output_dim
+    )
+    tl.store(
+        output_ptr + output_offsets,
+        accumulator,
+        mask=active[:, None] & channel_mask[None, :],
+    )
+
+
+@triton.jit
+def _update_conv_state_kernel(
+    x_ptr,
+    states_ptr,
+    new_states_ptr,
+    query_start_ptr,
+    state_indices_ptr,
+    has_initial_ptr,
+    dim,
+    stride_x_dim,
+    stride_x_token,
+    stride_state_seq,
+    stride_state_dim,
+    stride_state_token,
+    stride_new_batch,
+    stride_new_dim,
+    stride_new_token,
+    pad_slot_id,
+    null_block_id,
+    WIDTH: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BLOCK_STATE: tl.constexpr,
+):
+    sequence = tl.program_id(0)
+    channel = tl.program_id(1) * BLOCK_D + tl.arange(0, BLOCK_D)
+    state_token = tl.arange(0, BLOCK_STATE)
+    channel_mask = channel < dim
+    state_len: tl.constexpr = WIDTH - 1
+    state_mask = state_token < state_len
+
+    sequence_start = tl.load(query_start_ptr + sequence)
+    sequence_end = tl.load(query_start_ptr + sequence + 1)
+    sequence_length = sequence_end - sequence_start
+    state_index = tl.load(state_indices_ptr + sequence).to(tl.int64)
+    has_initial = tl.load(has_initial_ptr + sequence).to(tl.int1)
+    active = (
+        (state_index != pad_slot_id)
+        & (state_index != null_block_id)
+        & channel_mask[:, None]
+        & state_mask[None, :]
+    )
+
+    shift = state_len - tl.minimum(sequence_length, state_len)
+    from_old_state = state_token < shift
+    old_state_token = state_token + sequence_length
+    input_token = sequence_end - (state_len - state_token)
+
+    old_offsets = (
+        state_index * stride_state_seq
+        + channel[:, None] * stride_state_dim
+        + old_state_token[None, :] * stride_state_token
+    )
+    old_value = tl.load(
+        states_ptr + old_offsets,
+        mask=active & from_old_state[None, :] & has_initial,
+        other=0.0,
+    )
+    input_offsets = (
+        input_token[None, :] * stride_x_token + channel[:, None] * stride_x_dim
+    )
+    input_value = tl.load(
+        x_ptr + input_offsets,
+        mask=active & (~from_old_state[None, :]),
+        other=0.0,
+    )
+    value = tl.where(from_old_state[None, :], old_value, input_value)
+    destination = (
+        sequence * stride_new_batch
+        + channel[:, None] * stride_new_dim
+        + state_token[None, :] * stride_new_token
+    )
+    tl.store(new_states_ptr + destination, value, mask=active)
+
+
+@triton.jit
+def _scatter_conv_state_kernel(
+    new_states_ptr,
+    states_ptr,
+    state_indices_ptr,
+    total_elements,
+    elements_per_state,
+    stride_new_batch,
+    stride_new_dim,
+    stride_new_token,
+    stride_state_seq,
+    stride_state_dim,
+    stride_state_token,
+    state_len,
+    pad_slot_id,
+    null_block_id,
+    BLOCK: tl.constexpr,
+):
+    offset = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offset < total_elements
+    sequence = offset // elements_per_state
+    inner = offset % elements_per_state
+    channel = inner // state_len
+    state_token = inner % state_len
+    state_index = tl.load(
+        state_indices_ptr + sequence, mask=mask, other=null_block_id
+    ).to(tl.int64)
+    active = mask & (state_index != pad_slot_id) & (state_index != null_block_id)
+    source = (
+        sequence * stride_new_batch
+        + channel * stride_new_dim
+        + state_token * stride_new_token
+    )
+    destination = (
+        state_index * stride_state_seq
+        + channel * stride_state_dim
+        + state_token * stride_state_token
+    )
+    value = tl.load(new_states_ptr + source, mask=active)
+    tl.store(states_ptr + destination, value, mask=active)
+
+
+def generic_causal_conv1d(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    conv_states: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    cache_indices: torch.Tensor,
+    has_initial_state: torch.Tensor,
+    activation: str | bool | None,
+    pad_slot_id: int,
+    null_block_id: int,
+    output_cache_indices: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Self-owned generic packed-varlen causal-conv implementation."""
+    assert x.ndim == 2 and weight.ndim == 2 and conv_states.ndim == 3
+    assert query_start_loc.ndim == 1
+    batch = query_start_loc.numel() - 1
+    assert cache_indices.numel() >= batch
+    assert has_initial_state.numel() >= batch
+    if output_cache_indices is None:
+        output_cache_indices = cache_indices
+    assert output_cache_indices.numel() >= batch
+    dim, total_tokens = x.shape
+    width = weight.shape[1]
+    assert width in (2, 3, 4, 5)
+    output = torch.empty_like(x)
+    block_t = 16
+    block_d = 32
+    _causal_conv1d_varlen_kernel[
+        (triton.cdiv(total_tokens, block_t), triton.cdiv(dim, block_d))
+    ](
+        x,
+        weight,
+        bias,
+        conv_states,
+        query_start_loc,
+        cache_indices,
+        has_initial_state,
+        output,
+        total_tokens,
+        dim,
+        x.stride(0),
+        x.stride(1),
+        weight.stride(0),
+        weight.stride(1),
+        conv_states.stride(0),
+        conv_states.stride(1),
+        conv_states.stride(2),
+        output.stride(0),
+        output.stride(1),
+        pad_slot_id,
+        null_block_id,
+        BATCH=batch,
+        WIDTH=width,
+        HAS_BIAS=bias is not None,
+        ACTIVATION=activation in ("silu", "swish", True),
+        BLOCK_T=block_t,
+        BLOCK_D=block_d,
+        num_warps=4,
+    )
+    state_len = width - 1
+    new_states = torch.empty(
+        (batch, dim, state_len), dtype=conv_states.dtype, device=conv_states.device
+    )
+    _update_conv_state_kernel[(batch, triton.cdiv(dim, block_d))](
+        x,
+        conv_states,
+        new_states,
+        query_start_loc,
+        cache_indices,
+        has_initial_state,
+        dim,
+        x.stride(0),
+        x.stride(1),
+        conv_states.stride(0),
+        conv_states.stride(1),
+        conv_states.stride(2),
+        new_states.stride(0),
+        new_states.stride(1),
+        new_states.stride(2),
+        pad_slot_id,
+        null_block_id,
+        WIDTH=width,
+        BLOCK_D=block_d,
+        BLOCK_STATE=triton.next_power_of_2(state_len),
+        num_warps=4,
+    )
+    elements_per_state = dim * state_len
+    total_state_elements = batch * elements_per_state
+    state_block = 256
+    _scatter_conv_state_kernel[(triton.cdiv(total_state_elements, state_block),)](
+        new_states,
+        conv_states,
+        output_cache_indices,
+        total_state_elements,
+        elements_per_state,
+        new_states.stride(0),
+        new_states.stride(1),
+        new_states.stride(2),
+        conv_states.stride(0),
+        conv_states.stride(1),
+        conv_states.stride(2),
+        state_len,
+        pad_slot_id,
+        null_block_id,
+        BLOCK=state_block,
+        num_warps=4,
+    )
+    return output

--- a/vllm/model_executor/warmup/qwen_triton_warmup.py
+++ b/vllm/model_executor/warmup/qwen_triton_warmup.py
@@ -137,7 +137,7 @@ def _qwen_gdn_warmup_config(
 def _warm_causal_conv1d_fwd_kernel(
     device: torch.device, config: _QwenGDNWarmupConfig
 ) -> None:
-    from vllm.model_executor.layers.mamba.ops.causal_conv1d import (
+    from vllm.model_executor.layers.mamba.ops.gdn_causal_conv1d import (
         causal_conv1d_fn,
     )
     from vllm.v1.attention.backends.utils import NULL_BLOCK_ID, PAD_SLOT_ID


### PR DESCRIPTION
## Summary

Optimize Qwen GDN long-prefill causal convolution on NVIDIA SM103 while preserving the current operator as the fallback everywhere else.

This change adds:

- an SM103 BF16 width-4 CUDA specialization for the Qwen3.5 production layout;
- tiled Triton implementations for generic and packed-varlen long prefills;
- a tiled APC/prefix-cache implementation with intermediate state writes;
- conservative dispatch limited to SM103, long inputs, supported layouts, and bounded batch sizes;
- Qwen warmup routing through the same dispatcher used at runtime.

The GDN scan itself is unchanged and remains owned by FlashInfer/CuteDSL.

## Why this is not duplicate work

I repeated open-PR searches for `SM103 causal conv`, `GDN causal_conv1d prefill`, and `long prefill causal conv` before submission.

- #49953 adds a ROCm/AITER long-prefill split-QKV path. This PR targets NVIDIA SM103, does not change ROCm dispatch, and uses CUDA/Triton implementations under an SM103-only guard.
- #40738 is a speculative-decode state-correction bug fix. This PR optimizes the existing non-spec prefill contract and retains the existing fallback outside its guarded dispatch.
- #26807 adds GDN `all`-mode APC semantics. This PR implements the current causal-conv APC contract and does not introduce a competing cache mode.
- #45717, #42301, and #41457 optimize other GDN stages (scan-output handoff or input projections), not causal convolution.

No open PR was found that implements an NVIDIA SM103 GDN causal-conv prefill specialization.

## Dispatch and fallback

The optimized paths are selected only when all measured guards hold:

- NVIDIA compute capability 10.3;
- at least 1,024 total tokens;
- at most 4,096 channels for tiled Triton G/V/A, at most 32 sequences, and at least 128 average tokens per sequence;
- or the single-sequence BF16 width-4 CUDA specialization with aligned token strides, supported dtypes, state shape, and activation.

Short, unsupported, non-CUDA, non-SM103, and unbuilt configurations continue through the existing operator. The SM103 CUDA op is compiled only with CUDA >= 13.0 when SM103 is present in the requested CUDA architecture set, and has an explicit runtime availability guard.

## Correctness

The tests cover:

- width 2/3/4/5 reference semantics;
- BF16 and FP32;
- bias and activation variants;
- channel- and token-contiguous layouts;
- short sequences and mixed initial-state masks;
- packed varlen and null/padded slots;
- APC initial/final indices and intermediate block-state writes;
- mixed input/cache dtypes;
- production strided Qwen input;
- null state-slot preservation;
- official fallback and interface parity;
- misaligned-stride and non-CUDA fail-closed dispatch;
- Qwen mixed prefill/decode integration.

Focused result on B300/SM103:

```text
214 passed, 4 xfailed, 14 warnings in 74.37s
```

The xfails document the current official width-5 behavior; width-5 is not newly dispatched for short inputs.

Production shape correctness:

```text
x: [12288, 16384], stride [1, 20480], BF16, width 4
relative L2: 0.00379183
max absolute difference in a separate current-main run: 0.0009765625
```

## Operator performance

Hardware: NVIDIA B300, compute capability 10.3. Runtime: Torch 2.13.0+cu130, Triton 3.7.1, CUDA 13.2 driver/runtime environment. Measurements use `triton.testing.do_bench` after warmup.

Command:

```bash
PYTHONPATH=. .venv/bin/python \
  benchmarks/kernels/benchmark_gdn_causal_conv1d.py \
  --production-shape --apc
```

Results:

| Path | Current main | PR | Speedup |
|---|---:|---:|---:|
| single, activation=None, D4096/T4096 | 179.73 us | 49.73 us | 3.61x |
| packed varlen, D4096/total4096 | 181.25 us | 51.20 us | 3.54x |
| FP32, D2048/T1024 | 151.01 us | 49.50 us | 3.05x |
| width 3, D4096/T4096 | 181.22 us | 52.61 us | 3.44x |
| SM103 production shape | 570.46 us | 140.32 us | 4.07x |
| APC, D4096/T4096/block128 | 180.08 us | 90.46 us | 1.99x |

## Full-model trace

Model: Qwen3.5-122B-A10B NVFP4 compatibility checkpoint, TP1, BF16 activations, FlashInfer GDN backend, 8K prefill + one output token.

| Metric | Current main | PR | Delta |
|---|---:|---:|---:|
| causal-conv calls | 36 | 36 | — |
| causal-conv median | 143.39 us | 72.22 us | -49.6% |
| causal-conv total | 5.152 ms | 2.603 ms | -2.549 ms |
| total GPU busy | 122.878 ms | 119.411 ms | -3.467 ms |

The PR trace contains 36 `conv_fwd<4,128,64,6,8,false>` launches and zero `_causal_conv1d_fwd_kernel` launches. The current-main trace contains 36 `_causal_conv1d_fwd_kernel` launches.

NCU on the production specialization reports:

```text
duration:             136.416 us
DRAM throughput:      74.08%
compute throughput:   71.58%
achieved occupancy:   46.15%
registers/thread:     64
```

NCU classifies compute and memory as balanced.

## Serving A/B/A

Same Qwen3.5-122B TP1 server configuration, two warmups and ten measured requests per shape. Values are request-latency medians.

| Input | PR A1 | Main B | PR A2 |
|---:|---:|---:|---:|
| 2K | 63.44 ms | 67.69 ms | 66.49 ms |
| 4K | 72.61 ms | 74.26 ms | 72.73 ms |
| 8K | 135.92 ms | 137.87 ms | 136.38 ms |
| 16K | 277.62 ms | 281.37 ms | 276.37 ms |

Both PR arms are faster than the interleaved current-main arm at every measured shape.

## Model evaluation

Public `Qwen/Qwen3.5-0.8B`, GSM8K 5-shot, all 1,319 questions, greedy, max 256 output tokens, concurrency 128:

| Revision | Accuracy | Invalid |
|---|---:|---:|
| Current main | 32.4% | 0.8% |
| PR | 32.0% | 0.8% |

The -0.4 percentage-point delta is within the predeclared 1.0 percentage-point tolerance.

## Tests and checks

```text
# Focused CUDA/operator/integration tests
.venv/bin/python -m pytest \
  tests/kernels/mamba/test_causal_conv1d.py \
  tests/kernels/mamba/test_gdn_causal_conv1d_contract.py \
  tests/kernels/mamba/test_gdn_causal_conv1d_fast.py \
  tests/kernels/mamba/test_gdn_causal_conv1d_interface.py \
  tests/kernels/mamba/test_gdn_causal_conv1d_apc.py \
  tests/kernels/mamba/test_gdn_forward_core_split.py -q
# 214 passed, 4 xfailed

# Post-review guard/contract regression on the rebased branch
.venv/bin/python -m pytest \
  tests/kernels/mamba/test_gdn_causal_conv1d_fast.py \
  tests/kernels/mamba/test_gdn_causal_conv1d_interface.py \
  tests/kernels/mamba/test_gdn_causal_conv1d_contract.py \
  tests/kernels/mamba/test_gdn_causal_conv1d_apc.py -q
# 45 passed, 4 xfailed

# CMake architecture-gate check
# SM90 target: disabled; SM103 and SM103-family targets: enabled

# Stable extension target
cmake --build build-pr1 -j16 --target _C_stable_libtorch
# passed

# Changed-file pre-commit suite
pre-commit run --files <all changed files>
# passed, including ruff, mypy, clang-format, forbidden-import, and torch-CUDA-call checks
```

## Build and compatibility notes

- CUDA < 13.0 or builds whose requested architecture set excludes SM103 do not build or register the SM103 C++ op; runtime dispatch then uses the existing operator.
- Non-SM103, non-CUDA, misaligned, and unsupported inputs retain the existing operator.
- The historical implementation was used only as a reference; this change was rebased and validated against current official-main code rather than cherry-picked.

## AI assistance disclosure

AI assistance was used for implementation support, benchmark automation, test execution, and result summarization. I reviewed every changed line and remain responsible for the implementation, measurements, and claims in this PR.

