### PR TITLE
[ROCm] Route sparse-indexer decode top-k through AITER dispatcher

### DIFF
--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -380,6 +380,22 @@ def paged_mqa_logits_module():
     return None
 
 
+@functools.lru_cache
+def _aiter_top_k_per_row_decode():
+    """Resolve AITER's decode top-k, which routes FlyDSL vs HIP by arch/shape.
+
+    Returns None when the installed aiter predates the dispatcher, so the caller
+    falls back to the native ``torch.ops._C`` kernel.
+    """
+    if find_spec("aiter") is None:
+        return None
+    try:
+        from aiter import top_k_per_row_decode
+    except ImportError:
+        return None
+    return top_k_per_row_decode
+
+
 def rocm_fp8_paged_mqa_logits(
     q_fp8: torch.Tensor,
     kv_cache_fp8: torch.Tensor,
@@ -797,16 +813,29 @@ def rocm_aiter_sparse_attn_indexer(
         topk_indices = topk_indices_buffer[:num_padded_tokens, :topk_tokens]
         num_rows = logits.shape[0]
 
-        torch.ops._C.top_k_per_row_decode(
-            logits,
-            next_n,
-            decode_metadata.seq_lens,
-            topk_indices,
-            num_rows,
-            logits.stride(0),
-            logits.stride(1),
-            topk_tokens,
-        )
+        aiter_top_k_per_row_decode = _aiter_top_k_per_row_decode()
+        if aiter_top_k_per_row_decode is not None:
+            aiter_top_k_per_row_decode(
+                logits,
+                next_n,
+                decode_metadata.seq_lens,
+                topk_indices,
+                num_rows,
+                logits.stride(0),
+                logits.stride(1),
+                topk_tokens,
+            )
+        else:
+            torch.ops._C.top_k_per_row_decode(
+                logits,
+                next_n,
+                decode_metadata.seq_lens,
+                topk_indices,
+                num_rows,
+                logits.stride(0),
+                logits.stride(1),
+                topk_tokens,
+            )
 
         if decode_metadata.requires_padding:
             # if padded, we need to unpack


### PR DESCRIPTION
## Purpose

The DeepSeek-V3.2 / GLM-5 sparse attention indexer calls decode top-k on every
decode step. On the ROCm path that call is hardwired to
`torch.ops._C.top_k_per_row_decode` — a HIP radix kernel whose cost grows
~linearly with context width (~15× slower than NVIDIA B200's context-independent
`persistent_topk_kernel`; ~78 calls/step make it the dominant single-kernel gap
at long context).

This routes the call through `aiter.top_k_per_row_decode` instead, which gates a
**context-length-independent FlyDSL kernel** onto the arch/shape window where it
wins and keeps HIP everywhere else. vLLM adds **no gfx950 logic** — all
arch/shape routing and the HIP fallback live in AITER.

- Depends on the AITER decode-top-k dispatcher (ROCm/aiter, follow-up to
  https://github.com/ROCm/aiter/pull/4355). Until an aiter exposing
  `top_k_per_row_decode` is installed, this path is a **no-op** and the native
  kernel runs unchanged.
- Ticket: SILOTIGER-699 (epic SILOTIGER-606, GLM-5 MI355X perf uplift).

**What changes** — one file, `vllm/v1/attention/ops/rocm_aiter_mla_sparse.py`:

1. `_aiter_top_k_per_row_decode()` — cached resolver returning
   `aiter.top_k_per_row_decode` when importable, else `None`.
2. The decode call site calls the resolved op when present, else falls back to
   the existing `torch.ops._C.top_k_per_row_decode`.

Signatures are positionally identical, so the call is drop-in. Behavior when
aiter is absent or predates the dispatcher: resolver returns `None` → native
`_C` kernel, i.e. a no-op on current deployments.

## Test Plan

Tested on **gfx950 (MI355X)** against the AITER dispatcher branch,
`torch 2.10+rocm7.1`:

- AITER dispatch-gate unit tests (`op_tests/test_topk_decode_dispatch.py`)
- FlyDSL decode GPU correctness (`op_tests/flydsl_tests/test_flydsl_topk_per_row_decode.py`)
- End-to-end through vLLM's resolver (`_aiter_top_k_per_row_decode`) → AITER gate
  on 7 shapes, results compared to `torch.topk`
- Fallback path with aiter absent (resolver returns `None`)
- Kernel + per-step A/B, FlyDSL vs HIP, gate toggled via
  `AITER_DISABLE_FLYDSL_TOPK_DECODE`; each arm proves which kernel ran via an
  opt-in dispatch counter (FlyDSL arm flydsl>0, HIP arm flydsl=0)

## Test Result

**Correctness**
- Dispatch-gate unit tests: 34/34 pass
- FlyDSL decode GPU correctness: 99/99 pass
- vLLM resolver → gate, 7 shapes: in-gate route FlyDSL, out-of-gate
  (rows=2, width<131072, k=512) route HIP, all **set-equal to `torch.topk`**
- Fallback: aiter absent → resolver `None` → native `_C` path unchanged

**Kernel-level A/B** (same op, gate toggled), 200 calls/shape,
`hip/flydsl` ratio (>1 = FlyDSL faster):

| rows | width | FlyDSL µs | HIP µs | ratio |
|---|---|---|---|---|
| 4 | 131072 | 40.7 | 47.0 | 1.16 |
| 8 | 131072 | 40.6 | 52.9 | 1.30 |
| 16 | 131072 | 48.7 | 52.2 | 1.07 |
| 1 | 163840 | 31.2 | 37.3 | 1.20 |
| 4 | 163840 | 41.2 | 50.8 | 1.23 |
| 8 | 163840 | 44.6 | 51.7 | 1.16 |
| 16 | 163840 | 51.9 | 53.6 | 1.03 |

**Per-decode-step** (indexer calls decode top-k ~78×/step), in-gate widths,
ms/step (gate faster = >1×):

| rows | width | gate ms | HIP ms | speedup |
|---|---|---|---|---|
| 4 | 131072 | 2.93 | 3.67 | 1.26× |
| 8 | 131072 | 3.17 | 4.18 | 1.32× |
| 16 | 131072 | 3.95 | 4.10 | 1.04× |
| 1 | 163840 | 2.42 | 2.53 | 1.05× |
| 4 | 163840 | 3.20 | 3.98 | 1.24× |
| 8 | 163840 | 3.42 | 4.04 | 1.18× |
| 16 | 163840 | 4.06 | 4.18 | 1.03× |

FlyDSL faster on all in-gate cells, best in the realistic rows 4–8 band
(1.2–1.32×). Using the ticket's top-k ≈ 12.2% step share, cutting per-step
top-k ~20% projects **~2.4–2.5% TPOT** at width ≥131072 (a kernel-share
projection, not a live serving TPOT — see below).

**Pending (needs the serving cluster):**
- vLLM-side unit test asserting the resolver returns `None` without aiter and the
  callable with it (patchable, no GPU).
- End-to-end serving A/B (GSM8K + long-context TPOT) on GLM-5.2-MXFP4 TP4 at
  ISL 60k/120k, `--max-model-len ≥ 131072`, toggling
  `AITER_DISABLE_FLYDSL_TOPK_DECODE`. Kernel wins convert to TPOT only when top-k
  is a real share of step time (long context); a 1k/8k comparison shows flat and
  must not be read as a regression.

## Not a duplicate

No open vLLM PR wires AITER's top-k into the sparse indexer: `_aiter_ops.py`
registers no `top_k` op and the decode call site still uses
`torch.ops._C.top_k_per_row_decode`. Recent PRs in this file (#49714, #48788,
#44527) are DSV4 bugfixes/perf, none routing decode top-k to AITER.

---

AI assistance (Claude Code) was used; the submitter has reviewed every line and
run the tests above. Commit is DCO signed-off.
