### PR TITLE
[KVConnector][NIXL] Support attention-HMA layouts in pipeline-parallel push prefill

### DIFF
--- a/docs/design/nixl_kv_push_connector.md
+++ b/docs/design/nixl_kv_push_connector.md
@@ -181,6 +181,46 @@ The completion notif sent from P to D after a WRITE is the existing
 is D's own request id, taken from the registration), so the D-side
 accounting code is unchanged.
 
+## Pipeline parallelism and hybrid KV caches
+
+The pull connector requires the local and remote workers to expose a
+congruent list of KV regions — region *i* here corresponds to region
+*i* there. That assumption breaks under pipeline parallelism (PP)
+combined with a hybrid (HMA) KV layout:
+
+* a PP-sharded prefiller (**P**) holds only a slice of the model's
+  layers while the `PP=1` decoder (**D**) holds them all, so region
+  counts differ;
+* with HMA, several layer names are pooled into one region and the layer
+  that represents a pooled region can differ between P and D.
+
+`NixlPushConnector` handles this for PP-sharded producers by routing
+**by layer-name (member) identity** instead of by region index. Each
+worker advertises which layer names back each of its NIXL regions in the
+handshake metadata (`NixlAgentMetadata.region_members`). When a push
+producer's local layout requires member routing, `add_remote_agent`
+expands the remote metadata into exactly the members this stage owns and
+emits the local and remote descriptors in one canonical (local) member
+order, so both sides stay paired regardless of how each remote rank
+happens to order its metadata.
+
+Invariants enforced during expansion:
+
+* every locally owned member must be advertised exactly once by the
+  remote; a missing member fails the handshake rather than silently
+  leaving that layer's KV stale, and remote-only members (owned by other
+  PP stages) are ignored;
+* a remote that omits member metadata while the local layout requires
+  member routing fails the handshake instead of falling back to
+  region-index routing;
+* the member-ordered local source descriptors are registered once per
+  remote engine and shared across that engine's remote TP ranks, so each
+  rank's member layout is fingerprinted and must match before the cached
+  handle is reused.
+
+Decode-side PP is unsupported because completions are counted per
+consumer rank. Mamba/SSM hybrids are unsupported under PP.
+
 ## Scheduler-side responsibilities
 
 `NixlPushConnectorScheduler` extends the base scheduler with:

--- a/docs/features/nixl_connector_compatibility.md
+++ b/docs/features/nixl_connector_compatibility.md
@@ -102,6 +102,23 @@ By default, a **compatibility hash** is checked during handshake. P and D instan
 - `NHD` layout is supported but does **not** allow heterogeneous TP head splitting.
 - Experimental `HND` ↔ `NHD` permute: enable via `--kv-transfer-config '{"enable_permute_local_kv": true}'`. Not supported with HMA.
 
+### Pipeline parallelism
+
+The default (pull) NixlConnector does **not** support
+`pipeline-parallel-size > 1` together with a hybrid KV cache (HMA)
+layout: region indices are not a stable identity across the
+prefill/decode layer split, so the connector raises at startup. Use the
+push connector (`NixlPushConnector`) for pipeline parallelism with
+hybrid KV caches — it routes transfers by layer-name (member) identity,
+so a PP-sharded prefiller can write into a `PP=1` decoder. See
+[NIXL push-mode KV transfer](../design/nixl_kv_push_connector.md).
+
+Current push PP + HMA limitations:
+
+- Only the prefiller (producer) may be PP-sharded; decode-side PP is not supported.
+- Hybrid SSM/Mamba layouts are not supported under PP.
+- HMA requires the same block size on P and D.
+
 ### Quantized KV cache
 
 [Quantized KV cache](quantization/quantized_kvcache.md) (e.g., FP8) requires both P and D instances to use the **same** `cache_dtype`. Mismatched cache dtypes will fail the compatibility hash check during handshake.

--- a/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
@@ -1641,6 +1641,7 @@ def test_push_write_hybrid_mla_replicates_attention():
     worker._sending_transfers_lock = threading.Lock()
     worker.kv_cache_config = _make_hybrid_mla_kv_cache_config()
     worker._xfer_blocks = MagicMock(return_value=1)
+    worker._member_xfer_state = {}
 
     meta = MagicMock()
     meta.remote.engine_id = engine_id

