### PR TITLE
[CI/Build] Add uv cache mount to the mooncake wheel install

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1044,7 +1044,8 @@ RUN --mount=type=cache,target=/opt/uv/cache \
 # floor must be <= the FINAL_BASE_IMAGE's glibc.
 ARG MOONCAKE_WHEEL_AARCH64
 ARG MOONCAKE_WHEEL_X86_64
-RUN if [ "$INSTALL_KV_CONNECTORS" = "true" ]; then \
+RUN --mount=type=cache,target=/opt/uv/cache \
+    if [ "$INSTALL_KV_CONNECTORS" = "true" ]; then \
         if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
             WHEEL="${MOONCAKE_WHEEL_AARCH64}"; \
         else \


### PR DESCRIPTION
## Purpose

The published CUDA `vllm/vllm-openai` images retain uv's download and unpack cache for the mooncake wheel inside the image. In the current `latest` (amd64, digest `sha256:770fe65b2c73ee74a5c42165cf3433de4048cc2cd9c57a937ca4e35aba5aa87b`), the final layer is this Dockerfile's mooncake install RUN: 482,417,313 bytes compressed of the image's 8,914,042,324 byte compressed pull. Streaming that layer and tallying entries by path shows 783,486,803 bytes under `usr` (the installed package) and 790,287,022 bytes under `opt/uv/cache`. Of the cache, 783,483,919 bytes are byte for byte the wheel's uncompressed contents (uv's `archive-v0` unpack of the same wheel the RUN installs) and the remaining 6,803,103 bytes are package index metadata. The cache lands in the layer because this RUN is the only `uv pip install` in `docker/Dockerfile` without the `--mount=type=cache,target=/opt/uv/cache` that every other one carries, while the image sets `UV_CACHE_DIR=/opt/uv/cache` globally. The release pipeline passes the mooncake wheel arguments to the CUDA image builds, so the retained cache ships in each published CUDA variant.

This change adds the same cache mount the other installs already carry. The cache half is 50.2 percent of the layer's uncompressed contents; recompressing the layer's two halves separately at the shipped gzip settings measures the saving at 242.6 MB off the compressed pull (split-recompression delta +0.0011 percent against the shipped blob, whole-layer re-gzip control ratio 0.9674). The reproduction below measures the uncompressed layer directly, and no full CUDA image build was run. Unmounting the cache is safe for the installed files because the image also sets `UV_LINK_MODE=copy`, so installs copy out of the cache rather than link into it. The block was introduced in #42114; #41134 is the closest precedent for removing layer bloat in this file, with a different mechanism (duplicate files across two layers there, a retained build-time cache in one layer here). When `INSTALL_KV_CONNECTORS` is false or the wheel args are unset, the RUN short-circuits exactly as before, and the change has no runtime surface. A cache mount rather than `--no-cache` because it matches every other uv install in the file and keeps cross-build reuse.

On duplicate work: I checked the most recently updated open PRs touching `docker/Dockerfile` and the open PRs mentioning mooncake; none change this RUN. The nearest is #47468, which rewrites the comment block directly above it, two unchanged lines away, so whichever lands second needs a trivial rebase. There is no associated issue.

## Before-change evidence (published image, no rebuild needed)

With an anonymous Docker Hub token: read the amd64 manifest, match the image config's `created_by` history to confirm the final layer is this RUN, stream the layer blob through gzip and tar, and tally entry sizes by path prefix. Beyond `usr` and `opt/uv/cache`, the layer holds only a zero-byte uv lock file under `tmp` and whiteout entries, one of which records this RUN replacing the mooncake 0.3.12 that the kv_connectors install above it had already installed, which is why the layer carries a full second copy of the package rather than a delta. The wheel at the release pipeline's URL is 232,006,360 bytes compressed and 783,483,919 bytes uncompressed, exactly matching the cache's `archive-v0` copy; the installed copy under `usr` differs from it only by 2,884 bytes of `dist-info` and console scripts.

## Tests

A two-image BuildKit reproduction with the exact release wheel and the image's uv configuration, on an x86_64 host (Docker 28.3.1, BuildKit). The two Dockerfiles differ only in the mount:

```dockerfile
FROM python:3.12-slim
RUN pip install --no-cache-dir uv
ENV UV_CACHE_DIR=/opt/uv/cache
ENV UV_LINK_MODE=copy
RUN uv pip install --system --no-deps "<the release pipeline's mooncake x86_64 wheel URL>"
```

with the second image's install line prefixed by `--mount=type=cache,target=/opt/uv/cache`. The reproduction adds `--no-deps`, which the real RUN does not use, because mooncake's dependencies are already installed by the kv_connectors step in the real image but absent from `python:3.12-slim`; letting uv resolve them here would contaminate both layer sizes with unrelated packages.

| variant | install layer | total image | /opt/uv/cache in image | verification |
|---|---|---|---|---|
| without mount | 1.57 GB | 1,750,472,748 B | 783,486,187 B | import ok |
| with mount | 783 MB | 966,986,600 B | absent | import ok |

The 783,486,148 byte image-size delta matches the measured in-image cache to within 39 bytes. `pip show` reports the same version and location in both, and `python3 -c "import mooncake"` succeeds in both.
