### PR TITLE
[Perf][Quantization] Add opt-in NVFP4 load-time dequantization

### DIFF
--- a/tests/quantization/test_nvfp4_aot.py
+++ b/tests/quantization/test_nvfp4_aot.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import cast
+from unittest.mock import Mock
+
+import torch
+
+from vllm.model_executor.kernels.linear.nvfp4.base import NvFp4LinearKernel
+from vllm.model_executor.kernels.linear.nvfp4.marlin import (
+    MarlinNvFp4LinearKernel,
+)
+from vllm.model_executor.layers.quantization.utils import nvfp4_aot
+
+
+def _marlin_kernel() -> MarlinNvFp4LinearKernel:
+    return MarlinNvFp4LinearKernel.__new__(MarlinNvFp4LinearKernel)
+
+
+def test_aot_dequant_delegates_to_unquantized_linear(monkeypatch):
+    monkeypatch.setattr(
+        nvfp4_aot.envs,
+        "VLLM_NVFP4_DEQUANT_AT_LOAD",
+        True,
+    )
+    monkeypatch.setattr(
+        nvfp4_aot,
+        "dequantize_to_dtype",
+        Mock(return_value=torch.ones((1, 16), dtype=torch.bfloat16)),
+    )
+
+    runtime = nvfp4_aot.NvFp4LinearRuntime(_marlin_kernel())
+    assert runtime.unquantized_method is not None
+    runtime.unquantized_method.process_weights_after_loading = Mock()
+    runtime.unquantized_method.apply = Mock(return_value=torch.tensor([1.0]))
+
+    layer = torch.nn.Module()
+    layer.params_dtype = torch.bfloat16
+    layer.weight = torch.nn.Parameter(
+        torch.zeros((1, 8), dtype=torch.uint8),
+        requires_grad=False,
+    )
+    layer.weight_scale = torch.ones((1, 1), dtype=torch.float8_e4m3fn)
+    layer.weight_global_scale = torch.tensor(1.0)
+    packed_weight = layer.weight
+
+    runtime.process_weights_after_loading(layer)
+    output = runtime.apply(layer, torch.tensor([1.0]))
+
+    assert layer.weight.dtype == torch.bfloat16
+    dequant_args = nvfp4_aot.dequantize_to_dtype.call_args
+    assert dequant_args.args[0] is packed_weight
+    assert dequant_args.args[1] is layer.weight_scale
+    assert dequant_args.args[2] is layer.weight_global_scale
+    assert dequant_args.args[3] == torch.bfloat16
+    assert dequant_args.kwargs == {"block_size": 16, "swizzle": False}
+    runtime.unquantized_method.process_weights_after_loading.assert_called_once_with(
+        layer
+    )
+    runtime.unquantized_method.apply.assert_called_once()
+    assert torch.equal(output, torch.tensor([1.0]))
+
+
+def test_aot_dequant_disabled_keeps_nvfp4_kernel(monkeypatch):
+    monkeypatch.setattr(
+        nvfp4_aot.envs,
+        "VLLM_NVFP4_DEQUANT_AT_LOAD",
+        False,
+    )
+
+    kernel = _marlin_kernel()
+    kernel.process_weights_after_loading = Mock()
+    kernel.apply_weights = Mock(return_value=torch.tensor([2.0]))
+    runtime = nvfp4_aot.NvFp4LinearRuntime(kernel)
+
+    layer = torch.nn.Module()
+    runtime.process_weights_after_loading(layer)
+    output = runtime.apply(layer, torch.tensor([1.0]))
+
+    assert not runtime.uses_unquantized_linear
+    kernel.process_weights_after_loading.assert_called_once_with(layer)
+    kernel.apply_weights.assert_called_once()
+    assert torch.equal(output, torch.tensor([2.0]))
+
+
+def test_aot_dequant_only_replaces_marlin(monkeypatch):
+    monkeypatch.setattr(
+        nvfp4_aot.envs,
+        "VLLM_NVFP4_DEQUANT_AT_LOAD",
+        True,
+    )
+
+    non_marlin_kernel = cast(NvFp4LinearKernel, object())
+    runtime = nvfp4_aot.NvFp4LinearRuntime(non_marlin_kernel)
+
+    assert not runtime.uses_unquantized_linear

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -124,6 +124,7 @@ if TYPE_CHECKING:
     VLLM_ENABLE_FLA_PACKED_RECURRENT_DECODE: bool = True
     VLLM_DISABLE_PYNCCL: bool = False
     VLLM_USE_OINK_OPS: bool = False
