### PR TITLE
[Bugfix][MRV2] Require all requests to be decoding for uniform-decode dispatch

### DIFF
--- a/tests/v1/spec_decode/test_dynamic_sd_cug.py
+++ b/tests/v1/spec_decode/test_dynamic_sd_cug.py
@@ -5,6 +5,7 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
 import torch
 
@@ -16,6 +17,7 @@ from vllm.config import (
     VllmConfig,
 )
 from vllm.v1.worker.gpu import cudagraph_utils as gpu_cudagraph_utils
+from vllm.v1.worker.utils import get_uniform_decode_token_count
 
 pytestmark = pytest.mark.cpu_test
 
@@ -194,6 +196,85 @@ def test_dynamic_sd_non_uniform_batch_falls_back_to_piecewise(monkeypatch):
     assert desc.num_reqs is None
     assert desc.num_tokens == 3
     assert desc.num_active_loras == 0
+
+
+def test_prompt_chunks_shaped_like_spec_decode_miss_the_full_graph(monkeypatch):
+    """A batch holding K+1-token prompt chunks must not replay a decode graph.
+
+    The FULL spec-verify graph is selected on the batch shape alone
+    (num_reqs * (K + 1) tokens), which prompt chunks of exactly K + 1 tokens
+    satisfy by coincidence. Replaying it over prompt tokens corrupts every
+    request in the batch, not just the chunks, because the captured kernels
+    read per-request state that a batch containing prefills never refreshes.
+    See https://github.com/vllm-project/vllm/issues/49918.
+    """
+
+    max_spec_tokens = 7
+    decode_query_len = max_spec_tokens + 1
+
+    monkeypatch.setattr(
+        gpu_cudagraph_utils,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=True),
+    )
+
+    vllm_config = _create_vllm_config_for_dsd(
+        max_num_seqs=64,
+        max_spec_tokens=max_spec_tokens,
+        use_dynamic_sd=False,
+    )
+    manager = gpu_cudagraph_utils.CudaGraphManager(
+        vllm_config=vllm_config,
+        device=torch.device("cpu"),
+        cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
+        decode_query_len=decode_query_len,
+    )
+    manager._graphs_captured = True
+
+    num_decodes, num_chunks = 6, 2
+    num_reqs = num_decodes + num_chunks
+    num_tokens = num_reqs * decode_query_len
+    # The six decoding requests have their prompts fully computed; the two
+    # chunks are decode_query_len tokens into a longer, unfinished prompt.
+    prefill_lens = np.array([16] * num_decodes + [40] * num_chunks, dtype=np.int32)
+    num_computed = np.array(
+        [16] * num_decodes + [decode_query_len] * num_chunks, dtype=np.int32
+    )
+
+    # The batch shape is indistinguishable from a full batch of spec decodes.
+    assert (
+        gpu_cudagraph_utils.get_uniform_token_count(
+            num_reqs, num_tokens, decode_query_len
+        )
+        == decode_query_len
+    )
+
+    uniform_tok_count = get_uniform_decode_token_count(
+        num_reqs, num_tokens, decode_query_len, num_computed, prefill_lens
+    )
+    assert uniform_tok_count is None
+    desc = manager.dispatch(
+        num_reqs=num_reqs,
+        num_tokens=num_tokens,
+        uniform_token_count=uniform_tok_count,
+        num_active_loras=0,
+    )
+    assert desc.cg_mode == CUDAGraphMode.PIECEWISE
+    assert desc.uniform_token_count is None
+
+    # The same shape with every request decoding still gets its FULL graph.
+    uniform_tok_count = get_uniform_decode_token_count(
+        num_reqs, num_tokens, decode_query_len, prefill_lens, prefill_lens
+    )
+    assert uniform_tok_count == decode_query_len
+    desc = manager.dispatch(
+        num_reqs=num_reqs,
+        num_tokens=num_tokens,
+        uniform_token_count=uniform_tok_count,
+        num_active_loras=0,
+    )
+    assert desc.cg_mode == CUDAGraphMode.FULL
+    assert desc.uniform_token_count == decode_query_len
 
 
 def test_basic_sd_does_not_capture_shorter_full_decode_shapes(monkeypatch):

--- a/tests/v1/worker/test_gpu_batch_ordering.py
+++ b/tests/v1/worker/test_gpu_batch_ordering.py
@@ -1,18 +1,26 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Batch ordering in Model Runner V2 (vllm.v1.worker.gpu).
+"""Batch ordering and classification in Model Runner V2 (vllm.v1.worker.gpu).
 
 split_decodes_and_prefills assumes decode -> short_extend -> prefill request
 ordering. With spec decode (decode_query_len > 1), a shorter chunked-prefill
 tail sorted in front of the uniform decodes misclassifies every decode as a
 prefill.
+
+Conversely, a prompt chunk of exactly decode_query_len tokens has a decode
+batch's shape, and must not be classified as a uniform decode batch.
 """
 
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
 import torch
 
 from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.attention.backends.utils import split_decodes_and_prefills
