### PR TITLE
[Bugfix][Kimi K3] Fix chat rendering parity and response_format wiring

### DIFF
--- a/tests/entrypoints/openai/test_response_format_chat_params.py
+++ b/tests/entrypoints/openai/test_response_format_chat_params.py
@@ -181,3 +181,48 @@ class TestResponsesResponseFormatForwarding:
         )
         params = request.build_chat_params(None, "auto")
         assert params.response_format == {"type": "text", "json_schema": None}
+
+    def test_response_format_suppressed_for_required_tool_choice(self):
+        # Forced tool call: the tool-calling schema replaces the user format
+        # in adjust_request, so the user format must not reach the prompt.
+        request = self._build_responses_request(
+            tools=[
+                {
+                    "type": "function",
+                    "name": "get_weather",
+                    "parameters": {"type": "object", "properties": {}},
+                }
+            ],
+            tool_choice="required",
+            text={
+                "format": {
+                    "type": "json_schema",
+                    "name": "weather",
+                    "schema": _WEATHER_SCHEMA,
+                }
+            },
+        )
+        params = request.build_chat_params(None, "auto")
+        assert params.response_format is None
+
+    def test_response_format_kept_for_auto_tool_choice(self):
+        request = self._build_responses_request(
+            tools=[
+                {
+                    "type": "function",
+                    "name": "get_weather",
+                    "parameters": {"type": "object", "properties": {}},
+                }
+            ],
+            tool_choice="auto",
+            text={
+                "format": {
+                    "type": "json_schema",
+                    "name": "weather",
+                    "schema": _WEATHER_SCHEMA,
+                }
+            },
+        )
+        params = request.build_chat_params(None, "auto")
+        assert params.response_format is not None
+        assert params.response_format["type"] == "json_schema"

--- a/tests/entrypoints/openai/test_response_format_chat_params.py
+++ b/tests/entrypoints/openai/test_response_format_chat_params.py
@@ -171,3 +171,13 @@ class TestResponsesResponseFormatForwarding:
         request = self._build_responses_request()
         params = request.build_chat_params(None, "auto")
         assert params.response_format is None
+
+    def test_explicit_text_format_forwarded(self):
+        # Explicit type=text stays a real value so it overrides a conflicting
+        # chat_template_kwargs response_format instead of vanishing into None.
+        request = self._build_responses_request(
+            text={"format": {"type": "text"}},
+            chat_template_kwargs={"response_format": {"type": "json_object"}},
+        )
+        params = request.build_chat_params(None, "auto")
+        assert params.response_format == {"type": "text", "json_schema": None}

--- a/tests/entrypoints/openai/test_response_format_chat_params.py
+++ b/tests/entrypoints/openai/test_response_format_chat_params.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for top-level response_format forwarding into ChatParams.
+
+Most models treat response_format purely as a decoding constraint (guided
+decoding via structured_outputs), so it is not part of chat template
+rendering. Models whose chat encoding renders response_format into the
+prompt need the field at the renderer layer; the forwarding is inert for
+renderers that don't read it.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+)
+
+_WEATHER_SCHEMA = {
+    "type": "object",
+    "properties": {"city": {"type": "string"}},
+    "required": ["city"],
+    "additionalProperties": False,
+}
+
+
+def _build_chat_request(**kwargs) -> ChatCompletionRequest:
+    defaults = dict(
+        model="test-model",
+        messages=[{"role": "user", "content": "Hello"}],
+    )
+    defaults.update(kwargs)
+    return ChatCompletionRequest(**defaults)
+
+
+class TestResponseFormatForwarding:
+    def test_json_schema_forwarded(self):
+        request = _build_chat_request(
+            response_format={
+                "type": "json_schema",
+                "json_schema": {"name": "weather", "schema": _WEATHER_SCHEMA},
+            },
+        )
+        params = request.build_chat_params(None, "auto")
+        rf = params.response_format
+        assert rf is not None
+        assert rf.type == "json_schema"
+        assert rf.json_schema is not None
+        assert rf.json_schema.name == "weather"
+        assert rf.json_schema.json_schema == _WEATHER_SCHEMA
+
+    def test_json_object_forwarded(self):
+        request = _build_chat_request(
+            response_format={"type": "json_object"},
+        )
+        params = request.build_chat_params(None, "auto")
+        assert params.response_format is not None
+        assert params.response_format.type == "json_object"
+
+    def test_no_response_format_not_injected(self):
+        request = _build_chat_request()
+        params = request.build_chat_params(None, "auto")
+        assert params.response_format is None
+
+    def test_explicit_user_kwarg_kept_when_no_top_level_field(self):
+        # A client-provided chat_template_kwargs entry survives when the
+        # top-level field is absent.
+        request = _build_chat_request(
+            chat_template_kwargs={"response_format": {"type": "json_object"}},
+        )
+        params = request.build_chat_params(None, "auto")
+        assert params.response_format is None
+        assert params.chat_template_kwargs["response_format"] == {"type": "json_object"}
+
+    def test_guided_decoding_still_set(self):
+        # Forwarding must not eat the structured_outputs path.
+        request = _build_chat_request(
+            response_format={
+                "type": "json_schema",
+                "json_schema": {"name": "weather", "schema": _WEATHER_SCHEMA},
+            },
+        )
+        params = request.to_sampling_params(max_tokens=100, default_sampling_params={})
+        assert params.structured_outputs is not None
+        assert params.structured_outputs.json == _WEATHER_SCHEMA
+
+
+class TestStrictMustBeBoolean:
+    """Non-boolean `strict` is rejected at request validation (the server
+    maps the ValidationError to 400 BadRequest) instead of being
+    lax-coerced to a bool (e.g. "yes" -> True)."""
+
+    @pytest.mark.parametrize("bad_strict", ["yes", "true", "false", 1, 0])
+    def test_non_boolean_strict_rejected(self, bad_strict):
+        with pytest.raises(ValidationError):
+            _build_chat_request(
+                response_format={
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "weather",
+                        "schema": _WEATHER_SCHEMA,
+                        "strict": bad_strict,
+                    },
+                },
+            )
+
+    @pytest.mark.parametrize("good_strict", [True, False, None])
+    def test_boolean_strict_accepted(self, good_strict):
+        request = _build_chat_request(
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "weather",
+                    "schema": _WEATHER_SCHEMA,
+                    "strict": good_strict,
+                },
+            },
+        )
+        assert request.response_format is not None
+        assert request.response_format.json_schema is not None
+        assert request.response_format.json_schema.strict is good_strict
+
+
+class TestResponsesResponseFormatForwarding:
+    """Responses API: text.format is flattened (no `json_schema` nesting)
+    and must be re-nested to the Chat Completions shape for renderers."""
+
+    def _build_responses_request(self, **kwargs):
+        from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+
+        defaults = dict(
+            model="test-model",
+            input=[{"role": "user", "content": "Hello"}],
+        )
+        defaults.update(kwargs)
+        return ResponsesRequest(**defaults)
+
+    def test_json_schema_renested(self):
+        request = self._build_responses_request(
+            text={
+                "format": {
+                    "type": "json_schema",
+                    "name": "weather",
+                    "schema": _WEATHER_SCHEMA,
+                    "strict": True,
+                }
+            },
+        )
+        params = request.build_chat_params(None, "auto")
+        assert params.response_format == {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "weather",
+                "description": None,
+                "schema": _WEATHER_SCHEMA,
+                "strict": True,
+            },
+        }
+
+    def test_json_object_forwarded(self):
+        request = self._build_responses_request(
+            text={"format": {"type": "json_object"}},
+        )
+        params = request.build_chat_params(None, "auto")
+        assert params.response_format == {
+            "type": "json_object",
+            "json_schema": None,
+        }
+
+    def test_no_text_format_not_injected(self):
+        request = self._build_responses_request()
+        params = request.build_chat_params(None, "auto")
+        assert params.response_format is None

