### PR TITLE
[Bugfix][Core][Spec Decode] Exclude scheduler padding from draft metrics

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -379,7 +379,11 @@ def test_schedule_prefills_gating(has_running: bool):
     assert any(r.req_id == "new0" for r in output.scheduled_new_reqs)
 
 
-def _setup_remote_kv_resume(num_prompt_tokens: int, matched_tokens: int):
+def _setup_remote_kv_resume(
+    num_prompt_tokens: int,
+    matched_tokens: int,
+    num_speculative_tokens: int | None = None,
+):
     """Drive a remote-KV request `r2` to the resume point (async load complete)
     while another request `r1` is already decoding, so the step is throttle-
     eligible. Returns the scheduler. The connector matches `matched_tokens` of
@@ -392,6 +396,7 @@ def _setup_remote_kv_resume(num_prompt_tokens: int, matched_tokens: int):
         enable_prefix_caching=True,
         use_kv_connector=mock_kv(matched_tokens=matched_tokens, is_async=True),
         block_size=BLOCK_SIZE,
+        num_speculative_tokens=num_speculative_tokens,
     )
     # Distinct prompts so r2 gets no local prefix cache hit from r1, only the
     # connector's external async load.
@@ -1542,7 +1547,7 @@ def test_no_spec_tokens_scheduled_for_prefill_chunks():
 def _model_output(scheduler, output, sampled):
     """Feed `sampled` (per-request list) back to the scheduler."""
     req_ids = list(output.num_scheduled_tokens.keys())
-    scheduler.update_from_output(
+    return scheduler.update_from_output(
         output,
         ModelRunnerOutput(
             req_ids=req_ids,
@@ -1590,6 +1595,66 @@ def test_spec_decode_padding_first_decode_step():
     # r2 is padded to the 1 + num_spec shape with placeholder (-1) drafts.
     assert out.num_scheduled_tokens[r2.request_id] == 1 + num_spec
     assert out.scheduled_spec_decode_tokens[r2.request_id] == [-1] * num_spec
+    assert out.num_invalid_spec_tokens == {r2.request_id: num_spec}
+
+    # Simulate grammar validation shortening r1's real draft to one token.
+    # Its tail padding must merge with (not overwrite) r2's graph padding.
+    scheduler.update_draft_token_ids_in_output(
+        DraftTokenIds([r1.request_id], [[1]]),
+        out,
+    )
+    assert out.scheduled_spec_decode_tokens[r1.request_id] == [1, -1, -1]
+    assert out.num_invalid_spec_tokens == {
+        r1.request_id: 2,
+        r2.request_id: num_spec,
+    }
+
+    # A complete frame for r2 replaces its graph padding, so the stale invalid
+    # count must be removed without disturbing r1's partial-padding record.
+    scheduler.update_draft_token_ids_in_output(
+        DraftTokenIds([r2.request_id], [[10, 11, 12]]),
+        out,
+    )
+    assert out.scheduled_spec_decode_tokens[r2.request_id] == [10, 11, 12]
+    assert out.num_invalid_spec_tokens == {r1.request_id: 2}
+
+    # Padding still executes for r1, but metrics observe only its one real
+    # draft token plus r2's complete three-token draft.
+    engine_core_outputs = _model_output(
+        scheduler,
+        out,
+        [[1, 4], [10, 11, 12, 13]],
+    )
+    stats = engine_core_outputs[0].scheduler_stats.spec_decoding_stats
+    assert stats is not None
+    assert stats.num_drafts == 2
+    assert stats.num_draft_tokens == 4
+    assert stats.num_accepted_tokens == 4
+    assert stats.num_accepted_tokens_per_pos == [2, 1, 1]
+    assert stats.num_draft_tokens_per_pos == [2, 1, 1]
+
+
+def test_spec_decode_padding_after_remote_kv_resume_excluded_from_stats():
+    """A remote-KV resume keeps graph padding, but metrics ignore it."""
+    num_spec = 3
+    scheduler = _setup_remote_kv_resume(
+        num_prompt_tokens=32,
+        matched_tokens=32,
+        num_speculative_tokens=num_spec,
+    )
+    out = scheduler.schedule()
+
+    assert out.num_scheduled_tokens["r2"] == 1 + num_spec
+    assert out.scheduled_spec_decode_tokens["r2"] == [-1] * num_spec
+    assert out.num_invalid_spec_tokens == {"r2": num_spec}
+
+    req_ids = list(out.num_scheduled_tokens)
+    engine_core_outputs = _model_output(
+        scheduler,
+        out,
+        [[1000 + i] for i in range(len(req_ids))],
+    )
+    assert engine_core_outputs[0].scheduler_stats.spec_decoding_stats is None
 
 
 def test_spec_decode_padding_skipped_for_diffusion():

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -385,7 +385,11 @@ def test_schedule_prefills_gating(has_running: bool):
     assert any(r.req_id == "new0" for r in output.scheduled_new_reqs)
 
 
-def _setup_remote_kv_resume(num_prompt_tokens: int, matched_tokens: int):
+def _setup_remote_kv_resume(
+    num_prompt_tokens: int,
+    matched_tokens: int,
+    num_speculative_tokens: int | None = None,
+):
     """Drive a remote-KV request `r2` to the resume point (async load complete)
     while another request `r1` is already decoding, so the step is throttle-
     eligible. Returns the scheduler. The connector matches `matched_tokens` of
