### PR TITLE
[KVConnector] Let MultiConnector compose sub-connector hits

### DIFF
--- a/tests/v1/kv_connector/unit/test_multi_connector.py
+++ b/tests/v1/kv_connector/unit/test_multi_connector.py
@@ -1151,3 +1151,192 @@ def test_multi_connector_mixed_hma_disables_hybrid_kv_cache(monkeypatch):
             assert mc._all_support_hma is False
         finally:
             llm.llm_engine.engine_core.shutdown()
+
+
+# ============================================================================
+# Sub-connector composition (`compose_connectors`)
+# ============================================================================
+
+
+def _composing_mc(compose: bool) -> MultiConnector:
+    """MultiConnector over two mocked connectors, composition on or off."""
+    mock_connector_config = {
+        "kv_connector": "MockConnector",
+        "kv_role": "kv_both",
+        "kv_connector_module_path": "tests.v1.kv_connector.unit.test_multi_connector",
+    }
+    extra_config: dict[str, Any] = {
+        "connectors": [mock_connector_config, mock_connector_config],
+    }
+    if compose:
+        extra_config["compose_connectors"] = True
+
+    vllm_config = create_vllm_config(
+        kv_connector="MultiConnector",
+        kv_connector_extra_config=extra_config,
+    )
+    return MultiConnector(
+        vllm_config=vllm_config,
+        role=KVConnectorRole.SCHEDULER,
+        kv_cache_config=KVCacheConfig(
+            num_blocks=0, kv_cache_tensors=[], kv_cache_groups=[]
+        ),
+    )
+
+
+def _stub_matches(mc: MultiConnector, results: list[tuple[int | None, bool]]) -> None:
+    """Make sub-connector i report `results[i]` from get_num_new_matched_tokens.
+
+    Each return value is recorded against the `num_computed_tokens` it was
+    called with, so tests can assert what each connector was offered.
+    """
+    for connector, result in zip(mc._connectors, results):
+        connector.get_num_new_matched_tokens.return_value = result
+
+
+def _offered(mc: MultiConnector, index: int) -> int:
+    """The `num_computed_tokens` sub-connector `index` was last called with."""
+    return mc._connectors[index].get_num_new_matched_tokens.call_args[0][1]
+
+
+def _granted(mc: MultiConnector, index: int) -> int:
+    """The `num_external_tokens` sub-connector `index` was last handed."""
+    return mc._connectors[index].update_state_after_alloc.call_args[0][2]
+
+
+def test_compose_off_first_hit_takes_the_request():
+    """Default behaviour: the second connector contributes nothing."""
+    mc = _composing_mc(compose=False)
+    _stub_matches(mc, [(8, True), (4, True)])
+    request = MagicMock()
+    request.request_id = "req-0"
+
+    assert mc.get_num_new_matched_tokens(request, 0) == (8, True)
+
+    # Both are still asked, but from the same starting point.
+    assert _offered(mc, 0) == 0
+    assert _offered(mc, 1) == 0
+    mc.update_state_after_alloc(request, MagicMock(), 8)
+    assert _granted(mc, 0) == 8
+    assert _granted(mc, 1) == 0
+    # A single loader needs no extra-load accounting.
+    assert mc._extra_async_loads == {}
+
+
+def test_compose_on_sums_and_offers_the_remainder():
+    """Each connector is asked only about what the earlier ones did not cover."""
+    mc = _composing_mc(compose=True)
+    _stub_matches(mc, [(8, True), (4, True)])
+    request = MagicMock()
+    request.request_id = "req-0"
+
+    assert mc.get_num_new_matched_tokens(request, 16) == (12, True)
+
+    assert _offered(mc, 0) == 16
+    assert _offered(mc, 1) == 16 + 8
+    mc.update_state_after_alloc(request, MagicMock(), 12)
+    assert _granted(mc, 0) == 8
+    assert _granted(mc, 1) == 4
+    # Two loaders: the scheduler must see only the last report.
+    assert mc._extra_async_loads == {"req-0": 1}
+
+
+def test_compose_on_skips_connectors_with_no_hit():
+    """A connector reporting 0 opts out and is granted nothing."""
+    mc = _composing_mc(compose=True)
+    _stub_matches(mc, [(0, False), (4, True)])
+    request = MagicMock()
+    request.request_id = "req-0"
+
+    assert mc.get_num_new_matched_tokens(request, 0) == (4, True)
+
+    mc.update_state_after_alloc(request, MagicMock(), 4)
+    assert _granted(mc, 0) == 0
+    assert _granted(mc, 1) == 4
+    assert mc._extra_async_loads == {}
+
+
+def test_compose_on_refuses_to_mix_load_modes():
+    """The scheduler tracks one load mode per request, so a sync loader cannot
+    be combined with an async one."""
+    mc = _composing_mc(compose=True)
+    _stub_matches(mc, [(8, True), (4, False)])
+    request = MagicMock()
+    request.request_id = "req-0"
+
+    assert mc.get_num_new_matched_tokens(request, 0) == (8, True)
+
+    mc.update_state_after_alloc(request, MagicMock(), 8)
+    assert _granted(mc, 1) == 0
+    assert mc._extra_async_loads == {}
+
+
+def test_compose_on_pending_lookup_still_defers():
+    """A `None` from any connector means "ask again later"."""
+    mc = _composing_mc(compose=True)
+    _stub_matches(mc, [(8, True), (None, False)])
+    request = MagicMock()
+    request.request_id = "req-0"
+
+    assert mc.get_num_new_matched_tokens(request, 0) == (None, False)
+    assert mc._requests_to_connector == {}
+
+
+def test_compose_on_respects_a_reduced_allocation():
+    """The scheduler can allocate fewer tokens than we asked for; the tail
+    connectors are the ones that lose them."""
+    mc = _composing_mc(compose=True)
+    _stub_matches(mc, [(8, True), (4, True)])
+    request = MagicMock()
+    request.request_id = "req-0"
+    mc.get_num_new_matched_tokens(request, 0)
+
+    mc.update_state_after_alloc(request, MagicMock(), 10)
+
+    assert _granted(mc, 0) == 8
+    assert _granted(mc, 1) == 2
+
+
+def test_extra_async_loads_reach_the_worker():
+    """The count is computed scheduler-side and drained worker-side, so it
+    travels in the connector metadata like `extra_async_saves` does."""
+    mc = _composing_mc(compose=True)
+    _stub_matches(mc, [(8, True), (4, True)])
+    request = MagicMock()
+    request.request_id = "req-0"
+    mc.get_num_new_matched_tokens(request, 0)
+
+    metadata = mc.build_connector_meta(MagicMock())
+
+    assert metadata.extra_async_loads == {"req-0": 1}
+    # Handed off, so it is not shipped twice.
+    assert mc._extra_async_loads == {}
+
+
+def test_get_finished_reports_recving_only_after_the_last_loader():
+    """Two loaders means two reports; the scheduler must see exactly one, or
+    the second trips `assert RequestStatus.is_finished(req.status)` in
+    `Scheduler._update_from_kv_xfer_finished` and kills EngineCore."""
+    mc = _composing_mc(compose=True)
+    mc._extra_async_loads = {"req-0": 1}
+    mc._connectors[0].get_finished.return_value = (None, {"req-0"})
+    mc._connectors[1].get_finished.return_value = (None, None)
+
+    _, recving = mc.get_finished(set())
+    assert recving is None, "first of two loaders must not be forwarded"
+
+    mc._connectors[0].get_finished.return_value = (None, None)
+    mc._connectors[1].get_finished.return_value = (None, {"req-0"})
+    _, recving = mc.get_finished(set())
+    assert recving == {"req-0"}, "last loader completes the load"
+    assert mc._extra_async_loads == {}
+
+
+def test_get_finished_forwards_a_lone_loader_immediately():
+    """A single loader has no extra-load entry and is forwarded as-is."""
+    mc = _composing_mc(compose=True)
+    mc._connectors[0].get_finished.return_value = (None, {"req-0"})
+    mc._connectors[1].get_finished.return_value = (None, None)
+
+    _, recving = mc.get_finished(set())
+    assert recving == {"req-0"}

