### PR TITLE
[Bugfix][Parser] Emit REASONING_END for Inkling tool calls that follow no thinking block

### DIFF
--- a/tests/parser/engine/test_engine.py
+++ b/tests/parser/engine/test_engine.py
@@ -844,3 +844,61 @@ class TestSkipToolParsing:
         engine.skip_tool_parsing = True
         engine.reset()
         assert engine.skip_tool_parsing is True
+
+
+def _message_header_config(reasoning_end: bool) -> ParserEngineConfig:
+    """MESSAGE_HEADER-based grammar whose tool opener optionally carries
+    REASONING_END, mirroring the two shapes a transition table can take."""
+    return ParserEngineConfig(
+        name=f"message_header_test_{reasoning_end}",
+        initial_state=ParserState.MESSAGE_HEADER,
+        terminals={"HEADER_END": "<|header_end|>", "TOOL_START": "<tool_call>"},
+        transitions={
+            (ParserState.MESSAGE_HEADER, "HEADER_END"): Transition(
+                ParserState.CONTENT,
+                (EventType.TEXT_CHUNK,),
+            ),
+            (ParserState.MESSAGE_HEADER, "TOOL_START"): Transition(
+                ParserState.TOOL_ARGS,
+                (EventType.REASONING_END, EventType.TOOL_CALL_START)
+                if reasoning_end
+                else (EventType.TOOL_CALL_START,),
+            ),
+        },
+    )
+
+
+class TestSkipToolParsingFromMessageHeader:
+    """Leaving MESSAGE_HEADER through the skip_tool_parsing gate must honour
+    the transition's REASONING_END.
+
+    The reasoning pass hands off to the tool pass only once it has seen a
+    REASONING_END, so swallowing it under the header passthrough strands the
+    whole tool block in content. Tables carrying no REASONING_END keep the
+    plain passthrough.
+    """
+
+    @staticmethod
+    def _skip_events(reasoning_end: bool):
+        engine = StreamingParserEngine(
+            _message_header_config(reasoning_end), tokenizer=None
+        )
+        engine.skip_tool_parsing = True
+        return engine, engine.parse_complete("name<tool_call>{}")
+
+    def test_reasoning_end_precedes_forwarded_tool_syntax(self):
+        engine, events = self._skip_events(reasoning_end=True)
+        assert [e.type for e in events[:2]] == [
+            EventType.REASONING_END,
+            EventType.TEXT_CHUNK,
+        ]
+        assert events[1].value == "<tool_call>"
+        assert engine._message_header_buffer == ""
+
+    def test_passthrough_only_when_transition_omits_reasoning_end(self):
+        engine, events = self._skip_events(reasoning_end=False)
+        types = [e.type for e in events]
+        assert EventType.REASONING_END not in types
+        assert types[0] == EventType.TEXT_CHUNK
+        assert events[0].value == "<tool_call>"
+        assert engine._message_header_buffer == ""

--- a/tests/parser/engine/test_engine.py
+++ b/tests/parser/engine/test_engine.py
@@ -844,3 +844,67 @@ class TestSkipToolParsing:
         engine.skip_tool_parsing = True
         engine.reset()
         assert engine.skip_tool_parsing is True
