### PR TITLE
[Bugfix][Kimi K3] Stop streaming hold-back from leaking template markers

### DIFF
--- a/tests/reasoning/test_kimi_k3_reasoning_parser.py
+++ b/tests/reasoning/test_kimi_k3_reasoning_parser.py
@@ -9,7 +9,10 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
 from vllm.entrypoints.openai.engine.protocol import DeltaMessage
 from vllm.parser.kimi_k3 import KimiK3Parser
 from vllm.parser.parser_manager import ParserManager
-from vllm.reasoning.kimi_k3_reasoning_parser import KimiK3ReasoningParser
+from vllm.reasoning.kimi_k3_reasoning_parser import (
+    KimiK3ReasoningParser,
+    _hold_back_partial_marker,
+)
 
 pytestmark = pytest.mark.skip_global_cleanup
 
@@ -248,3 +251,73 @@ def test_adjust_request_keeps_xtml_markers_contiguous():
     assert adjusted.skip_special_tokens is False
     if hasattr(adjusted, "spaces_between_special_tokens"):
         assert adjusted.spaces_between_special_tokens is False
+
+
+# The detokenizer renders K3's structural markers with interior spacing
+# ("<|close|> think <|sep|>" rather than "<|close|>think<|sep|>").  The
+# streaming hold-back must tolerate that, otherwise the marker is released
+# into visible text as soon as the space arrives and the already-streamed
+# content is re-derived once the trailing regex finally strips it.
+SPACED_THINK_CLOSE = f"{CLOSE} think {SEP}"
+SPACED_RESPONSE_OPEN = f"{OPEN} response {SEP}"
+RESPONSE_CLOSE = f"{CLOSE}response{SEP}"
+
+
+def test_hold_back_withholds_spaced_complete_marker():
+    # A complete <|close|> whose <|sep|> has not arrived yet must be withheld
+    # in full, including the section name that follows the space.
+    assert _hold_back_partial_marker("answer <|close|> resp") == "answer "
+    assert _hold_back_partial_marker("answer <|close|>") == "answer "
+    assert _hold_back_partial_marker(f"answer {OPEN} response") == "answer "
+
+
+def test_hold_back_releases_terminated_marker():
+    # Once <|sep|> has arrived the marker is complete and nothing is pending;
+    # removing it is the caller's job, not the hold-back's.
+    text = f"a {SPACED_THINK_CLOSE} b"
+    assert _hold_back_partial_marker(text) == text
+
+
+def test_hold_back_still_buffers_incomplete_prefix():
+    # Original behaviour, preserved: a partial opener is buffered.
+    assert _hold_back_partial_marker("answer <|clo") == "answer "
+    assert _hold_back_partial_marker("answer <|") == "answer "
+
+
+def test_hold_back_leaves_plain_and_marker_like_text_alone():
+    assert _hold_back_partial_marker("hello world") == "hello world"
+    # A literal that merely looks like a marker is not a structural token and
+    # must reach the client untouched.
+    assert _hold_back_partial_marker("see <|test|> here") == "see <|test|> here"
+
+
+def test_streaming_spaced_close_marker_is_not_leaked_into_reasoning():
+    parser = KimiK3ReasoningParser(DummyTokenizer())
+
+    previous_text = f"{THINK_OPEN}step"
+    # <|close|> arrives, then " think", then " <|sep|>" -- three deltas.
+    after_close = parser.extract_reasoning_content_streaming(
+        previous_text=previous_text,
+        current_text=previous_text + CLOSE,
+        delta_text=CLOSE,
+        previous_token_ids=[1, 2, 3, 9],
+        current_token_ids=[1, 2, 3, 9, 4],
+        delta_token_ids=[4],
+    )
+    after_name = parser.extract_reasoning_content_streaming(
+        previous_text=previous_text + CLOSE,
+        current_text=previous_text + f"{CLOSE} think",
+        delta_text=" think",
+        previous_token_ids=[1, 2, 3, 9, 4],
+        current_token_ids=[1, 2, 3, 9, 4, 2],
+        delta_token_ids=[2],
+    )
+
+    for delta in (after_close, after_name):
+        if delta is None:
+            continue
+        for field in (delta.content, getattr(delta, "reasoning", None)):
+            if field:
+                assert OPEN not in field
+                assert CLOSE not in field
+                assert SEP not in field

