### PR TITLE
[Bugfix][Spec Decode] Make EAGLE weight sharing TP-consistent

### DIFF
--- a/tests/v1/spec_decode/test_eagle.py
+++ b/tests/v1/spec_decode/test_eagle.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
 from unittest import mock
 
 import numpy as np
@@ -31,6 +32,7 @@ from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.spec_decode.dflash import DFlashProposer
 from vllm.v1.spec_decode.draft_model import DraftModelProposer
 from vllm.v1.spec_decode.eagle import EagleProposer
+from vllm.v1.spec_decode.llm_base_proposer import SpecDecodeBaseProposer
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 
@@ -738,6 +740,7 @@ def test_set_inputs_first_pass_parallel_drafting():
 @pytest.mark.parametrize("pp_size", [1, 2])
 @pytest.mark.parametrize("use_distinct_embed_tokens", [True, False])
 @pytest.mark.parametrize("use_distinct_lm_head", [True, False])
+@mock.patch("vllm.v1.spec_decode.llm_base_proposer.get_tp_group")
 @mock.patch("vllm.v1.spec_decode.llm_base_proposer.get_pp_group")
 @mock.patch("vllm.v1.spec_decode.llm_base_proposer.get_layers_from_vllm_config")
 @mock.patch("vllm.v1.spec_decode.llm_base_proposer.get_model")
