### PR TITLE
[Bugfix] Validate tensor dtypes in the moe_wna16 GEMM op wrappers

### DIFF
--- a/csrc/libtorch_stable/moe/marlin_moe_wna16/ops.cu
+++ b/csrc/libtorch_stable/moe/marlin_moe_wna16/ops.cu
@@ -558,6 +558,14 @@ torch::stable::Tensor moe_wna16_marlin_gemm(
     int64_t size_n, int64_t size_k, bool is_k_full, bool use_atomic_add,
     bool use_fp32_reduce, bool is_zp_float, int64_t thread_k, int64_t thread_n,
     int64_t blocks_per_sm) {
+  // The kernel reinterprets topk_weights as `const float*` (see marlin_mm),
+  // so a non-float tensor would be silently type-punned, and for dtypes
+  // narrower than 4 bytes it would also be read out of bounds. Validate up
+  // front instead of relying on every caller to pass fp32.
+  STD_TORCH_CHECK(
+      topk_weights.scalar_type() == torch::headeronly::ScalarType::Float,
+      "scalar type of topk_weights must be float");
+
   vllm::ScalarTypeId a_type_id, c_type_id, s_type_id;
 
   auto c_dtype = a.scalar_type();

--- a/csrc/libtorch_stable/moe/moe_wna16.cu
+++ b/csrc/libtorch_stable/moe/moe_wna16.cu
@@ -285,6 +285,20 @@ torch::stable::Tensor moe_wna16_gemm(
     int64_t bit) {
   const torch::stable::accelerator::DeviceGuard device_guard(
       input.get_device_index());
+
+  // `b_scales` and `output` are fetched through the untyped `const_data_ptr()`
+  // / `mutable_data_ptr()` overloads and then reinterpret_cast to `scalar_t`,
+  // which is selected from `input.scalar_type()` alone. Their own scalar types
+  // are never consulted, so a mismatched tensor is silently type-punned — and
+  // for a dtype narrower than 2 bytes it is also read (or written) out of
+  // bounds. The other tensors are already covered by the templated
+  // `const_data_ptr<T>()` accessors, which check the scalar type themselves.
+  // Validate before `zero_()` so a rejected `output` is left untouched.
+  STD_TORCH_CHECK(b_scales.scalar_type() == input.scalar_type(),
+                  "scalar type of b_scales must match input");
+  STD_TORCH_CHECK(output.scalar_type() == input.scalar_type(),
+                  "scalar type of output must match input");
+
   torch::stable::zero_(output);
 
   const int num_experts = b_qweight.size(0);

--- a/tests/kernels/moe/test_moe.py
+++ b/tests/kernels/moe/test_moe.py
@@ -1073,6 +1073,62 @@ def test_fused_marlin_moe_rejects_non_fp32_topk_weights(bad_dtype):
         )
 
 
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")
+@pytest.mark.parametrize(
+    "mismatched,bad_dtype",
+    [
+        # same width (pure type-pun), wider (in-bounds garbage), and
+        # narrower than the assumed 2-byte element (out-of-bounds).
+        ("b_scales", torch.bfloat16),
+        ("b_scales", torch.float32),
+        ("b_scales", torch.int8),
+        ("output", torch.bfloat16),
+        ("output", torch.float32),
+        ("output", torch.int8),
+    ],
+)
+def test_moe_wna16_gemm_rejects_mismatched_dtypes(mismatched, bad_dtype):
+    """moe_wna16_gemm picks its `scalar_t` from `input.scalar_type()` only.
+
+    `b_scales` and `output` are then reinterpret_cast to that type without
+    consulting their own dtype, so a mismatch used to be silently type-punned
+    (and read/written out of bounds for dtypes narrower than 2 bytes). The op
+    must reject it instead.
+    """
+    import vllm._custom_ops as ops
+
+    e, m, n, k, topk = 4, 8, 64, 64, 2
+    group_size = 32
+    block_size_m = 16
+    dtype = torch.half
+
+    def _dev(shape, tensor_dtype):
+        return torch.zeros(shape, device="cuda", dtype=tensor_dtype)
+
+    scales_dtype = bad_dtype if mismatched == "b_scales" else dtype
+    output_dtype = bad_dtype if mismatched == "output" else dtype
+
+    with pytest.raises(
+        RuntimeError, match=f"scalar type of {mismatched} must match input"
+    ):
+        ops.moe_wna16_gemm(
+            _dev((m, k), dtype),
+            _dev((m * topk, n), output_dtype),
+            _dev((e, n, k // 2), torch.uint8),
+            _dev((e, n, k // group_size), scales_dtype),
+            None,
+            _dev((m, topk), torch.float32),
+            _dev((m * topk,), torch.int32),
+            _dev((m * topk // block_size_m + 1,), torch.int32),
+            _dev((1,), torch.int32),
+            topk,
+            block_size_m,
+            64,
+            group_size,
+            4,
+        )
+
+
 @pytest.mark.flaky(reruns=2)
 @pytest.mark.skipif(current_platform.is_rocm(), reason="Skip for rocm")
 @pytest.mark.usefixtures("default_vllm_config")

--- a/tests/kernels/moe/test_moe.py
+++ b/tests/kernels/moe/test_moe.py
@@ -1026,6 +1026,53 @@ def test_fused_marlin_moe(
     torch.testing.assert_close(marlin_output, torch_output, atol=4e-2, rtol=0)
 
 
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")
+@pytest.mark.parametrize("bad_dtype", [torch.bfloat16, torch.half])
+def test_fused_marlin_moe_rejects_non_fp32_topk_weights(bad_dtype):
+    """moe_wna16_marlin_gemm reads topk_weights as fp32.
+
+    Passing any other dtype used to be silently reinterpreted as float
+    (and read out of bounds for 2-byte dtypes), so the op must reject it.
+    """
+    import vllm._custom_ops as ops
+
+    e, m, n, k, topk = 4, 8, 64, 64, 2
+    moe_block_size = 16
+
+    def _dev(shape, dtype):
+        return torch.zeros(shape, device="cuda", dtype=dtype)
+
+    with pytest.raises(RuntimeError, match="topk_weights must be float"):
+        ops.moe_wna16_marlin_gemm(
+            _dev((m, k), torch.half),
+            None,
+            _dev((e, k // 16, n * 2), torch.int32),
+            None,
+            _dev((e, 1, n), torch.half),
+            None,
+            None,
+            None,
+            None,
+            None,
+            _dev((1024,), torch.int32),
+            _dev((m * topk,), torch.int32),
+            _dev((m * topk // moe_block_size + 1,), torch.int32),
+            _dev((1,), torch.int32),
+            _dev((m, topk), bad_dtype),
+            moe_block_size=moe_block_size,
+            top_k=topk,
+            mul_topk_weights=True,
+            b_q_type=scalar_types.uint4b8,
+            size_m=m,
+            size_n=n,
+            size_k=k,
+            is_k_full=True,
+            use_atomic_add=False,
+            use_fp32_reduce=True,
+            is_zp_float=False,
+        )
+
+
 @pytest.mark.flaky(reruns=2)
 @pytest.mark.skipif(current_platform.is_rocm(), reason="Skip for rocm")
 @pytest.mark.usefixtures("default_vllm_config")

--- a/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
@@ -97,6 +97,8 @@ def _fused_marlin_moe(
     activation_situ_linear_beta: float | None = None,
 ) -> torch.Tensor:
     assert hidden_states.ndim == 2
+    # The marlin moe kernel reads topk_weights as fp32.
+    assert topk_weights.dtype == torch.float32
     M, K = hidden_states.size()
     N = marlin_moe_intermediate_size(w1, w2)
     w13_num_shards = 2 if activation.is_gated else 1


### PR DESCRIPTION

## Purpose

Two op wrappers under `csrc/libtorch_stable/moe/` hand *untyped* data pointers to
kernels that reinterpret them as a fixed type, and never validate the tensor's
dtype. A caller passing the wrong dtype gets silently type-punned data — and
where the assumed element is wider than the real one, an out-of-bounds access
too. No error, wrong numbers.

Checked against vllm-project/vllm @ `8122a105`.

### 1. `moe_wna16_marlin_gemm` — `topk_weights` must be fp32

The kernel takes `topk_weights` as an untyped `void*` and reinterprets it as
`const float*`; the template signature is `const float* __restrict__
topk_weights`.

- kernel consumes fp32: `csrc/libtorch_stable/moe/marlin_moe_wna16/marlin_template.h#L71`, `#L272`, `#L520`
- unchecked reinterpret: `csrc/libtorch_stable/moe/marlin_moe_wna16/ops.cu#L402` (`(const float*)topk_weights` inside `marlin_mm`), fed by `ops.cu#L886`, which hands over `topk_weights.mutable_data_ptr()` untyped from the op entry at `ops.cu#L543`
- Python seam `_fused_marlin_moe` (`vllm/model_executor/layers/fused_moe/experts/marlin_moe.py`) had no assert, while the public entry points around it do (`assert topk_weights.dtype == torch.float32`)

### 2. `moe_wna16_gemm` — `b_scales` and `output` must match `input`

`moe_wna16_gemm` picks its `scalar_t` from `input.scalar_type()` alone
(`moe_wna16.cu#L321`, `#L333`), then reinterpret_casts `b_scales` and `output`
to that type. Both come from the *untyped* `const_data_ptr()` /
`mutable_data_ptr()` overloads, so their own scalar types are never consulted.

The rest of the wrapper is already safe, because the *templated*
`const_data_ptr<T>()` accessor does its own `STD_TORCH_CHECK` on the scalar
type. Full audit of every pointer the wrapper obtains:

| tensor | how the pointer is obtained | dtype validated? |
| --- | --- | --- |
| `input` | untyped `const_data_ptr()` + `reinterpret_cast` | yes — the cast is chosen *by* `input.scalar_type()`, and the `else` branch rejects anything but fp16/bf16 (`#L347`) |
| `output` | untyped `mutable_data_ptr()` + `reinterpret_cast` | **no** |
| `b_scales` | untyped `const_data_ptr()` + `reinterpret_cast` | **no** |
| `b_qweight` | `const_data_ptr<uint8_t>()` → `(const uint32_t*)` | yes (uint8) |
| `b_qzeros` | `const_data_ptr<uint8_t>()` → `(const uint32_t*)` | yes (uint8) |
| `topk_weights` | `const_data_ptr<float>()` | yes (float) |
| `sorted_token_ids` | `const_data_ptr<int32_t>()` | yes (int32) |
| `expert_ids` | `const_data_ptr<int32_t>()` | yes (int32) |
| `num_tokens_post_pad` | `const_data_ptr<int32_t>()` | yes (int32) |

Consequences of the two gaps:

- **same-width mismatch** (fp16 scales, bf16 input or vice versa): pure
  type-pun. bf16 bits decoded as fp16 give wildly wrong magnitudes. In bounds,
  silent.
- **wider actual dtype** (fp32 `b_scales`, fp16 `input`): offsets are computed
  in units of 2 bytes, so reads stay in bounds but pick up half of each fp32 —
  garbage scales, silent.
- **narrower actual dtype** (1-byte `b_scales`, e.g. an fp8 or int8 tensor):
  2 bytes read per logical element, so up to **2x the tensor length is read**,
  i.e. an OOB read of up to `nbytes(b_scales)` past the end. The `GROUPS == 8`
  path loads a `float4` (16 bytes) at a time, so the overshoot is not
  byte-granular.
- `output` is the same trap on the **write** side, through `atomicAdd`
  (`#L219`).

Note the triton sibling (`invoke_fused_moe_wna16_triton_kernel`) tolerates any
of this — triton loads `B_scale` at its real dtype. Only the CUDA variant has
this unwritten precondition, which is exactly why it is worth stating.

### Not a live regression

All in-tree callers already satisfy every check added here: the intermediate
caches in `fused_experts_impl` are allocated with `hidden_states.dtype`
(`fused_moe.py#L1712`, `#L1738`, `#L1750`), and `MoeWNA16Config` creates
`w13_scales` / `w2_scales` with `params_dtype`
(`quantization/moe_wna16.py#L301`, `#L313`). So both are latent misuse traps
rather than live bugs — but they fail silently, which is the worst mode for a
numerics kernel.

## Changes

- `marlin_moe_wna16/ops.cu`: `STD_TORCH_CHECK` that `topk_weights.scalar_type()
  == Float` at the top of the `moe_wna16_marlin_gemm` entry point, in the same
  form as the existing `a_scales` / `global_scale` float checks further down the
  same function (`ops.cu#L866-L871`).
- `marlin_moe.py`: the same assert at the `_fused_marlin_moe` seam, so misuse is
  reported at the Python boundary rather than from inside the extension.
- `moe_wna16.cu`: `STD_TORCH_CHECK` that `b_scales` and `output` match
  `input.scalar_type()`. Placed before `zero_()` and before the shape math, so a
  rejected `output` is not mutated first and a dtype mistake is reported as a
  dtype error instead of surfacing as a confusing `b_scales.size(2)` failure.
- `tests/kernels/moe/test_moe.py`: negative tests for both ops, covering each
  width class in the consequence list above (same-width, wider, and 1-byte).

No kernel, template or codegen changes; no behaviour change for correct callers.

## Test Plan

```bash
pytest tests/kernels/moe/test_moe.py -k "topk_weights or mismatched_dtypes"
```

Two negative tests, 8 cases total:

- `test_fused_marlin_moe_rejects_non_fp32_topk_weights` — `bfloat16`, `float16`
- `test_moe_wna16_gemm_rejects_mismatched_dtypes` — `{b_scales, output}` x
  `{bfloat16, float32, int8}`, i.e. one case per width class named above: same
  width (type-pun), wider (in-bounds garbage), and narrower than the assumed
  2-byte element (the out-of-bounds case).

Both call the ops directly with dummy zero tensors and assert `RuntimeError`.
Every new check sits immediately after the `DeviceGuard` and before `zero_()`,
the shape math and the kernel dispatch, so the tests need CUDA but **not** an
sm80+ marlin-capable GPU, and no kernel is launched.

## Test Result

Being explicit about what was and was not executed, since this matters for how
much the results are worth.

**Run locally, at the versions pinned in `.pre-commit-config.yaml`:**

| command | version | result |
| --- | --- | --- |
| `ruff check` (both changed `.py` files) | 0.14.0 | `All checks passed!` |
| `ruff format --diff` | 0.14.0 | `2 files already formatted` |
| `clang-format --dry-run --Werror csrc/libtorch_stable/moe/moe_wna16.cu` | 21.1.2 | clean, exit 0 |
| `clang-format --dry-run --Werror csrc/libtorch_stable/moe/marlin_moe_wna16/ops.cu` | 21.1.2 | clean, exit 0 |
| `mypy --python-version 3.12` (both changed `.py` files) | 1.20.2 | `Success: no issues found in 2 source files` |
| `python -m py_compile` (both changed `.py` files) | 3.12 | OK |
| `git diff --check` | — | clean |

**Not run — the new tests were NOT executed locally.** The GPU available to me
is compute capability 6.1; the wna16 CUDA and marlin paths need sm80+, and
neither `torch` nor `pytest` is importable in that environment, so not even
`--collect-only` was possible. **No CUDA build of the `.cu` changes was
performed.** The two new tests are therefore CI-covered only, and I have not
seen them pass. I would appreciate a maintainer kicking off the kernel test job.

What that leaves the C++ resting on: both changes are `STD_TORCH_CHECK` calls
using only `scalar_type()` and APIs already invoked elsewhere in the same
functions, in the same form as the neighbouring checks; the `match=` strings in
the tests were cross-checked character-by-character against the `.cu` sources
rather than by execution. If a check were mis-ordered, the tests would fail in
CI on message mismatch — a red test, not a false green.

One scoping note on the out-of-bounds claim: the OOB access described above is
**derived from the source** (element-width arithmetic on the `reinterpret_cast`
plus the `float4` load in the `GROUPS == 8` path), not something I observed
under a sanitizer. The `int8` test cases prove the op now *rejects* the 1-byte
dtype; they do not, and cannot, demonstrate the read that would have happened
without the check.

## Why this is not duplicating an existing PR

Searches run against `vllm-project/vllm`:

```bash
gh pr list --state open --search "moe_wna16"
gh pr list --state open --search "moe_wna16 dtype"
gh pr list --state open --search "48895 in:body"
gh issue list --state open --search "moe_wna16"
gh issue view 48895 --comments
```

Results:

- **#45884** (integer overflow, `moe_wna16.cu#L213-L220`) and **#45496**
  (out-of-bounds `sorted_token_ids`, `#L53-L55`) are both **kernel-body
  indexing** bugs, and both already have open PRs — **#45907** and **#45539**
  respectively. This PR is **host-side wrapper validation** at `#L286-L300`.
  No line overlap and no semantic overlap: these checks neither fix nor mask
  either issue, and neither of those PRs touches the op entry point.
- **#44563** is the nearest-sounding open PR (`moe_wna16` `BLOCK_SIZE_K`
  clamping) but it changes only
  `vllm/model_executor/layers/fused_moe/fused_moe.py` — no file overlap.
- No open issue or PR proposes dtype validation in either
  `moe_wna16.cu` or `marlin_moe_wna16/ops.cu`. #50561 is the only hit for a
  `moe_wna16` + dtype search.
- Nothing new has been filed against either file since 2026-07-31.

## AI assistance

AI assistance was used to produce this change. Per `AGENTS.md`, the commits
carry `Co-authored-by: Claude Opus 5 <noreply@anthropic.com>`. I have reviewed
every changed line myself and can defend the change end-to-end; the limits of
what I was able to execute are stated verbatim in **Test Result** above rather
than glossed over.

This change does not affect model output, accuracy, or serving behaviour for
any correct caller — it only rejects calls that were already producing
type-punned garbage — so no model evaluation results are included.


