### PR TITLE
[Bugfix][Model] Fix Gemma4 routed-expert manager initialization

### DIFF
--- a/tests/model_executor/test_routed_experts_capture.py
+++ b/tests/model_executor/test_routed_experts_capture.py
@@ -11,8 +11,14 @@ from vllm.distributed.eplb.eplb_state import EplbLayerState
 from vllm.model_executor.layers.fused_moe.config import RoutingMethodType
 from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
     RoutedExpertsCapturer,
+    RoutedExpertsManager,
 )
 from vllm.model_executor.layers.fused_moe.router.base_router import BaseRouter
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+)
 
 pytestmark = pytest.mark.cpu_test
 
@@ -70,6 +76,32 @@ def _make_modular_routed_experts():
     return types.SimpleNamespace(
         quant_method=types.SimpleNamespace(is_monolithic=False),
     )
+
+
+def test_routed_experts_manager_uses_gemma4_top_k_experts():
+    hf_config = SimpleNamespace(
+        num_experts=8,
+        top_k_experts=2,
+        num_hidden_layers=3,
+    )
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(hf_text_config=hf_config)
+    )
+    kv_cache_spec = FullAttentionSpec(
+        block_size=4,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=2,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec(["layer"], kv_cache_spec)],
+    )
+
+    manager = RoutedExpertsManager(vllm_config, kv_cache_config)
+
+    assert manager.routed_experts_by_slot.shape == (8, 3, 2)
 
 
 def test_base_router_capture_pre_eplb_mapping():

--- a/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py
@@ -301,7 +301,7 @@ class RoutedExpertsManager:
             self.routed_experts_by_slot.nbytes / 1e9,
             max_num_slots,
             hf_config.num_hidden_layers,
-            hf_config.num_experts_per_tok,
+            num_experts_per_tok,
             self.routed_experts_by_slot.dtype.name,
         )
 


### PR DESCRIPTION
Use the normalized per-token expert count when logging the routed-expert buffer configuration, avoiding direct access to the Gemma4-incompatible num_experts_per_tok attribute.

Assisted-by: OpenAI Codex




## Purpose

Fix `--enable-return-routed-experts` startup for Gemma4 MoE models.

`RoutedExpertsManager` resolves the model's per-token expert count through `_get_num_experts_per_tok()`, supporting both `num_experts_per_tok` and Gemma4's `top_k_experts`. However, the buffer allocation log directly accesses `hf_config.num_experts_per_tok`.

`AttributeError: 'Gemma4TextConfig' object has no attribute 'num_experts_per_tok'`

This change uses the normalized local `num_experts_per_tok` value in the log. This is a follow-up to #41401. That PR added the normalized lookup to the routed-expert capture path, but does not cover the current `RoutedExpertsManager` log statement. PR #39067 addresses the same configuration naming difference in a separate model-loading path.

I searched open issues and PRs for `RoutedExpertsManager`, Gemma4, `routed_experts_capturer.py`, `num_experts_per_tok`, and `top_k_experts`. I found no open PR covering this manager initialization failure.

## Test Plan

1. Construct RoutedExpertsManager using a Gemma4-style configuration with top_k_experts and without num_experts_per_tok.
2. Verify that manager initialization succeeds and creates the expected routed expert buffer shape.
3. Run the focused CPU regression test.
4. Run the repository pre-commit hooks.
5. Manually start nvidia/Gemma-4-26B-A4B-NVFP4 with --enable-return-routed-experts.

## Test Result
Focused regression test:
```
  .venv/bin/python -m pytest \
    tests/model_executor/test_routed_experts_capture.py \
    -k gemma4 \
    -v

  Result:

  collected 11 items / 10 deselected / 1 selected

  tests/model_executor/test_routed_experts_capture.py::test_routed_experts_manager_uses_gemma4_top_k_experts PASSED [100%]

  1 passed, 10 deselected
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

