### PR TITLE
[Hybrid KV Cache][Kimi K3] Retain two committed decode checkpoints

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3388,6 +3388,164 @@ def test_hybrid_local_kv_retention_latest_only_reuses_replay_boundary(monkeypatc
     assert len(computed_blocks.blocks[1]) == 0
 
 
+@pytest.mark.parametrize(
+    ("retain_decode_checkpoints", "expected_cached", "expected_hits"),
+    [
+        (False, {0}, (4, 4)),
+        (True, {0, 3, 4}, (16, 20)),
+    ],
+)
+def test_hybrid_local_kv_retention_reuses_decode_checkpoints(
+    monkeypatch,
+    retain_decode_checkpoints,
+    expected_cached,
+    expected_hits,
+):
+    """Only the latest two committed decode states remain locally reusable."""
+    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETENTION_INTERVAL", "0")
+    monkeypatch.setenv(
+        "VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS",
+        str(int(retain_decode_checkpoints)),
+    )
+    block_size = 4
+    manager = make_kv_cache_manager(
+        _make_hybrid_kv_cache_config(
+            block_size,
+            100,
+            ["full", "mamba_align"],
+        ),
+        max_model_len=1024,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+    req = make_request("producer", list(range(8)), block_size, sha256)
+
+    def compute(num_tokens):
+        manager.new_step_starts()
+        blocks = manager.allocate_slots(req, num_tokens)
+        assert blocks is not None
+        req.num_computed_tokens += num_tokens
+
+    # Materialize the prompt replay boundary, then three aligned decode
+    # checkpoints. Align-mode Mamba rotates its running-state block; the third
+    # decode checkpoint withdraws the first from the local prefix cache.
+    compute(4)
+    compute(4)
+    for token_ids in (range(8, 12), range(12, 16), range(16, 20)):
+        req.append_output_token_ids(list(token_ids))
+        compute(4)
+
+    manager.new_step_starts()
+    manager.free(req)
+
+    pool = manager.block_pool
+    cached = {
+        i
+        for i in range(5)
+        if pool.get_cached_block(req.block_hashes[i], kv_cache_group_ids=[1])
+        is not None
+    }
+    assert cached == expected_cached
+
+    shorter_branch = make_request(
+        "shorter_branch",
+        req.all_token_ids[:16] + [100, 101, 102, 103],
+        block_size,
+        sha256,
+    )
+    full_replay = make_request(
+        "full_replay",
+        list(req.all_token_ids) + [100, 101, 102, 103],
+        block_size,
+        sha256,
+    )
+    _, shorter_hit, _ = manager.get_computed_blocks(shorter_branch)
+    _, full_hit, _ = manager.get_computed_blocks(full_replay)
+    assert (shorter_hit, full_hit) == expected_hits
+
+
+@pytest.mark.parametrize(
+    ("retention_interval", "spec_types", "expected_match"),
+    [
+        (
+            None,
+            ["full", "mamba_align"],
+            "requires VLLM_PREFIX_CACHE_RETENTION_INTERVAL",
+        ),
+        ("0", ["full", "mamba"], "requires a Mamba KV cache group"),
+        ("0", ["full", "sliding_window"], "requires a Mamba KV cache group"),
+    ],
+)
+def test_decode_checkpoint_retention_rejects_unsupported_config(
+    monkeypatch,
+    retention_interval,
+    spec_types,
+    expected_match,
+):
+    """Decode checkpoint retention is an opt-in Mamba-align sparse policy."""
+    if retention_interval is not None:
+        monkeypatch.setenv("VLLM_PREFIX_CACHE_RETENTION_INTERVAL", retention_interval)
+    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS", "1")
+
+    with pytest.raises(ValueError, match=expected_match):
+        make_kv_cache_manager(
+            _make_hybrid_kv_cache_config(4, 100, spec_types),
+            max_model_len=1024,
+            enable_caching=True,
+            hash_block_size=4,
+        )
+
+
+def test_decode_checkpoint_retention_excludes_rejected_draft_tokens(monkeypatch):
+    """Only committed speculative-decode tokens can form a checkpoint."""
+    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETENTION_INTERVAL", "0")
+    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS", "1")
+    block_size = 4
+    manager = make_kv_cache_manager(
+        _make_hybrid_kv_cache_config(
+            block_size,
+            100,
+            ["full", "mamba_align"],
+        ),
+        max_model_len=1024,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+
+    def compute_prompt(request):
+        for _ in range(2):
+            manager.new_step_starts()
+            blocks = manager.allocate_slots(request, block_size)
+            assert blocks is not None
+            request.num_computed_tokens += block_size
+
+    req = make_request("producer", list(range(8)), block_size, sha256)
+    compute_prompt(req)
+
+    # The sampled token is committed, while the proposed suffix is not part of
+    # request.num_tokens and must not create a decode checkpoint.
+    req.append_output_token_ids([8])
+    req.spec_token_ids = list(range(9, 17))
+    manager.new_step_starts()
+    blocks = manager.allocate_slots(req, len(req.spec_token_ids))
+    assert blocks is not None
+    assert manager.block_pool.get_cached_block(req.block_hashes[0], [1]) is not None
+    assert manager.block_pool.get_cached_block(req.block_hashes[1], [1]) is None
+
+    # Accept the whole scheduled span. On the next step, boundary 16 is both
+    # committed and backed by the Mamba state materialized above, so it can be
+    # admitted. The newly proposed suffix is still excluded by the cap.
+    req.append_output_token_ids(list(range(9, 17)))
+    req.num_computed_tokens += len(req.spec_token_ids)
+    req.spec_token_ids = list(range(17, 25))
+    manager.new_step_starts()
+    blocks = manager.allocate_slots(req, len(req.spec_token_ids))
+    assert blocks is not None
+    assert manager.block_pool.get_cached_block(req.block_hashes[3], [1]) is not None
+
+    manager.free(req)
+
+
 def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary(monkeypatch):
     """Verify MTP/EAGLE SWA retention keeps the extra proof block.
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -298,6 +298,7 @@ if TYPE_CHECKING:
     VLLM_GPU_NIC_PCIE_MAPPING: str = ""
     VLLM_NIC_SELECTION_VARS: str = ""
     VLLM_PREFIX_CACHE_RETENTION_INTERVAL: int | None = None
+    VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS: bool = False
 
 
 def get_default_cache_root():
@@ -1114,11 +1115,19 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # retains only the latest completed prompt boundary. Positive values retain
     # checkpoints at the specified interval boundaries (rounded up to the
     # prefix-cache alignment).
-    # Applies to sliding-window attention for now but not yet Mamba/linear attention.
+    # Applies to sliding-window and Mamba/linear attention.
     "VLLM_PREFIX_CACHE_RETENTION_INTERVAL": lambda: (
         int(os.environ["VLLM_PREFIX_CACHE_RETENTION_INTERVAL"])
         if "VLLM_PREFIX_CACHE_RETENTION_INTERVAL" in os.environ
         else None
+    ),
+    # Under sparse retention, retain up to two additional scheduler-aligned
+    # checkpoints in the committed decode prefix of Mamba `align` groups.
+    # Older additional local entries are withdrawn from the prefix-cache hash
+    # map; interval checkpoints and remote KV-store copies keep their own
+    # eviction policy.
+    "VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS": lambda: bool(
+        int(os.getenv("VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS", "0"))
     ),
     # a local directory to look in for unrecognized LoRA adapters.
     # only works if plugins are enabled and

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -29,9 +29,27 @@ from vllm.v1.request import Request
 
 def _validate_prefix_cache_retention_interval(
     retention_interval: int | None,
+    retain_decode_checkpoints: bool,
     scheduler_block_size: int,
     kv_cache_config: KVCacheConfig,
 ) -> None:
+    if retain_decode_checkpoints:
+        if retention_interval is None:
+            raise ValueError(
+                "VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS requires "
+                "VLLM_PREFIX_CACHE_RETENTION_INTERVAL to enable sparse "
+                "retention."
+            )
+        if not any(
+            isinstance(g.kv_cache_spec, MambaSpec)
+            and g.kv_cache_spec.mamba_cache_mode == "align"
+            for g in kv_cache_config.kv_cache_groups
+        ):
+            raise ValueError(
+                "VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS requires a "
+                "Mamba KV cache group using mamba_cache_mode='align'."
+            )
+
     if retention_interval is None:
         return
 
@@ -123,8 +141,14 @@ class KVCacheCoordinator(ABC):
         # (``scheduler_block_size``) to land on real cache-hit boundaries.
         # 0 = keep only the latest replay boundary; None = dense;
         self.retention_interval = envs.VLLM_PREFIX_CACHE_RETENTION_INTERVAL
+        self.retain_decode_checkpoints = (
+            envs.VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS
+        )
         _validate_prefix_cache_retention_interval(
-            self.retention_interval, self.scheduler_block_size, kv_cache_config
+            self.retention_interval,
+            self.retain_decode_checkpoints,
+            self.scheduler_block_size,
+            kv_cache_config,
         )
 
     def get_num_blocks_to_allocate(
@@ -285,6 +309,7 @@ class KVCacheCoordinator(ABC):
                 request,
                 num_computed_tokens,
                 retention_interval=self.retention_interval,
+                retain_decode_checkpoints=self.retain_decode_checkpoints,
             )
 
     def free(self, request_id: str) -> None:
@@ -680,6 +705,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 request,
                 num_tokens_to_cache,
                 retention_interval=self.retention_interval,
+                retain_decode_checkpoints=self.retain_decode_checkpoints,
             )
 
     def find_longest_cache_hit(

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -13,6 +13,7 @@ from vllm.v1.core.kv_cache_utils import (
     BlockHashListWithBlockSize,
     BlockHashWithGroupId,
     KVCacheBlock,
+    make_block_hash_with_group_id,
     resolve_block_hashes,
 )
 from vllm.v1.kv_cache_interface import (
@@ -429,6 +430,7 @@ class SingleTypeKVCacheManager(ABC):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        retain_decode_checkpoints: bool = False,
     ) -> None:
         """
         Cache the blocks for the request.
@@ -440,7 +442,11 @@ class SingleTypeKVCacheManager(ABC):
             retention_interval: Sparse local-checkpoint granularity. ``None``
                 keeps dense checkpointing; ``0`` keeps only the latest replay
                 boundary; a positive multiple of ``scheduler_block_size`` keeps
-                a tail once per that-sized segment. Only SWA acts on it.
+                a tail once per that-sized segment.
+            retain_decode_checkpoints: Under sparse retention for Mamba
+                ``align`` mode, admit scheduler-aligned boundaries in the
+                committed decode prefix. The Mamba manager limits these to the
+                latest two checkpoints per request.
         """
         num_cached_blocks = self.num_cached_block.get(request.request_id, 0)
         num_full_blocks = num_tokens // self.block_size
@@ -454,6 +460,20 @@ class SingleTypeKVCacheManager(ABC):
         reachable_boundaries = [request.num_prompt_tokens - 1]
         if request.shared_prefix_boundary:
             reachable_boundaries.append(request.shared_prefix_boundary)
+        decode_boundary = 0
+        if (
+            retention_interval is not None
+            and retain_decode_checkpoints
+            and isinstance(self.kv_cache_spec, MambaSpec)
+            and self.kv_cache_spec.mamba_cache_mode == "align"
+        ):
+            decode_boundary = (
+                num_tokens // self.scheduler_block_size * self.scheduler_block_size
+            )
+            if decode_boundary <= request.num_prompt_tokens:
+                decode_boundary = 0
+            else:
+                reachable_boundaries.append(decode_boundary)
 
         block_mask = self.reachable_block_mask(
             start_block=num_cached_blocks,
@@ -781,8 +801,14 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        retain_decode_checkpoints: bool = False,
     ) -> None:
-        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        super().cache_blocks(
+            request,
+            num_tokens,
+            retention_interval=retention_interval,
+            retain_decode_checkpoints=retain_decode_checkpoints,
+        )
         hash_block_size = self.block_pool.hash_block_size
         if self.block_size == hash_block_size:
             return
@@ -1275,6 +1301,13 @@ class MambaManager(SingleTypeKVCacheManager):
             # into a private cow_block; we record that block for connector
             # offload (see _pending_partial_tail_offloads).
             self._producer_partial_tail_reqs: dict[str, int] = {}
+            # Latest scheduler-aligned checkpoints admitted from the committed
+            # decode prefix. Each entry records the physical block plus its
+            # exact hash so recycling cannot cause us to evict an unrelated
+            # cache entry.
+            self._decode_checkpoints: dict[
+                str, list[tuple[int, BlockHashWithGroupId]]
+            ] = {}
 
     @classmethod
     def find_longest_cache_hit(
@@ -1655,6 +1688,7 @@ class MambaManager(SingleTypeKVCacheManager):
             self._allocated_block_reqs.discard(request_id)
             self.last_state_block_idx.pop(request_id, None)
             self._producer_partial_tail_reqs.pop(request_id, None)
+            self._decode_checkpoints.pop(request_id, None)
             # A hand-off whose request died in this same scheduling pass must
             # not reach the connector: its unpin hook (free) has already run.
             self._pending_partial_tail_offloads = [
@@ -1677,10 +1711,25 @@ class MambaManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        retain_decode_checkpoints: bool = False,
     ) -> None:
         num_cached_blocks_before = self.num_cached_block.get(request.request_id, 0)
-        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        super().cache_blocks(
+            request,
+            num_tokens,
+            retention_interval=retention_interval,
+            retain_decode_checkpoints=retain_decode_checkpoints,
+        )
         num_cached_blocks_after = self.num_cached_block.get(request.request_id, 0)
+        if num_cached_blocks_after > num_cached_blocks_before:
+            checkpoint_hash = self._record_decode_checkpoint(
+                request,
+                num_tokens,
+                retention_interval,
+                retain_decode_checkpoints,
+            )
+            if checkpoint_hash is not None:
+                self.cached_blocks_this_step.add(checkpoint_hash)
         if self.mamba_cache_mode == "align":
             partial_hash = self._cache_partial_tail_block(request, num_tokens)
             if partial_hash is not None:
@@ -1699,6 +1748,86 @@ class MambaManager(SingleTypeKVCacheManager):
 
     def new_step_starts(self) -> None:
         self.cached_blocks_this_step.clear()
+
+    def _record_decode_checkpoint(
+        self,
+        request: Request,
+        num_tokens: int,
+        retention_interval: int | None,
+        retain_decode_checkpoints: bool,
+    ) -> BlockHashWithGroupId | None:
+        """Retain at most two committed, scheduler-aligned decode states.
+
+        The scheduler can only materialize recurrent state at boundaries it
+        actually computes. Keeping the latest two such boundaries covers the
+        common response-end alignment ambiguity without accumulating every
+        decode state for the lifetime of the request.
+
+        Older entries are withdrawn from the local prefix-cache hash map.
+        ``BlockPool.evict_blocks`` deliberately leaves referenced physical
+        blocks alive, and external stores retain any copies under their own
+        eviction policy.
+        """
+        if (
+            self.mamba_cache_mode != "align"
+            or retention_interval is None
+            or not retain_decode_checkpoints
+        ):
+            return None
+
+        decode_boundary = (
+            num_tokens // self.scheduler_block_size * self.scheduler_block_size
+        )
+        if decode_boundary <= request.num_prompt_tokens:
+            return None
+
+        block_idx = decode_boundary // self.block_size - 1
+        blocks = self.req_to_blocks[request.request_id]
+        if block_idx >= len(blocks):
+            return None
+        block = blocks[block_idx]
+        if block.is_null:
+            return None
+
+        block_hashes = resolve_block_hashes(
+            request.block_hashes,
+            self.block_pool.hash_block_size,
+            self.block_size,
+        )
+        if block_idx >= len(block_hashes):
+            return None
+        checkpoint_hash = make_block_hash_with_group_id(
+            block_hashes[block_idx], self.kv_cache_group_id
+        )
+        if not self.block_pool.cached_block_hash_to_block.contain(
+            checkpoint_hash, block.block_id
+        ):
+            return None
+
+        # A periodic segment checkpoint is retained independently of this
+        # decode policy, so it neither consumes one of the two extra slots nor
+        # gets withdrawn when newer decode checkpoints arrive.
+        if retention_interval > 0 and decode_boundary % retention_interval == 0:
+            return checkpoint_hash
+
+        checkpoints = self._decode_checkpoints.setdefault(request.request_id, [])
+        checkpoint = (block.block_id, checkpoint_hash)
+        if checkpoints and checkpoints[-1] == checkpoint:
+            return checkpoint_hash
+        checkpoints.append(checkpoint)
+
+        while len(checkpoints) > 2:
+            old_block_id, old_hash = checkpoints.pop(0)
+            retained_block_ids = {block_id for block_id, _ in checkpoints}
+            if (
+                old_block_id not in retained_block_ids
+                and self.block_pool.cached_block_hash_to_block.contain(
+                    old_hash, old_block_id
+                )
+            ):
+                self.block_pool.evict_blocks({old_block_id})
+
+        return checkpoint_hash
 
     def _cache_partial_tail_block(
         self,
@@ -1772,6 +1901,7 @@ class CrossAttentionManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        retain_decode_checkpoints: bool = False,
     ) -> None:
         # We do not cache blocks for cross-attention to be shared between
         # requests, so this method is not relevant.


### PR DESCRIPTION
## Purpose

This is an extraction from #49574 for the Kimi K3 preserved-thinking case.

With sparse hybrid-cache retention enabled, this PR lets Mamba `align` groups admit scheduler-aligned states from the committed decode prefix. It keeps at most two additional checkpoints per request in the local prefix-cache hash
map; when a third additional checkpoint is materialized, the oldest local hash is withdrawn without freeing a block that is still referenced.

Periodic checkpoints selected by a positive retention interval remain governed by that interval. Copies already exported to an external KV store remain governed by that store's eviction policy.

Enable the policy with prefix caching and Mamba align mode:

```bash
--enable-prefix-caching
--mamba-cache-mode align
VLLM_PREFIX_CACHE_RETENTION_INTERVAL=0
VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS=1
```

## Reuse examples

Kimi K3 preserves and re-renders complete assistant thinking/tool-call history ([model card](https://github.com/MoonshotAI/Kimi-K3/blob/main/README.md), [reference encoding](https://huggingface.co/moonshotai/Kimi-K3/blob/main/encoding_k3.py)). An exact next-turn request can therefore reuse tokens decoded by the previous request:

- Normal turn: `... assistant(reasoning_content + content) <|end_of_msg|> |   user ...` can hit through the latest aligned assistant prefix instead of stopping at the earlier prompt boundary.
- Tool turn: `... assistant(reasoning_content + tool_calls) <|end_of_msg|> |   tool ...` can hit through the latest aligned assistant tool-call prefix before the tool input/result.

The final non-aligned tail is still recomputed. Exact block hashes remain the correctness gate, so modified rendering or dropped thinking safely misses. Rejected speculative tokens are excluded by the existing committed-token cap, and a checkpoint is recorded only when the corresponding Mamba state was actually materialized.

In a P/D deployment, these admitted states are eligible for the existing Decode-side export/offload path and can be matched by Prefill workers using the same backing pool.

## Why not exact response-end retention

Keeping exactly one semantic response-end state involves chat renderer/parser and request protocol.

## Test plan

```bash
.venv/bin/python -m pytest -q tests/v1/core/test_prefix_caching.py
pre-commit run --files \
  vllm/envs.py \
  vllm/v1/core/kv_cache_coordinator.py \
  vllm/v1/core/single_type_kv_cache_manager.py \
  tests/v1/core/test_prefix_caching.py
```

## Test results

- Prefix-caching suite: **95 passed**.
- Pre-commit: **all hooks passed**, including Ruff, formatting, mypy, SPDX,
  and environment-default validation.
- Latest-two comparison: disabled caches the prompt replay point and hits
  `(4, 4)` tokens; enabled locally retains the latest two decode points and
  hits `(16, 20)` tokens for an earlier branch and the full assistant replay.
- Added fail-fast coverage for missing retention, Mamba non-align, and
  SWA-only configurations.
- Added speculative-decode coverage for rejected versus committed,
  materialized tokens.
- Model/GPU evaluation: not run. This changes cache admission metadata rather
  than model computation, tokenization, logits, or output accuracy.
  Connector-specific Kimi K3 P/D hit-rate and memory validation remains
  deployment follow-up work.

## AI assistance

AI was used to analyze the cache/offload paths, implement the change, and run the checks above.
