### PR TITLE
[Kernel][Helion] Optimize fused QK norm RoPE on B200 and H100

### DIFF
--- a/tests/kernels/helion/test_fused_qk_norm_rope.py
+++ b/tests/kernels/helion/test_fused_qk_norm_rope.py
@@ -33,10 +33,9 @@ if not has_helion():
 
 @default_vllm_config()
 def _generate_fake_input(
-    num_tokens: int, num_q_heads: int, num_kv_heads: int
+    num_tokens: int, num_q_heads: int, num_kv_heads: int, head_dim: int = 128
 ) -> tuple[Any, ...]:
     with FakeTensorMode():
-        head_dim = 128
         eps = 1e-6
         is_neox = True
         rotary_ratio = 1.0
@@ -125,6 +124,17 @@ class TestFusedQkNormRopeConfigPicker:
         assert selected_key == CaseKey(
             {"q_heads": 2048, "kv_heads": 64, "num_tokens": 32}
         )
+
+    def test_config_picker_prefers_exact_head_dim(self):
+        generic = CaseKey({"q_heads": 64, "kv_heads": 8, "num_tokens": 32})
+        head_dim_256 = CaseKey(
+            {"q_heads": 64, "kv_heads": 8, "num_tokens": 256, "head_dim": 256}
+        )
+
+        args = _generate_fake_input(32, 64, 8, head_dim=256)
+        selected_key = pick_config(args, [generic, head_dim_256])
+
+        assert selected_key == head_dim_256
 
     def test_config_picker_no_configs(self):
         config_keys: list[dict] = []

--- a/vllm/kernels/helion/configs/fused_qk_norm_rope/nvidia_b200.json
+++ b/vllm/kernels/helion/configs/fused_qk_norm_rope/nvidia_b200.json
@@ -2131,5 +2131,473 @@
       "num_sm_multiplier": 128,
       "maxnreg": 64
     }
