### PR TITLE
[Misc] Warn by name when a removed env var is set (VLLM_ATTENTION_BACKEND)

### DIFF
--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -14,6 +14,7 @@ from vllm.envs import (
     env_set_with_choices,
     env_with_choices,
     environment_variables,
+    validate_environ,
 )
 from vllm.exceptions import VLLMValidationError
 
@@ -566,3 +567,54 @@ class TestVllmMaxNSequences:
 
         with pytest.raises(VLLMValidationError, match="n must be at most 128"):
             SamplingParams(n=129)
+
+
+class TestValidateEnviron:
+    """Test cases for validate_environ's handling of removed env vars."""
+
+    def test_removed_var_warns_with_actionable_message(self, caplog_vllm):
+        with (
+            patch.dict(
+                os.environ, {"VLLM_ATTENTION_BACKEND": "TRITON_ATTN"}, clear=True
+            ),
+            caplog_vllm.at_level("WARNING"),
+        ):
+            validate_environ(hard_fail=False)
+        assert any(
+            "VLLM_ATTENTION_BACKEND is no longer read by vLLM" in message
+            and "--attention-backend" in message
+            for message in caplog_vllm.messages
+        )
+
+    def test_removed_var_raises_actionable_error_with_hard_fail(self):
+        """hard_fail already rejects this variable as an unknown one -- it must
+        keep raising, now naming the replacement."""
+        with (
+            patch.dict(
+                os.environ, {"VLLM_ATTENTION_BACKEND": "TRITON_ATTN"}, clear=True
+            ),
+            pytest.raises(
+                ValueError,
+                match=r"VLLM_ATTENTION_BACKEND is no longer read.*--attention-backend",
+            ),
+        ):
+            validate_environ(hard_fail=True)
+
+    def test_unrecognized_var_still_raises_with_hard_fail(self):
+        with (
+            patch.dict(os.environ, {"VLLM_THIS_IS_NOT_A_REAL_VAR": "1"}, clear=True),
+            pytest.raises(ValueError, match="Unknown vLLM environment variable"),
+        ):
+            validate_environ(hard_fail=True)
+
+    def test_unrecognized_var_warns_without_hard_fail(self, caplog_vllm):
+        with (
+            patch.dict(os.environ, {"VLLM_THIS_IS_NOT_A_REAL_VAR": "1"}, clear=True),
+            caplog_vllm.at_level("WARNING"),
+        ):
+            validate_environ(hard_fail=False)
+        assert any(
+            "Unknown vLLM environment variable detected: VLLM_THIS_IS_NOT_A_REAL_VAR"
+            in message
+            for message in caplog_vllm.messages
+        )

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -2100,9 +2100,30 @@ def is_set(name: str):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
+# Env vars vLLM used to read that were removed in favor of a CLI flag or a
+# different env var. Setting one now has no effect; the generic "unknown
+# variable" message below doesn't say why, so call these out by name.
+REMOVED_ENVIRONMENT_VARIABLES: dict[str, str] = {
+    "VLLM_ATTENTION_BACKEND": (
+        "the --attention-backend CLI flag or the attention_backend argument to "
+        "LLM()/EngineArgs"
+    ),
+}
+
+
 def validate_environ(hard_fail: bool) -> None:
     for env in os.environ:
-        if env.startswith("VLLM_") and env not in environment_variables:
+        if env in REMOVED_ENVIRONMENT_VARIABLES:
+            # These already raise under hard_fail as unknown VLLM_ variables;
+            # only the message changes, not the strict-mode control flow.
+            message = (
+                f"Environment variable {env} is no longer read by vLLM and has "
+                f"no effect; use {REMOVED_ENVIRONMENT_VARIABLES[env]} instead."
+            )
+            if hard_fail:
+                raise ValueError(message)
+            logger.warning(message)
+        elif env.startswith("VLLM_") and env not in environment_variables:
             if hard_fail:
                 raise ValueError(f"Unknown vLLM environment variable detected: {env}")
             else:


### PR DESCRIPTION
## Purpose

