### PR TITLE
[ROCm] Unify ViT FlashAttention backend selection

### DIFF
--- a/tests/v1/attention/test_rocm_attention_backends_selection.py
+++ b/tests/v1/attention/test_rocm_attention_backends_selection.py
@@ -345,3 +345,67 @@ def test_sparse_not_supported(mock_vllm_config):
         RocmPlatform.get_attn_backend_cls(
             selected_backend=None, attn_selector_config=attn_selector_config
         )
+
+
+_TRITON_HINT = (
+    "Set FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE to enable "
+    "Flash Attention Triton backend on ROCm."
+)
+_FLASH_ATTN_LOG = "Using Flash Attention backend for ViT model."
+
+
+@pytest.mark.parametrize(
+    "is_cdna, available, triton_env, expected_info",
+    [
+        (False, True, None, (_FLASH_ATTN_LOG, _TRITON_HINT)),
+        (True, True, "TRUE", (_FLASH_ATTN_LOG,)),
+        (False, False, None, ()),
+    ],
+    ids=[
+        "available",
+        "triton-enabled",
+        "unavailable",
+    ],
+)
+def test_vit_flash_attn_selection(
+    is_cdna,
+    available,
+    triton_env,
+    expected_info,
+    monkeypatch,
+):
+    """Test ViT FlashAttention selection across ROCm architectures."""
+    from vllm.platforms.rocm import RocmPlatform
+
+    if triton_env is None:
+        monkeypatch.delenv("FLASH_ATTENTION_TRITON_AMD_ENABLE", raising=False)
+    else:
+        monkeypatch.setenv("FLASH_ATTENTION_TRITON_AMD_ENABLE", triton_env)
+
+    with (
+        patch("vllm.platforms.rocm.on_cdna", return_value=is_cdna),
+        patch("vllm.platforms.rocm.on_rdna", return_value=not is_cdna),
+        patch("vllm._aiter_ops.rocm_aiter_ops.is_mha_enabled", return_value=False),
+        patch(
+            "vllm.v1.attention.backends.fa_utils.is_flash_attn_varlen_func_available",
+            return_value=available,
+        ),
+        patch("vllm.platforms.rocm.logger.info_once") as mock_info,
+        patch("vllm.platforms.rocm.logger.warning_once") as mock_warning,
+    ):
+        backend = RocmPlatform.get_vit_attn_backend(128, torch.float16)
+
+    expected_backend = (
+        AttentionBackendEnum.FLASH_ATTN
+        if available
+        else AttentionBackendEnum.TORCH_SDPA
+    )
+    assert backend == expected_backend
+    assert tuple(call.args[0] for call in mock_info.call_args_list) == expected_info
+    if available:
+        mock_warning.assert_not_called()
+    else:
+        mock_warning.assert_called_once_with(
+            "Flash Attention is unavailable for ViT attention. "
+            "Falling back to Torch SDPA."
+        )

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -406,40 +406,6 @@ def use_rocm_custom_paged_attention(
         )
 
 
