### PR TITLE
[Feature][Quantization] Add per-layer online quantization configuration (#50281)

### DIFF
--- a/tests/quantization/test_per_layer_online_quantization.py
+++ b/tests/quantization/test_per_layer_online_quantization.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+from unittest.mock import MagicMock
+from vllm.config import DeviceConfig, ModelConfig, VllmConfig
+from vllm.config.quantization import QuantizationConfigArgs, QuantSpec, resolve_quantization_config
+from vllm.config.vllm import set_current_vllm_config
+from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
+from vllm.model_executor.layers.quantization.online.base import OnlineQuantizationConfig
+from vllm.model_executor.layers.quantization.online.fp8 import Fp8PerTensorOnlineLinearMethod
+
+
+class TestPerLayerOnlineQuantization(unittest.TestCase):
+
+    def test_quantization_config_args_online_coercion(self):
+        config = QuantizationConfigArgs(
+            online={
+                "re:.*self_attn.*": "fp8_per_tensor",
+                "lm_head": "mxfp8",
+            }
+        )
+        self.assertIn("re:.*self_attn.*", config.online)
+        self.assertIsInstance(config.online["re:.*self_attn.*"], QuantSpec)
+        self.assertIn("lm_head", config.online)
+        self.assertIsInstance(config.online["lm_head"], QuantSpec)
+
+    def test_quantization_config_args_invalid_regex(self):
+        with self.assertRaises(ValueError):
+            QuantizationConfigArgs(
+                online={
+                    "re:[invalid_regex": "fp8_per_tensor",
+                }
+            )
+
+    def test_quantization_config_args_online_ignore_collision(self):
+        with self.assertRaises(ValueError):
+            QuantizationConfigArgs(
+                online={
+                    "lm_head": "fp8_per_tensor",
+                },
+                ignore=["lm_head"],
+            )
+
+    def test_resolve_quantization_config_with_online(self):
+        resolved = resolve_quantization_config(
+            quantization=None,
+            quantization_config={
+                "online": {
+                    "re:.*self_attn.*": "fp8_per_tensor",
+                }
+            },
+        )
+        self.assertIsNotNone(resolved)
+        self.assertIn("re:.*self_attn.*", resolved.online)
+
+    def test_online_quantization_config_layer_matching(self):
+        args = QuantizationConfigArgs(
+            online={
+                "re:.*self_attn.*": "fp8_per_tensor",
+            }
+        )
+        quant_config = OnlineQuantizationConfig(args)
+        linear_layer = MagicMock(spec=LinearBase)
+
+        model_config = ModelConfig(
+            model="facebook/opt-125m",
+            tokenizer="facebook/opt-125m",
+            dtype="float16",
+        )
+        device_config = DeviceConfig(device="cpu")
+        vllm_config = VllmConfig(model_config=model_config, device_config=device_config)
+
+        with set_current_vllm_config(vllm_config):
+            # Self-attention layer matching regex -> should return FP8 method
+            attn_method = quant_config.get_quant_method(linear_layer, "model.layers.0.self_attn.q_proj")
+            self.assertIsInstance(attn_method, Fp8PerTensorOnlineLinearMethod)
+
+            # MLP layer not matching regex -> should fall back to UnquantizedLinearMethod
+            mlp_method = quant_config.get_quant_method(linear_layer, "model.layers.0.mlp.gate_proj")
+            self.assertIsInstance(mlp_method, UnquantizedLinearMethod)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vllm/config/quantization.py
+++ b/vllm/config/quantization.py
@@ -3,7 +3,7 @@
 
 from typing import Annotated, Any
 
-from pydantic import Field, GetPydanticSchema, ValidationInfo, field_validator
+from pydantic import Field, GetPydanticSchema, ValidationInfo, field_validator, model_validator
 from pydantic_core import core_schema
 
 from vllm.config.utils import config
@@ -93,6 +93,34 @@ class QuantizationConfigArgs:
     ignore: list[str] = Field(default_factory=list)
     """Layers to skip quantization for."""
 
+    online: dict[str, QuantSpec | str] = Field(default_factory=dict)
+    """Per-layer online quantization configuration mapping layer patterns to QuantSpec or shorthand string."""
+
+    @field_validator("online", mode="before")
+    @classmethod
+    def _coerce_online(cls, v: Any) -> Any:
+        if not isinstance(v, dict):
+            return v
+        coerced = {}
+        for pattern, spec in v.items():
+            if pattern.startswith("re:"):
+                import re
+                try:
+                    re.compile(pattern[3:])
+                except re.error as e:
+                    raise ValueError(f"Invalid regex pattern in quantization online key {pattern!r}: {e}")
+            if isinstance(spec, str):
+                if spec in _ONLINE_SHORTHANDS:
+                    spec_val = _ONLINE_SHORTHANDS[spec].linear or _ONLINE_SHORTHANDS[spec].moe
+                    if spec_val is None:
+                        raise ValueError(f"online shorthand {spec!r} does not define a valid spec")
+                    coerced[pattern] = spec_val
+                else:
+                    coerced[pattern] = QuantSpec(weight=_coerce_quant_key(spec))
+            else:
+                coerced[pattern] = spec
+        return coerced
+
     @field_validator("linear", "moe", mode="before")
     @classmethod
     def _coerce_spec(cls, v: Any, info: ValidationInfo) -> Any:
@@ -108,6 +136,18 @@ class QuantizationConfigArgs:
                 )
             return spec
         return QuantSpec(weight=_coerce_quant_key(v))
