### PR TITLE
[Bugfix] Count prompt-opened Poolside reasoning tokens

### DIFF
--- a/tests/entrypoints/openai/responses/test_parsable_context_unit.py
+++ b/tests/entrypoints/openai/responses/test_parsable_context_unit.py
@@ -7,7 +7,7 @@ Parser (via parse) and properly builds response output items.
 """
 
 from collections.abc import Sequence
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 
@@ -161,7 +161,9 @@ def _make_request(**overrides) -> ResponsesRequest:
 def _make_request_output(
     text: str = "Hello, world!",
     token_ids: Sequence[int] = (1, 2, 3),
-    finish_reason: str = "stop",
+    finish_reason: str | None = "stop",
+    *,
+    finished: bool = True,
 ) -> RequestOutput:
     return RequestOutput(
         request_id="test",
@@ -178,7 +180,7 @@ def _make_request_output(
                 finish_reason=finish_reason,
             )
         ],
-        finished=True,
+        finished=finished,
     )
 
 
@@ -346,6 +348,34 @@ def test_multi_turn_accumulation():
     assert len(ctx.response_messages) == 2
     texts = [m.content[0].text for m in ctx.response_messages]
     assert texts == ["First turn", "Second turn"]
+
+
+def test_reasoning_tokens_counted_per_generation():
+    """Reasoning usage preserves generation boundaries across tool turns."""
+    response_parser = MagicMock()
+    response_parser.parse.return_value = (None, None, None)
+    counter = response_parser.reasoning_parser.count_reasoning_tokens
+    counter.side_effect = [2, 3]
+    ctx = _make_context(None, response_parser=response_parser)
+
+    ctx.append_output(
+        _make_request_output(
+            text="first delta",
+            token_ids=[10],
+            finish_reason=None,
+            finished=False,
+        )
+    )
+    assert ctx.num_reasoning_tokens == 0
+
+    ctx.append_output(_make_request_output(text="first turn", token_ids=[11, 2, 20]))
+    ctx.append_output(_make_request_output(text="second turn", token_ids=[12, 13, 2]))
+
+    assert ctx.num_reasoning_tokens == 5
+    assert counter.call_args_list == [
+        call([10, 11, 2, 20]),
+        call([12, 13, 2]),
+    ]
 
 
 def test_num_init_messages_offset():

--- a/tests/reasoning/test_poolside_v1_reasoning_parser.py
+++ b/tests/reasoning/test_poolside_v1_reasoning_parser.py
@@ -35,6 +35,12 @@ def _make_parser(*, enable_thinking: bool) -> PoolsideV1ReasoningParser:
     "enable_thinking,token_ids,expected",
     [
         pytest.param(True, [10, 11, END_ID, 20], 2, id="prompt_opened_span"),
+        pytest.param(
+            True,
+            [10, 11, END_ID, 20, START_ID, 21],
+            2,
+            id="prompt_opened_span_with_late_start",
+        ),
         pytest.param(True, [10, 11], 2, id="prompt_opened_truncation"),
         pytest.param(True, [9, START_ID, 10, 11, END_ID, 20], 2, id="explicit_span"),
         pytest.param(False, [20, 21], 0, id="disabled_message"),

--- a/tests/reasoning/test_poolside_v1_reasoning_parser.py
+++ b/tests/reasoning/test_poolside_v1_reasoning_parser.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.reasoning.poolside_v1_reasoning_parser import PoolsideV1ReasoningParser
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+START_ID = 1
+END_ID = 2
+TOOL_START_ID = 4
+TOOL_END_ID = 5
+
+
+class _StubTokenizer:
+    def get_vocab(self) -> dict[str, int]:
+        return {
+            "<think>": START_ID,
+            "</think>": END_ID,
+            "<assistant>": 3,
+            "<tool_call>": TOOL_START_ID,
+            "</tool_call>": TOOL_END_ID,
+        }
+
+
+def _make_parser(*, enable_thinking: bool) -> PoolsideV1ReasoningParser:
+    return PoolsideV1ReasoningParser(
+        _StubTokenizer(),
+        chat_template_kwargs={"enable_thinking": enable_thinking},
+    )
+
+
+@pytest.mark.parametrize(
+    "enable_thinking,token_ids,expected",
+    [
+        pytest.param(True, [10, 11, END_ID, 20], 2, id="prompt_opened_span"),
+        pytest.param(True, [10, 11], 2, id="prompt_opened_truncation"),
+        pytest.param(True, [9, START_ID, 10, 11, END_ID, 20], 2, id="explicit_span"),
+        pytest.param(False, [20, 21], 0, id="disabled_message"),
+        pytest.param(False, [TOOL_START_ID, 30, TOOL_END_ID], 0, id="disabled_tool"),
+        pytest.param(True, [END_ID, 20], 0, id="prompt_opened_empty_span"),
+    ],
+)
+def test_count_reasoning_tokens(
+    enable_thinking: bool,
+    token_ids: list[int],
+    expected: int,
+) -> None:
+    parser = _make_parser(enable_thinking=enable_thinking)
+
+    assert parser.count_reasoning_tokens(token_ids) == expected

--- a/vllm/entrypoints/openai/responses/context.py
+++ b/vllm/entrypoints/openai/responses/context.py
@@ -330,6 +330,7 @@ class ParsableContext(ConversationContext):
         self.input_messages: list[ResponseRawMessageAndToken] = []
         self.output_messages: list[ResponseRawMessageAndToken] = []
         self._accumulated_token_ids: list[int] = []
+        self._current_generation_token_ids: list[int] = []
         self.kv_transfer_params: dict[str, Any] | None = None
         self.ec_transfer_params: dict[str, Any] | None = None
 
@@ -381,7 +382,20 @@ class ParsableContext(ConversationContext):
                 )
             )
 
-        self._accumulated_token_ids.extend(completion.token_ids or [])
+        completion_token_ids = completion.token_ids or []
+        self._accumulated_token_ids.extend(completion_token_ids)
+        self._current_generation_token_ids.extend(completion_token_ids)
+        if output.finished:
+            reasoning_parser = (
+                self.response_parser.reasoning_parser
+                if self.response_parser is not None
+                else None
+            )
+            if reasoning_parser is not None:
+                self.num_reasoning_tokens += reasoning_parser.count_reasoning_tokens(
+                    self._current_generation_token_ids
+                )
+            self._current_generation_token_ids = []
 
         if self.request.enable_response_messages:
             output_prompt = output.prompt or ""

--- a/vllm/reasoning/poolside_v1_reasoning_parser.py
+++ b/vllm/reasoning/poolside_v1_reasoning_parser.py
@@ -53,11 +53,10 @@ class PoolsideV1ReasoningParser(DeepSeekV3ReasoningParser):
             return 0
 
         assert isinstance(self._parser, DeepSeekR1ReasoningParser)
-        if self._parser.start_token_id in token_ids:
-            return self._parser.count_reasoning_tokens(token_ids)
-
-        # Laguna's generation prompt can contain the opening <think> token.
+        # The first marker distinguishes explicit from prompt-opened reasoning.
         for index, token_id in enumerate(token_ids):
+            if token_id == self._parser.start_token_id:
+                return self._parser.count_reasoning_tokens(token_ids)
             if token_id == self._parser.end_token_id:
                 return index
         return len(token_ids)

--- a/vllm/reasoning/poolside_v1_reasoning_parser.py
+++ b/vllm/reasoning/poolside_v1_reasoning_parser.py
@@ -48,6 +48,20 @@ class PoolsideV1ReasoningParser(DeepSeekV3ReasoningParser):
             self._start_of_assistant_message
         ]
 
+    def count_reasoning_tokens(self, token_ids: Sequence[int]) -> int:
+        if isinstance(self._parser, IdentityReasoningParser):
+            return 0
+
+        assert isinstance(self._parser, DeepSeekR1ReasoningParser)
+        if self._parser.start_token_id in token_ids:
+            return self._parser.count_reasoning_tokens(token_ids)
+
+        # Laguna's generation prompt can contain the opening <think> token.
+        for index, token_id in enumerate(token_ids):
+            if token_id == self._parser.end_token_id:
+                return index
+        return len(token_ids)
+
     def is_reasoning_end(self, input_ids: Sequence[int]) -> bool:
         # IdentityReasoningParser always returns True: no reasoning to parse.
         if isinstance(self._parser, IdentityReasoningParser):


### PR DESCRIPTION
Count prompt-injected thinking spans through the first closing marker, including generations truncated before the marker, while preserving disabled-thinking accounting.

## Purpose

Poolside Laguna's chat template can inject the opening `<think>` token into the generation prompt. Generated token IDs then begin inside the reasoning span and contain only `</think>`, or contain no marker at all when generation is truncated.

`PoolsideV1ReasoningParser` currently inherits the default token counter through `DeepSeekV3ReasoningParser`, so the Responses API reports `reasoning_tokens=0` even when the parser emitted a reasoning item.

This change adds a Poolside-specific counter that:

- preserves zero reasoning tokens for the `IdentityReasoningParser` path;
- delegates generated `<think>...</think>` spans to the shared counter;
- counts prompt-opened reasoning up to the first `</think>`; and
- counts all generated tokens when generation truncates before `</think>`.

Fixes #49711.

This is not a duplicate of the related open PRs:

- #49743 handles output containing `</think>` without `<think>`, but its current implementation still returns zero when generation truncates before the closing marker.
- #41077 adds DeepSeek V3 forwarding and GLM-specific absent-start handling; it likewise returns zero when no closing marker is generated.
- #49728 changes Poolside's reasoning-parser enablement semantics. This change does not force reasoning on and preserves the existing Identity path for no-thinking messages and native tool calls.

The follow-up also updates ParsableContext to buffer token IDs for the current generation and count reasoning at the RequestOutput.finished boundary. This preserves streaming deltas within a generation while counting built-in-tool follow-up generations independently.

Model evaluation is not applicable because this patch only corrects token accounting in the Responses usage metadata. It does not change model generation, reasoning/content extraction, tool calling, or request execution. No documentation update is required because this restores the intended behavior of an existing API field without introducing a new option or interface.

## Test Plan

```bash
uv run --active --no-sync --with tblib python -m pytest \
  tests/reasoning/test_poolside_v1_reasoning_parser.py \
  tests/reasoning/test_base_thinking_reasoning_parser.py \
  tests/reasoning/test_deepseekv3_reasoning_parser.py \
  tests/reasoning/test_holo2_reasoning_parser.py -q

uv run --active --no-sync --with tblib python -m pytest \
  tests/reasoning/test_poolside_v1_reasoning_parser.py \
  tests/reasoning/test_deepseekr1_reasoning_parser.py \
  tests/entrypoints/openai/responses/test_serving_responses.py::test_reasoning_tokens_counted_for_text_reasoning_model \
  -q

uv run --active --no-sync pre-commit run \
  --from-ref origin/main --to-ref HEAD

git diff --check origin/main...HEAD
```

## Test Result

Before the fix, the new regression cases failed with `3 failed, 3 passed`.

After the fix:

- Targeted reasoning parser and Responses tests: 85 passed, 16 warnings.
- All pre-commit hooks passed.
- git diff --check origin/main...HEAD passed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