--- a/tests/renderers/test_kimi_k3.py
+++ b/tests/renderers/test_kimi_k3.py
@@ -448,6 +448,27 @@ def test_preserve_malformed_tool_arguments_helper():
     assert calls[2]["function"]["arguments"] == {"x": 1}
 
 
+def test_preserve_malformed_tool_arguments_whitespace_only():
+    # Whitespace-only arguments are normalized to empty arguments instead of
+    # failing json.loads downstream (K3 treats them as empty).
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "a",
+                    "type": "function",
+                    "function": {"name": "f", "arguments": "  \n "},
+                },
+            ],
+        },
+    ]
+
+    (out,) = _preserve_malformed_tool_arguments(messages)
+    assert out["tool_calls"][0]["function"]["arguments"] == "{}"
+
+
 def test_render_messages_preserves_malformed_tool_arguments():
     """Malformed tool-call arguments round-trip to K3's encoding byte-exact.
 
@@ -533,9 +554,42 @@ def test_render_messages_converts_developer_to_system():
 
     assert prompt == {"prompt_token_ids": [1, 2]}
     sent = tokenizer.conversations[-1]
-    assert sent[0]["role"] == "system"
-    assert sent[0]["content"] == "be terse"
-    assert sent[0]["tools"] == tools
+    # A developer message with BOTH content and tools is split in two
+    # (declare first, content second): the encoding renders a system
+    # message with tools as a tool-declare and would drop the content.
+    assert sent[0] == {"role": "system", "tools": tools}
+    assert sent[1] == {"role": "system", "content": "be terse"}
+
+
+def test_render_messages_converts_developer_without_tools_to_single_system():
+    tokenizer = StubTokenizer([1, 2])
+    renderer = _make_renderer(tokenizer)
+
+    conversation, prompt = renderer.render_messages(
+        [{"role": "developer", "content": "be terse"}],
+        ChatParams(),
+    )
+
+    assert prompt == {"prompt_token_ids": [1, 2]}
+    sent = tokenizer.conversations[-1]
+    assert sent[0] == {"role": "system", "content": "be terse", "tools": None}
+    assert len(sent) == 1
+
+
+def test_render_messages_converts_developer_tools_without_content_to_single():
+    tokenizer = StubTokenizer([1, 2])
+    renderer = _make_renderer(tokenizer)
+    tools = [{"type": "function", "function": {"name": "search"}}]
+
+    conversation, prompt = renderer.render_messages(
+        [{"role": "developer", "tools": tools}],
+        ChatParams(),
+    )
+
+    assert prompt == {"prompt_token_ids": [1, 2]}
+    sent = tokenizer.conversations[-1]
+    assert sent[0] == {"role": "system", "content": "", "tools": tools}
+    assert len(sent) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/renderers/test_kimi_k3.py
+++ b/tests/renderers/test_kimi_k3.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -7,7 +8,11 @@ import pytest
 
 from vllm.exceptions import VLLMValidationError
 from vllm.renderers import ChatParams
-from vllm.renderers.kimi_k3 import KimiK3Renderer, _merge_k3_media_io_kwargs
+from vllm.renderers.kimi_k3 import (
+    KimiK3Renderer,
+    _merge_k3_media_io_kwargs,
+    _preserve_malformed_tool_arguments,
+)
 from vllm.renderers.registry import RENDERER_REGISTRY
 from vllm.tokenizers.registry import TokenizerRegistry
 
@@ -351,3 +356,197 @@ async def test_render_messages_async_returns_token_prompt():
 
     assert prompt == {"prompt_token_ids": [4, 5]}
     assert conversation[0]["role"] == "user"
+
+
+def test_apply_chat_template_strips_null_tool_fields():
+    # The serving layer's model_dump() serializes unset tool fields as null;
+    # the platform tokenism omits them, so K3 drops them for prompt parity.
+    tokenizer = StubTokenizer([7, 8, 9])
+    renderer = _make_renderer(tokenizer)
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "foo",
+                "description": None,
+                "strict": None,
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    params = ChatParams(chat_template_kwargs={"tools": tools})
+
+    renderer._apply_chat_template([{"role": "user", "content": "hi"}], params)
+
+    assert tokenizer.calls[-1]["tools"] == [
+        {
+            "type": "function",
+            "function": {
+                "name": "foo",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+
+def test_apply_chat_template_keeps_user_schema_content():
+    # None values inside user-supplied `parameters` are schema content
+    # (e.g. "default": null) and must survive the null stripping.
+    tokenizer = StubTokenizer([7, 8, 9])
+    renderer = _make_renderer(tokenizer)
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "foo",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"x": {"type": "string", "default": None}},
+                },
+            },
+        }
+    ]
+    params = ChatParams(chat_template_kwargs={"tools": tools})
+
+    renderer._apply_chat_template([{"role": "user", "content": "hi"}], params)
+
+    assert tokenizer.calls[-1]["tools"] == tools
+
+
+def test_preserve_malformed_tool_arguments_helper():
+    # Malformed strings are wrapped as JSON string literals; valid strings,
+    # dicts and non-list tool_calls pass through untouched.
+    messages = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "a",
+                    "type": "function",
+                    "function": {"name": "f", "arguments": '{"x": 1'},
+                },
+                {
+                    "id": "b",
+                    "type": "function",
+                    "function": {"name": "g", "arguments": '{"x": 1}'},
+                },
+                {
+                    "id": "c",
+                    "type": "function",
+                    "function": {"name": "h", "arguments": {"x": 1}},
+                },
+            ],
+        },
+    ]
+
+    (out,) = _preserve_malformed_tool_arguments(messages)[1:2]
+    calls = out["tool_calls"]
+    assert json.loads(calls[0]["function"]["arguments"]) == '{"x": 1'
+    assert calls[1]["function"]["arguments"] == '{"x": 1}'
+    assert calls[2]["function"]["arguments"] == {"x": 1}
+
+
+def test_render_messages_preserves_malformed_tool_arguments():
+    """Malformed tool-call arguments round-trip to K3's encoding byte-exact.
+
+    parse_chat_messages json.loads string arguments, so the renderer wraps
+    unparsable ones as JSON string literals; the loads round-trips them to
+    the original string, which K3's encoding renders via its raw-text
+    fallback exactly like the platform tokenism.
+    """
+    tokenizer = StubTokenizer([1, 2])
+    renderer = _make_renderer(tokenizer)
+    malformed = '{"location":"北京"'
+
+    conversation, prompt = renderer.render_messages(
+        [
+            {"role": "user", "content": "北京天气怎么样？"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": malformed},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "晴"},
+            {"role": "user", "content": "继续"},
+        ],
+        ChatParams(),
+    )
+
+    assert prompt == {"prompt_token_ids": [1, 2]}
+    sent = tokenizer.conversations[-1]
+    assert sent[1]["tool_calls"][0]["function"]["arguments"] == malformed
+
+
+@pytest.mark.asyncio
+async def test_render_messages_async_preserves_malformed_tool_arguments():
+    tokenizer = StubTokenizer([3])
+    renderer = _make_renderer(tokenizer)
+    malformed = '{"location":"北京"'
+
+    await renderer.render_messages_async(
+        [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": malformed},
+                    }
+                ],
+            },
+        ],
+        ChatParams(),
+    )
+
+    sent = tokenizer.conversations[-1]
+    assert sent[0]["tool_calls"][0]["function"]["arguments"] == malformed
+
+
+def test_render_messages_converts_developer_to_system():
+    """developer messages must reach K3's encoding as system messages.
+
+    K3's encoding_k3 only recognizes system/user/assistant/tool and silently
+    drops other roles; developer (OpenAI's newer system-role name) is
+    converted with tools preserved so it renders as a dynamic tool declare.
+    """
+    tokenizer = StubTokenizer([1, 2])
+    renderer = _make_renderer(tokenizer)
+    tools = [{"type": "function", "function": {"name": "search"}}]
+
+    conversation, prompt = renderer.render_messages(
+        [
+            {"role": "developer", "content": "be terse", "tools": tools},
+            {"role": "user", "content": "hi"},
+        ],
+        ChatParams(),
+    )
+
+    assert prompt == {"prompt_token_ids": [1, 2]}
+    sent = tokenizer.conversations[-1]
+    assert sent[0]["role"] == "system"
+    assert sent[0]["content"] == "be terse"
+    assert sent[0]["tools"] == tools
+
+
+@pytest.mark.asyncio
+async def test_render_messages_async_converts_developer_to_system():
+    tokenizer = StubTokenizer([3])
+    renderer = _make_renderer(tokenizer)
+
+    await renderer.render_messages_async(
+        [{"role": "developer", "content": "be terse"}], ChatParams()
+    )
+
+    sent = tokenizer.conversations[-1]
+    assert sent[0]["role"] == "system"
+    assert sent[0]["content"] == "be terse"

--- a/tests/renderers/test_kimi_k3.py
+++ b/tests/renderers/test_kimi_k3.py
@@ -11,7 +11,7 @@ from vllm.renderers import ChatParams
 from vllm.renderers.kimi_k3 import (
     KimiK3Renderer,
     _merge_k3_media_io_kwargs,
-    _preserve_malformed_tool_arguments,
+    _preserve_raw_tool_arguments,
 )
 from vllm.renderers.registry import RENDERER_REGISTRY
 from vllm.tokenizers.registry import TokenizerRegistry
@@ -413,8 +413,9 @@ def test_apply_chat_template_keeps_user_schema_content():
     assert tokenizer.calls[-1]["tools"] == tools
 
 
-def test_preserve_malformed_tool_arguments_helper():
-    # Malformed strings are wrapped as JSON string literals; valid strings,
+def test_preserve_raw_tool_arguments_helper():
+    # Every string is wrapped as a JSON string literal -- valid or not -- so
+    # the downstream json.loads round-trips it to the original raw string;
     # dicts and non-list tool_calls pass through untouched.
     messages = [
         {"role": "user", "content": "hi"},
@@ -441,16 +442,17 @@ def test_preserve_malformed_tool_arguments_helper():
         },
     ]
 
-    (out,) = _preserve_malformed_tool_arguments(messages)[1:2]
+    (out,) = _preserve_raw_tool_arguments(messages)[1:2]
     calls = out["tool_calls"]
     assert json.loads(calls[0]["function"]["arguments"]) == '{"x": 1'
-    assert calls[1]["function"]["arguments"] == '{"x": 1}'
+    assert json.loads(calls[1]["function"]["arguments"]) == '{"x": 1}'
     assert calls[2]["function"]["arguments"] == {"x": 1}
 
 
-def test_preserve_malformed_tool_arguments_whitespace_only():
-    # Whitespace-only arguments are normalized to empty arguments instead of
-    # failing json.loads downstream (K3 treats them as empty).
+def test_preserve_raw_tool_arguments_whitespace_only():
+    # Whitespace-only arguments are preserved like everything else: they
+    # would fail json.loads downstream, and K3's encoding renders them via
+    # its raw-text fallback rather than treating them as empty.
     messages = [
         {
             "role": "assistant",
@@ -465,21 +467,24 @@ def test_preserve_malformed_tool_arguments_whitespace_only():
         },
     ]
 
-    (out,) = _preserve_malformed_tool_arguments(messages)
-    assert out["tool_calls"][0]["function"]["arguments"] == "{}"
+    (out,) = _preserve_raw_tool_arguments(messages)
+    assert json.loads(out["tool_calls"][0]["function"]["arguments"]) == "  \n "
 
 
-def test_render_messages_preserves_malformed_tool_arguments():
-    """Malformed tool-call arguments round-trip to K3's encoding byte-exact.
+def test_render_messages_preserves_raw_tool_arguments():
+    """Tool-call arguments round-trip to K3's encoding byte-exact.
 
-    parse_chat_messages json.loads string arguments, so the renderer wraps
-    unparsable ones as JSON string literals; the loads round-trips them to
-    the original string, which K3's encoding renders via its raw-text
-    fallback exactly like the platform tokenism.
+    parse_chat_messages json.loads string arguments into Python objects, so
+    the renderer wraps them as JSON string literals; the loads round-trips
+    them to the original string, which K3's encoding parses with literal
+    preservation -- or renders via its raw-text fallback for malformed JSON
+    -- exactly like the platform tokenism.
     """
     tokenizer = StubTokenizer([1, 2])
     renderer = _make_renderer(tokenizer)
     malformed = '{"location":"北京"'
+    literal = '{"temperature": 1e2, "dates": [1,2]}'
+    non_object = "[1,2]"
 
     conversation, prompt = renderer.render_messages(
         [
@@ -492,7 +497,17 @@ def test_render_messages_preserves_malformed_tool_arguments():
                         "id": "call_1",
                         "type": "function",
                         "function": {"name": "get_weather", "arguments": malformed},
-                    }
+                    },
+                    {
+                        "id": "call_2",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": literal},
+                    },
+                    {
+                        "id": "call_3",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": non_object},
+                    },
                 ],
             },
             {"role": "tool", "tool_call_id": "call_1", "content": "晴"},
