### PR TITLE
[Compressed-Tensors] Support Kimi-K3 quantized models

### DIFF
--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -951,7 +951,13 @@ class KimiDecoderLayer(nn.Module):
         return hidden_states, prefix_sum, residual
 
 
-class KimiLinearModel(nn.Module, EagleModelMixin):
+class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
+    packed_modules_mapping = {
+        "gate_up_proj": ["gate_proj", "up_proj"],
+        "in_proj_qkvgfab": ["q_proj", "k_proj", "v_proj", "b_proj", "f_a_proj"],
+        "conv1d": ["q_conv1d", "k_conv1d", "v_conv1d"],
+    }
+
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
 
@@ -1221,6 +1227,12 @@ class KimiLinearModel(nn.Module, EagleModelMixin):
         else:
             expert_params_mapping = []
         params_dict = dict(self.named_parameters())
+        # if is_global_first_rank():
+        #     import json
+        #     with open("params_dict", "w") as file:
+        #         json.dump(list(params_dict.keys()), file)
+        #     print("wrote file")
+
         # Under the MXFP4 quant interface the routed experts register unpacked
         # params (``w13_weight``), while the compressed-tensors checkpoint names
         # them ``.weight_packed``. Rebind so the expert mapping resolves; scales

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -1227,11 +1227,6 @@ class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
         else:
             expert_params_mapping = []
         params_dict = dict(self.named_parameters())
-        # if is_global_first_rank():
-        #     import json
-        #     with open("params_dict", "w") as file:
-        #         json.dump(list(params_dict.keys()), file)
-        #     print("wrote file")
 
         # Under the MXFP4 quant interface the routed experts register unpacked
         # params (``w13_weight``), while the compressed-tensors checkpoint names


### PR DESCRIPTION
## Purpose ##
* Support CT configs for Kimi-K3

## Changes ##
* Add `SupportsQuant` and `packed_modules_mapping` to `KimiLinearModel`. `SupportsQuant` reads the `packed_modules_mapping` and updates the quantization config accordingly so that fused modules (fused gate up modules of shared expert) are properly ignored.

## Testing ##
* Validated serve and eval against `RedHatAI/Kimi-K3-NVFP4`
* Validated serve and sanity against `moonshotai/Kimi-K3`