### PR TITLE
[CI] Initialize fused gated RMSNorm weights

### DIFF
--- a/tests/kernels/core/test_fused_rms_norm_gated.py
+++ b/tests/kernels/core/test_fused_rms_norm_gated.py
@@ -49,6 +49,11 @@ def test_compiled_vs_eager(
         device=device,
         dtype=dtype,
     )
+    # Model parameters use torch.empty because checkpoint loading overwrites
+    # them. Initialize the standalone test module so allocator contents cannot
+    # introduce NaNs and make this comparison flaky.
+    if module.weight is not None:
+        module.weight.uniform_(-1, 1)
     x = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
     g = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
 
@@ -94,6 +99,8 @@ def test_compiled_vs_eager_multidim(
         device=device,
         dtype=dtype,
     )
+    if module.weight is not None:
+        module.weight.uniform_(-1, 1)
     x = torch.randn(*shape, dtype=dtype, device=device)
     g = torch.randn(*shape, dtype=dtype, device=device)
 


### PR DESCRIPTION
- Fix the two BF16 affine failures from [AMD CI build 11459](https://buildkite.com/vllm/amd-ci/builds/11459/list?jid=019fb02e-7af9-4b17-a139-229bdc6da89d&tab=output), where both the eager and compiled paths produced NaNs.
- Initialize `FusedRMSNormGated.weight` in both standalone test paths when affine mode is enabled so the result no longer depends on allocator contents.
- Leave the production `torch.empty` initialization unchanged because model checkpoints overwrite that parameter.