--- a/tests/v1/kv_connector/unit/test_multi_connector.py
+++ b/tests/v1/kv_connector/unit/test_multi_connector.py
@@ -1122,3 +1122,192 @@ def test_multi_connector_mixed_hma_disables_hybrid_kv_cache(monkeypatch):
             assert mc._all_support_hma is False
         finally:
             llm.llm_engine.engine_core.shutdown()
+
+
+# ============================================================================
+# Sub-connector composition (`compose_connectors`)
+# ============================================================================
+
+
+def _composing_mc(compose: bool) -> MultiConnector:
+    """MultiConnector over two mocked connectors, composition on or off."""
+    mock_connector_config = {
+        "kv_connector": "MockConnector",
+        "kv_role": "kv_both",
+        "kv_connector_module_path": "tests.v1.kv_connector.unit.test_multi_connector",
+    }
+    extra_config: dict[str, Any] = {
+        "connectors": [mock_connector_config, mock_connector_config],
+    }
+    if compose:
+        extra_config["compose_connectors"] = True
+
+    vllm_config = create_vllm_config(
+        kv_connector="MultiConnector",
+        kv_connector_extra_config=extra_config,
+    )
+    return MultiConnector(
+        vllm_config=vllm_config,
+        role=KVConnectorRole.SCHEDULER,
+        kv_cache_config=KVCacheConfig(
+            num_blocks=0, kv_cache_tensors=[], kv_cache_groups=[]
+        ),
+    )
+
+
+def _stub_matches(mc: MultiConnector, results: list[tuple[int | None, bool]]) -> None:
+    """Make sub-connector i report `results[i]` from get_num_new_matched_tokens.
+
+    Each return value is recorded against the `num_computed_tokens` it was
+    called with, so tests can assert what each connector was offered.
+    """
+    for connector, result in zip(mc._connectors, results):
+        connector.get_num_new_matched_tokens.return_value = result
+
+
+def _offered(mc: MultiConnector, index: int) -> int:
+    """The `num_computed_tokens` sub-connector `index` was last called with."""
+    return mc._connectors[index].get_num_new_matched_tokens.call_args[0][1]
+
+
+def _granted(mc: MultiConnector, index: int) -> int:
+    """The `num_external_tokens` sub-connector `index` was last handed."""
+    return mc._connectors[index].update_state_after_alloc.call_args[0][2]
+
+
+def test_compose_off_first_hit_takes_the_request():
+    """Default behaviour: the second connector contributes nothing."""
+    mc = _composing_mc(compose=False)
+    _stub_matches(mc, [(8, True), (4, True)])
+    request = MagicMock()
+    request.request_id = "req-0"
+
+    assert mc.get_num_new_matched_tokens(request, 0) == (8, True)
+
+    # Both are still asked, but from the same starting point.
+    assert _offered(mc, 0) == 0
+    assert _offered(mc, 1) == 0
+    mc.update_state_after_alloc(request, MagicMock(), 8)
+    assert _granted(mc, 0) == 8
+    assert _granted(mc, 1) == 0
+    # A single loader needs no extra-load accounting.
+    assert mc._extra_async_loads == {}
+
+
+def test_compose_on_sums_and_offers_the_remainder():
+    """Each connector is asked only about what the earlier ones did not cover."""
+    mc = _composing_mc(compose=True)
+    _stub_matches(mc, [(8, True), (4, True)])
+    request = MagicMock()
+    request.request_id = "req-0"
+
+    assert mc.get_num_new_matched_tokens(request, 16) == (12, True)
+
+    assert _offered(mc, 0) == 16
+    assert _offered(mc, 1) == 16 + 8
+    mc.update_state_after_alloc(request, MagicMock(), 12)
+    assert _granted(mc, 0) == 8
+    assert _granted(mc, 1) == 4
+    # Two loaders: the scheduler must see only the last report.
+    assert mc._extra_async_loads == {"req-0": 1}
+
+
+def test_compose_on_skips_connectors_with_no_hit():
+    """A connector reporting 0 opts out and is granted nothing."""
+    mc = _composing_mc(compose=True)
+    _stub_matches(mc, [(0, False), (4, True)])
+    request = MagicMock()
+    request.request_id = "req-0"
+
+    assert mc.get_num_new_matched_tokens(request, 0) == (4, True)
+
+    mc.update_state_after_alloc(request, MagicMock(), 4)
+    assert _granted(mc, 0) == 0
+    assert _granted(mc, 1) == 4
+    assert mc._extra_async_loads == {}
+
+
+def test_compose_on_refuses_to_mix_load_modes():
+    """The scheduler tracks one load mode per request, so a sync loader cannot
+    be combined with an async one."""
+    mc = _composing_mc(compose=True)
+    _stub_matches(mc, [(8, True), (4, False)])
+    request = MagicMock()
+    request.request_id = "req-0"
+
+    assert mc.get_num_new_matched_tokens(request, 0) == (8, True)
+
+    mc.update_state_after_alloc(request, MagicMock(), 8)
+    assert _granted(mc, 1) == 0
+    assert mc._extra_async_loads == {}
+
+
+def test_compose_on_pending_lookup_still_defers():
+    """A `None` from any connector means "ask again later"."""
+    mc = _composing_mc(compose=True)
+    _stub_matches(mc, [(8, True), (None, False)])
+    request = MagicMock()
+    request.request_id = "req-0"
+
+    assert mc.get_num_new_matched_tokens(request, 0) == (None, False)
+    assert mc._requests_to_connector == {}
+
+
+def test_compose_on_respects_a_reduced_allocation():
+    """The scheduler can allocate fewer tokens than we asked for; the tail
+    connectors are the ones that lose them."""
+    mc = _composing_mc(compose=True)
+    _stub_matches(mc, [(8, True), (4, True)])
+    request = MagicMock()
+    request.request_id = "req-0"
+    mc.get_num_new_matched_tokens(request, 0)
+
+    mc.update_state_after_alloc(request, MagicMock(), 10)
+
+    assert _granted(mc, 0) == 8
+    assert _granted(mc, 1) == 2
+
+
+def test_extra_async_loads_reach_the_worker():
+    """The count is computed scheduler-side and drained worker-side, so it
+    travels in the connector metadata like `extra_async_saves` does."""
+    mc = _composing_mc(compose=True)
+    _stub_matches(mc, [(8, True), (4, True)])
+    request = MagicMock()
+    request.request_id = "req-0"
+    mc.get_num_new_matched_tokens(request, 0)
+
+    metadata = mc.build_connector_meta(MagicMock())
+
+    assert metadata.extra_async_loads == {"req-0": 1}
+    # Handed off, so it is not shipped twice.
+    assert mc._extra_async_loads == {}
+
+
+def test_get_finished_reports_recving_only_after_the_last_loader():
+    """Two loaders means two reports; the scheduler must see exactly one, or
+    the second trips `assert RequestStatus.is_finished(req.status)` in
+    `Scheduler._update_from_kv_xfer_finished` and kills EngineCore."""
+    mc = _composing_mc(compose=True)
+    mc._extra_async_loads = {"req-0": 1}
+    mc._connectors[0].get_finished.return_value = (None, {"req-0"})
+    mc._connectors[1].get_finished.return_value = (None, None)
+
+    _, recving = mc.get_finished(set())
+    assert recving is None, "first of two loaders must not be forwarded"
+
+    mc._connectors[0].get_finished.return_value = (None, None)
+    mc._connectors[1].get_finished.return_value = (None, {"req-0"})
+    _, recving = mc.get_finished(set())
+    assert recving == {"req-0"}, "last loader completes the load"
+    assert mc._extra_async_loads == {}
+
+
+def test_get_finished_forwards_a_lone_loader_immediately():
+    """A single loader has no extra-load entry and is forwarded as-is."""
+    mc = _composing_mc(compose=True)
+    mc._connectors[0].get_finished.return_value = (None, {"req-0"})
+    mc._connectors[1].get_finished.return_value = (None, None)
+
+    _, recving = mc.get_finished(set())
+    assert recving == {"req-0"}

