### PR TITLE
[ROCm][CI] Restore Mistral tool-parser compatibility after unification

### DIFF
--- a/vllm/parser/mistral.py
+++ b/vllm/parser/mistral.py
@@ -526,14 +526,18 @@ class MistralParser(ParserEngine):
     def _legacy_extract_tool_calls(
         self,
         model_output: str,
-        request: ChatCompletionRequest,
+        request: ChatCompletionRequest | None,
     ) -> ExtractedToolCallInformation:
         """Pre-v11 non-streaming extraction.
 
         Handles ``[TOOL_CALLS][{...}]`` and guided bare-array formats.
         """
-        tool_choice = getattr(request, "tool_choice", None)
-        tools = getattr(request, "tools", None)
+        if request is None:
+            tool_choice = None
+            tools = None
+        else:
+            tool_choice = request.tool_choice
+            tools = request.tools
 
         # tool_choice="none" with tools: never produce tool calls.
         if tool_choice == "none" and tools:

--- a/vllm/parser/mistral.py
+++ b/vllm/parser/mistral.py
@@ -532,8 +532,11 @@ class MistralParser(ParserEngine):
 
         Handles ``[TOOL_CALLS][{...}]`` and guided bare-array formats.
         """
+        tool_choice = getattr(request, "tool_choice", None)
+        tools = getattr(request, "tools", None)
+
         # tool_choice="none" with tools: never produce tool calls.
-        if request.tool_choice == "none" and request.tools:
+        if tool_choice == "none" and tools:
             return ExtractedToolCallInformation(
                 tools_called=False, tool_calls=[], content=model_output
             )
@@ -550,8 +553,8 @@ class MistralParser(ParserEngine):
                     f"but got {model_output}."
                 )
             stringified_tool_calls = raw_tool_calls[0].strip()
-        elif request.tool_choice == "required" or isinstance(
-            request.tool_choice, ChatCompletionNamedToolChoiceParam
+        elif tool_choice == "required" or isinstance(
+            tool_choice, ChatCompletionNamedToolChoiceParam
         ):
             # Guided bare-array output (no [TOOL_CALLS] marker).
             stringified_tool_calls = model_output.strip()

--- a/vllm/tool_parsers/mistral_tool_parser.py
+++ b/vllm/tool_parsers/mistral_tool_parser.py
@@ -25,6 +25,16 @@ class MistralToolParser(MistralParserToolAdapter):  # type: ignore[valid-type, m
     # correctly instead of crashing or dumping the raw envelope into arguments.
     supports_required_and_named = False
 
+    @property
+    def bot_token(self) -> str:
+        """Return the Mistral tool-call marker exposed by the legacy parser."""
+        return self._parser_engine.bot_token
+
+    @property
+    def bot_token_id(self) -> int | None:
+        """Return the token id for :attr:`bot_token`."""
+        return self._parser_engine.bot_token_id
+
     def adjust_request(
         self,
         request: ChatCompletionRequest | ResponsesRequest,


### PR DESCRIPTION
- `git bisect` identified [`1a20d23dab6e`](https://github.com/vllm-project/vllm/commit/1a20d23dab6eef0ce6ab97b7e03c944683cdf90b), [vLLM #48947](https://github.com/vllm-project/vllm/pull/48947), as the first revision with this failure.
- The unified parser moved `bot_token` and `bot_token_id` onto its nested engine and made legacy extraction assume a request object, breaking two behaviors preserved by the former `MistralToolParser`.

Motivation:

- [AMD CI build 11504 — Language Models Test (Extended Generation)](https://buildkite.com/vllm/amd-ci/builds/11504/list?sid=019fb494-a023-4562-bbca-b7c0d94c5c99&tab=output)

PR #48947 replaced the former standalone `MistralToolParser` with an adapter over the unified Mistral parser engine. `bot_token` and `bot_token_id` remained available only on the nested engine, while existing callers still access them on the adapter. Restoring those properties exposed a second compatibility regression: `_legacy_extract_tool_calls` directly accessed `request.tool_choice` and `request.tools`, although the established parser API permits `request=None` and the former implementation tolerated it.
