### PR TITLE
[Feature] add the option to continue serving unfinished requests after the recovery

### DIFF
--- a/tests/v1/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/v1/fault_tolerance/test_fault_tolerance_e2e.py
@@ -102,7 +102,9 @@ def _install_fault_injection(monkeypatch, tmp_path, rank: int, step: int) -> Non
     monkeypatch.setenv("VLLM_FT_TEST_INJECT_FAULT", f"rank={rank},step={step}")
 
 
-def _ft_server_args() -> list[str]:
+def _ft_server_args(
+    ft_config: str = '{"engine_recovery_timeout_sec": 120}',
+) -> list[str]:
     return [
         "--enforce-eager",
         "--dtype",
@@ -118,11 +120,11 @@ def _ft_server_args() -> list[str]:
         "--cpu-distributed-timeout-seconds",
         str(CPU_DISTRIBUTED_TIMEOUT_S),
         "--fault-tolerance-config",
-        '{"engine_recovery_timeout_sec": 120}',
+        ft_config,
     ]
 
 
-def _ft_manager():
+def _ft_manager(base_server_args: list[str] | None = None):
     """Build the shared DP+EP fault-tolerant server topology (one engine/server)."""
     from tests.v1.distributed.test_external_lb_dp import ExternalLBServerManager
 
@@ -130,7 +132,7 @@ def _ft_manager():
         MODEL_NAME,
         DP_SIZE,
         api_server_count=1,  # FT requires a single API server per engine
-        base_server_args=_ft_server_args(),
+        base_server_args=base_server_args or _ft_server_args(),
         tp_size=1,
     )
 
@@ -268,10 +270,12 @@ def _wait_for_ft_apply_outcome(server, request_id: str, deadline_s: int) -> str 
 @pytest.mark.skipif(not has_nixl_ep(), reason="Requires nixl_ep all2all backend")
 @multi_gpu_test(num_gpus=2)
 def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
-    """An exception injected into the inference path drives full retry recovery.
+    """An exception injected into the inference path drives full retry recovery,
+    with the in-flight request resumed (not aborted) afterwards.
 
     Injecting an exception into ``sync_cudagraph_and_dp_padding`` at a chosen
-    step on rank 1.
+    step on rank 1, while a long streaming completion runs on rank 0 with
+    ``resume_requests_after_recovery`` enabled.
 
     - Rank 1 raises inside the busy loop and goes UNHEALTHY.
     - Rank 0 detects the now-absent peer via the communication timeout and also
@@ -281,9 +285,13 @@ def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
     into the DP-sync fn from the test (via a generated ``sitecustomize``).
     """
     fault_step = int(os.getenv("FT_FAULT_STEP", "50"))
+    max_tokens = fault_step + 50  # the stream must still be running at the fault
     _install_fault_injection(monkeypatch, tmp_path, rank=1, step=fault_step)
 
-    with _ft_manager() as servers:
+    resume_args = _ft_server_args(
+        '{"engine_recovery_timeout_sec": 120, "resume_requests_after_recovery": true}'
+    )
+    with _ft_manager(resume_args) as servers:
         assert len(servers) == DP_SIZE
         rank0 = _server_for_rank(servers, 0)
         rank1 = _server_for_rank(servers, 1)
@@ -291,9 +299,32 @@ def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
         # 1. Both engines healthy and serving.
         _assert_serving_and_healthy((rank0, rank1))
 
-        # 2. Drive both ranks so rank 1 accumulates execute_model steps and trips
-        #    the injected fault; rank 0 then times out on the DP allreduce.
-        with _driving(rank0, rank1):
+        # 2. Start the long stream on rank 0; rank 1 is driven by background
+        #    traffic so it accumulates steps and trips the injected fault.
+        client = rank0.get_client()
+        stream = client.completions.create(
+            model=MODEL_NAME,
+            prompt="Hello, my name is",
+            max_tokens=max_tokens,
+            temperature=0.0,
+            stream=True,
+            timeout=600.0,
+        )
+        chunks = []
+        stream_error = None
+
+        def _consume():
+            nonlocal stream_error
+            try:
+                for chunk in stream:
+                    chunks.append(chunk)
+            except Exception as e:
+                stream_error = e
+
+        consumer = threading.Thread(target=_consume, daemon=True)
+        consumer.start()
+
+        with _driving(rank1):
             faulted = _wait_for_engines(
                 [rank0, rank1], match_key="status", match_values={"unhealthy"}
             )
@@ -307,12 +338,32 @@ def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
         assert faulted[1] is not None
         assert faulted[1].get("fault_info"), faulted[1]
 
+        # Mid-stream the request must be stalled, not terminated.
+        assert stream_error is None, stream_error
+        assert consumer.is_alive(), "stream ended instead of stalling at fault"
+
         # 3. retry both engines.
         for server in (rank0, rank1):
             _apply_ft(server, "retry")
 
         # 4. Recovery completes: both engines return to healthy and serve again.
         _assert_serving_and_healthy((rank0, rank1))
+
+        # 5. The stalled stream resumes and finishes without loss/duplication.
+        consumer.join(timeout=120)
+        assert not consumer.is_alive(), "stream did not complete after recovery"
+        assert stream_error is None, stream_error
+
+        content = [c for c in chunks if c.choices and c.choices[0].text]
+        assert len(content) == max_tokens, (
+            f"expected {max_tokens} streamed tokens, got {len(content)}"
+        )
+        finish_reasons = [
+            c.choices[0].finish_reason
+            for c in chunks
+            if c.choices and c.choices[0].finish_reason
+        ]
+        assert finish_reasons == ["length"], finish_reasons
 
 
 @pytest.mark.skipif(not has_nixl_ep(), reason="Requires nixl_ep all2all backend")

--- a/vllm/config/fault_tolerance.py
+++ b/vllm/config/fault_tolerance.py
@@ -16,3 +16,9 @@ class FaultToleranceConfig:
     instructions on how to handle the error and then recover from the fault.
     If vLLM does not recover during this time, the original error is raised.
     """