When a user sets `VLLM_ATTENTION_BACKEND` today, vLLM tells them nothing useful: the variable was intentionally removed, but the only feedback is the generic `Unknown vLLM environment variable detected` warning, which reads like a typo report and names no replacement. This teaches `validate_environ()` about removed variables so it says what happened and what to use instead.

FIX #50292

Before:

```
WARNING [envs.py:2109] Unknown vLLM environment variable detected: VLLM_ATTENTION_BACKEND
```

After:

```
WARNING [envs.py:2125] Environment variable VLLM_ATTENTION_BACKEND is no longer read by vLLM and has no effect; use the --attention-backend CLI flag or the attention_backend argument to LLM()/EngineArgs instead.
```

### History

- #26315 (merged 2025-12-05) deprecated the attention env vars as part of the `AttentionConfig` migration (#25700), replacing `VLLM_ATTENTION_BACKEND` with `--attention-backend` / `attention_config.backend`.
- #32812 (merged 2026-01-22) removed them once v0.14.0 had shipped. That is why the literal string no longer appears anywhere in the package, which is what the issue reporter observed.
- #47399 by @zbrad already implemented this warning. That PR was closed without merging, bundled together with an unrelated CUDA toolchain/driver PTX guard for GB10 — the guard was the only part reviewers questioned, and no one objected to the env-var warning. **This PR extracts the env-var warning portion of #47399 by @zbrad**; the `REMOVED_ENVIRONMENT_VARIABLES` design, the message wording, and the tests all follow that PR.

### Behavior notes

- **This is a message change only — the control flow in both modes is exactly what `main` does today.** `VLLM_ATTENTION_BACKEND` is not in `environment_variables`, so on `main` it already takes the unknown-`VLLM_`-variable path: warn when `hard_fail=False`, `raise ValueError` when `hard_fail=True` (`--fail-on-environ-validation`). This PR keeps both outcomes and only replaces the generic text with one that names the replacement. Unrecognized `VLLM_*` variables are untouched in both modes.
- **Deliberate deviation from #47399:** that PR let removed variables warn even under `hard_fail`. I did not carry that over. Making them never raise would silently relax strict mode — a `--fail-on-environ-validation` run that fails today on `VLLM_ATTENTION_BACKEND` would start passing — which is a policy change orthogonal to fixing the message, and strict mode exists precisely to reject configuration vLLM will not honor. If maintainers would rather have the never-raise semantics, it is a two-line change and I am happy to make it.
- **Only `VLLM_ATTENTION_BACKEND` is listed.** #32812 removed nine attention env vars, but three of their replacement fields (`use_cudnn_prefill`, `use_trtllm_ragged_deepseek_prefill`, `disable_flashinfer_prefill`) no longer exist on `main`, so there is no accurate replacement to point users at for those. Listing only the variable that has a correct answer avoids shipping misleading advice; the `dict[str, str]` makes adding more a one-line change when someone wants to.

### Why this is not duplicating an existing PR (AGENTS.md)

```
gh issue view 50292 --repo vllm-project/vllm --comments
gh pr list --repo vllm-project/vllm --state open --search "50292 in:body"
gh pr list --repo vllm-project/vllm --state open --search "VLLM_ATTENTION_BACKEND"
gh pr list --repo vllm-project/vllm --state open --search "removed environment variable"
gh pr list --repo vllm-project/vllm --state open --search "validate_environ"
```

