### PR TITLE
[Build] Update pin to build ABI stable FA2

### DIFF
--- a/.buildkite/check-torch-abi.py
+++ b/.buildkite/check-torch-abi.py
@@ -14,7 +14,6 @@ from torch_abi_audit.report import ExtensionReport, PackageReport
 # Shrink and remove over time.
 ALLOWED_UNSTABLE_LIBRARIES: tuple[str, ...] = (
     "_flashkda_C.abi3.so",
-    "vllm_flash_attn/_vllm_fa2_C.abi3.so",
     "vllm_flash_attn/_vllm_fa3_C.abi3.so",
     "third_party/deep_gemm/_C*.so",
 )

--- a/cmake/external_projects/vllm_flash_attn.cmake
+++ b/cmake/external_projects/vllm_flash_attn.cmake
@@ -38,8 +38,8 @@ if(VLLM_FLASH_ATTN_SRC_DIR)
 else()
   FetchContent_Declare(
           vllm-flash-attn
-          GIT_REPOSITORY https://github.com/janeyx99/flash-attention.git
-          GIT_TAG vllm-fa2-stable-abi
+          GIT_REPOSITORY https://github.com/vllm-project/flash-attention.git
+          GIT_TAG 28e862d21806bc3580207aa0ad4e2759151e9827
           GIT_PROGRESS TRUE
           # Don't share the vllm-flash-attn build between build types
           BINARY_DIR ${CMAKE_BINARY_DIR}/vllm-flash-attn

--- a/cmake/external_projects/vllm_flash_attn.cmake
+++ b/cmake/external_projects/vllm_flash_attn.cmake
@@ -38,8 +38,8 @@ if(VLLM_FLASH_ATTN_SRC_DIR)
 else()
   FetchContent_Declare(
           vllm-flash-attn
-          GIT_REPOSITORY https://github.com/vllm-project/flash-attention.git
-          GIT_TAG ec4a882d70b19235c824848db944d84a6cb8f9ee
+          GIT_REPOSITORY https://github.com/janeyx99/flash-attention.git
+          GIT_TAG vllm-fa2-stable-abi
           GIT_PROGRESS TRUE
           # Don't share the vllm-flash-attn build between build types
           BINARY_DIR ${CMAKE_BINARY_DIR}/vllm-flash-attn


### PR DESCRIPTION
## Purpose

As a part of #26946, completes making FA2 ABI stable (predecessor #46640). For now, this PR tests the new pin at https://github.com/vllm-project/flash-attention/pull/175

## Test Plan

CI should be green.

the .so has no unstable APIs:
```
(vllm-pt213) ➜  vllm git:(vllm-stable-fa2) ✗ torch-abi-audit  /home/janeyx/repos/vllm/vllm/vllm_flash_attn/_vllm_fa2_C.abi3.so 
Package: _vllm_fa2_C.abi3.so
  Root: /home/janeyx/repos/vllm/vllm/vllm_flash_attn
  Torch ABI:   STABLE
  CPython ABI: abi3
  Extensions:  1
  Bundled libs: 0
  -- extensions --
    [STABLE  ] [abi3-ok               ] _vllm_fa2_C.abi3.so  (stable_shim=67, unstable=0)
```

Locally: `pytest tests/kernels/attention/test_flash_attn.py -v -k "2-"` and the sparse test script in #46640.

## Test Result

All FA2 tests pass, failures are all fa3.
```
======================================================= short test summary info =======================================================
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-None-16-72-num_heads0-seq_lens0-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-None-16-72-num_heads0-seq_lens0-False] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-None-16-72-num_heads0-seq_lens1-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-None-16-72-num_heads0-seq_lens1-False] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-None-16-72-num_heads1-seq_lens0-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-None-16-72-num_heads1-seq_lens0-False] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-None-16-72-num_heads1-seq_lens1-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-None-16-72-num_heads1-seq_lens1-False] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-256-16-72-num_heads0-seq_lens0-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-256-16-72-num_heads0-seq_lens0-False] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-256-16-72-num_heads0-seq_lens1-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-256-16-72-num_heads0-seq_lens1-False] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-256-16-72-num_heads1-seq_lens0-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-256-16-72-num_heads1-seq_lens0-False] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-256-16-72-num_heads1-seq_lens1-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-32768-None-dtype0-256-16-72-num_heads1-seq_lens1-False] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-None-16-72-num_heads0-seq_lens0-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-None-16-72-num_heads0-seq_lens0-False] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-None-16-72-num_heads0-seq_lens1-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-None-16-72-num_heads0-seq_lens1-False] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-None-16-72-num_heads1-seq_lens0-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-None-16-72-num_heads1-seq_lens0-False] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-None-16-72-num_heads1-seq_lens1-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-None-16-72-num_heads1-seq_lens1-False] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-256-16-72-num_heads0-seq_lens0-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-256-16-72-num_heads0-seq_lens0-False] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-256-16-72-num_heads0-seq_lens1-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-256-16-72-num_heads0-seq_lens1-False] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-256-16-72-num_heads1-seq_lens0-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-256-16-72-num_heads1-seq_lens0-False] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-256-16-72-num_heads1-seq_lens1-True] - RuntimeError: head_size should be a multiple of 16
FAILED tests/kernels/attention/test_flash_attn.py::test_varlen_with_paged_kv[q_dtype1-3-2048-None-dtype0-256-16-72-num_heads1-seq_lens1-False] - RuntimeError: head_size should be a multiple of 16
======================== 32 failed, 192 passed, 160 skipped, 256 deselected, 14 warnings in 524.62s (0:08:44) =========================
```

Sparse script passes too. 90/90.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

