### PR TITLE
[Bugfix][Kimi K3] Fix message-level tools, response_format passthroug…

### DIFF
--- a/tests/entrypoints/openai/test_reasoning_content_compat.py
+++ b/tests/entrypoints/openai/test_reasoning_content_compat.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Backward-compat shim: responses mirror ``reasoning`` into the deprecated
+``reasoning_content`` field for clients that only read the latter."""
+
+import json
+
+import pytest
+
+from vllm.entrypoints.openai.chat_completion.protocol import ChatMessage
+from vllm.entrypoints.openai.engine.protocol import DeltaMessage
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+def test_delta_message_mirrors_reasoning_into_reasoning_content():
+    delta = DeltaMessage(reasoning="thinking out loud")
+
+    dumped = json.loads(delta.model_dump_json(exclude_unset=True))
+
+    assert dumped["reasoning"] == "thinking out loud"
+    assert dumped["reasoning_content"] == "thinking out loud"
+
+
+def test_delta_message_without_reasoning_omits_reasoning_content():
+    delta = DeltaMessage(content="hello")
+
+    dumped = json.loads(delta.model_dump_json(exclude_unset=True))
+
+    assert "reasoning" not in dumped
+    assert "reasoning_content" not in dumped
+
+
+def test_chat_message_mirrors_reasoning_into_reasoning_content():
+    message = ChatMessage(role="assistant", content="answer", reasoning="why")
+
+    dumped = json.loads(message.model_dump_json(exclude_unset=True))
+
+    assert dumped["reasoning"] == "why"
+    assert dumped["reasoning_content"] == "why"
+
+
+def test_chat_message_without_reasoning_omits_reasoning_content():
+    message = ChatMessage(role="assistant", content="answer")
+
+    dumped = json.loads(message.model_dump_json(exclude_unset=True))
+
+    assert "reasoning" not in dumped
+    assert "reasoning_content" not in dumped

--- a/tests/entrypoints/openai/test_response_format_chat_params.py
+++ b/tests/entrypoints/openai/test_response_format_chat_params.py
@@ -1,0 +1,251 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for top-level response_format forwarding into ChatParams.
+
+Most models treat response_format purely as a decoding constraint (guided
+decoding via structured_outputs), so it is not part of chat template
+rendering. Models whose chat encoding renders response_format into the
+prompt need the field at the renderer layer; the forwarding is inert for
+renderers that don't read it.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+)
+
+_WEATHER_SCHEMA = {
+    "type": "object",
+    "properties": {"city": {"type": "string"}},
+    "required": ["city"],
+    "additionalProperties": False,
+}
+
+
+def _build_chat_request(**kwargs) -> ChatCompletionRequest:
+    defaults = dict(
+        model="test-model",
+        messages=[{"role": "user", "content": "Hello"}],
+    )
+    defaults.update(kwargs)
+    return ChatCompletionRequest(**defaults)
+
+
+class TestResponseFormatForwarding:
+    def test_json_schema_forwarded(self):
+        request = _build_chat_request(
+            response_format={
+                "type": "json_schema",
+                "json_schema": {"name": "weather", "schema": _WEATHER_SCHEMA},
+            },
+        )
+        params = request.build_chat_params(None, "auto")
+        rf = params.response_format
+        assert rf is not None
+        assert rf.type == "json_schema"
+        assert rf.json_schema is not None
+        assert rf.json_schema.name == "weather"
+        assert rf.json_schema.json_schema == _WEATHER_SCHEMA
+
+    def test_json_object_forwarded(self):
+        request = _build_chat_request(
+            response_format={"type": "json_object"},
+        )
+        params = request.build_chat_params(None, "auto")
+        assert params.response_format is not None
+        assert params.response_format.type == "json_object"
+
+    def test_no_response_format_not_injected(self):
+        request = _build_chat_request()
+        params = request.build_chat_params(None, "auto")
+        assert params.response_format is None
+
+    def test_explicit_user_kwarg_kept_when_no_top_level_field(self):
+        # A client-provided chat_template_kwargs entry survives when the
+        # top-level field is absent.
+        request = _build_chat_request(
+            chat_template_kwargs={"response_format": {"type": "json_object"}},
+        )
+        params = request.build_chat_params(None, "auto")
+        assert params.response_format is None
+        assert params.chat_template_kwargs["response_format"] == {"type": "json_object"}
+
+    def test_guided_decoding_still_set(self):
+        # Forwarding must not eat the structured_outputs path.
+        request = _build_chat_request(
+            response_format={
+                "type": "json_schema",
+                "json_schema": {"name": "weather", "schema": _WEATHER_SCHEMA},
+            },
+        )
+        params = request.to_sampling_params(max_tokens=100, default_sampling_params={})
+        assert params.structured_outputs is not None
+        assert params.structured_outputs.json == _WEATHER_SCHEMA
+
+
+class TestStrictFalseDisablesGuidedDecoding:
+    """strict=false means prompt-instruction-only: the schema is forwarded
+    to the renderer, but no grammar constraint is applied. strict=true/absent
+    keeps full guided decoding."""
+
+    def _guided_json(self, request) -> dict | None:
+        params = request.to_sampling_params(max_tokens=100, default_sampling_params={})
+        if params.structured_outputs is None:
+            return None
+        return params.structured_outputs.json
+
+    def _chat_request(self, strict):
+        json_schema = {"name": "weather", "schema": _WEATHER_SCHEMA}
+        if strict is not ...:
+            json_schema["strict"] = strict
+        return _build_chat_request(
+            response_format={"type": "json_schema", "json_schema": json_schema}
+        )
+
+    def test_strict_false_disables_guided_decoding(self):
+        assert self._guided_json(self._chat_request(strict=False)) is None
+
+    def test_strict_true_keeps_guided_decoding(self):
+        assert self._guided_json(self._chat_request(strict=True)) == (_WEATHER_SCHEMA)
+
+    def test_strict_absent_keeps_guided_decoding(self):
+        # Compatibility: clients that never pass strict must not silently
+        # lose grammar constraints.
+        assert self._guided_json(self._chat_request(strict=...)) == (_WEATHER_SCHEMA)
+
+    def test_strict_false_still_forwards_to_renderer(self):
+        # The prompt-instruction channel must stay active when the grammar
+        # channel is off -- together they form "prompt-only" mode.
+        request = self._chat_request(strict=False)
+        params = request.build_chat_params(None, "auto")
+        rf = params.response_format
+        assert rf is not None and rf.json_schema is not None
+        assert rf.json_schema.json_schema == _WEATHER_SCHEMA
+        assert rf.json_schema.strict is False
+
+
+class TestStrictMustBeBoolean:
+    """Non-boolean `strict` is rejected at request validation (the server
+    maps the ValidationError to 400 BadRequest) instead of being
+    lax-coerced to a bool (e.g. "yes" -> True)."""
+
+    @pytest.mark.parametrize("bad_strict", ["yes", "true", "false", 1, 0])
+    def test_non_boolean_strict_rejected(self, bad_strict):
+        with pytest.raises(ValidationError):
+            _build_chat_request(
+                response_format={
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "weather",
+                        "schema": _WEATHER_SCHEMA,
+                        "strict": bad_strict,
+                    },
+                },
+            )
+
+    @pytest.mark.parametrize("good_strict", [True, False, None])
+    def test_boolean_strict_accepted(self, good_strict):
+        request = _build_chat_request(
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "weather",
+                    "schema": _WEATHER_SCHEMA,
+                    "strict": good_strict,
+                },
+            },
+        )
+        assert request.response_format is not None
+        assert request.response_format.json_schema is not None
+        assert request.response_format.json_schema.strict is good_strict
+
+
+class TestResponsesStrictFalse:
+    def _build_responses_request(self, strict):
+        from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+
+        fmt = {
+            "type": "json_schema",
+            "name": "weather",
+            "schema": _WEATHER_SCHEMA,
+        }
+        if strict is not ...:
+            fmt["strict"] = strict
+        return ResponsesRequest(
+            model="test-model",
+            input=[{"role": "user", "content": "Hello"}],
+            text={"format": fmt},
+        )
+
+    def _guided_json(self, request) -> dict | None:
+        params = request.to_sampling_params(default_max_tokens=100)
+        if params.structured_outputs is None:
+            return None
+        return params.structured_outputs.json
+
+    def test_strict_false_disables_guided_decoding(self):
+        assert self._guided_json(self._build_responses_request(False)) is None
+
+    def test_strict_true_keeps_guided_decoding(self):
+        assert self._guided_json(self._build_responses_request(True)) == (
+            _WEATHER_SCHEMA
+        )
+
+    def test_strict_absent_keeps_guided_decoding(self):
+        assert self._guided_json(self._build_responses_request(...)) == (
+            _WEATHER_SCHEMA
+        )
+
+
+class TestResponsesResponseFormatForwarding:
+    """Responses API: text.format is flattened (no `json_schema` nesting)
+    and must be re-nested to the Chat Completions shape for renderers."""
+
+    def _build_responses_request(self, **kwargs):
+        from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+
+        defaults = dict(
+            model="test-model",
+            input=[{"role": "user", "content": "Hello"}],
+        )
+        defaults.update(kwargs)
+        return ResponsesRequest(**defaults)
+
+    def test_json_schema_renested(self):
+        request = self._build_responses_request(
+            text={
+                "format": {
+                    "type": "json_schema",
+                    "name": "weather",
+                    "schema": _WEATHER_SCHEMA,
+                    "strict": True,
+                }
+            },
+        )
+        params = request.build_chat_params(None, "auto")
+        assert params.response_format == {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "weather",
+                "description": None,
+                "schema": _WEATHER_SCHEMA,
+                "strict": True,
+            },
+        }
+
+    def test_json_object_forwarded(self):
+        request = self._build_responses_request(
+            text={"format": {"type": "json_object"}},
+        )
+        params = request.build_chat_params(None, "auto")
+        assert params.response_format == {
+            "type": "json_object",
+            "json_schema": None,
+        }
+
+    def test_no_text_format_not_injected(self):
+        request = self._build_responses_request()
+        params = request.build_chat_params(None, "auto")
+        assert params.response_format is None

--- a/tests/entrypoints/openai/test_tool_choice_kwargs.py
+++ b/tests/entrypoints/openai/test_tool_choice_kwargs.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for tool_choice forwarding in build_chat_params.
+
+An absent tool_choice renders nothing in the prompt; only an explicitly
+provided one reaches the renderer. The request field's default "none" is
+serving-layer state and must not be rendered.
+"""
+
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+)
+
+_TOOL = {
+    "type": "function",
+    "function": {"name": "f", "parameters": {"type": "object", "properties": {}}},
+}
+
+
+def _request(**kwargs) -> ChatCompletionRequest:
+    defaults = {"model": "test-model", "messages": [{"role": "user", "content": "hi"}]}
+    defaults.update(kwargs)
+    return ChatCompletionRequest.model_validate(defaults)
+
+
+def _message_level_tools_request(**kwargs) -> ChatCompletionRequest:
+    messages = [
+        {"role": "system", "content": "sys", "tools": [_TOOL]},
+        {"role": "user", "content": "hi"},
+    ]
+    defaults = {"model": "test-model", "messages": messages}
+    defaults.update(kwargs)
+    return ChatCompletionRequest.model_validate(defaults)
+
+
+def test_absent_tool_choice_not_forwarded():
+    request = _request()
+    params = request.build_chat_params(None, "auto")
+    assert params.tool_choice is None
+
+
+def test_explicit_none_tool_choice_forwarded():
+    request = _request(tool_choice="none")
+    params = request.build_chat_params(None, "auto")
+    assert params.tool_choice == "none"
+
+
+def test_explicit_null_tool_choice_not_forwarded():
+    # Explicit null parses to None; the request must not resurrect the
+    # field default either.
+    request = _request(tool_choice=None)
+    params = request.build_chat_params(None, "auto")
+    assert params.tool_choice is None
+
+
+def test_auto_default_from_tools_forwarded():
+    request = _request(tools=[_TOOL])
+    params = request.build_chat_params(None, "auto")
+    assert params.tool_choice == "auto"
+
+
+def test_user_chat_template_kwarg_kept():
+    request = _request(chat_template_kwargs={"tool_choice": "none"})
+    params = request.build_chat_params(None, "auto")
+    assert params.chat_template_kwargs["tool_choice"] == "none"
+
+
+def test_message_level_tools_default_forwarded():
+    # The "auto" default triggered by message-level tools is forwarded, so
+    # the renderer does not treat the request as tool-less.
+    request = _message_level_tools_request()
+    assert request.tool_choice == "auto"
+    params = request.build_chat_params(None, "auto")
+    assert params.tool_choice == "auto"
+
+
+def test_message_level_tools_explicit_choice_forwarded():
+    request = _message_level_tools_request(tool_choice="required")
+    params = request.build_chat_params(None, "auto")
+    assert params.tool_choice == "required"

