### PR TITLE
[Bugfix] Reject KV caches FlexAttention cannot address in int32

### DIFF
--- a/tests/kernels/test_flex_attention.py
+++ b/tests/kernels/test_flex_attention.py
@@ -357,6 +357,45 @@ def test_block_mask_direct_vs_slow_path():
     )
 
 
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or TORCH_VERSION < DIRECT_BUILD_VERSION,
+    reason="CUDA not available or PyTorch version < 2.9",
+)
+def test_rejects_kv_cache_too_large_for_int32_paged_offsets():
+    """Regression test for https://github.com/vllm-project/vllm/issues/50427.
+
+    The flex-attention kernel gathers paged K/V with int32 element offsets, so a
+    KV cache holding 2**31 or more elements wraps to a negative offset and reads
+    outside the cache. Metadata building must reject such a cache instead of
+    letting the kernel crash or return silently wrong attention output.
+    """
+    device = torch.device("cuda")
+    batch_spec = BatchSpec(seq_lens=[64], query_lens=[64], name="test_int32_offsets")
+
+    def build(num_gpu_blocks: int):
+        vllm_config = create_vllm_config(
+            model_name="facebook/opt-125m",
+            block_size=16,
+            num_gpu_blocks=num_gpu_blocks,
+            max_num_seqs=8,
+        )
+        kv_cache_spec = create_standard_kv_cache_spec(vllm_config)
+        common_attn_metadata = create_common_attn_metadata(
+            batch_spec, vllm_config.cache_config.block_size, device
+        )
+        builder = FlexAttentionMetadataBuilder(kv_cache_spec, [], vllm_config, device)
+        builder.build(common_prefix_len=0, common_attn_metadata=common_attn_metadata)
+
+    spec = create_standard_kv_cache_spec(
+        create_vllm_config(model_name="facebook/opt-125m", block_size=16)
+    )
+    max_blocks = 2**31 // (16 * 2 * spec.num_kv_heads * spec.head_size)
+
+    build(max_blocks)
+    with pytest.raises(ValueError, match="overflow int32"):
+        build(max_blocks + 1)
+
+
 def test_physical_to_logical_mapping_handles_reused_blocks():
     """Regression test: reused physical blocks map to the latest logical block.
 

--- a/vllm/v1/attention/backends/flex_attention.py
+++ b/vllm/v1/attention/backends/flex_attention.py
@@ -1103,6 +1103,22 @@ class FlexAttentionMetadataBuilder(AttentionMetadataBuilder[FlexAttentionMetadat
             )
 
         uses_paged_kv = not isinstance(self.kv_cache_spec, EncoderOnlyAttentionSpec)
+        # The flex-attention kernel gathers paged K/V with `token_index *
+        # stride_kn` computed in int32, and K and V share one buffer so stride_kn
+        # spans both. Once that product reaches 2**31 it wraps negative and the
+        # kernel reads ~4 GiB below the KV cache: an illegal memory access, or
+        # silently wrong output when that address happens to be mapped.
+        # See https://github.com/vllm-project/vllm/issues/50427.
+        kv_stride = 2 * self.kv_cache_spec.num_kv_heads * self.kv_cache_spec.head_size
+        max_num_gpu_blocks = 2**31 // (block_size * kv_stride)
+        if uses_paged_kv and num_gpu_blocks > max_num_gpu_blocks:
+            raise ValueError(
+                f"FlexAttention cannot address {num_gpu_blocks} KV cache blocks: "
+                f"paged K/V offsets overflow int32 above {max_num_gpu_blocks} "
+                f"blocks. Lower --gpu-memory-utilization, or set "
+                f"--num-gpu-blocks-override to at most {max_num_gpu_blocks}."
+            )
+
         logical_mask_mod = (
             bidirectional_mask_mod
             if uses_paged_kv and not common_attn_metadata.causal


### PR DESCRIPTION
Fixes #50427

## What is wrong

The FlexAttention Triton kernel computes the paged K/V element offset as
`offs_n * stride_kn` in int32. This backend interleaves K and V in the content
dim (`(num_blocks, num_kv_heads, block_size, 2 * head_size)`), so the K view's
token stride is `2 * num_kv_heads * head_size` and its largest linear offset
spans the whole K+V buffer, not just K. Once one layer's KV cache holds 2**31
elements, that is
`num_gpu_blocks > 2**31 // (block_size * 2 * num_kv_heads * head_size)`, the
product wraps negative and the kernel gathers about 4 GiB below the cache. If
that address is unmapped you get an illegal memory access. If it is mapped, and
it usually is because vLLM allocates several large KV pools at descending
addresses, there is no error at all and attention output is silently wrong.

## What this changes

`FlexAttentionMetadataBuilder.build()` raises `ValueError` when `num_gpu_blocks`
is above what the int32 offsets can address, and says what the limit is and how
to get under it. Nothing else changes: no attention math, no KV cache layout.

The int32 arithmetic itself lives in PyTorch's generated kernel and is fixed
upstream by pytorch#185264, which is not in the pinned `torch==2.13.0`. vLLM
cannot widen the offsets from its side on that version: making `kv_indices`
int64 fails to compile, because `kv_offset = 0` in `forward_inner` is a hardcoded
int32 and becomes int64 in the loop
(`AssertionError('Loop-carried variable kv_offset has initial type int32 but is
re-assigned to int64 in loop!')`). De-interleaving K and V only doubles the
bound. So the honest options were "fail loudly" or "keep corrupting output", and
this picks the first. The guard can be dropped once the pinned torch carries
pytorch#185264.

## Verification

Hardware: NVIDIA A40 (sm_86), driver 560.35.03, CUDA 12.6, torch 2.13.0+cu126,
which is the pinned version and does not have pytorch#185264.

Reproduced the kernel bug first, on a standalone script that builds exactly the
views `FlexAttentionImpl.forward()` passes to `flex_attention`
(`num_kv_heads=8`, `head_size=128`, `block_size=16`, K filled with 0.125 and V
with 0.75, so correct output has mean 0.75). Predicted bound is 65536 blocks:

- block id 65535: `mean=0.750000`, correct.
- block id 65536: `CUDA error: an illegal memory access was encountered`.
- block id 65536 with 5 GiB of mapped memory placed below the K/V base:
  `mean=-8.000000`, no error, silently wrong.

Doubling `num_kv_heads` to 16 halves the bound to 32768 and moves the boundary
exactly there, confirming the multiplier is `stride_kn`. The guard uses that same
expression, so it allows the largest block count measured to be correct and
rejects the first one measured to be broken.

Tests run:

```
pytest tests/kernels/test_flex_attention.py -k "block_sizes or physical_to_logical
    or direct_vs_slow or sparsity_hint or int32"
9 passed, 4 deselected
```

The new test is
`test_rejects_kv_cache_too_large_for_int32_paged_offsets`. It builds metadata at
exactly the bound and one block over. Without the fix it reports
`Failed: DID NOT RAISE ValueError`; with it, it passes.

`ruff check` and `ruff format` are clean on both changed files.

No model evals. The change cannot alter output for any configuration that was
previously correct: below the bound nothing is touched, and above it the previous
behaviour was a crash or corrupted attention.

## Not verified

- No end to end vLLM run. There is no x86_64 precompiled wheel published for this
  commit, so `vllm._C` was not available in my environment. The FlexAttention
  tests were run against the source tree with a local pytest plugin stubbing
  `vllm._C_stable_libtorch`, `vllm.vllm_flash_attn`, and two
  `cutlass_scaled_mm_supports_*` probes. Nothing in the tested path uses them.
  I have therefore not watched the guard fire during a real engine startup.
- No capacity or throughput measurement. The reporter measured 4.1% of pool
  capacity lost and no throughput change for their 70,315 to 65,536 block case.
- The `_use_packed_kv_cache_config` / `_get_packed_kv_cache_layout` path uses a
  different `block_stride`. The issue flags it as unchecked and I did not check it
  either.
- Nothing on fp8 KV caches. This box is sm_86.

## Duplicate check

No open PR references #50427 or this bound. @kaining-never-stop commented on the
issue on 2026-07-30 offering to work on it with a similar plan and asked to be
assigned, but had not opened a PR. Happy to close this in favour of theirs.

Reported and diagnosed in detail by @ramber1836, including the derivation of the
bound and the two failure modes.

AI assistance was used to produce this change.