### PR TITLE
[ROCm] Implement is_integrated_gpu() for APU unified-memory accounting

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -775,6 +775,10 @@ class RocmPlatform(Platform):
         return torch.cuda.get_device_properties(device_id).total_memory
 
     @classmethod
+    def is_integrated_gpu(cls, device_id: int = 0) -> bool:
+        return bool(torch.cuda.get_device_properties(device_id).is_integrated)
+
+    @classmethod
     def apply_config_platform_defaults(cls, vllm_config: "VllmConfig") -> None:
         from vllm._aiter_ops import rocm_aiter_ops
 


### PR DESCRIPTION
## Purpose

`RocmPlatform` does not override `is_integrated_gpu()`, so it inherits the base `Platform` default (`False`) and the unified-memory paths added in #35356 never engage on AMD APUs: `MemorySnapshot.measure()` keeps HIP's free-memory figure instead of falling back to `psutil.virtual_memory().available`, and `release_device_memory_under_pressure()` is a no-op.

HIP populates the same `is_integrated` device property CUDA uses, so this is the one-liner `CudaPlatform` already has — no gfx arch allowlist, and future APUs are covered without maintenance.

### What I found while tracing APU memory accounting

Two separate defects are easy to conflate here, so to be precise about what this PR does and does not do:

- **Total memory** is wrong because `amd-smi` reports only the small BIOS VRAM carveout (0.50 GiB on my machine, against a 110 GiB GTT pool). That is a driver-side bug. I raised it with AMD and they are working on the fix in [ROCm/rocm-systems#8419](https://github.com/ROCm/rocm-systems/pull/8419) (`vram_total_prefer_kfd`, currently approved). **This PR deliberately carries no workaround for it** — it belongs in amd-smi, not vLLM.
- **Free memory** is what this PR addresses. `hipMemGetInfo` already reports total correctly (110.00 GiB); only the free figure is off, and no amd-smi fix can help, because the gap is a missing platform override in vLLM.

This also addresses the concern raised on #40963 that this was a transient ROCm nightly issue since fixed. The gap is not ROCm-version dependent and no ROCm release can close it: `RocmPlatform` simply has no `is_integrated_gpu()` implementation, so the inherited `False` is returned on every version. Together with the amd-smi fix, this PR should resolve the APU memory misallocations, and makes #40963 obsolete — that PR's `Platform.mem_get_info()` override is dead code (no such hook exists on `main`), and its `sysfs_vram > hip_total * 4` heuristic assumes a *large* BIOS carveout, so it evaluates `False` on a minimal-carveout config like mine. Credit to @hephaex for first flagging this in #40963.

Being straightforward about the size of the effect: because `total_consumed` is a *difference* of two free-memory readings, a constant offset between the two sources largely cancels in the KV-cache budget. The concrete wins are that the `request_memory()` startup check becomes accurate, that `total_consumed` now captures host-side allocations that come out of the same physical pool on UMA and that HIP does not see, and that `release_device_memory_under_pressure()` starts working at all.

## Test Plan

```bash
pre-commit run --files vllm/platforms/rocm.py
pytest tests/utils_/test_mem_utils.py -v
```

Run on Ryzen AI MAX+ 395 (Radeon 8060S, gfx1151, 128 GiB UMA). The test suite and the A/B below ran against **ROCm 7.14** (torch 2.11.0+rocm7.14.0); I additionally confirmed the device property and the free-memory discrepancy on ROCm 7.2 (torch 2.11.0+rocm7.2), so the behaviour is not version-specific.

To isolate the effect of the override I ran `test_memory_profiling` both ways on the same box: once as-is, and once with `is_integrated_gpu()` forced to `False` to reproduce current `main`.

## Test Result

`pre-commit` — all hooks pass (ruff check, ruff format, mypy 3.10, typos, SPDX).

`pytest tests/utils_/test_mem_utils.py -v` — **3 passed** with the override, and **3 passed** with it forced off. No regression either way.

Device state on ROCm 7.14:

```
gcnArchName                                        gfx1151
get_device_properties(0).is_integrated             1        -> override True
hipMemGetInfo  total                               110.00 GiB  (correct)
hipMemGetInfo  free                                 90.00 GiB  (over-reported)
psutil.virtual_memory().available                   83.26 GiB  (used after this PR)
sysfs mem_info_vram_total / gtt_total          0.50 / 110.00 GiB
```

`test_memory_profiling` A/B, allocating a known 512 MiB of weights plus 256 MiB of non-torch memory inside the profiling window (5% tolerance):

```
                       override ON      override OFF (main)   expected
non_torch_increase        253.9 MiB          257.0 MiB          256.0
torch_peak_increase      1024.0 MiB         1024.0 MiB         1024.0
total_consumed            765.9 MiB          769.0 MiB          768.0
non_kv_cache_memory      1789.9 MiB         1793.0 MiB         1792.0
```

Because `total_consumed` is a delta of two free-memory readings, the psutil source is inherently noisier than HIP's, so I checked whether that risks flaky CI: over five consecutive runs `total_consumed` stayed within **±0.6 %** (ratios 0.9985–1.0058), comfortably inside the 5 % tolerance. Only a cold first run after container start drifted further (0.9645), and it did not recur.

**Model evaluation:** not applicable — startup memory accounting only, no kernel, dtype or numerical path is touched, so model outputs are unchanged.

## Note for reviewers: MI300A

`hipDeviceProp_t.integrated` comes from `info.hostUnifiedMemory_` (`hipamd/src/hip_device.cpp`), which `rocclr/device/rocm/rocdevice.cpp` sets to 1 for HSA agents flagged `AGENT_IS_APU` or running `HSA_PROFILE_FULL`. So **MI300X and other discrete parts are unaffected** (`integrated = 0`, predicate returns `False`). **MI300A, being an APU, will newly take the psutil path.** Its HBM genuinely is shared, so I believe that is correct, but I cannot test it — could someone with MI300A confirm this is the desired behaviour? cc @tjtanaa @hongxiayang @mgehre-amd

---

AI assistance was used for the repository analysis, the upstream duplicate-work search and drafting this description. The measurements are from my own hardware, and I have reviewed every changed line.
