### PR TITLE
[Bugfix][Mooncake] Publish exact successful-store KV events

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -866,11 +866,30 @@ def test_store_sending_thread_releases_pin_on_batch_put_failure():
     store.batch_is_exist.return_value = [0, 0]
     store.batch_put_from_multi_buffers.side_effect = RuntimeError("rdma error")
     thread = _make_store_sending_thread(store)
+    thread.enable_kv_event = True
 
     thread.add_stored_request("req-a")
     thread._handle_request(_make_store_req("req-a", [b"a0", b"a1"]))
 
     assert thread.stored_requests["req-a"] == 0
+    assert thread.get_kv_events() == []
+
+
+def test_store_sending_thread_publishes_events_only_for_successful_puts():
+    from vllm.v1.core.kv_cache_utils import BlockHash, maybe_convert_block_hash
+
+    store = MagicMock()
+    store.batch_is_exist.return_value = [0, 0]
+    store.batch_put_from_multi_buffers.return_value = [256, -5]
+    thread = _make_store_sending_thread(store)
+    thread.enable_kv_event = True
+
+    thread.add_stored_request("req-a")
+    thread._handle_request(_make_store_req("req-a", [b"a0", b"a1"]))
+
+    events = thread.get_kv_events()
+    assert len(events) == 1
+    assert events[0].block_hashes == [maybe_convert_block_hash(BlockHash(b"a0"))]
 
 
 def test_store_recving_thread_reports_failed_block_ids():
@@ -1682,17 +1701,19 @@ def test_store_sending_thread_kv_events_use_group_chunk_metadata():
     )
 
     full_event, swa_event = thread.get_kv_events()
+    edge_hash = maybe_convert_block_hash(BlockHash(hs[3]))
+    parent_hash = maybe_convert_block_hash(BlockHash(hs[2]))
     assert full_event.group_idx == 0
-    assert full_event.block_size == 32
-    assert full_event.token_ids == list(range(32))
-    # block_size=32 over hash_block_size=8 (scale 4): the chunk is keyed by its
-    # last sub-hash, not the concatenation of all four.
-    assert full_event.block_hashes == [maybe_convert_block_hash(BlockHash(hs[3]))]
+    assert full_event.block_size == 8
+    assert full_event.token_ids == list(range(24, 32))
+    assert full_event.block_hashes == [edge_hash]
+    assert full_event.parent_block_hash == parent_hash
 
     assert swa_event.group_idx == 1
     assert swa_event.block_size == 8
     assert swa_event.token_ids == list(range(24, 32))
-    assert swa_event.block_hashes == [maybe_convert_block_hash(BlockHash(hs[3]))]
+    assert swa_event.block_hashes == [edge_hash]
+    assert swa_event.parent_block_hash == parent_hash
 
 
 def _auto_set_ready_event(*args, **kwargs):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -827,7 +827,6 @@ class KVCacheStoreSendingThread(KVTransferThread):
 
             # parent_block_hash chains live within a group, not across.
             if self.enable_kv_event:
-                prev_key_per_group: dict[int, Any] = {}
                 new_block_hashes = [
                     maybe_convert_block_hash(bh) for bh in kv_event_block_hashes
                 ]
@@ -837,23 +836,30 @@ class KVCacheStoreSendingThread(KVTransferThread):
             ):
                 db = self.token_databases[g_idx]
                 if self.enable_kv_event:
+                    hash_block_size = db.hash_block_size
+                    hash_idx = e // hash_block_size - 1
+                    edge_start = e - hash_block_size
                     token_ids = (
-                        req_meta.token_ids[s:e]
+                        req_meta.token_ids[edge_start:e]
                         if req_meta.token_ids is not None
+                        else None
+                    )
+                    parent_block_hash = (
+                        maybe_convert_block_hash(req_meta.block_hashes[hash_idx - 1])
+                        if hash_idx > 0
                         else None
                     )
                     stored_event = BlockStored(
                         block_hashes=[new_block_hashes[idx]],
-                        parent_block_hash=prev_key_per_group.get(g_idx),
+                        parent_block_hash=parent_block_hash,
                         token_ids=token_ids,
-                        block_size=db.block_size,
+                        block_size=hash_block_size,
                         lora_id=None,
                         medium="cpu",
                         lora_name=None,
                         group_idx=g_idx,
                     )
                     stored_events.append(stored_event)
