### PR TITLE
[DSv4 Perf] Remove redundant full kernel for dsv4, 1.88x kernel performance improvement

### DIFF
--- a/tests/kernels/attention/test_flashmla_sparse.py
+++ b/tests/kernels/attention/test_flashmla_sparse.py
@@ -135,7 +135,8 @@ def test_sparse_flashmla_decode_smoke():
     assert lse.shape[0] == batch_size
 
 
-def test_sparse_flashmla_prefill_smoke():
+@pytest.mark.parametrize("h_q", [64, 128])
+def test_sparse_flashmla_prefill_smoke(h_q: int):
     import vllm.v1.attention.ops.flashmla as fm
 
     ok, reason = fm.is_flashmla_sparse_supported()
@@ -143,22 +144,25 @@ def test_sparse_flashmla_prefill_smoke():
         pytest.skip(reason)
 
     device = torch.device("cuda")
+    torch.manual_seed(0)
     s_q = 1
-    s_kv = 1
-    h_q = 64  # kernel expects multiple of 64
+    s_kv = 8
     h_kv = 1
     d_qk = 576
     d_v = 512
     topk = 128
+    q = torch.randn((s_q, h_q, d_qk), dtype=torch.bfloat16, device=device)
+    kv = torch.randn((s_kv, h_kv, d_qk), dtype=torch.bfloat16, device=device)
+    indices = torch.randint(s_kv, (s_q, h_kv, topk), dtype=torch.int32, device=device)
+    reference_indices = indices.clone()
+    reference_indices[..., 1:] = -1
+    kwargs = {"topk_length": torch.ones(1, dtype=torch.int32, device=device)}
+    reference = fm.flash_mla_sparse_fwd(q, kv, reference_indices, 1.0, d_v, **kwargs)
+    actual = fm.flash_mla_sparse_fwd(q, kv, indices, 1.0, d_v, **kwargs)
 
-    q = torch.zeros((s_q, h_q, d_qk), dtype=torch.bfloat16, device=device)
-    kv = torch.zeros((s_kv, h_kv, d_qk), dtype=torch.bfloat16, device=device)
-    indices = torch.zeros((s_q, h_kv, topk), dtype=torch.int32, device=device)
-
-    out, max_logits, lse = fm.flash_mla_sparse_fwd(q, kv, indices, 1.0, d_v)
-    assert out.shape == (s_q, h_q, d_v)
-    assert max_logits.shape == (s_q, h_q)
-    assert lse.shape == (s_q, h_q)
+    for actual_tensor, reference_tensor in zip(actual, reference):
+        torch.testing.assert_close(actual_tensor, reference_tensor, rtol=0, atol=0)
+    assert actual[0].shape == (s_q, h_q, d_v)
 
 
 def test_deepseek_v4_prefill_chunk_planning_expands_for_short_sequences():

