### PR TITLE
[Spec Decode][Core] Run the Kimi K3 DFlash drafter with prefix caching enabled

### DIFF
--- a/tests/models/kimi_k3/test_aux_attn_res_stream.py
+++ b/tests/models/kimi_k3/test_aux_attn_res_stream.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Which value the DFlash drafter is fed under AttnRes.
+
+`_capture_aux_hidden_stream` picks the weights it mixes against from one of
+three places depending on where the tapped layer sits, and returns the plain
+running prefix when the feature is off. The mixture itself is the kernel's
+job and is covered by ``test_attn_res.py``; what is asserted here is the
+selection, which is the part that can silently feed the drafter the wrong
+tensor.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.models.kimi_k3.nvidia import model as k3_model
+
+END_LAYER = 4
+
+
+def _weights(tag: float) -> SimpleNamespace:
+    """A norm/projection pair that is identifiable by value."""
+    return SimpleNamespace(
+        weight=torch.full((2,), tag),
+        variance_epsilon=tag,
+    )
+
+
+def _stub_model(*, enabled: bool, use_attn_res: bool = True) -> SimpleNamespace:
+    """A stand-in carrying only what the tap reads.
+
+    Constructing the real model needs a distributed init and weights, and none
+    of it participates in the selection under test.
+    """
+    consumers = []
+    for i in range(END_LAYER):
+        consumers.append(
+            SimpleNamespace(
+                self_attention_res_norm=_weights(float(i)),
+                self_attention_res_proj=SimpleNamespace(
+                    weight=torch.full((1, 2), float(i))
+                ),
+                prev_valid_blocks=i,
+            )
+        )
+    return SimpleNamespace(
+        _aux_attn_res_stream=enabled,
+        use_attn_res=use_attn_res,
+        end_layer=END_LAYER,
+        layers=consumers,
+        output_attn_res_norm=_weights(99.0),
+        output_attn_res_proj=SimpleNamespace(weight=torch.full((1, 2), 99.0)),
+        num_attn_res_blocks=99,
+    )
+
+
+@pytest.fixture
+def recorder(monkeypatch):
+    """Replace the kernel so the call it would have made is inspectable."""
+    calls = []
+
+    def _fake_attn_res(prefix, delta, block_residual, norm_weight, proj_weight,
+                       output_norm_weight, **kwargs):
+        calls.append(
+            SimpleNamespace(
+                prefix=prefix,
+                delta=delta,
+                block_residual=block_residual,
+                norm_weight=norm_weight,
+                proj_weight=proj_weight,
+                kwargs=kwargs,
+            )
+        )
+        return torch.full_like(prefix, -1.0)
+
+    monkeypatch.setattr(k3_model, "attn_res", _fake_attn_res)
+    return calls
+
+
+def _set_last_rank(monkeypatch, is_last: bool):
+    monkeypatch.setattr(
+        k3_model, "get_pp_group",
+        lambda: SimpleNamespace(is_last_rank=is_last),
+    )
+
+
+def _call(stub, layer_idx, prefix_sum, pending_mlp_out, block_residual):
+    return k3_model.KimiLinearModel._capture_aux_hidden_stream(
+        stub, layer_idx, prefix_sum, pending_mlp_out, block_residual
+    )
+
+
+@pytest.mark.parametrize(
+    "enabled,use_attn_res", [(False, True), (True, False), (False, False)]
+)
+def test_disabled_reproduces_the_plain_residual_sum(recorder, monkeypatch,
+                                                    enabled, use_attn_res):
+    """Off, the tap must be exactly the sum it replaced.
+
+    Both conditions matter. `use_attn_res` is what constructs the norm and
+    projection weights, so without it the lookups below would raise rather
+    than fall back.
+    """
+    _set_last_rank(monkeypatch, True)
+    prefix_sum = torch.tensor([1.0, 2.0])
+    pending = torch.tensor([0.5, 0.25])
+
+    got = _call(_stub_model(enabled=enabled, use_attn_res=use_attn_res),
+                0, prefix_sum, pending, torch.zeros(2))
+
+    torch.testing.assert_close(got, prefix_sum + pending)
+    assert not recorder, "the kernel must not run when the tap is off"
+
+
+def test_taps_the_consumer_layer_when_one_follows(recorder, monkeypatch):
+    """The value the next layer reads is the mixture against *its* weights,
+    so the tap has to reach forward rather than use the current layer's."""
+    _set_last_rank(monkeypatch, True)
+
+    _call(_stub_model(enabled=True), 1, torch.zeros(2), None, torch.zeros(2))
+
+    assert len(recorder) == 1
+    call = recorder[0]
+    # Layer 2's weights, not layer 1's.
+    torch.testing.assert_close(call.norm_weight, torch.full((2,), 2.0))
+    assert call.kwargs["num_blocks"] == 2
+
+
+def test_last_layer_on_the_final_rank_uses_the_output_aggregation(
+    recorder, monkeypatch
+):
+    """Nothing downstream but the model's own output-side mixture."""
+    _set_last_rank(monkeypatch, True)
+
+    _call(_stub_model(enabled=True), END_LAYER - 1, torch.zeros(2), None,
+          torch.zeros(2))
+
+    assert len(recorder) == 1
+    torch.testing.assert_close(recorder[0].norm_weight, torch.full((2,), 99.0))
+    assert recorder[0].kwargs["num_blocks"] == 99
+
+
+def test_last_layer_of_a_non_final_stage_falls_back(recorder, monkeypatch):
+    """The consumer lives on the next rank and the output aggregation only
+    exists on the last one, so there is nothing here to mix against.
+
+    This is the case that would otherwise reach for weights this rank never
+    constructs. The forward guard is `layer_idx + 1 < end_layer`, where
+    `end_layer` is the rank's own exclusive bound from `get_pp_indices`, so a
+    `PPMissingLayer` is unreachable by construction -- the fallback below is
+    what makes that true rather than merely likely.
+    """
+    _set_last_rank(monkeypatch, False)
+    prefix_sum = torch.tensor([3.0, 4.0])
+
+    got = _call(_stub_model(enabled=True), END_LAYER - 1, prefix_sum, None,
+                torch.zeros(2))
+
+    torch.testing.assert_close(got, prefix_sum)
+    assert not recorder, "no weights exist on this rank to mix against"
+
+
+def test_pending_mlp_output_is_folded_in_rather_than_passed_as_delta(
+    recorder, monkeypatch
+):
+    """The kernel writes an applied delta back into the prefix in place, which
+    would double-add it into the live residual stream, so the pending output
+    has to arrive already summed into the prefix with `delta` left None."""
+    _set_last_rank(monkeypatch, True)
+    prefix_sum = torch.tensor([1.0, 2.0])
+    pending = torch.tensor([0.5, 0.25])
+
+    _call(_stub_model(enabled=True), 0, prefix_sum, pending, torch.zeros(2))
+
+    assert len(recorder) == 1
+    assert recorder[0].delta is None
+    torch.testing.assert_close(recorder[0].prefix, prefix_sum + pending)
+    # And the caller's tensor is not mutated on the way.
+    torch.testing.assert_close(prefix_sum, torch.tensor([1.0, 2.0]))

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -1586,3 +1586,95 @@ def test_two_dense_groups_agree_still_detects_genuine_sparse_lag():
         "genuinely has not cached the shared prefix both full-attention "
         "groups agree on."
     )
