### PR TITLE
feat: GladiusScheduler -- file-based policy control plane for the V1 …

### DIFF
--- a/gladius_vllm/__init__.py
+++ b/gladius_vllm/__init__.py
@@ -1,0 +1,12 @@
+"""GLADIUS control-plane integration for vLLM's V1 scheduler.
+
+Additive plugin package (not part of `vllm/`) that lets an external experience
+control plane influence live scheduling decisions via a versioned, file-based
+protocol (`policy_snapshot.json` in, `telemetry.jsonl` out). See
+`gladius_vllm.scheduler.GladiusScheduler` for the entry point, wired in via
+vLLM's existing `--scheduler-cls` plugin mechanism.
+"""
+
+from gladius_vllm.schema import SCHEMA_VERSION
+
+__all__ = ["SCHEMA_VERSION"]

--- a/gladius_vllm/errors.py
+++ b/gladius_vllm/errors.py
@@ -1,0 +1,24 @@
+"""Exception types for the GLADIUS policy protocol.
+
+These are used internally by PolicyLoader to classify a rejected snapshot;
+PolicyLoader.poll() catches all of them and never lets them escape (see
+policy.py), so request scheduling can never be taken down by a bad snapshot.
+"""
+
+from __future__ import annotations
+
+
+class PolicySnapshotError(Exception):
+    """Base class for all policy_snapshot.json validation failures."""
+
+
+class PolicyCorruptError(PolicySnapshotError):
+    """Snapshot is missing, malformed JSON, wrong types, or fails range/schema validation."""
+
+
+class PolicyStaleError(PolicySnapshotError):
+    """Snapshot's `generation` is <= the last-accepted generation."""
+
+
+class PolicyEngineMismatchError(PolicySnapshotError):
+    """Snapshot's `engine_id` or `model_id` does not match this scheduler's own."""

--- a/gladius_vllm/policy.py
+++ b/gladius_vllm/policy.py
@@ -1,0 +1,292 @@
+"""Atomic policy-snapshot hot-reload for GladiusScheduler.
+
+PolicyLoader.poll() is the single entry point: it never raises, and always
+returns a PolicyDecision usable directly by the scheduler. See the
+failure-mode table in the design plan for the exact mapping from file state
+to (decision, status) pairs.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal
+
+from gladius_vllm.errors import (
+    PolicyCorruptError,
+    PolicyEngineMismatchError,
+    PolicyStaleError,
+)
+from gladius_vllm.schema import (
+    DEFAULT_POLICY_POLL_INTERVAL_MS,
+    SUPPORTED_SCHEMA_MAJOR,
+    parse_iso8601,
+)
+
+PolicyStatus = Literal[
+    "active",
+    "no_policy",
+    "expired",
+    "corrupt",
+    "rejected_regression",
+    "rejected_engine_mismatch",
+]
+
+PolicySource = Literal["file", "default"]
+
+_REQUIRED_FIELDS = (
+    "schema_version",
+    "generation",
+    "policy_id",
+    "model_id",
+    "engine_id",
+    "created_at",
+    "expires_at",
+)
+_ADMISSION_ALLOWED_KEYS = {"max_num_seqs", "max_num_batched_tokens"}
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    """The scheduler's per-step admission ceilings and their provenance."""
+
+    max_num_seqs: int
+    max_num_batched_tokens: int
+    policy_id: str | None
+    generation: int | None
+    status: PolicyStatus
+    source: PolicySource
+
+
+def _default_decision(
+    startup_max_num_seqs: int,
+    startup_max_num_batched_tokens: int,
+    status: PolicyStatus,
+) -> PolicyDecision:
+    return PolicyDecision(
+        max_num_seqs=startup_max_num_seqs,
+        max_num_batched_tokens=startup_max_num_batched_tokens,
+        policy_id=None,
+        generation=None,
+        status=status,
+        source="default",
+    )
+
+
+def _parse_snapshot(
+    raw: dict, *, engine_id: str, model_id: str, last_accepted_generation: int | None
+) -> dict:
+    """Validate and return the parsed fields.
+
+    Raises PolicyCorruptError, PolicyEngineMismatchError, or PolicyStaleError.
+    """
+    for field in _REQUIRED_FIELDS:
+        if field not in raw:
+            raise PolicyCorruptError(f"missing required field: {field}")
+
+    schema_version = raw["schema_version"]
+    if not isinstance(schema_version, str):
+        raise PolicyCorruptError("schema_version must be a string")
+    if schema_version.split(".")[0] != SUPPORTED_SCHEMA_MAJOR:
+        raise PolicyCorruptError(
+            f"unsupported schema_version major: {schema_version!r} "
+            f"(expected major {SUPPORTED_SCHEMA_MAJOR!r})"
+        )
+
+    generation = raw["generation"]
+    if not isinstance(generation, int) or isinstance(generation, bool) or generation < 0:
+        raise PolicyCorruptError(f"generation must be a non-negative int, got {generation!r}")
+
+    policy_id = raw["policy_id"]
+    if not isinstance(policy_id, str) or not policy_id:
+        raise PolicyCorruptError("policy_id must be a non-empty string")
+
+    if raw["model_id"] != model_id:
+        raise PolicyEngineMismatchError(
+            f"model_id mismatch: snapshot={raw['model_id']!r} engine={model_id!r}"
+        )
+    if raw["engine_id"] != engine_id:
+        raise PolicyEngineMismatchError(
+            f"engine_id mismatch: snapshot={raw['engine_id']!r} engine={engine_id!r}"
+        )
+
+    try:
+        created_at = parse_iso8601(raw["created_at"])
+        expires_at = parse_iso8601(raw["expires_at"])
+    except (TypeError, ValueError) as exc:
+        raise PolicyCorruptError(f"invalid timestamp: {exc}") from exc
+    if expires_at <= created_at:
+        raise PolicyCorruptError("expires_at must be strictly after created_at")
+
+    admission = raw.get("admission") or {}
+    if not isinstance(admission, dict):
+        raise PolicyCorruptError("admission must be an object")
+    unknown_keys = set(admission) - _ADMISSION_ALLOWED_KEYS
+    if unknown_keys:
+        raise PolicyCorruptError(f"unrecognized admission keys: {sorted(unknown_keys)}")
+
+    max_num_seqs = admission.get("max_num_seqs")
+    if max_num_seqs is not None:
+        if not isinstance(max_num_seqs, int) or isinstance(max_num_seqs, bool) or max_num_seqs < 1:
+            raise PolicyCorruptError(
+                f"admission.max_num_seqs must be a positive int, got {max_num_seqs!r}"
+            )
+
+    max_num_batched_tokens = admission.get("max_num_batched_tokens")
+    if max_num_batched_tokens is not None:
+        if (
+            not isinstance(max_num_batched_tokens, int)
+            or isinstance(max_num_batched_tokens, bool)
+            or max_num_batched_tokens < 1
+        ):
+            raise PolicyCorruptError(
+                "admission.max_num_batched_tokens must be a positive int, "
+                f"got {max_num_batched_tokens!r}"
+            )
+
+    if last_accepted_generation is not None and generation <= last_accepted_generation:
+        raise PolicyStaleError(
+            f"generation {generation} <= last accepted {last_accepted_generation}"
+        )
+
+    return {
+        "generation": generation,
+        "policy_id": policy_id,
+        "expires_at": expires_at,
+        "max_num_seqs": max_num_seqs,
+        "max_num_batched_tokens": max_num_batched_tokens,
+    }
+
+
+class PolicyLoader:
+    """Polls `policy_snapshot.json` and returns hot-reloadable admission ceilings.
+
+    Startup ceilings act as both the "no policy" default and the hard upper
+    clamp — callers pass them in and get them back verbatim whenever no
+    policy is active, expired, or rejected.
+    """
+
+    def __init__(
+        self,
+        snapshot_path: Path | None,
+        engine_id: str,
+        model_id: str,
+        startup_max_num_seqs: int,
+        startup_max_num_batched_tokens: int,
+        poll_interval_ms: int = DEFAULT_POLICY_POLL_INTERVAL_MS,
+    ) -> None:
+        self._snapshot_path = snapshot_path
+        self._engine_id = engine_id
+        self._model_id = model_id
+        self._startup_max_num_seqs = startup_max_num_seqs
+        self._startup_max_num_batched_tokens = startup_max_num_batched_tokens
+        self._poll_interval_s = poll_interval_ms / 1000.0
+
+        self._last_stat: tuple[int, int] | None = None  # (mtime_ns, size)
+        self._last_poll_monotonic: float | None = None
+        self._last_accepted_generation: int | None = None
+        self._last_accepted_policy_id: str | None = None
+        self._last_accepted_expires_at: datetime | None = None
+        self._last_accepted_max_num_seqs: int | None = None
+        self._last_accepted_max_num_batched_tokens: int | None = None
+        self._last_decision: PolicyDecision = _default_decision(
+            startup_max_num_seqs, startup_max_num_batched_tokens, "no_policy"
+        )
+
+    def poll(self) -> PolicyDecision:
+        if self._snapshot_path is None:
+            return self._default("no_policy")
+
+        now_monotonic = time.monotonic()
+        if (
+            self._last_poll_monotonic is not None
+            and now_monotonic - self._last_poll_monotonic < self._poll_interval_s
+        ):
+            return self._check_expiry_only()
+        self._last_poll_monotonic = now_monotonic
+
+        try:
+            stat = self._snapshot_path.stat()
+        except FileNotFoundError:
+            self._last_stat = None
+            return self._default("no_policy")
+
+        current_stat = (stat.st_mtime_ns, stat.st_size)
+        if current_stat == self._last_stat:
+            return self._check_expiry_only()
+
+        self._last_stat = current_stat
+        try:
+            raw_text = self._snapshot_path.read_text()
+            raw = json.loads(raw_text)
+            parsed = _parse_snapshot(
+                raw,
+                engine_id=self._engine_id,
+                model_id=self._model_id,
+                last_accepted_generation=self._last_accepted_generation,
+            )
+        except (OSError, json.JSONDecodeError, PolicyCorruptError):
+            return self._reject_keep_last_or_default("corrupt")
+        except PolicyEngineMismatchError:
+            return self._reject_keep_last_or_default("rejected_engine_mismatch")
+        except PolicyStaleError:
+            return self._reject_keep_last_or_default("rejected_regression")
+
+        self._last_accepted_generation = parsed["generation"]
+        self._last_accepted_policy_id = parsed["policy_id"]
+        self._last_accepted_expires_at = parsed["expires_at"]
+        self._last_accepted_max_num_seqs = (
+            parsed["max_num_seqs"]
+            if parsed["max_num_seqs"] is not None
+            else self._startup_max_num_seqs
+        )
+        self._last_accepted_max_num_batched_tokens = (
+            parsed["max_num_batched_tokens"]
+            if parsed["max_num_batched_tokens"] is not None
+            else self._startup_max_num_batched_tokens
+        )
+        self._last_decision = PolicyDecision(
+            max_num_seqs=self._last_accepted_max_num_seqs,
+            max_num_batched_tokens=self._last_accepted_max_num_batched_tokens,
+            policy_id=self._last_accepted_policy_id,
+            generation=self._last_accepted_generation,
+            status="active",
+            source="file",
+        )
+        return self._check_expiry_only()
+
+    def _check_expiry_only(self) -> PolicyDecision:
+        """Re-check expiry every call, independent of whether the file changed."""
+        if self._last_accepted_expires_at is None:
+            return self._last_decision
+        if self._is_expired():
+            return self._default("expired")
+        return self._last_decision
+
+    def _is_expired(self) -> bool:
+        return datetime.now(timezone.utc) >= self._last_accepted_expires_at
+
+    def _reject_keep_last_or_default(self, status: PolicyStatus) -> PolicyDecision:
+        if self._last_accepted_generation is None:
+            decision = self._default(status)
+        else:
+            decision = PolicyDecision(
+                max_num_seqs=self._last_accepted_max_num_seqs,
+                max_num_batched_tokens=self._last_accepted_max_num_batched_tokens,
+                policy_id=self._last_accepted_policy_id,
+                generation=self._last_accepted_generation,
+                status=status,
+                source="file",
+            )
+        self._last_decision = decision
+        return decision
+
+    def _default(self, status: PolicyStatus) -> PolicyDecision:
+        decision = _default_decision(
+            self._startup_max_num_seqs, self._startup_max_num_batched_tokens, status
+        )
+        self._last_decision = decision
+        return decision