@@ -503,14 +518,23 @@ def test_render_messages_preserves_malformed_tool_arguments():
 
     assert prompt == {"prompt_token_ids": [1, 2]}
     sent = tokenizer.conversations[-1]
-    assert sent[1]["tool_calls"][0]["function"]["arguments"] == malformed
+    tool_calls = sent[1]["tool_calls"]
+    # Malformed JSON survives (a bare json.loads would 400 here).
+    assert tool_calls[0]["function"]["arguments"] == malformed
+    # Valid JSON keeps its literal bytes instead of round-tripping through
+    # a dict (``1e2`` -> ``100.0``, ``[1,2]`` -> ``[1, 2]``).
+    assert tool_calls[1]["function"]["arguments"] == literal
+    # Valid non-object JSON stays a string instead of becoming a list, which
+    # K3's encoding would reject with a TypeError.
+    assert tool_calls[2]["function"]["arguments"] == non_object
 
 
 @pytest.mark.asyncio
-async def test_render_messages_async_preserves_malformed_tool_arguments():
+async def test_render_messages_async_preserves_raw_tool_arguments():
     tokenizer = StubTokenizer([3])
     renderer = _make_renderer(tokenizer)
     malformed = '{"location":"北京"'
+    literal = '{"temperature": 1e2}'
 
     await renderer.render_messages_async(
         [
@@ -522,7 +546,12 @@ async def test_render_messages_async_preserves_malformed_tool_arguments():
                         "id": "call_1",
                         "type": "function",
                         "function": {"name": "get_weather", "arguments": malformed},
-                    }
+                    },
+                    {
+                        "id": "call_2",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": literal},
+                    },
                 ],
             },
         ],
