### PR TITLE
[Bugfix][LoRA] Make Punica shrink deterministic with split_k=1

### DIFF
--- a/tests/lora/test_compressed_tensors_lora_determinism.py
+++ b/tests/lora/test_compressed_tensors_lora_determinism.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Determinism regression for LoRA on compressed-tensors W4A16 (issue #50059)."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+import vllm
+from vllm.distributed import cleanup_dist_env_and_memory
+from vllm.lora.request import LoRARequest
+from vllm.platforms import current_platform
+
+# TinyLlama compressed-tensors W4A16 (group 128) — small enough for H20/L20.
+W4A16_MODEL = (
+    "nm-testing/TinyLlama-1.1B-Chat-v1.0-W4A16-G128-Asym-Updated-ActOrder"
+)
+
+# TinyLlama-1.1B architecture dims.
+_HIDDEN = 2048
+_INTERMEDIATE = 5632
+_NUM_LAYERS = 22
+_NUM_KV_HEADS = 4
+_HEAD_DIM = 64
+_KV_OUT = _NUM_KV_HEADS * _HEAD_DIM  # 256
+
+
+def _write_all_layer_lora(save_dir: Path, *, rank: int, seed: int = 0) -> Path:
+    """Create a PEFT LoRA covering all q/k/v/o/gate/up/down projections."""
+    save_dir.mkdir(parents=True, exist_ok=True)
+    torch.manual_seed(seed)
+
+    target_modules = [
+        "q_proj",
+        "k_proj",
+        "v_proj",
+        "o_proj",
+        "gate_proj",
+        "up_proj",
+        "down_proj",
+    ]
+    adapter_config = {
+        "peft_type": "LORA",
+        "base_model_name_or_path": W4A16_MODEL,
+        "task_type": "CAUSAL_LM",
+        "r": rank,
+        "lora_alpha": rank,
+        "lora_dropout": 0.0,
+        "bias": "none",
+        "target_modules": target_modules,
+        "inference_mode": True,
+    }
+    with open(save_dir / "adapter_config.json", "w", encoding="utf-8") as f:
+        json.dump(adapter_config, f, indent=2)
+
+    weights: dict[str, torch.Tensor] = {}
+    # (name_suffix, in_features, out_features)
+    per_layer = [
+        ("self_attn.q_proj", _HIDDEN, _HIDDEN),
+        ("self_attn.k_proj", _HIDDEN, _KV_OUT),
+        ("self_attn.v_proj", _HIDDEN, _KV_OUT),
+        ("self_attn.o_proj", _HIDDEN, _HIDDEN),
+        ("mlp.gate_proj", _HIDDEN, _INTERMEDIATE),
+        ("mlp.up_proj", _HIDDEN, _INTERMEDIATE),
+        ("mlp.down_proj", _INTERMEDIATE, _HIDDEN),
+    ]
+    for layer_idx in range(_NUM_LAYERS):
+        for suffix, in_f, out_f in per_layer:
+            prefix = f"base_model.model.model.layers.{layer_idx}.{suffix}"
+            lora_a = torch.randn(rank, in_f, dtype=torch.float16)
+            torch.nn.init.kaiming_uniform_(lora_a, a=5**0.5)
+            # Non-zero B so LoRA actually changes logits (not a no-op).
+            lora_b = torch.randn(out_f, rank, dtype=torch.float16) * 0.01
+            weights[f"{prefix}.lora_A.weight"] = lora_a
+            weights[f"{prefix}.lora_B.weight"] = lora_b
+
+    save_file(weights, str(save_dir / "adapter_model.safetensors"))
+    return save_dir
+
+
+def _greedy_texts(
+    llm: vllm.LLM,
+    lora_path: str,
+    *,
+    lora_id: int = 1,
+    max_tokens: int = 16,
+) -> list[str]:
+    prompts = [
+        "<|im_start|>user\nSay one short color name.<|im_end|>\n"
+        "<|im_start|>assistant\n",
+        "<|im_start|>user\nReply with exactly: OK.<|im_end|>\n"
+        "<|im_start|>assistant\n",
+    ]
+    sampling = vllm.SamplingParams(
+        temperature=0.0,
+        top_p=1.0,
+        top_k=-1,
+        max_tokens=max_tokens,
+        seed=1234,
+        stop=["<|im_end|>"],
+    )
+    outputs = llm.generate(
+        prompts,
+        sampling,
+        lora_request=LoRARequest(str(lora_id), lora_id, lora_path),
+    )
+    return [o.outputs[0].text for o in outputs]
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="compressed-tensors W4A16 + LoRA determinism needs CUDA",
+)
+@pytest.mark.parametrize("rank", [8, 16, 32])
+def test_w4a16_lora_greedy_deterministic_same_engine(tmp_path, rank: int):
+    """Same engine, repeated greedy generate must be identical (issue #50059)."""
+    lora_dir = _write_all_layer_lora(tmp_path / f"lora_r{rank}", rank=rank)
+    llm = vllm.LLM(
+        model=W4A16_MODEL,
+        enable_lora=True,
+        max_loras=2,
+        max_lora_rank=32,
+        max_model_len=256,
+        gpu_memory_utilization=0.25,
+        enforce_eager=True,
+        trust_remote_code=True,
+        enable_chunked_prefill=True,
+        enable_prefix_caching=False,
+        async_scheduling=False,
+        seed=0,
+    )
+    try:
+        # Discard Triton JIT / first-call warmup before measuring.
+        _ = _greedy_texts(llm, str(lora_dir))
+        baseline = _greedy_texts(llm, str(lora_dir))
+        for _ in range(4):
+            assert _greedy_texts(llm, str(lora_dir)) == baseline
+        # LoRA must actually move the output vs base (non-zero adapter).
+        base_out = llm.generate(
+            [
+                "<|im_start|>user\nSay one short color name.<|im_end|>\n"
+                "<|im_start|>assistant\n"
+            ],
+            vllm.SamplingParams(temperature=0.0, max_tokens=16, seed=1234),
+        )[0].outputs[0].text
+        assert baseline[0] != base_out or baseline[1] != "", (
+            "LoRA adapter produced no change; adapter may not have loaded"
+        )
+    finally:
+        del llm
+        cleanup_dist_env_and_memory()
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="compressed-tensors W4A16 + LoRA determinism needs CUDA",
+)
+@pytest.mark.parametrize("rank", [8, 16, 32])
+def test_w4a16_lora_greedy_deterministic_across_reloads(tmp_path, rank: int):
+    """Reload engine (restart-like) and compare greedy LoRA outputs (#50059)."""
+    lora_dir = _write_all_layer_lora(tmp_path / f"lora_r{rank}_reload", rank=rank)
+
+    def one_run() -> list[str]:
+        llm = vllm.LLM(
+            model=W4A16_MODEL,
+            enable_lora=True,
+            max_loras=2,
+            max_lora_rank=32,
+            max_model_len=256,
+            gpu_memory_utilization=0.25,
+            enforce_eager=True,
+            trust_remote_code=True,
+            enable_chunked_prefill=True,
+            enable_prefix_caching=False,
+            async_scheduling=False,
+            seed=0,
+        )
+        try:
+            _ = _greedy_texts(llm, str(lora_dir))  # warmup
+            return _greedy_texts(llm, str(lora_dir))
+        finally:
+            del llm
+            cleanup_dist_env_and_memory()
+
+    baseline = one_run()
+    for _ in range(2):
+        assert one_run() == baseline

