### PR TITLE
[K3] Enable DS align state copies with speculative decoding

### DIFF
--- a/tests/kernels/mamba/test_precopy_mamba_align.py
+++ b/tests/kernels/mamba/test_precopy_mamba_align.py
@@ -6,9 +6,8 @@ The V2 "align" pre-copy must migrate mamba state across block boundaries with
 byte-identical semantics to the V1 copy specs (``get_conv_copy_spec`` /
 ``get_temporal_copy_spec``):
 
-* conv state (SD layout, conv_width > 0): shift the sliding window by
-  ``token_bias`` tokens -- ``state[bt[src_col], token_bias:]`` ->
-  ``state[bt[dst_col], :conv_width - token_bias]``.
+* conv state (conv_width > 0): shift the sliding window by ``token_bias``
+  tokens along the state-length axis for both SD and DS layouts.
 * temporal state (conv_width == 0): ``token_bias`` selects the accepted
   speculative column -- ``state[bt[src_col + token_bias]]`` ->
   ``state[bt[dst_col]]``.
@@ -43,28 +42,29 @@ except ModuleNotFoundError:  # allow running directly as ``python <thisfile>``
 
 
 NUM_LAYERS = 3
-CONV_WIDTH = 4  # conv_kernel - 1 + num_spec
+CONV_WIDTH = 10  # conv_kernel - 1 + num_spec
 CONV_DIM = 96
 SSM_SHAPE = (4, 16, 16)
-MAX_COLS = 8
+MAX_COLS = 10
 
 
-def _build_state(num_blocks, device):
-    """Per-layer (conv SD [nb, width, dim] bf16, ssm [nb, *shape] fp32) pools."""
+def _build_state(num_blocks, device, conv_state_layout):
+    """Build per-layer convolution and temporal state pools."""
+    conv_shape = (
+        (num_blocks, CONV_DIM, CONV_WIDTH)
+        if conv_state_layout == "DS"
+        else (num_blocks, CONV_WIDTH, CONV_DIM)
+    )
     convs, ssms = [], []
     for _ in range(NUM_LAYERS):
-        convs.append(
-            torch.randn(
-                num_blocks, CONV_WIDTH, CONV_DIM, dtype=torch.bfloat16, device=device
-            )
-        )
+        convs.append(torch.randn(*conv_shape, dtype=torch.bfloat16, device=device))
         ssms.append(
             torch.randn(num_blocks, *SSM_SHAPE, dtype=torch.float32, device=device)
         )
     return convs, ssms
 
 
-def _build_meta(convs, ssms, device):
+def _build_meta(convs, ssms, device, conv_state_layout):
     """Flattened per-(layer, state-type) metadata, ordered conv, ssm per layer."""
     n = NUM_LAYERS * 2
     base = torch.zeros(n, dtype=torch.int64, device=device)
@@ -73,19 +73,23 @@ def _build_meta(convs, ssms, device):
     inner = torch.zeros(n, dtype=torch.int64, device=device)
     width = torch.zeros(n, dtype=torch.int32, device=device)
     group = torch.zeros(n, dtype=torch.int32, device=device)
-    drc = torch.zeros(n, dtype=torch.int32, device=device)  # DS rows (unused, SD)
+    drc = torch.zeros(n, dtype=torch.int32, device=device)
     drs = torch.zeros(n, dtype=torch.int64, device=device)
     i = 0
     for layer in range(NUM_LAYERS):
         conv, ssm = convs[layer], ssms[layer]
-        # conv (SD): width = size(1), inner = stride(1)
         base[i] = conv.data_ptr()
         blk_stride[i] = conv.stride(0) * conv.element_size()
         elem[i] = conv.element_size()
-        width[i] = conv.size(1)
-        inner[i] = conv.stride(1)
+        if conv_state_layout == "DS":
+            width[i] = conv.size(2)
+            inner[i] = 1
+            drc[i] = conv.size(1)
+            drs[i] = conv.stride(1) * conv.element_size()
+        else:
+            width[i] = conv.size(1)
+            inner[i] = conv.stride(1)
         i += 1
-        # ssm (temporal): width = 0, inner = elems per block
         base[i] = ssm.data_ptr()
         blk_stride[i] = ssm.stride(0) * ssm.element_size()
         elem[i] = ssm.element_size()
