### PR TITLE
[DOC][CPU] remove tcmalloc warning from CPU docs

### DIFF
--- a/docs/getting_started/installation/cpu.arm.inc.md
+++ b/docs/getting_started/installation/cpu.arm.inc.md
@@ -28,20 +28,6 @@ uv pip install https://github.com/vllm-project/vllm/releases/download/v${VLLM_VE
     pip install https://github.com/vllm-project/vllm/releases/download/v${VLLM_VERSION}/vllm-${VLLM_VERSION}+cpu-cp38-abi3-manylinux_2_34_aarch64.whl --extra-index-url https://download.pytorch.org/whl/cpu
     ```
 
-!!! warning "set `LD_PRELOAD`"
-    Before use vLLM CPU installed via wheels, make sure TCMalloc is installed and added to `LD_PRELOAD`:
-    ```bash
-    # install TCMalloc
-    sudo apt-get install -y --no-install-recommends libtcmalloc-minimal4
-
-    # manually find the path
-    sudo find / -iname *libtcmalloc_minimal.so.4
-    TC_PATH=...
-
-    # add them to LD_PRELOAD
-    export LD_PRELOAD="$TC_PATH:$LD_PRELOAD"
-    ```
-
 The `uv` approach works for vLLM `v0.6.6` and later. A unique feature of `uv` is that packages in `--extra-index-url` have [higher priority than the default index](https://docs.astral.sh/uv/pip/compatibility/#packages-that-exist-on-multiple-indexes). If the latest public release is `v0.6.6.post1`, `uv`'s behavior allows installing a commit before `v0.6.6.post1` by specifying the `--extra-index-url`. In contrast, `pip` combines packages from `--extra-index-url` and the default index, choosing only the latest version, which makes it difficult to install a development version prior to the released version.
 
 #### Install the latest code

--- a/docs/getting_started/installation/cpu.x86.inc.md
+++ b/docs/getting_started/installation/cpu.x86.inc.md
@@ -33,19 +33,14 @@ uv pip install https://github.com/vllm-project/vllm/releases/download/v${VLLM_VE
     pip install https://github.com/vllm-project/vllm/releases/download/v${VLLM_VERSION}/vllm-${VLLM_VERSION}+cpu-cp38-abi3-manylinux_2_34_x86_64.whl --extra-index-url https://download.pytorch.org/whl/cpu
     ```
 !!! warning "set `LD_PRELOAD`"
-    Before use vLLM CPU installed via wheels, make sure TCMalloc and Intel OpenMP are installed and added to `LD_PRELOAD`:
+    Before use vLLM CPU installed via wheels, make Intel OpenMP is added to `LD_PRELOAD`:
     ```bash
-    # install TCMalloc, Intel OpenMP is installed with vLLM CPU
-    sudo apt-get install -y --no-install-recommends libtcmalloc-minimal4
-
     # manually find the path
-    sudo find / -iname *libtcmalloc_minimal.so.4
     sudo find / -iname *libiomp5.so
-    TC_PATH=...
     IOMP_PATH=...
 
-    # add them to LD_PRELOAD
-    export LD_PRELOAD="$TC_PATH:$IOMP_PATH:$LD_PRELOAD"
+    # add it to LD_PRELOAD
+    export LD_PRELOAD="$IOMP_PATH:$LD_PRELOAD"
     ```
 
 #### Install the latest code
@@ -131,7 +126,7 @@ uv pip install dist/*.whl
     ```
 
 !!! warning "set `LD_PRELOAD`"
-    Before use vLLM CPU installed via wheels, make sure TCMalloc and Intel OpenMP are installed and added to `LD_PRELOAD`:
+    Before using vLLM CPU installed via wheels, make sure TCMalloc and Intel OpenMP are installed and added to `LD_PRELOAD`:
     ```bash
     # install TCMalloc, Intel OpenMP is installed with vLLM CPU
     sudo apt-get install -y --no-install-recommends libtcmalloc-minimal4


### PR DESCRIPTION
## Purpose

This is no longer needed as tcmalloc now is now bundled into the CPU wheel and ldpreloaded by default since: https://github.com/vllm-project/vllm/pull/37607

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

