### PR TITLE
[Bugfix][MoE] Write Humming results to the supplied output buffer

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/fused_humming_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/fused_humming_moe.py
@@ -662,11 +662,8 @@ class HummingIndexedExperts(HummingExpertsBase):
             topk_weights=topk_weights,
             topk_ids=topk_ids,
             expert_map=expert_map,
-            outputs=buffers["output"],
+            outputs=output,
         )
-
-        # Note: output is already written to buffers["output"]
-        # which aliases workspace13/output
 
 
 class HummingGroupedExperts(HummingExpertsBase):
@@ -777,15 +774,12 @@ class HummingGroupedExperts(HummingExpertsBase):
         )
 
         moe_unpermute(
-            out=buffers["output"],
+            out=output,
             permuted_hidden_states=buffers["down_output"].view(*topk_ids.shape, -1),
             topk_weights=topk_weights,
             inv_permuted_idx=inv_perm,
             expert_first_token_offset=expert_first_token_offset,
         )
-
-        # Note: output is already written to buffers["output"]
-        # which aliases workspace13/output
 
 
 class BatchedHummingGroupedExperts(HummingExpertsBase):
@@ -880,13 +874,10 @@ class BatchedHummingGroupedExperts(HummingExpertsBase):
             layer=self.layer,
             inputs=inputs,
             input_scale=input_scale,
-            outputs=buffers["down_output"].view(-1, hidden_states.size(-1)),
+            outputs=output.view(-1, hidden_states.size(-1)),
             valid_shape_m=valid_shape_m,
             expert_layout=expert_num_tokens,
             compute_config=self.compute_config_str,
             tuning_config=self.w2_tuning_config_str,
             sublayer_name="w2",
         )
-
-        # Note: output is already written to buffers["down_output"]
-        # which aliases workspace13/output


### PR DESCRIPTION
### Purpose

[Kimi K3 PR #50089](https://github.com/vllm-project/vllm/pull/50089) enabled the [generic CUDA modular-MoE output alias](https://github.com/vllm-project/vllm/blob/7c6729b769597541d327f666273cd972b8a5318d/vllm/model_executor/layers/fused_moe/modular_kernel.py#L1339-L1340) when the caller-provided output matches the fused-experts result.

Humming ignored the supplied `output` argument and wrote their final results to views of the internal workspaces. Once the alias was enabled, vLLM could return the caller-provided buffer even though Humming had written to a different buffer, causing corrupted model output.

Write each Humming finalization path directly to `output`. Before #50089,
`output` was the same workspace view, so this preserves the old behavior.

### Test Plan
- `pytest tests/kernels/moe/test_moe.py -k humming_gated_non_gated_shape_contract -v`
- GSM8K and GPQA accuracy evaluations with the same three options, compared against the default-backend baseline

### AI assistance
AI assistance was used.
