### PR TITLE
[Bugfix] Strip Gemma4 trailing sentinels regardless of order

### DIFF
--- a/tests/reasoning/test_gemma4_utils.py
+++ b/tests/reasoning/test_gemma4_utils.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.reasoning.gemma4_utils import parse_thinking_output
+
+TURN_END = "<turn|>"
+EOS = "<eos>"
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        "",
+        TURN_END,
+        EOS,
+        TURN_END + EOS,
+        EOS + TURN_END,
+        f" {TURN_END} {EOS}",
+        f" {EOS} {TURN_END}",
+        TURN_END + TURN_END,
+    ],
+    ids=[
+        "none",
+        "turn_only",
+        "eos_only",
+        "turn_then_eos",
+        "eos_then_turn",
+        "spaced_turn_then_eos",
+        "spaced_eos_then_turn",
+        "repeated_turn",
+    ],
+)
+def test_answer_is_cleaned_regardless_of_sentinel_order(suffix: str):
+    """Trailing sentinels must be stripped in any arrangement.
+
+    Stripping each sentinel once in a fixed order only cleans one
+    arrangement: checking ``<turn|>`` before ``<eos>`` leaves the turn
+    marker in the answer for ``...<turn|><eos>``, because at that point the
+    text ends with ``<eos>`` and the turn check has already been skipped.
+    """
+    result = parse_thinking_output(f"final answer{suffix}")
+
+    assert result["answer"] == "final answer"
+    assert TURN_END not in result["answer"]
+    assert EOS not in result["answer"]
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [TURN_END + EOS, EOS + TURN_END, TURN_END, EOS],
+)
+def test_thinking_block_answer_is_cleaned(suffix: str):
+    """The same cleaning applies to the answer that follows a thinking block."""
+    text = f"<|channel>thought\nsome reasoning<channel|>final answer{suffix}"
+    result = parse_thinking_output(text)
+
+    assert result["thinking"] == "some reasoning"
+    assert result["answer"] == "final answer"
+
+
+def test_answer_body_containing_sentinel_text_is_preserved():
+    """Only trailing sentinels are stripped, not ones inside the answer."""
+    result = parse_thinking_output(f"the marker is {TURN_END} in prose{TURN_END}")
+
+    assert result["answer"] == f"the marker is {TURN_END} in prose"

--- a/vllm/reasoning/gemma4_utils.py
+++ b/vllm/reasoning/gemma4_utils.py
@@ -40,6 +40,10 @@ _THINKING_END_TAG = "<channel|>"
 
 # Sentinel tokens that may appear in decoded output.
 _TURN_END_TAG = "<turn|>"
+_EOS_TAG = "<eos>"
+
+# Sentinels that may trail the answer, in any order and possibly repeated.
+_TRAILING_SENTINELS = (_TURN_END_TAG, _EOS_TAG)
 
 
 def parse_thinking_output(text: str) -> dict[str, str | None]:
@@ -119,12 +123,18 @@ def _clean_answer(text: str) -> str:
 
     Strips ``<turn|>``, ``<eos>``, and surrounding whitespace that the
     model appends at the end of its response.
+
+    The sentinels are stripped repeatedly rather than once each, because a
+    single pass in a fixed order only cleans one arrangement: checking
+    ``<turn|>`` before ``<eos>`` leaves the turn marker behind for
+    ``...<turn|><eos>``, since at that point the text ends with ``<eos>``.
     """
     text = text.strip()
-    # Strip trailing <turn|> (Gemma4 turn-end marker)
-    if text.endswith(_TURN_END_TAG):
-        text = text[: -len(_TURN_END_TAG)].rstrip()
-    # Strip trailing <eos> if present
-    if text.endswith("<eos>"):
-        text = text[:-5].rstrip()
+    changed = True
+    while changed:
+        changed = False
+        for tag in _TRAILING_SENTINELS:
+            if text.endswith(tag):
+                text = text[: -len(tag)].rstrip()
+                changed = True
     return text


### PR DESCRIPTION
## Purpose

`_clean_answer` in `vllm/reasoning/gemma4_utils.py` promises to strip the trailing `<turn|>` and `<eos>` sentinels from a Gemma4 answer, but it checks each one exactly once, in a fixed order:

```python
text = text.strip()
if text.endswith(_TURN_END_TAG):
    text = text[: -len(_TURN_END_TAG)].rstrip()
if text.endswith("<eos>"):
    text = text[:-5].rstrip()
```

That only cleans one arrangement. For `...<turn|><eos>` the first check is skipped — the text ends with `<eos>` at that point — and by the time `<eos>` has been removed, the turn check has already passed. The turn marker is then returned as part of `answer`:

```
'final answer<turn|><eos>'   ->  'final answer<turn|>'
'final answer <turn|> <eos>' ->  'final answer <turn|>'
'final answer<turn|><turn|>' ->  'final answer<turn|>'
```

A repeated sentinel leaks the same way.

This strips the sentinels in a loop until none remain, so any order or repetition is handled. `parse_thinking_output` routes both the plain answer and the answer following a thinking block through `_clean_answer`, so both paths are fixed.

## Test Plan

`parse_thinking_output` had no test coverage, so this adds `tests/reasoning/test_gemma4_utils.py`:

- every arrangement of the two sentinels (each alone, both orders, spaced, repeated) yields a clean answer
- the same for an answer following a `<|channel>thought ... <channel|>` block
- a sentinel appearing *inside* the answer body is preserved, so the fix does not over-strip

## Test Result

Against the previous implementation, 4 of the 13 cases fail:

```
FAILED tests/reasoning/test_gemma4_utils.py::test_answer_is_cleaned_regardless_of_sentinel_order[turn_then_eos]
FAILED tests/reasoning/test_gemma4_utils.py::test_answer_is_cleaned_regardless_of_sentinel_order[spaced_turn_then_eos]
FAILED tests/reasoning/test_gemma4_utils.py::test_answer_is_cleaned_regardless_of_sentinel_order[repeated_turn]
FAILED tests/reasoning/test_gemma4_utils.py::test_thinking_block_answer_is_cleaned[<turn|><eos>]
4 failed, 9 passed
```

With the change, all 13 pass. The existing `tests/reasoning/test_gemma4_reasoning_parser.py` suite also passes unchanged (29 passed), so the streaming and non-streaming parser paths are unaffected.

Possibly related: #49955 reports a trailing `<turn|>` appearing at the end of generated text. That issue has no body, so I cannot confirm it is this path and have not claimed it here.

Disclosure: this change was prepared with the assistance of an AI coding agent. The analysis, fix, and tests were verified against the source and executed locally before submitting.