### PR TITLE
[Rust Frontend] Propagate W3C trace headers to engine-core requests

### DIFF
--- a/rust/src/chat/src/lib.rs
+++ b/rust/src/chat/src/lib.rs
@@ -168,6 +168,7 @@ impl ChatRequestProcessor {
             cache_salt: request.cache_salt,
             add_special_tokens: request.add_special_tokens,
             data_parallel_rank: request.data_parallel_rank,
+            trace_headers: request.trace_headers,
             reasoning_parser_kwargs,
             lora_request: request.lora_request,
             arrival_time: Some(arrival_time),

--- a/rust/src/chat/src/request.rs
+++ b/rust/src/chat/src/request.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use llm_multimodal::ImageDetail;
 use serde::{Deserialize, Serialize};
@@ -491,6 +491,10 @@ pub struct ChatRequest {
     /// Override data parallel rank.
     #[serde(default)]
     pub data_parallel_rank: Option<u32>,
+    /// Optional W3C trace-context headers forwarded to engine-core and
+    /// downstream observability hooks.
+    #[serde(default)]
+    pub trace_headers: Option<BTreeMap<String, String>>,
     /// LoRA adapter selected for this request.
     #[serde(default)]
     pub lora_request: Option<LoraRequest>,
@@ -514,6 +518,7 @@ impl ChatRequest {
             cache_salt: None,
             add_special_tokens: false,
             data_parallel_rank: None,
+            trace_headers: None,
             lora_request: None,
         }
     }

--- a/rust/src/server/src/grpc/convert.rs
+++ b/rust/src/server/src/grpc/convert.rs
@@ -100,6 +100,9 @@ pub fn to_text_request(
         cache_salt: kv.map(|k| &k.cache_salt).filter(|s| !s.is_empty()).cloned(),
         add_special_tokens: true,
         data_parallel_rank: None,
+        // gRPC trace context propagates via metadata rather than headers;
+        // wiring that up is out of scope for HTTP header propagation.
+        trace_headers: None,
         reasoning_parser_kwargs: None,
         lora_request: None,
         arrival_time: None,

--- a/rust/src/server/src/routes/inference/generate/convert.rs
+++ b/rust/src/server/src/routes/inference/generate/convert.rs
@@ -75,6 +75,7 @@ pub(super) fn prepare_generate_request(
         cache_salt: request.cache_salt,
         add_special_tokens: false,
         data_parallel_rank: ctx.data_parallel_rank,
+        trace_headers: ctx.trace_headers,
         reasoning_parser_kwargs: None,
         lora_request: lora_resolution.lora_request.clone(),
         arrival_time: None,
@@ -95,6 +96,8 @@ pub(super) fn prepare_generate_request(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use serde_json::json;
     use vllm_text::Prompt;
 
@@ -208,5 +211,52 @@ mod tests {
 
         assert!(!prepared.options.include_usage);
         assert!(!prepared.options.include_continuous_usage);
+    }
+
+    #[test]
+    fn prepare_generate_request_threads_trace_headers() {
+        let request: GenerateRequest = serde_json::from_value(json!({
+            "model": "Qwen/Qwen1.5-0.5B-Chat",
+            "token_ids": [11, 22, 33],
+            "sampling_params": {}
+        }))
+        .expect("parse request");
+
+        let ctx = ResolvedRequestContext {
+            trace_headers: Some(BTreeMap::from([(
+                "traceparent".to_string(),
+                "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".to_string(),
+            )])),
+            ..ResolvedRequestContext::default()
+        };
+        let prepared = prepare_generate_request(request, &served(&["Qwen/Qwen1.5-0.5B-Chat"]), ctx)
+            .expect("prepare");
+
+        assert_eq!(
+            prepared.text_request.trace_headers,
+            Some(BTreeMap::from([(
+                "traceparent".to_string(),
+                "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".to_string(),
+            )]))
+        );
+    }
+
+    #[test]
+    fn prepare_generate_request_leaves_trace_headers_none_when_absent() {
+        let request: GenerateRequest = serde_json::from_value(json!({
+            "model": "Qwen/Qwen1.5-0.5B-Chat",
+            "token_ids": [11, 22, 33],
+            "sampling_params": {}
+        }))
+        .expect("parse request");
+
+        let prepared = prepare_generate_request(
+            request,
+            &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
+            ResolvedRequestContext::default(),
+        )
+        .expect("prepare");
+
+        assert_eq!(prepared.text_request.trace_headers, None);
     }
 }

--- a/rust/src/server/src/routes/openai/chat_completions/convert.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/convert.rs
@@ -177,6 +177,7 @@ pub(super) fn prepare_chat_request(
         cache_salt: request.cache_salt,
         add_special_tokens: request.add_special_tokens,
         data_parallel_rank: ctx.data_parallel_rank,
+        trace_headers: ctx.trace_headers,
         lora_request: lora_resolution.lora_request.clone(),
     };
 
@@ -409,7 +410,7 @@ fn convert_tool_choice(tool_choice: Option<&ToolChoice>) -> Result<ChatToolChoic
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
     use std::sync::Arc;
 
     use axum::http::HeaderMap;
@@ -1250,6 +1251,43 @@ mod tests {
         )
         .expect("request is valid");
         assert_eq!(prepared.chat_request.data_parallel_rank, None);
+    }
+
+    #[test]
+    fn prepare_chat_request_threads_trace_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "traceparent",
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".parse().unwrap(),
+        );
+        headers.insert("tracestate", "congo=t61rcWkgMzE".parse().unwrap());
+        let prepared = prepare_chat_request(
+            base_request(),
+            &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
+            request_context(&headers, None),
+        )
+        .expect("request is valid");
+        assert_eq!(
+            prepared.chat_request.trace_headers,
+            Some(BTreeMap::from([
+                (
+                    "traceparent".to_string(),
+                    "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".to_string(),
+                ),
+                ("tracestate".to_string(), "congo=t61rcWkgMzE".to_string()),
+            ]))
+        );
+    }
+
+    #[test]
+    fn prepare_chat_request_leaves_trace_headers_none_when_absent() {
+        let prepared = prepare_chat_request(
+            base_request(),
+            &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
+            ResolvedRequestContext::default(),
+        )
+        .expect("request is valid");
+        assert_eq!(prepared.chat_request.trace_headers, None);
     }
 
     #[test]