--- a/tests/entrypoints/unit_tests/test_chat_utils.py
+++ b/tests/entrypoints/unit_tests/test_chat_utils.py
@@ -2782,3 +2782,46 @@ async def test_resolve_items_does_not_leak_tasks_on_partial_failure():
         f"resolve_items left {len(leaked_tasks)} task(s) running after "
         f"raising: {leaked_tasks}"
     )
+
+
+_MESSAGE_LEVEL_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the weather",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+]
+
+
+@pytest.mark.parametrize("role", ["system", "developer"])
+def test_parse_message_level_tools_passed_through(role):
+    """Message-level tool declarations survive chat message parsing: tools
+    on "system"/"developer" messages pass through for the chat template /
+    encoding layer to expand.
+    """
+    from vllm.entrypoints.chat_utils import _parse_chat_message_content
+
+    result = _parse_chat_message_content(
+        {"role": role, "content": "instructions", "tools": _MESSAGE_LEVEL_TOOLS},
+        MagicMock(),
+        "string",
+        True,
+    )
+    assert result[0]["tools"] == _MESSAGE_LEVEL_TOOLS
+
+
+@pytest.mark.parametrize("role", ["user", "assistant", "tool"])
+def test_parse_message_level_tools_not_passed_for_other_roles(role):
+    """tools on non-system/developer roles are not passed through."""
+    from vllm.entrypoints.chat_utils import _parse_chat_message_content
+
+    result = _parse_chat_message_content(
+        {"role": role, "content": "text", "tools": _MESSAGE_LEVEL_TOOLS},
+        MagicMock(),
+        "string",
+        True,
+    )
+    assert "tools" not in result[0]