No open PR touches removed-env-var handling in `vllm/envs.py`. The open `VLLM_ATTENTION_BACKEND` hits are DCP error-message PRs (#37378, #38154, #38464, #41080, #46207) that mention the name in an unrelated error string. The one closed PR that did implement this, #47399, is credited above. The issue has no assignee and no linked PR.

## Test Plan

```bash
# Unit tests (4 new cases in TestValidateEnviron, 58 total in the file)
.venv/bin/python -m pytest tests/test_envs.py -v

# Behavior of the modified function, directly
VLLM_ATTENTION_BACKEND=TRITON_ATTN .venv/bin/python -c \
  "import vllm.envs as envs; envs.validate_environ(False)"
VLLM_ATTENTION_BACKEND=TRITON_ATTN .venv/bin/python -c \
  "import vllm.envs as envs; envs.validate_environ(True)"
VLLM_NOT_A_REAL_VAR=1 .venv/bin/python -c \
  "import vllm.envs as envs; envs.validate_environ(True)"

# Lint
pre-commit run --files vllm/envs.py tests/test_envs.py
```

## Test Result

**Unit tests** — `58 passed, 1 warning in 17.01s`, including:

```
tests/test_envs.py::TestValidateEnviron::test_removed_var_warns_with_actionable_message PASSED
tests/test_envs.py::TestValidateEnviron::test_removed_var_raises_actionable_error_with_hard_fail PASSED
tests/test_envs.py::TestValidateEnviron::test_unrecognized_var_still_raises_with_hard_fail PASSED
tests/test_envs.py::TestValidateEnviron::test_unrecognized_var_warns_without_hard_fail PASSED
```

Negative control — with `vllm/envs.py` reverted to its pre-change state and only the new tests run, exactly the two removed-var cases fail (`2 failed, 2 passed, 1 warning in 2.32s`), confirming the tests actually exercise the change:

```
FAILED tests/test_envs.py::TestValidateEnviron::test_removed_var_warns_with_actionable_message
FAILED tests/test_envs.py::TestValidateEnviron::test_removed_var_raises_actionable_error_with_hard_fail
```

The second failure is also the direct evidence that strict mode already rejects this variable on `main` — it fails on the message, not on the absence of an exception:

```
E   AssertionError: Regex pattern did not match.
E     Expected regex: 'VLLM_ATTENTION_BACKEND is no longer read.*--attention-backend'
E     Actual message: 'Unknown vLLM environment variable detected: VLLM_ATTENTION_BACKEND'
```

**Function behavior**

| command | before | after |
|---|---|---|
| `VLLM_ATTENTION_BACKEND=... validate_environ(False)` | `Unknown vLLM environment variable detected: VLLM_ATTENTION_BACKEND`, exit 0 | `Environment variable VLLM_ATTENTION_BACKEND is no longer read by vLLM and has no effect; use the --attention-backend CLI flag or the attention_backend argument to LLM()/EngineArgs instead.`, exit 0 |
| `VLLM_ATTENTION_BACKEND=... validate_environ(True)` | `ValueError: Unknown vLLM environment variable detected: VLLM_ATTENTION_BACKEND`, exit 1 | `ValueError: Environment variable VLLM_ATTENTION_BACKEND is no longer read by vLLM and has no effect; use the --attention-backend CLI flag or the attention_backend argument to LLM()/EngineArgs instead.`, exit 1 — still raises, now actionable |
| `VLLM_NOT_A_REAL_VAR=1 validate_environ(True)` | `ValueError: Unknown vLLM environment variable detected: VLLM_NOT_A_REAL_VAR`, exit 1 | unchanged |

**What the reporter actually hits (measured on vLLM 0.26.0)**

`LLM(...)` → `LLMEngine.from_engine_args` → `EngineArgs.create_engine_config` → `envs.validate_environ(self.fail_on_environ_validation)`, and `fail_on_environ_validation` defaults to `False` (`vllm/engine/arg_utils.py:736`). So the generic warning *is* emitted today — in a captured startup log it lands on line 5 of 135, and it is the only line in the entire log that mentions "attention". Nothing tells the user their requested backend was silently dropped. That is what this change fixes.

**Lint** — `pre-commit run --files vllm/envs.py tests/test_envs.py`: `ruff check`, `ruff format`, `typos`, `mypy-3.10`, SPDX headers, forbidden imports, lazy imports, and the remaining Python hooks all pass. (`update-dockerfile-graph` fails on my host with `Executable /bin/bash not found`; it is an unfiltered shell hook unrelated to these files.)

## AI assistance disclosure

Investigation, implementation, and this description were AI-assisted (Claude Code). I reviewed every changed line, ran the tests and the before/after commands above myself, and verified the #26315 → #32812 → #47399 history directly against those PRs' diffs.

Edited: tightened hard_fail semantics to preserve existing strict-mode behavior.