--- a/rust/src/server/src/routes/openai/completions/convert.rs
+++ b/rust/src/server/src/routes/openai/completions/convert.rs
@@ -147,6 +147,7 @@ pub(super) fn prepare_completion_request(
         cache_salt: request.cache_salt,
         add_special_tokens: request.add_special_tokens,
         data_parallel_rank: ctx.data_parallel_rank,
+        trace_headers: ctx.trace_headers,
         reasoning_parser_kwargs: None,
         lora_request: lora_resolution.lora_request.clone(),
         arrival_time: None,
@@ -198,6 +199,8 @@ fn completion_echo_text(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use axum::http::HeaderMap;
     use serde_json::json;
     use vllm_text::Prompt;
@@ -603,5 +606,58 @@ mod tests {
         )
         .expect("prepare");
         assert_eq!(prepared.text_request.data_parallel_rank, None);
+    }
+
+    #[test]
+    fn prepare_completion_request_threads_trace_headers() {
+        let request: CompletionRequest = serde_json::from_value(json!({
+            "model": "Qwen/Qwen1.5-0.5B-Chat",
+            "prompt": "hello",
+            "stream": false,
+        }))
+        .expect("parse request");
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "traceparent",
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".parse().unwrap(),
+        );
+        headers.insert("tracestate", "congo=t61rcWkgMzE".parse().unwrap());
+        let prepared = prepare_completion_request(
+            request,
+            &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
+            request_context(&headers, None),
+            &test_tokenizer(),
+        )
+        .expect("prepare");
+        assert_eq!(
+            prepared.text_request.trace_headers,
+            Some(BTreeMap::from([
+                (
+                    "traceparent".to_string(),
+                    "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".to_string(),
+                ),
+                ("tracestate".to_string(), "congo=t61rcWkgMzE".to_string()),
+            ]))
+        );
+    }
+
+    #[test]
+    fn prepare_completion_request_leaves_trace_headers_none_when_absent() {
+        let request: CompletionRequest = serde_json::from_value(json!({
+            "model": "Qwen/Qwen1.5-0.5B-Chat",
+            "prompt": "hello",
+            "stream": false,
+        }))
+        .expect("parse request");
+
+        let prepared = prepare_completion_request(
+            request,
+            &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
+            ResolvedRequestContext::default(),
+            &test_tokenizer(),
+        )
+        .expect("prepare");
+        assert_eq!(prepared.text_request.trace_headers, None);
     }
 }