--- a/tests/v1/kv_connector/unit/test_nixl_member_transfer.py
+++ b/tests/v1/kv_connector/unit/test_nixl_member_transfer.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for pure NIXL member-transfer planning."""
+
+import msgspec
+import pytest
+
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.member_transfer import (
+    plan_member_transfer,
+    validate_region_members,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+    NixlAgentMetadata,
+)
+
+
+def _metadata(
+    region_members: list[list[str]],
+    base_addresses: list[int],
+    block_lens: list[int],
+) -> NixlAgentMetadata:
+    return NixlAgentMetadata(
+        engine_id="remote-engine",
+        agent_metadata=b"agent",
+        kv_caches_base_addr=base_addresses,
+        device_id=7,
+        num_blocks=2,
+        block_lens=block_lens,
+        kv_cache_layout="HND",
+        block_size=16,
+        ssm_sizes=(0, 0),
+        attn_backend_name="FLASH_ATTN",
+        physical_blocks_per_logical_kv_block=1,
+        region_members=region_members,
+    )
+
+
+def test_member_metadata_round_trip():
+    metadata = _metadata([["L0", "L1"]], [0x10000], [256])
+
+    encoded = msgspec.msgpack.encode(metadata)
+    assert msgspec.msgpack.Decoder(NixlAgentMetadata).decode(encoded) == metadata
+
+
+def test_plan_member_transfer_expands_pooled_regions():
+    metadata = _metadata(
+        [["a", "a.swa"], ["b"]],
+        [0xA000, 0xB000],
+        [128, 128],
+    )
+
+    prepared, plan = plan_member_transfer(
+        metadata,
+        [["a", "a.swa"], ["b"]],
+        {"a": 0, "a.swa": 1, "b": 0},
+    )
+
+    assert plan.member_names == ("a", "a.swa", "b")
+    assert plan.local_regions == (0, 0, 1)
+    assert plan.group_ids == (0, 1, 0)
+    assert prepared.kv_caches_base_addr == [0xA000, 0xA000, 0xB000]
+    assert prepared.block_lens == [128, 128, 128]
+    assert prepared.region_members == []
+
+
+def test_plan_member_transfer_filters_and_reorders_a_pp_stage():
+    metadata = _metadata(
+        [["l2"], ["l0"], ["l3"], ["l1"]],
+        [0xC000, 0xA000, 0xD000, 0xB000],
+        [65536, 65536, 32768, 32768],
+    )
+
+    prepared, plan = plan_member_transfer(
+        metadata,
+        [["l2"], ["l3"]],
+        {"l2": 0, "l3": 1},
+    )
+
+    assert plan.local_regions == (0, 1)
+    assert plan.group_ids == (0, 1)
+    assert prepared.kv_caches_base_addr == [0xC000, 0xD000]
+    assert prepared.block_lens == [65536, 32768]
+
+
+def test_plan_member_transfer_rejects_missing_local_member():
+    metadata = _metadata([["l0"]], [0xA000], [128])
+
+    with pytest.raises(RuntimeError, match="missing locally owned"):
+        plan_member_transfer(
+            metadata,
+            [["l0"], ["l1"]],
+            {"l0": 0, "l1": 1},
+        )
+
+
+def test_plan_member_transfer_rejects_duplicate_remote_member():
+    metadata = _metadata([["a"], ["a"]], [0xA000, 0xB000], [128, 128])
+
+    with pytest.raises(RuntimeError, match="multiple NIXL regions"):
+        plan_member_transfer(metadata, [["a"]], {"a": 0})
+
+
+def test_plan_member_transfer_is_canonical_across_remote_orderings():
+    rank0 = _metadata([["x"], ["y"]], [0x1000, 0x2000], [64, 128])
+    rank1 = _metadata([["y"], ["x"]], [0x2000, 0x1000], [128, 64])
+    local_members = [["x"], ["y"]]
+    layer_to_group = {"x": 0, "y": 1}
+
+    _, plan0 = plan_member_transfer(rank0, local_members, layer_to_group)
+    prepared1, plan1 = plan_member_transfer(rank1, local_members, layer_to_group)
+
+    assert plan0 == plan1
+    assert prepared1.kv_caches_base_addr == [0x1000, 0x2000]
+    assert prepared1.block_lens == [64, 128]
+
+
+def test_validate_region_members_rejects_duplicate_local_member():
+    with pytest.raises(RuntimeError, match="spans multiple NIXL regions"):
+        validate_region_members([["a"], ["a"]])

--- a/tests/v1/kv_connector/unit/test_nixl_push_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_push_connector.py
@@ -32,6 +32,13 @@ from unittest.mock import MagicMock, patch
 import msgspec
 import pytest
 
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker import (
+    NixlBaseConnectorWorker,
+    _MemberTransferState,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.member_transfer import (
+    MemberTransferPlan,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
     PUSH_REG_NOTIF_PREFIX,
     NixlAgentMetadata,
@@ -330,11 +337,14 @@ class _StubWriterWorker(NixlPushConnectorWorker):
         # Base worker fields touched by start_load_kv / _get_new_notifs.
         w._recving_metadata = {}
         w._recving_transfers = defaultdict(list)
+        w._is_hma_required = False
+        w._member_xfer_state = {}
         w._reqs_to_process = set()
         w._reqs_to_send = {}
         w.consumer_notification_counts_by_req = defaultdict(int)
         w.tp_rank = 0
         w.world_size = 1
+        w.pp_size = 1
         w.engine_id = "test-decode-engine"
         w._remote_agents = {}
         w._physical_blocks_per_logical_kv_block = 1
@@ -1102,3 +1112,146 @@ class TestPushWriterMlaReplication:
         # All of the request's WRITE handles must be tracked together, so the
         # engine thread never sees a partial set and double-frees the request.
         assert sorted(w._sending_transfers["p-req"]) == [1000, 1001]
+
+
+def _agent_metadata(
+    region_members: list[list[str]],
+    base_addresses: list[int],
+    block_lens: list[int],
+) -> NixlAgentMetadata:
+    return NixlAgentMetadata(
+        engine_id="remote-engine",
+        agent_metadata=b"agent",
+        kv_caches_base_addr=base_addresses,
+        device_id=7,
+        num_blocks=2,
+        block_lens=block_lens,
+        kv_cache_layout="HND",
+        block_size=16,
+        ssm_sizes=(0, 0),
+        attn_backend_name="FLASH_ATTN",
+        physical_blocks_per_logical_kv_block=1,
+        region_members=region_members,
+    )
+
+
+def _member_worker(
+    region_members: list[list[str]],
+    group_by_member: dict[str, int],
+) -> _StubWriterWorker:
+    worker = _StubWriterWorker.fresh()
+    worker.pp_size = 2
+    worker._has_mamba = False
+    worker._is_hma_required = True
+    worker._layer_name_to_kv_group_index = group_by_member
+    worker.transfer_topo = MagicMock()
+    worker._set_region_members(region_members)
+    return worker
+
+
+def test_member_plan_routes_descriptor_blocks():
+    worker = _StubWriterWorker.fresh()
+    worker._has_mamba = False
+    worker.num_regions = 3
+    desc_ids = worker._compute_desc_ids(
+        block_ids=[[1, 2], [5]],
+        dst_num_blocks=10,
+        block_size_ratio=None,
+        physical_blocks_per_logical=1,
+        region_group_ids=(0, 1, 0),
+    )
+    assert desc_ids.tolist() == [1, 2, 15, 21, 22]
+
+
+def test_member_identity_gate_preserves_the_non_hma_path():
+    metadata = _agent_metadata([["a"]], [0xA000], [128])
+    worker = _member_worker([["a"]], {"a": 0})
+
+    assert worker._use_member_identity(metadata)
+    # A bare base worker (pull) never requires member routing.
+    assert not object.__new__(NixlBaseConnectorWorker)._use_member_identity(metadata)
+
+    # Local layout requires routing but the remote omitted member metadata:
+    # fail loud instead of silently falling back to region-index routing.
+    metadata.region_members = []
+    with pytest.raises(RuntimeError, match="requires member-identity routing"):
+        worker._use_member_identity(metadata)
+
+    # A non-HMA local layout does not require member routing.
+    worker._is_hma_required = False
+    metadata.region_members = [["a"]]
+    assert not worker._use_member_identity(metadata)
+
+    # PP=1 has congruent local/remote regions and keeps the legacy route even
+    # when its allocator is hybrid.
+    worker._is_hma_required = True
+    worker.pp_size = 1
+    assert not worker._use_member_identity(metadata)
+
+
+def test_attention_member_routing_rejects_decode_tp_fanout():
+    metadata = _agent_metadata([["a"]], [0xA000], [128])
+    worker = _member_worker([["a"]], {"a": 0})
+    worker.use_mla = False
+    worker.transfer_topo.get_engine_info.return_value.remote_tp_size = 2
+    worker.transfer_topo.tp_ratio.return_value = -2
+
+    with pytest.raises(NotImplementedError, match="decode TP greater"):
+        worker._validate_remote_agent_handshake(metadata, 2, MagicMock())
+
+
+def test_remote_cleanup_releases_member_handle():
+    worker = _StubWriterWorker.fresh()
+    worker.nixl_wrapper = MagicMock()
+    worker._remote_agents = {"remote": {(0, 0): "agent"}}
+    worker.dst_xfer_side_handles = {"remote": {0: 11}}
+    worker._member_xfer_state = {
+        "remote": _MemberTransferState(
+            handle=22,
+            plan=MemberTransferPlan(
+                member_names=("a",),
+                local_regions=(0,),
+                group_ids=(0,),
+            ),
+        )
+    }
+    worker.kv_caches_base_addr = {"remote": {0: [0x1000]}}
+    worker.dst_num_blocks = {"remote": 2}
+    worker.tp_mappings = {"remote": MagicMock()}
+    worker.transfer_topo = MagicMock()
+    worker._engine_last_active = {}
+    worker._engine_clock_offset = {}
+
+    worker._cleanup_remote_engine("remote")
+
+    released = [
+        call.args[0] for call in worker.nixl_wrapper.release_dlist_handle.call_args_list
+    ]
+    assert released == [11, 22]
+    assert "remote" not in worker._member_xfer_state
+    worker.nixl_wrapper.remove_remote_agent.assert_called_once_with("agent")
+
+
+def test_member_state_rejects_divergent_remote_ranks():
+    worker = _StubWriterWorker.fresh()
+    worker.register_local_xfer_handler = MagicMock(return_value=(99, []))
+    plan_a = MemberTransferPlan(
+        member_names=("a", "b"),
+        local_regions=(0, 1),
+        group_ids=(0, 1),
+    )
+    plan_b = MemberTransferPlan(
+        member_names=("b", "a"),
+        local_regions=(1, 0),
+        group_ids=(1, 0),
+    )
+
+    worker._register_member_state("eng", plan_a, 16)
+    assert worker._member_xfer_state["eng"].handle == 99
+    # A matching later rank passes the consistency check and reuses the handle.
+    worker._check_member_plan_consistency("eng", plan_a)
+    worker._register_member_state("eng", plan_a, 16)
+    worker.register_local_xfer_handler.assert_called_once()
+    # A rank whose member order differs is rejected before any registration.
+    with pytest.raises(RuntimeError, match="inconsistent member layouts"):
+        worker._check_member_plan_consistency("eng", plan_b)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -12,6 +12,7 @@ import uuid
 from collections import defaultdict
 from collections.abc import Iterator
 from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, cast
 
@@ -32,6 +33,11 @@ from vllm.distributed.kv_transfer.kv_connector.utils import (
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.base import CopyBlocksOp
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.member_transfer import (
+    MemberTransferPlan,
+    plan_member_transfer,
+    validate_region_members,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
     GET_META_MSG,
     NixlAgentMetadata,
@@ -87,8 +93,20 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
+@dataclass
+class _MemberTransferState:
+    """Cached local source handle and the plan that defines its layout."""
+
+    handle: int
+    plan: MemberTransferPlan
+
+
 class NixlBaseConnectorWorker:
     """Base implementation of Worker side methods shared by pull and push."""
+
+    # Member-major routing is supported only by NixlPushConnector for HMA KV
+    # caches under PP.
+    _supports_member_identity = False
 
     def _compute_desc_ids(
         self,
@@ -96,6 +114,7 @@ class NixlBaseConnectorWorker:
         dst_num_blocks: int,
         block_size_ratio: float | None,
         physical_blocks_per_logical: int,
+        region_group_ids: tuple[int, ...] | None = None,
     ) -> np.ndarray:
         """Compute NIXL descriptor IDs for given block IDs."""
         num_ssm_regions = 0
@@ -109,6 +128,15 @@ class NixlBaseConnectorWorker:
         num_blocks = dst_num_blocks
         if block_size_ratio is not None:
             num_blocks = int(num_blocks * block_size_ratio)
+
+        if region_group_ids is not None:
+            # Member-major descriptors, using each member's KV-cache group.
+            out = [
+                np.asarray(block_ids[g], dtype=np.int64) + k * num_blocks
+                for k, g in enumerate(region_group_ids)
+            ]
+            return np.concatenate(out) if out else np.empty(0, dtype=np.int64)
+
         num_fa_descs = self.num_regions * num_blocks
 
         # All-attention fast path: single vectorized broadcast.
@@ -244,6 +272,94 @@ class NixlBaseConnectorWorker:
         block_len_per_layer without register_kv_caches).
         """
         return region_idx < len(self._region_is_mla) and self._region_is_mla[region_idx]
