### PR TITLE
[Test] Add coverage for rope/config helpers in transformers_utils/config.py

### DIFF
--- a/tests/transformers_utils/test_config_helpers.py
+++ b/tests/transformers_utils/test_config_helpers.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for pure config-helper utilities in transformers_utils.config.
+
+These helpers are used by model loading / RoPE setup paths but previously had
+no direct coverage. Tests use lightweight stand-ins so they run on CPU without
+downloading Hugging Face models.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from transformers.configuration_utils import ALLOWED_LAYER_TYPES
+
+from vllm.transformers_utils.config import (
+    is_rope_parameters_nested,
+    thinker_uses_mrope,
+    uses_xdrope_dim,
+)
+
+
+class FakeConfig:
+    """Minimal stand-in for transformers.PretrainedConfig."""
+
+    def __init__(self, **attrs: Any) -> None:
+        for name, value in attrs.items():
+            setattr(self, name, value)
+
+    def get_text_config(self) -> FakeConfig:
+        return getattr(self, "text_config", self)
+
+
+@pytest.mark.parametrize(
+    ("rope_parameters", "expected"),
+    [
+        ({}, False),
+        ({"full_attention": {"type": "default"}}, True),
+        (
+            {
+                "full_attention": {"type": "default"},
+                "sliding_attention": {"type": "default"},
+            },
+            True,
+        ),
+        ({"not_a_layer_type": {}}, False),
+        ({"full_attention": {}, "not_a_layer_type": {}}, False),
+        # Sanity-check against the live transformers allow-list so a
+        # future rename of a real layer type does not silently flip this.
+        ({next(iter(ALLOWED_LAYER_TYPES)): {}}, True),
+    ],
+)
+def test_is_rope_parameters_nested(rope_parameters, expected):
+    assert is_rope_parameters_nested(rope_parameters) is expected
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        (FakeConfig(), False),
+        (FakeConfig(thinker_config=FakeConfig()), False),
+        (
+            FakeConfig(
+                thinker_config=FakeConfig(
+                    text_config=FakeConfig(rope_parameters={"type": "default"})
+                )
+            ),
+            False,
+        ),
+        (
+            FakeConfig(
+                thinker_config=FakeConfig(
+                    text_config=FakeConfig(
+                        rope_parameters={"mrope_section": [16, 24, 24]}
+                    )
+                )
+            ),
+            True,
+        ),
+        (
+            FakeConfig(
+                thinker_config=FakeConfig(text_config=FakeConfig(rope_parameters=None))
+            ),
+            False,
+        ),
+    ],
+)
+def test_thinker_uses_mrope(config, expected):
+    assert thinker_uses_mrope(config) is expected
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        (FakeConfig(), 0),
+        (FakeConfig(xdrope_section=[16, 24, 24]), 3),
+        (FakeConfig(xdrope_section="not-a-list"), 0),
+        (FakeConfig(rope_scaling=None), 0),
+        (FakeConfig(rope_scaling={"type": "yarn"}), 0),
+        (FakeConfig(rope_scaling={"xdrope_section": [8, 8]}), 2),
+        (FakeConfig(rope_scaling={"xdrope_section": None}), 0),
+        (FakeConfig(rope_scaling={"xdrope_section": "bad"}), 0),
+        # Top-level xdrope_section wins over rope_scaling.
+        (
+            FakeConfig(
+                xdrope_section=[1, 2, 3, 4],
+                rope_scaling={"xdrope_section": [8, 8]},
+            ),
+            4,
+        ),
+    ],
+)
+def test_uses_xdrope_dim(config, expected):
+    assert uses_xdrope_dim(config) == expected


### PR DESCRIPTION
## Purpose

Add unit tests for three pure config-helper functions in `vllm/transformers_utils/config.py` that are used by the model-loading, RoPE-setup, and speculative-decode paths but previously had **no direct test coverage**.

- **`is_rope_parameters_nested`** — 3 call sites:
  - `vllm/transformers_utils/config.py:517` (decides whether `patch_legacy_rope_type` walks nested or flat rope params)
  - `vllm/model_executor/models/transformers/utils.py:244` (decides whether to re-wrap rope params for the torch.compile compatibility check)
  - `vllm/config/model.py:2208` (max_model_len validation path)
- **`uses_xdrope_dim`** — called from the inference hot path: `vllm/v1/worker/gpu_model_runner.py` (12 sites), `vllm/v1/spec_decode/llm_base_proposer.py` (8 sites), `vllm/v1/worker/gpu/mm/rope.py:153`. Drives whether xdRoPE position tensors are allocated and how draft/target position dims align under spec decode.
- **`thinker_uses_mrope`** — called by `uses_mrope` (`vllm/transformers_utils/config.py:559`), which gates mrope handling.

These helpers returning wrong values → incorrect model config → silent load/inference bugs (e.g. spec-decode position misalignment producing garbage output without raising). Zero tests meant no regression net.

## What the tests cover

Parametrized cases for each branch of every helper:

- `is_rope_parameters_nested`: empty dict (short-circuits to `False`), all keys in `ALLOWED_LAYER_TYPES`, mixed keys, no valid keys, plus a sanity-check anchored to the live transformers allow-list
- `thinker_uses_mrope`: no `thinker_config`, thinker without `text_config`, thinker with/without `mrope_section`
- `uses_xdrope_dim`: no config, top-level `xdrope_section` (list), nested in `rope_scaling`, type-mismatched values (`None`/`str`), and top-level-wins-over-nested precedence

Tests use a lightweight `FakeConfig` stand-in (duck-typed `get_text_config`) so they run on **CPU without downloading Hugging Face models**.

## Test Plan

```bash
.venv/bin/python -m pytest tests/transformers_utils/test_config_helpers.py -v
```

## Test Result

```
20 passed in 2.14s
```

All tests run on Apple Silicon (M4) CPU backend — no GPU required.

## Not Duplicating Existing Work

Checked before submitting:
- `gh pr list --state all --search "is_rope_parameters_nested test"` — no PR adds tests for these helpers.
- `gh pr list --state all --search "uses_xdrope_dim test"` / `"thinker_uses_mrope test"` — none.
- `tests/transformers_utils/test_config.py` only covers `try_get_generation_config`; `test_utils.py` only covers cloud-storage URL helpers. Neither file touches these helpers.

## AI Assistance Disclosure

This PR was prepared with AI assistance (ZCode agent). I (the human submitter) have reviewed every line of the test file, validated each assertion against the source in `vllm/transformers_utils/config.py`, and run the tests end-to-end on my machine. The commit uses `Co-authored-by` per `AGENTS.md`.

(Note: `is_interleaved` was originally included but was removed from `vllm/transformers_utils/config.py` by #49803 during the course of this work, so it is not covered here.)