--- a/tests/tool_use/test_kimi_k3_tool_parser.py
+++ b/tests/tool_use/test_kimi_k3_tool_parser.py
@@ -15,7 +15,10 @@ from vllm.exceptions import VLLMValidationError
 from vllm.parser.kimi_k3 import KimiK3Parser
 from vllm.parser.parser_manager import ParserManager
 from vllm.reasoning.kimi_k3_reasoning_parser import KimiK3ReasoningParser
-from vllm.tool_parsers.kimi_k3_tool_parser import KimiK3ToolParser
+from vllm.tool_parsers.kimi_k3_tool_parser import (
+    KimiK3ToolParser,
+    _partial_tag_overlap,  # noqa: F401
+)
 
 OPEN = "<|open|>"
 CLOSE = "<|close|>"
@@ -598,3 +601,26 @@ def test_chat_params_keeps_template_tool_choice_when_api_auto():
 
     assert chat_params.chat_template_kwargs["tool_choice"] == "required"
     assert chat_params.tool_choice == "auto"
+
+
+def test_partial_tag_overlap_withholds_spaced_marker():
+    """The detokenizer spaces marker interiors; the hold-back must cope.
+
+    ``_partial_tag_overlap`` previously prefix-matched the space-free literal
+    ``"<|close|>response<|sep|>"``.  That match survives a bare ``<|close|>``
+    but breaks the moment the space arrives, releasing the marker into the
+    content channel.
+    """
+    response_close = "<|close|>response<|sep|>"
+
+    # Complete <|close|> with the section name in flight: withhold all of it.
+    assert _partial_tag_overlap("a <|close|> resp", response_close) == len(
+        "<|close|> resp"
+    )
+    assert _partial_tag_overlap("a <|close|>", response_close) == len("<|close|>")
+
+    # Terminated by <|sep|>: nothing is pending.
+    assert _partial_tag_overlap("a <|close|> response <|sep|> b", response_close) == 0
+
+    # Plain text is untouched.
+    assert _partial_tag_overlap("plain text", response_close) == 0

--- a/vllm/reasoning/kimi_k3_reasoning_parser.py
+++ b/vllm/reasoning/kimi_k3_reasoning_parser.py
@@ -47,6 +47,34 @@ def _subseq_index(haystack: Sequence[int], needle: Sequence[int]) -> int:
     return -1
 
 
+_PARTIAL_MARKER_OPENERS = ("<|open|>", "<|close|>", "<|sep|>")
+_COMPLETE_OPEN_CLOSE = re.compile(r"<\|(?:open|close)\|>")
+
+
+def _hold_back_partial_marker(text: str) -> str:
+    """Return ``text`` minus any trailing fragment that may still be a marker.
+
+    The detokenizer renders K3's structural markers with interior spacing
+    (``"<|close|> response <|sep|>"``), so prefix-matching the space-free
+    literal ``"<|close|>response<|sep|>"`` stops matching as soon as the space
+    arrives and the marker is released into visible text.  Hold back on two
+    conditions instead:
+
+    (a) a *complete* ``<|open|>``/``<|close|>`` that is not yet terminated by
+        ``<|sep|>`` -- the section name and separator are still in flight;
+    (b) an *incomplete* marker prefix at the very end, which preserves the
+        original behaviour so ``"<|clo"`` is still buffered.
+    """
+    for m in _COMPLETE_OPEN_CLOSE.finditer(text):
+        if "<|sep|>" not in text[m.end() :]:
+            return text[: m.start()]
+    for cand in _PARTIAL_MARKER_OPENERS:
+        for n in range(min(len(cand) - 1, len(text)), 0, -1):
+            if text.endswith(cand[:n]):
+                return text[:-n]
+    return text
+
+
 class KimiK3ReasoningParser(ReasoningParser):
     """Reasoning parser for the Kimi K3 (XTML) think channel."""
 
@@ -253,14 +281,7 @@ class KimiK3ReasoningParser(ReasoningParser):
         m_open = self._think_open_re.search(text)
         if m_open is not None:
             text = text[m_open.end() :]
