### PR TITLE
[Bugfix][Core] Serialize MessageQueue dequeue across threads

### DIFF
--- a/tests/distributed/test_shm_broadcast.py
+++ b/tests/distributed/test_shm_broadcast.py
@@ -6,6 +6,7 @@ import pickle
 import random
 import threading
 import time
+from contextlib import contextmanager, suppress
 from types import SimpleNamespace
 from unittest import mock
 
@@ -600,6 +601,71 @@ def test_reader_rechecks_shm_after_idle_wait_timeout_without_notify():
             reader._spin_condition.write_cancel_socket,
         ):
             socket.close(linger=0)
+
+
+def test_dequeue_serializes_concurrent_consumers():
+    """Concurrent consumers must not race the reader cursor or duplicate slots."""
+    writer = MessageQueue(
+        n_reader=1,
+        n_local_reader=1,
+        max_chunk_bytes=1024 * 1024,
+        max_chunks=2,
+    )
+    reader = MessageQueue.create_from_handle(writer.export_handle(), rank=0)
+    metadata_barrier = threading.Barrier(2)
+    data_barrier = threading.Barrier(2)
+    received = []
+    errors = []
+
+    original_get_metadata = reader.buffer.get_metadata
+    original_get_data = reader.buffer.get_data
+
+    @contextmanager
+    def synchronized_get_metadata(current_idx):
+        with original_get_metadata(current_idx) as metadata_buffer:
+            with suppress(threading.BrokenBarrierError):
+                metadata_barrier.wait(timeout=0.1)
+            yield metadata_buffer
+
+    @contextmanager
+    def synchronized_get_data(current_idx):
+        with original_get_data(current_idx) as data_buffer:
+            with suppress(threading.BrokenBarrierError):
+                data_barrier.wait(timeout=0.1)
+            yield data_buffer
+
+    def consume_one():
+        try:
+            received.append(reader.dequeue(timeout=1))
+        except Exception as exc:
+            errors.append(exc)
+
+    try:
+        writer.wait_until_ready()
+        reader.wait_until_ready()
+        writer.enqueue(0)
+        writer.enqueue(1)
+
+        with (
+            mock.patch.object(
+                reader.buffer, "get_metadata", side_effect=synchronized_get_metadata
+            ),
+            mock.patch.object(
+                reader.buffer, "get_data", side_effect=synchronized_get_data
+            ),
+        ):
+            threads = [threading.Thread(target=consume_one) for _ in range(2)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join(timeout=2)
+
+        assert all(not thread.is_alive() for thread in threads)
+        assert not errors
+        assert sorted(received) == [0, 1]
+    finally:
+        writer.shutdown()
+        reader.shutdown()
 
 
 def test_acquire_read_releases_slot_when_reader_raises():

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -482,6 +482,9 @@ class MessageQueue:
         n_remote_reader = n_reader - n_local_reader
         self.n_remote_reader = n_remote_reader
         self.shutting_down = False
+        # Protect per-reader cursor and socket state when dequeue is called
+        # concurrently from multiple threads.
+        self._dequeue_lock = threading.Lock()
         context = Context()
 
         if n_local_reader > 0:
@@ -603,6 +606,7 @@ class MessageQueue:
             self._spin_condition = None  # type: ignore
 
         self.shutting_down = False
+        self._dequeue_lock = threading.Lock()
         return self
 
     def wait_until_ready(self):
@@ -885,27 +889,40 @@ class MessageQueue:
         timeout: float | None = None,
         indefinite: bool = False,
     ):