@@ -530,7 +559,9 @@ async def test_render_messages_async_preserves_malformed_tool_arguments():
     )
 
     sent = tokenizer.conversations[-1]
-    assert sent[0]["tool_calls"][0]["function"]["arguments"] == malformed
+    tool_calls = sent[0]["tool_calls"]
+    assert tool_calls[0]["function"]["arguments"] == malformed
+    assert tool_calls[1]["function"]["arguments"] == literal
 
 
 def test_render_messages_converts_developer_to_system():

--- a/vllm/entrypoints/openai/engine/protocol.py
+++ b/vllm/entrypoints/openai/engine/protocol.py
@@ -139,11 +139,8 @@ class JsonSchemaResponseFormat(OpenAIBaseModel):
     # schema is the field in openai but that causes conflicts with pydantic so
     # instead use json_schema with an alias
     json_schema: dict[str, Any] | None = Field(default=None, alias="schema")
-    # strict defaults to true: guided decoding constrains the output to the
-    # schema. strict=false applies no grammar constraint, but the schema may
-    # still be rendered into the prompt by chat templates that consume
-    # response_format. StrictBool rejects non-boolean values (e.g. "yes")
-    # with a 400 instead of coercing them.
+    # StrictBool rejects non-boolean values (e.g. "yes") with a 400 instead
+    # of coercing them.
     strict: StrictBool | None = None
 
 

