### PR TITLE
[Model Runner V2][Spec Decode] Gather MM embeddings for all MTP modules

### DIFF
--- a/tests/v1/worker/test_encoder_runner.py
+++ b/tests/v1/worker/test_encoder_runner.py
@@ -2,11 +2,12 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Tests for EncoderRunner.gather_mm_embeddings (model runner V2).
 
-Covers the speculative-drafter encoder-cache handling: the drafter reads one
-position ahead of the target model (``draft_lookahead``). The +1 look-ahead
-feature past the processed boundary is used when its encoder output is present
-and tolerated (token-embedding fallback) when it is not, while a miss within
-the processed range still fails loudly.
+Covers the speculative-drafter encoder-cache handling: the drafter reads
+``draft_lookahead`` positions past the target's processed boundary. The +1
+look-ahead feature past that boundary is used when its encoder output is
+present and tolerated (token-embedding fallback) when it is not, while a miss
+within the processed range still fails loudly. Multi-module MTP looks further
+still, and those positions land in a per-request grid appended to the mask.
 """
 
 import numpy as np
@@ -158,6 +159,69 @@ def test_multi_request_batch_gathers_per_request(draft_lookahead):
     assert len(mm_embeds) == 2
     assert [e.modality for e in mm_embeds] == ["image", "image"]
     assert int(is_mm_embed.sum()) == (14 if draft_lookahead else 16)
+
+
+def test_extra_lookahead_extends_mask_with_per_request_grid():
+    """Multi-module MTP reads ``draft_lookahead`` positions past the target's
+    chunk end. Only the first has a query slot (the +1 skew); the rest land in
+    a dense [num_reqs, draft_lookahead - 1] grid appended to the mask, and
+    their embeddings are appended after every query-window one."""
+    # req0 is mid-prefill and f1 straddles its chunk end, so f1 contributes to
+    # both the query window and the grid. req1 contributes to the grid only,
+    # pinning the per-request row stride. req2 is decoding, so its row stays
+    # empty and must not shift the others.
+    f0 = _feature("f0", offset=0, length=8)
+    f1 = _feature("f1", offset=8, length=4)
+    g0 = _feature("g0", offset=10, length=1)
+    cache = EncoderCache()
+    cache.mm_features["req0"] = [f0, f1]
+    cache.mm_features["req1"] = [g0]
+    cache.mm_features["req2"] = []
+    for f in (f0, f1, g0):
+        length = f.mm_position.length
+        cache.encoder_outputs[f.identifier] = torch.arange(
+            length * HIDDEN, dtype=torch.float32
+        ).reshape(length, HIDDEN)
+    runner = EncoderRunner(
+        model=None,
+        max_num_tokens=64,
+        hidden_size=HIDDEN,
+        encoder_cache=cache,
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+    )
+
+    mm_embeds, is_mm_embed = runner.gather_mm_embeddings(
+        req_ids=["req0", "req1", "req2"],
+        total_num_scheduled_tokens=24,
+        num_scheduled_tokens=np.array([8, 8, 8]),
+        query_start_loc=np.array([0, 8, 16]),
+        prefill_lens=np.array([1000, 1000, 50]),
+        num_computed_tokens=np.array([0, 0, 100]),
+        draft_lookahead=3,
+    )
+
+    # 24 query slots, then one 2-wide grid row per request.
+    assert is_mm_embed.shape == (30,)
+    # req0's query window is positions 1..8 (its chunk 0..7, skewed by one):
+    # f0 marks 1..7 and f1 marks 8. req1 has no feature in its window, and
+    # req2 is decoding.
+    assert bool(is_mm_embed[:8].all())
+    assert not bool(is_mm_embed[8:24].any())
+    # Grid rows: req0 covers positions 9..10 (both f1), req1 covers 9..10 of
+    # which only 10 is g0, req2 contributes nothing.
+    assert is_mm_embed[24:].tolist() == [True, True, False, True, False, False]
+
+    # Query-window embeddings first, then the grid's:
+    # f0[1:8], f1[0:1] | f1[1:3], g0[0:1].
+    assert [tuple(e.shape) for e in mm_embeds] == [
+        (7, HIDDEN),
+        (1, HIDDEN),
+        (2, HIDDEN),
+        (1, HIDDEN),
+    ]
+    # The third entry is f1's grid slice (rows 1..2), not its query slice.
+    assert float(mm_embeds[2][0, 0]) == 4.0
 
 
 def test_gather_preserves_mixed_modalities():

--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -228,7 +228,10 @@ def test_multi_module_mm_support_configured_after_model_load(monkeypatch):
 
     assert speculator.supports_mm_inputs
     assert speculator.inputs_embeds is not None
-    assert speculator.inputs_embeds.shape == (4, 3)
+    # max_num_tokens, plus the future prefill token each of the max_num_reqs
+    # requests may append for each of the num_speculative_steps - 1 later
+    # MTP modules: 4 + 2 * 2.
+    assert speculator.inputs_embeds.shape == (8, 3)
     assert speculator.cached_draft_input_embeds is not None
     assert speculator.cached_draft_input_embeds.shape == (2, 2, 3)
 

--- a/vllm/v1/worker/gpu/mm/encoder_runner.py
+++ b/vllm/v1/worker/gpu/mm/encoder_runner.py
@@ -120,11 +120,28 @@ class EncoderRunner:
         num_computed_tokens: np.ndarray,
         draft_lookahead: int = 0,
     ) -> tuple[list[torch.Tensor], torch.Tensor]:
-        if draft_lookahead:
-            num_computed_tokens = num_computed_tokens + draft_lookahead
+        """Gather cached MM embeddings for the drafter's or target's token window.
 