@@ -398,6 +402,7 @@ def _setup_remote_kv_resume(num_prompt_tokens: int, matched_tokens: int):
         enable_prefix_caching=True,
         use_kv_connector=mock_kv(matched_tokens=matched_tokens, is_async=True),
         block_size=BLOCK_SIZE,
+        num_speculative_tokens=num_speculative_tokens,
     )
     # Distinct prompts so r2 gets no local prefix cache hit from r1, only the
     # connector's external async load.
@@ -1676,7 +1681,7 @@ def test_no_spec_tokens_scheduled_for_prefill_chunks():
 def _model_output(scheduler, output, sampled):
     """Feed `sampled` (per-request list) back to the scheduler."""
     req_ids = list(output.num_scheduled_tokens.keys())
-    scheduler.update_from_output(
+    return scheduler.update_from_output(
         output,
         ModelRunnerOutput(
             req_ids=req_ids,
@@ -1724,6 +1729,66 @@ def test_spec_decode_padding_first_decode_step():
     # r2 is padded to the 1 + num_spec shape with placeholder (-1) drafts.
     assert out.num_scheduled_tokens[r2.request_id] == 1 + num_spec
     assert out.scheduled_spec_decode_tokens[r2.request_id] == [-1] * num_spec
+    assert out.num_invalid_spec_tokens == {r2.request_id: num_spec}
+
+    # Simulate grammar validation shortening r1's real draft to one token.
+    # Its tail padding must merge with (not overwrite) r2's graph padding.
+    scheduler.update_draft_token_ids_in_output(
+        DraftTokenIds([r1.request_id], [[1]]),
+        out,
+    )
+    assert out.scheduled_spec_decode_tokens[r1.request_id] == [1, -1, -1]
+    assert out.num_invalid_spec_tokens == {
+        r1.request_id: 2,
+        r2.request_id: num_spec,
+    }
+
+    # A complete frame for r2 replaces its graph padding, so the stale invalid
+    # count must be removed without disturbing r1's partial-padding record.
+    scheduler.update_draft_token_ids_in_output(
+        DraftTokenIds([r2.request_id], [[10, 11, 12]]),
+        out,
+    )
+    assert out.scheduled_spec_decode_tokens[r2.request_id] == [10, 11, 12]
+    assert out.num_invalid_spec_tokens == {r1.request_id: 2}
+
+    # Padding still executes for r1, but metrics observe only its one real
+    # draft token plus r2's complete three-token draft.
+    engine_core_outputs = _model_output(
+        scheduler,
+        out,
+        [[1, 4], [10, 11, 12, 13]],
+    )
+    stats = engine_core_outputs[0].scheduler_stats.spec_decoding_stats
+    assert stats is not None
+    assert stats.num_drafts == 2
+    assert stats.num_draft_tokens == 4
+    assert stats.num_accepted_tokens == 4
+    assert stats.num_accepted_tokens_per_pos == [2, 1, 1]
+    assert stats.num_draft_tokens_per_pos == [2, 1, 1]
+
+
+def test_spec_decode_padding_after_remote_kv_resume_excluded_from_stats():
+    """A remote-KV resume keeps graph padding, but metrics ignore it."""
+    num_spec = 3
+    scheduler = _setup_remote_kv_resume(
+        num_prompt_tokens=32,
+        matched_tokens=32,
+        num_speculative_tokens=num_spec,
+    )
+    out = scheduler.schedule()
+
+    assert out.num_scheduled_tokens["r2"] == 1 + num_spec
+    assert out.scheduled_spec_decode_tokens["r2"] == [-1] * num_spec
+    assert out.num_invalid_spec_tokens == {"r2": num_spec}
+
+    req_ids = list(out.num_scheduled_tokens)
+    engine_core_outputs = _model_output(
+        scheduler,
+        out,
+        [[1000 + i] for i in range(len(req_ids))],
+    )
+    assert engine_core_outputs[0].scheduler_stats.spec_decoding_stats is None
 
 
 def test_spec_decode_padding_skipped_for_diffusion():

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -466,6 +466,9 @@ class Scheduler(SchedulerInterface):
         encoder_compute_budget = self.max_num_encoder_input_tokens
         # Spec decode-related.
         scheduled_spec_decode_tokens: dict[str, list[int]] = {}
+        # Number of trailing placeholders that keep the execution shape but
+        # do not represent logical draft tokens for each request.
+        num_invalid_spec_tokens: dict[str, int] = {}
         # Whether the running batch contains any prefill requests.
         prefill_scheduled = False
 
@@ -1077,6 +1080,9 @@ class Scheduler(SchedulerInterface):
                     scheduled_spec_decode_tokens[request_id] = [
                         -1
                     ] * self.num_spec_tokens
+                    # These placeholders enter the forward pass to match the
+                    # graph shape, but must not contribute to draft metrics.
+                    num_invalid_spec_tokens[request_id] = self.num_spec_tokens
                 # Only track requests that will still be prefilling after this chunk.
                 if num_computed_tokens + num_new_tokens < request.num_tokens:
                     self._inflight_prefills.add(request)
@@ -1225,6 +1231,7 @@ class Scheduler(SchedulerInterface):
             kv_cache_block_copies=pending_kv_cache_block_copies,
             partial_tail_offloads=pending_partial_tail_offloads,
             num_spec_tokens_to_schedule=num_spec_tokens_to_schedule,
+            num_invalid_spec_tokens=num_invalid_spec_tokens,
             ec_manager_metadata=self.encoder_cache_manager.get_manager_metadata(),
         )
 
@@ -1769,10 +1776,12 @@ class Scheduler(SchedulerInterface):
             if scheduled_spec_token_ids and (
                 generated_token_ids or self.num_sampled_tokens_per_step == 0
             ):
-                num_draft_tokens = len(scheduled_spec_token_ids)
+                # Rejection rollback uses the physical execution length. Draft
+                # metrics remove any trailing padding in the helper below.
+                num_physical_draft_tokens = len(scheduled_spec_token_ids)
                 num_sampled = self.num_sampled_tokens_per_step
                 num_accepted = max(len(generated_token_ids) - num_sampled, 0)
-                num_rejected = num_draft_tokens - num_accepted
+                num_rejected = num_physical_draft_tokens - num_accepted
                 # Rejections roll back num_computed_tokens (and, under async
                 # scheduling, num_output_placeholders, which covers the spec
                 # tokens). A stale rejection count predates the preemption
@@ -1784,7 +1793,7 @@ class Scheduler(SchedulerInterface):
                         request.num_output_placeholders -= num_rejected
                 spec_decoding_stats = self.make_spec_decoding_stats(
                     spec_decoding_stats,
-                    num_draft_tokens=num_draft_tokens,
+                    num_physical_draft_tokens=num_physical_draft_tokens,
                     num_accepted_tokens=num_accepted,
                     num_invalid_spec_tokens=scheduler_output.num_invalid_spec_tokens,
                     request_id=req_id,
@@ -2168,7 +2177,9 @@ class Scheduler(SchedulerInterface):
     def update_draft_token_ids_in_output(
         self, draft_token_ids: DraftTokenIds, scheduler_output: SchedulerOutput
     ) -> None:
-        num_invalid_spec_tokens: dict[str, int] = {}
+        # Preserve padding metadata for requests not present in this draft
+        # frame; entries for requests in the frame are reconciled below.
+        num_invalid_spec_tokens = dict(scheduler_output.num_invalid_spec_tokens or {})
 
         sched_spec_tokens = scheduler_output.scheduled_spec_decode_tokens
         for req_id, spec_token_ids in zip(
@@ -2197,6 +2208,10 @@ class Scheduler(SchedulerInterface):
             if num_invalid_tokens:
                 spec_token_ids.extend([-1] * num_invalid_tokens)
                 num_invalid_spec_tokens[req_id] = num_invalid_tokens
+            else:
+                # A complete draft frame replaces any padding previously
+                # registered for this request.
+                num_invalid_spec_tokens.pop(req_id, None)
 
             sched_spec_tokens[req_id] = spec_token_ids
 
@@ -2533,19 +2548,29 @@ class Scheduler(SchedulerInterface):
     def make_spec_decoding_stats(
         self,
         spec_decoding_stats: SpecDecodingStats | None,
-        num_draft_tokens: int,
+        num_physical_draft_tokens: int,
         num_accepted_tokens: int,
         num_invalid_spec_tokens: dict[str, int] | None,
         request_id: str,
     ) -> SpecDecodingStats | None:
-        if not self.log_stats or not num_draft_tokens:
+        if not self.log_stats or not num_physical_draft_tokens:
             return None
+        # Invalid spec tokens are always a contiguous trailing suffix. They
+        # execute physically but are excluded from logical draft metrics.
+        num_padding_tokens = (
+            num_invalid_spec_tokens.get(request_id, 0) if num_invalid_spec_tokens else 0
+        )
+        assert 0 <= num_padding_tokens <= num_physical_draft_tokens
+        num_valid_draft_tokens = num_physical_draft_tokens - num_padding_tokens
+        assert 0 <= num_accepted_tokens <= num_valid_draft_tokens
+        if not num_valid_draft_tokens:
+            # A full-padding frame contains no logical draft round.
+            return spec_decoding_stats
         if spec_decoding_stats is None:
             spec_decoding_stats = SpecDecodingStats.new(self.num_spec_tokens)
-        if num_invalid_spec_tokens:
-            num_draft_tokens -= num_invalid_spec_tokens.get(request_id, 0)
         spec_decoding_stats.observe_draft(
-            num_draft_tokens=num_draft_tokens, num_accepted_tokens=num_accepted_tokens
+            num_draft_tokens=num_valid_draft_tokens,
+            num_accepted_tokens=num_accepted_tokens,
         )
         return spec_decoding_stats
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2703,7 +2703,10 @@ class Scheduler(SchedulerInterface):
         )
         assert 0 <= num_padding_tokens <= num_physical_draft_tokens
         num_valid_draft_tokens = num_physical_draft_tokens - num_padding_tokens
-        assert 0 <= num_accepted_tokens <= num_valid_draft_tokens
+        assert 0 <= num_accepted_tokens <= num_physical_draft_tokens
+        num_accepted_tokens = min(
+            num_accepted_tokens, num_valid_draft_tokens
+        )
         if not num_valid_draft_tokens:
             # A full-padding frame contains no logical draft round.
             return spec_decoding_stats

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -530,6 +530,9 @@ class Scheduler(SchedulerInterface):
         encoder_compute_budget = self.max_num_encoder_input_tokens
         # Spec decode-related.
         scheduled_spec_decode_tokens: dict[str, list[int]] = {}
+        # Number of trailing placeholders that keep the execution shape but
+        # do not represent logical draft tokens for each request.
+        num_invalid_spec_tokens: dict[str, int] = {}
         # Whether the running batch contains any prefill requests.
         prefill_scheduled = False
 
@@ -1162,6 +1165,9 @@ class Scheduler(SchedulerInterface):
                     scheduled_spec_decode_tokens[request_id] = [
                         -1
                     ] * self.num_spec_tokens
+                    # These placeholders enter the forward pass to match the
+                    # graph shape, but must not contribute to draft metrics.
+                    num_invalid_spec_tokens[request_id] = self.num_spec_tokens
                 # Only track requests that will still be prefilling after this chunk.
                 if num_computed_tokens + num_new_tokens < request.num_tokens:
                     self._inflight_prefills.add(request)
@@ -1316,6 +1322,7 @@ class Scheduler(SchedulerInterface):
             kv_cache_block_copies=pending_kv_cache_block_copies,
             partial_tail_offloads=pending_partial_tail_offloads,
             num_spec_tokens_to_schedule=num_spec_tokens_to_schedule,
+            num_invalid_spec_tokens=num_invalid_spec_tokens,
             ec_manager_metadata=self.encoder_cache_manager.get_manager_metadata(),
         )
 
@@ -1862,10 +1869,12 @@ class Scheduler(SchedulerInterface):
             if scheduled_spec_token_ids and (
                 generated_token_ids or self.num_sampled_tokens_per_step == 0
             ):
-                num_draft_tokens = len(scheduled_spec_token_ids)
+                # Rejection rollback uses the physical execution length. Draft
+                # metrics remove any trailing padding in the helper below.
+                num_physical_draft_tokens = len(scheduled_spec_token_ids)
                 num_sampled = self.num_sampled_tokens_per_step
                 num_accepted = max(len(generated_token_ids) - num_sampled, 0)
-                num_rejected = num_draft_tokens - num_accepted
+                num_rejected = num_physical_draft_tokens - num_accepted
                 # Rejections roll back num_computed_tokens (and, under async
                 # scheduling, num_output_placeholders, which covers the spec
                 # tokens). A stale rejection count predates the preemption
@@ -1877,7 +1886,7 @@ class Scheduler(SchedulerInterface):
                         request.num_output_placeholders -= num_rejected
                 spec_decoding_stats = self.make_spec_decoding_stats(
                     spec_decoding_stats,
-                    num_draft_tokens=num_draft_tokens,
+                    num_physical_draft_tokens=num_physical_draft_tokens,
                     num_accepted_tokens=num_accepted,
                     num_invalid_spec_tokens=scheduler_output.num_invalid_spec_tokens,
                     request_id=req_id,
@@ -2304,7 +2313,9 @@ class Scheduler(SchedulerInterface):
     def update_draft_token_ids_in_output(
         self, draft_token_ids: DraftTokenIds, scheduler_output: SchedulerOutput
     ) -> None:
-        num_invalid_spec_tokens: dict[str, int] = {}
+        # Preserve padding metadata for requests not present in this draft
+        # frame; entries for requests in the frame are reconciled below.
+        num_invalid_spec_tokens = dict(scheduler_output.num_invalid_spec_tokens or {})
 
         sched_spec_tokens = scheduler_output.scheduled_spec_decode_tokens
         for req_id, spec_token_ids in zip(
@@ -2333,6 +2344,10 @@ class Scheduler(SchedulerInterface):
             if num_invalid_tokens:
                 spec_token_ids.extend([-1] * num_invalid_tokens)
                 num_invalid_spec_tokens[req_id] = num_invalid_tokens
+            else:
+                # A complete draft frame replaces any padding previously
+                # registered for this request.
+                num_invalid_spec_tokens.pop(req_id, None)
 
             sched_spec_tokens[req_id] = spec_token_ids
 
@@ -2674,19 +2689,29 @@ class Scheduler(SchedulerInterface):
     def make_spec_decoding_stats(
         self,
         spec_decoding_stats: SpecDecodingStats | None,
-        num_draft_tokens: int,
+        num_physical_draft_tokens: int,
         num_accepted_tokens: int,
         num_invalid_spec_tokens: dict[str, int] | None,
         request_id: str,
     ) -> SpecDecodingStats | None:
-        if not self.log_stats or not num_draft_tokens:
+        if not self.log_stats or not num_physical_draft_tokens:
             return None
+        # Invalid spec tokens are always a contiguous trailing suffix. They
+        # execute physically but are excluded from logical draft metrics.
+        num_padding_tokens = (
+            num_invalid_spec_tokens.get(request_id, 0) if num_invalid_spec_tokens else 0
+        )
+        assert 0 <= num_padding_tokens <= num_physical_draft_tokens
+        num_valid_draft_tokens = num_physical_draft_tokens - num_padding_tokens
+        assert 0 <= num_accepted_tokens <= num_valid_draft_tokens
+        if not num_valid_draft_tokens:
+            # A full-padding frame contains no logical draft round.
+            return spec_decoding_stats
         if spec_decoding_stats is None:
             spec_decoding_stats = SpecDecodingStats.new(self.num_spec_tokens)
-        if num_invalid_spec_tokens:
-            num_draft_tokens -= num_invalid_spec_tokens.get(request_id, 0)
         spec_decoding_stats.observe_draft(
-            num_draft_tokens=num_draft_tokens, num_accepted_tokens=num_accepted_tokens
+            num_draft_tokens=num_valid_draft_tokens,
+            num_accepted_tokens=num_accepted_tokens,
         )
         return spec_decoding_stats
 


### PR DESCRIPTION
## Purpose

Related to #45237.

Uniform speculative batches use trailing `-1` placeholders on the first decode step to preserve the fixed `1 + num_spec_tokens` execution and graph shape. These placeholders must still reach the forward/rejection path, but they are not logical draft proposals. Counting them in speculative-decoding statistics makes P/D disaggregated serving report lower acceptance metrics even when its real drafts behave like colocated serving.

This PR tracks the trailing padding count per request in `SchedulerOutput` and separates the two meanings of draft length:

- scheduler rejection rollback continues to use the physical execution length;
- speculative-decoding statistics use only the valid draft prefix;
- a full-padding frame contributes no logical draft round;
- deferred draft-frame updates preserve other requests' padding metadata and clear stale metadata when a complete frame replaces padding.

The implementation does not inspect token values, so opaque async draft IDs remain valid. It also keeps all public metrics names and formulas unchanged.

## Duplicate check

I searched open issues and PRs for speculative-decode padding, acceptance metrics, and #45237. No open PR addresses scheduler padding in draft statistics.

- #45237 introduced optional first-step padding for P/D decode graph uniformity; this PR preserves that execution behavior and fixes only its statistics.
- #47029 prevents placeholder IDs from reaching embedding lookup; it does not change metric accounting.
- #47464 skips this padding for diffusion models; autoregressive speculative decoding must retain it.
- Open PR #43114 pads variable-length suffix proposals with real EOS IDs inside the proposer, so it has a different source and token semantics.

## Test Plan

```bash
pre-commit run --files \
  vllm/v1/core/sched/scheduler.py \
  tests/v1/core/test_scheduler.py

.venv/bin/python -m pytest -q \
  tests/v1/core/test_scheduler.py \
  -k "spec_decoding_stats or spec_decode_padding"
```

The scheduler tests cover prefix-cache and remote-KV first-decode padding, mixed full/partial suffix padding, stale invalid-metadata replacement, and per-position statistics.

## Test Result

- Changed-file pre-commit suite: passed, including Ruff check/format and mypy.
- Targeted scheduler suite: `11 passed, 127 deselected, 14 warnings in 31.66s`.
- The targeted suite used a node-local DeepSeek V4 model redirect with Hugging Face and Transformers offline modes; it did not download a test model.
- `git diff --check github/main..HEAD`: passed.

Two controlled Mix/P/D runs used the same 48 prompts, concurrency 12, greedy sampling, `ignore_eos=true`, and exactly 700 output tokens per request (`num_spec_tokens=7`):

| Run | Deployment | Draft rounds | Accepted / drafted | Acceptance length |
|---|---|---:|---:|---:|
| 1 | Mix | 7,483 | 26,218 / 52,381 | 4.5037 |
| 1 | P/D | 7,466 | 26,216 / 52,262 | 4.5114 |
| 2 | Mix | 7,394 | 26,293 / 51,758 | 4.5560 |
| 2 | P/D | 7,330 | 26,340 / 51,310 | 4.5935 |

For all four windows, `drafted == 7 * draft_rounds`: first-step graph padding still executed but no longer entered the public draft counters. The previous P/D-only acceptance-length deficit was not reproduced in either post-fix run.

No documentation update is needed because this corrects internal accounting without changing configuration or the public metrics schema.

## AI assistance

This PR was prepared with OpenAI Codex assistance. I reviewed and understand the changed lines, ran the tests and controlled model evaluation above, and am responsible for the contribution.

---

<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR.
- [x] The test plan.
- [x] The test results and model evaluation.
- [x] Documentation impact considered.

</details>
