### PR TITLE
[Frontend] Migrate Responses API validation errors to VLLMValidationError

### DIFF
--- a/tests/entrypoints/openai/parser/test_harmony_utils.py
+++ b/tests/entrypoints/openai/parser/test_harmony_utils.py
@@ -978,8 +978,9 @@ class TestGetSystemMessage:
         with pytest.raises(
             VLLMValidationError,
             match="reasoning_effort='max' is not supported by Harmony",
-        ):
+        ) as exc_info:
             get_system_message(reasoning_effort="max")
+        assert exc_info.value.parameter == "reasoning_effort"
 
 
 class TestResponseInputToHarmonyReasoningItem:

--- a/tests/entrypoints/openai/parser/test_harmony_utils.py
+++ b/tests/entrypoints/openai/parser/test_harmony_utils.py
@@ -20,6 +20,7 @@ from vllm.entrypoints.openai.responses.harmony import (
     response_input_to_harmony,
     response_previous_input_to_harmony,
 )
+from vllm.exceptions import VLLMValidationError
 
 _TOOL_PARAMETERS = {
     "type": "object",
@@ -975,7 +976,7 @@ class TestGetSystemMessage:
 
     def test_unsupported_reasoning_effort_raises_clear_error(self) -> None:
         with pytest.raises(
-            ValueError,
+            VLLMValidationError,
             match="reasoning_effort='max' is not supported by Harmony",
         ):
             get_system_message(reasoning_effort="max")

--- a/tests/entrypoints/openai/responses/test_responses_utils.py
+++ b/tests/entrypoints/openai/responses/test_responses_utils.py
@@ -22,6 +22,7 @@ from vllm.entrypoints.openai.responses.utils import (
     construct_input_messages,
     should_continue_final_message,
 )
+from vllm.exceptions import VLLMValidationError
 
 
 def _single_chat_message(item):
@@ -223,7 +224,7 @@ class TestResponsesUtils:
             encrypted_content="TOP_SECRET_MESSAGE",
             status=None,
         )
