### PR TITLE
[Bugfix] Break cached Hub metadata traceback cycles

### DIFF
--- a/tests/transformers_utils/test_repo_utils.py
+++ b/tests/transformers_utils/test_repo_utils.py
@@ -2,10 +2,14 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+import gc
 import tempfile
+import weakref
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
+import httpx
+import huggingface_hub
 import pytest
 from huggingface_hub import _CACHED_NO_EXIST
 
@@ -15,6 +19,74 @@ from vllm.transformers_utils.repo_utils import (
     is_mistral_model_repo,
     list_filtered_repo_files,
 )
+
+
+def test_hf_hub_cached_fallback_does_not_retain_caller(monkeypatch, tmp_path):
+    class Owner:
+        pass
+
+    repo_id = "test-org/test-model"
+    filename = "config.json"
+    commit_hash = "0" * 40
+    storage = tmp_path / "models--test-org--test-model"
+    pointer = storage / "snapshots" / commit_hash / filename
+    pointer.parent.mkdir(parents=True)
+    pointer.write_text("{}")
+    refs = storage / "refs"
+    refs.mkdir()
+    (refs / "main").write_text(commit_hash)
+
+    def fail_metadata_request(*args, **kwargs):
+        try:
+            raise OSError("simulated connection reset")
+        except OSError as error:
+            raise httpx.ConnectError("simulated transient HEAD failure") from error
+
+    monkeypatch.setattr(
+        huggingface_hub.file_download,
+        "get_hf_file_metadata",
+        fail_metadata_request,
+    )
+
+    def download_from_caller(owner):
+        return huggingface_hub.hf_hub_download(
+            repo_id,
+            filename,
+            cache_dir=tmp_path,
+        )
+
+    gc_was_enabled = gc.isenabled()
+    gc.collect()
+    gc.disable()
+    try:
+        owner = Owner()
+        owner_ref = weakref.ref(owner)
+        assert Path(download_from_caller(owner)) == pointer
+        del owner
+        assert owner_ref() is None
+    finally:
+        if gc_was_enabled:
+            gc.enable()
+        gc.collect()
+
+
+def test_hf_hub_uncached_metadata_failure_still_raises(monkeypatch, tmp_path):
+    def fail_metadata_request(*args, **kwargs):
+        raise httpx.ConnectError("simulated transient HEAD failure")
+
+    monkeypatch.setattr(
+        huggingface_hub.file_download,
+        "get_hf_file_metadata",
+        fail_metadata_request,
+    )
+
+    with pytest.raises(huggingface_hub.errors.LocalEntryNotFoundError) as exc_info:
+        huggingface_hub.hf_hub_download(
+            "test-org/uncached-model",
+            "config.json",
+            cache_dir=tmp_path,
+        )
+    assert isinstance(exc_info.value.__cause__, httpx.ConnectError)
 
 
 @pytest.mark.parametrize(

--- a/vllm/transformers_utils/repo_utils.py
+++ b/vllm/transformers_utils/repo_utils.py
@@ -7,12 +7,13 @@ import json
 import os
 import time
 from collections.abc import Callable
-from functools import cache
+from functools import cache, wraps
 from pathlib import Path
 from typing import Any, TypeVar
 
 import huggingface_hub
 from huggingface_hub import HfApi, try_to_load_from_cache
+from huggingface_hub import file_download as hf_file_download
 from huggingface_hub.utils import (
     EntryNotFoundError,
     HfHubHTTPError,
@@ -28,6 +29,54 @@ from vllm.version import __version__ as VLLM_VERSION
 logger = init_logger(__name__)
 
 _hf_api: HfApi | None = None
+
+
+def _clear_exception_tracebacks(error: BaseException) -> None:
+    """Detach traceback frames from an exception chain."""
+    pending = [error]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        current.__traceback__ = None
+        if current.__cause__ is not None:
+            pending.append(current.__cause__)
+        if current.__context__ is not None:
+            pending.append(current.__context__)
+
+
+def _patch_hf_hub_metadata_error_tracebacks() -> None:
+    """Prevent cached Hub fallbacks from retaining their callers.
+
+    Hugging Face Hub returns metadata exceptions to its download helper. When
+    that helper falls back to a cached file, the exception is discarded with
+    its traceback still attached. The traceback frame chain can retain the
+    caller until cyclic GC runs.
+    """
+    original = getattr(hf_file_download, "_get_metadata_or_catch_error", None)
+    if original is None or getattr(original, "_vllm_tracebacks_cleared", False):
+        return
+
+    @wraps(original)
+    def without_tracebacks(*args: Any, **kwargs: Any) -> Any:
+        result = original(*args, **kwargs)
+        if (
+            isinstance(result, tuple)
+            and len(result) == 6
+            and isinstance(result[-1], Exception)
+        ):
+            _clear_exception_tracebacks(result[-1])
+        return result
+
+    without_tracebacks._vllm_tracebacks_cleared = True  # type: ignore[attr-defined]
+    # TODO: Remove this compatibility patch when Hugging Face Hub detaches
+    # metadata errors before returning them to its download helpers.
+    hf_file_download._get_metadata_or_catch_error = without_tracebacks
+
+
+_patch_hf_hub_metadata_error_tracebacks()
 
 
 def hf_api() -> HfApi:


### PR DESCRIPTION
- A transient Hugging Face Hub HEAD failure can return a cached file while its swallowed exception traceback retains the vLLM caller until cyclic GC.
- The vLLM Hub boundary now detaches the returned exception, cause, and context tracebacks before cached fallback completes.
- The fix is platform-independent and does not add `gc.collect()` or change successful download behavior.
- Regression coverage forces the cached fallback with automatic GC disabled and verifies that an uncached failure still raises normally.

Motivation:
- [Failed AMD CI attempt](https://buildkite.com/vllm/amd-ci/builds/11417#019fad1a-5245-4cd2-a783-966c0ac6d325)
- [Same-SHA retry passed](https://buildkite.com/vllm/amd-ci/builds/11417#019fae76-7e8b-4b9c-bc9c-1d1bc2a0c138)