+    VLLM_NVFP4_DEQUANT_AT_LOAD: bool = False
     VLLM_MXFP8_EMULATION_DEQUANT_AT_LOAD: bool = True
     VLLM_ROCM_USE_AITER: bool = False
     VLLM_ROCM_USE_AITER_CUSTOM_AR: bool = True
@@ -1176,6 +1177,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Disabled by default.
     "VLLM_USE_OINK_OPS": lambda: (
         os.getenv("VLLM_USE_OINK_OPS", "False").lower() in ("true", "1")
+    ),
+    # When Marlin is selected for NVFP4, optionally expand the weights to
+    # BF16/FP16 once at model load and delegate execution to the unquantized
+    # linear method. This uses roughly four times the weight memory. Default off.
+    "VLLM_NVFP4_DEQUANT_AT_LOAD": lambda: (
+        os.getenv("VLLM_NVFP4_DEQUANT_AT_LOAD", "False").lower() in ("true", "1")
     ),
     # Disable aiter ops unless specifically enabled.
     # Acts as a parent switch to enable the rest of the other operations.

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -13,6 +13,9 @@ from vllm.model_executor.layers.fusion.quant_activation import (
 from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
     CompressedTensorsScheme,
 )
+from vllm.model_executor.layers.quantization.utils.nvfp4_aot import (
+    NvFp4LinearRuntime,
+)
 from vllm.model_executor.parameter import (
     GroupQuantScaleParameter,
     ModelWeightParameter,
@@ -29,6 +32,7 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
     def __init__(self, use_a16: bool = False):
         self.use_a16 = use_a16
         self.kernel = init_nvfp4_linear_kernel(use_a16=use_a16)
+        self.runtime = NvFp4LinearRuntime(self.kernel)
         self.group_size = 16
 
     @classmethod
@@ -48,6 +52,7 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
         layer.logical_widths = output_partition_sizes
         layer.input_size_per_partition = input_size_per_partition
         layer.output_size_per_partition = output_size_per_partition
+        layer.params_dtype = params_dtype
 
         # Weight
         weight = ModelWeightParameter(
@@ -137,8 +142,7 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
                 requires_grad=False,
             )
 
-        # Convert layer to NVFP4 linear kernel format
-        self.kernel.process_weights_after_loading(layer)
+        self.runtime.process_weights_after_loading(layer)
 
     def apply_weights(
         self,
@@ -146,4 +150,4 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        return self.kernel.apply_weights(layer=layer, x=x, bias=bias)
+        return self.runtime.apply(layer, x, bias)

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -71,6 +71,9 @@ from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
     MXFP8_SCALE_DTYPE,
     MXFP8_VALUE_DTYPE,
 )
+from vllm.model_executor.layers.quantization.utils.nvfp4_aot import (
+    NvFp4LinearRuntime,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     GroupShape,
     create_fp8_quant_key,
@@ -1124,6 +1127,7 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
         self.quant_config = quant_config
         self.marlin_input_dtype = None
         self.kernel = init_nvfp4_linear_kernel()
+        self.runtime = NvFp4LinearRuntime(self.kernel)
 
     def create_weights(
         self,
@@ -1146,6 +1150,7 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
         layer.logical_widths = output_partition_sizes
         layer.input_size_per_partition = input_size_per_partition
         layer.output_size_per_partition = output_size_per_partition
+        layer.params_dtype = params_dtype
 
         if input_size_per_partition % 16 != 0:
             raise ValueError(
@@ -1231,8 +1236,7 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
             (1.0 / layer.input_global_scale).to(torch.float32), requires_grad=False
         )
 
-        # Convert layer to NVFP4 linear kernel format
-        self.kernel.process_weights_after_loading(layer)
+        self.runtime.process_weights_after_loading(layer)
 
     def apply(
         self,
@@ -1240,7 +1244,7 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        return self.kernel.apply_weights(layer=layer, x=x, bias=bias)
+        return self.runtime.apply(layer, x, bias)
 
 
 class ModelOptNvFp4W4A16LinearMethod(LinearMethodBase):
@@ -1278,6 +1282,7 @@ class ModelOptNvFp4W4A16LinearMethod(LinearMethodBase):
         # silently try to quantize activations (we have no input_scale). For
         # W4A16 there is exactly one valid kernel, so we pin it.
         self.kernel = MarlinNvFp4LinearKernel(NvFp4LinearLayerConfig())
+        self.runtime = NvFp4LinearRuntime(self.kernel)
 
     def create_weights(
         self,
@@ -1300,6 +1305,7 @@ class ModelOptNvFp4W4A16LinearMethod(LinearMethodBase):
         layer.logical_widths = output_partition_sizes
         layer.input_size_per_partition = input_size_per_partition
         layer.output_size_per_partition = output_size_per_partition
+        layer.params_dtype = params_dtype
 
         if input_size_per_partition % 16 != 0:
             raise ValueError(
@@ -1378,7 +1384,7 @@ class ModelOptNvFp4W4A16LinearMethod(LinearMethodBase):
         )
         del layer.weight_scale_2
 
-        self.kernel.process_weights_after_loading(layer)
+        self.runtime.process_weights_after_loading(layer)
 
     def apply(
         self,
@@ -1386,7 +1392,7 @@ class ModelOptNvFp4W4A16LinearMethod(LinearMethodBase):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        return self.kernel.apply_weights(layer=layer, x=x, bias=bias)
+        return self.runtime.apply(layer, x, bias)
 
 
 class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):

--- a/vllm/model_executor/layers/quantization/quark/schemes/quark_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/quark_nvfp4.py
@@ -14,6 +14,9 @@ from vllm.model_executor.kernels.linear.nvfp4.emulation import (
 from vllm.model_executor.layers.quantization.quark.schemes.quark_scheme import (
     QuarkScheme,
 )
+from vllm.model_executor.layers.quantization.utils.nvfp4_aot import (
+    NvFp4LinearRuntime,
+)
 from vllm.model_executor.parameter import (
     GroupQuantScaleParameter,
     ModelWeightParameter,
@@ -40,9 +43,12 @@ class QuarkNVFP4(QuarkScheme):
         self,
     ):
         self.kernel = init_nvfp4_linear_kernel()
+        self.runtime = NvFp4LinearRuntime(self.kernel)
         self.group_size = 16
 
-        if not isinstance(self.kernel, EmulationNvFp4LinearKernel):
+        if not self.runtime.uses_unquantized_linear and not isinstance(
+            self.kernel, EmulationNvFp4LinearKernel
+        ):
             logger.warning_once(
                 "Only EmulationNvFp4LinearKernel NVFP4 dense implementation is "
                 "tested with QuarkNVFP4, got kernel=%s. Correctness is not validated.",
@@ -67,6 +73,7 @@ class QuarkNVFP4(QuarkScheme):
         layer.logical_widths = output_partition_sizes
         layer.input_size_per_partition = input_size_per_partition
         layer.output_size_per_partition = output_size_per_partition
+        layer.params_dtype = params_dtype
 
         if input_size_per_partition % self.group_size != 0:
             raise ValueError(
@@ -142,8 +149,7 @@ class QuarkNVFP4(QuarkScheme):
             (1.0 / layer.input_global_scale).to(torch.float32), requires_grad=False
         )
 
-        # Convert layer to NVFP4 linear kernel format
-        self.kernel.process_weights_after_loading(layer)
+        self.runtime.process_weights_after_loading(layer)
 
     def apply_weights(
         self,
@@ -151,4 +157,4 @@ class QuarkNVFP4(QuarkScheme):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        return self.kernel.apply_weights(layer=layer, x=x, bias=bias)
+        return self.runtime.apply(layer, x, bias)

--- a/vllm/model_executor/layers/quantization/utils/nvfp4_aot.py
+++ b/vllm/model_executor/layers/quantization/utils/nvfp4_aot.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+import vllm.envs as envs
+from vllm.logger import init_logger
+from vllm.model_executor.kernels.linear.nvfp4.base import NvFp4LinearKernel
+from vllm.model_executor.kernels.linear.nvfp4.marlin import (
+    MarlinNvFp4LinearKernel,
+)
+from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+from vllm.model_executor.layers.quantization.utils.nvfp4_emulation_utils import (
+    dequantize_to_dtype,
+)
+from vllm.model_executor.utils import replace_parameter
+
+logger = init_logger(__name__)
+
+
+class NvFp4LinearRuntime:
+    """Select the execution method after an NVFP4 checkpoint is loaded."""
+
+    def __init__(self, kernel: NvFp4LinearKernel) -> None:
+        self.kernel = kernel
+        self.unquantized_method = (
+            UnquantizedLinearMethod()
+            if envs.VLLM_NVFP4_DEQUANT_AT_LOAD
+            and isinstance(kernel, MarlinNvFp4LinearKernel)
+            else None
+        )
+
+    @property
+    def uses_unquantized_linear(self) -> bool:
+        return self.unquantized_method is not None
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if self.unquantized_method is None:
+            self.kernel.process_weights_after_loading(layer)
+            return
+
+        logger.warning_once(
+            "VLLM_NVFP4_DEQUANT_AT_LOAD is enabled. Expanding NVFP4 weights "
+            "to BF16/FP16 at model load and using the unquantized linear "
+            "runtime. This uses roughly four times the weight memory."
+        )
+        weight = dequantize_to_dtype(
+            layer.weight,
+            layer.weight_scale,
+            layer.weight_global_scale,
+            layer.params_dtype,
+            block_size=16,
+            swizzle=False,
+        )
+        replace_parameter(layer, "weight", weight.contiguous())
+        self.unquantized_method.process_weights_after_loading(layer)
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if self.unquantized_method is not None:
+            return self.unquantized_method.apply(layer, x, bias)
+        return self.kernel.apply_weights(layer=layer, x=x, bias=bias)


### PR DESCRIPTION
## Purpose

Hopper does not have native FP4 tensor-core support, so dense NVFP4 layers fall
back to the Marlin W4A16 kernel. For large encode/prefill batches, profiling
showed that Marlin spends substantial time on runtime FP4 dequantization and
k-split overhead while leaving the BF16 tensor pipeline underutilized.

This PR adds an opt-in load-time conversion path:

```bash
VLLM_NVFP4_DEQUANT_AT_LOAD=1
```

When the selected NVFP4 kernel is Marlin, the packed FP4 weights are
dequantized to the model's BF16/FP16 parameter dtype once after checkpoint
loading. Forward execution is then delegated to vLLM's canonical
`UnquantizedLinearMethod`. The Marlin kernel remains quantized-only.

The path is wired through the ModelOpt, compressed-tensors, and Quark dense
NVFP4 checkpoint frontends.

## Behavior

| Configuration | Runtime |
|---|---|
| Environment variable unset or disabled | Existing NVFP4 kernel path; Marlin remains the Hopper fallback |
| Environment variable enabled and Marlin selected | Dequantize once at load, then use the regular BF16/FP16 linear runtime |
| Native NVFP4 kernel selected | Existing native kernel path, regardless of the environment variable |

The feature is disabled by default. Enabling it expands FP4 weights to
BF16/FP16 in device memory, requiring approximately 4x the packed weight
storage.

## H100 results

Measured with `nvidia/Nemotron-3-Embed-1B-NVFP4` on one H100 using the
equivalent load-time FP4-to-BF16 conversion and dense BF16 GEMM strategy.

### Correctness

- Real checkpoint linears (`q_proj`, `o_proj`, `gate_proj`, and `down_proj`):
  cosine similarity `1.00000` versus Marlin, with mean relative error at or
  below `0.0016`.
- End-to-end embeddings over four sentences: cosine similarity
  `0.9994-0.9998` versus the baseline server; worst case `0.999421`.
- 0 request errors in the 2,500-request serving comparison.

### Performance

| Measurement | Marlin baseline | Load-time dequant + BF16 linear | Result |
|---|---:|---:|---:|
| Fixed encode-shape GEMMs, M=2048/4096 | — | — | **2.4-2.8x faster** |
| In-server GEMM time from CUDA graph traces | 18.07 s | 7.38 s | **2.45x faster** |
| Total GPU-kernel time from CUDA graph traces | 20.66 s | 10.18 s | **0.49x** |
| ISL 4096 throughput, CC 64 | 37.67 req/s | 55.45 req/s | **+47%** |
| ISL 4096 average latency | 1601.6 ms | 760.4 ms | **-53%** |
| ISL 256 throughput, CC 64 | 357.38 req/s | 360.67 req/s | **+0.9%** |
| ISL 256 average latency | 175.53 ms | 174.34 ms | **-0.7%** |

At ISL 4096, the workload is GPU-compute-bound and the GEMM improvement
translates directly into end-to-end throughput and latency. At ISL 256, the
server is limited by CPU-side request handling, so end-to-end throughput stays
approximately flat even though GPU work is substantially reduced.

In the same ISL 4096 workload, the converted NVFP4 model was within about 2%
of the native BF16 checkpoint:

| Variant | Throughput | Average latency |
|---|---:|---:|
| Native BF16 | 56.78 req/s | 747 ms |
| NVFP4 + Marlin | 37.67 req/s | 1602 ms |
| NVFP4 + load-time dequant | 55.45 req/s | 760 ms |

This preserves the smaller NVFP4 checkpoint/download size, but runtime weight
memory is equivalent to the dequantized BF16/FP16 model.

## Test plan

- Added unit coverage for:
  - enabled load-time dequantization and delegation to
    `UnquantizedLinearMethod`;
  - the default disabled path continuing to use Marlin;
  - native/non-Marlin kernels remaining unchanged when the variable is enabled.
- Ran the repository pre-commit suite locally; Ruff, mypy, SPDX, environment
  validation, and all other applicable hooks passed.
- Full local pytest collection was blocked because the checkout does not have
  the compiled `vllm._C_stable_libtorch` extension. The focused test is
  included for CI execution.
