### PR TITLE
[XPU][UT] Fix explicit-overrides UT failure by enabling config-driven XPUGraph mode when VLLM_XPU_ENABLE_XPU_GRAPH is unset

### DIFF
--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -292,13 +292,9 @@ class XPUPlatform(Platform):
                 "XPU Graph is not supported in the current PyTorch version, "
                 "disabling cudagraph_mode."
             )
-        elif not envs.VLLM_XPU_ENABLE_XPU_GRAPH:
-            compilation_config.cudagraph_mode = CUDAGraphMode.NONE
-            logger.warning_once(
-                "XPU Graph is disabled by environment variable, "
-                "please set VLLM_XPU_ENABLE_XPU_GRAPH=1 to enable it."
-            )
-        else:
+        elif (
+            "VLLM_XPU_ENABLE_XPU_GRAPH" in os.environ and envs.VLLM_XPU_ENABLE_XPU_GRAPH
+        ) or compilation_config.cudagraph_mode != CUDAGraphMode.NONE:
             logger.warning_once(
                 "XPU Graph support is experimental and has known limitations: "
                 "(1) only single-GPU execution is supported; "
@@ -307,6 +303,12 @@ class XPUPlatform(Platform):
                 "(3) XPU Graph may increase device memory usage, "
                 "potentially causing OOM errors or leaving less memory "
                 "for the KV cache and reducing performance."
+            )
+        else:
+            compilation_config.cudagraph_mode = CUDAGraphMode.NONE
+            logger.warning_once(
+                "XPU Graph is disabled by environment variable, "
+                "please set VLLM_XPU_ENABLE_XPU_GRAPH=1 to enable it."
             )
 
         # Disable fusion passes not yet supported on XPU.


### PR DESCRIPTION
## Summary
This PR fixes XPU UT failure in `test_vllm_config_explicit_overrides` by preventing the default XPU env fallback from force-disabling XPUGraph mode when the env key `VLLM_XPU_ENABLE_XPU_GRAPH` is not explicitly set.

## What changed

Enable XPU graph when either:
  - `VLLM_XPU_ENABLE_XPU_GRAPH` is explicitly set to `1`, or
  - `cudagraph_mode` is already non-`NONE` from config/optimization.
 
## Root cause
On XPU, an unset VLLM_XPU_ENABLE_XPU_GRAPH was treated as disabled, so cudagraph_mode was forced to NONE regardless of the configured optimization level. This overrode the O2 default (FULL_AND_PIECEWISE) and caused the explicit-overrides UT to fail.

```
Observed failure:
    AssertionError: assert <CUDAGraphMode.NONE: 0> == <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>
```

## Example to reproduce (without this PR)
```
pytest -sv tests/test_config.py::test_vllm_config_explicit_overrides  # FAIL
VLLM_XPU_ENABLE_XPU_GRAPH=1 pytest -sv tests/test_config.py::test_vllm_config_explicit_overrides # PASS
```