### PR TITLE
[Bugfix] Preserve FlashInfer CUTLASS MoE constant storage across weight reload

### DIFF
--- a/tests/model_executor/model_loader/test_reload.py
+++ b/tests/model_executor/model_loader/test_reload.py
@@ -444,6 +444,179 @@ def test_marlin_act_order_layerwise_reload_accounting(monkeypatch, dist_init):
     assert torch.equal(layer.g_idx_sort_indices.data, expected_sort_indices)
 
 
+_FLASHINFER_NUM_EXPERTS = 8
+
+# variant -> (quant_dtype, weight_dtype, gemm1_clamp_limit,
+#             expected {constant name: value})
+_FLASHINFER_CONSTANT_VARIANTS = {
+    "mxfp4_bf16": (
+        None,
+        "mxfp4",
+        None,
+        {"gemm1_alpha": 1.702, "gemm1_beta": 1.0, "gemm1_clamp_limit": 7.0},
+    ),
+    "mxfp4_mxfp8": (
+        "mxfp8",
+        "mxfp4",
+        None,
+        {
+            "gemm1_alpha": 1.702,
+            "gemm1_beta": 1.0,
+            "gemm1_clamp_limit": 7.0,
+            "fake_input_scale": 1.0,
+        },
+    ),
+    "fp8_clamp": (
+        torch.float8_e4m3fn,
+        torch.float8_e4m3fn,
+        3.0,
+        {"gemm1_clamp_limit": 3.0},
+    ),
+}
+
+
+def _make_flashinfer_experts(layer, variant):
+    from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+    from vllm.model_executor.layers.fused_moe.config import (
+        FusedMoEConfig,
+        FusedMoEParallelConfig,
+        FusedMoEQuantConfig,
+        RoutingMethodType,
+    )
+    from vllm.model_executor.layers.fused_moe.experts.flashinfer_cutlass_moe import (
+        FlashInferExperts,
+    )
+
+    quant_dtype, weight_dtype, gemm1_clamp_limit, _ = _FLASHINFER_CONSTANT_VARIANTS[
+        variant
+    ]
+    moe_config = FusedMoEConfig(
+        num_experts=_FLASHINFER_NUM_EXPERTS,
+        experts_per_token=2,
+        hidden_dim=128,
+        intermediate_size=256,
+        num_local_experts=_FLASHINFER_NUM_EXPERTS,
+        num_logical_experts=_FLASHINFER_NUM_EXPERTS,
+        activation=MoEActivation.SILU,
+        device="cpu",
+        routing_method=RoutingMethodType.TopK,
+        moe_parallel_config=FusedMoEParallelConfig(
+            tp_size=1,
+            pcp_size=1,
+            dp_size=1,
+            ep_size=1,
+            tp_rank=0,
+            pcp_rank=0,
+            dp_rank=0,
+            ep_rank=0,
+            sp_size=1,
+            use_ep=False,
+            all2all_backend="naive",
+            enable_eplb=False,
+        ),
+        in_dtype=torch.bfloat16,
+    )
+    quant_config = FusedMoEQuantConfig.make(
+        quant_dtype=quant_dtype,
+        weight_dtype=weight_dtype,
+        gemm1_clamp_limit=gemm1_clamp_limit,
+    )
+    return FlashInferExperts(moe_config, quant_config, layer=layer)
+
+
+@pytest.mark.parametrize("variant", sorted(_FLASHINFER_CONSTANT_VARIANTS))
+def test_flashinfer_cutlass_moe_constants_preserve_addresses(variant, dist_init):
+    """FlashInferExperts is rebuilt by every post-load pass, but its per-expert
+    SwiGLU constants are read by captured CUDA graphs, so each rebuild must
+    reuse the storage the graph captured instead of allocating fresh tensors."""
+    expected = _FLASHINFER_CONSTANT_VARIANTS[variant][3]
+
+    layer = torch.nn.Module()
+    experts = _make_flashinfer_experts(layer, variant)
+
+    pointers = {name: getattr(layer, name).data_ptr() for name in expected}
+
+    # Reload: the quant method rebuilds the kernel, constructing a new
+    # experts object against the same layer
+    experts = _make_flashinfer_experts(layer, variant)
+
+    for name, value in expected.items():
+        constant = getattr(layer, name)
+        assert constant.data_ptr() == pointers[name], name
+        # registered as a Parameter so layerwise reload copy-back preserves it
+        assert isinstance(constant, torch.nn.Parameter), name
+        # the rebuilt experts object reads from the preserved storage
+        assert getattr(experts, name) is constant, name
+        assert torch.equal(
+            constant.data,
+            torch.full((_FLASHINFER_NUM_EXPERTS,), value, dtype=torch.float32),
+        ), name
+
+
+def test_flashinfer_cutlass_moe_layerwise_reload_accounting(dist_init):
+    """The SwiGLU constants are generated during weight processing and never
+    loaded from checkpoints. Registering them as Parameters must not count
+    them toward `load_numel_total`: reload restores the construction-time
+    tensor set before sizing, so the layer still processes during streaming
+    instead of deferring (and buffering weights) until finalization."""
+    from vllm.model_executor.layers.quantization.base_config import (
+        QuantizeMethodBase,
+    )
+    from vllm.model_executor.model_loader.reload.layerwise import get_layerwise_info
+
+    class _KernelQuantMethod(QuantizeMethodBase):
+        def create_weights(self, layer, *args, **kwargs):
+            raise NotImplementedError
+
+        def apply(self, layer, *args, **kwargs):
+            raise NotImplementedError
+
+        def process_weights_after_loading(self, layer):
+            # The kernel (and its experts object) is rebuilt on every pass
+            self.experts = _make_flashinfer_experts(layer, "mxfp4_bf16")
+
+    def _load_checkpoint_format_weights(layer, checkpoint):
+        for name, weight in checkpoint.items():
+            param = torch.nn.Parameter(weight.clone(), requires_grad=False)
+            param.weight_loader = default_weight_loader
+            setattr(layer, name, param)
+
+    def _make_checkpoint(fill):
+        return {
+            "w13_weight": torch.full((8, 16, 4), fill, dtype=torch.bfloat16),
+            "w2_weight": torch.full((8, 4, 8), fill, dtype=torch.bfloat16),
+        }
+
+    layer = torch.nn.Module()
+    layer.quant_method = _KernelQuantMethod()
+    _load_checkpoint_format_weights(layer, _make_checkpoint(1.0))
+
+    # Metadata is recorded at model construction, before any processing
+    record_metadata_for_reloading(layer)
+    checkpoint_numel = sum(t.numel() for t in get_layer_tensors(layer).values())
+
+    layer.quant_method.process_weights_after_loading(layer)
+    constants = {
+        name: getattr(layer, name)
+        for name in ("gemm1_alpha", "gemm1_beta", "gemm1_clamp_limit")
+    }
+
+    initialize_layerwise_reload(layer)
+    info = get_layerwise_info(layer)
+    assert info.load_numel_total == checkpoint_numel
+
+    # Stream a new checkpoint; the layer must process as soon as its last
+    # tensor arrives
+    for name, weight in _make_checkpoint(2.0).items():
+        param = getattr(layer, name)
+        param.weight_loader(param, weight)
+
+    assert not info.can_load()
+    assert not info.loaded_weights
+    for name, constant in constants.items():
+        assert getattr(layer, name) is constant, name
+
+
 def test_model_cleanup(dist_init, default_vllm_config):
     layer = QKVParallelLinear(2, 3, 4)
     assert layer.weight.weight_loader.__self__ is layer

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
@@ -23,6 +23,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kNvfp4Dynamic,
     kNvfp4Static,
 )
