### PR TITLE
[CI] Retry Buildkite API rate limits

### DIFF
--- a/.github/workflows/scripts/run_ci_command.py
+++ b/.github/workflows/scripts/run_ci_command.py
@@ -3,6 +3,7 @@
 
 import json
 import os
+import random
 import sys
 import time
 import urllib.error
@@ -40,14 +41,20 @@ class ApiError(RuntimeError):
         self.status = status
 
 
+def rate_limit_jitter() -> float:
+    return random.uniform(1, 5)
+
+
 class HttpTransport:
     def __init__(
         self,
         *,
-        max_attempts: int = 3,
+        max_retries: int = 3,
+        jitter: Callable[[], float] = rate_limit_jitter,
         sleep: Callable[[float], None] = time.sleep,
     ) -> None:
-        self.max_attempts = max_attempts
+        self.max_retries = max_retries
+        self.jitter = jitter
         self.sleep = sleep
 
     def request(
@@ -65,17 +72,19 @@ class HttpTransport:
             headers=dict(headers or {}),
             method=method,
         )
-        for attempt in range(self.max_attempts):
+        for attempt in range(self.max_retries + 1):
             try:
                 with urllib.request.urlopen(request, timeout=30) as response:
                     response_body = response.read().decode()
                 break
             except urllib.error.HTTPError as error:
                 response_body = error.read().decode()
-                if error.code == 429 and attempt + 1 < self.max_attempts:
+                if error.code == 429 and attempt < self.max_retries:
                     delay = self._rate_limit_delay(error, response_body)
                     print(
-                        f"API rate limit reached; retrying in {delay:g} seconds.",
+                        "API rate limit reached; "
+                        f"retry {attempt + 1}/{self.max_retries} "
+                        f"in {delay:g} seconds.",
                         file=sys.stderr,
                     )
                     self.sleep(delay)
@@ -106,8 +115,8 @@ class HttpTransport:
             return fallback
         return str(parsed.get("message", fallback))
 
-    @staticmethod
     def _rate_limit_delay(
+        self,
         error: urllib.error.HTTPError,
         response_body: str,
     ) -> float:
@@ -121,7 +130,6 @@ class HttpTransport:
             "RateLimit-User-Reset" if scope == "rest_user" else "RateLimit-Reset"
         )
         candidates = [
-            error.headers.get("Retry-After"),
             error.headers.get(reset_header),
             parsed.get("reset"),
         ]
@@ -131,8 +139,8 @@ class HttpTransport:
             except (TypeError, ValueError):
                 continue
             if delay >= 0:
-                return delay + 1
-        return 60
+                return delay + self.jitter()
+        return 60 + self.jitter()
 
 
 class GitHubClient:

--- a/.github/workflows/scripts/run_ci_command.py
+++ b/.github/workflows/scripts/run_ci_command.py
@@ -4,10 +4,11 @@
 import json
 import os
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
 COMMAND_RUN_CI = "/ci run"
@@ -40,6 +41,15 @@ class ApiError(RuntimeError):
 
 
 class HttpTransport:
+    def __init__(
+        self,
+        *,
+        max_attempts: int = 3,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        self.max_attempts = max_attempts
+        self.sleep = sleep
+
     def request(
         self,
         url: str,
@@ -55,18 +65,31 @@ class HttpTransport:
             headers=dict(headers or {}),
             method=method,
         )
-        try:
-            with urllib.request.urlopen(request, timeout=30) as response:
-                response_body = response.read().decode()
-        except urllib.error.HTTPError as error:
-            response_body = error.read().decode()
-            message = self._error_message(response_body, error.reason)
-            raise ApiError(
-                error.code,
-                f"API returned {error.code}: {message}",
-            ) from error
-        except urllib.error.URLError as error:
-            raise ApiError(None, f"API request failed: {error.reason}") from error
+        for attempt in range(self.max_attempts):
+            try:
+                with urllib.request.urlopen(request, timeout=30) as response:
+                    response_body = response.read().decode()
+                break
+            except urllib.error.HTTPError as error:
+                response_body = error.read().decode()
+                if error.code == 429 and attempt + 1 < self.max_attempts:
+                    delay = self._rate_limit_delay(error, response_body)
+                    print(
+                        f"API rate limit reached; retrying in {delay:g} seconds.",
+                        file=sys.stderr,
+                    )
+                    self.sleep(delay)
+                    continue
+                message = self._error_message(response_body, error.reason)
+                raise ApiError(
+                    error.code,
+                    f"API returned {error.code}: {message}",
+                ) from error
+            except urllib.error.URLError as error:
+                raise ApiError(
+                    None,
+                    f"API request failed: {error.reason}",
+                ) from error
 
         if not response_body:
             return None
@@ -82,6 +105,34 @@ class HttpTransport:
         except json.JSONDecodeError:
             return fallback
         return str(parsed.get("message", fallback))
+
+    @staticmethod
+    def _rate_limit_delay(
+        error: urllib.error.HTTPError,
+        response_body: str,
+    ) -> float:
+        try:
+            parsed = json.loads(response_body)
+        except json.JSONDecodeError:
+            parsed = {}
+
+        scope = parsed.get("scope")
+        reset_header = (
+            "RateLimit-User-Reset" if scope == "rest_user" else "RateLimit-Reset"
+        )
+        candidates = [
+            error.headers.get("Retry-After"),
+            error.headers.get(reset_header),
+            parsed.get("reset"),
+        ]
+        for candidate in candidates:
+            try:
+                delay = float(candidate)
+            except (TypeError, ValueError):
+                continue
+            if delay >= 0:
+                return delay + 1
+        return 60
 
 
 class GitHubClient:

--- a/.github/workflows/scripts/test_run_ci_command.py
+++ b/.github/workflows/scripts/test_run_ci_command.py
@@ -1,9 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import io
 import json
 import unittest
+import urllib.error
 from typing import Any
+from unittest.mock import patch
 
 from run_ci_command import (
     CI_AUTHORIZED_COMMENT_MARKER,
@@ -11,6 +14,7 @@ from run_ci_command import (
     COMMAND_RUN_CI,
     RETRY_STATES,
     BuildkiteClient,
+    HttpTransport,
     authorize,
     create_build_payload,
     has_trusted_approval,
@@ -160,7 +164,73 @@ class FakeTransport:
         return self.response
 
 
+class FakeHttpResponse:
+    def __init__(self, response: Any) -> None:
+        self.response = response
+
+    def __enter__(self) -> "FakeHttpResponse":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self.response).encode()
+
+
 class RunCiCommandTest(unittest.TestCase):
+    @patch("run_ci_command.urllib.request.urlopen")
+    def test_http_transport_retries_buildkite_rate_limit(self, urlopen: Any) -> None:
+        body = {
+            "message": "Please wait 9 seconds before making more requests.",
+            "reset": 9,
+            "scope": "rest",
+        }
+        rate_limit_error = urllib.error.HTTPError(
+            "https://api.buildkite.com/v2/builds",
+            429,
+            "Too Many Requests",
+            {
+                "RateLimit-Limit": "400",
+                "RateLimit-Remaining": "0",
+                "RateLimit-Reset": "9",
+            },
+            io.BytesIO(json.dumps(body).encode()),
+        )
+        urlopen.side_effect = [rate_limit_error, FakeHttpResponse({"ok": True})]
+        delays: list[float] = []
+
+        response = HttpTransport(sleep=delays.append).request(
+            "https://api.buildkite.com/v2/builds"
+        )
+
+        self.assertEqual(response, {"ok": True})
+        self.assertEqual(delays, [10])
+        self.assertEqual(urlopen.call_count, 2)
+
+    @patch("run_ci_command.urllib.request.urlopen")
+    def test_http_transport_does_not_retry_permission_error(self, urlopen: Any) -> None:
+        permission_error = urllib.error.HTTPError(
+            "https://api.github.com/repos/vllm-project/vllm/issues/1/comments",
+            403,
+            "Forbidden",
+            {},
+            io.BytesIO(b'{"message":"Resource not accessible by integration"}'),
+        )
+        urlopen.side_effect = permission_error
+        delays: list[float] = []
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Resource not accessible by integration",
+        ):
+            HttpTransport(sleep=delays.append).request(
+                "https://api.github.com/repos/vllm-project/vllm/issues/1/comments"
+            )
+
+        self.assertEqual(delays, [])
+        self.assertEqual(urlopen.call_count, 1)
+
     def test_only_exact_ci_commands_are_accepted(self) -> None:
         self.assertEqual(parse_command(COMMAND_RUN_CI), COMMAND_RUN_CI)
         self.assertEqual(

--- a/.github/workflows/scripts/test_run_ci_command.py
+++ b/.github/workflows/scripts/test_run_ci_command.py
@@ -200,13 +200,46 @@ class RunCiCommandTest(unittest.TestCase):
         urlopen.side_effect = [rate_limit_error, FakeHttpResponse({"ok": True})]
         delays: list[float] = []
 
-        response = HttpTransport(sleep=delays.append).request(
-            "https://api.buildkite.com/v2/builds"
-        )
+        response = HttpTransport(
+            jitter=lambda: 2.5,
+            sleep=delays.append,
+        ).request("https://api.buildkite.com/v2/builds")
 
         self.assertEqual(response, {"ok": True})
-        self.assertEqual(delays, [10])
+        self.assertEqual(delays, [11.5])
         self.assertEqual(urlopen.call_count, 2)
+
+    @patch("run_ci_command.urllib.request.urlopen")
+    def test_http_transport_retries_rate_limit_three_times(self, urlopen: Any) -> None:
+        def rate_limit_error() -> urllib.error.HTTPError:
+            body = {
+                "message": "Please wait 9 seconds before making more requests.",
+                "reset": 9,
+                "scope": "rest",
+            }
+            return urllib.error.HTTPError(
+                "https://api.buildkite.com/v2/builds",
+                429,
+                "Too Many Requests",
+                {
+                    "RateLimit-Limit": "400",
+                    "RateLimit-Remaining": "0",
+                    "RateLimit-Reset": "9",
+                },
+                io.BytesIO(json.dumps(body).encode()),
+            )
+
+        urlopen.side_effect = [rate_limit_error() for _ in range(4)]
+        delays: list[float] = []
+
+        with self.assertRaisesRegex(RuntimeError, "API returned 429"):
+            HttpTransport(
+                jitter=lambda: 2,
+                sleep=delays.append,
+            ).request("https://api.buildkite.com/v2/builds")
+
+        self.assertEqual(delays, [11, 11, 11])
+        self.assertEqual(urlopen.call_count, 4)
 
     @patch("run_ci_command.urllib.request.urlopen")
     def test_http_transport_does_not_retry_permission_error(self, urlopen: Any) -> None:
@@ -224,7 +257,10 @@ class RunCiCommandTest(unittest.TestCase):
             RuntimeError,
             "Resource not accessible by integration",
         ):
-            HttpTransport(sleep=delays.append).request(
+            HttpTransport(
+                jitter=lambda: 2,
+                sleep=delays.append,
+            ).request(
                 "https://api.github.com/repos/vllm-project/vllm/issues/1/comments"
             )
 


### PR DESCRIPTION
## Why

The first attempt of [Run CI from PR comment #30572134207](https://github.com/vllm-project/vllm/actions/runs/30572134207/job/90971214991) failed while listing Buildkite builds:

```
API returned 429: You have exceeded your rest API rate limit. Please wait 9 seconds before making more requests.
```

A later manual rerun succeeded. A live quota query also showed the vLLM organization REST bucket at its configured limit of 400/400 requests per minute.

## What changed

- Retry HTTP 429 responses up to three times after the initial request, for four maximum attempts.
- Select `RateLimit-Reset` or `RateLimit-User-Reset` according to Buildkite's reported rate-limit scope, falling back to the response body's `reset` value.
- Add a random 1–5 second delay after the reported reset to spread concurrent workflow retries.
- Fall back to 60 seconds plus jitter when Buildkite does not provide reset timing.
- Keep non-rate-limit errors such as permission-related 403 responses fail-closed without retrying.

## Duplicate-work check

I searched open PRs for Buildkite rate-limit retry work and found no duplicate. #50316 already contains the separate `notify-ci-authorized` permission fix, so this PR deliberately does not duplicate that change.

## Tests

- `uv run --no-project --python 3.12 .github/workflows/scripts/test_run_ci_command.py` — 31 tests passed, including a three-retry exhaustion case.
- `pre-commit run --files .github/workflows/scripts/run_ci_command.py .github/workflows/scripts/test_run_ci_command.py` — all applicable hooks passed, including ruff and mypy.

Model evaluation: not applicable; this change does not affect model output, accuracy, or serving.

AI assistance was used to diagnose the Actions logs, implement the retry logic, and add tests. The submitting human must review and understand every changed line before marking this PR ready.