### PR TITLE
[Bugfix][Scheduler] Clamp num_new_tokens to non-negative at max_model_len

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -519,6 +519,14 @@ class Scheduler(SchedulerInterface):
                 - self.num_sampled_tokens_per_step,
             )
 
+            # num_computed_tokens >= max_model_len (reachable via the optimistic
+            # spec-token advance under async scheduling on a disagg decode worker)
+            # makes the cap above negative. Clamp to 0 so it takes the intended
+            # "reached max_model_len" num_new_tokens == 0 path below (finished by
+            # the stop-check), instead of a negative num_scheduled_tokens crashing
+            # np.repeat(arange, -N) downstream in the model runner.
+            num_new_tokens = max(num_new_tokens, 0)
+
             # Schedule encoder inputs.
             encoder_inputs_to_schedule = None
             external_load_encoder_input: list[int] = []


### PR DESCRIPTION



## Purpose

Prevent a scheduler crash (np.repeat with a negative count) when a running request reaches max_model_len during speculative decoding. One-line defensive clamp; no behavior change on the normal path.

## Issue

With speculative decoding (MTP) — most reliably under disaggregated serving where the optimistic spec-advance runs ahead — a decode request can reach `num_computed_tokens >= max_model_len` before its stop-check finishes it. The `max_model_len` cap then produces a `negative` `num_new_tokens` (with `num_sampled_tokens_per_step == 1` the existing `num_new_tokens == 0` guard does not catch it), which flows into `num_scheduled_tokens` and crashes at `np.repeat(np.arange(...), num_scheduled_tokens)` with a negative repeat count.

### Reproduction

Serve a spec-decode (MTP) model with a finite `--max-model-len` and drive a request whose generation crosses that length within a step (long-context decode to the boundary). Without the fix: `ValueError`/crash at `np.repeat` (negative count) in `scheduler.py`. With the fix: the request ends cleanly with `finish_reason=length`.

## Test Plan

E2E: disagg + MTP long-context decode to the max_model_len boundary → expect finish_reason=length, no np.repeat crash.

## Test Result

Boundary E2E: 5/5 requests driven to the 262144 `max_model_len` boundary finished with `finish_reason=length` and zero `np.repeat crashes` (prior repro without the clamp: crash at the negative-count `np.repeat`)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