+
+    resume_requests_after_recovery: bool = False
+    """If True, in-flight requests are preempted back to the waiting queue on
+    fault (instead of being aborted) so they are automatically re-scheduled
+    after recovery via ``retry``. Clients will not receive abort notifications.
+    """

--- a/vllm/v1/fault_tolerance/engine_core_sentinel.py
+++ b/vllm/v1/fault_tolerance/engine_core_sentinel.py
@@ -4,6 +4,7 @@
 
 import json
 import threading
+import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
@@ -85,8 +86,21 @@ class EngineCoreSentinel:
         )
 
         engine = self.engine
-        aborted = engine.scheduler.finish_requests(None, RequestStatus.FINISHED_ABORTED)
-        engine._send_abort_outputs(aborted)
+        ft_config = self.parallel_config.fault_tolerance_config
+        if ft_config.resume_requests_after_recovery:
+            timestamp = time.monotonic()
+            while engine.scheduler.running:
+                request = engine.scheduler.running.pop()
+                engine.scheduler._preempt_request(
+                    request, timestamp, drop_stale_output=True
+                )
+            engine.scheduler.prev_step_scheduled_req_ids.clear()
+        else:
+            aborted = engine.scheduler.finish_requests(
+                None, RequestStatus.FINISHED_ABORTED
+            )
+            engine._send_abort_outputs(aborted)
+
         if engine.batch_queue is not None:
             engine.batch_queue.clear()
         if (

--- a/vllm/v1/fault_tolerance/engine_core_sentinel.py
+++ b/vllm/v1/fault_tolerance/engine_core_sentinel.py
@@ -87,6 +87,8 @@ class EngineCoreSentinel:
 
         engine = self.engine
         ft_config = self.parallel_config.fault_tolerance_config
+        self._clear_contaminated_blocks()
+
         if ft_config.resume_requests_after_recovery:
             timestamp = time.monotonic()
             while engine.scheduler.running:
@@ -118,6 +120,33 @@ class EngineCoreSentinel:
             exc_info=exc,
         )
         self._push_status()
+
+    def _clear_contaminated_blocks(self) -> None:
+        """Evict KV blocks possibly contaminated by the failed step."""
+
+        engine = self.engine
+        kv_cache_manager = engine.scheduler.kv_cache_manager
+        dirty_block_ids: set[int] = set()
+
+        for request in engine.scheduler.running:
+            num_written = request.num_in_flight_tokens
+            if num_written <= 0:
+                continue
+            start = max(request.num_computed_tokens - num_written, 0)
+            end = request.num_computed_tokens - 1
+
+            for mgr in kv_cache_manager.coordinator.single_type_managers:
+                blocks = mgr.req_to_blocks.get(request.request_id)
+                if not blocks:
+                    continue
+                blk_start = start // mgr.block_size
+                blk_end = end // mgr.block_size
+                for blk in blocks[blk_start:blk_end + 1]:
+                    if not blk.is_null:
+                        dirty_block_ids.add(blk.block_id)
+
+        if dirty_block_ids:
+            kv_cache_manager.evict_blocks(dirty_block_ids)
 
     def _push_status(self):
         """Push current health to the client so it can refresh its cache."""