-from vllm.v1.worker.gpu.model_runner import sort_batch_req_ids
+from vllm.v1.worker.gpu.model_runner import GPUModelRunner, sort_batch_req_ids
+from vllm.v1.worker.utils import get_uniform_decode_token_count
 
 
 def _make_common_attn_metadata(query_lens: list[int]) -> CommonAttentionMetadata:
@@ -34,6 +42,79 @@ def _make_common_attn_metadata(query_lens: list[int]) -> CommonAttentionMetadata
         max_query_len=max(query_lens),
         block_table_tensor=torch.zeros(num_reqs, 1, dtype=torch.int32),
         slot_mapping=torch.zeros(num_tokens, dtype=torch.int64),
+    )
+
+
+def _make_runner(req_states: dict[str, tuple[int, int]]) -> Any:
+    """Build a runner stub from {req_id: (num_computed_tokens, prefill_len)}."""
+    prefill_lens = np.array([s[1] for s in req_states.values()], dtype=np.int32)
+    num_computed = np.array([s[0] for s in req_states.values()], dtype=np.int32)
+    runner: Any = GPUModelRunner.__new__(GPUModelRunner)
+    runner.req_states = SimpleNamespace(
+        req_id_to_index={req_id: i for i, req_id in enumerate(req_states)},
+        # The runner keeps this as min(num_computed_tokens, prefill_len).
+        num_computed_prefill_tokens=np.minimum(num_computed, prefill_lens),
+        prefill_len=SimpleNamespace(np=prefill_lens),
+    )
+    return runner
+
+
+def _uniform_token_count(
+    req_states: dict[str, tuple[int, int]],
+    query_len: int,
+    dummy_run: bool = False,
+) -> int | None:
+    scheduler_output = SimpleNamespace(
+        num_scheduled_tokens={req_id: query_len for req_id in req_states},
+        total_num_scheduled_tokens=query_len * len(req_states),
+    )
+    return GPUModelRunner._get_uniform_token_count(
+        _make_runner(req_states),
+        scheduler_output,
+        len(req_states),
+        query_len * len(req_states),
+        query_len,
+        dummy_run,
+    )
+
+
+def test_spec_decode_batch_is_uniform_decode():
+    # decode_query_len == 8 (K=7): every request past its prefill.
+    decodes = {f"d{i}": (16, 16) for i in range(6)}
+    assert _uniform_token_count(decodes, 8) == 8
+
+
+def test_prompt_chunk_of_decode_query_len_is_not_uniform_decode():
+    # Two requests are 8 tokens into a 40-token prompt, so their query length
+    # only coincides with the K+1 spec-decode query length. Replaying the
+    # decode graph here corrupts the six decodes as well, so the whole batch
+    # must be rejected. See https://github.com/vllm-project/vllm/issues/49918.
+    batch = {f"d{i}": (16, 16) for i in range(6)}
+    batch.update({f"p{i}": (8, 40) for i in range(2)})
+    assert _uniform_token_count(batch, 8) is None
+
+    # Same collision without spec decoding: a 1-token prompt looks like a
+    # 1-token decode step.
+    assert _uniform_token_count({"p0": (0, 1)}, 1) is None
+
+    # A fresh prompt that happens to be exactly decode_query_len tokens long.
+    assert _uniform_token_count({"p0": (0, 8)}, 8) is None
+
+
+def test_dummy_batches_stay_uniform_decode():
+    # Dummy batches (DP padding, profiling, warmup) are uniform by
+    # construction and their requests have no state to consult, so they must be
+    # classified without one: looking one up would raise KeyError here, and
+    # rejecting them would make graph capture and replay disagree.
+    scheduler_output = SimpleNamespace(
+        num_scheduled_tokens={f"_dummy_req_{i}": 8 for i in range(4)},
+        total_num_scheduled_tokens=32,
+    )
+    assert (
+        GPUModelRunner._get_uniform_token_count(
+            _make_runner({}), scheduler_output, 4, 32, 8, True
+        )
+        == 8
     )
 
 
@@ -68,3 +149,97 @@ def test_spec_decodes_lead_short_prefill_tail():
     )
     assert (num_decodes, num_prefills) == (8, 1)
     assert (num_decode_tokens, num_prefill_tokens) == (16, 1)
