### PR TITLE
[Misc] Warn when --block-size is silently discarded by backend alignment

### DIFF
--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -357,6 +357,7 @@ steps:
   - tests/parser
   - tests/transformers_utils
   - tests/config
+  - tests/platforms
   device: cpu-small
   commands:
   - python3 standalone_tests/lazy_imports.py
@@ -374,6 +375,7 @@ steps:
   - pytest -v -s parser
   - pytest -v -s transformers_utils
   - pytest -v -s config
+  - pytest -v -s platforms
 
 - label: Batch Invariance (A100)
   key: batch-invariance-a100

--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -351,6 +351,7 @@ steps:
   - tests/parser
   - tests/transformers_utils
   - tests/config
+  - tests/platforms
   device: cpu-small
   commands:
   - python3 standalone_tests/lazy_imports.py
@@ -368,6 +369,7 @@ steps:
   - pytest -v -s parser
   - pytest -v -s transformers_utils
   - pytest -v -s config
+  - pytest -v -s platforms
 
 - label: Batch Invariance (A100)
   key: batch-invariance-a100

--- a/tests/platforms/test_interface.py
+++ b/tests/platforms/test_interface.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for Platform._align_hybrid_block_size's --block-size warning."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from vllm.config.cache import CacheConfig
+from vllm.platforms.interface import Platform
+from vllm.v1.attention.backend import MultipleOf
+
+
+def _make_backend_cls(
+    supported_sizes: list[int | MultipleOf],
+    preferred_block_size: int | None = None,
+) -> MagicMock:
+    """A backend double. `preferred_block_size` defaults to the backend's own
+    minimum, i.e. a backend with no preference beyond what it supports."""
+    backend_cls = MagicMock()
+    backend_cls.get_name.return_value = "MockAttentionBackend"
+    backend_cls.get_supported_kernel_block_sizes.return_value = supported_sizes
+    if preferred_block_size is None:
+        preferred_block_size = min(
+            s.base if isinstance(s, MultipleOf) else s for s in supported_sizes
+        )
+    backend_cls.get_preferred_block_size.return_value = preferred_block_size
+    return backend_cls
+
+
+def _make_vllm_config(block_size: int | None, use_mla: bool) -> MagicMock:
+    cache_config = CacheConfig(block_size=block_size, mamba_cache_mode="none")
+    model_config = MagicMock()
+    model_config.use_mla = use_mla
+    model_config.is_hybrid = True
+    model_config.dtype = torch.float16
+    model_config.architecture = "FakeHybridForCausalLM"
+    model_config.get_num_kv_heads.return_value = 1
+    model_config.get_head_size.return_value = 64
+    model_config.get_mamba_chunk_size.return_value = 256
+
+    vllm_config = MagicMock()
+    vllm_config.cache_config = cache_config
+    vllm_config.model_config = model_config
+    return vllm_config
+
+
+def _resolve_fake_hybrid_model_cls():
+    model_cls = MagicMock()
+    model_cls.get_mamba_state_shape_from_config.return_value = ((1, 8, 16),)
+    model_cls.get_mamba_state_dtype_from_config.return_value = (torch.float16,)
+    return patch(
+        "vllm.model_executor.models.ModelRegistry.resolve_model_cls",
+        return_value=(model_cls, "FakeHybridForCausalLM"),
+    )
+
+
+def _run_align_hybrid_block_size(
+    block_size: int | None,
+    use_mla: bool,
+    supported_sizes: list[int | MultipleOf],
+    preferred_block_size: int | None = None,
+) -> MagicMock:
+    vllm_config = _make_vllm_config(block_size, use_mla)
+    backend_cls = _make_backend_cls(supported_sizes, preferred_block_size)
+    with _resolve_fake_hybrid_model_cls():
+        Platform._align_hybrid_block_size(vllm_config, backend_cls)
+    return backend_cls
+
+
+@pytest.mark.parametrize(
+    "block_size,use_mla,supported_sizes,should_warn",
+    [
+        # Not explicitly set: never warn, whatever the backend/MLA floor is.
+        (None, True, [MultipleOf(64)], False),
+        (None, False, [MultipleOf(64)], False),
+        # Below the backend minimum: discarded, must warn.
+        (8, False, [MultipleOf(64)], True),
+        # At the backend minimum: still discarded (max() is a no-op), warn.
+        (64, False, [MultipleOf(64)], True),
+        # Above the backend minimum, non-MLA: takes effect, no warning.
+        (65, False, [MultipleOf(64)], False),
+        # Above the backend minimum but at/below the MLA 128 floor: this is
+        # the case a comparison against only the backend minimum would miss.
+        (100, True, [MultipleOf(64)], True),
+        (128, True, [MultipleOf(64)], True),
+        # Above the MLA floor: takes effect, no warning.
+        (256, True, [MultipleOf(64)], False),
+    ],
+)
+def test_block_size_warning_fires_only_when_value_is_discarded(
+    block_size, use_mla, supported_sizes, should_warn
+):
+    with patch("vllm.platforms.interface.logger") as mock_logger:
+        _run_align_hybrid_block_size(block_size, use_mla, supported_sizes)
+
+    assert mock_logger.warning_once.called == should_warn
+
+
+@pytest.mark.parametrize(
+    "block_size,should_warn",
+    [
+        # Below the floor but also below the backend's own preference: the
+        # backend would have picked 64 with the flag absent (Phase 1), so
+        # this explicit value still changes the outcome and must not warn.
+        # This is the FlashAttention-on-XPU case from the review: floor 16,
+        # preferred 64.
+        (8, False),
+        (16, False),
+        # Exactly the backend's preferred value: identical outcome to
+        # omitting the flag, so it does warn despite being "high".
+        (64, True),
+        # Above the backend's preference: changes the outcome, no warning.
+        (65, False),
+    ],
+)
+def test_block_size_warning_accounts_for_backend_preference_above_floor(
+    block_size, should_warn
+):
+    with patch("vllm.platforms.interface.logger") as mock_logger:
+        _run_align_hybrid_block_size(
+            block_size,
+            use_mla=False,
+            supported_sizes=[MultipleOf(16)],
+            preferred_block_size=64,
+        )
+
+    assert mock_logger.warning_once.called == should_warn
+
+
+def test_block_size_warning_message_reports_backend_name_and_alignment():
+    with patch("vllm.platforms.interface.logger") as mock_logger:
+        _run_align_hybrid_block_size(8, use_mla=False, supported_sizes=[MultipleOf(64)])
+
+    assert mock_logger.warning_once.called
+    args = mock_logger.warning_once.call_args.args
+    assert args[1] == 8
+    assert args[2] == "MockAttentionBackend"
+    assert args[3] == 64
+    assert args[4] == 64
+
+
+def test_update_block_size_for_backend_warns_only_through_phase_one():
+    """`_align_hybrid_block_size` is only Phase 2 of
+    `update_block_size_for_backend`; going through the public entry point
+    exercises Phase 1's `get_preferred_block_size` skip-on-explicit-flag
+    behavior, which is what makes the floor-only comparison unsound."""
+    backend_cls = _make_backend_cls([MultipleOf(16)], preferred_block_size=64)
+
+    def _make_config(block_size):
+        return _make_vllm_config(block_size, use_mla=False)
+
+    with (
+        patch.object(Platform, "_find_non_ssm_backend", return_value=backend_cls),
+        _resolve_fake_hybrid_model_cls(),
+    ):
+        # No flag: Phase 1 picks the backend's preferred 64.
+        no_flag_config = _make_config(None)
+        Platform.update_block_size_for_backend(no_flag_config)
+        assert no_flag_config.cache_config.block_size == 64
+
+        # Explicit value at/below the floor but below the backend's
+        # preference: Phase 1 is skipped, so this does change the outcome
+        # relative to the no-flag run above and must not warn.
+        with patch("vllm.platforms.interface.logger") as mock_logger:
+            low_config = _make_config(16)
+            Platform.update_block_size_for_backend(low_config)
+        assert low_config.cache_config.block_size == 16
+        assert not mock_logger.warning_once.called
+
+        # Explicit value equal to what Phase 1 would have chosen anyway:
+        # identical outcome to omitting the flag, so it does warn.
+        with patch("vllm.platforms.interface.logger") as mock_logger:
+            same_as_preferred_config = _make_config(64)
+            Platform.update_block_size_for_backend(same_as_preferred_config)
+        assert same_as_preferred_config.cache_config.block_size == 64
+        assert mock_logger.warning_once.called