--- a/gladius_vllm/registry.py
+++ b/gladius_vllm/registry.py
@@ -1,0 +1,26 @@
+"""Process-wide weakref registry bridging GladiusScheduler <-> GladiusStatLogger.
+
+Exactly one Scheduler exists per engine-core process, so a simple
+engine_id-keyed weakref map is sufficient -- no cross-process concerns within
+a single process. See gladius_vllm.stat_logger for the (optional, secondary)
+consumer and the cross-process caveat in the design plan.
+"""
+
+from __future__ import annotations
+
+import weakref
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from gladius_vllm.scheduler import GladiusScheduler
+
+_ACTIVE: dict[str, "weakref.ref[GladiusScheduler]"] = {}
+
+
+def register_scheduler(scheduler: "GladiusScheduler") -> None:
+    _ACTIVE[scheduler.engine_id] = weakref.ref(scheduler)
+
+
+def get_scheduler(engine_id: str) -> "GladiusScheduler | None":
+    ref = _ACTIVE.get(engine_id)
+    return ref() if ref is not None else None

--- a/gladius_vllm/scheduler.py
+++ b/gladius_vllm/scheduler.py
@@ -1,0 +1,114 @@
+"""GladiusScheduler: a vLLM V1 Scheduler that hot-reloads admission ceilings
+from an externally-published policy_snapshot.json.
+
+Wired in via vLLM's existing `--scheduler-cls` plugin mechanism (no upstream
+vllm/ changes needed):
+
+    vllm serve ... --scheduler-cls gladius_vllm.scheduler.GladiusScheduler
+
+Configuration is via environment variables (not VllmConfig/EngineArgs
+plumbing, to keep this a pure additive plugin):
+
+    GLADIUS_POLICY_DIR                directory holding policy_snapshot.json
+                                       and telemetry.jsonl. If unset, this
+                                       scheduler behaves exactly like a
+                                       vanilla Scheduler.
+    GLADIUS_ENGINE_ID                 stable engine id across restarts.
+    GLADIUS_POLICY_POLL_INTERVAL_MS   rate limit for policy file re-stat.
+    GLADIUS_TELEMETRY_SAMPLE_N        write 1-in-N telemetry lines.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from vllm.v1.core.sched.scheduler import Scheduler
+
+from gladius_vllm.policy import PolicyLoader
+from gladius_vllm.registry import register_scheduler
+from gladius_vllm.schema import (
+    DEFAULT_POLICY_POLL_INTERVAL_MS,
+    resolve_engine_id,
+    resolve_model_id,
+)
+from gladius_vllm.telemetry import TelemetryWriter
+
+if TYPE_CHECKING:
+    from vllm.v1.core.sched.output import SchedulerOutput
+
+POLICY_SNAPSHOT_FILENAME = "policy_snapshot.json"
+TELEMETRY_FILENAME = "telemetry.jsonl"
+
+
+class GladiusScheduler(Scheduler):
+    """Thin subclass: only __init__ and schedule() are overridden.
+
+    The safe-clamp invariant `effective = min(policy_requested, startup)` is
+    enforced fresh every step, so this scheduler degrades to byte-for-byte
+    vanilla `Scheduler` behavior whenever no policy is configured/active
+    (min(x, x) == x is a no-op), and can never admit more than the engine was
+    started with -- max_num_seqs/max_num_batched_tokens are baked into CUDA
+    graph capture sizes and torch.compile shapes at startup, so raising them
+    post-hoc is unsafe; this scheduler only ever clamps down.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        self.engine_id = resolve_engine_id(self.vllm_config)
+        self.model_id = resolve_model_id(self.vllm_config)
+
+        # Captured once, after super().__init__ has set these -- these are
+        # the values already baked into CUDA graph capture / compiled kernel
+        # shapes, and are never mutated by this class.
+        self.startup_max_num_seqs = self.max_num_running_reqs
+        self.startup_max_num_batched_tokens = self.max_num_scheduled_tokens
+
+        policy_dir_env = os.environ.get("GLADIUS_POLICY_DIR")
+        policy_dir = Path(policy_dir_env) if policy_dir_env else None
+        poll_interval_env = os.environ.get("GLADIUS_POLICY_POLL_INTERVAL_MS")
+        poll_interval_ms = (
+            int(poll_interval_env) if poll_interval_env else DEFAULT_POLICY_POLL_INTERVAL_MS
+        )
+
+        self._policy_loader = PolicyLoader(
+            snapshot_path=policy_dir / POLICY_SNAPSHOT_FILENAME if policy_dir else None,
+            engine_id=self.engine_id,
+            model_id=self.model_id,
+            startup_max_num_seqs=self.startup_max_num_seqs,
+            startup_max_num_batched_tokens=self.startup_max_num_batched_tokens,
+            poll_interval_ms=poll_interval_ms,
+        )
+        self._telemetry_writer = TelemetryWriter(
+            path=policy_dir / TELEMETRY_FILENAME if policy_dir else None,
+            engine_id=self.engine_id,
+            model_id=self.model_id,
+        )
+
+        register_scheduler(self)
+
+    def schedule(self) -> "SchedulerOutput":
+        decision = self._policy_loader.poll()
+        target_max_num_seqs = min(decision.max_num_seqs, self.startup_max_num_seqs)
+        # Never shrink below the number of requests already admitted: the
+        # base Scheduler enforces `len(self.running) <= max_num_running_reqs`
+        # as a forward-looking admission check only -- it has no preemption
+        # path to evict already-running requests down to a newly-lowered
+        # ceiling, and asserts the invariant unconditionally. A policy asking
+        # for fewer than what's already running takes effect gradually, as
+        # attrition (requests finishing) brings the running count back down.
+        self.max_num_running_reqs = max(target_max_num_seqs, len(self.running))
+        self.max_num_scheduled_tokens = min(
+            decision.max_num_batched_tokens, self.startup_max_num_batched_tokens
+        )
+
+        output = super().schedule()
+
+        self._telemetry_writer.record(self, output, decision)
+        return output
+
+    def shutdown(self) -> None:
+        self._telemetry_writer.close()
+        super().shutdown()

