### PR TITLE
[Bugfix][Tool Parser] Stop InternLM2 and Jamba truncating streamed tool arguments

### DIFF
--- a/tests/tool_parsers/test_internlm2_tool_parser.py
+++ b/tests/tool_parsers/test_internlm2_tool_parser.py
@@ -163,3 +163,54 @@ def test_streaming_arguments_in_single_delta(default_tokenizer: TokenizerLike) -
                 streamed += arguments
 
     assert json.loads(streamed) == {"city": "Dallas", "state": "TX"}
+
+
+def test_streaming_arguments_span_multiple_deltas(
+    default_tokenizer: TokenizerLike,
+) -> None:
+    """Arguments split across deltas must arrive whole, not truncated.
+
+    partial_json_parser closes the object optimistically, so the quote and brace
+    that end the arguments are produced by an early parse and then treated as
+    already streamed. The concatenated deltas used to stop at `{"city": "Paris`,
+    which is not parseable JSON.
+    """
+    tokenizer_vocab = default_tokenizer.get_vocab()
+    default_tokenizer.get_vocab = MagicMock()
+    tokenizer_vocab.update(
+        {
+            "<|action_start|>": 92540,
+            "<|plugin|>": 92541,
+            "<|action_end|>": 92542,
+        }
+    )
+    default_tokenizer.get_vocab.return_value = tokenizer_vocab
+    parser = Internlm2ToolParser(default_tokenizer)
+
+    body = '{"name": "get_weather", "parameters": {"city": "Paris"}}'
+    deltas = (
+        ["<|action_start|>", "<|plugin|>"]
+        + [body[i : i + 6] for i in range(0, len(body), 6)]
+        + ["<|action_end|>"]
+    )
+
+    streamed = ""
+    current_text = ""
+    for delta_text in deltas:
+        previous_text = current_text
+        current_text += delta_text
+        delta_message = parser.extract_tool_calls_streaming(
+            previous_text=previous_text,
+            current_text=current_text,
+            delta_text=delta_text,
+            previous_token_ids=[],
+            current_token_ids=[],
+            delta_token_ids=[],
+            request=None,
+        )
+        if delta_message and delta_message.tool_calls:
+            arguments = delta_message.tool_calls[0].function.arguments
+            if arguments:
+                streamed += arguments
+
+    assert json.loads(streamed) == {"city": "Paris"}

--- a/tests/tool_parsers/test_jamba_tool_parser.py
+++ b/tests/tool_parsers/test_jamba_tool_parser.py
@@ -337,3 +337,42 @@ def test_extract_tool_calls_streaming_arguments_in_single_delta(jamba_tool_parse
                 streamed_arguments += arguments
 
     assert json.loads(streamed_arguments) == {"city": "Dallas", "state": "TX"}
+
+
+def test_extract_tool_calls_streaming_arguments_span_multiple_deltas(
+    jamba_tool_parser,
+):
+    """Arguments split across deltas must arrive whole, not truncated.
+
+    partial_json_parser closes the object optimistically, so the quote and brace
+    that end the arguments are produced by an early parse and then treated as
+    already streamed. The concatenated deltas used to stop at `{"city": "Paris`,
+    which is not parseable JSON.
+    """
+    body = '[{"name": "get_current_weather", "arguments": {"city": "Paris"}}]'
+    deltas = (
+        ["<tool_calls>"]
+        + [body[i : i + 6] for i in range(0, len(body), 6)]
+        + ["</tool_calls>"]
+    )
+
+    streamed_arguments = ""
+    current_text = ""
+    for delta_text in deltas:
+        previous_text = current_text
+        current_text += delta_text
+        delta_message = jamba_tool_parser.extract_tool_calls_streaming(
+            previous_text=previous_text,
+            current_text=current_text,
+            delta_text=delta_text,
+            previous_token_ids=[],
+            current_token_ids=[],
+            delta_token_ids=[],
+            request=None,
+        )
+        if delta_message and delta_message.tool_calls:
+            arguments = delta_message.tool_calls[0].function.arguments
+            if arguments:
+                streamed_arguments += arguments
+
+    assert json.loads(streamed_arguments) == {"city": "Paris"}

--- a/vllm/tool_parsers/internlm2_tool_parser.py
+++ b/vllm/tool_parsers/internlm2_tool_parser.py
@@ -177,6 +177,18 @@ class Internlm2ToolParser(ToolParser):
                         cur_args_json, prev_args_json
                     )
 