+
+    def _set_region_members(self, region_members: list[list[str]]) -> None:
+        validate_region_members(region_members)
+        self.region_members: list[list[str]] = region_members
+
+    def _requires_member_identity(self) -> bool:
+        """Whether this worker's local layout must be routed by layer name.
+
+        True for a PP-sharded push producer whose local KV layout is hybrid
+        (HMA): region indices are not a stable identity across the P/D layer
+        split, so transfers must be keyed by member name. Independent of the
+        remote peer.
+        """
+        return (
+            self._supports_member_identity
+            and self.pp_size > 1
+            and self._is_hma_required
+            and not self._has_mamba
+        )
+
+    def _use_member_identity(self, nixl_agent_meta: NixlAgentMetadata) -> bool:
+        """Whether to route this remote's regions by layer name.
+
+        Raises:
+            RuntimeError: if the local layout requires member routing but the
+                remote peer advertised no member metadata. The compatibility
+                hash normally rejects such a peer, but the e2e HMA config runs
+                with ``enforce_handshake_compat=false``; falling back to
+                region-index routing here would silently transfer stale KV.
+        """
+        if not self._requires_member_identity():
+            return False
+        if not nixl_agent_meta.region_members:
+            raise RuntimeError(
+                "Local hybrid KV layout requires member-identity routing, but "
+                "the remote peer advertised no member metadata (region_members "
+                "is empty). The peer is likely running an incompatible connector "
+                "or configuration; refusing to fall back to region-index routing."
+            )
+        return True
+
+    def _expand_remote_members(
+        self, nixl_agent_meta: NixlAgentMetadata
+    ) -> tuple[NixlAgentMetadata, MemberTransferPlan]:
+        return plan_member_transfer(
+            nixl_agent_meta,
+            self.region_members,
+            self._layer_name_to_kv_group_index,
+        )
+
+    def _check_member_plan_consistency(
+        self, engine_id: EngineId, member_plan: MemberTransferPlan
+    ) -> None:
+        """Reject a later remote TP rank whose member layout diverges.
+
+        Every remote TP rank of one engine shares the single cached local
+        source handle, so its plan must match or the cached local descriptor
+        order would be paired with a different remote order. Called before any
+        per-rank NIXL resources are created, so a divergent rank fails without
+        leaking state.
+        """
+        existing = self._member_xfer_state.get(engine_id)
+        if existing is not None and existing.plan != member_plan:
+            raise RuntimeError(
+                f"Remote TP ranks of engine {engine_id!r} advertised inconsistent "
+                "member layouts; refusing to reuse the cached local member-ordered "
+                "transfer handle."
+            )
+
+    def _register_member_state(
+        self,
+        engine_id: EngineId,
+        member_plan: MemberTransferPlan,
+        remote_block_size: int,
+    ) -> None:
+        """Register the engine's member-ordered local source handle once.
+
+        Idempotent per engine: the first remote TP rank registers the handle;
+        later ranks reuse it (consistency already checked by
+        ``_check_member_plan_consistency``).
+        """
+        if engine_id in self._member_xfer_state:
+            return
+        handle = self.register_local_xfer_handler(remote_block_size, member_plan)[0]
+        self._member_xfer_state[engine_id] = _MemberTransferState(
+            handle=handle,
+            plan=member_plan,
+        )
 
     def __init__(
         self,
@@ -435,11 +551,22 @@ class NixlBaseConnectorWorker:
         # transfers into the matching sub-range of a PP=1 remote's regions.
         self.pp_size = vllm_config.parallel_config.pipeline_parallel_size
         self._remote_region_offset = 0
-        # PP push slices regions per layer (uniform count); HMA breaks that.
-        if self.pp_size > 1 and self._is_hma_required:
+        if (
+            self.pp_size > 1
+            and self._is_hma_required
+            and not self._supports_member_identity
+        ):
+            raise NotImplementedError(
+                "NixlConnector (pull) does not support pipeline_parallel_size "
+                "> 1 with hybrid KV cache layouts (HMA); use NixlPushConnector "
+                "for PP + HMA."
+            )
+        # PP push routes HMA (hybrid) attention layouts by pooled-member
+        # identity; Mamba/SSM hybrids are not yet supported under PP.
+        if self.pp_size > 1 and self._has_mamba:
             raise NotImplementedError(
                 "NixlPushConnector does not support pipeline_parallel_size > 1 "
-                "with hybrid KV cache layouts (HMA) yet."
+                "with Mamba/SSM hybrid KV cache layouts yet."
             )
         # Decode-side PP is unsupported (completions counted per consumer rank).
         if vllm_config.kv_transfer_config.kv_role == "kv_consumer" and self.pp_size > 1:
@@ -460,6 +587,8 @@ class NixlBaseConnectorWorker:
         self.src_xfer_handles_by_tp_ratio: dict[tuple[int, int], list[int]] = {}
         # Map of engine_id -> {tp_rank: nixl_prepped_dlist_handle (int)}.
         self.dst_xfer_side_handles = defaultdict[EngineId, dict[int, int]](dict)
+        # engine -> member-ordered source handle and its immutable layout plan
+        self._member_xfer_state: dict[EngineId, _MemberTransferState] = {}
 
         # Map of engine_id -> num_blocks. All ranks in the same deployment will
         # have the same number of blocks.
@@ -548,6 +677,13 @@ class NixlBaseConnectorWorker:
         # This is not used for SSM layers, which use the counterpart `mamba_ssm_size`.
         self.block_len_per_layer = list[int]()
 
+        # Member metadata is populated for HMA layouts.
+        self.region_members = []
+        self._layer_name_to_kv_group_index = {
+            layer: group_idx
+            for group_idx, group in enumerate(self.kv_cache_config.kv_cache_groups)
+            for layer in group.layer_names
+        }
         # Per-engine TP mappings. Generated during handshake.
         self.tp_mappings: dict[EngineId, TPMapping] = {}
 
@@ -1095,6 +1231,13 @@ class NixlBaseConnectorWorker:
         # With hybrid allocator, layers can share a kv cache tensor
         seen_base_addresses: list[int] = []
 
+        track_region_members = (
+            self._supports_member_identity
+            and self._is_hma_required
+            and not self._has_mamba
+        )
+        region_members: list[list[str]] = []
+
         # K and V are packed into the content dim, so each attention layer is a
         # single NIXL region whose block transfers as one unit. Mamba layers instead
         # register separate conv/ssm sub-regions (see `_build_mamba_local`).
@@ -1152,11 +1295,15 @@ class NixlBaseConnectorWorker:
                 # layer registered it first.
                 idx = seen_base_addresses.index(base_addr)
                 self._region_is_mla[idx] |= is_mla_region
+                if track_region_members:
+                    region_members[idx].append(layer_name)
                 logger.debug("Skipping %s because it's already seen", layer_name)
                 continue
             logger.debug(
                 "Registering layer %s with cache shape: %s", layer_name, cache.shape
             )
+            if track_region_members:
+                region_members.append([layer_name])
             seen_base_addresses.append(base_addr)
             # Only record non-Mamba page sizes.
             if isinstance(layer_spec, MambaSpec):
@@ -1210,7 +1357,9 @@ class NixlBaseConnectorWorker:
         self.kv_caches_base_addr[self.engine_id][self.tp_rank] = seen_base_addresses
         self.num_regions = len(caches_data)
 
-        if self.pp_size > 1:
+        self._set_region_members(region_members)
+
+        if self.pp_size > 1 and not self._is_hma_required:
             start_layer, end_layer = self.model_config.get_layers_start_end_indices(
                 self.vllm_config.parallel_config
             )
@@ -1267,6 +1416,7 @@ class NixlBaseConnectorWorker:
             physical_blocks_per_logical_kv_block=(
                 self._physical_blocks_per_logical_kv_block
             ),
+            region_members=self.region_members,
         )
         # Wrap metadata in payload with hash for defensive decoding
         assert self.compat_hash is not None