--- a/tests/reasoning/test_kimi_k3_reasoning_parser.py
+++ b/tests/reasoning/test_kimi_k3_reasoning_parser.py
@@ -248,3 +248,89 @@ def test_adjust_request_keeps_xtml_markers_contiguous():
     assert adjusted.skip_special_tokens is False
     if hasattr(adjusted, "spaces_between_special_tokens"):
         assert adjusted.spaces_between_special_tokens is False
+
+
+_TOOLS_CHANNEL = f"{OPEN}tools{SEP}x{CLOSE}tools{SEP}"
+
+
+def _message_level_tools_request(*, tool_choice="required") -> ChatCompletionRequest:
+    """Tools declared only on a system message (message-level declaration)."""
+    return ChatCompletionRequest(
+        model="test-model",
+        messages=[
+            {
+                "role": "system",
+                "content": "",
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "calc",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            },
+            {"role": "user", "content": "hi"},
+        ],
+        tool_choice=tool_choice,
+    )
+
+
+def test_extract_reasoning_preserves_tool_channels_for_message_level_tools():
+    """Message-level tools are invisible in `request.tools`, but the model
+    still emits a tools channel -- it must reach the tool parser raw."""
+    parser = KimiK3ReasoningParser(DummyTokenizer())
+    request = _message_level_tools_request(tool_choice="required")
+    rest = f"{RESPONSE_OPEN}answer{CLOSE}response{SEP}{_TOOLS_CHANNEL}"
+
+    reasoning, content = parser.extract_reasoning_content(
+        f"step{THINK_CLOSE}{rest}", request
+    )
+
+    assert reasoning == "step"
+    assert content == rest
+
+
+def test_extract_reasoning_strips_channels_for_message_level_tools_none():
+    """tool_choice='none' disables preservation even with message-level tools."""
+    parser = KimiK3ReasoningParser(DummyTokenizer())
+    request = _message_level_tools_request(tool_choice="none")
+    rest = f"{RESPONSE_OPEN}answer{CLOSE}response{SEP}{_TOOLS_CHANNEL}"
+
+    reasoning, content = parser.extract_reasoning_content(
+        f"step{THINK_CLOSE}{rest}", request
+    )
+
+    assert reasoning == "step"
+    assert content == "answer"
+
+
+def test_extract_reasoning_strips_channels_without_any_tools():
+    """No tools anywhere: the tools channel is unwrapped as before."""
+    parser = KimiK3ReasoningParser(DummyTokenizer())
+    request = ChatCompletionRequest(model="test-model", messages=[], tool_choice="auto")
+    rest = f"{RESPONSE_OPEN}answer{CLOSE}response{SEP}{_TOOLS_CHANNEL}"
+
+    reasoning, content = parser.extract_reasoning_content(
+        f"step{THINK_CLOSE}{rest}", request
+    )
+
+    assert reasoning == "step"
+    assert content == "answer"
+
+
+def test_is_reasoning_end_with_structural_think_in_history():
+    """Every history assistant message carries think open/close tags, and the
+    generation prefix re-opens the think channel. History close markers must
+    not mark the prompt as "reasoning ended"."""
+    parser = KimiK3ReasoningParser(DummyTokenizer())
+
+    history = [1, 2, 3, 4, 2, 3]  # <|open|>think<|sep|><|close|>think<|sep|>
+    generation_prefix = [1, 2, 3]  # <|open|>think<|sep|>
+    assert not parser.is_reasoning_end(history + generation_prefix)
+
+    # Generated output: open consumed by the prefix, close present -> ended.
+    assert parser.is_reasoning_end([9, 4, 2, 3, 10])
+    # Still reasoning: no close marker yet.
+    assert not parser.is_reasoning_end([9, 10])

--- a/tests/renderers/test_kimi_k3.py
+++ b/tests/renderers/test_kimi_k3.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -7,7 +8,11 @@ import pytest
 
 from vllm.exceptions import VLLMValidationError
 from vllm.renderers import ChatParams
-from vllm.renderers.kimi_k3 import KimiK3Renderer, _merge_k3_media_io_kwargs
+from vllm.renderers.kimi_k3 import (
+    KimiK3Renderer,
+    _merge_k3_media_io_kwargs,
+    _preserve_malformed_tool_arguments,
+)
 from vllm.renderers.registry import RENDERER_REGISTRY
 from vllm.tokenizers.registry import TokenizerRegistry
 
@@ -351,3 +356,197 @@ async def test_render_messages_async_returns_token_prompt():
 
     assert prompt == {"prompt_token_ids": [4, 5]}
     assert conversation[0]["role"] == "user"