+  },
+  {
+    "key": {
+      "q_heads": 16,
+      "kv_heads": 8,
+      "num_tokens": 2,
+      "head_dim": 256
+    },
+    "config": {
+      "block_sizes": [
+        1
+      ],
+      "loop_orders": [
+        [
+          0,
+          2,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 32,
+      "kv_heads": 8,
+      "num_tokens": 2,
+      "head_dim": 256
+    },
+    "config": {
+      "block_sizes": [
+        1
+      ],
+      "loop_orders": [
+        [
+          0,
+          2,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 64,
+      "kv_heads": 8,
+      "num_tokens": 2,
+      "head_dim": 256
+    },
+    "config": {
+      "block_sizes": [
+        1
+      ],
+      "loop_orders": [
+        [
+          0,
+          2,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 16,
+      "kv_heads": 8,
+      "num_tokens": 256,
+      "head_dim": 256
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 32,
+      "kv_heads": 8,
+      "num_tokens": 256,
+      "head_dim": 256
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 64,
+      "kv_heads": 8,
+      "num_tokens": 256,
+      "head_dim": 256
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 16,
+      "kv_heads": 8,
+      "num_tokens": 8192,
+      "head_dim": 256
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          2,
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 32,
+      "kv_heads": 8,
+      "num_tokens": 8192,
+      "head_dim": 256
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          2,
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 64,
+      "kv_heads": 8,
+      "num_tokens": 8192,
+      "head_dim": 256
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          2,
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
   }
 ]

--- a/vllm/kernels/helion/configs/fused_qk_norm_rope/nvidia_b200.json
+++ b/vllm/kernels/helion/configs/fused_qk_norm_rope/nvidia_b200.json
@@ -7,17 +7,17 @@
     },
     "config": {
       "block_sizes": [
-        4
+        1
       ],
       "loop_orders": [
         [
+          0,
           2,
-          1,
-          0
+          1
         ]
       ],
       "l2_groupings": [
-        8
+        1
       ],
       "range_unroll_factors": [
         0
@@ -33,30 +33,19 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "first",
-        "",
         "last",
-        "first",
-        "",
         "last",
-        "first"
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
       ],
       "num_warps": 1,
-      "num_stages": 5,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
+      "num_stages": 1,
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -69,79 +58,17 @@
     },
     "config": {
       "block_sizes": [
-        4
+        1
       ],
       "loop_orders": [
         [
           0,
-          1,
-          2
-        ]
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        null
-      ],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "",
-        "last",
-        "last",
-        "first",
-        "first",
-        ""
-      ],
-      "num_warps": 4,
-      "num_stages": 3,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 64,
-      "kv_heads": 8,
-      "num_tokens": 1
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
           2,
-          1,
-          0
+          1
         ]
       ],
       "l2_groupings": [
-        32
+        1
       ],
       "range_unroll_factors": [
         0
@@ -158,115 +85,41 @@
       ],
       "load_eviction_policies": [
         "last",
-        "first",
-        "",
-        "first",
         "last",
-        "first",
-        "first",
-        "first"
-      ],
-      "num_warps": 1,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 16,
-      "kv_heads": 8,
-      "num_tokens": 2
-    },
-    "config": {
-      "block_sizes": [
-        1
-      ],
-      "loop_orders": [
-        [
-          1,
-          2,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        64
-      ],
-      "range_unroll_factors": [
-        1
-      ],
-      "range_warp_specializes": [
-        false
-      ],
-      "range_multi_buffers": [
-        true
-      ],
-      "range_flattens": [
-        true
-      ],
-      "load_eviction_policies": [
         "last",
-        "first",
-        "",
         "last",
-        "first",
         "last",
-        "",
+        "last",
+        "last",
+        "last",
         "last"
       ],
       "num_warps": 1,
       "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
+      "indexing": "pointer",
       "atomic_indexing": [],
-      "pid_type": "persistent_interleaved",
-      "num_sm_multiplier": 4,
-      "maxnreg": 128
+      "pid_type": "flat"
     }
   },
   {
     "key": {
-      "q_heads": 32,
+      "q_heads": 64,
       "kv_heads": 8,
-      "num_tokens": 2
+      "num_tokens": 1
     },
     "config": {
       "block_sizes": [
-        4
+        1
       ],
       "loop_orders": [
         [
+          0,
           2,
-          1,
-          0
+          1
         ]
       ],
       "l2_groupings": [
-        32
+        1
       ],
       "range_unroll_factors": [
         0
@@ -283,29 +136,120 @@
       ],
       "load_eviction_policies": [
         "last",
-        "first",
-        "",
-        "first",
         "last",
-        "first",
-        "first",
-        "first"
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
       ],
       "num_warps": 1,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 16,
+      "kv_heads": 8,
+      "num_tokens": 2
+    },
+    "config": {
+      "block_sizes": [
+        1
       ],
+      "loop_orders": [
+        [
+          0,
+          2,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 32,
+      "kv_heads": 8,
+      "num_tokens": 2
+    },
+    "config": {
+      "block_sizes": [
+        1
+      ],
+      "loop_orders": [
+        [
+          0,
+          2,
+          1
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -318,17 +262,17 @@
     },
     "config": {
       "block_sizes": [
-        4
+        1
       ],
       "loop_orders": [
         [
+          0,
           2,
-          1,
-          0
+          1
         ]
       ],
       "l2_groupings": [
-        32
+        1
       ],
       "range_unroll_factors": [
         0
@@ -345,29 +289,18 @@
       ],
       "load_eviction_policies": [
         "last",
-        "first",
-        "",
-        "first",
         "last",
-        "first",
-        "first",
-        "first"
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
       ],
       "num_warps": 1,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
+      "num_stages": 1,
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -380,81 +313,18 @@
     },
     "config": {
       "block_sizes": [
-        8
-      ],
-      "loop_orders": [
-        [
-          2,
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        64
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        false
-      ],
-      "range_multi_buffers": [
-        true
-      ],
-      "range_flattens": [
-        false
-      ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "last",
-        "last",
-        "first",
-        "last",
-        "",
-        "last"
-      ],
-      "num_warps": 8,
-      "num_stages": 2,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "persistent_blocked",
-      "num_sm_multiplier": 4,
-      "maxnreg": 128
-    }
-  },
-  {
-    "key": {
-      "q_heads": 32,
-      "kv_heads": 8,
-      "num_tokens": 4
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          0,
-          1,
-          2
-        ]
-      ],
-      "l2_groupings": [
         2
       ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
       "range_unroll_factors": [
         0
       ],
@@ -469,30 +339,70 @@
         null
       ],
       "load_eviction_policies": [
-        "",
         "last",
         "last",
-        "first",
-        "first",
-        "first",
-        "",
-        "first"
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
       ],
       "num_warps": 1,
-      "num_stages": 3,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor"
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 32,
+      "kv_heads": 8,
+      "num_tokens": 4
+    },
+    "config": {
+      "block_sizes": [
+        2
       ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -505,198 +415,12 @@
     },
     "config": {
       "block_sizes": [
-        4
+        2
       ],
       "loop_orders": [
         [
-          2,
           1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        32
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        null
-      ],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "",
-        "first",
-        "last",
-        "first",
-        "first",
-        "first"
-      ],
-      "num_warps": 1,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 16,
-      "kv_heads": 8,
-      "num_tokens": 8
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          0,
           2,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        null
-      ],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "",
-        "",
-        "",
-        "last",
-        "last",
-        "first",
-        "first"
-      ],
-      "num_warps": 4,
-      "num_stages": 3,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 32,
-      "kv_heads": 8,
-      "num_tokens": 8
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          2,
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        32
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        null
-      ],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "",
-        "first",
-        "last",
-        "first",
-        "first",
-        "first"
-      ],
-      "num_warps": 1,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 64,
-      "kv_heads": 8,
-      "num_tokens": 8
-    },
-    "config": {
-      "block_sizes": [
-        8
-      ],
-      "loop_orders": [
-        [
-          2,
-          1,
           0
         ]
       ],
@@ -718,29 +442,171 @@
       ],
       "load_eviction_policies": [
         "last",
-        "first",
-        "first",
-        "first",
+        "last",
+        "last",
+        "last",
+        "last",
         "last",
         "last",
         "last",
         "last"
       ],
-      "num_warps": 8,
-      "num_stages": 3,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer"
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 16,
+      "kv_heads": 8,
+      "num_tokens": 8
+    },
+    "config": {
+      "block_sizes": [
+        2
       ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 32,
+      "kv_heads": 8,
+      "num_tokens": 8
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 64,
+      "kv_heads": 8,
+      "num_tokens": 8
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -753,7 +619,7 @@
     },
     "config": {
       "block_sizes": [
-        4
+        2
       ],
       "loop_orders": [
         [
@@ -763,7 +629,7 @@
         ]
       ],
       "l2_groupings": [
-        4
+        1
       ],
       "range_unroll_factors": [
         0
@@ -779,30 +645,19 @@
         null
       ],
       "load_eviction_policies": [
-        "",
         "last",
-        "first",
-        "",
-        "first",
-        "",
-        "",
-        "first"
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
       ],
-      "num_warps": 2,
-      "num_stages": 8,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -815,12 +670,12 @@
     },
     "config": {
       "block_sizes": [
-        4
+        2
       ],
       "loop_orders": [
         [
-          2,
           1,
+          2,
           0
         ]
       ],
@@ -841,30 +696,19 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
         "last",
-        "first",
-        "",
-        "first",
-        "first",
-        "",
-        "first"
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
       ],
-      "num_warps": 2,
-      "num_stages": 4,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor"
-      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -877,694 +721,12 @@
     },
     "config": {
       "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          0,
-          2,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        null
-      ],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "",
-        "",
-        "",
-        "last",
-        "last",
-        "first",
-        "first"
-      ],
-      "num_warps": 4,
-      "num_stages": 3,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 16,
-      "kv_heads": 8,
-      "num_tokens": 32
-    },
-    "config": {
-      "block_sizes": [
-        4
+        2
       ],
       "loop_orders": [
         [
           1,
           2,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        null
-      ],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "first",
-        "",
-        "first",
-        "",
-        "",
-        "first"
-      ],
-      "num_warps": 2,
-      "num_stages": 8,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 32,
-      "kv_heads": 8,
-      "num_tokens": 32
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          2,
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        32
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        null
-      ],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "last",
-        "last",
-        "",
-        "last",
-        "last",
-        "",
-        "first"
-      ],
-      "num_warps": 1,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 64,
-      "kv_heads": 8,
-      "num_tokens": 32
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          1,
-          2,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        null
-      ],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "first",
-        "",
-        "first",
-        "",
-        "",
-        "first"
-      ],
-      "num_warps": 2,
-      "num_stages": 8,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 16,
-      "kv_heads": 8,
-      "num_tokens": 64
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          1,
-          2,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        null
-      ],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "first",
-        "",
-        "first",
-        "",
-        "",
-        "first"
-      ],
-      "num_warps": 2,
-      "num_stages": 8,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 32,
-      "kv_heads": 8,
-      "num_tokens": 64
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          2,
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        32
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        null
-      ],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "last",
-        "first",
-        "",
-        "first",
-        "last",
-        "first",
-        "first",
-        "first"
-      ],
-      "num_warps": 1,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 64,
-      "kv_heads": 8,
-      "num_tokens": 64
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          0,
-          2,
-          1
-        ]
-      ],
-      "l2_groupings": [
-        1
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        null
-      ],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "first",
-        "last",
-        "first",
-        "",
-        "last",
-        "first",
-        "first",
-        "first"
-      ],
-      "num_warps": 2,
-      "num_stages": 7,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 16,
-      "kv_heads": 8,
-      "num_tokens": 128
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          1,
-          2,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        null
-      ],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "first",
-        "",
-        "first",
-        "",
-        "",
-        "first"
-      ],
-      "num_warps": 2,
-      "num_stages": 8,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 32,
-      "kv_heads": 8,
-      "num_tokens": 128
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          2,
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        8
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        null
-      ],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "",
-        "",
-        "last",
-        "last",
-        "first",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 7,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 64,
-      "kv_heads": 8,
-      "num_tokens": 128
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          2,
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        8
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        null
-      ],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "",
-        "last",
-        "first",
-        "",
-        "last",
-        "first"
-      ],
-      "num_warps": 1,
-      "num_stages": 5,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 16,
-      "kv_heads": 8,
-      "num_tokens": 256
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          1,
-          2,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        4
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [
-        null
-      ],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "first",
-        "",
-        "first",
-        "",
-        "",
-        "first"
-      ],
-      "num_warps": 2,
-      "num_stages": 8,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 32,
-      "kv_heads": 8,
-      "num_tokens": 256
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          2,
-          1,
           0
         ]
       ],
@@ -1585,53 +747,42 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
         "last",
-        "first",
-        "",
-        "first",
-        "first",
-        "",
-        "first"
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
       ],
-      "num_warps": 2,
-      "num_stages": 4,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor"
-      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "flat"
     }
   },
   {
     "key": {
-      "q_heads": 64,
+      "q_heads": 16,
       "kv_heads": 8,
-      "num_tokens": 256
+      "num_tokens": 32
     },
     "config": {
       "block_sizes": [
-        4
+        2
       ],
       "loop_orders": [
         [
-          2,
           1,
+          2,
           0
         ]
       ],
       "l2_groupings": [
-        32
+        1
       ],
       "range_unroll_factors": [
         0
@@ -1647,30 +798,580 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
         "last",
         "last",
-        "",
         "last",
         "last",
-        "",
-        "first"
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
       ],
       "num_warps": 1,
-      "num_stages": 2,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 32,
+      "kv_heads": 8,
+      "num_tokens": 32
+    },
+    "config": {
+      "block_sizes": [
+        2
       ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 64,
+      "kv_heads": 8,
+      "num_tokens": 32
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 16,
+      "kv_heads": 8,
+      "num_tokens": 64
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 32,
+      "kv_heads": 8,
+      "num_tokens": 64
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 64,
+      "kv_heads": 8,
+      "num_tokens": 64
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 16,
+      "kv_heads": 8,
+      "num_tokens": 128
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 32,
+      "kv_heads": 8,
+      "num_tokens": 128
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 64,
+      "kv_heads": 8,
+      "num_tokens": 128
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 16,
+      "kv_heads": 8,
+      "num_tokens": 256
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 32,
+      "kv_heads": 8,
+      "num_tokens": 256
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 64,
+      "kv_heads": 8,
+      "num_tokens": 256
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [
+        null
+      ],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -1718,19 +1419,7 @@
       ],
       "num_warps": 1,
       "num_stages": 1,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "flat"
     }
@@ -1777,19 +1466,7 @@
       ],
       "num_warps": 1,
       "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 32,
