### PR TITLE
[Bugfix][Frontend] Raise VLLMValidationError for user-facing errors in chat_utils.py

### DIFF
--- a/tests/entrypoints/unit_tests/test_chat_utils.py
+++ b/tests/entrypoints/unit_tests/test_chat_utils.py
@@ -2092,7 +2092,7 @@ def test_parse_chat_messages_multiple_images_interleave_with_placeholders(
     image_url,
 ):
     with pytest.raises(
-        ValueError,
+        VLLMValidationError,
         match=r"Found more '<|image_1|>' placeholders in input prompt "
         "than actual multimodal data items.",
     ):

--- a/tests/renderers/test_chat_utils_prompt_embeds.py
+++ b/tests/renderers/test_chat_utils_prompt_embeds.py
@@ -316,7 +316,7 @@ _PLACEHOLDER_ERROR_PATTERN: Final[str] = re.sub(
 def test_parse_chat_messages_rejects_placeholder_in_user_text(content):
     mc = _make_mock_model_config()  # enable_prompt_embeds=True by default
     messages = [{"role": "user", "content": content}]
-    with pytest.raises(ValueError, match=_PLACEHOLDER_ERROR_PATTERN):
+    with pytest.raises(VLLMValidationError, match=_PLACEHOLDER_ERROR_PATTERN):
         parse_chat_messages(messages, mc, content_format="openai")
 
 

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1333,11 +1333,10 @@ def validate_chat_template(chat_template: Path | str | None):
 
             builtin_template_path = CHAT_TEMPLATES_DIR / chat_template
             if not builtin_template_path.exists():
-                raise VLLMValidationError(
+                raise ValueError(
                     f"The supplied chat template string ({chat_template}) "
                     f"appears path-like, but doesn't exist! "
-                    f"Tried: {chat_template} and {builtin_template_path}",
-                    parameter="chat_template",
+                    f"Tried: {chat_template} and {builtin_template_path}"
                 )
 
     else:
@@ -1385,7 +1384,7 @@ def _load_chat_template(
                     f"Tried: {chat_template} and {builtin_template_path}. "
                     f"Reason: {e}"
                 )
-                raise VLLMValidationError(msg, parameter="chat_template") from e
+                raise ValueError(msg) from e
 
         # If opening a file fails, set chat template to be args to
         # ensure we decode so our escape are interpreted correctly

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -467,7 +467,7 @@ def _merge_embeds(
 
     first_keys = set(data_items[0].keys())
     if any(set(item.keys()) != first_keys for item in data_items[1:]):
-        raise ValueError(
+        raise VLLMValidationError(
             "All dictionaries in the list of embeddings must have the same keys."
         )
 
@@ -746,9 +746,15 @@ def _resolve_items(
         modality requires a processor, enforced by the guard below.
     """
     if "image" in items_by_modality and "image_embeds" in items_by_modality:
-        raise ValueError("Mixing raw image and embedding inputs is not allowed")
+        raise VLLMValidationError(
+            "Mixing raw image and embedding inputs is not allowed",
+            parameter="image_embeds",
+        )
     if "audio" in items_by_modality and "audio_embeds" in items_by_modality:
-        raise ValueError("Mixing raw audio and embedding inputs is not allowed")
+        raise VLLMValidationError(
+            "Mixing raw audio and embedding inputs is not allowed",
+            parameter="audio_embeds",
+        )
     # `prompt_embeds` bypasses HF MM processors. Every other modality requires one.
     processor_modalities = items_by_modality.keys() - {"prompt_embeds"}
     if processor_modalities and mm_processor is None:
@@ -1327,10 +1333,11 @@ def validate_chat_template(chat_template: Path | str | None):
 
             builtin_template_path = CHAT_TEMPLATES_DIR / chat_template
             if not builtin_template_path.exists():
-                raise ValueError(
+                raise VLLMValidationError(
                     f"The supplied chat template string ({chat_template}) "
                     f"appears path-like, but doesn't exist! "
-                    f"Tried: {chat_template} and {builtin_template_path}"
+                    f"Tried: {chat_template} and {builtin_template_path}",
+                    parameter="chat_template",
                 )
 
     else:
@@ -1378,7 +1385,7 @@ def _load_chat_template(
                     f"Tried: {chat_template} and {builtin_template_path}. "
                     f"Reason: {e}"
                 )
-                raise ValueError(msg) from e
+                raise VLLMValidationError(msg, parameter="chat_template") from e
 
         # If opening a file fails, set chat template to be args to
         # ensure we decode so our escape are interpreted correctly
@@ -1448,7 +1455,7 @@ def _get_full_multimodal_text_prompt(
                 interleave_strings,
             )
             logger.debug("Input prompt: %s", text_prompt)
-            raise ValueError(
+            raise VLLMValidationError(
                 f"Found more '{placeholder}' placeholders in input prompt than "
                 "actual multimodal data items."
             )
@@ -1696,7 +1703,7 @@ def _reject_reserved_placeholder_in_text(text: str, model_config: ModelConfig) -
     caller move or inject splice positions via plain text content.
     """
     if model_config.enable_prompt_embeds and PROMPT_EMBEDS_PLACEHOLDER_TOKEN in text:
-        raise ValueError(
+        raise VLLMValidationError(
             _RESERVED_PLACEHOLDER_IN_TEXT_ERROR.format(
                 token=PROMPT_EMBEDS_PLACEHOLDER_TOKEN
             )


### PR DESCRIPTION
## Purpose

Closes #50253.

After the `VLLMError` hierarchy migration in #49665, seven user-facing errors in `vllm/entrypoints/chat_utils.py` still raised a bare `ValueError`, so they bypassed `VLLMValidationError` and the structured request-error handling (the API `param` field came back `null`).

## Changes

Convert all seven to `VLLMValidationError`, adding `parameter=` where the failing request field is unambiguous:

- `validate_chat_template` / `_load_chat_template` → `parameter="chat_template"`
- `_resolve_items` raw-image/embeds and raw-audio/embeds mixing → `parameter="image_embeds"` / `parameter="audio_embeds"`
- `_merge_embeds` (embeds key mismatch), `_get_full_multimodal_text_prompt` (placeholder vs data-count mismatch), and `_reject_reserved_placeholder_in_text` are converted **without** a `parameter`, since there isn't a single obvious request field for them — happy to add names if you'd prefer.

Also updates the two unit tests that asserted `ValueError` on the affected paths (`test_chat_utils.py` placeholder-count test and `test_chat_utils_prompt_embeds.py` reserved-placeholder test) to expect `VLLMValidationError` (which is not a `ValueError` subclass).

## Test

`VLLMValidationError` was already imported in all three files. Verified `python -m py_compile` on the three changed files locally; I don't have a GPU, so I'm relying on CI for the full suite.

---

**Disclosure:** this change was prepared with AI assistance and reviewed by me before submitting.
