### PR TITLE
Update torch version to 2.13.0+cpu

### DIFF
--- a/requirements/build/tpu.txt
+++ b/requirements/build/tpu.txt
@@ -4,5 +4,5 @@ ninja
 setuptools>=77.0.3,<81.0.0
 setuptools-scm>=8
 setuptools-rust>=1.9.0
-torch==2.11.0+cpu
+torch==2.13.0+cpu
 wheel


### PR DESCRIPTION
## Purpose
Update the torch version from 2.11.0+cpu to 2.13.0+cpu in requirements/build/tpu.txt to fix the vllm-tpu wheel build failure caused by missing dependency torch==2.13.0

reference PR: https://github.com/vllm-project/vllm/pull/48155 

## Test Plan
1. Build vllm-tpu package locally
2. Verify the built wheel by launching the server

## Test Result

vllm-tpu built successfully, and the vLLM server started without issues.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