--- a/vllm/entrypoints/openai/engine/protocol.py
+++ b/vllm/entrypoints/openai/engine/protocol.py
@@ -13,6 +13,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    StrictBool,
     model_serializer,
     model_validator,
 )
@@ -138,7 +139,12 @@ class JsonSchemaResponseFormat(OpenAIBaseModel):
     # schema is the field in openai but that causes conflicts with pydantic so
     # instead use json_schema with an alias
     json_schema: dict[str, Any] | None = Field(default=None, alias="schema")
-    strict: bool | None = None
+    # strict defaults to true: guided decoding constrains the output to the
+    # schema. strict=false applies no grammar constraint, but the schema may
+    # still be rendered into the prompt by chat templates that consume
+    # response_format. StrictBool rejects non-boolean values (e.g. "yes")
+    # with a 400 instead of coercing them.
+    strict: StrictBool | None = None
 
 
 class LegacyStructuralTag(OpenAIBaseModel):

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -118,6 +118,20 @@ def serialize_messages(msgs):
     return [serialize_message(msg) for msg in msgs] if msgs else None
 
 
+def _is_forced_tool_choice(tool_choice: Any) -> bool:
+    """Whether the request forces a tool call (required or named).
+
+    In that case the tool-calling schema replaces the user's response
+    format in ``adjust_request``, so the user format must not reach the
+    prompt (it would instruct the model to emit an incompatible schema).
+    """
+    if tool_choice == "required":
+        return True
+    if isinstance(tool_choice, dict):
+        return tool_choice.get("type") == "function"
+    return getattr(tool_choice, "type", None) == "function"
+
+
 def _text_format_to_chat_response_format(
     text: ResponseTextConfig | None,
 ) -> dict[str, Any] | None:
@@ -369,8 +383,13 @@ class ResponsesRequest(OpenAIBaseModel):
             media_io_kwargs=self.media_io_kwargs,
             tool_choice=self.tool_choice if self.tools else None,
             # Forward the response format so templates that render it into
-            # the prompt can see it.
-            response_format=_text_format_to_chat_response_format(self.text),
+            # the prompt can see it. Suppressed for forced tool calls: the
+            # tool-calling schema replaces it in adjust_request.
+            response_format=(
+                None
+                if _is_forced_tool_choice(self.tool_choice)
+                else _text_format_to_chat_response_format(self.text)
+            ),
         )
 
     def build_tok_params(self, model_config: ModelConfig) -> TokenizeParams:

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -118,6 +118,31 @@ def serialize_messages(msgs):
     return [serialize_message(msg) for msg in msgs] if msgs else None
 
 
+def _text_format_to_chat_response_format(
+    text: ResponseTextConfig | None,
+) -> dict[str, Any] | None:
+    """Adapt Responses API ``text.format`` to the Chat Completions
+    ``response_format`` shape (schema nested under the ``json_schema`` key)
+    that chat renderers consuming ``response_format`` expect.
+    """
+    if text is None or text.format is None:
+        return None
+    fmt = text.format
+    if fmt.type == "json_schema":
+        return {
+            "type": "json_schema",
+            "json_schema": {
+                "name": getattr(fmt, "name", None),
+                "description": getattr(fmt, "description", None),
+                "schema": getattr(fmt, "schema_", None),
+                "strict": getattr(fmt, "strict", None),
+            },
+        }
+    if fmt.type == "json_object":
+        return {"type": "json_object", "json_schema": None}
+    return None
+
+
 class ResponseRawMessageAndToken(OpenAIBaseModel):
     """Class to show the raw message.
     If message / tokens diverge, tokens is the source of truth"""
