### PR TITLE
[Misc][Doc] Identify vLLM in the S3 client user agent

### DIFF
--- a/docs/models/extensions/runai_model_streamer.md
+++ b/docs/models/extensions/runai_model_streamer.md
@@ -51,6 +51,8 @@ vllm serve s3://core-llm/Llama-3-8b \
     --load-format runai_streamer
 ```
 
+Setting `AWS_ENDPOINT_URL` points the streamer at any S3-compatible object store, so the same `s3://` model paths work against Amazon S3, Backblaze B2, Cloudflare R2, MinIO, and other services that implement the S3 API. Replace the endpoint in the example above with your provider's S3 endpoint, such as `https://your-s3-endpoint.example.com`.
+
 ## Tunable parameters
 
 You can tune parameters using `--model-loader-extra-config`:

--- a/vllm/transformers_utils/s3_utils.py
+++ b/vllm/transformers_utils/s3_utils.py
@@ -5,14 +5,19 @@ import fnmatch
 from typing import TYPE_CHECKING
 
 from vllm.utils.import_utils import PlaceholderModule
+from vllm.version import __version__ as VLLM_VERSION
 
 if TYPE_CHECKING:
     from botocore.client import BaseClient
 
 try:
     import boto3
+    from botocore.config import Config
 except ImportError:
     boto3 = PlaceholderModule("boto3")  # type: ignore[assignment]
+    Config = PlaceholderModule("botocore").placeholder_attr(  # type: ignore[assignment]
+        "config.Config"
+    )
 
 
 def _filter_allow(paths: list[str], patterns: list[str]) -> list[str]:
@@ -48,7 +53,10 @@ def glob(
         list[str]: List of full S3 paths allowed by the pattern
     """
     if s3 is None:
-        s3 = boto3.client("s3")
+        s3 = boto3.client(
+            "s3",
+            config=Config(user_agent_extra=f"vLLM/{VLLM_VERSION}"),
+        )
     if not path.endswith("/"):
         path = path + "/"
     bucket_name, _, paths = list_files(s3, path=path, allow_pattern=allow_pattern)


### PR DESCRIPTION
> **Status: draft, awaiting maintainer input on #50472.**
> Opened per AGENTS.md rather than pushing an unsolicited small PR. #50472 asks whether the maintainers want this at all; this PR is the reference implementation so the diff is concrete. Happy to close it, reshape it, or drop either half.

Closes #50472 if accepted.

---

## Purpose

`glob()` in `vllm/transformers_utils/s3_utils.py` builds its client with a bare `boto3.client("s3")`, so the requests it makes carry only the default botocore user agent and nothing identifies the caller as vLLM. That client is what `sharded_state_loader.py` uses to list weights when the model path is an `s3://` URI, so in an object store's access log a vLLM weight load is indistinguishable from any other botocore process.

This passes `botocore.config.Config(user_agent_extra=f"vLLM/{__version__}")` when vLLM constructs the client, which appends a `vLLM/<version>` token to the user agent string. `user_agent_extra` appends, it does not replace the botocore identifiers, and a caller that supplies its own `s3` client is untouched. It mirrors what vLLM already does for its HTTP traffic in `vllm/connections.py`, which sets `{"User-Agent": f"vLLM/{VLLM_VERSION}"}`, so the two paths identify vLLM the same way.

The value is plainly small and operational: with the version in the log line, someone debugging a slow or throttled weight pull can tell which vLLM version issued the requests, and storage operators can attribute load traffic instead of guessing. It is the standard botocore mechanism for this and costs one keyword argument. The `except ImportError` branch gains a matching `Config` placeholder via `PlaceholderModule(...).placeholder_attr("config.Config")`, following the dotted-path usage already in `vllm/model_executor/model_loader/tensorizer.py`, so the no-boto3 install path keeps failing with the same "please install" message rather than a `NameError`.

The second commit is docs only. The "S3 compatible object store" section of `docs/models/extensions/runai_model_streamer.md` shows the pattern with `AWS_ENDPOINT_URL=https://storage.googleapis.com`, which reads as if the section were about Google Cloud Storage specifically (and GCS is already documented natively two examples above). The added sentence says that the endpoint URL is the substitution point, so the same `s3://` paths work against any service implementing the S3 API, naming Amazon S3, Backblaze B2, Cloudflare R2, and MinIO as examples, and gives a placeholder endpoint to replace. No behavior change and no new example block.

## Not a duplicate

There is no linked issue, so only the PR searches from `AGENTS.md` apply. Run today:

```bash
gh pr list --repo vllm-project/vllm --state all  --search "user_agent_extra in:body"   # no results
gh pr list --repo vllm-project/vllm --state open --search "s3_utils"                   # 45484, 38557
gh pr list --repo vllm-project/vllm --state open --search "botocore"                   # 45484, 46487, 50426
gh pr list --repo vllm-project/vllm --state open --search "boto3 s3 client"             # 45484, 50426
gh pr list --repo vllm-project/vllm --state open --search "S3-compatible"               # 47064, 43886, 40246, 50426
```

No open or merged PR sets a user agent on vLLM's S3 client. Two open PRs are adjacent and worth flagging rather than hiding:

- #45484 lazy-imports boto3 in the same file to cut cold-start time. Different purpose, but it rewrites the same `try/except ImportError` block, so whichever lands second needs a small textual rebase. I am happy to be the one to rebase.
- #47064 edits the same docs section to add another provider example. Different content, same paragraph. If maintainers prefer only one change to that section, I will drop the docs commit here.

## Test Plan

Linters on the changed file, as CI runs them:

```bash
ruff check vllm/transformers_utils/s3_utils.py
ruff format --check vllm/transformers_utils/s3_utils.py
```

And a standalone check of the mechanism itself, which needs no credentials and no network: build the client exactly the way the patch does, point it at a placeholder endpoint, register a `before-send` hook, and read the outgoing `User-Agent` with and without the config.

```python
import boto3
from botocore.config import Config

captured = {}

def record(request, **kwargs):
    captured["ua"] = request.headers.get("User-Agent")

for label, cfg in (("baseline", None), ("patched", Config(user_agent_extra="vLLM/0.0.0.dev0"))):
    client = boto3.client(
        "s3", region_name="us-east-1",
        aws_access_key_id="test", aws_secret_access_key="test",
        endpoint_url="https://your-s3-endpoint.example.com",
        **({"config": cfg} if cfg else {}),
    )
    client.meta.events.register_last("before-send.s3.*", record)
    try:
        client.list_objects_v2(Bucket="example-bucket", Prefix="model/")
    except Exception:
        pass
    print(label, captured["ua"])
```

## Test Result

Both linters clean:

```text
ruff check .............. All checks passed!
ruff format --check ..... 1 file already formatted
```

User agent before and after, boto3/botocore 1.43.31:

```text
baseline: Boto3/1.43.31 md/Botocore#1.43.31 ua/2.1 os/macos#25.6.0 md/arch#arm64 lang/python#3.11.15 md/pyimpl#CPython m/Z,e,D,N,b cfg/retry-mode#legacy Botocore/1.43.31
patched:  Boto3/1.43.31 md/Botocore#1.43.31 ua/2.1 os/macos#25.6.0 md/arch#arm64 lang/python#3.11.15 md/pyimpl#CPython m/Z,e,D,N,b cfg/retry-mode#legacy Botocore/1.43.31 vLLM/0.0.0.dev0
```

The `vLLM/<version>` token is appended and the botocore identifiers are preserved.

Gaps, stated plainly: `s3_utils.glob` has no unit test in the tree today, and I have not run an end to end `vllm serve s3://... --load-format sharded_state` against a live bucket, so the end to end path is verified only through the botocore behavior above and by reading the call site. If you want a unit test in this PR asserting `user_agent_extra` on the constructed client, say so and I will add one. Opened as a draft for that reason.

## AI assistance

This change was written with AI assistance (Claude). I reviewed every changed line, verified the `placeholder_attr` fallback against the existing dotted-path usage in `tensorizer.py`, and ran the checks reported above myself.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the Google Doc.
</details>