@@ -1840,19 +1517,7 @@
       ],
       "num_warps": 1,
       "num_stages": 1,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 32
@@ -1900,19 +1565,7 @@
       ],
       "num_warps": 1,
       "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 32,
@@ -1937,48 +1590,37 @@
         ]
       ],
       "l2_groupings": [
-        64
+        1
       ],
       "range_unroll_factors": [
-        2
+        0
       ],
       "range_warp_specializes": [
-        false
+        null
       ],
+      "range_num_stages": [],
       "range_multi_buffers": [
-        true
+        null
       ],
       "range_flattens": [
-        false
+        null
       ],
       "load_eviction_policies": [
-        "",
-        "last",
-        "",
-        "",
         "last",
         "last",
-        "first",
-        ""
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
       ],
       "num_warps": 1,
-      "num_stages": 7,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
+      "num_stages": 1,
+      "indexing": "pointer",
       "atomic_indexing": [],
-      "pid_type": "persistent_interleaved",
-      "num_sm_multiplier": 32
+      "pid_type": "flat"
     }
   },
   {
@@ -2025,19 +1667,7 @@
       ],
       "num_warps": 1,
       "num_stages": 6,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,
@@ -2062,48 +1692,37 @@
         ]
       ],
       "l2_groupings": [
-        64
+        1
       ],
       "range_unroll_factors": [
-        2
+        0
       ],
       "range_warp_specializes": [
-        false
+        null
       ],
+      "range_num_stages": [],
       "range_multi_buffers": [
-        true
+        null
       ],
       "range_flattens": [
-        false
+        null
       ],
       "load_eviction_policies": [
-        "",
-        "last",
-        "",
-        "",
         "last",
         "last",
-        "first",
-        ""
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last"
       ],
       "num_warps": 1,
-      "num_stages": 7,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
-      ],
+      "num_stages": 1,
+      "indexing": "pointer",
       "atomic_indexing": [],
-      "pid_type": "persistent_interleaved",
-      "num_sm_multiplier": 32
+      "pid_type": "flat"
     }
   },
   {
@@ -2150,19 +1769,7 @@
       ],
       "num_warps": 1,
       "num_stages": 8,
-      "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor"
-      ],
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "persistent_interleaved",
       "num_sm_multiplier": 32
@@ -2212,19 +1819,7 @@
       ],
       "num_warps": 1,
       "num_stages": 6,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,
@@ -2275,19 +1870,7 @@
       ],
       "num_warps": 1,
       "num_stages": 6,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,
@@ -2338,19 +1921,7 @@
       ],
       "num_warps": 1,
       "num_stages": 6,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,
@@ -2401,19 +1972,7 @@
       ],
       "num_warps": 1,
       "num_stages": 6,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,
@@ -2464,19 +2023,7 @@
       ],
       "num_warps": 1,
       "num_stages": 6,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,
@@ -2527,19 +2074,7 @@
       ],
       "num_warps": 1,
       "num_stages": 6,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,
@@ -2590,19 +2125,7 @@
       ],
       "num_warps": 1,
       "num_stages": 6,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
+      "indexing": "pointer",
       "atomic_indexing": [],
       "pid_type": "persistent_blocked",
       "num_sm_multiplier": 128,

--- a/vllm/kernels/helion/configs/fused_qk_norm_rope/nvidia_h100.json
+++ b/vllm/kernels/helion/configs/fused_qk_norm_rope/nvidia_h100.json
@@ -11,52 +11,53 @@
       ],
       "loop_orders": [
         [
-          1,
           0,
+          1,
           2
         ]
       ],
       "l2_groupings": [
-        64
+        1
       ],
       "range_unroll_factors": [
-        4
+        0
       ],
       "range_warp_specializes": [],
+      "range_num_stages": [],
       "range_multi_buffers": [
-        false
+        null
       ],
       "range_flattens": [
-        true
+        null
       ],
       "load_eviction_policies": [
-        "",
-        "",
+        "first",
+        "first",
+        "first",
+        "last",
         "first",
         "",
-        "",
         "last",
-        "",
+        "first",
         "first"
       ],
       "num_warps": 1,
-      "num_stages": 3,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
         "pointer",
         "pointer",
         "pointer",
         "tensor_descriptor",
         "pointer",
+        "pointer",
         "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
         "pointer"
       ],
       "atomic_indexing": [],
-      "pid_type": "persistent_blocked",
-      "num_sm_multiplier": 2
+      "pid_type": "flat"
     }
   },
   {
@@ -137,7 +138,7 @@
         ]
       ],
       "l2_groupings": [
-        8
+        1
       ],
       "range_unroll_factors": [
         0
@@ -152,26 +153,27 @@
       ],
       "load_eviction_policies": [
         "last",
-        "last",
+        "first",
         "last",
         "first",
         "first",
+        "",
         "last",
-        "last",
+        "first",
         "first"
       ],
-      "num_warps": 2,
+      "num_warps": 1,
       "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer",
         "pointer",
         "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
         "tensor_descriptor",
         "pointer"
       ],
@@ -191,13 +193,13 @@
       ],
       "loop_orders": [
         [
-          1,
           2,
+          1,
           0
         ]
       ],
       "l2_groupings": [
-        16
+        1
       ],
       "range_unroll_factors": [
         0
@@ -211,29 +213,30 @@
         null
       ],
       "load_eviction_policies": [
-        "",
-        "",
-        "",
+        "first",
         "first",
         "first",
         "last",
         "first",
-        "last"
+        "",
+        "last",
+        "last",
+        "first"
       ],
       "num_warps": 1,
-      "num_stages": 5,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer",
         "tensor_descriptor",
         "tensor_descriptor",
         "pointer",
+        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
+        "pointer",
+        "pointer",
+        "tensor_descriptor"
       ],
       "atomic_indexing": [],
       "pid_type": "flat"
@@ -311,8 +314,8 @@
       ],
       "loop_orders": [
         [
-          2,
           1,
+          2,
           0
         ]
       ],
@@ -331,29 +334,30 @@
         null
       ],
       "load_eviction_policies": [
+        "",
+        "first",
         "last",
         "first",
-        "",
+        "first",
         "",
         "last",
-        "",
-        "",
-        "first"
+        "first",
+        "last"
       ],
       "num_warps": 1,
-      "num_stages": 8,
+      "num_stages": 1,
       "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
         "pointer",
         "pointer",
-        "tensor_descriptor",
         "pointer",
         "tensor_descriptor",
         "pointer",
         "pointer",
-        "pointer",
-        "tensor_descriptor"
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
       ],
       "atomic_indexing": [],
       "pid_type": "flat"