+
+
+def test_uniform_decode_uses_state_index_not_batch_position():
+    """The predicate must read each request's own state, not its batch slot.
+
+    `req_id_to_index` is a persistent map into the runner's state arrays, so a
+    request's batch position and its state index diverge as requests come and
+    go. Here the only prefilling request sits at state index 0 while the two
+    scheduled decodes sit at 1 and 2, so a gather that used batch position
+    would read the prefilling row and wrongly reject the batch.
+    """
+    runner: Any = GPUModelRunner.__new__(GPUModelRunner)
+    # State arrays in state-index order: a prefilling request, then two decodes.
+    runner.req_states = SimpleNamespace(
+        req_id_to_index={"prefilling": 0, "decode_a": 1, "decode_b": 2},
+        num_computed_prefill_tokens=np.array([8, 16, 16], dtype=np.int32),
+        prefill_len=SimpleNamespace(np=np.array([40, 16, 16], dtype=np.int32)),
+    )
+    scheduler_output = SimpleNamespace(
+        num_scheduled_tokens={"decode_a": 8, "decode_b": 8},
+        total_num_scheduled_tokens=16,
+    )
+
+    assert (
+        GPUModelRunner._get_uniform_token_count(
+            runner, scheduler_output, 2, 16, 8, False
+        )
+        == 8
+    )
+
+    # Scheduling the prefilling request alongside them must reject the batch.
+    scheduler_output.num_scheduled_tokens = {
+        "decode_a": 8,
+        "prefilling": 8,
+        "decode_b": 8,
+    }
+    scheduler_output.total_num_scheduled_tokens = 24
+    assert (
+        GPUModelRunner._get_uniform_token_count(
+            runner, scheduler_output, 3, 24, 8, False
+        )
+        is None
+    )
+
+
+def test_predicate_agrees_with_is_prefilling():
+    """The drafter's call site passes `InputBatch`'s two arrays directly.
+
+    `InputBatch.is_prefilling_np` is documented as
+    `num_computed_prefill_tokens_np < prefill_len_np`, so the shared predicate
+    must reject a batch exactly when that flag is set for any request. This
+    pins the contract the drafter relies on without standing up a speculator.
+    """
+    cases = [
+        (np.array([16, 16], dtype=np.int32), np.array([16, 16], dtype=np.int32)),
+        (np.array([8, 16], dtype=np.int32), np.array([40, 16], dtype=np.int32)),
+        (np.array([0], dtype=np.int32), np.array([1], dtype=np.int32)),
+        (np.array([5, 5, 5], dtype=np.int32), np.array([5, 5, 5], dtype=np.int32)),
+    ]
+    for num_computed_prefill_tokens, prefill_lens in cases:
+        num_reqs = len(prefill_lens)
+        is_prefilling = num_computed_prefill_tokens < prefill_lens
+        result = get_uniform_decode_token_count(
+            num_reqs,
+            8 * num_reqs,
+            8,
+            num_computed_prefill_tokens,
+            prefill_lens,
+        )
+        assert (result is None) == bool(is_prefilling.any()), (
+            f"{num_computed_prefill_tokens} vs {prefill_lens} -> {result}"
+        )
+
+
+def test_non_uniform_shape_is_rejected_without_request_state():
+    """The shape test must decide on its own, ahead of any state lookup.
+
+    Most batches are mixed prefill/decode and fail on shape alone, so the O(1)
+    shape test runs before the per-request prefill state is gathered. A token
+    count that is not `num_reqs * max_query_len` has to be rejected even when
+    every request has finished prefilling, as they have here.
+    """
+    num_computed_prefill_tokens = np.array([16, 16], dtype=np.int32)
+    prefill_lens = np.array([16, 16], dtype=np.int32)
+    assert (
+        get_uniform_decode_token_count(
+            2,
+            12,  # No shared query length over 2 requests produces 12 tokens.
+            8,
+            num_computed_prefill_tokens,
+            prefill_lens,
+        )
+        is None
+    )

