### PR TITLE
[ROCm][Kimi-K3] Enable gfx942 serving

### DIFF
--- a/docker/Dockerfile.rocm_k3_gfx942
+++ b/docker/Dockerfile.rocm_k3_gfx942
@@ -1,0 +1,42 @@
+# Kimi-K3 on gfx942 (MI300/MI325).
+#
+# The published ROCm base images ship AITER v0.1.16.post5, which cannot run
+# Kimi-K3 at all: the vision tower imports aiter.ops.triton.conv.conv2d, and
+# that module first appears in v0.1.19. v0.1.19 also carries the tuned SiTUv2
+# MoE kernels and the tuned Kimi-K3 GEMM configs.
+#
+# Rebuilding the whole base from Dockerfile.rocm_base to move one dependency
+# costs hours and reproduces bit-identical torch, triton, flash-attention and
+# MORI, because those are pinned to the same commits. This layer swaps only
+# AITER on top of an image already built by Dockerfile.rocm.
+#
+# Build:
+#   docker build -f docker/Dockerfile.rocm_k3_gfx942 \
+#     --build-arg BASE_IMAGE=<image built from docker/Dockerfile.rocm> \
+#     -t <tag> .
+#
+# Serving Kimi-K3 on gfx942 additionally needs VLLM_ROCM_USE_AITER_MLA=0. The
+# AITER MLA backend wins selection at TP8 (12 heads per rank) and then asserts
+# inside a Gluon kernel that is gfx950-only.
+
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+ARG AITER_REPO="https://github.com/maeehart/aiter.git"
+ARG AITER_BRANCH="maeehart/kimi-k3-gfx942-tuning"
+# Add gfx950 to serve both MI325 and MI355 from one image, at the cost of
+# roughly double the kernel prebuild time.
+ARG GPU_ARCHS="gfx942"
+
+# aiter cannot be imported here to verify the install: rocminfo needs /dev/kfd
+# and the build container has no GPU. Verification happens at runtime.
+RUN rm -rf /app/aiter \
+    && git clone --recursive --branch ${AITER_BRANCH} ${AITER_REPO} /app/aiter \
+    && cd /app/aiter \
+    && git submodule update --init --recursive \
+    && pip install -r requirements.txt \
+    && pip install pyyaml \
+    && PREBUILD_KERNELS=1 AITER_USE_SYSTEM_TRITON=1 GPU_ARCHS=${GPU_ARCHS} \
+       python3 setup.py bdist_wheel --dist-dir=dist \
+    && pip install --force-reinstall --no-deps dist/*.whl \
+    && rm -rf /app/aiter/build /app/aiter/dist

--- a/docker/Dockerfile.rocm_k3_gfx942
+++ b/docker/Dockerfile.rocm_k3_gfx942
@@ -22,8 +22,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ARG AITER_REPO="https://github.com/maeehart/aiter.git"
-ARG AITER_BRANCH="maeehart/kimi-k3-gfx942-tuning"
+ARG AITER_REPO="https://github.com/ROCm/aiter.git"
+ARG AITER_BRANCH="v0.1.19"
 # Add gfx950 to serve both MI325 and MI355 from one image, at the cost of
 # roughly double the kernel prebuild time.
 ARG GPU_ARCHS="gfx942"

--- a/tests/models/kimi_k3/test_amd_attn_res.py
+++ b/tests/models/kimi_k3/test_amd_attn_res.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from vllm.models.kimi_k3.amd.ops.attn_res import attn_res
+from vllm.models.kimi_k3.amd.ops.attn_res import attn_res, attn_res_fused
 from vllm.platforms import current_platform
 
 pytestmark = pytest.mark.skipif(
@@ -100,3 +100,56 @@ def test_amd_attn_res_matches_reference(
     torch.testing.assert_close(blocks, original_blocks, atol=0, rtol=0)
     assert actual.shape == prefix.shape
     assert actual.is_contiguous()
+
+
+@pytest.mark.parametrize("num_tokens", [1, 17, 320])
+@pytest.mark.parametrize("has_addend", [False, True])
+def test_amd_attn_res_fused_matches_reference(
+    num_tokens: int,
+    has_addend: bool,
+) -> None:
+    hidden_size = 7168
+    num_blocks = 4
+    eps = 1e-5
+    prefix = _randn_with_row_padding(num_tokens, hidden_size)
+    addend = torch.randn_like(prefix) if has_addend else None
+    blocks = _randn_with_row_padding(num_tokens, num_blocks, hidden_size)
+    norm_weight = torch.randn(hidden_size, device="cuda", dtype=torch.bfloat16)
+    qk_weight = (
+        torch.randn(hidden_size, device="cuda", dtype=torch.bfloat16) / hidden_size**0.5
+    )
+    out_norm_weight = torch.randn_like(norm_weight)
+
+    expected_prefix = prefix + addend if addend is not None else prefix
+    expected = _reference(
+        expected_prefix,
+        blocks,
+        norm_weight,
+        qk_weight,
+        num_blocks,
+        eps,
+    )
+    expected = F.rms_norm(
+        expected.to(torch.bfloat16),
+        (hidden_size,),
+        out_norm_weight,
+        eps,
+    )
+
+    actual, actual_prefix = attn_res_fused(
+        prefix,
+        blocks,
+        norm_weight,
+        qk_weight,
+        num_blocks,
+        eps,
+        addend=addend,
+        out_norm_weight=out_norm_weight,
+        out_norm_eps=eps,
+    )
+
+    torch.testing.assert_close(actual, expected, atol=8e-2, rtol=3e-2)
+    if has_addend:
+        torch.testing.assert_close(actual_prefix, expected_prefix, atol=0, rtol=0)
+    else:
+        assert actual_prefix is None

--- a/vllm/config/quantization.py
+++ b/vllm/config/quantization.py
@@ -15,6 +15,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8Static128BlockSym,
     kFp8StaticChannelSym,
     kFp8StaticTensorSym,
+    kInt4Static32,
     kInt8StaticChannelSym,
     kMxfp4Dynamic,
     kMxfp8Dynamic,
@@ -32,6 +33,10 @@ QUANT_KEY_NAMES: dict[str, QuantKey] = {
     "mxfp8": kMxfp8Dynamic,
     "mxfp4": kMxfp4Dynamic,
     "int8_per_channel_static": kInt8StaticChannelSym,
+    # Groupwise int4 with a 32-element group. Used by the Kimi-K3 gfx942
+    # path, where MXFP4 experts are requantized so AITER's bf16 x int4
+    # kernels can run on hardware without a scaled MXFP4 MFMA.
+    "int4_per_group_32": kInt4Static32,
 }
 
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -131,6 +131,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_LINEAR_HIPBMM: bool = False
     VLLM_ROCM_USE_AITER_MOE: bool = True
     VLLM_ROCM_AITER_MOE_DISPATCH_POLICY: int = 0
+    VLLM_KIMI_ROW_PARALLEL_LATENT_UP_PROJ: int = 0
     AITER_SITUV2_A8W4: bool = False
     VLLM_ROCM_USE_AITER_RMSNORM: bool = True
     VLLM_ROCM_USE_AITER_MLA: bool = True
@@ -1226,6 +1227,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     #       see PR #39177 for benchmarks)
     "VLLM_ROCM_AITER_MOE_DISPATCH_POLICY": lambda: int(
         os.getenv("VLLM_ROCM_AITER_MOE_DISPATCH_POLICY", "0")
+    ),
+    # Min batch tokens for evaluating a latent-MoE up projection row-parallel
+    # over TP ranks instead of replicating it; 0 disables. A value above the
+    # decode batch size confines it to prefill.
+    "VLLM_KIMI_ROW_PARALLEL_LATENT_UP_PROJ": lambda: max(
+        0, int(os.getenv("VLLM_KIMI_ROW_PARALLEL_LATENT_UP_PROJ", "0"))
     ),
     # use aiter rms norm op if aiter ops are enabled.
     "VLLM_ROCM_USE_AITER_RMSNORM": lambda: (

--- a/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
@@ -472,10 +472,12 @@ class AiterExperts(mk.FusedMoEExpertsModular):
         ]
         if (weight_key, activation_key) not in SUPPORTED_W_A:
             return False
+        # CK MXFP4 MoE kernels are gfx950-only, but Kimi-K3's SiTU path runs
+        # via FlyDSL on gfx942 (MI325X) as well, so allow gfx942 here too.
         if weight_key == kMxfp4Static:
-            from vllm.platforms.rocm import on_gfx950, on_gfx1250
+            from vllm.platforms.rocm import on_gfx942, on_gfx950, on_gfx1250
 
-            if not on_gfx950() or on_gfx1250():
+            if not (on_gfx950() or on_gfx942()) or on_gfx1250():
                 return False
         return True
 
@@ -486,6 +488,7 @@ class AiterExperts(mk.FusedMoEExpertsModular):
             MoEActivation.GELU,
             MoEActivation.SWIGLUOAI,
             MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+            MoEActivation.SITU,
         ]
 
     @staticmethod

--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -114,9 +114,17 @@ class GateLinear(ReplicatedLinear):
         if self.allow_bf16x3_router_gemm:
             logger.info_once("Enabled experimental SM100 BF16x3 router GEMM.")
 
-        # cuBLAS bf16→fp32 eligibility
+        # Fused bf16 x bf16 -> fp32 GEMM eligibility. torch.mm's out_dtype
+        # epilogue folds the fp32 cast into the GEMM, removing the standalone
+        # bf16->fp32 copy kernel that otherwise runs before grouped_topk.
+        # cuBLAS on CUDA (SM90+, via allow_specialized_router_gemm); hipBLASLt on
+        # ROCm, which supports the same out_dtype epilogue.
+        self._router_gemm_no_bias = not bias
         self.allow_cublas_router_gemm = (
-            self.allow_specialized_router_gemm
+            (
+                self.allow_specialized_router_gemm
+                or (current_platform.is_rocm() and self._router_gemm_no_bias)
+            )
             and self.weight.dtype == torch.bfloat16
             and self.out_dtype == torch.float32
         )
@@ -148,7 +156,10 @@ class GateLinear(ReplicatedLinear):
 
         if (
             not self.allow_cublas_router_gemm
-            and self.allow_specialized_router_gemm
+            and (
+                self.allow_specialized_router_gemm
+                or (current_platform.is_rocm() and self._router_gemm_no_bias)
+            )
             and out_dtype == torch.float32
         ):
             self.allow_cublas_router_gemm = self.weight.dtype == torch.bfloat16

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -7,11 +7,14 @@ from typing import TYPE_CHECKING
 import torch
 import torch.nn.functional as F
 
+import vllm.envs as envs
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.config.parallel import ExpertPlacementStrategy
 from vllm.distributed import (
     get_ep_group,
     get_pcp_group,
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
     tensor_model_parallel_all_reduce,
 )
 from vllm.distributed.eplb.eplb_state import EplbLayerState
@@ -265,6 +268,9 @@ class MoERunner(MoERunnerInterface):
         self.shared_expert_gate = shared_expert_gate
         self.routed_experts = routed_experts
         self.enable_dbo = enable_dbo
+        self._row_parallel_up_proj_min_tokens = (
+            envs.VLLM_KIMI_ROW_PARALLEL_LATENT_UP_PROJ
+        )
 
         # When both gates are present and FSE is enabled, fuse their
         # weight matrices into [num_experts + num_shared, hidden] so one
@@ -373,18 +379,61 @@ class MoERunner(MoERunnerInterface):
             hidden_states if self._shared_experts is not None else None,
         )
 
+    def latent_up_proj_k_shard(self, num_tokens: int) -> tuple[int, int] | None:
+        """The latent slice this rank owns, or None to stay replicated.
+
+        Sharding is only sound if the partial it yields is summed by an
+        all-reduce that happens anyway, hence the shared-expert output to fold
+        into and a final all-reduce that is not suppressed.
+        """
+        min_tokens = self._row_parallel_up_proj_min_tokens
+        if min_tokens == 0 or num_tokens < min_tokens:
+            return None
+
+        transform = self.routed_output_transform
+        if transform is None or not getattr(transform, "supports_k_shard", False):
+            return None
+        up_proj = transform.up_proj
+        if up_proj.bias is not None:
+            # A replicated bias would be summed tp_size times.
+            return None
+
+        if (
+            self._shared_experts is None
+            or self.moe_config.is_sequence_parallel
+            or self.moe_config.skip_final_all_reduce
+        ):
+            return None
+
+        tp_size = get_tensor_model_parallel_world_size()
+        latent_dim = up_proj.weight.shape[1]
+        if tp_size <= 1 or latent_dim % tp_size:
+            return None
+
+        shard = latent_dim // tp_size
+        lo = get_tensor_model_parallel_rank() * shard
+        return lo, lo + shard
+
     def apply_routed_output_transform(
         self,
         fused_output: torch.Tensor,
+        k_shard: tuple[int, int] | None = None,
     ) -> torch.Tensor:
         """Apply transform to routed expert output (e.g., latent to full dim).
 
         Used by latent MoE models (e.g., NemotronH) where routed experts
         operate in a compressed latent space and need projection back to
         the full hidden dimension before combining with shared expert output.
+
+        With ``k_shard`` the transform returns this rank's partial contribution
+        rather than the full result.
         """
         if self.routed_output_transform is not None:
-            r = self.routed_output_transform(fused_output)
+            r = (
+                self.routed_output_transform(fused_output, k_shard)
+                if k_shard is not None
+                else self.routed_output_transform(fused_output)
+            )
             fused_output = r[0] if isinstance(r, tuple) else r
         return fused_output
 
@@ -755,10 +804,15 @@ class MoERunner(MoERunnerInterface):
             )
         )
 
+        # A sharded transform yields a partial, so the shared output must stay
+        # un-reduced and the sum is all-reduced once at the end instead.
+        k_shard = self.latent_up_proj_k_shard(fused_output.shape[0])
+        combined_is_reduced = fused_output_is_reduced and k_shard is None
+
         # If routed output is already reduced, reduce shared to match.
         # See note above re: the two all-reduce points.
         shared_output = self._maybe_reduce_shared_expert_output(
-            shared_output, fused_output_is_reduced
+            shared_output, combined_is_reduced
         )
 
         shared_output, fused_output = self._maybe_apply_routed_scale_to_output(
@@ -766,7 +820,7 @@ class MoERunner(MoERunnerInterface):
         )
 
         # Apply output transform (e.g. latent -> full dim)
-        fused_output = self.apply_routed_output_transform(fused_output)
+        fused_output = self.apply_routed_output_transform(fused_output, k_shard)
 
         if shared_output is not None:
             result = shared_output + fused_output
@@ -774,7 +828,7 @@ class MoERunner(MoERunnerInterface):
             result = fused_output
 
         result = self._maybe_reduce_final_output(
-            result, og_hidden_dim_post_xform, fused_output_is_reduced
+            result, og_hidden_dim_post_xform, combined_is_reduced
         )
 
         return self._maybe_add_zero_expert_output(result)

--- a/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
+++ b/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
@@ -97,7 +97,7 @@ class SharedExperts(torch.nn.Module):
             return SharedExpertsOrder.MK_INTERNAL_OVERLAPPED
 
         should_run_shared_in_aux_stream = (
-            current_platform.is_cuda()
+            current_platform.is_cuda_alike()
             and self._stream is not None
             and hidden_states.shape[0]
             <= envs.VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -911,47 +911,112 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         fp4_dtype = torch.float4_e2m1fn_x2
         e8m0_dtype = torch.float8_e8m0fnu
 
+        # The dequant chain cannot run in place: mxfp4_to_f32 does a
+        # repeat_interleave to split the packed nibbles, then an f32 LUT
+        # gather, so the working tensor grows 8x over the packed weight
+        # before per_1x32_i4_quant shrinks it again. Materializing that for
+        # a whole expert tensor peaks well above 20 GiB per rank, which does
+        # not fit once the weights are resident. Convert a slice of experts
+        # at a time and free each slice before the next, so the transient is
+        # bounded by _CONVERT_CHUNK / num_experts of the full tensor.
+        _CONVERT_CHUNK = 8
+
         def convert(
             weight: torch.nn.Parameter,
             scale: torch.nn.Parameter,
         ) -> tuple[torch.Tensor, torch.Tensor]:
-            weight_f32 = fp4_utils.mxfp4_to_f32(weight.data.view(fp4_dtype))
-            scale_f32 = fp4_utils.e8m0_to_f32(scale.data.view(e8m0_dtype))
-            num_experts, output_size, input_size = weight_f32.shape
-            weight_bf16 = (
-                (
-                    weight_f32.view(num_experts, output_size, input_size // 32, 32)
-                    * scale_f32.view(num_experts, output_size, input_size // 32, 1)
+            # Releases its source parameter before returning: the packed int4
+            # output is the same size as the packed MXFP4 source, so holding
+            # both doubles the expert footprint. Under expert parallel each
+            # rank owns 1/ep_size of the experts and both fit, but under pure
+            # tensor parallel every rank holds all experts and the second copy
+            # does not. The caller must install each result before converting
+            # the next tensor.
+            w_all = weight.data.view(fp4_dtype)
+            s_all = scale.data.view(e8m0_dtype)
+            num_experts = w_all.shape[0]
+
+            # Preallocate the outputs and write each chunk into its slice.
+            # Accumulating chunks in a list and torch.cat-ing at the end holds
+            # the whole result twice at the join, which is what the transient
+            # chunking was meant to avoid in the first place.
+            out_packed: torch.Tensor | None = None
+            out_scale: torch.Tensor | None = None
+            scale_stride = 0
+            for lo in range(0, num_experts, _CONVERT_CHUNK):
+                hi = min(lo + _CONVERT_CHUNK, num_experts)
+                weight_f32 = fp4_utils.mxfp4_to_f32(w_all[lo:hi])
+                scale_f32 = fp4_utils.e8m0_to_f32(s_all[lo:hi])
+                chunk_experts, output_size, input_size = weight_f32.shape
+                weight_bf16 = (
+                    (
+                        weight_f32.view(
+                            chunk_experts, output_size, input_size // 32, 32
+                        )
+                        * scale_f32.view(
+                            chunk_experts, output_size, input_size // 32, 1
+                        )
+                    )
+                    .view(chunk_experts, output_size, input_size)
+                    .to(torch.bfloat16)
                 )
-                .view(num_experts, output_size, input_size)
-                .to(torch.bfloat16)
-            )
-            del weight_f32, scale_f32
+                del weight_f32, scale_f32
 
-            weight_int4, weight_scale = per_1x32_i4_quant(weight_bf16)
-            del weight_bf16
-            weight_int4 = weight_int4.view(aiter_dtypes.i4x2).view(
-                num_experts, output_size, input_size
-            )
-            weight_packed = pack_int8_to_packed_int4(
-                shuffle_weight(weight_int4.view(aiter_dtypes.i8), (16, 16))
-            )
-            weight_packed = weight_packed.view(
-                num_experts, output_size, input_size // 2
-            ).view(aiter_dtypes.i4x2)
-            weight_scale = (
-                shuffle_scale_for_int4(weight_scale, group_size=32)
-                .view(-1)
-                .contiguous()
-            )
-            return weight_packed, weight_scale
+                weight_int4, weight_scale = per_1x32_i4_quant(weight_bf16)
+                del weight_bf16
+                weight_int4 = weight_int4.view(aiter_dtypes.i4x2).view(
+                    chunk_experts, output_size, input_size
+                )
+                weight_packed = pack_int8_to_packed_int4(
+                    shuffle_weight(weight_int4.view(aiter_dtypes.i8), (16, 16))
+                )
+                del weight_int4
+                chunk_packed = weight_packed.view(
+                    chunk_experts, output_size, input_size // 2
+                ).view(aiter_dtypes.i4x2)
+                chunk_scale = (
+                    shuffle_scale_for_int4(weight_scale, group_size=32)
+                    .view(-1)
+                    .contiguous()
+                )
+                if out_packed is None:
+                    out_packed = torch.empty(
+                        (num_experts,) + tuple(chunk_packed.shape[1:]),
+                        dtype=chunk_packed.dtype,
+                        device=chunk_packed.device,
+                    )
+                    scale_stride = chunk_scale.numel() // chunk_experts
+                    out_scale = torch.empty(
+                        num_experts * scale_stride,
+                        dtype=chunk_scale.dtype,
+                        device=chunk_scale.device,
+                    )
+                out_packed[lo:hi].copy_(chunk_packed)
+                out_scale[lo * scale_stride : hi * scale_stride].copy_(chunk_scale)
+                del weight_packed, weight_scale, chunk_packed, chunk_scale
+                torch.cuda.empty_cache()
 
+            # Every chunk has been read, so let the source storage go before
+            # the caller converts the next tensor.
+            del w_all, s_all
+            weight.data = torch.empty(0, dtype=torch.uint8, device=out_packed.device)
+            scale.data = torch.empty(0, dtype=torch.uint8, device=out_packed.device)
+            torch.cuda.empty_cache()
+            return out_packed, out_scale
+
+        # Install each result before converting the next tensor so only one
+        # source is ever live alongside its output.
         w13, w13_scale = convert(layer.w13_weight, layer.w13_weight_scale)
-        w2, w2_scale = convert(layer.w2_weight, layer.w2_weight_scale)
         replace_parameter(layer, "w13_weight", w13)
-        replace_parameter(layer, "w2_weight", w2)
         replace_parameter(layer, "w13_weight_scale", w13_scale)
+        del w13, w13_scale
+        torch.cuda.empty_cache()
+
+        w2, w2_scale = convert(layer.w2_weight, layer.w2_weight_scale)
+        replace_parameter(layer, "w2_weight", w2)
         replace_parameter(layer, "w2_weight_scale", w2_scale)
+        del w2, w2_scale
+        torch.cuda.empty_cache()
         layer.w13_weight.is_shuffled = True
         layer.w2_weight.is_shuffled = True
 

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -896,12 +896,8 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             num_experts, output_size, input_size = weight_f32.shape
             weight_bf16 = (
                 (
-                    weight_f32.view(
-                        num_experts, output_size, input_size // 32, 32
-                    )
-                    * scale_f32.view(
-                        num_experts, output_size, input_size // 32, 1
-                    )
+                    weight_f32.view(num_experts, output_size, input_size // 32, 32)
+                    * scale_f32.view(num_experts, output_size, input_size // 32, 1)
                 )
                 .view(num_experts, output_size, input_size)
                 .to(torch.bfloat16)
@@ -939,10 +935,9 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         # the bf16 correction bias to match on every step -- a per-layer,
         # per-token bf16->fp32 copy kernel. Keep the tiny [num_experts] bias in
         # fp32 so the runtime cast becomes a no-op.
-        if getattr(layer, "e_score_correction_bias", None) is not None:
-            layer.e_score_correction_bias.data = (
-                layer.e_score_correction_bias.data.to(torch.float32)
-            )
+        correction_bias = getattr(layer, "e_score_correction_bias", None)
+        if correction_bias is not None:
+            correction_bias.data = correction_bias.data.to(torch.float32)
 
         self.moe_quant_config = self.get_fused_moe_quant_config(layer)
         if self.moe_quant_config is not None and self.experts_cls is not None:

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -621,10 +621,12 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             act_dtype=act_dtype,
             moe_parallel_config=moe_parallel_config,
         )
-        if self.is_k3_situ_aiter:
+        if self.is_k3_situ_aiter or self.is_k3_situ_int4_gfx942:
             # K3's AITER A16W4 kernel handles K3's native intermediate size
             # (moe_intermediate 3072; e.g. 384/partition at TP8); the generic
-            # 256 round-up would inflate weights and OOM.
+            # 256 round-up would inflate weights and OOM. AITER's
+            # resolve_flydsl_stage1_tile_n() already downgrades tile_n 256->128
+            # for such shapes, so 384 is served natively.
             return hidden_size, intermediate_size_per_partition
         return mxfp4_round_up_hidden_size_and_intermediate_size(
             self.mxfp4_backend, hidden_size, intermediate_size_per_partition

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -513,6 +513,50 @@ def _use_k3_situ_aiter(moe: FusedMoEConfig) -> bool:
     )
 
 
+def _use_k3_situ_int4_gfx942(moe: FusedMoEConfig) -> bool:
+    """Whether Kimi-K3's SiTU MXFP4 experts should be requantized to int4 on gfx942.
+
+    gfx942 has no scaled MXFP4 MFMA, so the native MXFP4 kernels do not compile
+    there. Requantizing to groupwise int4 lets AITER's bf16 x int4 FlyDSL path
+    serve the model, at the cost of a lossy weight conversion. That trade is the
+    user's to make, so it is opt-in through
+    ``--quantization-config.moe.weight int4`` rather than inferred from the
+    hardware.
+    """
+    from vllm.platforms import current_platform
+
+    if not current_platform.is_rocm():
+        return False
+    from vllm._aiter_ops import rocm_aiter_ops
+    from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+    from vllm.platforms.rocm import on_gfx942
+
+    return (
+        rocm_aiter_ops.is_fused_moe_enabled()
+        and on_gfx942()
+        and moe.activation == MoEActivation.SITU
+        and moe.activation_situ_linear_beta is not None
+        and _moe_weight_override_is_int4()
+    )
+
+
+def _moe_weight_override_is_int4() -> bool:
+    """True when the user asked for int4 MoE weights on the command line.
+
+    Set with ``--quantization-config.moe.weight int4``. The requantization is
+    lossy, so it never happens unless it was requested.
+    """
+    from vllm.config import get_current_vllm_config
+
+    vllm_config = get_current_vllm_config()
+    if vllm_config is None:
+        return False
+    quant_args = getattr(vllm_config.model_config, "quantization_config", None)
+    moe_spec = getattr(quant_args, "moe", None)
+    weight = getattr(moe_spec, "weight", None)
+    return str(weight) == "int4"
+
+
 class Mxfp4MoEMethod(FusedMoEMethodBase):
     """MXFP4 MoE quantization method."""
 
@@ -520,8 +564,9 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         super().__init__(moe)
         self.weight_dtype = "mxfp4"
         self.is_k3_situ_aiter = _use_k3_situ_aiter(moe)
+        self.is_k3_situ_int4_gfx942 = _use_k3_situ_int4_gfx942(moe)
         self.experts_cls: type[mk.FusedMoEExperts] | None
-        if self.is_k3_situ_aiter:
+        if self.is_k3_situ_aiter or self.is_k3_situ_int4_gfx942:
             self.mxfp4_backend = Mxfp4MoeBackend.AITER_MXFP4_BF16
             self.experts_cls = backend_to_kernel_cls(self.mxfp4_backend)[0]
             logger.info_once("Using AITER_MXFP4_BF16 for Kimi-K3 SiTU MXFP4 MoE.")
@@ -813,6 +858,76 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         )
         w2_scale = e8m0_shuffle(w2_scale_raw.view(-1, w2_scale_raw.shape[-1]))
 
+    def _setup_kernel_k3_situ_gfx942(self, layer: RoutedExperts) -> None:
+        # gfx942 has no native MXFP4 matmul. Convert the weights to groupwise
+        # int4 once at load time for AITER's existing bf16 x int4 FlyDSL path.
+        import inspect
+
+        from aiter.ops.flydsl.kernels.moe_gemm_2stage import compile_moe_gemm1
+
+        # Before ROCm/aiter#4471 the packed-int4 stage1 dropped the requested
+        # activation and hardcoded SiLU, so K3 served fluent text while
+        # computing the wrong function. Refuse instead of repeating that.
+        if "act" not in inspect.signature(compile_moe_gemm1).parameters:
+            raise RuntimeError(
+                "This AITER build ignores the SiTUv2 activation on the "
+                "packed-int4 MoE path and would silently compute SiLU. "
+                "Rebuild with an AITER that includes ROCm/aiter#4471."
+            )
+
+        from aiter import dtypes as aiter_dtypes
+        from aiter.ops.quant import per_1x32_i4_quant
+        from aiter.ops.shuffle import (
+            pack_int8_to_packed_int4,
+            shuffle_scale_for_int4,
+            shuffle_weight,
+        )
+        from aiter.utility import fp4_utils
+
+        fp4_dtype = torch.float4_e2m1fn_x2
+        e8m0_dtype = torch.float8_e8m0fnu
+
+        def convert(
+            weight: torch.nn.Parameter,
+            scale: torch.nn.Parameter,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            weight_f32 = fp4_utils.mxfp4_to_f32(weight.data.view(fp4_dtype))
+            scale_f32 = fp4_utils.e8m0_to_f32(scale.data.view(e8m0_dtype))
+            num_experts, output_size, input_size = weight_f32.shape
+            weight_bf16 = (
+                (
+                    weight_f32.view(
+                        num_experts, output_size, input_size // 32, 32
+                    )
+                    * scale_f32.view(
+                        num_experts, output_size, input_size // 32, 1
+                    )
+                )
+                .view(num_experts, output_size, input_size)
+                .to(torch.bfloat16)
+            )
+            del weight_f32, scale_f32
+
+            weight_int4, weight_scale = per_1x32_i4_quant(weight_bf16)
+            del weight_bf16
+            weight_int4 = weight_int4.view(aiter_dtypes.i4x2).view(
+                num_experts, output_size, input_size
+            )
+            weight_packed = pack_int8_to_packed_int4(
+                shuffle_weight(weight_int4.view(aiter_dtypes.i8), (16, 16))
+            )
+            weight_packed = weight_packed.view(
+                num_experts, output_size, input_size // 2
+            ).view(aiter_dtypes.i4x2)
+            weight_scale = (
+                shuffle_scale_for_int4(weight_scale, group_size=32)
+                .view(-1)
+                .contiguous()
+            )
+            return weight_packed, weight_scale
+
+        w13, w13_scale = convert(layer.w13_weight, layer.w13_weight_scale)
+        w2, w2_scale = convert(layer.w2_weight, layer.w2_weight_scale)
         replace_parameter(layer, "w13_weight", w13)
         replace_parameter(layer, "w2_weight", w2)
         replace_parameter(layer, "w13_weight_scale", w13_scale)
@@ -834,6 +949,10 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
     def process_weights_after_loading(self, layer):
         if self.is_k3_situ_aiter:
             self._setup_kernel_k3_situ(layer)
+            return
+
+        if self.is_k3_situ_int4_gfx942:
+            self._setup_kernel_k3_situ_gfx942(layer)
             return
 
         w13 = layer.w13_weight

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -520,7 +520,7 @@ def _use_k3_situ_int4_gfx942(moe: FusedMoEConfig) -> bool:
     there. Requantizing to groupwise int4 lets AITER's bf16 x int4 FlyDSL path
     serve the model, at the cost of a lossy weight conversion. That trade is the
     user's to make, so it is opt-in through
-    ``--quantization-config.moe.weight int4`` rather than inferred from the
+    ``--quantization-config.moe.weight int4_per_group_32`` rather than inferred from the
     hardware.
     """
     from vllm.platforms import current_platform
@@ -543,8 +543,8 @@ def _use_k3_situ_int4_gfx942(moe: FusedMoEConfig) -> bool:
 def _moe_weight_override_is_int4() -> bool:
     """True when the user asked for int4 MoE weights on the command line.
 
-    Set with ``--quantization-config.moe.weight int4``. The requantization is
-    lossy, so it never happens unless it was requested.
+    Set with ``--quantization-config.moe.weight int4_per_group_32``. The
+    requantization is lossy, so it never happens unless it was requested.
     """
     from vllm.config import get_current_vllm_config
 
@@ -554,7 +554,13 @@ def _moe_weight_override_is_int4() -> bool:
     quant_args = getattr(vllm_config.model_config, "quantization_config", None)
     moe_spec = getattr(quant_args, "moe", None)
     weight = getattr(moe_spec, "weight", None)
-    return str(weight) == "int4"
+    if weight is None:
+        return False
+    from vllm.model_executor.layers.quantization.utils.quant_utils import (
+        kInt4Static32,
+    )
+
+    return weight == kInt4Static32
 
 
 class Mxfp4MoEMethod(FusedMoEMethodBase):

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -935,6 +935,15 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         layer.w13_weight.is_shuffled = True
         layer.w2_weight.is_shuffled = True
 
+        # The router emits fp32 logits, so aiter's biased_grouped_topk upcasts
+        # the bf16 correction bias to match on every step -- a per-layer,
+        # per-token bf16->fp32 copy kernel. Keep the tiny [num_experts] bias in
+        # fp32 so the runtime cast becomes a no-op.
+        if getattr(layer, "e_score_correction_bias", None) is not None:
+            layer.e_score_correction_bias.data = (
+                layer.e_score_correction_bias.data.to(torch.float32)
+            )
+
         self.moe_quant_config = self.get_fused_moe_quant_config(layer)
         if self.moe_quant_config is not None and self.experts_cls is not None:
             self.moe_kernel = make_mxfp4_moe_kernel(

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -858,6 +858,24 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         )
         w2_scale = e8m0_shuffle(w2_scale_raw.view(-1, w2_scale_raw.shape[-1]))
 
+        replace_parameter(layer, "w13_weight", w13)
+        replace_parameter(layer, "w2_weight", w2)
+        replace_parameter(layer, "w13_weight_scale", w13_scale)
+        replace_parameter(layer, "w2_weight_scale", w2_scale)
+        layer.w13_weight.is_shuffled = True
+        layer.w2_weight.is_shuffled = True
+
+        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
+        if self.moe_quant_config is not None and self.experts_cls is not None:
+            self.moe_kernel = make_mxfp4_moe_kernel(
+                moe_quant_config=self.moe_quant_config,
+                moe_config=self.moe,
+                mxfp4_backend=self.mxfp4_backend,
+                experts_cls=self.experts_cls,
+                routing_tables=layer._expert_routing_tables(),
+                layer=layer,
+            )
+
     def _setup_kernel_k3_situ_gfx942(self, layer: RoutedExperts) -> None:
         # gfx942 has no native MXFP4 matmul. Convert the weights to groupwise
         # int4 once at load time for AITER's existing bf16 x int4 FlyDSL path.

--- a/vllm/models/kimi_k3/amd/linear.py
+++ b/vllm/models/kimi_k3/amd/linear.py
@@ -61,7 +61,7 @@ from vllm.model_executor.models.utils import (
     make_layers,
     maybe_prefix,
 )
-from vllm.models.kimi_k3.amd.ops.attn_res import attn_res
+from vllm.models.kimi_k3.amd.ops.attn_res import attn_res, attn_res_fused
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
 from vllm.utils.math_utils import cdiv
@@ -153,6 +153,42 @@ def _apply_attn_res(
         num_valid_blocks,
         norm.variance_epsilon,
     )
+
+
+def _can_fuse_out_norm(out_norm: RMSNorm) -> bool:
+    return out_norm.has_weight and out_norm.variance_size_override is None
+
+
+def _apply_attn_res_norm(
+    prefix_sum: torch.Tensor,
+    block_residual: torch.Tensor,
+    proj: ReplicatedLinear,
+    norm: RMSNorm,
+    num_valid_blocks: int,
+    out_norm: RMSNorm,
+    addend: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Apply attn-res with its output norm and optional input residual add."""
+    if num_valid_blocks <= 0 or not _can_fuse_out_norm(out_norm):
+        if addend is not None:
+            prefix_sum = prefix_sum + addend
+        mixed = _apply_attn_res(
+            prefix_sum, block_residual, proj, norm, num_valid_blocks
+        )
+        return out_norm(mixed), prefix_sum
+
+    normed, fused_prefix_sum = attn_res_fused(
+        prefix_sum,
+        block_residual,
+        norm.weight,
+        proj.weight.squeeze(0),
+        num_valid_blocks,
+        norm.variance_epsilon,
+        addend=addend,
+        out_norm_weight=out_norm.weight,
+        out_norm_eps=out_norm.variance_epsilon,
+    )
+    return normed, (prefix_sum if addend is None else fused_prefix_sum)
 
 
 class KimiMoE(nn.Module):
@@ -601,38 +637,39 @@ class KimiDecoderLayer(nn.Module):
         block_residual: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         prefix_sum = hidden_states
-        hidden_states = _apply_attn_res(
+        hidden_states, prefix_sum = _apply_attn_res_norm(
             prefix_sum,
             block_residual,
             self.self_attention_res_proj,
             self.self_attention_res_norm,
             self.prev_valid_blocks,
+            self.input_layernorm,
         )
 
         if self.is_block_write_layer:
             block_residual[:, self.block_write_idx, :].copy_(prefix_sum)
             prefix_sum = None
 
-        hidden_states = self.input_layernorm(hidden_states)
         hidden_states = self._run_self_attn(positions, hidden_states)
-
-        if prefix_sum is not None:
-            prefix_sum = prefix_sum + hidden_states
-        else:
-            prefix_sum = hidden_states
 
         mlp_valid_blocks = self.prev_valid_blocks + (
             1 if self.is_block_write_layer else 0
         )
-        hidden_states = _apply_attn_res(
+        if prefix_sum is None:
+            prefix_sum = hidden_states
+            addend = None
+        else:
+            addend = hidden_states
+        hidden_states, prefix_sum = _apply_attn_res_norm(
             prefix_sum,
             block_residual,
             self.mlp_res_proj,
             self.mlp_res_norm,
             mlp_valid_blocks,
+            self.post_attention_layernorm,
+            addend=addend,
         )
 
-        hidden_states = self.post_attention_layernorm(hidden_states)
         hidden_states = self.mlp(hidden_states)
         prefix_sum = prefix_sum + hidden_states
         return prefix_sum, block_residual

--- a/vllm/models/kimi_k3/amd/linear.py
+++ b/vllm/models/kimi_k3/amd/linear.py
@@ -119,6 +119,9 @@ class KimiMLP(nn.Module):
 
 
 class KimiRoutedOutputTransform(nn.Module):
+    # Opts into MoERunner's row-parallel evaluation of the up projection.
+    supports_k_shard = True
+
     def __init__(
         self,
         norm: RMSNorm | None,
@@ -128,11 +131,23 @@ class KimiRoutedOutputTransform(nn.Module):
         self.norm = norm
         self.up_proj = up_proj
 
-    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        k_shard: tuple[int, int] | None = None,
+    ) -> torch.Tensor:
         if self.norm is not None:
             hidden_states = self.norm(hidden_states)
-        hidden_states, _ = self.up_proj(hidden_states)
-        return hidden_states
+        if k_shard is None:
+            hidden_states, _ = self.up_proj(hidden_states)
+            return hidden_states
+        # The norm is non-linear so it stays on the full latent; the projection
+        # after it is linear, so this rank contracts only its own slice and the
+        # caller sums the partials.
+        lo, hi = k_shard
+        return torch.matmul(
+            hidden_states[..., lo:hi], self.up_proj.weight[:, lo:hi].t()
+        )
 
 
 def _apply_attn_res(

--- a/vllm/models/kimi_k3/amd/ops/attn_res.py
+++ b/vllm/models/kimi_k3/amd/ops/attn_res.py
@@ -11,6 +11,9 @@ import torch
 
 from vllm.triton_utils import tl, triton
 
+_DECODE_NUM_WARPS = 8
+_PEEL_PREFIX_MIN_TOKENS = 256
+
 
 @triton.jit
 def _attn_res_kernel(
@@ -19,13 +22,26 @@ def _attn_res_kernel(
     norm_weight_ptr,
     qk_weight_ptr,
     output_ptr,
+    addend_ptr,
+    prefix_sum_ptr,
+    out_norm_weight_ptr,
+    norm_output_ptr,
     stride_prefix_m: tl.constexpr,
     stride_block_m: tl.constexpr,
     stride_block_r: tl.constexpr,
     stride_output_m: tl.constexpr,
+    stride_addend_m: tl.constexpr,
+    stride_prefix_sum_m: tl.constexpr,
+    stride_norm_output_m: tl.constexpr,
     num_blocks: tl.constexpr,
+    num_sources: tl.constexpr,
     hidden_size: tl.constexpr,
     eps: tl.constexpr,
+    out_norm_eps: tl.constexpr,
+    HAS_ADD: tl.constexpr,
+    HAS_NORM: tl.constexpr,
+    STORE_MIX: tl.constexpr,
+    PEEL_PREFIX: tl.constexpr,
     BLOCK_L: tl.constexpr,
     BLOCK_D: tl.constexpr,
 ):
@@ -38,14 +54,39 @@ def _attn_res_kernel(
         mask=d_mask,
         other=0.0,
     ).to(tl.float32)
+    if HAS_ADD:
+        # Round to bf16 before consuming the sum, so both the stored prefix-sum
+        # and the mix below see exactly what the separate bf16 `prefix + addend`
+        # op this replaces would have produced.
+        prefix_sum = (
+            prefix
+            + tl.load(
+                addend_ptr + row_idx * stride_addend_m + d_offsets,
+                mask=d_mask,
+                other=0.0,
+            ).to(tl.float32)
+        ).to(tl.bfloat16)
+        tl.store(
+            prefix_sum_ptr + row_idx * stride_prefix_sum_m + d_offsets,
+            prefix_sum,
+            mask=d_mask,
+        )
+        prefix = prefix_sum.to(tl.float32)
     input_qk_weight = tl.load(norm_weight_ptr + d_offsets, mask=d_mask, other=0.0).to(
         tl.float32
     ) * tl.load(qk_weight_ptr + d_offsets, mask=d_mask, other=0.0).to(tl.float32)
 
-    max_logit = tl.full((), -float("inf"), tl.float32)
-    denominator = tl.zeros((), tl.float32)
-    mixed = tl.zeros((BLOCK_D,), tl.float32)
-    num_sources = num_blocks + 1
+    if PEEL_PREFIX:
+        # Seed the online-softmax state with the prefix, then iterate blocks.
+        max_logit = tl.sum(prefix * input_qk_weight, axis=0) * tl.rsqrt(
+            tl.sum(prefix * prefix, axis=0) * (1.0 / hidden_size) + eps
+        )
+        denominator = tl.full((), 1.0, tl.float32)
+        mixed = prefix
+    else:
+        max_logit = tl.full((), -float("inf"), tl.float32)
+        denominator = tl.zeros((), tl.float32)
+        mixed = tl.zeros((BLOCK_D,), tl.float32)
 
     for source_tile in range(tl.cdiv(num_sources, BLOCK_L)):
         source_offsets = source_tile * BLOCK_L + tl.arange(0, BLOCK_L)
@@ -63,7 +104,10 @@ def _attn_res_kernel(
             other=0.0,
             eviction_policy="evict_first",
         ).to(tl.float32)
-        values = tl.where(is_prefix[:, None], prefix[None, :], block_values)
+        if PEEL_PREFIX:
+            values = block_values
+        else:
+            values = tl.where(is_prefix[:, None], prefix[None, :], block_values)
         reciprocal_std = tl.rsqrt(
             tl.sum(values * values, axis=1) * (1.0 / hidden_size) + eps
         )
@@ -78,21 +122,40 @@ def _attn_res_kernel(
         max_logit = new_max_logit
 
     output = mixed / denominator
-    tl.store(
-        output_ptr + row_idx * stride_output_m + d_offsets,
-        output,
-        mask=d_mask,
-    )
+    if STORE_MIX:
+        tl.store(
+            output_ptr + row_idx * stride_output_m + d_offsets,
+            output,
+            mask=d_mask,
+        )
+    if HAS_NORM:
+        # BLOCK_D already spans the whole hidden dimension, so this reduction is
+        # workgroup-local. Round first to match the standalone bf16 norm input.
+        mixed_bf16 = output.to(tl.bfloat16).to(tl.float32)
+        reciprocal_std = tl.rsqrt(
+            tl.sum(mixed_bf16 * mixed_bf16, axis=0) * (1.0 / hidden_size) + out_norm_eps
+        )
+        out_weight = tl.load(
+            out_norm_weight_ptr + d_offsets, mask=d_mask, other=0.0
+        ).to(tl.float32)
+        tl.store(
+            norm_output_ptr + row_idx * stride_norm_output_m + d_offsets,
+            mixed_bf16 * reciprocal_std * out_weight,
+            mask=d_mask,
+        )
 
 
-def attn_res(
+def _launch_attn_res(
     prefix: torch.Tensor,
     blocks: torch.Tensor,
     norm_weight: torch.Tensor,
     qk_weight: torch.Tensor,
     num_blocks: int,
     eps: float,
-) -> torch.Tensor:
+    addend: torch.Tensor | None,
+    out_norm_weight: torch.Tensor | None,
+    out_norm_eps: float,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
     num_tokens, hidden_size = prefix.shape
     assert 0 < num_blocks <= blocks.shape[1]
     assert blocks.shape[0] == num_tokens
@@ -103,30 +166,112 @@ def attn_res(
     assert norm_weight.stride(-1) == 1
     assert qk_weight.stride(-1) == 1
 
-    output = prefix.new_empty(prefix.shape)
-    if num_tokens == 0:
-        return output
+    if addend is not None:
+        assert addend.shape == prefix.shape
+        assert addend.stride(-1) == 1
+        addend_arg = addend
+        prefix_sum = prefix.new_empty(prefix.shape)
+        addend_stride = addend.stride(0)
+        prefix_sum_stride = prefix_sum.stride(0)
+    else:
+        addend_arg = prefix
+        prefix_sum = None
+        addend_stride = prefix_sum_stride = 0
 
-    if num_tokens >= 256 or num_blocks <= 1:
+    if out_norm_weight is not None:
+        assert out_norm_weight.numel() == hidden_size
+        assert out_norm_weight.stride(-1) == 1
+        out_norm_weight_arg = out_norm_weight
+    else:
+        out_norm_weight_arg = norm_weight
+
+    has_add = addend is not None
+    has_norm = out_norm_weight is not None
+    store_mix = not has_norm
+    result = prefix.new_empty(prefix.shape)
+    if num_tokens == 0:
+        return result, prefix_sum
+
+    peel_prefix = num_tokens >= _PEEL_PREFIX_MIN_TOKENS
+    if peel_prefix:
         block_l, num_warps = 1, 4
     else:
-        block_l, num_warps = 4, 8
+        block_l = min(triton.next_power_of_2(num_blocks + 1), 16)
+        num_warps = _DECODE_NUM_WARPS
     _attn_res_kernel[(num_tokens,)](
         prefix,
         blocks,
         norm_weight,
         qk_weight,
-        output,
+        result,
+        addend_arg,
+        prefix_sum if prefix_sum is not None else prefix,
+        out_norm_weight_arg,
+        result,
         prefix.stride(0),
         blocks.stride(0),
         blocks.stride(1),
-        output.stride(0),
+        result.stride(0),
+        addend_stride,
+        prefix_sum_stride,
+        result.stride(0),
         num_blocks,
+        num_blocks if peel_prefix else num_blocks + 1,
         hidden_size,
         eps,
+        out_norm_eps,
+        HAS_ADD=has_add,
+        HAS_NORM=has_norm,
+        STORE_MIX=store_mix,
+        PEEL_PREFIX=peel_prefix,
         BLOCK_L=block_l,
         BLOCK_D=triton.next_power_of_2(hidden_size),
         num_warps=num_warps,
         num_stages=2,
     )
+    return result, prefix_sum
+
+
+def attn_res(
+    prefix: torch.Tensor,
+    blocks: torch.Tensor,
+    norm_weight: torch.Tensor,
+    qk_weight: torch.Tensor,
+    num_blocks: int,
+    eps: float,
+) -> torch.Tensor:
+    output, _ = _launch_attn_res(
+        prefix, blocks, norm_weight, qk_weight, num_blocks, eps, None, None, 0.0
+    )
     return output
+
+
+def attn_res_fused(
+    prefix: torch.Tensor,
+    blocks: torch.Tensor,
+    norm_weight: torch.Tensor,
+    qk_weight: torch.Tensor,
+    num_blocks: int,
+    eps: float,
+    addend: torch.Tensor | None = None,
+    out_norm_weight: torch.Tensor | None = None,
+    out_norm_eps: float = 0.0,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Apply attn-res with an optional residual add and output RMSNorm.
+
+    Returns ``(output, prefix_sum)``. ``output`` is the RMSNorm of the mixed
+    result when ``out_norm_weight`` is given, and the raw mix otherwise;
+    ``prefix_sum`` is ``prefix + addend`` when ``addend`` is given, and ``None``
+    otherwise.
+    """
+    return _launch_attn_res(
+        prefix,
+        blocks,
+        norm_weight,
+        qk_weight,
+        num_blocks,
+        eps,
+        addend,
+        out_norm_weight,
+        out_norm_eps,
+    )

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -24,6 +24,7 @@ def _skip_aiter_sampler_on_gfx1250() -> bool:
 
     return on_gfx1250()
 
+
 def _aiter_topk_topp_unsupported_on_gfx942() -> bool:
     """AITER's ``top_k_top_p_sampling_from_probs`` is a gfx950-only prebuilt.
 

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -24,6 +24,19 @@ def _skip_aiter_sampler_on_gfx1250() -> bool:
 
     return on_gfx1250()
 
+def _aiter_topk_topp_unsupported_on_gfx942() -> bool:
+    """AITER's ``top_k_top_p_sampling_from_probs`` is a gfx950-only prebuilt.
+
+    It segfaults on gfx942 (MI325X / MI300X), so callers must fall back to the
+    native torch sampler on that architecture.
+    """
+    try:
+        from vllm.platforms.rocm import on_gfx942
+
+        return on_gfx942()
+    except Exception:  # noqa: BLE001
+        return False
+
 
 def flashinfer_sampler_supported() -> bool:
     """Decide whether FlashInfer's top-p/top-k sampler can be used.
@@ -118,6 +131,7 @@ class TopKTopPSampler(nn.Module):
             logprobs_mode not in PROCESSED_LOGPROBS_MODES
             and rocm_aiter_ops.is_enabled()
             and not _skip_aiter_sampler_on_gfx1250()  # TODO (JPVILLAM): Enable
+            and not _aiter_topk_topp_unsupported_on_gfx942()
         ):
             self.aiter_ops = None
             self._aiter_ops_import_failed = False


### PR DESCRIPTION
## Summary
- Enable the Kimi-K3 MXFP4 expert path on gfx942 by converting expert weights to groupwise int4 once at load time and dispatching AITER's bf16 x int4 FlyDSL kernels.
- Pad TP-sharded MLA query heads to the persistent AITER kernel's 16-head minimum, which allows TP8 Kimi-K3 to use AITER MLA on MI300X and MI325X.
- Add a reproducible gfx942 Docker layer with AITER v0.1.19, avoid the unsupported AITER sampler on gfx942, and remove two per-layer bf16-to-fp32 conversions in the MoE router path.
- Run eligible shared-expert work on the auxiliary stream for small batches.

## Scope of the PR.
PR #50089 added the Kimi-K3 model and kernels. This PR is the ROCm gfx942 enablement follow-up.


## Validation
- Targeted pre-commit hooks pass on every changed file, including Ruff, formatting, mypy, Docker dependency checks, SPDX checks, and configuration validation.
- TP8 MLA startup and serving passed on gfx942 with 12 query heads padded to 16 and no gfx950 Gluon dispatch.
- Arithmetic and factual API sanity requests returned the expected answers.
- Full gsm8k on the final image built from this current-main branch is pending.

## Test plan
- [x] Rebase the gfx942 changes onto current upstream `main` after PR #50089 merged.
- [x] Run targeted pre-commit hooks on all changed files.
- [x] Verify TP8 padded persistent MLA startup and serving on gfx942.
- [x] Measure focused MLA performance at concurrency 1 and 8.
- [ ] Build the final image from this branch and the pinned AITER revision.
- [ ] Run same-session default-versus-tuned 8192-token prefill measurements.
- [ ] Run full ISL 8192 and OSL 1024 serving benchmarks at concurrency 1 and 8.
- [ ] Run full 1319-sample gsm8k against the final image.

## AI assistance
AI tools assisted with implementation, conflict resolution, and drafting. I reviewed the changed code and validation results.

Made with [Cursor](https://cursor.com)