@@ -427,7 +431,7 @@
     },
     "config": {
       "block_sizes": [
-        2
+        1
       ],
       "loop_orders": [
         [
@@ -437,7 +441,7 @@
         ]
       ],
       "l2_groupings": [
-        32
+        1
       ],
       "range_unroll_factors": [
         0
@@ -452,23 +456,24 @@
       ],
       "load_eviction_policies": [
         "first",
-        "",
+        "first",
+        "first",
         "last",
-        "",
+        "last",
+        "last",
         "first",
-        "",
-        "first",
-        "last"
+        "last",
+        "first"
       ],
       "num_warps": 1,
-      "num_stages": 5,
+      "num_stages": 1,
       "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
         "tensor_descriptor",
         "pointer",
         "pointer",
@@ -847,7 +852,7 @@
     },
     "config": {
       "block_sizes": [
-        4
+        2
       ],
       "loop_orders": [
         [
@@ -857,7 +862,7 @@
         ]
       ],
       "l2_groupings": [
-        32
+        2
       ],
       "range_unroll_factors": [
         0
@@ -872,27 +877,28 @@
       ],
       "load_eviction_policies": [
         "first",
-        "last",
+        "first",
+        "",
         "",
         "first",
+        "",
         "last",
         "last",
-        "first",
         "first"
       ],
       "num_warps": 1,
-      "num_stages": 4,
+      "num_stages": 1,
       "indexing": [
         "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "tensor_descriptor",
         "pointer",
         "pointer",
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
         "tensor_descriptor"
       ],
       "atomic_indexing": [],
@@ -967,7 +973,7 @@
     },
     "config": {
       "block_sizes": [
-        4
+        2
       ],
       "loop_orders": [
         [
@@ -977,11 +983,13 @@
         ]
       ],
       "l2_groupings": [
-        32
+        2
       ],
       "range_unroll_factors": [
         0
       ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
       "range_multi_buffers": [
         null
       ],
@@ -991,12 +999,13 @@
       "load_eviction_policies": [
         "",
         "first",
-        "",
+        "last",
         "first",
-        "last",
+        "first",
         "",
         "last",
-        "last"
+        "",
+        ""
       ],
       "num_warps": 1,
       "num_stages": 2,
@@ -1004,19 +1013,17 @@
         "pointer",
         "pointer",
         "pointer",
+        "tensor_descriptor",
         "pointer",
         "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer"
       ],
-      "pid_type": "flat",
       "atomic_indexing": [],
-      "range_warp_specializes": [],
-      "range_num_stages": []
+      "pid_type": "flat"
     }
   },
   {
@@ -1027,7 +1034,7 @@
     },
     "config": {
       "block_sizes": [
-        4
+        2
       ],
       "loop_orders": [
         [
@@ -1052,27 +1059,28 @@
       ],
       "load_eviction_policies": [
         "last",
+        "first",
+        "",
+        "",
+        "first",
         "",
         "last",
         "last",
-        "first",
-        "last",
-        "first",
-        ""
+        "first"
       ],
       "num_warps": 1,
-      "num_stages": 2,
+      "num_stages": 1,
       "indexing": [
         "tensor_descriptor",
         "pointer",
         "tensor_descriptor",
         "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "tensor_descriptor",
         "pointer",
         "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
         "tensor_descriptor"
       ],
       "atomic_indexing": [],
@@ -1087,7 +1095,7 @@
     },
     "config": {
       "block_sizes": [
-        4
+        2
       ],
       "loop_orders": [
         [
@@ -1097,7 +1105,7 @@
         ]
       ],
       "l2_groupings": [
-        8
+        2
       ],
       "range_unroll_factors": [
         0
@@ -1114,25 +1122,26 @@
         "",
         "first",
         "last",
-        "",
-        "last",
         "last",
         "first",
-        "first"
+        "",
+        "last",
+        "",
+        ""
       ],
       "num_warps": 1,
-      "num_stages": 1,
+      "num_stages": 2,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
         "pointer",
         "pointer",
         "tensor_descriptor",
-        "tensor_descriptor",
         "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer"
       ],
       "atomic_indexing": [],
@@ -1147,17 +1156,17 @@
     },
     "config": {
       "block_sizes": [
-        4
+        2
       ],
       "loop_orders": [
         [
-          2,
           1,
+          2,
           0
         ]
       ],
       "l2_groupings": [
-        4
+        2
       ],
       "range_unroll_factors": [
         0
@@ -1171,28 +1180,29 @@
         null
       ],
       "load_eviction_policies": [
-        "first",
+        "",
         "first",
         "last",
+        "first",
+        "first",
         "",
         "last",
-        "last",
-        "last",
-        "first"
+        "",
+        ""
       ],
-      "num_warps": 2,
+      "num_warps": 1,
       "num_stages": 2,
       "indexing": [
         "pointer",
         "pointer",
         "pointer",
         "tensor_descriptor",
+        "pointer",
+        "pointer",
         "tensor_descriptor",
         "tensor_descriptor",
         "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
         "pointer"
       ],
       "atomic_indexing": [],
@@ -1267,12 +1277,12 @@
     },
     "config": {
       "block_sizes": [
-        4
+        2
       ],
       "loop_orders": [
         [
-          1,
           2,
+          1,
           0
         ]
       ],
@@ -1291,14 +1301,381 @@
         null
       ],
       "load_eviction_policies": [
+        "last",
+        "first",
         "",
+        "",
+        "first",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 1,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 32,
+      "kv_heads": 8,
+      "num_tokens": 128
+    },
+    "config": {
+      "block_sizes": [
+        4
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "last",
+        "first",
         "first",
         "last",
         "",
+        "",
+        ""
+      ],
+      "num_warps": 1,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 64,
+      "kv_heads": 8,
+      "num_tokens": 128
+    },
+    "config": {
+      "block_sizes": [
+        4
+      ],
+      "loop_orders": [
+        [
+          2,
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "first",
+        "first",
         "last",
+        "first",
+        "",
         "last",
         "first",
         "first"
+      ],
+      "num_warps": 1,
+      "num_stages": 2,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 16,
+      "kv_heads": 8,
+      "num_tokens": 256
+    },
+    "config": {
+      "block_sizes": [
+        4
+      ],
+      "loop_orders": [
+        [
+          2,
+          1,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "",
+        "",
+        "first",
+        "",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 32,
+      "kv_heads": 8,
+      "num_tokens": 256
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        "last",
+        "first",
+        "first",
+        "last",
+        "first"
+      ],
+      "num_warps": 1,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_blocked",
+      "num_sm_multiplier": 32,
+      "maxnreg": 64
+    }
+  },
+  {
+    "key": {
+      "q_heads": 64,
+      "kv_heads": 8,
+      "num_tokens": 256
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        "last",
+        "first",
+        "first",
+        "last",
+        "first"
+      ],
+      "num_warps": 1,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_blocked",
+      "num_sm_multiplier": 32,
+      "maxnreg": 64
+    }
+  },
+  {
+    "key": {
+      "q_heads": 16,
+      "kv_heads": 8,
+      "num_tokens": 512
+    },
+    "config": {
+      "block_sizes": [
+        4
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "first",
+        "last",
+        "first",
+        "first",
+        "first",
+        "last",
+        "",
+        "",
+        "last"
       ],
       "num_warps": 1,
       "num_stages": 1,
@@ -1313,495 +1690,132 @@
         "tensor_descriptor",
         "tensor_descriptor",
         "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 32,
-      "kv_heads": 8,
-      "num_tokens": 128
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          2,
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        64
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "",
-        "",
-        "last",
-        "last",
-        "last",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 64,
-      "kv_heads": 8,
-      "num_tokens": 128
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          2,
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        8
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "first",
-        "",
-        "",
-        "first",
-        "",
-        "first",
-        "first"
-      ],
-      "num_warps": 2,
-      "num_stages": 2,
-      "indexing": [
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 16,
-      "kv_heads": 8,
-      "num_tokens": 256
-    },
-    "config": {
-      "block_sizes": [
-        4
-      ],
-      "loop_orders": [
-        [
-          2,
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        64
-      ],
-      "range_unroll_factors": [
-        0
-      ],
-      "range_warp_specializes": [],
-      "range_num_stages": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "",
-        "",
-        "",
-        "last",
-        "last",
-        "last",
-        ""
-      ],
-      "num_warps": 2,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "flat"
-    }
-  },
-  {
-    "key": {
-      "q_heads": 32,
-      "kv_heads": 8,
-      "num_tokens": 256
-    },
-    "config": {
-      "block_sizes": [
-        2
-      ],
-      "loop_orders": [
-        [
-          1,
-          2,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        64
-      ],
-      "range_unroll_factors": [
-        2
-      ],
-      "range_warp_specializes": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "",
-        "last",
-        "first",
-        "first",
-        "last",
-        "first"
-      ],
-      "num_warps": 1,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "persistent_blocked",
-      "num_sm_multiplier": 32,
-      "maxnreg": 64
-    }
-  },
-  {
-    "key": {
-      "q_heads": 64,
-      "kv_heads": 8,
-      "num_tokens": 256
-    },
-    "config": {
-      "block_sizes": [
-        2
-      ],
-      "loop_orders": [
-        [
-          1,
-          2,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        64
-      ],
-      "range_unroll_factors": [
-        2
-      ],
-      "range_warp_specializes": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "",
-        "last",
-        "first",
-        "first",
-        "last",
-        "first"
-      ],
-      "num_warps": 1,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "persistent_blocked",
-      "num_sm_multiplier": 32,
-      "maxnreg": 64
-    }
-  },
-  {
-    "key": {
-      "q_heads": 16,
-      "kv_heads": 8,
-      "num_tokens": 512
-    },
-    "config": {
-      "block_sizes": [
-        2
-      ],
-      "loop_orders": [
-        [
-          1,
-          2,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        64
-      ],
-      "range_unroll_factors": [
-        2
-      ],
-      "range_warp_specializes": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "",
-        "last",
-        "first",
-        "first",
-        "last",
-        "first"
-      ],
-      "num_warps": 1,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "persistent_blocked",
-      "num_sm_multiplier": 32,
-      "maxnreg": 64
-    }
-  },
-  {
-    "key": {
-      "q_heads": 32,
-      "kv_heads": 8,
-      "num_tokens": 512
-    },
-    "config": {
-      "block_sizes": [
-        2
-      ],
-      "loop_orders": [
-        [
-          1,
-          2,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        64
-      ],
-      "range_unroll_factors": [
-        2
-      ],
-      "range_warp_specializes": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        null
-      ],
-      "load_eviction_policies": [
-        "",
-        "last",
-        "",
-        "last",
-        "first",
-        "first",
-        "last",
-        "first"
-      ],
-      "num_warps": 1,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
-      ],
-      "atomic_indexing": [],
-      "pid_type": "persistent_blocked",
-      "num_sm_multiplier": 32,
-      "maxnreg": 64
-    }
-  },
-  {
-    "key": {
-      "q_heads": 64,
-      "kv_heads": 8,
-      "num_tokens": 512
-    },
-    "config": {
-      "block_sizes": [
-        2
-      ],
-      "loop_orders": [
-        [
-          2,
-          1,
-          0
-        ]
-      ],
-      "l2_groupings": [
-        2
-      ],
-      "range_unroll_factors": [
-        4
-      ],
-      "range_warp_specializes": [],
-      "range_multi_buffers": [
-        null
-      ],
-      "range_flattens": [
-        true
-      ],
-      "load_eviction_policies": [
-        "first",
-        "",
-        "first",
-        "first",
-        "last",
-        "last",
-        "",
-        ""
-      ],
-      "num_warps": 1,
-      "num_stages": 5,
-      "indexing": [
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer",
-        "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
         "tensor_descriptor"
       ],
       "atomic_indexing": [],
-      "pid_type": "persistent_interleaved",
-      "num_sm_multiplier": 64,
+      "pid_type": "flat"
+    }
+  },
+  {
+    "key": {
+      "q_heads": 32,
+      "kv_heads": 8,
+      "num_tokens": 512
+    },
+    "config": {
+      "block_sizes": [
+        2
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        64
+      ],
+      "range_unroll_factors": [
+        2
+      ],
+      "range_warp_specializes": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "last",
+        "",
+        "last",
+        "first",
+        "first",
+        "last",
+        "first"
+      ],
+      "num_warps": 1,
+      "num_stages": 5,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "persistent_blocked",
+      "num_sm_multiplier": 32,
       "maxnreg": 64
+    }
+  },
+  {
+    "key": {
+      "q_heads": 64,
+      "kv_heads": 8,
+      "num_tokens": 512
+    },
+    "config": {
+      "block_sizes": [
+        4
+      ],
+      "loop_orders": [
+        [
+          1,
+          2,
+          0
+        ]
+      ],
+      "l2_groupings": [
+        32
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_warp_specializes": [],
+      "range_num_stages": [],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "last",
+        "",
+        "last",
+        "",
+        "last",
+        "first",
+        "last",
+        "last",
+        "last"
+      ],
+      "num_warps": 1,
+      "num_stages": 5,
+      "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor"
+      ],
+      "atomic_indexing": [],
+      "pid_type": "flat"
     }
   },
   {
@@ -1812,7 +1826,7 @@
     },
     "config": {
       "block_sizes": [
-        2
+        4
       ],
       "loop_orders": [
         [
@@ -1822,12 +1836,13 @@
         ]
       ],
       "l2_groupings": [
-        64
+        32
       ],
       "range_unroll_factors": [
-        2
+        0
       ],
       "range_warp_specializes": [],
+      "range_num_stages": [],
       "range_multi_buffers": [
         null
       ],
@@ -1835,34 +1850,33 @@
         null
       ],
       "load_eviction_policies": [
+        "last",
         "",
         "last",
         "",
         "last",
         "first",
-        "first",
         "last",
-        "first"
+        "last",
+        "last"
       ],
       "num_warps": 1,
       "num_stages": 5,
       "indexing": [
-        "pointer",
         "tensor_descriptor",
         "pointer",
         "tensor_descriptor",
         "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
         "tensor_descriptor",
         "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor",
-        "pointer"
+        "pointer",
+        "tensor_descriptor"
       ],
       "atomic_indexing": [],
