### PR TITLE
[RFC] Deprecate flex attention

### DIFF
--- a/vllm/v1/attention/selector.py
+++ b/vllm/v1/attention/selector.py
@@ -193,6 +193,12 @@ def _cached_get_attn_backend(
         )
     backend = resolve_obj_by_qualname(attention_cls)
 
+    if backend.get_name() == "FLEX_ATTENTION":
+        logger.warning_once(
+            "The FLEX_ATTENTION backend is deprecated and will be removed in "
+            "v0.30.0. Use TRITON_ATTN or FLASH_ATTN instead."
+        )
+
     # Adjust kv cache layout if the selected backend requires a specific one
     required_layout = backend.get_required_kv_cache_layout()
     if required_layout is not None:


### PR DESCRIPTION
## Purpose

Fixes https://github.com/vllm-project/vllm/issues/50324

### Motivation.

FlexAttention is no longer selected by default on ROCm and ranks behind TritonAttention on CUDA.

It has a lot of test coverage and is not used in practice, and sometimes breaks CI like https://github.com/vllm-project/vllm/issues/46531

**TritonAttention** now covers the standard FlexAttention use cases, including FP32, encoder-only, non-causal, sliding window, multimodal prefix, batch invariance, and Unlimited-OCR R-SWA.

Removing FlexAttention would eliminate roughly 1,900 lines of backend-specific implementation and tests, while reducing reliance on private PyTorch FlexAttention APIs.


### Proposed Change.

- Now: Mark `FLEX_ATTENTION` as deprecated.
- v0.29.0/v0.30.0: Remove the backend implementation, enum entry, Flex-specific configuration fields, and tests.
