### PR TITLE
[Test] Harden NVFP4 KV scale-layout validation

### DIFF
--- a/tests/kernels/attention/test_cache.py
+++ b/tests/kernels/attention/test_cache.py
@@ -354,28 +354,57 @@ def test_reshape_and_cache_flash(
             dequant_nvfp4_kv_cache,
         )
 
-        def dequant_nvfp4_cache_nhd(data_cache, scale_cache, global_scale):
+        def dequant_nvfp4_cache_nhd(
+            data_cache,
+            scale_cache,
+            global_scale,
+            scales_are_swizzled,
+        ):
             # data_cache:  [N, T, H, data_dim]  NHD (contiguous inner dims)
             # scale_cache: [N, T, H, scale_dim] NHD (contiguous inner dims)
             # Permute to HND layout for the dequant utility.
             data_hnd = data_cache.permute(0, 2, 1, 3)
             scale_hnd = scale_cache.permute(0, 2, 1, 3)
             result_hnd = dequant_nvfp4_kv_cache(
-                data_hnd, scale_hnd, global_scale, head_size, block_size
+                data_hnd,
+                scale_hnd,
+                global_scale,
+                head_size,
+                block_size,
+                scales_are_swizzled=scales_are_swizzled,
             )
             return result_hnd.permute(0, 2, 1, 3)  # back to [N, T, H, D]
 
+        # The current writer stores K scales linearly and V scales in the
+        # TRT-LLM 4x4 layout. Keep both contracts explicit in the reference.
         result_key_cache = dequant_nvfp4_cache_nhd(
-            nvfp4_key_data, key_scale_cache, k_scale.item()
+            nvfp4_key_data,
+            key_scale_cache,
+            k_scale.item(),
+            scales_are_swizzled=False,
         )
         result_value_cache = dequant_nvfp4_cache_nhd(
-            nvfp4_value_data, value_scale_cache, v_scale.item()
+            nvfp4_value_data,
+            value_scale_cache,
+            v_scale.item(),
+            scales_are_swizzled=True,
         )
 
         # Flatten [num_blocks, block_size] → [num_slots] and index by slot_mapping.
         num_slots = num_blocks * block_size
         result_key_flat = result_key_cache.reshape(num_slots, num_heads, head_size)
         result_value_flat = result_value_cache.reshape(num_slots, num_heads, head_size)
