### PR TITLE
[MoE][OOT] Add prepare/finalize factory registry

### DIFF
--- a/tests/kernels/moe/test_oot_prepare_finalize_registry.py
+++ b/tests/kernels/moe/test_oot_prepare_finalize_registry.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+from vllm.config import ParallelConfig
+from vllm.config import parallel as parallel_config_module
+from vllm.engine.arg_utils import get_kwargs
+from vllm.model_executor.layers.fused_moe import all2all_utils
+from vllm.model_executor.layers.fused_moe.prepare_finalize import (
+    MoEPrepareFinalizeFactory,
+)
+
+
+def test_register_prepare_finalize_factory(monkeypatch):
+    backend = "test_backend"
+    expected = object()
+    expected_manager = object()
+    monkeypatch.setattr(all2all_utils, "_PREPARE_FINALIZE_FACTORIES", {})
+    monkeypatch.setattr(
+        parallel_config_module,
+        "SEQUENCE_PARALLEL_MOE_BACKENDS",
+        set(),
+    )
+    monkeypatch.setattr(
+        all2all_utils,
+        "get_ep_all2all_manager",
+        lambda *args: expected_manager,
+    )
+
+    @all2all_utils.register_moe_prepare_finalize_factory
+    class TestPrepareFinalizeFactory(MoEPrepareFinalizeFactory):
+        backend_name = backend
+        supports_sequence_parallel = True
+
+        @classmethod
+        def create(
+            cls,
+            *,
+            moe,
+            quant_config,
+            routing_tables,
+            all2all_manager,
+            allow_new_interface,
+            use_monolithic,
+            eep_stage,
+        ):
+            assert all2all_manager is expected_manager
+            return expected
+
+    moe = SimpleNamespace(
+        moe_parallel_config=SimpleNamespace(
+            use_all2all_kernels=True,
+            all2all_backend=backend,
+        )
+    )
+
+    actual = all2all_utils.maybe_make_prepare_finalize(
+        moe=moe,
+        quant_config=None,
+        routing_tables=None,
+        allow_new_interface=True,
+    )
+
+    assert actual is expected
+    config = ParallelConfig(
+        all2all_backend=backend,
+        enable_expert_parallel=True,
+        tensor_parallel_size=2,
+        data_parallel_size=2,
+    )
+    assert config.use_sequence_parallel_moe
+
+
+def test_parallel_config_accepts_oot_all2all_backend():
+    config = ParallelConfig(all2all_backend="test_oot_prepare_finalize")
+    assert config.all2all_backend == "test_oot_prepare_finalize"
+
+    cli_kwargs = get_kwargs(ParallelConfig)["all2all_backend"]
+    assert cli_kwargs["type"] is str
+    assert "choices" not in cli_kwargs
+    assert "allgather_reducescatter" in cli_kwargs["metavar"]

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -39,7 +39,7 @@ DataParallelBackend = Literal["ray", "mp"]
 EPLBPolicyOption = Literal["default"]
 DCPCommBackend = Literal["ag_rs", "a2a"]
 EPLBCommunicatorBackend = Literal["torch_nccl", "torch_gloo", "nixl", "pynccl"]
