### PR TITLE
[Bugfix][ROCm] Reject incompatible mixed KV-cache layouts

### DIFF
--- a/tests/v1/worker/test_attn_utils.py
+++ b/tests/v1/worker/test_attn_utils.py
@@ -1,16 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import pytest
 import torch
 
 from vllm.v1.kv_cache_interface import (
+    CrossAttentionSpec,
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheTensor,
     KVQuantMode,
     MambaSpec,
 )
-from vllm.v1.worker.gpu.attn_utils import _reshape_kv_cache
+from vllm.v1.worker.gpu.attn_utils import (
+    _align_mixed_attention_kv_cache_views,
+    _reshape_kv_cache,
+)
 from vllm.v1.worker.utils import AttentionGroup
 
 
@@ -31,6 +36,10 @@ class FakeFlashAttentionBackend:
     ) -> tuple[int, ...]:
         assert not include_num_layers_dimension
         return (0, 1, 2, 3, 4)
+
+    @staticmethod
+    def get_kv_cache_block_dim(*args, **kwargs) -> int:
+        return 0
 
 
 class FakeHNDFlashAttentionBackend(FakeFlashAttentionBackend):
@@ -153,6 +162,75 @@ class FakeDiffKVBackend:
     ) -> tuple[int, ...]:
         assert not include_num_layers_dimension
         return (0, 1, 2, 3)
+
+
+class FakeKVFirstBackend:
+    @staticmethod
+    def get_kv_cache_block_dim(*args, **kwargs) -> int:
+        return 1
+
+
+def _align_shared_mixed_layout(blocks_first_spec):
+    num_blocks = 3
+    kv_first_spec = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=2,
+        head_size=2,
+        dtype=torch.float32,
+    )
+    raw_tensor = torch.zeros(2 * num_blocks * 16 * 2 * 2)
+    blocks_first_shape = (
+        (num_blocks, 2, 16, 2, 2)
+        if isinstance(blocks_first_spec, CrossAttentionSpec)
+        else (num_blocks, 2, 16, 4)
+    )
+    kv_caches = {
+        "blocks_first": raw_tensor.view(blocks_first_shape),
+        "kv_first": raw_tensor.view(2, num_blocks, 16, 2, 2),
+    }
+    attn_groups = [
+        AttentionGroup(
+            FakeFlashAttentionBackend, ["blocks_first"], blocks_first_spec, 0
+        ),
+        AttentionGroup(FakeKVFirstBackend, ["kv_first"], kv_first_spec, 1),
+    ]
+    kv_cache_config = KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[
+            KVCacheTensor(size=raw_tensor.nbytes, shared_by=list(kv_caches))
+        ],
+        kv_cache_groups=[],
+    )
+    _align_mixed_attention_kv_cache_views(
+        attn_groups,
+        kv_caches,
+        [16, 16],
+        "auto",
+        kv_cache_config,
+    )
+    return kv_caches["blocks_first"]
+
+
+def test_align_rejects_mixed_decoder_kv_cache_layouts():
+    spec = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=2,
+        head_size=2,
+        dtype=torch.float32,
+    )
+    with pytest.raises(ValueError, match="speculative_config.attention_backend"):
+        _align_shared_mixed_layout(spec)
+
+
+def test_aligns_mixed_encoder_decoder_kv_cache_layouts():
+    spec = CrossAttentionSpec(
+        block_size=16,
+        num_kv_heads=2,
+        head_size=2,
+        dtype=torch.float32,
+    )
+    kv_cache = _align_shared_mixed_layout(spec)
+    assert kv_cache.stride() == (64, 192, 4, 2, 1)
 
 
 def test_reshape_padded_diff_kv_cache_does_not_infer_kv_dim():

--- a/tests/v1/worker/test_attn_utils.py
+++ b/tests/v1/worker/test_attn_utils.py
@@ -1,10 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import pytest
 import torch
 
-from vllm.v1.kv_cache_interface import FullAttentionSpec, KVQuantMode
-from vllm.v1.worker.gpu.attn_utils import _reshape_kv_cache
+from vllm.v1.kv_cache_interface import (
+    CrossAttentionSpec,
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheTensor,
+    KVQuantMode,
+)
+from vllm.v1.worker.gpu.attn_utils import (
+    _align_mixed_attention_kv_cache_views,
+    _reshape_kv_cache,
+)
 from vllm.v1.worker.utils import AttentionGroup
 
 
@@ -25,6 +35,10 @@ class FakeFlashAttentionBackend:
     ) -> tuple[int, ...]:
         assert not include_num_layers_dimension
         return (0, 1, 2, 3, 4)
+
+    @staticmethod
+    def get_kv_cache_block_dim(*args, **kwargs) -> int:
+        return 0
 
 
 class FakeHNDFlashAttentionBackend(FakeFlashAttentionBackend):
@@ -147,6 +161,75 @@ class FakeDiffKVBackend:
     ) -> tuple[int, ...]:
         assert not include_num_layers_dimension
         return (0, 1, 2, 3)