--- a/gladius_vllm/schema.py
+++ b/gladius_vllm/schema.py
@@ -1,0 +1,67 @@
+"""Shared constants and id-resolution helpers for the GLADIUS control protocol.
+
+Kept in one module so `GladiusScheduler`, `PolicyLoader`, and `TelemetryWriter`
+derive `engine_id`/`model_id` identically instead of three independent
+implementations that could disagree.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+
+SCHEMA_VERSION = "1.0.0"
+SUPPORTED_SCHEMA_MAJOR = SCHEMA_VERSION.split(".")[0]
+
+DEFAULT_POLICY_POLL_INTERVAL_MS = 50
+DEFAULT_TELEMETRY_SAMPLE_N = 1
+
+POLICY_STATUSES = (
+    "active",
+    "no_policy",
+    "expired",
+    "corrupt",
+    "rejected_regression",
+    "rejected_engine_mismatch",
+)
+
+POLICY_SOURCES = ("file", "default")
+
+
+def parse_iso8601(value: str) -> datetime:
+    """Parse an ISO-8601 UTC string, tolerating a trailing 'Z' (py3.10 compat)."""
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def format_iso8601(dt: datetime | None = None) -> str:
+    dt = dt or datetime.now(timezone.utc)
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def resolve_engine_id(vllm_config: "VllmConfig") -> str:
+    """Stable id for this engine process.
+
+    Prefers an explicit `GLADIUS_ENGINE_ID` env var (recommended for
+    deployments that want a stable id across restarts, e.g. matching a pod
+    name), else falls back to `kv_transfer_config.engine_id` if disaggregated
+    KV transfer is configured, else mints a fresh uuid4 per process.
+    """
+    env_id = os.environ.get("GLADIUS_ENGINE_ID")
+    if env_id:
+        return env_id
+    kv_transfer_config = getattr(vllm_config, "kv_transfer_config", None)
+    kv_engine_id = getattr(kv_transfer_config, "engine_id", None)
+    if kv_engine_id:
+        return str(kv_engine_id)
+    return f"engine-{uuid.uuid4()}"
+
+
+def resolve_model_id(vllm_config: "VllmConfig") -> str:
+    model_config = vllm_config.model_config
+    served_name = getattr(model_config, "served_model_name", None)
+    return served_name or model_config.model

--- a/gladius_vllm/stat_logger.py
+++ b/gladius_vllm/stat_logger.py
@@ -1,0 +1,58 @@
+"""Optional, secondary GLADIUS stat-logger plugin.
+
+`StatLoggerBase.record()` receives only (scheduler_stats, iteration_stats,
+mm_cache_stats, engine_idx) -- no reference to the Scheduler instance or the
+per-step SchedulerOutput -- so this class cannot reproduce the full
+telemetry.jsonl feed on its own; that's `GladiusScheduler`/`TelemetryWriter`'s
+job (they have direct, always-in-process access to everything they need).
+
+This class exists only for users who also want the SchedulerStats-only
+subset of these numbers surfaced through vLLM's standard logging/Prometheus
+stat-logger plumbing (`vllm.stat_logger_plugins` entry-point group, or
+`AsyncLLM(stat_loggers=[...])`). It is NOT load-bearing for the
+GladiusScheduler <-> control-plane protocol.
+
+Known limitation (see design plan "Open risks"): in default
+VLLM_ENABLE_V1_MULTIPROCESSING=1 mode it is unconfirmed whether this class
+runs in the same OS process as the Scheduler it looks up via
+gladius_vllm.registry; if not, get_scheduler() below simply returns None and
+this logger degrades to reporting nothing extra.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from vllm.v1.metrics.loggers import StatLoggerBase
+
+from gladius_vllm.registry import get_scheduler
+from gladius_vllm.schema import resolve_engine_id
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+    from vllm.v1.metrics.stats import IterationStats, MultiModalCacheStats, SchedulerStats
+
+
+class GladiusStatLogger(StatLoggerBase):
+    def __init__(self, vllm_config: "VllmConfig", engine_index: int = 0) -> None:
+        self._engine_id = resolve_engine_id(vllm_config)
+        self._engine_index = engine_index
+
+    def record(
+        self,
+        scheduler_stats: "SchedulerStats | None",
+        iteration_stats: "IterationStats | None",
+        mm_cache_stats: "MultiModalCacheStats | None" = None,
+        engine_idx: int = 0,
+    ) -> None:
+        # Lazy per-call lookup (not cached at __init__) since construction
+        # order between GladiusScheduler and stat loggers isn't guaranteed.
+        scheduler = get_scheduler(self._engine_id)
+        if scheduler is None or scheduler_stats is None:
+            return
+        # Intentionally a no-op beyond the lookup for phase 1: GladiusScheduler
+        # already writes the authoritative telemetry.jsonl line itself. This
+        # hook is reserved for future Prometheus/console-log wiring.
+
+    def log_engine_initialized(self) -> None:
+        pass

