### PR TITLE
[Bugfix][Compile] Preserve independent input strides in piecewise create_concrete_args

### DIFF
--- a/vllm/compilation/piecewise_backend.py
+++ b/vllm/compilation/piecewise_backend.py
@@ -51,6 +51,46 @@ def create_concrete_args(graph: fx.GraphModule, size: int) -> list[Any]:
         expr = sym_val.node.expr
         return int(expr.subs({s: size for s in expr.free_symbols}))
 
+    def concretize_layout(sym_val: Any, size_symbols: set) -> int:
+        """Concretize a stride/storage-offset expression for single-size compile.
+
+        Symbols that appear in the tensor's shape (the dynamic size dim) are
+        specialized to ``size``. Any other symbol -- e.g. a persistent-buffer
+        row pitch that is independent of the token count, as in the sliced
+        M-RoPE positions buffer -- must be a value that is constant for this
+        specialization, so we bind it to its backed value; the compiled graph
+        then asserts the true input stride instead of a fabricated contiguous
+        one.
+
+        A non-size stride/offset symbol with no backed value is not amenable to
+        single-size specialization; we fail loudly rather than guess (guessing
+        the compile ``size`` is exactly the bug this replaces).
+        """
+        if not is_symbolic(sym_val):
+            return int(sym_val)
+        node = sym_val.node
+        expr = node.expr
+        shape_env = node.shape_env
+        var_to_val = getattr(shape_env, "backed_var_to_val", None)
+        if var_to_val is None:
+            var_to_val = shape_env.var_to_val
+        subs: dict[Any, int] = {}
+        for s in expr.free_symbols:
+            if s in size_symbols:
+                subs[s] = size
+                continue
+            hint = var_to_val.get(s)
+            if hint is None:
+                raise RuntimeError(
+                    "Cannot statically concretize input stride/offset for "
+                    f"single-size compilation (size={size}): symbol '{s}' in "
+                    f"'{expr}' is independent of the input shape and has no "
+                    "backed value, so it cannot be specialized to a constant. "
+                    "This input is not amenable to single-size compilation."
+                )
+            subs[s] = int(hint)
+        return int(expr.subs(subs))
+
     fake_mode = FakeTensorMode(shape_env=ShapeEnv())
 
     args: list[Any] = []
@@ -63,8 +103,16 @@ def create_concrete_args(graph: fx.GraphModule, size: int) -> list[Any]:
                 args.append(concretize(val))
             elif isinstance(val, torch.Tensor):
                 new_shape = tuple(concretize(d) for d in val.shape)
-                new_strides = tuple(concretize(s) for s in val.stride())
-                new_storage_offset = concretize(val.storage_offset())
+                size_symbols: set = set()
+                for d in val.shape:
+                    if is_symbolic(d):
+                        size_symbols |= d.node.expr.free_symbols
+                new_strides = tuple(
+                    concretize_layout(s, size_symbols) for s in val.stride()
+                )
+                new_storage_offset = concretize_layout(
+                    val.storage_offset(), size_symbols
+                )
                 needed_size = compute_required_storage_length(
                     new_shape, new_strides, new_storage_offset
                 )


### PR DESCRIPTION
## Summary

Fixes #50046. On torch 2.13, `Qwen/Qwen3.5-397B-A17B-FP8` (and other Qwen3-Next GDN models) crash during CUDA-graph warmup with:

```
assert_size_stride(arg17_1, (3, 512), (512, 1), 'input')
AssertionError: expected size 3==3, stride 4097==512 at dim=0
```

`--enforce-eager` avoids it. The crash is provably not triton (3.6.0 still fails), not Inductor comprehensive-padding (`TORCHINDUCTOR_COMPREHENSIVE_PADDING=0` doesn't help), and not fixed by reverting the candidate torch PRs discussed on the issue — because the defect is in vLLM.

## Root cause

`arg17_1` is the **M-RoPE positions tensor**. It is allocated as a persistent `(3, max_num_tokens + 1)` buffer (`gpu_model_runner.py`, the intentional `+1` from #12128) and fed to the compiled model as the slice `mrope_positions[:, :n]`, so its row-pitch stride is `max_num_tokens + 1 = 4097` — independent of the token count. The `3` is the T/H/W rope sections.

For single-size piecewise compilation, `create_concrete_args` in `vllm/compilation/piecewise_backend.py` concretized **every** symbol in an input's strides/storage-offset to the compile `size`. That collapses the independent `4097` pitch to `size` (e.g. `512`), fabricating a contiguous `(512, 1)` example input. Inductor faithfully bakes a stride guard for `(512, 1)`, which the real `(4097, 1)` runtime slice then trips at warmup.

This is latent before torch 2.13. torch 2.13 represents that pitch as a *symbolic* stride (2.11 kept it concrete), so the mis-concretization only bites on 2.13 — which is why reverting individual torch PRs does not recover it. It only surfaces with block-scale FP8 GDN models, where the FP8 DeepGEMM splitting ops make the RoPE gather a piecewise-partition input.

## Fix

Specialize only the **size** symbols (those appearing in the tensor's `shape`) to `size`; keep other stride/offset symbols at their real value from the shape env. The compiled graph then asserts the true `(4097, 1)` input stride.

This corrects what the graph *expects* rather than mutating the runtime tensor, so it stays **CUDA-graph safe**. (Forcing `.contiguous()` on the positions instead is not a valid fix: it clears the assert but breaks CUDA-graph replay — a fresh non-persistent tensor breaks the captured-address contract, giving an out-of-bounds RoPE gather.)

## Testing

- Repro: `Qwen/Qwen3.5-397B-A17B-FP8`, TP=8, 8×H100, torch 2.13, block-scale FP8 + DeepGEMM env (`VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER=1`, `VLLM_USE_DEEP_GEMM=1`, `VLLM_MOE_USE_DEEP_GEMM=0`, `VLLM_USE_DEEP_GEMM_E8M0=1`), compile + piecewise/full cudagraph, `enforce_eager=False`.
  - **Before:** crashes at warmup with the assertion above.
  - **After:** warmup + CUDA-graph capture + real text generation all succeed, no crash. Verified twice.
- Ruled out as non-fixes (by direct runs on the same setup): triton 3.6.0; `TORCHINDUCTOR_COMPREHENSIVE_PADDING=0`; reverting torch PRs #179919 / #184004 / #180197 / #184519.
- Lint: `ruff check` and `ruff format` clean.

## Model evaluation

No accuracy impact expected for previously-working models: for inputs whose strides were already concrete/correct, this changes nothing; it only replaces a fabricated contiguous stride with the true one. The repro generates coherent output post-fix. Happy to run a full `lm-eval` if a reviewer would like one.

## Not a duplicate

No open PR references #50046 or touches `create_concrete_args` / piecewise stride handling (checked).

---

AI assistance (Claude) was used to investigate the root cause and draft this change and description; I reviewed every changed line and ran the tests above.
