### PR TITLE
[Bugfix][KVConnector][Mooncake] Wire LookupKeyServer/Client close into store teardown

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
@@ -784,21 +784,44 @@ def test_del_invokes_shutdown_and_closes_store():
     worker.close.assert_called_once_with()
 
 
-def test_shutdown_scheduler_role_is_noop():
+def _make_scheduler_role_connector():
     vllm_config = _make_vllm_config()
     kv_cache_config = _make_kv_cache_config()
 
-    with (
-        set_current_vllm_config(vllm_config),
-        patch(
-            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store."
-            "connector.MooncakeStoreScheduler"
-        ),
-    ):
-        connector = mooncake_store_connector.MooncakeStoreConnector(
+    with set_current_vllm_config(vllm_config):
+        return mooncake_store_connector.MooncakeStoreConnector(
             vllm_config, KVConnectorRole.SCHEDULER, kv_cache_config
         )
 
-    # Scheduler role holds no store handle, so shutdown must be a safe no-op.
+
+def test_shutdown_scheduler_role_closes_lookup_client():
+    with patch(
+        "vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store."
+        "connector.MooncakeStoreScheduler"
+    ) as mock_scheduler_cls:
+        connector = _make_scheduler_role_connector()
+
+    # Scheduler role holds no store handle, but it owns the LookupKeyClient's
+    # ZMQ socket and lookup executor, which leak unless shutdown closes them.
     assert connector.connector_worker is None
+    client = MagicMock()
+    mock_scheduler_cls.return_value.client = client
+
+    connector.shutdown()
+
+    client.close.assert_called_once_with()
+
+
+def test_shutdown_scheduler_role_swallows_client_errors():
+    with patch(
+        "vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store."
+        "connector.MooncakeStoreScheduler"
+    ) as mock_scheduler_cls:
+        connector = _make_scheduler_role_connector()
+
+    client = MagicMock()
+    client.close.side_effect = RuntimeError("boom")
+    mock_scheduler_cls.return_value.client = client
+
+    # A failure tearing down the client must not propagate out of shutdown().
     connector.shutdown()

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -2618,25 +2618,54 @@ def test_store_worker_close_releases_store():
     assert worker.store is None
 
 
+def test_store_worker_close_releases_lookup_server():
+    worker = _make_bare_worker()
+    lookup_server = MagicMock()
+    worker.lookup_server = lookup_server
+
+    worker.close()
+
+    lookup_server.close.assert_called_once_with()
+    assert worker.lookup_server is None
+
+
 def test_store_worker_close_is_idempotent():
     worker = _make_bare_worker()
     store = worker.store
+    lookup_server = MagicMock()
+    worker.lookup_server = lookup_server
 
     worker.close()
     worker.close()
 
-    # Second call short-circuits because store was already released.
+    # Second call short-circuits because both resources were already released.
     store.close.assert_called_once_with()
+    lookup_server.close.assert_called_once_with()
 
 
 def test_store_worker_close_swallows_store_errors():
     worker = _make_bare_worker()
     worker.store.close.side_effect = RuntimeError("boom")
+    lookup_server = MagicMock()
+    worker.lookup_server = lookup_server
 
-    # A failure tearing down the store must not propagate out of close().
+    # A failure tearing down the store must not propagate out of close(),
+    # and must not strand the lookup server.
     worker.close()
 
     assert worker.store is None
+    lookup_server.close.assert_called_once_with()
+    assert worker.lookup_server is None
+
+
+def test_store_worker_close_swallows_lookup_server_errors():
+    worker = _make_bare_worker()
+    worker.lookup_server = MagicMock()
+    worker.lookup_server.close.side_effect = RuntimeError("boom")
+
+    worker.close()
+
+    assert worker.lookup_server is None
 
 
 def test_blob_block_hashes_wire_roundtrip():

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
@@ -164,14 +164,27 @@ class MooncakeStoreConnector(KVConnectorBase_V1, SupportsHMA):
     def shutdown(self):
         """Release connector resources on teardown.
 
-        Closes the worker's MooncakeDistributedStore handle so its
-        TransferEngine and RDMA registrations are released. Invoked from the
-        engine's explicit shutdown path and as a backstop from ``__del__``;
-        a no-op on the scheduler role, which holds no store handle.
+        Worker role: closes the MooncakeDistributedStore (TransferEngine,
+        RDMA buffers, master-server connection) and the LookupKeyServer
+        (ZMQ socket, IPC file).
+        Scheduler role: closes the LookupKeyClient (ZMQ socket, lookup
+        executor).
+
+        Invoked from the engine's explicit shutdown path and as a backstop
+        from ``__del__``.
         """
         worker = getattr(self, "connector_worker", None)
         if worker is not None:
             worker.close()
+
+        scheduler = getattr(self, "connector_scheduler", None)
+        if scheduler is not None:
+            client = getattr(scheduler, "client", None)
+            if client is not None:
+                try:
+                    client.close()
+                except Exception as e:
+                    logger.warning("Error closing LookupKeyClient: %s", e)
 
     def __del__(self):
         self.shutdown()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -1785,20 +1785,28 @@ class MooncakeStoreWorker:
         return []
 
     def close(self) -> None:
-        """Release the MooncakeDistributedStore handle on teardown.
+        """Release worker resources on teardown.
 
-        Closing the store frees its TransferEngine, the registered RDMA
-        buffers, and the connection to the master server. Idempotent so it is
-        safe to call from both the explicit shutdown path and ``__del__``.
+        Closes the MooncakeDistributedStore (TransferEngine, RDMA buffers,
+        master-server connection) and the LookupKeyServer (ZMQ socket, IPC
+        file). Idempotent so it is safe to call from both the explicit
+        shutdown path and ``__del__``.
         """
         store = getattr(self, "store", None)
-        if store is None:
-            return
-        self.store = None
-        try:
-            store.close()
-        except Exception as e:
-            logger.warning("Error closing MooncakeDistributedStore: %s", e)
+        if store is not None:
+            self.store = None
+            try:
+                store.close()
+            except Exception as e:
+                logger.warning("Error closing MooncakeDistributedStore: %s", e)
+
+        lookup_server = getattr(self, "lookup_server", None)
+        if lookup_server is not None:
+            self.lookup_server = None
+            try:
+                lookup_server.close()
+            except Exception as e:
+                logger.warning("Error closing LookupKeyServer: %s", e)
 
 
 # ============================================================
@@ -1875,6 +1883,7 @@ class LookupKeyServer:
         self.thread.start()
 
     def close(self):
+        self.running = False
         self.socket.close(linger=0)
         if os.path.exists(self._ipc_path):
             os.unlink(self._ipc_path)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -1883,7 +1883,10 @@ class LookupKeyServer:
         self.thread.start()
 
     def close(self):
-        self.running = False
+        # The request thread is left to its blocking recv: closing the socket
+        # under it does not raise, so ``running`` cannot be observed and the
+        # thread is not joinable here. It is a daemon, so it dies with the
+        # process. Draining it cleanly needs a polling loop (follow-up).
         self.socket.close(linger=0)
         if os.path.exists(self._ipc_path):
             os.unlink(self._ipc_path)


### PR DESCRIPTION
## Purpose

`MooncakeStoreConnector.shutdown()` released the worker's `MooncakeDistributedStore` handle but left the LookupKey admin channel open, so connector teardown leaked ZMQ resources on both roles:

- **Worker role:** `MooncakeStoreWorker.close()` never touched `self.lookup_server`, so the `LookupKeyServer`'s bound ZMQ socket stayed open and its IPC file was left on disk. (A stale file does not accumulate — `LookupKeyServer.__init__` unlinks the path before binding — but the socket is never released, and the file lingers for the lifetime of the process.)
- **Scheduler role:** `shutdown()` was documented as a no-op because the scheduler holds no store handle. That stopped being true once the scheduler gained `self.client = LookupKeyClient(...)`, which owns a ZMQ socket and a `ThreadPoolExecutor`. `LookupKeyClient.close()` already existed but had no caller anywhere in the tree.

Both roles reach `shutdown()` on an explicit path, so this is not GC-dependent:

- scheduler: `Scheduler.shutdown()` → `self.connector.shutdown()` (`vllm/v1/core/sched/scheduler.py`)
- worker: `Worker.shutdown()` → `ensure_kv_transfer_shutdown()` → `_KV_CONNECTOR_AGENT.shutdown()` (`vllm/v1/worker/gpu_worker.py`, `kv_transfer_state.py`)

This matters for hosts that create and destroy engines repeatedly in one process (RL rollouts, tests, multi-engine servers), where each cycle previously stranded a socket per role.

## Approach

- `MooncakeStoreWorker.close()`: also release `self.lookup_server`. Restructured from an early `return` into independent blocks so a store-close failure cannot strand the lookup server. Still idempotent (each handle is set to `None` before its `close()`) and still swallows/logs errors, since it runs from `__del__`.
- `MooncakeStoreConnector.shutdown()`: close the scheduler's `LookupKeyClient`, guarded with `getattr` and a warn-only `except` so GC-time teardown never raises.

No behavioral change on the serving path — this only affects teardown.

## Known limitation (deliberately out of scope)

`LookupKeyServer`'s request thread is **not** stopped by this PR. It blocks in `socket.recv_multipart()`, and closing the socket underneath it neither raises nor returns, so the existing `self.running` flag is never re-read. I confirmed this empirically: after `socket.close(linger=0)` from another thread, the receiving thread stays alive with no exception raised.

I initially set `self.running = False` in `close()` and removed it again, because it reads as a fix while doing nothing. Stopping the thread cleanly requires converting the loop to `socket.poll(timeout=...)` so the flag is observed, then joining the thread before closing the socket and terminating the context. That is a behavioral change to the request loop and belongs in its own PR; the thread is a daemon, so it does not block interpreter exit today. `close()` now documents the constraint rather than implying the thread is stopped. Happy to fold that change in here instead if a maintainer prefers it bundled.

## Test Plan

Extended the existing teardown tests in the two suites that cover these paths:

- `test_store_worker_close_releases_lookup_server` — worker closes the lookup server and clears the attribute.
- `test_store_worker_close_is_idempotent` — a second `close()` short-circuits for *both* handles.
- `test_store_worker_close_swallows_store_errors` — a failing store close still releases the lookup server.
- `test_store_worker_close_swallows_lookup_server_errors` — a failing lookup-server close does not propagate.
- `test_shutdown_scheduler_role_closes_lookup_client` — replaces `test_shutdown_scheduler_role_is_noop`, which asserted the behavior this PR fixes.
- `test_shutdown_scheduler_role_swallows_client_errors` — a failing client close does not propagate out of `shutdown()`.

These assert teardown wiring against mocks, in the style of the surrounding suite. They do not assert OS-level release of the socket or IPC file.

## Test Result

```
$ pytest tests/v1/kv_connector/unit/test_mooncake_store_connector.py \
         tests/v1/kv_connector/unit/test_mooncake_store_worker.py -q
118 passed, 135 warnings in 63.15s
```

Confirmed the new tests are not vacuous: with only the two source files reverted, `test_shutdown_scheduler_role_closes_lookup_client`, `test_store_worker_close_releases_lookup_server`, and `test_store_worker_close_swallows_lookup_server_errors` fail; all pass with the fix applied.

The wider Mooncake unit run shows 18 failures in `test_mooncake_connector.py`, `test_mooncake_connector_hma.py`, and `test_mooncake_connector_hybrid_mamba.py`. These are pre-existing in my environment and unrelated: the identical 18 fail on clean `main` with these changes stashed, and they cover `mooncake_connector.py`, which this PR does not touch.

`pre-commit run` passes on all changed files, including `mypy`.

No model evaluation is included because this change affects only connector teardown — it does not touch the serving, sampling, or KV-transfer data paths, so it cannot alter model output or accuracy.

## Notes

This supersedes #45503, which I closed after it rotted into a merge conflict and attracted no review. This is a fresh implementation against current `main` (`837eae645`); it stacks on the merged #45206 (store close on teardown), and I re-verified that the async-lookup refactor in #45659 did not change this code path.

Duplicate-work check: no open PR addresses the LookupKeyServer/Client teardown leak. Of the ~30 open Mooncake PRs, none touch `shutdown()`/`close()` in `store/connector.py` or `store/worker.py`; searches for `LookupKeyClient`, `LookupKeyServer`, and mooncake teardown/socket-leak terms return nothing overlapping.

## AI Assistance Disclosure

This PR was developed with AI assistance (Cursor). The leak was identified by tracing the engine teardown path into `MooncakeStoreConnector.shutdown()` and cross-referencing `LookupKeyServer`/`LookupKeyClient` lifetimes against their owners; the thread-shutdown claim above was checked with a standalone pyzmq experiment rather than assumed. I have reviewed every changed line and run the tests reported above.
