### PR TITLE
[Core] Add TP-invariant tree kernels across TP sizes

### DIFF
--- a/csrc/custom_all_reduce.cuh
+++ b/csrc/custom_all_reduce.cuh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "core/batch_invariant.hpp"
 #include "custom_collective_common.cuh"
 
 namespace vllm {
@@ -284,13 +285,15 @@ class CustomAllreduce {
             ". Valid values: 1stage, oneshot, 2stage, twoshot");
       }
     }
+    const bool batch_invariant_1stage =
+        vllm_is_batch_invariant() && (world_size_ == 2 || world_size_ == 4);
 
 #define KL(ngpus, name)                                                       \
   name<T, ngpus><<<blocks, threads, 0, stream>>>(ptrs, sg_, self_sg_, output, \
                                                  rank_, size);
 #define REDUCE_CASE(ngpus)                              \
   case ngpus: {                                         \
-    if (force_1stage) {                                 \
+    if (force_1stage || batch_invariant_1stage) {       \
       KL(ngpus, cross_device_reduce_1stage);            \
     } else if (force_2stage) {                          \
       KL(ngpus, cross_device_reduce_2stage);            \

--- a/tests/distributed/test_custom_all_reduce.py
+++ b/tests/distributed/test_custom_all_reduce.py
@@ -223,6 +223,38 @@ def eager_allreduce(
         torch.testing.assert_close(out, inp * (tp_size**num_communication))
 
 
+@ray.remote(num_gpus=1, max_calls=1)
+def batch_invariant_allreduce(
+    monkeypatch: pytest.MonkeyPatch,
+    tp_size,
+    pp_size,
+    rank,
+    distributed_init_port,
+):
+    with monkeypatch.context() as m:
+        m.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+        m.delenv("HIP_VISIBLE_DEVICES", raising=False)
+        m.setenv("VLLM_BATCH_INVARIANT", "1")
+        m.delenv("VLLM_CUSTOM_ALLREDUCE_ALGO", raising=False)
+        device = torch.device(f"cuda:{rank}")
+        torch.accelerator.set_device_index(device)
+        init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
+
+        custom_allreduce = get_tp_group().device_communicator.ca_comm
+        assert custom_allreduce is not None
+        assert not custom_allreduce.disabled
+
+        torch.manual_seed(rank)
+        target = torch.randn((1, 65536), dtype=torch.bfloat16, device=device)
+        target_alone = custom_allreduce.all_reduce(target)
+
+        batch = torch.randn((8, 65536), dtype=torch.bfloat16, device=device)
+        batch[3].copy_(target[0])
+        target_in_batch = custom_allreduce.all_reduce(batch)[3]
+
+        assert torch.equal(target_alone[0], target_in_batch)
+
+
 @pytest.mark.parametrize("tp_size", [2])
 @pytest.mark.parametrize("pipeline_parallel_size", [1, 2])
 @pytest.mark.parametrize("test_target", [eager_allreduce, graph_allreduce])
@@ -247,3 +279,13 @@ def test_custom_collectives_world_size_four(
     if torch.accelerator.device_count() < 4:
         pytest.skip("Not enough GPUs to run the test.")
     multi_process_parallel(monkeypatch, 4, 1, test_target)
+
+
+@pytest.mark.parametrize("tp_size", [2, 4])
+def test_batch_invariant_custom_allreduce(
+    monkeypatch: pytest.MonkeyPatch,
+    tp_size,
+):
+    if torch.accelerator.device_count() < tp_size:
+        pytest.skip("Not enough GPUs to run the test.")
+    multi_process_parallel(monkeypatch, tp_size, 1, batch_invariant_allreduce)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,7 +25,7 @@ from vllm.config import (
     VllmConfig,
     update_config,
 )
-from vllm.config.compilation import CompilationMode, CUDAGraphMode
+from vllm.config.compilation import CompilationMode, CUDAGraphMode, PassConfig
 from vllm.config.kernel import IrOpPriorityConfig
 from vllm.config.load import LoadConfig
 from vllm.config.utils import get_field
@@ -37,6 +37,47 @@ from vllm.platforms import current_platform
 from vllm.v1.attention.backend import AttentionCGSupport
 
 DEVICE_TYPE = current_platform.device_type
+
+
+@pytest.mark.parametrize(
+    ("tensor_parallel_size", "expected_disabled"),
+    [(1, True), (2, False), (4, False), (8, True)],
+)
+def test_batch_invariant_custom_all_reduce_policy(
+    monkeypatch,
+    tensor_parallel_size,
+    expected_disabled,
+):
+    monkeypatch.setattr(envs, "VLLM_BATCH_INVARIANT", True)
+    monkeypatch.setattr(current_platform, "use_custom_allreduce", lambda: True)
+
+    config = ParallelConfig(tensor_parallel_size=tensor_parallel_size)
+
+    assert config.disable_custom_all_reduce is expected_disabled
+
+
+def test_batch_invariant_preserves_explicit_custom_all_reduce_disable(monkeypatch):
+    monkeypatch.setattr(envs, "VLLM_BATCH_INVARIANT", True)
+    monkeypatch.setattr(current_platform, "use_custom_allreduce", lambda: True)
+
+    config = ParallelConfig(
+        tensor_parallel_size=2,
+        disable_custom_all_reduce=True,
+    )
+
+    assert config.disable_custom_all_reduce is True
+
+
+def test_batch_invariant_disables_allreduce_rms_fusion(monkeypatch):
+    monkeypatch.setattr(envs, "VLLM_BATCH_INVARIANT", True)
+
+    config = VllmConfig(
+        compilation_config=CompilationConfig(
+            pass_config=PassConfig(fuse_allreduce_rms=True)
+        )
+    )
+
+    assert config.compilation_config.pass_config.fuse_allreduce_rms is False
 
 
 def test_compile_config_repr_succeeds():

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -999,8 +999,9 @@ class ParallelConfig:
         # Lazy import to avoid circular import
         from vllm.v1.executor import Executor
 
-        # Enable batch invariance settings if requested
-        if envs.VLLM_BATCH_INVARIANT:
+        # The one-stage custom all-reduce is batch invariant for TP2 and TP4.
+        # Other TP sizes continue to use the PyNCCL fallback.
+        if envs.VLLM_BATCH_INVARIANT and self.tensor_parallel_size not in (2, 4):
             self.disable_custom_all_reduce = True
 
         if (

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1273,6 +1273,15 @@ class VllmConfig:
 
         default_config = OPTIMIZATION_LEVEL_TO_CONFIG[self.optimization_level]
         self._apply_optimization_level_defaults(default_config)
+        if (
+            envs.VLLM_BATCH_INVARIANT
+            and self.compilation_config.pass_config.fuse_allreduce_rms
+        ):
+            logger.warning_once(
+                "Disabling all-reduce/RMSNorm fusion because it does not support "
+                "batch-invariant inference."
+            )
+            self.compilation_config.pass_config.fuse_allreduce_rms = False
         if self.kernel_config.enable_flashinfer_autotune is None:
             raise ValueError(
                 "KernelConfig.enable_flashinfer_autotune must be set after applying "


### PR DESCRIPTION
## Purpose

This draft is being expanded into a vLLM implementation of Tree-Based
Invariant Kernels (TBIK): co-designed row-parallel MatMul and all-reduce
primitives whose global floating-point reduction order is independent of the
tensor-parallel degree.

The intended contract is bitwise-identical inference across TP1, TP2, TP4, and
TP8 when combined with vLLM's batch-invariant operators.

The current commit contains only the first fixed-TP all-reduce experiment. It
does not yet satisfy the cross-TP contract and is not ready for review.

## Required validation

- kernel outputs are bitwise identical at TP1/2/4/8 against one canonical tree
  oracle
- a public model produces identical tokens and probabilities at TP1/2/4/8
- Holo 3.1 with expert parallelism disabled produces identical teacher-forced
  and rollout probabilities at TP2/4/8
- every TP configuration remains invariant when the target runs alone and
  under mixed prefill/decode traffic
- unsupported operators and configurations fail initialization rather than
  silently falling back

The implementation will be written from the published algorithm. The public
reference repository currently has no license, so its source will not be
copied or adapted.

## Test Plan

Pending implementation.

## Test Result

Pending implementation.

AI assistance is being used for implementation, experiment automation, and
drafting. I will review the complete diff and test evidence before requesting
review.
