### PR TITLE
[Bugfix] Preserve truncated Kimi K3 reasoning

### DIFF
--- a/tests/reasoning/test_kimi_k3_reasoning_parser.py
+++ b/tests/reasoning/test_kimi_k3_reasoning_parser.py
@@ -80,6 +80,31 @@ def test_extract_reasoning_with_generation_prefix_consumed():
     assert content == "answer"
 
 
+def test_extract_reasoning_truncated_before_close_marker():
+    parser = KimiK3ReasoningParser(DummyTokenizer())
+    request = ChatCompletionRequest(model="test-model", messages=[])
+
+    reasoning, content = parser.extract_reasoning_content(
+        "unfinished reasoning",
+        request,
+    )
+
+    assert reasoning == "unfinished reasoning"
+    assert content is None
+
+
+def test_extract_markerless_output_with_thinking_disabled():
+    parser = KimiK3ReasoningParser(
+        DummyTokenizer(), chat_template_kwargs={"thinking": False}
+    )
+    request = ChatCompletionRequest(model="test-model", messages=[])
+
+    reasoning, content = parser.extract_reasoning_content("answer", request)
+
+    assert reasoning is None
+    assert content == "answer"
+
+
 def test_delegating_parser_strips_response_wrapper_without_tool_parser():
     parser = ReasoningOnlyParser(DummyTokenizer())
     request = ChatCompletionRequest(model="test-model", messages=[])
@@ -179,6 +204,23 @@ def test_streaming_split_close_marker_hands_content_downstream():
     assert closed.reasoning is None
     assert closed.content == f"{RESPONSE_OPEN}answer"
     assert parser.extract_content_ids([2, 3, 10]) == [10]
+
+
+def test_streaming_truncated_before_close_marker():
+    parser = KimiK3ReasoningParser(DummyTokenizer())
+
+    delta = parser.extract_reasoning_content_streaming(
+        previous_text="",
+        current_text="unfinished reasoning",
+        delta_text="unfinished reasoning",
+        previous_token_ids=[],
+        current_token_ids=[9],
+        delta_token_ids=[9],
+    )
+
+    assert isinstance(delta, DeltaMessage)
+    assert delta.reasoning == "unfinished reasoning"
+    assert delta.content is None
 
 
 def test_thinking_disabled_streams_content():

--- a/vllm/reasoning/kimi_k3_reasoning_parser.py
+++ b/vllm/reasoning/kimi_k3_reasoning_parser.py
@@ -204,11 +204,13 @@ class KimiK3ReasoningParser(ReasoningParser):
     ) -> tuple[str | None, str | None]:
         """Split full text into ``(reasoning, rest)`` for the non-streaming path.
 
-        Handles three shapes:
-          * no think channel at all   -> ``(None, model_output)`` (all content)
+        Handles four shapes:
+          * thinking disabled         -> ``(None, model_output)`` (all content)
           * open marker present       -> reasoning starts after ``<|open|>think<|sep|>``
           * open marker absent but a   close marker exists (gen-prefix consumed
             the open) -> reasoning starts at offset 0
+          * no marker while thinking   -> generation was truncated before the close
+            marker, so all output is reasoning
         ``rest`` is whatever follows the close marker, fed on to the tool parser.
         """
         if not self._thinking_enabled:
@@ -218,9 +220,6 @@ class KimiK3ReasoningParser(ReasoningParser):
         # reasoning content begins right after think-open (or at start if the
         # open marker was already consumed as a generation prefix)
         content_start = m_open.end() if m_open is not None else 0
-        # if there is no think channel at all, everything is content
-        if m_open is None and self._think_close_re.search(model_output) is None:
-            return None, self._content_after_reasoning(model_output, request)
 
         m_close = self._think_close_re.search(model_output, content_start)
         if m_close is not None:


### PR DESCRIPTION
## Purpose

Fixes #50258.

Kimi K3 can enter the thinking channel through the generation prefix, so the
generated text may not contain a think-open marker. If generation reaches its
token limit before emitting the think-close marker, the non-streaming parser
currently treats the markerless text as final content. The streaming path
already classifies the same unfinished text as reasoning.

This change removes that non-streaming fallback so markerless output remains
reasoning while thinking is enabled. Requests that explicitly disable thinking
continue to receive markerless output as normal content.

The regression tests cover:

- non-streaming truncation before the think-close marker;
- the equivalent streaming path; and
- markerless output when thinking is disabled.

No open pull request references #50258 or addresses this Kimi K3 parser case.

## Test Plan

```text
PYTHONPATH=. .venv/bin/python -m pytest \
  --confcutdir=tests/reasoning \
  tests/reasoning/test_kimi_k3_reasoning_parser.py -q

PRE_COMMIT_HOME=.pre-commit-cache .venv/bin/pre-commit run ruff-check --files \
  vllm/reasoning/kimi_k3_reasoning_parser.py \
  tests/reasoning/test_kimi_k3_reasoning_parser.py
PRE_COMMIT_HOME=.pre-commit-cache .venv/bin/pre-commit run ruff-format --files \
  vllm/reasoning/kimi_k3_reasoning_parser.py \
  tests/reasoning/test_kimi_k3_reasoning_parser.py
PRE_COMMIT_HOME=.pre-commit-cache .venv/bin/pre-commit run typos --files \
  vllm/reasoning/kimi_k3_reasoning_parser.py \
  tests/reasoning/test_kimi_k3_reasoning_parser.py
```

## Test Result

- Kimi K3 reasoning-parser tests: 15 passed.
- Ruff check, Ruff format, and typos hooks passed for both changed files.
- The pre-fix reduced reproducer returned unfinished reasoning as content; the
  same reproducer returns it as reasoning after this change.
- End-to-end Kimi K3 model evaluation was not run because compatible GPU
  hardware is unavailable in the local environment.