+from vllm.model_executor.utils import replace_parameter
 from vllm.platforms import current_platform
 from vllm.utils.flashinfer import (
     flashinfer_cutlass_fused_moe,
@@ -69,6 +70,7 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
         self,
         moe_config: mk.FusedMoEConfig,
         quant_config: FusedMoEQuantConfig,
+        layer: torch.nn.Module | None = None,
     ):
         super().__init__(moe_config, quant_config)
 
@@ -95,33 +97,45 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
         self.use_deepseek_fp8_block_scale = quant_config.is_block_quantized
         self.gemm1_clamp_limit: torch.Tensor | None = None
         if quant_config.gemm1_clamp_limit is not None:
-            self.gemm1_clamp_limit = torch.tensor(
-                [quant_config.gemm1_clamp_limit] * self.num_experts,
-                dtype=torch.float32,
-                device=self.device,
+            self.gemm1_clamp_limit = self._stable_constant(
+                layer, "gemm1_clamp_limit", quant_config.gemm1_clamp_limit
             )
 
         if quant_config.weight_quant_dtype == "mxfp4":
             # This value is used specifically for gpt-oss,
             # Need to revisit this for other models
-            self.gemm1_alpha = torch.tensor(
-                [1.702] * self.num_experts, dtype=torch.float32, device=self.device
-            )
-            self.gemm1_beta = torch.tensor(
-                [1.0] * self.num_experts, dtype=torch.float32, device=self.device
-            )
+            self.gemm1_alpha = self._stable_constant(layer, "gemm1_alpha", 1.702)
+            self.gemm1_beta = self._stable_constant(layer, "gemm1_beta", 1.0)
             if self.gemm1_clamp_limit is None:
-                self.gemm1_clamp_limit = torch.tensor(
-                    [7.0] * self.num_experts,
-                    dtype=torch.float32,
-                    device=self.device,
+                self.gemm1_clamp_limit = self._stable_constant(
+                    layer, "gemm1_clamp_limit", 7.0
                 )
             if quant_config.quant_dtype == "mxfp8":
-                self.fake_input_scale = torch.ones(
-                    self.num_experts,
-                    device=self.device,
-                    dtype=torch.float32,
+                self.fake_input_scale = self._stable_constant(
+                    layer, "fake_input_scale", 1.0
                 )
+
+    def _stable_constant(
+        self, layer: torch.nn.Module | None, name: str, value: float
+    ) -> torch.Tensor:
+        """Allocate a per-expert constant at a reload-stable address.
+
+        This object is rebuilt by every process_weights_after_loading pass,
+        but these tensors are passed to the kernel each forward, so captured
+        CUDA graphs bake their addresses (see #48312). Registering them on
+        the layer with replace_parameter(prefer_copy=True) makes every
+        rebuild copy into the storage the graph captured instead of
+        allocating a fresh tensor.
+        """
+        constant = torch.full(
+            (self.num_experts,), value, dtype=torch.float32, device=self.device
+        )
+        if layer is None:
+            # Direct construction without an owning layer (tests, benchmarks):
+            # nothing survives a rebuild, so plain storage is equivalent.
+            return constant
+        replace_parameter(layer, name, constant, prefer_copy=True)
+        return getattr(layer, name)
 
     @property
     def expects_unquantized_inputs(self) -> bool:

--- a/vllm/model_executor/layers/fused_moe/oracle/fp8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/fp8.py
@@ -687,8 +687,17 @@ def make_fp8_moe_kernel(
 
     logger.info_once("Using %s", prepare_finalize.__class__.__name__)
 
+    from vllm.model_executor.layers.fused_moe.experts.flashinfer_cutlass_moe import (
+        FlashInferExperts,
+    )
+
     extra_kwargs = {}
     if fp8_backend == Fp8MoeBackend.HUMMING:
+        assert layer is not None
+        extra_kwargs = {"layer": layer}
+    elif experts_cls is FlashInferExperts:
+        # FlashInferExperts registers its per-expert constants on the layer
+        # so they keep their storage across kernel rebuilds (see #48312).
         assert layer is not None
         extra_kwargs = {"layer": layer}
 

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -1719,8 +1719,17 @@ def make_mxfp4_moe_kernel(
     logger.info_once("Using %s", prepare_finalize.__class__.__name__)
     logger.info_once("Using %s", experts_cls.__name__)
 
+    from vllm.model_executor.layers.fused_moe.experts.flashinfer_cutlass_moe import (
+        FlashInferExperts,
+    )
+
     extra_kwargs = {}
     if mxfp4_backend == Mxfp4MoeBackend.HUMMING:
+        assert layer is not None
+        extra_kwargs["layer"] = layer
+    elif experts_cls is FlashInferExperts:
+        # FlashInferExperts registers its per-expert constants on the layer
+        # so they keep their storage across kernel rebuilds (see #48312).
         assert layer is not None
         extra_kwargs["layer"] = layer
 

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -543,8 +543,17 @@ def make_nvfp4_moe_kernel(
 
     logger.info_once("Using %s", prepare_finalize.__class__.__name__)
 
+    from vllm.model_executor.layers.fused_moe.experts.flashinfer_cutlass_moe import (
+        FlashInferExperts,
+    )
+
     extra_kwargs = {}
     if backend == NvFp4MoeBackend.HUMMING:
+        assert layer is not None
+        extra_kwargs = {"layer": layer}
+    elif experts_cls is FlashInferExperts:
+        # FlashInferExperts registers its per-expert constants on the layer
+        # so they keep their storage across kernel rebuilds (see #48312).
         assert layer is not None
         extra_kwargs = {"layer": layer}
     if backend == NvFp4MoeBackend.FLASHINFER_TRTLLM and per_token_activation:

--- a/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_moe.py
+++ b/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_moe.py
@@ -215,6 +215,7 @@ class INCMxfp4MoEMethod(FusedMoEMethodBase):
                 experts_cls=self.experts_cls,
                 mxfp4_backend=self.mxfp4_backend,
                 routing_tables=layer._expert_routing_tables(),
+                layer=layer,
             )
 
     def apply(

--- a/vllm/model_executor/layers/quantization/quark/quark_moe.py
+++ b/vllm/model_executor/layers/quantization/quark/quark_moe.py
@@ -457,6 +457,7 @@ class QuarkW8A8Fp8MoEMethod(QuarkMoEMethod):
             fp8_backend=self.fp8_backend,
             experts_cls=self.experts_cls,
             routing_tables=layer._expert_routing_tables(),
+            layer=layer,
         )
 
     def get_fused_moe_quant_config(self, layer: RoutedExperts) -> FusedMoEQuantConfig:
@@ -1339,6 +1340,7 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
                 mxfp4_backend=self.mxfp4_backend,
                 experts_cls=self.experts_cls,
                 routing_tables=layer._expert_routing_tables(),
+                layer=layer,
             )
 
     def get_fused_moe_quant_config(


### PR DESCRIPTION
### Purpose

Fixes the FlashInfer CUTLASS MoE row of RFC #48312 (category 1, storage identity), confirmed on H100 with gpt-oss-20b: rebuilding the experts object replaced `gemm1_alpha`, `gemm1_beta`, and `gemm1_clamp_limit`, 72/72 graph-visible tensors moved, and every capture-time storage expired.

`FlashInferExperts.__init__` allocates per-expert constants that `apply` passes to the kernel on every forward call: the SwiGLU parameters `gemm1_alpha`, `gemm1_beta`, and `gemm1_clamp_limit`, plus `fake_input_scale` on the mxfp4 + mxfp8 path. The quant methods rebuild the modular kernel, including the experts object, on every `process_weights_after_loading` pass. After an RL weight update the new experts object owns fresh tensors while a captured CUDA graph keeps reading the capture-time addresses. Once the old storage is reclaimed, replay reads freed memory. The values are config-derived, so the failure is a silent stale read rather than a crash.

The fix follows the same pattern as #48438 (Marlin) and #48539 (Machete): register the tensors on the owning layer with `replace_parameter(prefer_copy=True)`. The first construction registers them; every later rebuild copies into the same storage, so graph-captured addresses stay valid and the rebuilt experts object reads through the layer. The layer is threaded to `FlashInferExperts` through the existing `extra_kwargs` mechanism in the fp8, nvfp4, and mxfp4 kernel factories (the same idiom the HUMMING backend already uses), with an assert so a future call site that fails to supply the layer fails loudly instead of silently reintroducing the bug. Quark fp8, quark mxfp4, and INC mxfp4 called these factories without the layer argument and would have missed the fix; they now pass it.

The unquantized path is deliberately unchanged: `UnquantizedFusedMoEMethod` builds its kernel only on the first `process_weights_after_loading` call (guarded by `is_weight_update`), so the experts object is never rebuilt there and the constants cannot rebind.

### Notes for reviewers

- The constants become registered Parameters, so each FlashInfer CUTLASS MoE layer gains up to four float32 entries of `num_local_experts` elements in `named_parameters` and `state_dict`. `TrtLlmNvFp4ExpertsBase` already registers parameters with the same names on its layers, so the naming follows existing precedent, and only one experts backend is ever active per layer.
- The constants are generated during weight processing and never loaded from checkpoints, so they must not count toward layerwise reload's `load_numel_total`. The accounting test covers this.
- `replace_parameter(prefer_copy=True)` falls back to re-registering when the existing parameter is incompatible (shape, dtype, or device mismatch). That cannot happen here because the values are config-derived and the config is constant across reloads. A fail-closed `replace_parameter` for all call sites is part of the #48478 discussion.
- `FlashInferExperts` constructed without a layer (direct construction in kernel tests and benchmarks) keeps the previous behavior: plain tensors, which is fine because nothing survives a rebuild in that usage.

### Test Plan

Unit tests in `tests/model_executor/model_loader/test_reload.py`, mirroring the Marlin tests from #48438:

- `test_flashinfer_cutlass_moe_constants_preserve_addresses`, parametrized over three variants: mxfp4 weights with bf16 activations (the gpt-oss path), mxfp4 with mxfp8 activations (adds `fake_input_scale`), and fp8 with a config-provided clamp limit. Asserts stable `data_ptr` across an experts rebuild, Parameter registration, that the rebuilt experts object reads the preserved storage, and correct values.
- `test_flashinfer_cutlass_moe_layerwise_reload_accounting`: records reload metadata at construction, processes the layer (which builds the experts object and registers the constants), initializes layerwise reload, asserts `load_numel_total` equals the checkpoint-loadable numel, streams a new checkpoint, and asserts the layer finalizes during streaming and the constants keep their identity through the reload cycle.

I verified both tests discriminate. With registration disabled (simulating unfixed behavior) all three address variants and the accounting test fail. With metadata recorded after processing instead of before, the accounting total inflates from 768 to 792 (three constants times eight experts) and the first assert fails.

H100 NVL validation on gpt-oss-20b with `moe_backend="flashinfer_cutlass"` (the mxfp4 + bf16 SM90 path), CUDA graphs enabled, vLLM wheel built at the base commit with only these files overlaid. Protocol: capture, census every constant (data_ptr, value sum, registration state), greedy baseline, `reload_weights` with the same checkpoint, second census, generation before allocation pressure, pressure, generation after. 24 MoE layers times 3 constants = 72 graph-visible tensors.

- Red (stock): 0/72 constants registered on layers, 0/72 graph-visible pointers stable across reload (72/72 moved). Every experts rebuild abandons the storage captured graphs read; the freed capture-time allocations retain their old bits until reclaimed, which is why this fails silently rather than crashing.
- Green (this fix): 72/72 registered at first load, 72/72 graph-visible pointers stable across reload, 72/72 values intact after allocation pressure, 72/72 still registered after reload.

Note on the reload flow: layerwise reload's copy-back is what carries the storage. The experts object rebuilt during `process_weights_after_loading` transiently binds the parameter registered before copy-back re-registers the original; both hold identical values, captured graphs read the preserved original, and only eager calls read the transient, so this is benign. The same-weights token comparison diverges after reload on both red and green builds equally, which is a sibling reload defect in this model outside the constants this PR fixes (tracked by the other #48312 rows); the pointer and value census above is the oracle for this change.

### Test Result

- All 10 marlin and flashinfer tests in `test_reload.py` pass locally.
- ruff lint and format clean on all changed files.
- H100 red/green: see numbers above.

Related: RFC #48312 (FlashInfer CUTLASS MoE confirmed row), #48478 (fail-closed storage contract), #49789 (the transaction draft lists `FlashInferExperts` on its known-raw worklist; this fixes that entry on main).

This PR includes AI-generated code (Claude Code). I reviewed every changed line, and validated the fix end-to-end on H100 hardware with the red/green protocol described above.