+
+
+def _message_header_config(reasoning_end: bool) -> ParserEngineConfig:
+    """MESSAGE_HEADER-based config whose tool terminal optionally carries
+    REASONING_END, mirroring the two shapes a transition table can take."""
+    tool_events = (
+        (EventType.REASONING_END, EventType.TOOL_CALL_START)
+        if reasoning_end
+        else (EventType.TOOL_CALL_START,)
+    )
+    return ParserEngineConfig(
+        name=f"message_header_test_{reasoning_end}",
+        initial_state=ParserState.MESSAGE_HEADER,
+        terminals={"HEADER_END": "<|header_end|>", "TOOL_START": "<tool_call>"},
+        transitions={
+            (ParserState.MESSAGE_HEADER, "HEADER_END"): Transition(
+                ParserState.CONTENT,
+                (EventType.TEXT_CHUNK,),
+            ),
+            (ParserState.MESSAGE_HEADER, "TOOL_START"): Transition(
+                ParserState.TOOL_ARGS,
+                tool_events,
+            ),
+        },
+    )
+
+
+class TestSkipToolParsingFromMessageHeader:
+    """``skip_tool_parsing`` must let REASONING_END out of MESSAGE_HEADER.
+
+    The reasoning pass hands off to the tool pass only once it has seen a
+    REASONING_END, so swallowing it in MESSAGE_HEADER strands the whole
+    tool block in content (issue #50512).
+    """
+
+    @staticmethod
+    def _skip_parse(config: ParserEngineConfig, text: str):
+        engine = StreamingParserEngine(config, tokenizer=None)
+        engine.skip_tool_parsing = True
+        return engine, engine.parse_complete(text)
+
+    def test_emits_reasoning_end_when_transition_carries_it(self):
+        _, events = self._skip_parse(
+            _message_header_config(reasoning_end=True), "name<tool_call>{}"
+        )
+        assert EventType.REASONING_END in [e.type for e in events]
+
+    def test_silent_when_transition_omits_it(self):
+        """Configs whose table has no REASONING_END are unaffected."""
+        _, events = self._skip_parse(
+            _message_header_config(reasoning_end=False), "name<tool_call>{}"
+        )
+        types = [e.type for e in events]
+        assert EventType.REASONING_END not in types
+        assert EventType.TEXT_CHUNK in types
+
+    @pytest.mark.parametrize("reasoning_end", [True, False])
+    def test_header_buffer_is_discarded(self, reasoning_end):
+        """The buffered header must not survive to prefix a later header."""
+        engine, _ = self._skip_parse(
+            _message_header_config(reasoning_end), "name<tool_call>{}"
+        )
+        assert engine._message_header_buffer == ""
+        assert engine.state == ParserState.CONTENT

--- a/tests/parser/engine/test_inkling.py
+++ b/tests/parser/engine/test_inkling.py
@@ -23,8 +23,10 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionToolsParam,
     FunctionDefinition,
 )
+from vllm.parser.engine.events import EventType
 from vllm.parser.engine.parser_engine_config import ParserState
-from vllm.parser.inkling import InklingParser, _inkling_arg_converter
+from vllm.parser.engine.streaming_parser_engine import StreamingParserEngine
+from vllm.parser.inkling import InklingParser, _inkling_arg_converter, inkling_config
 from vllm.parser.parser_manager import ParserManager
 
 MSG_MODEL = "<|message_model|>"
@@ -786,3 +788,84 @@ class TestDelegatingTwoPass:
         assert json.loads(args[0]) == {"city": "SF"}
         assert TOOL_JSON not in content
         assert END_MESSAGE not in content
+
+    @pytest.mark.parametrize("chunk_size", [1, 3, 7, 64])
+    def test_tool_start_from_message_header_streaming(
+        self, mock_tokenizer, mock_request, chunk_size
+    ):
+        """A tool call with no block of any kind ahead of it.
+
+        The generation prompt ends in ``<|message_model|>``, so this fires
+        TOOL_START straight from MESSAGE_HEADER. A tool block is the one
+        opener that confirms no reasoning is open without rendering visible
+        content, so it is the case the visible-block openers cannot cover.
+        """
+        tools = [_function_tool()]
+        mock_request.tools = tools
+        content, _, names, args = _stream_delegating(
+            _delegating(mock_tokenizer, tools),
+            mock_request,
+            _tool_block("get_weather", '{"city":"Seattle"}'),
+            chunk_size,
+            self.GEN_PROMPT,
+        )
+        assert names == ["get_weather"]
+        assert json.loads(args[0]) == {"city": "Seattle"}
+        assert content == ""
+        assert TOOL_JSON not in content
+        assert END_MESSAGE not in content
+
+    def test_function_name_header_before_tool_start_streaming(
+        self, mock_tokenizer, mock_request
+    ):
+        """The optional function name between ``<|message_model|>`` and the
+        content-kind marker is metadata: the buffered header must be
+        discarded on the way out, not flushed into content."""
+        tools = [_function_tool()]
+        mock_request.tools = tools
+        content, _, names, args = _stream_delegating(
+            _delegating(mock_tokenizer, tools),
+            mock_request,
+            "someFn" + _tool_block("get_weather", '{"city":"Seattle"}'),
+            1,
+            self.GEN_PROMPT,
+        )
+        assert names == ["get_weather"]
+        assert json.loads(args[0]) == {"city": "Seattle"}
+        assert content == ""
+
+    def test_content_state_tool_start_streaming(self, mock_tokenizer, mock_request):
+        """Same opener reached from CONTENT rather than MESSAGE_HEADER: a
+        text block closed with no ``<|message_model|>`` before the tool
+        block. Preceding text must reach content exactly once, unmarked."""
+        tools = [_function_tool()]
+        mock_request.tools = tools
+        content, _, names, args = _stream_delegating(
+            _delegating(mock_tokenizer, tools),
+            mock_request,
+            f"{TEXT_START}intro{END_MESSAGE}"
+            + _tool_block("get_weather", '{"city":"Seattle"}'),
+            1,
+            self.GEN_PROMPT,
+        )
+        assert names == ["get_weather"]
+        assert json.loads(args[0]) == {"city": "Seattle"}
+        assert content == "intro"
+
+
+def test_content_tool_start_emits_reasoning_end_in_reasoning_pass():
+    """(CONTENT, TOOL_START) must carry REASONING_END through the
+    reasoning pass. Every visible-block opener already confirms the
+    boundary (#49876), but the header-flush path
+    (MESSAGE_HEADER --END_MESSAGE--> CONTENT) reaches CONTENT without
+    one, so a tool block opening from there relies on this transition
+    alone to hand off to the tool pass."""
+    engine = StreamingParserEngine(inkling_config(), tokenizer=None)
+    engine.skip_tool_parsing = True
+    engine.reset(initial_state=ParserState.CONTENT)
+    events = engine.parse_complete(f'{TOOL_JSON}{{"name":"f","args":{{}}}}')
+    assert [e.type for e in events[:2]] == [
+        EventType.REASONING_END,
+        EventType.TEXT_CHUNK,
+    ]
+    assert events[1].value == TOOL_JSON

