### PR TITLE
[Spec Decode][Core] Run an all-sliding DFlash drafter with prefix caching enabled

### DIFF
--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -23,6 +23,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
     MambaSpec,
+    SlidingWindowSpec,
 )
 
 
@@ -1181,3 +1182,405 @@ def test_hybrid_partial_hit_with_eagle_stays_within_group_blocks():
         len(group) * block_size >= num_computed for group in computed_blocks.blocks
     )
     assert manager.allocate_slots(req1, 4, num_computed, computed_blocks) is not None
+
+
+def test_hybrid_sliding_window_group_keeps_block_aligned_hits():
+    """A sliding-window group makes the whole model fall back to
+    block-aligned hits. ``SlidingWindowManager.find_longest_cache_hit``
+    indexes ``block_hashes`` in whole blocks, so a hash-granularity alignment
+    would read the wrong entries; it asserts instead, which used to abort the
+    engine on the first request of a mamba-"align" + SWA model."""
+    hash_block_size = 2
+    block_size = 2 * hash_block_size
+    kv_cache_config = KVCacheConfig(
+        num_blocks=32,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["swa"],
+                SlidingWindowSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                    sliding_window=block_size,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+
+    tokens = [1, 2, 3, 4, 5, 6, 7, 8]
+    req0 = make_request("0", tokens, hash_block_size, sha256)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(req0)
+    assert manager.allocate_slots(req0, 8, num_computed, computed_blocks) is not None
+    manager.cache_blocks(req0, 8)
+    swa_block_ids = [b.block_id for b in manager.get_blocks("0").blocks[0]]
+    manager.free(req0)
+    manager.new_step_starts()
+
+    req1 = make_request("1", tokens + [9, 10, 11, 12], hash_block_size, sha256)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(req1)
+    assert not manager.coordinator.enable_partial_hash_hits
+    assert num_computed == 8
+    # Out-of-window positions come back null, but every matched block must sit
+    # at the position it was cached at, not at that of its trailing hash unit.
+    swa_hit = computed_blocks.blocks[0]
+    null_block = manager.block_pool.null_block
+    assert len(swa_hit) * block_size == num_computed
+    assert swa_hit[-1] is not null_block
+    assert all(
+        block is null_block or block.block_id == swa_block_ids[i]
+        for i, block in enumerate(swa_hit)
+    )
+
+
+def test_hybrid_without_block_aligned_group_keeps_fine_grained_hits():
+    """The control for the fallback above.
+
+    The gate is a conjunction, so it can only ever over-fire. Without a
+    block-aligned-only group the mamba-"align" model must still get its
+    fine-grained partial hits, at a hit length that is not a multiple of the
+    physical block size.
+    """
+    hash_block_size = 2
+    block_size = 2 * hash_block_size
+    kv_cache_config = KVCacheConfig(
+        num_blocks=32,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+
+    assert manager.coordinator.enable_partial_hash_hits
+
+
+def test_hybrid_partial_hash_truncates_every_full_attention_group():
+    """Every full-attention-typed group is trimmed to the reconciled hit, not
+    just ``attention_groups[0]``.
+
+    Full attention is downward-closed, so the fixed-point loop looks each such
+    group up once and skips it on later passes. Only the final truncation
+    brings the block lists back to the reconciled length, and it used to visit
+    the first group alone. A second full-attention group therefore kept the
+    longer list from its own earlier lookup, and ``add_local_computed_blocks``
+    would extend the request's block table with blocks past the reconciled
+    boundary -- blocks it does not own.
+
+    One full-attention group cannot expose this, since sorting guarantees it is
+    the one the truncation visits.
+    """
+    hash_block_size = 2
+    block_size = 2 * hash_block_size
+    kv_cache_config = KVCacheConfig(
+        num_blocks=32,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full_a"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            # A *different* full-attention spec, so this does not merge into
+            # the group above. Two groups sharing one spec collapse into a
+            # single attention group whose `group_ids` the old truncation
+            # already iterated, which is why identical specs cannot expose
+            # this.
+            KVCacheGroupSpec(
+                ["full_b"],
+                FullAttentionSpec(
+                    block_size=2 * block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    pool = manager.block_pool
+    # 24 tokens, so the wider group holds three whole blocks. With a shorter
+    # request it holds one, which is indistinguishable from the correctly
+    # trimmed answer and the assertion below cannot discriminate.
+    req = make_request(
+        "0",
+        [i // 2 for i in range(24)],
+        hash_block_size,
+        sha256,
+    )
+
+    # Both full-attention groups cache their whole prefix; the mamba group
+    # caches far less, so it is what drives the reconciled hit down.
+    for group_id in (0, 1):
+        group_bs = block_size * (1 + group_id)
+        num_full = 24 // group_bs
+        blocks = pool.get_new_blocks(num_full)
+        pool.cache_full_blocks(
+            request=req,
+            blocks=blocks,
+            num_cached_blocks=0,
+            num_full_blocks=num_full,
+            block_size=group_bs,
+            kv_cache_group_id=group_id,
+        )
+
+    # Genuinely partial: ``cache_partial_block`` asserts the entry does not
+    # land on a block boundary.
+    mamba_block = pool.get_new_blocks(1)[0]
+    pool.cache_partial_block(
+        request=req,
+        block=mamba_block,
+        num_tokens=6,
+        kv_cache_group_id=2,
+        block_size=block_size,
+    )
+
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(req)
+
+    # The invariant, asserted per group rather than against hand-computed
+    # counts: no group may report blocks covering more than the reconciled hit.
+    for group_id, blocks in enumerate(computed_blocks.blocks):
+        group_block_size = manager.coordinator.single_type_managers[group_id].block_size
+        assert len(blocks) <= -(-max(num_computed, 0) // group_block_size), (
+            f"group {group_id} returned {len(blocks)} blocks of "
+            f"{group_block_size} tokens, past the reconciled hit of "
+            f"{num_computed} tokens"
+        )
+
+
+def _two_dense_groups_plus_mamba_config(
+    hash_block_size: int, block_size: int, coarse_block_size: int
+) -> KVCacheConfig:
+    """Two full-attention groups at different block sizes plus a mamba
+    "align" group -- the DFlash-drafter-as-full-attention shape."""
+    return KVCacheConfig(
+        num_blocks=32,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full_fine"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["full_coarse"],
+                FullAttentionSpec(
+                    block_size=coarse_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+
+
+def test_two_dense_groups_granularity_gap_is_not_an_uncached_prefix():
+    """Two full-attention groups at different block sizes, no sparse group
+    lagging: the finer group (e.g. a DFlash drafter booking its
+    sliding-window layers as full attention) legitimately completes more of
+    its own small blocks than the coarser (target) group for the same real
+    progress, purely from block-size granularity. That gap must not be read
+    as an uncached shared prefix -- nothing failed to cache anything; the
+    coarser group simply has not finished its next, bigger block yet.
+    """
+    hash_block_size = 2
+    block_size = 2 * hash_block_size  # fine group + mamba: 4
+    coarse_block_size = 2 * block_size  # 8
+    kv_cache_config = _two_dense_groups_plus_mamba_config(
+        hash_block_size, block_size, coarse_block_size
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    pool = manager.block_pool
+    req = make_request("0", [i // 2 for i in range(16)], hash_block_size, sha256)
+
+    # Fine group: three whole 4-token blocks, genuinely caught up to 12.
+    fine_blocks = pool.get_new_blocks(3)
+    pool.cache_full_blocks(
+        request=req,
+        blocks=fine_blocks,
+        num_cached_blocks=0,
+        num_full_blocks=3,
+        block_size=block_size,
+        kv_cache_group_id=0,
+    )
+    # Coarse group: one whole 8-token block. 12 is not a multiple of its own
+    # (larger) block size, so it has nothing more to report -- not eviction,
+    # just granularity.
+    coarse_blocks = pool.get_new_blocks(1)
+    pool.cache_full_blocks(
+        request=req,
+        blocks=coarse_blocks,
+        num_cached_blocks=0,
+        num_full_blocks=1,
+        block_size=coarse_block_size,
+        kv_cache_group_id=1,
+    )
+    # Mamba matches the fine group exactly: no sparse-retention group is
+    # lagging behind anything here.
+    mamba_blocks = pool.get_new_blocks(3)
+    pool.cache_full_blocks(
+        request=req,
+        blocks=mamba_blocks,
+        num_cached_blocks=0,
+        num_full_blocks=3,
+        block_size=block_size,
+        kv_cache_group_id=2,
+    )
+
+    _blocks, hit_length, num_uncached = manager.coordinator.find_longest_cache_hit(
+        req.block_hashes, req.num_tokens - 1
+    )
+
+    assert hit_length == 8
+    assert num_uncached == 0, (
+        f"num_uncached_common_prefix_tokens={num_uncached}, expected 0: the "
+        "gap comes from two full-attention groups' block-size granularity, "
+        "not from a sparse-retention group lagging behind."
+    )
+
+
+def test_two_dense_groups_agree_still_detects_genuine_sparse_lag():
+    """Control for the case above: when the two full-attention groups
+    genuinely agree on a longer prefix (the coarse group has its own partial
+    entry at the shared boundary, exactly as a request ending there would
+    produce) and only mamba lags, the gap must still be reported so
+    cross-request reuse is not lost.
+    """
+    hash_block_size = 2
+    block_size = 2 * hash_block_size
+    coarse_block_size = 2 * block_size
+    kv_cache_config = _two_dense_groups_plus_mamba_config(
+        hash_block_size, block_size, coarse_block_size
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    pool = manager.block_pool
+    req = make_request("0", [i // 2 for i in range(16)], hash_block_size, sha256)
+
+    fine_blocks = pool.get_new_blocks(3)
+    pool.cache_full_blocks(
+        request=req,
+        blocks=fine_blocks,
+        num_cached_blocks=0,
+        num_full_blocks=3,
+        block_size=block_size,
+        kv_cache_group_id=0,
+    )
+    # Coarse group genuinely reaches the same 12-token boundary via its own
+    # partial entry -- both dense groups agree here.
+    coarse_blocks = pool.get_new_blocks(2)
+    pool.cache_full_blocks(
+        request=req,
+        blocks=coarse_blocks,
+        num_cached_blocks=0,
+        num_full_blocks=1,
+        block_size=coarse_block_size,
+        kv_cache_group_id=1,
+    )
+    pool.cache_partial_block(
+        request=req,
+        block=coarse_blocks[1],
+        num_tokens=12,
+        kv_cache_group_id=1,
+        block_size=coarse_block_size,
+    )
+    # Mamba genuinely lags: only two whole blocks (8 tokens).
+    mamba_blocks = pool.get_new_blocks(2)
+    pool.cache_full_blocks(
+        request=req,
+        blocks=mamba_blocks,
+        num_cached_blocks=0,
+        num_full_blocks=2,
+        block_size=block_size,
+        kv_cache_group_id=2,
+    )
+
+    _blocks, hit_length, num_uncached = manager.coordinator.find_longest_cache_hit(
+        req.block_hashes, req.num_tokens - 1
+    )
+
+    assert hit_length == 8
+    assert num_uncached == 4, (
+        f"num_uncached_common_prefix_tokens={num_uncached}, expected 4: mamba "
+        "genuinely has not cached the shared prefix both full-attention "
+        "groups agree on."
+    )

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -1584,3 +1584,93 @@ def test_two_dense_groups_agree_still_detects_genuine_sparse_lag():
         "genuinely has not cached the shared prefix both full-attention "
         "groups agree on."
     )
+
+
+def test_connector_fast_path_trims_the_deeper_dense_group():
+    """The connector fast path must trim its block lists, not just lower the
+    length it reports.
+
+    ``get_computed_blocks_for_connector`` looks each group up independently
+    and then reports ``min`` over the full-attention groups, because that is
+    the only length every dense group's blocks actually cover. The blocks
+    themselves still come back at each group's own, possibly deeper, hit.
+    Scheduler hands the pair to ``add_local_computed_blocks`` unchanged, so an
+    untrimmed deeper group extends the request's block table past the reported
+    boundary with blocks it does not own -- the same defect the reconciling
+    path's truncation exists to prevent.
+
+    Needs two dense groups at different block sizes: with one, ``min`` is that
+    group's own hit and its list is trimmed by construction.
+    """
+    hash_block_size = 2
+    block_size = 2 * hash_block_size  # fine dense group + mamba: 4
+    coarse_block_size = 2 * block_size  # 8
+    kv_cache_config = _two_dense_groups_plus_mamba_config(
+        hash_block_size, block_size, coarse_block_size
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    pool = manager.block_pool
+    req = make_request("0", [i // 2 for i in range(16)], hash_block_size, sha256)
+
+    # Fine dense group reaches 12 tokens; coarse reaches 8. The reported hit
+    # is therefore 8, and the fine group's three blocks cover 12 -- one more
+    # block than the report admits to.
+    fine_blocks = pool.get_new_blocks(3)
+    pool.cache_full_blocks(
+        request=req,
+        blocks=fine_blocks,
+        num_cached_blocks=0,
+        num_full_blocks=3,
+        block_size=block_size,
+        kv_cache_group_id=0,
+    )
+    coarse_blocks = pool.get_new_blocks(1)
+    pool.cache_full_blocks(
+        request=req,
+        blocks=coarse_blocks,
+        num_cached_blocks=0,
+        num_full_blocks=1,
+        block_size=coarse_block_size,
+        kv_cache_group_id=1,
+    )
+    mamba_blocks = pool.get_new_blocks(3)
+    pool.cache_full_blocks(
+        request=req,
+        blocks=mamba_blocks,
+        num_cached_blocks=0,
+        num_full_blocks=3,
+        block_size=block_size,
+        kv_cache_group_id=2,
+    )
+
+    blocks, num_local, _boundary, _diverged = manager.get_computed_blocks_for_connector(
+        req
+    )
+
+    assert num_local == 8, (
+        f"expected the reported hit to be min over the dense groups (8), "
+        f"got {num_local}"
+    )
+    # Asserted over the full-attention groups only. A block count is the right
+    # invariant for them because their lists are dense and downward-closed, so
+    # a prefix of the list is exactly what a shorter lookup returns. It is the
+    # wrong invariant for a mamba group, whose list is null-padded with only
+    # the tail carrying the state: looked up at 12 it returns
+    # [null, null, state@12] and at 8 it returns [null, state@8], so dropping
+    # the tail entry would discard the state rather than shorten the hit.
+    # That is why the shared truncation skips groups that are not
+    # downward-closed, and why widening it here would be a bug.
+    for group_id in manager.coordinator.full_attention_group_ids:
+        group_blocks = blocks.blocks[group_id]
+        group_block_size = manager.coordinator.single_type_managers[group_id].block_size
+        allowed = -(-num_local // group_block_size)
+        assert len(group_blocks) <= allowed, (
+            f"group {group_id} returned {len(group_blocks)} blocks of "
+            f"{group_block_size} tokens, past the reported hit of "
+            f"{num_local} tokens ({allowed} blocks)"
+        )

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -1701,3 +1701,405 @@ def test_dcp_partial_hit_with_eagle_rewinds_one_hash_unit():
     assert num_computed == 4
     assert [len(group) for group in computed_blocks.blocks] == [1, 1]
     assert manager.allocate_slots(req1, 4, num_computed, computed_blocks) is not None
+
+
+def test_hybrid_sliding_window_group_keeps_block_aligned_hits():
+    """A sliding-window group makes the whole model fall back to
+    block-aligned hits. ``SlidingWindowManager.find_longest_cache_hit``
+    indexes ``block_hashes`` in whole blocks, so a hash-granularity alignment
+    would read the wrong entries; it asserts instead, which used to abort the
+    engine on the first request of a mamba-"align" + SWA model."""
+    hash_block_size = 2
+    block_size = 2 * hash_block_size
+    kv_cache_config = KVCacheConfig(
+        num_blocks=32,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["swa"],
+                SlidingWindowSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                    sliding_window=block_size,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+
+    tokens = [1, 2, 3, 4, 5, 6, 7, 8]
+    req0 = make_request("0", tokens, hash_block_size, sha256)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(req0)
+    assert manager.allocate_slots(req0, 8, num_computed, computed_blocks) is not None
+    manager.cache_blocks(req0, 8)
+    swa_block_ids = [b.block_id for b in manager.get_blocks("0").blocks[0]]
+    manager.free(req0)
+    manager.new_step_starts()
+
+    req1 = make_request("1", tokens + [9, 10, 11, 12], hash_block_size, sha256)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(req1)
+    assert not manager.coordinator.enable_partial_hash_hits
+    assert num_computed == 8
+    # Out-of-window positions come back null, but every matched block must sit
+    # at the position it was cached at, not at that of its trailing hash unit.
+    swa_hit = computed_blocks.blocks[0]
+    null_block = manager.block_pool.null_block
+    assert len(swa_hit) * block_size == num_computed
+    assert swa_hit[-1] is not null_block
+    assert all(
+        block is null_block or block.block_id == swa_block_ids[i]
+        for i, block in enumerate(swa_hit)
+    )
+
+
+def test_hybrid_without_block_aligned_group_keeps_fine_grained_hits():
+    """The control for the fallback above.
+
+    The gate is a conjunction, so it can only ever over-fire. Without a
+    block-aligned-only group the mamba-"align" model must still get its
+    fine-grained partial hits, at a hit length that is not a multiple of the
+    physical block size.
+    """
+    hash_block_size = 2
+    block_size = 2 * hash_block_size
+    kv_cache_config = KVCacheConfig(
+        num_blocks=32,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+
+    assert manager.coordinator.enable_partial_hash_hits
+
+
+def test_hybrid_partial_hash_truncates_every_full_attention_group():
+    """Every full-attention-typed group is trimmed to the reconciled hit, not
+    just ``attention_groups[0]``.
+
+    Full attention is downward-closed, so the fixed-point loop looks each such
+    group up once and skips it on later passes. Only the final truncation
+    brings the block lists back to the reconciled length, and it used to visit
+    the first group alone. A second full-attention group therefore kept the
+    longer list from its own earlier lookup, and ``add_local_computed_blocks``
+    would extend the request's block table with blocks past the reconciled
+    boundary -- blocks it does not own.
+
+    One full-attention group cannot expose this, since sorting guarantees it is
+    the one the truncation visits.
+    """
+    hash_block_size = 2
+    block_size = 2 * hash_block_size
+    kv_cache_config = KVCacheConfig(
+        num_blocks=32,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full_a"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            # A *different* full-attention spec, so this does not merge into
+            # the group above. Two groups sharing one spec collapse into a
+            # single attention group whose `group_ids` the old truncation
+            # already iterated, which is why identical specs cannot expose
+            # this.
+            KVCacheGroupSpec(
+                ["full_b"],
+                FullAttentionSpec(
+                    block_size=2 * block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    pool = manager.block_pool
+    # 24 tokens, so the wider group holds three whole blocks. With a shorter
+    # request it holds one, which is indistinguishable from the correctly
+    # trimmed answer and the assertion below cannot discriminate.
+    req = make_request(
+        "0",
+        [i // 2 for i in range(24)],
+        hash_block_size,
+        sha256,
+    )
+
+    # Both full-attention groups cache their whole prefix; the mamba group
+    # caches far less, so it is what drives the reconciled hit down.
+    for group_id in (0, 1):
+        group_bs = block_size * (1 + group_id)
+        num_full = 24 // group_bs
+        blocks = pool.get_new_blocks(num_full)
+        pool.cache_full_blocks(
+            request=req,
+            blocks=blocks,
+            num_cached_blocks=0,
+            num_full_blocks=num_full,
+            block_size=group_bs,
+            kv_cache_group_id=group_id,
+        )
+
+    # Genuinely partial: ``cache_partial_block`` asserts the entry does not
+    # land on a block boundary.
+    mamba_block = pool.get_new_blocks(1)[0]
+    pool.cache_partial_block(
+        request=req,
+        block=mamba_block,
+        num_tokens=6,
+        kv_cache_group_id=2,
+        block_size=block_size,
+    )
+
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(req)
+
+    # The invariant, asserted per group rather than against hand-computed
+    # counts: no group may report blocks covering more than the reconciled hit.
+    for group_id, blocks in enumerate(computed_blocks.blocks):
+        group_block_size = manager.coordinator.single_type_managers[group_id].block_size
+        assert len(blocks) <= -(-max(num_computed, 0) // group_block_size), (
+            f"group {group_id} returned {len(blocks)} blocks of "
+            f"{group_block_size} tokens, past the reconciled hit of "
+            f"{num_computed} tokens"
+        )
+
+
+def _two_dense_groups_plus_mamba_config(
+    hash_block_size: int, block_size: int, coarse_block_size: int
+) -> KVCacheConfig:
+    """Two full-attention groups at different block sizes plus a mamba
+    "align" group -- the DFlash-drafter-as-full-attention shape."""
+    return KVCacheConfig(
+        num_blocks=32,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full_fine"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["full_coarse"],
+                FullAttentionSpec(
+                    block_size=coarse_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+
+
+def test_two_dense_groups_granularity_gap_is_not_an_uncached_prefix():
+    """Two full-attention groups at different block sizes, no sparse group
+    lagging: the finer group (e.g. a DFlash drafter booking its
+    sliding-window layers as full attention) legitimately completes more of
+    its own small blocks than the coarser (target) group for the same real
+    progress, purely from block-size granularity. That gap must not be read
+    as an uncached shared prefix -- nothing failed to cache anything; the
+    coarser group simply has not finished its next, bigger block yet.
+    """
+    hash_block_size = 2
+    block_size = 2 * hash_block_size  # fine group + mamba: 4
+    coarse_block_size = 2 * block_size  # 8
+    kv_cache_config = _two_dense_groups_plus_mamba_config(
+        hash_block_size, block_size, coarse_block_size
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    pool = manager.block_pool
+    req = make_request("0", [i // 2 for i in range(16)], hash_block_size, sha256)
+
+    # Fine group: three whole 4-token blocks, genuinely caught up to 12.
+    fine_blocks = pool.get_new_blocks(3)
+    pool.cache_full_blocks(
+        request=req,
+        blocks=fine_blocks,
+        num_cached_blocks=0,
+        num_full_blocks=3,
+        block_size=block_size,
+        kv_cache_group_id=0,
+    )
+    # Coarse group: one whole 8-token block. 12 is not a multiple of its own
+    # (larger) block size, so it has nothing more to report -- not eviction,
+    # just granularity.
+    coarse_blocks = pool.get_new_blocks(1)
+    pool.cache_full_blocks(
+        request=req,
+        blocks=coarse_blocks,
+        num_cached_blocks=0,
+        num_full_blocks=1,
+        block_size=coarse_block_size,
+        kv_cache_group_id=1,
+    )
+    # Mamba matches the fine group exactly: no sparse-retention group is
+    # lagging behind anything here.
+    mamba_blocks = pool.get_new_blocks(3)
+    pool.cache_full_blocks(
+        request=req,
+        blocks=mamba_blocks,
+        num_cached_blocks=0,
+        num_full_blocks=3,
+        block_size=block_size,
+        kv_cache_group_id=2,
+    )
+
+    _blocks, hit_length, num_uncached = manager.coordinator.find_longest_cache_hit(
+        req.block_hashes, req.num_tokens - 1
+    )
+
+    assert hit_length == 8
+    assert num_uncached == 0, (
+        f"num_uncached_common_prefix_tokens={num_uncached}, expected 0: the "
+        "gap comes from two full-attention groups' block-size granularity, "
+        "not from a sparse-retention group lagging behind."
+    )
+
+
+def test_two_dense_groups_agree_still_detects_genuine_sparse_lag():
+    """Control for the case above: when the two full-attention groups
+    genuinely agree on a longer prefix (the coarse group has its own partial
+    entry at the shared boundary, exactly as a request ending there would
+    produce) and only mamba lags, the gap must still be reported so
+    cross-request reuse is not lost.
+    """
+    hash_block_size = 2
+    block_size = 2 * hash_block_size
+    coarse_block_size = 2 * block_size
+    kv_cache_config = _two_dense_groups_plus_mamba_config(
+        hash_block_size, block_size, coarse_block_size
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    pool = manager.block_pool
+    req = make_request("0", [i // 2 for i in range(16)], hash_block_size, sha256)
+
+    fine_blocks = pool.get_new_blocks(3)
+    pool.cache_full_blocks(
+        request=req,
+        blocks=fine_blocks,
+        num_cached_blocks=0,
+        num_full_blocks=3,
+        block_size=block_size,
+        kv_cache_group_id=0,
+    )
+    # Coarse group genuinely reaches the same 12-token boundary via its own
+    # partial entry -- both dense groups agree here.
+    coarse_blocks = pool.get_new_blocks(2)
+    pool.cache_full_blocks(
+        request=req,
+        blocks=coarse_blocks,
+        num_cached_blocks=0,
+        num_full_blocks=1,
+        block_size=coarse_block_size,
+        kv_cache_group_id=1,
+    )
+    pool.cache_partial_block(
+        request=req,
+        block=coarse_blocks[1],
+        num_tokens=12,
+        kv_cache_group_id=1,
+        block_size=coarse_block_size,
+    )
+    # Mamba genuinely lags: only two whole blocks (8 tokens).
+    mamba_blocks = pool.get_new_blocks(2)
+    pool.cache_full_blocks(
+        request=req,
+        blocks=mamba_blocks,
+        num_cached_blocks=0,
+        num_full_blocks=2,
+        block_size=block_size,
+        kv_cache_group_id=2,
+    )
+
+    _blocks, hit_length, num_uncached = manager.coordinator.find_longest_cache_hit(
+        req.block_hashes, req.num_tokens - 1
+    )
+
+    assert hit_length == 8
+    assert num_uncached == 4, (
+        f"num_uncached_common_prefix_tokens={num_uncached}, expected 4: mamba "
+        "genuinely has not cached the shared prefix both full-attention "
+        "groups agree on."
+    )

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -1704,11 +1704,7 @@ def test_dcp_partial_hit_with_eagle_rewinds_one_hash_unit():
 
 
 def test_hybrid_sliding_window_group_keeps_block_aligned_hits():
-    """A sliding-window group makes the whole model fall back to
-    block-aligned hits. ``SlidingWindowManager.find_longest_cache_hit``
-    indexes ``block_hashes`` in whole blocks, so a hash-granularity alignment
-    would read the wrong entries; it asserts instead, which used to abort the
-    engine on the first request of a mamba-"align" + SWA model."""
+    """Sliding-window groups force block-aligned hybrid cache hits."""
     hash_block_size = 2
     block_size = 2 * hash_block_size
     kv_cache_config = KVCacheConfig(
@@ -1769,13 +1765,7 @@ def test_hybrid_sliding_window_group_keeps_block_aligned_hits():
 
 
 def test_hybrid_without_block_aligned_group_keeps_fine_grained_hits():
-    """The control for the fallback above.
-
-    The gate is a conjunction, so it can only ever over-fire. Without a
-    block-aligned-only group the mamba-"align" model must still get its
-    fine-grained partial hits, at a hit length that is not a multiple of the
-    physical block size.
-    """
+    """Without a block-aligned group, fine-grained Mamba hits remain available."""
     hash_block_size = 2
     block_size = 2 * hash_block_size
     kv_cache_config = KVCacheConfig(

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -2105,7 +2105,8 @@ def test_two_dense_groups_agree_still_detects_genuine_sparse_lag():
     )
 
 
-def test_connector_fast_path_trims_the_deeper_dense_group():
+@pytest.mark.parametrize("mamba_num_blocks", [3, 2])
+def test_connector_fast_path_trims_the_deeper_dense_group(mamba_num_blocks):
     """The connector fast path must trim its block lists, not just lower the
     length it reports.
 
@@ -2157,12 +2158,12 @@ def test_connector_fast_path_trims_the_deeper_dense_group():
         block_size=coarse_block_size,
         kv_cache_group_id=1,
     )
-    mamba_blocks = pool.get_new_blocks(3)
+    mamba_blocks = pool.get_new_blocks(mamba_num_blocks)
     pool.cache_full_blocks(
         request=req,
         blocks=mamba_blocks,
         num_cached_blocks=0,
-        num_full_blocks=3,
+        num_full_blocks=mamba_num_blocks,
         block_size=block_size,
         kv_cache_group_id=2,
     )
@@ -2175,6 +2176,20 @@ def test_connector_fast_path_trims_the_deeper_dense_group():
         f"expected the reported hit to be min over the dense groups (8), "
         f"got {num_local}"
     )
+    if mamba_num_blocks == 3:
+        expected, expected_local, expected_boundary = manager.get_computed_blocks(req)
+        assert num_local == expected_local
+        assert _boundary == expected_boundary
+        assert _diverged is False
+        assert [[block.block_id for block in group] for group in blocks.blocks] == [
+            [block.block_id for block in group] for group in expected.blocks
+        ]
+        assert all(
+            block.is_null for block in blocks.blocks[2][num_local // block_size :]
+        )
+        return
+
+    assert _diverged is False
     # Asserted over the full-attention groups only. A block count is the right
     # invariant for them because their lists are dense and downward-closed, so
     # a prefix of the list is exactly what a shorter lookup returns. It is the

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -2103,3 +2103,93 @@ def test_two_dense_groups_agree_still_detects_genuine_sparse_lag():
         "genuinely has not cached the shared prefix both full-attention "
         "groups agree on."
     )
+
+
+def test_connector_fast_path_trims_the_deeper_dense_group():
+    """The connector fast path must trim its block lists, not just lower the
+    length it reports.
+
+    ``get_computed_blocks_for_connector`` looks each group up independently
+    and then reports ``min`` over the full-attention groups, because that is
+    the only length every dense group's blocks actually cover. The blocks
+    themselves still come back at each group's own, possibly deeper, hit.
+    Scheduler hands the pair to ``add_local_computed_blocks`` unchanged, so an
+    untrimmed deeper group extends the request's block table past the reported
+    boundary with blocks it does not own -- the same defect the reconciling
+    path's truncation exists to prevent.
+
+    Needs two dense groups at different block sizes: with one, ``min`` is that
+    group's own hit and its list is trimmed by construction.
+    """
+    hash_block_size = 2
+    block_size = 2 * hash_block_size  # fine dense group + mamba: 4
+    coarse_block_size = 2 * block_size  # 8
+    kv_cache_config = _two_dense_groups_plus_mamba_config(
+        hash_block_size, block_size, coarse_block_size
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    pool = manager.block_pool
+    req = make_request("0", [i // 2 for i in range(16)], hash_block_size, sha256)
+
+    # Fine dense group reaches 12 tokens; coarse reaches 8. The reported hit
+    # is therefore 8, and the fine group's three blocks cover 12 -- one more
+    # block than the report admits to.
+    fine_blocks = pool.get_new_blocks(3)
+    pool.cache_full_blocks(
+        request=req,
+        blocks=fine_blocks,
+        num_cached_blocks=0,
+        num_full_blocks=3,
+        block_size=block_size,
+        kv_cache_group_id=0,
+    )
+    coarse_blocks = pool.get_new_blocks(1)
+    pool.cache_full_blocks(
+        request=req,
+        blocks=coarse_blocks,
+        num_cached_blocks=0,
+        num_full_blocks=1,
+        block_size=coarse_block_size,
+        kv_cache_group_id=1,
+    )
+    mamba_blocks = pool.get_new_blocks(3)
+    pool.cache_full_blocks(
+        request=req,
+        blocks=mamba_blocks,
+        num_cached_blocks=0,
+        num_full_blocks=3,
+        block_size=block_size,
+        kv_cache_group_id=2,
+    )
+
+    blocks, num_local, _boundary, _diverged = manager.get_computed_blocks_for_connector(
+        req
+    )
+
+    assert num_local == 8, (
+        f"expected the reported hit to be min over the dense groups (8), "
+        f"got {num_local}"
+    )
+    # Asserted over the full-attention groups only. A block count is the right
+    # invariant for them because their lists are dense and downward-closed, so
+    # a prefix of the list is exactly what a shorter lookup returns. It is the
+    # wrong invariant for a mamba group, whose list is null-padded with only
+    # the tail carrying the state: looked up at 12 it returns
+    # [null, null, state@12] and at 8 it returns [null, state@8], so dropping
+    # the tail entry would discard the state rather than shorten the hit.
+    # That is why the shared truncation skips groups that are not
+    # downward-closed, and why widening it here would be a bug.
+    for group_id in manager.coordinator.full_attention_group_ids:
+        group_blocks = blocks.blocks[group_id]
+        group_block_size = manager.coordinator.single_type_managers[group_id].block_size
+        allowed = -(-num_local // group_block_size)
+        assert len(group_blocks) <= allowed, (
+            f"group {group_id} returned {len(group_blocks)} blocks of "
+            f"{group_block_size} tokens, past the reported hit of "
+            f"{num_local} tokens ({allowed} blocks)"
+        )

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -1752,8 +1752,7 @@ def test_hybrid_sliding_window_group_keeps_block_aligned_hits():
     computed_blocks, num_computed, _ = manager.get_computed_blocks(req1)
     assert not manager.coordinator.enable_partial_hash_hits
     assert num_computed == 8
-    # Out-of-window positions come back null, but every matched block must sit
-    # at the position it was cached at, not at that of its trailing hash unit.
+    # Out-of-window positions are null; matched blocks keep their cached slots.
     swa_hit = computed_blocks.blocks[0]
     null_block = manager.block_pool.null_block
     assert len(swa_hit) * block_size == num_computed
@@ -1803,20 +1802,7 @@ def test_hybrid_without_block_aligned_group_keeps_fine_grained_hits():
 
 
 def test_hybrid_partial_hash_truncates_every_full_attention_group():
-    """Every full-attention-typed group is trimmed to the reconciled hit, not
-    just ``attention_groups[0]``.
-
-    Full attention is downward-closed, so the fixed-point loop looks each such
-    group up once and skips it on later passes. Only the final truncation
-    brings the block lists back to the reconciled length, and it used to visit
-    the first group alone. A second full-attention group therefore kept the
-    longer list from its own earlier lookup, and ``add_local_computed_blocks``
-    would extend the request's block table with blocks past the reconciled
-    boundary -- blocks it does not own.
-
-    One full-attention group cannot expose this, since sorting guarantees it is
-    the one the truncation visits.
-    """
+    """Trim every full-attention group to the reconciled hit."""
     hash_block_size = 2
     block_size = 2 * hash_block_size
     kv_cache_config = KVCacheConfig(
@@ -1832,11 +1818,7 @@ def test_hybrid_partial_hash_truncates_every_full_attention_group():
                     dtype=torch.float32,
                 ),
             ),
-            # A *different* full-attention spec, so this does not merge into
-            # the group above. Two groups sharing one spec collapse into a
-            # single attention group whose `group_ids` the old truncation
-            # already iterated, which is why identical specs cannot expose
-            # this.
+            # Use a distinct spec so the groups remain separate.
             KVCacheGroupSpec(
                 ["full_b"],
                 FullAttentionSpec(
@@ -1864,9 +1846,7 @@ def test_hybrid_partial_hash_truncates_every_full_attention_group():
         hash_block_size=hash_block_size,
     )
     pool = manager.block_pool
-    # 24 tokens, so the wider group holds three whole blocks. With a shorter
-    # request it holds one, which is indistinguishable from the correctly
-    # trimmed answer and the assertion below cannot discriminate.
+    # The wider group holds three blocks and must be trimmed for a shorter hit.
     req = make_request(
         "0",
         [i // 2 for i in range(24)],
@@ -1874,8 +1854,7 @@ def test_hybrid_partial_hash_truncates_every_full_attention_group():
         sha256,
     )
 
-    # Both full-attention groups cache their whole prefix; the mamba group
-    # caches far less, so it is what drives the reconciled hit down.
+    # The Mamba group is shorter and drives reconciliation.
     for group_id in (0, 1):
         group_bs = block_size * (1 + group_id)
         num_full = 24 // group_bs
@@ -1889,8 +1868,7 @@ def test_hybrid_partial_hash_truncates_every_full_attention_group():
             kv_cache_group_id=group_id,
         )
 
-    # Genuinely partial: ``cache_partial_block`` asserts the entry does not
-    # land on a block boundary.
+    # Store a genuinely partial Mamba hit.
     mamba_block = pool.get_new_blocks(1)[0]
     pool.cache_partial_block(
         request=req,
@@ -1902,8 +1880,7 @@ def test_hybrid_partial_hash_truncates_every_full_attention_group():
 
     computed_blocks, num_computed, _ = manager.get_computed_blocks(req)
 
-    # The invariant, asserted per group rather than against hand-computed
-    # counts: no group may report blocks covering more than the reconciled hit.
+    # No group may report blocks beyond the reconciled hit.
     for group_id, blocks in enumerate(computed_blocks.blocks):
         group_block_size = manager.coordinator.single_type_managers[group_id].block_size
         assert len(blocks) <= -(-max(num_computed, 0) // group_block_size), (
@@ -1916,8 +1893,7 @@ def test_hybrid_partial_hash_truncates_every_full_attention_group():
 def _two_dense_groups_plus_mamba_config(
     hash_block_size: int, block_size: int, coarse_block_size: int
 ) -> KVCacheConfig:
-    """Two full-attention groups at different block sizes plus a mamba
-    "align" group -- the DFlash-drafter-as-full-attention shape."""
+    """Build two dense groups and one Mamba align group."""
     return KVCacheConfig(
         num_blocks=32,
         kv_cache_tensors=[],
@@ -1954,14 +1930,7 @@ def _two_dense_groups_plus_mamba_config(
 
 
 def test_two_dense_groups_granularity_gap_is_not_an_uncached_prefix():
-    """Two full-attention groups at different block sizes, no sparse group
-    lagging: the finer group (e.g. a DFlash drafter booking its
-    sliding-window layers as full attention) legitimately completes more of
-    its own small blocks than the coarser (target) group for the same real
-    progress, purely from block-size granularity. That gap must not be read
-    as an uncached shared prefix -- nothing failed to cache anything; the
-    coarser group simply has not finished its next, bigger block yet.
-    """
+    """Do not treat dense block-size granularity as an uncached prefix."""
     hash_block_size = 2
     block_size = 2 * hash_block_size  # fine group + mamba: 4
     coarse_block_size = 2 * block_size  # 8
@@ -1977,7 +1946,7 @@ def test_two_dense_groups_granularity_gap_is_not_an_uncached_prefix():
     pool = manager.block_pool
     req = make_request("0", [i // 2 for i in range(16)], hash_block_size, sha256)
 
-    # Fine group: three whole 4-token blocks, genuinely caught up to 12.
+    # Fine group: three whole 4-token blocks, reaching 12 tokens.
     fine_blocks = pool.get_new_blocks(3)
     pool.cache_full_blocks(
         request=req,
@@ -1987,9 +1956,7 @@ def test_two_dense_groups_granularity_gap_is_not_an_uncached_prefix():
         block_size=block_size,
         kv_cache_group_id=0,
     )
-    # Coarse group: one whole 8-token block. 12 is not a multiple of its own
-    # (larger) block size, so it has nothing more to report -- not eviction,
-    # just granularity.
+    # Coarse group has one whole 8-token block; the gap is granularity.
     coarse_blocks = pool.get_new_blocks(1)
     pool.cache_full_blocks(
         request=req,
@@ -1999,8 +1966,7 @@ def test_two_dense_groups_granularity_gap_is_not_an_uncached_prefix():
         block_size=coarse_block_size,
         kv_cache_group_id=1,
     )
-    # Mamba matches the fine group exactly: no sparse-retention group is
-    # lagging behind anything here.
+    # Mamba matches the fine group, so no sparse group lags.
     mamba_blocks = pool.get_new_blocks(3)
     pool.cache_full_blocks(
         request=req,
@@ -2024,12 +1990,7 @@ def test_two_dense_groups_granularity_gap_is_not_an_uncached_prefix():
 
 
 def test_two_dense_groups_agree_still_detects_genuine_sparse_lag():
-    """Control for the case above: when the two full-attention groups
-    genuinely agree on a longer prefix (the coarse group has its own partial
-    entry at the shared boundary, exactly as a request ending there would
-    produce) and only mamba lags, the gap must still be reported so
-    cross-request reuse is not lost.
-    """
+    """Detect a sparse lag when both dense groups agree."""
     hash_block_size = 2
     block_size = 2 * hash_block_size
     coarse_block_size = 2 * block_size
@@ -2054,8 +2015,7 @@ def test_two_dense_groups_agree_still_detects_genuine_sparse_lag():
         block_size=block_size,
         kv_cache_group_id=0,
     )
-    # Coarse group genuinely reaches the same 12-token boundary via its own
-    # partial entry -- both dense groups agree here.
+    # The partial entry brings the coarse group to the 12-token boundary.
     coarse_blocks = pool.get_new_blocks(2)
     pool.cache_full_blocks(
         request=req,
@@ -2072,7 +2032,7 @@ def test_two_dense_groups_agree_still_detects_genuine_sparse_lag():
         kv_cache_group_id=1,
         block_size=coarse_block_size,
     )
-    # Mamba genuinely lags: only two whole blocks (8 tokens).
+    # Mamba lags at 8 tokens.
     mamba_blocks = pool.get_new_blocks(2)
     pool.cache_full_blocks(
         request=req,
@@ -2097,21 +2057,7 @@ def test_two_dense_groups_agree_still_detects_genuine_sparse_lag():
 
 @pytest.mark.parametrize("mamba_num_blocks", [3, 2])
 def test_connector_fast_path_trims_the_deeper_dense_group(mamba_num_blocks):
-    """The connector fast path must trim its block lists, not just lower the
-    length it reports.
-
-    ``get_computed_blocks_for_connector`` looks each group up independently
-    and then reports ``min`` over the full-attention groups, because that is
-    the only length every dense group's blocks actually cover. The blocks
-    themselves still come back at each group's own, possibly deeper, hit.
-    Scheduler hands the pair to ``add_local_computed_blocks`` unchanged, so an
-    untrimmed deeper group extends the request's block table past the reported
-    boundary with blocks it does not own -- the same defect the reconciling
-    path's truncation exists to prevent.
-
-    Needs two dense groups at different block sizes: with one, ``min`` is that
-    group's own hit and its list is trimmed by construction.
-    """
+    """Trim dense connector hits to the shortest full-attention prefix."""
     hash_block_size = 2
     block_size = 2 * hash_block_size  # fine dense group + mamba: 4
     coarse_block_size = 2 * block_size  # 8
@@ -2127,9 +2073,7 @@ def test_connector_fast_path_trims_the_deeper_dense_group(mamba_num_blocks):
     pool = manager.block_pool
     req = make_request("0", [i // 2 for i in range(16)], hash_block_size, sha256)
 
-    # Fine dense group reaches 12 tokens; coarse reaches 8. The reported hit
-    # is therefore 8, and the fine group's three blocks cover 12 -- one more
-    # block than the report admits to.
+    # Fine reaches 12 tokens; coarse reaches 8, so the reported hit is 8.
     fine_blocks = pool.get_new_blocks(3)
     pool.cache_full_blocks(
         request=req,
@@ -2180,15 +2124,7 @@ def test_connector_fast_path_trims_the_deeper_dense_group(mamba_num_blocks):
         return
 
     assert _diverged is False
-    # Asserted over the full-attention groups only. A block count is the right
-    # invariant for them because their lists are dense and downward-closed, so
-    # a prefix of the list is exactly what a shorter lookup returns. It is the
-    # wrong invariant for a mamba group, whose list is null-padded with only
-    # the tail carrying the state: looked up at 12 it returns
-    # [null, null, state@12] and at 8 it returns [null, state@8], so dropping
-    # the tail entry would discard the state rather than shorten the hit.
-    # That is why the shared truncation skips groups that are not
-    # downward-closed, and why widening it here would be a bug.
+    # Dense groups are safe to trim because they are downward-closed.
     for group_id in manager.coordinator.full_attention_group_ids:
         group_blocks = blocks.blocks[group_id]
         group_block_size = manager.coordinator.single_type_managers[group_id].block_size

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -4311,3 +4311,225 @@ def test_swa_shared_prefix_reuse_under_zero_retention(monkeypatch):
     assert last_req_hit(retention=0, pin=False) == 0
     # retention=0 with the pin keeps the junction window -> reuse restored.
     assert last_req_hit(retention=0, pin=True) == 4 * block_size
+
+
+def _mamba_align_manager(block_size: int = 16, num_blocks: int = 60):
+    manager = make_kv_cache_manager(
+        _make_hybrid_kv_cache_config(block_size, num_blocks, ["full", "mamba_align"]),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+    mamba = manager.coordinator.single_type_managers[1]
+    assert mamba.mamba_cache_mode == "align"
+    return manager, mamba
+
+
+def _hashed_mamba_blocks(mamba, request) -> list[int]:
+    return [
+        index
+        for index, block in enumerate(mamba.req_to_blocks[request.request_id])
+        if not block.is_null and block.block_hash is not None
+    ]
+
+
+def test_mamba_align_records_where_the_forward_leaves_the_state():
+    """`allocate_new_blocks` is where the write position becomes knowable.
+
+    In align mode it already computes `num_tokens_main_model`, which counts the
+    unverified draft tokens the target runs over and is therefore exactly the
+    position the state write covers.
+    """
+    block_size = 16
+    manager, mamba = _mamba_align_manager(block_size)
+    prompt = [i for i in range(2) for _ in range(block_size)]
+    request = make_request("record", prompt, block_size, sha256)
+
+    manager.allocate_slots(request, len(prompt), 0, None)
+
+    assert mamba._state_write_tokens[request.request_id] == len(prompt)
+
+
+def test_mamba_align_admits_a_state_block_written_at_its_own_boundary():
+    """A prefill chunk is clipped onto a boundary, so its block is cacheable.
+
+    This is the other half of the rule and it has to be asserted alongside the
+    withholding case: a mask that degenerated to all-False would withhold these
+    too, take mamba hits to zero, and look like a stricter version of the same
+    fix rather than a broken one.
+    """
+    block_size = 16
+    manager, mamba = _mamba_align_manager(block_size)
+    prompt = [i for i in range(2) for _ in range(block_size)]
+    request = make_request("prefill", prompt, block_size, sha256)
+
+    manager.allocate_slots(request, len(prompt), 0, None)
+
+    assert _hashed_mamba_blocks(mamba, request), (
+        "a write that landed exactly on a block boundary, over committed "
+        "tokens only, is the case the cache is allowed to keep"
+    )
+
+
+def test_mamba_align_ands_a_caller_mask_into_its_own():
+    """`MambaManager` computes a boundary mask internally, but it still has to
+    honour one handed in by a caller.
+
+    Every sibling manager takes `extra_block_mask`, and the coordinator already
+    calls `cache_blocks` polymorphically for `retention_interval`. Dropping the
+    parameter here would make the one manager this feature exists for the only
+    one that raises `TypeError` on that call, and would silently ignore a
+    caller that is trying to withhold a block.
+    """
+    block_size = 16
+    manager, mamba = _mamba_align_manager(block_size)
+    prompt = [i for i in range(2) for _ in range(block_size)]
+    request = make_request("masked", prompt, block_size, sha256)
+
+    manager.allocate_slots(request, len(prompt), 0, None, delay_cache_blocks=True)
+    mamba.cache_blocks(request, len(prompt), extra_block_mask=[False, False])
+
+    assert _hashed_mamba_blocks(mamba, request) == [], (
+        "an all-False caller mask has to withhold every block, even the one "
+        "the boundary rule would have admitted on its own"
+    )
+
+
+def _decode(manager, mamba, request_id, block_size, prompt_blocks, step, num_steps):
+    """Prefill a whole number of blocks, then take uniform decode steps.
+
+    Returns one ``(state write position, admitted mamba blocks)`` pair per
+    decode step.
+    """
+    prompt = [i for i in range(prompt_blocks) for _ in range(block_size)]
+    request = make_request(request_id, prompt, block_size, sha256)
+    manager.allocate_slots(request, len(prompt), 0, None)
+    request.num_computed_tokens = len(prompt)
+
+    steps = []
+    for _ in range(num_steps):
+        request.append_output_token_ids([7] * step)
+        manager.allocate_slots(request, step, 0, None)
+        request.num_computed_tokens += step
+        steps.append(
+            (
+                mamba._state_write_tokens[request.request_id],
+                tuple(_hashed_mamba_blocks(mamba, request)),
+            )
+        )
+    return steps
+
+
+def test_mamba_align_withholds_blocks_a_decode_step_stepped_over():
+    """A decode step is not clipped onto a boundary, so with a step size that
+    does not divide the block size it steps over every boundary it passes.
+
+    Without the rule each of those crossings enters another block into the hash
+    map keyed to a prefix the state it holds does not correspond to.
+    """
+    block_size = 16
+    manager, mamba = _mamba_align_manager(block_size)
+
+    # 17 tokens per step: one committed token plus a fully accepted draft of
+    # 16. Starting from 32, the writes land at 49, 66, 83 -- never on a
+    # multiple of 16.
+    steps = _decode(manager, mamba, "crossed", block_size, 2, 17, 3)
+
+    assert [write for write, _ in steps] == [49, 66, 83]
+    admitted = {block for _, blocks in steps for block in blocks}
+    assert admitted == {1}, (
+        "only the prefill block, whose chunk was clipped onto the 32-token "
+        f"boundary, may be cached; got {sorted(admitted)}"
+    )
+
+
+def test_mamba_align_keeps_admissions_when_decode_lands_on_boundaries():
+    """The rule is targeted, not merely strict: a decode step whose write does
+    land on a boundary over committed tokens is still admitted.
+
+    Without this the fix could pass its withholding tests while degenerating to
+    withholding everything, which would take mamba prefix hits to zero.
+    """
+    block_size = 16
+    manager, mamba = _mamba_align_manager(block_size)
+
+    # A step equal to the block size lands on a boundary every time.
+    steps = _decode(manager, mamba, "aligned", block_size, 2, block_size, 4)
+
+    assert [write for write, _ in steps] == [48, 64, 80, 96]
+    assert [blocks for _, blocks in steps] == [(1, 2), (2, 3), (3, 4), (4, 5)]
+
+
+def test_mamba_align_withholds_a_boundary_write_still_holding_drafts():
+    """Landing on the boundary is not sufficient; the tokens must be committed.
+
+    Under speculation the forward runs over draft tokens that may be rejected,
+    so a write can land exactly on a boundary and still carry contributions
+    that are undone on the next step.
+    """
+    block_size = 16
+    _, mamba = _mamba_align_manager(block_size)
+    request = make_request("drafts", [1] * 32, block_size, sha256)
+    request.append_output_token_ids([7] * 16)
+    assert request.num_tokens == 48
+
+    # A write to the 64-token boundary while only 48 tokens are committed.
+    mamba._state_write_tokens[request.request_id] = 64
+
+    assert mamba._boundary_state_block_mask(request, 0, 4) == [False] * 4
+
+
+def test_mamba_align_withholds_when_no_write_was_recorded():
+    """Callers outside `allocate_slots` -- async output processing, connector
+    load completion -- can reach `cache_blocks` for a request this manager has
+    not sized a step for. Fail closed rather than admitting on no evidence."""
+    block_size = 16
+    _, mamba = _mamba_align_manager(block_size)
+    request = make_request("unknown", [1] * 32, block_size, sha256)
+
+    assert mamba._boundary_state_block_mask(request, 0, 2) == [False, False]
+
+
+def test_mamba_non_align_caching_is_untouched():
+    """Outside align the recurrent state is not block-snapshotted, so dense
+    caching is correct and the rule must not constrain it."""
+    block_size = 16
+    manager = make_kv_cache_manager(
+        _make_hybrid_kv_cache_config(block_size, 60, ["full", "mamba"]),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+    mamba = manager.coordinator.single_type_managers[1]
+    assert mamba.mamba_cache_mode != "align"
+    request = make_request("dense", [1] * 32, block_size, sha256)
+
+    assert mamba._boundary_state_block_mask(request, 0, 2) is None
+
+
+def test_extra_block_mask_can_only_withhold_never_admit():
+    """The mask is ANDed into whatever the manager already computed, so it can
+    take a block out of the admitted set but never put one in."""
+    block_size = 16
+    manager = make_kv_cache_manager(
+        _make_hybrid_kv_cache_config(block_size, 60, ["full"]),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+    full = manager.coordinator.single_type_managers[0]
+    prompt = [i for i in range(2) for _ in range(block_size)]
+
+    def hashes_with(extra_block_mask, request_id):
+        request = make_request(request_id, prompt, block_size, sha256)
+        # Full attention caches densely, so without an extra mask both blocks
+        # are admitted; that is the control the mask has to be able to override.
+        manager.allocate_slots(request, len(prompt), 0, None, delay_cache_blocks=True)
+        full.cache_blocks(request, len(prompt), extra_block_mask=extra_block_mask)
+        return [
+            block.block_hash is not None
+            for block in full.req_to_blocks[request.request_id]
+        ]
+
+    assert hashes_with(None, "dense") == [True, True]
+    assert hashes_with([False, False], "withheld") == [False, False]

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -4371,7 +4371,7 @@ def test_mamba_align_admits_a_state_block_written_at_its_own_boundary():
     )
 
 
-def test_mamba_align_ands_a_caller_mask_into_its_own():
+def test_mamba_align_intersects_a_caller_mask_with_its_own():
     """`MambaManager` computes a boundary mask internally, but it still has to
     honour one handed in by a caller.
 
@@ -4508,7 +4508,7 @@ def test_mamba_non_align_caching_is_untouched():
 
 
 def test_extra_block_mask_can_only_withhold_never_admit():
-    """The mask is ANDed into whatever the manager already computed, so it can
+    """The mask is intersected with whatever the manager already computed, so it can
     take a block out of the admitted set but never put one in."""
     block_size = 16
     manager = make_kv_cache_manager(

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -4333,3 +4333,225 @@ def test_swa_shared_prefix_reuse_under_zero_retention():
     assert last_req_hit(retention=0, pin=False) == 0
     # retention=0 with the pin keeps the junction window -> reuse restored.
     assert last_req_hit(retention=0, pin=True) == 4 * block_size
+
+
+def _mamba_align_manager(block_size: int = 16, num_blocks: int = 60):
+    manager = make_kv_cache_manager(
+        _make_hybrid_kv_cache_config(block_size, num_blocks, ["full", "mamba_align"]),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+    mamba = manager.coordinator.single_type_managers[1]
+    assert mamba.mamba_cache_mode == "align"
+    return manager, mamba
+
+
+def _hashed_mamba_blocks(mamba, request) -> list[int]:
+    return [
+        index
+        for index, block in enumerate(mamba.req_to_blocks[request.request_id])
+        if not block.is_null and block.block_hash is not None
+    ]
+
+
+def test_mamba_align_records_where_the_forward_leaves_the_state():
+    """`allocate_new_blocks` is where the write position becomes knowable.
+
+    In align mode it already computes `num_tokens_main_model`, which counts the
+    unverified draft tokens the target runs over and is therefore exactly the
+    position the state write covers.
+    """
+    block_size = 16
+    manager, mamba = _mamba_align_manager(block_size)
+    prompt = [i for i in range(2) for _ in range(block_size)]
+    request = make_request("record", prompt, block_size, sha256)
+
+    manager.allocate_slots(request, len(prompt), 0, None)
+
+    assert mamba._state_write_tokens[request.request_id] == len(prompt)
+
+
+def test_mamba_align_admits_a_state_block_written_at_its_own_boundary():
+    """A prefill chunk is clipped onto a boundary, so its block is cacheable.
+
+    This is the other half of the rule and it has to be asserted alongside the
+    withholding case: a mask that degenerated to all-False would withhold these
+    too, take mamba hits to zero, and look like a stricter version of the same
+    fix rather than a broken one.
+    """
+    block_size = 16
+    manager, mamba = _mamba_align_manager(block_size)
+    prompt = [i for i in range(2) for _ in range(block_size)]
+    request = make_request("prefill", prompt, block_size, sha256)
+
+    manager.allocate_slots(request, len(prompt), 0, None)
+
+    assert _hashed_mamba_blocks(mamba, request), (
+        "a write that landed exactly on a block boundary, over committed "
+        "tokens only, is the case the cache is allowed to keep"
+    )
+
+
+def test_mamba_align_ands_a_caller_mask_into_its_own():
+    """`MambaManager` computes a boundary mask internally, but it still has to
+    honour one handed in by a caller.
+
+    Every sibling manager takes `extra_block_mask`, and the coordinator already
+    calls `cache_blocks` polymorphically for `retention_interval`. Dropping the
+    parameter here would make the one manager this feature exists for the only
+    one that raises `TypeError` on that call, and would silently ignore a
+    caller that is trying to withhold a block.
+    """
+    block_size = 16
+    manager, mamba = _mamba_align_manager(block_size)
+    prompt = [i for i in range(2) for _ in range(block_size)]
+    request = make_request("masked", prompt, block_size, sha256)
+
+    manager.allocate_slots(request, len(prompt), 0, None, delay_cache_blocks=True)
+    mamba.cache_blocks(request, len(prompt), extra_block_mask=[False, False])
+
+    assert _hashed_mamba_blocks(mamba, request) == [], (
+        "an all-False caller mask has to withhold every block, even the one "
+        "the boundary rule would have admitted on its own"
+    )
+
+
+def _decode(manager, mamba, request_id, block_size, prompt_blocks, step, num_steps):
+    """Prefill a whole number of blocks, then take uniform decode steps.
+
+    Returns one ``(state write position, admitted mamba blocks)`` pair per
+    decode step.
+    """
+    prompt = [i for i in range(prompt_blocks) for _ in range(block_size)]
+    request = make_request(request_id, prompt, block_size, sha256)
+    manager.allocate_slots(request, len(prompt), 0, None)
+    request.num_computed_tokens = len(prompt)
+
+    steps = []
+    for _ in range(num_steps):
+        request.append_output_token_ids([7] * step)
+        manager.allocate_slots(request, step, 0, None)
+        request.num_computed_tokens += step
+        steps.append(
+            (
+                mamba._state_write_tokens[request.request_id],
+                tuple(_hashed_mamba_blocks(mamba, request)),
+            )
+        )
+    return steps
+
+
+def test_mamba_align_withholds_blocks_a_decode_step_stepped_over():
+    """A decode step is not clipped onto a boundary, so with a step size that
+    does not divide the block size it steps over every boundary it passes.
+
+    Without the rule each of those crossings enters another block into the hash
+    map keyed to a prefix the state it holds does not correspond to.
+    """
+    block_size = 16
+    manager, mamba = _mamba_align_manager(block_size)
+
+    # 17 tokens per step: one committed token plus a fully accepted draft of
+    # 16. Starting from 32, the writes land at 49, 66, 83 -- never on a
+    # multiple of 16.
+    steps = _decode(manager, mamba, "crossed", block_size, 2, 17, 3)
+
+    assert [write for write, _ in steps] == [49, 66, 83]
+    admitted = {block for _, blocks in steps for block in blocks}
+    assert admitted == {1}, (
+        "only the prefill block, whose chunk was clipped onto the 32-token "
+        f"boundary, may be cached; got {sorted(admitted)}"
+    )
+
+
+def test_mamba_align_keeps_admissions_when_decode_lands_on_boundaries():
+    """The rule is targeted, not merely strict: a decode step whose write does
+    land on a boundary over committed tokens is still admitted.
+
+    Without this the fix could pass its withholding tests while degenerating to
+    withholding everything, which would take mamba prefix hits to zero.
+    """
+    block_size = 16
+    manager, mamba = _mamba_align_manager(block_size)
+
+    # A step equal to the block size lands on a boundary every time.
+    steps = _decode(manager, mamba, "aligned", block_size, 2, block_size, 4)
+
+    assert [write for write, _ in steps] == [48, 64, 80, 96]
+    assert [blocks for _, blocks in steps] == [(1, 2), (2, 3), (3, 4), (4, 5)]
+
+
+def test_mamba_align_withholds_a_boundary_write_still_holding_drafts():
+    """Landing on the boundary is not sufficient; the tokens must be committed.
+
+    Under speculation the forward runs over draft tokens that may be rejected,
+    so a write can land exactly on a boundary and still carry contributions
+    that are undone on the next step.
+    """
+    block_size = 16
+    _, mamba = _mamba_align_manager(block_size)
+    request = make_request("drafts", [1] * 32, block_size, sha256)
+    request.append_output_token_ids([7] * 16)
+    assert request.num_tokens == 48
+
+    # A write to the 64-token boundary while only 48 tokens are committed.
+    mamba._state_write_tokens[request.request_id] = 64
+
+    assert mamba._boundary_state_block_mask(request, 0, 4) == [False] * 4
+
+
+def test_mamba_align_withholds_when_no_write_was_recorded():
+    """Callers outside `allocate_slots` -- async output processing, connector
+    load completion -- can reach `cache_blocks` for a request this manager has
+    not sized a step for. Fail closed rather than admitting on no evidence."""
+    block_size = 16
+    _, mamba = _mamba_align_manager(block_size)
+    request = make_request("unknown", [1] * 32, block_size, sha256)
+
+    assert mamba._boundary_state_block_mask(request, 0, 2) == [False, False]
+
+
+def test_mamba_non_align_caching_is_untouched():
+    """Outside align the recurrent state is not block-snapshotted, so dense
+    caching is correct and the rule must not constrain it."""
+    block_size = 16
+    manager = make_kv_cache_manager(
+        _make_hybrid_kv_cache_config(block_size, 60, ["full", "mamba"]),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+    mamba = manager.coordinator.single_type_managers[1]
+    assert mamba.mamba_cache_mode != "align"
+    request = make_request("dense", [1] * 32, block_size, sha256)
+
+    assert mamba._boundary_state_block_mask(request, 0, 2) is None
+
+
+def test_extra_block_mask_can_only_withhold_never_admit():
+    """The mask is ANDed into whatever the manager already computed, so it can
+    take a block out of the admitted set but never put one in."""
+    block_size = 16
+    manager = make_kv_cache_manager(
+        _make_hybrid_kv_cache_config(block_size, 60, ["full"]),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+    full = manager.coordinator.single_type_managers[0]
+    prompt = [i for i in range(2) for _ in range(block_size)]
+
+    def hashes_with(extra_block_mask, request_id):
+        request = make_request(request_id, prompt, block_size, sha256)
+        # Full attention caches densely, so without an extra mask both blocks
+        # are admitted; that is the control the mask has to be able to override.
+        manager.allocate_slots(request, len(prompt), 0, None, delay_cache_blocks=True)
+        full.cache_blocks(request, len(prompt), extra_block_mask=extra_block_mask)
+        return [
+            block.block_hash is not None
+            for block in full.req_to_blocks[request.request_id]
+        ]
+
+    assert hashes_with(None, "dense") == [True, True]
+    assert hashes_with([False, False], "withheld") == [False, False]

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -4393,7 +4393,7 @@ def test_mamba_align_admits_a_state_block_written_at_its_own_boundary():
     )
 
 
-def test_mamba_align_ands_a_caller_mask_into_its_own():
+def test_mamba_align_intersects_a_caller_mask_with_its_own():
     """`MambaManager` computes a boundary mask internally, but it still has to
     honour one handed in by a caller.
 
@@ -4530,7 +4530,7 @@ def test_mamba_non_align_caching_is_untouched():
 
 
 def test_extra_block_mask_can_only_withhold_never_admit():
-    """The mask is ANDed into whatever the manager already computed, so it can
+    """The mask is intersected with whatever the manager already computed, so it can
     take a block out of the admitted set but never put one in."""
     block_size = 16
     manager = make_kv_cache_manager(

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3,6 +3,7 @@
 """Compare the with and without prefix caching."""
 
 import copy
+from collections import deque
 from collections.abc import Callable
 from dataclasses import replace
 from math import lcm
@@ -4367,9 +4368,9 @@ def test_mamba_align_records_where_the_forward_leaves_the_state():
     prompt = [i for i in range(2) for _ in range(block_size)]
     request = make_request("record", prompt, block_size, sha256)
 
-    manager.allocate_slots(request, len(prompt), 0, None)
+    manager.allocate_slots(request, len(prompt), 0, None, delay_cache_blocks=True)
 
-    assert mamba._state_write_tokens[request.request_id] == len(prompt)
+    assert list(mamba._state_write_tokens[request.request_id]) == [len(prompt)]
 
 
 def test_mamba_align_admits_a_state_block_written_at_its_own_boundary():
@@ -4391,6 +4392,38 @@ def test_mamba_align_admits_a_state_block_written_at_its_own_boundary():
         "a write that landed exactly on a block boundary, over committed "
         "tokens only, is the case the cache is allowed to keep"
     )
+
+
+def test_mamba_align_keeps_an_async_step_boundary_write():
+    """A later scheduled step must not hide an earlier pending write."""
+    block_size = 16
+    manager, mamba = _mamba_align_manager(block_size)
+    request = make_request("async", [], block_size, sha256)
+
+    manager.allocate_slots(request, block_size, 0, None, delay_cache_blocks=True)
+    request.num_computed_tokens = block_size
+    manager.allocate_slots(request, block_size, 0, None, delay_cache_blocks=True)
+
+    request.append_output_token_ids([7] * block_size)
+    mamba.cache_blocks(request, request.num_tokens)
+
+    assert 0 in _hashed_mamba_blocks(mamba, request)
+
+
+def test_mamba_align_prunes_a_rejected_boundary_write():
+    """A rescheduled step invalidates writes beyond its new start."""
+    block_size = 16
+    manager, mamba = _mamba_align_manager(block_size)
+    request = make_request("rejected", [1] * block_size, block_size, sha256)
+    request.num_computed_tokens = block_size
+
+    manager.allocate_slots(request, block_size + 1, 0, None, delay_cache_blocks=True)
+    manager.allocate_slots(request, 1, 0, None, delay_cache_blocks=True)
+
+    request.append_output_token_ids([7] * (block_size + 1))
+    mamba.cache_blocks(request, request.num_tokens)
+
+    assert 1 not in _hashed_mamba_blocks(mamba, request)
 
 
 def test_mamba_align_intersects_a_caller_mask_with_its_own():
@@ -4431,11 +4464,13 @@ def _decode(manager, mamba, request_id, block_size, prompt_blocks, step, num_ste
     steps = []
     for _ in range(num_steps):
         request.append_output_token_ids([7] * step)
-        manager.allocate_slots(request, step, 0, None)
+        manager.allocate_slots(request, step, 0, None, delay_cache_blocks=True)
         request.num_computed_tokens += step
+        write = mamba._state_write_tokens[request.request_id][-1]
+        mamba.cache_blocks(request, request.num_tokens)
         steps.append(
             (
-                mamba._state_write_tokens[request.request_id],
+                write,
                 tuple(_hashed_mamba_blocks(mamba, request)),
             )
         )
@@ -4496,7 +4531,7 @@ def test_mamba_align_withholds_a_boundary_write_still_holding_drafts():
     assert request.num_tokens == 48
 
     # A write to the 64-token boundary while only 48 tokens are committed.
-    mamba._state_write_tokens[request.request_id] = 64
+    mamba._state_write_tokens[request.request_id] = deque([64])
 
     assert mamba._boundary_state_block_mask(request, 0, 4) == [False] * 4
 

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -4404,10 +4404,14 @@ def test_mamba_align_keeps_an_async_step_boundary_write():
     request.num_computed_tokens = block_size
     manager.allocate_slots(request, block_size, 0, None, delay_cache_blocks=True)
 
-    request.append_output_token_ids([7] * block_size)
-    mamba.cache_blocks(request, request.num_tokens)
+    request.append_output_token_ids([7] * (2 * block_size))
+    mamba.cache_blocks(request, block_size)
 
     assert 0 in _hashed_mamba_blocks(mamba, request)
+    assert list(mamba._state_write_tokens[request.request_id]) == [2 * block_size]
+
+    mamba.cache_blocks(request, 2 * block_size)
+    assert 1 in _hashed_mamba_blocks(mamba, request)
 
 
 def test_mamba_align_prunes_a_rejected_boundary_write():

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -4357,12 +4357,7 @@ def _hashed_mamba_blocks(mamba, request) -> list[int]:
 
 
 def test_mamba_align_records_where_the_forward_leaves_the_state():
-    """`allocate_new_blocks` is where the write position becomes knowable.
-
-    In align mode it already computes `num_tokens_main_model`, which counts the
-    unverified draft tokens the target runs over and is therefore exactly the
-    position the state write covers.
-    """
+    """Record the state-write position during block allocation."""
     block_size = 16
     manager, mamba = _mamba_align_manager(block_size)
     prompt = [i for i in range(2) for _ in range(block_size)]
@@ -4374,13 +4369,7 @@ def test_mamba_align_records_where_the_forward_leaves_the_state():
 
 
 def test_mamba_align_admits_a_state_block_written_at_its_own_boundary():
-    """A prefill chunk is clipped onto a boundary, so its block is cacheable.
-
-    This is the other half of the rule and it has to be asserted alongside the
-    withholding case: a mask that degenerated to all-False would withhold these
-    too, take mamba hits to zero, and look like a stricter version of the same
-    fix rather than a broken one.
-    """
+    """Admit a state block written at its own boundary."""
     block_size = 16
     manager, mamba = _mamba_align_manager(block_size)
     prompt = [i for i in range(2) for _ in range(block_size)]
@@ -4431,15 +4420,7 @@ def test_mamba_align_prunes_a_rejected_boundary_write():
 
 
 def test_mamba_align_intersects_a_caller_mask_with_its_own():
-    """`MambaManager` computes a boundary mask internally, but it still has to
-    honour one handed in by a caller.
-
-    Every sibling manager takes `extra_block_mask`, and the coordinator already
-    calls `cache_blocks` polymorphically for `retention_interval`. Dropping the
-    parameter here would make the one manager this feature exists for the only
-    one that raises `TypeError` on that call, and would silently ignore a
-    caller that is trying to withhold a block.
-    """
+    """Intersect the caller's mask with the Mamba boundary mask."""
     block_size = 16
     manager, mamba = _mamba_align_manager(block_size)
     prompt = [i for i in range(2) for _ in range(block_size)]
@@ -4455,11 +4436,7 @@ def test_mamba_align_intersects_a_caller_mask_with_its_own():
 
 
 def _decode(manager, mamba, request_id, block_size, prompt_blocks, step, num_steps):
-    """Prefill a whole number of blocks, then take uniform decode steps.
-
-    Returns one ``(state write position, admitted mamba blocks)`` pair per
-    decode step.
-    """
+    """Prefill blocks and return each decode write with admitted blocks."""
     prompt = [i for i in range(prompt_blocks) for _ in range(block_size)]
     request = make_request(request_id, prompt, block_size, sha256)
     manager.allocate_slots(request, len(prompt), 0, None)
@@ -4482,18 +4459,11 @@ def _decode(manager, mamba, request_id, block_size, prompt_blocks, step, num_ste
 
 
 def test_mamba_align_withholds_blocks_a_decode_step_stepped_over():
-    """A decode step is not clipped onto a boundary, so with a step size that
-    does not divide the block size it steps over every boundary it passes.
-
-    Without the rule each of those crossings enters another block into the hash
-    map keyed to a prefix the state it holds does not correspond to.
-    """
+    """Withhold blocks crossed by a non-aligned decode step."""
     block_size = 16
     manager, mamba = _mamba_align_manager(block_size)
 
-    # 17 tokens per step: one committed token plus a fully accepted draft of
-    # 16. Starting from 32, the writes land at 49, 66, 83 -- never on a
-    # multiple of 16.
+    # These writes cross boundaries without landing on one.
     steps = _decode(manager, mamba, "crossed", block_size, 2, 17, 3)
 
     assert [write for write, _ in steps] == [49, 66, 83]
@@ -4505,12 +4475,7 @@ def test_mamba_align_withholds_blocks_a_decode_step_stepped_over():
 
 
 def test_mamba_align_keeps_admissions_when_decode_lands_on_boundaries():
-    """The rule is targeted, not merely strict: a decode step whose write does
-    land on a boundary over committed tokens is still admitted.
-
-    Without this the fix could pass its withholding tests while degenerating to
-    withholding everything, which would take mamba prefix hits to zero.
-    """
+    """Admit decode writes that land on committed boundaries."""
     block_size = 16
     manager, mamba = _mamba_align_manager(block_size)
 
@@ -4522,28 +4487,21 @@ def test_mamba_align_keeps_admissions_when_decode_lands_on_boundaries():
 
 
 def test_mamba_align_withholds_a_boundary_write_still_holding_drafts():
-    """Landing on the boundary is not sufficient; the tokens must be committed.
-
-    Under speculation the forward runs over draft tokens that may be rejected,
-    so a write can land exactly on a boundary and still carry contributions
-    that are undone on the next step.
-    """
+    """Withhold a boundary write whose draft tokens are uncommitted."""
     block_size = 16
     _, mamba = _mamba_align_manager(block_size)
     request = make_request("drafts", [1] * 32, block_size, sha256)
     request.append_output_token_ids([7] * 16)
     assert request.num_tokens == 48
 
-    # A write to the 64-token boundary while only 48 tokens are committed.
+    # The boundary write includes uncommitted draft tokens.
     mamba._state_write_tokens[request.request_id] = deque([64])
 
     assert mamba._boundary_state_block_mask(request, 0, 4) == [False] * 4
 
 
 def test_mamba_align_withholds_when_no_write_was_recorded():
-    """Callers outside `allocate_slots` -- async output processing, connector
-    load completion -- can reach `cache_blocks` for a request this manager has
-    not sized a step for. Fail closed rather than admitting on no evidence."""
+    """Withhold blocks when no state write was recorded."""
     block_size = 16
     _, mamba = _mamba_align_manager(block_size)
     request = make_request("unknown", [1] * 32, block_size, sha256)
@@ -4552,8 +4510,7 @@ def test_mamba_align_withholds_when_no_write_was_recorded():
 
 
 def test_mamba_non_align_caching_is_untouched():
-    """Outside align the recurrent state is not block-snapshotted, so dense
-    caching is correct and the rule must not constrain it."""
+    """Leave dense caching unchanged outside align mode."""
     block_size = 16
     manager = make_kv_cache_manager(
         _make_hybrid_kv_cache_config(block_size, 60, ["full", "mamba"]),
@@ -4569,8 +4526,7 @@ def test_mamba_non_align_caching_is_untouched():
 
 
 def test_extra_block_mask_can_only_withhold_never_admit():
-    """The mask is intersected with whatever the manager already computed, so it can
-    take a block out of the admitted set but never put one in."""
+    """Ensure an extra mask can withhold but never admit blocks."""
     block_size = 16
     manager = make_kv_cache_manager(
         _make_hybrid_kv_cache_config(block_size, 60, ["full"]),
@@ -4583,8 +4539,7 @@ def test_extra_block_mask_can_only_withhold_never_admit():
 
     def hashes_with(extra_block_mask, request_id):
         request = make_request(request_id, prompt, block_size, sha256)
-        # Full attention caches densely, so without an extra mask both blocks
-        # are admitted; that is the control the mask has to be able to override.
+        # Full attention admits both blocks unless the extra mask withholds one.
         manager.allocate_slots(request, len(prompt), 0, None, delay_cache_blocks=True)
         full.cache_blocks(request, len(prompt), extra_block_mask=extra_block_mask)
         return [

--- a/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
@@ -232,6 +232,25 @@ def test_coordinator_fine_grained_partial_tail_hit():
     assert hit == 48
 
 
+def test_coordinator_sliding_window_group_disables_fine_grained_hits():
+    """A sliding-window group only supports block-aligned lookup, so the
+    connector must keep the scheduler-block alignment (and stay in step with
+    core) instead of handing the manager hash-granularity hashes."""
+    groups = [
+        KVCacheGroupSpec(["L0"], _swa(32, 64)),
+        KVCacheGroupSpec(["L1"], _mamba_align(32)),
+    ]
+    coord = _make_coord(groups, hash_block_size=16)
+    hs = _hashes(4)
+    exists = {(g, bytes(h)) for g in (0, 1) for h in (hs[1], hs[3])}
+    cmap = ExternalCachedBlockPool(16, exists)
+    _masks, hit = coord.find_longest_cache_hit(
+        hs, max_length=64, cached_block_pool=cmap
+    )
+    assert not coord.enable_partial_hash_hits
+    assert hit == 64
+
+
 def test_coordinator_fine_grained_clips_when_one_group_missing_tail():
     """If only one group has the sub-block boundary, min-convergence clips the
     reconciled hit back to the block boundary (32)."""

--- a/tests/v1/spec_decode/test_dflash_draft_full_attention_spec.py
+++ b/tests/v1/spec_decode/test_dflash_draft_full_attention_spec.py
@@ -17,6 +17,9 @@ import pytest
 from tests.v1.worker.test_gpu_model_runner import get_vllm_config
 from vllm.config import set_current_vllm_config
 from vllm.model_executor.layers.attention.attention import Attention
+from vllm.model_executor.models.qwen3_dflash import (
+    _should_book_draft_kv_as_full_attention,
+)
 from vllm.v1.kv_cache_interface import FullAttentionSpec, SlidingWindowSpec
 
 WINDOW = 4096
@@ -95,6 +98,48 @@ def test_conversion_does_not_touch_a_non_sliding_layer():
     assert isinstance(before, FullAttentionSpec)
     assert isinstance(after, FullAttentionSpec)
     assert after.sliding_window is None
+
+
+@pytest.mark.parametrize(
+    "enable_prefix_caching,mamba_cache_mode,expected",
+    [
+        (True, "align", True),
+        # A drafter cannot be handed a hit finer than its own block size unless
+        # a mamba "align" group turns fine-grained hits on, and paying
+        # max_model_len per layer to serve a lookup nobody makes is a pure loss.
+        (True, "none", False),
+        (True, "all", False),
+        (False, "align", False),
+        (False, "none", False),
+    ],
+)
+def test_conversion_needs_a_layout_that_can_produce_a_finer_hit(
+    enable_prefix_caching, mamba_cache_mode, expected
+):
+    vllm_config = get_vllm_config()
+    vllm_config.cache_config.enable_prefix_caching = enable_prefix_caching
+    vllm_config.cache_config.mamba_cache_mode = mamba_cache_mode
+
+    assert (
+        _should_book_draft_kv_as_full_attention(6, 6, vllm_config.cache_config)
+        is expected
+    )
+
+
+@pytest.mark.parametrize("num_sliding,num_layers", [(0, 6), (3, 6), (0, 0)])
+def test_a_drafter_that_is_not_all_sliding_is_left_alone(num_sliding, num_layers):
+    """The mixed case is handled by `_dflash_needs_multi_kv_group`, which gives
+    it a KV cache group per attention type rather than converting either."""
+    vllm_config = get_vllm_config()
+    vllm_config.cache_config.enable_prefix_caching = True
+    vllm_config.cache_config.mamba_cache_mode = "align"
+
+    assert (
+        _should_book_draft_kv_as_full_attention(
+            num_sliding, num_layers, vllm_config.cache_config
+        )
+        is False
+    )
 
 
 if __name__ == "__main__":

--- a/tests/v1/spec_decode/test_dflash_draft_full_attention_spec.py
+++ b/tests/v1/spec_decode/test_dflash_draft_full_attention_spec.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""A DFlash drafter may book its sliding-window layers as full attention.
+
+The conversion exists so an all-sliding drafter can take part in prefix
+caching: ``SlidingWindowManager`` cannot serve the fine-grained (partial)
+hits a hybrid coordinator hands it, while ``FullAttentionManager`` can.
+
+The property that matters and is easy to lose is that ``sliding_window``
+survives onto the converted spec. The window is enforced at compute time by
+reading it off the spec, so a conversion that dropped it would silently
+enforce no window at all rather than failing loudly.
+"""
+
+import pytest
+
+from tests.v1.worker.test_gpu_model_runner import get_vllm_config
+from vllm.config import set_current_vllm_config
+from vllm.model_executor.layers.attention.attention import Attention
+from vllm.v1.kv_cache_interface import FullAttentionSpec, SlidingWindowSpec
+
+WINDOW = 4096
+
+
+def _sliding_window_layer(vllm_config):
+    model_config = vllm_config.model_config
+    return Attention(
+        model_config.get_num_kv_heads(vllm_config.parallel_config),
+        model_config.get_head_size(),
+        0.1,
+        per_layer_sliding_window=WINDOW,
+    )
+
+
+def test_sliding_window_layer_defaults_to_sliding_window_spec():
+    """Opt-in: without the flag the layer is unchanged."""
+    vllm_config = get_vllm_config()
+    with set_current_vllm_config(vllm_config):
+        layer = _sliding_window_layer(vllm_config)
+        assert layer.book_sliding_window_as_full_attention is False
+        spec = layer.get_kv_cache_spec(vllm_config)
+
+    assert isinstance(spec, SlidingWindowSpec)
+    assert spec.sliding_window == WINDOW
+
+
+def test_booking_as_full_attention_preserves_the_window():
+    """The converted spec is full attention but still carries the window.
+
+    Both halves are load-bearing. The spec *type* is what routes the group to
+    a manager that supports partial hits; the ``sliding_window`` *field* is
+    what keeps the kernel masking to the window. Asserting only the type
+    would let a regression that drops the window pass.
+    """
+    vllm_config = get_vllm_config()
+    with set_current_vllm_config(vllm_config):
+        layer = _sliding_window_layer(vllm_config)
+        sliding_spec = layer.get_kv_cache_spec(vllm_config)
+
+        layer.book_sliding_window_as_full_attention = True
+        converted = layer.get_kv_cache_spec(vllm_config)
+
+    assert isinstance(converted, FullAttentionSpec)
+    assert converted.sliding_window == WINDOW
+
+    # The block size stays the sliding-window one rather than the model's, so
+    # page unification can still scale it by an integer ratio. This is also
+    # why a converted drafter produces a *second* full-attention group at a
+    # different block size from the target's.
+    assert converted.block_size == sliding_spec.block_size
+
+    # `page_size_padded` also carries over. The ordinary full-attention path
+    # sets neither this nor a sliding-window block size, so a converted spec is
+    # not interchangeable with one built that way -- both fields are what let
+    # page unification scale this group against the target's by an integer
+    # ratio instead of rejecting the pair.
+    assert converted.page_size_padded == sliding_spec.page_size_padded
+
+
+def test_conversion_does_not_touch_a_non_sliding_layer():
+    """A layer with no window is full attention either way, and setting the
+    flag must not invent one."""
+    vllm_config = get_vllm_config()
+    with set_current_vllm_config(vllm_config):
+        model_config = vllm_config.model_config
+        layer = Attention(
+            model_config.get_num_kv_heads(vllm_config.parallel_config),
+            model_config.get_head_size(),
+            0.1,
+        )
+        before = layer.get_kv_cache_spec(vllm_config)
+        layer.book_sliding_window_as_full_attention = True
+        after = layer.get_kv_cache_spec(vllm_config)
+
+    assert isinstance(before, FullAttentionSpec)
+    assert isinstance(after, FullAttentionSpec)
+    assert after.sliding_window is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
@@ -378,11 +378,8 @@ class MooncakeStoreCoordinator:
         # Truncate full-attention hit_blocks to final converged length;
         # other specs already trim themselves inside their hit logic. cdiv keeps
         # the partial tail block when hit_length is not block-aligned.
-        # Every full-attention group, not just the first: a DFlash drafter
-        # booking its sliding-window layers as full attention keeps the
-        # sliding-window block size, so a model can carry two full-attention
-        # groups at different block sizes. Mirrors the core coordinator, which
-        # must not disagree with this one.
+        # Every full-attention group, not just the first. Mirrors the core
+        # coordinator, which must not disagree with this one.
         truncate_downward_closed_groups(
             ((g.spec, g.group_ids) for g in self.attention_groups),
             hit_length,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
@@ -14,6 +14,8 @@ from vllm.v1.core.kv_cache_coordinator import SpecGroup
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
     KVCacheBlock,
+    partial_hash_hits_enabled,
+    truncate_downward_closed_groups,
 )
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
@@ -376,14 +378,18 @@ class MooncakeStoreCoordinator:
         # Truncate full-attention hit_blocks to final converged length;
         # other specs already trim themselves inside their hit logic. cdiv keeps
         # the partial tail block when hit_length is not block-aligned.
-        first_group = self.attention_groups[0]
-        if isinstance(first_group.spec, FullAttentionSpec):
-            num_blocks = cdiv(hit_length, first_group.spec.block_size)
-            for group_id in first_group.group_ids:
-                full_blks = hit_blocks_by_group[group_id]
-                assert full_blks is not None
-                del full_blks[num_blocks:]
-                hit_length_by_group[group_id] = hit_length
+        # Every full-attention group, not just the first: a DFlash drafter
+        # booking its sliding-window layers as full attention keeps the
+        # sliding-window block size, so a model can carry two full-attention
+        # groups at different block sizes. Mirrors the core coordinator, which
+        # must not disagree with this one.
+        truncate_downward_closed_groups(
+            ((g.spec, g.group_ids) for g in self.attention_groups),
+            hit_length,
+            hit_blocks_by_group,
+            hit_length_by_group,
+            lambda gid: self.kv_cache_groups[gid].kv_cache_spec.block_size,
+        )
 
         return (
             tuple(blks if blks is not None else [] for blks in hit_blocks_by_group),
@@ -395,18 +401,3 @@ def _unwrap_spec(spec: KVCacheSpec) -> KVCacheSpec:
     if isinstance(spec, UniformTypeKVCacheSpecs):
         return next(iter(spec.kv_cache_specs.values()))
     return spec
-
-
-def partial_hash_hits_enabled(
-    kv_cache_groups: list[KVCacheGroupSpec], hash_block_size: int
-) -> bool:
-    """Mirror of core's ``HybridKVCacheCoordinator.enable_partial_hash_hits``
-    (its dcp == 1 clause holds: the connector rejects hybrid + DCP/PCP > 1).
-    Single copy on purpose — scheduler and coordinator must not disagree.
-    """
-    return any(
-        isinstance(spec := _unwrap_spec(g.kv_cache_spec), MambaSpec)
-        and spec.mamba_cache_mode == "align"
-        and spec.block_size > hash_block_size
-        for g in kv_cache_groups
-    )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
@@ -11,9 +11,6 @@ from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorMetadata,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.coordinator import (  # noqa: E501
-    partial_hash_hits_enabled,
-)
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (  # noqa: E501
     LoadSpec,
     MooncakeStoreConnectorMetadata,
@@ -25,7 +22,10 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.worker import (
 )
 from vllm.logger import init_logger
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
-from vllm.v1.core.kv_cache_utils import resolve_kv_cache_block_sizes
+from vllm.v1.core.kv_cache_utils import (
+    partial_hash_hits_enabled,
+    resolve_kv_cache_block_sizes,
+)
 from vllm.v1.core.sched.output import NewRequestData, SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.request import Request

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
@@ -9,9 +9,6 @@ from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorMetadata,
 )
-from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.coordinator import (  # noqa: E501
-    partial_hash_hits_enabled,
-)
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (  # noqa: E501
     LoadSpec,
     MooncakeStoreConnectorMetadata,
@@ -25,7 +22,10 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.worker import (
 from vllm.logger import init_logger
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
-from vllm.v1.core.kv_cache_utils import resolve_kv_cache_block_sizes
+from vllm.v1.core.kv_cache_utils import (
+    partial_hash_hits_enabled,
+    resolve_kv_cache_block_sizes,
+)
 from vllm.v1.core.sched.output import NewRequestData, SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.outputs import KVConnectorOutput

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -633,19 +633,12 @@ class Attention(nn.Module, AttentionLayerBase):
             sw_block_size = _largest_kernel_block_within(
                 self.attn_backend, sw_per_token, shared_page, block_size
             )
-            # Booking as full attention routes the layer to
-            # FullAttentionManager, which supports fine-grained (partial)
-            # prefix-cache hits where SlidingWindowManager asserts against
-            # them. Only the block bookkeeping changes: `sliding_window` is
-            # carried either way and the metadata builder reads the window off
-            # the spec, so the kernel still masks to it. The block size stays
-            # the sliding-window one so page unification can scale it by an
-            # integer ratio.
+            # FullAttentionManager serves the fine-grained prefix-cache hits
+            # SlidingWindowManager asserts against. Only block bookkeeping
+            # changes: the builder reads the window off the spec either way.
             #
-            # One constructor on purpose. The fields must stay identical
-            # between the two, and the window in particular is load-bearing --
-            # dropping it would not merely fail to enforce the window, it would
-            # override the impl's correct one with "no window at all".
+            # One constructor on purpose -- `sliding_window` is load-bearing,
+            # and dropping it here would enforce no window at all.
             spec_cls = (
                 FullAttentionSpec
                 if self.book_sliding_window_as_full_attention

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -445,6 +445,11 @@ class Attention(nn.Module, AttentionLayerBase):
         # Gemma4: clamp mm_prefix bidirectional ranges by the sliding window
         # (read by the Triton backend impl). Default False for all other models.
         self.mm_prefix_clamp_sliding_window = mm_prefix_clamp_sliding_window
+        # Book this layer's KV as full attention while still masking to the
+        # window at compute time -- the same trade `unify_hybrid_kv_cache_specs`
+        # makes, but per layer instead of for the whole model. Opt-in; set by
+        # the model after construction (see `qwen3_dflash`).
+        self.book_sliding_window_as_full_attention = False
 
         # use a placeholder kv cache tensor during init, which will be replaced
         # by bind_kv_cache
@@ -628,7 +633,25 @@ class Attention(nn.Module, AttentionLayerBase):
             sw_block_size = _largest_kernel_block_within(
                 self.attn_backend, sw_per_token, shared_page, block_size
             )
-            return SlidingWindowSpec(
+            # Booking as full attention routes the layer to
+            # FullAttentionManager, which supports fine-grained (partial)
+            # prefix-cache hits where SlidingWindowManager asserts against
+            # them. Only the block bookkeeping changes: `sliding_window` is
+            # carried either way and the metadata builder reads the window off
+            # the spec, so the kernel still masks to it. The block size stays
+            # the sliding-window one so page unification can scale it by an
+            # integer ratio.
+            #
+            # One constructor on purpose. The fields must stay identical
+            # between the two, and the window in particular is load-bearing --
+            # dropping it would not merely fail to enforce the window, it would
+            # override the impl's correct one with "no window at all".
+            spec_cls = (
+                FullAttentionSpec
+                if self.book_sliding_window_as_full_attention
+                else SlidingWindowSpec
+            )
+            return spec_cls(
                 block_size=sw_block_size,
                 num_kv_heads=self.num_kv_heads,
                 head_size=self.head_size,

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -445,6 +445,11 @@ class Attention(nn.Module, AttentionLayerBase):
         # Gemma4: clamp mm_prefix bidirectional ranges by the sliding window
         # (read by the Triton backend impl). Default False for all other models.
         self.mm_prefix_clamp_sliding_window = mm_prefix_clamp_sliding_window
+        # Book this layer's KV as full attention while still masking to the
+        # window at compute time -- the same trade `unify_hybrid_kv_cache_specs`
+        # makes, but per layer instead of for the whole model. Opt-in; set by
+        # the model after construction (see `qwen3_dflash`).
+        self.book_sliding_window_as_full_attention = False
 
         # use a placeholder kv cache tensor during init, which will be replaced
         # by bind_kv_cache
@@ -634,7 +639,18 @@ class Attention(nn.Module, AttentionLayerBase):
             sw_block_size = _largest_kernel_block_within(
                 self.attn_backend, sw_per_token, shared_page, block_size
             )
-            return SlidingWindowSpec(
+            # FullAttentionManager serves the fine-grained prefix-cache hits
+            # SlidingWindowManager asserts against. Only block bookkeeping
+            # changes: the builder reads the window off the spec either way.
+            #
+            # One constructor on purpose -- `sliding_window` is load-bearing,
+            # and dropping it here would enforce no window at all.
+            spec_cls = (
+                FullAttentionSpec
+                if self.book_sliding_window_as_full_attention
+                else SlidingWindowSpec
+            )
+            return spec_cls(
                 block_size=sw_block_size,
                 num_kv_heads=self.num_kv_heads,
                 head_size=self.head_size,

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -83,6 +83,38 @@ def _get_dflash_fc_input_size(vllm_config: VllmConfig) -> int:
     return target_hidden_size * num_features_to_use
 
 
+def _should_book_draft_kv_as_full_attention(
+    num_sliding_layers: int, num_layers: int, cache_config: CacheConfig
+) -> bool:
+    """Whether an all-sliding drafter should book its KV as full attention.
+
+    ``SlidingWindowManager`` refuses fine-grained (partial) prefix-cache hits,
+    so a drafter whose every layer is sliding cannot be looked up at a hash
+    granularity finer than its own block size. Booking those layers as full
+    attention gives the coordinator a manager that serves such a lookup; the
+    window stays on the spec and is still applied at compute time, so only
+    block accounting changes. The mixed sliding/full case is handled earlier,
+    by ``VllmConfig._dflash_needs_multi_kv_group``.
+
+    That granularity only ever becomes finer when a mamba "align" group is
+    present: ``partial_hash_hits_enabled`` returns False without one, and the
+    coordinator then hands every group scheduler-block-aligned lengths, which
+    ``SlidingWindowManager`` already serves (see
+    ``test_eagle_swa_alignment_caches_extra_block``). Converting anyway would
+    budget each drafter layer at ``max_model_len`` rather than at its window,
+    costing KV capacity for a lookup nothing asks for.
+
+    The predicate cannot be consulted directly here. It reads the KV cache
+    specs, and this drafter's own spec is one of its inputs -- the layers do
+    not exist yet when the decision has to be made.
+    """
+    if num_layers == 0 or num_sliding_layers != num_layers:
+        return False
+    if not cache_config.enable_prefix_caching:
+        return False
+    return cache_config.mamba_cache_mode == "align"
+
+
 def _resolve_layer_attention(
     config: Qwen3Config, layer_idx: int
 ) -> tuple[int | None, bool]:
@@ -408,23 +440,13 @@ class DFlashQwen3Model(nn.Module):
                 for layer_idx in range(self.config.num_hidden_layers)
             ]
         )
-        # An all-sliding drafter makes the prefix-cache hash granularity
-        # unsatisfiable, since SlidingWindowManager refuses partial hits.
-        # FullAttentionManager serves them; the window stays on the spec and is
-        # still applied by the kernel, so only block accounting changes. The
-        # mixed case is already handled by `_dflash_needs_multi_kv_group`.
-        #
-        # Gated on prefix caching because the conversion costs KV capacity: a
-        # full-attention group is budgeted at max_model_len, not at the window.
         swa_layers = [
             layer.self_attn.attn
             for layer in self.layers
             if layer.self_attn.attn.sliding_window is not None
         ]
-        if (
-            swa_layers
-            and len(swa_layers) == len(self.layers)
-            and vllm_config.cache_config.enable_prefix_caching
+        if _should_book_draft_kv_as_full_attention(
+            len(swa_layers), len(self.layers), vllm_config.cache_config
         ):
             for attn in swa_layers:
                 attn.book_sliding_window_as_full_attention = True

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -408,6 +408,41 @@ class DFlashQwen3Model(nn.Module):
                 for layer_idx in range(self.config.num_hidden_layers)
             ]
         )
+        # An all-sliding drafter makes the model's prefix-cache hash granularity
+        # unsatisfiable: it has to divide the target's block size and be a whole
+        # multiple of the drafter's at the same time, because
+        # SlidingWindowManager refuses partial hits. Booking the drafter's KV as
+        # full attention routes it to FullAttentionManager instead, which does
+        # support them. The window stays on the spec and is still applied by the
+        # kernel; only the block accounting changes.
+        #
+        # Derived rather than flagged, on two conditions. A drafter that *mixes*
+        # sliding and full attention is already handled by
+        # `_dflash_needs_multi_kv_group`; this is the case that gate excludes.
+        # And with prefix caching off there is nothing to gain, while the
+        # conversion still costs KV capacity -- a full-attention group is
+        # budgeted at max_model_len rather than at the window.
+        swa_layers = [
+            layer.self_attn.attn
+            for layer in self.layers
+            if layer.self_attn.attn.sliding_window is not None
+        ]
+        if (
+            swa_layers
+            and len(swa_layers) == len(self.layers)
+            and vllm_config.cache_config.enable_prefix_caching
+        ):
+            for attn in swa_layers:
+                attn.book_sliding_window_as_full_attention = True
+            logger.info(
+                "DFlash drafter: booking %d sliding-window layers as full "
+                "attention for KV cache accounting, so the drafter can take "
+                "part in prefix caching (window still enforced at compute "
+                "time). This budgets the drafter's KV at max_model_len rather "
+                "than at its %d-token window.",
+                len(swa_layers),
+                swa_layers[0].sliding_window,
+            )
         if self.use_aux_hidden_state:
             self.fc = ReplicatedLinear(
                 input_size=_get_dflash_fc_input_size(

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -408,20 +408,14 @@ class DFlashQwen3Model(nn.Module):
                 for layer_idx in range(self.config.num_hidden_layers)
             ]
         )
-        # An all-sliding drafter makes the model's prefix-cache hash granularity
-        # unsatisfiable: it has to divide the target's block size and be a whole
-        # multiple of the drafter's at the same time, because
-        # SlidingWindowManager refuses partial hits. Booking the drafter's KV as
-        # full attention routes it to FullAttentionManager instead, which does
-        # support them. The window stays on the spec and is still applied by the
-        # kernel; only the block accounting changes.
+        # An all-sliding drafter makes the prefix-cache hash granularity
+        # unsatisfiable, since SlidingWindowManager refuses partial hits.
+        # FullAttentionManager serves them; the window stays on the spec and is
+        # still applied by the kernel, so only block accounting changes. The
+        # mixed case is already handled by `_dflash_needs_multi_kv_group`.
         #
-        # Derived rather than flagged, on two conditions. A drafter that *mixes*
-        # sliding and full attention is already handled by
-        # `_dflash_needs_multi_kv_group`; this is the case that gate excludes.
-        # And with prefix caching off there is nothing to gain, while the
-        # conversion still costs KV capacity -- a full-attention group is
-        # budgeted at max_model_len rather than at the window.
+        # Gated on prefix caching because the conversion costs KV capacity: a
+        # full-attention group is budgeted at max_model_len, not at the window.
         swa_layers = [
             layer.self_attn.attn
             for layer in self.layers

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -450,6 +450,35 @@ class DFlashQwen3Model(nn.Module):
                 for layer_idx in range(self.config.num_hidden_layers)
             ]
         )
+        # An all-sliding drafter makes the prefix-cache hash granularity
+        # unsatisfiable, since SlidingWindowManager refuses partial hits.
+        # FullAttentionManager serves them; the window stays on the spec and is
+        # still applied by the kernel, so only block accounting changes. The
+        # mixed case is already handled by `_dflash_needs_multi_kv_group`.
+        #
+        # Gated on prefix caching because the conversion costs KV capacity: a
+        # full-attention group is budgeted at max_model_len, not at the window.
+        swa_layers = [
+            layer.self_attn.attn
+            for layer in self.layers
+            if layer.self_attn.attn.sliding_window is not None
+        ]
+        if (
+            swa_layers
+            and len(swa_layers) == len(self.layers)
+            and vllm_config.cache_config.enable_prefix_caching
+        ):
+            for attn in swa_layers:
+                attn.book_sliding_window_as_full_attention = True
+            logger.info(
+                "DFlash drafter: booking %d sliding-window layers as full "
+                "attention for KV cache accounting, so the drafter can take "
+                "part in prefix caching (window still enforced at compute "
+                "time). This budgets the drafter's KV at max_model_len rather "
+                "than at its %d-token window.",
+                len(swa_layers),
+                swa_layers[0].sliding_window,
+            )
         if self.use_aux_hidden_state:
             self.fc = ReplicatedLinear(
                 input_size=_get_dflash_fc_input_size(

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -106,6 +106,38 @@ def _get_dflash_fc_input_size(vllm_config: VllmConfig) -> int:
     return target_hidden_size * num_features_to_use
 
 
+def _should_book_draft_kv_as_full_attention(
+    num_sliding_layers: int, num_layers: int, cache_config: CacheConfig
+) -> bool:
+    """Whether an all-sliding drafter should book its KV as full attention.
+
+    ``SlidingWindowManager`` refuses fine-grained (partial) prefix-cache hits,
+    so a drafter whose every layer is sliding cannot be looked up at a hash
+    granularity finer than its own block size. Booking those layers as full
+    attention gives the coordinator a manager that serves such a lookup; the
+    window stays on the spec and is still applied at compute time, so only
+    block accounting changes. The mixed sliding/full case is handled earlier,
+    by ``VllmConfig._dflash_needs_multi_kv_group``.
+
+    That granularity only ever becomes finer when a mamba "align" group is
+    present: ``partial_hash_hits_enabled`` returns False without one, and the
+    coordinator then hands every group scheduler-block-aligned lengths, which
+    ``SlidingWindowManager`` already serves (see
+    ``test_eagle_swa_alignment_caches_extra_block``). Converting anyway would
+    budget each drafter layer at ``max_model_len`` rather than at its window,
+    costing KV capacity for a lookup nothing asks for.
+
+    The predicate cannot be consulted directly here. It reads the KV cache
+    specs, and this drafter's own spec is one of its inputs -- the layers do
+    not exist yet when the decision has to be made.
+    """
+    if num_layers == 0 or num_sliding_layers != num_layers:
+        return False
+    if not cache_config.enable_prefix_caching:
+        return False
+    return cache_config.mamba_cache_mode == "align"
+
+
 def _resolve_layer_attention(
     config: Qwen3Config, layer_idx: int
 ) -> tuple[int | None, bool]:
@@ -450,23 +482,13 @@ class DFlashQwen3Model(nn.Module):
                 for layer_idx in range(self.config.num_hidden_layers)
             ]
         )
-        # An all-sliding drafter makes the prefix-cache hash granularity
-        # unsatisfiable, since SlidingWindowManager refuses partial hits.
-        # FullAttentionManager serves them; the window stays on the spec and is
-        # still applied by the kernel, so only block accounting changes. The
-        # mixed case is already handled by `_dflash_needs_multi_kv_group`.
-        #
-        # Gated on prefix caching because the conversion costs KV capacity: a
-        # full-attention group is budgeted at max_model_len, not at the window.
         swa_layers = [
             layer.self_attn.attn
             for layer in self.layers
             if layer.self_attn.attn.sliding_window is not None
         ]
-        if (
-            swa_layers
-            and len(swa_layers) == len(self.layers)
-            and vllm_config.cache_config.enable_prefix_caching
+        if _should_book_draft_kv_as_full_attention(
+            len(swa_layers), len(self.layers), vllm_config.cache_config
         ):
             for attn in swa_layers:
                 attn.book_sliding_window_as_full_attention = True

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -5,12 +5,14 @@ from collections.abc import Sequence
 from typing import NamedTuple
 
 from vllm import envs
-from vllm.utils.math_utils import cdiv
+from vllm.logger import init_logger
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
     KVCacheBlock,
+    partial_hash_hits_enabled,
+    truncate_downward_closed_groups,
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     CrossAttentionManager,
@@ -25,6 +27,8 @@ from vllm.v1.kv_cache_interface import (
     SlidingWindowSpec,
 )
 from vllm.v1.request import Request
+
+logger = init_logger(__name__)
 
 
 def _validate_prefix_cache_retention_interval(
@@ -579,12 +583,12 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     f"{type(g.kv_cache_spec).__name__}."
                 )
         # Partial hash hits are limited to full-attention + mamba ("align")
-        # without context parallelism.
-        self.enable_partial_hash_hits = dcp_world_size == 1 and any(
-            isinstance(g.kv_cache_spec, MambaSpec)
-            and g.kv_cache_spec.mamba_cache_mode == "align"
-            and g.kv_cache_spec.block_size > hash_block_size
-            for g in kv_cache_config.kv_cache_groups
+        # without context parallelism, and only when no other group forces
+        # block-aligned lookup.
+        self.enable_partial_hash_hits = partial_hash_hits_enabled(
+            kv_cache_config.kv_cache_groups,
+            hash_block_size,
+            dcp_world_size=dcp_world_size,
         )
         self.verify_and_split_kv_cache_groups()
 
@@ -795,17 +799,38 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             if is_simple_hybrid:
                 break
 
-        # Truncate full attention blocks to final hit_length (if present)
-        first_group = self.attention_groups[0]
-        if isinstance(first_group.spec, FullAttentionSpec):
-            group_block_size = self.single_type_managers[
-                first_group.group_ids[0]
-            ].block_size
-            num_blocks = cdiv(hit_length, group_block_size)
-            for group_id in first_group.group_ids:
-                if (blks := hit_blocks_by_group[group_id]) is not None:
-                    del blks[num_blocks:]
-                    hit_length_by_group[group_id] = hit_length
+        if len(self.full_attention_group_ids) > 1:
+            # With more than one full-attention group -- a DFlash drafter
+            # booking its sliding-window layers as full attention keeps its
+            # own, smaller block size alongside the target's -- the loop
+            # above records each dense group's *own* hit as it is reached,
+            # and a finer group legitimately completes its next block sooner
+            # than a coarser one for identical underlying progress. That
+            # disagreement is block-size granularity, not a sparse-retention
+            # group falling behind, so the dense reference is where every
+            # dense group agrees (the min) rather than the deepest any one of
+            # them individually reached. Must run before the truncation below,
+            # which overwrites `hit_length_by_group` for these groups.
+            longest_hit_length = min(
+                hit_length_by_group[gid] for gid in self.full_attention_group_ids
+            )
+
+        # Truncate every full attention group to the final hit_length. Each is
+        # looked up once (they are downward-closed) against a candidate length
+        # that later iterations may have reduced, so the trim is what makes the
+        # returned blocks agree with the reconciled hit. There can be more than
+        # one such group with different block sizes -- a DFlash drafter booking
+        # its sliding-window layers as full attention keeps the sliding-window
+        # block size -- so each trims at its own, and a group left untrimmed
+        # hands `add_local_computed_blocks` more blocks than the hit covers,
+        # which lands as a copy-on-write assertion on the first partial hit.
+        truncate_downward_closed_groups(
+            ((g.spec, g.group_ids) for g in self.attention_groups),
+            hit_length,
+            hit_blocks_by_group,
+            hit_length_by_group,
+            lambda gid: self.single_type_managers[gid].block_size,
+        )
 
         # Uncached shared prefix detection: if any attn. group cached a longer
         # prefix than the reconciled hit, it is an uncached common prefix across

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -646,13 +646,12 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         self.full_attention_group_id: int | None = (
             first.group_ids[0] if isinstance(first.spec, FullAttentionSpec) else None
         )
-        # Every full-attention group, not just the first. A model can carry
-        # more than one at different block sizes -- a DFlash drafter booking
-        # its sliding-window layers as full attention keeps the smaller
-        # sliding-window block size -- and a finer-grained group reports a
+        # Every full-attention group, not just the first: a model can carry
+        # more than one at different block sizes (see
+        # truncate_downward_closed_groups). A finer-grained group reports a
         # legitimately deeper per-group hit whenever the reconciled hit is not
-        # a multiple of the coarser group's block size. Taking the first alone
-        # as the dense reference reads that as eviction.
+        # a multiple of the coarser group's block size, and taking the first
+        # alone as the dense reference reads that as eviction.
         self.full_attention_group_ids: list[int] = [
             group_id
             for group in self.attention_groups
@@ -831,10 +830,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         # Truncate every full attention group to the final hit_length. Each is
         # looked up once (they are downward-closed) against a candidate length
         # that later iterations may have reduced, so the trim is what makes the
-        # returned blocks agree with the reconciled hit. There can be more than
-        # one such group with different block sizes -- a DFlash drafter booking
-        # its sliding-window layers as full attention keeps the sliding-window
-        # block size -- so each trims at its own, and a group left untrimmed
+        # returned blocks agree with the reconciled hit. A group left untrimmed
         # hands `add_local_computed_blocks` more blocks than the hit covers,
         # which lands as a copy-on-write assertion on the first partial hit.
         truncate_downward_closed_groups(

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -648,10 +648,8 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         )
         # Every full-attention group, not just the first: a model can carry
         # more than one at different block sizes (see
-        # truncate_downward_closed_groups). A finer-grained group reports a
-        # legitimately deeper per-group hit whenever the reconciled hit is not
-        # a multiple of the coarser group's block size, and taking the first
-        # alone as the dense reference reads that as eviction.
+        # truncate_downward_closed_groups). Taking the first alone as the
+        # dense reference reads a granularity difference as eviction.
         self.full_attention_group_ids: list[int] = [
             group_id
             for group in self.attention_groups
@@ -812,27 +810,19 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 break
 
         if len(self.full_attention_group_ids) > 1:
-            # With more than one full-attention group -- a DFlash drafter
-            # booking its sliding-window layers as full attention keeps its
-            # own, smaller block size alongside the target's -- the loop
-            # above records each dense group's *own* hit as it is reached,
-            # and a finer group legitimately completes its next block sooner
-            # than a coarser one for identical underlying progress. That
-            # disagreement is block-size granularity, not a sparse-retention
-            # group falling behind, so the dense reference is where every
-            # dense group agrees (the min) rather than the deepest any one of
-            # them individually reached. Must run before the truncation below,
-            # which overwrites `hit_length_by_group` for these groups.
+            # Dense groups can disagree purely on block-size granularity: a
+            # finer group completes its next block sooner than a coarser one
+            # for identical progress. That is not a sparse group falling
+            # behind, so the reference is where every dense group agrees.
+            # Must precede the truncation below, which overwrites these.
             longest_hit_length = min(
                 hit_length_by_group[gid] for gid in self.full_attention_group_ids
             )
 
-        # Truncate every full attention group to the final hit_length. Each is
-        # looked up once (they are downward-closed) against a candidate length
-        # that later iterations may have reduced, so the trim is what makes the
-        # returned blocks agree with the reconciled hit. A group left untrimmed
-        # hands `add_local_computed_blocks` more blocks than the hit covers,
-        # which lands as a copy-on-write assertion on the first partial hit.
+        # Each group was looked up once against a candidate length that later
+        # iterations may have reduced. Leaving one untrimmed hands
+        # `add_local_computed_blocks` more blocks than the hit covers, which
+        # lands as a copy-on-write assertion on the first partial hit.
         truncate_downward_closed_groups(
             ((g.spec, g.group_ids) for g in self.attention_groups),
             hit_length,

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -646,6 +646,19 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         self.full_attention_group_id: int | None = (
             first.group_ids[0] if isinstance(first.spec, FullAttentionSpec) else None
         )
+        # Every full-attention group, not just the first. A model can carry
+        # more than one at different block sizes -- a DFlash drafter booking
+        # its sliding-window layers as full attention keeps the smaller
+        # sliding-window block size -- and a finer-grained group reports a
+        # legitimately deeper per-group hit whenever the reconciled hit is not
+        # a multiple of the coarser group's block size. Taking the first alone
+        # as the dense reference reads that as eviction.
+        self.full_attention_group_ids: list[int] = [
+            group_id
+            for group in self.attention_groups
+            if isinstance(group.spec, FullAttentionSpec)
+            for group_id in group.group_ids
+        ]
 
         # Propagate the eagle bit to each manager (default to ``use_eagle=False``).
         for group in self.attention_groups:

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -5,12 +5,14 @@ from collections.abc import Sequence
 from typing import NamedTuple
 
 from vllm.logger import init_logger
-from vllm.utils.math_utils import cdiv, round_down
+from vllm.utils.math_utils import round_down
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
     KVCacheBlock,
+    partial_hash_hits_enabled,
+    truncate_downward_closed_groups,
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     CrossAttentionManager,
@@ -619,36 +621,13 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     "full-attention and Mamba groups, got: "
                     f"{type(g.kv_cache_spec).__name__}."
                 )
-        # Fine-grained hash hits require Mamba "align" and compatible cache
-        # managers in every group. TP needs hashing finer than the Mamba block;
-        # DCP accepts equality because it scales the effective full-attention
-        # block instead.
-        has_partial_mamba_group = any(
-            isinstance(g.kv_cache_spec, MambaSpec)
-            and g.kv_cache_spec.mamba_cache_mode == "align"
-            and (
-                (dcp_world_size == 1 and g.kv_cache_spec.block_size > hash_block_size)
-                or (
-                    dcp_world_size > 1 and g.kv_cache_spec.block_size >= hash_block_size
-                )
-            )
-            for g in kv_cache_config.kv_cache_groups
+        # Partial hash hits are limited to full-attention + mamba ("align"),
+        # and only when no other group forces block-aligned lookup.
+        self.enable_partial_hash_hits = partial_hash_hits_enabled(
+            kv_cache_config.kv_cache_groups,
+            hash_block_size,
+            dcp_world_size=dcp_world_size,
         )
-        self.enable_partial_hash_hits = has_partial_mamba_group
-        if self.enable_partial_hash_hits:
-            unsupported_partial_hit_managers = {
-                type(manager).__name__
-                for manager in self.single_type_managers
-                if not manager.supports_fine_grained_hash_lookup
-                and manager.block_size != hash_block_size
-            }
-            if unsupported_partial_hit_managers:
-                self.enable_partial_hash_hits = False
-                logger.warning_once(
-                    "Disabling fine-grained prefix-cache hits because these KV "
-                    "cache managers require block-aligned lookups: %s.",
-                    ", ".join(sorted(unsupported_partial_hit_managers)),
-                )
         self.verify_and_split_kv_cache_groups()
 
     @property
@@ -867,17 +846,38 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             if is_simple_hybrid:
                 break
 
-        # Truncate full attention blocks to final hit_length (if present)
-        first_group = self.attention_groups[0]
-        if isinstance(first_group.spec, FullAttentionSpec):
-            group_block_size = self.single_type_managers[
-                first_group.group_ids[0]
-            ].block_size
-            num_blocks = cdiv(hit_length, group_block_size)
-            for group_id in first_group.group_ids:
-                if (blks := hit_blocks_by_group[group_id]) is not None:
-                    del blks[num_blocks:]
-                    hit_length_by_group[group_id] = hit_length
+        if len(self.full_attention_group_ids) > 1:
+            # With more than one full-attention group -- a DFlash drafter
+            # booking its sliding-window layers as full attention keeps its
+            # own, smaller block size alongside the target's -- the loop
+            # above records each dense group's *own* hit as it is reached,
+            # and a finer group legitimately completes its next block sooner
+            # than a coarser one for identical underlying progress. That
+            # disagreement is block-size granularity, not a sparse-retention
+            # group falling behind, so the dense reference is where every
+            # dense group agrees (the min) rather than the deepest any one of
+            # them individually reached. Must run before the truncation below,
+            # which overwrites `hit_length_by_group` for these groups.
+            longest_hit_length = min(
+                hit_length_by_group[gid] for gid in self.full_attention_group_ids
+            )
+
+        # Truncate every full attention group to the final hit_length. Each is
+        # looked up once (they are downward-closed) against a candidate length
+        # that later iterations may have reduced, so the trim is what makes the
+        # returned blocks agree with the reconciled hit. There can be more than
+        # one such group with different block sizes -- a DFlash drafter booking
+        # its sliding-window layers as full attention keeps the sliding-window
+        # block size -- so each trims at its own, and a group left untrimmed
+        # hands `add_local_computed_blocks` more blocks than the hit covers,
+        # which lands as a copy-on-write assertion on the first partial hit.
+        truncate_downward_closed_groups(
+            ((g.spec, g.group_ids) for g in self.attention_groups),
+            hit_length,
+            hit_blocks_by_group,
+            hit_length_by_group,
+            lambda gid: self.single_type_managers[gid].block_size,
+        )
 
         # Uncached shared prefix detection: if any attn. group cached a longer
         # prefix than the reconciled hit, it is an uncached common prefix across

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -273,6 +273,7 @@ class KVCacheCoordinator(ABC):
         num_tokens: int,
         num_tokens_main_model: int,
         num_encoder_tokens: int = 0,
+        num_new_tokens: int | None = None,
     ) -> tuple[list[KVCacheBlock], ...]:
         """
         Allocate new blocks for the request to give it at least `num_tokens`
@@ -287,6 +288,7 @@ class KVCacheCoordinator(ABC):
                 with spec decode, it is num_tokens - num_lookahead_tokens.
             num_encoder_tokens: The number of encoder tokens for allocating
                 blocks for cross-attention.
+            num_new_tokens: The number of tokens newly scheduled in this step.
 
         Returns:
             The new allocated blocks.
@@ -298,6 +300,7 @@ class KVCacheCoordinator(ABC):
                 if isinstance(manager, CrossAttentionManager)
                 else num_tokens,
                 num_tokens_main_model,
+                num_new_tokens,
             )
             for manager in self.single_type_managers
         )

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -684,6 +684,19 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         self.full_attention_group_id: int | None = (
             first.group_ids[0] if isinstance(first.spec, FullAttentionSpec) else None
         )
+        # Every full-attention group, not just the first. A model can carry
+        # more than one at different block sizes -- a DFlash drafter booking
+        # its sliding-window layers as full attention keeps the smaller
+        # sliding-window block size -- and a finer-grained group reports a
+        # legitimately deeper per-group hit whenever the reconciled hit is not
+        # a multiple of the coarser group's block size. Taking the first alone
+        # as the dense reference reads that as eviction.
+        self.full_attention_group_ids: list[int] = [
+            group_id
+            for group in self.attention_groups
+            if isinstance(group.spec, FullAttentionSpec)
+            for group_id in group.group_ids
+        ]
 
         # Propagate the eagle bit to each manager (default to ``use_eagle=False``).
         for group in self.attention_groups:

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -684,13 +684,10 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         self.full_attention_group_id: int | None = (
             first.group_ids[0] if isinstance(first.spec, FullAttentionSpec) else None
         )
-        # Every full-attention group, not just the first. A model can carry
-        # more than one at different block sizes -- a DFlash drafter booking
-        # its sliding-window layers as full attention keeps the smaller
-        # sliding-window block size -- and a finer-grained group reports a
-        # legitimately deeper per-group hit whenever the reconciled hit is not
-        # a multiple of the coarser group's block size. Taking the first alone
-        # as the dense reference reads that as eviction.
+        # Every full-attention group, not just the first: a model can carry
+        # more than one at different block sizes (see
+        # truncate_downward_closed_groups). Taking the first alone as the
+        # dense reference reads a granularity difference as eviction.
         self.full_attention_group_ids: list[int] = [
             group_id
             for group in self.attention_groups
@@ -860,30 +857,19 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 break
 
         if len(self.full_attention_group_ids) > 1:
-            # With more than one full-attention group -- a DFlash drafter
-            # booking its sliding-window layers as full attention keeps its
-            # own, smaller block size alongside the target's -- the loop
-            # above records each dense group's *own* hit as it is reached,
-            # and a finer group legitimately completes its next block sooner
-            # than a coarser one for identical underlying progress. That
-            # disagreement is block-size granularity, not a sparse-retention
-            # group falling behind, so the dense reference is where every
-            # dense group agrees (the min) rather than the deepest any one of
-            # them individually reached. Must run before the truncation below,
-            # which overwrites `hit_length_by_group` for these groups.
+            # Dense groups can disagree purely on block-size granularity: a
+            # finer group completes its next block sooner than a coarser one
+            # for identical progress. That is not a sparse group falling
+            # behind, so the reference is where every dense group agrees.
+            # Must precede the truncation below, which overwrites these.
             longest_hit_length = min(
                 hit_length_by_group[gid] for gid in self.full_attention_group_ids
             )
 
-        # Truncate every full attention group to the final hit_length. Each is
-        # looked up once (they are downward-closed) against a candidate length
-        # that later iterations may have reduced, so the trim is what makes the
-        # returned blocks agree with the reconciled hit. There can be more than
-        # one such group with different block sizes -- a DFlash drafter booking
-        # its sliding-window layers as full attention keeps the sliding-window
-        # block size -- so each trims at its own, and a group left untrimmed
-        # hands `add_local_computed_blocks` more blocks than the hit covers,
-        # which lands as a copy-on-write assertion on the first partial hit.
+        # Each group was looked up once against a candidate length that later
+        # iterations may have reduced. Leaving one untrimmed hands
+        # `add_local_computed_blocks` more blocks than the hit covers, which
+        # lands as a copy-on-write assertion on the first partial hit.
         truncate_downward_closed_groups(
             ((g.spec, g.group_ids) for g in self.attention_groups),
             hit_length,

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -687,10 +687,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         self.full_attention_group_id: int | None = (
             first.group_ids[0] if isinstance(first.spec, FullAttentionSpec) else None
         )
-        # Every full-attention group, not just the first: a model can carry
-        # more than one at different block sizes (see
-        # truncate_downward_closed_groups). Taking the first alone as the
-        # dense reference reads a granularity difference as eviction.
+        # Keep every full-attention group as a dense reference.
         self.full_attention_group_ids: list[int] = [
             group_id
             for group in self.attention_groups
@@ -860,19 +857,12 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 break
 
         if len(self.full_attention_group_ids) > 1:
-            # Dense groups can disagree purely on block-size granularity: a
-            # finer group completes its next block sooner than a coarser one
-            # for identical progress. That is not a sparse group falling
-            # behind, so the reference is where every dense group agrees.
-            # Must precede the truncation below, which overwrites these.
+            # Dense groups may differ only because of block-size granularity.
             longest_hit_length = min(
                 hit_length_by_group[gid] for gid in self.full_attention_group_ids
             )
 
-        # Each group was looked up once against a candidate length that later
-        # iterations may have reduced. Leaving one untrimmed hands
-        # `add_local_computed_blocks` more blocks than the hit covers, which
-        # lands as a copy-on-write assertion on the first partial hit.
+        # Trim lists looked up before the fixed-point hit was reduced.
         truncate_downward_closed_groups(
             ((g.spec, g.group_ids) for g in self.attention_groups),
             hit_length,

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -333,12 +333,8 @@ class KVCacheManager:
         computed, per_group_hits = coordinator.find_longest_cache_hit_per_group(
             request.block_hashes, request.num_tokens - 1
         )
-        # Two different questions, so two different reductions over the dense
-        # groups. There can be more than one (see
-        # truncate_downward_closed_groups), and the finer-grained one
-        # legitimately hits deeper whenever the reconciled hit is not a
-        # multiple of the coarser block size. Both reduce to the single-group
-        # behaviour when there is one.
+        # Two questions, so two reductions over the dense groups. Both
+        # reduce to the single-group behaviour when there is only one.
         dense_hits = [
             per_group_hits[group_id]
             for group_id in coordinator.full_attention_group_ids

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -334,11 +334,11 @@ class KVCacheManager:
             request.block_hashes, request.num_tokens - 1
         )
         # Two different questions, so two different reductions over the dense
-        # groups. There can be more than one -- a DFlash drafter booking its
-        # sliding-window layers as full attention adds a second at a smaller
-        # block size -- and the finer-grained one legitimately hits deeper
-        # whenever the reconciled hit is not a multiple of the coarser block
-        # size. Both reduce to the single-group behaviour when there is one.
+        # groups. There can be more than one (see
+        # truncate_downward_closed_groups), and the finer-grained one
+        # legitimately hits deeper whenever the reconciled hit is not a
+        # multiple of the coarser block size. Both reduce to the single-group
+        # behaviour when there is one.
         dense_hits = [
             per_group_hits[group_id]
             for group_id in coordinator.full_attention_group_ids
@@ -365,6 +365,8 @@ class KVCacheManager:
             ((g.spec, g.group_ids) for g in coordinator.attention_groups),
             num_local,
             hit_blocks,
+            # A copy on purpose: only the trimmed blocks are wanted here, and
+            # the caller-visible flag below reports on the pre-trim hits.
             list(per_group_hits),
             lambda gid: coordinator.single_type_managers[gid].block_size,
         )

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -14,7 +14,11 @@ from vllm.v1.core.kv_cache_coordinator import (
     get_kv_cache_coordinator,
 )
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
-from vllm.v1.core.kv_cache_utils import KVCacheBlock, KVCacheBlockCopy
+from vllm.v1.core.kv_cache_utils import (
+    KVCacheBlock,
+    KVCacheBlockCopy,
+    truncate_downward_closed_groups,
+)
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     CrossAttentionSpec,
@@ -326,18 +330,45 @@ class KVCacheManager:
         if not self.prefix_cache_lookup_enabled(request):
             return self.empty_kv_cache_blocks, 0, 0, False
 
-        fa_group_id = coordinator.full_attention_group_id
         computed, per_group_hits = coordinator.find_longest_cache_hit_per_group(
             request.block_hashes, request.num_tokens - 1
         )
-        if any(hit > per_group_hits[fa_group_id] for hit in per_group_hits):
-            # A lagging group hit deeper than full attention means its
-            # full-attention blocks were evicted; use the reconciled boundary
-            # that every group agrees on.
+        # Two different questions, so two different reductions over the dense
+        # groups. There can be more than one -- a DFlash drafter booking its
+        # sliding-window layers as full attention adds a second at a smaller
+        # block size -- and the finer-grained one legitimately hits deeper
+        # whenever the reconciled hit is not a multiple of the coarser block
+        # size. Both reduce to the single-group behaviour when there is one.
+        dense_hits = [
+            per_group_hits[group_id]
+            for group_id in coordinator.full_attention_group_ids
+        ]
+        if any(hit > max(dense_hits) for hit in per_group_hits):
+            # Eviction test: a group deeper than *every* dense group means the
+            # dense blocks were evicted. Comparing against one arbitrary dense
+            # group instead would read a finer-grained sibling as eviction and
+            # give up the fast path on most hits.
             return *self.get_computed_blocks(request), False
 
-        num_local = per_group_hits[fa_group_id]
-        blocks = self.create_kv_cache_blocks(computed)
+        # Reported length: the blocks below come from the per-group lookup at
+        # each group's own hit, not from a reconciled one, so this must be a
+        # length every dense group's list actually covers. The max would name a
+        # boundary the coarser group's blocks fall short of.
+        num_local = min(dense_hits)
+        # Reducing the reported length is not enough on its own: a dense group
+        # that hit deeper keeps a block list longer than `num_local` covers,
+        # and the pair is handed straight to `add_local_computed_blocks`. Trim
+        # for the same reason the reconciling path does, at each group's own
+        # block size.
+        hit_blocks = [list(blocks) for blocks in computed]
+        truncate_downward_closed_groups(
+            ((g.spec, g.group_ids) for g in coordinator.attention_groups),
+            num_local,
+            hit_blocks,
+            list(per_group_hits),
+            lambda gid: coordinator.single_type_managers[gid].block_size,
+        )
+        blocks = self.create_kv_cache_blocks(tuple(hit_blocks))
         # Per-group lookups do not detect an uncached shared prefix (boundary 0).
         return blocks, num_local, 0, min(per_group_hits) < num_local
 

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -349,23 +349,18 @@ class KVCacheManager:
         ):
             return *self.get_computed_blocks(request), False
 
-        # Reducing the reported length is not enough on its own: a dense group
-        # that hit deeper keeps a block list longer than `num_local` covers,
-        # and the pair is handed straight to `add_local_computed_blocks`. Trim
-        # for the same reason the reconciling path does, at each group's own
-        # block size.
+        # Trim deeper downward-closed block lists to the reported length.
         hit_blocks = [list(blocks) for blocks in computed]
         truncate_downward_closed_groups(
             ((g.spec, g.group_ids) for g in coordinator.attention_groups),
             num_local,
             hit_blocks,
-            # A copy on purpose: only the trimmed blocks are wanted here, and
-            # the caller-visible flag below reports on the pre-trim hits.
+            # Keep the divergence flag based on the original hit lengths.
             list(per_group_hits),
             lambda gid: coordinator.single_type_managers[gid].block_size,
         )
         blocks = self.create_kv_cache_blocks(tuple(hit_blocks))
-        # Per-group lookups do not detect an uncached shared prefix (boundary 0).
+        # Per-group lookups do not detect an uncached shared prefix.
         return blocks, num_local, 0, min(per_group_hits) < num_local
 
     def allocate_slots(

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -571,6 +571,7 @@ class KVCacheManager:
             num_tokens_need_slot,
             num_tokens_main_model,
             num_encoder_tokens,
+            num_new_tokens,
         )
 
         # P/D: delay caching blocks if we have to recv from

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -336,24 +336,19 @@ class KVCacheManager:
         computed, per_group_hits = coordinator.find_longest_cache_hit_per_group(
             request.block_hashes, request.num_tokens - 1
         )
-        # Two questions, so two reductions over the dense groups. Both
-        # reduce to the single-group behaviour when there is only one.
+        # Report the shortest dense hit, then reconcile deeper sparse hits.
         dense_hits = [
             per_group_hits[group_id]
             for group_id in coordinator.full_attention_group_ids
         ]
-        if any(hit > max(dense_hits) for hit in per_group_hits):
-            # Eviction test: a group deeper than *every* dense group means the
-            # dense blocks were evicted. Comparing against one arbitrary dense
-            # group instead would read a finer-grained sibling as eviction and
-            # give up the fast path on most hits.
+        num_local = min(dense_hits)
+        if any(
+            hit > num_local
+            and not coordinator.single_type_managers[group_id].is_downward_closed
+            for group_id, hit in enumerate(per_group_hits)
+        ):
             return *self.get_computed_blocks(request), False
 
-        # Reported length: the blocks below come from the per-group lookup at
-        # each group's own hit, not from a reconciled one, so this must be a
-        # length every dense group's list actually covers. The max would name a
-        # boundary the coarser group's blocks fall short of.
-        num_local = min(dense_hits)
         # Reducing the reported length is not enough on its own: a dense group
         # that hit deeper keeps a block list longer than `num_local` covers,
         # and the pair is handed straight to `add_local_computed_blocks`. Trim

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -14,7 +14,11 @@ from vllm.v1.core.kv_cache_coordinator import (
     get_kv_cache_coordinator,
 )
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
-from vllm.v1.core.kv_cache_utils import KVCacheBlock, KVCacheBlockCopy
+from vllm.v1.core.kv_cache_utils import (
+    KVCacheBlock,
+    KVCacheBlockCopy,
+    truncate_downward_closed_groups,
+)
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     CrossAttentionSpec,
@@ -329,18 +333,45 @@ class KVCacheManager:
         if not self.prefix_cache_lookup_enabled(request):
             return self.empty_kv_cache_blocks, 0, 0, False
 
-        fa_group_id = coordinator.full_attention_group_id
         computed, per_group_hits = coordinator.find_longest_cache_hit_per_group(
             request.block_hashes, request.num_tokens - 1
         )
-        if any(hit > per_group_hits[fa_group_id] for hit in per_group_hits):
-            # A lagging group hit deeper than full attention means its
-            # full-attention blocks were evicted; use the reconciled boundary
-            # that every group agrees on.
+        # Two different questions, so two different reductions over the dense
+        # groups. There can be more than one -- a DFlash drafter booking its
+        # sliding-window layers as full attention adds a second at a smaller
+        # block size -- and the finer-grained one legitimately hits deeper
+        # whenever the reconciled hit is not a multiple of the coarser block
+        # size. Both reduce to the single-group behaviour when there is one.
+        dense_hits = [
+            per_group_hits[group_id]
+            for group_id in coordinator.full_attention_group_ids
+        ]
+        if any(hit > max(dense_hits) for hit in per_group_hits):
+            # Eviction test: a group deeper than *every* dense group means the
+            # dense blocks were evicted. Comparing against one arbitrary dense
+            # group instead would read a finer-grained sibling as eviction and
+            # give up the fast path on most hits.
             return *self.get_computed_blocks(request), False
 
-        num_local = per_group_hits[fa_group_id]
-        blocks = self.create_kv_cache_blocks(computed)
+        # Reported length: the blocks below come from the per-group lookup at
+        # each group's own hit, not from a reconciled one, so this must be a
+        # length every dense group's list actually covers. The max would name a
+        # boundary the coarser group's blocks fall short of.
+        num_local = min(dense_hits)
+        # Reducing the reported length is not enough on its own: a dense group
+        # that hit deeper keeps a block list longer than `num_local` covers,
+        # and the pair is handed straight to `add_local_computed_blocks`. Trim
+        # for the same reason the reconciling path does, at each group's own
+        # block size.
+        hit_blocks = [list(blocks) for blocks in computed]
+        truncate_downward_closed_groups(
+            ((g.spec, g.group_ids) for g in coordinator.attention_groups),
+            num_local,
+            hit_blocks,
+            list(per_group_hits),
+            lambda gid: coordinator.single_type_managers[gid].block_size,
+        )
+        blocks = self.create_kv_cache_blocks(tuple(hit_blocks))
         # Per-group lookups do not detect an uncached shared prefix (boundary 0).
         return blocks, num_local, 0, min(per_group_hits) < num_local
 

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -336,12 +336,8 @@ class KVCacheManager:
         computed, per_group_hits = coordinator.find_longest_cache_hit_per_group(
             request.block_hashes, request.num_tokens - 1
         )
-        # Two different questions, so two different reductions over the dense
-        # groups. There can be more than one -- a DFlash drafter booking its
-        # sliding-window layers as full attention adds a second at a smaller
-        # block size -- and the finer-grained one legitimately hits deeper
-        # whenever the reconciled hit is not a multiple of the coarser block
-        # size. Both reduce to the single-group behaviour when there is one.
+        # Two questions, so two reductions over the dense groups. Both
+        # reduce to the single-group behaviour when there is only one.
         dense_hits = [
             per_group_hits[group_id]
             for group_id in coordinator.full_attention_group_ids
@@ -368,6 +364,8 @@ class KVCacheManager:
             ((g.spec, g.group_ids) for g in coordinator.attention_groups),
             num_local,
             hit_blocks,
+            # A copy on purpose: only the trimmed blocks are wanted here, and
+            # the caller-visible flag below reports on the pre-trim hits.
             list(per_group_hits),
             lambda gid: coordinator.single_type_managers[gid].block_size,
         )

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -2384,7 +2384,7 @@ def partial_hash_hits_enabled(
 def truncate_downward_closed_groups(
     groups: Iterable[tuple[KVCacheSpec, Sequence[int]]],
     hit_length: int,
-    hit_blocks_by_group: list[list["KVCacheBlock"] | None],
+    hit_blocks_by_group: Sequence[list["KVCacheBlock"] | None],
     hit_length_by_group: list[int],
     block_size_of: Callable[[int], int],
 ) -> None:

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -2398,8 +2398,11 @@ def truncate_downward_closed_groups(
     shared blocks the request does not own in the worst.
 
     There can be more than one such group, at different block sizes, so each
-    trims at its own. Callers pass ``block_size_of`` because the coordinator's
-    manager block size is DCP-scaled while a spec-level caller's is not.
+    trims at its own: a DFlash drafter booking its sliding-window layers as
+    full attention keeps the smaller sliding-window block size, giving a model
+    two full-attention groups. Callers pass ``block_size_of`` because the
+    coordinator's manager block size is DCP-scaled while a spec-level caller's
+    is not.
     """
     for spec, group_ids in groups:
         manager_cls = KVCacheSpecRegistry.get_manager_class(spec)

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -2315,3 +2315,98 @@ def resolve_block_hashes(
         return block_hashes
     assert block_size % hash_block_size == 0
     return BlockHashListWithBlockSize(block_hashes, hash_block_size, block_size)
+
+
+def partial_hash_hits_enabled(
+    kv_cache_groups: Sequence[KVCacheGroupSpec],
+    hash_block_size: int,
+    *,
+    dcp_world_size: int = 1,
+) -> bool:
+    """Whether fine-grained (partial) prefix-cache hits may be enabled.
+
+    Two conditions. The feature exists for mamba "align" groups whose block
+    size exceeds the hash granularity, so at least one must be present. And
+    every group must be *able* to be looked up at that granularity: a manager
+    without fine-grained lookup indexes the block-hash list in units of its own
+    block size, so including one at a finer alignment would key its lookups off
+    the wrong hashes.
+
+    The single copy on purpose. The core coordinator, the Mooncake store
+    coordinator and the scheduler all need this answer, and when they computed
+    it separately they disagreed -- the scheduler kept emitting a sub-block
+    prefill stop for a partial tail entry the coordinator would no longer
+    accept.
+
+    Args:
+        kv_cache_groups: One entry per KV cache group.
+        hash_block_size: The granularity ``Request.block_hashes`` is computed at.
+        dcp_world_size: Partial hits are unsupported under context parallelism.
+    """
+    if dcp_world_size != 1:
+        return False
+
+    specs = [
+        next(iter(g.kv_cache_spec.kv_cache_specs.values()))
+        if isinstance(g.kv_cache_spec, UniformTypeKVCacheSpecs)
+        else g.kv_cache_spec
+        for g in kv_cache_groups
+    ]
+    if not any(
+        isinstance(spec, MambaSpec)
+        and spec.mamba_cache_mode == "align"
+        and spec.block_size > hash_block_size
+        for spec in specs
+    ):
+        return False
+
+    unsupported = set()
+    for spec in specs:
+        manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
+        assert manager_cls is not None, f"No manager registered for KVCacheSpec {spec}"
+        if (
+            not manager_cls.supports_fine_grained_hash_lookup
+            and spec.block_size != hash_block_size
+        ):
+            unsupported.add(manager_cls.__name__)
+    if not unsupported:
+        return True
+    logger.warning_once(
+        "Disabling fine-grained (partial) prefix-cache hits: the prefix match "
+        "unit is %d but these block-aligned-only KV cache managers use a "
+        "larger block size: %s.",
+        hash_block_size,
+        ", ".join(sorted(unsupported)),
+    )
+    return False
+
+
+def truncate_downward_closed_groups(
+    groups: Iterable[tuple[KVCacheSpec, Sequence[int]]],
+    hit_length: int,
+    hit_blocks_by_group: list[list["KVCacheBlock"] | None],
+    hit_length_by_group: list[int],
+    block_size_of: Callable[[int], int],
+) -> None:
+    """Trim every downward-closed group's block list to ``hit_length``.
+
+    A downward-closed manager is looked up once against the initial candidate
+    length and skipped on later fixed-point passes, so a reduction afterwards
+    leaves its list too long. Untrimmed, the extra blocks reach
+    ``add_local_computed_blocks``, which extends the request's block table with
+    blocks past the reconciled boundary -- an assertion in the best case and
+    shared blocks the request does not own in the worst.
+
+    There can be more than one such group, at different block sizes, so each
+    trims at its own. Callers pass ``block_size_of`` because the coordinator's
+    manager block size is DCP-scaled while a spec-level caller's is not.
+    """
+    for spec, group_ids in groups:
+        manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
+        if manager_cls is None or not manager_cls.is_downward_closed:
+            continue
+        for group_id in group_ids:
+            if (blocks := hit_blocks_by_group[group_id]) is None:
+                continue
+            del blocks[cdiv(hit_length, block_size_of(group_id)) :]
+            hit_length_by_group[group_id] = hit_length

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -2492,8 +2492,11 @@ def truncate_downward_closed_groups(
     shared blocks the request does not own in the worst.
 
     There can be more than one such group, at different block sizes, so each
-    trims at its own. Callers pass ``block_size_of`` because the coordinator's
-    manager block size is DCP-scaled while a spec-level caller's is not.
+    trims at its own: a DFlash drafter booking its sliding-window layers as
+    full attention keeps the smaller sliding-window block size, giving a model
+    two full-attention groups. Callers pass ``block_size_of`` because the
+    coordinator's manager block size is DCP-scaled while a spec-level caller's
+    is not.
     """
     for spec, group_ids in groups:
         manager_cls = KVCacheSpecRegistry.get_manager_class(spec)

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -2397,3 +2397,110 @@ def resolve_block_hashes(
         return block_hashes
     assert block_size % hash_block_size == 0
     return BlockHashListWithBlockSize(block_hashes, hash_block_size, block_size)
+
+
+def partial_hash_hits_enabled(
+    kv_cache_groups: Sequence[KVCacheGroupSpec],
+    hash_block_size: int,
+    *,
+    dcp_world_size: int = 1,
+) -> bool:
+    """Whether fine-grained (partial) prefix-cache hits may be enabled.
+
+    Two conditions. The feature exists for mamba "align" groups whose block
+    size exceeds the hash granularity, so at least one must be present. And
+    every group must be *able* to be looked up at that granularity: a manager
+    without fine-grained lookup indexes the block-hash list in units of its own
+    block size, so including one at a finer alignment would key its lookups off
+    the wrong hashes.
+
+    The single copy on purpose. The core coordinator, the Mooncake store
+    coordinator and the scheduler all need this answer, and when they computed
+    it separately they disagreed -- the scheduler kept emitting a sub-block
+    prefill stop for a partial tail entry the coordinator would no longer
+    accept.
+
+    Under DCP the attention managers scale their effective block size by the
+    world size, so the mamba "align" trigger accepts equality with the hash
+    granularity and the compatibility check compares against the scaled size.
+
+    Args:
+        kv_cache_groups: One entry per KV cache group.
+        hash_block_size: The granularity ``Request.block_hashes`` is computed at.
+        dcp_world_size: The decode-context-parallel world size.
+    """
+    specs = [
+        next(iter(g.kv_cache_spec.kv_cache_specs.values()))
+        if isinstance(g.kv_cache_spec, UniformTypeKVCacheSpecs)
+        else g.kv_cache_spec
+        for g in kv_cache_groups
+    ]
+    if not any(
+        isinstance(spec, MambaSpec)
+        and spec.mamba_cache_mode == "align"
+        and (
+            spec.block_size > hash_block_size
+            if dcp_world_size == 1
+            else spec.block_size >= hash_block_size
+        )
+        for spec in specs
+    ):
+        return False
+
+    unsupported = set()
+    for spec in specs:
+        manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
+        assert manager_cls is not None, f"No manager registered for KVCacheSpec {spec}"
+        # Mamba state is replicated across DCP ranks; attention KV is
+        # partitioned, scaling the manager's effective block size.
+        block_size = (
+            spec.block_size
+            if isinstance(spec, MambaSpec)
+            else spec.block_size * dcp_world_size
+        )
+        if (
+            not manager_cls.supports_fine_grained_hash_lookup
+            and block_size != hash_block_size
+        ):
+            unsupported.add(manager_cls.__name__)
+    if not unsupported:
+        return True
+    logger.warning_once(
+        "Disabling fine-grained (partial) prefix-cache hits: the prefix match "
+        "unit is %d but these block-aligned-only KV cache managers use a "
+        "larger block size: %s.",
+        hash_block_size,
+        ", ".join(sorted(unsupported)),
+    )
+    return False
+
+
+def truncate_downward_closed_groups(
+    groups: Iterable[tuple[KVCacheSpec, Sequence[int]]],
+    hit_length: int,
+    hit_blocks_by_group: list[list["KVCacheBlock"] | None],
+    hit_length_by_group: list[int],
+    block_size_of: Callable[[int], int],
+) -> None:
+    """Trim every downward-closed group's block list to ``hit_length``.
+
+    A downward-closed manager is looked up once against the initial candidate
+    length and skipped on later fixed-point passes, so a reduction afterwards
+    leaves its list too long. Untrimmed, the extra blocks reach
+    ``add_local_computed_blocks``, which extends the request's block table with
+    blocks past the reconciled boundary -- an assertion in the best case and
+    shared blocks the request does not own in the worst.
+
+    There can be more than one such group, at different block sizes, so each
+    trims at its own. Callers pass ``block_size_of`` because the coordinator's
+    manager block size is DCP-scaled while a spec-level caller's is not.
+    """
+    for spec, group_ids in groups:
+        manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
+        if manager_cls is None or not manager_cls.is_downward_closed:
+            continue
+        for group_id in group_ids:
+            if (blocks := hit_blocks_by_group[group_id]) is None:
+                continue
+            del blocks[cdiv(hit_length, block_size_of(group_id)) :]
+            hit_length_by_group[group_id] = hit_length

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -2478,7 +2478,7 @@ def partial_hash_hits_enabled(
 def truncate_downward_closed_groups(
     groups: Iterable[tuple[KVCacheSpec, Sequence[int]]],
     hit_length: int,
-    hit_blocks_by_group: list[list["KVCacheBlock"] | None],
+    hit_blocks_by_group: Sequence[list["KVCacheBlock"] | None],
     hit_length_by_group: list[int],
     block_size_of: Callable[[int], int],
 ) -> None:

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -2405,30 +2405,7 @@ def partial_hash_hits_enabled(
     *,
     dcp_world_size: int = 1,
 ) -> bool:
-    """Whether fine-grained (partial) prefix-cache hits may be enabled.
-
-    Two conditions. The feature exists for mamba "align" groups whose block
-    size exceeds the hash granularity, so at least one must be present. And
-    every group must be *able* to be looked up at that granularity: a manager
-    without fine-grained lookup indexes the block-hash list in units of its own
-    block size, so including one at a finer alignment would key its lookups off
-    the wrong hashes.
-
-    The single copy on purpose. The core coordinator, the Mooncake store
-    coordinator and the scheduler all need this answer, and when they computed
-    it separately they disagreed -- the scheduler kept emitting a sub-block
-    prefill stop for a partial tail entry the coordinator would no longer
-    accept.
-
-    Under DCP the attention managers scale their effective block size by the
-    world size, so the mamba "align" trigger accepts equality with the hash
-    granularity and the compatibility check compares against the scaled size.
-
-    Args:
-        kv_cache_groups: One entry per KV cache group.
-        hash_block_size: The granularity ``Request.block_hashes`` is computed at.
-        dcp_world_size: The decode-context-parallel world size.
-    """
+    """Return whether fine-grained prefix-cache hits are supported."""
     specs = [
         next(iter(g.kv_cache_spec.kv_cache_specs.values()))
         if isinstance(g.kv_cache_spec, UniformTypeKVCacheSpecs)
@@ -2482,22 +2459,7 @@ def truncate_downward_closed_groups(
     hit_length_by_group: list[int],
     block_size_of: Callable[[int], int],
 ) -> None:
-    """Trim every downward-closed group's block list to ``hit_length``.
-
-    A downward-closed manager is looked up once against the initial candidate
-    length and skipped on later fixed-point passes, so a reduction afterwards
-    leaves its list too long. Untrimmed, the extra blocks reach
-    ``add_local_computed_blocks``, which extends the request's block table with
-    blocks past the reconciled boundary -- an assertion in the best case and
-    shared blocks the request does not own in the worst.
-
-    There can be more than one such group, at different block sizes, so each
-    trims at its own: a DFlash drafter booking its sliding-window layers as
-    full attention keeps the smaller sliding-window block size, giving a model
-    two full-attention groups. Callers pass ``block_size_of`` because the
-    coordinator's manager block size is DCP-scaled while a spec-level caller's
-    is not.
-    """
+    """Trim each downward-closed group's blocks to ``hit_length``."""
     for spec, group_ids in groups:
         manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
         if manager_cls is None or not manager_cls.is_downward_closed:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -317,12 +317,9 @@ class Scheduler(SchedulerInterface):
         # A finer prefix_match_unit is configured: a mamba partial tail entry
         # can only be registered by a step ending exactly at the prompt's last
         # hash boundary, so the split adds that stop.
-        # Ask the coordinator rather than recomputing: the sub-block stop this
-        # gates exists solely so a mamba partial-tail entry can be registered,
-        # and the coordinator may have disabled fine-grained hits for a reason
-        # this expression cannot see (a group that can only be looked up at
-        # block granularity). Computing it here as well is how the two came to
-        # disagree, leaving a stop that could no longer serve any purpose.
+        # Ask the coordinator rather than recomputing: it may have disabled
+        # fine-grained hits for a reason this expression cannot see, and a
+        # second copy of the rule is how the two came to disagree.
         self.mamba_partial_cache_hit = (
             self.need_mamba_block_aligned_split
             and self.hash_block_size < self.block_size

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -317,9 +317,18 @@ class Scheduler(SchedulerInterface):
         # A finer prefix_match_unit is configured: a mamba partial tail entry
         # can only be registered by a step ending exactly at the prompt's last
         # hash boundary, so the split adds that stop.
+        # Ask the coordinator rather than recomputing: the sub-block stop this
+        # gates exists solely so a mamba partial-tail entry can be registered,
+        # and the coordinator may have disabled fine-grained hits for a reason
+        # this expression cannot see (a group that can only be looked up at
+        # block granularity). Computing it here as well is how the two came to
+        # disagree, leaving a stop that could no longer serve any purpose.
         self.mamba_partial_cache_hit = (
             self.need_mamba_block_aligned_split
             and self.hash_block_size < self.block_size
+            and getattr(
+                self.kv_cache_manager.coordinator, "enable_partial_hash_hits", True
+            )
         )
 
         # Counts of non-empty steps scheduled / processed. update_from_output

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -327,6 +327,9 @@ class Scheduler(SchedulerInterface):
         # A finer prefix_match_unit is configured: a mamba partial tail entry
         # can only be registered by a step ending exactly at the prompt's last
         # hash boundary, so the split adds that stop.
+        # Ask the coordinator rather than recomputing: it may have disabled
+        # fine-grained hits for a reason this expression cannot see, and a
+        # second copy of the rule is how the two came to disagree.
         self.mamba_partial_cache_hit = (
             self.need_mamba_block_aligned_split
             and self.hash_block_size < self.block_size

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -440,6 +440,7 @@ class SingleTypeKVCacheManager(ABC):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        extra_block_mask: list[bool] | None = None,
     ) -> None:
         """
         Cache the blocks for the request.
@@ -452,6 +453,12 @@ class SingleTypeKVCacheManager(ABC):
                 keeps dense checkpointing; ``0`` keeps only the latest replay
                 boundary; a positive multiple of ``scheduler_block_size`` keeps
                 a tail once per that-sized segment. Only SWA acts on it.
+            extra_block_mask: Optional mask aligned with
+                ``blocks[num_cached_blocks:num_full_blocks]``, ANDed with this
+                manager's own ``reachable_block_mask``. A manager whose blocks
+                only sometimes hold the content the hash they would be keyed
+                under describes uses this to withhold the ones that do not. It
+                can only remove admissions, never add them.
         """
         num_cached_blocks = self.num_cached_block.get(request.request_id, 0)
         num_full_blocks = num_tokens // self.block_size
@@ -475,6 +482,16 @@ class SingleTypeKVCacheManager(ABC):
             retention_interval=retention_interval,
             reachable_boundaries=reachable_boundaries,
         )
+        if extra_block_mask is not None:
+            assert len(extra_block_mask) == num_full_blocks - num_cached_blocks
+            block_mask = (
+                extra_block_mask
+                if block_mask is None
+                else [
+                    reachable and admitted
+                    for reachable, admitted in zip(block_mask, extra_block_mask)
+                ]
+            )
         self.block_pool.cache_full_blocks(
             request=request,
             blocks=self.req_to_blocks[request.request_id],
@@ -793,8 +810,14 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        extra_block_mask: list[bool] | None = None,
     ) -> None:
-        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        super().cache_blocks(
+            request,
+            num_tokens,
+            retention_interval=retention_interval,
+            extra_block_mask=extra_block_mask,
+        )
         hash_block_size = self.block_pool.hash_block_size
         if self.block_size == hash_block_size:
             return
@@ -1297,6 +1320,12 @@ class MambaManager(SingleTypeKVCacheManager):
             # into a private cow_block; we record that block for connector
             # offload (see _pending_partial_tail_offloads).
             self._producer_partial_tail_reqs: dict[str, int] = {}
+            # Mapping from request ID to the token count the most recently
+            # scheduled forward leaves the recurrent state at. This is the
+            # position the state written into `last_state_block_idx + 1`
+            # describes, and it is what decides whether that block may be
+            # keyed under a block-boundary hash.
+            self._state_write_tokens: dict[str, int] = {}
 
     @classmethod
     def find_longest_cache_hit(
@@ -1570,6 +1599,11 @@ class MambaManager(SingleTypeKVCacheManager):
             # We can ignore lookahead tokens because current draft models don't have
             # mamba layers.
             num_tokens = num_tokens_main_model
+            # Where this step's forward leaves the recurrent state. It counts
+            # the unverified draft tokens the target model runs over, which is
+            # exactly what the state write covers, and is recorded before the
+            # early return below so every scheduled step is represented.
+            self._state_write_tokens[request_id] = num_tokens
             req_blocks: list[KVCacheBlock] = self.req_to_blocks[request_id]
             # NOTE(tdouble): this is an over-estimate of how many blocks we need because
             # num_tokens can include draft tokens that will later be rejected.
@@ -1677,6 +1711,7 @@ class MambaManager(SingleTypeKVCacheManager):
             self._allocated_block_reqs.discard(request_id)
             self.last_state_block_idx.pop(request_id, None)
             self._producer_partial_tail_reqs.pop(request_id, None)
+            self._state_write_tokens.pop(request_id, None)
             # A hand-off whose request died in this same scheduling pass must
             # not reach the connector: its unpin hook (free) has already run.
             self._pending_partial_tail_offloads = [
@@ -1699,9 +1734,27 @@ class MambaManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        extra_block_mask: list[bool] | None = None,
     ) -> None:
         num_cached_blocks_before = self.num_cached_block.get(request.request_id, 0)
-        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        boundary_mask = self._boundary_state_block_mask(
+            request,
+            start_block=num_cached_blocks_before,
+            end_block=num_tokens // self.block_size,
+        )
+        if extra_block_mask is not None:
+            boundary_mask = [
+                caller and boundary
+                for caller, boundary in zip(
+                    extra_block_mask, boundary_mask, strict=True
+                )
+            ]
+        super().cache_blocks(
+            request,
+            num_tokens,
+            retention_interval=retention_interval,
+            extra_block_mask=boundary_mask,
+        )
         num_cached_blocks_after = self.num_cached_block.get(request.request_id, 0)
         if self.mamba_cache_mode == "align":
             partial_hash = self._cache_partial_tail_block(request, num_tokens)
@@ -1718,6 +1771,48 @@ class MambaManager(SingleTypeKVCacheManager):
                 if block.is_null or block.block_hash is None:
                     continue
                 self.cached_blocks_this_step.add(block.block_hash)
+
+    def _boundary_state_block_mask(
+        self,
+        request: Request,
+        start_block: int,
+        end_block: int,
+    ) -> list[bool] | None:
+        """Admit only a state block that holds the state at its own boundary.
+
+        A cached block ``j`` is keyed under the hash of the prefix ending at
+        ``(j + 1) * block_size`` and registered with that many hash tokens, so
+        a request restoring from it resumes as if exactly that many tokens had
+        been consumed. In "align" mode the recurrent state saved in block ``j``
+        is instead whatever the forward left after the tokens that step
+        scheduled, which only coincides with the boundary when the step happens
+        to end on it. Prefill chunks are clipped to end on one; decode steps are
+        not, and a step that speculates also runs over draft tokens that may be
+        rejected afterwards.
+
+        Admit the single block that this step's write lands on, and only when
+        that landing is both exactly on the boundary and entirely made of
+        committed tokens. Everything else is withheld, including blocks written
+        by an earlier step: those were offered under this same rule when they
+        were written, so a second look can only re-offer a state the rule has
+        already rejected.
+
+        Returns ``None`` in non-align mode, where the state block is not
+        snapshotted per block and dense caching is correct.
+        """
+        if self.mamba_cache_mode != "align":
+            return None
+        num_state_tokens = self._state_write_tokens.get(request.request_id)
+        # `request.num_tokens` counts committed tokens only, so a write that
+        # ran past it covers draft tokens that are not decided yet.
+        if (
+            num_state_tokens is None
+            or num_state_tokens % self.block_size != 0
+            or num_state_tokens > request.num_tokens
+        ):
+            return [False] * max(end_block - start_block, 0)
+        boundary_block = num_state_tokens // self.block_size - 1
+        return [block == boundary_block for block in range(start_block, end_block)]
 
     def new_step_starts(self) -> None:
         self.cached_blocks_this_step.clear()
@@ -1794,6 +1889,7 @@ class CrossAttentionManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        extra_block_mask: list[bool] | None = None,
     ) -> None:
         # We do not cache blocks for cross-attention to be shared between
         # requests, so this method is not relevant.

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -41,6 +41,17 @@ class SingleTypeKVCacheManager(ABC):
 
     supports_fine_grained_hash_lookup: ClassVar[bool] = False
 
+    is_downward_closed: ClassVar[bool] = False
+    """Whether a hit at length N implies a hit at every shorter length.
+
+    A downward-closed manager is looked up once against the coordinator's
+    initial candidate length and then skipped on later fixed-point passes, so
+    whatever reduced the reconciled length afterwards leaves its block list too
+    long. Callers that reconcile across groups must trim every such group at
+    the end. Declared here rather than tested with ``isinstance`` at each site,
+    because the same omission has been fixed three times in different files.
+    """
+
     def __init__(
         self,
         kv_cache_spec: KVCacheSpec,
@@ -677,6 +688,7 @@ class SingleTypeKVCacheManager(ABC):
 
 class FullAttentionManager(SingleTypeKVCacheManager):
     supports_fine_grained_hash_lookup: ClassVar[bool] = True
+    is_downward_closed: ClassVar[bool] = True
 
     @classmethod
     def find_longest_cache_hit(
@@ -911,7 +923,17 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         )
         assert dcp_world_size == 1, "DCP not support sliding window attn now."
         assert pcp_world_size == 1, "PCP not support sliding window attn now."
-        # Fine-grained partial hits are not supported for sliding window now
+        # The scan below indexes `block_hashes` in whole blocks, so a finer
+        # alignment would read the wrong entries. The coordinator keeps this
+        # unreachable by disabling partial hash hits for models containing a
+        # group that only supports block-aligned lookup.
+        # TODO: supporting them here would let a mamba-"align" + sliding-window
+        # model keep its partial hits instead of falling back. It needs a
+        # block-size view for the contiguous-run scan alongside the raw hashes
+        # (as FullAttentionManager keeps), a partial-tail cache entry to match
+        # against, a `reachable_block_mask` that accepts a sub-block alignment,
+        # and a contiguous-block requirement computed from the partial tail
+        # length rather than once from the window.
         assert alignment_tokens % kv_cache_spec.block_size == 0, (
             "SlidingWindowManager does not support fine-grained (partial) cache hits"
         )

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -454,7 +454,7 @@ class SingleTypeKVCacheManager(ABC):
                 boundary; a positive multiple of ``scheduler_block_size`` keeps
                 a tail once per that-sized segment. Only SWA acts on it.
             extra_block_mask: Optional mask aligned with
-                ``blocks[num_cached_blocks:num_full_blocks]``, ANDed with this
+                ``blocks[num_cached_blocks:num_full_blocks]``, intersected with this
                 manager's own ``reachable_block_mask``. A manager whose blocks
                 only sometimes hold the content the hash they would be keyed
                 under describes uses this to withhold the ones that do not. It
@@ -1741,12 +1741,19 @@ class MambaManager(SingleTypeKVCacheManager):
             end_block=num_tokens // self.block_size,
         )
         if extra_block_mask is not None:
-            boundary_mask = [
-                caller and boundary
-                for caller, boundary in zip(
-                    extra_block_mask, boundary_mask, strict=True
-                )
-            ]
+            # A `None` boundary mask means non-align mode, where this manager
+            # imposes no per-block constraint, so the caller's mask stands on
+            # its own rather than being intersected with anything.
+            boundary_mask = (
+                extra_block_mask
+                if boundary_mask is None
+                else [
+                    caller and boundary
+                    for caller, boundary in zip(
+                        extra_block_mask, boundary_mask, strict=True
+                    )
+                ]
+            )
         super().cache_blocks(
             request,
             num_tokens,

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -952,11 +952,9 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         # group that only supports block-aligned lookup.
         # TODO: supporting them here would let a mamba-"align" + sliding-window
         # model keep its partial hits instead of falling back. It needs a
-        # block-size view for the contiguous-run scan alongside the raw hashes
-        # (as FullAttentionManager keeps), a partial-tail cache entry to match
-        # against, a `reachable_block_mask` that accepts a sub-block alignment,
-        # and a contiguous-block requirement computed from the partial tail
-        # length rather than once from the window.
+        # block-size view for the scan, a partial-tail cache entry, a
+        # sub-block-aligned `reachable_block_mask`, and a contiguous-block
+        # requirement derived from the tail length rather than the window.
         assert alignment_tokens % kv_cache_spec.block_size == 0, (
             "SlidingWindowManager does not support fine-grained (partial) cache hits"
         )

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -451,7 +451,7 @@ class SingleTypeKVCacheManager(ABC):
                 boundary; a positive multiple of ``scheduler_block_size`` keeps
                 a tail once per that-sized segment. Only SWA acts on it.
             extra_block_mask: Optional mask aligned with
-                ``blocks[num_cached_blocks:num_full_blocks]``, ANDed with this
+                ``blocks[num_cached_blocks:num_full_blocks]``, intersected with this
                 manager's own ``reachable_block_mask``. A manager whose blocks
                 only sometimes hold the content the hash they would be keyed
                 under describes uses this to withhold the ones that do not. It
@@ -1757,12 +1757,19 @@ class MambaManager(SingleTypeKVCacheManager):
             end_block=num_tokens // self.block_size,
         )
         if extra_block_mask is not None:
-            boundary_mask = [
-                caller and boundary
-                for caller, boundary in zip(
-                    extra_block_mask, boundary_mask, strict=True
-                )
-            ]
+            # A `None` boundary mask means non-align mode, where this manager
+            # imposes no per-block constraint, so the caller's mask stands on
+            # its own rather than being intersected with anything.
+            boundary_mask = (
+                extra_block_mask
+                if boundary_mask is None
+                else [
+                    caller and boundary
+                    for caller, boundary in zip(
+                        extra_block_mask, boundary_mask, strict=True
+                    )
+                ]
+            )
         super().cache_blocks(
             request,
             num_tokens,

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import itertools
 from abc import ABC, abstractmethod
-from collections import defaultdict
+from collections import defaultdict, deque
 from collections.abc import Sequence
 from typing import ClassVar
 
@@ -336,7 +336,11 @@ class SingleTypeKVCacheManager(ABC):
             self.new_block_ids.extend(b.block_id for b in allocated_blocks)
 
     def allocate_new_blocks(
-        self, request_id: str, num_tokens: int, num_tokens_main_model: int
+        self,
+        request_id: str,
+        num_tokens: int,
+        num_tokens_main_model: int,
+        num_new_tokens: int | None = None,
     ) -> list[KVCacheBlock]:
         """
         Allocate new blocks for the request to give it at least `num_tokens`
@@ -349,6 +353,7 @@ class SingleTypeKVCacheManager(ABC):
             num_tokens_main_model: The number of tokens for the main model (aka target
                 model in spec decode). w/o spec decode, it is num_tokens;
                 with spec decode, it is num_tokens - num_lookahead_tokens.
+            num_new_tokens: The number of tokens newly scheduled in this step.
         Returns:
             The new allocated blocks.
         """
@@ -1338,7 +1343,7 @@ class MambaManager(SingleTypeKVCacheManager):
             # position the state written into `last_state_block_idx + 1`
             # describes, and it is what decides whether that block may be
             # keyed under a block-boundary hash.
-            self._state_write_tokens: dict[str, int] = {}
+            self._state_write_tokens: dict[str, deque[int]] = {}
 
     @classmethod
     def find_longest_cache_hit(
@@ -1594,7 +1599,11 @@ class MambaManager(SingleTypeKVCacheManager):
             return num_new_blocks + num_evictable_computed_blocks
 
     def allocate_new_blocks(
-        self, request_id: str, num_tokens: int, num_tokens_main_model: int
+        self,
+        request_id: str,
+        num_tokens: int,
+        num_tokens_main_model: int,
+        num_new_tokens: int | None = None,
     ) -> list[KVCacheBlock]:
         assert isinstance(self.kv_cache_spec, MambaSpec)
         if self.mamba_cache_mode != "align":
@@ -1612,11 +1621,12 @@ class MambaManager(SingleTypeKVCacheManager):
             # We can ignore lookahead tokens because current draft models don't have
             # mamba layers.
             num_tokens = num_tokens_main_model
-            # Where this step's forward leaves the recurrent state. It counts
-            # the unverified draft tokens the target model runs over, which is
-            # exactly what the state write covers, and is recorded before the
-            # early return below so every scheduled step is represented.
-            self._state_write_tokens[request_id] = num_tokens
+            assert num_new_tokens is not None
+            pending_writes = self._state_write_tokens.setdefault(request_id, deque())
+            step_start = num_tokens_main_model - num_new_tokens
+            while pending_writes and pending_writes[-1] > step_start:
+                pending_writes.pop()
+            pending_writes.append(num_tokens_main_model)
             req_blocks: list[KVCacheBlock] = self.req_to_blocks[request_id]
             # NOTE(tdouble): this is an over-estimate of how many blocks we need because
             # num_tokens can include draft tokens that will later be rejected.
@@ -1823,17 +1833,18 @@ class MambaManager(SingleTypeKVCacheManager):
         """
         if self.mamba_cache_mode != "align":
             return None
-        num_state_tokens = self._state_write_tokens.get(request.request_id)
-        # `request.num_tokens` counts committed tokens only, so a write that
-        # ran past it covers draft tokens that are not decided yet.
-        if (
-            num_state_tokens is None
-            or num_state_tokens % self.block_size != 0
-            or num_state_tokens > request.num_tokens
-        ):
-            return [False] * max(end_block - start_block, 0)
-        boundary_block = num_state_tokens // self.block_size - 1
-        return [block == boundary_block for block in range(start_block, end_block)]
+        pending_writes = self._state_write_tokens.get(request.request_id)
+        mask = [False] * max(end_block - start_block, 0)
+        if pending_writes is None:
+            return mask
+        while pending_writes and pending_writes[0] <= request.num_tokens:
+            num_state_tokens = pending_writes.popleft()
+            if num_state_tokens % self.block_size != 0:
+                continue
+            boundary_block = num_state_tokens // self.block_size - 1
+            if start_block <= boundary_block < end_block:
+                mask[boundary_block - start_block] = True
+        return mask
 
     def new_step_starts(self) -> None:
         self.cached_blocks_this_step.clear()

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1338,11 +1338,7 @@ class MambaManager(SingleTypeKVCacheManager):
             # into a private cow_block; we record that block for connector
             # offload (see _pending_partial_tail_offloads).
             self._producer_partial_tail_reqs: dict[str, int] = {}
-            # Mapping from request ID to the token count the most recently
-            # scheduled forward leaves the recurrent state at. This is the
-            # position the state written into `last_state_block_idx + 1`
-            # describes, and it is what decides whether that block may be
-            # keyed under a block-boundary hash.
+            # Pending state-write positions, in scheduling order.
             self._state_write_tokens: dict[str, deque[int]] = {}
 
     @classmethod
@@ -1555,11 +1551,7 @@ class MambaManager(SingleTypeKVCacheManager):
                 apply_admission_cap=apply_admission_cap,
             )
         else:
-            # We don't allocate blocks for lookahead tokens in align mode, because if
-            # x * block_size tokens are scheduled, num_tokens is
-            # x * block_size + num_lookahead_tokens and breaks the alignment.
-            # We can ignore lookahead tokens because current draft models don't have
-            # mamba layers.
+            # Align mode ignores lookahead tokens; draft models have no Mamba layers.
             num_tokens = num_tokens_main_model
 
             # NOTE(tdouble): this is an over-estimate of how many blocks we need because
@@ -1809,27 +1801,9 @@ class MambaManager(SingleTypeKVCacheManager):
         start_block: int,
         end_block: int,
     ) -> list[bool] | None:
-        """Admit only a state block that holds the state at its own boundary.
+        """Admit committed state writes that land on block boundaries.
 
-        A cached block ``j`` is keyed under the hash of the prefix ending at
-        ``(j + 1) * block_size`` and registered with that many hash tokens, so
-        a request restoring from it resumes as if exactly that many tokens had
-        been consumed. In "align" mode the recurrent state saved in block ``j``
-        is instead whatever the forward left after the tokens that step
-        scheduled, which only coincides with the boundary when the step happens
-        to end on it. Prefill chunks are clipped to end on one; decode steps are
-        not, and a step that speculates also runs over draft tokens that may be
-        rejected afterwards.
-
-        Admit the single block that this step's write lands on, and only when
-        that landing is both exactly on the boundary and entirely made of
-        committed tokens. Everything else is withheld, including blocks written
-        by an earlier step: those were offered under this same rule when they
-        were written, so a second look can only re-offer a state the rule has
-        already rejected.
-
-        Returns ``None`` in non-align mode, where the state block is not
-        snapshotted per block and dense caching is correct.
+        Non-align mode uses dense caching and has no boundary mask.
         """
         if self.mamba_cache_mode != "align":
             return None

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -437,6 +437,7 @@ class SingleTypeKVCacheManager(ABC):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        extra_block_mask: list[bool] | None = None,
     ) -> None:
         """
         Cache the blocks for the request.
@@ -449,6 +450,12 @@ class SingleTypeKVCacheManager(ABC):
                 keeps dense checkpointing; ``0`` keeps only the latest replay
                 boundary; a positive multiple of ``scheduler_block_size`` keeps
                 a tail once per that-sized segment. Only SWA acts on it.
+            extra_block_mask: Optional mask aligned with
+                ``blocks[num_cached_blocks:num_full_blocks]``, ANDed with this
+                manager's own ``reachable_block_mask``. A manager whose blocks
+                only sometimes hold the content the hash they would be keyed
+                under describes uses this to withhold the ones that do not. It
+                can only remove admissions, never add them.
         """
         num_cached_blocks = self.num_cached_block.get(request.request_id, 0)
         num_full_blocks = num_tokens // self.block_size
@@ -472,6 +479,16 @@ class SingleTypeKVCacheManager(ABC):
             retention_interval=retention_interval,
             reachable_boundaries=reachable_boundaries,
         )
+        if extra_block_mask is not None:
+            assert len(extra_block_mask) == num_full_blocks - num_cached_blocks
+            block_mask = (
+                extra_block_mask
+                if block_mask is None
+                else [
+                    reachable and admitted
+                    for reachable, admitted in zip(block_mask, extra_block_mask)
+                ]
+            )
         self.block_pool.cache_full_blocks(
             request=request,
             blocks=self.req_to_blocks[request.request_id],
@@ -795,8 +812,14 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        extra_block_mask: list[bool] | None = None,
     ) -> None:
-        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        super().cache_blocks(
+            request,
+            num_tokens,
+            retention_interval=retention_interval,
+            extra_block_mask=extra_block_mask,
+        )
         hash_block_size = self.block_pool.hash_block_size
         if self.block_size == hash_block_size:
             return
@@ -1310,6 +1333,12 @@ class MambaManager(SingleTypeKVCacheManager):
             # into a private cow_block; we record that block for connector
             # offload (see _pending_partial_tail_offloads).
             self._producer_partial_tail_reqs: dict[str, int] = {}
+            # Mapping from request ID to the token count the most recently
+            # scheduled forward leaves the recurrent state at. This is the
+            # position the state written into `last_state_block_idx + 1`
+            # describes, and it is what decides whether that block may be
+            # keyed under a block-boundary hash.
+            self._state_write_tokens: dict[str, int] = {}
 
     @classmethod
     def find_longest_cache_hit(
@@ -1583,6 +1612,11 @@ class MambaManager(SingleTypeKVCacheManager):
             # We can ignore lookahead tokens because current draft models don't have
             # mamba layers.
             num_tokens = num_tokens_main_model
+            # Where this step's forward leaves the recurrent state. It counts
+            # the unverified draft tokens the target model runs over, which is
+            # exactly what the state write covers, and is recorded before the
+            # early return below so every scheduled step is represented.
+            self._state_write_tokens[request_id] = num_tokens
             req_blocks: list[KVCacheBlock] = self.req_to_blocks[request_id]
             # NOTE(tdouble): this is an over-estimate of how many blocks we need because
             # num_tokens can include draft tokens that will later be rejected.
@@ -1691,6 +1725,7 @@ class MambaManager(SingleTypeKVCacheManager):
             self._allocated_block_reqs.discard(request_id)
             self.last_state_block_idx.pop(request_id, None)
             self._producer_partial_tail_reqs.pop(request_id, None)
+            self._state_write_tokens.pop(request_id, None)
             # A hand-off whose request died in this same scheduling pass must
             # not reach the connector: its unpin hook (free) has already run.
             self._pending_partial_tail_offloads = [
@@ -1713,9 +1748,27 @@ class MambaManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        extra_block_mask: list[bool] | None = None,
     ) -> None:
         num_cached_blocks_before = self.num_cached_block.get(request.request_id, 0)
-        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        boundary_mask = self._boundary_state_block_mask(
+            request,
+            start_block=num_cached_blocks_before,
+            end_block=num_tokens // self.block_size,
+        )
+        if extra_block_mask is not None:
+            boundary_mask = [
+                caller and boundary
+                for caller, boundary in zip(
+                    extra_block_mask, boundary_mask, strict=True
+                )
+            ]
+        super().cache_blocks(
+            request,
+            num_tokens,
+            retention_interval=retention_interval,
+            extra_block_mask=boundary_mask,
+        )
         num_cached_blocks_after = self.num_cached_block.get(request.request_id, 0)
         if self.mamba_cache_mode == "align":
             partial_hash = self._cache_partial_tail_block(request, num_tokens)
@@ -1732,6 +1785,48 @@ class MambaManager(SingleTypeKVCacheManager):
                 if block.is_null or block.block_hash is None:
                     continue
                 self.cached_blocks_this_step.add(block.block_hash)
+
+    def _boundary_state_block_mask(
+        self,
+        request: Request,
+        start_block: int,
+        end_block: int,
+    ) -> list[bool] | None:
+        """Admit only a state block that holds the state at its own boundary.
+
+        A cached block ``j`` is keyed under the hash of the prefix ending at
+        ``(j + 1) * block_size`` and registered with that many hash tokens, so
+        a request restoring from it resumes as if exactly that many tokens had
+        been consumed. In "align" mode the recurrent state saved in block ``j``
+        is instead whatever the forward left after the tokens that step
+        scheduled, which only coincides with the boundary when the step happens
+        to end on it. Prefill chunks are clipped to end on one; decode steps are
+        not, and a step that speculates also runs over draft tokens that may be
+        rejected afterwards.
+
+        Admit the single block that this step's write lands on, and only when
+        that landing is both exactly on the boundary and entirely made of
+        committed tokens. Everything else is withheld, including blocks written
+        by an earlier step: those were offered under this same rule when they
+        were written, so a second look can only re-offer a state the rule has
+        already rejected.
+
+        Returns ``None`` in non-align mode, where the state block is not
+        snapshotted per block and dense caching is correct.
+        """
+        if self.mamba_cache_mode != "align":
+            return None
+        num_state_tokens = self._state_write_tokens.get(request.request_id)
+        # `request.num_tokens` counts committed tokens only, so a write that
+        # ran past it covers draft tokens that are not decided yet.
+        if (
+            num_state_tokens is None
+            or num_state_tokens % self.block_size != 0
+            or num_state_tokens > request.num_tokens
+        ):
+            return [False] * max(end_block - start_block, 0)
+        boundary_block = num_state_tokens // self.block_size - 1
+        return [block == boundary_block for block in range(start_block, end_block)]
 
     def new_step_starts(self) -> None:
         self.cached_blocks_this_step.clear()
@@ -1808,6 +1903,7 @@ class CrossAttentionManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        extra_block_mask: list[bool] | None = None,
     ) -> None:
         # We do not cache blocks for cross-attention to be shared between
         # requests, so this method is not relevant.

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -41,6 +41,17 @@ class SingleTypeKVCacheManager(ABC):
 
     supports_fine_grained_hash_lookup: ClassVar[bool] = False
 
+    is_downward_closed: ClassVar[bool] = False
+    """Whether a hit at length N implies a hit at every shorter length.
+
+    A downward-closed manager is looked up once against the coordinator's
+    initial candidate length and then skipped on later fixed-point passes, so
+    whatever reduced the reconciled length afterwards leaves its block list too
+    long. Callers that reconcile across groups must trim every such group at
+    the end. Declared here rather than tested with ``isinstance`` at each site,
+    because the same omission has been fixed three times in different files.
+    """
+
     def __init__(
         self,
         kv_cache_spec: KVCacheSpec,
@@ -679,6 +690,7 @@ class SingleTypeKVCacheManager(ABC):
 
 class FullAttentionManager(SingleTypeKVCacheManager):
     supports_fine_grained_hash_lookup: ClassVar[bool] = True
+    is_downward_closed: ClassVar[bool] = True
 
     @classmethod
     def find_longest_cache_hit(
@@ -917,7 +929,15 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         )
         assert dcp_world_size == 1, "DCP not support sliding window attn now."
         assert pcp_world_size == 1, "PCP not support sliding window attn now."
-        # Fine-grained partial hits are not supported for sliding window now
+        # The scan below indexes `block_hashes` in whole blocks, so a finer
+        # alignment would read the wrong entries. The coordinator keeps this
+        # unreachable by disabling partial hash hits for models containing a
+        # group that only supports block-aligned lookup.
+        # TODO: supporting them here would let a mamba-"align" + sliding-window
+        # model keep its partial hits instead of falling back. It needs a
+        # block-size view for the scan, a partial-tail cache entry, a
+        # sub-block-aligned `reachable_block_mask`, and a contiguous-block
+        # requirement derived from the tail length rather than the window.
         assert alignment_tokens % kv_cache_spec.block_size == 0, (
             "SlidingWindowManager does not support fine-grained (partial) cache hits"
         )

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -42,15 +42,7 @@ class SingleTypeKVCacheManager(ABC):
     supports_fine_grained_hash_lookup: ClassVar[bool] = False
 
     is_downward_closed: ClassVar[bool] = False
-    """Whether a hit at length N implies a hit at every shorter length.
-
-    A downward-closed manager is looked up once against the coordinator's
-    initial candidate length and then skipped on later fixed-point passes, so
-    whatever reduced the reconciled length afterwards leaves its block list too
-    long. Callers that reconcile across groups must trim every such group at
-    the end. Declared here rather than tested with ``isinstance`` at each site,
-    because the same omission has been fixed three times in different files.
-    """
+    """Whether a hit at length N implies hits at shorter lengths."""
 
     def __init__(
         self,
@@ -455,12 +447,7 @@ class SingleTypeKVCacheManager(ABC):
                 keeps dense checkpointing; ``0`` keeps only the latest replay
                 boundary; a positive multiple of ``scheduler_block_size`` keeps
                 a tail once per that-sized segment. Only SWA acts on it.
-            extra_block_mask: Optional mask aligned with
-                ``blocks[num_cached_blocks:num_full_blocks]``, intersected with this
-                manager's own ``reachable_block_mask``. A manager whose blocks
-                only sometimes hold the content the hash they would be keyed
-                under describes uses this to withhold the ones that do not. It
-                can only remove admissions, never add them.
+            extra_block_mask: Optional admission mask for the uncached blocks.
         """
         num_cached_blocks = self.num_cached_block.get(request.request_id, 0)
         num_full_blocks = num_tokens // self.block_size
@@ -957,15 +944,8 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         )
         assert dcp_world_size == 1, "DCP not support sliding window attn now."
         assert pcp_world_size == 1, "PCP not support sliding window attn now."
-        # The scan below indexes `block_hashes` in whole blocks, so a finer
-        # alignment would read the wrong entries. The coordinator keeps this
-        # unreachable by disabling partial hash hits for models containing a
-        # group that only supports block-aligned lookup.
-        # TODO: supporting them here would let a mamba-"align" + sliding-window
-        # model keep its partial hits instead of falling back. It needs a
-        # block-size view for the scan, a partial-tail cache entry, a
-        # sub-block-aligned `reachable_block_mask`, and a contiguous-block
-        # requirement derived from the tail length rather than the window.
+        # Whole-block hash lookup cannot serve finer alignments.
+        # TODO: Add a block-size view before enabling partial hits here.
         assert alignment_tokens % kv_cache_spec.block_size == 0, (
             "SlidingWindowManager does not support fine-grained (partial) cache hits"
         )
@@ -1759,9 +1739,7 @@ class MambaManager(SingleTypeKVCacheManager):
             end_block=num_tokens // self.block_size,
         )
         if extra_block_mask is not None:
-            # A `None` boundary mask means non-align mode, where this manager
-            # imposes no per-block constraint, so the caller's mask stands on
-            # its own rather than being intersected with anything.
+            # Non-align mode has no internal boundary constraint.
             boundary_mask = (
                 extra_block_mask
                 if boundary_mask is None

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1811,8 +1811,14 @@ class MambaManager(SingleTypeKVCacheManager):
         mask = [False] * max(end_block - start_block, 0)
         if pending_writes is None:
             return mask
-        while pending_writes and pending_writes[0] <= request.num_tokens:
-            num_state_tokens = pending_writes.popleft()
+        while pending_writes:
+            num_state_tokens = pending_writes[0]
+            if (
+                num_state_tokens > request.num_tokens
+                or num_state_tokens > end_block * self.block_size
+            ):
+                break
+            pending_writes.popleft()
             if num_state_tokens % self.block_size != 0:
                 continue
             boundary_block = num_state_tokens // self.block_size - 1


### PR DESCRIPTION
## Purpose

Prefix caching is incorrect once the KV cache holds heterogeneous groups —
sliding-window, mamba `align`, and full attention together — in four connected
places, all in `HybridKVCacheCoordinator` and its dependents. Fixing them lets
a DFlash speculative drafter whose layers are *all* sliding-window run with
prefix caching enabled, instead of either crashing on the first request or
running with caching silently defeated.

Nothing here is specific to one checkpoint. The condition is structural — every
drafter layer sliding, and prefix caching on — and `qwen3_dflash.py` is the
shared DFlash implementation, so any such drafter is affected. A drafter that
*mixes* sliding and full attention is already handled by
`_dflash_needs_multi_kv_group` from #47914; this is the case that gate
excludes. Kimi K3's drafter, which declares all six of its layers
`sliding_attention`, is the checkpoint the bugs were found and measured on, and
is what the end-to-end numbers below were taken against.

The four commits, in the order they build on each other:

1. **`972f164ef` — Reconcile hybrid prefix-cache hits across every KV cache
   group.** Two independent bugs in `HybridKVCacheCoordinator`, both latent
   until a model has more than one full-attention-typed group. First,
   fine-grained (partial) prefix-cache hits were enabled for *every* group
   whenever a mamba `align` group needed them, including a `SlidingWindowSpec`
   group whose manager cannot serve them —
   `SlidingWindowManager.find_longest_cache_hit` asserts against exactly this
   and the assertion is reachable, killing the engine core on the first
   request. Second, only `attention_groups[0]` was truncated to the reconciled
   hit length; with a single full-attention group that is the whole set, but
   with a second one the untrimmed group's blocks are handed to
   `add_local_computed_blocks`, and a request ends up writing into shared
   prefix-cache blocks it does not own. Both fixes are applied identically in
   the external-store (Mooncake) mirror — `partial_hash_hits_enabled` and
   `truncate_downward_closed_groups` are hoisted into `kv_cache_utils.py` and
   called from both `vllm/v1/core/kv_cache_coordinator.py` and
   `vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py`
   (and `store/scheduler.py`), so core and the connector cannot disagree on
   the alignment.
2. **`adfd8212f` — Let an all-sliding DFlash drafter book its KV as full
   attention.** A DFlash drafter whose layers are *all* `sliding_attention`
   (Kimi K3's has six) falls outside the multi-KV-group gate added in #47914
   and still builds a `SlidingWindowSpec` group, which is exactly the group
   commit 1 above teaches the coordinator to route around — so the drafter's
   own KV never gets partial hits, which on a hybrid model means the whole
   engine loses partial hits, and on any model it means the drafter re-reads
   its ~33k-token prompt on every turn. Booking those layers as
   `FullAttentionSpec` instead (with `sliding_window` carried onto the spec,
   since the metadata builder reads the window off the spec to enforce it at
   compute time) gives the group a manager that supports fine-grained lookup.
   This is derived from the drafter's own layer types and whether prefix
   caching is on, not exposed as a flag, so it enters
   `SpeculativeConfig.compute_hash` and two runs differing only in it cannot
   share a KV cache identity by accident.
3. **`237fe29cd` — Reconcile the connector's dense reference across
   full-attention groups.** Commit 2 creates a second full-attention group
   (the drafter's, at a smaller block size than the target's), and
   `get_computed_blocks_for_connector` compared every group's hit against only
   the first one. The finer-grained group legitimately hits deeper whenever
   the reconciled hit isn't a multiple of the coarser block size, so the
   single-group comparison misread that as eviction and gave up the fast path
   on most hits. The eviction test now takes the max over every dense group
   (a group is only evidence of eviction if it hit deeper than *all* of them)
   and the reported length takes the min (the length every dense group's
   returned blocks actually cover), reusing commit 1's truncation rather than
   open-coding a second copy.

   **Commits 2 and 3 must ship together.** Converting the drafter's group to
   full attention (commit 2) makes it downward-closed and eligible for
   fine-grained hits, which is what makes `_apply_cow`'s
   `assert req_blocks[block_idx] is source_block` reachable for that group in
   the first place — `add_local_computed_blocks` only ever populates
   `_partial_hit_reqs` (the state `_apply_cow` reads) on a partial hit, and a
   partial hit on the drafter's group cannot happen before commit 2. Commit 3
   is what keeps that reachable path correct once there are two full-attention
   groups at different block sizes: without it, the drafter's group can be
   handed an untrimmed block list and an inconsistent `block_idx`/`source_block`
   pair, which is exactly the mismatch the `_apply_cow` assertion exists to
   catch. Conversely, commit 3 is inert without commit 2, since there is no
   second full-attention group for it to reconcile.
4. **`f05401420` — Cache a mamba "align" state block only at its own
   boundary.** Unrelated to the drafter path; found by inspection while
   working on the above. In `align` mode a mamba state block can be entered
   into the prefix cache under a hash whose token boundary the state it holds
   does not correspond to: prefill always clips chunks onto a block boundary,
   but a decode step does not, and a step that speculates can run over draft
   tokens that are later rejected. A request that later hits such a block
   restores a recurrent state that doesn't match the prefix the cache entry
   claims. The fix withholds a block admission unless this step's write lands
   exactly on the boundary and is made entirely of committed tokens, expressed
   as a mask ANDed into the admission mask `cache_blocks` already computes —
   verified (see `test_extra_block_mask_can_only_withhold_never_admit`) to
   only ever remove admissions, never add them, for every caller of
   `cache_blocks` including the ones outside `allocate_slots`.

I checked for duplicate/overlapping open PRs (`gh pr list --search` on "partial prefix cache hits", "sliding window full attention spec drafter", and "mamba align prefix caching"). Four open PRs are adjacent and none overlaps: #50344 gates divergent per-group hits behind a connector capability, where this reconciles the hit length across groups that are already permitted to diverge; #50409 and #45614 both fix the *lookup* half in `find_longest_cache_hit` and `_mamba_block_aligned_split`, where the mamba commit here fixes the *admission* half in `cache_blocks`; #50169 gives EAGLE drafter layers dedicated KV groups, where this changes one group's spec type and leaves group assignment alone; and #47914's `0 < num_sliding < len(layer_types)` gate is false for an all-sliding drafter, which is exactly the case handled here, so this is additive to it rather than a competing implementation. I used AI assistance (Cursor) to draft, test, and validate this change, and I reviewed every changed line before submitting.

## Test Plan

Focused tests added or modified by these commits, then the broader
`tests/v1/core/` suite, on CPU:

```
pytest tests/v1/core/prefix_cache/ \
       tests/v1/core/test_prefix_caching.py \
       tests/v1/spec_decode/test_dflash_draft_full_attention_spec.py \
       tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py -v

pytest tests/v1/core/ -q
```

End to end: Kimi K3 on 8×B300 at TP8, DFlash drafter at `num_speculative_tokens
16`, prefix caching enabled, against a multi-turn agentic workload with long
shared prefixes (~33k-token prompts). Acceptance is computed as
`1 + accepted/steps` from raw Prometheus counter deltas, not the engine's own
`SpecDecoding metrics` unweighted mean (which runs several percent high in our
measurements).

## Test Result

**Unit**, real output from this branch:

```
tests/v1/core/prefix_cache/ ................................... 35 passed
tests/v1/core/test_prefix_caching.py ........................... 97 passed
tests/v1/spec_decode/test_dflash_draft_full_attention_spec.py ... 3 passed
tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py ... 33 passed

tests/v1/core/ (full suite): 468 passed, 1 failed, 2 errors in 277.14s
```

The 1 failure and 2 errors (`test_reset_prefix_cache_e2e.py::test_reset_prefix_cache_e2e`,
`test_scheduler_e2e.py::test_concurrent_partial_prefill`,
`test_scheduler_e2e.py::test_prefix_cache_stats_is_recorded`) fail identically
on the unmodified base, at worker init with `AttributeError: '_OpNamespace'
'_C' object has no attribute 'init_cpu_memory_env'`. None of the commits touch
those test files or anything on the path to that error.

**End to end.** Before these commits, enabling prefix caching on the Kimi K3
DFlash lane either raised `AssertionError: SlidingWindowManager does not
support fine-grained (partial) cache hits` on the first request, or (with only
commit 2's spec change and none of the coordinator fixes) ran but with caching
effectively defeated. With all four commits, the lane runs with prefix caching
enabled at a 95.5% cache hit rate and zero failed requests. Acceptance length
measured at 4.9554 at draft width 16.0, computed from raw Prometheus counters
as `1 + accepted/steps`.

Commit 4 closes an invariant violation rather than buying throughput: during
decode the scheduler returns early while `cache_blocks` keeps admitting mamba
blocks under a hash for a boundary they do not hold. It is carried by its unit
tests, and it costs nothing measurable on the workload it was found on —
acceptance 1.249 → 1.294, cache hit rate unchanged at 50.5%, on a workload
where only 3 of 32 requests cross a block boundary during decode at all. A
smaller block size, or generations long relative to it, exercises the rule
much harder.

**Limits, stated plainly.** No correctness evaluation (AIME, perplexity) has
been run specifically against this branch. The end-to-end numbers above are a
single measurement rather than a replicated series.

The conversion gate is also only half exercisable end to end. It fires when an
all-sliding drafter meets prefix caching *and* a mamba `align` group, and the
negative branch cannot be reached on this model at all: with prefix caching on,
`models/config.py` resolves `mamba_cache_mode` to `align` for any hybrid model
that does not support mamba prefix caching, rewriting both `none` and `all`,
and with caching off the same function forces `none`. So no single-variable
end-to-end arm can hold caching fixed while moving the cache mode. The
`enable_prefix_caching` x `mamba_cache_mode` matrix is covered by parametrized
unit tests over the predicate instead, in
`tests/v1/spec_decode/test_dflash_draft_full_attention_spec.py`.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>