--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -46,6 +46,7 @@ logger = init_logger(__name__)
 class MultiKVConnectorMetadata(KVConnectorMetadata):
     metadata: tuple[KVConnectorMetadata, ...]
     extra_async_saves: dict[str, int] | None = None
+    extra_async_loads: dict[str, int] | None = None
 
 
 @dataclass
@@ -193,15 +194,32 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
             or self._all_support_hma
         ), "HMA should not be enabled unless all sub-connectors support it"
 
-        # A mapping from request id to the index of the connector chosen to
-        # load the request from (if any).
-        self._requests_to_connector: dict[str, int] = {}
+        # Whether to let sub-connectors *compose* their hits for one request:
+        # each connector is offered the tokens the earlier ones did not cover,
+        # instead of the first one with a hit taking the whole request. Opt-in
+        # because it changes how many tokens each sub-connector is asked to
+        # load; see `get_num_new_matched_tokens`.
+        self._compose_connectors = bool(
+            vllm_config.kv_transfer_config.get_from_extra_config(
+                "compose_connectors", False
+            )
+        )
+
+        # A mapping from request id to {connector index: number of tokens that
+        # connector is loading}. Without composition this holds at most one
+        # entry -- the connector chosen to load the request.
+        self._requests_to_connector: dict[str, dict[int, int]] = {}
 
         # Keeps track of *additional* remaining async saves (beyond 1) to be
