### PR TITLE
[Bugfix] Stop mamba align prefill at the replay boundary

### DIFF
--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -75,6 +75,34 @@ def test_mamba_align_split_partial_tail_schedule():
     assert split(self=mock, request=req2, num_new_tokens=1000) == 512
 
 
+def test_mamba_align_split_stops_at_replay_boundary():
+    """A prompt whose length is an exact multiple of block_size still gets a
+    chunk end one block below it. Otherwise the only cached Mamba state sits
+    at num_tokens, one token above the cache-hit cap (num_tokens - 1), and a
+    later request replaying the prompt misses the prefix cache entirely."""
+    block_size = 512
+    hash_block_size = 32
+    mock = SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=block_size),
+        use_eagle=False,
+        hash_block_size=hash_block_size,
+        mamba_partial_cache_hit=True,
+    )
+    split = Scheduler._mamba_block_aligned_split
+
+    req = make_request("0", [0] * 4096, hash_block_size, sha256)
+    req.num_computed_tokens = 0
+    assert split(self=mock, request=req, num_new_tokens=4096) == 3584
+    req.num_computed_tokens = 3584
+    assert split(self=mock, request=req, num_new_tokens=512) == 512
+
+    # One token more: the replay boundary is the last block boundary already,
+    # so the chunking is unchanged.
+    req2 = make_request("1", [0] * 4097, hash_block_size, sha256)
+    req2.num_computed_tokens = 0
+    assert split(self=mock, request=req2, num_new_tokens=4097) == 4096
+
+
 def test_hybrid_mamba_align_partial_hash_hit():
     hash_block_size = 2
     mamba_block_size = 2 * hash_block_size

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -394,6 +394,14 @@ class Scheduler(SchedulerInterface):
             end = end // block_size * block_size
 
         next_block_boundary = (start // block_size + 1) * block_size
+        # A later request replaying this prompt resumes at `num_tokens - 1` at
+        # the latest (`get_computed_blocks` caps the hit there), so the block
+        # boundary at or below that must be a chunk end too: when `num_tokens`
+        # is an exact multiple of `block_size` the only state cached below it
+        # would otherwise sit one token above the cap, missing entirely.
+        replay_boundary = min(
+            (request.num_tokens - 1) // block_size * block_size, last_cache_position
+        )
         tail_boundary = (
             request.num_prompt_tokens // self.hash_block_size * self.hash_block_size
             if self.mamba_partial_cache_hit
@@ -408,6 +416,8 @@ class Scheduler(SchedulerInterface):
             else 0,
             # Never run past the last cacheable block boundary mid-chunk.
             last_cache_position,
+            # Keep the boundary a replay of this prompt can resume from.
+            replay_boundary,
             # Fine-grained hits: the prompt's partial-tail entry can only be
             # registered by a chunk ending exactly at its last hash boundary.
             tail_boundary


### PR DESCRIPTION
Fixes #50235

`_mamba_block_aligned_split` picks its mandatory chunk stops from `last_cache_position =
num_tokens - num_tokens % block_size`. When the prompt length is an exact multiple of the block
size that is `num_tokens` itself, so the prefill runs as a single chunk and, in `align` mode where
SSM state only materializes at chunk ends, the only Mamba state cached sits at `num_tokens`.
`get_computed_blocks` caps every lookup at `num_tokens - 1`, one token below it, so the Mamba group
reports a 0-token hit and the reconciled hybrid hit is 0 even though full attention has the whole
prefix.

The patch adds the replay boundary, `(num_tokens - 1) // block_size * block_size`, as another
mandatory stop. It is clamped to `last_cache_position`, so it only differs from an existing stop
when `num_tokens % block_size == 0`, and it is always a duplicate under eagle (which already backs
`last_cache_position` off by a block). Cost is one extra scheduling step for prompts whose length is
an exact multiple of the block size.

Verified on CPU only, driving a real `Scheduler` with a full attention + Mamba `align` KV cache
config (block 16, prefix caching on, no connector): a producer prompt of 32 tokens followed by the
same 32-token prompt went from a 0-token local prefix hit to 16, and 48 -> 48 went from 0 to 32.
Producer lengths 31 and 33 were already fine and are unchanged, and `mamba_cache_mode="all"` is
unaffected. A sweep over producer lengths 1-66, consumer lengths P, P+1, P+2, block/hash sizes
16/16 and 16/4, both cache modes, two token budgets and two pool sizes shows no other change.

Tests run:
- `tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py` -> 18 passed. The new test
  `test_mamba_align_split_stops_at_replay_boundary` fails with the scheduler change reverted
  (`assert 4096 == 3584`).
- `tests/v1/core/test_prefix_caching.py`, `tests/v1/core/test_single_type_kv_cache_manager.py`,
  `tests/v1/core/test_kv_cache_utils.py`, `tests/v1/core/prefix_cache/` -> 198 passed, 1 failure
  that only reproduces with `VLLM_LOGGING_LEVEL=ERROR` set (a caplog assertion) and passes without it.
- `tests/v1/core/test_scheduler.py` -> 136 passed, 1 failure
  (`test_async_scheduling_pp_allows_rescheduling_with_output_placeholders`) that reproduces on a
  clean tree.
- `ruff check` and `ruff format --check` clean on both changed files.

Not verified: nothing here ran on a real Kimi-K3 deployment, on 8x TP, with fp8 KV cache, or with
the `OffloadingConnector`, so no model eval is included. The change only moves a chunk boundary and
does not touch what is computed, so model output is unchanged by construction.

One caveat on the reported reproduction. Rows 1 and 4 of the table in the issue reproduce exactly.
Rows 2 and 3 (producer 3072, consumer 3073 / 3074) do not: a consumer of `P+1` tokens has a lookup
cap of exactly `P`, so it still reaches the state at `P` both before and after this patch. The case
I do reproduce has the same trigger, a producer whose prompt length is an exact multiple of the
block size, with the consumer's cap landing below that boundary. There may be a second cause behind
rows 2 and 3 that this patch does not address.

Thanks to the reporter for the length table, which is what made the boundary condition obvious.

AI assistance was used to investigate and write this change.

Duplicate check: no open PR references #50235. Two open PRs do touch
`_mamba_block_aligned_split` and neither covers this. #45477 fixes the eagle prune zeroing
`last_cache_position` on short prompts, which lets chunk ends drift off the block grid and poisons
the cache under spec decode; that is a correctness bug on a different branch of the same function.
#48815 adds an opt-in MTP retention tweak behind `VLLM_MAMBA_ALIGN_RETAIN_MTP_CACHE_BLOCK` and
explicitly leaves prompts ending exactly at a block boundary on the existing eagle backoff. This
change is on the non-eagle path and adds a stop that neither PR adds.