### PR TITLE
[Kernel] Fuse strided GDN RMSNorm gating on SM103

### DIFF
--- a/benchmarks/kernels/benchmark_gdn_rmsnorm.py
+++ b/benchmarks/kernels/benchmark_gdn_rmsnorm.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Benchmark strided GDN RMSNormGated implementations."""
+
+import argparse
+
+import torch
+
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.model_executor.layers.layernorm import RMSNormGated
+from vllm.model_executor.layers.mamba.ops.gdn_rmsnorm import (
+    fused_gdn_rmsnorm_gated,
+)
+from vllm.triton_utils import triton
+
+
+def _bench(function) -> list[float]:
+    return [
+        value * 1000
+        for value in triton.testing.do_bench(
+            function,
+            warmup=100,
+            rep=300,
+            quantiles=[0.2, 0.5, 0.8],
+        )
+    ]
+
+
+def benchmark_case(tokens: int, heads: int, hidden_size: int) -> None:
+    torch.manual_seed(0)
+    with set_current_vllm_config(VllmConfig()):
+        layer = RMSNormGated(
+            hidden_size,
+            eps=1e-6,
+            norm_before_gate=True,
+            activation="silu",
+            device="cuda",
+            dtype=torch.bfloat16,
+        )
+    x = torch.randn(tokens, heads, hidden_size, device="cuda", dtype=torch.bfloat16)
+    projected = torch.randn(
+        tokens,
+        heads + 96,
+        hidden_size,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    z = projected[:, 96:, :]
+    compiled_native = torch.compile(layer.forward_native, fullgraph=True)
+
+    reference = compiled_native(x, z)
+    optimized = fused_gdn_rmsnorm_gated(x, z, layer.weight, layer.eps)
+    difference = (optimized.float() - reference.float()).double()
+    relative_l2 = torch.linalg.vector_norm(difference) / torch.linalg.vector_norm(
+        reference.float().double()
+    )
+
+    native_us = _bench(lambda: compiled_native(x, z))
+    cuda_us = _bench(lambda: layer.forward_cuda(x, z))
+    optimized_us = _bench(
+        lambda: fused_gdn_rmsnorm_gated(x, z, layer.weight, layer.eps)
+    )
+    print(
+        f"D={hidden_size:3d} T={tokens:5d} H={heads:2d} "
+        f"native={native_us[1]:8.2f} us "
+        f"cuda={cuda_us[1]:8.2f} us "
+        f"optimized={optimized_us[1]:8.2f} us "
+        f"speedup={native_us[1] / optimized_us[1]:5.2f}x "
+        f"rel_l2={relative_l2.item():.3g}"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--hidden-sizes", type=int, nargs="+", default=[64, 96, 128, 192, 256]
+    )
+    parser.add_argument("--tokens", type=int, default=2048)
+    parser.add_argument("--heads", type=int, default=64)
+    parser.add_argument("--production-shape", action="store_true")
+    args = parser.parse_args()
+
+    for hidden_size in args.hidden_sizes:
+        benchmark_case(args.tokens, args.heads, hidden_size)
+    if args.production_shape:
+        benchmark_case(8192, 64, 128)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/kernels/test_fla_layernorm_guard.py
+++ b/tests/kernels/test_fla_layernorm_guard.py
@@ -523,6 +523,32 @@ def test_strided_gdn_rmsnorm_gated_rejects_unsupported_shape(
     assert output is None
 
 
+def test_strided_gdn_rmsnorm_gated_rejects_cpu_input(monkeypatch) -> None:
+    from vllm.model_executor.layers.mamba.ops import gdn_rmsnorm
+
+    monkeypatch.setattr(gdn_rmsnorm, "_IS_SM103", True)
+    monkeypatch.setattr(
+        gdn_rmsnorm,
+        "fused_gdn_rmsnorm_gated_op",
+        lambda *args, **kwargs: torch.empty_like(args[0]),
+    )
+    x = torch.empty(8, 4, 128, dtype=torch.bfloat16)
+    z = torch.empty_like(x)
+    weight = torch.empty(128, dtype=torch.bfloat16)
+
+    output = gdn_rmsnorm.try_fused_gdn_rmsnorm_gated(
+        x,
+        z,
+        weight,
+        1e-6,
+        group_size=None,
+        norm_before_gate=True,
+        activation="silu",
+    )
+
+    assert output is None
+
+
 @pytest.mark.skipif(
     current_platform.get_device_capability() != (10, 3),
     reason="Qwen strided GDN RMSNorm dispatch is SM103-specific",

--- a/tests/kernels/test_fla_layernorm_guard.py
+++ b/tests/kernels/test_fla_layernorm_guard.py
@@ -1,10 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 import torch.nn.functional as F
 
+from vllm.platforms import current_platform
 from vllm.third_party.flash_linear_attention.ops.layernorm_guard import (
     layer_norm_fwd,
     layernorm_fn,
@@ -440,6 +443,137 @@ def test_rmsnorm_gated_forward_native_dtype(
         upcast=True,
     )
     torch.testing.assert_close(out, ref_out, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("hidden_size", [64, 96, 128, 192, 256])
+@pytest.mark.parametrize("num_tokens", [1, 17, 257])
+@torch.inference_mode()
+def test_strided_gdn_rmsnorm_gated_matches_native(
+    default_vllm_config,
+    hidden_size: int,
+    num_tokens: int,
+) -> None:
+    from vllm.model_executor.layers.mamba.ops.gdn_rmsnorm import (
+        fused_gdn_rmsnorm_gated,
+    )
+
+    set_random_seed(42)
+    heads = 8
+    x = torch.randn(
+        num_tokens,
+        heads,
+        hidden_size,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    projected = torch.randn(
+        num_tokens,
+        heads + 12,
+        hidden_size,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    z = projected[:, 12:, :]
+    weight = torch.randn(hidden_size, device="cuda", dtype=torch.bfloat16)
+    eps = 1e-6
+
+    actual = fused_gdn_rmsnorm_gated(x, z, weight, eps)
+    x_float = x.float()
+    variance = x_float.square().mean(dim=-1, keepdim=True)
+    expected = x_float * torch.rsqrt(variance + eps)
+    expected *= weight.float() * torch.nn.functional.silu(z.float())
+    expected = expected.to(torch.bfloat16)
+
+    difference = actual.float() - expected.float()
+    relative_l2 = torch.linalg.vector_norm(difference) / torch.linalg.vector_norm(
+        expected.float()
+    )
+    assert relative_l2.item() <= 1e-3
+    assert not torch.isnan(actual).any()
+    assert not torch.isinf(actual).any()
+
+
+@pytest.mark.parametrize(
+    ("tokens", "heads", "hidden_size"),
+    [(1, 1, 384), (2049, 64, 192)],
+)
+def test_strided_gdn_rmsnorm_gated_rejects_unsupported_shape(
+    monkeypatch,
+    tokens: int,
+    heads: int,
+    hidden_size: int,
+) -> None:
+    from vllm.model_executor.layers.mamba.ops import gdn_rmsnorm
+
+    monkeypatch.setattr(gdn_rmsnorm, "_IS_SM103", True)
+    x = torch.empty(tokens, heads, hidden_size, device="meta", dtype=torch.bfloat16)
+    z = torch.empty_like(x)
+    weight = torch.empty(hidden_size, device="meta", dtype=torch.bfloat16)
+
+    output = gdn_rmsnorm.try_fused_gdn_rmsnorm_gated(
+        x,
+        z,
+        weight,
+        1e-6,
+        group_size=None,
+        norm_before_gate=True,
+        activation="silu",
+    )
+
+    assert output is None
+
+
+@pytest.mark.skipif(
+    current_platform.get_device_capability() != (10, 3),
+    reason="Qwen strided GDN RMSNorm dispatch is SM103-specific",
+)
+def test_qwen_output_projection_uses_strided_gdn_rmsnorm() -> None:
+    from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
+        QwenGatedDeltaNetAttention,
+    )
+    from vllm.model_executor.layers.mamba.ops.gdn_rmsnorm import (
+        fused_gdn_rmsnorm_gated,
+    )
+
+    set_random_seed(42)
+    x = torch.randn(17, 8, 128, device="cuda", dtype=torch.bfloat16)
+    projected = torch.randn(17, 20, 128, device="cuda", dtype=torch.bfloat16)
+    z = projected[:, 12:, :]
+    weight = torch.randn(128, device="cuda", dtype=torch.bfloat16)
+    layer = SimpleNamespace(
+        norm=SimpleNamespace(
+            weight=weight,
+            eps=1e-6,
+            group_size=None,
+            norm_before_gate=True,
+            activation="silu",
+        ),
+        out_proj=lambda value: (value, None),
+    )
+
+    actual = QwenGatedDeltaNetAttention._output_projection(layer, x, z)
+    expected = fused_gdn_rmsnorm_gated(x, z, weight, 1e-6).flatten(-2)
+
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+def test_strided_gdn_rmsnorm_gated_preserves_fake_layout() -> None:
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    from vllm.model_executor.layers.mamba.ops.gdn_rmsnorm import (
+        fused_gdn_rmsnorm_gated_op,
+    )
+
+    mode = FakeTensorMode()
+    x = mode.from_tensor(torch.empty(8, 16, 128))
+    z = mode.from_tensor(torch.empty_strided((8, 16, 128), (4096, 128, 1)))
+    weight = mode.from_tensor(torch.empty(128))
+
+    output = fused_gdn_rmsnorm_gated_op(x, z, weight, 1e-6)
+
+    assert output.shape == x.shape
+    assert output.stride() == x.stride()
+    assert output.is_contiguous()
 
 
 if __name__ == "__main__":

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -36,6 +36,9 @@ from vllm.model_executor.layers.mamba.ops.causal_conv1d import (
     causal_conv1d_fn,
     causal_conv1d_update,
 )
+from vllm.model_executor.layers.mamba.ops.gdn_rmsnorm import (
+    try_fused_gdn_rmsnorm_gated,
+)
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.quantization.auto_awq import AutoAWQConfig
 from vllm.model_executor.layers.quantization.auto_gptq import AutoGPTQConfig
@@ -781,13 +784,22 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         The RMSNormGated + quant sequence is eligible for fusion
         by the compilation pass when fuse_norm_quant is enabled.
         """
