### PR TITLE
[Bugfix] complete VLLMValidationError migration in chat_utils.py

### DIFF
--- a/tests/entrypoints/launchers/test_cli_args.py
+++ b/tests/entrypoints/launchers/test_cli_args.py
@@ -11,6 +11,7 @@ from vllm.entrypoints.launchers.cli_args import (
     validate_parsed_serve_args,
 )
 from vllm.entrypoints.openai.models.protocol import LoRAModulePath
+from vllm.exceptions import VLLMValidationError
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 
 LORA_MODULE = {
@@ -204,7 +205,7 @@ def test_chat_template_validation_for_happy_paths(serve_parser):
 def test_chat_template_validation_for_sad_paths(serve_parser):
     """Ensure validation fails if the chat template doesn't exist"""
     args = serve_parser.parse_args(args=["--chat-template", "does/not/exist"])
-    with pytest.raises(ValueError):
+    with pytest.raises(VLLMValidationError):
         validate_parsed_serve_args(args)
 
 

--- a/tests/renderers/test_hf.py
+++ b/tests/renderers/test_hf.py
@@ -6,6 +6,7 @@ import pytest
 from vllm.config import ModelConfig
 from vllm.entrypoints.chat_utils import load_chat_template
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.exceptions import VLLMValidationError
 from vllm.renderers.hf import (
     _consolidate_system_messages,
     _convert_developer_to_system,
@@ -97,7 +98,7 @@ def test_no_load_chat_template_filelike():
     # Testing chatml template
     template = "../../examples/does_not_exist"
 
-    with pytest.raises(ValueError, match="looks like a file path"):
+    with pytest.raises(VLLMValidationError, match="looks like a file path"):
         load_chat_template(chat_template=template)
 
 

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1446,10 +1446,11 @@ def validate_chat_template(chat_template: Path | str | None):
 
             builtin_template_path = CHAT_TEMPLATES_DIR / chat_template
             if not builtin_template_path.exists():
-                raise ValueError(
+                raise VLLMValidationError(
                     f"The supplied chat template string ({chat_template}) "
                     f"appears path-like, but doesn't exist! "
-                    f"Tried: {chat_template} and {builtin_template_path}"
+                    f"Tried: {chat_template} and {builtin_template_path}",
+                    parameter="chat_template",
                 )
 
     else:
@@ -1497,7 +1498,7 @@ def _load_chat_template(
                     f"Tried: {chat_template} and {builtin_template_path}. "
                     f"Reason: {e}"
                 )
-                raise ValueError(msg) from e
+                raise VLLMValidationError(msg, parameter="chat_template") from e
 
         # If opening a file fails, set chat template to be args to
         # ensure we decode so our escape are interpreted correctly
@@ -1575,7 +1576,8 @@ def _get_full_multimodal_text_prompt(
             logger.debug("Input prompt: %s", text_prompt)
             raise VLLMValidationError(
                 f"Found more '{placeholder}' placeholders in input prompt than "
-                "actual multimodal data items."
+                "actual multimodal data items.",
+                parameter="messages",
             )
 
         missing_placeholders.extend([placeholder] * placeholder_counts[placeholder])
@@ -1833,7 +1835,8 @@ def _reject_reserved_placeholder_in_text(text: str, model_config: ModelConfig) -
         raise VLLMValidationError(
             _RESERVED_PLACEHOLDER_IN_TEXT_ERROR.format(
                 token=PROMPT_EMBEDS_PLACEHOLDER_TOKEN
-            )
+            ),
+            parameter="messages",
         )
 
 

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -467,7 +467,7 @@ def _merge_embeds(
 
     first_keys = set(data_items[0].keys())
     if any(set(item.keys()) != first_keys for item in data_items[1:]):
-        raise ValueError(
+        raise VLLMValidationError(
             "All dictionaries in the list of embeddings must have the same keys."
         )
 
@@ -746,9 +746,15 @@ def _resolve_items(
         modality requires a processor, enforced by the guard below.
     """
     if "image" in items_by_modality and "image_embeds" in items_by_modality:
-        raise ValueError("Mixing raw image and embedding inputs is not allowed")
+        raise VLLMValidationError(
+            "Mixing raw image and embedding inputs is not allowed",
+            parameter="messages",
+        )
     if "audio" in items_by_modality and "audio_embeds" in items_by_modality:
-        raise ValueError("Mixing raw audio and embedding inputs is not allowed")
+        raise VLLMValidationError(
+            "Mixing raw audio and embedding inputs is not allowed",
+            parameter="messages",
+        )
     # `prompt_embeds` bypasses HF MM processors. Every other modality requires one.
     processor_modalities = items_by_modality.keys() - {"prompt_embeds"}
     if processor_modalities and mm_processor is None:
@@ -1319,10 +1325,11 @@ def validate_chat_template(chat_template: Path | str | None):
 
             builtin_template_path = CHAT_TEMPLATES_DIR / chat_template
             if not builtin_template_path.exists():
-                raise ValueError(
+                raise VLLMValidationError(
                     f"The supplied chat template string ({chat_template}) "
                     f"appears path-like, but doesn't exist! "
-                    f"Tried: {chat_template} and {builtin_template_path}"
+                    f"Tried: {chat_template} and {builtin_template_path}",
+                    parameter="chat_template",
                 )
 
     else:
@@ -1370,7 +1377,7 @@ def _load_chat_template(
                     f"Tried: {chat_template} and {builtin_template_path}. "
                     f"Reason: {e}"
                 )
-                raise ValueError(msg) from e
+                raise VLLMValidationError(msg, parameter="chat_template") from e
 
         # If opening a file fails, set chat template to be args to
         # ensure we decode so our escape are interpreted correctly
@@ -1440,9 +1447,10 @@ def _get_full_multimodal_text_prompt(
                 interleave_strings,
             )
             logger.debug("Input prompt: %s", text_prompt)
-            raise ValueError(
+            raise VLLMValidationError(
                 f"Found more '{placeholder}' placeholders in input prompt than "
-                "actual multimodal data items."
+                "actual multimodal data items.",
+                parameter="messages",
             )
 
         missing_placeholders.extend([placeholder] * placeholder_counts[placeholder])
@@ -1688,10 +1696,11 @@ def _reject_reserved_placeholder_in_text(text: str, model_config: ModelConfig) -
     caller move or inject splice positions via plain text content.
     """
     if model_config.enable_prompt_embeds and PROMPT_EMBEDS_PLACEHOLDER_TOKEN in text:
-        raise ValueError(
+        raise VLLMValidationError(
             _RESERVED_PLACEHOLDER_IN_TEXT_ERROR.format(
                 token=PROMPT_EMBEDS_PLACEHOLDER_TOKEN
-            )
+            ),
+            parameter="messages",
         )
 
 


### PR DESCRIPTION
Fixes https://github.com/vllm-project/vllm/issues/50253

  ## Summary

  PR #49665 migrated the serving layer from raw `ValueError` to `VLLMValidationError`
  but left seven user-facing validation errors in `chat_utils.py` unmigrated.
  These errors reach clients as `{"param": null}` instead of the structured
  `{"param": "chat_template"}` / `{"param": "messages"}` that `VLLMValidationError` provides.

  The TODO in `vllm/entrypoints/serve/utils/error_response.py` explicitly requests this migration:
  ```python
  # TODO(zqzten): remove these fallback handlers after migration to VLLMError
  elif isinstance(exc, (ValueError, TypeError, OverflowError)):
      param = None  # raw ValueError loses param field

  Changes in vllm/entrypoints/chat_utils.py (1 file, 7 raise sites):
  - L470: embedding dict key mismatch → VLLMValidationError
  - L749/751: mixing raw image/audio with embedding inputs → VLLMValidationError(parameter="messages")
  - L1322/1373: invalid chat_template path → VLLMValidationError(parameter="chat_template")
  - L1443: excess multimodal placeholder tokens → VLLMValidationError(parameter="messages")
  - L1691: reserved prompt_embeds placeholder in text → VLLMValidationError(parameter="messages")

  Why not a duplicate

  - PR #49665 intentionally targeted only the serving request validation layer
  - No open PR addresses chat_utils.py ValueError migration (checked via gh pr list --search)
  - This PR completes the migration path the TODO comment already tracks

  Test plan

  # Lint check
  pre-commit run ruff-check --files vllm/entrypoints/chat_utils.py

  # Unit tests covering these code paths
  .venv/bin/python -m pytest tests/entrypoints/openai/test_chat_utils.py -v

  # Verify VLLMValidationError flows through to HTTP 400 + param field
  .venv/bin/python -m pytest tests/entrypoints/openai/ -k "chat" -v

  AI assistance disclosure

  AI assistance (Claude) was used to identify the migration gap and draft the changes.
  All changed lines were reviewed and verified by the submitter.