### PR TITLE
[Bugfix][TurboQuant] Add KV quant mode for turboquant 

### DIFF
--- a/tests/quantization/test_turboquant.py
+++ b/tests/quantization/test_turboquant.py
@@ -277,6 +277,29 @@ class TestHybridAttentionIndices:
         assert _get_full_attention_layer_indices(mc) == []
 
 
+class TestTurboQuantKVCacheSpec:
+    @pytest.mark.parametrize("preset", ALL_PRESETS)
+    def test_kv_cache_spec_sets_kv_quant_mode(self, preset):
+        from vllm.model_executor.layers.attention.attention import Attention
+        from vllm.v1.kv_cache_interface import KVQuantMode, TQFullAttentionSpec
+
+        layer = SimpleNamespace(
+            attn_type="decoder",
+            kv_cache_dtype=preset,
+            kv_cache_torch_dtype=torch.uint8,
+            head_size=128,
+            head_size_v=128,
+            num_kv_heads=4,
+            sliding_window=None,
+        )
+        vllm_config = SimpleNamespace(cache_config=SimpleNamespace(block_size=32))
+
+        spec = Attention.get_kv_cache_spec(layer, vllm_config)
+
+        assert isinstance(spec, TQFullAttentionSpec)
+        assert spec.kv_quant_mode == KVQuantMode.TURBOQUANT
+
+
 class TestTurboQuantWorkspaceReservation:
     @staticmethod
     def _fake_vllm_config(

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -680,6 +680,7 @@ class Attention(nn.Module, AttentionLayerBase):
                 head_size=self.head_size,
                 head_size_v=self.head_size,
                 dtype=self.kv_cache_torch_dtype,
+                kv_quant_mode=quant_mode,
                 tq_slot_size=tq_config.slot_size_aligned,
             )
         else:

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -43,6 +43,7 @@ class KVQuantMode(IntEnum):
     FP8_PER_TOKEN_HEAD = 3  # per-token-head dynamic scales for fp8
     INT4_PER_TOKEN_HEAD = 4  # packed 2×int4/byte, RHT + asymmetric zp
     NVFP4 = 5  # packed fp4 data + fp8 block scales
+    TURBOQUANT = 6  # Hadamard-rotated Lloyd-Max quant, packed K+V per slot
 
     @property
     def is_per_token_head(self) -> bool:
@@ -58,6 +59,11 @@ class KVQuantMode(IntEnum):
         """True for NVFP4 packed quantization mode."""
         return self == KVQuantMode.NVFP4
 
+    @property
+    def is_turboquant(self) -> bool:
+        """True for turboquant quantization mode."""
+        return self == KVQuantMode.TURBOQUANT
+
 
 def get_kv_quant_mode(kv_cache_dtype: str) -> KVQuantMode:
     """Map a ``kv_cache_dtype`` string to a :class:`KVQuantMode`."""
@@ -69,6 +75,8 @@ def get_kv_quant_mode(kv_cache_dtype: str) -> KVQuantMode:
         return KVQuantMode.FP8_PER_TOKEN_HEAD
     if kv_cache_dtype == "nvfp4":
         return KVQuantMode.NVFP4
+    if isinstance(kv_cache_dtype, str) and kv_cache_dtype.startswith("turboquant_"):
+        return KVQuantMode.TURBOQUANT
     if isinstance(kv_cache_dtype, str) and kv_cache_dtype.startswith("fp8"):
         return KVQuantMode.FP8_PER_TENSOR
     return KVQuantMode.NONE

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -27,7 +27,6 @@ from vllm.v1.kv_cache_interface import (
     KVCacheSpec,
     KVQuantMode,
     MambaSpec,
-    TQFullAttentionSpec,
     UniformTypeKVCacheSpecs,
 )
 from vllm.v1.worker.gpu.model_states.interface import ModelSpecificAttnMetadata
@@ -324,7 +323,6 @@ def _reshape_kv_cache(
                 layer_cache_dtype = (
                     "auto"
                     if kv_cache_spec.kv_quant_mode == KVQuantMode.NONE
-                    and not isinstance(kv_cache_spec, TQFullAttentionSpec)
                     else cache_dtype
                 )
                 kv_cache_shape = group.backend.get_kv_cache_shape(


### PR DESCRIPTION

## Purpose
Adds KV quant mode for turboquant KV cache. This fix prevents the KV cache dtype string being set to auto which causes the following failure in TurboQuant observed in  https://github.com/vllm-project/vllm/pull/47609 https://github.com/vllm-project/vllm/pull/48177/ https://github.com/vllm-project/vllm/pull/48907

```
vllm serve Qwen/Qwen3-30B-A3B-Thinking-2507  --kv-cache-dtype turboquant_4bit_nc
```
```
(EngineCore pid=21869)   File "/tmp/vllm/vllm/v1/worker/gpu_model_runner.py", line 6499, in profile_cudagraph_memory
(EngineCore pid=21869)     self._init_minimal_kv_cache_for_profiling()
(EngineCore pid=21869)   File "/tmp/vllm/vllm/v1/worker/gpu_model_runner.py", line 6383, in _init_minimal_kv_cache_for_profiling
(EngineCore pid=21869)     self.initialize_kv_cache(minimal_config, is_profiling=True)
(EngineCore pid=21869)   File "/tmp/vllm/vllm/v1/worker/gpu_model_runner.py", line 7439, in initialize_kv_cache
(EngineCore pid=21869)     kv_caches = self.initialize_kv_cache_tensors(
(EngineCore pid=21869)                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=21869)   File "/tmp/vllm/vllm/v1/worker/gpu_model_runner.py", line 7356, in initialize_kv_cache_tensors
(EngineCore pid=21869)     kv_caches = self._reshape_kv_cache_tensors(
(EngineCore pid=21869)                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=21869)   File "/tmp/vllm/vllm/v1/worker/gpu_model_runner.py", line 7201, in _reshape_kv_cache_tensors
(EngineCore pid=21869)     kv_cache_shape = attn_backend.get_kv_cache_shape(
(EngineCore pid=21869)                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=21869)   File "/tmp/vllm/vllm/v1/attention/backends/turboquant_attn.py", line 161, in get_kv_cache_shape
(EngineCore pid=21869)     tq_config = TurboQuantConfig.from_cache_dtype(cache_dtype_str, head_size)
(EngineCore pid=21869)                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=21869)   File "/tmp/vllm/vllm/model_executor/layers/quantization/turboquant/config.py", line 222, in from_cache_dtype
(EngineCore pid=21869)     raise ValueError(
(EngineCore pid=21869) ValueError: Unknown TurboQuant cache dtype: 'auto'. Valid presets: turboquant_k8v4, turboquant_4bit_nc, turboquant_k3v4_nc, turboquant_3bit_nc
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

