### PR TITLE
[CI] KimiLinear PD in nightlies 

### DIFF
--- a/.buildkite/test_areas/disaggregated.yaml
+++ b/.buildkite/test_areas/disaggregated.yaml
@@ -241,3 +241,20 @@ steps:
   commands:
     - bash /vllm-workspace/.buildkite/scripts/install-kv-connectors.sh
     - bash v1/kv_connector/nixl_integration/run_accuracy_test.sh
+
+- label: Kimi-Linear-48B-A3B Disaggregated DP EP
+  key: kimi-linear-disaggregated
+  timeout_in_minutes: 40
+  device: h200
+  optional: true
+  working_dir: "/vllm-workspace/tests"
+  num_devices: 2
+  env:
+    ENABLE_HMA_FLAG: "1"
+    DP_EP: "1"
+    GPU_MEMORY_UTILIZATION: "0.85"
+    MODEL_NAMES: "moonshotai/Kimi-Linear-48B-A3B-Instruct"
+    VLLM_SERVE_EXTRA_ARGS: "--trust-remote-code"
+  commands:
+    - bash /vllm-workspace/.buildkite/scripts/install-kv-connectors.sh
+    - bash v1/kv_connector/nixl_integration/run_accuracy_test.sh

--- a/.buildkite/test_areas/disaggregated.yaml
+++ b/.buildkite/test_areas/disaggregated.yaml
@@ -254,7 +254,7 @@ steps:
     DP_EP: "1"
     GPU_MEMORY_UTILIZATION: "0.85"
     MODEL_NAMES: "moonshotai/Kimi-Linear-48B-A3B-Instruct"
-    VLLM_SERVE_EXTRA_ARGS: "--trust-remote-code"
+    VLLM_SERVE_EXTRA_ARGS: "--trust-remote-code,--mamba-cache-mode align"
   commands:
     - bash /vllm-workspace/.buildkite/scripts/install-kv-connectors.sh
     - bash v1/kv_connector/nixl_integration/run_accuracy_test.sh

--- a/.buildkite/test_areas/disaggregated.yaml
+++ b/.buildkite/test_areas/disaggregated.yaml
@@ -244,7 +244,7 @@ steps:
 
 - label: Kimi-Linear-48B-A3B Disaggregated DP EP
   key: kimi-linear-disaggregated
-  timeout_in_minutes: 40
+  timeout_in_minutes: 60
   device: h200
   optional: true
   working_dir: "/vllm-workspace/tests"
@@ -252,9 +252,9 @@ steps:
   env:
     ENABLE_HMA_FLAG: "1"
     DP_EP: "1"
-    GPU_MEMORY_UTILIZATION: "0.85"
+    GPU_MEMORY_UTILIZATION: "0.9"
     MODEL_NAMES: "moonshotai/Kimi-Linear-48B-A3B-Instruct"
-    VLLM_SERVE_EXTRA_ARGS: "--trust-remote-code,--mamba-cache-mode align"
+    VLLM_SERVE_EXTRA_ARGS: "--trust-remote-code,--mamba-cache-mode align,--max-model-len 8192,--max-num-batched-tokens 4096"
   commands:
     - bash /vllm-workspace/.buildkite/scripts/install-kv-connectors.sh
     - bash v1/kv_connector/nixl_integration/run_accuracy_test.sh

--- a/.buildkite/test_areas/disaggregated.yaml
+++ b/.buildkite/test_areas/disaggregated.yaml
@@ -253,8 +253,7 @@ steps:
     ENABLE_HMA_FLAG: "1"
     DP_EP: "1"
     GPU_MEMORY_UTILIZATION: "0.9"
-    # 48B bf16 weights are ~92GiB, so a single H200 leaves no room for the KV
-    # cache. Shard P over TP2 and D over DP2+EP, and cap the 1M default context.
+    VLLM_SSM_CONV_STATE_LAYOUT: "DS"
     PREFILLER_TP_SIZE: "2"
     DECODER_TP_SIZE: "2"
     MODEL_NAMES: "moonshotai/Kimi-Linear-48B-A3B-Instruct"

--- a/.buildkite/test_areas/disaggregated.yaml
+++ b/.buildkite/test_areas/disaggregated.yaml
@@ -248,13 +248,17 @@ steps:
   device: h200
   optional: true
   working_dir: "/vllm-workspace/tests"
-  num_devices: 2
+  num_devices: 4
   env:
     ENABLE_HMA_FLAG: "1"
     DP_EP: "1"
     GPU_MEMORY_UTILIZATION: "0.9"
+    # 48B bf16 weights are ~92GiB, so a single H200 leaves no room for the KV
+    # cache. Shard P over TP2 and D over DP2+EP, and cap the 1M default context.
+    PREFILLER_TP_SIZE: "2"
+    DECODER_TP_SIZE: "2"
     MODEL_NAMES: "moonshotai/Kimi-Linear-48B-A3B-Instruct"
-    VLLM_SERVE_EXTRA_ARGS: "--trust-remote-code,--mamba-cache-mode align,--max-model-len 8192,--max-num-batched-tokens 4096"
+    VLLM_SERVE_EXTRA_ARGS: "--trust-remote-code,--mamba-cache-mode align,--max-model-len 32768"
   commands:
     - bash /vllm-workspace/.buildkite/scripts/install-kv-connectors.sh
     - bash v1/kv_connector/nixl_integration/run_accuracy_test.sh

--- a/tests/v1/kv_connector/nixl_integration/test_accuracy.py
+++ b/tests/v1/kv_connector/nixl_integration/test_accuracy.py
@@ -59,7 +59,8 @@ def test_accuracy():
             f"model={MODEL_NAME},"
             f"base_url={BASE_URL}/chat/completions,"
             f"num_concurrent={NUM_CONCURRENT},"
-            "tokenizer_backend=huggingface"
+            "tokenizer_backend=huggingface,"
+            "trust_remote_code=True"
         )
         results = lm_eval.simple_evaluate(
             model="local-chat-completions",
@@ -72,7 +73,8 @@ def test_accuracy():
         model_args = (
             f"model={MODEL_NAME},"
             f"base_url={BASE_URL}/completions,"
-            f"num_concurrent={NUM_CONCURRENT},tokenized_requests=False"
+            f"num_concurrent={NUM_CONCURRENT},tokenized_requests=False,"
+            "trust_remote_code=True"
         )
         results = lm_eval.simple_evaluate(
             model="local-completions",


### PR DESCRIPTION
Follow up to https://github.com/vllm-project/vllm/pull/49762 to cover Kimi KDA disagg on CI.
`moonshotai/Kimi-Linear-48B-A3B-Instruct` is still a bit too big to run on each PR, so I am adding it to nightlies as a fast proxy to track K3 P/D.