### PR TITLE
[ROCm][CI] Update Transformers AR+RMS fusion expectation

### DIFF
--- a/tests/compile/fusions_e2e/test_tp2_ar_rms.py
+++ b/tests/compile/fusions_e2e/test_tp2_ar_rms.py
@@ -219,9 +219,9 @@ def test_tp2_ar_rms_fusions(
 
     matches = matches_fn(n_layers)
     if model_impl == "transformers":
-        # TODO(BadrBasowid): Match the vLLM backend's fusion count once the
-        # separate residual add and RMSNorm operations are fused.
-        matches = matches._replace(aiter_ar_rms_fusion=1)
+        # Transformers add+RMSNorm canonicalization exposes every generic
+        # AR+RMS fusion site, including the final norm.
+        matches = matches._replace(aiter_ar_rms_fusion=matches.ar_rms_fusion)
 
     # Reduce size of model and skip weight loading time
     model_kwargs["hf_overrides"] = hf_overrides(n_layers)


### PR DESCRIPTION
- `git bisect` identified [`59e831c09a22`](https://github.com/vllm-project/vllm/commit/59e831c09a22bdd2732b86a158ff771584b14793), [vLLM #48757](https://github.com/vllm-project/vllm/pull/48757), as the first revision with this failure.
- The PR intentionally canonicalizes separate residual-add and RMSNorm operations before the AITER AR+RMS fusion pass. That exposes all nine valid fusion sites instead of the one visible before the change.

Motivation:

- [AMD CI build 11504 — Distributed Compile Unit Tests](https://buildkite.com/vllm/amd-ci/builds/11504/list?sid=019fb494-9ff8-4e8d-a55e-a909d001390b&tab=output)

PR #48757 enables `AddRMSNormFusionPass` before the AITER all-reduce/RMSNorm fusion for Transformers models. The leaf graph rewrite canonicalizes eight previously separate `aten.add` + `rms_norm` sites. Together with the one site that was already visible, the expected count becomes nine.