### PR TITLE
[Model] Add Mage-VL multimodal model support

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -557,6 +557,7 @@ These models primarily accept the [`LLM.generate`](./generative_models.md#llmgen
 | `LlavaNextVideoForConditionalGeneration` | LLaVA-NeXT-Video | T + V | `llava-hf/LLaVA-NeXT-Video-7B-hf`, etc. | ✅︎ | ✅︎ |
 | `LlavaOnevision2ForConditionalGeneration` | LLaVA-OneVision-2 | T + I<sup>+</sup> + V<sup>+</sup> | `lmms-lab-encoder/LLaVA-OneVision-2-8B-Instruct` | | |
 | `LlavaOnevisionForConditionalGeneration` | LLaVA-Onevision | T + I<sup>+</sup> + V<sup>+</sup> | `llava-hf/llava-onevision-qwen2-7b-ov-hf`, `llava-hf/llava-onevision-qwen2-0.5b-ov-hf`, etc. | | ✅︎ |
+| `MageVLForConditionalGeneration` | Mage-VL | T + I<sup>+</sup> + V<sup>+</sup> | `microsoft/Mage-VL` | | |
 | `MiDashengLMModel` | MiDashengLM | T + A<sup>+</sup> | `mispeech/midashenglm-7b` | | ✅︎ |
 | `MiMoV2OmniForCausalLM` | MiMo-V2.5-Omni | T + I<sup>E+</sup> + V<sup>E+</sup> + A<sup>+</sup> | `XiaomiMiMo/MiMo-V2.5-Omni` | | ✅︎ |
 | `MiniCPMO` | MiniCPM-O | T + I<sup>E+</sup> + V<sup>E+</sup> + A<sup>E+</sup> | `openbmb/MiniCPM-o-2_6`, etc. | ✅︎ | ✅︎ |

--- a/tests/models/multimodal/processing/test_llava_onevision2.py
+++ b/tests/models/multimodal/processing/test_llava_onevision2.py
@@ -24,6 +24,7 @@ import pytest
 from vllm.model_executor.models.llava_onevision2 import (
     _CODEC_VIDEO_MARKER,
     LlavaOnevision2VideoBackend,
+    _codec_module_name,
     _extract_codec_video_paths,
     _frame_video_to_pil_and_timestamps,
     _validate_video_source,
@@ -300,3 +301,34 @@ def test_backend_target_fps_controls_sampling_when_below_cap():
     # fps-derived nframes (2) is below the 128 cap, so fps wins.
     assert len(idx) <= 8
     assert len(idx) % 2 == 0
+
+
+# ---------------------------------------------------------------------------
+# Remote-code module naming. Every checkpoint on this architecture ships the
+# same three trust_remote_code modules under its own suffix (OV2:
+# ``*_llava_onevision2``; Mage-VL: ``*_mage_vl``), so the codec module is
+# derived from the loaded processor's module name rather than hardcoded.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "processor_module,expected",
+    [
+        ("processing_llava_onevision2", "codec_video_processing_llava_onevision2"),
+        ("processing_mage_vl", "codec_video_processing_mage_vl"),
+    ],
+)
+def test_codec_module_name(processor_module, expected):
+    assert _codec_module_name(processor_module) == expected
+
+
+def test_video_backend_registered_for_both_checkpoints():
+    # The frame backend is selected by ``video_processor_type``; both OV2 and
+    # Mage-VL checkpoints must resolve to this backend.
+    from vllm.multimodal.video import VIDEO_LOADER_REGISTRY
+
+    for name in ("LlavaOnevision2VideoProcessor", "MageVLVideoProcessor"):
+        assert (
+            VIDEO_LOADER_REGISTRY.get_backend_for_video_processor(name)
+            == "llava_onevision2"
+        )

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -1076,6 +1076,12 @@ _MULTIMODAL_EXAMPLE_MODELS = {
     "LlavaOnevisionForConditionalGeneration": _HfExamplesInfo(
         "llava-hf/llava-onevision-qwen2-0.5b-ov-hf"
     ),
+    "MageVLForConditionalGeneration": _HfExamplesInfo(
+        "microsoft/Mage-VL",
+        trust_remote_code=True,
+        # Keep the init/schema harness eager (these tests never run forward).
+        enforce_eager=True,
+    ),
     "MiDashengLMModel": _HfExamplesInfo(
         "mispeech/midashenglm-7b", trust_remote_code=True
     ),

--- a/vllm/model_executor/models/llava_onevision2.py
+++ b/vllm/model_executor/models/llava_onevision2.py
@@ -3,9 +3,13 @@
 """
 Inference-only LLaVA-OneVision-2 (OV2) model for vLLM.
 
+Also serves ``MageVLForConditionalGeneration`` (``microsoft/Mage-VL``), which
+uses the same architecture with a Qwen3-4B backbone and its own remote-code
+module names (resolved from the checkpoint's ``auto_map``).
+
 Architecture notes:
 
-  * LLM backbone is plain Qwen3-8B with 1-D position_ids (no M-RoPE).
+  * LLM backbone is plain Qwen3 with 1-D position_ids (no M-RoPE).
   * Vision tower removes the CLS token (no class_embedding/class_pos_emb).
   * Vision RoPE is 3-D (T:H:W) with a 4:6:6 head_dim split and uses
     ``patch_positions`` instead of grid_thw to compute per-token freqs.
@@ -112,6 +116,26 @@ from vllm.utils.tensor_schema import TensorSchema, TensorShape
 logger = init_logger(__name__)
 
 
+# Remote-code entry points, keyed by the ``auto_map`` entry each checkpoint
+# publishes. Every OV2-architecture checkpoint ships the same three modules
+# under its own name (OV2: ``*_llava_onevision2``; Mage-VL: ``*_mage_vl``), so
+# the references are read from ``auto_map`` rather than hardcoded.
+_DEFAULT_AUTO_MAP = {
+    "AutoProcessor": "processing_llava_onevision2.LlavaOnevision2Processor",
+    "AutoVideoProcessor": (
+        "video_processing_llava_onevision2.LlavaOnevision2VideoProcessor"
+    ),
+}
+
+
+def _codec_module_name(processor_module: str) -> str:
+    """Map a processor module to its sibling codec module.
+
+    ``processing_mage_vl`` -> ``codec_video_processing_mage_vl``.
+    """
+    return f"codec_video_processing_{processor_module.removeprefix('processing_')}"
+
+
 @lru_cache
 def _load_ov2_processor(
     model: str,
@@ -129,14 +153,29 @@ def _load_ov2_processor(
     path = convert_model_repo_to_path(model)
     revision = revision or "main"
 
+    # Codec defaults live under the "codec" key of preprocessor_config.json,
+    # which Qwen2VLImageProcessor does not preserve; read them directly so the
+    # codec video backend keeps its configured defaults. The same file carries
+    # the ``auto_map`` naming the checkpoint's remote-code classes.
+    codec_config: dict = {}
+    auto_map: dict = {}
+    try:
+        preprocessor_config = get_hf_file_to_dict(
+            "preprocessor_config.json", path, revision
+        )
+        codec_config = (preprocessor_config or {}).get("codec", {}) or {}
+        auto_map = (preprocessor_config or {}).get("auto_map", {}) or {}
+    except Exception:
+        logger.debug("OV2: no codec defaults found in preprocessor_config.json")
+
     processor_cls = get_class_from_dynamic_module(
-        "processing_llava_onevision2.LlavaOnevision2Processor",
+        auto_map.get("AutoProcessor", _DEFAULT_AUTO_MAP["AutoProcessor"]),
         path,
         revision=revision,
         trust_remote_code=trust_remote_code,
     )
     video_processor_cls = get_class_from_dynamic_module(
-        "video_processing_llava_onevision2.LlavaOnevision2VideoProcessor",
+        auto_map.get("AutoVideoProcessor", _DEFAULT_AUTO_MAP["AutoVideoProcessor"]),
         path,
         revision=revision,
         trust_remote_code=trust_remote_code,
@@ -157,18 +196,6 @@ def _load_ov2_processor(
         patch_size=getattr(image_processor, "patch_size", 14),
         spatial_merge_size=getattr(image_processor, "merge_size", 2),
     )
-
-    # Codec defaults live under the "codec" key of preprocessor_config.json,
-    # which Qwen2VLImageProcessor does not preserve; read them directly so the
-    # codec video backend keeps its configured defaults.
-    codec_config: dict = {}
-    try:
-        preprocessor_config = get_hf_file_to_dict(
-            "preprocessor_config.json", path, revision
-        )
-        codec_config = (preprocessor_config or {}).get("codec", {}) or {}
-    except Exception:
-        logger.debug("OV2: no codec defaults found in preprocessor_config.json")
 
     return processor_cls(
         image_processor=image_processor,
@@ -343,14 +370,12 @@ def _codec_fps_for(video_path: str, hf_processor) -> float:
         return _CODEC_FPS_CACHE[video_path]
     # The codec module is shipped inside the HF transformers_modules package
     # for OV2, so an absolute import does not resolve. Locate it relative to
-    # the processor module (which lives in the same package).
+    # the processor module (which lives in the same package, and whose name
+    # carries the checkpoint's module suffix).
     proc_module_name = type(hf_processor).__module__
-    pkg = proc_module_name.rsplit(".", 1)[0] if "." in proc_module_name else ""
-    codec_mod = importlib.import_module(
-        f"{pkg}.codec_video_processing_llava_onevision2"
-        if pkg
-        else "codec_video_processing_llava_onevision2"
-    )
+    pkg, _, leaf = proc_module_name.rpartition(".")
+    codec_leaf = _codec_module_name(leaf)
+    codec_mod = importlib.import_module(f"{pkg}.{codec_leaf}" if pkg else codec_leaf)
     CodecConfig = codec_mod.CodecConfig
     process_codec_video = codec_mod.process_codec_video
     cfg_defaults = dict(getattr(hf_processor, "_codec_config_defaults", {}))
@@ -641,15 +666,15 @@ def _ov2_smart_nframes(
 
 @VIDEO_LOADER_REGISTRY.register(
     "llava_onevision2",
-    video_processor="LlavaOnevision2VideoProcessor",
+    video_processor=("LlavaOnevision2VideoProcessor", "MageVLVideoProcessor"),
 )
 class LlavaOnevision2VideoBackend(VideoBackend):
-    """Frame-sampling backend for LLaVA-OneVision-2.
+    """Frame-sampling backend for LLaVA-OneVision-2 and Mage-VL.
 
-    Selected automatically for OV2 via the ``video_processor`` binding
-    (``video_processor_type == "LlavaOnevision2VideoProcessor"`` in the model's
-    ``video_preprocessor_config.json``). Decoding uses the inherited OpenCV /
-    PyAV codecs; only the sampling index policy is overridden to match qwen.
+    Selected automatically via the ``video_processor`` binding (the
+    ``video_processor_type`` in the model's ``video_preprocessor_config.json``).
+    Decoding uses the inherited OpenCV / PyAV codecs; only the sampling index
+    policy is overridden to match qwen.
     """
 
     _sampling_suffix = "_llava_onevision2"

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -487,6 +487,10 @@ _MULTIMODAL_MODELS = {
         "llava_onevision2",
         "LlavaOnevision2ForConditionalGeneration",
     ),
+    "MageVLForConditionalGeneration": (
+        "llava_onevision2",
+        "LlavaOnevision2ForConditionalGeneration",
+    ),
     "MiDashengLMModel": ("midashenglm", "MiDashengLMModel"),
     "MiMoV2OmniForCausalLM": ("mimo_v2_omni", "MiMoV2OmniForCausalLM"),
     "MiniMaxM3SparseForConditionalGeneration": (


### PR DESCRIPTION
## Purpose

Add support for **Mage-VL** ([`microsoft/Mage-VL`](https://huggingface.co/microsoft/Mage-VL)), a 4B codec-native streaming multimodal model (Mage-ViT visual encoder trained from scratch + Qwen3-4B-Instruct-2507 decoder). Paper: [arXiv:2607.24904](https://arxiv.org/abs/2607.24904).

Mage-VL shares its architecture with `LlavaOnevision2ForConditionalGeneration`, which vLLM already supports:

* Qwen3 backbone with 1-D `position_ids` (no M-RoPE)
* CLS-free vision tower (no `class_embedding` / `class_pos_emb`)
* 3-D vision RoPE with a 4:6:6 (T:H:W) head-dim split, driven by `patch_positions` rather than `grid_thw`
* interleaved `rotate_half` (`(::2, 1::2)`)
* windowed vision-attention `cu_seqlens` (`frame_windows_size` on the T dim)
* video frame- and codec-backends both alias to the image path inside the HF processor

I diffed the two HF remote-code repos after normalising identifiers: `modeling_*`, `configuration_*`, `processing_*` and `video_processing_*` are identical modulo renames. The only deltas are outside vLLM's execution path:

* Mage-VL adds an optional `streammind_gate` head shipped in a separate `streammind_gate.safetensors` (not in `model.safetensors.index.json`, not on the LM forward path). Streaming/proactive-gate inference is out of scope here.
* `codec_video_processing_*` adds a DCVC-RT neural-codec engine — HF-side asset generation that runs in a subprocess.
* Default `patch_size` is 16 instead of 14 (config-driven; only a fallback default needed updating).

Checkpoint weight prefixes (`model.language_model.*`, `model.visual.*`, `lm_head.*`) match exactly, so the existing `WeightsMapper` applies unchanged.

Per review feedback, this reuses the existing `LlavaOnevision2ForConditionalGeneration` implementation rather than adding a renamed copy. `MageVLForConditionalGeneration` is mapped onto the existing module/class in `registry.py`.

The only thing the two checkpoints genuinely differ on is the *names* of the `trust_remote_code` modules they ship, so `llava_onevision2.py` now:

* resolves the processor / video-processor classes from the checkpoint's `auto_map` (falling back to the OV2 names),
* derives the codec module from the loaded processor's module name (`processing_mage_vl` -> `codec_video_processing_mage_vl`),
* binds the frame-sampling video backend to both `LlavaOnevision2VideoProcessor` and `MageVLVideoProcessor`.

Net change is +96/-28 lines. `docs/models/supported_models.md`, `tests/models/registry.py` and the existing OV2 test module are updated accordingly.

### Not a duplicate

`gh pr list --repo vllm-project/vllm --state open --search "Mage-VL" / "mage_vl in:body" / "microsoft/Mage"` and the equivalent issue searches return nothing — the model was released after the last vLLM release and no other PR or issue tracks it.

## Test Plan

```bash
# unit tests
.venv/bin/python -m pytest tests/models/test_registry.py \
  tests/models/multimodal/processing/test_llava_onevision2.py -q

# lint
pre-commit run --files vllm/model_executor/models/llava_onevision2.py \
  vllm/model_executor/models/registry.py tests/models/registry.py \
  tests/models/multimodal/processing/test_llava_onevision2.py \
  docs/models/supported_models.md
```

E2E parity against HF `transformers` on the two example inputs shipped with the checkpoint
(`examples/dog.jpg`, `examples/soccer-broadcast.mp4`), greedy decoding, 1x RTX A6000, bf16, `enforce_eager=True`.

Because the shared `llava_onevision2.py` is modified, LLaVA-OneVision-2 itself is re-run on the same
input before and after the change to confirm no regression.

## Test Result

**Unit tests / lint**

```
tests/models/test_registry.py + test_llava_onevision2.py   391 passed, 15 skipped
pre-commit (ruff, ruff-format, mypy, typos, ...)          all hooks passed
```

**Image — `examples/dog.jpg`, "Describe this image in detail."**

HF `transformers` (reference, matches the model card verbatim):

> The image depicts a dog sitting on a patterned rug. The dog appears to be a medium-sized breed with a thick, fluffy coat. Its fur is primarily white with patches of black and brown. The dog's ears are perked up, and it has a calm and attentive expression. The background features a large, ornate rug with intricate patterns [...]

vLLM free-running greedy output agrees for the first ~30 tokens and then takes a different (equally valid) continuation, which is the usual bf16 tie-break between different attention kernels. To confirm this is not a numerical bug, I teacher-forced the full HF greedy output through vLLM and compared vLLM's argmax at every position:

```
teacher-forced top-1 agreement: 122/122 = 1.0000
```

i.e. vLLM's next-token argmax matches HF at **every** step of the reference output — the vision tower, projector and decoder are functionally equivalent.

**Video (frame backend) — `examples/soccer-broadcast.mp4`, 32 frames, "Describe this video."**

vLLM reproduces the model card's reference output verbatim:

> The video opens with a man in a black polo shirt, sporting a short haircut, standing in a stadium. He is holding a yellow microphone with the BBC Sport logo on it. The background reveals a large crowd of spectators [...]

Weight loading reports no missing or unexpected tensors.

**LLaVA-OneVision-2 regression check**

`lmms-lab-encoder/LLaVA-OneVision-2-8B-Instruct` on `examples/dog.jpg`, greedy, before vs after this change:

```
output is byte-identical
```

**Not covered:** the codec video backend (H.264/HEVC and DCVC-RT). It needs the external `cv-preinfer` binary or DCVC-RT checkpoints and real video bytes, so it cannot run in CI — same situation as the existing LLaVA-OneVision-2 codec path, whose marker/plumbing layer is covered by the ported unit tests. The `streammind_gate` streaming path is not implemented in vLLM.

---

**AI assistance disclosure:** this change was produced with AI assistance (architecture diffing, the rename, and the test/eval scripts). I am an author of Mage-VL, have reviewed every changed line, and ran all the commands and evaluations reported above myself.