@@ -338,6 +363,9 @@ class ResponsesRequest(OpenAIBaseModel):
             ),
             media_io_kwargs=self.media_io_kwargs,
             tool_choice=self.tool_choice if self.tools else None,
+            # Forward the response format so templates that render it into
+            # the prompt can see it.
+            response_format=_text_format_to_chat_response_format(self.text),
         )
 
     def build_tok_params(self, model_config: ModelConfig) -> TokenizeParams:

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -140,6 +140,11 @@ def _text_format_to_chat_response_format(
         }
     if fmt.type == "json_object":
         return {"type": "json_object", "json_schema": None}
+    if fmt.type == "text":
+        # Keep the explicit field instead of returning None: otherwise a
+        # conflicting chat_template_kwargs entry would survive and still
+        # inject formatting for renderers that consume response_format.
+        return {"type": "text", "json_schema": None}
     return None
 
 

--- a/vllm/renderers/kimi_k3.py
+++ b/vllm/renderers/kimi_k3.py
@@ -39,17 +39,35 @@ def _convert_developer_to_system(
     """Map ``developer`` messages to ``system`` for K3's chat encoding.
 
     K3's ``encoding_k3`` only recognizes ``system`` and silently drops other
-    roles. Unlike the HF renderer's variant, ``tools`` is kept: K3 renders a
-    tools-carrying system message as a dynamic tool declare.
+    roles. A system message carrying ``tools`` is rendered as a dynamic tool
+    declare with its content ignored, so a developer message with BOTH
+    content and tools is split in two (declare first, content second),
+    matching the Rust frontend.
     """
-    return [
-        (
-            {**msg, "role": "system"}  # type: ignore[misc]
-            if msg["role"] == "developer"
-            else msg
+    converted: list[ConversationMessage] = []
+    for msg in conversation:
+        if msg["role"] != "developer":
+            converted.append(msg)
+            continue
+        content = msg.get("content")
+        has_content = bool(
+            content
+            if isinstance(content, str)
+            else (content is not None and content != [])
         )
-        for msg in conversation
-    ]
+        if has_content and msg.get("tools"):
+            converted.append(
+                {"role": "system", "tools": msg["tools"]}  # type: ignore[misc]
+            )
+            converted.append(
+                {
+                    **{k: v for k, v in msg.items() if k != "tools"},
+                    "role": "system",
+                }  # type: ignore[misc]
+            )
+        else:
+            converted.append({**msg, "role": "system"})  # type: ignore[misc]
+    return converted
 
 
 def _drop_null_tool_fields(tools: Any) -> Any:
@@ -97,17 +115,26 @@ def _preserve_malformed_tool_arguments(
                 function = tool_call.get("function")
                 if isinstance(function, dict):
                     arguments = function.get("arguments")
-                    if isinstance(arguments, str) and arguments.strip():
-                        try:
-                            json.loads(arguments)
-                        except json.JSONDecodeError:
+                    if isinstance(arguments, str):
+                        if not arguments.strip():
+                            # Whitespace-only arguments read as a non-empty
+                            # string downstream and fail json.loads; K3 treats
+                            # them as empty arguments.
                             tool_call = {
                                 **tool_call,
-                                "function": {
-                                    **function,
-                                    "arguments": json.dumps(arguments),
-                                },
+                                "function": {**function, "arguments": "{}"},
                             }
+                        else:
+                            try:
+                                json.loads(arguments)
+                            except json.JSONDecodeError:
+                                tool_call = {
+                                    **tool_call,
+                                    "function": {
+                                        **function,
+                                        "arguments": json.dumps(arguments),
+                                    },
+                                }
             new_calls.append(tool_call)
         preserved.append({**message, "tool_calls": new_calls})  # type: ignore[typeddict-item]
     return preserved

--- a/vllm/renderers/kimi_k3.py
+++ b/vllm/renderers/kimi_k3.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
 from typing import Any, cast
 
 from vllm.config import VllmConfig
@@ -30,6 +31,86 @@ def _merge_k3_media_io_kwargs(
     media_io_kwargs: dict[str, dict[str, Any]] | None,
 ) -> dict[str, dict[str, Any]] | None:
     return merge_media_io_kwargs(_K3_MEDIA_IO_DEFAULTS, media_io_kwargs)
+
+
+def _convert_developer_to_system(
+    conversation: list[ConversationMessage],
+) -> list[ConversationMessage]:
+    """Map ``developer`` messages to ``system`` for K3's chat encoding.
+
+    K3's ``encoding_k3`` only recognizes ``system`` and silently drops other
+    roles. Unlike the HF renderer's variant, ``tools`` is kept: K3 renders a
+    tools-carrying system message as a dynamic tool declare.
+    """
+    return [
+        (
+            {**msg, "role": "system"}  # type: ignore[misc]
+            if msg["role"] == "developer"
+            else msg
+        )
+        for msg in conversation
+    ]
+
+
+def _drop_null_tool_fields(tools: Any) -> Any:
+    """Drop keys with ``None`` values at the tool and function level.
+
+    The serving layer's ``model_dump()`` keeps unset optional fields as
+    explicit ``null``, which the platform tokenism omits -- the nulls would
+    diverge the rendered prompt. Only the two pydantic-model levels are
+    touched; schema content under ``parameters`` is left alone.
+    """
+    if not isinstance(tools, list):
+        return tools
+    cleaned = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            cleaned.append(tool)
+            continue
+        tool = {k: v for k, v in tool.items() if v is not None}
+        function = tool.get("function")
+        if isinstance(function, dict):
+            tool["function"] = {k: v for k, v in function.items() if v is not None}
+        cleaned.append(tool)
+    return cleaned
+
+
+def _preserve_malformed_tool_arguments(
+    messages: list[ChatCompletionMessageParam],
+) -> list[ChatCompletionMessageParam]:
+    """Wrap unparsable tool-call ``arguments`` as JSON string literals.
+
+    ``parse_chat_messages`` rejects malformed JSON arguments with a 400,
+    while K3's encoding tolerates them via a raw-text fallback. Wrapping the
+    string as a JSON string literal survives that ``loads`` (round-tripping
+    to the original string), so the text reaches K3's encoding byte-exact.
+    """
+    preserved: list[ChatCompletionMessageParam] = []
+    for message in messages:
+        tool_calls = message.get("tool_calls") if isinstance(message, dict) else None
+        if not isinstance(tool_calls, list):
+            preserved.append(message)
+            continue
+        new_calls = []
+        for tool_call in tool_calls:
+            if isinstance(tool_call, dict):
+                function = tool_call.get("function")
+                if isinstance(function, dict):
+                    arguments = function.get("arguments")
+                    if isinstance(arguments, str) and arguments.strip():
+                        try:
+                            json.loads(arguments)
+                        except json.JSONDecodeError:
+                            tool_call = {
+                                **tool_call,
+                                "function": {
+                                    **function,
+                                    "arguments": json.dumps(arguments),
+                                },
+                            }
+            new_calls.append(tool_call)
+        preserved.append({**message, "tool_calls": new_calls})  # type: ignore[typeddict-item]
+    return preserved
 
 
 def _dump_k3_template_value(value: Any) -> Any:
@@ -169,6 +250,8 @@ class KimiK3Renderer(BaseRenderer[HfTokenizer]):
             kwargs["tool_choice"] = _dump_k3_template_value(params.tool_choice)
         if params.response_format is not None:
             kwargs["response_format"] = _dump_k3_template_value(params.response_format)
+        if (tools := kwargs.get("tools")) is not None:
+            kwargs["tools"] = _drop_null_tool_fields(tools)
         kwargs["tokenize"] = True
         return self.get_tokenizer().apply_chat_template(conversation, **kwargs)
 
@@ -178,14 +261,16 @@ class KimiK3Renderer(BaseRenderer[HfTokenizer]):
         params: ChatParams,
     ) -> tuple[list[ConversationMessage], DictPrompt]:
         conversation, mm_data, mm_uuids = parse_chat_messages(
-            messages,
+            _preserve_malformed_tool_arguments(messages),
             self.model_config,
             content_format="string",
             media_io_kwargs=_merge_k3_media_io_kwargs(params.media_io_kwargs),
             mm_processor_kwargs=params.mm_processor_kwargs,
         )
 
-        rendered_conversation = _normalize_k3_tool_messages(conversation)
+        rendered_conversation = _normalize_k3_tool_messages(
+            _convert_developer_to_system(conversation)
+        )
         prompt = parse_dec_only_prompt(
             self._apply_chat_template(rendered_conversation, params)
         )
@@ -202,14 +287,16 @@ class KimiK3Renderer(BaseRenderer[HfTokenizer]):
         params: ChatParams,
     ) -> tuple[list[ConversationMessage], DictPrompt]:
         conversation, mm_data, mm_uuids = await parse_chat_messages_async(
-            messages,
+            _preserve_malformed_tool_arguments(messages),
             self.model_config,
             content_format="string",
             media_io_kwargs=_merge_k3_media_io_kwargs(params.media_io_kwargs),
             mm_processor_kwargs=params.mm_processor_kwargs,
         )
 
-        rendered_conversation = _normalize_k3_tool_messages(conversation)
+        rendered_conversation = _normalize_k3_tool_messages(
+            _convert_developer_to_system(conversation)
+        )
         token_ids = await self._apply_chat_template_async(rendered_conversation, params)
         prompt = parse_dec_only_prompt(token_ids)
         if mm_data is not None:

--- a/vllm/renderers/kimi_k3.py
+++ b/vllm/renderers/kimi_k3.py
@@ -60,10 +60,13 @@ def _convert_developer_to_system(
                 {"role": "system", "tools": msg["tools"]}  # type: ignore[misc]
             )
             converted.append(
-                {
-                    **{k: v for k, v in msg.items() if k != "tools"},
-                    "role": "system",
-                }  # type: ignore[misc]
+                cast(
+                    ConversationMessage,
+                    {
+                        **{k: v for k, v in msg.items() if k != "tools"},
+                        "role": "system",
+                    },
+                )
             )
         else:
             converted.append({**msg, "role": "system"})  # type: ignore[misc]
@@ -93,15 +96,20 @@ def _drop_null_tool_fields(tools: Any) -> Any:
     return cleaned
 
 
-def _preserve_malformed_tool_arguments(
+def _preserve_raw_tool_arguments(
     messages: list[ChatCompletionMessageParam],
 ) -> list[ChatCompletionMessageParam]:
-    """Wrap unparsable tool-call ``arguments`` as JSON string literals.
+    """Wrap string tool-call ``arguments`` as JSON string literals.
 
-    ``parse_chat_messages`` rejects malformed JSON arguments with a 400,
-    while K3's encoding tolerates them via a raw-text fallback. Wrapping the
-    string as a JSON string literal survives that ``loads`` (round-tripping
-    to the original string), so the text reaches K3's encoding byte-exact.
+    ``parse_chat_messages`` unconditionally ``json.loads`` string arguments
+    into Python objects (the Transformers dict convention), while K3's
+    ``encoding_k3`` wants the raw string: valid JSON objects keep their
+    literal bytes (``1e2`` stays ``1e2``, ``[1,2]`` keeps its compact form),
+    and anything else -- malformed JSON, valid non-object JSON, whitespace --
+    falls back to a raw-text block rendered from the original string.
+    Wrapping the string as a JSON string literal survives that ``loads``
+    (round-tripping to the original string), so the text reaches K3's
+    encoding byte-exact in every case.
     """
     preserved: list[ChatCompletionMessageParam] = []
     for message in messages:
@@ -116,25 +124,13 @@ def _preserve_malformed_tool_arguments(
                 if isinstance(function, dict):
                     arguments = function.get("arguments")
                     if isinstance(arguments, str):
-                        if not arguments.strip():
-                            # Whitespace-only arguments read as a non-empty
-                            # string downstream and fail json.loads; K3 treats
-                            # them as empty arguments.
-                            tool_call = {
-                                **tool_call,
-                                "function": {**function, "arguments": "{}"},
-                            }
-                        else:
-                            try:
-                                json.loads(arguments)
-                            except json.JSONDecodeError:
-                                tool_call = {
-                                    **tool_call,
-                                    "function": {
-                                        **function,
-                                        "arguments": json.dumps(arguments),
-                                    },
-                                }
+                        tool_call = {
+                            **tool_call,
+                            "function": {
+                                **function,
+                                "arguments": json.dumps(arguments),
+                            },
+                        }
             new_calls.append(tool_call)
         preserved.append({**message, "tool_calls": new_calls})  # type: ignore[typeddict-item]
     return preserved
@@ -288,7 +284,7 @@ class KimiK3Renderer(BaseRenderer[HfTokenizer]):
         params: ChatParams,
     ) -> tuple[list[ConversationMessage], DictPrompt]:
         conversation, mm_data, mm_uuids = parse_chat_messages(
-            _preserve_malformed_tool_arguments(messages),
+            _preserve_raw_tool_arguments(messages),
             self.model_config,
             content_format="string",
             media_io_kwargs=_merge_k3_media_io_kwargs(params.media_io_kwargs),
@@ -314,7 +310,7 @@ class KimiK3Renderer(BaseRenderer[HfTokenizer]):
         params: ChatParams,
     ) -> tuple[list[ConversationMessage], DictPrompt]:
         conversation, mm_data, mm_uuids = await parse_chat_messages_async(
-            _preserve_malformed_tool_arguments(messages),
+            _preserve_raw_tool_arguments(messages),
             self.model_config,
             content_format="string",
             media_io_kwargs=_merge_k3_media_io_kwargs(params.media_io_kwargs),


### PR DESCRIPTION
K3-renderer-scoped fixes plus Responses API response_format wiring:

- Render developer messages as system for K3 encoding (they were silently dropped, content included); a developer message with both content and tools is split in two system messages (declare first, content second), matching the Rust frontend.
- Drop null tool fields from model_dump() serialization for prompt parity with the platform tokenism (schema content under "parameters" is left alone).
- Preserve tool-call argument strings byte-exact for K3's encoding. parse_chat_messages unconditionally json.loads string arguments into Python objects (the Transformers dict convention), which loses the raw string that K3's encoding_k3 keys on: valid JSON objects keep their literal bytes (1e2 stays 1e2, [1,2] keeps its compact form), and anything else -- malformed JSON, valid non-object JSON, whitespace-only text -- falls back to a raw-text block rendered from the original string. Wrapping every string argument as a JSON string literal round-trips it through that loads, so the text reaches K3's encoding byte-exact in all cases (previously malformed JSON failed the request with a 400, and valid non-object JSON became a list that encoding_k3 rejects with a TypeError).
- Forward response_format to renderers on the Responses API by re-nesting the flat text.format into the Chat Completions shape; suppressed for forced tool choices (tool_choice required/named), where adjust_request replaces text.format with the tool-calling schema.
- Reject non-boolean response_format strict values with 400 instead of lax-coercing them (StrictBool).

## Purpose

Fix prompt-rendering parity between the vLLM serving path and the platform tokenism / checkpoint encoding for Kimi K3, plus response_format wiring on the Responses API. All changes are scoped to the K3 renderer and protocol models; the shared upstream parse_chat_messages logic is untouched.

## Test Plan

- `pytest tests/renderers/test_kimi_k3.py`
- `pytest tests/entrypoints/openai/test_response_format_chat_params.py`
- `pre-commit run --files vllm/renderers/kimi_k3.py tests/renderers/test_kimi_k3.py`

## Test Result

- 33/33 renderer tests pass; 19/19 response_format tests pass.
- pre-commit hooks (ruff check/format, mypy 3.10, etc.) green.
- Every argument shape (valid object, malformed, valid non-object, whitespace-only, empty, dict) driven through moonshotai/Kimi-K3's encoding_k3.py (main @ a590ce090c) renders identically to the direct-encoding (tokenism) path.

AI assistance: this PR was developed with AI assistance (see the Co-authored-by trailer).

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