+                    # extract_intermediate_diff reports the characters inserted
+                    # between the two parses, which is not the same as the text the
+                    # client still needs: partial_json_parser closes the object
+                    # optimistically, so a quote or brace it produced in an earlier
+                    # parse counts as already sent even though it never was, and the
+                    # arguments arrive truncated. Once the JSON is complete, reconcile
+                    # the delta against what has actually been streamed.
+                    if is_complete_json(parsable_arr):
+                        streamed = self.streamed_args_for_tool[self.current_tool_id]
+                        if cur_args_json.startswith(streamed + argument_diff):
+                            argument_diff = cur_args_json[len(streamed) :]
+
                     delta = DeltaMessage(
                         tool_calls=[
                             DeltaToolCall(

--- a/vllm/tool_parsers/jamba_tool_parser.py
+++ b/vllm/tool_parsers/jamba_tool_parser.py
@@ -305,6 +305,19 @@ class JambaToolParser(ToolParser):
                     argument_diff = extract_intermediate_diff(
                         cur_args_json, prev_args_json
                     )
+
+                    # extract_intermediate_diff reports the characters inserted
+                    # between the two parses, which is not the same as the text the
+                    # client still needs: partial_json_parser closes the object
+                    # optimistically, so a quote or brace it produced in an earlier
+                    # parse counts as already sent even though it never was, and the
+                    # arguments arrive truncated. Once the JSON is complete, reconcile
+                    # the delta against what has actually been streamed.
+                    if is_complete_json(parsable_arr):
+                        streamed = self.streamed_args_for_tool[self.current_tool_id]
+                        if cur_args_json.startswith(streamed + argument_diff):
+                            argument_diff = cur_args_json[len(streamed) :]
+
                     logger.debug("got arguments diff: %s", argument_diff)
                     delta = DeltaMessage(
                         tool_calls=[


### PR DESCRIPTION
## Summary

`Internlm2ToolParser` and `JambaToolParser` truncate tool-call arguments in streaming mode, so what a client assembles from the deltas is not parseable JSON and does not match what the non-streaming path returns for the same output.

```
model output   <|action_start|><|plugin|>{"name": "get_weather", "parameters": {"city": "Paris"}}<|action_end|>

extract_tool_calls            arguments = {"city": "Paris"}
extract_tool_calls_streaming  arguments = {"city": "Paris      <- json.JSONDecodeError
```

## Root cause

The `cur_arguments and prev_arguments` branch computes the delta with `extract_intermediate_diff(cur_args_json, prev_args_json)`, which reports the characters *inserted* between two successive parses. That is not the text the client still needs, because `partial_json_parser` closes the object optimistically: the closing quote and brace are produced by an early parse, so they count as already streamed even though they were never sent. Per-delta trace on the example above:

| delta | parsed arguments so far | emitted |
|---|---|---|
| `'ty": "'` | `{"city": ""}` | `{"city": "` |
| `'Paris"'` | `{"city": "Paris"}` | `Paris` |
| `'}}'` | `{"city": "Paris"}` | (nothing) |
| `<\|action_end\|>` | `{"city": "Paris"}` | (nothing) |

The `"}` is in the parsed value from the `'Paris"'` step onward, but `extract_intermediate_diff` only ever reports the inserted middle, so it is never sent.

## Fix

Once the JSON is complete, reconcile the delta against what has actually been streamed rather than against the previous parse. This is the same safety valve #48852 added to the neighbouring first-arguments branch a few days ago; that PR did not reach this branch, which is why the truncation survived it.

## Not a duplicate

- `gh pr list --repo vllm-project/vllm --state open --search "internlm tool parser"` returns only #40115, which adds a different parser.
- No open PR mentions `extract_intermediate_diff`.
- The most recent change to this file is #48852, "Fix dropped streaming arguments in Jamba and InternLM2 parsers". That PR changed only the `cur_arguments and not prev_arguments` branch, adding a `find`/`is_complete_json` fallback there. The bug fixed here is in the `cur_arguments and prev_arguments` branch, which it left untouched, and it still reproduces on current `main` at `837eae645`.

## Tests

Added `test_streaming_arguments_span_multiple_deltas` to the existing `tests/tool_parsers/test_internlm2_tool_parser.py`, alongside the single-delta test #48852 added, since the two failures are the same family.

Being straight about how this was run: `pytest tests/tool_parsers/` segfaults on my machine (exit 139, no output) inside the native `xgrammar`/`llguidance` import chain, unrelated to this change, so I could not use pytest as the runner. I extracted the two module-level streaming tests with `ast` and executed them directly against the real parser and a real `openai-community/gpt2` tokenizer, which is the same code path pytest would run:

```
with this fix
  PASS  test_streaming_arguments_in_single_delta
  PASS  test_streaming_arguments_span_multiple_deltas

fix reverted, tests unchanged
  PASS  test_streaming_arguments_in_single_delta
  ERROR test_streaming_arguments_span_multiple_deltas: JSONDecodeError: Unterminated string starting at: line 1 column 10
```

The pre-existing test still passing with the fix reverted is the point: this is a distinct case from the one #48852 covered.

Beyond the two tests, I swept 7 argument bodies against 8 delta chunkings (1, 2, 3, 4, 6, 8, 12 characters and all-at-once), comparing the concatenated stream against `extract_tool_calls` on the same text:

```
baseline (main)   5/56 combinations agree
with this fix    35/56 combinations agree
regressions       0
```

The regression count is per-combination, not a delta of totals: every combination passing on `main` still passes here.

**What this does not fix, stated explicitly.** 21 of those 56 still disagree, all of them shapes where the positional diff mangles the middle rather than the tail, for example `{"city": "A, "n": 12, "ok": true}` losing a quote on a three-key body. Those need the argument streaming reworked so it never emits an optimistic closing character in the first place, rather than reconciling afterwards. I tried that rewrite and my version regressed other cases, so I am not attempting it here; this PR fixes the truncation and leaves that larger change to someone who owns this state machine. **Jamba is included, after verifying it.** When I first wrote this I said I had not checked `jamba_tool_parser.py` because my fixture for it was wrong. I fixed the fixture and it has the identical defect in the identical branch, so it is now in this PR: 3 argument bodies against the same 8 chunkings go from **1/24 to 12/24** agreeing with non-streaming, and `test_extract_tool_calls_streaming_arguments_span_multiple_deltas` fails with the same `JSONDecodeError: Unterminated string` on the unfixed parser. #48852 fixed the neighbouring branch in both parsers in one PR, so keeping the pair together follows that precedent, and fixing one of two identical defects would have been worse than fixing neither.

Lint: `ruff 0.14.0`, the version pinned in `.pre-commit-config.yaml`, reports `All checks passed!` and `2 files already formatted`.

## Model evaluation

Not applicable, and I would rather say so than skip the requirement quietly. This changes how already-decoded tool-call arguments are split across streaming deltas in the API layer. It touches no weights, sampling, kernels or scheduling, and cannot change which tokens a model generates: identical output text produces identical results, only the concatenation the client receives changes, and this PR makes that concatenation equal what the non-streaming path already returns. The behaviour is fully determined on CPU, which is what the evidence above exercises. I have no GPU available to run `tests/evals/`, and an eval would not reach this code.

AI assistance was used for this change.
