### PR TITLE
[Bugfix] Use MIG handle for GPU memory lookup

### DIFF
--- a/tests/cuda/test_cuda_context.py
+++ b/tests/cuda/test_cuda_context.py
@@ -3,6 +3,7 @@
 
 import ctypes
 from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -113,6 +114,45 @@ def test_get_device_capability_uses_visible_device_ordinal(monkeypatch):
     assert capability is not None
     assert capability.to_int() == 90
     assert seen_indices == [1]
+
+
+@pytest.mark.parametrize(
+    "device_env_var",
+    ["CUDA_VISIBLE_DEVICES", "NVIDIA_VISIBLE_DEVICES"],
+)
+def test_get_device_total_memory_uses_mig_uuid_handle(monkeypatch, device_env_var):
+    import vllm.platforms.interface as platform_interface
+    from vllm.platforms.cuda import NvmlCudaPlatform, pynvml
+
+    mig_uuid = "MIG-be6b2880-0e33-5698-a7c1-3972ccc1f981"
+    mig_handle = object()
+    total_memory = 33280 * 2**20
+
+    monkeypatch.setattr(platform_interface, "_assigned_physical_gpu_ids", None)
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    monkeypatch.delenv("NVIDIA_VISIBLE_DEVICES", raising=False)
+    monkeypatch.setenv(device_env_var, mig_uuid)
+    monkeypatch.setattr(pynvml, "nvmlInit", lambda: None)
+    monkeypatch.setattr(pynvml, "nvmlShutdown", lambda: None)
+    monkeypatch.setattr(
+        pynvml,
+        "nvmlDeviceGetHandleByUUID",
+        lambda device_uuid: mig_handle if device_uuid == mig_uuid else None,
+    )
+    monkeypatch.setattr(
+        pynvml,
+        "nvmlDeviceGetHandleByIndex",
+        lambda _index: pytest.fail("queried the parent GPU handle"),
+    )
+    monkeypatch.setattr(
+        pynvml,
+        "nvmlDeviceGetMemoryInfo",
+        lambda handle: SimpleNamespace(total=total_memory)
+        if handle is mig_handle
+        else pytest.fail("queried memory for the wrong device"),
+    )
+
+    assert NvmlCudaPlatform.get_device_total_memory() == total_memory
 
 
 if __name__ == "__main__":

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -29,7 +29,13 @@ from vllm.logger import init_logger
 from vllm.utils.import_utils import import_pynvml
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
-from .interface import DeviceCapability, Platform, PlatformEnum, in_wsl
+from .interface import (
+    DeviceCapability,
+    Platform,
+    PlatformEnum,
+    get_assigned_physical_gpu_ids,
+    in_wsl,
+)
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -720,6 +726,32 @@ class CudaPlatformBase(Platform):
 # the major benefit of using NVML is that it will not initialize CUDA
 class NvmlCudaPlatform(CudaPlatformBase):
     @classmethod
+    def _get_nvml_device_handle(cls, device_id: int):
+        assigned_device_ids = get_assigned_physical_gpu_ids()
+        device_control_env = os.environ.get(cls.device_control_env_var, "")
+        nvidia_visible_devices = os.environ.get("NVIDIA_VISIBLE_DEVICES", "")
+        if assigned_device_ids is None and any(
+            device_control_id.startswith("MIG-")
+            for device_control_id in nvidia_visible_devices.split(",")
+        ):
+            device_control_env = nvidia_visible_devices
+
+        if device_control_env:
+            visible_device_id = (
+                device_id
+                if assigned_device_ids is None
+                else cls.logical_device_id_to_visible_device_id(device_id)
+            )
+            device_control_id = device_control_env.split(",")[visible_device_id]
+            try:
+                return pynvml.nvmlDeviceGetHandleByIndex(int(device_control_id))
+            except ValueError:
+                return pynvml.nvmlDeviceGetHandleByUUID(device_control_id)
+
+        physical_device_id = cls.device_id_to_physical_device_id(device_id)
+        return pynvml.nvmlDeviceGetHandleByIndex(physical_device_id)
+
+    @classmethod
     @with_nvml_context
     def device_control_id_to_physical_device_id(cls, device_id: str) -> int:
         try:
@@ -768,8 +800,7 @@ class NvmlCudaPlatform(CudaPlatformBase):
     @classmethod
     @with_nvml_context
     def get_device_total_memory(cls, device_id: int = 0) -> int:
-        physical_device_id = cls.device_id_to_physical_device_id(device_id)
-        handle = pynvml.nvmlDeviceGetHandleByIndex(physical_device_id)
+        handle = cls._get_nvml_device_handle(device_id)
         return int(pynvml.nvmlDeviceGetMemoryInfo(handle).total)
 
     @classmethod


### PR DESCRIPTION
## Summary

