### PR TITLE
[Bugfix][Core] Don't cache the reader's ring slot across acquire_read retries

### DIFF
--- a/tests/distributed/test_shm_broadcast.py
+++ b/tests/distributed/test_shm_broadcast.py
@@ -633,6 +633,83 @@ def test_acquire_read_releases_slot_when_reader_raises():
         reader.shutdown()
 
 
+def test_concurrent_readers_are_not_stranded_on_stale_ring_slot():
+    """Two threads sharing one reader must both make progress.
+
+    `acquire_read` used to bind the metadata slot for `current_idx` once,
+    outside its retry loop. Once one thread consumed a block and advanced
+    `current_idx`, the other kept polling the slot it had already captured and
+    blocked until its own timeout, even though a later message was ready.
+    """
+    writer = MessageQueue(
+        n_reader=1,
+        n_local_reader=1,
+        max_chunk_bytes=1024 * 1024,
+        max_chunks=10,
+    )
+    reader = MessageQueue.create_from_handle(writer.export_handle(), rank=0)
+
+    results: dict[str, object] = {}
+    parked: set[str] = set()
+    parked_lock = threading.Lock()
+    both_parked = threading.Event()
+    real_wait = reader._spin_condition.wait
+
+    def counting_wait(*args, **kwargs):
+        with parked_lock:
+            parked.add(threading.current_thread().name)
+            if len(parked) == 2:
+                both_parked.set()
+        return real_wait(*args, **kwargs)
+
+    def dequeue_once(name: str):
+        try:
+            results[name] = reader.dequeue(timeout=30.0)
+        except Exception as exc:  # noqa: BLE001
+            results[name] = exc
+
+    threads = [
+        threading.Thread(target=dequeue_once, args=(name,), name=name, daemon=True)
+        for name in ("reader-a", "reader-b")
+    ]
+    try:
+        writer.wait_until_ready()
+        reader.wait_until_ready()
+
+        with mock.patch.object(
+            reader._spin_condition, "wait", side_effect=counting_wait
+        ):
+            for t in threads:
+                t.start()
+            # Both threads have to be waiting on the same `current_idx` with no
+            # message available: that is the state the bug was triggered from.
+            assert both_parked.wait(timeout=10)
+
+            writer.enqueue("first")
+            writer.enqueue("second")
+
+            for t in threads:
+                t.join(timeout=15)
+            assert not any(t.is_alive() for t in threads)
+    finally:
+        writer.shutdown()
+        reader.shutdown()
+        for socket in (
+            writer.local_socket,
+            writer._spin_condition.local_notify_socket,
+            reader.local_socket,
+            reader._spin_condition.local_notify_socket,
+            reader._spin_condition.read_cancel_socket,
+            reader._spin_condition.write_cancel_socket,
+        ):
+            socket.close(linger=0)
+
+    for name, value in results.items():
+        if isinstance(value, BaseException):
+            raise AssertionError(f"{name} failed to dequeue") from value
+    assert sorted(results.values()) == ["first", "second"]
+
+
 def test_warning_logs(caplog_vllm):
     """
     Test that warning logs are emitted at VLLM_RINGBUFFER_WARNING_INTERVAL intervals

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -768,8 +768,14 @@ class MessageQueue:
         read_timeout = self.ReadTimeoutWithWarnings(
             timeout=timeout, should_warn=not indefinite
         )
-        with self.buffer.get_metadata(self.current_idx) as metadata_buffer:
-            while True:
+        while True:
+            # Re-read `current_idx` on every attempt and use that single value
+            # for both the metadata and the data slot. Another thread sharing
+            # this queue can advance `current_idx`, and a metadata slot cached
+            # across attempts would leave this reader spinning on a block the
+            # writer has already moved past.
+            current_idx = self.current_idx
+            with self.buffer.get_metadata(current_idx) as metadata_buffer:
 
                 def check():
                     memory_fence()
@@ -806,7 +812,7 @@ class MessageQueue:
                     continue
                 # found a block that is not read by this reader
                 # let caller read from the buffer
-                with self.buffer.get_data(self.current_idx) as buf:
+                with self.buffer.get_data(current_idx) as buf:
                     try:
                         yield buf
                     finally:
@@ -816,8 +822,7 @@ class MessageQueue:
                         # Without this, writer may not see our read completion and
                         # could wait indefinitely for all readers to finish.
                         memory_fence()
-                        next_idx = self.current_idx + 1
-                        self.current_idx = next_idx % self.buffer.max_chunks
+                        self.current_idx = (current_idx + 1) % self.buffer.max_chunks
                         self._spin_condition.record_read()
                 break
 


### PR DESCRIPTION
## Purpose

Fixes #50398.

`MessageQueue.acquire_read` bound the metadata slot for `current_idx` **once, outside** its
retry loop:

```python
with self.buffer.get_metadata(self.current_idx) as metadata_buffer:
    while True:
        ...
```

`current_idx` is mutable instance state. When a second thread sharing the queue consumes a
block and advances it, the first thread keeps polling the slot it captured before the loop —
a block the writer has already moved past — and blocks until its own timeout even though a
later message is ready. That is the hang reported in #50398 (originally
vllm-project/vllm-omni#5554).

The same staleness has a second consequence: `get_data` still re-read `self.current_idx`, so
the metadata slot and the data slot could refer to **different blocks**, which would return
silently wrong bytes rather than hanging.

This is a regression from #34856 (`40b2f1c`), which hoisted the `get_metadata` call out of
the loop. Note `acquire_write` was not changed by that commit and still re-reads the index
every iteration.

## Fix

Re-read `current_idx` once per attempt and use that single local value for **both** the
metadata and the data slot, restoring the shape `acquire_write` already uses.

The reverted hoist only costs an extra memoryview slice on the **retry** path, which already
pays for a `memory_fence()` and a `_spin_condition.wait()` zmq poll — the fast path (block
already available) enters the context manager exactly once either way, as before.

### Scope / what this does not fix

This fixes the reported blocking regression. `MessageQueue` remains **not** thread-safe in
general: two threads can still claim the same `current_idx` concurrently and get duplicate
delivery. Making concurrent `dequeue` fully correct needs a lock around the claim, which is a
design decision for maintainers — happy to follow up if that is wanted here.

## Not a duplicate

Checked before opening:

- No open PR references #50398, and the issue has no linked PR and no assignee.
- Searched open PRs touching `shm_broadcast` / `MessageQueue` / `acquire_read` — nothing
  addressing this.
- Nearby recent bug reports are separately claimed and untouched here (#50456 → #50462,
  #50381 → #50393, #50427 → #50483).

## Testing

Added `test_concurrent_readers_are_not_stranded_on_stale_ring_slot` to
`tests/distributed/test_shm_broadcast.py`. It parks two threads inside `acquire_read` on the
same `current_idx` (deterministically, by counting entries into `_spin_condition.wait`), then
enqueues two messages and asserts both threads return with distinct payloads.

The test is a genuine regression guard — it **fails on `main`** and passes with this change:

```
# with the source fix reverted, test kept:
tests/distributed/test_shm_broadcast.py::test_concurrent_readers_are_not_stranded_on_stale_ring_slot FAILED
>               assert not any(t.is_alive() for t in threads)
E               assert not True
================ 1 failed, 28 deselected in 15.22s =================

# with the fix:
================ 1 passed, 28 deselected in 0.13s =================
```

Full in-process suite for the touched file:

```
$ python -m pytest tests/distributed/test_shm_broadcast.py -q \
    --deselect ...::test_shm_broadcast --deselect ...::test_message_queue_shutdown_busy \
    --deselect ...::test_message_queue_shutdown_idle --deselect ...::test_message_queue_idle_wake \
    --deselect ...::test_message_queue_busy_to_idle --deselect ...::test_tensor_broadcast
22 passed, 1 skipped, 6 deselected, 3 warnings in 2.09s
```

The 6 deselected tests spawn processes and call gloo `dist.barrier()` in a forked child, which
SIGABRTs/hangs on the macOS arm64 machine used here — verified to behave identically on a clean
`main`, so it is environmental and not caused by this change. Those need to run in CI.

Lint: `ruff check` and `ruff format --check` clean on both files.

## Model evaluation

Not applicable — this changes only shared-memory ring-buffer index bookkeeping in the
reader's control flow. It does not touch model execution, sampling, or any tensor path, so
generated output is unaffected.

## Note

AI assistance (Claude) was used to investigate and draft this change. I have reviewed every
changed line, reproduced the original hang, and run the tests reported above myself.
