### PR TITLE
[Security] Fix chat template resource-exhaustion DoS (GHSA-4hhp-h66f-…

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -61,7 +61,7 @@ itertools = "0.14.0"
 libc = "0.2.177"
 llm-multimodal = { git = "https://github.com/smg-project/llm-multimodal", rev = "15adba5e025d8636ba4a334fb379b1371f6196a1", default-features = false, features = ["native-tls"] }
 mimalloc = "0.1.52"
-minijinja = { version = "2.0", features = ["unstable_machinery", "json", "builtins", "loader", "loop_controls", "preserve_order"] }
+minijinja = { version = "2.0", features = ["unstable_machinery", "json", "builtins", "loader", "loop_controls", "preserve_order", "fuel"] }
 minijinja-contrib = { version = "2.0", features = ["pycompat"] }
 native-tls-vendored = { package = "native-tls", version = "0.2.18", features = ["vendored"] }
 ndarray = { version = "0.17", features = ["serde"] }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -62,7 +62,7 @@ itertools = "0.14.0"
 libc = "0.2.177"
 llm-multimodal = { git = "https://github.com/smg-project/llm-multimodal", rev = "24c676dd49d73f05cb4068aade2e60397a5c0afe", default-features = false, features = ["native-tls"] }
 mimalloc = "0.1.52"
-minijinja = { version = "2.24", features = ["unstable_machinery", "json", "builtins", "loader", "loop_controls", "preserve_order"] }
+minijinja = { version = "2.24", features = ["unstable_machinery", "json", "builtins", "loader", "loop_controls", "preserve_order", "fuel"] }
 minijinja-contrib = { version = "2.24", features = ["pycompat"] }
 native-tls-vendored = { package = "native-tls", version = "0.2.18", features = ["vendored"] }
 ndarray = { version = "0.17", features = ["serde"] }

--- a/rust/src/chat/src/lib.rs
+++ b/rust/src/chat/src/lib.rs
@@ -147,7 +147,12 @@ impl ChatRequestProcessor {
         // Stamp before rendering so render and tokenize count toward TTFT/e2e.
         let arrival_time = vllm_llm::current_unix_timestamp_secs();
         let output_processor = self.backend.new_chat_output_processor(&mut request, options)?;
-        let rendered = self.backend.chat_renderer().render(&request)?;
+
+        let renderer = self.backend.chat_renderer();
+        let (rendered, request) =
+            tokio::task::spawn_blocking(move || renderer.render(&request).map(|r| (r, request)))
+                .await
+                .map_err(|e| Error::ChatTemplate(format!("render task join error: {e}")))??;
         let reasoning_parser_kwargs =
             request
                 .sampling_params
@@ -311,7 +316,11 @@ impl ChatLlm {
     pub async fn tokenize_chat(&self, request: ChatRequest) -> Result<Vec<u32>> {
         request.validate()?;
 
-        let rendered = self.processor.backend.chat_renderer().render(&request)?;
+        let renderer = self.processor.backend.chat_renderer();
+        let (rendered, request) =
+            tokio::task::spawn_blocking(move || renderer.render(&request).map(|r| (r, request)))
+                .await
+                .map_err(|e| Error::ChatTemplate(format!("render task join error: {e}")))??;
         let (prompt, _mm_features) =
             self.processor.finalize_rendered_prompt(&request, rendered).await?;
 

--- a/rust/src/chat/src/lib.rs
+++ b/rust/src/chat/src/lib.rs
@@ -148,7 +148,12 @@ impl ChatRequestProcessor {
     async fn prepare_text_request(&self, request: ChatRequest) -> Result<TextRequest> {
         // Stamp before rendering so render and tokenize count toward TTFT/e2e.
         let arrival_time = vllm_llm::current_unix_timestamp_secs();
-        let rendered = self.backend.chat_renderer().render(&request)?;
+        let renderer = self.backend.chat_renderer();
+        let (rendered, request) = tokio::task::spawn_blocking(move || {
+            renderer.render(&request).map(|rendered| (rendered, request))
+        })
+        .await
+        .map_err(|e| Error::ChatTemplate(format!("render task join error: {e}")))??;
         let reasoning_parser_kwargs =
             request
                 .sampling_params

--- a/rust/src/chat/src/renderer/hf/template.rs
+++ b/rust/src/chat/src/renderer/hf/template.rs
@@ -25,12 +25,19 @@ use crate::renderer::hf::{TemplateMessage, TemplateTool};
 
 type Result<T> = std::result::Result<T, TemplateError>;
 
+/// Default fuel budget for template rendering. Prevents unbounded loops and
+/// string operations from exhausting CPU. Each template instruction consumes
+/// one unit of fuel; when depleted, rendering aborts with an error.
+const DEFAULT_TEMPLATE_FUEL: u64 = 500_000;
+
 /// Build a pre-configured environment with the given template string.
 fn build_environment(template: String) -> Result<Environment<'static>> {
     let mut env = Environment::new();
 
     env.set_trim_blocks(true);
     env.set_lstrip_blocks(true);
+
+    env.set_fuel(Some(DEFAULT_TEMPLATE_FUEL));
 
     env.add_template_owned("chat".to_owned(), template)?;
 

--- a/tests/renderers/test_executor_replace.py
+++ b/tests/renderers/test_executor_replace.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+import torch
+
+from vllm.renderers.base import _SwappableExecutor
+from vllm.renderers.hf import HfRenderer
+from vllm.renderers.params import TokenizeParams
+from vllm.utils.async_utils import make_async
+
+MODEL_NAME = "openai-community/gpt2"
+
+
+@dataclass
+class MockHFConfig:
+    model_type: str = "any"
+
+
+@dataclass
+class MockModelConfig:
+    runner_type = "generate"
+    model: str = MODEL_NAME
+    tokenizer: str = MODEL_NAME
+    trust_remote_code: bool = False
+    tokenizer_revision = None
+    tokenizer_mode = "auto"
+    hf_config = MockHFConfig()
+    encoder_config: dict[str, Any] | None = None
+    enable_prompt_embeds: bool = False
+    skip_tokenizer_init: bool = False
+    is_encoder_decoder: bool = False
+    is_multimodal_model: bool = False
+    renderer_num_workers: int = 1
+    hidden_size: int = 768
+    dtype: torch.dtype = torch.float32
+
+    def get_hidden_size(self) -> int:
+        return self.hidden_size
+
+
+@dataclass
+class MockParallelConfig:
+    _api_process_rank: int = 0
+
+
+@dataclass
+class MockVllmConfig:
+    model_config: MockModelConfig
+    parallel_config: MockParallelConfig
+
+
+@dataclass
+class DummyTokenizer:
+    truncation_side: str = "left"
+    max_chars_per_token: int = 1
+    is_fast: bool = False
+
+    def decode(self, tokens: list[int], **kwargs):
+        return str(tokens)
+
+    def encode(self, text: str, **kwargs):
+        return list(range(len(text)))
+
+    def __call__(self, text: str, **kwargs):
+        return {"input_ids": self.encode(text, **kwargs)}
+
+
+def _build_renderer() -> HfRenderer:
+    return HfRenderer(
+        MockVllmConfig(MockModelConfig(), parallel_config=MockParallelConfig()),
+        tokenizer=DummyTokenizer(),
+    )
+
+
+def test_swappable_executor_keeps_make_async_wrappers_alive():
+    pool = _SwappableExecutor(max_workers=1)
+    async_add = make_async(lambda x: x + 1, executor=pool)
+
+    async def _run():
+        assert await async_add(1) == 2
+        old_inner = pool._inner
+        pool.replace_inner()
+
+        with pytest.raises(RuntimeError, match="cannot schedule new futures"):
+            old_inner.submit(lambda: None)
+
+        assert await async_add(40) == 41
+
+    try:
+        asyncio.run(_run())
+    finally:
+        pool.shutdown(wait=False)
+
+
+def test_replace_executor_does_not_break_tokenize_or_decode():
+    renderer = _build_renderer()
+    executor = renderer._executor
+    old_inner = executor._inner
+
+    async def _run():
+        assert await renderer._tokenize_prompt_async(
+            {"prompt": "ab"},
+            TokenizeParams(max_total_tokens=100),
+        )
+        renderer._replace_executor()
+        assert renderer._executor is executor
+        assert executor._inner is not old_inner
+
+        with pytest.raises(RuntimeError, match="cannot schedule new futures"):
+            old_inner.submit(lambda: None)
+
+        tokenized = await renderer._tokenize_prompt_async(
+            {"prompt": "abc"},
+            TokenizeParams(max_total_tokens=100),
+        )
+        assert tokenized["prompt_token_ids"] == [0, 1, 2]
+        assert await renderer._async_tokenizer_decode([1, 2]) == "[1, 2]"
+
+    try:
+        asyncio.run(_run())
+    finally:
+        renderer.shutdown()

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -353,6 +353,16 @@ class OpenAIServingResponses(GenerateBaseServing):
         if maybe_validation_error is not None:
             return maybe_validation_error
 
+        maybe_template_error = self.online_renderer.validate_chat_template(
+            request_chat_template=None,
+            chat_template_kwargs=request.chat_template_kwargs,
+            trust_request_chat_template=(
+                self.online_renderer.trust_request_chat_template
+            ),
+        )
+        if maybe_template_error is not None:
+            return maybe_template_error
+
         # If the engine is dead, raise the engine's DEAD_ERROR.
         # This is required for the streaming case, where we return a
         # success status before we actually start generating text :).

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -325,6 +325,16 @@ class OpenAIServingResponses(GenerateBaseServing):
         if maybe_validation_error is not None:
             return maybe_validation_error
 
+        maybe_template_error = self.online_renderer.validate_chat_template(
+            request_chat_template=None,
+            chat_template_kwargs=request.chat_template_kwargs,
+            trust_request_chat_template=(
+                self.online_renderer.trust_request_chat_template
+            ),
+        )
+        if maybe_template_error is not None:
+            return maybe_template_error
+
         self._preflight()
 
         if request.store and not self.enable_store:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     CUDA_VISIBLE_DEVICES: str | None = None
     VLLM_ENGINE_ITERATION_TIMEOUT_S: int = 60
     VLLM_ENGINE_READY_TIMEOUT_S: int = 600
+    VLLM_CHAT_TEMPLATE_RENDER_TIMEOUT: float = 30.0
     VLLM_API_KEY: str | None = None
     VLLM_DEBUG_LOG_API_SERVER_RESPONSE: bool = False
     S3_ACCESS_KEY_ID: str | None = None
@@ -785,6 +786,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # during startup. Default is 600 seconds (10 minutes).
     "VLLM_ENGINE_READY_TIMEOUT_S": lambda: int(
         os.environ.get("VLLM_ENGINE_READY_TIMEOUT_S", "600")
+    ),
+    # Maximum wall-clock seconds allowed for a single chat template render.
+    # Set to 0 to disable the timeout.
+    "VLLM_CHAT_TEMPLATE_RENDER_TIMEOUT": lambda: float(
+        os.environ.get("VLLM_CHAT_TEMPLATE_RENDER_TIMEOUT", "30")
     ),
     # API key for vLLM API server
     "VLLM_API_KEY": lambda: os.environ.get("VLLM_API_KEY", None),

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     CUDA_VISIBLE_DEVICES: str | None = None
     VLLM_ENGINE_ITERATION_TIMEOUT_S: int = 60
     VLLM_ENGINE_READY_TIMEOUT_S: int = 600
+    VLLM_CHAT_TEMPLATE_RENDER_TIMEOUT: float = 30.0
     VLLM_API_KEY: str | None = None
     VLLM_DEBUG_LOG_API_SERVER_RESPONSE: bool = False
     S3_ACCESS_KEY_ID: str | None = None
@@ -810,6 +811,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # during startup. Default is 600 seconds (10 minutes).
     "VLLM_ENGINE_READY_TIMEOUT_S": lambda: int(
         os.environ.get("VLLM_ENGINE_READY_TIMEOUT_S", "600")
+    ),
+    # Maximum wall-clock seconds allowed for a single chat template render.
+    # Set to 0 to disable the timeout.
+    "VLLM_CHAT_TEMPLATE_RENDER_TIMEOUT": lambda: float(
+        os.environ.get("VLLM_CHAT_TEMPLATE_RENDER_TIMEOUT", "30")
     ),
     # API key for vLLM API server
     "VLLM_API_KEY": lambda: os.environ.get("VLLM_API_KEY", None),

--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -5,7 +5,7 @@ import time
 import weakref
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import Executor, Future, ThreadPoolExecutor
 from contextlib import ExitStack
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Generic, overload

--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -71,6 +71,31 @@ logger = init_logger(__name__)
 _T = TypeVar("_T", bound=TokenizerLike, default=TokenizerLike)
 
 
+class _SwappableExecutor(Executor):
+    """Executor whose inner pool can be replaced without changing identity.
+
+    ``make_async`` captures the executor object at wrap time. Replacing
+    ``self._executor`` with a new ``ThreadPoolExecutor`` would leave those
+    wrappers (tokenize, decode, pooling, derender) bound to a shutdown pool.
+    """
+
+    def __init__(self, max_workers: int) -> None:
+        super().__init__()
+        self._max_workers = max_workers
+        self._inner = ThreadPoolExecutor(max_workers=max_workers)
+
+    def submit(self, fn, /, *args, **kwargs):
+        return self._inner.submit(fn, *args, **kwargs)
+
+    def shutdown(self, wait: bool = True, *, cancel_futures: bool = False) -> None:
+        self._inner.shutdown(wait=wait, cancel_futures=cancel_futures)
+
+    def replace_inner(self) -> None:
+        old = self._inner
+        old.shutdown(wait=False)
+        self._inner = ThreadPoolExecutor(max_workers=self._max_workers)
+
+
 class BaseRenderer(ABC, Generic[_T]):
     def __init__(self, config: "VllmConfig", tokenizer: _T | None) -> None:
         super().__init__()
@@ -109,7 +134,7 @@ class BaseRenderer(ABC, Generic[_T]):
         # multimodal processor receives a deep-copied tokenizer (see #36557)
         # so it is safe to run tokenization and MM preprocessing concurrently.
         pool_workers = config.model_config.renderer_num_workers
-        self._executor = ThreadPoolExecutor(max_workers=pool_workers)
+        self._executor = _SwappableExecutor(max_workers=pool_workers)
         self._resources.callback(self._executor.shutdown, wait=False)
 
         # Separate single-worker executor so tokenization never queues behind

--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -2,12 +2,14 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from __future__ import annotations
 
+import asyncio
 import copy
 import inspect
 import itertools
 import weakref
 from collections import defaultdict, deque
 from collections.abc import Mapping, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Final, Literal, cast, overload
 
@@ -20,6 +22,7 @@ import jinja2.sandbox
 import torch
 from typing_extensions import override
 
+from vllm import envs
 from vllm.entrypoints.chat_utils import (
     PROMPT_EMBEDS_PLACEHOLDER_TOKEN,
     ChatTemplateResolutionError,
@@ -921,6 +924,48 @@ class HfRenderer(BaseRenderer[HfTokenizer]):
                 self.tokenizer, config.model_config.renderer_num_workers + 1
             )
 
+    def _replace_executor(self) -> None:
+        """Replace the render executor with a fresh pool.
+
+        Called after a render timeout so that the stuck thread (which CPython
+        cannot interrupt) does not permanently block all subsequent renders.
+        The old executor is abandoned with wait=False — its thread will
+        eventually finish or be reaped on process exit.
+        """
+        old = self._executor
+        old.shutdown(wait=False)
+        pool_workers = self.model_config.renderer_num_workers
+        self._executor = ThreadPoolExecutor(max_workers=pool_workers)
+        self._apply_chat_template_async = make_async(
+            safe_apply_chat_template, executor=self._executor
+        )
+        logger.warning(
+            "Chat template render timed out — executor pool replaced "
+            "(%d worker(s)). The stuck thread may continue consuming "
+            "CPU until the process exits.",
+            pool_workers,
+        )
+
+    async def _render_with_timeout(self, coro):
+        """Run a template-rendering coroutine with a timeout.
+
+        On timeout, replaces the executor so subsequent renders are not
+        permanently blocked by the stuck thread.
+        """
+        timeout = envs.VLLM_CHAT_TEMPLATE_RENDER_TIMEOUT
+        if timeout <= 0:
+            return await coro
+        try:
+            return await asyncio.wait_for(coro, timeout=timeout)
+        except asyncio.TimeoutError:
+            self._replace_executor()
+            raise TimeoutError(
+                f"Chat template rendering timed out after "
+                f"{timeout}s. This may indicate a malicious or "
+                f"excessively complex template. Adjust "
+                f"VLLM_CHAT_TEMPLATE_RENDER_TIMEOUT to override."
+            ) from None
+
     def _can_produce_offsets(self) -> bool:
         # HF tokenizers may be slow (use_fast=False); only fast tokenizers
         # expose offset_mapping.
@@ -1094,25 +1139,29 @@ class HfRenderer(BaseRenderer[HfTokenizer]):
         if params.return_assistant_tokens_mask:
             result_with_mask = cast(
                 tuple[list[int], list[int] | None],
-                await make_async(
-                    safe_apply_chat_template,
-                    executor=self._executor,
-                )(
-                    model_config,
-                    tokenizer,
-                    conversation,
-                    return_assistant_tokens_mask=True,  # type: ignore[arg-type]
-                    **chat_template_kwargs,
+                await self._render_with_timeout(
+                    make_async(
+                        safe_apply_chat_template,
+                        executor=self._executor,
+                    )(
+                        model_config,
+                        tokenizer,
+                        conversation,
+                        return_assistant_tokens_mask=True,  # type: ignore[arg-type]
+                        **chat_template_kwargs,
+                    )
                 ),
             )
             prompt_raw: str | list[int] = result_with_mask[0]
             assistant_tokens_mask = result_with_mask[1]
         else:
-            prompt_raw = await self._apply_chat_template_async(
-                model_config,
-                tokenizer,
-                conversation,
-                **chat_template_kwargs,
+            prompt_raw = await self._render_with_timeout(
+                self._apply_chat_template_async(
+                    model_config,
+                    tokenizer,
+                    conversation,
+                    **chat_template_kwargs,
+                )
             )
 
         # NOTE: use_unified_vision_chunk is currently specific to Kimi-K2.5

--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -9,7 +9,6 @@ import itertools
 import weakref
 from collections import defaultdict, deque
 from collections.abc import Mapping, Sequence
-from concurrent.futures import ThreadPoolExecutor
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Final, Literal, cast, overload
 
@@ -1016,25 +1015,21 @@ class HfRenderer(BaseRenderer[HfTokenizer]):
             )
 
     def _replace_executor(self) -> None:
-        """Replace the render executor with a fresh pool.
+        """Replace the inner render pool after a stuck worker.
 
         Called after a render timeout so that the stuck thread (which CPython
         cannot interrupt) does not permanently block all subsequent renders.
-        The old executor is abandoned with wait=False — its thread will
+        The executor *object* is kept so ``make_async`` wrappers bound at
+        init (tokenize, decode, pooling, derender) keep submitting work.
+        The old inner pool is abandoned with wait=False — its thread will
         eventually finish or be reaped on process exit.
         """
-        old = self._executor
-        old.shutdown(wait=False)
-        pool_workers = self.model_config.renderer_num_workers
-        self._executor = ThreadPoolExecutor(max_workers=pool_workers)
-        self._apply_chat_template_async = make_async(
-            safe_apply_chat_template, executor=self._executor
-        )
+        self._executor.replace_inner()
         logger.warning(
             "Chat template render timed out — executor pool replaced "
             "(%d worker(s)). The stuck thread may continue consuming "
             "CPU until the process exits.",
-            pool_workers,
+            self.model_config.renderer_num_workers,
         )
 
     async def _render_with_timeout(self, coro):

--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -2,12 +2,14 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from __future__ import annotations
 
+import asyncio
 import copy
 import inspect
 import itertools
 import weakref
 from collections import defaultdict, deque
 from collections.abc import Mapping, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Final, Literal, cast, overload
 
@@ -20,6 +22,7 @@ import jinja2.sandbox
 import torch
 from typing_extensions import override
 
+from vllm import envs
 from vllm.entrypoints.chat_utils import (
     PROMPT_EMBEDS_PLACEHOLDER_TOKEN,
     ChatTemplateResolutionError,
@@ -1012,6 +1015,48 @@ class HfRenderer(BaseRenderer[HfTokenizer]):
                 self.tokenizer, config.model_config.renderer_num_workers + 1
             )
 
+    def _replace_executor(self) -> None:
+        """Replace the render executor with a fresh pool.
+
+        Called after a render timeout so that the stuck thread (which CPython
+        cannot interrupt) does not permanently block all subsequent renders.
+        The old executor is abandoned with wait=False — its thread will
+        eventually finish or be reaped on process exit.
+        """
+        old = self._executor
+        old.shutdown(wait=False)
+        pool_workers = self.model_config.renderer_num_workers
+        self._executor = ThreadPoolExecutor(max_workers=pool_workers)
+        self._apply_chat_template_async = make_async(
+            safe_apply_chat_template, executor=self._executor
+        )
+        logger.warning(
+            "Chat template render timed out — executor pool replaced "
+            "(%d worker(s)). The stuck thread may continue consuming "
+            "CPU until the process exits.",
+            pool_workers,
+        )
+
+    async def _render_with_timeout(self, coro):
+        """Run a template-rendering coroutine with a timeout.
+
+        On timeout, replaces the executor so subsequent renders are not
+        permanently blocked by the stuck thread.
+        """
+        timeout = envs.VLLM_CHAT_TEMPLATE_RENDER_TIMEOUT
+        if timeout <= 0:
+            return await coro
+        try:
+            return await asyncio.wait_for(coro, timeout=timeout)
+        except asyncio.TimeoutError:
+            self._replace_executor()
+            raise TimeoutError(
+                f"Chat template rendering timed out after "
+                f"{timeout}s. This may indicate a malicious or "
+                f"excessively complex template. Adjust "
+                f"VLLM_CHAT_TEMPLATE_RENDER_TIMEOUT to override."
+            ) from None
+
     def _can_produce_offsets(self) -> bool:
         # HF tokenizers may be slow (use_fast=False); only fast tokenizers
         # expose offset_mapping.
@@ -1185,25 +1230,29 @@ class HfRenderer(BaseRenderer[HfTokenizer]):
         if params.return_assistant_tokens_mask:
             result_with_mask = cast(
                 tuple[list[int], list[int] | None],
-                await make_async(
-                    safe_apply_chat_template,
-                    executor=self._executor,
-                )(
-                    model_config,
-                    tokenizer,
-                    conversation,
-                    return_assistant_tokens_mask=True,  # type: ignore[arg-type]
-                    **chat_template_kwargs,
+                await self._render_with_timeout(
+                    make_async(
+                        safe_apply_chat_template,
+                        executor=self._executor,
+                    )(
+                        model_config,
+                        tokenizer,
+                        conversation,
+                        return_assistant_tokens_mask=True,  # type: ignore[arg-type]
+                        **chat_template_kwargs,
+                    )
                 ),
             )
             prompt_raw: str | list[int] = result_with_mask[0]
             assistant_tokens_mask = result_with_mask[1]
         else:
-            prompt_raw = await self._apply_chat_template_async(
-                model_config,
-                tokenizer,
-                conversation,
-                **chat_template_kwargs,
+            prompt_raw = await self._render_with_timeout(
+                self._apply_chat_template_async(
+                    model_config,
+                    tokenizer,
+                    conversation,
+                    **chat_template_kwargs,
+                )
             )
 
         # NOTE: use_unified_vision_chunk is currently specific to Kimi-K2.5


### PR DESCRIPTION
…j5j7)

Block unbounded Jinja2 template rendering that allows an authenticated API client to permanently wedge all chat-style endpoints via CPU or memory exhaustion.

Python frontend:
- Reject user-supplied chat_template in /v1/responses chat_template_kwargs (closes the GHSA-jmjw-q4x3-hmc2 gate omission)
- Add static AST validation rejecting dangerous patterns (excessive range(), string multiplication, deeply nested loops) before rendering
- Add configurable async render timeout (VLLM_CHAT_TEMPLATE_RENDER_TIMEOUT)

Rust frontend:
- Enable minijinja fuel feature and set 500K instruction budget per render
- Wrap synchronous render() in tokio::task::spawn_blocking to avoid stalling the shared async runtime