+
+        # The elementwise tolerance below can hide a structurally wrong scale
+        # ordering. Normal NVFP4 loss is about 0.1 relative L2 for these inputs.
+        for name, actual, expected in (
+            ("key", result_key_flat[slot_mapping], key.float()),
+            ("value", result_value_flat[slot_mapping], value.float()),
+        ):
+            rel_l2 = torch.linalg.vector_norm(
+                actual - expected
+            ) / torch.linalg.vector_norm(expected)
+            assert rel_l2 < 0.15, f"{name} NVFP4 relative L2 error: {rel_l2}"
 
         torch.testing.assert_close(
             result_key_flat[slot_mapping], key.float(), atol=1.5, rtol=0.5

--- a/tests/kernels/attention/test_cache.py
+++ b/tests/kernels/attention/test_cache.py
@@ -356,28 +356,57 @@ def test_reshape_and_cache_flash(
             dequant_nvfp4_kv_cache,
         )
 
-        def dequant_nvfp4_cache(data_cache, scale_cache, global_scale):
+        def dequant_nvfp4_cache(
+            data_cache,
+            scale_cache,
+            global_scale,
+            scales_are_swizzled,
+        ):
             # data_cache:  [B, N, H, data_dim]  logical view (layout in strides)
             # scale_cache: [B, N, H, scale_dim] logical view (layout in strides)
             # Permute to [B, H, N, dim] for the dequant utility.
             data_hnd = data_cache.permute(0, 2, 1, 3)
             scale_hnd = scale_cache.permute(0, 2, 1, 3)
             result_hnd = dequant_nvfp4_kv_cache(
-                data_hnd, scale_hnd, global_scale, head_size, block_size
+                data_hnd,
+                scale_hnd,
+                global_scale,
+                head_size,
+                block_size,
+                scales_are_swizzled=scales_are_swizzled,
             )
             return result_hnd.permute(0, 2, 1, 3)  # back to [B, N, H, dim]
 
+        # The current writer stores K scales linearly and V scales in the
+        # TRT-LLM 4x4 layout. Keep both contracts explicit in the reference.
         result_key_cache = dequant_nvfp4_cache(
-            nvfp4_key_data, key_scale_cache, k_scale.item()
+            nvfp4_key_data,
+            key_scale_cache,
+            k_scale.item(),
+            scales_are_swizzled=False,
         )
         result_value_cache = dequant_nvfp4_cache(
-            nvfp4_value_data, value_scale_cache, v_scale.item()
+            nvfp4_value_data,
+            value_scale_cache,
+            v_scale.item(),
+            scales_are_swizzled=True,
         )
 
         # Flatten [num_blocks, block_size] → [num_slots] and index by slot_mapping.
         num_slots = num_blocks * block_size
         result_key_flat = result_key_cache.reshape(num_slots, num_heads, head_size)
         result_value_flat = result_value_cache.reshape(num_slots, num_heads, head_size)
+
+        # The elementwise tolerance below can hide a structurally wrong scale
+        # ordering. Normal NVFP4 loss is about 0.1 relative L2 for these inputs.
+        for name, actual, expected in (
+            ("key", result_key_flat[slot_mapping], key.float()),
+            ("value", result_value_flat[slot_mapping], value.float()),
+        ):
+            rel_l2 = torch.linalg.vector_norm(
+                actual - expected
+            ) / torch.linalg.vector_norm(expected)
+            assert rel_l2 < 0.15, f"{name} NVFP4 relative L2 error: {rel_l2}"
 
         torch.testing.assert_close(
             result_key_flat[slot_mapping], key.float(), atol=1.5, rtol=0.5

--- a/tests/kernels/quantization/nvfp4_utils.py
+++ b/tests/kernels/quantization/nvfp4_utils.py
@@ -94,8 +94,9 @@ def dequant_nvfp4_kv_cache(
     global_scale: float,
     head_size: int,
     block_size: int,
+    scales_are_swizzled: bool = True,
 ) -> torch.Tensor:
-    """Dequantize an NVFP4 KV cache with 4x4-swizzled block scales.
+    """Dequantize an NVFP4 KV cache.
 
     The input must be in HND layout so that the last two dims are
     (block_size, last_dim).  For NHD caches, permute to HND first.
@@ -107,6 +108,7 @@ def dequant_nvfp4_kv_cache(
         global_scale: checkpoint dequant scale (k_scale or v_scale).
         head_size: head dimension.
         block_size: page size.
+        scales_are_swizzled: Whether block scales use TRT-LLM's 4x4 layout.
 
     Returns:
         [..., num_heads, block_size, head_size] float32.
@@ -115,18 +117,22 @@ def dequant_nvfp4_kv_cache(
     scale_dim = head_size // 16
 
     fp4_packed = fp4_data
-    sf_swizzled = block_scale.view(torch.uint8)
-
-    # Unswizzle 4x4 block scales on (block_size, scale_dim) plane.
-    # [..., T, S] → [..., T//4, 4, sg, 4] → permute → [..., T, S]
-    batch_shape = sf_swizzled.shape[:-2]
-    T, S = block_size, scale_dim
-    sg = S // 4
-    sf_reshape = sf_swizzled.reshape(*batch_shape, T // 4, 4, sg, 4)
-    ndim = sf_reshape.ndim
-    # Swap the last four dims: (..., T//4, 4, sg, 4) → (..., T//4, 4, 4, sg)
-    perm = list(range(ndim - 4)) + [ndim - 4, ndim - 1, ndim - 3, ndim - 2]
-    sf_linear = sf_reshape.permute(*perm).reshape(*batch_shape, T, S)
+    sf_linear = block_scale.view(torch.uint8)
+    if scales_are_swizzled:
+        # Unswizzle 4x4 block scales on (block_size, scale_dim) plane.
+        # [..., T, S] → [..., T//4, 4, sg, 4] → permute → [..., T, S]
+        batch_shape = sf_linear.shape[:-2]
+        T, S = block_size, scale_dim
+        sg = S // 4
+        sf_reshape = sf_linear.reshape(*batch_shape, T // 4, 4, sg, 4)
+        ndim = sf_reshape.ndim
+        perm = list(range(ndim - 4)) + [
+            ndim - 4,
+            ndim - 1,
+            ndim - 3,
+            ndim - 2,
+        ]
+        sf_linear = sf_reshape.permute(*perm).reshape(*batch_shape, T, S)
     sf_f32 = sf_linear.view(torch.float8_e4m3fn).to(torch.float32)
 
     # Unpack fp4

--- a/tests/kernels/quantization/nvfp4_utils.py
+++ b/tests/kernels/quantization/nvfp4_utils.py
@@ -97,8 +97,9 @@ def dequant_nvfp4_kv_cache(
     global_scale: float,
     head_size: int,
     block_size: int,
+    scales_are_swizzled: bool = True,
 ) -> torch.Tensor:
-    """Dequantize an NVFP4 KV cache with 4x4-swizzled block scales.
+    """Dequantize an NVFP4 KV cache.
 
     The input must be in HND layout so that the last two dims are
     (block_size, last_dim).  For NHD caches, permute to HND first.
@@ -110,6 +111,7 @@ def dequant_nvfp4_kv_cache(
         global_scale: checkpoint dequant scale (k_scale or v_scale).
         head_size: head dimension.
         block_size: page size.
+        scales_are_swizzled: Whether block scales use TRT-LLM's 4x4 layout.
 
     Returns:
         [..., num_heads, block_size, head_size] float32.
@@ -118,18 +120,22 @@ def dequant_nvfp4_kv_cache(
     scale_dim = head_size // 16
 
     fp4_packed = fp4_data
-    sf_swizzled = block_scale.view(torch.uint8)
-
-    # Unswizzle 4x4 block scales on (block_size, scale_dim) plane.
-    # [..., T, S] → [..., T//4, 4, sg, 4] → permute → [..., T, S]
-    batch_shape = sf_swizzled.shape[:-2]
-    T, S = block_size, scale_dim
-    sg = S // 4
-    sf_reshape = sf_swizzled.reshape(*batch_shape, T // 4, 4, sg, 4)
-    ndim = sf_reshape.ndim
-    # Swap the last four dims: (..., T//4, 4, sg, 4) → (..., T//4, 4, 4, sg)
-    perm = list(range(ndim - 4)) + [ndim - 4, ndim - 1, ndim - 3, ndim - 2]
-    sf_linear = sf_reshape.permute(*perm).reshape(*batch_shape, T, S)
+    sf_linear = block_scale.view(torch.uint8)
+    if scales_are_swizzled:
+        # Unswizzle 4x4 block scales on (block_size, scale_dim) plane.
+        # [..., T, S] → [..., T//4, 4, sg, 4] → permute → [..., T, S]
+        batch_shape = sf_linear.shape[:-2]
+        T, S = block_size, scale_dim
+        sg = S // 4
+        sf_reshape = sf_linear.reshape(*batch_shape, T // 4, 4, sg, 4)
+        ndim = sf_reshape.ndim
+        perm = list(range(ndim - 4)) + [
+            ndim - 4,
+            ndim - 1,
+            ndim - 3,
+            ndim - 2,
+        ]
+        sf_linear = sf_reshape.permute(*perm).reshape(*batch_shape, T, S)
     sf_f32 = sf_linear.view(torch.float8_e4m3fn).to(torch.float32)
 
     # Unpack fp4


### PR DESCRIPTION
## Summary

Harden the NVFP4 KV-cache writer test so a structurally wrong block-scale
layout cannot pass behind the existing loose elementwise tolerance.

- Let the test dequantizer handle linear and TRT-LLM 4x4-swizzled block
  scales explicitly.
- Decode K as linear and V as swizzled, matching the current-main writer
  contract.
- Add a relative-L2 bound of 0.15 for both K and V while retaining the
  existing elementwise check.

This changes test/reference code only. It does not change a runtime kernel,
backend selection, or model output.

## Why this matters

`test_reshape_and_cache_flash` previously unswizzled both K and V even though
the writer stores K linearly and V in the TRT-LLM layout. Its
`assert_close(atol=1.5, rtol=0.5)` was loose enough to hide a structurally
wrong scale ordering. Normal loss for the deterministic NVFP4 inputs is about
0.1 relative L2, while the independently measured wrong-layout regime is
0.76-0.79.

In a local red/green check, deliberately interpreting the current swizzled V
scales as linear failed the new guard; restoring the current writer contract
passed the identical case.

## Non-duplicate rationale

I checked #50084 and searched open PRs for its number, NVFP4 relative-L2/layout
tests, and `dequant_nvfp4_kv_cache`; no open PR contains this hardening.

#46329 changes the SM12x writer/integration contract but does not modify either
test file changed here. This PR intentionally records current main's writer
layout. If #46329 lands, its architecture-dependent V layout should update the
explicit V flag rather than weakening the error bound. The earlier #50085 was
self-closed as a duplicate runtime fix; this draft extracts only its unclaimed
test-hardening portion.

## Validation

On RTX 5090 (SM120), using the freshly built current-main native extension.
The relevant kernel/binding files are unchanged between that build and this
branch:

```text
pytest tests/kernels/attention/test_cache.py \
  -k "test_reshape_and_cache_flash and nvfp4" -q
24 passed, 264 skipped, 945 deselected

ruff check tests/kernels/attention/test_cache.py \
  tests/kernels/quantization/nvfp4_utils.py
All checks passed!

ruff format --check tests/kernels/attention/test_cache.py \
  tests/kernels/quantization/nvfp4_utils.py
2 files already formatted
```

No model evaluation was run because this PR changes tests only and has no
runtime behavior.

## AI assistance

AI assistance was used to reconstruct the prior test diff, audit duplicate
work, run the checks, and draft this description. The hardware measurements
and underlying investigation were produced and verified by me. Before this
draft is marked ready, I will personally review and understand every changed
line as required by `AGENTS.md`.
