### PR TITLE
[Bugfix][Frontend] message-level tool declarations 

### DIFF
--- a/tests/entrypoints/openai/test_tool_choice_kwargs.py
+++ b/tests/entrypoints/openai/test_tool_choice_kwargs.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for tool_choice forwarding in build_chat_params.
+
+An absent tool_choice renders nothing in the prompt; only an explicitly
+provided one reaches the renderer. The request field's default "none" is
+serving-layer state and must not be rendered.
+"""
+
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+)
+
+_TOOL = {
+    "type": "function",
+    "function": {"name": "f", "parameters": {"type": "object", "properties": {}}},
+}
+
+
+def _request(**kwargs) -> ChatCompletionRequest:
+    defaults = {"model": "test-model", "messages": [{"role": "user", "content": "hi"}]}
+    defaults.update(kwargs)
+    return ChatCompletionRequest.model_validate(defaults)
+
+
+def _message_level_tools_request(**kwargs) -> ChatCompletionRequest:
+    messages = [
+        {"role": "system", "content": "sys", "tools": [_TOOL]},
+        {"role": "user", "content": "hi"},
+    ]
+    defaults = {"model": "test-model", "messages": messages}
+    defaults.update(kwargs)
+    return ChatCompletionRequest.model_validate(defaults)
+
+
+def test_absent_tool_choice_not_forwarded():
+    request = _request()
+    params = request.build_chat_params(None, "auto")
+    assert params.tool_choice is None
+
+
+def test_explicit_none_tool_choice_forwarded():
+    request = _request(tool_choice="none")
+    params = request.build_chat_params(None, "auto")
+    assert params.tool_choice == "none"
+
+
+def test_explicit_null_tool_choice_not_forwarded():
+    # Explicit null parses to None; the request must not resurrect the
+    # field default either.
+    request = _request(tool_choice=None)
+    params = request.build_chat_params(None, "auto")
+    assert params.tool_choice is None
+
+
+def test_auto_default_from_tools_forwarded():
+    request = _request(tools=[_TOOL])
+    params = request.build_chat_params(None, "auto")
+    assert params.tool_choice == "auto"
+
+
+def test_user_chat_template_kwarg_kept():
+    request = _request(chat_template_kwargs={"tool_choice": "none"})
+    params = request.build_chat_params(None, "auto")
+    assert params.chat_template_kwargs["tool_choice"] == "none"
+
+
+def test_message_level_tools_default_forwarded():
+    # The "auto" default triggered by message-level tools is forwarded, so
+    # the renderer does not treat the request as tool-less.
+    request = _message_level_tools_request()
+    assert request.tool_choice == "auto"
+    params = request.build_chat_params(None, "auto")
+    assert params.tool_choice == "auto"
+
+
+def test_message_level_tools_explicit_choice_forwarded():
+    request = _message_level_tools_request(tool_choice="required")
+    params = request.build_chat_params(None, "auto")
+    assert params.tool_choice == "required"

--- a/tests/entrypoints/unit_tests/test_chat_utils.py
+++ b/tests/entrypoints/unit_tests/test_chat_utils.py
@@ -2806,3 +2806,46 @@ async def test_resolve_items_does_not_leak_tasks_on_partial_failure():
         f"resolve_items left {len(leaked_tasks)} task(s) running after "
         f"raising: {leaked_tasks}"
     )
+
+
+_MESSAGE_LEVEL_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the weather",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+]
+
+
+@pytest.mark.parametrize("role", ["system", "developer"])
+def test_parse_message_level_tools_passed_through(role):
+    """Message-level tool declarations survive chat message parsing: tools
+    on "system"/"developer" messages pass through for the chat template /
+    encoding layer to expand.
+    """
+    from vllm.entrypoints.chat_utils import _parse_chat_message_content
+
+    result = _parse_chat_message_content(
+        {"role": role, "content": "instructions", "tools": _MESSAGE_LEVEL_TOOLS},
+        MagicMock(),
+        "string",
+        True,
+    )
+    assert result[0]["tools"] == _MESSAGE_LEVEL_TOOLS
+
+
+@pytest.mark.parametrize("role", ["user", "assistant", "tool"])
+def test_parse_message_level_tools_not_passed_for_other_roles(role):
+    """tools on non-system/developer roles are not passed through."""
+    from vllm.entrypoints.chat_utils import _parse_chat_message_content
+
+    result = _parse_chat_message_content(
+        {"role": role, "content": "text", "tools": _MESSAGE_LEVEL_TOOLS},
+        MagicMock(),
+        "string",
+        True,
+    )
+    assert "tools" not in result[0]

--- a/tests/reasoning/test_kimi_k3_reasoning_parser.py
+++ b/tests/reasoning/test_kimi_k3_reasoning_parser.py
@@ -248,3 +248,89 @@ def test_adjust_request_keeps_xtml_markers_contiguous():
     assert adjusted.skip_special_tokens is False
     if hasattr(adjusted, "spaces_between_special_tokens"):
         assert adjusted.spaces_between_special_tokens is False
+
+
+_TOOLS_CHANNEL = f"{OPEN}tools{SEP}x{CLOSE}tools{SEP}"
+
+
+def _message_level_tools_request(*, tool_choice="required") -> ChatCompletionRequest:
+    """Tools declared only on a system message (message-level declaration)."""
+    return ChatCompletionRequest(
+        model="test-model",
+        messages=[
+            {
+                "role": "system",
+                "content": "",
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "calc",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            },
+            {"role": "user", "content": "hi"},
+        ],
+        tool_choice=tool_choice,
+    )
+
+
+def test_extract_reasoning_preserves_tool_channels_for_message_level_tools():
+    """Message-level tools are invisible in `request.tools`, but the model
+    still emits a tools channel -- it must reach the tool parser raw."""
+    parser = KimiK3ReasoningParser(DummyTokenizer())
+    request = _message_level_tools_request(tool_choice="required")
+    rest = f"{RESPONSE_OPEN}answer{CLOSE}response{SEP}{_TOOLS_CHANNEL}"
+
+    reasoning, content = parser.extract_reasoning_content(
+        f"step{THINK_CLOSE}{rest}", request
+    )
+
+    assert reasoning == "step"
+    assert content == rest
+
+
+def test_extract_reasoning_strips_channels_for_message_level_tools_none():
+    """tool_choice='none' disables preservation even with message-level tools."""
+    parser = KimiK3ReasoningParser(DummyTokenizer())
+    request = _message_level_tools_request(tool_choice="none")
+    rest = f"{RESPONSE_OPEN}answer{CLOSE}response{SEP}{_TOOLS_CHANNEL}"
+
+    reasoning, content = parser.extract_reasoning_content(
+        f"step{THINK_CLOSE}{rest}", request
+    )
+
+    assert reasoning == "step"
+    assert content == "answer"
+
+
+def test_extract_reasoning_strips_channels_without_any_tools():
+    """No tools anywhere: the tools channel is unwrapped as before."""
+    parser = KimiK3ReasoningParser(DummyTokenizer())
+    request = ChatCompletionRequest(model="test-model", messages=[], tool_choice="auto")
+    rest = f"{RESPONSE_OPEN}answer{CLOSE}response{SEP}{_TOOLS_CHANNEL}"
+
+    reasoning, content = parser.extract_reasoning_content(
+        f"step{THINK_CLOSE}{rest}", request
+    )
+
+    assert reasoning == "step"
+    assert content == "answer"
+
+
+def test_is_reasoning_end_with_structural_think_in_history():
+    """Every history assistant message carries think open/close tags, and the
+    generation prefix re-opens the think channel. History close markers must
+    not mark the prompt as "reasoning ended"."""
+    parser = KimiK3ReasoningParser(DummyTokenizer())
+
+    history = [1, 2, 3, 4, 2, 3]  # <|open|>think<|sep|><|close|>think<|sep|>
+    generation_prefix = [1, 2, 3]  # <|open|>think<|sep|>
+    assert not parser.is_reasoning_end(history + generation_prefix)
+
+    # Generated output: open consumed by the prefix, close present -> ended.
+    assert parser.is_reasoning_end([9, 4, 2, 3, 10])
+    # Still reasoning: no close marker yet.
+    assert not parser.is_reasoning_end([9, 10])

--- a/tests/tool_use/test_chat_completion_request_validations.py
+++ b/tests/tool_use/test_chat_completion_request_validations.py
@@ -40,28 +40,29 @@ def test_chat_completion_request_with_no_tools():
 
 @pytest.mark.parametrize("tool_choice", ["auto", "required"])
 def test_chat_completion_request_with_tool_choice_but_no_tools(tool_choice):
-    with pytest.raises(
-        VLLMValidationError, match="When using `tool_choice`, `tools` must be set."
-    ):
-        ChatCompletionRequest.model_validate(
+    # Finer-grained rules: "auto" without tools is a harmless no-op;
+    # "required"/named without any tool source (request level OR message
+    # level) is rejected.
+    expected = None if tool_choice == "auto" else VLLMValidationError
+    if expected is None:
+        request = ChatCompletionRequest.model_validate(
             {
                 "messages": [{"role": "user", "content": "Hello"}],
                 "model": "facebook/opt-125m",
                 "tool_choice": tool_choice,
             }
         )
-
-    with pytest.raises(
-        VLLMValidationError, match="When using `tool_choice`, `tools` must be set."
-    ):
-        ChatCompletionRequest.model_validate(
-            {
-                "messages": [{"role": "user", "content": "Hello"}],
-                "model": "facebook/opt-125m",
-                "tool_choice": tool_choice,
-                "tools": None,
-            }
-        )
+        assert request.tool_choice == tool_choice
+    else:
+        with pytest.raises(expected, match="tools must be declared"):
+            ChatCompletionRequest.model_validate(
+                {
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    "model": "facebook/opt-125m",
+                    "tool_choice": tool_choice,
+                    "tools": None,
+                }
+            )
 
 
 def test_reasoning_content_normalized_to_reasoning():
@@ -179,6 +180,171 @@ def test_multiple_structured_outputs_rejected():
                 "structured_outputs": {
                     "json": {"type": "object"},
                     "regex": ".*",
+                },
+            }
+        )
+
+
+_SAMPLE_TOOL_DICT = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the weather",
+        "parameters": {"type": "object", "properties": {}},
+    },
+}
+
+
+def test_request_level_tools_still_default_tool_choice_auto():
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [{"role": "user", "content": "Hello"}],
+            "model": "facebook/opt-125m",
+            "tools": [_SAMPLE_TOOL_DICT],
+        }
+    )
+    assert request.tool_choice == "auto"
+
+
+@pytest.mark.parametrize("role", ["system", "developer"])
+def test_message_level_tools_default_tool_choice_auto(role):
+    # Message-level tool declarations must also default tool_choice to
+    # "auto"; the field default "none" would tell the model not to call the
+    # tools the client just declared.
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [
+                {"role": role, "content": "instructions", "tools": [_SAMPLE_TOOL_DICT]},
+                {"role": "user", "content": "Hello"},
+            ],
+            "model": "facebook/opt-125m",
+        }
+    )
+    assert request.tool_choice == "auto"
+
+
+def test_message_level_tools_do_not_override_explicit_tool_choice():
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "instructions",
+                    "tools": [_SAMPLE_TOOL_DICT],
+                },
+                {"role": "user", "content": "Hello"},
+            ],
+            "model": "facebook/opt-125m",
+            "tool_choice": "required",
+        }
+    )
+    assert request.tool_choice == "required"
+
+
+def test_tools_on_other_roles_do_not_default_tool_choice_auto():
+    # tools on roles that are not passed through to the template (user,
+    # assistant, tool) must not influence the tool_choice default.
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [
+                {"role": "user", "content": "Hello", "tools": [_SAMPLE_TOOL_DICT]},
+            ],
+            "model": "facebook/opt-125m",
+        }
+    )
+    assert request.tool_choice == "none"
+
+
+def test_auto_tool_choice_without_tools_allowed():
+    # "auto" without any tools is a harmless no-op: the model simply answers.
+    for tools_kwarg in ({}, {"tools": None}):
+        request = ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "model": "facebook/opt-125m",
+                "tool_choice": "auto",
+                **tools_kwarg,
+            }
+        )
+        assert request.tool_choice == "auto"
+
+
+def test_required_tool_choice_without_any_tools_rejected():
+    # "required" is contradictory without any tool source: reject unless
+    # tools are declared at the request level OR on a message.
+    with pytest.raises(VLLMValidationError, match="tools must be declared"):
+        ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "model": "facebook/opt-125m",
+                "tool_choice": "required",
+            }
+        )
+
+
+def test_required_tool_choice_with_message_level_tools_allowed():
+    # Tools declared on a system message satisfy the requirement.
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [
+                {"role": "system", "content": "", "tools": [SAMPLE_TOOL]},
+                {"role": "user", "content": "Hello"},
+            ],
+            "model": "facebook/opt-125m",
+            "tool_choice": "required",
+        }
+    )
+    assert request.tool_choice == "required"
+
+
+def test_named_tool_choice_without_any_tools_rejected():
+    # A named tool_choice with no tool declared anywhere is rejected.
+    with pytest.raises(VLLMValidationError, match="tools must be declared"):
+        ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "model": "facebook/opt-125m",
+                "tool_choice": {
+                    "type": "function",
+                    "function": {"name": "get_weather"},
+                },
+            }
+        )
+
+
+def test_named_tool_choice_with_message_level_tools_allowed():
+    # A named tool_choice without request-level tools is allowed when the
+    # named tool may be declared at the message level (not cross-checked).
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [
+                {"role": "system", "content": "", "tools": [SAMPLE_TOOL]},
+                {"role": "user", "content": "Hello"},
+            ],
+            "model": "facebook/opt-125m",
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": "get_weather"},
+            },
+        }
+    )
+    assert request.tool_choice.function.name == "get_weather"
+
+
+def test_named_tool_choice_must_match_declared_tools():
+    # When request-level tools ARE present, a named tool_choice must still
+    # match one of them.
+    with pytest.raises(
+        VLLMValidationError, match="does not match any of the specified `tools`"
+    ):
+        ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "model": "facebook/opt-125m",
+                "tools": [SAMPLE_TOOL],
+                "tool_choice": {
+                    "type": "function",
+                    "function": {"name": "nondefined_function_name"},
                 },
             }
         )

--- a/tests/tool_use/test_chat_completion_request_validations.py
+++ b/tests/tool_use/test_chat_completion_request_validations.py
@@ -313,8 +313,8 @@ def test_named_tool_choice_without_any_tools_rejected():
 
 
 def test_named_tool_choice_with_message_level_tools_allowed():
-    # A named tool_choice without request-level tools is allowed when the
-    # named tool may be declared at the message level (not cross-checked).
+    # A named tool_choice matching a message-level declaration is allowed
+    # without request-level tools.
     request = ChatCompletionRequest.model_validate(
         {
             "messages": [
@@ -331,11 +331,79 @@ def test_named_tool_choice_with_message_level_tools_allowed():
     assert request.tool_choice.function.name == "get_weather"
 
 
+def test_named_tool_choice_mismatched_message_level_tools_rejected():
+    # A named tool_choice that matches NO declaration anywhere is rejected,
+    # even when message-level tools are present.
+    with pytest.raises(
+        VLLMValidationError, match="does not match any of the declared `tools`"
+    ):
+        ChatCompletionRequest.model_validate(
+            {
+                "messages": [
+                    {"role": "system", "content": "", "tools": [SAMPLE_TOOL]},
+                    {"role": "user", "content": "Hello"},
+                ],
+                "model": "facebook/opt-125m",
+                "tool_choice": {
+                    "type": "function",
+                    "function": {"name": "nondefined_function_name"},
+                },
+            }
+        )
+
+
+def test_named_tool_choice_matches_message_level_among_request_tools():
+    # Mixed sources: the named tool may come from a message even when
+    # unrelated request-level tools are present.
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [
+                {"role": "system", "content": "", "tools": [SAMPLE_TOOL]},
+                {"role": "user", "content": "Hello"},
+            ],
+            "model": "facebook/opt-125m",
+            "tools": [_SAMPLE_TOOL_DICT],
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": "get_weather"},
+            },
+        }
+    )
+    assert request.tool_choice.function.name == "get_weather"
+
+
+def test_malformed_message_level_tools_not_a_tool_source():
+    # Malformed declarations like [{}] do not count as a tool source:
+    # no "auto" default, and required is still rejected.
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [
+                {"role": "system", "content": "", "tools": [{}]},
+                {"role": "user", "content": "Hello"},
+            ],
+            "model": "facebook/opt-125m",
+        }
+    )
+    assert request.tool_choice == "none"
+
+    with pytest.raises(VLLMValidationError, match="tools must be declared"):
+        ChatCompletionRequest.model_validate(
+            {
+                "messages": [
+                    {"role": "system", "content": "", "tools": [{}]},
+                    {"role": "user", "content": "Hello"},
+                ],
+                "model": "facebook/opt-125m",
+                "tool_choice": "required",
+            }
+        )
+
+
 def test_named_tool_choice_must_match_declared_tools():
     # When request-level tools ARE present, a named tool_choice must still
     # match one of them.
     with pytest.raises(
-        VLLMValidationError, match="does not match any of the specified `tools`"
+        VLLMValidationError, match="does not match any of the declared `tools`"
     ):
         ChatCompletionRequest.model_validate(
             {

--- a/tests/tool_use/test_kimi_k3_tool_parser.py
+++ b/tests/tool_use/test_kimi_k3_tool_parser.py
@@ -604,3 +604,97 @@ def test_chat_params_keeps_template_tool_choice_when_api_auto():
 
     assert chat_params.chat_template_kwargs["tool_choice"] == "required"
     assert chat_params.tool_choice == "auto"
+
+
+def _dynamic_tools_request(*, tool_choice="auto") -> ChatCompletionRequest:
+    """Tools declared only on a system message; ``request.tools`` is empty
+    by design."""
+    return ChatCompletionRequest(
+        model="test-model",
+        messages=[
+            {
+                "role": "system",
+                "content": "",
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "calc",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            },
+            {"role": "user", "content": "Call the calc tool."},
+        ],
+        tool_choice=tool_choice,
+    )
+
+
+def test_delegating_parser_message_level_tools_required():
+    """Message-level-only tools: the reasoning parser must preserve the raw
+    XTML for the tool parser even though ``request.tools`` is empty
+    (non-stream regression: gating on request-level tools used to strip the
+    tools channel, so the tool call vanished)."""
+    parser = KimiK3DelegatingParser(DummyTokenizer())
+    output = (
+        f"{THINK_OPEN}step{THINK_CLOSE}"
+        + _response("")
+        + _tools(_call("calc", 1, _arg("x", "number", "1")))
+    )
+
+    reasoning, content, tool_calls = parser.parse(
+        output,
+        _dynamic_tools_request(tool_choice="required"),
+        enable_auto_tools=True,
+    )
+
+    assert reasoning == "step"
+    assert content is None
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0].name == "calc"
+    assert json.loads(tool_calls[0].arguments) == {"x": 1}
+
+
+def test_delegating_parser_message_level_tools_auto():
+    parser = KimiK3DelegatingParser(DummyTokenizer())
+    output = (
+        f"{THINK_OPEN}step{THINK_CLOSE}"
+        + _response("answer")
+        + _tools(_call("calc", 1, _arg("x", "number", "1")))
+    )
+
+    reasoning, content, tool_calls = parser.parse(
+        output,
+        _dynamic_tools_request(tool_choice="auto"),
+        enable_auto_tools=True,
+    )
+
+    assert reasoning == "step"
+    assert content == "answer"
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0].name == "calc"
+    assert json.loads(tool_calls[0].arguments) == {"x": 1}
+
+
+def test_delegating_parser_message_level_tools_none_strips_channels():
+    """tool_choice='none' keeps the old behavior: the reasoning parser
+    unwraps the response channel itself and no tool parsing happens."""
+    parser = KimiK3DelegatingParser(DummyTokenizer())
+    output = (
+        f"{THINK_OPEN}step{THINK_CLOSE}"
+        + _response("answer")
+        + _tools(_call("calc", 1, _arg("x", "number", "1")))
+    )
+
+    reasoning, content, tool_calls = parser.parse(
+        output,
+        _dynamic_tools_request(tool_choice="none"),
+        enable_auto_tools=True,
+    )
+
+    assert reasoning == "step"
+    assert content == "answer"
+    assert not tool_calls

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1897,8 +1897,13 @@ def _parse_chat_message_content(
         if "task" in message and isinstance(message["task"], str):
             result_msg["task"] = message["task"]
 
-        if role == "developer":
-            result_msg["tools"] = message.get("tools", None)
+        # Tool declarations on individual messages (e.g. "developer" or
+        # "system" roles) pass through for the chat template to expand.
+        if (
+            role in ("developer", "system")
+            and (msg_tools := message.get("tools")) is not None
+        ):
+            result_msg["tools"] = msg_tools
     return result
 
 

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -188,6 +188,22 @@ class ChatCompletionNamedFunction(OpenAIBaseModel):
     name: str
 
 
+def _has_message_level_tools(messages: Any) -> bool:
+    """Whether any message carries a message-level tool declaration.
+
+    Mirrors the roles that `parse_chat_messages` passes through to the chat
+    template ("system", "developer").
+    """
+    if not isinstance(messages, list):
+        return False
+    return any(
+        isinstance(msg, dict)
+        and msg.get("role") in ("system", "developer")
+        and bool(msg.get("tools"))
+        for msg in messages
+    )
+
+
 class ChatCompletionNamedToolChoiceParam(OpenAIBaseModel):
     function: ChatCompletionNamedFunction
     type: Literal["function"] = "function"
@@ -568,8 +584,15 @@ class ChatCompletionRequest(OpenAIBaseModel):
             # No-tools requests default to tool_choice="none" at the API
             # layer. Collapse that default before rendering, so K3 emits a
             # model-visible tool-choice instruction only for requests with a
-            # tools block.
-            tool_choice=self.tool_choice if self.tools else None,
+            # tools block. Message-level tool declarations count as tools
+            # here, and an explicitly provided tool_choice is always kept.
+            tool_choice=(
+                self.tool_choice
+                if self.tools
+                or _has_message_level_tools(self.messages)
+                or "tool_choice" in self.model_fields_set
+                else None
+            ),
             response_format=self.response_format,
         )
 
@@ -872,9 +895,13 @@ class ChatCompletionRequest(OpenAIBaseModel):
                 parameter="tools",
             )
 
-        # if "tool_choice" is not specified but tools are provided,
-        # default to "auto" tool_choice
-        if "tool_choice" not in data and data.get("tools"):
+        # Extend the tool_choice="auto" default to tools declared on
+        # individual messages, not just request-level `tools`. Otherwise the
+        # field default "none" would make templates instruct the model NOT to
+        # call the very tools the client just declared.
+        if "tool_choice" not in data and (
+            data.get("tools") or _has_message_level_tools(data.get("messages"))
+        ):
             data["tool_choice"] = "auto"
 
         # if "tool_choice" is "none" -- no validation is needed for tools
@@ -883,10 +910,18 @@ class ChatCompletionRequest(OpenAIBaseModel):
 
         # if "tool_choice" is specified -- validation
         if "tool_choice" in data and data["tool_choice"] is not None:
-            # ensure that if "tool choice" is specified, tools are present
-            if "tools" not in data or data["tools"] is None:
+            # "required"/named tool_choice is contradictory without any tool
+            # source (request-level `tools` OR message-level declarations).
+            # "auto"/"none" without tools are harmless no-ops.
+            if (
+                data["tool_choice"] == "required"
+                or isinstance(data["tool_choice"], dict)
+            ) and not (
+                data.get("tools") or _has_message_level_tools(data.get("messages"))
+            ):
                 raise VLLMValidationError(
-                    "When using `tool_choice`, `tools` must be set.",
+                    "When using `tool_choice`, tools must be declared either "
+                    "at the request level or on individual messages.",
                     parameter="tool_choice",
                 )
 
@@ -930,11 +965,14 @@ class ChatCompletionRequest(OpenAIBaseModel):
                         f" in `tool_choice`! {correct_usage_message}",
                         parameter="tool_choice.function.name",
                     )
-                for tool in data["tools"]:
+                # Only cross-check the name against request-level `tools`
+                # when they are present; the named tool may be declared at
+                # the message level, which is not visible here.
+                for tool in data.get("tools") or []:
                     if tool["function"]["name"] == function_name:
                         valid_tool = True
                         break
-                if not valid_tool:
+                if data.get("tools") and not valid_tool:
                     raise VLLMValidationError(
                         "The tool specified in `tool_choice` does not match any"
                         " of the specified `tools`",

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -188,20 +188,32 @@ class ChatCompletionNamedFunction(OpenAIBaseModel):
     name: str
 
 
+def _message_level_tool_declarations(messages: Any) -> list[dict]:
+    """All message-level tool declarations (on system/developer messages).
+
+    Mirrors the roles that `parse_chat_messages` passes through to the chat
+    template. Only non-empty dict entries count -- malformed declarations
+    such as ``[{}]`` are not a tool source.
+    """
+    if not isinstance(messages, list):
+        return []
+    declarations = []
+    for msg in messages:
+        if not isinstance(msg, dict) or msg.get("role") not in ("system", "developer"):
+            continue
+        tools = msg.get("tools")
+        if isinstance(tools, list):
+            declarations.extend(t for t in tools if isinstance(t, dict) and t)
+    return declarations
+
+
 def _has_message_level_tools(messages: Any) -> bool:
     """Whether any message carries a message-level tool declaration.
 
     Mirrors the roles that `parse_chat_messages` passes through to the chat
     template ("system", "developer").
     """
-    if not isinstance(messages, list):
-        return False
-    return any(
-        isinstance(msg, dict)
-        and msg.get("role") in ("system", "developer")
-        and bool(msg.get("tools"))
-        for msg in messages
-    )
+    return bool(_message_level_tool_declarations(messages))
 
 
 class ChatCompletionNamedToolChoiceParam(OpenAIBaseModel):
@@ -944,7 +956,6 @@ class ChatCompletionRequest(OpenAIBaseModel):
                 ' "function": {"name": "my_function"}}`'
             )
             if isinstance(data["tool_choice"], dict):
-                valid_tool = False
                 function = data["tool_choice"].get("function")
                 if not isinstance(function, dict):
                     raise VLLMValidationError(
@@ -965,17 +976,22 @@ class ChatCompletionRequest(OpenAIBaseModel):
                         f" in `tool_choice`! {correct_usage_message}",
                         parameter="tool_choice.function.name",
                     )
-                # Only cross-check the name against request-level `tools`
-                # when they are present; the named tool may be declared at
-                # the message level, which is not visible here.
-                for tool in data.get("tools") or []:
-                    if tool["function"]["name"] == function_name:
-                        valid_tool = True
-                        break
-                if data.get("tools") and not valid_tool:
+                # Cross-check the name against declarations at either level:
+                # request-level `tools` or message-level declarations (the
+                # named tool may be declared on a system/developer message).
+                eligible_names = [
+                    tool["function"]["name"] for tool in data.get("tools") or []
+                ]
+                eligible_names += [
+                    fn_name
+                    for tool in _message_level_tool_declarations(data.get("messages"))
+                    if isinstance(tool.get("function"), dict)
+                    and (fn_name := tool["function"].get("name"))
+                ]
+                if function_name not in eligible_names:
                     raise VLLMValidationError(
                         "The tool specified in `tool_choice` does not match any"
-                        " of the specified `tools`",
+                        " of the declared `tools`",
                         parameter="tool_choice",
                     )
         return data

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -37,6 +37,7 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionResponseStreamChoice,
     ChatCompletionStreamResponse,
     ChatMessage,
+    _has_message_level_tools,
 )
 from vllm.entrypoints.openai.engine.protocol import (
     DeltaMessage,
@@ -925,9 +926,10 @@ class OpenAIServingChat(GenerateBaseServing):
             elif not request.tool_choice or request.tool_choice == "none":
                 message = ChatMessage(role=role, reasoning=reasoning, content=content)
 
-            # handle when there are tools and tool choice is auto
+            # handle when there are tools (request-level or message-level)
+            # and tool choice is auto
             elif (
-                request.tools
+                (request.tools or _has_message_level_tools(request.messages))
                 and (request.tool_choice == "auto" or request.tool_choice is None)
                 and self.enable_auto_tools
                 and tool_parser_cls

--- a/vllm/reasoning/kimi_k3_reasoning_parser.py
+++ b/vllm/reasoning/kimi_k3_reasoning_parser.py
@@ -28,6 +28,9 @@ from typing import TYPE_CHECKING
 import regex as re
 from transformers import PreTrainedTokenizerBase
 
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    _has_message_level_tools,
+)
 from vllm.entrypoints.openai.engine.protocol import DeltaMessage
 from vllm.reasoning import ReasoningParser
 
@@ -186,9 +189,14 @@ class KimiK3ReasoningParser(ReasoningParser):
     def _should_preserve_tool_channels(
         request: "ChatCompletionRequest | ResponsesRequest",
     ) -> bool:
-        return bool(getattr(request, "tools", None)) and (
-            getattr(request, "tool_choice", None) != "none"
-        )
+        if getattr(request, "tool_choice", None) == "none":
+            return False
+        if getattr(request, "tools", None):
+            return True
+        # Message-level tool declarations (on system/developer messages)
+        # never appear in `request.tools`; preserve the raw XTML so the
+        # tool parser sees it.
+        return _has_message_level_tools(getattr(request, "messages", None))
 
     def _content_after_reasoning(
         self,

--- a/vllm/renderers/online_renderer.py
+++ b/vllm/renderers/online_renderer.py
@@ -14,6 +14,7 @@ from vllm.entrypoints.chat_utils import (
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionNamedToolChoiceParam,
     ChatCompletionRequest,
+    _has_message_level_tools,
 )
 from vllm.entrypoints.openai.completion.protocol import (
     CompletionRequest,
@@ -140,10 +141,20 @@ class OnlineRenderer:
             and not self.use_harmony
         )
 
-        # Validate tool_choice when tool parsing is required but unavailable
-        if tool_parsing_unavailable and request.tool_choice not in (
-            None,
-            "none",
+        # Validate tool_choice when tool parsing is required but unavailable.
+        # "auto" with no tools anywhere is a harmless no-op and does not
+        # require a parser; required/named without any tool source is
+        # already rejected at request validation.
+        has_any_tools = bool(request.tools) or _has_message_level_tools(
+            request.messages
+        )
+        if (
+            tool_parsing_unavailable
+            and request.tool_choice not in (
+                None,
+                "none",
+            )
+            and has_any_tools
         ):
             if request.tool_choice == "auto" and not self.enable_auto_tools:
                 # for hf tokenizers, "auto" tools requires


### PR DESCRIPTION
Tools declared on individual messages (e.g. dynamic tools on system messages, or developer messages) previously fell through every layer that only inspects the top-level tools field:

- chat message parsing dropped them for roles other than developer;
- tool_choice defaulted to "none", making templates that render tool-choice directives instruct the model NOT to call the very tools the client just declared;
- request validation rejected any explicit tool_choice without request-level tools, although the tools may be declared on messages;
- the K3 reasoning parser stripped the XTML tools channel, so the tool parser never saw the calls (tool calls silently vanished from non-stream responses);
- the non-stream serving path skipped tool parsing for such requests.

Thread message-level declarations through all of these: parsing, tool_choice defaulting/validation, chat params forwarding, channel preservation, and the non-stream auto-tool branch. Auto/none without any tools stays a harmless no-op; required/named without any tool source (request-level or message-level) is still rejected.




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

