### PR TITLE
[ROCm][CI] Wait for VRAM to settle in speculators spec-decode test

### DIFF
--- a/tests/v1/e2e/spec_decode/test_spec_decode.py
+++ b/tests/v1/e2e/spec_decode/test_spec_decode.py
@@ -429,6 +429,8 @@ def test_speculators_model_integration(
     del spec_llm
     torch.accelerator.empty_cache()
     cleanup_dist_env_and_memory()
+    # ROCm frees VRAM lazily; wait so the reference engine below does not OOM.
+    wait_for_rocm_memory_to_settle()
 
     # Second run: Reference without speculative decoding
     ref_llm = LLM(model=verifier_model, max_model_len=4096, gpu_memory_utilization=0.92)


### PR DESCRIPTION
## Purpose

`test_speculators_model_integration` loads two engines back to back within a single test: first the speculator (`spec_llm`), then a reference engine (`ref_llm`). On ROCm the driver reclaims VRAM lazily, and the first engine's VRAM is held by its child EngineCore process, not the main pytest process. The `del spec_llm` + `cleanup_dist_env_and_memory()` calls run in the main process and do not block on the child's teardown, so the reference engine intermittently starts before the ~63 GiB is released and fails its startup memory guard with `ValueError: Free memory on device cuda:0 (0.99/63.98 GiB) on startup is less than desired GPU memory utilization (0.92, 58.87 GiB)`. This is flaky: the very next parametrization (`qwen3_eagle3_speculator`) does the same two-engine sequence and passes when the child happens to die in time.

The fix calls `wait_for_rocm_memory_to_settle()` between the two loads — the purpose-built helper for exactly this ROCm lazy-reclaim window, already used the same way in `_run_eagle_correctness` in this file. It is a no-op off ROCm, so CUDA CI is unaffected.

This is not a duplicate of #37477, which lowers the output-match accuracy threshold (66%→60%) for a different, correctness-heuristic flake; it does not touch the second-engine startup OOM addressed here.

AI assistance (Claude) was used to investigate the CI log and prepare this change; a human has reviewed every line.

## Test Plan

AMD CI step (`.buildkite/test-amd.yaml`), `working_dir: /vllm-workspace/tests`, single MI300 GPU:

```
pytest -v -s v1/e2e/spec_decode -k "speculators or mtp_correctness"
```

Single-case reproduction used during development (MI300, gfx942, single GPU):

```
pytest -v -s "v1/e2e/spec_decode/test_spec_decode.py::test_speculators_model_integration[llama3_eagle3_speculator]"
```

## Test Result

Before: CI failed at the reference-engine startup with `ValueError: Free memory on device cuda:0 (0.99/63.98 GiB) on startup is less than desired GPU memory utilization (0.92, 58.87 GiB)`; the first engine's EngineCore shutdown (SIGTERM) was logged ~2s *after* the reference engine had already errored, confirming the child still held VRAM at reference startup.

After: `test_speculators_model_integration[llama3_eagle3_speculator]` passes on a single MI300 GPU (`1 passed in 315.39s`), with the second engine now starting from the full `63.8/63.98 GiB` free.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