+
+
+class FakeKVFirstBackend:
+    @staticmethod
+    def get_kv_cache_block_dim(*args, **kwargs) -> int:
+        return 1
+
+
+def _align_shared_mixed_layout(blocks_first_spec):
+    num_blocks = 3
+    kv_first_spec = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=2,
+        head_size=2,
+        dtype=torch.float32,
+    )
+    raw_tensor = torch.zeros(2 * num_blocks * 16 * 2 * 2)
+    blocks_first_shape = (
+        (num_blocks, 2, 16, 2, 2)
+        if isinstance(blocks_first_spec, CrossAttentionSpec)
+        else (num_blocks, 2, 16, 4)
+    )
+    kv_caches = {
+        "blocks_first": raw_tensor.view(blocks_first_shape),
+        "kv_first": raw_tensor.view(2, num_blocks, 16, 2, 2),
+    }
+    attn_groups = [
+        AttentionGroup(
+            FakeFlashAttentionBackend, ["blocks_first"], blocks_first_spec, 0
+        ),
+        AttentionGroup(FakeKVFirstBackend, ["kv_first"], kv_first_spec, 1),
+    ]
+    kv_cache_config = KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[
+            KVCacheTensor(size=raw_tensor.nbytes, shared_by=list(kv_caches))
+        ],
+        kv_cache_groups=[],
+    )
+    _align_mixed_attention_kv_cache_views(
+        attn_groups,
+        kv_caches,
+        [16, 16],
+        "auto",
+        kv_cache_config,
+    )
+    return kv_caches["blocks_first"]
+
+
+def test_align_rejects_mixed_decoder_kv_cache_layouts():
+    spec = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=2,
+        head_size=2,
+        dtype=torch.float32,
+    )
+    with pytest.raises(ValueError, match="speculative_config.attention_backend"):
+        _align_shared_mixed_layout(spec)
+
+
+def test_aligns_mixed_encoder_decoder_kv_cache_layouts():
+    spec = CrossAttentionSpec(
+        block_size=16,
+        num_kv_heads=2,
+        head_size=2,
+        dtype=torch.float32,
+    )
+    kv_cache = _align_shared_mixed_layout(spec)
+    assert kv_cache.stride() == (64, 192, 4, 2, 1)
 
 
 def test_reshape_padded_diff_kv_cache_does_not_infer_kv_dim():

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -23,6 +23,7 @@ from vllm.v1.attention.backend import (
 )
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
+    CrossAttentionSpec,
     KVCacheConfig,
     KVCacheSpec,
     KVQuantMode,