--- a/tests/parser/engine/test_inkling.py
+++ b/tests/parser/engine/test_inkling.py
@@ -19,8 +19,10 @@ from tests.parser.engine.streaming_helpers import (
     collect_function_name,
     collect_tool_arguments,
 )
+from vllm.parser.engine.events import EventType
 from vllm.parser.engine.parser_engine_config import ParserState
-from vllm.parser.inkling import InklingParser, _inkling_arg_converter
+from vllm.parser.engine.streaming_parser_engine import StreamingParserEngine
+from vllm.parser.inkling import InklingParser, _inkling_arg_converter, inkling_config
 from vllm.parser.parser_manager import ParserManager
 
 MSG_MODEL = "<|message_model|>"
@@ -454,6 +456,245 @@ class TestPromptSeededState:
         )
         assert second is not None
         assert second.content == "plain answer"
+
+
+# ── Issue #50512: a turn that never opens a thinking block ────────────
+# `<|message_model|>` is prefilled by the generation prompt, so generation
+# starts in MESSAGE_HEADER. Which state TOOL_START then fires from depends
+# only on what the turn emits first; it is verified per test name below.
+
+_TOOL_TURN = _tool_block("get_weather", '{"city":"Seattle"}')
+
+# TOOL_START from MESSAGE_HEADER — the reported trigger.
+BARE_TOOL_TURN = _TOOL_TURN
+# Same, plus the optional function-name header the renderer emits between
+# `<|message_model|>` and the content-kind marker; exercises the
+# MESSAGE_HEADER buffer on the way out.
+NAMED_TOOL_TURN = "get_weather" + _TOOL_TURN
+# Text block, a fresh message header, then the tool call: still
+# MESSAGE_HEADER, but with visible text that must survive intact.
+TEXT_HEADER_TOOL_TURN = (
+    f"{TEXT_START}Let me check.{END_MESSAGE}{MSG_MODEL}" + _TOOL_TURN
+)
+# Text block, tool block, no intervening `<|message_model|>`: TOOL_START
+# fires from CONTENT instead — the same hole, one state over.
+TEXT_TOOL_TURN = f"{TEXT_START}Let me check.{END_MESSAGE}" + _TOOL_TURN
+# Control: opens with reasoning, so REASONING_END already arrives from
+# `(REASONING, THINK_END)`. This path always worked.
+REASONING_TOOL_TURN = (
+    f"{THINK_START}I should check.{END_MESSAGE}{MSG_MODEL}" + _TOOL_TURN
+)
+
+# One token per delta and the whole turn in one delta — the two
+# boundaries. Intermediate sizes add cost without adding a code path.
+CHUNK_BOUNDARIES = [1, 4096]
+
+SINGLE_TURN_PROMPT = f"{TEXT_START}hi{END_MESSAGE}{MSG_MODEL}"
+# A prior assistant tool call plus its result, i.e. the shape that exists
+# from turn 2 onwards. Both prompts share the
+# `<|end_message|><|message_model|>` tail the renderer always emits.
+MULTI_TURN_PROMPT = (
+    f"{TEXT_START}hi{END_MESSAGE}"
+    f"{MSG_MODEL}" + _tool_block("get_weather", '{"city":"SF"}') + f"{TEXT_START}sunny"
+    f"{END_MESSAGE}{MSG_MODEL}"
+)
+
+
+def _delegating_parser(mock_tokenizer, *, reasoning: bool = True):
+    parser_cls = ParserManager.get_parser(
+        tool_parser_name="inkling",
+        reasoning_parser_name="inkling" if reasoning else None,
+        enable_auto_tools=True,
+    )
+    return parser_cls(mock_tokenizer, [])
+
+
+def _stream_delta(parser, request, text: str, chunk_size: int, prompt: str):
+    """Drive ``parse_delta`` the way the serving layer does — one call per
+    delta, ``prompt_token_ids`` passed every time, ``finished`` on the last.
+
+    This is the entry point where the reasoning-pass → tool-pass handoff
+    lives, which is why these cases cannot go through ``_stream``.
+    Results are shaped like ``_stream``'s so the shared collectors apply.
+    """
+    prompt_token_ids = [token_id for token_id, _ in _tokenize(prompt)]
+    tokens = _tokenize(text)
+    results = []
+    for start in range(0, len(tokens), chunk_size):
+        batch = tokens[start : start + chunk_size]
+        delta = parser.parse_delta(
+            delta_text="".join(t for _, t in batch),
+            delta_token_ids=[token_id for token_id, _ in batch],
+            request=request,
+            prompt_token_ids=prompt_token_ids,
+            finished=start + chunk_size >= len(tokens),
+        )
+        results.append((delta, text))
+    return results
+
+
+def _assert_get_weather_call(results, expected_content: str) -> None:
+    """The tool block became a ``get_weather`` call and content is exactly
+    ``expected_content``.
+
+    When a text block precedes the tool call, a trailing bare
+    ``<|end_message|>`` is tolerated: that is the separate end-of-block
+    leakage of #49865, which travels the ``(CONTENT, THINK_END)`` path and
+    is out of scope here. A turn with no text block cannot trigger #49865,
+    so it gets no such amnesty and content must be exactly empty.
+    """
+    content = collect_content(results)
+    assert collect_function_name(results) == "get_weather", (
+        f"no get_weather call; content={content!r}"
+    )
+    assert json.loads(collect_tool_arguments(results)) == {"city": "Seattle"}
+    if expected_content:
+        content = content.removesuffix(END_MESSAGE)
+    assert content == expected_content
+
+
+class TestToolStartWithoutThinking:
+    """Issue #50512: a turn reaching its tool block without first closing a
+    thinking block leaked the whole tool markup into ``delta.content`` and
+    emitted no tool calls.
+
+    The discriminant is the missing leading thinking block, not turn count.
+    The reasoning pass runs with ``skip_tool_parsing`` and hands off to the
+    tool pass only once it has seen a REASONING_END; a turn opening with a
+    thinking block gets one from ``(REASONING, THINK_END)``, and a turn that
+    does not used to get none at all.
+    """
+
+    @pytest.mark.parametrize("chunk_size", CHUNK_BOUNDARIES)
+    def test_tool_start_from_message_header(
+        self, mock_tokenizer, mock_request, chunk_size
+    ):
+        results = _stream_delta(
+            _delegating_parser(mock_tokenizer),
+            mock_request,
+            BARE_TOOL_TURN,
+            chunk_size,
+            SINGLE_TURN_PROMPT,
+        )
+        _assert_get_weather_call(results, "")
+
+    @pytest.mark.parametrize("chunk_size", CHUNK_BOUNDARIES)
+    def test_tool_start_from_content(self, mock_tokenizer, mock_request, chunk_size):
+        results = _stream_delta(
+            _delegating_parser(mock_tokenizer),
+            mock_request,
+            TEXT_TOOL_TURN,
+            chunk_size,
+            SINGLE_TURN_PROMPT,
+        )
+        _assert_get_weather_call(results, "Let me check.")
+
+    @pytest.mark.parametrize("chunk_size", CHUNK_BOUNDARIES)
+    def test_visible_text_survives_exactly_once(
+        self, mock_tokenizer, mock_request, chunk_size
+    ):
+        """Text block, fresh header, tool call: the text must reach content
+        once — neither dropped nor replayed by the handoff."""
+        results = _stream_delta(
+            _delegating_parser(mock_tokenizer),
+            mock_request,
+            TEXT_HEADER_TOOL_TURN,
+            chunk_size,
+            SINGLE_TURN_PROMPT,
+        )
+        _assert_get_weather_call(results, "Let me check.")
+
+    def test_function_name_header_before_tool_block(self, mock_tokenizer, mock_request):
+        """The buffered header name must be discarded, not emitted."""
+        results = _stream_delta(
+            _delegating_parser(mock_tokenizer),
+            mock_request,
+            NAMED_TOOL_TURN,
+            1,
+            SINGLE_TURN_PROMPT,
+        )
+        _assert_get_weather_call(results, "")
+
+    @pytest.mark.parametrize(
+        "turn, expected_content",
+        [
+            pytest.param(BARE_TOOL_TURN, "", id="from_message_header"),
+            pytest.param(TEXT_TOOL_TURN, "Let me check.", id="from_content"),
+        ],
+    )
+    def test_multi_turn_prompt_is_no_different(
+        self, mock_tokenizer, mock_request, turn, expected_content
+    ):
+        """Turn depth is not the discriminant: the same turns behave the
+        same after a prompt that already contains a tool call and result."""
+        results = _stream_delta(
+            _delegating_parser(mock_tokenizer),
+            mock_request,
+            turn,
+            1,
+            MULTI_TURN_PROMPT,
+        )
+        _assert_get_weather_call(results, expected_content)
+
+    @pytest.mark.parametrize(
+        "turn, expected_content",
+        [
+            pytest.param(BARE_TOOL_TURN, None, id="from_message_header"),
+            pytest.param(TEXT_TOOL_TURN, "Let me check.", id="from_content"),
+        ],
+    )
+    def test_non_streaming_agrees_with_streaming(
+        self, parser, mock_request, turn, expected_content
+    ):
+        """Streaming and non-streaming must reach the same answer. The
+        single-pass path never sets ``skip_tool_parsing``, so it was always
+        correct; this is the invariant the issue is really about."""
+        _, content, tools = parser.parse(turn, mock_request)
+        assert [t.name for t in tools] == ["get_weather"]
+        assert json.loads(tools[0].arguments) == {"city": "Seattle"}
+        assert content == expected_content
+
+    def test_tool_only_parser_is_unaffected(self, mock_tokenizer, mock_request):
+        """With no reasoning parser there is no handoff to get wrong, so
+        this cell must stay green independently of the reasoning pass."""
+        results = _stream_delta(
+            _delegating_parser(mock_tokenizer, reasoning=False),
+            mock_request,
+            BARE_TOOL_TURN,
+            1,
+            SINGLE_TURN_PROMPT,
+        )
+        _assert_get_weather_call(results, "")
+
+    def test_reasoning_first_turn_still_hands_off(self, mock_tokenizer, mock_request):
+        """Control: the path that already worked must keep working, and the
+        second REASONING_END on the tool terminal must stay a no-op."""
+        results = _stream_delta(
+            _delegating_parser(mock_tokenizer),
+            mock_request,
+            REASONING_TOOL_TURN,
+            1,
+            SINGLE_TURN_PROMPT,
+        )
+        assert _collect_reasoning(results) == "I should check."
+        _assert_get_weather_call(results, "")
+
+
+class TestMessageHeaderExitsWithoutReasoningEnd:
+    """``<|end_message|>`` and ``<|content_model_end_sampling|>`` also leave
+    MESSAGE_HEADER through the ``skip_tool_parsing`` gate, but carry no
+    REASONING_END. They pin the reordered branch on Inkling's real table:
+    the generic config in ``test_engine.py`` cannot show that.
+    """
+
+    @pytest.mark.parametrize("terminator", [END_MESSAGE, END_SAMPLING])
+    def test_no_reasoning_end_and_header_discarded(self, mock_tokenizer, terminator):
+        engine = StreamingParserEngine(inkling_config(), mock_tokenizer)
+        engine.reset(initial_state=ParserState.MESSAGE_HEADER)
+        engine.skip_tool_parsing = True
+        events = engine.parse_complete(f"get_weather{terminator}")
+        assert EventType.REASONING_END not in [event.type for event in events]
+        assert engine._message_header_buffer == ""
 
 
 class TestToolCallFiltering:

--- a/vllm/parser/engine/streaming_parser_engine.py
+++ b/vllm/parser/engine/streaming_parser_engine.py
@@ -342,16 +342,12 @@ class StreamingParserEngine:
                     self._in_skipped_tool_span = True
                 elif is_exit:
                     self._in_skipped_tool_span = False
-                if self.state == ParserState.MESSAGE_HEADER:
-                    self.state = ParserState.CONTENT
+                leaving_message_header = self.state == ParserState.MESSAGE_HEADER
+                if leaving_message_header:
                     self._message_header_buffer = ""
-                    return [
-                        SemanticEvent(
-                            EventType.TEXT_CHUNK,
-                            value=value,
-                            tool_index=self.tool_index,
-                        )
-                    ]
+                # A tool terminal that implicitly ends reasoning must report
+                # that even from the header state, or the reasoning pass never
+                # hands the block to the tool pass.
                 if EventType.REASONING_END in transition.events:
                     self.state = ParserState.CONTENT
                     return [
@@ -365,6 +361,15 @@ class StreamingParserEngine:
                             value=value,
                             tool_index=self.tool_index,
                         ),
+                    ]
+                elif leaving_message_header:
+                    self.state = ParserState.CONTENT
+                    return [
+                        SemanticEvent(
+                            EventType.TEXT_CHUNK,
+                            value=value,
+                            tool_index=self.tool_index,
+                        )
                     ]
                 content_type = self.config.content_events.get(self.state)
                 if content_type is not None:

--- a/vllm/parser/engine/streaming_parser_engine.py
+++ b/vllm/parser/engine/streaming_parser_engine.py
@@ -319,16 +319,13 @@ class StreamingParserEngine:
             return self._emit_for_state(value)
 
         if self.skip_tool_parsing and terminal in self._tool_terminals:
-            if self.state == ParserState.MESSAGE_HEADER:
-                self.state = ParserState.CONTENT
+            # A tool terminal that implicitly ends reasoning must emit
+            # REASONING_END from *any* state, MESSAGE_HEADER included —
+            # otherwise the reasoning pass never confirms the end and the
+            # whole tool block is handed back as content.
+            leaving_header = self.state == ParserState.MESSAGE_HEADER
+            if leaving_header:
                 self._message_header_buffer = ""
-                return [
-                    SemanticEvent(
-                        EventType.TEXT_CHUNK,
-                        value=value,
-                        tool_index=self.tool_index,
-                    )
-                ]
             if EventType.REASONING_END in transition.events:
                 self.state = ParserState.CONTENT
                 return [
@@ -342,6 +339,15 @@ class StreamingParserEngine:
                         value=value,
                         tool_index=self.tool_index,
                     ),
+                ]
+            if leaving_header:
+                self.state = ParserState.CONTENT
+                return [
+                    SemanticEvent(
+                        EventType.TEXT_CHUNK,
+                        value=value,
+                        tool_index=self.tool_index,
+                    )
                 ]
             content_type = self.config.content_events.get(self.state)
             if content_type is not None:

--- a/vllm/parser/inkling.py
+++ b/vllm/parser/inkling.py
@@ -197,9 +197,14 @@ def inkling_config() -> ParserEngineConfig:
             ParserState.REASONING,
             (EventType.REASONING_START,),
         ),
+        # A tool block implicitly ends reasoning even when this turn never
+        # opened a thinking block, so REASONING_END rides along on every
+        # TOOL_START (as it does for Qwen3/Mistral). Without it the
+        # reasoning pass never confirms the end and the tool pass is never
+        # handed the block.
         (ParserState.CONTENT, "TOOL_START"): Transition(
             ParserState.TOOL_ARGS,
-            (EventType.TOOL_CALL_START,),
+            (EventType.REASONING_END, EventType.TOOL_CALL_START),
         ),
         # Raw / error tool blocks render as visible text.
         (ParserState.CONTENT, "TOOL_TEXT"): Transition(
@@ -226,7 +231,7 @@ def inkling_config() -> ParserEngineConfig:
         ),
         (ParserState.MESSAGE_HEADER, "TOOL_START"): Transition(
             ParserState.TOOL_ARGS,
-            (EventType.TOOL_CALL_START,),
+            (EventType.REASONING_END, EventType.TOOL_CALL_START),
         ),
         (ParserState.MESSAGE_HEADER, "TOOL_TEXT"): Transition(
             ParserState.CONTENT,

--- a/vllm/parser/inkling.py
+++ b/vllm/parser/inkling.py
@@ -202,9 +202,11 @@ def inkling_config() -> ParserEngineConfig:
             ParserState.REASONING,
             (EventType.REASONING_START,),
         ),