--- a/tests/platforms/test_interface.py
+++ b/tests/platforms/test_interface.py
@@ -176,3 +176,44 @@ def test_update_block_size_for_backend_warns_only_through_phase_one():
             Platform.update_block_size_for_backend(same_as_preferred_config)
         assert same_as_preferred_config.cache_config.block_size == 64
         assert mock_logger.warning_once.called
+
+
+@pytest.mark.parametrize(
+    "block_size,should_warn",
+    [
+        # A platform that resolves 128 with the flag absent. Passing 16 lands
+        # at 16, so the flag does change the outcome and must not warn -- the
+        # backend's own preference of 16 is not what an omitted flag gives on
+        # such a platform. This is the CPU case from the review.
+        (16, False),
+        (64, False),
+        # Exactly what the platform resolves anyway: identical outcome.
+        (128, True),
+        (256, False),
+    ],
+)
+def test_block_size_warning_uses_the_platform_no_flag_value(block_size, should_warn):
+    class PlatformWithOwnDefault(Platform):
+        @classmethod
+        def block_size_without_user_flag(cls, backend_cls) -> int:
+            return 128
+
+    vllm_config = _make_vllm_config(block_size, use_mla=False)
+    backend_cls = _make_backend_cls([MultipleOf(16)])
+    with (
+        _resolve_fake_hybrid_model_cls(),
+        patch("vllm.platforms.interface.logger") as mock_logger,
+    ):
+        PlatformWithOwnDefault._align_hybrid_block_size(vllm_config, backend_cls)
+
+    assert mock_logger.warning_once.called == should_warn
+
+
+def test_cpu_platform_no_flag_block_size_matches_what_it_configures():
+    """CpuPlatform skips Phase 1, so its no-flag value has to come from
+    `check_and_update_config`, which sets an unspecified block size to 128."""
+    from vllm.platforms.cpu import CpuPlatform
+
+    backend_cls = _make_backend_cls([MultipleOf(16)], preferred_block_size=16)
+
+    assert CpuPlatform.block_size_without_user_flag(backend_cls) == 128

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -25,6 +25,7 @@ logger = init_logger(__name__)
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
+    from vllm.v1.attention.backend import AttentionBackend
     from vllm.v1.attention.selector import AttentionSelectorConfig
 else:
     VllmConfig = None
