### PR TITLE
[KV Connector][Mooncake] Add MooncakePromMetrics and wire via build_prom_metrics

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_stats.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_stats.py
@@ -2,7 +2,11 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import threading
+from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock
+
+from prometheus_client import Counter, Gauge, Histogram
 
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector import (
     MooncakeConnector,
@@ -11,6 +15,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector im
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.stats import (
     MooncakeKVConnectorStats,
+    MooncakePromMetrics,
 )
 
 
@@ -279,3 +284,93 @@ def test_expired_request_bumps_counter():
     assert worker.xfer_stats.data["num_kv_expired_reqs"] == [1]
     # Expired transfer also cleaned out of reqs_need_send.
     assert "tid1" not in worker.reqs_need_send
+
+
+class _FakeMetric:
+    def __init__(self, **kwargs: Any):
+        self.kwargs = kwargs
+        self.children: list[_FakeMetric] = []
+        self.observed: list[int | float] = []
+        self.increments: list[int | float] = []
+        self.labelvalues: tuple[object, ...] = ()
+
+    def labels(self, *labelvalues: object) -> "_FakeMetric":
+        child = _FakeMetric(**self.kwargs)
+        child.labelvalues = labelvalues
+        self.children.append(child)
+        return child
+
+    def observe(self, value: int | float) -> None:
+        self.observed.append(value)
+
+    def inc(self, value: int | float = 1) -> None:
+        self.increments.append(value)
+
+
+class _FakeVllmConfig:
+    def __init__(self) -> None:
+        self.kv_transfer_config = SimpleNamespace()
+
+
+def test_mooncake_prom_metrics_observe():
+    prom_metrics = MooncakePromMetrics(
+        vllm_config=_FakeVllmConfig(),  # type: ignore[arg-type]
+        metric_types={
+            Gauge: _FakeMetric,
+            Counter: _FakeMetric,
+            Histogram: _FakeMetric,
+        },
+        labelnames=["model_name", "engine"],
+        per_engine_labelvalues={0: ["model", "0"]},
+    )
+
+    prom_metrics.observe(
+        {
+            "transfer_duration": [0.001, 0.002],
+            "bytes_transferred": [1024, 2048],
+            "num_descriptors": [4, 6],
+            "num_failed_transfers": [1],
+            "num_failed_recvs": [0],
+            "num_kv_expired_reqs": [1],
+        },
+        engine_idx=0,
+    )
+
+    assert prom_metrics.mooncake_histogram_xfer_time[0].observed == [0.001, 0.002]
+    assert prom_metrics.mooncake_histogram_bytes_transferred[0].observed == [1024, 2048]
+    assert prom_metrics.mooncake_histogram_num_descriptors[0].observed == [4, 6]
+    assert prom_metrics.counter_mooncake_num_failed_transfers[0].increments == [1]
+    assert prom_metrics.counter_mooncake_num_failed_recvs[0].increments == [0]
+    assert prom_metrics.counter_mooncake_num_kv_expired_reqs[0].increments == [1]
+
+
+def test_mooncake_prom_metrics_observe_empty_data():
+    prom_metrics = MooncakePromMetrics(
+        vllm_config=_FakeVllmConfig(),  # type: ignore[arg-type]
+        metric_types={
+            Gauge: _FakeMetric,
+            Counter: _FakeMetric,
+            Histogram: _FakeMetric,
+        },
+        labelnames=["model_name", "engine"],
+        per_engine_labelvalues={0: ["model", "0"]},
+    )
+
+    prom_metrics.observe(
+        {
+            "transfer_duration": [],
+            "bytes_transferred": [],
+            "num_descriptors": [],
+            "num_failed_transfers": [],
+            "num_failed_recvs": [],
+            "num_kv_expired_reqs": [],
+        },
+        engine_idx=0,
+    )
+
+    assert prom_metrics.mooncake_histogram_xfer_time[0].observed == []
+    assert prom_metrics.mooncake_histogram_bytes_transferred[0].observed == []
+    assert prom_metrics.mooncake_histogram_num_descriptors[0].observed == []
+    assert prom_metrics.counter_mooncake_num_failed_transfers[0].increments == []
+    assert prom_metrics.counter_mooncake_num_failed_recvs[0].increments == []
+    assert prom_metrics.counter_mooncake_num_kv_expired_reqs[0].increments == []

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -30,7 +30,12 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorRole,
     SupportsHMA,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
+    KVConnectorPromMetrics,
+    KVConnectorStats,
+    PromMetric,
+    PromMetricT,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_utils import (
     MooncakeBootstrapServer,
     RegisterWorkerPayload,
@@ -608,6 +613,21 @@ class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
         cls, data: dict[str, Any] | None = None
     ) -> KVConnectorStats | None:
         return MooncakeKVConnectorStats(data=data or {})
+
+    @classmethod
+    def build_prom_metrics(
+        cls,
+        vllm_config: VllmConfig,
+        metric_types: dict[type[PromMetric], type[PromMetricT]],
+        labelnames: list[str],
+        per_engine_labelvalues: dict[int, list[object]],
+    ) -> KVConnectorPromMetrics:
+        from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.stats import (
+            MooncakePromMetrics,
+        )
+        return MooncakePromMetrics(
+            vllm_config, metric_types, labelnames, per_engine_labelvalues
+        )
 
 
 class MooncakeConnectorScheduler:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/stats.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/stats.py
@@ -8,12 +8,14 @@ from typing import Any
 
 import numpy as np
 
+from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
+    KVConnectorPromMetrics,
     KVConnectorStats,
+    PromMetric,
+    PromMetricT,
 )
