### PR TITLE
[Model][Perf] Overlap mixed GDN decode and prefill recurrent kernels

### DIFF
--- a/benchmarks/kernels/benchmark_gdn_forward_core_overlap.py
+++ b/benchmarks/kernels/benchmark_gdn_forward_core_overlap.py
@@ -1,0 +1,267 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Benchmark mixed decode/prefill GDN overlap through the real forward core."""
+
+import argparse
+import dataclasses
+import statistics
+import types
+from collections.abc import Callable
+from typing import Any
+from unittest.mock import patch
+
+import torch
+
+from tests.v1.attention.utils import (
+    BatchSpec,
+    create_common_attn_metadata,
+    create_vllm_config,
+)
+from vllm.config import set_current_vllm_config
+from vllm.model_executor.layers.mamba.gdn import qwen_gdn_linear_attn
+from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
+    ChunkGatedDeltaRule,
+    QwenGatedDeltaNetAttention,
+)
+from vllm.model_executor.layers.mamba.mamba_utils import MambaStateShapeCalculator
+from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
+from vllm.v1.kv_cache_interface import MambaSpec
+
+H = 16
+HV = 64
+K = 128
+V = 128
+CONV_KERNEL = 4
+KEY_DIM = H * K
+VALUE_DIM = HV * V
+CONV_DIM = 2 * KEY_DIM + VALUE_DIM
+BLOCK_SIZE = 16
+PREFIX = "model.layers.0.linear_attn"
+
+
+def measure_us(
+    modes: dict[str, Callable[[], Any]], warmup: int, repeats: int
+) -> dict[str, float]:
+    names = list(modes)
+    for _ in range(warmup):
+        for fn in modes.values():
+            fn()
+    torch.accelerator.synchronize()
+
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    samples: dict[str, list[float]] = {name: [] for name in names}
+    for repeat in range(repeats):
+        rotated = names[repeat % len(names) :] + names[: repeat % len(names)]
+        for name in rotated:
+            start.record()
+            modes[name]()
+            end.record()
+            end.synchronize()
+            samples[name].append(start.elapsed_time(end) * 1000)
+    return {name: statistics.median(values) for name, values in samples.items()}
+
+
+def build_layer(
+    vllm_config,
+    conv_state,
+    ssm_state,
+    a_log,
+    dt_bias,
+    conv_weight,
+    conv_bias,
+    enable_overlap: bool,
+):
+    layer = types.SimpleNamespace()
+    layer.prefix = PREFIX
+    layer.enable_packed_recurrent_decode = False
+    layer.tp_size = 1
+    layer.num_k_heads = H
+    layer.num_v_heads = HV
+    layer.head_k_dim = K
+    layer.head_v_dim = V
+    layer.key_dim = KEY_DIM
+    layer.value_dim = VALUE_DIM
+    layer.activation = "silu"
+    layer.A_log = a_log
+    layer.dt_bias = dt_bias
+    layer.conv1d = types.SimpleNamespace(weight=conv_weight, bias=conv_bias)
+    layer.kv_cache = (conv_state, ssm_state)
+    with set_current_vllm_config(vllm_config):
+        layer.chunk_gated_delta_rule = ChunkGatedDeltaRule()
+    layer.gdn_prefill_backend = layer.chunk_gated_delta_rule.gdn_prefill_backend
+    layer.gdn_decode_prefill_overlap = enable_overlap
+    layer.gdn_overlap_stream = torch.cuda.Stream() if enable_overlap else None
+    layer.gdn_overlap_start_event = torch.cuda.Event() if enable_overlap else None
+    layer.gdn_overlap_done_event = torch.cuda.Event() if enable_overlap else None
+    for name in ("rearrange_mixed_qkv", "_forward_core"):
+        setattr(
+            layer,
+            name,
+            types.MethodType(getattr(QwenGatedDeltaNetAttention, name), layer),
+        )
+    return layer
+
+
+def main() -> None:
+    global H, HV, KEY_DIM, VALUE_DIM, CONV_DIM
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--num-decodes", type=int, default=63)
+    parser.add_argument("--prefill-tokens", type=int, default=8192)
+    parser.add_argument("--state-dtype", choices=("bf16", "fp32"), default="bf16")
+    parser.add_argument("--num-k-heads", type=int, default=H)
+    parser.add_argument("--num-v-heads", type=int, default=HV)
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--repeats", type=int, default=10)
+    parser.add_argument("--trace-path")
+    args = parser.parse_args()
+
+    H = args.num_k_heads
+    HV = args.num_v_heads
+    KEY_DIM = H * K
+    VALUE_DIM = HV * V
+    CONV_DIM = 2 * KEY_DIM + VALUE_DIM
+
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    state_dtype = {
+        "bf16": torch.bfloat16,
+        "fp32": torch.float32,
+    }[args.state_dtype]
+
+    vllm_config = create_vllm_config(
+        model_name="Qwen/Qwen3.5-0.8B",
+        block_size=BLOCK_SIZE,
+        hf_config_override={"linear_key_head_dim": K},
+    )
+    vllm_config.additional_config = {"gdn_prefill_backend": "flashinfer"}
+
+    seq_lens = [64] * args.num_decodes + [args.prefill_tokens + 37]
+    query_lens = [1] * args.num_decodes + [args.prefill_tokens]
+    batch = BatchSpec(seq_lens=seq_lens, query_lens=query_lens)
+    builder = GDNAttentionMetadataBuilder(
+        kv_cache_spec=MambaSpec(
+            block_size=BLOCK_SIZE, shapes=((16, 64),), dtypes=(torch.float16,)
+        ),
+        layer_names=[PREFIX],
+        vllm_config=vllm_config,
+        device=device,
+    )
+    common = create_common_attn_metadata(
+        batch, BLOCK_SIZE, device, arange_block_indices=True
+    )
+    with set_current_vllm_config(vllm_config):
+        metadata = builder.build(common_prefix_len=0, common_attn_metadata=common)
+    compact_state_indices = torch.arange(
+        1, len(query_lens) + 1, dtype=torch.int32, device=device
+    )
+    metadata = dataclasses.replace(
+        metadata,
+        non_spec_state_indices_tensor=compact_state_indices,
+        prefill_state_indices=compact_state_indices[args.num_decodes :],
+    )
+
+    num_tokens = sum(query_lens)
+    pool_size = len(query_lens) + 1
+    conv_shape, state_shape = MambaStateShapeCalculator.gated_delta_net_state_shape(
+        1, H, HV, K, V, CONV_KERNEL, num_spec=0
+    )
+    conv_state = (
+        torch.randn(pool_size, *conv_shape, dtype=torch.bfloat16, device=device) * 0.05
+    )
+    ssm_state = (
+        torch.randn(pool_size, *state_shape, dtype=state_dtype, device=device) * 0.05
+    )
+    a_log = torch.randn(HV, dtype=torch.float32, device=device) * 0.1
+    dt_bias = torch.randn(HV, dtype=torch.float32, device=device) * 0.1
+    conv_weight = (
+        torch.randn(CONV_DIM, 1, CONV_KERNEL, dtype=torch.bfloat16, device=device) * 0.1
+    )
+    conv_bias = torch.randn(CONV_DIM, dtype=torch.bfloat16, device=device) * 0.1
+    mixed_qkv = (
+        torch.randn(num_tokens, CONV_DIM, dtype=torch.bfloat16, device=device) * 0.1
+    )
+    a = torch.randn(num_tokens, HV, dtype=torch.bfloat16, device=device) * 0.1
+    b = torch.randn(num_tokens, HV, dtype=torch.bfloat16, device=device) * 0.1
+
+    serial_layer = build_layer(
+        vllm_config,
+        conv_state.clone(),
+        ssm_state.clone(),
+        a_log,
+        dt_bias,
+        conv_weight,
+        conv_bias,
+        False,
+    )
+    overlap_layer = build_layer(
+        vllm_config,
+        conv_state.clone(),
+        ssm_state.clone(),
+        a_log,
+        dt_bias,
+        conv_weight,
+        conv_bias,
+        True,
+    )
+    serial_output = torch.zeros(num_tokens, HV, V, dtype=torch.bfloat16, device=device)
+    overlap_output = torch.zeros_like(serial_output)
+    context = types.SimpleNamespace(attn_metadata={PREFIX: metadata})
+
+    def run(layer, output):
+        layer._forward_core(
+            mixed_qkv=mixed_qkv,
+            b=b,
+            a=a,
+            core_attn_out=output,
+        )
+
+    with patch.object(
+        qwen_gdn_linear_attn, "get_forward_context", return_value=context
+    ):
+        run(serial_layer, serial_output)
+        run(overlap_layer, overlap_output)
+        torch.accelerator.synchronize()
+        torch.testing.assert_close(serial_output, overlap_output, atol=0, rtol=0)
+        torch.testing.assert_close(
+            serial_layer.kv_cache[0], overlap_layer.kv_cache[0], atol=0, rtol=0
+        )
+        torch.testing.assert_close(
+            serial_layer.kv_cache[1], overlap_layer.kv_cache[1], atol=0, rtol=0
+        )
+        timings = measure_us(
+            {
+                "serial": lambda: run(serial_layer, serial_output),
+                "overlap": lambda: run(overlap_layer, overlap_output),
+            },
+            args.warmup,
+            args.repeats,
+        )
+        if args.trace_path:
+            with torch.profiler.profile(
+                activities=[
+                    torch.profiler.ProfilerActivity.CPU,
+                    torch.profiler.ProfilerActivity.CUDA,
+                ]
+            ) as profiler:
+                run(overlap_layer, overlap_output)
+            torch.accelerator.synchronize()
+            profiler.export_chrome_trace(args.trace_path)
+
+    serial_us = timings["serial"]
+    overlap_us = timings["overlap"]
+    hidden_us = serial_us - overlap_us
+    print(f"GPU: {torch.cuda.get_device_name()}")
+    print(
+        f"shape: decodes={args.num_decodes}, prefill_tokens={args.prefill_tokens}, "
+        f"state_dtype={args.state_dtype}, H={H}, HV={HV}"
+    )
+    print(f"serial:  {serial_us:10.2f} us")
+    print(f"overlap: {overlap_us:10.2f} us")
+    print(f"hidden:  {hidden_us:10.2f} us")
+    print(f"speedup: {hidden_us / serial_us:10.2%}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/kernels/mamba/test_gdn_forward_core_split.py
+++ b/tests/kernels/mamba/test_gdn_forward_core_split.py
@@ -57,6 +57,7 @@ from vllm.model_executor.layers.mamba.gdn import qwen_gdn_linear_attn  # noqa: E
 from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (  # noqa: E402
     ChunkGatedDeltaRule,
     QwenGatedDeltaNetAttention,
+    _gdn_overlap_supported_for_cache_mode,
 )
 from vllm.model_executor.layers.mamba.mamba_utils import (  # noqa: E402
     MambaStateShapeCalculator,
@@ -97,6 +98,16 @@ def _make_vllm_config(gdn_backend: str):
     )
     cfg.additional_config = {"gdn_prefill_backend": gdn_backend}
     return cfg
+
+
+@pytest.mark.parametrize(
+    ("cache_mode", "expected"),
+    [("none", True), ("align", False), ("all", False)],
+)
+def test_gdn_overlap_requires_unshared_state_slots(
+    cache_mode: str, expected: bool
+) -> None:
+    assert _gdn_overlap_supported_for_cache_mode(cache_mode) is expected
 
 
 def _build_layer(
@@ -328,8 +339,27 @@ def test_forward_core_split_matches_unified(
                 a=a,
                 core_attn_out=captured_out,
             )
+        reference_layer = _build_layer(
+            vllm_config,
+            layer_overlap.kv_cache[0].clone(),
+            layer_overlap.kv_cache[1].clone(),
+            A_log,
+            dt_bias,
+            conv_weight,
+            conv_bias,
+        )
         graph.replay()
+        expected_replay = _run_forward_core(
+            reference_layer, meta_split, mixed_qkv, b, a, num_tokens
+        )
         torch.accelerator.synchronize()
+        torch.testing.assert_close(captured_out, expected_replay, atol=0, rtol=0)
+        torch.testing.assert_close(
+            layer_overlap.kv_cache[0], reference_layer.kv_cache[0], atol=0, rtol=0
+        )
+        torch.testing.assert_close(
+            layer_overlap.kv_cache[1], reference_layer.kv_cache[1], atol=0, rtol=0
+        )
 
     # ---- Unified path (real _forward_core, meta_unified) ----
     conv_state_unified = conv_state0.clone()

--- a/tests/kernels/mamba/test_gdn_forward_core_split.py
+++ b/tests/kernels/mamba/test_gdn_forward_core_split.py
@@ -68,6 +68,7 @@ from vllm.third_party.flash_linear_attention.ops.index import (  # noqa: E402
 from vllm.third_party.flash_linear_attention.ops.utils import (  # noqa: E402
     FLA_CHUNK_SIZE,
 )
+from vllm.utils.multi_stream_utils import execute_in_parallel  # noqa: E402
 from vllm.v1.attention.backends.gdn_attn import (  # noqa: E402
     GDNAttentionMetadataBuilder,
 )
@@ -86,24 +87,27 @@ BLOCK_SIZE = 16
 PREFIX = "model.layers.0.linear_attn"
 
 
-def _make_vllm_config():
+def _make_vllm_config(gdn_backend: str):
     # A small, ungated GDN model whose config is cached locally; only the config
-    # (scheduler/cache/compilation/hf) is used here, never the weights. Inject
-    # linear_key_head_dim=128 and request the CuteDSL prefill backend -- the
-    # supported GDN chunk kernel on Blackwell (the Triton/FLA chunk kernel is
-    # unsupported on SM10x). CuteDSL consumes chunk_indices/chunk_offsets, so
-    # this also exercises the prefill-only chunk-metadata wiring.
+    # (scheduler/cache/compilation/hf) is used here, never the weights.
     cfg = create_vllm_config(
         model_name="Qwen/Qwen3.5-0.8B",
         block_size=BLOCK_SIZE,
         hf_config_override={"linear_key_head_dim": K},
     )
-    cfg.additional_config = {"gdn_prefill_backend": "cutedsl"}
+    cfg.additional_config = {"gdn_prefill_backend": gdn_backend}
     return cfg
 
 
 def _build_layer(
-    vllm_config, conv_state, ssm_state, A_log, dt_bias, conv_weight, conv_bias
+    vllm_config,
+    conv_state,
+    ssm_state,
+    A_log,
+    dt_bias,
+    conv_weight,
+    conv_bias,
+    enable_overlap: bool = False,
 ):
     """A minimal object that runs the real ``_forward_core`` bound to it."""
     layer = types.SimpleNamespace()
@@ -123,6 +127,11 @@ def _build_layer(
     layer.kv_cache = (conv_state, ssm_state)
     with set_current_vllm_config(vllm_config):
         layer.chunk_gated_delta_rule = ChunkGatedDeltaRule()
+    layer.gdn_prefill_backend = layer.chunk_gated_delta_rule.gdn_prefill_backend
+    layer.gdn_decode_prefill_overlap = enable_overlap
+    layer.gdn_overlap_stream = torch.cuda.Stream() if enable_overlap else None
+    layer.gdn_overlap_start_event = torch.cuda.Event() if enable_overlap else None
+    layer.gdn_overlap_done_event = torch.cuda.Event() if enable_overlap else None
     for name in (
         "rearrange_mixed_qkv",
         "_forward_core",
@@ -150,10 +159,14 @@ def _run_forward_core(layer, meta, mixed_qkv, b, a, num_tokens):
     return core_attn_out
 
 
+@pytest.mark.parametrize("gdn_backend", ["cutedsl", "flashinfer"])
 @pytest.mark.parametrize("state_dtype", [torch.bfloat16, torch.float32])
-@pytest.mark.parametrize("num_decodes,prefill_lens", [(3, [512, 300]), (4, [64, 5])])
+@pytest.mark.parametrize(
+    "num_decodes,prefill_lens", [(3, [512, 300]), (4, [64, 5]), (3, [4096])]
+)
 @pytest.mark.parametrize("fresh_prefill", [False, True])
 def test_forward_core_split_matches_unified(
+    gdn_backend: str,
     state_dtype: torch.dtype,
     num_decodes: int,
     prefill_lens: list[int],
@@ -161,7 +174,7 @@ def test_forward_core_split_matches_unified(
 ) -> None:
     torch.manual_seed(0)
     device = torch.device("cuda")
-    vllm_config = _make_vllm_config()
+    vllm_config = _make_vllm_config(gdn_backend)
 
     # Decode-first batch: D 1-token decodes (with context), then the prefills.
     decode_seq_lens = [64] * num_decodes
@@ -193,7 +206,7 @@ def test_forward_core_split_matches_unified(
     assert meta_split.num_decodes == num_decodes
     assert meta_split.num_prefills == len(prefill_lens)
     assert meta_split.num_decode_tokens == num_decodes
-    assert builder.gdn_prefill_backend == "cutedsl"
+    assert builder.gdn_prefill_backend == gdn_backend
 
     num_tokens = sum(query_lens)
 
@@ -272,6 +285,51 @@ def test_forward_core_split_matches_unified(
         conv_bias,
     )
     out_split = _run_forward_core(layer_split, meta_split, mixed_qkv, b, a, num_tokens)
+
+    # ---- Overlap path (real _forward_core, same split metadata) ----
+    conv_state_overlap = conv_state0.clone()
+    ssm_state_overlap = ssm_state0.clone()
+    layer_overlap = _build_layer(
+        vllm_config,
+        conv_state_overlap,
+        ssm_state_overlap,
+        A_log,
+        dt_bias,
+        conv_weight,
+        conv_bias,
+        enable_overlap=True,
+    )
+    with patch.object(
+        qwen_gdn_linear_attn,
+        "execute_in_parallel",
+        wraps=execute_in_parallel,
+    ) as parallel:
+        out_overlap = _run_forward_core(
+            layer_overlap, meta_split, mixed_qkv, b, a, num_tokens
+        )
+    expected_overlap = gdn_backend == "flashinfer" and sum(prefill_lens) >= 4096
+    assert parallel.call_count == int(expected_overlap)
+    torch.testing.assert_close(out_overlap, out_split, atol=0, rtol=0)
+    torch.testing.assert_close(conv_state_overlap, conv_state_split, atol=0, rtol=0)
+    torch.testing.assert_close(ssm_state_overlap, ssm_state_split, atol=0, rtol=0)
+
+    if expected_overlap:
+        captured_out = torch.zeros_like(out_overlap)
+        ctx = types.SimpleNamespace(attn_metadata={PREFIX: meta_split})
+        graph = torch.cuda.CUDAGraph()
+        torch.accelerator.synchronize()
+        with (
+            patch.object(qwen_gdn_linear_attn, "get_forward_context", return_value=ctx),
+            torch.cuda.graph(graph),
+        ):
+            layer_overlap._forward_core(
+                mixed_qkv=mixed_qkv,
+                b=b,
+                a=a,
+                core_attn_out=captured_out,
+            )
+        graph.replay()
+        torch.accelerator.synchronize()
 
     # ---- Unified path (real _forward_core, meta_unified) ----
     conv_state_unified = conv_state0.clone()

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -122,6 +122,7 @@ if TYPE_CHECKING:
     VLLM_SKIP_P2P_CHECK: bool = False
     VLLM_DISABLED_KERNELS: list[str] = []
     VLLM_ENABLE_FLA_PACKED_RECURRENT_DECODE: bool = True
+    VLLM_GDN_DECODE_PREFILL_OVERLAP: bool = False
     VLLM_DISABLE_PYNCCL: bool = False
     VLLM_USE_OINK_OPS: bool = False
     VLLM_MXFP8_EMULATION_DEQUANT_AT_LOAD: bool = True
@@ -1167,6 +1168,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_ENABLE_FLA_PACKED_RECURRENT_DECODE": lambda: bool(
         int(os.getenv("VLLM_ENABLE_FLA_PACKED_RECURRENT_DECODE", "1"))
+    ),
+    "VLLM_GDN_DECODE_PREFILL_OVERLAP": lambda: bool(
+        int(os.getenv("VLLM_GDN_DECODE_PREFILL_OVERLAP", "0"))
     ),
     # Disable pynccl (using torch.distributed instead)
     "VLLM_DISABLE_PYNCCL": lambda: (

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -86,6 +86,12 @@ _GDN_DECODE_PREFILL_OVERLAP_MIN_PREFILL_TOKENS = 4096
 _gdn_overlap_stream: torch.cuda.Stream | None = None
 
 
+def _gdn_overlap_supported_for_cache_mode(cache_mode: str) -> bool:
+    # Prefix-cache modes may read shared state slots. Keep concurrent state
+    # updates restricted to the one-private-slot-per-request cache contract.
+    return cache_mode == "none"
+
+
 def _get_gdn_overlap_stream() -> torch.cuda.Stream:
     global _gdn_overlap_stream
     if _gdn_overlap_stream is None:
@@ -545,6 +551,9 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             envs.VLLM_GDN_DECODE_PREFILL_OVERLAP
             and current_platform.is_cuda_alike()
             and self.gdn_prefill_backend == "flashinfer"
+            and _gdn_overlap_supported_for_cache_mode(
+                vllm_config.cache_config.mamba_cache_mode
+            )
         )
         self.gdn_overlap_stream = (
             _get_gdn_overlap_stream() if self.gdn_decode_prefill_overlap else None

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -57,6 +57,7 @@ from vllm.third_party.flash_linear_attention.ops.chunk import l2norm_fwd
 from vllm.third_party.flash_linear_attention.ops.utils import FLA_CHUNK_SIZE
 from vllm.transformers_utils.configs.qwen3_next import Qwen3NextConfig
 from vllm.triton_utils import tl, triton
+from vllm.utils.multi_stream_utils import execute_in_parallel
 from vllm.utils.torch_utils import (
     LayerNameType,
     _encode_layer_name,
@@ -80,6 +81,16 @@ if GDN_AITER_TRITON_AVAILABLE:
     )
 
 logger = init_logger(__name__)
+
+_GDN_DECODE_PREFILL_OVERLAP_MIN_PREFILL_TOKENS = 4096
+_gdn_overlap_stream: torch.cuda.Stream | None = None
+
+
+def _get_gdn_overlap_stream() -> torch.cuda.Stream:
+    global _gdn_overlap_stream
+    if _gdn_overlap_stream is None:
+        _gdn_overlap_stream = torch.cuda.Stream()
+    return _gdn_overlap_stream
 
 
 def _resolve_gdn_prefill_backend(
@@ -158,6 +169,59 @@ def _log_gdn_backend_decision(
             "FlashInfer GDN prefill is JIT-compiled; first run may take a "
             "while. Set --gdn-prefill-backend triton to skip JIT.",
         )
+
+
+def _prepare_fi_chunk_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    q = q.squeeze(0).contiguous()
+    k = k.squeeze(0).contiguous()
+    v = v.squeeze(0).contiguous()
+    g = g.squeeze(0).contiguous()
+    beta = beta.squeeze(0).contiguous()
+    fi_state = initial_state.to(torch.float32)
+    fi_g = g.to(torch.float32)
+    fi_beta = beta.to(torch.float32)
+    return q, k, v, torch.exp(fi_g), fi_beta, fi_state
+
+
+def _run_prepared_fi_chunk_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor,
+    cu_seqlens: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    from flashinfer.gdn_prefill import (
+        chunk_gated_delta_rule as chunk_gated_delta_rule_fi,
+    )
+
+    result = chunk_gated_delta_rule_fi(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        initial_state=initial_state,
+        output_final_state=True,
+        cu_seqlens=cu_seqlens,
+    )
+    output, final_state = result
+    return output.unsqueeze(0), final_state
 
 
 def fi_chunk_gated_delta_rule(
@@ -477,6 +541,20 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
 
         self.chunk_gated_delta_rule = ChunkGatedDeltaRule()
         self.gdn_prefill_backend = self.chunk_gated_delta_rule.gdn_prefill_backend
+        self.gdn_decode_prefill_overlap = (
+            envs.VLLM_GDN_DECODE_PREFILL_OVERLAP
+            and current_platform.is_cuda_alike()
+            and self.gdn_prefill_backend == "flashinfer"
+        )
+        self.gdn_overlap_stream = (
+            _get_gdn_overlap_stream() if self.gdn_decode_prefill_overlap else None
+        )
+        self.gdn_overlap_start_event = (
+            torch.cuda.Event() if self.gdn_decode_prefill_overlap else None
+        )
+        self.gdn_overlap_done_event = (
+            torch.cuda.Event() if self.gdn_decode_prefill_overlap else None
+        )
         self._prefill_kernels_warmed_up = False
         self.enable_packed_recurrent_decode = (
             envs.VLLM_ENABLE_FLA_PACKED_RECURRENT_DECODE
@@ -1396,8 +1474,74 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         else:
             core_attn_out_spec, last_recurrent_state = None, None
 
+        use_decode_prefill_overlap = (
+            split_non_spec
+            and self.gdn_decode_prefill_overlap
+            and self.gdn_prefill_backend == "flashinfer"
+            and attn_metadata.num_prefill_tokens
+            >= _GDN_DECODE_PREFILL_OVERLAP_MIN_PREFILL_TOKENS
+        )
+
         # 2.2: Process non-spec-decode part
-        if split_non_spec:
+        if use_decode_prefill_overlap:
+            query_decode, key_decode, value_decode = self.rearrange_mixed_qkv(
+                mixed_qkv_non_spec[:num_decode_tokens]  # type: ignore[index]
+            )
+            prefill_state_indices = attn_metadata.prefill_state_indices
+            prefill_has_initial_state = attn_metadata.prefill_has_initial_state
+            assert prefill_state_indices is not None
+            assert prefill_has_initial_state is not None
+            initial_state = ssm_state[prefill_state_indices]
+            initial_state[~prefill_has_initial_state, ...] = 0
+            prepared_prefill_inputs = _prepare_fi_chunk_gated_delta_rule(
+                query_non_spec,
+                key_non_spec,
+                value_non_spec,
+                g_non_spec,
+                beta_non_spec,
+                initial_state,
+            )
+            assert self.gdn_overlap_stream is not None
+            assert self.gdn_overlap_start_event is not None
+            assert self.gdn_overlap_done_event is not None
+
+            def run_prefill():
+                output, final_state = _run_prepared_fi_chunk_gated_delta_rule(
+                    *prepared_prefill_inputs,
+                    attn_metadata.prefill_query_start_loc,
+                )
+                ssm_state[prefill_state_indices] = final_state.to(ssm_state.dtype)
+                return output, final_state
+
+            def run_decode():
+                return fused_sigmoid_gating_delta_rule_update(
+                    A_log=self.A_log,
+                    a=a[:num_decode_tokens],
+                    b=b[:num_decode_tokens],
+                    dt_bias=self.dt_bias,
+                    q=query_decode,
+                    k=key_decode,
+                    v=value_decode,
+                    initial_state=ssm_state,
+                    inplace_final_state=True,
+                    cu_seqlens=non_spec_query_start_loc[  # type: ignore[index]
+                        : attn_metadata.num_decodes + 1
+                    ],
+                    ssm_state_indices=non_spec_state_indices_tensor,
+                    use_qk_l2norm_in_kernel=True,
+                )
+
+            decode_result, prefill_results = execute_in_parallel(
+                default_fn=run_decode,
+                aux_fns=[run_prefill],
+                start_event=self.gdn_overlap_start_event,
+                done_events=[self.gdn_overlap_done_event],
+                aux_streams=[self.gdn_overlap_stream],
+                enable=True,
+            )
+            core_attn_out_non_spec, last_recurrent_state = prefill_results[0]
+            core_attn_out_decode, _ = decode_result
+        elif split_non_spec:
             query_decode, key_decode, value_decode = self.rearrange_mixed_qkv(
                 mixed_qkv_non_spec[:num_decode_tokens]  # type: ignore[index]
             )
@@ -1422,34 +1566,37 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
 
         # 2.3: Process the remaining part (prefill chunk, or non-spec decode-only)
         if attn_metadata.num_prefills > 0:
-            # State indices, initial-state mask and cu_seqlens for the chunk
-            # kernel are precomputed by the metadata builder (the prefill tail
-            # when decodes are peeled off, else the full non-spec batch), so they
-            # don't need to be re-derived per layer.
-            prefill_state_indices = attn_metadata.prefill_state_indices
-            prefill_has_initial_state = attn_metadata.prefill_has_initial_state
-            assert prefill_state_indices is not None
-            assert prefill_has_initial_state is not None
-            initial_state = ssm_state[prefill_state_indices]
-            initial_state[~prefill_has_initial_state, ...] = 0
-            (
-                core_attn_out_non_spec,
-                last_recurrent_state,
-            ) = self.chunk_gated_delta_rule(
-                q=query_non_spec,
-                k=key_non_spec,
-                v=value_non_spec,
-                g=g_non_spec,
-                beta=beta_non_spec,
-                initial_state=initial_state,
-                output_final_state=True,
-                cu_seqlens=attn_metadata.prefill_query_start_loc,
-                chunk_indices=attn_metadata.chunk_indices,
-                chunk_offsets=attn_metadata.chunk_offsets,
-                use_qk_l2norm_in_kernel=False,
-            )
-            # Init cache
-            ssm_state[prefill_state_indices] = last_recurrent_state.to(ssm_state.dtype)
+            if not use_decode_prefill_overlap:
+                # State indices, initial-state mask and cu_seqlens for the chunk
+                # kernel are precomputed by the metadata builder (the prefill tail
+                # when decodes are peeled off, else the full non-spec batch), so they
+                # don't need to be re-derived per layer.
+                prefill_state_indices = attn_metadata.prefill_state_indices
+                prefill_has_initial_state = attn_metadata.prefill_has_initial_state
+                assert prefill_state_indices is not None
+                assert prefill_has_initial_state is not None
+                initial_state = ssm_state[prefill_state_indices]
+                initial_state[~prefill_has_initial_state, ...] = 0
+                (
+                    core_attn_out_non_spec,
+                    last_recurrent_state,
+                ) = self.chunk_gated_delta_rule(
+                    q=query_non_spec,
+                    k=key_non_spec,
+                    v=value_non_spec,
+                    g=g_non_spec,
+                    beta=beta_non_spec,
+                    initial_state=initial_state,
+                    output_final_state=True,
+                    cu_seqlens=attn_metadata.prefill_query_start_loc,
+                    chunk_indices=attn_metadata.chunk_indices,
+                    chunk_offsets=attn_metadata.chunk_offsets,
+                    use_qk_l2norm_in_kernel=False,
+                )
+                # Init cache
+                ssm_state[prefill_state_indices] = last_recurrent_state.to(
+                    ssm_state.dtype
+                )
 
             if split_non_spec:
                 # Stitch the peeled decode outputs in front of the prefill


### PR DESCRIPTION
## Summary

Overlap the already-separated non-spec GDN recurrent decode update with the
FlashInfer prefill chunk scan in mixed Qwen GDN batches.

The path is opt-in through `VLLM_GDN_DECODE_PREFILL_OVERLAP=1` and remains
fail-closed unless all of the following hold:

- CUDA-like platform;
- FlashInfer GDN prefill backend;
- `mamba_cache_mode="none"`, which provides one private state slot per request;
- mixed non-spec decode + prefill batch;
- at least 4096 prefill tokens.

The existing serial decode-then-prefill route remains unchanged for feature-off,
small, pure, speculative, non-FlashInfer, non-CUDA, and prefix-cache-mode cases.

## Implementation

- Prepare FlashInfer-only dtype/layout conversions before the stream fork.
- Launch the FlashInfer chunk scan first on one shared GDN auxiliary stream.
- Launch recurrent decode on the current stream and join before state/output use.
- Reuse streams and CUDA events created during layer initialization.
- Preserve decode-first output order and disjoint SSM-state updates.

The pre-launch preparation is necessary: traces showed that invoking the full
FlashInfer Python wrapper inside the side stream delayed the scan launch until a
realistic decode kernel had already completed. Splitting preparation from launch
produces actual temporal overlap.

## Duplicate-work check

No open PR was found for recurrent decode/prefill GDN kernel overlap.

- #44700 is the prerequisite split and remains serial.
- #42301 overlaps Qwen GDN input projections, not recurrent kernels.
- #49827 changes the mixed route for batch invariance, not stream scheduling.
- #45717 covers shared-expert/input-projection/copy-elision optimizations, not
  recurrent decode/prefill overlap.

Searches used:

```bash
gh issue view 44700 --repo vllm-project/vllm --comments
gh pr list --repo vllm-project/vllm --state open --search '44700 in:body'
gh pr list --repo vllm-project/vllm --state open --search 'mixed GDN overlap'
gh pr list --repo vllm-project/vllm --state open --search 'decode prefill GDN'
```

## Correctness

The real `_forward_core` test now compares serial, overlapped, and unified
references with metadata from `GDNAttentionMetadataBuilder` across:

- FlashInfer and CuteDSL;
- BF16 and FP32 recurrent state;
- cached and fresh prefill state;
- threshold and below-threshold shapes;
- `none`, `align`, and `all` cache-mode dispatch guards.

It checks output, complete convolution state, complete SSM-state pool, dispatch
gating, and CUDA Graph capture/replay. Replay output, convolution state, and
SSM state are compared against an equivalent serial transition. Serial and
overlap output/state are bitwise equal (`atol=0`, `rtol=0`).

A deterministic 122B serving comparison also produced identical generated text,
input lengths, and output lengths for all 50 requests, with zero failures in
both runs.

## Performance

Environment:

- B300 / CUDA capability 10.3 (platform reports `NVIDIA L20D` mock label)
- vLLM main after v0.26.0
- Qwen3.5-122B TP1 dimensions (`H=16`, `HV=64`, `K=V=128`)
- FlashInfer 0.6.14
- median of 50 repetitions through the real `_forward_core`

| Value heads | Decode | Prefill | State | Serial | Overlap | Speedup |
|---:|---:|---:|---|---:|---:|---:|
| 16 | 8 | 4096 | BF16 | 629.54 us | 586.96 us | 6.76% |
| 16 | 63 | 4096 | BF16 | 627.87 us | 580.05 us | 7.62% |
| 32 | 63 | 4096 | BF16 | 641.46 us | 600.50 us | 6.39% |
| 64 | 63 | 4096 | BF16 | 667.95 us | 639.98 us | 4.19% |
| 64 | 63 | 8192 | FP32 | 957.01 us | 854.24 us | 10.74% |

A PyTorch trace for `(63 decode, 8192 prefill, FP32 state)` shows:

```text
FlashInfer chunk scan: start 2297414353376.758, duration 415.298 us, stream 13
recurrent decode:      start 2297414353552.567, duration 171.553 us, stream 7
```

The recurrent update is temporally contained within the scan for about 171 us.

For the aligned 122B serving guardrail (50 requests, random 4K-12K input,
400-1200 output, concurrency 32), stable feature-off/on repetitions were within
run-to-run noise and showed no material throughput or TPOT regression. A
controlled continuous mixed workload similarly changed throughput by +0.12%
and TPOT by -0.26%. The claim of this PR is the localized mixed GDN layer gain,
not a fixed end-to-end serving percentage; scheduler mixed-step frequency
controls end-to-end exposure.

## Tests

```bash
CUDA_VISIBLE_DEVICES=6 .venv/bin/python -m pytest \
  tests/kernels/mamba/test_gdn_forward_core_split.py -q
# 27 passed

.venv/bin/python -m pytest tests/test_envs.py -q
# 54 passed

.venv/bin/pre-commit run --files \
  vllm/envs.py \
  vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py \
  tests/kernels/mamba/test_gdn_forward_core_split.py \
  benchmarks/kernels/benchmark_gdn_forward_core_overlap.py
# passed

.venv/bin/pre-commit run mypy-3.12 --hook-stage manual --files \
  vllm/envs.py \
  vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
# passed
```

Additional regression run:

```bash
CUDA_VISIBLE_DEVICES=6 .venv/bin/python -m pytest \
  tests/kernels/mamba/test_gdn_prefill_cutedsl.py -q
```

This unrelated CuteDSL numerical suite produced 5 passes and one existing
random-input tolerance failure (`state_error.mean=7.30e-4` vs `6e-4`); the
changed path is FlashInfer-only and the complete mixed `_forward_core` CuteDSL
matrix passed.

## Scope exclusions

- speculative/MTP decode;
- CuteDSL overlap;
- non-CUDA platforms;
- `align` and `all` prefix-cache modes, where state sources may be shared;
- prefill chunks below 4096 tokens.

## AI assistance

This contribution was developed with OpenAI Codex assistance. The human
submitter reviewed the final diff and validation evidence and remains
responsible for the implementation and claims.

