### PR TITLE
[torch.compile] Compile `CustomOp.forward_native` for ReLU^2 to avoid raw torch ops inside opaque custom ops

### DIFF
--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -658,8 +658,8 @@ class ReLUSquaredActivation(CustomOp):
 
     # --8<-- [end:relu2]
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *, compile_native: bool = True):
+        super().__init__(compile_native=compile_native)
         if current_platform.is_cuda_alike():
             self.op = torch.ops._C.relu_squared
 


### PR DESCRIPTION



## Purpose
Following in the footsteps of #32806 , this PR enables the same `compile_native` flag for the ReLU^2 activation, used by NemotronH models.

Before:
<img width="987" height="125" alt="image" src="https://github.com/user-attachments/assets/402016c6-6d9a-484f-bc34-17242b3cd003" />
The first kernel is an elementwise clamp scalar kernel, which takes around 1.47us. The second an elementwise pow tensor scalar, taking around 1.34us.
After:
<img width="987" height="150" alt="image" src="https://github.com/user-attachments/assets/c275b83e-9430-43fc-ac0a-7082f4b96da9" />
A single fused triton kernel, performing pow and ReLU, taking around 1.5us.

For nvidia/Nemotron-3-Nano-30B-A3B-NVFP4, on a single H100, got the following results.

```
vllm bench latency --model nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4

PR:
Avg latency: 0.6291245840994331 seconds
10% percentile latency: 0.6160365409567021 seconds
25% percentile latency: 0.6223003387858626 seconds
50% percentile latency: 0.63013166107703 seconds
75% percentile latency: 0.6364057449973188 seconds
90% percentile latency: 0.6406407461850904 seconds
99% percentile latency: 0.6431744112621527 seconds

Main:
Avg latency: 0.6327978691008563 seconds
10% percentile latency: 0.6289539415040053 seconds
25% percentile latency: 0.6315469837281853 seconds
50% percentile latency: 0.6352052194997668 seconds
75% percentile latency: 0.638096136477543 seconds
90% percentile latency: 0.6411816275212914 seconds
99% percentile latency: 0.6440613135357853 seconds
```

```
vllm bench throughput --model nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4

PR:
Throughput: 25.75 requests/s, 29665.47 total tokens/s, 3296.16 output tokens/s
Total num prompt tokens:  1024001
Total num output tokens:  128000

Main:
Throughput: 25.35 requests/s, 29199.01 total tokens/s, 3244.33 output tokens/s
Total num prompt tokens:  1024001
Total num output tokens:  128000
```

```
vllm serve --model nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4 &
vllm bench serve --model nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4

PR:
============ Serving Benchmark Result ============
Successful requests:                     1000
Failed requests:                         0
Benchmark duration (s):                  39.96
Total input tokens:                      1024001
Total generated tokens:                  128000
Request throughput (req/s):              25.02
Output token throughput (tok/s):         3203.18
Peak output token throughput (tok/s):    12919.00
Peak concurrent requests:                1000.00
Total token throughput (tok/s):          28828.60
---------------Time to First Token----------------
Mean TTFT (ms):                          17417.08
Median TTFT (ms):                        16849.11
P99 TTFT (ms):                           35422.40
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          156.10
Median TPOT (ms):                        165.84
P99 TPOT (ms):                           230.32
---------------Inter-token Latency----------------
Mean ITL (ms):                           156.11
Median ITL (ms):                         104.72
P99 ITL (ms):                            452.80
==================================================

Main:
============ Serving Benchmark Result ============
Successful requests:                     1000
Failed requests:                         0
Benchmark duration (s):                  40.01
Total input tokens:                      1024001
Total generated tokens:                  128000
Request throughput (req/s):              24.99
Output token throughput (tok/s):         3198.93
Peak output token throughput (tok/s):    13504.00
Peak concurrent requests:                1000.00
Total token throughput (tok/s):          28790.42
---------------Time to First Token----------------
Mean TTFT (ms):                          17541.41
Median TTFT (ms):                        17054.20
P99 TTFT (ms):                           35407.77
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          154.88
Median TPOT (ms):                        164.53
P99 TPOT (ms):                           227.81
---------------Inter-token Latency----------------
Mean ITL (ms):                           154.96
Median ITL (ms):                         92.12
P99 ITL (ms):                            463.30
==================================================
```

```
lm_eval --model local-completions --model_args pretrained=nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4,base_url=http://0.0.0.0:8000/v1/completions,num_concurrent=50,max_retries=3 --tasks gsm8k --num_fewshot 5 --batch_size auto --limit 100

PR:
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.48|±  |0.0502|
|     |       |strict-match    |     5|exact_match|↑  | 0.92|±  |0.0273|

Main:
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.44|±  |0.0499|
|     |       |strict-match    |     5|exact_match|↑  | 0.92|±  |0.0273|
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