--- a/gladius_vllm/telemetry.py
+++ b/gladius_vllm/telemetry.py
@@ -1,0 +1,125 @@
+"""Append-only telemetry.jsonl writer, one line per scheduling step.
+
+Owned directly by GladiusScheduler (not the StatLoggerBase path) since it
+already has everything it needs -- the scheduler instance, the fresh
+SchedulerOutput, and the current PolicyDecision -- with no cross-process
+ambiguity. See gladius_vllm.stat_logger for the optional secondary path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from gladius_vllm.policy import PolicyDecision
+from gladius_vllm.schema import DEFAULT_TELEMETRY_SAMPLE_N, SCHEMA_VERSION, format_iso8601
+
+if TYPE_CHECKING:
+    from vllm.v1.core.sched.output import SchedulerOutput
+
+
+def _count_prefill_decode(scheduler: Any, output: "SchedulerOutput") -> tuple[int, int]:
+    """Derive prefill/decode counts from SchedulerOutput + Request state.
+
+    A request counts as "prefill" this step if it's a brand-new admission (in
+    scheduled_new_reqs) or a cached continuation still mid-prompt
+    (num_computed_tokens < num_prompt_tokens, i.e. a chunked-prefill
+    continuation); everything else scheduled this step is "decode".
+    """
+    new_req_ids = {req.req_id for req in output.scheduled_new_reqs}
+    num_prefill = 0
+    num_decode = 0
+    for req_id in output.num_scheduled_tokens:
+        if req_id in new_req_ids:
+            num_prefill += 1
+            continue
+        request = scheduler.requests.get(req_id)
+        if request is not None and request.num_computed_tokens < request.num_prompt_tokens:
+            num_prefill += 1
+        else:
+            num_decode += 1
+    return num_prefill, num_decode
+
+
+def _resolve_sample_every_n_steps(explicit: int | None) -> int:
+    if explicit is not None:
+        return explicit
+    env_value = os.environ.get("GLADIUS_TELEMETRY_SAMPLE_N")
+    return int(env_value) if env_value else DEFAULT_TELEMETRY_SAMPLE_N
+
+
+class TelemetryWriter:
+    """Appends one JSON line per scheduling step to telemetry.jsonl."""
+
+    def __init__(
+        self,
+        path: Path | None,
+        engine_id: str,
+        model_id: str,
+        sample_every_n_steps: int | None = None,
+    ) -> None:
+        self._path = path
+        self._engine_id = engine_id
+        self._model_id = model_id
+        self._sample_every_n_steps = _resolve_sample_every_n_steps(sample_every_n_steps)
+        self._step = 0
+        self._file = None
+        if self._path is not None:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            self._file = open(self._path, "a")
+
+    def record(
+        self,
+        scheduler: Any,
+        output: "SchedulerOutput",
+        decision: PolicyDecision,
+    ) -> None:
+        self._step += 1
+        if self._file is None:
+            return
+        if self._step % self._sample_every_n_steps != 0:
+            return
+
+        num_prefill, num_decode = _count_prefill_decode(scheduler, output)
+        stats = scheduler.make_stats()
+
+        clamped_max_num_seqs = decision.max_num_seqs > scheduler.startup_max_num_seqs
+        clamped_max_num_batched_tokens = (
+            decision.max_num_batched_tokens > scheduler.startup_max_num_batched_tokens
+        )
+
+        record = {
+            "schema_version": SCHEMA_VERSION,
+            "generation": decision.generation,
+            "policy_id": decision.policy_id,
+            "model_id": self._model_id,
+            "engine_id": self._engine_id,
+            "created_at": format_iso8601(),
+            "expires_at": None,
+            "step": self._step,
+            "num_running_reqs": stats.num_running_reqs if stats else len(scheduler.running),
+            "num_waiting_reqs": stats.num_waiting_reqs if stats else len(scheduler.waiting),
+            "num_skipped_waiting_reqs": (
+                stats.num_skipped_waiting_reqs if stats else len(scheduler.skipped_waiting)
+            ),
+            "num_scheduled_reqs": len(output.num_scheduled_tokens),
+            "num_scheduled_tokens": output.total_num_scheduled_tokens,
+            "num_prefill_reqs": num_prefill,
+            "num_decode_reqs": num_decode,
+            "kv_cache_usage": stats.kv_cache_usage if stats else None,
+            "policy_status": decision.status,
+            "policy_source": decision.source,
+            "clamped": {
+                "max_num_seqs": clamped_max_num_seqs,
+                "max_num_batched_tokens": clamped_max_num_batched_tokens,
+            },
+        }
+        self._file.write(json.dumps(record) + "\n")
+        self._file.flush()
+
+    def close(self) -> None:
+        if self._file is not None:
+            self._file.close()
+            self._file = None

--- a/tests/gladius/test_gladius_contract_e2e.py
+++ b/tests/gladius/test_gladius_contract_e2e.py
@@ -1,0 +1,114 @@
+"""Real-vLLM contract test for GladiusScheduler.
+
+Mirrors tests/plugins_tests/test_scheduler_plugins.py's in-process pattern
+(VLLM_ENABLE_V1_MULTIPROCESSING=0, enforce_eager=True) but drives a real
+LLMEngine end to end with a real (small, locally-cached) model and a real
+policy_snapshot.json produced by the gladius-side policy_writer-equivalent
+helper below, asserting the full loop: no-policy startup, a published
+snapshot actually lowering admission, and telemetry.jsonl reflecting it.
+
+Needs a real model load (~GB-scale weights) and a working CPU/GPU execution
+backend -- this is the one test in this suite that cannot run in a
+network/model-cache-less CI lane. Run manually:
+
+    pytest tests/gladius/test_gladius_contract_e2e.py -v -s
+"""
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+
+os.environ.setdefault("HF_HUB_OFFLINE", "1")
+os.environ.pop("ALL_PROXY", None)
+os.environ.pop("all_proxy", None)
+
+import pytest
+
+MODEL = "Qwen/Qwen3-1.7B"
+
+
+def _write_snapshot(directory, *, engine_id, model_id, generation, max_num_seqs, ttl_seconds=60.0):
+    now = datetime.now(timezone.utc)
+    payload = {
+        "schema_version": "1.0.0",
+        "generation": generation,
+        "policy_id": f"policy-{generation}",
+        "model_id": model_id,
+        "engine_id": engine_id,
+        "created_at": now.isoformat().replace("+00:00", "Z"),
+        "expires_at": (now + timedelta(seconds=ttl_seconds)).isoformat().replace("+00:00", "Z"),
+        "admission": {"max_num_seqs": max_num_seqs, "max_num_batched_tokens": None},
+        "notes": None,
+    }
+    path = directory / "policy_snapshot.json"
+    tmp = directory / ".policy_snapshot.tmp"
+    tmp.write_text(json.dumps(payload))
+    os.replace(tmp, path)
+    return path
+
+
+@pytest.mark.slow_test
+def test_gladius_scheduler_real_engine_contract(tmp_path, monkeypatch):
+    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    monkeypatch.setenv("GLADIUS_ENGINE_ID", "contract-test-engine")
+    monkeypatch.setenv("GLADIUS_POLICY_DIR", str(tmp_path))
+    monkeypatch.setenv("GLADIUS_POLICY_POLL_INTERVAL_MS", "0")
+
+    from vllm.engine.arg_utils import EngineArgs
+    from vllm.sampling_params import SamplingParams
+    from vllm.v1.engine.llm_engine import LLMEngine
+
+    from gladius_vllm.scheduler import GladiusScheduler
+
+    engine_args = EngineArgs(
+        model=MODEL,
+        enforce_eager=True,
+        scheduler_cls=GladiusScheduler,
+        max_num_seqs=16,
+        max_model_len=2048,
+        gpu_memory_utilization=0.3,
+    )
+    engine = LLMEngine.from_engine_args(engine_args=engine_args)
+    scheduler = engine.engine_core.engine_core.scheduler
+    assert isinstance(scheduler, GladiusScheduler)
+
+    # Phase 1: no snapshot published yet -- native-equivalent behavior.
+    sampling_params = SamplingParams(max_tokens=4)
+    for i in range(4):
+        engine.add_request(str(i), "Hello, world! " * 4, sampling_params)
+    engine.step()
+    assert scheduler.max_num_running_reqs == scheduler.startup_max_num_seqs == 16
+
+    # Phase 2: publish a snapshot lowering the ceiling to 2, matching this
+    # engine's real engine_id/model_id, and confirm it takes effect without
+    # restarting the process.
+    _write_snapshot(
+        tmp_path,
+        engine_id=scheduler.engine_id,
+        model_id=scheduler.model_id,
+        generation=1,
+        max_num_seqs=2,
+    )
+    for i in range(4, 8):
+        engine.add_request(str(i), "Hello, world! " * 4, sampling_params)
+    engine.step()
+
+    # The 4 phase-1 requests are still running, above the new cap of 2 --
+    # this must not crash (no forced eviction of already-admitted requests
+    # in phase 1 scope; see the equivalent CPU-only test for the isolated
+    # case). Drain until they finish naturally; the cap then takes hold for
+    # new admissions.
+    for _ in range(20):
+        if not engine.has_unfinished_requests():
+            break
+        engine.step()
+
+    assert scheduler.max_num_running_reqs == 2
+
+    telemetry_path = tmp_path / "telemetry.jsonl"
+    assert telemetry_path.exists()
+    lines = [json.loads(line) for line in telemetry_path.read_text().splitlines() if line]
+    assert len(lines) >= 2
+    assert lines[0]["policy_status"] == "no_policy"
+    assert any(line["policy_status"] == "active" for line in lines)
+    assert any(line["generation"] == 1 for line in lines)

--- a/tests/gladius/test_gladius_scheduler_cpu.py
+++ b/tests/gladius/test_gladius_scheduler_cpu.py
@@ -1,0 +1,284 @@
+"""CPU-only tests for GladiusScheduler -- no GPU, no executor, real vLLM
+Scheduler/Request objects via tests/v1/core/utils.py's create_scheduler()/
+create_requests() helpers (upstream's own vehicle for scheduler-only unit
+tests). GladiusScheduler isn't reachable through create_scheduler() directly
+(it hardcodes Scheduler/AsyncScheduler), so _build_gladius_scheduler() below
+is a small local wrapper that reuses a vanilla-built Scheduler's already-
+constructed VllmConfig/KVCacheConfig/StructuredOutputManager to build a
+GladiusScheduler with an identical configuration -- it does not modify the
+upstream helper file.
+"""
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+
+# Requires network-derived HF metadata to be avoided: the cached model below
+# is already on disk, but ModelConfig construction still eagerly builds an
+# HTTP client that fails validation against a SOCKS proxy URL scheme unless
+# these are set before any vllm config object is constructed.
+os.environ.setdefault("HF_HUB_OFFLINE", "1")
+os.environ.pop("ALL_PROXY", None)
+os.environ.pop("all_proxy", None)
+
+import pytest
+
+from tests.v1.core.utils import create_requests, create_scheduler
+from gladius_vllm.scheduler import GladiusScheduler
+
+MODEL = "Qwen/Qwen3-1.7B"  # already present in the local HF cache
+
+
+def _write_snapshot(
+    directory,
+    *,
+    engine_id: str,
+    model_id: str,
+    generation: int,
+    max_num_seqs=None,
+    max_num_batched_tokens=None,
+    ttl_seconds: float = 30.0,
+    created_at=None,
+):
+    created_at = created_at or datetime.now(timezone.utc)
+    expires_at = created_at + timedelta(seconds=ttl_seconds)
+    payload = {
+        "schema_version": "1.0.0",
+        "generation": generation,
+        "policy_id": f"policy-{generation}",
+        "model_id": model_id,
+        "engine_id": engine_id,
+        "created_at": created_at.isoformat().replace("+00:00", "Z"),
+        "expires_at": expires_at.isoformat().replace("+00:00", "Z"),
+        "admission": {
+            "max_num_seqs": max_num_seqs,
+            "max_num_batched_tokens": max_num_batched_tokens,
+        },
+        "notes": None,
+    }
+    path = directory / "policy_snapshot.json"
+    tmp = directory / ".policy_snapshot.tmp"
+    tmp.write_text(json.dumps(payload))
+    os.replace(tmp, path)
+    return path
+
+
+def _build_gladius_scheduler(vanilla, block_size=16):
+    return GladiusScheduler(
+        vllm_config=vanilla.vllm_config,
+        kv_cache_config=vanilla.kv_cache_config,
+        structured_output_manager=vanilla.structured_output_manager,
+        block_size=block_size,
+        log_stats=True,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _fixed_engine_id(monkeypatch):
+    monkeypatch.setenv("GLADIUS_ENGINE_ID", "test-engine")
+    monkeypatch.setenv("GLADIUS_POLICY_POLL_INTERVAL_MS", "0")
+
+
+def test_no_policy_file_matches_vanilla_scheduler_decisions(tmp_path, monkeypatch):
+    monkeypatch.setenv("GLADIUS_POLICY_DIR", str(tmp_path))  # dir exists, no file in it
+
+    vanilla = create_scheduler(model=MODEL, max_num_seqs=16, max_num_batched_tokens=8192)
+    gladius = _build_gladius_scheduler(vanilla)
+
+    for req in create_requests(num_requests=20, num_tokens=50, max_tokens=8):
+        vanilla.add_request(req)
+    for req in create_requests(num_requests=20, num_tokens=50, max_tokens=8):
+        gladius.add_request(req)
+
+    vanilla_output = vanilla.schedule()
+    gladius_output = gladius.schedule()
+
+    assert gladius.max_num_running_reqs == vanilla.max_num_running_reqs
+    assert gladius.max_num_scheduled_tokens == vanilla.max_num_scheduled_tokens
+    assert sorted(gladius_output.num_scheduled_tokens.items()) == sorted(
+        vanilla_output.num_scheduled_tokens.items()
+    )
+    assert gladius_output.total_num_scheduled_tokens == vanilla_output.total_num_scheduled_tokens
+    assert {r.req_id for r in gladius_output.scheduled_new_reqs} == {
+        r.req_id for r in vanilla_output.scheduled_new_reqs
+    }
+
+
+def test_no_policy_dir_configured_at_all_matches_vanilla(monkeypatch):
+    monkeypatch.delenv("GLADIUS_POLICY_DIR", raising=False)
+
+    vanilla = create_scheduler(model=MODEL, max_num_seqs=16, max_num_batched_tokens=8192)
+    gladius = _build_gladius_scheduler(vanilla)
+
+    for req in create_requests(num_requests=5, num_tokens=50, max_tokens=8):
+        vanilla.add_request(req)
+    for req in create_requests(num_requests=5, num_tokens=50, max_tokens=8):
+        gladius.add_request(req)
+
+    vanilla_output = vanilla.schedule()
+    gladius_output = gladius.schedule()
+    assert gladius_output.total_num_scheduled_tokens == vanilla_output.total_num_scheduled_tokens
+
+
+def test_policy_lowering_max_num_seqs_changes_admission(tmp_path, monkeypatch):
+    monkeypatch.setenv("GLADIUS_POLICY_DIR", str(tmp_path))
+
+    vanilla = create_scheduler(model=MODEL, max_num_seqs=16, max_num_batched_tokens=8192)
+    gladius = _build_gladius_scheduler(vanilla)
+    _write_snapshot(
+        tmp_path,
+        engine_id=gladius.engine_id,
+        model_id=gladius.model_id,
+        generation=1,
+        max_num_seqs=4,
+    )
+
+    for req in create_requests(num_requests=20, num_tokens=10, max_tokens=8):
+        gladius.add_request(req)
+
+    output = gladius.schedule()
+    assert gladius.max_num_running_reqs == 4
+    assert len(gladius.running) == 4
+    assert len(output.scheduled_new_reqs) == 4
+
+
+def test_policy_lowering_token_budget_changes_scheduled_tokens(tmp_path, monkeypatch):
+    monkeypatch.setenv("GLADIUS_POLICY_DIR", str(tmp_path))
+
+    vanilla = create_scheduler(model=MODEL, max_num_seqs=16, max_num_batched_tokens=8192)
+    gladius = _build_gladius_scheduler(vanilla)
+    _write_snapshot(
+        tmp_path,
+        engine_id=gladius.engine_id,
+        model_id=gladius.model_id,
+        generation=1,
+        max_num_batched_tokens=64,
+    )
+
+    for req in create_requests(num_requests=10, num_tokens=50, max_tokens=8):
+        gladius.add_request(req)
+
+    output = gladius.schedule()
+    assert gladius.max_num_scheduled_tokens == 64
+    assert output.total_num_scheduled_tokens <= 64
+
+
+def test_policy_above_startup_ceiling_is_clamped_not_applied(tmp_path, monkeypatch):
+    monkeypatch.setenv("GLADIUS_POLICY_DIR", str(tmp_path))
+
+    vanilla = create_scheduler(model=MODEL, max_num_seqs=16, max_num_batched_tokens=8192)
+    gladius = _build_gladius_scheduler(vanilla)
+    _write_snapshot(
+        tmp_path,
+        engine_id=gladius.engine_id,
+        model_id=gladius.model_id,
+        generation=1,
+        max_num_seqs=999,
+        max_num_batched_tokens=999999,
+    )
+
+    for req in create_requests(num_requests=20, num_tokens=10, max_tokens=8):
+        gladius.add_request(req)
+    gladius.schedule()
+
+    # Effective ceiling never exceeds startup values, even though the policy
+    # requested far more.
+    assert gladius.max_num_running_reqs == gladius.startup_max_num_seqs == 16
+    assert (
+        gladius.max_num_scheduled_tokens == gladius.startup_max_num_batched_tokens == 8192
+    )
+
+
+def test_corrupt_then_valid_then_stale_generation_sequence(tmp_path, monkeypatch):
+    # The lowered ceiling (4) is published *before* the first schedule() call
+    # so the running count never starts out above it -- shrinking the
+    # ceiling below an already-larger running count is a distinct, separate
+    # safety behavior covered by test_running_count_floor_when_ceiling_drops
+    # below (the base Scheduler has no preemption path to evict already-
+    # admitted requests, so this scheduler floors the ceiling at the current
+    # running count rather than violating vLLM's own admission invariant).
+    monkeypatch.setenv("GLADIUS_POLICY_DIR", str(tmp_path))
+
+    vanilla = create_scheduler(model=MODEL, max_num_seqs=16, max_num_batched_tokens=8192)
+    gladius = _build_gladius_scheduler(vanilla)
+
+    for req in create_requests(num_requests=20, num_tokens=10, max_tokens=8):
+        gladius.add_request(req)
+
+    # Step 1: valid snapshot, generation 5, lowers ceiling to 4 from the start.
+    _write_snapshot(
+        tmp_path, engine_id=gladius.engine_id, model_id=gladius.model_id,
+        generation=5, max_num_seqs=4,
+    )
+    gladius.schedule()
+    assert gladius.max_num_running_reqs == 4
+
+    # Step 2: corrupt write -> keep last-good (still 4).
+    (tmp_path / "policy_snapshot.json").write_text("{not valid json")
+    gladius.schedule()
+    assert gladius.max_num_running_reqs == 4
+
+    # Step 3: a regressed generation (3 < 5) -> rejected, still 4.
+    _write_snapshot(
+        tmp_path, engine_id=gladius.engine_id, model_id=gladius.model_id,
+        generation=3, max_num_seqs=8,
+    )
+    gladius.schedule()
+    assert gladius.max_num_running_reqs == 4
+
+    # Step 4: a genuinely newer generation (6) -> accepted, ceiling raised to 8.
+    _write_snapshot(
+        tmp_path, engine_id=gladius.engine_id, model_id=gladius.model_id,
+        generation=6, max_num_seqs=8,
+    )
+    gladius.schedule()
+    assert gladius.max_num_running_reqs == 8
+
+
+def test_running_count_floor_when_ceiling_drops_below_already_admitted(tmp_path, monkeypatch):
+    monkeypatch.setenv("GLADIUS_POLICY_DIR", str(tmp_path))
+
+    vanilla = create_scheduler(model=MODEL, max_num_seqs=16, max_num_batched_tokens=8192)
+    gladius = _build_gladius_scheduler(vanilla)
+
+    for req in create_requests(num_requests=20, num_tokens=10, max_tokens=8):
+        gladius.add_request(req)
+
+    # No policy yet: admits up to the startup ceiling (16).
+    gladius.schedule()
+    assert len(gladius.running) == 16
+
+    # Now lower the ceiling to 4 -- fewer than what's already running. This
+    # must not crash (no forced eviction/preemption in phase 1 scope); the
+    # scheduler floors the effective ceiling at the current running count
+    # instead of violating the base Scheduler's own admission invariant.
+    _write_snapshot(
+        tmp_path, engine_id=gladius.engine_id, model_id=gladius.model_id,
+        generation=1, max_num_seqs=4,
+    )
+    gladius.schedule()
+    assert gladius.max_num_running_reqs == 16
+    assert len(gladius.running) == 16
+
+
+def test_engine_degrades_when_policy_expires_mid_run(tmp_path, monkeypatch):
+    monkeypatch.setenv("GLADIUS_POLICY_DIR", str(tmp_path))
+
+    vanilla = create_scheduler(model=MODEL, max_num_seqs=16, max_num_batched_tokens=8192)
+    gladius = _build_gladius_scheduler(vanilla)
+
+    for req in create_requests(num_requests=20, num_tokens=10, max_tokens=8):
+        gladius.add_request(req)
+
+    _write_snapshot(
+        tmp_path, engine_id=gladius.engine_id, model_id=gladius.model_id,
+        generation=1, max_num_seqs=4, ttl_seconds=0.05,
+    )
+    gladius.schedule()
+    assert gladius.max_num_running_reqs == 4
+
+    import time
+
+    time.sleep(0.15)
+    gladius.schedule()
+    assert gladius.max_num_running_reqs == gladius.startup_max_num_seqs == 16

--- a/tests/gladius/test_policy_loader.py
+++ b/tests/gladius/test_policy_loader.py
@@ -1,0 +1,288 @@
+"""Pure-Python tests for PolicyLoader -- no GPU, no model, no vllm executor.
+
+These do import `gladius_vllm.policy`, which has no vllm-internal
+dependencies beyond the package's own `schema.py`/`errors.py`.
+"""
+
+import json
+import os
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from gladius_vllm.policy import PolicyLoader
+
+ENGINE_ID = "engine-test"
+MODEL_ID = "facebook/opt-125m"
+STARTUP_SEQS = 64
+STARTUP_TOKENS = 4096
+
+
+def _write(path: Path, **overrides):
+    now = datetime.now(timezone.utc)
+    payload = {
+        "schema_version": "1.0.0",
+        "generation": 1,
+        "policy_id": "policy-1",
+        "model_id": MODEL_ID,
+        "engine_id": ENGINE_ID,
+        "created_at": now.isoformat().replace("+00:00", "Z"),
+        "expires_at": (now + timedelta(seconds=30)).isoformat().replace("+00:00", "Z"),
+        "admission": {"max_num_seqs": 16, "max_num_batched_tokens": 512},
+        "notes": None,
+    }
+    payload.update(overrides)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(payload))
+    os.replace(tmp, path)
+    return payload
+
+
+def _loader(path: Path | None, poll_interval_ms: int = 0) -> PolicyLoader:
+    return PolicyLoader(
+        snapshot_path=path,
+        engine_id=ENGINE_ID,
+        model_id=MODEL_ID,
+        startup_max_num_seqs=STARTUP_SEQS,
+        startup_max_num_batched_tokens=STARTUP_TOKENS,
+        poll_interval_ms=poll_interval_ms,
+    )
+
+
+def test_missing_file_returns_no_policy_status(tmp_path):
+    loader = _loader(tmp_path / "policy_snapshot.json")
+    decision = loader.poll()
+    assert decision.status == "no_policy"
+    assert decision.source == "default"
+    assert decision.max_num_seqs == STARTUP_SEQS
+    assert decision.max_num_batched_tokens == STARTUP_TOKENS
+
+
+def test_none_path_returns_no_policy_status():
+    loader = _loader(None)
+    decision = loader.poll()
+    assert decision.status == "no_policy"
+    assert decision.max_num_seqs == STARTUP_SEQS
+
+
+def test_first_valid_load_accepted(tmp_path):
+    path = tmp_path / "policy_snapshot.json"
+    _write(path)
+    loader = _loader(path)
+    decision = loader.poll()
+    assert decision.status == "active"
+    assert decision.source == "file"
+    assert decision.max_num_seqs == 16
+    assert decision.max_num_batched_tokens == 512
+    assert decision.policy_id == "policy-1"
+    assert decision.generation == 1
+
+
+def test_null_admission_fields_fall_back_to_startup_ceiling(tmp_path):
+    path = tmp_path / "policy_snapshot.json"
+    _write(path, admission={"max_num_seqs": None, "max_num_batched_tokens": None})
+    loader = _loader(path)
+    decision = loader.poll()
+    assert decision.status == "active"
+    assert decision.max_num_seqs == STARTUP_SEQS
+    assert decision.max_num_batched_tokens == STARTUP_TOKENS
+
+
+def test_corrupt_json_first_load_falls_back_to_default(tmp_path):
+    path = tmp_path / "policy_snapshot.json"
+    path.write_text("{not valid json")
+    loader = _loader(path)
+    decision = loader.poll()
+    assert decision.status == "corrupt"
+    assert decision.source == "default"
+    assert decision.max_num_seqs == STARTUP_SEQS
+
+
+def test_corrupt_json_after_good_load_keeps_last_good(tmp_path):
+    path = tmp_path / "policy_snapshot.json"
+    _write(path)
+    loader = _loader(path)
+    good = loader.poll()
+    assert good.status == "active"
+
+    path.write_text("{not valid json")
+    decision = loader.poll()
+    assert decision.status == "corrupt"
+    assert decision.source == "file"
+    assert decision.max_num_seqs == 16
+    assert decision.generation == 1
+
+
+def test_missing_required_field_rejected_as_corrupt(tmp_path):
+    path = tmp_path / "policy_snapshot.json"
+    now = datetime.now(timezone.utc)
+    payload = {
+        "schema_version": "1.0.0",
+        "generation": 1,
+        "policy_id": "policy-1",
+        "model_id": MODEL_ID,
+        # engine_id missing
+        "created_at": now.isoformat(),
+        "expires_at": (now + timedelta(seconds=30)).isoformat(),
+    }
+    path.write_text(json.dumps(payload))
+    loader = _loader(path)
+    decision = loader.poll()
+    assert decision.status == "corrupt"
+
+
+def test_generation_regression_rejected(tmp_path):
+    path = tmp_path / "policy_snapshot.json"
+    _write(path, generation=5)
+    loader = _loader(path)
+    first = loader.poll()
+    assert first.generation == 5
+
+    _write(path, generation=3)
+    decision = loader.poll()
+    assert decision.status == "rejected_regression"
+    assert decision.generation == 5  # unchanged
+
+
+def test_generation_equal_rejected(tmp_path):
+    path = tmp_path / "policy_snapshot.json"
+    _write(path, generation=5)
+    loader = _loader(path)
+    loader.poll()
+
+    _write(path, generation=5)
+    decision = loader.poll()
+    assert decision.status == "rejected_regression"
+
+
+def test_engine_id_mismatch_rejected(tmp_path):
+    path = tmp_path / "policy_snapshot.json"
+    _write(path, engine_id="some-other-engine")
+    loader = _loader(path)
+    decision = loader.poll()
+    assert decision.status == "rejected_engine_mismatch"
+    assert decision.source == "default"
+
+
+def test_model_id_mismatch_rejected(tmp_path):
+    path = tmp_path / "policy_snapshot.json"
+    _write(path, model_id="some-other-model")
+    loader = _loader(path)
+    decision = loader.poll()
+    assert decision.status == "rejected_engine_mismatch"
+
+
+def test_expired_policy_falls_back_to_default(tmp_path):
+    path = tmp_path / "policy_snapshot.json"
+    now = datetime.now(timezone.utc)
+    _write(
+        path,
+        created_at=(now - timedelta(seconds=10)).isoformat().replace("+00:00", "Z"),
+        expires_at=(now - timedelta(seconds=1)).isoformat().replace("+00:00", "Z"),
+    )
+    loader = _loader(path)
+    decision = loader.poll()
+    assert decision.status == "expired"
+    assert decision.source == "default"
+    assert decision.max_num_seqs == STARTUP_SEQS
+
+
+def test_policy_expires_mid_run_after_being_valid(tmp_path):
+    path = tmp_path / "policy_snapshot.json"
+    now = datetime.now(timezone.utc)
+    _write(
+        path,
+        created_at=now.isoformat().replace("+00:00", "Z"),
+        expires_at=(now + timedelta(milliseconds=50)).isoformat().replace("+00:00", "Z"),
+    )
+    loader = _loader(path, poll_interval_ms=0)
+    first = loader.poll()
+    assert first.status == "active"
+
+    time.sleep(0.1)
+    decision = loader.poll()
+    assert decision.status == "expired"
+    assert decision.source == "default"
+
+
+def test_unchanged_file_skips_reparse(tmp_path, monkeypatch):
+    path = tmp_path / "policy_snapshot.json"
+    _write(path)
+    loader = _loader(path)
+    loader.poll()
+
+    real_read_text = Path.read_text
+    call_count = {"n": 0}
+
+    def counting_read_text(self, *args, **kwargs):
+        call_count["n"] += 1
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", counting_read_text)
+    loader.poll()
+    loader.poll()
+    assert call_count["n"] == 0
+
+
+def test_schema_version_major_mismatch_rejected(tmp_path):
+    path = tmp_path / "policy_snapshot.json"
+    _write(path, schema_version="2.0.0")
+    loader = _loader(path)
+    decision = loader.poll()
+    assert decision.status == "corrupt"
+
+
+@pytest.mark.parametrize(
+    "admission",
+    [
+        {"max_num_seqs": 0, "max_num_batched_tokens": 512},
+        {"max_num_seqs": 16, "max_num_batched_tokens": -1},
+        {"max_num_seqs": "not-an-int", "max_num_batched_tokens": 512},
+    ],
+)
+def test_range_validation_rejects_bad_values(tmp_path, admission):
+    path = tmp_path / "policy_snapshot.json"
+    _write(path, admission=admission)
+    loader = _loader(path)
+    decision = loader.poll()
+    assert decision.status == "corrupt"
+
+
+def test_policy_above_startup_ceiling_passes_through_unclamped_at_loader_level(tmp_path):
+    path = tmp_path / "policy_snapshot.json"
+    _write(
+        path,
+        admission={
+            "max_num_seqs": STARTUP_SEQS * 10,
+            "max_num_batched_tokens": STARTUP_TOKENS * 10,
+        },
+    )
+    loader = _loader(path)
+    decision = loader.poll()
+    assert decision.status == "active"
+    # Loader itself does not clamp -- that's GladiusScheduler's job.
+    assert decision.max_num_seqs == STARTUP_SEQS * 10
+    assert decision.max_num_batched_tokens == STARTUP_TOKENS * 10
+
+
+def test_unrecognized_admission_key_rejected(tmp_path):
+    path = tmp_path / "policy_snapshot.json"
+    _write(path, admission={"max_num_seqs": 16, "enable_prefix_caching": True})
+    loader = _loader(path)
+    decision = loader.poll()
+    assert decision.status == "corrupt"
+
+
+def test_expires_at_before_created_at_rejected(tmp_path):
+    path = tmp_path / "policy_snapshot.json"
+    now = datetime.now(timezone.utc)
+    _write(
+        path,
+        created_at=now.isoformat().replace("+00:00", "Z"),
+        expires_at=(now - timedelta(seconds=1)).isoformat().replace("+00:00", "Z"),
+    )
+    loader = _loader(path)
+    decision = loader.poll()
+    assert decision.status == "corrupt"

--- a/tests/gladius/test_telemetry_writer.py
+++ b/tests/gladius/test_telemetry_writer.py
@@ -1,0 +1,212 @@
+"""Pure-Python tests for TelemetryWriter -- hand-built fixtures, no vllm
+executor/GPU, and no real Scheduler/SchedulerOutput instances needed since
+TelemetryWriter only duck-types on a handful of attributes.
+"""
+
+import json
+from types import SimpleNamespace
+
+from gladius_vllm.policy import PolicyDecision
+from gladius_vllm.telemetry import TelemetryWriter
+
+EXPECTED_FIELDS = {
+    "schema_version",
+    "generation",
+    "policy_id",
+    "model_id",
+    "engine_id",
+    "created_at",
+    "expires_at",
+    "step",
+    "num_running_reqs",
+    "num_waiting_reqs",
+    "num_skipped_waiting_reqs",
+    "num_scheduled_reqs",
+    "num_scheduled_tokens",
+    "num_prefill_reqs",
+    "num_decode_reqs",
+    "kv_cache_usage",
+    "policy_status",
+    "policy_source",
+    "clamped",
+}
+
+
+def _fake_request(num_computed_tokens: int, num_prompt_tokens: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        num_computed_tokens=num_computed_tokens, num_prompt_tokens=num_prompt_tokens
+    )
+
+
+def _fake_scheduler(
+    *,
+    requests: dict,
+    running: list,
+    waiting: list,
+    skipped_waiting: list,
+    startup_max_num_seqs: int = 64,
+    startup_max_num_batched_tokens: int = 4096,
+) -> SimpleNamespace:
+    stats = SimpleNamespace(
+        num_running_reqs=len(running),
+        num_waiting_reqs=len(waiting),
+        num_skipped_waiting_reqs=len(skipped_waiting),
+        kv_cache_usage=0.42,
+    )
+    return SimpleNamespace(
+        requests=requests,
+        running=running,
+        waiting=waiting,
+        skipped_waiting=skipped_waiting,
+        startup_max_num_seqs=startup_max_num_seqs,
+        startup_max_num_batched_tokens=startup_max_num_batched_tokens,
+        make_stats=lambda: stats,
+    )
+
+
+def _fake_output(new_req_ids: list, scheduled_tokens: dict) -> SimpleNamespace:
+    return SimpleNamespace(
+        scheduled_new_reqs=[SimpleNamespace(req_id=rid) for rid in new_req_ids],
+        num_scheduled_tokens=scheduled_tokens,
+        total_num_scheduled_tokens=sum(scheduled_tokens.values()),
+    )
+
+
+def _decision(**overrides) -> PolicyDecision:
+    defaults = dict(
+        max_num_seqs=64,
+        max_num_batched_tokens=4096,
+        policy_id="policy-1",
+        generation=3,
+        status="active",
+        source="file",
+    )
+    defaults.update(overrides)
+    return PolicyDecision(**defaults)
+
+
+def test_writes_one_valid_json_line_with_all_fields(tmp_path):
+    path = tmp_path / "telemetry.jsonl"
+    writer = TelemetryWriter(path=path, engine_id="engine-1", model_id="model-1")
+    scheduler = _fake_scheduler(
+        requests={"r1": _fake_request(10, 10)},
+        running=["r1"],
+        waiting=[],
+        skipped_waiting=[],
+    )
+    output = _fake_output(new_req_ids=["r1"], scheduled_tokens={"r1": 1})
+    writer.record(scheduler, output, _decision())
+    writer.close()
+
+    lines = path.read_text().splitlines()
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert set(record.keys()) == EXPECTED_FIELDS
+    assert record["policy_status"] == "active"
+    assert record["policy_source"] == "file"
+    assert record["clamped"] == {"max_num_seqs": False, "max_num_batched_tokens": False}
+
+
+def test_prefill_decode_split_new_request_counts_as_prefill(tmp_path):
+    path = tmp_path / "telemetry.jsonl"
+    writer = TelemetryWriter(path=path, engine_id="e", model_id="m")
+    scheduler = _fake_scheduler(
+        requests={"new1": _fake_request(0, 50)},
+        running=[],
+        waiting=[],
+        skipped_waiting=[],
+    )
+    output = _fake_output(new_req_ids=["new1"], scheduled_tokens={"new1": 50})
+    writer.record(scheduler, output, _decision())
+    writer.close()
+    record = json.loads(path.read_text().splitlines()[0])
+    assert record["num_prefill_reqs"] == 1
+    assert record["num_decode_reqs"] == 0
+
+
+def test_prefill_decode_split_cached_mid_prompt_counts_as_prefill(tmp_path):
+    path = tmp_path / "telemetry.jsonl"
+    writer = TelemetryWriter(path=path, engine_id="e", model_id="m")
+    scheduler = _fake_scheduler(
+        requests={"cached1": _fake_request(num_computed_tokens=20, num_prompt_tokens=50)},
+        running=["cached1"],
+        waiting=[],
+        skipped_waiting=[],
+    )
+    output = _fake_output(new_req_ids=[], scheduled_tokens={"cached1": 30})
+    writer.record(scheduler, output, _decision())
+    writer.close()
+    record = json.loads(path.read_text().splitlines()[0])
+    assert record["num_prefill_reqs"] == 1
+    assert record["num_decode_reqs"] == 0
+
+
+def test_prefill_decode_split_cached_finished_prompt_counts_as_decode(tmp_path):
+    path = tmp_path / "telemetry.jsonl"
+    writer = TelemetryWriter(path=path, engine_id="e", model_id="m")
+    scheduler = _fake_scheduler(
+        requests={"cached1": _fake_request(num_computed_tokens=50, num_prompt_tokens=50)},
+        running=["cached1"],
+        waiting=[],
+        skipped_waiting=[],
+    )
+    output = _fake_output(new_req_ids=[], scheduled_tokens={"cached1": 1})
+    writer.record(scheduler, output, _decision())
+    writer.close()
+    record = json.loads(path.read_text().splitlines()[0])
+    assert record["num_prefill_reqs"] == 0
+    assert record["num_decode_reqs"] == 1
+
+
+def test_clamped_flag_true_when_decision_exceeds_startup_ceiling(tmp_path):
+    path = tmp_path / "telemetry.jsonl"
+    writer = TelemetryWriter(path=path, engine_id="e", model_id="m")
+    scheduler = _fake_scheduler(
+        requests={},
+        running=[],
+        waiting=[],
+        skipped_waiting=[],
+        startup_max_num_seqs=16,
+        startup_max_num_batched_tokens=2048,
+    )
+    output = _fake_output(new_req_ids=[], scheduled_tokens={})
+    decision = _decision(max_num_seqs=999, max_num_batched_tokens=999999)
+    writer.record(scheduler, output, decision)
+    writer.close()
+    record = json.loads(path.read_text().splitlines()[0])
+    assert record["clamped"] == {"max_num_seqs": True, "max_num_batched_tokens": True}
+
+
+def test_no_path_configured_is_a_silent_noop():
+    writer = TelemetryWriter(path=None, engine_id="e", model_id="m")
+    scheduler = _fake_scheduler(requests={}, running=[], waiting=[], skipped_waiting=[])
+    output = _fake_output(new_req_ids=[], scheduled_tokens={})
+    writer.record(scheduler, output, _decision())  # must not raise
+    writer.close()
+
+
+def test_sample_every_n_steps_downsamples(tmp_path):
+    path = tmp_path / "telemetry.jsonl"
+    writer = TelemetryWriter(
+        path=path, engine_id="e", model_id="m", sample_every_n_steps=3
+    )
+    scheduler = _fake_scheduler(requests={}, running=[], waiting=[], skipped_waiting=[])
+    output = _fake_output(new_req_ids=[], scheduled_tokens={})
+    for _ in range(7):
+        writer.record(scheduler, output, _decision())
+    writer.close()
+    lines = path.read_text().splitlines()
+    assert len(lines) == 2  # steps 3 and 6
+    assert json.loads(lines[0])["step"] == 3
+    assert json.loads(lines[1])["step"] == 6
+
+
+def test_expires_at_is_always_null(tmp_path):
+    path = tmp_path / "telemetry.jsonl"
+    writer = TelemetryWriter(path=path, engine_id="e", model_id="m")
+    scheduler = _fake_scheduler(requests={}, running=[], waiting=[], skipped_waiting=[])
+    output = _fake_output(new_req_ids=[], scheduled_tokens={})
+    writer.record(scheduler, output, _decision())
+    writer.close()
+    record = json.loads(path.read_text().splitlines()[0])
+    assert record["expires_at"] is None


### PR DESCRIPTION
…scheduler

Adds gladius_vllm/, an additive plugin package (zero changes to vllm/) wired in via the existing --scheduler-cls mechanism:

- GladiusScheduler(Scheduler): hot-reloads admission ceilings (max_num_seqs/max_num_batched_tokens) from an externally-published policy_snapshot.json, polled synchronously at the top of schedule() with no background thread. Degrades to byte-for-byte vanilla Scheduler behavior when no policy is configured, and never admits above the startup ceiling (those values are baked into CUDA graph capture sizes and torch.compile shapes, so raising them post-hoc is unsafe -- this scheduler only ever clamps down). Also floors the effective ceiling at the current running-request count, since there is no preemption path to evict already-admitted requests down to a newly-lowered cap.
- PolicyLoader: atomic snapshot read (temp-file+rename on the writer side), generation monotonicity, expiry, and corruption handling -- never raises, so a bad snapshot can never take down request scheduling.
- TelemetryWriter: appends one JSON line per scheduling step to telemetry.jsonl (running/waiting counts, scheduled tokens, KV cache usage, prefill/decode split, policy status/generation).
- GladiusStatLogger: optional secondary StatLoggerBase hook (not load-bearing; StatLoggerBase.record() has no scheduler/SchedulerOutput access, so GladiusScheduler itself is telemetry's authoritative writer).

Tests (tests/gladius/): 21 pure-Python PolicyLoader tests, 8 TelemetryWriter tests, 8 CPU-only scheduler tests via a local wrapper around tests/v1/core/utils.create_scheduler(), and one real-engine contract test (marked slow_test) against a live vLLM engine.




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

