### PR TITLE
[Perf][MoE] Enable clamped SwiGLU and fused unpermute for NVFP4 CUTLASS

### DIFF
--- a/tests/kernels/moe/test_cutlass_moe.py
+++ b/tests/kernels/moe/test_cutlass_moe.py
@@ -3,6 +3,7 @@
 import copy
 import dataclasses
 from math import prod
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -26,7 +27,15 @@ from vllm.model_executor.layers.fused_moe.experts.cutlass_moe import (
     CutlassExpertsFp8,
     run_cutlass_moe_fp8,
 )
+from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
+    NvFp4MoeBackend,
+    select_nvfp4_moe_backend,
+)
 from vllm.model_executor.layers.fused_moe.utils import moe_kernel_quantize_input
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kNvfp4Dynamic,
+    kNvfp4Static,
+)
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
@@ -53,10 +62,38 @@ MNK_FACTORS = [
 vllm_config = VllmConfig(parallel_config=ParallelConfig(pipeline_parallel_size=1))
 
 
-def test_cutlass_moe_supports_gelu_tanh_activation_metadata():
+def test_cutlass_moe_supports_activation_metadata():
     assert CutlassExpertsFp8._supports_activation(MoEActivation.GELU_TANH)
     assert CutlassExpertsFp4._supports_activation(MoEActivation.GELU_TANH)
     assert CutlassExpertsFp4._supports_activation(MoEActivation.GELU_TANH_NO_MUL)
+    assert CutlassExpertsFp4._supports_activation(MoEActivation.SWIGLUOAI_UNINTERLEAVE)
+
+
+def test_clamped_nvfp4_can_select_vllm_cutlass():
+    moe_config = dataclasses.replace(
+        make_dummy_moe_config(
+            hidden_dim=16,
+            activation=MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+        ),
+        moe_backend="cutlass",
+        swiglu_limit=7.0,
+        swiglu_alpha=1.702,
+        swiglu_beta=1.0,
+    )
+
+    with patch.object(
+        CutlassExpertsFp4,
+        "_supports_current_device",
+        return_value=True,
+    ):
+        backend, experts_cls = select_nvfp4_moe_backend(
+            moe_config,
+            weight_key=kNvfp4Static,
+            activation_key=kNvfp4Dynamic,
+        )
+
+    assert backend is NvFp4MoeBackend.VLLM_CUTLASS
+    assert experts_cls is CutlassExpertsFp4
 
 
 @dataclasses.dataclass

--- a/tests/kernels/moe/test_nvfp4_moe.py
+++ b/tests/kernels/moe/test_nvfp4_moe.py
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import dataclasses
+import itertools
+
 import pytest
 import torch
 
@@ -44,14 +47,44 @@ MNK_FACTORS = [
     (224, 1024, 1536),
 ]
 
+CUTLASS_FP4_CASES = [
+    (*mnk, e, topk, torch.bfloat16, MoEActivation.SILU, None, 1.0, 0.0)
+    for mnk, e, topk in itertools.product(MNK_FACTORS, [40, 64, 256], [1, 6, 8])
+]
+CUTLASS_FP4_CASES.append(
+    pytest.param(
+        16,
+        256,
+        256,
+        8,
+        2,
+        torch.bfloat16,
+        MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+        7.0,
+        1.702,
+        1.0,
+        id="minimax-m3-swiglu",
+    )
+)
 
-@pytest.mark.parametrize("m,n,k", MNK_FACTORS)
-@pytest.mark.parametrize("e", [40, 64, 256])
-@pytest.mark.parametrize("topk", [1, 6, 8])
-@pytest.mark.parametrize("dtype", [torch.bfloat16])
+
+@pytest.mark.parametrize(
+    "m,n,k,e,topk,dtype,activation,clamp_limit,alpha,beta",
+    CUTLASS_FP4_CASES,
+)
 @torch.inference_mode()
 def test_cutlass_fp4_moe_no_graph(
-    m: int, n: int, k: int, e: int, topk: int, dtype: torch.dtype, workspace_init
+    m: int,
+    n: int,
+    k: int,
+    e: int,
+    topk: int,
+    dtype: torch.dtype,
+    activation: MoEActivation,
+    clamp_limit: float | None,
+    alpha: float,
+    beta: float,
+    workspace_init,
 ):
     set_random_seed(7)
     with set_current_vllm_config(
@@ -91,8 +124,20 @@ def test_cutlass_fp4_moe_no_graph(
             a2_gscale=a2_gs,
             w1_scale=w1_blockscale,
             w2_scale=w2_blockscale,
+            gemm1_clamp_limit=clamp_limit,
         )
-        moe_config = make_dummy_moe_config()
+        moe_config = dataclasses.replace(
+            make_dummy_moe_config(
+                num_experts=e,
+                experts_per_token=topk,
+                hidden_dim=k,
+                intermediate_size=n,
+                activation=activation,
+            ),
+            swiglu_limit=clamp_limit,
+            swiglu_alpha=alpha,
+            swiglu_beta=beta,
+        )
 
         kernel = mk.FusedMoEKernel(
             maybe_make_prepare_finalize(
@@ -114,7 +159,7 @@ def test_cutlass_fp4_moe_no_graph(
             topk_weights=topk_weights,
             topk_ids=topk_ids,
             global_num_experts=e,
-            activation=mk.MoEActivation.SILU,
+            activation=activation,
             apply_router_weight_on_input=False,
             expert_map=None,
         )
@@ -155,7 +200,24 @@ def test_cutlass_fp4_moe_no_graph(
                 block_size=quant_blocksize,
             )
 
-        torch_output = torch_moe(a_in_dtype, w1_d, w2_d, score, topk)
+        activation_kwargs = (
+            {
+                "swiglu_limit": clamp_limit,
+                "alpha": alpha,
+                "beta": beta,
+            }
+            if activation == MoEActivation.SWIGLUOAI_UNINTERLEAVE
+            else None
+        )
+        torch_output = torch_moe(
+            a_in_dtype,
+            w1_d,
+            w2_d,
+            score,
+            topk,
+            activation=activation,
+            activation_kwargs=activation_kwargs,
+        )
 
         torch.testing.assert_close(torch_output, cutlass_output, atol=1e-1, rtol=1e-1)
 

--- a/tests/kernels/utils.py
+++ b/tests/kernels/utils.py
@@ -871,6 +871,7 @@ def torch_experts(
     block_shape: list[int] | None = None,
     apply_router_weights_on_input: bool = False,
     activation: MoEActivation = MoEActivation.SILU,
+    activation_kwargs: dict[str, Any] | None = None,
 ) -> torch.Tensor:
     assert (
         global_num_experts == -1
@@ -914,6 +915,7 @@ def torch_experts(
     f32 = torch.float32
 
     act = op_registry[activation.custom_op_name]
+    activation_kwargs = activation_kwargs or {}
 
     for i in range(num_experts):
         mask = topk_ids == i
@@ -922,7 +924,7 @@ def torch_experts(
                 tmp1 = a[mask] @ w1[i].transpose(0, 1)
                 if b_bias1 is not None:
                     tmp1 = tmp1 + b_bias1[i].view(1, -1).to(tmp1.dtype)
-                tmp2 = act()(tmp1)
+                tmp2 = act(**activation_kwargs)(tmp1)
                 out[mask] = tmp2 @ w2[i].transpose(0, 1)
                 if b_bias2 is not None:
                     out[mask] = out[mask] + b_bias2[i].view(1, -1).to(tmp1.dtype)
@@ -970,7 +972,7 @@ def torch_experts(
                 if b_bias1 is not None:
                     tmp1 = tmp1 + b_bias1[i].view(1, -1).to(out.dtype)
 
-                tmp2 = act()(tmp1).to(out.dtype)
+                tmp2 = act(**activation_kwargs)(tmp1).to(out.dtype)
 
                 tmp2, b_scale = moe_kernel_quantize_input(
                     tmp2, a2_scale, quant_dtype, per_act_token_quant, block_shape
@@ -1004,6 +1006,7 @@ def torch_moe(
     global_num_experts: int = -1,
     expert_map: torch.Tensor | None = None,
     activation: MoEActivation = MoEActivation.SILU,
+    activation_kwargs: dict[str, Any] | None = None,
 ) -> torch.Tensor:
     score = torch.softmax(score, dim=-1, dtype=torch.float32)
     topk_weight, topk_ids = torch.topk(score, topk)
@@ -1018,6 +1021,7 @@ def torch_moe(
         b_bias2,
         expert_map,
         activation=activation,
+        activation_kwargs=activation_kwargs,
     )
 
 

--- a/vllm/model_executor/layers/fused_moe/experts/cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/cutlass_moe.py
@@ -512,6 +512,9 @@ def run_cutlass_moe_fp4(
     e: int,
     device: torch.device,
     apply_router_weight_on_input: bool = False,
+    clamp_limit: float | None = None,
+    alpha: float = 1.0,
+    beta: float = 0.0,
 ) -> None:
     """
     MoE implementation for FP4 Inputs
@@ -633,7 +636,7 @@ def run_cutlass_moe_fp4(
         blockscale_offsets[:-1],
     )
     del rep_a_fp4, rep_a_blockscale
-    if activation == MoEActivation.SILU:
+    if activation == MoEActivation.SILU and clamp_limit is None:
         # Fused SiLU+Mul+NVFP4 quantization
         # Note: c2 workspace is no longer needed since SiLU is fused with quantization.
         # c3 reuses workspace13 after c1 is consumed.
@@ -641,7 +644,14 @@ def run_cutlass_moe_fp4(
             c1, a2_gscale, expert_offsets, blockscale_offsets, num_topk
         )
     else:
-        apply_moe_activation(activation, c2, c1)
+        apply_moe_activation(
+            activation,
+            c2,
+            c1,
+            clamp_limit=clamp_limit,
+            alpha=alpha,
+            beta=beta,
+        )
         int_fp4, int_blockscale = ops.scaled_fp4_experts_quant(
             c2, a2_gscale, expert_offsets, blockscale_offsets, num_topk
         )
@@ -659,18 +669,24 @@ def run_cutlass_moe_fp4(
     )
     del int_fp4, int_blockscale
 
-    c3 = ops.shuffle_rows(c3, c_map)
+    assert (
+        output.untyped_storage().data_ptr() != workspace13.untyped_storage().data_ptr()
+    ), "moe_unpermute source and destination must use disjoint storage"
 
     assert output.dtype == out_dtype
     if not apply_router_weight_on_input:
-        output.copy_(
-            (
-                c3.view(m, num_topk, k)
-                * topk_weights.view(m, num_topk, 1).to(out_dtype)
-            ).sum(dim=1),
-            non_blocking=True,
+        moe_unpermute(
+            out=output,
+            permuted_hidden_states=c3,
+            topk_weights=topk_weights,
+            inv_permuted_idx=c_map.view(m, num_topk),
+            # get_cutlass_moe_mm_data emits int32 expert offsets, while
+            # moe_unpermute's optional offsets must be int64. This backend
+            # only supports EP1, so there are no skipped expert rows.
+            expert_first_token_offset=None,
         )
     else:
+        c3 = ops.shuffle_rows(c3, c_map)
         output.copy_(c3.view(m, num_topk, k).sum(dim=1), non_blocking=True)
     return
 
@@ -721,6 +737,7 @@ class CutlassExpertsFp4(mk.FusedMoEExpertsModular):
             MoEActivation.GELU,
             MoEActivation.GELU_TANH,
             MoEActivation.SWIGLUOAI,
+            MoEActivation.SWIGLUOAI_UNINTERLEAVE,
             MoEActivation.SWIGLUSTEP,
             MoEActivation.SILU_NO_MUL,
             MoEActivation.GELU_NO_MUL,
@@ -781,6 +798,16 @@ class CutlassExpertsFp4(mk.FusedMoEExpertsModular):
         e, m, n, k, _ = self.moe_problem_size(hidden_states, w1, w2, topk_ids)
         n = w2.shape[2] * 2
 
+        clamp_limit = self.quant_config.gemm1_clamp_limit
+        if clamp_limit is None:
+            clamp_limit = self.moe_config.swiglu_limit
+        alpha = self.quant_config.gemm1_alpha
+        if alpha is None:
+            alpha = self.moe_config.swiglu_alpha
+        beta = self.quant_config.gemm1_beta
+        if beta is None:
+            beta = self.moe_config.swiglu_beta
+
         run_cutlass_moe_fp4(
             output=output,
             a=hidden_states,
@@ -803,6 +830,9 @@ class CutlassExpertsFp4(mk.FusedMoEExpertsModular):
             e=e,
             device=hidden_states.device,
             apply_router_weight_on_input=apply_router_weight_on_input,
+            clamp_limit=clamp_limit,
+            alpha=1.0 if alpha is None else alpha,
+            beta=0.0 if beta is None else beta,
         )
 
 

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -190,6 +190,7 @@ def select_nvfp4_moe_backend(
     NVFP4_BACKENDS_WITH_CLAMP = {
         NvFp4MoeBackend.FLASHINFER_TRTLLM,
         NvFp4MoeBackend.FLASHINFER_CUTLASS,
+        NvFp4MoeBackend.VLLM_CUTLASS,
         NvFp4MoeBackend.MARLIN,
     }
 
@@ -258,8 +259,8 @@ def select_nvfp4_moe_backend(
             raise ValueError(
                 f"Model sets swiglu_limit={config.swiglu_limit}, but the "
                 f"explicitly requested moe_backend={runner_backend!r} does "
-                f"not apply the SwiGLU clamp. Use 'flashinfer_trtllm' or "
-                f"'flashinfer_cutlass' instead."
+                f"not apply the SwiGLU clamp. Use 'cutlass', "
+                f"'flashinfer_trtllm', 'flashinfer_cutlass', or 'marlin' instead."
             )
         return _return_or_raise(
             requested_backend, config, weight_key, activation_key, activation_format


### PR DESCRIPTION
## Purpose

Enable the native CUTLASS NVFP4 W4A4 MoE path for models that use packed, clamped SwiGLU-OAI, and fuse the common post-GEMM inverse permutation, router weighting, and reduction through the existing `moe_unpermute` kernel.

MiniMax-M3 uses `SWIGLUOAI_UNINTERLEAVE` with `limit=7`, `alpha=1.702`, and `beta=1`. The NVFP4 backend oracle previously filtered out native CUTLASS when a clamp was present, while the CUTLASS path did not forward those activation parameters. After GEMM2, that path also materialized a shuffled `[M * topk, K]` tensor before doing router weighting and reduction in PyTorch.

This PR:

- resolves GEMM1 clamp/alpha/beta from the quant config, with model config fallback;
- retains fused SiLU + NVFP4 quantization for the unclamped SiLU fast path and uses the generic activation plus NVFP4 quantization when activation metadata is required;
- uses `moe_unpermute` to write the router-weighted reduction directly to disjoint caller output storage;
- preserves the existing shuffle-and-sum branch when router weights are applied on input;
- allows native `VLLM_CUTLASS` selection for clamped NVFP4;
- extends the existing NVFP4 CUDA matrix with a MiniMax-M3-shaped numerical case and adds backend-selection coverage.

Current `main` already aliases the modular kernel's CUDA output to caller storage, so this port does not need a modular-kernel change.

### Related open PRs / duplicate check

This is not a duplicate of the closest open work:

- #48929 addresses MiniMax-M3 correctness through FlashInfer/Marlin and explicitly does not change native CUTLASS or its low-level execution path.
- #43694 addresses router weighting on input and retains the FP4 post-GEMM shuffle/copy; this PR changes the common router-weight-on-output path and preserves the input-weighting branch.
- #45738 is FlashInfer-only clamp support.
- #49941 is Marlin-only alpha/beta support.

There may be integration overlap in activation metadata, but the native CUTLASS fused-unpermute path here is materially distinct.

## Test Plan

- Run all pre-commit hooks on the five changed files.
- Compile the changed Python modules.
- Run the existing CUDA NVFP4 MoE matrix, including the added `minimax-m3-swiglu` case, in vLLM CI.
- Re-run the InferenceMAX GSM8K and coherence-v2 gates and the official C64 throughput workload on the production image.

## Test Result

### Lightweight validation on current main

- `.venv/bin/pre-commit run --files tests/kernels/moe/test_cutlass_moe.py tests/kernels/moe/test_nvfp4_moe.py tests/kernels/utils.py vllm/model_executor/layers/fused_moe/experts/cutlass_moe.py vllm/model_executor/layers/fused_moe/oracle/nvfp4.py`: all hooks passed.
- `.venv/bin/python -m py_compile` on all five changed files: passed.
- `git diff --check`: passed.

A focused CUDA pytest was not rerun in this current-main checkout because the precompiled wheel metadata for this commit returned HTTP 404. The numerical CUDA case is included for CI. The model-level results below come from the accuracy-qualified source implementation in the exact production image, not from this current-main checkout:

`vllm/vllm-openai:vllm-minimax-m3-perf-x86_64-13.0.1-8b00f41@sha256:6af4be7ae69a5f424de85b3d514ac79778bdcf4a9d05f93ec908a4095e0f1253`

### Accuracy-qualified official C64 result

All official C64 rows used the same request vectors and totals, with 128 warmup requests and 640 measured requests.

| Configuration | Total tok/s/GPU | Output tok/s/GPU | Tok/s/user |
|---|---:|---:|---:|
| W4A16 + local argmax (primary causal baseline) | 1424.2842374633228 | 157.5032013272953 | 11.17231710858176 |
| W4A4 fused unpermute | 1487.7474007401365 | 164.5212186018931 | 11.518615905906067 |
| Delta | **+4.4557934%** | **+4.4557934%** | **+3.0996148%** |

Additional deltas against the primary exact-vector baseline (lower is better): mean TTFT **-5.0867%**, mean TPOT **-3.8467%**, mean E2EL **-3.9283%**, average power **-6.3212%**, and joules/output-token **-10.3173%**.

For continuity with the canonical W4A16 baseline:

| Configuration | Total tok/s/GPU | Output tok/s/GPU | Tok/s/user |
|---|---:|---:|---:|
| Canonical W4A16 | 1401.0807379640391 | 154.93726304264334 | 10.857239129500492 |
| W4A4 fused unpermute | 1487.7474007401365 | 164.5212186018931 | 11.518615905906067 |
| Delta | **+6.1857008%** | **+6.1857008%** | **+6.0915745%** |

Accuracy gate for the W4A4 candidate:

| Gate | Result |
|---|---:|
| coherence-v2 | 4/4 |
| GSM8K generations | 1319/1319 |
| GSM8K strict | 0.9545109932 |
| GSM8K flexible | 0.9537528431 |
| Failures | 0 |

### Directional W1M2 screens (not accuracy-qualified)

These paired screens are shape-dependent directional data, not official performance claims. The full concurrency curve is still being measured.

| Concurrency | Configuration | Total tok/s/GPU | Output tok/s/GPU | Tok/s/user |
|---:|---|---:|---:|---:|
| 4 | W4A16 + local argmax | 532.6190023 | 57.9824005 | 79.3408997 |
| 4 | W4A4 fused unpermute | 569.6289254 | 62.0114047 | 90.9414524 |
| 4 | Delta | **+6.948667%** | **+6.948667%** | **+14.621151%** |
| 8 | W4A16 + local argmax | 793.7679284 | 87.3584843 | 60.0080116 |
| 8 | W4A4 fused unpermute | 685.5045377 | 75.4435084 | 51.7740167 |
| 8 | Delta | **-13.639174%** | **-13.639174%** | **-13.721493%** |
| 16 | W4A16 + local argmax | 946.8501119 | 106.3024070 | 35.7343158 |
| 16 | W4A4 fused unpermute | 895.7974927 | 100.5707539 | 34.7570186 |
| 16 | Delta | **-5.391837%** | **-5.391837%** | **-2.734898%** |
| 32 | W4A16 + local argmax | 1194.8109698 | 134.4671250 | 21.6182930 |
| 32 | W4A4 fused unpermute | 1201.7164399 | 135.2442845 | 24.3238472 |
| 32 | Delta | **+0.577955%** | **+0.577955%** | **+12.515115%** |

## AI assistance

Codex was used to port the qualified change, update tests, run the lightweight checks, and prepare this description. This is intentionally a draft pending human submitter review of every changed line and the relevant CUDA test/CI results before it is marked ready for review.
