### PR TITLE
[Kernel] Fuse FlashInfer GDN prefill state I/O

### DIFF
--- a/benchmarks/kernels/benchmark_gdn_state_io.py
+++ b/benchmarks/kernels/benchmark_gdn_state_io.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Benchmark FlashInfer GDN recurrent-state preparation and writeback."""
+
+import torch
+
+from vllm.model_executor.layers.mamba.ops.gdn_state_io import (
+    gather_gdn_initial_state,
+    scatter_gdn_final_state,
+)
+from vllm.triton_utils import triton
+
+
+def _bench(function) -> list[float]:
+    return [
+        value * 1000
+        for value in triton.testing.do_bench(
+            function,
+            warmup=100,
+            rep=300,
+            quantiles=[0.2, 0.5, 0.8],
+        )
+    ]
+
+
+def benchmark_case(batch: int, cache_dtype: torch.dtype) -> None:
+    torch.manual_seed(0)
+    heads, rows, columns = 64, 128, 128
+    cache = torch.randn(
+        32,
+        heads,
+        rows,
+        columns,
+        device="cuda",
+        dtype=cache_dtype,
+    )
+    indices = torch.arange(1, batch + 1, device="cuda", dtype=torch.int32)
+    has_initial_state = torch.arange(batch, device="cuda") % 2 == 0
+    final_state = torch.randn(
+        batch,
+        heads,
+        rows,
+        columns,
+        device="cuda",
+        dtype=torch.float32,
+    )
+
+    def gather_pytorch() -> torch.Tensor:
+        output = cache[indices]
+        output[~has_initial_state] = 0
+        return output.float()
+
+    def scatter_pytorch() -> None:
+        cache[indices] = final_state.to(cache.dtype)
+
+    gather_reference = gather_pytorch()
+    gather_actual = gather_gdn_initial_state(cache, indices, has_initial_state)
+    torch.testing.assert_close(gather_actual, gather_reference, atol=0, rtol=0)
+
+    scatter_reference = cache.clone()
+    scatter_reference[indices.long()] = final_state.to(cache.dtype)
+    scatter_actual = cache.clone()
+    scatter_gdn_final_state(scatter_actual, indices, final_state)
+    torch.testing.assert_close(scatter_actual, scatter_reference, atol=0, rtol=0)
+
+    gather_baseline_us = _bench(gather_pytorch)
+    gather_fused_us = _bench(
+        lambda: gather_gdn_initial_state(cache, indices, has_initial_state)
+    )
+    scatter_baseline_us = _bench(scatter_pytorch)
+    scatter_fused_us = _bench(
+        lambda: scatter_gdn_final_state(cache, indices, final_state)
+    )
+    print(
+        f"batch={batch:2d} dtype={str(cache_dtype):14s} "
+        f"gather={gather_baseline_us[1]:7.2f}->{gather_fused_us[1]:7.2f} us "
+        f"({gather_baseline_us[1] / gather_fused_us[1]:4.2f}x) "
+        f"scatter={scatter_baseline_us[1]:7.2f}->{scatter_fused_us[1]:7.2f} us "
+        f"({scatter_baseline_us[1] / scatter_fused_us[1]:4.2f}x)"
+    )
+
+
+def main() -> None:
+    for cache_dtype in (torch.bfloat16, torch.float32):
+        for batch in (1, 4, 16):
+            benchmark_case(batch, cache_dtype)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/kernels/mamba/test_gdn_state_io.py
+++ b/tests/kernels/mamba/test_gdn_state_io.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.mamba.ops.gdn_state_io import (
+    gather_gdn_initial_state,
+    scatter_gdn_final_state,
+)
+
+
+@pytest.mark.parametrize("cache_dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("batch", [1, 3])
+def test_gather_gdn_initial_state_matches_pytorch(
+    cache_dtype: torch.dtype,
+    batch: int,
+) -> None:
+    torch.manual_seed(0)
+    cache = torch.randn(7, 4, 8, 16, device="cuda", dtype=cache_dtype)
+    indices = torch.tensor([5, 1, 6], device="cuda", dtype=torch.int32)[:batch]
+    has_initial_state = torch.tensor(
+        [True, False, True], device="cuda", dtype=torch.bool
+    )[:batch]
+
+    actual = gather_gdn_initial_state(cache, indices, has_initial_state)
+    expected = cache[indices].float()
+    expected[~has_initial_state] = 0
+
+    assert actual.dtype == torch.float32
+    assert actual.is_contiguous()
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("cache_dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("batch", [1, 3])
+def test_scatter_gdn_final_state_matches_pytorch(
+    cache_dtype: torch.dtype,
+    batch: int,
+) -> None:
+    torch.manual_seed(0)
+    cache = torch.randn(7, 4, 8, 16, device="cuda", dtype=cache_dtype)
+    indices = torch.tensor([5, 1, 6], device="cuda", dtype=torch.int32)[:batch]
+    final_state = torch.randn(batch, 4, 8, 16, device="cuda", dtype=torch.float32)
+
+    expected = cache.clone()
+    expected[indices.long()] = final_state.to(cache_dtype)
+    actual = cache.clone()
+    scatter_gdn_final_state(actual, indices, final_state)
+
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+def test_gdn_state_io_supports_noncontiguous_final_state() -> None:
+    torch.manual_seed(0)
+    cache = torch.randn(5, 4, 8, 16, device="cuda", dtype=torch.bfloat16)
+    indices = torch.tensor([4, 2], device="cuda", dtype=torch.int32)
+    backing = torch.randn(2, 4, 8, 32, device="cuda", dtype=torch.float32)
+    final_state = backing[..., ::2]
+
+    expected = cache.clone()
+    expected[indices.long()] = final_state.to(cache.dtype)
+    scatter_gdn_final_state(cache, indices, final_state)
+
+    torch.testing.assert_close(cache, expected, atol=0, rtol=0)

--- a/tests/kernels/mamba/test_gdn_state_io.py
+++ b/tests/kernels/mamba/test_gdn_state_io.py
@@ -51,6 +51,21 @@ def test_scatter_gdn_final_state_matches_pytorch(
     torch.testing.assert_close(actual, expected, atol=0, rtol=0)
 
 
+def test_gdn_state_io_supports_distinct_source_and_destination_indices() -> None:
+    torch.manual_seed(0)
+    cache = torch.randn(6, 4, 8, 16, device="cuda", dtype=torch.bfloat16)
+    source_indices = torch.tensor([1, 4], device="cuda", dtype=torch.int32)
+    destination_indices = torch.tensor([2, 5], device="cuda", dtype=torch.int32)
+    has_initial_state = torch.ones(2, device="cuda", dtype=torch.bool)
+
+    initial_state = gather_gdn_initial_state(cache, source_indices, has_initial_state)
+    expected = cache.clone()
+    expected[destination_indices.long()] = initial_state.to(cache.dtype)
+    scatter_gdn_final_state(cache, destination_indices, initial_state)
+
+    torch.testing.assert_close(cache, expected, atol=0, rtol=0)
+
+
 def test_gdn_state_io_supports_noncontiguous_final_state() -> None:
     torch.manual_seed(0)
     cache = torch.randn(5, 4, 8, 16, device="cuda", dtype=torch.bfloat16)

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -36,6 +36,10 @@ from vllm.model_executor.layers.mamba.ops.causal_conv1d import (
     causal_conv1d_fn,
     causal_conv1d_update,
 )
+from vllm.model_executor.layers.mamba.ops.gdn_state_io import (
+    gather_gdn_initial_state,
+    scatter_gdn_final_state,
+)
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.quantization.auto_awq import AutoAWQConfig
 from vllm.model_executor.layers.quantization.auto_gptq import AutoGPTQConfig
@@ -1430,8 +1434,18 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             prefill_has_initial_state = attn_metadata.prefill_has_initial_state
             assert prefill_state_indices is not None
             assert prefill_has_initial_state is not None
-            initial_state = ssm_state[prefill_state_indices]
-            initial_state[~prefill_has_initial_state, ...] = 0
+            use_flashinfer_state_io = (
+                getattr(self, "gdn_prefill_backend", None) == "flashinfer"
+            )
+            if use_flashinfer_state_io:
+                initial_state = gather_gdn_initial_state(
+                    ssm_state,
+                    prefill_state_indices,
+                    prefill_has_initial_state,
+                )
+            else:
+                initial_state = ssm_state[prefill_state_indices]
+                initial_state[~prefill_has_initial_state, ...] = 0
             (
                 core_attn_out_non_spec,
                 last_recurrent_state,
@@ -1449,7 +1463,16 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 use_qk_l2norm_in_kernel=False,
             )
             # Init cache
-            ssm_state[prefill_state_indices] = last_recurrent_state.to(ssm_state.dtype)
+            if use_flashinfer_state_io:
+                scatter_gdn_final_state(
+                    ssm_state,
+                    prefill_state_indices,
+                    last_recurrent_state,
+                )
+            else:
+                ssm_state[prefill_state_indices] = last_recurrent_state.to(
+                    ssm_state.dtype
+                )
 
             if split_non_spec:
                 # Stitch the peeled decode outputs in front of the prefill

--- a/vllm/model_executor/layers/mamba/ops/gdn_state_io.py
+++ b/vllm/model_executor/layers/mamba/ops/gdn_state_io.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def _gather_gdn_initial_state_kernel(
+    state_ptr,
+    indices_ptr,
+    has_initial_state_ptr,
+    output_ptr,
+    elements_per_state,
+    total_elements,
+    stride_state,
+    stride_head,
+    stride_row,
+    stride_column,
+    ROWS: tl.constexpr,
+    COLUMNS: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    offset = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offset < total_elements
+    batch = offset // elements_per_state
+    inner = offset % elements_per_state
+    head = inner // (ROWS * COLUMNS)
+    row = (inner // COLUMNS) % ROWS
+    column = inner % COLUMNS
+
+    state_index = tl.load(indices_ptr + batch, mask=mask, other=0).to(tl.int64)
+    has_initial_state = tl.load(has_initial_state_ptr + batch, mask=mask, other=0).to(
+        tl.int1
+    )
+    source_offset = (
+        state_index * stride_state
+        + head * stride_head
+        + row * stride_row
+        + column * stride_column
+    )
+    value = tl.load(
+        state_ptr + source_offset,
+        mask=mask & has_initial_state,
+        other=0.0,
+    )
+    tl.store(output_ptr + offset, value.to(tl.float32), mask=mask)
+
+
+@triton.jit
+def _scatter_gdn_final_state_kernel(
+    cache_ptr,
+    indices_ptr,
+    final_state_ptr,
+    elements_per_state,
+    total_elements,
+    stride_cache_state,
+    stride_cache_head,
+    stride_cache_row,
+    stride_cache_column,
+    stride_source_batch,
+    stride_source_head,
+    stride_source_row,
+    stride_source_column,
+    ROWS: tl.constexpr,
+    COLUMNS: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    offset = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offset < total_elements
+    batch = offset // elements_per_state
+    inner = offset % elements_per_state
+    head = inner // (ROWS * COLUMNS)
+    row = (inner // COLUMNS) % ROWS
+    column = inner % COLUMNS
+
+    state_index = tl.load(indices_ptr + batch, mask=mask, other=0).to(tl.int64)
+    source_offset = (
+        batch * stride_source_batch
+        + head * stride_source_head
+        + row * stride_source_row
+        + column * stride_source_column
+    )
+    destination_offset = (
+        state_index * stride_cache_state
+        + head * stride_cache_head
+        + row * stride_cache_row
+        + column * stride_cache_column
+    )
+    value = tl.load(final_state_ptr + source_offset, mask=mask)
+    tl.store(cache_ptr + destination_offset, value, mask=mask)
+
+
+def gather_gdn_initial_state(
+    state: torch.Tensor,
+    indices: torch.Tensor,
+    has_initial_state: torch.Tensor,
+) -> torch.Tensor:
+    """Gather, mask, and cast GDN recurrent states to contiguous FP32."""
+    batch = indices.numel()
+    output = torch.empty(
+        (batch, *state.shape[1:]), dtype=torch.float32, device=state.device
+    )
+    elements_per_state = state[0].numel()
+    total_elements = output.numel()
+    block = 256
+    _gather_gdn_initial_state_kernel[(triton.cdiv(total_elements, block),)](
+        state,
+        indices,
+        has_initial_state,
+        output,
+        elements_per_state,
+        total_elements,
+        state.stride(0),
+        state.stride(1),
+        state.stride(2),
+        state.stride(3),
+        ROWS=state.shape[2],
+        COLUMNS=state.shape[3],
+        BLOCK=block,
+        num_warps=4,
+    )
+    return output
+
+
+def scatter_gdn_final_state(
+    cache: torch.Tensor,
+    indices: torch.Tensor,
+    final_state: torch.Tensor,
+) -> None:
+    """Cast and scatter GDN final states into the recurrent-state cache."""
+    elements_per_state = final_state[0].numel()
+    total_elements = final_state.numel()
+    block = 256
+    _scatter_gdn_final_state_kernel[(triton.cdiv(total_elements, block),)](
+        cache,
+        indices,
+        final_state,
+        elements_per_state,
+        total_elements,
+        cache.stride(0),
+        cache.stride(1),
+        cache.stride(2),
+        cache.stride(3),
+        final_state.stride(0),
+        final_state.stride(1),
+        final_state.stride(2),
+        final_state.stride(3),
+        ROWS=cache.shape[2],
+        COLUMNS=cache.shape[3],
+        BLOCK=block,
+        num_warps=4,
+    )

--- a/vllm/model_executor/layers/mamba/ops/gdn_state_io.py
+++ b/vllm/model_executor/layers/mamba/ops/gdn_state_io.py
@@ -97,7 +97,11 @@ def gather_gdn_initial_state(
     indices: torch.Tensor,
     has_initial_state: torch.Tensor,
 ) -> torch.Tensor:
-    """Gather, mask, and cast GDN recurrent states to contiguous FP32."""
+    """Gather, mask, and cast GDN recurrent states to contiguous FP32.
+
+    The state pool must have shape ``[slots, heads, rows, columns]``. ``indices``
+    and ``has_initial_state`` contain one entry for each output batch element.
+    """
     batch = indices.numel()
     output = torch.empty(
         (batch, *state.shape[1:]), dtype=torch.float32, device=state.device
@@ -129,7 +133,12 @@ def scatter_gdn_final_state(
     indices: torch.Tensor,
     final_state: torch.Tensor,
 ) -> None:
-    """Cast and scatter GDN final states into the recurrent-state cache."""
+    """Cast and scatter GDN final states into the recurrent-state cache.
+
+    ``cache`` and ``final_state`` must be four-dimensional with matching head,
+    row, and column dimensions. ``indices`` selects one destination cache slot
+    for each final-state batch element and may differ from gather source indices.
+    """
     elements_per_state = final_state[0].numel()
     total_elements = final_state.numel()
     block = 256


### PR DESCRIPTION
## Summary

Fuse recurrent-state preparation and writeback around the FlashInfer GDN prefill scan.

Before the scan, one Triton kernel now performs:

- indexed state-pool gather;
- `has_initial_state` masking and zero fill;
- conversion to the contiguous FP32 state expected by FlashInfer.

After the scan, one Triton kernel performs:

- FP32 final-state load;
- conversion to the configured cache dtype;
- indexed scatter back into the recurrent-state pool.

The change is restricted to the FlashInfer prefill backend. Triton/FLA, CuteDSL, decode, causal-conv, RMSNorm, and the FlashInfer scan kernel itself are unchanged.

## Why this is not duplicate work

I repeated open-PR searches for `FlashInfer GDN state gather scatter`, `GDN state I/O`, and `GDN state preparation writeback` before submission.

- #41824 passes the state pool directly into the Triton/FLA chunk kernel and explicitly retains FlashInfer's external gather/scatter behavior. This PR addresses that unchanged FlashInfer path without modifying the scan kernel.
- #46912 is a draft for copy-free align-prefix-cache source-state resolution. This PR implements the current prefill metadata contract and does not change prefix-cache state ownership.
- #48792 and #49887 optimize standard/speculative decode through ReplaySSM. This PR changes prefill only.
- #26807 adds GDN `all`-mode APC semantics and does not fuse the current FlashInfer state I/O chain.

No open PR was found that fuses FlashInfer GDN prefill state preparation and writeback.

## Correctness

The tests cover:

- BF16 and FP32 state-cache destinations;
- batch sizes 1 and 3;
- mixed initial-state masks;
- exact FP32 gathered state;
- exact cache writeback and untouched slots;
- distinct gather-source and scatter-destination indices for future prefix-cache metadata integration;
- non-contiguous FlashInfer final-state views;
- Qwen mixed prefill/decode integration;
- the existing CuteDSL prefill path, which remains unchanged.

Focused result on B300/SM103:

```text
24 passed, 14 warnings in 38.07s
```

Both gather and scatter are bit-exact against the current PyTorch chains in the focused matrix.

## Operator performance

Hardware: NVIDIA B300, compute capability 10.3. Measurements used official main `a0c092ee7` as the source baseline; the branch has since been rebased onto `060185079` with no relevant GDN-path changes. Runtime: Torch 2.13.0+cu130, Triton 3.7.1, CUDA 13.2 environment.

Command:

```bash
PYTHONPATH=. .venv/bin/python benchmarks/kernels/benchmark_gdn_state_io.py
```

| Batch | Cache dtype | Gather current -> PR | Speedup | Scatter current -> PR | Speedup |
|---:|---|---:|---:|---:|---:|
| 1 | BF16 | 28.58 -> 9.15 us | 3.12x | 16.42 -> 9.18 us | 1.79x |
| 4 | BF16 | 32.64 -> 15.33 us | 2.13x | 29.92 -> 15.36 us | 1.95x |
| 16 | BF16 | 83.71 -> 41.76 us | 2.00x | 85.06 -> 41.95 us | 2.03x |
| 1 | FP32 | 20.35 -> 9.18 us | 2.22x | 15.39 -> 9.18 us | 1.68x |
| 4 | FP32 | 26.66 -> 15.33 us | 1.74x | 29.70 -> 15.36 us | 1.93x |
| 16 | FP32 | 71.55 -> 40.16 us | 1.78x | 85.06 -> 41.98 us | 2.03x |

## Full-model trace

Model: Qwen3.5-122B-A10B NVFP4 compatibility checkpoint, TP1, BF16 activations/state cache, FlashInfer GDN backend, VLLM_CUTLASS MoE backend, 8K prefill + one output token.

| Metric | Current main | PR | Delta |
|---|---:|---:|---:|
| Total GPU kernels | 2025 | 1809 | -216 (-6/layer) |
| Total GPU busy | 187.416 ms | 186.411 ms | -1.006 ms |
| Fused gather kernels | — | 36 / 0.143 ms | replaces gather/mask/cast chain |
| Fused scatter kernels | — | 36 / 0.144 ms | replaces cast/index/scatter chain |

The trace confirms exactly one gather and one scatter kernel per GDN layer. The previous indexed gather, mask, cast/index-copy, and indexed writeback kernels are absent from the FlashInfer state-I/O path.

NCU on the production batch-1 state shape reports:

| Kernel | Duration | Compute | DRAM | Achieved occupancy | Registers/thread |
|---|---:|---:|---:|---:|---:|
| Gather | 6.592 us | 18.81% | 4.16% | 70.39% | 21 |
| Scatter | 6.656 us | 24.66% | 8.27% | 69.83% | 22 |

## Serving measurements

Qwen3.5-122B TP1, VLLM_CUTLASS MoE, five warmups and thirty measured requests per shape. A later adjacent PR/main pair produced:

| Input | PR | Current main | Delta |
|---:|---:|---:|---:|
| 2K | 67.54 ms | 69.10 ms | -2.3% |
| 4K | 106.33 ms | 107.41 ms | -1.0% |
| 8K | 197.15 ms | 198.05 ms | -0.5% |
| 16K | 394.95 ms | 396.28 ms | -0.3% |

Additional process-interleaved runs showed 4K/8K improvements and 16K movement within roughly 1% run-to-run noise. No stable guard-shape regression was observed; the profiler provides the structural and GPU-time attribution above.

## Model evaluation

Public `Qwen/Qwen3.5-0.8B`, GSM8K 5-shot, all 1,319 questions, greedy, max 256 output tokens, concurrency 1 to avoid the known mixed-batch invariance issue tracked by #49827:

| Revision | Accuracy | Invalid | Output tokens |
|---|---:|---:|---:|
| Current main | 31.8423% | 0.7582% | 155,733 |
| PR | 31.8423% | 0.7582% | 155,733 |

The aggregate correctness and generated-token count are identical.

## Tests and checks

```text
.venv/bin/python -m pytest \
  tests/kernels/mamba/test_gdn_state_io.py \
  tests/kernels/mamba/test_gdn_forward_core_split.py \
  tests/kernels/mamba/test_gdn_prefill_cutedsl.py -q
# 24 passed

pre-commit run --files \
  benchmarks/kernels/benchmark_gdn_state_io.py \
  tests/kernels/mamba/test_gdn_state_io.py \
  vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py \
  vllm/model_executor/layers/mamba/ops/gdn_state_io.py
# passed, including ruff, mypy, forbidden-import, and torch-CUDA-call checks
```

## AI assistance disclosure

AI assistance was used for implementation support, benchmark automation, test execution, and result summarization. I reviewed every changed line and remain responsible for the implementation, measurements, and claims in this PR.

