### PR TITLE
[Bugfix] Zero-fill rematerialized weights so reload preserves padding

### DIFF
--- a/tests/model_executor/model_loader/test_reload.py
+++ b/tests/model_executor/model_loader/test_reload.py
@@ -167,6 +167,72 @@ def test_materialize_layer_preserves_non_meta_tensors():
     assert torch.equal(layer.bias.data, bias_values)
 
 
+def _poison_allocator(shape, dtype=torch.float32, count=8):
+    """Allocate and free garbage-filled blocks so a subsequent same-size
+    allocation is likely to reuse one. Makes uninitialized-memory bugs
+    deterministic enough to catch instead of relying on fresh zero pages."""
+    poison = [torch.full(shape, float("nan"), dtype=dtype) for _ in range(count)]
+    del poison
+
+
+def test_materialize_meta_tensor_zero_fills():
+    """Regions a weight loader never writes (kernel alignment padding) must
+    rematerialize as zeros: create_weights() zero-initializes padded weights,
+    and post-load processing packs whatever the pad region holds into the
+    kernel weights."""
+    meta = to_meta_tensor(torch.empty(64, 64))
+    _poison_allocator((64, 64))
+    tensor = materialize_meta_tensor(meta)
+    assert torch.equal(tensor, torch.zeros(64, 64))
+
+
+class _PaddedWeightLayer(torch.nn.Module):
+    """Mimics a quant method whose created weight is padded for kernel
+    alignment (e.g. mxfp4 rounding 2880 up to 2944): the checkpoint backs
+    only the leading columns and the pad region is zero-initialized."""
+
+    REAL_COLS = 48
+
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.zeros(64, 64), requires_grad=False)
+        self.weight.weight_loader = self._load_padded
+
+    @staticmethod
+    def _load_padded(param, loaded_weight):
+        param.data[:, : _PaddedWeightLayer.REAL_COLS].copy_(loaded_weight)
+
+
+def test_layerwise_reload_preserves_padded_weight_zeros():
+    """A padded layer under-loads (load_numel < load_numel_total), so it takes
+    the delayed-processing path at finalization. The pad region must come back
+    as zeros, matching first-load create_weights() state, not as reused
+    allocator memory."""
+    layer = _PaddedWeightLayer()
+    model = torch.nn.Sequential(layer)
+    checkpoint = torch.arange(
+        64 * _PaddedWeightLayer.REAL_COLS, dtype=torch.float32
+    ).reshape(64, _PaddedWeightLayer.REAL_COLS)
+
+    record_metadata_for_reloading(model)
+    layer.weight.weight_loader(layer.weight, checkpoint)
+    kernel_ptr = layer.weight.data_ptr()
+
+    initialize_layerwise_reload(model)
+    layer.weight.weight_loader(layer.weight, checkpoint + 1)
+    _poison_allocator((64, 64))
+    finalize_layerwise_reload(model, model_config=None)
+
+    # storage preserved for captured graphs, loaded slice refreshed
+    assert layer.weight.data_ptr() == kernel_ptr
+    assert torch.equal(
+        layer.weight.data[:, : _PaddedWeightLayer.REAL_COLS], checkpoint + 1
+    )
+    # the never-loaded pad region must match its create_weights() zero state
+    pad = layer.weight.data[:, _PaddedWeightLayer.REAL_COLS :]
+    assert torch.equal(pad, torch.zeros_like(pad))
+
+
 _MARLIN_SIZE_K, _MARLIN_SIZE_N, _MARLIN_GROUP_SIZE = 128, 64, 64
 
 

--- a/vllm/model_executor/model_loader/reload/meta.py
+++ b/vllm/model_executor/model_loader/reload/meta.py
@@ -57,6 +57,12 @@ def materialize_meta_tensor(meta_tensor: torch.Tensor) -> torch.Tensor:
         dtype=meta_tensor.dtype,
         requires_grad=False,
     )
+    # Padded weights are zero-initialized by create_weights() and only their
+    # checkpoint-backed slices are written by weight loaders, so any region a
+    # loader does not cover must rematerialize as zeros. Reusing allocator
+    # garbage there changes the values that post-load processing packs into
+    # the kernel weights, silently corrupting every reload of a padded layer.
+    tensor.zero_()
     tensor.__class__ = meta_tensor.__class__
     tensor.__dict__ = meta_tensor.__dict__.copy()
     return tensor


### PR DESCRIPTION
### Purpose