--- a/rust/src/server/src/routes/tokenize/types.rs
+++ b/rust/src/server/src/routes/tokenize/types.rs
@@ -95,6 +95,7 @@ impl TokenizeChatRequest {
             cache_salt: None,
             add_special_tokens: self.add_special_tokens,
             data_parallel_rank: None,
+            trace_headers: None,
             lora_request: None,
         })
     }

--- a/rust/src/server/src/utils.rs
+++ b/rust/src/server/src/utils.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use axum::http::HeaderMap;
@@ -15,7 +15,12 @@ use crate::error::ApiError;
 pub struct ResolvedRequestContext {
     pub request_id: String,
     pub data_parallel_rank: Option<u32>,
+    pub trace_headers: Option<BTreeMap<String, String>>,
 }
+
+/// W3C trace-context headers propagated to engine-core, mirroring Python
+/// vLLM's `TRACE_HEADERS` in `vllm/tracing/utils.py`.
+const TRACE_HEADERS: [&str; 2] = ["traceparent", "tracestate"];
 
 /// Return the current Unix timestamp in seconds for OpenAI response objects.
 pub fn unix_timestamp() -> u64 {
@@ -91,8 +96,9 @@ pub fn convert_logit_bias(
         .transpose()
 }
 
-/// Extract common request metadata from HTTP headers: the external request ID
-/// and the optional data-parallel rank used for engine routing.
+/// Extract common request metadata from HTTP headers: the external request ID,
+/// the optional data-parallel rank used for engine routing, and the W3C
+/// trace-context headers forwarded to engine-core.
 pub fn resolve_request_context(
     headers: &HeaderMap,
     request_id: Option<&str>,
@@ -107,9 +113,25 @@ pub fn resolve_request_context(
     let request_id_header = headers.get("X-Request-Id").and_then(|value| value.to_str().ok());
     let request_id = resolve_base_request_id(request_id_header, request_id);
 
+    // Unlike Python vLLM, extraction is not gated on the engine having tracing
+    // enabled: the Rust server emits no spans itself, so `trace_headers` is
+    // pure propagation and is populated whenever the headers are present.
+    // Non-UTF-8 header values are skipped silently.
+    let trace_headers: BTreeMap<String, String> = TRACE_HEADERS
+        .into_iter()
+        .filter_map(|name| {
+            headers
+                .get(name)
+                .and_then(|value| value.to_str().ok())
+                .map(|value| (name.to_string(), value.to_string()))
+        })
+        .collect();
+    let trace_headers = (!trace_headers.is_empty()).then_some(trace_headers);
+
     ResolvedRequestContext {
         request_id,
         data_parallel_rank,
+        trace_headers,
     }
 }
 
@@ -124,4 +146,70 @@ pub fn resolve_base_request_id(
         id.truncate(8);
         id
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use axum::http::HeaderMap;
+
+    use super::resolve_request_context;
+
+    #[test]
+    fn resolve_request_context_extracts_trace_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "traceparent",
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".parse().unwrap(),
+        );
+        headers.insert("tracestate", "congo=t61rcWkgMzE".parse().unwrap());
+
+        let ctx = resolve_request_context(&headers, None);
+        assert_eq!(
+            ctx.trace_headers,
+            Some(BTreeMap::from([
+                (
+                    "traceparent".to_string(),
+                    "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".to_string(),
+                ),
+                ("tracestate".to_string(), "congo=t61rcWkgMzE".to_string()),
+            ]))
+        );
+    }
+
+    #[test]
+    fn resolve_request_context_extracts_traceparent_alone() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "traceparent",
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".parse().unwrap(),
+        );
+
+        let ctx = resolve_request_context(&headers, None);
+        assert_eq!(
+            ctx.trace_headers,
+            Some(BTreeMap::from([(
+                "traceparent".to_string(),
+                "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".to_string(),
+            )]))
+        );
+    }
+
+    #[test]
+    fn resolve_request_context_leaves_trace_headers_none_when_absent() {
+        let ctx = resolve_request_context(&HeaderMap::new(), None);
+        assert_eq!(ctx.trace_headers, None);
+    }
+
+    #[test]
+    fn resolve_request_context_ignores_non_trace_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Request-Id", "req-1".parse().unwrap());
+        headers.insert("baggage", "key=value".parse().unwrap());
+
+        let ctx = resolve_request_context(&headers, None);
+        assert_eq!(ctx.trace_headers, None);
+        assert_eq!(ctx.request_id, "req-1");
+    }
 }

