### PR TITLE
perf(rocm): fuse Kimi-K3 B1 pre-route and shared-expert projections

### DIFF
--- a/tests/model_executor/layers/fused_moe/test_shared_experts.py
+++ b/tests/model_executor/layers/fused_moe/test_shared_experts.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+import vllm.model_executor.layers.fused_moe.runner.shared_experts as shared_module
+from vllm.model_executor.layers.fused_moe.runner.shared_experts import (
+    SharedExperts,
+    SharedExpertsOrder,
+)
+
+
+def _make_shared_experts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> SharedExperts:
+    monkeypatch.setattr(
+        shared_module,
+        "dbo_current_ubatch_id",
+        lambda: 0,
+    )
+    shared = SharedExperts.__new__(SharedExperts)
+    torch.nn.Module.__init__(shared)
+    shared.enable_dbo = False
+    shared._output = [None, None]
+    shared._precomputed_output = [None, None]
+    shared._layer = lambda tensor: tensor + 1
+    shared._determine_shared_experts_order = lambda _: SharedExpertsOrder.NO_OVERLAP
+    return shared
+
+
+def test_precomputed_output_bypasses_layer_and_is_consumed_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shared = _make_shared_experts(monkeypatch)
+    precomputed = torch.randn(2, 4)
+
+    with shared.use_precomputed_output(precomputed):
+        shared.maybe_sync_shared_experts_stream(torch.empty_like(precomputed))
+        shared(
+            torch.empty_like(precomputed),
+            SharedExpertsOrder.NO_OVERLAP,
+        )
+        assert shared.output is precomputed
+
+    assert shared._output == [None, None]
+    assert shared._precomputed_output == [None, None]
+
+
+def test_precomputed_output_rejects_collision_and_cleans_up_on_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shared = _make_shared_experts(monkeypatch)
+
+    with (
+        pytest.raises(RuntimeError, match="downstream failure"),
+        shared.use_precomputed_output(torch.zeros(1)),
+    ):
+        with (
+            pytest.raises(RuntimeError, match="already occupied"),
+            shared.use_precomputed_output(torch.ones(1)),
+        ):
+            pass
+        raise RuntimeError("downstream failure")
+
+    assert shared._output == [None, None]
+    assert shared._precomputed_output == [None, None]
+
+
+def test_normal_shared_expert_path_is_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shared = _make_shared_experts(monkeypatch)
+    hidden = torch.randn(2, 4)
+
+    shared(hidden, SharedExpertsOrder.NO_OVERLAP)
+
+    torch.testing.assert_close(shared.output, hidden + 1)

