### PR TITLE
[Doc] Add MatrixHub as a model loading source

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -289,6 +289,21 @@ os.environ["http_proxy"] = "http://your.proxy.server:port"
 os.environ["https_proxy"] = "http://your.proxy.server:port"
 ```
 
+### MatrixHub
+
+[MatrixHub](https://github.com/matrixhub-ai/matrixhub) is a self-hosted model registry and distribution layer that caches models from upstream hubs and serves them over a Hugging Face-compatible API inside your own network.
+
+Since the API is Hugging Face-compatible, you only need to point `HF_ENDPOINT` at your MatrixHub instance:
+
+```shell
+export HF_ENDPOINT="http://<your-matrixhub-address>"
+vllm serve Qwen/Qwen3-0.6B
+```
+
+vLLM then downloads model weights from MatrixHub over the internal network instead of the public Hugging Face Hub, which is useful for air-gapped clusters and for avoiding repeated downloads across nodes.
+
+See the [MatrixHub guide for vLLM](https://matrixhub.ai/docs/guides/use-with-vllm/) for an end-to-end walkthrough, including Docker and Kubernetes deployment examples.
+
 ### ModelScope
 
 To use models from [ModelScope](https://www.modelscope.cn) instead of Hugging Face Hub, set an environment variable:


### PR DESCRIPTION
## Purpose

Document [MatrixHub](https://github.com/matrixhub-ai/matrixhub) as a model loading source in `docs/models/supported_models.md`, next to the existing Hugging Face Hub and ModelScope sections.

MatrixHub is a self-hosted, Apache 2.0 licensed model registry that caches models from upstream hubs and serves them over a Hugging Face-compatible API. Since the API is HF-compatible, vLLM works with it out of the box by setting `HF_ENDPOINT` — no code changes are needed. This is useful for air-gapped clusters and for avoiding repeated model downloads across nodes.

## Test Plan

Docs-only change. Ran `markdownlint-cli2` with the repo config (0 issues).

## Test Result

N/A