--- a/rust/src/text/src/lower.rs
+++ b/rust/src/text/src/lower.rs
@@ -62,7 +62,7 @@ pub fn lower_text_request(
         reasoning_parser_kwargs: request.reasoning_parser_kwargs.clone(),
         lora_request: request.lora_request.clone(),
         arrival_time: request.arrival_time,
-        trace_headers: None,
+        trace_headers: request.trace_headers.clone(),
     };
 
     Ok(PreparedTextRequest {
@@ -313,7 +313,7 @@ fn merge_unique_token_ids(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{BTreeSet, HashMap};
+    use std::collections::{BTreeMap, BTreeSet, HashMap};
 
     use serial_test::file_serial;
     use vllm_engine_core_client::protocol::multimodal::{MmFeatureSpec, PlaceholderRange};
@@ -1299,6 +1299,43 @@ mod tests {
         .unwrap();
 
         assert_eq!(prepared.generate_request.arrival_time, None);
+    }
+
+    #[test]
+    fn lower_text_request_passes_trace_headers_through() {
+        let trace_headers = BTreeMap::from([(
+            "traceparent".to_string(),
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".to_string(),
+        )]);
+        let request = TextRequest {
+            trace_headers: Some(trace_headers.clone()),
+            ..sample_request()
+        };
+
+        let prepared = lower_text_request(
+            request,
+            vec![1, 2, 3],
+            sample_sampling_hints(),
+            sample_sampling_limits(),
+            &stub_tokenizer(),
+        )
+        .unwrap();
+
+        assert_eq!(prepared.generate_request.trace_headers, Some(trace_headers));
+    }
+
+    #[test]
+    fn lower_text_request_leaves_trace_headers_unset_when_absent() {
+        let prepared = lower_text_request(
+            sample_request(),
+            vec![1, 2, 3],
+            sample_sampling_hints(),
+            sample_sampling_limits(),
+            &stub_tokenizer(),
+        )
+        .unwrap();
+
+        assert_eq!(prepared.generate_request.trace_headers, None);
     }
 
     #[test]

--- a/rust/src/text/src/request.rs
+++ b/rust/src/text/src/request.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use enum_as_inner::EnumAsInner;
 use serde::{Deserialize, Serialize};
@@ -183,6 +183,10 @@ pub struct TextRequest {
     /// Override data parallel rank.
     #[serde(default)]
     pub data_parallel_rank: Option<u32>,
+    /// Optional W3C trace-context headers forwarded to engine-core and
+    /// downstream observability hooks.
+    #[serde(default)]
+    pub trace_headers: Option<BTreeMap<String, String>>,
     /// Optional reasoning-parser kwargs forwarded to engine-side structured
     /// output logic.
     #[serde(default)]
@@ -212,6 +216,7 @@ impl TextRequest {
             cache_salt: None,
             add_special_tokens: false,
             data_parallel_rank: None,
+            trace_headers: None,
             reasoning_parser_kwargs: None,
             lora_request: None,
             arrival_time: None,


### PR DESCRIPTION
## Purpose

The `EngineCoreRequest.trace_headers` protocol field exists and is already threaded into the engine (`llm::GenerateRequest::prepare()` copies it through), but the Rust HTTP server never populates it — `vllm-text`'s `lower_text_request` hardcodes `trace_headers: None` and the HTTP layer extracts no trace headers at all.

Python vLLM extracts `traceparent` / `tracestate` from incoming request headers (`TRACE_HEADERS` in `vllm/tracing/utils.py`, `_get_trace_headers` in the serving classes) and attaches them to every engine request. This PR implements the same extraction in the Rust server so downstream engines can join the upstream trace — e.g. a router (or any OTel-instrumented client) calling the Rust frontend gets true router → engine distributed tracing once the engine side consumes the propagated context.

**Semantic note (deliberate difference from Python):** extraction is *not* gated on the engine having tracing enabled. The Rust server emits no spans itself, so `trace_headers` is pure propagation; whenever the headers are present they are forwarded, and engines that don't care simply ignore them. This keeps the frontend stateless about engine tracing config.

**Relation to #44567:** that PR (closed unmerged) added a handshake `tracing_enabled` bit and gated forwarding on it. This PR takes the minimal approach the reviewer pointed at: no protocol surface changes, no handshake, no gating — just header extraction plus pass-through to the existing `trace_headers` field.

What changed:

- `rust/src/server/src/utils.rs`: `ResolvedRequestContext` gains `trace_headers: Option<BTreeMap<String, String>>`; `resolve_request_context` extracts exactly `traceparent` + `tracestate` (Python's `TRACE_HEADERS` set; axum `HeaderMap` lookup is case-insensitive; non-UTF-8 values are skipped silently) — `Some(map)` when non-empty, else `None`.
- Pass-through only: `TextRequest` / `ChatRequest` gain the field (`#[serde(default)]`, wire-compatible), threaded into `llm::GenerateRequest` in `lower_text_request`; the completions, chat completions, and `/generate` convert paths set it from the request context.
- gRPC convert sets `trace_headers: None` — trace context propagates via gRPC metadata rather than HTTP headers, left as a follow-up.
- No changes to the `llm` or `engine-core-client` crates (the field already exists end-to-end there).

## Test Plan

From `rust/`:

```bash
cargo fmt -p vllm-text -p vllm-chat -p vllm-server -- --check
cargo clippy -p vllm-text -p vllm-chat -p vllm-server --all-targets -- -D warnings
cargo nextest run -p vllm-text -p vllm-chat --lib
cargo nextest run -p vllm-server --lib
```

New unit tests:

- `resolve_request_context` extraction: both headers present, only `traceparent`, neither, non-trace headers ignored.
- Convert tests for all three routes (completions / chat completions / generate) asserting `trace_headers` reaches the lowered request, and stays `None` when absent.
- `lower_text_request` tests asserting `trace_headers` reaches the `llm::GenerateRequest`.

## Test Result

- `cargo fmt -- --check`: clean.
- `cargo clippy ... -- -D warnings`: exit 0, no warnings.
- `cargo nextest run -p vllm-text -p vllm-chat --lib`: 321 passed, 1 skipped.
- `cargo nextest run -p vllm-server --lib`: 328 passed, 0 skipped (includes all new tests).
