### PR TITLE
[CI] Un-gate and unify CUDA/ROCm custom-all-reduce + KDA tests broken by Kimi K3

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -1661,26 +1661,6 @@ steps:
   commands:
   - pytest -v -s lora --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --ignore=lora/test_chatglm3_tp.py --ignore=lora/test_llama_tp.py --ignore=lora/test_qwen3_with_multi_loras.py --ignore=lora/test_olmoe_tp.py --ignore=lora/test_deepseekv2_tp.py --ignore=lora/test_gptoss_tp.py --ignore=lora/test_qwen3moe_tp.py --ignore=lora/test_qwen35_densemodel_lora.py
 
-- label: LoRA TP (Distributed) # TBD
-  timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_4
-  num_gpus: 4
-  working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/lora
-  - tests/lora
-  - vllm/platforms/rocm.py
-  commands:
-  - pytest -v -s -x lora/test_chatglm3_tp.py
-  - pytest -v -s -x lora/test_llama_tp.py
-  - pytest -v -s -x lora/test_qwen3_with_multi_loras.py
-  - pytest -v -s -x lora/test_olmoe_tp.py
-  - pytest -v -s -x lora/test_gptoss_tp.py
-  - pytest -v -s -x lora/test_qwen35_densemodel_lora.py
-  - pytest -v -s -x lora/test_mixtral.py
-
 #------------------------------------------------------  mi300 · model_executor  -------------------------------------------------------#
 
 - label: Model Executor # TBD

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -807,22 +807,6 @@ steps:
   - VLLM_ALLOW_INSECURE_SERIALIZATION=1 pytest -v -s tests/distributed/test_weight_transfer.py
   - pytest -v -s tests/distributed/test_packed_tensor.py
 
-- label: Distributed Tests (4xA100-4xMI300) # TBD
-  timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
-  dind: false
-  agent_pool: mi300_4
-  num_gpus: 4
-  optional: true
-  working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  commands:
-  - pytest -v -s distributed/test_custom_all_reduce.py
-  - torchrun --nproc_per_node=2 distributed/test_ca_buffer_sharing.py
-  - TARGET_TEST_SUITE=MI300 pytest basic_correctness/ -v -s -m 'distributed(num_gpus=2)'
-  - pytest -v -s -x lora/test_mixtral.py
-
 - label: Distributed Torchrun + Examples (4 GPUs) # TBD
   timeout_in_minutes: 180
   mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
@@ -1571,7 +1555,6 @@ steps:
   mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
   dind: false
   agent_pool: mi300_1
-  optional: true
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:
   - vllm/third_party/flash_linear_attention/ops/kda.py
@@ -1696,6 +1679,7 @@ steps:
   - pytest -v -s -x lora/test_olmoe_tp.py
   - pytest -v -s -x lora/test_gptoss_tp.py
   - pytest -v -s -x lora/test_qwen35_densemodel_lora.py
+  - pytest -v -s -x lora/test_mixtral.py
 
 #------------------------------------------------------  mi300 · model_executor  -------------------------------------------------------#
 

--- a/.buildkite/test_areas/basic_correctness.yaml
+++ b/.buildkite/test_areas/basic_correctness.yaml
@@ -21,8 +21,6 @@ steps:
       dind: false
       device: mi300_1
       timeout_in_minutes: 60
-      depends_on:
-      - image-build-amd
 
 - label: Basic Correctness (Distributed)
   key: basic-correctness-distributed

--- a/.buildkite/test_areas/basic_correctness.yaml
+++ b/.buildkite/test_areas/basic_correctness.yaml
@@ -37,8 +37,6 @@ steps:
   - tests/basic_correctness/test_basic_correctness.py
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
-  # NOTE: don't test llama model here, it seems hf implementation is buggy
-  # see https://github.com/vllm-project/vllm/pull/5689 for details
   - TARGET_TEST_SUITE=A100 pytest -v -s basic_correctness/ -m 'distributed(num_gpus=2)'
   mirror:
     amd:

--- a/.buildkite/test_areas/basic_correctness.yaml
+++ b/.buildkite/test_areas/basic_correctness.yaml
@@ -23,3 +23,27 @@ steps:
       timeout_in_minutes: 60
       depends_on:
       - image-build-amd
+
+- label: Basic Correctness (Distributed)
+  key: basic-correctness-distributed
+  timeout_in_minutes: 30
+  device: a100
+  num_devices: 2
+  source_file_dependencies:
+  - vllm/config/parallel.py
+  - vllm/distributed/device_communicators/ray_communicator.py
+  - vllm/v1/executor/
+  - vllm/v1/engine/llm_engine.py
+  - tests/basic_correctness/test_basic_correctness.py
+  commands:
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  # NOTE: don't test llama model here, it seems hf implementation is buggy
+  # see https://github.com/vllm-project/vllm/pull/5689 for details
+  - TARGET_TEST_SUITE=A100 pytest -v -s basic_correctness/ -m 'distributed(num_gpus=2)'
+  mirror:
+    amd:
+      device: mi300_2
+      dind: false
+      commands:
+      - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+      - TARGET_TEST_SUITE=MI300 pytest -v -s basic_correctness/ -m 'distributed(num_gpus=2)'

--- a/.buildkite/test_areas/distributed.yaml
+++ b/.buildkite/test_areas/distributed.yaml
@@ -197,20 +197,30 @@ steps:
   # test with torchrun tp=2 and dp=4 with ep
   - torchrun --nproc-per-node=8 ../examples/features/torchrun/torchrun_dp_example_offline.py --tp-size=2 --pp-size=1 --dp-size=4 --enable-ep
 
-- label: Distributed Tests (4xA100)
-  key: distributed-tests-4xa100
+- label: Distributed Custom All-Reduce Tests
+  key: distributed-custom-all-reduce
   device: a100
-  optional: true
-  num_devices: 4
+  num_devices: 2
   source_file_dependencies:
-  - vllm/
+  - vllm/distributed/device_communicators/cuda_communicator.py
+  - vllm/distributed/device_communicators/custom_all_reduce.py
+  - vllm/distributed/device_communicators/aiter_custom_all_reduce.py
+  - vllm/distributed/device_communicators/quick_all_reduce.py
+  - vllm/distributed/device_communicators/all_reduce_utils.py
+  - vllm/distributed/device_communicators/cuda_wrapper.py
+  - vllm/distributed/parallel_state.py
+  - vllm/distributed/communication_op.py
+  - csrc/custom_all_reduce.cuh
+  - csrc/libtorch_stable/custom_all_reduce.cu
+  - tests/distributed/test_custom_all_reduce.py
+  - tests/distributed/test_ca_buffer_sharing.py
   commands:
-  # NOTE: don't test llama model here, it seems hf implementation is buggy
-  # see https://github.com/vllm-project/vllm/pull/5689 for details
   - pytest -v -s distributed/test_custom_all_reduce.py
   - torchrun --nproc_per_node=2 distributed/test_ca_buffer_sharing.py
-  - TARGET_TEST_SUITE=A100 pytest basic_correctness/ -v -s -m 'distributed(num_gpus=2)'
-  - pytest -v -s -x lora/test_mixtral.py
+  mirror:
+    amd:
+      device: mi300_2
+      dind: false
 
 - label: Distributed Tests (2xH100-2xMI300)
   key: distributed-tests-2xh100-2xmi300

--- a/.buildkite/test_areas/lora.yaml
+++ b/.buildkite/test_areas/lora.yaml
@@ -51,3 +51,11 @@ steps:
     - pytest -v -s -x lora/test_gptoss_tp.py
     - pytest -v -s -x lora/test_qwen35_densemodel_lora.py
     - pytest -v -s -x lora/test_mixtral.py