- preserve UUID-based NVML handles when a CUDA device is a MIG partition
- recognize MIG UUIDs exposed through either `CUDA_VISIBLE_DEVICES` or
  `NVIDIA_VISIBLE_DEVICES`
- add regression coverage proving memory is queried from the MIG handle rather
  than an index-based parent GPU handle

## Why

On H200 1g.35gb CI workers, CUDA workloads can use the full 32.5 GiB MIG
partition, but the container is not permitted to query aggregate memory from
the parent H200. `NvmlCudaPlatform.get_device_total_memory()` converted the MIG
UUID to an index and then reacquired an index-based handle. NVML returned
`Insufficient Permissions`, and `large_gpu_mark()` treated the error as zero
available memory, falsely skipping tests whose requirements were satisfied.

This change keeps the MIG-specific handle for the memory query, avoiding both
the parent permission failure and CUDA initialization during pytest collection.

Observed example:
https://buildkite.com/vllm/ci/builds/81166/canvas?tab=output&jid=019faff0-ff67-4b95-9b76-f5be866f7473#L829

## Duplicate-work check

I searched open vLLM PRs for `large_gpu_mark` and
`MIG NVML memory permission`, and open issues for the same MIG/NVML failure. No
matching PR or issue was found. The existing `khluu/mig` branch also has no pull
request; this PR is a narrow implementation against current `main`.

## Validation

- Commit-time pre-commit suite passed, including Ruff, Ruff format, typos,
  mypy, SPDX headers, forbidden imports, and sign-off checks.
- `UV_CACHE_DIR=/private/tmp/codex-vllm-uv-cache uvx --from ruff==0.14.0 ruff check vllm/platforms/cuda.py tests/cuda/test_cuda_context.py`
  passed.
- `UV_CACHE_DIR=/private/tmp/codex-vllm-uv-cache uvx --from ruff==0.14.0 ruff format --check vllm/platforms/cuda.py tests/cuda/test_cuda_context.py`
  passed.
- `.venv/bin/python -m pytest tests/cuda/test_cuda_context.py -q` could not run
  locally because this checkout's `.venv/bin/python` resolves to an x86-64
  Linux ELF interpreter on an Apple Silicon macOS host. The new mocked-NVML
  test is included for CUDA CI execution.
- MIG CI used combined validation commit
  `b067353edbeef689ebfa23e612c4a724060e28e8` (PR #50330 test layout plus this
  PR):
  - [`h200_18gb` e2e Scheduling](https://buildkite.com/vllm/ci/builds/81439#019fb582-19bb-4015-9569-8c24eb0b8f77):
    the `@large_gpu_mark(min_gb=16)` async-scheduling Eagle3 case ran and
    passed.
  - [`h200_35gb` Model Runner V2 Core](https://buildkite.com/vllm/ci/builds/81439#019fb5c5-0039-481f-9805-52163675b40a):
    the same decorated async-scheduling case ran and passed.
  - [`h200_18gb` V1 Sample + Logits](https://buildkite.com/vllm/ci/builds/81439#019fb582-1a4e-4309-bb2d-abbdf9b673fb):
    both `@large_gpu_mark(min_gb=24)` large-batch cases were collected and
    correctly skipped because the slice exposed 17.18 GB.
  - [`h200_35gb` V1 Sample + Logits rerun](https://buildkite.com/vllm/ci/builds/81474#019fb5f5-50d8-45c2-86e3-6aa098ea1b65):
    `test_token_logprobs_large_batch_int64_row_offset` and
    `TestTritonTopkTopp::test_large_batch_int64_row_offset` both explicitly
    ran and passed.
  - [`h200_35gb` Acceptance Length](https://buildkite.com/vllm/ci/builds/81439#019fb582-1a49-40b3-9435-d03def6fa761)
    and [`h200_35gb` multimodal generation](https://buildkite.com/vllm/ci/builds/81439#019fb582-1a73-4fd9-884a-bd63cc7e1d50)
    correctly skipped literal decorators requiring 40, 48, or 80 GB because
    the slice exposed 34.90 GB.
  - None of these MIG jobs emitted
    `An error occurred when finding the available memory: Insufficient Permissions`.
- The original
  [Medusa acceptance validation](https://buildkite.com/vllm/ci/builds/81439#019fb582-1aa6-4ff3-8681-8af71ce57348)
  also passed all four tests on `h200_35gb`; Medusa acceptance was 0.2202
  (minimum 0.198). At the combined validation commit, `test_medusa.py` no
  longer has a literal `@large_gpu_mark`, so this is supporting rather than
  decorator-specific evidence.
- Model evaluation: not applicable; this changes device-memory discovery and
  test selection, not model outputs or serving behavior.

## AI assistance

AI assistance from OpenAI Codex was used for diagnosis, implementation,
testing, and PR drafting. The human submitter must review every changed line
and confirm they understand and can defend the change before marking this PR
ready.
