### PR TITLE
[ROCm][CI] Fall back to lossless Kimi K3 MXFP4 emulation on gfx942

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/ocp_mx_emulation_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/ocp_mx_emulation_moe.py
@@ -69,9 +69,15 @@ class OCP_MXQuantizationEmulationTritonExperts(TritonExperts):
         self.quantization_emulation = True
 
         if self.ocp_mx_scheme in {
+            OCP_MX_Scheme.w_mxfp4,
+            OCP_MX_Scheme.w_mxfp6_e3m2,
+            OCP_MX_Scheme.w_mxfp6_e2m3,
+        }:
+            # Weight-only schemes leave activations unquantized.
+            self._quant_dtype = None
+        elif self.ocp_mx_scheme in {
             OCP_MX_Scheme.w_mxfp4_a_mxfp4,
         }:
-            # Weight has to be dequantized for mxfp4 emulation.
             self._quant_dtype = "mxfp4"
         elif self.ocp_mx_scheme in [
             OCP_MX_Scheme.w_mxfp4_a_mxfp6_e3m2,

--- a/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
@@ -140,6 +140,7 @@ class TritonExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
             MoEActivation.SILU,
             MoEActivation.GELU,
             MoEActivation.GELU_TANH,
+            MoEActivation.SITU,
             MoEActivation.SWIGLUOAI,
             MoEActivation.SWIGLUOAI_UNINTERLEAVE,
             MoEActivation.SWIGLUSTEP,

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -337,7 +337,10 @@ def _get_priority_backends() -> list[Mxfp4MoeBackend]:
     backend-level ``is_supported_config`` check filters by device capability).
     """
     if current_platform.is_rocm():
-        return [Mxfp4MoeBackend.AITER_MXFP4_BF16]
+        return [
+            Mxfp4MoeBackend.AITER_MXFP4_BF16,
+            Mxfp4MoeBackend.EMULATION,
+        ]
     if current_platform.is_xpu():
         return [Mxfp4MoeBackend.XPU]
     _AVAILABLE_BACKENDS = [
@@ -1555,8 +1558,12 @@ def convert_weight_to_mxfp4_moe_kernel_format(
             w13_bias,
             w2_bias,
         )
-    elif mxfp4_backend == Mxfp4MoeBackend.XPU:
-        # No additional transformation needed for XPU backend
+    elif mxfp4_backend in (
+        Mxfp4MoeBackend.XPU,
+        Mxfp4MoeBackend.EMULATION,
+    ):
+        # No additional transformation is needed: XPU consumes the checkpoint
+        # layout directly, while emulation dequantizes that layout at runtime.
         return (
             w13_weight,
             w2_weight,
@@ -1568,7 +1575,7 @@ def convert_weight_to_mxfp4_moe_kernel_format(
     else:
         raise ValueError(
             f"Unsupported mxfp4_backend for Mxfp4MoEMethod: {mxfp4_backend}. "
-            f"Expected TRTLLM, Triton, AITER, or XPU backend."
+            f"Expected TRTLLM, Triton, AITER, XPU, or emulation backend."
         )
 
 

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -15,6 +15,9 @@ from vllm.model_executor.layers.fused_moe import (
     SharedExperts,
 )
 from vllm.model_executor.layers.fused_moe import modular_kernel as mk
+from vllm.model_executor.layers.fused_moe.config import (
+    mxfp4_w4a16_moe_quant_config,
+)
 from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import (
     TRITON_BACKENDS,
     Mxfp4MoeBackend,
@@ -867,6 +870,18 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         else:
             w1_scale = layer.w13_weight_scale
             w2_scale = layer.w2_weight_scale
+
+        if self.mxfp4_backend == Mxfp4MoeBackend.EMULATION:
+            # Canonical ``mxfp4`` checkpoints are weight-only W4A16. The
+            # generic EMULATION config is W4A4, so preserve BF16 activations
+            # while the fallback dequantizes only the weights.
+            return mxfp4_w4a16_moe_quant_config(
+                w1_scale=w1_scale,
+                w2_scale=w2_scale,
+                w1_bias=w1_bias,
+                w2_bias=w2_bias,
+                gemm1_clamp_limit=swiglu_limit,
+            )
 
         return make_mxfp4_moe_quant_config(
             mxfp4_backend=self.mxfp4_backend,


### PR DESCRIPTION
- `git bisect` identified [`aeeb36b1f171`](https://github.com/vllm-project/vllm/commit/aeeb36b1f17145975c6713242f2447bb8b98782b), [vLLM #50000](https://github.com/vllm-project/vllm/pull/50000), as the first revision with both Kimi K3 failures.
- Kimi K3's default MXFP4 RoutedExperts path only advertises AITER on ROCm, but the native backend rejects SiTU on MI300/gfx942 and leaves the model without a selectable backend.

Motivation:

- [AMD CI build 11504 — Kimi K3 Model Initialization](https://buildkite.com/vllm/amd-ci/builds/11504/list?jid=019fb494-a0dc-4350-9b57-0e7e095feb7a&tab=output)
- [AMD CI build 11504 — multimodal tensor schema](https://buildkite.com/vllm/amd-ci/builds/11504/list?sid=019fb494-a028-428a-a0fb-9306a354a615&tab=output)

PR #50000 defaults Kimi K3 to an MXFP4 RoutedExperts configuration. The model-specific native path handles gfx950, while gfx942 reaches the generic MXFP4 MoE oracle. That oracle offered only `AITER_MXFP4_BF16` on ROCm. AITER rejects this SiTU/gfx942 combination, leaving no selectable backend and raising `NotImplementedError` during model construction. The tensor-schema test fails for the same reason before reaching schema processing. The emulation leaf also treated the generic configuration as W4A4. Kimi's checkpoint is weight-only W4A16, so the fallback must keep activations in BF16 and consume the checkpoint's packed MXFP4 layout without conversion.