@@ -1385,15 +1535,23 @@ class NixlBaseConnectorWorker:
         self,
         base_addresses: list[int],
         block_size_ratio: int,
+        member_plan: MemberTransferPlan | None = None,
     ) -> np.ndarray:
-        """Build local FA descriptors for all layers as an Nx3 uint64 array."""
+        """Build local FA descriptors as an Nx3 uint64 array, optionally in
+        member order."""
         assert self.transfer_topo is not None
         assert base_addresses, "Local KV cache base addresses must not be empty."
         num_blocks = self.num_blocks * block_size_ratio
         device_id = self.device_id
         block_arange = np.arange(num_blocks, dtype=np.uint64)
+        if member_plan is None:
+            region_iter = list(enumerate(base_addresses))
+        else:
+            region_iter = [
+                (region, base_addresses[region]) for region in member_plan.local_regions
+            ]
         parts: list[np.ndarray] = []
-        for i, base_addr in enumerate(base_addresses):
+        for i, base_addr in region_iter:
             # K/V are packed into the content dim, so the whole block transfers
             # as one unit: desc length equals the block stride.
             block_len = self.block_len_per_layer[i] // block_size_ratio
@@ -1406,8 +1564,10 @@ class NixlBaseConnectorWorker:
         plan: TPMapping,
         nixl_agent_meta: NixlAgentMetadata,
         block_size_ratio: int,
