### PR TITLE
Revert "[Misc][Minimax-M3]add default video_processor (#50092)"

### DIFF
--- a/tests/multimodal/test_video.py
+++ b/tests/multimodal/test_video.py
@@ -14,7 +14,6 @@ from transformers import AutoVideoProcessor
 from transformers.video_utils import VideoMetadata
 
 from vllm.assets.base import get_vllm_public_assets
-from vllm.models.minimax_m3.common.mm_preprocess import MiniMaxM3VideoBackend
 from vllm.multimodal.video import (
     PYNVVIDEOCODEC_DECODER_CACHE_SIZE,
     PYNVVIDEOCODEC_VIDEO_BACKEND,
@@ -388,12 +387,6 @@ def test_cosmos3_edge_uses_qwen3_vl_video_backend():
             Qwen2VLVideoBackend,
             {"fps": 2},
             id="qwen2_5_vl",
-        ),
-        pytest.param(
-            "MiniMaxAI/MiniMax-M3",
-            MiniMaxM3VideoBackend,
-            None,
-            id="minimax_m3_vl",
         ),
     ],
 )

--- a/vllm/models/minimax_m3/common/mm_preprocess.py
+++ b/vllm/models/minimax_m3/common/mm_preprocess.py
@@ -3,9 +3,8 @@
 
 import math
 from collections.abc import Mapping, Sequence
-from typing import Any, Literal, cast
+from typing import cast
 
-import numpy.typing as npt
 import torch
 from transformers import BatchFeature
 from transformers.video_utils import VideoMetadata
@@ -470,39 +469,10 @@ class MiniMaxM3VLMultiModalProcessor(
         ]
 
 
-@VIDEO_LOADER_REGISTRY.register(
-    name="minimax_m3_vl",
-    video_processor="MiniMaxM3VLVideoProcessor",
-)
+# TODO(Isotr0py): Tie with MinimaxVideoProcessor
+# after https://github.com/vllm-project/vllm/pull/44126
+@VIDEO_LOADER_REGISTRY.register("minimax_m3_vl")
 class MiniMaxM3VideoBackend(VideoBackend):
-    @classmethod
-    def load_bytes(
-        cls,
-        data: bytes,
-        num_frames: int = -1,
-        fps: int = 1,
-        max_duration: int = 300,
-        frame_recovery: bool = False,
-        *,
-        backend: Literal[
-            "opencv",
-            "pyav",
-            "torchcodec",
-            "pynvvideocodec",
-            "deepstream",
-        ] = "opencv",
-        **kwargs,
-    ) -> tuple[npt.NDArray, dict[str, Any]]:
-        return super().load_bytes(
-            data,
-            num_frames=num_frames,
-            fps=fps,
-            max_duration=max_duration,
-            frame_recovery=frame_recovery,
-            backend=backend,
-            **kwargs,
-        )
-
     @classmethod
     def compute_frames_index_to_sample(
         cls,
@@ -513,6 +483,7 @@ class MiniMaxM3VideoBackend(VideoBackend):
         total_frames = source.total_frames_num
         video_fps = source.original_fps
         fps = target.fps
+
         if total_frames <= 0 or video_fps <= 0 or fps <= 0:
             return [0] if total_frames > 0 else []
 
@@ -532,9 +503,8 @@ class MiniMaxM3VideoBackend(VideoBackend):
                 break
             indices.append(target_frame)
             prev_kept_ts = target_frame / video_fps
-        # Because HF sample_frames includes the last frame,
-        # we will use HF as the standard.
-        last_frame_idx = total_frames
+
+        last_frame_idx = total_frames - 1
         last_ts = last_frame_idx / video_fps
         if indices and indices[-1] != last_frame_idx and last_ts - prev_kept_ts > eps:
             indices.append(last_frame_idx)


### PR DESCRIPTION
This reverts commit df2735ea2e14b377ce71571ed27a63b9ceae2ba3 from PR https://github.com/vllm-project/vllm/pull/50092 which broke a CI test:

```
vllm/compilation/passes/fusion/rms_quant_fusion.py:121: in <module>
    ): torch.ops._C.rms_norm_static_fp8_quant.default,  # noqa: E501
torch/_ops.py:1392: in __getattr__
    raise AttributeError(
E   AttributeError: '_OpNamespace' '_C' object has no attribute 'rms_norm_static_fp8_quant'
```