@@ -351,6 +352,13 @@ class CpuPlatform(Platform):
                 vllm_config.model_config.max_model_len,
                 vllm_config.scheduler_config.DEFAULT_MAX_NUM_BATCHED_TOKENS,
             )
+
+    @classmethod
+    def block_size_without_user_flag(cls, backend_cls: type["AttentionBackend"]) -> int:
+        # check_and_update_config sets this above, and the override below skips
+        # the backend-preference phase entirely, so the backend preference is
+        # not what an omitted --block-size resolves to here.
+        return 128
 
     @classmethod
     def update_block_size_for_backend(cls, vllm_config: "VllmConfig") -> None:

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -25,6 +25,7 @@ logger = init_logger(__name__)
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
+    from vllm.v1.attention.backend import AttentionBackend
     from vllm.v1.attention.selector import AttentionSelectorConfig
 else:
     VllmConfig = None
@@ -324,6 +325,13 @@ class CpuPlatform(Platform):
                 vllm_config.model_config.max_model_len,
                 vllm_config.scheduler_config.DEFAULT_MAX_NUM_BATCHED_TOKENS,
             )
+
+    @classmethod
+    def block_size_without_user_flag(cls, backend_cls: type["AttentionBackend"]) -> int:
+        # check_and_update_config sets this above, and the override below skips
+        # the backend-preference phase entirely, so the backend preference is
+        # not what an omitted --block-size resolves to here.
+        return 128
 
     @classmethod
     def update_block_size_for_backend(cls, vllm_config: "VllmConfig") -> None:

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -773,6 +773,7 @@ class Platform:
         """
         from math import lcm
 
+        from vllm.config.cache import CacheConfig
         from vllm.config.vllm import set_current_vllm_config
         from vllm.model_executor.models import ModelRegistry
         from vllm.utils.math_utils import cdiv
@@ -873,19 +874,48 @@ class Platform:
 
         # Get kernel block alignment from the backend's supported sizes
         with set_current_vllm_config(vllm_config):
-            kernel_block_alignment_size = max(
-                min(
-                    s.base if isinstance(s, MultipleOf) else s
-                    for s in backend_cls.get_supported_kernel_block_sizes()
-                ),
-                cache_config.block_size,
+            backend_min_block_size = min(
+                s.base if isinstance(s, MultipleOf) else s
+                for s in backend_cls.get_supported_kernel_block_sizes()
             )
+            # The floor forced by the backend and (for MLA) the kernel's
+            # 128-alignment requirement, independent of any user-supplied
+            # `--block-size`.
+            kernel_block_alignment_floor = backend_min_block_size
             if model_config.use_mla:
                 # TRTLLM/FlashInfer MLA decode kernels require the physical
                 # number of kernel blocks to be aligned to 128 / kernel_block_size.
                 # For hybrid MLA/Mamba models, make the manager block size a
                 # multiple of 128 so split kernel blocks keep that invariant.
-                kernel_block_alignment_size = max(kernel_block_alignment_size, 128)
+                kernel_block_alignment_floor = max(kernel_block_alignment_floor, 128)
+            kernel_block_alignment_size = max(
+                kernel_block_alignment_floor,
+                cache_config.block_size,
+            )
+            # What Phase 1 of `update_block_size_for_backend` would have
+            # chosen had `--block-size` not been set explicitly, so a value
+            # below the floor isn't assumed to be discarded when the backend
+            # would otherwise have preferred something above it.
+            no_flag_alignment_size = max(
+                kernel_block_alignment_floor,
+                backend_cls.get_preferred_block_size(CacheConfig.DEFAULT_BLOCK_SIZE),
+            )
+
+        # An explicit --block-size that resolves to the same kernel block
+        # alignment as omitting it entirely has no effect; say so once.
+        if (
+            cache_config.user_specified_block_size
+            and kernel_block_alignment_size == no_flag_alignment_size
+        ):
+            logger.warning_once(
+                "--block-size %d has no effect: kernel block alignment for "
+                "%s resolves to %d whether or not it is passed. Pass a "
+                "value above %d to change the kernel block alignment size.",
+                cache_config.block_size,
+                backend_cls.get_name(),
+                kernel_block_alignment_size,
+                kernel_block_alignment_size,
+            )
 
         if cache_config.mamba_cache_mode == "all":
             # With prefix caching, align to mamba chunk size for kernel perf

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -878,9 +878,7 @@ class Platform:
                 s.base if isinstance(s, MultipleOf) else s
                 for s in backend_cls.get_supported_kernel_block_sizes()
             )
-            # The floor forced by the backend and (for MLA) the kernel's
-            # 128-alignment requirement, independent of any user-supplied
-            # `--block-size`.
+            # Independent of any user-supplied --block-size.
             kernel_block_alignment_floor = backend_min_block_size
             if model_config.use_mla:
                 # TRTLLM/FlashInfer MLA decode kernels require the physical
@@ -892,17 +890,14 @@ class Platform:
                 kernel_block_alignment_floor,
                 cache_config.block_size,
             )
-            # What Phase 1 of `update_block_size_for_backend` would have
-            # chosen had `--block-size` not been set explicitly, so a value
-            # below the floor isn't assumed to be discarded when the backend
-            # would otherwise have preferred something above it.
+            # What the backend would have picked with no --block-size at all.
+            # Comparing against the floor alone would warn on a flag that does
+            # change the result, when the preferred size sits above the floor.
             no_flag_alignment_size = max(
                 kernel_block_alignment_floor,
                 backend_cls.get_preferred_block_size(CacheConfig.DEFAULT_BLOCK_SIZE),
             )
 
-        # An explicit --block-size that resolves to the same kernel block
-        # alignment as omitting it entirely has no effect; say so once.
         if (
             cache_config.user_specified_block_size
             and kernel_block_alignment_size == no_flag_alignment_size

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -762,6 +762,25 @@ class Platform:
             cache_config.mamba_page_size_padded = shared_page
 
     @classmethod
+    def block_size_without_user_flag(cls, backend_cls: type["AttentionBackend"]) -> int:
+        """Block size this platform resolves when `--block-size` is not passed.
+
+        Only used to decide whether an explicit `--block-size` changed
+        anything. Platforms that do not take `update_block_size_for_backend`'s
+        phase 1 must override this, or the comparison is against a value they
+        would never have produced.
+
+        Args:
+            backend_cls: The resolved non-SSM attention backend.
+
+        Returns:
+            The block size that would be resolved with no user flag.
+        """
+        from vllm.config.cache import CacheConfig
+
+        return backend_cls.get_preferred_block_size(CacheConfig.DEFAULT_BLOCK_SIZE)
+
+    @classmethod
     def _align_hybrid_block_size(
         cls,
         vllm_config: "VllmConfig",
@@ -773,7 +792,6 @@ class Platform:
         """
         from math import lcm
 