--- a/tests/v1/worker/test_gpu_batch_ordering.py
+++ b/tests/v1/worker/test_gpu_batch_ordering.py
@@ -11,6 +11,8 @@ Conversely, a prompt chunk of exactly decode_query_len tokens has a decode
 batch's shape, and must not be classified as a uniform decode batch.
 """
 
+import ast
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -242,4 +244,38 @@ def test_non_uniform_shape_is_rejected_without_request_state():
             prefill_lens,
         )
         is None
+    )
+
+
+def test_no_speculator_dispatches_on_query_length_alone():
+    """No speculator may pick its cudagraph from a shape test.
+
+    `get_uniform_token_count` and `is_uniform_query_len` both answer a question
+    about batch shape, which a prompt chunk satisfies by coincidence whenever it
+    happens to be `1 + num_speculative_tokens` tokens wide. Dispatching on
+    either replays a decode-captured graph over prompt tokens.
+
+    This is written over the whole package rather than over the one speculator
+    that had the bug, because speculators are added by copying an existing one:
+    the shape-only call reappeared verbatim, comment included, in a speculator
+    added after the original two call sites were fixed. A per-file test would
+    pass again the next time that happens.
+    """
+    import vllm.v1.worker.gpu.spec_decode as spec_decode
+
+    shape_only = {"get_uniform_token_count", "is_uniform_query_len"}
+    root = Path(spec_decode.__file__).parent
+    offenders = []
+    for path in sorted(root.rglob("speculator.py")):
+        for node in ast.walk(ast.parse(path.read_text())):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", "")
+            if name in shape_only:
+                offenders.append(f"{path.relative_to(root)}:{node.lineno} {name}")
+
+    assert not offenders, (
+        "these speculators classify a decode batch by query length alone; use "
+        f"get_uniform_decode_token_count instead: {offenders}"
     )

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -35,7 +35,7 @@ from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.cp_utils import prepare_dcp_local_seq_lens
 from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
 from vllm.v1.worker.gpu.model_states.interface import ModelState
-from vllm.v1.worker.utils import AttentionGroup
+from vllm.v1.worker.utils import AttentionGroup, is_uniform_query_len
 
 logger = init_logger(__name__)
 
@@ -97,10 +97,13 @@ def get_uniform_token_count(
     """
     Return the uniform token count if batch is uniform, else None.
     A batch is uniform if all requests have the same number of tokens.
+
+    This is a shape test, so it is only valid for batches whose requests are
+    known to be decoding by construction (e.g. dummy runs, or a drafter step
+    that emits a fixed number of tokens per request). Batches coming from a
+    scheduler step must go through `get_uniform_decode_token_count`.
     """
-    if (max_query_len == num_tokens // num_reqs) and (
-        num_tokens == max_query_len * num_reqs
-    ):
+    if is_uniform_query_len(num_reqs, num_tokens, max_query_len):
         return max_query_len
     return None
 

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -131,6 +131,7 @@ from vllm.v1.worker.utils import (
     KVBlockZeroer,
     copy_kv_cache_blocks_inplace,
     get_uniform_decode_token_count,
+    is_uniform_query_len,
 )
 
 logger = init_logger(__name__)
@@ -1244,6 +1245,12 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         """
         if dummy_run:
             return get_uniform_token_count(num_reqs, num_tokens, max_query_len)
