### PR TITLE
[Bugfix][ROCm] Launch KV block zeroing on a 3-D grid

### DIFF
--- a/tests/v1/worker/test_kv_block_zeroer.py
+++ b/tests/v1/worker/test_kv_block_zeroer.py
@@ -89,11 +89,44 @@ def test_non_uniform_page_sizes():
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_many_blocks_exceed_flat_grid_limit():
+    """Zero enough blocks that a flat 1-D grid would be an illegal launch.
+
+    AMD rejects a launch whose work groups times threads per block overflow
+    uint32, i.e. more than ``(2**32 - 1) // 256 == 16777215`` work groups for
+    the default 4 warps of 64 lanes (WG size = 4 * 64 = 256).
+    """
+    device = torch.device("cuda")
+    page_size_el = 1_048_577
+    num_blocks = 18
+    # len(block_ids) * page_size_el > (2**32 - 1) // 256
+    block_ids = list(range(1, num_blocks))
+
+    storage = torch.ones((num_blocks, page_size_el), dtype=torch.int32, device=device)
+
+    zeroer = KVBlockZeroer.__new__(KVBlockZeroer)
+    zeroer.device = device
+    zeroer._meta = (
+        torch.tensor([storage.data_ptr()], dtype=torch.uint64, device=device),
+        torch.tensor([page_size_el], dtype=torch.int64, device=device),
+        page_size_el,  # max_chunks
+        1,  # blk_size
+        1,  # n_segs
+    )
+
+    zeroer.zero_block_ids(block_ids)
+    torch.accelerator.synchronize()
+
+    assert torch.all(storage[0] == 1)
+    assert torch.all(storage[1:] == 0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_warmup_compiles_every_n_blocks_specialization():
     """After warmup, no launch should trigger a first-request JIT compile.
 
-    ``n_blocks`` is ``do_not_specialize``, so a single warmup launch must
-    cover every block count.
+    The block count is carried by the grid rather than by an argument, so a
+    single warmup launch must cover every block count.
     """
     device = torch.device("cuda")
     num_blocks = 64

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -40,14 +40,11 @@ from vllm.v1.kv_cache_interface import (
 logger = init_logger(__name__)
 
 
-@triton.jit(do_not_specialize=["n_blocks"])
+@triton.jit
 def _zero_kv_blocks_kernel(
     seg_addrs_ptr,
     seg_page_sizes_ptr,
     block_ids_ptr,
-    n_blocks,
-    N_SEGS: tl.constexpr,
-    MAX_CHUNKS: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
     """Zero KV cache blocks across all segments in a single launch.
@@ -65,16 +62,14 @@ def _zero_kv_blocks_kernel(
     seg_addrs_ptr holds absolute byte addresses (int64) for each segment,
     allowing segments to live in different CUDA allocations.
 
-    Programs are mapped as (block_index, seg_index, chunk_index).
+    The grid is (chunk_index, seg_index, block_index).  A flat 1-D grid
+    would multiply the three out into a single dimension, which AMD caps at
+    ``(2**32 - 1) // threads_per_block`` work groups; a 3-D grid keeps each
+    extent small because only the x dimension is scaled by the block size.
     """
-    pid = tl.program_id(0)
-    work_per_block = N_SEGS * MAX_CHUNKS
-    block_index = pid // work_per_block
-    if block_index >= n_blocks:
-        return
-    remainder = pid % work_per_block
-    seg_index = remainder // MAX_CHUNKS
-    chunk_index = remainder % MAX_CHUNKS
+    chunk_index = tl.program_id(0)
+    seg_index = tl.program_id(1)
+    block_index = tl.program_id(2)
     page_size_el = tl.load(seg_page_sizes_ptr + seg_index)
     if chunk_index >= page_size_el // BLOCK_SIZE:
         return
@@ -193,16 +188,12 @@ class KVBlockZeroer:
         if not block_ids or self._meta is None:
             return
         seg_addrs, seg_page_sizes, max_chunks, blk_size, n_segs = self._meta
-        n_blocks = len(block_ids)
         idx = async_tensor_h2d(block_ids, device=self.device, dtype=torch.int64)
-        grid = (n_blocks * n_segs * max_chunks,)
+        grid = (max_chunks, n_segs, len(block_ids))
         _zero_kv_blocks_kernel[grid](
             seg_addrs,
             seg_page_sizes,
             idx,
-            n_blocks,
-            N_SEGS=n_segs,
-            MAX_CHUNKS=max_chunks,
             BLOCK_SIZE=blk_size,
         )
 


### PR DESCRIPTION
# [Bugfix][ROCm] Launch the KV block zeroing kernel on a 3-D grid

## Purpose
`_zero_kv_blocks_kernel` flattens `(block, segment, chunk)` into a single grid dimension. On AMD that dimension is capped (limit is `(2^32 - 1) / WG size`), so on models with many segments and large pages the launch is rejected, and every worker dies on the first request.

It leads to the following error when running DSV4 on MI355, TP8:
```
gpu_model_runner.py:1222  _zero_block_ids(scheduler_output.new_block_ids_to_zero)
worker/utils.py:199       _zero_kv_blocks_kernel[grid](...)
RuntimeError: Triton Error [HIP]:  Code: 1, Messsage: invalid argument
```
HIP code 1 is `hipErrorInvalidValue`.

This PR changes the flattened 1d grid to explicit 3d grid to resolve this problem.

## Test Plan

`test_many_blocks_exceed_flat_grid_limit` in `tests/v1/worker/test_kv_block_zeroer.py`.

This test designed to create a grid that leads to a failure in old version but passes with 3d grid.

## Test Result

Added tests pass and server starts and processes requests successfully and after the fix.
