### PR TITLE
[Docs] Add the GLM-5.2 low-latency B300 TP8 MTP=5 serving recipe

### DIFF
--- a/recipes/glm5.2-ll-b300-tp8-mtp5.md
+++ b/recipes/glm5.2-ll-b300-tp8-mtp5.md
@@ -1,0 +1,41 @@
+# GLM-5.2-NVFP4 — Low-Latency (LL) serving recipe · 8×B300 · TP8 · MTP=5
+
+Single-node 8×B300 (sm_100/103), pure tensor parallel, NVFP4 weights, fp8 KV cache,
+MTP=5 speculative decode, model runner v2.
+
+Validated on `glm5.2-LL` @ `8d407aee1`.
+
+## Versions
+
+| Component | Version |
+| --- | --- |
+| vLLM | `glm5.2-LL` @ `8d407aee1` |
+| flashinfer-python | `0.6.15` |
+| Model | `nvidia/GLM-5.2-NVFP4` (`modelopt_fp4`) |
+
+## Build (once)
+
+```bash
+pip install 'flashinfer-python==0.6.15'
+
+CUDA_HOME=/usr/local/cuda-13.0 TORCH_CUDA_ARCH_LIST="10.0 10.3" MAX_JOBS=96 \
+VLLM_USE_PRECOMPILED=0 VLLM_USE_PRECOMPILED_RUST=0 \
+pip install -e . --no-deps --no-build-isolation
+```
+
+## Server
+
+```bash
+export VLLM_USE_V2_MODEL_RUNNER=1          # model runner v2
+export VLLM_DEEP_GEMM_WARMUP=skip
+
+vllm serve nvidia/GLM-5.2-NVFP4 \
+  --trust-remote-code \
+  --tensor-parallel-size 8 \
+  --quantization modelopt_fp4 --kv-cache-dtype fp8_e4m3 \
+  --max-model-len 32768 --max-num-batched-tokens 16384 --max-num-seqs 256 \
+  --no-enable-prefix-caching --gpu-memory-utilization 0.85 \
+  --speculative-config '{"method":"mtp","num_speculative_tokens":5}' \
+  --kernel-config '{"ir_op_priority":{"rms_norm":["vllm_c","native"],"fused_add_rms_norm":["vllm_c","native"]}}' \
+  --host 0.0.0.0 --port 8000
+```


### PR DESCRIPTION
## What this does

Add the serving recipe for GLM-5.2-NVFP4 low-latency mode on a single 8×B300 node
(TP8, MTP=5, model runner V2, fp8 KV cache): build flags, server command, and the
versions it was validated against. Documentation only.

Part of the #48597 re-split — see that PR for the tracker and merge order.

## Benchmark

8×B300 TP8, `nvidia/GLM-5.2-NVFP4`, MTP=5, `VLLM_USE_V2_MODEL_RUNNER=1`, fp8 KV
cache, 8192 input / 1024 output tokens, concurrency 1, 64 prompts.

```bash
VLLM_USE_V2_MODEL_RUNNER=1 vllm serve $MODEL --served-model-name glm-5.2 \
  -tp 8 --port 8300 \
  --kv-cache-dtype fp8_e4m3 --max-model-len 16384 \
  --max-num-seqs 256 --max-num-batched-tokens 16384 \
  --no-enable-prefix-caching --gpu-memory-utilization 0.85 \
  --speculative-config '{"method":"mtp","num_speculative_tokens":5}' \
  --kernel-config '{"ir_op_priority":{"rms_norm":["vllm_c","native"],"fused_add_rms_norm":["vllm_c","native"]},"enable_flashinfer_autotune":false}'
```

| | output tok/s | total tok/s | median TPOT |
| --- | --- | --- | --- |
| `main` (torch-compiled, verified: 16 Dynamo transforms) | 446.7 | 4019.8 | 1.94 ms |
| this PR alone | n/a (docs) | |  |
| full series | 542.5 | 4882.7 | 1.56 ms |

The `main` and per-PR rows are from the original session on one build. The
`full series` row was re-measured on 2026-07-30 with all six branches
cherry-picked onto `main` @ `48a077e4cf`, same node, dataset and server flags;
`main` was not re-run on that newer base, so the two are separate sessions
rather than one back-to-back delta.

> The prompts come from a low-entropy synthetic dataset, so MTP acceptance sits
> near the ceiling (~5.98 of 6 draft tokens accepted, >99%). Real traffic accepts
> far less, so these absolute throughput numbers are optimistic; the comparison
> between rows is still apples-to-apples since every row uses the same dataset and
> the same acceptance rate.

`lm_eval gsm8k` 5-shot on the full series: 0.9393 flexible / 0.9386 strict.
Re-measured 2026-07-30 with `tests/evals/gsm8k` (500 questions, 5-shot): 0.950,
no invalid responses; MTP acceptance length 5.97.
`pytest tests/kernels/test_bf16_skinny_gemm.py tests/kernels/test_fused_deepseek_v32_norm_rope.py` → 100 passed
(241 passed on the 2026-07-30 re-run, which picks up the new GLM-5.2 cases).

AI assistance (Claude) was used for the split and the benchmarks; every changed line has been reviewed.