-        # finished per request. Not needed for async loads since we only allow
-        # a single connector to load.
+        # finished per request.
         # Propagated from scheduler to worker side via the connector metadata.
         self._extra_async_saves: dict[str, int] = {}
+
+        # Same, for async loads: with composition more than one connector can
+        # be loading a single request, and the scheduler must not resume it
+        # until all of them are done. Without composition this stays empty.
+        # Propagated from scheduler to worker side via the connector metadata.
+        self._extra_async_loads: dict[str, int] = {}
 
     @property
     def prefer_cross_layer_blocks(self) -> bool:
@@ -265,6 +283,8 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         assert isinstance(connector_metadata, MultiKVConnectorMetadata)
         if connector_metadata.extra_async_saves:
             self._extra_async_saves.update(connector_metadata.extra_async_saves)
+        if connector_metadata.extra_async_loads:
+            self._extra_async_loads.update(connector_metadata.extra_async_loads)
         for c, cm in zip(self._connectors, connector_metadata.metadata):
             c.bind_connector_metadata(cm)
         super().bind_connector_metadata(connector_metadata)
@@ -321,23 +341,42 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
             sending, recving = c.get_finished(finished_req_ids)
             if not recving and not sending:
                 continue
-            # Aggregate finished recving request ids.
-            finished_recving.update(recving or ())
+            # Aggregate finished recving request ids - only include once we've
+            # drained the "extra" count, exactly as for sends below. With
+            # composition more than one connector loads a single request, and
+            # the scheduler must not be told the load is complete until the
+            # last of them reports: the first report moves the request out of
+            # WAITING_FOR_REMOTE_KVS, so a second one would hit
+            # `assert RequestStatus.is_finished(req.status)` in
+            # `Scheduler._update_from_kv_xfer_finished` and kill EngineCore.
+            for req_id in recving or ():
+                if self._drain_extra(self._extra_async_loads, req_id):
+                    finished_recving.add(req_id)
             # Aggregate finished sending request ids - only include
             # once we've drained the "extra" count (for cases where
             # more than one connector is async-saving the same request).
             for req_id in sending or ():
-                extra_pending = self._extra_async_saves.get(req_id)
-                if extra_pending is None:
+                if self._drain_extra(self._extra_async_saves, req_id):
                     finished_sending.add(req_id)
-                    continue
-                assert extra_pending > 0
-                if extra_pending == 1:
-                    del self._extra_async_saves[req_id]
-                else:
-                    self._extra_async_saves[req_id] = extra_pending - 1
 
         return finished_sending or None, finished_recving or None
