### PR TITLE
[Draft][Reload] Add manifest-driven load receipts and update scopes

### DIFF
--- a/TRANSACTION.md
+++ b/TRANSACTION.md
@@ -1,0 +1,517 @@
+# 将权重更新设计成事务：#48312 的统一方案
+
+状态：**部分实现，持续演进**。本文结合 `feat/reload-arena` 分支的历史提交、`REPORT.md`、`DESIGN.md` 和 `LOAD_MANIFEST_DESIGN.md`，描述权重 reload/transfer 应当具备的事务语义，并明确哪些能力已经落地、哪些仍属于后续设计。当前实现已经覆盖稳定存储、首次加载 manifest、manifest 驱动完成条件、结构化 `LoadReceipt` 和 event-key collision 审计，但尚未实现统一的 `ReloadTransaction` 协调器、跨 rank 的全局 commit barrier、失败回滚，以及缓存代际等所有检查器。
+
+## 1. 为什么要把权重更新看成事务
+
+一次 RL 权重同步或 checkpoint reload 并不是简单执行若干次 `copy_`。它会经过暂停请求、接收权重、恢复 checkpoint 布局、调用不同类型的 `weight_loader`、重新运行 `process_weights_after_loading`（下文简称 PWAL）、重建量化或 MoE 派生状态、恢复 KV cache 并继续推理。任何一步不完整，都可能出现“接口返回成功，但模型已经处于部分更新或内部状态不一致”的情况。
+
+因此，正确性不能定义为“函数没有抛异常”，而应定义为：**本次更新声明的全部 source 均已到达；每个 source 被正确路由到本 rank 的目标 fragment；所有必需 fragment 均已消费；PWAL 后图可见存储地址没有漂移；所有 rank 都通过检查；只有这时模型才能恢复服务。** 这对应下面的事务生命周期：
+
+```text
+BEGIN
+  → 建立本次更新的 scope 和基线
+  → APPLY：接收并加载权重
+  → FINALIZE：完成 PWAL 和层恢复
+  → VALIDATE：source、event manifest、arena、其他状态逐项对账
+  → COMMIT：所有检查通过后恢复推理
+  → ABORT：任一检查失败则禁止将本次更新视为成功
+```
+
+这里的“事务”强调原子可见性、完整性验证和统一提交门禁，不等同于数据库事务。当前只有部分检查已经 fail closed：首次基线 collision、dummy 首次真实更新不完整以及显式声明的 source manifest 不匹配会直接失败；普通 reload 的 completion/arena 问题目前主要进入 `LoadManifestReport`，仍要求调用方检查 `report.ok`。因此统一 commit gate 尚未完成。系统也没有保存旧权重副本，所以 **ABORT 目前表示拒绝把更新视为成功并停止继续服务，不表示已经自动回滚到旧模型值**。
+
+
+### 1.1 端到端事务流程图
+
+下面保留原方案中的服务生命周期，并将当前已经实现的 manifest、receipt 和 arena 校验放回统一事务位置：
+
+```mermaid
+flowchart LR
+    A[暂停接收新请求] --> B[Drain 在途请求]
+    B --> C[Sleep / 释放 KV cache]
+    C --> D[BEGIN 权重更新事务]
+    D --> E[声明 transaction scope<br/>source manifest / rank / generation]
+    E --> F[APPLY 接收并加载权重]
+    F --> G[FINALIZE<br/>Layerwise processing + PWAL]
+    G --> H[VALIDATE]
+    H --> H1[Source manifest 对账]
+    H --> H2[Required / received event 对账]
+    H --> H3[LoadReceipt collision 审计]
+    H --> H4[ReloadArena storage 校验]
+    H1 --> I{所有本地检查通过?}
+    H2 --> I
+    H3 --> I
+    H4 --> I
+    I -- 否 --> X[ABORT<br/>禁止恢复服务并报告 findings]
+    I -- 是 --> J{所有 rank 都通过?}
+    J -- 否或超时 --> X
+    J -- 是 --> K[COMMIT<br/>提升 weight generation]
+    K --> L[Wake KV cache]
+    L --> M[失效旧 generation 缓存]
+    M --> N[恢复推理服务]
+```
+
+事务内部的实际权重加载流程如下：
+
+```mermaid
+flowchart TD
+    A[BEGIN] --> B{是否已有精确 required_keys?}
+    B -- 是 --> C[Snapshot arena<br/>恢复 checkpoint/meta 布局]
+    B -- 否: dummy/首次在线量化 --> D[建立 provisional required_target_keys]
+    C --> E[安装 online weight_loader wrapper]
+    D --> E
+    E --> F[读取或接收 source tensor]
+    F --> G[设置 current source key]
+    G --> H[执行真实 weight_loader]
+    H --> I[获得结构化 LoadReceipt]
+    I --> J[生成 source=>target fragment event]
+    J --> K[记录 LoadCallWitness 并执行 collision audit]
+    K --> L{Receipt consumed?}
+    L -- 否: non-local / skipped --> M[继续下一个 source]
+    L -- 是 --> N[加入 received_keys 和 received_target_keys]
+    N --> O{已有精确 manifest 且本层事件齐全?}
+    O -- 是 --> P[本层 PWAL 并验证 arena]
+    O -- 否 --> M
+    P --> M
+    M --> Q{source stream 结束?}
+    Q -- 否 --> F
+    Q -- 是 --> R[FINALIZE 剩余层]
+    R --> S[最终 required/received/target 对账]
+    S --> T{首次真实更新且目标完整?}
+    T -- 是 --> U[将 received_keys 提升为永久 required_keys]
+    T -- 否或已有基线 --> V[保留原 required_keys]
+    U --> W[生成 rank-local LoadManifestReport]
+    V --> W
+```
+
+## 2. 需要维护的事务不变量
+
+| 类别 | 不变量 | 当前状态 |
+|---|---|---|
+| 存储身份 | CUDA Graph、量化 kernel 或 MoE workspace 捕获的地址在 reload 前后不变 | 已实现 arena 与逐层校验 |
+| source 完整性 | 发送端声明的 source 名称与接收端实际收到的名称一致 | 已实现 transfer source manifest；dummy 首次真实传输强制声明 |
+| loader 完整性 | 首次加载实际消费的逻辑事件，在 reload 时全部再次发生 | 已实现 required/received manifest |
+| fragment 唯一性 | Q/K/V、MoE expert/shard 等不能因为回执字段缺失而折叠为同一事件 | 已实现结构化 `LoadReceipt` 与 collision audit |
+| 完成时机 | 层是否完成由事件集合决定，不能由内部 `copy_` 次数或 numel 猜测 | 已实现 manifest 驱动，`load_numel` 已删除 |
+| rank 隔离 | TP/PP/DP/EP 各 rank 只验证本 rank 应消费的 fragment | 已实现 rank-local report；全局 barrier 尚未统一实现 |
+| 无 key 状态 | 非持久 buffer、alias、派生值在 reload 后应保留或按声明重建 | 部分覆盖，统一 checker 尚未实现 |
+| 路由正确性 | source 不仅要“被加载”，还必须落到正确 rank、expert 和 shard | receipt 提供身份；跨 rank sentinel 仍待实现 |
+| 缓存一致性 | prefix cache、LoRA、多模态缓存等不得继续使用旧权重代际 | 尚未实现统一 generation checker |
+
+这些不变量由不同机制维护，但它们共享同一个提交时刻，因此应由统一事务报告汇总，而不是散落在各个入口函数里各自判断。
+
+## 3. 当前实现的历史演进
+
+本分支不是一次性加入完整事务，而是按“先稳定存储，再建立可验证 manifest，最后让 manifest 成为完成条件”的顺序演进：
+
+| 提交 | 作用 |
+|---|---|
+| `5532d3a69` | 引入 layer-owned `ReloadArena`，为图可见临时 tensor 提供稳定存储 |
+| `6f725f866`、`dead65972` | 将 Machete、RDNA3 WNA16 MoE 等派生 scratch 接入 arena |
+| `14a226b68` | 捕获 module-level tensor storage，补充 arena 以外的第二层存储检查 |
+| `91e05c188`～`ba8bd7a2f` | 建立 registry、首次 forward、dataflow 和 MoE experts 的 CI 扫描 |
+| `bdc1ee506` | 将 arena snapshot/verify 放入逐层 reload 流程 |
+| `3a90010d3` | required 集合改为首次真实加载时观察，不再根据模型结构预测 |
+| `7645c60fb` | 加入 source、target、fragment manifest，覆盖多 loader 和 weight-transfer 路径 |
+| `19969814d` | 删除 `load_numel/load_numel_total`，由 manifest 决定完成时机 |
+| `cd44e02e3` | 引入结构化 `LoadReceipt`，迁移 QKV、MergedColumn、RoutedExperts 和 composed loader |
+| `810280d52` | 引入 event-key collision 审计，检测 receipt 字段遗漏、状态冲突和 schema 漂移 |
+
+因此，旧文档中把 `CompletionManifestChecker` 标成“design”的描述已经过时：manifest、结构化回执和 collision audit 已经有代码和模型验证。仍未落地的是将这些能力统一包装成一个显式 `ReloadTransaction` 对象，以及将所有 rank 的报告统一成一个全局 commit 决策。
+
+
+### 3.1 实现状态总览
+
+本文使用以下标记，避免把目标设计误写成现有能力：
+
+- **【已实现】**：分支中已经有代码，并至少经过单元测试或真实模型验证；
+- **【部分实现】**：底层数据和局部检查已经存在，但尚未接入统一 commit gate，或仍有入口没有覆盖；
+- **【待实现】**：当前只有设计，没有可依赖的完整运行时代码；
+- **【待定】**：接口形式尚未确定，文中的代码仅用于表达职责边界，不能作为最终 API。
+
+#### 已实现
+
+- ReloadArena 稳定存储、逐层 snapshot/verify，以及 module-level storage manifest；
+- 首次 checkpoint 加载期间观察 `required_keys`，reload 期间记录 `received_keys`；
+- source→target fragment event、rank-local `LoadManifestScope/LoadManifestReport`；
+- dummy 首轮 provisional target baseline，以及完整首轮后提升为精确事件基线；
+- manifest 完成条件取代 `load_numel/load_numel_total`；
+- `LoadReceipt/LoadFragment`，以及 QKV、MergedColumn、RoutedExperts、composed loader 接入；
+- event-key/target collision、状态冲突、schema drift 和声明不匹配审计；
+- WeightTransferEngine 的 declared source manifest 检查；
+- Qwen3 MoE TP/EP、Qwen CUDA IPC 和多类 synthetic 负向测试。
+
+#### 部分实现
+
+- Fail-closed：首次 collision、dummy 首轮不完整和 declared source mismatch 已直接失败；普通 reload 的 completion/arena finding 仍主要依赖调用方检查 `report.ok`；
+- 分布式提交：已经生成 rank-local scope/report，并做过多 rank 验证，但尚无统一 all-rank commit barrier；
+- loader 覆盖：标准 checkpoint、IPC/NCCL 和若干 external loader 已接入，sparse/direct mutation 仍需独立事务 hook；
+- draft/MTP：设计上要求独立 scope，但尚未形成统一 model-role/generation 协议；
+- keyless state 和派生状态：arena 覆盖部分图可见 tensor，尚无统一 buffer/alias checker。
+
+#### 待实现
+
+- 统一事务协调器及其最终 API；
+- 所有 rank 的 commit barrier、timeout 和 all-or-none resume；
+- rollback：shadow model/双缓冲或 undo log；
+- transaction ID、weight generation、晚到 chunk 和并发更新隔离；
+- sparse/direct update 的标准 source/dirty-generation 协议；
+- `LoaderEpochChecker`、`KeylessStateChecker`、`ShardRoutingChecker`、`CacheGenerationChecker` 和 `IdempotencyChecker`；
+- target、draft、MTP 的正式 scope 数据结构及独立对账；
+- prefix cache、LoRA、多模态等缓存的 generation 失效机制。
+
+## 4. 【已实现】事务中的三层身份
+
+### 4.1 Source identity
+
+source identity 是发送端或 checkpoint 侧的稳定权重名称，例如：
+
+```text
+model.layers.0.self_attn.q_proj.weight
+model.layers.0.mlp.experts.7.gate_proj.weight
+```
+
+checkpoint loader 通过 `observe_weight_sources()` 在迭代权重时保存当前 source key，使模型内部经过名称映射、packed routing 或 expert routing 后仍能知道原始 source。IPC/NCCL 等分块传输还可以独立声明 `expected_source_names`，接收端在 transaction finalize 时检查：
+
+```text
+missing = expected_source_names - received_source_names
+unexpected = received_source_names - expected_source_names
+```
+
+dummy 初始化没有真实 checkpoint source，因此无法从首次 dummy load 学到 source 基线。对于可能分块、丢包或由调用方决定发送集合的 IPC/NCCL 传输，第一次真实传输必须携带权威 source manifest；否则无法判断某个从未到达的 source。直接读取完整 checkpoint 文件时，checkpoint 索引/迭代器本身可以作为 source 边界，但仍要结合 provisional target baseline 检查本 rank 的目标是否全部触达。
+
+### 4.2 Target fragment identity
+
+一个 Parameter 不一定对应一个逻辑权重。QKV、merged MLP、MoE 和量化权重经常将多个 source 写入同一个 packed Parameter，因此目标身份必须表示为：
+
+```text
+param_name + logical fragment
+```
+
+例如：
+
+```text
+weight[loaded_shard_id='q']
+w13_weight[shard_id='w1',expert_id=7,weight_name='...w13_weight']
+```
+
+### 4.3 Full load event identity
+
+最终 manifest 事件是：
+
+```text
+source_key => target fragment
+```
+
+例如：
+
+```text
+model.layers.0.self_attn.q_proj.weight=>weight[loaded_shard_id='q']
+model.layers.0.mlp.experts.7.gate_proj.weight=>w13_weight[shard_id='w1',expert_id=7,weight_name='model.layers.0.mlp.experts.w13_weight']
+```
+
+事务完成条件比较的是完整事件集合；collision audit 还会单独比较去掉 source 后的 target fragment，防止不同 source 因 receipt 不完整而错误声明同一个目标区域。
+
+## 5. 【已实现】结构化 LoadReceipt
+
+每次逻辑 loader 调用返回一个结构化回执：
+
+```python
+@dataclass(frozen=True)
+class LoadReceipt:
+    consumed: bool
+    fragment: LoadFragment
+    collision_policy: LoadCollisionPolicy
+```
+
+普通成功加载：
+
+```python
+return LoadReceipt.accepted(loaded_shard_id="q")
+```
+
+当前 rank 不负责的 expert：
+
+```python
+return LoadReceipt.skipped(
+    shard_id=shard_id,
+    expert_id=expert_id,
+    weight_name=weight_name,
+)
+```
+
+分支复杂、暂时仍返回 `None/bool` 的旧 loader 可以用 decorator 迁移：
+
+```python
+@returns_load_receipt("shard_id", "expert_id", "weight_name")
+def weight_loader(..., return_success=False):
+    ...
+```
+
+`LoadReceipt.__bool__()` 保留旧条件 loader 的 truthiness，因此现有 `if success:` 路由可以继续工作。尚未迁移的 loader 通过 `_legacy_load_receipt(bound_args, result)` 兼容；该路径仍会从约定参数名推测 fragment，只是迁移期 fallback，不应成为新增 loader 的默认设计。
+
+### 5.1 当前模型路径的 fragment 定义
+
+| Loader | Receipt fragment | 原因 |
+|---|---|---|
+| `QKVParallelLinear` | `loaded_shard_id=q/k/v` | 同一个 packed Parameter 内必须区分 Q、K、V 区域 |
+| `MergedColumnParallelLinear` | `loaded_shard_id=0/1/...` | gate/up 等 source 写入不同 merged shard |
+| `RoutedExperts` | `shard_id + expert_id + weight_name` | 区分 expert、w1/w2/w3 及量化或特殊权重分支 |
+| 普通一对一 loader | 空 fragment | source 和 param 已足以确定唯一目标 |
+| composed loader | 原样传播底层 receipt | 后处理 `copy_(fn(param))` 不是第二个 source 消费事件 |
+
+receipt 描述的是“本次 loader 调用消费了哪个逻辑 fragment”，而不是内部执行了几次 `copy_`。这正是它能够覆盖 #44814 类型问题的原因。
+
+## 6. 【已实现】Event-key collision 审计
+
+只比较首次基线和 reload 的集合仍有盲点：如果首次加载和 reload 都返回同一个不完整 receipt，两个不同 fragment 会在两边同时折叠，最终仍可能出现 `required == received`。`810280d52` 增加了独立于 receipt 的 `LoadEventAudit` 来检测这种情况。
+
+每次 loader 调用除了生成 manifest key，还生成 `LoadCallWitness`。witness 记录：loader 的 module/qualname、source key、目标参数名、`BoundArguments` 中稳定可序列化的标量参数，以及 loaded tensor 的 shape/dtype；它不记录 Tensor 内容、对象地址或设备指针。审计类型包括：
+
+| Finding | 含义 |
+|---|---|
+| `EVENT_KEY_COLLISION` | 同一完整 event key 对应两个不同调用 witness |
+| `TARGET_ALIAS_COLLISION` | 不同 source 或调用错误地声明同一 target fragment |
+| `STATUS_CONFLICT` | 同一逻辑事件在同一事务中既 accepted 又 skipped |
+| `SCHEMA_DRIFT` | 同一个 loader 在一轮加载中返回了不同 fragment schema |
+| `RECEIPT_SCHEMA_MISMATCH` | decorator 声明的字段与实际 receipt 不一致 |
+
+例如 QKV loader 漏掉 `loaded_shard_id` 时，完整 source key 仍然不同，但 target 都退化为 `weight`，审计会给出：
+
+```text
+TARGET_ALIAS_COLLISION
+first_source=q_proj.weight
+second_source=k_proj.weight
+differing_arguments=('loaded_shard_id',)
+possible_missing_receipt_fields=('loaded_shard_id',)
+```
+
+完全相同的重复调用不视为 identity collision。如果业务确实需要多个 source 有意覆盖同一目标，loader 必须显式返回 `collision_policy=LoadCollisionPolicy.OVERWRITE`；不能使用按模型名称维护的隐式白名单。
+
+首次 checkpoint 加载在 `finalize_load_recording()` 汇总 collision，发现问题就拒绝建立错误基线；reload 阶段将 collision 写入 `LoadManifestReport.completion_findings`，使该 rank 的 `report.ok` 变为 false。
+
+## 7. 【已实现】Manifest 的建立与使用
+
+### 7.1 普通 checkpoint 首次加载
+
+```text
+模型参数已经创建
+→ record_metadata_for_reloading(model)
+→ record_load_consumption(model)，包装每个有效 weight_loader
+→ checkpoint stream 逐个设置 source context
+→ loader 返回或被适配为 LoadReceipt
+→ 记录 source=>target[fragment] 到 required_keys
+→ 同时运行 LoadEventAudit
+→ finalize_load_recording(model)
+→ 恢复原 loader；collision 为零后基线生效
+```
+
+`required_keys` 是实际观察结果，不是根据 `state_dict()`、Parameter 数量或模型架构预测出来的集合。因此 EP 非本地 expert、共享 alias、没有 checkpoint source 的运行时状态不会被错误加入本 rank 的 required 集合。
+
+### 7.2 普通 reload
+
+```text
+initialize_layerwise_reload(model)
+→ snapshot arena
+→ 将需要重载的层恢复到 meta/checkpoint 布局
+→ 安装 online loader wrapper
+→ 每个成功 receipt 加入 received_keys
+→ required_keys ⊆ received_keys 时允许该层执行 PWAL
+→ checkpoint iterator 结束后做最终集合对账
+→ 校验 arena snapshot
+→ 生成 rank-local LoadManifestReport
+```
+
+完成条件是事件集合，不再使用 `load_numel >= load_numel_total`。`copied_numel_diagnostic` 可以保留用于日志，但不参与完成、commit 或 fallback 判断。
+
+### 7.3 Dummy 初始化后的第一次真实传输
+
+Dummy loader 没有 source stream，只能建立 provisional target baseline：
+
+```text
+required_target_keys = 本 rank 必须触达的参数目标
+required_keys = 空，表示尚无精确 source/fragment 基线
+```
+
+第一次真实更新必须完成目标检查；对于 IPC/NCCL 等分块传输还必须完成 source 检查：发送端声明的 source manifest 全部到达，并且所有 provisional target 都至少被成功 receipt 触达。由于一个 target 可能承载多个 QKV/MoE fragment，这一轮不能在第一次触达 target 后提前执行 PWAL，必须缓冲到事务结束。验证通过后，本轮 `received_keys` 被提升为永久 `required_keys`，后续 reload 即可按精确事件逐层完成。
+
+### 7.4 在线量化与外部 tensor loader
+
+首次在线量化同样可能没有精确 fragment 基线，应使用 provisional target 流程。对于 Modelexpress、RunAI、Tensorizer 或直接传输已经处理好的 tensor、完全绕过 `weight_loader` 的路径，不能伪造 loader receipt；它们应通过 `record_external_tensor_manifest()` 或 `record_direct_load_consumption()` 发布 source→target 事件。覆盖能力必须按 loader 的真实数据流声明，不能仅因为目录中存在某个 loader 文件就认为已经自动覆盖。
+
+## 8. 【已实现】存储事务：ReloadArena 与 PWAL
+
+manifest 证明“该加载的逻辑权重都加载了”，arena 证明“PWAL 后图和 kernel 仍引用正确存储”。两者解决不同问题，必须同时存在。
+
+每个使用 arena 的 layer 在 reload 开始时 snapshot slot identity；PWAL 重建后调用 `arena.verify(snapshot)`，检查 slot 是否消失、地址移动或 layout 改变。arena 自身拥有稳定 buffer，PWAL 通过 `put()` 将新派生值写回已有 storage，而不是重新绑定 graph-visible tensor。逐层验证必须发生在 `LayerReloadingInfo.reset()` 之前，否则 snapshot 会丢失。
+
+当前 `LoadManifestReport` 包含：
+
+```python
+LoadManifestReport(
+    scope=LoadManifestScope(...),
+    required_event_count=...,
+    received_event_count=...,
+    completion_findings=(...),
+    arena_findings=(...),
+)
+```
+
+`report.ok` 只有在 completion 和 arena finding 都为空时才为 true。collision finding 当前归入 completion findings。
+
+## 9. 【部分实现】分布式事务 scope 与提交决策
+
+manifest 必须按 worker/rank 保存，不能先跨 rank 求并集。TP、PP、EP worker 本来就消费不同 fragment；如果先合并，rank 0 缺失的事件可能被 rank 1 的事件掩盖。每份 report 携带：global rank/world size，以及 TP、PP、DP、EP 的 rank/world size。
+
+正确的全局提交协议应当是：
+
+```text
+每个 rank 完成本地 APPLY 和 VALIDATE
+→ controller 收集所有 rank 的 LoadManifestReport
+→ 任一 report.ok == false，则整个 update ABORT
+→ 所有 report.ok == true，经过 barrier 后统一 COMMIT/RESUME
+```
+
+当前已经能够生成和收集 rank-local report，也完成了 TP/EP 等模型验证；但统一的全局 commit barrier 尚未抽象成通用 `ReloadTransaction`。在此之前，各入口必须明确检查所有 worker report，不能只检查 rank 0，也不能让通过的 rank 先恢复请求。
+
+MTP 和投机推理应使用独立 scope。target model 与 draft model 可能具有不同参数集合、并行配置和更新节奏，不能把事件放进同一个无前缀集合。建议 scope 至少包含：
+
+```text
+model_role = target | draft | mtp
+model_instance_id
+parallel coordinates
+weight generation
+```
+
+如果只更新 target，draft scope 必须明确声明“不参与本事务”，而不是因没有 receipt 被误判为缺失。
+
+## 10. 【部分实现】入口覆盖与事务边界
+
+权重更新入口并不唯一：checkpoint `reload_weights`、IPC、NCCL、sparse NCCL、Modelexpress、RunAI、Tensorizer，以及框架通过 RPC 直接调用 `model.load_weights`。因此不能只在某个 API 名称上放一个 gate，然后声称覆盖全部流程。
+
+当前可归纳为三类：
+
+1. **调用标准 `weight_loader` 的 checkpoint-format 路径**：通过 source observation、LoadReceipt、layerwise manifest 和 arena 完整覆盖。
+2. **传输已处理 tensor、直接恢复 state 的路径**：通过 external/direct manifest 发布事件，不应强行套用 fragment loader 语义。
+3. **直接对已有 Parameter 做 `index_copy_` 等 sparse patch 的路径**：不会触发标准 loader，需要独立声明 source manifest、dirty generation 和 commit 检查；这是当前仍需继续补齐的路径。
+
+未来统一协调器应位于“模型恢复推理之前”，而不是绑定某个调用入口。所有入口都必须执行：`begin_update → observe/apply → finish_update → validate → commit`。嵌套入口必须有 transaction depth/reentrancy guard，避免 `reload_weights`、NCCL engine 和 `model.load_weights` 重复执行 initialize/finalize。
+
+## 11. 【待定】统一 ReloadTransaction 的候选职责与接口
+
+> **接口待定：** 当前尚未决定最终由 `ReloadTransaction` 类、WeightTransferEngine 生命周期，还是 worker/controller 协议承担协调职责。下面的代码只表达 BEGIN/APPLY/FINALIZE/VALIDATE/COMMIT/ABORT 的职责边界，不是已实现接口，也不作为后续代码必须遵循的类名、方法签名或调用层级。
+
+候选职责可以表示为：
+
+```python
+class ReloadTransaction:
+    def begin(self) -> None:
+        """冻结 scope，清空本轮 received 状态，snapshot arena/cache。"""
+
+    def apply(self, update) -> None:
+        """唯一允许修改模型状态的阶段。"""
+
+    def finalize(self) -> None:
+        """完成 layerwise processing、PWAL 和 backend finalize。"""
+
+    def validate(self) -> list[LoadManifestReport]:
+        """只读汇总 source、receipt、collision、arena 和扩展 checker。"""
+
+    def commit(self) -> None:
+        """所有 rank 通过后提升 generation 并恢复服务。"""
+
+    def abort(self, findings) -> NoReturn:
+        """禁止恢复服务；未来可在这里执行 rollback。"""
+```
+
+检查器建议采用统一协议：
+
+```python
+class ReloadChecker(Protocol):
+    name: str
+    def snapshot(self, ctx: ReloadContext) -> None: ...
+    def verify(self, ctx: ReloadContext) -> list[Finding]: ...
+```
+
+已经具备 checker 数据基础的模块包括：`CompletionManifestChecker`（required/received/source/collision）和 `StorageIdentityChecker`（arena/module storage）。后续应补充：
+
+- `KeylessStateChecker`：persistent=False buffer、alias 和无 checkpoint key 状态；
+- `LoaderEpochChecker`：防止 checkpoint-layout loader 写入 kernel-layout storage；
+- `ShardRoutingChecker`：通过 rank-distinct sentinel 验证 TP/EP 路由；
+- `CacheGenerationChecker`：更新后使 prefix/LoRA/多模态缓存失效；
+- `IdempotencyChecker`：identity reload 时验证参数、buffer、storage 和输出不变。
+
+## 12. 【部分实现 / 待完善】失败语义、rollback 与并发
+
+当前事务最重要的保证是“不把未验证更新报告为成功”。发现以下问题时必须失败：source manifest 缺失或多余；required event 未收到；dummy target 未触达；LoadReceipt collision/schema 错误；arena storage 漂移；任一 rank report 不通过。
+
+但当前 apply 是原地修改，失败时模型可能已经部分写入。因此生产级事务还需要二选一：
+
+1. **Shadow/双缓冲更新**：在不可见的新模型或新 arena generation 上完成加载和验证，commit 时原子切换；优点是真正可回滚，代价是额外显存。
+2. **Undo log**：更新前保存将被修改的 parameter/buffer，失败时恢复；显存可按层控制，但必须覆盖 PWAL 派生状态和 alias，复杂度较高。
+
+在 rollback 落地之前，ABORT 后必须保持 worker 不接收新请求，由上层销毁并重建 worker，不能继续使用“可能已部分更新”的模型。
+
+并发方面，同一个 model instance 同时只允许一个 active transaction。每次更新分配单调递增的 `transaction_id/weight_generation`；晚到的 chunk、重复 finalize、旧 generation 的 RPC 都必须被拒绝。跨 rank timeout 也应作为 violation 进入统一 abort，而不是无限等待。
+
+## 13. 【已实现】验证矩阵与现有证据
+
+当前实现已覆盖以下关键场景：
+
+| 场景 | 结果 |
+|---|---|
+| synthetic composed/Mamba loader，内部执行两次 `copy_` | 一个逻辑 receipt，不会因 numel 双计数提前完成 |
+| QKV q/k/v packed loading | 三个独立 fragment；漏字段测试触发 target collision |
+| RoutedExperts 普通 MoE | expert/shard/weight 类型均进入 receipt |
+| EP 非本地 expert | 返回 skipped，不进入本 rank required 集合 |
+| Qwen3 MoE dummy→real→reload，TP=1 | 两轮 789/789，token `[15616, 534]` |
+| Qwen3 MoE TP=2 | 两个 rank 的精确 manifest 均完成 |
+| Qwen3 MoE EP=2 | 每个 rank 按本地 expert 对账，405/405 |
+| Qwen3-0.6B packed CUDA IPC | 310/310，冷加载与 IPC 输出一致 |
+| LoadReceipt collision 负向测试 | QKV/MoE 字段缺失、状态冲突、schema drift 均可检测 |
+| 显式 overwrite 与相同重复调用 | 不产生误报 |
+
+主要日志位于：
+
+```text
+logs/loaders/load_receipt_moe_tp1.log
+logs/loaders/load_receipt_moe_ep2.log
+logs/loaders/load_receipt_rl_ipc.log
+logs/loaders/collision_moe_tp1.log
+logs/loaders/manifest_only_moe_tp2.log
+logs/loaders/manifest_only_deepseek_fp8.log
+```
+
+最后一次 collision 版本的 Qwen3 MoE TP1 实测结果为：首次真实加载 `789/789`，第二次 reload `789/789`，`completion_findings=[]`，`FLOW_OK=True`。
+
+## 14. 【已实现】代码位置
+
+| 功能 | 代码位置 |
+|---|---|
+| `LoadReceipt/LoadFragment/LoadCollisionPolicy` | `vllm/model_executor/load_receipt.py` |
+| source context | `vllm/model_executor/model_loader/reload/source.py` |
+| required/received、dummy baseline、layerwise finalize | `vllm/model_executor/model_loader/reload/layerwise.py` |
+| collision witness/audit | `vllm/model_executor/model_loader/reload/audit.py` |
+| manifest scope/report、逐层状态 | `vllm/model_executor/model_loader/reload/types.py` |
+| transport source manifest | `vllm/distributed/weight_transfer/base.py` |
+| loader 入口 observation | `default_loader.py`、`bitsandbytes_loader.py`、`tensorizer_loader.py`、`runai_streamer_loader.py` 等 |
+| QKV/Merged receipt | `vllm/model_executor/layers/linear.py` |
+| MoE receipt | `vllm/model_executor/layers/fused_moe/routed_experts.py` |
+| composed receipt 传播 | `vllm/model_executor/model_loader/weight_utils.py` |
+| arena | `vllm/model_executor/reload_arena.py` 及各 backend 接入点 |
+
+## 15. 【待实现】完成标准与后续顺序
+
+将“权重更新事务”视为完整落地，至少需要满足：所有权重更新入口都被纳入 transaction scope；首次真实加载可以建立无 collision 的精确 manifest；dummy/在线量化后的首轮流式传输必须有独立 source 声明；reload 完成完全由 manifest 驱动；所有 rank 在同一 barrier 上提交；任何 violation 都禁止恢复推理；target/draft/MTP scope 隔离；缓存代际正确失效；失败后能够回滚或强制重建 worker。
+
+建议后续按以下顺序推进：
+
+1. 抽取显式 `ReloadTransaction` 和统一 `Finding/Report`，把现有 completion、collision、arena 先接入，不改变行为；
+2. 在 worker/controller 增加 all-rank commit barrier 和 timeout；
+3. 给 sparse/direct update 路径补 source manifest 与 generation/dirty 标记；
+4. 实现 keyless state、loader epoch 和 cache generation checker；
+5. 明确 target、draft、MTP 独立 scope；
+6. 选择 shadow model 或 undo log，补齐真正 rollback；
+7. 将新增 checker 从观察模式逐步升级为 strict gate，并纳入持续模型矩阵。
+
+总体原则是：**首次加载负责建立可证明、无碰撞的 ground truth；每次更新负责重放并对账这份 ground truth；arena 证明地址稳定；跨 rank gate 决定全局是否提交。任何没有证据证明完整性的路径，都不能仅凭 HTTP/RPC 成功返回而被视为事务成功。**

--- a/TRANSACTION.md
+++ b/TRANSACTION.md
@@ -1,513 +1,372 @@
-# Designing Weight Updates as Transactions: A Unified Plan for #48312
+# Reload as a Transaction — the Top-Down Design for #48312
 
-Status: **partially implemented and still evolving**. This document combines the commit history on `feat/reload-arena` with the findings in `REPORT.md`, `DESIGN.md`, and `LOAD_MANIFEST_DESIGN.md`. It describes the transaction semantics required by weight reload and weight-transfer operations, and distinguishes implemented behavior from future work. Stable storage, first-load manifests, manifest-driven completion, structured `LoadReceipt`s, and event-key collision auditing are implemented. A unified `ReloadTransaction` coordinator, an all-rank commit barrier, rollback, and several cache/state checkers are not.
+Status: **partially implemented**. This document defines what a correct weight update must guarantee, which failure category each mechanism addresses, and where the remaining gaps are. It intentionally describes the correctness contract before the implementation. Detailed manifest and receipt internals belong in `LOAD_MANIFEST_DESIGN.md`.
 
-## 1. Why a weight update must be a transaction
+Status labels used below:
 
-An RL weight synchronization or checkpoint reload is not merely a sequence of `copy_` calls. It may pause request processing, receive weights, restore checkpoint layouts, invoke many kinds of `weight_loader`, rerun `process_weights_after_loading` (PWAL), rebuild quantization or MoE-derived state, wake the KV cache, and resume inference. If any stage is incomplete, the API may report success while the model contains a partial update or internally inconsistent state.
+- **Implemented**: code exists on `feat/reload-arena` and has test or model evidence.
+- **Partially implemented**: the mechanism exists, but coverage or commit enforcement is incomplete.
+- **To be implemented**: design only.
+- **TBD**: even the final API or ownership boundary has not been decided.
 
-Correctness therefore cannot mean “no function raised.” It must mean: **every declared source arrived; every source was routed to the correct rank-local target fragment; every required fragment was consumed; graph-visible storage remained stable after PWAL; every rank passed validation; and only then did the model resume serving.** This gives the following lifecycle:
+## 1. Why a transaction, not a collection of fixes
+
+The reload investigation found several independent classes of failure. Stable storage fixes one class, but it cannot prove that all weights arrived, that a loader wrote the correct shard, that non-checkpoint state survived, or that downstream caches were invalidated.
+
+| Category | The invariant is about | Typical failure | Primary mechanism | Status |
+|---|---|---|---|---|
+| 1. Storage identity | A captured address remains valid | CUDA Graph or kernel keeps an address that PWAL replaced | `ReloadArena` and storage verification | Implemented |
+| 2. Value refresh | Derived storage contains values from the new weights | Address is stable, but scratch/scale contents remain stale | Arena `put()` and backend refresh hooks | Partially implemented |
+| 3. Loader lifecycle | The loading process is complete and uses the correct layout | A loader finishes early, writes through a stale layout, or misses a fragment | Completion manifest, `LoadReceipt`, loader epoch | Manifest implemented; epoch pending |
+| 4. State preservation | State without a checkpoint key survives or is rebuilt | Non-persistent buffers, aliases, or config-dependent state are lost | Keyless-state and config-context checks | Partially implemented |
+| 5. Routing and sharding | An update reaches the correct rank, expert, and shard | A loader consumes a tensor but writes the wrong TP/EP destination | Receipt fragments and distributed sentinels | Receipt identity implemented; sentinels pending |
+| 6. Name and key mapping | Every expected source resolves exactly once | Prefix mapping, packed routing, or loader-specific renaming drops a key | Source/event manifests and collision audit | Implemented for covered loaders |
+| 7. Cache coherence | Consumers do not use state from an old weight generation | Prefix, LoRA, or multimodal cache survives an update | Generation-aware cache invalidation | To be implemented |
+
+These invariants do not share one mechanism. They share one **decision point**: immediately before the engine resumes inference. A weight update is correct only if every applicable invariant is proven at that point.
+
+The transaction model is therefore:
 
 ```text
-BEGIN
-  -> establish the update scope and baselines
-  -> APPLY: receive and load weights
-  -> FINALIZE: finish PWAL and layer restoration
-  -> VALIDATE: reconcile sources, event manifests, arena storage, and state
-  -> COMMIT: resume inference only after every check passes
-  -> ABORT: do not treat the update as successful if any check fails
+BEGIN -> APPLY -> FINALIZE -> VERIFY ALL -> COMMIT or ABORT
 ```
 
-“Transaction” here means atomic visibility, completeness validation, and a unified commit gate; it is not a database transaction. Only some checks currently fail closed. Initial-baseline collisions, incomplete first real updates after dummy initialization, and declared source-manifest mismatches raise immediately. Ordinary reload completion and arena violations are primarily exposed through `LoadManifestReport`, so callers must still enforce `report.ok`. The unified commit gate is therefore unfinished. The system also does not retain an old-weight snapshot: **ABORT currently means rejecting the update and refusing to continue serving, not automatically rolling back to the previous values.**
+The important inversion is that reload no longer “does some work and hopes.” It collects evidence and refuses to call the update successful when required evidence is missing.
 
-### 1.1 End-to-end transaction flow
-
-The first diagram retains the original service lifecycle and places the implemented manifest, receipt, and arena checks at their intended transaction boundary:
+## 2. End-to-end lifecycle
 
 ```mermaid
 flowchart LR
     A[Stop accepting new requests] --> B[Drain in-flight requests]
     B --> C[Sleep / release KV cache]
-    C --> D[BEGIN weight-update transaction]
-    D --> E[Declare transaction scope<br/>source manifest / rank / generation]
-    E --> F[APPLY receive and load weights]
+    C --> D[BEGIN update]
+    D --> E[Declare scope<br/>sources / rank / generation]
+    E --> F[APPLY weights]
     F --> G[FINALIZE<br/>layerwise processing + PWAL]
-    G --> H[VALIDATE]
-    H --> H1[Reconcile source manifest]
-    H --> H2[Reconcile required / received events]
-    H --> H3[Audit LoadReceipt collisions]
-    H --> H4[Verify ReloadArena storage]
+    G --> H[VERIFY ALL]
+    H --> H1[Storage identity]
+    H --> H2[Source and event completeness]
+    H --> H3[Receipt identity and collisions]
+    H --> H4[State, routing, and cache checks]
     H1 --> I{All local checks pass?}
     H2 --> I
     H3 --> I
     H4 --> I
-    I -- No --> X[ABORT<br/>report findings and do not resume]
-    I -- Yes --> J{Did every rank pass?}
+    I -- No --> X[ABORT<br/>do not resume]
+    I -- Yes --> J{All ranks pass?}
     J -- No or timeout --> X
-    J -- Yes --> K[COMMIT<br/>advance weight generation]
-    K --> L[Wake KV cache]
-    L --> M[Invalidate old-generation caches]
-    M --> N[Resume inference]
+    J -- Yes --> K[COMMIT generation]
+    K --> L[Wake and invalidate old caches]
+    L --> M[Resume inference]
 ```
 
-The internal loading path is:
+A transaction has four properties:
+
+1. **A baseline exists before mutation.** Address snapshots, required load events, source declarations, and state policies are established before they are verified.
+2. **Mutation is bounded.** Loading and PWAL happen in APPLY/FINALIZE; verification should inspect rather than silently repair state.
+3. **Commit is explicit.** API success, copied numel, and “no exception” are not correctness oracles.
+4. **Failure is fail closed.** A failed rank or unproven invariant must prevent every rank from resuming.
+
+Current limitation: updates modify the live model in place. ABORT means “reject the update and do not continue serving,” not automatic rollback. True rollback remains future work.
+
+## 3. The checks and the problems they solve
+
+### C1 — StorageIdentityChecker
+
+**Problem.** PWAL may rebuild a tensor that a CUDA Graph, quantized kernel, or MoE backend captured by address. The Python object appears valid, but replay still reads the old allocation. This failure class includes Marlin/Machete scratch tensors, CUTLASS layouts, W4A8 derived storage, and MLA-related state.
+
+**Invariant.** Every graph-visible slot that existed at BEGIN still exists after FINALIZE with the same storage identity and compatible layout.
+
+**Mechanism.** A layer-owned `ReloadArena` owns stable buffers. Backends refresh values with `put()` rather than rebinding tensors. Reload snapshots arena slots before restoring checkpoint layout and verifies them after PWAL.
+
+**Status: Implemented.** Arena integration, per-layer verification, module-level storage manifests, and registry/dataflow CI sweeps are present. Coverage still depends on discovering every graph-visible tensor.
+
+### C2 — DerivedValueRefreshChecker
+
+**Problem.** Stable storage alone is insufficient. A backend may keep the same address but fail to write newly derived scales, permutations, workspaces, or packed values after the base weights change.
+
+**Invariant.** Every derived slot declares its source generation and is refreshed from the committed weights before resume.
+
+**Mechanism.** Arena-backed tensors are updated in place. A future generalized checker should track a derived-value generation or refresh receipt rather than infer correctness from address stability.
+
+**Status: Partially implemented.** Arena `put()` covers migrated backends, but there is no general refresh-generation checker.
+
+### C3a — LoaderEpochChecker
+
+**Problem.** A `weight_loader` created for checkpoint layout can survive a layout conversion and later write checkpoint-format bytes into kernel-format storage. The call succeeds, but the destination interpretation is stale.
+
+**Invariant.** A loader executes only against the layout epoch for which it was created, or the reload pipeline restores the expected layout before invoking it.
+
+**Mechanism.** Layout conversions should advance an epoch; loaders should carry the epoch they expect. The transaction verifies that no stale loader executed. Wrapping `model.load_weights` is complementary because it routes external calls through the restore/load/PWAL lifecycle.
+
+**Status: To be implemented.** The current layerwise path reduces exposure, but there is no explicit epoch contract.
+
+### C3b/C6 — CompletionManifestChecker
+
+**Problem.** Numel counting cannot represent logical loading. A composed loader may execute two `copy_` calls for one source, Q/K/V may share one Parameter, MoE experts may be rank-local, and a missing source contributes zero calls. These cases can cause premature completion or silent omissions.
+
+**Invariant.** The exact logical events consumed by a correct first load are all consumed again during reload, in the same rank-local scope. A streamed transfer must also reconcile its declared source set.
+
+**Mechanism.** The first real load observes events of the form:
+
+```text
+source_key => target_parameter[logical_fragment]
+```
+
+Reload records `received_keys`; layer completion is driven by `required_keys <= received_keys`, not copied numel. Dummy initialization first establishes a provisional target baseline and promotes the first complete real update to an exact event baseline.
+
+**Status: Implemented for covered paths.** `load_numel/load_numel_total` have been removed as completion state. Checkpoint loaders, IPC/NCCL transfer hooks, and several external/direct loaders publish manifests. Sparse direct mutation still needs a standard hook.
+
+### C3c/C5/C6 — LoadReceiptIdentityChecker
+
+**Problem.** A manifest can still be wrong if its receipt identity is incomplete. For example, Q, K, and V can collapse to one packed target, or multiple MoE experts/shards can collapse to one event. If the first load and reload both make the same mistake, ordinary set equality passes.
+
+**Invariant.** Each loader returns a structured description of whether it consumed the source and which logical target fragment it wrote. Distinct semantic calls must not collapse to one event or target key.
+
+**Mechanism.** `LoadReceipt` carries `consumed`, a `LoadFragment`, and a collision policy. Current schemas include:
+
+| Loader | Logical fragment |
+|---|---|
+| `QKVParallelLinear` | `loaded_shard_id=q/k/v` |
+| `MergedColumnParallelLinear` | `loaded_shard_id=0/1/...` |
+| `RoutedExperts` | `shard_id + expert_id + weight_name` |
+| Composed loader | The underlying receipt, unchanged |
+
+`LoadEventAudit` independently derives a stable call witness from source, loader identity, scalar arguments, shape, and dtype. It detects:
+
+- `EVENT_KEY_COLLISION`;
+- `TARGET_ALIAS_COLLISION`;
+- `STATUS_CONFLICT` between accepted and skipped;
+- `SCHEMA_DRIFT`;
+- `RECEIPT_SCHEMA_MISMATCH`.
+
+**Status: Implemented.** QKV, merged-column, RoutedExperts, composed loaders, legacy adaptation, negative collision tests, and real Qwen MoE validation are present. New loaders still need deliberate schema review.
+
+### C4a — KeylessStateChecker
+
+**Problem.** Not every model state item has a checkpoint key. `persistent=False` buffers, parameter aliases, runtime bookkeeping, and backend caches can be overwritten, independently copied, or recreated with the wrong persistence policy during reload.
+
+**Invariant.** Each keyless state item declares one policy: PRESERVE, RECOMPUTE, or INVALIDATE. Aliases preserve their relationship and must not be treated as independent values.
+
+**Mechanism.** Snapshot values, persistence flags, and alias relationships at BEGIN; verify the declared policy after FINALIZE.
+
+**Status: To be implemented.** Existing metadata and arena logic cover individual cases, not a general policy checker.
+
+### C4b — ConfigContextChecker
+
+**Problem.** PWAL can depend on the active `VllmConfig`. Reloading outside the original config context can fail or rebuild a backend using a different configuration.
+
+**Invariant.** Every config-dependent rebuild runs under the same relevant configuration identity as model initialization.
+
+**Mechanism.** Bound APPLY/FINALIZE with `set_current_vllm_config` and verify that no PWAL-reachable config lookup escaped or used a mismatched config.
+
+**Status: Partially implemented.** The config boundary exists in the current reload path; generalized identity verification is pending.
+
+### C4c — IdempotencyChecker
+
+**Problem.** Reloading weights with values identical to the current model may still change buffers, layouts, addresses, or output. Such a change reveals an untracked side effect even when ordinary accuracy tests are unavailable.
+
+**Invariant.** An identity update preserves parameter/buffer values, required storage identities, and deterministic output.
+
+**Mechanism.** Run an admission test per model/backend using identical weights and compare state plus greedy output.
+
+**Status: To be implemented as a common checker.** Individual smoke tests provide partial evidence.
+
+### C5 — ShardRoutingChecker
+
+**Problem.** A loader may consume every expected key yet ignore `tp_rank`, map an expert to the wrong EP rank, or write a correct shard into the wrong destination. Completeness alone cannot prove placement.
+
+**Invariant.** Rank-distinct and shard-distinct values land in the expected rank-local target fragment.
+
+**Mechanism.** A distributed test lane injects sentinel values and verifies placement on every TP/EP rank. Runtime receipts provide the fragment identity but do not prove the tensor bytes landed there.
+
+**Status: To be implemented.** Rank-local receipt scopes and TP/EP model tests exist; generalized sentinel verification does not.
+
+### C7 — CacheGenerationChecker
+
+**Problem.** Prefix KV, LoRA, multimodal, or backend-specific caches can serve generation-N state after weights advance to generation N+1.
+
+**Invariant.** Every registered cache either includes weight generation in its key or is invalidated before COMMIT resumes inference.
+
+**Mechanism.** Advance `weight_generation` only at commit and require cache participants to acknowledge the new generation.
+
+**Status: To be implemented.** No unified cache-generation protocol exists.
+
+## 4. How the implemented load manifest works
+
+The implementation has three identities:
+
+1. **Source identity:** the original checkpoint or sender-side name.
+2. **Target-fragment identity:** parameter name plus QKV/MoE/merged logical fragment.
+3. **Full event identity:** `source => target[fragment]`.
+
+The high-level flow is:
 
 ```mermaid
 flowchart TD
-    A[BEGIN] --> B{Exact required_keys already available?}
-    B -- Yes --> C[Snapshot arena<br/>restore checkpoint/meta layout]
-    B -- No: dummy or first online quantization --> D[Create provisional required_target_keys]
-    C --> E[Install online weight_loader wrappers]
-    D --> E
-    E --> F[Read or receive a source tensor]
-    F --> G[Set current source key]
-    G --> H[Execute the real weight_loader]
-    H --> I[Obtain a structured LoadReceipt]
-    I --> J[Create source-to-target-fragment event]
-    J --> K[Record LoadCallWitness and run collision audit]
-    K --> L{Was the receipt consumed?}
-    L -- No: non-local or skipped --> M[Continue with the next source]
-    L -- Yes --> N[Add received_keys and received_target_keys]
-    N --> O{Exact manifest exists and layer events are complete?}
-    O -- Yes --> P[Run layer PWAL and verify arena]
-    O -- No --> M
-    P --> M
-    M --> Q{End of source stream?}
-    Q -- No --> F
-    Q -- Yes --> R[FINALIZE remaining layers]
-    R --> S[Final required / received / target reconciliation]
-    S --> T{First real update and all targets complete?}
-    T -- Yes --> U[Promote received_keys to permanent required_keys]
-    T -- No or baseline already exists --> V[Retain the original required_keys]
-    U --> W[Produce rank-local LoadManifestReport]
-    V --> W
+    A[First real load] --> B[Observe source context]
+    B --> C[Run weight_loader]
+    C --> D[Obtain LoadReceipt]
+    D --> E[Record required event and collision witness]
+    E --> F[Finalize collision-free baseline]
+    F --> G[Later reload]
+    G --> H[Record received events]
+    H --> I{Layer manifest complete?}
+    I -- Yes --> J[Run PWAL and verify arena]
+    I -- No --> K[Keep buffering]
+    J --> L[Final transaction reconciliation]
+    K --> L
 ```
 
-## 2. Transaction invariants
+For dummy or first online-quantization loads, no exact source baseline exists. The model records rank-local `required_target_keys`, buffers the first real update until the source stream ends, verifies that all targets were touched, and promotes that update's exact events to permanent `required_keys`. Chunked IPC/NCCL transfers also require an independently declared source manifest so a source that never arrived can be detected.
 
-| Area | Invariant | Current status |
-|---|---|---|
-| Storage identity | Addresses captured by CUDA Graphs, quantization kernels, or MoE workspaces remain stable across reload | Arena and per-layer verification implemented |
-| Source completeness | Declared source names equal the names actually received | Transfer source manifest implemented; required for the first streamed update after dummy init |
-| Loader completeness | Every logical event consumed during the correct first load occurs again during reload | Required/received manifest implemented |
-| Fragment uniqueness | Q/K/V and MoE expert/shard events do not collapse because of incomplete receipts | Structured receipts and collision audit implemented |
-| Completion timing | Layer completion depends on event sets, not internal `copy_` counts or numel estimates | Manifest-driven completion implemented; `load_numel` removed |
-| Rank isolation | Every TP/PP/DP/EP rank validates only its rank-local fragments | Rank-local reports implemented; unified global barrier pending |
-| Keyless state | Non-persistent buffers, aliases, and derived values are preserved or rebuilt according to policy | Partially covered; unified checker pending |
-| Routing correctness | A source reaches the correct rank, expert, and shard, not merely any loader | Receipt identity exists; distributed sentinel validation pending |
-| Cache coherence | Prefix, LoRA, and multimodal caches never serve state from an old weight generation | Unified generation checker pending |
+This implementation answers the category-3/6 completeness problem. It does not replace storage, state, routing, or cache checkers.
 
-These invariants require different mechanisms, but they share one commit point. A transaction report should aggregate them instead of allowing each update entry point to make an unrelated decision.
+## 5. Report and commit policy
 
-## 3. Implementation history
+The current rank-local report contains scope coordinates, required and received event counts, completion findings, and arena findings. `report.ok` is true only when both finding sets are empty. Receipt collision findings are currently included in completion findings.
 
-The branch evolved in stages: stabilize storage first, establish verifiable manifests next, then make the manifest authoritative for completion.
-
-| Commit | Purpose |
-|---|---|
-| `5532d3a69` | Introduced layer-owned `ReloadArena` storage for graph-visible temporary tensors |
-| `6f725f866`, `dead65972` | Moved Machete and RDNA3 WNA16 MoE derived scratch tensors into the arena |
-| `14a226b68` | Added capture-time module-level storage manifests beyond arena-owned tensors |
-| `91e05c188` through `ba8bd7a2f` | Added registry, first-forward, dataflow, and MoE-expert CI discovery |
-| `bdc1ee506` | Moved arena snapshot/verification into the per-layer reload pipeline |
-| `3a90010d3` | Observed required events during the first real load instead of predicting them from model structure |
-| `7645c60fb` | Added source, target, and fragment manifests across loader and weight-transfer paths |
-| `19969814d` | Removed `load_numel/load_numel_total` and made manifests drive completion |
-| `cd44e02e3` | Added structured `LoadReceipt`s for QKV, merged-column, RoutedExperts, and composed loaders |
-| `810280d52` | Added event-key collision auditing for missing fields, status conflicts, and schema drift |
-
-Older descriptions that label `CompletionManifestChecker` as design-only are now stale. Manifests, structured receipts, and collision auditing have code and model-level validation. What remains is a unified coordinator and a global all-rank commit decision.
-
-### 3.1 Status legend and summary
-
-The document uses four status labels:
-
-- **[Implemented]**: code exists on the branch and has unit-test or real-model evidence;
-- **[Partially implemented]**: lower-level state or checks exist, but the unified gate or some update paths are missing;
-- **[To be implemented]**: design only; no complete runtime implementation can be relied upon;
-- **[TBD]**: the interface shape has not been decided; example code expresses responsibilities only.
-
-#### Implemented
-
-- Stable ReloadArena storage, per-layer snapshot/verification, and module-level storage manifests;
-- first-checkpoint-load observation of `required_keys` and reload-time collection of `received_keys`;
-- source-to-target-fragment events and rank-local `LoadManifestScope`/`LoadManifestReport`;
-- provisional dummy baselines and promotion to exact event baselines after a complete first real update;
-- manifest completion in place of `load_numel/load_numel_total`;
-- `LoadReceipt`/`LoadFragment` support in QKV, MergedColumn, RoutedExperts, and composed loaders;
-- event-key/target collisions, status conflicts, schema drift, and declared-schema mismatch detection;
-- declared source-manifest validation in `WeightTransferEngine`;
-- Qwen3 MoE TP/EP, Qwen CUDA IPC, and synthetic negative tests.
-
-#### Partially implemented
-
-- Fail-closed behavior: first-load collisions, incomplete dummy-first-real updates, and declared source mismatches fail directly; normal completion/arena findings still depend on callers enforcing `report.ok`;
-- distributed commit: rank-local scopes/reports and multi-rank validation exist, but no universal all-rank commit barrier exists;
-- loader coverage: standard checkpoint, IPC/NCCL, and several external loaders are covered, while sparse/direct mutation needs a transaction hook;
-- draft/MTP: independent scopes are required by design, but no common model-role/generation protocol exists;
-- keyless and derived state: the arena covers some graph-visible tensors, but there is no general buffer/alias checker.
-
-#### To be implemented
-
-- A unified coordinator and its final public/internal API;
-- all-rank commit barrier, timeout, and all-or-none resume;
-- rollback through a shadow model/double buffer or undo log;
-- transaction ID, weight generation, late-chunk rejection, and concurrent-update isolation;
-- a standard source/dirty-generation protocol for sparse and direct updates;
-- `LoaderEpochChecker`, `KeylessStateChecker`, `ShardRoutingChecker`, `CacheGenerationChecker`, and `IdempotencyChecker`;
-- formal target/draft/MTP scope types and independent reconciliation;
-- generation-based invalidation for prefix, LoRA, multimodal, and related caches.
-
-## 4. [Implemented] Three layers of identity
-
-### 4.1 Source identity
-
-A source identity is the stable sender-side or checkpoint-side name, for example:
+The intended policy is per checker:
 
 ```text
-model.layers.0.self_attn.q_proj.weight
-model.layers.0.mlp.experts.7.gate_proj.weight
+strict  -> any violation aborts the update
+warn    -> record and resume while a new checker gathers field evidence
+off     -> checker is disabled explicitly
 ```
 
-Checkpoint loaders use `observe_weight_sources()` to preserve the original source key while the model performs name mapping, packed routing, or expert routing. Chunked IPC/NCCL transfers may independently declare `expected_source_names`, allowing final reconciliation:
+A new checker should normally land in warn mode, gather real-model evidence, then graduate to strict. One noisy checker must be downgradeable without disabling all other protections.
+
+Current enforcement is incomplete:
+
+- first-load receipt collisions fail immediately;
+- incomplete dummy-first-real updates fail immediately;
+- declared source-manifest mismatches fail immediately;
+- normal reload completion and arena findings are reported, but a universal resume gate does not yet enforce all reports.
+
+## 6. Multi-rank commit
+
+Reload is collective. Validation is rank-local, but the decision must be global:
 
 ```text
-missing = expected_source_names - received_source_names
-unexpected = received_source_names - expected_source_names
+each rank validates its own scope
+-> controller collects every report
+-> one failed or timed-out rank aborts the update
+-> all ranks cross one commit barrier
+-> all ranks resume together
 ```
 
-Dummy initialization has no checkpoint source stream and cannot learn a source baseline. For IPC/NCCL transfers where the caller chooses and chunks the source set, the first real transfer must carry an authoritative source manifest; otherwise a source that never arrived cannot be distinguished from a source that was not expected. When loading a complete checkpoint directly, the checkpoint index/iterator can define the source boundary, but the rank-local provisional target baseline must still be satisfied.
+Manifests must not be unioned before reconciliation because one rank's event could hide another rank's omission. Target, draft, and MTP models also require independent scopes containing at least model role, model instance, parallel coordinates, and weight generation.
 
-### 4.2 Target-fragment identity
+**Status: Partially implemented.** Rank-local TP/PP/DP/EP scopes and multi-rank validation exist. A universal all-rank commit barrier, timeout, and model-role scope protocol remain to be implemented.
 
-One Parameter does not necessarily represent one logical weight. QKV, merged MLP, MoE, and quantized weights often place multiple sources into one packed Parameter. The target identity must therefore be:
+## 7. Entry points and coverage boundaries
+
+Updates do not all pass through `reload_weights`:
 
 ```text
-parameter name + logical fragment
+checkpoint reload -> model.load_weights -> standard weight_loaders
+IPC/NCCL transfer -> receive weights -> standard or processed-tensor loading
+external loaders  -> direct state restoration or published tensors
+sparse transfer   -> direct index_copy_ into parameters
+framework RPC     -> may call model.load_weights directly
 ```
 
-Examples:
+A gate attached to one API method is therefore insufficient. The robust boundary is “before the model resumes after any weight mutation.” Standard loader paths publish receipts, processed-tensor paths publish external/direct manifest events, and sparse mutation paths must mark the model dirty and publish their own transaction evidence.
 
-```text
-weight[loaded_shard_id='q']
-w13_weight[shard_id='w1',expert_id=7,weight_name='...w13_weight']
-```
+Nested paths require a transaction-depth or reentrancy guard. Otherwise `reload_weights`, a transfer engine, and a wrapped `model.load_weights` can initialize/finalize the same reload more than once.
 
-### 4.3 Full load-event identity
+**Status: Partially implemented.** Standard checkpoint, IPC/NCCL, Modelexpress, RunAI, Tensorizer, and sharded paths have hooks or tests. Sparse/direct mutation and arbitrary framework RPC remain explicit gaps.
 
-The final manifest event is:
+## 8. [TBD] Unified transaction interface
 
-```text
-source key => target fragment
-```
-
-Examples:
-
-```text
-model.layers.0.self_attn.q_proj.weight=>weight[loaded_shard_id='q']
-model.layers.0.mlp.experts.7.gate_proj.weight=>w13_weight[shard_id='w1',expert_id=7,weight_name='model.layers.0.mlp.experts.w13_weight']
-```
-
-Transaction completion compares full event sets. Collision auditing additionally compares target fragments without source names, because different sources can incorrectly claim the same target if a receipt omits a discriminator.
-
-## 5. [Implemented] Structured LoadReceipt
-
-Every logical loader call returns a structured receipt:
-
-```python
-@dataclass(frozen=True)
-class LoadReceipt:
-    consumed: bool
-    fragment: LoadFragment
-    collision_policy: LoadCollisionPolicy
-```
-
-A normal successful load returns:
-
-```python
-return LoadReceipt.accepted(loaded_shard_id="q")
-```
-
-An expert not owned by the current rank returns:
-
-```python
-return LoadReceipt.skipped(
-    shard_id=shard_id,
-    expert_id=expert_id,
-    weight_name=weight_name,
-)
-```
-
-An existing loader with many branches and a historical `None`/`bool` result can migrate through a declarative adapter:
-
-```python
-@returns_load_receipt("shard_id", "expert_id", "weight_name")
-def weight_loader(..., return_success=False):
-    ...
-```
-
-`LoadReceipt.__bool__()` preserves conditional-loader truthiness, so existing `if success:` routing continues to work. Loaders not yet migrated use `_legacy_load_receipt(bound_args, result)`, which infers fragments from known argument names. That path is a migration fallback and should not be the default for new loaders.
-
-### 5.1 Fragment definitions in validated model paths
-
-| Loader | Receipt fragment | Reason |
-|---|---|---|
-| `QKVParallelLinear` | `loaded_shard_id=q/k/v` | Distinguishes Q, K, and V regions inside one packed Parameter |
-| `MergedColumnParallelLinear` | `loaded_shard_id=0/1/...` | Distinguishes gate/up or other merged shards |
-| `RoutedExperts` | `shard_id + expert_id + weight_name` | Distinguishes experts, w1/w2/w3, and quantized/special weight branches |
-| Ordinary one-to-one loader | Empty fragment | Source and parameter name already identify one target |
-| Composed loader | Propagates the underlying receipt unchanged | Post-load `copy_(fn(param))` is not a second source-consumption event |
-
-A receipt describes which logical fragment one loader invocation consumed. It does not count internal `copy_` calls. This is why the model can handle the #44814 failure class without numel-based completion.
-
-## 6. [Implemented] Event-key collision audit
-
-Comparing first-load and reload sets has a blind spot: if both phases return the same incomplete receipt, two distinct fragments can collapse on both sides and still satisfy `required == received`. Commit `810280d52` adds `LoadEventAudit`, an independent witness mechanism.
-
-For every loader call, the audit creates a `LoadCallWitness` containing the loader module/qualname, source key, target parameter name, stable serializable scalar arguments from `BoundArguments`, and loaded-tensor shape/dtype. It never records tensor contents, object addresses, or device pointers.
-
-| Finding | Meaning |
-|---|---|
-| `EVENT_KEY_COLLISION` | One full event key corresponds to two different call witnesses |
-| `TARGET_ALIAS_COLLISION` | Different sources or calls incorrectly claim the same target fragment |
-| `STATUS_CONFLICT` | One logical event is both accepted and skipped in one transaction |
-| `SCHEMA_DRIFT` | One loader returns different fragment schemas during one load |
-| `RECEIPT_SCHEMA_MISMATCH` | The decorator declaration and actual receipt fields disagree |
-
-If a QKV loader omits `loaded_shard_id`, its source keys are still different, but all targets collapse to `weight`. The audit reports:
-
-```text
-TARGET_ALIAS_COLLISION
-first_source=q_proj.weight
-second_source=k_proj.weight
-differing_arguments=('loaded_shard_id',)
-possible_missing_receipt_fields=('loaded_shard_id',)
-```
-
-Identical duplicate calls are not identity collisions. A loader that intentionally allows several sources to overwrite one target must explicitly use `collision_policy=LoadCollisionPolicy.OVERWRITE`; model-name allowlists are not used.
-
-`finalize_load_recording()` rejects collisions while establishing a checkpoint baseline. During reload, collision findings are added to `LoadManifestReport.completion_findings`, making the rank-local `report.ok` false.
-
-## 7. [Implemented] Manifest creation and replay
-
-### 7.1 Normal first checkpoint load
-
-```text
-model parameters exist
--> record_metadata_for_reloading(model)
--> record_load_consumption(model) wraps effective weight loaders
--> checkpoint iteration establishes a source context
--> loader returns or is adapted to LoadReceipt
--> source=>target[fragment] is added to required_keys
--> LoadEventAudit runs in parallel
--> finalize_load_recording(model)
--> original loaders are restored; the baseline becomes valid if no collision exists
-```
-
-`required_keys` is observed ground truth, not a prediction derived from `state_dict()`, parameter counts, or architecture names. EP-nonlocal experts, shared aliases, and runtime state without checkpoint sources are therefore absent from the rank-local required set by construction.
-
-### 7.2 Normal reload
-
-```text
-initialize_layerwise_reload(model)
--> snapshot arena storage
--> restore reloadable layers to checkpoint/meta layout
--> install online loader wrappers
--> add each consumed receipt to received_keys
--> when required_keys is a subset of received_keys, allow layer PWAL
--> after checkpoint exhaustion, perform final set reconciliation
--> verify arena snapshots
--> produce a rank-local LoadManifestReport
-```
-
-The event set determines completion. `copied_numel_diagnostic` may remain as a log-only metric, but it does not participate in completion, commit, or fallback decisions.
-
-### 7.3 First real update after dummy initialization
-
-A dummy load has no source stream and can establish only a provisional target baseline:
-
-```text
-required_target_keys = rank-local parameter targets that must be touched
-required_keys = empty, meaning no exact source/fragment baseline exists yet
-```
-
-The first real update must satisfy every provisional target. Chunked IPC/NCCL transfers must additionally prove that every source in the independently declared source manifest arrived. One target may contain many QKV or MoE fragments, so the first touch cannot trigger early PWAL; this phase remains buffered until transaction finalization. After successful validation, `received_keys` is promoted to permanent `required_keys`, and later reloads can finalize layers from exact events.
-
-### 7.4 Online quantization and external tensor loaders
-
-First-load online quantization may also lack an exact fragment baseline and follows the provisional-target path. Modelexpress, RunAI, Tensorizer, or processed-tensor transfers may bypass vLLM `weight_loader` functions entirely. They must publish source-to-target events through `record_external_tensor_manifest()` or `record_direct_load_consumption()` rather than fabricating receipts. Coverage must follow the actual dataflow; the mere presence of a loader file does not imply transaction coverage.
-
-## 8. [Implemented] Storage transaction: ReloadArena and PWAL
-
-The manifest proves that every logical weight was loaded. The arena proves that graph and kernel consumers still reference valid storage after PWAL. These are separate invariants and both are required.
-
-At reload start, each arena-backed layer snapshots slot identities. After PWAL rebuilds derived tensors, `arena.verify(snapshot)` checks for missing slots, moved addresses, or layout changes. The arena owns stable buffers, and PWAL uses `put()` to refresh values in existing storage instead of rebinding graph-visible tensors. Verification must happen before `LayerReloadingInfo.reset()` clears the snapshot.
-
-The current report is:
-
-```python
-LoadManifestReport(
-    scope=LoadManifestScope(...),
-    required_event_count=...,
-    received_event_count=...,
-    completion_findings=(...),
-    arena_findings=(...),
-)
-```
-
-`report.ok` is true only when completion and arena findings are both empty. Collision findings currently belong to `completion_findings`.
-
-## 9. [Partially implemented] Distributed scope and commit decision
-
-Manifests must remain per worker/rank; they cannot be unioned before reconciliation. TP, PP, and EP workers legitimately consume different fragments. A union could hide a missing rank-0 event behind an event received by rank 1. Each report therefore carries global rank/world size and TP, PP, DP, and EP coordinates.
-
-The intended global protocol is:
-
-```text
-each rank completes local APPLY and VALIDATE
--> controller collects every rank-local LoadManifestReport
--> if any report.ok is false, ABORT the entire update
--> if every report.ok is true, cross a barrier and COMMIT/RESUME together
-```
-
-Rank-local report generation and multi-rank model validation exist. A universal global commit barrier does not. Until it does, each entry point must check all worker reports rather than rank 0 alone, and a successful rank must not resume before failed ranks.
-
-MTP and speculative decoding require independent scopes. Target and draft models can have different parameter sets, parallel layouts, and update cadence. Events must not share an unqualified set. A future scope should contain at least:
-
-```text
-model_role = target | draft | mtp
-model_instance_id
-parallel coordinates
-weight generation
-```
-
-If only the target model is updated, the draft scope must explicitly be out of the transaction rather than appearing to have missing receipts.
-
-## 10. [Partially implemented] Entry-point coverage and transaction boundaries
-
-Weight updates have many entry points: checkpoint `reload_weights`, IPC, NCCL, sparse NCCL, Modelexpress, RunAI, Tensorizer, and framework RPC calls to `model.load_weights`. A gate attached to one API method cannot claim complete coverage.
-
-The paths fall into three groups:
-
-1. **Checkpoint-format paths using standard `weight_loader`s:** covered by source observation, LoadReceipt, layerwise manifests, and arena verification.
-2. **Processed-tensor or direct-state restoration paths:** publish external/direct manifest events and should not be forced into fragment-loader semantics.
-3. **Sparse patches using `index_copy_` or similar direct mutations:** do not invoke standard loaders and need an explicit source manifest, dirty-generation marker, and commit check.
-
-A future coordinator should sit at the resume boundary rather than at one named API. Every entry point must run `begin_update -> observe/apply -> finish_update -> validate -> commit`. Nested paths need transaction-depth or reentrancy guards so `reload_weights`, an NCCL engine, and `model.load_weights` do not run initialize/finalize repeatedly.
-
-## 11. [TBD] Candidate responsibilities and interface for a unified transaction
-
-> **Interface TBD:** It has not been decided whether coordination ultimately belongs in a `ReloadTransaction` class, the `WeightTransferEngine` lifecycle, or a worker/controller protocol. The following code expresses BEGIN/APPLY/FINALIZE/VALIDATE/COMMIT/ABORT responsibilities only. It is not an implemented API and does not prescribe the final class name, method signatures, or call hierarchy.
-
-One possible responsibility split is:
+The final ownership boundary is deliberately **TBD**. It may become a `ReloadTransaction` class, an extension of the `WeightTransferEngine` lifecycle, or a worker/controller protocol. The design requires these responsibilities, not these exact methods:
 
 ```python
 class ReloadTransaction:
-    def begin(self) -> None:
-        """Freeze scope, clear received state, and snapshot arenas/caches."""
-
-    def apply(self, update) -> None:
-        """The only phase allowed to mutate model state."""
-
-    def finalize(self) -> None:
-        """Finish layerwise processing, PWAL, and backend finalization."""
-
-    def validate(self) -> list[LoadManifestReport]:
-        """Read-only aggregation of source, receipt, collision, arena, and checks."""
-
-    def commit(self) -> None:
-        """Advance generation and resume only after every rank passes."""
-
-    def abort(self, findings) -> NoReturn:
-        """Refuse to resume; a future implementation may roll back here."""
+    def begin(self) -> None: ...      # freeze scope and snapshot baselines
+    def apply(self, update) -> None: ...
+    def finalize(self) -> None: ...   # PWAL and backend finalization
+    def validate(self) -> Report: ...
+    def commit(self) -> None: ...     # all-rank generation advance
+    def abort(self, findings) -> NoReturn: ...
 ```
 
-A common checker protocol could be:
+The final API must answer:
 
-```python
-class ReloadChecker(Protocol):
-    name: str
-    def snapshot(self, ctx: ReloadContext) -> None: ...
-    def verify(self, ctx: ReloadContext) -> list[Finding]: ...
-```
+- who owns nesting and reentrancy;
+- where rank-local reports are collected;
+- which component prevents resume;
+- how target/draft/MTP scopes are represented;
+- how non-loader mutations join a transaction;
+- how rollback or worker reconstruction is triggered.
 
-Existing data can support `CompletionManifestChecker` (required/received/source/collision) and `StorageIdentityChecker` (arena/module storage). Future checkers include:
+Until these questions are resolved, the example above is not an implementation contract.
 
-- `KeylessStateChecker` for `persistent=False` buffers, aliases, and state without checkpoint keys;
-- `LoaderEpochChecker` to prevent checkpoint-layout loaders from writing kernel-layout storage;
-- `ShardRoutingChecker` with rank-distinct sentinels for TP/EP routing;
-- `CacheGenerationChecker` for prefix, LoRA, and multimodal cache invalidation;
-- `IdempotencyChecker` to verify that an identity reload preserves parameters, buffers, storage, and output.
+## 9. Rollback and concurrency
 
-## 12. [Partially implemented / incomplete] Failure semantics, rollback, and concurrency
+APPLY currently mutates the live model. A production transaction needs either:
 
-The key contract is that an unvalidated update must not be reported as successful. Missing/unexpected source names, missing required events, untouched dummy targets, receipt collisions/schema errors, arena drift, or any failed rank must eventually reject the transaction.
+1. **Shadow/double-buffer update:** build and validate an invisible model or generation, then atomically switch; or
+2. **Undo log:** save modified state and restore it on failure, including aliases and PWAL-derived tensors.
 
-APPLY currently mutates the live model in place, so a failure may leave partially changed values. A production transaction needs one of:
+Until rollback exists, ABORT must prevent new requests and force worker reconstruction.
 
-1. **Shadow/double-buffer update:** load and validate an invisible model or arena generation, then atomically switch on commit. This provides true rollback at the cost of memory.
-2. **Undo log:** save parameters/buffers before modification and restore them on failure. Memory can be managed layer by layer, but PWAL-derived state and aliases make this more complex.
+Only one update may be active per model instance. A future protocol needs a monotonic transaction ID and weight generation, rejection of late chunks and duplicate finalize calls, and timeout-driven global abort.
 
-Until rollback exists, an aborted worker must not accept new requests. The controller should destroy and rebuild it rather than use a possibly partial model.
+**Status: To be implemented.**
 
-Only one transaction may be active for one model instance. Each update should receive a monotonically increasing `transaction_id` and `weight_generation`; late chunks, duplicate finalization, and old-generation RPCs must be rejected. A rank timeout should become an abort finding rather than an indefinite barrier wait.
-
-## 13. [Implemented] Validation matrix and evidence
+## 10. Implemented evidence
 
 | Scenario | Result |
 |---|---|
-| Synthetic composed/Mamba loader with two internal `copy_` calls | One logical receipt; no early completion from double numel counting |
-| Packed QKV loading | Three independent fragments; missing-field test triggers target collision |
-| RoutedExperts MoE | Expert, shard, and weight category are present in receipts |
-| EP-nonlocal expert | Returns skipped and is absent from rank-local required events |
-| Qwen3 MoE dummy -> real -> reload, TP=1 | Both real loads 789/789; tokens `[15616, 534]` |
+| Composed/Mamba-style loader with two internal `copy_` calls | One logical event; no numel-driven early completion |
+| Packed QKV | q/k/v are independent fragments; missing shard identity is detected |
+| RoutedExperts MoE | expert, shard, and weight category are recorded |
+| EP-nonlocal expert | skipped and excluded from rank-local required events |
+| Qwen3 MoE dummy -> real -> reload, TP=1 | 789/789 twice; stable tokens `[15616, 534]` |
 | Qwen3 MoE TP=2 | Exact manifests complete on both ranks |
-| Qwen3 MoE EP=2 | Rank-local expert reconciliation, 405/405 per rank |
-| Qwen3-0.6B packed CUDA IPC | 310/310; IPC output matches cold load |
-| Negative collision tests | Missing QKV/MoE fields, status conflict, and schema drift detected |
-| Explicit overwrite and identical duplicate calls | No false positive |
+| Qwen3 MoE EP=2 | 405/405 per rank |
+| Qwen3-0.6B packed CUDA IPC | 310/310; output matches cold load |
+| Collision negative tests | Missing QKV/MoE fields, status conflicts, and schema drift detected |
+| Identical duplicate and explicit overwrite | No false collision |
 
-Relevant logs are under:
+Relevant logs are in the reproduction workspace under `logs/loaders/`, including `load_receipt_moe_tp1.log`, `load_receipt_moe_ep2.log`, `load_receipt_rl_ipc.log`, and `collision_moe_tp1.log`.
 
-```text
-logs/loaders/load_receipt_moe_tp1.log
-logs/loaders/load_receipt_moe_ep2.log
-logs/loaders/load_receipt_rl_ipc.log
-logs/loaders/collision_moe_tp1.log
-logs/loaders/manifest_only_moe_tp2.log
-logs/loaders/manifest_only_deepseek_fp8.log
-```
+## 11. Implementation history and code map
 
-The latest collision-enabled Qwen3 MoE TP1 run completed the first real load and second reload at `789/789`, produced `completion_findings=[]`, and ended with `FLOW_OK=True`.
-
-## 14. [Implemented] Code map
-
-| Capability | Location |
+| Commit | Capability |
 |---|---|
-| `LoadReceipt`, `LoadFragment`, `LoadCollisionPolicy` | `vllm/model_executor/load_receipt.py` |
+| `5532d3a69` | Layer-owned stable `ReloadArena` |
+| `14a226b68` | Module-level storage manifest |
+| `91e05c188`–`ba8bd7a2f` | Registry, first-forward, dataflow, and MoE CI discovery |
+| `bdc1ee506` | Per-layer arena verification inside reload |
+| `3a90010d3` | First-load observation of required events |
+| `7645c60fb` | Source/target/fragment manifests and transfer coverage |
+| `19969814d` | Manifest-driven completion; removal of load numel state |
+| `cd44e02e3` | Structured LoadReceipt integration |
+| `810280d52` | Event-key collision audit |
+
+| Capability | Main code location |
+|---|---|
+| Structured receipts | `vllm/model_executor/load_receipt.py` |
 | Source context | `vllm/model_executor/model_loader/reload/source.py` |
-| Required/received sets, dummy baseline, layerwise finalization | `vllm/model_executor/model_loader/reload/layerwise.py` |
-| Collision witnesses and audit | `vllm/model_executor/model_loader/reload/audit.py` |
-| Manifest scope/report and per-layer state | `vllm/model_executor/model_loader/reload/types.py` |
+| Manifest lifecycle | `vllm/model_executor/model_loader/reload/layerwise.py` |
+| Collision audit | `vllm/model_executor/model_loader/reload/audit.py` |
+| Scope and report types | `vllm/model_executor/model_loader/reload/types.py` |
 | Transfer source manifest | `vllm/distributed/weight_transfer/base.py` |
-| Loader observation entry points | `default_loader.py`, `bitsandbytes_loader.py`, `tensorizer_loader.py`, `runai_streamer_loader.py`, etc. |
-| QKV and merged-column receipts | `vllm/model_executor/layers/linear.py` |
+| QKV/merged receipts | `vllm/model_executor/layers/linear.py` |
 | MoE receipts | `vllm/model_executor/layers/fused_moe/routed_experts.py` |
-| Composed receipt propagation | `vllm/model_executor/model_loader/weight_utils.py` |
-| Stable arena | `vllm/model_executor/reload_arena.py` and backend integration points |
+| Stable storage | `vllm/model_executor/reload_arena.py` |
 
-## 15. [To be implemented] Completion criteria and next steps
+## 12. Remaining work, in dependency order
 
-The weight-update transaction is complete only when all update entry points participate in a transaction scope; a first real load can establish a collision-free exact manifest; the first streamed update after dummy/online initialization has an independent source declaration; reload completion is entirely manifest-driven; every rank commits at one barrier; any violation prevents resume; target/draft/MTP scopes are isolated; caches invalidate by generation; and failures either roll back or force worker reconstruction.
+1. Define the unified report/finding model and wire existing completion, collision, and arena evidence into one gate without changing behavior.
+2. Add the all-rank commit barrier and timeout at the resume boundary.
+3. Add transaction hooks for sparse/direct updates and arbitrary framework entry points.
+4. Implement loader epoch and keyless-state checks.
+5. Define target, draft, and MTP scopes plus weight generation.
+6. Add cache-generation invalidation and distributed shard sentinels.
+7. Choose shadow-model or undo-log rollback.
+8. Graduate proven checks from warn to strict and keep them in a continuous model matrix.
 
-Recommended order:
-
-1. Extract a coordinator plus common `Finding`/`Report` types, initially wiring existing completion, collision, and arena checks without changing behavior.
-2. Add an all-rank commit barrier and timeout in the worker/controller path.
-3. Add source-manifest and dirty-generation hooks for sparse/direct updates.
-4. Implement keyless-state, loader-epoch, and cache-generation checkers.
-5. Define independent target, draft, and MTP scopes.
-6. Choose shadow-model or undo-log rollback.
-7. Graduate new checkers from observation to strict gating and add them to the continuous model matrix.
-
-The governing rule is: **the first load establishes collision-free, provable ground truth; every update replays and reconciles that ground truth; the arena proves storage stability; and a cross-rank gate decides whether the update commits. A path without evidence of completeness must never be considered successful merely because an HTTP or RPC call returned successfully.**
+The governing rule is: **each mechanism proves one invariant, while the transaction combines those proofs into one all-or-none decision. A successful RPC is never sufficient evidence that a weight update is correct.**

--- a/TRANSACTION.md
+++ b/TRANSACTION.md
@@ -1,220 +1,218 @@
-# 将权重更新设计成事务：#48312 的统一方案
+# Designing Weight Updates as Transactions: A Unified Plan for #48312
 
-状态：**部分实现，持续演进**。本文结合 `feat/reload-arena` 分支的历史提交、`REPORT.md`、`DESIGN.md` 和 `LOAD_MANIFEST_DESIGN.md`，描述权重 reload/transfer 应当具备的事务语义，并明确哪些能力已经落地、哪些仍属于后续设计。当前实现已经覆盖稳定存储、首次加载 manifest、manifest 驱动完成条件、结构化 `LoadReceipt` 和 event-key collision 审计，但尚未实现统一的 `ReloadTransaction` 协调器、跨 rank 的全局 commit barrier、失败回滚，以及缓存代际等所有检查器。
+Status: **partially implemented and still evolving**. This document combines the commit history on `feat/reload-arena` with the findings in `REPORT.md`, `DESIGN.md`, and `LOAD_MANIFEST_DESIGN.md`. It describes the transaction semantics required by weight reload and weight-transfer operations, and distinguishes implemented behavior from future work. Stable storage, first-load manifests, manifest-driven completion, structured `LoadReceipt`s, and event-key collision auditing are implemented. A unified `ReloadTransaction` coordinator, an all-rank commit barrier, rollback, and several cache/state checkers are not.
 
-## 1. 为什么要把权重更新看成事务
+## 1. Why a weight update must be a transaction
 
-一次 RL 权重同步或 checkpoint reload 并不是简单执行若干次 `copy_`。它会经过暂停请求、接收权重、恢复 checkpoint 布局、调用不同类型的 `weight_loader`、重新运行 `process_weights_after_loading`（下文简称 PWAL）、重建量化或 MoE 派生状态、恢复 KV cache 并继续推理。任何一步不完整，都可能出现“接口返回成功，但模型已经处于部分更新或内部状态不一致”的情况。
+An RL weight synchronization or checkpoint reload is not merely a sequence of `copy_` calls. It may pause request processing, receive weights, restore checkpoint layouts, invoke many kinds of `weight_loader`, rerun `process_weights_after_loading` (PWAL), rebuild quantization or MoE-derived state, wake the KV cache, and resume inference. If any stage is incomplete, the API may report success while the model contains a partial update or internally inconsistent state.
 
-因此，正确性不能定义为“函数没有抛异常”，而应定义为：**本次更新声明的全部 source 均已到达；每个 source 被正确路由到本 rank 的目标 fragment；所有必需 fragment 均已消费；PWAL 后图可见存储地址没有漂移；所有 rank 都通过检查；只有这时模型才能恢复服务。** 这对应下面的事务生命周期：
+Correctness therefore cannot mean “no function raised.” It must mean: **every declared source arrived; every source was routed to the correct rank-local target fragment; every required fragment was consumed; graph-visible storage remained stable after PWAL; every rank passed validation; and only then did the model resume serving.** This gives the following lifecycle:
 
 ```text
 BEGIN
-  → 建立本次更新的 scope 和基线
-  → APPLY：接收并加载权重
-  → FINALIZE：完成 PWAL 和层恢复
-  → VALIDATE：source、event manifest、arena、其他状态逐项对账
-  → COMMIT：所有检查通过后恢复推理
-  → ABORT：任一检查失败则禁止将本次更新视为成功
+  -> establish the update scope and baselines
+  -> APPLY: receive and load weights
+  -> FINALIZE: finish PWAL and layer restoration
+  -> VALIDATE: reconcile sources, event manifests, arena storage, and state
+  -> COMMIT: resume inference only after every check passes
+  -> ABORT: do not treat the update as successful if any check fails
 ```
 
-这里的“事务”强调原子可见性、完整性验证和统一提交门禁，不等同于数据库事务。当前只有部分检查已经 fail closed：首次基线 collision、dummy 首次真实更新不完整以及显式声明的 source manifest 不匹配会直接失败；普通 reload 的 completion/arena 问题目前主要进入 `LoadManifestReport`，仍要求调用方检查 `report.ok`。因此统一 commit gate 尚未完成。系统也没有保存旧权重副本，所以 **ABORT 目前表示拒绝把更新视为成功并停止继续服务，不表示已经自动回滚到旧模型值**。
+“Transaction” here means atomic visibility, completeness validation, and a unified commit gate; it is not a database transaction. Only some checks currently fail closed. Initial-baseline collisions, incomplete first real updates after dummy initialization, and declared source-manifest mismatches raise immediately. Ordinary reload completion and arena violations are primarily exposed through `LoadManifestReport`, so callers must still enforce `report.ok`. The unified commit gate is therefore unfinished. The system also does not retain an old-weight snapshot: **ABORT currently means rejecting the update and refusing to continue serving, not automatically rolling back to the previous values.**
 
+### 1.1 End-to-end transaction flow
 
-### 1.1 端到端事务流程图
-
-下面保留原方案中的服务生命周期，并将当前已经实现的 manifest、receipt 和 arena 校验放回统一事务位置：
+The first diagram retains the original service lifecycle and places the implemented manifest, receipt, and arena checks at their intended transaction boundary:
 
 ```mermaid
 flowchart LR
-    A[暂停接收新请求] --> B[Drain 在途请求]
-    B --> C[Sleep / 释放 KV cache]
-    C --> D[BEGIN 权重更新事务]
-    D --> E[声明 transaction scope<br/>source manifest / rank / generation]
-    E --> F[APPLY 接收并加载权重]
-    F --> G[FINALIZE<br/>Layerwise processing + PWAL]
+    A[Stop accepting new requests] --> B[Drain in-flight requests]
+    B --> C[Sleep / release KV cache]
+    C --> D[BEGIN weight-update transaction]
+    D --> E[Declare transaction scope<br/>source manifest / rank / generation]
+    E --> F[APPLY receive and load weights]
+    F --> G[FINALIZE<br/>layerwise processing + PWAL]
     G --> H[VALIDATE]
-    H --> H1[Source manifest 对账]
-    H --> H2[Required / received event 对账]
-    H --> H3[LoadReceipt collision 审计]
-    H --> H4[ReloadArena storage 校验]
-    H1 --> I{所有本地检查通过?}
+    H --> H1[Reconcile source manifest]
+    H --> H2[Reconcile required / received events]
+    H --> H3[Audit LoadReceipt collisions]
+    H --> H4[Verify ReloadArena storage]
+    H1 --> I{All local checks pass?}
     H2 --> I
     H3 --> I
     H4 --> I
-    I -- 否 --> X[ABORT<br/>禁止恢复服务并报告 findings]
-    I -- 是 --> J{所有 rank 都通过?}
-    J -- 否或超时 --> X
-    J -- 是 --> K[COMMIT<br/>提升 weight generation]
+    I -- No --> X[ABORT<br/>report findings and do not resume]
+    I -- Yes --> J{Did every rank pass?}
+    J -- No or timeout --> X
+    J -- Yes --> K[COMMIT<br/>advance weight generation]
     K --> L[Wake KV cache]
-    L --> M[失效旧 generation 缓存]
-    M --> N[恢复推理服务]
+    L --> M[Invalidate old-generation caches]
+    M --> N[Resume inference]
 ```
 
-事务内部的实际权重加载流程如下：
+The internal loading path is:
 
 ```mermaid
 flowchart TD
-    A[BEGIN] --> B{是否已有精确 required_keys?}
-    B -- 是 --> C[Snapshot arena<br/>恢复 checkpoint/meta 布局]
-    B -- 否: dummy/首次在线量化 --> D[建立 provisional required_target_keys]
-    C --> E[安装 online weight_loader wrapper]
+    A[BEGIN] --> B{Exact required_keys already available?}
+    B -- Yes --> C[Snapshot arena<br/>restore checkpoint/meta layout]
+    B -- No: dummy or first online quantization --> D[Create provisional required_target_keys]
+    C --> E[Install online weight_loader wrappers]
     D --> E
-    E --> F[读取或接收 source tensor]
-    F --> G[设置 current source key]
-    G --> H[执行真实 weight_loader]
-    H --> I[获得结构化 LoadReceipt]
-    I --> J[生成 source=>target fragment event]
-    J --> K[记录 LoadCallWitness 并执行 collision audit]
-    K --> L{Receipt consumed?}
-    L -- 否: non-local / skipped --> M[继续下一个 source]
-    L -- 是 --> N[加入 received_keys 和 received_target_keys]
-    N --> O{已有精确 manifest 且本层事件齐全?}
-    O -- 是 --> P[本层 PWAL 并验证 arena]
-    O -- 否 --> M
+    E --> F[Read or receive a source tensor]
+    F --> G[Set current source key]
+    G --> H[Execute the real weight_loader]
+    H --> I[Obtain a structured LoadReceipt]
+    I --> J[Create source-to-target-fragment event]
+    J --> K[Record LoadCallWitness and run collision audit]
+    K --> L{Was the receipt consumed?}
+    L -- No: non-local or skipped --> M[Continue with the next source]
+    L -- Yes --> N[Add received_keys and received_target_keys]
+    N --> O{Exact manifest exists and layer events are complete?}
+    O -- Yes --> P[Run layer PWAL and verify arena]
+    O -- No --> M
     P --> M
-    M --> Q{source stream 结束?}
-    Q -- 否 --> F
-    Q -- 是 --> R[FINALIZE 剩余层]
-    R --> S[最终 required/received/target 对账]
-    S --> T{首次真实更新且目标完整?}
-    T -- 是 --> U[将 received_keys 提升为永久 required_keys]
-    T -- 否或已有基线 --> V[保留原 required_keys]
-    U --> W[生成 rank-local LoadManifestReport]
+    M --> Q{End of source stream?}
+    Q -- No --> F
+    Q -- Yes --> R[FINALIZE remaining layers]
+    R --> S[Final required / received / target reconciliation]
+    S --> T{First real update and all targets complete?}
+    T -- Yes --> U[Promote received_keys to permanent required_keys]
+    T -- No or baseline already exists --> V[Retain the original required_keys]
+    U --> W[Produce rank-local LoadManifestReport]
     V --> W
 ```
 
-## 2. 需要维护的事务不变量
+## 2. Transaction invariants
 
-| 类别 | 不变量 | 当前状态 |
+| Area | Invariant | Current status |
 |---|---|---|
-| 存储身份 | CUDA Graph、量化 kernel 或 MoE workspace 捕获的地址在 reload 前后不变 | 已实现 arena 与逐层校验 |
-| source 完整性 | 发送端声明的 source 名称与接收端实际收到的名称一致 | 已实现 transfer source manifest；dummy 首次真实传输强制声明 |
-| loader 完整性 | 首次加载实际消费的逻辑事件，在 reload 时全部再次发生 | 已实现 required/received manifest |
-| fragment 唯一性 | Q/K/V、MoE expert/shard 等不能因为回执字段缺失而折叠为同一事件 | 已实现结构化 `LoadReceipt` 与 collision audit |
-| 完成时机 | 层是否完成由事件集合决定，不能由内部 `copy_` 次数或 numel 猜测 | 已实现 manifest 驱动，`load_numel` 已删除 |
-| rank 隔离 | TP/PP/DP/EP 各 rank 只验证本 rank 应消费的 fragment | 已实现 rank-local report；全局 barrier 尚未统一实现 |
-| 无 key 状态 | 非持久 buffer、alias、派生值在 reload 后应保留或按声明重建 | 部分覆盖，统一 checker 尚未实现 |
-| 路由正确性 | source 不仅要“被加载”，还必须落到正确 rank、expert 和 shard | receipt 提供身份；跨 rank sentinel 仍待实现 |
-| 缓存一致性 | prefix cache、LoRA、多模态缓存等不得继续使用旧权重代际 | 尚未实现统一 generation checker |
+| Storage identity | Addresses captured by CUDA Graphs, quantization kernels, or MoE workspaces remain stable across reload | Arena and per-layer verification implemented |
+| Source completeness | Declared source names equal the names actually received | Transfer source manifest implemented; required for the first streamed update after dummy init |
+| Loader completeness | Every logical event consumed during the correct first load occurs again during reload | Required/received manifest implemented |
+| Fragment uniqueness | Q/K/V and MoE expert/shard events do not collapse because of incomplete receipts | Structured receipts and collision audit implemented |
+| Completion timing | Layer completion depends on event sets, not internal `copy_` counts or numel estimates | Manifest-driven completion implemented; `load_numel` removed |
+| Rank isolation | Every TP/PP/DP/EP rank validates only its rank-local fragments | Rank-local reports implemented; unified global barrier pending |
+| Keyless state | Non-persistent buffers, aliases, and derived values are preserved or rebuilt according to policy | Partially covered; unified checker pending |
+| Routing correctness | A source reaches the correct rank, expert, and shard, not merely any loader | Receipt identity exists; distributed sentinel validation pending |
+| Cache coherence | Prefix, LoRA, and multimodal caches never serve state from an old weight generation | Unified generation checker pending |
 
-这些不变量由不同机制维护，但它们共享同一个提交时刻，因此应由统一事务报告汇总，而不是散落在各个入口函数里各自判断。
+These invariants require different mechanisms, but they share one commit point. A transaction report should aggregate them instead of allowing each update entry point to make an unrelated decision.
 
-## 3. 当前实现的历史演进
+## 3. Implementation history
 
-本分支不是一次性加入完整事务，而是按“先稳定存储，再建立可验证 manifest，最后让 manifest 成为完成条件”的顺序演进：
+The branch evolved in stages: stabilize storage first, establish verifiable manifests next, then make the manifest authoritative for completion.
 
-| 提交 | 作用 |
+| Commit | Purpose |
 |---|---|
-| `5532d3a69` | 引入 layer-owned `ReloadArena`，为图可见临时 tensor 提供稳定存储 |
-| `6f725f866`、`dead65972` | 将 Machete、RDNA3 WNA16 MoE 等派生 scratch 接入 arena |
-| `14a226b68` | 捕获 module-level tensor storage，补充 arena 以外的第二层存储检查 |
-| `91e05c188`～`ba8bd7a2f` | 建立 registry、首次 forward、dataflow 和 MoE experts 的 CI 扫描 |
-| `bdc1ee506` | 将 arena snapshot/verify 放入逐层 reload 流程 |
-| `3a90010d3` | required 集合改为首次真实加载时观察，不再根据模型结构预测 |
-| `7645c60fb` | 加入 source、target、fragment manifest，覆盖多 loader 和 weight-transfer 路径 |
-| `19969814d` | 删除 `load_numel/load_numel_total`，由 manifest 决定完成时机 |
-| `cd44e02e3` | 引入结构化 `LoadReceipt`，迁移 QKV、MergedColumn、RoutedExperts 和 composed loader |
-| `810280d52` | 引入 event-key collision 审计，检测 receipt 字段遗漏、状态冲突和 schema 漂移 |
+| `5532d3a69` | Introduced layer-owned `ReloadArena` storage for graph-visible temporary tensors |
+| `6f725f866`, `dead65972` | Moved Machete and RDNA3 WNA16 MoE derived scratch tensors into the arena |
+| `14a226b68` | Added capture-time module-level storage manifests beyond arena-owned tensors |
+| `91e05c188` through `ba8bd7a2f` | Added registry, first-forward, dataflow, and MoE-expert CI discovery |
+| `bdc1ee506` | Moved arena snapshot/verification into the per-layer reload pipeline |
+| `3a90010d3` | Observed required events during the first real load instead of predicting them from model structure |
+| `7645c60fb` | Added source, target, and fragment manifests across loader and weight-transfer paths |
+| `19969814d` | Removed `load_numel/load_numel_total` and made manifests drive completion |
+| `cd44e02e3` | Added structured `LoadReceipt`s for QKV, merged-column, RoutedExperts, and composed loaders |
+| `810280d52` | Added event-key collision auditing for missing fields, status conflicts, and schema drift |
 
-因此，旧文档中把 `CompletionManifestChecker` 标成“design”的描述已经过时：manifest、结构化回执和 collision audit 已经有代码和模型验证。仍未落地的是将这些能力统一包装成一个显式 `ReloadTransaction` 对象，以及将所有 rank 的报告统一成一个全局 commit 决策。
+Older descriptions that label `CompletionManifestChecker` as design-only are now stale. Manifests, structured receipts, and collision auditing have code and model-level validation. What remains is a unified coordinator and a global all-rank commit decision.
 
+### 3.1 Status legend and summary
 
-### 3.1 实现状态总览
+The document uses four status labels:
 
-本文使用以下标记，避免把目标设计误写成现有能力：
+- **[Implemented]**: code exists on the branch and has unit-test or real-model evidence;
+- **[Partially implemented]**: lower-level state or checks exist, but the unified gate or some update paths are missing;
+- **[To be implemented]**: design only; no complete runtime implementation can be relied upon;
+- **[TBD]**: the interface shape has not been decided; example code expresses responsibilities only.
 
-- **【已实现】**：分支中已经有代码，并至少经过单元测试或真实模型验证；
-- **【部分实现】**：底层数据和局部检查已经存在，但尚未接入统一 commit gate，或仍有入口没有覆盖；
-- **【待实现】**：当前只有设计，没有可依赖的完整运行时代码；
-- **【待定】**：接口形式尚未确定，文中的代码仅用于表达职责边界，不能作为最终 API。
+#### Implemented
 
-#### 已实现
+- Stable ReloadArena storage, per-layer snapshot/verification, and module-level storage manifests;
+- first-checkpoint-load observation of `required_keys` and reload-time collection of `received_keys`;
+- source-to-target-fragment events and rank-local `LoadManifestScope`/`LoadManifestReport`;
+- provisional dummy baselines and promotion to exact event baselines after a complete first real update;
+- manifest completion in place of `load_numel/load_numel_total`;
+- `LoadReceipt`/`LoadFragment` support in QKV, MergedColumn, RoutedExperts, and composed loaders;
+- event-key/target collisions, status conflicts, schema drift, and declared-schema mismatch detection;
+- declared source-manifest validation in `WeightTransferEngine`;
+- Qwen3 MoE TP/EP, Qwen CUDA IPC, and synthetic negative tests.
 
-- ReloadArena 稳定存储、逐层 snapshot/verify，以及 module-level storage manifest；
-- 首次 checkpoint 加载期间观察 `required_keys`，reload 期间记录 `received_keys`；
-- source→target fragment event、rank-local `LoadManifestScope/LoadManifestReport`；
-- dummy 首轮 provisional target baseline，以及完整首轮后提升为精确事件基线；
-- manifest 完成条件取代 `load_numel/load_numel_total`；
-- `LoadReceipt/LoadFragment`，以及 QKV、MergedColumn、RoutedExperts、composed loader 接入；
-- event-key/target collision、状态冲突、schema drift 和声明不匹配审计；
-- WeightTransferEngine 的 declared source manifest 检查；
-- Qwen3 MoE TP/EP、Qwen CUDA IPC 和多类 synthetic 负向测试。
+#### Partially implemented
 
-#### 部分实现
+- Fail-closed behavior: first-load collisions, incomplete dummy-first-real updates, and declared source mismatches fail directly; normal completion/arena findings still depend on callers enforcing `report.ok`;
+- distributed commit: rank-local scopes/reports and multi-rank validation exist, but no universal all-rank commit barrier exists;
+- loader coverage: standard checkpoint, IPC/NCCL, and several external loaders are covered, while sparse/direct mutation needs a transaction hook;
+- draft/MTP: independent scopes are required by design, but no common model-role/generation protocol exists;
+- keyless and derived state: the arena covers some graph-visible tensors, but there is no general buffer/alias checker.
 
-- Fail-closed：首次 collision、dummy 首轮不完整和 declared source mismatch 已直接失败；普通 reload 的 completion/arena finding 仍主要依赖调用方检查 `report.ok`；
-- 分布式提交：已经生成 rank-local scope/report，并做过多 rank 验证，但尚无统一 all-rank commit barrier；
-- loader 覆盖：标准 checkpoint、IPC/NCCL 和若干 external loader 已接入，sparse/direct mutation 仍需独立事务 hook；
-- draft/MTP：设计上要求独立 scope，但尚未形成统一 model-role/generation 协议；
-- keyless state 和派生状态：arena 覆盖部分图可见 tensor，尚无统一 buffer/alias checker。
+#### To be implemented
 
-#### 待实现
+- A unified coordinator and its final public/internal API;
+- all-rank commit barrier, timeout, and all-or-none resume;
+- rollback through a shadow model/double buffer or undo log;
+- transaction ID, weight generation, late-chunk rejection, and concurrent-update isolation;
+- a standard source/dirty-generation protocol for sparse and direct updates;
+- `LoaderEpochChecker`, `KeylessStateChecker`, `ShardRoutingChecker`, `CacheGenerationChecker`, and `IdempotencyChecker`;
+- formal target/draft/MTP scope types and independent reconciliation;
+- generation-based invalidation for prefix, LoRA, multimodal, and related caches.
 
-- 统一事务协调器及其最终 API；
-- 所有 rank 的 commit barrier、timeout 和 all-or-none resume；
-- rollback：shadow model/双缓冲或 undo log；
-- transaction ID、weight generation、晚到 chunk 和并发更新隔离；
-- sparse/direct update 的标准 source/dirty-generation 协议；
-- `LoaderEpochChecker`、`KeylessStateChecker`、`ShardRoutingChecker`、`CacheGenerationChecker` 和 `IdempotencyChecker`；
-- target、draft、MTP 的正式 scope 数据结构及独立对账；
-- prefix cache、LoRA、多模态等缓存的 generation 失效机制。
-
-## 4. 【已实现】事务中的三层身份
+## 4. [Implemented] Three layers of identity
 
 ### 4.1 Source identity
 
-source identity 是发送端或 checkpoint 侧的稳定权重名称，例如：
+A source identity is the stable sender-side or checkpoint-side name, for example:
 
 ```text
 model.layers.0.self_attn.q_proj.weight
 model.layers.0.mlp.experts.7.gate_proj.weight
 ```
 
-checkpoint loader 通过 `observe_weight_sources()` 在迭代权重时保存当前 source key，使模型内部经过名称映射、packed routing 或 expert routing 后仍能知道原始 source。IPC/NCCL 等分块传输还可以独立声明 `expected_source_names`，接收端在 transaction finalize 时检查：
+Checkpoint loaders use `observe_weight_sources()` to preserve the original source key while the model performs name mapping, packed routing, or expert routing. Chunked IPC/NCCL transfers may independently declare `expected_source_names`, allowing final reconciliation:
 
 ```text
 missing = expected_source_names - received_source_names
 unexpected = received_source_names - expected_source_names
 ```
 
-dummy 初始化没有真实 checkpoint source，因此无法从首次 dummy load 学到 source 基线。对于可能分块、丢包或由调用方决定发送集合的 IPC/NCCL 传输，第一次真实传输必须携带权威 source manifest；否则无法判断某个从未到达的 source。直接读取完整 checkpoint 文件时，checkpoint 索引/迭代器本身可以作为 source 边界，但仍要结合 provisional target baseline 检查本 rank 的目标是否全部触达。
+Dummy initialization has no checkpoint source stream and cannot learn a source baseline. For IPC/NCCL transfers where the caller chooses and chunks the source set, the first real transfer must carry an authoritative source manifest; otherwise a source that never arrived cannot be distinguished from a source that was not expected. When loading a complete checkpoint directly, the checkpoint index/iterator can define the source boundary, but the rank-local provisional target baseline must still be satisfied.
 
-### 4.2 Target fragment identity
+### 4.2 Target-fragment identity
 
-一个 Parameter 不一定对应一个逻辑权重。QKV、merged MLP、MoE 和量化权重经常将多个 source 写入同一个 packed Parameter，因此目标身份必须表示为：
+One Parameter does not necessarily represent one logical weight. QKV, merged MLP, MoE, and quantized weights often place multiple sources into one packed Parameter. The target identity must therefore be:
 
 ```text
-param_name + logical fragment
+parameter name + logical fragment
 ```
 
-例如：
+Examples:
 
 ```text
 weight[loaded_shard_id='q']
 w13_weight[shard_id='w1',expert_id=7,weight_name='...w13_weight']
 ```
 
-### 4.3 Full load event identity
+### 4.3 Full load-event identity
 
-最终 manifest 事件是：
+The final manifest event is:
 
 ```text
-source_key => target fragment
+source key => target fragment
 ```
 
-例如：
+Examples:
 
 ```text
 model.layers.0.self_attn.q_proj.weight=>weight[loaded_shard_id='q']
 model.layers.0.mlp.experts.7.gate_proj.weight=>w13_weight[shard_id='w1',expert_id=7,weight_name='model.layers.0.mlp.experts.w13_weight']
 ```
 
-事务完成条件比较的是完整事件集合；collision audit 还会单独比较去掉 source 后的 target fragment，防止不同 source 因 receipt 不完整而错误声明同一个目标区域。
+Transaction completion compares full event sets. Collision auditing additionally compares target fragments without source names, because different sources can incorrectly claim the same target if a receipt omits a discriminator.
 
-## 5. 【已实现】结构化 LoadReceipt
+## 5. [Implemented] Structured LoadReceipt
 
-每次逻辑 loader 调用返回一个结构化回执：
+Every logical loader call returns a structured receipt:
 
 ```python
 @dataclass(frozen=True)
@@ -224,13 +222,13 @@ class LoadReceipt:
     collision_policy: LoadCollisionPolicy
 ```
 
-普通成功加载：
+A normal successful load returns:
 
 ```python
 return LoadReceipt.accepted(loaded_shard_id="q")
 ```
 
-当前 rank 不负责的 expert：
+An expert not owned by the current rank returns:
 
 ```python
 return LoadReceipt.skipped(
@@ -240,7 +238,7 @@ return LoadReceipt.skipped(
 )
 ```
 
-分支复杂、暂时仍返回 `None/bool` 的旧 loader 可以用 decorator 迁移：
+An existing loader with many branches and a historical `None`/`bool` result can migrate through a declarative adapter:
 
 ```python
 @returns_load_receipt("shard_id", "expert_id", "weight_name")
@@ -248,35 +246,35 @@ def weight_loader(..., return_success=False):
     ...
 ```
 
-`LoadReceipt.__bool__()` 保留旧条件 loader 的 truthiness，因此现有 `if success:` 路由可以继续工作。尚未迁移的 loader 通过 `_legacy_load_receipt(bound_args, result)` 兼容；该路径仍会从约定参数名推测 fragment，只是迁移期 fallback，不应成为新增 loader 的默认设计。
+`LoadReceipt.__bool__()` preserves conditional-loader truthiness, so existing `if success:` routing continues to work. Loaders not yet migrated use `_legacy_load_receipt(bound_args, result)`, which infers fragments from known argument names. That path is a migration fallback and should not be the default for new loaders.
 
-### 5.1 当前模型路径的 fragment 定义
+### 5.1 Fragment definitions in validated model paths
 
-| Loader | Receipt fragment | 原因 |
+| Loader | Receipt fragment | Reason |
 |---|---|---|
-| `QKVParallelLinear` | `loaded_shard_id=q/k/v` | 同一个 packed Parameter 内必须区分 Q、K、V 区域 |
-| `MergedColumnParallelLinear` | `loaded_shard_id=0/1/...` | gate/up 等 source 写入不同 merged shard |
-| `RoutedExperts` | `shard_id + expert_id + weight_name` | 区分 expert、w1/w2/w3 及量化或特殊权重分支 |
-| 普通一对一 loader | 空 fragment | source 和 param 已足以确定唯一目标 |
-| composed loader | 原样传播底层 receipt | 后处理 `copy_(fn(param))` 不是第二个 source 消费事件 |
+| `QKVParallelLinear` | `loaded_shard_id=q/k/v` | Distinguishes Q, K, and V regions inside one packed Parameter |
+| `MergedColumnParallelLinear` | `loaded_shard_id=0/1/...` | Distinguishes gate/up or other merged shards |
+| `RoutedExperts` | `shard_id + expert_id + weight_name` | Distinguishes experts, w1/w2/w3, and quantized/special weight branches |
+| Ordinary one-to-one loader | Empty fragment | Source and parameter name already identify one target |
+| Composed loader | Propagates the underlying receipt unchanged | Post-load `copy_(fn(param))` is not a second source-consumption event |
 
-receipt 描述的是“本次 loader 调用消费了哪个逻辑 fragment”，而不是内部执行了几次 `copy_`。这正是它能够覆盖 #44814 类型问题的原因。
+A receipt describes which logical fragment one loader invocation consumed. It does not count internal `copy_` calls. This is why the model can handle the #44814 failure class without numel-based completion.
 
-## 6. 【已实现】Event-key collision 审计
+## 6. [Implemented] Event-key collision audit
 
-只比较首次基线和 reload 的集合仍有盲点：如果首次加载和 reload 都返回同一个不完整 receipt，两个不同 fragment 会在两边同时折叠，最终仍可能出现 `required == received`。`810280d52` 增加了独立于 receipt 的 `LoadEventAudit` 来检测这种情况。
+Comparing first-load and reload sets has a blind spot: if both phases return the same incomplete receipt, two distinct fragments can collapse on both sides and still satisfy `required == received`. Commit `810280d52` adds `LoadEventAudit`, an independent witness mechanism.
 
-每次 loader 调用除了生成 manifest key，还生成 `LoadCallWitness`。witness 记录：loader 的 module/qualname、source key、目标参数名、`BoundArguments` 中稳定可序列化的标量参数，以及 loaded tensor 的 shape/dtype；它不记录 Tensor 内容、对象地址或设备指针。审计类型包括：
+For every loader call, the audit creates a `LoadCallWitness` containing the loader module/qualname, source key, target parameter name, stable serializable scalar arguments from `BoundArguments`, and loaded-tensor shape/dtype. It never records tensor contents, object addresses, or device pointers.
 
-| Finding | 含义 |
+| Finding | Meaning |
 |---|---|
-| `EVENT_KEY_COLLISION` | 同一完整 event key 对应两个不同调用 witness |
-| `TARGET_ALIAS_COLLISION` | 不同 source 或调用错误地声明同一 target fragment |
-| `STATUS_CONFLICT` | 同一逻辑事件在同一事务中既 accepted 又 skipped |
-| `SCHEMA_DRIFT` | 同一个 loader 在一轮加载中返回了不同 fragment schema |
-| `RECEIPT_SCHEMA_MISMATCH` | decorator 声明的字段与实际 receipt 不一致 |
+| `EVENT_KEY_COLLISION` | One full event key corresponds to two different call witnesses |
+| `TARGET_ALIAS_COLLISION` | Different sources or calls incorrectly claim the same target fragment |
+| `STATUS_CONFLICT` | One logical event is both accepted and skipped in one transaction |
+| `SCHEMA_DRIFT` | One loader returns different fragment schemas during one load |
+| `RECEIPT_SCHEMA_MISMATCH` | The decorator declaration and actual receipt fields disagree |
 
-例如 QKV loader 漏掉 `loaded_shard_id` 时，完整 source key 仍然不同，但 target 都退化为 `weight`，审计会给出：
+If a QKV loader omits `loaded_shard_id`, its source keys are still different, but all targets collapse to `weight`. The audit reports:
 
 ```text
 TARGET_ALIAS_COLLISION
@@ -286,66 +284,66 @@ differing_arguments=('loaded_shard_id',)
 possible_missing_receipt_fields=('loaded_shard_id',)
 ```
 
-完全相同的重复调用不视为 identity collision。如果业务确实需要多个 source 有意覆盖同一目标，loader 必须显式返回 `collision_policy=LoadCollisionPolicy.OVERWRITE`；不能使用按模型名称维护的隐式白名单。
+Identical duplicate calls are not identity collisions. A loader that intentionally allows several sources to overwrite one target must explicitly use `collision_policy=LoadCollisionPolicy.OVERWRITE`; model-name allowlists are not used.
 
-首次 checkpoint 加载在 `finalize_load_recording()` 汇总 collision，发现问题就拒绝建立错误基线；reload 阶段将 collision 写入 `LoadManifestReport.completion_findings`，使该 rank 的 `report.ok` 变为 false。
+`finalize_load_recording()` rejects collisions while establishing a checkpoint baseline. During reload, collision findings are added to `LoadManifestReport.completion_findings`, making the rank-local `report.ok` false.
 
-## 7. 【已实现】Manifest 的建立与使用
+## 7. [Implemented] Manifest creation and replay
 
-### 7.1 普通 checkpoint 首次加载
+### 7.1 Normal first checkpoint load
 
 ```text
-模型参数已经创建
-→ record_metadata_for_reloading(model)
-→ record_load_consumption(model)，包装每个有效 weight_loader
-→ checkpoint stream 逐个设置 source context
-→ loader 返回或被适配为 LoadReceipt
-→ 记录 source=>target[fragment] 到 required_keys
-→ 同时运行 LoadEventAudit
-→ finalize_load_recording(model)
-→ 恢复原 loader；collision 为零后基线生效
+model parameters exist
+-> record_metadata_for_reloading(model)
+-> record_load_consumption(model) wraps effective weight loaders
+-> checkpoint iteration establishes a source context
+-> loader returns or is adapted to LoadReceipt
+-> source=>target[fragment] is added to required_keys
+-> LoadEventAudit runs in parallel
+-> finalize_load_recording(model)
+-> original loaders are restored; the baseline becomes valid if no collision exists
 ```
 
-`required_keys` 是实际观察结果，不是根据 `state_dict()`、Parameter 数量或模型架构预测出来的集合。因此 EP 非本地 expert、共享 alias、没有 checkpoint source 的运行时状态不会被错误加入本 rank 的 required 集合。
+`required_keys` is observed ground truth, not a prediction derived from `state_dict()`, parameter counts, or architecture names. EP-nonlocal experts, shared aliases, and runtime state without checkpoint sources are therefore absent from the rank-local required set by construction.
 
-### 7.2 普通 reload
+### 7.2 Normal reload
 
 ```text
 initialize_layerwise_reload(model)
-→ snapshot arena
-→ 将需要重载的层恢复到 meta/checkpoint 布局
-→ 安装 online loader wrapper
-→ 每个成功 receipt 加入 received_keys
-→ required_keys ⊆ received_keys 时允许该层执行 PWAL
-→ checkpoint iterator 结束后做最终集合对账
-→ 校验 arena snapshot
-→ 生成 rank-local LoadManifestReport
+-> snapshot arena storage
+-> restore reloadable layers to checkpoint/meta layout
+-> install online loader wrappers
+-> add each consumed receipt to received_keys
+-> when required_keys is a subset of received_keys, allow layer PWAL
+-> after checkpoint exhaustion, perform final set reconciliation
+-> verify arena snapshots
+-> produce a rank-local LoadManifestReport
 ```
 
-完成条件是事件集合，不再使用 `load_numel >= load_numel_total`。`copied_numel_diagnostic` 可以保留用于日志，但不参与完成、commit 或 fallback 判断。
+The event set determines completion. `copied_numel_diagnostic` may remain as a log-only metric, but it does not participate in completion, commit, or fallback decisions.
 
-### 7.3 Dummy 初始化后的第一次真实传输
+### 7.3 First real update after dummy initialization
 
-Dummy loader 没有 source stream，只能建立 provisional target baseline：
+A dummy load has no source stream and can establish only a provisional target baseline:
 
 ```text
-required_target_keys = 本 rank 必须触达的参数目标
-required_keys = 空，表示尚无精确 source/fragment 基线
+required_target_keys = rank-local parameter targets that must be touched
+required_keys = empty, meaning no exact source/fragment baseline exists yet
 ```
 
-第一次真实更新必须完成目标检查；对于 IPC/NCCL 等分块传输还必须完成 source 检查：发送端声明的 source manifest 全部到达，并且所有 provisional target 都至少被成功 receipt 触达。由于一个 target 可能承载多个 QKV/MoE fragment，这一轮不能在第一次触达 target 后提前执行 PWAL，必须缓冲到事务结束。验证通过后，本轮 `received_keys` 被提升为永久 `required_keys`，后续 reload 即可按精确事件逐层完成。
+The first real update must satisfy every provisional target. Chunked IPC/NCCL transfers must additionally prove that every source in the independently declared source manifest arrived. One target may contain many QKV or MoE fragments, so the first touch cannot trigger early PWAL; this phase remains buffered until transaction finalization. After successful validation, `received_keys` is promoted to permanent `required_keys`, and later reloads can finalize layers from exact events.
 
-### 7.4 在线量化与外部 tensor loader
+### 7.4 Online quantization and external tensor loaders
 
-首次在线量化同样可能没有精确 fragment 基线，应使用 provisional target 流程。对于 Modelexpress、RunAI、Tensorizer 或直接传输已经处理好的 tensor、完全绕过 `weight_loader` 的路径，不能伪造 loader receipt；它们应通过 `record_external_tensor_manifest()` 或 `record_direct_load_consumption()` 发布 source→target 事件。覆盖能力必须按 loader 的真实数据流声明，不能仅因为目录中存在某个 loader 文件就认为已经自动覆盖。
+First-load online quantization may also lack an exact fragment baseline and follows the provisional-target path. Modelexpress, RunAI, Tensorizer, or processed-tensor transfers may bypass vLLM `weight_loader` functions entirely. They must publish source-to-target events through `record_external_tensor_manifest()` or `record_direct_load_consumption()` rather than fabricating receipts. Coverage must follow the actual dataflow; the mere presence of a loader file does not imply transaction coverage.
 
-## 8. 【已实现】存储事务：ReloadArena 与 PWAL
+## 8. [Implemented] Storage transaction: ReloadArena and PWAL
 
-manifest 证明“该加载的逻辑权重都加载了”，arena 证明“PWAL 后图和 kernel 仍引用正确存储”。两者解决不同问题，必须同时存在。
+The manifest proves that every logical weight was loaded. The arena proves that graph and kernel consumers still reference valid storage after PWAL. These are separate invariants and both are required.
 
-每个使用 arena 的 layer 在 reload 开始时 snapshot slot identity；PWAL 重建后调用 `arena.verify(snapshot)`，检查 slot 是否消失、地址移动或 layout 改变。arena 自身拥有稳定 buffer，PWAL 通过 `put()` 将新派生值写回已有 storage，而不是重新绑定 graph-visible tensor。逐层验证必须发生在 `LayerReloadingInfo.reset()` 之前，否则 snapshot 会丢失。
+At reload start, each arena-backed layer snapshots slot identities. After PWAL rebuilds derived tensors, `arena.verify(snapshot)` checks for missing slots, moved addresses, or layout changes. The arena owns stable buffers, and PWAL uses `put()` to refresh values in existing storage instead of rebinding graph-visible tensors. Verification must happen before `LayerReloadingInfo.reset()` clears the snapshot.
 
-当前 `LoadManifestReport` 包含：
+The current report is:
 
 ```python
 LoadManifestReport(
@@ -357,24 +355,24 @@ LoadManifestReport(
 )
 ```
 
-`report.ok` 只有在 completion 和 arena finding 都为空时才为 true。collision finding 当前归入 completion findings。
+`report.ok` is true only when completion and arena findings are both empty. Collision findings currently belong to `completion_findings`.
 
-## 9. 【部分实现】分布式事务 scope 与提交决策
+## 9. [Partially implemented] Distributed scope and commit decision
 
-manifest 必须按 worker/rank 保存，不能先跨 rank 求并集。TP、PP、EP worker 本来就消费不同 fragment；如果先合并，rank 0 缺失的事件可能被 rank 1 的事件掩盖。每份 report 携带：global rank/world size，以及 TP、PP、DP、EP 的 rank/world size。
+Manifests must remain per worker/rank; they cannot be unioned before reconciliation. TP, PP, and EP workers legitimately consume different fragments. A union could hide a missing rank-0 event behind an event received by rank 1. Each report therefore carries global rank/world size and TP, PP, DP, and EP coordinates.
 
-正确的全局提交协议应当是：
+The intended global protocol is:
 
 ```text
-每个 rank 完成本地 APPLY 和 VALIDATE
-→ controller 收集所有 rank 的 LoadManifestReport
-→ 任一 report.ok == false，则整个 update ABORT
-→ 所有 report.ok == true，经过 barrier 后统一 COMMIT/RESUME
+each rank completes local APPLY and VALIDATE
+-> controller collects every rank-local LoadManifestReport
+-> if any report.ok is false, ABORT the entire update
+-> if every report.ok is true, cross a barrier and COMMIT/RESUME together
 ```
 
-当前已经能够生成和收集 rank-local report，也完成了 TP/EP 等模型验证；但统一的全局 commit barrier 尚未抽象成通用 `ReloadTransaction`。在此之前，各入口必须明确检查所有 worker report，不能只检查 rank 0，也不能让通过的 rank 先恢复请求。
+Rank-local report generation and multi-rank model validation exist. A universal global commit barrier does not. Until it does, each entry point must check all worker reports rather than rank 0 alone, and a successful rank must not resume before failed ranks.
 
-MTP 和投机推理应使用独立 scope。target model 与 draft model 可能具有不同参数集合、并行配置和更新节奏，不能把事件放进同一个无前缀集合。建议 scope 至少包含：
+MTP and speculative decoding require independent scopes. Target and draft models can have different parameter sets, parallel layouts, and update cadence. Events must not share an unqualified set. A future scope should contain at least:
 
 ```text
 model_role = target | draft | mtp
@@ -383,48 +381,48 @@ parallel coordinates
 weight generation
 ```
 
-如果只更新 target，draft scope 必须明确声明“不参与本事务”，而不是因没有 receipt 被误判为缺失。
+If only the target model is updated, the draft scope must explicitly be out of the transaction rather than appearing to have missing receipts.
 
-## 10. 【部分实现】入口覆盖与事务边界
+## 10. [Partially implemented] Entry-point coverage and transaction boundaries
 
-权重更新入口并不唯一：checkpoint `reload_weights`、IPC、NCCL、sparse NCCL、Modelexpress、RunAI、Tensorizer，以及框架通过 RPC 直接调用 `model.load_weights`。因此不能只在某个 API 名称上放一个 gate，然后声称覆盖全部流程。
+Weight updates have many entry points: checkpoint `reload_weights`, IPC, NCCL, sparse NCCL, Modelexpress, RunAI, Tensorizer, and framework RPC calls to `model.load_weights`. A gate attached to one API method cannot claim complete coverage.
 
-当前可归纳为三类：
+The paths fall into three groups:
 
-1. **调用标准 `weight_loader` 的 checkpoint-format 路径**：通过 source observation、LoadReceipt、layerwise manifest 和 arena 完整覆盖。
-2. **传输已处理 tensor、直接恢复 state 的路径**：通过 external/direct manifest 发布事件，不应强行套用 fragment loader 语义。
-3. **直接对已有 Parameter 做 `index_copy_` 等 sparse patch 的路径**：不会触发标准 loader，需要独立声明 source manifest、dirty generation 和 commit 检查；这是当前仍需继续补齐的路径。
+1. **Checkpoint-format paths using standard `weight_loader`s:** covered by source observation, LoadReceipt, layerwise manifests, and arena verification.
+2. **Processed-tensor or direct-state restoration paths:** publish external/direct manifest events and should not be forced into fragment-loader semantics.
+3. **Sparse patches using `index_copy_` or similar direct mutations:** do not invoke standard loaders and need an explicit source manifest, dirty-generation marker, and commit check.
 
-未来统一协调器应位于“模型恢复推理之前”，而不是绑定某个调用入口。所有入口都必须执行：`begin_update → observe/apply → finish_update → validate → commit`。嵌套入口必须有 transaction depth/reentrancy guard，避免 `reload_weights`、NCCL engine 和 `model.load_weights` 重复执行 initialize/finalize。
+A future coordinator should sit at the resume boundary rather than at one named API. Every entry point must run `begin_update -> observe/apply -> finish_update -> validate -> commit`. Nested paths need transaction-depth or reentrancy guards so `reload_weights`, an NCCL engine, and `model.load_weights` do not run initialize/finalize repeatedly.
 
-## 11. 【待定】统一 ReloadTransaction 的候选职责与接口
+## 11. [TBD] Candidate responsibilities and interface for a unified transaction
 
-> **接口待定：** 当前尚未决定最终由 `ReloadTransaction` 类、WeightTransferEngine 生命周期，还是 worker/controller 协议承担协调职责。下面的代码只表达 BEGIN/APPLY/FINALIZE/VALIDATE/COMMIT/ABORT 的职责边界，不是已实现接口，也不作为后续代码必须遵循的类名、方法签名或调用层级。
+> **Interface TBD:** It has not been decided whether coordination ultimately belongs in a `ReloadTransaction` class, the `WeightTransferEngine` lifecycle, or a worker/controller protocol. The following code expresses BEGIN/APPLY/FINALIZE/VALIDATE/COMMIT/ABORT responsibilities only. It is not an implemented API and does not prescribe the final class name, method signatures, or call hierarchy.
 
-候选职责可以表示为：
+One possible responsibility split is:
 
 ```python
 class ReloadTransaction:
     def begin(self) -> None:
-        """冻结 scope，清空本轮 received 状态，snapshot arena/cache。"""
+        """Freeze scope, clear received state, and snapshot arenas/caches."""
 
     def apply(self, update) -> None:
-        """唯一允许修改模型状态的阶段。"""
+        """The only phase allowed to mutate model state."""
 
     def finalize(self) -> None:
-        """完成 layerwise processing、PWAL 和 backend finalize。"""
+        """Finish layerwise processing, PWAL, and backend finalization."""
 
     def validate(self) -> list[LoadManifestReport]:
-        """只读汇总 source、receipt、collision、arena 和扩展 checker。"""
+        """Read-only aggregation of source, receipt, collision, arena, and checks."""
 
     def commit(self) -> None:
-        """所有 rank 通过后提升 generation 并恢复服务。"""
+        """Advance generation and resume only after every rank passes."""
 
     def abort(self, findings) -> NoReturn:
-        """禁止恢复服务；未来可在这里执行 rollback。"""
+        """Refuse to resume; a future implementation may roll back here."""
 ```
 
-检查器建议采用统一协议：
+A common checker protocol could be:
 
 ```python
 class ReloadChecker(Protocol):
@@ -433,45 +431,43 @@ class ReloadChecker(Protocol):
     def verify(self, ctx: ReloadContext) -> list[Finding]: ...
 ```
 
-已经具备 checker 数据基础的模块包括：`CompletionManifestChecker`（required/received/source/collision）和 `StorageIdentityChecker`（arena/module storage）。后续应补充：
+Existing data can support `CompletionManifestChecker` (required/received/source/collision) and `StorageIdentityChecker` (arena/module storage). Future checkers include:
 
-- `KeylessStateChecker`：persistent=False buffer、alias 和无 checkpoint key 状态；
-- `LoaderEpochChecker`：防止 checkpoint-layout loader 写入 kernel-layout storage；
-- `ShardRoutingChecker`：通过 rank-distinct sentinel 验证 TP/EP 路由；
-- `CacheGenerationChecker`：更新后使 prefix/LoRA/多模态缓存失效；
-- `IdempotencyChecker`：identity reload 时验证参数、buffer、storage 和输出不变。
+- `KeylessStateChecker` for `persistent=False` buffers, aliases, and state without checkpoint keys;
+- `LoaderEpochChecker` to prevent checkpoint-layout loaders from writing kernel-layout storage;
+- `ShardRoutingChecker` with rank-distinct sentinels for TP/EP routing;
+- `CacheGenerationChecker` for prefix, LoRA, and multimodal cache invalidation;
+- `IdempotencyChecker` to verify that an identity reload preserves parameters, buffers, storage, and output.
 
-## 12. 【部分实现 / 待完善】失败语义、rollback 与并发
+## 12. [Partially implemented / incomplete] Failure semantics, rollback, and concurrency
 
-当前事务最重要的保证是“不把未验证更新报告为成功”。发现以下问题时必须失败：source manifest 缺失或多余；required event 未收到；dummy target 未触达；LoadReceipt collision/schema 错误；arena storage 漂移；任一 rank report 不通过。
+The key contract is that an unvalidated update must not be reported as successful. Missing/unexpected source names, missing required events, untouched dummy targets, receipt collisions/schema errors, arena drift, or any failed rank must eventually reject the transaction.
 
-但当前 apply 是原地修改，失败时模型可能已经部分写入。因此生产级事务还需要二选一：
+APPLY currently mutates the live model in place, so a failure may leave partially changed values. A production transaction needs one of:
 
-1. **Shadow/双缓冲更新**：在不可见的新模型或新 arena generation 上完成加载和验证，commit 时原子切换；优点是真正可回滚，代价是额外显存。
-2. **Undo log**：更新前保存将被修改的 parameter/buffer，失败时恢复；显存可按层控制，但必须覆盖 PWAL 派生状态和 alias，复杂度较高。
+1. **Shadow/double-buffer update:** load and validate an invisible model or arena generation, then atomically switch on commit. This provides true rollback at the cost of memory.
+2. **Undo log:** save parameters/buffers before modification and restore them on failure. Memory can be managed layer by layer, but PWAL-derived state and aliases make this more complex.
 
-在 rollback 落地之前，ABORT 后必须保持 worker 不接收新请求，由上层销毁并重建 worker，不能继续使用“可能已部分更新”的模型。
+Until rollback exists, an aborted worker must not accept new requests. The controller should destroy and rebuild it rather than use a possibly partial model.
 
-并发方面，同一个 model instance 同时只允许一个 active transaction。每次更新分配单调递增的 `transaction_id/weight_generation`；晚到的 chunk、重复 finalize、旧 generation 的 RPC 都必须被拒绝。跨 rank timeout 也应作为 violation 进入统一 abort，而不是无限等待。
+Only one transaction may be active for one model instance. Each update should receive a monotonically increasing `transaction_id` and `weight_generation`; late chunks, duplicate finalization, and old-generation RPCs must be rejected. A rank timeout should become an abort finding rather than an indefinite barrier wait.
 
-## 13. 【已实现】验证矩阵与现有证据
+## 13. [Implemented] Validation matrix and evidence
 
-当前实现已覆盖以下关键场景：
-
-| 场景 | 结果 |
+| Scenario | Result |
 |---|---|
-| synthetic composed/Mamba loader，内部执行两次 `copy_` | 一个逻辑 receipt，不会因 numel 双计数提前完成 |
-| QKV q/k/v packed loading | 三个独立 fragment；漏字段测试触发 target collision |
-| RoutedExperts 普通 MoE | expert/shard/weight 类型均进入 receipt |
-| EP 非本地 expert | 返回 skipped，不进入本 rank required 集合 |
-| Qwen3 MoE dummy→real→reload，TP=1 | 两轮 789/789，token `[15616, 534]` |
-| Qwen3 MoE TP=2 | 两个 rank 的精确 manifest 均完成 |
-| Qwen3 MoE EP=2 | 每个 rank 按本地 expert 对账，405/405 |
-| Qwen3-0.6B packed CUDA IPC | 310/310，冷加载与 IPC 输出一致 |
-| LoadReceipt collision 负向测试 | QKV/MoE 字段缺失、状态冲突、schema drift 均可检测 |
-| 显式 overwrite 与相同重复调用 | 不产生误报 |
+| Synthetic composed/Mamba loader with two internal `copy_` calls | One logical receipt; no early completion from double numel counting |
+| Packed QKV loading | Three independent fragments; missing-field test triggers target collision |
+| RoutedExperts MoE | Expert, shard, and weight category are present in receipts |
+| EP-nonlocal expert | Returns skipped and is absent from rank-local required events |
+| Qwen3 MoE dummy -> real -> reload, TP=1 | Both real loads 789/789; tokens `[15616, 534]` |
+| Qwen3 MoE TP=2 | Exact manifests complete on both ranks |
+| Qwen3 MoE EP=2 | Rank-local expert reconciliation, 405/405 per rank |
+| Qwen3-0.6B packed CUDA IPC | 310/310; IPC output matches cold load |
+| Negative collision tests | Missing QKV/MoE fields, status conflict, and schema drift detected |
+| Explicit overwrite and identical duplicate calls | No false positive |
 
-主要日志位于：
+Relevant logs are under:
 
 ```text
 logs/loaders/load_receipt_moe_tp1.log
@@ -482,36 +478,36 @@ logs/loaders/manifest_only_moe_tp2.log
 logs/loaders/manifest_only_deepseek_fp8.log
 ```
 
-最后一次 collision 版本的 Qwen3 MoE TP1 实测结果为：首次真实加载 `789/789`，第二次 reload `789/789`，`completion_findings=[]`，`FLOW_OK=True`。
+The latest collision-enabled Qwen3 MoE TP1 run completed the first real load and second reload at `789/789`, produced `completion_findings=[]`, and ended with `FLOW_OK=True`.
 
-## 14. 【已实现】代码位置
+## 14. [Implemented] Code map
 
-| 功能 | 代码位置 |
+| Capability | Location |
 |---|---|
-| `LoadReceipt/LoadFragment/LoadCollisionPolicy` | `vllm/model_executor/load_receipt.py` |
-| source context | `vllm/model_executor/model_loader/reload/source.py` |
-| required/received、dummy baseline、layerwise finalize | `vllm/model_executor/model_loader/reload/layerwise.py` |
-| collision witness/audit | `vllm/model_executor/model_loader/reload/audit.py` |
-| manifest scope/report、逐层状态 | `vllm/model_executor/model_loader/reload/types.py` |
-| transport source manifest | `vllm/distributed/weight_transfer/base.py` |
-| loader 入口 observation | `default_loader.py`、`bitsandbytes_loader.py`、`tensorizer_loader.py`、`runai_streamer_loader.py` 等 |
-| QKV/Merged receipt | `vllm/model_executor/layers/linear.py` |
-| MoE receipt | `vllm/model_executor/layers/fused_moe/routed_experts.py` |
-| composed receipt 传播 | `vllm/model_executor/model_loader/weight_utils.py` |
-| arena | `vllm/model_executor/reload_arena.py` 及各 backend 接入点 |
+| `LoadReceipt`, `LoadFragment`, `LoadCollisionPolicy` | `vllm/model_executor/load_receipt.py` |
+| Source context | `vllm/model_executor/model_loader/reload/source.py` |
+| Required/received sets, dummy baseline, layerwise finalization | `vllm/model_executor/model_loader/reload/layerwise.py` |
+| Collision witnesses and audit | `vllm/model_executor/model_loader/reload/audit.py` |
+| Manifest scope/report and per-layer state | `vllm/model_executor/model_loader/reload/types.py` |
+| Transfer source manifest | `vllm/distributed/weight_transfer/base.py` |
+| Loader observation entry points | `default_loader.py`, `bitsandbytes_loader.py`, `tensorizer_loader.py`, `runai_streamer_loader.py`, etc. |
+| QKV and merged-column receipts | `vllm/model_executor/layers/linear.py` |
+| MoE receipts | `vllm/model_executor/layers/fused_moe/routed_experts.py` |
+| Composed receipt propagation | `vllm/model_executor/model_loader/weight_utils.py` |
+| Stable arena | `vllm/model_executor/reload_arena.py` and backend integration points |
 
-## 15. 【待实现】完成标准与后续顺序
+## 15. [To be implemented] Completion criteria and next steps
 
-将“权重更新事务”视为完整落地，至少需要满足：所有权重更新入口都被纳入 transaction scope；首次真实加载可以建立无 collision 的精确 manifest；dummy/在线量化后的首轮流式传输必须有独立 source 声明；reload 完成完全由 manifest 驱动；所有 rank 在同一 barrier 上提交；任何 violation 都禁止恢复推理；target/draft/MTP scope 隔离；缓存代际正确失效；失败后能够回滚或强制重建 worker。
+The weight-update transaction is complete only when all update entry points participate in a transaction scope; a first real load can establish a collision-free exact manifest; the first streamed update after dummy/online initialization has an independent source declaration; reload completion is entirely manifest-driven; every rank commits at one barrier; any violation prevents resume; target/draft/MTP scopes are isolated; caches invalidate by generation; and failures either roll back or force worker reconstruction.
 
-建议后续按以下顺序推进：
+Recommended order:
 
-1. 抽取显式 `ReloadTransaction` 和统一 `Finding/Report`，把现有 completion、collision、arena 先接入，不改变行为；
-2. 在 worker/controller 增加 all-rank commit barrier 和 timeout；
-3. 给 sparse/direct update 路径补 source manifest 与 generation/dirty 标记；
-4. 实现 keyless state、loader epoch 和 cache generation checker；
-5. 明确 target、draft、MTP 独立 scope；
-6. 选择 shadow model 或 undo log，补齐真正 rollback；
-7. 将新增 checker 从观察模式逐步升级为 strict gate，并纳入持续模型矩阵。
+1. Extract a coordinator plus common `Finding`/`Report` types, initially wiring existing completion, collision, and arena checks without changing behavior.
+2. Add an all-rank commit barrier and timeout in the worker/controller path.
+3. Add source-manifest and dirty-generation hooks for sparse/direct updates.
+4. Implement keyless-state, loader-epoch, and cache-generation checkers.
+5. Define independent target, draft, and MTP scopes.
+6. Choose shadow-model or undo-log rollback.
+7. Graduate new checkers from observation to strict gating and add them to the continuous model matrix.
 
-总体原则是：**首次加载负责建立可证明、无碰撞的 ground truth；每次更新负责重放并对账这份 ground truth；arena 证明地址稳定；跨 rank gate 决定全局是否提交。任何没有证据证明完整性的路径，都不能仅凭 HTTP/RPC 成功返回而被视为事务成功。**
+The governing rule is: **the first load establishes collision-free, provable ground truth; every update replays and reconciles that ground truth; the arena proves storage stability; and a cross-rank gate decides whether the update commits. A path without evidence of completeness must never be considered successful merely because an HTTP or RPC call returned successfully.**

--- a/docs/design/TRANSACTION.md
+++ b/docs/design/TRANSACTION.md
@@ -15,13 +15,10 @@ The reload investigation found several independent classes of failure. Stable st
 
 | Category | The invariant is about | Typical failure | Primary mechanism | Status |
 |---|---|---|---|---|
-| 1. Storage identity | A captured address remains valid | CUDA Graph or kernel keeps an address that PWAL replaced | `ReloadArena` and storage verification | Implemented |
+| 1. Storage identity | A captured address remains valid | CUDA Graph or kernel keeps an address that PWAL replaced | `ReloadArena` and storage verification | Partially implemented |
 | 2. Value refresh | Derived storage contains values from the new weights | Address is stable, but scratch/scale contents remain stale | Arena `put()` and backend refresh hooks | Partially implemented |
-| 3. Loader lifecycle | The loading process is complete and uses the correct layout | A loader finishes early, writes through a stale layout, or misses a fragment | Completion manifest, `LoadReceipt`, loader epoch | Manifest implemented; epoch pending |
-| 4. State preservation | State without a checkpoint key survives or is rebuilt | Non-persistent buffers, aliases, or config-dependent state are lost | Keyless-state and config-context checks | Partially implemented |
-| 5. Routing and sharding | An update reaches the correct rank, expert, and shard | A loader consumes a tensor but writes the wrong TP/EP destination | Receipt fragments and distributed sentinels | Receipt identity implemented; sentinels pending |
-| 6. Name and key mapping | Every expected source resolves exactly once | Prefix mapping, packed routing, or loader-specific renaming drops a key | Source/event manifests and collision audit | Implemented for covered loaders |
-| 7. Cache coherence | Consumers do not use state from an old weight generation | Prefix, LoRA, or multimodal cache survives an update | Generation-aware cache invalidation | To be implemented |
+| 3. Loader correctness | Every reload entry point runs the complete lifecycle, and loading is complete with the correct layout, key mapping, fragment, rank, expert, and shard | A caller invokes raw `model.load_weights`, a loader finishes early, uses a stale layout, drops a key, or writes the wrong destination | Transaction entry-point guard, completion/source manifests, `LoadReceipt`, collision audit, and distributed sentinels | Manifest and receipt checks implemented; universal entry-point guard and sentinels pending |
+| 4. State preservation | State without a checkpoint key survives or is rebuilt, and consumers do not retain an old weight generation | Non-persistent buffers, aliases, config-dependent state, or caches become stale | Keyless-state, config-context, idempotency, and cache-generation checks | Partially implemented |
 
 These invariants do not share one mechanism. They share one **decision point**: immediately before the engine resumes inference. A weight update is correct only if every applicable invariant is proven at that point.
 
@@ -39,7 +36,7 @@ The following table maps every numbered issue listed by RFC #48312 under categor
 | 1. Storage identity | [#48539](https://github.com/vllm-project/vllm/issues/48539) | Machete act-order permutation storage is recreated on every post-load pass | C1 `StorageIdentityChecker` |
 | 1. Storage identity | [RFC #48478](https://github.com/vllm-project/vllm/issues/48478) | Defines the production fail-closed graph-storage contract for category 1 | C1 production registration/verification boundary |
 | 2. Runtime value refresh | [#48251](https://github.com/vllm-project/vllm/issues/48251) | A BF16/FP16 checkpoint sink changes while its FP32 runtime copy remains stale | C2 `DerivedValueRefreshChecker` |
-| 3. Loader lifecycle | [#42821](https://github.com/vllm-project/vllm/issues/42821), fix [#42823](https://github.com/vllm-project/vllm/pull/42823) | A loader survives layout conversion and corrupts the second `model.load_weights` call | C3a `LoaderEpochChecker` and transaction entry-point wrapping |
+| 3. Loader lifecycle | [#42821](https://github.com/vllm-project/vllm/issues/42821), proposed fix [#42823](https://github.com/vllm-project/vllm/pull/42823) | A direct post-init `model.load_weights` call bypasses restore/load/PWAL/copy-back and writes checkpoint-format bytes into kernel-layout storage | C3a `ReloadEntryPointChecker` and the transaction protocol |
 | 3. Loader lifecycle | [#44814](https://github.com/vllm-project/vllm/pull/44814) | A composed loader double-counts copied elements and finalizes Mamba2 before `mixer.D` arrives | C3b `CompletionManifestChecker` |
 | 3. Loader lifecycle | [#37334](https://github.com/vllm-project/vllm/issues/37334), [#38746](https://github.com/vllm-project/vllm/issues/38746) | Skipped/shared tensors make numel completion finish too early or never finish | C3b `CompletionManifestChecker` |
 | 4. Reload state preservation | [#42481](https://github.com/vllm-project/vllm/issues/42481) | Parent/child parameter-buffer aliasing is not preserved during copy-back | C4a `KeylessStateChecker` |
@@ -48,7 +45,7 @@ The following table maps every numbered issue listed by RFC #48312 under categor
 | 4. Reload state preservation | [#45989](https://github.com/vllm-project/vllm/issues/45989) | Reload rebuilds MoE with a missing or incorrect active `VllmConfig` | C4b `ConfigContextChecker` |
 | 4. Reload state preservation | [#48284](https://github.com/vllm-project/vllm/issues/48284) | Identity reload changes unquantized hybrid/Mamba state and output | C4c `IdempotencyChecker` |
 | 4. Reload state preservation | [#40647](https://github.com/vllm-project/vllm/issues/40647) | Historical umbrella for config-context, alias, and unloaded-state failures | C4a plus C4b; tracked by the more specific issues above |
-| 4. Reload state preservation | [#45835](https://github.com/vllm-project/vllm/pull/45835) | Partial FP8 updates need an explicit preserve-or-reject policy for omitted scales | C4a state policy plus C3b/C6 exact key accounting |
+| 4. Reload state preservation | [#45835](https://github.com/vllm-project/vllm/pull/45835) | Partial FP8 updates need an explicit preserve-or-reject policy for omitted scales | C4a state policy plus C3b exact key accounting |
 
 The transaction model is therefore:
 
@@ -104,7 +101,18 @@ Current limitation: updates modify the live model in place. ABORT means “rejec
 
 **Mechanism.** A layer-owned `ReloadArena` owns stable buffers. Backends refresh values with `put()` rather than rebinding tensors. Reload snapshots arena slots before restoring checkpoint layout and verifies them after PWAL.
 
-**Status: Implemented.** Arena integration, per-layer verification, module-level storage manifests, and registry/dataflow CI sweeps are present. Coverage still depends on discovering every graph-visible tensor.
+**Status: Partially implemented.** Arena integration, per-layer verification, module-level storage manifests, and registry/dataflow CI sweeps are present. `StorageIdentityChecker` is not complete because the runtime gate only has authoritative coverage for registered storage, while the edge conditions below are not universally covered.
+
+#### Pointer-drift coverage boundaries — Remain to be done
+
+The existing runtime gate is strict for storage already registered in a `ReloadArena`, and the current CI sweeps compare pointers across repeated PWAL/rebuild passes for covered backends. This is not yet a universal first-load -> real reload pointer oracle. The following boundaries remain open and are part of C1:
+
+1. **Storage that bypasses the arena.** A backend can bind a fresh tensor to an ordinary layer/kernel attribute without modifying any registered arena slot. Runtime arena verification cannot see that rebind. CI currently discovers many such tensors by inspecting attributes, containers, partials, and closures, but discovery is heuristic. A new network structure or allocation pattern can remain invisible unless it is registered or the census is extended.
+2. **Lazy storage created on first forward.** Repeating `process_weights_after_loading` does not cover tensors allocated only when a kernel first executes. CI must run the relevant forward path before taking the baseline, perform reload, execute the path again, and compare every graph-visible address. The existing lazy-storage tests cover selected backends, not the complete backend/model matrix.
+3. **A precise definition of which pointers must remain stable.** Comparing every `named_parameter` and buffer is incorrect because checkpoint-format parameters may legitimately be restored, materialized, or copied back during reload. The universal oracle must distinguish replaceable checkpoint storage from CUDA-Graph-visible or long-lived runtime storage, otherwise it will either miss escaped tensors or report legitimate pointer changes.
+4. **End-to-end stale-read validation.** Pointer equality alone proves address stability, not that the stable allocation contains values derived from the new weights. CI still needs a generalized test lane that captures with weight generation A, reloads distinct values B, creates allocation pressure, replays the captured graph, and verifies B-derived output. Existing backend-specific reproductions are evidence, but they are not a universal CI gate.
+
+Completion criteria for this item are: automatic registration or sound discovery of graph-visible storage, coverage of first-forward allocation, an explicit pointer-stability policy, and a continuous real-model/backend reload matrix. Until then, adding a new architecture or backend requires an explicit storage-coverage review even if the generic CI sweeps pass.
 
 ### C2 — DerivedValueRefreshChecker
 
@@ -116,17 +124,43 @@ Current limitation: updates modify the live model in place. ABORT means “rejec
 
 **Status: Partially implemented.** Arena `put()` covers migrated backends, but there is no general refresh-generation checker.
 
-### C3a — LoaderEpochChecker
+### C3a — ReloadEntryPointChecker
 
-**Problem.** A `weight_loader` created for checkpoint layout can survive a layout conversion and later write checkpoint-format bytes into kernel-format storage. The call succeeds, but the destination interpretation is stale.
+**Problem.** After first load, PWAL may convert parameters from checkpoint layout to kernel layout while preserving their `weight_loader`. A caller that invokes `model.load_weights` directly bypasses the reload lifecycle and writes checkpoint-format bytes into kernel-layout storage. This is the root cause of #42821; it is not primarily a stale-loader-epoch problem.
 
-**Invariant.** A loader executes only against the layout epoch for which it was created, or the reload pipeline restores the expected layout before invoking it.
+**Invariant.** Every post-initialization weight mutation, including direct `model.load_weights`, executes inside exactly one reload transaction: restore checkpoint layout, load, run PWAL/finalization, copy results back into stable runtime storage, validate all applicable C1-C4 evidence, and only then commit/resume.
 
-**Mechanism.** Layout conversions should advance an epoch; loaders should carry the epoch they expect. The transaction verifies that no stale loader executed. Wrapping `model.load_weights` is complementary because it routes external calls through the restore/load/PWAL lifecycle.
+**Mechanism.** PR #42823 proposes wrapping `model.load_weights` after initial model loading so subsequent direct calls run `initialize_layerwise_reload -> original_load_weights -> finalize_layerwise_reload`. That closes the specific bypass and should be integrated as an adapter into `ReloadTransaction`, rather than making the two layerwise functions the public transaction protocol. A layout epoch may still be useful as defense in depth, but it does not establish completeness, storage validation, all-rank commit, cache invalidation, or abort semantics.
 
-**Status: To be implemented.** The current layerwise path reduces exposure, but there is no explicit epoch contract.
+**Status: To be implemented as a transaction entry-point contract.** The current worker and transfer paths call the layerwise functions explicitly, but raw post-init `model.load_weights` is not universally enrolled in a transaction. PR #42823 is the concrete proposed adapter for that entry point.
 
-### C3b/C6 — CompletionManifestChecker
+#### Why `initialize_layerwise_reload` and `finalize_layerwise_reload` are not the whole protocol
+
+Those functions should remain the **layer-format restore/finalize hooks** used by a transaction, not absorb every reload responsibility. Putting all logic into them would create several problems:
+
+- they do not own request draining, dirty-state tracking, transaction ID/generation, or model-role scope;
+- they cannot independently reconcile source manifests or collect all-rank results;
+- `finalize_layerwise_reload` runs PWAL and copy-back, but transaction validation and COMMIT must happen after it;
+- nested callers (`reload_weights` calling a wrapped `model.load_weights`) need one reentrant transaction owner, not two independently initialized lifecycles;
+- loader exceptions require ABORT cleanup and must not accidentally turn a partial load into a successful FINALIZE/COMMIT;
+- direct mutation paths that do not call `model.load_weights` still need to join the same protocol.
+
+The intended layering is therefore:
+
+```text
+public mutation entry point / model.load_weights adapter
+  -> ReloadTransaction.begin()              # scope, generation, baselines
+  -> initialize_layerwise_reload()          # restore loadable layer layout
+  -> APPLY callback                         # original load_weights/transfer
+  -> finalize_layerwise_reload()            # PWAL + stable copy-back
+  -> ReloadTransaction.validate()            # C1-C4, rank-local report
+  -> controller all-rank decision
+  -> commit() or abort()
+```
+
+The adapter around `model.load_weights` should enter this protocol only after first-load initialization, preserve the original return value, and use a transaction-depth guard. If it is already inside the same transaction, it should execute only the APPLY callback. On an exception it should run explicit layerwise cleanup/abort logic; using an unconditional `finally: finalize_layerwise_reload(...)` is acceptable only if finalization is defined as cleanup-safe and the transaction is irrevocably marked failed before any commit decision.
+
+### C3b — CompletionManifestChecker
 
 **Problem.** Numel counting cannot represent logical loading. A composed loader may execute two `copy_` calls for one source, Q/K/V may share one Parameter, MoE experts may be rank-local, and a missing source contributes zero calls. These cases can cause premature completion or silent omissions.
 
@@ -142,7 +176,7 @@ Reload records `received_keys`; layer completion is driven by `required_keys <= 
 
 **Status: Implemented for covered paths.** `load_numel/load_numel_total` have been removed as completion state. Checkpoint loaders, IPC/NCCL transfer hooks, and several external/direct loaders publish manifests. Sparse direct mutation still needs a standard hook.
 
-### C3c/C5/C6 — LoadReceiptIdentityChecker
+### C3c — LoadReceiptIdentityChecker
 
 **Problem.** A manifest can still be wrong if its receipt identity is incomplete. For example, Q, K, and V can collapse to one packed target, or multiple MoE experts/shards can collapse to one event. If the first load and reload both make the same mistake, ordinary set equality passes.
 
@@ -166,6 +200,16 @@ Reload records `received_keys`; layer completion is driven by `required_keys <= 
 - `RECEIPT_SCHEMA_MISMATCH`.
 
 **Status: Implemented.** QKV, merged-column, RoutedExperts, composed loaders, legacy adaptation, negative collision tests, and real Qwen MoE validation are present. New loaders still need deliberate schema review.
+
+### C3d — ShardRoutingChecker
+
+**Problem.** A loader may consume every expected key yet ignore `tp_rank`, map an expert to the wrong EP rank, or write a correct shard into the wrong destination. Completeness alone cannot prove placement.
+
+**Invariant.** Rank-distinct and shard-distinct values land in the expected rank-local target fragment.
+
+**Mechanism.** A distributed test lane injects sentinel values and verifies placement on every TP/EP rank. Runtime receipts provide the fragment identity but do not prove the tensor bytes landed there.
+
+**Status: To be implemented.** Rank-local receipt scopes and TP/EP model tests exist; generalized sentinel verification does not.
 
 ### C4a — KeylessStateChecker
 
@@ -197,17 +241,7 @@ Reload records `received_keys`; layer completion is driven by `required_keys <= 
 
 **Status: To be implemented as a common checker.** Individual smoke tests provide partial evidence.
 
-### C5 — ShardRoutingChecker
-
-**Problem.** A loader may consume every expected key yet ignore `tp_rank`, map an expert to the wrong EP rank, or write a correct shard into the wrong destination. Completeness alone cannot prove placement.
-
-**Invariant.** Rank-distinct and shard-distinct values land in the expected rank-local target fragment.
-
-**Mechanism.** A distributed test lane injects sentinel values and verifies placement on every TP/EP rank. Runtime receipts provide the fragment identity but do not prove the tensor bytes landed there.
-
-**Status: To be implemented.** Rank-local receipt scopes and TP/EP model tests exist; generalized sentinel verification does not.
-
-### C7 — CacheGenerationChecker
+### C4d — CacheGenerationChecker
 
 **Problem.** Prefix KV, LoRA, multimodal, or backend-specific caches can serve generation-N state after weights advance to generation N+1.
 
@@ -245,7 +279,7 @@ flowchart TD
 
 For dummy or first online-quantization loads, no exact source baseline exists. The model records rank-local `required_target_keys`, buffers the first real update until the source stream ends, verifies that all targets were touched, and promotes that update's exact events to permanent `required_keys`. Chunked IPC/NCCL transfers also require an independently declared source manifest so a source that never arrived can be detected.
 
-This implementation answers the category-3/6 completeness problem. It does not replace storage, state, routing, or cache checkers.
+This implementation answers the category-3 completeness problem. It does not replace storage, state, routing, or cache checkers.
 
 ## 5. Report and commit policy
 
@@ -388,7 +422,7 @@ Relevant logs are in the reproduction workspace under `logs/loaders/`, including
 1. Define the unified report/finding model and wire existing completion, collision, and arena evidence into one gate without changing behavior.
 2. Add the all-rank commit barrier and timeout at the resume boundary.
 3. Add transaction hooks for sparse/direct updates and arbitrary framework entry points.
-4. Implement loader epoch and keyless-state checks.
+4. Integrate the post-init `model.load_weights` adapter into the transaction protocol, define exception-safe layerwise abort cleanup, and implement keyless-state checks.
 5. Define target, draft, and MTP scopes plus weight generation.
 6. Add cache-generation invalidation and distributed shard sentinels.
 7. Choose shadow-model or undo-log rollback.

--- a/docs/design/TRANSACTION.md
+++ b/docs/design/TRANSACTION.md
@@ -130,13 +130,19 @@ Completion criteria for this item are: automatic registration or sound discovery
 
 **Invariant.** Every post-initialization weight mutation, including direct `model.load_weights`, executes inside exactly one reload transaction: restore checkpoint layout, load, run PWAL/finalization, copy results back into stable runtime storage, validate all applicable C1-C4 evidence, and only then commit/resume.
 
-**Mechanism.** PR #42823 proposes wrapping `model.load_weights` after initial model loading so subsequent direct calls run `initialize_layerwise_reload -> original_load_weights -> finalize_layerwise_reload`. That closes the specific bypass and should be integrated as an adapter into `ReloadTransaction`, rather than making the two layerwise functions the public transaction protocol. A layout epoch may still be useful as defense in depth, but it does not establish completeness, storage validation, all-rank commit, cache invalidation, or abort semantics.
+**Mechanism.** PR #42823 proposes wrapping `model.load_weights` after initial model loading so subsequent direct calls run `initialize_layerwise_reload -> original_load_weights -> finalize_layerwise_reload`. That closes the specific bypass. How these functions relate to the eventual `ReloadTransaction` protocol is intentionally left open below. A layout epoch may still be useful as defense in depth, but by itself it does not establish completeness, storage validation, all-rank commit, cache invalidation, or abort semantics.
 
 **Status: To be implemented as a transaction entry-point contract.** The current worker and transfer paths call the layerwise functions explicitly, but raw post-init `model.load_weights` is not universally enrolled in a transaction. PR #42823 is the concrete proposed adapter for that entry point.
 
-#### Why `initialize_layerwise_reload` and `finalize_layerwise_reload` are not the whole protocol
+#### Protocol design question: should `initialize_layerwise_reload` and `finalize_layerwise_reload` become the complete protocol?
 
-Those functions should remain the **layer-format restore/finalize hooks** used by a transaction, not absorb every reload responsibility. Putting all logic into them would create several problems:
+This is **TBD** and should be resolved through design discussion. There are two plausible designs.
+
+**Option A: extend the existing pair into the public transaction boundary.** `initialize_layerwise_reload` would perform transaction BEGIN in addition to restoring loadable layout, and `finalize_layerwise_reload` would perform PWAL, validation, all-rank decision, COMMIT/ABORT, and cleanup. This minimizes the number of APIs and makes PR #42823's wrapper close to the final shape. It may be appropriate if every update entry point can reliably call the pair, both functions receive a transaction/controller context, and `finalize` has explicit success-versus-failure semantics.
+
+**Option B: keep the pair as layer-format hooks under a separate `ReloadTransaction`.** The transaction owns scope, nesting, reports, distributed commit, and abort; it calls the existing pair only for checkpoint-layout restore and PWAL/copy-back. This preserves their current narrow responsibility and lets direct mutation paths participate even when they do not need layerwise restore.
+
+The decision cannot be made only from the current names or implementation. The complete protocol must account for:
 
 - they do not own request draining, dirty-state tracking, transaction ID/generation, or model-role scope;
 - they cannot independently reconcile source manifests or collect all-rank results;
@@ -145,7 +151,7 @@ Those functions should remain the **layer-format restore/finalize hooks** used b
 - loader exceptions require ABORT cleanup and must not accidentally turn a partial load into a successful FINALIZE/COMMIT;
 - direct mutation paths that do not call `model.load_weights` still need to join the same protocol.
 
-The intended layering is therefore:
+Under Option B, the layering would be:
 
 ```text
 public mutation entry point / model.load_weights adapter
@@ -158,7 +164,19 @@ public mutation entry point / model.load_weights adapter
   -> commit() or abort()
 ```
 
-The adapter around `model.load_weights` should enter this protocol only after first-load initialization, preserve the original return value, and use a transaction-depth guard. If it is already inside the same transaction, it should execute only the APPLY callback. On an exception it should run explicit layerwise cleanup/abort logic; using an unconditional `finally: finalize_layerwise_reload(...)` is acceptable only if finalization is defined as cleanup-safe and the transaction is irrevocably marked failed before any commit decision.
+Under Option A, the same responsibilities must be represented by the initialize/finalize pair rather than omitted; in particular, `finalize_layerwise_reload` would need enough context to distinguish successful APPLY from an exception and to participate in the global decision.
+
+Whichever option is chosen, the `model.load_weights` adapter should activate only after first-load initialization, preserve the original return value, and use a transaction-depth guard. If it is already inside the same transaction, it should execute only the APPLY callback. On an exception it needs explicit cleanup/abort semantics. An unconditional `finally: finalize_layerwise_reload(...)` is safe only if `finalize` accepts the failed outcome, performs cleanup without treating a partial load as valid, and irrevocably prevents COMMIT.
+
+The design should choose between A and B after answering these review questions:
+
+1. Can every checkpoint, IPC/NCCL, sparse/direct, and framework-RPC update be represented by the same initialize/finalize pair?
+2. Should worker/controller responsibilities such as request draining and all-rank commit live in model-loader code?
+3. What object carries transaction ID, generation, model role, source manifest, and rank-local findings between initialize and finalize?
+4. How does finalize distinguish success, partial load, loader exception, validation failure, and global timeout?
+5. Can nested calls be proven to produce exactly one BEGIN, one validation, and one COMMIT/ABORT?
+
+Until these questions are answered, neither option is the implementation contract.
 
 ### C3b — CompletionManifestChecker
 
@@ -172,7 +190,7 @@ The adapter around `model.load_weights` should enter this protocol only after fi
 source_key => target_parameter[logical_fragment]
 ```
 
-Reload records `received_keys`; layer completion is driven by `required_keys <= received_keys`, not copied numel. Dummy initialization first establishes a provisional target baseline and promotes the first complete real update to an exact event baseline.
+Reload records `received_keys`; layer completion is driven by `required_keys <= received_keys`, not copied numel. Dummy initialization uses the metadata-only probe in Section 4.1 when a local safetensors schema exists; otherwise it establishes a provisional target baseline and promotes the first complete real update to an exact event baseline.
 
 **Status: Implemented for covered paths.** `load_numel/load_numel_total` have been removed as completion state. Checkpoint loaders, IPC/NCCL transfer hooks, and several external/direct loaders publish manifests. Sparse direct mutation still needs a standard hook.
 
@@ -277,9 +295,85 @@ flowchart TD
     K --> L
 ```
 
-For dummy or first online-quantization loads, no exact source baseline exists. The model records rank-local `required_target_keys`, buffers the first real update until the source stream ends, verifies that all targets were touched, and promotes that update's exact events to permanent `required_keys`. Chunked IPC/NCCL transfers also require an independently declared source manifest so a source that never arrived can be detected.
+### 4.1 Metadata-only baseline for `DummyModelLoader`
+
+**Status: Implemented for local safetensors models.** A dummy-loaded model no longer has to learn its first exact event baseline from the first real transfer when the checkpoint schema is locally available. `DummyModelLoader` reads only safetensors headers, creates one meta tensor per source, and runs the model's real `load_weights` method under `LoadProbeMode`, a `TorchDispatchMode` that suppresses mutable tensor operators. The same model-specific name mapping, QKV/merged routing, MoE expert routing, composed loaders, and `LoadReceipt` wrappers therefore execute without reading checkpoint payloads or copying weight data.
+
+```text
+local safetensors headers
+  -> (source name, shape, dtype) meta tensors
+  -> real model.load_weights
+  -> real weight_loader dispatch and LoadReceipt
+  -> TorchDispatchMode intercepts copy_/index_copy_/other schema writes
+  -> exact rank-local required event manifest
+  -> ordinary dummy PWAL and warmup
+```
+
+The probe is architecture-generic because it does not predict mappings from the model structure; it executes each architecture's actual `load_weights`. Coverage is fail closed:
+
+- every intercepted write is associated with the active source key;
+- every source that writes must produce a `LoadReceipt` event;
+- mutable operators are detected from dispatcher schema alias annotations, not a `copy_` allowlist;
+- factories and source-derived materialization stay on the meta device;
+- unsupported/data-dependent operators raise instead of inventing a default event;
+- Python-side model bindings are restored after the probe, and parameter/buffer/module rebinding is rejected.
+
+This gate found two unobserved GPT-OSS attention-sink writes during validation. Those paths now call the parameter's `weight_loader` instead of copying directly, so they participate in the same receipt protocol.
+
+The following H200 model matrix completed automatic dummy probing, a subsequent real checkpoint reload, exact required/received reconciliation, and inference:
+
+| Model/structure | Probe result | Real reload result |
+|---|---:|---:|
+| Qwen3-0.6B, packed attention QKV | 310 events | 310/310 |
+| Qwen3-30B-A3B 2-layer MoE | 789 events | 789/789 |
+| Qwen3-30B-A3B 2-layer MoE, TP=2 | 789 events per rank | 789/789 per rank |
+| DeepSeek-V3 reduced MoE/MLA | 785 events | 785/785 |
+| GPT-OSS 20B 2-layer MXFP4/MoE | 41 events | 41/41 |
+| TinyLlama GPTQ act-order | 663 events | 663/663 |
+| Qwen3 MoE W4A8 | 2,341 events | 2,341/2,341 |
+
+Unit tests additionally pin ordinary, routed-fragment, composed/double-write, factory-allocation, data-dependent failure, direct-write-without-receipt, metadata-reader, provisional-fallback, and exception-restoration behavior.
+
+If the dummy model does not have a local safetensors schema (for example, an unresolved remote model ID or another checkpoint format), the existing provisional `required_target_keys` path remains active. The first real update must then carry an independently declared source manifest, is buffered until the source stream ends, and promotes its exact observed events only after target/source reconciliation succeeds. First-load online quantization also retains this provisional path where the checkpoint-layout probe cannot run before layer processing.
 
 This implementation answers the category-3 completeness problem. It does not replace storage, state, routing, or cache checkers.
+
+### 4.2 Layerwise staging, PWAL, receipts, and arena storage
+
+The reload path operates on three distinct kinds of storage. They must not be conflated:
+
+1. **Temporary checkpoint/runtime tensors.** `initialize_layerwise_reload` saves the serving tensors in `info.kernel_tensors`, restores the layer's checkpoint-format metadata on the meta device, and `materialize_layer` allocates temporary tensors. Buffered `weight_loader` calls write the new checkpoint values into these temporary tensors.
+2. **Original serving parameter/buffer storage.** CUDA graphs or kernels may retain these addresses. After PWAL converts the temporary tensors into runtime layout, `_copy_and_restore_kernel_tensors` copies their values into the original storage and rebinds the layer to the original objects.
+3. **ReloadArena slots.** These are neither parameters nor buffers and are not handled by `_copy_and_restore_kernel_tensors`. PWAL or a later forward updates/reacquires them through the arena API.
+
+The resulting non-attention lifecycle is:
+
+```text
+save original runtime parameter/buffer storage
+  -> restore checkpoint-layout metadata on meta
+  -> materialize temporary tensors
+  -> replay buffered weight_loader calls into the temporary tensors
+  -> quant_method.process_weights_after_loading(layer)
+  -> PWAL updates/reacquires ReloadArena slots
+  -> copy processed temporary parameters/buffers into original storage
+  -> rebind the layer to the original serving objects
+  -> verify registered arena slot identity
+```
+
+Calling both `param.weight_loader(...)` and `_copy_and_restore_kernel_tensors(...)` is necessary. The loader understands checkpoint layout and must not write directly into storage that may already have a transformed kernel layout. The copy-back occurs only after PWAL has produced the new runtime layout, and publishes that result at the old graph-visible addresses. On first load `info.kernel_tensors` is `None`, so there is no old serving storage to restore and copy-back is a no-op.
+
+Attention and MLA layers are deferred. `_finalize_attention_layer` reloads their scales and calls `layer.process_weights_after_loading(model_config.dtype)` after the other layers have completed. MLA updates derived `W_UV` and `W_UK_T` slots from this path. Ordinary quantized linear and MoE layers enter PWAL through `quant_method.process_weights_after_loading(layer)`.
+
+The arena has two acquisition forms:
+
+- `arena.put(name, value)` publishes an already computed derived value. The first call adopts a private contiguous copy; later calls perform `existing.copy_(value)`. The caller must bind and expose the returned stable tensor.
+- `arena.get_or_alloc(name, shape, dtype, device, init=...)` returns stable workspace or scratch storage whose contents will be produced later by the caller or kernel. Reacquisition returns the same tensor; `ZERO` clears it when reacquired, while `EMPTY`/`PRESERVE` keep the existing contents.
+
+`_verify_layer_arena` is a registered-slot contract assertion, not a complete storage oracle. At reload initialization it snapshots the identity and specification of slots already present in the layer's arena; after PWAL it reports slots that vanished, moved, or changed layout. The public arena APIs already make such drift unlikely by returning existing storage or copying in place, so this check primarily catches arena replacement, direct `_slots` mutation, or a regression in the arena implementation. It cannot prove that every graph-visible tensor was registered, that a backend bound the consumer to the tensor returned by the arena, that newly created slots were captured, or that a stable slot received generation-N+1 values.
+
+`online_process_loader` calls `_wrap_parameters_weight_loader(layer)` on both sides of the original loader invocation. The pre-call scan catches parameters registered or replaced between source events. The post-call scan catches parameters dynamically created or replaced by the current loader and extends the provisional target manifest before completion is evaluated. Wrapping is idempotent, so ordinary static layers only pay a repeated scan and do not accumulate wrapper layers.
+
+Each loader invocation also produces a `LoadReceipt`. `_audit_load_receipt` is intentionally a stateful observer with no return value: it adds the invocation to the layer's `LoadEventAudit`, which compares multiple calls over the whole load. The audit detects event-key collisions, consumed-status conflicts, unique-target alias collisions, declared receipt-schema mismatch, and schema drift. A single first event cannot reveal most of these failures; findings are therefore drained at initial-load or reload finalization. To provide strict transaction semantics, those accumulated findings must be checked before per-layer publish and included in the all-rank commit decision.
 
 ## 5. Report and commit policy
 
@@ -411,6 +505,8 @@ Relevant logs are in the reproduction workspace under `logs/loaders/`, including
 | Source context | `vllm/model_executor/model_loader/reload/source.py` |
 | Manifest lifecycle | `vllm/model_executor/model_loader/reload/layerwise.py` |
 | Collision audit | `vllm/model_executor/model_loader/reload/audit.py` |
+| Metadata-only dummy probe | `vllm/model_executor/model_loader/reload/probe.py` |
+| Automatic dummy baseline | `vllm/model_executor/model_loader/dummy_loader.py` |
 | Scope and report types | `vllm/model_executor/model_loader/reload/types.py` |
 | Transfer source manifest | `vllm/distributed/weight_transfer/base.py` |
 | QKV/merged receipts | `vllm/model_executor/layers/linear.py` |

--- a/docs/design/TRANSACTION.md
+++ b/docs/design/TRANSACTION.md
@@ -1,6 +1,6 @@
 # Reload as a Transaction — the Top-Down Design for #48312
 
-Status: **partially implemented**. This document defines what a correct weight update must guarantee, which failure category each mechanism addresses, and where the remaining gaps are. It intentionally describes the correctness contract before the implementation. Detailed manifest and receipt internals belong in `LOAD_MANIFEST_DESIGN.md`.
+Status: **partially implemented**. This document is the transaction design for [RFC #48312: Weight Reload Correctness for RL](https://github.com/vllm-project/vllm/issues/48312). It defines what a correct weight update must guarantee, which RFC failure category each mechanism addresses, and where the remaining gaps are. It intentionally describes the correctness contract before the implementation. Detailed manifest and receipt internals belong in `LOAD_MANIFEST_DESIGN.md`.
 
 Status labels used below:
 
@@ -24,6 +24,31 @@ The reload investigation found several independent classes of failure. Stable st
 | 7. Cache coherence | Consumers do not use state from an old weight generation | Prefix, LoRA, or multimodal cache survives an update | Generation-aware cache invalidation | To be implemented |
 
 These invariants do not share one mechanism. They share one **decision point**: immediately before the engine resumes inference. A weight update is correct only if every applicable invariant is proven at that point.
+
+### 1.1 RFC categories 1–4 and their tracked issues
+
+The following table maps every numbered issue listed by RFC #48312 under categories 1–4 to the checker or policy in this document. Cross-category issues intentionally appear more than once when one fix cannot prove both invariants.
+
+| RFC category | Tracked issue | Failure represented in this design | Transaction section |
+|---|---|---|---|
+| 1. Storage identity | [#48251](https://github.com/vllm-project/vllm/issues/48251) | Generic MLA post-load tensors are rebound after graph capture | C1 `StorageIdentityChecker`; its stale attention-sink copy also maps to C2 |
+| 1. Storage identity | [#40390](https://github.com/vllm-project/vllm/issues/40390) | ROCm AITER unquantized-MoE shuffle replaces graph-visible runtime parameters | C1 `StorageIdentityChecker` |
+| 1. Storage identity | [#46009](https://github.com/vllm-project/vllm/issues/46009) | ROCm unquantized-MoE padding replaces parameter storage through `.data` | C1 `StorageIdentityChecker` |
+| 1. Storage identity | [#41670](https://github.com/vllm-project/vllm/issues/41670) | Rebuilding CUTLASS grouped-GEMM FP8 experts replaces stride and staged-scale storage | C1 `StorageIdentityChecker`, with C2 refresh implications |
+| 1. Storage identity | [#48438](https://github.com/vllm-project/vllm/issues/48438) | Marlin workspace and act-order sort-index storage are rebound | C1 `StorageIdentityChecker` |
+| 1. Storage identity | [#48539](https://github.com/vllm-project/vllm/issues/48539) | Machete act-order permutation storage is recreated on every post-load pass | C1 `StorageIdentityChecker` |
+| 1. Storage identity | [RFC #48478](https://github.com/vllm-project/vllm/issues/48478) | Defines the production fail-closed graph-storage contract for category 1 | C1 production registration/verification boundary |
+| 2. Runtime value refresh | [#48251](https://github.com/vllm-project/vllm/issues/48251) | A BF16/FP16 checkpoint sink changes while its FP32 runtime copy remains stale | C2 `DerivedValueRefreshChecker` |
+| 3. Loader lifecycle | [#42821](https://github.com/vllm-project/vllm/issues/42821), fix [#42823](https://github.com/vllm-project/vllm/pull/42823) | A loader survives layout conversion and corrupts the second `model.load_weights` call | C3a `LoaderEpochChecker` and transaction entry-point wrapping |
+| 3. Loader lifecycle | [#44814](https://github.com/vllm-project/vllm/pull/44814) | A composed loader double-counts copied elements and finalizes Mamba2 before `mixer.D` arrives | C3b `CompletionManifestChecker` |
+| 3. Loader lifecycle | [#37334](https://github.com/vllm-project/vllm/issues/37334), [#38746](https://github.com/vllm-project/vllm/issues/38746) | Skipped/shared tensors make numel completion finish too early or never finish | C3b `CompletionManifestChecker` |
+| 4. Reload state preservation | [#42481](https://github.com/vllm-project/vllm/issues/42481) | Parent/child parameter-buffer aliasing is not preserved during copy-back | C4a `KeylessStateChecker` |
+| 4. Reload state preservation | [#44371](https://github.com/vllm-project/vllm/issues/44371) | Unloaded non-persistent buffers are overwritten from materialized/meta state | C4a `KeylessStateChecker` |
+| 4. Reload state preservation | [#44613](https://github.com/vllm-project/vllm/issues/44613) | Backend rebuild depends on a global config value that was not snapshotted | C4b `ConfigContextChecker` |
+| 4. Reload state preservation | [#45989](https://github.com/vllm-project/vllm/issues/45989) | Reload rebuilds MoE with a missing or incorrect active `VllmConfig` | C4b `ConfigContextChecker` |
+| 4. Reload state preservation | [#48284](https://github.com/vllm-project/vllm/issues/48284) | Identity reload changes unquantized hybrid/Mamba state and output | C4c `IdempotencyChecker` |
+| 4. Reload state preservation | [#40647](https://github.com/vllm-project/vllm/issues/40647) | Historical umbrella for config-context, alias, and unloaded-state failures | C4a plus C4b; tracked by the more specific issues above |
+| 4. Reload state preservation | [#45835](https://github.com/vllm-project/vllm/pull/45835) | Partial FP8 updates need an explicit preserve-or-reject policy for omitted scales | C4a state policy plus C3b/C6 exact key accounting |
 
 The transaction model is therefore:
 

--- a/docs/design/TRANSACTION.md
+++ b/docs/design/TRANSACTION.md
@@ -190,7 +190,7 @@ Until these questions are answered, neither option is the implementation contrac
 source_key => target_parameter[logical_fragment]
 ```
 
-Reload records `received_keys`; layer completion is driven by `required_keys <= received_keys`, not copied numel. Dummy initialization uses the metadata-only probe in Section 4.1 when a local safetensors schema exists; otherwise it establishes a provisional target baseline and promotes the first complete real update to an exact event baseline.
+Reload records `received_keys`; layer completion is driven by `required_keys <= received_keys`, not copied numel. Dummy initialization can use the metadata-only probe in Section 4.1 when `model_loader_extra_config={"enable_load_probe": true}` is set; otherwise it establishes a provisional target baseline and promotes the first complete real update to an exact event baseline.
 
 **Status: Implemented for covered paths.** `load_numel/load_numel_total` have been removed as completion state. Checkpoint loaders, IPC/NCCL transfer hooks, and several external/direct loaders publish manifests. Sparse direct mutation still needs a standard hook.
 
@@ -297,7 +297,7 @@ flowchart TD
 
 ### 4.1 Metadata-only baseline for `DummyModelLoader`
 
-**Status: Implemented for local safetensors models.** A dummy-loaded model no longer has to learn its first exact event baseline from the first real transfer when the checkpoint schema is locally available. `DummyModelLoader` reads only safetensors headers, creates one meta tensor per source, and runs the model's real `load_weights` method under `LoadProbeMode`, a `TorchDispatchMode` that suppresses mutable tensor operators. The same model-specific name mapping, QKV/merged routing, MoE expert routing, composed loaders, and `LoadReceipt` wrappers therefore execute without reading checkpoint payloads or copying weight data.
+**Status: Implemented for safetensors models when explicitly enabled.** A dummy-loaded model no longer has to learn its first exact event baseline from the first real transfer when `model_loader_extra_config={"enable_load_probe": true}` is set and a safetensors checkpoint schema is available. `DummyModelLoader` resolves local paths, Hugging Face repo IDs, and ModelScope repo IDs through the same download/cache helpers used by ordinary loaders, reads only safetensors headers, creates one meta tensor per source, and runs the model's real `load_weights` method under `LoadProbeMode`, a `TorchDispatchMode` that suppresses mutable tensor operators. The same model-specific name mapping, QKV/merged routing, MoE expert routing, composed loaders, and `LoadReceipt` wrappers therefore execute without reading checkpoint payloads into tensors or copying weight data.
 
 ```text
 local safetensors headers
@@ -334,7 +334,7 @@ The following H200 model matrix completed automatic dummy probing, a subsequent 
 
 Unit tests additionally pin ordinary, routed-fragment, composed/double-write, factory-allocation, data-dependent failure, direct-write-without-receipt, metadata-reader, provisional-fallback, and exception-restoration behavior.
 
-If the dummy model does not have a local safetensors schema (for example, an unresolved remote model ID or another checkpoint format), the existing provisional `required_target_keys` path remains active. The first real update must then carry an independently declared source manifest, is buffered until the source stream ends, and promotes its exact observed events only after target/source reconciliation succeeds. First-load online quantization also retains this provisional path where the checkpoint-layout probe cannot run before layer processing.
+If dummy load probing is disabled or the dummy model does not have a safetensors schema, the existing provisional `required_target_keys` path remains active. The first real update must then carry an independently declared source manifest, is buffered until the source stream ends, and promotes its exact observed events only after target/source reconciliation succeeds. First-load online quantization also retains this provisional path where the checkpoint-layout probe cannot run before layer processing.
 
 This implementation answers the category-3 completeness problem. It does not replace storage, state, routing, or cache checkers.
 

--- a/docs/design/UPDATE_SCOPE.md
+++ b/docs/design/UPDATE_SCOPE.md
@@ -136,7 +136,7 @@ flowchart TD
     C -- No --> G[Require declared source manifest on first real update]
     G --> H[Receive complete real update]
     H --> I{Every provisional target consumed?}
-    I -- No --> X[Fail; baseline remains provisional]
+    I -- No --> X[Fail and keep baseline provisional]
     I -- Yes --> J[Promote observed receipts to exact baseline]
     J --> F
 ```
@@ -177,7 +177,7 @@ flowchart TD
     K --> L[Finalize affected layers and reconcile required events]
     L --> M[Build rank-local LoadManifestReport]
     M --> N{Local report clean?}
-    N -- No --> Y[Fail closed; do not resume]
+    N -- No --> Y[Fail closed and do not resume]
     N -- Yes --> O{Every worker reports success?}
     O -- No --> Y
     O -- Yes --> P[Commit generation and invalidate dependent caches]
@@ -253,7 +253,7 @@ flowchart TD
     G -- Yes --> H[Collect exact consumed events]
     H --> I[Require received sources equal declared sources]
     I --> J[Require received events equal resolved local events]
-    J --> K[Finalize selected units; preserve all others]
+    J --> K[Finalize selected units and preserve all others]
     K --> L[Return rank-local report]
 ```
 
@@ -308,7 +308,7 @@ sequenceDiagram
         C->>C: Invalidate prefix, MM, and encoder caches
     else any worker failed
         E->>W: abort_lora_update(adapter_id)
-        W->>W: Drop staged adapter; keep old adapter
+        W->>W: Drop staged adapter and keep old adapter
         E-->>C: Failure
     end
 ```
@@ -336,7 +336,7 @@ flowchart TD
     G --> H[Construct TensorLoRARequest]
     H --> I[Each worker builds and validates complete LoRAModel]
     I --> J{All workers prepared?}
-    J -- No --> K[Abort staged adapters; keep old adapter]
+    J -- No --> K[Abort staged adapters and keep old adapter]
     J -- Yes --> L[Commit replacement once]
     L --> M[Invalidate dependent caches]
 ```

--- a/docs/design/UPDATE_SCOPE.md
+++ b/docs/design/UPDATE_SCOPE.md
@@ -196,8 +196,9 @@ rank-local sources selected from the baseline.
 kind=base_checkpoint, mode=full
 kind=base_checkpoint, mode=partial, source_names=[...]
 kind=base_kernel, target_names=[...]
-kind=lora_adapter, operation=replace|remove,
-    adapter_id=..., adapter_name=..., tensor_names=[...],
+kind=lora_adapter, operation=replace|patch|remove,
+    adapter_id=..., adapter_name=..., base_generation=...,
+    module_names=[...], tensor_names=[...],
     config_digest=..., artifact_digest=...
 ```
 
@@ -351,15 +352,40 @@ fields are invalid. Removal has no receipt stream because no new adapter payload
 is consumed. The controller must remove the identified adapter on every worker
 and invalidate caches that may retain adapter-dependent results.
 
+### LoRA adapter partial patch
+
+A patch updates complete runtime LoRA modules while preserving every module
+outside the scope. The caller obtains `module_names` and `generation` from
+`GET /weight_update_manifest`, then declares the selected modules and matching
+`base_generation`. Packed QKV and MoE modules are atomic runtime modules; their
+internal fragments cannot be patched independently.
+
+```mermaid
+flowchart TD
+    A[Read adapter manifest and generation] --> B[Declare patch module_names]
+    B --> C[Validate adapter on every worker]
+    C --> D[Validate base_generation and global module union]
+    D --> E[Load patch payload without publishing]
+    E --> F[Pack payload into runtime LoRA modules]
+    F --> G[Require complete selected modules and A/B pairs]
+    G --> H[Clone current adapter metadata]
+    H --> I[Replace selected modules and preserve unselected modules]
+    I --> J{Every worker prepared the same generation?}
+    J -- No --> K[Abort candidates and keep current adapter]
+    J -- Yes --> L[Commit candidates and increment generation]
+    L --> M[Invalidate dependent caches]
+```
+
 ## Completion semantics by mode
 
 | Mode | Declaration | Completion rule | Out-of-scope input | Processing boundary |
-|---|---|---|---|---|
+| --- | --- | --- | --- | --- |
 | Full checkpoint | Omitted or `mode=full` | Initial local events are a subset of received events | Compatible extras may be accepted | All reloadable layers |
 | Partial checkpoint | Exact source names | Resolved local events equal received events | Reject | Whole layerwise units only |
 | Kernel format | Exact target names | Declared targets equal received targets | Reject | Individual runtime parameters |
 | LoRA path replace | Adapter identity and optional digests | Every worker stages one complete validated adapter | Reject identity/digest mismatch | Complete adapter |
 | LoRA tensor replace | Adapter identity, exact tensor names, config | Declared tensors equal accumulated tensors; every worker stages successfully | Reject unknown/duplicate tensors | Complete adapter |
+| LoRA partial patch | Adapter identity, generation, modules, payload | Every selected runtime module has complete A/B weights on every owning worker | Reject stale generation or undeclared modules | Selected complete runtime modules |
 | LoRA remove | Adapter identity | Adapter removed on every worker | No payload allowed | Complete adapter |
 
 ## Failure boundaries

--- a/docs/design/UPDATE_SCOPE.md
+++ b/docs/design/UPDATE_SCOPE.md
@@ -1,0 +1,165 @@
+# Weight Update Scope
+
+## Status
+
+This document defines the implementation plan for explicit weight-update
+scopes. It complements `TRANSACTION.md`; it does not move the existing arena
+verification points or claim to provide rollback.
+
+## Goals
+
+An update declares exactly which model state it is allowed to change. The
+declaration is also the completion contract:
+
+- omitted state outside the scope is preserved;
+- missing state inside the scope fails completion;
+- state received outside an explicit scope is rejected;
+- checkpoint-format partial updates never split a post-load processing unit;
+- a LoRA update replaces or removes one complete adapter while preserving the
+  base model.
+
+Transport chunks are not scopes. In particular, splitting a full checkpoint or
+adapter into IPC/NCCL buckets does not make each bucket a partial update.
+
+## Scope kinds
+
+### Full checkpoint weights
+
+The default and backward-compatible scope. Every source/target/fragment event
+observed during the initial real checkpoint load is required.
+
+### Partial checkpoint weights
+
+The caller declares exact checkpoint source names. Each worker resolves those
+names against its rank-local initial-load manifest. A selected source expands
+to every local target fragment it drove during the baseline load.
+
+Checkpoint restoration and `process_weights_after_loading` operate on whole
+modules. Therefore a partial checkpoint scope is accepted only when, for every
+module, it selects either no baseline events or all baseline events. Selecting
+only Q from a packed QKV layer, one quantization scale, or some experts from a
+post-load processing unit is rejected before layerwise mutation starts.
+
+Only selected modules are restored to meta, wrapped, replayed, and processed.
+
+### Kernel-format weights
+
+The caller declares exact target parameter names. These updates use in-place
+`copy_` and do not restore checkpoint layout or rerun post-load processing.
+Parameter-level subsets are therefore allowed, subject to exact name, shape,
+and dtype checks.
+
+### LoRA adapter
+
+A LoRA scope identifies one adapter and an operation (`replace` or `remove`).
+Replacement means a complete adapter replacement, not an incremental patch of
+the old adapter. The base model is outside the scope.
+
+Two payload forms are supported by the completion model:
+
+- path/artifact, as used by SkyRL;
+- an exact tensor manifest accumulated across transport buckets, as used by
+  VERL before constructing a tensor-backed LoRA request.
+
+The adapter is staged and validated before it is installed. Validation covers
+the declared tensor manifest, PEFT configuration identity, supported target
+modules, rank/shape compatibility, and A/B pairing. Expert-parallel workers may
+materialize different local subsets, but must agree on the global declaration.
+
+## Data model
+
+`UpdateScope` is a serializable tagged structure:
+
+```text
+kind=base_checkpoint, mode=full
+kind=base_checkpoint, mode=partial, source_names=[...]
+kind=base_kernel, target_names=[...]
+kind=lora_adapter, operation=replace|remove,
+    adapter_id=..., adapter_name=..., tensor_names=[...],
+    config_digest=..., artifact_digest=...
+```
+
+The scope is normalized at the API boundary. Duplicate names, invalid field
+combinations, empty explicit subsets, and inconsistent declarations fail
+before transfer or model mutation.
+
+Checkpoint event identity is structured as source, target, and fragment.
+Formatting it into a string is for diagnostics only; scope resolution must not
+parse the legacy display string.
+
+## Lifecycle
+
+```text
+declare scope
+  -> normalize and validate declaration
+  -> resolve rank-local effective manifest
+  -> validate checkpoint layer closure
+  -> initialize only affected state
+  -> receive chunks and reject out-of-scope names
+  -> replay/process affected layers or stage a complete adapter
+  -> reconcile expected == received for explicit scopes
+  -> produce a rank-local report
+  -> caller collects all reports and decides commit/abort
+```
+
+The existing arena verification remains in its current location. This work
+does not reorder verification relative to copy-back.
+
+## LoRA integration
+
+SkyRL path:
+
+```text
+LoRAAdapterScope(artifact declaration)
+  -> load a staged LoRAModel from the shared path
+  -> validate artifact/config/local tensors
+  -> install with the existing load-in-place adapter path
+```
+
+VERL tensor path:
+
+```text
+LoRAAdapterScope(exact tensor_names)
+  -> receive all buckets
+  -> require received_names == tensor_names
+  -> construct and validate the staged LoRAModel
+  -> replace the adapter once
+```
+
+If a dummy base model has not received its first complete real base update,
+adapter-only replacement is rejected.
+
+## Compatibility
+
+- Omitting a scope retains full checkpoint behavior.
+- Existing `expected_names` is accepted during migration, but when an explicit
+  scope also supplies source/tensor names the declarations must agree.
+- Exact completion is enabled for explicit scopes. Legacy full reload keeps
+  its current compatibility behavior until all loaders emit structured
+  receipts.
+
+## Implementation sequence
+
+1. Add scope types, normalization, structured event identities, and
+   scope-aware reports.
+2. Resolve checkpoint source subsets, enforce whole-layer closure, initialize
+   only affected layers, and reconcile the effective manifest.
+3. Add exact kernel-target completion.
+4. Add LoRA artifact/tensor manifests and staged adapter replacement.
+5. Return reports from workers and enforce the all-rank decision above the
+   worker; invalidate prefix, multimodal, and encoder caches after commit.
+
+## Required tests
+
+- legacy full reload remains unchanged;
+- one or multiple complete checkpoint layers can be selected;
+- a split QKV, quantized layer, or expert processing unit is rejected before
+  initialization;
+- unknown, missing, duplicate, and unexpected names fail;
+- PP no-op and TP/EP rank-local resolution are valid;
+- kernel target subsets require exact names, shapes, and dtypes;
+- path-backed and tensor-backed LoRA replacement succeed;
+- incomplete A/B pairs, manifest/config mismatch, and adapter update before a
+  real dummy-base sync fail without removing the old adapter;
+- multi-bucket LoRA installs exactly once after all tensors arrive;
+- cache invalidation and all-rank report enforcement occur before resume.

--- a/docs/design/UPDATE_SCOPE.md
+++ b/docs/design/UPDATE_SCOPE.md
@@ -1,74 +1,196 @@
-# Weight Update Scope
+# Load Receipts and Weight Update Scopes
 
-## Status
+## Status and purpose
 
-This document defines the implementation plan for explicit weight-update
-scopes. It complements `TRANSACTION.md`; it does not move the existing arena
-verification points or claim to provide rollback.
+This document describes the end-to-end completion protocol implemented by load
+receipts and explicit update scopes. It complements `TRANSACTION.md`: this
+document owns the identity, baseline, scope-resolution, receipt, and
+reconciliation flow, while `TRANSACTION.md` covers the wider reload transaction,
+including storage stability and the engine-level commit decision.
 
-## Goals
+The protocol answers four questions for every update:
 
-An update declares exactly which model state it is allowed to change. The
-declaration is also the completion contract:
+1. What state is the caller allowed to change?
+2. What logical load events must each worker observe?
+3. Did the transport deliver the declared sources and did loaders consume the
+   expected target fragments?
+4. Is the worker allowed to report success?
 
-- omitted state outside the scope is preserved;
-- missing state inside the scope fails completion;
-- state received outside an explicit scope is rejected;
-- checkpoint-format partial updates never split a post-load processing unit;
-- a LoRA update replaces or removes one complete adapter while preserving the
-  base model.
+It does not provide rollback for base-weight updates. A failed base update is
+rejected and serving must not resume with that worker's partially mutated model.
+LoRA replacement is different: it stages a complete adapter before replacing the
+live adapter.
 
-Transport chunks are not scopes. In particular, splitting a full checkpoint or
-adapter into IPC/NCCL buckets does not make each bucket a partial update.
+## Concepts
 
-## Scope kinds
+### Load receipt
 
-### Full checkpoint weights
+A `LoadReceipt` is the result of one logical `weight_loader` invocation:
 
-The default and backward-compatible scope. Every source/target/fragment event
-observed during the initial real checkpoint load is required.
+```text
+LoadReceipt(
+    consumed=True | False,
+    fragment=(loaded_shard_id=q, expert_id=7, ...),
+    collision_policy=unique | overwrite,
+)
+```
 
-### Partial checkpoint weights
+`consumed=False` means that the loader deliberately skipped the source, for
+example because an expert does not belong to the local EP rank. A skipped call
+does not enter the completion baseline.
 
-The caller declares exact checkpoint source names. Each worker resolves those
-names against its rank-local initial-load manifest. A selected source expands
-to every local target fragment it drove during the baseline load.
+The fragment identifies the logical part of a packed target. Examples include
+Q/K/V shards, merged-column indices, and `(shard_id, expert_id, weight_name)` for
+routed experts. A loader invocation is one logical event regardless of how many
+internal `copy_` operations it performs.
 
-Checkpoint restoration and `process_weights_after_loading` operate on whole
-modules. Therefore a partial checkpoint scope is accepted only when, for every
-module, it selects either no baseline events or all baseline events. Selecting
-only Q from a packed QKV layer, one quantization scale, or some experts from a
-post-load processing unit is rejected before layerwise mutation starts.
+Legacy loaders may still return `None` or `bool`; the compatibility adapter
+derives a receipt from known scalar loader arguments. New packed or conditional
+loaders should return a structured receipt deliberately.
 
-Only selected modules are restored to meta, wrapped, replayed, and processed.
+### Load event
 
-### Kernel-format weights
+A consumed receipt becomes a structured, rank-local `LoadEventIdentity`:
 
-The caller declares exact target parameter names. These updates use in-place
-`copy_` and do not restore checkpoint layout or rerun post-load processing.
-Parameter-level subsets are therefore allowed, subject to exact name, shape,
-and dtype checks.
+```text
+(canonical source name, target parameter name, logical fragment)
+```
 
-### LoRA adapter
+For example:
 
-A LoRA scope identifies one adapter and an operation (`replace` or `remove`).
-Replacement means a complete adapter replacement, not an incremental patch of
-the old adapter. The base model is outside the scope.
+```text
+model.layers.0.self_attn.q_proj.weight
+  => model.layers.0.self_attn.qkv_proj.weight[loaded_shard_id='q']
+```
 
-Two payload forms are supported by the completion model:
+Event identity is never reconstructed by parsing this display string. The
+source, target, and fragment remain separate structured fields.
 
-- path/artifact, as used by SkyRL;
-- an exact tensor manifest accumulated across transport buckets, as used by
-  VERL before constructing a tensor-backed LoRA request.
+### Baseline
 
-The adapter is staged and validated before it is installed. Validation covers
-the declared tensor manifest, PEFT configuration identity, supported target
-modules, rank/shape compatibility, and A/B pairing. Expert-parallel workers may
-materialize different local subsets, but must agree on the global declaration.
+The initial known-good load records the exact events consumed by each worker.
+This rank-local baseline is the completion contract for later full reloads and
+the source of truth from which partial checkpoint scopes are resolved.
 
-## Data model
+Baselines must remain rank-local. TP, PP, DP, and EP workers can consume
+different targets or fragments; unioning their events before reconciliation
+could hide a missing shard on one worker behind an event observed by another.
 
-`UpdateScope` is a serializable tagged structure:
+### Update scope
+
+An `UpdateScope` declares which model state one update may change. For an
+explicit scope, the declaration is both an allowlist and an exact completion
+contract:
+
+- missing in-scope state fails completion;
+- consumed out-of-scope state is rejected;
+- state outside the scope is preserved;
+- duplicate transport names are rejected;
+- transport chunks are delivery units, not independent scopes.
+
+## Baseline construction
+
+### Real initial checkpoint load
+
+The recorder wraps effective loaders before the first checkpoint iterator is
+consumed. It records only successful, consumed applications and removes itself
+immediately after loading.
+
+```mermaid
+flowchart TD
+    A[Construct model and weight loaders] --> B[Install load-consumption recorders]
+    B --> C[Iterate canonical checkpoint sources]
+    C --> D[Invoke rank-local weight_loader]
+    D --> E[Loader returns LoadReceipt]
+    E --> F{consumed?}
+    F -- No --> G[Exclude skipped call]
+    F -- Yes --> H[Create source-target-fragment event]
+    H --> I[Audit event key, target alias, and schema]
+    I --> J{Audit clean?}
+    J -- No --> X[Fail initial load]
+    J -- Yes --> K[Add event to rank-local baseline]
+    G --> L{More sources?}
+    K --> L
+    L -- Yes --> C
+    L -- No --> M[Remove recorder wrappers]
+    M --> N[Freeze exact baseline for later reloads]
+```
+
+The collision audit detects event-key collisions, target alias collisions,
+accepted/skipped status conflicts, schema drift, and receipt-schema mismatch.
+This prevents a baseline from silently treating distinct semantic loader calls
+as the same event.
+
+### Dummy model load
+
+A dummy load has no canonical checkpoint source stream. It therefore records a
+provisional target-only baseline. There are two ways to obtain an exact baseline:
+
+```mermaid
+flowchart TD
+    A[Dummy model initialization] --> B[Record local loadable target names]
+    B --> C{Dummy load probe enabled?}
+    C -- Yes --> D[Probe model.load_weights with metadata tensors]
+    D --> E[Record exact source-target-fragment events]
+    E --> F[Exact baseline ready]
+    C -- No --> G[Require declared source manifest on first real update]
+    G --> H[Receive complete real update]
+    H --> I{Every provisional target consumed?}
+    I -- No --> X[Fail; baseline remains provisional]
+    I -- Yes --> J[Promote observed receipts to exact baseline]
+    J --> F
+```
+
+Partial checkpoint updates and adapter-only replacement are rejected while the
+base model has only a provisional dummy baseline. The first real update must be
+complete so that later scopes are based on an authoritative event set.
+
+The baseline API returns `exact`, `provisional`, or `unavailable`. Aggregating
+rank-local reports also exposes `atomic_source_groups`: a legal partial
+checkpoint scope is a union of these groups.
+
+## Common update lifecycle
+
+Checkpoint transports validate completion at two independent levels:
+
+- **source manifest:** did IPC/NCCL deliver exactly the declared source names?
+- **load events:** did rank-local loaders consume the required target fragments?
+
+Matching only one level is insufficient. A source can arrive but be routed to
+the wrong fragment, while correct loader receipts cannot prove that an omitted
+transport chunk was intentional.
+
+```mermaid
+flowchart TD
+    A[Caller declares UpdateScope] --> B[Normalize fields and reject invalid combinations]
+    B --> C[Resolve scope against each worker's baseline]
+    C --> D{Scope valid and layer-closed?}
+    D -- No --> X[Reject before model mutation]
+    D -- Yes --> E[BEGIN: initialize affected state]
+    E --> F[Receive one or more transport chunks]
+    F --> G[Validate names against source allowlist]
+    G --> H[Run loaders and collect LoadReceipts]
+    H --> I[Audit and record consumed events]
+    I --> J{More chunks?}
+    J -- Yes --> F
+    J -- No --> K[Reconcile declared sources with received sources]
+    K --> L[Finalize affected layers and reconcile required events]
+    L --> M[Build rank-local LoadManifestReport]
+    M --> N{Local report clean?}
+    N -- No --> Y[Fail closed; do not resume]
+    N -- Yes --> O{Every worker reports success?}
+    O -- No --> Y
+    O -- Yes --> P[Commit generation and invalidate dependent caches]
+    P --> Q[Resume inference]
+```
+
+The report includes worker parallel coordinates, required and received event
+counts, completion findings, scope kind/mode, declared source names, and the
+rank-local sources selected from the baseline.
+
+## Scope modes
+
+`UpdateScope` is a serializable tagged declaration:
 
 ```text
 kind=base_checkpoint, mode=full
@@ -79,87 +201,216 @@ kind=lora_adapter, operation=replace|remove,
     config_digest=..., artifact_digest=...
 ```
 
-The scope is normalized at the API boundary. Duplicate names, invalid field
-combinations, empty explicit subsets, and inconsistent declarations fail
-before transfer or model mutation.
+`None` normalizes to the backward-compatible full checkpoint scope. Duplicate
+names, empty explicit sets, unknown fields, and inconsistent field combinations
+fail at normalization.
 
-Checkpoint event identity is structured as source, target, and fragment.
-Formatting it into a string is for diagnostics only; scope resolution must not
-parse the legacy display string.
+### Full checkpoint reload
 
-## Lifecycle
+Full checkpoint mode uses every event in the worker's exact baseline. Its
+completion rule is a lower bound: every baseline event must be observed, while
+additional accepted applications remain compatible with legacy full reload.
+Transport source equality is enforced when the caller supplies
+`expected_names`; it is mandatory for the first real update after an unprobed
+dummy load.
 
-```text
-declare scope
-  -> normalize and validate declaration
-  -> resolve rank-local effective manifest
-  -> validate checkpoint layer closure
-  -> initialize only affected state
-  -> receive chunks and reject out-of-scope names
-  -> replay/process affected layers or stage a complete adapter
-  -> reconcile expected == received for explicit scopes
-  -> produce a rank-local report
-  -> caller collects all reports and decides commit/abort
+```mermaid
+flowchart LR
+    A[scope omitted or full] --> B[Select complete local baseline]
+    B --> C[Restore all reloadable layers]
+    C --> D[Receive checkpoint chunks]
+    D --> E[Collect source names and receipts]
+    E --> F[Require baseline events subset of received events]
+    F --> G[Finalize all layers]
+    G --> H[Return rank-local report]
 ```
 
-The existing arena verification remains in its current location. This work
-does not reorder verification relative to copy-back.
+This compatibility mode is suitable for a complete replacement stream. It is
+not a declaration that omitted weights should retain their old values.
 
-## LoRA integration
+### Partial checkpoint reload
 
-SkyRL path:
+The caller supplies exact canonical checkpoint `source_names`. Each worker
+looks those names up in its own baseline and expands them to the corresponding
+target fragments.
 
-```text
-LoRAAdapterScope(artifact declaration)
-  -> load a staged LoRAModel from the shared path
-  -> validate artifact/config/local tensors
-  -> install with the existing load-in-place adapter path
+Checkpoint restoration and `process_weights_after_loading` operate on whole
+layerwise processing units. A partial scope is accepted only if every affected
+unit selects all of its baseline events. Selecting only Q from packed QKV, one
+quantization scale, or a subset of a processed MoE unit is rejected before
+restoration begins.
+
+```mermaid
+flowchart TD
+    A[Partial scope with source_names] --> B[Resolve names in each local baseline]
+    B --> C[Group selected events by layerwise processing unit]
+    C --> D{Each unit selected fully or not at all?}
+    D -- No --> X[Reject before mutation]
+    D -- Yes --> E[Restore and wrap selected units only]
+    E --> F[Receive chunks]
+    F --> G{Source name declared and not duplicate?}
+    G -- No --> Y[Reject chunk]
+    G -- Yes --> H[Collect exact consumed events]
+    H --> I[Require received sources equal declared sources]
+    I --> J[Require received events equal resolved local events]
+    J --> K[Finalize selected units; preserve all others]
+    K --> L[Return rank-local report]
 ```
 
-VERL tensor path:
+PP ranks with no selected local events are valid no-op participants. TP and EP
+ranks can resolve the same global source declaration to different local event
+sets, but each rank must reconcile its own set exactly.
 
-```text
-LoRAAdapterScope(exact tensor_names)
-  -> receive all buckets
-  -> require received_names == tensor_names
-  -> construct and validate the staged LoRAModel
-  -> replace the adapter once
+### Kernel-format update
+
+Kernel-format updates target already processed parameters directly and do not
+restore checkpoint layout or rerun post-load processing. The caller declares
+exact `target_names`; parameter-level subsets are therefore legal.
+
+```mermaid
+flowchart LR
+    A[Kernel scope with target_names] --> B[Validate exact targets]
+    B --> C[Receive in-place patches]
+    C --> D[Reject duplicate or undeclared targets]
+    D --> E[Check target shape and dtype]
+    E --> F[Apply copy or sparse patch]
+    F --> G[Require received targets equal declared targets]
+    G --> H[Finish without checkpoint-layout processing]
 ```
 
-If a dummy base model has not received its first complete real base update,
-adapter-only replacement is rejected.
+This mode does not use checkpoint load receipts because it bypasses
+`weight_loader`. Its equivalent completion evidence is exact target-name,
+shape, dtype, and transport reconciliation.
 
-## Compatibility
+### LoRA adapter replacement from a path
 
-- Omitting a scope retains full checkpoint behavior.
-- Existing `expected_names` is accepted during migration, but when an explicit
-  scope also supplies source/tensor names the declarations must agree.
-- Exact completion is enabled for explicit scopes. Legacy full reload keeps
-  its current compatibility behavior until all loaders emit structured
-  receipts.
+A LoRA scope identifies one adapter and a complete `replace` operation. A
+path-backed request may declare artifact and PEFT configuration digests, but
+cannot declare `tensor_names` because the worker reads the artifact itself.
 
-## Implementation sequence
+```mermaid
+sequenceDiagram
+    participant C as Controller
+    participant E as Executor
+    participant W as Every worker
+    participant L as Live adapter cache
 
-1. Add scope types, normalization, structured event identities, and
-   scope-aware reports.
-2. Resolve checkpoint source subsets, enforce whole-layer closure, initialize
-   only affected layers, and reconcile the effective manifest.
-3. Add exact kernel-target completion.
-4. Add LoRA artifact/tensor manifests and staged adapter replacement.
-5. Return reports from workers and enforce the all-rank decision above the
-   worker; invalidate prefix, multimodal, and encoder caches after commit.
+    C->>E: add_lora(path request, replace scope)
+    E->>W: prepare_lora_update(request)
+    W->>W: Validate scope identity and digests
+    W->>W: Load complete LoRAModel from path
+    W->>W: Validate config, modules, rank/shape, and A/B pairs
+    W-->>E: Prepared without publishing
+    alt every worker prepared
+        E->>W: commit_lora_update(adapter_id)
+        W->>L: Replace adapter and activate GPU slot
+        E-->>C: Success
+        C->>C: Invalidate prefix, MM, and encoder caches
+    else any worker failed
+        E->>W: abort_lora_update(adapter_id)
+        W->>W: Drop staged adapter; keep old adapter
+        E-->>C: Failure
+    end
+```
 
-## Required tests
+The prepare phase protects the old adapter from load or validation failures.
+Commit is coordinated after all workers prepare, but automatic rollback of a
+commit failure is not provided.
 
-- legacy full reload remains unchanged;
-- one or multiple complete checkpoint layers can be selected;
-- a split QKV, quantized layer, or expert processing unit is rejected before
-  initialization;
-- unknown, missing, duplicate, and unexpected names fail;
-- PP no-op and TP/EP rank-local resolution are valid;
-- kernel target subsets require exact names, shapes, and dtypes;
-- path-backed and tensor-backed LoRA replacement succeed;
-- incomplete A/B pairs, manifest/config mismatch, and adapter update before a
-  real dummy-base sync fail without removing the old adapter;
-- multi-bucket LoRA installs exactly once after all tensors arrive;
-- cache invalidation and all-rank report enforcement occur before resume.
+### LoRA adapter replacement from tensors
+
+The tensor-backed path is intended for training integrations that deliver one
+adapter across multiple buckets. It requires an exact global `tensor_names`
+manifest and a PEFT configuration.
+
+```mermaid
+flowchart TD
+    A[Create TensorLoRAUpdateSession from replace scope] --> B[Receive tensor bucket]
+    B --> C{Names declared, unique, and not seen before?}
+    C -- No --> X[Reject session]
+    C -- Yes --> D[Stage tensors by canonical name]
+    D --> E{More buckets?}
+    E -- Yes --> B
+    E -- No --> F[Require received tensor names equal declared manifest]
+    F --> G[Validate PEFT config digest]
+    G --> H[Construct TensorLoRARequest]
+    H --> I[Each worker builds and validates complete LoRAModel]
+    I --> J{All workers prepared?}
+    J -- No --> K[Abort staged adapters; keep old adapter]
+    J -- Yes --> L[Commit replacement once]
+    L --> M[Invalidate dependent caches]
+```
+
+Transport buckets do not become separate update scopes. Installation occurs
+once, after the complete tensor manifest and all A/B pairs have been validated.
+
+### LoRA adapter removal
+
+A remove scope carries only adapter identity and `operation=remove`; replacement
+fields are invalid. Removal has no receipt stream because no new adapter payload
+is consumed. The controller must remove the identified adapter on every worker
+and invalidate caches that may retain adapter-dependent results.
+
+## Completion semantics by mode
+
+| Mode | Declaration | Completion rule | Out-of-scope input | Processing boundary |
+|---|---|---|---|---|
+| Full checkpoint | Omitted or `mode=full` | Initial local events are a subset of received events | Compatible extras may be accepted | All reloadable layers |
+| Partial checkpoint | Exact source names | Resolved local events equal received events | Reject | Whole layerwise units only |
+| Kernel format | Exact target names | Declared targets equal received targets | Reject | Individual runtime parameters |
+| LoRA path replace | Adapter identity and optional digests | Every worker stages one complete validated adapter | Reject identity/digest mismatch | Complete adapter |
+| LoRA tensor replace | Adapter identity, exact tensor names, config | Declared tensors equal accumulated tensors; every worker stages successfully | Reject unknown/duplicate tensors | Complete adapter |
+| LoRA remove | Adapter identity | Adapter removed on every worker | No payload allowed | Complete adapter |
+
+## Failure boundaries
+
+The protocol fails before mutation whenever possible:
+
+- malformed scope declarations;
+- partial checkpoint scopes that split a processing unit;
+- undeclared or duplicate transport names;
+- load-receipt collision or schema findings;
+- LoRA identity, manifest, digest, module, shape, or A/B-pair mismatch.
+
+Failures discovered after a base checkpoint/kernel mutation are fail-closed:
+the update is unsuccessful and the engine must not resume that generation. The
+current implementation does not reconstruct the previous base-weight values.
+
+LoRA replacement keeps the old adapter until preparation succeeds everywhere.
+An abort discards pending adapters. Once commit begins, however, a worker-level
+commit failure is not automatically rolled back on workers that already
+published the replacement.
+
+## Compatibility and migration
+
+- Omitting a scope preserves legacy full-checkpoint behavior.
+- Existing `expected_names` remains accepted. If an explicit scope also
+  declares names, both declarations must agree.
+- Legacy `None`/`bool` loaders are adapted to receipts while loader schemas are
+  migrated.
+- Exact lower-and-upper-bound completion is required for explicit scopes.
+- Full reload retains lower-bound event completion to tolerate established
+  broadcast and loader behavior.
+- A dummy model must establish an exact baseline through probing or its first
+  complete real update before partial checkpoint or LoRA-only updates.
+
+## Required validation
+
+- a real first load records consumed rank-local events and excludes skipped EP
+  applications;
+- receipt schemas distinguish packed QKV, merged projections, and routed MoE
+  fragments without collisions;
+- dummy probing or first-real-update promotion produces an exact baseline;
+- full reload detects missing baseline events without rejecting compatible
+  extras;
+- partial scopes accept unions of atomic source groups and reject split units;
+- source and event reconciliation catch unknown, missing, duplicate, and
+  unexpected names independently;
+- PP no-op and TP/EP rank-local resolutions succeed;
+- kernel scopes enforce exact target names, shapes, and dtypes;
+- path-backed and multi-bucket tensor-backed LoRA replacement stage before
+  publish and install exactly once;
+- LoRA manifest/config mismatch and incomplete A/B pairs preserve the old
+  adapter;
+- every worker report is checked and dependent caches are invalidated before
+  inference resumes.

--- a/docs/serving/offline_inference.md
+++ b/docs/serving/offline_inference.md
@@ -62,7 +62,7 @@ For further details on metrics, please refer to [this page](../design/metrics.md
 For further details on Weight Transfer, please refer to [this page](../training/weight_transfer/README.md).
 
 - `LLM.init_weight_transfer_engine` - Initializes the weight transfer engine for RL training.
-- `LLM.get_weight_update_baseline` - Lists legal partial checkpoint update groups.
+- `LLM.get_weight_update_manifest` - Lists updatable model weights and LoRA adapters.
 - `LLM.start_weight_update` - Starts a new weight update cycle.
 - `LLM.update_weights` - Updates the model weights.
 - `LLM.finish_weight_update` - Finishes the current weight update cycle.

--- a/docs/serving/offline_inference.md
+++ b/docs/serving/offline_inference.md
@@ -62,6 +62,7 @@ For further details on metrics, please refer to [this page](../design/metrics.md
 For further details on Weight Transfer, please refer to [this page](../training/weight_transfer/README.md).
 
 - `LLM.init_weight_transfer_engine` - Initializes the weight transfer engine for RL training.
+- `LLM.get_weight_update_baseline` - Lists legal partial checkpoint update groups.
 - `LLM.start_weight_update` - Starts a new weight update cycle.
 - `LLM.update_weights` - Updates the model weights.
 - `LLM.finish_weight_update` - Finishes the current weight update cycle.

--- a/docs/serving/online_serving/README.md
+++ b/docs/serving/online_serving/README.md
@@ -171,7 +171,7 @@ For further details on Weight Transfer, please refer to [this page](../../traini
 - `/resume` - Resume generation
 - `/is_paused` - Check if generation is paused
 - `/init_weight_transfer_engine` - Initialize weight transfer engine for RLHF
-- `/weight_update_baseline` - List legal partial checkpoint update groups
+- `/weight_update_manifest` - List updatable model weights and LoRA adapters
 - `/start_weight_update` - Prepares the inference engine for a weight update.
 - `/update_weights` - Update model weights (can alter model behavior)
 - `/finish_weight_update` - Finalizes the weight update

--- a/docs/serving/online_serving/README.md
+++ b/docs/serving/online_serving/README.md
@@ -171,6 +171,7 @@ For further details on Weight Transfer, please refer to [this page](../../traini
 - `/resume` - Resume generation
 - `/is_paused` - Check if generation is paused
 - `/init_weight_transfer_engine` - Initialize weight transfer engine for RLHF
+- `/weight_update_baseline` - List legal partial checkpoint update groups
 - `/start_weight_update` - Prepares the inference engine for a weight update.
 - `/update_weights` - Update model weights (can alter model behavior)
 - `/finish_weight_update` - Finalizes the weight update

--- a/docs/training/weight_transfer/README.md
+++ b/docs/training/weight_transfer/README.md
@@ -51,6 +51,7 @@ When running vLLM as an HTTP server, the following endpoints are available for w
 | Endpoint | Method | Description |
 | -------- | ------ | ----------- |
 | `/init_weight_transfer_engine` | POST | Initialize the weight transfer engine with backend-specific info |
+| `/weight_update_baseline` | GET | Get checkpoint sources grouped into legal partial-update units |
 | `/start_weight_update` | POST | Start a weight update |
 | `/update_weights` | POST | Transfer a batch of weights with backend-specific metadata |
 | `/finish_weight_update` | POST | Finish the weight update and run post-processing |
@@ -60,6 +61,30 @@ When running vLLM as an HTTP server, the following endpoints are available for w
 
 !!! note
     The HTTP weight transfer endpoints require `VLLM_SERVER_DEV_MODE=1` to be set.
+
+### Discovering legal partial-update scopes
+
+Call `GET /weight_update_baseline` after model loading. The response includes
+all source names observed during the initial checkpoint load and
+`atomic_source_groups`. The corresponding `atomic_update_scopes` entries can
+be sent directly to `/start_weight_update`. A larger legal partial scope is a
+union of complete atomic groups:
+
+```json
+{
+  "kind": "base_checkpoint",
+  "mode": "partial",
+  "source_names": [
+    "model.layers.0.input_layernorm.weight",
+    "model.layers.0.post_attention_layernorm.weight"
+  ]
+}
+```
+
+The groups are merged across workers, so TP, PP, and EP closure constraints
+are preserved. Use the scope only when the response has `"ready": true`.
+A dummy model without metadata probing returns a provisional baseline until it
+has completed one real full base-weight update.
 
 ## Trainer-Side API
 

--- a/docs/training/weight_transfer/README.md
+++ b/docs/training/weight_transfer/README.md
@@ -51,7 +51,7 @@ When running vLLM as an HTTP server, the following endpoints are available for w
 | Endpoint | Method | Description |
 | -------- | ------ | ----------- |
 | `/init_weight_transfer_engine` | POST | Initialize the weight transfer engine with backend-specific info |
-| `/weight_update_baseline` | GET | Get checkpoint sources grouped into legal partial-update units |
+| `/weight_update_manifest` | GET | Get updatable model-weight and LoRA manifests |
 | `/start_weight_update` | POST | Start a weight update |
 | `/update_weights` | POST | Transfer a batch of weights with backend-specific metadata |
 | `/finish_weight_update` | POST | Finish the weight update and run post-processing |
@@ -64,11 +64,12 @@ When running vLLM as an HTTP server, the following endpoints are available for w
 
 ### Discovering legal partial-update scopes
 
-Call `GET /weight_update_baseline` after model loading. The response includes
+Call `GET /weight_update_manifest` after model loading. The response includes
+separate `model_weights` and `lora_adapters` fields. `model_weights` contains
 all source names observed during the initial checkpoint load and
-`atomic_source_groups`. The corresponding `atomic_update_scopes` entries can
-be sent directly to `/start_weight_update`. A larger legal partial scope is a
-union of complete atomic groups:
+`atomic_source_groups`. The corresponding `atomic_update_scopes` entries can be
+sent directly to `/start_weight_update`. A larger legal partial scope is a union
+of complete atomic groups:
 
 ```json
 {
@@ -82,9 +83,15 @@ union of complete atomic groups:
 ```
 
 The groups are merged across workers, so TP, PP, and EP closure constraints
-are preserved. Use the scope only when the response has `"ready": true`.
+are preserved. Use the scope only when `model_weights.ready` is `true`.
 A dummy model without metadata probing returns a provisional baseline until it
 has completed one real full base-weight update.
+
+Each entry in `lora_adapters` includes adapter identity, generation, the union
+of rank-local runtime module names, and templates for replacement, partial
+patch, and removal. A patch must use the current `base_generation`, select
+complete runtime modules, and provide complete A/B pairs for every selected
+module. Unselected modules retain their current weights.
 
 ## Trainer-Side API
 

--- a/tests/distributed/test_weight_transfer.py
+++ b/tests/distributed/test_weight_transfer.py
@@ -7,6 +7,7 @@ Integration tests for NCCL and IPC weight transfer between processes using Ray.
 """
 
 import pickle
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pybase64 as base64
@@ -18,6 +19,7 @@ from torch.multiprocessing.reductions import reduce_tensor
 from vllm.config.parallel import ParallelConfig
 from vllm.config.weight_transfer import WeightTransferConfig
 from vllm.distributed.weight_transfer import WeightTransferEngineFactory
+from vllm.distributed.weight_transfer.base import WeightTransferEngine
 from vllm.distributed.weight_transfer.ipc_engine import (
     IPCWeightTransferEngine,
     IPCWeightTransferInitInfo,
@@ -89,6 +91,50 @@ def create_mock_vllm_config(
     vllm_config.parallel_config = create_mock_parallel_config(rank, world_size, dp_rank)
     vllm_config.model_config = MagicMock()
     return vllm_config
+
+
+class TestDeclaredSourceManifest:
+    def _state(self, *, required: bool = True):
+        return SimpleNamespace(
+            _requires_declared_source_manifest=required,
+            _expected_source_names=None,
+            _received_source_names=set(),
+        )
+
+    def test_complete_chunked_manifest(self):
+        state = self._state()
+        WeightTransferEngine.observe_source_manifest(
+            state, ["q_proj.weight"], ["q_proj.weight", "k_proj.weight"]
+        )
+        WeightTransferEngine.observe_source_manifest(
+            state, ["k_proj.weight"], None
+        )
+        WeightTransferEngine.finish_source_manifest_validation(state)
+
+    def test_missing_packed_fragment_fails(self):
+        state = self._state()
+        WeightTransferEngine.observe_source_manifest(
+            state,
+            ["q_proj.weight", "v_proj.weight"],
+            ["q_proj.weight", "k_proj.weight", "v_proj.weight"],
+        )
+        with pytest.raises(RuntimeError, match=r"k_proj\.weight"):
+            WeightTransferEngine.finish_source_manifest_validation(state)
+
+    def test_dummy_first_transfer_requires_declaration(self):
+        state = self._state()
+        WeightTransferEngine.observe_source_manifest(
+            state, ["q_proj.weight"], None
+        )
+        with pytest.raises(RuntimeError, match="authoritative expected"):
+            WeightTransferEngine.finish_source_manifest_validation(state)
+
+    def test_later_transfer_keeps_backward_compatibility(self):
+        state = self._state(required=False)
+        WeightTransferEngine.observe_source_manifest(
+            state, ["q_proj.weight"], None
+        )
+        WeightTransferEngine.finish_source_manifest_validation(state)
 
 
 # --- Unit Tests: NCCLWeightTransferUpdateInfo Validation ---

--- a/tests/entrypoints/weight_transfer/test_weight_update_baseline_api.py
+++ b/tests/entrypoints/weight_transfer/test_weight_update_baseline_api.py
@@ -7,32 +7,35 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 from vllm.entrypoints.serve.dev.rlhf.api_router import (
-    get_weight_update_baseline,
+    get_weight_update_manifest,
 )
 
 
-def test_weight_update_baseline_endpoint_returns_engine_manifest() -> None:
-    baseline = {
-        "ready": True,
-        "scope_template": {
-            "kind": "base_checkpoint",
-            "mode": "partial",
-            "source_names": [],
+def test_weight_update_manifest_endpoint_returns_engine_manifest() -> None:
+    manifest = {
+        "model_weights": {
+            "ready": True,
+            "scope_template": {
+                "kind": "base_checkpoint",
+                "mode": "partial",
+                "source_names": [],
+            },
+            "source_names": ["layer.weight"],
+            "atomic_source_groups": [["layer.weight"]],
+            "workers": [],
+            "reason": None,
         },
-        "source_names": ["layer.weight"],
-        "atomic_source_groups": [["layer.weight"]],
-        "workers": [],
-        "reason": None,
+        "lora_adapters": [],
     }
     engine = SimpleNamespace(
-        get_weight_update_baseline=AsyncMock(return_value=baseline)
+        get_weight_update_manifest=AsyncMock(return_value=manifest)
     )
     request = SimpleNamespace(
         app=SimpleNamespace(state=SimpleNamespace(engine_client=engine))
     )
 
-    response = asyncio.run(get_weight_update_baseline(request))
+    response = asyncio.run(get_weight_update_manifest(request))
 
     assert response.status_code == 200
-    assert json.loads(response.body) == baseline
-    engine.get_weight_update_baseline.assert_awaited_once_with()
+    assert json.loads(response.body) == manifest
+    engine.get_weight_update_manifest.assert_awaited_once_with()

--- a/tests/entrypoints/weight_transfer/test_weight_update_baseline_api.py
+++ b/tests/entrypoints/weight_transfer/test_weight_update_baseline_api.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from vllm.entrypoints.serve.dev.rlhf.api_router import (
+    get_weight_update_baseline,
+)
+
+
+def test_weight_update_baseline_endpoint_returns_engine_manifest() -> None:
+    baseline = {
+        "ready": True,
+        "scope_template": {
+            "kind": "base_checkpoint",
+            "mode": "partial",
+            "source_names": [],
+        },
+        "source_names": ["layer.weight"],
+        "atomic_source_groups": [["layer.weight"]],
+        "workers": [],
+        "reason": None,
+    }
+    engine = SimpleNamespace(
+        get_weight_update_baseline=AsyncMock(return_value=baseline)
+    )
+    request = SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(engine_client=engine))
+    )
+
+    response = asyncio.run(get_weight_update_baseline(request))
+
+    assert response.status_code == 200
+    assert json.loads(response.body) == baseline
+    engine.get_weight_update_baseline.assert_awaited_once_with()

--- a/tests/model_executor/model_loader/test_load_probe.py
+++ b/tests/model_executor/model_loader/test_load_probe.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 from safetensors.torch import save_file
 
+from vllm.config.load import LoadConfig
 from vllm.model_executor.load_receipt import returns_load_receipt
 from vllm.model_executor.model_loader.dummy_loader import DummyModelLoader
 from vllm.model_executor.model_loader.reload.layerwise import (
@@ -260,3 +261,102 @@ def test_dummy_finalize_keeps_exact_probe_manifest():
 
     assert info.required_keys == {"layer.weight=>weight"}
     assert info.required_target_keys is None
+
+
+def test_dummy_loader_probe_is_explicitly_configured():
+    default_loader = DummyModelLoader(LoadConfig(load_format="dummy"))
+    enabled_loader = DummyModelLoader(
+        LoadConfig(
+            load_format="dummy",
+            model_loader_extra_config={"enable_load_probe": True},
+        )
+    )
+
+    assert not default_loader.enable_load_probe
+    assert enabled_loader.enable_load_probe
+
+
+@pytest.mark.parametrize(
+    "extra_config, match",
+    [
+        ({"enable_load_probe": "yes"}, "enable_load_probe must be a bool"),
+        ({"unknown": True}, "Unexpected extra config keys"),
+    ],
+)
+def test_dummy_loader_rejects_invalid_probe_config(extra_config, match):
+    with pytest.raises(ValueError, match=match):
+        DummyModelLoader(
+            LoadConfig(
+                load_format="dummy",
+                model_loader_extra_config=extra_config,
+            )
+        )
+
+
+def test_dummy_loader_probe_resolves_remote_safetensors(monkeypatch, tmp_path):
+    save_file({"layer.weight": torch.ones(8)}, tmp_path / "model.safetensors")
+    calls = []
+
+    def fake_download_weights_from_hf(
+        model_name_or_path,
+        cache_dir,
+        allow_patterns,
+        revision=None,
+        subfolder=None,
+        ignore_patterns=None,
+    ):
+        calls.append(
+            (
+                model_name_or_path,
+                cache_dir,
+                allow_patterns,
+                revision,
+                subfolder,
+                ignore_patterns,
+            )
+        )
+        return str(tmp_path)
+
+    monkeypatch.setattr(
+        "vllm.model_executor.model_loader.dummy_loader.download_weights_from_hf",
+        fake_download_weights_from_hf,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.model_loader.dummy_loader."
+        "download_safetensors_index_file_from_hf",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.model_loader.dummy_loader."
+        "maybe_download_from_modelscope",
+        lambda *args, **kwargs: None,
+    )
+
+    loader = DummyModelLoader(
+        LoadConfig(
+            load_format="dummy",
+            download_dir="/tmp/vllm-test-cache",
+            ignore_patterns=["original/**/*"],
+            model_loader_extra_config={"enable_load_probe": True},
+        )
+    )
+    model_config = type(
+        "ModelConfigStub",
+        (),
+        {"model": "org/model", "revision": "main"},
+    )()
+
+    weights = dict(loader._probe_meta_weights(model_config))
+
+    assert calls == [
+        (
+            "org/model",
+            "/tmp/vllm-test-cache",
+            ["*.safetensors"],
+            "main",
+            None,
+            ["original/**/*"],
+        )
+    ]
+    assert weights["layer.weight"].is_meta
+    assert weights["layer.weight"].shape == (8,)

--- a/tests/model_executor/model_loader/test_load_probe.py
+++ b/tests/model_executor/model_loader/test_load_probe.py
@@ -1,0 +1,262 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from vllm.model_executor.load_receipt import returns_load_receipt
+from vllm.model_executor.model_loader.dummy_loader import DummyModelLoader
+from vllm.model_executor.model_loader.reload.layerwise import (
+    finalize_load_recording,
+    get_layerwise_info,
+    record_load_consumption,
+    record_metadata_for_reloading,
+)
+from vllm.model_executor.model_loader.reload.probe import (
+    LoadProbeError,
+    probe_dummy_load_manifest,
+    probe_model_load,
+    safetensors_meta_weights,
+    validate_probe_receipt_coverage,
+)
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+
+
+class ProbeModel(torch.nn.Module):
+    def __init__(self, loader=default_weight_loader):
+        super().__init__()
+        self.layer = torch.nn.Module()
+        weight = torch.nn.Parameter(torch.arange(8, dtype=torch.float32))
+        weight.weight_loader = loader
+        self.layer.register_parameter("weight", weight)
+
+    def load_weights(self, weights):
+        loaded = set()
+        for name, value in weights:
+            assert name.startswith("layer.")
+            param = self.get_parameter(name)
+            param.weight_loader(param, value)
+            loaded.add(name)
+        return loaded
+
+
+def meta_weight(size=8):
+    return torch.empty(size, dtype=torch.float32, device="meta")
+
+
+def test_probe_runs_real_loader_without_changing_parameter():
+    model = ProbeModel()
+    before = model.layer.weight.detach().clone()
+
+    report = probe_model_load(model, [("layer.weight", meta_weight())])
+
+    assert report.ok
+    assert report.loaded_weights == {"layer.weight"}
+    assert report.intercepted_writes == ["aten.copy_.default"]
+    assert report.write_sources == {"layer.weight"}
+    assert torch.equal(model.layer.weight, before)
+
+
+def test_probe_receipt_matches_real_source_and_fragment():
+    @returns_load_receipt("loaded_shard_id")
+    def shard_loader(param, loaded_weight, loaded_shard_id):
+        param.copy_(loaded_weight)
+
+    model = ProbeModel(shard_loader)
+    record_load_consumption(model)
+    try:
+        with pytest.raises(LoadProbeError, match="PROBE_LOADER_EXCEPTION"):
+            # The model does not supply the required routing argument. A
+            # probe executes the real call signature rather than inventing a
+            # default fragment.
+            probe_model_load(model, [("layer.weight", meta_weight())])
+    finally:
+        finalize_load_recording(model)
+
+
+def test_probe_records_routed_fragment_from_real_model_mapping():
+    @returns_load_receipt("loaded_shard_id")
+    def shard_loader(param, loaded_weight, loaded_shard_id):
+        param.copy_(loaded_weight)
+
+    class RoutedProbeModel(ProbeModel):
+        def load_weights(self, weights):
+            for name, value in weights:
+                source, shard = name.rsplit(".", 1)
+                assert source == "layer.weight"
+                self.layer.weight.weight_loader(
+                    self.layer.weight,
+                    value,
+                    shard,
+                )
+            return {"layer.weight"}
+
+    model = RoutedProbeModel(shard_loader)
+    record_metadata_for_reloading(model)
+    info = get_layerwise_info(model.layer)
+    info.required_keys = set()
+    info.required_target_keys = {"weight"}
+
+    probe_dummy_load_manifest(
+        model,
+        [
+            ("layer.weight.q", meta_weight()),
+            ("layer.weight.k", meta_weight()),
+            ("layer.weight.v", meta_weight()),
+        ],
+    )
+
+    assert info.required_keys == {
+        "layer.weight.k=>weight[loaded_shard_id='k']",
+        "layer.weight.q=>weight[loaded_shard_id='q']",
+        "layer.weight.v=>weight[loaded_shard_id='v']",
+    }
+
+
+def test_probe_preserves_composed_loader_write_count():
+    def composed_loader(param, loaded_weight):
+        param.copy_(loaded_weight)
+        param.copy_(loaded_weight)
+
+    model = ProbeModel(composed_loader)
+    report = probe_model_load(model, [("layer.weight", meta_weight())])
+
+    assert report.intercepted_writes == [
+        "aten.copy_.default",
+        "aten.copy_.default",
+    ]
+
+
+def test_probe_redirects_loader_factories_to_meta():
+    def allocating_loader(param, loaded_weight):
+        temporary = torch.zeros(
+            loaded_weight.shape,
+            dtype=loaded_weight.dtype,
+            device=param.device,
+        )
+        param.copy_(loaded_weight + temporary)
+
+    model = ProbeModel(allocating_loader)
+    report = probe_model_load(model, [("layer.weight", meta_weight())])
+
+    assert report.ok
+    assert report.intercepted_writes == ["aten.copy_.default"]
+
+
+def test_probe_rejects_real_source_storage():
+    model = ProbeModel()
+    with pytest.raises(ValueError, match="requires meta source tensors"):
+        probe_model_load(model, [("layer.weight", torch.empty(8))])
+
+
+def test_probe_fails_closed_on_data_dependent_loader():
+    def data_dependent_loader(param, loaded_weight):
+        if loaded_weight.sum().item() > 0:
+            param.copy_(loaded_weight)
+
+    model = ProbeModel(data_dependent_loader)
+    with pytest.raises(LoadProbeError, match="PROBE_UNSUPPORTED_OPERATOR"):
+        probe_model_load(model, [("layer.weight", meta_weight())])
+
+
+def test_probe_can_establish_exact_recorded_event():
+    model = ProbeModel()
+    record_load_consumption(model)
+    try:
+        report = probe_model_load(model, [("layer.weight", meta_weight())])
+    finally:
+        finalize_load_recording(model)
+
+    assert report.ok
+    info = get_layerwise_info(model.layer)
+    assert info.required_keys == {"layer.weight=>weight"}
+
+
+def test_probe_rejects_direct_write_without_receipt():
+    class DirectWriteModel(ProbeModel):
+        def load_weights(self, weights):
+            for name, value in weights:
+                self.get_parameter(name).copy_(value)
+            return {"layer.weight"}
+
+    model = DirectWriteModel()
+    record_load_consumption(model)
+    try:
+        report = probe_model_load(model, [("layer.weight", meta_weight())])
+        with pytest.raises(
+            LoadProbeError,
+            match="without LoadReceipt coverage",
+        ):
+            validate_probe_receipt_coverage(model, report)
+    finally:
+        finalize_load_recording(model)
+
+
+def test_dummy_probe_replaces_provisional_target_baseline():
+    model = ProbeModel()
+    record_metadata_for_reloading(model)
+    info = get_layerwise_info(model.layer)
+    info.required_keys = set()
+    info.required_target_keys = {"weight"}
+
+    report = probe_dummy_load_manifest(
+        model,
+        [("layer.weight", meta_weight())],
+    )
+
+    assert report.ok
+    assert info.required_target_keys is None
+    assert info.required_keys == {"layer.weight=>weight"}
+
+
+def test_failed_dummy_probe_restores_provisional_baseline():
+    def data_dependent_loader(param, loaded_weight):
+        if loaded_weight.sum().item() > 0:
+            param.copy_(loaded_weight)
+
+    model = ProbeModel(data_dependent_loader)
+    record_metadata_for_reloading(model)
+    info = get_layerwise_info(model.layer)
+    info.required_keys = set()
+    info.required_target_keys = {"weight"}
+
+    with pytest.raises(LoadProbeError):
+        probe_dummy_load_manifest(
+            model,
+            [("layer.weight", meta_weight())],
+        )
+
+    assert info.required_target_keys == {"weight"}
+    assert info.required_keys == set()
+
+
+def test_safetensors_schema_reader_returns_meta_tensors(tmp_path):
+    save_file(
+        {
+            "layer.weight": torch.ones(8, dtype=torch.float32),
+            "layer.scale": torch.ones(2, dtype=torch.bfloat16),
+        },
+        tmp_path / "model.safetensors",
+    )
+
+    weights = dict(safetensors_meta_weights(str(tmp_path)))
+
+    assert set(weights) == {"layer.weight", "layer.scale"}
+    assert weights["layer.weight"].is_meta
+    assert weights["layer.weight"].shape == (8,)
+    assert weights["layer.weight"].dtype == torch.float32
+    assert weights["layer.scale"].is_meta
+    assert weights["layer.scale"].dtype == torch.bfloat16
+
+
+def test_dummy_finalize_keeps_exact_probe_manifest():
+    model = ProbeModel()
+    info = get_layerwise_info(model.layer)
+    info.required_keys = {"layer.weight=>weight"}
+    info.required_target_keys = None
+
+    DummyModelLoader.finalize_load_manifest(object(), model)
+
+    assert info.required_keys == {"layer.weight=>weight"}
+    assert info.required_target_keys is None

--- a/tests/model_executor/model_loader/test_modelexpress_loader.py
+++ b/tests/model_executor/model_loader/test_modelexpress_loader.py
@@ -5,6 +5,7 @@ import sys
 from types import ModuleType, SimpleNamespace
 
 import pytest
+import torch
 from torch import nn
 
 from vllm.config import VllmConfig
@@ -13,11 +14,13 @@ from vllm.model_executor.model_loader import get_model_loader
 from vllm.model_executor.model_loader.modelexpress_loader import (
     ModelExpressModelLoader,
 )
+from vllm.model_executor.model_loader.reload.layerwise import get_layerwise_info
 
 
 class FakeModelexpressLoader:
     calls: list[tuple[str, tuple, dict]] = []
     loaded_model: nn.Module
+    tensors: dict[str, torch.Tensor]
 
     def __init__(self, load_config: LoadConfig):
         self.load_config = load_config
@@ -36,6 +39,7 @@ class FakeModelexpressLoader:
 def _install_fake_modelexpress(monkeypatch):
     FakeModelexpressLoader.calls = []
     FakeModelexpressLoader.loaded_model = nn.Module()
+    FakeModelexpressLoader.tensors = {}
 
     for name in [
         "modelexpress",
@@ -88,6 +92,24 @@ def test_modelexpress_loader_delegates_to_modelexpress(monkeypatch):
             },
         ),
     ]
+
+
+def test_modelexpress_records_published_processed_tensors(monkeypatch):
+    _install_fake_modelexpress(monkeypatch)
+    model = nn.Linear(4, 4, bias=False)
+    FakeModelexpressLoader.loaded_model = model
+    FakeModelexpressLoader.tensors = {"model.weight": model.weight}
+
+    loader = ModelExpressModelLoader(LoadConfig(load_format="modelexpress"))
+    result = loader.load_model(
+        vllm_config=SimpleNamespace(),
+        model_config=SimpleNamespace(),
+    )
+
+    assert result is model
+    assert get_layerwise_info(model).required_keys == {
+        "modelexpress://model.weight=>weight"
+    }
 
 
 def test_modelexpress_loader_missing_modelexpress_error(monkeypatch):

--- a/tests/model_executor/model_loader/test_registry.py
+++ b/tests/model_executor/model_loader/test_registry.py
@@ -28,6 +28,12 @@ def test_register_model_loader():
     assert isinstance(get_model_loader(load_config), CustomModelLoader)
 
 
+def test_custom_loader_without_manifest_adapter_fails_closed():
+    loader = CustomModelLoader(LoadConfig(load_format="custom_load_format"))
+    with pytest.raises(RuntimeError, match="without producing any load-manifest"):
+        loader._ensure_manifest_observed(nn.Linear(2, 2))
+
+
 def test_invalid_model_loader():
     with pytest.raises(ValueError):
 

--- a/tests/model_executor/model_loader/test_reload.py
+++ b/tests/model_executor/model_loader/test_reload.py
@@ -118,6 +118,76 @@ def test_reload_lifecycle():
         assert tensor.__dict__ == materialized_tensor.__dict__
 
 
+@pytest.mark.parametrize("restored_kind", ["parameter", "buffer"])
+@pytest.mark.parametrize("current_kind", ["parameter", "buffer", "attribute", "none"])
+def test_restore_layer_handles_tensor_slot_kind_changes(
+    restored_kind: str, current_kind: str
+):
+    """Quantization may change a weight's Module registration after loading."""
+    layer = torch.nn.Module()
+    original = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+    if restored_kind == "parameter":
+        layer.register_parameter(
+            "weight", torch.nn.Parameter(original, requires_grad=False)
+        )
+    else:
+        layer.register_buffer("weight", original, persistent=False)
+
+    info = LayerReloadingInfo(
+        restore_metadata=capture_layer_to_meta(layer),
+        restore_device=torch.device("cpu"),
+    )
+
+    # Simulate the different shapes left by quantization/kernel setup.
+    delattr(layer, "weight")
+    replacement = torch.ones(1)
+    if current_kind == "parameter":
+        layer.register_parameter(
+            "weight", torch.nn.Parameter(replacement, requires_grad=False)
+        )
+    elif current_kind == "buffer":
+        layer.register_buffer("weight", replacement, persistent=False)
+    elif current_kind == "attribute":
+        layer.weight = replacement
+    else:
+        layer.register_parameter("weight", None)
+
+    restore_layer_on_meta(layer, info)
+
+    assert layer.weight.is_meta
+    assert layer.weight.shape == original.shape
+    if restored_kind == "parameter":
+        assert "weight" in layer._parameters
+        assert "weight" not in layer._buffers
+    else:
+        assert "weight" not in layer._parameters
+        assert "weight" in layer._buffers
+        # capture/restore currently restores buffers as persistent.
+        assert "weight" not in layer._non_persistent_buffers_set
+
+
+def test_restore_layer_preserves_registered_none_slots():
+    """Structural optional tensor slots must survive a reload round trip.
+
+    Linear layers created with ``bias=False`` register ``bias`` as a None
+    parameter. Dropping that registration makes forward fail after reload
+    because ``self.bias`` no longer exists.
+    """
+    layer = torch.nn.Linear(3, 2, bias=False)
+    layer.register_buffer("optional_buffer", None, persistent=False)
+    info = LayerReloadingInfo(
+        restore_metadata=capture_layer_to_meta(layer),
+        restore_device=torch.device("cpu"),
+    )
+
+    restore_layer_on_meta(layer, info)
+
+    assert "bias" in layer._parameters
+    assert layer.bias is None
+    assert "optional_buffer" in layer._buffers
+    assert layer.optional_buffer is None
+
+
 def test_materialize_layer_preserves_non_meta_tensors():
     """Ensure that materialize_layer does not overwrite non meta tensors."""
     layer = torch.nn.Linear(2, 3, bias=True)

--- a/tests/model_executor/model_loader/test_reload.py
+++ b/tests/model_executor/model_loader/test_reload.py
@@ -9,10 +9,14 @@ import torch
 from torch.nn.parameter import UninitializedParameter
 
 import vllm.model_executor.model_loader.reload.meta as reload_meta
+import vllm.model_executor.model_loader.reload.layerwise as reload_layerwise
 from vllm.model_executor.layers.linear import QKVParallelLinear
 from vllm.model_executor.model_loader.reload.layerwise import (
     finalize_layerwise_reload,
+    finalize_load_recording,
+    get_layerwise_info,
     initialize_layerwise_reload,
+    record_load_consumption,
     record_metadata_for_reloading,
 )
 from vllm.model_executor.model_loader.reload.meta import (
@@ -252,18 +256,16 @@ def test_get_numel_loaded():
     assert ret == "value"
 
 
-def test_get_numel_loaded_caps_at_param_size():
-    # composed_weight_loader copies into the param twice (the load and the
-    # in-place post-load transform), but only param.numel() distinct elements
-    # are loaded. get_numel_loaded must not double-count, otherwise a layer's
-    # loaded-element total can be reached early and trailing params get dropped.
+def test_get_numel_loaded_is_diagnostic_for_composed_loader():
+    # The diagnostic reports both internal writes. This no longer controls
+    # layer completion, which is driven by logical manifest events.
     param = torch.empty(10)
     loaded_weight = torch.ones(10)
     loader = composed_weight_loader(default_weight_loader, lambda x: x + 1)
 
     args = inspect.signature(loader).bind(param, loaded_weight)
     num_loaded, _ = get_numel_loaded(loader, args)
-    assert num_loaded == 10
+    assert num_loaded == 20
 
 
 class _ComposedLoaderLayer(torch.nn.Module):
@@ -324,6 +326,59 @@ def test_layerwise_reload_composed_loader_does_not_drop_params(monkeypatch):
         param.weight_loader(param, loaded[name])
     finalize_layerwise_reload(model, model_config=None)
 
+    assert torch.equal(layer.A, -torch.exp(loaded["A"]))
+    assert torch.equal(layer.dt_bias, loaded["dt_bias"])
+    assert torch.equal(layer.D, loaded["D"])
+
+
+def test_exact_manifest_replaces_numel_completion_for_composed_loader(
+    monkeypatch,
+):
+    """An established event manifest, not copy_ numel, completes the layer."""
+    layer = _ComposedLoaderLayer()
+    model = torch.nn.Sequential(layer)
+    loaded = {
+        "A": torch.full((4,), 0.5),
+        "dt_bias": torch.full((4,), 3.0),
+        "D": torch.full((4,), 7.0),
+    }
+
+    # Establish the exact baseline through the same wrappers used by a normal
+    # checkpoint-backed first model load.
+    record_load_consumption(model)
+    for name in ("A", "dt_bias", "D"):
+        param = getattr(layer, name)
+        param.weight_loader(param, loaded[name])
+    finalize_load_recording(model)
+
+    record_metadata_for_reloading(model)
+    initialize_layerwise_reload(model)
+
+    # Recreate the pre-#44814 over-count. If numel still controlled completion,
+    # A + dt_bias would finalize the layer and D would remain uninitialized.
+    monkeypatch.setattr(
+        reload_layerwise,
+        "get_numel_loaded",
+        lambda loader, args: (
+            (
+                2 * args.arguments["param"].numel()
+                if args.arguments["param"] is layer.A
+                else args.arguments["param"].numel()
+            ),
+            loader(*args.args, **args.kwargs),
+        ),
+    )
+
+    params = dict(layer.named_parameters())
+    for name in ("A", "dt_bias", "D"):
+        param = params[name]
+        param.weight_loader(param, loaded[name])
+        if name == "dt_bias":
+            # Numel has already reached the old threshold, but the D event is
+            # still missing, so manifest-driven processing must remain active.
+            assert get_layerwise_info(layer).can_load()
+
+    finalize_layerwise_reload(model, model_config=None)
     assert torch.equal(layer.A, -torch.exp(loaded["A"]))
     assert torch.equal(layer.dt_bias, loaded["dt_bias"])
     assert torch.equal(layer.D, loaded["D"])

--- a/tests/model_executor/model_loader/test_reload_completion_set.py
+++ b/tests/model_executor/model_loader/test_reload_completion_set.py
@@ -9,8 +9,8 @@ from layer structure (`get_layer_size`, minus a hand-maintained
 required key set from the first load, reconcile against it on reload.
 
 Runs on CPU over the real reload machinery on synthetic layers -- no GPU, no
-checkpoint. Dual-run: numel stays authoritative; the set criterion records
-disagreements.
+checkpoint. These tests cover both the historical disagreement and the
+manifest-authoritative completion path that replaces copied-numel accounting.
 """
 
 import pytest
@@ -378,6 +378,35 @@ class TestDualRunCatchesDroppedKey:
             "layer.D=>D",
             "layer.dt_bias=>dt_bias",
         }
+
+    def test_dummy_target_manifest_replaces_numel_completion(self, monkeypatch):
+        m = _CountedModel()
+        record_metadata_for_reloading(m)
+        record_dummy_load_manifest(m)
+        initialize_layerwise_reload(m)
+
+        # Even a permanently zero diagnostic counter must not prevent target
+        # manifest completion during the first real transfer.
+        monkeypatch.setattr(
+            "vllm.model_executor.model_loader.reload.layerwise.get_numel_loaded",
+            lambda loader, args: (
+                0,
+                loader(*args.args, **args.kwargs),
+            ),
+        )
+        m.load_weights(observe_weight_sources([
+            ("layer.A", torch.ones(4)),
+            ("layer.D", torch.full((4,), 2.0)),
+            ("layer.dt_bias", torch.full((4,), 3.0)),
+        ]))
+
+        # A provisional target set cannot say how many QKV/MoE fragments map
+        # to one target, so the first source-bearing load remains buffered
+        # until transaction finalization.
+        assert get_layerwise_info(m.layer).can_load()
+        finalize_layerwise_reload(m, _Cfg())
+        assert torch.equal(m.layer.D, torch.full((4,), 2.0))
+        assert get_layerwise_info(m.layer).required_target_keys is None
 
     def test_checkpoint_backed_skip_tensor_receipt_can_arrive_last(self):
         """A skipped alias remains device-resident but is still load-required.

--- a/tests/model_executor/model_loader/test_reload_completion_set.py
+++ b/tests/model_executor/model_loader/test_reload_completion_set.py
@@ -18,6 +18,7 @@ import torch
 from torch import nn
 
 from vllm.model_executor.load_receipt import (
+    LoadCollisionPolicy,
     LoadReceipt,
     returns_load_receipt,
 )
@@ -55,6 +56,248 @@ def _named_param_loader(model, name_value_pairs):
 
 
 class TestObservation:
+
+    def test_receipt_audit_rejects_missing_qkv_fragment(self):
+        class Layer(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = nn.Parameter(torch.zeros(12))
+
+                def loader(param, loaded_weight, loaded_shard_id):
+                    offset = {"q": 0, "k": 4, "v": 8}[loaded_shard_id]
+                    param.data[offset:offset + 4].copy_(loaded_weight)
+                    # Deliberately incomplete: all three shards claim the
+                    # same packed target.
+                    return LoadReceipt.accepted()
+
+                self.weight.weight_loader = loader
+
+        layer = Layer()
+        model = nn.Sequential(layer)
+        record_load_consumption(model)
+        for source, shard in (("q.weight", "q"), ("k.weight", "k")):
+            for _, weight in observe_weight_sources(
+                [(source, torch.ones(4))]
+            ):
+                layer.weight.weight_loader(layer.weight, weight, shard)
+
+        with pytest.raises(
+            RuntimeError,
+            match=r"TARGET_ALIAS_COLLISION.*loaded_shard_id",
+        ):
+            finalize_load_recording(model)
+
+    def test_receipt_audit_accepts_complete_qkv_fragments(self):
+        class Layer(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = nn.Parameter(torch.zeros(12))
+
+                def loader(param, loaded_weight, loaded_shard_id):
+                    return LoadReceipt.accepted(
+                        loaded_shard_id=loaded_shard_id
+                    )
+
+                self.weight.weight_loader = loader
+
+        layer = Layer()
+        model = nn.Sequential(layer)
+        record_load_consumption(model)
+        for source, shard in (
+            ("q.weight", "q"),
+            ("k.weight", "k"),
+            ("v.weight", "v"),
+        ):
+            for _, weight in observe_weight_sources(
+                [(source, torch.ones(4))]
+            ):
+                layer.weight.weight_loader(layer.weight, weight, shard)
+        finalize_load_recording(model)
+
+    @pytest.mark.parametrize(
+        ("omitted_field", "first", "second"),
+        [
+            (
+                "shard_id",
+                ("expert.0.gate.weight", "w1", 0),
+                ("expert.0.up.weight", "w3", 0),
+            ),
+            (
+                "expert_id",
+                ("expert.0.gate.weight", "w1", 0),
+                ("expert.1.gate.weight", "w1", 1),
+            ),
+        ],
+    )
+    def test_receipt_audit_rejects_missing_moe_fragment(
+        self,
+        omitted_field,
+        first,
+        second,
+    ):
+        class Layer(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = nn.Parameter(torch.zeros(2, 2, 4))
+
+                def loader(param, loaded_weight, shard_id, expert_id):
+                    fragment = {
+                        "shard_id": shard_id,
+                        "expert_id": expert_id,
+                    }
+                    fragment.pop(omitted_field)
+                    return LoadReceipt.accepted(**fragment)
+
+                self.weight.weight_loader = loader
+
+        layer = Layer()
+        model = nn.Sequential(layer)
+        record_load_consumption(model)
+        for source, shard_id, expert_id in (first, second):
+            for _, weight in observe_weight_sources(
+                [(source, torch.ones(4))]
+            ):
+                layer.weight.weight_loader(
+                    layer.weight,
+                    weight,
+                    shard_id,
+                    expert_id,
+                )
+
+        with pytest.raises(
+            RuntimeError,
+            match=rf"TARGET_ALIAS_COLLISION.*{omitted_field}",
+        ):
+            finalize_load_recording(model)
+
+    def test_receipt_audit_allows_identical_duplicate_call(self):
+        class Layer(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = nn.Parameter(torch.zeros(4))
+
+                def loader(param, loaded_weight, shard_id):
+                    return LoadReceipt.accepted(shard_id=shard_id)
+
+                self.weight.weight_loader = loader
+
+        layer = Layer()
+        model = nn.Sequential(layer)
+        record_load_consumption(model)
+        for _, weight in observe_weight_sources(
+            [
+                ("weight", torch.ones(4)),
+                ("weight", torch.ones(4)),
+            ]
+        ):
+            layer.weight.weight_loader(layer.weight, weight, "w1")
+        finalize_load_recording(model)
+
+    def test_receipt_audit_rejects_status_conflict(self):
+        class Layer(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = nn.Parameter(torch.zeros(4))
+
+                def loader(param, loaded_weight, consume):
+                    receipt = (
+                        LoadReceipt.accepted
+                        if consume
+                        else LoadReceipt.skipped
+                    )
+                    return receipt(fragment=0)
+
+                self.weight.weight_loader = loader
+
+        layer = Layer()
+        model = nn.Sequential(layer)
+        record_load_consumption(model)
+        for consume in (True, False):
+            for _, weight in observe_weight_sources(
+                [("weight", torch.ones(4))]
+            ):
+                layer.weight.weight_loader(layer.weight, weight, consume)
+
+        with pytest.raises(RuntimeError, match="STATUS_CONFLICT"):
+            finalize_load_recording(model)
+
+    def test_receipt_audit_rejects_schema_drift(self):
+        class Layer(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = nn.Parameter(torch.zeros(4))
+
+                def loader(param, loaded_weight, mode):
+                    if mode == "a":
+                        return LoadReceipt.accepted(first=0)
+                    return LoadReceipt.accepted(second=0)
+
+                self.weight.weight_loader = loader
+
+        layer = Layer()
+        model = nn.Sequential(layer)
+        record_load_consumption(model)
+        for mode in ("a", "b"):
+            for _, weight in observe_weight_sources(
+                [(f"{mode}.weight", torch.ones(4))]
+            ):
+                layer.weight.weight_loader(layer.weight, weight, mode)
+
+        with pytest.raises(RuntimeError, match="SCHEMA_DRIFT"):
+            finalize_load_recording(model)
+
+    def test_receipt_audit_checks_declared_schema(self):
+        class Layer(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = nn.Parameter(torch.zeros(4))
+
+                @returns_load_receipt("shard_id")
+                def loader(param, loaded_weight, shard_id):
+                    return LoadReceipt.accepted()
+
+                self.weight.weight_loader = loader
+
+        layer = Layer()
+        model = nn.Sequential(layer)
+        record_load_consumption(model)
+        for _, weight in observe_weight_sources(
+            [("weight", torch.ones(4))]
+        ):
+            layer.weight.weight_loader(layer.weight, weight, "w1")
+
+        with pytest.raises(
+            RuntimeError,
+            match="RECEIPT_SCHEMA_MISMATCH",
+        ):
+            finalize_load_recording(model)
+
+    def test_receipt_audit_allows_explicit_overwrite(self):
+        class Layer(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = nn.Parameter(torch.zeros(4))
+
+                def loader(param, loaded_weight, source_slot):
+                    return LoadReceipt.accepted(
+                        collision_policy=LoadCollisionPolicy.OVERWRITE
+                    )
+
+                self.weight.weight_loader = loader
+
+        layer = Layer()
+        model = nn.Sequential(layer)
+        record_load_consumption(model)
+        for source_slot in (0, 1):
+            for _, weight in observe_weight_sources(
+                [(f"source.{source_slot}", torch.ones(4))]
+            ):
+                layer.weight.weight_loader(
+                    layer.weight,
+                    weight,
+                    source_slot,
+                )
+        finalize_load_recording(model)
 
     def test_receipt_adapter_handles_conditional_loader(self):
         @returns_load_receipt("shard_id", "expert_id")
@@ -412,6 +655,51 @@ class _CountedModel(nn.Module):
 
 
 class TestDualRunCatchesDroppedKey:
+
+    def test_reload_reports_receipt_target_collision(self):
+        class Layer(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = nn.Parameter(torch.zeros(8))
+                self.incomplete_receipt = False
+
+                def loader(param, loaded_weight, loaded_shard_id):
+                    offset = 0 if loaded_shard_id == "q" else 4
+                    param.data[offset:offset + 4].copy_(loaded_weight)
+                    if self.incomplete_receipt:
+                        return LoadReceipt.accepted()
+                    return LoadReceipt.accepted(
+                        loaded_shard_id=loaded_shard_id
+                    )
+
+                self.weight.weight_loader = loader
+
+        layer = Layer()
+        model = nn.Sequential(layer)
+        record_metadata_for_reloading(model)
+        record_load_consumption(model)
+        for source, shard in (("q.weight", "q"), ("k.weight", "k")):
+            for _, weight in observe_weight_sources(
+                [(source, torch.ones(4))]
+            ):
+                layer.weight.weight_loader(layer.weight, weight, shard)
+        finalize_load_recording(model)
+
+        layer.incomplete_receipt = True
+        initialize_layerwise_reload(model)
+        for source, shard in (("q.weight", "q"), ("k.weight", "k")):
+            for _, weight in observe_weight_sources(
+                [(source, torch.ones(4))]
+            ):
+                layer.weight.weight_loader(layer.weight, weight, shard)
+        finalize_layerwise_reload(model, _Cfg())
+
+        findings = get_layer_completion_findings()
+        assert any(
+            "TARGET_ALIAS_COLLISION" in finding
+            and "loaded_shard_id" in finding
+            for finding in findings
+        )
 
     def test_dummy_manifest_validates_first_real_transfer(self):
         """Dummy initialization must not leave the first RL transfer unchecked."""

--- a/tests/model_executor/model_loader/test_reload_completion_set.py
+++ b/tests/model_executor/model_loader/test_reload_completion_set.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Observe-not-predict completion accounting (COMPLETION.md).
+
+The reload completion criterion (`load_numel >= load_numel_total`) produced
+#44814/#37334/#38746. The root cause is that the expected side is predicted
+from layer structure (`get_layer_size`, minus a hand-maintained
+`SKIP_TENSORS` allowlist). This exercises the alternative: observe the
+required key set from the first load, reconcile against it on reload.
+
+Runs on CPU over the real reload machinery on synthetic layers -- no GPU, no
+checkpoint. Dual-run: numel stays authoritative; the set criterion records
+disagreements.
+"""
+
+import torch
+from torch import nn
+
+from vllm.model_executor.layers.quantization.base_config import (
+    QuantizeMethodBase)
+from vllm.model_executor.model_loader.reload.layerwise import (
+    finalize_layerwise_reload, finalize_load_recording,
+    get_layer_completion_findings, get_layerwise_info,
+    initialize_layerwise_reload, record_load_consumption,
+    record_metadata_for_reloading)
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+
+
+class _Cfg:
+    model = "synthetic"
+    dtype = torch.float32
+
+
+def _named_param_loader(model, name_value_pairs):
+    """Load via each param's own weight_loader, honoring the observation
+    wrappers installed by record_load_consumption."""
+    params = dict(model.named_parameters())
+    loaded = set()
+    for name, w in name_value_pairs:
+        p = params[name]
+        getattr(p, "weight_loader", default_weight_loader)(p, w)
+        loaded.add(name)
+    return loaded
+
+
+class TestObservation:
+
+    def test_required_excludes_never_loaded_buffer(self):
+        """A buffer that is set directly (never through a loader) -- the
+        _expert_map / e_score_correction_bias shape -- is absent from the
+        observed required set, with no SKIP_TENSORS consulted."""
+
+        class Layer(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = nn.Parameter(torch.zeros(4))
+                # bookkeeping: exists, but no weight_loader, never loaded
+                self.register_buffer("expert_map", torch.zeros(4),
+                                     persistent=False)
+
+        class M(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layer = Layer()
+
+            def load_weights(self, weights):
+                return _named_param_loader(self, weights)
+
+        m = M()
+        record_load_consumption(m)
+        m.load_weights([("layer.weight", torch.ones(4))])
+        finalize_load_recording(m)
+
+        req = get_layerwise_info(m.layer).required_keys
+        assert req == {"weight"}, req          # expert_map NOT in it
+        # and the recording wrappers were removed
+        assert not getattr(m.layer.weight.weight_loader, "_vllm_recording",
+                           False)
+
+    def test_required_survives_reset(self):
+        """The observed baseline must persist across reloads, like
+        restore_metadata."""
+
+        class M(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layer = nn.Linear(4, 4)
+
+            def load_weights(self, weights):
+                return _named_param_loader(self, weights)
+
+        m = M()
+        record_load_consumption(m)
+        m.load_weights([("layer.weight", torch.ones(4, 4)),
+                        ("layer.bias", torch.ones(4))])
+        finalize_load_recording(m)
+        info = get_layerwise_info(m.layer)
+        baseline = set(info.required_keys)
+        assert baseline == {"weight", "bias"}
+
+        info.reset()
+        assert info.required_keys == baseline      # survived
+        assert info.received_keys == set()         # cleared
+
+
+class _CountedLayer(nn.Module):
+    """A layer whose composed loader copies twice into one param -- the
+    #44814 shape, where numel double-counts and can reach the total before a
+    later param arrives."""
+
+    def __init__(self):
+        super().__init__()
+        self.A = nn.Parameter(torch.zeros(4))
+        self.D = nn.Parameter(torch.zeros(4))
+        self.dt_bias = nn.Parameter(torch.zeros(4))
+
+        def composed(param, w):        # copies twice: numel counts 2x
+            param.data.copy_(w)
+            param.data.copy_(-torch.exp(w.float()))
+
+        self.A.weight_loader = composed
+
+    class _QM(QuantizeMethodBase):
+        def create_weights(self, *a, **k):
+            pass
+
+        def apply(self, *a, **k):
+            pass
+
+        def process_weights_after_loading(self, layer):
+            pass
+
+    @property
+    def quant_method(self):
+        return _CountedLayer._QM()
+
+
+class _CountedModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layer = _CountedLayer()
+
+    def load_weights(self, weights):
+        return _named_param_loader(self, weights)
+
+
+class TestDualRunCatchesDroppedKey:
+
+    def test_set_criterion_flags_the_44814_shape(self):
+        """First load consumes A, D, dt_bias. On reload, if only A and
+        dt_bias arrive, numel (2n from A's double copy + n from dt_bias = 3n
+        == total) says complete, but the observed set requires D -- the set
+        criterion records the disagreement."""
+        m = _CountedModel()
+        # observe the correct baseline: all three loaded
+        record_load_consumption(m)
+        m.load_weights([("layer.A", torch.ones(4)),
+                        ("layer.D", torch.ones(4)),
+                        ("layer.dt_bias", torch.ones(4))])
+        finalize_load_recording(m)
+        assert get_layerwise_info(m.layer).required_keys == {
+            "A", "D", "dt_bias"}
+
+        # reload dropping D (arrives after premature numel completion)
+        record_metadata_for_reloading(m)
+        initialize_layerwise_reload(m)
+        m.load_weights([("layer.A", torch.ones(4)),
+                        ("layer.dt_bias", torch.ones(4))])
+        finalize_layerwise_reload(m, _Cfg())
+
+        findings = get_layer_completion_findings()
+        assert findings, "set criterion missed the dropped key that numel let through"
+        assert any("D" in f for f in findings)
+
+    def test_clean_reload_no_disagreement(self):
+        m = _CountedModel()
+        record_load_consumption(m)
+        m.load_weights([("layer.A", torch.ones(4)),
+                        ("layer.D", torch.ones(4)),
+                        ("layer.dt_bias", torch.ones(4))])
+        finalize_load_recording(m)
+
+        record_metadata_for_reloading(m)
+        initialize_layerwise_reload(m)
+        m.load_weights([("layer.A", torch.ones(4)),
+                        ("layer.D", torch.ones(4)),
+                        ("layer.dt_bias", torch.ones(4))])
+        finalize_layerwise_reload(m, _Cfg())
+        assert get_layer_completion_findings() == []
+
+    def test_no_baseline_means_no_dual_run(self):
+        """Without a first-load observation (required_keys is None), the
+        dual-run is silent rather than guessing."""
+        m = _CountedModel()   # no record_load_consumption
+        record_metadata_for_reloading(m)
+        initialize_layerwise_reload(m)
+        m.load_weights([("layer.A", torch.ones(4)),
+                        ("layer.dt_bias", torch.ones(4))])
+        finalize_layerwise_reload(m, _Cfg())
+        assert get_layer_completion_findings() == []

--- a/tests/model_executor/model_loader/test_reload_completion_set.py
+++ b/tests/model_executor/model_loader/test_reload_completion_set.py
@@ -17,6 +17,10 @@ import pytest
 import torch
 from torch import nn
 
+from vllm.model_executor.load_receipt import (
+    LoadReceipt,
+    returns_load_receipt,
+)
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizeMethodBase)
 from vllm.model_executor.model_loader.reload.layerwise import (
@@ -27,7 +31,10 @@ from vllm.model_executor.model_loader.reload.layerwise import (
     record_direct_load_consumption, record_dummy_load_manifest,
     record_metadata_for_reloading)
 from vllm.model_executor.model_loader.reload.source import observe_weight_sources
-from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.model_loader.weight_utils import (
+    composed_weight_loader,
+    default_weight_loader,
+)
 
 
 class _Cfg:
@@ -48,6 +55,62 @@ def _named_param_loader(model, name_value_pairs):
 
 
 class TestObservation:
+
+    def test_receipt_adapter_handles_conditional_loader(self):
+        @returns_load_receipt("shard_id", "expert_id")
+        def loader(param, loaded_weight, shard_id, expert_id,
+                   return_success=False):
+            return expert_id == 0 if return_success else None
+
+        accepted = loader(None, None, "w1", 0, return_success=True)
+        skipped = loader(None, None, "w1", 1, return_success=True)
+        assert isinstance(accepted, LoadReceipt)
+        assert accepted.consumed
+        assert accepted.fragment.format() == "shard_id='w1',expert_id=0"
+        assert not skipped
+
+    def test_composed_loader_preserves_receipt(self):
+        def base_loader(param, loaded_weight):
+            param.data.copy_(loaded_weight)
+            return LoadReceipt.accepted(transform="source")
+
+        loader = composed_weight_loader(base_loader, lambda value: -value)
+        param = nn.Parameter(torch.zeros(4))
+        receipt = loader(param, torch.ones(4))
+        assert receipt == LoadReceipt.accepted(transform="source")
+        assert torch.equal(param, -torch.ones(4))
+
+    def test_structured_receipt_defines_fragment_schema(self):
+        class Layer(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = nn.Parameter(torch.zeros(4))
+
+                def loader(param, loaded_weight, opaque_partition):
+                    param.data.copy_(loaded_weight)
+                    return LoadReceipt.accepted(
+                        partition=opaque_partition,
+                        layout="custom",
+                    )
+
+                self.weight.weight_loader = loader
+
+        layer = Layer()
+        model = nn.Sequential(layer)
+        record_load_consumption(model)
+        for _, weight in observe_weight_sources(
+            [("checkpoint.weight", torch.ones(4))]
+        ):
+            layer.weight.weight_loader(
+                layer.weight,
+                weight,
+                opaque_partition=7,
+            )
+        finalize_load_recording(model)
+
+        assert get_layerwise_info(layer).required_keys == {
+            "checkpoint.weight=>weight[partition=7,layout='custom']"
+        }
 
     def test_direct_write_loader_records_source_and_target(self):
         model = nn.Sequential(nn.Linear(4, 4, bias=False))
@@ -125,7 +188,11 @@ class TestObservation:
                                   expert_id, return_success=False):
                     shard_idx = {"w1": 0, "w2": 1, "w3": 2}[shard_id]
                     param.data[expert_id, shard_idx].copy_(loaded_weight)
-                    return True if return_success else None
+                    return LoadReceipt.accepted(
+                        shard_id=shard_id,
+                        expert_id=expert_id,
+                        weight_name=weight_name,
+                    )
 
                 self.packed.weight_loader = expert_loader
 
@@ -161,7 +228,16 @@ class TestObservation:
                     success = expert_id == 0
                     if success:
                         param.data.copy_(loaded_weight)
-                    return success if return_success else None
+                    receipt = (
+                        LoadReceipt.accepted
+                        if success
+                        else LoadReceipt.skipped
+                    )
+                    return receipt(
+                        shard_id=shard_id,
+                        expert_id=expert_id,
+                        weight_name=weight_name,
+                    )
 
                 self.packed.weight_loader = expert_loader
 
@@ -195,6 +271,9 @@ class TestObservation:
                 def qkv_loader(param, loaded_weight, loaded_shard_id):
                     offset = {"q": 0, "k": 4, "v": 8}[loaded_shard_id]
                     param.data[offset:offset + 4].copy_(loaded_weight)
+                    return LoadReceipt.accepted(
+                        loaded_shard_id=loaded_shard_id
+                    )
 
                 self.weight.weight_loader = qkv_loader
 
@@ -304,6 +383,7 @@ class _CountedLayer(nn.Module):
         def composed(param, w):        # copies twice: numel counts 2x
             param.data.copy_(w)
             param.data.copy_(-torch.exp(w.float()))
+            return LoadReceipt.accepted()
 
         self.A.weight_loader = composed
 

--- a/tests/model_executor/model_loader/test_reload_completion_set.py
+++ b/tests/model_executor/model_loader/test_reload_completion_set.py
@@ -13,6 +13,7 @@ checkpoint. Dual-run: numel stays authoritative; the set criterion records
 disagreements.
 """
 
+import pytest
 import torch
 from torch import nn
 
@@ -21,8 +22,11 @@ from vllm.model_executor.layers.quantization.base_config import (
 from vllm.model_executor.model_loader.reload.layerwise import (
     finalize_layerwise_reload, finalize_load_recording,
     get_layer_completion_findings, get_layerwise_info,
+    get_load_manifest_report,
     initialize_layerwise_reload, record_load_consumption,
+    record_direct_load_consumption, record_dummy_load_manifest,
     record_metadata_for_reloading)
+from vllm.model_executor.model_loader.reload.source import observe_weight_sources
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 
 
@@ -44,6 +48,13 @@ def _named_param_loader(model, name_value_pairs):
 
 
 class TestObservation:
+
+    def test_direct_write_loader_records_source_and_target(self):
+        model = nn.Sequential(nn.Linear(4, 4, bias=False))
+        record_direct_load_consumption(model, "0.weight", "rank0.weight")
+        assert get_layerwise_info(model[0]).required_keys == {
+            "rank0.weight=>weight"
+        }
 
     def test_required_excludes_never_loaded_buffer(self):
         """A buffer that is set directly (never through a loader) -- the
@@ -102,6 +113,182 @@ class TestObservation:
         assert info.required_keys == baseline      # survived
         assert info.received_keys == set()         # cleared
 
+    def test_packed_expert_calls_are_distinct_events(self):
+        """One packed destination still has one event per expert/shard call."""
+
+        class Layer(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.packed = nn.Parameter(torch.zeros(2, 3, 4))
+
+                def expert_loader(param, loaded_weight, weight_name, shard_id,
+                                  expert_id, return_success=False):
+                    shard_idx = {"w1": 0, "w2": 1, "w3": 2}[shard_id]
+                    param.data[expert_id, shard_idx].copy_(loaded_weight)
+                    return True if return_success else None
+
+                self.packed.weight_loader = expert_loader
+
+        layer = Layer()
+        model = nn.Sequential(layer)
+        record_load_consumption(model)
+        for expert_id in range(2):
+            for shard_id in ("w1", "w2", "w3"):
+                layer.packed.weight_loader(
+                    layer.packed,
+                    torch.ones(4),
+                    weight_name=f"experts.{expert_id}.{shard_id}.weight",
+                    shard_id=shard_id,
+                    expert_id=expert_id,
+                    return_success=True,
+                )
+        finalize_load_recording(model)
+
+        required = get_layerwise_info(layer).required_keys
+        assert required is not None
+        assert len(required) == 6
+        assert any("expert_id=1" in event and "shard_id='w3'" in event
+                   for event in required)
+
+    def test_non_local_expert_is_not_required(self):
+        class Layer(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.packed = nn.Parameter(torch.zeros(4))
+
+                def expert_loader(param, loaded_weight, weight_name, shard_id,
+                                  expert_id, return_success=False):
+                    success = expert_id == 0
+                    if success:
+                        param.data.copy_(loaded_weight)
+                    return success if return_success else None
+
+                self.packed.weight_loader = expert_loader
+
+        layer = Layer()
+        model = nn.Sequential(layer)
+        record_load_consumption(model)
+        for expert_id in (0, 1):
+            layer.packed.weight_loader(
+                layer.packed,
+                torch.ones(4),
+                weight_name=f"experts.{expert_id}.w1.weight",
+                shard_id="w1",
+                expert_id=expert_id,
+                return_success=True,
+            )
+        finalize_load_recording(model)
+
+        required = get_layerwise_info(layer).required_keys
+        assert required is not None
+        assert len(required) == 1
+        assert "expert_id=0" in next(iter(required))
+
+    def test_source_keys_survive_qkv_routing(self):
+        """The original checkpoint keys remain attached after q/k/v merge."""
+
+        class Layer(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = nn.Parameter(torch.zeros(12, 4))
+
+                def qkv_loader(param, loaded_weight, loaded_shard_id):
+                    offset = {"q": 0, "k": 4, "v": 8}[loaded_shard_id]
+                    param.data[offset:offset + 4].copy_(loaded_weight)
+
+                self.weight.weight_loader = qkv_loader
+
+        layer = Layer()
+        model = nn.Sequential(layer)
+        source_weights = [
+            ("model.layers.0.self_attn.q_proj.weight", torch.ones(4, 4)),
+            ("model.layers.0.self_attn.k_proj.weight", torch.ones(4, 4)),
+            ("model.layers.0.self_attn.v_proj.weight", torch.ones(4, 4)),
+        ]
+
+        record_load_consumption(model)
+        for (source_key, loaded_weight), shard_id in zip(
+                observe_weight_sources(source_weights), ("q", "k", "v")):
+            # Stand in for a model-specific mapper/routing layer. The source
+            # context must remain the pre-mapping checkpoint key.
+            layer.weight.weight_loader(
+                layer.weight, loaded_weight, loaded_shard_id=shard_id)
+        finalize_load_recording(model)
+
+        required = get_layerwise_info(layer).required_keys
+        assert required == {
+            "model.layers.0.self_attn.q_proj.weight"
+            "=>weight[loaded_shard_id='q']",
+            "model.layers.0.self_attn.k_proj.weight"
+            "=>weight[loaded_shard_id='k']",
+            "model.layers.0.self_attn.v_proj.weight"
+            "=>weight[loaded_shard_id='v']",
+        }
+
+    def test_source_keys_cover_one_to_one_and_merged_mlp(self):
+        class Layer(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.norm = nn.Parameter(torch.zeros(4))
+                self.gate_up = nn.Parameter(torch.zeros(8, 4))
+
+                def merged_loader(param, loaded_weight, loaded_shard_id):
+                    offset = 0 if loaded_shard_id == 0 else 4
+                    param.data[offset:offset + 4].copy_(loaded_weight)
+
+                self.gate_up.weight_loader = merged_loader
+
+        layer = Layer()
+        model = nn.Sequential(layer)
+        record_load_consumption(model)
+        weights = observe_weight_sources([
+            ("input_layernorm.weight", torch.ones(4)),
+            ("mlp.gate_proj.weight", torch.ones(4, 4)),
+            ("mlp.up_proj.weight", torch.ones(4, 4)),
+        ])
+        _, norm = next(weights)
+        layer.norm.weight_loader(layer.norm, norm)
+        _, gate = next(weights)
+        layer.gate_up.weight_loader(
+            layer.gate_up, gate, loaded_shard_id=0)
+        _, up = next(weights)
+        layer.gate_up.weight_loader(
+            layer.gate_up, up, loaded_shard_id=1)
+        finalize_load_recording(model)
+
+        assert get_layerwise_info(layer).required_keys == {
+            "input_layernorm.weight=>norm",
+            "mlp.gate_proj.weight=>gate_up[loaded_shard_id=0]",
+            "mlp.up_proj.weight=>gate_up[loaded_shard_id=1]",
+        }
+
+    def test_one_fused_source_can_emit_multiple_target_fragments(self):
+        class Layer(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.packed = nn.Parameter(torch.zeros(2, 4))
+
+                def shard_loader(param, loaded_weight, loaded_shard_id):
+                    param.data[loaded_shard_id].copy_(loaded_weight)
+
+                self.packed.weight_loader = shard_loader
+
+        layer = Layer()
+        model = nn.Sequential(layer)
+        record_load_consumption(model)
+        for _, fused in observe_weight_sources([
+                ("mlp.gate_up_proj.weight", torch.ones(2, 4))]):
+            layer.packed.weight_loader(
+                layer.packed, fused[0], loaded_shard_id=0)
+            layer.packed.weight_loader(
+                layer.packed, fused[1], loaded_shard_id=1)
+        finalize_load_recording(model)
+
+        assert get_layerwise_info(layer).required_keys == {
+            "mlp.gate_up_proj.weight=>packed[loaded_shard_id=0]",
+            "mlp.gate_up_proj.weight=>packed[loaded_shard_id=1]",
+        }
+
 
 class _CountedLayer(nn.Module):
     """A layer whose composed loader copies twice into one param -- the
@@ -146,6 +333,99 @@ class _CountedModel(nn.Module):
 
 class TestDualRunCatchesDroppedKey:
 
+    def test_dummy_manifest_validates_first_real_transfer(self):
+        """Dummy initialization must not leave the first RL transfer unchecked."""
+        m = _CountedModel()
+        record_metadata_for_reloading(m)
+        record_dummy_load_manifest(m)
+        info = get_layerwise_info(m.layer)
+        assert info.required_target_keys == {"A", "D", "dt_bias"}
+        assert info.required_keys == set()
+
+        initialize_layerwise_reload(m)
+        # The old numel counter reaches its total because A's composed loader
+        # counts twice, but the dummy target baseline still requires D.
+        m.load_weights(observe_weight_sources([
+            ("layer.A", torch.ones(4)),
+            ("layer.dt_bias", torch.ones(4)),
+        ]))
+        with pytest.raises(RuntimeError, match="after dummy initialization"):
+            finalize_layerwise_reload(m, _Cfg())
+
+        findings = get_layer_completion_findings()
+        assert any("dummy-baseline" in finding and "D" in finding
+                   for finding in findings)
+        assert info.required_target_keys == {"A", "D", "dt_bias"}
+
+    def test_dummy_manifest_promotes_first_complete_real_transfer(self):
+        m = _CountedModel()
+        record_metadata_for_reloading(m)
+        record_dummy_load_manifest(m)
+
+        initialize_layerwise_reload(m)
+        m.load_weights(observe_weight_sources([
+            ("layer.A", torch.ones(4)),
+            ("layer.D", torch.ones(4)),
+            ("layer.dt_bias", torch.ones(4)),
+        ]))
+        finalize_layerwise_reload(m, _Cfg())
+
+        info = get_layerwise_info(m.layer)
+        assert get_layer_completion_findings() == []
+        assert info.required_target_keys is None
+        assert info.required_keys == {
+            "layer.A=>A",
+            "layer.D=>D",
+            "layer.dt_bias=>dt_bias",
+        }
+
+    def test_checkpoint_backed_skip_tensor_receipt_can_arrive_last(self):
+        """A skipped alias remains device-resident but is still load-required.
+
+        DeepSeek's gate.e_score_correction_bias has this shape: the ordinary
+        gate weight can trigger numel completion before the correction bias
+        appears later in the checkpoint stream.
+        """
+
+        class Gate(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = nn.Parameter(torch.zeros(4, 4))
+                self.e_score_correction_bias = nn.Parameter(torch.zeros(4))
+
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.gate = Gate()
+
+            def load_weights(self, weights):
+                return _named_param_loader(self, weights)
+
+        m = Model()
+        first = [
+            ("gate.weight", torch.ones(4, 4)),
+            ("gate.e_score_correction_bias", torch.arange(4.0)),
+        ]
+        record_load_consumption(m)
+        m.load_weights(first)
+        finalize_load_recording(m)
+        assert get_layerwise_info(m.gate).required_keys == {
+            "weight",
+            "e_score_correction_bias",
+        }
+
+        record_metadata_for_reloading(m)
+        initialize_layerwise_reload(m)
+        # Deliberately place the skipped tensor after numel completion.
+        m.load_weights(first)
+        finalize_layerwise_reload(m, _Cfg())
+
+        assert get_layer_completion_findings() == []
+        torch.testing.assert_close(
+            m.gate.e_score_correction_bias, torch.arange(4.0))
+        assert m.gate.e_score_correction_bias.weight_loader.__name__ == (
+            "default_weight_loader")
+
     def test_set_criterion_flags_the_44814_shape(self):
         """First load consumes A, D, dt_bias. On reload, if only A and
         dt_bias arrive, numel (2n from A's double copy + n from dt_bias = 3n
@@ -187,6 +467,13 @@ class TestDualRunCatchesDroppedKey:
                         ("layer.dt_bias", torch.ones(4))])
         finalize_layerwise_reload(m, _Cfg())
         assert get_layer_completion_findings() == []
+        report = get_load_manifest_report(m)
+        assert report.ok
+        assert report.required_event_count == 3
+        assert report.received_event_count == 3
+        # CPU tests do not initialize model-parallel groups. Reporting remains
+        # usable and clearly marks the coordinates as unavailable.
+        assert report.scope.global_rank is None
 
     def test_no_baseline_means_no_dual_run(self):
         """Without a first-load observation (required_keys is None), the

--- a/tests/model_executor/model_loader/test_reload_completion_set.py
+++ b/tests/model_executor/model_loader/test_reload_completion_set.py
@@ -17,20 +17,24 @@ import pytest
 import torch
 from torch import nn
 
+from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
 from vllm.model_executor.load_receipt import (
     LoadCollisionPolicy,
     LoadReceipt,
     returns_load_receipt,
 )
-from vllm.model_executor.layers.quantization.base_config import (
-    QuantizeMethodBase)
 from vllm.model_executor.model_loader.reload.layerwise import (
-    finalize_layerwise_reload, finalize_load_recording,
-    get_layer_completion_findings, get_layerwise_info,
+    finalize_layerwise_reload,
+    finalize_load_recording,
+    get_layer_completion_findings,
+    get_layerwise_info,
     get_load_manifest_report,
-    initialize_layerwise_reload, record_load_consumption,
-    record_direct_load_consumption, record_dummy_load_manifest,
-    record_metadata_for_reloading)
+    initialize_layerwise_reload,
+    record_direct_load_consumption,
+    record_dummy_load_manifest,
+    record_load_consumption,
+    record_metadata_for_reloading,
+)
 from vllm.model_executor.model_loader.reload.source import observe_weight_sources
 from vllm.model_executor.model_loader.weight_utils import (
     composed_weight_loader,
@@ -539,12 +543,18 @@ class TestObservation:
 
         required = get_layerwise_info(layer).required_keys
         assert required == {
-            "model.layers.0.self_attn.q_proj.weight"
-            "=>weight[loaded_shard_id='q']",
-            "model.layers.0.self_attn.k_proj.weight"
-            "=>weight[loaded_shard_id='k']",
-            "model.layers.0.self_attn.v_proj.weight"
-            "=>weight[loaded_shard_id='v']",
+            (
+                "model.layers.0.self_attn.q_proj.weight"
+                "=>weight[loaded_shard_id='q']"
+            ),
+            (
+                "model.layers.0.self_attn.k_proj.weight"
+                "=>weight[loaded_shard_id='k']"
+            ),
+            (
+                "model.layers.0.self_attn.v_proj.weight"
+                "=>weight[loaded_shard_id='v']"
+            ),
         }
 
     def test_source_keys_cover_one_to_one_and_merged_mlp(self):

--- a/tests/model_executor/model_loader/test_update_scope.py
+++ b/tests/model_executor/model_loader/test_update_scope.py
@@ -10,6 +10,13 @@ from vllm.lora.update import (
     config_digest,
     validate_complete_lora_weights,
 )
+from vllm.model_executor.model_loader.reload.baseline import (
+    WeightUpdateBaselineEvent,
+    WeightUpdateBaselineGroup,
+    WeightUpdateBaselineReport,
+    aggregate_weight_update_baselines,
+    get_weight_update_baseline,
+)
 from vllm.model_executor.model_loader.reload.layerwise import (
     finalize_layerwise_reload,
     finalize_load_recording,
@@ -25,6 +32,7 @@ from vllm.model_executor.model_loader.reload.scope import (
     normalize_update_scope,
 )
 from vllm.model_executor.model_loader.reload.source import observe_weight_sources
+from vllm.model_executor.model_loader.reload.types import LoadManifestScope
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 
 pytestmark = pytest.mark.skip_global_cleanup
@@ -124,6 +132,99 @@ def test_partial_scope_rejects_split_processing_unit_before_mutation() -> None:
 
     assert model.layer.left is left_before
     assert not model.layer.left.is_meta
+
+
+def test_weight_update_baseline_exposes_atomic_source_groups() -> None:
+    model = nn.Module()
+    model.layer = _WeightLayer(("left", "right"))
+
+    def load(weights):
+        for source_name, weight in weights:
+            parameter = getattr(model.layer, source_name.rsplit(".", 1)[-1])
+            parameter.weight_loader(parameter, weight)
+
+    record_metadata_for_reloading(model)
+    record_load_consumption(model)
+    load(
+        observe_weight_sources(
+            [
+                ("checkpoint.left", torch.ones(2)),
+                ("checkpoint.right", torch.ones(2)),
+            ]
+        )
+    )
+    finalize_load_recording(model)
+
+    report = get_weight_update_baseline(model)
+    assert report.state == "exact"
+    assert len(report.groups) == 1
+    assert report.groups[0].module_name == "layer"
+    assert report.groups[0].source_names == (
+        "checkpoint.left",
+        "checkpoint.right",
+    )
+    assert {event.target_name for event in report.groups[0].events} == {
+        "layer.left",
+        "layer.right",
+    }
+
+
+def test_weight_update_baseline_merges_cross_rank_closure_constraints() -> None:
+    def report(*groups: tuple[str, ...]) -> WeightUpdateBaselineReport:
+        return WeightUpdateBaselineReport(
+            scope=LoadManifestScope(),
+            state="exact",
+            groups=tuple(
+                WeightUpdateBaselineGroup(
+                    module_name=f"layer.{index}",
+                    events=tuple(
+                        WeightUpdateBaselineEvent(name, name, ()) for name in names
+                    ),
+                )
+                for index, names in enumerate(groups)
+            ),
+        )
+
+    baseline = aggregate_weight_update_baselines(
+        [
+            report(("q", "k"), ("mlp",)),
+            report(("k", "v"), ("expert.3",)),
+        ]
+    )
+
+    assert baseline["ready"] is True
+    assert baseline["atomic_source_groups"] == [
+        ["expert.3"],
+        ["k", "q", "v"],
+        ["mlp"],
+    ]
+    assert baseline["scope_template"] == {
+        "kind": "base_checkpoint",
+        "mode": "partial",
+        "source_names": [],
+    }
+    assert baseline["atomic_update_scopes"][1]["source_names"] == [
+        "k",
+        "q",
+        "v",
+    ]
+
+
+def test_weight_update_baseline_reports_dummy_target_baseline() -> None:
+    model = _ScopedModel()
+    record_metadata_for_reloading(model)
+    from vllm.model_executor.model_loader.reload.layerwise import (
+        record_dummy_load_manifest,
+    )
+
+    record_dummy_load_manifest(model)
+    report = get_weight_update_baseline(model)
+    baseline = aggregate_weight_update_baselines([report])
+
+    assert report.state == "provisional"
+    assert baseline["ready"] is False
+    assert "first.weight" in report.provisional_target_names
+    assert "complete real base-weight update" in baseline["reason"]
 
 
 def test_scope_normalization_rejects_duplicates() -> None:

--- a/tests/model_executor/model_loader/test_update_scope.py
+++ b/tests/model_executor/model_loader/test_update_scope.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+from torch import nn
+
+from vllm.lora.update import (
+    TensorLoRAUpdateSession,
+    config_digest,
+    validate_complete_lora_weights,
+)
+from vllm.model_executor.model_loader.reload.layerwise import (
+    finalize_layerwise_reload,
+    finalize_load_recording,
+    get_layer_completion_findings,
+    get_layerwise_info,
+    initialize_layerwise_reload,
+    record_load_consumption,
+    record_metadata_for_reloading,
+)
+from vllm.model_executor.model_loader.reload.scope import (
+    LoRAAdapterScope,
+    PartialBaseWeightScope,
+    normalize_update_scope,
+)
+from vllm.model_executor.model_loader.reload.source import observe_weight_sources
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+class _Cfg:
+    dtype = torch.float32
+
+
+class _WeightLayer(nn.Module):
+    def __init__(self, names: tuple[str, ...]) -> None:
+        super().__init__()
+        for name in names:
+            parameter = nn.Parameter(torch.zeros(2), requires_grad=False)
+            parameter.weight_loader = default_weight_loader
+            self.register_parameter(name, parameter)
+
+
+class _ScopedModel(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.first = _WeightLayer(("weight",))
+        self.second = _WeightLayer(("weight",))
+
+    def load_weights(self, weights):
+        loaded = set()
+        for source_name, weight in weights:
+            module_name, parameter_name = source_name.split(".")
+            parameter = getattr(getattr(self, module_name), parameter_name)
+            parameter.weight_loader(parameter, weight)
+            loaded.add(source_name)
+        return loaded
+
+
+def _record_baseline(model: nn.Module, names: tuple[str, ...]) -> None:
+    record_metadata_for_reloading(model)
+    record_load_consumption(model)
+    model.load_weights(
+        observe_weight_sources(
+            (name, torch.ones(2)) for name in names
+        )
+    )
+    finalize_load_recording(model)
+
+
+def test_partial_scope_initializes_only_selected_layers() -> None:
+    model = _ScopedModel()
+    _record_baseline(model, ("first.weight", "second.weight"))
+    second_before = model.second.weight
+
+    scope = PartialBaseWeightScope(("first.weight",))
+    initialize_layerwise_reload(model, scope)
+
+    assert get_layerwise_info(model.first).can_load()
+    assert not get_layerwise_info(model.second).can_load()
+    assert model.second.weight is second_before
+
+    model.load_weights(
+        observe_weight_sources(
+            [("first.weight", torch.full((2,), 3.0))]
+        )
+    )
+    finalize_layerwise_reload(model, _Cfg())
+
+    assert torch.equal(model.first.weight, torch.full((2,), 3.0))
+    assert model.second.weight is second_before
+    assert get_layer_completion_findings() == []
+
+
+def test_partial_scope_rejects_split_processing_unit_before_mutation() -> None:
+    model = nn.Module()
+    model.layer = _WeightLayer(("left", "right"))
+
+    def load(weights):
+        for source_name, weight in weights:
+            parameter = getattr(model.layer, source_name.rsplit(".", 1)[-1])
+            parameter.weight_loader(parameter, weight)
+
+    record_metadata_for_reloading(model)
+    record_load_consumption(model)
+    load(
+        observe_weight_sources(
+            [
+                ("layer.left", torch.ones(2)),
+                ("layer.right", torch.ones(2)),
+            ]
+        )
+    )
+    finalize_load_recording(model)
+    left_before = model.layer.left
+
+    with pytest.raises(ValueError, match="splits a layerwise processing unit"):
+        initialize_layerwise_reload(
+            model,
+            PartialBaseWeightScope(("layer.left",)),
+        )
+
+    assert model.layer.left is left_before
+    assert not model.layer.left.is_meta
+
+
+def test_scope_normalization_rejects_duplicates() -> None:
+    with pytest.raises(ValueError, match="duplicate"):
+        normalize_update_scope(
+            {
+                "kind": "base_checkpoint",
+                "mode": "partial",
+                "source_names": ["a", "a"],
+            }
+        )
+
+
+def test_tensor_lora_scope_requires_complete_manifest() -> None:
+    peft_config = {
+        "r": 2,
+        "lora_alpha": 2,
+        "target_modules": ["q_proj"],
+    }
+    names = (
+        "base_model.model.q_proj.lora_A.weight",
+        "base_model.model.q_proj.lora_B.weight",
+    )
+    scope = LoRAAdapterScope(
+        adapter_id=7,
+        adapter_name="policy",
+        tensor_names=names,
+        config_digest=config_digest(peft_config),
+    )
+    session = TensorLoRAUpdateSession(scope, peft_config)
+    session.add_tensors({names[0]: torch.ones(2, 4)})
+
+    with pytest.raises(ValueError, match="manifest mismatch"):
+        session.finish()
+
+    session.add_tensors({names[1]: torch.ones(4, 2)})
+    request = session.finish()
+    assert set(request.lora_tensors) == set(names)
+
+
+def test_lora_replacement_rejects_incomplete_ab_pair() -> None:
+    class Weights:
+        lora_a = torch.ones(2, 4)
+        lora_b = None
+
+    with pytest.raises(ValueError, match="incomplete A/B"):
+        validate_complete_lora_weights({"model.q_proj": Weights()})
+
+
+def test_lora_remove_scope_rejects_replacement_manifest() -> None:
+    with pytest.raises(ValueError, match="cannot declare replacement data"):
+        LoRAAdapterScope(
+            adapter_id=7,
+            adapter_name="policy",
+            operation="remove",
+            tensor_names=("q_proj.lora_A.weight",),
+        )

--- a/tests/model_executor/model_loader/test_update_scope.py
+++ b/tests/model_executor/model_loader/test_update_scope.py
@@ -5,16 +5,22 @@ import pytest
 import torch
 from torch import nn
 
+from vllm.lora.lora_model import LoRAModel
+from vllm.lora.lora_weights import LoRALayerWeights, PackedLoRALayerWeights
+from vllm.lora.request import LoRARequest
 from vllm.lora.update import (
     TensorLoRAUpdateSession,
     config_digest,
+    merge_lora_patch,
     validate_complete_lora_weights,
 )
+from vllm.lora.worker_manager import LRUCacheWorkerLoRAManager
 from vllm.model_executor.model_loader.reload.baseline import (
     WeightUpdateBaselineEvent,
     WeightUpdateBaselineGroup,
     WeightUpdateBaselineReport,
     aggregate_weight_update_baselines,
+    aggregate_weight_update_manifests,
     get_weight_update_baseline,
 )
 from vllm.model_executor.model_loader.reload.layerwise import (
@@ -70,11 +76,7 @@ class _ScopedModel(nn.Module):
 def _record_baseline(model: nn.Module, names: tuple[str, ...]) -> None:
     record_metadata_for_reloading(model)
     record_load_consumption(model)
-    model.load_weights(
-        observe_weight_sources(
-            (name, torch.ones(2)) for name in names
-        )
-    )
+    model.load_weights(observe_weight_sources((name, torch.ones(2)) for name in names))
     finalize_load_recording(model)
 
 
@@ -91,9 +93,7 @@ def test_partial_scope_initializes_only_selected_layers() -> None:
     assert model.second.weight is second_before
 
     model.load_weights(
-        observe_weight_sources(
-            [("first.weight", torch.full((2,), 3.0))]
-        )
+        observe_weight_sources([("first.weight", torch.full((2,), 3.0))])
     )
     finalize_layerwise_reload(model, _Cfg())
 
@@ -282,3 +282,205 @@ def test_lora_remove_scope_rejects_replacement_manifest() -> None:
             operation="remove",
             tensor_names=("q_proj.lora_A.weight",),
         )
+
+
+def _lora_layer(name: str, value: float) -> LoRALayerWeights:
+    return LoRALayerWeights(
+        name,
+        rank=2,
+        lora_alpha=2,
+        lora_a=torch.full((2, 4), value),
+        lora_b=torch.full((4, 2), value),
+    )
+
+
+def test_lora_partial_patch_preserves_unselected_modules() -> None:
+    old_left = _lora_layer("model.left", 1)
+    old_right = _lora_layer("model.right", 2)
+    current = LoRAModel(
+        7,
+        rank=2,
+        loras={"model.left": old_left, "model.right": old_right},
+        adapter_name="policy",
+        is_runtime_packed=True,
+    )
+    new_left = _lora_layer("model.left", 9)
+    patch = LoRAModel(
+        7,
+        rank=2,
+        loras={"model.left": new_left},
+        adapter_name="policy",
+        is_runtime_packed=True,
+    )
+
+    merged = merge_lora_patch(current, patch, {"model.left"})
+
+    assert merged is not current
+    assert merged.loras["model.left"] is new_left
+    assert merged.loras["model.right"] is old_right
+    assert current.loras["model.left"] is old_left
+
+
+def test_lora_partial_patch_requires_exact_runtime_modules() -> None:
+    current = LoRAModel(
+        7,
+        rank=2,
+        loras={"model.left": _lora_layer("model.left", 1)},
+        is_runtime_packed=True,
+    )
+    patch = LoRAModel(
+        7,
+        rank=2,
+        loras={"model.right": _lora_layer("model.right", 2)},
+        is_runtime_packed=True,
+    )
+
+    with pytest.raises(ValueError, match="module manifest mismatch"):
+        merge_lora_patch(current, patch, {"model.left"})
+
+
+def test_lora_partial_patch_rejects_incomplete_packed_module() -> None:
+    q, k = _lora_layer("model.q", 1), _lora_layer("model.k", 2)
+    current = LoRAModel(
+        7,
+        rank=2,
+        loras={"model.qkv": PackedLoRALayerWeights.pack([q, k])},
+        is_runtime_packed=True,
+    )
+    patch = LoRAModel(
+        7,
+        rank=2,
+        loras={"model.qkv": PackedLoRALayerWeights.pack([q, None])},
+        is_runtime_packed=True,
+    )
+
+    with pytest.raises(ValueError, match="fragment presence mismatch"):
+        merge_lora_patch(current, patch, {"model.qkv"})
+
+
+def test_lora_patch_scope_requires_base_generation() -> None:
+    with pytest.raises(ValueError, match="base_generation"):
+        LoRAAdapterScope(
+            adapter_id=7,
+            adapter_name="policy",
+            operation="patch",
+            module_names=("model.left",),
+        )
+
+
+def test_lora_partial_patch_prepares_then_commits(monkeypatch) -> None:
+    old_left = _lora_layer("model.left", 1)
+    old_right = _lora_layer("model.right", 2)
+    current = LoRAModel(
+        7,
+        rank=2,
+        loras={"model.left": old_left, "model.right": old_right},
+        adapter_name="policy",
+        is_runtime_packed=True,
+    )
+    patch = LoRAModel(
+        7,
+        rank=2,
+        loras={"model.left": _lora_layer("model.left", 9)},
+        adapter_name="policy",
+        is_runtime_packed=True,
+    )
+
+    class FakeAdapterManager:
+        capacity = 2
+
+        def __init__(self):
+            self.current = current
+
+        def get_adapter(self, adapter_id):
+            return self.current if self.current.id == adapter_id else None
+
+        def _create_merged_loras_inplace(self, lora):
+            lora.is_runtime_packed = True
+
+        def remove_adapter(self, adapter_id):
+            self.current = None
+            return True
+
+        def add_adapter(self, lora):
+            self.current = lora
+            return True
+
+        def activate_adapter(self, adapter_id):
+            return True
+
+        def __len__(self):
+            return int(self.current is not None)
+
+    manager = object.__new__(LRUCacheWorkerLoRAManager)
+    manager._adapter_manager = FakeAdapterManager()
+    manager._adapter_generations = {7: 1}
+    monkeypatch.setattr(manager, "_load_adapter", lambda request: patch)
+    monkeypatch.setattr(manager, "list_adapters", lambda: {7})
+    request = LoRARequest(
+        lora_name="policy",
+        lora_int_id=7,
+        lora_path="/unused",
+        load_inplace=True,
+        update_scope={
+            "kind": "lora_adapter",
+            "operation": "patch",
+            "adapter_id": 7,
+            "adapter_name": "policy",
+            "base_generation": 1,
+            "module_names": ["model.left"],
+        },
+    )
+
+    assert manager.prepare_adapter(request)
+    assert manager._adapter_manager.current is current
+    assert manager.commit_adapter(7)
+    assert (
+        manager._adapter_manager.current.loras["model.left"]
+        is patch.loras["model.left"]
+    )
+    assert manager._adapter_manager.current.loras["model.right"] is old_right
+    assert manager._adapter_generations[7] == 2
+
+
+def test_weight_update_manifest_separates_model_and_lora_state() -> None:
+    model_report = WeightUpdateBaselineReport(
+        scope=LoadManifestScope(), state="exact", groups=()
+    )
+    local_adapter = {
+        "adapter_id": 7,
+        "adapter_name": "policy",
+        "rank": 2,
+        "generation": 3,
+        "module_names": ["model.left"],
+        "modules": [
+            {
+                "module_name": "model.left",
+                "lora_a": {"shape": [2, 4], "dtype": "torch.float32"},
+                "lora_b": {"shape": [4, 2], "dtype": "torch.float32"},
+            }
+        ],
+        "replace_scope_template": {"operation": "replace"},
+        "patch_scope_template": {
+            "operation": "patch",
+            "base_generation": 3,
+        },
+        "remove_scope_template": {"operation": "remove"},
+    }
+
+    manifest = aggregate_weight_update_manifests(
+        [
+            {
+                "model_weights": model_report,
+                "lora_adapters": [local_adapter],
+            }
+        ]
+    )
+
+    assert set(manifest) == {"model_weights", "lora_adapters"}
+    assert manifest["model_weights"]["ready"] is True
+    assert manifest["lora_adapters"][0]["module_names"] == ["model.left"]
+    assert manifest["lora_adapters"][0]["modules"][0]["workers"][0]["lora_a"][
+        "shape"
+    ] == [2, 4]
+    assert manifest["lora_adapters"][0]["generation"] == 3

--- a/tests/models/test_deepseek_v4_mega_moe.py
+++ b/tests/models/test_deepseek_v4_mega_moe.py
@@ -60,16 +60,13 @@ def test_deepseek_v4_mega_moe_weight_loader_uses_ep_expert_ownership():
     )
 
     nonlocal_weight = torch.ones(128, 64, dtype=torch.uint8)
-    assert (
-        experts.weight_loader(
-            experts.w13_weight,
-            nonlocal_weight,
-            "experts.w13_weight",
-            shard_id="w1",
-            expert_id=1,
-            return_success=True,
-        )
-        is False
+    assert not experts.weight_loader(
+        experts.w13_weight,
+        nonlocal_weight,
+        "experts.w13_weight",
+        shard_id="w1",
+        expert_id=1,
+        return_success=True,
     )
 
     w1 = torch.full((128, 64), 3, dtype=torch.uint8)

--- a/vllm/distributed/weight_transfer/base.py
+++ b/vllm/distributed/weight_transfer/base.py
@@ -3,6 +3,7 @@
 """Base class for weight transfer engines."""
 
 from abc import ABC, abstractmethod
+from collections import Counter
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
@@ -11,6 +12,7 @@ import torch
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
+    from vllm.model_executor.model_loader.reload.scope import UpdateScope
 
 from vllm.config.parallel import ParallelConfig
 from vllm.config.weight_transfer import WeightTransferConfig
@@ -98,8 +100,12 @@ class WeightTransferEngine(ABC, Generic[TInitInfo, TUpdateInfo]):
         self._expected_source_names: set[str] | None = None
         self._received_source_names: set[str] = set()
         self._requires_declared_source_manifest = False
+        self._update_scope: UpdateScope | None = None
 
-    def start_source_manifest_validation(self) -> None:
+    def start_source_manifest_validation(
+        self,
+        update_scope: "UpdateScope | dict[str, Any] | None" = None,
+    ) -> None:
         """Start transport-level source reconciliation for one transaction.
 
         A model created with ``load_format=dummy`` has no checkpoint source
@@ -111,8 +117,13 @@ class WeightTransferEngine(ABC, Generic[TInitInfo, TUpdateInfo]):
         from vllm.model_executor.model_loader.reload.layerwise import (
             has_dummy_load_manifest,
         )
+        from vllm.model_executor.model_loader.reload.scope import (
+            normalize_update_scope,
+            scope_source_names,
+        )
 
-        self._expected_source_names = None
+        self._update_scope = normalize_update_scope(update_scope)
+        self._expected_source_names = scope_source_names(self._update_scope)
         self._received_source_names.clear()
         self._requires_declared_source_manifest = has_dummy_load_manifest(self.model)
 
@@ -122,6 +133,21 @@ class WeightTransferEngine(ABC, Generic[TInitInfo, TUpdateInfo]):
         expected_names: list[str] | None,
     ) -> None:
         """Record one received chunk and its transaction declaration."""
+        if self._expected_source_names is not None:
+            duplicate_names = {
+                name for name, count in Counter(names).items() if count > 1
+            } | (set(names) & self._received_source_names)
+            if duplicate_names:
+                raise ValueError(
+                    "Explicit weight update scope received duplicate names: "
+                    f"{sorted(duplicate_names)[:20]}"
+                )
+            unexpected_chunk = set(names) - self._expected_source_names
+            if unexpected_chunk:
+                raise ValueError(
+                    "Weight update chunk contains names outside its explicit "
+                    f"scope: {sorted(unexpected_chunk)[:20]}"
+                )
         if expected_names is not None:
             declared = set(expected_names)
             if len(declared) != len(expected_names):
@@ -213,7 +239,10 @@ class WeightTransferEngine(ABC, Generic[TInitInfo, TUpdateInfo]):
         raise NotImplementedError
 
     @abstractmethod
-    def start_weight_update(self) -> None:
+    def start_weight_update(
+        self,
+        update_scope: "UpdateScope | dict[str, Any] | None" = None,
+    ) -> None:
         """
         Prepare the engine for a new weight update.
 

--- a/vllm/distributed/weight_transfer/base.py
+++ b/vllm/distributed/weight_transfer/base.py
@@ -95,6 +95,71 @@ class WeightTransferEngine(ABC, Generic[TInitInfo, TUpdateInfo]):
         self.model_config = vllm_config.model_config
         self.device = device
         self.model = model
+        self._expected_source_names: set[str] | None = None
+        self._received_source_names: set[str] = set()
+        self._requires_declared_source_manifest = False
+
+    def start_source_manifest_validation(self) -> None:
+        """Start transport-level source reconciliation for one transaction.
+
+        A model created with ``load_format=dummy`` has no checkpoint source
+        stream from which an exact baseline can be learned.  Its first real
+        transfer must therefore carry an independently declared source
+        manifest.  Later transfers are also checked when a declaration is
+        supplied, but retain compatibility with existing callers.
+        """
+        from vllm.model_executor.model_loader.reload.layerwise import (
+            has_dummy_load_manifest,
+        )
+
+        self._expected_source_names = None
+        self._received_source_names.clear()
+        self._requires_declared_source_manifest = has_dummy_load_manifest(self.model)
+
+    def observe_source_manifest(
+        self,
+        names: list[str],
+        expected_names: list[str] | None,
+    ) -> None:
+        """Record one received chunk and its transaction declaration."""
+        if expected_names is not None:
+            declared = set(expected_names)
+            if len(declared) != len(expected_names):
+                raise ValueError(
+                    "The declared weight-transfer source manifest contains "
+                    "duplicate names"
+                )
+            if (
+                self._expected_source_names is not None
+                and self._expected_source_names != declared
+            ):
+                raise ValueError(
+                    "Conflicting expected source manifests were supplied for "
+                    "the same weight-update transaction"
+                )
+            self._expected_source_names = declared
+        self._received_source_names.update(names)
+
+    def finish_source_manifest_validation(self) -> None:
+        """Fail closed before commit if the declared source stream is incomplete."""
+        if (
+            self._requires_declared_source_manifest
+            and self._expected_source_names is None
+        ):
+            raise RuntimeError(
+                "The first real weight transfer after dummy initialization "
+                "requires an authoritative expected source manifest"
+            )
+        if self._expected_source_names is None:
+            return
+        missing = self._expected_source_names - self._received_source_names
+        unexpected = self._received_source_names - self._expected_source_names
+        if missing or unexpected:
+            raise RuntimeError(
+                "Weight-transfer source manifest mismatch: "
+                f"missing={sorted(missing)[:20]}, "
+                f"unexpected={sorted(unexpected)[:20]}"
+            )
 
     def parse_init_info(self, init_dict: dict[str, Any]) -> TInitInfo:
         """

--- a/vllm/distributed/weight_transfer/ipc_engine.py
+++ b/vllm/distributed/weight_transfer/ipc_engine.py
@@ -215,23 +215,37 @@ class IPCWeightTransferEngine(
         """
         pass
 
-    def start_weight_update(self) -> None:
+    def start_weight_update(self, update_scope=None) -> None:
         """Initialize layerwise reloading for the incoming checkpoint weights."""
         from vllm.model_executor.model_loader.reload import (
             initialize_layerwise_reload,
         )
+        from vllm.model_executor.model_loader.reload.scope import (
+            FullBaseWeightScope,
+            PartialBaseWeightScope,
+            normalize_update_scope,
+        )
 
-        self.start_source_manifest_validation()
-        initialize_layerwise_reload(self.model)
+        scope = normalize_update_scope(update_scope)
+        if not isinstance(scope, (FullBaseWeightScope, PartialBaseWeightScope)):
+            raise ValueError(
+                "IPC checkpoint transfer only supports base checkpoint scopes"
+            )
+        self.start_source_manifest_validation(scope)
+        initialize_layerwise_reload(self.model, scope)
 
-    def finish_weight_update(self) -> None:
+    def finish_weight_update(self):
         """Finalize layerwise reloading after all weights have been received."""
         from vllm.model_executor.model_loader.reload import (
             finalize_layerwise_reload,
         )
+        from vllm.model_executor.model_loader.reload.layerwise import (
+            get_load_manifest_report,
+        )
 
         self.finish_source_manifest_validation()
         finalize_layerwise_reload(self.model, self.model_config)
+        return get_load_manifest_report(self.model)
 
     def receive_weights(self, update_info: IPCWeightTransferUpdateInfo) -> None:
         """

--- a/vllm/distributed/weight_transfer/ipc_engine.py
+++ b/vllm/distributed/weight_transfer/ipc_engine.py
@@ -46,6 +46,13 @@ class IPCTrainerSendWeightsArgs:
     """Whether to use packed tensor transfer for bounded-memory chunking."""
     packed_buffer_size_bytes: int = DEFAULT_PACKED_BUFFER_SIZE_BYTES
     """Size in bytes for each packed tensor buffer when packed=True."""
+    expected_names: list[str] | None = None
+    """Authoritative names expected in the complete transaction.
+
+    This must be derived independently from the iterator being sent (for
+    example from the trainer model state schema).  It is required by a vLLM
+    model's first real transfer after ``load_format=dummy``.
+    """
 
     def __post_init__(self):
         """Validate that required arguments are provided for the selected mode."""
@@ -87,6 +94,8 @@ class IPCWeightTransferUpdateInfo(WeightTransferUpdateInfo):
     Required when packed=True, unused otherwise."""
     packed: bool = False
     """Whether this update uses packed tensor format."""
+    expected_names: list[str] | None = None
+    """Authoritative source manifest for the complete transaction."""
 
     def __post_init__(self):
         if self.ipc_handles_pickled is not None:
@@ -212,6 +221,7 @@ class IPCWeightTransferEngine(
             initialize_layerwise_reload,
         )
 
+        self.start_source_manifest_validation()
         initialize_layerwise_reload(self.model)
 
     def finish_weight_update(self) -> None:
@@ -220,6 +230,7 @@ class IPCWeightTransferEngine(
             finalize_layerwise_reload,
         )
 
+        self.finish_source_manifest_validation()
         finalize_layerwise_reload(self.model, self.model_config)
 
     def receive_weights(self, update_info: IPCWeightTransferUpdateInfo) -> None:
@@ -231,6 +242,8 @@ class IPCWeightTransferEngine(
                         and IPC handles. Each IPC handle is a mapping between physical
                         GPU UUID and the rebuild_cuda_tensor args tuple.
         """
+        self.observe_source_manifest(update_info.names, update_info.expected_names)
+
         # Use the worker's assigned device rather than the ambient current
         # device: the receive path is no longer wrapped in
         # `with torch.device(self.device)` by the caller, so the current device
@@ -274,7 +287,11 @@ class IPCWeightTransferEngine(
                 weight = rebuild_cuda_tensor(*list_args)
                 weights.append((name, weight))
 
-        self.model.load_weights(weights)
+        from vllm.model_executor.model_loader.reload.source import (
+            observe_weight_sources,
+        )
+
+        self.model.load_weights(observe_weight_sources(weights))
 
     def shutdown(self) -> None:
         pass
@@ -410,6 +427,7 @@ class IPCWeightTransferEngine(
                 dtype_names=dtype_names,
                 shapes=shapes,
                 ipc_handles=ipc_handles,
+                expected_names=args.expected_names,
             )
 
         IPCWeightTransferEngine._post_send_sync()
@@ -423,6 +441,7 @@ class IPCWeightTransferEngine(
         """Send weights in bounded-memory chunks (packed mode)."""
         post_iter_func: Callable = lambda item: item[1]
 
+        first_chunk = True
         for chunk in packed_ipc_producer(
             iterator=iterator,
             gpu_uuid=gpu_uuid,
@@ -442,9 +461,11 @@ class IPCWeightTransferEngine(
                     ipc_handles=ipc_handle,
                     tensor_sizes=chunk.tensor_sizes,
                     packed=True,
+                    expected_names=args.expected_names if first_chunk else None,
                 )
 
             IPCWeightTransferEngine._post_send_sync()
+            first_chunk = False
 
     @staticmethod
     def _do_send(
@@ -455,6 +476,7 @@ class IPCWeightTransferEngine(
         ipc_handles: list[dict[str, tuple]] | dict[str, tuple],
         tensor_sizes: list[int] | None = None,
         packed: bool = False,
+        expected_names: list[str] | None = None,
     ) -> None:
         """Send a single update payload via the configured transport."""
         update_fields: dict[str, Any] = {
@@ -462,6 +484,7 @@ class IPCWeightTransferEngine(
             "dtype_names": dtype_names,
             "shapes": shapes,
             "packed": packed,
+            "expected_names": expected_names,
         }
         if tensor_sizes is not None:
             update_fields["tensor_sizes"] = tensor_sizes

--- a/vllm/distributed/weight_transfer/nccl_engine.py
+++ b/vllm/distributed/weight_transfer/nccl_engine.py
@@ -136,23 +136,37 @@ class NCCLWeightTransferEngine(
             init_info, self.parallel_config
         )
 
-    def start_weight_update(self) -> None:
+    def start_weight_update(self, update_scope=None) -> None:
         """Initialize layerwise reloading for the incoming checkpoint weights."""
         from vllm.model_executor.model_loader.reload import (
             initialize_layerwise_reload,
         )
+        from vllm.model_executor.model_loader.reload.scope import (
+            FullBaseWeightScope,
+            PartialBaseWeightScope,
+            normalize_update_scope,
+        )
 
-        self.start_source_manifest_validation()
-        initialize_layerwise_reload(self.model)
+        scope = normalize_update_scope(update_scope)
+        if not isinstance(scope, (FullBaseWeightScope, PartialBaseWeightScope)):
+            raise ValueError(
+                "NCCL checkpoint transfer only supports base checkpoint scopes"
+            )
+        self.start_source_manifest_validation(scope)
+        initialize_layerwise_reload(self.model, scope)
 
-    def finish_weight_update(self) -> None:
+    def finish_weight_update(self):
         """Finalize layerwise reloading after all weights have been received."""
         from vllm.model_executor.model_loader.reload import (
             finalize_layerwise_reload,
         )
+        from vllm.model_executor.model_loader.reload.layerwise import (
+            get_load_manifest_report,
+        )
 
         self.finish_source_manifest_validation()
         finalize_layerwise_reload(self.model, self.model_config)
+        return get_load_manifest_report(self.model)
 
     def receive_weights(self, update_info: NCCLWeightTransferUpdateInfo) -> None:
         """

--- a/vllm/distributed/weight_transfer/nccl_engine.py
+++ b/vllm/distributed/weight_transfer/nccl_engine.py
@@ -80,6 +80,8 @@ class NCCLWeightTransferUpdateInfo(WeightTransferUpdateInfo):
     packed_num_buffers: int = DEFAULT_PACKED_NUM_BUFFERS
     """Number of buffers for double/triple buffering during packed transfer.
     Both producer and consumer must use the same value."""
+    expected_names: list[str] | None = None
+    """Authoritative source manifest for the complete transaction."""
 
     def __post_init__(self):
         """Validate that all lists have the same length."""
@@ -140,6 +142,7 @@ class NCCLWeightTransferEngine(
             initialize_layerwise_reload,
         )
 
+        self.start_source_manifest_validation()
         initialize_layerwise_reload(self.model)
 
     def finish_weight_update(self) -> None:
@@ -148,6 +151,7 @@ class NCCLWeightTransferEngine(
             finalize_layerwise_reload,
         )
 
+        self.finish_source_manifest_validation()
         finalize_layerwise_reload(self.model, self.model_config)
 
     def receive_weights(self, update_info: NCCLWeightTransferUpdateInfo) -> None:
@@ -162,6 +166,7 @@ class NCCLWeightTransferEngine(
             update_info: NCCL update info containing parameter names, dtypes, shapes,
                         and packed flag
         """
+        self.observe_source_manifest(update_info.names, update_info.expected_names)
         if self.model_update_group is None:
             raise RuntimeError(
                 "NCCL weight transfer not initialized. "
@@ -169,6 +174,10 @@ class NCCLWeightTransferEngine(
             )
 
         if update_info.packed:
+            from vllm.model_executor.model_loader.reload.source import (
+                observe_weight_sources,
+            )
+
             # Build iterator of (name, (shape, dtype)) from update_info
             def state_dict_info_iterator():
                 for name, dtype_name, shape in zip(
@@ -181,12 +190,18 @@ class NCCLWeightTransferEngine(
                 iterator=state_dict_info_iterator(),
                 group=self.model_update_group,
                 src=0,
-                post_unpack_func=self.model.load_weights,
+                post_unpack_func=lambda weights: self.model.load_weights(
+                    observe_weight_sources(weights)
+                ),
                 buffer_size_bytes=update_info.packed_buffer_size_bytes,
                 num_buffers=update_info.packed_num_buffers,
                 device=self.device,
             )
         else:
+            from vllm.model_executor.model_loader.reload.source import (
+                observe_weight_sources,
+            )
+
             # Use simple one-by-one broadcasting
             for name, dtype_name, shape in zip(
                 update_info.names, update_info.dtype_names, update_info.shapes
@@ -196,7 +211,9 @@ class NCCLWeightTransferEngine(
                 self.model_update_group.broadcast(
                     weight, src=0, stream=torch.cuda.current_stream()
                 )
-                self.model.load_weights([(name, weight)])
+                self.model.load_weights(
+                    observe_weight_sources([(name, weight)])
+                )
                 del weight
 
     def shutdown(self) -> None:

--- a/vllm/distributed/weight_transfer/sparse_nccl_engine.py
+++ b/vllm/distributed/weight_transfer/sparse_nccl_engine.py
@@ -116,19 +116,38 @@ class SparseNCCLWeightTransferEngine(
             init_info, self.parallel_config
         )
 
-    def start_weight_update(self) -> None:
+    def start_weight_update(self, update_scope=None) -> None:
         """No-op: sparse patches are applied in place, no layerwise reload."""
+        from vllm.model_executor.model_loader.reload.scope import (
+            KernelWeightScope,
+            normalize_update_scope,
+        )
+
         if self.parallel_config.world_size != 1:
             raise NotImplementedError(
                 "Sparse weight updates currently require TP=1 and PP=1"
             )
+        if update_scope is None:
+            self._update_scope = None
+            self._expected_source_names = None
+            self._received_source_names.clear()
+            return
+        scope = normalize_update_scope(update_scope)
+        if not isinstance(scope, KernelWeightScope):
+            raise ValueError(
+                "Sparse NCCL updates require an explicit base_kernel scope"
+            )
+        self._update_scope = scope
+        self._expected_source_names = set(scope.target_names)
+        self._received_source_names.clear()
 
     def finish_weight_update(self) -> None:
         """No-op: sparse patches are applied in place, no layerwise reload."""
-        pass
+        self.finish_source_manifest_validation()
 
     def receive_weights(self, update_info: SparseNCCLWeightTransferUpdateInfo) -> None:
         """Receive sparse flat-index patches from the trainer and apply them."""
+        self.observe_source_manifest(update_info.names, None)
         if self.model_update_group is None:
             raise RuntimeError(
                 "NCCL weight transfer not initialized. "

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -253,8 +253,8 @@ class EngineClient(ABC):
         """Start a new weight update."""
         raise NotImplementedError
 
-    async def get_weight_update_baseline(self) -> dict:
-        """Return the initial-load manifest used to build partial scopes."""
+    async def get_weight_update_manifest(self) -> dict:
+        """Return all model-weight and LoRA state available for update."""
         raise NotImplementedError
 
     async def update_weights(self, request: WeightTransferUpdateRequest) -> None:

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -253,6 +253,10 @@ class EngineClient(ABC):
         """Start a new weight update."""
         raise NotImplementedError
 
+    async def get_weight_update_baseline(self) -> dict:
+        """Return the initial-load manifest used to build partial scopes."""
+        raise NotImplementedError
+
     async def update_weights(self, request: WeightTransferUpdateRequest) -> None:
         """Batched weight update for RL training."""
         raise NotImplementedError

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -181,6 +181,11 @@ class EngineClient(ABC):
         ...
 
     @abstractmethod
+    async def remove_lora(self, lora_id: int) -> bool:
+        """Remove one LoRA adapter from the engine."""
+        ...
+
+    @abstractmethod
     async def pause_generation(
         self,
         *,
@@ -244,7 +249,7 @@ class EngineClient(ABC):
         """Initialize weight transfer for RL training."""
         raise NotImplementedError
 
-    async def start_weight_update(self) -> None:
+    async def start_weight_update(self, update_scope: dict | None = None) -> None:
         """Start a new weight update."""
         raise NotImplementedError
 

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -879,14 +879,14 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
             "start_weight_update", kwargs={"update_scope": update_scope}
         )
 
-    def get_weight_update_baseline(self) -> dict:
-        """Return the global initial-load manifest used to build partial scopes."""
+    def get_weight_update_manifest(self) -> dict:
+        """Return all model-weight and LoRA state available for update."""
         from vllm.model_executor.model_loader.reload.baseline import (
-            aggregate_weight_update_baselines,
+            aggregate_weight_update_manifests,
         )
 
-        reports = self.llm_engine.collective_rpc("get_weight_update_baseline")
-        return aggregate_weight_update_baselines(reports)
+        manifests = self.llm_engine.collective_rpc("get_weight_update_manifest")
+        return aggregate_weight_update_manifests(manifests)
 
     def update_weights(self, request: WeightTransferUpdateRequest | dict) -> None:
         """
@@ -913,14 +913,11 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
                 f"{len(failed)} worker(s): {failed[:4]}"
             )
         scoped_reports = [
-            report
-            for report in reports
-            if getattr(report, "declared_source_names", ())
+            report for report in reports if getattr(report, "declared_source_names", ())
         ]
         if scoped_reports:
             declarations = {
-                frozenset(report.declared_source_names)
-                for report in scoped_reports
+                frozenset(report.declared_source_names) for report in scoped_reports
             }
             if len(declarations) != 1:
                 raise RuntimeError(

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -879,6 +879,15 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
             "start_weight_update", kwargs={"update_scope": update_scope}
         )
 
+    def get_weight_update_baseline(self) -> dict:
+        """Return the global initial-load manifest used to build partial scopes."""
+        from vllm.model_executor.model_loader.reload.baseline import (
+            aggregate_weight_update_baselines,
+        )
+
+        reports = self.llm_engine.collective_rpc("get_weight_update_baseline")
+        return aggregate_weight_update_baselines(reports)
+
     def update_weights(self, request: WeightTransferUpdateRequest | dict) -> None:
         """
         Update the weights of the model.

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -873,9 +873,11 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
             "init_weight_transfer_engine", kwargs={"init_info": init_info_dict}
         )
 
-    def start_weight_update(self) -> None:
+    def start_weight_update(self, update_scope: dict | None = None) -> None:
         """Start a new weight update."""
-        self.llm_engine.collective_rpc("start_weight_update")
+        self.llm_engine.collective_rpc(
+            "start_weight_update", kwargs={"update_scope": update_scope}
+        )
 
     def update_weights(self, request: WeightTransferUpdateRequest | dict) -> None:
         """
@@ -894,7 +896,42 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
 
     def finish_weight_update(self) -> None:
         """Finish the current weight update."""
-        self.llm_engine.collective_rpc("finish_weight_update")
+        reports = self.llm_engine.collective_rpc("finish_weight_update")
+        failed = [report for report in reports if not getattr(report, "ok", True)]
+        if failed:
+            raise RuntimeError(
+                "Weight update failed rank-local completion on "
+                f"{len(failed)} worker(s): {failed[:4]}"
+            )
+        scoped_reports = [
+            report
+            for report in reports
+            if getattr(report, "declared_source_names", ())
+        ]
+        if scoped_reports:
+            declarations = {
+                frozenset(report.declared_source_names)
+                for report in scoped_reports
+            }
+            if len(declarations) != 1:
+                raise RuntimeError(
+                    "Workers disagreed on the explicit weight update scope"
+                )
+            declared = set(next(iter(declarations)))
+            resolved = {
+                name
+                for report in scoped_reports
+                for name in report.resolved_source_names
+            }
+            if missing := declared - resolved:
+                raise RuntimeError(
+                    "Explicit weight update scope contains source names not "
+                    f"resolved by any worker: {sorted(missing)[:20]}"
+                )
+        if not self.reset_prefix_cache(reset_connector=True):
+            raise RuntimeError("Failed to invalidate prefix cache after weight update")
+        self.reset_mm_cache()
+        self.llm_engine.reset_encoder_cache()
 
     def __repr__(self) -> str:
         """Return a transformers-style hierarchical view of the model."""

--- a/vllm/entrypoints/openai/models/serving.py
+++ b/vllm/entrypoints/openai/models/serving.py
@@ -23,6 +23,10 @@ from vllm.exceptions import LoRAAdapterNotFoundError
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.lora.resolver import LoRAResolver, LoRAResolverRegistry
+from vllm.model_executor.model_loader.reload.scope import (
+    LoRAAdapterScope,
+    normalize_update_scope,
+)
 from vllm.utils.counter import AtomicCounter
 
 logger = init_logger(__name__)
@@ -187,6 +191,7 @@ class OpenAIServingModels:
                 lora_path=lora_path,
                 load_inplace=request.load_inplace,
                 is_3d_lora_weight=request.is_3d_lora_weight,
+                update_scope=request.update_scope,
             )
             if base_model_name is not None and self.is_base_model(base_model_name):
                 lora_request.base_model_name = base_model_name
@@ -228,6 +233,47 @@ class OpenAIServingModels:
             error_check_ret = await self._check_unload_lora_adapter_request(request)
             if error_check_ret is not None:
                 return error_check_ret
+
+            loaded_request = self.lora_requests[lora_name]
+            if request.update_scope is not None:
+                scope = normalize_update_scope(request.update_scope)
+                if (
+                    not isinstance(scope, LoRAAdapterScope)
+                    or scope.operation != "remove"
+                ):
+                    return create_error_response(
+                        message="LoRA unload requires a matching remove scope.",
+                        err_type="InvalidUserInput",
+                        status_code=HTTPStatus.BAD_REQUEST,
+                    )
+                if (scope.adapter_id, scope.adapter_name) != (
+                    loaded_request.lora_int_id,
+                    loaded_request.lora_name,
+                ):
+                    return create_error_response(
+                        message="LoRA remove scope does not match the loaded adapter.",
+                        err_type="InvalidUserInput",
+                        status_code=HTTPStatus.BAD_REQUEST,
+                    )
+                removed = await self.engine_client.remove_lora(
+                    loaded_request.lora_int_id
+                )
+                if not removed:
+                    return create_error_response(
+                        message="Not every worker removed the scoped LoRA adapter.",
+                        err_type="InternalServerError",
+                        status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                    )
+                if not await self.engine_client.reset_prefix_cache(
+                    reset_connector=True
+                ):
+                    return create_error_response(
+                        message="Failed to invalidate prefix cache after LoRA removal.",
+                        err_type="InternalServerError",
+                        status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                    )
+                await self.engine_client.reset_mm_cache()
+                await self.engine_client.reset_encoder_cache()
 
             # Safe to delete now since we hold the lock
             del self.lora_requests[lora_name]

--- a/vllm/entrypoints/serve/dev/rlhf/api_router.py
+++ b/vllm/entrypoints/serve/dev/rlhf/api_router.py
@@ -139,6 +139,13 @@ async def start_weight_update(raw_request: Request):
     return JSONResponse(content={"message": "Weight update started"})
 
 
+@router.get("/weight_update_baseline")
+async def get_weight_update_baseline(raw_request: Request):
+    """Return checkpoint sources grouped by the smallest legal update units."""
+    baseline = await engine_client(raw_request).get_weight_update_baseline()
+    return JSONResponse(content=baseline)
+
+
 @router.post("/update_weights")
 async def update_weights(raw_request: Request):
     try:

--- a/vllm/entrypoints/serve/dev/rlhf/api_router.py
+++ b/vllm/entrypoints/serve/dev/rlhf/api_router.py
@@ -139,11 +139,11 @@ async def start_weight_update(raw_request: Request):
     return JSONResponse(content={"message": "Weight update started"})
 
 
-@router.get("/weight_update_baseline")
-async def get_weight_update_baseline(raw_request: Request):
-    """Return checkpoint sources grouped by the smallest legal update units."""
-    baseline = await engine_client(raw_request).get_weight_update_baseline()
-    return JSONResponse(content=baseline)
+@router.get("/weight_update_manifest")
+async def get_weight_update_manifest(raw_request: Request):
+    """Return all model-weight and LoRA state available for update."""
+    manifest = await engine_client(raw_request).get_weight_update_manifest()
+    return JSONResponse(content=manifest)
 
 
 @router.post("/update_weights")

--- a/vllm/entrypoints/serve/dev/rlhf/api_router.py
+++ b/vllm/entrypoints/serve/dev/rlhf/api_router.py
@@ -129,7 +129,13 @@ async def init_weight_transfer_engine(raw_request: Request):
 
 @router.post("/start_weight_update")
 async def start_weight_update(raw_request: Request):
-    await engine_client(raw_request).start_weight_update()
+    try:
+        body = await raw_request.json()
+    except json.JSONDecodeError:
+        body = {}
+    await engine_client(raw_request).start_weight_update(
+        update_scope=body.get("update_scope")
+    )
     return JSONResponse(content={"message": "Weight update started"})
 
 

--- a/vllm/entrypoints/serve/lora/protocol.py
+++ b/vllm/entrypoints/serve/lora/protocol.py
@@ -9,8 +9,10 @@ class LoadLoRAAdapterRequest(BaseModel):
     lora_path: str
     load_inplace: bool = False
     is_3d_lora_weight: bool = False
+    update_scope: dict | None = None
 
 
 class UnloadLoRAAdapterRequest(BaseModel):
     lora_name: str
     lora_int_id: int | None = Field(default=None)
+    update_scope: dict | None = None

--- a/vllm/lora/lora_model.py
+++ b/vllm/lora/lora_model.py
@@ -66,6 +66,8 @@ class LoRAModel:
         rank: int,
         loras: dict[str, LoRALayerWeights],
         is_3d_lora_weight: bool = False,
+        adapter_name: str | None = None,
+        is_runtime_packed: bool = False,
     ) -> None:
         """
         Args:
@@ -86,17 +88,22 @@ class LoRAModel:
         self.rank = rank
         self.loras: dict[str, LoRALayerWeights] = loras
         self.is_3d_lora_weight = is_3d_lora_weight
+        self.adapter_name = adapter_name
+        self.is_runtime_packed = is_runtime_packed
 
     def clone(self, lora_model_id: int) -> "LoRAModel":
         """Return a copy of the object with different ids.
 
         Will share the underlying tensors."""
-        return self.__class__(
+        clone = self.__class__(
             lora_model_id,
             rank=self.rank,
             loras=self.loras.copy(),
             is_3d_lora_weight=self.is_3d_lora_weight,
         )
+        clone.adapter_name = self.adapter_name
+        clone.is_runtime_packed = self.is_runtime_packed
+        return clone
 
     def get_lora(self, module_name: str) -> LoRALayerWeights | None:
         """Get LoRA for a given module by name"""

--- a/vllm/lora/model_manager.py
+++ b/vllm/lora/model_manager.py
@@ -732,6 +732,8 @@ class LoRAModelManager:
         ]
 
     def _create_merged_loras_inplace(self, lora_model: LoRAModel) -> None:
+        if lora_model.is_runtime_packed:
+            return
         for module_name, new_module_names in self.packed_modules.items():
             # For 2D FusedMoE modules with EP, narrow the per-expert
             # sub-module list to this rank's owned experts so pack_moe
@@ -823,6 +825,8 @@ class LoRAModelManager:
                 else:
                     lora.lora_a = lora.lora_a.pin_memory()
                     lora.lora_b = lora.lora_b.pin_memory()
+
+        lora_model.is_runtime_packed = True
 
     def _stack_moe_lora_weights(
         self, lora_model: LoRAModel, module: FusedMoE3DWithLoRA, module_name: str

--- a/vllm/lora/request.py
+++ b/vllm/lora/request.py
@@ -2,7 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+from dataclasses import dataclass
+
 import msgspec
+import torch
 
 
 class LoRARequest(
@@ -29,6 +32,7 @@ class LoRARequest(
     tensorizer_config_dict: dict | None = None
     load_inplace: bool = False
     is_3d_lora_weight: bool = False
+    update_scope: dict | None = None
     """Whether this adapter's MoE weights are stored in the 3D fused
     `gate_up_proj` / `down_proj` layout (one fused tensor per layer) or the
     2D per-expert split layout (separate `gate_proj` / `up_proj` / `down_proj`
@@ -71,3 +75,39 @@ class LoRARequest(
         identified by their names across engines.
         """
         return hash(self.lora_name)
+
+
+@dataclass
+class TensorLoRARequest:
+    """In-memory complete LoRA replacement used by training integrations."""
+
+    lora_name: str
+    lora_int_id: int
+    lora_tensors: dict[str, torch.Tensor]
+    peft_config: dict
+    load_inplace: bool = True
+    base_model_name: str | None = None
+    is_3d_lora_weight: bool = False
+    update_scope: dict | None = None
+    lora_path: str = "<in-memory>"
+    tensorizer_config_dict: dict | None = None
+
+    def __post_init__(self) -> None:
+        if self.lora_int_id < 1:
+            raise ValueError(f"id must be > 0, got {self.lora_int_id}")
+        if not self.lora_name:
+            raise ValueError("lora_name must not be empty")
+        if not self.lora_tensors:
+            raise ValueError("lora_tensors must not be empty")
+
+    @property
+    def adapter_id(self) -> int:
+        return self.lora_int_id
+
+    @property
+    def name(self) -> str:
+        return self.lora_name
+
+    @property
+    def path(self) -> str:
+        return self.lora_path

--- a/vllm/lora/update.py
+++ b/vllm/lora/update.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Completion and staging helpers for explicit LoRA replacement scopes."""
+
+import hashlib
+import json
+from pathlib import Path
+
+import torch
+
+from vllm.lora.request import LoRARequest, TensorLoRARequest
+from vllm.model_executor.model_loader.reload.scope import (
+    LoRAAdapterScope,
+    normalize_update_scope,
+)
+
+
+def config_digest(config: dict) -> str:
+    payload = json.dumps(
+        config,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def artifact_digest(path: str) -> str:
+    """Hash the adapter files which determine one path-backed replacement."""
+    root = Path(path)
+    candidates = (
+        "adapter_config.json",
+        "adapter_model.safetensors",
+        "adapter_model.bin",
+        "adapter_model.pt",
+    )
+    digest = hashlib.sha256()
+    found = False
+    for name in candidates:
+        file_path = root / name
+        if not file_path.is_file():
+            continue
+        found = True
+        digest.update(name.encode())
+        with file_path.open("rb") as file:
+            while chunk := file.read(1024 * 1024):
+                digest.update(chunk)
+    if not found:
+        raise ValueError(f"{path} does not contain a LoRA adapter artifact")
+    return digest.hexdigest()
+
+
+def validate_lora_update_scope(
+    request: LoRARequest | TensorLoRARequest,
+) -> LoRAAdapterScope | None:
+    """Validate an optional scope before loading or replacing an adapter."""
+    if request.update_scope is None:
+        return None
+    scope = normalize_update_scope(request.update_scope)
+    if not isinstance(scope, LoRAAdapterScope):
+        raise ValueError("A LoRA request requires a lora_adapter update scope")
+    if scope.operation != "replace":
+        raise ValueError("add_lora only accepts a LoRA replace scope")
+    if not request.load_inplace:
+        raise ValueError("A scoped LoRA replacement requires load_inplace=True")
+    if (scope.adapter_id, scope.adapter_name) != (
+        request.lora_int_id,
+        request.lora_name,
+    ):
+        raise ValueError(
+            "LoRA request identity does not match its update scope: "
+            f"request=({request.lora_int_id}, {request.lora_name!r}), "
+            f"scope=({scope.adapter_id}, {scope.adapter_name!r})"
+        )
+
+    if isinstance(request, TensorLoRARequest):
+        received = set(request.lora_tensors)
+        if scope.tensor_names is None:
+            raise ValueError(
+                "An in-memory LoRA replacement scope requires tensor_names"
+            )
+        expected = set(scope.tensor_names)
+        missing = expected - received
+        unexpected = received - expected
+        if missing or unexpected:
+            raise ValueError(
+                "LoRA tensor manifest mismatch: "
+                f"missing={sorted(missing)[:20]}, "
+                f"unexpected={sorted(unexpected)[:20]}"
+            )
+        if (
+            scope.config_digest is not None
+            and config_digest(request.peft_config) != scope.config_digest
+        ):
+            raise ValueError("LoRA PEFT configuration digest mismatch")
+    else:
+        if scope.tensor_names is not None:
+            raise ValueError(
+                "A path-backed LoRA replacement cannot declare tensor_names"
+            )
+        if (
+            scope.artifact_digest is not None
+            and artifact_digest(request.lora_path) != scope.artifact_digest
+        ):
+            raise ValueError("LoRA adapter artifact digest mismatch")
+        if scope.config_digest is not None:
+            config_path = Path(request.lora_path) / "adapter_config.json"
+            if not config_path.is_file():
+                raise ValueError("LoRA adapter configuration is missing")
+            with config_path.open() as file:
+                path_config = json.load(file)
+            if config_digest(path_config) != scope.config_digest:
+                raise ValueError("LoRA PEFT configuration digest mismatch")
+    return scope
+
+
+def validate_complete_lora_weights(loras: dict[str, object]) -> None:
+    """Require every staged module to contain both low-rank matrices."""
+    incomplete = sorted(
+        name
+        for name, weights in loras.items()
+        if getattr(weights, "lora_a", None) is None
+        or getattr(weights, "lora_b", None) is None
+    )
+    if incomplete:
+        raise ValueError(
+            "LoRA replacement contains incomplete A/B pairs for modules: "
+            f"{incomplete[:20]}"
+        )
+
+
+class TensorLoRAUpdateSession:
+    """Accumulate transport buckets and construct one complete replacement."""
+
+    def __init__(
+        self,
+        scope: LoRAAdapterScope | dict,
+        peft_config: dict,
+    ) -> None:
+        normalized = normalize_update_scope(scope)
+        if not isinstance(normalized, LoRAAdapterScope):
+            raise ValueError("TensorLoRAUpdateSession requires a LoRA scope")
+        if normalized.operation != "replace" or normalized.tensor_names is None:
+            raise ValueError(
+                "Tensor LoRA updates require replace and an exact tensor manifest"
+            )
+        self.scope = normalized
+        self.peft_config = peft_config
+        self._tensors: dict[str, torch.Tensor] = {}
+
+    def add_tensors(self, tensors: dict[str, torch.Tensor]) -> None:
+        expected = set(self.scope.tensor_names or ())
+        unexpected = set(tensors) - expected
+        duplicates = set(tensors) & set(self._tensors)
+        if unexpected or duplicates:
+            raise ValueError(
+                "Invalid LoRA tensor bucket: "
+                f"unexpected={sorted(unexpected)[:20]}, "
+                f"duplicates={sorted(duplicates)[:20]}"
+            )
+        self._tensors.update(tensors)
+
+    def finish(self) -> TensorLoRARequest:
+        request = TensorLoRARequest(
+            lora_name=self.scope.adapter_name,
+            lora_int_id=self.scope.adapter_id,
+            lora_tensors=self._tensors,
+            peft_config=self.peft_config,
+            update_scope={
+                "kind": self.scope.kind.value,
+                "operation": self.scope.operation,
+                "adapter_id": self.scope.adapter_id,
+                "adapter_name": self.scope.adapter_name,
+                "tensor_names": list(self.scope.tensor_names or ()),
+                "config_digest": self.scope.config_digest,
+                "artifact_digest": self.scope.artifact_digest,
+            },
+        )
+        validate_lora_update_scope(request)
+        return request
+
+
+__all__ = [
+    "TensorLoRAUpdateSession",
+    "artifact_digest",
+    "config_digest",
+    "validate_complete_lora_weights",
+    "validate_lora_update_scope",
+]

--- a/vllm/lora/update.py
+++ b/vllm/lora/update.py
@@ -1,13 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Completion and staging helpers for explicit LoRA replacement scopes."""
+"""Completion and staging helpers for explicit LoRA update scopes."""
 
 import hashlib
 import json
+from collections.abc import Mapping
 from pathlib import Path
 
 import torch
 
+from vllm.lora.lora_model import LoRAModel
 from vllm.lora.request import LoRARequest, TensorLoRARequest
 from vllm.model_executor.model_loader.reload.scope import (
     LoRAAdapterScope,
@@ -59,10 +61,10 @@ def validate_lora_update_scope(
     scope = normalize_update_scope(request.update_scope)
     if not isinstance(scope, LoRAAdapterScope):
         raise ValueError("A LoRA request requires a lora_adapter update scope")
-    if scope.operation != "replace":
-        raise ValueError("add_lora only accepts a LoRA replace scope")
+    if scope.operation not in ("replace", "patch"):
+        raise ValueError("add_lora only accepts a LoRA replace or patch scope")
     if not request.load_inplace:
-        raise ValueError("A scoped LoRA replacement requires load_inplace=True")
+        raise ValueError("A scoped LoRA update requires load_inplace=True")
     if (scope.adapter_id, scope.adapter_name) != (
         request.lora_int_id,
         request.lora_name,
@@ -114,7 +116,7 @@ def validate_lora_update_scope(
     return scope
 
 
-def validate_complete_lora_weights(loras: dict[str, object]) -> None:
+def validate_complete_lora_weights(loras: Mapping[str, object]) -> None:
     """Require every staged module to contain both low-rank matrices."""
     incomplete = sorted(
         name
@@ -129,8 +131,71 @@ def validate_complete_lora_weights(loras: dict[str, object]) -> None:
         )
 
 
+def merge_lora_patch(
+    current: LoRAModel,
+    patch: LoRAModel,
+    module_names: set[str],
+) -> LoRAModel:
+    """Build a copy-on-write adapter by replacing complete runtime modules."""
+    if current.rank != patch.rank:
+        raise ValueError(
+            f"LoRA patch rank mismatch: current={current.rank}, patch={patch.rank}"
+        )
+    if current.is_3d_lora_weight != patch.is_3d_lora_weight:
+        raise ValueError("LoRA patch storage format does not match the adapter")
+    missing_current = module_names - set(current.loras)
+    missing_patch = module_names - set(patch.loras)
+    unexpected = set(patch.loras) - module_names
+    if missing_current or missing_patch or unexpected:
+        raise ValueError(
+            "LoRA patch module manifest mismatch: "
+            f"unknown={sorted(missing_current)[:20]}, "
+            f"missing={sorted(missing_patch)[:20]}, "
+            f"unexpected={sorted(unexpected)[:20]}"
+        )
+    for name in module_names:
+        current_weights = current.loras[name]
+        patch_weights = patch.loras[name]
+        _validate_patch_tensor_layout(
+            current_weights.lora_a, patch_weights.lora_a, f"{name}.lora_a"
+        )
+        _validate_patch_tensor_layout(
+            current_weights.lora_b, patch_weights.lora_b, f"{name}.lora_b"
+        )
+    merged = current.clone(current.id)
+    merged.loras.update({name: patch.loras[name] for name in module_names})
+    return merged
+
+
+def _validate_patch_tensor_layout(
+    current: torch.Tensor | list[torch.Tensor | None],
+    patch: torch.Tensor | list[torch.Tensor | None],
+    name: str,
+) -> None:
+    if isinstance(current, list) or isinstance(patch, list):
+        if not isinstance(current, list) or not isinstance(patch, list):
+            raise ValueError(f"LoRA patch layout mismatch for {name}")
+        if len(current) != len(patch):
+            raise ValueError(f"LoRA patch fragment count mismatch for {name}")
+        for index, (current_item, patch_item) in enumerate(zip(current, patch)):
+            if current_item is None or patch_item is None:
+                if current_item is not patch_item:
+                    raise ValueError(
+                        f"LoRA patch fragment presence mismatch for {name}[{index}]"
+                    )
+                continue
+            _validate_patch_tensor_layout(current_item, patch_item, f"{name}[{index}]")
+        return
+    if current.shape != patch.shape or current.dtype != patch.dtype:
+        raise ValueError(
+            f"LoRA patch tensor mismatch for {name}: "
+            f"current=({tuple(current.shape)}, {current.dtype}), "
+            f"patch=({tuple(patch.shape)}, {patch.dtype})"
+        )
+
+
 class TensorLoRAUpdateSession:
-    """Accumulate transport buckets and construct one complete replacement."""
+    """Accumulate transport buckets and construct one LoRA update."""
 
     def __init__(
         self,
@@ -140,9 +205,13 @@ class TensorLoRAUpdateSession:
         normalized = normalize_update_scope(scope)
         if not isinstance(normalized, LoRAAdapterScope):
             raise ValueError("TensorLoRAUpdateSession requires a LoRA scope")
-        if normalized.operation != "replace" or normalized.tensor_names is None:
+        if (
+            normalized.operation not in ("replace", "patch")
+            or normalized.tensor_names is None
+        ):
             raise ValueError(
-                "Tensor LoRA updates require replace and an exact tensor manifest"
+                "Tensor LoRA updates require replace or patch and an exact "
+                "tensor manifest"
             )
         self.scope = normalized
         self.peft_config = peft_config
@@ -171,6 +240,12 @@ class TensorLoRAUpdateSession:
                 "operation": self.scope.operation,
                 "adapter_id": self.scope.adapter_id,
                 "adapter_name": self.scope.adapter_name,
+                "base_generation": self.scope.base_generation,
+                "module_names": (
+                    None
+                    if self.scope.module_names is None
+                    else list(self.scope.module_names)
+                ),
                 "tensor_names": list(self.scope.tensor_names or ()),
                 "config_digest": self.scope.config_digest,
                 "artifact_digest": self.scope.artifact_digest,
@@ -184,6 +259,7 @@ __all__ = [
     "TensorLoRAUpdateSession",
     "artifact_digest",
     "config_digest",
+    "merge_lora_patch",
     "validate_complete_lora_weights",
     "validate_lora_update_scope",
 ]

--- a/vllm/lora/worker_manager.py
+++ b/vllm/lora/worker_manager.py
@@ -19,6 +19,7 @@ from vllm.lora.model_manager import (
 from vllm.lora.peft_helper import PEFTHelper
 from vllm.lora.request import LoRARequest, TensorLoRARequest
 from vllm.lora.update import (
+    merge_lora_patch,
     validate_complete_lora_weights,
     validate_lora_update_scope,
 )
@@ -71,6 +72,7 @@ class WorkerLoRAManager:
                 text_config, "max_position_embeddings", None
             )
         self.device = device
+        self._adapter_generations: dict[int, int] = {}
         # Lazily initialized by create_lora_manager.
         self._adapter_manager: LoRAModelManager
 
@@ -126,9 +128,7 @@ class WorkerLoRAManager:
             if isinstance(lora_request, TensorLoRARequest):
                 lora_path = None
                 peft_helper = PEFTHelper.from_dict(lora_request.peft_config)
-                peft_helper.vllm_max_position_embeddings = (
-                    self.max_position_embeddings
-                )
+                peft_helper.vllm_max_position_embeddings = self.max_position_embeddings
             else:
                 lora_path = get_adapter_absolute_path(lora_request.lora_path)
                 peft_helper = PEFTHelper.from_local_dir(
@@ -184,6 +184,7 @@ class WorkerLoRAManager:
             # adapter manager can route 3D-format checkpoints through the
             # 3D->2D conversion when running under the universal 2D wrapper.
             lora.is_3d_lora_weight = lora_request.is_3d_lora_weight
+            lora.adapter_name = lora_request.lora_name
 
         except FileNotFoundError as e:
             # FileNotFoundError should be raised if both
@@ -320,9 +321,43 @@ class LRUCacheWorkerLoRAManager(WorkerLoRAManager):
         if pending is None:
             pending = {}
             self._pending_adapters = pending
+        lora = self._load_adapter(lora_request)
+        from vllm.model_executor.model_loader.reload.scope import LoRAAdapterScope
+
+        scope = validate_lora_update_scope(lora_request)
+        if isinstance(scope, LoRAAdapterScope) and scope.operation == "patch":
+            current = self._adapter_manager.get_adapter(lora_request.lora_int_id)
+            if current is None:
+                raise ValueError(
+                    f"Cannot patch unknown LoRA adapter {lora_request.lora_int_id}"
+                )
+            generation = self._adapter_generations.get(current.id, 1)
+            if scope.base_generation != generation:
+                raise ValueError(
+                    "LoRA patch base generation is stale: "
+                    f"expected={generation}, received={scope.base_generation}"
+                )
+            self._adapter_manager._create_merged_loras_inplace(lora)
+            declared = set(scope.module_names or ())
+            current_names = set(current.loras)
+            patch_names = set(lora.loras)
+            local_expected = declared & current_names
+            unexpected = (patch_names & current_names) - declared
+            if unexpected:
+                raise ValueError(
+                    "LoRA patch module manifest mismatch: "
+                    f"unexpected={sorted(unexpected)[:20]}"
+                )
+            lora.loras = {
+                name: lora.loras[name] for name in local_expected if name in lora.loras
+            }
+            merged = merge_lora_patch(current, lora, local_expected)
+            merged.adapter_name = current.adapter_name or lora_request.lora_name
+            lora = merged
         pending[lora_request.lora_int_id] = (
             lora_request,
-            self._load_adapter(lora_request),
+            lora,
+            None if scope is None else scope.base_generation,
         )
         return True
 
@@ -335,17 +370,80 @@ class LRUCacheWorkerLoRAManager(WorkerLoRAManager):
         pending = getattr(self, "_pending_adapters", None)
         if pending is None or lora_id not in pending:
             return self._adapter_manager.get_adapter(lora_id) is not None
-        lora_request, lora = pending.pop(lora_id)
+        lora_request, lora, base_generation = pending.pop(lora_id)
+        if (
+            base_generation is not None
+            and self._adapter_generations.get(lora_id, 1) != base_generation
+        ):
+            raise RuntimeError(
+                f"LoRA adapter {lora_id} changed after its patch was prepared"
+            )
         return self._install_adapter(lora_request, lora)
 
     def _install_adapter(self, lora_request, lora) -> bool:
+        next_generation = self._adapter_generations.get(lora.id, 0) + 1
         self._adapter_manager.remove_adapter(lora.id)
         if len(self._adapter_manager) + 1 > self._adapter_manager.capacity:
             assert isinstance(self._adapter_manager, LRUCacheLoRAModelManager)
             self._adapter_manager.remove_oldest_adapter()
         loaded = self._adapter_manager.add_adapter(lora)
         self._adapter_manager.activate_adapter(lora_request.lora_int_id)
+        self._adapter_generations[lora.id] = next_generation
         return loaded
+
+    def get_adapter_manifests(self) -> list[dict[str, object]]:
+        """Return rank-local manifests for adapters that can be updated."""
+
+        def tensor_spec(
+            value: torch.Tensor | list[torch.Tensor | None],
+        ) -> object:
+            if isinstance(value, list):
+                return [None if item is None else tensor_spec(item) for item in value]
+            return {"shape": list(value.shape), "dtype": str(value.dtype)}
+
+        manifests = []
+        for adapter_id, adapter in self._adapter_manager.list_adapters().items():
+            module_names = sorted(adapter.loras)
+            adapter_name = adapter.adapter_name or str(adapter_id)
+            generation = self._adapter_generations.get(adapter_id, 1)
+            manifests.append(
+                {
+                    "adapter_id": adapter_id,
+                    "adapter_name": adapter_name,
+                    "rank": adapter.rank,
+                    "generation": generation,
+                    "module_names": module_names,
+                    "modules": [
+                        {
+                            "module_name": name,
+                            "lora_a": tensor_spec(adapter.loras[name].lora_a),
+                            "lora_b": tensor_spec(adapter.loras[name].lora_b),
+                        }
+                        for name in module_names
+                    ],
+                    "replace_scope_template": {
+                        "kind": "lora_adapter",
+                        "operation": "replace",
+                        "adapter_id": adapter_id,
+                        "adapter_name": adapter_name,
+                    },
+                    "patch_scope_template": {
+                        "kind": "lora_adapter",
+                        "operation": "patch",
+                        "adapter_id": adapter_id,
+                        "adapter_name": adapter_name,
+                        "base_generation": generation,
+                        "module_names": [],
+                    },
+                    "remove_scope_template": {
+                        "kind": "lora_adapter",
+                        "operation": "remove",
+                        "adapter_id": adapter_id,
+                        "adapter_name": adapter_name,
+                    },
+                }
+            )
+        return manifests
 
     def add_adapter(self, lora_request: LoRARequest) -> bool:
         # Note that this method is not thread-safe. It may be invoked multiple

--- a/vllm/lora/worker_manager.py
+++ b/vllm/lora/worker_manager.py
@@ -17,7 +17,11 @@ from vllm.lora.model_manager import (
     create_lora_manager,
 )
 from vllm.lora.peft_helper import PEFTHelper
-from vllm.lora.request import LoRARequest
+from vllm.lora.request import LoRARequest, TensorLoRARequest
+from vllm.lora.update import (
+    validate_complete_lora_weights,
+    validate_lora_update_scope,
+)
 from vllm.lora.utils import get_adapter_absolute_path
 
 logger = init_logger(__name__)
@@ -102,8 +106,12 @@ class WorkerLoRAManager:
         self._adapter_manager = lora_manager
         return lora_manager.model
 
-    def _load_adapter(self, lora_request: LoRARequest) -> LoRAModel:
+    def _load_adapter(
+        self,
+        lora_request: LoRARequest | TensorLoRARequest,
+    ) -> LoRAModel:
         try:
+            validate_lora_update_scope(lora_request)
             supported_lora_modules = self._adapter_manager.supported_lora_modules
             packed_modules_mapping = self._adapter_manager.packed_modules_mapping
             expected_lora_lst: list[str] = []
@@ -115,13 +123,19 @@ class WorkerLoRAManager:
                 if module == "experts":
                     expected_lora_lst.append(module)
             expected_lora_modules = set(expected_lora_lst)
-            lora_path = get_adapter_absolute_path(lora_request.lora_path)
-
-            peft_helper = PEFTHelper.from_local_dir(
-                lora_path,
-                self.max_position_embeddings,
-                lora_request.tensorizer_config_dict,
-            )
+            if isinstance(lora_request, TensorLoRARequest):
+                lora_path = None
+                peft_helper = PEFTHelper.from_dict(lora_request.peft_config)
+                peft_helper.vllm_max_position_embeddings = (
+                    self.max_position_embeddings
+                )
+            else:
+                lora_path = get_adapter_absolute_path(lora_request.lora_path)
+                peft_helper = PEFTHelper.from_local_dir(
+                    lora_path,
+                    self.max_position_embeddings,
+                    lora_request.tensorizer_config_dict,
+                )
 
             # Validates the LoRA configuration against requirements before
             # loading weights, throwing an exception if validation fails.
@@ -139,19 +153,33 @@ class WorkerLoRAManager:
             # Get model-defined prefixes to skip during LoRA loading.
             lora_skip_prefixes = getattr(model, "lora_skip_prefixes", None)
 
-            lora = self._lora_model_cls.from_local_checkpoint(
-                lora_path,
-                expected_lora_modules,
-                peft_helper=peft_helper,
-                lora_model_id=lora_request.lora_int_id,
-                device="cpu",
-                dtype=self.lora_config.lora_dtype,
-                model_vocab_size=self.vocab_size,
-                tensorizer_config_dict=lora_request.tensorizer_config_dict,
-                weights_mapper=hf_to_vllm_mapper,
-                skip_prefixes=lora_skip_prefixes,
-                moe_ep_spec=self._adapter_manager.moe_ep_load_spec,
-            )
+            if isinstance(lora_request, TensorLoRARequest):
+                lora = self._lora_model_cls.from_lora_tensors(
+                    lora_model_id=lora_request.lora_int_id,
+                    tensors=lora_request.lora_tensors,
+                    peft_helper=peft_helper,
+                    device="cpu",
+                    dtype=self.lora_config.lora_dtype,
+                    model_vocab_size=self.vocab_size,
+                    weights_mapper=hf_to_vllm_mapper,
+                    skip_prefixes=lora_skip_prefixes,
+                )
+            else:
+                assert lora_path is not None
+                lora = self._lora_model_cls.from_local_checkpoint(
+                    lora_path,
+                    expected_lora_modules,
+                    peft_helper=peft_helper,
+                    lora_model_id=lora_request.lora_int_id,
+                    device="cpu",
+                    dtype=self.lora_config.lora_dtype,
+                    model_vocab_size=self.vocab_size,
+                    tensorizer_config_dict=lora_request.tensorizer_config_dict,
+                    weights_mapper=hf_to_vllm_mapper,
+                    skip_prefixes=lora_skip_prefixes,
+                    moe_ep_spec=self._adapter_manager.moe_ep_load_spec,
+                )
+            validate_complete_lora_weights(lora.loras)
             # Stamp the on-disk MoE layout onto the loaded model so the
             # adapter manager can route 3D-format checkpoints through the
             # 3D->2D conversion when running under the universal 2D wrapper.
@@ -282,6 +310,43 @@ class LRUCacheWorkerLoRAManager(WorkerLoRAManager):
         for lora in loras_map.values():
             self.add_adapter(lora)
 
+    def prepare_adapter(self, lora_request: LoRARequest) -> bool:
+        """Load and validate an adapter without publishing it to live slots."""
+        if not lora_request.load_inplace and (
+            lora_request.lora_int_id in self.list_adapters()
+        ):
+            return True
+        pending = getattr(self, "_pending_adapters", None)
+        if pending is None:
+            pending = {}
+            self._pending_adapters = pending
+        pending[lora_request.lora_int_id] = (
+            lora_request,
+            self._load_adapter(lora_request),
+        )
+        return True
+
+    def abort_adapter(self, lora_id: int) -> None:
+        pending = getattr(self, "_pending_adapters", None)
+        if pending is not None:
+            pending.pop(lora_id, None)
+
+    def commit_adapter(self, lora_id: int) -> bool:
+        pending = getattr(self, "_pending_adapters", None)
+        if pending is None or lora_id not in pending:
+            return self._adapter_manager.get_adapter(lora_id) is not None
+        lora_request, lora = pending.pop(lora_id)
+        return self._install_adapter(lora_request, lora)
+
+    def _install_adapter(self, lora_request, lora) -> bool:
+        self._adapter_manager.remove_adapter(lora.id)
+        if len(self._adapter_manager) + 1 > self._adapter_manager.capacity:
+            assert isinstance(self._adapter_manager, LRUCacheLoRAModelManager)
+            self._adapter_manager.remove_oldest_adapter()
+        loaded = self._adapter_manager.add_adapter(lora)
+        self._adapter_manager.activate_adapter(lora_request.lora_int_id)
+        return loaded
+
     def add_adapter(self, lora_request: LoRARequest) -> bool:
         # Note that this method is not thread-safe. It may be invoked multiple
         # times for the same adapter when using multiple API servers.
@@ -298,17 +363,7 @@ class LRUCacheWorkerLoRAManager(WorkerLoRAManager):
             # exceed `--max-cpu-loras`.
             lora = self._load_adapter(lora_request)
 
-            # Remove the existing adapter if it exists
-            # Use case for LoRA inplace
-            self._adapter_manager.remove_adapter(lora.id)
-
-            # Loading succeeded, now check if we will exceed cache capacity and
-            # evict if the oldest adapter if so
-            if len(self._adapter_manager) + 1 > self._adapter_manager.capacity:
-                assert isinstance(self._adapter_manager, LRUCacheLoRAModelManager)
-                self._adapter_manager.remove_oldest_adapter()
-            # Then add the new adapter to the cache
-            loaded = self._adapter_manager.add_adapter(lora)
+            return self._install_adapter(lora_request, lora)
         else:
             # If the lora is already loaded, just touch it to
             # update its position in the caches

--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
@@ -25,6 +25,10 @@ from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import (
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig,
 )
+from vllm.model_executor.load_receipt import (
+    LoadReceipt,
+    returns_load_receipt,
+)
 
 if TYPE_CHECKING:
     from vllm.model_executor.layers.fused_moe.runner.shared_experts import SharedExperts
@@ -569,7 +573,7 @@ class RoutedExperts(PluggableLayer):
         shard_id: str,
         expert_id: int,
         return_success: Literal[False],
-    ) -> None: ...
+    ) -> LoadReceipt: ...
 
     @overload
     def weight_loader(
@@ -580,8 +584,9 @@ class RoutedExperts(PluggableLayer):
         shard_id: str,
         expert_id: int,
         return_success: Literal[True],
-    ) -> bool: ...
+    ) -> LoadReceipt: ...
 
+    @returns_load_receipt("shard_id", "expert_id", "weight_name")
     def weight_loader(
         self,
         param: torch.nn.Parameter,
@@ -590,7 +595,7 @@ class RoutedExperts(PluggableLayer):
         shard_id: str,
         expert_id: int,
         return_success: bool = False,
-    ) -> bool | None:
+    ) -> LoadReceipt:
         quant_config_name = self.quant_config and self.quant_config.get_name()
         if quant_config_name == "gpt_oss_mxfp4":
             # (FIXME) for gpt-oss all experts are combined

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -31,6 +31,7 @@ from vllm.model_executor.layers.quantization.base_config import (
 from vllm.model_executor.layers.utils import (
     dispatch_unquantized_gemm,
 )
+from vllm.model_executor.load_receipt import returns_load_receipt
 from vllm.model_executor.parameter import (
     BasevLLMParameter,
     BlockQuantScaleParameter,
@@ -662,6 +663,7 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
             return True
         raise ValueError("This line should not be reached")
 
+    @returns_load_receipt("loaded_shard_id")
     def weight_loader(
         self,
         param: Parameter,
@@ -847,6 +849,7 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
             )
             self.weight_loader_v2(param, loaded_weight_shard, shard_id)
 
+    @returns_load_receipt("loaded_shard_id")
     def weight_loader_v2(
         self,
         param: BasevLLMParameter,
@@ -1095,6 +1098,7 @@ class QKVParallelLinear(ColumnParallelLinear):
             )
             self.weight_loader_v2(param, loaded_weight_shard, shard_id)
 
+    @returns_load_receipt("loaded_shard_id")
     def weight_loader_v2(
         self,
         param: BasevLLMParameter,
@@ -1142,6 +1146,7 @@ class QKVParallelLinear(ColumnParallelLinear):
             tp_rank=self.tp_rank,
         )
 
+    @returns_load_receipt("loaded_shard_id")
     def weight_loader(
         self,
         param: Parameter,

--- a/vllm/model_executor/load_receipt.py
+++ b/vllm/model_executor/load_receipt.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Structured result of one logical weight-loader invocation."""
+
+import inspect
+from collections.abc import Callable
+from dataclasses import dataclass
+from functools import wraps
+from typing import TypeAlias
+
+FragmentScalar: TypeAlias = str | int | float | bool
+FragmentValue: TypeAlias = FragmentScalar | tuple[FragmentScalar, ...]
+
+
+@dataclass(frozen=True)
+class LoadFragment:
+    """Stable logical identity of a target slice.
+
+    Items are stored in caller-provided schema order. Tensor values and other
+    process-local objects are intentionally unsupported.
+    """
+
+    items: tuple[tuple[str, FragmentValue], ...] = ()
+
+    @classmethod
+    def from_fields(cls, **fields: FragmentValue | None) -> "LoadFragment":
+        return cls(
+            tuple(
+                (name, value)
+                for name, value in fields.items()
+                if value is not None
+            )
+        )
+
+    def format(self) -> str:
+        return ",".join(f"{name}={value!r}" for name, value in self.items)
+
+
+@dataclass(frozen=True)
+class LoadReceipt:
+    """Whether a loader consumed a source tensor and which fragment it wrote."""
+
+    consumed: bool = True
+    fragment: LoadFragment = LoadFragment()
+
+    def __bool__(self) -> bool:
+        """Preserve compatibility with conditional loaders returning bool."""
+        return self.consumed
+
+    @classmethod
+    def accepted(cls, **fragment: FragmentValue | None) -> "LoadReceipt":
+        return cls(consumed=True, fragment=LoadFragment.from_fields(**fragment))
+
+    @classmethod
+    def skipped(cls, **fragment: FragmentValue | None) -> "LoadReceipt":
+        return cls(consumed=False, fragment=LoadFragment.from_fields(**fragment))
+
+
+def returns_load_receipt(*fragment_arguments: str):
+    """Declare a loader's fragment schema and return a structured receipt.
+
+    This adapter lets an existing None/bool loader migrate without duplicating
+    receipt construction at every return branch. Conditional loaders retain
+    their historical truthiness through ``LoadReceipt.__bool__``.
+    """
+
+    def decorate(loader: Callable) -> Callable:
+        signature = inspect.signature(loader)
+
+        @wraps(loader)
+        def wrapped(*args, **kwargs):
+            bound = signature.bind(*args, **kwargs)
+            bound.apply_defaults()
+            result = loader(*args, **kwargs)
+            if isinstance(result, LoadReceipt):
+                return result
+            consumed = (
+                result is True
+                if bound.arguments.get("return_success") is True
+                else True
+            )
+            fragment = {
+                name: bound.arguments.get(name)
+                for name in fragment_arguments
+                if bound.arguments.get(name) is not None
+            }
+            return LoadReceipt(
+                consumed=consumed,
+                fragment=LoadFragment.from_fields(**fragment),
+            )
+
+        wrapped.load_receipt_fragment_arguments = fragment_arguments
+        return wrapped
+
+    return decorate
+
+
+__all__ = [
+    "FragmentValue",
+    "LoadFragment",
+    "LoadReceipt",
+    "returns_load_receipt",
+]

--- a/vllm/model_executor/load_receipt.py
+++ b/vllm/model_executor/load_receipt.py
@@ -3,6 +3,7 @@
 """Structured result of one logical weight-loader invocation."""
 
 import inspect
+from enum import Enum
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import wraps
@@ -10,6 +11,13 @@ from typing import TypeAlias
 
 FragmentScalar: TypeAlias = str | int | float | bool
 FragmentValue: TypeAlias = FragmentScalar | tuple[FragmentScalar, ...]
+
+
+class LoadCollisionPolicy(str, Enum):
+    """Whether more than one source may claim the same target fragment."""
+
+    UNIQUE = "unique"
+    OVERWRITE = "overwrite"
 
 
 @dataclass(frozen=True)
@@ -42,18 +50,37 @@ class LoadReceipt:
 
     consumed: bool = True
     fragment: LoadFragment = LoadFragment()
+    collision_policy: LoadCollisionPolicy = LoadCollisionPolicy.UNIQUE
 
     def __bool__(self) -> bool:
         """Preserve compatibility with conditional loaders returning bool."""
         return self.consumed
 
     @classmethod
-    def accepted(cls, **fragment: FragmentValue | None) -> "LoadReceipt":
-        return cls(consumed=True, fragment=LoadFragment.from_fields(**fragment))
+    def accepted(
+        cls,
+        *,
+        collision_policy: LoadCollisionPolicy = LoadCollisionPolicy.UNIQUE,
+        **fragment: FragmentValue | None,
+    ) -> "LoadReceipt":
+        return cls(
+            consumed=True,
+            fragment=LoadFragment.from_fields(**fragment),
+            collision_policy=collision_policy,
+        )
 
     @classmethod
-    def skipped(cls, **fragment: FragmentValue | None) -> "LoadReceipt":
-        return cls(consumed=False, fragment=LoadFragment.from_fields(**fragment))
+    def skipped(
+        cls,
+        *,
+        collision_policy: LoadCollisionPolicy = LoadCollisionPolicy.UNIQUE,
+        **fragment: FragmentValue | None,
+    ) -> "LoadReceipt":
+        return cls(
+            consumed=False,
+            fragment=LoadFragment.from_fields(**fragment),
+            collision_policy=collision_policy,
+        )
 
 
 def returns_load_receipt(*fragment_arguments: str):
@@ -97,6 +124,7 @@ def returns_load_receipt(*fragment_arguments: str):
 
 __all__ = [
     "FragmentValue",
+    "LoadCollisionPolicy",
     "LoadFragment",
     "LoadReceipt",
     "returns_load_receipt",

--- a/vllm/model_executor/load_receipt.py
+++ b/vllm/model_executor/load_receipt.py
@@ -3,9 +3,9 @@
 """Structured result of one logical weight-loader invocation."""
 
 import inspect
-from enum import Enum
 from collections.abc import Callable
 from dataclasses import dataclass
+from enum import Enum
 from functools import wraps
 from typing import TypeAlias
 

--- a/vllm/model_executor/model_loader/base_loader.py
+++ b/vllm/model_executor/model_loader/base_loader.py
@@ -98,6 +98,7 @@ class BaseModelLoader(ABC):
 
     def finalize_load_manifest(self, model: nn.Module) -> None:
         """Allow source-less loaders to establish a post-processing baseline."""
+        return None
 
     def _ensure_manifest_observed(self, model: nn.Module) -> None:
         """Fail closed when a loader bypasses every supported observer."""

--- a/vllm/model_executor/model_loader/base_loader.py
+++ b/vllm/model_executor/model_loader/base_loader.py
@@ -9,7 +9,11 @@ import vllm.envs as envs
 from vllm.config import ModelConfig, VllmConfig
 from vllm.config.load import LoadConfig
 from vllm.logger import init_logger
-from vllm.model_executor.model_loader.reload import finalize_layerwise_processing
+from vllm.model_executor.model_loader.reload import (
+    finalize_layerwise_processing,
+    finalize_load_recording,
+    record_load_consumption,
+)
 from vllm.model_executor.model_loader.utils import (
     initialize_model,
     process_weights_after_loading,
@@ -61,7 +65,15 @@ class BaseModelLoader(ABC):
             log_model_inspection(model)
 
             logger.debug("Loading weights on %s ...", load_device)
-            self.load_weights(model, model_config)
+            # Observe the set of keys a correct load consumes, so a later
+            # reload can reconcile against ground truth rather than a
+            # structure-derived prediction (COMPLETION.md). Wrapping is
+            # removed immediately after, leaving the loaders as they were.
+            record_load_consumption(model)
+            try:
+                self.load_weights(model, model_config)
+            finally:
+                finalize_load_recording(model)
 
             # Log peak GPU memory after loading weights. This is needed
             # to have test coverage on peak memory for online quantization.

--- a/vllm/model_executor/model_loader/base_loader.py
+++ b/vllm/model_executor/model_loader/base_loader.py
@@ -14,6 +14,7 @@ from vllm.model_executor.model_loader.reload import (
     finalize_load_recording,
     record_load_consumption,
 )
+from vllm.model_executor.model_loader.reload.layerwise import get_layerwise_info
 from vllm.model_executor.model_loader.utils import (
     initialize_model,
     process_weights_after_loading,
@@ -90,8 +91,30 @@ class BaseModelLoader(ABC):
                 finalize_layerwise_processing(model, model_config)
 
             process_weights_after_loading(model, model_config, target_device)
+            self.finalize_load_manifest(model)
+            self._ensure_manifest_observed(model)
 
         return model.eval()
+
+    def finalize_load_manifest(self, model: nn.Module) -> None:
+        """Allow source-less loaders to establish a post-processing baseline."""
+
+    def _ensure_manifest_observed(self, model: nn.Module) -> None:
+        """Fail closed when a loader bypasses every supported observer."""
+        if not any(True for _ in model.parameters()):
+            return
+        observed = 0
+        for module in model.modules():
+            info = get_layerwise_info(module)
+            observed += len(info.required_keys or ())
+            observed += len(info.required_target_keys or ())
+        if observed == 0:
+            raise RuntimeError(
+                f"{self.__class__.__name__} loaded a parameterized model "
+                "without producing any load-manifest event. The loader likely "
+                "uses an uninstrumented direct-write path; add a source/target "
+                "adapter before using it for reload or RL weight transfer."
+            )
 
 
 def log_model_inspection(model: nn.Module) -> None:

--- a/vllm/model_executor/model_loader/bitsandbytes_loader.py
+++ b/vllm/model_executor/model_loader/bitsandbytes_loader.py
@@ -31,6 +31,7 @@ from vllm.model_executor.layers.linear import (
     RowParallelLinear,
 )
 from vllm.model_executor.model_loader.base_loader import BaseModelLoader
+from vllm.model_executor.model_loader.reload.source import observe_weight_sources
 from vllm.model_executor.model_loader.utils import ParamMapping
 from vllm.model_executor.model_loader.weight_utils import (
     download_safetensors_index_file_from_hf,
@@ -808,7 +809,8 @@ class BitsAndBytesModelLoader(BaseModelLoader):
             model_config.revision,
         )
         weights_to_load = {name for name, _ in model.named_parameters()}
-        loaded_weights = model.load_weights(qweight_iterator)
+        loaded_weights = model.load_weights(
+            observe_weight_sources(qweight_iterator))
         # Some models may have weights loading tracker unimplemented.
         if loaded_weights is not None:
             weights_not_loaded = weights_to_load - loaded_weights

--- a/vllm/model_executor/model_loader/default_loader.py
+++ b/vllm/model_executor/model_loader/default_loader.py
@@ -19,6 +19,7 @@ from vllm.model_executor.model_loader.base_loader import BaseModelLoader
 from vllm.model_executor.model_loader.ep_weight_filter import (
     compute_local_expert_ids,
 )
+from vllm.model_executor.model_loader.reload.source import observe_weight_sources
 from vllm.model_executor.model_loader.weight_utils import (
     download_safetensors_index_file_from_hf,
     download_weights_from_hf,
@@ -330,14 +331,16 @@ class DefaultModelLoader(BaseModelLoader):
             fall_back_to_pt=getattr(model, "fall_back_to_pt_during_load", True),
             allow_patterns_overrides=getattr(model, "allow_patterns_overrides", None),
         )
-        yield from self._get_weights_iterator(primary_weights)
+        yield from observe_weight_sources(
+            self._get_weights_iterator(primary_weights))
 
         secondary_weights = cast(
             Iterable[DefaultModelLoader.Source],
             getattr(model, "secondary_weights", ()),
         )
         for source in secondary_weights:
-            yield from self._get_weights_iterator(source)
+            yield from observe_weight_sources(
+                self._get_weights_iterator(source))
 
     def download_model(self, model_config: ModelConfig) -> None:
         self._prepare_weights(

--- a/vllm/model_executor/model_loader/dummy_loader.py
+++ b/vllm/model_executor/model_loader/dummy_loader.py
@@ -9,6 +9,7 @@ from vllm.model_executor.model_loader.base_loader import BaseModelLoader
 from vllm.model_executor.model_loader.reload.layerwise import (
     _get_original_loader,
     get_layerwise_info,
+    record_dummy_load_manifest,
 )
 from vllm.model_executor.model_loader.reload.meta import materialize_layer
 from vllm.model_executor.model_loader.reload.types import LayerReloadingInfo
@@ -42,6 +43,9 @@ class DummyModelLoader(BaseModelLoader):
                 # NOTE(woosuk): For accurate performance evaluation, we assign
                 # random values to the weights.
                 initialize_dummy_weights(layer, model_config)
+
+    def finalize_load_manifest(self, model: nn.Module) -> None:
+        record_dummy_load_manifest(model)
 
     def _process_online_quant_layer(
         self,

--- a/vllm/model_executor/model_loader/dummy_loader.py
+++ b/vllm/model_executor/model_loader/dummy_loader.py
@@ -4,6 +4,7 @@ import torch.nn as nn
 
 from vllm.config import ModelConfig
 from vllm.config.load import LoadConfig
+from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
 from vllm.model_executor.model_loader.base_loader import BaseModelLoader
 from vllm.model_executor.model_loader.reload.layerwise import (
@@ -12,12 +13,19 @@ from vllm.model_executor.model_loader.reload.layerwise import (
     record_dummy_load_manifest,
 )
 from vllm.model_executor.model_loader.reload.meta import materialize_layer
+from vllm.model_executor.model_loader.reload.probe import (
+    probe_model_load,
+    safetensors_meta_weights,
+    validate_probe_receipt_coverage,
+)
 from vllm.model_executor.model_loader.reload.types import LayerReloadingInfo
 from vllm.model_executor.model_loader.reload.utils import get_layer_tensors
 from vllm.model_executor.model_loader.weight_utils import (
     initialize_dummy_weights,
     initialize_single_dummy_weight,
 )
+
+logger = init_logger(__name__)
 
 
 class DummyModelLoader(BaseModelLoader):
@@ -35,16 +43,42 @@ class DummyModelLoader(BaseModelLoader):
         pass  # Nothing to download
 
     def load_weights(self, model: nn.Module, model_config: ModelConfig) -> None:
+        supports_metadata_probe = True
         for layer in model.modules():
             info = get_layerwise_info(layer)
             if info.can_load():
+                # Online quantization has already transformed the layer away
+                # from the checkpoint layout. Its exact baseline must be
+                # learned from the first real transfer instead.
+                supports_metadata_probe = False
                 self._process_online_quant_layer(layer, info)
             else:
                 # NOTE(woosuk): For accurate performance evaluation, we assign
                 # random values to the weights.
                 initialize_dummy_weights(layer, model_config)
 
+        weights = (
+            safetensors_meta_weights(model_config.model)
+            if supports_metadata_probe
+            else []
+        )
+        if weights:
+            report = probe_model_load(model, weights)
+            report.raise_for_error()
+            validate_probe_receipt_coverage(model, report)
+            logger.info(
+                "Probed %d checkpoint sources through dummy model loaders "
+                "without materializing weight data",
+                len(weights),
+            )
+
     def finalize_load_manifest(self, model: nn.Module) -> None:
+        exact_events = sum(
+            len(get_layerwise_info(layer).required_keys or ())
+            for layer in model.modules()
+        )
+        if exact_events:
+            return
         record_dummy_load_manifest(model)
 
     def _process_online_quant_layer(

--- a/vllm/model_executor/model_loader/dummy_loader.py
+++ b/vllm/model_executor/model_loader/dummy_loader.py
@@ -1,6 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import glob
+import os
+
+import torch
 import torch.nn as nn
+from transformers.utils import SAFE_WEIGHTS_INDEX_NAME
 
 from vllm.config import ModelConfig
 from vllm.config.load import LoadConfig
@@ -15,14 +20,18 @@ from vllm.model_executor.model_loader.reload.layerwise import (
 from vllm.model_executor.model_loader.reload.meta import materialize_layer
 from vllm.model_executor.model_loader.reload.probe import (
     probe_model_load,
-    safetensors_meta_weights,
+    safetensors_meta_weights_from_files,
     validate_probe_receipt_coverage,
 )
 from vllm.model_executor.model_loader.reload.types import LayerReloadingInfo
 from vllm.model_executor.model_loader.reload.utils import get_layer_tensors
 from vllm.model_executor.model_loader.weight_utils import (
+    download_safetensors_index_file_from_hf,
+    download_weights_from_hf,
+    filter_duplicate_safetensors_files,
     initialize_dummy_weights,
     initialize_single_dummy_weight,
+    maybe_download_from_modelscope,
 )
 
 logger = init_logger(__name__)
@@ -33,14 +42,31 @@ class DummyModelLoader(BaseModelLoader):
 
     def __init__(self, load_config: LoadConfig):
         super().__init__(load_config)
-        if load_config.model_loader_extra_config:
+        extra_config = load_config.model_loader_extra_config
+        if not isinstance(extra_config, dict):
             raise ValueError(
-                f"Model loader extra config is not supported for "
-                f"load format {load_config.load_format}"
+                f"model_loader_extra_config must be a dict for load format "
+                f"{load_config.load_format}, got {type(extra_config).__name__}"
             )
+        allowed_keys = {"enable_load_probe"}
+        unexpected_keys = set(extra_config.keys()) - allowed_keys
+        if unexpected_keys:
+            raise ValueError(
+                f"Unexpected extra config keys for load format "
+                f"{load_config.load_format}: {unexpected_keys}"
+            )
+        enable_load_probe = extra_config.get("enable_load_probe", False)
+        if not isinstance(enable_load_probe, bool):
+            raise ValueError(
+                f"enable_load_probe must be a bool, got "
+                f"{type(enable_load_probe).__name__}"
+            )
+        self.enable_load_probe = enable_load_probe
+        self._probe_weights_cache: list[tuple[str, torch.Tensor]] | None = None
 
     def download_model(self, model_config: ModelConfig) -> None:
-        pass  # Nothing to download
+        if self.enable_load_probe:
+            self._probe_meta_weights(model_config)
 
     def load_weights(self, model: nn.Module, model_config: ModelConfig) -> None:
         supports_metadata_probe = True
@@ -58,8 +84,8 @@ class DummyModelLoader(BaseModelLoader):
                 initialize_dummy_weights(layer, model_config)
 
         weights = (
-            safetensors_meta_weights(model_config.model)
-            if supports_metadata_probe
+            self._probe_meta_weights(model_config)
+            if self.enable_load_probe and supports_metadata_probe
             else []
         )
         if weights:
@@ -71,6 +97,49 @@ class DummyModelLoader(BaseModelLoader):
                 "without materializing weight data",
                 len(weights),
             )
+
+    def _probe_meta_weights(
+        self,
+        model_config: ModelConfig,
+    ) -> list[tuple[str, torch.Tensor]]:
+        if self._probe_weights_cache is not None:
+            return self._probe_weights_cache
+        model_name_or_path = (
+            maybe_download_from_modelscope(
+                model_config.model,
+                revision=model_config.revision,
+                download_dir=self.load_config.download_dir,
+                ignore_patterns=self.load_config.ignore_patterns,
+                allow_patterns=["*.safetensors"],
+            )
+            or model_config.model
+        )
+        is_local = os.path.isdir(model_name_or_path)
+        if not is_local:
+            hf_folder = download_weights_from_hf(
+                model_name_or_path,
+                self.load_config.download_dir,
+                ["*.safetensors"],
+                model_config.revision,
+                ignore_patterns=self.load_config.ignore_patterns,
+            )
+            download_safetensors_index_file_from_hf(
+                model_name_or_path,
+                SAFE_WEIGHTS_INDEX_NAME,
+                self.load_config.download_dir,
+                revision=model_config.revision,
+            )
+        else:
+            hf_folder = model_name_or_path
+
+        filenames = sorted(glob.glob(os.path.join(hf_folder, "*.safetensors")))
+        filenames = filter_duplicate_safetensors_files(
+            filenames,
+            hf_folder,
+            SAFE_WEIGHTS_INDEX_NAME,
+        )
+        self._probe_weights_cache = safetensors_meta_weights_from_files(filenames)
+        return self._probe_weights_cache
 
     def finalize_load_manifest(self, model: nn.Module) -> None:
         exact_events = sum(

--- a/vllm/model_executor/model_loader/modelexpress_loader.py
+++ b/vllm/model_executor/model_loader/modelexpress_loader.py
@@ -10,6 +10,11 @@ from torch import nn
 from vllm.config import ModelConfig, VllmConfig
 from vllm.config.load import LoadConfig
 from vllm.model_executor.model_loader.base_loader import BaseModelLoader
+from vllm.model_executor.model_loader.reload.layerwise import (
+    finalize_load_recording,
+    record_external_tensor_manifest,
+    record_load_consumption,
+)
 from vllm.tracing import instrument
 
 _MODELEXPRESS_LOADER_MODULE = "modelexpress.engines.vllm.loader"
@@ -53,7 +58,11 @@ class ModelExpressModelLoader(BaseModelLoader):
         self._loader.download_model(model_config)
 
     def load_weights(self, model: nn.Module, model_config: ModelConfig) -> None:
-        self._loader.load_weights(model, model_config)
+        record_load_consumption(model)
+        try:
+            self._loader.load_weights(model, model_config)
+        finally:
+            finalize_load_recording(model)
 
     @instrument(span_name="Load model")
     def load_model(
@@ -67,4 +76,25 @@ class ModelExpressModelLoader(BaseModelLoader):
             model_config=model_config,
             prefix=prefix,
         )
+        tensors = getattr(self._loader, "tensors", {})
+        has_parameters = any(True for _ in model.parameters())
+        if not tensors and has_parameters:
+            # ModelExpress skips its registry walk when no metadata/NIXL
+            # publication path is configured. Manifest construction still
+            # needs the same final post-PWAL tensor set.
+            from modelexpress.tensor_utils import collect_module_tensors
+
+            tensors = collect_module_tensors(model)
+        if tensors:
+            record_external_tensor_manifest(
+                model,
+                tensors,
+                source_scheme="modelexpress",
+            )
+        elif has_parameters:
+            raise RuntimeError(
+                "ModelExpress returned a parameterized model without its "
+                "published tensor registry; a complete load manifest cannot "
+                "be established."
+            )
         return model.eval()

--- a/vllm/model_executor/model_loader/reload/__init__.py
+++ b/vllm/model_executor/model_loader/reload/__init__.py
@@ -22,6 +22,8 @@ __all__ = [
     "initialize_layerwise_reload",
     "finalize_layerwise_processing",
     "finalize_layerwise_reload",
+    "record_load_consumption",
+    "finalize_load_recording",
     "set_torchao_reload_attrs",
     "support_quantized_model_reload_from_hp_weights",
 ]
@@ -29,7 +31,9 @@ __all__ = [
 from .layerwise import (
     finalize_layerwise_processing,
     finalize_layerwise_reload,
+    finalize_load_recording,
     initialize_layerwise_reload,
+    record_load_consumption,
     record_metadata_for_reloading,
 )
 from .torchao_decorator import (

--- a/vllm/model_executor/model_loader/reload/__init__.py
+++ b/vllm/model_executor/model_loader/reload/__init__.py
@@ -10,12 +10,11 @@ Limitations:
 1. Composition with CPU offloading has not been implemented
 2. Tied parameters will only reflect processing from one of the parent layers (for
    example, only processing from embed_tokens will have an effect)
-3. This design assumes that the number of weights loaded from disk is the same as the
-   number of weights created at model init time. This is not true for quant methods
-   which (1) pad weights or (2) load qkv weights into the same parameter. Both of these
-   cases are non-issues for today's quant methods, but future quantizations may cause
-   reloading to fail
+3. A loader returning ``None`` or ``bool`` uses the legacy fragment-argument
+   adapter. New loaders should return ``LoadReceipt`` with an explicit fragment.
 """
+
+from vllm.model_executor.load_receipt import LoadFragment, LoadReceipt
 
 __all__ = [
     "record_metadata_for_reloading",
@@ -26,6 +25,8 @@ __all__ = [
     "finalize_load_recording",
     "set_torchao_reload_attrs",
     "support_quantized_model_reload_from_hp_weights",
+    "LoadFragment",
+    "LoadReceipt",
 ]
 
 from .layerwise import (

--- a/vllm/model_executor/model_loader/reload/__init__.py
+++ b/vllm/model_executor/model_loader/reload/__init__.py
@@ -14,7 +14,11 @@ Limitations:
    adapter. New loaders should return ``LoadReceipt`` with an explicit fragment.
 """
 
-from vllm.model_executor.load_receipt import LoadFragment, LoadReceipt
+from vllm.model_executor.load_receipt import (
+    LoadCollisionPolicy,
+    LoadFragment,
+    LoadReceipt,
+)
 
 __all__ = [
     "record_metadata_for_reloading",
@@ -27,6 +31,7 @@ __all__ = [
     "support_quantized_model_reload_from_hp_weights",
     "LoadFragment",
     "LoadReceipt",
+    "LoadCollisionPolicy",
 ]
 
 from .layerwise import (

--- a/vllm/model_executor/model_loader/reload/__init__.py
+++ b/vllm/model_executor/model_loader/reload/__init__.py
@@ -32,6 +32,14 @@ __all__ = [
     "LoadFragment",
     "LoadReceipt",
     "LoadCollisionPolicy",
+    "probe_dummy_load_manifest",
+    "FullBaseWeightScope",
+    "KernelWeightScope",
+    "LoRAAdapterScope",
+    "PartialBaseWeightScope",
+    "UpdateKind",
+    "UpdateScope",
+    "normalize_update_scope",
 ]
 
 from .layerwise import (
@@ -41,6 +49,16 @@ from .layerwise import (
     initialize_layerwise_reload,
     record_load_consumption,
     record_metadata_for_reloading,
+)
+from .probe import probe_dummy_load_manifest
+from .scope import (
+    FullBaseWeightScope,
+    KernelWeightScope,
+    LoRAAdapterScope,
+    PartialBaseWeightScope,
+    UpdateKind,
+    UpdateScope,
+    normalize_update_scope,
 )
 from .torchao_decorator import (
     set_torchao_reload_attrs,

--- a/vllm/model_executor/model_loader/reload/audit.py
+++ b/vllm/model_executor/model_loader/reload/audit.py
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Detect incomplete identities returned by weight-loader receipts."""
+
+import enum
+import inspect
+from dataclasses import dataclass, field
+from typing import TypeAlias
+
+import torch
+
+from vllm.model_executor.load_receipt import (
+    LoadCollisionPolicy,
+    LoadReceipt,
+)
+
+AuditScalar: TypeAlias = str | int | float | bool | None
+AuditValue: TypeAlias = AuditScalar | tuple[AuditScalar, ...]
+
+_EXCLUDED_ARGUMENTS = {
+    "self",
+    "param",
+    "loaded_weight",
+    "return_success",
+}
+_MAX_FINDINGS = 20
+
+
+def _normalize_argument(value: object) -> AuditValue | None:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, enum.Enum):
+        return f"{value.__class__.__qualname__}.{value.name}"
+    if isinstance(value, tuple):
+        normalized: list[AuditScalar] = []
+        for item in value:
+            normalized_item = _normalize_argument(item)
+            if isinstance(normalized_item, tuple):
+                return None
+            if normalized_item is None and item is not None:
+                return None
+            normalized.append(normalized_item)
+        return tuple(normalized)
+    return None
+
+
+def _stable_arguments(
+    args: inspect.BoundArguments,
+) -> tuple[tuple[str, AuditValue], ...]:
+    values = []
+    for name, value in args.arguments.items():
+        if name in _EXCLUDED_ARGUMENTS or isinstance(value, torch.Tensor):
+            continue
+        normalized = _normalize_argument(value)
+        if normalized is not None or value is None:
+            values.append((name, normalized))
+    return tuple(values)
+
+
+def _loaded_tensor_metadata(
+    args: inspect.BoundArguments,
+) -> tuple[tuple[int, ...] | None, str | None]:
+    loaded_weight = args.arguments.get("loaded_weight")
+    if not isinstance(loaded_weight, torch.Tensor):
+        return None, None
+    return tuple(loaded_weight.shape), str(loaded_weight.dtype)
+
+
+def _loader_id(loader: object) -> str:
+    unwrapped = inspect.unwrap(loader)  # type: ignore[arg-type]
+    module = getattr(unwrapped, "__module__", type(unwrapped).__module__)
+    qualname = getattr(unwrapped, "__qualname__", type(unwrapped).__qualname__)
+    return f"{module}.{qualname}"
+
+
+def _declared_schema(loader: object) -> tuple[str, ...] | None:
+    current = loader
+    while current is not None:
+        schema = getattr(current, "load_receipt_fragment_arguments", None)
+        if schema is not None:
+            return tuple(schema)
+        current = getattr(current, "__wrapped__", None)
+    return None
+
+
+@dataclass(frozen=True)
+class LoadCallWitness:
+    """Stable, receipt-independent description of one loader invocation."""
+
+    loader_id: str
+    source_key: str | None
+    param_name: str
+    stable_arguments: tuple[tuple[str, AuditValue], ...]
+    loaded_shape: tuple[int, ...] | None
+    loaded_dtype: str | None
+
+
+@dataclass
+class LoadEventAudit:
+    """Per-layer collision detector for one first-load or reload pass."""
+
+    event_witnesses: dict[str, tuple[LoadCallWitness, bool]] = field(
+        default_factory=dict
+    )
+    target_owners: dict[
+        str, tuple[LoadCallWitness, LoadCollisionPolicy]
+    ] = field(default_factory=dict)
+    loader_schemas: dict[str, tuple[str, ...]] = field(default_factory=dict)
+    findings: list[str] = field(default_factory=list)
+    _finding_keys: set[tuple[object, ...]] = field(default_factory=set)
+    _reported: bool = False
+
+    def observe(
+        self,
+        *,
+        param_name: str,
+        receipt: LoadReceipt,
+        args: inspect.BoundArguments,
+        loader: object,
+        source_key: str | None,
+    ) -> None:
+        fragment = receipt.fragment.format()
+        target_key = (
+            param_name if not fragment else f"{param_name}[{fragment}]"
+        )
+        event_key = (
+            target_key
+            if source_key is None
+            else f"{source_key}=>{target_key}"
+        )
+        loaded_shape, loaded_dtype = _loaded_tensor_metadata(args)
+        witness = LoadCallWitness(
+            loader_id=_loader_id(loader),
+            source_key=source_key,
+            param_name=param_name,
+            stable_arguments=_stable_arguments(args),
+            loaded_shape=loaded_shape,
+            loaded_dtype=loaded_dtype,
+        )
+
+        previous_event = self.event_witnesses.get(event_key)
+        if previous_event is not None:
+            previous_witness, previous_consumed = previous_event
+            if previous_witness != witness:
+                self._report_collision(
+                    "EVENT_KEY_COLLISION",
+                    event_key,
+                    receipt,
+                    previous_witness,
+                    witness,
+                )
+            if previous_consumed != receipt.consumed:
+                self._report_collision(
+                    "STATUS_CONFLICT",
+                    event_key,
+                    receipt,
+                    previous_witness,
+                    witness,
+                )
+        else:
+            self.event_witnesses[event_key] = (witness, receipt.consumed)
+
+        if receipt.consumed:
+            previous_owner = self.target_owners.get(target_key)
+            if (
+                previous_owner is not None
+                and previous_owner[0] != witness
+                and previous_owner[1] is LoadCollisionPolicy.UNIQUE
+                and receipt.collision_policy is LoadCollisionPolicy.UNIQUE
+            ):
+                self._report_collision(
+                    "TARGET_ALIAS_COLLISION",
+                    target_key,
+                    receipt,
+                    previous_owner[0],
+                    witness,
+                )
+            else:
+                self.target_owners[target_key] = (
+                    witness,
+                    receipt.collision_policy,
+                )
+
+        declared_schema = _declared_schema(loader)
+        actual_fields = tuple(name for name, _ in receipt.fragment.items)
+        if declared_schema is not None:
+            expected_fields = tuple(
+                name
+                for name in declared_schema
+                if args.arguments.get(name) is not None
+            )
+        else:
+            expected_fields = actual_fields
+        if declared_schema is not None and actual_fields != expected_fields:
+            self._report(
+                (
+                    "RECEIPT_SCHEMA_MISMATCH",
+                    witness.loader_id,
+                    expected_fields,
+                    actual_fields,
+                ),
+                f"RECEIPT_SCHEMA_MISMATCH: loader={witness.loader_id}, "
+                f"expected_fields={expected_fields!r}, "
+                f"actual_fields={actual_fields!r}",
+            )
+        schema = declared_schema or actual_fields
+        previous_schema = self.loader_schemas.get(witness.loader_id)
+        if previous_schema is not None and previous_schema != schema:
+            self._report(
+                (
+                    "SCHEMA_DRIFT",
+                    witness.loader_id,
+                    previous_schema,
+                    schema,
+                ),
+                f"SCHEMA_DRIFT: loader={witness.loader_id}, "
+                f"first_schema={previous_schema!r}, schema={schema!r}",
+            )
+        else:
+            self.loader_schemas[witness.loader_id] = schema
+
+    def _report_collision(
+        self,
+        kind: str,
+        key: str,
+        receipt: LoadReceipt,
+        first: LoadCallWitness,
+        second: LoadCallWitness,
+    ) -> None:
+        first_args = dict(first.stable_arguments)
+        second_args = dict(second.stable_arguments)
+        differing = tuple(
+            sorted(
+                name
+                for name in first_args.keys() | second_args.keys()
+                if first_args.get(name) != second_args.get(name)
+            )
+        )
+        receipt_fields = {name for name, _ in receipt.fragment.items}
+        missing_fields = tuple(
+            name for name in differing if name not in receipt_fields
+        )
+        self._report(
+            (kind, key, first, second),
+            f"{kind}: key={key!r}, loader={second.loader_id}, "
+            f"first_source={first.source_key!r}, "
+            f"second_source={second.source_key!r}, "
+            f"differing_arguments={differing!r}, "
+            f"possible_missing_receipt_fields={missing_fields!r}",
+        )
+
+    def _report(self, finding_key: tuple[object, ...], message: str) -> None:
+        if finding_key in self._finding_keys:
+            return
+        self._finding_keys.add(finding_key)
+        if len(self.findings) < _MAX_FINDINGS:
+            self.findings.append(message)
+
+    def take_findings(self) -> tuple[str, ...]:
+        """Return findings once, even if a layer is finalized in stages."""
+        if self._reported:
+            return ()
+        self._reported = True
+        return tuple(self.findings)
+
+
+__all__ = [
+    "LoadCallWitness",
+    "LoadEventAudit",
+]

--- a/vllm/model_executor/model_loader/reload/baseline.py
+++ b/vllm/model_executor/model_loader/reload/baseline.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Serializable initial-load baseline for constructing partial update scopes."""
+
+from dataclasses import asdict, dataclass
+from typing import Any, Literal
+
+import torch
+
+from vllm.model_executor.load_receipt import FragmentValue
+
+from .layerwise import get_layerwise_info, get_load_manifest_scope
+from .types import LoadEventIdentity, LoadManifestScope
+
+
+@dataclass(frozen=True)
+class WeightUpdateBaselineEvent:
+    source_name: str
+    target_name: str
+    fragment: tuple[tuple[str, FragmentValue], ...]
+
+
+@dataclass(frozen=True)
+class WeightUpdateBaselineGroup:
+    module_name: str
+    events: tuple[WeightUpdateBaselineEvent, ...]
+
+    @property
+    def source_names(self) -> tuple[str, ...]:
+        return tuple(sorted({event.source_name for event in self.events}))
+
+
+@dataclass(frozen=True)
+class WeightUpdateBaselineReport:
+    scope: LoadManifestScope
+    state: Literal["exact", "provisional", "unavailable"]
+    groups: tuple[WeightUpdateBaselineGroup, ...]
+    provisional_target_names: tuple[str, ...] = ()
+    reason: str | None = None
+
+
+def _event_sort_key(event: LoadEventIdentity) -> str:
+    return event.format()
+
+
+def get_weight_update_baseline(
+    model: torch.nn.Module,
+) -> WeightUpdateBaselineReport:
+    """Return this worker's immutable first-load completion baseline."""
+    groups: list[WeightUpdateBaselineGroup] = []
+    provisional_targets: list[str] = []
+    has_parameters = any(True for _ in model.parameters())
+    has_unaddressable_event = False
+
+    for module_name, module in model.named_modules():
+        info = get_layerwise_info(module)
+        provisional_targets.extend(
+            f"{module_name}.{name}" if module_name else name
+            for name in (info.required_target_keys or ())
+        )
+        events = []
+        for event in sorted(info.required_events or (), key=_event_sort_key):
+            if event.source_name is None:
+                has_unaddressable_event = True
+                continue
+            target_name = (
+                f"{module_name}.{event.target_name}"
+                if module_name
+                else event.target_name
+            )
+            events.append(
+                WeightUpdateBaselineEvent(
+                    source_name=event.source_name,
+                    target_name=target_name,
+                    fragment=event.fragment.items,
+                )
+            )
+        if events:
+            groups.append(
+                WeightUpdateBaselineGroup(
+                    module_name=module_name,
+                    events=tuple(events),
+                )
+            )
+
+    state: Literal["exact", "provisional", "unavailable"]
+    reason: str | None
+    if provisional_targets:
+        state = "provisional"
+        reason = (
+            "The model has only a target-side dummy baseline. Run one complete "
+            "real base-weight update or enable dummy load probing before "
+            "requesting partial checkpoint scopes."
+        )
+    elif has_unaddressable_event:
+        state = "unavailable"
+        reason = "The initial-load baseline contains events without source names."
+    elif has_parameters and not groups:
+        state = "unavailable"
+        reason = "No structured initial-load baseline was recorded."
+    else:
+        state = "exact"
+        reason = None
+
+    return WeightUpdateBaselineReport(
+        scope=get_load_manifest_scope(),
+        state=state,
+        groups=tuple(groups),
+        provisional_target_names=tuple(sorted(set(provisional_targets))),
+        reason=reason,
+    )
+
+
+def aggregate_weight_update_baselines(
+    reports: list[WeightUpdateBaselineReport],
+) -> dict[str, Any]:
+    """Merge rank-local closure constraints into global atomic source groups."""
+    non_exact = [report for report in reports if report.state != "exact"]
+    all_sources = {
+        event.source_name
+        for report in reports
+        for group in report.groups
+        for event in group.events
+    }
+
+    parent = {name: name for name in all_sources}
+
+    def find(name: str) -> str:
+        while parent[name] != name:
+            parent[name] = parent[parent[name]]
+            name = parent[name]
+        return name
+
+    def union(left: str, right: str) -> None:
+        left_root, right_root = find(left), find(right)
+        if left_root != right_root:
+            parent[right_root] = left_root
+
+    for report in reports:
+        for group in report.groups:
+            names = group.source_names
+            for name in names[1:]:
+                union(names[0], name)
+
+    components: dict[str, set[str]] = {}
+    for name in all_sources:
+        components.setdefault(find(name), set()).add(name)
+    atomic_groups = sorted(
+        (sorted(names) for names in components.values()),
+        key=lambda names: names[0],
+    )
+
+    return {
+        "ready": not non_exact,
+        "reason": (
+            None
+            if not non_exact
+            else "; ".join(
+                sorted({report.reason or report.state for report in non_exact})
+            )
+        ),
+        "scope_template": {
+            "kind": "base_checkpoint",
+            "mode": "partial",
+            "source_names": [],
+        },
+        "source_names": sorted(all_sources),
+        # A legal partial scope is a union of these connected components.
+        "atomic_source_groups": atomic_groups,
+        "atomic_update_scopes": [
+            {
+                "kind": "base_checkpoint",
+                "mode": "partial",
+                "source_names": names,
+            }
+            for names in atomic_groups
+        ],
+        "workers": [asdict(report) for report in reports],
+    }
+
+
+__all__ = [
+    "WeightUpdateBaselineEvent",
+    "WeightUpdateBaselineGroup",
+    "WeightUpdateBaselineReport",
+    "aggregate_weight_update_baselines",
+    "get_weight_update_baseline",
+]

--- a/vllm/model_executor/model_loader/reload/baseline.py
+++ b/vllm/model_executor/model_loader/reload/baseline.py
@@ -179,10 +179,91 @@ def aggregate_weight_update_baselines(
     }
 
 
+def get_weight_update_manifest(
+    model: torch.nn.Module,
+    lora_adapters: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Return one worker's model-weight and LoRA update manifests."""
+    return {
+        "model_weights": get_weight_update_baseline(model),
+        "lora_adapters": list(lora_adapters or ()),
+    }
+
+
+def aggregate_weight_update_manifests(
+    manifests: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Aggregate all worker-local updatable-weight manifests."""
+    model_weights = aggregate_weight_update_baselines(
+        [manifest["model_weights"] for manifest in manifests]
+    )
+    adapters: dict[tuple[int, str], dict[str, Any]] = {}
+    for worker_index, manifest in enumerate(manifests):
+        for local in manifest.get("lora_adapters", ()):
+            key = (local["adapter_id"], local["adapter_name"])
+            adapter = adapters.setdefault(
+                key,
+                {
+                    "adapter_id": local["adapter_id"],
+                    "adapter_name": local["adapter_name"],
+                    "rank": local["rank"],
+                    "generation": local["generation"],
+                    "module_names": set(),
+                    "modules": {},
+                    "workers": [],
+                    "replace_scope_template": local["replace_scope_template"],
+                    "patch_scope_template": local["patch_scope_template"],
+                    "remove_scope_template": local["remove_scope_template"],
+                },
+            )
+            if adapter["rank"] != local["rank"]:
+                raise RuntimeError(
+                    "Workers disagree on LoRA rank for adapter "
+                    f"{local['adapter_id']} ({local['adapter_name']!r})"
+                )
+            if adapter["generation"] != local["generation"]:
+                raise RuntimeError(
+                    "Workers disagree on LoRA generation for adapter "
+                    f"{local['adapter_id']} ({local['adapter_name']!r})"
+                )
+            adapter["module_names"].update(local["module_names"])
+            for module in local["modules"]:
+                adapter["modules"].setdefault(module["module_name"], []).append(
+                    {
+                        "worker_index": worker_index,
+                        "lora_a": module["lora_a"],
+                        "lora_b": module["lora_b"],
+                    }
+                )
+            adapter["workers"].append(
+                {
+                    "worker_index": worker_index,
+                    "module_names": local["module_names"],
+                }
+            )
+    lora_adapters = []
+    for adapter in adapters.values():
+        adapter["module_names"] = sorted(adapter["module_names"])
+        adapter["modules"] = [
+            {"module_name": name, "workers": workers}
+            for name, workers in sorted(adapter["modules"].items())
+        ]
+        lora_adapters.append(adapter)
+    lora_adapters.sort(
+        key=lambda adapter: (adapter["adapter_id"], adapter["adapter_name"])
+    )
+    return {
+        "model_weights": model_weights,
+        "lora_adapters": lora_adapters,
+    }
+
+
 __all__ = [
     "WeightUpdateBaselineEvent",
     "WeightUpdateBaselineGroup",
     "WeightUpdateBaselineReport",
     "aggregate_weight_update_baselines",
+    "aggregate_weight_update_manifests",
     "get_weight_update_baseline",
+    "get_weight_update_manifest",
 ]

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -13,8 +13,6 @@ from vllm.model_executor.layers.attention import Attention, MLAAttention
 from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
 from vllm.model_executor.load_receipt import LoadFragment, LoadReceipt
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
-from vllm.model_executor.reload_arena import peek_reload_arena
-
 from .audit import LoadEventAudit
 from .meta import (
     SKIP_TENSORS,

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -57,6 +57,7 @@ __all__ = [
     "finalize_load_recording",
     "get_layer_completion_findings",
     "get_load_manifest_report",
+    "get_load_manifest_scope",
     "record_dummy_load_manifest",
     "record_direct_load_consumption",
     "record_external_tensor_manifest",
@@ -105,7 +106,7 @@ def get_layer_completion_findings() -> list[str]:
     return list(_LAYER_COMPLETION_FINDINGS)
 
 
-def _get_load_manifest_scope() -> LoadManifestScope:
+def get_load_manifest_scope() -> LoadManifestScope:
     """Best-effort distributed coordinates without requiring distributed init."""
     try:
         from vllm.distributed.parallel_state import (
@@ -164,7 +165,7 @@ def get_load_manifest_report(
         else FullBaseWeightScope()
     )
     return LoadManifestReport(
-        scope=_get_load_manifest_scope(),
+        scope=get_load_manifest_scope(),
         required_event_count=(
             _LAST_RELOAD_REQUIRED_EVENT_COUNTS.get(model, 0)
             if model is not None

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -23,9 +23,16 @@ from .meta import (
     materialize_layer,
     restore_layer_on_meta,
 )
+from .scope import (
+    FullBaseWeightScope,
+    PartialBaseWeightScope,
+    UpdateScope,
+    normalize_update_scope,
+)
 from .source import get_current_source_key
 from .types import (
     LayerReloadingInfo,
+    LoadEventIdentity,
     LoadManifestGroupScope,
     LoadManifestReport,
     LoadManifestScope,
@@ -81,6 +88,15 @@ _DUMMY_BASELINE_FAILURES: list[str] = []
 _LAST_RELOAD_RECEIVED_EVENT_COUNTS: WeakKeyDictionary[torch.nn.Module, int] = (
     WeakKeyDictionary()
 )
+_LAST_RELOAD_REQUIRED_EVENT_COUNTS: WeakKeyDictionary[torch.nn.Module, int] = (
+    WeakKeyDictionary()
+)
+_LAST_RELOAD_SCOPES: WeakKeyDictionary[torch.nn.Module, UpdateScope] = (
+    WeakKeyDictionary()
+)
+_LAST_RELOAD_RESOLVED_SOURCES: WeakKeyDictionary[
+    torch.nn.Module, set[str]
+] = WeakKeyDictionary()
 
 
 def get_layer_completion_findings() -> list[str]:
@@ -142,10 +158,17 @@ def get_load_manifest_report(
         if model is not None
         else list(LAYERWISE_INFO.values())
     )
+    update_scope = (
+        _LAST_RELOAD_SCOPES.get(model, FullBaseWeightScope())
+        if model is not None
+        else FullBaseWeightScope()
+    )
     return LoadManifestReport(
         scope=_get_load_manifest_scope(),
-        required_event_count=sum(
-            len(info.required_keys or ()) for info in infos
+        required_event_count=(
+            _LAST_RELOAD_REQUIRED_EVENT_COUNTS.get(model, 0)
+            if model is not None
+            else sum(len(info.required_keys or ()) for info in infos)
         ),
         received_event_count=(
             _LAST_RELOAD_RECEIVED_EVENT_COUNTS.get(model, 0)
@@ -153,6 +176,16 @@ def get_load_manifest_report(
             else sum(_LAST_RELOAD_RECEIVED_EVENT_COUNTS.values())
         ),
         completion_findings=tuple(_LAYER_COMPLETION_FINDINGS),
+        update_kind=update_scope.kind.value,
+        update_mode=getattr(update_scope, "mode", "full"),
+        declared_source_names=(
+            tuple(sorted(update_scope.source_names))
+            if isinstance(update_scope, PartialBaseWeightScope)
+            else ()
+        ),
+        resolved_source_names=tuple(
+            sorted(_LAST_RELOAD_RESOLVED_SOURCES.get(model, set()))
+        ),
     )
 
 
@@ -182,6 +215,8 @@ def record_load_consumption(model: torch.nn.Module) -> None:
         info.load_event_audit = LoadEventAudit()
         if info.required_keys is None:
             info.required_keys = set()
+        if info.required_events is None:
+            info.required_events = set()
         for name, tensor in get_layer_tensors(layer).items():
             # Wrap the effective loader (falling back to default_weight_loader,
             # same as the reload path), so params that rely on the default are
@@ -242,13 +277,26 @@ def record_direct_load_consumption(
         layer, param_name = model, target_name
     info = get_layerwise_info(layer)
     event = f"{source_key}=>{param_name}"
+    identity = LoadEventIdentity(source_key, param_name)
+    if (
+        info.active_required_events is not None
+        and identity not in info.active_required_events
+    ):
+        raise ValueError(
+            "Direct weight load targeted state outside the explicit update "
+            f"scope: {identity.format()}"
+        )
     if info.can_load():
         info.received_keys.add(event)
+        info.received_events.add(identity)
         info.received_target_keys.add(param_name)
     else:
         if info.required_keys is None:
             info.required_keys = set()
+        if info.required_events is None:
+            info.required_events = set()
         info.required_keys.add(event)
+        info.required_events.add(identity)
 
 
 def record_external_tensor_manifest(
@@ -277,9 +325,12 @@ def record_external_tensor_manifest(
         info = get_layerwise_info(layer)
         if info.required_keys is None:
             info.required_keys = set()
-        info.required_keys.add(
-            f"{source_scheme}://{source_name}=>{local_name}"
-        )
+        if info.required_events is None:
+            info.required_events = set()
+        source_key = f"{source_scheme}://{source_name}"
+        identity = LoadEventIdentity(source_key, local_name)
+        info.required_keys.add(identity.format())
+        info.required_events.add(identity)
         recorded_names.add(source_name)
 
     # External registries may use aliases that are not resolvable as module
@@ -299,10 +350,15 @@ def record_external_tensor_manifest(
             seen.add(storage_ptr)
             if info.required_keys is None:
                 info.required_keys = set()
+            if info.required_events is None:
+                info.required_events = set()
             source_name = names_by_storage[storage_ptr]
-            info.required_keys.add(
-                f"{source_scheme}://{source_name}=>{local_name}"
+            identity = LoadEventIdentity(
+                f"{source_scheme}://{source_name}",
+                local_name,
             )
+            info.required_keys.add(identity.format())
+            info.required_events.add(identity)
 
 
 def _make_recording_loader(info: LayerReloadingInfo, name: str,
@@ -324,7 +380,10 @@ def _make_recording_loader(info: LayerReloadingInfo, name: str,
             original,
         )
         if receipt.consumed:
-            info.required_keys.add(_load_event_key(name, receipt))
+            event = _load_event_identity(name, receipt)
+            info.required_keys.add(event.format())
+            assert info.required_events is not None
+            info.required_events.add(event)
         return result
 
     # A distinct __name__ so _get_original_loader (which unwraps only
@@ -384,12 +443,18 @@ def _load_event_key(param_name: str, receipt: LoadReceipt) -> str:
     Keeping the no-fragment representation equal to ``param_name`` preserves
     compatibility for ordinary parameters and existing diagnostics.
     """
-    fragment = receipt.fragment.format()
-    target = param_name if not fragment else f"{param_name}[{fragment}]"
-    source_key = get_current_source_key()
-    if source_key is None:
-        return target
-    return f"{source_key}=>{target}"
+    return _load_event_identity(param_name, receipt).format()
+
+
+def _load_event_identity(
+    param_name: str,
+    receipt: LoadReceipt,
+) -> LoadEventIdentity:
+    return LoadEventIdentity(
+        source_name=get_current_source_key(),
+        target_name=param_name,
+        fragment=receipt.fragment,
+    )
 
 
 def _audit_load_receipt(
@@ -448,6 +513,17 @@ def _check_set_completion(layer: torch.nn.Module,
     checkpoint-backed tensor excluded from meta restoration can legitimately
     arrive later. Numel stays authoritative; this only records discrepancies.
     """
+    if info.active_required_events is not None:
+        missing_events = info.active_required_events - info.received_events
+        unexpected_events = info.received_events - info.active_required_events
+        if missing_events or unexpected_events:
+            _LAYER_COMPLETION_FINDINGS.append(
+                f"{layer.__class__.__name__}: explicit update scope mismatch: "
+                f"missing={sorted(e.format() for e in missing_events)[:8]}, "
+                f"unexpected={sorted(e.format() for e in unexpected_events)[:8]}"
+            )
+        return
+
     if info.required_keys is None:
         return  # no observed baseline (first-load recording did not run)
     missing_targets = (
@@ -471,6 +547,7 @@ def _check_set_completion(layer: torch.nn.Module,
         # The first complete real transfer turns the provisional dummy target
         # baseline into the exact source/fragment manifest.
         info.required_keys = set(info.received_keys)
+        info.required_events = set(info.received_events)
         info.required_target_keys = None
 
 
@@ -482,10 +559,17 @@ def _has_exact_manifest(info: LayerReloadingInfo) -> bool:
     transfer.  Such a transfer still uses the legacy completion path while it
     learns the rank-local exact event set.
     """
+    if info.active_required_events is not None:
+        return bool(info.active_required_events)
     return bool(info.required_keys) and info.required_target_keys is None
 
 
 def _manifest_complete(info: LayerReloadingInfo) -> bool:
+    if info.active_required_events is not None:
+        return (
+            bool(info.active_required_events)
+            and info.active_required_events <= info.received_events
+        )
     return (
         _has_exact_manifest(info)
         and info.required_keys is not None
@@ -520,8 +604,51 @@ def record_metadata_for_reloading(model: torch.nn.Module):
         info.restore_device = torch.get_default_device()
 
 
+def _resolve_partial_checkpoint_scope(
+    model: torch.nn.Module,
+    scope: PartialBaseWeightScope,
+) -> dict[torch.nn.Module, set[LoadEventIdentity]]:
+    """Resolve source names and reject scopes that split one processing unit."""
+    declared = set(scope.source_names)
+    resolved: dict[torch.nn.Module, set[LoadEventIdentity]] = {}
+
+    for layer in model.modules():
+        info = get_layerwise_info(layer)
+        if info.required_target_keys is not None:
+            raise RuntimeError(
+                "Partial checkpoint updates are not allowed before a dummy "
+                "model has received one complete real base-weight update"
+            )
+        baseline = info.required_events
+        if baseline is None:
+            if info.required_keys:
+                raise RuntimeError(
+                    "Partial checkpoint updates require a structured initial-load "
+                    f"manifest; {layer.__class__.__name__} only has legacy keys"
+                )
+            resolved[layer] = set()
+            continue
+
+        selected = {
+            event for event in baseline if event.source_name in declared
+        }
+        if selected and selected != baseline:
+            missing = sorted(event.format() for event in baseline - selected)
+            raise ValueError(
+                "Partial checkpoint update splits a layerwise processing unit "
+                f"{layer.__class__.__name__}: selected={len(selected)}, "
+                f"required={len(baseline)}, missing={missing[:8]}"
+            )
+        resolved[layer] = selected
+
+    return resolved
+
+
 @torch.no_grad()
-def initialize_layerwise_reload(model: torch.nn.Module):
+def initialize_layerwise_reload(
+    model: torch.nn.Module,
+    update_scope: UpdateScope | dict | None = None,
+):
     """
     Set up layerwise weight loading with deferred processing.
 
@@ -536,6 +663,24 @@ def initialize_layerwise_reload(model: torch.nn.Module):
     3. Run quantization processing if applicable
     4. Copy processed values back to original tensor storage
     """
+    scope = normalize_update_scope(update_scope)
+    _LAST_RELOAD_SCOPES[model] = scope
+    partial = (
+        _resolve_partial_checkpoint_scope(model, scope)
+        if isinstance(scope, PartialBaseWeightScope)
+        else None
+    )
+    _LAST_RELOAD_RESOLVED_SOURCES[model] = (
+        {
+            event.source_name
+            for events in partial.values()
+            for event in events
+            if event.source_name is not None
+        }
+        if partial is not None
+        else set()
+    )
+
     # disable torchao reloading to avoid infinite recursion
     model._original_do_torchao_reload = getattr(model, "_do_torchao_reload", False)
     model._do_torchao_reload = False
@@ -544,9 +689,15 @@ def initialize_layerwise_reload(model: torch.nn.Module):
         _LAYER_COMPLETION_FINDINGS.clear()
         _DUMMY_BASELINE_FAILURES.clear()
         _LAST_RELOAD_RECEIVED_EVENT_COUNTS[model] = 0
+        _LAST_RELOAD_REQUIRED_EVENT_COUNTS[model] = 0
 
     for layer in model.modules():
         info = get_layerwise_info(layer)
+
+        if partial is not None:
+            info.active_required_events = partial[layer]
+            if not info.active_required_events:
+                continue
 
         # Skip if the layer has already been initialized
         if info.can_load():
@@ -575,6 +726,7 @@ def initialize_online_processing(layer: torch.nn.Module):
 
     # Track loading progress to determine when to process/copy
     info.received_keys.clear()
+    info.received_events.clear()
     info.received_target_keys.clear()
     info.load_event_audit = LoadEventAudit()
     info.is_loading = True
@@ -644,7 +796,9 @@ def _make_receipt_observer(info: LayerReloadingInfo, param_name: str,
             original_loader,
         )
         if receipt.consumed:
-            info.received_keys.add(_load_event_key(param_name, receipt))
+            event = _load_event_identity(param_name, receipt)
+            info.received_keys.add(event.format())
+            info.received_events.add(event)
             info.received_target_keys.add(param_name)
         return result
 
@@ -695,7 +849,9 @@ def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Calla
             original_loader,
         )
         if receipt.consumed:
-            info.received_keys.add(_load_event_key(param_name, receipt))
+            event = _load_event_identity(param_name, receipt)
+            info.received_keys.add(event.format())
+            info.received_events.add(event)
             info.received_target_keys.add(param_name)
 
         logger.debug(
@@ -756,11 +912,17 @@ def finalize_layerwise_processing(model: torch.nn.Module, model_config: ModelCon
     if hasattr(model, "_original_do_torchao_reload"):
         model._do_torchao_reload = model._original_do_torchao_reload
 
+    required_event_count = 0
     received_event_count = 0
     deferred_attn: list[tuple[torch.nn.Module, LayerReloadingInfo]] = []
 
     for layer in model.modules():
         info = get_layerwise_info(layer)
+        required_event_count += (
+            len(info.active_required_events)
+            if info.active_required_events is not None
+            else len(info.required_keys or ())
+        )
         if not info.can_load():
             received_event_count += len(info.received_keys)
             _check_set_completion(layer, info)
@@ -812,6 +974,7 @@ def finalize_layerwise_processing(model: torch.nn.Module, model_config: ModelCon
         info.reset()
 
     LOADING_LAYERS.clear()
+    _LAST_RELOAD_REQUIRED_EVENT_COUNTS[model] = required_event_count
     _LAST_RELOAD_RECEIVED_EVENT_COUNTS[model] = received_event_count
     if _DUMMY_BASELINE_FAILURES:
         raise RuntimeError(

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -11,7 +11,9 @@ from vllm.config import ModelConfig
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention import Attention, MLAAttention
 from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
+from vllm.model_executor.load_receipt import LoadFragment, LoadReceipt
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.reload_arena import peek_reload_arena
 
 from .meta import (
     SKIP_TENSORS,
@@ -311,8 +313,9 @@ def _make_recording_loader(info: LayerReloadingInfo, name: str,
         bound_args.apply_defaults()
         result = original(*args, **kwargs)
         assert info.required_keys is not None
-        if _load_call_consumed(bound_args, result):
-            info.required_keys.add(_load_event_key(name, bound_args))
+        receipt = _get_load_receipt(bound_args, result)
+        if receipt.consumed:
+            info.required_keys.add(_load_event_key(name, receipt))
         return result
 
     # A distinct __name__ so _get_original_loader (which unwraps only
@@ -333,8 +336,37 @@ _LOAD_FRAGMENT_ARGUMENTS = (
 )
 
 
-def _load_event_key(param_name: str,
-                    args: inspect.BoundArguments) -> str:
+def _legacy_load_receipt(
+    args: inspect.BoundArguments,
+    result: object,
+) -> LoadReceipt:
+    """Adapt existing None/bool loaders during the receipt migration."""
+    consumed = (
+        result is True
+        if args.arguments.get("return_success") is True
+        else True
+    )
+    fields = {
+        name: args.arguments.get(name)
+        for name in _LOAD_FRAGMENT_ARGUMENTS
+        if args.arguments.get(name) is not None
+    }
+    return LoadReceipt(
+        consumed=consumed,
+        fragment=LoadFragment.from_fields(**fields),
+    )
+
+
+def _get_load_receipt(
+    args: inspect.BoundArguments,
+    result: object,
+) -> LoadReceipt:
+    if isinstance(result, LoadReceipt):
+        return result
+    return _legacy_load_receipt(args, result)
+
+
+def _load_event_key(param_name: str, receipt: LoadReceipt) -> str:
     """Return the logical target fragment consumed by one loader call.
 
     A loader invocation is one event regardless of how many internal writes
@@ -343,24 +375,12 @@ def _load_event_key(param_name: str,
     Keeping the no-fragment representation equal to ``param_name`` preserves
     compatibility for ordinary parameters and existing diagnostics.
     """
-    fragments = []
-    for name in _LOAD_FRAGMENT_ARGUMENTS:
-        value = args.arguments.get(name)
-        if value is not None:
-            fragments.append(f"{name}={value!r}")
-    target = (param_name if not fragments else
-              f"{param_name}[{','.join(fragments)}]")
+    fragment = receipt.fragment.format()
+    target = param_name if not fragment else f"{param_name}[{fragment}]"
     source_key = get_current_source_key()
     if source_key is None:
         return target
     return f"{source_key}=>{target}"
-
-
-def _load_call_consumed(args: inspect.BoundArguments, result: object) -> bool:
-    """Whether a conditional loader reports that it consumed this fragment."""
-    if args.arguments.get("return_success") is True:
-        return result is True
-    return True
 
 
 def finalize_load_recording(model: torch.nn.Module) -> None:
@@ -568,8 +588,9 @@ def _make_receipt_observer(info: LayerReloadingInfo, param_name: str,
         bound_args = loader_signature.bind(*args, **kwargs)
         bound_args.apply_defaults()
         result = original_loader(*args, **kwargs)
-        if _load_call_consumed(bound_args, result):
-            info.received_keys.add(_load_event_key(param_name, bound_args))
+        receipt = _get_load_receipt(bound_args, result)
+        if receipt.consumed:
+            info.received_keys.add(_load_event_key(param_name, receipt))
             info.received_target_keys.add(param_name)
         return result
 
@@ -611,8 +632,9 @@ def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Calla
         # This distinguishes Q/K/V shards and MoE expert/shard calls that
         # share one packed destination parameter. Internal copy_ calls remain
         # invisible: the loader invocation, not a storage write, is the event.
-        if _load_call_consumed(bound_args, ret):
-            info.received_keys.add(_load_event_key(param_name, bound_args))
+        receipt = _get_load_receipt(bound_args, ret)
+        if receipt.consumed:
+            info.received_keys.add(_load_event_key(param_name, receipt))
             info.received_target_keys.add(param_name)
 
         logger.debug(

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -37,6 +37,9 @@ __all__ = [
     "initialize_layerwise_reload",
     "finalize_layerwise_processing",
     "finalize_layerwise_reload",
+    "record_load_consumption",
+    "finalize_load_recording",
+    "get_layer_completion_findings",
 ]
 
 
@@ -51,6 +54,101 @@ LAYERWISE_INFO: WeakKeyDictionary[torch.nn.Module, LayerReloadingInfo] = (
 
 # Global set used to track loading for logging purposes only
 LOADING_LAYERS: WeakSet[torch.nn.Module] = WeakSet()
+
+# Per-layer disagreements between the numel completion criterion and the
+# observed-key-set criterion, found during the current reload. Cleared at
+# reload start, read after finalize. Dual-run signal only -- numel stays
+# authoritative until the set criterion has a release of agreement.
+_LAYER_COMPLETION_FINDINGS: list[str] = []
+
+
+def get_layer_completion_findings() -> list[str]:
+    """Where the numel and observed-key-set completion criteria disagreed
+    during the last reload."""
+    return list(_LAYER_COMPLETION_FINDINGS)
+
+
+def record_load_consumption(model: torch.nn.Module) -> None:
+    """Observe the required key set from the first load.
+
+    Wrap every parameter/buffer weight_loader so it records its name into the
+    owning layer's ``required_keys`` when it fires. Install this BEFORE the
+    first ``load_weights``; call ``finalize_load_recording`` after.
+
+    The observed set is the ground truth of what a correct load consumes, with
+    no prediction from layer structure: a tensor that is never routed through a
+    loader (EP bookkeeping such as ``_expert_map``, a shared bias copy with no
+    checkpoint key) simply never fires, so it is absent from ``required_keys``.
+    That is what removes the need for a hand-maintained ``SKIP_TENSORS``
+    allowlist -- and it is exactly the "capturing how many weights are loaded
+    on first pass" that make_online_process_loader's own comment anticipated.
+
+    Note: parameters must exist when this is called. Quantization weights and
+    biases are created at model init (before the first load), so the common
+    case is covered; a parameter registered during load itself would be
+    missed (a known edge, shared with the reload path's late-registration
+    handling).
+    """
+    for layer in model.modules():
+        info = get_layerwise_info(layer)
+        if info.required_keys is None:
+            info.required_keys = set()
+        for name, tensor in get_layer_tensors(layer).items():
+            # Wrap the effective loader (falling back to default_weight_loader,
+            # same as the reload path), so params that rely on the default are
+            # observed too. A tensor the checkpoint never drives -- a
+            # bookkeeping buffer with no key -- simply never has its loader
+            # called, so it stays out of required_keys.
+            current = getattr(tensor, "weight_loader", None)
+            if current is not None and getattr(current, "_vllm_recording",
+                                               False):
+                continue
+            tensor.weight_loader = _make_recording_loader(
+                info, name, _get_weight_loader(tensor))
+
+
+def _make_recording_loader(info: LayerReloadingInfo, name: str,
+                           original: Callable) -> Callable:
+    @wraps(original, assigned=("__doc__", "__annotations__"))
+    def recording_loader(*args, **kwargs):
+        assert info.required_keys is not None
+        info.required_keys.add(name)
+        return original(*args, **kwargs)
+
+    # A distinct __name__ so _get_original_loader (which unwraps only
+    # "online_process_loader") does not strip it; finalize_load_recording
+    # removes it explicitly instead.
+    recording_loader.__name__ = "recording_loader"
+    recording_loader._vllm_recording = True  # type: ignore[attr-defined]
+    recording_loader._vllm_orig = original  # type: ignore[attr-defined]
+    return recording_loader
+
+
+def finalize_load_recording(model: torch.nn.Module) -> None:
+    """Remove the recording wrappers installed by record_load_consumption,
+    restoring the original loaders so the reload path is unaffected."""
+    for layer in model.modules():
+        for name, tensor in get_layer_tensors(layer).items():
+            loader = getattr(tensor, "weight_loader", None)
+            if loader is not None and getattr(loader, "_vllm_recording", False):
+                tensor.weight_loader = loader._vllm_orig
+
+
+def _check_set_completion(layer: torch.nn.Module,
+                          info: LayerReloadingInfo) -> None:
+    """Dual-run: at the moment the numel criterion fires completion, record
+    whether the observed-key-set criterion agrees. A disagreement where numel
+    says complete but keys are still missing is the #44814 shape (a dropped
+    parameter masked by an over-count). Numel stays authoritative; this only
+    records the discrepancy."""
+    if info.required_keys is None:
+        return  # no observed baseline (first-load recording did not run)
+    missing = info.required_keys - info.received_keys
+    if missing:
+        _LAYER_COMPLETION_FINDINGS.append(
+            f"{layer.__class__.__name__}: numel completion fired but "
+            f"{len(missing)} observed key(s) not yet received: "
+            f"{sorted(missing)[:8]}")
 
 
 def get_layerwise_info(layer: torch.nn.Module) -> LayerReloadingInfo:
@@ -99,6 +197,9 @@ def initialize_layerwise_reload(model: torch.nn.Module):
     # disable torchao reloading to avoid infinite recursion
     model._original_do_torchao_reload = getattr(model, "_do_torchao_reload", False)
     model._do_torchao_reload = False
+
+    if not any(get_layerwise_info(m).can_load() for m in model.modules()):
+        _LAYER_COMPLETION_FINDINGS.clear()
 
     for layer in model.modules():
         info = get_layerwise_info(layer)
@@ -185,6 +286,13 @@ def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Calla
         info.loaded_weights.append((param_name, bound_args))
         num_loaded, ret = get_numel_loaded(original_loader, bound_args)
         info.load_numel += num_loaded
+
+        # Observed-key-set accounting, dual-run alongside numel. A set dedups
+        # naturally, so a key loaded more than once (some qconfigs load
+        # weight_shape per qkv partition -- see "Excessive loading" above) is
+        # idempotent here rather than an error; strict duplicate rejection is
+        # a later, separate policy.
+        info.received_keys.add(param_name)
 
         logger.debug(
             "%s: %d / %d",
@@ -302,7 +410,6 @@ def _finalize_attention_layer(
         _place_kernel_tensors(layer, info)
     layer.process_weights_after_loading(model_config.dtype)
 
-
 def _reload_attention_scales(layer: torch.nn.Module, info: LayerReloadingInfo) -> None:
     """Load and process attention scale weights (k_scale, v_scale, etc.)
     during reload.
@@ -365,6 +472,12 @@ def _layerwise_process(layer: torch.nn.Module, info: LayerReloadingInfo):
     # this code is a no-op if not reloading (because kernel tensors is empty)
     if info.kernel_tensors is not None:
         _copy_and_restore_kernel_tensors(layer, info)
+
+    # Dual-run: does the observed key set agree the layer is complete? Runs
+    # here (covering online-completed AND delayed layers) because received_keys
+    # is still alive before reset(); required_keys survives reset, received
+    # does not, so this cannot be deferred to the finalize reset loop.
+    _check_set_completion(layer, info)
 
     info.reset()
     logger.debug("%s: Processed", layer.__class__.__name__)

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -13,6 +13,7 @@ from vllm.model_executor.layers.attention import Attention, MLAAttention
 from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
 from vllm.model_executor.load_receipt import LoadFragment, LoadReceipt
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+
 from .audit import LoadEventAudit
 from .meta import (
     SKIP_TENSORS,

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -20,7 +20,13 @@ from .meta import (
     materialize_layer,
     restore_layer_on_meta,
 )
-from .types import LayerReloadingInfo
+from .source import get_current_source_key
+from .types import (
+    LayerReloadingInfo,
+    LoadManifestGroupScope,
+    LoadManifestReport,
+    LoadManifestScope,
+)
 from .utils import (
     get_info_size,
     get_layer_params_buffers,
@@ -40,6 +46,11 @@ __all__ = [
     "record_load_consumption",
     "finalize_load_recording",
     "get_layer_completion_findings",
+    "get_load_manifest_report",
+    "record_dummy_load_manifest",
+    "record_direct_load_consumption",
+    "record_external_tensor_manifest",
+    "has_dummy_load_manifest",
 ]
 
 
@@ -60,12 +71,86 @@ LOADING_LAYERS: WeakSet[torch.nn.Module] = WeakSet()
 # reload start, read after finalize. Dual-run signal only -- numel stays
 # authoritative until the set criterion has a release of agreement.
 _LAYER_COMPLETION_FINDINGS: list[str] = []
+_DUMMY_BASELINE_FAILURES: list[str] = []
+# The per-layer receipt sets are transient and are cleared at finalize. Keep
+# one aggregate per model so a controller can inspect it afterwards without
+# mixing staged/replaced models that temporarily share a worker process.
+_LAST_RELOAD_RECEIVED_EVENT_COUNTS: WeakKeyDictionary[torch.nn.Module, int] = (
+    WeakKeyDictionary()
+)
 
 
 def get_layer_completion_findings() -> list[str]:
     """Where the numel and observed-key-set completion criteria disagreed
     during the last reload."""
     return list(_LAYER_COMPLETION_FINDINGS)
+
+
+def _get_load_manifest_scope() -> LoadManifestScope:
+    """Best-effort distributed coordinates without requiring distributed init."""
+    try:
+        from vllm.distributed.parallel_state import (
+            get_dp_group,
+            get_ep_group,
+            get_pp_group,
+            get_tp_group,
+            get_world_group,
+        )
+
+        world = get_world_group()
+
+        def group_scope(get_group: Callable) -> LoadManifestGroupScope | None:
+            try:
+                group = get_group()
+            except (AssertionError, RuntimeError):
+                return None
+            return LoadManifestGroupScope(
+                rank=group.rank_in_group,
+                world_size=group.world_size,
+            )
+
+        return LoadManifestScope(
+            global_rank=world.rank,
+            global_world_size=world.world_size,
+            tp=group_scope(get_tp_group),
+            pp=group_scope(get_pp_group),
+            dp=group_scope(get_dp_group),
+            ep=group_scope(get_ep_group),
+        )
+    except (AssertionError, RuntimeError):
+        return LoadManifestScope()
+
+
+def get_load_manifest_report(
+    model: torch.nn.Module | None = None,
+) -> LoadManifestReport:
+    """Return this worker's rank-local manifest/reconciliation result.
+
+    The event sets stay process-local by design. Combining them before
+    reconciliation would hide a missing TP/PP/EP shard on one rank behind an
+    event received by another rank. Executors/controllers should collect one
+    report per worker and require every report to be ``ok``.
+    """
+    # Supplying the model avoids mixing manifests if a process temporarily
+    # retains more than one model (tests and staged model replacement can do
+    # this). Worker RPC callers should always provide their active model.
+    infos = (
+        [get_layerwise_info(module) for module in model.modules()]
+        if model is not None
+        else list(LAYERWISE_INFO.values())
+    )
+    return LoadManifestReport(
+        scope=_get_load_manifest_scope(),
+        required_event_count=sum(
+            len(info.required_keys or ()) for info in infos
+        ),
+        received_event_count=(
+            _LAST_RELOAD_RECEIVED_EVENT_COUNTS.get(model, 0)
+            if model is not None
+            else sum(_LAST_RELOAD_RECEIVED_EVENT_COUNTS.values())
+        ),
+        completion_findings=tuple(_LAYER_COMPLETION_FINDINGS),
+    )
 
 
 def record_load_consumption(model: torch.nn.Module) -> None:
@@ -107,13 +192,128 @@ def record_load_consumption(model: torch.nn.Module) -> None:
                 info, name, _get_weight_loader(tensor))
 
 
+def record_dummy_load_manifest(model: torch.nn.Module) -> None:
+    """Establish a rank-local target baseline after dummy initialization.
+
+    Dummy weights have no checkpoint source keys, so inventing source events
+    would make the first real RL transfer impossible to reconcile. Instead,
+    require every unique local parameter target to be consumed. A successful
+    first real load promotes its exact observed source/fragment receipts to the
+    normal manifest used by subsequent reloads.
+    """
+    for layer in model.modules():
+        info = get_layerwise_info(layer)
+        # Restore metadata is the authoritative pre-PWAL shape that the
+        # layerwise transfer will materialize. Current parameters may already
+        # have been packed/replaced by quantization.
+        required = {
+            name
+            for name, param in info.restore_metadata[0].items()
+            if param is not None and name not in SKIP_TENSORS
+        }
+        if required:
+            info.required_target_keys = required
+            # Empty means "not established from a real source stream yet".
+            info.required_keys = set()
+
+
+def has_dummy_load_manifest(model: torch.nn.Module) -> bool:
+    """Whether this model still awaits its first real source-bearing load."""
+    return any(
+        get_layerwise_info(layer).required_target_keys is not None
+        for layer in model.modules()
+    )
+
+
+def record_direct_load_consumption(
+    model: torch.nn.Module,
+    target_name: str,
+    source_key: str,
+) -> None:
+    """Record a source-to-target event for loaders that write state_dict directly."""
+    if "." in target_name:
+        module_name, param_name = target_name.rsplit(".", 1)
+        layer = model.get_submodule(module_name)
+    else:
+        layer, param_name = model, target_name
+    info = get_layerwise_info(layer)
+    event = f"{source_key}=>{param_name}"
+    if info.can_load():
+        info.received_keys.add(event)
+        info.received_target_keys.add(param_name)
+    else:
+        if info.required_keys is None:
+            info.required_keys = set()
+        info.required_keys.add(event)
+
+
+def record_external_tensor_manifest(
+    model: torch.nn.Module,
+    tensors: dict[str, torch.Tensor],
+    *,
+    source_scheme: str,
+) -> None:
+    """Record a post-PWAL tensor manifest supplied by an external loader.
+
+    Some loaders transfer fully processed tensors and never invoke vLLM
+    ``weight_loader`` functions. Match their published tensors back to the
+    owning module by identity and retain one canonical event per tensor.
+    """
+    recorded_names: set[str] = set()
+    for source_name in tensors:
+        target_name = source_name.removesuffix(".__storage")
+        if "." in target_name:
+            module_name, local_name = target_name.rsplit(".", 1)
+            try:
+                layer = model.get_submodule(module_name)
+            except AttributeError:
+                continue
+        else:
+            layer, local_name = model, target_name
+        info = get_layerwise_info(layer)
+        if info.required_keys is None:
+            info.required_keys = set()
+        info.required_keys.add(
+            f"{source_scheme}://{source_name}=>{local_name}"
+        )
+        recorded_names.add(source_name)
+
+    # External registries may use aliases that are not resolvable as module
+    # paths. Match those by storage as a fallback.
+    names_by_storage = {
+        tensor.untyped_storage().data_ptr(): name
+        for name, tensor in tensors.items()
+        if name not in recorded_names
+    }
+    seen: set[int] = set()
+    for layer in model.modules():
+        info = get_layerwise_info(layer)
+        for local_name, tensor in get_layer_tensors(layer).items():
+            storage_ptr = tensor.untyped_storage().data_ptr()
+            if storage_ptr in seen or storage_ptr not in names_by_storage:
+                continue
+            seen.add(storage_ptr)
+            if info.required_keys is None:
+                info.required_keys = set()
+            source_name = names_by_storage[storage_ptr]
+            info.required_keys.add(
+                f"{source_scheme}://{source_name}=>{local_name}"
+            )
+
+
 def _make_recording_loader(info: LayerReloadingInfo, name: str,
                            original: Callable) -> Callable:
+    loader_signature = inspect.signature(original)
+
     @wraps(original, assigned=("__doc__", "__annotations__"))
     def recording_loader(*args, **kwargs):
+        bound_args = loader_signature.bind(*args, **kwargs)
+        bound_args.apply_defaults()
+        result = original(*args, **kwargs)
         assert info.required_keys is not None
-        info.required_keys.add(name)
-        return original(*args, **kwargs)
+        if _load_call_consumed(bound_args, result):
+            info.required_keys.add(_load_event_key(name, bound_args))
+        return result
 
     # A distinct __name__ so _get_original_loader (which unwraps only
     # "online_process_loader") does not strip it; finalize_load_recording
@@ -122,6 +322,45 @@ def _make_recording_loader(info: LayerReloadingInfo, name: str,
     recording_loader._vllm_recording = True  # type: ignore[attr-defined]
     recording_loader._vllm_orig = original  # type: ignore[attr-defined]
     return recording_loader
+
+
+_LOAD_FRAGMENT_ARGUMENTS = (
+    "loaded_shard_id",
+    "loaded_weight_shard_id",
+    "shard_id",
+    "expert_id",
+    "weight_name",
+)
+
+
+def _load_event_key(param_name: str,
+                    args: inspect.BoundArguments) -> str:
+    """Return the logical target fragment consumed by one loader call.
+
+    A loader invocation is one event regardless of how many internal writes
+    it performs. Packed, merged and expert loaders are distinguished by the
+    routing arguments already present in their public loader signature.
+    Keeping the no-fragment representation equal to ``param_name`` preserves
+    compatibility for ordinary parameters and existing diagnostics.
+    """
+    fragments = []
+    for name in _LOAD_FRAGMENT_ARGUMENTS:
+        value = args.arguments.get(name)
+        if value is not None:
+            fragments.append(f"{name}={value!r}")
+    target = (param_name if not fragments else
+              f"{param_name}[{','.join(fragments)}]")
+    source_key = get_current_source_key()
+    if source_key is None:
+        return target
+    return f"{source_key}=>{target}"
+
+
+def _load_call_consumed(args: inspect.BoundArguments, result: object) -> bool:
+    """Whether a conditional loader reports that it consumed this fragment."""
+    if args.arguments.get("return_success") is True:
+        return result is True
+    return True
 
 
 def finalize_load_recording(model: torch.nn.Module) -> None:
@@ -136,19 +375,37 @@ def finalize_load_recording(model: torch.nn.Module) -> None:
 
 def _check_set_completion(layer: torch.nn.Module,
                           info: LayerReloadingInfo) -> None:
-    """Dual-run: at the moment the numel criterion fires completion, record
-    whether the observed-key-set criterion agrees. A disagreement where numel
-    says complete but keys are still missing is the #44814 shape (a dropped
-    parameter masked by an over-count). Numel stays authoritative; this only
-    records the discrepancy."""
+    """At end of reload, record whether all first-load events were received.
+
+    Reconciliation deliberately happens only after the checkpoint iterator is
+    exhausted. Numel-driven processing may finish earlier, while a
+    checkpoint-backed tensor excluded from meta restoration can legitimately
+    arrive later. Numel stays authoritative; this only records discrepancies.
+    """
     if info.required_keys is None:
         return  # no observed baseline (first-load recording did not run)
+    missing_targets = (
+        (info.required_target_keys or set()) - info.received_target_keys
+    )
+    if missing_targets:
+        finding = (
+            f"{layer.__class__.__name__}: reload finalized but "
+            f"{len(missing_targets)} dummy-baseline target(s) not received: "
+            f"{sorted(missing_targets)[:8]}"
+        )
+        _LAYER_COMPLETION_FINDINGS.append(finding)
+        _DUMMY_BASELINE_FAILURES.append(finding)
     missing = info.required_keys - info.received_keys
     if missing:
         _LAYER_COMPLETION_FINDINGS.append(
-            f"{layer.__class__.__name__}: numel completion fired but "
+            f"{layer.__class__.__name__}: reload finalized but "
             f"{len(missing)} observed key(s) not yet received: "
             f"{sorted(missing)[:8]}")
+    if info.required_target_keys is not None and not missing_targets:
+        # The first complete real transfer turns the provisional dummy target
+        # baseline into the exact source/fragment manifest.
+        info.required_keys = set(info.received_keys)
+        info.required_target_keys = None
 
 
 def get_layerwise_info(layer: torch.nn.Module) -> LayerReloadingInfo:
@@ -200,6 +457,8 @@ def initialize_layerwise_reload(model: torch.nn.Module):
 
     if not any(get_layerwise_info(m).can_load() for m in model.modules()):
         _LAYER_COMPLETION_FINDINGS.clear()
+        _DUMMY_BASELINE_FAILURES.clear()
+        _LAST_RELOAD_RECEIVED_EVENT_COUNTS[model] = 0
 
     for layer in model.modules():
         info = get_layerwise_info(layer)
@@ -230,6 +489,8 @@ def initialize_online_processing(layer: torch.nn.Module):
     info = get_layerwise_info(layer)
 
     # Track loading progress to determine when to process/copy
+    info.received_keys.clear()
+    info.received_target_keys.clear()
     info.load_numel = 0
     info.load_numel_total = get_layer_size(layer)
     _wrap_parameters_weight_loader(layer)
@@ -237,12 +498,43 @@ def initialize_online_processing(layer: torch.nn.Module):
 
 def _wrap_parameters_weight_loader(layer: torch.nn.Module) -> None:
     """Wrap each parameter's weight loader."""
+    info = get_layerwise_info(layer)
     # Note that nested wrapping will occur for shared tensors
     for name, tensor in get_layer_tensors(layer).items():
         if name in SKIP_TENSORS:
+            # Some skipped tensors are nevertheless checkpoint-backed. They
+            # stay on device because they are aliases or runtime bookkeeping,
+            # but their real loader invocation must still produce a receipt.
+            # Keep this lightweight observer installed until the *whole*
+            # checkpoint iterator is exhausted: such a tensor may arrive
+            # after the other tensors made this layer reach numel completion.
+            loader = _get_weight_loader(tensor)
+            if not getattr(loader, "_vllm_receipt_observer", False):
+                tensor.weight_loader = _make_receipt_observer(
+                    info, name, _get_original_loader(tensor))
             continue
         if _get_weight_loader(tensor).__name__ != "online_process_loader":
             tensor.weight_loader = make_online_process_loader(layer, name)
+
+
+def _make_receipt_observer(info: LayerReloadingInfo, param_name: str,
+                           original_loader: Callable) -> Callable:
+    """Observe a checkpoint load without deferring or counting the tensor."""
+    loader_signature = inspect.signature(original_loader)
+
+    @wraps(original_loader, assigned=("__doc__", "__annotations__"))
+    def receipt_observer(*args, **kwargs):
+        bound_args = loader_signature.bind(*args, **kwargs)
+        bound_args.apply_defaults()
+        result = original_loader(*args, **kwargs)
+        if _load_call_consumed(bound_args, result):
+            info.received_keys.add(_load_event_key(param_name, bound_args))
+            info.received_target_keys.add(param_name)
+        return result
+
+    receipt_observer.__name__ = "reload_receipt_observer"
+    receipt_observer._vllm_receipt_observer = True  # type: ignore[attr-defined]
+    return receipt_observer
 
 
 def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Callable:
@@ -287,12 +579,13 @@ def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Calla
         num_loaded, ret = get_numel_loaded(original_loader, bound_args)
         info.load_numel += num_loaded
 
-        # Observed-key-set accounting, dual-run alongside numel. A set dedups
-        # naturally, so a key loaded more than once (some qconfigs load
-        # weight_shape per qkv partition -- see "Excessive loading" above) is
-        # idempotent here rather than an error; strict duplicate rejection is
-        # a later, separate policy.
-        info.received_keys.add(param_name)
+        # Observe the same logical target fragment as the first-load wrapper.
+        # This distinguishes Q/K/V shards and MoE expert/shard calls that
+        # share one packed destination parameter. Internal copy_ calls remain
+        # invisible: the loader invocation, not a storage write, is the event.
+        if _load_call_consumed(bound_args, ret):
+            info.received_keys.add(_load_event_key(param_name, bound_args))
+            info.received_target_keys.add(param_name)
 
         logger.debug(
             "%s: %d / %d",
@@ -347,11 +640,15 @@ def finalize_layerwise_processing(model: torch.nn.Module, model_config: ModelCon
     if hasattr(model, "_original_do_torchao_reload"):
         model._do_torchao_reload = model._original_do_torchao_reload
 
+    received_event_count = 0
     deferred_attn: list[tuple[torch.nn.Module, LayerReloadingInfo]] = []
 
     for layer in model.modules():
         info = get_layerwise_info(layer)
         if not info.can_load():
+            received_event_count += len(info.received_keys)
+            _check_set_completion(layer, info)
+            _unwrap_receipt_observers(layer)
             info.reset()
             continue
 
@@ -380,14 +677,26 @@ def finalize_layerwise_processing(model: torch.nn.Module, model_config: ModelCon
             logger.debug("%s: Delayed processing", layer.__class__.__name__)
             _layerwise_process(layer, info)
 
+        received_event_count += len(info.received_keys)
+        _check_set_completion(layer, info)
+        _unwrap_receipt_observers(layer)
         info.reset()
 
     # Process attention layers after all other layers are done
     for layer, info in deferred_attn:
         _finalize_attention_layer(layer, info, model_config)
+        received_event_count += len(info.received_keys)
+        _check_set_completion(layer, info)
+        _unwrap_receipt_observers(layer)
         info.reset()
 
     LOADING_LAYERS.clear()
+    _LAST_RELOAD_RECEIVED_EVENT_COUNTS[model] = received_event_count
+    if _DUMMY_BASELINE_FAILURES:
+        raise RuntimeError(
+            "First real weight load after dummy initialization was incomplete:\n  "
+            + "\n  ".join(_DUMMY_BASELINE_FAILURES[:20])
+        )
 
 
 def finalize_layerwise_reload(*args, **kwargs):
@@ -409,6 +718,7 @@ def _finalize_attention_layer(
     else:
         _place_kernel_tensors(layer, info)
     layer.process_weights_after_loading(model_config.dtype)
+
 
 def _reload_attention_scales(layer: torch.nn.Module, info: LayerReloadingInfo) -> None:
     """Load and process attention scale weights (k_scale, v_scale, etc.)
@@ -454,7 +764,11 @@ def _layerwise_process(layer: torch.nn.Module, info: LayerReloadingInfo):
         delattr(layer, "_already_called_process_weights_after_loading")
 
     # Unwrap layerwise loading wrappers
-    for param in get_layer_tensors(layer).values():
+    for name, param in get_layer_tensors(layer).items():
+        if (name in SKIP_TENSORS
+                and getattr(_get_weight_loader(param),
+                            "_vllm_receipt_observer", False)):
+            continue
         param.weight_loader = _get_original_loader(param)
 
     # Load all buffered weights into materialized layer (using original loaders)
@@ -473,23 +787,28 @@ def _layerwise_process(layer: torch.nn.Module, info: LayerReloadingInfo):
     if info.kernel_tensors is not None:
         _copy_and_restore_kernel_tensors(layer, info)
 
-    # Dual-run: does the observed key set agree the layer is complete? Runs
-    # here (covering online-completed AND delayed layers) because received_keys
-    # is still alive before reset(); required_keys survives reset, received
-    # does not, so this cannot be deferred to the finalize reset loop.
-    _check_set_completion(layer, info)
-
-    info.reset()
+    # The checkpoint iterator may still contain checkpoint-backed SKIP_TENSORS
+    # (for example DeepSeek's gate.e_score_correction_bias). Keep all receipts
+    # until finalize_layerwise_processing can reconcile the complete stream.
+    info.reset(preserve_received_keys=True)
     logger.debug("%s: Processed", layer.__class__.__name__)
 
 
 def _get_original_loader(tensor: torch.Tensor) -> Callable:
     """Return the weight loader with any layerwise wrappers removed"""
     loader = _get_weight_loader(tensor)
-    while loader.__name__ == "online_process_loader":
+    while loader.__name__ in ("online_process_loader",
+                              "reload_receipt_observer"):
         loader = loader.__wrapped__  # type: ignore[union-attr]
 
     return loader
+
+
+def _unwrap_receipt_observers(layer: torch.nn.Module) -> None:
+    for tensor in get_layer_tensors(layer).values():
+        loader = _get_weight_loader(tensor)
+        if getattr(loader, "_vllm_receipt_observer", False):
+            tensor.weight_loader = _get_original_loader(tensor)
 
 
 def _get_weight_loader(tensor: torch.Tensor):

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -408,6 +408,25 @@ def _check_set_completion(layer: torch.nn.Module,
         info.required_target_keys = None
 
 
+def _has_exact_manifest(info: LayerReloadingInfo) -> bool:
+    """Whether this layer has a real source/fragment baseline.
+
+    ``required_keys == set()`` is deliberately not authoritative: that is the
+    provisional state installed by DummyModelLoader before the first real
+    transfer.  Such a transfer still uses the legacy completion path while it
+    learns the rank-local exact event set.
+    """
+    return bool(info.required_keys) and info.required_target_keys is None
+
+
+def _manifest_complete(info: LayerReloadingInfo) -> bool:
+    return (
+        _has_exact_manifest(info)
+        and info.required_keys is not None
+        and info.required_keys <= info.received_keys
+    )
+
+
 def get_layerwise_info(layer: torch.nn.Module) -> LayerReloadingInfo:
     """
     Get information related to restoring and layerwise processing. If no previous
@@ -491,14 +510,36 @@ def initialize_online_processing(layer: torch.nn.Module):
     # Track loading progress to determine when to process/copy
     info.received_keys.clear()
     info.received_target_keys.clear()
-    info.load_numel = 0
-    info.load_numel_total = get_layer_size(layer)
+    info.is_loading = True
+    info.copied_numel_diagnostic = 0
+    info.layer_numel_diagnostic = get_layer_size(layer)
+    if info.required_keys is None and info.required_target_keys is None:
+        # Online quantization can install this machinery while the model is
+        # still being constructed, before BaseModelLoader starts observing
+        # the first checkpoint stream. Establish a provisional target
+        # manifest so even that first load is event-driven.
+        targets = {
+            name
+            for name, tensor in get_layer_tensors(layer).items()
+            if tensor is not None and name not in SKIP_TENSORS
+        }
+        if targets:
+            info.required_target_keys = targets
     _wrap_parameters_weight_loader(layer)
 
 
 def _wrap_parameters_weight_loader(layer: torch.nn.Module) -> None:
     """Wrap each parameter's weight loader."""
     info = get_layerwise_info(layer)
+    if info.required_target_keys is not None:
+        # A loader may register additional parameters dynamically. Re-running
+        # this function after every loader call grows the provisional target
+        # manifest before completion can be declared.
+        info.required_target_keys.update(
+            name
+            for name, tensor in get_layer_tensors(layer).items()
+            if tensor is not None and name not in SKIP_TENSORS
+        )
     # Note that nested wrapping will occur for shared tensors
     for name, tensor in get_layer_tensors(layer).items():
         if name in SKIP_TENSORS:
@@ -547,27 +588,13 @@ def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Calla
     @wraps(original_loader, assigned=("__doc__", "__annotations__"))
     def online_process_loader(*args, **kwargs):
         if not info.can_load():
-            # Unfortunately, some qconfigs are set up to load the same weight
-            # multiple times. For example, CT_WNA16 loads `weight_shape` for
-            # each of the qkv partitions. This results in layers loading extra
-            # weights (beyond load_numel_total) after it's already processed.
-            #
-            # Best solution is to ensure that `load_numel_total` reflects the
-            # actual number of weights loaded, either by modifying qconfigs to
-            # create as many weights as loaded (see padding issue as well)
-            # or maybe capturing how many weights are loaded on first pass
-            #
-            # For now, `load_numel_total` is still safe to use as long as
-            # there's no way to reach `load_numel_total` without loading all
-            # necessary weights. `weight_shape` is very small, so this is safe.
-            # see Limitations(4)
-            logger.debug("%s: Excessive loading", layer.__class__.__name__)
+            logger.debug("%s: Event arrived after layer completion",
+                         layer.__class__.__name__)
             return
 
-        # Re-run on each load: layers may register parameters later (e.g., `bias`).
-        # Wrap late parameters and refresh `load_numel_total` so processing waits
-        # until all parameters are loaded.
-        info.load_numel_total = get_layer_size(layer)
+        # Re-run on each load: layers may register parameters later (e.g.,
+        # ``bias``). The provisional target manifest is extended below.
+        info.layer_numel_diagnostic = get_layer_size(layer)
         _wrap_parameters_weight_loader(layer)
 
         # Bind and normalize arguments
@@ -577,7 +604,8 @@ def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Calla
         # Buffer loaded weights, track loading progress
         info.loaded_weights.append((param_name, bound_args))
         num_loaded, ret = get_numel_loaded(original_loader, bound_args)
-        info.load_numel += num_loaded
+        info.copied_numel_diagnostic += num_loaded
+        _wrap_parameters_weight_loader(layer)
 
         # Observe the same logical target fragment as the first-load wrapper.
         # This distinguishes Q/K/V shards and MoE expert/shard calls that
@@ -590,8 +618,8 @@ def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Calla
         logger.debug(
             "%s: %d / %d",
             layer.__class__.__name__,
-            info.load_numel,
-            info.load_numel_total,
+            info.copied_numel_diagnostic,
+            info.layer_numel_diagnostic,
         )
 
         # Do not online process attention layers, must wait until finalize
@@ -614,8 +642,13 @@ def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Calla
                     str(list(names)),
                 )
 
-        # Process and copy when all weights are loaded
-        if info.load_numel >= info.load_numel_total:  # type: ignore[operator]
+        # Once an exact first-load manifest exists, it is the authoritative
+        # layer completion criterion.  Numel remains the compatibility path
+        # only for the dummy first transfer and loaders without a manifest.
+        # This prevents composed loaders from finalizing a layer early merely
+        # because one logical event performs multiple internal copy_ calls.
+        manifest_driven = _has_exact_manifest(info)
+        if manifest_driven and _manifest_complete(info):
             _layerwise_process(layer, info)
             LOADING_LAYERS.discard(layer)
 
@@ -657,15 +690,17 @@ def finalize_layerwise_processing(model: torch.nn.Module, model_config: ModelCon
             deferred_attn.append((layer, info))
             continue
 
+        has_loaded_events = bool(info.loaded_weights)
+
         # No weights were loaded
-        if info.load_numel <= 0:
+        if not has_loaded_events:
             # first load: checkpoint did not contain weights for this layer
             if info.kernel_tensors is None:
                 _layerwise_process(layer, info)
                 continue
 
             # reloading: place kernel tensors back as a fallback
-            elif info.load_numel_total > 0:  # type: ignore[operator]
+            elif get_layer_size(layer) > 0:
                 logger.warning("%s: Failed to load weights", layer.__class__.__name__)
                 _place_kernel_tensors(layer, info)
 
@@ -673,7 +708,7 @@ def finalize_layerwise_processing(model: torch.nn.Module, model_config: ModelCon
         # if the created weight has extra padding elements which are not loaded
         # Having too many of these delayed layers can lead to excess memory usage
         # see Limitations(4)
-        elif info.load_numel > 0 and info.load_numel < info.load_numel_total:  # type: ignore[operator]
+        elif has_loaded_events:
             logger.debug("%s: Delayed processing", layer.__class__.__name__)
             _layerwise_process(layer, info)
 
@@ -706,11 +741,12 @@ def finalize_layerwise_reload(*args, **kwargs):
 def _finalize_attention_layer(
     layer: torch.nn.Module, info: LayerReloadingInfo, model_config: ModelConfig
 ) -> None:
-    if info.load_numel > 0 and info.kernel_tensors is not None:
+    has_loaded_events = bool(info.loaded_weights)
+    if has_loaded_events and info.kernel_tensors is not None:
         # Reload with new scale weights from checkpoint
         _place_kernel_tensors(layer, info)
         _reload_attention_scales(layer, info)
-    elif info.load_numel > 0 or info.kernel_tensors is None:
+    elif has_loaded_events or info.kernel_tensors is None:
         raise ValueError(
             "Layerwise loading of attention layers is not supported. "
             "Attention must always process after linears."

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -15,6 +15,7 @@ from vllm.model_executor.load_receipt import LoadFragment, LoadReceipt
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.reload_arena import peek_reload_arena
 
+from .audit import LoadEventAudit
 from .meta import (
     SKIP_TENSORS,
     capture_layer_to_meta,
@@ -178,6 +179,7 @@ def record_load_consumption(model: torch.nn.Module) -> None:
     """
     for layer in model.modules():
         info = get_layerwise_info(layer)
+        info.load_event_audit = LoadEventAudit()
         if info.required_keys is None:
             info.required_keys = set()
         for name, tensor in get_layer_tensors(layer).items():
@@ -314,6 +316,13 @@ def _make_recording_loader(info: LayerReloadingInfo, name: str,
         result = original(*args, **kwargs)
         assert info.required_keys is not None
         receipt = _get_load_receipt(bound_args, result)
+        _audit_load_receipt(
+            info,
+            name,
+            receipt,
+            bound_args,
+            original,
+        )
         if receipt.consumed:
             info.required_keys.add(_load_event_key(name, receipt))
         return result
@@ -383,14 +392,51 @@ def _load_event_key(param_name: str, receipt: LoadReceipt) -> str:
     return f"{source_key}=>{target}"
 
 
+def _audit_load_receipt(
+    info: LayerReloadingInfo,
+    param_name: str,
+    receipt: LoadReceipt,
+    args: inspect.BoundArguments,
+    loader: Callable,
+) -> None:
+    info.load_event_audit.observe(
+        param_name=param_name,
+        receipt=receipt,
+        args=args,
+        loader=loader,
+        source_key=get_current_source_key(),
+    )
+
+
 def finalize_load_recording(model: torch.nn.Module) -> None:
     """Remove the recording wrappers installed by record_load_consumption,
     restoring the original loaders so the reload path is unaffected."""
+    findings = []
     for layer in model.modules():
+        info = get_layerwise_info(layer)
         for name, tensor in get_layer_tensors(layer).items():
             loader = getattr(tensor, "weight_loader", None)
             if loader is not None and getattr(loader, "_vllm_recording", False):
                 tensor.weight_loader = loader._vllm_orig
+        findings.extend(
+            f"{layer.__class__.__name__}: {finding}"
+            for finding in info.load_event_audit.take_findings()
+        )
+    if findings:
+        raise RuntimeError(
+            "LoadReceipt collision audit failed during initial loading:\n  "
+            + "\n  ".join(findings)
+        )
+
+
+def _record_load_audit_findings(
+    layer: torch.nn.Module,
+    info: LayerReloadingInfo,
+) -> None:
+    _LAYER_COMPLETION_FINDINGS.extend(
+        f"{layer.__class__.__name__}: {finding}"
+        for finding in info.load_event_audit.take_findings()
+    )
 
 
 def _check_set_completion(layer: torch.nn.Module,
@@ -530,6 +576,7 @@ def initialize_online_processing(layer: torch.nn.Module):
     # Track loading progress to determine when to process/copy
     info.received_keys.clear()
     info.received_target_keys.clear()
+    info.load_event_audit = LoadEventAudit()
     info.is_loading = True
     info.copied_numel_diagnostic = 0
     info.layer_numel_diagnostic = get_layer_size(layer)
@@ -589,6 +636,13 @@ def _make_receipt_observer(info: LayerReloadingInfo, param_name: str,
         bound_args.apply_defaults()
         result = original_loader(*args, **kwargs)
         receipt = _get_load_receipt(bound_args, result)
+        _audit_load_receipt(
+            info,
+            param_name,
+            receipt,
+            bound_args,
+            original_loader,
+        )
         if receipt.consumed:
             info.received_keys.add(_load_event_key(param_name, receipt))
             info.received_target_keys.add(param_name)
@@ -633,6 +687,13 @@ def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Calla
         # share one packed destination parameter. Internal copy_ calls remain
         # invisible: the loader invocation, not a storage write, is the event.
         receipt = _get_load_receipt(bound_args, ret)
+        _audit_load_receipt(
+            info,
+            param_name,
+            receipt,
+            bound_args,
+            original_loader,
+        )
         if receipt.consumed:
             info.received_keys.add(_load_event_key(param_name, receipt))
             info.received_target_keys.add(param_name)
@@ -703,6 +764,7 @@ def finalize_layerwise_processing(model: torch.nn.Module, model_config: ModelCon
         if not info.can_load():
             received_event_count += len(info.received_keys)
             _check_set_completion(layer, info)
+            _record_load_audit_findings(layer, info)
             _unwrap_receipt_observers(layer)
             info.reset()
             continue
@@ -736,6 +798,7 @@ def finalize_layerwise_processing(model: torch.nn.Module, model_config: ModelCon
 
         received_event_count += len(info.received_keys)
         _check_set_completion(layer, info)
+        _record_load_audit_findings(layer, info)
         _unwrap_receipt_observers(layer)
         info.reset()
 
@@ -744,6 +807,7 @@ def finalize_layerwise_processing(model: torch.nn.Module, model_config: ModelCon
         _finalize_attention_layer(layer, info, model_config)
         received_event_count += len(info.received_keys)
         _check_set_completion(layer, info)
+        _record_load_audit_findings(layer, info)
         _unwrap_receipt_observers(layer)
         info.reset()
 

--- a/vllm/model_executor/model_loader/reload/meta.py
+++ b/vllm/model_executor/model_loader/reload/meta.py
@@ -228,17 +228,7 @@ def get_numel_loaded(
     with CopyCounter() as counter:
         return_value = weight_loader(*args.args, **args.kwargs)
 
-    # A weight loader fills a single destination parameter, so the number of
-    # loaded elements is at most that parameter's size. Some loaders copy into
-    # the parameter more than once -- e.g. ``composed_weight_loader`` runs an
-    # in-place post-load transform (``param.copy_(fn(param))``) on top of the
-    # initial copy -- which would make CopyCounter report twice the parameter
-    # size. Over-counting inflates the layer's loaded-element total and can
-    # finalize the layer before every parameter is loaded, silently dropping
-    # the trailing parameter(s) (e.g. Mamba ``mixer.D``). Cap the count at the
-    # destination size to keep the per-layer accounting correct.
-    numel = counter.copied_numel
-    param = args.arguments.get("param", None)
-    if isinstance(param, torch.Tensor):
-        numel = min(numel, param.numel())
-    return numel, return_value
+    # Diagnostic only. Layer completion is driven by logical manifest events,
+    # so composed loaders may report every internal copy_ without affecting
+    # correctness.
+    return counter.copied_numel, return_value

--- a/vllm/model_executor/model_loader/reload/meta.py
+++ b/vllm/model_executor/model_loader/reload/meta.py
@@ -8,8 +8,8 @@ from torch.nn.parameter import UninitializedParameter
 from torch.utils._python_dispatch import TorchDispatchMode
 
 from .sanitize import restore_layer_refs, sanitize_layer_refs
-from .types import LayerReloadingInfo, LayerTensors
-from .utils import get_layer_params_buffers, get_layer_tensors
+from .types import LayerReloadingInfo, LayerRestoreMetadata
+from .utils import get_layer_tensors
 
 __all__ = [
     "to_meta_tensor",
@@ -89,27 +89,60 @@ def _parameter_storage_ptrs(layer: torch.nn.Module) -> set[int]:
     }
 
 
-def capture_layer_to_meta(layer: torch.nn.Module) -> LayerTensors:
+def capture_layer_to_meta(layer: torch.nn.Module) -> LayerRestoreMetadata:
     if layer.__class__.__name__ in SKIP_MODULES:
         return ({}, {})
 
-    params, buffers = get_layer_params_buffers(layer)
+    params = layer._parameters
+    buffers = layer._buffers
     parameter_storage_ptrs = _parameter_storage_ptrs(layer)
     return (
         {
-            name: sanitize_layer_refs(to_meta_tensor(param), layer)
+            name: (
+                None
+                if param is None
+                else sanitize_layer_refs(to_meta_tensor(param), layer)
+            )
             for name, param in params.items()
             if name not in SKIP_TENSORS
         },
         {
-            name: sanitize_layer_refs(to_meta_tensor(buffer), layer)
+            name: (
+                None
+                if buffer is None
+                else sanitize_layer_refs(to_meta_tensor(buffer), layer)
+            )
             for name, buffer in buffers.items()
             if name not in SKIP_TENSORS
-            and not _is_non_persistent_parameter_alias_buffer(
-                layer, name, buffer, parameter_storage_ptrs
+            and (
+                buffer is None
+                or not _is_non_persistent_parameter_alias_buffer(
+                    layer, name, buffer, parameter_storage_ptrs
+                )
             )
         },
     )
+
+
+def _remove_tensor_slot(layer: torch.nn.Module, name: str) -> None:
+    """Remove any instance-level value occupying a tensor slot.
+
+    Quantization post-processing is allowed to change a load-time parameter
+    into a buffer or an ordinary tensor attribute (and vice versa).  Removing
+    only the tensors returned by ``get_layer_tensors`` misses the latter:
+    ``Module.register_parameter`` then rejects the restore because ``hasattr``
+    still finds the ordinary attribute.
+
+    Update the three instance-level namespaces directly so this also handles
+    ``None`` entries and does not depend on the current value's tensor type.
+    The metadata being restored proves that the name was originally a valid
+    parameter/buffer name, so an instance attribute with the same name is
+    kernel-format state and must not survive the restore.
+    """
+    layer._parameters.pop(name, None)
+    layer._buffers.pop(name, None)
+    layer._non_persistent_buffers_set.discard(name)
+    layer.__dict__.pop(name, None)
 
 
 def restore_layer_on_meta(layer: torch.nn.Module, info: LayerReloadingInfo):
@@ -117,19 +150,28 @@ def restore_layer_on_meta(layer: torch.nn.Module, info: LayerReloadingInfo):
     if layer.__class__.__name__ in SKIP_MODULES:
         return
 
-    for name in get_layer_tensors(layer):
-        if name not in SKIP_TENSORS:
-            delattr(layer, name)
-
     restore_params, restore_buffers = info.restore_metadata
+
+    # Clear both the current registered tensors and every destination slot.
+    # The destination union is important when post-processing replaced an
+    # original parameter/buffer with an ordinary attribute, which is invisible
+    # to get_layer_tensors().
+    current_names = set(layer._parameters) | set(layer._buffers)
+    restore_names = set(restore_params) | set(restore_buffers)
+    for name in current_names | restore_names:
+        if name not in SKIP_TENSORS:
+            _remove_tensor_slot(layer, name)
+
     for name, param in restore_params.items():
         if name not in SKIP_TENSORS:
-            param = restore_layer_refs(param, layer)
+            if param is not None:
+                param = restore_layer_refs(param, layer)
             layer.register_parameter(name, param)
 
     for name, buffer in restore_buffers.items():
         if name not in SKIP_TENSORS:
-            buffer = restore_layer_refs(buffer, layer)
+            if buffer is not None:
+                buffer = restore_layer_refs(buffer, layer)
             layer.register_buffer(name, buffer)
 
 

--- a/vllm/model_executor/model_loader/reload/probe.py
+++ b/vllm/model_executor/model_loader/reload/probe.py
@@ -436,7 +436,6 @@ def probe_dummy_load_manifest(
         for layer, info in infos.items()
     }
     global_state = {
-        "_LAYER_ARENA_FINDINGS": list(layerwise._LAYER_ARENA_FINDINGS),
         "_LAYER_COMPLETION_FINDINGS": list(layerwise._LAYER_COMPLETION_FINDINGS),
         "_DUMMY_BASELINE_FAILURES": list(layerwise._DUMMY_BASELINE_FAILURES),
     }

--- a/vllm/model_executor/model_loader/reload/probe.py
+++ b/vllm/model_executor/model_loader/reload/probe.py
@@ -26,6 +26,7 @@ __all__ = [
     "probe_dummy_load_manifest",
     "probe_model_load",
     "safetensors_meta_weights",
+    "safetensors_meta_weights_from_files",
     "validate_probe_receipt_coverage",
 ]
 
@@ -135,19 +136,10 @@ _SAFETENSORS_DTYPES = {
 }
 
 
-def safetensors_meta_weights(
-    model_path: str,
+def safetensors_meta_weights_from_files(
+    filenames: Iterable[str],
 ) -> list[tuple[str, torch.Tensor]]:
-    """Read a local safetensors schema without materializing tensor data."""
-    from pathlib import Path
-
-    path = Path(model_path)
-    if not path.is_dir():
-        return []
-    filenames = sorted(path.glob("*.safetensors"))
-    if not filenames:
-        return []
-
+    """Read safetensors schemas without materializing tensor data."""
     weights = []
     seen = set()
     for filename in filenames:
@@ -176,6 +168,21 @@ def safetensors_meta_weights(
                     )
                 )
     return weights
+
+
+def safetensors_meta_weights(
+    model_path: str,
+) -> list[tuple[str, torch.Tensor]]:
+    """Read a local safetensors schema without materializing tensor data."""
+    from pathlib import Path
+
+    path = Path(model_path)
+    if not path.is_dir():
+        return []
+    filenames = sorted(str(filename) for filename in path.glob("*.safetensors"))
+    if not filenames:
+        return []
+    return safetensors_meta_weights_from_files(filenames)
 
 
 class LoadProbeMode(TorchDispatchMode):

--- a/vllm/model_executor/model_loader/reload/probe.py
+++ b/vllm/model_executor/model_loader/reload/probe.py
@@ -1,0 +1,478 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Metadata-only execution of model weight loaders."""
+
+import copy
+from collections.abc import Iterable
+from contextlib import AbstractContextManager
+from dataclasses import dataclass, field, fields
+from typing import Any
+
+import torch
+from safetensors import safe_open
+from torch.utils._python_dispatch import TorchDispatchMode
+from torch.utils._pytree import tree_flatten
+
+from vllm.model_executor.model_loader.reload.source import (
+    get_current_source_key,
+    observe_weight_sources,
+)
+
+__all__ = [
+    "LoadProbeError",
+    "LoadProbeFinding",
+    "LoadProbeMode",
+    "LoadProbeReport",
+    "probe_dummy_load_manifest",
+    "probe_model_load",
+    "safetensors_meta_weights",
+    "validate_probe_receipt_coverage",
+]
+
+
+class LoadProbeError(RuntimeError):
+    """Raised when a loader cannot be executed without touching tensor data."""
+
+
+@dataclass(frozen=True)
+class LoadProbeFinding:
+    code: str
+    operation: str
+    detail: str
+
+    def format(self) -> str:
+        return f"{self.code}: {self.operation}: {self.detail}"
+
+
+@dataclass
+class LoadProbeReport:
+    """Result of one metadata-only ``model.load_weights`` execution."""
+
+    loaded_weights: set[str] = field(default_factory=set)
+    intercepted_writes: list[str] = field(default_factory=list)
+    write_sources: set[str | None] = field(default_factory=set)
+    restored_python_mutations: list[str] = field(default_factory=list)
+    findings: list[LoadProbeFinding] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.findings
+
+    def raise_for_error(self) -> None:
+        if self.findings:
+            raise LoadProbeError(
+                "Weight-loader probe is incomplete:\n  "
+                + "\n  ".join(finding.format() for finding in self.findings)
+            )
+
+
+def _tensor_values(args: tuple[Any, ...], kwargs: dict[str, Any]):
+    flat, _ = tree_flatten((args, kwargs))
+    return [value for value in flat if isinstance(value, torch.Tensor)]
+
+
+def _write_arguments(
+    func,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> list[torch.Tensor]:
+    writes: list[torch.Tensor] = []
+    for index, argument in enumerate(func._schema.arguments):
+        if index < len(args):
+            value = args[index]
+        elif argument.name in kwargs:
+            value = kwargs[argument.name]
+        else:
+            continue
+        alias = argument.alias_info
+        if alias is not None and alias.is_write and isinstance(value, torch.Tensor):
+            writes.append(value)
+    return writes
+
+
+def _has_meta_tensor(args: tuple[Any, ...], kwargs: dict[str, Any]) -> bool:
+    return any(tensor.is_meta for tensor in _tensor_values(args, kwargs))
+
+
+_FACTORY_OPS = {
+    "aten::arange",
+    "aten::empty",
+    "aten::empty_like",
+    "aten::empty_strided",
+    "aten::full",
+    "aten::full_like",
+    "aten::new_empty",
+    "aten::new_empty_strided",
+    "aten::new_full",
+    "aten::new_ones",
+    "aten::new_zeros",
+    "aten::ones",
+    "aten::ones_like",
+    "aten::rand",
+    "aten::rand_like",
+    "aten::randn",
+    "aten::randn_like",
+    "aten::zeros",
+    "aten::zeros_like",
+}
+
+_SAFETENSORS_DTYPES = {
+    "BOOL": "bool",
+    "BF16": "bfloat16",
+    "F16": "float16",
+    "F32": "float32",
+    "F64": "float64",
+    "F8_E4M3": "float8_e4m3fn",
+    "F8_E5M2": "float8_e5m2",
+    "I8": "int8",
+    "I16": "int16",
+    "I32": "int32",
+    "I64": "int64",
+    "U8": "uint8",
+    "U16": "uint16",
+    "U32": "uint32",
+    "U64": "uint64",
+}
+
+
+def safetensors_meta_weights(
+    model_path: str,
+) -> list[tuple[str, torch.Tensor]]:
+    """Read a local safetensors schema without materializing tensor data."""
+    from pathlib import Path
+
+    path = Path(model_path)
+    if not path.is_dir():
+        return []
+    filenames = sorted(path.glob("*.safetensors"))
+    if not filenames:
+        return []
+
+    weights = []
+    seen = set()
+    for filename in filenames:
+        with safe_open(filename, framework="pt", device="cpu") as handle:
+            for name in list(handle.keys()):
+                if name in seen:
+                    raise LoadProbeError(f"duplicate safetensors source key {name!r}")
+                seen.add(name)
+                tensor_slice = handle.get_slice(name)
+                dtype_name = tensor_slice.get_dtype()
+                torch_name = _SAFETENSORS_DTYPES.get(dtype_name)
+                dtype = getattr(torch, torch_name, None) if torch_name else None
+                if not isinstance(dtype, torch.dtype):
+                    raise LoadProbeError(
+                        "unsupported safetensors dtype "
+                        f"{dtype_name!r} for source {name!r}"
+                    )
+                weights.append(
+                    (
+                        name,
+                        torch.empty(
+                            tensor_slice.get_shape(),
+                            dtype=dtype,
+                            device="meta",
+                        ),
+                    )
+                )
+    return weights
+
+
+class LoadProbeMode(TorchDispatchMode):
+    """Suppress tensor mutations while preserving loader control flow.
+
+    Source weights must be meta tensors. Metadata/view operations execute
+    normally. Mutable dispatcher operations are recorded and return their
+    destination without running a kernel.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.report = LoadProbeReport()
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        kwargs = dict(kwargs or {})
+        writes = _write_arguments(func, args, kwargs)
+        if writes:
+            self.report.intercepted_writes.append(str(func))
+            self.report.write_sources.add(get_current_source_key())
+            if len(func._schema.returns) == 0:
+                return None
+            if len(func._schema.returns) == 1:
+                return writes[0]
+            finding = LoadProbeFinding(
+                code="PROBE_UNSUPPORTED_MUTATION_RETURN",
+                operation=str(func),
+                detail=f"mutable operator has {len(func._schema.returns)} returns",
+            )
+            self.report.findings.append(finding)
+            raise LoadProbeError(finding.format())
+
+        if func._schema.name in _FACTORY_OPS or (
+            _has_meta_tensor(args, kwargs) and func._schema.name == "aten::_to_copy"
+        ):
+            kwargs["device"] = torch.device("meta")
+
+        try:
+            return func(*args, **kwargs)
+        except Exception as exc:
+            finding = LoadProbeFinding(
+                code="PROBE_UNSUPPORTED_OPERATOR",
+                operation=str(func),
+                detail=f"{type(exc).__name__}: {exc}",
+            )
+            self.report.findings.append(finding)
+            raise LoadProbeError(finding.format()) from exc
+
+
+def _copy_attribute(value: Any) -> Any:
+    if isinstance(value, dict):
+        return value.copy()
+    if isinstance(value, list):
+        return value.copy()
+    if isinstance(value, set):
+        return value.copy()
+    return value
+
+
+def _same_attribute(current: Any, saved: Any) -> bool:
+    if isinstance(saved, dict):
+        return (
+            isinstance(current, dict)
+            and current.keys() == saved.keys()
+            and all(current[key] is value for key, value in saved.items())
+        )
+    if isinstance(saved, list):
+        return (
+            isinstance(current, list)
+            and len(current) == len(saved)
+            and all(left is right for left, right in zip(current, saved))
+        )
+    if isinstance(saved, set):
+        return isinstance(current, set) and current == saved
+    return current is saved
+
+
+class _ModelStateGuard(AbstractContextManager):
+    """Restore Python-side model bindings after a probe."""
+
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        report: LoadProbeReport,
+        *,
+        allow_binding_mutations: bool = False,
+    ):
+        self.model = model
+        self.report = report
+        self.allow_binding_mutations = allow_binding_mutations
+        self.module_state: dict[torch.nn.Module, dict[str, Any]] = {}
+        self.tensor_state: dict[torch.Tensor, dict[str, Any]] = {}
+
+    def __enter__(self):
+        for module in self.model.modules():
+            self.module_state[module] = {
+                key: _copy_attribute(value) for key, value in vars(module).items()
+            }
+            for tensor in (
+                *module.parameters(recurse=False),
+                *module.buffers(recurse=False),
+            ):
+                self.tensor_state[tensor] = {
+                    key: _copy_attribute(value) for key, value in vars(tensor).items()
+                }
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        mutated = []
+        binding_mutations = []
+        for module, state in self.module_state.items():
+            current = vars(module)
+            changed = {
+                key
+                for key in set(current) | set(state)
+                if key not in current
+                or key not in state
+                or not _same_attribute(current[key], state[key])
+            }
+            if changed:
+                mutated.append(type(module).__name__)
+                if changed & {"_parameters", "_buffers", "_modules"}:
+                    binding_mutations.append(
+                        f"{type(module).__name__}:{sorted(changed)}"
+                    )
+            current.clear()
+            current.update(state)
+        for tensor, state in self.tensor_state.items():
+            current = vars(tensor)
+            if set(current) != set(state):
+                mutated.append(f"{type(tensor).__name__}.__dict__")
+            current.clear()
+            current.update(state)
+        if binding_mutations and not self.allow_binding_mutations:
+            self.report.findings.append(
+                LoadProbeFinding(
+                    code="PROBE_TENSOR_BINDING_MUTATION",
+                    operation=f"{type(self.model).__name__}.load_weights",
+                    detail=f"restored {binding_mutations[:8]}",
+                )
+            )
+        if mutated:
+            self.report.restored_python_mutations.extend(sorted(set(mutated)))
+        return False
+
+
+@torch.no_grad()
+def probe_model_load(
+    model: torch.nn.Module,
+    weights: Iterable[tuple[str, torch.Tensor]],
+) -> LoadProbeReport:
+    """Run the model's real weight routing without copying tensor data.
+
+    Args:
+        model: Initialized model whose ``load_weights`` method is probed.
+        weights: Source-name and metadata-tensor pairs. Every tensor must be
+            on the meta device.
+
+    Returns:
+        The intercepted writes and the names returned by ``model.load_weights``.
+
+    Raises:
+        ValueError: If a source tensor owns real storage.
+        LoadProbeError: If an operator cannot be represented metadata-only.
+    """
+    materialized = [(name, tensor) for name, tensor in weights]
+    non_meta = [name for name, tensor in materialized if not tensor.is_meta]
+    if non_meta:
+        raise ValueError(
+            "Weight-loader probe requires meta source tensors; got real "
+            f"storage for {non_meta[:8]}"
+        )
+
+    mode = LoadProbeMode()
+    try:
+        with _ModelStateGuard(model, mode.report), mode:
+            loaded = model.load_weights(observe_weight_sources(materialized))
+        if loaded is not None:
+            mode.report.loaded_weights = set(loaded)
+    except LoadProbeError:
+        raise
+    except Exception as exc:
+        finding = LoadProbeFinding(
+            code="PROBE_LOADER_EXCEPTION",
+            operation=f"{type(model).__name__}.load_weights",
+            detail=f"{type(exc).__name__}: {exc}",
+        )
+        mode.report.findings.append(finding)
+        raise LoadProbeError(finding.format()) from exc
+    return mode.report
+
+
+def validate_probe_receipt_coverage(
+    model: torch.nn.Module,
+    report: LoadProbeReport,
+) -> None:
+    """Require every intercepted source write to have a recorded receipt."""
+    from vllm.model_executor.model_loader.reload.layerwise import (
+        get_layerwise_info,
+    )
+
+    events = {
+        event
+        for layer in model.modules()
+        for event in (get_layerwise_info(layer).required_keys or ())
+    }
+    event_sources = {event.split("=>", 1)[0] for event in events if "=>" in event}
+    missing_receipts = {
+        source
+        for source in report.write_sources
+        if source is None or source not in event_sources
+    }
+    if missing_receipts:
+        raise LoadProbeError(
+            "Weight-loader probe observed tensor writes without LoadReceipt "
+            "coverage for source(s): "
+            f"{sorted(map(str, missing_receipts))[:20]}"
+        )
+
+
+def probe_dummy_load_manifest(
+    model: torch.nn.Module,
+    weights: Iterable[tuple[str, torch.Tensor]],
+) -> LoadProbeReport:
+    """Replace a dummy target baseline with probed source/fragment events.
+
+    The model must already have a provisional manifest installed by
+    ``DummyModelLoader``. The source stream is executed through the real
+    ``model.load_weights`` routing under :class:`LoadProbeMode`.
+    """
+    from vllm.model_executor.model_loader.reload import layerwise
+    from vllm.model_executor.model_loader.reload.layerwise import (
+        get_layerwise_info,
+        has_dummy_load_manifest,
+        initialize_layerwise_reload,
+    )
+
+    if not has_dummy_load_manifest(model):
+        raise ValueError("model does not have a dummy load manifest")
+
+    infos = {layer: get_layerwise_info(layer) for layer in model.modules()}
+    info_state = {
+        layer: {
+            item.name: (
+                copy.deepcopy(getattr(info, item.name))
+                if item.name == "load_event_audit"
+                else _copy_attribute(getattr(info, item.name))
+            )
+            for item in fields(info)
+        }
+        for layer, info in infos.items()
+    }
+    global_state = {
+        "_LAYER_ARENA_FINDINGS": list(layerwise._LAYER_ARENA_FINDINGS),
+        "_LAYER_COMPLETION_FINDINGS": list(layerwise._LAYER_COMPLETION_FINDINGS),
+        "_DUMMY_BASELINE_FAILURES": list(layerwise._DUMMY_BASELINE_FAILURES),
+    }
+    source_weights = list(weights)
+    report = LoadProbeReport()
+    try:
+        with _ModelStateGuard(
+            model,
+            report,
+            allow_binding_mutations=True,
+        ):
+            initialize_layerwise_reload(model)
+            mode = LoadProbeMode()
+            with mode:
+                loaded = model.load_weights(observe_weight_sources(source_weights))
+            report.loaded_weights = set(loaded or ())
+            report.intercepted_writes.extend(mode.report.intercepted_writes)
+            report.write_sources.update(mode.report.write_sources)
+            report.findings.extend(mode.report.findings)
+            required = {layer: set(info.received_keys) for layer, info in infos.items()}
+            for layer, info in infos.items():
+                report.findings.extend(
+                    LoadProbeFinding(
+                        code="PROBE_RECEIPT_AUDIT",
+                        operation=type(layer).__name__,
+                        detail=finding,
+                    )
+                    for finding in info.load_event_audit.take_findings()
+                )
+        report.raise_for_error()
+    finally:
+        for layer, info in infos.items():
+            state = info_state[layer]
+            for item in fields(info):
+                if item.name in state:
+                    setattr(info, item.name, state[item.name])
+        for name, value in global_state.items():
+            target = getattr(layerwise, name)
+            target.clear()
+            target.extend(value)
+
+    for layer, events in required.items():
+        info = infos[layer]
+        info.required_keys = events
+        info.required_target_keys = None
+    return report

--- a/vllm/model_executor/model_loader/reload/scope.py
+++ b/vllm/model_executor/model_loader/reload/scope.py
@@ -42,7 +42,9 @@ class KernelWeightScope:
 class LoRAAdapterScope:
     adapter_id: int
     adapter_name: str
-    operation: Literal["replace", "remove"] = "replace"
+    operation: Literal["replace", "patch", "remove"] = "replace"
+    base_generation: int | None = None
+    module_names: tuple[str, ...] | None = None
     tensor_names: tuple[str, ...] | None = None
     config_digest: str | None = None
     artifact_digest: str | None = None
@@ -53,26 +55,37 @@ class LoRAAdapterScope:
             raise ValueError("adapter_id must be greater than zero")
         if not isinstance(self.adapter_name, str) or not self.adapter_name:
             raise ValueError("adapter_name must not be empty")
-        if self.operation not in ("replace", "remove"):
+        if self.operation not in ("replace", "patch", "remove"):
             raise ValueError(f"Unsupported LoRA operation: {self.operation}")
+        if self.module_names is not None:
+            _validate_names("module_names", self.module_names)
         if self.tensor_names is not None:
             _validate_names("tensor_names", self.tensor_names)
+        if self.operation == "patch" and self.module_names is None:
+            raise ValueError("A LoRA patch scope requires module_names")
+        if self.operation == "patch" and (
+            not isinstance(self.base_generation, int) or self.base_generation < 1
+        ):
+            raise ValueError("A LoRA patch scope requires a positive base_generation")
+        if self.operation != "patch" and self.base_generation is not None:
+            raise ValueError("base_generation is only valid for a LoRA patch")
+        if self.operation != "patch" and self.module_names is not None:
+            raise ValueError("module_names is only valid for a LoRA patch")
         if self.operation == "remove" and any(
             value is not None
             for value in (
+                self.module_names,
                 self.tensor_names,
                 self.config_digest,
                 self.artifact_digest,
+                self.base_generation,
             )
         ):
             raise ValueError("A LoRA remove scope cannot declare replacement data")
 
 
 UpdateScope: TypeAlias = (
-    FullBaseWeightScope
-    | PartialBaseWeightScope
-    | KernelWeightScope
-    | LoRAAdapterScope
+    FullBaseWeightScope | PartialBaseWeightScope | KernelWeightScope | LoRAAdapterScope
 )
 
 
@@ -137,11 +150,14 @@ def normalize_update_scope(scope: UpdateScope | dict[str, Any] | None) -> Update
 
     adapter_id = values.pop("adapter_id", None)
     adapter_name = values.pop("adapter_name", None)
+    module_names = values.pop("module_names", None)
     tensor_names = values.pop("tensor_names", None)
     result = LoRAAdapterScope(
         adapter_id=adapter_id,
         adapter_name=adapter_name,
         operation=values.pop("operation", "replace"),
+        base_generation=values.pop("base_generation", None),
+        module_names=None if module_names is None else tuple(module_names),
         tensor_names=None if tensor_names is None else tuple(tensor_names),
         config_digest=values.pop("config_digest", None),
         artifact_digest=values.pop("artifact_digest", None),

--- a/vllm/model_executor/model_loader/reload/scope.py
+++ b/vllm/model_executor/model_loader/reload/scope.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Serializable declarations for one model-state update."""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Literal, TypeAlias
+
+
+class UpdateKind(str, Enum):
+    BASE_CHECKPOINT = "base_checkpoint"
+    BASE_KERNEL = "base_kernel"
+    LORA_ADAPTER = "lora_adapter"
+
+
+@dataclass(frozen=True)
+class FullBaseWeightScope:
+    kind: Literal[UpdateKind.BASE_CHECKPOINT] = UpdateKind.BASE_CHECKPOINT
+    mode: Literal["full"] = "full"
+
+
+@dataclass(frozen=True)
+class PartialBaseWeightScope:
+    source_names: tuple[str, ...]
+    kind: Literal[UpdateKind.BASE_CHECKPOINT] = UpdateKind.BASE_CHECKPOINT
+    mode: Literal["partial"] = "partial"
+
+    def __post_init__(self) -> None:
+        _validate_names("source_names", self.source_names)
+
+
+@dataclass(frozen=True)
+class KernelWeightScope:
+    target_names: tuple[str, ...]
+    kind: Literal[UpdateKind.BASE_KERNEL] = UpdateKind.BASE_KERNEL
+
+    def __post_init__(self) -> None:
+        _validate_names("target_names", self.target_names)
+
+
+@dataclass(frozen=True)
+class LoRAAdapterScope:
+    adapter_id: int
+    adapter_name: str
+    operation: Literal["replace", "remove"] = "replace"
+    tensor_names: tuple[str, ...] | None = None
+    config_digest: str | None = None
+    artifact_digest: str | None = None
+    kind: Literal[UpdateKind.LORA_ADAPTER] = UpdateKind.LORA_ADAPTER
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.adapter_id, int) or self.adapter_id < 1:
+            raise ValueError("adapter_id must be greater than zero")
+        if not isinstance(self.adapter_name, str) or not self.adapter_name:
+            raise ValueError("adapter_name must not be empty")
+        if self.operation not in ("replace", "remove"):
+            raise ValueError(f"Unsupported LoRA operation: {self.operation}")
+        if self.tensor_names is not None:
+            _validate_names("tensor_names", self.tensor_names)
+        if self.operation == "remove" and any(
+            value is not None
+            for value in (
+                self.tensor_names,
+                self.config_digest,
+                self.artifact_digest,
+            )
+        ):
+            raise ValueError("A LoRA remove scope cannot declare replacement data")
+
+
+UpdateScope: TypeAlias = (
+    FullBaseWeightScope
+    | PartialBaseWeightScope
+    | KernelWeightScope
+    | LoRAAdapterScope
+)
+
+
+def _validate_names(field: str, names: tuple[str, ...]) -> None:
+    if not names:
+        raise ValueError(f"{field} must not be empty")
+    if any(not name for name in names):
+        raise ValueError(f"{field} must not contain empty names")
+    if len(set(names)) != len(names):
+        raise ValueError(f"{field} must not contain duplicate names")
+
+
+def normalize_update_scope(scope: UpdateScope | dict[str, Any] | None) -> UpdateScope:
+    """Normalize an API declaration into one immutable scope."""
+    if scope is None:
+        return FullBaseWeightScope()
+    if isinstance(
+        scope,
+        (
+            FullBaseWeightScope,
+            PartialBaseWeightScope,
+            KernelWeightScope,
+            LoRAAdapterScope,
+        ),
+    ):
+        return scope
+    if not isinstance(scope, dict):
+        raise TypeError("update scope must be a scope object, dict, or None")
+
+    values = dict(scope)
+    try:
+        kind = UpdateKind(values.pop("kind"))
+    except (KeyError, ValueError) as error:
+        raise ValueError("update scope requires a valid `kind`") from error
+
+    if kind is UpdateKind.BASE_CHECKPOINT:
+        mode = values.pop("mode", "full")
+        if mode == "full":
+            if values:
+                raise ValueError(
+                    f"Unexpected full checkpoint scope fields: {sorted(values)}"
+                )
+            return FullBaseWeightScope()
+        if mode == "partial":
+            names = values.pop("source_names", None)
+            if values:
+                raise ValueError(
+                    f"Unexpected partial checkpoint scope fields: {sorted(values)}"
+                )
+            if names is None:
+                raise ValueError("partial checkpoint scope requires source_names")
+            return PartialBaseWeightScope(tuple(names))
+        raise ValueError(f"Unsupported checkpoint scope mode: {mode}")
+
+    if kind is UpdateKind.BASE_KERNEL:
+        names = values.pop("target_names", None)
+        if values:
+            raise ValueError(f"Unexpected kernel scope fields: {sorted(values)}")
+        if names is None:
+            raise ValueError("kernel scope requires target_names")
+        return KernelWeightScope(tuple(names))
+
+    adapter_id = values.pop("adapter_id", None)
+    adapter_name = values.pop("adapter_name", None)
+    tensor_names = values.pop("tensor_names", None)
+    result = LoRAAdapterScope(
+        adapter_id=adapter_id,
+        adapter_name=adapter_name,
+        operation=values.pop("operation", "replace"),
+        tensor_names=None if tensor_names is None else tuple(tensor_names),
+        config_digest=values.pop("config_digest", None),
+        artifact_digest=values.pop("artifact_digest", None),
+    )
+    if values:
+        raise ValueError(f"Unexpected LoRA scope fields: {sorted(values)}")
+    return result
+
+
+def scope_source_names(scope: UpdateScope) -> set[str] | None:
+    """Return an exact transport manifest declared by a scope, if any."""
+    if isinstance(scope, PartialBaseWeightScope):
+        return set(scope.source_names)
+    if isinstance(scope, LoRAAdapterScope) and scope.tensor_names is not None:
+        return set(scope.tensor_names)
+    return None
+
+
+__all__ = [
+    "FullBaseWeightScope",
+    "KernelWeightScope",
+    "LoRAAdapterScope",
+    "PartialBaseWeightScope",
+    "UpdateKind",
+    "UpdateScope",
+    "normalize_update_scope",
+    "scope_source_names",
+]

--- a/vllm/model_executor/model_loader/reload/source.py
+++ b/vllm/model_executor/model_loader/reload/source.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Checkpoint source-key context for logical weight-load events.
+
+The context is established by the outer checkpoint iterator and remains
+active while the consumer handles the yielded tensor. Target-side
+``weight_loader`` wrappers can therefore associate a routed target fragment
+with the original checkpoint key without changing hundreds of model-specific
+``load_weights`` implementations.
+"""
+
+from collections.abc import Generator, Iterable
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
+
+import torch
+
+__all__ = ["get_current_source_key", "observe_weight_sources"]
+
+_CURRENT_SOURCE_KEY: ContextVar[str | None] = ContextVar(
+    "vllm_weight_load_source_key", default=None)
+
+
+@contextmanager
+def _source_key_context(source_key: str):
+    token: Token[str | None] = _CURRENT_SOURCE_KEY.set(source_key)
+    try:
+        yield
+    finally:
+        _CURRENT_SOURCE_KEY.reset(token)
+
+
+def get_current_source_key() -> str | None:
+    """Return the original checkpoint key currently being consumed."""
+    return _CURRENT_SOURCE_KEY.get()
+
+
+def observe_weight_sources(
+    weights: Iterable[tuple[str, torch.Tensor]],
+) -> Generator[tuple[str, torch.Tensor], None, None]:
+    """Yield weights while exposing each original source key to loaders.
+
+    A generator remains suspended inside the context manager for the whole
+    duration of ``yield``. Consequently synchronous mapper/routing layers can
+    rename or split the item while target loaders still observe its original
+    checkpoint key. A truly deferred loader must persist the source key with
+    its deferred arguments instead of relying on this transient context.
+    """
+    for source_key, loaded_weight in weights:
+        with _source_key_context(source_key):
+            yield source_key, loaded_weight

--- a/vllm/model_executor/model_loader/reload/types.py
+++ b/vllm/model_executor/model_loader/reload/types.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass, field
 from inspect import BoundArguments
 import torch
 
+from .audit import LoadEventAudit
+
 __all__ = [
     "LayerTensors",
     "LayerRestoreMetadata",
@@ -104,6 +106,10 @@ class LayerReloadingInfo:
     required_target_keys: "set[str] | None" = None
     received_target_keys: set[str] = field(default_factory=set)
 
+    # Independent witnesses used to detect multiple semantic loader calls
+    # collapsing to the same LoadReceipt event/target identity.
+    load_event_audit: LoadEventAudit = field(default_factory=LoadEventAudit)
+
     def reset(self, *, preserve_received_keys: bool = False):
         # required_keys is the observed baseline and must survive across
         # reloads, like restore_metadata. A layer can finish its numel-driven
@@ -114,6 +120,11 @@ class LayerReloadingInfo:
         received_target_keys = (
             self.received_target_keys if preserve_received_keys else set()
         )
+        load_event_audit = (
+            self.load_event_audit
+            if preserve_received_keys
+            else LoadEventAudit()
+        )
         self.__init__(  # type: ignore[misc]
             restore_metadata=self.restore_metadata,
             restore_device=self.restore_device,
@@ -121,6 +132,7 @@ class LayerReloadingInfo:
             received_keys=received_keys,
             required_target_keys=self.required_target_keys,
             received_target_keys=received_target_keys,
+            load_event_audit=load_event_audit,
         )
 
     def can_load(self) -> bool:

--- a/vllm/model_executor/model_loader/reload/types.py
+++ b/vllm/model_executor/model_loader/reload/types.py
@@ -4,12 +4,15 @@ from dataclasses import dataclass, field
 from inspect import BoundArguments
 import torch
 
+from vllm.model_executor.load_receipt import LoadFragment
+
 from .audit import LoadEventAudit
 
 __all__ = [
     "LayerTensors",
     "LayerRestoreMetadata",
     "LayerReloadingInfo",
+    "LoadEventIdentity",
     "LoadManifestGroupScope",
     "LoadManifestScope",
     "LoadManifestReport",
@@ -23,6 +26,26 @@ LayerRestoreMetadata = tuple[
     dict[str, torch.Tensor | None],
     dict[str, torch.Tensor | None],
 ]
+
+
+@dataclass(frozen=True)
+class LoadEventIdentity:
+    """Structured identity of one consumed checkpoint fragment."""
+
+    source_name: str | None
+    target_name: str
+    fragment: LoadFragment = LoadFragment()
+
+    def format(self) -> str:
+        fragment = self.fragment.format()
+        target = (
+            self.target_name
+            if not fragment
+            else f"{self.target_name}[{fragment}]"
+        )
+        if self.source_name is None:
+            return target
+        return f"{self.source_name}=>{target}"
 
 
 @dataclass(frozen=True)
@@ -59,6 +82,10 @@ class LoadManifestReport:
     required_event_count: int
     received_event_count: int
     completion_findings: tuple[str, ...]
+    update_kind: str = "base_checkpoint"
+    update_mode: str = "full"
+    declared_source_names: tuple[str, ...] = ()
+    resolved_source_names: tuple[str, ...] = ()
 
     @property
     def ok(self) -> bool:
@@ -93,10 +120,20 @@ class LayerReloadingInfo:
     # needed. It is a BASELINE -- survives reset(), like restore_metadata.
     required_keys: "set[str] | None" = None
 
+    # Structured form of required_keys used for scope resolution. Kept next to
+    # the display-key set while callers migrate to structured reports.
+    required_events: set[LoadEventIdentity] | None = None
+
     # Keys received during the current reload, accumulated by the online
     # loader wrapper. Transient: cleared by reset() each reload. Completion
     # by set reconciliation is received_keys >= required_keys.
     received_keys: set[str] = field(default_factory=set)
+    received_events: set[LoadEventIdentity] = field(default_factory=set)
+
+    # Effective completion contract for the active update. None means use the
+    # full baseline. An empty set means this layer is outside an explicit
+    # partial scope and must not be initialized or processed.
+    active_required_events: set[LoadEventIdentity] | None = None
 
     # Dummy loading has no checkpoint source stream, but it still has to
     # protect the first real RL weight transfer. This rank-local target
@@ -120,6 +157,7 @@ class LayerReloadingInfo:
         received_target_keys = (
             self.received_target_keys if preserve_received_keys else set()
         )
+        received_events = self.received_events if preserve_received_keys else set()
         load_event_audit = (
             self.load_event_audit
             if preserve_received_keys
@@ -129,7 +167,12 @@ class LayerReloadingInfo:
             restore_metadata=self.restore_metadata,
             restore_device=self.restore_device,
             required_keys=self.required_keys,
+            required_events=self.required_events,
             received_keys=received_keys,
+            received_events=received_events,
+            active_required_events=(
+                self.active_required_events if preserve_received_keys else None
+            ),
             required_target_keys=self.required_target_keys,
             received_target_keys=received_target_keys,
             load_event_audit=load_event_audit,

--- a/vllm/model_executor/model_loader/reload/types.py
+++ b/vllm/model_executor/model_loader/reload/types.py
@@ -71,9 +71,11 @@ class LayerReloadingInfo:
     # device to materialize layers with, recorded by `record_metadata_for_reloading`
     restore_device: torch.device
 
-    # track how many elements are ready for loading, used by `online_process_loader`
-    load_numel: int = 0
-    load_numel_total: int | None = None
+    # Whether this layer currently has online reload wrappers installed.
+    # Completion is manifest-driven; copied element counts are diagnostics only.
+    is_loading: bool = False
+    copied_numel_diagnostic: int = 0
+    layer_numel_diagnostic: int | None = None
 
     # used by `online_process_loader` to buffer args and tensors until ready to load
     loaded_weights: list[tuple[str, BoundArguments]] = field(default_factory=list)
@@ -122,4 +124,4 @@ class LayerReloadingInfo:
         )
 
     def can_load(self) -> bool:
-        return self.load_numel_total is not None
+        return self.is_loading

--- a/vllm/model_executor/model_loader/reload/types.py
+++ b/vllm/model_executor/model_loader/reload/types.py
@@ -4,16 +4,69 @@ from dataclasses import dataclass, field
 from inspect import BoundArguments
 import torch
 
-__all__ = ["LayerTensors", "LayerReloadingInfo"]
+__all__ = [
+    "LayerTensors",
+    "LayerRestoreMetadata",
+    "LayerReloadingInfo",
+    "LoadManifestGroupScope",
+    "LoadManifestScope",
+    "LoadManifestReport",
+]
 
-# encodes both parameters and buffers separately
+# Runtime tensors contain only materialized Tensor values. Restore metadata
+# additionally preserves registered ``None`` slots such as ``Linear.bias``
+# when a layer was constructed with ``bias=False``.
 LayerTensors = tuple[dict[str, torch.Tensor], dict[str, torch.Tensor]]
+LayerRestoreMetadata = tuple[
+    dict[str, torch.Tensor | None],
+    dict[str, torch.Tensor | None],
+]
+
+
+@dataclass(frozen=True)
+class LoadManifestGroupScope:
+    """The current worker's coordinate in one parallel group."""
+
+    rank: int
+    world_size: int
+
+
+@dataclass(frozen=True)
+class LoadManifestScope:
+    """Rank coordinates attached to a process-local load manifest.
+
+    A manifest is intentionally not unioned across workers: TP, PP and EP
+    workers consume different target fragments, while DP replicas own
+    independent model state. The controller may collect these coordinates and
+    reports, but reconciliation must happen in each worker first.
+    """
+
+    global_rank: int | None = None
+    global_world_size: int | None = None
+    tp: LoadManifestGroupScope | None = None
+    pp: LoadManifestGroupScope | None = None
+    dp: LoadManifestGroupScope | None = None
+    ep: LoadManifestGroupScope | None = None
+
+
+@dataclass(frozen=True)
+class LoadManifestReport:
+    """Serializable result of one worker's local reconciliation."""
+
+    scope: LoadManifestScope
+    required_event_count: int
+    received_event_count: int
+    completion_findings: tuple[str, ...]
+
+    @property
+    def ok(self) -> bool:
+        return not self.completion_findings
 
 
 @dataclass
 class LayerReloadingInfo:
     # model format metadata, recorded by `record_metadata_for_reloading`
-    restore_metadata: LayerTensors
+    restore_metadata: LayerRestoreMetadata
 
     # device to materialize layers with, recorded by `record_metadata_for_reloading`
     restore_device: torch.device
@@ -41,13 +94,31 @@ class LayerReloadingInfo:
     # by set reconciliation is received_keys >= required_keys.
     received_keys: set[str] = field(default_factory=set)
 
-    def reset(self):
+    # Dummy loading has no checkpoint source stream, but it still has to
+    # protect the first real RL weight transfer. This rank-local target
+    # baseline lists every parameter that must be touched at least once.
+    # After the first complete real load it is replaced by the exact observed
+    # source-to-target event set above.
+    required_target_keys: "set[str] | None" = None
+    received_target_keys: set[str] = field(default_factory=set)
+
+    def reset(self, *, preserve_received_keys: bool = False):
         # required_keys is the observed baseline and must survive across
-        # reloads, like restore_metadata; everything else is per-reload state.
+        # reloads, like restore_metadata. A layer can finish its numel-driven
+        # processing before the checkpoint iterator is exhausted, so receipts
+        # optionally survive that *internal* reset and are cleared only when
+        # the whole reload is finalized.
+        received_keys = self.received_keys if preserve_received_keys else set()
+        received_target_keys = (
+            self.received_target_keys if preserve_received_keys else set()
+        )
         self.__init__(  # type: ignore[misc]
             restore_metadata=self.restore_metadata,
             restore_device=self.restore_device,
             required_keys=self.required_keys,
+            received_keys=received_keys,
+            required_target_keys=self.required_target_keys,
+            received_target_keys=received_target_keys,
         )
 
     def can_load(self) -> bool:

--- a/vllm/model_executor/model_loader/reload/types.py
+++ b/vllm/model_executor/model_loader/reload/types.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from dataclasses import dataclass, field
 from inspect import BoundArguments
+
 import torch
 
 from vllm.model_executor.load_receipt import LoadFragment

--- a/vllm/model_executor/model_loader/reload/types.py
+++ b/vllm/model_executor/model_loader/reload/types.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from dataclasses import dataclass, field
 from inspect import BoundArguments
-
 import torch
 
 __all__ = ["LayerTensors", "LayerReloadingInfo"]
@@ -29,9 +28,26 @@ class LayerReloadingInfo:
     # kernel formatted tensors, copied into by `_layerwise_process` when reloading
     kernel_tensors: LayerTensors | None = None
 
+    # The set of parameter keys a correct load actually consumes, OBSERVED at
+    # the first load (record_load_consumption), not predicted from layer
+    # structure. This is the ground-truth "required" for completion: tensors
+    # never routed through a loader (EP bookkeeping, shared copies) are absent
+    # by construction, so no SKIP_TENSORS-style hand-maintained exclusion is
+    # needed. It is a BASELINE -- survives reset(), like restore_metadata.
+    required_keys: "set[str] | None" = None
+
+    # Keys received during the current reload, accumulated by the online
+    # loader wrapper. Transient: cleared by reset() each reload. Completion
+    # by set reconciliation is received_keys >= required_keys.
+    received_keys: set[str] = field(default_factory=set)
+
     def reset(self):
+        # required_keys is the observed baseline and must survive across
+        # reloads, like restore_metadata; everything else is per-reload state.
         self.__init__(  # type: ignore[misc]
-            restore_metadata=self.restore_metadata, restore_device=self.restore_device
+            restore_metadata=self.restore_metadata,
+            restore_device=self.restore_device,
+            required_keys=self.required_keys,
         )
 
     def can_load(self) -> bool:

--- a/vllm/model_executor/model_loader/runai_streamer_loader.py
+++ b/vllm/model_executor/model_loader/runai_streamer_loader.py
@@ -10,6 +10,7 @@ from transformers.utils import SAFE_WEIGHTS_INDEX_NAME
 from vllm.config import ModelConfig
 from vllm.config.load import LoadConfig
 from vllm.model_executor.model_loader.base_loader import BaseModelLoader
+from vllm.model_executor.model_loader.reload.source import observe_weight_sources
 from vllm.model_executor.model_loader.weight_utils import (
     download_safetensors_index_file_from_hf,
     download_weights_from_hf,
@@ -136,5 +137,6 @@ class RunaiModelStreamerLoader(BaseModelLoader):
         if model_weights_override := model_config.model_weights:
             model_weights = model_weights_override
         model.load_weights(
-            self._get_weights_iterator(model_weights, model_config.revision)
+            observe_weight_sources(
+                self._get_weights_iterator(model_weights, model_config.revision))
         )

--- a/vllm/model_executor/model_loader/sharded_state_loader.py
+++ b/vllm/model_executor/model_loader/sharded_state_loader.py
@@ -16,6 +16,10 @@ from vllm.config import ModelConfig
 from vllm.config.load import LoadConfig
 from vllm.logger import init_logger
 from vllm.model_executor.model_loader.base_loader import BaseModelLoader
+from vllm.model_executor.model_loader.reload.layerwise import (
+    record_direct_load_consumption,
+)
+from vllm.model_executor.model_loader.reload.source import observe_weight_sources
 from vllm.model_executor.model_loader.weight_utils import (
     download_weights_from_hf,
     runai_safetensors_weights_iterator,
@@ -135,7 +139,9 @@ class ShardedStateLoader(BaseModelLoader):
             )
         state_dict = self._filter_subtensors(model.state_dict())
         counter_before_loading_weights = time.perf_counter()
-        for key, tensor in self.iterate_over_files(filepaths):
+        for key, tensor in observe_weight_sources(
+            self.iterate_over_files(filepaths)
+        ):
             # If loading with LoRA enabled, additional padding may
             # be added to certain parameters. We only load into a
             # narrowed view of the parameter data.
@@ -152,6 +158,7 @@ class ShardedStateLoader(BaseModelLoader):
                     param_shape,
                 )
             param_data.copy_(tensor)
+            record_direct_load_consumption(model, key, key)
             state_dict.pop(key)
         counter_after_loading_weights = time.perf_counter()
         logger.info_once(

--- a/vllm/model_executor/model_loader/tensorizer_loader.py
+++ b/vllm/model_executor/model_loader/tensorizer_loader.py
@@ -11,6 +11,7 @@ from vllm.config import ModelConfig, ParallelConfig, VllmConfig
 from vllm.config.load import LoadConfig
 from vllm.logger import init_logger
 from vllm.model_executor.model_loader.base_loader import BaseModelLoader
+from vllm.model_executor.model_loader.reload.source import observe_weight_sources
 from vllm.model_executor.model_loader.tensorizer import (
     TensorizerConfig,
     deserialize_tensorizer_model,
@@ -83,7 +84,8 @@ class TensorizerLoader(BaseModelLoader):
             with torch.device(device_config.device):
                 model = initialize_model(vllm_config=vllm_config, prefix=prefix)
 
-            model.load_weights(self._get_weights_iterator())
+            model.load_weights(
+                observe_weight_sources(self._get_weights_iterator()))
         return model.eval()
 
     def download_model(self, model_config: ModelConfig) -> None:
@@ -110,7 +112,8 @@ class TensorizerLoader(BaseModelLoader):
             tensorizer_config = self._patch_tensorizer_config(model_config)
             deserialize_tensorizer_model(model, tensorizer_config)
         else:
-            model.load_weights(self._get_weights_iterator())
+            model.load_weights(
+                observe_weight_sources(self._get_weights_iterator()))
 
     def load_model(
         self, vllm_config: VllmConfig, model_config: ModelConfig, prefix: str = ""

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -1231,7 +1231,7 @@ def row_parallel_weight_loader(
     return default_weight_loader(param, loaded_weight)
 
 
-LoaderFunction = Callable[[torch.Tensor, torch.Tensor], None]
+LoaderFunction = Callable[[torch.Tensor, torch.Tensor], object]
 
 
 def sharded_weight_loader(shard_axis: int) -> LoaderFunction:
@@ -1254,10 +1254,12 @@ def composed_weight_loader(
 ) -> LoaderFunction:
     """Create a weight loader that post-processes the weights after loading"""
 
-    def composed_loader(param: torch.Tensor, loaded_weight: torch.Tensor) -> None:
-        loader(param, loaded_weight)
+    def composed_loader(param: torch.Tensor, loaded_weight: torch.Tensor):
+        receipt = loader(param, loaded_weight)
         param.data.copy_(fn(param))
-        return
+        # Preserve a structured LoadReceipt returned by the logical source
+        # loader. The post-load transform is not a second load event.
+        return receipt
 
     return composed_loader
 

--- a/vllm/model_executor/models/gpt_oss.py
+++ b/vllm/model_executor/models/gpt_oss.py
@@ -543,7 +543,8 @@ class GptOssModel(nn.Module, EagleModelMixin):
                 # Handle attention sinks (distributed across ranks)
                 param = params_dict[name]
                 narrow_weight = weight.narrow(0, head_start, heads_per_rank)
-                param.data.copy_(narrow_weight)
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, narrow_weight)
                 loaded_params.add(name)
                 continue
             for param_name, weight_name, shard_id in stacked_params_mapping:
@@ -901,7 +902,8 @@ class GptOssModel(nn.Module, EagleModelMixin):
                 # Handle attention sinks (distributed across ranks)
                 param = params_dict[name]
                 narrow_weight = loaded_weight.narrow(0, head_start, heads_per_rank)
-                param.data.copy_(narrow_weight)
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, narrow_weight)
                 loaded_params.add(name)
                 continue
 
@@ -1072,7 +1074,8 @@ class GptOssModel(nn.Module, EagleModelMixin):
                 # Handle attention sinks (distributed across ranks)
                 param = params_dict[name]
                 narrow_weight = weight.narrow(0, head_start, heads_per_rank)
-                param.data.copy_(narrow_weight)
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, narrow_weight)
                 loaded_params.add(name)
                 continue
             for param_name, weight_name, shard_id in stacked_params_mapping:

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -1094,14 +1094,14 @@ class AsyncLLM(EngineClient):
             "start_weight_update", kwargs={"update_scope": update_scope}
         )
 
-    async def get_weight_update_baseline(self) -> dict:
-        """Return the global initial-load manifest used to build partial scopes."""
+    async def get_weight_update_manifest(self) -> dict:
+        """Return all model-weight and LoRA state available for update."""
         from vllm.model_executor.model_loader.reload.baseline import (
-            aggregate_weight_update_baselines,
+            aggregate_weight_update_manifests,
         )
 
-        reports = await self.collective_rpc("get_weight_update_baseline")
-        return aggregate_weight_update_baselines(reports)
+        manifests = await self.collective_rpc("get_weight_update_manifest")
+        return aggregate_weight_update_manifests(manifests)
 
     async def update_weights(self, request: WeightTransferUpdateRequest) -> None:
         """
@@ -1132,14 +1132,11 @@ class AsyncLLM(EngineClient):
                 f"{len(failed)} worker(s): {failed[:4]}"
             )
         scoped_reports = [
-            report
-            for report in reports
-            if getattr(report, "declared_source_names", ())
+            report for report in reports if getattr(report, "declared_source_names", ())
         ]
         if scoped_reports:
             declarations = {
-                frozenset(report.declared_source_names)
-                for report in scoped_reports
+                frozenset(report.declared_source_names) for report in scoped_reports
             }
             if len(declarations) != 1:
                 raise RuntimeError(

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -1094,6 +1094,15 @@ class AsyncLLM(EngineClient):
             "start_weight_update", kwargs={"update_scope": update_scope}
         )
 
+    async def get_weight_update_baseline(self) -> dict:
+        """Return the global initial-load manifest used to build partial scopes."""
+        from vllm.model_executor.model_loader.reload.baseline import (
+            aggregate_weight_update_baselines,
+        )
+
+        reports = await self.collective_rpc("get_weight_update_baseline")
+        return aggregate_weight_update_baselines(reports)
+
     async def update_weights(self, request: WeightTransferUpdateRequest) -> None:
         """
         Batched weight update for RL training.

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -947,7 +947,15 @@ class AsyncLLM(EngineClient):
 
     async def add_lora(self, lora_request: LoRARequest) -> bool:
         """Load a new LoRA adapter into the engine for future requests."""
-        return await self.engine_core.add_lora_async(lora_request)
+        loaded = await self.engine_core.add_lora_async(lora_request)
+        if getattr(lora_request, "update_scope", None) is not None:
+            if not await self.reset_prefix_cache(reset_connector=True):
+                raise RuntimeError(
+                    "Failed to invalidate prefix cache after LoRA update"
+                )
+            await self.reset_mm_cache()
+            await self.reset_encoder_cache()
+        return loaded
 
     async def remove_lora(self, lora_id: int) -> bool:
         """Remove an already loaded LoRA adapter."""
@@ -1080,9 +1088,11 @@ class AsyncLLM(EngineClient):
             "init_weight_transfer_engine", kwargs={"init_info": init_info_dict}
         )
 
-    async def start_weight_update(self) -> None:
+    async def start_weight_update(self, update_scope: dict | None = None) -> None:
         """Start a new weight update."""
-        await self.collective_rpc("start_weight_update")
+        await self.collective_rpc(
+            "start_weight_update", kwargs={"update_scope": update_scope}
+        )
 
     async def update_weights(self, request: WeightTransferUpdateRequest) -> None:
         """
@@ -1105,4 +1115,39 @@ class AsyncLLM(EngineClient):
 
     async def finish_weight_update(self) -> None:
         """Finish the current weight update."""
-        await self.collective_rpc("finish_weight_update")
+        reports = await self.collective_rpc("finish_weight_update")
+        failed = [report for report in reports if not getattr(report, "ok", True)]
+        if failed:
+            raise RuntimeError(
+                "Weight update failed rank-local completion on "
+                f"{len(failed)} worker(s): {failed[:4]}"
+            )
+        scoped_reports = [
+            report
+            for report in reports
+            if getattr(report, "declared_source_names", ())
+        ]
+        if scoped_reports:
+            declarations = {
+                frozenset(report.declared_source_names)
+                for report in scoped_reports
+            }
+            if len(declarations) != 1:
+                raise RuntimeError(
+                    "Workers disagreed on the explicit weight update scope"
+                )
+            declared = set(next(iter(declarations)))
+            resolved = {
+                name
+                for report in scoped_reports
+                for name in report.resolved_source_names
+            }
+            if missing := declared - resolved:
+                raise RuntimeError(
+                    "Explicit weight update scope contains source names not "
+                    f"resolved by any worker: {sorted(missing)[:20]}"
+                )
+        if not await self.reset_prefix_cache(reset_connector=True):
+            raise RuntimeError("Failed to invalidate prefix cache after weight update")
+        await self.reset_mm_cache()
+        await self.reset_encoder_cache()

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -291,6 +291,25 @@ class Executor(ABC):
 
     def add_lora(self, lora_request: LoRARequest) -> bool:
         assert lora_request.lora_int_id > 0, "lora_id must be greater than 0."
+        if getattr(lora_request, "update_scope", None) is not None:
+            try:
+                prepared = self.collective_rpc(
+                    "prepare_lora_update", args=(lora_request,)
+                )
+                if not all(prepared):
+                    raise RuntimeError("Not every worker staged the LoRA update")
+                return all(
+                    self.collective_rpc(
+                        "commit_lora_update",
+                        args=(lora_request.lora_int_id,),
+                    )
+                )
+            except BaseException:
+                self.collective_rpc(
+                    "abort_lora_update",
+                    args=(lora_request.lora_int_id,),
+                )
+                raise
         return all(self.collective_rpc("add_lora", args=(lora_request,)))
 
     def remove_lora(self, lora_id: int) -> bool:

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from concurrent.futures import Future
 from functools import cached_property
-from typing import TYPE_CHECKING, Literal, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload
 
 import vllm.envs as envs
 from vllm.config import VllmConfig
@@ -292,8 +292,43 @@ class Executor(ABC):
     def add_lora(self, lora_request: LoRARequest) -> bool:
         assert lora_request.lora_int_id > 0, "lora_id must be greater than 0."
         if getattr(lora_request, "update_scope", None) is not None:
+            from vllm.model_executor.model_loader.reload.scope import (
+                LoRAAdapterScope,
+                normalize_update_scope,
+            )
+
+            scope = normalize_update_scope(lora_request.update_scope)
+            if isinstance(scope, LoRAAdapterScope) and scope.operation == "patch":
+                worker_manifests: list[list[dict[str, Any]]] = self.collective_rpc(
+                    "get_lora_update_manifests"
+                )
+                matching = [
+                    adapter
+                    for manifest in worker_manifests
+                    for adapter in manifest
+                    if adapter["adapter_id"] == scope.adapter_id
+                    and adapter["adapter_name"] == scope.adapter_name
+                ]
+                if len(matching) != len(worker_manifests):
+                    raise ValueError(
+                        "The LoRA adapter to patch is not present on every worker"
+                    )
+                generations = {adapter["generation"] for adapter in matching}
+                if generations != {scope.base_generation}:
+                    raise ValueError(
+                        "LoRA patch base generation does not match every worker"
+                    )
+                available_modules = {
+                    name for adapter in matching for name in adapter["module_names"]
+                }
+                unknown = set(scope.module_names or ()) - available_modules
+                if unknown:
+                    raise ValueError(
+                        "LoRA patch references unknown runtime modules: "
+                        f"{sorted(unknown)[:20]}"
+                    )
             try:
-                prepared = self.collective_rpc(
+                prepared: list[bool] = self.collective_rpc(
                     "prepare_lora_update", args=(lora_request,)
                 )
                 if not all(prepared):

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4,6 +4,7 @@
 import functools
 import gc
 import itertools
+import os
 import threading
 import time
 from collections import defaultdict
@@ -5441,6 +5442,7 @@ class GPUModelRunner(
         weights_iterator: Iterable[tuple[str, torch.Tensor]] | None = None,
         weights_path: str | None = None,
         is_checkpoint_format: bool = True,
+        update_scope: dict | None = None,
     ) -> None:
         """
         Reload weights from a weights iterator or from disk
@@ -5460,6 +5462,25 @@ class GPUModelRunner(
                 "Please use `is_checkpoint_format=True` "
                 "to avoid weight reloading errors"
             )
+
+        from vllm.model_executor.model_loader.reload.scope import (
+            FullBaseWeightScope,
+            KernelWeightScope,
+            PartialBaseWeightScope,
+            normalize_update_scope,
+        )
+
+        scope = normalize_update_scope(update_scope)
+        if is_checkpoint_format and not isinstance(
+            scope, (FullBaseWeightScope, PartialBaseWeightScope)
+        ):
+            raise ValueError("Checkpoint reload requires a base_checkpoint scope")
+        if not is_checkpoint_format and update_scope is None:
+            scope = KernelWeightScope(
+                tuple(name for name, _ in self.get_model().named_parameters())
+            )
+        if not is_checkpoint_format and not isinstance(scope, KernelWeightScope):
+            raise ValueError("Kernel-format reload requires a base_kernel scope")
 
         model = self.get_model()
         weights_to_load = {name for name, _ in model.named_parameters()}
@@ -5482,23 +5503,72 @@ class GPUModelRunner(
 
         # begin loading weights
         logger.info_once("Reloading weights inplace...")
-        if is_checkpoint_format:
-            # load weights from checkpoint/ original model format
-            initialize_layerwise_reload(model)
-            loaded_weights = model.load_weights(weights_iterator)
-            finalize_layerwise_reload(model, self.model_config)
+        # The config context must span post-load processing: PWAL rebuild
+        # paths (e.g. QuantFP8 CustomOp construction) read the global config,
+        # and reload runs outside the startup context that initial loading
+        # had. Boundary-wide context rather than per-field snapshots so new
+        # config consumers stay covered.
+        with set_current_vllm_config(self.vllm_config):
+            if is_checkpoint_format:
+                # load weights from checkpoint/ original model format
+                initialize_layerwise_reload(model, scope)
+                loaded_weights = model.load_weights(weights_iterator)
+                finalize_layerwise_reload(model, self.model_config)
+                if isinstance(scope, PartialBaseWeightScope):
+                    from vllm.model_executor.model_loader.reload.layerwise import (
+                        get_layer_completion_findings,
+                    )
 
-        else:
-            # load weights from kernel format
-            logger.warning_once(
-                "Reloading with `is_checkpoint_format=True` requires that "
-                "weights be in kernel format and already sharded",
-            )
-            loaded_weights = set()
-            for name, loaded_weight in weights_iterator:
-                param = model.get_parameter(name)  # TODO: buffers?
-                param.copy_(loaded_weight)
-                loaded_weights.add(name)
+                    completion_findings = get_layer_completion_findings()
+                    if completion_findings:
+                        raise RuntimeError(
+                            "Partial checkpoint update did not satisfy its "
+                            "explicit scope:\n  "
+                            + "\n  ".join(completion_findings[:20])
+                        )
+
+            else:
+                # load weights from kernel format
+                logger.warning_once(
+                    "Reloading with `is_checkpoint_format=True` requires that "
+                    "weights be in kernel format and already sharded",
+                )
+                loaded_weights = set()
+                if isinstance(scope, KernelWeightScope):
+                    weights_iterator = list(weights_iterator)
+                    received_names = [name for name, _ in weights_iterator]
+                    received = set(received_names)
+                    expected = set(scope.target_names)
+                    if len(received) != len(received_names):
+                        raise ValueError(
+                            "Kernel-format update contains duplicate target names"
+                        )
+                    missing = expected - received
+                    unexpected = received - expected
+                    if missing or unexpected:
+                        raise ValueError(
+                            "Kernel-format update scope mismatch: "
+                            f"missing={sorted(missing)[:20]}, "
+                            f"unexpected={sorted(unexpected)[:20]}"
+                        )
+                kernel_weights = []
+                for name, loaded_weight in weights_iterator:
+                    param = model.get_parameter(name)  # TODO: buffers?
+                    if param.shape != loaded_weight.shape:
+                        raise ValueError(
+                            f"Kernel weight {name} shape mismatch: "
+                            f"expected={tuple(param.shape)}, "
+                            f"received={tuple(loaded_weight.shape)}"
+                        )
+                    if param.dtype != loaded_weight.dtype:
+                        raise ValueError(
+                            f"Kernel weight {name} dtype mismatch: "
+                            f"expected={param.dtype}, received={loaded_weight.dtype}"
+                        )
+                    kernel_weights.append((name, param, loaded_weight))
+                for name, param, loaded_weight in kernel_weights:
+                    param.copy_(loaded_weight)
+                    loaded_weights.add(name)
 
         # logging and validation
         counter_after_reloading = time.perf_counter()
@@ -6709,6 +6779,16 @@ class GPUModelRunner(
             elapsed_time,
             cuda_graph_size / (1 << 30),
         )
+
+        # Record module-level tensor storage as the graphs just captured it.
+        # These have no owning layer, so neither copy-back nor the reload
+        # arena covers them; the manifest is what lets a reload notice if a
+        # global cache rebinds an address a graph baked in.
+        if os.environ.get("VLLM_RELOAD_GLOBAL_MANIFEST", "warn") != "off":
+            from vllm.model_executor.reload_manifest import (
+                record_global_storage)
+            record_global_storage()
+
         return cuda_graph_size
 
     def _warmup_and_capture(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4,7 +4,6 @@
 import functools
 import gc
 import itertools
-import os
 import threading
 import time
 from collections import defaultdict
@@ -6779,15 +6778,6 @@ class GPUModelRunner(
             elapsed_time,
             cuda_graph_size / (1 << 30),
         )
-
-        # Record module-level tensor storage as the graphs just captured it.
-        # These have no owning layer, so neither copy-back nor the reload
-        # arena covers them; the manifest is what lets a reload notice if a
-        # global cache rebinds an address a graph baked in.
-        if os.environ.get("VLLM_RELOAD_GLOBAL_MANIFEST", "warn") != "off":
-            from vllm.model_executor.reload_manifest import (
-                record_global_storage)
-            record_global_storage()
 
         return cuda_graph_size
 

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1103,7 +1103,31 @@ class Worker(WorkerBase):
         self.model_runner._dummy_run(num_tokens, uniform_decode=True)
 
     def add_lora(self, lora_request: LoRARequest) -> bool:
+        self._check_lora_update_base(lora_request)
         return self.model_runner.add_lora(lora_request)
+
+    def prepare_lora_update(self, lora_request: LoRARequest) -> bool:
+        self._check_lora_update_base(lora_request)
+        return self.model_runner.prepare_lora_update(lora_request)
+
+    def commit_lora_update(self, lora_id: int) -> bool:
+        return self.model_runner.commit_lora_update(lora_id)
+
+    def abort_lora_update(self, lora_id: int) -> None:
+        self.model_runner.abort_lora_update(lora_id)
+
+    def _check_lora_update_base(self, lora_request: LoRARequest) -> None:
+        if getattr(lora_request, "update_scope", None) is None:
+            return
+        from vllm.model_executor.model_loader.reload.layerwise import (
+            has_dummy_load_manifest,
+        )
+
+        if has_dummy_load_manifest(self.model_runner.get_model()):
+            raise RuntimeError(
+                "A LoRA-only update cannot be applied before a dummy "
+                "model receives one complete real base-weight update"
+            )
 
     def remove_lora(self, lora_id: int) -> bool:
         return self.model_runner.remove_lora(lora_id)
@@ -1161,7 +1185,7 @@ class Worker(WorkerBase):
         typed_init_info = self.weight_transfer_engine.parse_init_info(init_info)
         self.weight_transfer_engine.init_transfer_engine(typed_init_info)
 
-    def start_weight_update(self) -> None:
+    def start_weight_update(self, update_scope: dict | None = None) -> None:
         """
         Start a new weight update session.
 
@@ -1178,7 +1202,10 @@ class Worker(WorkerBase):
                 "active. Call finish_weight_update first."
             )
 
-        self.weight_transfer_engine.start_weight_update()
+        if update_scope is None:
+            self.weight_transfer_engine.start_weight_update()
+        else:
+            self.weight_transfer_engine.start_weight_update(update_scope)
         self._weight_update_active = True
 
     def update_weights(self, update_info: dict) -> None:
@@ -1205,7 +1232,7 @@ class Worker(WorkerBase):
             self._weight_update_active = False
             raise
 
-    def finish_weight_update(self) -> None:
+    def finish_weight_update(self):
         """Finish the current weight update session."""
         self._check_weight_transfer_engine()
         assert self.weight_transfer_engine is not None
@@ -1215,8 +1242,10 @@ class Worker(WorkerBase):
                 "finish_weight_update called without a matching start_weight_update."
             )
 
-        self.weight_transfer_engine.finish_weight_update()
-        self._weight_update_active = False
+        try:
+            return self.weight_transfer_engine.finish_weight_update()
+        finally:
+            self._weight_update_active = False
 
     def shutdown(self) -> None:
         gc.unfreeze()

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1208,13 +1208,18 @@ class Worker(WorkerBase):
             self.weight_transfer_engine.start_weight_update(update_scope)
         self._weight_update_active = True
 
-    def get_weight_update_baseline(self):
-        """Return this rank's initial-load manifest for partial update scopes."""
+    def get_weight_update_manifest(self):
+        """Return this rank's updatable model-weight and LoRA manifests."""
         from vllm.model_executor.model_loader.reload.baseline import (
-            get_weight_update_baseline,
+            get_weight_update_manifest,
         )
 
-        return get_weight_update_baseline(self.get_model())
+        return get_weight_update_manifest(
+            self.get_model(), self.model_runner.get_lora_update_manifests()
+        )
+
+    def get_lora_update_manifests(self):
+        return self.model_runner.get_lora_update_manifests()
 
     def update_weights(self, update_info: dict) -> None:
         """

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1208,6 +1208,14 @@ class Worker(WorkerBase):
             self.weight_transfer_engine.start_weight_update(update_scope)
         self._weight_update_active = True
 
+    def get_weight_update_baseline(self):
+        """Return this rank's initial-load manifest for partial update scopes."""
+        from vllm.model_executor.model_loader.reload.baseline import (
+            get_weight_update_baseline,
+        )
+
+        return get_weight_update_baseline(self.get_model())
+
     def update_weights(self, update_info: dict) -> None:
         """
         Receive one weight update chunk from the trainer.

--- a/vllm/v1/worker/lora_model_runner_mixin.py
+++ b/vllm/v1/worker/lora_model_runner_mixin.py
@@ -275,6 +275,18 @@ class LoRAModelRunnerMixin:
         self._ensure_lora_enabled()
         return self.lora_manager.add_adapter(lora_request)
 
+    def prepare_lora_update(self, lora_request: LoRARequest) -> bool:
+        self._ensure_lora_enabled()
+        return self.lora_manager.prepare_adapter(lora_request)
+
+    def commit_lora_update(self, lora_id: int) -> bool:
+        self._ensure_lora_enabled()
+        return self.lora_manager.commit_adapter(lora_id)
+
+    def abort_lora_update(self, lora_id: int) -> None:
+        self._ensure_lora_enabled()
+        self.lora_manager.abort_adapter(lora_id)
+
     def remove_lora(self, lora_id: int) -> bool:
         self._ensure_lora_enabled()
         return self.lora_manager.remove_adapter(lora_id)

--- a/vllm/v1/worker/lora_model_runner_mixin.py
+++ b/vllm/v1/worker/lora_model_runner_mixin.py
@@ -298,3 +298,8 @@ class LoRAModelRunnerMixin:
     def list_loras(self) -> set[int]:
         self._ensure_lora_enabled()
         return self.lora_manager.list_adapters()
+
+    def get_lora_update_manifests(self) -> list[dict[str, object]]:
+        if not hasattr(self, "lora_manager"):
+            return []
+        return self.lora_manager.get_adapter_manifests()


### PR DESCRIPTION
## Summary

This draft splits the load-completion and receipt work out of #49789 into a focused branch on top of `releases/v0.25.1`:

- observe the exact rank-local source-to-target fragment manifest during the first real load;
- use that manifest, rather than copied element counts, as the reload completion contract;
- add structured `LoadReceipt` support and collision/schema audits for packed, merged, and MoE loaders;
- validate checkpoint and IPC/NCCL source manifests;
- support explicit full/partial update scopes, with exact scope enforcement for legal partial updates;
- probe dummy-load target manifests and expose the resulting baseline so training can construct valid update scopes.

## Why this is not a duplicate

This is the receipt/completion half split from draft #49789. After this split, `feat/reload-arena` contains only arena/storage-stability work, while this PR contains only reload receipt, completion, source-manifest, update-scope, dummy-probe, and baseline API work. It does not include `ReloadArena` or CUDAGraph storage changes.

PR #50075 also introduces manifest-driven completion, but this draft additionally provides structured receipts, fragment/collision auditing, source-manifest validation, explicit partial-update scopes, dummy-load probing, and a baseline API. The overlapping completion mechanism should be reconciled during review rather than merged independently without coordination.

## Completion semantics

- Full reload treats the initial rank-local manifest as a lower bound: every expected consumed application must be observed; additional accepted applications are allowed.
- Loader calls declined with `consumed=False` are not part of the baseline or observed completion set, including non-local EP experts offered by a broadcasting sender.
- Explicit partial updates enforce both bounds: all selected events must be observed and no consumed event may escape the declared scope.

## Validation

Tests run on NVIDIA H200:

- update-scope, completion-set, and dummy-probe tests: `54 passed`;
- partial-update baseline API test: `1 passed`;
- worker weight-transfer tests: `6 passed`.

## AI assistance

AI assistance was used to analyze the existing reload paths, implement portions of the change, split the original branch, and prepare this draft. The human submitter is responsible for reviewing every changed line, understanding the design end-to-end, and validating the final change before it is marked ready for review.