@@ -398,6 +399,7 @@ def _align_mixed_attention_kv_cache_views(
     logical views so block IDs address the same bytes.
     """
     block_dims_by_layer: dict[str, int] = {}
+    cross_attention_layers: set[str] = set()
     for group in attn_groups:
         kv_cache_spec = group.kv_cache_spec
         if not isinstance(kv_cache_spec, AttentionSpec):
@@ -413,6 +415,8 @@ def _align_mixed_attention_kv_cache_views(
         for layer_name in group.layer_names:
             if layer_name in kv_caches:
                 block_dims_by_layer[layer_name] = block_dim
+                if isinstance(kv_cache_spec, CrossAttentionSpec):
+                    cross_attention_layers.add(layer_name)
 
     for kv_tensor in kv_cache_config.kv_cache_tensors:
         if kv_tensor.block_stride > 0:
@@ -426,17 +430,31 @@ def _align_mixed_attention_kv_cache_views(
             continue
 
         for layer_name in kv_tensor.shared_by:
-            if block_dims_by_layer.get(layer_name) == 0:
-                _restride_blocks_first_kv_cache_to_kv_first_storage(
-                    kv_caches[layer_name]
+            if block_dims_by_layer.get(layer_name) != 0:
+                continue
+            if layer_name not in cross_attention_layers:
+                raise ValueError(
+                    "Cannot align mixed K/V-first and blocks-first KV cache "
+                    f"layouts for non-cross-attention layer {layer_name!r} with "
+                    f"shape {tuple(kv_caches[layer_name].shape)}. Select attention "
+                    "backends with matching KV cache layouts. For speculative "
+                    "decoding, set `speculative_config.attention_backend` "
+                    "explicitly."
                 )
+            _restride_blocks_first_kv_cache_to_kv_first_storage(kv_caches[layer_name])
 
 
 def _restride_blocks_first_kv_cache_to_kv_first_storage(
     kv_cache: torch.Tensor,
 ) -> None:
-    assert kv_cache.ndim >= 3
-    assert kv_cache.shape[1] == 2
+    if kv_cache.ndim < 3 or kv_cache.shape[1] != 2:
+        raise ValueError(
+            "Cannot align mixed K/V-first and blocks-first KV cache layouts for "
+            f"shape {tuple(kv_cache.shape)}. The blocks-first cache must have an "
+            "explicit K/V dimension at index 1. Select attention backends with "
+            "matching KV cache layouts. For speculative decoding, set "
+            "`speculative_config.attention_backend` explicitly."
+        )
     page_size = kv_cache.shape[2:].numel()
     num_blocks = kv_cache.shape[0]
     expected_tail_stride = torch.empty(kv_cache.shape[2:]).stride()

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -23,6 +23,7 @@ from vllm.v1.attention.backend import (
 )
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
+    CrossAttentionSpec,
     KVCacheConfig,
     KVCacheSpec,
     KVQuantMode,
@@ -482,6 +483,7 @@ def _align_mixed_attention_kv_cache_views(
     logical views so block IDs address the same bytes.
     """
     block_dims_by_layer: dict[str, int] = {}
+    cross_attention_layers: set[str] = set()
     for group in attn_groups:
         kv_cache_spec = group.kv_cache_spec
         if not isinstance(kv_cache_spec, AttentionSpec):
@@ -497,6 +499,8 @@ def _align_mixed_attention_kv_cache_views(
         for layer_name in group.layer_names:
             if layer_name in kv_caches:
                 block_dims_by_layer[layer_name] = block_dim
+                if isinstance(kv_cache_spec, CrossAttentionSpec):
+                    cross_attention_layers.add(layer_name)
 
     for kv_tensor in kv_cache_config.kv_cache_tensors:
         if kv_tensor.block_stride > 0:
@@ -515,17 +519,31 @@ def _align_mixed_attention_kv_cache_views(
             continue
 
         for layer_name in kv_tensor.shared_by:
-            if block_dims_by_layer.get(layer_name) == 0:
-                _restride_blocks_first_kv_cache_to_kv_first_storage(
-                    kv_caches[layer_name]
+            if block_dims_by_layer.get(layer_name) != 0:
+                continue
+            if layer_name not in cross_attention_layers:
+                raise ValueError(
+                    "Cannot align mixed K/V-first and blocks-first KV cache "
+                    f"layouts for non-cross-attention layer {layer_name!r} with "
+                    f"shape {tuple(kv_caches[layer_name].shape)}. Select attention "
+                    "backends with matching KV cache layouts. For speculative "
+                    "decoding, set `speculative_config.attention_backend` "
+                    "explicitly."
                 )
+            _restride_blocks_first_kv_cache_to_kv_first_storage(kv_caches[layer_name])
 
 
 def _restride_blocks_first_kv_cache_to_kv_first_storage(
     kv_cache: torch.Tensor,
 ) -> None:
-    assert kv_cache.ndim >= 3
-    assert kv_cache.shape[1] == 2
+    if kv_cache.ndim < 3 or kv_cache.shape[1] != 2:
+        raise ValueError(
+            "Cannot align mixed K/V-first and blocks-first KV cache layouts for "
+            f"shape {tuple(kv_cache.shape)}. The blocks-first cache must have an "
+            "explicit K/V dimension at index 1. Select attention backends with "
+            "matching KV cache layouts. For speculative decoding, set "
+            "`speculative_config.attention_backend` explicitly."
+        )
     page_size = kv_cache.shape[2:].numel()
     num_blocks = kv_cache.shape[0]
     expected_tail_stride = torch.empty(kv_cache.shape[2:]).stride()


### PR DESCRIPTION
## Purpose

Fixes #50237.

Mixed block dimensions are only safe for the encoder-decoder cross-attention
case this alignment path was designed for. A speculative target/drafter pair can
otherwise hit an assertion, or bypass the shape check when it has two KV heads.
Validate the blocks-first layer is cross-attention before restriding and report
the layer, shape, and `speculative_config.attention_backend` remedy. Backend
selection is unchanged.

AI assistance: OpenAI Codex assisted with investigation and drafting. The human
submitter reviewed and understands every changed line.

## Test Plan

```text
.venv/bin/pre-commit run --files vllm/v1/worker/gpu/attn_utils.py tests/v1/worker/test_attn_utils.py
.venv/bin/pre-commit run --hook-stage manual mypy-3.12 --files vllm/v1/worker/gpu/attn_utils.py tests/v1/worker/test_attn_utils.py
pytest tests/v1/worker/test_attn_utils.py -q
```

Run stock, patched, and matching-backend startup arms on 8x MI308X using the
same vLLM 0.26.0 ROCm image and MiniMax-M3/DSpark inputs.

## Test Result

- Contributor hooks and Python 3.12 mypy pass.
- The complete unit file passes: `6 passed`. With two KV heads, the new negative
  test fails against stock because the incompatible layout does not raise.
- Stock target `TRITON_ATTN` plus drafter `ROCM_ATTN` reproduces the assertion on
  all workers.
- The final patched arm reports the non-cross-attention layer, shape
  `(213012, 1, 128, 256)`, and the matching-backend remedy.
- Stock target and drafter `TRITON_ATTN` reach readiness; all four smoke prompts
  finish with `stop` (230/360 draft tokens accepted).

No benchmark or LMCache workload was run.