-All2AllBackend = Literal[
+BuiltinAll2AllBackend = Literal[
     "naive",
     "pplx",
     "deepep_high_throughput",
@@ -53,6 +53,16 @@ All2AllBackend = Literal[
     "flashinfer_nvlink_two_sided",
     "flashinfer_nvlink_one_sided",
 ]
+# Preserve built-in CLI choices while accepting OOT backends.
+All2AllBackend = BuiltinAll2AllBackend | str
+SEQUENCE_PARALLEL_MOE_BACKENDS = {
+    "allgather_reducescatter",
+    "deepep_high_throughput",
+    "deepep_low_latency",
+    "mori_high_throughput",
+    "mori_low_latency",
+    "nixl_ep",
+}
 
 
 @config
@@ -672,15 +682,7 @@ class ParallelConfig:
     @property
     def use_sequence_parallel_moe(self) -> bool:
         return (
-            self.all2all_backend
-            in (
-                "allgather_reducescatter",
-                "deepep_high_throughput",
-                "deepep_low_latency",
-                "mori_high_throughput",
-                "mori_low_latency",
-                "nixl_ep",
-            )
+            self.all2all_backend in SEQUENCE_PARALLEL_MOE_BACKENDS
             and self.enable_expert_parallel
             and self.tensor_parallel_size > 1
             and self.data_parallel_size > 1

--- a/vllm/model_executor/layers/fused_moe/all2all_utils.py
+++ b/vllm/model_executor/layers/fused_moe/all2all_utils.py
@@ -6,6 +6,7 @@ from typing import Any
 import torch
 
 from vllm.config import get_current_vllm_config
+from vllm.config import parallel as parallel_config
 from vllm.distributed import (
     get_ep_group,
 )
@@ -20,6 +21,7 @@ from vllm.model_executor.layers.fused_moe.modular_kernel import (
 )
 from vllm.model_executor.layers.fused_moe.prepare_finalize import (
     BatchedPrepareAndFinalize,
+    MoEPrepareFinalizeFactory,
     make_moe_prepare_and_finalize_naive_dp_ep,
     make_moe_prepare_and_finalize_no_dp_ep,
 )
@@ -38,6 +40,34 @@ from vllm.utils.import_utils import (
 )
 
 logger = init_logger(__name__)
+
+_PREPARE_FINALIZE_FACTORIES: dict[str, type[MoEPrepareFinalizeFactory]] = {}
+
+
+def register_moe_prepare_finalize_factory(
+    factory: type[MoEPrepareFinalizeFactory],
+) -> type[MoEPrepareFinalizeFactory]:
+    """Register a MoE Prepare/Finalize factory.
+
+    Args:
+        factory: Factory class to register.
+
+    Raises:
+        ValueError: If its backend name is empty or already registered.
+    """
+    backend_name = factory.backend_name
+    if not backend_name:
+        raise ValueError("MoE all2all backend name must not be empty")
+    previous = _PREPARE_FINALIZE_FACTORIES.get(backend_name)
+    if previous is not None and previous is not factory:
+        raise ValueError(
+            f"MoE Prepare/Finalize backend {backend_name!r} is already registered"
+        )
+    _PREPARE_FINALIZE_FACTORIES[backend_name] = factory
+    if factory.supports_sequence_parallel:
+        parallel_config.SEQUENCE_PARALLEL_MOE_BACKENDS.add(backend_name)
+    return factory
+
 
 if current_platform.is_cuda_alike():
     if has_deep_ep():
@@ -153,6 +183,19 @@ def maybe_make_prepare_finalize(
             return make_moe_prepare_and_finalize_no_dp_ep(use_monolithic)
 
     all2all_manager = get_ep_all2all_manager(eep_stage)
+    registered_prepare_finalize_factory = _PREPARE_FINALIZE_FACTORIES.get(
+        moe.moe_parallel_config.all2all_backend
+    )
+    if registered_prepare_finalize_factory is not None:
+        return registered_prepare_finalize_factory.create(
+            moe=moe,
+            quant_config=quant_config,
+            routing_tables=routing_tables,
+            allow_new_interface=allow_new_interface,
+            use_monolithic=use_monolithic,
+            eep_stage=eep_stage,
+            all2all_manager=all2all_manager,
+        )
 
     prepare_finalize: FusedMoEPrepareAndFinalize | None = None
 

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/__init__.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/__init__.py
@@ -4,6 +4,9 @@
 from vllm.model_executor.layers.fused_moe.prepare_finalize.batched import (
     BatchedPrepareAndFinalize,
 )
+from vllm.model_executor.layers.fused_moe.prepare_finalize.factory import (
+    MoEPrepareFinalizeFactory,
+)
 from vllm.model_executor.layers.fused_moe.prepare_finalize.naive_dp_ep import (
     MoEPrepareAndFinalizeNaiveDPEPModular,
     MoEPrepareAndFinalizeNaiveDPEPMonolithic,
@@ -17,6 +20,7 @@ from vllm.model_executor.layers.fused_moe.prepare_finalize.no_dp_ep import (
 
 __all__ = [
     "BatchedPrepareAndFinalize",
+    "MoEPrepareFinalizeFactory",
     "MoEPrepareAndFinalizeNaiveDPEPMonolithic",
     "MoEPrepareAndFinalizeNaiveDPEPModular",
     "make_moe_prepare_and_finalize_naive_dp_ep",

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/factory.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/factory.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from abc import ABC, abstractmethod
+from typing import Any, ClassVar
+
+import torch
+
+from vllm.model_executor.layers.fused_moe.config import (
+    FusedMoEConfig,
+    FusedMoEQuantConfig,
+)
+from vllm.model_executor.layers.fused_moe.modular_kernel import (
+    FusedMoEPrepareAndFinalize,
+)
+
+
+class MoEPrepareFinalizeFactory(ABC):
+    """Factory for a MoE Prepare/Finalize backend."""
+
+    backend_name: ClassVar[str]
+    supports_sequence_parallel: ClassVar[bool] = False
+
+    @classmethod
+    @abstractmethod
+    def create(
+        cls,
+        *,
+        moe: FusedMoEConfig,
+        quant_config: FusedMoEQuantConfig | None,
+        routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None,
+        allow_new_interface: bool,
+        use_monolithic: bool,
+        eep_stage: bool,
+        all2all_manager: Any,
+    ) -> FusedMoEPrepareAndFinalize: ...


### PR DESCRIPTION
## Purpose

Allow out-of-tree platforms to provide MoE Prepare/Finalize implementations without copying or patching the built-in backend selection chain.

This PR adds a narrow extension point that:

- registers a factory class by `all2all_backend` name;
- invokes the registered factory from `maybe_make_prepare_finalize()`;
- lets a registered backend declare sequence-parallel support; and
- accepts OOT backend names in `ParallelConfig` while preserving built-in names in CLI help.

Built-in backends keep their existing selection and construction paths. This PR does not add a communicator, transport implementation, or model-specific behavior.

Duplicate-work check: open vLLM PRs and issues were searched for MoE Prepare/Finalize factories, OOT registries, and all2all backend registries. No equivalent work was found. #47948 adds concrete in-tree FlashInfer EP backends but does not provide an OOT registration point.

Developed with Codex assistance and validated by the submitter.

## Test Plan

```bash
pytest tests/kernels/moe/test_oot_prepare_finalize_registry.py -v
```

## Test Result

The two registry and configuration test cases passed. On the current CPU-only runner, the repository-wide accelerator cleanup fixture subsequently reported teardown errors after both test cases completed successfully.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

