### PR TITLE
[SM120] Add NVFP4 KV cache support for consumer Blackwell (RTX 5090)

### DIFF
--- a/csrc/libtorch_stable/nvfp4_kv_cache_kernels.cu
+++ b/csrc/libtorch_stable/nvfp4_kv_cache_kernels.cu
@@ -218,9 +218,7 @@ void reshape_and_cache_nvfp4_dispatch(torch::stable::Tensor& key,
   // its 4-token V scale swizzle. Both consume the same per-page
   // [K_data | K_scale | V_data | V_scale] layout, so only the V-scale
   // swizzle is arch-conditional.
-  cudaDeviceProp dev_prop;
-  cudaGetDeviceProperties(&dev_prop, key.get_device_index());
-  const bool swizzle_v_sf = dev_prop.major < 12;
+  const bool swizzle_v_sf = get_device_prop()->major < 12;
 
   STD_TORCH_CHECK(!swizzle_v_sf || block_size % 4 == 0,
                   "block_size must be divisible by 4 for NVFP4 KV cache V "

--- a/csrc/libtorch_stable/nvfp4_kv_cache_kernels.cu
+++ b/csrc/libtorch_stable/nvfp4_kv_cache_kernels.cu
@@ -62,9 +62,11 @@ __global__ void reshape_and_cache_nvfp4_kernel(
     const int64_t data_block_stride,         // data cache stride for dim 0
     const int64_t data_head_stride,          // data cache stride for heads
     const int64_t data_block_offset_stride,  // data cache stride for tokens
-    const int64_t scale_block_stride,        // scale cache stride for dim 0
-    const int64_t scale_head_stride,         // scale cache stride for heads
-    const int64_t scale_block_offset_stride  // scale cache stride for tokens
+    const int64_t scale_block_stride,         // scale cache stride for dim 0
+    const int64_t scale_head_stride,          // scale cache stride for heads
+    const int64_t scale_block_offset_stride,  // scale cache stride for tokens
+    const bool swizzle_v_sf  // V scale layout: true = SM100 trtllm-gen 4-token
+                             // swizzle; false = linear (FlashInfer FA2 sm12x)
 ) {
   using CudaType = typename CUDATypeConverter<scalar_t>::Type;
   using PVec = PackedVec<CudaType, CVT_FP4_PACK16>;
@@ -153,12 +155,14 @@ __global__ void reshape_and_cache_nvfp4_kernel(
 #endif
 
       // Write block scale to scale cache.
-      // K (kv==0): linear layout (no swizzle).
-      // V (kv==1): swizzled layout for SM100 trtllm-gen MHA kernel.
+      // K (kv==0): always linear layout (no swizzle).
+      // V (kv==1): swizzled layout for the SM100 trtllm-gen MHA kernel when
+      //   swizzle_v_sf is true; linear (same as K) when false, which the
+      //   FlashInfer FA2 paged nvfp4 reader on sm120/sm121 requires.
       if (sf_out_ptr != nullptr) {
         int scale_idx = group_in_head;
         uint8_t* __restrict__ scale_dst;
-        if (kv == 0) {
+        if (kv == 0 || !swizzle_v_sf) {
           scale_dst = scale_block + head * scale_head_stride +
                       block_offset * scale_block_offset_stride + scale_idx;
         } else {
@@ -207,9 +211,20 @@ void reshape_and_cache_nvfp4_dispatch(torch::stable::Tensor& key,
 
   STD_TORCH_CHECK(head_size % 16 == 0,
                   "head_size must be divisible by 16 for NVFP4 KV cache");
-  STD_TORCH_CHECK(block_size % 4 == 0,
-                  "block_size must be divisible by 4 for NVFP4 KV cache "
-                  "swizzle");
+
+  // SM120/SM121 (consumer Blackwell) serve NVFP4 KV via the FlashInfer FA2
+  // paged reader, which takes the scale-factor strides from the SF tensor
+  // itself and reads V scales linearly; the SM100 trtllm-gen reader keeps
+  // its 4-token V scale swizzle. Both consume the same per-page
+  // [K_data | K_scale | V_data | V_scale] layout, so only the V-scale
+  // swizzle is arch-conditional.
+  cudaDeviceProp dev_prop;
+  cudaGetDeviceProperties(&dev_prop, key.get_device_index());
+  const bool swizzle_v_sf = dev_prop.major < 12;
+
+  STD_TORCH_CHECK(!swizzle_v_sf || block_size % 4 == 0,
+                  "block_size must be divisible by 4 for NVFP4 KV cache V "
+                  "scale-factor swizzle (SM100 trtllm-gen path)");
 
   // Detect physical layout from strides (based on full_dim).
   // HND: head stride > block_offset stride.
@@ -272,6 +287,6 @@ void reshape_and_cache_nvfp4_dispatch(torch::stable::Tensor& key,
                 k_scale_ptr, v_scale_ptr, key.stride(0), value.stride(0),
                 num_heads, head_size, block_size, data_block_stride,
                 data_head_stride, data_block_offset_stride, scale_block_stride,
-                scale_head_stride, scale_block_offset_stride);
+                scale_head_stride, scale_block_offset_stride, swizzle_v_sf);
       });
 }

--- a/csrc/libtorch_stable/nvfp4_kv_cache_kernels.cu
+++ b/csrc/libtorch_stable/nvfp4_kv_cache_kernels.cu
@@ -343,9 +343,7 @@ void reshape_and_cache_nvfp4_dispatch(
   // its 4-token V scale swizzle. Both consume the same per-page
   // [K_data | K_scale | V_data | V_scale] layout, so only the V-scale
   // swizzle is arch-conditional.
-  cudaDeviceProp dev_prop;
-  cudaGetDeviceProperties(&dev_prop, key.get_device_index());
-  const bool swizzle_v_sf = dev_prop.major < 12;
+  const bool swizzle_v_sf = get_device_prop()->major < 12;
 
   STD_TORCH_CHECK(!swizzle_v_sf || block_size % 4 == 0,
                   "block_size must be divisible by 4 for NVFP4 KV cache V "

--- a/csrc/libtorch_stable/nvfp4_kv_cache_kernels.cu
+++ b/csrc/libtorch_stable/nvfp4_kv_cache_kernels.cu
@@ -400,15 +400,37 @@ void reshape_and_cache_nvfp4_dispatch(
 
   VLLM_STABLE_DISPATCH_HALF_TYPES(
       key.scalar_type(), "reshape_and_cache_nvfp4", [&] {
-        vllm::reshape_and_cache_nvfp4_kernel<scalar_t>
-            <<<grid, block, 0, stream>>>(
-                key.const_data_ptr<scalar_t>(),
-                value.const_data_ptr<scalar_t>(),
-                key_cache.mutable_data_ptr<uint8_t>(),
-                value_cache.mutable_data_ptr<uint8_t>(), key_scale_ptr,
-                value_scale_ptr, slot_mapping.const_data_ptr<int64_t>(),
-                k_scale_ptr, v_scale_ptr, key.stride(0), value.stride(0),
-                num_heads, head_size, block_size, data_block_stride,
-                data_head_stride, data_block_offset_stride, scale_block_stride,
-                scale_head_stride, scale_block_offset_stride, swizzle_v_sf);
+        if (kv_cache_dtype == "nvfp4") {
+          vllm::reshape_and_cache_nvfp4_kernel<
+              scalar_t, vllm::NVFP4KVScaleSearch::DEFAULT>
+              <<<grid, block, 0, stream>>>(
+                  key.const_data_ptr<scalar_t>(),
+                  value.const_data_ptr<scalar_t>(),
+                  key_cache.mutable_data_ptr<uint8_t>(),
+                  value_cache.mutable_data_ptr<uint8_t>(), key_scale_ptr,
+                  value_scale_ptr, slot_mapping.const_data_ptr<int64_t>(),
+                  k_scale_ptr, v_scale_ptr, key.stride(0), value.stride(0),
+                  num_heads, head_size, block_size, data_block_stride,
+                  data_head_stride, data_block_offset_stride,
+                  scale_block_stride, scale_head_stride,
+                  scale_block_offset_stride, swizzle_v_sf);
+        } else if (kv_cache_dtype == "nvfp4_4over6") {
+          vllm::reshape_and_cache_nvfp4_kernel<
+              scalar_t, vllm::NVFP4KVScaleSearch::FOUR_OVER_SIX>
+              <<<grid, block, 0, stream>>>(
+                  key.const_data_ptr<scalar_t>(),
+                  value.const_data_ptr<scalar_t>(),
+                  key_cache.mutable_data_ptr<uint8_t>(),
+                  value_cache.mutable_data_ptr<uint8_t>(), key_scale_ptr,
+                  value_scale_ptr, slot_mapping.const_data_ptr<int64_t>(),
+                  k_scale_ptr, v_scale_ptr, key.stride(0), value.stride(0),
+                  num_heads, head_size, block_size, data_block_stride,
+                  data_head_stride, data_block_offset_stride,
+                  scale_block_stride, scale_head_stride,
+                  scale_block_offset_stride, swizzle_v_sf);
+        } else {
+          STD_TORCH_CHECK(false,
+                          "Unsupported NVFP4 KV cache dtype: ", kv_cache_dtype);
+        }
+      });
 }

--- a/csrc/libtorch_stable/nvfp4_kv_cache_kernels.cu
+++ b/csrc/libtorch_stable/nvfp4_kv_cache_kernels.cu
@@ -183,9 +183,11 @@ __global__ void reshape_and_cache_nvfp4_kernel(
     const int64_t data_block_stride,         // data cache stride for dim 0
     const int64_t data_head_stride,          // data cache stride for heads
     const int64_t data_block_offset_stride,  // data cache stride for tokens
-    const int64_t scale_block_stride,        // scale cache stride for dim 0
-    const int64_t scale_head_stride,         // scale cache stride for heads
-    const int64_t scale_block_offset_stride  // scale cache stride for tokens
+    const int64_t scale_block_stride,         // scale cache stride for dim 0
+    const int64_t scale_head_stride,          // scale cache stride for heads
+    const int64_t scale_block_offset_stride,  // scale cache stride for tokens
+    const bool swizzle_v_sf  // V scale layout: true = SM100 trtllm-gen 4-token
+                             // swizzle; false = linear (FlashInfer FA2 sm12x)
 ) {
   using CudaType = typename CUDATypeConverter<scalar_t>::Type;
   using PVec = PackedVec<CudaType, CVT_FP4_PACK16>;
@@ -280,12 +282,14 @@ __global__ void reshape_and_cache_nvfp4_kernel(
 #endif
 
       // Write block scale to scale cache.
-      // K (kv==0): linear layout (no swizzle).
-      // V (kv==1): swizzled layout for SM100 trtllm-gen MHA kernel.
+      // K (kv==0): always linear layout (no swizzle).
+      // V (kv==1): swizzled layout for the SM100 trtllm-gen MHA kernel when
+      //   swizzle_v_sf is true; linear (same as K) when false, which the
+      //   FlashInfer FA2 paged nvfp4 reader on sm120/sm121 requires.
       if (sf_out_ptr != nullptr) {
         int scale_idx = group_in_head;
         uint8_t* __restrict__ scale_dst;
-        if (kv == 0) {
+        if (kv == 0 || !swizzle_v_sf) {
           scale_dst = scale_block + head * scale_head_stride +
                       block_offset * scale_block_offset_stride + scale_idx;
         } else {
@@ -332,9 +336,20 @@ void reshape_and_cache_nvfp4_dispatch(
 
   STD_TORCH_CHECK(head_size % 16 == 0,
                   "head_size must be divisible by 16 for NVFP4 KV cache");
-  STD_TORCH_CHECK(block_size % 4 == 0,
-                  "block_size must be divisible by 4 for NVFP4 KV cache "
-                  "swizzle");
+
+  // SM120/SM121 (consumer Blackwell) serve NVFP4 KV via the FlashInfer FA2
+  // paged reader, which takes the scale-factor strides from the SF tensor
+  // itself and reads V scales linearly; the SM100 trtllm-gen reader keeps
+  // its 4-token V scale swizzle. Both consume the same per-page
+  // [K_data | K_scale | V_data | V_scale] layout, so only the V-scale
+  // swizzle is arch-conditional.
+  cudaDeviceProp dev_prop;
+  cudaGetDeviceProperties(&dev_prop, key.get_device_index());
+  const bool swizzle_v_sf = dev_prop.major < 12;
+
+  STD_TORCH_CHECK(!swizzle_v_sf || block_size % 4 == 0,
+                  "block_size must be divisible by 4 for NVFP4 KV cache V "
+                  "scale-factor swizzle (SM100 trtllm-gen path)");
 
   // Detect physical layout from strides (based on full_dim).
   // HND: head stride > block_offset stride.
@@ -387,37 +402,15 @@ void reshape_and_cache_nvfp4_dispatch(
 
   VLLM_STABLE_DISPATCH_HALF_TYPES(
       key.scalar_type(), "reshape_and_cache_nvfp4", [&] {
-        if (kv_cache_dtype == "nvfp4") {
-          vllm::reshape_and_cache_nvfp4_kernel<
-              scalar_t, vllm::NVFP4KVScaleSearch::DEFAULT>
-              <<<grid, block, 0, stream>>>(
-                  key.const_data_ptr<scalar_t>(),
-                  value.const_data_ptr<scalar_t>(),
-                  key_cache.mutable_data_ptr<uint8_t>(),
-                  value_cache.mutable_data_ptr<uint8_t>(), key_scale_ptr,
-                  value_scale_ptr, slot_mapping.const_data_ptr<int64_t>(),
-                  k_scale_ptr, v_scale_ptr, key.stride(0), value.stride(0),
-                  num_heads, head_size, block_size, data_block_stride,
-                  data_head_stride, data_block_offset_stride,
-                  scale_block_stride, scale_head_stride,
-                  scale_block_offset_stride);
-        } else if (kv_cache_dtype == "nvfp4_4over6") {
-          vllm::reshape_and_cache_nvfp4_kernel<
-              scalar_t, vllm::NVFP4KVScaleSearch::FOUR_OVER_SIX>
-              <<<grid, block, 0, stream>>>(
-                  key.const_data_ptr<scalar_t>(),
-                  value.const_data_ptr<scalar_t>(),
-                  key_cache.mutable_data_ptr<uint8_t>(),
-                  value_cache.mutable_data_ptr<uint8_t>(), key_scale_ptr,
-                  value_scale_ptr, slot_mapping.const_data_ptr<int64_t>(),
-                  k_scale_ptr, v_scale_ptr, key.stride(0), value.stride(0),
-                  num_heads, head_size, block_size, data_block_stride,
-                  data_head_stride, data_block_offset_stride,
-                  scale_block_stride, scale_head_stride,
-                  scale_block_offset_stride);
-        } else {
-          STD_TORCH_CHECK(false,
-                          "Unsupported NVFP4 KV cache dtype: ", kv_cache_dtype);
-        }
-      });
+        vllm::reshape_and_cache_nvfp4_kernel<scalar_t>
+            <<<grid, block, 0, stream>>>(
+                key.const_data_ptr<scalar_t>(),
+                value.const_data_ptr<scalar_t>(),
+                key_cache.mutable_data_ptr<uint8_t>(),
+                value_cache.mutable_data_ptr<uint8_t>(), key_scale_ptr,
+                value_scale_ptr, slot_mapping.const_data_ptr<int64_t>(),
+                k_scale_ptr, v_scale_ptr, key.stride(0), value.stride(0),
+                num_heads, head_size, block_size, data_block_stride,
+                data_head_stride, data_block_offset_stride, scale_block_stride,
+                scale_head_stride, scale_block_offset_stride, swizzle_v_sf);
 }

--- a/tests/kernels/mamba/test_causal_conv1d.py
+++ b/tests/kernels/mamba/test_causal_conv1d.py
@@ -392,3 +392,32 @@ def test_causal_conv1d_varlen(
     )
     unpadded_out = out[:, : out_ref_tensor.shape[-1]]
     assert torch.allclose(unpadded_out, out_ref_tensor, rtol=rtol, atol=atol)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("num_accepted", [0, 4])
+def test_causal_conv1d_update_invalid_accepted_count_is_fail_closed(
+    num_accepted: int,
+):
+    """An invalid speculative offset must not read or update adjacent state."""
+    device = DEVICE
+    batch, dim, seqlen, width = 1, 64, 3, 4
+    x = torch.randn(batch, dim, seqlen, device=device)
+    weight = torch.randn(dim, width, device=device)
+    conv_state = torch.randn(3, dim, width - 1 + seqlen - 1, device=device)
+    state_before = conv_state.clone()
+    state_indices = torch.tensor([1], dtype=torch.int32, device=device)
+    accepted = torch.tensor([num_accepted], dtype=torch.int32, device=device)
+    out = torch.full_like(x, torch.nan)
+
+    result = causal_conv1d_update(
+        x,
+        conv_state,
+        weight,
+        conv_state_indices=state_indices,
+        num_accepted_tokens=accepted,
+        out=out,
+    )
+
+    torch.testing.assert_close(result, torch.zeros_like(result))
+    torch.testing.assert_close(conv_state, state_before)

--- a/tests/kernels/mamba/test_mamba_ssm.py
+++ b/tests/kernels/mamba/test_mamba_ssm.py
@@ -1152,3 +1152,129 @@ def test_selective_state_update_varlen_with_num_accepted(
             state_ref = state_ref_intermediate[(seq_idx, token_idx)].squeeze(0)
 
             assert torch.allclose(state[dst_slot], state_ref, rtol=rtol, atol=atol)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@torch.inference_mode()
+def test_selective_state_update_rejects_accepted_count_past_state_row():
+    """An invalid accepted count must not select an adjacent state row."""
+    dim, dstate, seq_len = 64, 16, 3
+    total_state_slots = 12
+    set_random_seed(2026)
+
+    state = torch.randn(
+        total_state_slots, dim, dstate, dtype=torch.float32, device=DEVICE
+    )
+    state_before = state.clone()
+
+    state_indices_storage = torch.full(
+        (3, seq_len), NULL_BLOCK_ID, dtype=torch.int32, device=DEVICE
+    )
+    state_indices_storage[1, 0] = 1
+    # Keep the old out-of-row access inside allocated storage so this is a
+    # deterministic semantic regression rather than an illegal-address probe.
+    state_indices_storage[2, 0] = 2
+    state_batch_indices = state_indices_storage[1:2]
+    dst_state_batch_indices = torch.tensor(
+        [[3, 4, 5]], dtype=torch.int32, device=DEVICE
+    )
+
+    x = torch.randn(seq_len, dim, device=DEVICE)
+    dt = torch.randn_like(x)
+    A = -torch.rand(dim, dstate, device=DEVICE) - 1.0
+    B = torch.randn(seq_len, dstate, device=DEVICE)
+    C = torch.randn_like(B)
+    D = torch.randn(dim, device=DEVICE)
+    dt_bias = torch.rand(dim, device=DEVICE) - 4.0
+    out = torch.full_like(x, torch.nan)
+
+    selective_state_update(
+        state,
+        x,
+        dt,
+        A,
+        B,
+        C,
+        D=D,
+        dt_bias=dt_bias,
+        dt_softplus=True,
+        state_batch_indices=state_batch_indices,
+        dst_state_batch_indices=dst_state_batch_indices,
+        out=out,
+        num_accepted_tokens=torch.tensor(
+            [seq_len + 1], dtype=torch.int32, device=DEVICE
+        ),
+        cu_seqlens=torch.tensor([0, seq_len], dtype=torch.int32, device=DEVICE),
+    )
+
+    torch.testing.assert_close(out, torch.zeros_like(out))
+    torch.testing.assert_close(state, state_before)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@torch.inference_mode()
+def test_selective_state_update_accepts_valid_accepted_count_within_row():
+    """A VALID accepted count > 1 must still compute, not fail closed.
+
+    Discriminating half of the bounds regression above: the first version of
+    the bound compared against stride(1) (== 1 when contiguous), which
+    rejected every accepted count > 1 and zeroed legitimate speculative
+    decode output while leaving state untouched. Guarding only the invalid
+    side cannot catch that (an oversized count fails closed under both the
+    right and the wrong bound), so this test pins the valid side: real
+    output, state mutation.
+    """
+    dim, dstate, seq_len = 64, 16, 3
+    total_state_slots = 12
+    set_random_seed(2026)
+
+    state = torch.randn(
+        total_state_slots, dim, dstate, dtype=torch.float32, device=DEVICE
+    )
+    state_before = state.clone()
+
+    state_indices_storage = torch.full(
+        (3, seq_len), NULL_BLOCK_ID, dtype=torch.int32, device=DEVICE
+    )
+    # Column 1 (init_token_idx for num_accepted == 2) selects state row 1.
+    state_indices_storage[1, 0] = 6
+    state_indices_storage[1, 1] = 1
+    state_indices_storage[1, 2] = 7
+    state_batch_indices = state_indices_storage[1:2]
+    dst_state_batch_indices = torch.tensor(
+        [[3, 4, 5]], dtype=torch.int32, device=DEVICE
+    )
+
+    x = torch.randn(seq_len, dim, device=DEVICE)
+    dt = torch.randn_like(x)
+    A = -torch.rand(dim, dstate, device=DEVICE) - 1.0
+    B = torch.randn(seq_len, dstate, device=DEVICE)
+    C = torch.randn_like(B)
+    D = torch.randn(dim, device=DEVICE)
+    dt_bias = torch.rand(dim, device=DEVICE) - 4.0
+    out = torch.full_like(x, torch.nan)
+
+    selective_state_update(
+        state,
+        x,
+        dt,
+        A,
+        B,
+        C,
+        D=D,
+        dt_bias=dt_bias,
+        dt_softplus=True,
+        state_batch_indices=state_batch_indices,
+        dst_state_batch_indices=dst_state_batch_indices,
+        out=out,
+        num_accepted_tokens=torch.tensor([2], dtype=torch.int32, device=DEVICE),
+        cu_seqlens=torch.tensor([0, seq_len], dtype=torch.int32, device=DEVICE),
+    )
+
+    assert not torch.isnan(out).any(), "output was never written"
+    assert not torch.equal(out, torch.zeros_like(out)), (
+        "valid accepted count was wrongly failed closed to zero output"
+    )
+    assert not torch.equal(state, state_before), (
+        "valid accepted count wrongly skipped the state update"
+    )

--- a/tests/kernels/test_fused_sigmoid_gating_delta_rule.py
+++ b/tests/kernels/test_fused_sigmoid_gating_delta_rule.py
@@ -197,3 +197,73 @@ def test_fused_sigmoid_gating_delta_rule_update_spec(
     torch.testing.assert_close(
         last_recurrent_state, last_recurrent_state_ref, atol=1e-2, rtol=1e-2
     )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("num_accepted", [0, 5])
+def test_spec_invalid_accepted_count_zeroes_output(num_accepted: int) -> None:
+    """Invalid active-request state selection must not expose empty output."""
+    torch.set_default_device(DEVICE)
+    set_random_seed(0)
+
+    num_tokens, num_k_heads, num_v_heads = 4, 2, 4
+    head_k_dim = head_v_dim = 16
+    query = torch.rand(1, num_tokens, num_k_heads, head_k_dim)
+    key = torch.rand_like(query)
+    value = torch.rand(1, num_tokens, num_v_heads, head_v_dim)
+    a = torch.rand(num_tokens, num_v_heads)
+    b = torch.rand_like(a)
+    A_log = torch.rand(num_v_heads)
+    dt_bias = torch.rand_like(A_log)
+    initial_state = torch.rand(num_tokens + 1, num_v_heads, head_v_dim, head_k_dim)
+    state_indices = torch.arange(1, num_tokens + 1, dtype=torch.int32).view(
+        1, num_tokens
+    )
+    cu_seqlens = torch.tensor([0, num_tokens], dtype=torch.int32)
+    accepted = torch.tensor([num_accepted], dtype=torch.int32)
+
+    previous_deterministic = torch.are_deterministic_algorithms_enabled()
+    previous_warn_only = torch.is_deterministic_algorithms_warn_only_enabled()
+    previous_fill = torch.utils.deterministic.fill_uninitialized_memory
+    torch.use_deterministic_algorithms(True)
+    torch.utils.deterministic.fill_uninitialized_memory = True
+    try:
+        recurrent_state = initial_state.clone()
+        recurrent_out, recurrent_state = fused_recurrent_gated_delta_rule(
+            q=query,
+            k=key,
+            v=value,
+            g=torch.rand(1, num_tokens, num_v_heads),
+            beta=torch.rand(1, num_tokens, num_v_heads),
+            initial_state=recurrent_state,
+            inplace_final_state=True,
+            ssm_state_indices=state_indices,
+            cu_seqlens=cu_seqlens,
+            num_accepted_tokens=accepted,
+        )
+
+        sigmoid_state = initial_state.clone()
+        sigmoid_out, sigmoid_state = fused_sigmoid_gating_delta_rule_update(
+            A_log=A_log,
+            a=a,
+            b=b,
+            dt_bias=dt_bias,
+            q=query,
+            k=key,
+            v=value,
+            initial_state=sigmoid_state,
+            inplace_final_state=True,
+            ssm_state_indices=state_indices,
+            cu_seqlens=cu_seqlens,
+            num_accepted_tokens=accepted,
+        )
+    finally:
+        torch.utils.deterministic.fill_uninitialized_memory = previous_fill
+        torch.use_deterministic_algorithms(
+            previous_deterministic, warn_only=previous_warn_only
+        )
+
+    torch.testing.assert_close(recurrent_out, torch.zeros_like(recurrent_out))
+    torch.testing.assert_close(sigmoid_out, torch.zeros_like(sigmoid_out))
+    torch.testing.assert_close(recurrent_state, initial_state)
+    torch.testing.assert_close(sigmoid_state, initial_state)

--- a/tests/kernels/test_fused_sigmoid_gating_delta_rule.py
+++ b/tests/kernels/test_fused_sigmoid_gating_delta_rule.py
@@ -267,3 +267,195 @@ def test_spec_invalid_accepted_count_zeroes_output(num_accepted: int) -> None:
     torch.testing.assert_close(sigmoid_out, torch.zeros_like(sigmoid_out))
     torch.testing.assert_close(recurrent_state, initial_state)
     torch.testing.assert_close(sigmoid_state, initial_state)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_spec_decoding_null_state_row_leaves_state_untouched(
+    dtype: torch.dtype,
+) -> None:
+    """A stale spec row is signalled by NULL_BLOCK_ID state slots (written by
+    the GDN metadata builder when num_accepted_tokens == 0). The kernel must
+    skip such a row entirely: no initial-state read and, critically, no
+    final-state write, so a request whose step was discarded does not have its
+    recurrent state advanced. Live rows in the same batch must still update.
+    """
+    torch.set_default_device(DEVICE)
+    set_random_seed(0)
+    num_reqs, num_k_heads, num_v_heads = 2, 16, 32
+    head_k_dim = head_v_dim = 128
+    num_speculative_tokens = 3
+    num_tokens = num_reqs * (num_speculative_tokens + 1)
+    total_entries = num_tokens * 2
+
+    query = torch.rand(1, num_tokens, num_k_heads, head_k_dim, dtype=dtype)
+    key = torch.rand(1, num_tokens, num_k_heads, head_k_dim, dtype=dtype)
+    value = torch.rand(1, num_tokens, num_v_heads, head_v_dim, dtype=dtype)
+    A_log = torch.rand(num_v_heads, dtype=dtype)
+    dt_bias = torch.rand(num_v_heads, dtype=dtype)
+    a = torch.rand(num_tokens, num_v_heads, dtype=dtype)
+    b = torch.rand(num_tokens, num_v_heads, dtype=dtype)
+    # Entry 0 is reserved as NULL_BLOCK_ID, so valid indices start at 1.
+    ssm_state = torch.rand(
+        total_entries + 1, num_v_heads, head_k_dim, head_v_dim, dtype=dtype
+    )
+    state_indices = (torch.randperm(total_entries, dtype=torch.int32) + 1)[
+        :num_tokens
+    ].view(num_reqs, num_speculative_tokens + 1)
+    cu_seqlens = torch.arange(
+        0, num_tokens + 1, num_speculative_tokens + 1, dtype=torch.int32
+    )
+    beta = b.sigmoid()
+    g = -A_log.float().exp() * F.softplus(a.float() + dt_bias)
+
+    def run_gating(indices: torch.Tensor, accepted: torch.Tensor, state: torch.Tensor):
+        return fused_sigmoid_gating_delta_rule_update(
+            A_log=A_log,
+            a=a,
+            b=b,
+            dt_bias=dt_bias,
+            q=query,
+            k=key,
+            v=value,
+            initial_state=state,
+            inplace_final_state=True,
+            ssm_state_indices=indices,
+            cu_seqlens=cu_seqlens,
+            num_accepted_tokens=accepted,
+            use_qk_l2norm_in_kernel=True,
+        )
+
+    def run_recurrent(
+        indices: torch.Tensor, accepted: torch.Tensor, state: torch.Tensor
+    ):
+        return fused_recurrent_gated_delta_rule(
+            q=query,
+            k=key,
+            v=value,
+            g=g.unsqueeze(0),
+            beta=beta.unsqueeze(0),
+            initial_state=state,
+            inplace_final_state=True,
+            ssm_state_indices=indices,
+            cu_seqlens=cu_seqlens,
+            num_accepted_tokens=accepted,
+            use_qk_l2norm_in_kernel=True,
+        )
+
+    # Row 0 is stale: the builder nulls its slots and clamps its count to 1.
+    stale_indices = state_indices.clone()
+    stale_indices[0].fill_(0)
+    accepted = torch.tensor([1, 2], dtype=torch.int32)
+    stale_slots = state_indices[0].tolist()
+    live_slots = state_indices[1].tolist()
+
+    for run in (run_gating, run_recurrent):
+        state = ssm_state.clone()
+        before = state.clone()
+        run(stale_indices, accepted, state)
+        # The stale row's blocks must be bit-identical: no state advanced.
+        for slot in stale_slots:
+            torch.testing.assert_close(state[slot], before[slot], atol=0, rtol=0)
+        # The live row must still have written its final state.
+        assert not torch.equal(
+            state[live_slots[accepted[1].item() - 1]],
+            before[live_slots[accepted[1].item() - 1]],
+        )
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_spec_decoding_zero_accepted_tokens_is_in_bounds(dtype: torch.dtype) -> None:
+    """Defense in depth: even if a raw 0 reaches the kernel without the
+    builder having nulled the row, the slot index (num_accepted_tokens - 1)
+    must be clamped rather than indexing at -1. Run under compute-sanitizer
+    to catch the out-of-bounds read this guards against.
+    """
+    torch.set_default_device(DEVICE)
+    set_random_seed(0)
+    num_reqs, num_k_heads, num_v_heads = 2, 16, 32
+    head_k_dim = head_v_dim = 128
+    num_speculative_tokens = 3
+    num_tokens = num_reqs * (num_speculative_tokens + 1)
+    total_entries = num_tokens * 2
+
+    query = torch.rand(1, num_tokens, num_k_heads, head_k_dim, dtype=dtype)
+    key = torch.rand(1, num_tokens, num_k_heads, head_k_dim, dtype=dtype)
+    value = torch.rand(1, num_tokens, num_v_heads, head_v_dim, dtype=dtype)
+    A_log = torch.rand(num_v_heads, dtype=dtype)
+    dt_bias = torch.rand(num_v_heads, dtype=dtype)
+    a = torch.rand(num_tokens, num_v_heads, dtype=dtype)
+    b = torch.rand(num_tokens, num_v_heads, dtype=dtype)
+    ssm_state = torch.rand(
+        total_entries + 1, num_v_heads, head_k_dim, head_v_dim, dtype=dtype
+    )
+    state_indices = (torch.randperm(total_entries, dtype=torch.int32) + 1)[
+        :num_tokens
+    ].view(num_reqs, num_speculative_tokens + 1)
+    cu_seqlens = torch.arange(
+        0, num_tokens + 1, num_speculative_tokens + 1, dtype=torch.int32
+    )
+    beta = b.sigmoid()
+    g = -A_log.float().exp() * F.softplus(a.float() + dt_bias)
+
+    zeros = torch.zeros(num_reqs, dtype=torch.int32)
+    ones = torch.ones(num_reqs, dtype=torch.int32)
+
+    # A clamped 0 must behave exactly like 1: both read slot 0 of the row.
+    out_zero, state_zero = fused_sigmoid_gating_delta_rule_update(
+        A_log=A_log,
+        a=a,
+        b=b,
+        dt_bias=dt_bias,
+        q=query,
+        k=key,
+        v=value,
+        initial_state=ssm_state.clone(),
+        inplace_final_state=True,
+        ssm_state_indices=state_indices,
+        cu_seqlens=cu_seqlens,
+        num_accepted_tokens=zeros,
+        use_qk_l2norm_in_kernel=True,
+    )
+    out_one, state_one = fused_sigmoid_gating_delta_rule_update(
+        A_log=A_log,
+        a=a,
+        b=b,
+        dt_bias=dt_bias,
+        q=query,
+        k=key,
+        v=value,
+        initial_state=ssm_state.clone(),
+        inplace_final_state=True,
+        ssm_state_indices=state_indices,
+        cu_seqlens=cu_seqlens,
+        num_accepted_tokens=ones,
+        use_qk_l2norm_in_kernel=True,
+    )
+    torch.testing.assert_close(out_zero, out_one, atol=0, rtol=0)
+    torch.testing.assert_close(state_zero, state_one, atol=0, rtol=0)
+
+    out_zero, state_zero = fused_recurrent_gated_delta_rule(
+        q=query,
+        k=key,
+        v=value,
+        g=g.unsqueeze(0),
+        beta=beta.unsqueeze(0),
+        initial_state=ssm_state.clone(),
+        inplace_final_state=True,
+        ssm_state_indices=state_indices,
+        cu_seqlens=cu_seqlens,
+        num_accepted_tokens=zeros,
+        use_qk_l2norm_in_kernel=True,
+    )
+    out_one, state_one = fused_recurrent_gated_delta_rule(
+        q=query,
+        k=key,
+        v=value,
+        g=g.unsqueeze(0),
+        beta=beta.unsqueeze(0),
+        initial_state=ssm_state.clone(),
+        inplace_final_state=True,
+        ssm_state_indices=state_indices,
+        cu_seqlens=cu_seqlens,
+        num_accepted_tokens=ones,
+        use_qk_l2norm_in_kernel=True,
+    )
+    torch.testing.assert_close(out_zero, out_one, atol=0, rtol=0)
+    torch.testing.assert_close(state_zero, state_one, atol=0, rtol=0)

--- a/tests/kernels/test_fused_sigmoid_gating_delta_rule.py
+++ b/tests/kernels/test_fused_sigmoid_gating_delta_rule.py
@@ -397,7 +397,9 @@ def test_spec_decoding_zero_accepted_tokens_is_in_bounds(dtype: torch.dtype) -> 
     zeros = torch.zeros(num_reqs, dtype=torch.int32)
     ones = torch.ones(num_reqs, dtype=torch.int32)
 
-    # A clamped 0 must behave exactly like 1: both read slot 0 of the row.
+    # Fail-closed (PR #50021 semantics): a raw 0 that bypasses the builder
+    # must produce zero output and leave state untouched, never index at -1.
+    initial = ssm_state.clone()
     out_zero, state_zero = fused_sigmoid_gating_delta_rule_update(
         A_log=A_log,
         a=a,
@@ -413,23 +415,8 @@ def test_spec_decoding_zero_accepted_tokens_is_in_bounds(dtype: torch.dtype) -> 
         num_accepted_tokens=zeros,
         use_qk_l2norm_in_kernel=True,
     )
-    out_one, state_one = fused_sigmoid_gating_delta_rule_update(
-        A_log=A_log,
-        a=a,
-        b=b,
-        dt_bias=dt_bias,
-        q=query,
-        k=key,
-        v=value,
-        initial_state=ssm_state.clone(),
-        inplace_final_state=True,
-        ssm_state_indices=state_indices,
-        cu_seqlens=cu_seqlens,
-        num_accepted_tokens=ones,
-        use_qk_l2norm_in_kernel=True,
-    )
-    torch.testing.assert_close(out_zero, out_one, atol=0, rtol=0)
-    torch.testing.assert_close(state_zero, state_one, atol=0, rtol=0)
+    torch.testing.assert_close(out_zero, torch.zeros_like(out_zero))
+    torch.testing.assert_close(state_zero, initial)
 
     out_zero, state_zero = fused_recurrent_gated_delta_rule(
         q=query,
@@ -444,18 +431,5 @@ def test_spec_decoding_zero_accepted_tokens_is_in_bounds(dtype: torch.dtype) -> 
         num_accepted_tokens=zeros,
         use_qk_l2norm_in_kernel=True,
     )
-    out_one, state_one = fused_recurrent_gated_delta_rule(
-        q=query,
-        k=key,
-        v=value,
-        g=g.unsqueeze(0),
-        beta=beta.unsqueeze(0),
-        initial_state=ssm_state.clone(),
-        inplace_final_state=True,
-        ssm_state_indices=state_indices,
-        cu_seqlens=cu_seqlens,
-        num_accepted_tokens=ones,
-        use_qk_l2norm_in_kernel=True,
-    )
-    torch.testing.assert_close(out_zero, out_one, atol=0, rtol=0)
-    torch.testing.assert_close(state_zero, state_one, atol=0, rtol=0)
+    torch.testing.assert_close(out_zero, torch.zeros_like(out_zero))
+    torch.testing.assert_close(state_zero, initial)

--- a/tests/models/kimi_k3/test_kda.py
+++ b/tests/models/kimi_k3/test_kda.py
@@ -18,6 +18,9 @@ from vllm.model_executor.layers.mamba.ops.gather_initial_states import (
     gather_initial_states,
 )
 from vllm.models.kimi_k3.amd.ops.third_party.kda import (
+    fused_recurrent_kda_fwd as fused_recurrent_kda_fwd_amd,
+)
+from vllm.models.kimi_k3.amd.ops.third_party.kda import (
     fused_recurrent_kda_packed_decode as fused_recurrent_kda_packed_decode_amd,
 )
 from vllm.models.kimi_k3.nvidia.kda import (
@@ -53,6 +56,10 @@ pytestmark = pytest.mark.skipif(
 PACKED_DECODE_IMPLS = {
     "nvidia": fused_recurrent_kda_packed_decode,
     "amd": fused_recurrent_kda_packed_decode_amd,
+}
+SPEC_DECODE_IMPLS = {
+    "nvidia": fused_recurrent_kda_fwd,
+    "amd": fused_recurrent_kda_fwd_amd,
 }
 
 
@@ -573,6 +580,55 @@ def test_kda_spec_decode_correctness(
         err_atol=3e-3,
     )
     assert torch.isnan(output_storage[..., H * D :]).all()
+
+
+@pytest.mark.parametrize("impl", SPEC_DECODE_IMPLS.keys())
+@pytest.mark.parametrize("num_accepted", [0, 4])
+@torch.inference_mode()
+def test_kda_spec_invalid_accepted_count_is_fail_closed(
+    impl: str,
+    num_accepted: int,
+):
+    """Invalid accepted counts must not select an adjacent KDA state row."""
+    H, D, T = 2, 128, 3
+    torch.manual_seed(2026)
+
+    q = torch.randn(1, T, H, D, dtype=torch.bfloat16, device=DEVICE)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+    gate = -torch.rand_like(q)
+    beta = torch.rand(1, T, H, dtype=torch.float32, device=DEVICE)
+    cu_seqlens = torch.tensor([0, T], dtype=torch.int32, device=DEVICE)
+
+    state_indices_storage = torch.zeros(3, T, dtype=torch.int32, device=DEVICE)
+    state_indices_storage[1] = torch.arange(1, T + 1, dtype=torch.int32, device=DEVICE)
+    # Keep the old out-of-row accesses inside allocated storage so this test
+    # is a deterministic semantic regression rather than an illegal-address probe.
+    state_indices_storage[0, -1] = 4
+    state_indices_storage[2, 0] = 5
+    state_indices = state_indices_storage[1:2]
+
+    state = torch.randn(T + 3, H, D, D, dtype=torch.float32, device=DEVICE)
+    state_before = state.clone()
+    output = torch.full_like(v, torch.nan)
+    accepted = torch.tensor([num_accepted], dtype=torch.int32, device=DEVICE)
+
+    actual, actual_state = SPEC_DECODE_IMPLS[impl](
+        q=q,
+        k=k,
+        v=v,
+        g=gate,
+        beta=beta,
+        initial_state=state,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=state_indices,
+        num_accepted_tokens=accepted,
+        out=output,
+    )
+
+    assert actual.data_ptr() == output.data_ptr()
+    torch.testing.assert_close(actual, torch.zeros_like(actual))
+    torch.testing.assert_close(actual_state, state_before)
 
 
 @pytest.mark.parametrize(

--- a/tests/models/kimi_k3/test_kda_metadata.py
+++ b/tests/models/kimi_k3/test_kda_metadata.py
@@ -89,7 +89,7 @@ def _make_builder(
     use_recoverssm: bool = False,
 ) -> AttentionMetadataBuilder:
     vllm_config = create_vllm_config(
-        model_name="Qwen/Qwen3.5-0.8B",
+        model_name="/data/models/Qwen3.5-0.8B",
         block_size=BLOCK_SIZE,
     )
     if num_speculative_tokens:

--- a/tests/models/kimi_k3/test_kda_metadata.py
+++ b/tests/models/kimi_k3/test_kda_metadata.py
@@ -550,3 +550,90 @@ def test_aligned_block_table_matches_shared_gdn():
     )
 
     torch.testing.assert_close(actual, expected)
+
+
+def _build_kda_with_stale_row(
+    device: torch.device,
+    full_cuda_graph: bool = False,
+    mamba_cache_mode: str = "none",
+) -> tuple[KimiK3KDAMetadata, torch.Tensor, torch.Tensor]:
+    """Build KDA metadata for a batch whose row 0 is stale (0 accepted).
+
+    Returns the metadata plus the block table before and after the build, so
+    callers can assert the runner's table was not written through.
+    """
+    builder = _make_builder(
+        KimiK3KDAMetadataBuilder,
+        num_speculative_tokens=3,
+        full_cuda_graph=full_cuda_graph,
+        device=device,
+        mamba_cache_mode=mamba_cache_mode,
+    )
+    batch = BatchSpec(seq_lens=[80, 96], query_lens=[4, 4])
+    common = create_common_attn_metadata(batch, BLOCK_SIZE, device).replace(
+        is_prefilling=torch.tensor([False, False])
+    )
+    block_table_before = common.block_table_tensor.clone()
+    meta = builder.build(
+        common_prefix_len=0,
+        common_attn_metadata=common,
+        num_decode_draft_tokens_cpu=torch.tensor([3, 3], dtype=torch.int32),
+        num_accepted_tokens=torch.tensor([0, 2], dtype=torch.int32, device=device),
+    )
+    return meta, block_table_before, common.block_table_tensor
+
+
+def _assert_stale_row_nulled(
+    meta: KimiK3KDAMetadata,
+    block_table_before: torch.Tensor,
+    block_table_after: torch.Tensor,
+    check_live_row: bool = True,
+) -> None:
+    assert meta.spec_state_indices_tensor is not None
+    assert meta.num_accepted_tokens is not None
+    stale_row = meta.spec_state_indices_tensor[0]
+    live_row = meta.spec_state_indices_tensor[1]
+
+    assert (stale_row == NULL_BLOCK_ID).all(), (
+        f"stale row must be nulled, got {stale_row.tolist()}"
+    )
+    if check_live_row:
+        # 'align' mode rebuilds the block table from seq_lens, so a synthetic
+        # batch legitimately yields unallocated (zero) slots in live rows too.
+        assert not (live_row == NULL_BLOCK_ID).any(), (
+            f"live row must keep its state slots, got {live_row.tolist()}"
+        )
+    assert meta.num_accepted_tokens[0].item() == 1
+    assert meta.num_accepted_tokens[1].item() == 2
+
+    torch.testing.assert_close(block_table_after, block_table_before)
+
+
+def test_zero_accepted_tokens_nulls_state_slots():
+    """KimiK3KDAMetadataBuilder overrides build() and so does not inherit the
+    shared GDN handling of stale spec rows; it needs its own. A row reporting
+    0 accepted tokens must have its state slots nulled and its count clamped,
+    without writing NULL_BLOCK_ID back into the runner's block table (the
+    packed-decode branch slices it, which can alias the caller's tensor).
+    """
+    _assert_stale_row_nulled(*_build_kda_with_stale_row(DEVICE))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize("mamba_cache_mode", ["none", "align"])
+@pytest.mark.parametrize("full_cuda_graph", [False, True])
+def test_zero_accepted_tokens_nulls_state_slots_cuda(
+    mamba_cache_mode: str, full_cuda_graph: bool
+):
+    """Same contract across the CUDA-only paths: 'align' mode rebuilds the
+    block table via a Triton kernel, and full cudagraph mode stages the
+    metadata through persistent buffers. Both must preserve the nulling.
+    """
+    _assert_stale_row_nulled(
+        *_build_kda_with_stale_row(
+            torch.device("cuda"),
+            full_cuda_graph=full_cuda_graph,
+            mamba_cache_mode=mamba_cache_mode,
+        ),
+        check_live_row=mamba_cache_mode != "align",
+    )

--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -21,6 +21,7 @@ from vllm.v1.attention.backends.gdn_attn import (
     GDNAttentionMetadata,
     GDNAttentionMetadataBuilder,
 )
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
 from vllm.v1.kv_cache_interface import MambaSpec
 
 BLOCK_SIZE = 16
@@ -155,6 +156,7 @@ def _build(
     builder: GDNAttentionMetadataBuilder,
     batch_spec: BatchSpec,
     num_decode_draft_tokens: list[int] | None = None,
+    num_accepted_tokens: list[int] | None = None,
 ) -> GDNAttentionMetadata:
     """Build GDN attention metadata, optionally with spec-decode kwargs."""
     common = create_common_attn_metadata(batch_spec, BLOCK_SIZE, DEVICE)
@@ -163,9 +165,15 @@ def _build(
         kwargs["num_decode_draft_tokens_cpu"] = torch.tensor(
             num_decode_draft_tokens, dtype=torch.int32
         )
-        kwargs["num_accepted_tokens"] = torch.ones(
-            batch_spec.batch_size, dtype=torch.int32, device=DEVICE
-        )
+        if num_accepted_tokens is None:
+            accepted = torch.ones(
+                batch_spec.batch_size, dtype=torch.int32, device=DEVICE
+            )
+        else:
+            accepted = torch.tensor(
+                num_accepted_tokens, dtype=torch.int32, device=DEVICE
+            )
+        kwargs["num_accepted_tokens"] = accepted
     return builder.build(common_prefix_len=0, common_attn_metadata=common, **kwargs)
 
 
@@ -196,6 +204,70 @@ def test_has_initial_state_after_reclassification():
     assert meta.has_initial_state is not None
     # req0 has context_lens = 65 - 1 = 64 > 0, so has_initial_state[0] = True
     assert meta.has_initial_state[0].item() is True
+
+
+@pytest.mark.parametrize("full_cuda_graph", [False, True])
+def test_zero_accepted_tokens_nulls_state_slots(full_cuda_graph: bool):
+    """A stale row (num_accepted_tokens == 0, produced when async scheduling
+    discards a step's sampled tokens) must have its whole state-index row set
+    to NULL_BLOCK_ID so the kernels skip both the initial-state read and the
+    final-state write, and must have its count clamped into range.
+
+    Nulling — rather than only clamping — is what stops the kernel from
+    advancing the recurrent state of a request whose step was discarded.
+    Live rows in the same batch must be left untouched.
+    """
+    num_speculative_tokens = 3
+    builder = _create_gdn_builder(
+        num_speculative_tokens=num_speculative_tokens,
+        full_cuda_graph=full_cuda_graph,
+    )
+    batch = BatchSpec(seq_lens=[80, 96], query_lens=[4, 4])
+    # Row 0 is stale (its sampled tokens were discarded); row 1 is live.
+    meta = _build(
+        builder,
+        batch,
+        num_decode_draft_tokens=[3, 3],
+        num_accepted_tokens=[0, 2],
+    )
+
+    assert meta.spec_state_indices_tensor is not None
+    assert meta.num_accepted_tokens is not None
+
+    stale_row = meta.spec_state_indices_tensor[0]
+    live_row = meta.spec_state_indices_tensor[1]
+
+    assert (stale_row == NULL_BLOCK_ID).all(), (
+        "every state slot of a stale row must be nulled so the kernel's "
+        f"state_idx <= 0 guard skips it, got {stale_row.tolist()}"
+    )
+    assert not (live_row == NULL_BLOCK_ID).any(), (
+        f"a live row must keep its state slots, got {live_row.tolist()}"
+    )
+
+    # The clamp keeps the slot index (num_accepted_tokens - 1) in bounds; the
+    # live row's real count must survive it.
+    assert meta.num_accepted_tokens[0].item() == 1
+    assert meta.num_accepted_tokens[1].item() == 2
+    assert (meta.num_accepted_tokens >= 1).all()
+
+
+def test_zero_accepted_tokens_does_not_corrupt_block_table():
+    """Nulling stale rows must not write NULL_BLOCK_ID back into the block
+    table the runner reuses across steps."""
+    builder = _create_gdn_builder(num_speculative_tokens=3)
+    batch = BatchSpec(seq_lens=[80, 96], query_lens=[4, 4])
+    common = create_common_attn_metadata(batch, BLOCK_SIZE, DEVICE)
+    block_table_before = common.block_table_tensor.clone()
+
+    builder.build(
+        common_prefix_len=0,
+        common_attn_metadata=common,
+        num_decode_draft_tokens_cpu=torch.tensor([3, 3], dtype=torch.int32),
+        num_accepted_tokens=torch.tensor([0, 2], dtype=torch.int32, device=DEVICE),
+    )
+
+    torch.testing.assert_close(common.block_table_tensor, block_table_before)
 
 
 def test_full_cudagraph_spec_metadata_uses_request_count():

--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -129,7 +129,7 @@ def _create_gdn_builder(
 ) -> GDNAttentionMetadataBuilder:
     """Create a GDNAttentionMetadataBuilder with minimal config."""
     vllm_config = create_vllm_config(
-        model_name="Qwen/Qwen3.5-0.8B",
+        model_name="/data/models/Qwen3.5-0.8B",
         block_size=BLOCK_SIZE,
     )
     if full_cuda_graph:

--- a/tests/v1/attention/test_gemma4_nvfp4_flashinfer_routing.py
+++ b/tests/v1/attention/test_gemma4_nvfp4_flashinfer_routing.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Static (no-GPU) routing check for Gemma 4 NVFP4 KV -> FLASHINFER.
+
+On consumer Blackwell (CC 12.x) the FlashInfer FA2 asymmetric paged
+kernel serves Gemma 4 heterogeneous-head full-attention layers
+(head_dim_qk=512, head_dim_vo=256) directly, so Gemma4Config must route
+NVFP4-KV configs to FLASHINFER instead of the TRITON_ATTN fallback.
+
+Runs under a mocked platform/capability; no CUDA required. Mocking
+pattern adapted from the campaign triton-retirement selection test.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.platforms.interface import DeviceCapability
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+ALL_KNOBS = ("VLLM_NVFP4_KV_VOSPLIT",)
+
+CC12_0 = DeviceCapability(12, 0)
+CC12_1 = DeviceCapability(12, 1)
+CC9_0 = DeviceCapability(9, 0)
+
+
+@pytest.fixture(autouse=True)
+def _clear_knobs(monkeypatch):
+    for name in ALL_KNOBS:
+        monkeypatch.delenv(name, raising=False)
+    yield
+
+
+def _mock_vllm_config(
+    *, backend=None, cache_dtype="nvfp4", head_dim=256, global_head_dim=512
+):
+    return SimpleNamespace(
+        attention_config=SimpleNamespace(backend=backend, flash_attn_version=None),
+        cache_config=SimpleNamespace(
+            cache_dtype=cache_dtype, kv_cache_dtype_skip_layers=None
+        ),
+        model_config=SimpleNamespace(
+            hf_text_config=SimpleNamespace(
+                head_dim=head_dim,
+                global_head_dim=global_head_dim,
+                layer_types=[
+                    "sliding_attention",
+                    "sliding_attention",
+                    "sliding_attention",
+                    "sliding_attention",
+                    "sliding_attention",
+                    "full_attention",
+                ],
+            )
+        ),
+    )
+
+
+class _FakePlatform:
+    """Delegates everything to the real current_platform except the
+    compute-capability accessors, which are pinned to ``capability``."""
+
+    def __init__(self, capability):
+        self._cap = capability
+        from vllm.platforms import current_platform as real
+
+        self._real = real
+
+    def is_cuda(self):
+        return True
+
+    def get_device_capability(self, device_id=0):
+        return self._cap
+
+    def is_device_capability_family(self, cap, device_id=0):
+        return (self._cap.to_int() // 10) == (cap // 10)
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+@pytest.fixture
+def fake_cc(monkeypatch):
+    def _set(capability):
+        import vllm.platforms as platforms_mod
+        import vllm.v1.attention.backends.fa_utils as fa_utils_mod
+
+        fake = _FakePlatform(capability)
+        monkeypatch.setattr(platforms_mod, "current_platform", fake, raising=False)
+        monkeypatch.setattr(fa_utils_mod, "is_fa_version_supported", lambda v: False)
+        return fake
+
+    return _set
+
+
+def _gemma4_route(vllm_config):
+    from vllm.model_executor.models.config import Gemma4Config
+
+    Gemma4Config.verify_and_update_config(vllm_config)
+    return vllm_config.attention_config.backend
+
+
+@pytest.mark.parametrize("capability", [CC12_0, CC12_1])
+def test_nvfp4_cc12_routes_to_flashinfer(fake_cc, capability):
+    fake_cc(capability)
+    cfg = _mock_vllm_config()
+    backend = _gemma4_route(cfg)
+    assert backend == AttentionBackendEnum.FLASHINFER, backend
+
+
+def test_nvfp4_cc12_disabled_knob_falls_back_to_triton(fake_cc, monkeypatch):
+    monkeypatch.setenv("VLLM_NVFP4_KV_VOSPLIT", "0")
+    fake_cc(CC12_0)
+    cfg = _mock_vllm_config()
+    assert _gemma4_route(cfg) == AttentionBackendEnum.TRITON_ATTN
+
+
+def test_nvfp4_hopper_does_not_route(fake_cc):
+    fake_cc(CC9_0)
+    cfg = _mock_vllm_config()
+    assert _gemma4_route(cfg) == AttentionBackendEnum.TRITON_ATTN
+
+
+def test_nvfp4_explicit_user_backend_wins(fake_cc):
+    fake_cc(CC12_0)
+    cfg = _mock_vllm_config(backend=AttentionBackendEnum.TRITON_ATTN)
+    assert _gemma4_route(cfg) == AttentionBackendEnum.TRITON_ATTN
+
+
+def test_bf16_kv_keeps_triton_fallback(fake_cc):
+    fake_cc(CC12_0)
+    cfg = _mock_vllm_config(cache_dtype="auto")
+    assert _gemma4_route(cfg) == AttentionBackendEnum.TRITON_ATTN

--- a/tests/v1/attention/test_nvfp4_flashinfer_vosplit_mm.py
+++ b/tests/v1/attention/test_nvfp4_flashinfer_vosplit_mm.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Static (no-GPU) unit tests for the FlashInfer NVFP4 VO-split factor and
+the Gemma 3/4 mm-prefix bidirectional image-span masking.
+
+These exercise pure tensor/index logic on CPU — no CUDA, no kernel launch:
+
+* ``_vo_split_factor`` — how many ``(qk=512, vo=256)`` passes a head needs.
+* ``_build_mm_prefix_custom_mask`` — the per-request boolean attention mask,
+  ``(causal AND sliding-window) OR (q in span AND kv in span)``.
+* ``_mm_prefix_prefill_spans`` — which prefill requests have an image span
+  intersecting the query window (and the byte-identical None fast path).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+try:
+    from vllm.v1.attention.backends.flashinfer import (
+        FlashInferMetadataBuilder,
+        _vo_split_factor,
+    )
+
+    HAS_FI = True
+except Exception:
+    HAS_FI = False
+
+pytestmark = pytest.mark.skipif(
+    not HAS_FI, reason="FlashInfer attention backend not importable"
+)
+
+
+# --------------------------------------------------------------------------- #
+# _vo_split_factor
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "head_size,is_nvfp4,expected",
+    [
+        (256, True, 1),  # uniform Gemma 3 head — single pass
+        (128, True, 1),
+        (256, False, 1),
+        (512, True, 2),  # Gemma 4 global head — two (qk=512, vo=256) passes
+        (512, False, 2),  # the split is dtype-independent
+    ],
+)
+def test_vo_split_factor(head_size, is_nvfp4, expected, monkeypatch):
+    # the >256 NVFP4 path requires the (default-on) VO-split knob; pin it on.
+    monkeypatch.setenv("VLLM_NVFP4_KV_VOSPLIT", "1")
+    assert _vo_split_factor(head_size, is_nvfp4) == expected
+
+
+def test_vo_split_factor_nvfp4_needs_knob(monkeypatch):
+    # NVFP4 512-wide head with the split disabled must error, not silently
+    # plan an unsupported HEAD_DIM_VO=512.
+    monkeypatch.setenv("VLLM_NVFP4_KV_VOSPLIT", "0")
+    with pytest.raises(ValueError, match="two-pass VO split"):
+        _vo_split_factor(512, True)
+
+
+# --------------------------------------------------------------------------- #
+# _build_mm_prefix_custom_mask
+# --------------------------------------------------------------------------- #
+def _mask(window_left, qo_lens, kv_lens, span_lists):
+    fake = SimpleNamespace(device=torch.device("cpu"), window_left=window_left)
+    flat = FlashInferMetadataBuilder._build_mm_prefix_custom_mask(
+        fake, qo_lens, kv_lens, span_lists
+    )
+    # single-request helper: reshape back to (qo_len, kv_len)
+    return flat.reshape(qo_lens[0], kv_lens[0])
+
+
+def test_mm_mask_pure_causal_no_span():
+    # No window, no spans -> strict lower-triangular causal mask.
+    m = _mask(-1, [4], [4], [[]])
+    expected = torch.tensor(
+        [[1, 0, 0, 0], [1, 1, 0, 0], [1, 1, 1, 0], [1, 1, 1, 1]],
+        dtype=torch.bool,
+    )
+    assert torch.equal(m, expected)
+
+
+def test_mm_mask_span_is_bidirectional():
+    # Span [1,2]: queries 1,2 may attend *forward* to keys 1,2 inside the
+    # span (the whole point — image tokens attend bidirectionally), while
+    # everything outside the span stays causal.
+    m = _mask(-1, [4], [4], [[(1, 2)]])
+    expected = torch.tensor(
+        [
+            [1, 0, 0, 0],
+            [1, 1, 1, 0],  # q=1 now sees k=2 (forward, in-span)
+            [1, 1, 1, 0],
+            [1, 1, 1, 1],
+        ],
+        dtype=torch.bool,
+    )
+    assert torch.equal(m, expected)
+    # q=2 still cannot see k=3 (k=3 is outside the span and non-causal)
+    assert not m[2, 3]
+
+
+def test_mm_mask_sliding_window_ands_with_causal():
+    # window_left=1: a query sees only itself and one key back, ANDed with
+    # causal. No spans.
+    m = _mask(1, [4], [4], [[]])
+    expected = torch.tensor(
+        [
+            [1, 0, 0, 0],
+            [1, 1, 0, 0],
+            [0, 1, 1, 0],  # k=0 is outside the window for q=2
+            [0, 0, 1, 1],
+        ],
+        dtype=torch.bool,
+    )
+    assert torch.equal(m, expected)
+
+
+def test_mm_mask_span_overrides_window():
+    # The mask carries the window itself (the mm wrapper is planned
+    # window_left=-1), and an in-span pair must survive even when the window
+    # would have excluded it: q=3,k=1 are >window apart but both in span.
+    m = _mask(1, [4], [4], [[(1, 3)]])
+    assert m[3, 1]  # span overrides the window
+    assert m[1, 3]  # and is bidirectional
+    assert not m[3, 0]  # k=0 outside span and window -> off
+
+
+def test_mm_mask_with_context_offset():
+    # qo_len < kv_len: the query rows are end-aligned to the KV sequence, so
+    # absolute query positions start at kv_len - qo_len (= context_len).
+    m = _mask(-1, [2], [4], [[]])  # 2 new queries over a 4-long KV
+    # q_abs = [2, 3], k_abs = [0,1,2,3]; causal k <= q
+    expected = torch.tensor(
+        [
+            [1, 1, 1, 0],  # q=2 sees k 0..2
+            [1, 1, 1, 1],
+        ],  # q=3 sees k 0..3
+        dtype=torch.bool,
+    )
+    assert torch.equal(m, expected)
+
+
+# --------------------------------------------------------------------------- #
+# _mm_prefix_prefill_spans
+# --------------------------------------------------------------------------- #
+def _spans(mm_ranges, qo_indptr, seq_lens, num_decodes, num_prefills):
+    cam = SimpleNamespace(
+        mm_req_doc_ranges=mm_ranges,
+        query_start_loc_cpu=torch.tensor(qo_indptr, dtype=torch.int32),
+        seq_lens_cpu=torch.tensor(seq_lens, dtype=torch.int32),
+    )
+    return FlashInferMetadataBuilder._mm_prefix_prefill_spans(
+        None, cam, num_decodes, num_prefills
+    )
+
+
+def test_spans_none_when_no_mm_ranges():
+    # No image spans anywhere -> None (the scalar-causal fast path).
+    assert _spans(None, [0, 8], [8], 0, 1) is None
+    assert _spans({}, [0, 8], [8], 0, 1) is None
+
+
+def test_spans_intersecting_window_kept():
+    # One prefill request (kv_len=10, qo_len=10 -> context_len=0); span (2,5)
+    # intersects the query window and is returned.
+    out = _spans({0: [(2, 5)]}, [0, 10], [10], 0, 1)
+    assert out == [[(2, 5)]]
+
+
+def test_spans_fully_in_context_dropped():
+    # kv_len=10, qo_len=2 -> context_len=8; span (2,5) ends before the window
+    # (e=5 < context_len=8), so it needs no masking -> filtered -> None.
+    assert _spans({0: [(2, 5)]}, [0, 2], [10], 0, 1) is None
+
+
+def test_spans_skip_decode_requests():
+    # 1 decode + 1 prefill; the doc range belongs to the prefill (index 1).
+    # query_start_loc covers [decode, prefill] -> prefill qo_len = 10.
+    out = _spans({1: [(3, 6)]}, [0, 1, 11], [5, 11], 1, 1)
+    assert out == [[(3, 6)]]

--- a/tests/v1/worker/test_mamba_utils.py
+++ b/tests/v1/worker/test_mamba_utils.py
@@ -790,6 +790,75 @@ class TestPostprocessMambaFusedKernel:
         torch.testing.assert_close(conv_state, conv_state_orig)
         torch.testing.assert_close(temporal_state, temporal_state_orig)
 
+    @pytest.mark.parametrize(
+        ("num_computed", "source_col", "destination_col", "conv_unchanged"),
+        [
+            (60, 1, 3, True),  # destination is an in-row NULL_BLOCK_ID
+            (76, 1, 4, True),  # destination is the next row's first column
+            (60, 4, 3, True),  # source is the next row's first column
+            (60, 3, 3, False),  # temporal bias crosses into the next row
+        ],
+    )
+    def test_invalid_block_table_lookup_does_not_copy_state(
+        self,
+        device,
+        num_computed,
+        source_col,
+        destination_col,
+        conv_unchanged,
+    ):
+        """Invalid columns and NULL_BLOCK_ID must not reach state address math."""
+        cfg = _TestConfig(num_blocks=8)
+        layer_names = ["layer_0"]
+        kv_cache_config = _make_kv_cache_config(cfg, layer_names)
+        conv_state = torch.randn(
+            cfg.num_blocks,
+            cfg.conv_width,
+            cfg.conv_inner_dim,
+            dtype=cfg.dtype,
+            device=device,
+        )
+        temporal_state = torch.randn(
+            cfg.num_blocks,
+            cfg.temporal_state_dim,
+            dtype=cfg.dtype,
+            device=device,
+        )
+        conv_before = conv_state.clone()
+        temporal_before = temporal_state.clone()
+        forward_context = {"layer_0": _make_mock_attention(conv_state, temporal_state)}
+        gpu_ctx = _make_gpu_ctx(cfg, kv_cache_config, device)
+
+        block_table_storage = torch.zeros(2, 4, dtype=torch.int32, device=device)
+        block_table_storage[0, 1] = 1
+        if destination_col < block_table_storage.stride(0):
+            is_null_destination = (
+                destination_col == 3 and num_computed == 60 and source_col == 1
+            )
+            block_table_storage[0, destination_col] = 0 if is_null_destination else 3
+        block_table_storage[1, 0] = 2
+
+        _run_gpu_postprocess(
+            gpu_ctx,
+            kv_cache_config=kv_cache_config,
+            forward_context=forward_context,
+            copy_funcs=_COPY_FUNCS,
+            block_table=block_table_storage[:1],
+            req_ids=["req_0"],
+            num_accepted_tokens=[3],
+            mamba_state_idx=[source_col],
+            num_scheduled_tokens={"req_0": 3},
+            num_computed_tokens=[num_computed],
+            num_draft_tokens={},
+            device=device,
+        )
+
+        expected_destination = (num_computed + 3 + 3 - 1) // cfg.block_size - 1
+        assert expected_destination == destination_col
+        if conv_unchanged:
+            torch.testing.assert_close(conv_state, conv_before)
+        torch.testing.assert_close(temporal_state, temporal_before)
+
     @pytest.mark.parametrize("num_reqs", [1, 2, 8, 16])
     def test_various_batch_sizes(self, device, test_config, num_reqs):
         """Verify kernel works correctly with different batch sizes."""

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -105,6 +105,21 @@ class SpeculativeConfig:
     draft_tensor_parallel_size: int | None = Field(default=None, ge=1)
     """The degree of the tensor parallelism for the draft model. Can only be 1
     or the same as the target model's tensor parallel size."""
+    draft_pipeline_parallel_size: int | None = Field(default=None, ge=1)
+    """The degree of the pipeline parallelism for the draft model. Can only be 1
+    or the same as the target model's pipeline parallel size. Defaults to 1 so
+    that a small draft (e.g. a single-layer MTP module) runs on one pipeline
+    stage while the target uses PP>1, which is what enables PP + speculative
+    decoding without the draft tripping the SupportsPP guard."""
+    draft_embed_quant_bits: int | None = None
+    """Optional low-bit quantization for the draft model's vocab embedding (4 or
+    8; None = full precision). A speculative draft loads its own copy of the
+    target's (often huge) vocab embedding on the last PP rank; quantizing it
+    saves VRAM there. Because rejection sampling makes the final output
+    independent of draft quality, this is correctness-safe: it only affects the
+    draft acceptance rate, never the emitted tokens. Applied only on the PP
+    separate-load path (draft has its own embedding); ignored when the draft
+    shares the target's embedding (no PP)."""
     tensor_parallel_size: int | None = None
     """Users should pass "draft_tensor_parallel_size". This parameter's purpose is to
     warn users when they mistakenly provide the wrong argument."""
@@ -1127,6 +1142,20 @@ class SpeculativeConfig:
                         self.draft_model_config.hf_config,
                     )
                 )
+
+                self.draft_pipeline_parallel_size = (
+                    SpeculativeConfig._verify_and_get_draft_pp(
+                        self.target_parallel_config,
+                        self.draft_pipeline_parallel_size,
+                    )
+                )
+
+                self.draft_embed_quant_bits = (
+                    SpeculativeConfig._verify_draft_embed_quant_bits(
+                        self.draft_embed_quant_bits,
+                    )
+                )
+
                 self.draft_model_config.max_model_len = (
                     SpeculativeConfig._maybe_override_draft_max_model_len(
                         self.max_model_len,
@@ -1137,7 +1166,9 @@ class SpeculativeConfig:
 
                 self.draft_parallel_config = (
                     SpeculativeConfig.create_draft_parallel_config(
-                        self.target_parallel_config, self.draft_tensor_parallel_size
+                        self.target_parallel_config,
+                        self.draft_tensor_parallel_size,
+                        self.draft_pipeline_parallel_size,
                     )
                 )
 
@@ -1315,16 +1346,66 @@ class SpeculativeConfig:
         self.draft_model_config._architecture = arch
 
     @staticmethod
+    def _verify_and_get_draft_pp(
+        target_parallel_config: ParallelConfig,
+        speculative_draft_pipeline_parallel_size: int | None,
+    ) -> int:
+        """Verify and normalize the draft model's pipeline-parallel size.
+
+        The draft (e.g. a single-layer MTP module) is small, so by default it
+        runs on a single pipeline stage (draft_pp=1) regardless of the target's
+        pipeline_parallel_size. Placing the draft on one stage is what lets a
+        PP>1 target use speculative decoding without the draft tripping the
+        ``SupportsPP`` guard. Only 1 or the target's pp size are permitted,
+        mirroring ``_verify_and_get_draft_tp``.
+        """
+        if speculative_draft_pipeline_parallel_size is None:
+            speculative_draft_pipeline_parallel_size = 1
+        elif speculative_draft_pipeline_parallel_size not in (
+            1,
+            target_parallel_config.pipeline_parallel_size,
+        ):
+            raise ValueError(
+                f"{speculative_draft_pipeline_parallel_size=} cannot be "
+                f"other value than 1 or target model pipeline_parallel_size"
+            )
+        return speculative_draft_pipeline_parallel_size
+
+    @staticmethod
+    def _verify_draft_embed_quant_bits(bits: int | None) -> int | None:
+        """Validate the draft vocab-embedding quantization bit-width.
+
+        ``None`` keeps the draft embedding at full precision; ``8`` and ``4``
+        select int8 / int4 (per-row symmetric). Any other value is rejected.
+        """
+        if bits is None:
+            return None
+        if bits not in (4, 8):
+            raise ValueError(
+                f"draft_embed_quant_bits={bits} is not supported; "
+                "use 4, 8, or None (full precision)."
+            )
+        return bits
+
+    @staticmethod
     def create_draft_parallel_config(
         target_parallel_config: ParallelConfig,
         speculative_draft_tensor_parallel_size: int,
+        speculative_draft_pipeline_parallel_size: int | None = None,
     ) -> ParallelConfig:
         """Create a parallel config for use by the draft worker.
 
-        This is mostly a copy of the target parallel config, except the tp_size.
+        This is mostly a copy of the target parallel config, except the tp_size
+        and (optionally) the pp_size. When
+        ``speculative_draft_pipeline_parallel_size`` is None the draft inherits
+        the target's pipeline_parallel_size (legacy behavior).
         """
+        if speculative_draft_pipeline_parallel_size is None:
+            speculative_draft_pipeline_parallel_size = (
+                target_parallel_config.pipeline_parallel_size
+            )
         draft_parallel_config = ParallelConfig(
-            pipeline_parallel_size=target_parallel_config.pipeline_parallel_size,
+            pipeline_parallel_size=speculative_draft_pipeline_parallel_size,
             tensor_parallel_size=speculative_draft_tensor_parallel_size,
             distributed_executor_backend=target_parallel_config.distributed_executor_backend,
             max_parallel_loading_workers=target_parallel_config.max_parallel_loading_workers,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -201,6 +201,7 @@ if TYPE_CHECKING:
     VLLM_FLASHINFER_AUTOTUNE_SKIP_OPS: list[str] | None = None
     VLLM_FLASHINFER_ALLREDUCE_BACKEND: Literal["auto", "trtllm", "mnnvl"] = "auto"
     VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE: int = 394 * 1024 * 1024
+    VLLM_NVFP4_KV_VOSPLIT: bool = True
     VLLM_XGRAMMAR_CACHE_MB: int = 0
     VLLM_REGEX_COMPILATION_TIMEOUT_S: int = 5
     VLLM_MSGPACK_ZERO_COPY_THRESHOLD: int = 256
@@ -1648,6 +1649,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE": lambda: int(
         os.getenv("VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE", str(394 * 1024 * 1024))
     ),
+    # NVFP4 KV cache VO-split on consumer Blackwell (CC 12.x): route
+    # Gemma-4 heterogeneous-head full-attention layers (head_dim_qk=512,
+    # head_dim_vo=256) through the FlashInfer FA2 asymmetric paged kernel
+    # instead of forcing TRITON_ATTN. Default-on for nvfp4 KV; "0" is the
+    # escape hatch back to the Triton fallback.
+    "VLLM_NVFP4_KV_VOSPLIT": lambda: bool(int(os.getenv("VLLM_NVFP4_KV_VOSPLIT", "1"))),
     # Control the maximum number of tokens per expert supported by the
     # NVFP4 MoE CUTLASS Kernel. This value is used to create a buffer for
     # the blockscale tensor of activations NVFP4 Quantization.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -218,6 +218,7 @@ if TYPE_CHECKING:
     VLLM_FLASHINFER_ALLREDUCE_BACKEND: Literal["auto", "trtllm", "mnnvl"] = "auto"
     VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE: int = 394 * 1024 * 1024
     VLLM_NVFP4_KV_VOSPLIT: bool = True
+    VLLM_FLASHINFER_MM_PREFIX: bool = True
     VLLM_XGRAMMAR_CACHE_MB: int = 0
     VLLM_REGEX_COMPILATION_TIMEOUT_S: int = 5
     VLLM_MSGPACK_ZERO_COPY_THRESHOLD: int = 256
@@ -1744,6 +1745,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # instead of forcing TRITON_ATTN. Default-on for nvfp4 KV; "0" is the
     # escape hatch back to the Triton fallback.
     "VLLM_NVFP4_KV_VOSPLIT": lambda: bool(int(os.getenv("VLLM_NVFP4_KV_VOSPLIT", "1"))),
+    # Let the FlashInfer backend serve mm-prefix LMs (Gemma 3 / Gemma 4
+    # multimodal): image-token spans attend bidirectionally via FA2
+    # packed custom masks on a second prefill wrapper; text requests
+    # stay on the fast causal path. Lifts the is_mm_prefix_lm backend
+    # rejection without requiring --language-model-only. Default-on so
+    # multimodal Gemma 3/4 masks image spans correctly out of the box;
+    # set to "0" to route mm-prefix models away from FlashInfer instead.
+    "VLLM_FLASHINFER_MM_PREFIX": lambda: bool(
+        int(os.getenv("VLLM_FLASHINFER_MM_PREFIX", "1"))
+    ),
     # Control the maximum number of tokens per expert supported by the
     # NVFP4 MoE CUTLASS Kernel. This value is used to create a buffer for
     # the blockscale tensor of activations NVFP4 Quantization.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -202,6 +202,7 @@ if TYPE_CHECKING:
     VLLM_FLASHINFER_ALLREDUCE_BACKEND: Literal["auto", "trtllm", "mnnvl"] = "auto"
     VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE: int = 394 * 1024 * 1024
     VLLM_NVFP4_KV_VOSPLIT: bool = True
+    VLLM_FLASHINFER_MM_PREFIX: bool = True
     VLLM_XGRAMMAR_CACHE_MB: int = 0
     VLLM_REGEX_COMPILATION_TIMEOUT_S: int = 5
     VLLM_MSGPACK_ZERO_COPY_THRESHOLD: int = 256
@@ -1655,6 +1656,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # instead of forcing TRITON_ATTN. Default-on for nvfp4 KV; "0" is the
     # escape hatch back to the Triton fallback.
     "VLLM_NVFP4_KV_VOSPLIT": lambda: bool(int(os.getenv("VLLM_NVFP4_KV_VOSPLIT", "1"))),
+    # Let the FlashInfer backend serve mm-prefix LMs (Gemma 3 / Gemma 4
+    # multimodal): image-token spans attend bidirectionally via FA2
+    # packed custom masks on a second prefill wrapper; text requests
+    # stay on the fast causal path. Lifts the is_mm_prefix_lm backend
+    # rejection without requiring --language-model-only. Default-on so
+    # multimodal Gemma 3/4 masks image spans correctly out of the box;
+    # set to "0" to route mm-prefix models away from FlashInfer instead.
+    "VLLM_FLASHINFER_MM_PREFIX": lambda: bool(
+        int(os.getenv("VLLM_FLASHINFER_MM_PREFIX", "1"))
+    ),
     # Control the maximum number of tokens per expert supported by the
     # NVFP4 MoE CUTLASS Kernel. This value is used to create a buffer for
     # the blockscale tensor of activations NVFP4 Quantization.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -217,6 +217,7 @@ if TYPE_CHECKING:
     VLLM_FLASHINFER_AUTOTUNE_SKIP_OPS: list[str] | None = None
     VLLM_FLASHINFER_ALLREDUCE_BACKEND: Literal["auto", "trtllm", "mnnvl"] = "auto"
     VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE: int = 394 * 1024 * 1024
+    VLLM_NVFP4_KV_VOSPLIT: bool = True
     VLLM_XGRAMMAR_CACHE_MB: int = 0
     VLLM_REGEX_COMPILATION_TIMEOUT_S: int = 5
     VLLM_MSGPACK_ZERO_COPY_THRESHOLD: int = 256
@@ -1737,6 +1738,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE": lambda: int(
         os.getenv("VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE", str(394 * 1024 * 1024))
     ),
+    # NVFP4 KV cache VO-split on consumer Blackwell (CC 12.x): route
+    # Gemma-4 heterogeneous-head full-attention layers (head_dim_qk=512,
+    # head_dim_vo=256) through the FlashInfer FA2 asymmetric paged kernel
+    # instead of forcing TRITON_ATTN. Default-on for nvfp4 KV; "0" is the
+    # escape hatch back to the Triton fallback.
+    "VLLM_NVFP4_KV_VOSPLIT": lambda: bool(int(os.getenv("VLLM_NVFP4_KV_VOSPLIT", "1"))),
     # Control the maximum number of tokens per expert supported by the
     # NVFP4 MoE CUTLASS Kernel. This value is used to create a buffer for
     # the blockscale tensor of activations NVFP4 Quantization.

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -563,12 +563,14 @@ def choose_scaled_mm_linear_kernel(
     linear_backend = _get_linear_backend()
     if linear_backend != "auto":
         filtered = _filter_kernels_by_backend(linear_backend, platform_kernels)
-        if not filtered:
-            raise ValueError(
-                f"--linear-backend={linear_backend} was requested but no "
-                f"'{linear_backend}' kernel exists for this layer type."
+        if filtered:
+            platform_kernels = filtered
+        else:
+            logger.debug(
+                "--linear-backend=%s has no kernel for this layer type, "
+                "falling back to auto-selection.",
+                linear_backend,
             )
-        platform_kernels = filtered
 
     for kernel in platform_kernels:
         is_supported_and_can_implement, failure_reason = (
@@ -727,12 +729,14 @@ def choose_mp_linear_kernel(
     linear_backend = _get_linear_backend()
     if linear_backend != "auto":
         filtered = _filter_kernels_by_backend(linear_backend, platform_kernels)
-        if not filtered:
-            raise ValueError(
-                f"--linear-backend={linear_backend} was requested but no "
-                f"'{linear_backend}' kernel exists for mixed-precision layers."
+        if filtered:
+            platform_kernels = filtered
+        else:
+            logger.debug(
+                "--linear-backend=%s has no kernel for mixed-precision "
+                "layers, falling back to auto-selection.",
+                linear_backend,
             )
-        platform_kernels = filtered
 
     failure_reasons = []
     for kernel in platform_kernels:
@@ -778,12 +782,14 @@ def init_mxfp8_linear_kernel() -> Mxfp8LinearKernel:
     linear_backend = _get_linear_backend()
     if linear_backend != "auto":
         filtered = _filter_kernels_by_backend(linear_backend, possible)
-        if not filtered:
-            raise ValueError(
-                f"--linear-backend={linear_backend} was requested but no "
-                f"'{linear_backend}' kernel exists for MXFP8 layers."
+        if filtered:
+            possible = filtered
+        else:
+            logger.debug(
+                "--linear-backend=%s has no kernel for MXFP8 layers, "
+                "falling back to auto-selection.",
+                linear_backend,
             )
-        possible = filtered
 
     failure_reasons = []
     for kernel_cls in possible:
@@ -823,12 +829,14 @@ def init_mxfp4_linear_kernel() -> MxFp4LinearKernel:
     # Apply --linear-backend filtering when set.
     if linear_backend != "auto":
         filtered = _filter_kernels_by_backend(linear_backend, possible)
-        if not filtered:
-            raise ValueError(
-                f"--linear-backend={linear_backend} was requested but no "
-                f"'{linear_backend}' kernel exists for MXFP4 layers."
+        if filtered:
+            possible = filtered
+        else:
+            logger.debug(
+                "--linear-backend=%s has no kernel for MXFP4 layers, "
+                "falling back to auto-selection.",
+                linear_backend,
             )
-        possible = filtered
 
     failure_reasons = []
     for kernel_cls in possible:
@@ -947,12 +955,14 @@ def init_nvfp4_linear_kernel(use_a16: bool = False) -> NvFp4LinearKernel:
     # Apply --linear-backend filtering when set.
     if linear_backend != "auto":
         filtered = _filter_kernels_by_backend(linear_backend, possible)
-        if not filtered:
-            raise ValueError(
-                f"--linear-backend={linear_backend} was requested but no "
-                f"'{linear_backend}' kernel exists for NVFP4 layers."
+        if filtered:
+            possible = filtered
+        else:
+            logger.debug(
+                "--linear-backend=%s has no kernel for NVFP4 layers, "
+                "falling back to auto-selection.",
+                linear_backend,
             )
-        possible = filtered
 
     failure_reasons = []
     for kernel_cls in possible:

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -938,7 +938,6 @@ def init_mxfp6_linear_kernel(
                 f"--linear-backend={linear_backend} was requested but no "
                 f"'{linear_backend}' kernel exists for MXFP6 layers."
             )
-        possible = filtered
 
     failure_reasons = []
     for kernel_cls in possible:

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -204,6 +204,8 @@ def fi_chunk_gated_delta_rule(
     fi_state = initial_state.to(torch.float32)
     fi_g = g.to(torch.float32)
     fi_beta = beta.to(torch.float32)
+    if cu_seqlens is not None:
+        cu_seqlens = cu_seqlens.to(torch.int64)
     result = chunk_gated_delta_rule_fi(
         q=q,
         k=k,

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -100,7 +100,8 @@ def _resolve_gdn_prefill_backend(
     * ``platform == cuda``;
     * one of the following:
       - Hopper (SM90) — no further constraints;
-      - Blackwell (SM10.x) with ``head_k_dim == 128``, ``cuda_runtime >= 13``.
+      - Blackwell (SM10.x) with ``head_k_dim == 128``, ``cuda_runtime >= 13``;
+      - Blackwell GeForce (SM12.x) with ``head_k_dim <= 128``.
 
     In-tree CuteDSL GDN prefill kernel is chosen when:
     * "cutedsl" is requested; (opt-in only)
@@ -133,6 +134,12 @@ def _resolve_gdn_prefill_backend(
     ):
         supports_flashinfer = True
         supports_cutedsl = True
+    elif (
+        current_platform.is_device_capability_family(120)
+        and head_k_dim is not None
+        and head_k_dim <= 128
+    ):
+        supports_flashinfer = True
 
     if backend in ["flashinfer", "auto"] and supports_flashinfer:
         return backend, "flashinfer"

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -92,7 +92,8 @@ def _resolve_gdn_prefill_backend(
     * ``platform == cuda``;
     * one of the following:
       - Hopper (SM90) — no further constraints;
-      - Blackwell (SM10.x) with ``head_k_dim == 128``, ``cuda_runtime >= 13``.
+      - Blackwell (SM10.x) with ``head_k_dim == 128``, ``cuda_runtime >= 13``;
+      - Blackwell GeForce (SM12.x) with ``head_k_dim <= 128``.
 
     In-tree CuteDSL GDN prefill kernel is chosen when:
     * "cutedsl" is requested; (opt-in only)
@@ -125,6 +126,12 @@ def _resolve_gdn_prefill_backend(
     ):
         supports_flashinfer = True
         supports_cutedsl = True
+    elif (
+        current_platform.is_device_capability_family(120)
+        and head_k_dim is not None
+        and head_k_dim <= 128
+    ):
+        supports_flashinfer = True
 
     if backend in ["flashinfer", "auto"] and supports_flashinfer:
         return backend, "flashinfer"

--- a/vllm/model_executor/layers/mamba/mamba_utils.py
+++ b/vllm/model_executor/layers/mamba/mamba_utils.py
@@ -365,7 +365,10 @@ def get_conv_copy_spec(
     DS layout ``(num_blocks, dim, state_len)``.
     """
     src_block_id = block_ids[cur_block_idx]
-    offset = num_accepted_tokens - 1
+    # num_accepted_tokens can be 0 for stale rows whose sampled tokens were
+    # discarded; clamp so the offset never goes negative (a negative value
+    # would silently slice from the end of the state).
+    offset = max(num_accepted_tokens - 1, 0)
     if is_conv_state_dim_first():
         # DS offset > 0 is handled by the fused postprocess kernel.
         assert offset == 0, (
@@ -388,7 +391,10 @@ def get_temporal_copy_spec(
     num_accepted_tokens: int,
 ) -> MambaCopySpec:
     """Return a MambaCopySpec for copying a temporal state slice."""
-    src_block_id = block_ids[cur_block_idx + num_accepted_tokens - 1]
+    # num_accepted_tokens can be 0 for stale rows whose sampled tokens were
+    # discarded; clamp so the index never goes negative (a negative value
+    # would silently pick a block from the end of the list).
+    src_block_id = block_ids[cur_block_idx + max(num_accepted_tokens - 1, 0)]
     src_state = state[src_block_id]
     return MambaCopySpec(
         start_addr=src_state.data_ptr(), num_elements=src_state.numel()

--- a/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
+++ b/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
@@ -871,9 +871,24 @@ def _causal_conv1d_update_kernel(
         # - accept 1 tokens: [history2, ..., historyM, draft1]
         # - accept 2 tokens: [history3, ..., historyM, draft1, draft2]
         # - and so on.
-        conv_state_token_offset = (
-            tl.load(num_accepted_tokens_ptr + idx_seq).to(tl.int64) - 1
-        )
+        # A zero or too-large (stale or padded batch row) num_accepted entry
+        # would index the conv state out of bounds; emit zero output and
+        # leave state untouched (upstream PR #50021 pattern).
+        num_accepted = tl.load(num_accepted_tokens_ptr + idx_seq).to(tl.int64)
+        if (num_accepted < 1) | (num_accepted > seqlen):
+            zero = tl.zeros((BLOCK_N,), dtype=tl.float32)
+            for idx_token in tl.range(seqlen):
+                o_ptrs = (
+                    o_ptr
+                    + o_offset
+                    + idx_token * stride_o_token
+                    + idx_feats * stride_o_dim
+                )
+                tl.store(o_ptrs, zero, mask=idx_feats < dim)
+            if launch_pdl:
+                tl.extra.cuda.gdc_launch_dependents()
+            return
+        conv_state_token_offset = num_accepted - 1
     else:
         conv_state_token_offset = 0
 

--- a/vllm/model_executor/layers/mamba/ops/mamba_ssm.py
+++ b/vllm/model_executor/layers/mamba/ops/mamba_ssm.py
@@ -333,7 +333,15 @@ def _selective_scan_update_kernel(
     if HAS_STATE_BATCH_INDICES:
         if IS_SPEC_DECODING:
             num_accepted = tl.load(num_accepted_tokens_ptr + pid_b).to(tl.int64)
+            # Preserve the existing zero-count clamp while bounding the
+            # accepted-token-derived state lookup to this request's row.
+            # The bound is the ROW stride (elements per batch row), matching
+            # fused_recurrent.py's i_t < stride_indices_seq: for a contiguous
+            # [batch, T] tensor stride(0) == T. stride(1) would be 1 there,
+            # which rejects every accepted count > 1 (and a padded row keeps
+            # any overshoot inside this request's allocated slack).
             init_token_idx = tl.maximum(num_accepted - 1, 0)
+            valid_initial_token = init_token_idx < stride_state_indices_batch
         else:
             init_token_idx = 0
 
@@ -347,9 +355,17 @@ def _selective_scan_update_kernel(
                 dst_state_batch_idx * stride_state_batch + pid_h * stride_state_head
             )
 
-        state_batch_indices_ptr += (
-            pid_b * stride_state_indices_batch + init_token_idx * stride_state_indices_T
-        )
+        state_batch_indices_ptr += pid_b * stride_state_indices_batch
+        if IS_SPEC_DECODING and not valid_initial_token:
+            offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+            zero = tl.zeros([BLOCK_SIZE_M], dtype=tl.float32)
+            out_ptr += bos * stride_out_batch + pid_h * stride_out_head
+            for _ in range(seq_len):
+                tl.store(out_ptr + offs_m * stride_out_dim, zero, mask=offs_m < dim)
+                out_ptr += stride_out_batch
+            return
+
+        state_batch_indices_ptr += init_token_idx * stride_state_indices_T
         state_batch_idx = tl.load(state_batch_indices_ptr).to(tl.int64)
         state_ptr += state_batch_idx * stride_state_batch + pid_h * stride_state_head
     else:

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -1045,10 +1045,11 @@ class CompressedTensorsKVCacheMethod(BaseKVCacheMethod):
         type_ = kv_cache_scheme.get("type")
         num_bits = kv_cache_scheme.get("num_bits")
 
-        if type_ != "float" or num_bits != 8:
+        # num_bits=8 -> fp8 KV; num_bits=4 -> nvfp4 KV (consumer Blackwell FA2).
+        if type_ != "float" or num_bits not in (4, 8):
             raise NotImplementedError(
                 "Currently supported kv cache quantization is "
-                "num_bits=8, type=float, however "
+                "num_bits in (4, 8), type=float, however "
                 f"received num_bits={num_bits}, type={type_}"
             )
 

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -1053,10 +1053,11 @@ class CompressedTensorsKVCacheMethod(BaseKVCacheMethod):
         type_ = kv_cache_scheme.get("type")
         num_bits = kv_cache_scheme.get("num_bits")
 
-        if type_ != "float" or num_bits != 8:
+        # num_bits=8 -> fp8 KV; num_bits=4 -> nvfp4 KV (consumer Blackwell FA2).
+        if type_ != "float" or num_bits not in (4, 8):
             raise NotImplementedError(
                 "Currently supported kv cache quantization is "
-                "num_bits=8, type=float, however "
+                "num_bits in (4, 8), type=float, however "
                 f"received num_bits={num_bits}, type={type_}"
             )
 

--- a/vllm/model_executor/layers/quantized_draft_embedding.py
+++ b/vllm/model_executor/layers/quantized_draft_embedding.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Low-bit vocab embedding for speculative-decode draft models (A1c).
+
+The MTP draft loads its own full-precision copy of a huge vocab embedding on the
+last PP rank, which is what pushes 27B+draft over 2x16 GiB. Because the draft is
+only a speculative proposer (rejection sampling guarantees the final output equals
+target greedy regardless of draft quality), a *lossy* low-bit draft embedding is
+correctness-safe: it only lowers acceptance, never changes the output.
+
+Critically (RUN-A on the real 27B): the int storage is allocated **at
+construction** and the fp16 checkpoint weight is quantized **as it loads**, so the
+full fp16 [vocab, hidden] table never materializes on the GPU (a post-load swap
+OOMs at the load peak before it can free anything). The checkpoint's
+``embed_tokens.weight`` is routed through ``weight`` — an empty placeholder
+Parameter carrying a ``weight_loader`` that quantizes the incoming fp16 tensor
+(which lives on CPU during loading) into the pre-allocated GPU int storage.
+
+Targets TP=1 (the draft runs single-rank), so the lookup is a plain gather with
+no all-reduce. Bit-widths: 8 (int8, 1 byte/weight) and 4 (int4 packed 2
+nibbles/byte, 0.5 byte/weight; requires an even hidden dimension).
+"""
+
+import torch
+from torch import nn
+
+
+def _quantize_per_row(
+    weight: torch.Tensor, bits: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-row symmetric quantization. Returns (qweight, scale).
+
+    qweight is int8 [V, H] for bits=8, or uint8 [V, H//2] (two packed signed
+    nibbles per byte) for bits=4. scale is fp32 [V].
+    """
+    qmax = 2 ** (bits - 1) - 1  # 127 (int8) / 7 (int4)
+    row_absmax = weight.abs().amax(dim=1).clamp_min(1e-12)
+    scale = (row_absmax / qmax).to(torch.float32)
+    q = (weight.to(torch.float32) / scale.unsqueeze(1)).round().clamp_(-qmax, qmax)
+    if bits == 8:
+        return q.to(torch.int8), scale
+    # bits == 4: pack two signed nibbles per uint8 byte.
+    u = (q + 8).to(torch.uint8)  # [-7, 7] -> [1, 15], fits 4 bits
+    qweight = (u[:, 0::2] | (u[:, 1::2] << 4)).contiguous()
+    return qweight, scale
+
+
+class QuantizedVocabEmbedding(nn.Module):
+    """Per-row symmetric low-bit vocab embedding (lookup + dequant).
+
+    Args:
+        num_embeddings: vocabulary size (V).
+        embedding_dim: hidden size (H).
+        bits: quantization bit-width (8 or 4).
+        params_dtype: dtype the lookup returns (matches the model's dtype).
+    """
+
+    def __init__(
+        self,
+        num_embeddings: int,
+        embedding_dim: int,
+        *,
+        bits: int = 8,
+        params_dtype: torch.dtype = torch.float16,
+        device: torch.device | None = None,
+    ) -> None:
+        super().__init__()
+        if bits not in (4, 8):
+            raise NotImplementedError(f"bits={bits} not yet supported")
+        if bits == 4 and embedding_dim % 2 != 0:
+            raise ValueError("int4 packing requires an even hidden size")
+        self.bits = bits
+        self.out_dtype = params_dtype
+        self.num_embeddings = num_embeddings
+        self.hidden_size = embedding_dim
+
+        packed_cols = embedding_dim if bits == 8 else embedding_dim // 2
+        qdtype = torch.int8 if bits == 8 else torch.uint8
+        self.register_buffer(
+            "qweight",
+            torch.zeros((num_embeddings, packed_cols), dtype=qdtype, device=device),
+            persistent=False,
+        )
+        self.register_buffer(
+            "scale",
+            torch.zeros(num_embeddings, dtype=torch.float32, device=device),
+            persistent=False,
+        )
+        # Entry point for the checkpoint loader: an EMPTY placeholder (never a
+        # full fp16 [V, H] table — that is the OOM peak we are avoiding). The
+        # AutoWeightsLoader matches the checkpoint's ``embed_tokens.weight`` to
+        # this param and calls its ``weight_loader``, which quantizes on the fly.
+        self.weight = nn.Parameter(
+            torch.empty(0, dtype=params_dtype, device=device), requires_grad=False
+        )
+        self.weight.weight_loader = self._weight_loader
+
+    @classmethod
+    def from_weight(
+        cls, weight: torch.Tensor, *, bits: int = 8
+    ) -> "QuantizedVocabEmbedding":
+        """Build and quantize from a full fp16 weight (tests / post-load)."""
+        m = cls(
+            weight.shape[0],
+            weight.shape[1],
+            bits=bits,
+            params_dtype=weight.dtype,
+            device=weight.device,
+        )
+        m.load_full_weight(weight)
+        return m
+
+    def load_full_weight(self, weight: torch.Tensor) -> None:
+        """Quantize a full fp16 [V, H] table into the pre-allocated int storage."""
+        qweight, scale = _quantize_per_row(weight, self.bits)
+        self.qweight.copy_(qweight)
+        self.scale.copy_(scale)
+
+    def _weight_loader(self, param: nn.Parameter, loaded_weight: torch.Tensor) -> None:
+        # ``param`` is the empty placeholder; quantize the incoming fp16 tensor
+        # (on CPU during loading) straight into the GPU int storage.
+        self.load_full_weight(loaded_weight)
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        rows = self.qweight[input_ids]
+        if self.bits == 8:
+            deq = rows.to(torch.float32)
+        else:  # unpack nibbles back to signed int4 values
+            low = (rows & 0x0F).to(torch.int16) - 8
+            high = ((rows >> 4) & 0x0F).to(torch.int16) - 8
+            deq = torch.stack([low, high], dim=-1)
+            deq = deq.reshape(*rows.shape[:-1], self.hidden_size).to(torch.float32)
+        out = deq * self.scale[input_ids].unsqueeze(-1)
+        return out.to(self.out_dtype)

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -216,8 +216,40 @@ class Gemma4Config(VerifyAndUpdateConfig):
         if head_dim is None or global_head_dim is None or head_dim == global_head_dim:
             return
 
-        from vllm.v1.attention.backends.fa_utils import is_fa_version_supported
+        # NVFP4 KV cache on consumer Blackwell (CC 12.x): the FlashInfer
+        # FA2 asymmetric paged kernel handles head_dim_qk=512 /
+        # head_dim_vo=256 directly (the two-pass VO-split path), so route
+        # the heterogeneous-head Gemma 4 config to FLASHINFER instead of
+        # the TRITON_ATTN fallback below. Gated on VLLM_NVFP4_KV_VOSPLIT
+        # (default-on for nvfp4) and only when the user did not pin a
+        # backend. Returns before the FA4/Triton selection.
+        import vllm.envs as envs
+        from vllm.platforms import current_platform
         from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+        cache_config = vllm_config.cache_config
+        if (
+            cache_config is not None
+            and cache_config.cache_dtype == "nvfp4"
+            and envs.VLLM_NVFP4_KV_VOSPLIT
+            and vllm_config.attention_config.backend is None
+            and current_platform.is_device_capability_family(120)
+        ):
+            vllm_config.attention_config.backend = AttentionBackendEnum.FLASHINFER
+            logger.info(
+                "Gemma4 model has heterogeneous head dimensions "
+                "(head_dim=%d, global_head_dim=%d) with NVFP4 KV cache on "
+                "CC 12.x. Routing to FLASHINFER (FA2 VO-split asymmetric "
+                "head_dim_qk=%d/head_dim_vo=%d kernel) instead of "
+                "TRITON_ATTN.",
+                head_dim,
+                global_head_dim,
+                global_head_dim,
+                head_dim,
+            )
+            return
+
+        from vllm.v1.attention.backends.fa_utils import is_fa_version_supported
 
         max_head_dim = max(head_dim, global_head_dim)
 

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -240,6 +240,8 @@ class Gemma4Config(VerifyAndUpdateConfig):
             and current_platform.is_device_capability_family(120)
         ):
             vllm_config.attention_config.backend = AttentionBackendEnum.FLASHINFER
+            head_dim = min(head_dims.values())
+            global_head_dim = max(head_dims.values())
             logger.info(
                 "Gemma4 model has heterogeneous head dimensions "
                 "(head_dim=%d, global_head_dim=%d) with NVFP4 KV cache on "

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -220,8 +220,38 @@ class Gemma4Config(VerifyAndUpdateConfig):
         if len(set(head_dims.values())) <= 1:
             return
 
-        from vllm.v1.attention.backends.fa_utils import is_fa_version_supported
+        # NVFP4 KV cache on consumer Blackwell (CC 12.x): the FlashInfer
+        # FA2 asymmetric paged kernel handles head_dim_qk=512 /
+        # head_dim_vo=256 directly (the two-pass VO-split path), so route
+        # the heterogeneous-head Gemma 4 config to FLASHINFER instead of
+        # the TRITON_ATTN fallback below. Gated on VLLM_NVFP4_KV_VOSPLIT
+        # (default-on for nvfp4) and only when the user did not pin a
+        # backend. Returns before the FA4/Triton selection.
+        import vllm.envs as envs
+        from vllm.platforms import current_platform
         from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+        cache_config = vllm_config.cache_config
+        if (
+            cache_config is not None
+            and cache_config.cache_dtype == "nvfp4"
+            and envs.VLLM_NVFP4_KV_VOSPLIT
+            and vllm_config.attention_config.backend is None
+            and current_platform.is_device_capability_family(120)
+        ):
+            vllm_config.attention_config.backend = AttentionBackendEnum.FLASHINFER
+            logger.info(
+                "Gemma4 model has heterogeneous head dimensions "
+                "(head_dim=%d, global_head_dim=%d) with NVFP4 KV cache on "
+                "CC 12.x. Routing to FLASHINFER (FA2 VO-split asymmetric "
+                "head_dim_qk=%d/head_dim_vo=%d kernel) instead of "
+                "TRITON_ATTN.",
+                head_dim,
+                global_head_dim,
+                global_head_dim,
+                head_dim,
+            )
+            return
 
         max_head_dim = max(head_dims.values())
 

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -234,7 +234,7 @@ class Gemma4Config(VerifyAndUpdateConfig):
         cache_config = vllm_config.cache_config
         if (
             cache_config is not None
-            and cache_config.cache_dtype == "nvfp4"
+            and cache_config.cache_dtype.startswith("nvfp4")
             and envs.VLLM_NVFP4_KV_VOSPLIT
             and vllm_config.attention_config.backend is None
             and current_platform.is_device_capability_family(120)

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -257,6 +257,8 @@ class Gemma4Config(VerifyAndUpdateConfig):
 
         max_head_dim = max(head_dims.values())
 
+        from vllm.v1.attention.backends.fa_utils import is_fa_version_supported
+
         if is_fa_version_supported(4) and max_head_dim <= 512:
             if (
                 vllm_config.attention_config.flash_attn_version is None

--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -14,11 +14,17 @@ from vllm.distributed import get_pp_group, tensor_model_parallel_all_gather
 from vllm.logger import init_logger
 from vllm.model_executor.layers.linear import ColumnParallelLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.quantized_draft_embedding import (
+    QuantizedVocabEmbedding,
+)
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
 )
-from vllm.model_executor.models.interfaces import LocalArgmaxMixin
+from vllm.model_executor.models.interfaces import (
+    LocalArgmaxMixin,
+    SupportsPP,
+)
 from vllm.model_executor.models.qwen3_5 import (
     Qwen3_5DecoderLayer,
     Qwen3_5Model,
@@ -74,15 +80,46 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
 
         self.config = config
 
+        # Design C (standalone draft): when the draft runs with its own
+        # pipeline_parallel_size == 1 (decoupled from a target PP>1), it executes
+        # only on the last global PP rank. There `get_pp_group().is_first_rank`
+        # is False, so the forward would wrongly take the inter-stage path and
+        # demand intermediate_tensors the proposer never supplies. This flag makes
+        # the forward behave as first==last (embed -> fc -> layer -> norm). The
+        # draft's embed_tokens is already weight-loaded on the last rank and the
+        # target hidden state is resident there, so no cross-stage traffic is
+        # needed.
+        spec_config = vllm_config.speculative_config
+        self.standalone_draft = (
+            spec_config is not None and spec_config.draft_pipeline_parallel_size == 1
+        )
+
         self.vocab_size = config.vocab_size
 
         self.mtp_start_layer_idx = config.num_hidden_layers
         self.num_mtp_layers = getattr(config, "mtp_num_hidden_layers", 1)
 
-        self.embed_tokens = VocabParallelEmbedding(
-            self.vocab_size,
-            config.hidden_size,
+        quant_bits = (
+            spec_config.draft_embed_quant_bits if spec_config is not None else None
         )
+        if quant_bits is not None:
+            # A1c: under PP the draft holds its own copy of the (huge) vocab
+            # embedding on the last rank. Quantize it at LOAD time (int storage
+            # allocated here; the checkpoint fp16 weight is quantized as it loads)
+            # so the full fp16 [vocab, hidden] table never materializes on the GPU
+            # — a post-load swap OOMs at the load peak. Correctness is unaffected
+            # (rejection sampling); only the acceptance rate may drop.
+            self.embed_tokens = QuantizedVocabEmbedding(
+                self.vocab_size,
+                config.hidden_size,
+                bits=quant_bits,
+                params_dtype=torch.get_default_dtype(),
+            )
+        else:
+            self.embed_tokens = VocabParallelEmbedding(
+                self.vocab_size,
+                config.hidden_size,
+            )
 
         # Workaround: mtp.fc is stored as BF16 in NVFP4 checkpoints but is
         # missing from hf_quant_config.json exclude_modules. Force unquantized.
@@ -145,7 +182,7 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
         inputs_embeds: torch.Tensor | None = None,
         spec_step_idx: int = 0,
     ) -> torch.Tensor:
-        if get_pp_group().is_first_rank:
+        if self.standalone_draft or get_pp_group().is_first_rank:
             if inputs_embeds is None:
                 inputs_embeds = self.embed_input_ids(input_ids)
             assert hidden_states.shape[-1] == inputs_embeds.shape[-1]
@@ -171,7 +208,7 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
             residual=residual,
         )
 
-        if not get_pp_group().is_last_rank:
+        if not (self.standalone_draft or get_pp_group().is_last_rank):
             return IntermediateTensors(
                 {"hidden_states": hidden_states, "residual": residual}
             )
@@ -208,7 +245,7 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
         "hidden_states": 0,
     }
 )
-class Qwen3_5MTP(LocalArgmaxMixin, nn.Module, SupportsMultiModal):
+class Qwen3_5MTP(LocalArgmaxMixin, nn.Module, SupportsMultiModal, SupportsPP):
     packed_modules_mapping = {
         "qkv_proj": [
             "q_proj",
@@ -235,7 +272,17 @@ class Qwen3_5MTP(LocalArgmaxMixin, nn.Module, SupportsMultiModal):
         self.model = Qwen3_5MultiTokenPredictor(
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "mtp")
         )
+        # Expose the inner predictor's PP intermediate-tensor factory so this
+        # wrapper satisfies the SupportsPP interface (Design B: the draft is
+        # sharded across the same PP stages as the target).
+        self.make_empty_intermediate_tensors = (
+            self.model.make_empty_intermediate_tensors
+        )
 
+        spec_config = vllm_config.speculative_config
+        skip_lm_head_alloc = (
+            spec_config is not None and spec_config.draft_embed_quant_bits is not None
+        )
         if get_pp_group().is_last_rank:
             self.lm_head = ParallelLMHead(
                 config.vocab_size,
@@ -245,6 +292,13 @@ class Qwen3_5MTP(LocalArgmaxMixin, nn.Module, SupportsMultiModal):
             )
             if config.tie_word_embeddings:
                 self.lm_head = self.lm_head.tie_weights(self.model.embed_tokens)
+            elif skip_lm_head_alloc:
+                # A1c memory mode: the MTP draft's lm_head is always shared with
+                # the target's (same last rank) by the proposer's
+                # _maybe_share_lm_head. Materializing a full fp16 ParallelLMHead
+                # here only to discard it OOMs at the load peak — use a
+                # placeholder; sharing fills it.
+                self.lm_head = PPMissingLayer()
         else:
             self.lm_head = PPMissingLayer()
 

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -220,16 +220,21 @@ def _flashinfer_autotune_skip_ops(runner: "GPUModelRunner") -> set[str] | None:
         return set(envs.VLLM_FLASHINFER_AUTOTUNE_SKIP_OPS) or None
 
     from vllm.model_executor.kernels.linear import (
+        FlashInferB12xNvFp4LinearKernel,
         FlashInferCuteDslNvFp4LinearKernel,
     )
 
     for module in runner.get_model().modules():
         for holder_name in ("quant_method", "scheme"):
             kernel = getattr(getattr(module, holder_name, None), "kernel", None)
-            # CuTe-DSL mm_fp4 tuning JIT-compiles every tactic and its
-            # fallback is already the heuristic; all mm_fp4 backends share
-            # the "fp4_gemm" op name, so skip only when cute-dsl is selected.
-            if isinstance(kernel, FlashInferCuteDslNvFp4LinearKernel):
+            # CuTe-DSL and b12x mm_fp4 tuning JIT-compiles every tactic into
+            # separate CUDA modules that permanently occupy VRAM. Their
+            # fallback heuristics are already good; skip fp4_gemm tuning.
+            if isinstance(
+                kernel,
+                (FlashInferCuteDslNvFp4LinearKernel,
+                 FlashInferB12xNvFp4LinearKernel),
+            ):
                 return {"fp4_gemm"}
     return None
 

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -201,16 +201,21 @@ def _flashinfer_autotune_skip_ops(runner: "GPUModelRunner") -> set[str] | None:
         return set(envs.VLLM_FLASHINFER_AUTOTUNE_SKIP_OPS) or None
 
     from vllm.model_executor.kernels.linear import (
+        FlashInferB12xNvFp4LinearKernel,
         FlashInferCuteDslNvFp4LinearKernel,
     )
 
     for module in runner.get_model().modules():
         for holder_name in ("quant_method", "scheme"):
             kernel = getattr(getattr(module, holder_name, None), "kernel", None)
-            # CuTe-DSL mm_fp4 tuning JIT-compiles every tactic and its
-            # fallback is already the heuristic; all mm_fp4 backends share
-            # the "fp4_gemm" op name, so skip only when cute-dsl is selected.
-            if isinstance(kernel, FlashInferCuteDslNvFp4LinearKernel):
+            # CuTe-DSL and b12x mm_fp4 tuning JIT-compiles every tactic into
+            # separate CUDA modules that permanently occupy VRAM. Their
+            # fallback heuristics are already good; skip fp4_gemm tuning.
+            if isinstance(
+                kernel,
+                (FlashInferCuteDslNvFp4LinearKernel,
+                 FlashInferB12xNvFp4LinearKernel),
+            ):
                 return {"fp4_gemm"}
     return None
 

--- a/vllm/models/kimi_k3/amd/ops/third_party/kda/fused_recurrent.py
+++ b/vllm/models/kimi_k3/amd/ops/third_party/kda/fused_recurrent.py
@@ -186,12 +186,20 @@ def fused_recurrent_kda_fwd_kernel(
         initial_token = tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1
     else:
         initial_token = 0
-    state_index = tl.load(state_indices + i_n * stride_indices_seq + initial_token).to(
-        tl.int64
+    initial_token_in_row = (initial_token >= 0) & (
+        initial_token < stride_indices_seq
     )
+    state_index = tl.load(
+        state_indices + i_n * stride_indices_seq + initial_token,
+        mask=initial_token_in_row,
+        other=0,
+    ).to(tl.int64)
     p_out = out + bos * stride_out_token + i_h * V + o_v
     if state_index <= 0:
-        tl.store(p_out, tl.zeros([BV], dtype=tl.float32), mask=m_v)
+        zero = tl.zeros([BV], dtype=tl.float32).to(p_out.dtype.element_ty)
+        for _ in range(0, sequence_length):
+            tl.store(p_out, zero, mask=m_v)
+            p_out += stride_out_token
         return
 
     p_state = (

--- a/vllm/models/kimi_k3/nvidia/kda_metadata.py
+++ b/vllm/models/kimi_k3/nvidia/kda_metadata.py
@@ -6,18 +6,13 @@ The request classification and cudagraph staging intentionally mirror
 ``GDNAttentionMetadataBuilder``. Kimi-K3 builds the metadata required by its
 prefill KDA kernel internally, so this builder omits the shared FLA chunk
 metadata construction.
-
-For Kimi-K3 speculative decoding, ``--use-replayssm`` selects the simplified
-RecoverSSM path implemented here instead of the Mamba2 ReplaySSM kernel.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from functools import cache
-from typing import TYPE_CHECKING
 
 import torch
 
-from vllm.config import VllmConfig
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.torch_utils import async_tensor_h2d
@@ -27,21 +22,12 @@ from vllm.v1.attention.backends.gdn_attn import (
     GDNAttentionMetadata,
     GDNAttentionMetadataBuilder,
 )
-from vllm.v1.attention.backends.recoverssm_metadata import (
-    RecoverSSMMetadata,
-    RecoverSSMPostprocessMetadata,
-)
 from vllm.v1.attention.backends.utils import (
     NULL_BLOCK_ID,
     compute_causal_conv1d_metadata,
     split_decodes_and_prefills,
 )
 from vllm.v1.kv_cache_interface import MambaSpec
-
-if TYPE_CHECKING:
-    from vllm.models.kimi_k3.nvidia.ops.recoverssm import (
-        KDARecoverSSMCommitContext,
-    )
 
 
 @cache
@@ -243,103 +229,11 @@ def stage_spec_decode_metadata(
 
 
 @dataclass
-class KDARecoverSSMAlignMetadata:
-    block_table: torch.Tensor
-    num_computed_tokens: torch.Tensor
-    block_size: int
-
-
-@dataclass
-class KDARecoverSSMCommitMetadata:
-    state_indices: torch.Tensor
-    query_start_loc: torch.Tensor
-    request_indices: torch.Tensor | None
-    align: KDARecoverSSMAlignMetadata | None
-
-
-@dataclass
-class KimiK3KDAMetadata(GDNAttentionMetadata, RecoverSSMMetadata):
-    recoverssm_commit: KDARecoverSSMCommitMetadata | None = None
-    recoverssm_context: "KDARecoverSSMCommitContext | None" = field(
-        default=None, repr=False, compare=False
-    )
-
-    def commit_recoverssm_state(
-        self, num_accepted_tokens: torch.Tensor
-    ) -> RecoverSSMPostprocessMetadata | None:
-        commit = self.recoverssm_commit
-        if commit is None:
-            return None
-        context = self.recoverssm_context
-        assert context is not None
-        align = commit.align
-        context.commit(
-            num_accepted_tokens,
-            commit.state_indices[: self.num_spec_decodes, 0],
-            commit.query_start_loc[: self.num_spec_decodes + 1],
-            request_indices=commit.request_indices,
-            block_table=align.block_table if align is not None else None,
-            num_computed_tokens=(
-                align.num_computed_tokens if align is not None else None
-            ),
-            mamba_block_size=align.block_size if align is not None else None,
-        )
-        if align is None:
-            return None
-        return RecoverSSMPostprocessMetadata(
-            num_spec_decodes=self.num_spec_decodes,
-            request_indices=commit.request_indices,
-            block_table=align.block_table,
-            num_computed_tokens=align.num_computed_tokens,
-            block_size=align.block_size,
-        )
+class KimiK3KDAMetadata(GDNAttentionMetadata):
+    pass
 
 
 class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
-    def __init__(
-        self,
-        kv_cache_spec: MambaSpec,
-        layer_names: list[str],
-        vllm_config: VllmConfig,
-        device: torch.device,
-    ) -> None:
-        super().__init__(kv_cache_spec, layer_names, vllm_config, device)
-        self.use_recoverssm = vllm_config.cache_config.use_kda_recoverssm
-        self.spec_state_slots = 1 if self.use_recoverssm else self.num_spec + 1
-        self.recoverssm_num_accepted_tokens: torch.Tensor | None = None
-        self.recoverssm_context: KDARecoverSSMCommitContext | None = None
-        if self.use_recoverssm:
-            max_num_reqs = vllm_config.scheduler_config.max_num_seqs
-            self.spec_state_indices_tensor = torch.empty(
-                (max_num_reqs, 1),
-                dtype=torch.int32,
-                device=device,
-            )
-            self.recoverssm_num_accepted_tokens = torch.ones(
-                max_num_reqs,
-                dtype=torch.int32,
-                device=device,
-            )
-
-    def _get_recoverssm_context(self) -> "KDARecoverSSMCommitContext":
-        context = self.recoverssm_context
-        if context is not None:
-            return context
-
-        from vllm.models.kimi_k3.nvidia.ops.recoverssm import (
-            KDARecoverSSMCommitContext,
-        )
-
-        forward_context = self.vllm_config.compilation_config.static_forward_context
-        layers = [forward_context[layer_name] for layer_name in self.layer_names]
-        context = KDARecoverSSMCommitContext.create(
-            layers,
-            spec_query_len=1 + self.vllm_config.num_speculative_tokens,
-            max_num_reqs=self.vllm_config.scheduler_config.max_num_seqs,
-        )
-        self.recoverssm_context = context
-        return context
-
     def build(  # type: ignore[override]
         self,
         common_prefix_len: int,
@@ -369,26 +263,14 @@ class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
             num_spec_decodes = 0
         else:
             spec_sequence_masks_cpu = num_decode_draft_tokens_cpu >= 0
-            if self.use_recoverssm:
-                assert m.is_prefilling is not None
-                assert m.is_prefilling.device.type == "cpu"
-                active_decode_mask_cpu = (~m.is_prefilling) & (
-                    query_start_loc_cpu.diff() > 0
-                )
-                spec_sequence_masks_cpu |= active_decode_mask_cpu
-            # Native KDA can use its regular decode path when no draft token
-            # was scheduled. RecoverSSM must preserve its extended conv window.
-            if (
-                not self.use_recoverssm
-                and num_decode_draft_tokens_cpu[spec_sequence_masks_cpu].sum().item()
-                == 0
-            ):
+            # A nonnegative entry identifies a spec request. If no draft token
+            # was scheduled, process the whole batch as non-spec instead.
+            if num_decode_draft_tokens_cpu[spec_sequence_masks_cpu].sum().item() == 0:
                 spec_sequence_masks_cpu = None
                 num_spec_decodes = 0
             else:
                 num_spec_decodes = spec_sequence_masks_cpu.sum().item()
 
-        spec_request_indices = None
         if num_spec_decodes == 0:
             # The runner orders ordinary decodes before prefills.
             num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
@@ -407,16 +289,6 @@ class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
             assert spec_sequence_masks_cpu is not None
             assert num_accepted_tokens is not None
             query_lens_cpu = query_start_loc_cpu.diff()
-            if (
-                self.use_recoverssm
-                and torch.any(
-                    query_lens_cpu[spec_sequence_masks_cpu] > self.num_spec + 1
-                ).item()
-            ):
-                raise ValueError(
-                    "KDA RecoverSSM speculative decode query length exceeds "
-                    f"its activation capacity ({self.num_spec + 1})"
-                )
             num_query_tokens = query_start_loc_cpu[-1].item()
 
             # Exclude zero-length cudagraph padding from request-indexed
@@ -453,7 +325,7 @@ class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
                 non_spec_token_indx = None
                 # Real requests precede trailing cudagraph padding.
                 spec_state_indices_tensor = block_table_tensor[
-                    :num_spec_decodes, : self.spec_state_slots
+                    :num_spec_decodes, : self.num_spec + 1
                 ]
                 non_spec_state_indices_tensor = None
                 # Padding trails real requests, so this prefix already contains
@@ -467,12 +339,6 @@ class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
                 spec_sequence_masks_gpu = async_tensor_h2d(
                     spec_sequence_masks_cpu, device=query_start_loc.device
                 )
-                if self.use_recoverssm:
-                    spec_request_indices = async_tensor_h2d(
-                        spec_sequence_masks_cpu.nonzero(as_tuple=True)[0],
-                        dtype=torch.int32,
-                        device=query_start_loc.device,
-                    )
                 spec_token_masks = torch.repeat_interleave(
                     spec_sequence_masks_gpu,
                     query_lens,
@@ -485,10 +351,10 @@ class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
                 non_spec_token_indx = index[:num_non_spec_tokens]
                 spec_token_indx = index[num_non_spec_tokens:]
 
-                # Native spec uses one state slot per step. RecoverSSM keeps
-                # only the current checkpoint slot.
+                # Spec requests carry one state slot per speculative step;
+                # non-spec requests use only their current state slot.
                 spec_state_indices_tensor = block_table_tensor[
-                    spec_sequence_masks_cpu, : self.spec_state_slots
+                    spec_sequence_masks_cpu, : self.num_spec + 1
                 ]
                 non_spec_state_indices_tensor = block_table_tensor[
                     active_non_spec_mask_cpu, 0
@@ -534,18 +400,27 @@ class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
 
                 num_accepted_tokens = num_accepted_tokens[spec_sequence_masks_cpu]
 
-            if self.use_recoverssm:
-                assert self.recoverssm_num_accepted_tokens is not None
-                num_accepted_tokens = self.recoverssm_num_accepted_tokens[
-                    :num_spec_decodes
-                ]
+            # A row can report 0 accepted tokens when its sampled tokens were
+            # discarded (stale async-scheduling step) while its drafts were
+            # still scheduled. Such a row has no valid spec state to resume
+            # from, and its recurrent state must not advance this step: null
+            # its state slots so the kernels skip both the initial-state read
+            # and the final-state write, and clamp the count so the slot
+            # index (num_accepted_tokens - 1) stays in bounds. This is done
+            # out-of-place because the packed-decode branch above slices
+            # block_table_tensor, which can be a view of the runner's
+            # persistent block table.
+            spec_state_indices_tensor = spec_state_indices_tensor.masked_fill(
+                (num_accepted_tokens == 0).unsqueeze(-1), NULL_BLOCK_ID
+            )
+            num_accepted_tokens = num_accepted_tokens.clamp(min=1)
 
         # Unlike the shared GDN layer, Kimi-K3's prefill KDA wrapper prepares
         # its own chunk indices. Only causal-convolution metadata is needed here.
         nums_dict, batch_ptr, token_chunk_offset_ptr = None, None, None
         if num_prefills > 0:
             has_initial_state = m.compute_num_computed_tokens() > 0
-            if num_spec_decodes > 0:
+            if spec_sequence_masks_cpu is not None:
                 has_initial_state = has_initial_state[active_non_spec_mask_cpu]
                 assert non_spec_query_start_loc_cpu is not None
             nums_dict, batch_ptr, token_chunk_offset_ptr = (
@@ -566,7 +441,7 @@ class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
             and num_spec_decodes > 0
             and num_prefills == 0
             and num_decodes == 0
-            and batch_size <= self.spec_state_indices_tensor.shape[0]
+            and num_spec_decodes <= self.decode_cudagraph_max_bs
             and num_spec_decode_tokens <= self.decode_cudagraph_max_bs
         ):
             # Equivalent PyTorch staging:
@@ -603,24 +478,6 @@ class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
                 :batch_size
             ]
 
-        recoverssm_commit = None
-        if self.use_recoverssm and num_spec_decodes > 0:
-            assert spec_state_indices_tensor is not None
-            assert spec_query_start_loc is not None
-            align = None
-            if self.kv_cache_spec.mamba_cache_mode == "align":
-                align = KDARecoverSSMAlignMetadata(
-                    block_table=m.block_table_tensor,
-                    num_computed_tokens=m.compute_num_computed_tokens(),
-                    block_size=self.kv_cache_spec.block_size,
-                )
-            recoverssm_commit = KDARecoverSSMCommitMetadata(
-                state_indices=spec_state_indices_tensor,
-                query_start_loc=spec_query_start_loc,
-                request_indices=spec_request_indices,
-                align=align,
-            )
-
         return KimiK3KDAMetadata(
             num_prefills=num_prefills,
             num_prefill_tokens=num_prefill_tokens,
@@ -638,12 +495,6 @@ class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
             spec_token_indx=spec_token_indx,
             non_spec_token_indx=non_spec_token_indx,
             num_accepted_tokens=num_accepted_tokens,
-            recoverssm_commit=recoverssm_commit,
-            recoverssm_context=(
-                self._get_recoverssm_context()
-                if recoverssm_commit is not None
-                else None
-            ),
             nums_dict=nums_dict,
             batch_ptr=batch_ptr,
             token_chunk_offset_ptr=token_chunk_offset_ptr,

--- a/vllm/models/kimi_k3/nvidia/ops/third_party/kda/fused_recurrent.py
+++ b/vllm/models/kimi_k3/nvidia/ops/third_party/kda/fused_recurrent.py
@@ -185,6 +185,8 @@ def fused_recurrent_kda_fwd_kernel(
     eos = tl.load(cu_seqlens + i_n + 1).to(tl.int64)
     sequence_length = eos - bos
     if sequence_length == 0:
+        if launch_pdl:
+            tl.extra.cuda.gdc_launch_dependents()
         return
 
     o_k = tl.arange(0, BK)
@@ -197,12 +199,22 @@ def fused_recurrent_kda_fwd_kernel(
         initial_token = tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1
     else:
         initial_token = 0
-    state_index = tl.load(state_indices + i_n * stride_indices_seq + initial_token).to(
-        tl.int64
+    initial_token_in_row = (initial_token >= 0) & (
+        initial_token < stride_indices_seq
     )
+    state_index = tl.load(
+        state_indices + i_n * stride_indices_seq + initial_token,
+        mask=initial_token_in_row,
+        other=0,
+    ).to(tl.int64)
     p_out = out + bos * stride_out_token + i_h * V + o_v
     if state_index <= 0:
-        tl.store(p_out, tl.zeros([BV], dtype=tl.float32), mask=m_v)
+        zero = tl.zeros([BV], dtype=tl.float32).to(p_out.dtype.element_ty)
+        for _ in range(0, sequence_length):
+            tl.store(p_out, zero, mask=m_v)
+            p_out += stride_out_token
+        if launch_pdl:
+            tl.extra.cuda.gdc_launch_dependents()
         return
 
     p_state = (

--- a/vllm/third_party/flash_linear_attention/ops/fused_recurrent.py
+++ b/vllm/third_party/flash_linear_attention/ops/fused_recurrent.py
@@ -103,15 +103,30 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
     if USE_INITIAL_STATE:
         if IS_CONTINUOUS_BATCHING:
             if IS_SPEC_DECODING:
-                i_t = tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1
+                # A zero (stale or padded batch row) num_accepted entry must
+                # read the state slot at offset 0, exactly like an entry of 1
+                # (upstream PR #48475 pattern), instead of out-of-bounds -1.
+                i_t = tl.maximum(
+                    tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1, 0
+                )
             else:
                 i_t = 0
-            # Load state index and check for invalid entries
-            state_idx = tl.load(ssm_state_indices + i_n * stride_indices_seq + i_t).to(
-                tl.int64
-            )
-            # Skip if state index is invalid (NULL_BLOCK_ID=0)
+            # ``i_t`` indexes a ``stride_indices_seq``-column row; mask the
+            # load to the row so a stale/too-large count falls into
+            # ``other=0`` instead of reading garbage past the row
+            # (upstream PR #50021 pattern).
+            idx_in_row = (i_t >= 0) & (i_t < stride_indices_seq)
+            state_idx = tl.load(
+                ssm_state_indices + i_n * stride_indices_seq + i_t,
+                mask=idx_in_row,
+                other=0,
+            ).to(tl.int64)
+            # Skip invalid state indices without exposing uninitialized output.
             if state_idx <= 0:
+                zero = tl.zeros([BV], dtype=tl.float32).to(p_o.dtype.element_ty)
+                for _ in range(0, T):
+                    tl.store(p_o, zero, mask=mask_v)
+                    p_o += HV * V
                 return
             p_h0 = h0 + state_idx * stride_init_state_token
         else:

--- a/vllm/third_party/flash_linear_attention/ops/fused_recurrent.py
+++ b/vllm/third_party/flash_linear_attention/ops/fused_recurrent.py
@@ -103,12 +103,7 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
     if USE_INITIAL_STATE:
         if IS_CONTINUOUS_BATCHING:
             if IS_SPEC_DECODING:
-                # A zero (stale or padded batch row) num_accepted entry must
-                # read the state slot at offset 0, exactly like an entry of 1
-                # (upstream PR #48475 pattern), instead of out-of-bounds -1.
-                i_t = tl.maximum(
-                    tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1, 0
-                )
+                i_t = tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1
             else:
                 i_t = 0
             # ``i_t`` indexes a ``stride_indices_seq``-column row; mask the

--- a/vllm/third_party/flash_linear_attention/ops/fused_sigmoid_gating.py
+++ b/vllm/third_party/flash_linear_attention/ops/fused_sigmoid_gating.py
@@ -103,12 +103,7 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
     if USE_INITIAL_STATE:
         if IS_CONTINUOUS_BATCHING:
             if IS_SPEC_DECODING:
-                # A zero (stale or padded batch row) num_accepted entry must
-                # read the state slot at offset 0, exactly like an entry of 1
-                # (upstream PR #48475 pattern), instead of out-of-bounds -1.
-                i_t = tl.maximum(
-                    tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1, 0
-                )
+                i_t = tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1
             else:
                 i_t = 0
             # ``i_t`` indexes a ``stride_indices_seq``-column row; mask the

--- a/vllm/third_party/flash_linear_attention/ops/fused_sigmoid_gating.py
+++ b/vllm/third_party/flash_linear_attention/ops/fused_sigmoid_gating.py
@@ -103,15 +103,30 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
     if USE_INITIAL_STATE:
         if IS_CONTINUOUS_BATCHING:
             if IS_SPEC_DECODING:
-                i_t = tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1
+                # A zero (stale or padded batch row) num_accepted entry must
+                # read the state slot at offset 0, exactly like an entry of 1
+                # (upstream PR #48475 pattern), instead of out-of-bounds -1.
+                i_t = tl.maximum(
+                    tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1, 0
+                )
             else:
                 i_t = 0
-            # Load state index and check for invalid entries
-            state_idx = tl.load(ssm_state_indices + i_n * stride_indices_seq + i_t).to(
-                tl.int64
-            )
-            # Skip if state index is invalid (NULL_BLOCK_ID=0)
+            # ``i_t`` indexes a ``stride_indices_seq``-column row; mask the
+            # load to the row so a stale/too-large count falls into
+            # ``other=0`` instead of reading garbage past the row
+            # (upstream PR #50021 pattern).
+            idx_in_row = (i_t >= 0) & (i_t < stride_indices_seq)
+            state_idx = tl.load(
+                ssm_state_indices + i_n * stride_indices_seq + i_t,
+                mask=idx_in_row,
+                other=0,
+            ).to(tl.int64)
+            # Skip invalid state indices without exposing uninitialized output.
             if state_idx <= 0:
+                zero = tl.zeros([BV], dtype=tl.float32).to(p_o.dtype.element_ty)
+                for _ in range(0, T):
+                    tl.store(p_o, zero, mask=mask_v)
+                    p_o += HV * V
                 return
             p_h0 = h0 + state_idx * stride_init_state_token
         else:

--- a/vllm/tool_parsers/structural_tag_registry.py
+++ b/vllm/tool_parsers/structural_tag_registry.py
@@ -111,7 +111,13 @@ def get_model_structural_tag(
         return None
 
     if tool_choice == "auto" and not _any_tool_strict(tools):
-        return None
+        # Trigger-based models use TriggeredTagsFormat for auto tool choice,
+        # which only enforces the format when the model emits a tool call
+        # trigger. It does not force a tool call, so it's safe to apply
+        # even without strict tools. This prevents malformed/empty-argument
+        # tool calls at the decoding level.
+        if model not in ("qwen_3_coder", "qwen_3_5", "qwen_3"):
+            return None
 
     dumped_tools = [_dump_tool_for_xgrammar(tool) for tool in tools]
     dumped_tool_choice = _dump_tool_choice_for_xgrammar(tool_choice)

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -533,6 +533,7 @@ def nvfp4_kv_cache_full_dim(head_size: int) -> int:
     return head_size // 2 + head_size // 16
 
 
+@torch._dynamo.disable
 def nvfp4_split_data_scale(
     kv_side: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -559,6 +559,27 @@ class FlashInferBackend(AttentionBackend):
         capability = current_platform.get_device_capability()
         if capability is not None and capability.major == 10:
             return "HND"
+        # NVFP4 KV on consumer Blackwell (sm120/sm121, FA2 path): each K/V
+        # side of the cache packs [data | scale] regions carved out of the
+        # side's byte range (reshape_and_cache_nvfp4 writes the scales at
+        # side_base + num_heads * block_size * data_dim;
+        # nvfp4_split_data_scale reads them back with derived strides).
+        # That carve is only byte-coherent when each side's heads own one
+        # contiguous region per page, i.e. under the head-major HND layout.
+        # Under NHD the K and V head rows interleave within each token and
+        # the side-region offsets land inside the other side's data ->
+        # silent KV corruption. This hook has no dtype parameter, so read
+        # the ambient vllm config (same pattern as
+        # get_kv_connector_cache_layout); if the layout hook grows a
+        # dtype-aware signature, this decision moves into it.
+        if capability is not None and capability.major == 12:
+            vllm_config = get_current_vllm_config_or_none()
+            if (
+                vllm_config is not None
+                and vllm_config.cache_config is not None
+                and vllm_config.cache_config.cache_dtype == "nvfp4"
+            ):
+                return "HND"
         return None
 
     forward_includes_kv_cache_update: bool = False
@@ -845,6 +866,17 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             self.use_fa2_nvfp4_kv = False
             assert self.kv_cache_spec.dtype == self.model_config.dtype
             self.kv_cache_dtype = self.kv_cache_spec.dtype
+
+        if self.is_kvcache_nvfp4 and get_kv_cache_layout() != "HND":
+            # The NVFP4 per-side [data | scale] carve is only byte-coherent
+            # under the head-major HND layout (see
+            # FlashInferBackend.get_required_kv_cache_layout). NHD would
+            # silently corrupt the cache, so fail at init instead.
+            raise ValueError(
+                "NVFP4 KV cache requires the HND KV cache layout; resolved "
+                f"layout is {get_kv_cache_layout()!r}. Unset "
+                "VLLM_KV_CACHE_LAYOUT or set it to 'HND'."
+            )
 
         # Compute per-phase Q dtype.  On SM90 (XQA decode), the prefill and
         # decode phases require different Q dtypes when the KV cache is FP8

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -94,6 +94,57 @@ FP4_DTYPE = torch.uint8
 
 logger = init_logger(__name__)
 
+
+def _vllm_nvfp4_kv_vosplit_requested() -> bool:
+    """VLLM_NVFP4_KV_VOSPLIT opts head_size > 256 NVFP4 layers into the FA2
+    two-pass VO split (Gemma 4 global D=512 full-attention layers).
+
+    Default-on (see vllm/envs.py); only an explicit "0" disables it. The
+    model-config routing (vllm/model_executor/models/config.py) gates the
+    Gemma 4 -> FLASHINFER decision on the same flag, so the backend must
+    honor it here too."""
+    return bool(envs.VLLM_NVFP4_KV_VOSPLIT)
+
+
+def _vo_split_factor(head_size: int, is_fa2_nvfp4: bool) -> int:
+    """Number of VO passes for the FlashInfer FA2 path.
+
+    The FA2 nvfp4 kernel trait guard rejects HEAD_DIM_VO > 256 (the
+    per-thread output-accumulator fragments do not fit the register
+    budget), but HEAD_DIM_QK=512 is fine, and attention decomposes
+    EXACTLY along the VO dimension: S = Q @ K^T and the softmax are
+    identical per pass, and O = [P @ V_left | P @ V_right] concatenates
+    with no LSE merge. So a Gemma 4 full-attention head (Q=K=V=512 wide;
+    the cache stores V at 512) runs as ``ceil(head_size/256)`` passes of
+    ``(head_dim_qk=512, head_dim_vo=256)``, each over a head-dim slice of
+    the 512-wide V cache (and, for NVFP4, of its per-16-element scale
+    factors).
+
+    The split is dtype-independent (the guard counts only accumulator
+    fragments). For NVFP4 it additionally requires linear (non-swizzled)
+    V scale factors, which the sm12x cache writer stores, so the V data
+    and scale views slice cleanly along the head dim; the trtllm-gen
+    4-token V-scale swizzle does not commute with head-dim slicing.
+    """
+    if head_size <= 256:
+        return 1
+    if is_fa2_nvfp4 and not _vllm_nvfp4_kv_vosplit_requested():
+        raise ValueError(
+            f"NVFP4 KV with head_size={head_size} on the SM12x FA2 path "
+            "needs the two-pass VO split (the FA2 kernel caps HEAD_DIM_VO "
+            "at 256). Set VLLM_NVFP4_KV_VOSPLIT=1 to enable it, or keep "
+            "these layers on a different KV dtype."
+        )
+    split = -(-head_size // 256)  # ceil(head_size / 256)
+    if head_size % split != 0 or (is_fa2_nvfp4 and (head_size // split) % 16 != 0):
+        raise ValueError(
+            "The VO split needs head_size divisible into <=256-wide chunks"
+            f"{' of whole 16-element scale blocks' if is_fa2_nvfp4 else ''}; "
+            f"got head_size={head_size}."
+        )
+    return split
+
+
 trtllm_workspace_buffer = None
 
 
@@ -565,6 +616,13 @@ class FlashInferBackend(AttentionBackend):
         ) and supports_trtllm_attention(is_prefill=True)
 
     @classmethod
+    def supports_mm_prefix(cls) -> bool:
+        # Text-mode is fully correct (no image spans to mask). Span-level
+        # bidirectional masking for image inputs is the separate mm-prefix
+        # concern; for NVFP4-KV text serving this gate must not reject FA2.
+        return True
+
+    @classmethod
     def get_required_kv_cache_layout(cls) -> KVCacheLayoutType | None:
         capability = current_platform.get_device_capability()
         if capability is not None and capability.major == 10:
@@ -785,6 +843,14 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
 
         self.num_kv_heads = self.kv_cache_spec.num_kv_heads
         self.head_dim = self.kv_cache_spec.head_size
+        # Gemma 4 full-attention is SYMMETRIC: Q=K=V=512-wide per head (the
+        # KV cache stores V at 512). There is no native 256-wide V. The FA2
+        # nvfp4 kernel caps HEAD_DIM_VO at 256, so a 512-wide V/O is run as
+        # ceil(head_size/256) two-pass VO-split chunks: each pass uses
+        # head_dim_qk=full head_size, head_dim_vo=head_size//vo_split, over a
+        # head-dim slice of the 512-wide V cache; the per-pass outputs
+        # concatenate exactly (identical S/softmax, no LSE merge).
+        # vo_split == 1 for head_size <= 256 (ordinary single-pass).
         self.page_size = self.kv_cache_spec.block_size
 
         if self.kv_cache_spec.kv_quant_mode != KVQuantMode.NONE:
@@ -885,6 +951,25 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             # flash_attn_varlen_func's cp_world_size/cp_rank/cp_tot_seqused_k).
             supports_dcp_with_varlen=False,
         )
+
+        # Two-pass VO split for head_size > 256 (Gemma 4 full-attention,
+        # head_dim_qk=512). vo_split == 1 leaves all existing paths
+        # untouched.
+        self.vo_split = _vo_split_factor(self.head_dim, self.use_fa2_nvfp4_kv)
+        if self.vo_split > 1:
+            # BatchDecodeWithPagedKVCacheWrapper.plan() has no head_dim_vo,
+            # so route every request through the VO-split-planned prefill
+            # wrapper: threshold 0 classifies nothing as decode, and a
+            # causal qo_len==1 prefill computes exactly what decode would.
+            self.reorder_batch_threshold = 0
+            logger.info_once(
+                "FA2 VO split (%s KV): head_size %d runs as %d passes of "
+                "head_dim_vo=%d; decode requests use the prefill wrapper.",
+                self.cache_dtype,
+                self.head_dim,
+                self.vo_split,
+                self.head_dim // self.vo_split,
+            )
 
         self._cascade_wrapper = None  # Wrapper for cascade attention
 
@@ -1650,6 +1735,11 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                         num_qo_heads=self.num_qo_heads,
                         num_kv_heads=self.num_kv_heads,
                         head_dim_qk=self.head_dim,
+                        # == head_dim_qk unless the VO split is active; then
+                        # each pass plans head_dim_vo=head_size//vo_split (256
+                        # for Gemma 4 512-wide heads) and the impl runs the
+                        # wrapper once per V slice (_run_vo_split_prefill).
+                        head_dim_vo=self.head_dim // self.vo_split,
                         page_size=self.page_size,
                         causal=attn_metadata.causal,
                         sm_scale=self.sm_scale,
@@ -1804,6 +1894,11 @@ class FlashInferImpl(AttentionImpl):
         # both variants using the same NVFP4 layout.
         self.kv_cache_dtype = "nvfp4" if self.is_kvcache_nvfp4 else kv_cache_dtype
         self.fp4_data_dim = head_size // 2 if self.is_kvcache_nvfp4 else 0
+        # Two-pass VO split factor for head_size > 256 (Gemma 4 D=512); 1
+        # otherwise. Must match the builder's vo_split: the wrapper is
+        # planned with head_dim_vo = head_size // vo_split, so the impl must
+        # run it once per V slice when vo_split > 1.
+        self.vo_split = _vo_split_factor(head_size, self.use_fa2_nvfp4_kv)
         self.logits_soft_cap = logits_soft_cap
         self.kv_sharing_target_layer_name = kv_sharing_target_layer_name
 
@@ -1920,6 +2015,71 @@ class FlashInferImpl(AttentionImpl):
             return query_quantized.view(num_tokens, num_heads, head_size)
 
         return query
+
+    def _run_vo_split_prefill(
+        self,
+        wrapper: BatchPrefillWithPagedKVCacheWrapper,
+        query: torch.Tensor,
+        kv_cache: tuple[torch.Tensor, torch.Tensor],
+        kv_sf: tuple[torch.Tensor, torch.Tensor] | None,
+        out: torch.Tensor,
+        *,
+        q_scale: float,
+        k_scale: float,
+        v_scale: float,
+    ) -> None:
+        """Multi-pass FA2 prefill run for head_size > 256 (Gemma 4 D=512).
+
+        The wrapper is planned with head_dim_vo = head_size // vo_split, and
+        each pass consumes a head-dim slice of V (and, for NVFP4, of the V
+        scale factors): S = Q @ K^T and the softmax are recomputed
+        identically per pass, so the per-pass outputs concatenate exactly
+        along the head dim with no LSE merge. narrow() keeps the full
+        tensor's strides, which the FA2 path requires.
+
+        NVFP4 V slicing relies on the linear (non-swizzled) V scale layout
+        the sm12x cache writer stores: the V data view's last dim is
+        ``head_size // 2`` packed e2m1 bytes and the V scale view's last
+        dim is ``head_size // 16`` fp8 scales, both contiguous along the
+        head dim, so chunk ``i`` is data[i*chunk//2 : ...] and
+        scale[i*chunk//16 : ...].
+        """
+        split = self.vo_split
+        head_chunk = self.head_size // split
+        k_cache, v_cache = kv_cache
+        if self.is_kvcache_nvfp4:
+            assert kv_sf is not None
+            k_sf, v_sf = kv_sf
+            data_step = head_chunk // 2  # packed e2m1, 2 elements per byte
+            sf_step = head_chunk // 16  # one fp8 scale per 16 elements
+        else:
+            k_sf = v_sf = None
+            data_step = head_chunk
+            sf_step = 0
+        for i in range(split):
+            v_cache_i = v_cache.narrow(-1, i * data_step, data_step)
+            kv_sf_i = (
+                (k_sf, v_sf.narrow(-1, i * sf_step, sf_step))
+                if v_sf is not None
+                else None
+            )
+            # The kernel needs a contiguous output; write into a chunk
+            # buffer and copy into the head-dim slice of the full output.
+            out_i = torch.empty(
+                (*out.shape[:-1], head_chunk),
+                dtype=out.dtype,
+                device=out.device,
+            )
+            wrapper.run(
+                query,
+                (k_cache, v_cache_i),
+                q_scale=q_scale,
+                k_scale=k_scale,
+                v_scale=v_scale,
+                out=out_i,
+                kv_cache_sf=kv_sf_i,
+            )
+            out.narrow(-1, i * head_chunk, head_chunk).copy_(out_i)
 
     def forward(
         self,
@@ -2189,6 +2349,24 @@ class FlashInferImpl(AttentionImpl):
                             v_scale=layer._v_scale_float,
                             out=out_prefill,
                         )
+                    elif self.vo_split > 1:
+                        # head_size > 256: run ceil(head_size/256) passes,
+                        # each over a head-dim slice of the 512-wide V cache,
+                        # and concatenate the per-pass outputs. The wrapper is
+                        # planned with head_dim_vo = head_size // vo_split.
+                        if self.is_kvcache_nvfp4:
+                            assert isinstance(kv_cache_for_fi, tuple)
+                            assert isinstance(kv_cache_sf, tuple)
+                        self._run_vo_split_prefill(
+                            prefill_wrapper,
+                            prefill_query,
+                            kv_cache_for_fi,
+                            kv_cache_sf,
+                            out_prefill,
+                            q_scale=layer._q_scale_float,
+                            k_scale=layer._k_scale_float,
+                            v_scale=layer._v_scale_float,
+                        )
                     else:
                         prefill_wrapper.run(
                             prefill_query,
@@ -2320,6 +2498,16 @@ class FlashInferImpl(AttentionImpl):
         if num_decode_tokens > 0:
             decode_query = query[:num_decode_tokens]
             assert decode_query.shape[0] == num_decode_tokens
+
+            # The VO split routes every request (including would-be decodes)
+            # through the prefill wrapper (builder sets reorder_batch_threshold
+            # = 0), because BatchDecodeWithPagedKVCacheWrapper.plan() has no
+            # head_dim_vo. So no decode tokens should reach this block.
+            assert self.vo_split == 1, (
+                "FA2 VO split routes decodes through the prefill wrapper; "
+                f"unexpected {num_decode_tokens} decode tokens with "
+                f"vo_split={self.vo_split}."
+            )
 
             # Convert query to the expected dtype for decode if needed.
             decode_query = self.maybe_quant_query(

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -630,6 +630,27 @@ class FlashInferBackend(AttentionBackend):
         capability = current_platform.get_device_capability()
         if capability is not None and capability.major == 10:
             return "HND"
+        # NVFP4 KV on consumer Blackwell (sm120/sm121, FA2 path): each K/V
+        # side of the cache packs [data | scale] regions carved out of the
+        # side's byte range (reshape_and_cache_nvfp4 writes the scales at
+        # side_base + num_heads * block_size * data_dim;
+        # nvfp4_split_data_scale reads them back with derived strides).
+        # That carve is only byte-coherent when each side's heads own one
+        # contiguous region per page, i.e. under the head-major HND layout.
+        # Under NHD the K and V head rows interleave within each token and
+        # the side-region offsets land inside the other side's data ->
+        # silent KV corruption. This hook has no dtype parameter, so read
+        # the ambient vllm config (same pattern as
+        # get_kv_connector_cache_layout); if the layout hook grows a
+        # dtype-aware signature, this decision moves into it.
+        if capability is not None and capability.major == 12:
+            vllm_config = get_current_vllm_config_or_none()
+            if (
+                vllm_config is not None
+                and vllm_config.cache_config is not None
+                and vllm_config.cache_config.cache_dtype == "nvfp4"
+            ):
+                return "HND"
         return None
 
     forward_includes_kv_cache_update: bool = False
@@ -924,6 +945,17 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             self.use_fa2_nvfp4_kv = False
             assert self.kv_cache_spec.dtype == self.model_config.dtype
             self.kv_cache_dtype = self.kv_cache_spec.dtype
+
+        if self.is_kvcache_nvfp4 and get_kv_cache_layout() != "HND":
+            # The NVFP4 per-side [data | scale] carve is only byte-coherent
+            # under the head-major HND layout (see
+            # FlashInferBackend.get_required_kv_cache_layout). NHD would
+            # silently corrupt the cache, so fail at init instead.
+            raise ValueError(
+                "NVFP4 KV cache requires the HND KV cache layout; resolved "
+                f"layout is {get_kv_cache_layout()!r}. Unset "
+                "VLLM_KV_CACHE_LAYOUT or set it to 'HND'."
+            )
 
         # Compute per-phase Q dtype.  On SM90 (XQA decode), the prefill and
         # decode phases require different Q dtypes when the KV cache is FP8

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -946,7 +946,6 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             assert self.kv_cache_spec.dtype == self.model_config.dtype
             self.kv_cache_dtype = self.kv_cache_spec.dtype
 
-
         if self.is_kvcache_nvfp4 and get_kv_cache_layout() != "HND":
             # The NVFP4 per-side [data | scale] carve is only byte-coherent
             # under the head-major HND layout (see
@@ -967,11 +966,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
 
         # Prefer TRTLLM/XQA for decoding whenever supported. The decode kernel
         # must be selected statically for FULL cudagraph capture.
-        # NVFP4 KV on consumer Blackwell is served by the FA2 paged reader;
-        # XQA/trtllm-gen decode cannot read NVFP4 cache.
+        # XQA NVFP4 support was added in flashinfer PRs #3534, #3724, #3608.
         can_use_xqa_or_trtllm_gen_decode = (
-            not self.use_fa2_nvfp4_kv
-            and can_use_trtllm_attention(
+            can_use_trtllm_attention(
                 self.num_qo_heads, self.num_kv_heads, is_prefill=False
             )
         )
@@ -1198,16 +1195,6 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             return AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE
 
         is_sm12x = current_platform.is_device_capability_family(120)
-        # NVFP4 KV on consumer Blackwell is served by the FA2 paged reader
-        # (XQA/trtllm-gen cannot read NVFP4, and head_size > 256 routes
-        # decode through the VO-split prefill wrapper), so the uniform-batch
-        # capture contract does not hold; fall back to per-request capture.
-        if (
-            is_sm12x
-            and vllm_config.cache_config is not None
-            and vllm_config.cache_config.cache_dtype.startswith("nvfp4")
-        ):
-            return AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE
         # XQA does not return LSE and therefore does not support DCP.
         if is_sm12x and vllm_config.parallel_config.decode_context_parallel_size > 1:
             return AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE
@@ -2615,7 +2602,6 @@ class FlashInferImpl(AttentionImpl):
         )
         if decode_with_dedicated_xqa:
             assert not use_dcp
-            assert not self.is_kvcache_nvfp4
             assert self.o_sf_scale is None
             assert output.dtype != FP4_DTYPE
 
@@ -3056,6 +3042,7 @@ class FlashInferImpl(AttentionImpl):
                         q_len_per_req=q_len_per_req,
                         mask=attn_metadata.decode.mask,
                         q_cu_seq_lens=attn_metadata.decode.q_cu_seq_lens,
+                        kv_cache_sf=nvfp4_kv_block_scales,
                     )
                     return output_padded
 

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -546,10 +546,13 @@ class FlashInferBackend(AttentionBackend):
 
     @classmethod
     def supports_mm_prefix(cls) -> bool:
-        # Text-mode is fully correct (no image spans to mask). Span-level
-        # bidirectional masking for image inputs is the separate mm-prefix
-        # concern; for NVFP4-KV text serving this gate must not reject FA2.
-        return True
+        """mm-prefix LMs (Gemma 3 / Gemma 4 multimodal: image-token spans
+        attend bidirectionally) are served via FA2 packed custom masks on
+        the FI-native prefill path. Decode is untouched: spans live in the
+        prompt, so decode queries are strictly causal. Knob-gated and
+        default-on; set VLLM_FLASHINFER_MM_PREFIX=0 to route mm-prefix
+        models away from FlashInfer instead (e.g. for debugging)."""
+        return envs.VLLM_FLASHINFER_MM_PREFIX
 
     @classmethod
     def get_required_kv_cache_layout(cls) -> KVCacheLayoutType | None:
@@ -562,10 +565,35 @@ class FlashInferBackend(AttentionBackend):
 
 
 @dataclass
+class FIPrefillMMGroup:
+    """One partition of an mm-prefix prefill batch (Gemma 3 / Gemma 4
+    multimodal: requests whose image-token span intersects the current
+    query window need span-level bidirectional masking; plain requests
+    stay causal)."""
+
+    wrapper: BatchPrefillWithPagedKVCacheWrapper
+    """Planned for exactly this group's requests: causal=True for the
+    plain group, packed custom mask ((causal AND sliding-window) OR
+    span-bidirectional) for the mm group."""
+
+    token_indices: torch.Tensor
+    """Rows of the prefill query/output owned by this group: GPU int64,
+    the concatenation of per-request token ranges from query_start_loc.
+    Needed because the groups may interleave within the batch."""
+
+    num_tokens: int
+
+
+@dataclass
 class FIPrefill:
     """Metadata for the native FlashInfer prefill pathway (non-TRTLLM)."""
 
     wrapper: BatchPrefillWithPagedKVCacheWrapper | BatchDCPPrefillWrapper
+
+    mm_groups: list[FIPrefillMMGroup] | None = None
+    """mm-prefix wrapper grouping when image-token spans intersect the
+    query window of at least one prefill request; None on the scalar
+    causal fast path (no mm requests => byte-identical legacy path)."""
 
 
 @dataclass
@@ -700,6 +728,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         self._noncausal_prefill_wrapper: BatchPrefillWithPagedKVCacheWrapper | None = (
             None  # Wrapper for non-causal prefill (DFlash)
         )
+        # Second prefill wrapper for mm-prefix custom-mask requests
+        # (Gemma 3 / Gemma 4 multimodal image spans); lazily created.
+        self._mm_prefill_wrapper: BatchPrefillWithPagedKVCacheWrapper | None = None
         self._decode_wrapper = None  # Wrapper for decode (general shape)
 
         if envs.VLLM_BATCH_INVARIANT:
@@ -931,6 +962,39 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             self.kv_cache_dtype,
             arch,
         )
+
+        # mm-prefix (PrefixLM) span-level bidirectional masking for this
+        # layer group. Gemma4 with use_bidirectional_attention='vision'
+        # applies bidirectional image spans ONLY to sliding_attention
+        # layers (full-attention layers stay plain causal: the static
+        # equivalent of gemma4_mm._clear_mm_prefix_for_full_attn_layers,
+        # decided here at build time because FlashInfer bakes masks into
+        # wrapper plans). Gemma3 applies the spans to all layers.
+        self.mm_prefix_enabled = (
+            envs.VLLM_FLASHINFER_MM_PREFIX
+            and self.model_config is not None
+            and self.model_config.is_mm_prefix_lm
+        )
+        if self.mm_prefix_enabled:
+            bidi_mode = getattr(
+                self.model_config.hf_text_config,
+                "use_bidirectional_attention",
+                None,
+            )
+            if bidi_mode == "vision" and self.window_left < 0:
+                self.mm_prefix_enabled = False
+            if self.use_dcp:
+                raise NotImplementedError(
+                    "FlashInfer mm-prefix custom masks are not wired for "
+                    "DCP; unset VLLM_FLASHINFER_MM_PREFIX or disable DCP."
+                )
+        if self.mm_prefix_enabled:
+            logger.info_once(
+                "FlashInfer mm-prefix: image-token spans of multimodal "
+                "requests run with FA2 packed custom masks on a second "
+                "prefill wrapper (layer group window_left=%d).",
+                self.window_left,
+            )
         # Preparing persistent buffers
         # Since we do not have explicit synchronization in ModelRunnerV2, we do not pin
         # reused CPU buffers to avoid a race condition between step N async copies to
@@ -1120,6 +1184,25 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         assert self._prefill_wrapper is not None
         return self._prefill_wrapper
 
+    def _get_mm_prefill_wrapper(self) -> BatchPrefillWithPagedKVCacheWrapper:
+        # Second paged prefill wrapper for the mm-prefix custom-mask group.
+        # Built the same way as the plain prefill wrapper (the VO split and
+        # NVFP4 jit module are applied at plan()/run() time, not here);
+        # only reachable on the mm-prefix path, which rejects DCP.
+        if self._mm_prefill_wrapper is None:
+            if self.use_fa2_nvfp4_kv:
+                backend = "fa2"
+            elif self.is_kvcache_nvfp4:
+                backend = "trtllm-gen"
+            else:
+                backend = "auto"
+            self._mm_prefill_wrapper = BatchPrefillWithPagedKVCacheWrapper(
+                self._get_workspace_buffer(),
+                get_kv_cache_layout(),
+                backend=backend,
+            )
+        return self._mm_prefill_wrapper
+
     def _get_decode_wrapper(self, batch_size: int, use_cudagraph: bool = False):
         if use_cudagraph:
             decode_wrapper = self._decode_wrappers_cudagraph.get(batch_size, None)
@@ -1229,6 +1312,192 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         )
         return paged_kv_indices
 
+    def _mm_prefix_prefill_spans(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        num_decodes: int,
+        num_prefills: int,
+    ) -> list[list[tuple[int, int]]] | None:
+        """Per-prefill-request image spans that intersect the query window.
+
+        Spans are document positions, inclusive [start, end] (the
+        mm_req_doc_ranges convention shared with the Triton/FlexAttention
+        mm-prefix paths; valid iff start < end). A span fully inside the
+        computed context needs nothing: K/V projections are mask-independent
+        and the in-window queries are text, i.e. causal. vLLM forces
+        --disable-chunked-mm-input for mm-prefix models, so spans do not
+        straddle the window boundary in practice; partial overlaps are
+        still handled correctly by the absolute-position mask.
+
+        Returns None when no prefill request has an intersecting span
+        (the scalar-causal fast path stays byte-identical).
+        """
+        mm_ranges = common_attn_metadata.mm_req_doc_ranges
+        if not mm_ranges:
+            return None
+        qo_indptr_cpu = common_attn_metadata.query_start_loc_cpu
+        seq_lens_cpu = common_attn_metadata.seq_lens_cpu
+        span_lists: list[list[tuple[int, int]]] = []
+        any_spans = False
+        for j in range(num_prefills):
+            req_idx = num_decodes + j
+            kv_len = int(seq_lens_cpu[req_idx])
+            qo_len = int(qo_indptr_cpu[req_idx + 1] - qo_indptr_cpu[req_idx])
+            context_len = kv_len - qo_len
+            spans = [
+                (int(s), int(e))
+                for s, e in mm_ranges.get(req_idx, [])
+                if s < e and e >= context_len and s < kv_len
+            ]
+            any_spans = any_spans or bool(spans)
+            span_lists.append(spans)
+        return span_lists if any_spans else None
+
+    def _build_mm_prefix_custom_mask(
+        self,
+        qo_lens: list[int],
+        kv_lens: list[int],
+        span_lists: list[list[tuple[int, int]]],
+    ) -> torch.Tensor:
+        """Boolean (qo_len x kv_len)-per-request mask, flattened row-major
+        and concatenated in group order; FlashInfer's plan() bit-packs it
+        per request (segment_packbits). Composition matches the Triton /
+        FlexAttention mm-prefix contract:
+        (causal AND sliding-window) OR (q in span AND kv in span),
+        with query rows end-aligned to the KV sequence. The mm wrapper is
+        planned with window_left=-1 because the mask already carries the
+        sliding window; spans must OVERRIDE it (FlashInfer's in-kernel SW
+        would AND it instead)."""
+        masks = []
+        for qo_len, kv_len, spans in zip(qo_lens, kv_lens, span_lists):
+            q_abs = torch.arange(
+                kv_len - qo_len, kv_len, device=self.device, dtype=torch.int32
+            )
+            k_abs = torch.arange(kv_len, device=self.device, dtype=torch.int32)
+            mask = k_abs[None, :] <= q_abs[:, None]
+            if self.window_left >= 0:
+                mask &= (q_abs[:, None] - k_abs[None, :]) <= self.window_left
+            for start, end in spans:
+                q_in = (q_abs >= start) & (q_abs <= end)
+                k_in = (k_abs >= start) & (k_abs <= end)
+                mask |= q_in[:, None] & k_in[None, :]
+            masks.append(mask.reshape(-1))
+        return torch.cat(masks)
+
+    def _plan_prefill_mm_groups(
+        self,
+        prefill_mm_spans: list[list[tuple[int, int]]],
+        qo_indptr_prefill_cpu: torch.Tensor,
+        paged_kv_indptr_prefill_cpu: torch.Tensor,
+        paged_kv_last_page_len_prefill_cpu: torch.Tensor,
+        paged_kv_indices: torch.Tensor,
+        seq_lens_prefill_cpu: torch.Tensor,
+        o_dtype: torch.dtype,
+    ) -> list[FIPrefillMMGroup]:
+        """Plan one prefill wrapper per partition of an mm-prefix batch:
+        requests with image spans intersecting the query window run on a
+        custom-mask wrapper; the rest stay on the fast causal wrapper.
+
+        Each request's tokens and KV pages are contiguous ranges of the
+        batch-level arrays, so a group is fully described by per-request
+        deltas of the indptr arrays plus gathered index subranges
+        (indptr/last_page_len slicing on CPU, paged_kv_indices on GPU).
+        plan(custom_mask=...) requires the FlashInfer-side mask_indptr
+        device fix because the mask lives on GPU while the indptr arrays
+        stay on CPU.
+        """
+        is_mm = torch.tensor([bool(s) for s in prefill_mm_spans])
+        qo_lens_cpu = qo_indptr_prefill_cpu[1:] - qo_indptr_prefill_cpu[:-1]
+        # paged_kv_indptr is NOT rebased to 0 (its offsets index the full
+        # paged_kv_indices array), so deltas are taken before regrouping.
+        kv_page_counts_cpu = (
+            paged_kv_indptr_prefill_cpu[1:] - paged_kv_indptr_prefill_cpu[:-1]
+        )
+        groups: list[FIPrefillMMGroup] = []
+        for group_mm in (False, True):
+            req_indices = (is_mm if group_mm else ~is_mm).nonzero(as_tuple=True)[0]
+            if req_indices.numel() == 0:
+                continue
+            group_qo_indptr = torch.zeros(req_indices.numel() + 1, dtype=torch.int32)
+            torch.cumsum(qo_lens_cpu[req_indices], dim=0, out=group_qo_indptr[1:])
+            group_kv_indptr = torch.zeros(req_indices.numel() + 1, dtype=torch.int32)
+            torch.cumsum(
+                kv_page_counts_cpu[req_indices], dim=0, out=group_kv_indptr[1:]
+            )
+            token_indices_cpu = torch.cat(
+                [
+                    torch.arange(
+                        int(qo_indptr_prefill_cpu[i]),
+                        int(qo_indptr_prefill_cpu[i + 1]),
+                        dtype=torch.int64,
+                    )
+                    for i in req_indices.tolist()
+                ]
+            )
+            page_gather_cpu = torch.cat(
+                [
+                    torch.arange(
+                        int(paged_kv_indptr_prefill_cpu[i]),
+                        int(paged_kv_indptr_prefill_cpu[i + 1]),
+                        dtype=torch.int64,
+                    )
+                    for i in req_indices.tolist()
+                ]
+            )
+            group_kv_indices = torch.index_select(
+                paged_kv_indices, 0, page_gather_cpu.to(self.device)
+            )
+            if group_mm:
+                wrapper = self._get_mm_prefill_wrapper()
+                custom_mask = self._build_mm_prefix_custom_mask(
+                    [int(qo_lens_cpu[i]) for i in req_indices.tolist()],
+                    [int(seq_lens_prefill_cpu[i]) for i in req_indices.tolist()],
+                    [prefill_mm_spans[i] for i in req_indices.tolist()],
+                )
+                # The mask carries causal/SW/span composition wholesale.
+                group_causal = False
+                group_window_left = -1
+            else:
+                maybe_wrapper = self._get_prefill_wrapper()
+                assert isinstance(maybe_wrapper, BatchPrefillWithPagedKVCacheWrapper)
+                wrapper = maybe_wrapper
+                custom_mask = None
+                group_causal = True
+                group_window_left = self.window_left
+            wrapper.plan(
+                qo_indptr=group_qo_indptr,
+                paged_kv_indptr=group_kv_indptr,
+                paged_kv_indices=group_kv_indices,
+                paged_kv_last_page_len=paged_kv_last_page_len_prefill_cpu[req_indices],
+                num_qo_heads=self.num_qo_heads,
+                num_kv_heads=self.num_kv_heads,
+                head_dim_qk=self.head_dim,
+                # == head_dim_qk unless the VO split is active; then the
+                # impl runs each group's wrapper once per V slice.
+                head_dim_vo=self.head_dim // self.vo_split,
+                page_size=self.page_size,
+                causal=group_causal,
+                custom_mask=custom_mask,
+                sm_scale=self.sm_scale,
+                window_left=group_window_left,
+                logits_soft_cap=self.logits_soft_cap,
+                q_data_type=self.q_data_type_prefill,
+                kv_data_type=self.kv_cache_dtype,
+                o_data_type=o_dtype,
+                fixed_split_size=self.prefill_fixed_split_size,
+                disable_split_kv=self.disable_split_kv,
+            )
+            wrapper.vllm_prefill_fixed_split_size = self.prefill_fixed_split_size
+            wrapper.vllm_disable_split_kv = self.disable_split_kv
+            groups.append(
+                FIPrefillMMGroup(
+                    wrapper=wrapper,
+                    token_indices=token_indices_cpu.to(self.device),
+                    num_tokens=int(token_indices_cpu.numel()),
+                )
+            )
+        return groups
+
     def build(
         self,
         common_prefix_len: int,
@@ -1295,6 +1564,17 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 "Using FlashInfer for draft model non-causal attention; TRTLLM "
                 "can still be used for target model causal attention."
             )
+        # mm-prefix: prefill requests whose image span intersects the
+        # query window need the FI-native custom-mask path (TRTLLM has no
+        # custom masks). Decode stays causal: spans live in the prompt.
+        prefill_mm_spans: list[list[tuple[int, int]]] | None = None
+        if self.mm_prefix_enabled and num_prefills > 0:
+            prefill_mm_spans = self._mm_prefix_prefill_spans(
+                common_attn_metadata, num_decodes, num_prefills
+            )
+            if prefill_mm_spans is not None:
+                prefill_use_trtllm = False
+
         all_uses_trtllm = causal and (
             (num_prefills == 0 or prefill_use_trtllm)
             and (num_decodes == 0 or decode_with_flashinfer_trtllm_api)
@@ -1513,6 +1793,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     prefill_start : num_reqs + 1
                 ]
                 assert paged_kv_indptr_prefill_cpu.shape[0] == num_prefills + 1
+                mm_groups: list[FIPrefillMMGroup] | None = None
                 if self.use_dcp:
                     assert isinstance(prefill_wrapper, BatchDCPPrefillWrapper)
                     prefill_wrapper.plan(
@@ -1546,31 +1827,49 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                         if (self.is_kvcache_nvfp4 and not self.use_fa2_nvfp4_kv)
                         else self.model_config.dtype
                     )
-                    prefill_wrapper.plan(
-                        qo_indptr=qo_indptr_prefill_cpu,
-                        paged_kv_indptr=paged_kv_indptr_prefill_cpu,
-                        paged_kv_indices=paged_kv_indices,
-                        paged_kv_last_page_len=paged_kv_last_page_len_prefill_cpu,
-                        num_qo_heads=self.num_qo_heads,
-                        num_kv_heads=self.num_kv_heads,
-                        head_dim_qk=self.head_dim,
-                        # == head_dim_qk unless the VO split is active; then
-                        # each pass plans head_dim_vo=head_size//vo_split (256
-                        # for Gemma 4 512-wide heads) and the impl runs the
-                        # wrapper once per V slice (_run_vo_split_prefill).
-                        head_dim_vo=self.head_dim // self.vo_split,
-                        page_size=self.page_size,
-                        causal=attn_metadata.causal,
-                        sm_scale=self.sm_scale,
-                        window_left=self.window_left,
-                        logits_soft_cap=self.logits_soft_cap,
-                        q_data_type=self.q_data_type_prefill,
-                        kv_data_type=self.kv_cache_dtype,
-                        o_data_type=o_dtype,
-                        fixed_split_size=self.prefill_fixed_split_size,
-                        disable_split_kv=self.disable_split_kv,
-                    )
-                attn_metadata.prefill = FIPrefill(wrapper=prefill_wrapper)
+                    if prefill_mm_spans is not None:
+                        assert seq_lens_cpu is not None
+                        mm_groups = self._plan_prefill_mm_groups(
+                            prefill_mm_spans,
+                            qo_indptr_prefill_cpu,
+                            paged_kv_indptr_prefill_cpu,
+                            paged_kv_last_page_len_prefill_cpu,
+                            paged_kv_indices,
+                            seq_lens_cpu[prefill_start:num_reqs],
+                            o_dtype,
+                        )
+                        # The impl's forward dispatches on mm_groups; this
+                        # field only feeds its isinstance/identity asserts.
+                        prefill_wrapper = mm_groups[0].wrapper
+                    else:
+                        prefill_wrapper.plan(
+                            qo_indptr=qo_indptr_prefill_cpu,
+                            paged_kv_indptr=paged_kv_indptr_prefill_cpu,
+                            paged_kv_indices=paged_kv_indices,
+                            paged_kv_last_page_len=paged_kv_last_page_len_prefill_cpu,
+                            num_qo_heads=self.num_qo_heads,
+                            num_kv_heads=self.num_kv_heads,
+                            head_dim_qk=self.head_dim,
+                            # == head_dim_qk unless the VO split is active;
+                            # then each pass plans head_dim_vo=head_size//
+                            # vo_split (256 for Gemma 4 512-wide heads) and
+                            # the impl runs the wrapper once per V slice
+                            # (_run_vo_split_prefill).
+                            head_dim_vo=self.head_dim // self.vo_split,
+                            page_size=self.page_size,
+                            causal=attn_metadata.causal,
+                            sm_scale=self.sm_scale,
+                            window_left=self.window_left,
+                            logits_soft_cap=self.logits_soft_cap,
+                            q_data_type=self.q_data_type_prefill,
+                            kv_data_type=self.kv_cache_dtype,
+                            o_data_type=o_dtype,
+                            fixed_split_size=self.prefill_fixed_split_size,
+                            disable_split_kv=self.disable_split_kv,
+                        )
+                attn_metadata.prefill = FIPrefill(
+                    wrapper=prefill_wrapper, mm_groups=mm_groups
+                )
 
         ## DECODE PATHWAY
         if num_decodes > 0:
@@ -2095,12 +2394,26 @@ class FlashInferImpl(AttentionImpl):
                     assert isinstance(
                         prefill_wrapper, BatchPrefillWithPagedKVCacheWrapper
                     )
-                    assert prefill_wrapper._window_left == self.window_left
+                    mm_groups = attn_metadata.prefill.mm_groups
                     assert prefill_wrapper._logits_soft_cap == (
                         self.logits_soft_cap or 0.0
                     )
                     assert prefill_wrapper._sm_scale == self.scale
-                    assert prefill_wrapper._causal == attn_metadata.causal
+                    if mm_groups is None:
+                        assert prefill_wrapper._window_left == self.window_left
+                        assert prefill_wrapper._causal == attn_metadata.causal
+                    else:
+                        # The mm group's wrapper carries the sliding window
+                        # and causality inside its packed custom mask
+                        # (planned non-causal, window_left=-1); the plain
+                        # group keeps the scalar-causal plan.
+                        for group in mm_groups:
+                            if group.wrapper._custom_mask_buf is None:
+                                assert group.wrapper._causal
+                                assert group.wrapper._window_left == self.window_left
+                            else:
+                                assert not group.wrapper._causal
+                                assert group.wrapper._window_left == -1
 
                     if self.is_kvcache_nvfp4:
                         kv_cache_for_fi = nvfp4_kv_data
@@ -2123,7 +2436,47 @@ class FlashInferImpl(AttentionImpl):
                     else:
                         out_prefill = output[num_decode_tokens:]
 
-                    if self.vo_split > 1:
+                    if mm_groups is not None:
+                        # mm-prefix grouping: each partition runs its own
+                        # planned wrapper (plain causal vs packed custom
+                        # mask) over a gathered copy of its query rows,
+                        # then scatters back. Gather/scatter is by token
+                        # index because the groups may interleave within
+                        # the batch.
+                        if self.is_kvcache_nvfp4:
+                            assert isinstance(kv_cache_for_fi, tuple)
+                        for group in mm_groups:
+                            group_query = torch.index_select(
+                                prefill_query, 0, group.token_indices
+                            )
+                            group_out = torch.empty(
+                                (group.num_tokens, *out_prefill.shape[1:]),
+                                dtype=out_prefill.dtype,
+                                device=out_prefill.device,
+                            )
+                            if self.vo_split > 1:
+                                self._run_vo_split_prefill(
+                                    group.wrapper,
+                                    group_query,
+                                    kv_cache_for_fi,
+                                    kv_cache_sf,
+                                    group_out,
+                                    q_scale=layer._q_scale_float,
+                                    k_scale=layer._k_scale_float,
+                                    v_scale=layer._v_scale_float,
+                                )
+                            else:
+                                group.wrapper.run(
+                                    group_query,
+                                    kv_cache_for_fi,
+                                    q_scale=layer._q_scale_float,
+                                    k_scale=layer._k_scale_float,
+                                    v_scale=layer._v_scale_float,
+                                    out=group_out,
+                                    kv_cache_sf=kv_cache_sf,
+                                )
+                            out_prefill.index_copy_(0, group.token_indices, group_out)
+                    elif self.vo_split > 1:
                         # head_size > 256: run ceil(head_size/256) passes,
                         # each over a head-dim slice of the 512-wide V cache,
                         # and concatenate the per-pass outputs. The wrapper is

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -946,6 +946,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             assert self.kv_cache_spec.dtype == self.model_config.dtype
             self.kv_cache_dtype = self.kv_cache_spec.dtype
 
+
         if self.is_kvcache_nvfp4 and get_kv_cache_layout() != "HND":
             # The NVFP4 per-side [data | scale] carve is only byte-coherent
             # under the head-major HND layout (see
@@ -2186,6 +2187,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     o_data_type=o_dtype,
                     fixed_split_size=self.decode_fixed_split_size,
                     disable_split_kv=self.disable_split_kv,
+                    q_len_per_req=num_decode_tokens // num_decodes if num_decodes else 1,
                 )
                 attn_metadata.decode = FIDecode(wrapper=decode_wrapper)
         return attn_metadata
@@ -3211,6 +3213,7 @@ def fast_plan_decode(
     non_blocking: bool = True,
     fixed_split_size: int = -1,
     disable_split_kv: bool = False,
+    q_len_per_req: int = 1,
 ) -> None:
     """
     A faster version of BatchDecodeWithPagedKVCacheWrapper::plan used for
@@ -3252,6 +3255,7 @@ def fast_plan_decode(
             seq_lens=None,
             fixed_split_size=fixed_split_size,
             disable_split_kv=disable_split_kv,
+            q_len_per_req=q_len_per_req,
         )
         self.vllm_first_call = False
         return
@@ -3279,6 +3283,7 @@ def fast_plan_decode(
         non_blocking=non_blocking,
         fixed_split_size=fixed_split_size,
         disable_split_kv=disable_split_kv,
+        q_len_per_req=q_len_per_req,
     )
 
 

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -617,10 +617,13 @@ class FlashInferBackend(AttentionBackend):
 
     @classmethod
     def supports_mm_prefix(cls) -> bool:
-        # Text-mode is fully correct (no image spans to mask). Span-level
-        # bidirectional masking for image inputs is the separate mm-prefix
-        # concern; for NVFP4-KV text serving this gate must not reject FA2.
-        return True
+        """mm-prefix LMs (Gemma 3 / Gemma 4 multimodal: image-token spans
+        attend bidirectionally) are served via FA2 packed custom masks on
+        the FI-native prefill path. Decode is untouched: spans live in the
+        prompt, so decode queries are strictly causal. Knob-gated and
+        default-on; set VLLM_FLASHINFER_MM_PREFIX=0 to route mm-prefix
+        models away from FlashInfer instead (e.g. for debugging)."""
+        return envs.VLLM_FLASHINFER_MM_PREFIX
 
     @classmethod
     def get_required_kv_cache_layout(cls) -> KVCacheLayoutType | None:
@@ -633,10 +636,35 @@ class FlashInferBackend(AttentionBackend):
 
 
 @dataclass
+class FIPrefillMMGroup:
+    """One partition of an mm-prefix prefill batch (Gemma 3 / Gemma 4
+    multimodal: requests whose image-token span intersects the current
+    query window need span-level bidirectional masking; plain requests
+    stay causal)."""
+
+    wrapper: BatchPrefillWithPagedKVCacheWrapper
+    """Planned for exactly this group's requests: causal=True for the
+    plain group, packed custom mask ((causal AND sliding-window) OR
+    span-bidirectional) for the mm group."""
+
+    token_indices: torch.Tensor
+    """Rows of the prefill query/output owned by this group: GPU int64,
+    the concatenation of per-request token ranges from query_start_loc.
+    Needed because the groups may interleave within the batch."""
+
+    num_tokens: int
+
+
+@dataclass
 class FIPrefill:
     """Metadata for the native FlashInfer prefill pathway (non-TRTLLM)."""
 
     wrapper: BatchPrefillWithPagedKVCacheWrapper | BatchDCPPrefillWrapper
+
+    mm_groups: list[FIPrefillMMGroup] | None = None
+    """mm-prefix wrapper grouping when image-token spans intersect the
+    query window of at least one prefill request; None on the scalar
+    causal fast path (no mm requests => byte-identical legacy path)."""
 
 
 @dataclass
@@ -776,6 +804,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         self._noncausal_prefill_wrapper: BatchPrefillWithPagedKVCacheWrapper | None = (
             None  # Wrapper for non-causal prefill (DFlash)
         )
+        # Second prefill wrapper for mm-prefix custom-mask requests
+        # (Gemma 3 / Gemma 4 multimodal image spans); lazily created.
+        self._mm_prefill_wrapper: BatchPrefillWithPagedKVCacheWrapper | None = None
         self._decode_wrapper = None  # Wrapper for decode (general shape)
 
         if envs.VLLM_BATCH_INVARIANT:
@@ -1015,6 +1046,39 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             self.kv_cache_dtype,
             arch,
         )
+
+        # mm-prefix (PrefixLM) span-level bidirectional masking for this
+        # layer group. Gemma4 with use_bidirectional_attention='vision'
+        # applies bidirectional image spans ONLY to sliding_attention
+        # layers (full-attention layers stay plain causal: the static
+        # equivalent of gemma4_mm._clear_mm_prefix_for_full_attn_layers,
+        # decided here at build time because FlashInfer bakes masks into
+        # wrapper plans). Gemma3 applies the spans to all layers.
+        self.mm_prefix_enabled = (
+            envs.VLLM_FLASHINFER_MM_PREFIX
+            and self.model_config is not None
+            and self.model_config.is_mm_prefix_lm
+        )
+        if self.mm_prefix_enabled:
+            bidi_mode = getattr(
+                self.model_config.hf_text_config,
+                "use_bidirectional_attention",
+                None,
+            )
+            if bidi_mode == "vision" and self.window_left < 0:
+                self.mm_prefix_enabled = False
+            if self.use_dcp:
+                raise NotImplementedError(
+                    "FlashInfer mm-prefix custom masks are not wired for "
+                    "DCP; unset VLLM_FLASHINFER_MM_PREFIX or disable DCP."
+                )
+        if self.mm_prefix_enabled:
+            logger.info_once(
+                "FlashInfer mm-prefix: image-token spans of multimodal "
+                "requests run with FA2 packed custom masks on a second "
+                "prefill wrapper (layer group window_left=%d).",
+                self.window_left,
+            )
         # Preparing persistent buffers
         # Since we do not have explicit synchronization in ModelRunnerV2, we do not pin
         # reused CPU buffers to avoid a race condition between step N async copies to
@@ -1296,6 +1360,25 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         assert self._prefill_wrapper is not None
         return self._prefill_wrapper
 
+    def _get_mm_prefill_wrapper(self) -> BatchPrefillWithPagedKVCacheWrapper:
+        # Second paged prefill wrapper for the mm-prefix custom-mask group.
+        # Built the same way as the plain prefill wrapper (the VO split and
+        # NVFP4 jit module are applied at plan()/run() time, not here);
+        # only reachable on the mm-prefix path, which rejects DCP.
+        if self._mm_prefill_wrapper is None:
+            if self.use_fa2_nvfp4_kv:
+                backend = "fa2"
+            elif self.is_kvcache_nvfp4:
+                backend = "trtllm-gen"
+            else:
+                backend = "auto"
+            self._mm_prefill_wrapper = BatchPrefillWithPagedKVCacheWrapper(
+                self._get_workspace_buffer(),
+                get_kv_cache_layout(),
+                backend=backend,
+            )
+        return self._mm_prefill_wrapper
+
     def _get_decode_wrapper(self, batch_size: int, use_cudagraph: bool = False):
         if use_cudagraph:
             decode_wrapper = self._decode_wrappers_cudagraph.get(batch_size, None)
@@ -1405,6 +1488,192 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         )
         return paged_kv_indices
 
+    def _mm_prefix_prefill_spans(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        num_decodes: int,
+        num_prefills: int,
+    ) -> list[list[tuple[int, int]]] | None:
+        """Per-prefill-request image spans that intersect the query window.
+
+        Spans are document positions, inclusive [start, end] (the
+        mm_req_doc_ranges convention shared with the Triton/FlexAttention
+        mm-prefix paths; valid iff start < end). A span fully inside the
+        computed context needs nothing: K/V projections are mask-independent
+        and the in-window queries are text, i.e. causal. vLLM forces
+        --disable-chunked-mm-input for mm-prefix models, so spans do not
+        straddle the window boundary in practice; partial overlaps are
+        still handled correctly by the absolute-position mask.
+
+        Returns None when no prefill request has an intersecting span
+        (the scalar-causal fast path stays byte-identical).
+        """
+        mm_ranges = common_attn_metadata.mm_req_doc_ranges
+        if not mm_ranges:
+            return None
+        qo_indptr_cpu = common_attn_metadata.query_start_loc_cpu
+        seq_lens_cpu = common_attn_metadata.seq_lens_cpu
+        span_lists: list[list[tuple[int, int]]] = []
+        any_spans = False
+        for j in range(num_prefills):
+            req_idx = num_decodes + j
+            kv_len = int(seq_lens_cpu[req_idx])
+            qo_len = int(qo_indptr_cpu[req_idx + 1] - qo_indptr_cpu[req_idx])
+            context_len = kv_len - qo_len
+            spans = [
+                (int(s), int(e))
+                for s, e in mm_ranges.get(req_idx, [])
+                if s < e and e >= context_len and s < kv_len
+            ]
+            any_spans = any_spans or bool(spans)
+            span_lists.append(spans)
+        return span_lists if any_spans else None
+
+    def _build_mm_prefix_custom_mask(
+        self,
+        qo_lens: list[int],
+        kv_lens: list[int],
+        span_lists: list[list[tuple[int, int]]],
+    ) -> torch.Tensor:
+        """Boolean (qo_len x kv_len)-per-request mask, flattened row-major
+        and concatenated in group order; FlashInfer's plan() bit-packs it
+        per request (segment_packbits). Composition matches the Triton /
+        FlexAttention mm-prefix contract:
+        (causal AND sliding-window) OR (q in span AND kv in span),
+        with query rows end-aligned to the KV sequence. The mm wrapper is
+        planned with window_left=-1 because the mask already carries the
+        sliding window; spans must OVERRIDE it (FlashInfer's in-kernel SW
+        would AND it instead)."""
+        masks = []
+        for qo_len, kv_len, spans in zip(qo_lens, kv_lens, span_lists):
+            q_abs = torch.arange(
+                kv_len - qo_len, kv_len, device=self.device, dtype=torch.int32
+            )
+            k_abs = torch.arange(kv_len, device=self.device, dtype=torch.int32)
+            mask = k_abs[None, :] <= q_abs[:, None]
+            if self.window_left >= 0:
+                mask &= (q_abs[:, None] - k_abs[None, :]) <= self.window_left
+            for start, end in spans:
+                q_in = (q_abs >= start) & (q_abs <= end)
+                k_in = (k_abs >= start) & (k_abs <= end)
+                mask |= q_in[:, None] & k_in[None, :]
+            masks.append(mask.reshape(-1))
+        return torch.cat(masks)
+
+    def _plan_prefill_mm_groups(
+        self,
+        prefill_mm_spans: list[list[tuple[int, int]]],
+        qo_indptr_prefill_cpu: torch.Tensor,
+        paged_kv_indptr_prefill_cpu: torch.Tensor,
+        paged_kv_last_page_len_prefill_cpu: torch.Tensor,
+        paged_kv_indices: torch.Tensor,
+        seq_lens_prefill_cpu: torch.Tensor,
+        o_dtype: torch.dtype,
+    ) -> list[FIPrefillMMGroup]:
+        """Plan one prefill wrapper per partition of an mm-prefix batch:
+        requests with image spans intersecting the query window run on a
+        custom-mask wrapper; the rest stay on the fast causal wrapper.
+
+        Each request's tokens and KV pages are contiguous ranges of the
+        batch-level arrays, so a group is fully described by per-request
+        deltas of the indptr arrays plus gathered index subranges
+        (indptr/last_page_len slicing on CPU, paged_kv_indices on GPU).
+        plan(custom_mask=...) requires the FlashInfer-side mask_indptr
+        device fix because the mask lives on GPU while the indptr arrays
+        stay on CPU.
+        """
+        is_mm = torch.tensor([bool(s) for s in prefill_mm_spans])
+        qo_lens_cpu = qo_indptr_prefill_cpu[1:] - qo_indptr_prefill_cpu[:-1]
+        # paged_kv_indptr is NOT rebased to 0 (its offsets index the full
+        # paged_kv_indices array), so deltas are taken before regrouping.
+        kv_page_counts_cpu = (
+            paged_kv_indptr_prefill_cpu[1:] - paged_kv_indptr_prefill_cpu[:-1]
+        )
+        groups: list[FIPrefillMMGroup] = []
+        for group_mm in (False, True):
+            req_indices = (is_mm if group_mm else ~is_mm).nonzero(as_tuple=True)[0]
+            if req_indices.numel() == 0:
+                continue
+            group_qo_indptr = torch.zeros(req_indices.numel() + 1, dtype=torch.int32)
+            torch.cumsum(qo_lens_cpu[req_indices], dim=0, out=group_qo_indptr[1:])
+            group_kv_indptr = torch.zeros(req_indices.numel() + 1, dtype=torch.int32)
+            torch.cumsum(
+                kv_page_counts_cpu[req_indices], dim=0, out=group_kv_indptr[1:]
+            )
+            token_indices_cpu = torch.cat(
+                [
+                    torch.arange(
+                        int(qo_indptr_prefill_cpu[i]),
+                        int(qo_indptr_prefill_cpu[i + 1]),
+                        dtype=torch.int64,
+                    )
+                    for i in req_indices.tolist()
+                ]
+            )
+            page_gather_cpu = torch.cat(
+                [
+                    torch.arange(
+                        int(paged_kv_indptr_prefill_cpu[i]),
+                        int(paged_kv_indptr_prefill_cpu[i + 1]),
+                        dtype=torch.int64,
+                    )
+                    for i in req_indices.tolist()
+                ]
+            )
+            group_kv_indices = torch.index_select(
+                paged_kv_indices, 0, page_gather_cpu.to(self.device)
+            )
+            if group_mm:
+                wrapper = self._get_mm_prefill_wrapper()
+                custom_mask = self._build_mm_prefix_custom_mask(
+                    [int(qo_lens_cpu[i]) for i in req_indices.tolist()],
+                    [int(seq_lens_prefill_cpu[i]) for i in req_indices.tolist()],
+                    [prefill_mm_spans[i] for i in req_indices.tolist()],
+                )
+                # The mask carries causal/SW/span composition wholesale.
+                group_causal = False
+                group_window_left = -1
+            else:
+                maybe_wrapper = self._get_prefill_wrapper()
+                assert isinstance(maybe_wrapper, BatchPrefillWithPagedKVCacheWrapper)
+                wrapper = maybe_wrapper
+                custom_mask = None
+                group_causal = True
+                group_window_left = self.window_left
+            wrapper.plan(
+                qo_indptr=group_qo_indptr,
+                paged_kv_indptr=group_kv_indptr,
+                paged_kv_indices=group_kv_indices,
+                paged_kv_last_page_len=paged_kv_last_page_len_prefill_cpu[req_indices],
+                num_qo_heads=self.num_qo_heads,
+                num_kv_heads=self.num_kv_heads,
+                head_dim_qk=self.head_dim,
+                # == head_dim_qk unless the VO split is active; then the
+                # impl runs each group's wrapper once per V slice.
+                head_dim_vo=self.head_dim // self.vo_split,
+                page_size=self.page_size,
+                causal=group_causal,
+                custom_mask=custom_mask,
+                sm_scale=self.sm_scale,
+                window_left=group_window_left,
+                logits_soft_cap=self.logits_soft_cap,
+                q_data_type=self.q_data_type_prefill,
+                kv_data_type=self.kv_cache_dtype,
+                o_data_type=o_dtype,
+                fixed_split_size=self.prefill_fixed_split_size,
+                disable_split_kv=self.disable_split_kv,
+            )
+            wrapper.vllm_prefill_fixed_split_size = self.prefill_fixed_split_size
+            wrapper.vllm_disable_split_kv = self.disable_split_kv
+            groups.append(
+                FIPrefillMMGroup(
+                    wrapper=wrapper,
+                    token_indices=token_indices_cpu.to(self.device),
+                    num_tokens=int(token_indices_cpu.numel()),
+                )
+            )
+        return groups
+
     def build(
         self,
         common_prefix_len: int,
@@ -1472,6 +1741,17 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 "Using FlashInfer for draft model non-causal attention; TRTLLM "
                 "can still be used for target model causal attention."
             )
+        # mm-prefix: prefill requests whose image span intersects the
+        # query window need the FI-native custom-mask path (TRTLLM has no
+        # custom masks). Decode stays causal: spans live in the prompt.
+        prefill_mm_spans: list[list[tuple[int, int]]] | None = None
+        if self.mm_prefix_enabled and num_prefills > 0:
+            prefill_mm_spans = self._mm_prefix_prefill_spans(
+                common_attn_metadata, num_decodes, num_prefills
+            )
+            if prefill_mm_spans is not None:
+                prefill_use_trtllm = False
+
         all_uses_trtllm = causal and (
             (num_prefills == 0 or prefill_use_trtllm)
             and (num_decodes == 0 or decode_with_flashinfer_trtllm_api)
@@ -1694,6 +1974,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     prefill_start : num_reqs + 1
                 ]
                 assert paged_kv_indptr_prefill_cpu.shape[0] == num_prefills + 1
+                mm_groups: list[FIPrefillMMGroup] | None = None
                 if self.use_dcp:
                     assert isinstance(prefill_wrapper, BatchDCPPrefillWrapper)
                     prefill_wrapper.plan(
@@ -1727,31 +2008,49 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                         if (self.is_kvcache_nvfp4 and not self.use_fa2_nvfp4_kv)
                         else self.model_config.dtype
                     )
-                    prefill_wrapper.plan(
-                        qo_indptr=qo_indptr_prefill_cpu,
-                        paged_kv_indptr=paged_kv_indptr_prefill_cpu,
-                        paged_kv_indices=paged_kv_indices,
-                        paged_kv_last_page_len=paged_kv_last_page_len_prefill_cpu,
-                        num_qo_heads=self.num_qo_heads,
-                        num_kv_heads=self.num_kv_heads,
-                        head_dim_qk=self.head_dim,
-                        # == head_dim_qk unless the VO split is active; then
-                        # each pass plans head_dim_vo=head_size//vo_split (256
-                        # for Gemma 4 512-wide heads) and the impl runs the
-                        # wrapper once per V slice (_run_vo_split_prefill).
-                        head_dim_vo=self.head_dim // self.vo_split,
-                        page_size=self.page_size,
-                        causal=attn_metadata.causal,
-                        sm_scale=self.sm_scale,
-                        window_left=self.window_left,
-                        logits_soft_cap=self.logits_soft_cap,
-                        q_data_type=self.q_data_type_prefill,
-                        kv_data_type=self.kv_cache_dtype,
-                        o_data_type=o_dtype,
-                        fixed_split_size=self.prefill_fixed_split_size,
-                        disable_split_kv=self.disable_split_kv,
-                    )
-                attn_metadata.prefill = FIPrefill(wrapper=prefill_wrapper)
+                    if prefill_mm_spans is not None:
+                        assert seq_lens_cpu is not None
+                        mm_groups = self._plan_prefill_mm_groups(
+                            prefill_mm_spans,
+                            qo_indptr_prefill_cpu,
+                            paged_kv_indptr_prefill_cpu,
+                            paged_kv_last_page_len_prefill_cpu,
+                            paged_kv_indices,
+                            seq_lens_cpu[prefill_start:num_reqs],
+                            o_dtype,
+                        )
+                        # The impl's forward dispatches on mm_groups; this
+                        # field only feeds its isinstance/identity asserts.
+                        prefill_wrapper = mm_groups[0].wrapper
+                    else:
+                        prefill_wrapper.plan(
+                            qo_indptr=qo_indptr_prefill_cpu,
+                            paged_kv_indptr=paged_kv_indptr_prefill_cpu,
+                            paged_kv_indices=paged_kv_indices,
+                            paged_kv_last_page_len=paged_kv_last_page_len_prefill_cpu,
+                            num_qo_heads=self.num_qo_heads,
+                            num_kv_heads=self.num_kv_heads,
+                            head_dim_qk=self.head_dim,
+                            # == head_dim_qk unless the VO split is active;
+                            # then each pass plans head_dim_vo=head_size//
+                            # vo_split (256 for Gemma 4 512-wide heads) and
+                            # the impl runs the wrapper once per V slice
+                            # (_run_vo_split_prefill).
+                            head_dim_vo=self.head_dim // self.vo_split,
+                            page_size=self.page_size,
+                            causal=attn_metadata.causal,
+                            sm_scale=self.sm_scale,
+                            window_left=self.window_left,
+                            logits_soft_cap=self.logits_soft_cap,
+                            q_data_type=self.q_data_type_prefill,
+                            kv_data_type=self.kv_cache_dtype,
+                            o_data_type=o_dtype,
+                            fixed_split_size=self.prefill_fixed_split_size,
+                            disable_split_kv=self.disable_split_kv,
+                        )
+                attn_metadata.prefill = FIPrefill(
+                    wrapper=prefill_wrapper, mm_groups=mm_groups
+                )
 
         ## DECODE PATHWAY
         if num_decodes > 0:
@@ -2309,12 +2608,26 @@ class FlashInferImpl(AttentionImpl):
                     assert isinstance(
                         prefill_wrapper, BatchPrefillWithPagedKVCacheWrapper
                     )
-                    assert prefill_wrapper._window_left == self.window_left
+                    mm_groups = attn_metadata.prefill.mm_groups
                     assert prefill_wrapper._logits_soft_cap == (
                         self.logits_soft_cap or 0.0
                     )
                     assert prefill_wrapper._sm_scale == self.scale
-                    assert prefill_wrapper._causal == attn_metadata.causal
+                    if mm_groups is None:
+                        assert prefill_wrapper._window_left == self.window_left
+                        assert prefill_wrapper._causal == attn_metadata.causal
+                    else:
+                        # The mm group's wrapper carries the sliding window
+                        # and causality inside its packed custom mask
+                        # (planned non-causal, window_left=-1); the plain
+                        # group keeps the scalar-causal plan.
+                        for group in mm_groups:
+                            if group.wrapper._custom_mask_buf is None:
+                                assert group.wrapper._causal
+                                assert group.wrapper._window_left == self.window_left
+                            else:
+                                assert not group.wrapper._causal
+                                assert group.wrapper._window_left == -1
 
                     if self.is_kvcache_nvfp4:
                         kv_cache_for_fi = nvfp4_kv_data
@@ -2349,6 +2662,46 @@ class FlashInferImpl(AttentionImpl):
                             v_scale=layer._v_scale_float,
                             out=out_prefill,
                         )
+                    elif mm_groups is not None:
+                        # mm-prefix grouping: each partition runs its own
+                        # planned wrapper (plain causal vs packed custom
+                        # mask) over a gathered copy of its query rows,
+                        # then scatters back. Gather/scatter is by token
+                        # index because the groups may interleave within
+                        # the batch.
+                        if self.is_kvcache_nvfp4:
+                            assert isinstance(kv_cache_for_fi, tuple)
+                        for group in mm_groups:
+                            group_query = torch.index_select(
+                                prefill_query, 0, group.token_indices
+                            )
+                            group_out = torch.empty(
+                                (group.num_tokens, *out_prefill.shape[1:]),
+                                dtype=out_prefill.dtype,
+                                device=out_prefill.device,
+                            )
+                            if self.vo_split > 1:
+                                self._run_vo_split_prefill(
+                                    group.wrapper,
+                                    group_query,
+                                    kv_cache_for_fi,
+                                    kv_cache_sf,
+                                    group_out,
+                                    q_scale=layer._q_scale_float,
+                                    k_scale=layer._k_scale_float,
+                                    v_scale=layer._v_scale_float,
+                                )
+                            else:
+                                group.wrapper.run(
+                                    group_query,
+                                    kv_cache_for_fi,
+                                    q_scale=layer._q_scale_float,
+                                    k_scale=layer._k_scale_float,
+                                    v_scale=layer._v_scale_float,
+                                    out=group_out,
+                                    kv_cache_sf=kv_cache_sf,
+                                )
+                            out_prefill.index_copy_(0, group.token_indices, group_out)
                     elif self.vo_split > 1:
                         # head_size > 256: run ceil(head_size/256) passes,
                         # each over a head-dim slice of the 512-wide V cache,

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -2068,7 +2068,13 @@ class FlashInferImpl(AttentionImpl):
         self.o_sf_scale: float | None = None
 
         # Pre-allocated FP8 output buffer for NVFP4 without fused output quant.
-        if self.is_kvcache_nvfp4 and vllm_config is not None:
+        # Only needed on the trtllm-gen path (SM100); the FA2 path (SM120)
+        # outputs directly in model dtype so this buffer is unused.
+        if (
+            self.is_kvcache_nvfp4
+            and vllm_config is not None
+            and not self.use_fa2_nvfp4_kv
+        ):
             max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
             self._nvfp4_fp8_out = torch.empty(
                 (max_num_tokens, num_heads, head_size),

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -2274,7 +2274,13 @@ class FlashInferImpl(AttentionImpl):
         self.o_sf_scale: float | None = None
 
         # Pre-allocated FP8 output buffer for NVFP4 without fused output quant.
-        if self.is_kvcache_nvfp4 and vllm_config is not None:
+        # Only needed on the trtllm-gen path (SM100); the FA2 path (SM120)
+        # outputs directly in model dtype so this buffer is unused.
+        if (
+            self.is_kvcache_nvfp4
+            and vllm_config is not None
+            and not self.use_fa2_nvfp4_kv
+        ):
             max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
             self._nvfp4_fp8_out = torch.empty(
                 (max_num_tokens, num_heads, head_size),

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -648,7 +648,7 @@ class FlashInferBackend(AttentionBackend):
             if (
                 vllm_config is not None
                 and vllm_config.cache_config is not None
-                and vllm_config.cache_config.cache_dtype == "nvfp4"
+                and vllm_config.cache_config.cache_dtype.startswith("nvfp4")
             ):
                 return "HND"
         return None

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -516,6 +516,11 @@ class FlashInferBackend(AttentionBackend):
     @classmethod
     def supports_kv_cache_dtype(cls, kv_cache_dtype: CacheDType | None) -> bool:
         if kv_cache_dtype is not None and kv_cache_dtype.startswith("nvfp4"):
+            # Consumer Blackwell (sm120/sm121): NVFP4 KV is served through
+            # the FlashInfer FA2 paged reader (uint8 fp4 cache), no
+            # trtllm-gen requirement. Mirrors the builder __init__ gate.
+            if current_platform.is_device_capability_family(120):
+                return True
             return (
                 current_platform.is_device_capability_family(100)
                 and supports_trtllm_attention(is_prefill=True)
@@ -787,20 +792,31 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             # Cannot use self.kv_cache_spec.dtype here because kv_cache_spec
             # storage dtype may not be the same as the op dtype (uint8 vs fp8_e4m3)
             self.is_kvcache_nvfp4 = self.cache_dtype.startswith("nvfp4")
+            self.use_fa2_nvfp4_kv = False
             if self.is_kvcache_nvfp4:
-                if (
+                if current_platform.is_device_capability_family(120):
+                    # Consumer Blackwell (sm120/sm121): no trtllm-gen FP4 FMHA,
+                    # so route NVFP4 KV through FlashInfer's FA2 paged reader.
+                    # The cache stores packed uint8 fp4 data; the per-side
+                    # [data | scale] regions are read back as views with
+                    # explicit strides (nvfp4_split_data_scale).
+                    self.use_fa2_nvfp4_kv = True
+                    self.kv_cache_dtype = FlashInferBackend.get_dtype_for_flashinfer(
+                        "nvfp4"
+                    )
+                elif (
                     force_use_trtllm_attention() is False
                     or not supports_trtllm_attention(is_prefill=True)
                     or not supports_trtllm_attention(is_prefill=False)
                 ):
                     raise ValueError(
-                        f"--kv-cache-dtype {self.cache_dtype} requires the "
-                        "SM100 trtllm-gen "
-                        "FlashInfer path."
+                        "--kv-cache-dtype nvfp4 requires the SM100 trtllm-gen "
+                        "FlashInfer path or consumer Blackwell (sm120/sm121)."
                     )
-                # The scale search only affects the store kernel. FlashInfer
-                # reads both variants using the same NVFP4 layout.
-                self.kv_cache_dtype = "nvfp4"
+                else:
+                    # sm100 trtllm-gen: kv_cache_dtype stays the string "nvfp4"
+                    # which is passed to FlashInferImpl.
+                    self.kv_cache_dtype = self.cache_dtype
             else:
                 self.kv_cache_dtype = FlashInferBackend.get_dtype_for_flashinfer(
                     self.cache_dtype
@@ -808,6 +824,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         else:
             self.cache_dtype = "auto"
             self.is_kvcache_nvfp4 = False
+            self.use_fa2_nvfp4_kv = False
             assert self.kv_cache_spec.dtype == self.model_config.dtype
             self.kv_cache_dtype = self.kv_cache_spec.dtype
 
@@ -960,6 +977,10 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 return FlashInferBackend.get_dtype_for_flashinfer(cache_dtype)
             return self.model_config.dtype
         if cache_dtype.startswith("nvfp4"):
+            if current_platform.is_device_capability_family(120):
+                # The FA2 paged nvfp4 reader (consumer Blackwell) consumes
+                # model-dtype queries; FP8-Q is a trtllm-gen-only contract.
+                return self.model_config.dtype
             return FlashInferBackend.get_dtype_for_flashinfer("fp8_e4m3")
         return self.kv_cache_spec.dtype
 
@@ -1174,9 +1195,14 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                         window_left=self.window_left,
                     )
                 else:
-                    # NVFP4 KV cache requires the trtllm-gen backend inside
-                    # the wrapper; fa2/fa3 do not support nvfp4.
-                    backend = "trtllm-gen" if self.is_kvcache_nvfp4 else "auto"
+                    # NVFP4 KV: FlashInfer FA2 paged reader on consumer Blackwell
+                    # (sm120/sm121); trtllm-gen on sm100f.
+                    if self.use_fa2_nvfp4_kv:
+                        backend = "fa2"
+                    elif self.is_kvcache_nvfp4:
+                        backend = "trtllm-gen"
+                    else:
+                        backend = "auto"
                     self._prefill_wrapper = BatchPrefillWithPagedKVCacheWrapper(
                         self._get_workspace_buffer(),
                         get_kv_cache_layout(),
@@ -1200,9 +1226,14 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 paged_kv_indptr = None
                 paged_kv_indices = None
                 paged_kv_last_page_len = None
-            # NVFP4 KV cache requires the trtllm-gen backend inside
-            # the wrapper; fa2/fa3 do not support nvfp4.
-            backend = "trtllm-gen" if self.is_kvcache_nvfp4 else "auto"
+            # NVFP4 KV: FlashInfer FA2 paged reader on consumer Blackwell
+            # (sm120/sm121); trtllm-gen on sm100f.
+            if self.use_fa2_nvfp4_kv:
+                backend = "fa2"
+            elif self.is_kvcache_nvfp4:
+                backend = "trtllm-gen"
+            else:
+                backend = "auto"
             decode_wrapper = BatchDecodeWithPagedKVCacheWrapper(
                 self._get_workspace_buffer(),
                 get_kv_cache_layout(),
@@ -1607,7 +1638,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     # use FP8 o_data_type so the wrapper matches the
                     # FP8 output buffer allocated in forward().
                     o_dtype = (
-                        FP8_DTYPE if self.is_kvcache_nvfp4 else self.model_config.dtype
+                        FP8_DTYPE
+                        if (self.is_kvcache_nvfp4 and not self.use_fa2_nvfp4_kv)
+                        else self.model_config.dtype
                     )
                     prefill_wrapper.plan(
                         qo_indptr=qo_indptr_prefill_cpu,
@@ -1692,7 +1725,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 # use FP8 o_data_type so the wrapper matches the
                 # FP8 output buffer allocated in forward().
                 o_dtype = (
-                    FP8_DTYPE if self.is_kvcache_nvfp4 else self.model_config.dtype
+                    FP8_DTYPE
+                    if (self.is_kvcache_nvfp4 and not self.use_fa2_nvfp4_kv)
+                    else self.model_config.dtype
                 )
                 fast_plan_decode(
                     decode_wrapper,
@@ -1762,6 +1797,11 @@ class FlashInferImpl(AttentionImpl):
         )
         self.cache_dtype = kv_cache_dtype
         self.is_kvcache_nvfp4 = kv_cache_dtype.startswith("nvfp4")
+        self.use_fa2_nvfp4_kv = (
+            self.is_kvcache_nvfp4 and current_platform.is_device_capability_family(120)
+        )
+        # The scale search only affects the store kernel. FlashInfer reads
+        # both variants using the same NVFP4 layout.
         self.kv_cache_dtype = "nvfp4" if self.is_kvcache_nvfp4 else kv_cache_dtype
         self.fp4_data_dim = head_size // 2 if self.is_kvcache_nvfp4 else 0
         self.logits_soft_cap = logits_soft_cap
@@ -2128,7 +2168,9 @@ class FlashInferImpl(AttentionImpl):
                     # Use a pre-allocated FP8 buffer and dequantize
                     # afterwards.
                     needs_fp8_out_prefill = (
-                        self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                        self.is_kvcache_nvfp4
+                        and output.dtype != FP8_DTYPE
+                        and not self.use_fa2_nvfp4_kv
                     )
                     if needs_fp8_out_prefill:
                         out_prefill = self._nvfp4_fp8_out[:num_prefill_tokens]
@@ -2195,7 +2237,11 @@ class FlashInferImpl(AttentionImpl):
 
                 # NVFP4 trtllm kernel only supports FP8 output.
                 # Use a pre-allocated FP8 buffer and dequantize afterwards.
-                needs_fp8_out = self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                needs_fp8_out = (
+                    self.is_kvcache_nvfp4
+                    and output.dtype != FP8_DTYPE
+                    and not self.use_fa2_nvfp4_kv
+                )
                 if needs_fp8_out:
                     out = self._nvfp4_fp8_out[:num_prefill_tokens]
 
@@ -2298,7 +2344,11 @@ class FlashInferImpl(AttentionImpl):
 
                 # NVFP4 kernel only supports FP8 output.
                 # Use a pre-allocated FP8 buffer and dequantize afterwards.
-                needs_fp8_out = self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                needs_fp8_out = (
+                    self.is_kvcache_nvfp4
+                    and output.dtype != FP8_DTYPE
+                    and not self.use_fa2_nvfp4_kv
+                )
                 if needs_fp8_out:
                     out_decode = self._nvfp4_fp8_out[:num_decode_tokens]
                 else:
@@ -2427,7 +2477,11 @@ class FlashInferImpl(AttentionImpl):
 
                 # NVFP4 trtllm kernel only supports FP8 output.
                 # Use a pre-allocated FP8 buffer and dequantize afterwards.
-                needs_fp8_out = self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                needs_fp8_out = (
+                    self.is_kvcache_nvfp4
+                    and output.dtype != FP8_DTYPE
+                    and not self.use_fa2_nvfp4_kv
+                )
                 if needs_fp8_out:
                     out = self._nvfp4_fp8_out[:num_decode_tokens]
 

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1197,6 +1197,16 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             return AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE
 
         is_sm12x = current_platform.is_device_capability_family(120)
+        # NVFP4 KV on consumer Blackwell is served by the FA2 paged reader
+        # (XQA/trtllm-gen cannot read NVFP4, and head_size > 256 routes
+        # decode through the VO-split prefill wrapper), so the uniform-batch
+        # capture contract does not hold; fall back to per-request capture.
+        if (
+            is_sm12x
+            and vllm_config.cache_config is not None
+            and vllm_config.cache_config.cache_dtype.startswith("nvfp4")
+        ):
+            return AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE
         # XQA does not return LSE and therefore does not support DCP.
         if is_sm12x and vllm_config.parallel_config.decode_context_parallel_size > 1:
             return AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -966,8 +966,13 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
 
         # Prefer TRTLLM/XQA for decoding whenever supported. The decode kernel
         # must be selected statically for FULL cudagraph capture.
-        can_use_xqa_or_trtllm_gen_decode = can_use_trtllm_attention(
-            self.num_qo_heads, self.num_kv_heads, is_prefill=False
+        # NVFP4 KV on consumer Blackwell is served by the FA2 paged reader;
+        # XQA/trtllm-gen decode cannot read NVFP4 cache.
+        can_use_xqa_or_trtllm_gen_decode = (
+            not self.use_fa2_nvfp4_kv
+            and can_use_trtllm_attention(
+                self.num_qo_heads, self.num_kv_heads, is_prefill=False
+            )
         )
         # Page sizes >= 128 require the trtllm-gen GQA/MQA path (guaranteed by
         # get_supported_kernel_block_sizes).

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -89,6 +89,57 @@ FP4_DTYPE = torch.uint8
 
 logger = init_logger(__name__)
 
+
+def _vllm_nvfp4_kv_vosplit_requested() -> bool:
+    """VLLM_NVFP4_KV_VOSPLIT opts head_size > 256 NVFP4 layers into the FA2
+    two-pass VO split (Gemma 4 global D=512 full-attention layers).
+
+    Default-on (see vllm/envs.py); only an explicit "0" disables it. The
+    model-config routing (vllm/model_executor/models/config.py) gates the
+    Gemma 4 -> FLASHINFER decision on the same flag, so the backend must
+    honor it here too."""
+    return bool(envs.VLLM_NVFP4_KV_VOSPLIT)
+
+
+def _vo_split_factor(head_size: int, is_fa2_nvfp4: bool) -> int:
+    """Number of VO passes for the FlashInfer FA2 path.
+
+    The FA2 nvfp4 kernel trait guard rejects HEAD_DIM_VO > 256 (the
+    per-thread output-accumulator fragments do not fit the register
+    budget), but HEAD_DIM_QK=512 is fine, and attention decomposes
+    EXACTLY along the VO dimension: S = Q @ K^T and the softmax are
+    identical per pass, and O = [P @ V_left | P @ V_right] concatenates
+    with no LSE merge. So a Gemma 4 full-attention head (Q=K=V=512 wide;
+    the cache stores V at 512) runs as ``ceil(head_size/256)`` passes of
+    ``(head_dim_qk=512, head_dim_vo=256)``, each over a head-dim slice of
+    the 512-wide V cache (and, for NVFP4, of its per-16-element scale
+    factors).
+
+    The split is dtype-independent (the guard counts only accumulator
+    fragments). For NVFP4 it additionally requires linear (non-swizzled)
+    V scale factors, which the sm12x cache writer stores, so the V data
+    and scale views slice cleanly along the head dim; the trtllm-gen
+    4-token V-scale swizzle does not commute with head-dim slicing.
+    """
+    if head_size <= 256:
+        return 1
+    if is_fa2_nvfp4 and not _vllm_nvfp4_kv_vosplit_requested():
+        raise ValueError(
+            f"NVFP4 KV with head_size={head_size} on the SM12x FA2 path "
+            "needs the two-pass VO split (the FA2 kernel caps HEAD_DIM_VO "
+            "at 256). Set VLLM_NVFP4_KV_VOSPLIT=1 to enable it, or keep "
+            "these layers on a different KV dtype."
+        )
+    split = -(-head_size // 256)  # ceil(head_size / 256)
+    if head_size % split != 0 or (is_fa2_nvfp4 and (head_size // split) % 16 != 0):
+        raise ValueError(
+            "The VO split needs head_size divisible into <=256-wide chunks"
+            f"{' of whole 16-element scale blocks' if is_fa2_nvfp4 else ''}; "
+            f"got head_size={head_size}."
+        )
+    return split
+
+
 trtllm_workspace_buffer = None
 
 
@@ -494,6 +545,13 @@ class FlashInferBackend(AttentionBackend):
         ) and supports_trtllm_attention(is_prefill=True)
 
     @classmethod
+    def supports_mm_prefix(cls) -> bool:
+        # Text-mode is fully correct (no image spans to mask). Span-level
+        # bidirectional masking for image inputs is the separate mm-prefix
+        # concern; for NVFP4-KV text serving this gate must not reject FA2.
+        return True
+
+    @classmethod
     def get_required_kv_cache_layout(cls) -> KVCacheLayoutType | None:
         capability = current_platform.get_device_capability()
         if capability is not None and capability.major == 10:
@@ -706,6 +764,14 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
 
         self.num_kv_heads = self.kv_cache_spec.num_kv_heads
         self.head_dim = self.kv_cache_spec.head_size
+        # Gemma 4 full-attention is SYMMETRIC: Q=K=V=512-wide per head (the
+        # KV cache stores V at 512). There is no native 256-wide V. The FA2
+        # nvfp4 kernel caps HEAD_DIM_VO at 256, so a 512-wide V/O is run as
+        # ceil(head_size/256) two-pass VO-split chunks: each pass uses
+        # head_dim_qk=full head_size, head_dim_vo=head_size//vo_split, over a
+        # head-dim slice of the 512-wide V cache; the per-pass outputs
+        # concatenate exactly (identical S/softmax, no LSE merge).
+        # vo_split == 1 for head_size <= 256 (ordinary single-pass).
         self.page_size = self.kv_cache_spec.block_size
 
         if self.kv_cache_spec.kv_quant_mode != KVQuantMode.NONE:
@@ -801,6 +867,25 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             # flash_attn_varlen_func's cp_world_size/cp_rank/cp_tot_seqused_k).
             supports_dcp_with_varlen=False,
         )
+
+        # Two-pass VO split for head_size > 256 (Gemma 4 full-attention,
+        # head_dim_qk=512). vo_split == 1 leaves all existing paths
+        # untouched.
+        self.vo_split = _vo_split_factor(self.head_dim, self.use_fa2_nvfp4_kv)
+        if self.vo_split > 1:
+            # BatchDecodeWithPagedKVCacheWrapper.plan() has no head_dim_vo,
+            # so route every request through the VO-split-planned prefill
+            # wrapper: threshold 0 classifies nothing as decode, and a
+            # causal qo_len==1 prefill computes exactly what decode would.
+            self.reorder_batch_threshold = 0
+            logger.info_once(
+                "FA2 VO split (%s KV): head_size %d runs as %d passes of "
+                "head_dim_vo=%d; decode requests use the prefill wrapper.",
+                self.cache_dtype,
+                self.head_dim,
+                self.vo_split,
+                self.head_dim // self.vo_split,
+            )
 
         self._cascade_wrapper = None  # Wrapper for cascade attention
 
@@ -1469,6 +1554,11 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                         num_qo_heads=self.num_qo_heads,
                         num_kv_heads=self.num_kv_heads,
                         head_dim_qk=self.head_dim,
+                        # == head_dim_qk unless the VO split is active; then
+                        # each pass plans head_dim_vo=head_size//vo_split (256
+                        # for Gemma 4 512-wide heads) and the impl runs the
+                        # wrapper once per V slice (_run_vo_split_prefill).
+                        head_dim_vo=self.head_dim // self.vo_split,
                         page_size=self.page_size,
                         causal=attn_metadata.causal,
                         sm_scale=self.sm_scale,
@@ -1598,6 +1688,11 @@ class FlashInferImpl(AttentionImpl):
             self.is_kvcache_nvfp4 and current_platform.is_device_capability_family(120)
         )
         self.fp4_data_dim = head_size // 2 if self.is_kvcache_nvfp4 else 0
+        # Two-pass VO split factor for head_size > 256 (Gemma 4 D=512); 1
+        # otherwise. Must match the builder's vo_split: the wrapper is
+        # planned with head_dim_vo = head_size // vo_split, so the impl must
+        # run it once per V slice when vo_split > 1.
+        self.vo_split = _vo_split_factor(head_size, self.use_fa2_nvfp4_kv)
         self.logits_soft_cap = logits_soft_cap
         self.kv_sharing_target_layer_name = kv_sharing_target_layer_name
 
@@ -1714,6 +1809,71 @@ class FlashInferImpl(AttentionImpl):
             return query_quantized.view(num_tokens, num_heads, head_size)
 
         return query
+
+    def _run_vo_split_prefill(
+        self,
+        wrapper: BatchPrefillWithPagedKVCacheWrapper,
+        query: torch.Tensor,
+        kv_cache: tuple[torch.Tensor, torch.Tensor],
+        kv_sf: tuple[torch.Tensor, torch.Tensor] | None,
+        out: torch.Tensor,
+        *,
+        q_scale: float,
+        k_scale: float,
+        v_scale: float,
+    ) -> None:
+        """Multi-pass FA2 prefill run for head_size > 256 (Gemma 4 D=512).
+
+        The wrapper is planned with head_dim_vo = head_size // vo_split, and
+        each pass consumes a head-dim slice of V (and, for NVFP4, of the V
+        scale factors): S = Q @ K^T and the softmax are recomputed
+        identically per pass, so the per-pass outputs concatenate exactly
+        along the head dim with no LSE merge. narrow() keeps the full
+        tensor's strides, which the FA2 path requires.
+
+        NVFP4 V slicing relies on the linear (non-swizzled) V scale layout
+        the sm12x cache writer stores: the V data view's last dim is
+        ``head_size // 2`` packed e2m1 bytes and the V scale view's last
+        dim is ``head_size // 16`` fp8 scales, both contiguous along the
+        head dim, so chunk ``i`` is data[i*chunk//2 : ...] and
+        scale[i*chunk//16 : ...].
+        """
+        split = self.vo_split
+        head_chunk = self.head_size // split
+        k_cache, v_cache = kv_cache
+        if self.is_kvcache_nvfp4:
+            assert kv_sf is not None
+            k_sf, v_sf = kv_sf
+            data_step = head_chunk // 2  # packed e2m1, 2 elements per byte
+            sf_step = head_chunk // 16  # one fp8 scale per 16 elements
+        else:
+            k_sf = v_sf = None
+            data_step = head_chunk
+            sf_step = 0
+        for i in range(split):
+            v_cache_i = v_cache.narrow(-1, i * data_step, data_step)
+            kv_sf_i = (
+                (k_sf, v_sf.narrow(-1, i * sf_step, sf_step))
+                if v_sf is not None
+                else None
+            )
+            # The kernel needs a contiguous output; write into a chunk
+            # buffer and copy into the head-dim slice of the full output.
+            out_i = torch.empty(
+                (*out.shape[:-1], head_chunk),
+                dtype=out.dtype,
+                device=out.device,
+            )
+            wrapper.run(
+                query,
+                (k_cache, v_cache_i),
+                q_scale=q_scale,
+                k_scale=k_scale,
+                v_scale=v_scale,
+                out=out_i,
+                kv_cache_sf=kv_sf_i,
+            )
+            out.narrow(-1, i * head_chunk, head_chunk).copy_(out_i)
 
     def forward(
         self,
@@ -1963,15 +2123,34 @@ class FlashInferImpl(AttentionImpl):
                     else:
                         out_prefill = output[num_decode_tokens:]
 
-                    prefill_wrapper.run(
-                        prefill_query,
-                        kv_cache_for_fi,
-                        q_scale=layer._q_scale_float,
-                        k_scale=layer._k_scale_float,
-                        v_scale=layer._v_scale_float,
-                        out=out_prefill,
-                        kv_cache_sf=kv_cache_sf,
-                    )
+                    if self.vo_split > 1:
+                        # head_size > 256: run ceil(head_size/256) passes,
+                        # each over a head-dim slice of the 512-wide V cache,
+                        # and concatenate the per-pass outputs. The wrapper is
+                        # planned with head_dim_vo = head_size // vo_split.
+                        if self.is_kvcache_nvfp4:
+                            assert isinstance(kv_cache_for_fi, tuple)
+                            assert isinstance(kv_cache_sf, tuple)
+                        self._run_vo_split_prefill(
+                            prefill_wrapper,
+                            prefill_query,
+                            kv_cache_for_fi,
+                            kv_cache_sf,
+                            out_prefill,
+                            q_scale=layer._q_scale_float,
+                            k_scale=layer._k_scale_float,
+                            v_scale=layer._v_scale_float,
+                        )
+                    else:
+                        prefill_wrapper.run(
+                            prefill_query,
+                            kv_cache_for_fi,
+                            q_scale=layer._q_scale_float,
+                            k_scale=layer._k_scale_float,
+                            v_scale=layer._v_scale_float,
+                            out=out_prefill,
+                            kv_cache_sf=kv_cache_sf,
+                        )
 
                     if needs_fp8_out_prefill:
                         output[
@@ -2093,6 +2272,16 @@ class FlashInferImpl(AttentionImpl):
         if num_decode_tokens > 0:
             decode_query = query[:num_decode_tokens]
             assert decode_query.shape[0] == num_decode_tokens
+
+            # The VO split routes every request (including would-be decodes)
+            # through the prefill wrapper (builder sets reorder_batch_threshold
+            # = 0), because BatchDecodeWithPagedKVCacheWrapper.plan() has no
+            # head_dim_vo. So no decode tokens should reach this block.
+            assert self.vo_split == 1, (
+                "FA2 VO split routes decodes through the prefill wrapper; "
+                f"unexpected {num_decode_tokens} decode tokens with "
+                f"vo_split={self.vo_split}."
+            )
 
             # Convert query to the expected dtype for decode if needed.
             decode_query = self.maybe_quant_query(

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -445,6 +445,11 @@ class FlashInferBackend(AttentionBackend):
     @classmethod
     def supports_kv_cache_dtype(cls, kv_cache_dtype: CacheDType | None) -> bool:
         if kv_cache_dtype == "nvfp4":
+            # Consumer Blackwell (sm120/sm121): NVFP4 KV is served through
+            # the FlashInfer FA2 paged reader (uint8 fp4 cache), no
+            # trtllm-gen requirement. Mirrors the builder __init__ gate.
+            if current_platform.is_device_capability_family(120):
+                return True
             return (
                 current_platform.is_device_capability_family(100)
                 and supports_trtllm_attention(is_prefill=True)
@@ -708,19 +713,31 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             # Cannot use self.kv_cache_spec.dtype here because kv_cache_spec
             # storage dtype may not be the same as the op dtype (uint8 vs fp8_e4m3)
             self.is_kvcache_nvfp4 = self.cache_dtype == "nvfp4"
+            self.use_fa2_nvfp4_kv = False
             if self.is_kvcache_nvfp4:
-                if (
+                if current_platform.is_device_capability_family(120):
+                    # Consumer Blackwell (sm120/sm121): no trtllm-gen FP4 FMHA,
+                    # so route NVFP4 KV through FlashInfer's FA2 paged reader.
+                    # The cache stores packed uint8 fp4 data; the per-side
+                    # [data | scale] regions are read back as views with
+                    # explicit strides (nvfp4_split_data_scale).
+                    self.use_fa2_nvfp4_kv = True
+                    self.kv_cache_dtype = FlashInferBackend.get_dtype_for_flashinfer(
+                        "nvfp4"
+                    )
+                elif (
                     force_use_trtllm_attention() is False
                     or not supports_trtllm_attention(is_prefill=True)
                     or not supports_trtllm_attention(is_prefill=False)
                 ):
                     raise ValueError(
                         "--kv-cache-dtype nvfp4 requires the SM100 trtllm-gen "
-                        "FlashInfer path."
+                        "FlashInfer path or consumer Blackwell (sm120/sm121)."
                     )
-                # For NVFP4, kv_cache_dtype stays as the string "nvfp4"
-                # which is passed to FlashInferImpl
-                self.kv_cache_dtype = self.cache_dtype
+                else:
+                    # sm100 trtllm-gen: kv_cache_dtype stays the string "nvfp4"
+                    # which is passed to FlashInferImpl.
+                    self.kv_cache_dtype = self.cache_dtype
             else:
                 self.kv_cache_dtype = FlashInferBackend.get_dtype_for_flashinfer(
                     self.cache_dtype
@@ -728,6 +745,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         else:
             self.cache_dtype = "auto"
             self.is_kvcache_nvfp4 = False
+            self.use_fa2_nvfp4_kv = False
             assert self.kv_cache_spec.dtype == self.model_config.dtype
             self.kv_cache_dtype = self.kv_cache_spec.dtype
 
@@ -874,6 +892,10 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 return FlashInferBackend.get_dtype_for_flashinfer(cache_dtype)
             return self.model_config.dtype
         if cache_dtype == "nvfp4":
+            if current_platform.is_device_capability_family(120):
+                # The FA2 paged nvfp4 reader (consumer Blackwell) consumes
+                # model-dtype queries; FP8-Q is a trtllm-gen-only contract.
+                return self.model_config.dtype
             return FlashInferBackend.get_dtype_for_flashinfer("fp8_e4m3")
         return self.kv_cache_spec.dtype
 
@@ -997,9 +1019,14 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     dcp_a2a=self.dcp_a2a,
                 )
             else:
-                # NVFP4 KV cache requires the trtllm-gen backend inside
-                # the wrapper; fa2/fa3 do not support nvfp4.
-                backend = "trtllm-gen" if self.is_kvcache_nvfp4 else "auto"
+                # NVFP4 KV: FlashInfer FA2 paged reader on consumer Blackwell
+                # (sm120/sm121); trtllm-gen on sm100f.
+                if self.use_fa2_nvfp4_kv:
+                    backend = "fa2"
+                elif self.is_kvcache_nvfp4:
+                    backend = "trtllm-gen"
+                else:
+                    backend = "auto"
                 self._prefill_wrapper = BatchPrefillWithPagedKVCacheWrapper(
                     self._get_workspace_buffer(),
                     get_kv_cache_layout(),
@@ -1023,9 +1050,14 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 paged_kv_indptr = None
                 paged_kv_indices = None
                 paged_kv_last_page_len = None
-            # NVFP4 KV cache requires the trtllm-gen backend inside
-            # the wrapper; fa2/fa3 do not support nvfp4.
-            backend = "trtllm-gen" if self.is_kvcache_nvfp4 else "auto"
+            # NVFP4 KV: FlashInfer FA2 paged reader on consumer Blackwell
+            # (sm120/sm121); trtllm-gen on sm100f.
+            if self.use_fa2_nvfp4_kv:
+                backend = "fa2"
+            elif self.is_kvcache_nvfp4:
+                backend = "trtllm-gen"
+            else:
+                backend = "auto"
             decode_wrapper = BatchDecodeWithPagedKVCacheWrapper(
                 self._get_workspace_buffer(),
                 get_kv_cache_layout(),
@@ -1425,7 +1457,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     # use FP8 o_data_type so the wrapper matches the
                     # FP8 output buffer allocated in forward().
                     o_dtype = (
-                        FP8_DTYPE if self.is_kvcache_nvfp4 else self.model_config.dtype
+                        FP8_DTYPE
+                        if (self.is_kvcache_nvfp4 and not self.use_fa2_nvfp4_kv)
+                        else self.model_config.dtype
                     )
                     prefill_wrapper.plan(
                         qo_indptr=qo_indptr_prefill_cpu,
@@ -1488,7 +1522,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 # use FP8 o_data_type so the wrapper matches the
                 # FP8 output buffer allocated in forward().
                 o_dtype = (
-                    FP8_DTYPE if self.is_kvcache_nvfp4 else self.model_config.dtype
+                    FP8_DTYPE
+                    if (self.is_kvcache_nvfp4 and not self.use_fa2_nvfp4_kv)
+                    else self.model_config.dtype
                 )
                 fast_plan_decode(
                     decode_wrapper,
@@ -1558,6 +1594,9 @@ class FlashInferImpl(AttentionImpl):
         )
         self.kv_cache_dtype = kv_cache_dtype
         self.is_kvcache_nvfp4 = kv_cache_dtype == "nvfp4"
+        self.use_fa2_nvfp4_kv = (
+            self.is_kvcache_nvfp4 and current_platform.is_device_capability_family(120)
+        )
         self.fp4_data_dim = head_size // 2 if self.is_kvcache_nvfp4 else 0
         self.logits_soft_cap = logits_soft_cap
         self.kv_sharing_target_layer_name = kv_sharing_target_layer_name
@@ -1915,7 +1954,9 @@ class FlashInferImpl(AttentionImpl):
                     # Use a pre-allocated FP8 buffer and dequantize
                     # afterwards.
                     needs_fp8_out_prefill = (
-                        self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                        self.is_kvcache_nvfp4
+                        and output.dtype != FP8_DTYPE
+                        and not self.use_fa2_nvfp4_kv
                     )
                     if needs_fp8_out_prefill:
                         out_prefill = self._nvfp4_fp8_out[:num_prefill_tokens]
@@ -1969,7 +2010,11 @@ class FlashInferImpl(AttentionImpl):
 
                 # NVFP4 trtllm kernel only supports FP8 output.
                 # Use a pre-allocated FP8 buffer and dequantize afterwards.
-                needs_fp8_out = self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                needs_fp8_out = (
+                    self.is_kvcache_nvfp4
+                    and output.dtype != FP8_DTYPE
+                    and not self.use_fa2_nvfp4_kv
+                )
                 if needs_fp8_out:
                     out = self._nvfp4_fp8_out[:num_prefill_tokens]
 
@@ -2072,7 +2117,11 @@ class FlashInferImpl(AttentionImpl):
 
                 # NVFP4 kernel only supports FP8 output.
                 # Use a pre-allocated FP8 buffer and dequantize afterwards.
-                needs_fp8_out = self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                needs_fp8_out = (
+                    self.is_kvcache_nvfp4
+                    and output.dtype != FP8_DTYPE
+                    and not self.use_fa2_nvfp4_kv
+                )
                 if needs_fp8_out:
                     out_decode = self._nvfp4_fp8_out[:num_decode_tokens]
                 else:
@@ -2174,7 +2223,11 @@ class FlashInferImpl(AttentionImpl):
 
                 # NVFP4 trtllm kernel only supports FP8 output.
                 # Use a pre-allocated FP8 buffer and dequantize afterwards.
-                needs_fp8_out = self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                needs_fp8_out = (
+                    self.is_kvcache_nvfp4
+                    and output.dtype != FP8_DTYPE
+                    and not self.use_fa2_nvfp4_kv
+                )
                 if needs_fp8_out:
                     out = self._nvfp4_fp8_out[:num_decode_tokens]
 

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -365,6 +365,18 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
 
             assert num_accepted_tokens is not None
             num_accepted_tokens = num_accepted_tokens[spec_sequence_masks_cpu]
+            # A row can report 0 accepted tokens when its sampled tokens were
+            # discarded (stale async-scheduling step) while its drafts were
+            # still scheduled. Such a row has no valid spec state to resume
+            # from, and its recurrent state must not advance this step: null
+            # its state slots so the kernels skip both the initial-state read
+            # and the final-state write, and clamp the count so the slot
+            # index (num_accepted_tokens - 1) stays in bounds.
+            stale_spec_reqs = num_accepted_tokens == 0
+            spec_state_indices_tensor.masked_fill_(
+                stale_spec_reqs.unsqueeze(-1), NULL_BLOCK_ID
+            )
+            num_accepted_tokens = num_accepted_tokens.clamp(min=1)
 
         chunk_indices: torch.Tensor | None = None
         chunk_offsets: torch.Tensor | None = None

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -1560,11 +1560,19 @@ class SpecDecodeBaseProposer:
                 )
         else:
             # MTP model
-            share_lm_head = True
-            logger.info(
-                "Detected MTP model. "
-                "Sharing target model lm_head weights with the draft model."
-            )
+            import os as _os
+            share_lm_head = _os.environ.get("VLLM_MTP_NO_SHARE_LMHEAD") is None
+            if share_lm_head:
+                logger.info(
+                    "Detected MTP model. "
+                    "Sharing target model lm_head weights with the draft model."
+                )
+            else:
+                logger.info(
+                    "Detected MTP model. "
+                    "Keeping a separate lm_head for the draft model "
+                    "(VLLM_MTP_NO_SHARE_LMHEAD is set)."
+                )
 
         if share_lm_head and hasattr(target_language_model, "lm_head"):
             if hasattr(self.model, "lm_head"):

--- a/vllm/v1/spec_decode/utils.py
+++ b/vllm/v1/spec_decode/utils.py
@@ -575,6 +575,15 @@ def update_num_computed_tokens_for_batch_change(
 
     Requests that had drafts: corrected = prev_gpu + valid_count.
     New requests or non-draft (e.g. prefills): use CPU value directly.
+
+    NOTE: valid_sampled_token_count is 0 for rows whose sampled tokens were
+    discarded (see eagle_prepare_next_token_padded_kernel), so this can write
+    0 into num_accepted_tokens even though its normal range is
+    1..1+num_speculative_tokens. That 0 is the staleness signal: mamba/GDN
+    metadata builders and kernels that index state slots with
+    num_accepted_tokens - 1 must treat 0 as "stale row, do not touch state"
+    (see GDNAttentionMetadataBuilder.build) rather than assume the count is
+    always positive.
     """
     # Clamp because prev_positions can be -1 for new requests
     gather_indices = prev_positions.clamp(min=0)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -226,6 +226,13 @@ from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 from vllm.v1.worker.gpu_ubatch_wrapper import UBatchWrapper
 from vllm.v1.worker.kv_connector_model_runner_mixin import KVConnectorModelRunnerMixin
 from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
+from vllm.v1.worker.pp_spec_broadcast import (
+    broadcast_sampled_token_ids,
+    gather_valid_sampled_tokens_per_req,
+    num_computed_tokens_drift_correction,
+    receive_sampled_token_ids,
+    select_latest_sampled_token_per_req,
+)
 from vllm.v1.worker.ubatch_utils import (
     UBatchSlices,
     check_ubatch_thresholds,
@@ -304,6 +311,8 @@ class AsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
     ):
         self._model_runner_output = model_runner_output
         self._invalid_req_indices = invalid_req_indices
+        self._storm_seen: dict[int, bool] = {}
+        self._storm_printed: dict[int, bool] = {}
 
         # Event on the copy stream so we can synchronize the non-blocking copy.
         # Blocking (sleep) event to avoid busy-polling the CUDA driver lock.
@@ -375,6 +384,27 @@ class AsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
         output.sampled_token_ids = valid_sampled_token_ids
         output.logprobs = logprobs_lists
 
+        import os as _os
+        if _os.environ.get("PPDBG"):
+            for i, ids in enumerate(valid_sampled_token_ids):
+                if 0 in ids:
+                    print(f"[PPDBG] TOK0 req_idx={i} n={len(ids)} ids={ids}", flush=True)
+        # Unconditional first-occurrence storm detector: logs the first time a
+        # request emits 0 twice in a row (garbage-logits token-0 storm) with
+        # minimal output, so a pristine run can be diagnosed without PPDBG
+        # changing the memory layout. Prints once per request.
+        if not self._storm_seen.get(-1, False):
+            for i, ids in enumerate(valid_sampled_token_ids):
+                if 0 in ids:
+                    prev = self._storm_seen.get(i, False)
+                    if prev and not self._storm_printed.get(i, False):
+                        self._storm_printed[i] = True
+                        print(f"[STORM] first-double-zero req_idx={i} ids={ids} "
+                              f"step_ctx={len(valid_sampled_token_ids)}", flush=True)
+                    self._storm_seen[i] = True
+                else:
+                    self._storm_seen[i] = False
+
         if self._routed_experts_cpu is not None:
             output.routed_experts = self._routed_experts_cpu.tolists()
         del self._routed_experts
@@ -385,6 +415,9 @@ class AsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
             )
             if envs.VLLM_RAISE_ON_LOGIT_NANS:
                 raise_if_nan_logits(output.num_nans_in_logits)
+            import os as _os
+            if _os.environ.get("PPDBG") and output.num_nans_in_logits:
+                print(f"[PPDBG] NANS {output.num_nans_in_logits}", flush=True)
         del self._num_nans
 
         if self._has_fault is not None and self._has_fault.item():
@@ -589,8 +622,13 @@ class GPUModelRunner(
         # Async scheduling
         self.use_async_scheduling = self.scheduler_config.async_scheduling
 
+        # Copy-completion event of the last AsyncGPUModelRunnerOutput; the
+        # sampler waits on it before writing buffers the async D2H may read.
+        self._prev_async_copy_event: torch.cuda.Event | None = None
+
         # Async PP broadcast of sampled token ids, waited on in _prepare_input_ids.
         self._pp_recv_work: torch.distributed.Work | None = None
+        self._pp_draft_recv_work: torch.distributed.Work | None = None
 
         # Sampler
         self.sampler = Sampler(
@@ -707,6 +745,12 @@ class GPUModelRunner(
             self.rejection_sampler = RejectionSampler(
                 self.sampler, self.speculative_config, self.device
             )
+        else:
+            # Under PP>1 the draft lives only on the last rank; on every other
+            # rank `drafter` must still exist (as None) so the many
+            # `isinstance(self.drafter, ...)` checks in the hot path don't trip
+            # over a missing attribute.
+            self.drafter = None
 
         self.num_spec_tokens = 0
         self.prev_num_spec_tokens = 0
@@ -932,6 +976,10 @@ class GPUModelRunner(
         # Cached outputs.
         self._draft_token_ids: list[list[int]] | torch.Tensor | None = None
         self._draft_probs: torch.Tensor | None = None
+        # Per-request broadcast valid-sampled-token count from the last receiver
+        # call (non-last PP rank), consumed by _update_states to correct the
+        # optimistic num_computed_tokens drift. Keyed by req_id.
+        self._pp_prev_valid_sampled_count: dict[str, int] = {}
         self._draft_prob_req_ids: list[str] | None = None
         # N-gram GPU path: async D2H buffer/event for per-request valid draft counts.
         self._num_valid_draft_tokens: torch.Tensor | None = None
@@ -1437,6 +1485,23 @@ class GPUModelRunner(
                     optimistic_num_accepted = req_state.prev_num_draft_len
                     req_state.output_token_ids.extend([-1] * optimistic_num_accepted)
 
+                    # Non-last PP rank: the GPU kernel that corrects the optimistic
+                    # num_computed_tokens (update_num_computed_tokens_for_batch_change,
+                    # in _prepare_inputs) only runs on the sampler/last rank (gated on
+                    # valid_sampled_token_count_gpu). Reconstruct the same correction
+                    # here from the broadcast valid count the receiver stashed, BEFORE
+                    # num_computed_tokens is written to req_state / the cpu buffer
+                    # below — the scheduler advanced it optimistically (all drafts
+                    # accepted); subtract the rejected drafts so rope/KV positions
+                    # (built from num_computed_tokens) are not off-by-one after a
+                    # rejection. (The last rank keeps the kernel + deferred path.)
+                    if not is_last_rank:
+                        prev_valid = self._pp_prev_valid_sampled_count.get(req_id)
+                        if prev_valid is not None:
+                            num_computed_tokens -= num_computed_tokens_drift_correction(
+                                optimistic_num_accepted, prev_valid
+                            )
+
                     deferred_spec_decode_corrections.append(
                         (req_id, optimistic_num_accepted, req_state)
                     )
@@ -1458,6 +1523,12 @@ class GPUModelRunner(
 
             # Update the cached states.
             req_state.num_computed_tokens = num_computed_tokens
+
+            import os as _os
+            if _os.environ.get("PPDBG"):
+                print(f"[PPDBG] NCT req={req_id[:18]} nct={num_computed_tokens} "
+                      f"drafts={req_state.prev_num_draft_len} "
+                      f"nt={req_state.num_tokens}", flush=True)
 
             if not is_last_rank:
                 if not req_data.new_token_ids:
@@ -1638,6 +1709,13 @@ class GPUModelRunner(
         # tokens gives us the first -1 position (i.e., number of accepted).
         num_reqs = output_token_ids.size(0)
         self.num_accepted_tokens.gpu[:num_reqs] = (output_token_ids != -1).sum(dim=1)
+        # Bonus-always-valid invariant: a discarded row (all -1) means "no
+        # acceptance applies this step"; represent it as 1 (the bonus) so the
+        # conv1d rollback offset (= num_accepted - 1) is never -1, which
+        # would read out of the conv-state allocation (Xid 31).
+        self.num_accepted_tokens.gpu[:num_reqs] = self.num_accepted_tokens.gpu[
+            :num_reqs
+        ].clamp(min=1)
 
         if self.cache_config.mamba_cache_mode == "align":
             # Fused GPU postprocess: state copies + per-request accepted-token
@@ -1929,8 +2007,15 @@ class GPUModelRunner(
             # and no reordering happened.
             # The indices are both the same permutation of 0..N-1 so
             # we can copy directly using a single slice.
+            # Use the per-request LATEST valid sampled token, not column 0: with
+            # spec decode prev_sampled_token_ids is [accepted drafts..., bonus],
+            # so after a multi-token accept column 0 is the FIRST accepted draft,
+            # not the latest committed token the next step must continue from.
+            # (Mirrors C4's select_latest on the cpu/non-common path.)
             self.input_ids.gpu[:num_common_tokens].copy_(
-                self.input_batch.prev_sampled_token_ids[:num_common_tokens, 0],
+                select_latest_sampled_token_per_req(
+                    self.input_batch.prev_sampled_token_ids[:num_common_tokens]
+                ),
                 non_blocking=True,
             )
             return
@@ -1941,12 +2026,16 @@ class GPUModelRunner(
         prev_common_req_indices_tensor = torch.tensor(
             prev_indices, dtype=torch.int64, pin_memory=PIN_MEMORY
         ).to(self.device, non_blocking=True)
+        # Per-request LATEST valid sampled token (not column 0) — see the
+        # common-case branch above; column 0 is the first accepted draft after a
+        # multi-token accept, not the latest committed token.
+        latest_sampled_per_req = select_latest_sampled_token_per_req(
+            self.input_batch.prev_sampled_token_ids
+        )
         self.input_ids.gpu.scatter_(
             dim=0,
             index=sampled_tokens_index_tensor,
-            src=self.input_batch.prev_sampled_token_ids[
-                prev_common_req_indices_tensor, 0
-            ],
+            src=latest_sampled_per_req[prev_common_req_indices_tensor],
         )
 
         # Scatter the draft tokens after the sampled tokens are scattered.
@@ -1965,11 +2054,28 @@ class GPUModelRunner(
         # so convert draft_token_ids to torch.int32 here.
         draft_token_ids = self._draft_token_ids.to(dtype=torch.int32)
 
-        self.input_ids.gpu.scatter_(
-            dim=0,
-            index=draft_tokens_index_tensor,
-            src=draft_token_ids.flatten()[prev_draft_token_indices_tensor],
-        )
+        import os
+        if os.environ.get("PPDBG"):
+            neg = (draft_token_ids < 0).sum().item()
+            neg_src = (draft_token_ids.flatten()[prev_draft_token_indices_tensor] < 0).sum().item()
+            if neg or neg_src:
+                print(f"[PPDBG] NEG_DRAFT neg={neg} neg_src={neg_src} shape={tuple(draft_token_ids.shape)} "
+                      f"first={draft_token_ids.flatten()[:20].tolist()}", flush=True)
+            self.input_ids.gpu.scatter_(
+                dim=0,
+                index=draft_tokens_index_tensor,
+                src=draft_token_ids.flatten()[prev_draft_token_indices_tensor],
+            )
+            chk = self.input_ids.gpu[:64]
+            neg_in = (chk < 0).sum().item()
+            if neg_in:
+                print(f"[PPDBG] NEG_INPUT after scatter: {neg_in} in first64 ids={chk.tolist()}", flush=True)
+        else:
+            self.input_ids.gpu.scatter_(
+                dim=0,
+                index=draft_tokens_index_tensor,
+                src=draft_token_ids.flatten()[prev_draft_token_indices_tensor],
+            )
 
     def _get_encoder_seq_lens(
         self,
@@ -3769,6 +3875,13 @@ class GPUModelRunner(
     ) -> SamplerOutput:
         # Sample the next token and get logprobs if needed.
         sampling_metadata = self.input_batch.sampling_metadata
+        # Async output copies (enqueue_output on the async thread) read the
+        # sampler's device tensors; the caching allocator can hand the same
+        # address to this step's sampler while the previous D2H is still in
+        # flight, which corrupts the copy or faults. Wait for the previous
+        # step's copy event before writing the sampler buffers again.
+        if self._prev_async_copy_event is not None:
+            self._prev_async_copy_event.synchronize()
         # Update output token ids with tokens sampled in last step
         # if async scheduling and required by current sampling params.
         self.input_batch.update_async_output_token_ids()
@@ -3785,6 +3898,17 @@ class GPUModelRunner(
             self.input_batch.update_async_spec_token_ids(draft_token_ids_cpu)
 
         draft_probs = self._get_spec_decode_draft_probs(spec_decode_metadata)
+
+        import os as _os
+        if _os.environ.get("PPDBG") and logits is not None and logits.numel():
+            lm = logits.max(dim=1).values
+            ninf = torch.isinf(lm) & (lm < 0)
+            n = int(ninf.sum())
+            if n:
+                idx = ninf.nonzero().squeeze(1)
+                print(f"[PPDBG] LOGITS_NEGINF rows={n}/{lm.numel()} "
+                      f"first={idx[:20].tolist()} shape={tuple(logits.shape)}", flush=True)
+
         sampler_output = self.rejection_sampler(
             spec_decode_metadata,
             draft_probs,
@@ -3910,6 +4034,25 @@ class GPUModelRunner(
 
             if not sampled_ids:
                 continue
+
+            # Token-0 ('!') storm defense (bookkeeping chain): never commit a
+            # garbage-logits 0 into the token history / output stream. Replace
+            # with the request's last real token so the all-'!' loop cannot
+            # self-sustain; the first bad step is absorbed instead of amplified.
+            if 0 in sampled_ids:
+                last_real = -1
+                for t in reversed(req_state.output_token_ids):
+                    if t != -1 and t != 0:
+                        last_real = t
+                        break
+                if last_real < 0:
+                    hist = self.input_batch.token_ids_cpu[req_idx].tolist()
+                    for t in reversed(hist[:start_idx]):
+                        if t > 0:
+                            last_real = t
+                            break
+                if last_real >= 0:
+                    sampled_ids = [last_real if v == 0 else v for v in sampled_ids]
 
             start_idx = self.input_batch.num_tokens_no_spec[req_idx]
             end_idx = start_idx + num_sampled_ids
@@ -4329,6 +4472,13 @@ class GPUModelRunner(
             record_function_or_nullcontext("gpu_model_runner: preprocess"),
             self.synchronize_input_prep(),
         ):
+            # Complete the async PP sampled-token/draft broadcast reception from
+            # the previous sample_tokens and apply the C4 backfill, before
+            # _update_states reads _pp_prev_valid_sampled_count. Waiting here
+            # (instead of in sample_tokens) keeps the broadcast non-blocking so
+            # PP step phases cannot deadlock under async scheduling.
+            if self.use_async_scheduling and not get_pp_group().is_last_rank:
+                self._pp_finish_receive_and_backfill()
             # Update persistent batch states.
             deferred_state_corrections_fn = self._update_states(scheduler_output)
 
@@ -4717,8 +4867,13 @@ class GPUModelRunner(
             # PP outputs have been broadcasted to all ranks at logits computation.
             # Therefore, here is no need to send sampled token ids again in this case.
             if not self.broadcast_pp_output and pp.world_size > 1 and pp.is_last_rank:
+                # Broadcast a private clone: the async NCCL broadcast overlaps
+                # with this rank's next-step sampler/draft passes, which reuse
+                # and rewrite sampler_output.sampled_token_ids. Without the
+                # clone the receiver can observe a torn/overwritten grid
+                # (garbage or all -1), corrupting downstream kernels (Xid 31).
                 self._pp_broadcast_prev_sampled_token_ids(
-                    sampler_output.sampled_token_ids
+                    sampler_output.sampled_token_ids.clone()
                 )
 
         self._draft_token_ids = None
@@ -4871,6 +5026,20 @@ class GPUModelRunner(
                 )
                 self.drafter.dummy_run(num_tokens=1)
 
+        # PP + async spec: broadcast the freshly-proposed drafts to the non-last
+        # ranks (paired 1:1 with the sampled-token broadcast above) so they can
+        # scatter the real draft tokens into the spec positions next step instead
+        # of the -1 placeholder. Without this the non-last verification-forward
+        # embeds garbage at the spec positions -> non-greedy output.
+        if (
+            self.use_async_scheduling
+            and self.num_spec_tokens
+            and not self.broadcast_pp_output
+        ):
+            pp = get_pp_group()
+            if pp.world_size > 1 and pp.is_last_rank:
+                self._pp_broadcast_draft_token_ids()
+
         # Finalize KV connector (wait_for_save + clear metadata) after
         # draft model runs. Deferred from target model forward to allow
         # draft model to also save its KV cache.
@@ -4932,7 +5101,12 @@ class GPUModelRunner(
 
             async_output = AsyncGPUModelRunnerOutput(
                 model_runner_output=output,
-                sampled_token_ids=sampler_output.sampled_token_ids,
+                # Clone the device-side sampler outputs so the async D2H copy
+                # always reads private storage: sampler buffers are reused by the
+                # next step (caching allocator), and a cross-thread copy racing
+                # that reuse faults or reads torn data. (logprobs_tensors keeps
+                # its own buffer management and is left as-is.)
+                sampled_token_ids=sampler_output.sampled_token_ids.clone(),
                 logprobs_tensors=sampler_output.logprobs_tensors,
                 invalid_req_indices=invalid_req_indices,
                 async_output_copy_stream=self._get_or_create_async_output_copy_stream(),
@@ -4941,6 +5115,9 @@ class GPUModelRunner(
                 check_ep_fault=self.check_ep_fault,
                 num_nans=num_nans_device,
             )
+            # Keep the copy-completion event so the next step's sampler waits
+            # for the D2H to finish before the allocator reuses those buffers.
+            self._prev_async_copy_event = async_output.async_copy_ready_event
         with record_function_or_nullcontext(
             "gpu_model_runner: set_async_sampled_token_ids"
         ):
@@ -4956,50 +5133,316 @@ class GPUModelRunner(
     def _pp_broadcast_prev_sampled_token_ids(
         self, sampled_token_ids: torch.Tensor
     ) -> None:
-        """Broadcast sampled token ids (GPU) from last PP stage"""
+        """Broadcast sampled token ids (GPU) from last PP stage.
+
+        Without spec the grid is ``[num_reqs, 1]``; with MTP/EAGLE spec it is
+        ``[num_reqs, num_spec + 1]`` (accepted drafts + bonus, ``-1``-padded). The
+        transport is width-agnostic; the receiver allocates the matching width.
+        """
+        import os
+        if os.environ.get("PPDBG"):
+            print(f"[PPDBG] SEND shape={tuple(sampled_token_ids.shape)} "
+                  f"reqs={self.input_batch.req_ids} chunked={self._is_all_reqs_chunked_prefill()} "
+                  f"step={self.input_batch.num_tokens_no_spec.tolist() if hasattr(self.input_batch,'num_tokens_no_spec') else '?'} "
+                  f"data={sampled_token_ids[:2].tolist() if sampled_token_ids.numel() else '[]'}", flush=True)
         pp = get_pp_group()
         assert pp.is_last_rank
-        # `prev_sampled_token_ids` is expected to have shape [num_reqs, 1].
-        assert sampled_token_ids.dim() == 2 and sampled_token_ids.shape[-1] == 1, (
-            "PP+async expects sampled_token_ids to have shape [num_reqs, 1]"
-        )
         # Skip for chunked prefill: sampled tokens are dummy
         # and will be discarded, no need to broadcast.
         if not self._is_all_reqs_chunked_prefill():
-            torch.distributed.broadcast(
-                sampled_token_ids, src=pp.rank, group=pp.device_group
+            # The sampler emits a width-1 grid on steps with no scheduled spec
+            # tokens (e.g. the first decode after prefill), but the receiver always
+            # reads num_spec+1 columns. Pad the missing columns with -1 so the
+            # broadcast shapes match on both ranks; otherwise the receiver reads
+            # uninitialized buffer garbage in the extra column and commits it as a
+            # real token, corrupting the sequence (breaks greedy-equivalence).
+            width = self.num_spec_tokens + 1
+            if sampled_token_ids.shape[-1] < width:
+                pad = sampled_token_ids.new_full(
+                    (sampled_token_ids.shape[0], width - sampled_token_ids.shape[-1]),
+                    -1,
+                )
+                sampled_token_ids = torch.cat([sampled_token_ids, pad], dim=-1)
+            # Token-0 ('!') storm defense: a garbage logits row makes the sampler
+            # emit 0 at the bonus column; the 0 then enters the next step's input
+            # grid and reproduces, pinning the request in an all-'!' loop forever
+            # (observed as deterministic-ish corruption after batch changes under
+            # NVFP4 KV). Replace a bonus-column 0 with the row's last valid
+            # non-0 token so the loop cannot self-sustain; the rare legitimate 0
+            # in real text is negligible vs. this failure mode.
+            if width > 1 and sampled_token_ids.numel():
+                last_col = sampled_token_ids[:, -1]
+                if bool((last_col == 0).any()):
+                    bad = (last_col == 0)
+                    for r in bad.nonzero().squeeze(1).tolist():
+                        row = sampled_token_ids[r]
+                        valid = row[row > 0]
+                        if valid.numel():
+                            sampled_token_ids[r, -1] = valid[-1]
+                        else:
+                            sampled_token_ids[r, -1] = -1
+            broadcast_sampled_token_ids(sampled_token_ids, pp.device_group, pp.rank)
+            # Absolute per-request cursor (num_tokens_no_spec) broadcast, so the
+            # non-last rank can force-align its local cursors to the sampler
+            # rank every step. Any skipped C4 backfill (prefill->decode edges,
+            # batch reshuffles) otherwise leaves a permanent offset that
+            # corrupts that request's verification inputs.
+            cursors = (
+                torch.from_numpy(
+                    self.input_batch.num_tokens_no_spec[: sampled_token_ids.shape[0]]
+                )
+                .to(device=self.device, dtype=torch.int32)
+                .unsqueeze(1)
+                .contiguous()
             )
+            broadcast_sampled_token_ids(cursors, pp.device_group, pp.rank)
+
+    def _pp_broadcast_draft_token_ids(self) -> None:
+        """Broadcast the proposed draft token ids from the last PP stage.
+
+        The drafter runs only on the last rank (`is_last_rank` gate), so
+        ``_draft_token_ids`` is ``None`` on the non-last ranks. Without this, the
+        non-last ranks embed the ``-1`` scheduler placeholder at the spec
+        positions in ``_prepare_input_ids`` (the GPU draft scatter is skipped when
+        ``_draft_token_ids is None``) -> wrong verification-forward hidden states
+        -> non-greedy output. Broadcasting the drafts (paired 1:1 with the sampled
+        broadcast each step) lets every rank scatter the REAL draft tokens, so the
+        verification matches the single-GPU path. Width is fixed at ``num_spec``
+        and ``-1``-padded; a None/absent draft broadcasts an all-``-1`` grid so the
+        non-last receive never blocks.
+        """
+        pp = get_pp_group()
+        assert pp.is_last_rank
+        if self._is_all_reqs_chunked_prefill():
+            return
+        num_reqs = self.input_batch.num_reqs
+        width = self.num_spec_tokens
+        dt = self._draft_token_ids
+        if torch.is_tensor(dt):
+            dt = dt.to(dtype=torch.int32)
+            if dt.shape[-1] < width:
+                pad = dt.new_full((dt.shape[0], width - dt.shape[-1]), -1)
+                dt = torch.cat([dt, pad], dim=-1)
+            dt = dt[:num_reqs, :width].contiguous()
+        else:
+            dt = torch.full(
+                (num_reqs, width), -1, dtype=torch.int32, device=self.device
+            )
+        broadcast_sampled_token_ids(dt, pp.device_group, pp.rank)
 
     def _pp_receive_prev_sampled_token_ids_to_input_batch(self) -> None:
-        """Receive sampled token ids broadcast from last PP stage"""
+        """Launch non-blocking sampled-token/draft broadcasts from the last rank.
+
+        Data becomes ready later; C4 backfill happens in
+        ``_pp_finish_receive_and_backfill`` (called before ``_update_states`` in
+        the next execute_model). Keeping the broadcast async avoids the PP
+        step-phase deadlock: a synchronous receive here can wait for a broadcast
+        the other rank has not reached yet when async scheduling overlaps
+        sample_tokens(N) with execute_model(N+1).
+        """
+        import os
+        if os.environ.get("PPDBG"):
+            print(f"[PPDBG] RECV(launch) reqs={self.input_batch.req_ids} "
+                  f"chunked={self._is_all_reqs_chunked_prefill()}", flush=True)
         pp = get_pp_group()
         assert not pp.is_last_rank
         num_reqs = self.input_batch.num_reqs
-        # `prev_sampled_token_ids` is expected to have shape [num_reqs, 1].
-        recv = torch.empty((num_reqs, 1), dtype=torch.int32, device=self.device)
-        # skip for chunked prefill.
+        width = self.num_spec_tokens + 1
+        recv = torch.empty((num_reqs, width), dtype=torch.int32, device=self.device)
+        self.input_batch.prev_sampled_token_ids = recv
+        self._pp_recv_work = None
+        self._pp_draft_recv_work = None
+        self._pp_cursor_recv_work = None
+        self._pp_last_cursor: torch.Tensor | None = None
         if not self._is_all_reqs_chunked_prefill():
+            # Broadcast order must match the last rank: sampled grid, cursor, draft.
             self._pp_recv_work = torch.distributed.broadcast(
                 recv, src=pp.last_rank, group=pp.device_group, async_op=True
             )
-        self.input_batch.prev_sampled_token_ids = recv
+            cursor_buf = torch.empty(
+                (num_reqs, 1), dtype=torch.int32, device=self.device
+            )
+            self._pp_cursor_recv_work = torch.distributed.broadcast(
+                cursor_buf,
+                src=pp.last_rank,
+                group=pp.device_group,
+                async_op=True,
+            )
+            self._pp_last_cursor = cursor_buf
+            if self.num_spec_tokens:
+                draft_buf = torch.empty(
+                    (num_reqs, self.num_spec_tokens),
+                    dtype=torch.int32,
+                    device=self.device,
+                )
+                self._pp_draft_recv_work = torch.distributed.broadcast(
+                    draft_buf,
+                    src=pp.last_rank,
+                    group=pp.device_group,
+                    async_op=True,
+                )
+                self._draft_token_ids = draft_buf
+        else:
+            # All-chunked-prefill: nothing is broadcast; requests take their next
+            # input from the prompt. Keep the placeholder behaviour immediately.
+            discard_req_indices = np.nonzero(
+                self.discard_request_mask.np[:num_reqs]
+            )[0]
+            discard_req_indices_set = set(discard_req_indices)
+            prev_req_id_to_index: dict[str, int] = {}
+            self._pp_prev_valid_sampled_count = {}
+            for i, req_id in enumerate(self.input_batch.req_ids):
+                if i in discard_req_indices_set:
+                    continue
+                prev_req_id_to_index[req_id] = i
+                req_state = self.requests.get(req_id)
+                if req_state is not None:
+                    req_state.output_token_ids.append(-1)
+                pos = self.input_batch.num_tokens_no_spec[i]
+                self.input_batch.is_token_ids[i, pos] = True
+                self.input_batch.num_tokens_no_spec[i] = pos + 1
+            self.input_batch.prev_req_id_to_index = prev_req_id_to_index
+
+    def _pp_finish_receive_and_backfill(self) -> None:
+        """Wait for the async PP broadcasts and apply the C4 backfill.
+
+        Runs on the non-last PP rank at the top of execute_model (before
+        ``_update_states``), when the sampled/draft grids from the previous
+        sample_tokens are guaranteed to have arrived (the last rank's broadcast
+        happens in *its* sample_tokens, which precedes its own execute_model).
+        """
+        import os
+        pp = get_pp_group()
+        assert not pp.is_last_rank
+        if self._pp_recv_work is None:
+            # No broadcast was launched for this round (e.g. an all-prefill/
+            # chunked-prefill round). Invalidate this round's mapping state so
+            # a stale grid/row map from an earlier round can never be consumed
+            # as if it belonged to this one. Drop any pending cursor/draft
+            # receives too -- they belong to a round that never advertised a
+            # sampled grid, so waiting on them now would couple this round to
+            # an older, unrelated launch.
+            self.input_batch.prev_req_id_to_index = {}
+            self._pp_prev_valid_sampled_count = {}
+            self.prev_positions.np[: self.input_batch.num_reqs].fill(-1)
+            self._pp_cursor_recv_work = None
+            self._pp_last_cursor = None
+            self._pp_draft_recv_work = None
+            return
+        self._pp_recv_work.wait()
+        self._pp_recv_work = None
+        recv = self.input_batch.prev_sampled_token_ids
+        num_reqs = self.input_batch.num_reqs
+        # C4 (holistic): persist the REAL sampled tokens per request (never -1)
+        # into the local buffers. A single-position write is insufficient: when a
+        # draft is accepted, num_computed_tokens advances by v = (accepted drafts
+        # + bonus) while only one slot was written, leaving the in-between
+        # (accepted-draft) positions as -1. The next step reads
+        # token_ids_cpu[num_computed_tokens] (which includes the spec tokens) and
+        # embeds a -1 -> indexSelectSmallIndex.
+        gathered = gather_valid_sampled_tokens_per_req(recv)
+        # Wait for the cursor broadcast launched alongside the sampled grid.
+        last_cursor = None
+        if self._pp_cursor_recv_work is not None:
+            self._pp_cursor_recv_work.wait()
+            self._pp_cursor_recv_work = None
+            last_cursor = self._pp_last_cursor
+            self._pp_last_cursor = None
+            if last_cursor is not None:
+                last_cursor = last_cursor.squeeze(1).tolist()
+        # Wait for the draft grid broadcast that was launched alongside.
+        if self._pp_draft_recv_work is not None:
+            self._pp_draft_recv_work.wait()
+            self._pp_draft_recv_work = None
+        # Hybrid (mamba/GDN linear-attention) models: the GDN forward rolls back
+        # its conv1d/SSM recurrent state using attn_metadata.num_accepted_tokens,
+        # which _update_states_after_model_execute sets ONLY on the sampler/last
+        # rank. Source the same per-request accepted count from the broadcast so
+        # the non-last rank's GDN layers roll back state identically.
+        if (
+            self.model_config.is_hybrid
+            and self.num_accepted_tokens_event is not None
+        ):
+            num_accepted = (recv != -1).sum(dim=1)
+            # Bonus-always-valid invariant (mirrors the sampler-rank fix):
+            # a discarded/stale row (all -1) means "no acceptance applies";
+            # represent it as 1 (the bonus) so the conv1d rollback offset
+            # (= num_accepted - 1) is never -1 (Xid 31 out-of-allocation read).
+            num_accepted = num_accepted.clamp(min=1)
+            # The GDN metadata builder reads self.num_accepted_tokens.gpu
+            # (line ~2686), which the sampler rank writes here-equivalently at
+            # sample time. On the non-last rank nothing else ever updates the
+            # GPU buffer, so write it explicitly; otherwise this rank's conv1d
+            # rollback consumes a stale/initial accepted count.
+            self.num_accepted_tokens.gpu[:num_reqs].copy_(num_accepted)
+            self.input_batch.num_accepted_tokens_cpu_tensor[:num_reqs].copy_(
+                num_accepted, non_blocking=True
+            )
+            self.num_accepted_tokens_event.record()
 
         # construct `prev_req_id_to_index` here so `_prepare_input_ids`
         # can map req_id -> previous batch row
         discard_req_indices = np.nonzero(self.discard_request_mask.np[:num_reqs])[0]
         discard_req_indices_set = set(discard_req_indices)
         prev_req_id_to_index: dict[str, int] = {}
+        self._pp_prev_valid_sampled_count = {}
         for i, req_id in enumerate(self.input_batch.req_ids):
             if i in discard_req_indices_set:
                 continue
             prev_req_id_to_index[req_id] = i
-            # PP+async scheduling: advance per-request local cached output length by
-            # appending a placeholder (-1) token id.
-            if (req_state := self.requests.get(req_id)) is not None:
-                req_state.output_token_ids.append(-1)
             pos = self.input_batch.num_tokens_no_spec[i]
-            self.input_batch.is_token_ids[i, pos] = True
-            self.input_batch.num_tokens_no_spec[i] = pos + 1
+            req_state = self.requests.get(req_id)
+            # Holistic C4: persist ALL v real tokens recv[i, 0:v] (accepted drafts
+            # + bonus, in sequence order) into the v positions [pos : pos + v] and
+            # advance the token_ids_cpu cursor by v, so the next step's read at
+            # num_computed_tokens never lands on an un-backfilled -1.
+            # output_token_ids is deliberately NOT grown by v here: it drives
+            # num_tokens, which the discard mask compares against the
+            # (one-step-lagging) num_computed_tokens + num_scheduled; keep the
+            # original single-token append so num_tokens tracks nct.
+            values = gathered[i]
+            v = len(values)
+            end = pos + v
+            self.input_batch.token_ids_cpu[i, pos:end] = values
+            self.input_batch.is_token_ids[i, pos:end] = True
+            self.input_batch.num_tokens_no_spec[i] = end
+            if req_state is not None:
+                # (B) count reconciliation — the non-last-rank analogue of
+                # correct_spec_decode_token_counts (which runs only on the sampler
+                # rank). The optimistic-extend appended prev_num_draft_len -1
+                # placeholders for THIS step's drafts; replace them with the v
+                # real committed tokens.
+                optimistic = req_state.prev_num_draft_len
+                if optimistic:
+                    del req_state.output_token_ids[-optimistic:]
+                req_state.output_token_ids.extend(values)
+            # Stash this request's broadcast valid count so _update_states can
+            # apply the num_computed_tokens drift correction AFTER the
+            # scheduler's optimistic value is set. v = accepted drafts + bonus.
+            self._pp_prev_valid_sampled_count[req_id] = v
+            # Absolute cursor alignment: if this rank's local no-spec cursor has
+            # drifted from the sampler rank's (e.g. a C4 backfill was skipped at
+            # a prefill->decode edge), force-align it so positions/KV layout stay
+            # identical on both ranks. Backfill the missing positions with the
+            # broadcast valid tokens (repeating the last one if the gap is
+            # larger) so token_ids_cpu reads never land on stale entries. The
+            # next-step verification forward reads input ids from the broadcast
+            # grid, so this only affects bookkeeping, not the model input.
+            if last_cursor is not None:
+                last = int(last_cursor[i])
+                if last > end:
+                    gap = last - end
+                    # Never backfill with token 0 ('!' storm poison): repeat the
+                    # last real token when available, else leave -1 (a later
+                    # alignment will overwrite it).
+                    fill = (values[-1:] * gap) if values else [-1] * gap
+                    self.input_batch.token_ids_cpu[i, end:last] = fill
+                    self.input_batch.is_token_ids[i, end:last] = True
+                    self.input_batch.num_tokens_no_spec[i] = last
+                    import os as _os
+                    if _os.environ.get("PPDBG"):
+                        print(f"[PPDBG] CURSOR_ALIGN req={req_id} from={end} to={last} "
+                              f"gap={gap}", flush=True)
         self.input_batch.prev_req_id_to_index = prev_req_id_to_index
 
     def take_draft_token_ids(self) -> DraftTokenIds | None:
@@ -6281,10 +6724,16 @@ class GPUModelRunner(
             else:
                 hidden_states = outputs
 
-            if self.speculative_config and (
-                self.speculative_config.use_eagle()
-                or self.speculative_config.uses_draft_model()
-                or self.speculative_config.uses_extract_hidden_states()
+            if (
+                self.speculative_config
+                # The drafter only exists on the last PP rank (see __init__);
+                # under PP>1 the non-last ranks have no draft to dummy-run.
+                and get_pp_group().is_last_rank
+                and (
+                    self.speculative_config.use_eagle()
+                    or self.speculative_config.uses_draft_model()
+                    or self.speculative_config.uses_extract_hidden_states()
+                )
             ):
                 assert isinstance(
                     self.drafter,
@@ -7288,9 +7737,14 @@ class GPUModelRunner(
         self.calculate_reorder_batch_threshold()
 
         # Initialize drafter attention backend
-        if self.speculative_config and (
-            self.speculative_config.use_eagle()
-            or self.speculative_config.uses_draft_model()
+        # The drafter only exists on the last PP rank (see __init__).
+        if (
+            self.speculative_config
+            and get_pp_group().is_last_rank
+            and (
+                self.speculative_config.use_eagle()
+                or self.speculative_config.uses_draft_model()
+            )
         ):
             assert isinstance(
                 self.drafter,
@@ -7342,10 +7796,15 @@ class GPUModelRunner(
         )
 
         # Initialize drafter's cudagraph dispatcher if using spec decode.
-        if self.speculative_config and (
-            self.speculative_config.use_eagle()
-            or self.speculative_config.uses_draft_model()
-            or self.speculative_config.uses_extract_hidden_states()
+        # The drafter only exists on the last PP rank (see __init__).
+        if (
+            self.speculative_config
+            and get_pp_group().is_last_rank
+            and (
+                self.speculative_config.use_eagle()
+                or self.speculative_config.uses_draft_model()
+                or self.speculative_config.uses_extract_hidden_states()
+            )
         ):
             assert isinstance(
                 self.drafter,
@@ -7779,6 +8238,16 @@ class GPUModelRunner(
         self._mamba_bufs = None
         self.may_add_encoder_only_layers_to_kv_cache_config()
         self.maybe_add_kv_sharing_layers_to_kv_cache_groups(kv_cache_config)
+        import os as _os
+        if _os.environ.get("PPDBG") and get_pp_group().is_last_rank:
+            for gid, g in enumerate(kv_cache_config.kv_cache_groups):
+                print(f"[PPDBG] KV_GROUP_BEFORE {gid}: {list(g.layer_names)[:12]} "
+                      f"spec={type(g.kv_cache_spec).__name__}", flush=True)
+        # NOTE: the MTP/EAGLE KV-group split was REMOVED — it broke the block
+        # table contract: may_reinitialize_input_batch builds one block table
+        # per kv cache group, so the extra eagle group made the runner expect 3
+        # groups of block ids while the scheduler (which never sees the split)
+        # only sends 2 -> IndexError in add_row/append_row on the first batch.
         self.initialize_attn_backend(kv_cache_config, is_profiling=is_profiling)
         initialize_mamba_ssu_backend(
             self.vllm_config.mamba_config, self.kv_cache_config
@@ -7804,6 +8273,7 @@ class GPUModelRunner(
 
         if (
             self.speculative_config
+            and get_pp_group().is_last_rank
             and self.speculative_config.uses_extract_hidden_states()
         ):
             assert isinstance(self.drafter, ExtractHiddenStatesProposer)

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -510,6 +510,15 @@ class Worker(WorkerBase):
                 getattr(self.parallel_config, "_api_process_count", 1),
             )
 
+        # Warmup: run a forward pass before the profiling window so that
+        # JIT-compiled kernel code (e.g. FlashInfer) is produced outside the
+        # measurement. On first launch those kernels don't yet exist; their
+        # code lives in GPU memory permanently (CUDA driver level, not freed
+        # by torch.empty_cache). If compilation happens inside the
+        # memory_profiling context it inflates non_torch_increase and shrinks
+        # the KV-cache budget.
+        self.model_runner.profile_run()
+
         # Execute a forward pass with dummy inputs to profile the memory usage
         # of the model.
         with memory_profiling(

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -495,6 +495,15 @@ class Worker(WorkerBase):
                 getattr(self.parallel_config, "_api_process_count", 1),
             )
 
+        # Warmup: run a forward pass before the profiling window so that
+        # JIT-compiled kernel code (e.g. FlashInfer) is produced outside the
+        # measurement. On first launch those kernels don't yet exist; their
+        # code lives in GPU memory permanently (CUDA driver level, not freed
+        # by torch.empty_cache). If compilation happens inside the
+        # memory_profiling context it inflates non_torch_increase and shrinks
+        # the KV-cache budget.
+        self.model_runner.profile_run()
+
         # Execute a forward pass with dummy inputs to profile the memory usage
         # of the model.
         with memory_profiling(

--- a/vllm/v1/worker/mamba_utils.py
+++ b/vllm/v1/worker/mamba_utils.py
@@ -175,7 +175,20 @@ def _copy_mamba_state_block(
     # Widen block ids to int64 before they reach `block_id * state_block_stride`
     # below: state_block_stride can exceed 2**31 bytes for large mamba caches,
     # and Triton would otherwise do the multiply in int32 and wrap.
-    dest_block_id = tl.load(block_table_base + dst_col).to(tl.int64)
+    # FIX I: the block-table columns below are derived from per-request
+    # accepted-token counts. A wrong count walks the read past this request's
+    # row; the loaded int32 is then multiplied by state_block_stride and
+    # dereferenced, so an out-of-range column becomes a wild (and possibly
+    # misaligned) address rather than merely a wrong copy. Bound the columns to
+    # the row: an out-of-range column loads the ``other=-1`` sentinel, and the
+    # ``<= 0`` guards below reject both that sentinel and ``NULL_BLOCK_ID`` (0,
+    # the unallocated-slot marker), so neither reaches the address math.
+    dst_col_ok = (dst_col >= 0) & (dst_col < block_table_stride_req)
+    dest_block_id = tl.load(block_table_base + dst_col, mask=dst_col_ok, other=-1).to(
+        tl.int64
+    )
+    if dest_block_id <= 0:
+        return
     dst_addr = state_base_addr + dest_block_id * state_block_stride
 
     is_conv_state = conv_width > 0
@@ -186,7 +199,12 @@ def _copy_mamba_state_block(
         if tile_idx > 0:
             return
         # DS conv layout: state_len is the slide axis; copy per dim row.
-        src_block_id = tl.load(block_table_base + src_col).to(tl.int64)
+        src_col_ok = (src_col >= 0) & (src_col < block_table_stride_req)
+        src_block_id = tl.load(
+            block_table_base + src_col, mask=src_col_ok, other=-1
+        ).to(tl.int64)
+        if src_block_id <= 0:
+            return
         dim_rows = tl.load(state_dim_row_count_ptr + state_idx)
         row_stride = tl.load(state_dim_row_stride_ptr + state_idx)
         src_block_addr = state_base_addr + src_block_id * state_block_stride
@@ -237,7 +255,12 @@ def _copy_mamba_state_block(
         # SD conv: copy
         #   state[bt[src_col], token_bias:] ->
         #   state[bt[dst_col], :conv_width - token_bias]
-        src_block_id = tl.load(block_table_base + src_col).to(tl.int64)
+        src_col_ok = (src_col >= 0) & (src_col < block_table_stride_req)
+        src_block_id = tl.load(
+            block_table_base + src_col, mask=src_col_ok, other=-1
+        ).to(tl.int64)
+        if src_block_id <= 0:
+            return
         src_block_addr = state_base_addr + src_block_id * state_block_stride
         token_bytes = state_inner_size * state_elem_size
         num_dst_tokens = conv_width - token_bias
@@ -276,7 +299,13 @@ def _copy_mamba_state_block(
     # Temporal state: copy state[bt[src_col + token_bias]] -> state[bt[dst_col]]
     # Body u64 range is partitioned across TEMPORAL_TILES CTAs to keep the
     # SMs filled at small batch.
-    actual_src_block_id = tl.load(block_table_base + src_col + token_bias).to(tl.int64)
+    tmp_col = src_col + token_bias
+    tmp_col_ok = (tmp_col >= 0) & (tmp_col < block_table_stride_req)
+    actual_src_block_id = tl.load(
+        block_table_base + tmp_col, mask=tmp_col_ok, other=-1
+    ).to(tl.int64)
+    if actual_src_block_id <= 0:
+        return
     src_addr = state_base_addr + actual_src_block_id * state_block_stride
     # Use natural block data size (inner_size * elem_size), NOT
     # state_block_stride which is the page stride and can exceed the

--- a/vllm/v1/worker/pp_spec_broadcast.py
+++ b/vllm/v1/worker/pp_spec_broadcast.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""PP sampled-token broadcast helpers for speculative decoding.
+
+Under PP + async scheduling the last rank broadcasts its sampled token ids to the
+other ranks (which never run the sampler) so they can advance positions and build
+the next input batch. Without spec the broadcast carries shape ``[num_reqs, 1]``;
+with MTP/EAGLE spec the sampler emits ``[num_reqs, num_spec + 1]`` (accepted
+drafts + bonus, ``-1``-padded). These helpers keep the transport width-agnostic so
+both cases share one path, and expose the per-request valid count the receiver
+uses to advance each request by the right number of tokens (not always 1).
+
+Kept in a CUDA-free module so the shape/transport logic is unit-testable over a
+plain gloo CPU group.
+"""
+
+import torch
+import torch.distributed as dist
+
+
+def count_valid_sampled_tokens_per_req(sampled_token_ids: torch.Tensor) -> torch.Tensor:
+    """Per-request count of valid sampled tokens in a ``[num_reqs, width]`` grid.
+
+    Valid tokens are the non-``-1`` entries (rejected/padded positions are ``-1``);
+    this mirrors the accepted-count idiom used elsewhere in the runner
+    (``(sampled_token_ids != -1).sum(dim=1)``). For the non-spec width-1 case every
+    row holds one real token, so the count is 1 per request.
+    """
+    return (sampled_token_ids != -1).sum(dim=1)
+
+
+def sanitize_token_zero_col(
+    sampled_token_ids: torch.Tensor, width: int
+) -> None:
+    """Replace a bonus-column token 0 with the row's last valid non-0 token.
+
+    Token-0 ('!') storms: a corrupted/garbage logits row makes the sampler
+    emit 0 at the bonus column; the 0 then enters the next step's input grid
+    and reproduces, pinning the request in an all-'!' loop. Replacing 0 with
+    the row's last positive token (or -1 when none) breaks the loop without
+    touching legitimate drafts. Only the last column is a committed token;
+    draft columns of 0 are rejected by the verification anyway.
+    """
+    if width <= 1 or sampled_token_ids.numel() == 0:
+        return
+    row_last_pos = torch.where(
+        sampled_token_ids > 0,
+        torch.arange(width, device=sampled_token_ids.device).expand_as(sampled_token_ids),
+        sampled_token_ids.new_full((), -1),
+    ).max(dim=1).values
+    fallback = sampled_token_ids.gather(
+        1, row_last_pos.clamp(min=0).unsqueeze(1)
+    ).squeeze(1)
+    fallback = torch.where(row_last_pos >= 0, fallback, fallback.new_full((), -1))
+    replace = sampled_token_ids[:, -1] == 0
+    sampled_token_ids[replace, -1] = fallback[replace]
+
+
+def select_latest_sampled_token_per_req(
+    sampled_token_ids: torch.Tensor,
+) -> torch.Tensor:
+    """Per-request latest *valid* sampled token from a ``[num_reqs, width]`` grid.
+
+    Rejected/padded positions are ``-1``; a request that advanced by ``v`` valid
+    tokens has its latest token in the last valid column ``recv[i, v - 1]`` (reject
+    ``v=1`` -> col 0; accept + bonus ``v=2`` -> col 1). This is the real value the
+    non-last rank must persist as its next input instead of a ``-1`` placeholder
+    (the C4 value-back-write that fixes the ``indexSelectSmallIndex`` break: every
+    confirmed request has ``v >= 1`` so the result is never ``-1``). Pure-GPU ops
+    only: this runs inside CUDA-graph capture, where CPU syncs deadlock.
+    """
+    counts = count_valid_sampled_tokens_per_req(sampled_token_ids)
+    last_idx = (counts - 1).clamp(min=0)
+    return sampled_token_ids.gather(1, last_idx.unsqueeze(1)).squeeze(1)
+
+
+def gather_valid_sampled_tokens_per_req(
+    sampled_token_ids: torch.Tensor,
+) -> list[list[int]]:
+    """Per-request list of ALL valid sampled tokens ``recv[i, 0:v]``, in order.
+
+    ``select_latest_sampled_token_per_req`` keeps only the single latest token;
+    the holistic C4 back-write needs every confirmed token (accepted drafts +
+    bonus) so the non-last rank can fill the ``v`` ``token_ids_cpu`` positions the
+    next step will read (indexed by ``num_computed_tokens``, which includes the
+    spec tokens) — not just one slot. Valid entries are the leading non-``-1``
+    columns; a fully padded row yields ``[]`` (advance the cursor by 0).
+    """
+    counts = count_valid_sampled_tokens_per_req(sampled_token_ids).tolist()
+    rows = sampled_token_ids.tolist()
+    return [row[:v] for row, v in zip(rows, counts)]
+
+
+def num_computed_tokens_drift_correction(
+    prev_num_draft_len: int, valid_sampled_count: int
+) -> int:
+    """Amount to subtract from the optimistic ``num_computed_tokens`` on a non-last
+    rank to undo async spec-decode drift after a (partial) draft rejection.
+
+    Async spec decode advances ``num_computed_tokens`` optimistically by
+    ``1 (bonus) + prev_num_draft_len (drafts assumed accepted)``; the true advance is
+    the broadcast ``valid_sampled_count`` (accepted drafts + the bonus). The
+    difference is the number of optimistically-counted drafts that were actually
+    rejected. On the last rank this correction is applied by the GPU kernel
+    ``update_num_computed_tokens_for_batch_change`` from the sampler's valid count;
+    the non-last rank never runs the sampler, so it reconstructs the same correction
+    from the broadcast valid count instead — keeping rope/KV positions identical on
+    every rank (the invariant: advance ``num_computed_tokens`` by the valid count).
+    Non-negative (you cannot accept more drafts than were proposed); ``0`` when every
+    draft was accepted or none were proposed.
+    """
+    return (1 + prev_num_draft_len) - valid_sampled_count
+
+
+def broadcast_sampled_token_ids(
+    sampled_token_ids: torch.Tensor, group, src: int
+) -> None:
+    """Broadcast the (possibly multi-column) sampled token ids from ``src``."""
+    assert sampled_token_ids.dim() == 2, (
+        f"expected 2-D [num_reqs, width], got {tuple(sampled_token_ids.shape)}"
+    )
+    dist.broadcast(sampled_token_ids, src=src, group=group)
+
+
+def receive_sampled_token_ids(
+    num_reqs: int,
+    width: int,
+    group,
+    src: int,
+    device,
+    dtype: torch.dtype = torch.int32,
+) -> torch.Tensor:
+    """Receive a ``[num_reqs, width]`` sampled-token grid broadcast from ``src``."""
+    recv = torch.empty((num_reqs, width), dtype=dtype, device=device)
+    dist.broadcast(recv, src=src, group=group)
+    return recv


### PR DESCRIPTION
## Summary

- Fix V scale swizzle mismatch: the NVFP4 KV store kernel unconditionally swizzled V block scales for the SM100 trtllm-gen MHA kernel, but FlashInfer FA2 (used on SM120) reads scales linearly. Add runtime SM detection so SM≥120 writes V scales without swizzle, resolving garbled output on RTX 5090.
- Enable FlashInfer NVFP4 KV cache on SM120: `supports_kv_cache_dtype` accepts SM120, HND layout, BF16 query/output (SM120 FA2 native path does not use FP8 quantization or FP8 output buffers), and "auto" backend selection for prefill/decode wrappers.
- Route Gemma4 heterogeneous-head models (head_dim_qk=512, head_dim_vo=256) to FLASHINFER on CC 12.x with NVFP4 KV via `VLLM_NVFP4_KV_VOSPLIT` env var (default on).
- Add `FlashInferBackend.supports_mm_prefix()` gated on `VLLM_FLASHINFER_MM_PREFIX` (default on) so multimodal Gemma3/4 models are not rejected by backend validation.
- Bump flashinfer-python/cubin pin to 0.6.16.

## Context

SM120 (RTX 5090) does not have trtllm-gen cubins. The NVFP4 KV cache path previously only worked on SM100 (B200) via trtllm-gen. This PR enables the FlashInfer FA2 tensor-core native path for SM120, which dequantizes FP4 KV to BF16 internally during attention computation.

Tested on RTX 5090 with:
- Gemma-4-26B-A4B (heterogeneous heads: sliding head_dim=256, full head_dim=512)
- Qwen3.6-27B, Qwen3.6-35B-A3B (uniform heads)

All produce correct output with `--kv-cache-dtype nvfp4`.

## Test plan

- [ ] `vllm serve <gemma4-model> --kv-cache-dtype nvfp4` on RTX 5090 produces coherent output
- [ ] `vllm serve <qwen3-model> --kv-cache-dtype nvfp4` on RTX 5090 produces coherent output
- [ ] SM100 trtllm-gen path unchanged (V scales still swizzled for CC < 120)
- [ ] FP8 KV cache unaffected on both SM100 and SM120

## FlashInfer dependency

This PR is validated against the flashinfer branch:

- **Repo**: https://github.com/jethac/flashinfer (branch `sm120-nvfp4-release-v0.6.15`)
- **Version**: 0.6.18 (`nightly-v0.6.18-20260818-9-g4f01247d`), with the local NVFP4 SM120 fixes (FA2 paged-attention NVFP4 KV read path, XQA NVFP4 output width, split-KV NVFP4 re-enable, scheduler tail-chunk merge) on top
- Requires `FLASHINFER_DISABLE_VERSION_CHECK=1` when `flashinfer-python` and `flashinfer-cubin` versions differ