+
+
+def test_apply_chat_template_strips_null_tool_fields():
+    # The serving layer's model_dump() serializes unset tool fields as null;
+    # the platform tokenism omits them, so K3 drops them for prompt parity.
+    tokenizer = StubTokenizer([7, 8, 9])
+    renderer = _make_renderer(tokenizer)
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "foo",
+                "description": None,
+                "strict": None,
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    params = ChatParams(chat_template_kwargs={"tools": tools})
+
+    renderer._apply_chat_template([{"role": "user", "content": "hi"}], params)
+
+    assert tokenizer.calls[-1]["tools"] == [
+        {
+            "type": "function",
+            "function": {
+                "name": "foo",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+
+def test_apply_chat_template_keeps_user_schema_content():
+    # None values inside user-supplied `parameters` are schema content
+    # (e.g. "default": null) and must survive the null stripping.
+    tokenizer = StubTokenizer([7, 8, 9])
+    renderer = _make_renderer(tokenizer)
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "foo",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"x": {"type": "string", "default": None}},
+                },
+            },
+        }
+    ]
+    params = ChatParams(chat_template_kwargs={"tools": tools})
+
+    renderer._apply_chat_template([{"role": "user", "content": "hi"}], params)
+
+    assert tokenizer.calls[-1]["tools"] == tools
+
+
+def test_preserve_malformed_tool_arguments_helper():
+    # Malformed strings are wrapped as JSON string literals; valid strings,
+    # dicts and non-list tool_calls pass through untouched.
+    messages = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "a",
+                    "type": "function",
+                    "function": {"name": "f", "arguments": '{"x": 1'},
+                },
+                {
+                    "id": "b",
+                    "type": "function",
+                    "function": {"name": "g", "arguments": '{"x": 1}'},
+                },
+                {
+                    "id": "c",
+                    "type": "function",
+                    "function": {"name": "h", "arguments": {"x": 1}},
+                },
+            ],
+        },
+    ]
+
+    (out,) = _preserve_malformed_tool_arguments(messages)[1:2]
+    calls = out["tool_calls"]
+    assert json.loads(calls[0]["function"]["arguments"]) == '{"x": 1'
+    assert calls[1]["function"]["arguments"] == '{"x": 1}'
+    assert calls[2]["function"]["arguments"] == {"x": 1}
+
+
+def test_render_messages_preserves_malformed_tool_arguments():
+    """Malformed tool-call arguments round-trip to K3's encoding byte-exact.
+
+    parse_chat_messages json.loads string arguments, so the renderer wraps
+    unparsable ones as JSON string literals; the loads round-trips them to
+    the original string, which K3's encoding renders via its raw-text
+    fallback exactly like the platform tokenism.
+    """
+    tokenizer = StubTokenizer([1, 2])
+    renderer = _make_renderer(tokenizer)
+    malformed = '{"location":"北京"'
+
+    conversation, prompt = renderer.render_messages(
+        [
+            {"role": "user", "content": "北京天气怎么样？"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": malformed},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "晴"},
+            {"role": "user", "content": "继续"},
+        ],
+        ChatParams(),
+    )
+
+    assert prompt == {"prompt_token_ids": [1, 2]}
+    sent = tokenizer.conversations[-1]
+    assert sent[1]["tool_calls"][0]["function"]["arguments"] == malformed
+
+
+@pytest.mark.asyncio
+async def test_render_messages_async_preserves_malformed_tool_arguments():
+    tokenizer = StubTokenizer([3])
+    renderer = _make_renderer(tokenizer)
+    malformed = '{"location":"北京"'
+
+    await renderer.render_messages_async(
+        [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": malformed},
+                    }
+                ],
+            },
+        ],
+        ChatParams(),
+    )
+
+    sent = tokenizer.conversations[-1]
+    assert sent[0]["tool_calls"][0]["function"]["arguments"] == malformed
+
+
+def test_render_messages_converts_developer_to_system():
+    """developer messages must reach K3's encoding as system messages.
+
+    K3's encoding_k3 only recognizes system/user/assistant/tool and silently
+    drops other roles; developer (OpenAI's newer system-role name) is
+    converted with tools preserved so it renders as a dynamic tool declare.
+    """
+    tokenizer = StubTokenizer([1, 2])
+    renderer = _make_renderer(tokenizer)
+    tools = [{"type": "function", "function": {"name": "search"}}]
+
+    conversation, prompt = renderer.render_messages(
+        [
+            {"role": "developer", "content": "be terse", "tools": tools},
+            {"role": "user", "content": "hi"},
+        ],
+        ChatParams(),
+    )
+
+    assert prompt == {"prompt_token_ids": [1, 2]}
+    sent = tokenizer.conversations[-1]
+    assert sent[0]["role"] == "system"
+    assert sent[0]["content"] == "be terse"
+    assert sent[0]["tools"] == tools
+
+
+@pytest.mark.asyncio
+async def test_render_messages_async_converts_developer_to_system():
+    tokenizer = StubTokenizer([3])
+    renderer = _make_renderer(tokenizer)
+
+    await renderer.render_messages_async(
+        [{"role": "developer", "content": "be terse"}], ChatParams()
+    )
+
+    sent = tokenizer.conversations[-1]
+    assert sent[0]["role"] == "system"
+    assert sent[0]["content"] == "be terse"

--- a/tests/tool_use/test_chat_completion_request_validations.py
+++ b/tests/tool_use/test_chat_completion_request_validations.py
@@ -40,28 +40,29 @@ def test_chat_completion_request_with_no_tools():
 
 @pytest.mark.parametrize("tool_choice", ["auto", "required"])
 def test_chat_completion_request_with_tool_choice_but_no_tools(tool_choice):
