### PR TITLE
[Bugfix][Gemma4] Map stacked expert LoRA tensors onto the MoE parent module

### DIFF
--- a/tests/lora/test_lora_checkpoints.py
+++ b/tests/lora/test_lora_checkpoints.py
@@ -7,6 +7,7 @@ from vllm.lora.lora_model import LoRAModel
 from vllm.lora.peft_helper import PEFTHelper
 from vllm.lora.utils import parse_fine_tuned_lora_name
 from vllm.model_executor.models.gemma4 import Gemma4ForCausalLM
+from vllm.model_executor.models.gemma4_mm import Gemma4ForConditionalGeneration
 from vllm.model_executor.models.utils import WeightsMapper
 
 lora_lst = ["baichuan7B", "baichuan7B-zero", "baichuan7B-zero-regex", "chatglm3-6b"]
@@ -154,3 +155,65 @@ def test_gemma4_moe_lora_weights_mapping():
         "model.layers.9.moe.gate_up_proj",
         False,
     )
+
+
+@pytest.mark.parametrize(
+    "model_cls,prefix",
+    [
+        (Gemma4ForCausalLM, "model"),
+        (Gemma4ForConditionalGeneration, "language_model.model"),
+    ],
+)
+def test_gemma4_stacked_expert_lora_weights_mapping(model_cls, prefix):
+    """Stacked (PEFT ``target_parameters``) expert LoRA tensors must be
+    rewritten onto the ``.moe.experts`` parent module.
+
+    These adapters store the expert deltas as two tensor pairs per layer that
+    name the ``experts`` module itself rather than a child module:
+    ``...experts.base_layer.lora_{A,B}`` (gate_up_proj) and
+    ``...experts.lora_{A,B}`` (down_proj). ``_convert_3d_to_2d_moe_lora``
+    looks these up under the registered module name, which carries the
+    ``.moe.`` segment, so the mapper has to add it here as well.
+    """
+    mapper = model_cls.hf_to_vllm_mapper
+    base = "base_model.model.model.language_model.layers.9.experts"
+    assert parse_fine_tuned_lora_name(f"{base}.base_layer.lora_A.weight", mapper) == (
+        f"{prefix}.layers.9.moe.experts.base_layer",
+        True,
+    )
+    assert parse_fine_tuned_lora_name(f"{base}.base_layer.lora_B.weight", mapper) == (
+        f"{prefix}.layers.9.moe.experts.base_layer",
+        False,
+    )
+    assert parse_fine_tuned_lora_name(f"{base}.lora_A.weight", mapper) == (
+        f"{prefix}.layers.9.moe.experts",
+        True,
+    )
+    assert parse_fine_tuned_lora_name(f"{base}.lora_B.weight", mapper) == (
+        f"{prefix}.layers.9.moe.experts",
+        False,
+    )
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        # ModelOpt `quantized_layers` entries name the parent module exactly.
+        ("model.language_model.layers.9.experts", "model.layers.9.moe.experts"),
+        # Already-normalized names are not rewritten twice.
+        ("model.layers.9.moe.experts", "model.layers.9.moe.experts"),
+        # Non-LoRA children of `experts` keep their names.
+        (
+            "model.language_model.layers.9.experts.gate_up_proj",
+            "model.layers.9.experts.gate_up_proj",
+        ),
+        (
+            "model.language_model.layers.9.experts.down_proj_packed",
+            "model.layers.9.experts.down_proj_packed",
+        ),
+    ],
+)
+def test_gemma4_expert_parent_mapper_non_lora_names(name, expected):
+    """The expert-parent rewrite stays limited to the parent module itself and
+    to stacked expert LoRA tensors."""
+    assert Gemma4ForCausalLM.hf_to_vllm_mapper._map_name(name) == expected