-        z_shape_og = z.shape
-        core_attn_out = core_attn_out.reshape(-1, core_attn_out.shape[-1])
-        z = z.reshape(-1, z.shape[-1])
-        core_attn_out = self.norm(core_attn_out, z)
-        core_attn_out = core_attn_out.reshape(z_shape_og)
-        core_attn_out = core_attn_out.flatten(-2)  # ... h d -> ... (h d)
-        output, _ = self.out_proj(core_attn_out)
+        normalized = try_fused_gdn_rmsnorm_gated(
+            core_attn_out,
+            z,
+            self.norm.weight,
+            self.norm.eps,
+            self.norm.group_size,
+            self.norm.norm_before_gate,
+            self.norm.activation,
+        )
+        if normalized is None:
+            z_shape = z.shape
+            core_attn_out = core_attn_out.reshape(-1, core_attn_out.shape[-1])
+            z = z.reshape(-1, z.shape[-1])
+            normalized = self.norm(core_attn_out, z).reshape(z_shape)
+        normalized = normalized.flatten(-2)  # ... h d -> ... (h d)
+        output, _ = self.out_proj(normalized)
         return output
 
     def forward_hip(

--- a/vllm/model_executor/layers/mamba/ops/gdn_rmsnorm.py
+++ b/vllm/model_executor/layers/mamba/ops/gdn_rmsnorm.py
@@ -141,6 +141,7 @@ def try_fused_gdn_rmsnorm_gated(
     rows = x.numel() // hidden_size
     eligible = (
         _IS_SM103
+        and x.is_cuda
         and x.dtype == torch.bfloat16
         and z.dtype == x.dtype
         and weight.dtype == x.dtype

--- a/vllm/model_executor/layers/mamba/ops/gdn_rmsnorm.py
+++ b/vllm/model_executor/layers/mamba/ops/gdn_rmsnorm.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+from vllm.utils.torch_utils import direct_register_custom_op
+
+_SUPPORTED_HIDDEN_SIZES = frozenset({64, 96, 128, 192, 256})
+_LARGE_CONFIG_ROWS = 262144
+_MAX_WIDE_DIM_ROWS = 131072
+_IS_SM103 = current_platform.get_device_capability() == (10, 3)
+
+
+@triton.jit
+def _fused_gdn_rmsnorm_gated_kernel(
+    x_ptr,
+    z_ptr,
+    weight_ptr,
+    output_ptr,
+    rows,
+    stride_z_token,
+    stride_z_head,
+    eps,
+    HEADS: tl.constexpr,
+    HIDDEN_SIZE: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+):
+    row = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)
+    column = tl.arange(0, BLOCK_D)
+    mask = (row[:, None] < rows) & (column[None, :] < HIDDEN_SIZE)
+
+    x = tl.load(
+        x_ptr + row[:, None] * HIDDEN_SIZE + column[None, :],
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    variance = tl.sum(x * x, axis=1) / HIDDEN_SIZE
+    reciprocal_std = tl.rsqrt(variance + eps)
+    weight = tl.load(weight_ptr + column, mask=column < HIDDEN_SIZE, other=0.0).to(
+        tl.float32
+    )
+
+    token = row // HEADS
+    head = row % HEADS
+    z_offsets = (
+        token[:, None] * stride_z_token
+        + head[:, None] * stride_z_head
+        + column[None, :]
+    )
+    z = tl.load(z_ptr + z_offsets, mask=mask, other=0.0).to(tl.float32)
+    output = x * reciprocal_std[:, None] * weight[None, :]
+    output *= z * tl.sigmoid(z)
+    tl.store(
+        output_ptr + row[:, None] * HIDDEN_SIZE + column[None, :],
+        output,
+        mask=mask,
+    )
+
+
+def _launch_config(hidden_size: int, rows: int) -> tuple[int, int]:
+    if hidden_size == 64:
+        return (32 if rows >= _LARGE_CONFIG_ROWS else 16), 4
+    if hidden_size == 96:
+        return (32 if rows >= _LARGE_CONFIG_ROWS else 8), 4
+    if hidden_size == 128:
+        return (16 if rows >= _LARGE_CONFIG_ROWS else 8), 4
+    if hidden_size in (192, 256):
+        return (8 if rows >= _LARGE_CONFIG_ROWS else 4), 4
+    raise ValueError(f"Unsupported GDN RMSNorm hidden size: {hidden_size}")
+
+
+def fused_gdn_rmsnorm_gated(
+    x: torch.Tensor,
+    z: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    """Apply RMSNorm and a strided SiLU gate in one Triton kernel."""
+    hidden_size = x.shape[-1]
+    rows = x.numel() // hidden_size
+    block_m, num_warps = _launch_config(hidden_size, rows)
+    output = torch.empty_like(x)
+    _fused_gdn_rmsnorm_gated_kernel[(triton.cdiv(rows, block_m),)](
+        x,
+        z,
+        weight,
+        output,
+        rows,
+        z.stride(0),
+        z.stride(1),
+        eps,
+        HEADS=x.shape[1],
+        HIDDEN_SIZE=hidden_size,
+        BLOCK_D=triton.next_power_of_2(hidden_size),
+        BLOCK_M=block_m,
+        num_warps=num_warps,
+    )
+    return output
+
+
+def _fused_gdn_rmsnorm_gated_fake(
+    x: torch.Tensor,
+    z: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    return torch.empty_like(x)
+
+
+direct_register_custom_op(
+    op_name="fused_gdn_rmsnorm_gated",
+    op_func=fused_gdn_rmsnorm_gated,
+    mutates_args=[],
+    fake_impl=_fused_gdn_rmsnorm_gated_fake,
+)
+
+
+def fused_gdn_rmsnorm_gated_op(
+    x: torch.Tensor,
+    z: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    return torch.ops.vllm.fused_gdn_rmsnorm_gated(x, z, weight, eps)
+
+
+def try_fused_gdn_rmsnorm_gated(
+    x: torch.Tensor,
+    z: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    group_size: int | None,
+    norm_before_gate: bool,
+    activation: str,
+) -> torch.Tensor | None:
+    """Return the SM103 fast path output, or ``None`` when unsupported."""
+    hidden_size = x.shape[-1]
+    rows = x.numel() // hidden_size
+    eligible = (
+        _IS_SM103
+        and x.dtype == torch.bfloat16
+        and z.dtype == x.dtype
+        and weight.dtype == x.dtype
+        and x.device == z.device == weight.device
+        and x.ndim == 3
+        and x.is_contiguous()
+        and z.shape == x.shape
+        and z.stride(-1) == 1
+        and weight.shape == (hidden_size,)
+        and weight.stride(0) == 1
+        and hidden_size in _SUPPORTED_HIDDEN_SIZES
+        and group_size is None
+        and norm_before_gate
+        and activation in ("silu", "swish")
+        and not (hidden_size in (192, 256) and rows > _MAX_WIDE_DIM_ROWS)
+    )
+    if not eligible:
+        return None
+    return fused_gdn_rmsnorm_gated_op(x, z, weight, eps)


### PR DESCRIPTION
## Summary

Fuse Qwen GDN RMSNorm and strided SiLU gating into one Triton kernel on NVIDIA SM103.

The fast path:

- consumes the three-dimensional projected `z` view directly instead of reshaping/materializing it;
- performs the FP32 RMS reduction, weight scaling, and SiLU gate in one launch;
- supports hidden dimensions 64, 96, 128, 192, and 256 with dimension/row-count-specific launch configurations;
- keeps the existing compiled/native path as the fallback for unsupported devices, dtypes, layouts, dimensions, group norms, gate order, and activations.

The GDN scan and output projection GEMM are unchanged.

## Why this is not duplicate work

I repeated open-PR searches for `RMSNormGated GDN` and `strided RMSNorm gated` before submission.

- #47842 removes an output reshape/copy on ROCm. This PR targets NVIDIA SM103 and optimizes the RMS reduction plus strided SiLU gate itself. It leaves ROCm on the current path.
- #36469 unifies two RMSNormGated module classes but does not add this kernel.
- #38798 ports RMSNormGated into vLLM IR but does not optimize projected strided GDN gates.
- #40921 fixes Dynamo tracing in the existing input guard.
- #46998 is already merged and forms part of the current-main compiled baseline used below.

No open PR was found that implements an SM103 strided RMSNormGated kernel.

## Dispatch and fallback

The optimized path requires:

- NVIDIA compute capability 10.3;
- BF16 contiguous CUDA `x` and BF16 `z`/weight on the same CUDA device;
- three-dimensional `x` and shape-matched `z` with contiguous hidden dimension;
- hidden size in `{64, 96, 128, 192, 256}`;
- no group norm, norm-before-gate, and SiLU/Swish activation.

Dimensions 192 and 256 use the fast path only up to 131,072 rows, where the measured speedup remains at least 18%. Larger configurations retain the compiled native path. Every failed guard follows the existing implementation.

## Correctness

The test matrix covers:

- hidden sizes 64, 96, 128, 192, and 256;
- token counts 1, 17, and 257;
- non-compact projected `z` strides;
- FP32 reference math and BF16 output;
- NaN/Inf checks;
- unsupported hidden sizes, non-CUDA inputs, and large-row fallback;
- FakeTensor output layout;
- Qwen output-projection routing;
- the existing FLA layernorm and Qwen GDN integration suites.

Focused result on B300/SM103:

```text
1580 passed, 14 warnings in 409.72s
```

Across the benchmark matrix, relative L2 error versus the compiled native implementation is `5.05e-6` to `6.98e-6`. The production D=128 case is `5.82e-6` with maximum absolute difference `0.015625`.

## Operator performance

Hardware: NVIDIA B300, compute capability 10.3. Source baseline: official main `5b29c958c`. Runtime: Torch 2.13.0+cu130, Triton 3.7.1, CUDA 13.2 environment.

Command:

```bash
PYTHONPATH=. .venv/bin/python \
  benchmarks/kernels/benchmark_gdn_rmsnorm.py --production-shape
```

| Shape | Compiled native | Existing CUDA | PR | Speedup vs fastest baseline |
|---|---:|---:|---:|---:|
| D64, T2048, H64 | 40.67 us | 44.16 us | 15.36 us | 2.65x |
| D96, T2048, H64 | 48.64 us | 54.37 us | 23.52 us | 2.07x |
| D128, T2048, H64 | 48.96 us | 64.61 us | 25.57 us | 1.91x |
| D192, T2048, H64 | 51.26 us | 95.33 us | 40.93 us | 1.25x |
| D256, T2048, H64 | 49.49 us | 115.74 us | 41.98 us | 1.18x |
| D128, T8192, H64 | 88.86 us | 230.50 us | 74.72 us | 1.19x |

D192/D256 at 262,144 rows measured only 1.08x, so the runtime guard intentionally falls back above 131,072 rows.

## Full-model trace

Model: Qwen3.5-122B-A10B NVFP4 compatibility checkpoint, TP1, BF16 activations, FlashInfer GDN backend, VLLM_CUTLASS MoE backend, 8K prefill + one output token.

| Metric | Current main | PR | Delta |
|---|---:|---:|---:|
| GDN norm/gate launches | 60 | 36 | -24 |
| GDN norm/gate GPU time | 3.366 ms | 2.501 ms | -0.865 ms (-25.7%) |
| Total GPU busy | 187.674 ms | 185.632 ms | -2.042 ms |

Current main emits 24 reduction kernels plus 36 pointwise/gate kernels. The PR emits one `_fused_gdn_rmsnorm_gated_kernel` per GDN layer.

NCU on the production D=128 specialization reports:

```text
duration:             68.640 us
DRAM throughput:      70.87%
compute throughput:   73.42%
achieved occupancy:   65.91%
registers/thread:     40
```

NCU classifies compute and memory as balanced.

## Serving A/B/A

Same Qwen3.5-122B TP1 configuration and VLLM_CUTLASS MoE backend, two warmups and ten measured requests per shape. Values are request-latency medians.

| Input | PR A1 | Main B | PR A2 |
|---:|---:|---:|---:|
| 2K | 70.00 ms | 70.60 ms | 70.75 ms |
| 4K | 107.12 ms | 110.17 ms | 106.97 ms |
| 8K | 196.18 ms | 201.61 ms | 196.33 ms |
| 16K | 389.63 ms | 397.08 ms | 391.01 ms |

The 2K control is within run-to-run noise. Both PR arms improve 4K and 8K by about 2.7-2.9%, and 16K by 1.5-1.9%.

## Model evaluation

Public `Qwen/Qwen3.5-0.8B`, GSM8K 5-shot, all 1,319 questions, greedy, max 256 output tokens, concurrency 128:

| Revision | Accuracy | Invalid |
|---|---:|---:|
| Current main | 32.15% | 0.76% |
| PR | 32.07% | 0.68% |

The -0.08 percentage-point delta is within the predeclared 1.0 percentage-point tolerance.

## Tests and checks

```text
# Existing FLA layernorm matrix + Qwen GDN integration
.venv/bin/python -m pytest \
  tests/kernels/test_fla_layernorm_guard.py \
  tests/kernels/mamba/test_gdn_forward_core_split.py -q
# 1580 passed

# Post-review fast-path/fallback matrix on the rebased branch
.venv/bin/python -m pytest \
  tests/kernels/test_fla_layernorm_guard.py -k strided_gdn -q
# 20 passed

# Changed-file pre-commit suite
pre-commit run --files \
  benchmarks/kernels/benchmark_gdn_rmsnorm.py \
  tests/kernels/test_fla_layernorm_guard.py \
  vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py \
  vllm/model_executor/layers/mamba/ops/gdn_rmsnorm.py
# passed, including ruff, mypy, forbidden-import, and torch-CUDA-call checks
```

## AI assistance disclosure

AI assistance was used for implementation support, benchmark automation, test execution, and result summarization. I reviewed every changed line and remain responsible for the implementation, measurements, and claims in this PR.