-    with pytest.raises(
-        VLLMValidationError, match="When using `tool_choice`, `tools` must be set."
-    ):
-        ChatCompletionRequest.model_validate(
+    # Finer-grained rules: "auto" without tools is a harmless no-op;
+    # "required"/named without any tool source (request level OR message
+    # level) is rejected.
+    expected = None if tool_choice == "auto" else VLLMValidationError
+    if expected is None:
+        request = ChatCompletionRequest.model_validate(
             {
                 "messages": [{"role": "user", "content": "Hello"}],
                 "model": "facebook/opt-125m",
                 "tool_choice": tool_choice,
             }
         )
-
-    with pytest.raises(
-        VLLMValidationError, match="When using `tool_choice`, `tools` must be set."
-    ):
-        ChatCompletionRequest.model_validate(
-            {
-                "messages": [{"role": "user", "content": "Hello"}],
-                "model": "facebook/opt-125m",
-                "tool_choice": tool_choice,
-                "tools": None,
-            }
-        )
+        assert request.tool_choice == tool_choice
+    else:
+        with pytest.raises(expected, match="tools must be declared"):
+            ChatCompletionRequest.model_validate(
+                {
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    "model": "facebook/opt-125m",
+                    "tool_choice": tool_choice,
+                    "tools": None,
+                }
+            )
 
 
 def test_reasoning_content_normalized_to_reasoning():
@@ -179,6 +180,171 @@ def test_multiple_structured_outputs_rejected():
                 "structured_outputs": {
                     "json": {"type": "object"},
                     "regex": ".*",
+                },
+            }
+        )
+
+
+_SAMPLE_TOOL_DICT = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the weather",
+        "parameters": {"type": "object", "properties": {}},
+    },
+}
+
+
+def test_request_level_tools_still_default_tool_choice_auto():
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [{"role": "user", "content": "Hello"}],
+            "model": "facebook/opt-125m",
+            "tools": [_SAMPLE_TOOL_DICT],
+        }
+    )
+    assert request.tool_choice == "auto"
+
+
+@pytest.mark.parametrize("role", ["system", "developer"])
+def test_message_level_tools_default_tool_choice_auto(role):
+    # Message-level tool declarations must also default tool_choice to
+    # "auto"; the field default "none" would tell the model not to call the
+    # tools the client just declared.
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [
+                {"role": role, "content": "instructions", "tools": [_SAMPLE_TOOL_DICT]},
+                {"role": "user", "content": "Hello"},
+            ],
+            "model": "facebook/opt-125m",
+        }
+    )
+    assert request.tool_choice == "auto"
+
+
+def test_message_level_tools_do_not_override_explicit_tool_choice():
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "instructions",
+                    "tools": [_SAMPLE_TOOL_DICT],
+                },
+                {"role": "user", "content": "Hello"},
+            ],
+            "model": "facebook/opt-125m",
+            "tool_choice": "required",
+        }
+    )
+    assert request.tool_choice == "required"
+
+
+def test_tools_on_other_roles_do_not_default_tool_choice_auto():
+    # tools on roles that are not passed through to the template (user,
+    # assistant, tool) must not influence the tool_choice default.
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [
+                {"role": "user", "content": "Hello", "tools": [_SAMPLE_TOOL_DICT]},
+            ],
+            "model": "facebook/opt-125m",
+        }
+    )
+    assert request.tool_choice == "none"
+
+
+def test_auto_tool_choice_without_tools_allowed():
+    # "auto" without any tools is a harmless no-op: the model simply answers.
+    for tools_kwarg in ({}, {"tools": None}):
+        request = ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "model": "facebook/opt-125m",
+                "tool_choice": "auto",
+                **tools_kwarg,
+            }
+        )
+        assert request.tool_choice == "auto"
+
+
+def test_required_tool_choice_without_any_tools_rejected():
+    # "required" is contradictory without any tool source: reject unless
+    # tools are declared at the request level OR on a message.
+    with pytest.raises(VLLMValidationError, match="tools must be declared"):
+        ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "model": "facebook/opt-125m",
+                "tool_choice": "required",
+            }
+        )
+
+
+def test_required_tool_choice_with_message_level_tools_allowed():
+    # Tools declared on a system message satisfy the requirement.
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [
+                {"role": "system", "content": "", "tools": [SAMPLE_TOOL]},
+                {"role": "user", "content": "Hello"},
+            ],
+            "model": "facebook/opt-125m",
+            "tool_choice": "required",
+        }
+    )
+    assert request.tool_choice == "required"
+
+
+def test_named_tool_choice_without_any_tools_rejected():
+    # A named tool_choice with no tool declared anywhere is rejected.
+    with pytest.raises(VLLMValidationError, match="tools must be declared"):
+        ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "model": "facebook/opt-125m",
+                "tool_choice": {
+                    "type": "function",
+                    "function": {"name": "get_weather"},
+                },
+            }
+        )
+
+
+def test_named_tool_choice_with_message_level_tools_allowed():
+    # A named tool_choice without request-level tools is allowed when the
+    # named tool may be declared at the message level (not cross-checked).
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [
+                {"role": "system", "content": "", "tools": [SAMPLE_TOOL]},
+                {"role": "user", "content": "Hello"},
+            ],
+            "model": "facebook/opt-125m",
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": "get_weather"},
+            },
+        }
+    )
+    assert request.tool_choice.function.name == "get_weather"
+
+
+def test_named_tool_choice_must_match_declared_tools():
+    # When request-level tools ARE present, a named tool_choice must still
+    # match one of them.
+    with pytest.raises(
+        VLLMValidationError, match="does not match any of the specified `tools`"
+    ):
+        ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "model": "facebook/opt-125m",
+                "tools": [SAMPLE_TOOL],
+                "tool_choice": {
+                    "type": "function",
+                    "function": {"name": "nondefined_function_name"},
                 },
             }
         )

--- a/tests/tool_use/test_kimi_k3_tool_parser.py
+++ b/tests/tool_use/test_kimi_k3_tool_parser.py
@@ -598,3 +598,97 @@ def test_chat_params_keeps_template_tool_choice_when_api_auto():
 
     assert chat_params.chat_template_kwargs["tool_choice"] == "required"
     assert chat_params.tool_choice == "auto"
