### PR TITLE
Fix UVA fallback for environments without pinned memory support (e.g. WSL2)

### DIFF
--- a/vllm/v1/worker/gpu/buffer_utils.py
+++ b/vllm/v1/worker/gpu/buffer_utils.py
@@ -43,11 +43,19 @@ def async_copy_to_gpu(
 
 class UvaBuffer:
     def __init__(self, size: int | Sequence[int], dtype: torch.dtype):
-        if not is_uva_available():
-            raise RuntimeError("UVA is not available")
-        self.cpu = torch.zeros(size, dtype=dtype, device="cpu", pin_memory=True)
-        self.np = self.cpu.numpy()
-        self.uva = get_accelerator_view_from_cpu_tensor(self.cpu)
+        self._zero_copy = is_uva_available()
+        if self._zero_copy:
+            self.cpu = torch.zeros(size, dtype=dtype, device="cpu", pin_memory=True)
+            self.np = self.cpu.numpy()
+            self.uva = get_accelerator_view_from_cpu_tensor(self.cpu)
+        else:
+            self.cpu = torch.zeros(size, dtype=dtype, device="cpu", pin_memory=False)
+            self.np = self.cpu.numpy()
+            self.uva = torch.zeros(size, dtype=dtype, device="cuda")
+
+    def sync(self) -> None:
+        if not self._zero_copy:
+            self.uva.copy_(self.cpu, non_blocking=True)
 
 
 class UvaBufferPool:
@@ -76,6 +84,7 @@ class UvaBufferPool:
         dst = buf.cpu if isinstance(x, torch.Tensor) else buf.np
         n = len(x)
         dst[:n] = x
+        buf.sync()
         return buf.uva[:n]
 
     def copy_to_gpu(


### PR DESCRIPTION
Fixes #50239

`UvaBuffer.__init__` previously raised `RuntimeError("UVA is not available")`
whenever pinned/UVA memory wasn't available — which is always the case on
WSL2, since `is_pin_memory_available()` returns `False` there. This made the
V2 model runner completely unusable on WSL2, even for basic single-GPU
inference with no CPU offloading.

This PR adds a fallback: when UVA isn't available, `UvaBuffer` allocates a
real GPU tensor instead of a zero-copy UVA view, and a new `sync()` method
explicitly copies data from the CPU staging buffer to the GPU tensor.
`UvaBufferPool.copy_to_uva()` calls `sync()` after writing to the CPU buffer,
so behavior is transparent to all callers — no other code needed to change.

### Testing
Verified end-to-end on WSL2 Ubuntu with an RTX 5050 Laptop GPU (sm_120,
Blackwell). Before this fix, model loading crashed immediately with
`RuntimeError: UVA is not available`. After this fix, the V2 model runner
loads the model, captures CUDA graphs, and runs inference successfully —
no workaround flags required. Confirmed working across a fresh WSL session
as well.

### Performance note
On WSL2 (where this fallback is used), buffer writes now go through an
explicit GPU copy instead of a zero-copy view, so there's a small overhead
compared to native Linux with working UVA. This only affects WSL2/UVA-
unavailable environments — behavior and performance on systems with UVA
support are unchanged.