### PR TITLE
[Bugfix] Preserve FlashInfer B12x MoE runtime tensors across reload

### DIFF
--- a/tests/model_executor/model_loader/test_reload.py
+++ b/tests/model_executor/model_loader/test_reload.py
@@ -951,3 +951,140 @@ def test_online_quantize_reload(
         mul_perp = llm.generate_prompt_perplexity(["3 4 = 12"], mask=["3 4 ="])[0]
         add_perp = llm.generate_prompt_perplexity(["3 4 = 7"], mask=["3 4 ="])[0]
         assert add_perp < mul_perp
+
+
+_B12X_NUM_EXPERTS = 4
+_B12X_HIDDEN = 32
+_B12X_INTER = 16
+
+
+class _B12xLayer(torch.nn.Module):
+    """Minimal RoutedExperts stand-in with the params b12x post-load reads."""
+
+    def __init__(self):
+        super().__init__()
+        E, H, N = _B12X_NUM_EXPERTS, _B12X_HIDDEN, _B12X_INTER
+
+        def param(t):
+            return torch.nn.Parameter(t, requires_grad=False)
+
+        self.w13_weight = param(torch.zeros(E, 2 * N, H // 2, dtype=torch.uint8))
+        self.w13_weight_scale = param(torch.full((E, 2 * N, H // 16), 2.0))
+        self.w13_weight_scale_2 = param(torch.full((E,), 3.0))
+        self.w2_weight_scale = param(torch.full((E, H, N // 16), 2.0))
+        self.w2_weight_scale_2 = param(torch.full((E,), 3.0))
+
+
+def _make_b12x_experts(layer):
+    from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+    from vllm.model_executor.layers.fused_moe.config import (
+        FusedMoEConfig,
+        FusedMoEParallelConfig,
+        FusedMoEQuantConfig,
+        RoutingMethodType,
+    )
+    from vllm.model_executor.layers.fused_moe.experts.flashinfer_b12x_moe import (
+        FlashInferB12xExperts,
+    )
+
+    E = _B12X_NUM_EXPERTS
+    moe_config = FusedMoEConfig(
+        num_experts=E,
+        experts_per_token=2,
+        hidden_dim=_B12X_HIDDEN,
+        intermediate_size=_B12X_INTER,
+        num_local_experts=E,
+        num_logical_experts=E,
+        activation=MoEActivation.SILU,
+        device="cpu",
+        routing_method=RoutingMethodType.TopK,
+        moe_parallel_config=FusedMoEParallelConfig(
+            tp_size=1,
+            pcp_size=1,
+            dp_size=1,
+            ep_size=1,
+            tp_rank=0,
+            pcp_rank=0,
+            dp_rank=0,
+            ep_rank=0,
+            sp_size=1,
+            use_ep=False,
+            all2all_backend="naive",
+            enable_eplb=False,
+        ),
+        in_dtype=torch.bfloat16,
+    )
+    # Mirror the real flow: the quant config is rebuilt from the live layer
+    # params on every post-load pass.
+    quant_config = FusedMoEQuantConfig.make(
+        quant_dtype="nvfp4",
+        w1_scale=layer.w13_weight_scale,
+        w2_scale=layer.w2_weight_scale,
+        g1_alphas=torch.ones(E),
+        g2_alphas=torch.ones(E),
+        a2_gscale=torch.full((E,), 5.0),
+    )
+    return FlashInferB12xExperts(moe_config, quant_config)
+
+
+def test_b12x_post_load_preserves_runtime_tensor_addresses(monkeypatch, dist_init):
+    """FlashInferB12xExperts is rebuilt by every post-load pass, but its
+    runtime scale tensors and the flashinfer wrapper's workspaces are read by
+    captured CUDA graphs, so each rebuild must reuse the layer-held storage
+    the graph captured instead of allocating fresh objects (#48312)."""
+    import vllm.model_executor.layers.fused_moe.experts.flashinfer_b12x_moe as b12x
+
+    # The real MMA-layout conversion needs flashinfer + SM120; substitute a
+    # deterministic value-dependent transform so refresh is observable.
+    monkeypatch.setattr(
+        b12x,
+        "flashinfer_convert_sf_to_mma_layout",
+        lambda t, m, k, num_groups: t.float().clone(),
+    )
+    build_calls = []
+    monkeypatch.setattr(
+        b12x.FlashInferB12xExperts,
+        "_build_wrapper",
+        lambda self: build_calls.append(1) or object(),
+        raising=False,
+    )
+
+    layer = _B12xLayer()
+
+    experts_a = _make_b12x_experts(layer)
+    experts_a.process_weights_after_loading(layer)
+
+    names = ("fc2_input_scale", "w1_sf_mma", "w2_sf_mma")
+    ptrs = {n: getattr(layer, n).data_ptr() for n in names}
+    for n in names:
+        assert isinstance(getattr(layer, n), torch.nn.Parameter)
+    # w13_weight_scale (2.0) baked with scale_2 (3.0) -> 6.0.
+    assert torch.equal(layer.w1_sf_mma, torch.full_like(layer.w1_sf_mma, 6.0))
+    wrapper = experts_a._wrapper
+    assert wrapper is not None
+    assert layer._flashinfer_b12x_wrapper is wrapper
+    assert len(build_calls) == 1
+
+    # Simulate a weight reload: loaders restore checkpoint scale values, then
+    # a fresh experts object runs post-load processing again.
+    layer.w13_weight_scale.data = torch.full_like(layer.w13_weight_scale, 4.0)
+    layer.w13_weight_scale_2.data = torch.full_like(layer.w13_weight_scale_2, 3.0)
+    layer.w2_weight_scale.data = torch.full_like(layer.w2_weight_scale, 4.0)
+    layer.w2_weight_scale_2.data = torch.full_like(layer.w2_weight_scale_2, 3.0)
+
+    experts_b = _make_b12x_experts(layer)
+    experts_b.process_weights_after_loading(layer)
+
+    for n in names:
+        assert getattr(layer, n).data_ptr() == ptrs[n], n
+    # Rebuild refreshed the values in place: 4.0 * 3.0 = 12.0.
+    assert torch.equal(layer.w1_sf_mma, torch.full_like(layer.w1_sf_mma, 12.0))
+    assert torch.equal(layer.w2_sf_mma, torch.full_like(layer.w2_sf_mma, 12.0))
+    assert torch.equal(layer.fc2_input_scale, torch.ones_like(layer.fc2_input_scale))
+    # The experts attributes are the layer-registered tensors, and the
+    # flashinfer wrapper (whose workspaces graphs also capture) is reused.
+    assert experts_b._fc2_input_scale is layer.fc2_input_scale
+    assert experts_b.w1_sf_mma is layer.w1_sf_mma
+    assert experts_b.w2_sf_mma is layer.w2_sf_mma
+    assert experts_b._wrapper is wrapper
+    assert len(build_calls) == 1

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
@@ -20,6 +20,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kNvfp4Dynamic,
     kNvfp4Static,
 )
+from vllm.model_executor.utils import replace_parameter
 from vllm.platforms import current_platform
 from vllm.utils.flashinfer import (
     flashinfer_convert_sf_to_mma_layout,
@@ -118,43 +119,80 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
         # is intended for static-quantisation backends (TRTLLM/CUTLASS) and
         # causes every intermediate activation to saturate at max FP4 when
         # multiplied by values that large.  Force to 1.0 so the kernel uses
-        # its own per-block dynamic scale.
+        # its own per-block dynamic scale.  W4A16 NVFP4 checkpoints have no
+        # calibrated a2_gscale at all; b12x performs dynamic per-block
+        # FC2-input quantization, so a uniform 1.0 scale per expert is
+        # equivalent in both cases.  Allocate once here so apply() stays
+        # alloc-free.
         if self.a2_gscale is not None:
             self.a2_gscale.fill_(1.0)
-            self._fc2_input_scale = self.a2_gscale
-        else:
-            # W4A16 NVFP4 checkpoints have no calibrated a2_gscale; b12x
-            # performs dynamic per-block FC2-input quantization, so a uniform
-            # 1.0 scale per expert is equivalent to the bake-in above for
-            # static-quant checkpoints. Allocate once here so apply() stays
-            # alloc-free.
-            self._fc2_input_scale = torch.ones(
+        self._fc2_input_scale = self._stable_runtime_tensor(
+            layer,
+            "fc2_input_scale",
+            torch.ones(
                 self.num_local_experts,
                 device=layer.w13_weight.device,
                 dtype=torch.float32,
-            )
+            ),
+        )
+
+        # Bind the flashinfer wrapper cached on the layer. The wrapper
+        # pre-allocates its CUDA-graph workspaces and output buffer at
+        # construction, so captured graphs bake those addresses too; a fresh
+        # wrapper per experts rebuild would leave replayed graphs writing
+        # into freed workspace storage after a weight reload.
+        wrapper = getattr(layer, "_flashinfer_b12x_wrapper", None)
+        if wrapper is None:
+            wrapper = self._build_wrapper()
+            layer._flashinfer_b12x_wrapper = wrapper
+        self._wrapper = wrapper
 
         # Precompute MMA-layout views of the weight scale factors once here
         # rather than recomputing on every forward pass.
         assert self.w1_scale is not None
         num_experts_w1, m1, k1_sf = self.w1_scale.shape
         k1 = k1_sf * 16
-        self.w1_sf_mma = flashinfer_convert_sf_to_mma_layout(
-            self.w1_scale.reshape(num_experts_w1 * m1, k1_sf),
-            m=m1,
-            k=k1,
-            num_groups=num_experts_w1,
+        self.w1_sf_mma = self._stable_runtime_tensor(
+            layer,
+            "w1_sf_mma",
+            flashinfer_convert_sf_to_mma_layout(
+                self.w1_scale.reshape(num_experts_w1 * m1, k1_sf),
+                m=m1,
+                k=k1,
+                num_groups=num_experts_w1,
+            ),
         )
 
         assert self.w2_scale is not None
         num_experts_w2, m2, k2_sf = self.w2_scale.shape
         k2 = k2_sf * 16
-        self.w2_sf_mma = flashinfer_convert_sf_to_mma_layout(
-            self.w2_scale.reshape(num_experts_w2 * m2, k2_sf),
-            m=m2,
-            k=k2,
-            num_groups=num_experts_w2,
+        self.w2_sf_mma = self._stable_runtime_tensor(
+            layer,
+            "w2_sf_mma",
+            flashinfer_convert_sf_to_mma_layout(
+                self.w2_scale.reshape(num_experts_w2 * m2, k2_sf),
+                m=m2,
+                k=k2,
+                num_groups=num_experts_w2,
+            ),
         )
+
+    def _stable_runtime_tensor(
+        self, layer: torch.nn.Module, name: str, value: torch.Tensor
+    ) -> torch.Tensor:
+        """Bind a runtime tensor to a reload-stable address on the layer.
+
+        This experts object is rebuilt by every process_weights_after_loading
+        pass, and these tensors are passed to the fused kernel each forward,
+        so captured CUDA graphs bake their addresses (see #48312).
+        Registering them on the owning layer with
+        replace_parameter(prefer_copy=True) makes every rebuild copy into the
+        storage the graph captured instead of allocating fresh tensors, and
+        layer registration puts them inside layerwise reload's kernel-tensor
+        copy-back so a reload refreshes them at the captured address.
+        """
+        replace_parameter(layer, name, value, prefer_copy=True)
+        return getattr(layer, name)
 
     @staticmethod
     def activation_format() -> mk.FusedMoEActivationFormat:
@@ -227,14 +265,10 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
         # from pre-quantizing activations.
         return True
 
-    def _ensure_wrapper(self) -> None:
-        """Lazily create B12xMoEWrapper on first use."""
-        if self._wrapper is not None:
-            return
-
+    def _build_wrapper(self) -> Any:
         from flashinfer.fused_moe import B12xMoEWrapper
 
-        self._wrapper = B12xMoEWrapper(
+        return B12xMoEWrapper(
             num_experts=self.global_num_experts,
             top_k=self.topk,
             hidden_size=self.hidden_dim,
@@ -244,6 +278,13 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
             num_local_experts=self.num_local_experts,
             activation=self._activation_str,
         )
+
+    def _ensure_wrapper(self) -> None:
+        """Create B12xMoEWrapper on first use if process_weights_after_loading
+        did not already bind the layer-cached one (tests, direct use)."""
+        if self._wrapper is not None:
+            return
+        self._wrapper = self._build_wrapper()
 
     def apply(
         self,


### PR DESCRIPTION
### Purpose

Fixes the FlashInfer B12x MoE runtime scales row of #48312 (category 1, storage identity). On SM120 with `moe_backend="flashinfer_b12x"`, a same-weights `reload_weights` leaves every captured CUDA graph reading freed storage, and the engine hangs on the first post-reload batch.

Two defects, both from the experts object being rebuilt by every `process_weights_after_loading` pass:

1. `FlashInferB12xExperts` reallocates `_fc2_input_scale`, `w1_sf_mma`, and `w2_sf_mma` on the new experts object. These are passed to the fused kernel every forward, so captured graphs bake their addresses; after a reload the graphs read freed storage while the refreshed values live in tensors the graphs never see.
2. The lazily constructed `B12xMoEWrapper` pre-allocates CUDA-graph workspaces (routing metadata) and its output buffer at construction. A rebuilt experts object constructs a fresh wrapper, so replayed graphs write routing metadata into freed workspace storage and read garbage loop bounds back. This is the hang mechanism: the first post-reload generation pins the GPU at 100% indefinitely (EngineCore blocked, killed after 10+ minutes on a 4-prompt greedy batch that takes seconds at baseline).

The fix routes the three tensors through `replace_parameter(prefer_copy=True)` on the owning layer (the same pattern as #48438, #48539, and #50521): the first pass registers them, capture binds that storage, every rebuild copies new values into the same address, and layer registration puts them inside layerwise reload's kernel-tensor copy-back. The wrapper is cached on the layer as a plain attribute and rebound in `process_weights_after_loading`, so its workspaces survive rebuilds; the lazy `_ensure_wrapper` path remains for direct construction without a layer. A secondary effect of stable weight and scale pointers is that the wrapper's pointer-keyed weight-view caches stay valid across reloads instead of being rebuilt.

The `fc2_input_scale` binding is also unified: both the static-quant and W4A16 branches now register a per-expert ones tensor (the static branch already forced the calibrated `a2_gscale` to 1.0, and it still does for other consumers), which avoids aliasing the quant config tensor.

Note on why this row was hard to confirm before: on builds without #49489 (including release 0.26.0), layerwise reload on this model family crashes outright in copy-back on the expanded `w13_input_scale`/`w2_input_scale` views, before the stale-pointer state is reachable. #49489 materialized those views on main, which unmasks this bug: reload now completes and then hangs at replay.

### Test Plan

CPU regression test in `tests/model_executor/model_loader/test_reload.py`:

- `test_b12x_post_load_preserves_runtime_tensor_addresses`: builds the experts against a minimal layer, runs post-load processing twice with checkpoint-restored scale values in between (the reload sequence), and asserts the three layer-registered tensors keep their storage addresses while carrying the refreshed values, that the experts attributes are the layer-registered tensors, and that the flashinfer wrapper is constructed exactly once and reused. The MMA-layout conversion is stubbed with a deterministic value-dependent transform so the test runs without flashinfer or SM120 hardware. On stock code the test fails at the first assertion (nothing is registered on the layer).

GPU red/green on an RTX PRO 6000 Blackwell (SM120), `NVFP4/Qwen3-30B-A3B-Instruct-2507-FP4` (modelopt NVFP4), `moe_backend="flashinfer_b12x"`, CUDA graphs enabled (default `FULL_AND_PIECEWISE`), stock per-commit wheel with only this file overlaid for green. Oracle: pointer census over the three tensors across all 48 MoE layers (144 tensors) via `apply_model`, with the 192 layer-registered weight/scale params as a control group, plus a same-weights `reload_weights` and post-reload generation.

- Red (stock main): 144/144 graph-visible pointers move and all 48 experts objects are rebuilt, while 0/192 control params move (copy-back preserves everything it can see; these tensors are exactly the storage outside it). The first post-reload generation hangs indefinitely at 100% GPU and had to be killed; reproduced three times across two wheels.
- Green (this fix): 144/144 graph-visible pointers stable, 144/144 layer-registered before and after reload, values preserved, post-reload generation completes promptly, and the reload is byte-identical (md5 over all 672 MoE layer params and backend tensors: 0 changed).
- Token-comparison control: this backend's kernels are not run-to-run deterministic even without a reload (two back-to-back greedy generations differ), so token equality is not a valid oracle here; the pointer census and hang/no-hang carry the red/green.

### Test Result

- New CPU test passes with the fix and fails on stock; the pre-existing reload unit tests pass; ruff lint and format clean.
- GPU red/green as above.

Related: RFC #48312, #49489 (unmasked this bug), #50521 (same fix pattern for FlashInfer CUTLASS).

This PR includes AI-generated code (Claude Code). I reviewed every changed line and validated the fix end-to-end on SM120 hardware with the red/green protocol described above.