-      "pid_type": "persistent_blocked",
-      "num_sm_multiplier": 32,
-      "maxnreg": 64
+      "pid_type": "flat"
     }
   },
   {
@@ -1995,12 +2009,12 @@
     },
     "config": {
       "block_sizes": [
-        2
+        4
       ],
       "loop_orders": [
         [
-          1,
           2,
+          1,
           0
         ]
       ],
@@ -2008,44 +2022,44 @@
         16
       ],
       "range_unroll_factors": [
-        1
+        0
       ],
       "range_warp_specializes": [],
+      "range_num_stages": [],
       "range_multi_buffers": [
-        false
+        null
       ],
       "range_flattens": [
-        false
+        null
       ],
       "load_eviction_policies": [
-        "",
-        "",
-        "",
-        "last",
-        "",
-        "last",
         "first",
-        ""
+        "",
+        "last",
+        "",
+        "",
+        "first",
+        "last",
+        "last",
+        "last"
       ],
       "num_warps": 1,
-      "num_stages": 4,
+      "num_stages": 8,
       "indexing": [
-        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "tensor_descriptor",
         "pointer",
         "pointer",
-        "pointer",
         "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
         "pointer"
       ],
       "atomic_indexing": [],
-      "pid_type": "persistent_blocked",
-      "num_sm_multiplier": 64,
-      "maxnreg": 256
+      "pid_type": "flat"
     }
   },
   {
@@ -2056,7 +2070,7 @@
     },
     "config": {
       "block_sizes": [
-        2
+        4
       ],
       "loop_orders": [
         [
@@ -2069,44 +2083,44 @@
         16
       ],
       "range_unroll_factors": [
-        1
+        0
       ],
       "range_warp_specializes": [],
+      "range_num_stages": [],
       "range_multi_buffers": [
         null
       ],
       "range_flattens": [
-        true
+        null
       ],
       "load_eviction_policies": [
+        "first",
         "",
-        "first",
-        "first",
         "last",
         "",
         "",
+        "first",
         "last",
-        "first"
+        "last",
+        "last"
       ],
       "num_warps": 1,
-      "num_stages": 1,
+      "num_stages": 8,
       "indexing": [
-        "pointer",
         "tensor_descriptor",
         "tensor_descriptor",
         "tensor_descriptor",
         "pointer",
+        "pointer",
         "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
       ],
       "atomic_indexing": [],
-      "pid_type": "persistent_blocked",
-      "num_sm_multiplier": 64,
-      "maxnreg": 128
+      "pid_type": "flat"
     }
   },
   {
@@ -2117,7 +2131,7 @@
     },
     "config": {
       "block_sizes": [
-        2
+        4
       ],
       "loop_orders": [
         [
@@ -2130,44 +2144,44 @@
         16
       ],
       "range_unroll_factors": [
-        1
+        0
       ],
       "range_warp_specializes": [],
+      "range_num_stages": [],
       "range_multi_buffers": [
         null
       ],
       "range_flattens": [
-        true
+        null
       ],
       "load_eviction_policies": [
+        "first",
         "",
-        "first",
-        "first",
         "last",
         "",
         "",
+        "first",
         "last",
-        "first"
+        "last",
+        "last"
       ],
       "num_warps": 1,
-      "num_stages": 1,
+      "num_stages": 8,
       "indexing": [
-        "pointer",
         "tensor_descriptor",
         "tensor_descriptor",
         "tensor_descriptor",
         "pointer",
+        "pointer",
         "tensor_descriptor",
         "pointer",
-        "pointer",
-        "pointer",
-        "pointer",
-        "tensor_descriptor"
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
       ],
       "atomic_indexing": [],
-      "pid_type": "persistent_blocked",
-      "num_sm_multiplier": 64,
-      "maxnreg": 128
+      "pid_type": "flat"
     }
   },
   {
@@ -2182,53 +2196,53 @@
       ],
       "loop_orders": [
         [
-          1,
           2,
+          1,
           0
         ]
       ],
       "l2_groupings": [
-        16
+        2
       ],
       "range_unroll_factors": [
-        1
+        0
       ],
