### PR TITLE
[ROCm][CI] Fix Kimi K3 KDA on ROCm

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -1576,10 +1576,14 @@ steps:
   - vllm/third_party/flash_linear_attention/ops/kda.py
   - vllm/third_party/flash_linear_attention/ops/chunk_delta_h.py
   - vllm/third_party/flash_linear_attention/ops/l2norm.py
-  - tests/kernels/test_kda.py
+  - vllm/models/kimi_k3/nvidia/kda.py
+  - vllm/models/kimi_k3/nvidia/kda_metadata.py
+  - vllm/models/kimi_k3/nvidia/ops/third_party/kda/
+  - tests/models/kimi_k3/test_kda.py
+  - tests/models/kimi_k3/test_kda_metadata.py
   - vllm/platforms/rocm.py
   commands:
-  - pytest -v -s kernels/test_kda.py
+  - pytest -v -s models/kimi_k3/test_kda.py models/kimi_k3/test_kda_metadata.py
 
 - label: Kernels Mamba Test # TBD
   timeout_in_minutes: 180

--- a/vllm/models/kimi_k3/nvidia/kda.py
+++ b/vllm/models/kimi_k3/nvidia/kda.py
@@ -164,6 +164,8 @@ def is_flashkda_supported(
     dtype: torch.dtype,
     lower_bound: float | None,
 ) -> bool:
+    if not current_platform.is_cuda():
+        return False
     capability = current_platform.get_device_capability()
     return (
         capability is not None


### PR DESCRIPTION
## Purpose

The AMD "Kernels KDA Test" job (`mi300_1`) was red. Investigation uncovered two
separate problems, fixed here in two commits:

1. **Stale CI path** the job pointed at a test file that was moved by another PR,
   so it failed before running anything.
2. **ROCm false-positive kernel selection** once the job was repointed and
   actually ran, it surfaced a genuine ROCm bug: FlashKDA (a CUDA-only extension)
   was being selected on ROCm, crashing at import.

---

## Problem 1 CI job pointed at a deleted path

### What broke it
- **Cause PR:** [#50089](https://github.com/vllm-project/vllm/pull/50089) — "[Model] Add Kimi K3 support: model files and kernels [1/N]"
  (commit `7c6729b76`, merged 2026-07-29).
- That PR **deleted** `tests/kernels/test_kda.py` and **re-added** the KDA tests
  under `tests/models/kimi_k3/` (`test_kda.py`, `test_kda_metadata.py`).
- The AMD "Kernels KDA Test" job still ran `pytest -v -s kernels/test_kda.py`.
  The path no longer exists, so pytest exits with **code 4 (file/dir not found)**
  → the job is red and tests nothing.

### Fix (commit 1)
Repoint the command to the new location and refresh `source_file_dependencies`
to the kimi_k3 KDA sources so the job retriggers on the relevant changes:


## Problem 2 FlashKDA selected on ROCm (discovered after the repoint)

After repointing, the job ran but produced **1 failure**:
`test_flashkda_correctness → ModuleNotFoundError: No module named 'vllm._flashkda_C'`.

### Root cause
`is_flashkda_supported()` gated only on the CUDA compute-capability major:

```python
capability.major in (9, 10, 12)   # SM90 / SM10x / SM12x
```

On ROCm, gfx942 reports `DeviceCapability(major=9, minor=4)`, so `major == 9`
matched the SM90 check and the function returned **True** on ROCm, even though
FlashKDA (`vllm._flashkda_C`, added in #50089) is a **CUDA-only** extension.

### Fix (commit 2)
Add an explicit `is_cuda()` guard so FlashKDA is only chosen on CUDA; ROCm falls
back to the Triton KDA prefill path:

`is_fused_kda_decode_supported()` is unaffected it already guards on
`hasattr(torch.ops._C, "fused_kda_decode")`, which is False on ROCm (verified).

---

## Test Plan

```bash
# gfx942 (MI300), single GPU
 python -m pytest -q \
  models/kimi_k3/test_kda.py models/kimi_k3/test_kda_metadata.py
```

## Test Result (gfx942 / MI300)

| Stage | Result |
|---|---|
| Old CI command `pytest kernels/test_kda.py` | exit code 4 file not found (red, nothing run) |
| After repoint, before source fix | **45 passed, 5 skipped, 1 failed** (`test_flashkda_correctness`) |
| After source fix | **45 passed, 6 skipped, 0 failed** `test_flashkda_correctness` skips cleanly |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