--- a/tests/lora/test_punica_ops.py
+++ b/tests/lora/test_punica_ops.py
@@ -636,3 +636,56 @@ def test_add_lora_fused_moe_early_exit(device):
     assert torch.equal(y, y_snapshot), (
         "add_lora_fused_moe modified output tensor despite no_lora_flag_cpu=True"
     )
+
+
+@pytest.mark.parametrize("rank", [8, 16, 32])
+def test_lora_shrink_is_deterministic(rank: int) -> None:
+    """Regression for vllm-project/vllm#50059 (split_k atomic_add)."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+
+    device = DEVICE_TYPE
+    batches, seq_length, hidden_size = 4, 8, 4096
+    dtype = torch.float16
+    nslices = 1
+    num_loras = 1
+
+    def run_once() -> torch.Tensor:
+        data = generate_data_for_nslices(
+            batches,
+            hidden_size,
+            num_loras,
+            rank,
+            seq_length,
+            nslices,
+            dtype,
+            "shrink",
+            device,
+        )
+        _, token_nums = data.meta()
+        lora_meta = LoRAKernelMeta.make(
+            max_loras=num_loras,
+            max_num_tokens=token_nums,
+            device=device,
+        )
+        lora_meta.prepare_tensors(data.token_lora_mapping)
+        out = data.our_out_tensor.clone()
+        with _dict_lock:
+            _LORA_A_PTR_DICT.clear()
+            triton_ops.lora_shrink(
+                data.inputs_tensor,
+                data.lora_weights,
+                out,
+                *lora_meta.meta_args(
+                    token_nums=token_nums, specialize_active_lora=False
+                ),
+                1.0,
+            )
+        return out.detach().cpu()
+
+    set_random_seed(0)
+    baseline = run_once()
+    for _ in range(20):
+        set_random_seed(0)
+        out = run_once()
+        assert torch.equal(out, baseline)

--- a/vllm/lora/ops/triton_ops/lora_shrink_fp8_op.py
+++ b/vllm/lora/ops/triton_ops/lora_shrink_fp8_op.py
@@ -316,7 +316,7 @@ def _lora_shrink_fp8(
     BLOCK_M = kernel_config["block_m"]
     BLOCK_N = kernel_config["block_n"]
     BLOCK_K = kernel_config["block_k"]
-    SPLIT_K = kernel_config["split_k"]
+    SPLIT_K = 1
     NUM_WARPS = kernel_config["num_warps"]
     NUM_STAGES = kernel_config["num_stages"]
     NUM_CTAS = kernel_config["num_ctas"]

--- a/vllm/lora/ops/triton_ops/lora_shrink_op.py
+++ b/vllm/lora/ops/triton_ops/lora_shrink_op.py
@@ -210,7 +210,9 @@ def _lora_shrink(
     BLOCK_M = kernel_config["block_m"]
     BLOCK_N = kernel_config["block_n"]
     BLOCK_K = kernel_config["block_k"]
-    SPLIT_K = kernel_config["split_k"]
+    # Enforce deterministic reduction: tuned configs must not re-enable
+    # split_k > 1 (atomic_add in do_shrink_kernel). See #50059.
+    SPLIT_K = 1
     NUM_WARPS = kernel_config["num_warps"]
     NUM_STAGES = kernel_config["num_stages"]
     NUM_CTAS = kernel_config["num_ctas"]

--- a/vllm/lora/ops/triton_ops/utils.py
+++ b/vllm/lora/ops/triton_ops/utils.py
@@ -218,12 +218,15 @@ def get_lora_op_configs(
     # default config
     default = {}
     if op_type == "shrink":
-        split_k = 64 if batch < 128 else 8
-        if is_batch_invariant:
-            split_k = 1
+        # split_k > 1 uses tl.atomic_add in do_shrink_kernel, which is
+        # non-deterministic due to relaxed floating-point reduction order.
+        # Fused MoE LoRA shrink already pins split_k=1; match that here
+        # (see vllm-project/vllm#50059).
+        split_k = 1
+        block_n = max(16, min(64, next_power_of_2(rank)))
         default = {
             "block_m": 32,
-            "block_n": 16,
+            "block_n": block_n,
             "block_k": 256 if batch < 128 else 32,
             "split_k": split_k,
             "num_warps": 4,


### PR DESCRIPTION
## Summary

Fixes #50059.

Runtime LoRA on compressed-tensors W4A16 uses Marlin/Machete for the base GEMM and Punica Triton for the LoRA path (`shrink` → expand). With temperature 0, rank-32 all-layer adapters were non-reproducible across restarts; rank-8 partial adapters were fine. The same adapter is deterministic on llama.cpp.

**Root cause:** default Punica shrink used `split_k=64` / `8`, so K-reduction went through `tl.atomic_add(..., sem="relaxed")` and was non-deterministic. With `block_n=16`, rank 32 spans two N-tiles; full-layer LoRA then amplifies ULP drift into different greedy outputs.

**Fix** (match fused MoE LoRA shrink):

- `split_k=1`
- `block_n = max(16, min(64, next_power_of_2(rank)))` so ranks 8/16/32 use one N-tile
- Force `SPLIT_K=1` at shrink launch even if a tuned JSON asks for more

## Changes

| File | What |
|------|------|
| `vllm/lora/ops/triton_ops/utils.py` | Default shrink: `split_k=1`; adaptive `block_n` |
| `vllm/lora/ops/triton_ops/lora_shrink_op.py` | Force `SPLIT_K=1` |
| `vllm/lora/ops/triton_ops/lora_shrink_fp8_op.py` | Same for FP8 shrink |
| `tests/lora/test_punica_ops.py` | `test_lora_shrink_is_deterministic` |
| `tests/lora/test_compressed_tensors_lora_determinism.py` | W4A16 + all-layer LoRA greedy determinism |

## Test results (NVIDIA H20, vLLM 0.22.0 + PyTorch 2.11/cu129)

**Punica shrink** — 24 repeats, `hidden_size=4096`:

| Phase | Config @ rank 32 | max_drift @ 8/16/32 |
|-------|------------------|---------------------|
| Before | `split_k=64`, `block_n=16` | **2.44e-4** |
| After | `split_k=1`, `block_n=32` | **0.0** |

**W4A16 + LoRA** — TinyLlama W4A16, synthetic all-layer PEFT, ranks 8/16/32, temperature 0:

- Same engine + reload: OK
- `pytest tests/lora/test_compressed_tensors_lora_determinism.py`: 6 passed
- OpenAI serve + `--lora-modules`, rank 32 × 12 completions: one unique output

On this small base, upstream often still matches at the **text** level; the kernel probe is what shows the race. OLMo-32B reporter repro not run here.

## Test plan

- [x] Shrink bit-exact probe on H20
- [x] W4A16 + LoRA same-engine / reload + pytest
- [x] Serve completions loop, rank 32
- [ ] Optional: reporter re-check on OLMo-3.1-32B int4 + rank-32 LoRA

## Notes

`split_k=1` may cost some shrink throughput; fused MoE LoRA already made that trade-off. Tuned JSON can no longer raise shrink `split_k`.