--- a/vllm/models/deepseek_v4/common/ops/cache_utils.py
+++ b/vllm/models/deepseek_v4/common/ops/cache_utils.py
@@ -535,6 +535,7 @@ def combine_topk_swa_indices(
     topk: int,
     M: int,
     N: int,
+    out: tuple[torch.Tensor, torch.Tensor] | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     num_tokens = topk_indices.shape[0]
     combined_topk = (
@@ -542,15 +543,18 @@ def combine_topk_swa_indices(
         // _SPARSE_PREFILL_TOPK_ALIGNMENT
         * _SPARSE_PREFILL_TOPK_ALIGNMENT
     )
-    combined_indices = torch.full(
-        (num_tokens, combined_topk),
-        fill_value=-1,
-        dtype=torch.int32,
-        device=topk_indices.device,
-    )
-    combined_lens = torch.empty(
-        num_tokens, dtype=torch.int32, device=topk_indices.device
-    )
+    if out is None:
+        combined_indices = torch.full(
+            (num_tokens, combined_topk),
+            fill_value=-1,
+            dtype=torch.int32,
+            device=topk_indices.device,
+        )
+        combined_lens = torch.empty(
+            num_tokens, dtype=torch.int32, device=topk_indices.device
+        )
+    else:
+        combined_indices, combined_lens = out
 
     _COMBINE_TOPK_SWA_INDICES_KERNEL(
         combined_indices,

--- a/vllm/models/deepseek_v4/nvidia/flashmla.py
+++ b/vllm/models/deepseek_v4/nvidia/flashmla.py
@@ -20,6 +20,7 @@ from vllm.models.deepseek_v4.sparse_mla import (
     DeepseekV4FlashMLABackend,
     DeepseekV4FlashMLAMetadata,
 )
+from vllm.utils.math_utils import round_up
 from vllm.v1.attention.ops.flashmla import (
     flash_mla_sparse_fwd,
     flash_mla_with_kvcache,
@@ -95,8 +96,13 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
                 // self.compress_ratio
             )
             M = N + self.window_size + self.max_num_batched_tokens
+            assert self.topk_indices_buffer is not None
+            top_k = 0 if swa_only else self.topk_indices_buffer.shape[-1]
+            combined_topk = round_up(top_k + self.window_size, 128)
             current_workspace_manager().get_simultaneous(
                 ((self.PREFILL_CHUNK_SIZE, M, q.shape[-1]), torch.bfloat16),
+                ((self.max_num_batched_tokens, combined_topk), torch.int32),
+                ((self.max_num_batched_tokens,), torch.int32),
             )
             output.zero_()
             return
@@ -284,11 +290,15 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
         )
         assert chunk_plan, "prefill chunk plan must be non-empty when num_prefills > 0"
         workspace_manager = current_workspace_manager()
+        combined_topk = round_up(top_k + self.window_size, 128)
         for chunk_start, chunk_end, chunk_N, chunk_M in chunk_plan:
             chunk_size = chunk_end - chunk_start
-            kv = workspace_manager.get_simultaneous(
+            workspace = workspace_manager.get_simultaneous(
                 ((chunk_size, chunk_M, q.shape[-1]), torch.bfloat16),
-            )[0]
+                ((self.max_num_batched_tokens, combined_topk), torch.int32),
+                ((self.max_num_batched_tokens,), torch.int32),
+            )
+            kv, combined_indices_out, combined_lens_out = workspace
             if not swa_only:
                 # Gather compressed KV
                 assert attn_metadata is not None
@@ -322,6 +332,8 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
             query_end = (
                 query_start_loc_cpu[num_decodes + chunk_end] - prefill_token_base
             )
+            combined_indices_out = combined_indices_out[: query_end - query_start]
+            combined_lens_out = combined_lens_out[: query_end - query_start]
 
             combined_indices, combined_lens = combine_topk_swa_indices(
                 topk_indices[query_start:query_end],
@@ -335,6 +347,7 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
                 top_k,
                 chunk_M,
                 chunk_N,
+                out=(combined_indices_out, combined_lens_out),
             )
             flash_mla_sparse_fwd(
                 q=q[query_start:query_end],


### PR DESCRIPTION
## Purpose

Part of https://github.com/vllm-project/vllm/issues/45861

Passing an out tensor to avoid additional `torch.full` kernel call

## Test

Covered in unit tests

Perf can be seen in this AI generated script

```py
import gc
import statistics
import time
from collections.abc import Callable

import torch

from vllm.models.deepseek_v4.common.ops.cache_utils import (
    combine_topk_swa_indices,
)

# Fixed production-like C128A prefill configuration.
NUM_TOKENS = 8192
MAX_MODEL_LEN = 1_048_576
COMPRESS_RATIO = 128
WINDOW_SIZE = 128
TOPK_WIDTH = MAX_MODEL_LEN // COMPRESS_RATIO
COMBINED_TOPK = (
    (TOPK_WIDTH + WINDOW_SIZE + 127) // 128 * 128
)

# Timing configuration.  The first calls compile/warm the Triton kernel and are
# deliberately excluded.  Rounds alternate provider order to reduce bias.
WARMUP_ITERS = 5
ITERS_PER_ROUND = 20
NUM_ROUNDS = 5

Provider = Callable[[], tuple[torch.Tensor, torch.Tensor]]


def make_inputs() -> tuple[
    torch.Tensor,
    torch.Tensor,
    torch.Tensor,
    torch.Tensor,
]:
    """Create the metadata seen by one fresh 8192-token C128A prefill."""
    device = torch.device("cuda")

    # C128A reserves MAX_MODEL_LEN / COMPRESS_RATIO columns.  For an 8192-token
    # prompt only the first 64 can be valid, so leave the unused tail untouched.
    topk_indices = torch.empty(
        (NUM_TOKENS, TOPK_WIDTH), dtype=torch.int32, device=device
    )
    valid_topk = NUM_TOKENS // COMPRESS_RATIO
    topk_indices[:, :valid_topk] = torch.arange(
        valid_topk, dtype=torch.int32, device=device
    )

    query_start_loc = torch.tensor(
        [0, NUM_TOKENS], dtype=torch.int32, device=device
    )
    seq_lens = torch.tensor([NUM_TOKENS], dtype=torch.int32, device=device)
    gather_lens = torch.tensor(
        [min(NUM_TOKENS, WINDOW_SIZE)], dtype=torch.int32, device=device
    )
    return topk_indices, query_start_loc, seq_lens, gather_lens


def measure_batch(provider: Provider) -> tuple[float, float]:
    """Return average (GPU event ms, synchronized wall-clock ms) per call."""
    start_event = torch.cuda.Event(enable_timing=True)
    end_event = torch.cuda.Event(enable_timing=True)

    torch.cuda.synchronize()
    wall_start = time.perf_counter()
    start_event.record()
    for _ in range(ITERS_PER_ROUND):
        result = provider()
        # Drop the old-path output immediately, matching its temporary lifetime
        # in _forward_prefill and allowing normal CUDA allocator reuse.
        del result
    end_event.record()
    end_event.synchronize()
    wall_end = time.perf_counter()

    return (
        start_event.elapsed_time(end_event) / ITERS_PER_ROUND,
        (wall_end - wall_start) * 1000 / ITERS_PER_ROUND,
    )


def report(
    before_gpu: list[float],
    after_gpu: list[float],
    before_wall: list[float],
    after_wall: list[float],
) -> None:
    before_gpu_ms = statistics.median(before_gpu)
    after_gpu_ms = statistics.median(after_gpu)
    before_wall_ms = statistics.median(before_wall)
    after_wall_ms = statistics.median(after_wall)

    gpu_speedup = before_gpu_ms / after_gpu_ms
    wall_speedup = before_wall_ms / after_wall_ms
    gpu_reduction = (1.0 - after_gpu_ms / before_gpu_ms) * 100
    wall_reduction = (1.0 - after_wall_ms / before_wall_ms) * 100

    print("\nResults (median of per-round averages)")
    print("-" * 72)
    print(f"{'Provider':<12} {'GPU latency':>16} {'Wall latency':>16}")
    print(f"{'before':<12} {before_gpu_ms:>13.3f} ms {before_wall_ms:>13.3f} ms")
    print(f"{'after':<12} {after_gpu_ms:>13.3f} ms {after_wall_ms:>13.3f} ms")
    print("-" * 72)
    print(f"GPU:  {gpu_speedup:.2f}x speedup, {gpu_reduction:.1f}% lower latency")
    print(f"Wall: {wall_speedup:.2f}x speedup, {wall_reduction:.1f}% lower latency")
    print(
        "\nThis is the combine-index micro-operation speedup, not full-model "
        "prefill speedup."
    )


@torch.inference_mode()
def main() -> None:
    if not torch.cuda.is_available():
        raise RuntimeError("This benchmark requires a CUDA GPU")

    torch.cuda.set_device(0)
    topk_indices, query_start_loc, seq_lens, gather_lens = make_inputs()

    compressed_len = NUM_TOKENS // COMPRESS_RATIO
    n = compressed_len
    m = n + WINDOW_SIZE

    workspace_indices = torch.empty(
        (NUM_TOKENS, COMBINED_TOPK), dtype=torch.int32, device="cuda"
    )
    workspace_lens = torch.empty(NUM_TOKENS, dtype=torch.int32, device="cuda")

    def before() -> tuple[torch.Tensor, torch.Tensor]:
        return combine_topk_swa_indices(
            topk_indices,
            query_start_loc,
            seq_lens,
            gather_lens,
            WINDOW_SIZE,
            COMPRESS_RATIO,
            TOPK_WIDTH,
            m,
            n,
        )

    def after() -> tuple[torch.Tensor, torch.Tensor]:
        return combine_topk_swa_indices(
            topk_indices,
            query_start_loc,
            seq_lens,
            gather_lens,
            WINDOW_SIZE,
            COMPRESS_RATIO,
            TOPK_WIDTH,
            m,
            n,
            out=(workspace_indices, workspace_lens),
        )

    print("DSv4 C128A prefill combine-index microbenchmark")
    print("=" * 72)
    print(f"GPU:                 {torch.cuda.get_device_name(0)}")
    print(f"Prompt tokens:       {NUM_TOKENS}")
    print(f"Maximum model len:   {MAX_MODEL_LEN}")
    print(f"C128A index width:   {TOPK_WIDTH}")
    print(f"Combined width:      {COMBINED_TOPK}")
    print(
        "Output buffer:       "
        f"{NUM_TOKENS * COMBINED_TOPK * torch.int32.itemsize / 2**20:.1f} MiB"
    )
    print(
        f"Timing:              {NUM_ROUNDS} rounds x {ITERS_PER_ROUND} calls"
    )

    # Compile both paths and stabilize allocator/workspace state.
    for provider in (before, after):
        for _ in range(WARMUP_ITERS):
            result = provider()
            del result
        torch.cuda.synchronize()

    # The new path intentionally leaves padding uninitialized.  Compare only
    # lengths and valid entries, which are the values consumed by FlashMLA.
    reference_indices, reference_lens = before()
    actual_indices, actual_lens = after()
    torch.testing.assert_close(reference_lens, actual_lens, rtol=0, atol=0)
    sample_rows = (127, NUM_TOKENS // 2, NUM_TOKENS - 1)
    sample_lens = actual_lens[list(sample_rows)].cpu().tolist()
    for row, length in zip(sample_rows, sample_lens):
        torch.testing.assert_close(
            reference_indices[row, :length],
            actual_indices[row, :length],
            rtol=0,
            atol=0,
        )
    del reference_indices, reference_lens, actual_indices, actual_lens
    gc.collect()
    torch.cuda.synchronize()
    print("Correctness check:   passed (lengths and sampled valid entries)")

    samples: dict[str, list[tuple[float, float]]] = {
        "before": [],
        "after": [],
    }
    for round_idx in range(NUM_ROUNDS):
        order = (("before", before), ("after", after))
        if round_idx % 2:
            order = tuple(reversed(order))
        for name, provider in order:
            samples[name].append(measure_batch(provider))

    report(
        [sample[0] for sample in samples["before"]],
        [sample[0] for sample in samples["after"]],
        [sample[1] for sample in samples["before"]],
        [sample[1] for sample in samples["after"]],
    )


if __name__ == "__main__":
    main()

```

And we get

```bash
DSv4 C128A prefill combine-index microbenchmark
========================================================================
GPU:                 NVIDIA B300 SXM6 AC
Prompt tokens:       8192
Maximum model len:   1048576
C128A index width:   8192
Combined width:      8320
Output buffer:       260.0 MiB
Timing:              5 rounds x 20 calls
Correctness check:   passed (lengths and sampled valid entries)

Results (median of per-round averages)
------------------------------------------------------------------------
Provider          GPU latency     Wall latency
before               0.093 ms         0.094 ms
after                0.049 ms         0.050 ms
------------------------------------------------------------------------
GPU:  1.88x speedup, 46.8% lower latency
Wall: 1.86x speedup, 46.3% lower latency
```