### PR TITLE
[CPU][BugFix] Remove redundant kv cache write

### DIFF
--- a/.buildkite/scripts/hardware_ci/run-cpu-test-arm.sh
+++ b/.buildkite/scripts/hardware_ci/run-cpu-test-arm.sh
@@ -56,10 +56,11 @@ function cpu_tests() {
     set -e
     python3 examples/basic/offline_inference/generate.py --model facebook/opt-125m"
 
-  # Run model tests
+  # Test encoder-decoder and encoder-only models
   docker exec cpu-test bash -c "
     set -e
-    pytest -x -v -s tests/models/multimodal/generation/test_whisper.py -m cpu_model"
+    pytest -x -v -s tests/models/multimodal/generation/test_whisper.py -m cpu_model
+    pytest -x -v -s 'tests/models/language/pooling/test_embedding.py::test_models[sentence-transformers/all-MiniLM-L12-v2]'"
 
   # Run quantized model tests
   docker exec cpu-test bash -c "

--- a/tests/kernels/attention/test_cpu_attn.py
+++ b/tests/kernels/attention/test_cpu_attn.py
@@ -686,6 +686,7 @@ def test_varlen_encoder_attention_vec(
         isa=isa,
     )
 
+
 @pytest.mark.parametrize("seq_lens", ENCODER_SEQ_LENS)
 @pytest.mark.parametrize("num_heads", NUM_HEADS)
 @pytest.mark.parametrize("head_size", HEAD_SIZES)
@@ -720,6 +721,7 @@ def test_varlen_encoder_attention_neon(
         block_size=block_size,
         isa=isa,
     )
+
 
 @pytest.mark.parametrize("seq_lens", ENCODER_SEQ_LENS)
 @pytest.mark.parametrize("num_heads", NUM_HEADS)

--- a/tests/kernels/attention/test_cpu_attn.py
+++ b/tests/kernels/attention/test_cpu_attn.py
@@ -686,6 +686,40 @@ def test_varlen_encoder_attention_vec(
         isa=isa,
     )
 
+@pytest.mark.parametrize("seq_lens", ENCODER_SEQ_LENS)
+@pytest.mark.parametrize("num_heads", NUM_HEADS)
+@pytest.mark.parametrize("head_size", HEAD_SIZES)
+@pytest.mark.parametrize(
+    "block_size",
+    [
+        128,
+    ],
+)
+@pytest.mark.parametrize("sliding_window", SLIDING_WINDOWS)
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("isa", ["neon"])
+@pytest.mark.skipif(
+    current_platform.get_cpu_architecture() != CpuArchEnum.ARM,
+    reason="Not an Arm CPU.",
+)
+def test_varlen_encoder_attention_neon(
+    seq_lens: list[int],
+    num_heads: tuple[int, int],
+    head_size: int,
+    sliding_window: int | None,
+    dtype: torch.dtype,
+    block_size: int,
+    isa: str,
+) -> None:
+    varlen_encoder_attention(
+        seq_lens=seq_lens,
+        num_heads=num_heads,
+        head_size=head_size,
+        sliding_window=sliding_window,
+        dtype=dtype,
+        block_size=block_size,
+        isa=isa,
+    )
 
 @pytest.mark.parametrize("seq_lens", ENCODER_SEQ_LENS)
 @pytest.mark.parametrize("num_heads", NUM_HEADS)

--- a/vllm/v1/attention/backends/cpu_attn.py
+++ b/vllm/v1/attention/backends/cpu_attn.py
@@ -350,8 +350,11 @@ class CPUAttentionBackendImpl(AttentionImpl):
 
         num_actual_tokens = attn_metadata.num_actual_tokens
 
-        # For encoder attention
-        if self.attn_type in (AttentionType.ENCODER_ONLY, AttentionType.ENCODER):
+        is_encoder_attention = self.attn_type in (
+            AttentionType.ENCODER_ONLY,
+            AttentionType.ENCODER,
+        )
+        if is_encoder_attention:
             # For encoder attention,
             kv_cache = attn_metadata.encoder_cache
 
@@ -362,14 +365,7 @@ class CPUAttentionBackendImpl(AttentionImpl):
         kv_cache = kv_cache.view((num_blocks, num_kv_heads, block_size * 2, -1))
         key_cache, value_cache = kv_cache.chunk(2, dim=2)
 
-        # key and value may be None in the case of cross attention. They are
-        # calculated once based on the output from the encoder and then cached
-        # in KV cache.
-        if (
-            self.kv_sharing_target_layer_name is None
-            and key is not None
-            and value is not None
-        ):
+        if is_encoder_attention:
             ops.cpu_attn_reshape_and_cache(
                 key,
                 value,


### PR DESCRIPTION
## Purpose

While profiling some LLMs, I noticed that `cpu_attn_reshape_and_cache` gets called twice for each invocation of the attention kernel for causal and cross attention.

Since https://github.com/vllm-project/vllm/pull/40470 - the kv write, for causal and cross attention is done by the caller (CPUAttentionBackend.do_kv_cache_update) - `forward_includes_kv_cache_update` is set to false

We now only run `cpu_attn_reshape_and_cache` in the forward method for encoder-only models - it's needed here for us to reuse the existing attention kernel for encoder attention

This PR also adds some encoder/embedding tests for Arm CPUs

## Test Plan

Tested locally, we also have end to end tests in CI for encoder-only, encoder-decoder and decoder-only models 

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [Y] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [Y] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