-      "range_warp_specializes": [],
       "range_multi_buffers": [
-        false
+        null
       ],
       "range_flattens": [
-        false
+        null
       ],
       "load_eviction_policies": [
         "",
-        "",
-        "",
-        "last",
-        "",
         "last",
         "first",
-        ""
+        "last",
+        "",
+        "last",
+        "",
+        "first"
       ],
       "num_warps": 1,
-      "num_stages": 4,
+      "num_stages": 6,
       "indexing": [
         "pointer",
-        "tensor_descriptor",
         "pointer",
         "pointer",
         "pointer",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer",
         "pointer",
         "pointer",
         "pointer",
         "pointer"
       ],
+      "pid_type": "persistent_interleaved",
+      "num_sm_multiplier": 128,
+      "maxnreg": 64,
       "atomic_indexing": [],
-      "pid_type": "persistent_blocked",
-      "num_sm_multiplier": 64,
-      "maxnreg": 256
+      "range_warp_specializes": []
     }
   },
   {
@@ -2239,7 +2253,7 @@
     },
     "config": {
       "block_sizes": [
-        2
+        4
       ],
       "loop_orders": [
         [
@@ -2249,47 +2263,47 @@
         ]
       ],
       "l2_groupings": [
-        2
+        16
       ],
       "range_unroll_factors": [
-        1
+        0
       ],
       "range_warp_specializes": [],
+      "range_num_stages": [],
       "range_multi_buffers": [
-        false
+        null
       ],
       "range_flattens": [
         null
       ],
       "load_eviction_policies": [
-        "",
         "first",
+        "",
         "last",
         "",
         "",
-        "",
-        "",
-        "first"
+        "first",
+        "last",
+        "last",
+        "last"
       ],
       "num_warps": 1,
-      "num_stages": 2,
+      "num_stages": 8,
       "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
         "tensor_descriptor",
         "tensor_descriptor",
         "pointer",
         "pointer",
         "tensor_descriptor",
+        "pointer",
         "tensor_descriptor",
         "tensor_descriptor",
-        "tensor_descriptor"
+        "tensor_descriptor",
+        "pointer"
       ],
       "atomic_indexing": [],
-      "pid_type": "persistent_blocked",
-      "num_sm_multiplier": 128,
-      "maxnreg": 64
+      "pid_type": "flat"
     }
   },
   {
@@ -2300,12 +2314,12 @@
     },
     "config": {
       "block_sizes": [
-        2
+        4
       ],
       "loop_orders": [
         [
-          2,
           1,
+          2,
           0
         ]
       ],
@@ -2313,44 +2327,44 @@
         2
       ],
       "range_unroll_factors": [
-        1
+        0
       ],
       "range_warp_specializes": [],
+      "range_num_stages": [],
       "range_multi_buffers": [
-        false
+        null
       ],
       "range_flattens": [
         null
       ],
       "load_eviction_policies": [
+        "first",
         "",
+        "",
+        "last",
+        "first",
         "first",
         "last",
-        "",
-        "",
-        "",
-        "",
-        "first"
+        "last",
+        "last"
       ],
       "num_warps": 1,
-      "num_stages": 2,
+      "num_stages": 1,
       "indexing": [
         "pointer",
         "pointer",
         "pointer",
-        "tensor_descriptor",
-        "tensor_descriptor",
+        "pointer",
+        "pointer",
         "pointer",
         "pointer",
         "tensor_descriptor",
         "tensor_descriptor",
         "tensor_descriptor",
-        "tensor_descriptor"
+        "pointer"
       ],
       "atomic_indexing": [],
-      "pid_type": "persistent_blocked",
-      "num_sm_multiplier": 128,
-      "maxnreg": 64
+      "pid_type": "flat"
     }
   },
   {
@@ -2361,7 +2375,7 @@
     },
     "config": {
       "block_sizes": [
-        2
+        4
       ],
       "loop_orders": [
         [
@@ -2371,47 +2385,47 @@
         ]
       ],
       "l2_groupings": [
-        2
+        16
       ],
       "range_unroll_factors": [
-        1
+        0
       ],
       "range_warp_specializes": [],
+      "range_num_stages": [],
       "range_multi_buffers": [
-        false
+        null
       ],
       "range_flattens": [
         null
       ],
       "load_eviction_policies": [
-        "",
         "first",
+        "",
         "last",
         "",
         "",
-        "",
-        "",
-        "first"
+        "first",
+        "last",
+        "last",
+        "last"
       ],
       "num_warps": 1,
-      "num_stages": 2,
+      "num_stages": 8,
       "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
         "tensor_descriptor",
         "tensor_descriptor",
         "pointer",
         "pointer",
         "tensor_descriptor",
+        "pointer",
         "tensor_descriptor",
         "tensor_descriptor",
-        "tensor_descriptor"
+        "tensor_descriptor",
+        "pointer"
       ],
       "atomic_indexing": [],
-      "pid_type": "persistent_blocked",
-      "num_sm_multiplier": 128,
-      "maxnreg": 64
+      "pid_type": "flat"
     }
   },
   {
@@ -2422,7 +2436,7 @@
     },
     "config": {
       "block_sizes": [
-        2
+        4
       ],
       "loop_orders": [
         [
@@ -2432,47 +2446,47 @@
         ]
       ],
       "l2_groupings": [
-        2
+        16
       ],
       "range_unroll_factors": [
-        1
+        0
       ],
       "range_warp_specializes": [],
+      "range_num_stages": [],
       "range_multi_buffers": [
-        false
+        null
       ],
       "range_flattens": [
         null
       ],
       "load_eviction_policies": [
-        "",
         "first",
+        "",
         "last",
         "",
         "",
-        "",
-        "",
-        "first"
+        "first",
+        "last",
+        "last",
+        "last"
       ],
       "num_warps": 1,
-      "num_stages": 2,
+      "num_stages": 8,
       "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
         "tensor_descriptor",
         "tensor_descriptor",
         "pointer",
         "pointer",
         "tensor_descriptor",
+        "pointer",
         "tensor_descriptor",
         "tensor_descriptor",
-        "tensor_descriptor"
+        "tensor_descriptor",
+        "pointer"
       ],
       "atomic_indexing": [],
