### PR TITLE
[Frontend] strict=false in response_format json_schema

### DIFF
--- a/tests/entrypoints/openai/test_response_format_chat_params.py
+++ b/tests/entrypoints/openai/test_response_format_chat_params.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for top-level response_format forwarding into ChatParams.
+
+Most models treat response_format purely as a decoding constraint (guided
+decoding via structured_outputs), so it is not part of chat template
+rendering. Models whose chat encoding renders response_format into the
+prompt need the field at the renderer layer; the forwarding is inert for
+renderers that don't read it.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+)
+
+_WEATHER_SCHEMA = {
+    "type": "object",
+    "properties": {"city": {"type": "string"}},
+    "required": ["city"],
+    "additionalProperties": False,
+}
+
+
+def _build_chat_request(**kwargs) -> ChatCompletionRequest:
+    defaults = dict(
+        model="test-model",
+        messages=[{"role": "user", "content": "Hello"}],
+    )
+    defaults.update(kwargs)
+    return ChatCompletionRequest(**defaults)
+
+
+class TestStrictFalseDisablesGuidedDecoding:
+    """strict=false means prompt-instruction-only: the schema is forwarded
+    to the renderer, but no grammar constraint is applied. strict=true/absent
+    keeps full guided decoding."""
+
+    def _guided_json(self, request) -> dict | None:
+        params = request.to_sampling_params(max_tokens=100, default_sampling_params={})
+        if params.structured_outputs is None:
+            return None
+        return params.structured_outputs.json
+
+    def _chat_request(self, strict):
+        json_schema = {"name": "weather", "schema": _WEATHER_SCHEMA}
+        if strict is not ...:
+            json_schema["strict"] = strict
+        return _build_chat_request(
+            response_format={"type": "json_schema", "json_schema": json_schema}
+        )
+
+    def test_strict_false_disables_guided_decoding(self):
+        assert self._guided_json(self._chat_request(strict=False)) is None
+
+    def test_strict_true_keeps_guided_decoding(self):
+        assert self._guided_json(self._chat_request(strict=True)) == (_WEATHER_SCHEMA)
+
+    def test_strict_absent_keeps_guided_decoding(self):
+        # Compatibility: clients that never pass strict must not silently
+        # lose grammar constraints.
+        assert self._guided_json(self._chat_request(strict=...)) == (_WEATHER_SCHEMA)
+
+    def test_strict_false_still_forwards_to_renderer(self):
+        # The prompt-instruction channel must stay active when the grammar
+        # channel is off -- together they form "prompt-only" mode.
+        request = self._chat_request(strict=False)
+        params = request.build_chat_params(None, "auto")
+        rf = params.response_format
+        assert rf is not None and rf.json_schema is not None
+        assert rf.json_schema.json_schema == _WEATHER_SCHEMA
+        assert rf.json_schema.strict is False
+
+
+class TestResponsesStrictFalse:
+    def _build_responses_request(self, strict):
+        from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+
+        fmt = {
+            "type": "json_schema",
+            "name": "weather",
+            "schema": _WEATHER_SCHEMA,
+        }
+        if strict is not ...:
+            fmt["strict"] = strict
+        return ResponsesRequest(
+            model="test-model",
+            input=[{"role": "user", "content": "Hello"}],
+            text={"format": fmt},
+        )
+
+    def _guided_json(self, request) -> dict | None:
+        params = request.to_sampling_params(default_max_tokens=100)
+        if params.structured_outputs is None:
+            return None
+        return params.structured_outputs.json
+
+    def test_strict_false_disables_guided_decoding(self):
+        assert self._guided_json(self._build_responses_request(False)) is None
+
+    def test_strict_true_keeps_guided_decoding(self):
+        assert self._guided_json(self._build_responses_request(True)) == (
+            _WEATHER_SCHEMA
+        )
+
+    def test_strict_absent_keeps_guided_decoding(self):
+        assert self._guided_json(self._build_responses_request(...)) == (
+            _WEATHER_SCHEMA
+        )
+

