### PR TITLE
[Bugfix] Fix stale latent MoE residual pointer in CUDA graphs

### DIFF
--- a/vllm/model_executor/layers/fused_moe/runner/latent_moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/latent_moe_runner.py
@@ -77,25 +77,30 @@ class LatentMoERunner(MoERunner):
             )
             self._k3_latent_moe_tail_op = op
 
-    def _get_zero_residual(self, hidden_states: torch.Tensor) -> torch.Tensor:
+    def _get_zero_residual(
+        self,
+        hidden_states: torch.Tensor,
+        max_token_num: int,
+    ) -> torch.Tensor:
         """Read-only zero ``residual_in`` for the fused AR+RMSNorm kernel.
 
         flashinfer requires a residual buffer even when there is no residual to
         add.
         """
-        numel = hidden_states.numel()
         buf = getattr(self, "_zero_residual", None)
-        if (
-            buf is None
-            or buf.dtype != hidden_states.dtype
-            or buf.device != hidden_states.device
-            or buf.numel() < numel
-        ):
+        if buf is None:
             buf = torch.zeros(
-                numel, dtype=hidden_states.dtype, device=hidden_states.device
+                max_token_num * hidden_states.shape[-1],
+                dtype=hidden_states.dtype,
+                device=hidden_states.device,
             )
             self._zero_residual = buf
-        return buf[:numel].view_as(hidden_states)
+
+        assert buf.dtype == hidden_states.dtype
+        assert buf.device == hidden_states.device
+        assert hidden_states.numel() <= buf.numel()
+
+        return buf[: hidden_states.numel()].view_as(hidden_states)
 
     def _use_fused_path(self) -> bool:
         # The fused path merges the latent and shared reductions into one
@@ -239,7 +244,7 @@ class LatentMoERunner(MoERunner):
                 # buffer and the normalized result into norm_out.
                 flashinfer_trtllm_fused_allreduce_norm(
                     allreduce_in=hidden_states,
-                    residual=self._get_zero_residual(hidden_states),
+                    residual=self._get_zero_residual(hidden_states, max_token_num),
                     rms_gamma=norm.weight,
                     rms_eps=norm.variance_epsilon,
                     world_size=self.moe_config.tp_size,


### PR DESCRIPTION
## Purpose
Fix a bug in Latent MoE runner where CUDA graphs hold stale pointers which can be freed by eager execution, causing illegal memory access.

Current code:
```
def _get_zero_residual(self, hidden_states: torch.Tensor) -> torch.Tensor:
        numel = hidden_states.numel()
        buf = getattr(self, "_zero_residual", None)
        if (
            buf is None
            or buf.dtype != hidden_states.dtype
            or buf.device != hidden_states.device
            or buf.numel() < numel
        ):
            buf = torch.zeros(
                numel, dtype=hidden_states.dtype, device=hidden_states.device
            )
            self._zero_residual = buf
        return buf[:numel].view_as(hidden_states)
```

`buf` is allocated outside graph capture, and can be reassigned when a larger hidden states tensor requires a larger buffer in eager execution. Thus, the cuda graphs still point to the stale memory address, resulting in illegal memory access when memory pressure is high.

The PR fixes it by allocating a static buffer using `max_num_tokens` to eliminate stale memory caused by reassignment.

## Test Plan
Tested that before the change, workloads hits `torch.AcceleratorError: CUDA error: an illegal memory access was encountered` consistently. With the patch, the issue is gone.

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

