### PR TITLE
[Bugfix][Mooncake] Order async loads after cache block copies

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -2666,3 +2666,22 @@ def test_blob_block_hashes_empty():
     view = BlobBlockHashes(memoryview(b""), 0)
     assert len(view) == 0
     assert list(view) == []
+
+
+def test_worker_records_receive_event_before_queueing_partial_load():
+    worker_instance = _make_bare_worker()
+    worker_instance.kv_role = "kv_consumer"
+    worker_instance.load_async = True
+    worker_instance.kv_recv_threads = []
+    event = MagicMock()
+    request = _make_load_req("req", [b"h0"], token_len=16)
+    meta = SimpleNamespace(
+        requests=[request], preempted_req_ids=set(), unfinished_request_ids=set()
+    )
+
+    with patch.object(torch.cuda, "Event", return_value=event):
+        worker_instance.get_finished(set(), meta)
+
+    event.record.assert_called_once_with()
+    assert request.current_event is event
+    assert worker_instance.recv_request_queue.get_nowait() is request

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -1008,6 +1008,12 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             size_list.extend(g_sizes)
             block_id_list.extend(g_block_ids)
 
+        # CoW page copies are enqueued on the compute stream before this event
+        # is recorded. Do not let RDMA overwrite a shared tail destination
+        # until those copies have completed.
+        if req_meta.current_event is not None:
+            req_meta.current_event.synchronize()
+
         # Rotate aligned lists by tp_rank for load balancing.
         rotation = self.tp_rank % len(key_list)
         key_list_c = _rotate_list(key_list, rotation)
@@ -1541,13 +1547,22 @@ class MooncakeStoreWorker:
         compute is launched on the compute stream) for better
         compute-I/O overlap.
         """
-        # Issue async loads
-        for request in meta.requests:
+        # Record after the model runner enqueues scheduler-issued CoW copies.
+        # Receive threads wait on this event before writing partial pages.
+        load_requests = [
+            request
+            for request in meta.requests
+            if request.load_spec is not None and request.load_spec.can_load
+        ]
+        load_event = None
+        if load_requests:
+            load_event = torch.cuda.Event()
+            load_event.record()
+        for request in load_requests:
             load_spec = request.load_spec
-            if load_spec is None or not load_spec.can_load:
-                continue
-
+            assert load_spec is not None
             load_spec.token_len = load_spec.kvpool_cached_tokens
+            request.current_event = load_event
             self.recv_request_queue.put(request)
 
         assert self.load_async, "load_async must be True for better performance."


### PR DESCRIPTION
## Purpose

Prevent asynchronous Mooncake loads from racing scheduler-issued copy-on-write cache block copies.

The model runner enqueues a cache-page copy on the compute stream before Mooncake may write the destination page. Previously, a background receive thread could start the Mooncake GET before that copy completed, allowing the copy and external DMA to write the same page concurrently.

This change records one CUDA event after the copies are enqueued, attaches it to the load requests, and makes the background receive thread wait before issuing the external write. The wait is scoped to the background transfer thread and the recorded stream; it is not a device-wide synchronization. It mirrors the existing store path, which waits before Mooncake reads GPU KV memory.

### Duplicate-work check

The following open-PR searches were run:

```bash
gh pr list --repo vllm-project/vllm --state open --search "Mooncake asynchronous load cache block copy"
gh pr list --repo vllm-project/vllm --state open --search "Mooncake RDMA copy-on-write race"
```

No open PR addresses this load/copy ordering race. Returned PRs concerned EC hidden-state transfer, MultiConnector state, or request-lifecycle leaks (#47302, #42841, and #36014).

AI assistance was used. The human submitter reviewed the change intent and is responsible for reviewing the final OSS diff before merge.

## Test Plan

```bash
.venv/bin/python -m pytest -q tests/v1/kv_connector/unit/test_mooncake_store_worker.py
pre-commit run ruff-check --files tests/v1/kv_connector/unit/test_mooncake_store_worker.py vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
pre-commit run ruff-format --files tests/v1/kv_connector/unit/test_mooncake_store_worker.py vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
```

No model evaluation was run because this changes transfer ordering rather than model computation. A real GPU/Mooncake overlap benchmark remains follow-up validation.

## Test Result

```text
89 passed, 14 warnings
ruff-check: passed
ruff-format: passed
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] Purpose and race description
- [x] Test plan and results
- [x] Duplicate-work and AI-assistance disclosures
</details>