### PR TITLE
[Bugfix][Frontend] Enforce parallel_tool_calls=false in the required-tool grammar

### DIFF
--- a/tests/tool_use/test_tool_choice_required.py
+++ b/tests/tool_use/test_tool_choice_required.py
@@ -9,6 +9,8 @@ from openai.types.responses import FunctionTool, WebSearchTool
 from pydantic import TypeAdapter
 
 from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionNamedFunction,
+    ChatCompletionNamedToolChoiceParam,
     ChatCompletionToolsParam,
 )
 from vllm.tool_parsers.streaming import extract_required_tool_call_streaming
@@ -68,11 +70,18 @@ EXAMPLE_TOOLS = [
 
 
 def _compile_and_check(
-    tools: list[ChatCompletionToolsParam], sample_output, should_match: bool
+    tools: list[ChatCompletionToolsParam],
+    sample_output,
+    should_match: bool,
+    parallel_tool_calls: bool | None = None,
 ):
     # self = MagicMock(tool_choice="required", tools=tools)
     # schema = ChatCompletionRequest._get_json_schema_from_tool(self)
-    schema = get_json_schema_from_tools(tools=tools, tool_choice="required")
+    schema = get_json_schema_from_tools(
+        tools=tools,
+        tool_choice="required",
+        parallel_tool_calls=parallel_tool_calls,
+    )
     assert isinstance(schema, dict)
 
     # use build_regex_from_schema used in JSONLogitsProcessor to create Guide
@@ -394,3 +403,57 @@ class TestNonFunctionToolsSkipped:
         any_of = schema["items"]["anyOf"]
         assert len(any_of) == 1
         assert any_of[0]["properties"]["name"]["enum"] == ["get_weather"]
+
+
+class TestParallelToolCallsConstraint:
+    """`parallel_tool_calls=false` must be enforced by the decoding grammar.
+
+    Without a `maxItems` bound the model is free to emit an unbounded run of
+    tool calls that are only discarded afterwards, wasting the token budget and
+    risking truncation of the one call the client actually receives."""
+
+    TOOLS = TypeAdapter(list[ChatCompletionToolsParam]).validate_python(EXAMPLE_TOOLS)
+    ONE_CALL = [{"name": "get_current_weather", "parameters": {"city": "Vienna"}}]
+    TWO_CALLS = [
+        {"name": "get_current_weather", "parameters": {"city": "Vienna"}},
+        {"name": "get_current_weather", "parameters": {"city": "Berlin"}},
+    ]
+
+    def test_disabled_rejects_a_second_tool_call(self):
+        _compile_and_check(self.TOOLS, self.ONE_CALL, True, parallel_tool_calls=False)
+        _compile_and_check(self.TOOLS, self.TWO_CALLS, False, parallel_tool_calls=False)
+
+    @pytest.mark.parametrize("parallel_tool_calls", [True, None])
+    def test_enabled_or_unset_still_allows_multiple(self, parallel_tool_calls):
+        _compile_and_check(
+            self.TOOLS,
+            self.TWO_CALLS,
+            True,
+            parallel_tool_calls=parallel_tool_calls,
+        )
+
+    @pytest.mark.parametrize(
+        "parallel_tool_calls,expected",
+        [(False, 1), (True, None), (None, None)],
+    )
+    def test_max_items_bound(self, parallel_tool_calls, expected):
+        schema = get_json_schema_from_tools(
+            tools=self.TOOLS,
+            tool_choice="required",
+            parallel_tool_calls=parallel_tool_calls,
+        )
+        assert isinstance(schema, dict)
+        assert schema["minItems"] == 1
+        assert schema.get("maxItems") == expected
+
+    def test_forced_named_tool_is_unaffected(self):
+        # Named tool choice yields a bare parameters object, never an array.
+        schema = get_json_schema_from_tools(
+            tools=self.TOOLS,
+            tool_choice=ChatCompletionNamedToolChoiceParam(
+                function=ChatCompletionNamedFunction(name="get_current_weather")
+            ),
+            parallel_tool_calls=False,
+        )
+        assert isinstance(schema, dict)
+        assert "maxItems" not in schema

--- a/vllm/tool_parsers/abstract_tool_parser.py
+++ b/vllm/tool_parsers/abstract_tool_parser.py
@@ -135,7 +135,9 @@ class ToolParser:
             return request
 
         json_schema_from_tool = get_json_schema_from_tools(
-            tool_choice=request.tool_choice, tools=request.tools
+            tool_choice=request.tool_choice,
+            tools=request.tools,
+            parallel_tool_calls=getattr(request, "parallel_tool_calls", None),
         )
         # Set structured output params for tool calling
         if json_schema_from_tool is not None:

--- a/vllm/tool_parsers/utils.py
+++ b/vllm/tool_parsers/utils.py
@@ -349,6 +349,7 @@ def _get_tool_schema_defs(
 
 def _get_json_schema_from_tools(
     tools: list[Tool],
+    parallel_tool_calls: bool | None = None,
 ) -> dict:
     fn_tool_schemas: list[dict[str, Any]] = []
     fn_tools: list[Tool] = []
@@ -363,7 +364,7 @@ def _get_json_schema_from_tools(
         elif _is_function_tool(tool):
             fn_tool_schemas.append(_get_tool_schema_from_tool(tool))
             fn_tools.append(tool)
-    json_schema = {
+    json_schema: dict[str, Any] = {
         "type": "array",
         "minItems": 1,
         "items": {
@@ -371,6 +372,10 @@ def _get_json_schema_from_tools(
             "anyOf": fn_tool_schemas,
         },
     }
+    # Only an explicit `false` opts out of parallel tool calls; `None` means the
+    # field was never set and the default (true) applies.
+    if parallel_tool_calls is False:
+        json_schema["maxItems"] = 1
     json_schema_defs = _get_tool_schema_defs(fn_tools)
     if json_schema_defs:
         json_schema["$defs"] = json_schema_defs
@@ -380,6 +385,7 @@ def _get_json_schema_from_tools(
 def get_json_schema_from_tools(
     tool_choice: str | ToolChoiceFunction | ChatCompletionNamedToolChoiceParam,
     tools: list[Tool] | None,
+    parallel_tool_calls: bool | None = None,
 ) -> str | dict | None:
     # tool_choice: "none"
     if tool_choice in ("none", None) or tools is None:
@@ -415,7 +421,7 @@ def get_json_schema_from_tools(
         return chat_tool_map[tool_name].function.parameters
     # tool_choice: "required"
     if tool_choice == "required":
-        return _get_json_schema_from_tools(tools)
+        return _get_json_schema_from_tools(tools, parallel_tool_calls)
     # tool_choice: "auto"
     return None
 


### PR DESCRIPTION
## Purpose

With `tool_choice="required"`, the structured-output schema built in
`_get_json_schema_from_tools` (`vllm/tool_parsers/utils.py`) is an array with `minItems: 1` and **no
upper bound**, and `parallel_tool_calls` is never consulted — `adjust_request`
(`vllm/tool_parsers/abstract_tool_parser.py`) only passes `tool_choice` and `tools`.

So a client that explicitly sends `parallel_tool_calls: false` still gets a grammar that permits an
unbounded run of tool calls. vLLM lets the model generate them and then discards all but the first
*after the fact*, in `maybe_filter_parallel_tool_calls`
(`vllm/entrypoints/serve/utils/tool_calls_utils.py`). Consequences:

- Token budget and latency are spent on calls that are thrown away.
- If the model keeps going until `max_tokens`, `finish_reason` is `"length"` rather than
  `"tool_calls"`.
- Worst case, the budget runs out while the **first** call's arguments are still being emitted, so
  the one tool call the client actually receives is truncated into invalid JSON.

The client asked for at most one tool call; the decoding constraint should enforce that instead of
post-filtering.

### Fix

Thread `parallel_tool_calls` into `get_json_schema_from_tools` and set `"maxItems": 1` when it is
explicitly `False`, so the grammar itself stops after one tool call.

Only a literal `false` opts out — `None` means the field was never set and the default (true)
applies. This matches the convention already used by `maybe_filter_parallel_tool_calls`
(`if request.parallel_tool_calls is not False`), which was established deliberately in #44955
("Fix parallel_tool_calls: null treated as false instead of default true").

`maybe_filter_parallel_tool_calls` is left in place as a safety net for parsers that bypass the
generic grammar (e.g. those setting `supports_required_and_named`, cf. #50180).

Forced named tool choice is unaffected: those branches return a bare parameters object, never an
array.

### Backend compatibility

`maxItems` is supported by the structured-output backends.
`has_xgrammar_unsupported_json_features` (`vllm/v1/structured_output/backend_xgrammar.py`) rejects
only `uniqueItems`, `contains`, `minContains` and `maxContains` for arrays; `minItems` is already
relied on today by this same schema. `outlines_core` and llguidance both handle `maxItems`.

### Relationship to #50399

This is **related to** #50399, not a fix for it. That reporter used the default `parallel_tool_calls`
(true), where multiple tool calls are legal per the OpenAI spec and the observed looping is
model/template behaviour on GLM-5.2. This change does make `parallel_tool_calls: false` an effective
constraint-level mitigation for that class of runaway generation, and it closes a genuine
spec-compliance gap on its own merits.

### Not a duplicate

Checked before opening: no open PR touches `parallel_tool_calls` in the schema path, and no open PR
references #50399.

```console
$ curl -s "https://api.github.com/search/issues?q=repo:vllm-project/vllm+is:pr+is:open+parallel_tool_calls+maxItems"
total_count: 0
$ curl -s "https://api.github.com/search/issues?q=repo:vllm-project/vllm+is:pr+50399"
total_count: 0
```

## Test Plan

Extended the existing `tests/tool_use/test_tool_choice_required.py` (already
`pytestmark = pytest.mark.cpu_test`), reusing its `_compile_and_check` helper, which compiles the
generated schema to a regex via `outlines_core.json_schema.build_regex_from_schema` — the same path
used by the JSON logits processor. No new test file, no model or GPU required.

New `TestParallelToolCallsConstraint` covers:

- `parallel_tool_calls=False` → the compiled grammar matches a one-element array and **rejects** a
  two-element array.
- `parallel_tool_calls=True` / `None` → a two-element array still matches (guards against
  regressing default parallel tool calling).
- The `maxItems` bound is `1` / absent / absent for `False` / `True` / `None`, with `minItems` still
  `1` in all three.
- Forced named tool choice with `parallel_tool_calls=False` still yields a schema with no
  `maxItems`.

```bash
pytest -v tests/tool_use/test_tool_choice_required.py
pytest -v tests/tool_parsers/ tests/tool_use/test_gemma4_responses_adjust_request.py
pre-commit run --files vllm/tool_parsers/utils.py \
    vllm/tool_parsers/abstract_tool_parser.py \
    tests/tool_use/test_tool_choice_required.py
```

## Test Result

```console
$ pytest -q tests/tool_use/test_tool_choice_required.py
170 passed, 17 warnings in 27.98s
# 163 before this change + 7 new

$ pytest -q tests/tool_parsers/ tests/tool_use/test_gemma4_responses_adjust_request.py \
      tests/tool_use/test_tool_choice_required.py \
      --ignore=tests/tool_parsers/test_llama3_json_tool_parser.py
1085 passed, 3 skipped, 34 xfailed, 21 warnings in 591.22s (0:09:51)

$ pre-commit run --files vllm/tool_parsers/utils.py \
      vllm/tool_parsers/abstract_tool_parser.py \
      tests/tool_use/test_tool_choice_required.py
ruff check.......................................................Passed
ruff format......................................................Passed
typos............................................................Passed
Run mypy for Python 3.10.........................................Passed
Check SPDX headers...............................................Passed
Check for forbidden imports......................................Passed
```

`tests/tool_parsers/test_llama3_json_tool_parser.py` is excluded above because its fixtures download
a gated Llama tokenizer and error with HF `401 Unauthorized` in this environment. Verified
pre-existing: the same 15 setup errors occur on a clean checkout of `main` without this change.

### Negative control

To confirm the new tests actually catch the bug rather than passing vacuously, the `maxItems`
assignment was temporarily disabled and the suite re-run:

```console
$ pytest -q tests/tool_use/test_tool_choice_required.py -k ParallelToolCalls
>       assert matches == should_match
E       assert True == False
>       assert schema.get("maxItems") == expected
E       AssertionError: assert None == 1
FAILED ...::TestParallelToolCallsConstraint::test_disabled_rejects_a_second_tool_call
FAILED ...::TestParallelToolCallsConstraint::test_max_items_bound[False-1]
2 failed, 5 passed
```

Without the fix the grammar demonstrably **accepts** a second tool call under
`parallel_tool_calls: false`, which is the bug.

### Model evaluation

No model eval was run. This change alters generated output only when a request explicitly sets
`parallel_tool_calls: false`, and only by removing continuations from the decoding grammar — there is
no change to weights, kernels, sampling, or the default (`parallel_tool_calls` unset/true) path,
which is covered by the regression tests above. The behavioural claim is verified at the grammar
level in the negative control. A served end-to-end check against a tool-calling model would need GPU
hardware I do not have access to; happy to add e2e results if a maintainer considers them necessary.

---

**AI assistance disclosure:** this PR was developed with AI assistance (Claude). I have reviewed
every changed line, run all tests listed above locally, and take responsibility for the change.
