### PR TITLE
[Model] Apertus 1.5

### DIFF
--- a/docs/features/reasoning_outputs.md
+++ b/docs/features/reasoning_outputs.md
@@ -13,6 +13,7 @@ vLLM currently supports the following reasoning models:
 
 | Model Series | Parser Name | Structured Output Support | Tool Calling |
 | ------------ | ----------- | ---------------- | ----------- |
+| [Apertus series](https://huggingface.co/collections/swiss-ai/apertus-v15) | `apertus` | `json`, `regex` | ✅ |
 | [Cohere Command A Reasoning](https://huggingface.co/CohereLabs/command-a-reasoning-08-2025) | `cohere_command3` | `json`, `regex` | ✅ |
 | [DeepSeek R1 series](https://huggingface.co/collections/deepseek-ai/deepseek-r1-678e1e131c0169c0bc89728d) | `deepseek_r1` | `json`, `regex` | ❌ |
 | [Gemma 4 series](https://huggingface.co/google/gemma-4-26B-A4B-it) | `gemma4` | `json`, `regex` | ✅ |

--- a/docs/features/tool_calling.md
+++ b/docs/features/tool_calling.md
@@ -463,12 +463,17 @@ Flags: `--tool-call-parser gigachat3`
 
 ### Apertus Models (`apertus`)
 
-Use the chat template from the examples folder; it fixes several OpenAI compatibility issues: `--chat-template /vllm-workspace/examples/tool_chat_template_apertus.jinja`
+Use the chat template from the examples folder; it fixes several OpenAI compatibility issues:
+`--chat-template /vllm-workspace/examples/tool_chat_template_apertus.jinja`.
+
+For Apertus 1.5 models, use the chat template packaged with the checkpoint.
 
 Supported models:
 
 * `swiss-ai/Apertus-8B-Instruct-2509`
 * `swiss-ai/Apertus-70B-Instruct-2509`
+* `swiss-ai/Apertus-v1.5-8B`
+* `swiss-ai/Apertus-v1.5-70B`
 
 Flags: `--tool-call-parser apertus`
 

--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -504,6 +504,7 @@ These models primarily accept the [`LLM.generate`](./generative_models.md#llmgen
 
 | Architecture | Models | Inputs | Example HF Models | [LoRA](../features/lora.md) | [PP](../serving/parallelism_scaling.md) |
 | ------------ | ------ | ------ | ----------------- | -------------------- | ------------------------- |
+| `Apertus1p5ForConditionalGeneration` | Apertus 1.5 | T + I<sup>+</sup> + A<sup>+</sup> | `swiss-ai/Apertus-v1.5-8B`, `swiss-ai/Apertus-v1.5-70B` | ✅︎ | ✅︎ |
 | `AriaForConditionalGeneration` | Aria | T + I<sup>+</sup> | `rhymes-ai/Aria` | | |
 | `AudioFlamingo3ForConditionalGeneration` | AudioFlamingo3 | T + A | `nvidia/audio-flamingo-3-hf`, `nvidia/music-flamingo-hf` | ✅︎ | ✅︎ |
 | `BagelForConditionalGeneration` | BAGEL | T + I<sup>+</sup> | `ByteDance-Seed/BAGEL-7B-MoT` | ✅︎ | ✅︎ |

--- a/tests/models/multimodal/generation/test_common.py
+++ b/tests/models/multimodal/generation/test_common.py
@@ -14,6 +14,7 @@ from transformers import (
     AutoModel,
     AutoModelForCausalLM,
     AutoModelForImageTextToText,
+    AutoModelForMultimodalLM,
     AutoModelForTextToWaveform,
 )
 from transformers import __version__ as TRANSFORMERS_VERSION
@@ -217,6 +218,19 @@ VLM_TEST_SETTINGS = {
                 reason="Custom model code is not compatible with Transformers v5"
             ),
         ],
+    ),
+    "apertus_1p5": VLMTestInfo(
+        models=["swiss-ai/Apertus-v1.5-8B"],
+        # The shared audio test resamples inputs to 16 kHz, but Apertus
+        # requires 24 kHz audio inputs, so it cannot cover Apertus audio.
+        test_type=(VLMTestType.IMAGE, VLMTestType.MULTI_IMAGE),
+        prompt_formatter=lambda prompt: (
+            f"<|user_start|>{prompt}<|user_end|><|assistant_start|>"
+        ),
+        img_idx_to_prompt=lambda idx: "<|image|>",
+        max_model_len=16384,
+        max_num_seqs=2,
+        auto_cls=AutoModelForMultimodalLM,
     ),
     #### Transformers fallback to test
     ## To reduce test burden, we only test batching arbitrary image size

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -777,6 +777,11 @@ _AUTOMATIC_CONVERTED_MODELS = {
 
 _MULTIMODAL_EXAMPLE_MODELS = {
     # [Decoder-only]
+    "Apertus1p5ForConditionalGeneration": _HfExamplesInfo(
+        "swiss-ai/Apertus-v1.5-8B",
+        # TODO: Update to the latest released Transformers version.
+        min_transformers_version="5.14",
+    ),
     "AriaForConditionalGeneration": _HfExamplesInfo("rhymes-ai/Aria"),
     "AudioFlamingo3ForConditionalGeneration": _HfExamplesInfo(
         "nvidia/audio-flamingo-3-hf",

--- a/tests/reasoning/test_apertus_reasoning_parser.py
+++ b/tests/reasoning/test_apertus_reasoning_parser.py
@@ -14,12 +14,6 @@ INNER_VOCAB = {
     "<think>": 500,
     "</think>": 501,
 }
-THINK_VOCAB = {
-    "<think>": 32,
-    "</think>": 33,
-    "<|inner_prefix|>": 900,
-    "<|inner_suffix|>": 901,
-}
 
 
 class MockTokenizer:
@@ -39,20 +33,29 @@ def make_parser(vocab: dict[str, int]) -> ReasoningParser:
     return parser_cls(MockTokenizer(vocab))
 
 
-@pytest.mark.parametrize(
-    "vocab, start, end",
-    [
-        (INNER_VOCAB, "<|inner_prefix|>", "<|inner_suffix|>"),
-        (THINK_VOCAB, "<think>", "</think>"),
-    ],
-)
-def test_delimiters_follow_the_tokenizer(vocab, start, end):
-    """The emitted (lower-id) delimiter pair wins, whichever scheme the
-    tokenizer build registers there."""
-    parser = make_parser(vocab)
+def test_delimiters_are_the_inner_pair():
+    """The inner pair carries the ids the model emits for thinking."""
+    parser = make_parser(INNER_VOCAB)
 
-    assert (parser.start_token, parser.end_token) == (start, end)
+    assert (parser.start_token, parser.end_token) == (
+        "<|inner_prefix|>",
+        "<|inner_suffix|>",
+    )
     assert (parser.start_token_id, parser.end_token_id) == (32, 33)
+
+
+def test_think_strings_are_not_delimiters():
+    """``<think>`` is an ordinary vocab entry: the tokenizer's normalizer maps it
+    to the inner pair on input only, so generated ``<think>`` text is content."""
+    parser = make_parser(INNER_VOCAB)
+    output = "<think>not a thinking block</think>plain answer"
+
+    reasoning, content = run_reasoning_extraction(
+        reasoning_parser=parser, model_output=[output]
+    )
+
+    assert reasoning is None
+    assert content == output
 
 
 @pytest.mark.parametrize("streaming", [True, False])

--- a/tests/reasoning/test_apertus_reasoning_parser.py
+++ b/tests/reasoning/test_apertus_reasoning_parser.py
@@ -33,17 +33,6 @@ def make_parser(vocab: dict[str, int]) -> ReasoningParser:
     return parser_cls(MockTokenizer(vocab))
 
 
-def test_delimiters_are_the_inner_pair():
-    """The inner pair carries the ids the model emits for thinking."""
-    parser = make_parser(INNER_VOCAB)
-
-    assert (parser.start_token, parser.end_token) == (
-        "<|inner_prefix|>",
-        "<|inner_suffix|>",
-    )
-    assert (parser.start_token_id, parser.end_token_id) == (32, 33)
-
-
 def test_think_strings_are_not_delimiters():
     """``<think>`` is an ordinary vocab entry: the tokenizer's normalizer maps it
     to the inner pair on input only, so generated ``<think>`` text is content."""

--- a/tests/reasoning/test_apertus_reasoning_parser.py
+++ b/tests/reasoning/test_apertus_reasoning_parser.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from tests.reasoning.utils import run_reasoning_extraction
+from vllm.reasoning import ReasoningParser, ReasoningParserManager
+
+parser_name = "apertus"
+
+INNER_VOCAB = {
+    "<|inner_prefix|>": 32,
+    "<|inner_suffix|>": 33,
+    "<think>": 500,
+    "</think>": 501,
+}
+THINK_VOCAB = {
+    "<think>": 32,
+    "</think>": 33,
+    "<|inner_prefix|>": 900,
+    "<|inner_suffix|>": 901,
+}
+
+
+class MockTokenizer:
+    def __init__(self, vocab: dict[str, int]):
+        self._vocab = vocab
+
+    def get_vocab(self) -> dict[str, int]:
+        return self._vocab
+
+    def tokenize(self, text: str) -> list[str]:
+        # Only special tokens matter to the parser; deltas are fed one per token.
+        return [text] if text in self._vocab else []
+
+
+def make_parser(vocab: dict[str, int]) -> ReasoningParser:
+    parser_cls = ReasoningParserManager.get_reasoning_parser(parser_name)
+    return parser_cls(MockTokenizer(vocab))
+
+
+@pytest.mark.parametrize(
+    "vocab, start, end",
+    [
+        (INNER_VOCAB, "<|inner_prefix|>", "<|inner_suffix|>"),
+        (THINK_VOCAB, "<think>", "</think>"),
+    ],
+)
+def test_delimiters_follow_the_tokenizer(vocab, start, end):
+    """The emitted (lower-id) delimiter pair wins, whichever scheme the
+    tokenizer build registers there."""
+    parser = make_parser(vocab)
+
+    assert (parser.start_token, parser.end_token) == (start, end)
+    assert (parser.start_token_id, parser.end_token_id) == (32, 33)
+
+
+@pytest.mark.parametrize("streaming", [True, False])
+def test_deliberation_block_is_reasoning(streaming: bool):
+    parser = make_parser(INNER_VOCAB)
+    output = ["<|inner_prefix|>", "Let me think", "<|inner_suffix|>", "The answer"]
+
+    reasoning, content = run_reasoning_extraction(
+        reasoning_parser=parser, model_output=output, streaming=streaming
+    )
+
+    assert reasoning == "Let me think"
+    assert content == "The answer"
+
+
+def test_output_without_deliberation_is_all_content():
+    """A direct tool call carries no inner block; it must reach the tool parser
+    as content rather than being swallowed as reasoning."""
+    parser = make_parser(INNER_VOCAB)
+    output = '<|tools_prefix|>[{"get_weather": {"city": "Bern"}}]<|tools_suffix|>'
+
+    reasoning, content = run_reasoning_extraction(
+        reasoning_parser=parser, model_output=[output]
+    )
+
+    assert reasoning is None
+    assert content == output

--- a/vllm/model_executor/models/apertus_mm.py
+++ b/vllm/model_executor/models/apertus_mm.py
@@ -542,13 +542,13 @@ class Apertus1p5ForConditionalGeneration(
 
         # The vision tower expects a single image with a batch dimension;
         # per-item encoding avoids quality degradation from tokenizer batching.
-        with torch.inference_mode():
-            ids_per_image = []
-            for image in images:
-                image_codes = vision_tower.encode(
-                    image.unsqueeze(0).to(device=target_device, dtype=target_dtype)
-                )
-                ids_per_image.append(image_codes.flatten())
+        ids_per_image = []
+        for image in images:
+            image_codes = vision_tower.encode(
+                image.unsqueeze(0).to(device=target_device, dtype=target_dtype)
+            )
+            ids_per_image.append(image_codes.flatten())
+
         ids_per_image = [
             ids.to(torch.long) + self.image_token_offset for ids in ids_per_image
         ]
@@ -571,15 +571,15 @@ class Apertus1p5ForConditionalGeneration(
 
         # The audio tower expects a single clip with batch/channel dimensions;
         # per-item encoding avoids quality degradation from tokenizer batching.
-        with torch.inference_mode():
-            ids_per_audio = []
-            for audio in audios:
-                audio_codes = audio_tower.encode(
-                    audio.unsqueeze(0)
-                    .unsqueeze(0)
-                    .to(device=target_device, dtype=target_dtype)
-                ).audio_codes
-                ids_per_audio.append(audio_codes.squeeze(0).squeeze(0))
+        ids_per_audio = []
+        for audio in audios:
+            audio_codes = audio_tower.encode(
+                audio.unsqueeze(0)
+                .unsqueeze(0)
+                .to(device=target_device, dtype=target_dtype)
+            ).audio_codes
+            ids_per_audio.append(audio_codes.squeeze(0).squeeze(0))
+
         ids_per_audio = [
             ids.to(torch.long) + self.audio_token_offset for ids in ids_per_audio
         ]

--- a/vllm/model_executor/models/apertus_mm.py
+++ b/vllm/model_executor/models/apertus_mm.py
@@ -1,0 +1,636 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Apertus 1.5 multimodal model."""
+
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from math import isqrt
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+from transformers import (
+    Apertus1p5VisionTokenizerModel,
+    AutoConfig,
+    AutoModel,
+    PretrainedConfig,
+)
+
+from vllm.config import VllmConfig
+from vllm.config.multimodal import BaseDummyOptions
+from vllm.distributed import get_pp_group
+from vllm.inputs import MultiModalDataDict, MultiModalInput, mm_input
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
+from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.inputs import (
+    MultiModalFieldConfig,
+    MultiModalKwargsItems,
+    PlaceholderRange,
+)
+from vllm.multimodal.parse import (
+    AudioProcessorItems,
+    ImageProcessorItems,
+    MultiModalDataParser,
+)
+from vllm.multimodal.processing import (
+    BaseDummyInputsBuilder,
+    BaseMultiModalProcessor,
+    BaseProcessingInfo,
+    ProcessorInputs,
+    PromptUpdate,
+    TimingContext,
+)
+from vllm.sequence import IntermediateTensors
+from vllm.utils.torch_utils import set_default_torch_dtype
+
+from .apertus import ApertusForCausalLM, ApertusModel
+from .interfaces import (
+    MultiModalEmbeddings,
+    SupportsEagle,
+    SupportsEagle3,
+    SupportsLoRA,
+    SupportsMultiModal,
+    SupportsPP,
+)
+from .utils import (
+    AutoWeightsLoader,
+    PPMissingLayer,
+    WeightsMapper,
+    maybe_prefix,
+)
+
+_IMAGE_TOKEN_BUDGET_OVERHEAD = 512
+_MAX_AUDIO_SECONDS = 300
+_AUDIO_TOKEN_BUDGET_OVERHEAD = 4
+
+_DEFAULT_IMAGE_PLACEHOLDER = "<|image|>"
+_DEFAULT_BOI_TOKEN = "<|img_start|>"
+_DEFAULT_EOI_TOKEN = "<|img_end|>"
+_DEFAULT_AUDIO_PLACEHOLDER = "<|audio|>"
+_DEFAULT_AUDIO_START_TOKEN = "<|audio_start|>"
+_DEFAULT_AUDIO_END_TOKEN = "<|audio_end|>"
+
+_DEFAULT_IMAGE_TOKEN_ID = 131079
+_DEFAULT_AUDIO_TOKEN_ID = 131085
+_DEFAULT_IMAGE_TOKEN_OFFSET = 131272
+_DEFAULT_AUDIO_TOKEN_OFFSET = 262344
+_DEFAULT_IMAGE_START_TOKEN_ID = 131073
+_DEFAULT_IMAGE_END_TOKEN_ID = 131074
+_DEFAULT_AUDIO_START_TOKEN_ID = 131080
+_DEFAULT_AUDIO_END_TOKEN_ID = 131081
+
+
+def _pad_logits_to_input_vocab(
+    logits: torch.Tensor, input_vocab_size: int
+) -> torch.Tensor:
+    # Keep input-only token IDs unsampleable while preserving the expected shape.
+    return F.pad(
+        logits,
+        (0, input_vocab_size - logits.shape[-1]),
+        value=float("-inf"),
+    )
+
+
+def _init_component_model(
+    component_config: PretrainedConfig,
+    model_cls: type[torch.nn.Module] | None = None,
+) -> torch.nn.Module:
+    config_dict = component_config.to_dict()
+    config = AutoConfig.for_model(config_dict.pop("model_type"), **config_dict)
+    return AutoModel.from_config(config) if model_cls is None else model_cls(config)
+
+
+class Apertus1p5ProcessingInfo(BaseProcessingInfo):
+    def get_data_parser(self) -> MultiModalDataParser:
+        audio_feature_extractor = self.get_hf_processor().feature_extractor
+        return MultiModalDataParser(
+            target_sr=audio_feature_extractor.sampling_rate,
+            target_channels=1,
+            expected_hidden_size=self._get_expected_hidden_size(),
+        )
+
+    def get_default_tok_params(self):
+        """Avoid duplicate BOS when a chat template renders it."""
+        tokenizer = self.ctx.get_tokenizer()
+        has_chat_template = getattr(tokenizer, "chat_template", None) is not None
+
+        params = super().get_default_tok_params()
+        if has_chat_template:
+            # The template emits BOS itself; suppress tokenizer-added BOS to
+            # avoid sending two BOS tokens to the model.
+            params = params.with_kwargs(add_special_tokens=False)
+        return params
+
+    def get_supported_mm_limits(self) -> Mapping[str, int | None]:
+        return {"image": None, "audio": None}
+
+    def get_mm_max_tokens_per_item(
+        self,
+        seq_len: int,
+        mm_counts: Mapping[str, int],
+    ) -> Mapping[str, int] | None:
+        del mm_counts
+        processor = self.get_hf_processor()
+        image_processor = processor.image_processor
+        feature_extractor = processor.feature_extractor
+        return {
+            # Maximum image codes plus room for the image layout's wrapper
+            # and row-separator tokens.
+            "image": min(
+                (image_processor.max_pixels // (image_processor.spatial_factor**2))
+                + _IMAGE_TOKEN_BUDGET_OVERHEAD,
+                seq_len,
+            ),
+            # Maximum audio codes for the configured duration plus special tokens.
+            "audio": min(
+                (
+                    feature_extractor.get_num_audio_codes(
+                        feature_extractor.sampling_rate
+                    )
+                    * _MAX_AUDIO_SECONDS
+                )
+                + _AUDIO_TOKEN_BUDGET_OVERHEAD,
+                seq_len,
+            ),
+        }
+
+
+class Apertus1p5DummyInputsBuilder(BaseDummyInputsBuilder[Apertus1p5ProcessingInfo]):
+    def get_dummy_text(self, mm_counts: Mapping[str, int]) -> str:
+        tokenizer = self.info.get_tokenizer()
+        image_placeholder = getattr(
+            tokenizer, "image_token", _DEFAULT_IMAGE_PLACEHOLDER
+        )
+        audio_placeholder = getattr(
+            tokenizer, "audio_token", _DEFAULT_AUDIO_PLACEHOLDER
+        )
+        return image_placeholder * mm_counts.get(
+            "image", 0
+        ) + audio_placeholder * mm_counts.get("audio", 0)
+
+    def get_dummy_mm_data(
+        self,
+        seq_len: int,
+        mm_counts: Mapping[str, int],
+        mm_options: Mapping[str, BaseDummyOptions],
+    ) -> MultiModalDataDict:
+        image_overrides = mm_options.get("image")
+        audio_overrides = mm_options.get("audio")
+        processor = self.info.get_hf_processor()
+        max_image_side = isqrt(processor.image_processor.max_pixels)
+
+        return {
+            "image": self._get_dummy_images(
+                width=max_image_side,
+                height=max_image_side,
+                num_images=mm_counts.get("image", 0),
+                overrides=image_overrides,
+            ),
+            "audio": self._get_dummy_audios(
+                length=processor.feature_extractor.sampling_rate * _MAX_AUDIO_SECONDS,
+                num_audios=mm_counts.get("audio", 0),
+                overrides=audio_overrides,
+            ),
+        }
+
+
+class Apertus1p5MultiModalProcessor(BaseMultiModalProcessor[Apertus1p5ProcessingInfo]):
+    """Process Apertus multimodal inputs on the CPU."""
+
+    def __init__(
+        self,
+        info: Apertus1p5ProcessingInfo,
+        dummy_inputs: BaseDummyInputsBuilder,
+        *,
+        cache: object | None = None,
+    ) -> None:
+        super().__init__(info, dummy_inputs, cache=cache)
+        tokenizer = info.get_tokenizer()
+        self.hf_processor = info.get_hf_processor()
+        config = info.get_hf_config()
+        self.image_token_id = getattr(config, "image_token_id", _DEFAULT_IMAGE_TOKEN_ID)
+        self.audio_token_id = getattr(config, "audio_token_id", _DEFAULT_AUDIO_TOKEN_ID)
+        self.image_start_token = getattr(tokenizer, "boi_token", _DEFAULT_BOI_TOKEN)
+        self.image_end_token = getattr(tokenizer, "eoi_token", _DEFAULT_EOI_TOKEN)
+        self.audio_start_token = getattr(
+            tokenizer, "boa_token", _DEFAULT_AUDIO_START_TOKEN
+        )
+        self.audio_end_token = getattr(tokenizer, "eoa_token", _DEFAULT_AUDIO_END_TOKEN)
+        self.image_start_token_id = getattr(
+            tokenizer, "boi_token_id", _DEFAULT_IMAGE_START_TOKEN_ID
+        )
+        self.image_end_token_id = getattr(
+            tokenizer, "eoi_token_id", _DEFAULT_IMAGE_END_TOKEN_ID
+        )
+        self.audio_start_token_id = getattr(
+            tokenizer, "boa_token_id", _DEFAULT_AUDIO_START_TOKEN_ID
+        )
+        self.audio_end_token_id = getattr(
+            tokenizer, "eoa_token_id", _DEFAULT_AUDIO_END_TOKEN_ID
+        )
+
+    def _get_mm_fields_config(
+        self,
+        hf_inputs: object,
+        hf_processor_mm_kwargs: Mapping[str, object],
+    ) -> Mapping[str, MultiModalFieldConfig]:
+        """Routes per-item tensors to the GPU Worker's embed_multimodal kwargs."""
+        return {
+            "pixel_values": MultiModalFieldConfig.batched("image"),
+            "audio_values": MultiModalFieldConfig.batched("audio"),
+        }
+
+    def _get_prompt_updates(self, *args: Any, **kwargs: Any) -> Sequence[PromptUpdate]:
+        return []
+
+    def apply(
+        self, inputs: ProcessorInputs, timing_ctx: TimingContext
+    ) -> MultiModalInput:
+        tokenizer = self.info.get_tokenizer()
+        prompt_text = (
+            inputs.prompt
+            if isinstance(inputs.prompt, str)
+            else tokenizer.decode(inputs.prompt)
+        )
+
+        tokenization_kwargs = dict(inputs.tokenization_kwargs)
+        if not isinstance(inputs.prompt, str):
+            # A template-rendered prompt already starts with BOS. Otherwise,
+            # restore the BOS added before token IDs were decoded to text.
+            tokenization_kwargs.setdefault(
+                "add_special_tokens",
+                not (
+                    bool(inputs.prompt) and inputs.prompt[0] == tokenizer.bos_token_id
+                ),
+            )
+
+        num_images = inputs.mm_data_items.get_count("image", strict=False)
+        num_audios = inputs.mm_data_items.get_count("audio", strict=False)
+
+        images = (
+            inputs.mm_data_items.get_items("image", ImageProcessorItems).get_all()
+            if num_images > 0
+            else None
+        )
+        audios = (
+            inputs.mm_data_items.get_items("audio", AudioProcessorItems).get_all()
+            if num_audios > 0
+            else None
+        )
+
+        mm_kwargs: dict[str, torch.Tensor | list[torch.Tensor]] = {}
+
+        with timing_ctx.record("preprocess_apertus"):
+            hf_outputs = self.hf_processor(
+                text=prompt_text,
+                images=images,
+                audio=audios,
+                padding=True,
+                return_tensors="pt",
+                **tokenization_kwargs,
+            )
+            prompt_token_ids = hf_outputs["input_ids"][0].tolist()
+
+        if num_images > 0:
+            # Hugging Face pads images in a multimodal batch to a common size.
+            # Crop each item back to its reported dimensions before encoding it.
+            pixel_values = [
+                image[:, : int(height), : int(width)].contiguous()
+                for image, (height, width) in zip(
+                    hf_outputs["pixel_values"],
+                    hf_outputs["image_sizes"],
+                )
+            ]
+            mm_kwargs["pixel_values"] = pixel_values
+
+        if num_audios > 0:
+            # Hugging Face pads audio features in a multimodal batch to a common
+            # length. Remove that padding with each item's attention mask.
+            audio_values = [
+                audio[0, : int(mask.sum())].contiguous()
+                for audio, mask in zip(
+                    hf_outputs["input_features"],
+                    hf_outputs["feature_attention_mask"],
+                )
+            ]
+            mm_kwargs["audio_values"] = audio_values
+
+        # Each placeholder range marks the token positions replaced by embeddings.
+        with timing_ctx.record("get_mm_hashes"):
+            mm_hashes = inputs.get_mm_hashes(self.info.model_id)
+
+        def _span_ranges(
+            start_token: str,
+            start_id: int,
+            end_token: str,
+            end_id: int,
+            embed_token_id: int,
+            count: int,
+        ) -> list[PlaceholderRange]:
+            """Locate processor-created multimodal spans and embedding slots.
+
+            The Hugging Face processor expands images into
+            ``<|img_start|>H*W<|img_token_start|><|image|>...<|img_end|>``
+            and audio into ``<|audio_start|><|audio|>...<|audio_end|>``.
+            For each item, find the next complete range after the previous
+            one and mark its ``<|image|>`` or ``<|audio|>`` positions for
+            replacement with the corresponding encoded embeddings.
+            """
+            ranges: list[PlaceholderRange] = []
+            pos = 0
+            for _ in range(count):
+                try:
+                    s = prompt_token_ids.index(start_id, pos)
+                    e = prompt_token_ids.index(end_id, s)
+                except ValueError as exc:
+                    raise ValueError(
+                        f"Apertus MM: {start_token!r}/{end_token!r} pair not "
+                        f"found in prompt (search from {pos})"
+                    ) from exc
+                span = prompt_token_ids[s : e + 1]
+                is_embed = torch.tensor(
+                    [tok == embed_token_id for tok in span], dtype=torch.bool
+                )
+                ranges.append(
+                    PlaceholderRange(offset=s, length=e - s + 1, is_embed=is_embed)
+                )
+                pos = e + 1
+            return ranges
+
+        mm_placeholders: dict[str, list[PlaceholderRange]] = {}
+        if num_images > 0:
+            mm_placeholders["image"] = _span_ranges(
+                self.image_start_token,
+                self.image_start_token_id,
+                self.image_end_token,
+                self.image_end_token_id,
+                self.image_token_id,
+                num_images,
+            )
+        if num_audios > 0:
+            mm_placeholders["audio"] = _span_ranges(
+                self.audio_start_token,
+                self.audio_start_token_id,
+                self.audio_end_token,
+                self.audio_end_token_id,
+                self.audio_token_id,
+                num_audios,
+            )
+
+        return mm_input(
+            prompt_token_ids=prompt_token_ids,
+            mm_kwargs=MultiModalKwargsItems.from_hf_inputs(
+                mm_kwargs, self._get_mm_fields_config(mm_kwargs, {})
+            ),
+            mm_hashes=mm_hashes,
+            mm_placeholders=mm_placeholders,
+        )
+
+
+@MULTIMODAL_REGISTRY.register_processor(
+    Apertus1p5MultiModalProcessor,
+    info=Apertus1p5ProcessingInfo,
+    dummy_inputs=Apertus1p5DummyInputsBuilder,
+)
+class Apertus1p5ForConditionalGeneration(
+    torch.nn.Module,
+    SupportsMultiModal,
+    SupportsLoRA,
+    SupportsPP,
+    SupportsEagle,
+    SupportsEagle3,
+):
+    hf_to_vllm_mapper = ApertusForCausalLM.hf_to_vllm_mapper | WeightsMapper(
+        orig_to_new_prefix={
+            "model.language_model.": "language_model.",
+            "model.vision_tokenizer.": "vision_tower.",
+            "model.audio_tokenizer.": "audio_tower.",
+        }
+    )
+
+    packed_modules_mapping = ApertusForCausalLM.packed_modules_mapping
+    embedding_modules = ApertusForCausalLM.embedding_modules
+    allow_patterns_overrides = None
+
+    @classmethod
+    def get_placeholder_str(cls, modality: str, i: int) -> str | None:
+        if modality.startswith("image"):
+            return _DEFAULT_IMAGE_PLACEHOLDER
+        if modality.startswith("audio"):
+            return _DEFAULT_AUDIO_PLACEHOLDER
+        raise ValueError(f"Unsupported modality: {modality}")
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        config = vllm_config.model_config.hf_config
+        text_config = vllm_config.model_config.hf_text_config
+        self.config = config
+
+        with self._mark_language_model(vllm_config):
+            self.language_model = ApertusModel(
+                vllm_config=vllm_config.with_hf_config(text_config),
+                prefix=maybe_prefix(prefix, "language_model"),
+            )
+        self.make_empty_intermediate_tensors = (
+            self.language_model.make_empty_intermediate_tensors
+        )
+
+        # `output_vocab_size` is the number of rows in the output LM head. The
+        # pruned head contains text tokens only; image, audio, and omni special
+        # token IDs remain input-only embeddings and cannot be generated.
+        output_vocab_size = (
+            getattr(text_config, "output_vocab_size", None) or text_config.vocab_size
+        )
+        if output_vocab_size > text_config.vocab_size:
+            raise ValueError("Output vocabulary cannot exceed input vocabulary.")
+        self._input_vocab_size = text_config.vocab_size
+        self._should_pad_logits_to_input_vocab = (
+            output_vocab_size != text_config.vocab_size
+        )
+        if get_pp_group().is_last_rank:
+            self.lm_head = ParallelLMHead(
+                output_vocab_size,
+                text_config.hidden_size,
+                quant_config=vllm_config.quant_config,
+                prefix=maybe_prefix(prefix, "lm_head"),
+            )
+            if config.tie_word_embeddings:
+                raise ValueError(
+                    "Apertus 1.5 does not support tied input and output embeddings."
+                )
+            logit_scale = getattr(config, "logit_scale", 1.0)
+            self.logits_processor = LogitsProcessor(
+                output_vocab_size, scale=logit_scale
+            )
+        else:
+            self.lm_head = PPMissingLayer()
+
+        self.vision_tower: Any | None = None
+        self.audio_tower: Any | None = None
+        # A single primary source now yields the vision/audio tensors too (routed by
+        # hf_to_vllm_mapper)
+        self.secondary_weights = []
+        if get_pp_group().is_first_rank:
+            with set_default_torch_dtype(torch.float32):
+                with self._mark_tower_model(vllm_config, "image"):
+                    self.vision_tower = _init_component_model(
+                        config.vision_tokenizer_config,
+                        model_cls=Apertus1p5VisionTokenizerModel,
+                    )
+                with self._mark_tower_model(vllm_config, "audio"):
+                    self.audio_tower = _init_component_model(
+                        config.audio_tokenizer_config,
+                    )
+
+        self.image_token_offset = getattr(
+            config, "image_token_offset", _DEFAULT_IMAGE_TOKEN_OFFSET
+        )
+        self.audio_token_offset = getattr(
+            config, "audio_token_offset", _DEFAULT_AUDIO_TOKEN_OFFSET
+        )
+
+    def get_language_model(self):
+        return self.language_model
+
+    def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor | None:
+        logits = self.logits_processor(self.lm_head, hidden_states)
+        if logits is None or not self._should_pad_logits_to_input_vocab:
+            return logits
+        # The text-only LM head is narrower than the input vocabulary used by
+        # repetition penalties and other sampler logic.
+        return _pad_logits_to_input_vocab(logits, self._input_vocab_size)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs: object,
+    ) -> torch.Tensor | IntermediateTensors:
+        return self.language_model(
+            input_ids,
+            positions,
+            intermediate_tensors,
+            inputs_embeds,
+        )
+
+    def load_weights(
+        self,
+        weights: Iterable[tuple[str, torch.Tensor]],
+    ) -> set[str]:
+        skip_prefixes = ["lm_head."] if self.config.tie_word_embeddings else []
+        if not get_pp_group().is_first_rank:
+            skip_prefixes.extend(["vision_tower.", "audio_tower."])
+
+        loader = AutoWeightsLoader(self, skip_prefixes=skip_prefixes)
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+
+    def _get_module_device_dtype(
+        self,
+        module: torch.nn.Module,
+    ) -> tuple[torch.device, torch.dtype]:
+        parameter = next(module.parameters())
+        return parameter.device, parameter.dtype
+
+    def _encode_image_to_llm_ids(
+        self,
+        image: torch.Tensor,
+    ) -> torch.Tensor:
+        vision_tower = self.vision_tower
+        assert vision_tower is not None
+        target_device, target_dtype = self._get_module_device_dtype(vision_tower)
+        # The vision tower expects a single image with a batch dimension;
+        # per-item encoding avoids quality degradation from tokenizer batching.
+        image = image.unsqueeze(0).to(device=target_device, dtype=target_dtype)
+        with torch.inference_mode():
+            valid_codes = vision_tower.encode(image).flatten()
+        return valid_codes.to(torch.long) + self.image_token_offset
+
+    def _encode_audio_to_llm_ids(
+        self,
+        audio: torch.Tensor,
+    ) -> torch.Tensor:
+        audio_tower = self.audio_tower
+        assert audio_tower is not None
+        target_device, target_dtype = self._get_module_device_dtype(audio_tower)
+        # The audio tower expects a single clip with batch/channel dimensions;
+        # per-item encoding avoids quality degradation from tokenizer batching.
+        with torch.inference_mode():
+            output = audio_tower.encode(
+                audio.unsqueeze(0)
+                .unsqueeze(0)
+                .to(device=target_device, dtype=target_dtype)
+            )
+            valid_codes = output.audio_codes.squeeze(0).squeeze(0)
+
+        return valid_codes.to(torch.long) + self.audio_token_offset
+
+    def _process_modality_input(
+        self,
+        values: torch.Tensor | list[torch.Tensor],
+        encode_fn: Callable[[torch.Tensor], torch.Tensor],
+        device: torch.device,
+    ) -> list[torch.Tensor]:
+        """Encode modality items one by one, then batch-lookup their embeddings."""
+        items = list(values.unbind(0)) if isinstance(values, torch.Tensor) else values
+        if not items:
+            return []
+
+        # Encode each item independently to preserve HuggingFace parity for image
+        # and audio inputs.
+        ids_per_item = [encode_fn(item) for item in items]
+        lengths = [ids.shape[0] for ids in ids_per_item]
+
+        all_ids = torch.cat(ids_per_item).to(device)
+        all_embeds = self.language_model.embed_input_ids(all_ids)
+        return list(all_embeds.split(lengths))
+
+    def embed_multimodal(
+        self,
+        **kwargs: object,
+    ) -> MultiModalEmbeddings:
+        """Encode all modality batches into language embeddings."""
+        try:
+            device = next(self.parameters()).device
+        except StopIteration:
+            device = torch.device("cuda")
+
+        multimodal_embeddings: list[torch.Tensor] = []
+
+        for input_key in kwargs:
+            if input_key == "pixel_values":
+                pixel_values = kwargs[input_key]
+                if pixel_values is not None and self.vision_tower is not None:
+                    image_embeds = self._process_modality_input(
+                        pixel_values,  # type: ignore
+                        self._encode_image_to_llm_ids,
+                        device,
+                    )
+                    multimodal_embeddings.extend(image_embeds)
+            elif input_key == "audio_values":
+                audio_values = kwargs[input_key]
+                if audio_values is not None and self.audio_tower is not None:
+                    audio_embeds = self._process_modality_input(
+                        audio_values,  # type: ignore
+                        self._encode_audio_to_llm_ids,
+                        device,
+                    )
+                    multimodal_embeddings.extend(audio_embeds)
+
+        return multimodal_embeddings
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: MultiModalEmbeddings | None = None,
+        *,
+        is_multimodal: torch.Tensor | None = None,
+        **kwargs: object,
+    ) -> torch.Tensor:
+        return SupportsMultiModal.embed_input_ids(
+            self,
+            input_ids,
+            multimodal_embeddings=multimodal_embeddings,
+            is_multimodal=is_multimodal,
+        )

--- a/vllm/model_executor/models/apertus_mm.py
+++ b/vllm/model_executor/models/apertus_mm.py
@@ -2,9 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Apertus 1.5 multimodal model."""
 
-from collections.abc import Callable, Iterable, Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from math import isqrt
-from typing import Any
+from typing import Annotated, Any, Literal
 
 import torch
 import torch.nn.functional as F
@@ -41,6 +41,7 @@ from vllm.multimodal.processing import (
     TimingContext,
 )
 from vllm.sequence import IntermediateTensors
+from vllm.utils.tensor_schema import TensorSchema, TensorShape
 from vllm.utils.torch_utils import set_default_torch_dtype
 
 from .apertus import ApertusForCausalLM, ApertusModel
@@ -78,6 +79,28 @@ _DEFAULT_IMAGE_START_TOKEN_ID = 131073
 _DEFAULT_IMAGE_END_TOKEN_ID = 131074
 _DEFAULT_AUDIO_START_TOKEN_ID = 131080
 _DEFAULT_AUDIO_END_TOKEN_ID = 131081
+
+
+class Apertus1p5ImageInputs(TensorSchema):
+    """Processed image inputs for the Apertus vision tokenizer."""
+
+    type: Literal["pixel_values"]
+
+    pixel_values: Annotated[
+        torch.Tensor | list[torch.Tensor],
+        TensorShape("ni", 3, "h", "w", dynamic_dims={"h", "w"}),
+    ]
+
+
+class Apertus1p5AudioInputs(TensorSchema):
+    """Processed audio inputs for the Apertus audio tokenizer."""
+
+    type: Literal["audio_values"]
+
+    audio_values: Annotated[
+        torch.Tensor | list[torch.Tensor],
+        TensorShape("na", "t", dynamic_dims={"t"}),
+    ]
 
 
 def _pad_logits_to_input_vocab(
@@ -304,8 +327,9 @@ class Apertus1p5MultiModalProcessor(BaseMultiModalProcessor[Apertus1p5Processing
             mm_kwargs["pixel_values"] = pixel_values
 
         if num_audios > 0:
-            # Hugging Face pads audio features in a multimodal batch to a common
-            # length. Remove that padding with each item's attention mask.
+            # Apertus1p5 input-processor pads audio features in a multimodal
+            # batch to a common length. Remove that padding with each item's
+            # attention mask.
             audio_values = [
                 audio[0, : int(mask.sum())].contiguous()
                 for audio, mask in zip(
@@ -329,7 +353,7 @@ class Apertus1p5MultiModalProcessor(BaseMultiModalProcessor[Apertus1p5Processing
         ) -> list[PlaceholderRange]:
             """Locate processor-created multimodal spans and embedding slots.
 
-            The Hugging Face processor expands images into
+            The Apertus1p5 input-processor from transformers expands images into
             ``<|img_start|>H*W<|img_token_start|><|image|>...<|img_end|>``
             and audio into ``<|audio_start|><|audio|>...<|audio_end|>``.
             For each item, find the next complete range after the previous
@@ -465,8 +489,6 @@ class Apertus1p5ForConditionalGeneration(
         else:
             self.lm_head = PPMissingLayer()
 
-        self.vision_tower: Any | None = None
-        self.audio_tower: Any | None = None
         # A single primary source now yields the vision/audio tensors too (routed by
         # hf_to_vllm_mapper)
         self.secondary_weights = []
@@ -520,9 +542,6 @@ class Apertus1p5ForConditionalGeneration(
         weights: Iterable[tuple[str, torch.Tensor]],
     ) -> set[str]:
         skip_prefixes = ["lm_head."] if self.config.tie_word_embeddings else []
-        if not get_pp_group().is_first_rank:
-            skip_prefixes.extend(["vision_tower.", "audio_tower."])
-
         loader = AutoWeightsLoader(self, skip_prefixes=skip_prefixes)
         return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
 
@@ -533,90 +552,123 @@ class Apertus1p5ForConditionalGeneration(
         parameter = next(module.parameters())
         return parameter.device, parameter.dtype
 
-    def _encode_image_to_llm_ids(
+    def _encode_image_to_llm(
         self,
-        image: torch.Tensor,
-    ) -> torch.Tensor:
+        image_input: Apertus1p5ImageInputs,
+    ) -> list[torch.Tensor]:
         vision_tower = self.vision_tower
         assert vision_tower is not None
         target_device, target_dtype = self._get_module_device_dtype(vision_tower)
+
+        # `list()` expands tensors along dimension 0 while preserving list inputs.
+        images = list(image_input["pixel_values"])
+        if not images:
+            return []
+
         # The vision tower expects a single image with a batch dimension;
         # per-item encoding avoids quality degradation from tokenizer batching.
-        image = image.unsqueeze(0).to(device=target_device, dtype=target_dtype)
         with torch.inference_mode():
-            valid_codes = vision_tower.encode(image).flatten()
-        return valid_codes.to(torch.long) + self.image_token_offset
+            ids_per_image = []
+            for image in images:
+                image_codes = vision_tower.encode(
+                    image.unsqueeze(0).to(device=target_device, dtype=target_dtype)
+                )
+                ids_per_image.append(image_codes.flatten())
+        ids_per_image = [
+            ids.to(torch.long) + self.image_token_offset for ids in ids_per_image
+        ]
+        lengths = [ids.shape[0] for ids in ids_per_image]
+        all_embeds = self.language_model.embed_input_ids(torch.cat(ids_per_image))
+        return list(all_embeds.split(lengths))
 
-    def _encode_audio_to_llm_ids(
+    def _encode_audio_to_llm(
         self,
-        audio: torch.Tensor,
-    ) -> torch.Tensor:
+        audio_input: Apertus1p5AudioInputs,
+    ) -> list[torch.Tensor]:
         audio_tower = self.audio_tower
         assert audio_tower is not None
         target_device, target_dtype = self._get_module_device_dtype(audio_tower)
+
+        # `list()` expands tensors along dimension 0 while preserving list inputs.
+        audios = list(audio_input["audio_values"])
+        if not audios:
+            return []
+
         # The audio tower expects a single clip with batch/channel dimensions;
         # per-item encoding avoids quality degradation from tokenizer batching.
         with torch.inference_mode():
-            output = audio_tower.encode(
-                audio.unsqueeze(0)
-                .unsqueeze(0)
-                .to(device=target_device, dtype=target_dtype)
-            )
-            valid_codes = output.audio_codes.squeeze(0).squeeze(0)
-
-        return valid_codes.to(torch.long) + self.audio_token_offset
-
-    def _process_modality_input(
-        self,
-        values: torch.Tensor | list[torch.Tensor],
-        encode_fn: Callable[[torch.Tensor], torch.Tensor],
-        device: torch.device,
-    ) -> list[torch.Tensor]:
-        """Encode modality items one by one, then batch-lookup their embeddings."""
-        items = list(values.unbind(0)) if isinstance(values, torch.Tensor) else values
-        if not items:
-            return []
-
-        # Encode each item independently to preserve HuggingFace parity for image
-        # and audio inputs.
-        ids_per_item = [encode_fn(item) for item in items]
-        lengths = [ids.shape[0] for ids in ids_per_item]
-
-        all_ids = torch.cat(ids_per_item).to(device)
-        all_embeds = self.language_model.embed_input_ids(all_ids)
+            ids_per_audio = []
+            for audio in audios:
+                audio_codes = audio_tower.encode(
+                    audio.unsqueeze(0)
+                    .unsqueeze(0)
+                    .to(device=target_device, dtype=target_dtype)
+                ).audio_codes
+                ids_per_audio.append(audio_codes.squeeze(0).squeeze(0))
+        ids_per_audio = [
+            ids.to(torch.long) + self.audio_token_offset for ids in ids_per_audio
+        ]
+        lengths = [ids.shape[0] for ids in ids_per_audio]
+        all_embeds = self.language_model.embed_input_ids(torch.cat(ids_per_audio))
         return list(all_embeds.split(lengths))
+
+    def _parse_and_validate_image_input(
+        self, **kwargs: object
+    ) -> Apertus1p5ImageInputs | None:
+        pixel_values = kwargs.pop("pixel_values", None)
+        if pixel_values is None:
+            return None
+
+        return Apertus1p5ImageInputs(
+            type="pixel_values",
+            pixel_values=pixel_values,
+        )
+
+    def _parse_and_validate_audio_input(
+        self, **kwargs: object
+    ) -> Apertus1p5AudioInputs | None:
+        audio_values = kwargs.pop("audio_values", None)
+        if audio_values is None:
+            return None
+
+        return Apertus1p5AudioInputs(
+            type="audio_values",
+            audio_values=audio_values,
+        )
+
+    def _parse_and_validate_multimodal_inputs(self, **kwargs: object) -> dict:
+        modalities: dict[str, Any] = {}
+
+        # Preserve the order of modalities when images and audio are interleaved.
+        for input_key in kwargs:
+            if input_key == "pixel_values" and "images" not in modalities:
+                image_input = self._parse_and_validate_image_input(**kwargs)
+                assert image_input is not None
+                modalities["images"] = image_input
+            if input_key == "audio_values" and "audios" not in modalities:
+                audio_input = self._parse_and_validate_audio_input(**kwargs)
+                assert audio_input is not None
+                modalities["audios"] = audio_input
+
+        return modalities
 
     def embed_multimodal(
         self,
         **kwargs: object,
     ) -> MultiModalEmbeddings:
         """Encode all modality batches into language embeddings."""
-        try:
-            device = next(self.parameters()).device
-        except StopIteration:
-            device = torch.device("cuda")
-
+        modalities = self._parse_and_validate_multimodal_inputs(**kwargs)
         multimodal_embeddings: list[torch.Tensor] = []
 
-        for input_key in kwargs:
-            if input_key == "pixel_values":
-                pixel_values = kwargs[input_key]
-                if pixel_values is not None and self.vision_tower is not None:
-                    image_embeds = self._process_modality_input(
-                        pixel_values,  # type: ignore
-                        self._encode_image_to_llm_ids,
-                        device,
-                    )
-                    multimodal_embeddings.extend(image_embeds)
-            elif input_key == "audio_values":
-                audio_values = kwargs[input_key]
-                if audio_values is not None and self.audio_tower is not None:
-                    audio_embeds = self._process_modality_input(
-                        audio_values,  # type: ignore
-                        self._encode_audio_to_llm_ids,
-                        device,
-                    )
-                    multimodal_embeddings.extend(audio_embeds)
+        for modality in modalities:
+            if modality == "images" and self.vision_tower is not None:
+                image_input = modalities["images"]
+                image_embeds = self._encode_image_to_llm(image_input)
+                multimodal_embeddings.extend(image_embeds)
+            if modality == "audios" and self.audio_tower is not None:
+                audio_input = modalities["audios"]
+                audio_embeds = self._encode_audio_to_llm(audio_input)
+                multimodal_embeddings.extend(audio_embeds)
 
         return multimodal_embeddings
 

--- a/vllm/model_executor/models/apertus_mm.py
+++ b/vllm/model_executor/models/apertus_mm.py
@@ -9,36 +9,36 @@ from typing import Annotated, Any, Literal
 import torch
 import torch.nn.functional as F
 from transformers import (
+    Apertus1p5Config,
+    Apertus1p5ImageProcessor,
+    Apertus1p5Processor,
     Apertus1p5VisionTokenizerModel,
     AutoConfig,
     AutoModel,
+    BatchFeature,
     PretrainedConfig,
 )
+from transformers.models.wavtokenizer import WavTokenizerFeatureExtractor
 
 from vllm.config import VllmConfig
 from vllm.config.multimodal import BaseDummyOptions
 from vllm.distributed import get_pp_group
-from vllm.inputs import MultiModalDataDict, MultiModalInput, mm_input
+from vllm.inputs import MultiModalDataDict
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.inputs import (
     MultiModalFieldConfig,
     MultiModalKwargsItems,
-    PlaceholderRange,
 )
-from vllm.multimodal.parse import (
-    AudioProcessorItems,
-    ImageProcessorItems,
-    MultiModalDataParser,
-)
+from vllm.multimodal.parse import MultiModalDataItems, MultiModalDataParser
 from vllm.multimodal.processing import (
     BaseDummyInputsBuilder,
     BaseMultiModalProcessor,
     BaseProcessingInfo,
-    ProcessorInputs,
+    PromptReplacement,
     PromptUpdate,
-    TimingContext,
+    PromptUpdateDetails,
 )
 from vllm.sequence import IntermediateTensors
 from vllm.utils.tensor_schema import TensorSchema, TensorShape
@@ -65,20 +65,12 @@ _MAX_AUDIO_SECONDS = 300
 _AUDIO_TOKEN_BUDGET_OVERHEAD = 4
 
 _DEFAULT_IMAGE_PLACEHOLDER = "<|image|>"
-_DEFAULT_BOI_TOKEN = "<|img_start|>"
-_DEFAULT_EOI_TOKEN = "<|img_end|>"
 _DEFAULT_AUDIO_PLACEHOLDER = "<|audio|>"
-_DEFAULT_AUDIO_START_TOKEN = "<|audio_start|>"
-_DEFAULT_AUDIO_END_TOKEN = "<|audio_end|>"
 
 _DEFAULT_IMAGE_TOKEN_ID = 131079
 _DEFAULT_AUDIO_TOKEN_ID = 131085
 _DEFAULT_IMAGE_TOKEN_OFFSET = 131272
 _DEFAULT_AUDIO_TOKEN_OFFSET = 262344
-_DEFAULT_IMAGE_START_TOKEN_ID = 131073
-_DEFAULT_IMAGE_END_TOKEN_ID = 131074
-_DEFAULT_AUDIO_START_TOKEN_ID = 131080
-_DEFAULT_AUDIO_END_TOKEN_ID = 131081
 
 
 class Apertus1p5ImageInputs(TensorSchema):
@@ -124,8 +116,26 @@ def _init_component_model(
 
 
 class Apertus1p5ProcessingInfo(BaseProcessingInfo):
+    def get_hf_config(self) -> Apertus1p5Config:
+        return self.ctx.get_hf_config(Apertus1p5Config)
+
+    def get_hf_processor(self, **kwargs: object) -> Apertus1p5Processor:
+        return self.ctx.get_hf_processor(Apertus1p5Processor, **kwargs)
+
+    def get_image_processor(self, **kwargs: object) -> Apertus1p5ImageProcessor:
+        hf_processor = self.get_hf_processor(**kwargs)
+        image_processor = hf_processor.image_processor
+        assert isinstance(image_processor, Apertus1p5ImageProcessor)
+        return image_processor
+
+    def get_feature_extractor(self, **kwargs: object) -> WavTokenizerFeatureExtractor:
+        hf_processor = self.get_hf_processor(**kwargs)
+        feature_extractor = hf_processor.feature_extractor
+        assert isinstance(feature_extractor, WavTokenizerFeatureExtractor)
+        return feature_extractor
+
     def get_data_parser(self) -> MultiModalDataParser:
-        audio_feature_extractor = self.get_hf_processor().feature_extractor
+        audio_feature_extractor = self.get_feature_extractor()
         return MultiModalDataParser(
             target_sr=audio_feature_extractor.sampling_rate,
             target_channels=1,
@@ -153,9 +163,8 @@ class Apertus1p5ProcessingInfo(BaseProcessingInfo):
         mm_counts: Mapping[str, int],
     ) -> Mapping[str, int] | None:
         del mm_counts
-        processor = self.get_hf_processor()
-        image_processor = processor.image_processor
-        feature_extractor = processor.feature_extractor
+        image_processor = self.get_image_processor()
+        feature_extractor = self.get_feature_extractor()
         return {
             # Maximum image codes plus room for the image layout's wrapper
             # and row-separator tokens.
@@ -199,8 +208,9 @@ class Apertus1p5DummyInputsBuilder(BaseDummyInputsBuilder[Apertus1p5ProcessingIn
     ) -> MultiModalDataDict:
         image_overrides = mm_options.get("image")
         audio_overrides = mm_options.get("audio")
-        processor = self.info.get_hf_processor()
-        max_image_side = isqrt(processor.image_processor.max_pixels)
+        image_processor = self.info.get_image_processor()
+        feature_extractor = self.info.get_feature_extractor()
+        max_image_side = isqrt(image_processor.max_pixels)
 
         return {
             "image": self._get_dummy_images(
@@ -210,7 +220,7 @@ class Apertus1p5DummyInputsBuilder(BaseDummyInputsBuilder[Apertus1p5ProcessingIn
                 overrides=image_overrides,
             ),
             "audio": self._get_dummy_audios(
-                length=processor.feature_extractor.sampling_rate * _MAX_AUDIO_SECONDS,
+                length=feature_extractor.sampling_rate * _MAX_AUDIO_SECONDS,
                 num_audios=mm_counts.get("audio", 0),
                 overrides=audio_overrides,
             ),
@@ -228,33 +238,28 @@ class Apertus1p5MultiModalProcessor(BaseMultiModalProcessor[Apertus1p5Processing
         cache: object | None = None,
     ) -> None:
         super().__init__(info, dummy_inputs, cache=cache)
-        tokenizer = info.get_tokenizer()
-        self.hf_processor = info.get_hf_processor()
         config = info.get_hf_config()
         self.image_token_id = getattr(config, "image_token_id", _DEFAULT_IMAGE_TOKEN_ID)
         self.audio_token_id = getattr(config, "audio_token_id", _DEFAULT_AUDIO_TOKEN_ID)
-        self.image_start_token = getattr(tokenizer, "boi_token", _DEFAULT_BOI_TOKEN)
-        self.image_end_token = getattr(tokenizer, "eoi_token", _DEFAULT_EOI_TOKEN)
-        self.audio_start_token = getattr(
-            tokenizer, "boa_token", _DEFAULT_AUDIO_START_TOKEN
-        )
-        self.audio_end_token = getattr(tokenizer, "eoa_token", _DEFAULT_AUDIO_END_TOKEN)
-        self.image_start_token_id = getattr(
-            tokenizer, "boi_token_id", _DEFAULT_IMAGE_START_TOKEN_ID
-        )
-        self.image_end_token_id = getattr(
-            tokenizer, "eoi_token_id", _DEFAULT_IMAGE_END_TOKEN_ID
-        )
-        self.audio_start_token_id = getattr(
-            tokenizer, "boa_token_id", _DEFAULT_AUDIO_START_TOKEN_ID
-        )
-        self.audio_end_token_id = getattr(
-            tokenizer, "eoa_token_id", _DEFAULT_AUDIO_END_TOKEN_ID
-        )
+
+    def _apply_hf_processor_tokens_only(
+        self,
+        prompt_tokens: list[int],
+    ) -> list[int]:
+        tokenizer = self.info.get_tokenizer()
+        bos_token_id = tokenizer.bos_token_id
+
+        # Keep raw token prompts aligned with HF's text-processing path.
+        if bos_token_id is not None and (
+            not prompt_tokens or prompt_tokens[0] != bos_token_id
+        ):
+            return [bos_token_id, *prompt_tokens]
+
+        return prompt_tokens
 
     def _get_mm_fields_config(
         self,
-        hf_inputs: object,
+        hf_inputs: BatchFeature,
         hf_processor_mm_kwargs: Mapping[str, object],
     ) -> Mapping[str, MultiModalFieldConfig]:
         """Routes per-item tensors to the GPU Worker's embed_multimodal kwargs."""
@@ -263,152 +268,122 @@ class Apertus1p5MultiModalProcessor(BaseMultiModalProcessor[Apertus1p5Processing
             "audio_values": MultiModalFieldConfig.batched("audio"),
         }
 
-    def _get_prompt_updates(self, *args: Any, **kwargs: Any) -> Sequence[PromptUpdate]:
-        return []
-
-    def apply(
-        self, inputs: ProcessorInputs, timing_ctx: TimingContext
-    ) -> MultiModalInput:
+    def _get_prompt_updates(
+        self,
+        mm_items: MultiModalDataItems,
+        hf_processor_mm_kwargs: Mapping[str, object],
+        out_mm_kwargs: MultiModalKwargsItems,
+    ) -> Sequence[PromptUpdate]:
+        del mm_items
+        processor = self.info.get_hf_processor(**hf_processor_mm_kwargs)
+        image_processor = self.info.get_image_processor(**hf_processor_mm_kwargs)
+        feature_extractor = self.info.get_feature_extractor(**hf_processor_mm_kwargs)
         tokenizer = self.info.get_tokenizer()
-        prompt_text = (
-            inputs.prompt
-            if isinstance(inputs.prompt, str)
-            else tokenizer.decode(inputs.prompt)
-        )
 
-        tokenization_kwargs = dict(inputs.tokenization_kwargs)
-        if not isinstance(inputs.prompt, str):
-            # A template-rendered prompt already starts with BOS. Otherwise,
-            # restore the BOS added before token IDs were decoded to text.
-            tokenization_kwargs.setdefault(
-                "add_special_tokens",
-                not (
-                    bool(inputs.prompt) and inputs.prompt[0] == tokenizer.bos_token_id
-                ),
-            )
-
-        num_images = inputs.mm_data_items.get_count("image", strict=False)
-        num_audios = inputs.mm_data_items.get_count("audio", strict=False)
-
-        images = (
-            inputs.mm_data_items.get_items("image", ImageProcessorItems).get_all()
-            if num_images > 0
-            else None
-        )
-        audios = (
-            inputs.mm_data_items.get_items("audio", AudioProcessorItems).get_all()
-            if num_audios > 0
-            else None
-        )
-
-        mm_kwargs: dict[str, torch.Tensor | list[torch.Tensor]] = {}
-
-        with timing_ctx.record("preprocess_apertus"):
-            hf_outputs = self.hf_processor(
-                text=prompt_text,
-                images=images,
-                audio=audios,
-                padding=True,
-                return_tensors="pt",
-                **tokenization_kwargs,
-            )
-            prompt_token_ids = hf_outputs["input_ids"][0].tolist()
-
-        if num_images > 0:
-            # Hugging Face pads images in a multimodal batch to a common size.
-            # Crop each item back to its reported dimensions before encoding it.
-            pixel_values = [
-                image[:, : int(height), : int(width)].contiguous()
-                for image, (height, width) in zip(
-                    hf_outputs["pixel_values"],
-                    hf_outputs["image_sizes"],
-                )
+        def get_image_replacement(item_idx: int) -> PromptUpdateDetails:
+            pixel_values = out_mm_kwargs["image"][item_idx]["pixel_values"].data
+            assert isinstance(pixel_values, torch.Tensor)
+            height, width = pixel_values.shape[-2:]
+            # Pixels were cropped to HF's per-image size before reaching here.
+            image_grids = [
+                [
+                    height // image_processor.spatial_factor,
+                    width // image_processor.spatial_factor,
+                ]
             ]
-            mm_kwargs["pixel_values"] = pixel_values
-
-        if num_audios > 0:
-            # Apertus1p5 input-processor pads audio features in a multimodal
-            # batch to a common length. Remove that padding with each item's
-            # attention mask.
-            audio_values = [
-                audio[0, : int(mask.sum())].contiguous()
-                for audio, mask in zip(
-                    hf_outputs["input_features"],
-                    hf_outputs["feature_attention_mask"],
-                )
-            ]
-            mm_kwargs["audio_values"] = audio_values
-
-        # Each placeholder range marks the token positions replaced by embeddings.
-        with timing_ctx.record("get_mm_hashes"):
-            mm_hashes = inputs.get_mm_hashes(self.info.model_id)
-
-        def _span_ranges(
-            start_token: str,
-            start_id: int,
-            end_token: str,
-            end_id: int,
-            embed_token_id: int,
-            count: int,
-        ) -> list[PlaceholderRange]:
-            """Locate processor-created multimodal spans and embedding slots.
-
-            The Apertus1p5 input-processor from transformers expands images into
-            ``<|img_start|>H*W<|img_token_start|><|image|>...<|img_end|>``
-            and audio into ``<|audio_start|><|audio|>...<|audio_end|>``.
-            For each item, find the next complete range after the previous
-            one and mark its ``<|image|>`` or ``<|audio|>`` positions for
-            replacement with the corresponding encoded embeddings.
-            """
-            ranges: list[PlaceholderRange] = []
-            pos = 0
-            for _ in range(count):
-                try:
-                    s = prompt_token_ids.index(start_id, pos)
-                    e = prompt_token_ids.index(end_id, s)
-                except ValueError as exc:
-                    raise ValueError(
-                        f"Apertus MM: {start_token!r}/{end_token!r} pair not "
-                        f"found in prompt (search from {pos})"
-                    ) from exc
-                span = prompt_token_ids[s : e + 1]
-                is_embed = torch.tensor(
-                    [tok == embed_token_id for tok in span], dtype=torch.bool
-                )
-                ranges.append(
-                    PlaceholderRange(offset=s, length=e - s + 1, is_embed=is_embed)
-                )
-                pos = e + 1
-            return ranges
-
-        mm_placeholders: dict[str, list[PlaceholderRange]] = {}
-        if num_images > 0:
-            mm_placeholders["image"] = _span_ranges(
-                self.image_start_token,
-                self.image_start_token_id,
-                self.image_end_token,
-                self.image_end_token_id,
-                self.image_token_id,
-                num_images,
+            image_replacement = processor.replace_image_token(
+                {"image_grids": image_grids}, 0
             )
-        if num_audios > 0:
-            mm_placeholders["audio"] = _span_ranges(
-                self.audio_start_token,
-                self.audio_start_token_id,
-                self.audio_end_token,
-                self.audio_end_token_id,
-                self.audio_token_id,
-                num_audios,
-            )
+            image_ids = tokenizer.encode(image_replacement, add_special_tokens=False)
 
-        return mm_input(
-            prompt_token_ids=prompt_token_ids,
-            mm_kwargs=MultiModalKwargsItems.from_hf_inputs(
-                mm_kwargs, self._get_mm_fields_config(mm_kwargs, {})
+            return PromptUpdateDetails.select_token_id(image_ids, self.image_token_id)
+
+        def get_audio_replacement(item_idx: int) -> PromptUpdateDetails:
+            audio_values = out_mm_kwargs["audio"][item_idx]["audio_values"].data
+            assert isinstance(audio_values, torch.Tensor)
+            # Use HF's code-count calculation so cache replay follows HF exactly.
+            num_audio_codes = feature_extractor.get_num_audio_codes(
+                audio_values.shape[-1]
+            )
+            audio_replacement = processor.replace_audio_token(
+                {"num_audio_codes": [num_audio_codes]}, 0
+            )
+            audio_ids = tokenizer.encode(audio_replacement, add_special_tokens=False)
+
+            return PromptUpdateDetails.select_token_id(audio_ids, self.audio_token_id)
+
+        return [
+            PromptReplacement(
+                modality="image",
+                target=[self.image_token_id],
+                replacement=get_image_replacement,
             ),
-            mm_hashes=mm_hashes,
-            mm_placeholders=mm_placeholders,
+            PromptReplacement(
+                modality="audio",
+                target=[self.audio_token_id],
+                replacement=get_audio_replacement,
+            ),
+        ]
+
+    def _call_hf_processor(
+        self,
+        prompt: str,
+        mm_data: Mapping[str, object],
+        mm_kwargs: Mapping[str, object],
+        tok_kwargs: Mapping[str, object],
+    ) -> BatchFeature:
+        if not mm_data.get("images", []) and not mm_data.get("audios", []):
+            # Apertus HF rejects raw MM markers without their media. The cache's
+            # text-only pass needs those raw markers so BaseMultiModalProcessor
+            # can apply the cached PromptReplacement entries itself.
+            tokenizer = self.info.get_tokenizer()
+            prompt_ids = tokenizer.encode(
+                prompt,
+                add_special_tokens=tok_kwargs.get("add_special_tokens", True),
+            )
+            prompt_ids = self._apply_hf_processor_tokens_only(prompt_ids)
+            return BatchFeature(dict(input_ids=[prompt_ids]), tensor_type="pt")
+
+        item_processor_data = dict(mm_data)
+        audios = item_processor_data.pop("audios", [])
+        if audios:
+            # MultiModalDataItems uses the plural modality key; HF uses audio.
+            item_processor_data["audio"] = audios
+            feature_extractor = self.info.get_feature_extractor(**mm_kwargs)
+            mm_kwargs = dict(
+                **mm_kwargs,
+                sampling_rate=feature_extractor.sampling_rate,
+            )
+
+        processed_outputs = super()._call_hf_processor(
+            prompt=prompt,
+            mm_data=item_processor_data,
+            mm_kwargs=mm_kwargs,
+            tok_kwargs={**tok_kwargs, "padding": True},
         )
+
+        if "pixel_values" in processed_outputs:
+            pixel_values = processed_outputs["pixel_values"]
+            image_sizes = processed_outputs["image_sizes"]
+            assert isinstance(image_sizes, torch.Tensor)
+            # Apertus1p5 input-processor pads images to a common request size.
+            # Cache each image without that request-dependent padding.
+            processed_outputs["pixel_values"] = [
+                image[:, : int(height), : int(width)].contiguous()
+                for image, (height, width) in zip(pixel_values, image_sizes)
+            ]
+
+        if "input_features" in processed_outputs:
+            input_features = processed_outputs["input_features"]
+            attention_mask = processed_outputs["feature_attention_mask"]
+            # Apertus1p5 input-processor pads audio to a common request size.
+            # Cache each feature without that request-dependent padding.
+            processed_outputs["audio_values"] = [
+                audio[0, : int(mask.sum())].contiguous()
+                for audio, mask in zip(input_features, attention_mask)
+            ]
+
+        return processed_outputs
 
 
 @MULTIMODAL_REGISTRY.register_processor(

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -344,6 +344,10 @@ _SEQUENCE_CLASSIFICATION_MODELS = {
 
 _MULTIMODAL_MODELS = {
     # [Decoder-only]
+    "Apertus1p5ForConditionalGeneration": (
+        "apertus_mm",
+        "Apertus1p5ForConditionalGeneration",
+    ),
     "AriaForConditionalGeneration": ("aria", "AriaForConditionalGeneration"),
     "AudioFlamingo3ForConditionalGeneration": (
         "audioflamingo3",

--- a/vllm/reasoning/__init__.py
+++ b/vllm/reasoning/__init__.py
@@ -20,6 +20,10 @@ Example:
 
 
 _REASONING_PARSERS_TO_REGISTER = {
+    "apertus": (
+        "apertus_reasoning_parser",
+        "ApertusReasoningParser",
+    ),
     "deepseek_r1": (  # name
         "deepseek_r1_reasoning_parser",  # filename
         "DeepSeekR1ReasoningParser",  # class_name

--- a/vllm/reasoning/apertus_reasoning_parser.py
+++ b/vllm/reasoning/apertus_reasoning_parser.py
@@ -2,13 +2,12 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Reasoning parser for Apertus models.
 
-Apertus wraps its thinking between a start/end pair of special tokens. The
-canonical pair is ``<|inner_prefix|>``/``<|inner_suffix|>``, but some tokenizer
-builds register ``<think>``/``</think>`` at the emitted ids instead. The parser
-selects whichever pair the loaded tokenizer exposes at the lower start-token id.
+Apertus wraps its thinking between ``<|inner_prefix|>`` and ``<|inner_suffix|>``.
+The tokenizer also rewrites ``<think>``/``</think>`` to that pair, but only
+through its ``normalizer``, which runs on the encode path; the emitted ids always
+detokenize to ``<|inner_*|>``, so only that pair delimits generated reasoning.
 """
 
-from functools import cached_property
 from typing import TYPE_CHECKING
 
 from vllm.reasoning.basic_parsers import BaseThinkingReasoningParser
@@ -17,33 +16,17 @@ if TYPE_CHECKING:
     from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
     from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 
-# Candidate (start, end) delimiter pairs, in fallback order.
-_CANDIDATE_PAIRS = (
-    ("<|inner_prefix|>", "<|inner_suffix|>"),
-    ("<think>", "</think>"),
-)
-
 
 class ApertusReasoningParser(BaseThinkingReasoningParser):
     """Reasoning parser for the Apertus thinking block."""
 
-    @cached_property
-    def _pair(self) -> tuple[str, str]:
-        vocab = self.vocab
-        present = sorted(
-            (vocab[start], start, end)
-            for start, end in _CANDIDATE_PAIRS
-            if start in vocab and end in vocab
-        )
-        return (present[0][1], present[0][2]) if present else _CANDIDATE_PAIRS[0]
-
     @property
     def start_token(self) -> str:
-        return self._pair[0]
+        return "<|inner_prefix|>"
 
     @property
     def end_token(self) -> str:
-        return self._pair[1]
+        return "<|inner_suffix|>"
 
     def extract_reasoning(
         self, model_output: str, request: "ChatCompletionRequest | ResponsesRequest"

--- a/vllm/reasoning/apertus_reasoning_parser.py
+++ b/vllm/reasoning/apertus_reasoning_parser.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Reasoning parser for Apertus models.
+
+Apertus wraps its thinking between a start/end pair of special tokens. The
+canonical pair is ``<|inner_prefix|>``/``<|inner_suffix|>``, but some tokenizer
+builds register ``<think>``/``</think>`` at the emitted ids instead. The parser
+selects whichever pair the loaded tokenizer exposes at the lower start-token id.
+"""
+
+from functools import cached_property
+from typing import TYPE_CHECKING
+
+from vllm.reasoning.basic_parsers import BaseThinkingReasoningParser
+
+if TYPE_CHECKING:
+    from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+    from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+
+# Candidate (start, end) delimiter pairs, in fallback order.
+_CANDIDATE_PAIRS = (
+    ("<|inner_prefix|>", "<|inner_suffix|>"),
+    ("<think>", "</think>"),
+)
+
+
+class ApertusReasoningParser(BaseThinkingReasoningParser):
+    """Reasoning parser for the Apertus thinking block."""
+
+    @cached_property
+    def _pair(self) -> tuple[str, str]:
+        vocab = self.vocab
+        present = sorted(
+            (vocab[start], start, end)
+            for start, end in _CANDIDATE_PAIRS
+            if start in vocab and end in vocab
+        )
+        return (present[0][1], present[0][2]) if present else _CANDIDATE_PAIRS[0]
+
+    @property
+    def start_token(self) -> str:
+        return self._pair[0]
+
+    @property
+    def end_token(self) -> str:
+        return self._pair[1]
+
+    def extract_reasoning(
+        self, model_output: str, request: "ChatCompletionRequest | ResponsesRequest"
+    ) -> tuple[str | None, str | None]:
+        # With no thinking block at all (direct tool call or plain answer),
+        # the base class would label the whole output as reasoning, hiding tool
+        # calls from the tool parser. Return it as content instead.
+        if self.start_token not in model_output and self.end_token not in model_output:
+            return None, model_output
+        return super().extract_reasoning(model_output, request)


### PR DESCRIPTION
## General Information

  This change enables support for serving Apertus v1.5 multimodal (hf tags apertus-ai/Apertus-v1.5-8B,  apertus-ai/Apertus-v1.5-70B) 

  Special thanks to @blancsw  for creating a workable refactor  from https://github.com/swiss-ai/vllm/tree/apertus_integration that optimizes the multimodal inference pipeline and provides a foundation for future integration. Also, special thanks to @tomas-polach for the bug-fix contribution, @AryanAhadinia for the reasoning parser, and @robmsmt for the double BOS-token fix.

This PR depends on transformers [PR](https://github.com/huggingface/transformers/pull/47662).

  ## Test Plan

```
  vllm serve apertus-ai/Apertus-v1.5-70B \
    --max-model-len 100000 \
    --tensor-parallel-size 4 \
    --enable-chunked-prefill \
    --async-scheduling \
    --enable-prefix-caching \
    --max-num-seqs 128 \
    --max-num-batched-tokens 65536 \
    --block-size 16 \
    --enable-auto-tool-choice \
    --tool-call-parser apertus \
    --reasoning-parser apertus \
    --chat-template-content-format string
 ```   
 
 ## Tests added

Audio tests were not added because default sample rate supported is 16Khz and Apertus 1.5 works with 24Khz hence leading to test failures. and multiple audio case does not exist.

```
XDG_CACHE_HOME=/tmp/vllm-test-cache /opt/venv/bin/python -m pytest \
    tests/models/multimodal/processing/test_common.py \
    -k 'Apertus-v1.5-8B' -v

 XDG_CACHE_HOME=/tmp/vllm-test-cache /opt/venv/bin/python -m pytest \
    tests/models/multimodal/generation/test_common.py \
    -k apertus_1p5 -v
```