+
+    @staticmethod
+    def _drain_extra(extra: dict[str, int], req_id: str) -> bool:
+        """Whether this is the last connector to report `req_id`.
+
+        `extra` holds the number of reports still expected *beyond* this one.
+        A missing entry means no other connector is working on the request.
+        """
+        extra_pending = extra.get(req_id)
+        if extra_pending is None:
+            return True
+        assert extra_pending > 0
+        if extra_pending == 1:
+            del extra[req_id]
+        else:
+            extra[req_id] = extra_pending - 1
+        return False
 
     def get_block_ids_with_load_errors(self) -> set[int]:
         agg_block_ids: set[int] = set()
@@ -387,33 +426,77 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         request: "Request",
         num_computed_tokens: int,
     ) -> tuple[int | None, bool]:
-        to_return = (0, False)
+        """Ask each sub-connector how many tokens it can supply.
+
+        Default (`compose_connectors` off): the first connector reporting a
+        non-zero count is assigned the whole request and the rest contribute
+        nothing, even when they hold tokens the winner does not.
+
+        With `compose_connectors` on, each connector is instead offered the
+        tokens the earlier ones did not cover, by advancing the
+        `num_computed_tokens` we pass down. That is the same "everything up to
+        here is already covered" contract the scheduler uses, so a connector
+        needs no changes to participate -- it simply reports the prefix it can
+        serve beyond what it is told exists, and returning 0 opts it out.
+
+        Composition is restricted to connectors that agree with the first
+        contributor on `load_async`: the scheduler tracks one load mode per
+        request, so mixing a synchronous loader (which loads inside the forward
+        pass) with an asynchronous one (which loads between steps) is not
+        expressible. Connectors that disagree are offered nothing.
+        """
+        per_connector: dict[int, int] = {}
+        total = 0
+        load_async_mode: bool | None = None
         for i, c in enumerate(self._connectors):
+            # Only advance the offer when composing. Otherwise every connector
+            # is asked exactly the question the scheduler asked us, so the
+            # first-hit-takes-all path is bit-for-bit unchanged.
+            covered = total if self._compose_connectors else 0
             toks, load_async = c.get_num_new_matched_tokens(
-                request, num_computed_tokens
+                request, num_computed_tokens + covered
             )
             # If there is a connector still looking up the matches,
             # we return None to indicate that we are not done yet.
             if toks is None:
                 return (None, False)
-            # The first connector that has new matched tokens will be assigned
-            # to this request.
-            if to_return[0] == 0 and toks > 0:
-                self._requests_to_connector[request.request_id] = i
-                to_return = (toks, load_async)
-        return to_return
+            if toks == 0:
+                continue
+            if load_async_mode is None:
+                # First contributor decides the load mode for this request.
+                load_async_mode = load_async
+            elif not self._compose_connectors or load_async != load_async_mode:
+                # Either we are not composing (first hit takes everything), or
+                # this connector cannot be combined with the ones before it.
+                continue
+            per_connector[i] = toks
+            total += toks
+
+        if not per_connector:
+            return (0, False)
+
+        self._requests_to_connector[request.request_id] = per_connector
+        if len(per_connector) > 1:
+            self._extra_async_loads[request.request_id] = len(per_connector) - 1
+        assert load_async_mode is not None
+        return (total, load_async_mode)
 
     def update_state_after_alloc(
         self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
     ):
-        chosen_connector = self._requests_to_connector.get(request.request_id, -1)
+        per_connector = self._requests_to_connector.get(request.request_id) or {}
+        # `num_external_tokens` is the scheduler's final say and can be lower
+        # than what we asked for; hand it out in connector order so the tail
+        # connectors are the ones that lose tokens, and pass 0 to a connector
+        # once the budget runs out so it skips its load. It is also 0 on the
+        # second call for async-load requests, which correctly tells every
+        # sub-connector there is nothing more to do.
+        budget = num_external_tokens
         for i, c in enumerate(self._connectors):
-            if i == chosen_connector:
-                # Forward call to the chosen connector (if any).
-                c.update_state_after_alloc(request, blocks, num_external_tokens)
-            else:
-                # Other connectors still receive the request's real blocks
-                c.update_state_after_alloc(request, blocks, 0)
+            share = min(per_connector.get(i, 0), budget)
+            budget -= share
+            # Every connector still receives the request's real blocks.
+            c.update_state_after_alloc(request, blocks, share)
 
     def on_new_request(self, request: "Request") -> None:
         for c in self._connectors:
@@ -430,6 +513,9 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         if self._extra_async_saves:
             metadata.extra_async_saves = self._extra_async_saves
             self._extra_async_saves = {}
+        if self._extra_async_loads:
+            metadata.extra_async_loads = self._extra_async_loads
+            self._extra_async_loads = {}
         return metadata
 
     def update_connector_output(self, connector_output: KVConnectorOutput):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -46,6 +46,7 @@ logger = init_logger(__name__)
 class MultiKVConnectorMetadata(KVConnectorMetadata):
     metadata: tuple[KVConnectorMetadata, ...]
     extra_async_saves: dict[str, int] | None = None
+    extra_async_loads: dict[str, int] | None = None
 
 
 @dataclass
@@ -193,15 +194,32 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
             or self._all_support_hma
         ), "HMA should not be enabled unless all sub-connectors support it"
 