-        overlap = 0
-        for marker in (self._think_open, self._think_close):
-            max_check = min(len(marker) - 1, len(text))
-            for n in range(max_check, 0, -1):
-                if text.endswith(marker[:n]):
-                    overlap = max(overlap, n)
-                    break
-        return text[:-overlap] if overlap else text
+        return _hold_back_partial_marker(text)
 
     def _content_ready_to_emit(self, text: str) -> str:
         """Return the content prefix that is safe to stream now.
@@ -280,18 +301,7 @@ class KimiK3ReasoningParser(ReasoningParser):
         text = self._message_close_re.sub("", text)
 
         # Hold back partial markers at the end
-        overlap = 0
-        for marker in (
-            self._response_open,
-            self._response_close,
-            self._message_close,
-        ):
-            max_check = min(len(marker) - 1, len(text))
-            for n in range(max_check, 0, -1):
-                if text.endswith(marker[:n]):
-                    overlap = max(overlap, n)
-                    break
-        return text[:-overlap] if overlap else text
+        return _hold_back_partial_marker(text)
 
     def strip_content_streaming(
         self,

--- a/vllm/tool_parsers/kimi_k3_tool_parser.py
+++ b/vllm/tool_parsers/kimi_k3_tool_parser.py
@@ -61,7 +61,25 @@ _O, _C, _S = r"<\|open\|>", r"<\|close\|>", r"<\|sep\|>"
 _TEXT_UNTIL_SEP = r"(?:(?!" + _S + r").)*?"
 
 
+_UNTERMINATED_MARKER = re.compile(r"<\|(?:open|close)\|>(?:(?!" + _S + r").)*\Z", re.S)
+
+
 def _partial_tag_overlap(text: str, tag: str) -> int:
+    """Number of trailing characters that must be withheld from streaming.
+
+    The detokenizer renders markers with interior spacing
+    (``"<|close|> response <|sep|>"``), so prefix-matching the space-free
+    literal ``"<|close|>response<|sep|>"`` stops matching once the space
+    arrives and the marker leaks into visible text.  Withhold on two
+    conditions:
+
+    (a) a *complete* ``<|open|>``/``<|close|>`` whose ``<|sep|>`` has not
+        arrived yet -- the section name and separator are still in flight;
+    (b) an *incomplete* tag prefix at the very end (original behaviour).
+    """
+    m = _UNTERMINATED_MARKER.search(text)
+    if m is not None:
+        return len(text) - m.start()
     max_len = min(len(text), len(tag) - 1)
     for n in range(max_len, 0, -1):
         if text.endswith(tag[:n]):


### PR DESCRIPTION
## Purpose

Kimi K3 leaks its structural markers (`<|open|>`, `<|close|>`, `<|sep|>`) into visible assistant text on the streaming `/v1/responses` path, and emits the visible answer more than once.

Both K3 parsers strip **complete** markers with whitespace-tolerant regexes (`<\|close\|>\s*response\s*<\|sep\|>`), but decide how much text is **safe to stream now** by prefix-matching the space-free literal `"<|close|>response<|sep|>"`. The detokenizer renders these markers with interior spacing, so the hold-back fails:

1. accumulated text ends `…<|close|>` → matches the literal prefix → correctly withheld
2. next delta arrives → text ends `…<|close|> response` → matches neither `"<|close|>r"` nor `"<|close|>"` → **the hold-back releases and the marker is streamed as visible text**
3. `<|sep|>` finally arrives → the tolerant regex strips the now-complete marker **from the buffer** → already-streamed content is re-derived → **the answer is emitted again**

The leaked markers and the duplication are one defect, not two.

Streaming `/v1/responses`, `"Reply with exactly: hello world"`, one SSE event per line:

```text
reasoning_text.delta   ' The',' user',' wants',…,' instruction','.',' '
reasoning_text.delta   '<|close|> think'
reasoning_text.delta   ' The user wants me to reply with exactly "hello world". Simple instruction. '
output_text.delta      ' ','<|open|> response',' hello',' world',' '
output_text.delta      '<|close|> response'
output_text.delta      ' hello world '
output_text.delta      '<|close|> message',' hello world  '
```

`hello world` is emitted three times and the reasoning twice.

### Why two files

The reasoning parser only strips the content channel when the tool parser is bypassed (`tool_choice="none"`, i.e. requests without tools). The same defect therefore exists independently in:

- `vllm/reasoning/kimi_k3_reasoning_parser.py` — the hold-back loops in `_reasoning_text_ready_to_emit` and `_content_ready_to_emit`
- `vllm/tool_parsers/kimi_k3_tool_parser.py` — `_partial_tag_overlap`, a shared helper with three call sites

Fixing only the reasoning parser leaves every request that sends `tools` still leaking, which is the common case for agentic clients. An intermediate version of this patch did exactly that and passed a no-tools test while the reported symptom persisted.

### The change

Hold back on two conditions instead of a literal prefix match:

- **(a)** a *complete* `<|open|>`/`<|close|>` whose `<|sep|>` has not arrived yet — the section name and separator are still in flight
- **(b)** an *incomplete* marker prefix at the very end — the original behaviour, retained so `"<|clo"` is still buffered

No signature changes, and a no-op on clean input. Non-streaming paths never reach the hold-back, which is why they were already correct.

## Test Plan

```bash
pytest tests/reasoning/test_kimi_k3_reasoning_parser.py \
       tests/tool_use/test_kimi_k3_tool_parser.py
```

Six tests added to the existing K3 suites: the spaced-marker regression in both parsers, plus release-on-`<|sep|>`, the retained incomplete-prefix buffering, plain-text and literal `<|test|>` passthrough, and a streaming case that splits the spaced marker across deltas.

End-to-end validation used a ROCm image built from these exact files, served on 8x AMD MI355X (TP8), with a second identical node left on the unpatched base as a control. Provenance was checked inside the running container first: both file checksums match this branch, `main`'s `extract_content_ids` token-id caching is present, and there are no file overlays.

## Test Result

Unit tests: **6 passed**. Without the fix, `test_partial_tag_overlap_withholds_spaced_marker` fails, so the tests capture the defect rather than merely passing alongside it.

`pre-commit run` on the four changed files: all hooks pass, including `ruff check`, `ruff format`, and mypy for both 3.10 and 3.12 (`--hook-stage manual`).

| Case (streaming `/v1/responses`) | Before | After |
|---|---|---|
| plain text | markers present, answer 3x | clean, answer once |
| `enable_thinking=false` | markers present | clean |
| long output (list 1 to 40) | markers present | clean, tail intact |
| response ending in `<` | markers present | clean, trailing `<` preserved |
| literal `<\|test\|>` in content | passes through | passes through |
| tool call emitted | 2 events | 2 events |
| **assistant text alongside a tool call** | **markers present** | **clean** |
| tool call via Chat Completions | `finish_reason=tool_calls` | unchanged |
| post-tool follow-up | clean | clean |
| reasoning channel | parsed | parsed |
| vision (solid-colour images) | correct | correct |

The hold-back runs once per streamed delta over the *accumulated* text, so 3000-token generations were compared for late-stream drift — inter-token latency in the last quarter of the stream against the first, which surfaces a per-delta O(n) cost that a whole-run p50 hides:

| | ITL p50 | first quarter | last quarter | drift |
|---|---|---|---|---|
| this branch | 25.32 ms | 24.58 ms | 26.06 ms | 1.061x |
| control | 25.15 ms | 24.50 ms | 25.81 ms | 1.054x |

The control already drifts 1.054x from KV growth alone; this branch adds 0.007x, and 0.17 ms (0.7%) on ITL p50 — below the trial-to-trial variation, since generated lengths differed (n=3 per configuration).

**Model evaluation:** not applicable. Only the characters the frontend withholds from an in-flight stream change — sampling, the engine and the generated token sequence are untouched, so accuracy cannot move.

Kimi K3 support landed on `main` in #50089 and #50093 (both merged 2026-07-29; #50000 remains open as the umbrella), but no published image contains it yet — the most recent nightly is built from `6f91edf9`, authored ~3h before those merges — so validation used the pre-release `kimi-k3-rocm` image rather than a `main` build. The same fix was also served on NVIDIA B300 through a production llm-d gateway, on that image's parser baseline rather than `main`'s; in that image the tool parser is byte-identical to `main` and the reasoning parser differs only by the caching addition noted above, which the MI355X run exercises directly.

## Not a duplicate

Checked before opening:

```
gh pr list --repo vllm-project/vllm --state open --search "kimi_k3 parser"
gh pr list --repo vllm-project/vllm --state open --search "kimi k3 streaming"
gh pr list --repo vllm-project/vllm --state open --search "partial_tag_overlap"
gh pr list --repo vllm-project/vllm --state open --search "ready_to_emit"
gh search issues --repo vllm-project/vllm "kimi k3 template marker" --state open
gh search issues --repo vllm-project/vllm "reasoning marker leak" --state open
```

The nearest open work does not overlap. #50291 touches the same two files but addresses non-streaming classification of markerless truncated output, with zero hunks in the hold-back; whichever of the two lands second will need a trivial rebase. #50228 touches `kimi_k3_reasoning_parser.py` in a disjoint region and does not change the hold-back. #50303 fixes this class of defect in `granite_reasoning_parser.py`, which shares no code with K3. I found no open issue for the streaming case.

## AI assistance disclosure

AI assistance (Claude Code) was used to investigate this defect, author the change and tests, and run the verification above.