-                    prev_key_per_group[g_idx] = new_block_hashes[idx]
 
             if current_event is not None:
                 current_event.synchronize()
@@ -867,7 +873,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     sizes,
                     self.replicate_config,
                 )
-                failed = [i for i, v in enumerate(res) if v < 0]
+                failed = [i for i in range(len(keys)) if i >= len(res) or res[i] < 0]
                 self._record_operation(
                     "save_put",
                     put_start,
@@ -877,7 +883,9 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     num_failed_keys=len(failed),
                 )
                 if failed:
-                    failed_codes = set(res[i] for i in failed)
+                    failed_codes = {res[i] for i in failed if i < len(res)}
+                    if len(res) < len(keys):
+                        failed_codes.add("missing_result")
                     logger.warning(
                         "batch_put failed: %d/%d keys failed "
                         "(codes=%s, batch_bytes=%d, num_keys=%d), "
@@ -887,7 +895,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
                         failed_codes,
                         batch_bytes,
                         len(keys),
-                        keys[0] if keys else "N/A",
+                        keys[0],
                     )
                     if (
                         MOONCAKE_NO_AVAILABLE_HANDLE in failed_codes
@@ -907,6 +915,14 @@ class KVCacheStoreSendingThread(KVTransferThread):
                             "Mooncake CPU/disk offloading pressure cleared "
                             "after a successful store batch"
                         )
+                if self.enable_kv_event:
+                    successful_events = [
+                        event
+                        for event_idx, event in enumerate(stored_events)
+                        if event_idx < len(res) and res[event_idx] >= 0
+                    ]
+                    if successful_events:
+                        self.update_kv_event(successful_events)
             except Exception as e:
                 self._record_operation(
                     "save_put",
@@ -916,10 +932,15 @@ class KVCacheStoreSendingThread(KVTransferThread):
                     status="error",
                     num_failed_keys=len(keys),
                 )
-                logger.error("Failed to put key %s, error: %s", keys, e)
+                logger.error(
+                    "Failed to put Mooncake batch "
+                    "(num_keys=%d, batch_bytes=%d, first_key=%s): %s",
+                    len(keys),
+                    batch_bytes,
+                    keys[0],
+                    e,
+                )
 
-            if self.enable_kv_event and stored_events:
-                self.update_kv_event(stored_events)
         finally:
             self.dec_stored_request(req_id)
             self.request_queue.task_done()


### PR DESCRIPTION
## Purpose

Make Mooncake BlockStored events describe exact hash-edge objects and publish them only for PUTs that succeeded.

For a 32-token physical cache page with an 8-token hash unit, an object keyed at token 32 is now announced as an 8-token edge containing tokens 24 through 31, with hash@24 as its true parent. The physical transfer remains unchanged; only the control-plane event geometry is corrected.

For a two-key PUT returning `[256, -5]`, the connector now publishes only the first event. Missing result entries are also failures, and an exceptional batch publishes no events. This prevents schedulers from treating absent external objects as resident.

### Duplicate-work check

The following open-PR searches were run:

```bash
gh pr list --repo vllm-project/vllm --state open --search "Mooncake KV events successful store"
gh pr list --repo vllm-project/vllm --state open --search "Mooncake BlockStored partial failure"
```

No open PR addresses exact Mooncake event geometry or success filtering. The broader Mooncake group-semantics PR #44956 changes Store grouping and does not modify KV event publication.

AI assistance was used. The human submitter reviewed the change intent and is responsible for reviewing the final OSS diff before merge.

## Test Plan

```bash
.venv/bin/python -m pytest -q tests/v1/kv_connector/unit/test_mooncake_store_worker.py
pre-commit run ruff-check --files tests/v1/kv_connector/unit/test_mooncake_store_worker.py vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
pre-commit run ruff-format --files tests/v1/kv_connector/unit/test_mooncake_store_worker.py vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
```

No model evaluation was run because this changes external-cache event metadata and failure reporting rather than model computation.

## Test Result

```text
89 passed, 14 warnings
ruff-check: passed
ruff-format: passed
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] Purpose and concrete event examples
- [x] Test plan and results
- [x] Duplicate-work and AI-assistance disclosures
</details>