### PR TITLE
[Perf] Skip detokenization in offline beam search

### DIFF
--- a/vllm/entrypoints/generate/beam_search/offline.py
+++ b/vllm/entrypoints/generate/beam_search/offline.py
@@ -119,6 +119,7 @@ class BeamSearchOfflineMixin(OfflineInferenceMixin):
             logprobs=2 * beam_width,
             max_tokens=1,
             temperature=temperature,
+            detokenize=False,
             skip_clone=True,  # Internal beam search, safe to skip clone
         )
         instances: list[BeamSearchInstance] = []
@@ -443,6 +444,7 @@ class BeamSearchOfflineMixin(OfflineInferenceMixin):
                 logprobs=base_params.logprobs,
                 max_tokens=1,
                 temperature=base_params.temperature,
+                detokenize=False,
                 allowed_token_ids=(
                     allowed_ids
                     if len(allowed_ids) <= _MAX_NUM_ALLOWED_TOKEN_IDS


### PR DESCRIPTION
## What & why

Follow-up to #46422, which skipped detokenization in online beam search and noted the offline path has the identical pattern.

Offline beam search asks for `logprobs = 2 * beam_width` on every internal per-step request. The engine detokenizes all of those token ids into strings on every step, but beam search never reads them. It ranks beams by `cum_logprob` and decodes the final text itself. This PR sets `detokenize=False` on the two internal `SamplingParams`, same as #46422 did for the online path.

As with #46422, the per-step `Logprob` entries in the returned sequences no longer carry `decoded_token` strings. Final output text is unchanged.

## Benchmark

A100, Qwen/Qwen3-1.7B (same model as #46422), offline `LLM.beam_search`, 8 prompts of 256 tokens, 32 output tokens, temperature 0, `enforce_eager`. One arm per process. Output token ids are sha256-compared across arms as a hard gate.

| beam width | wall clock (before → after) | speedup | outputs identical |
|---|---|---|---|
| 4 | 2.67s → 2.13s | 1.25x | yes |
| 8 | 3.58s → 2.71s | 1.32x | yes |
| 20 | 9.41s → 6.61s | 1.42x | yes |

The win grows with beam width, matching the O(beam_width) per-step cost #46422 measured on the online path (1.80x at width 20 there; eager mode inflates the per-step GPU time here, so these numbers are conservative).

## Correctness

Output token ids are bit-identical between arms at all three beam widths on the A100 run (sha256 gate). I also verified output equality on CPU (TinyLlama-1.1B, beam widths 4 and 8, 3 interleaved rounds each). The existing `tests/samplers/test_beam_search.py` suite covers the offline path against HF reference outputs in CI.

## Duplicate check

No open PR applies this to the offline path. #47630 touches the same file for `allowed_token_ids` handling and does not conflict with this change.

Done with Claude Code assistance, mostly on the benchmark harness and runs. I reviewed the change and validated the results.