+        ``draft_lookahead`` is how many positions past the target's chunk end the
+        caller reads: 0 for the target itself, 1 for a single-module drafter, and
+        one more for each later multi-module MTP module. A drafter's slot j holds
+        target token j + 1, so its query window is the target's shifted one
+        position ahead, which consumes the first lookahead position. Any remaining
+        positions have no query slot and land in a dense
+        [num_reqs, max(draft_lookahead - 1, 0)] grid appended to the mask, stopping
+        at the end of each request's known prefill. The matching embeddings are
+        appended after the query window's.
+        """
+
+        window_shift = 1 if draft_lookahead else 0
+        num_extra_lookahead = max(draft_lookahead - 1, 0)
+        num_computed_tokens = num_computed_tokens + window_shift
+
+        num_reqs = len(req_ids)
         is_mm_embed = torch.zeros(
-            total_num_scheduled_tokens, dtype=torch.bool, device="cpu"
+            total_num_scheduled_tokens + num_reqs * num_extra_lookahead,
+            dtype=torch.bool,
+            device="cpu",
         )
 
         # Whether to gather media embeddings this step.
@@ -141,6 +158,7 @@ class EncoderRunner:
         query_end = (num_computed_tokens + num_scheduled_tokens).tolist()
 
         mm_embeds: list[torch.Tensor] = []
+        extra_lookahead_mm_embeds: list[torch.Tensor] = []
         for i, req_id in enumerate(req_ids):
             if exclude_embeddings is not None and exclude_embeddings[i]:
                 continue
@@ -148,53 +166,103 @@ class EncoderRunner:
             cur_query_start = query_start[i]
             cur_query_end = query_end[i]
 
-            mm_features = self.encoder_cache.mm_features[req_id]
-            lo, hi = get_mm_features_in_window(
-                mm_features, start=cur_query_start, end=cur_query_end
+            # The query window sits window_shift positions ahead of the
+            # target's, so undo the shift to recover the target's chunk end.
+            target_chunk_end = cur_query_end - window_shift
+            self._gather_mm_features_in_window(
+                req_id,
+                window_start=cur_query_start,
+                window_end=cur_query_end,
+                is_mm_embed=is_mm_embed,
+                mask_offset=int(query_start_loc[i]) - cur_query_start,
+                mm_embeds=mm_embeds,
+                target_chunk_end=target_chunk_end,
             )
-            for idx in range(lo, hi):
-                mm_feature = mm_features[idx]
-                pos_info = mm_feature.mm_position
-                start_pos = pos_info.offset
-                num_encoder_tokens = pos_info.length
 
-                start_idx = max(cur_query_start - start_pos, 0)
-                end_idx = min(cur_query_end - start_pos, num_encoder_tokens)
-                assert start_idx < end_idx
-                curr_embeds_start, curr_embeds_end = (
-                    pos_info.get_embeds_indices_in_range(start_idx, end_idx)
-                )
-                # If there are no embeddings in the current range, we skip
-                # gathering the embeddings.
-                if curr_embeds_start == curr_embeds_end:
+            # The lookahead positions with no query slot pick up where the
+            # query window ends, and stop at the end of the known prefill.
+            extra_start = cur_query_end
+            extra_end = min(extra_start + num_extra_lookahead, int(prefill_lens[i]))
+            if extra_start >= extra_end:
+                continue
+            self._gather_mm_features_in_window(
+                req_id,
+                window_start=extra_start,
+                window_end=extra_end,
+                is_mm_embed=is_mm_embed,
+                mask_offset=(
+                    total_num_scheduled_tokens + i * num_extra_lookahead - extra_start
+                ),
+                mm_embeds=extra_lookahead_mm_embeds,
+                target_chunk_end=target_chunk_end,
+            )
+
+        # The extra-lookahead embeddings come after all query window ones,
+        # matching their mask positions at the end of the extended mask.
+        return mm_embeds + extra_lookahead_mm_embeds, is_mm_embed
+
+    def _gather_mm_features_in_window(
+        self,
+        req_id: str,
+        window_start: int,
+        window_end: int,
+        is_mm_embed: torch.Tensor,
+        mask_offset: int,
+        mm_embeds: list[torch.Tensor],
+        target_chunk_end: int,
+    ) -> None:
+        """Gather the cached MM embeddings covering [window_start, window_end).
+
+        The mask bit for position p is written at is_mm_embed[mask_offset + p].
+        A feature starting before target_chunk_end was consumed by the target,
+        so a missing encoder output there is a bug; one starting at or after it
+        is only reachable by looking ahead and is skipped on a miss.
+        """
+        mm_features = self.encoder_cache.mm_features[req_id]
+        lo, hi = get_mm_features_in_window(
+            mm_features, start=window_start, end=window_end
+        )
+        for idx in range(lo, hi):
+            mm_feature = mm_features[idx]
+            pos_info = mm_feature.mm_position
+            start_pos = pos_info.offset
+            num_encoder_tokens = pos_info.length
+
+            start_idx = max(window_start - start_pos, 0)
+            end_idx = min(window_end - start_pos, num_encoder_tokens)
+            assert start_idx < end_idx
+            curr_embeds_start, curr_embeds_end = pos_info.get_embeds_indices_in_range(
+                start_idx, end_idx
+            )
+            # If there are no embeddings in the current range, we skip
+            # gathering the embeddings.
+            if curr_embeds_start == curr_embeds_end:
+                continue
+
+            mm_hash = mm_feature.identifier
+            encoder_output = self.encoder_cache.encoder_outputs.get(mm_hash, None)
+            if encoder_output is None:
+                # A feature starting at/after the processed boundary is only
+                # reached via the drafter's look-ahead and might not be encoded
+                # yet; fall back to the token embedding for drafting.
+                if start_pos >= target_chunk_end:
                     continue
+                raise RuntimeError(f"Encoder cache miss for {mm_hash}.")
 
-                mm_hash = mm_feature.identifier
-                encoder_output = self.encoder_cache.encoder_outputs.get(mm_hash, None)
-                if encoder_output is None:
-                    # A feature starting at/after the processed boundary is only
-                    # reached via the drafter's +1 look-ahead and might not be
-                    # encoded yet; fall back to the token embedding for drafting.
-                    if start_pos + draft_lookahead >= cur_query_end:
-                        continue
-                    raise RuntimeError(f"Encoder cache miss for {mm_hash}.")
+            if (is_embed := pos_info.is_embed) is not None:
+                is_embed = is_embed[start_idx:end_idx]
+                mm_embeds_item = encoder_output[curr_embeds_start:curr_embeds_end]
+            else:
+                mm_embeds_item = encoder_output[start_idx:end_idx]
 
-                if (is_embed := pos_info.is_embed) is not None:
-                    is_embed = is_embed[start_idx:end_idx]
-                    mm_embeds_item = encoder_output[curr_embeds_start:curr_embeds_end]
-                else:
-                    mm_embeds_item = encoder_output[start_idx:end_idx]
+            # Attach modality for Omni interleaved merge (collected on demand).
+            set_mm_embedding_modality(mm_embeds_item, mm_feature.modality)
 
-                # Attach modality for Omni interleaved merge (collected on demand).
-                set_mm_embedding_modality(mm_embeds_item, mm_feature.modality)
-
-                req_start_pos = query_start_loc[i] + start_pos - cur_query_start
-                is_mm_embed[req_start_pos + start_idx : req_start_pos + end_idx] |= (
-                    True if is_embed is None else is_embed
-                )
-                mm_embeds.append(mm_embeds_item)
-
-        return mm_embeds, is_mm_embed
+            mask_start_pos = mask_offset + start_pos
+            is_mm_embed[mask_start_pos + start_idx : mask_start_pos + end_idx] |= (
+                True if is_embed is None else is_embed
+            )
+            mm_embeds.append(mm_embeds_item)
 
     @torch.inference_mode()
     def get_inputs_embeds(

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -658,10 +658,19 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             assert self.sampler is not None
             mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None
             if self.speculator.supports_mm_inputs:
+                assert self.speculative_config is not None
+                # Mirror gather_mm_embeddings' layout: the query window, then a
+                # dense grid holding the lookahead positions.
+                mm_draft_lookahead = (
+                    self.num_speculative_steps
+                    if self.speculative_config.use_multi_module_mtp()
+                    else 1
+                )
                 mm_inputs = (
                     [],
                     torch.zeros(
-                        input_batch.num_tokens,
+                        input_batch.num_tokens
+                        + input_batch.num_reqs * (mm_draft_lookahead - 1),
                         dtype=torch.bool,
                         device="cpu",
                     ),
@@ -1587,11 +1596,17 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             # Get cached multimodal embeddings for draft forward.
             # NOTE: This is done here because postprocess updates
             # num_computed_prefill_tokens.
-            # The EAGLE/MTP drafter reads one position ahead of the target.
-            # TODO(TheEpicDolphin): Gather MM embeddings for all speculative
-            # steps during multi-module MTP.
+            # EAGLE/single-module MTP reads one position ahead of the target.
+            # Multi-module MTP reads one further for each later module.
+            assert self.speculative_config is not None
+            mm_draft_lookahead = (
+                self.num_speculative_steps
+                if self.speculative_config.use_multi_module_mtp()
+                else 1
+            )
             mm_inputs = self.model_state.gather_mm_embeddings(
-                input_batch, draft_lookahead=1
+                input_batch,
+                draft_lookahead=mm_draft_lookahead,
             )
 
         # Postprocess results and update request states.

--- a/vllm/v1/worker/gpu/spec_decode/multi_module_mtp/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/multi_module_mtp/speculator.py
@@ -30,6 +30,18 @@ class MultiModuleMTPSpeculator(DraftModelSpeculator):
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
         super().__init__(vllm_config, device)
 
+        self.input_buffers = InputBuffers(
+            max_num_reqs=self.max_num_reqs,
+            # Extend max_num_tokens by the future prefill token each request may
+            # append for each of the last num_speculative_steps - 1 MTP modules.
+            max_num_tokens=(
+                self.max_num_tokens
+                + self.max_num_reqs * (self.num_speculative_steps - 1)
+            ),
+            device=device,
+        )
+        self.inputs_embeds: torch.Tensor | None = None
+
         self.hidden_states = torch.zeros(
             self.max_num_tokens, self.hidden_size, dtype=self.dtype, device=device
         )
@@ -38,16 +50,14 @@ class MultiModuleMTPSpeculator(DraftModelSpeculator):
             self.max_num_reqs, dtype=torch.int64, device=device
         )
 
-        self.inputs_embeds: torch.Tensor | None = None
-
-        # Input id overrides for the last num_speculative_steps - 1 draft steps.
-        # Used by chunked-prefilling requests to swap in the future prefill token
-        # for the sampled draft token. Non-chunked-prefilling requests fill the -1
-        # value, indicating that the sampled draft token should be used.
-        self.draft_input_id_overrides = torch.full(
-            (self.max_num_reqs, self.num_speculative_steps - 1),
-            -1,
-            dtype=torch.int64,
+        # Whether each of the last num_speculative_steps - 1 draft steps appends
+        # a known future prefill token rather than the token sampled from that
+        # step's draft. True only for chunked-prefilling requests, and only for
+        # steps that land inside the request's remaining prefill.
+        self.is_next_prefill_token = torch.zeros(
+            self.max_num_reqs,
+            self.num_speculative_steps - 1,
+            dtype=torch.bool,
             device=device,
         )
 
@@ -84,7 +94,9 @@ class MultiModuleMTPSpeculator(DraftModelSpeculator):
             return
 
         self.inputs_embeds = torch.zeros(
-            self.max_num_tokens,
+            # Extend max_num_tokens by the future prefill token each request may
+            # append for each of the last num_speculative_steps - 1 MTP modules.
+            self.max_num_tokens + self.max_num_reqs * (self.num_speculative_steps - 1),
             self.hidden_size,
             dtype=self.dtype,
             device=self.device,
@@ -322,13 +334,14 @@ class MultiModuleMTPSpeculator(DraftModelSpeculator):
         num_reqs = input_batch.num_reqs
         prepare_input_buffers(
             num_reqs,
+            num_tokens,
             input_batch,
             self.cached_draft_input_ids,
             num_sampled,
             num_rejected,
             last_sampled,
             next_prefill_tokens,
-            self.draft_input_id_overrides,
+            self.is_next_prefill_token,
             self.input_buffers,
             self.last_token_indices,
             self.max_num_reqs,
@@ -337,20 +350,27 @@ class MultiModuleMTPSpeculator(DraftModelSpeculator):
 
         # Compute the input embeddings with the MM embeddings merged in.
         # TODO(TheEpicDolphin): When the batch has no MM content (is_mm_embed
-        # all False), skip this embed/copy and run the model with
-        # inputs_embeds=None. Requirements:
+        # all False, which now spans the future prefill tokens too), skip this
+        # embed and run the model with inputs_embeds=None. Requirements:
         # 1. Eager steps can switch freely, but FULL cudagraphs bake the
-        # embeds/no-embeds path at capture, so extending to decode steps
-        # needs a uses_input_embeds property in the graph descriptors,
-        # resulting in 2x captures.
+        # embeds/no-embeds path at capture. FULL needs a uniform token count,
+        # i.e. an all-decode batch, which carries no MM content -- so capturing
+        # only the no-embeds path and forcing need_eager when embeds are
+        # required avoids 2x captures. need_eager is a per-rank host decision
+        # though, so it needs an allreduce before dispatch or DP ranks desync.
         # 2. The skip condition must also verify the request's cached
         # re-prefill window (cached_draft_input_embeds) holds no MM
         # embeddings, or the rejection re-prefill gap would be re-embedded
         # from token ids incorrectly.
         if self.inputs_embeds is not None:
             mm_embeds, is_mm_embed = mm_inputs or (None, None)
-            self.inputs_embeds[:num_tokens] = self.model.embed_input_ids(
-                self.input_buffers.input_ids[:num_tokens],
+            # Embed the query tokens and the future prefill tokens staged after
+            # them in one pass. EncoderRunner.gather_mm_embeddings lays is_mm_embed
+            # out to match this exact slice: packed query tokens, then the dense
+            # [num_reqs, num_speculative_steps - 1] grid.
+            num_embed_tokens = num_tokens + num_reqs * (self.num_speculative_steps - 1)
+            self.inputs_embeds[:num_embed_tokens] = self.model.embed_input_ids(
+                self.input_buffers.input_ids[:num_embed_tokens],
                 multimodal_embeddings=mm_embeds,
                 is_multimodal=is_mm_embed,
             )
@@ -428,25 +448,23 @@ class MultiModuleMTPSpeculator(DraftModelSpeculator):
             self.draft_tokens[:num_reqs, step] = draft_tokens
             if step < self.num_speculative_steps - 1:
                 self.hidden_states[:num_tokens] = hidden_states
-                # Mid-prefill requests append the known future prefill token
-                # instead of the sampled draft.
-                overrides = self.draft_input_id_overrides[:num_reqs, step]
-                next_input_tokens = torch.where(overrides >= 0, overrides, draft_tokens)
-                # Shift the draft inputs left by one and append the next
-                # input token id/embeddings.
-                draft_embeds = (
-                    self.model.embed_input_ids(next_input_tokens)
-                    if self.inputs_embeds is not None
-                    else None
-                )
+                # Shift the draft inputs left by one and append this step's
+                # drafted token id/embedding. Mid-prefill requests append their
+                # known future prefill token/embedding.
+                draft_embeds = None
+                if self.inputs_embeds is not None:
+                    draft_embeds = self.model.embed_input_ids(draft_tokens)
                 update_draft_inputs(
-                    next_input_tokens,
+                    draft_tokens,
                     draft_embeds,
+                    self.is_next_prefill_token,
+                    step,
                     self.input_buffers,
                     self.inputs_embeds,
                     last_token_indices,
                     idx_mapping,
                     num_reqs,
+                    self.num_speculative_steps,
                 )
                 sample_positions += 1
 
@@ -461,16 +479,17 @@ def _prepare_input_buffers_kernel(
     target_positions_ptr,
     cached_draft_input_ids_ptr,
     cached_draft_input_ids_stride0,
-    draft_input_id_overrides_ptr,
-    draft_input_id_overrides_stride0,
     idx_mapping_ptr,
     last_sampled_ptr,
     next_prefill_tokens_ptr,
     next_prefill_tokens_stride0,
+    is_next_prefill_token_ptr,
+    is_next_prefill_token_stride,
     num_sampled_ptr,
     num_rejected_ptr,
     target_seq_lens_ptr,
     query_start_loc_ptr,
+    total_num_tokens,
     max_num_reqs,
     num_speculative_steps,
     BLOCK_SIZE: tl.constexpr,
@@ -502,30 +521,6 @@ def _prepare_input_buffers_kernel(
     # Write the updated sequence length.
     tl.store(draft_seq_lens_ptr + req_idx, seq_len)
 
-    # Get the next draft input token.
-    num_sampled = tl.load(num_sampled_ptr + req_idx)
-    if num_sampled > 0:
-        next_token = tl.load(last_sampled_ptr + req_state_idx).to(tl.int32)
-    else:
-        # Chunked prefill. Seed with the next prefill token.
-        next_token = tl.load(next_prefill_tokens_ptr + req_state_idx)
-
-    # For chunked-prefilling requests, copy the future prefill tokens that
-    # will later override the input token ids for the last
-    # num_speculative_steps - 1 draft steps.
-    for i in range(1, num_speculative_steps):
-        future_token = tl.load(
-            next_prefill_tokens_ptr + i * next_prefill_tokens_stride0 + req_state_idx
-        )
-        override = tl.where(num_sampled > 0, -1, future_token).to(tl.int64)
-        tl.store(
-            draft_input_id_overrides_ptr
-            + req_idx * draft_input_id_overrides_stride0
-            + i
-            - 1,
-            override,
-        )
-
     # Copy the target's input ids (read at the target offset) shifted left by 1,
     # and right by the number of re-prefills, into the draft buffer.
     for i in range(1, num_input_tokens, BLOCK_SIZE):
@@ -539,7 +534,38 @@ def _prepare_input_buffers_kernel(
         )
     last_token_index = query_start + num_reprefill_tokens + num_input_tokens - 1
     tl.store(last_token_indices_ptr + req_idx, last_token_index)
+
+    # Get the next draft input token.
+    num_sampled = tl.load(num_sampled_ptr + req_idx)
+    if num_sampled > 0:
+        next_token = tl.load(last_sampled_ptr + req_state_idx).to(tl.int32)
+    else:
+        # Chunked prefill. Seed with the next prefill token.
+        next_token = tl.load(next_prefill_tokens_ptr + req_state_idx)
     tl.store(draft_input_ids_ptr + last_token_index, next_token)
+
+    # Stage the future prefill token each of the last num_speculative_steps - 1
+    # draft steps will append, and flag which of those steps actually has one.
+    # next_prefill_tokens already holds 0 past the end of the request's prefill.
+    for i in range(num_speculative_steps - 1):
+        next_prefill_token = tl.load(
+            next_prefill_tokens_ptr
+            + (i + 1) * next_prefill_tokens_stride0
+            + req_state_idx
+        )
+        is_next_prefill = (num_sampled == 0) & (next_prefill_token > 0)
+        tl.store(
+            is_next_prefill_token_ptr + req_idx * is_next_prefill_token_stride + i,
+            is_next_prefill,
+        )
+        # Store the next prefill tokens at the end of the draft input ids.
+        tl.store(
+            draft_input_ids_ptr
+            + total_num_tokens
+            + req_idx * (num_speculative_steps - 1)
+            + i,
+            tl.where(is_next_prefill, next_prefill_token, 0),
+        )
 
     # Copy the target's positions, shifted over by the number of tokens to be
     # re-prefilled.
@@ -590,6 +616,7 @@ def _prepare_input_buffers_kernel(
 
 def prepare_input_buffers(
     num_reqs: int,
+    num_tokens: int,
     input_batch: InputBatch,
     # [max_num_reqs, num_speculative_steps - 1]
     cached_draft_input_ids: torch.Tensor,
@@ -602,7 +629,7 @@ def prepare_input_buffers(
     # [num_prefill_lookahead, max_num_reqs]
     next_prefill_tokens: torch.Tensor,
     # [max_num_reqs, num_speculative_steps - 1]
-    draft_input_id_overrides: torch.Tensor,
+    is_next_prefill_token: torch.Tensor,
     input_buffers: InputBuffers,
     # [max_num_reqs]
     last_token_indices: torch.Tensor,
@@ -618,16 +645,17 @@ def prepare_input_buffers(
         input_batch.positions,
         cached_draft_input_ids,
         cached_draft_input_ids.stride(0) if cached_draft_input_ids is not None else 0,
-        draft_input_id_overrides,
-        draft_input_id_overrides.stride(0),
         input_batch.idx_mapping,
         last_sampled,
         next_prefill_tokens,
         next_prefill_tokens.stride(0),
+        is_next_prefill_token,
+        is_next_prefill_token.stride(0),
         num_sampled,
         num_rejected,
         input_batch.seq_lens,
         input_buffers.query_start_loc,
+        num_tokens,
         max_num_reqs,
         num_speculative_steps,
         BLOCK_SIZE=1024,
@@ -973,15 +1001,31 @@ def cache_inputs(
 
 
 @triton.jit
+def _next_prefill_token_row(
+    query_start_loc_ptr, num_reqs, req_idx, step, num_speculative_steps
+):
+    return (
+        tl.load(query_start_loc_ptr + num_reqs)
+        + req_idx * (num_speculative_steps - 1)
+        + step
+    )
+
+
+@triton.jit
 def _shift_input_ids_kernel(
     input_ids_ptr,
     idx_mapping_ptr,
     query_start_loc_ptr,
     last_token_indices_ptr,
     draft_tokens_ptr,
+    is_next_prefill_token_ptr,
+    is_next_prefill_token_stride,
+    step,
+    num_speculative_steps,
     BLOCK_SIZE: tl.constexpr,
 ):
     req_idx = tl.program_id(0)
+    num_reqs = tl.num_programs(0)
     req_state_idx = tl.load(idx_mapping_ptr + req_idx)
     if req_state_idx < 0:
         # Skip cudagraph padded requests.
@@ -994,14 +1038,25 @@ def _shift_input_ids_kernel(
     query_len = last_token_index - query_start + 1
 
     # Shift input token ids to the left by one position and
-    # insert the last sampled draft token.
+    # insert this step's input token.
     for i in range(1, query_len, BLOCK_SIZE):
         block = i + tl.arange(0, BLOCK_SIZE)
         mask = block < query_len
         input_ids = tl.load(input_ids_ptr + query_start + block, mask=mask)
         tl.store(input_ids_ptr + query_start + block - 1, input_ids, mask=mask)
-    draft_token = tl.load(draft_tokens_ptr + req_idx)
-    tl.store(input_ids_ptr + last_token_index, draft_token)
+
+    # Mid-prefill requests append their known future prefill token.
+    # The rest append this step's sampled draft token id.
+    if tl.load(
+        is_next_prefill_token_ptr + req_idx * is_next_prefill_token_stride + step
+    ):
+        row = _next_prefill_token_row(
+            query_start_loc_ptr, num_reqs, req_idx, step, num_speculative_steps
+        )
+        next_token = tl.load(input_ids_ptr + row)
+    else:
+        next_token = tl.load(draft_tokens_ptr + req_idx).to(tl.int32)
+    tl.store(input_ids_ptr + last_token_index, next_token)
 
 
 @triton.jit
@@ -1010,14 +1065,19 @@ def _shift_input_embeds_kernel(
     input_embeds_stride0,
     draft_embeds_ptr,
     draft_embeds_stride0,
+    is_next_prefill_token_ptr,
+    is_next_prefill_token_stride,
     idx_mapping_ptr,
     query_start_loc_ptr,
     last_token_indices_ptr,
+    step,
+    num_speculative_steps,
     hidden_size,
     BLOCK_SIZE_Q: tl.constexpr,
     BLOCK_SIZE_H: tl.constexpr,
 ):
     req_idx = tl.program_id(0)
+    num_reqs = tl.num_programs(0)
     req_state_idx = tl.load(idx_mapping_ptr + req_idx)
     if req_state_idx < 0:
         # Skip cudagraph padded requests.
@@ -1032,7 +1092,7 @@ def _shift_input_embeds_kernel(
     query_len = last_token_index - query_start + 1
 
     # Shift input token embeddings to the left by one position and
-    # insert the last sampled draft token's embeddings.
+    # insert this step's input token embedding.
     for i in range(1, query_len, BLOCK_SIZE_Q):
         query_block = i + tl.arange(0, BLOCK_SIZE_Q)
         query_mask = query_block < query_len
@@ -1050,25 +1110,45 @@ def _shift_input_embeds_kernel(
             input_embed,
             mask=mask,
         )
-    draft_embed = tl.load(
-        draft_embeds_ptr + req_idx * draft_embeds_stride0 + dim_block,
-        mask=dim_mask,
-    )
+
+    # Mid-prefill requests append their known future prefill token embeddings.
+    # The rest append the embedding of this step's sampled draft token.
+    if tl.load(
+        is_next_prefill_token_ptr + req_idx * is_next_prefill_token_stride + step
+    ):
+        row = _next_prefill_token_row(
+            query_start_loc_ptr, num_reqs, req_idx, step, num_speculative_steps
+        )
+        next_embed = tl.load(
+            input_embeds_ptr + row * input_embeds_stride0 + dim_block,
+            mask=dim_mask,
+        )
+    else:
+        next_embed = tl.load(
+            draft_embeds_ptr + req_idx * draft_embeds_stride0 + dim_block,
+            mask=dim_mask,
+        )
     tl.store(
         input_embeds_ptr + last_token_index * input_embeds_stride0 + dim_block,
-        draft_embed,
+        next_embed,
         mask=dim_mask,
     )
 
 
 def update_draft_inputs(
+    # [num_reqs]
     draft_tokens: torch.Tensor,
+    # [num_reqs, hidden_size]
     draft_embeds: torch.Tensor | None,
+    # [max_num_reqs, num_speculative_steps - 1]
+    is_next_prefill_token: torch.Tensor,
+    step: int,
     input_buffers: InputBuffers,
     input_embeds: torch.Tensor | None,
     last_token_indices: torch.Tensor,
     idx_mapping: torch.Tensor,
     num_reqs: int,
+    num_speculative_steps: int,
 ) -> None:
     _shift_input_ids_kernel[(num_reqs,)](
         input_buffers.input_ids,
@@ -1076,6 +1156,10 @@ def update_draft_inputs(
         input_buffers.query_start_loc,
         last_token_indices,
         draft_tokens,
+        is_next_prefill_token,
+        is_next_prefill_token.stride(0),
+        step,
+        num_speculative_steps,
         BLOCK_SIZE=1024,
     )
     if input_embeds is not None:
@@ -1089,9 +1173,13 @@ def update_draft_inputs(
             input_embeds.stride(0),
             draft_embeds,
             draft_embeds.stride(0),
+            is_next_prefill_token,
+            is_next_prefill_token.stride(0),
             idx_mapping,
             input_buffers.query_start_loc,
             last_token_indices,
+            step,
+            num_speculative_steps,
             hidden_size,
             BLOCK_SIZE_Q=16,
             BLOCK_SIZE_H=hidden_block_size,


### PR DESCRIPTION
# Context
Currently, the last N-1 MTP layers will not receive MM embeddings past the chunk boundary during chunked prefill. In such cases, the multi-modal padding token embeddings are instead used. This means that the last N-1 MTP layer KV caches will technically have incorrect values stored, theoretically causing suboptimal acceptance rates.