### PR TITLE
Test W8A8 block INT8 matmul with INT8 inputs

### DIFF
--- a/tests/kernels/quantization/test_block_int8.py
+++ b/tests/kernels/quantization/test_block_int8.py
@@ -40,13 +40,13 @@ def test_w8a8_block_int8_matmul(M, N, K, block_size, out_dtype, seed):
     int8_info = torch.iinfo(torch.int8)
     int8_max, int8_min = int8_info.max, int8_info.min
 
-    A_fp32 = torch.rand(M, K, dtype=torch.float32, device=device)
-    A_fp32 = (A_fp32 - 0.5) * 2 * int8_max
-    A_fp8 = A_fp32.clamp(min=int8_min, max=int8_max).to(torch.float8_e4m3fn)
+    A_int8 = torch.randint(
+        int8_min, int8_max + 1, (M, K), dtype=torch.int16, device=device
+    ).to(torch.int8)
 
-    B_fp32 = torch.rand(N, K, dtype=torch.float32, device=device)
-    B_fp32 = (B_fp32 - 0.5) * 2 * int8_max
-    B_fp8 = B_fp32.clamp(min=int8_min, max=int8_max).to(torch.float8_e4m3fn)
+    B_int8 = torch.randint(
+        int8_min, int8_max + 1, (N, K), dtype=torch.int16, device=device
+    ).to(torch.int8)
 
     block_n, block_k = block_size[0], block_size[1]
     n_tiles = (N + block_n - 1) // block_n
@@ -58,8 +58,8 @@ def test_w8a8_block_int8_matmul(M, N, K, block_size, out_dtype, seed):
         * factor_for_scale
     )
 
-    ref_out = native_w8a8_block_matmul(A_fp8, B_fp8, As, Bs, block_size, out_dtype)
-    out = w8a8_block_int8_matmul(A_fp8, B_fp8, As, Bs, block_size, out_dtype)
+    ref_out = native_w8a8_block_matmul(A_int8, B_int8, As, Bs, block_size, out_dtype)
+    out = w8a8_block_int8_matmul(A_int8, B_int8, As, Bs, block_size, out_dtype)
 
     rel_diff = torch.mean(
         torch.abs(out.to(torch.float32) - ref_out.to(torch.float32))

--- a/vllm/model_executor/layers/quantization/utils/int8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/int8_utils.py
@@ -320,10 +320,10 @@ def get_w8a8_block_int8_configs(
     N: int, K: int, block_n: int, block_k: int
 ) -> dict[int, Any] | None:
     """
-    Return optimized configurations for the w8a8 block fp8 kernel.
+    Return optimized configurations for the w8a8 block INT8 kernel.
 
     The return value will be a dictionary that maps an irregular grid of
-    batch sizes to configurations of the w8a8 block fp8 kernel. To evaluate the
+    batch sizes to configurations of the w8a8 block INT8 kernel. To evaluate the
     kernel on a given batch size bs, the closest batch size in the grid should
     be picked and the associated configuration chosen to invoke the kernel.
     """
@@ -368,7 +368,7 @@ def w8a8_block_int8_matmul(
     """This function performs matrix multiplication with block-wise
     quantization.
 
-    It takes two input tensors `A` and `B` with scales `As` and `Bs`.
+    It takes two INT8 input tensors `A` and `B` with scales `As` and `Bs`.
     The output is returned in the specified `output_dtype`.
 
     Args:


### PR DESCRIPTION
Refs #50143.

## Purpose

This PR updates the W8A8 block INT8 matmul kernel test to use real `torch.int8` inputs instead of FP8 tensors.

The helper is named and configured as an INT8 block-scaled matmul, but the existing test generated FP8 A/B tensors. Using INT8 inputs makes the test cover the path it is intended to validate.

This PR also fixes stale block-INT8 docstrings that referred to the FP8 kernel.

## Test Plan

- `python -m ruff check tests/kernels/quantization/test_block_int8.py vllm/model_executor/layers/quantization/utils/int8_utils.py`
- `python -m pytest tests/kernels/quantization/test_block_int8.py -q`

## Test Result

- `ruff`: passed
- `pytest tests/kernels/quantization/test_block_int8.py -q`: 32 passed