-        # A mapping from request id to the index of the connector chosen to
-        # load the request from (if any).
-        self._requests_to_connector: dict[str, int] = {}
+        # Whether to let sub-connectors *compose* their hits for one request:
+        # each connector is offered the tokens the earlier ones did not cover,
+        # instead of the first one with a hit taking the whole request. Opt-in
+        # because it changes how many tokens each sub-connector is asked to
+        # load; see `get_num_new_matched_tokens`.
+        self._compose_connectors = bool(
+            vllm_config.kv_transfer_config.get_from_extra_config(
+                "compose_connectors", False
+            )
+        )
+
+        # A mapping from request id to {connector index: number of tokens that
+        # connector is loading}. Without composition this holds at most one
+        # entry -- the connector chosen to load the request.
+        self._requests_to_connector: dict[str, dict[int, int]] = {}
 
         # Keeps track of *additional* remaining async saves (beyond 1) to be
-        # finished per request. Not needed for async loads since we only allow
-        # a single connector to load.
+        # finished per request.
         # Propagated from scheduler to worker side via the connector metadata.
         self._extra_async_saves: dict[str, int] = {}
+
+        # Same, for async loads: with composition more than one connector can
+        # be loading a single request, and the scheduler must not resume it
+        # until all of them are done. Without composition this stays empty.
+        # Propagated from scheduler to worker side via the connector metadata.
+        self._extra_async_loads: dict[str, int] = {}
 
     @property
     def supports_divergent_local_hybrid_hits(self) -> bool:
@@ -271,6 +289,8 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         assert isinstance(connector_metadata, MultiKVConnectorMetadata)
         if connector_metadata.extra_async_saves:
             self._extra_async_saves.update(connector_metadata.extra_async_saves)
+        if connector_metadata.extra_async_loads:
+            self._extra_async_loads.update(connector_metadata.extra_async_loads)
         for c, cm in zip(self._connectors, connector_metadata.metadata):
             c.bind_connector_metadata(cm)
         super().bind_connector_metadata(connector_metadata)
@@ -327,23 +347,42 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
             sending, recving = c.get_finished(finished_req_ids)
             if not recving and not sending:
                 continue
-            # Aggregate finished recving request ids.
-            finished_recving.update(recving or ())
+            # Aggregate finished recving request ids - only include once we've
+            # drained the "extra" count, exactly as for sends below. With
+            # composition more than one connector loads a single request, and
+            # the scheduler must not be told the load is complete until the
+            # last of them reports: the first report moves the request out of
+            # WAITING_FOR_REMOTE_KVS, so a second one would hit
+            # `assert RequestStatus.is_finished(req.status)` in
+            # `Scheduler._update_from_kv_xfer_finished` and kill EngineCore.
+            for req_id in recving or ():
+                if self._drain_extra(self._extra_async_loads, req_id):
+                    finished_recving.add(req_id)
             # Aggregate finished sending request ids - only include
             # once we've drained the "extra" count (for cases where
             # more than one connector is async-saving the same request).
             for req_id in sending or ():
-                extra_pending = self._extra_async_saves.get(req_id)
-                if extra_pending is None:
+                if self._drain_extra(self._extra_async_saves, req_id):
                     finished_sending.add(req_id)
-                    continue
-                assert extra_pending > 0
-                if extra_pending == 1:
-                    del self._extra_async_saves[req_id]
-                else:
-                    self._extra_async_saves[req_id] = extra_pending - 1
 
         return finished_sending or None, finished_recving or None
+
+    @staticmethod
+    def _drain_extra(extra: dict[str, int], req_id: str) -> bool:
+        """Whether this is the last connector to report `req_id`.
+
+        `extra` holds the number of reports still expected *beyond* this one.
+        A missing entry means no other connector is working on the request.
+        """
+        extra_pending = extra.get(req_id)
+        if extra_pending is None:
+            return True
+        assert extra_pending > 0
+        if extra_pending == 1:
+            del extra[req_id]
+        else:
+            extra[req_id] = extra_pending - 1
+        return False
 
     def get_block_ids_with_load_errors(self) -> set[int]:
         agg_block_ids: set[int] = set()
@@ -393,33 +432,77 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         request: "Request",
         num_computed_tokens: int,
     ) -> tuple[int | None, bool]:
-        to_return = (0, False)
+        """Ask each sub-connector how many tokens it can supply.
+
+        Default (`compose_connectors` off): the first connector reporting a
+        non-zero count is assigned the whole request and the rest contribute
+        nothing, even when they hold tokens the winner does not.
+
+        With `compose_connectors` on, each connector is instead offered the
+        tokens the earlier ones did not cover, by advancing the
+        `num_computed_tokens` we pass down. That is the same "everything up to
+        here is already covered" contract the scheduler uses, so a connector
+        needs no changes to participate -- it simply reports the prefix it can
+        serve beyond what it is told exists, and returning 0 opts it out.
+
+        Composition is restricted to connectors that agree with the first
+        contributor on `load_async`: the scheduler tracks one load mode per
+        request, so mixing a synchronous loader (which loads inside the forward
+        pass) with an asynchronous one (which loads between steps) is not
+        expressible. Connectors that disagree are offered nothing.
+        """
+        per_connector: dict[int, int] = {}
+        total = 0
+        load_async_mode: bool | None = None
         for i, c in enumerate(self._connectors):