-        """Read from message queue with optional timeout (in seconds)"""
-        if self._is_local_reader:
-            with self.acquire_read(timeout, indefinite) as buf:
-                overflow = buf[0] == 1
-                if not overflow:
-                    offset = 3
-                    buf_count = from_bytes_big(buf[1:offset])
-                    all_buffers = []
-                    for i in range(buf_count):
-                        buf_offset = offset + 4
-                        buf_len = from_bytes_big(buf[offset:buf_offset])
-                        offset = buf_offset + buf_len
-                        all_buffers.append(buf[buf_offset:offset])
-                    obj = pickle.loads(all_buffers[0], buffers=all_buffers[1:])
-            if overflow:
-                obj = MessageQueue.recv(self.local_socket, timeout)
-        elif self._is_remote_reader:
-            obj = MessageQueue.recv(self.remote_socket, timeout)
-        else:
-            raise RuntimeError("Only readers can dequeue")
-        return obj
+        """Read from message queue with optional timeout (in seconds).
+
+        Dequeue is serialized per reader because the ring-buffer cursor and
+        receive sockets are shared mutable state.
+        """
+        if not self._dequeue_lock.acquire(blocking=False):
+            if timeout is None:
+                self._dequeue_lock.acquire()
+            elif not self._dequeue_lock.acquire(timeout=max(0, timeout)):
+                raise TimeoutError
+
+        try:
+            if self._is_local_reader:
+                with self.acquire_read(timeout, indefinite) as buf:
+                    overflow = buf[0] == 1
+                    if not overflow:
+                        offset = 3
+                        buf_count = from_bytes_big(buf[1:offset])
+                        all_buffers = []
+                        for i in range(buf_count):
+                            buf_offset = offset + 4
+                            buf_len = from_bytes_big(buf[offset:buf_offset])
+                            offset = buf_offset + buf_len
+                            all_buffers.append(buf[buf_offset:offset])
+                        obj = pickle.loads(all_buffers[0], buffers=all_buffers[1:])
+                if overflow:
+                    obj = MessageQueue.recv(self.local_socket, timeout)
+            elif self._is_remote_reader:
+                obj = MessageQueue.recv(self.remote_socket, timeout)
+            else:
+                raise RuntimeError("Only readers can dequeue")
+            return obj
+        finally:
+            self._dequeue_lock.release()
 
     @staticmethod
     def recv(socket: zmq.Socket, timeout: float | None) -> Any:


### PR DESCRIPTION
## Summary

Fixes #50398.

`MessageQueue.dequeue()` mutates per-reader state (`current_idx`) and may also receive from a shared SUB socket. If two threads call `dequeue()` on the same reader concurrently, both can capture metadata for the same ring-buffer slot before either advances the cursor. One thread can then advance `current_idx` while the other keeps observing stale metadata, leading to a timeout/block; if both reach the data path together they can also consume the same slot twice.

This change serializes each reader's dequeue transaction with a per-instance lock. The uncontended path uses a non-blocking acquire first, so the usual single-consumer path does not pay the more expensive timed-lock acquisition. If there is contention and a finite `timeout` was supplied, the same timeout also bounds waiting for the dequeue lock.

The lock covers the full dequeue transaction rather than only `current_idx`: overflow and remote-reader paths share ZMQ receive sockets, which should not be consumed concurrently either.

## Duplicate-work check

Before opening the PR I checked the live issue and open PRs for `#50398`, `MessageQueue.dequeue`, and concurrent/multi-threaded MessageQueue fixes. The issue was open, unassigned, had no comments, and there was no competing open PR addressing this race.

## Regression coverage

The new test deliberately forces two consumer threads to capture the same metadata/data slot on the pre-fix implementation.

On unmodified `main` the test fails deterministically with duplicate consumption:

```text
assert sorted(received) == [0, 1]
E assert [0, 0] == [0, 1]
```

With this patch:

```text
1 passed
```

## Test plan

Project hooks on the changed files:

```bash
.venv/bin/pre-commit run --files \
  vllm/distributed/device_communicators/shm_broadcast.py \
  tests/distributed/test_shm_broadcast.py
```

All applicable hooks passed, including Ruff check/format, typos, mypy, SPDX, forbidden-import checks, and project validators.

CPU MessageQueue suite:

```bash
.venv/bin/python -m pytest tests/distributed/test_shm_broadcast.py \
  -q --confcutdir=tests/distributed \
  -k 'not test_message_queue_shutdown_busy and not test_warning_logs'
```

Result:

```text
26 passed, 1 skipped, 2 deselected
```

The two deselected tests use the repo-wide `caplog_vllm` fixture; the modified concurrency path and the surrounding SHM/timeout/tensor tests all ran in the local CPU environment.

Note: the documented `VLLM_USE_PRECOMPILED=1 uv pip install -e . --torch-backend=auto` setup could not complete on this x86_64 WSL host because the current nightly metadata for this commit only exposed an aarch64 precompiled wheel. The tests above used an `uv`-managed `.venv` with CPU Torch and the project Python dependencies and imported the checkout directly.

## Microbenchmark

Real `MessageQueue`, one writer thread + one local reader thread, 30,000 tiny integer messages, 7 runs per checkout. This intentionally exaggerates per-message synchronization overhead.

```text
main median:    0.859062 s  (~34,922 msg/s)
patched median: 0.864040 s  (~34,721 msg/s)
delta:          +0.58% elapsed / -0.58% throughput
```

That is within run-to-run noise on this host; no material uncontended-path regression was observed.

## AI assistance disclosure

AI assistance (ChatGPT) was used during investigation, implementation drafting, test construction, and benchmark preparation. The commit includes an `Assisted-by: ChatGPT` trailer. The behavior was validated against current `main` with a deterministic fail-before/pass-after regression test, the surrounding CPU MessageQueue tests, project pre-commit hooks, and an A/B microbenchmark.