+        # Shape first. This is the same test get_uniform_decode_token_count
+        # runs before it looks at any request state, and it rejects every
+        # mixed prefill/decode batch, which is most of them. Checking it here
+        # keeps the gather below off the hot path in that case.
+        if not is_uniform_query_len(num_reqs, num_tokens, max_query_len):
+            return None
         idx_mapping_np = np.fromiter(
             map(
                 self.req_states.req_id_to_index.__getitem__,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -137,6 +137,7 @@ from vllm.v1.worker.utils import (
     KVBlockZeroer,
     copy_kv_cache_blocks_inplace,
     get_uniform_decode_token_count,
+    is_uniform_query_len,
 )
 
 logger = init_logger(__name__)
@@ -1271,6 +1272,12 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         """
         if dummy_run:
             return get_uniform_token_count(num_reqs, num_tokens, max_query_len)
+        # Shape first. This is the same test get_uniform_decode_token_count
+        # runs before it looks at any request state, and it rejects every
+        # mixed prefill/decode batch, which is most of them. Checking it here
+        # keeps the gather below off the hot path in that case.
+        if not is_uniform_query_len(num_reqs, num_tokens, max_query_len):
+            return None
         idx_mapping_np = np.fromiter(
             map(
                 self.req_states.req_id_to_index.__getitem__,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -133,7 +133,11 @@ from vllm.v1.worker.gpu.spec_decode.utils import DraftTokensHandler
 from vllm.v1.worker.gpu.states import RequestState
 from vllm.v1.worker.gpu.structured_outputs import StructuredOutputsWorker
 from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
-from vllm.v1.worker.utils import KVBlockZeroer, copy_kv_cache_blocks_inplace
+from vllm.v1.worker.utils import (
+    KVBlockZeroer,
+    copy_kv_cache_blocks_inplace,
+    get_uniform_decode_token_count,
+)
 
 logger = init_logger(__name__)
 
@@ -1250,6 +1254,39 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             idx_mapping, num_sampled, self.req_states.num_computed_tokens.gpu
         )
 
+    def _get_uniform_token_count(
+        self,
+        scheduler_output: SchedulerOutput,
+        num_reqs: int,
+        num_tokens: int,
+        max_query_len: int,
+        dummy_run: bool,
+    ) -> int | None:
+        """Per-request token count of a uniform decode batch, or None.
+
+        Dummy batches (DP padding, memory profiling, warmup) are uniform by
+        construction and have no request state to consult, so they are
+        classified by shape alone. This mirrors `InputBatch.make_dummy`, which
+        marks every dummy request as not prefilling.
+        """
+        if dummy_run:
+            return get_uniform_token_count(num_reqs, num_tokens, max_query_len)
+        idx_mapping_np = np.fromiter(
+            map(
+                self.req_states.req_id_to_index.__getitem__,
+                scheduler_output.num_scheduled_tokens,
+            ),
+            dtype=np.intp,
+            count=num_reqs,
+        )
+        return get_uniform_decode_token_count(
+            num_reqs,
+            num_tokens,
+            max_query_len,
+            self.req_states.num_computed_prefill_tokens[idx_mapping_np],
+            self.req_states.prefill_len.np[idx_mapping_np],
+        )
+
     @torch.inference_mode()
     def execute_model(
         self,
@@ -1276,7 +1313,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         num_reqs = len(scheduler_output.num_scheduled_tokens)
         num_toks = scheduler_output.total_num_scheduled_tokens
         max_query_len = max(scheduler_output.num_scheduled_tokens.values())
-        uniform_tok_count = get_uniform_token_count(num_reqs, num_toks, max_query_len)
+        uniform_tok_count = self._get_uniform_token_count(
+            scheduler_output, num_reqs, num_toks, max_query_len, dummy_run
+        )
 
         num_active_loras = 0
         if self.lora_config:

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -127,7 +127,11 @@ from vllm.v1.worker.gpu.spec_decode.utils import DraftTokensHandler
 from vllm.v1.worker.gpu.states import RequestState
 from vllm.v1.worker.gpu.structured_outputs import StructuredOutputsWorker
 from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
-from vllm.v1.worker.utils import KVBlockZeroer, copy_kv_cache_blocks_inplace
+from vllm.v1.worker.utils import (
+    KVBlockZeroer,
+    copy_kv_cache_blocks_inplace,
+    get_uniform_decode_token_count,
+)
 
 logger = init_logger(__name__)
 
@@ -1223,6 +1227,39 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             idx_mapping, num_sampled, self.req_states.num_computed_tokens.gpu
         )
 
+    def _get_uniform_token_count(
+        self,
+        scheduler_output: SchedulerOutput,
+        num_reqs: int,
+        num_tokens: int,
+        max_query_len: int,
+        dummy_run: bool,
+    ) -> int | None:
+        """Per-request token count of a uniform decode batch, or None.
+
+        Dummy batches (DP padding, memory profiling, warmup) are uniform by
+        construction and have no request state to consult, so they are
+        classified by shape alone. This mirrors `InputBatch.make_dummy`, which
+        marks every dummy request as not prefilling.
+        """
+        if dummy_run:
+            return get_uniform_token_count(num_reqs, num_tokens, max_query_len)
+        idx_mapping_np = np.fromiter(
+            map(
+                self.req_states.req_id_to_index.__getitem__,
+                scheduler_output.num_scheduled_tokens,
+            ),
+            dtype=np.intp,
+            count=num_reqs,
+        )
+        return get_uniform_decode_token_count(
+            num_reqs,
+            num_tokens,
+            max_query_len,
+            self.req_states.num_computed_prefill_tokens[idx_mapping_np],
+            self.req_states.prefill_len.np[idx_mapping_np],
+        )
+
     @torch.inference_mode()
     def execute_model(
         self,
@@ -1249,7 +1286,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         num_reqs = len(scheduler_output.num_scheduled_tokens)
         num_toks = scheduler_output.total_num_scheduled_tokens
         max_query_len = max(scheduler_output.num_scheduled_tokens.values())
-        uniform_tok_count = get_uniform_token_count(num_reqs, num_toks, max_query_len)
+        uniform_tok_count = self._get_uniform_token_count(
+            scheduler_output, num_reqs, num_toks, max_query_len, dummy_run
+        )
 
         num_active_loras = 0
         if self.lora_config:

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -13,10 +13,7 @@ from vllm.triton_utils import tl, triton
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
 from vllm.v1.worker.gpu.block_table import BlockTables
-from vllm.v1.worker.gpu.cudagraph_utils import (
-    BatchExecutionDescriptor,
-    get_uniform_token_count,
-)
+from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
 from vllm.v1.worker.gpu.dp_utils import dispatch_cg_and_sync_dp
 from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
 from vllm.v1.worker.gpu.model_states.interface import ModelState
@@ -24,8 +21,7 @@ from vllm.v1.worker.gpu.spec_decode.autoregressive.cudagraph_utils import (
     SpeculatorCudaGraphManager,
 )
 from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
-from vllm.v1.worker.utils import AttentionGroup
-from vllm.v1.worker.utils import get_uniform_decode_token_count
+from vllm.v1.worker.utils import AttentionGroup, get_uniform_decode_token_count
 
 logger = init_logger(__name__)
 

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -11,16 +11,14 @@ from vllm.forward_context import BatchDescriptor, set_forward_context
 from vllm.logger import init_logger
 from vllm.triton_utils import tl, triton
 from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
-from vllm.v1.worker.gpu.cudagraph_utils import (
-    BatchExecutionDescriptor,
-    get_uniform_token_count,
-)
+from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
 from vllm.v1.worker.gpu.dp_utils import dispatch_cg_and_sync_dp
 from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
 from vllm.v1.worker.gpu.spec_decode.autoregressive.cudagraph_utils import (
     SpeculatorCudaGraphManager,
 )
 from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
+from vllm.v1.worker.utils import get_uniform_decode_token_count
 
 logger = init_logger(__name__)
 
@@ -204,12 +202,14 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
 
         # When all requests are decoding (no true prefills), each has
         # num_speculative_steps + 1 tokens, enabling FULL graph replay.
-        uniform_token_count = get_uniform_token_count(
+        uniform_token_count = get_uniform_decode_token_count(
             num_reqs,
             # Use the actual number of tokens without padding added by
             # the target model during FULL cudagraph.
             input_batch.num_tokens,
             max_query_len,
+            input_batch.num_computed_prefill_tokens_np,
+            input_batch.prefill_len_np,
         )
         prefill_batch_desc, num_tokens_across_dp = dispatch_cg_and_sync_dp(
             self.prefill_cudagraph_manager,

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -25,6 +25,7 @@ from vllm.v1.worker.gpu.spec_decode.autoregressive.cudagraph_utils import (
 )
 from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
 from vllm.v1.worker.utils import AttentionGroup
+from vllm.v1.worker.utils import get_uniform_decode_token_count
 
 logger = init_logger(__name__)
 
@@ -274,12 +275,14 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
 
         # When all requests are decoding (no true prefills), each has
         # num_speculative_steps + 1 tokens, enabling FULL graph replay.
-        uniform_token_count = get_uniform_token_count(
+        uniform_token_count = get_uniform_decode_token_count(
             num_reqs,
             # Use the actual number of tokens without padding added by
             # the target model during FULL cudagraph.
             num_tokens,
             max_query_len,
+            input_batch.num_computed_prefill_tokens_np,
+            input_batch.prefill_len_np,
         )
         prefill_batch_desc, num_tokens_across_dp = dispatch_cg_and_sync_dp(
             self.prefill_cudagraph_manager,

--- a/vllm/v1/worker/gpu/spec_decode/multi_module_mtp/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/multi_module_mtp/speculator.py
@@ -12,9 +12,6 @@ from vllm.logger import init_logger
 from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
-from vllm.v1.worker.gpu.cudagraph_utils import (
-    get_uniform_token_count,
-)
 from vllm.v1.worker.gpu.dp_utils import dispatch_cg_and_sync_dp
 from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
 from vllm.v1.worker.gpu.spec_decode.autoregressive.cudagraph_utils import (
@@ -22,6 +19,7 @@ from vllm.v1.worker.gpu.spec_decode.autoregressive.cudagraph_utils import (
 )
 from vllm.v1.worker.gpu.spec_decode.eagle.utils import load_eagle_model
 from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
+from vllm.v1.worker.utils import get_uniform_decode_token_count
 
 logger = init_logger(__name__)
 
@@ -190,10 +188,12 @@ class MultiModuleMTPSpeculator(DraftModelSpeculator):
 
         # When all requests are decoding (no true prefills), each has
         # num_speculative_steps + 1 tokens, enabling FULL graph replay.
-        uniform_token_count = get_uniform_token_count(
+        uniform_token_count = get_uniform_decode_token_count(
             num_reqs,
             num_tokens,
             max_query_len,
+            input_batch.num_computed_prefill_tokens_np,
+            input_batch.prefill_len_np,
         )
         batch_desc, num_tokens_across_dp = dispatch_cg_and_sync_dp(
             self.cudagraph_manager,

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -611,6 +611,63 @@ def copy_kv_cache_blocks_inplace(
         blocks[dst_indices] = blocks[src_indices]
 
 
+def is_uniform_query_len(num_reqs: int, num_tokens: int, max_query_len: int) -> bool:
+    """Whether every request in the batch has the same query length.
+
+    This tests the batch shape only. Callers classifying a scheduled batch as a
+    decode batch must use ``get_uniform_decode_token_count`` instead, because a
+    prompt chunk can have a decode batch's shape.
+
+    Args:
+        num_reqs: Number of requests in the batch.
+        num_tokens: Total number of tokens in the batch.
+        max_query_len: Largest per-request query length in the batch.
+    """
+    return num_reqs > 0 and num_tokens == max_query_len * num_reqs
+
+
+def get_uniform_decode_token_count(
+    num_reqs: int,
+    num_tokens: int,
+    max_query_len: int,
+    num_computed_tokens: np.ndarray,
+    prefill_lens: np.ndarray,
+) -> int | None:
+    """Per-request token count of a uniform decode batch, or None.
+
+    A batch is a uniform decode batch only if every request has the same query
+    length *and* no request is still prefilling. Query length alone is a shape
+    test that a prompt chunk satisfies by coincidence: a prompt chunk of
+    ``1 + num_speculative_tokens`` tokens has the shape of a spec-decode step,
+    and a 1-token chunk has the shape of a plain decode step. Classifying such
+    a batch as a decode batch replays a decode-captured cudagraph over prompt
+    tokens, whose captured kernels read per-request state that a prefill
+    metadata build does not refresh.
+
+    Args:
+        num_reqs: Number of requests in the batch.
+        num_tokens: Total number of tokens in the batch.
+        max_query_len: Largest per-request query length in the batch.
+        num_computed_tokens: Per-request tokens computed before this step, in
+            batch order. Must be exactly ``num_reqs`` long; a full
+            ``max_num_reqs`` state array would compare the wrong requests.
+        prefill_lens: Per-request prefill length, i.e. the prompt plus any
+            output tokens recomputed after preemption, in batch order. Same
+            length requirement.
+
+    Returns:
+        The shared per-request query length, or None if the batch is not a
+        uniform decode batch.
+    """
+    if not is_uniform_query_len(num_reqs, num_tokens, max_query_len):
+        return None
+    # Equivalent to `InputBatch.is_prefilling_np.any()`, which the drafter's
+    # call site derives from the same two arrays.
+    if np.any(num_computed_tokens < prefill_lens):
+        return None
+    return max_query_len
+
+
 def is_residual_scattered_for_sp(
     vllm_config: VllmConfig, num_input_tokens: int
 ) -> bool:

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -564,6 +564,63 @@ def copy_kv_cache_blocks_inplace(
         blocks[dst_indices] = blocks[src_indices]
 
 
+def is_uniform_query_len(num_reqs: int, num_tokens: int, max_query_len: int) -> bool:
+    """Whether every request in the batch has the same query length.
+
+    This tests the batch shape only. Callers classifying a scheduled batch as a
+    decode batch must use ``get_uniform_decode_token_count`` instead, because a
+    prompt chunk can have a decode batch's shape.
+
+    Args:
+        num_reqs: Number of requests in the batch.
+        num_tokens: Total number of tokens in the batch.
+        max_query_len: Largest per-request query length in the batch.
+    """
+    return num_reqs > 0 and num_tokens == max_query_len * num_reqs
+
+
+def get_uniform_decode_token_count(
+    num_reqs: int,
+    num_tokens: int,
+    max_query_len: int,
+    num_computed_tokens: np.ndarray,
+    prefill_lens: np.ndarray,
+) -> int | None:
+    """Per-request token count of a uniform decode batch, or None.
+
+    A batch is a uniform decode batch only if every request has the same query
+    length *and* no request is still prefilling. Query length alone is a shape
+    test that a prompt chunk satisfies by coincidence: a prompt chunk of
+    ``1 + num_speculative_tokens`` tokens has the shape of a spec-decode step,
+    and a 1-token chunk has the shape of a plain decode step. Classifying such
+    a batch as a decode batch replays a decode-captured cudagraph over prompt
+    tokens, whose captured kernels read per-request state that a prefill
+    metadata build does not refresh.
+
+    Args:
+        num_reqs: Number of requests in the batch.
+        num_tokens: Total number of tokens in the batch.
+        max_query_len: Largest per-request query length in the batch.
+        num_computed_tokens: Per-request tokens computed before this step, in
+            batch order. Must be exactly ``num_reqs`` long; a full
+            ``max_num_reqs`` state array would compare the wrong requests.
+        prefill_lens: Per-request prefill length, i.e. the prompt plus any
+            output tokens recomputed after preemption, in batch order. Same
+            length requirement.
+
+    Returns:
+        The shared per-request query length, or None if the batch is not a
+        uniform decode batch.
+    """
+    if not is_uniform_query_len(num_reqs, num_tokens, max_query_len):
+        return None
+    # Equivalent to `InputBatch.is_prefilling_np.any()`, which the drafter's
+    # call site derives from the same two arrays.
+    if np.any(num_computed_tokens < prefill_lens):
+        return None
+    return max_query_len
+
+
 def is_residual_scattered_for_sp(
     vllm_config: VllmConfig, num_input_tokens: int
 ) -> bool:


### PR DESCRIPTION
# [Bugfix][MRV2] Require all requests to be decoding for uniform-decode dispatch

## Purpose

Split out of #50488 at a maintainer's request, so each fix is reviewable on its
own.

V2 classified a batch as uniform decode from its shape alone
(`num_tokens == num_reqs * max_query_len`) and nothing about whether the
requests were actually decoding. A prompt chunk of exactly
`1 + num_speculative_tokens` tokens has that shape, so a prefill was dispatched
with `cg_mode=FULL` and replayed the captured spec-verify decode graph over
prompt tokens. Without spec decoding the same collision exists between a
1-token prompt chunk and the q=1 decode graph.

Dense models survive it, because spec-verify attention over a fresh sequence is
the same computation as prefill attention. Recurrent-state models do not: the
mis-dispatched batch still builds prefill metadata, so the GDN builder's
persistent-buffer refresh is skipped and the replayed graph reads capture-time
state indices. `state_idx <= 0` makes the fused GDN kernels skip the recurrent
state read and store, so the prompt's conv/SSM state is never created. The gate
is per batch, so genuine decodes sharing a batch with such a chunk lose their
refresh too. This is the mechanism behind #49918.

The predicate now requires every request in the batch to be past its prefill,
not merely for the batch to have the right shape. Dummy batches (DP padding,
memory profiling, warmup) are uniform by construction and have no request state
to consult, so they stay classified by shape, mirroring `InputBatch.make_dummy`.

The second commit is a performance follow-on in the same path: the shape test is
O(1) and rejects every mixed prefill/decode batch, which is most of them, so it
is hoisted ahead of the `np.fromiter` gather of request state rather than run
after it.

A third commit covers `multi_module_mtp/speculator.py`, which landed on main
after this branch was cut. It is a copy of the autoregressive speculator,
comment included, and repeats the shape-only call, so it carries the same
defect. The guard added alongside it is written over every speculator in the
package rather than over that one file, because copying is how the call
reappeared; it fails on the offending line without the change and passes with
it.

## Test Plan

- `tests/v1/worker/test_gpu_batch_ordering.py` — the classification itself,
  including the prompt-chunk shapes that previously passed and the dummy-run
  path that must keep passing, plus the dispatch consequences: an 8-token
  prefill dispatches PIECEWISE and answers the prompt, control outputs are
  unchanged byte for byte, and genuine decode steps still replay their FULL
  graphs. A further case pins that the O(1) shape test rejects a non-uniform
  batch on its own, which is the ordering the second commit relies on.
- `tests/v1/spec_decode/test_dynamic_sd_cug.py` — the dynamic speculative
  schedule path over the same dispatch.

## Test Result

`pytest tests/v1/spec_decode/test_dynamic_sd_cug.py
tests/v1/worker/test_gpu_batch_ordering.py` — **14 passed**, run on an H100
sandbox against this branch overlaid on the pinned nightly wheel
(`0.26.1rc1.dev77+g6f91edf96`).

Revert check: with the decoding clause removed from the predicate,
`test_prompt_chunks_shaped_like_spec_decode_miss_the_full_graph` and
`test_prompt_chunk_of_decode_query_len_is_not_uniform_decode` fail while the
uniform-decode and dummy-run cases still pass.

`ruff check` and `ruff format --check` are clean on every touched file.

### Model evaluation

`tests/evals/gsm8k/gsm8k_eval.py`, 400 questions, 5-shot, greedy, on
`Qwen/Qwen3-4B` with the published `z-lab/Qwen3-4B-DFlash-b16` drafter at
`num_speculative_tokens=16`, V2 model runner, single H100: **accuracy 0.880,
0.000 invalid, 400 questions**. This was measured on the combined set of fixes
before the split, so it covers this change together with the others rather than
in isolation.

## Related

- #49918 — reproduces this independently of proposer (MTP and ngram),
  quantization and batch size, with PIECEWISE or enforce-eager as workarounds.

Split from #50488, alongside the warmup lookahead reservation fix and the CUDA
graph capture-size fix. I checked for duplicate and overlapping open PRs
(`gh pr list --search` on "uniform decode cudagraph", "uniform decode
dispatch", "prefill full cudagraph") and found none besides #49918, which is an
issue rather than a fix.

I used AI assistance (Cursor) to draft, test, and validate this change, and I
reviewed every changed line before submitting.