### PR TITLE
[Model] Step3: guard tie_word_embeddings access for pipeline parallelism

### DIFF
--- a/vllm/model_executor/models/step3_text.py
+++ b/vllm/model_executor/models/step3_text.py
@@ -320,7 +320,7 @@ class Step3TextModel(nn.Module):
         self.config = config
 
         if get_pp_group().is_first_rank or (
-            config.tie_word_embeddings and get_pp_group().is_last_rank
+            getattr(config, "tie_word_embeddings", False) and get_pp_group().is_last_rank
         ):
             self.embed_tokens = VocabParallelEmbedding(
                 self.vocab_size,

--- a/vllm/model_executor/models/step3p5.py
+++ b/vllm/model_executor/models/step3p5.py
@@ -558,7 +558,7 @@ class Step3p5Model(nn.Module):
         self.moe_num_experts = config.moe_num_experts
 
         if get_pp_group().is_first_rank or (
-            config.tie_word_embeddings and get_pp_group().is_last_rank
+            getattr(config, "tie_word_embeddings", False) and get_pp_group().is_last_rank
         ):
             self.embed_tokens = VocabParallelEmbedding(
                 self.vocab_size,


### PR DESCRIPTION
## Summary

`Step3TextModel` / `Step3p5Model` read `config.tie_word_embeddings` **unconditionally** when deciding whether to build `embed_tokens` on non-first pipeline-parallel ranks (`step3_text.py`, `step3p5.py`). Step-3.7-Flash's text config (`Step3p7TextConfig`, loaded via `trust_remote_code`) does not define `tie_word_embeddings`, so any run with `pipeline_parallel_size > 1` crashes at worker init:

```
AttributeError: 'Step3p7TextConfig' object has no attribute 'tie_word_embeddings'
```

## Why it only surfaces under pipeline parallelism

The access is guarded by:

```python
if get_pp_group().is_first_rank or (
    config.tie_word_embeddings and get_pp_group().is_last_rank
):
```

With TP-only (a single PP rank), `is_first_rank` is `True`, so Python short-circuits the `or` and `config.tie_word_embeddings` is **never evaluated**. That's why aggregated / tensor-parallel serving works fine and the bug is invisible until `pipeline_parallel_size > 1` — only ranks `1..N-1` reach the right-hand side.

## Fix

Guard the two accesses with `getattr(config, "tie_word_embeddings", False)`. `False` is the correct default for this model: its checkpoint ships a **separate, untied `lm_head`**, which matches the existing behavior of the last-rank path that always builds a standalone `ParallelLMHead`.

## Testing

With this change, `Step-3.7-Flash-FP8` loads and serves with `--pipeline-parallel-size 4 --tensor-parallel-size 1` on 4×H100 (weights sharded across the 4 PP stages, ~42 GiB/rank) and produces correct output. TP paths are unchanged (short-circuit behavior preserved).

> Note: PP remains incompatible with MTP speculative decoding for this model because `Step3p5MTP` does not implement `SupportsPP` — that's a separate, larger change. This PR only unblocks **base-model** pipeline parallelism.

## Contribution disclosure

- Searched open PRs for `Step3 tie_word_embeddings pipeline parallelism`; no duplicate implementation was found.
- AI assistance was used to help diagnose and prepare this change. The submitter reviewed the changed lines and validated the model behavior described above.