+  mirror:
+    amd:
+      dind: false
+      device: mi300_4
+      source_file_dependencies:
+      - vllm/platforms/rocm.py
+      depends_on:
+      - image-build-amd

--- a/.buildkite/test_areas/lora.yaml
+++ b/.buildkite/test_areas/lora.yaml
@@ -33,6 +33,8 @@ steps:
   source_file_dependencies:
   - vllm/lora
   - vllm/model_executor/layers/fused_moe/
+  - vllm/v1/executor/
+  - vllm/distributed/device_communicators/ray_communicator.py
   - tests/lora
   commands:
     # FIXIT: find out which code initialize cuda before running the test
@@ -48,3 +50,4 @@ steps:
     - pytest -v -s -x lora/test_olmoe_tp.py
     - pytest -v -s -x lora/test_gptoss_tp.py
     - pytest -v -s -x lora/test_qwen35_densemodel_lora.py
+    - pytest -v -s -x lora/test_mixtral.py

--- a/.buildkite/test_areas/lora.yaml
+++ b/.buildkite/test_areas/lora.yaml
@@ -57,5 +57,3 @@ steps:
       device: mi300_4
       source_file_dependencies:
       - vllm/platforms/rocm.py
-      depends_on:
-      - image-build-amd

--- a/tests/basic_correctness/test_basic_correctness.py
+++ b/tests/basic_correctness/test_basic_correctness.py
@@ -32,8 +32,13 @@ MODELS = [
 TARGET_TEST_SUITE_ENV = "VLLM_TARGET_TEST_SUITE"
 LEGACY_TARGET_TEST_SUITE_ENV = "TARGET_TEST_SUITE"
 
-GENERIC_DISTRIBUTED_TEST_SUITES = ("L4", "MI250", "MI300", "MI325", "MI355")
-ALL_DISTRIBUTED_TEST_SUITES = (*GENERIC_DISTRIBUTED_TEST_SUITES, "A100")
+# meta-llama/Llama-3.2-1B-Instruct is excluded from A100 pending
+# re-validation of https://github.com/vllm-project/vllm/pull/5689, which
+# reported HF/vLLM output divergence on A100 for a different model
+# (Llama-2-7b-hf) under 2024-era transformers. TODO: re-test on A100 under
+# current transformers and drop this exclusion if it no longer reproduces.
+NON_A100_DISTRIBUTED_TEST_SUITES = ("L4", "MI250", "MI300", "MI325", "MI355")
+ALL_DISTRIBUTED_TEST_SUITES = (*NON_A100_DISTRIBUTED_TEST_SUITES, "A100")
 
 
 def _default_target_test_suite() -> str:
@@ -197,14 +202,14 @@ def test_models(
             "meta-llama/Llama-3.2-1B-Instruct",
             "ray",
             "",
-            GENERIC_DISTRIBUTED_TEST_SUITES,
+            NON_A100_DISTRIBUTED_TEST_SUITES,
             {},
         ),
         (
             "meta-llama/Llama-3.2-1B-Instruct",
             "mp",
             "",
-            GENERIC_DISTRIBUTED_TEST_SUITES,
+            NON_A100_DISTRIBUTED_TEST_SUITES,
             {},
         ),
     ],