-
-# TODO(mooncake-stats): add MooncakePromMetrics (mirror NixlPromMetrics)
-# and wire it via MooncakeConnector.build_prom_metrics in a follow-up PR.
+from vllm.v1.metrics.utils import create_metric_per_engine
 
 
 @dataclass
@@ -144,3 +146,140 @@ class MooncakeKVConnectorStats(KVConnectorStats):
     @property
     def num_successful_transfers(self) -> int:
         return len(self.data["transfer_duration"])
+
+
+class MooncakePromMetrics(KVConnectorPromMetrics):
+    """Prometheus metrics for Mooncake KV transfer."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        metric_types: dict[type[PromMetric], type[PromMetricT]],
+        labelnames: list[str],
+        per_engine_labelvalues: dict[int, list[object]],
+    ):
+        super().__init__(vllm_config, metric_types, labelnames, per_engine_labelvalues)
+
+        buckets = [
+            0.001,
+            0.005,
+            0.01,
+            0.025,
+            0.05,
+            0.075,
+            0.1,
+            0.2,
+            0.3,
+            0.5,
+            0.75,
+            1.0,
+            5.0,
+        ]
+        mooncake_histogram_xfer_time = self._histogram_cls(
+            name="vllm:mooncake_xfer_time_seconds",
+            documentation=(
+                "Histogram of transfer duration for Mooncake"
+                " KV Cache transfers."
+            ),
+            buckets=buckets[1:],
+            labelnames=labelnames,
+        )
+        self.mooncake_histogram_xfer_time = create_metric_per_engine(
+            mooncake_histogram_xfer_time, self.per_engine_labelvalues
+        )
+        buckets = [2 ** (10 + i) for i in range(1, 25, 2)]
+        mooncake_histogram_bytes_transferred = self._histogram_cls(
+            name="vllm:mooncake_bytes_transferred",
+            documentation=(
+                "Histogram of bytes transferred per Mooncake"
+                " KV Cache transfer."
+            ),
+            buckets=buckets,
+            labelnames=labelnames,
+        )
+        self.mooncake_histogram_bytes_transferred = create_metric_per_engine(
+            mooncake_histogram_bytes_transferred, self.per_engine_labelvalues
+        )
+        buckets = [
+            10,
+            20,
+            30,
+            50,
+            75,
+            100,
+            200,
+            400,
+            1000,
+            2000,
+            4000,
+            10000,
+            20000,
+            50000,
+        ]
+        mooncake_histogram_num_descriptors = self._histogram_cls(
+            name="vllm:mooncake_num_descriptors",
+            documentation=(
+                "Histogram of number of descriptors per Mooncake"
+                " KV Cache transfer."
+            ),
+            buckets=buckets,
+            labelnames=labelnames,
+        )
+        self.mooncake_histogram_num_descriptors = create_metric_per_engine(
+            mooncake_histogram_num_descriptors, self.per_engine_labelvalues
+        )
+        counter_mooncake_num_failed_transfers = self._counter_cls(
+            name="vllm:mooncake_num_failed_transfers",
+            documentation="Number of failed Mooncake KV Cache transfers.",
+            labelnames=labelnames,
+        )
+        self.counter_mooncake_num_failed_transfers = create_metric_per_engine(
+            counter_mooncake_num_failed_transfers, self.per_engine_labelvalues
+        )
+        counter_mooncake_num_failed_recvs = self._counter_cls(
+            name="vllm:mooncake_num_failed_recvs",
+            documentation="Number of failed Mooncake KV Cache receives.",
+            labelnames=labelnames,
+        )
+        self.counter_mooncake_num_failed_recvs = create_metric_per_engine(
+            counter_mooncake_num_failed_recvs, self.per_engine_labelvalues
+        )
+        counter_mooncake_num_kv_expired_reqs = self._counter_cls(
+            name="vllm:mooncake_num_kv_expired_reqs",
+            documentation="Number of requests that had their KV expire. "
+            "NOTE: This metric is tracked on the P instance.",
+            labelnames=labelnames,
+        )
+        self.counter_mooncake_num_kv_expired_reqs = create_metric_per_engine(
+            counter_mooncake_num_kv_expired_reqs, self.per_engine_labelvalues
+        )
+
+    def observe(self, transfer_stats_data: dict[str, Any], engine_idx: int = 0):
+        for prom_obj, list_item_key in zip(
+            [
+                self.mooncake_histogram_xfer_time,
+                self.mooncake_histogram_bytes_transferred,
+                self.mooncake_histogram_num_descriptors,
+            ],
+            [
+                "transfer_duration",
+                "bytes_transferred",
+                "num_descriptors",
+            ],
+        ):
+            for list_item in transfer_stats_data[list_item_key]:
+                prom_obj[engine_idx].observe(list_item)
+        for counter_obj, counter_item_key in zip(
+            [
+                self.counter_mooncake_num_failed_transfers,
+                self.counter_mooncake_num_failed_recvs,
+                self.counter_mooncake_num_kv_expired_reqs,
+            ],
+            [
+                "num_failed_transfers",
+                "num_failed_recvs",
+                "num_kv_expired_reqs",
+            ],
+        ):
+            for list_item in transfer_stats_data[counter_item_key]:
+                counter_obj[engine_idx].inc(list_item)


### PR DESCRIPTION
## Summary

Add `MooncakePromMetrics` class mirroring `NixlPromMetrics` to expose per-engine Prometheus metrics for Mooncake KV transfer operations, and wire it via `MooncakeConnector.build_prom_metrics`.

## Changes

### `vllm/distributed/kv_transfer/kv_connector/v1/mooncake/stats.py`
- Added imports: `VllmConfig`, `KVConnectorPromMetrics`, `PromMetric`, `PromMetricT`, `create_metric_per_engine`
- Removed the TODO comment (now implemented)
- Added `MooncakePromMetrics(KVConnectorPromMetrics)` class with 6 Prometheus metrics:
  - `vllm:mooncake_xfer_time_seconds` (histogram)
  - `vllm:mooncake_bytes_transferred` (histogram)
  - `vllm:mooncake_num_descriptors` (histogram)
  - `vllm:mooncake_num_failed_transfers` (counter)
  - `vllm:mooncake_num_failed_recvs` (counter)
  - `vllm:mooncake_num_kv_expired_reqs` (counter)
- Implements `observe()` to record stats data per-engine, following the same pattern as `NixlPromMetrics.observe()`

### `vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py`
- Added `KVConnectorPromMetrics`, `PromMetric`, `PromMetricT` to imports
- Added `build_prom_metrics` classmethod to `MooncakeConnector` that returns a `MooncakePromMetrics` instance

### `tests/v1/kv_connector/unit/test_mooncake_stats.py`
- Added `_FakeMetric` and `_FakeVllmConfig` helper classes
- Added `test_mooncake_prom_metrics_observe` — verifies `observe()` records histogram and counter values correctly
- Added `test_mooncake_prom_metrics_observe_empty_data` — verifies `observe()` with empty lists doesn't error

## Pattern

Follows the established `NixlPromMetrics` + `NixlConnector.build_prom_metrics` pattern in the codebase. The wiring is automatic — `KVConnectorProm` in `metrics.py` already calls `connector_cls.build_prom_metrics(...)` via the factory, and `MultiConnector` delegates to each sub-connector, so both standalone and PD-disaggregated usage will pick up the new metrics.

## Validation

- All files pass `ruff check`
- Syntax validated via `ast.parse`
- Test file syntax validated
- No existing PRs or issues for this work