### PR TITLE
[CI] Retire the v1 PR label rule, add mrv2

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -375,17 +375,19 @@ pull_request_rules:
       add:
         - speculative-decoding
 
-- name: label-v1
-  description: Automatically apply v1 label
+- name: label-mrv2
+  description: Automatically apply mrv2 label
   conditions:
     - label != stale
     - or:
-      - files~=^vllm/v1/
-      - files~=^tests/v1/
+      # Model Runner V2 subtree. The trailing slash is required: the MRv1
+      # files (gpu_model_runner.py, gpu_worker.py, ...) sit one level up.
+      - files~=^vllm/v1/worker/gpu/
+      - title~=(?i)(?:\bmrv2\b|model[-\s]?runner[-\s]?v2)
   actions:
     label:
       add:
-        - v1
+        - mrv2
 
 - name: label-tpu
   description: Automatically apply tpu label


### PR DESCRIPTION
## Purpose

Two related changes to PR auto-labeling, per discussion with @njhill:

**Retire `label-v1`.** Now that V1 is the only engine, `^vllm/v1/` or `^tests/v1/` matches ~28% of PRs (55 of the last 200 commits). The label no longer partitions anything, so it reads as noise. This removes the *rule* only — the `v1` label itself is untouched and stays intact on every PR and issue that already carries it.

**Add `label-mrv2`** for Model Runner V2, taking the slot `v1` occupied. Matches either the `vllm/v1/worker/gpu/` subtree or an MRv2 mention in the PR title.

> [!IMPORTANT]
> **Prerequisite:** the existing `v2` label needs renaming to `mrv2` before this merges. Renaming (rather than creating new + deleting) preserves the label on everything already tagged, including #47172.

### Notes on scope

- **PRs only, not issues.** `issue_autolabel.yml` matches keywords in title/body and has no path awareness, so a path spec buys nothing there. Left untouched.
- **No `tests/` matcher.** There is no `tests/v1/worker/gpu/` mirroring the source tree — MRv2 tests are flat under `tests/v1/worker/`, mostly `test_gpu_*.py` but not all (`test_attn_utils.py`, `test_cp_utils.py`, `test_encoder_runner.py`). Most tests aren't inherently MRv1/MRv2 specific and test-only PRs are uncommon, so this skips them rather than shipping a matcher that silently misses.
- **The trailing slash in the path is load-bearing.** `vllm/v1/worker/` holds the MRv1 files at top level (`gpu_model_runner.py`, `gpu_worker.py`, `gpu_input_batch.py`). `^vllm/v1/worker/gpu/` excludes them; without the slash it would label every MRv1 PR as MRv2. Called out in a comment so it survives future edits.
- **Title matching is unbracketed** (`\bmrv2\b`, `model[-\s]?runner[-\s]?v2`) rather than requiring `[MRV2]`. Measured against repo history below. This matches existing convention in the file (`\bbug\b`, `\bP/?D\b`, `\bk3\b`, `(?i)(?:kimi|moonshot)`).
- No rule collision: the only other rules touching `v1/worker` are the XPU ones (`xpu_worker.py`, `xpu_model_runner.py`) — siblings of `gpu/`, not inside it.

## Test Plan

No runtime code changes, so there is no unit test surface. Validated the config and both regexes against real repository data.

## Test Result

**Config validity** — `pre-commit run --files .github/mergify.yml`: all hooks pass. YAML parses to 34 rules; no residual references to `label-v1` or the `v1` label anywhere in `.github/` or `docs/`.

**Title regex, against every MRv2-titled PR in repo history (223 titles):**

| Pattern | Matched |
|---|---|
| Bracketed-only `\[(?:mrv2\|model[-\s]?runner[-\s]?v2)\]` | 183 / 219 (84%) |
| **Unbracketed (shipped)** | **223 / 223 (100%)** |

The 36 titles the bracketed form misses are all genuine MRv2 work with the tag in prose rather than a bracket — e.g. `[Core][PCP] Support data parallelism with MRV2 PCP`, `[Bugfix][CPU] Fix CPU model runner v2`, `[Perf] Optimize Sampler Redundant Copy for Model Runner v2`.

**False positives:** 0 of 924 unrelated PR titles sampled (queries: attention, kernel, docs, bugfix, quantization, model runner).

**Path regex:** matches 70/70 files in `vllm/v1/worker/gpu/`; correctly excludes `gpu_model_runner.py`, `gpu_worker.py`, `gpu_input_batch.py`, `gpu_ubatch_wrapper.py`, `xpu_worker.py`.

**Expected volume:** `vllm/v1/worker/gpu/` appears in 13 of the last 200 commits (~6.5%), versus `v1`'s ~28% — the high-signal, low-volume label `v1` stopped being.

**Model evaluation:** N/A — CI configuration only, no effect on model output, accuracy, or serving.

## Duplicate check

`gh pr list`/`gh search prs` for open PRs touching mergify labeling, `mrv2`, or the `v1` rule returned nothing addressing this. The two changes are bundled because they are one story — retiring a label that stopped partitioning anything and standing up one that does — and because either alone would be a trivial one-off PR.

---

AI assistance (Claude Code) was used to draft this change. I have reviewed every changed line, verified the regex behavior against the repository data reported above, and can defend the change end-to-end.