-      "pid_type": "persistent_blocked",
-      "num_sm_multiplier": 128,
-      "maxnreg": 64
+      "pid_type": "flat"
     }
   },
   {
@@ -2483,7 +2497,7 @@
     },
     "config": {
       "block_sizes": [
-        2
+        4
       ],
       "loop_orders": [
         [
@@ -2493,47 +2507,47 @@
         ]
       ],
       "l2_groupings": [
-        2
+        16
       ],
       "range_unroll_factors": [
-        1
+        0
       ],
       "range_warp_specializes": [],
+      "range_num_stages": [],
       "range_multi_buffers": [
-        false
+        null
       ],
       "range_flattens": [
         null
       ],
       "load_eviction_policies": [
-        "",
         "first",
+        "",
         "last",
         "",
         "",
-        "",
-        "",
-        "first"
+        "first",
+        "last",
+        "last",
+        "last"
       ],
       "num_warps": 1,
-      "num_stages": 2,
+      "num_stages": 8,
       "indexing": [
-        "pointer",
-        "pointer",
-        "pointer",
+        "tensor_descriptor",
         "tensor_descriptor",
         "tensor_descriptor",
         "pointer",
         "pointer",
         "tensor_descriptor",
+        "pointer",
         "tensor_descriptor",
         "tensor_descriptor",
-        "tensor_descriptor"
+        "tensor_descriptor",
+        "pointer"
       ],
       "atomic_indexing": [],
-      "pid_type": "persistent_blocked",
-      "num_sm_multiplier": 128,
-      "maxnreg": 64
+      "pid_type": "flat"
     }
   },
   {

--- a/vllm/kernels/helion/ops/fused_qk_norm_rope.py
+++ b/vllm/kernels/helion/ops/fused_qk_norm_rope.py
@@ -290,6 +290,8 @@ def fused_qk_norm_rope(
             x1_offset = hl.arange(embed_dim) * 2
             x2_offset = x1_offset + 1
 
+        # Partial RoPE still requires RMSNorm over the full head, including the
+        # unrotated tail, so retain the full-head normalization path.
         if rotary_dim < head_dim:
             x_blk = qkv[tile_m, tile_gn, tile_n].to(dtype=torch.float32)
             rms = torch.rsqrt(x_blk.pow(2).sum(dim=-1) * (1.0 / head_dim) + eps)
@@ -303,6 +305,8 @@ def fused_qk_norm_rope(
             x1_blk = qkv[tile_m, tile_gn, x1_offset]
             x2_blk = qkv[tile_m, tile_gn, x2_offset]
         else:
+            # Full RoPE covers the entire head. Keep both rotary halves in
+            # registers through RMSNorm and RoPE to avoid a store/reload round trip.
             x1_blk = qkv[tile_m, tile_gn, x1_offset].to(dtype=torch.float32)
             x2_blk = qkv[tile_m, tile_gn, x2_offset].to(dtype=torch.float32)
             rms = x1_blk.pow(2).sum(dim=-1) + x2_blk.pow(2).sum(dim=-1)

--- a/vllm/kernels/helion/ops/fused_qk_norm_rope.py
+++ b/vllm/kernels/helion/ops/fused_qk_norm_rope.py
@@ -281,23 +281,7 @@ def fused_qk_norm_rope(
     for tile_m, tile_gn, tile_n in hl.tile(
         [num_tokens, qk_heads, head_dim], block_size=[1, None, head_dim]
     ):
-        x_blk = qkv[tile_m, tile_gn, tile_n].to(dtype=torch.float32)
-
-        rms = x_blk.pow(2).sum(dim=-1)
-        rms = torch.rsqrt(rms * (1.0 / head_dim) + eps)
-
         use_q_weight = (tile_gn.index < num_heads_q)[None, :, None]
-        w_blk = torch.where(
-            use_q_weight, q_weight[None, None, tile_n], k_weight[None, None, tile_n]
-        )
-
-        x_blk = (x_blk * rms[:, :, None]).to(qkv.dtype) * w_blk
-
-        qkv[tile_m, tile_gn, tile_n] = x_blk
-
-        pos_id = position_ids[tile_m]
-        cos_blk = cos_sin_cache[pos_id, hl.arange(embed_dim)]
-        sin_blk = cos_sin_cache[pos_id, hl.arange(embed_dim) + embed_dim]
 
         if is_neox:
             x1_offset = hl.arange(embed_dim)
@@ -306,8 +290,39 @@ def fused_qk_norm_rope(
             x1_offset = hl.arange(embed_dim) * 2
             x2_offset = x1_offset + 1
 
-        x1_blk = qkv[tile_m, tile_gn, x1_offset]
-        x2_blk = qkv[tile_m, tile_gn, x2_offset]
+        if rotary_dim < head_dim:
+            x_blk = qkv[tile_m, tile_gn, tile_n].to(dtype=torch.float32)
+            rms = torch.rsqrt(x_blk.pow(2).sum(dim=-1) * (1.0 / head_dim) + eps)
+            weight = torch.where(
+                use_q_weight,
+                q_weight[None, None, tile_n],
+                k_weight[None, None, tile_n],
+            )
+            x_blk = (x_blk * rms[:, :, None]).to(qkv.dtype) * weight
+            qkv[tile_m, tile_gn, tile_n] = x_blk
+            x1_blk = qkv[tile_m, tile_gn, x1_offset]
+            x2_blk = qkv[tile_m, tile_gn, x2_offset]
+        else:
+            x1_blk = qkv[tile_m, tile_gn, x1_offset].to(dtype=torch.float32)
+            x2_blk = qkv[tile_m, tile_gn, x2_offset].to(dtype=torch.float32)
+            rms = x1_blk.pow(2).sum(dim=-1) + x2_blk.pow(2).sum(dim=-1)
+            rms = torch.rsqrt(rms * (1.0 / head_dim) + eps)
+            x1_weight = torch.where(
+                use_q_weight,
+                q_weight[None, None, x1_offset],
+                k_weight[None, None, x1_offset],
+            )
+            x2_weight = torch.where(
+                use_q_weight,
+                q_weight[None, None, x2_offset],
+                k_weight[None, None, x2_offset],
+            )
+            x1_blk = (x1_blk * rms[:, :, None]).to(qkv.dtype) * x1_weight
+            x2_blk = (x2_blk * rms[:, :, None]).to(qkv.dtype) * x2_weight
+
+        pos_id = position_ids[tile_m]
+        cos_blk = cos_sin_cache[pos_id, hl.arange(embed_dim)]
+        sin_blk = cos_sin_cache[pos_id, hl.arange(embed_dim) + embed_dim]
 
         o1_blk = x1_blk * cos_blk[:, None, :] - x2_blk * sin_blk[:, None, :]
         o2_blk = x2_blk * cos_blk[:, None, :] + x1_blk * sin_blk[:, None, :]

--- a/vllm/kernels/helion/ops/fused_qk_norm_rope.py
+++ b/vllm/kernels/helion/ops/fused_qk_norm_rope.py
@@ -53,7 +53,7 @@ def generate_inputs() -> dict[CaseKey, tuple[Any, ...]]:
         (32, 8),
         (64, 8),
     ]
-    head_dim = 128
+    head_dim_list = [64, 128, 256]
     in_dtype: torch.dtype = torch.bfloat16
     rotary_ratio = 1.0
     is_neox = True
@@ -61,8 +61,8 @@ def generate_inputs() -> dict[CaseKey, tuple[Any, ...]]:
     device = "cuda"
     inputs = {}
 
-    for num_tokens, (num_q_heads, num_kv_heads) in product(
-        num_tokens_list, num_heads_pair
+    for num_tokens, (num_q_heads, num_kv_heads), head_dim in product(
+        num_tokens_list, num_heads_pair, head_dim_list
     ):
         total_dim = (num_q_heads + 2 * num_kv_heads) * head_dim
         qkv = torch.empty(
@@ -84,6 +84,7 @@ def generate_inputs() -> dict[CaseKey, tuple[Any, ...]]:
                 "q_heads": num_q_heads,
                 "kv_heads": num_kv_heads,
                 "num_tokens": num_tokens,
+                "head_dim": head_dim,
             }
         )
         inputs[config_key] = (

--- a/vllm/kernels/helion/ops/fused_qk_norm_rope.py
+++ b/vllm/kernels/helion/ops/fused_qk_norm_rope.py
@@ -104,18 +104,20 @@ def generate_inputs() -> dict[CaseKey, tuple[Any, ...]]:
     return inputs
 
 
-_pick_cache: dict[tuple[int, int, int], CaseKey | None] = {}
+_pick_cache: dict[tuple[int, int, int, int], CaseKey | None] = {}
 
 
 def pick_config(args: tuple[Any, ...], config_keys: list[CaseKey]) -> CaseKey | None:
     """Pick the best pre-tuned config for the given input shape.
 
     Selection strategy:
-      1. Find the closest q_heads among available configs
+      1. Prefer configs tuned for the exact head_dim. If none exist, use
+         configs without a head_dim key, then fall back to the closest head_dim.
+      2. Find the closest q_heads among available configs
          (exact match preferred).
-      2. Find the closest kv_heads among available configs
+      3. Find the closest kv_heads among available configs
          (exact match preferred).
-      3. Among the num_tokens values tuned for that q_heads and q_heads, pick
+      4. Among the num_tokens values tuned for that q_heads and kv_heads, pick
          the smallest num_tokens >= the input's num_tokens. If the input is
          larger than all available num_tokens, fall back to the largest.
     """
@@ -123,18 +125,31 @@ def pick_config(args: tuple[Any, ...], config_keys: list[CaseKey]) -> CaseKey | 
     if not config_keys:
         return None
 
-    qkv, q_heads, kv_heads, *_ = args
+    qkv, q_heads, kv_heads, _, head_dim, *_ = args
     num_tokens = qkv.shape[0]
 
-    cache_key = (num_tokens, q_heads, kv_heads)
+    cache_key = (num_tokens, q_heads, kv_heads, head_dim)
     cached = _pick_cache.get(cache_key)
     if cached is not None:
         return cached
 
+    non_default_keys = [key for key in config_keys if not key.is_default()]
+    candidate_keys = [
+        key for key in non_default_keys if key.get("head_dim") == head_dim
+    ]
+    if not candidate_keys:
+        candidate_keys = [key for key in non_default_keys if "head_dim" not in key]
+    if not candidate_keys and non_default_keys:
+        best_head_dim = min(
+            {key["head_dim"] for key in non_default_keys},
+            key=lambda value: abs(value - head_dim),
+        )
+        candidate_keys = [
+            key for key in non_default_keys if key["head_dim"] == best_head_dim
+        ]
+
     configs: dict[int, dict[int, list[int]]] = {}
-    for key in config_keys:
-        if key.is_default():
-            continue
+    for key in candidate_keys:
         configs.setdefault(key["q_heads"], {}).setdefault(key["kv_heads"], []).append(
             key["num_tokens"]
         )
@@ -149,12 +164,12 @@ def pick_config(args: tuple[Any, ...], config_keys: list[CaseKey]) -> CaseKey | 
         (n for n in available_num_tokens if n >= num_tokens), available_num_tokens[-1]
     )
 
-    result = CaseKey(
-        {
-            "q_heads": best_q_heads,
-            "kv_heads": best_kv_heads,
-            "num_tokens": best_num_tokens,
-        }
+    result = next(
+        key
+        for key in candidate_keys
+        if key["q_heads"] == best_q_heads
+        and key["kv_heads"] == best_kv_heads
+        and key["num_tokens"] == best_num_tokens
     )
     _pick_cache[cache_key] = result
     return result


### PR DESCRIPTION
## Purpose

Eliminate the intermediate normalized-QKV store/barrier/reload from the full-rotary `fused_qk_norm_rope` Helion kernel, retune its H100 and B200 schedules, and extend benchmark input coverage to head dimensions 64, 128, and 256.

For full rotary dimensions, the kernel now loads the two rotary halves directly, computes RMSNorm from those register-resident values, applies the Q/K weights and RoPE, and writes each half once. Partial rotary dimensions keep the existing robust full-head fallback.

The emitted full-rotary Triton has:

- 2 QKV loads
- 2 QKV stores
- 0 `tl.debug_barrier()` calls

`generate_inputs()` produces 126 distinct cases across `head_dim in {64, 128, 256}`. `head_dim` is part of each generated `CaseKey`, preventing cases from overwriting one another.

## Configs

The existing generic configs remain the fallback for head dimensions without dedicated schedules. The picker prefers exact `head_dim` keys when present.

On B200, nine sparse `head_dim=256` anchors cover three schedule regions for each Q-head count. The smallest-greater-or-equal token selection maps all 42 generated 256-dimensional cases onto those regions.

On H100, all 45 checked-in generic schedule entries were re-evaluated for the register-resident kernel. The selected configs improve the 42-case `head_dim=128` sweep from a `1.158x` to `1.269x` geometric-mean speedup over CUDA. The remaining three entries retain coverage for the 16384-token bucket.

## Duplicate-work check

This is materially different from #50193. That draft selects existing H100 schedule source keys based on runtime `head_dim`; this PR changes the kernel dataflow and adds measured schedules for the register-resident implementation. Searches for `fused qk norm rope helion` and `fused_qk_norm_rope` found #50193 and related routing/version/kernel PRs, but no open PR implementing this register-resident path or these schedules.

## Test plan

```bash
PYTHONPATH=$PWD CUDA_VISIBLE_DEVICES=0 .venv/bin/python -m pytest \
  tests/kernels/helion/test_fused_qk_norm_rope.py -q

CUDA_VISIBLE_DEVICES=0 .venv/bin/python \
  scripts/benchmark_helion_kernels.py \
  --kernel fused_qk_norm_rope \
  --baseline cuda \
  --repeat 100 \
  --return-mode mean \
  --output /tmp/fused_qk_norm_rope_h100_retuned_final.json

pre-commit run
```

The benchmark clears L2 between timed samples through the benchmark harness.

## Results

- Correctness suite: `103 passed`
- Pre-commit hooks run by the commit: all applicable hooks passed
- H100 before retuning: `29/42` wins, `1.158x` geometric mean, `0.883x` minimum
- H100 after retuning: `41/42` wins, `1.269x` geometric mean, `0.980x` minimum
- H100 after retuning: `42/42` cases are within 2% of CUDA and no case is more than 5% slower
- Complete B200 sweep: `122/126` shapes beat CUDA, `1.310x` geometric mean
- B200 `head_dim=128`: `42/42` wins, `1.077x` minimum, `1.278x` geometric mean
- B200 `head_dim=256`: `42/42` wins, `1.141x` minimum, `1.358x` geometric mean
- B200 `head_dim=64`: `38/42` wins, `0.877x` minimum, `1.295x` geometric mean

No model evaluation was run because this is a numerics-preserving kernel implementation and schedule change. The correctness matrix covers BF16/FP16, NeoX/interleaved layouts, full/partial rotary dimensions, and multiple token/head shapes.

## AI assistance

AI assistance was used to inspect generated Triton, develop the dataflow rewrite, tune schedules, run validation, and draft this description. The human submitter must review every changed line and validate the results before requesting review.