+
+
+def _dynamic_tools_request(*, tool_choice="auto") -> ChatCompletionRequest:
+    """Tools declared only on a system message; ``request.tools`` is empty
+    by design."""
+    return ChatCompletionRequest(
+        model="test-model",
+        messages=[
+            {
+                "role": "system",
+                "content": "",
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "calc",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            },
+            {"role": "user", "content": "Call the calc tool."},
+        ],
+        tool_choice=tool_choice,
+    )
+
+
+def test_delegating_parser_message_level_tools_required():
+    """Message-level-only tools: the reasoning parser must preserve the raw
+    XTML for the tool parser even though ``request.tools`` is empty
+    (non-stream regression: gating on request-level tools used to strip the
+    tools channel, so the tool call vanished)."""
+    parser = KimiK3DelegatingParser(DummyTokenizer())
+    output = (
+        f"{THINK_OPEN}step{THINK_CLOSE}"
+        + _response("")
+        + _tools(_call("calc", 1, _arg("x", "number", "1")))
+    )
+
+    reasoning, content, tool_calls = parser.parse(
+        output,
+        _dynamic_tools_request(tool_choice="required"),
+        enable_auto_tools=True,
+    )
+
+    assert reasoning == "step"
+    assert content is None
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0].name == "calc"
+    assert json.loads(tool_calls[0].arguments) == {"x": 1}
+
+
+def test_delegating_parser_message_level_tools_auto():
+    parser = KimiK3DelegatingParser(DummyTokenizer())
+    output = (
+        f"{THINK_OPEN}step{THINK_CLOSE}"
+        + _response("answer")
+        + _tools(_call("calc", 1, _arg("x", "number", "1")))
+    )
+
+    reasoning, content, tool_calls = parser.parse(
+        output,
+        _dynamic_tools_request(tool_choice="auto"),
+        enable_auto_tools=True,
+    )
+
+    assert reasoning == "step"
+    assert content == "answer"
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0].name == "calc"
+    assert json.loads(tool_calls[0].arguments) == {"x": 1}
+
+
+def test_delegating_parser_message_level_tools_none_strips_channels():
+    """tool_choice='none' keeps the old behavior: the reasoning parser
+    unwraps the response channel itself and no tool parsing happens."""
+    parser = KimiK3DelegatingParser(DummyTokenizer())
+    output = (
+        f"{THINK_OPEN}step{THINK_CLOSE}"
+        + _response("answer")
+        + _tools(_call("calc", 1, _arg("x", "number", "1")))
+    )
+
+    reasoning, content, tool_calls = parser.parse(
+        output,
+        _dynamic_tools_request(tool_choice="none"),
+        enable_auto_tools=True,
+    )
+
+    assert reasoning == "step"
+    assert content == "answer"
+    assert not tool_calls

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1889,8 +1889,13 @@ def _parse_chat_message_content(
         if "task" in message and isinstance(message["task"], str):
             result_msg["task"] = message["task"]
 
-        if role == "developer":
-            result_msg["tools"] = message.get("tools", None)
+        # Tool declarations on individual messages (e.g. "developer" or
+        # "system" roles) pass through for the chat template to expand.
+        if (
+            role in ("developer", "system")
+            and (msg_tools := message.get("tools")) is not None
+        ):
+            result_msg["tools"] = msg_tools
     return result
 
 

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -63,6 +63,15 @@ class ChatMessage(OpenAIBaseModel):
 
     # vLLM-specific fields that are not in OpenAI spec
     reasoning: str | None = None
+    reasoning_content: str | None = None
+    """Deprecated: use `reasoning` instead."""
+
+    @model_validator(mode="after")
+    def handle_deprecated_reasoning_content(self):
+        """Copy reasoning to reasoning_content for backward compatibility."""
+        if self.reasoning is not None:
+            self.reasoning_content = self.reasoning
+        return self
 
     @model_serializer(mode="wrap")
     def _serialize(self, handler):
@@ -186,6 +195,22 @@ class ChatCompletionToolsParam(OpenAIBaseModel):
 
 class ChatCompletionNamedFunction(OpenAIBaseModel):
     name: str
+
+
+def _has_message_level_tools(messages: Any) -> bool:
+    """Whether any message carries a message-level tool declaration.
+
+    Mirrors the roles that `parse_chat_messages` passes through to the chat
+    template ("system", "developer").
+    """
+    if not isinstance(messages, list):
+        return False
+    return any(
+        isinstance(msg, dict)
+        and msg.get("role") in ("system", "developer")
+        and bool(msg.get("tools"))
+        for msg in messages
+    )
 
 
 class ChatCompletionNamedToolChoiceParam(OpenAIBaseModel):
@@ -568,8 +593,15 @@ class ChatCompletionRequest(OpenAIBaseModel):
             # No-tools requests default to tool_choice="none" at the API
             # layer. Collapse that default before rendering, so K3 emits a
             # model-visible tool-choice instruction only for requests with a
-            # tools block.
-            tool_choice=self.tool_choice if self.tools else None,
+            # tools block. Message-level tool declarations count as tools
+            # here, and an explicitly provided tool_choice is always kept.
+            tool_choice=(
+                self.tool_choice
+                if self.tools
+                or _has_message_level_tools(self.messages)
+                or "tool_choice" in self.model_fields_set
+                else None
+            ),
             response_format=self.response_format,
         )
 
@@ -872,9 +904,13 @@ class ChatCompletionRequest(OpenAIBaseModel):
                 parameter="tools",
             )
 
-        # if "tool_choice" is not specified but tools are provided,
-        # default to "auto" tool_choice
-        if "tool_choice" not in data and data.get("tools"):
+        # Extend the tool_choice="auto" default to tools declared on
+        # individual messages, not just request-level `tools`. Otherwise the
+        # field default "none" would make templates instruct the model NOT to
+        # call the very tools the client just declared.
+        if "tool_choice" not in data and (
+            data.get("tools") or _has_message_level_tools(data.get("messages"))
+        ):
             data["tool_choice"] = "auto"
 
         # if "tool_choice" is "none" -- no validation is needed for tools
@@ -883,10 +919,18 @@ class ChatCompletionRequest(OpenAIBaseModel):
 
         # if "tool_choice" is specified -- validation
         if "tool_choice" in data and data["tool_choice"] is not None:
-            # ensure that if "tool choice" is specified, tools are present
-            if "tools" not in data or data["tools"] is None:
+            # "required"/named tool_choice is contradictory without any tool
+            # source (request-level `tools` OR message-level declarations).
+            # "auto"/"none" without tools are harmless no-ops.
+            if (
+                data["tool_choice"] == "required"
+                or isinstance(data["tool_choice"], dict)
+            ) and not (
+                data.get("tools") or _has_message_level_tools(data.get("messages"))
+            ):
                 raise VLLMValidationError(
-                    "When using `tool_choice`, `tools` must be set.",
+                    "When using `tool_choice`, tools must be declared either "
+                    "at the request level or on individual messages.",
                     parameter="tool_choice",
                 )
 
@@ -930,11 +974,14 @@ class ChatCompletionRequest(OpenAIBaseModel):
                         f" in `tool_choice`! {correct_usage_message}",
                         parameter="tool_choice.function.name",
                     )
-                for tool in data["tools"]:
+                # Only cross-check the name against request-level `tools`
+                # when they are present; the named tool may be declared at
+                # the message level, which is not visible here.
+                for tool in data.get("tools") or []:
                     if tool["function"]["name"] == function_name:
                         valid_tool = True
                         break