+            # Only advance the offer when composing. Otherwise every connector
+            # is asked exactly the question the scheduler asked us, so the
+            # first-hit-takes-all path is bit-for-bit unchanged.
+            covered = total if self._compose_connectors else 0
             toks, load_async = c.get_num_new_matched_tokens(
-                request, num_computed_tokens
+                request, num_computed_tokens + covered
             )
             # If there is a connector still looking up the matches,
             # we return None to indicate that we are not done yet.
             if toks is None:
                 return (None, False)
-            # The first connector that has new matched tokens will be assigned
-            # to this request.
-            if to_return[0] == 0 and toks > 0:
-                self._requests_to_connector[request.request_id] = i
-                to_return = (toks, load_async)
-        return to_return
+            if toks == 0:
+                continue
+            if load_async_mode is None:
+                # First contributor decides the load mode for this request.
+                load_async_mode = load_async
+            elif not self._compose_connectors or load_async != load_async_mode:
+                # Either we are not composing (first hit takes everything), or
+                # this connector cannot be combined with the ones before it.
+                continue
+            per_connector[i] = toks
+            total += toks
+
+        if not per_connector:
+            return (0, False)
+
+        self._requests_to_connector[request.request_id] = per_connector
+        if len(per_connector) > 1:
+            self._extra_async_loads[request.request_id] = len(per_connector) - 1
+        assert load_async_mode is not None
+        return (total, load_async_mode)
 
     def update_state_after_alloc(
         self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
     ):
-        chosen_connector = self._requests_to_connector.get(request.request_id, -1)
+        per_connector = self._requests_to_connector.get(request.request_id) or {}
+        # `num_external_tokens` is the scheduler's final say and can be lower
+        # than what we asked for; hand it out in connector order so the tail
+        # connectors are the ones that lose tokens, and pass 0 to a connector
+        # once the budget runs out so it skips its load. It is also 0 on the
+        # second call for async-load requests, which correctly tells every
+        # sub-connector there is nothing more to do.
+        budget = num_external_tokens
         for i, c in enumerate(self._connectors):
-            if i == chosen_connector:
-                # Forward call to the chosen connector (if any).
-                c.update_state_after_alloc(request, blocks, num_external_tokens)
-            else:
-                # Other connectors still receive the request's real blocks
-                c.update_state_after_alloc(request, blocks, 0)
+            share = min(per_connector.get(i, 0), budget)
+            budget -= share
+            # Every connector still receives the request's real blocks.
+            c.update_state_after_alloc(request, blocks, share)
 
     def on_new_request(self, request: "Request") -> None:
         for c in self._connectors:
@@ -436,6 +519,9 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         if self._extra_async_saves:
             metadata.extra_async_saves = self._extra_async_saves
             self._extra_async_saves = {}
+        if self._extra_async_loads:
+            metadata.extra_async_loads = self._extra_async_loads
+            self._extra_async_loads = {}
         return metadata
 
     def update_connector_output(self, connector_output: KVConnectorOutput):


### PR DESCRIPTION
## Purpose

Two related things, one of which is a live bug.

**1. `MultiConnector` cannot combine its sub-connectors.** It is winner-takes-all: the first sub-connector whose `get_num_new_matched_tokens` returns a non-zero count is assigned the whole request (`self._requests_to_connector[request.request_id] = i`), and every other sub-connector is called with `0`. There is no summation, so tokens a *later* connector holds but the winner does not are recomputed even though they were cached.

This PR adds an opt-in `compose_connectors` mode that offers each connector the tokens the earlier ones did not cover, by advancing the `num_computed_tokens` passed down. That is the same "everything up to here is already covered" contract the scheduler uses when it calls us, so a sub-connector needs **no changes** to participate — it reports the prefix it can serve beyond what it is told exists, and returning `0` opts out.

**2. `finished_recving` is not counted, and that is a bug today.** `get_finished` already drains an "extra" count for saves:

```python
finished_recving.update(recving or ())          # <- blind union
for req_id in sending or ():                    # <- counted via _extra_async_saves
    extra_pending = self._extra_async_saves.get(req_id)
    ...
```

The comment on `_extra_async_saves` says loads need no equivalent because "we only allow a single connector to load" — but nothing enforces that. Any two sub-connectors that both match one request each report it through `get_finished`; the first report moves the request out of `WAITING_FOR_REMOTE_KVS`, and the second lands in the `else` branch of `_update_from_kv_xfer_finished`:

```python
File "vllm/v1/core/sched/scheduler.py", in _update_from_kv_xfer_finished
    assert RequestStatus.is_finished(req.status)
AssertionError
```

EngineCore dies and the API server returns `500 EngineDeadError` for everything after. Reproduced deterministically with `MultiConnector` over `[NixlConnector, LMCacheMPConnector]` in a prefill/decode disaggregated deployment. Wrapping each sub-connector's `get_finished` showed both reporting the same id in consecutive steps:

```
[1] LMCacheMPConnector.get_finished -> recving=['cmpl-...-0-9d1eed60']
    scheduler: recving=[...] status={'cmpl-...': 'WAITING_FOR_REMOTE_KVS'}   <- ok
[0] NixlConnector.get_finished      -> recving=['cmpl-...-0-9d1eed60']
    scheduler: recving=[...] status={'cmpl-...': 'RUNNING'}                  <- AssertionError
```

Composition *requires* fixing this, since it deliberately has several connectors loading one request. So the PR mirrors the save-side accounting with `_extra_async_loads`, propagated scheduler → worker through the connector metadata exactly as `extra_async_saves` is, and factors the shared drain into `_drain_extra`.

### Behaviour with the flag off

Unchanged. Every connector is asked exactly the question the scheduler asked us (the offer is only advanced when composing), at most one is granted tokens, and no `_extra_async_loads` entry is created so recv reports are forwarded immediately as before. A regression test pins this.

### Deliberate restriction

Composition only combines connectors that agree with the first contributor on `load_async`. The scheduler tracks one load mode per request, so mixing a synchronous loader (loads inside the forward pass) with an asynchronous one (loads between steps) is not expressible on the current interface. Connectors that disagree are offered nothing rather than silently mis-scheduled.

### Usage

```json
{
  "kv_connector": "MultiConnector",
  "kv_role": "kv_both",
  "kv_connector_extra_config": {
    "compose_connectors": true,
    "connectors": [
      {"kv_connector": "NixlConnector",     "kv_role": "kv_both"},
      {"kv_connector": "LMCacheMPConnector", "kv_role": "kv_both"}
    ]
  }
}
```

## Test Plan

`tests/v1/kv_connector/unit/test_multi_connector.py` — 9 new tests:

| test | pins |
|---|---|
| `test_compose_off_first_hit_takes_the_request` | flag off is unchanged: same offer to every connector, one grantee, no load accounting |
| `test_compose_on_sums_and_offers_the_remainder` | totals sum; connector 1 offered `num_computed_tokens + t0`; both granted their share |
| `test_compose_on_skips_connectors_with_no_hit` | a `0` report opts out |
| `test_compose_on_refuses_to_mix_load_modes` | sync + async are not combined |
| `test_compose_on_pending_lookup_still_defers` | a `None` from any connector still returns `(None, False)` and records nothing |
| `test_compose_on_respects_a_reduced_allocation` | a smaller `num_external_tokens` is spent in connector order |
| `test_extra_async_loads_reach_the_worker` | the count ships in the metadata and is not shipped twice |
| `test_get_finished_reports_recving_only_after_the_last_loader` | **the crash**: first of two reports is withheld, second completes |
| `test_get_finished_forwards_a_lone_loader_immediately` | a single loader is not delayed |

```bash
pytest tests/v1/kv_connector/unit/test_multi_connector.py
```

## Test Result

**9/9 pass**, and one of them caught a real regression during development: an earlier draft advanced the offer unconditionally, which changed what the second connector was asked in the flag-off path. `test_compose_off_first_hit_takes_the_request` failed with `assert 8 == 0` and the offer is now only advanced when composing.

`ruff check` and `ruff format --check` clean on both files.

**Caveat on how the tests were run — please treat CI as the real gate.** I could not build vLLM from source in my environment (`ImportError: cannot import name '_StreamPlaceholder' from partially initialized module 'vllm.utils.torch_utils'`, and `tests/conftest.py` needs `tblib`). To get real execution evidence rather than none, I ported the identical change onto the installed vLLM in my venv — the touched regions are byte-identical between that build and `main` apart from one `empty_blocks` line this PR rewrites anyway — and ran the 9 tests against it, then restored the venv and confirmed it byte-matched its backup. So the *logic* is executed and verified; the *integration against this tree* is not, and I have not run the nixl integration suites.

End-to-end measurement on a prefill/decode disaggregated deployment (Qwen3-4B, `--block-size 1024`, `--no-enable-prefix-caching`, prompt of 2560 tokens whose first 2048 were in the second connector's cache):

| connectors | total computed tokens | transfer | median latency |
|---|---|---|---|
| `[nixl]` | 2560 | 432 MiB | 0.425 s |
| `[lmcache, nixl]` | 1024 (512 duplicated) | 0 | 0.435 s |
| `[nixl, lmcache]` | **EngineCore crash** | — | — |
| `[nixl, lmcache]` + this PR | **512** | 432 MiB | 0.389 s |

Generated output was verified token-identical to a reference instance running with no KV connector at all (`temperature=0`, deterministic prompt, `max_tokens=32`, 3/3 repeats). Latency is informational — a 2560-token prompt is too small on that hardware to separate a 5x difference in computed tokens.

Note that the third row crashes for a reason that also exists in `LMCacheMPConnector`, which ignores its `num_external_tokens` argument; that side is fixed separately in LMCache/LMCache#4355. This PR is what stops *any* pair of loading connectors from taking EngineCore down, and what makes their hits add up instead of one being discarded.

### Known limitation

`_extra_async_loads` can leak an entry if a request is aborted between the count being shipped and the loads reporting. `_extra_async_saves` has the same exposure today; I kept the mirror exact rather than fixing one side asymmetrically. Happy to address both in this PR if preferred.