+        member_plan: MemberTransferPlan | None = None,
     ) -> np.ndarray:
-        """Build remote FA descriptors for all layers as an Nx3 uint64 array."""
+        """Build remote FA descriptors as an Nx3 uint64 array, optionally in
+        member order."""
         assert self.transfer_topo is not None
         assert nixl_agent_meta.kv_caches_base_addr, (
             "Remote KV cache base addresses must not be empty."
@@ -1423,9 +1583,10 @@ class NixlBaseConnectorWorker:
         block_arange = np.arange(num_blocks, dtype=np.uint64)
         parts: list[np.ndarray] = []
         for i, base_addr in enumerate(nixl_agent_meta.kv_caches_base_addr):
-            replicated = self._is_region_replicated(i)
+            local_region = member_plan.local_regions[i] if member_plan else i
+            replicated = self._is_region_replicated(local_region)
             # Read our whole local region size from remote..
-            local_block_len = self.block_len_per_layer[i]
+            local_block_len = self.block_len_per_layer[local_region]
             remote_kv_block_len = local_block_len // block_size_ratio
             if block_size_ratio > 1:
                 # ..using remote kv_block_len as transfer unit
@@ -1447,6 +1608,7 @@ class NixlBaseConnectorWorker:
     def register_local_xfer_handler(
         self,
         block_size: int,
+        member_plan: MemberTransferPlan | None = None,
     ) -> tuple[int, np.ndarray]:
         """
         Function used for register local xfer handler with local block_size or
@@ -1458,12 +1620,18 @@ class NixlBaseConnectorWorker:
         When remote block size is less than local block size, we need to use
         register another local_xfer_handler using remote block len to ensure
         data copy correctness.
+
+        ``member_plan`` registers one descriptor group per pooled member.
         """
         assert self.transfer_topo is not None
         block_size_ratio = self.block_size // block_size
         local_base_addresses = self.kv_caches_base_addr[self.engine_id][self.tp_rank]
 
-        blocks_data = self._build_fa_local(local_base_addresses, block_size_ratio)
+        blocks_data = self._build_fa_local(
+            local_base_addresses,
+            block_size_ratio,
+            member_plan,
+        )
         logger.debug(
             "Created %s blocks for src engine %s and rank %s on device id %s",
             len(blocks_data),
@@ -1547,22 +1715,31 @@ class NixlBaseConnectorWorker:
             )
             return self._remote_agents[engine_id][(0, remote_tp_rank)]
 
-        # Number of physical regions registered locally (one per layer/tensor).
-        num_local_regions = len(self.block_len_per_layer)
-        if (
-            self.pp_size > 1
-            and len(nixl_agent_meta.kv_caches_base_addr) > num_local_regions
-        ):
-            # This worker holds a PP layer-slice; the PP=1 remote registered
-            # the full model. Slice its regions to our layer window so the
-            # logic below sees congruent local/remote lists.
-            start = self._remote_region_offset
-            end = start + num_local_regions
-            assert len(nixl_agent_meta.kv_caches_base_addr) >= end
-            nixl_agent_meta.kv_caches_base_addr = nixl_agent_meta.kv_caches_base_addr[
-                start:end
-            ]
-            nixl_agent_meta.block_lens = nixl_agent_meta.block_lens[start:end]
+        member_plan: MemberTransferPlan | None = None
+        if self._use_member_identity(nixl_agent_meta):
+            nixl_agent_meta, member_plan = self._expand_remote_members(nixl_agent_meta)
+        else:
+            # Number of physical regions registered locally (one per layer/tensor).
+            num_local_regions = len(self.block_len_per_layer)
+            if (
+                self.pp_size > 1
+                and len(nixl_agent_meta.kv_caches_base_addr) > num_local_regions
+            ):
+                # This worker holds a PP layer-slice; the PP=1 remote registered
+                # the full model. Slice its regions to our layer window so the
+                # logic below sees congruent local/remote lists.
+                start = self._remote_region_offset
+                end = start + num_local_regions
+                assert len(nixl_agent_meta.kv_caches_base_addr) >= end
+                nixl_agent_meta.kv_caches_base_addr = (
+                    nixl_agent_meta.kv_caches_base_addr[start:end]
+                )
+                nixl_agent_meta.block_lens = nixl_agent_meta.block_lens[start:end]
+
+        # Reject a divergent later TP rank before creating any per-rank NIXL
+        # resources, so the failure can't leak an unpublished remote agent.
+        if member_plan is not None:
+            self._check_member_plan_consistency(engine_id, member_plan)
 
         ### Register remote engine in TransferTopology (idempotent).
         assert self.transfer_topo is not None
@@ -1605,7 +1782,9 @@ class NixlBaseConnectorWorker:
         self.kv_caches_base_addr[engine_id][remote_tp_rank] = (
             nixl_agent_meta.kv_caches_base_addr
         )
-        self._validate_remote_agent_handshake(nixl_agent_meta, remote_tp_size)
+        self._validate_remote_agent_handshake(
+            nixl_agent_meta, remote_tp_size, member_plan
+        )
 
         # This is 1 when P and D `--tensor-parallel-size` match. Otherwise,
         # this is the ratio between the two sizes.
@@ -1667,9 +1846,7 @@ class NixlBaseConnectorWorker:
 
         # Register all remote blocks, but only the corresponding kv heads.
         blocks_data = self._build_fa_remote(
-            plan,
-            nixl_agent_meta,
-            block_size_ratio,
+            plan, nixl_agent_meta, block_size_ratio, member_plan
         )
         logger.debug(
             "Created %s blocks for dst engine %s with remote rank %s and local rank %s",
@@ -1693,15 +1870,20 @@ class NixlBaseConnectorWorker:
             self.nixl_wrapper.prep_xfer_dlist(remote_agent_name, descs)
         )
 
+        if member_plan is not None:
+            self._register_member_state(
+                engine_id, member_plan, nixl_agent_meta.block_size
+            )
+
         return remote_agent_name
 
     def _validate_remote_agent_handshake(
-        self, nixl_agent_meta: NixlAgentMetadata, remote_tp_size: int
+        self,
+        nixl_agent_meta: NixlAgentMetadata,
+        remote_tp_size: int,
+        member_plan: MemberTransferPlan | None = None,
     ):
-        """
-        Validate the remote agent handshake metadata ensuring the
-        invariants hold true.
-        """
+        """Validate the remote agent handshake metadata."""
         remote_engine_id = nixl_agent_meta.engine_id
 
         assert self.transfer_topo is not None
@@ -1712,6 +1894,11 @@ class NixlBaseConnectorWorker:
         block_size_ratio = self.transfer_topo.block_size_ratio(
             nixl_agent_meta.block_size
         )
+        if member_plan is not None and tp_ratio < 0 and not self.use_mla:
+            raise NotImplementedError(
+                "Attention-HMA push does not support decode TP greater than "
+                "prefill TP yet"
+            )
         # num_kv_heads > tp_size with P_TP > D_TP not supported for non-mamba.
         # Mamba models can have replicated FA KV with tp_ratio < 0.
         # MLA models do not need to handle kv replication.
@@ -1822,8 +2009,15 @@ class NixlBaseConnectorWorker:
                 f"remote={nixl_agent_meta.block_lens}."
             )
         elif not self._has_mamba:
-            assert len(self.block_len_per_layer) == len(nixl_agent_meta.block_lens), (
-                "Number of KV layers must match between prefill and decode"
+            if member_plan is not None:
+                local_lens = [
+                    self.block_len_per_layer[region]
+                    for region in member_plan.local_regions
+                ]
+            else:
+                local_lens = self.block_len_per_layer
+            assert len(local_lens) == len(nixl_agent_meta.block_lens), (
+                "Number of KV layers/members must match between prefill and decode"
             )
             model_replicated = self.use_mla or self.transfer_topo.is_kv_replicated(
                 remote_engine_id
@@ -1831,8 +2025,9 @@ class NixlBaseConnectorWorker:
             total_kv_heads = self.transfer_topo.total_num_kv_heads
             local_heads = self.transfer_topo.local_physical_heads
             remote_heads = max(1, total_kv_heads // remote_tp_size)
-            for i, local_len in enumerate(self.block_len_per_layer):
-                replicated = model_replicated or self._is_region_replicated(i)
+            for i, local_len in enumerate(local_lens):
+                region_idx = member_plan.local_regions[i] if member_plan else i
+                replicated = model_replicated or self._is_region_replicated(region_idx)
                 remote_len = nixl_agent_meta.block_lens[i]
                 if replicated:
                     assert local_len // block_size_ratio == remote_len, (
@@ -1863,8 +2058,12 @@ class NixlBaseConnectorWorker:
 
         # TP workers that handhshake with same remote have same #blocks.
         assert self.dst_num_blocks[remote_engine_id] == nixl_agent_meta.num_blocks
-        # Same number of regions/~layers.
-        assert len(nixl_agent_meta.kv_caches_base_addr) == len(self.block_len_per_layer)
+        expected_regions = (
+            len(member_plan.local_regions)
+            if member_plan is not None
+            else len(self.block_len_per_layer)
+        )
+        assert len(nixl_agent_meta.kv_caches_base_addr) == expected_regions
 
     def sync_recved_kv_to_device(self, req_id: str, meta: ReqMeta):
         """copy recved kv from host buffer to device."""
@@ -2549,6 +2748,9 @@ class NixlBaseConnectorWorker:
         # Notif-only engines (push-mode D side) have no descriptor state.
         for handle in self.dst_xfer_side_handles.pop(engine_id, {}).values():
             self.nixl_wrapper.release_dlist_handle(handle)
+        member_state = self._member_xfer_state.pop(engine_id, None)
+        if member_state is not None:
+            self.nixl_wrapper.release_dlist_handle(member_state.handle)
         for agent_name in self._remote_agents.pop(engine_id).values():
             self.nixl_wrapper.remove_remote_agent(agent_name)
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/member_transfer.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/member_transfer.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Pure layout planning for member-ordered NIXL transfers."""
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, replace
+
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+    NixlAgentMetadata,
+)
+
+
+@dataclass(frozen=True)
+class MemberTransferPlan:
+    """Local descriptor layout for a member-ordered transfer."""
+
+    member_names: tuple[str, ...]
+    local_regions: tuple[int, ...]
+    group_ids: tuple[int, ...]
+
+
+def validate_region_members(region_members: Sequence[Sequence[str]]) -> None:
+    """Ensure every layer name belongs to exactly one region."""
+    members = [member for region in region_members for member in region]
+    if len(members) != len(set(members)):
+        raise RuntimeError("A KV cache layer spans multiple NIXL regions")
+
+
+def plan_member_transfer(
+    remote_metadata: NixlAgentMetadata,
+    local_region_members: Sequence[Sequence[str]],
+    layer_to_group: Mapping[str, int],
+) -> tuple[NixlAgentMetadata, MemberTransferPlan]:
+    """Build canonical member metadata and a plan without mutating inputs."""
+    num_regions = len(remote_metadata.region_members)
+    if (
+        len(remote_metadata.kv_caches_base_addr) != num_regions
+        or len(remote_metadata.block_lens) != num_regions
+    ):
+        raise RuntimeError("NIXL region metadata has inconsistent lengths")
+
+    remote_region_of: dict[str, int] = {}
+    for region_idx, remote_members in enumerate(remote_metadata.region_members):
+        for layer_name in remote_members:
+            if layer_name in remote_region_of:
+                raise RuntimeError(
+                    f"Remote advertised KV cache layer {layer_name!r} in "
+                    "multiple NIXL regions"
+                )
+            remote_region_of[layer_name] = region_idx
+
+    member_names: list[str] = []
+    local_regions: list[int] = []
+    group_ids: list[int] = []
+    remote_base_addresses: list[int] = []
+    remote_block_lens: list[int] = []
+    for local_region, local_members in enumerate(local_region_members):
+        for layer_name in local_members:
+            remote_region = remote_region_of.get(layer_name)
+            if remote_region is None:
+                raise RuntimeError(
+                    "Remote NIXL metadata is missing locally owned KV cache "
+                    f"layer {layer_name!r}; the transfer would leave it stale"
+                )
+            group_id = layer_to_group.get(layer_name)
+            if group_id is None:
+                raise RuntimeError(
+                    f"KV cache layer {layer_name!r} is not in a local cache group"
+                )
+
+            remote_base = remote_metadata.kv_caches_base_addr[remote_region]
+            remote_len = remote_metadata.block_lens[remote_region]
+            member_names.append(layer_name)
+            local_regions.append(local_region)
+            group_ids.append(group_id)
+            remote_base_addresses.append(remote_base)
+            remote_block_lens.append(remote_len)
+
+    if not member_names:
+        raise RuntimeError("Remote NIXL metadata has no members owned by this worker")
+
+    prepared_metadata = replace(
+        remote_metadata,
+        kv_caches_base_addr=remote_base_addresses,
+        block_lens=remote_block_lens,
+        region_members=[],
+    )
+    return prepared_metadata, MemberTransferPlan(
+        member_names=tuple(member_names),
+        local_regions=tuple(local_regions),
+        group_ids=tuple(group_ids),
+    )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Metadata dataclasses and helpers for the NIXL connector."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from vllm.config import VllmConfig
@@ -42,8 +42,9 @@ PUSH_REG_NOTIF_PREFIX = b"PUSH_REG:"
 #   5: Add remote_blocks_expiry_time to kv_transfer_params + handshake
 #      clock-sync timestamp
 #   6: Validate EAGLE/MTP speculative configuration compatibility
+#   7: Add per-region member names for PP push.
 #
-NIXL_CONNECTOR_VERSION: int = 6
+NIXL_CONNECTOR_VERSION: int = 7
 
 
 @dataclass
@@ -59,6 +60,8 @@ class NixlAgentMetadata:
     ssm_sizes: tuple[int, int]
     attn_backend_name: str
     physical_blocks_per_logical_kv_block: int
+    # Layer names sharing each advertised region, in region order.
+    region_members: list[list[str]] = field(default_factory=list)
 
 
 @dataclass

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -77,6 +77,8 @@ _PUSH_WRITER_POLL_INTERVAL_MS = 1.0
 class NixlPushConnectorWorker(NixlBaseConnectorWorker):
     """Push-specific (WRITE) worker logic. See module docstring."""
 
+    _supports_member_identity = True
+
     def __init__(
         self,
         vllm_config: "VllmConfig",
@@ -503,6 +505,10 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         plan = self.tp_mappings[engine_id]
         remote_info = self.transfer_topo.get_engine_info(engine_id)
         tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
+        member_state = self._member_xfer_state.get(engine_id)
+        member_groups = (
+            member_state.plan.group_ids if member_state is not None else None
+        )
 
         # Expand D's logical IDs using the ratio learned during the
         # NIXL handshake. ``meta`` is freshly built by
@@ -557,7 +563,9 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                 remote_block_size,
                 req_id,
             )
-            if tp_ratio < 0 and (not self.use_mla or len(plan.all_source_ranks) > 1):
+            if member_state is not None:
+                local_xfer_side_handle = member_state.handle
+            elif tp_ratio < 0 and (not self.use_mla or len(plan.all_source_ranks) > 1):
                 # Multiple targets: write each rank its chunk of local memory.
                 # Hybrid MLA+SSM also lands here: its split handles replicate
                 # the attention descriptors and chunk only the SSM state.
@@ -579,6 +587,7 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                 remote_request_id=meta.remote.request_id,
                 local_xfer_side_handle=local_xfer_side_handle,
                 remote_xfer_side_handle=remote_xfer_side_handle,
+                region_group_ids=member_groups,
             )
             if handle is not None:
                 handles.append(handle)
@@ -598,6 +607,7 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         remote_request_id: str,
         local_xfer_side_handle: int,
         remote_xfer_side_handle: int,
+        region_group_ids: tuple[int, ...] | None = None,
     ) -> int | None:
         """Post a WRITE point-to-point xfer request.
 
@@ -643,12 +653,14 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
             dst_num_blocks=self.dst_num_blocks[dst_engine_id],
             block_size_ratio=None,
             physical_blocks_per_logical=remote_info.remote_physical_blocks_per_logical,
+            region_group_ids=region_group_ids,
         )
         local_block_descs_ids = self._compute_desc_ids(
             block_ids=local_block_ids,
             dst_num_blocks=self.dst_num_blocks[self.engine_id],
             block_size_ratio=block_size_ratio,
             physical_blocks_per_logical=self._physical_blocks_per_logical_kv_block,
+            region_group_ids=region_group_ids,
         )
 
         assert len(local_block_descs_ids) == len(remote_block_descs_ids)


### PR DESCRIPTION
## Purpose

Enable attention HMA with pipeline-parallel prefill in `NixlPushConnector`,
following #45880. Producer PP stages and a PP1 decoder may pool the same layers
into different physical KV-cache regions. This PR matches layers by name and
builds descriptors using each side's region geometry.

This updates the existing push-mode PR. Pull-mode work in #43368/#48263 and
the earlier #47981 prototype use different implementations. Packed MLA is the
stacked follow-up #50499, which should land after this PR.

## Design and rebase

- `NixlAgentMetadata.region_members` advertises layer names; wire version **11 → 12**.
- Registration derives `_transfer_layer_names`, `_transfer_layer_region_indices`,
  and `_transfer_layer_group_ids` per worker. `_supports_pp_hma` expresses the
  connector capability; `_requires_layer_name_routing()` applies runtime gates.
- Remote layer alignment selects this PP stage's layers and reorders addresses,
  lengths, strides, capacities, group IDs, names, and memory types. Missing or
  duplicate layers and inconsistent metadata fail explicitly.
- Descriptors use cumulative per-region capacities; physical allocations are
  registered once. PP1 and non-HMA layouts retain region-index routing.
- Unequal block sizes and unsupported non-MLA TP expansion are rejected before
  topology/NIXL registration.

Rebased onto `main@df42d112ee88dd4a9b64efbad55621af6a66a44b` on September 15.
The rebase preserves upstream PCP/DCP transfer ranks, HiSparse geometry,
`KVConnectorTransferResults`, and the latest NIXL multi-handle failure handling.

The conflict was in receive-lifecycle tests. Main's fixtures and regressions
supersede the earlier PR versions, so that file now matches main. The PR's
production-code additions/removals are unchanged from the reviewed version.
The three PP startup restrictions remain grouped under one PP-size guard.

Main now completes producer sends on consumer acknowledgement or lease expiry.
The follow-up replaces the obsolete local-WRITE completion expectation with
PP1 and PP2/HMA cases in upstream's notification test, preserving partial-handle
polling and exactly-once lease/eviction checks. No extra production changes.

## Test plan

Run from the repository's `.venv` on one node with four GB200s:

```bash
CUDA_VISIBLE_DEVICES=3 VLLM_NIXL_SIDE_CHANNEL_PORT=5700 \
  .venv/bin/python -m pytest -q tests/v1/kv_connector/unit/test_nixl*.py
CUDA_VISIBLE_DEVICES=3 VLLM_NIXL_SIDE_CHANNEL_PORT=5700 \
  .venv/bin/python -m pytest -q \
  tests/v1/kv_connector/unit/test_kv_load_failure_recovery.py \
  tests/v1/kv_connector/unit/test_output_aggregator.py \
  tests/v1/kv_connector/unit/test_tp_mapping.py
.venv/bin/pre-commit run --files $(git diff --name-only origin/main...HEAD)
.venv/bin/pre-commit run mypy-3.12 --hook-stage manual \
  --files $(git diff --name-only origin/main...HEAD)
```

Fresh Gemma-4-26B-A4B-it E2E uses **PP2/TP1 → PP1/TP1**, HMA enabled, prefix
caching disabled, strict handshake compatibility, eager execution, explicit
`--attention-backend TRITON_ATTN` on both peers, bf16 KV, V2 runner, cumem
allocation, max length 8192, and `UCX_TLS=tcp,cuda_copy`.

GSM8K: 200 questions per route, 5-shot chat, concurrency 8, temperature 0,
2048 generation tokens. Direct producer baseline and toy-proxy disaggregation
use the same checkpoint `4d7ae4984b7db7de8f8457170b3f1a419ee76d52`.

```bash
lm_eval --model local-chat-completions --tasks gsm8k --num_fewshot 5 \
  --apply_chat_template --fewshot_as_multiturn --limit 200 --log_samples \
  --gen_kwargs max_gen_toks=2048 --output_path "$OUTPUT_DIR" \
  --model_args "model=$MODEL,base_url=http://127.0.0.1:$PORT/v1/chat/completions,num_concurrent=8,max_retries=3,tokenized_requests=False"
```

Use port 8100 for the baseline and 8000 for the proxy. Probes are recorded
separately; transfer/cache metrics and health are checked after 35 seconds idle.

## Test results

September 15 validation on `b74b0866cea9d3969a8f34a67caca0c68c9af028`:

- **562 applicable unit cases passed; 2 ROCm-only skips.** Validation combines
  the full NIXL/supporting-suite run with a rerun of the entire push-connector
  test file after the test-only update: **484 unaffected cases passed** in the
  full run, and **all 78 final push tests passed** (19.66 seconds). The initial
  run exposed the two obsolete WRITE-completion assertions described above.
- Changed-file pre-commit and manual mypy Python 3.12 passed, including the
  test follow-up. No production files changed after the full test run.
- E2E was not rerun for this rebase. The full model results below belong to
  the earlier tested commit, rather than the new head.

Validated September 14, 2026 on `5c12ce79ada8246f341be97414b3df60d147b818`:

- **502 NIXL tests passed, 2 ROCm-only skips**, 448.02 seconds, 17 warnings.
- **49 scheduler/failure-recovery/aggregation/TP-mapping tests passed**,
  23.94 seconds. Pre-commit and manual mypy Python 3.12 passed.
- All **400 GSM8K evaluation requests** completed. All 200 document, prompt,
  and target hashes match between routes.

| Route | Strict match | Flexible extraction |
| --- | ---: | ---: |
| Direct producer baseline | 95.0% | 95.0% |
| PP2 push-disaggregated | 96.0% | 95.5% |

Exact generated-text parity and code-caused accuracy improvements are not
claimed. The flexible regression on question 174 is extraction of 35 from the
correct 95-minute answer expressed as “1 hour and 35 minutes.”

- **402 completed WRITEs / 45,439,385,600 bytes**, including the probe.
- **Zero failed transfers, failed notifications, expired leases, or serving
  errors**, including the idle audit. All completion HTTP responses were 200.
- Decoder evaluation-only counters: **217,085 external hits / 217,085 queries**,
  **zero locally computed prefill tokens**. Its separate probe contributes one
  computed token.
- Strict metadata audit passed: 15+15 producer layers, 30 decoder layers,
  block size 16; capacities 383,323 per producer region and 191,976 per decoder
  region. Runtime source hashes match the published source.

Environment: torch 2.13.0+cu130, NIXL 1.1.0, FlashInfer Python/cubin/JIT cache
0.6.18.post1. Compiled artifacts are from `dc36fcce902a63eab06c1b93a5c4a5ee178a0c56`,
the immediate parent of the selected main; their only difference is a Python
frontend relocation, with identical compiled sources and build dependencies.

## Limitations

- Gemma validation explicitly uses `TRITON_ATTN`. The new auto-selected
  `TRITON_FLASHINFER` composite failed cache registration before any inference
  requests; this rebase does not add support for that layout.
- Equal P/D block sizes are required. Non-MLA decode TP greater than prefill TP,
  pull-mode PP/HMA, decode-side PP, and PP with Mamba/SSM remain unsupported.
- Packed MLA belongs to #50499. These runs do not establish DP/EP/CP E2E or
  RDMA performance coverage, and do not include live fault injection.
- Local passes do not establish required upstream GPU CI or human approval.

## AI assistance

AI assistance (Claude and Codex) was used for implementation, review, and
validation. The human submitter retains responsibility for reviewing and
understanding every changed line; maintainers retain merge responsibility.

Co-authored-by: Yiliu Dong https://github.com/qianlihuang