-        from vllm.config.cache import CacheConfig
         from vllm.config.vllm import set_current_vllm_config
         from vllm.model_executor.models import ModelRegistry
         from vllm.utils.math_utils import cdiv
@@ -890,12 +908,12 @@ class Platform:
                 kernel_block_alignment_floor,
                 cache_config.block_size,
             )
-            # What the backend would have picked with no --block-size at all.
-            # Comparing against the floor alone would warn on a flag that does
-            # change the result, when the preferred size sits above the floor.
+            # What this platform would have resolved with no --block-size at
+            # all. Comparing against the floor alone would warn on a flag that
+            # does change the result, when the no-flag size sits above it.
             no_flag_alignment_size = max(
                 kernel_block_alignment_floor,
-                backend_cls.get_preferred_block_size(CacheConfig.DEFAULT_BLOCK_SIZE),
+                cls.block_size_without_user_flag(backend_cls),
             )
 
         if (


### PR DESCRIPTION
## Purpose

`Platform._align_hybrid_block_size` computes the kernel block alignment as `max(backend_minimum, cache_config.block_size)`, further floored at 128 for MLA. When the backend minimum (or MLA floor) exceeds the requested value, an explicit `--block-size` is silently discarded — and the log line further down reports the *derived* value, never the input that produced it, so an accepted and a discarded `--block-size` look identical in the logs. On a hybrid model this derived value also fixes the prefix-cache match granularity (GCD over group block sizes), so two otherwise identical configurations differing only in whether `--block-size` cleared the floor can silently diverge in cache-hit behavior. One such pair took most of a day to diagnose: the two lanes' KV cache pools differed by ~20% (1,950,541 vs. 2,332,440 tokens) with nothing in either log explaining why.

This PR adds a one-time warning when that happens. It fires only when `--block-size` was explicitly passed, and only when the resulting alignment is identical to what `update_block_size_for_backend`'s Phase 1 would have picked with the flag absent (via `backend_cls.get_preferred_block_size`) — not simply whenever the value is at or below the backend minimum. That distinction matters: a backend whose preferred size exceeds its own minimum (e.g. FlashAttention on XPU, floor 16 / preferred 64) has its outcome changed by an explicit low `--block-size`, since it suppresses Phase 1's preferred-size selection, so that case must not be flagged as having no effect. This is a logging-only change; it does not alter any computed block size.

I checked for duplicate and overlapping open PRs (`gh pr list --search` on
"block size warning", "block_size alignment", "kernel_block_alignment" and
"preferred block size"). Two are adjacent and neither overlaps.

#48499 touches the same file for the neighbouring case: a user-specified
`--block-size` the active backend does not support at all, which it rejects
early instead of letting it fail after model load. This change is about a
value the backend *does* accept, which alignment then silently raises, so the
flag is honoured as far as validation is concerned and still has no effect —
#48499 would not fire on it, and this warning would not fire on #48499's case.
The two are complementary, and I am happy to fold this into #48499 if the
maintainers would rather have one change in that function.

#48402 also warns about a block size, but on a different condition in a
different file: prefix caching going inert when the block size exceeds
`max_model_len`.

I used AI assistance (Cursor) to draft, test, and validate this change, and I
reviewed every changed line before submitting.

## Test Plan

New unit tests in `tests/platforms/test_interface.py`, wired into CI via `.buildkite/test_areas/misc.yaml` (`pytest -v -s platforms`). They mock the attention backend and a hybrid model to exercise `_align_hybrid_block_size` directly, and separately drive the same scenarios through the public `update_block_size_for_backend` entry point so Phase 1's skip-on-explicit-flag behavior is exercised rather than bypassed.

Ran on a machine with the compiled CUDA extensions:

```
python3 -m pytest tests/platforms/test_interface.py -v
python3 -m pytest tests/v1/attention/test_mla_prefill_selector.py -q
```

## Test Result

```
tests/platforms/test_interface.py::test_block_size_warning_fires_only_when_value_is_discarded[None-True-supported_sizes0-False] PASSED
tests/platforms/test_interface.py::test_block_size_warning_fires_only_when_value_is_discarded[None-False-supported_sizes1-False] PASSED
tests/platforms/test_interface.py::test_block_size_warning_fires_only_when_value_is_discarded[8-False-supported_sizes2-True] PASSED
tests/platforms/test_interface.py::test_block_size_warning_fires_only_when_value_is_discarded[64-False-supported_sizes3-True] PASSED
tests/platforms/test_interface.py::test_block_size_warning_fires_only_when_value_is_discarded[65-False-supported_sizes4-False] PASSED
tests/platforms/test_interface.py::test_block_size_warning_fires_only_when_value_is_discarded[100-True-supported_sizes5-True] PASSED
tests/platforms/test_interface.py::test_block_size_warning_fires_only_when_value_is_discarded[128-True-supported_sizes6-True] PASSED
tests/platforms/test_interface.py::test_block_size_warning_fires_only_when_value_is_discarded[256-True-supported_sizes7-False] PASSED
tests/platforms/test_interface.py::test_block_size_warning_accounts_for_backend_preference_above_floor[8-False] PASSED
tests/platforms/test_interface.py::test_block_size_warning_accounts_for_backend_preference_above_floor[16-False] PASSED
tests/platforms/test_interface.py::test_block_size_warning_accounts_for_backend_preference_above_floor[64-True] PASSED
tests/platforms/test_interface.py::test_block_size_warning_accounts_for_backend_preference_above_floor[65-False] PASSED
tests/platforms/test_interface.py::test_block_size_warning_message_reports_backend_name_and_alignment PASSED
tests/platforms/test_interface.py::test_update_block_size_for_backend_warns_only_through_phase_one PASSED
14 passed in 42.75s

tests/v1/attention/test_mla_prefill_selector.py: all passed
```