-        with pytest.raises(ValueError):
+        with pytest.raises(VLLMValidationError):
             construct_chat_messages_with_tool_call([item])
 
         output_item = ResponseOutputMessage(
@@ -350,7 +351,7 @@ class TestReasoningItemContentPriority:
         assert formatted["reasoning"] == ""
 
     def test_encrypted_content_raises(self):
-        """Encrypted content should still raise ValueError."""
+        """Encrypted content should raise VLLMValidationError."""
         item = ResponseReasoningItem(
             id="reasoning_6",
             summary=[
@@ -369,7 +370,7 @@ class TestReasoningItemContentPriority:
             encrypted_content="ENCRYPTED",
             status=None,
         )
-        with pytest.raises(ValueError):
+        with pytest.raises(VLLMValidationError):
             construct_chat_messages_with_tool_call([item])
 
     @patch("vllm.entrypoints.openai.responses.utils.logger")

--- a/tests/entrypoints/openai/responses/test_responses_utils.py
+++ b/tests/entrypoints/openai/responses/test_responses_utils.py
@@ -224,8 +224,9 @@ class TestResponsesUtils:
             encrypted_content="TOP_SECRET_MESSAGE",
             status=None,
         )
-        with pytest.raises(VLLMValidationError):
+        with pytest.raises(VLLMValidationError) as exc_info:
             construct_chat_messages_with_tool_call([item])
+        assert exc_info.value.parameter == "input"
 
         output_item = ResponseOutputMessage(
             id="msg_bf585bbbe3d500e0",
@@ -370,8 +371,9 @@ class TestReasoningItemContentPriority:
             encrypted_content="ENCRYPTED",
             status=None,
         )
-        with pytest.raises(VLLMValidationError):
+        with pytest.raises(VLLMValidationError) as exc_info:
             construct_chat_messages_with_tool_call([item])
+        assert exc_info.value.parameter == "input"
 
     @patch("vllm.entrypoints.openai.responses.utils.logger")
     def test_summary_with_multiple_entries_uses_first(self, mock_logger):

--- a/vllm/entrypoints/openai/parser/harmony_utils.py
+++ b/vllm/entrypoints/openai/parser/harmony_utils.py
@@ -24,6 +24,7 @@ from openai_harmony import (
 
 from vllm import envs
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionToolsParam
+from vllm.exceptions import VLLMValidationError
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
@@ -123,9 +124,10 @@ def get_system_message(
     if reasoning_effort is not None:
         if reasoning_effort not in REASONING_EFFORT:
             supported_values = ", ".join(REASONING_EFFORT)
-            raise ValueError(
+            raise VLLMValidationError(
                 f"reasoning_effort={reasoning_effort!r} is not supported by "
-                f"Harmony. Supported values are: {supported_values}."
+                f"Harmony. Supported values are: {supported_values}.",
+                parameter="reasoning_effort",
             )
         sys_msg_content = sys_msg_content.with_reasoning_effort(
             REASONING_EFFORT[reasoning_effort]
@@ -181,7 +183,10 @@ def get_developer_message(
             elif tool.type == "function":
                 function_tools.append(tool)
             else:
-                raise ValueError(f"tool type {tool.type} not supported")
+                raise VLLMValidationError(
+                    f"tool type {tool.type!r} is not supported.",
+                    parameter="tools",
+                )
         if function_tools:
             function_tool_descriptions = [
                 create_tool_definition(tool) for tool in function_tools
@@ -297,7 +302,10 @@ def extract_instructions_from_messages(
         elif hasattr(first_message, "model_dump"):
             first_message = first_message.model_dump(exclude_none=True)
         else:
-            raise ValueError(f"Unknown message type: {type(first_message)}")
+            raise VLLMValidationError(
+                f"Unknown message type: {type(first_message)}",
+                parameter="input",
+            )
 
     if first_message.get("role") not in (
         "system",

--- a/vllm/entrypoints/openai/responses/utils.py
+++ b/vllm/entrypoints/openai/responses/utils.py
@@ -31,6 +31,7 @@ from openai.types.responses.tool import Tool
 
 from vllm import envs
 from vllm.entrypoints.chat_utils import make_tool_call_id
+from vllm.exceptions import VLLMValidationError
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionMessageParam
 from vllm.entrypoints.openai.engine.protocol import FunctionCall
 from vllm.entrypoints.openai.responses.protocol import ResponseInputOutputItem
@@ -270,7 +271,10 @@ def _construct_message_from_response_item(
     elif isinstance(item, ResponseReasoningItem):
         reasoning = ""
         if item.encrypted_content:
-            raise ValueError("Encrypted content is not supported.")
+            raise VLLMValidationError(
+                "Encrypted content is not supported.",
+                parameter="input",
+            )
         elif item.content and len(item.content) >= 1:
             reasoning = item.content[0].text
         elif len(item.summary) >= 1:

--- a/vllm/entrypoints/openai/responses/utils.py
+++ b/vllm/entrypoints/openai/responses/utils.py
@@ -37,6 +37,7 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionToolsParam,
 )
 from vllm.entrypoints.openai.responses.protocol import ResponseInputOutputItem
+from vllm.exceptions import VLLMValidationError
 from vllm.logger import init_logger
 from vllm.tool_parsers.utils import (
     build_responses_tool_call_name_map,
@@ -273,7 +274,10 @@ def _construct_message_from_response_item(
     elif isinstance(item, ResponseReasoningItem):
         reasoning = ""
         if item.encrypted_content:
-            raise ValueError("Encrypted content is not supported.")
+            raise VLLMValidationError(
+                "Encrypted content is not supported.",
+                parameter="input",
+            )
         elif item.content and len(item.content) >= 1:
             reasoning = item.content[0].text
         elif len(item.summary) >= 1:


### PR DESCRIPTION
Fixes https://github.com/vllm-project/vllm/issues/50256

Summary

  Follow-up to #49665 ([Frontend][Core] Standardize request error handling with VLLMError hierarchy). Four user-facing validation errors in the /v1/responses
  serving path still raise raw ValueError, causing them to be caught by the
  fallback handler in api_server.py with param=None.

  The TODO comment in api_server.py explicitly asks for this:
  # TODO(zqzten): remove these fallback handlers after migration to VLLMError

  Changes (2 files, 4 raise sites):
  - responses/utils.py: encrypted reasoning content → VLLMValidationError(parameter="input")
  - harmony_utils.py: reasoning_effort bad value → VLLMValidationError(parameter="reasoning_effort")
  - harmony_utils.py: unsupported tool type → VLLMValidationError(parameter="tools")
  - harmony_utils.py: unknown first message type → VLLMValidationError(parameter="input")

  Why not a duplicate

  - PR #49665 migrated the main serving request handlers, leaving harmony_utils.py
  and responses/utils.py untouched
  - No open PR covers these files (checked via gh pr list --search)
  - This is the direct continuation requested by the TODO comment

  Test plan

  pre-commit run ruff-check --files \
    vllm/entrypoints/openai/parser/harmony_utils.py \
    vllm/entrypoints/openai/responses/utils.py

  .venv/bin/python -m pytest tests/entrypoints/openai/ -k "responses" -v