--- a/tests/models/kimi_k3/test_amd_moe_preroute.py
+++ b/tests/models/kimi_k3/test_amd_moe_preroute.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from vllm.platforms import current_platform
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_rocm(),
+    reason="Kimi-K3 BF16 pre-route fusion requires ROCm",
+)
+
+
+def test_preroute_factory_owns_model_eligibility(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm.models.kimi_k3.amd.ops.moe_preroute import (
+        KimiK3PrerouteBf16,
+    )
+
+    monkeypatch.setattr(
+        KimiK3PrerouteBf16,
+        "is_backend_available",
+        staticmethod(lambda: True),
+    )
+    supported = {
+        "use_latent_moe": True,
+        "tensor_parallel_size": 8,
+        "shared_experts": object(),
+        "routed_projection": object(),
+        "situ_beta": 4.0,
+        "situ_linear_beta": 25.0,
+        "lora_enabled": False,
+    }
+    assert KimiK3PrerouteBf16.create_if_supported(**supported) is not None
+
+    unsupported = (
+        {"use_latent_moe": False},
+        {"tensor_parallel_size": 4},
+        {"shared_experts": None},
+        {"routed_projection": None},
+        {"situ_beta": None},
+        {"situ_linear_beta": None},
+        {"lora_enabled": True},
+    )
+    for override in unsupported:
+        config = supported | override
+        assert KimiK3PrerouteBf16.create_if_supported(**config) is None
+
+
+def _relative_rmse(
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+) -> float:
+    error = (actual.float() - expected.float()).square().mean().sqrt()
+    reference = expected.float().square().mean().sqrt().clamp_min(1e-12)
+    return (error / reference).item()
+
+
+def test_amd_moe_preroute_bf16_matches_reference() -> None:
+    from aiter.jit.utils.chip_info import get_gfx_runtime
+    from aiter.ops.flydsl.utils import is_flydsl_available
+
+    from vllm.models.kimi_k3.amd.ops.moe_preroute import (
+        KimiK3PrerouteBf16,
+    )
+
+    if not is_flydsl_available() or get_gfx_runtime() != "gfx950":
+        pytest.skip("requires FlyDSL on gfx950")
+
+    torch.manual_seed(20260729)
+    hidden = torch.randn(
+        (1, 7168),
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    routed_weight = torch.randn(
+        (3584, 7168),
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    shared_gate_up_weight = torch.randn(
+        (1536, 7168),
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    shared_down_weight = torch.randn(
+        (7168, 768),
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    original_hidden = hidden.clone()
+
+    preroute = KimiK3PrerouteBf16(
+        situ_beta=4.0,
+        situ_linear_beta=25.0,
+    )
+    output = preroute(
+        hidden,
+        routed_weight,
+        shared_gate_up_weight,
+        shared_down_weight,
+    )
+    assert output is not None
+    routed, shared = output
+
+    routed_reference = F.linear(
+        hidden.float(),
+        routed_weight.float(),
+    ).to(torch.bfloat16)
+    gate_up_reference = F.linear(
+        hidden.float(),
+        shared_gate_up_weight.float(),
+    ).to(torch.bfloat16)
+    gate, up = gate_up_reference.float().chunk(2, dim=-1)
+    activated = (
+        4.0
+        * torch.tanh(gate / 4.0)
+        * torch.sigmoid(gate)
+        * 25.0
+        * torch.tanh(up / 25.0)
+    ).to(torch.bfloat16)
+    shared_reference = F.linear(
+        activated.float(),
+        shared_down_weight.float(),
+    ).to(torch.bfloat16)
+
+    assert _relative_rmse(routed, routed_reference) < 2e-4
+    assert _relative_rmse(shared, shared_reference) < 2e-4
+    torch.testing.assert_close(
+        hidden,
+        original_hidden,
+        atol=0,
+        rtol=0,
+    )
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = preroute(
+            hidden,
+            routed_weight,
+            shared_gate_up_weight,
+            shared_down_weight,
+        )
+    assert captured is not None
+    captured_routed, captured_shared = captured
+    graph.replay()
+    expected_routed = captured_routed.clone()
+    expected_shared = captured_shared.clone()
+    graph.replay()
+    torch.testing.assert_close(
+        captured_routed,
+        expected_routed,
+        atol=0,
+        rtol=0,
+    )
+    torch.testing.assert_close(
+        captured_shared,
+        expected_shared,
+        atol=0,
+        rtol=0,
+    )

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -270,6 +270,7 @@ if TYPE_CHECKING:
     VLLM_GC_DEBUG: str = ""
     VLLM_DEBUG_WORKSPACE: bool = False
     VLLM_ENABLE_K3_LATENT_MOE_TAIL_FUSION: bool = False
+    VLLM_ROCM_USE_KIMI_K3_PREROUTE_BF16: bool = False
     VLLM_DISABLE_SHARED_EXPERTS_STREAM: bool = False
     VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD: int = 256
     VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD: int = 1024
@@ -1899,6 +1900,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Currently supported only on SM100 with TP=8/16 and BF16.
     "VLLM_ENABLE_K3_LATENT_MOE_TAIL_FUSION": lambda: bool(
         int(os.getenv("VLLM_ENABLE_K3_LATENT_MOE_TAIL_FUSION", "0"))
+    ),
+    # Enable the exact-BF16 Kimi-K3 B1 pre-route fusion on gfx950.
+    "VLLM_ROCM_USE_KIMI_K3_PREROUTE_BF16": lambda: bool(
+        int(os.getenv("VLLM_ROCM_USE_KIMI_K3_PREROUTE_BF16", "0"))
     ),
     # Disables parallel execution of shared_experts via separate cuda stream
     "VLLM_DISABLE_SHARED_EXPERTS_STREAM": lambda: bool(

--- a/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
+++ b/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from collections.abc import Callable
+from collections.abc import Callable, Generator
+from contextlib import contextmanager
 from enum import IntEnum
 
 import torch
@@ -52,6 +53,7 @@ class SharedExperts(torch.nn.Module):
         # index is always 0 and the second output list element is ignored.
         self.enable_dbo = enable_dbo
         self._output: list[torch.Tensor | None] = [None, None]
+        self._precomputed_output: list[torch.Tensor | None] = [None, None]
         self._layer = layer
         self._moe_config = moe_config
 
@@ -112,6 +114,8 @@ class SharedExperts(torch.nn.Module):
         self,
         shared_experts_input: torch.Tensor,
     ):
+        if self._precomputed_output[self._output_idx] is not None:
+            return
         experts_order = self._determine_shared_experts_order(shared_experts_input)
 
         if experts_order == SharedExpertsOrder.MULTI_STREAM_OVERLAPPED:
@@ -147,16 +151,43 @@ class SharedExperts(torch.nn.Module):
 
     @property
     def output(self) -> torch.Tensor:
-        assert self._output[self._output_idx] is not None
-        output = self._output[self._output_idx]
-        self._output[self._output_idx] = None
+        output_idx = self._output_idx
+        precomputed_output = self._precomputed_output[output_idx]
+        if precomputed_output is not None:
+            self._precomputed_output[output_idx] = None
+            return precomputed_output
+
+        assert self._output[output_idx] is not None
+        output = self._output[output_idx]
+        self._output[output_idx] = None
         return output
+
+    @contextmanager
+    def use_precomputed_output(
+        self,
+        output: torch.Tensor,
+    ) -> Generator[None, None, None]:
+        """Use a shared-expert output produced by an enclosing fusion."""
+
+        output_idx = self._output_idx
+        if (
+            self._output[output_idx] is not None
+            or self._precomputed_output[output_idx] is not None
+        ):
+            raise RuntimeError("shared expert output slot is already occupied")
+        self._precomputed_output[output_idx] = output
+        try:
+            yield
+        finally:
+            self._precomputed_output[output_idx] = None
 
     def forward(
         self,
         shared_experts_input: torch.Tensor,
         order: SharedExpertsOrder,
     ):
+        if self._precomputed_output[self._output_idx] is not None:
+            return None
         experts_order = self._determine_shared_experts_order(shared_experts_input)
 
         if order != experts_order:

--- a/vllm/models/kimi_k3/amd/linear.py
+++ b/vllm/models/kimi_k3/amd/linear.py
@@ -7,6 +7,7 @@ from typing import Any
 import torch
 from torch import nn
 
+import vllm.envs as envs
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import (
     get_pp_group,
@@ -62,6 +63,9 @@ from vllm.model_executor.models.utils import (
     maybe_prefix,
 )
 from vllm.models.kimi_k3.amd.ops.attn_res import attn_res
+from vllm.models.kimi_k3.amd.ops.moe_preroute import (
+    KimiK3PrerouteBf16,
+)
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
 from vllm.utils.math_utils import cdiv
@@ -200,6 +204,8 @@ class KimiMoE(nn.Module):
         activation_situ_linear_beta = (
             config.activation_situ_linear_beta if config.hidden_act == "situ" else None
         )
+        self.activation_situ_beta = activation_situ_beta
+        self.activation_situ_linear_beta = activation_situ_linear_beta
 
         # Route with fp32 logits for numerically stable expert selection.
         self.gate = GateLinear(
@@ -294,13 +300,52 @@ class KimiMoE(nn.Module):
                 moe_intermediate_size // self.tp_size
             )
 
+        self._preroute_bf16: KimiK3PrerouteBf16 | None = None
+        if envs.VLLM_ROCM_USE_KIMI_K3_PREROUTE_BF16:
+            self._preroute_bf16 = KimiK3PrerouteBf16.create_if_supported(
+                use_latent_moe=self.use_latent_moe,
+                tensor_parallel_size=self.tp_size,
+                shared_experts=self.shared_experts,
+                routed_projection=self.routed_expert_down_proj,
+                situ_beta=activation_situ_beta,
+                situ_linear_beta=activation_situ_linear_beta,
+                lora_enabled=self.experts.moe_config.is_lora_enabled,
+            )
+            if self._preroute_bf16 is None:
+                logger.warning_once(
+                    "Kimi-K3 BF16 pre-route fusion is unavailable for this "
+                    "configuration; using the existing projection path."
+                )
+
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         num_tokens, hidden_size = hidden_states.shape
         hidden_states = hidden_states.view(-1, hidden_size)
         router_logits, _ = self.gate(hidden_states)
-        final_hidden_states = self.experts(
-            hidden_states=hidden_states, router_logits=router_logits
-        )
+        preroute_output = None
+        if self._preroute_bf16 is not None:
+            assert self.routed_expert_down_proj is not None
+            assert self.shared_experts is not None
+            preroute_output = self._preroute_bf16(
+                hidden_states,
+                self.routed_expert_down_proj.weight,
+                self.shared_experts.gate_up_proj.weight,
+                self.shared_experts.down_proj.weight,
+            )
+        if preroute_output is None:
+            final_hidden_states = self.experts(
+                hidden_states=hidden_states,
+                router_logits=router_logits,
+            )
+        else:
+            routed_hidden_states, shared_output = preroute_output
+            shared_experts = self.experts.shared_experts
+            assert shared_experts is not None
+            with shared_experts.use_precomputed_output(shared_output):
+                final_hidden_states = self.experts(
+                    hidden_states=routed_hidden_states,
+                    router_logits=router_logits,
+                    shared_experts_input=hidden_states,
+                )
         return final_hidden_states.view(num_tokens, hidden_size)
 
 

--- a/vllm/models/kimi_k3/amd/ops/moe_preroute.py
+++ b/vllm/models/kimi_k3/amd/ops/moe_preroute.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Kimi-K3 AMD pre-route projection fusion."""
+
+import torch
+from torch import nn
+
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import direct_register_custom_op
+
+
+def supports_kimi_k3_preroute_bf16(
+    hidden_states: torch.Tensor,
+    routed_weight: torch.Tensor,
+    shared_gate_up_weight: torch.Tensor,
+    shared_down_weight: torch.Tensor,
+) -> bool:
+    """Return whether AITER supports the exact-BF16 B1 projection cluster."""
+
+    try:
+        from aiter.ops.flydsl.kimi_k3_moe_preroute_bf16 import (
+            supports_kimi_k3_moe_preroute_bf16,
+        )
+    except (ImportError, ModuleNotFoundError):
+        return False
+
+    return supports_kimi_k3_moe_preroute_bf16(
+        hidden_states,
+        routed_weight,
+        shared_gate_up_weight,
+        shared_down_weight,
+    )
+
+
+def _kimi_k3_preroute_bf16_impl(
+    hidden_states: torch.Tensor,
+    routed_weight: torch.Tensor,
+    shared_gate_up_weight: torch.Tensor,
+    shared_down_weight: torch.Tensor,
+    situ_beta: float,
+    situ_linear_beta: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    from aiter.ops.flydsl.kimi_k3_moe_preroute_bf16 import (
+        kimi_k3_moe_preroute_bf16,
+    )
+
+    return kimi_k3_moe_preroute_bf16(
+        hidden_states,
+        routed_weight,
+        shared_gate_up_weight,
+        shared_down_weight,
+        situ_beta,
+        situ_linear_beta,
+    )
+
+
+def _kimi_k3_preroute_bf16_fake(
+    hidden_states: torch.Tensor,
+    routed_weight: torch.Tensor,
+    shared_gate_up_weight: torch.Tensor,
+    shared_down_weight: torch.Tensor,
+    situ_beta: float,
+    situ_linear_beta: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del shared_gate_up_weight, shared_down_weight, situ_beta, situ_linear_beta
+    return (
+        hidden_states.new_empty((hidden_states.shape[0], routed_weight.shape[0])),
+        hidden_states.new_empty(hidden_states.shape),
+    )
+
+
+direct_register_custom_op(
+    op_name="kimi_k3_preroute_bf16",
+    op_func=_kimi_k3_preroute_bf16_impl,
+    mutates_args=[],
+    fake_impl=_kimi_k3_preroute_bf16_fake,
+    dispatch_key=current_platform.dispatch_key,
+)
+
+
+class KimiK3PrerouteBf16(nn.Module):
+    """Compile-safe wrapper for the fixed-shape AITER fusion."""
+
+    def __init__(
+        self,
+        situ_beta: float,
+        situ_linear_beta: float,
+    ) -> None:
+        super().__init__()
+        self.situ_beta = situ_beta
+        self.situ_linear_beta = situ_linear_beta
+
+    @staticmethod
+    def is_backend_available() -> bool:
+        from vllm._aiter_ops import rocm_aiter_ops
+
+        if not rocm_aiter_ops.is_enabled():
+            return False
+        try:
+            from aiter.ops.flydsl.kimi_k3_moe_preroute_bf16 import (
+                is_kimi_k3_moe_preroute_bf16_available,
+            )
+        except (ImportError, ModuleNotFoundError):
+            return False
+        return is_kimi_k3_moe_preroute_bf16_available()
+
+    @classmethod
+    def create_if_supported(
+        cls,
+        *,
+        use_latent_moe: bool,
+        tensor_parallel_size: int,
+        shared_experts: object | None,
+        routed_projection: object | None,
+        situ_beta: float | None,
+        situ_linear_beta: float | None,
+        lora_enabled: bool,
+    ) -> "KimiK3PrerouteBf16 | None":
+        """Create the specialization only for its complete model contract."""
+
+        if not (
+            cls.is_backend_available()
+            and use_latent_moe
+            and tensor_parallel_size == 8
+            and shared_experts is not None
+            and routed_projection is not None
+            and situ_beta is not None
+            and situ_linear_beta is not None
+            and not lora_enabled
+        ):
+            return None
+        return cls(situ_beta, situ_linear_beta)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        routed_weight: torch.Tensor,
+        shared_gate_up_weight: torch.Tensor,
+        shared_down_weight: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor] | None:
+        if not supports_kimi_k3_preroute_bf16(
+            hidden_states,
+            routed_weight,
+            shared_gate_up_weight,
+            shared_down_weight,
+        ):
+            return None
+        return torch.ops.vllm.kimi_k3_preroute_bf16(
+            hidden_states,
+            routed_weight,
+            shared_gate_up_weight,
+            shared_down_weight,
+            self.situ_beta,
+            self.situ_linear_beta,
+        )


### PR DESCRIPTION
# Proposed vLLM PR

Title:

`perf(rocm): fuse Kimi-K3 B1 pre-route and shared-expert projections`

Depends on ROCm/aiter#4442.

## Summary

Integrate the AITER exact-BF16 Kimi-K3 pre-route specialization behind one
ROCm opt-in:

`VLLM_ROCM_USE_KIMI_K3_PREROUTE_BF16=1`

The fusion returns the routed latent activation and the already-computed
shared-expert output. The existing MoE runner consumes both without repeating
shared gate/up, SiTU, or shared-down work.

## Design

`KimiK3PrerouteBf16.create_if_supported` owns the complete construction-time
eligibility policy:

- AITER ROCm backend enabled;
- FlyDSL available on gfx950;
- latent MoE;
- TP8;
- shared experts and routed-down projection present;
- SiTU parameters present;
- LoRA disabled.

The Kimi forward path has one optional specialization call. Tensor-level
shape/dtype/layout checks remain in AITER and return `None` to the existing
path when the runtime contract is not satisfied.

`SharedExperts.use_precomputed_output` is a small backend-neutral ownership
mechanism:

- one output slot per DBO microbatch;
- collision detection;
- one-shot consumption through the existing `output` property;
- exception-safe cleanup;
- unchanged ordinary shared-expert execution when no value is installed.

No parameter is re-registered or duplicated. The specialization receives the
existing projection weights as explicit custom-op inputs, so checkpoint
loading and state dicts are unchanged.

## Performance

Kimi-K3 TP8, batch 1, 8K input / 1K output, no speculative decoding:

- accepted control: 60.9086 tok/s, 16.4180 ms mean TPOT;
- candidate run 1: 64.0798 tok/s;
- candidate run 2: 64.4691 tok/s;
- candidate mean: 64.2744 tok/s;
- uplift: +5.53%;
- measured saving: 0.8596 ms/token;
- launch reduction: 184/token.

## Fallback and NVIDIA impact

The environment variable defaults off. Unsupported configurations log once
at construction and use the existing projection path.

The code change is confined to the AMD Kimi implementation plus the generic
`SharedExperts` one-shot output slot. When the slot is empty, the ordinary
control flow and kernels are unchanged. No NVIDIA module, kernel, import, or
runner-selection code changes.

## Tests

- `test_amd_moe_preroute.py`
  - construction policy ownership;
  - gfx950 output accuracy;
  - input immutability.
- `test_shared_experts.py`
  - precomputed output bypass and one-shot consumption;
  - collision rejection;
  - exception cleanup;
  - unchanged ordinary path.

Validation:

- [x] ruff
- [x] format
- [x] Python compilation
- [x] diff check
- [x] focused pytest in pinned ROCm image (5 passed)
- [x] graph capture/replay on gfx950
- [x] frozen GSM8K gate: 0.943139 accuracy, 0.001516 invalid rate

The frozen gate uses all 1319 GSM8K questions, 5-shot prompts, temperature 0,
seed 42, max concurrency 1, and the completion API. The result SHA-256 is
`dc402c40c86bd8dd863ff3dbbb26e2c6295151cca6a557027729a2e561b70dfc`.