@@ -95,7 +99,7 @@ def _build_meta(convs, ssms, device):
     return base, blk_stride, elem, inner, width, group, drc, drs
 
 
-def _reference(convs, ssms, bt, src_col, dst_col, bias, num_reqs):
+def _reference(convs, ssms, bt, src_col, dst_col, bias, num_reqs, conv_state_layout):
     """Apply the V1 copy semantics on clones, reading from the pre-copy state."""
     conv_pre = [c.clone() for c in convs]
     ssm_pre = [s.clone() for s in ssms]
@@ -108,14 +112,20 @@ def _reference(convs, ssms, bt, src_col, dst_col, bias, num_reqs):
         sblk, dblk = int(bt[r, sc]), int(bt[r, dc])
         tblk = int(bt[r, sc + tb])  # temporal src column shifted by bias
         for layer in range(NUM_LAYERS):
-            conv_ref[layer][dblk, : CONV_WIDTH - tb] = conv_pre[layer][sblk, tb:]
+            if conv_state_layout == "DS":
+                conv_ref[layer][dblk, :, : CONV_WIDTH - tb] = conv_pre[layer][
+                    sblk, :, tb:
+                ]
+            else:
+                conv_ref[layer][dblk, : CONV_WIDTH - tb] = conv_pre[layer][sblk, tb:]
             ssm_ref[layer][dblk] = ssm_pre[layer][tblk]
     return conv_ref, ssm_ref
 
 
+@_parametrize("conv_state_layout", ["SD", "DS"])
 @_parametrize("num_reqs", [1, 4, 16])
-@_parametrize("token_bias", [0, 1, 2])
-def test_precopy_matches_v1_copy_specs(num_reqs, token_bias):
+@_parametrize("token_bias", [0, 1, 7])
+def test_precopy_matches_v1_copy_specs(num_reqs, token_bias, conv_state_layout):
     device = torch.device("cuda")
     torch.manual_seed(0)
     # Distinct physical block per (req, col) so copies never alias.
@@ -136,13 +146,20 @@ def test_precopy_matches_v1_copy_specs(num_reqs, token_bias):
     if num_reqs >= 2:
         dst_col[1] = 1  # src_col == dst_col -> no copy
 
-    convs, ssms = _build_state(num_blocks, device)
+    convs, ssms = _build_state(num_blocks, device, conv_state_layout)
     conv_ref, ssm_ref = _reference(
-        convs, ssms, bt.cpu(), src_col.cpu(), dst_col.cpu(), bias.cpu(), num_reqs
+        convs,
+        ssms,
+        bt.cpu(),
+        src_col.cpu(),
+        dst_col.cpu(),
+        bias.cpu(),
+        num_reqs,
+        conv_state_layout,
     )
 
     base, blk_stride, elem, inner, width, group, drc, drs = _build_meta(
-        convs, ssms, device
+        convs, ssms, device, conv_state_layout
     )
     bt_ptrs = torch.tensor([bt.data_ptr()], dtype=torch.int64, device=device)
     idx_mapping = torch.arange(num_reqs, dtype=torch.int32, device=device)
@@ -164,7 +181,7 @@ def test_precopy_matches_v1_copy_specs(num_reqs, token_bias):
         idx_mapping,
         num_reqs,
         COPY_BLOCK_SIZE=1024,
-        CONV_STATE_DIM_FIRST=False,
+        CONV_STATE_DIM_FIRST=conv_state_layout == "DS",
     )
     torch.accelerator.synchronize()
 
@@ -174,7 +191,8 @@ def test_precopy_matches_v1_copy_specs(num_reqs, token_bias):
 
 
 if __name__ == "__main__":
-    for nr in (1, 4, 16):
-        for tb in (0, 1, 2):
-            test_precopy_matches_v1_copy_specs(nr, tb)
-            print(f"OK num_reqs={nr} token_bias={tb}")
+    for layout in ("SD", "DS"):
+        for nr in (1, 4, 16):
+            for tb in (0, 1, 7):
+                test_precopy_matches_v1_copy_specs(nr, tb, layout)
+                print(f"OK layout={layout} num_reqs={nr} token_bias={tb}")

--- a/tests/v1/e2e/general/test_mamba_prefix_cache.py
+++ b/tests/v1/e2e/general/test_mamba_prefix_cache.py
@@ -16,7 +16,10 @@ from tests.utils import create_new_process_for_each_test
 from vllm import LLM, SamplingParams, TokensPrompt
 from vllm.config import CacheConfig
 from vllm.distributed import cleanup_dist_env_and_memory