--- a/tests/models/kimi_k3/test_kda.py
+++ b/tests/models/kimi_k3/test_kda.py
@@ -6,6 +6,8 @@ Compares chunk_kda against a naive recurrent reference (float32).
 Uses torch.rand for q/k/v to match FLA's test pattern.
 """
 
+from unittest.mock import patch
+
 import pytest
 import torch
 import torch.nn.functional as F
@@ -27,6 +29,7 @@ from vllm.models.kimi_k3.nvidia.ops.third_party.kda import (
     fused_recurrent_kda_fwd,
     fused_recurrent_kda_packed_decode,
 )
+from vllm.platforms.interface import DeviceCapability
 from vllm.third_party.flash_linear_attention.ops.l2norm import l2norm_fwd
 
 DEVICE = "cuda"
@@ -682,6 +685,38 @@ def test_fused_kda_decode_rejects_speculative_conv_state():
         input_dtype=torch.bfloat16,
         conv_state_dtype=torch.bfloat16,
     )
+
+
+_KDA_PLATFORM = "vllm.models.kimi_k3.nvidia.kda.current_platform"
+
+
+@pytest.mark.parametrize(
+    ("is_cuda", "capability_major", "head_dim", "dtype", "lower_bound", "expected"),
+    [
+        # ROCm gfx942 reports major=9, the same value as CUDA SM90. FlashKDA
+        # is CUDA-only, so this must stay False regardless of major matching.
+        (False, 9, 128, torch.bfloat16, -3.0, False),
+        (False, 10, 128, torch.bfloat16, -3.0, False),
+        (True, 9, 128, torch.bfloat16, -3.0, True),
+        (True, 10, 128, torch.bfloat16, -3.0, True),
+        (True, 12, 128, torch.bfloat16, -3.0, True),
+        (True, 8, 128, torch.bfloat16, -3.0, False),
+        (True, 9, 64, torch.bfloat16, -3.0, False),
+        (True, 9, 128, torch.float16, -3.0, False),
+        (True, 9, 128, torch.bfloat16, None, False),
+    ],
+)
+def test_is_flashkda_supported_platform_gate(
+    is_cuda, capability_major, head_dim, dtype, lower_bound, expected
+):
+    with (
+        patch(f"{_KDA_PLATFORM}.is_cuda", return_value=is_cuda),
+        patch(
+            f"{_KDA_PLATFORM}.get_device_capability",
+            return_value=DeviceCapability(major=capability_major, minor=0),
+        ),
+    ):
+        assert is_flashkda_supported(head_dim, dtype, lower_bound) is expected
 
 
 @torch.inference_mode()


### PR DESCRIPTION
Looking for feedback here, especially from @AndreasKaratzas and @khluu. We want to eventually migrate all of `test-amd.yaml` to `test_areas`, right? If so, hoping I'm hitting a few birds with one stone here:

1) updating some AMD tests to be non-optional, so they would've blocked the Kimi PR
2) consolidating Lora and Distributed Tests into `test_areas` so that CUDA and ROCm share the same source_file_dependencies (no independent list drift)
3) adding missing KDA platform gate test that would've also blocked the Kimi PR
4) splitting out large test step into more focused test areas

Could you confirm if the pipeline will execute the steps from `test-amd` as well as `test_areas`, i.e. the removal of the test steps from `test-amd` wont cause the tests to be removed from the pipeline entirely?

## Purpose

Last week's Kimi K3 onboarding (#50000/#50089) broke ROCm CI twice. Both breaks were caught by tests correctly scoped via `source_file_dependencies` — but marked `optional: true`, so they only ran on the nightly mirror, a day after merge, instead of on the PR:

- #50262: `Kernels KDA Test` (stale test path + FlashKDA wrongly selected on gfx942, since its capability check collided major=9 with CUDA SM90).
- #50304: custom-all-reduce tests in `Distributed Tests (4xA100-4xMI300)` (premature AG/RS test additions).

## Changes

  - `Kernels KDA Test`: drop `optional: true` — deps already narrow (9 Kimi-K3/KDA files).
  - Custom-all-reduce tests: migrated to a new non-optional `Distributed Custom All-Reduce Tests` step in `test_areas/distributed.yaml`, mirrored to AMD instead of duplicated in
  `test-amd.yaml`.
  - New test `test_is_flashkda_supported_platform_gate` (`tests/models/kimi_k3/test_kda.py`) pins the ROCm/CUDA capability-major collision that caused #50262.
  - Split the old bundled `Distributed Tests (4xA100-4xMI300)` step into native `Basic Correctness (Distributed)` and `LoRA TP (Distributed)` steps in `test_areas/`.
  - `LoRA TP (Distributed)`: added an AMD mirror to the native step and removed the now-redundant hand-maintained duplicate from `test-amd.yaml`.
  - `LoRA %N`'s `test-amd.yaml` duplicate is separately stale (already has a working native mirror) but untouched here — out of scope.
  - Dropped the redundant explicit `depends_on: [image-build-amd]` from the `Basic Correctness` and `LoRA TP (Distributed)` AMD mirrors — `normalize_amd_depends_on` in ci-infra's generator inserts it automatically either way, confirmed by reading the generator source.

## Why not duplicate

Searched open PRs for test-amd.yaml gating / KDA / custom-all-reduce / test_areas mirror migration — nothing in flight. #50262 and #50304 fixed the content but not the gating. Checked `ci-infra` open PRs (#437, #445, #429, #435) — none touch or block this mechanism; `#437` adds a `key:` requirement on mirror steps that this step already satisfies.

## Test Plan / Result

CI-config: YAML validated, no label collisions, `num_devices: 2` confirmed correct for both the CUDA (`a100`, no fixed-pool constraint) and AMD (`mi300_2`, exact-match enforced by `resolve_amd_gpu_count`) sides. AG/RS exclusion and `cuda_communicator.py` inclusion confirmed by tracing the actual call graph, not filename guessing.

Validated the new `test_areas/distributed.yaml` step against a local clone of `vllm-project/ci-infra`'s actual pipeline generator (not just read — executed):
- Baseline generator test suite: `pytest buildkite/tests/pipeline_generator` — 59 passed.
- Custom script feeding the real Kimi K3 diff through `convert_group_step_to_buildkite_step`: both the CUDA step and the AMD mirror render as directly-runnable (no manual-unblock gate) — confirming this would have blocked the original PR.
- Same script with an unrelated diff: both correctly render behind a `block-*` step — confirming scoping still holds, no over-triggering.
- Caught and fixed one real bug in the process: the new generator enforces `device:` as a fixed-size AMD pool (`resolve_amd_gpu_count`), unlike the legacy `agent_pool: mi300_4` + `num_gpus: 2` override pattern — had to use `device: mi300_2` instead of `mi300_4`.

Same method applied to the new `LoRA TP (Distributed)` mirror in `test_areas/lora.yaml`:
- `tests/lora/test_mixtral.py` diff (only in the parent's deps) → AMD mirror renders un-gated, confirming the union with the parent's `source_file_dependencies` works.
- `vllm/platforms/rocm.py` diff (only in the mirror's own deps) → also renders un-gated.
- Unrelated diff → AMD mirror renders behind a `block-*` step, confirming no over-triggering.
- AMD step's `VLLM_TEST_COMMANDS` env exactly matches the parent step's `commands` — confirms the mirror reuses the shared command list rather than a hand-copy.
- Resolves to the correct 4-GPU pool: `agents.queue == "amd_mi300_4"`.

Can't run the actual AMD/CUDA Buildkite jobs locally — verified on this PR's own CI.

New test: ran locally, no GPU needed.
```
python -m pytest tests/models/kimi_k3/test_kda.py -k test_is_flashkda_supported_platform_gate -v
# 9 passed
```
Verified detection power: temporarily reverted `is_flashkda_supported()` to drop the `is_cuda()` check (reproducing the pre-#50262 bug) — exactly the 2 ROCm-parametrized cases failed, then restored the source. `ruff`, `ruff format`, `mypy` clean via `pre-commit run`.

---

*AI assistance disclosure: drafted with Claude Code (root-cause investigation, CI config analysis, call-graph tracing, cross-repo generator validation against `ci-infra`, and the new regression test). I reviewed the full change and verified the test's detection power myself before pushing.*