--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -84,9 +84,19 @@ from .utils import (
 
 logger = init_logger(__name__)
 
+# Rewrites the MoE parent module `...layers.N.experts` to the name vLLM
+# registers it under, `...layers.N.moe.experts`. The lookahead keeps the
+# original end-anchored behaviour (ModelOpt `quantized_layers` entries name the
+# parent module exactly) and additionally covers PEFT `target_parameters` LoRA
+# tensors, whose names continue past the module
+# (`...experts[.base_layer].lora_{A,B}.weight`). Names of the form
+# `...experts.<child>` (`gate_up_proj`, `w13_weight`, `0.down_proj`, ...) are
+# left untouched, as before.
 _GEMMA4_EXPERT_PARENT_MAPPER = WeightsMapper(
     orig_to_new_regex={
-        re.compile(r"(?<!\.moe)\.experts$"): ".moe.experts",
+        re.compile(
+            r"(?<!\.moe)\.experts(?=$|\.(?:base_layer\.)?lora_)"
+        ): ".moe.experts",
     }
 )
 


### PR DESCRIPTION
## Purpose

Stacked ("3D") expert LoRA adapters for Gemma-4 MoE load without error and then
apply **no expert deltas at all** — silently. The adapter's attention/MLP deltas
still apply, so an all-experts fine-tune reads as "the adapter does nothing".

`_GEMMA4_EXPERT_PARENT_MAPPER` rewrites the MoE parent module
`...layers.N.experts` to the name vLLM registers it under,
`...layers.N.moe.experts`. It was added in #48563 for ModelOpt
`quantized_layers` entries, which name the parent module exactly, so the
pattern is end-anchored:

```python
re.compile(r"(?<!\.moe)\.experts$"): ".moe.experts"
```

That mapper is also the model's `hf_to_vllm_mapper`, i.e. the one
`parse_fine_tuned_lora_name()` applies to LoRA tensor names — and LoRA names
always continue past the module. A PEFT `target_parameters` adapter
(`["experts.gate_up_proj", "experts.down_proj"]`, what Unsloth exports for
Gemma-4 MoE) stores the expert deltas as two stacked pairs per layer:

| tensor name | holds |
|---|---|
| `...layers.N.experts.base_layer.lora_{A,B}.weight` | `gate_up_proj` |
| `...layers.N.experts.lora_{A,B}.weight` | `down_proj` |

Neither matches `\.experts$`, so `parse_fine_tuned_lora_name()` returns module
names **without** the `.moe.` segment:

```
base_model.model.model.language_model.layers.9.experts.base_layer.lora_A.weight
  before -> ('language_model.model.layers.9.experts.base_layer', True)
  after  -> ('language_model.model.layers.9.moe.experts.base_layer', True)
```

`_convert_3d_to_2d_moe_lora()` then looks the layer up under the registered,
`.moe.`-qualified module name, gets `None` for both halves and takes its
documented early `return`. The expert tensors are loaded into the `LoRAModel`
and wired nowhere. Nothing is logged.

The fix widens the pattern with a lookahead so it also matches stacked expert
LoRA tensor names:

```python
re.compile(r"(?<!\.moe)\.experts(?=$|\.(?:base_layer\.)?lora_)"): ".moe.experts"
```

Non-LoRA behaviour is unchanged by construction — the only names that newly
match are `...experts[.base_layer].lora_*`, which exist solely in adapters. The
parent module itself still matches, already-normalized `.moe.experts` keys are
still skipped by the lookbehind, and `...experts.<child>` names
(`gate_up_proj`, `w13_weight`, `0.down_proj`, …) are still left alone. There is
a unit test for each of those cases.

### Relation to open issues

This is **not** a fix for #41754 as diagnosed in that thread — the reporters
there landed on the aliasing mechanism of #39815 (open fix: #39816), which
applies to the dense Gemma-4 variants. On current `main` that mechanism did not
reproduce in our runs (attention/MLP deltas measurably applied). What this PR
fixes is a **second, independent silent-drop path with the same user-visible
symptom**, specific to Gemma-4 MoE + stacked expert adapters. Worth flagging
for anyone who arrives at #41754 with a 26B-A4B adapter.

### Deliberately out of scope

Two related gaps were found in the same investigation and are **not** touched
here, to keep the fix reviewable:

1. **No silent-drop guard.** If an adapter contains `.experts.` LoRA keys that
   end up attached to no module, nothing warns. Every hour of the diagnosis
   below would have been one log line.
2. **The declared 3D orientation is trusted unchecked.** PEFT inverted
   `ParamWrapper.swap_in_out_features` in 0.19.1, so adapters exported with
   PEFT ≤ 0.19.0 are transposed relative to what `_convert_3d_to_2d_moe_lora()`
   expects. For Gemma-4 that happens to fail loudly (`size of tensor a (704)
   must match tensor b (1408)`) only because the expert `in`/`out` dims differ;
   a geometry where they coincide would silently compute garbage. A shape check
   (and, where shape can't disambiguate, a warning off `peft_version` from
   `adapter_config.json`) would close it.

Happy to follow up with either if reviewers want them.

### Adapter-side artifacts this fix does not remove

The mapper fix is the engine-side half. Depending on how the adapter was
exported, two adapter-side artifacts can also stand in the way — both are
properties of the older Unsloth/PEFT toolchain, not of vLLM, and a current
export has neither:

- **Vision-tower LoRA tensors.** The older export's `target_modules` regex also
  matched the vision tower, giving 378 vision LoRA tensors alongside the 530
  language ones. For a text-only fine-tune they are identically zero (the tower
  never enters the forward pass and `lora_B` is zero-init), so we stripped them
  offline before serving and did not test whether vLLM's Gemma-4 path accepts
  them as-is; Gemma-4 vision-tower LoRA is being handled separately in #42662.
  A language-only export has none.
- **Stacked-expert orientation** (the PEFT 0.19.1 flip described above): the
  older export needed re-orienting, a 0.19.1+ export serves raw.

Both were verified irrelevant to the bug itself: the second adapter used below
was exported by a current toolchain (PEFT 0.19.1, language-only
`target_modules`), needs **neither** step, and is still silently dropped
without this change. The mapper keys off tensor *names*, which are identical
across PEFT versions — which is also why re-mapping keys on the adapter side,
as tried in the linked issues, cannot fix it.

## Test Plan

**Unit** — four new cases in `tests/lora/test_lora_checkpoints.py`, CPU-only,
no model download:

```bash
pytest tests/lora/test_lora_checkpoints.py -k gemma4
```

- `test_gemma4_stacked_expert_lora_weights_mapping` (parametrized over
  `Gemma4ForCausalLM` and `Gemma4ForConditionalGeneration`) pins the four
  stacked expert tensor names to the module names
  `_convert_3d_to_2d_moe_lora()` looks up.
- `test_gemma4_expert_parent_mapper_non_lora_names` pins the non-LoRA
  behaviour of the mapper (parent module, already-normalized name, two
  `experts.<child>` names).

**End-to-end** — `google/gemma-4-26B-A4B-it` on RTX PRO 6000 Blackwell 96 GB.
Root-caused on one machine with an editable source build, then reproduced from
scratch on a second machine using the official nightly image, so the finding
does not depend on a local build:

| # | build | how | result |
|---|---|---|---|
| 1 | `0.23.1rc1.dev301+g04c2a8dea` | official nightly image, older | engine-init crash, `get_expert_mapping must be implemented` — predates the generic `RoutedExperts` discovery, unrelated to this fix |
| 2 | `0.23.1rc1.dev1407+gf83de6d44` | editable source build, machine A | adapter loads; expert deltas provably absent. Mechanism isolated here |
| 3 | `0.23.1rc1.dev1403+g4080263bb` | official nightly image `4080263b`, machine B, stock | same silent drop, independently reproduced |
| 4 | build 3 + this one-line change | `FROM`-nightly image, Python-only patch | expert deltas apply |

Rows 3 and 4 differ **only** by this change — same image, same adapter, same
flags, same prompts.

**Relevance to current `main`:** the three files this depends on —
`vllm/model_executor/models/gemma4.py`, `vllm/lora/model_manager.py`,
`vllm/lora/utils.py` — are byte-identical between the nightly used above
(`4080263b`) and `main` at the time of writing (`72297d859`):

```bash
git diff 4080263b..72297d859 -- vllm/model_executor/models/gemma4.py \
    vllm/lora/model_manager.py vllm/lora/utils.py    # empty
```

The unit tests were run against both.

Serve command (rows 3 and 4):

```bash
vllm serve google/gemma-4-26B-A4B-it \
  --enable-lora --enable-mixed-moe-lora-format --max-lora-rank 16 \
  --lora-modules '{"name":"a","path":"<adapter>","base_model_name":"google/gemma-4-26B-A4B-it","is_3d_lora_weight":true}'
# env on Blackwell: VLLM_USE_FLASHINFER_SAMPLER=0 VLLM_ATTENTION_BACKEND=TRITON_ATTN
```

Two independently trained r16 QLoRA all-experts adapters for that base were
used, one exported with PEFT 0.18.1 and one with PEFT 0.19.1 (the latter needs
no repackaging; see the orientation note above).

The discriminating instrument is an **experts-only** adapter: every tensor
except the 120 stacked expert tensors stripped out, so any output change is
attributable to the expert path alone. Compared against the base model with
greedy decoding (temperature 0, 10 fixed prompts), token-identical output means
the expert deltas did not reach the model. Rank-level checks
(`--enable-mixed-moe-lora-format` on/off, `is_3d_lora_weight` on/off,
deliberately mis-oriented adapter) were run as controls.

## Test Result

**Unit tests** — the two stacked-mapping cases fail without the change and pass
with it; the non-LoRA cases pass either way:

```
# nightly 4080263b, unpatched
FAILED test_gemma4_stacked_expert_lora_weights_mapping[Gemma4ForCausalLM-model]
FAILED test_gemma4_stacked_expert_lora_weights_mapping[Gemma4ForConditionalGeneration-language_model.model]
2 failed, 6 passed
E  At index 0 diff: 'language_model.model.layers.9.experts.base_layer'
                != 'language_model.model.layers.9.moe.experts.base_layer'

# same image + this change
8 passed
```

**Experts-only adapter vs. base, greedy, 10 prompts** — number of prompts whose
output differs from base:

| adapter export | before | after |
|---|---|---|
| PEFT 0.18.1 (re-oriented) | **0 / 10** | 3 / 10 |
| PEFT 0.19.1 (as exported) | **0 / 10** | 2 / 10 |

`0 / 10` is not "small effect", it is a provable no-op: in the root-cause run
the experts-only adapter's per-token logprobs were **bit-identical to base to
16 significant digits**. The change is exactly what moves it off zero. (The
post-fix counts are low because these are mild fine-tunes on short generic
prompts; the signal is zero versus non-zero.)

**Correctness of the applied deltas** — teacher-forced NLL against the
offline-merged checkpoint's own outputs, scored under each engine
(`/v1/completions`, `echo` + `logprobs`, chat template rendered client-side,
token IDs submitted directly). With the fix, the full adapter's NLL gap to the
merged checkpoint shrinks **2–20×** relative to base's gap on 7 of 8
informative prompts (e.g. 0.0029 vs 0.0574 nats/token) — the unmerged adapter
now behaves like the merged weights, not like base.

**End-to-end equivalence** — on a 247-item internal document-extraction
benchmark, the adapter served unmerged on the patched engine scored **79.6 %**
versus **79.2 %** for the same fine-tune merged offline and served as full
weights (same metric, same prompts; that benchmark's run-to-run noise is
≈ ±1.5 pp). Unmerged and merged are functionally the same model.

**No regression on non-LoRA paths.** The mapper's non-LoRA output is unchanged
(unit-tested above, and by construction: the only new matches contain `lora_`).
Empirically, the base model and an offline-merged fine-tune were both served on
the patched image and scored inside the same benchmark's noise band as on the
unpatched one.

**Also verified on the patched build:** several adapters co-served against one
base (`--max-loras 2`, per-request routing) all register and produce distinct
output, and a latency sweep at concurrency 8/16/32 shows no measurable penalty
for mixed base+adapter traffic versus adapter-only traffic (34.4 vs 33.9 req/s
at c32).

**On the `get_expert_mapping` crash** (row 1 of the build table): it does not
reproduce on any build from row 2 onward — generic `RoutedExperts` discovery
removed the raise site. Noting it only so the open PRs proposing to re-add that
hook are not confused with this one; that blocker is gone, this one is not.

## AI assistance

Investigated and drafted with Claude Code, in a
hypothesis-then-measure loop over the runs above. All changed lines were
reviewed by me, and every claim in this description is backed by a run I
executed and kept the artifacts for. Commit carries
`Co-authored-by: Claude`.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

</details>