-from vllm.model_executor.layers.mamba.mamba_utils import MambaStateCopyFunc
+from vllm.model_executor.layers.mamba.mamba_utils import (
+    MambaStateCopyFunc,
+    get_conv_state_layout,
+)
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
@@ -909,13 +912,17 @@ def test_mamba_prefix_cache_mrv1_async(monkeypatch: pytest.MonkeyPatch):
 
 
 def _run_mamba_prefix_cache_mrv2(
-    monkeypatch: pytest.MonkeyPatch, async_scheduling: bool
+    monkeypatch: pytest.MonkeyPatch,
+    async_scheduling: bool,
+    conv_state_layout: str = "SD",
 ):
     global async_scheduling_mode
     async_scheduling_mode = async_scheduling
     monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
     monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", "1")
+    monkeypatch.setenv("VLLM_SSM_CONV_STATE_LAYOUT", conv_state_layout)
     envs.disable_envs_cache()
+    get_conv_state_layout.cache_clear()
 
     from vllm.v1.worker.gpu.model_runner import GPUModelRunner as MRV2GPUModelRunner
     from vllm.v1.worker.gpu.model_states.mamba_hybrid import (
@@ -1175,3 +1182,12 @@ def test_mamba_prefix_cache_mrv2(monkeypatch: pytest.MonkeyPatch):
 @create_new_process_for_each_test()
 def test_mamba_prefix_cache_mrv2_async(monkeypatch: pytest.MonkeyPatch):
     _run_mamba_prefix_cache_mrv2(monkeypatch, async_scheduling=True)
+
+
+@create_new_process_for_each_test()
+def test_mamba_prefix_cache_mrv2_ds_async(monkeypatch: pytest.MonkeyPatch):
+    _run_mamba_prefix_cache_mrv2(
+        monkeypatch,
+        async_scheduling=True,
+        conv_state_layout="DS",
+    )

--- a/vllm/model_executor/layers/mamba/mamba_utils.py
+++ b/vllm/model_executor/layers/mamba/mamba_utils.py
@@ -337,10 +337,10 @@ def get_conv_copy_spec(
     src_block_id = block_ids[cur_block_idx]
     offset = num_accepted_tokens - 1
     if is_conv_state_dim_first():
-        # DS offset > 0 is handled by the fused postprocess kernel.
+        # DS offset > 0 is handled by the fused state-copy kernels.
         assert offset == 0, (
             "DS conv state with num_accepted_tokens > 1 must be handled by "
-            "the fused postprocess kernel, not get_conv_copy_spec"
+            "the fused state-copy kernels, not get_conv_copy_spec"
         )
         src_state = state[src_block_id]
     else:

--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -9,10 +9,6 @@ import torch.nn as nn
 
 from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
-from vllm.model_executor.layers.mamba.mamba_utils import (
-    get_conv_copy_spec,
-    is_conv_state_dim_first,
-)
 from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
 from vllm.v1.attention.backends.mamba2_attn import Mamba2AttentionMetadataBuilder
@@ -133,14 +129,6 @@ class MambaHybridModelState(DefaultModelState):
     ) -> MambaSpecDecodeGPUContext:
         if self._mamba_ctx is None:
             copy_funcs = self.model.get_mamba_state_copy_func()
-            # The fused copy kernels shift conv windows assuming the SD layout;
-            # the DS layout cannot express a >0 spec-decode shift as a single
-            # contiguous copy (mirrors get_conv_copy_spec's NotImplementedError).
-            if get_conv_copy_spec in copy_funcs and is_conv_state_dim_first():
-                assert self.vllm_config.speculative_config is None, (
-                    "DS conv state layout does not support mamba align state "
-                    "copies with speculative decoding"
-                )
             self._mamba_ctx = MambaSpecDecodeGPUContext.create(
                 max_num_reqs=self.max_num_reqs,
                 kv_cache_config=kv_cache_config,


### PR DESCRIPTION
## Summary

This is a focused follow-up to #50000 that enables the DS convolution-state
layout with Model Runner V2, align-mode Mamba prefix caching, asynchronous
scheduling, and speculative decoding.

The fused pre-copy and postprocess kernels already support DS state by shifting
along the state-length axis using per-row count and stride metadata. The
remaining blocker was a stale assertion in `MambaHybridModelState` based on the
older contiguous `MambaCopySpec` path, which cannot represent a strided DS
slice.

- Remove the stale DS plus speculative-decoding guard from the MRV2 align path.
- Clarify that DS offsets are handled by both fused state-copy kernels.
- Extend the existing fused pre-copy equivalence test across SD and DS layouts,
  request counts 1/4/16, and token offsets 0/1/7.
- Add an MRV2 DS plus asynchronous-scheduling prefix-cache test case.

Related issue: #38897.

## Duplicate-work check

The required searches were run:

```bash
gh issue view 38897 --repo vllm-project/vllm --comments
gh pr list --repo vllm-project/vllm --state open \
  --search "38897 in:body"
gh pr list --repo vllm-project/vllm --state open \
  --search "DS conv state layout speculative decoding mamba align"
```

No open PR references #38897, and the area search found no direct duplicate.
The nearest open work is materially different:

- #49436 optimizes state-copy kernel tiling; it does not remove the DS/spec
  guard or add DS MRV2 coverage.
- #46912 is a broader, draft pre-copy-free redesign of align-mode prefix
  caching.
- #42792 provides the broader MRV2 speculative-decoding align implementation.
  This patch uses that implementation already present in the `kimi-k3` base
  and narrowly unblocks and validates DS.

This PR is stacked on #50000 and is intended to target its `kimi-k3` branch.

## Testing

### Focused CUDA correctness

```bash
.venv/bin/python -m pytest \
  tests/kernels/mamba/test_precopy_mamba_align.py -v
```

Result: 18 passed. The matrix covers both layouts, 1/4/16 requests, offsets
0/1/7, fresh requests, same-block no-ops, cross-block convolution-state
shifts, and temporal-state copies. State comparisons use zero tolerance.

```bash
pre-commit run --files \
  tests/kernels/mamba/test_precopy_mamba_align.py \
  tests/v1/e2e/general/test_mamba_prefix_cache.py \
  vllm/model_executor/layers/mamba/mamba_utils.py \
  vllm/v1/worker/gpu/model_states/mamba_hybrid.py
git diff --check origin/kimi-k3...HEAD
```

Result: all applicable pre-commit hooks passed; `git diff --check` produced no
errors.

### E2E and model evaluation

The run served `moonshotai/Kimi-K3` as one TP8 replica on two GB300 nodes with:

- `VLLM_USE_V2_MODEL_RUNNER=1`
- `VLLM_SSM_CONV_STATE_LAYOUT=DS`
- align-mode Mamba prefix caching
- automatically enabled asynchronous scheduling
- dSpark speculative decoding with 7 draft tokens
- `max_num_seqs=256` and `max_num_batched_tokens=32768`

Five full GSM8K 5-shot evaluations ran at concurrency 512, with 1,319 samples per run:

| Run | Strict exact match | Flexible exact match |
| ---: | -----------------: | -------------------: |
| 1 | 0.9629 | 0.9629 |
| 2 | 0.9613 | 0.9613 |
| 3 | 0.9613 | 0.9613 |
| 4 | 0.9621 | 0.9621 |
| 5 | 0.9613 | 0.9613 |

The output scanner checked all 6,595 generations and reported 0 garbage
responses.

An additional held-server probe exercised exact Mamba block boundaries, shared
prefixes, and full scheduler occupancy under the same configuration:

- 510/510 requests succeeded; the cumulative prefix-cache hit rate was 65.1%
  (810,240 of 1,244,567 queried tokens).
- Repeated 1,537/2,303/2,305/3,071/3,073-token prompts produced identical
  outputs and hit 768/768/1,536/1,536/2,304 prefix tokens, respectively.
- A repeated 6,789-token chat completed 16/16 requests, with all 8 replays
  matching and 5,376 cached tokens per replay.
- A 256-request concurrent wave completed 256/256 requests with unique response
  IDs and no garbage output.
- dSpark accepted 14,101 of 27,174 drafted tokens. Health remained HTTP 200,
  with no queued requests or live engine/CUDA/NCCL failures after the probes.

## AI assistance and human accountability

OpenAI Codex was used for implementation support, test authoring, log analysis,
and drafting this description.