--- a/vllm/v1/fault_tolerance/engine_core_sentinel.py
+++ b/vllm/v1/fault_tolerance/engine_core_sentinel.py
@@ -6,7 +6,7 @@ import json
 import threading
 import time
 from collections.abc import Callable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import msgspec
 
@@ -15,6 +15,7 @@ from vllm.distributed import stateless_destroy_torch_distributed_process_group
 from vllm.distributed.utils import stateless_init_torch_distributed_process_group
 from vllm.logger import init_logger
 from vllm.utils.network_utils import get_open_port
+from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.engine import (
     FT_STATUS_CALL_ID,
     EngineCoreOutputs,
@@ -86,21 +87,20 @@ class EngineCoreSentinel:
         )
 
         engine = self.engine
+        scheduler = cast(Scheduler, engine.scheduler)
         ft_config = self.parallel_config.fault_tolerance_config
         self._clear_contaminated_blocks()
 
         if ft_config.resume_requests_after_recovery:
             timestamp = time.monotonic()
-            while engine.scheduler.running:
-                request = engine.scheduler.running.pop()
-                engine.scheduler._preempt_request(
-                    request, timestamp, drop_stale_output=True
-                )
-            engine.scheduler.prev_step_scheduled_req_ids.clear()
+            while scheduler.running:
+                request = scheduler.running.pop()
+                scheduler._preempt_request(request, timestamp)
+                request.num_in_flight_tokens = 0
+                request.num_stale_output_tokens = 0
+            scheduler.prev_step_scheduled_req_ids.clear()
         else:
-            aborted = engine.scheduler.finish_requests(
-                None, RequestStatus.FINISHED_ABORTED
-            )
+            aborted = scheduler.finish_requests(None, RequestStatus.FINISHED_ABORTED)
             engine._send_abort_outputs(aborted)
 
         if engine.batch_queue is not None:
@@ -124,11 +124,11 @@ class EngineCoreSentinel:
     def _clear_contaminated_blocks(self) -> None:
         """Evict KV blocks possibly contaminated by the failed step."""
 
-        engine = self.engine
-        kv_cache_manager = engine.scheduler.kv_cache_manager
+        scheduler = cast(Scheduler, self.engine.scheduler)
+        kv_cache_manager = scheduler.kv_cache_manager
         dirty_block_ids: set[int] = set()
 
-        for request in engine.scheduler.running:
+        for request in scheduler.running:
             num_written = request.num_in_flight_tokens
             if num_written <= 0:
                 continue
@@ -141,7 +141,7 @@ class EngineCoreSentinel:
                     continue
                 blk_start = start // mgr.block_size
                 blk_end = end // mgr.block_size
-                for blk in blocks[blk_start:blk_end + 1]:
+                for blk in blocks[blk_start : blk_end + 1]:
                     if not blk.is_null:
                         dirty_block_ids.add(blk.block_id)
 

--- a/vllm/v1/worker/sentinel/gpu_worker_sentinel.py
+++ b/vllm/v1/worker/sentinel/gpu_worker_sentinel.py
@@ -70,6 +70,8 @@ class WorkerSentinel:
     def _clean_worker_state(self):
         model_runner = self.worker.model_runner
         model_runner.execute_model_state = None
+        ft_config = model_runner.vllm_config.parallel_config.fault_tolerance_config
+        resume = ft_config.resume_requests_after_recovery
         if self.worker.use_v2_model_runner:
             runner = cast("GPUModelRunnerV2", model_runner)
             for req_id in list(runner.req_states.req_id_to_index):
@@ -80,8 +82,9 @@ class WorkerSentinel:
             input_batch = model_runner.input_batch
             cached_req_ids = list(input_batch.req_id_to_index)
             for req_id in cached_req_ids:
-                model_runner.requests.pop(req_id, None)
-                model_runner.num_prompt_logprobs.pop(req_id, None)
+                if not resume:
+                    model_runner.requests.pop(req_id, None)
+                    model_runner.num_prompt_logprobs.pop(req_id, None)
                 input_batch.remove_request(req_id)
 
             input_batch.condense()

--- a/vllm/v1/worker/sentinel/gpu_worker_sentinel.py
+++ b/vllm/v1/worker/sentinel/gpu_worker_sentinel.py
@@ -82,6 +82,9 @@ class WorkerSentinel:
             input_batch = model_runner.input_batch
             cached_req_ids = list(input_batch.req_id_to_index)
             for req_id in cached_req_ids:
+                # Resume keeps CachedRequestState: the MRV1 resumed-request
+                # path (scheduled_cached_reqs.resumed_req_ids) indexes
+                # model_runner.requests[req_id] directly.
                 if not resume:
                     model_runner.requests.pop(req_id, None)
                     model_runner.num_prompt_logprobs.pop(req_id, None)


### PR DESCRIPTION
## Purpose

Add a `resume_requests_after_recovery` option to `FaultToleranceConfig` (`--fault-tolerance-config='{"resume_requests_after_recovery": true}'`, default `False`) that lets in-flight requests continue generating after the engine recovers from a fault, instead of being aborted — with no duplicated or lost tokens visible to the client.

Today, when the busy loop raises under the fault-tolerance framework, `EngineCoreSentinel.on_fault()` aborts every running request (`finish_requests(..., FINISHED_ABORTED)` + `_send_abort_outputs`), and the client receives an abort notification — even though the engine is about to recover via `retry` and could have continued serving them.

With `resume_requests_after_recovery: true`:

**Engine side** (`EngineCoreSentinel.on_fault`):

1. **Contaminated KV eviction** (`_clear_contaminated_blocks`): the faulted step may have partially written KV for in-flight tokens. The blocks covering `[num_computed_tokens - num_in_flight_tokens, num_computed_tokens - 1]` of each running request are evicted from the prefix cache, so the post-recovery re-prefill never reuses KV written by the failed step.
2. **Preempt instead of abort**: all running requests are moved back to the waiting queue via the scheduler's existing `_preempt_request` (frees blocks, resets `num_computed_tokens = 0`). `num_in_flight_tokens` / `num_stale_output_tokens` are then zeroed because the faulted step's output frames will never return — there is nothing left to drain. `prev_step_scheduled_req_ids` is cleared.
3. After `retry` completes and the busy loop restarts, the scheduler re-schedules the preempted requests automatically. The re-prefill covers the prompt plus already-generated tokens and hits the retained prefix cache, so recovery is cheap; decoding then continues and only **new** tokens are streamed. The client observes a stall, not a failure — no abort, no duplicated or lost tokens.

**Worker side** (`WorkerSentinel._clean_worker_state`):

- Model runner V2: unchanged — all per-request state is dropped via `_remove_request`, and resumed requests are rebuilt from scratch by `add_requests` after recovery. No resume-specific handling needed.
- MRV1: the persistent batch is still cleared, but `CachedRequestState` (`model_runner.requests`, `num_prompt_logprobs`) is retained, because the resumed-request path (`scheduled_cached_reqs.resumed_req_ids`) indexes `model_runner.requests[req_id]` directly.

Default is `False` — existing behavior (abort on fault) is unchanged unless explicitly opted in.

## Test Plan

E2E (`tests/v1/fault_tolerance/test_fault_tolerance_e2e.py`, requires 2 GPUs + nixl_ep):

```bash
DP_SIZE=2 .venv/bin/python -m pytest tests/v1/fault_tolerance/test_fault_tolerance_e2e.py -v -s
```

`test_injected_fault_retry_recovers_all_ranks` is extended to cover the resume path: a long streaming completion (`max_tokens = fault_step + 50`) runs on rank 0 with `resume_requests_after_recovery: true`, while a fault is injected into the DP-sync allreduce (`sync_cudagraph_and_dp_padding`) on rank 1 at `fault_step`. The test asserts that:

- at fault time the stream **stalls** — still alive, no exception;
- after `retry` on both engines, the stream **resumes and completes** with exactly `max_tokens` chunks (no loss, no duplication) and `finish_reason == "length"`.

Manual E2E (external LB mode, DP+EP, `--enable-fault-tolerance`, `resume_requests_after_recovery: true`):

1. Launch the server; a client sends a long streaming generation.
2. Inject a fault right after the DP allreduce while the request is in flight — the stream stalls but receives no abort/error.
3. Send `retry` via `POST /fault_tolerance/apply`.
4. After recovery the stalled stream resumes generating and completes normally.

## Test Result

- E2E test file above passes on a 2-GPU nixl_ep setup (`2 passed`).
- Manual E2E: after injecting the post-allreduce fault mid-generation and issuing `retry`, the in-flight streaming request resumed and generated to completion; the client received no abort notification and no duplicate tokens, and both engines returned to `healthy` and kept serving.



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
