### PR TITLE
[Rust Frontend] Clamp logit_bias values to the valid range

### DIFF
--- a/rust/src/server/src/utils.rs
+++ b/rust/src/server/src/utils.rs
@@ -68,7 +68,7 @@ pub fn merge_ec_transfer_params(
 
 /// Convert OpenAI-style `logit_bias` with string token-ID keys into the
 /// internal `HashMap<u32, f32>` representation, validating that every key
-/// parses as a `u32`.
+/// parses as a `u32` and clamping values to the OpenAI-compatible range.
 pub fn convert_logit_bias(
     logit_bias: Option<HashMap<String, f32>>,
 ) -> Result<Option<HashMap<u32, f32>>, ApiError> {
@@ -76,6 +76,7 @@ pub fn convert_logit_bias(
         .map(|bias| {
             bias.into_iter()
                 .map(|(key, value)| {
+                    let value = value.clamp(-100.0, 100.0);
                     key.parse().map(|k| (k, value)).map_err(|_| {
                         ApiError::invalid_request(
                             format!(
@@ -124,4 +125,39 @@ pub fn resolve_base_request_id(
         id.truncate(8);
         id
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, HashMap};
+
+    use expect_test::expect;
+
+    use super::convert_logit_bias;
+
+    #[test]
+    fn convert_logit_bias_clamps_values_to_python_range() {
+        let converted = convert_logit_bias(Some(HashMap::from([
+            ("0".to_string(), -500.0),
+            ("1".to_string(), -100.0),
+            ("2".to_string(), 0.0),
+            ("3".to_string(), 100.0),
+            ("4".to_string(), 500.0),
+        ])))
+        .expect("valid token IDs")
+        .expect("logit bias is present")
+        .into_iter()
+        .collect::<BTreeMap<_, _>>();
+
+        expect![[r#"
+            {
+                0: -100.0,
+                1: -100.0,
+                2: 0.0,
+                3: 100.0,
+                4: 100.0,
+            }
+        "#]]
+        .assert_debug_eq(&converted);
+    }
 }


### PR DESCRIPTION





## Purpose

  The Rust frontend converts `logit_bias` token ID keys but currently forwards
  the associated values without applying the required range limit. For example,
  a value of `500.0` reaches the engine unchanged instead of being limited to
  `100.0`.

  Clamp each value to `[-100, 100]` before forwarding it to the engine, matching
  the existing Python behavior. Values already within the range and existing
  token ID validation remain unchanged.

## Test Plan

```
  cargo nextest run -p vllm-server \
    convert_logit_bias_clamps_values_to_python_range \
    --all-features --locked
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

