### PR TITLE
[Bugfix] Make Rust HF dataset endpoint configurable

### DIFF
--- a/rust/src/bench/README.md
+++ b/rust/src/bench/README.md
@@ -801,6 +801,7 @@ The Rust implementation matches Python `vllm bench serve` in:
 | ---------- | ------------- |
 | `OPENAI_API_KEY` | API key for authenticated endpoints (cached, not read per-request) |
 | `HF_TOKEN` | HuggingFace token for gated model tokenizers and gated datasets |
+| `HF_DATASETS_SERVER_ENDPOINT` | Dataset Viewer API base URL for `--dataset-name hf` (default: `https://datasets-server.huggingface.co`) |
 | `TOKIO_WORKER_THREADS` | Override tokio worker thread count (default: physical cores) |
 
 ## License

--- a/rust/src/bench/README.md
+++ b/rust/src/bench/README.md
@@ -811,6 +811,7 @@ The Rust implementation matches Python `vllm bench serve` in:
 | `OPENAI_API_KEY` | API key for authenticated endpoints (cached, not read per-request) |
 | `HF_TOKEN` | HuggingFace token for gated/private tokenizers and datasets (falls back to the `hf auth login` token file) |
 | `HF_HOME` | Overrides the HuggingFace cache location (default `~/.cache/huggingface`) used for tokenizers and dataset parquet shards |
+| `HF_DATASETS_SERVER_ENDPOINT` | Dataset Viewer API base URL for `--dataset-name hf` (default: `https://datasets-server.huggingface.co`) |
 | `TOKIO_WORKER_THREADS` | Override tokio worker thread count (default: physical cores) |
 
 ## License

--- a/rust/src/bench/src/datasets/hf_dataset.rs
+++ b/rust/src/bench/src/datasets/hf_dataset.rs
@@ -13,6 +13,27 @@ use super::SampleRequest;
 use crate::error::{BenchError, Result};
 use crate::tokenizer::TokenizerKind;
 