-                if not valid_tool:
+                if data.get("tools") and not valid_tool:
                     raise VLLMValidationError(
                         "The tool specified in `tool_choice` does not match any"
                         " of the specified `tools`",

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -37,6 +37,7 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionResponseStreamChoice,
     ChatCompletionStreamResponse,
     ChatMessage,
+    _has_message_level_tools,
 )
 from vllm.entrypoints.openai.engine.protocol import (
     DeltaMessage,
@@ -935,9 +936,10 @@ class OpenAIServingChat(GenerateBaseServing):
             elif not request.tool_choice or request.tool_choice == "none":
                 message = ChatMessage(role=role, reasoning=reasoning, content=content)
 
-            # handle when there are tools and tool choice is auto
+            # handle when there are tools (request-level or message-level)
+            # and tool choice is auto
             elif (
-                request.tools
+                (request.tools or _has_message_level_tools(request.messages))
                 and (request.tool_choice == "auto" or request.tool_choice is None)
                 and self.enable_auto_tools
                 and tool_parser_cls

--- a/vllm/entrypoints/openai/engine/protocol.py
+++ b/vllm/entrypoints/openai/engine/protocol.py
@@ -13,6 +13,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    StrictBool,
     model_serializer,
     model_validator,
 )
@@ -138,7 +139,12 @@ class JsonSchemaResponseFormat(OpenAIBaseModel):
     # schema is the field in openai but that causes conflicts with pydantic so
     # instead use json_schema with an alias
     json_schema: dict[str, Any] | None = Field(default=None, alias="schema")
-    strict: bool | None = None
+    # strict defaults to true: guided decoding constrains the output to the
+    # schema. strict=false applies no grammar constraint, but the schema may
+    # still be rendered into the prompt by chat templates that consume
+    # response_format. StrictBool rejects non-boolean values (e.g. "yes")
+    # with a 400 instead of coercing them.
+    strict: StrictBool | None = None
 
 
 class LegacyStructuralTag(OpenAIBaseModel):
@@ -190,7 +196,13 @@ def structured_outputs_from_response_format(
     elif response_format.type == "json_schema":
         json_schema = response_format.json_schema
         assert json_schema is not None
-        overrides = {"json": json_schema.json_schema}
+        # strict=false means prompt-instruction-only: no grammar constraint
+        # is applied, but the schema may still be rendered into the prompt by
+        # chat templates that consume response_format. Default (None) and
+        # true keep full guided decoding.
+        overrides = (
+            {"json": json_schema.json_schema} if json_schema.strict is not False else {}
+        )
     else:
         assert isinstance(
             response_format,
@@ -202,6 +214,9 @@ def structured_outputs_from_response_format(
         overrides = {
             "structural_tag": json.dumps(response_format.model_dump(by_alias=True))
         }
+
+    if not overrides:
+        return structured_outputs
 
     if structured_outputs is None:
         return StructuredOutputsParams(**overrides)
@@ -394,7 +409,16 @@ class DeltaMessage(OpenAIBaseModel):
     role: str | None = None
     content: str | None = None
     reasoning: str | None = None
+    reasoning_content: str | None = None
+    """Deprecated: use `reasoning` instead."""
     tool_calls: list[DeltaToolCall] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def handle_deprecated_reasoning_content(self):
+        """Copy reasoning to reasoning_content for backward compatibility."""
+        if self.reasoning is not None:
+            self.reasoning_content = self.reasoning
+        return self
 
     @model_serializer(mode="wrap")
     def _serialize(self, handler):

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -118,6 +118,31 @@ def serialize_messages(msgs):
     return [serialize_message(msg) for msg in msgs] if msgs else None
 
 
+def _text_format_to_chat_response_format(
+    text: ResponseTextConfig | None,
+) -> dict[str, Any] | None:
+    """Adapt Responses API ``text.format`` to the Chat Completions
+    ``response_format`` shape (schema nested under the ``json_schema`` key)
+    that chat renderers consuming ``response_format`` expect.
+    """
+    if text is None or text.format is None:
+        return None
+    fmt = text.format
+    if fmt.type == "json_schema":
+        return {
+            "type": "json_schema",
+            "json_schema": {
+                "name": getattr(fmt, "name", None),
+                "description": getattr(fmt, "description", None),
+                "schema": getattr(fmt, "schema_", None),
+                "strict": getattr(fmt, "strict", None),
+            },
+        }
+    if fmt.type == "json_object":
+        return {"type": "json_object", "json_schema": None}
+    return None
+
+
 class ResponseRawMessageAndToken(OpenAIBaseModel):
     """Class to show the raw message.
     If message / tokens diverge, tokens is the source of truth"""
@@ -338,6 +363,9 @@ class ResponsesRequest(OpenAIBaseModel):
             ),
             media_io_kwargs=self.media_io_kwargs,
             tool_choice=self.tool_choice if self.tools else None,
+            # Forward the response format so templates that render it into
+            # the prompt can see it.
+            response_format=_text_format_to_chat_response_format(self.text),
         )
 
     def build_tok_params(self, model_config: ModelConfig) -> TokenizeParams:
@@ -372,6 +400,9 @@ class ResponsesRequest(OpenAIBaseModel):
         if (
             response_format.type == "json_schema"
             and response_format.schema_ is not None
+            # strict=false means prompt-instruction-only: no grammar
+            # constraint is applied.
+            and getattr(response_format, "strict", None) is not False
         ):
             return StructuredOutputsParams(
                 json=response_format.schema_  # type: ignore[call-arg]

--- a/vllm/reasoning/kimi_k3_reasoning_parser.py
+++ b/vllm/reasoning/kimi_k3_reasoning_parser.py
@@ -28,6 +28,9 @@ from typing import TYPE_CHECKING
 import regex as re
 from transformers import PreTrainedTokenizerBase
 
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    _has_message_level_tools,
+)
 from vllm.entrypoints.openai.engine.protocol import DeltaMessage
 from vllm.reasoning import ReasoningParser
 
@@ -186,9 +189,14 @@ class KimiK3ReasoningParser(ReasoningParser):
     def _should_preserve_tool_channels(
         request: "ChatCompletionRequest | ResponsesRequest",
     ) -> bool:
-        return bool(getattr(request, "tools", None)) and (
-            getattr(request, "tool_choice", None) != "none"
-        )
+        if getattr(request, "tool_choice", None) == "none":
+            return False
+        if getattr(request, "tools", None):
+            return True
+        # Message-level tool declarations (on system/developer messages)
+        # never appear in `request.tools`; preserve the raw XTML so the
+        # tool parser sees it.
+        return _has_message_level_tools(getattr(request, "messages", None))
 
     def _content_after_reasoning(
         self,

--- a/vllm/renderers/kimi_k3.py
+++ b/vllm/renderers/kimi_k3.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
 from typing import Any, cast
 
 from vllm.config import VllmConfig
@@ -30,6 +31,86 @@ def _merge_k3_media_io_kwargs(
     media_io_kwargs: dict[str, dict[str, Any]] | None,
 ) -> dict[str, dict[str, Any]] | None:
     return merge_media_io_kwargs(_K3_MEDIA_IO_DEFAULTS, media_io_kwargs)
+
+
+def _convert_developer_to_system(
+    conversation: list[ConversationMessage],
+) -> list[ConversationMessage]:
+    """Map ``developer`` messages to ``system`` for K3's chat encoding.
+
+    K3's ``encoding_k3`` only recognizes ``system`` and silently drops other
+    roles. Unlike the HF renderer's variant, ``tools`` is kept: K3 renders a
+    tools-carrying system message as a dynamic tool declare.
+    """
+    return [
+        (
+            {**msg, "role": "system"}  # type: ignore[misc]
+            if msg["role"] == "developer"
+            else msg
+        )
+        for msg in conversation
+    ]
+
+
+def _drop_null_tool_fields(tools: Any) -> Any:
+    """Drop keys with ``None`` values at the tool and function level.
+
+    The serving layer's ``model_dump()`` keeps unset optional fields as
+    explicit ``null``, which the platform tokenism omits -- the nulls would
+    diverge the rendered prompt. Only the two pydantic-model levels are
+    touched; schema content under ``parameters`` is left alone.
+    """
+    if not isinstance(tools, list):
+        return tools
+    cleaned = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            cleaned.append(tool)
+            continue
+        tool = {k: v for k, v in tool.items() if v is not None}
+        function = tool.get("function")
+        if isinstance(function, dict):
+            tool["function"] = {k: v for k, v in function.items() if v is not None}
+        cleaned.append(tool)
+    return cleaned
+
+
+def _preserve_malformed_tool_arguments(
+    messages: list[ChatCompletionMessageParam],
+) -> list[ChatCompletionMessageParam]:
+    """Wrap unparsable tool-call ``arguments`` as JSON string literals.
+
+    ``parse_chat_messages`` rejects malformed JSON arguments with a 400,
+    while K3's encoding tolerates them via a raw-text fallback. Wrapping the
+    string as a JSON string literal survives that ``loads`` (round-tripping
+    to the original string), so the text reaches K3's encoding byte-exact.
+    """
+    preserved: list[ChatCompletionMessageParam] = []
+    for message in messages:
+        tool_calls = message.get("tool_calls") if isinstance(message, dict) else None
+        if not isinstance(tool_calls, list):
+            preserved.append(message)
+            continue
+        new_calls = []
+        for tool_call in tool_calls:
+            if isinstance(tool_call, dict):
+                function = tool_call.get("function")
+                if isinstance(function, dict):
+                    arguments = function.get("arguments")
+                    if isinstance(arguments, str) and arguments.strip():
+                        try:
+                            json.loads(arguments)
+                        except json.JSONDecodeError:
+                            tool_call = {
+                                **tool_call,
+                                "function": {
+                                    **function,
+                                    "arguments": json.dumps(arguments),
+                                },
+                            }
+            new_calls.append(tool_call)
+        preserved.append({**message, "tool_calls": new_calls})  # type: ignore[typeddict-item]
+    return preserved
 
 
 def _dump_k3_template_value(value: Any) -> Any:
@@ -169,6 +250,8 @@ class KimiK3Renderer(BaseRenderer[HfTokenizer]):
             kwargs["tool_choice"] = _dump_k3_template_value(params.tool_choice)
         if params.response_format is not None:
             kwargs["response_format"] = _dump_k3_template_value(params.response_format)
+        if (tools := kwargs.get("tools")) is not None:
+            kwargs["tools"] = _drop_null_tool_fields(tools)
         kwargs["tokenize"] = True
         return self.get_tokenizer().apply_chat_template(conversation, **kwargs)
 
@@ -178,14 +261,16 @@ class KimiK3Renderer(BaseRenderer[HfTokenizer]):
         params: ChatParams,
     ) -> tuple[list[ConversationMessage], DictPrompt]:
         conversation, mm_data, mm_uuids = parse_chat_messages(
-            messages,
+            _preserve_malformed_tool_arguments(messages),
             self.model_config,
             content_format="string",
             media_io_kwargs=_merge_k3_media_io_kwargs(params.media_io_kwargs),
             mm_processor_kwargs=params.mm_processor_kwargs,
         )
 
-        rendered_conversation = _normalize_k3_tool_messages(conversation)
+        rendered_conversation = _normalize_k3_tool_messages(
+            _convert_developer_to_system(conversation)
+        )
         prompt = parse_dec_only_prompt(
             self._apply_chat_template(rendered_conversation, params)
         )
@@ -202,14 +287,16 @@ class KimiK3Renderer(BaseRenderer[HfTokenizer]):
         params: ChatParams,
     ) -> tuple[list[ConversationMessage], DictPrompt]:
         conversation, mm_data, mm_uuids = await parse_chat_messages_async(
-            messages,
+            _preserve_malformed_tool_arguments(messages),
             self.model_config,
             content_format="string",
             media_io_kwargs=_merge_k3_media_io_kwargs(params.media_io_kwargs),
             mm_processor_kwargs=params.mm_processor_kwargs,
         )
 
-        rendered_conversation = _normalize_k3_tool_messages(conversation)
+        rendered_conversation = _normalize_k3_tool_messages(
+            _convert_developer_to_system(conversation)
+        )
         token_ids = await self._apply_chat_template_async(rendered_conversation, params)
         prompt = parse_dec_only_prompt(token_ids)
         if mm_data is not None:


### PR DESCRIPTION
Fix several Kimi K3 frontend gaps left after #50093:

- Message-level tool declarations (tools on system/developer messages) now work end to end: they pass through chat message parsing, default tool_choice to "auto", satisfy tool_choice validation, keep the XTML tools channel intact for the tool parser, and are honored by the non-stream auto-tool path. Previously tool calls were silently lost for such requests.
- Render developer messages as system for K3 encoding; drop null tool fields for prompt parity with the platform tokenism; preserve malformed tool-call arguments byte-exact instead of failing with 400.
- Forward response_format to renderers on both Chat Completions and Responses APIs; strict=false disables guided decoding (prompt-instruction-only); non-boolean strict is rejected with 400.
- Mirror reasoning into the deprecated reasoning_content field on ChatMessage/DeltaMessage for backward compatibility.




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