--- a/tests/entrypoints/openai/test_response_format_chat_params.py
+++ b/tests/entrypoints/openai/test_response_format_chat_params.py
@@ -9,9 +9,6 @@ prompt need the field at the renderer layer; the forwarding is inert for
 renderers that don't read it.
 """
 
-import pytest
-from pydantic import ValidationError
-
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
 )
@@ -100,6 +97,17 @@ class TestResponsesStrictFalse:
     def test_strict_false_disables_guided_decoding(self):
         assert self._guided_json(self._build_responses_request(False)) is None
 
+    def test_strict_false_keeps_explicit_structured_outputs(self):
+        # strict=false contributes no decoding constraint, so an explicit
+        # structured_outputs coexists with it without conflict.
+        from vllm.sampling_params import StructuredOutputsParams
+
+        request = self._build_responses_request(False)
+        explicit = StructuredOutputsParams(regex=r"\d+")
+        request = request.model_copy(update={"structured_outputs": explicit})
+        params = request.to_sampling_params(default_max_tokens=100)
+        assert params.structured_outputs is explicit
+
     def test_strict_true_keeps_guided_decoding(self):
         assert self._guided_json(self._build_responses_request(True)) == (
             _WEATHER_SCHEMA
@@ -109,4 +117,3 @@ class TestResponsesStrictFalse:
         assert self._guided_json(self._build_responses_request(...)) == (
             _WEATHER_SCHEMA
         )
-

--- a/vllm/entrypoints/openai/engine/protocol.py
+++ b/vllm/entrypoints/openai/engine/protocol.py
@@ -190,7 +190,13 @@ def structured_outputs_from_response_format(
     elif response_format.type == "json_schema":
         json_schema = response_format.json_schema
         assert json_schema is not None
-        overrides = {"json": json_schema.json_schema}
+        # strict=false means prompt-instruction-only: no grammar constraint
+        # is applied, but the schema may still be rendered into the prompt by
+        # chat templates that consume response_format. Default (None) and
+        # true keep full guided decoding.
+        overrides = (
+            {"json": json_schema.json_schema} if json_schema.strict is not False else {}
+        )
     else:
         assert isinstance(
             response_format,
@@ -202,6 +208,9 @@ def structured_outputs_from_response_format(
         overrides = {
             "structural_tag": json.dumps(response_format.model_dump(by_alias=True))
         }
+
+    if not overrides:
+        return structured_outputs
 
     if structured_outputs is None:
         return StructuredOutputsParams(**overrides)

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -372,6 +372,9 @@ class ResponsesRequest(OpenAIBaseModel):
         if (
             response_format.type == "json_schema"
             and response_format.schema_ is not None
+            # strict=false means prompt-instruction-only: no grammar
+            # constraint is applied.
+            and getattr(response_format, "strict", None) is not False
         ):
             return StructuredOutputsParams(
                 json=response_format.schema_  # type: ignore[call-arg]

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -360,13 +360,20 @@ class ResponsesRequest(OpenAIBaseModel):
         if self.text is None or self.text.format is None:
             return self.structured_outputs
 
+        response_format = self.text.format
+        if (
+            response_format.type == "json_schema"
+            and getattr(response_format, "strict", None) is False
+        ):
+            # strict=false contributes no decoding constraint, so an
+            # explicit structured_outputs coexists with it without conflict.
+            return self.structured_outputs
+
         if self.structured_outputs is not None:
             raise VLLMValidationError(
                 "Cannot specify both structured_outputs and text.format",
                 parameter="structured_outputs",
             )
-
-        response_format = self.text.format
         if response_format.type == "json_object":
             return StructuredOutputsParams(json_object=True)
         if (

--- a/vllm/parser/mistral.py
+++ b/vllm/parser/mistral.py
@@ -394,10 +394,12 @@ class MistralParser(ParserEngine):
             if request.response_format.type == "json_object":
                 json_schema = _DEFAULT_JSON_SCHEMA
             elif request.response_format.type == "json_schema":
-                if request.response_format.json_schema is not None:
-                    json_schema = request.response_format.json_schema.json_schema
-                else:
+                rf_json_schema = request.response_format.json_schema
+                if rf_json_schema is None:
                     json_schema = _DEFAULT_JSON_SCHEMA
+                elif rf_json_schema.strict is not False:
+                    json_schema = rf_json_schema.json_schema
+                # strict=false: prompt-instruction-only, no grammar constraint
             else:
                 raise ValueError(
                     "MistralParser only accepts `text`, `json_object` or "

--- a/vllm/reasoning/cohere_command_reasoning_parser.py
+++ b/vllm/reasoning/cohere_command_reasoning_parser.py
@@ -357,6 +357,11 @@ def _schema_dict_from_chat_response_format(
         if isinstance(rf, dict)
         else getattr(rf, "json_schema", None)
     )
+    if js_wr is not None:
+        strict = js_wr.get("strict") if isinstance(js_wr, dict) else js_wr.strict
+        if strict is False:
+            # strict=false: prompt-instruction-only, no decoding constraint.
+            return None
     return _schema_from_json_schema_field(js_wr)
 
 


### PR DESCRIPTION
Per OpenAI semantics, strict=false means best-effort: the schema may guide the model via the prompt, but the output is not grammar constrained. vLLM previously ignored the flag and always applied guided decoding. Now skip the json structured-output override when strict=false, on both Chat Completions and Responses APIs. Default (absent) and strict=true keep full guided decoding, so existing clients are unaffected.




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

