### PR TITLE
[UT] add skipif for rocm aiter sampler UT

### DIFF
--- a/tests/v1/sample/test_topk_topp_sampler.py
+++ b/tests/v1/sample/test_topk_topp_sampler.py
@@ -65,6 +65,10 @@ def test_sampler_threads_fp64_gumbel_to_topk_topp_sampler():
     assert sampler.topk_topp_sampler.use_fp64_gumbel
 
 
+@pytest.mark.skipif(
+    not current_platform.is_rocm(),
+    reason="ROCm aiter sampler test only runs on ROCm",
+)
 def test_rocm_aiter_sampler_defers_import_when_generators_force_native(
     monkeypatch: pytest.MonkeyPatch,
 ):


### PR DESCRIPTION
This case use MockPlatform to replace current_platform, which causes error on other platform like CUDA and XPU.

On CUDA:
<img width="1857" height="255" alt="image" src="https://github.com/user-attachments/assets/66778510-bede-46d8-8d80-3567391b7c70" />

On XPU:
<img width="708" height="329" alt="image" src="https://github.com/user-attachments/assets/3ab14ab6-3772-44e6-a54e-fe8b424d3628" />


Add skipif to make this case run only on ROCM.