-@cache
-def flash_attn_triton_available() -> bool:
-    if not on_gfx1x():
-        return False
-    try:
-        from importlib.util import find_spec
-
-        # Locate the Triton-AMD kernels. Older ROCm/flash-attention (pre
-        # 2026-03) shipped them as the flash_attn.flash_attn_triton_amd
-        # subpackage. The main_perf migration commit 3f94643 moved them
-        # into aiter at aiter.ops.triton._triton_kernels.flash_attn_triton_amd,
-        # so accept either location.
-        def _has_spec(name: str) -> bool:
-            try:
-                return find_spec(name) is not None
-            except (ImportError, ValueError):
-                return False
-
-        if not (
-            _has_spec("flash_attn.flash_attn_triton_amd")
-            or _has_spec("aiter.ops.triton._triton_kernels.flash_attn_triton_amd")
-        ):
-            return False
-        if os.environ.get("FLASH_ATTENTION_TRITON_AMD_ENABLE") != "TRUE":
-            logger.info_once(
-                "Set FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE to enable "
-                "Flash Attention Triton backend on RDNA."
-            )
-            return False
-        return True
-    except ImportError:
-        return False
-
-
 def _get_backend_priorities(
     use_mla: bool,
     use_sparse: bool,
@@ -689,31 +655,32 @@ class RocmPlatform(Platform):
             logger.info_once(f"Using backend {backend} for vit attention")
             return backend
 
-        from importlib.util import find_spec
-
         from vllm._aiter_ops import rocm_aiter_ops
 
         if rocm_aiter_ops.is_mha_enabled() and on_cdna():
             logger.info_once("Using AITER Flash Attention backend for ViT model.")
             return AttentionBackendEnum.ROCM_AITER_FA
 
-        if (
-            on_cdna()
-            and find_spec("flash_attn") is not None
-            and (dtype == torch.float16 or dtype == torch.bfloat16)
+        if (on_cdna() or on_rdna()) and (
+            dtype == torch.float16 or dtype == torch.bfloat16
         ):
-            logger.info_once("Using Flash Attention backend for ViT model.")
-            return AttentionBackendEnum.FLASH_ATTN
-
-        # RDNA3/RDNA4 (gfx11xx/gfx12xx): Use Flash Attention Triton backend
-        if (
-            on_gfx1x()
-            and flash_attn_triton_available()
-            and (dtype == torch.float16 or dtype == torch.bfloat16)
-        ):
-            logger.info_once(
-                "Using Flash Attention (Triton backend) for ViT model on RDNA."
+            from vllm.v1.attention.backends.fa_utils import (
+                is_flash_attn_varlen_func_available,
             )
+
+            if not is_flash_attn_varlen_func_available():
+                logger.warning_once(
+                    "Flash Attention is unavailable for ViT attention. "
+                    "Falling back to Torch SDPA."
+                )
+                return AttentionBackendEnum.TORCH_SDPA
+
+            logger.info_once("Using Flash Attention backend for ViT model.")
+            if os.environ.get("FLASH_ATTENTION_TRITON_AMD_ENABLE") != "TRUE":
+                logger.info_once(
+                    "Set FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE to enable "
+                    "Flash Attention Triton backend on ROCm."
+                )
             return AttentionBackendEnum.FLASH_ATTN
 
         logger.info_once("Using Torch SDPA backend for ViT model.")


### PR DESCRIPTION
## Purpose

Enable the upstream FlashAttention CK backend for ViT attention on ROCm gfx11 and gfx12 GPUs.

The existing ROCm selector only allows the standard FlashAttention path on gfx9. On gfx11/gfx12, it requires the Triton environment variable and probes the private `flash_attn.flash_attn_triton_amd` module, preventing recent FlashAttention versions from using their CK backend by default.

This PR:
  - uses the same FlashAttention selection path for gfx9 and gfx11/gfx12;
  - checks the public `flash_attn_varlen_func` availability instead of probing private CK or Triton implementation modules;
  - allows upstream FlashAttention to select CK by default or Triton when `FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE` is set;
  - falls back to Torch SDPA with a warning when the public FlashAttention callable is unavailable;
  - logs how to enable the ROCm Triton backend after FlashAttention is selected and the Triton environment variable is not set.

AITER FlashAttention priority on supported gfx9 devices remains unchanged.

## Test Plan

Run the ROCm attention backend selection tests:

```bash
python -m pytest \
  tests/v1/attention/test_rocm_attention_backends_selection.py -v
```

Did an end-to-end multimodal runtime validation with Qwen3.5-9B:

```bash
vllm bench throughput \
  --model /home/user/workspace/models/Qwen3.5-9B \
  --trust-remote-code \
  --backend vllm-chat \
  --dataset-name random-mm \
  --dataset-path /dev/null \
  --random-mm-bucket-config '{(1024, 1024, 1): 1.0}' \
  --random-input-len 1024 \
  --random-output-len 128 \
  --num-prompts 100 \
  --num-warmups 1 \
  --max-model-len 4096
```
The Runtime validation was run with the following ViT attention configurations:
  - Torch SDPA: --mm-encoder-attn-backend TORCH_SDPA
  - FlashAttention default path (CK by default): environment variable unset or FLASH_ATTENTION_TRITON_AMD_ENABLE=FALSE
  - FlashAttention Triton path: FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE


## Test Result
### Unit tests

23 passed, 14 warnings

The added cases cover:

- selecting FlashAttention through its public callable on gfx9 and gfx11/gfx12;
- emitting the Triton enablement hint when the environment variable is unset;
- suppressing the hint when the environment variable is already TRUE;
- falling back to Torch SDPA with a warning when FlashAttention is unavailable.


### Runtime validation

A 100-request multimodal workload was also run successfully with all three ViT attention configurations:

- Torch SDPA
- FlashAttention default path
- FlashAttention Triton

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