+
+
+def test_connector_fast_path_trims_the_deeper_dense_group():
+    """The connector fast path must trim its block lists, not just lower the
+    length it reports.
+
+    ``get_computed_blocks_for_connector`` looks each group up independently
+    and then reports ``min`` over the full-attention groups, because that is
+    the only length every dense group's blocks actually cover. The blocks
+    themselves still come back at each group's own, possibly deeper, hit.
+    Scheduler hands the pair to ``add_local_computed_blocks`` unchanged, so an
+    untrimmed deeper group extends the request's block table past the reported
+    boundary with blocks it does not own -- the same defect the reconciling
+    path's truncation exists to prevent.
+
+    Needs two dense groups at different block sizes: with one, ``min`` is that
+    group's own hit and its list is trimmed by construction.
+    """
+    hash_block_size = 2
+    block_size = 2 * hash_block_size  # fine dense group + mamba: 4
+    coarse_block_size = 2 * block_size  # 8
+    kv_cache_config = _two_dense_groups_plus_mamba_config(
+        hash_block_size, block_size, coarse_block_size
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    pool = manager.block_pool
+    req = make_request("0", [i // 2 for i in range(16)], hash_block_size, sha256)
+
+    # Fine dense group reaches 12 tokens; coarse reaches 8. The reported hit
+    # is therefore 8, and the fine group's three blocks cover 12 -- one more
+    # block than the report admits to.
+    fine_blocks = pool.get_new_blocks(3)
+    pool.cache_full_blocks(
+        request=req,
+        blocks=fine_blocks,
+        num_cached_blocks=0,
+        num_full_blocks=3,
+        block_size=block_size,
+        kv_cache_group_id=0,
+    )
+    coarse_blocks = pool.get_new_blocks(1)
+    pool.cache_full_blocks(
+        request=req,
+        blocks=coarse_blocks,
+        num_cached_blocks=0,
+        num_full_blocks=1,
+        block_size=coarse_block_size,
+        kv_cache_group_id=1,
+    )
+    mamba_blocks = pool.get_new_blocks(3)
+    pool.cache_full_blocks(
+        request=req,
+        blocks=mamba_blocks,
+        num_cached_blocks=0,
+        num_full_blocks=3,
+        block_size=block_size,
+        kv_cache_group_id=2,
+    )
+
+    blocks, num_local, _boundary, _diverged = (
+        manager.get_computed_blocks_for_connector(req)
+    )
+
+    assert num_local == 8, (
+        f"expected the reported hit to be min over the dense groups (8), "
+        f"got {num_local}"
+    )
+    # Asserted over the full-attention groups only. A block count is the right
+    # invariant for them because their lists are dense and downward-closed, so
+    # a prefix of the list is exactly what a shorter lookup returns. It is the
+    # wrong invariant for a mamba group, whose list is null-padded with only
+    # the tail carrying the state: looked up at 12 it returns
+    # [null, null, state@12] and at 8 it returns [null, state@8], so dropping
+    # the tail entry would discard the state rather than shorten the hit.
+    # That is why the shared truncation skips groups that are not
+    # downward-closed, and why widening it here would be a bug.
+    for group_id in manager.coordinator.full_attention_group_ids:
+        group_blocks = blocks.blocks[group_id]
+        group_block_size = manager.coordinator.single_type_managers[
+            group_id
+        ].block_size
+        allowed = -(-num_local // group_block_size)
+        assert len(group_blocks) <= allowed, (
+            f"group {group_id} returned {len(group_blocks)} blocks of "
+            f"{group_block_size} tokens, past the reported hit of "
+            f"{num_local} tokens ({allowed} blocks)"
+        )

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -23,6 +23,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
     MambaSpec,
+    SlidingWindowSpec,
 )
 
 
@@ -1181,3 +1182,407 @@ def test_hybrid_partial_hit_with_eagle_stays_within_group_blocks():
         len(group) * block_size >= num_computed for group in computed_blocks.blocks
     )
     assert manager.allocate_slots(req1, 4, num_computed, computed_blocks) is not None
+
+
+def test_hybrid_sliding_window_group_keeps_block_aligned_hits():
+    """A sliding-window group makes the whole model fall back to
+    block-aligned hits. ``SlidingWindowManager.find_longest_cache_hit``
+    indexes ``block_hashes`` in whole blocks, so a hash-granularity alignment
+    would read the wrong entries; it asserts instead, which used to abort the
+    engine on the first request of a mamba-"align" + SWA model."""
+    hash_block_size = 2
+    block_size = 2 * hash_block_size
+    kv_cache_config = KVCacheConfig(
+        num_blocks=32,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["swa"],
+                SlidingWindowSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                    sliding_window=block_size,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+
+    tokens = [1, 2, 3, 4, 5, 6, 7, 8]
+    req0 = make_request("0", tokens, hash_block_size, sha256)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(req0)
+    assert manager.allocate_slots(req0, 8, num_computed, computed_blocks) is not None
+    manager.cache_blocks(req0, 8)
+    swa_block_ids = [b.block_id for b in manager.get_blocks("0").blocks[0]]
+    manager.free(req0)
+    manager.new_step_starts()
+
+    req1 = make_request("1", tokens + [9, 10, 11, 12], hash_block_size, sha256)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(req1)
+    assert not manager.coordinator.enable_partial_hash_hits
+    assert num_computed == 8
+    # Out-of-window positions come back null, but every matched block must sit
+    # at the position it was cached at, not at that of its trailing hash unit.
+    swa_hit = computed_blocks.blocks[0]
+    null_block = manager.block_pool.null_block
+    assert len(swa_hit) * block_size == num_computed
+    assert swa_hit[-1] is not null_block
+    assert all(
+        block is null_block or block.block_id == swa_block_ids[i]
+        for i, block in enumerate(swa_hit)
+    )
+
+
+def test_hybrid_without_block_aligned_group_keeps_fine_grained_hits():
+    """The control for the fallback above.
+
+    The gate is a conjunction, so it can only ever over-fire. Without a
+    block-aligned-only group the mamba-"align" model must still get its
+    fine-grained partial hits, at a hit length that is not a multiple of the
+    physical block size.
+    """
+    hash_block_size = 2
+    block_size = 2 * hash_block_size
+    kv_cache_config = KVCacheConfig(
+        num_blocks=32,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+
+    assert manager.coordinator.enable_partial_hash_hits
+
+
+def test_hybrid_partial_hash_truncates_every_full_attention_group():
+    """Every full-attention-typed group is trimmed to the reconciled hit, not
+    just ``attention_groups[0]``.
+
+    Full attention is downward-closed, so the fixed-point loop looks each such
+    group up once and skips it on later passes. Only the final truncation
+    brings the block lists back to the reconciled length, and it used to visit
+    the first group alone. A second full-attention group therefore kept the
+    longer list from its own earlier lookup, and ``add_local_computed_blocks``
+    would extend the request's block table with blocks past the reconciled
+    boundary -- blocks it does not own.
+
+    One full-attention group cannot expose this, since sorting guarantees it is
+    the one the truncation visits.
+    """
+    hash_block_size = 2
+    block_size = 2 * hash_block_size
+    kv_cache_config = KVCacheConfig(
+        num_blocks=32,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full_a"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            # A *different* full-attention spec, so this does not merge into
+            # the group above. Two groups sharing one spec collapse into a
+            # single attention group whose `group_ids` the old truncation
+            # already iterated, which is why identical specs cannot expose
+            # this.
+            KVCacheGroupSpec(
+                ["full_b"],
+                FullAttentionSpec(
+                    block_size=2 * block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    pool = manager.block_pool
+    # 24 tokens, so the wider group holds three whole blocks. With a shorter
+    # request it holds one, which is indistinguishable from the correctly
+    # trimmed answer and the assertion below cannot discriminate.
+    req = make_request(
+        "0",
+        [i // 2 for i in range(24)],
+        hash_block_size,
+        sha256,
+    )
+
+    # Both full-attention groups cache their whole prefix; the mamba group
+    # caches far less, so it is what drives the reconciled hit down.
+    for group_id in (0, 1):
+        group_bs = block_size * (1 + group_id)
+        num_full = 24 // group_bs
+        blocks = pool.get_new_blocks(num_full)
+        pool.cache_full_blocks(
+            request=req,
+            blocks=blocks,
+            num_cached_blocks=0,
+            num_full_blocks=num_full,
+            block_size=group_bs,
+            kv_cache_group_id=group_id,
+        )
+
+    # Genuinely partial: ``cache_partial_block`` asserts the entry does not
+    # land on a block boundary.
+    mamba_block = pool.get_new_blocks(1)[0]
+    pool.cache_partial_block(
+        request=req,
+        block=mamba_block,
+        num_tokens=6,
+        kv_cache_group_id=2,
+        block_size=block_size,
+    )
+
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(req)
+
+    # The invariant, asserted per group rather than against hand-computed
+    # counts: no group may report blocks covering more than the reconciled hit.
+    for group_id, blocks in enumerate(computed_blocks.blocks):
+        group_block_size = manager.coordinator.single_type_managers[
+            group_id
+        ].block_size
+        assert len(blocks) <= -(-max(num_computed, 0) // group_block_size), (
+            f"group {group_id} returned {len(blocks)} blocks of "
+            f"{group_block_size} tokens, past the reconciled hit of "
+            f"{num_computed} tokens"
+        )
+
+
+def _two_dense_groups_plus_mamba_config(
+    hash_block_size: int, block_size: int, coarse_block_size: int
+) -> KVCacheConfig:
+    """Two full-attention groups at different block sizes plus a mamba
+    "align" group -- the DFlash-drafter-as-full-attention shape."""
+    return KVCacheConfig(
+        num_blocks=32,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full_fine"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["full_coarse"],
+                FullAttentionSpec(
+                    block_size=coarse_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+
+
+def test_two_dense_groups_granularity_gap_is_not_an_uncached_prefix():
+    """Two full-attention groups at different block sizes, no sparse group
+    lagging: the finer group (e.g. a DFlash drafter booking its
+    sliding-window layers as full attention) legitimately completes more of
+    its own small blocks than the coarser (target) group for the same real
+    progress, purely from block-size granularity. That gap must not be read
+    as an uncached shared prefix -- nothing failed to cache anything; the
+    coarser group simply has not finished its next, bigger block yet.
+    """
+    hash_block_size = 2
+    block_size = 2 * hash_block_size  # fine group + mamba: 4
+    coarse_block_size = 2 * block_size  # 8
+    kv_cache_config = _two_dense_groups_plus_mamba_config(
+        hash_block_size, block_size, coarse_block_size
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    pool = manager.block_pool
+    req = make_request("0", [i // 2 for i in range(16)], hash_block_size, sha256)
+
+    # Fine group: three whole 4-token blocks, genuinely caught up to 12.
+    fine_blocks = pool.get_new_blocks(3)
+    pool.cache_full_blocks(
+        request=req,
+        blocks=fine_blocks,
+        num_cached_blocks=0,
+        num_full_blocks=3,
+        block_size=block_size,
+        kv_cache_group_id=0,
+    )
+    # Coarse group: one whole 8-token block. 12 is not a multiple of its own
+    # (larger) block size, so it has nothing more to report -- not eviction,
+    # just granularity.
+    coarse_blocks = pool.get_new_blocks(1)
+    pool.cache_full_blocks(
+        request=req,
+        blocks=coarse_blocks,
+        num_cached_blocks=0,
+        num_full_blocks=1,
+        block_size=coarse_block_size,
+        kv_cache_group_id=1,
+    )
+    # Mamba matches the fine group exactly: no sparse-retention group is
+    # lagging behind anything here.
+    mamba_blocks = pool.get_new_blocks(3)
+    pool.cache_full_blocks(
+        request=req,
+        blocks=mamba_blocks,
+        num_cached_blocks=0,
+        num_full_blocks=3,
+        block_size=block_size,
+        kv_cache_group_id=2,
+    )
+
+    _blocks, hit_length, num_uncached = manager.coordinator.find_longest_cache_hit(
+        req.block_hashes, req.num_tokens - 1
+    )
+
+    assert hit_length == 8
+    assert num_uncached == 0, (
+        f"num_uncached_common_prefix_tokens={num_uncached}, expected 0: the "
+        "gap comes from two full-attention groups' block-size granularity, "
+        "not from a sparse-retention group lagging behind."
+    )
+
+
+def test_two_dense_groups_agree_still_detects_genuine_sparse_lag():
+    """Control for the case above: when the two full-attention groups
+    genuinely agree on a longer prefix (the coarse group has its own partial
+    entry at the shared boundary, exactly as a request ending there would
+    produce) and only mamba lags, the gap must still be reported so
+    cross-request reuse is not lost.
+    """
+    hash_block_size = 2
+    block_size = 2 * hash_block_size
+    coarse_block_size = 2 * block_size
+    kv_cache_config = _two_dense_groups_plus_mamba_config(
+        hash_block_size, block_size, coarse_block_size
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    pool = manager.block_pool
+    req = make_request("0", [i // 2 for i in range(16)], hash_block_size, sha256)
+
+    fine_blocks = pool.get_new_blocks(3)
+    pool.cache_full_blocks(
+        request=req,
+        blocks=fine_blocks,
+        num_cached_blocks=0,
+        num_full_blocks=3,
+        block_size=block_size,
+        kv_cache_group_id=0,
+    )
+    # Coarse group genuinely reaches the same 12-token boundary via its own
+    # partial entry -- both dense groups agree here.
+    coarse_blocks = pool.get_new_blocks(2)
+    pool.cache_full_blocks(
+        request=req,
+        blocks=coarse_blocks,
+        num_cached_blocks=0,
+        num_full_blocks=1,
+        block_size=coarse_block_size,
+        kv_cache_group_id=1,
+    )
+    pool.cache_partial_block(
+        request=req,
+        block=coarse_blocks[1],
+        num_tokens=12,
+        kv_cache_group_id=1,
+        block_size=coarse_block_size,
+    )
+    # Mamba genuinely lags: only two whole blocks (8 tokens).
+    mamba_blocks = pool.get_new_blocks(2)
+    pool.cache_full_blocks(
+        request=req,
+        blocks=mamba_blocks,
+        num_cached_blocks=0,
+        num_full_blocks=2,
+        block_size=block_size,
+        kv_cache_group_id=2,
+    )
+
+    _blocks, hit_length, num_uncached = manager.coordinator.find_longest_cache_hit(
+        req.block_hashes, req.num_tokens - 1
+    )
+
+    assert hit_length == 8
+    assert num_uncached == 4, (
+        f"num_uncached_common_prefix_tokens={num_uncached}, expected 4: mamba "
+        "genuinely has not cached the shared prefix both full-attention "
+        "groups agree on."
+    )

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -4311,3 +4311,201 @@ def test_swa_shared_prefix_reuse_under_zero_retention(monkeypatch):
     assert last_req_hit(retention=0, pin=False) == 0
     # retention=0 with the pin keeps the junction window -> reuse restored.
     assert last_req_hit(retention=0, pin=True) == 4 * block_size
+
+
+def _mamba_align_manager(block_size: int = 16, num_blocks: int = 60):
+    manager = make_kv_cache_manager(
+        _make_hybrid_kv_cache_config(block_size, num_blocks, ["full", "mamba_align"]),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+    mamba = manager.coordinator.single_type_managers[1]
+    assert mamba.mamba_cache_mode == "align"
+    return manager, mamba
+
+
+def _hashed_mamba_blocks(mamba, request) -> list[int]:
+    return [
+        index
+        for index, block in enumerate(mamba.req_to_blocks[request.request_id])
+        if not block.is_null and block.block_hash is not None
+    ]
+
+
+def test_mamba_align_records_where_the_forward_leaves_the_state():
+    """`allocate_new_blocks` is where the write position becomes knowable.
+
+    In align mode it already computes `num_tokens_main_model`, which counts the
+    unverified draft tokens the target runs over and is therefore exactly the
+    position the state write covers.
+    """
+    block_size = 16
+    manager, mamba = _mamba_align_manager(block_size)
+    prompt = [i for i in range(2) for _ in range(block_size)]
+    request = make_request("record", prompt, block_size, sha256)
+
+    manager.allocate_slots(request, len(prompt), 0, None)
+
+    assert mamba._state_write_tokens[request.request_id] == len(prompt)
+
+
+def test_mamba_align_admits_a_state_block_written_at_its_own_boundary():
+    """A prefill chunk is clipped onto a boundary, so its block is cacheable.
+
+    This is the other half of the rule and it has to be asserted alongside the
+    withholding case: a mask that degenerated to all-False would withhold these
+    too, take mamba hits to zero, and look like a stricter version of the same
+    fix rather than a broken one.
+    """
+    block_size = 16
+    manager, mamba = _mamba_align_manager(block_size)
+    prompt = [i for i in range(2) for _ in range(block_size)]
+    request = make_request("prefill", prompt, block_size, sha256)
+
+    manager.allocate_slots(request, len(prompt), 0, None)
+
+    assert _hashed_mamba_blocks(mamba, request), (
+        "a write that landed exactly on a block boundary, over committed "
+        "tokens only, is the case the cache is allowed to keep"
+    )
+
+
+def _decode(manager, mamba, request_id, block_size, prompt_blocks, step, num_steps):
+    """Prefill a whole number of blocks, then take uniform decode steps.
+
+    Returns one ``(state write position, admitted mamba blocks)`` pair per
+    decode step.
+    """
+    prompt = [i for i in range(prompt_blocks) for _ in range(block_size)]
+    request = make_request(request_id, prompt, block_size, sha256)
+    manager.allocate_slots(request, len(prompt), 0, None)
+    request.num_computed_tokens = len(prompt)
+
+    steps = []
+    for _ in range(num_steps):
+        request.append_output_token_ids([7] * step)
+        manager.allocate_slots(request, step, 0, None)
+        request.num_computed_tokens += step
+        steps.append(
+            (
+                mamba._state_write_tokens[request.request_id],
+                tuple(_hashed_mamba_blocks(mamba, request)),
+            )
+        )
+    return steps
+
+
+def test_mamba_align_withholds_blocks_a_decode_step_stepped_over():
+    """A decode step is not clipped onto a boundary, so with a step size that
+    does not divide the block size it steps over every boundary it passes.
+
+    Without the rule each of those crossings enters another block into the hash
+    map keyed to a prefix the state it holds does not correspond to.
+    """
+    block_size = 16
+    manager, mamba = _mamba_align_manager(block_size)
+
+    # 17 tokens per step: one committed token plus a fully accepted draft of
+    # 16. Starting from 32, the writes land at 49, 66, 83 -- never on a
+    # multiple of 16.
+    steps = _decode(manager, mamba, "crossed", block_size, 2, 17, 3)
+
+    assert [write for write, _ in steps] == [49, 66, 83]
+    admitted = {block for _, blocks in steps for block in blocks}
+    assert admitted == {1}, (
+        "only the prefill block, whose chunk was clipped onto the 32-token "
+        f"boundary, may be cached; got {sorted(admitted)}"
+    )
+
+
+def test_mamba_align_keeps_admissions_when_decode_lands_on_boundaries():
+    """The rule is targeted, not merely strict: a decode step whose write does
+    land on a boundary over committed tokens is still admitted.
+
+    Without this the fix could pass its withholding tests while degenerating to
+    withholding everything, which would take mamba prefix hits to zero.
+    """
+    block_size = 16
+    manager, mamba = _mamba_align_manager(block_size)
+
+    # A step equal to the block size lands on a boundary every time.
+    steps = _decode(manager, mamba, "aligned", block_size, 2, block_size, 4)
+
+    assert [write for write, _ in steps] == [48, 64, 80, 96]
+    assert [blocks for _, blocks in steps] == [(1, 2), (2, 3), (3, 4), (4, 5)]
+
+
+def test_mamba_align_withholds_a_boundary_write_still_holding_drafts():
+    """Landing on the boundary is not sufficient; the tokens must be committed.
+
+    Under speculation the forward runs over draft tokens that may be rejected,
+    so a write can land exactly on a boundary and still carry contributions
+    that are undone on the next step.
+    """
+    block_size = 16
+    _, mamba = _mamba_align_manager(block_size)
+    request = make_request("drafts", [1] * 32, block_size, sha256)
+    request.append_output_token_ids([7] * 16)
+    assert request.num_tokens == 48
+
+    # A write to the 64-token boundary while only 48 tokens are committed.
+    mamba._state_write_tokens[request.request_id] = 64
+
+    assert mamba._boundary_state_block_mask(request, 0, 4) == [False] * 4
+
+
+def test_mamba_align_withholds_when_no_write_was_recorded():
+    """Callers outside `allocate_slots` -- async output processing, connector
+    load completion -- can reach `cache_blocks` for a request this manager has
+    not sized a step for. Fail closed rather than admitting on no evidence."""
+    block_size = 16
+    _, mamba = _mamba_align_manager(block_size)
+    request = make_request("unknown", [1] * 32, block_size, sha256)
+
+    assert mamba._boundary_state_block_mask(request, 0, 2) == [False, False]
+
+
+def test_mamba_non_align_caching_is_untouched():
+    """Outside align the recurrent state is not block-snapshotted, so dense
+    caching is correct and the rule must not constrain it."""
+    block_size = 16
+    manager = make_kv_cache_manager(
+        _make_hybrid_kv_cache_config(block_size, 60, ["full", "mamba"]),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+    mamba = manager.coordinator.single_type_managers[1]
+    assert mamba.mamba_cache_mode != "align"
+    request = make_request("dense", [1] * 32, block_size, sha256)
+
+    assert mamba._boundary_state_block_mask(request, 0, 2) is None
+
+
+def test_extra_block_mask_can_only_withhold_never_admit():
+    """The mask is ANDed into whatever the manager already computed, so it can
+    take a block out of the admitted set but never put one in."""
+    block_size = 16
+    manager = make_kv_cache_manager(
+        _make_hybrid_kv_cache_config(block_size, 60, ["full"]),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+    full = manager.coordinator.single_type_managers[0]
+    prompt = [i for i in range(2) for _ in range(block_size)]
+
+    def hashes_with(extra_block_mask, request_id):
+        request = make_request(request_id, prompt, block_size, sha256)
+        # Full attention caches densely, so without an extra mask both blocks
+        # are admitted; that is the control the mask has to be able to override.
+        manager.allocate_slots(request, len(prompt), 0, None, delay_cache_blocks=True)
+        full.cache_blocks(request, len(prompt), extra_block_mask=extra_block_mask)
+        return [
+            block.block_hash is not None
+            for block in full.req_to_blocks[request.request_id]
+        ]
+
+    assert hashes_with(None, "dense") == [True, True]
+    assert hashes_with([False, False], "withheld") == [False, False]

--- a/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
@@ -232,6 +232,25 @@ def test_coordinator_fine_grained_partial_tail_hit():
     assert hit == 48
 
 
+def test_coordinator_sliding_window_group_disables_fine_grained_hits():
+    """A sliding-window group only supports block-aligned lookup, so the
+    connector must keep the scheduler-block alignment (and stay in step with
+    core) instead of handing the manager hash-granularity hashes."""
+    groups = [
+        KVCacheGroupSpec(["L0"], _swa(32, 64)),
+        KVCacheGroupSpec(["L1"], _mamba_align(32)),
+    ]
+    coord = _make_coord(groups, hash_block_size=16)
+    hs = _hashes(4)
+    exists = {(g, bytes(h)) for g in (0, 1) for h in (hs[1], hs[3])}
+    cmap = ExternalCachedBlockPool(16, exists)
+    _masks, hit = coord.find_longest_cache_hit(
+        hs, max_length=64, cached_block_pool=cmap
+    )
+    assert not coord.enable_partial_hash_hits
+    assert hit == 64
+
+
 def test_coordinator_fine_grained_clips_when_one_group_missing_tail():
     """If only one group has the sub-block boundary, min-convergence clips the
     reconciled hit back to the block boundary (32)."""

--- a/tests/v1/spec_decode/test_dflash_draft_full_attention_spec.py
+++ b/tests/v1/spec_decode/test_dflash_draft_full_attention_spec.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""A DFlash drafter may book its sliding-window layers as full attention.
+
+The conversion exists so an all-sliding drafter can take part in prefix
+caching: ``SlidingWindowManager`` cannot serve the fine-grained (partial)
+hits a hybrid coordinator hands it, while ``FullAttentionManager`` can.
+
+The property that matters and is easy to lose is that ``sliding_window``
+survives onto the converted spec. The window is enforced at compute time by
+reading it off the spec, so a conversion that dropped it would silently
+enforce no window at all rather than failing loudly.
+"""
+
+import pytest
+
+from tests.v1.worker.test_gpu_model_runner import get_vllm_config
+from vllm.config import set_current_vllm_config
+from vllm.model_executor.layers.attention.attention import Attention
+from vllm.v1.kv_cache_interface import FullAttentionSpec, SlidingWindowSpec
+
+WINDOW = 4096
+
+
+def _sliding_window_layer(vllm_config):
+    model_config = vllm_config.model_config
+    return Attention(
+        model_config.get_num_kv_heads(vllm_config.parallel_config),
+        model_config.get_head_size(),
+        0.1,
+        per_layer_sliding_window=WINDOW,
+    )
+
+
+def test_sliding_window_layer_defaults_to_sliding_window_spec():
+    """Opt-in: without the flag the layer is unchanged."""
+    vllm_config = get_vllm_config()
+    with set_current_vllm_config(vllm_config):
+        layer = _sliding_window_layer(vllm_config)
+        assert layer.book_sliding_window_as_full_attention is False
+        spec = layer.get_kv_cache_spec(vllm_config)
+
+    assert isinstance(spec, SlidingWindowSpec)
+    assert spec.sliding_window == WINDOW
+
+
+def test_booking_as_full_attention_preserves_the_window():
+    """The converted spec is full attention but still carries the window.
+
+    Both halves are load-bearing. The spec *type* is what routes the group to
+    a manager that supports partial hits; the ``sliding_window`` *field* is
+    what keeps the kernel masking to the window. Asserting only the type
+    would let a regression that drops the window pass.
+    """
+    vllm_config = get_vllm_config()
+    with set_current_vllm_config(vllm_config):
+        layer = _sliding_window_layer(vllm_config)
+        sliding_spec = layer.get_kv_cache_spec(vllm_config)
+
+        layer.book_sliding_window_as_full_attention = True
+        converted = layer.get_kv_cache_spec(vllm_config)
+
+    assert isinstance(converted, FullAttentionSpec)
+    assert converted.sliding_window == WINDOW
+
+    # The block size stays the sliding-window one rather than the model's, so
+    # page unification can still scale it by an integer ratio. This is also
+    # why a converted drafter produces a *second* full-attention group at a
+    # different block size from the target's.
+    assert converted.block_size == sliding_spec.block_size
+
+    # `page_size_padded` also carries over. The ordinary full-attention path
+    # sets neither this nor a sliding-window block size, so a converted spec is
+    # not interchangeable with one built that way -- both fields are what let
+    # page unification scale this group against the target's by an integer
+    # ratio instead of rejecting the pair.
+    assert converted.page_size_padded == sliding_spec.page_size_padded
+
+
+def test_conversion_does_not_touch_a_non_sliding_layer():
+    """A layer with no window is full attention either way, and setting the
+    flag must not invent one."""
+    vllm_config = get_vllm_config()
+    with set_current_vllm_config(vllm_config):
+        model_config = vllm_config.model_config
+        layer = Attention(
+            model_config.get_num_kv_heads(vllm_config.parallel_config),
+            model_config.get_head_size(),
+            0.1,
+        )
+        before = layer.get_kv_cache_spec(vllm_config)
+        layer.book_sliding_window_as_full_attention = True
+        after = layer.get_kv_cache_spec(vllm_config)
+
+    assert isinstance(before, FullAttentionSpec)
+    assert isinstance(after, FullAttentionSpec)
+    assert after.sliding_window is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/v1/spec_decode/test_dynamic_sd_cug.py
+++ b/tests/v1/spec_decode/test_dynamic_sd_cug.py
@@ -5,6 +5,7 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
 import torch
 
@@ -16,6 +17,7 @@ from vllm.config import (
     VllmConfig,
 )
 from vllm.v1.worker.gpu import cudagraph_utils as gpu_cudagraph_utils
+from vllm.v1.worker.utils import get_uniform_decode_token_count
 
 pytestmark = pytest.mark.cpu_test
 
@@ -194,6 +196,85 @@ def test_dynamic_sd_non_uniform_batch_falls_back_to_piecewise(monkeypatch):
     assert desc.num_reqs is None
     assert desc.num_tokens == 3
     assert desc.num_active_loras == 0
+
+
+def test_prompt_chunks_shaped_like_spec_decode_miss_the_full_graph(monkeypatch):
+    """A batch holding K+1-token prompt chunks must not replay a decode graph.
+
+    The FULL spec-verify graph is selected on the batch shape alone
+    (num_reqs * (K + 1) tokens), which prompt chunks of exactly K + 1 tokens
+    satisfy by coincidence. Replaying it over prompt tokens corrupts every
+    request in the batch, not just the chunks, because the captured kernels
+    read per-request state that a batch containing prefills never refreshes.
+    See https://github.com/vllm-project/vllm/issues/49918.
+    """
+
+    max_spec_tokens = 7
+    decode_query_len = max_spec_tokens + 1
+
+    monkeypatch.setattr(
+        gpu_cudagraph_utils,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=True),
+    )
+
+    vllm_config = _create_vllm_config_for_dsd(
+        max_num_seqs=64,
+        max_spec_tokens=max_spec_tokens,
+        use_dynamic_sd=False,
+    )
+    manager = gpu_cudagraph_utils.CudaGraphManager(
+        vllm_config=vllm_config,
+        device=torch.device("cpu"),
+        cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
+        decode_query_len=decode_query_len,
+    )
+    manager._graphs_captured = True
+
+    num_decodes, num_chunks = 6, 2
+    num_reqs = num_decodes + num_chunks
+    num_tokens = num_reqs * decode_query_len
+    # The six decoding requests have their prompts fully computed; the two
+    # chunks are decode_query_len tokens into a longer, unfinished prompt.
+    prefill_lens = np.array([16] * num_decodes + [40] * num_chunks, dtype=np.int32)
+    num_computed = np.array(
+        [16] * num_decodes + [decode_query_len] * num_chunks, dtype=np.int32
+    )
+
+    # The batch shape is indistinguishable from a full batch of spec decodes.
+    assert (
+        gpu_cudagraph_utils.get_uniform_token_count(
+            num_reqs, num_tokens, decode_query_len
+        )
+        == decode_query_len
+    )
+
+    uniform_tok_count = get_uniform_decode_token_count(
+        num_reqs, num_tokens, decode_query_len, num_computed, prefill_lens
+    )
+    assert uniform_tok_count is None
+    desc = manager.dispatch(
+        num_reqs=num_reqs,
+        num_tokens=num_tokens,
+        uniform_token_count=uniform_tok_count,
+        num_active_loras=0,
+    )
+    assert desc.cg_mode == CUDAGraphMode.PIECEWISE
+    assert desc.uniform_token_count is None
+
+    # The same shape with every request decoding still gets its FULL graph.
+    uniform_tok_count = get_uniform_decode_token_count(
+        num_reqs, num_tokens, decode_query_len, prefill_lens, prefill_lens
+    )
+    assert uniform_tok_count == decode_query_len
+    desc = manager.dispatch(
+        num_reqs=num_reqs,
+        num_tokens=num_tokens,
+        uniform_token_count=uniform_tok_count,
+        num_active_loras=0,
+    )
+    assert desc.cg_mode == CUDAGraphMode.FULL
+    assert desc.uniform_token_count == decode_query_len
 
 
 def test_basic_sd_does_not_capture_shorter_full_decode_shapes(monkeypatch):

--- a/tests/v1/worker/test_gpu_batch_ordering.py
+++ b/tests/v1/worker/test_gpu_batch_ordering.py
@@ -1,18 +1,26 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Batch ordering in Model Runner V2 (vllm.v1.worker.gpu).
+"""Batch ordering and classification in Model Runner V2 (vllm.v1.worker.gpu).
 
 split_decodes_and_prefills assumes decode -> short_extend -> prefill request
 ordering. With spec decode (decode_query_len > 1), a shorter chunked-prefill
 tail sorted in front of the uniform decodes misclassifies every decode as a
 prefill.
+
+Conversely, a prompt chunk of exactly decode_query_len tokens has a decode
+batch's shape, and must not be classified as a uniform decode batch.
 """
 
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
 import torch
 
 from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.attention.backends.utils import split_decodes_and_prefills
-from vllm.v1.worker.gpu.model_runner import sort_batch_req_ids
+from vllm.v1.worker.gpu.model_runner import GPUModelRunner, sort_batch_req_ids
+from vllm.v1.worker.utils import get_uniform_decode_token_count
 
 
 def _make_common_attn_metadata(query_lens: list[int]) -> CommonAttentionMetadata:
@@ -34,6 +42,79 @@ def _make_common_attn_metadata(query_lens: list[int]) -> CommonAttentionMetadata
         max_query_len=max(query_lens),
         block_table_tensor=torch.zeros(num_reqs, 1, dtype=torch.int32),
         slot_mapping=torch.zeros(num_tokens, dtype=torch.int64),
+    )
+
+
+def _make_runner(req_states: dict[str, tuple[int, int]]) -> Any:
+    """Build a runner stub from {req_id: (num_computed_tokens, prefill_len)}."""
+    prefill_lens = np.array([s[1] for s in req_states.values()], dtype=np.int32)
+    num_computed = np.array([s[0] for s in req_states.values()], dtype=np.int32)
+    runner: Any = GPUModelRunner.__new__(GPUModelRunner)
+    runner.req_states = SimpleNamespace(
+        req_id_to_index={req_id: i for i, req_id in enumerate(req_states)},
+        # The runner keeps this as min(num_computed_tokens, prefill_len).
+        num_computed_prefill_tokens=np.minimum(num_computed, prefill_lens),
+        prefill_len=SimpleNamespace(np=prefill_lens),
+    )
+    return runner
+
+
+def _uniform_token_count(
+    req_states: dict[str, tuple[int, int]],
+    query_len: int,
+    dummy_run: bool = False,
+) -> int | None:
+    scheduler_output = SimpleNamespace(
+        num_scheduled_tokens={req_id: query_len for req_id in req_states},
+        total_num_scheduled_tokens=query_len * len(req_states),
+    )
+    return GPUModelRunner._get_uniform_token_count(
+        _make_runner(req_states),
+        scheduler_output,
+        len(req_states),
+        query_len * len(req_states),
+        query_len,
+        dummy_run,
+    )
+
+
+def test_spec_decode_batch_is_uniform_decode():
+    # decode_query_len == 8 (K=7): every request past its prefill.
+    decodes = {f"d{i}": (16, 16) for i in range(6)}
+    assert _uniform_token_count(decodes, 8) == 8
+
+
+def test_prompt_chunk_of_decode_query_len_is_not_uniform_decode():
+    # Two requests are 8 tokens into a 40-token prompt, so their query length
+    # only coincides with the K+1 spec-decode query length. Replaying the
+    # decode graph here corrupts the six decodes as well, so the whole batch
+    # must be rejected. See https://github.com/vllm-project/vllm/issues/49918.
+    batch = {f"d{i}": (16, 16) for i in range(6)}
+    batch.update({f"p{i}": (8, 40) for i in range(2)})
+    assert _uniform_token_count(batch, 8) is None
+
+    # Same collision without spec decoding: a 1-token prompt looks like a
+    # 1-token decode step.
+    assert _uniform_token_count({"p0": (0, 1)}, 1) is None
+
+    # A fresh prompt that happens to be exactly decode_query_len tokens long.
+    assert _uniform_token_count({"p0": (0, 8)}, 8) is None
+
+
+def test_dummy_batches_stay_uniform_decode():
+    # Dummy batches (DP padding, profiling, warmup) are uniform by
+    # construction and their requests have no state to consult, so they must be
+    # classified without one: looking one up would raise KeyError here, and
+    # rejecting them would make graph capture and replay disagree.
+    scheduler_output = SimpleNamespace(
+        num_scheduled_tokens={f"_dummy_req_{i}": 8 for i in range(4)},
+        total_num_scheduled_tokens=32,
+    )
+    assert (
+        GPUModelRunner._get_uniform_token_count(
+            _make_runner({}), scheduler_output, 4, 32, 8, True
+        )
+        == 8
     )
 
 
@@ -68,3 +149,75 @@ def test_spec_decodes_lead_short_prefill_tail():
     )
     assert (num_decodes, num_prefills) == (8, 1)
     assert (num_decode_tokens, num_prefill_tokens) == (16, 1)
+
+
+def test_uniform_decode_uses_state_index_not_batch_position():
+    """The predicate must read each request's own state, not its batch slot.
+
+    `req_id_to_index` is a persistent map into the runner's state arrays, so a
+    request's batch position and its state index diverge as requests come and
+    go. Here the only prefilling request sits at state index 0 while the two
+    scheduled decodes sit at 1 and 2, so a gather that used batch position
+    would read the prefilling row and wrongly reject the batch.
+    """
+    runner: Any = GPUModelRunner.__new__(GPUModelRunner)
+    # State arrays in state-index order: a prefilling request, then two decodes.
+    runner.req_states = SimpleNamespace(
+        req_id_to_index={"prefilling": 0, "decode_a": 1, "decode_b": 2},
+        num_computed_prefill_tokens=np.array([8, 16, 16], dtype=np.int32),
+        prefill_len=SimpleNamespace(np=np.array([40, 16, 16], dtype=np.int32)),
+    )
+    scheduler_output = SimpleNamespace(
+        num_scheduled_tokens={"decode_a": 8, "decode_b": 8},
+        total_num_scheduled_tokens=16,
+    )
+
+    assert (
+        GPUModelRunner._get_uniform_token_count(
+            runner, scheduler_output, 2, 16, 8, False
+        )
+        == 8
+    )
+
+    # Scheduling the prefilling request alongside them must reject the batch.
+    scheduler_output.num_scheduled_tokens = {
+        "decode_a": 8,
+        "prefilling": 8,
+        "decode_b": 8,
+    }
+    scheduler_output.total_num_scheduled_tokens = 24
+    assert (
+        GPUModelRunner._get_uniform_token_count(
+            runner, scheduler_output, 3, 24, 8, False
+        )
+        is None
+    )
+
+
+def test_predicate_agrees_with_is_prefilling():
+    """The drafter's call site passes `InputBatch`'s two arrays directly.
+
+    `InputBatch.is_prefilling_np` is documented as
+    `num_computed_prefill_tokens_np < prefill_len_np`, so the shared predicate
+    must reject a batch exactly when that flag is set for any request. This
+    pins the contract the drafter relies on without standing up a speculator.
+    """
+    cases = [
+        (np.array([16, 16], dtype=np.int32), np.array([16, 16], dtype=np.int32)),
+        (np.array([8, 16], dtype=np.int32), np.array([40, 16], dtype=np.int32)),
+        (np.array([0], dtype=np.int32), np.array([1], dtype=np.int32)),
+        (np.array([5, 5, 5], dtype=np.int32), np.array([5, 5, 5], dtype=np.int32)),
+    ]
+    for num_computed_prefill_tokens, prefill_lens in cases:
+        num_reqs = len(prefill_lens)
+        is_prefilling = num_computed_prefill_tokens < prefill_lens
+        result = get_uniform_decode_token_count(
+            num_reqs,
+            8 * num_reqs,
+            8,
+            num_computed_prefill_tokens,
+            prefill_lens,
+        )
+        assert (result is None) == bool(is_prefilling.any()), (
+            f"{num_computed_prefill_tokens} vs {prefill_lens} -> {result}"
+        )

--- a/tests/v1/worker/test_gpu_rejection_sampler_padded_argmax.py
+++ b/tests/v1/worker/test_gpu_rejection_sampler_padded_argmax.py
@@ -1,0 +1,387 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""A padded-lane argmax index must not escape the real block count.
+
+Two reductions in the V2 rejection sampler run ``tl.argmax`` over
+``PADDED_*_NUM_BLOCKS`` lanes -- the next power of two -- and then index a
+companion tensor that is only ``*_num_blocks`` wide::
+
+    _gather_global_argmax (target)  vocab 163840 / 8192 ->  20 real,  32 padded
+    _gather_global_argmax (resample) vocab 163840 / 1024 -> 160 real, 256 padded
+
+The companion max load is masked with ``other=-inf``, so a padded lane cannot
+win on value alone. It can win when a real lane holds NaN. Triton's argmax
+combine is ``gt = (value1 > value2) or (value1 == value2 and index1 < index2)``
+and both comparisons are false for an unordered operand, so a NaN yields the
+*other* operand and an arbitrary surviving index. The gather that follows is
+neither masked nor clamped, so whatever index survives is applied directly to
+the companion tensor -- for the last row of a batch, past its allocation.
+
+Which lane survives depends on the order in which the reduction happens to
+combine lanes, which is a property of the Triton build rather than of this
+code. So the kernel-level tests here do not assert an index; they assert that
+the block index cannot escape the real block count, by filling the companion
+tensor with in-vocabulary ids so that only an escaped *index* can be observed.
+The end-to-end test at the bottom of this file covers the complementary half,
+that the *id* the sampler emits is inside the vocabulary, which the companion's
+own producers can otherwise violate.
+
+To observe an escaped index rather than read past the allocation, the
+companion tensor is over-allocated to the padded width and its out-of-range
+columns are filled with a sentinel. The strides handed to the kernels are the
+over-allocated ones, so the indexing under test is the production indexing with
+a wider row: an escaped index lands on the sentinel rather than on the next
+row's valid id, which in production would be indistinguishable from a correct
+result on any row but the last. The sentinel is the value a mixed batch
+produced in the field -- two INT32_MAX halves, i.e. uninitialized memory read
+as an int64.
+
+The batch geometry mirrors the one that first exposed this: two requests, the
+first carrying draft tokens and the second none. ``warmup.py`` builds that
+shape deliberately, and the scheduler produces it in ordinary serving whenever
+the drafter proposes nothing for a request.
+"""
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+from vllm.v1.worker.gpu.spec_decode.rejection_sampler_utils import (
+    _gather_global_argmax,
+    _insert_resampled_kernel,
+    rejection_sample,
+)
+
+# An exact multiple of both block sizes, so the real block counts are 20 and
+# 160 and neither is a power of two -- which is what leaves padded lanes for
+# the reduction to reach.
+VOCAB_SIZE = 163840
+# Mirrors the constants in `rejection_sample`.
+VOCAB_BLOCK_SIZE = 8192
+RESAMPLE_BLOCK_SIZE = 1024
+
+NUM_SPECULATIVE_STEPS = 2
+
+# What the escaped gather returned in the field: 0x7FFFFFFF7FFFFFFF, two
+# INT32_MAX halves. Any id at or beyond the vocabulary would do; this one names
+# the failure.
+SENTINEL = 0x7FFFFFFF7FFFFFFF
+
+# NaN placements among the real lanes. "all" is the one that escapes: with no
+# finite real lane left, every combine order settles on the lowest-indexed
+# masked lane, which is exactly `num_blocks`. The others leave a finite lane
+# that usually survives, and are here because the invariant has to hold for
+# them too however the reduction is ordered.
+NAN_PATTERNS = ["all", "leading_half", "first", "last"]
+
+
+def _local_max_row(num_blocks: int, winner: int, dtype, device) -> torch.Tensor:
+    """Strictly decreasing values with a unique maximum at ``winner``.
+
+    ``winner`` is deliberately not the last real block, so a test that clamps
+    to ``num_blocks - 1`` cannot be mistaken for one that found the true max.
+    """
+    row = -torch.arange(num_blocks, dtype=dtype, device=device)
+    row[winner] = 1000.0
+    return row
+
+
+def _poison(real_lanes: torch.Tensor, pattern: str) -> None:
+    """Write ``pattern`` into a view of the real lanes, in place."""
+    num_blocks = real_lanes.shape[-1]
+    if pattern == "all":
+        real_lanes.fill_(float("nan"))
+    elif pattern == "leading_half":
+        real_lanes[..., : num_blocks // 2] = float("nan")
+    elif pattern == "first":
+        real_lanes[..., 0] = float("nan")
+    elif pattern == "last":
+        real_lanes[..., num_blocks - 1] = float("nan")
+    else:
+        raise AssertionError(f"unknown NaN pattern {pattern!r}")
+
+
+def _companion_tensors(
+    num_rows: int,
+    num_blocks: int,
+    padded_num_blocks: int,
+    block_size: int,
+    max_dtype: torch.dtype,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Over-allocated (local_argmax, local_max), sentinel past the real width.
+
+    Production sizes both to ``num_blocks``; widening them to the padded width
+    is what turns an out-of-bounds read into an observable value.
+    """
+    local_argmax = torch.full(
+        (num_rows, padded_num_blocks), SENTINEL, dtype=torch.int64, device=device
+    )
+    # Real lanes hold the first token id of their block, as the producers store.
+    local_argmax[:, :num_blocks] = (
+        torch.arange(num_blocks, dtype=torch.int64, device=device) * block_size
+    )
+    # Padded lanes of the max are read under `mask`, so +inf here is unreachable
+    # while the mask holds -- and wins outright the moment it stops holding.
+    local_max = torch.full(
+        (num_rows, padded_num_blocks),
+        float("inf"),
+        dtype=max_dtype,
+        device=device,
+    )
+    return local_argmax, local_max
+
+
+@triton.jit
+def _target_argmax_probe_kernel(
+    out_ptr,
+    target_local_max_ptr,
+    target_local_max_stride,
+    target_local_argmax_ptr,
+    target_local_argmax_stride,
+    vocab_num_blocks,
+    PADDED_VOCAB_NUM_BLOCKS: tl.constexpr,
+):
+    """Expose the device function under test one row per program.
+
+    ``_gather_global_argmax`` is a ``triton.jit`` device function called from
+    inside ``_rejection_kernel``, so reaching it needs a launchable wrapper.
+    This one adds nothing but the store.
+    """
+    logit_idx = tl.program_id(0)
+    token_id = _gather_global_argmax(
+        target_local_max_ptr,
+        target_local_max_stride,
+        target_local_argmax_ptr,
+        target_local_argmax_stride,
+        logit_idx,
+        vocab_num_blocks,
+        PADDED_VOCAB_NUM_BLOCKS,
+    )
+    tl.store(out_ptr + logit_idx, token_id)
+
+
+def _run_target_argmax(
+    nan_pattern: str | None, winner: int, device: torch.device
+) -> torch.Tensor:
+    num_blocks = triton.cdiv(VOCAB_SIZE, VOCAB_BLOCK_SIZE)
+    padded_num_blocks = triton.next_power_of_2(num_blocks)
+    assert padded_num_blocks > num_blocks, "no padded lanes; test proves nothing"
+
+    # One row per logit of the mixed batch below: 3 for the request with draft
+    # tokens, 1 for the request without.
+    num_logits = (NUM_SPECULATIVE_STEPS + 1) + 1
+    local_argmax, local_max = _companion_tensors(
+        num_logits,
+        num_blocks,
+        padded_num_blocks,
+        VOCAB_BLOCK_SIZE,
+        torch.float32,
+        device,
+    )
+    local_max[:, :num_blocks] = _local_max_row(
+        num_blocks, winner, torch.float32, device
+    )
+    if nan_pattern is not None:
+        _poison(local_max[:, :num_blocks], nan_pattern)
+
+    out = torch.zeros(num_logits, dtype=torch.int64, device=device)
+    _target_argmax_probe_kernel[(num_logits,)](
+        out,
+        local_max,
+        local_max.stride(0),
+        local_argmax,
+        local_argmax.stride(0),
+        num_blocks,
+        PADDED_VOCAB_NUM_BLOCKS=padded_num_blocks,
+    )
+    return out
+
+
+def _run_insert_resampled(
+    nan_pattern: str | None,
+    winner: int,
+    max_dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    """Return the id ``_insert_resampled_kernel`` wrote for each request."""
+    num_blocks = triton.cdiv(VOCAB_SIZE, RESAMPLE_BLOCK_SIZE)
+    padded_num_blocks = triton.next_power_of_2(num_blocks)
+    assert padded_num_blocks > num_blocks, "no padded lanes; test proves nothing"
+
+    # Request 0 carries draft tokens (1 + k logits), request 1 carries none (1
+    # logit). This is the mixed shape; it is also why the second request is the
+    # last row, the one whose escaped gather leaves the allocation.
+    num_reqs = 2
+    cu_num_logits = torch.tensor(
+        [0, NUM_SPECULATIVE_STEPS + 1, NUM_SPECULATIVE_STEPS + 2],
+        dtype=torch.int32,
+        device=device,
+    )
+    num_logits = int(cu_num_logits[-1])
+    # Request 0 accepted one token and resamples at its second logit; request 1
+    # has no drafts, so its only logit is the bonus. Both reach the gather.
+    num_sampled = torch.tensor([1, 0], dtype=torch.int32, device=device)
+    write_col = num_sampled.clone()
+
+    expanded_idx_mapping = torch.zeros(num_logits, dtype=torch.int32, device=device)
+    expanded_idx_mapping[NUM_SPECULATIVE_STEPS + 1 :] = 1
+    # Non-zero temperature everywhere, so neither request takes the greedy
+    # early return above the gather.
+    temperature = torch.ones(num_reqs, dtype=torch.float32, device=device)
+
+    local_argmax, local_max = _companion_tensors(
+        num_reqs,
+        num_blocks,
+        padded_num_blocks,
+        RESAMPLE_BLOCK_SIZE,
+        max_dtype,
+        device,
+    )
+    local_max[:, :num_blocks] = _local_max_row(num_blocks, winner, max_dtype, device)
+    if nan_pattern is not None:
+        _poison(local_max[:, :num_blocks], nan_pattern)
+
+    sampled = torch.zeros(
+        num_reqs, NUM_SPECULATIVE_STEPS + 1, dtype=torch.int64, device=device
+    )
+    _insert_resampled_kernel[(num_reqs,)](
+        sampled,
+        sampled.stride(0),
+        num_sampled,
+        local_argmax,
+        local_argmax.stride(0),
+        local_max,
+        local_max.stride(0),
+        num_blocks,
+        cu_num_logits,
+        expanded_idx_mapping,
+        temperature,
+        PADDED_RESAMPLE_NUM_BLOCKS=padded_num_blocks,
+    )
+    return sampled.gather(1, write_col.to(torch.int64).unsqueeze(1)).squeeze(1)
+
+
+def _assert_in_vocab(ids: torch.Tensor) -> None:
+    """Every real lane of the companion holds an in-vocabulary id, so this can
+    only fire on an id gathered from an escaped block index."""
+    out_of_range = (ids < 0) | (ids >= VOCAB_SIZE)
+    assert not out_of_range.any(), (
+        f"sampler emitted ids outside [0, {VOCAB_SIZE}): {ids.tolist()}"
+    )
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")
+@pytest.mark.parametrize("nan_pattern", NAN_PATTERNS)
+def test_target_argmax_stays_in_vocab_with_nan_logits(nan_pattern: str):
+    """A NaN block max must not let the greedy argmax gather past the row."""
+    ids = _run_target_argmax(nan_pattern, winner=7, device=torch.device("cuda:0"))
+    _assert_in_vocab(ids)
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")
+@pytest.mark.parametrize("nan_pattern", NAN_PATTERNS)
+@pytest.mark.parametrize("max_dtype", [torch.float32, torch.float64])
+def test_insert_resampled_stays_in_vocab_with_nan_logits(
+    nan_pattern: str, max_dtype: torch.dtype
+):
+    """The same for the resample gather, over both `use_fp64` layouts.
+
+    This is the site with the widest overrun: 160 real lanes against 256
+    padded, so an escaped index reaches up to 95 int64 words past the last
+    request's row.
+    """
+    ids = _run_insert_resampled(
+        nan_pattern, winner=37, max_dtype=max_dtype, device=torch.device("cuda:0")
+    )
+    _assert_in_vocab(ids)
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")
+def test_target_argmax_unchanged_without_nan():
+    """The control. Finite logits must still resolve to the true maximum.
+
+    Without this the tests above could be satisfied by a fix that clamps every
+    lookup to the last block.
+    """
+    winner = 7
+    ids = _run_target_argmax(None, winner=winner, device=torch.device("cuda:0"))
+    _assert_in_vocab(ids)
+    assert torch.all(ids == winner * VOCAB_BLOCK_SIZE), ids.tolist()
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")
+@pytest.mark.parametrize("max_dtype", [torch.float32, torch.float64])
+def test_insert_resampled_unchanged_without_nan(max_dtype: torch.dtype):
+    """The same control for the resample gather."""
+    winner = 37
+    ids = _run_insert_resampled(
+        None, winner=winner, max_dtype=max_dtype, device=torch.device("cuda:0")
+    )
+    _assert_in_vocab(ids)
+    assert torch.all(ids == winner * RESAMPLE_BLOCK_SIZE), ids.tolist()
+
+
+# The two reductions above consume a companion tensor that `rejection_sample`
+# fills in with its own masked reductions, which build a token id by arithmetic
+# rather than by dereferencing an index. Those can put an out-of-vocabulary lane
+# of a partial block into the companion, so the end-to-end invariant needs its
+# own coverage. A vocabulary smaller than a block size makes block 0 itself
+# partial, which is the case an all-NaN row settles on.
+SMALL_VOCAB_SIZES = [900, 5000]
+
+
+def _run_rejection_sample(vocab_size: int, temperature: float) -> torch.Tensor:
+    """Drive `rejection_sample` on an all-NaN target and return the emitted ids."""
+    device = torch.device("cuda:0")
+    num_reqs = 2
+    logits_per_req = NUM_SPECULATIVE_STEPS + 1
+    num_logits = num_reqs * logits_per_req
+
+    target_logits = torch.full(
+        (num_logits, vocab_size), float("nan"), dtype=torch.float32, device=device
+    )
+    idx_mapping = torch.arange(num_reqs, dtype=torch.int32, device=device)
+    sampled, num_sampled = rejection_sample(
+        target_logits=target_logits,
+        draft_logits=None,
+        draft_sampled=torch.zeros(num_logits, dtype=torch.int64, device=device),
+        cu_num_logits=torch.arange(
+            0, num_logits + 1, logits_per_req, dtype=torch.int32, device=device
+        ),
+        pos=torch.arange(num_logits, dtype=torch.int64, device=device),
+        idx_mapping=idx_mapping,
+        expanded_idx_mapping=idx_mapping.repeat_interleave(logits_per_req),
+        expanded_local_pos=torch.arange(
+            logits_per_req, dtype=torch.int32, device=device
+        )
+        .repeat(num_reqs)
+        .contiguous(),
+        temperature=torch.full(
+            (num_reqs,), temperature, dtype=torch.float32, device=device
+        ),
+        seed=torch.full((num_reqs,), 42, dtype=torch.int64, device=device),
+        num_speculative_steps=NUM_SPECULATIVE_STEPS,
+    )
+    steps = torch.arange(NUM_SPECULATIVE_STEPS + 1, device=device)
+    return sampled[steps.unsqueeze(0) < num_sampled.unsqueeze(1)]
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")
+@pytest.mark.parametrize("vocab_size", SMALL_VOCAB_SIZES)
+@pytest.mark.parametrize("temperature", [0.0, 1.0])
+def test_rejection_sample_stays_in_vocab_with_nan_logits(
+    vocab_size: int, temperature: float
+):
+    """No NaN target row may make the sampler emit an id outside the vocabulary.
+
+    Covers greedy (the target-argmax companion) and sampling (the resample
+    companion), whose block sizes differ, so one vocabulary leaves block 0
+    partial for one path and not the other.
+    """
+    ids = _run_rejection_sample(vocab_size, temperature)
+    assert ids.numel() > 0
+    assert torch.all((ids >= 0) & (ids < vocab_size)), (
+        f"emitted out-of-vocabulary id: {ids.tolist()} (vocab_size={vocab_size})"
+    )

--- a/tests/v1/worker/test_gpu_warmup_blocks.py
+++ b/tests/v1/worker/test_gpu_warmup_blocks.py
@@ -1,0 +1,359 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""The V2 warmup must reserve the KV blocks the scheduler would reserve.
+
+`KVCacheManager.allocate_slots` sizes every allocation for
+`num_computed + num_scheduled + num_lookahead_tokens`, because the speculator
+writes KV past the token range the target model was scheduled for. The warmup
+hand-builds its `SchedulerOutput`s, so it has to reserve the same blocks.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from tests.v1.core.test_prefix_caching import make_kv_cache_manager
+from tests.v1.core.utils import create_requests
+from vllm.config.speculative import SpeculativeConfig
+from vllm.config.vllm import VllmConfig
+from vllm.platforms import current_platform
+from vllm.utils.math_utils import cdiv
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MambaSpec,
+)
+from vllm.v1.worker.gpu.warmup import (
+    _reserved_block_count,
+    run_mixed_prefill_decode_warmup,
+    warmup_kernels,
+)
+
+BLOCK_SIZE = 16
+MAX_MODEL_LEN = 1024
+NUM_SPEC_STEPS = 3
+
+# `warmup_kernels` ends on `torch.accelerator.synchronize()`.
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="warmup synchronizes on the accelerator"
+)
+
+
+def _attention_group() -> KVCacheGroupSpec:
+    return KVCacheGroupSpec(
+        ["layer"],
+        FullAttentionSpec(
+            block_size=BLOCK_SIZE,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+        ),
+    )
+
+
+def _mamba_group(mamba_cache_mode: str) -> KVCacheGroupSpec:
+    # Name carries the mode so several groups can coexist in one config.
+    return KVCacheGroupSpec(
+        [f"mamba_{mamba_cache_mode}"],
+        MambaSpec(
+            block_size=BLOCK_SIZE,
+            shapes=((1,),),
+            dtypes=(torch.float32,),
+            mamba_cache_mode=mamba_cache_mode,
+            num_speculative_blocks=NUM_SPEC_STEPS,
+        ),
+    )
+
+
+def _make_runner(
+    kv_cache_groups: list[KVCacheGroupSpec],
+    num_lookahead_tokens: int,
+    num_spec_steps: int = NUM_SPEC_STEPS,
+) -> SimpleNamespace:
+    """Stub model runner exposing only what the warmup entry points read."""
+    return SimpleNamespace(
+        num_speculative_steps=num_spec_steps,
+        decode_query_len=num_spec_steps + 1,
+        is_pooling_model=False,
+        is_encoder_decoder=False,
+        is_last_pp_rank=True,
+        max_num_reqs=4,
+        max_model_len=MAX_MODEL_LEN,
+        model_config=SimpleNamespace(get_vocab_size=lambda: 64),
+        model_state=SimpleNamespace(max_encoder_len=0),
+        scheduler_config=SimpleNamespace(max_num_seqs=4, max_num_batched_tokens=2048),
+        kv_cache_config=SimpleNamespace(
+            kv_cache_groups=kv_cache_groups, num_blocks=1024
+        ),
+        vllm_config=SimpleNamespace(num_lookahead_tokens=num_lookahead_tokens),
+        kv_block_zeroer=None,
+        kv_connector=SimpleNamespace(set_disabled=lambda disabled: None),
+    )
+
+
+class _StepRecorder:
+    """Rebuilds each request's per-group block holdings from the warmup steps."""
+
+    def __init__(self) -> None:
+        # (blocks held per group, num_computed_tokens, num_scheduled_tokens)
+        self.steps: list[tuple[list[int], int, int]] = []
+        self._held: dict[str, list[int]] = {}
+
+    def execute_model(self, scheduler_output) -> None:
+        for new_req in scheduler_output.scheduled_new_reqs:
+            self._held[new_req.req_id] = [len(ids) for ids in new_req.block_ids]
+            self._record(new_req.req_id, new_req.num_computed_tokens, scheduler_output)
+        cached = scheduler_output.scheduled_cached_reqs
+        for i, req_id in enumerate(cached.req_ids):
+            new_block_ids = cached.new_block_ids[i]
+            if new_block_ids is not None:
+                self._held[req_id] = [
+                    held + len(ids)
+                    for held, ids in zip(self._held[req_id], new_block_ids)
+                ]
+            self._record(req_id, cached.num_computed_tokens[i], scheduler_output)
+
+    def _record(self, req_id: str, num_computed: int, scheduler_output) -> None:
+        self.steps.append(
+            (
+                list(self._held[req_id]),
+                num_computed,
+                scheduler_output.num_scheduled_tokens[req_id],
+            )
+        )
+
+    def sample_tokens(self, grammar_output=None) -> None:
+        return None
+
+
+def _assert_covers_lookahead(
+    steps: list[tuple[list[int], int, int]], num_lookahead_tokens: int
+) -> None:
+    assert steps, "warmup ran no steps"
+    for num_blocks, num_computed, num_scheduled in steps:
+        num_tokens = min(
+            num_computed + num_scheduled + num_lookahead_tokens, MAX_MODEL_LEN
+        )
+        assert num_blocks[0] >= cdiv(num_tokens, BLOCK_SIZE), (
+            f"{num_blocks[0]} blocks for {num_computed}+{num_scheduled} tokens "
+            f"and {num_lookahead_tokens} lookahead tokens"
+        )
+
+
+# 0 covers eagle / MTP / draft models, 1 covers DFlash's extra in-fill query.
+@pytest.mark.parametrize("extra_lookahead", [0, 1])
+@pytest.mark.parametrize("num_spec_steps", [2, 3, 5, 7])
+def test_warmup_kernels_reserves_lookahead_blocks(num_spec_steps, extra_lookahead):
+    num_lookahead_tokens = num_spec_steps + extra_lookahead
+    recorder = _StepRecorder()
+
+    warmup_kernels(
+        _make_runner([_attention_group()], num_lookahead_tokens, num_spec_steps),
+        recorder.execute_model,
+        recorder.sample_tokens,
+    )
+
+    _assert_covers_lookahead(recorder.steps, num_lookahead_tokens)
+
+
+def test_mixed_warmup_reserves_lookahead_blocks():
+    num_lookahead_tokens = NUM_SPEC_STEPS + 1
+    recorder = _StepRecorder()
+
+    assert run_mixed_prefill_decode_warmup(
+        _make_runner([_attention_group()], num_lookahead_tokens),
+        worker_execute_model=recorder.execute_model,
+        worker_sample_tokens=recorder.sample_tokens,
+        num_tokens=128,
+    )
+
+    _assert_covers_lookahead(recorder.steps, num_lookahead_tokens)
+
+
+@pytest.mark.parametrize("mamba_cache_mode", ["none", "all", "align"])
+def test_warmup_reserves_mamba_speculative_blocks(mamba_cache_mode):
+    """Mamba groups hold the running-state block plus the speculative tail.
+
+    `MambaManager` reserves `num_speculative_blocks` blocks past the token
+    range in every cache mode, and the mamba kernels read all
+    `1 + num_speculative_blocks` of those block-table columns (see
+    `mamba_get_block_table_tensor`).
+    """
+    recorder = _StepRecorder()
+
+    warmup_kernels(
+        _make_runner(
+            [_attention_group(), _mamba_group(mamba_cache_mode)], NUM_SPEC_STEPS
+        ),
+        recorder.execute_model,
+        recorder.sample_tokens,
+    )
+
+    assert recorder.steps, "warmup ran no steps"
+    for num_blocks, num_computed, num_scheduled in recorder.steps:
+        # `MambaManager` drops the lookahead tokens in align mode to keep the
+        # allocation block-aligned, and keeps them otherwise. Pin the token
+        # range and the speculative tail separately, so an implementation that
+        # returned a flat `1 + num_speculative_blocks` would fail.
+        if mamba_cache_mode == "align":
+            # Align mode sizes from the uncapped main-model range.
+            lookahead, num_tokens = 0, num_computed + num_scheduled
+        else:
+            lookahead = NUM_SPEC_STEPS
+            num_tokens = min(num_computed + num_scheduled + lookahead, MAX_MODEL_LEN)
+        assert num_blocks[1] == cdiv(num_tokens, BLOCK_SIZE) + NUM_SPEC_STEPS, (
+            f"{mamba_cache_mode}: {num_blocks[1]} mamba blocks for "
+            f"{num_computed}+{num_scheduled} tokens and {lookahead} lookahead"
+        )
+
+
+def _hybrid_kv_cache_config(num_blocks: int) -> KVCacheConfig:
+    """Full attention plus one Mamba group per cache mode, so a single manager
+    exercises every branch `_reserved_block_count` has.
+
+    "none" and "all" reach the same branch of both `_reserved_block_count` and
+    `MambaManager`, which tests only for "align". They are still both listed:
+    the mode is a spec-level input, and having the real manager confirm the
+    prediction for each is what keeps a future divergence between them from
+    landing unnoticed.
+    """
+    return KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            _attention_group(),
+            _mamba_group("none"),
+            _mamba_group("all"),
+            _mamba_group("align"),
+        ],
+    )
+
+
+def test_reserved_block_count_matches_real_kv_cache_manager():
+    """`_reserved_block_count` must predict exactly what the real
+    `KVCacheManager.allocate_slots` consumes, for every group, at every step
+    of a warmup-realistic trajectory: a prefill followed by decode steps that
+    mix spec and non-spec shapes, all at the fixed `num_lookahead_tokens`
+    `_warmup_block_counter` binds once per model runner.
+
+    The existing tests above pin this arithmetic against a hand-built
+    `_StepRecorder` fake, which only proves the fake and the production
+    function agree with each other. Driving `allocate_slots` itself is the
+    only way to catch a real divergence from the allocator warmup has to
+    match.
+
+    Since `num_computed_tokens` only grows and `num_lookahead_tokens` is held
+    fixed across the trajectory, the real manager's held-block count is
+    non-decreasing in lockstep with the prediction, so equality (not just
+    the reservation lower bound) holds at every step -- exactly the shape of
+    trajectory `warmup_kernels` itself drives the allocator through.
+    """
+    num_lookahead_tokens = NUM_SPEC_STEPS + 1
+    decode_query_len = NUM_SPEC_STEPS + 1
+
+    kv_cache_config = _hybrid_kv_cache_config(num_blocks=256)
+    specs = [g.kv_cache_spec for g in kv_cache_config.kv_cache_groups]
+    manager = make_kv_cache_manager(
+        kv_cache_config,
+        max_model_len=MAX_MODEL_LEN,
+        hash_block_size=BLOCK_SIZE,
+        enable_caching=False,
+    )
+    (request,) = create_requests(
+        num_requests=1, num_tokens=decode_query_len + 1, block_size=BLOCK_SIZE
+    )
+
+    def _step(num_new_tokens: int) -> None:
+        computed_blocks, num_new_computed, _ = manager.get_computed_blocks(request)
+        blocks = manager.allocate_slots(
+            request,
+            num_new_tokens,
+            num_new_computed,
+            computed_blocks,
+            num_lookahead_tokens=num_lookahead_tokens,
+        )
+        assert blocks is not None, "block pool exhausted"
+        held = manager.get_block_ids(request.request_id)
+        num_tokens = request.num_computed_tokens + num_new_tokens
+        for spec, group_held in zip(specs, held):
+            expected = _reserved_block_count(
+                num_tokens,
+                spec,
+                num_lookahead_tokens=num_lookahead_tokens,
+                max_model_len=MAX_MODEL_LEN,
+                max_encoder_len=0,
+            )
+            assert len(group_held) == expected, (
+                f"{type(spec).__name__} "
+                f"mode={getattr(spec, 'mamba_cache_mode', None)}: real manager "
+                f"holds {len(group_held)} blocks for {num_tokens} tokens, "
+                f"_reserved_block_count predicts {expected}"
+            )
+        request.num_computed_tokens = num_tokens
+
+    # Prefill, a spec decode step, a no-draft decode step, and another spec
+    # decode step: the same shapes `warmup_kernels` drives its decode steps
+    # through (see `decode_steps` in `warmup.py`).
+    _step(decode_query_len + 1)
+    _step(decode_query_len)
+    _step(1)
+    _step(decode_query_len)
+
+    manager.free(request)
+
+
+@pytest.mark.parametrize(
+    ("method", "expected"),
+    [
+        ("eagle", NUM_SPEC_STEPS),
+        ("eagle3", NUM_SPEC_STEPS),
+        ("mtp", NUM_SPEC_STEPS),
+        ("dspark", NUM_SPEC_STEPS),
+        ("draft_model", NUM_SPEC_STEPS),
+        # DFlash's in-fill decoding adds a query for the last sampled token.
+        ("dflash", NUM_SPEC_STEPS + 1),
+        ("ngram", 0),
+        ("ngram_gpu", 0),
+        ("medusa", 0),
+        ("mlp_speculator", 0),
+        ("suffix", 0),
+        ("extract_hidden_states", 0),
+    ],
+)
+def test_num_lookahead_tokens_per_method(method: str, expected: int):
+    """`VllmConfig.num_lookahead_tokens` is the single source of the reservation.
+
+    Both the scheduler and the warmup read it, so a wrong answer here silently
+    changes how many blocks every request holds. Exercises the real property
+    and the real `SpeculativeConfig` predicates; the config is built without
+    `__post_init__` because the speculative methods otherwise require a draft
+    model to be resolvable.
+    """
+
+    class _Config:
+        num_speculative_tokens = VllmConfig.num_speculative_tokens
+        num_lookahead_tokens = VllmConfig.num_lookahead_tokens
+
+    speculative_config = object.__new__(SpeculativeConfig)
+    object.__setattr__(speculative_config, "method", method)
+    object.__setattr__(speculative_config, "num_speculative_tokens", NUM_SPEC_STEPS)
+
+    config = _Config()
+    config.speculative_config = speculative_config
+    config.diffusion_config = None
+
+    assert config.num_lookahead_tokens == expected
+
+
+def test_num_lookahead_tokens_without_speculation():
+    class _Config:
+        num_speculative_tokens = VllmConfig.num_speculative_tokens
+        num_lookahead_tokens = VllmConfig.num_lookahead_tokens
+
+    config = _Config()
+    config.speculative_config = None
+    config.diffusion_config = None
+
+    assert config.num_lookahead_tokens == 0

--- a/tests/v1/worker/test_uniform_decode_token_count.py
+++ b/tests/v1/worker/test_uniform_decode_token_count.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""`get_uniform_decode_token_count` gates FULL-graph replay: rejecting a
+uniform-shaped batch that is actually still prefilling is a correctness
+requirement, but rejecting a genuinely uniform decode batch is a silent
+performance regression (falls back to PIECEWISE) rather than a crash. Both
+directions are pinned here as a pure predicate test, with no model runner.
+"""
+
+import numpy as np
+
+from vllm.v1.worker.utils import get_uniform_decode_token_count
+
+
+def test_uniform_decode_batch_is_classified_as_uniform():
+    # Every request has finished its prefill, so the shared query length is
+    # a real decode step and must not fall back to PIECEWISE.
+    num_reqs = 4
+    query_len = 8
+    num_computed_tokens = np.array([16, 32, 64, 128], dtype=np.int32)
+    prefill_lens = np.array([16, 32, 64, 128], dtype=np.int32)
+
+    assert (
+        get_uniform_decode_token_count(
+            num_reqs,
+            num_reqs * query_len,
+            query_len,
+            num_computed_tokens,
+            prefill_lens,
+        )
+        == query_len
+    )
+
+
+def test_prompt_chunk_shaped_like_decode_is_not_uniform():
+    # A K+1-token prompt chunk has the exact shape of a spec-decode step
+    # (uniform query length, K+1 tokens per request) but is not a decode.
+    # See https://github.com/vllm-project/vllm/issues/49918.
+    num_reqs = 2
+    query_len = 8  # K + 1 with K == 7 speculative tokens.
+    num_computed_tokens = np.array([0, 0], dtype=np.int32)
+    prefill_lens = np.array([40, 40], dtype=np.int32)
+
+    assert (
+        get_uniform_decode_token_count(
+            num_reqs,
+            num_reqs * query_len,
+            query_len,
+            num_computed_tokens,
+            prefill_lens,
+        )
+        is None
+    )
+
+
+def test_one_still_prefilling_request_rejects_the_whole_batch():
+    # Uniform query length, but one request out of several has not reached
+    # its prefill length yet -- the whole batch must fall back, not just the
+    # prefilling request.
+    num_reqs = 3
+    query_len = 4
+    num_computed_tokens = np.array([16, 16, 12], dtype=np.int32)
+    prefill_lens = np.array([16, 16, 20], dtype=np.int32)
+
+    assert (
+        get_uniform_decode_token_count(
+            num_reqs,
+            num_reqs * query_len,
+            query_len,
+            num_computed_tokens,
+            prefill_lens,
+        )
+        is None
+    )
+
+
+def test_non_uniform_query_length_is_not_uniform_regardless_of_prefill_state():
+    # Shape check runs first: a non-uniform batch is rejected even though
+    # every request has finished prefilling.
+    num_reqs = 2
+    num_computed_tokens = np.array([16, 16], dtype=np.int32)
+    prefill_lens = np.array([16, 16], dtype=np.int32)
+
+    assert (
+        get_uniform_decode_token_count(
+            num_reqs,
+            12,  # Not max_query_len * num_reqs for any shared query length.
+            8,
+            num_computed_tokens,
+            prefill_lens,
+        )
+        is None
+    )

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -575,6 +575,33 @@ class VllmConfig:
         return 0
 
     @property
+    def num_lookahead_tokens(self) -> int:
+        """KV slots to reserve past the tokens the target model is scheduled for.
+
+        The drafter writes KV for positions beyond the target model's query
+        range, so every component that reserves blocks must add this margin:
+        the scheduler through `allocate_slots`, and the worker warmup, which
+        builds its own `SchedulerOutput`s. Consumers must read this property
+        rather than re-deriving their own per-method lookahead, so the
+        scheduler and warmup cannot drift apart.
+        """
+        speculative_config = self.speculative_config
+        if speculative_config is None:
+            return 0
+        if speculative_config.use_dflash():
+            # DFlash requires an extra lookahead slot since it uses in-fill-style
+            # decoding instead of standard next-token sampling, so it has a query
+            # for the last sampled token plus queries for each draft token.
+            return self.num_speculative_tokens + 1
+        if speculative_config.use_eagle() or speculative_config.uses_draft_model():
+            # DSpark (covered by use_eagle) drafts a block of num_speculative_tokens
+            # query tokens in which the anchor itself is the first prediction
+            # position (no separate bonus query), so it needs exactly
+            # num_speculative_tokens lookahead slots.
+            return self.num_speculative_tokens
+        return 0
+
+    @property
     def use_v2_model_runner(self) -> bool:
         use_v2_model_runner = envs.VLLM_USE_V2_MODEL_RUNNER
         if use_v2_model_runner is not None:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
@@ -13,6 +13,8 @@ from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
     KVCacheBlock,
+    partial_hash_hits_enabled,
+    truncate_downward_closed_groups,
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     SingleTypeKVCacheManager,
@@ -377,14 +379,18 @@ class MooncakeStoreCoordinator:
         # Truncate full-attention hit_blocks to final converged length;
         # other specs already trim themselves inside their hit logic. cdiv keeps
         # the partial tail block when hit_length is not block-aligned.
-        spec0, group_ids0, _ = self.attention_groups[0]
-        if isinstance(spec0, FullAttentionSpec):
-            num_blocks = cdiv(hit_length, spec0.block_size)
-            for gid in group_ids0:
-                full_blks = hit_blocks_by_group[gid]
-                assert full_blks is not None
-                del full_blks[num_blocks:]
-                hit_length_by_group[gid] = hit_length
+        # Every full-attention group, not just the first: a DFlash drafter
+        # booking its sliding-window layers as full attention keeps the
+        # sliding-window block size, so a model can carry two full-attention
+        # groups at different block sizes. Mirrors the core coordinator, which
+        # must not disagree with this one.
+        truncate_downward_closed_groups(
+            ((spec, group_ids) for spec, group_ids, _ in self.attention_groups),
+            hit_length,
+            hit_blocks_by_group,
+            hit_length_by_group,
+            lambda gid: self.kv_cache_groups[gid].kv_cache_spec.block_size,
+        )
 
         return (
             tuple(blks if blks is not None else [] for blks in hit_blocks_by_group),
@@ -398,16 +404,3 @@ def _unwrap_spec(spec: KVCacheSpec) -> KVCacheSpec:
     return spec
 
 
-def partial_hash_hits_enabled(
-    kv_cache_groups: list[KVCacheGroupSpec], hash_block_size: int
-) -> bool:
-    """Mirror of core's ``HybridKVCacheCoordinator.enable_partial_hash_hits``
-    (its dcp == 1 clause holds: the connector rejects hybrid + DCP/PCP > 1).
-    Single copy on purpose — scheduler and coordinator must not disagree.
-    """
-    return any(
-        isinstance(spec := _unwrap_spec(g.kv_cache_spec), MambaSpec)
-        and spec.mamba_cache_mode == "align"
-        and spec.block_size > hash_block_size
-        for g in kv_cache_groups
-    )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
@@ -11,9 +11,6 @@ from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorMetadata,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.coordinator import (  # noqa: E501
-    partial_hash_hits_enabled,
-)
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (  # noqa: E501
     LoadSpec,
     MooncakeStoreConnectorMetadata,
@@ -25,7 +22,10 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.worker import (
 )
 from vllm.logger import init_logger
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
-from vllm.v1.core.kv_cache_utils import resolve_kv_cache_block_sizes
+from vllm.v1.core.kv_cache_utils import (
+    partial_hash_hits_enabled,
+    resolve_kv_cache_block_sizes,
+)
 from vllm.v1.core.sched.output import NewRequestData, SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.request import Request

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -196,6 +196,7 @@ if TYPE_CHECKING:
     ] = "relax"
     VLLM_USE_FUSED_MOE_GROUPED_TOPK: bool = True
     VLLM_MOE_SKIP_PADDING: bool = True
+    VLLM_KIMI_K3_AUX_ATTN_RES_STREAM: bool = False
     VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER: bool = True
     VLLM_USE_FLASHINFER_MOE_INT4: bool = False
     VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR: str | None = None
@@ -1532,6 +1533,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # ids to -1 so the dispatch and experts drop them. Requires a MoE kernel that
     # treats topk_id == -1 as a skip sentinel
     "VLLM_MOE_SKIP_PADDING": lambda: bool(int(os.getenv("VLLM_MOE_SKIP_PADDING", "1"))),
+    "VLLM_KIMI_K3_AUX_ATTN_RES_STREAM": lambda: bool(
+        int(os.getenv("VLLM_KIMI_K3_AUX_ATTN_RES_STREAM", "0"))
+    ),
     # Allow use of FlashInfer FP8 block-scale GEMM for linear layers.
     # This uses TensorRT-LLM kernels and requires SM90+ (Hopper).
     "VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER": lambda: bool(

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -456,6 +456,11 @@ class Attention(nn.Module, AttentionLayerBase):
         # Gemma4: clamp mm_prefix bidirectional ranges by the sliding window
         # (read by the Triton backend impl). Default False for all other models.
         self.mm_prefix_clamp_sliding_window = mm_prefix_clamp_sliding_window
+        # Book this layer's KV as full attention while still masking to the
+        # window at compute time -- the same trade `unify_hybrid_kv_cache_specs`
+        # makes, but per layer instead of for the whole model. Opt-in; set by
+        # the model after construction (see `qwen3_dflash`).
+        self.book_sliding_window_as_full_attention = False
 
         # use a placeholder kv cache tensor during init, which will be replaced
         # by bind_kv_cache
@@ -655,7 +660,25 @@ class Attention(nn.Module, AttentionLayerBase):
             sw_block_size = _largest_kernel_block_within(
                 self.attn_backend, sw_per_token, shared_page, block_size
             )
-            return SlidingWindowSpec(
+            # Booking as full attention routes the layer to
+            # FullAttentionManager, which supports fine-grained (partial)
+            # prefix-cache hits where SlidingWindowManager asserts against
+            # them. Only the block bookkeeping changes: `sliding_window` is
+            # carried either way and the metadata builder reads the window off
+            # the spec, so the kernel still masks to it. The block size stays
+            # the sliding-window one so page unification can scale it by an
+            # integer ratio.
+            #
+            # One constructor on purpose. The fields must stay identical
+            # between the two, and the window in particular is load-bearing --
+            # dropping it would not merely fail to enforce the window, it would
+            # override the impl's correct one with "no window at all".
+            spec_cls = (
+                FullAttentionSpec
+                if self.book_sliding_window_as_full_attention
+                else SlidingWindowSpec
+            )
+            return spec_cls(
                 block_size=sw_block_size,
                 num_kv_heads=self.num_kv_heads,
                 head_size=self.head_size,

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -408,6 +408,45 @@ class DFlashQwen3Model(nn.Module):
                 for layer_idx in range(self.config.num_hidden_layers)
             ]
         )
+        # An all-sliding drafter makes the model's prefix-cache hash granularity
+        # unsatisfiable: it has to divide the target's block size and be a whole
+        # multiple of the drafter's at the same time, because
+        # SlidingWindowManager refuses partial hits. Booking the drafter's KV as
+        # full attention routes it to FullAttentionManager instead, which does
+        # support them. The window stays on the spec and is still applied by the
+        # kernel; only the block accounting changes.
+        #
+        # Derived rather than flagged, on two conditions. A drafter that *mixes*
+        # sliding and full attention is already handled by
+        # `_dflash_needs_multi_kv_group`; this is the case that gate excludes.
+        # And with prefix caching off there is nothing to gain, while the
+        # conversion still costs KV capacity -- a full-attention group is
+        # budgeted at max_model_len rather than at the window.
+        swa_layers = [
+            layer.self_attn.attn
+            for layer in self.layers
+            if layer.self_attn.attn.sliding_window is not None
+        ]
+        if (
+            swa_layers
+            and len(swa_layers) == len(self.layers)
+            # Read this off the same config the layers above were built with:
+            # `Attention.__init__` can itself turn prefix caching off on the
+            # config it is handed, and converting a drafter whose engine will
+            # not cache costs KV capacity for nothing.
+            and current_vllm_config.cache_config.enable_prefix_caching
+        ):
+            for attn in swa_layers:
+                attn.book_sliding_window_as_full_attention = True
+            logger.info(
+                "DFlash drafter: booking %d sliding-window layers as full "
+                "attention for KV cache accounting, so the drafter can take "
+                "part in prefix caching (window still enforced at compute "
+                "time). This budgets the drafter's KV at max_model_len rather "
+                "than at its %d-token window.",
+                len(swa_layers),
+                swa_layers[0].sliding_window,
+            )
         if self.use_aux_hidden_state:
             self.fc = ReplicatedLinear(
                 input_size=_get_dflash_fc_input_size(

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -1050,6 +1050,85 @@ class KimiLinearModel(nn.Module, EagleModelMixin):
             }
         )
 
+    def _set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
+        super()._set_aux_hidden_state_layers(layers)
+        if self.use_attn_res:
+            # Emitted once, at configuration time. Which layers are tapped and
+            # which convention is in force are the two things you need to
+            # confirm from a running process, and neither is recoverable from
+            # the served output.
+            logger.info(
+                "Kimi-K3 aux hidden capture: layers=%s mode=%s "
+                "(VLLM_KIMI_K3_AUX_ATTN_RES_STREAM=%d)",
+                layers,
+                "attn_res_stream" if self._aux_attn_res_stream else "prefix_only",
+                int(self._aux_attn_res_stream),
+            )
+
+    @property
+    def _aux_attn_res_stream(self) -> bool:
+        return envs.VLLM_KIMI_K3_AUX_ATTN_RES_STREAM
+
+    def _capture_aux_hidden_stream(
+        self,
+        layer_idx: int,
+        prefix_sum: torch.Tensor,
+        pending_mlp_out: torch.Tensor | None,
+        block_residual: torch.Tensor,
+    ) -> torch.Tensor:
+        """Auxiliary feature tapped after ``layer_idx`` under AttnRes.
+
+        The wire between layers only carries the current block's running prefix;
+        the committed blocks live in the bank. The value the next consumer
+        actually reads is the pre-norm AttnRes mixture over
+        ``bank[:num_blocks] + prefix``, which is what the DFlash drafters were
+        trained against. ``attn_res`` with no delta, no block write and no
+        output norm computes exactly that and leaves both the prefix and the
+        bank untouched.
+
+        Folding the pending MLP output into the prefix rather than passing it as
+        ``delta`` is deliberate: the kernel writes an applied delta back into
+        the prefix in place, which would double-add it into the live residual
+        stream.
+        """
+        prefix = prefix_sum if pending_mlp_out is None else prefix_sum + pending_mlp_out
+        # `use_attn_res` is what constructs the norm and projection weights this
+        # reads; without it there is no mixture to compute and the attribute
+        # lookups below would raise.
+        if not (self._aux_attn_res_stream and self.use_attn_res):
+            return prefix
+
+        if layer_idx + 1 < self.end_layer:
+            consumer = self.layers[layer_idx + 1]
+            score_norm = consumer.self_attention_res_norm
+            score_proj = consumer.self_attention_res_proj
+            num_blocks = consumer.prev_valid_blocks
+        elif get_pp_group().is_last_rank:
+            # Nothing downstream but the model's own output-side aggregation.
+            score_norm = self.output_attn_res_norm
+            score_proj = self.output_attn_res_proj
+            num_blocks = self.num_attn_res_blocks
+        else:
+            # Last layer of a non-final pipeline stage: the consumer lives on
+            # the next rank and the output-side aggregation only exists on the
+            # last one, so there is nothing here to mix against. Falling back
+            # to the running prefix keeps the tap defined rather than reaching
+            # for weights this rank does not construct.
+            return prefix
+
+        return attn_res(
+            prefix,
+            None,
+            block_residual,
+            score_norm.weight,
+            score_proj.weight.squeeze(0),
+            None,
+            num_blocks=num_blocks,
+            block_write_idx=-1,
+            eps=score_norm.variance_epsilon,
+            output_norm_eps=0.0,
+        )
+
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
 
@@ -1116,7 +1195,10 @@ class KimiLinearModel(nn.Module, EagleModelMixin):
             if (layer_idx + 1) in self.aux_hidden_state_layers:
                 if self.use_attn_res:
                     assert prefix_sum is not None
-                    aux_hidden_state = prefix_sum + hidden_states
+                    assert residual is not None
+                    aux_hidden_state = self._capture_aux_hidden_stream(
+                        layer_idx, prefix_sum, hidden_states, residual
+                    )
                 else:
                     assert residual is not None
                     aux_hidden_state = hidden_states + residual

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -873,11 +873,12 @@ class Platform:
 
         # Get kernel block alignment from the backend's supported sizes
         with set_current_vllm_config(vllm_config):
+            backend_min_block_size = min(
+                s.base if isinstance(s, MultipleOf) else s
+                for s in backend_cls.get_supported_kernel_block_sizes()
+            )
             kernel_block_alignment_size = max(
-                min(
-                    s.base if isinstance(s, MultipleOf) else s
-                    for s in backend_cls.get_supported_kernel_block_sizes()
-                ),
+                backend_min_block_size,
                 cache_config.block_size,
             )
             if model_config.use_mla:
@@ -886,6 +887,36 @@ class Platform:
                 # For hybrid MLA/Mamba models, make the manager block size a
                 # multiple of 128 so split kernel blocks keep that invariant.
                 kernel_block_alignment_size = max(kernel_block_alignment_size, 128)
+
+        # The `max`es above silently discard a user `--block-size` below the
+        # alignment finally chosen, so such a value is indistinguishable from
+        # passing nothing -- including from the resulting logs, since the line
+        # below reports the derived attention block size rather than the input
+        # that produced it. On a hybrid model the derived size also sets the
+        # prefix-cache match granularity, so two lanes that differ only in an
+        # ignored `--block-size` can end up with different cache behaviour for
+        # reasons nothing in the output explains. Say so once.
+        #
+        # Test against the final alignment rather than the backend minimum: an
+        # MLA model floors it at 128 whatever the backend asks for, and that
+        # floor is the case most likely to surprise. Strictly below, because a
+        # value equal to the alignment is the one the `max` returns and is
+        # therefore honoured.
+        if (
+            cache_config.user_specified_block_size
+            and cache_config.block_size < kernel_block_alignment_size
+        ):
+            logger.warning_once(
+                "--block-size %d has no effect: block size alignment uses %d "
+                "instead (%s requires at least %d%s). Pass a value above %d to "
+                "change the derived attention block size.",
+                cache_config.block_size,
+                kernel_block_alignment_size,
+                backend_cls.__name__,
+                backend_min_block_size,
+                ", and MLA requires a multiple of 128" if model_config.use_mla else "",
+                kernel_block_alignment_size,
+            )
 
         if cache_config.mamba_cache_mode == "all":
             # With prefix caching, align to mamba chunk size for kernel perf

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -646,6 +646,19 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         self.full_attention_group_id: int | None = (
             first.group_ids[0] if isinstance(first.spec, FullAttentionSpec) else None
         )
+        # Every full-attention group, not just the first. A model can carry
+        # more than one at different block sizes -- a DFlash drafter booking
+        # its sliding-window layers as full attention keeps the smaller
+        # sliding-window block size -- and a finer-grained group reports a
+        # legitimately deeper per-group hit whenever the reconciled hit is not
+        # a multiple of the coarser group's block size. Taking the first alone
+        # as the dense reference reads that as eviction.
+        self.full_attention_group_ids: list[int] = [
+            group_id
+            for group in self.attention_groups
+            if isinstance(group.spec, FullAttentionSpec)
+            for group_id in group.group_ids
+        ]
 
         # Propagate the eagle bit to each manager (default to ``use_eagle=False``).
         for group in self.attention_groups:

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -5,12 +5,14 @@ from collections.abc import Sequence
 from typing import NamedTuple
 
 from vllm import envs
-from vllm.utils.math_utils import cdiv
+from vllm.logger import init_logger
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
     KVCacheBlock,
+    partial_hash_hits_enabled,
+    truncate_downward_closed_groups,
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     CrossAttentionManager,
@@ -25,6 +27,8 @@ from vllm.v1.kv_cache_interface import (
     SlidingWindowSpec,
 )
 from vllm.v1.request import Request
+
+logger = init_logger(__name__)
 
 
 def _validate_prefix_cache_retention_interval(
@@ -579,12 +583,12 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     f"{type(g.kv_cache_spec).__name__}."
                 )
         # Partial hash hits are limited to full-attention + mamba ("align")
-        # without context parallelism.
-        self.enable_partial_hash_hits = dcp_world_size == 1 and any(
-            isinstance(g.kv_cache_spec, MambaSpec)
-            and g.kv_cache_spec.mamba_cache_mode == "align"
-            and g.kv_cache_spec.block_size > hash_block_size
-            for g in kv_cache_config.kv_cache_groups
+        # without context parallelism, and only when no other group forces
+        # block-aligned lookup.
+        self.enable_partial_hash_hits = partial_hash_hits_enabled(
+            kv_cache_config.kv_cache_groups,
+            hash_block_size,
+            dcp_world_size=dcp_world_size,
         )
         self.verify_and_split_kv_cache_groups()
 
@@ -795,17 +799,53 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             if is_simple_hybrid:
                 break
 
-        # Truncate full attention blocks to final hit_length (if present)
-        first_group = self.attention_groups[0]
-        if isinstance(first_group.spec, FullAttentionSpec):
-            group_block_size = self.single_type_managers[
-                first_group.group_ids[0]
-            ].block_size
-            num_blocks = cdiv(hit_length, group_block_size)
-            for group_id in first_group.group_ids:
-                if (blks := hit_blocks_by_group[group_id]) is not None:
-                    del blks[num_blocks:]
-                    hit_length_by_group[group_id] = hit_length
+        if len(self.full_attention_group_ids) > 1:
+            # With more than one full-attention group -- a DFlash drafter
+            # booking its sliding-window layers as full attention keeps its
+            # own, smaller block size alongside the target's -- the loop
+            # above records each dense group's *own* hit as it is reached,
+            # and a finer group legitimately completes its next block sooner
+            # than a coarser one for identical underlying progress. That
+            # disagreement is block-size granularity, not a sparse-retention
+            # group falling behind, so the dense reference is where every
+            # dense group agrees (the min) rather than the deepest any one of
+            # them individually reached. Must run before the truncation below,
+            # which overwrites `hit_length_by_group` for these groups.
+            #
+            # Only the dense groups' disagreement is discounted. A non-dense
+            # group that matched past the reconciled hit is the sparse-lag
+            # signal this value exists to carry, so it still counts -- reducing
+            # to the dense minimum alone would switch that detection off for
+            # every model that has two dense groups.
+            dense_group_ids = set(self.full_attention_group_ids)
+            longest_hit_length = max(
+                min(hit_length_by_group[gid] for gid in dense_group_ids),
+                max(
+                    (
+                        hit_length_by_group[gid]
+                        for gid in range(num_groups)
+                        if gid not in dense_group_ids
+                    ),
+                    default=0,
+                ),
+            )
+
+        # Truncate every full attention group to the final hit_length. Each is
+        # looked up once (they are downward-closed) against a candidate length
+        # that later iterations may have reduced, so the trim is what makes the
+        # returned blocks agree with the reconciled hit. There can be more than
+        # one such group with different block sizes -- a DFlash drafter booking
+        # its sliding-window layers as full attention keeps the sliding-window
+        # block size -- so each trims at its own, and a group left untrimmed
+        # hands `add_local_computed_blocks` more blocks than the hit covers,
+        # which lands as a copy-on-write assertion on the first partial hit.
+        truncate_downward_closed_groups(
+            ((g.spec, g.group_ids) for g in self.attention_groups),
+            hit_length,
+            hit_blocks_by_group,
+            hit_length_by_group,
+            lambda gid: self.single_type_managers[gid].block_size,
+        )
 
         # Uncached shared prefix detection: if any attn. group cached a longer
         # prefix than the reconciled hit, it is an uncached common prefix across

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -14,7 +14,11 @@ from vllm.v1.core.kv_cache_coordinator import (
     get_kv_cache_coordinator,
 )
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
-from vllm.v1.core.kv_cache_utils import KVCacheBlock, KVCacheBlockCopy
+from vllm.v1.core.kv_cache_utils import (
+    KVCacheBlock,
+    KVCacheBlockCopy,
+    truncate_downward_closed_groups,
+)
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     CrossAttentionSpec,
@@ -326,18 +330,49 @@ class KVCacheManager:
         if not self.prefix_cache_lookup_enabled(request):
             return self.empty_kv_cache_blocks, 0, 0, False
 
-        fa_group_id = coordinator.full_attention_group_id
         computed, per_group_hits = coordinator.find_longest_cache_hit_per_group(
             request.block_hashes, request.num_tokens - 1
         )
-        if any(hit > per_group_hits[fa_group_id] for hit in per_group_hits):
-            # A lagging group hit deeper than full attention means its
-            # full-attention blocks were evicted; use the reconciled boundary
-            # that every group agrees on.
+        # Two different questions, so two different reductions over the dense
+        # groups. There can be more than one -- a DFlash drafter booking its
+        # sliding-window layers as full attention adds a second at a smaller
+        # block size -- and the finer-grained one legitimately hits deeper
+        # whenever the reconciled hit is not a multiple of the coarser block
+        # size. Both reduce to the single-group behaviour when there is one.
+        dense_hits = [
+            per_group_hits[group_id]
+            for group_id in coordinator.full_attention_group_ids
+        ]
+        if any(hit > max(dense_hits) for hit in per_group_hits):
+            # Eviction test: a group deeper than *every* dense group means the
+            # dense blocks were evicted. Comparing against one arbitrary dense
+            # group instead would read a finer-grained sibling as eviction and
+            # give up the fast path on most hits.
             return *self.get_computed_blocks(request), False
 
-        num_local = per_group_hits[fa_group_id]
-        blocks = self.create_kv_cache_blocks(computed)
+        # Reported length: the blocks below come from the per-group lookup at
+        # each group's own hit, not from a reconciled one, so this must be a
+        # length every dense group's list actually covers. The max would name a
+        # boundary the coarser group's blocks fall short of.
+        num_local = min(dense_hits)
+        # Reducing the reported length is not enough on its own: a dense group
+        # that hit deeper keeps a block list longer than `num_local` covers,
+        # and the pair is handed straight to `add_local_computed_blocks`. Trim
+        # for the same reason the reconciling path does, at each group's own
+        # block size.
+        hit_blocks = [list(blocks) for blocks in computed]
+        # The per-group lengths it rewrites go into a throwaway copy on
+        # purpose. `hit_diverged` below is about the raw per-group lookups --
+        # whether a group genuinely lagged -- so it must see the lengths as
+        # looked up, not as trimmed to the reconciled value.
+        truncate_downward_closed_groups(
+            ((g.spec, g.group_ids) for g in coordinator.attention_groups),
+            num_local,
+            hit_blocks,
+            list(per_group_hits),
+            lambda gid: coordinator.single_type_managers[gid].block_size,
+        )
+        blocks = self.create_kv_cache_blocks(tuple(hit_blocks))
         # Per-group lookups do not detect an uncached shared prefix (boundary 0).
         return blocks, num_local, 0, min(per_group_hits) < num_local
 

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -2349,3 +2349,98 @@ def resolve_block_hashes(
         return block_hashes
     assert block_size % hash_block_size == 0
     return BlockHashListWithBlockSize(block_hashes, hash_block_size, block_size)
+
+
+def partial_hash_hits_enabled(
+    kv_cache_groups: Sequence[KVCacheGroupSpec],
+    hash_block_size: int,
+    *,
+    dcp_world_size: int = 1,
+) -> bool:
+    """Whether fine-grained (partial) prefix-cache hits may be enabled.
+
+    Two conditions. The feature exists for mamba "align" groups whose block
+    size exceeds the hash granularity, so at least one must be present. And
+    every group must be *able* to be looked up at that granularity: a manager
+    without fine-grained lookup indexes the block-hash list in units of its own
+    block size, so including one at a finer alignment would key its lookups off
+    the wrong hashes.
+
+    The single copy on purpose. The core coordinator, the Mooncake store
+    coordinator and the scheduler all need this answer, and when they computed
+    it separately they disagreed -- the scheduler kept emitting a sub-block
+    prefill stop for a partial tail entry the coordinator would no longer
+    accept.
+
+    Args:
+        kv_cache_groups: One entry per KV cache group.
+        hash_block_size: The granularity ``Request.block_hashes`` is computed at.
+        dcp_world_size: Partial hits are unsupported under context parallelism.
+    """
+    if dcp_world_size != 1:
+        return False
+
+    specs = [
+        next(iter(g.kv_cache_spec.kv_cache_specs.values()))
+        if isinstance(g.kv_cache_spec, UniformTypeKVCacheSpecs)
+        else g.kv_cache_spec
+        for g in kv_cache_groups
+    ]
+    if not any(
+        isinstance(spec, MambaSpec)
+        and spec.mamba_cache_mode == "align"
+        and spec.block_size > hash_block_size
+        for spec in specs
+    ):
+        return False
+
+    unsupported = set()
+    for spec in specs:
+        manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
+        assert manager_cls is not None, f"No manager registered for KVCacheSpec {spec}"
+        if (
+            not manager_cls.supports_fine_grained_hash_lookup
+            and spec.block_size != hash_block_size
+        ):
+            unsupported.add(manager_cls.__name__)
+    if not unsupported:
+        return True
+    logger.warning_once(
+        "Disabling fine-grained (partial) prefix-cache hits: the prefix match "
+        "unit is %d but these block-aligned-only KV cache managers use a "
+        "larger block size: %s.",
+        hash_block_size,
+        ", ".join(sorted(unsupported)),
+    )
+    return False
+
+
+def truncate_downward_closed_groups(
+    groups: Iterable[tuple[KVCacheSpec, Sequence[int]]],
+    hit_length: int,
+    hit_blocks_by_group: list[list["KVCacheBlock"] | None],
+    hit_length_by_group: list[int],
+    block_size_of: Callable[[int], int],
+) -> None:
+    """Trim every downward-closed group's block list to ``hit_length``.
+
+    A downward-closed manager is looked up once against the initial candidate
+    length and skipped on later fixed-point passes, so a reduction afterwards
+    leaves its list too long. Untrimmed, the extra blocks reach
+    ``add_local_computed_blocks``, which extends the request's block table with
+    blocks past the reconciled boundary -- an assertion in the best case and
+    shared blocks the request does not own in the worst.
+
+    There can be more than one such group, at different block sizes, so each
+    trims at its own. Callers pass ``block_size_of`` because the coordinator's
+    manager block size is DCP-scaled while a spec-level caller's is not.
+    """
+    for spec, group_ids in groups:
+        manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
+        if manager_cls is None or not manager_cls.is_downward_closed:
+            continue
+        for group_id in group_ids:
+            if (blocks := hit_blocks_by_group[group_id]) is None:
+                continue
+            del blocks[cdiv(hit_length, block_size_of(group_id)) :]
+            hit_length_by_group[group_id] = hit_length

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -317,9 +317,18 @@ class Scheduler(SchedulerInterface):
         # A finer prefix_match_unit is configured: a mamba partial tail entry
         # can only be registered by a step ending exactly at the prompt's last
         # hash boundary, so the split adds that stop.
+        # Ask the coordinator rather than recomputing: the sub-block stop this
+        # gates exists solely so a mamba partial-tail entry can be registered,
+        # and the coordinator may have disabled fine-grained hits for a reason
+        # this expression cannot see (a group that can only be looked up at
+        # block granularity). Computing it here as well is how the two came to
+        # disagree, leaving a stop that could no longer serve any purpose.
         self.mamba_partial_cache_hit = (
             self.need_mamba_block_aligned_split
             and self.hash_block_size < self.block_size
+            and getattr(
+                self.kv_cache_manager.coordinator, "enable_partial_hash_hits", True
+            )
         )
 
         # Counts of non-empty steps scheduled / processed. update_from_output

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -244,7 +244,7 @@ class Scheduler(SchedulerInterface):
         speculative_config = vllm_config.speculative_config
         self.use_eagle = False
         self.num_spec_tokens = vllm_config.num_speculative_tokens
-        self.num_lookahead_tokens = 0
+        self.num_lookahead_tokens = vllm_config.num_lookahead_tokens
         self.dynamic_sd_lookup: list[int] | None = None
         if speculative_config is not None:
             if speculative_config.num_speculative_tokens_per_batch_size:
@@ -253,21 +253,7 @@ class Scheduler(SchedulerInterface):
                     vllm_max_batch_size=self.scheduler_config.max_num_seqs,
                     vllm_num_speculative_tokens=self.num_spec_tokens,
                 )
-            if speculative_config.use_eagle():
-                self.use_eagle = True
-                self.num_lookahead_tokens = self.num_spec_tokens
-            if speculative_config.uses_draft_model():
-                self.num_lookahead_tokens = self.num_spec_tokens
-            if speculative_config.use_dflash():
-                # DFlash requires an extra lookahead slot since it uses in-fill-style
-                # decoding instead of standard next-token sampling, so it has a query
-                # for the last sampled token plus queries for each draft token.
-                self.num_lookahead_tokens = self.num_spec_tokens + 1
-            if speculative_config.use_dspark():
-                # DSpark drafts a block of num_spec_tokens query tokens in which the
-                # anchor itself is the first prediction position (no separate bonus
-                # query), so it needs exactly num_spec_tokens lookahead slots.
-                self.num_lookahead_tokens = self.num_spec_tokens
+            self.use_eagle = speculative_config.use_eagle()
 
         # Create the KV cache manager.
         if hash_block_size is None:

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -41,6 +41,17 @@ class SingleTypeKVCacheManager(ABC):
 
     supports_fine_grained_hash_lookup: ClassVar[bool] = False
 
+    is_downward_closed: ClassVar[bool] = False
+    """Whether a hit at length N implies a hit at every shorter length.
+
+    A downward-closed manager is looked up once against the coordinator's
+    initial candidate length and then skipped on later fixed-point passes, so
+    whatever reduced the reconciled length afterwards leaves its block list too
+    long. Callers that reconcile across groups must trim every such group at
+    the end. Declared here rather than tested with ``isinstance`` at each site,
+    because the same omission has been fixed three times in different files.
+    """
+
     def __init__(
         self,
         kv_cache_spec: KVCacheSpec,
@@ -677,6 +688,7 @@ class SingleTypeKVCacheManager(ABC):
 
 class FullAttentionManager(SingleTypeKVCacheManager):
     supports_fine_grained_hash_lookup: ClassVar[bool] = True
+    is_downward_closed: ClassVar[bool] = True
 
     @classmethod
     def find_longest_cache_hit(
@@ -911,7 +923,17 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         )
         assert dcp_world_size == 1, "DCP not support sliding window attn now."
         assert pcp_world_size == 1, "PCP not support sliding window attn now."
-        # Fine-grained partial hits are not supported for sliding window now
+        # The scan below indexes `block_hashes` in whole blocks, so a finer
+        # alignment would read the wrong entries. The coordinator keeps this
+        # unreachable by disabling partial hash hits for models containing a
+        # group that only supports block-aligned lookup.
+        # TODO: supporting them here would let a mamba-"align" + sliding-window
+        # model keep its partial hits instead of falling back. It needs a
+        # block-size view for the contiguous-run scan alongside the raw hashes
+        # (as FullAttentionManager keeps), a partial-tail cache entry to match
+        # against, a `reachable_block_mask` that accepts a sub-block alignment,
+        # and a contiguous-block requirement computed from the partial tail
+        # length rather than once from the window.
         assert alignment_tokens % kv_cache_spec.block_size == 0, (
             "SlidingWindowManager does not support fine-grained (partial) cache hits"
         )

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -440,6 +440,7 @@ class SingleTypeKVCacheManager(ABC):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        extra_block_mask: list[bool] | None = None,
     ) -> None:
         """
         Cache the blocks for the request.
@@ -452,6 +453,12 @@ class SingleTypeKVCacheManager(ABC):
                 keeps dense checkpointing; ``0`` keeps only the latest replay
                 boundary; a positive multiple of ``scheduler_block_size`` keeps
                 a tail once per that-sized segment. Only SWA acts on it.
+            extra_block_mask: Optional mask aligned with
+                ``blocks[num_cached_blocks:num_full_blocks]``, ANDed with this
+                manager's own ``reachable_block_mask``. A manager whose blocks
+                only sometimes hold the content the hash they would be keyed
+                under describes uses this to withhold the ones that do not. It
+                can only remove admissions, never add them.
         """
         num_cached_blocks = self.num_cached_block.get(request.request_id, 0)
         num_full_blocks = num_tokens // self.block_size
@@ -475,6 +482,16 @@ class SingleTypeKVCacheManager(ABC):
             retention_interval=retention_interval,
             reachable_boundaries=reachable_boundaries,
         )
+        if extra_block_mask is not None:
+            assert len(extra_block_mask) == num_full_blocks - num_cached_blocks
+            block_mask = (
+                extra_block_mask
+                if block_mask is None
+                else [
+                    reachable and admitted
+                    for reachable, admitted in zip(block_mask, extra_block_mask)
+                ]
+            )
         self.block_pool.cache_full_blocks(
             request=request,
             blocks=self.req_to_blocks[request.request_id],
@@ -793,8 +810,14 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        extra_block_mask: list[bool] | None = None,
     ) -> None:
-        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        super().cache_blocks(
+            request,
+            num_tokens,
+            retention_interval=retention_interval,
+            extra_block_mask=extra_block_mask,
+        )
         hash_block_size = self.block_pool.hash_block_size
         if self.block_size == hash_block_size:
             return
@@ -1297,6 +1320,12 @@ class MambaManager(SingleTypeKVCacheManager):
             # into a private cow_block; we record that block for connector
             # offload (see _pending_partial_tail_offloads).
             self._producer_partial_tail_reqs: dict[str, int] = {}
+            # Mapping from request ID to the token count the most recently
+            # scheduled forward leaves the recurrent state at. This is the
+            # position the state written into `last_state_block_idx + 1`
+            # describes, and it is what decides whether that block may be
+            # keyed under a block-boundary hash.
+            self._state_write_tokens: dict[str, int] = {}
 
     @classmethod
     def find_longest_cache_hit(
@@ -1570,6 +1599,11 @@ class MambaManager(SingleTypeKVCacheManager):
             # We can ignore lookahead tokens because current draft models don't have
             # mamba layers.
             num_tokens = num_tokens_main_model
+            # Where this step's forward leaves the recurrent state. It counts
+            # the unverified draft tokens the target model runs over, which is
+            # exactly what the state write covers, and is recorded before the
+            # early return below so every scheduled step is represented.
+            self._state_write_tokens[request_id] = num_tokens
             req_blocks: list[KVCacheBlock] = self.req_to_blocks[request_id]
             # NOTE(tdouble): this is an over-estimate of how many blocks we need because
             # num_tokens can include draft tokens that will later be rejected.
@@ -1677,6 +1711,7 @@ class MambaManager(SingleTypeKVCacheManager):
             self._allocated_block_reqs.discard(request_id)
             self.last_state_block_idx.pop(request_id, None)
             self._producer_partial_tail_reqs.pop(request_id, None)
+            self._state_write_tokens.pop(request_id, None)
             # A hand-off whose request died in this same scheduling pass must
             # not reach the connector: its unpin hook (free) has already run.
             self._pending_partial_tail_offloads = [
@@ -1701,7 +1736,16 @@ class MambaManager(SingleTypeKVCacheManager):
         retention_interval: int | None = None,
     ) -> None:
         num_cached_blocks_before = self.num_cached_block.get(request.request_id, 0)
-        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        super().cache_blocks(
+            request,
+            num_tokens,
+            retention_interval=retention_interval,
+            extra_block_mask=self._boundary_state_block_mask(
+                request,
+                start_block=num_cached_blocks_before,
+                end_block=num_tokens // self.block_size,
+            ),
+        )
         num_cached_blocks_after = self.num_cached_block.get(request.request_id, 0)
         if self.mamba_cache_mode == "align":
             partial_hash = self._cache_partial_tail_block(request, num_tokens)
@@ -1718,6 +1762,48 @@ class MambaManager(SingleTypeKVCacheManager):
                 if block.is_null or block.block_hash is None:
                     continue
                 self.cached_blocks_this_step.add(block.block_hash)
+
+    def _boundary_state_block_mask(
+        self,
+        request: Request,
+        start_block: int,
+        end_block: int,
+    ) -> list[bool] | None:
+        """Admit only a state block that holds the state at its own boundary.
+
+        A cached block ``j`` is keyed under the hash of the prefix ending at
+        ``(j + 1) * block_size`` and registered with that many hash tokens, so
+        a request restoring from it resumes as if exactly that many tokens had
+        been consumed. In "align" mode the recurrent state saved in block ``j``
+        is instead whatever the forward left after the tokens that step
+        scheduled, which only coincides with the boundary when the step happens
+        to end on it. Prefill chunks are clipped to end on one; decode steps are
+        not, and a step that speculates also runs over draft tokens that may be
+        rejected afterwards.
+
+        Admit the single block that this step's write lands on, and only when
+        that landing is both exactly on the boundary and entirely made of
+        committed tokens. Everything else is withheld, including blocks written
+        by an earlier step: those were offered under this same rule when they
+        were written, so a second look can only re-offer a state the rule has
+        already rejected.
+
+        Returns ``None`` in non-align mode, where the state block is not
+        snapshotted per block and dense caching is correct.
+        """
+        if self.mamba_cache_mode != "align":
+            return None
+        num_state_tokens = self._state_write_tokens.get(request.request_id)
+        # `request.num_tokens` counts committed tokens only, so a write that
+        # ran past it covers draft tokens that are not decided yet.
+        if (
+            num_state_tokens is None
+            or num_state_tokens % self.block_size != 0
+            or num_state_tokens > request.num_tokens
+        ):
+            return [False] * max(end_block - start_block, 0)
+        boundary_block = num_state_tokens // self.block_size - 1
+        return [block == boundary_block for block in range(start_block, end_block)]
 
     def new_step_starts(self) -> None:
         self.cached_blocks_this_step.clear()
@@ -1794,6 +1880,7 @@ class CrossAttentionManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        extra_block_mask: list[bool] | None = None,
     ) -> None:
         # We do not cache blocks for cross-attention to be shared between
         # requests, so this method is not relevant.

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -35,7 +35,7 @@ from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.cp_utils import prepare_dcp_local_seq_lens
 from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
 from vllm.v1.worker.gpu.model_states.interface import ModelState
-from vllm.v1.worker.utils import AttentionGroup
+from vllm.v1.worker.utils import AttentionGroup, is_uniform_query_len
 
 logger = init_logger(__name__)
 
@@ -97,10 +97,13 @@ def get_uniform_token_count(
     """
     Return the uniform token count if batch is uniform, else None.
     A batch is uniform if all requests have the same number of tokens.
+
+    This is a shape test, so it is only valid for batches whose requests are
+    known to be decoding by construction (e.g. dummy runs, or a drafter step
+    that emits a fixed number of tokens per request). Batches coming from a
+    scheduler step must go through `get_uniform_decode_token_count`.
     """
-    if (max_query_len == num_tokens // num_reqs) and (
-        num_tokens == max_query_len * num_reqs
-    ):
+    if is_uniform_query_len(num_reqs, num_tokens, max_query_len):
         return max_query_len
     return None
 

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -118,7 +118,11 @@ from vllm.v1.worker.gpu.spec_decode.utils import DraftTokensHandler
 from vllm.v1.worker.gpu.states import RequestState
 from vllm.v1.worker.gpu.structured_outputs import StructuredOutputsWorker
 from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
-from vllm.v1.worker.utils import KVBlockZeroer, copy_kv_cache_blocks_inplace
+from vllm.v1.worker.utils import (
+    KVBlockZeroer,
+    copy_kv_cache_blocks_inplace,
+    get_uniform_decode_token_count,
+)
 
 logger = init_logger(__name__)
 
@@ -1186,6 +1190,39 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             idx_mapping, num_sampled, self.req_states.num_computed_tokens.gpu
         )
 
+    def _get_uniform_token_count(
+        self,
+        scheduler_output: SchedulerOutput,
+        num_reqs: int,
+        num_tokens: int,
+        max_query_len: int,
+        dummy_run: bool,
+    ) -> int | None:
+        """Per-request token count of a uniform decode batch, or None.
+
+        Dummy batches (DP padding, memory profiling, warmup) are uniform by
+        construction and have no request state to consult, so they are
+        classified by shape alone. This mirrors `InputBatch.make_dummy`, which
+        marks every dummy request as not prefilling.
+        """
+        if dummy_run:
+            return get_uniform_token_count(num_reqs, num_tokens, max_query_len)
+        idx_mapping_np = np.fromiter(
+            map(
+                self.req_states.req_id_to_index.__getitem__,
+                scheduler_output.num_scheduled_tokens,
+            ),
+            dtype=np.intp,
+            count=num_reqs,
+        )
+        return get_uniform_decode_token_count(
+            num_reqs,
+            num_tokens,
+            max_query_len,
+            self.req_states.num_computed_prefill_tokens[idx_mapping_np],
+            self.req_states.prefill_len.np[idx_mapping_np],
+        )
+
     @torch.inference_mode()
     def execute_model(
         self,
@@ -1212,7 +1249,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         num_reqs = len(scheduler_output.num_scheduled_tokens)
         num_toks = scheduler_output.total_num_scheduled_tokens
         max_query_len = max(scheduler_output.num_scheduled_tokens.values())
-        uniform_tok_count = get_uniform_token_count(num_reqs, num_toks, max_query_len)
+        uniform_tok_count = self._get_uniform_token_count(
+            scheduler_output, num_reqs, num_toks, max_query_len, dummy_run
+        )
 
         num_active_loras = 0
         if self.lora_config:

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -11,16 +11,14 @@ from vllm.logger import init_logger
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.triton_utils import tl, triton
 from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
-from vllm.v1.worker.gpu.cudagraph_utils import (
-    BatchExecutionDescriptor,
-    get_uniform_token_count,
-)
+from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
 from vllm.v1.worker.gpu.dp_utils import dispatch_cg_and_sync_dp
 from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
 from vllm.v1.worker.gpu.spec_decode.autoregressive.cudagraph_utils import (
     SpeculatorCudaGraphManager,
 )
 from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
+from vllm.v1.worker.utils import get_uniform_decode_token_count
 
 logger = init_logger(__name__)
 
@@ -198,12 +196,14 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
 
         # When all requests are decoding (no true prefills), each has
         # num_speculative_steps + 1 tokens, enabling FULL graph replay.
-        uniform_token_count = get_uniform_token_count(
+        uniform_token_count = get_uniform_decode_token_count(
             num_reqs,
             # Use the actual number of tokens without padding added by
             # the target model during FULL cudagraph.
             input_batch.num_tokens,
             max_query_len,
+            input_batch.num_computed_prefill_tokens_np,
+            input_batch.prefill_len_np,
         )
         prefill_batch_desc, num_tokens_across_dp = dispatch_cg_and_sync_dp(
             self.prefill_cudagraph_manager,

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
@@ -92,26 +92,32 @@ def _compute_global_residual_mass(
 
 
 @triton.jit
-def _compute_global_target_argmax(
-    target_local_max_ptr,
-    target_local_max_stride,
-    target_local_argmax_ptr,
-    target_local_argmax_stride,
-    logit_idx,
-    vocab_num_blocks,
-    PADDED_VOCAB_NUM_BLOCKS: tl.constexpr,
+def _gather_global_argmax(
+    # [num_rows, num_blocks]
+    local_max_ptr,
+    local_max_stride,
+    # [num_rows, num_blocks]
+    local_argmax_ptr,
+    local_argmax_stride,
+    row_idx,
+    num_blocks,
+    PADDED_NUM_BLOCKS: tl.constexpr,
 ):
-    blocks = tl.arange(0, PADDED_VOCAB_NUM_BLOCKS)
-    blocks_mask = blocks < vocab_num_blocks
+    blocks = tl.arange(0, PADDED_NUM_BLOCKS)
     local_max = tl.load(
-        target_local_max_ptr + logit_idx * target_local_max_stride + blocks,
-        mask=blocks_mask,
+        local_max_ptr + row_idx * local_max_stride + blocks,
+        mask=blocks < num_blocks,
         other=float("-inf"),
     )
-    max_block_idx = tl.argmax(local_max, axis=0)
-    return tl.load(
-        target_local_argmax_ptr + logit_idx * target_local_argmax_stride + max_block_idx
-    ).to(tl.int64)
+    # The reduction runs over the padded lanes too. Both of argmax's comparisons
+    # are false against a NaN, so a NaN in a real lane can leave a padded lane's
+    # index as the winner. The gather below is unmasked, so that index reads past
+    # the row, and past the tensor on the last row.
+    local_max = tl.where(local_max == local_max, local_max, float("-inf"))
+    max_block_idx = tl.minimum(tl.argmax(local_max, axis=0), num_blocks - 1)
+    return tl.load(local_argmax_ptr + row_idx * local_argmax_stride + max_block_idx).to(
+        tl.int64
+    )
 
 
 @triton.jit
@@ -240,7 +246,10 @@ def _compute_local_logits_stats_kernel(
             other=float("-inf"),
         ).to(tl.float32)
         value, idx = tl.max(target_logits, axis=0, return_indices=True)
-        token_id = block_idx * BLOCK_SIZE + idx
+        # A NaN can leave an out-of-vocabulary lane of the final block holding
+        # the winning index, for the same unordered-compare reason as the
+        # block reduction below.
+        token_id = tl.minimum(block_idx * BLOCK_SIZE + idx, vocab_size - 1)
         tl.store(
             target_local_argmax_ptr
             + logit_idx * target_local_argmax_stride
@@ -565,7 +574,7 @@ def _rejection_kernel(
                 # Greedy sampling. Accept IFF draft matches target argmax.
                 # NOTE: Target argmax is stored directly so that resampling
                 # can be skipped upon rejection.
-                target_argmax = _compute_global_target_argmax(
+                target_argmax = _gather_global_argmax(
                     target_local_max_ptr,
                     target_local_max_stride,
                     target_local_argmax_ptr,
@@ -789,7 +798,7 @@ def _resample_kernel(
         APPLY_TEMPERATURE=False,
         USE_FP64=USE_FP64,
     )
-    token_id = block_idx * BLOCK_SIZE + idx
+    token_id = tl.minimum(block_idx * BLOCK_SIZE + idx, vocab_size - 1)
     tl.store(
         resampled_local_argmax_ptr
         + req_idx * resampled_local_argmax_stride
@@ -842,18 +851,14 @@ def _insert_resampled_kernel(
         return
 
     # Insert the resampled token.
-    block = tl.arange(0, PADDED_RESAMPLE_NUM_BLOCKS)
-    mask = block < resample_num_blocks
-    resampled_local_max = tl.load(
-        resampled_local_max_ptr + req_idx * resampled_local_max_stride + block,
-        mask=mask,
-        other=float("-inf"),
-    )
-    resampled_max_block_idx = tl.argmax(resampled_local_max, axis=0)
-    resampled = tl.load(
-        resampled_local_argmax_ptr
-        + req_idx * resampled_local_argmax_stride
-        + resampled_max_block_idx,
+    resampled = _gather_global_argmax(
+        resampled_local_max_ptr,
+        resampled_local_max_stride,
+        resampled_local_argmax_ptr,
+        resampled_local_argmax_stride,
+        req_idx,
+        resample_num_blocks,
+        PADDED_RESAMPLE_NUM_BLOCKS,
     )
     tl.store(
         sampled_ptr + req_idx * sampled_stride + num_sampled,

--- a/vllm/v1/worker/gpu/warmup.py
+++ b/vllm/v1/worker/gpu/warmup.py
@@ -18,11 +18,78 @@ from vllm.v1.core.sched.output import (
     NewRequestData,
     SchedulerOutput,
 )
-from vllm.v1.kv_cache_interface import CrossAttentionSpec, MambaSpec
+from vllm.v1.kv_cache_interface import CrossAttentionSpec, KVCacheSpec, MambaSpec
 from vllm.v1.request import Request
 from vllm.v1.worker.gpu.model_runner import GPUModelRunner
 
 logger = init_logger(__name__)
+
+
+def _reserved_block_count(
+    num_tokens: int,
+    spec: KVCacheSpec,
+    *,
+    num_lookahead_tokens: int,
+    max_model_len: int,
+    max_encoder_len: int,
+) -> int:
+    """Number of blocks the scheduler would hold for a request of `num_tokens`.
+
+    Warmup feeds the model runner hand-built `SchedulerOutput`s, so it has to
+    reserve what `KVCacheManager.allocate_slots` reserves: the token range plus
+    `num_lookahead_tokens`, which is where the speculator writes the KV of the
+    tokens it drafts. Without that margin the drafter's slot mapping indexes a
+    block-table column the request never got, which reads back as the null
+    block instead of a block the request owns.
+
+    Args:
+        num_tokens: Computed plus scheduled tokens of the request.
+        spec: KV cache spec of the group being sized.
+        num_lookahead_tokens: `VllmConfig.num_lookahead_tokens`.
+        max_model_len: Cap on the reserved token range.
+        max_encoder_len: Encoder length, used by cross-attention groups.
+
+    Returns:
+        Blocks of `spec`'s group that the request must hold.
+    """
+    if isinstance(spec, CrossAttentionSpec):
+        # Cross-attention blocks cover the encoder sequence, which the drafter
+        # does not extend.
+        return cdiv(max_encoder_len, spec.block_size)
+    num_speculative_blocks = 0
+    if isinstance(spec, MambaSpec):
+        # Extra blocks beyond the token range hold the speculative-decode
+        # running-state snapshots; MambaManager appends them in every cache
+        # mode, and drops the lookahead tokens in align mode to keep the
+        # allocation block-aligned.
+        num_speculative_blocks = spec.num_speculative_blocks
+        if spec.mamba_cache_mode == "align":
+            # Align mode sizes from the uncapped main-model range:
+            # `allocate_slots` caps `num_tokens_need_slot`, the
+            # lookahead-extended range, and not `num_tokens_main_model`.
+            return cdiv(num_tokens, spec.block_size) + num_speculative_blocks
+    num_tokens = min(num_tokens + num_lookahead_tokens, max_model_len)
+    return cdiv(num_tokens, spec.block_size) + num_speculative_blocks
+
+
+def _warmup_block_counter(
+    model_runner: GPUModelRunner,
+) -> Callable[[int, KVCacheSpec], int]:
+    """Bind `_reserved_block_count` to `model_runner`'s reservation policy."""
+    num_lookahead_tokens = model_runner.vllm_config.num_lookahead_tokens
+    max_model_len = model_runner.max_model_len
+    max_encoder_len = getattr(model_runner.model_state, "max_encoder_len", 0)
+
+    def block_count(num_tokens: int, spec: KVCacheSpec) -> int:
+        return _reserved_block_count(
+            num_tokens,
+            spec,
+            num_lookahead_tokens=num_lookahead_tokens,
+            max_model_len=max_model_len,
+            max_encoder_len=max_encoder_len,
+        )
+
+    return block_count
 
 
 def run_mixed_prefill_decode_warmup(
@@ -48,21 +115,20 @@ def run_mixed_prefill_decode_warmup(
 
     kv_cache_groups = model_runner.kv_cache_config.kv_cache_groups
     num_kv_cache_groups = len(kv_cache_groups)
-    group_block_sizes = [g.kv_cache_spec.block_size for g in kv_cache_groups]
+    block_count = _warmup_block_counter(model_runner)
+    kv_cache_specs = [g.kv_cache_spec for g in kv_cache_groups]
     decode_prefill_block_counts = [
-        cdiv(decode_prompt_len, block_size) for block_size in group_block_sizes
+        block_count(decode_prompt_len, s) for s in kv_cache_specs
     ]
     decode_block_counts = [
-        cdiv(decode_prompt_len + decode_scheduled_tokens, block_size)
-        for block_size in group_block_sizes
+        block_count(decode_prompt_len + decode_scheduled_tokens, s)
+        for s in kv_cache_specs
     ]
     decode_block_deltas = [
         decode - prefill
         for decode, prefill in zip(decode_block_counts, decode_prefill_block_counts)
     ]
-    prefill_block_counts = [
-        cdiv(prefill_len, block_size) for block_size in group_block_sizes
-    ]
+    prefill_block_counts = [block_count(prefill_len, s) for s in kv_cache_specs]
     required_blocks = sum(decode_block_counts) + sum(prefill_block_counts)
     if model_runner.kv_cache_config.num_blocks <= required_blocks:
         logger.warning(
@@ -197,19 +263,10 @@ def warmup_kernels(
         ]
 
     # Compute per-request block counts for each KV cache group.
-    def _warmup_block_count(num_tokens: int, spec: Any) -> int:
-        if isinstance(spec, CrossAttentionSpec):
-            num_tokens = max_encoder_len
-        num_blocks = cdiv(num_tokens, spec.block_size)
-        if isinstance(spec, MambaSpec) and spec.mamba_cache_mode == "align":
-            # Align mode reserves extra blocks beyond the token range for the
-            # speculative-decode running-state snapshots.
-            num_blocks += spec.num_speculative_blocks
-        return num_blocks
-
+    block_count = _warmup_block_counter(model_runner)
     kv_cache_specs = [g.kv_cache_spec for g in kv_cache_groups]
-    prefill_block_counts = [_warmup_block_count(prompt_len, s) for s in kv_cache_specs]
-    decode_block_counts = [_warmup_block_count(decode_len, s) for s in kv_cache_specs]
+    prefill_block_counts = [block_count(prompt_len, s) for s in kv_cache_specs]
+    decode_block_counts = [block_count(decode_len, s) for s in kv_cache_specs]
     max_blocks_per_req = sum(decode_block_counts)
 
     num_reqs = min(
@@ -313,7 +370,7 @@ def warmup_kernels(
                 num_tokens = decode_query_len if use_spec else 1
                 after = req_computed[i] + num_tokens
                 deltas = [
-                    _warmup_block_count(after, spec) - held
+                    block_count(after, spec) - held
                     for spec, held in zip(kv_cache_specs, req_blocks[i])
                 ]
                 cached_req_data.new_block_ids.append(

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -553,6 +553,63 @@ def copy_kv_cache_blocks_inplace(
         blocks[dst_indices] = blocks[src_indices]
 
 
+def is_uniform_query_len(num_reqs: int, num_tokens: int, max_query_len: int) -> bool:
+    """Whether every request in the batch has the same query length.
+
+    This tests the batch shape only. Callers classifying a scheduled batch as a
+    decode batch must use ``get_uniform_decode_token_count`` instead, because a
+    prompt chunk can have a decode batch's shape.
+
+    Args:
+        num_reqs: Number of requests in the batch.
+        num_tokens: Total number of tokens in the batch.
+        max_query_len: Largest per-request query length in the batch.
+    """
+    return num_reqs > 0 and num_tokens == max_query_len * num_reqs
+
+
+def get_uniform_decode_token_count(
+    num_reqs: int,
+    num_tokens: int,
+    max_query_len: int,
+    num_computed_tokens: np.ndarray,
+    prefill_lens: np.ndarray,
+) -> int | None:
+    """Per-request token count of a uniform decode batch, or None.
+
+    A batch is a uniform decode batch only if every request has the same query
+    length *and* no request is still prefilling. Query length alone is a shape
+    test that a prompt chunk satisfies by coincidence: a prompt chunk of
+    ``1 + num_speculative_tokens`` tokens has the shape of a spec-decode step,
+    and a 1-token chunk has the shape of a plain decode step. Classifying such
+    a batch as a decode batch replays a decode-captured cudagraph over prompt
+    tokens, whose captured kernels read per-request state that a prefill
+    metadata build does not refresh.
+
+    Args:
+        num_reqs: Number of requests in the batch.
+        num_tokens: Total number of tokens in the batch.
+        max_query_len: Largest per-request query length in the batch.
+        num_computed_tokens: Per-request tokens computed before this step, in
+            batch order. Must be exactly ``num_reqs`` long; a full
+            ``max_num_reqs`` state array would compare the wrong requests.
+        prefill_lens: Per-request prefill length, i.e. the prompt plus any
+            output tokens recomputed after preemption, in batch order. Same
+            length requirement.
+
+    Returns:
+        The shared per-request query length, or None if the batch is not a
+        uniform decode batch.
+    """
+    if not is_uniform_query_len(num_reqs, num_tokens, max_query_len):
+        return None
+    # Equivalent to `InputBatch.is_prefilling_np.any()`, which the drafter's
+    # call site derives from the same two arrays.
+    if np.any(num_computed_tokens < prefill_lens):
+        return None
+    return max_query_len
+
+
 def is_residual_scattered_for_sp(
     vllm_config: VllmConfig, num_input_tokens: int
 ) -> bool:


### PR DESCRIPTION
## Purpose

A DFlash speculative drafter could not run with prefix caching enabled. The
first request died on

```
AssertionError: SlidingWindowManager does not support fine-grained (partial) cache hits
```

and the only way to serve the lane was `--no-enable-prefix-caching`, which
re-prefills the whole prompt on every request. On a multi-turn agentic workload
with ~33k-token prompts that is the dominant cost.

The root cause is the drafter's own KV group. A DFlash drafter whose layers are
all `sliding_attention` builds a `SlidingWindowSpec` group, and that group's
manager cannot serve the fine-grained hits the hybrid coordinator hands it.
Booking those layers as full attention (carrying the `sliding_window` field, so
the window is still enforced by the metadata builder) removes the group, which
in turn flips `enable_partial_hash_hits` to True and makes a second latent
defect reachable in the coordinator.

The nine commits are the two that unblock this, the core reconciliation fixes
they expose, and independent defects found on the way there. Each is
self-contained and reviewable on its own:

1. **`[Bugfix][Spec Decode]` rejection sampler per-block argmax gather** — a
   `tl.argmax` reduced over the *padded* lane count indexes a companion tensor
   sized to the *real* block count, unclamped and unmasked. A padded lane wins
   the reduction whenever a real lane holds NaN, because Triton's argmax
   combine is false in both comparisons for an unordered operand. Reachable by
   any speculative method on the V2 runner as soon as one step mixes requests
   with and without draft tokens.
2. **`[Bugfix][Core]` reconcile hybrid prefix-cache hits across every group** —
   gate fine-grained partial hits on all groups supporting them, rather than
   letting a group that only does block-aligned lookup receive one.
3. **`[Spec Decode]` all-sliding DFlash drafter books its KV as full
   attention** — the fix described above. Derived from the drafter's layer
   types and the caching state rather than gated behind an env var.
4. **`[Bugfix][Core]` reconcile the connector's dense reference across
   full-attention groups** — the truncation assumed a single full-attention
   group; converting the drafter creates a second one, and the deeper group
   kept a block list longer than the reconciled hit.
5. **`[Bugfix][MRV2]` reserve spec-decode lookahead blocks in V2 warmup.**
6. **`[Bugfix][MRV2]` require all requests to be decoding for uniform-decode
   dispatch** — otherwise a decode CUDA graph can be replayed over prompt
   tokens.
7. **`[Model][Spec Decode]` tap the pre-norm AttnRes mixture as the Kimi K3
   DFlash aux state.**
8. **`[Misc]` warn when `--block-size` is silently discarded** — values at or
   below the backend minimum are rounded away, so passing one is
   indistinguishable from passing nothing.
9. **`[Bugfix][Core]` cache a mamba "align" state block only at its own
   boundary** — a decode step is not clipped onto a block boundary, so it
   generally steps over one, entering a block into the hash map keyed to a
   prefix its recurrent state does not correspond to.

## Test Plan

Unit tests, all runnable on CPU:

```
pytest tests/v1/core/test_prefix_caching.py \
       tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py \
       tests/v1/spec_decode/test_dflash_draft_full_attention_spec.py \
       tests/v1/worker/test_gpu_warmup_blocks.py \
       tests/v1/worker/test_uniform_decode_token_count.py \
       tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
```

End to end: Kimi K3 on 8×B300 at TP8, DFlash drafter at `num_speculative_tokens
16`, prefix caching enabled, against a multi-turn agentic workload with long
shared prefixes. Acceptance is computed as `1 + accepted/steps` from raw counter
deltas; the engine's own `SpecDecoding metrics` unweighted mean of its
10-second samples runs several percent high and is not used.

## Test Result

**Unit.** The commits that change behaviour ship with tests that fail without
them. For commit 9, three withholding tests fail when the rule is neutralised
while the two "still admits" controls pass in both arms — the controls matter
because a mask that degenerated to withholding everything would take mamba
prefix hits to zero and still pass the withholding tests.

**End to end.** With prefix caching enabled the lane serves, where before it
died on the first request. At one concurrent user over 120 s: acceptance 3.456
(4,008 accepted over 1,632 steps at draft width exactly 16.0), position-0
acceptance 0.639, decode 173.0 / 154.7 tok/s/user, prefix cache hit rate 95.5%,
80 requests and zero failures. Across a concurrency sweep, p50 decode at 16
users goes 4.2 → 15.7 tok/s/user and the hit rate stops decaying with load
(36.1% → 94.2%).

Confirming the conversion is live is worth stating because the flag alone does
not tell you: the "Disabling fine-grained (partial) prefix-cache hits" warning
must be **absent**, `SlidingWindowManager` must appear nowhere, every worker
logs the sliding-window layers being booked as full attention, and the KV pool
falls from 2,032,138 to 1,950,541 tokens.

**Limits of the above, stated plainly.** The control and treatment arms ran in
different containers rather than the same one. It is one 120-second draw plus
one sweep, with no replicate. Commits 3 and 4 were measured together, so
neither is isolated on GPU. Commit 9 was measured and found **inert** on this
workload — the block size and completion length there leave the affected
population nearly empty (3 of 32 requests crossed a boundary during decode), so
acceptance moved 1.249 → 1.294 and the hit rate was unchanged at 50.5%; that is
evidence it costs nothing, not evidence it helps. Commits 5 and 6 are
correctness guards covered by unit tests and have not been isolated on GPU. No
correctness evaluation has been run against this stack.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