+        # A tool block confirms the same boundary, and is the one opener that
+        # can start a turn with no visible block ahead of it.
         (ParserState.CONTENT, "TOOL_START"): Transition(
             ParserState.TOOL_ARGS,
-            (EventType.TOOL_CALL_START,),
+            (EventType.REASONING_END, EventType.TOOL_CALL_START),
         ),
         # Raw / error tool blocks render as visible text.
         (ParserState.CONTENT, "TOOL_TEXT"): Transition(
@@ -231,7 +233,7 @@ def inkling_config() -> ParserEngineConfig:
         ),
         (ParserState.MESSAGE_HEADER, "TOOL_START"): Transition(
             ParserState.TOOL_ARGS,
-            (EventType.TOOL_CALL_START,),
+            (EventType.REASONING_END, EventType.TOOL_CALL_START),
         ),
         (ParserState.MESSAGE_HEADER, "TOOL_TEXT"): Transition(
             ParserState.CONTENT,


### PR DESCRIPTION
## Purpose

Fixes #50512. With `--tool-call-parser inkling --reasoning-parser inkling`, a streaming turn that opens straight into its tool block emitted zero tool calls and returned the whole `<|content_invoke_tool_json|>{...}<|end_message|>` markup as `delta.content`.

The issue title says multi-turn; that is not the discriminant. What decides it is **whether the generated turn confirms the reasoning boundary before its tool block** — single-turn leaks identically. The measured matrix is in [this issue comment](https://github.com/vllm-project/vllm/issues/50512#issuecomment-5139289290).

Rebased onto current `main`, which now contains both #51391 and #49876. This PR composes with them; see [Related work](#related-work).

### Root cause

The reasoning pass runs with `skip_tool_parsing` and hands off to the tool pass only once it has seen a `REASONING_END`. #49876 made every opener that renders *visible content* confirm that boundary: `TEXT_START`, `TOOL_TEXT`, `TOOL_ERROR`.

A tool block renders no visible content, and `TOOL_START` was left out. A turn whose first block *is* the tool call therefore still confirms nothing: `reasoning_ended` never flips, `should_transition` in `DelegatingParser.parse_delta` never fires, and the tool engine is fed nothing at all. Hitting a tool terminal in `MESSAGE_HEADER` means reasoning ended with zero length, and the delegating layer has to be told.

There is a second, independent reason `TOOL_START` could not simply be added to the table. Unlike the openers #49876 fixed, `TOOL_START` **is** a tool terminal, so under `skip_tool_parsing` it is routed through the forwarding gate in `StreamingParserEngine._on_terminal` instead of the ordinary transition path. That gate's `MESSAGE_HEADER` arm returned unconditionally, ahead of the `REASONING_END` check, making that check unreachable from `MESSAGE_HEADER`. The config change alone would have been swallowed on exactly the reported path — which is why #49876 needed no engine change and this does.

### Changes

- **Config** (`inkling.py`): add `REASONING_END` to `(MESSAGE_HEADER, TOOL_START)` and `(CONTENT, TOOL_START)`.
- **Engine** (`streaming_parser_engine.py`): inside the existing `skip_tool_parsing` gate, run the `REASONING_END` check before the `MESSAGE_HEADER` passthrough, and hoist the header-buffer cleanup above both so the passthrough return is otherwise byte-for-byte unchanged.

### Blast radius

The gate is shared by every engine-based parser, so the scope question is which of them can reach `MESSAGE_HEADER` at all:

```bash
grep -rl "MESSAGE_HEADER" vllm/parser/ --include="*.py"
# vllm/parser/engine/parser_engine_config.py   (the enum itself)
# vllm/parser/engine/streaming_parser_engine.py
# vllm/parser/inkling.py
```

**Inkling is the only parser config in the package that names `MESSAGE_HEADER`.** For every other parser that arm of the gate is dead code, which is why the asymmetry survived this long.

The engine change is config-driven, not parser-specific: a table that does not carry `REASONING_END` on a tool terminal keeps the plain passthrough. `TestSkipToolParsingFromMessageHeader::test_passthrough_only_when_transition_omits_reasoning_end` pins that directly, with a synthetic `MESSAGE_HEADER` config built both ways.

Of Inkling's three tool terminals leaving `MESSAGE_HEADER` (`TOOL_START`, `THINK_END`, `END_SAMPLING`), only `TOOL_START` gains `REASONING_END`; the two block-enders are untouched.

`(CONTENT, TOOL_START)` is included alongside the `MESSAGE_HEADER` entry because it is the same opener one state over, and because Inkling was the outlier: `vllm/parser/qwen3.py` already spells `(CONTENT, TOOL_START)` as `(REASONING_END, TOOL_CALL_START)`, as do `gemma4.py`, `glm47_moe.py` and `mistral.py`. This pulls Inkling back to that convention. Emitting `REASONING_END` where reasoning is already closed is harmless — the handler is `self._reasoning_ended = True`, idempotent.

### Related work

- **#51391 (merged)** — trailing block-end leakage with tools. Its skipped-tool-span bookkeeping (`_in_skipped_tool_span`, `is_opener`/`is_exit`, `used_as_plain_closer`) is preserved **unchanged**; only the `MESSAGE_HEADER` handling nested inside it is reordered. Because #51391 removed trailing-marker leakage, every content assertion added here is exact (`content == ""`, `content == "intro"`) — no `endswith` allowance, no strip-based tolerance.
- **#49876 (merged)** — the complementary half of the same boundary problem, narrowed to `REASONING_END` on the *visible-content* openers `TEXT_START`, `TOOL_TEXT` and `TOOL_ERROR`. This PR covers `TOOL_START`, the one opener that confirms the boundary without rendering visible content, and is therefore the only one that also has to traverse the `skip_tool_parsing` gate. Disjoint entries in the same table, disjoint code paths.

## Test Plan and Result

9 tests: 7 in the existing `tests/parser/engine/test_inkling.py` (six driving `DelegatingParser.parse_delta`, where the handoff actually lives, plus one engine-level), and 2 engine-level guards for the shared gate in the existing `tests/parser/engine/test_engine.py`, alongside the `TestSkipToolParsing` class already there. No new file — per AGENTS.md "reuse before create". Both test files are touched by additions only; no pre-existing test was edited. The repro is pure CPU: mock tokenizer, no weights, no server.

All numbers below come from exactly this command:

```bash
python -m pytest tests/parser/ -q --ignore=tests/parser/mistral
```

`tests/parser/mistral/` is excluded because it fails at collection with `ImportError: llguidance is not installed` — a missing `mistral-common[guidance]` extra that reproduces identically on unmodified `main`. Nothing else is excluded and nothing is skipped.

| run | new tests | whole suite |
| --- | --- | --- |
| pristine `main` (1c1077c6c) | n/a | 0 failed, 3886 passed |
| this branch, production fix reverted | **7 failed**, 2 passed | 7 failed, 3888 passed |
| this branch | 0 failed, **9 passed** | 0 failed, **3895 passed** |

3895 − 9 = 3886, so no pre-existing test was changed, removed, or regressed.

The 7 that fail without the fix are the bug: a tool call streamed from `MESSAGE_HEADER` at chunk sizes 1/3/7/64, the same with an optional function-name header ahead of it, the engine-level guard that `REASONING_END` precedes the forwarded tool syntax, and the engine-level guard on `(CONTENT, TOOL_START)` described below.

The 2 that pass without the fix are stated controls, not padding:
- `test_passthrough_only_when_transition_omits_reasoning_end` — the negative case; it must stay green, since a table with no `REASONING_END` must keep the old passthrough.
- `test_content_state_tool_start_streaming` — reaches `TOOL_START` from `CONTENT` after a text block. #49876 already ends reasoning at `TEXT_START`, so this passes on `main` today; it is here as the composition guard for the `(CONTENT, TOOL_START)` half of the table change, and it asserts exact content (`"intro"`), which only holds because of #51391. The engine-level test `test_content_tool_start_emits_reasoning_end_in_reasoning_pass` closes this gap: it pins the (CONTENT, TOOL_START) REASONING_END directly and fails if the event is removed.

`pre-commit run --files` over the four touched files passes, including `mypy-3.12 --hook-stage manual`. (`update-dockerfile-graph` fails locally with `Executable /bin/bash not found`, a Windows limitation; it inspects no file in this diff.)

No model evaluation: this is a parser-only change that cannot affect model output, sampling, or accuracy — it only reclassifies already-generated text between `delta.content` and `delta.tool_calls`. The issue names no public Inkling checkpoint and the repro needs no weights.

### Rust frontend

`rust/src/parser/src/unified/inkling.rs` is a genuinely unified single-pass parser: there is no `skip_tool_parsing` flag and no `reasoning_ended` handoff gate anywhere in `rust/`, so the two-pass asymmetry that causes this bug is structurally absent. `inkling_initialize_model_opener_starts_in_message_header` already covers the same scenario there, so scoping this PR to Python is deliberate; no Rust files are touched.

### AI assistance

AI assistance was used on this change. The human submitter reported and scoped the issue, directed the investigation, chose to widen it from the reported multi-turn framing to the actual reasoning-boundary discriminant, required the blast-radius audit before the shared gate was touched, decided that `(CONTENT, TOOL_START)` was in scope, and has reviewed every changed line and every test result above.

Duplicate check re-run immediately before this update (`50512 in:body`, `inkling`, `streaming_parser_engine`): no other open PR references #50512, and no other open PR touches `streaming_parser_engine.py`.