+
+    @model_validator(mode="after")
+    def _check_online_ignore_collision(self) -> "QuantizationConfigArgs":
+        if self.online and self.ignore:
+            colliding = set(self.online.keys()) & set(self.ignore)
+            if colliding:
+                raise ValueError(
+                    f"quantization_config.online and quantization_config.ignore collide on keys: {sorted(colliding)}"
+                )
+        return self
+
+
 
 
 # CLI shorthands accepted by `--quantization`. Each desugars to a full
@@ -186,4 +226,6 @@ def resolve_quantization_config(
         linear=quantization_config.linear or base.linear,
         moe=quantization_config.moe or base.moe,
         ignore=quantization_config.ignore or base.ignore,
+        online={**(base.online if base else {}), **(quantization_config.online if quantization_config else {})},
     )
+

--- a/vllm/model_executor/layers/quantization/online/base.py
+++ b/vllm/model_executor/layers/quantization/online/base.py
@@ -23,6 +23,7 @@ from vllm.model_executor.layers.quantization.base_config import (
     QuantizeMethodBase,
 )
 from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
+    _is_equal_or_regex_match,
     should_ignore_layer,
 )
 from vllm.model_executor.layers.quantization.online.fp8 import (
@@ -85,11 +86,11 @@ class OnlineQuantizationConfig(QuantizationConfig):
         args: QuantizationConfigArgs,
     ) -> None:
         super().__init__()
-        if args.linear is None and args.moe is None:
+        if args.linear is None and args.moe is None and not args.online:
             raise ValueError(
                 "OnlineQuantizationConfig requires at least one of "
-                "quantization_config.linear or quantization_config.moe "
-                "to be set."
+                "quantization_config.linear, quantization_config.moe, or "
+                "quantization_config.online to be set."
             )
         self.args = args
         self.ignored_layers: list[str] = args.ignore
@@ -147,6 +148,21 @@ class OnlineQuantizationConfig(QuantizationConfig):
             return cls(layer=layer)
         return cls()
 
+    def _get_spec_for_layer(
+        self, prefix: str, default_spec: QuantSpec | None
+    ) -> QuantSpec | None:
+        if not self.args.online:
+            return default_spec
+        matched_spec = None
+        for pattern, spec in self.args.online.items():
+            if _is_equal_or_regex_match(prefix, pattern):
+                if matched_spec is not None and matched_spec != spec:
+                    raise ValueError(
+                        f"Layer {prefix!r} matches multiple online quantization patterns with conflicting specs."
+                    )
+                matched_spec = spec
+        return matched_spec if matched_spec is not None else default_spec
+
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str
     ) -> "QuantizeMethodBase | None":
@@ -157,7 +173,8 @@ class OnlineQuantizationConfig(QuantizationConfig):
                 fused_mapping=self.packed_modules_mapping,
             ):
                 return UnquantizedLinearMethod()
-            method = self._dispatch(self.args.linear, _ONLINE_LINEAR_METHODS, layer)
+            spec = self._get_spec_for_layer(prefix, self.args.linear)
+            method = self._dispatch(spec, _ONLINE_LINEAR_METHODS, layer)
             return method if method is not None else UnquantizedLinearMethod()
         elif isinstance(layer, RoutedExperts):
             if should_ignore_layer(
@@ -166,7 +183,8 @@ class OnlineQuantizationConfig(QuantizationConfig):
                 fused_mapping=self.packed_modules_mapping,
             ):
                 return UnquantizedFusedMoEMethod(layer.moe_config)
-            method = self._dispatch(self.args.moe, _ONLINE_MOE_METHODS, layer)
+            spec = self._get_spec_for_layer(prefix, self.args.moe)
+            method = self._dispatch(spec, _ONLINE_MOE_METHODS, layer)
             return (
                 method
                 if method is not None


### PR DESCRIPTION
## Purpose

Resolves #50281.

Currently, vLLM online quantization provides coarse-grained controls for applying quantization to `linear` and `moe` layers, requiring users to specify long exclusion lists when they want to quantize only specific layer groups.

This PR adds a fine-grained, per-layer online quantization mapping `online` to `QuantizationConfigArgs`. Keys accept exact layer names or `re:` regex patterns, and values accept online quantization shorthand names (e.g. `"fp8_per_tensor"`, `"mxfp8"`) or `QuantSpec` objects.

### Changes:
- **`vllm/config/quantization.py`**: Added `online: dict[str, QuantSpec | str]` field to `QuantizationConfigArgs`, `_coerce_online` validator for string shorthand coercion and regex syntax validation, `@model_validator` to detect key collisions between `online` and `ignore`, and updated `resolve_quantization_config`.
- **`vllm/model_executor/layers/quantization/online/base.py`**: Updated `OnlineQuantizationConfig.__init__` to allow `args.online`, added `_get_spec_for_layer(prefix, default_spec)`, and updated layer quantization method dispatching for linear and MoE layers.
- **`tests/quantization/test_per_layer_online_quantization.py`**: Added unit tests covering shorthand coercion, invalid regex validation, key collision detection, argument resolution, and per-layer regex pattern matching.

## Test Plan

Ran unit test suite:
```bash
python tests/quantization/test_per_layer_online_quantization.py
