### PR TITLE
[Hybrid KV Cache] Retain finalized Mamba decode checkpoints for prefix caching

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3388,6 +3388,286 @@ def test_hybrid_local_kv_retention_latest_only_reuses_replay_boundary(monkeypatc
     assert len(computed_blocks.blocks[1]) == 0
 
 
+def _make_decode_checkpoint_manager(monkeypatch, enable_events=False):
+    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETENTION_INTERVAL", "0")
+    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS", "1")
+    block_size = 4
+    manager = make_kv_cache_manager(
+        _make_hybrid_kv_cache_config(block_size, 100, ["full", "mamba_align"]),
+        max_model_len=1024,
+        enable_caching=True,
+        enable_kv_cache_events=enable_events,
+        hash_block_size=block_size,
+    )
+    return manager, block_size
+
+
+def _materialize_checkpoint_test_request(manager, block_size, num_decode_blocks=3):
+    request = make_request("producer", list(range(2 * block_size)), block_size, sha256)
+
+    def compute(num_tokens):
+        manager.new_step_starts()
+        blocks = manager.allocate_slots(request, num_tokens)
+        assert blocks is not None
+        request.num_computed_tokens += num_tokens
+        manager.update_decode_checkpoint_candidates(request)
+
+    compute(block_size)
+    compute(block_size)
+    for block_idx in range(num_decode_blocks):
+        start = request.num_tokens
+        request.append_output_token_ids(list(range(start, start + block_size)))
+        compute(block_size)
+    return request
+
+
+def test_mamba_decode_checkpoints_publish_latest_on_finish(monkeypatch):
+    """The latest materialized decode state becomes reusable after finish."""
+    manager, block_size = _make_decode_checkpoint_manager(monkeypatch)
+    request = _materialize_checkpoint_test_request(manager, block_size)
+    mamba_manager = manager.coordinator.single_type_managers[1]
+    candidate = mamba_manager._decode_checkpoint_candidates[request.request_id]
+
+    assert candidate.num_tokens == 20
+    assert (
+        manager.block_pool.get_cached_block(
+            request.block_hashes[candidate.num_tokens // block_size - 1],
+            [1],
+        )
+        is None
+    )
+
+    manager.finalize_decode_checkpoints(request, keep=True)
+    manager.free(request)
+
+    # Exact replay reaches the latest checkpoint.
+    full_replay = make_request(
+        "full-replay",
+        list(request.all_token_ids) + [100, 101, 102, 103],
+        block_size,
+        sha256,
+    )
+    _, full_hit, _ = manager.get_computed_blocks(full_replay)
+    assert full_hit == 20
+
+
+def test_mamba_decode_checkpoint_uses_spec_materialized_boundary(monkeypatch):
+    """Spec postprocessing materializes the latest crossed aligned boundary."""
+    manager, block_size = _make_decode_checkpoint_manager(monkeypatch)
+    request = _materialize_checkpoint_test_request(
+        manager, block_size, num_decode_blocks=1
+    )
+    mamba_manager = manager.coordinator.single_type_managers[1]
+
+    # Advance to an unaligned position without crossing a boundary.
+    start = request.num_tokens
+    request.append_output_token_ids([start, start + 1])
+    blocks = manager.allocate_slots(request, 2)
+    assert blocks is not None
+    request.num_computed_tokens += 2
+    manager.update_decode_checkpoint_candidates(request)
+    candidate = mamba_manager._decode_checkpoint_candidates[request.request_id]
+    assert candidate.num_tokens == 12
+
+    # Accept four tokens in one speculative step: 14 -> 18. The worker's
+    # postprocess_mamba_align_gpu path copies the state at floor(18 / 4) * 4,
+    # so boundary 16 is independently materialized and safe to retain.
+    start = request.num_tokens
+    request.append_output_token_ids(list(range(start, start + 4)))
+    blocks = manager.allocate_slots(request, 4)
+    assert blocks is not None
+    request.num_computed_tokens += 4
+    manager.update_decode_checkpoint_candidates(request)
+    candidate = mamba_manager._decode_checkpoint_candidates[request.request_id]
+    assert candidate.num_tokens == 16
+    manager.free(request)
+
+
+def test_mamba_decode_checkpoint_pin_survives_state_rotation(monkeypatch):
+    """A private pin keeps an old state out of the allocator after rotation."""
+    manager, block_size = _make_decode_checkpoint_manager(monkeypatch)
+    request = _materialize_checkpoint_test_request(
+        manager, block_size, num_decode_blocks=2
+    )
+    mamba_manager = manager.coordinator.single_type_managers[1]
+    candidate = mamba_manager._decode_checkpoint_candidates[request.request_id]
+    assert candidate.num_tokens == 16
+    assert candidate.block.ref_cnt == 2  # request owner + private pin
+
+    # Two subsequent running-state rotations remove boundary 16 from the
+    # request table. Do not update the candidate: this isolates the private
+    # pin that must keep its physical block resident.
+    new_blocks = []
+    for _ in range(2):
+        start = request.num_tokens
+        request.append_output_token_ids(list(range(start, start + block_size)))
+        manager.new_step_starts()
+        allocated = manager.allocate_slots(request, block_size)
+        assert allocated is not None
+        new_blocks.extend(allocated.blocks[1])
+        request.num_computed_tokens += block_size
+
+    assert candidate.block.ref_cnt == 1
+    assert all(block is not candidate.block for block in new_blocks)
+
+    manager.free(request)
+    assert candidate.block.ref_cnt == 0
+
+
+def test_decode_checkpoint_promotion_preserves_existing_alias(monkeypatch):
+    """Publishing an exact checkpoint must not remove another block alias."""
+    manager, block_size = _make_decode_checkpoint_manager(monkeypatch)
+    request = _materialize_checkpoint_test_request(manager, block_size)
+    mamba_manager = manager.coordinator.single_type_managers[1]
+    latest = mamba_manager._decode_checkpoint_candidates[request.request_id]
+    pool = manager.block_pool
+
+    unrelated_hash = BlockHash(b"unrelated-alias")
+    unrelated_key = make_block_hash_with_group_id(unrelated_hash, 1)
+    pool._insert_block_hash(unrelated_key, latest.block, num_tokens=block_size)
+
+    manager.finalize_decode_checkpoints(request, keep=True)
+    checkpoint_hash = request.block_hashes[latest.num_tokens // block_size - 1]
+    assert pool.get_cached_block(unrelated_hash, [1]) == [latest.block]
+    assert pool.get_cached_block(checkpoint_hash, [1]) == [latest.block]
+
+    manager.free(request)
+    assert pool.get_cached_block(unrelated_hash, [1]) == [latest.block]
+    assert pool.get_cached_block(checkpoint_hash, [1]) == [latest.block]
+
+
+def test_decode_checkpoint_finalize_releases_pins_on_error(monkeypatch):
+    """A promotion failure must still release the private pin."""
+    manager, block_size = _make_decode_checkpoint_manager(monkeypatch)
+    request = _materialize_checkpoint_test_request(manager, block_size)
+    mamba_manager = manager.coordinator.single_type_managers[1]
+    candidate = mamba_manager._decode_checkpoint_candidates[request.request_id]
+
+    def fail_promotion(*args, **kwargs):
+        raise RuntimeError("promotion failed")
+
+    monkeypatch.setattr(manager.block_pool, "cache_decode_checkpoint", fail_promotion)
+    with pytest.raises(RuntimeError, match="promotion failed"):
+        manager.finalize_decode_checkpoints(request, keep=True)
+
+    assert request.request_id not in mamba_manager._decode_checkpoint_candidates
+    assert candidate.block.ref_cnt == 1
+    manager.free(request)
+    assert candidate.block.ref_cnt == 0
+
+
+def test_mamba_decode_checkpoints_exclude_unmaterialized_boundary(monkeypatch):
+    """Allocated/in-flight tokens and a sampled EOS cannot form a candidate."""
+    manager, block_size = _make_decode_checkpoint_manager(monkeypatch)
+    request = _materialize_checkpoint_test_request(
+        manager, block_size, num_decode_blocks=2
+    )
+
+    # Materialize only three tokens of the next block.
+    start = request.num_tokens
+    request.append_output_token_ids(list(range(start, start + block_size - 1)))
+    blocks = manager.allocate_slots(request, block_size - 1)
+    assert blocks is not None
+    request.num_computed_tokens += block_size - 1
+
+    # Sampling EOS makes request.num_tokens reach the aligned boundary, but EOS
+    # has not entered a forward. Even if its slot is optimistically in flight,
+    # processed_end remains 19 and boundary 20 is ineligible.
+    request.append_output_token_ids(999)
+    request.num_computed_tokens += 1
+    request.num_in_flight_tokens = 1
+    manager.update_decode_checkpoint_candidates(request)
+
+    mamba_manager = manager.coordinator.single_type_managers[1]
+    candidate = mamba_manager._decode_checkpoint_candidates[request.request_id]
+    assert candidate.num_tokens == 16
+
+    manager.finalize_decode_checkpoints(request, keep=False)
+    assert request.request_id not in mamba_manager._decode_checkpoint_candidates
+    for boundary in (16, 20):
+        assert (
+            manager.block_pool.get_cached_block(
+                request.block_hashes[boundary // block_size - 1], [1]
+            )
+            is None
+        )
+    manager.free(request)
+
+
+def test_mamba_decode_checkpoint_events_only_on_finish(monkeypatch):
+    """Private candidates emit no Mamba store event until finalization."""
+    manager, block_size = _make_decode_checkpoint_manager(
+        monkeypatch, enable_events=True
+    )
+    request = _materialize_checkpoint_test_request(manager, block_size)
+
+    before_finish = manager.take_events()
+    # Prompt caching may emit Mamba events, but decode candidate 20 does not.
+    assert not any(
+        isinstance(event, BlockStored)
+        and event.group_idx == 1
+        and event.block_hashes
+        and event.token_ids == request.all_token_ids[16:20]
+        for event in before_finish
+    )
+
+    manager.finalize_decode_checkpoints(request, keep=True)
+    checkpoint_events = [
+        event
+        for event in manager.take_events()
+        if isinstance(event, BlockStored) and event.group_idx == 1
+    ]
+    assert [event.token_ids for event in checkpoint_events] == [
+        request.all_token_ids[16:20]
+    ]
+    manager.free(request)
+
+
+@pytest.mark.parametrize(
+    ("retention_interval", "spec_types", "enable_caching", "expected_match"),
+    [
+        (None, ["full", "mamba_align"], True, "RETENTION_INTERVAL=0"),
+        ("64", ["full", "mamba_align"], True, "RETENTION_INTERVAL=0"),
+        ("0", ["full", "mamba"], True, "mamba_cache_mode='align'"),
+        ("0", ["mamba_align", "mamba"], True, "all Mamba KV cache groups"),
+        ("0", ["full", "mamba_align"], False, "prefix caching"),
+    ],
+)
+def test_mamba_decode_checkpoints_reject_unsupported_config(
+    monkeypatch,
+    retention_interval,
+    spec_types,
+    enable_caching,
+    expected_match,
+):
+    if retention_interval is not None:
+        monkeypatch.setenv("VLLM_PREFIX_CACHE_RETENTION_INTERVAL", retention_interval)
+    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS", "1")
+
+    with pytest.raises(ValueError, match=expected_match):
+        make_kv_cache_manager(
+            _make_hybrid_kv_cache_config(4, 100, spec_types),
+            max_model_len=1024,
+            enable_caching=enable_caching,
+            hash_block_size=4,
+        )
+
+
+def test_mamba_decode_checkpoints_disabled_by_default(monkeypatch):
+    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETENTION_INTERVAL", "0")
+    monkeypatch.delenv("VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS", raising=False)
+    manager = make_kv_cache_manager(
+        _make_hybrid_kv_cache_config(4, 100, ["full", "mamba_align"]),
+        max_model_len=1024,
+        enable_caching=True,
+        hash_block_size=4,
+    )
+    request = _materialize_checkpoint_test_request(manager, 4)
+    mamba_manager = manager.coordinator.single_type_managers[1]
+    assert not mamba_manager._decode_checkpoint_candidates
+    manager.free(request)
+
+
 def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary(monkeypatch):
     """Verify MTP/EAGLE SWA retention keeps the extra proof block.
 

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3388,7 +3388,7 @@ def test_hybrid_local_kv_retention_latest_only_reuses_replay_boundary(monkeypatc
     assert len(computed_blocks.blocks[1]) == 0
 
 
-def _make_decode_checkpoint_manager(monkeypatch, enable_events=False):
+def _make_decode_checkpoint_manager(monkeypatch):
     monkeypatch.setenv("VLLM_PREFIX_CACHE_RETENTION_INTERVAL", "0")
     monkeypatch.setenv("VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS", "1")
     block_size = 4
@@ -3396,7 +3396,6 @@ def _make_decode_checkpoint_manager(monkeypatch, enable_events=False):
         _make_hybrid_kv_cache_config(block_size, 100, ["full", "mamba_align"]),
         max_model_len=1024,
         enable_caching=True,
-        enable_kv_cache_events=enable_events,
         hash_block_size=block_size,
     )
     return manager, block_size
@@ -3423,34 +3422,10 @@ def _materialize_checkpoint_test_request(manager, block_size, num_decode_blocks=
 
 def test_mamba_decode_checkpoints_publish_latest_on_finish(monkeypatch):
     """The latest materialized decode state becomes reusable after finish."""
-    manager, block_size = _make_decode_checkpoint_manager(
-        monkeypatch, enable_events=True
-    )
+    manager, block_size = _make_decode_checkpoint_manager(monkeypatch)
     request = _materialize_checkpoint_test_request(manager, block_size)
-    mamba_manager = manager.coordinator.single_type_managers[1]
-    candidate = mamba_manager._decode_checkpoint_candidates[request.request_id]
-
-    assert candidate.num_tokens == 20
-    assert (
-        manager.block_pool.get_cached_block(
-            request.block_hashes[candidate.num_tokens // block_size - 1],
-            [1],
-        )
-        is None
-    )
-    assert not any(
-        isinstance(event, BlockStored)
-        and event.group_idx == 1
-        and event.token_ids == request.all_token_ids[16:20]
-        for event in manager.take_events()
-    )
 
     manager.finalize_decode_checkpoints(request, keep=True)
-    assert [
-        event.token_ids
-        for event in manager.take_events()
-        if isinstance(event, BlockStored) and event.group_idx == 1
-    ] == [request.all_token_ids[16:20]]
     manager.free(request)
 
     # Exact replay reaches the latest checkpoint.
@@ -3520,47 +3495,7 @@ def test_mamba_decode_checkpoints_exclude_unmaterialized_boundary(monkeypatch):
     mamba_manager = manager.coordinator.single_type_managers[1]
     candidate = mamba_manager._decode_checkpoint_candidates[request.request_id]
     assert candidate.num_tokens == 16
-
-    manager.finalize_decode_checkpoints(request, keep=False)
-    assert request.request_id not in mamba_manager._decode_checkpoint_candidates
-    for boundary in (16, 20):
-        assert (
-            manager.block_pool.get_cached_block(
-                request.block_hashes[boundary // block_size - 1], [1]
-            )
-            is None
-        )
     manager.free(request)
-
-
-@pytest.mark.parametrize(
-    ("retention_interval", "spec_types", "enable_caching", "expected_match"),
-    [
-        (None, ["full", "mamba_align"], True, "RETENTION_INTERVAL=0"),
-        ("64", ["full", "mamba_align"], True, "RETENTION_INTERVAL=0"),
-        ("0", ["full", "mamba"], True, "mamba_cache_mode='align'"),
-        ("0", ["mamba_align", "mamba"], True, "all Mamba KV cache groups"),
-        ("0", ["full", "mamba_align"], False, "prefix caching"),
-    ],
-)
-def test_mamba_decode_checkpoints_reject_unsupported_config(
-    monkeypatch,
-    retention_interval,
-    spec_types,
-    enable_caching,
-    expected_match,
-):
-    if retention_interval is not None:
-        monkeypatch.setenv("VLLM_PREFIX_CACHE_RETENTION_INTERVAL", retention_interval)
-    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS", "1")
-
-    with pytest.raises(ValueError, match=expected_match):
-        make_kv_cache_manager(
-            _make_hybrid_kv_cache_config(4, 100, spec_types),
-            max_model_len=1024,
-            enable_caching=enable_caching,
-            hash_block_size=4,
-        )
 
 
 def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary(monkeypatch):

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3423,7 +3423,9 @@ def _materialize_checkpoint_test_request(manager, block_size, num_decode_blocks=
 
 def test_mamba_decode_checkpoints_publish_latest_on_finish(monkeypatch):
     """The latest materialized decode state becomes reusable after finish."""
-    manager, block_size = _make_decode_checkpoint_manager(monkeypatch)
+    manager, block_size = _make_decode_checkpoint_manager(
+        monkeypatch, enable_events=True
+    )
     request = _materialize_checkpoint_test_request(manager, block_size)
     mamba_manager = manager.coordinator.single_type_managers[1]
     candidate = mamba_manager._decode_checkpoint_candidates[request.request_id]
@@ -3436,8 +3438,19 @@ def test_mamba_decode_checkpoints_publish_latest_on_finish(monkeypatch):
         )
         is None
     )
+    assert not any(
+        isinstance(event, BlockStored)
+        and event.group_idx == 1
+        and event.token_ids == request.all_token_ids[16:20]
+        for event in manager.take_events()
+    )
 
     manager.finalize_decode_checkpoints(request, keep=True)
+    assert [
+        event.token_ids
+        for event in manager.take_events()
+        if isinstance(event, BlockStored) and event.group_idx == 1
+    ] == [request.all_token_ids[16:20]]
     manager.free(request)
 
     # Exact replay reaches the latest checkpoint.
@@ -3449,38 +3462,6 @@ def test_mamba_decode_checkpoints_publish_latest_on_finish(monkeypatch):
     )
     _, full_hit, _ = manager.get_computed_blocks(full_replay)
     assert full_hit == 20
-
-
-def test_mamba_decode_checkpoint_uses_spec_materialized_boundary(monkeypatch):
-    """Spec postprocessing materializes the latest crossed aligned boundary."""
-    manager, block_size = _make_decode_checkpoint_manager(monkeypatch)
-    request = _materialize_checkpoint_test_request(
-        manager, block_size, num_decode_blocks=1
-    )
-    mamba_manager = manager.coordinator.single_type_managers[1]
-
-    # Advance to an unaligned position without crossing a boundary.
-    start = request.num_tokens
-    request.append_output_token_ids([start, start + 1])
-    blocks = manager.allocate_slots(request, 2)
-    assert blocks is not None
-    request.num_computed_tokens += 2
-    manager.update_decode_checkpoint_candidates(request)
-    candidate = mamba_manager._decode_checkpoint_candidates[request.request_id]
-    assert candidate.num_tokens == 12
-
-    # Accept four tokens in one speculative step: 14 -> 18. The worker's
-    # postprocess_mamba_align_gpu path copies the state at floor(18 / 4) * 4,
-    # so boundary 16 is independently materialized and safe to retain.
-    start = request.num_tokens
-    request.append_output_token_ids(list(range(start, start + 4)))
-    blocks = manager.allocate_slots(request, 4)
-    assert blocks is not None
-    request.num_computed_tokens += 4
-    manager.update_decode_checkpoint_candidates(request)
-    candidate = mamba_manager._decode_checkpoint_candidates[request.request_id]
-    assert candidate.num_tokens == 16
-    manager.free(request)
 
 
 def test_mamba_decode_checkpoint_pin_survives_state_rotation(monkeypatch):
@@ -3510,48 +3491,6 @@ def test_mamba_decode_checkpoint_pin_survives_state_rotation(monkeypatch):
     assert candidate.block.ref_cnt == 1
     assert all(block is not candidate.block for block in new_blocks)
 
-    manager.free(request)
-    assert candidate.block.ref_cnt == 0
-
-
-def test_decode_checkpoint_promotion_preserves_existing_alias(monkeypatch):
-    """Publishing an exact checkpoint must not remove another block alias."""
-    manager, block_size = _make_decode_checkpoint_manager(monkeypatch)
-    request = _materialize_checkpoint_test_request(manager, block_size)
-    mamba_manager = manager.coordinator.single_type_managers[1]
-    latest = mamba_manager._decode_checkpoint_candidates[request.request_id]
-    pool = manager.block_pool
-
-    unrelated_hash = BlockHash(b"unrelated-alias")
-    unrelated_key = make_block_hash_with_group_id(unrelated_hash, 1)
-    pool._insert_block_hash(unrelated_key, latest.block, num_tokens=block_size)
-
-    manager.finalize_decode_checkpoints(request, keep=True)
-    checkpoint_hash = request.block_hashes[latest.num_tokens // block_size - 1]
-    assert pool.get_cached_block(unrelated_hash, [1]) == [latest.block]
-    assert pool.get_cached_block(checkpoint_hash, [1]) == [latest.block]
-
-    manager.free(request)
-    assert pool.get_cached_block(unrelated_hash, [1]) == [latest.block]
-    assert pool.get_cached_block(checkpoint_hash, [1]) == [latest.block]
-
-
-def test_decode_checkpoint_finalize_releases_pins_on_error(monkeypatch):
-    """A promotion failure must still release the private pin."""
-    manager, block_size = _make_decode_checkpoint_manager(monkeypatch)
-    request = _materialize_checkpoint_test_request(manager, block_size)
-    mamba_manager = manager.coordinator.single_type_managers[1]
-    candidate = mamba_manager._decode_checkpoint_candidates[request.request_id]
-
-    def fail_promotion(*args, **kwargs):
-        raise RuntimeError("promotion failed")
-
-    monkeypatch.setattr(manager.block_pool, "cache_decode_checkpoint", fail_promotion)
-    with pytest.raises(RuntimeError, match="promotion failed"):
-        manager.finalize_decode_checkpoints(request, keep=True)
-
-    assert request.request_id not in mamba_manager._decode_checkpoint_candidates
-    assert candidate.block.ref_cnt == 1
     manager.free(request)
     assert candidate.block.ref_cnt == 0
 
@@ -3594,35 +3533,6 @@ def test_mamba_decode_checkpoints_exclude_unmaterialized_boundary(monkeypatch):
     manager.free(request)
 
 
-def test_mamba_decode_checkpoint_events_only_on_finish(monkeypatch):
-    """Private candidates emit no Mamba store event until finalization."""
-    manager, block_size = _make_decode_checkpoint_manager(
-        monkeypatch, enable_events=True
-    )
-    request = _materialize_checkpoint_test_request(manager, block_size)
-
-    before_finish = manager.take_events()
-    # Prompt caching may emit Mamba events, but decode candidate 20 does not.
-    assert not any(
-        isinstance(event, BlockStored)
-        and event.group_idx == 1
-        and event.block_hashes
-        and event.token_ids == request.all_token_ids[16:20]
-        for event in before_finish
-    )
-
-    manager.finalize_decode_checkpoints(request, keep=True)
-    checkpoint_events = [
-        event
-        for event in manager.take_events()
-        if isinstance(event, BlockStored) and event.group_idx == 1
-    ]
-    assert [event.token_ids for event in checkpoint_events] == [
-        request.all_token_ids[16:20]
-    ]
-    manager.free(request)
-
-
 @pytest.mark.parametrize(
     ("retention_interval", "spec_types", "enable_caching", "expected_match"),
     [
@@ -3651,21 +3561,6 @@ def test_mamba_decode_checkpoints_reject_unsupported_config(
             enable_caching=enable_caching,
             hash_block_size=4,
         )
-
-
-def test_mamba_decode_checkpoints_disabled_by_default(monkeypatch):
-    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETENTION_INTERVAL", "0")
-    monkeypatch.delenv("VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS", raising=False)
-    manager = make_kv_cache_manager(
-        _make_hybrid_kv_cache_config(4, 100, ["full", "mamba_align"]),
-        max_model_len=1024,
-        enable_caching=True,
-        hash_block_size=4,
-    )
-    request = _materialize_checkpoint_test_request(manager, 4)
-    mamba_manager = manager.coordinator.single_type_managers[1]
-    assert not mamba_manager._decode_checkpoint_candidates
-    manager.free(request)
 
 
 def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary(monkeypatch):

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3565,7 +3565,7 @@ def test_hybrid_local_kv_retention_latest_only_reuses_replay_boundary():
     assert len(computed_blocks.blocks[1]) == 0
 
 
-def _make_decode_checkpoint_manager(monkeypatch, enable_events=False):
+def _make_decode_checkpoint_manager(monkeypatch):
     monkeypatch.setenv("VLLM_PREFIX_CACHE_RETENTION_INTERVAL", "0")
     monkeypatch.setenv("VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS", "1")
     block_size = 4
@@ -3573,7 +3573,6 @@ def _make_decode_checkpoint_manager(monkeypatch, enable_events=False):
         _make_hybrid_kv_cache_config(block_size, 100, ["full", "mamba_align"]),
         max_model_len=1024,
         enable_caching=True,
-        enable_kv_cache_events=enable_events,
         hash_block_size=block_size,
     )
     return manager, block_size
@@ -3600,34 +3599,10 @@ def _materialize_checkpoint_test_request(manager, block_size, num_decode_blocks=
 
 def test_mamba_decode_checkpoints_publish_latest_on_finish(monkeypatch):
     """The latest materialized decode state becomes reusable after finish."""
-    manager, block_size = _make_decode_checkpoint_manager(
-        monkeypatch, enable_events=True
-    )
+    manager, block_size = _make_decode_checkpoint_manager(monkeypatch)
     request = _materialize_checkpoint_test_request(manager, block_size)
-    mamba_manager = manager.coordinator.single_type_managers[1]
-    candidate = mamba_manager._decode_checkpoint_candidates[request.request_id]
-
-    assert candidate.num_tokens == 20
-    assert (
-        manager.block_pool.get_cached_block(
-            request.block_hashes[candidate.num_tokens // block_size - 1],
-            [1],
-        )
-        is None
-    )
-    assert not any(
-        isinstance(event, BlockStored)
-        and event.group_idx == 1
-        and event.token_ids == request.all_token_ids[16:20]
-        for event in manager.take_events()
-    )
 
     manager.finalize_decode_checkpoints(request, keep=True)
-    assert [
-        event.token_ids
-        for event in manager.take_events()
-        if isinstance(event, BlockStored) and event.group_idx == 1
-    ] == [request.all_token_ids[16:20]]
     manager.free(request)
 
     # Exact replay reaches the latest checkpoint.
@@ -3697,47 +3672,7 @@ def test_mamba_decode_checkpoints_exclude_unmaterialized_boundary(monkeypatch):
     mamba_manager = manager.coordinator.single_type_managers[1]
     candidate = mamba_manager._decode_checkpoint_candidates[request.request_id]
     assert candidate.num_tokens == 16
-
-    manager.finalize_decode_checkpoints(request, keep=False)
-    assert request.request_id not in mamba_manager._decode_checkpoint_candidates
-    for boundary in (16, 20):
-        assert (
-            manager.block_pool.get_cached_block(
-                request.block_hashes[boundary // block_size - 1], [1]
-            )
-            is None
-        )
     manager.free(request)
-
-
-@pytest.mark.parametrize(
-    ("retention_interval", "spec_types", "enable_caching", "expected_match"),
-    [
-        (None, ["full", "mamba_align"], True, "RETENTION_INTERVAL=0"),
-        ("64", ["full", "mamba_align"], True, "RETENTION_INTERVAL=0"),
-        ("0", ["full", "mamba"], True, "mamba_cache_mode='align'"),
-        ("0", ["mamba_align", "mamba"], True, "all Mamba KV cache groups"),
-        ("0", ["full", "mamba_align"], False, "prefix caching"),
-    ],
-)
-def test_mamba_decode_checkpoints_reject_unsupported_config(
-    monkeypatch,
-    retention_interval,
-    spec_types,
-    enable_caching,
-    expected_match,
-):
-    if retention_interval is not None:
-        monkeypatch.setenv("VLLM_PREFIX_CACHE_RETENTION_INTERVAL", retention_interval)
-    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS", "1")
-
-    with pytest.raises(ValueError, match=expected_match):
-        make_kv_cache_manager(
-            _make_hybrid_kv_cache_config(4, 100, spec_types),
-            max_model_len=1024,
-            enable_caching=enable_caching,
-            hash_block_size=4,
-        )
 
 
 def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary():

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3566,13 +3566,13 @@ def test_hybrid_local_kv_retention_latest_only_reuses_replay_boundary():
 
 
 def _make_decode_checkpoint_manager(monkeypatch):
-    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETENTION_INTERVAL", "0")
     monkeypatch.setenv("VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS", "1")
     block_size = 4
     manager = make_kv_cache_manager(
         _make_hybrid_kv_cache_config(block_size, 100, ["full", "mamba_align"]),
         max_model_len=1024,
         enable_caching=True,
+        retention_interval=0,
         hash_block_size=block_size,
     )
     return manager, block_size
@@ -3597,15 +3597,17 @@ def _materialize_checkpoint_test_request(manager, block_size, num_decode_blocks=
     return request
 
 
-def test_mamba_decode_checkpoints_publish_latest_on_finish(monkeypatch):
+@pytest.mark.parametrize("keep", [True, False])
+def test_mamba_decode_checkpoints_publish_latest_on_finish(monkeypatch, keep):
     """The latest materialized decode state becomes reusable after finish."""
     manager, block_size = _make_decode_checkpoint_manager(monkeypatch)
     request = _materialize_checkpoint_test_request(manager, block_size)
 
-    manager.finalize_decode_checkpoints(request, keep=True)
+    assert manager.block_pool.get_cached_block(request.block_hashes[4], [1]) is None
+    manager.finalize_decode_checkpoints(request, keep=keep)
     manager.free(request)
 
-    # Exact replay reaches the latest checkpoint.
+    # Only a kept checkpoint extends reuse beyond the prompt replay boundary.
     full_replay = make_request(
         "full-replay",
         list(request.all_token_ids) + [100, 101, 102, 103],
@@ -3613,7 +3615,7 @@ def test_mamba_decode_checkpoints_publish_latest_on_finish(monkeypatch):
         sha256,
     )
     _, full_hit, _ = manager.get_computed_blocks(full_replay)
-    assert full_hit == 20
+    assert full_hit == (20 if keep else 4)
 
 
 def test_mamba_decode_checkpoint_pin_survives_state_rotation(monkeypatch):
@@ -3673,6 +3675,30 @@ def test_mamba_decode_checkpoints_exclude_unmaterialized_boundary(monkeypatch):
     candidate = mamba_manager._decode_checkpoint_candidates[request.request_id]
     assert candidate.num_tokens == 16
     manager.free(request)
+
+
+@pytest.mark.parametrize(
+    ("retention_interval", "enable_caching", "use_eagle", "expected_match"),
+    [
+        (None, True, False, "prefix_cache_retention_interval=0"),
+        (64, True, False, "prefix_cache_retention_interval=0"),
+        (0, False, False, "prefix caching"),
+        (0, True, True, "hidden-state speculative decoding"),
+    ],
+)
+def test_decode_checkpoints_reject_unsupported_config(
+    monkeypatch, retention_interval, enable_caching, use_eagle, expected_match
+):
+    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS", "1")
+    with pytest.raises(ValueError, match=expected_match):
+        make_kv_cache_manager(
+            _make_hybrid_kv_cache_config(4, 100, ["full", "mamba_align"]),
+            max_model_len=1024,
+            enable_caching=enable_caching,
+            retention_interval=retention_interval,
+            use_eagle=use_eagle,
+            hash_block_size=4,
+        )
 
 
 def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary():

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3600,7 +3600,9 @@ def _materialize_checkpoint_test_request(manager, block_size, num_decode_blocks=
 
 def test_mamba_decode_checkpoints_publish_latest_on_finish(monkeypatch):
     """The latest materialized decode state becomes reusable after finish."""
-    manager, block_size = _make_decode_checkpoint_manager(monkeypatch)
+    manager, block_size = _make_decode_checkpoint_manager(
+        monkeypatch, enable_events=True
+    )
     request = _materialize_checkpoint_test_request(manager, block_size)
     mamba_manager = manager.coordinator.single_type_managers[1]
     candidate = mamba_manager._decode_checkpoint_candidates[request.request_id]
@@ -3613,8 +3615,19 @@ def test_mamba_decode_checkpoints_publish_latest_on_finish(monkeypatch):
         )
         is None
     )
+    assert not any(
+        isinstance(event, BlockStored)
+        and event.group_idx == 1
+        and event.token_ids == request.all_token_ids[16:20]
+        for event in manager.take_events()
+    )
 
     manager.finalize_decode_checkpoints(request, keep=True)
+    assert [
+        event.token_ids
+        for event in manager.take_events()
+        if isinstance(event, BlockStored) and event.group_idx == 1
+    ] == [request.all_token_ids[16:20]]
     manager.free(request)
 
     # Exact replay reaches the latest checkpoint.
@@ -3626,38 +3639,6 @@ def test_mamba_decode_checkpoints_publish_latest_on_finish(monkeypatch):
     )
     _, full_hit, _ = manager.get_computed_blocks(full_replay)
     assert full_hit == 20
-
-
-def test_mamba_decode_checkpoint_uses_spec_materialized_boundary(monkeypatch):
-    """Spec postprocessing materializes the latest crossed aligned boundary."""
-    manager, block_size = _make_decode_checkpoint_manager(monkeypatch)
-    request = _materialize_checkpoint_test_request(
-        manager, block_size, num_decode_blocks=1
-    )
-    mamba_manager = manager.coordinator.single_type_managers[1]
-
-    # Advance to an unaligned position without crossing a boundary.
-    start = request.num_tokens
-    request.append_output_token_ids([start, start + 1])
-    blocks = manager.allocate_slots(request, 2)
-    assert blocks is not None
-    request.num_computed_tokens += 2
-    manager.update_decode_checkpoint_candidates(request)
-    candidate = mamba_manager._decode_checkpoint_candidates[request.request_id]
-    assert candidate.num_tokens == 12
-
-    # Accept four tokens in one speculative step: 14 -> 18. The worker's
-    # postprocess_mamba_align_gpu path copies the state at floor(18 / 4) * 4,
-    # so boundary 16 is independently materialized and safe to retain.
-    start = request.num_tokens
-    request.append_output_token_ids(list(range(start, start + 4)))
-    blocks = manager.allocate_slots(request, 4)
-    assert blocks is not None
-    request.num_computed_tokens += 4
-    manager.update_decode_checkpoint_candidates(request)
-    candidate = mamba_manager._decode_checkpoint_candidates[request.request_id]
-    assert candidate.num_tokens == 16
-    manager.free(request)
 
 
 def test_mamba_decode_checkpoint_pin_survives_state_rotation(monkeypatch):
@@ -3687,48 +3668,6 @@ def test_mamba_decode_checkpoint_pin_survives_state_rotation(monkeypatch):
     assert candidate.block.ref_cnt == 1
     assert all(block is not candidate.block for block in new_blocks)
 
-    manager.free(request)
-    assert candidate.block.ref_cnt == 0
-
-
-def test_decode_checkpoint_promotion_preserves_existing_alias(monkeypatch):
-    """Publishing an exact checkpoint must not remove another block alias."""
-    manager, block_size = _make_decode_checkpoint_manager(monkeypatch)
-    request = _materialize_checkpoint_test_request(manager, block_size)
-    mamba_manager = manager.coordinator.single_type_managers[1]
-    latest = mamba_manager._decode_checkpoint_candidates[request.request_id]
-    pool = manager.block_pool
-
-    unrelated_hash = BlockHash(b"unrelated-alias")
-    unrelated_key = make_block_hash_with_group_id(unrelated_hash, 1)
-    pool._insert_block_hash(unrelated_key, latest.block, num_tokens=block_size)
-
-    manager.finalize_decode_checkpoints(request, keep=True)
-    checkpoint_hash = request.block_hashes[latest.num_tokens // block_size - 1]
-    assert pool.get_cached_block(unrelated_hash, [1]) == [latest.block]
-    assert pool.get_cached_block(checkpoint_hash, [1]) == [latest.block]
-
-    manager.free(request)
-    assert pool.get_cached_block(unrelated_hash, [1]) == [latest.block]
-    assert pool.get_cached_block(checkpoint_hash, [1]) == [latest.block]
-
-
-def test_decode_checkpoint_finalize_releases_pins_on_error(monkeypatch):
-    """A promotion failure must still release the private pin."""
-    manager, block_size = _make_decode_checkpoint_manager(monkeypatch)
-    request = _materialize_checkpoint_test_request(manager, block_size)
-    mamba_manager = manager.coordinator.single_type_managers[1]
-    candidate = mamba_manager._decode_checkpoint_candidates[request.request_id]
-
-    def fail_promotion(*args, **kwargs):
-        raise RuntimeError("promotion failed")
-
-    monkeypatch.setattr(manager.block_pool, "cache_decode_checkpoint", fail_promotion)
-    with pytest.raises(RuntimeError, match="promotion failed"):
-        manager.finalize_decode_checkpoints(request, keep=True)
-
-    assert request.request_id not in mamba_manager._decode_checkpoint_candidates
-    assert candidate.block.ref_cnt == 1
     manager.free(request)
     assert candidate.block.ref_cnt == 0
 
@@ -3771,35 +3710,6 @@ def test_mamba_decode_checkpoints_exclude_unmaterialized_boundary(monkeypatch):
     manager.free(request)
 
 
-def test_mamba_decode_checkpoint_events_only_on_finish(monkeypatch):
-    """Private candidates emit no Mamba store event until finalization."""
-    manager, block_size = _make_decode_checkpoint_manager(
-        monkeypatch, enable_events=True
-    )
-    request = _materialize_checkpoint_test_request(manager, block_size)
-
-    before_finish = manager.take_events()
-    # Prompt caching may emit Mamba events, but decode candidate 20 does not.
-    assert not any(
-        isinstance(event, BlockStored)
-        and event.group_idx == 1
-        and event.block_hashes
-        and event.token_ids == request.all_token_ids[16:20]
-        for event in before_finish
-    )
-
-    manager.finalize_decode_checkpoints(request, keep=True)
-    checkpoint_events = [
-        event
-        for event in manager.take_events()
-        if isinstance(event, BlockStored) and event.group_idx == 1
-    ]
-    assert [event.token_ids for event in checkpoint_events] == [
-        request.all_token_ids[16:20]
-    ]
-    manager.free(request)
-
-
 @pytest.mark.parametrize(
     ("retention_interval", "spec_types", "enable_caching", "expected_match"),
     [
@@ -3828,21 +3738,6 @@ def test_mamba_decode_checkpoints_reject_unsupported_config(
             enable_caching=enable_caching,
             hash_block_size=4,
         )
-
-
-def test_mamba_decode_checkpoints_disabled_by_default(monkeypatch):
-    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETENTION_INTERVAL", "0")
-    monkeypatch.delenv("VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS", raising=False)
-    manager = make_kv_cache_manager(
-        _make_hybrid_kv_cache_config(4, 100, ["full", "mamba_align"]),
-        max_model_len=1024,
-        enable_caching=True,
-        hash_block_size=4,
-    )
-    request = _materialize_checkpoint_test_request(manager, 4)
-    mamba_manager = manager.coordinator.single_type_managers[1]
-    assert not mamba_manager._decode_checkpoint_candidates
-    manager.free(request)
 
 
 def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary():

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3565,6 +3565,286 @@ def test_hybrid_local_kv_retention_latest_only_reuses_replay_boundary():
     assert len(computed_blocks.blocks[1]) == 0
 
 
+def _make_decode_checkpoint_manager(monkeypatch, enable_events=False):
+    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETENTION_INTERVAL", "0")
+    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS", "1")
+    block_size = 4
+    manager = make_kv_cache_manager(
+        _make_hybrid_kv_cache_config(block_size, 100, ["full", "mamba_align"]),
+        max_model_len=1024,
+        enable_caching=True,
+        enable_kv_cache_events=enable_events,
+        hash_block_size=block_size,
+    )
+    return manager, block_size
+
+
+def _materialize_checkpoint_test_request(manager, block_size, num_decode_blocks=3):
+    request = make_request("producer", list(range(2 * block_size)), block_size, sha256)
+
+    def compute(num_tokens):
+        manager.new_step_starts()
+        blocks = manager.allocate_slots(request, num_tokens)
+        assert blocks is not None
+        request.num_computed_tokens += num_tokens
+        manager.update_decode_checkpoint_candidates(request)
+
+    compute(block_size)
+    compute(block_size)
+    for block_idx in range(num_decode_blocks):
+        start = request.num_tokens
+        request.append_output_token_ids(list(range(start, start + block_size)))
+        compute(block_size)
+    return request
+
+
+def test_mamba_decode_checkpoints_publish_latest_on_finish(monkeypatch):
+    """The latest materialized decode state becomes reusable after finish."""
+    manager, block_size = _make_decode_checkpoint_manager(monkeypatch)
+    request = _materialize_checkpoint_test_request(manager, block_size)
+    mamba_manager = manager.coordinator.single_type_managers[1]
+    candidate = mamba_manager._decode_checkpoint_candidates[request.request_id]
+
+    assert candidate.num_tokens == 20
+    assert (
+        manager.block_pool.get_cached_block(
+            request.block_hashes[candidate.num_tokens // block_size - 1],
+            [1],
+        )
+        is None
+    )
+
+    manager.finalize_decode_checkpoints(request, keep=True)
+    manager.free(request)
+
+    # Exact replay reaches the latest checkpoint.
+    full_replay = make_request(
+        "full-replay",
+        list(request.all_token_ids) + [100, 101, 102, 103],
+        block_size,
+        sha256,
+    )
+    _, full_hit, _ = manager.get_computed_blocks(full_replay)
+    assert full_hit == 20
+
+
+def test_mamba_decode_checkpoint_uses_spec_materialized_boundary(monkeypatch):
+    """Spec postprocessing materializes the latest crossed aligned boundary."""
+    manager, block_size = _make_decode_checkpoint_manager(monkeypatch)
+    request = _materialize_checkpoint_test_request(
+        manager, block_size, num_decode_blocks=1
+    )
+    mamba_manager = manager.coordinator.single_type_managers[1]
+
+    # Advance to an unaligned position without crossing a boundary.
+    start = request.num_tokens
+    request.append_output_token_ids([start, start + 1])
+    blocks = manager.allocate_slots(request, 2)
+    assert blocks is not None
+    request.num_computed_tokens += 2
+    manager.update_decode_checkpoint_candidates(request)
+    candidate = mamba_manager._decode_checkpoint_candidates[request.request_id]
+    assert candidate.num_tokens == 12
+
+    # Accept four tokens in one speculative step: 14 -> 18. The worker's
+    # postprocess_mamba_align_gpu path copies the state at floor(18 / 4) * 4,
+    # so boundary 16 is independently materialized and safe to retain.
+    start = request.num_tokens
+    request.append_output_token_ids(list(range(start, start + 4)))
+    blocks = manager.allocate_slots(request, 4)
+    assert blocks is not None
+    request.num_computed_tokens += 4
+    manager.update_decode_checkpoint_candidates(request)
+    candidate = mamba_manager._decode_checkpoint_candidates[request.request_id]
+    assert candidate.num_tokens == 16
+    manager.free(request)
+
+
+def test_mamba_decode_checkpoint_pin_survives_state_rotation(monkeypatch):
+    """A private pin keeps an old state out of the allocator after rotation."""
+    manager, block_size = _make_decode_checkpoint_manager(monkeypatch)
+    request = _materialize_checkpoint_test_request(
+        manager, block_size, num_decode_blocks=2
+    )
+    mamba_manager = manager.coordinator.single_type_managers[1]
+    candidate = mamba_manager._decode_checkpoint_candidates[request.request_id]
+    assert candidate.num_tokens == 16
+    assert candidate.block.ref_cnt == 2  # request owner + private pin
+
+    # Two subsequent running-state rotations remove boundary 16 from the
+    # request table. Do not update the candidate: this isolates the private
+    # pin that must keep its physical block resident.
+    new_blocks = []
+    for _ in range(2):
+        start = request.num_tokens
+        request.append_output_token_ids(list(range(start, start + block_size)))
+        manager.new_step_starts()
+        allocated = manager.allocate_slots(request, block_size)
+        assert allocated is not None
+        new_blocks.extend(allocated.blocks[1])
+        request.num_computed_tokens += block_size
+
+    assert candidate.block.ref_cnt == 1
+    assert all(block is not candidate.block for block in new_blocks)
+
+    manager.free(request)
+    assert candidate.block.ref_cnt == 0
+
+
+def test_decode_checkpoint_promotion_preserves_existing_alias(monkeypatch):
+    """Publishing an exact checkpoint must not remove another block alias."""
+    manager, block_size = _make_decode_checkpoint_manager(monkeypatch)
+    request = _materialize_checkpoint_test_request(manager, block_size)
+    mamba_manager = manager.coordinator.single_type_managers[1]
+    latest = mamba_manager._decode_checkpoint_candidates[request.request_id]
+    pool = manager.block_pool
+
+    unrelated_hash = BlockHash(b"unrelated-alias")
+    unrelated_key = make_block_hash_with_group_id(unrelated_hash, 1)
+    pool._insert_block_hash(unrelated_key, latest.block, num_tokens=block_size)
+
+    manager.finalize_decode_checkpoints(request, keep=True)
+    checkpoint_hash = request.block_hashes[latest.num_tokens // block_size - 1]
+    assert pool.get_cached_block(unrelated_hash, [1]) == [latest.block]
+    assert pool.get_cached_block(checkpoint_hash, [1]) == [latest.block]
+
+    manager.free(request)
+    assert pool.get_cached_block(unrelated_hash, [1]) == [latest.block]
+    assert pool.get_cached_block(checkpoint_hash, [1]) == [latest.block]
+
+
+def test_decode_checkpoint_finalize_releases_pins_on_error(monkeypatch):
+    """A promotion failure must still release the private pin."""
+    manager, block_size = _make_decode_checkpoint_manager(monkeypatch)
+    request = _materialize_checkpoint_test_request(manager, block_size)
+    mamba_manager = manager.coordinator.single_type_managers[1]
+    candidate = mamba_manager._decode_checkpoint_candidates[request.request_id]
+
+    def fail_promotion(*args, **kwargs):
+        raise RuntimeError("promotion failed")
+
+    monkeypatch.setattr(manager.block_pool, "cache_decode_checkpoint", fail_promotion)
+    with pytest.raises(RuntimeError, match="promotion failed"):
+        manager.finalize_decode_checkpoints(request, keep=True)
+
+    assert request.request_id not in mamba_manager._decode_checkpoint_candidates
+    assert candidate.block.ref_cnt == 1
+    manager.free(request)
+    assert candidate.block.ref_cnt == 0
+
+
+def test_mamba_decode_checkpoints_exclude_unmaterialized_boundary(monkeypatch):
+    """Allocated/in-flight tokens and a sampled EOS cannot form a candidate."""
+    manager, block_size = _make_decode_checkpoint_manager(monkeypatch)
+    request = _materialize_checkpoint_test_request(
+        manager, block_size, num_decode_blocks=2
+    )
+
+    # Materialize only three tokens of the next block.
+    start = request.num_tokens
+    request.append_output_token_ids(list(range(start, start + block_size - 1)))
+    blocks = manager.allocate_slots(request, block_size - 1)
+    assert blocks is not None
+    request.num_computed_tokens += block_size - 1
+
+    # Sampling EOS makes request.num_tokens reach the aligned boundary, but EOS
+    # has not entered a forward. Even if its slot is optimistically in flight,
+    # processed_end remains 19 and boundary 20 is ineligible.
+    request.append_output_token_ids(999)
+    request.num_computed_tokens += 1
+    request.num_in_flight_tokens = 1
+    manager.update_decode_checkpoint_candidates(request)
+
+    mamba_manager = manager.coordinator.single_type_managers[1]
+    candidate = mamba_manager._decode_checkpoint_candidates[request.request_id]
+    assert candidate.num_tokens == 16
+
+    manager.finalize_decode_checkpoints(request, keep=False)
+    assert request.request_id not in mamba_manager._decode_checkpoint_candidates
+    for boundary in (16, 20):
+        assert (
+            manager.block_pool.get_cached_block(
+                request.block_hashes[boundary // block_size - 1], [1]
+            )
+            is None
+        )
+    manager.free(request)
+
+
+def test_mamba_decode_checkpoint_events_only_on_finish(monkeypatch):
+    """Private candidates emit no Mamba store event until finalization."""
+    manager, block_size = _make_decode_checkpoint_manager(
+        monkeypatch, enable_events=True
+    )
+    request = _materialize_checkpoint_test_request(manager, block_size)
+
+    before_finish = manager.take_events()
+    # Prompt caching may emit Mamba events, but decode candidate 20 does not.
+    assert not any(
+        isinstance(event, BlockStored)
+        and event.group_idx == 1
+        and event.block_hashes
+        and event.token_ids == request.all_token_ids[16:20]
+        for event in before_finish
+    )
+
+    manager.finalize_decode_checkpoints(request, keep=True)
+    checkpoint_events = [
+        event
+        for event in manager.take_events()
+        if isinstance(event, BlockStored) and event.group_idx == 1
+    ]
+    assert [event.token_ids for event in checkpoint_events] == [
+        request.all_token_ids[16:20]
+    ]
+    manager.free(request)
+
+
+@pytest.mark.parametrize(
+    ("retention_interval", "spec_types", "enable_caching", "expected_match"),
+    [
+        (None, ["full", "mamba_align"], True, "RETENTION_INTERVAL=0"),
+        ("64", ["full", "mamba_align"], True, "RETENTION_INTERVAL=0"),
+        ("0", ["full", "mamba"], True, "mamba_cache_mode='align'"),
+        ("0", ["mamba_align", "mamba"], True, "all Mamba KV cache groups"),
+        ("0", ["full", "mamba_align"], False, "prefix caching"),
+    ],
+)
+def test_mamba_decode_checkpoints_reject_unsupported_config(
+    monkeypatch,
+    retention_interval,
+    spec_types,
+    enable_caching,
+    expected_match,
+):
+    if retention_interval is not None:
+        monkeypatch.setenv("VLLM_PREFIX_CACHE_RETENTION_INTERVAL", retention_interval)
+    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS", "1")
+
+    with pytest.raises(ValueError, match=expected_match):
+        make_kv_cache_manager(
+            _make_hybrid_kv_cache_config(4, 100, spec_types),
+            max_model_len=1024,
+            enable_caching=enable_caching,
+            hash_block_size=4,
+        )
+
+
+def test_mamba_decode_checkpoints_disabled_by_default(monkeypatch):
+    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETENTION_INTERVAL", "0")
+    monkeypatch.delenv("VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS", raising=False)
+    manager = make_kv_cache_manager(
+        _make_hybrid_kv_cache_config(4, 100, ["full", "mamba_align"]),
+        max_model_len=1024,
+        enable_caching=True,
+        hash_block_size=4,
+    )
+    request = _materialize_checkpoint_test_request(manager, 4)
+    mamba_manager = manager.coordinator.single_type_managers[1]
+    assert not mamba_manager._decode_checkpoint_candidates
+    manager.free(request)
+
+
 def test_hybrid_local_kv_retention_mtp_reuses_latest_boundary():
     """Verify MTP/EAGLE SWA retention keeps the extra proof block.
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -298,6 +298,7 @@ if TYPE_CHECKING:
     VLLM_GPU_NIC_PCIE_MAPPING: str = ""
     VLLM_NIC_SELECTION_VARS: str = ""
     VLLM_PREFIX_CACHE_RETENTION_INTERVAL: int | None = None
+    VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS: bool = False
 
 
 def get_default_cache_root():
@@ -1114,11 +1115,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # retains only the latest completed prompt boundary. Positive values retain
     # checkpoints at the specified interval boundaries (rounded up to the
     # prefix-cache alignment).
-    # Applies to sliding-window attention for now but not yet Mamba/linear attention.
+    # Applies to sliding-window and Mamba/linear attention.
     "VLLM_PREFIX_CACHE_RETENTION_INTERVAL": lambda: (
         int(os.environ["VLLM_PREFIX_CACHE_RETENTION_INTERVAL"])
         if "VLLM_PREFIX_CACHE_RETENTION_INTERVAL" in os.environ
         else None
+    ),
+    # With latest-only retention, privately pin the latest materialized
+    # scheduler-aligned Mamba decode state and publish it on a stopped finish.
+    "VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS": lambda: bool(
+        int(os.getenv("VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS", "0"))
     ),
     # a local directory to look in for unrecognized LoRA adapters.
     # only works if plugins are enabled and

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -327,6 +327,7 @@ if TYPE_CHECKING:
     VLLM_NIC_SELECTION_VARS: str = ""
     VLLM_PREFIX_CACHE_RETENTION_INTERVAL: int | None = None
     VLLM_ENABLE_HPC_OPS: bool = False
+    VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS: bool = False
 
 
 def get_default_cache_root():
@@ -1176,6 +1177,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
         int(os.environ["VLLM_PREFIX_CACHE_RETENTION_INTERVAL"])
         if "VLLM_PREFIX_CACHE_RETENTION_INTERVAL" in os.environ
         else None
+    ),
+    # With latest-only retention, privately pin the latest materialized
+    # scheduler-aligned Mamba decode state and publish it on a stopped finish.
+    "VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS": lambda: bool(
+        int(os.getenv("VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS", "0"))
     ),
     # a local directory to look in for unrecognized LoRA adapters.
     # only works if plugins are enabled and

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -370,6 +370,72 @@ class BlockPool:
             group_idx=kv_cache_group_id,
         )
 
+    def cache_decode_checkpoint(
+        self,
+        request: Request,
+        block: KVCacheBlock,
+        block_hash_with_group_id: BlockHashWithGroupId,
+        num_tokens: int,
+        block_size: int,
+        kv_cache_group_id: int,
+    ) -> bool:
+        """Publish one exact, already-materialized recurrent-state checkpoint.
+
+        Unlike ``cache_full_blocks``, this inserts only the supplied hash alias.
+        Any other hashes owned by ``block`` remain intact.
+        """
+        assert self.enable_caching
+        assert not block.is_null and block.ref_cnt > 0
+        assert num_tokens > 0 and num_tokens % block_size == 0
+        assert get_group_id(block_hash_with_group_id) == kv_cache_group_id
+
+        block_hashes = resolve_block_hashes(
+            request.block_hashes, self.hash_block_size, block_size
+        )
+        block_idx = num_tokens // block_size - 1
+        assert 0 <= block_idx < len(block_hashes)
+        block_hash = block_hashes[block_idx]
+        assert block_hash_with_group_id == make_block_hash_with_group_id(
+            block_hash, kv_cache_group_id
+        )
+
+        if self.cached_block_hash_to_block.contain(
+            block_hash_with_group_id, block.block_id
+        ):
+            return False
+
+        self._insert_block_hash(
+            block_hash_with_group_id,
+            block,
+            num_tokens=num_tokens,
+        )
+        if self.enable_kv_cache_events:
+            parent_block_hash = (
+                maybe_convert_block_hash(block_hashes[block_idx - 1])
+                if block_idx > 0
+                else None
+            )
+            block_start = num_tokens - block_size
+            extra_keys, _ = generate_block_hash_extra_keys(
+                request,
+                block_start,
+                num_tokens,
+                0,
+            )
+            self.kv_event_queue.append(
+                self._build_block_stored_event(
+                    request,
+                    block_hashes=[maybe_convert_block_hash(block_hash)],
+                    parent_block_hash=parent_block_hash,
+                    start_token_idx=block_start,
+                    end_token_idx=num_tokens,
+                    block_size=block_size,
+                    kv_cache_group_id=kv_cache_group_id,
+                    extra_keys_list=[extra_keys],
+                )
+            )
+        return True
+
     def emit_cached_block_events(
         self,
         request: Request,

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -371,6 +371,72 @@ class BlockPool:
             session_id=request.session_id,
         )
 
+    def cache_decode_checkpoint(
+        self,
+        request: Request,
+        block: KVCacheBlock,
+        block_hash_with_group_id: BlockHashWithGroupId,
+        num_tokens: int,
+        block_size: int,
+        kv_cache_group_id: int,
+    ) -> bool:
+        """Publish one exact, already-materialized recurrent-state checkpoint.
+
+        Unlike ``cache_full_blocks``, this inserts only the supplied hash alias.
+        Any other hashes owned by ``block`` remain intact.
+        """
+        assert self.enable_caching
+        assert not block.is_null and block.ref_cnt > 0
+        assert num_tokens > 0 and num_tokens % block_size == 0
+        assert get_group_id(block_hash_with_group_id) == kv_cache_group_id
+
+        block_hashes = resolve_block_hashes(
+            request.block_hashes, self.hash_block_size, block_size
+        )
+        block_idx = num_tokens // block_size - 1
+        assert 0 <= block_idx < len(block_hashes)
+        block_hash = block_hashes[block_idx]
+        assert block_hash_with_group_id == make_block_hash_with_group_id(
+            block_hash, kv_cache_group_id
+        )
+
+        if self.cached_block_hash_to_block.contain(
+            block_hash_with_group_id, block.block_id
+        ):
+            return False
+
+        self._insert_block_hash(
+            block_hash_with_group_id,
+            block,
+            num_tokens=num_tokens,
+        )
+        if self.enable_kv_cache_events:
+            parent_block_hash = (
+                maybe_convert_block_hash(block_hashes[block_idx - 1])
+                if block_idx > 0
+                else None
+            )
+            block_start = num_tokens - block_size
+            extra_keys, _ = generate_block_hash_extra_keys(
+                request,
+                block_start,
+                num_tokens,
+                0,
+            )
+            self.kv_event_queue.append(
+                self._build_block_stored_event(
+                    request,
+                    block_hashes=[maybe_convert_block_hash(block_hash)],
+                    parent_block_hash=parent_block_hash,
+                    start_token_idx=block_start,
+                    end_token_idx=num_tokens,
+                    block_size=block_size,
+                    kv_cache_group_id=kv_cache_group_id,
+                    extra_keys_list=[extra_keys],
+                )
+            )
+        return True
+
     def emit_cached_block_events(
         self,
         request: Request,

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -160,6 +160,11 @@ class KVCacheCoordinator(ABC):
         self.retain_decode_checkpoints = (
             envs.VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS
         )
+        if self.retain_decode_checkpoints and use_eagle:
+            raise ValueError(
+                "VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS is not compatible "
+                "with hidden-state speculative decoding."
+            )
         _validate_prefix_cache_retention_interval(
             self.retention_interval,
             self.retain_decode_checkpoints,

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -29,9 +29,43 @@ from vllm.v1.request import Request
 
 def _validate_prefix_cache_retention_interval(
     retention_interval: int | None,
+    retain_decode_checkpoints: bool,
+    enable_caching: bool,
     scheduler_block_size: int,
     kv_cache_config: KVCacheConfig,
 ) -> None:
+    if retain_decode_checkpoints:
+        if not enable_caching:
+            raise ValueError(
+                "VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS requires "
+                "prefix caching to be enabled."
+            )
+        if retention_interval != 0:
+            raise ValueError(
+                "VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS requires "
+                "VLLM_PREFIX_CACHE_RETENTION_INTERVAL=0."
+            )
+        mamba_specs = [
+            group.kv_cache_spec
+            for group in kv_cache_config.kv_cache_groups
+            if isinstance(group.kv_cache_spec, MambaSpec)
+        ]
+        if not mamba_specs:
+            raise ValueError(
+                "VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS requires a "
+                "Mamba KV cache group."
+            )
+        if any(spec.mamba_cache_mode != "align" for spec in mamba_specs):
+            raise ValueError(
+                "VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS requires all "
+                "Mamba KV cache groups to use mamba_cache_mode='align'."
+            )
+        if any(spec.block_size != scheduler_block_size for spec in mamba_specs):
+            raise ValueError(
+                "VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS requires every "
+                "Mamba block size to equal scheduler_block_size."
+            )
+
     if retention_interval is None:
         return
 
@@ -123,8 +157,15 @@ class KVCacheCoordinator(ABC):
         # (``scheduler_block_size``) to land on real cache-hit boundaries.
         # 0 = keep only the latest replay boundary; None = dense;
         self.retention_interval = envs.VLLM_PREFIX_CACHE_RETENTION_INTERVAL
+        self.retain_decode_checkpoints = (
+            envs.VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS
+        )
         _validate_prefix_cache_retention_interval(
-            self.retention_interval, self.scheduler_block_size, kv_cache_config
+            self.retention_interval,
+            self.retain_decode_checkpoints,
+            self.enable_caching,
+            self.scheduler_block_size,
+            kv_cache_config,
         )
 
     def get_num_blocks_to_allocate(
@@ -286,6 +327,31 @@ class KVCacheCoordinator(ABC):
                 num_computed_tokens,
                 retention_interval=self.retention_interval,
             )
+
+    def update_decode_checkpoint_candidates(
+        self, request: Request, materialized_tokens: int
+    ) -> None:
+        """Privately retain newly materialized recurrent decode states."""
+        if not self.retain_decode_checkpoints:
+            return
+        for manager in self.single_type_managers:
+            manager.update_decode_checkpoint_candidate(request, materialized_tokens)
+
+    def finalize_decode_checkpoints(
+        self, request: Request, materialized_tokens: int, keep: bool
+    ) -> None:
+        """Publish stopped-finish candidates, or discard their private pins."""
+        managers = iter(self.single_type_managers)
+        try:
+            for manager in managers:
+                manager.finalize_decode_checkpoints(request, materialized_tokens, keep)
+        finally:
+            # A manager releases its own pins in a finally block. If promotion
+            # raises, discard candidates belonging to groups not yet visited.
+            for manager in managers:
+                manager.finalize_decode_checkpoints(
+                    request, materialized_tokens, keep=False
+                )
 
     def free(self, request_id: str) -> None:
         """

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -197,6 +197,11 @@ class KVCacheCoordinator(ABC):
         self.retain_decode_checkpoints = (
             envs.VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS
         )
+        if self.retain_decode_checkpoints and use_eagle:
+            raise ValueError(
+                "VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS is not compatible "
+                "with hidden-state speculative decoding."
+            )
         _validate_prefix_cache_retention_interval(
             self.retention_interval,
             self.retain_decode_checkpoints,

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -33,9 +33,43 @@ logger = init_logger(__name__)
 
 def _validate_prefix_cache_retention_interval(
     retention_interval: int | None,
+    retain_decode_checkpoints: bool,
+    enable_caching: bool,
     scheduler_block_size: int,
     kv_cache_config: KVCacheConfig,
 ) -> None:
+    if retain_decode_checkpoints:
+        if not enable_caching:
+            raise ValueError(
+                "VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS requires "
+                "prefix caching to be enabled."
+            )
+        if retention_interval != 0:
+            raise ValueError(
+                "VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS requires "
+                "VLLM_PREFIX_CACHE_RETENTION_INTERVAL=0."
+            )
+        mamba_specs = [
+            group.kv_cache_spec
+            for group in kv_cache_config.kv_cache_groups
+            if isinstance(group.kv_cache_spec, MambaSpec)
+        ]
+        if not mamba_specs:
+            raise ValueError(
+                "VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS requires a "
+                "Mamba KV cache group."
+            )
+        if any(spec.mamba_cache_mode != "align" for spec in mamba_specs):
+            raise ValueError(
+                "VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS requires all "
+                "Mamba KV cache groups to use mamba_cache_mode='align'."
+            )
+        if any(spec.block_size != scheduler_block_size for spec in mamba_specs):
+            raise ValueError(
+                "VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS requires every "
+                "Mamba block size to equal scheduler_block_size."
+            )
+
     if retention_interval is None:
         return
 
@@ -160,8 +194,15 @@ class KVCacheCoordinator(ABC):
         # (``scheduler_block_size``) to land on real cache-hit boundaries.
         # 0 = keep only the latest replay boundary; None = dense;
         self.retention_interval = kv_cache_config.prefix_cache_retention_interval
+        self.retain_decode_checkpoints = (
+            envs.VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS
+        )
         _validate_prefix_cache_retention_interval(
-            self.retention_interval, self.scheduler_block_size, kv_cache_config
+            self.retention_interval,
+            self.retain_decode_checkpoints,
+            self.enable_caching,
+            self.scheduler_block_size,
+            kv_cache_config,
         )
 
     def get_num_blocks_to_allocate(
@@ -351,6 +392,31 @@ class KVCacheCoordinator(ABC):
                 retention_interval=self.retention_interval,
                 replay_boundaries=boundaries,
             )
+
+    def update_decode_checkpoint_candidates(
+        self, request: Request, materialized_tokens: int
+    ) -> None:
+        """Privately retain newly materialized recurrent decode states."""
+        if not self.retain_decode_checkpoints:
+            return
+        for manager in self.single_type_managers:
+            manager.update_decode_checkpoint_candidate(request, materialized_tokens)
+
+    def finalize_decode_checkpoints(
+        self, request: Request, materialized_tokens: int, keep: bool
+    ) -> None:
+        """Publish stopped-finish candidates, or discard their private pins."""
+        managers = iter(self.single_type_managers)
+        try:
+            for manager in managers:
+                manager.finalize_decode_checkpoints(request, materialized_tokens, keep)
+        finally:
+            # A manager releases its own pins in a finally block. If promotion
+            # raises, discard candidates belonging to groups not yet visited.
+            for manager in managers:
+                manager.finalize_decode_checkpoints(
+                    request, materialized_tokens, keep=False
+                )
 
     def free(self, request_id: str) -> None:
         """

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from typing import NamedTuple
 
+from vllm import envs
 from vllm.logger import init_logger
 from vllm.utils.math_utils import cdiv, round_down
 from vllm.v1.core.block_pool import BlockPool
@@ -47,7 +48,7 @@ def _validate_prefix_cache_retention_interval(
         if retention_interval != 0:
             raise ValueError(
                 "VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS requires "
-                "VLLM_PREFIX_CACHE_RETENTION_INTERVAL=0."
+                "prefix_cache_retention_interval=0."
             )
         mamba_specs = [
             group.kv_cache_spec
@@ -205,7 +206,7 @@ class KVCacheCoordinator(ABC):
         _validate_prefix_cache_retention_interval(
             self.retention_interval,
             self.retain_decode_checkpoints,
-            self.enable_caching,
+            enable_caching,
             self.scheduler_block_size,
             kv_cache_config,
         )

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -577,6 +577,32 @@ class KVCacheManager:
             self.block_pool.free_blocks(pins)
         self.coordinator.free(request.request_id)
 
+    def update_decode_checkpoint_candidates(self, request: Request) -> None:
+        """Retain checkpoints only for tokens whose forward has completed."""
+        if not self.coordinator.retain_decode_checkpoints:
+            return
+        if not self.enable_caching:
+            return
+        processed_end = max(
+            0, request.num_computed_tokens - request.num_in_flight_tokens
+        )
+        materialized_tokens = min(processed_end, request.num_tokens)
+        self.coordinator.update_decode_checkpoint_candidates(
+            request, materialized_tokens
+        )
+
+    def finalize_decode_checkpoints(self, request: Request, keep: bool) -> None:
+        """Publish or discard the request's private decode checkpoints."""
+        if not self.coordinator.retain_decode_checkpoints:
+            return
+        if not self.enable_caching:
+            return
+        processed_end = max(
+            0, request.num_computed_tokens - request.num_in_flight_tokens
+        )
+        materialized_tokens = min(processed_end, request.num_tokens)
+        self.coordinator.finalize_decode_checkpoints(request, materialized_tokens, keep)
+
     def remove_skipped_blocks(
         self,
         request_id: str,

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -590,6 +590,32 @@ class KVCacheManager:
         """
         self.coordinator.free(request.request_id)
 
+    def update_decode_checkpoint_candidates(self, request: Request) -> None:
+        """Retain checkpoints only for tokens whose forward has completed."""
+        if not self.coordinator.retain_decode_checkpoints:
+            return
+        if not self.enable_caching:
+            return
+        processed_end = max(
+            0, request.num_computed_tokens - request.num_in_flight_tokens
+        )
+        materialized_tokens = min(processed_end, request.num_tokens)
+        self.coordinator.update_decode_checkpoint_candidates(
+            request, materialized_tokens
+        )
+
+    def finalize_decode_checkpoints(self, request: Request, keep: bool) -> None:
+        """Publish or discard the request's private decode checkpoints."""
+        if not self.coordinator.retain_decode_checkpoints:
+            return
+        if not self.enable_caching:
+            return
+        processed_end = max(
+            0, request.num_computed_tokens - request.num_in_flight_tokens
+        )
+        materialized_tokens = min(processed_end, request.num_tokens)
+        self.coordinator.finalize_decode_checkpoints(request, materialized_tokens, keep)
+
     def remove_skipped_blocks(
         self,
         request_id: str,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1842,6 +1842,9 @@ class Scheduler(SchedulerInterface):
                     request.resumable = False
                     stopped = True
 
+            if not output_is_stale:
+                self.kv_cache_manager.update_decode_checkpoint_candidates(request)
+
             routed_experts = None
             if (
                 self.enable_return_routed_experts
@@ -2302,6 +2305,10 @@ class Scheduler(SchedulerInterface):
     ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
         assert request.is_finished()
 
+        self.kv_cache_manager.finalize_decode_checkpoints(
+            request,
+            keep=request.status == RequestStatus.FINISHED_STOPPED,
+        )
         self._inflight_prefills.discard(request)
         connector_delay_free_blocks, kv_xfer_params = self._connector_finished(request)
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2066,6 +2066,9 @@ class Scheduler(SchedulerInterface):
                     request.resumable = False
                     stopped = True
 
+            if not output_is_stale:
+                self.kv_cache_manager.update_decode_checkpoint_candidates(request)
+
             routed_experts = None
             if (
                 self.enable_return_routed_experts
@@ -2568,6 +2571,10 @@ class Scheduler(SchedulerInterface):
     ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
         assert request.is_finished()
 
+        self.kv_cache_manager.finalize_decode_checkpoints(
+            request,
+            keep=request.status == RequestStatus.FINISHED_STOPPED,
+        )
         self._inflight_prefills.discard(request)
         connector_delay_free_blocks, kv_xfer_params = self._connector_finished(request)
 

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -4,6 +4,7 @@ import itertools
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import ClassVar
 
 from vllm.utils.math_utils import cdiv
@@ -13,6 +14,7 @@ from vllm.v1.core.kv_cache_utils import (
     BlockHashListWithBlockSize,
     BlockHashWithGroupId,
     KVCacheBlock,
+    make_block_hash_with_group_id,
     resolve_block_hashes,
 )
 from vllm.v1.kv_cache_interface import (
@@ -31,6 +33,15 @@ from vllm.v1.kv_cache_interface import (
 )
 from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 from vllm.v1.request import Request
+
+
+@dataclass(frozen=True)
+class DecodeCheckpointCandidate:
+    """A materialized recurrent state kept private until request finalization."""
+
+    num_tokens: int
+    block: KVCacheBlock
+    block_hash: BlockHashWithGroupId
 
 
 class SingleTypeKVCacheManager(ABC):
@@ -475,6 +486,18 @@ class SingleTypeKVCacheManager(ABC):
         )
 
         self.num_cached_block[request.request_id] = num_full_blocks
+
+    def update_decode_checkpoint_candidate(
+        self, request: Request, materialized_tokens: int
+    ) -> None:
+        """Record a private decode checkpoint for managers that support it."""
+        return
+
+    def finalize_decode_checkpoints(
+        self, request: Request, materialized_tokens: int, keep: bool
+    ) -> None:
+        """Publish or discard private decode checkpoints for this group."""
+        return
 
     @classmethod
     def reachable_block_mask(
@@ -1275,6 +1298,9 @@ class MambaManager(SingleTypeKVCacheManager):
             # into a private cow_block; we record that block for connector
             # offload (see _pending_partial_tail_offloads).
             self._producer_partial_tail_reqs: dict[str, int] = {}
+            self._decode_checkpoint_candidates: dict[
+                str, DecodeCheckpointCandidate
+            ] = {}
 
     @classmethod
     def find_longest_cache_hit(
@@ -1652,6 +1678,7 @@ class MambaManager(SingleTypeKVCacheManager):
 
     def pop_blocks_for_free(self, request_id: str) -> list[KVCacheBlock]:
         if self.mamba_cache_mode == "align":
+            self._discard_decode_checkpoint_candidates(request_id)
             self._allocated_block_reqs.discard(request_id)
             self.last_state_block_idx.pop(request_id, None)
             self._producer_partial_tail_reqs.pop(request_id, None)
@@ -1699,6 +1726,84 @@ class MambaManager(SingleTypeKVCacheManager):
 
     def new_step_starts(self) -> None:
         self.cached_blocks_this_step.clear()
+
+    def update_decode_checkpoint_candidate(
+        self, request: Request, materialized_tokens: int
+    ) -> None:
+        """Privately pin the latest materialized aligned decode state."""
+        if self.mamba_cache_mode != "align":
+            return
+
+        # Spec-decode postprocessing explicitly copies the state at this
+        # floored boundary into its position-indexed Mamba block (see
+        # postprocess_mamba_align_gpu). Non-spec decode advances one token at a
+        # time, while aligned prefill is split by the scheduler. The floor is
+        # therefore a worker materialization contract, not an inferred state.
+        boundary = (
+            materialized_tokens // self.scheduler_block_size * self.scheduler_block_size
+        )
+        if boundary <= request.num_prompt_tokens:
+            return
+
+        previous = self._decode_checkpoint_candidates.get(request.request_id)
+        if previous is not None and previous.num_tokens == boundary:
+            return
+
+        block_idx = boundary // self.block_size - 1
+        blocks = self.req_to_blocks.get(request.request_id)
+        if blocks is None or block_idx >= len(blocks):
+            return
+        block = blocks[block_idx]
+        if block.is_null:
+            return
+        assert block.ref_cnt > 0, (
+            "Decode checkpoint block must still be owned by the running request"
+        )
+
+        block_hashes = resolve_block_hashes(
+            request.block_hashes,
+            self.block_pool.hash_block_size,
+            self.block_size,
+        )
+        if block_idx >= len(block_hashes):
+            return
+        block_hash = make_block_hash_with_group_id(
+            block_hashes[block_idx], self.kv_cache_group_id
+        )
+        candidate = DecodeCheckpointCandidate(boundary, block, block_hash)
+
+        self.block_pool.touch((block,))
+        self._decode_checkpoint_candidates[request.request_id] = candidate
+        if previous is not None:
+            self.block_pool.free_blocks((previous.block,))
+
+    def finalize_decode_checkpoints(
+        self, request: Request, materialized_tokens: int, keep: bool
+    ) -> None:
+        """Publish the private candidate only after a stopped completion."""
+        if self.mamba_cache_mode != "align":
+            return
+        candidate = self._decode_checkpoint_candidates.pop(request.request_id, None)
+        if candidate is None:
+            return
+
+        try:
+            if keep and candidate.num_tokens <= materialized_tokens:
+                self.block_pool.cache_decode_checkpoint(
+                    request=request,
+                    block=candidate.block,
+                    block_hash_with_group_id=candidate.block_hash,
+                    num_tokens=candidate.num_tokens,
+                    block_size=self.block_size,
+                    kv_cache_group_id=self.kv_cache_group_id,
+                )
+        finally:
+            self.block_pool.free_blocks((candidate.block,))
+
+    def _discard_decode_checkpoint_candidates(self, request_id: str) -> None:
+        candidate = self._decode_checkpoint_candidates.pop(request_id, None)
+        if candidate is not None:
+            self.block_pool.free_blocks((candidate.block,))
 
     def _cache_partial_tail_block(
         self,

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -4,6 +4,7 @@ import itertools
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import ClassVar
 
 from vllm.logger import init_logger
@@ -14,6 +15,7 @@ from vllm.v1.core.kv_cache_utils import (
     BlockHashListWithBlockSize,
     BlockHashWithGroupId,
     KVCacheBlock,
+    make_block_hash_with_group_id,
     resolve_block_hashes,
 )
 from vllm.v1.kv_cache_interface import (
@@ -38,6 +40,15 @@ from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 from vllm.v1.request import Request
 
 logger = init_logger(__name__)
+
+
+@dataclass(frozen=True)
+class DecodeCheckpointCandidate:
+    """A materialized recurrent state kept private until request finalization."""
+
+    num_tokens: int
+    block: KVCacheBlock
+    block_hash: BlockHashWithGroupId
 
 
 class SingleTypeKVCacheManager(ABC):
@@ -502,6 +513,18 @@ class SingleTypeKVCacheManager(ABC):
         )
 
         self.num_cached_block[request.request_id] = num_full_blocks
+
+    def update_decode_checkpoint_candidate(
+        self, request: Request, materialized_tokens: int
+    ) -> None:
+        """Record a private decode checkpoint for managers that support it."""
+        return
+
+    def finalize_decode_checkpoints(
+        self, request: Request, materialized_tokens: int, keep: bool
+    ) -> None:
+        """Publish or discard private decode checkpoints for this group."""
+        return
 
     @classmethod
     def reachable_block_mask(
@@ -1454,6 +1477,9 @@ class MambaManager(SingleTypeKVCacheManager):
             # connector; a request that finishes first hands off this table
             # source directly.
             self._producer_partial_tail_reqs: dict[str, tuple[KVCacheBlock, int]] = {}
+            self._decode_checkpoint_candidates: dict[
+                str, DecodeCheckpointCandidate
+            ] = {}
 
     @classmethod
     def find_longest_cache_hit(
@@ -1912,6 +1938,7 @@ class MambaManager(SingleTypeKVCacheManager):
 
     def pop_blocks_for_free(self, request_id: str) -> list[KVCacheBlock]:
         if self.mamba_cache_mode == "align":
+            self._discard_decode_checkpoint_candidates(request_id)
             self._allocated_block_reqs.discard(request_id)
             self.last_state_block_idx.pop(request_id, None)
             self._checkpoints.pop(request_id, None)
@@ -1983,6 +2010,84 @@ class MambaManager(SingleTypeKVCacheManager):
 
     def new_step_starts(self) -> None:
         self.cached_blocks_this_step.clear()
+
+    def update_decode_checkpoint_candidate(
+        self, request: Request, materialized_tokens: int
+    ) -> None:
+        """Privately pin the latest materialized aligned decode state."""
+        if self.mamba_cache_mode != "align":
+            return
+
+        # Spec-decode postprocessing explicitly copies the state at this
+        # floored boundary into its position-indexed Mamba block (see
+        # postprocess_mamba_align_gpu). Non-spec decode advances one token at a
+        # time, while aligned prefill is split by the scheduler. The floor is
+        # therefore a worker materialization contract, not an inferred state.
+        boundary = (
+            materialized_tokens // self.scheduler_block_size * self.scheduler_block_size
+        )
+        if boundary <= request.num_prompt_tokens:
+            return
+
+        previous = self._decode_checkpoint_candidates.get(request.request_id)
+        if previous is not None and previous.num_tokens == boundary:
+            return
+
+        block_idx = boundary // self.block_size - 1
+        blocks = self.req_to_blocks.get(request.request_id)
+        if blocks is None or block_idx >= len(blocks):
+            return
+        block = blocks[block_idx]
+        if block.is_null:
+            return
+        assert block.ref_cnt > 0, (
+            "Decode checkpoint block must still be owned by the running request"
+        )
+
+        block_hashes = resolve_block_hashes(
+            request.block_hashes,
+            self.block_pool.hash_block_size,
+            self.block_size,
+        )
+        if block_idx >= len(block_hashes):
+            return
+        block_hash = make_block_hash_with_group_id(
+            block_hashes[block_idx], self.kv_cache_group_id
+        )
+        candidate = DecodeCheckpointCandidate(boundary, block, block_hash)
+
+        self.block_pool.touch((block,))
+        self._decode_checkpoint_candidates[request.request_id] = candidate
+        if previous is not None:
+            self.block_pool.free_blocks((previous.block,))
+
+    def finalize_decode_checkpoints(
+        self, request: Request, materialized_tokens: int, keep: bool
+    ) -> None:
+        """Publish the private candidate only after a stopped completion."""
+        if self.mamba_cache_mode != "align":
+            return
+        candidate = self._decode_checkpoint_candidates.pop(request.request_id, None)
+        if candidate is None:
+            return
+
+        try:
+            if keep and candidate.num_tokens <= materialized_tokens:
+                self.block_pool.cache_decode_checkpoint(
+                    request=request,
+                    block=candidate.block,
+                    block_hash_with_group_id=candidate.block_hash,
+                    num_tokens=candidate.num_tokens,
+                    block_size=self.block_size,
+                    kv_cache_group_id=self.kv_cache_group_id,
+                )
+        finally:
+            self.block_pool.free_blocks((candidate.block,))
+
+    def _discard_decode_checkpoint_candidates(self, request_id: str) -> None:
+        candidate = self._decode_checkpoint_candidates.pop(request_id, None)
+        if candidate is not None:
+            self.block_pool.free_blocks((candidate.block,))
 
     def _cache_partial_tail_block(
         self,

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -2018,11 +2018,9 @@ class MambaManager(SingleTypeKVCacheManager):
         if self.mamba_cache_mode != "align":
             return
 
-        # Spec-decode postprocessing explicitly copies the state at this
-        # floored boundary into its position-indexed Mamba block (see
-        # postprocess_mamba_align_gpu). Non-spec decode advances one token at a
-        # time, while aligned prefill is split by the scheduler. The floor is
-        # therefore a worker materialization contract, not an inferred state.
+        # Non-spec decode advances one token at a time, leaving the completed
+        # aligned state in its position-indexed block when the running state
+        # rotates. Hidden-state speculative decoding is guarded at setup.
         boundary = (
             materialized_tokens // self.scheduler_block_size * self.scheduler_block_size
         )


### PR DESCRIPTION
## Purpose

With:

```bash
VLLM_PREFIX_CACHE_RETENTION_INTERVAL=0
```

vLLM uses a sparse retention policy that aims to maximize cache reuse per retained SSM state, providing high prefix-cache hit potential with minimal storage overhead.

Currently, it retains the prompt replay boundary and reactively discovered Marconi-style shared-prefix junctions. Marconi's admission policy also retains the last decoded state for conversation-history reuse.

This PR completes that behavior for sparse retention by privately pinning the latest materialized, scheduler-aligned decode checkpoint and publishing it to the local prefix cache after `FINISHED_STOPPED`.

Enable with:

```bash
VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS=1 vllm serve <model> \
  --enable-prefix-caching \
  --mamba-cache-mode align \
  --prefix-cache-retention-interval 0
```

### Examples

Kimi K3 requires the complete assistant message returned by the API, including `reasoning_content` and `tool_calls`, to be passed back in the next request.

<details>
<summary>History prefix hit examples</summary>

#### History followed by a tool result

```text
... history ...

<|open|>message role="assistant"<|sep|>
<|open|>think<|sep|>...<|close|>think<|sep|>
<|open|>response<|sep|>...<|close|>response<|sep|>
<|open|>tools<|sep|>...<|close|>tools<|sep|>
<|close|>message<|sep|><|end_of_msg|>

<|open|>message role="tool" tool="get_weather" index="1"<|sep|>
Sunny, 31°C
<|close|>message<|sep|><|end_of_msg|>
```

The hit lands at the deepest scheduler-aligned boundary within the replayed assistant prefix.

#### History followed by a user message

```text
... history ...

<|open|>message role="assistant"<|sep|>
<|open|>think<|sep|>...<|close|>think<|sep|>
<|open|>response<|sep|>previous answer<|close|>response<|sep|>
<|close|>message<|sep|><|end_of_msg|>

<|open|>message role="user"<|sep|>
Can you explain that further?
<|close|>message<|sep|><|end_of_msg|>
```

Again, the hit is the deepest aligned checkpoint within the replayed assistant prefix.
</details>

Because the completed assistant message is rendered again before the new tool or user message, the latest decode checkpoint provides the deepest reusable prefix.

## Test Plan

### Server

```
export VLLM_PREFIX_CACHE_RETENTION_INTERVAL=0
export VLLM_PREFIX_CACHE_RETAIN_DECODE_CHECKPOINTS=<0-or-1>

vllm serve /qwen3p6-35b-a3b-nvfp4 \
  --trust-remote-code \
  -tp 2 \
  --language-model-only \
  --enable-prefix-caching \
  --mamba-cache-mode align \
  --prefix-match-unit 16 \
  --enable-auto-tool-choice \
  --tool-call-parser qwen3_xml \
  --reasoning-parser qwen3 \
  --default-chat-template-kwargs \
    '{"enable_thinking":true,"preserve_thinking":true}' \
  --enable-prompt-tokens-details
```

### Client

```
#!/usr/bin/env python3
"""Decode-checkpoint retention A/B — one-shot client.

Runs a fixed multi-turn dialog (full-history replay, bs=1, temp=0, seed=42)
against a running vLLM server, prints per-request cached_tokens + output hash.
The FULL assistant message (reasoning + content + tool_calls) is replayed
verbatim each turn, so the replay token sequence matches what was generated —
required for PR #50551 decode checkpoints to hit.

Run once per arm (retain=0, then retain=1) and diff the two prints.
Usage:
  python3 ab_client.py
"""
import hashlib
import json

from openai import OpenAI

MODEL = "/qwen3p6-35b-a3b-nvfp4"
BASE = "http://127.0.0.1:8000/v1"
SEED, TEMP = 42, 0.0

USER_MSGS = [
    "Analyze the trade-offs between cloud-based and on-premises deployment "
    "for a financial services company that must meet strict data residency "
    "requirements. Cover cost, latency, security, compliance, and operational "
    "complexity, then recommend a hybrid approach with a phased migration plan.",
    "Based on the previous analysis, propose a detailed incident-response runbook "
    "for a hybrid cloud outage. Include team roles, escalation path, communication "
    "channels, and step-by-step recovery for both the on-prem and cloud tiers.",
    "Now write a risk register for that runbook: for each of the top 6 risks, "
    "give likelihood, impact, mitigations, and a monitoring metric that would "
    "have caught it early.",
    "Draft the executive summary of this whole plan for the board — under 300 "
    "words, non-technical, focused on business continuity and the expected "
    "downtime budget.",
    "Finally, produce a comparison table as plain text with columns for cloud, "
    "on-prem, and hybrid across 8 dimensions, and a one-line recommendation "
    "justification for each dimension.",
]


def main():
    client = OpenAI(base_url=BASE, api_key="dummy")
    messages = []
    rows = []
    for turn, user_msg in enumerate(USER_MSGS):
        messages.append({"role": "user", "content": user_msg})
        resp = client.chat.completions.create(
            model=MODEL, messages=messages, temperature=TEMP, seed=SEED)
        choice = resp.choices[0]
        if choice.finish_reason != "stop":
            raise RuntimeError(f"turn={turn}: finish_reason={choice.finish_reason!r}")
        usage = resp.usage
        details = getattr(usage, "prompt_tokens_details", None)
        cached = getattr(details, "cached_tokens", 0) or 0 if details else 0

        msg_data = choice.message.model_dump(exclude_none=True)
        content = msg_data.get("content") or ""
        reasoning = (msg_data.get("reasoning")
                     or msg_data.get("reasoning_content") or "")
        tool_calls = msg_data.get("tool_calls") or []

        rows.append({
            "turn": turn,
            "prompt_tokens": usage.prompt_tokens,
            "cached_tokens": cached,
            "completion_tokens": usage.completion_tokens,
            "reasoning_chars": len(reasoning),
            "content_chars": len(content),
            "output_sha": hashlib.sha256(json.dumps(
                {"reasoning": reasoning, "content": content,
                 "tool_calls": tool_calls},
                sort_keys=True, ensure_ascii=False).encode()).hexdigest()[:12],
        })

        # Replay the FULL assistant message, not just content.
        assistant_message = {"role": "assistant", "content": content}
        if reasoning:
            assistant_message["reasoning"] = reasoning
        if tool_calls:
            assistant_message["tool_calls"] = tool_calls
        messages.append(assistant_message)

        print(f"turn={turn} pt={usage.prompt_tokens} ct={usage.completion_tokens} "
              f"cached={cached} reasoning_chars={len(reasoning)}", flush=True)

    print("\nturn | cached/pt/ct | reasoning_chars/content_chars | output_sha")
    for i, r in enumerate(rows):
        print(f"{i} | {r['cached_tokens']}/{r['prompt_tokens']}/{r['completion_tokens']} "
              f"| {r['reasoning_chars']}/{r['content_chars']} | {r['output_sha']}")

    pt = sum(r["prompt_tokens"] for r in rows)
    ca = sum(r["cached_tokens"] for r in rows)
    ct = sum(r["completion_tokens"] for r in rows)
    print(f"TOTAL | cached={ca}/prompt={pt}/completion={ct} | hit_rate={ca/pt:.1%}")


if __name__ == "__main__":
    main()
```


## Test Result

| Turn | Retain=0 (cached / prompt / completion) | Retain=1 (cached / prompt / completion) |
|---:|---:|---:|
0 | 0 / 61 / 3613 | 0 / 61 / 3518
1 | 48 / 3729 / 4374 | 3168 / 3634 / 4080
2 | 3728 / 8151 / 2950 | 7392 / 7763 / 3071
3 | 8144 / 11145 / 1977 | 10560 / 10878 / 1290
4 | 11136 / 13168 / 8126 | 11616 / 12214 / 2935
Total | 23056 / 36254 / 21040 | 32736 / 34550 / 14894
Hit rate | 63.6% | 94.7%

## Relationship to prior work

#37898 added Marconi-style shared-prefix admission while preserving the existing last-state behavior.

#45845 introduced sparse Mamba retention. With VLLM_PREFIX_CACHE_RETENTION_INTERVAL=0, retention became based on replay boundaries and no longer included the finalized decode endpoint.

#47782 preserved shared-prefix junctions under sparse retention, but did not restore the finalized decode endpoint.

This PR restores that remaining last-state behavior.

## Future work

A separate follow-up will support hidden-state drafting.

A follow-up can offload finalized Decode-side checkpoints through KV connectors for reuse by Prefill workers in P/D deployments.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