+const DEFAULT_DATASETS_SERVER_ENDPOINT: &str = "https://datasets-server.huggingface.co";
+const DATASETS_SERVER_ENDPOINT_ENV: &str = "HF_DATASETS_SERVER_ENDPOINT";
+const DATASETS_SERVER_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+fn dataset_server_url(endpoint: &str, route: &str) -> Result<url::Url> {
+    let mut url = url::Url::parse(endpoint).map_err(|e| {
+        BenchError::Config(format!(
+            "Invalid HF datasets server endpoint '{endpoint}': {e}"
+        ))
+    })?;
+    let path = format!(
+        "{}/{}",
+        url.path().trim_end_matches('/'),
+        route.trim_start_matches('/')
+    );
+    url.set_path(&path);
+    url.set_query(None);
+    url.set_fragment(None);
+    Ok(url)
+}
+
 /// Detected column format for extracting prompts from HF dataset rows.
 enum ColumnFormat {
     /// Column contains chat messages (array of {role, content} or {from, value}).
@@ -101,11 +122,12 @@ pub async fn download_hf_dataset(
     seed: u64,
     disable_shuffle: bool,
 ) -> Result<(Vec<serde_json::Value>, String, String)> {
-    let encoded_dataset: String =
-        url::form_urlencoded::byte_serialize(dataset.as_bytes()).collect();
+    let datasets_server_endpoint = std::env::var(DATASETS_SERVER_ENDPOINT_ENV)
+        .unwrap_or_else(|_| DEFAULT_DATASETS_SERVER_ENDPOINT.to_string());
 
-    let mut client_builder =
-        reqwest::Client::builder().timeout(std::time::Duration::from_secs(120));
+    let mut client_builder = reqwest::Client::builder()
+        .connect_timeout(DATASETS_SERVER_CONNECT_TIMEOUT)
+        .timeout(std::time::Duration::from_secs(120));
 
     // Match hf-hub's auth for shard downloads: HF_TOKEN env var, then the hub token file
     let token = std::env::var("HF_TOKEN")
@@ -131,9 +153,9 @@ pub async fn download_hf_dataset(
     } else if let Some(info) = {
         // Call /info to discover available configs and splits. Private datasets are not
         // processed by the dataset viewer; fall back to datasets-library defaults.
-        let info_url =
-            format!("https://datasets-server.huggingface.co/info?dataset={encoded_dataset}");
-        match get_with_retry(&client, &info_url, "HF dataset /info").await {
+        let mut info_url = dataset_server_url(&datasets_server_endpoint, "info")?;
+        info_url.query_pairs_mut().append_pair("dataset", dataset);
+        match get_with_retry(&client, info_url.as_str(), "HF dataset /info").await {
             Ok(info) => Some(info),
             Err(e) => {
                 tracing::warn!(
@@ -219,21 +241,28 @@ pub async fn download_hf_dataset(
         "resolved Hugging Face dataset"
     );
 
-    let (revision, mut shard_paths) =
-        match convert_parquet_shards(&client, dataset, &resolved_config, &resolved_split).await {
-            Ok(paths) => (PARQUET_REVISION, paths),
-            Err(e) => {
-                tracing::info!(
-                    dataset,
-                    error = %e,
-                    "no dataset-viewer parquet export; trying native parquet files on main"
-                );
-                (
-                    "main",
-                    native_data_files(dataset, &resolved_config, &resolved_split).await?,
-                )
-            }
-        };
+    let (revision, mut shard_paths) = match convert_parquet_shards(
+        &client,
+        &datasets_server_endpoint,
+        dataset,
+        &resolved_config,
+        &resolved_split,
+    )
+    .await
+    {
+        Ok(paths) => (PARQUET_REVISION, paths),
+        Err(e) => {
+            tracing::info!(
+                dataset,
+                error = %e,
+                "no dataset-viewer parquet export; trying native parquet files on main"
+            );
+            (
+                "main",
+                native_data_files(dataset, &resolved_config, &resolved_split).await?,
+            )
+        }
+    };
 
     // Sort for determinism, then shuffle shard order so samples are not always drawn
     // from the start of the split (mirrors the datasets library's streaming shuffle).
@@ -266,14 +295,14 @@ fn shard_repo_path(url: &str) -> Option<String> {
 /// List the dataset-viewer's auto-converted parquet shards for a config/split.
 async fn convert_parquet_shards(
     client: &reqwest::Client,
+    datasets_server_endpoint: &str,
     dataset: &str,
     config: &str,
     split: &str,
 ) -> Result<Vec<String>> {
-    let encoded_dataset: String =
-        url::form_urlencoded::byte_serialize(dataset.as_bytes()).collect();
-    let url = format!("https://datasets-server.huggingface.co/parquet?dataset={encoded_dataset}");
-    let listing = get_with_retry(client, &url, "HF dataset /parquet").await?;
+    let mut url = dataset_server_url(datasets_server_endpoint, "parquet")?;
+    url.query_pairs_mut().append_pair("dataset", dataset);
+    let listing = get_with_retry(client, url.as_str(), "HF dataset /parquet").await?;
 
     // Partially converted datasets (>5GB) export under a "partial-" split prefix.
     let partial_split = format!("partial-{split}");
@@ -906,6 +935,20 @@ pub fn load_hf_dataset(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_dataset_server_url_uses_configured_endpoint() {
+        let url = dataset_server_url("https://datasets.example/api/", "parquet").unwrap();
+
+        assert_eq!(url.as_str(), "https://datasets.example/api/parquet");
+    }
+
+    #[test]
+    fn test_dataset_server_url_rejects_invalid_endpoint() {
+        let err = dataset_server_url("not a URL", "info").unwrap_err();
+
+        assert!(err.to_string().contains("Invalid HF datasets server endpoint"));
+    }
 
     #[test]
     fn test_detect_chat_conversation() {

--- a/rust/src/bench/src/datasets/hf_dataset.rs
+++ b/rust/src/bench/src/datasets/hf_dataset.rs
@@ -12,6 +12,10 @@ use super::progress::RowDownloadReporter;
 use crate::error::{BenchError, Result};
 use crate::tokenizer::TokenizerKind;
 
+const DEFAULT_DATASETS_SERVER_ENDPOINT: &str = "https://datasets-server.huggingface.co";
+const DATASETS_SERVER_ENDPOINT_ENV: &str = "HF_DATASETS_SERVER_ENDPOINT";
+const DATASETS_SERVER_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 /// Cache directory for downloaded HF datasets.
 fn cache_dir() -> std::path::PathBuf {
     dirs::cache_dir()
@@ -31,6 +35,23 @@ fn sanitize_name(name: &str) -> String {
             }
         })
         .collect()
+}
+
+fn dataset_server_url(endpoint: &str, route: &str) -> Result<url::Url> {
+    let mut url = url::Url::parse(endpoint).map_err(|e| {
+        BenchError::Config(format!(
+            "Invalid HF datasets server endpoint '{endpoint}': {e}"
+        ))
+    })?;
+    let path = format!(
+        "{}/{}",
+        url.path().trim_end_matches('/'),
+        route.trim_start_matches('/')
+    );
+    url.set_path(&path);
+    url.set_query(None);
+    url.set_fragment(None);
+    Ok(url)
 }
 
 /// Detected column format for extracting prompts from HF dataset rows.
@@ -114,11 +135,12 @@ pub async fn download_hf_dataset(
     split: Option<&str>,
     num_rows_needed: usize,
 ) -> Result<(String, String, String)> {
-    let encoded_dataset: String =
-        url::form_urlencoded::byte_serialize(dataset.as_bytes()).collect();
+    let datasets_server_endpoint = std::env::var(DATASETS_SERVER_ENDPOINT_ENV)
+        .unwrap_or_else(|_| DEFAULT_DATASETS_SERVER_ENDPOINT.to_string());
 
-    let mut client_builder =
-        reqwest::Client::builder().timeout(std::time::Duration::from_secs(120));
+    let mut client_builder = reqwest::Client::builder()
+        .connect_timeout(DATASETS_SERVER_CONNECT_TIMEOUT)
+        .timeout(std::time::Duration::from_secs(120));
 
     // Add HF_TOKEN auth header if available
     if let Ok(token) = std::env::var("HF_TOKEN") {
@@ -139,9 +161,9 @@ pub async fn download_hf_dataset(
         (cfg.to_string(), spl.to_string())
     } else {
         // Call /info to discover available configs and splits
-        let info_url =
-            format!("https://datasets-server.huggingface.co/info?dataset={encoded_dataset}");
-        let info = get_with_retry(&client, &info_url, "HF dataset /info").await?;
+        let mut info_url = dataset_server_url(&datasets_server_endpoint, "info")?;
+        info_url.query_pairs_mut().append_pair("dataset", dataset);
+        let info = get_with_retry(&client, info_url.as_str(), "HF dataset /info").await?;
 
         let dataset_info =
             info.get("dataset_info").and_then(|d| d.as_object()).ok_or_else(|| {
@@ -234,27 +256,21 @@ pub async fn download_hf_dataset(
         "downloading Hugging Face dataset"
     );
 
-    let encoded_config: String =
-        url::form_urlencoded::byte_serialize(resolved_config.as_bytes()).collect();
-    let encoded_split: String =
-        url::form_urlencoded::byte_serialize(resolved_split.as_bytes()).collect();
-
     let mut all_rows: Vec<serde_json::Value> = Vec::new();
     let mut offset = 0usize;
     let page_size = 100usize;
     let mut progress = RowDownloadReporter::new();
 
     loop {
-        let url = format!(
-            "https://datasets-server.huggingface.co/rows\
-             ?dataset={encoded_dataset}\
-             &config={encoded_config}\
-             &split={encoded_split}\
-             &offset={offset}\
-             &length={page_size}"
-        );
+        let mut url = dataset_server_url(&datasets_server_endpoint, "rows")?;
+        url.query_pairs_mut()
+            .append_pair("dataset", dataset)
+            .append_pair("config", &resolved_config)
+            .append_pair("split", &resolved_split)
+            .append_pair("offset", &offset.to_string())
+            .append_pair("length", &page_size.to_string());
 
-        let data = get_with_retry(&client, &url, "HF dataset /rows").await?;
+        let data = get_with_retry(&client, url.as_str(), "HF dataset /rows").await?;
 
         let rows = data["rows"]
             .as_array()
@@ -973,6 +989,20 @@ mod tests {
         );
         assert_eq!(sanitize_name("simple-name"), "simple-name");
         assert_eq!(sanitize_name("org/sub/deep"), "org_sub_deep");
+    }
+
+    #[test]
+    fn test_dataset_server_url_uses_configured_endpoint() {
+        let url = dataset_server_url("https://datasets.example/api/", "rows").unwrap();
+
+        assert_eq!(url.as_str(), "https://datasets.example/api/rows");
+    }
+
+    #[test]
+    fn test_dataset_server_url_rejects_invalid_endpoint() {
+        let err = dataset_server_url("not a URL", "info").unwrap_err();
+
+        assert!(err.to_string().contains("Invalid HF datasets server endpoint"));
     }
 
     // --- extract_chat_prompt edge cases ---


### PR DESCRIPTION
## Purpose

Fixes #50271.

The Rust `hf` dataset loader built its Dataset Viewer API URLs from a fixed
`datasets-server.huggingface.co` origin. This prevented users from routing
dataset metadata and parquet discovery through an accessible Dataset Viewer
service. The client also had a 120-second request timeout but no shorter
connection timeout, so an unreachable host could appear to hang before prompt
generation.

This change:

- reads the Dataset Viewer base URL from `HF_DATASETS_SERVER_ENDPOINT`, while
  preserving the current Hugging Face endpoint as the default;
- constructs both `/info` and `/parquet` URLs with `url::Url`;
- applies a 10-second connection timeout while retaining the existing request
  timeout and retry policy; and
- documents the endpoint override.

No other open pull request references #50271 or addresses this endpoint
configuration. AI assistance was used in developing this change.

This only changes Dataset Viewer endpoint routing and connection-failure
latency; it does not affect model output or accuracy, so no model evaluation is
applicable.

## Test Plan

```text
cargo fmt --all --check
cargo test -p vllm-bench test_dataset_server_url --no-fail-fast
cargo test -p vllm-bench datasets::hf_dataset::tests --no-fail-fast
cargo test -p vllm-bench --no-fail-fast
git diff upstream/main...HEAD --check
```

## Test Result

- Endpoint regression tests: 2 passed.
- HF dataset module: 49 passed, 2 network tests ignored.
- Full `vllm-bench` suite: 169 passed, 12 ignored, 0 failed.
- Rust formatting and diff checks passed.
