### PR TITLE
[CI] Remove default_torch_num_threads workaround from llava-onevision-transformers test

### DIFF
--- a/tests/models/multimodal/generation/test_common.py
+++ b/tests/models/multimodal/generation/test_common.py
@@ -234,7 +234,6 @@ VLM_TEST_SETTINGS = {
         image_size_factors=[(0.25, 0.5, 1.0)],
         vllm_runner_kwargs={
             "model_impl": "transformers",
-            "default_torch_num_threads": 1,
         },
         marks=[pytest.mark.core_model],
     ),


### PR DESCRIPTION
## Purpose

Removes the `"default_torch_num_threads": 1` workaround from the
`llava-onevision-transformers` entry in
`tests/models/multimodal/generation/test_common.py`.

Fixes #50130 (or reopens it with a real reproduction — see below).

The line was added in #25307 to avoid a hang reportedly occurring at the third
request. I could not reproduce that hang locally, and I found a reason it may
no longer bite: in my environment the engine core runs under `spawn`, and under
`spawn` the workaround cannot reach the engine core process at all
(`set_multiprocessing_worker_envs()` is only called from `MultiprocExecutor`,
and this test is TP=1 → `UniProcExecutor`; `spawn` re-imports torch fresh). Full
investigation notes are in
[[my comment on the issue](https://github.com/vllm-project/vllm/issues/50130)](https://github.com/vllm-project/vllm/issues/50130).

**I am explicitly opening this so CI can answer the one question I could not.**
I don't have access to the hardware this job runs on, and a nondeterministic
hang that doesn't reproduce in 29 local runs is not proven absent. If CI hangs,
that is the reproduction the issue has been missing since September, and I'll
follow up with `--timeout --timeout-method=thread` on this branch to capture
thread dumps rather than a silent 40-minute timeout.

## Test Plan

Run on vLLM v0.26.0, RTX 4090 (24 GB), CUDA 13.0, torch 2.11.0+cu130
(`ATen parallel backend: OpenMP`), transformers 5.13.1 — not HEAD, because no
x86_64 precompiled wheel exists for recent commits.

**1. The repro command from the issue, with the line removed — 20 runs:**

```
pytest tests/models/multimodal/generation/test_common.py -k llava-onevision-transformers
```

**2. The way CI actually invokes it** (`.buildkite/test_areas/models_multimodal.yaml`,
job "Multi-Modal Models (Standard) 3"), with the line removed — 9 tests sharing
one process, which the repro command above does not exercise:

```
pytest -v -s models/multimodal/generation/test_common.py -m core_model -k "not qwen2 and not qwen3 and not gemma"
```

## Test Result

**1.** 20/20 passed, no hang. Per-request timings for all three prompts of the
batch, from an instrumented run:

```
ADD_REQUEST_END idx=1 secs=0.215
ADD_REQUEST_END idx=2 secs=0.001
ADD_REQUEST_END idx=3 secs=0.002
```

No stall at request 3, or anywhere else.

**2.** `9 passed, 1 skipped, 249 deselected in 717.28s (0:11:57)`.

For (2) I needed `gpu_memory_utilization: 0.55` on that entry, because a 24 GB
card OOMs in the SigLIP vision tower on the largest image where CI's H200/35 GB
does not. **That change is not part of this PR** — it only affects memory
headroom, not threading, and is not present in the diff.

## Caveats

- Tested at v0.26.0, not HEAD.
- 29 clean runs is not proof of absence for a nondeterministic hang. This PR is
  as much a CI experiment as a cleanup.
- I could not exercise a surviving `fork` path locally: preventing the early
  CUDA initialization that forces `spawn` also makes the forked engine core die
  with `CUDA driver initialization failed`. If CI takes the `fork` path, my
  local results do not transfer.

@hmellor — you handed me #50130, thanks. Could you add `ready` when you get a
chance? The point of this PR is to let CI answer the question, so it isn't
useful until the pipeline runs.