### PR TITLE
[ROCm][CI] Avoid Ray worker startup env race

### DIFF
--- a/requirements/test/rocm.in
+++ b/requirements/test/rocm.in
@@ -21,7 +21,7 @@ vector_quantize_pytorch # required for minicpmo_26 test
 vocos # required for minicpmo_26 test
 peft>=0.19.1 # required for phi-4-mm test
 pqdm
-ray[cgraph,default]>=2.48.0 # Ray Compiled Graph, required by pipeline parallelism tests
+ray[cgraph,default]==2.55.1 # Includes worker startup getenv/setenv race fix
 sentence-transformers>=5.2.0 # required for embedding tests
 soundfile # required for audio tests
 jiwer # required for audio tests

--- a/requirements/test/rocm.txt
+++ b/requirements/test/rocm.txt
@@ -956,7 +956,7 @@ rapidfuzz==3.12.1
     # via
     #   -r requirements/test/rocm.in
     #   jiwer
-ray==2.54.0
+ray==2.55.1
     # via -r requirements/test/rocm.in
 redis==7.3.0
     # via tensorizer


### PR DESCRIPTION
- No vLLM PR introduced this failure: the good and failing builds used the same Ray 2.54.0 pin and byte-identical Ray executor and pipeline-test code.
- The vulnerable async metrics-exporter initialization came from [Ray #55152](https://github.com/ray-project/ray/pull/55152); the `getenv`/`setenv` race was fixed by [Ray #61034](https://github.com/ray-project/ray/pull/61034) and [Ray #61281](https://github.com/ray-project/ray/pull/61281).
- [Ray 2.55.0](https://github.com/ray-project/ray/releases/tag/ray-2.55.0) is the first release containing the fix, and ROCm CI is pinned to its 2.55.1 patch release.
- The same PP=4 test passed in [AMD CI build 11413](https://buildkite.com/vllm/amd-ci/builds/11413#019facb1-b728-4bd0-a23a-5f2a280404df), confirming the failure was intermittent rather than a deterministic vLLM source regression.

Motivation: 
- [AMD CI build 11417 — RayExecutorV2 (4 GPUs)](https://buildkite.com/vllm/amd-ci/builds/11417/list?sid=019fad1a-5180-4a0b-877b-bbaea3cca6c6&tab=output): one Ray actor crashed in libc `getenv` while importing its class.