### PR TITLE
[Bugfix][Mooncake] Revalidate exact partial-hash hit boundaries

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
@@ -251,6 +251,32 @@ def test_coordinator_fine_grained_clips_when_one_group_missing_tail():
     assert hit == 32
 
 
+def test_coordinator_revalidates_reconciled_partial_tail_key():
+    """A longer FA hit does not imply its reconciled partial key exists."""
+    groups = [
+        KVCacheGroupSpec(["L0"], _full(32)),
+        KVCacheGroupSpec(["L1"], _mamba_align(32)),
+    ]
+    coord = _make_coord(groups, hash_block_size=16)
+    hs = _hashes(4)
+    # FullAttention reaches token 64 via hs[3], while Mamba clips the joint
+    # hit to token 48 via hs[2]. FullAttention has no hs[2] object, so token
+    # 48 is not externally loadable; both groups do have token 32 via hs[1].
+    exists = {
+        (0, bytes(hs[1])),
+        (0, bytes(hs[3])),
+        (1, bytes(hs[1])),
+        (1, bytes(hs[2])),
+    }
+    cmap = ExternalCachedBlockPool(16, exists)
+
+    _masks, hit = coord.find_longest_cache_hit(
+        hs, max_length=64, cached_block_pool=cmap
+    )
+
+    assert hit == 32
+
+
 # ----- store_mask -----
 
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
@@ -97,6 +97,14 @@ class MooncakeStoreCoordinator:
             self.eagle_group_ids = set(range(len(kv_cache_groups)))
         self._verify_and_split_kv_cache_groups()
 
+    @property
+    def cache_hit_alignment_tokens(self) -> int:
+        return (
+            self.hash_block_size
+            if self.enable_partial_hash_hits
+            else self.lcm_block_size
+        )
+
     def align_lookup_length(self, length: int) -> int:
         alignment = (
             self.hash_block_size
@@ -156,14 +164,42 @@ class MooncakeStoreCoordinator:
         already reflects the eagle-pruned hit length and a second pop would
         leave the trailing block unloaded.
         """
-        blocks_per_group, hit_length = self._find_hit_blocks(
-            block_hashes, max_length, cached_block_pool, apply_eagle=apply_eagle
+        candidate_length = max_length
+        while True:
+            blocks_per_group, hit_length = self._find_hit_blocks(
+                block_hashes,
+                candidate_length,
+                cached_block_pool,
+                apply_eagle=apply_eagle,
+            )
+            masks = tuple(
+                [blk is not cached_block_pool.null_block for blk in blocks]
+                for blocks in blocks_per_group
+            )
+            if hit_length == 0 or self._exact_partial_hit_key_exists(
+                block_hashes, hit_length, cached_block_pool
+            ):
+                return masks, hit_length
+
+            candidate_length = max(0, hit_length - self.cache_hit_alignment_tokens)
+
+    def _exact_partial_hit_key_exists(
+        self,
+        block_hashes: Sequence[BlockHash],
+        hit_length: int,
+        cached_block_pool: ExternalCachedBlockPool,
+    ) -> bool:
+        """Whether the reconciled partial FullAttention tail can be loaded."""
+        if not self.enable_partial_hash_hits:
+            return True
+
+        spec, group_ids, _ = self.attention_groups[0]
+        assert isinstance(spec, FullAttentionSpec)
+        hash_idx = hit_length // self.hash_block_size - 1
+        return (
+            cached_block_pool.get_cached_block(block_hashes[hash_idx], group_ids)
+            is not None
         )
-        masks = tuple(
-            [blk is not cached_block_pool.null_block for blk in blocks]
-            for blocks in blocks_per_group
-        )
-        return masks, hit_length
 
     def load_mask(
         self,


### PR DESCRIPTION
## Purpose

Mooncake objects identify exact stored hash boundaries. A longer stored key proves that one object exists at that endpoint; it does not imply that Mooncake also contains independently addressable objects at every shorter hash boundary.

This matters for hybrid FullAttention plus align-mode Mamba caches, where two granularities coexist:

```text
H = hash_block_size                    (lookup/key granularity)
B = physical cache-group block size   (page/snapshot granularity)
H < B
```

Public main automatically enables partial-hash lookup for this supported hybrid layout. Each group can initially report a different hit length, and the coordinator reconciles them to the longest jointly usable prefix.

### Failure example

Using the regression-test geometry:

```text
H = 16 tokens
B = 32 tokens

FullAttention objects: key@32, key@64
Mamba objects:        key@32, key@48
```

FullAttention initially reaches token 64. Mamba shortens the joint prefix to token 48. The old coordinator returned token 48 by truncating the previously discovered FullAttention hit, even though FullAttention had no `key@48` object.

```text
FullAttention hit:          64
Hybrid reconciliation:      48
FullAttention key@48:       missing
Old reported hit:           48  (not externally loadable)
Correct reported hit:       32
```

### Change

After hybrid or speculative reconciliation produces a shorter hit, the coordinator checks whether the FullAttention group has an exact object at that final hash edge. If the key is absent, it steps back one cacheable unit and reruns the complete per-group lookup:

```text
candidate 64 -> reconciled 48 -> key@48 missing
candidate 32 -> reconciled 32 -> key@32 present
return 32
```

Rerunning the complete lookup is necessary because lowering only the integer hit length would leave stale per-group load masks and block selections from the rejected candidate.

The retry is strictly decreasing and terminates at an exact key or zero. In partial-hash mode it steps by `hash_block_size`; the non-partial path keeps its existing LCM alignment and behavior.

The check operates on the `ExternalCachedBlockPool` populated by the existing Mooncake existence lookup, so it adds no new remote Store RPC. It changes neither object keys nor transfer layout; it only prevents the scheduler from accepting an externally unloadable prefix boundary.

### Public-main adaptation

The internal version introduced an opt-in constructor argument. Public vLLM already derives `enable_partial_hash_hits` automatically for supported align-mode Mamba hybrids, so this port preserves that automatic activation and adds only the exact-boundary retry and regression test.

### Duplicate-work check

The following open-PR searches were run:

```bash
gh pr list --repo vllm-project/vllm --state open --search "Mooncake partial hash boundary"
gh pr list --repo vllm-project/vllm --state open --search "Mooncake Mamba prefix"
```

No open PR implements this retry. The searches returned unrelated Mooncake group-semantics and retention-policy work (#44956 and #46906).

AI assistance was used. The human submitter reviewed the change intent and is responsible for reviewing the final OSS diff before merge.

## Test Plan

```bash
.venv/bin/python -m pytest -q tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
pre-commit run ruff-check --files tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
pre-commit run ruff-format --files tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
```

No model evaluation was run because this changes only external-cache hit validation and does not alter model execution or output computation.

## Test Result

```text
33 passed, 14 warnings
ruff-check: passed
ruff-format: passed
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] Purpose and failure example
- [x] Test plan and results
- [x] Duplicate-work and AI-assistance disclosures
</details>