@@ -745,6 +748,7 @@ def test_load_model(
     mock_get_model,
     mock_get_layers,
     mock_get_pp_group,
+    mock_get_tp_group,
     method,
     attn_backend,
     pp_size,
@@ -791,6 +795,10 @@ def test_load_model(
     mock_pp_group.world_size = pp_size
     mock_get_pp_group.return_value = mock_pp_group
 
+    mock_tp_group = mock.MagicMock()
+    mock_tp_group.world_size = 1
+    mock_get_tp_group.return_value = mock_tp_group
+
     # Set up the target model mock with a custom class so that
     # isinstance() checks match the expected type.
     class _TargetModelStub(LlamaForCausalLM):
@@ -829,6 +837,58 @@ def test_load_model(
         assert proposer.model.model.embed_tokens is not target_model.model.embed_tokens
     else:
         assert proposer.model.model.embed_tokens is target_model.model.embed_tokens
+
+
+@pytest.mark.parametrize("global_vote", [0, 1])
+@mock.patch("vllm.v1.spec_decode.llm_base_proposer.get_tp_group")
+@mock.patch("vllm.v1.spec_decode.llm_base_proposer.get_pp_group")
+def test_eagle_weight_sharing_requires_all_tp_shards_to_match(
+    mock_get_pp_group,
+    mock_get_tp_group,
+    global_vote,
+    monkeypatch,
+):
+    mock_get_pp_group.return_value = SimpleNamespace(world_size=1)
+    cpu_group = object()
+    mock_get_tp_group.return_value = SimpleNamespace(world_size=2, cpu_group=cpu_group)
+
+    def all_reduce(vote, *, op, group):
+        assert vote.item() == 1
+        assert vote.device.type == "cpu"
+        assert op == torch.distributed.ReduceOp.MIN
+        assert group is cpu_group
+        vote.fill_(global_vote)
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", all_reduce)
+
+    target_embed = SimpleNamespace(weight=torch.ones(4, 2))
+    target_lm_head = SimpleNamespace(weight=torch.ones(4, 2))
+    draft_embed = SimpleNamespace(weight=torch.ones(4, 2))
+    draft_lm_head = SimpleNamespace(weight=torch.ones(4, 2))
+
+    proposer = object.__new__(SpecDecodeBaseProposer)
+    proposer.vllm_config = SimpleNamespace(speculative_config=None)
+    proposer.use_local_argmax_reduction = False
+    proposer.model = SimpleNamespace(
+        has_own_embed_tokens=True,
+        has_own_lm_head=True,
+        model=SimpleNamespace(embed_tokens=draft_embed),
+        lm_head=draft_lm_head,
+    )
+    target_model = SimpleNamespace(
+        model=SimpleNamespace(embed_tokens=target_embed),
+        lm_head=target_lm_head,
+    )
+
+    proposer._maybe_share_embeddings(target_model)
+    proposer._maybe_share_lm_head(target_model)
+
+    if global_vote:
+        assert proposer.model.model.embed_tokens is target_embed
+        assert proposer.model.lm_head is target_lm_head
+    else:
+        assert proposer.model.model.embed_tokens is draft_embed
+        assert proposer.model.lm_head is draft_lm_head
 
 
 @pytest.mark.parametrize("method", ["eagle", "eagle3"])

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from vllm.v1.spec_decode.vocab_mapping import VocabMapping
 
 from vllm.distributed.eplb.eplb_state import EplbState
-from vllm.distributed.parallel_state import get_pp_group
+from vllm.distributed.parallel_state import get_pp_group, get_tp_group
 from vllm.forward_context import set_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
@@ -1418,6 +1418,20 @@ class SpecDecodeBaseProposer:
             else:
                 self.parallel_drafting_hidden_state_tensor.copy_(flat_mask)
 
+    @staticmethod
+    def _all_tp_ranks_agree(local_decision: bool) -> bool:
+        tp_group = get_tp_group()
+        if tp_group.world_size == 1:
+            return local_decision
+
+        decision = torch.tensor(local_decision, dtype=torch.int32, device="cpu")
+        torch.distributed.all_reduce(
+            decision,
+            op=torch.distributed.ReduceOp.MIN,
+            group=tp_group.cpu_group,
+        )
+        return bool(decision.item())
+
     def _maybe_share_embeddings(self, target_language_model: nn.Module) -> None:
         """
         Some draft models may not have their own embedding layers, and some may
@@ -1441,14 +1455,7 @@ class SpecDecodeBaseProposer:
             share_embeddings = False
             if hasattr(self.model, "has_own_embed_tokens"):
                 # EAGLE model
-                if not self.model.has_own_embed_tokens:
-                    share_embeddings = True
-                    logger.info(
-                        "Detected EAGLE model without its own embed_tokens in the"
-                        " checkpoint. Sharing target model embedding weights with the"
-                        " draft model."
-                    )
-                elif (
+                if not self.model.has_own_embed_tokens or (
                     isinstance(target_embed_tokens.weight, torch.Tensor)
                     and isinstance(self.model.model.embed_tokens.weight, torch.Tensor)
                     # TODO: Offload to CPU for comparison to avoid extra GPU memory
@@ -1459,11 +1466,21 @@ class SpecDecodeBaseProposer:
                     )
                 ):
                     share_embeddings = True
-                    logger.info(
-                        "Detected EAGLE model with embed_tokens identical to the target"
-                        " model. Sharing target model embedding weights with the draft"
-                        " model."
-                    )
+
+                share_embeddings = self._all_tp_ranks_agree(share_embeddings)
+                if share_embeddings:
+                    if self.model.has_own_embed_tokens:
+                        logger.info(
+                            "Detected EAGLE model with embed_tokens identical to the"
+                            " target model. Sharing target model embedding weights"
+                            " with the draft model."
+                        )
+                    else:
+                        logger.info(
+                            "Detected EAGLE model without its own embed_tokens in the"
+                            " checkpoint. Sharing target model embedding weights with"
+                            " the draft model."
+                        )
                 else:
                     logger.info(
                         "Detected EAGLE model with distinct embed_tokens weights. "
@@ -1520,13 +1537,7 @@ class SpecDecodeBaseProposer:
         share_lm_head = False
         if hasattr(self.model, "has_own_lm_head"):
             # EAGLE model
-            if not self.model.has_own_lm_head:
-                share_lm_head = True
-                logger.info(
-                    "Detected EAGLE model without its own lm_head in the checkpoint. "
-                    "Sharing target model lm_head weights with the draft model."
-                )
-            elif (
+            if not self.model.has_own_lm_head or (
                 hasattr(target_language_model, "lm_head")
                 and hasattr(target_language_model.lm_head, "weight")
                 and hasattr(self.model.lm_head, "weight")
@@ -1540,10 +1551,21 @@ class SpecDecodeBaseProposer:
                 )
             ):
                 share_lm_head = True
-                logger.info(
-                    "Detected EAGLE model with lm_head identical to the target model. "
-                    "Sharing target model lm_head weights with the draft model."
-                )
+
+            share_lm_head = self._all_tp_ranks_agree(share_lm_head)
+            if share_lm_head:
+                if self.model.has_own_lm_head:
+                    logger.info(
+                        "Detected EAGLE model with lm_head identical to the target"
+                        " model. Sharing target model lm_head weights with the draft"
+                        " model."
+                    )
+                else:
+                    logger.info(
+                        "Detected EAGLE model without its own lm_head in the"
+                        " checkpoint. Sharing target model lm_head weights with the"
+                        " draft model."
+                    )
             else:
                 logger.info(
                     "Detected EAGLE model with distinct lm_head weights. "


### PR DESCRIPTION
## Purpose

Addresses the rank-divergent EAGLE weight-sharing decision described in #50158. The issue stays open: real-hardware runs (see discussion below) show the acceptance collapse reported there persists after this fix and has a separate root cause that is still under investigation.

EAGLE currently decides whether to share the target model's `embed_tokens` and `lm_head` by comparing each tensor-parallel rank's local shards independently. If equality differs across ranks, some ranks replace the draft module with the target module while others keep the draft weights. The ranks then build different drafters, which can severely reduce speculative acceptance.

This change requires unanimous TP-wide agreement before sharing either module. Each rank contributes its local decision to a CPU-group `MIN` reduction, so any mismatch keeps the draft weights on every rank. TP size 1 preserves the existing fast path without a collective. The regression test covers both unanimous agreement and one-rank mismatch for `embed_tokens` and `lm_head`.

The change is limited to the existing EAGLE weight-sharing decisions. The collectives occur in the same fixed model-load order on every TP rank and do not affect inference-time execution.

## Test Plan

```bash
pytest -q tests/v1/spec_decode/test_eagle.py::test_eagle_weight_sharing_requires_all_tp_shards_to_match
pre-commit run --files vllm/v1/spec_decode/llm_base_proposer.py tests/v1/spec_decode/test_eagle.py
```

## Test Result

- Targeted regression test: `2 passed`. On macOS, the platform backend list was patched to a non-empty value before module collection; the test itself mocks the TP CPU-group reduction.
- All applicable pre-commit hooks passed on both changed files, including Ruff, formatting, typos, mypy, SPDX, import checks, and forbidden-import checks.
- Real-hardware validation (community, 2x RTX 3090, TP=2, see discussion): the consensus mechanism works as designed — both ranks now log the same verdict where stock vLLM disagreed on every boot; no measurable perf change. The acceptance collapse from #50158 is unaffected by this change (separate root cause, tracked in the open issue).

AI assistance: OpenAI Codex was used for analysis, implementation, testing, and PR preparation. All changes were reviewed by the submitter.