A same-weights `reload_weights` silently changes any model whose quant method pads weights for kernel alignment. Found while validating #50521 on H100: gpt-oss-20b greedy output diverged from the first token after reloading the identical checkpoint, on stock main, with all storage addresses preserved.

Root cause: quant methods that round weight dims up for kernel alignment (for mxfp4, `mxfp4_round_up_hidden_size_and_intermediate_size` pads gpt-oss's 2880 to 2944 on every backend) create those weights zero-initialized, and weight loaders only ever write the checkpoint-backed slices, so correctness of the pad regions depends on the initial zeros. Layerwise reload restores the construction-time parameter set on meta and rematerializes it with `torch.empty_strided`, which is uninitialized. After streaming refills the real slices, the pad regions hold allocator garbage, the layer under-loads (`load_numel < load_numel_total`) into the delayed-processing path, and `process_weights_after_loading` packs the garbage into the kernel weights. Garbage pad rows of `w13_weight` and pad entries of `w13_bias` produce nonzero activations at pad intermediate channels, and garbage pad columns of `w2_weight` contract those into every real hidden output, so all logits change.

The fix zero-fills the tensor in `materialize_meta_tensor`. This restores the `create_weights` initial state for every region a loader does not cover, making reload byte-identical to first load. Cost is one memset per restored tensor during reload, which is negligible against the weight copy itself.

This maps to RFC #48312 category 4 (reload state preservation) and the category 3 padding-accounting subtype, whose text already flags padding as needing explicit treatment.

### Notes for reviewers

- Zero is the correct fill for the padded-weights pattern because `create_weights` zero-initializes these tensors. A parameter whose initial value is non-zero and is only partially loaded would still be wrong after this fix, but it is deterministic-wrong instead of garbage-wrong, and no such site is known; the fail-closed direction (declaring loadable regions explicitly) is part of the #48478 discussion.
- The diagnosis that led here: md5 over every parameter and buffer localized the drift to exactly the 138 padded MoE tensors, with all other model parameters byte-identical and zero storage moves. The exact-zero count dropped from 475,537,003 to 273,111,316 after one reload, and per layer `w13_bias` lost exactly 32 experts x 128 pad elements of zeros. Hashes changed again on a second reload (87/96), ruling out a deterministic double-transform and fingerprinting uninitialized memory.

### Test Plan

Unit tests in `tests/model_executor/model_loader/test_reload.py`:

- `test_materialize_meta_tensor_zero_fills`: the direct contract. Poisons the allocator with freed NaN-filled blocks so unfixed code demonstrably returns garbage, then asserts materialization yields zeros.
- `test_layerwise_reload_preserves_padded_weight_zeros`: end-to-end layerwise cycle with a padded layer whose loader writes only the leading columns. The layer under-loads, takes the delayed-processing path at finalization, and the test asserts the kernel storage address is preserved, the loaded slice carries the new values, and the pad region comes back as zeros.

Both discriminate: with `zero_()` removed, both fail under allocator poisoning.

H100 NVL validation on gpt-oss-20b (mxfp4, flashinfer_cutlass backend, CUDA graphs enabled), vLLM wheel at the base commit with only `reload/meta.py` overlaid for green. Oracle: md5 over all 96 MoE weights, scales, and biases across two same-weights reloads, plus greedy token comparison.

- Red (stock): 138/144 tensor hashes change after one same-weights reload, and 135/144 change again between reload 1 and reload 2 (non-deterministic, fingerprinting uninitialized memory). Zero elements drop from 475,537,003 to 311,188,846. Greedy tokens diverge from the first position.
- Green (this fix): 0/144 hash changes across two reloads and the zero count is byte-identical. Reload reproduces first-load bytes exactly.
- Combined with #50521: greedy tokens match baseline after both reload 1 and reload 2. With only one of the two fixes applied, tokens still diverge (this fix alone leaves the graph-captured constants storage freed and reclaimed by the reload's own allocations; #50521 alone leaves the padded weights corrupted), so the pair jointly restores end-to-end same-weights reload correctness for this model, and each PR's own oracle isolates its half.

### Test Result

- Both new tests pass; the pre-existing reload unit tests pass; ruff lint and format clean.
- H100 red/green: see above.

Related: RFC #48312, #48478, #50521 (whose H100 validation surfaced this defect and documented the contaminated token oracle).

This PR includes AI-generated code (Claude Code). I reviewed every changed line, and validated the fix end-to-end on H100 hardware with the red/green protocol described above.
