### PR TITLE
[Bugfix][Frontend] Avoid mutating OpenAI request extra args

### DIFF
--- a/tests/entrypoints/openai/test_request_extra_args.py
+++ b/tests/entrypoints/openai/test_request_extra_args.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import Any
+
+import pytest
+
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+)
+from vllm.entrypoints.openai.completion.protocol import CompletionRequest
+from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+
+KV_TRANSFER_PARAMS = {"request_id": "kv-request"}
+EC_TRANSFER_PARAMS = {"request_id": "ec-request"}
+
+
+@pytest.mark.parametrize(
+    ("request_cls", "request_kwargs", "sampling_kwargs"),
+    [
+        (
+            ChatCompletionRequest,
+            {"messages": [{"role": "user", "content": "hello"}]},
+            {"max_tokens": 8, "default_sampling_params": {}},
+        ),
+        (
+            CompletionRequest,
+            {"prompt": "hello"},
+            {"max_tokens": 8},
+        ),
+        (
+            ResponsesRequest,
+            {"input": "hello"},
+            {"default_max_tokens": 8},
+        ),
+    ],
+)
+def test_to_sampling_params_does_not_mutate_request_extra_args(
+    request_cls: type[ChatCompletionRequest | CompletionRequest | ResponsesRequest],
+    request_kwargs: dict[str, Any],
+    sampling_kwargs: dict[str, Any],
+) -> None:
+    original_xargs = {"custom_key": "custom_value"}
+    request = request_cls(
+        model="test-model",
+        vllm_xargs=original_xargs.copy(),
+        kv_transfer_params=KV_TRANSFER_PARAMS,
+        ec_transfer_params=EC_TRANSFER_PARAMS,
+        **request_kwargs,
+    )
+    expected_extra_args = {
+        **original_xargs,
+        "kv_transfer_params": KV_TRANSFER_PARAMS,
+        "ec_transfer_params": EC_TRANSFER_PARAMS,
+    }
+
+    assert request.vllm_xargs == original_xargs
+    first_params = request.to_sampling_params(**sampling_kwargs)
+    second_params = request.to_sampling_params(**sampling_kwargs)
+
+    assert request.vllm_xargs == original_xargs
+    assert first_params.extra_args == expected_extra_args
+    assert second_params.extra_args == expected_extra_args
+    assert first_params.extra_args is not request.vllm_xargs
+    assert second_params.extra_args is not request.vllm_xargs
+    assert first_params.extra_args is not second_params.extra_args
+    request_cls.model_validate(request.model_dump())

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -671,7 +671,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
         if prompt_logprobs is None and self.echo:
             prompt_logprobs = self.top_logprobs
 
-        extra_args: dict[str, Any] = self.vllm_xargs if self.vllm_xargs else {}
+        extra_args: dict[str, Any] = dict(self.vllm_xargs or {})
         if self.kv_transfer_params:
             # Pass in kv_transfer_params via extra_args
             extra_args["kv_transfer_params"] = self.kv_transfer_params

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -344,7 +344,7 @@ class CompletionRequest(OpenAIBaseModel):
 
         echo_without_generation = self.echo and self.max_tokens == 0
 
-        extra_args: dict[str, Any] = self.vllm_xargs if self.vllm_xargs else {}
+        extra_args: dict[str, Any] = dict(self.vllm_xargs or {})
         if self.kv_transfer_params:
             # Pass in kv_transfer_params via extra_args
             extra_args["kv_transfer_params"] = self.kv_transfer_params

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -417,7 +417,7 @@ class ResponsesRequest(OpenAIBaseModel):
         if isinstance(stop, str):
             stop = [stop]
 
-        extra_args: dict[str, Any] = self.vllm_xargs if self.vllm_xargs else {}
+        extra_args: dict[str, Any] = dict(self.vllm_xargs or {})
         if self.kv_transfer_params:
             extra_args["kv_transfer_params"] = self.kv_transfer_params
         if self.ec_transfer_params:


### PR DESCRIPTION


## Purpose

`to_sampling_params()` directly reused the mutable `vllm_xargs`
dictionary as `SamplingParams.extra_args`. Merging
`kv_transfer_params` and `ec_transfer_params` therefore mutated the
original request object and allowed conversion-specific state to persist
across repeated calls.

This PR copies `vllm_xargs` before merging transfer metadata for
`ChatCompletionRequest`, `CompletionRequest`, and `ResponsesRequest`.
It preserves the existing merge behavior and empty-value semantics while
separating the request and sampling parameter dictionaries.

A parameterized regression test covers all three request types, including:

- preservation of the original `vllm_xargs`
- KV and EC transfer parameter merging
- independent dictionary ownership
- repeated conversion without state accumulation
- request serialization and validation round trips

No documentation changes are required because this is an internal
correctness fix with no API changes.

## Test Plan

```bash
python -m pytest -q tests/entrypoints/openai/test_request_extra_args.py
python -m pytest -q \
  tests/entrypoints/openai/responses/test_sampling_params.py \
  tests/entrypoints/openai/test_stop_token_ids.py
python -m pytest -q tests/test_sampling_params.py
pre-commit run --files \
  vllm/entrypoints/openai/chat_completion/protocol.py \
  vllm/entrypoints/openai/completion/protocol.py \
  vllm/entrypoints/openai/responses/protocol.py \
  tests/entrypoints/openai/test_request_extra_args.py
git diff --check origin/main...HEAD
```

Test Result
New regression tests: 3 passed
Related OpenAI protocol tests: 16 passed
Sampling parameter tests: 11 passed
Total: 30 passed
Applicable pre-commit checks passed
git diff --check passed