### PR TITLE
[ROCm][Bugfix] Keep the MLA query in bf16 for AITER Gluon fp8 KV decode

### DIFF
--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -20,6 +20,7 @@ from vllm.model_executor.layers.attention.mla_attention import (
     QueryLenSupport,
 )
 from vllm.triton_utils import tl, triton
+from vllm.utils.torch_utils import is_quantized_kv_cache
 from vllm.v1.attention.backend import (
     AttentionCGSupport,
     AttentionLayer,
@@ -860,6 +861,17 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
             **mla_args,
         )
         AiterMLAHelper.check_num_heads_validity(num_heads)
+
+        # Decode with fewer than 16 heads is served by AITER's Gluon MLA
+        # kernel. Its fp8 KV regime (bh16bn128) takes a bf16 query and folds
+        # the KV dequant scale into the QK temperature, so a pre-quantized
+        # query is rejected with "q_nope/q_pe must be bf16". Tell the common
+        # layer to leave the query alone, as TritonMLAImpl already does for
+        # its own fp8 KV path.
+        if num_heads < AiterMLAHelper._AITER_MIN_MLA_HEADS and is_quantized_kv_cache(
+            self.kv_cache_dtype
+        ):
+            self.supports_quant_query_input = False
 
         unsupported_features = [alibi_slopes, sliding_window, logits_soft_cap]
         if any(unsupported_features):


### PR DESCRIPTION
## Purpose

Fixes fp8 KV cache on the ROCm AITER MLA backend for models with fewer than 16
MLA heads per rank.

`AiterMLAImpl` inherits `supports_quant_query_input = True` from
`MLACommonImpl`, so with an fp8 KV cache the common MLA layer pre-quantizes the
decode query
([`mla_attention.py`](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/layers/attention/mla_attention.py)
`if fp8_attention and self.impl.supports_quant_query_input:`).

For fewer than 16 heads the backend dispatches decode to AITER's Gluon MLA
kernel. Its fp8 KV regime (`bh16bn128`) is a **bf16-query / fp8-KV** kernel: it
folds the KV dequant scale into the QK temperature and asserts a bf16 query. So
the pre-quantized query is rejected and the engine dies during init:

```text
RuntimeError: Worker failed with error
  'q_nope/q_pe must be bf16, got torch.float8_e4m3fn/torch.float8_e4m3fn'
RuntimeError: Engine core initialization failed.
```

Kimi-K3 TP8 hits this: 96 MLA heads over 8 ranks is 12 heads per rank.

## Fix

Leave the query unquantized for that combination, exactly as `TritonMLAImpl`
already does for its own fp8 KV path
([`triton_mla.py`](https://github.com/vllm-project/vllm/blob/main/vllm/v1/attention/backends/mla/triton_mla.py)):

```python
if num_heads < AiterMLAHelper._AITER_MIN_MLA_HEADS and is_quantized_kv_cache(
    self.kv_cache_dtype
):
    self.supports_quant_query_input = False
```

Head counts of 16 and above are untouched and keep using the fp8 query the asm
kernels expect. bf16 KV caches are untouched at every head count.

## Test Plan

Serve Kimi-K3 TP8 on gfx950 with `--kv-cache-dtype fp8` and drive concurrent
decode, comparing against the same run without the flag.

```
Hardware   8x AMD Instinct MI355X (gfx950), ROCm 7.2.3
vLLM       0.1.dev19253+g5f76ae224.d20260727
AITER      0.1.17.dev395+g68e42f5f4 + ROCm/aiter#4480
Model      Kimi-K3 (MXFP4), TP8 -> 12 MLA heads/rank
```

```bash
export VLLM_ROCM_USE_AITER=1
export NCCL_DMABUF_ENABLE=0
export VLLM_ALLREDUCE_USE_FLASHINFER=1
export VLLM_ENGINE_READY_TIMEOUT_S=3600
export HSA_NO_SCRATCH_RECLAIM=1        # MEC firmware 34 < 177

vllm serve /root/models/Kimi-K3 --port 39005 \
  --tensor-parallel-size=8 \
  --gpu-memory-utilization 0.9 \
  --max-model-len 13312 \
  --trust-remote-code \
  --enable-prefix-caching \
  --moe-backend auto \
  --load-format auto \
  --max-num-seqs 512 \
  --max-cudagraph-capture-size 256 \
  --kv-cache-dtype fp8          # omitted for the bf16 baseline
```

Load generator: N concurrent `/v1/completions` requests at `temperature=0`,
each with a unique ~8192-token prompt and `max_tokens=256`. Identical protocol
on both sides: one discarded warmup pass, then five timed repetitions of 64
requests at concurrency 32; the first timed repetition was a cold outlier on
both sides and is excluded.

## Test Result

Without this change the server never reaches startup; it fails engine init with
the `q_nope/q_pe must be bf16` error above. With it, `Application startup
complete`, and 64/64 requests succeed in every repetition.

Capacity, from the engine's own accounting (deterministic across reboots):

| | bf16 KV | fp8 KV | delta |
|---|---:|---:|---:|
| Available KV cache memory | 48.21 GiB | 43.71 GiB | |
| GPU KV cache size | 1,348,394 tok | 1,955,976 tok | **+45%** |
| max concurrency @ 13312 | 101.29x | 146.93x | **+45%** |

Throughput at ISL 8192 / OSL 256 / concurrency 32:

| | bf16 KV | fp8 KV |
|---|---:|---:|
| throughput median | 579.9 tok/s | 600.2 tok/s |
| throughput range (4 reps) | 559.9 - 611.5 | 517.6 - 626.9 |
| p50 latency median | 11.4 s | 10.9 s |

fp8 is 3.5% faster at the median, but the ranges overlap, so this is within
run-to-run variance and is not claimed as a speedup. The benefit of fp8 KV on
this model is the +45% capacity; MLA is only ~10% of GPU time at this shape.

Greedy output is byte-identical between fp8 and bf16 for the shared prompts.
(Capacity grows +45% rather than 2x because only Kimi-K3's 24 full-attention
layers use the MLA cache; the other 69 are KDA and are not quantized.)

Kernel-level numerics for the fp8 regime at batch > 1 were validated separately
against an fp32 reference over the dequantized cache; see the companion AITER
PR.

## Companion PR

This change alone is not sufficient: AITER's `mla_gluon` also asserts
`batch_size == 1` in the `bh16bn128` regime, so with only this PR the server
fails with `mla_gluon[bh16bn128] requires batch_size=1, got 512`.

- ROCm/aiter#4480

The two are mutually dependent for fp8 KV to work and independently harmless,
since fp8 KV on small-head MLA is currently broken in every combination. Merge
order does not matter.

## Related

- #50347 is a different failure on the same kernel and the same MI355X /
  Kimi-K3 TP8 stack (illegal memory access at ~337K context). It is not
  addressed here: that report's KV pool works out to roughly 2.10M slots
  (337,128 tokens at 16.08% usage), which is below the 3.73M-slot int32
  row-base limit fixed in the companion AITER PR, so the two are distinct.
- #50371 enables the same 12-head Kimi-K3 TP8 decode shape via head padding
  onto the 16-head persistent asm kernel, but is restricted to bf16 query and
  bf16 KV, so it does not overlap with this fp8 path.

---

*Found and validated with [ROCm Hyperloom](https://github.com/AMD-AGI/Hyperloom), an agentic system that auto-optimizes LLM inference workloads on AMD GPUs.*
