### PR TITLE
fix(config): guard LlamaBidirectionalConfig against missing hf_config.pooling

### DIFF
--- a/tests/models/test_config_verify_and_update.py
+++ b/tests/models/test_config_verify_and_update.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for VerifyAndUpdateConfig subclasses in models/config.py.
+
+These use lightweight mock config objects so they run on CPU without
+downloading any model.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.model_executor.models.config import LlamaBidirectionalConfig
+
+
+def _mock_model_config(hf_config):
+    return SimpleNamespace(
+        hf_config=hf_config,
+        pooler_config=SimpleNamespace(seq_pooling_type=None),
+    )
+
+
+def test_llama_bidirectional_missing_pooling_raises_value_error():
+    # NV-Embed-v2 style config: no top-level ``pooling`` attribute. Before the
+    # guard this raised an opaque ``AttributeError`` deep in engine-core spawn.
+    model_config = _mock_model_config(SimpleNamespace())
+    with pytest.raises(ValueError, match="pooling"):
+        LlamaBidirectionalConfig.verify_and_update_model_config(model_config)
+
+
+def test_llama_bidirectional_unsupported_pooling_raises_value_error():
+    model_config = _mock_model_config(SimpleNamespace(pooling="latent"))
+    with pytest.raises(ValueError, match="pool_type"):
+        LlamaBidirectionalConfig.verify_and_update_model_config(model_config)
+
+
+@pytest.mark.parametrize(
+    "pooling,expected",
+    [("avg", "MEAN"), ("cls", "CLS"), ("last", "LAST")],
+)
+def test_llama_bidirectional_valid_pooling(pooling, expected):
+    model_config = _mock_model_config(SimpleNamespace(pooling=pooling))
+    LlamaBidirectionalConfig.verify_and_update_model_config(model_config)
+    assert model_config.pooler_config.seq_pooling_type == expected
+    assert model_config.hf_config.is_causal is False

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -549,9 +549,19 @@ class LlamaBidirectionalConfig(VerifyAndUpdateConfig):
             "last": "LAST",
         }
 
-        pooling_type = pooling_type_map.get(hf_config.pooling)
+        pooling = getattr(hf_config, "pooling", None)
+        if pooling is None:
+            raise ValueError(
+                "This bidirectional model requires a 'pooling' field in its HF "
+                "config (one of 'avg', 'cls', 'last'), but none was found. "
+                "Unlike the VL variants, no default is assumed here because "
+                "silently picking a pooling for an embedding model can produce "
+                "wrong embeddings."
+            )
+
+        pooling_type = pooling_type_map.get(pooling)
         if pooling_type is None:
-            raise ValueError(f"pool_type {hf_config.pooling!r} not supported")
+            raise ValueError(f"pool_type {pooling!r} not supported")
 
         assert model_config.pooler_config is not None
         model_config.pooler_config.seq_pooling_type = pooling_type

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -563,9 +563,19 @@ class LlamaBidirectionalConfig(VerifyAndUpdateConfig):
             "last": "LAST",
         }
 
-        pooling_type = pooling_type_map.get(hf_config.pooling)
+        pooling = getattr(hf_config, "pooling", None)
+        if pooling is None:
+            raise ValueError(
+                "This bidirectional model requires a 'pooling' field in its HF "
+                "config (one of 'avg', 'cls', 'last'), but none was found. "
+                "Unlike the VL variants, no default is assumed here because "
+                "silently picking a pooling for an embedding model can produce "
+                "wrong embeddings."
+            )
+
+        pooling_type = pooling_type_map.get(pooling)
         if pooling_type is None:
-            raise ValueError(f"pool_type {hf_config.pooling!r} not supported")
+            raise ValueError(f"pool_type {pooling!r} not supported")
 
         model_config.pooler_config.seq_pooling_type = pooling_type
 


### PR DESCRIPTION
`LlamaBidirectionalConfig.verify_and_update_model_config` reads `hf_config.pooling` directly. A bidirectional-Llama checkpoint whose HF config carries no `pooling` field (e.g. `nvidia/NV-Embed-v2`) hits an opaque `AttributeError` during engine-core spawn instead of a clear message.

Guard it with `getattr` and raise an actionable `ValueError`. The VL siblings (`LlamaNemotronVLConfig`) default to `avg`, but I didn't default here on purpose — silently picking a pooling for an embedding model can produce wrong embeddings, so failing loudly is safer. If a default is actually wanted for these, happy to switch.

Scope: this is only the vLLM-side AttributeError from #50495. The primary blocker there (the `_LazyConfigMapping` pickle failure) lives in the model's own HF config, same class as #11055 — not touched here.

Test: added a CPU unit test (mock configs, no download) covering missing / unsupported / valid pooling.
```
tests/models/test_config_verify_and_update.py ..... 5 passed in 0.81s
```