### PR TITLE
[Reload] Probe dummy-load manifests for layerwise reload

### DIFF
--- a/tests/model_executor/model_loader/test_load_probe.py
+++ b/tests/model_executor/model_loader/test_load_probe.py
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from vllm.config.load import LoadConfig
+from vllm.model_executor.model_loader.dummy_loader import DummyModelLoader
+from vllm.model_executor.model_loader.reload.layerwise import (
+    freeze_load_plan,
+    record_metadata_for_reloading,
+)
+from vllm.model_executor.model_loader.reload.plan import get_load_plan
+from vllm.model_executor.model_loader.reload.probe import (
+    LoadProbeError,
+    probe_model_load,
+    safetensors_meta_weights,
+    validate_probe_plan_coverage,
+)
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+
+
+class ProbeModel(torch.nn.Module):
+    def __init__(self, loader=default_weight_loader):
+        super().__init__()
+        self.layer = torch.nn.Module()
+        weight = torch.nn.Parameter(torch.arange(8, dtype=torch.float32))
+        weight.weight_loader = loader
+        self.layer.register_parameter("weight", weight)
+
+    def load_weights(self, weights):
+        loaded = set()
+        for name, value in weights:
+            param = self.get_parameter(name)
+            param.weight_loader(param, value)
+            loaded.add(name)
+        return loaded
+
+
+def meta_weight(size=8):
+    return torch.empty(size, dtype=torch.float32, device="meta")
+
+
+def test_probe_records_plan_without_changing_parameter():
+    model = ProbeModel()
+    record_metadata_for_reloading(model)
+    before = model.layer.weight.detach().clone()
+
+    report = probe_model_load(model, [("layer.weight", meta_weight())])
+    validate_probe_plan_coverage(model, report)
+    freeze_load_plan(model)
+
+    assert report.loaded_weights == {"layer.weight"}
+    assert report.intercepted_writes == ["aten.copy_.default"]
+    assert torch.equal(model.layer.weight, before)
+    assert get_load_plan(model.layer) == {
+        ("layer.weight", "weight", ()): 1,
+    }
+
+
+def test_probe_records_selector_from_real_routing():
+    def shard_loader(param, loaded_weight, loaded_shard_id):
+        param.copy_(loaded_weight)
+
+    class RoutedModel(ProbeModel):
+        def load_weights(self, weights):
+            for name, value in weights:
+                source, shard = name.rsplit(".", 1)
+                assert source == "layer.weight"
+                self.layer.weight.weight_loader(self.layer.weight, value, shard)
+            return {"layer.weight"}
+
+    model = RoutedModel(shard_loader)
+    record_metadata_for_reloading(model)
+    report = probe_model_load(
+        model,
+        [
+            ("layer.weight.q", meta_weight()),
+            ("layer.weight.k", meta_weight()),
+        ],
+    )
+    validate_probe_plan_coverage(model, report)
+    freeze_load_plan(model)
+
+    assert get_load_plan(model.layer) == {
+        ("layer.weight.q", "weight", (("loaded_shard_id", "q"),)): 1,
+        ("layer.weight.k", "weight", (("loaded_shard_id", "k"),)): 1,
+    }
+
+
+def test_probe_records_expert_selector_and_omits_declined_load():
+    def expert_loader(param, loaded_weight, expert_id, return_success=False):
+        if expert_id != 0:
+            return False if return_success else None
+        param.copy_(loaded_weight)
+        return True if return_success else None
+
+    class ExpertModel(ProbeModel):
+        def load_weights(self, weights):
+            for name, value in weights:
+                expert_id = int(name.rsplit(".", 1)[1])
+                self.layer.weight.weight_loader(
+                    self.layer.weight,
+                    value,
+                    expert_id,
+                    return_success=True,
+                )
+
+    model = ExpertModel(expert_loader)
+    record_metadata_for_reloading(model)
+    report = probe_model_load(
+        model,
+        [("layer.weight.0", meta_weight()), ("layer.weight.1", meta_weight())],
+    )
+    validate_probe_plan_coverage(model, report)
+    freeze_load_plan(model)
+
+    assert get_load_plan(model.layer) == {
+        ("layer.weight.0", "weight", (("expert_id", 0),)): 1,
+    }
+
+
+def test_probe_rejects_direct_write_without_plan_key():
+    class DirectWriteModel(ProbeModel):
+        def load_weights(self, weights):
+            for name, value in weights:
+                self.get_parameter(name).copy_(value)
+            return {"layer.weight"}
+
+    model = DirectWriteModel()
+    record_metadata_for_reloading(model)
+    report = probe_model_load(model, [("layer.weight", meta_weight())])
+
+    with pytest.raises(LoadProbeError, match="without LoadPlan coverage"):
+        validate_probe_plan_coverage(model, report)
+
+
+def test_probe_fails_closed_on_data_dependent_loader():
+    def data_dependent_loader(param, loaded_weight):
+        if loaded_weight.sum().item() > 0:
+            param.copy_(loaded_weight)
+
+    model = ProbeModel(data_dependent_loader)
+    record_metadata_for_reloading(model)
+    with pytest.raises(LoadProbeError, match="PROBE_UNSUPPORTED_OPERATOR"):
+        probe_model_load(model, [("layer.weight", meta_weight())])
+
+
+def test_safetensors_schema_reader_returns_meta_tensors(tmp_path):
+    save_file(
+        {
+            "layer.weight": torch.ones(8, dtype=torch.float32),
+            "layer.scale": torch.ones(2, dtype=torch.bfloat16),
+        },
+        tmp_path / "model.safetensors",
+    )
+
+    weights = dict(safetensors_meta_weights(str(tmp_path)))
+
+    assert set(weights) == {"layer.weight", "layer.scale"}
+    assert weights["layer.weight"].is_meta
+    assert weights["layer.weight"].shape == (8,)
+    assert weights["layer.scale"].dtype == torch.bfloat16
+
+
+def test_dummy_loader_probe_is_explicitly_configured():
+    default_loader = DummyModelLoader(LoadConfig(load_format="dummy"))
+    enabled_loader = DummyModelLoader(
+        LoadConfig(
+            load_format="dummy",
+            model_loader_extra_config={"enable_load_probe": True},
+        )
+    )
+
+    assert not default_loader.enable_load_probe
+    assert enabled_loader.enable_load_probe
+
+
+@pytest.mark.parametrize(
+    "extra_config, match",
+    [
+        ({"enable_load_probe": "yes"}, "enable_load_probe must be a bool"),
+        ({"unknown": True}, "Unexpected extra config keys"),
+    ],
+)
+def test_dummy_loader_rejects_invalid_probe_config(extra_config, match):
+    with pytest.raises(ValueError, match=match):
+        DummyModelLoader(
+            LoadConfig(
+                load_format="dummy",
+                model_loader_extra_config=extra_config,
+            )
+        )
+
+
+def test_dummy_loader_probe_resolves_remote_safetensors(monkeypatch, tmp_path):
+    save_file({"layer.weight": torch.ones(8)}, tmp_path / "model.safetensors")
+    calls = []
+
+    def fake_download_weights_from_hf(
+        model_name_or_path,
+        cache_dir,
+        allow_patterns,
+        revision=None,
+        subfolder=None,
+        ignore_patterns=None,
+    ):
+        calls.append((model_name_or_path, allow_patterns, revision))
+        return str(tmp_path)
+
+    monkeypatch.setattr(
+        "vllm.model_executor.model_loader.dummy_loader.download_weights_from_hf",
+        fake_download_weights_from_hf,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.model_loader.dummy_loader."
+        "download_safetensors_index_file_from_hf",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.model_loader.dummy_loader.maybe_download_from_modelscope",
+        lambda *args, **kwargs: None,
+    )
+
+    loader = DummyModelLoader(
+        LoadConfig(
+            load_format="dummy",
+            model_loader_extra_config={"enable_load_probe": True},
+        )
+    )
+    model_config = type(
+        "ModelConfigStub",
+        (),
+        {"model": "org/model", "revision": "main"},
+    )()
+
+    weights = dict(loader._probe_meta_weights(model_config))
+
+    assert calls == [("org/model", ["*.safetensors"], "main")]
+    assert weights["layer.weight"].is_meta

--- a/tests/model_executor/model_loader/test_reload.py
+++ b/tests/model_executor/model_loader/test_reload.py
@@ -1,17 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import gc
-import inspect
 from weakref import WeakKeyDictionary, ref
 
 import pytest
 import torch
 from torch.nn.parameter import UninitializedParameter
 
+import vllm.model_executor.model_loader.reload.layerwise as reload_layerwise
 import vllm.model_executor.model_loader.reload.meta as reload_meta
 from vllm.model_executor.layers.linear import QKVParallelLinear
 from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
 from vllm.model_executor.model_loader.reload.layerwise import (
+    finalize_layerwise_processing,
     finalize_layerwise_reload,
     initialize_layerwise_reload,
     initialize_online_processing,
@@ -19,14 +20,21 @@ from vllm.model_executor.model_loader.reload.layerwise import (
 )
 from vllm.model_executor.model_loader.reload.meta import (
     capture_layer_to_meta,
-    get_numel_loaded,
     materialize_layer,
     materialize_meta_tensor,
     restore_layer_on_meta,
     to_meta_tensor,
 )
+from vllm.model_executor.model_loader.reload.plan import (
+    freeze_load_plan,
+    get_load_plan,
+    load_source,
+)
 from vllm.model_executor.model_loader.reload.types import LayerReloadingInfo
-from vllm.model_executor.model_loader.reload.utils import get_layer_tensors
+from vllm.model_executor.model_loader.reload.utils import (
+    get_layer_tensors,
+    get_loadable_layer_tensors,
+)
 from vllm.model_executor.model_loader.weight_utils import (
     composed_weight_loader,
     default_weight_loader,
@@ -99,6 +107,7 @@ class _NonPersistentBufferLayer(torch.nn.Module):
         super().__init__()
         self.weight = torch.nn.Parameter(torch.ones(2, 2))
         self.register_buffer("scale", torch.tensor(0.25), persistent=False)
+        self.scale.weight_loader = default_weight_loader
 
 
 def test_move_metatensors():
@@ -465,35 +474,6 @@ def test_model_cleanup(dist_init, default_vllm_config):
     assert len(mock_info_dict) == 0
 
 
-def test_get_numel_loaded():
-    param = torch.empty(10, device="meta")
-    loaded_weight = torch.empty(10)
-
-    def complex_weight_loader(param, loaded_weight):
-        param[:3] = loaded_weight[:3]
-        param[5:8] = loaded_weight[5:8]
-        return "value"
-
-    args = inspect.signature(complex_weight_loader).bind(param, loaded_weight)
-    num_loaded, ret = get_numel_loaded(complex_weight_loader, args)
-    assert num_loaded == 6
-    assert ret == "value"
-
-
-def test_get_numel_loaded_caps_at_param_size():
-    # composed_weight_loader copies into the param twice (the load and the
-    # in-place post-load transform), but only param.numel() distinct elements
-    # are loaded. get_numel_loaded must not double-count, otherwise a layer's
-    # loaded-element total can be reached early and trailing params get dropped.
-    param = torch.empty(10)
-    loaded_weight = torch.ones(10)
-    loader = composed_weight_loader(default_weight_loader, lambda x: x + 1)
-
-    args = inspect.signature(loader).bind(param, loaded_weight)
-    num_loaded, _ = get_numel_loaded(loader, args)
-    assert num_loaded == 10
-
-
 class _ComposedLoaderLayer(torch.nn.Module):
     """Mimics a Mamba2 mixer's equal-numel direct params (A, D, dt_bias).
 
@@ -543,13 +523,19 @@ def test_layerwise_reload_composed_loader_does_not_drop_params(monkeypatch):
     }
 
     record_metadata_for_reloading(model)
+    for name in ("A", "dt_bias", "D"):
+        param = getattr(layer, name)
+        with load_source(name):
+            param.weight_loader(param, torch.zeros_like(param))
+    freeze_load_plan(model)
     initialize_layerwise_reload(model)
     # Mimic real load_weights: resolve params once, then load in checkpoint
     # order with D last (the param that was dropped).
     params = dict(layer.named_parameters())
     for name in ("A", "dt_bias", "D"):
         param = params[name]
-        param.weight_loader(param, loaded[name])
+        with load_source(name):
+            param.weight_loader(param, loaded[name])
     finalize_layerwise_reload(model, model_config=None)
 
     assert torch.equal(layer.A, -torch.exp(loaded["A"]))
@@ -630,9 +616,13 @@ def test_layerwise_reload_skips_non_persistent_parameter_alias_buffers(monkeypat
         reload_meta, "materialize_meta_tensor", materialize_with_sentinel
     )
 
-    record_metadata_for_reloading(model)
+    _initial_load(
+        model,
+        lambda: layer.weight.weight_loader(layer.weight, layer.weight.detach().clone()),
+    )
     initialize_layerwise_reload(model)
-    layer.weight.weight_loader(layer.weight, loaded_weight)
+    with load_source("test.weight"):
+        layer.weight.weight_loader(layer.weight, loaded_weight)
     finalize_layerwise_reload(model, model_config=None)
 
     assert torch.equal(layer.weight, loaded_weight)
@@ -674,9 +664,18 @@ def test_layerwise_reload_skips_child_parameter_alias_buffers(monkeypatch):
     )
 
     record_metadata_for_reloading(model)
+    with load_source("conv1d.weight"):
+        layer.conv1d.weight.weight_loader(
+            layer.conv1d.weight, layer.conv1d.weight.detach().clone()
+        )
+    with load_source("scale"):
+        layer.scale.weight_loader(layer.scale, layer.scale.detach().clone())
+    freeze_load_plan(model)
     initialize_layerwise_reload(model)
-    layer.conv1d.weight.weight_loader(layer.conv1d.weight, loaded_conv)
-    layer.scale.weight_loader(layer.scale, loaded_scale)
+    with load_source("conv1d.weight"):
+        layer.conv1d.weight.weight_loader(layer.conv1d.weight, loaded_conv)
+    with load_source("scale"):
+        layer.scale.weight_loader(layer.scale, loaded_scale)
     finalize_layerwise_reload(model, model_config=None)
 
     assert torch.equal(layer.conv1d.weight, loaded_conv)
@@ -709,9 +708,15 @@ def test_layerwise_reload_restores_alias_buffer_on_zero_size_layer(monkeypatch):
         reload_meta, "materialize_meta_tensor", materialize_with_sentinel
     )
 
-    record_metadata_for_reloading(model)
+    _initial_load(
+        model,
+        lambda: layer.conv1d.weight.weight_loader(
+            layer.conv1d.weight, layer.conv1d.weight.detach().clone()
+        ),
+    )
     initialize_layerwise_reload(model)
-    layer.conv1d.weight.weight_loader(layer.conv1d.weight, loaded_conv)
+    with load_source("test.weight"):
+        layer.conv1d.weight.weight_loader(layer.conv1d.weight, loaded_conv)
     finalize_layerwise_reload(model, model_config=None)
 
     assert torch.equal(layer.conv_weights, loaded_conv.view(-1))
@@ -744,9 +749,13 @@ def test_layerwise_reload_preserves_unloaded_non_persistent_buffers(monkeypatch)
         reload_meta, "materialize_meta_tensor", materialize_with_sentinel
     )
 
-    record_metadata_for_reloading(model)
+    _initial_load(
+        model,
+        lambda: layer.weight.weight_loader(layer.weight, layer.weight.detach().clone()),
+    )
     initialize_layerwise_reload(model)
-    layer.weight.weight_loader(layer.weight, loaded_weight)
+    with load_source("test.weight"):
+        layer.weight.weight_loader(layer.weight, loaded_weight)
     finalize_layerwise_reload(model, model_config=None)
 
     assert torch.equal(layer.weight, loaded_weight)
@@ -778,9 +787,16 @@ def test_layerwise_reload_updates_loaded_non_persistent_buffers(monkeypatch):
     )
 
     record_metadata_for_reloading(model)
+    with load_source("weight"):
+        layer.weight.weight_loader(layer.weight, layer.weight.detach().clone())
+    with load_source("scale"):
+        layer.scale.weight_loader(layer.scale, layer.scale.detach().clone())
+    freeze_load_plan(model)
     initialize_layerwise_reload(model)
-    layer.weight.weight_loader(layer.weight, loaded_weight)
-    layer.scale.weight_loader(layer.scale, loaded_scale)
+    with load_source("weight"):
+        layer.weight.weight_loader(layer.weight, loaded_weight)
+    with load_source("scale"):
+        layer.scale.weight_loader(layer.scale, loaded_scale)
     finalize_layerwise_reload(model, model_config=None)
 
     assert torch.equal(layer.weight, loaded_weight)
@@ -951,3 +967,475 @@ def test_online_quantize_reload(
         mul_perp = llm.generate_prompt_perplexity(["3 4 = 12"], mask=["3 4 ="])[0]
         add_perp = llm.generate_prompt_perplexity(["3 4 = 7"], mask=["3 4 ="])[0]
         assert add_perp < mul_perp
+
+
+class _PaddedDerivedLayer(torch.nn.Module):
+    """Mirrors Kimi GDN, whose padding row and loader-derived buffer are storage
+    no checkpoint tensor can write, putting an element count out of reach."""
+
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.zeros(4, 2))
+        self.register_buffer("derived", torch.zeros(5), persistent=False)
+        derived = self.derived
+
+        def loader(param, loaded_weight, loaded_shard_id=None):
+            param.data[:3].copy_(loaded_weight)
+            derived.fill_(float(loaded_weight.sum()))
+
+        self.weight.weight_loader = loader
+
+
+def _initial_load(model, apply_weights, source="test.weight"):
+    """Run the recorded initial load and freeze the contract, as load_model does."""
+    record_metadata_for_reloading(model)
+    with load_source(source):
+        apply_weights()
+    freeze_load_plan(model)
+
+
+class _ShardedExpertLayer(torch.nn.Module):
+    """Stand-in for vLLM's shared MoE loader, which declines a non-local expert
+    via `return_success` without touching storage."""
+
+    def __init__(self, local_experts: list[int]):
+        super().__init__()
+        self.local_experts = local_experts
+        self.w = torch.nn.Parameter(torch.zeros(len(local_experts), 2))
+
+        def loader(param, loaded_weight, expert_id, return_success=False):
+            if expert_id not in self.local_experts:
+                return False if return_success else None
+            param.data[self.local_experts.index(expert_id)].copy_(loaded_weight)
+            return True if return_success else None
+
+        self.w.weight_loader = loader
+
+
+def _load_experts(layer, expert_ids, value, *, return_success=False):
+    """Offer one application per expert, as a broadcasting sender does."""
+    # Omitted rather than passed as False, so a loader predating the protocol
+    # can be driven by the same helper.
+    kwargs = {"return_success": True} if return_success else {}
+    results = []
+    for expert_id in expert_ids:
+        with load_source(f"experts.{expert_id}.w"):
+            results.append(
+                layer.w.weight_loader(
+                    layer.w, torch.full((2,), float(value)), expert_id, **kwargs
+                )
+            )
+    return results
+
+
+def test_non_local_expert_applications_are_absorbed():
+    """A broadcast expert that is not local to this rank writes nothing, so it
+    must not fail the update whether it lands before or after publish."""
+    layer = _ShardedExpertLayer(local_experts=[0, 1])
+    model = torch.nn.Sequential(layer)
+
+    record_metadata_for_reloading(model)
+    _load_experts(layer, [0, 1], 1.0)  # rank-filtered, as from disk
+    freeze_load_plan(model)
+
+    initialize_layerwise_reload(model)
+    # A contiguous expert map puts this rank's experts first.
+    _load_experts(layer, [0, 1], 5.0, return_success=True)
+    assert not layer.w.is_meta, "layer must publish on its own expected set"
+
+    # So the trailing non-local applications land on a published layer.
+    assert _load_experts(layer, [2, 3], 5.0, return_success=True) == [False, False]
+    assert torch.equal(layer.w, torch.full((2, 2), 5.0))
+
+    finalize_layerwise_reload(model, model_config=None)
+    assert torch.equal(layer.w, torch.full((2, 2), 5.0))
+
+
+class _QuietExpertLayer(torch.nn.Module):
+    """An expert loader predating `return_success`, which can only ignore a
+    non-local expert rather than report it."""
+
+    def __init__(self, local_experts: list[int]):
+        super().__init__()
+        self.local_experts = local_experts
+        self.w = torch.nn.Parameter(torch.zeros(len(local_experts), 2))
+
+        def loader(param, loaded_weight, expert_id):
+            if expert_id in self.local_experts:
+                param.data[self.local_experts.index(expert_id)].copy_(loaded_weight)
+
+        self.w.weight_loader = loader
+
+
+def test_extra_applications_before_publish_do_not_fail_validation():
+    """Completion is a lower bound, so an application counted outside the
+    contract must be absorbed rather than fail the update."""
+    layer = _QuietExpertLayer(local_experts=[0, 1])
+    model = torch.nn.Sequential(layer)
+
+    record_metadata_for_reloading(model)
+    _load_experts(layer, [0, 1], 1.0)  # rank-filtered, as from disk
+    freeze_load_plan(model)
+
+    initialize_layerwise_reload(model)
+    # Expert 2 is interleaved so it lands while the layer is still incomplete.
+    _load_experts(layer, [0, 2, 1], 5.0)
+    assert not layer.w.is_meta, "the expected set alone must publish the layer"
+
+    finalize_layerwise_reload(model, model_config=None)
+    assert torch.equal(layer.w, torch.full((2, 2), 5.0))
+
+
+def test_loader_return_value_reaches_the_caller():
+    """14 MoE models branch on `return_success`; the wrapper must not swallow it."""
+    layer = _ShardedExpertLayer(local_experts=[0])
+    model = torch.nn.Sequential(layer)
+
+    record_metadata_for_reloading(model)
+    _load_experts(layer, [0], 1.0)
+    freeze_load_plan(model)
+
+    initialize_layerwise_reload(model)
+    assert _load_experts(layer, [0, 1], 5.0, return_success=True) == [True, False]
+
+
+def test_write_after_publish_without_decline_protocol_raises():
+    """A loader that cannot decline has no business writing to a published layer."""
+    layer = torch.nn.Module()
+    layer.weight = torch.nn.Parameter(torch.zeros(4))
+    layer.weight.weight_loader = default_weight_loader
+    model = torch.nn.Sequential(layer)
+
+    _initial_load(
+        model, lambda: layer.weight.weight_loader(layer.weight, torch.ones(4))
+    )
+
+    initialize_layerwise_reload(model)
+    with load_source("test.weight"):
+        layer.weight.weight_loader(layer.weight, torch.full((4,), 5.0))
+    assert not layer.weight.is_meta, "single-source layer publishes immediately"
+
+    with (
+        load_source("other.weight"),
+        pytest.raises(RuntimeError, match="after the layer completed"),
+    ):
+        layer.weight.weight_loader(layer.weight, torch.full((4,), 9.0))
+
+
+def test_load_plan_records_shard_selectors():
+    """The contract is a multiset of loader applications keyed by destination
+    and selector, so one packed parameter fanning in from N checkpoint tensors
+    requires all N on reload."""
+    layer = torch.nn.Module()
+    layer.weight = torch.nn.Parameter(torch.zeros(4))
+    calls = []
+    layer.weight.weight_loader = lambda param, w, loaded_shard_id=None: calls.append(
+        loaded_shard_id
+    )
+    model = torch.nn.Sequential(layer)
+
+    _initial_load(
+        model,
+        lambda: [
+            layer.weight.weight_loader(layer.weight, torch.ones(2), shard)
+            for shard in ("q", "k", "q")
+        ],
+    )
+
+    plan = get_load_plan(layer)
+    assert plan == {
+        ("test.weight", "weight", (("loaded_shard_id", "q"),)): 2,
+        ("test.weight", "weight", (("loaded_shard_id", "k"),)): 1,
+    }
+    assert calls == ["q", "k", "q"]
+
+
+def test_payload_dtype_does_not_change_the_contract():
+    """An fp32 payload where the checkpoint held bf16 is the same loader
+    application, so it must satisfy the contract rather than read as missing."""
+    layer = torch.nn.Module()
+    layer.weight = torch.nn.Parameter(torch.zeros(4, dtype=torch.bfloat16))
+    layer.weight.weight_loader = lambda param, w: param.data.copy_(w)
+    model = torch.nn.Sequential(layer)
+
+    _initial_load(
+        model,
+        lambda: layer.weight.weight_loader(
+            layer.weight, torch.ones(4, dtype=torch.bfloat16)
+        ),
+    )
+
+    initialize_layerwise_reload(model)
+    with load_source("test.weight"):
+        layer.weight.weight_loader(layer.weight, torch.full((4,), 5.0))
+
+    assert reload_layerwise.get_layerwise_info(layer).is_complete()
+    assert not layer.weight.is_meta
+
+
+def test_freeze_load_plan_removes_recorders():
+    """Recorders must not survive into serving: a leaked wrapper would keep
+    recording and would shadow the real loader identity."""
+    layer = torch.nn.Module()
+    layer.weight = torch.nn.Parameter(torch.zeros(4))
+    original = lambda param, w: param.data.copy_(w)  # noqa: E731
+    layer.weight.weight_loader = original
+    layer.no_loader = torch.nn.Parameter(torch.zeros(2))
+    model = torch.nn.Sequential(layer)
+
+    record_metadata_for_reloading(model)
+    assert layer.weight.weight_loader is not original
+
+    with load_source("test.weight"):
+        layer.weight.weight_loader(layer.weight, torch.ones(4))
+    freeze_load_plan(model)
+
+    assert layer.weight.weight_loader is original
+    # A tensor that never had a loader must not acquire one.
+    assert not hasattr(layer.no_loader, "weight_loader")
+
+
+def test_padded_derived_layer_completes_online_without_annotation():
+    """A layer with padding and a derived buffer must complete during the stream
+    with no model-side declaration, or it stays buffered through finalize."""
+    layer = _PaddedDerivedLayer()
+    model = torch.nn.Sequential(layer)
+    initial = torch.full((3, 2), 7.0)
+    _initial_load(model, lambda: layer.weight.weight_loader(layer.weight, initial))
+
+    initialize_layerwise_reload(model)
+    reloaded = torch.full((3, 2), 9.0)
+    with load_source("test.weight"):
+        layer.weight.weight_loader(layer.weight, reloaded)
+
+    # Processed during the stream, not deferred: materialized and buffers freed.
+    assert not layer.weight.is_meta
+    assert not reload_layerwise.get_layerwise_info(layer).loaded_weights
+    assert torch.equal(layer.weight[:3], reloaded)
+    assert torch.equal(layer.weight[3], torch.zeros(2))
+    assert torch.equal(layer.derived, torch.full_like(layer.derived, 54.0))
+
+    finalize_layerwise_processing(model, model_config=None)
+    assert torch.equal(layer.weight[:3], reloaded)
+
+
+def test_runtime_only_buffers_are_not_loadable_destinations():
+    """Completion must ignore non-persistent buffers without a loader."""
+    layer = _PaddedDerivedLayer()
+
+    assert set(get_loadable_layer_tensors(layer)) == {"weight"}
+    assert "derived" in get_layer_tensors(layer)
+
+
+def test_incomplete_update_defers_then_fails_closed():
+    """A partial update must not publish the layer, and must not commit."""
+    layer = torch.nn.Module()
+    layer.weight = torch.nn.Parameter(torch.zeros(4))
+    layer.weight.weight_loader = lambda param, w, loaded_shard_id=None: (
+        param.data.copy_(w)
+    )
+    model = torch.nn.Sequential(layer)
+
+    _initial_load(
+        model,
+        lambda: [
+            layer.weight.weight_loader(layer.weight, torch.ones(4), shard)
+            for shard in ("q", "k")
+        ],
+    )
+
+    initialize_layerwise_reload(model)
+    with load_source("test.weight"):
+        layer.weight.weight_loader(layer.weight, torch.full((4,), 5.0), "q")
+
+    info = reload_layerwise.get_layerwise_info(layer)
+    assert not info.is_complete()
+    assert layer.weight.is_meta, "layer must stay deferred until finalization"
+
+    with pytest.raises(RuntimeError, match="'k'"):
+        finalize_layerwise_processing(model, model_config=None)
+
+
+def test_reload_without_contract_fails_closed():
+    """An update without a startup contract must not guess or mutate meta data."""
+    layer = torch.nn.Module()
+    layer.weight = torch.nn.Parameter(torch.zeros(4))
+    layer.weight.weight_loader = default_weight_loader
+    model = torch.nn.Sequential(layer)
+
+    record_metadata_for_reloading(model)
+    freeze_load_plan(model)  # nothing was loaded, so no contract is recorded
+    assert get_load_plan(layer) is None
+
+    initialize_layerwise_reload(model)
+    with load_source("test.weight"):
+        layer.weight.weight_loader(layer.weight, torch.full((4,), 5.0))
+
+    # No contract means no completion, so the transaction must not commit.
+    with pytest.raises(RuntimeError, match="no startup contract"):
+        finalize_layerwise_reload(model, model_config=None)
+
+
+def test_load_plan_distinguishes_canonical_sources():
+    """A duplicate source cannot substitute for another source with the same I/O."""
+    layer = torch.nn.Module()
+    layer.weight = torch.nn.Parameter(torch.zeros(4))
+    layer.weight.weight_loader = default_weight_loader
+    model = torch.nn.Sequential(layer)
+
+    record_metadata_for_reloading(model)
+    for source in ("source_a.weight", "source_b.weight"):
+        with load_source(source):
+            layer.weight.weight_loader(layer.weight, torch.ones(4))
+    freeze_load_plan(model)
+
+    initialize_layerwise_reload(model)
+    for value in (2.0, 3.0):
+        with load_source("source_b.weight"):
+            layer.weight.weight_loader(layer.weight, torch.full((4,), value))
+
+    # Sending one source twice is absorbed rather than rejected, but it cannot
+    # stand in for the source that never arrived, so the layer stays deferred.
+    info = reload_layerwise.get_layerwise_info(layer)
+    assert not info.is_complete()
+    assert layer.weight.is_meta
+
+
+def test_load_source_reaches_a_nested_custom_loader():
+    """`AutoWeightsLoader` hands a derived iterator to a child's `load_weights`,
+    so one tag at the model boundary is still active when the child loads."""
+    from vllm.model_executor.models.utils import AutoWeightsLoader
+
+    class Child(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.zeros(4))
+            self.weight.weight_loader = default_weight_loader
+
+        def load_weights(self, weights):
+            loaded = set()
+            for name, weight in weights:
+                self.weight.weight_loader(self.weight, weight)
+                loaded.add(name)
+            return loaded
+
+    class Parent(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.child = Child()
+
+        def load_weights(self, weights):
+            return AutoWeightsLoader(self).load_weights(weights)
+
+    model = Parent()
+    record_metadata_for_reloading(model)
+    model.load_weights([("child.weight", torch.ones(4))])
+    freeze_load_plan(model)
+
+    assert get_load_plan(model.child) == {("child.weight", "weight", ()): 1}
+
+
+def test_model_load_weights_propagates_source_to_direct_custom_loader():
+    """The root input stream covers models that do not use AutoWeightsLoader."""
+
+    class DirectModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.zeros(4))
+            self.weight.weight_loader = default_weight_loader
+
+        def load_weights(self, weights):
+            for _, loaded_weight in weights:
+                self.weight.weight_loader(self.weight, loaded_weight)
+
+    model = DirectModel()
+    record_metadata_for_reloading(model)
+    model.load_weights([("canonical.weight", torch.ones(4))])
+    freeze_load_plan(model)
+
+    plan = get_load_plan(model)
+    assert plan is not None
+    assert {key[0] for key in plan} == {"canonical.weight"}
+
+    initialize_layerwise_reload(model)
+    model.load_weights([("canonical.weight", torch.full((4,), 7.0))])
+    finalize_layerwise_reload(model, model_config=None)
+    assert torch.equal(model.weight, torch.full((4,), 7.0))
+
+
+def test_applied_layer_rejects_trailing_application_until_finish():
+    """Online copy-back must not remove the transaction guard."""
+    layer = torch.nn.Module()
+    layer.weight = torch.nn.Parameter(torch.zeros(4))
+    layer.weight.weight_loader = default_weight_loader
+    model = torch.nn.Sequential(layer)
+    _initial_load(
+        model,
+        lambda: layer.weight.weight_loader(layer.weight, torch.ones(4)),
+    )
+
+    initialize_layerwise_reload(model)
+    staged_param = layer.weight
+    staged_loader = staged_param.weight_loader
+    with load_source("test.weight"):
+        staged_loader(staged_param, torch.full((4,), 5.0))
+
+    info = reload_layerwise.get_layerwise_info(layer)
+    assert info.applied
+    assert torch.equal(layer.weight, torch.full((4,), 5.0))
+
+    with (
+        load_source("test.weight"),
+        pytest.raises(RuntimeError, match="after the layer completed"),
+    ):
+        layer.weight.weight_loader(layer.weight, torch.full((4,), 9.0))
+    with (
+        load_source("test.weight"),
+        pytest.raises(RuntimeError, match="after the layer completed"),
+    ):
+        staged_loader(staged_param, torch.full((4,), 9.0))
+    assert torch.equal(layer.weight, torch.full((4,), 5.0))
+
+    finalize_layerwise_reload(model, model_config=None)
+    assert not reload_layerwise.get_layerwise_info(layer).can_load()
+
+
+def test_frozen_plan_is_reused_across_transactions():
+    layer = torch.nn.Module()
+    layer.weight = torch.nn.Parameter(torch.zeros(4))
+    layer.weight.weight_loader = default_weight_loader
+    model = torch.nn.Sequential(layer)
+    _initial_load(
+        model,
+        lambda: layer.weight.weight_loader(layer.weight, torch.ones(4)),
+    )
+
+    for value in (3.0, 7.0):
+        initialize_layerwise_reload(model)
+        with load_source("test.weight"):
+            layer.weight.weight_loader(layer.weight, torch.full((4,), value))
+        finalize_layerwise_reload(model, model_config=None)
+        assert torch.equal(layer.weight, torch.full((4,), value))
+
+
+def test_online_processing_armed_before_the_recorder_still_gets_a_plan():
+    """Online quantization arms a layer before the recorder is installed, and
+    the recording must still reach it or every reload falls back to finalize."""
+    layer = torch.nn.Module()
+    layer.weight = torch.nn.Parameter(torch.zeros(4))
+    layer.weight.weight_loader = default_weight_loader
+    model = torch.nn.Sequential(layer)
+
+    initialize_online_processing(layer)
+    record_metadata_for_reloading(model)
+    with load_source("test.weight"):
+        layer.weight.weight_loader(layer.weight, torch.ones(4))
+    freeze_load_plan(model)
+
+    assert get_load_plan(layer)
+
+    initialize_layerwise_reload(model)
+    with load_source("test.weight"):
+        layer.weight.weight_loader(layer.weight, torch.full((4,), 5.0))
+    finalize_layerwise_reload(model, model_config=None)
+    assert torch.equal(layer.weight, torch.full((4,), 5.0))

--- a/tests/model_executor/model_loader/test_reload.py
+++ b/tests/model_executor/model_loader/test_reload.py
@@ -1035,7 +1035,7 @@ def test_non_local_expert_applications_are_absorbed():
     model = torch.nn.Sequential(layer)
 
     record_metadata_for_reloading(model)
-    _load_experts(layer, [0, 1], 1.0)  # rank-filtered, as from disk
+    _load_experts(layer, [0, 1, 2, 3], 1.0, return_success=True)
     freeze_load_plan(model)
 
     initialize_layerwise_reload(model)
@@ -1082,6 +1082,27 @@ def test_extra_applications_before_publish_do_not_fail_validation():
     _load_experts(layer, [0, 2, 1], 5.0)
     assert not layer.w.is_meta, "the expected set alone must publish the layer"
 
+    finalize_layerwise_reload(model, model_config=None)
+    assert torch.equal(layer.w, torch.full((2, 2), 5.0))
+
+
+def test_declined_startup_application_stays_off_the_contract():
+    """The startup load is offered every expert, not a rank-filtered subset.
+
+    Recording an expert this rank declines would demand it on every reload,
+    where the same loader declines it again and it is never observed.
+    """
+    layer = _ShardedExpertLayer(local_experts=[0, 1])
+    model = torch.nn.Sequential(layer)
+
+    record_metadata_for_reloading(model)
+    _load_experts(layer, [0, 1, 2, 3], 1.0, return_success=True)
+    freeze_load_plan(model)
+
+    assert sum(get_load_plan(layer).values()) == 2, "only local experts wrote"
+
+    initialize_layerwise_reload(model)
+    _load_experts(layer, [0, 1, 2, 3], 5.0, return_success=True)
     finalize_layerwise_reload(model, model_config=None)
     assert torch.equal(layer.w, torch.full((2, 2), 5.0))
 

--- a/tests/model_executor/model_loader/test_reload.py
+++ b/tests/model_executor/model_loader/test_reload.py
@@ -1051,6 +1051,37 @@ def test_non_local_expert_applications_are_absorbed():
     assert torch.equal(layer.w, torch.full((2, 2), 5.0))
 
 
+def test_published_layer_absorbs_without_invoking_the_loader():
+    """A published layer's storage is the live kernel tensors, so a decline
+    must be decided from the contract rather than by running the loader to see
+    what it returns."""
+    layer = _ShardedExpertLayer(local_experts=[0, 1])
+    invocations: list[int] = []
+    inner = layer.w.weight_loader
+
+    def counting_loader(param, loaded_weight, expert_id, return_success=False):
+        invocations.append(expert_id)
+        return inner(param, loaded_weight, expert_id, return_success=return_success)
+
+    layer.w.weight_loader = counting_loader
+    model = torch.nn.Sequential(layer)
+
+    record_metadata_for_reloading(model)
+    _load_experts(layer, [0, 1, 2, 3], 1.0, return_success=True)
+    freeze_load_plan(model)
+
+    initialize_layerwise_reload(model)
+    _load_experts(layer, [0, 1], 5.0, return_success=True)
+    assert not layer.w.is_meta, "layer must publish on its own expected set"
+
+    invocations.clear()
+    assert _load_experts(layer, [2, 3], 5.0, return_success=True) == [False, False]
+    assert invocations == [], "the loader must not run against live storage"
+
+    finalize_layerwise_reload(model, model_config=None)
+    assert torch.equal(layer.w, torch.full((2, 2), 5.0))
+
+
 class _QuietExpertLayer(torch.nn.Module):
     """An expert loader predating `return_success`, which can only ignore a
     non-local expert rather than report it."""

--- a/vllm/model_executor/model_loader/base_loader.py
+++ b/vllm/model_executor/model_loader/base_loader.py
@@ -9,7 +9,10 @@ import vllm.envs as envs
 from vllm.config import ModelConfig, VllmConfig
 from vllm.config.load import LoadConfig
 from vllm.logger import init_logger
-from vllm.model_executor.model_loader.reload import finalize_layerwise_processing
+from vllm.model_executor.model_loader.reload import (
+    finalize_layerwise_processing,
+    freeze_load_plan,
+)
 from vllm.model_executor.model_loader.utils import (
     initialize_model,
     process_weights_after_loading,
@@ -63,6 +66,10 @@ class BaseModelLoader(ABC):
             logger.debug("Loading weights on %s ...", load_device)
             self.load_weights(model, model_config)
 
+            # Close the recording opened at model init, before post-load
+            # processing replaces any parameter.
+            freeze_load_plan(model)
+
             # Log peak GPU memory after loading weights. This is needed
             # to have test coverage on peak memory for online quantization.
             if current_platform.is_cuda_alike() or current_platform.is_xpu():
@@ -75,7 +82,10 @@ class BaseModelLoader(ABC):
             # Process weights into kernel format. Note that when using online
             # quantization, weights are (typically) quantized as they are loaded.
             if _has_online_quant(model):
-                finalize_layerwise_processing(model, model_config)
+                # The pass that records the contract cannot be held to it.
+                finalize_layerwise_processing(
+                    model, model_config, fail_on_incomplete=False
+                )
 
             process_weights_after_loading(model, model_config, target_device)
 

--- a/vllm/model_executor/model_loader/dummy_loader.py
+++ b/vllm/model_executor/model_loader/dummy_loader.py
@@ -1,9 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import glob
+import os
+
+import torch
 import torch.nn as nn
+from transformers.utils import SAFE_WEIGHTS_INDEX_NAME
 
 from vllm.config import ModelConfig
 from vllm.config.load import LoadConfig
+from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
 from vllm.model_executor.model_loader.base_loader import BaseModelLoader
 from vllm.model_executor.model_loader.reload.layerwise import (
@@ -11,12 +17,23 @@ from vllm.model_executor.model_loader.reload.layerwise import (
     get_layerwise_info,
 )
 from vllm.model_executor.model_loader.reload.meta import materialize_layer
+from vllm.model_executor.model_loader.reload.probe import (
+    probe_model_load,
+    safetensors_meta_weights_from_files,
+    validate_probe_plan_coverage,
+)
 from vllm.model_executor.model_loader.reload.types import LayerReloadingInfo
 from vllm.model_executor.model_loader.reload.utils import get_layer_tensors
 from vllm.model_executor.model_loader.weight_utils import (
+    download_safetensors_index_file_from_hf,
+    download_weights_from_hf,
+    filter_duplicate_safetensors_files,
     initialize_dummy_weights,
     initialize_single_dummy_weight,
+    maybe_download_from_modelscope,
 )
+
+logger = init_logger(__name__)
 
 
 class DummyModelLoader(BaseModelLoader):
@@ -24,24 +41,102 @@ class DummyModelLoader(BaseModelLoader):
 
     def __init__(self, load_config: LoadConfig):
         super().__init__(load_config)
-        if load_config.model_loader_extra_config:
+        extra_config = load_config.model_loader_extra_config
+        if not isinstance(extra_config, dict):
             raise ValueError(
-                f"Model loader extra config is not supported for "
-                f"load format {load_config.load_format}"
+                "model_loader_extra_config must be a dict for load format "
+                f"{load_config.load_format}, got {type(extra_config).__name__}"
             )
+        unexpected_keys = set(extra_config) - {"enable_load_probe"}
+        if unexpected_keys:
+            raise ValueError(
+                "Unexpected extra config keys for load format "
+                f"{load_config.load_format}: {unexpected_keys}"
+            )
+        enable_load_probe = extra_config.get("enable_load_probe", False)
+        if not isinstance(enable_load_probe, bool):
+            raise ValueError(
+                "enable_load_probe must be a bool, got "
+                f"{type(enable_load_probe).__name__}"
+            )
+        self.enable_load_probe = enable_load_probe
+        self._probe_weights_cache: list[tuple[str, torch.Tensor]] | None = None
 
     def download_model(self, model_config: ModelConfig) -> None:
-        pass  # Nothing to download
+        if self.enable_load_probe:
+            self._probe_meta_weights(model_config)
 
     def load_weights(self, model: nn.Module, model_config: ModelConfig) -> None:
+        supports_metadata_probe = True
         for layer in model.modules():
             info = get_layerwise_info(layer)
             if info.can_load():
+                # Online quantization has already transformed the layer away
+                # from the checkpoint layout. Its exact baseline must be
+                # learned from the first real transfer instead.
+                supports_metadata_probe = False
                 self._process_online_quant_layer(layer, info)
             else:
                 # NOTE(woosuk): For accurate performance evaluation, we assign
                 # random values to the weights.
                 initialize_dummy_weights(layer, model_config)
+
+        weights = (
+            self._probe_meta_weights(model_config)
+            if self.enable_load_probe and supports_metadata_probe
+            else []
+        )
+        if weights:
+            report = probe_model_load(model, weights)
+            report.raise_for_error()
+            validate_probe_plan_coverage(model, report)
+            logger.info(
+                "Probed %d checkpoint sources through dummy model loaders "
+                "without materializing weight data",
+                len(weights),
+            )
+
+    def _probe_meta_weights(
+        self,
+        model_config: ModelConfig,
+    ) -> list[tuple[str, torch.Tensor]]:
+        if self._probe_weights_cache is not None:
+            return self._probe_weights_cache
+        model_name_or_path = (
+            maybe_download_from_modelscope(
+                model_config.model,
+                revision=model_config.revision,
+                download_dir=self.load_config.download_dir,
+                ignore_patterns=self.load_config.ignore_patterns,
+                allow_patterns=["*.safetensors"],
+            )
+            or model_config.model
+        )
+        if not os.path.isdir(model_name_or_path):
+            hf_folder = download_weights_from_hf(
+                model_name_or_path,
+                self.load_config.download_dir,
+                ["*.safetensors"],
+                model_config.revision,
+                ignore_patterns=self.load_config.ignore_patterns,
+            )
+            download_safetensors_index_file_from_hf(
+                model_name_or_path,
+                SAFE_WEIGHTS_INDEX_NAME,
+                self.load_config.download_dir,
+                revision=model_config.revision,
+            )
+        else:
+            hf_folder = model_name_or_path
+
+        filenames = sorted(glob.glob(os.path.join(hf_folder, "*.safetensors")))
+        filenames = filter_duplicate_safetensors_files(
+            filenames,
+            hf_folder,
+            SAFE_WEIGHTS_INDEX_NAME,
+        )
+        self._probe_weights_cache = safetensors_meta_weights_from_files(filenames)
+        return self._probe_weights_cache
 
     def _process_online_quant_layer(
         self,

--- a/vllm/model_executor/model_loader/reload/__init__.py
+++ b/vllm/model_executor/model_loader/reload/__init__.py
@@ -10,16 +10,15 @@ Limitations:
 1. Composition with CPU offloading has not been implemented
 2. Tied parameters will only reflect processing from one of the parent layers (for
    example, only processing from embed_tokens will have an effect)
-3. This design assumes that the number of weights loaded from disk is the same as the
-   number of weights created at model init time. This is not true for quant methods
-   which (1) pad weights or (2) load qkv weights into the same parameter. Both of these
-   cases are non-issues for today's quant methods, but future quantizations may cause
-   reloading to fail
+3. Strict reload requires the initial checkpoint and runtime updates to use the same
+   canonical loader-application schema.
 """
 
 __all__ = [
     "record_metadata_for_reloading",
+    "freeze_load_plan",
     "initialize_layerwise_reload",
+    "validate_layerwise_reload",
     "finalize_layerwise_processing",
     "finalize_layerwise_reload",
     "set_torchao_reload_attrs",
@@ -29,8 +28,10 @@ __all__ = [
 from .layerwise import (
     finalize_layerwise_processing,
     finalize_layerwise_reload,
+    freeze_load_plan,
     initialize_layerwise_reload,
     record_metadata_for_reloading,
+    validate_layerwise_reload,
 )
 from .torchao_decorator import (
     set_torchao_reload_attrs,

--- a/vllm/model_executor/model_loader/reload/__init__.py
+++ b/vllm/model_executor/model_loader/reload/__init__.py
@@ -23,6 +23,9 @@ __all__ = [
     "finalize_layerwise_reload",
     "set_torchao_reload_attrs",
     "support_quantized_model_reload_from_hp_weights",
+    "LoadProbeError",
+    "LoadProbeReport",
+    "probe_model_load",
 ]
 
 from .layerwise import (
@@ -33,6 +36,7 @@ from .layerwise import (
     record_metadata_for_reloading,
     validate_layerwise_reload,
 )
+from .probe import LoadProbeError, LoadProbeReport, probe_model_load
 from .torchao_decorator import (
     set_torchao_reload_attrs,
     support_quantized_model_reload_from_hp_weights,

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -177,9 +177,17 @@ def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Calla
         bound_args.apply_defaults()
 
         if info.applied:
-            # A declined application writes nothing, so a published layer can
-            # still absorb one; anything that would apply is an error.
-            if _declines(original_loader, loader_signature, bound_args):
+            # A published layer can still absorb an application the loader
+            # would decline, e.g. an expert this rank does not own: it is
+            # absent from the contract, which holds only applications that
+            # wrote. Decided from the signature and the contract, never by
+            # probing the loader, whose storage is now live kernel tensors.
+            key = make_load_key(param_name, bound_args)
+            if (
+                "return_success" in loader_signature.parameters
+                and key is not None
+                and key not in info.expected_loads
+            ):
                 return False
             raise RuntimeError(
                 f"{layer.__class__.__name__}.{param_name} received a weight "
@@ -207,6 +215,16 @@ def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Calla
         info.loaded_weights.append((param_name, bound_args))
         if (key := make_load_key(param_name, bound_args)) is not None:
             info.observed_loads[key] += 1
+            # Absorbed rather than rejected, since an update may legitimately
+            # offer a target the startup checkpoint never did, but a misrouted
+            # tensor name arrives the same way and would otherwise be silent.
+            if info.expected_loads and key not in info.expected_loads:
+                logger.warning_once(
+                    "%s.%s: applying %s, which the startup checkpoint did not",
+                    layer.__class__.__name__,
+                    param_name,
+                    key[0],
+                )
 
         # Do not online process attention layers, must wait until finalize
         if isinstance(layer, (Attention, MLAAttention)):
@@ -236,21 +254,6 @@ def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Calla
         return ret
 
     return online_process_loader
-
-
-def _declines(
-    original_loader: Callable,
-    signature: inspect.Signature,
-    bound_args: inspect.BoundArguments,
-) -> bool:
-    """Whether a loader implementing `return_success` refuses this application,
-    which it decides before touching storage and so is safe to probe."""
-    if "return_success" not in signature.parameters:
-        return False
-    arguments = dict(bound_args.arguments)
-    arguments["return_success"] = True
-    probe = inspect.BoundArguments(signature, arguments)  # type: ignore[arg-type]
-    return original_loader(*probe.args, **probe.kwargs) is False
 
 
 def validate_layerwise_reload(model: torch.nn.Module) -> None:

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import inspect
+from collections import Counter
 from collections.abc import Callable
 from functools import wraps
 from weakref import WeakKeyDictionary, WeakSet
@@ -14,18 +15,23 @@ from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBa
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 
 from .meta import (
-    SKIP_LOAD_TENSORS,
     capture_layer_to_meta,
-    get_numel_loaded,
     materialize_layer,
     restore_layer_on_meta,
+)
+from .plan import (
+    freeze_load_plan,
+    get_load_plan,
+    install_load_recorder,
+    install_load_source_dispatch,
+    make_load_key,
 )
 from .types import LayerReloadingInfo
 from .utils import (
     get_info_size,
     get_layer_params_buffers,
-    get_layer_size,
     get_layer_tensors,
+    get_loadable_layer_tensors,
     has_device_tensors,
 )
 
@@ -34,7 +40,9 @@ logger = init_logger(__name__)
 __all__ = [
     "get_layerwise_info",
     "record_metadata_for_reloading",
+    "freeze_load_plan",
     "initialize_layerwise_reload",
+    "validate_layerwise_reload",
     "finalize_layerwise_processing",
     "finalize_layerwise_reload",
 ]
@@ -71,13 +79,20 @@ def record_metadata_for_reloading(model: torch.nn.Module):
     """
     Record layer metadata needed for later reloading.
 
-    Stores parameter and buffer metadata as meta tensors for restoration.
+    Stores parameter and buffer metadata as meta tensors for restoration, and
+    instruments weight loaders so the initial load becomes each layer's
+    completion contract.
+
     Must be called before `initialize_layerwise_reload`.
     """
+    install_load_source_dispatch(model)
+
     for layer in model.modules():
         info = get_layerwise_info(layer)
         info.restore_metadata = capture_layer_to_meta(layer)
         info.restore_device = torch.get_default_device()
+
+    install_load_recorder(model)
 
 
 @torch.no_grad()
@@ -103,8 +118,12 @@ def initialize_layerwise_reload(model: torch.nn.Module):
     for layer in model.modules():
         info = get_layerwise_info(layer)
 
-        # Skip if the layer has already been initialized
+        # Armed by online quantization before any plan existed, so its storage
+        # is ready but the contract still has to be picked up.
         if info.can_load():
+            info.expected_loads = get_load_plan(layer) or info.expected_loads
+            info.observed_loads.clear()
+            info.applied = False
             continue
 
         # Save current tensors for later copying
@@ -129,19 +148,17 @@ def initialize_online_processing(layer: torch.nn.Module):
         layer: layer whose parameter weight loaders will be wrapped
     """
     info = get_layerwise_info(layer)
-
-    # Track loading progress to determine when to process/copy
-    info.load_numel = 0
-    info.load_numel_total = get_layer_size(layer)
+    info.active = True
+    info.expected_loads = get_load_plan(layer) or Counter()
+    info.observed_loads.clear()
+    info.applied = False
     _wrap_parameters_weight_loader(layer)
 
 
 def _wrap_parameters_weight_loader(layer: torch.nn.Module) -> None:
     """Wrap each parameter's weight loader."""
     # Note that nested wrapping will occur for shared tensors
-    for name, tensor in get_layer_tensors(layer).items():
-        if name in SKIP_LOAD_TENSORS:
-            continue
+    for name, tensor in get_loadable_layer_tensors(layer).items():
         if _get_weight_loader(tensor).__name__ != "online_process_loader":
             tensor.weight_loader = make_online_process_loader(layer, name)
 
@@ -155,45 +172,41 @@ def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Calla
 
     @wraps(original_loader, assigned=("__doc__", "__annotations__"))
     def online_process_loader(*args, **kwargs):
-        if not info.can_load():
-            # Unfortunately, some qconfigs are set up to load the same weight
-            # multiple times. For example, CT_WNA16 loads `weight_shape` for
-            # each of the qkv partitions. This results in layers loading extra
-            # weights (beyond load_numel_total) after it's already processed.
-            #
-            # Best solution is to ensure that `load_numel_total` reflects the
-            # actual number of weights loaded, either by modifying qconfigs to
-            # create as many weights as loaded (see padding issue as well)
-            # or maybe capturing how many weights are loaded on first pass
-            #
-            # For now, `load_numel_total` is still safe to use as long as
-            # there's no way to reach `load_numel_total` without loading all
-            # necessary weights. `weight_shape` is very small, so this is safe.
-            # see Limitations(4)
-            logger.debug("%s: Excessive loading", layer.__class__.__name__)
-            return
-
-        # Re-run on each load: layers may register parameters later (e.g., `bias`).
-        # Wrap late parameters and refresh `load_numel_total` so processing waits
-        # until all parameters are loaded.
-        info.load_numel_total = get_layer_size(layer)
-        _wrap_parameters_weight_loader(layer)
-
         # Bind and normalize arguments
         bound_args = loader_signature.bind(*args, **kwargs)
         bound_args.apply_defaults()
 
-        # Buffer loaded weights, track loading progress
-        info.loaded_weights.append((param_name, bound_args))
-        num_loaded, ret = get_numel_loaded(original_loader, bound_args)
-        info.load_numel += num_loaded
+        if info.applied:
+            # A declined application writes nothing, so a published layer can
+            # still absorb one; anything that would apply is an error.
+            if _declines(original_loader, loader_signature, bound_args):
+                return False
+            raise RuntimeError(
+                f"{layer.__class__.__name__}.{param_name} received a weight "
+                "application after the layer completed its transaction plan"
+            )
 
-        logger.debug(
-            "%s: %d / %d",
-            layer.__class__.__name__,
-            info.load_numel,
-            info.load_numel_total,
-        )
+        if not info.can_load():
+            # Wrappers come off when a transaction ends, so reaching one on a
+            # disarmed layer means the two went out of sync.
+            raise RuntimeError(
+                f"{layer.__class__.__name__}.{param_name} received a weight "
+                "application outside a layerwise transaction"
+            )
+
+        # Layers may register parameters later (e.g. `bias`); wrap late arrivals.
+        _wrap_parameters_weight_loader(layer)
+
+        # Run against the meta layer, which writes nothing but preserves the
+        # return value that 14 MoE models branch on.
+        ret = original_loader(*bound_args.args, **bound_args.kwargs)
+        if ret is False:
+            # Declined, so it would write nothing on replay either.
+            return ret
+
+        info.loaded_weights.append((param_name, bound_args))
+        if (key := make_load_key(param_name, bound_args)) is not None:
+            info.observed_loads[key] += 1
 
         # Do not online process attention layers, must wait until finalize
         if isinstance(layer, (Attention, MLAAttention)):
@@ -215,9 +228,9 @@ def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Calla
                     str(list(names)),
                 )
 
-        # Process and copy when all weights are loaded
-        if info.load_numel >= info.load_numel_total:  # type: ignore[operator]
-            _layerwise_process(layer, info)
+        # Process and copy when every expected application has arrived
+        if info.is_complete():
+            _layerwise_process(layer, info, keep_transaction=True)
             LOADING_LAYERS.discard(layer)
 
         return ret
@@ -225,7 +238,55 @@ def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Calla
     return online_process_loader
 
 
-def finalize_layerwise_processing(model: torch.nn.Module, model_config: ModelConfig):
+def _declines(
+    original_loader: Callable,
+    signature: inspect.Signature,
+    bound_args: inspect.BoundArguments,
+) -> bool:
+    """Whether a loader implementing `return_success` refuses this application,
+    which it decides before touching storage and so is safe to probe."""
+    if "return_success" not in signature.parameters:
+        return False
+    arguments = dict(bound_args.arguments)
+    arguments["return_success"] = True
+    probe = inspect.BoundArguments(signature, arguments)  # type: ignore[arg-type]
+    return original_loader(*probe.args, **probe.kwargs) is False
+
+
+def validate_layerwise_reload(model: torch.nn.Module) -> None:
+    """Fail closed on a missing application, but not an extra one, because an
+    EP rank loads a filtered set from disk yet is offered every expert."""
+    missing: list[str] = []
+    for layer in model.modules():
+        info = get_layerwise_info(layer)
+        if not info.can_load():
+            continue
+        if not info.expected_loads:
+            if info.received_any():
+                missing.append(f"{layer.__class__.__name__}: no startup contract")
+            continue
+        for key, expected in info.expected_loads.items():
+            observed = info.observed_loads[key]
+            if observed < expected:
+                missing.append(
+                    f"{layer.__class__.__name__}: {key!r} "
+                    f"expected={expected}, observed={observed}"
+                )
+    if missing:
+        # Layers still staged on meta stay there, so the caller must treat this
+        # as fatal and resend the whole update.
+        raise RuntimeError(
+            "Weight update did not match the startup load contract, leaving the "
+            "model partially updated:\n" + "\n".join(missing[:20])
+        )
+
+
+def finalize_layerwise_processing(
+    model: torch.nn.Module,
+    model_config: ModelConfig,
+    *,
+    fail_on_incomplete: bool = True,
+):
     """
     Apply processing to any layers which were not layerwise processed during loading.
     This includes attention layers and layers which have weight elements which are not
@@ -238,6 +299,9 @@ def finalize_layerwise_processing(model: torch.nn.Module, model_config: ModelCon
         model: model to finalize processing for
         model_config: config needed for applying processing to attention layers
     """
+    if fail_on_incomplete:
+        validate_layerwise_reload(model)
+
     if hasattr(model, "_original_do_torchao_reload"):
         model._do_torchao_reload = model._original_do_torchao_reload
 
@@ -249,30 +313,33 @@ def finalize_layerwise_processing(model: torch.nn.Module, model_config: ModelCon
             info.reset()
             continue
 
+        if info.applied:
+            _unwrap_online_process_loaders(layer)
+            info.reset()
+            continue
+
         # Attention/MLA layers are processed after all other layers
         if isinstance(layer, (Attention, MLAAttention)):
             deferred_attn.append((layer, info))
             continue
 
         # No weights were loaded
-        if info.load_numel <= 0:
+        if not info.received_any():
             # first load: checkpoint did not contain weights for this layer
             if info.kernel_tensors is None:
                 _layerwise_process(layer, info)
                 continue
 
             # reloading: place kernel tensors back as a fallback. Always place, even
-            # when nothing is loadable (load_numel_total == 0), so parameter-alias
-            # buffers on such layers are restored rather than left deleted.
-            if info.load_numel_total > 0:  # type: ignore[operator]
+            # when nothing is loadable, so parameter-alias buffers on such layers
+            # are restored rather than left deleted.
+            if info.expected_loads:
                 logger.warning("%s: Failed to load weights", layer.__class__.__name__)
             _place_kernel_tensors(layer, info)
 
-        # Process non-attention layers which did not load all elements. This can happen
-        # if the created weight has extra padding elements which are not loaded
-        # Having too many of these delayed layers can lead to excess memory usage
-        # see Limitations(4)
-        elif info.load_numel > 0 and info.load_numel < info.load_numel_total:  # type: ignore[operator]
+        # Layers short of their expected set stay buffered until here, so too
+        # many of them costs memory.
+        elif not info.is_complete():
             logger.debug("%s: Delayed processing", layer.__class__.__name__)
             _layerwise_process(layer, info)
 
@@ -293,11 +360,11 @@ def finalize_layerwise_reload(*args, **kwargs):
 def _finalize_attention_layer(
     layer: torch.nn.Module, info: LayerReloadingInfo, model_config: ModelConfig
 ) -> None:
-    if info.load_numel > 0 and info.kernel_tensors is not None:
+    if info.received_any() and info.kernel_tensors is not None:
         # Reload with new scale weights from checkpoint
         _place_kernel_tensors(layer, info)
         _reload_attention_scales(layer, info)
-    elif info.load_numel > 0 or info.kernel_tensors is None:
+    elif info.received_any() or info.kernel_tensors is None:
         raise ValueError(
             "Layerwise loading of attention layers is not supported. "
             "Attention must always process after linears."
@@ -332,7 +399,12 @@ def _reload_attention_scales(layer: torch.nn.Module, info: LayerReloadingInfo) -
     _copy_and_restore_kernel_tensors(layer, info)
 
 
-def _layerwise_process(layer: torch.nn.Module, info: LayerReloadingInfo):
+def _layerwise_process(
+    layer: torch.nn.Module,
+    info: LayerReloadingInfo,
+    *,
+    keep_transaction: bool = False,
+):
     """
     Finalize layer loading after all weights have been buffered.
 
@@ -375,17 +447,31 @@ def _layerwise_process(layer: torch.nn.Module, info: LayerReloadingInfo):
     if info.kernel_tensors is not None:
         _copy_and_restore_kernel_tensors(layer, info)
 
-    info.reset()
+    if keep_transaction and info.kernel_tensors is not None:
+        info.loaded_weights.clear()
+        info.applied = True
+        _wrap_parameters_weight_loader(layer)
+    else:
+        info.reset()
     logger.debug("%s: Processed", layer.__class__.__name__)
 
 
 def _get_original_loader(tensor: torch.Tensor) -> Callable:
     """Return the weight loader with any layerwise wrappers removed"""
     loader = _get_weight_loader(tensor)
-    while loader.__name__ == "online_process_loader":
+    while loader.__name__ == "online_process_loader" or getattr(
+        loader, "_is_load_recorder", False
+    ):
         loader = loader.__wrapped__  # type: ignore[union-attr]
 
     return loader
+
+
+def _unwrap_online_process_loaders(layer: torch.nn.Module) -> None:
+    for tensor in get_layer_tensors(layer).values():
+        loader = _get_weight_loader(tensor)
+        if loader.__name__ == "online_process_loader":
+            tensor.weight_loader = _get_original_loader(tensor)
 
 
 def _get_weight_loader(tensor: torch.Tensor):

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -230,7 +230,7 @@ def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Calla
 
         # Process and copy when every expected application has arrived
         if info.is_complete():
-            _layerwise_process(layer, info, keep_transaction=True)
+            _layerwise_process(layer, info, mid_update=True)
             LOADING_LAYERS.discard(layer)
 
         return ret
@@ -254,8 +254,8 @@ def _declines(
 
 
 def validate_layerwise_reload(model: torch.nn.Module) -> None:
-    """Fail closed on a missing application, but not an extra one, because an
-    EP rank loads a filtered set from disk yet is offered every expert."""
+    """Fail closed on a missing application, but not an extra one: an update
+    may offer a target the startup checkpoint never did."""
     missing: list[str] = []
     for layer in model.modules():
         info = get_layerwise_info(layer)
@@ -328,6 +328,7 @@ def finalize_layerwise_processing(
             # first load: checkpoint did not contain weights for this layer
             if info.kernel_tensors is None:
                 _layerwise_process(layer, info)
+                info.reset()
                 continue
 
             # reloading: place kernel tensors back as a fallback. Always place, even
@@ -403,7 +404,7 @@ def _layerwise_process(
     layer: torch.nn.Module,
     info: LayerReloadingInfo,
     *,
-    keep_transaction: bool = False,
+    mid_update: bool = False,
 ):
     """
     Finalize layer loading after all weights have been buffered.
@@ -447,12 +448,14 @@ def _layerwise_process(
     if info.kernel_tensors is not None:
         _copy_and_restore_kernel_tensors(layer, info)
 
-    if keep_transaction and info.kernel_tensors is not None:
-        info.loaded_weights.clear()
+    # The staging buffers have been consumed either way.
+    info.loaded_weights.clear()
+
+    # Publishing before the update ends leaves the layer live: its progress must
+    # survive for validation, and further applications may still arrive.
+    if mid_update and info.kernel_tensors is not None:
         info.applied = True
         _wrap_parameters_weight_loader(layer)
-    else:
-        info.reset()
     logger.debug("%s: Processed", layer.__class__.__name__)
 
 

--- a/vllm/model_executor/model_loader/reload/meta.py
+++ b/vllm/model_executor/model_loader/reload/meta.py
@@ -1,11 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import inspect
-from collections.abc import Callable
-
 import torch
 from torch.nn.parameter import UninitializedParameter
-from torch.utils._python_dispatch import TorchDispatchMode
 
 from .sanitize import restore_layer_refs, sanitize_layer_refs
 from .types import LayerReloadingInfo, LayerTensors
@@ -17,7 +13,6 @@ __all__ = [
     "capture_layer_to_meta",
     "restore_layer_on_meta",
     "materialize_layer",
-    "get_numel_loaded",
 ]
 
 # Modules whose tensors are never moved to, or materialized from, the meta device.
@@ -130,14 +125,14 @@ def restore_layer_on_meta(layer: torch.nn.Module, info: LayerReloadingInfo):
 
     restore_params, restore_buffers = info.restore_metadata
     for name, param in restore_params.items():
-        if name not in SKIP_TENSORS:
-            param = restore_layer_refs(param, layer)
-            layer.register_parameter(name, param)
+        layer.register_parameter(name, restore_layer_refs(param, layer))
 
     for name, buffer in restore_buffers.items():
-        if name not in SKIP_TENSORS:
-            buffer = restore_layer_refs(buffer, layer)
-            layer.register_buffer(name, buffer, persistent=name not in non_persistent)
+        layer.register_buffer(
+            name,
+            restore_layer_refs(buffer, layer),
+            persistent=name not in non_persistent,
+        )
 
 
 def materialize_layer(layer: torch.nn.Module, info: LayerReloadingInfo):
@@ -149,61 +144,3 @@ def materialize_layer(layer: torch.nn.Module, info: LayerReloadingInfo):
         for name, tensor in get_layer_tensors(layer).items():
             if name not in SKIP_TENSORS and tensor.is_meta:
                 setattr(layer, name, materialize_meta_tensor(tensor))
-
-
-class CopyCounter(TorchDispatchMode):
-    """
-    Tracks total number of elements modified with `copy_`.
-
-    Useful for keeping track of weight loading where underlying weights can be
-    arbitrarily transformed (such as with `narrow`) before calling copy.
-
-    Note: Assumes that copy kwargs are not used.
-    """
-
-    def __init__(self):
-        super().__init__()
-        self.copied_numel = 0
-
-    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
-        if kwargs is None:
-            kwargs = {}
-
-        if func is torch.ops.aten.copy_.default:
-            assert args[0].numel() == args[1].numel()
-            self.copied_numel += args[0].numel()
-
-        return func(*args, **kwargs)
-
-
-def get_numel_loaded(
-    weight_loader: Callable, args: inspect.BoundArguments
-) -> tuple[int, object]:
-    """
-    Determine how many elements would be loaded by a weight loader call.
-
-    Args:
-        weight_loader: used to load weights
-        args: bound arguments to weight loader
-
-    Returns:
-        number of elements loaded by the weight loader, the return value of the
-        weight loader
-    """
-    with CopyCounter() as counter:
-        return_value = weight_loader(*args.args, **args.kwargs)
-
-    # A weight loader fills a single destination parameter, so the number of
-    # loaded elements is at most that parameter's size. Some loaders copy into
-    # the parameter more than once -- e.g. ``composed_weight_loader`` runs an
-    # in-place post-load transform (``param.copy_(fn(param))``) on top of the
-    # initial copy -- which would make CopyCounter report twice the parameter
-    # size. Over-counting inflates the layer's loaded-element total and can
-    # finalize the layer before every parameter is loaded, silently dropping
-    # the trailing parameter(s) (e.g. Mamba ``mixer.D``). Cap the count at the
-    # destination size to keep the per-layer accounting correct.
-    numel = counter.copied_numel
-    param = args.arguments.get("param", None)
-    if isinstance(param, torch.Tensor):
-        numel = min(numel, param.numel())
-    return numel, return_value

--- a/vllm/model_executor/model_loader/reload/plan.py
+++ b/vllm/model_executor/model_loader/reload/plan.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Records the initial checkpoint load as the set of ``weight_loader``
+applications every later reload must repeat."""
+
+import inspect
+from collections import Counter
+from collections.abc import Callable, Hashable, Iterable, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from functools import wraps
+from weakref import WeakKeyDictionary
+
+import torch
+
+from .utils import get_loadable_layer_tensors
+
+# (canonical_source_name, tensor_name, selectors), e.g.
+# ("model.layers.0.q_proj.weight", "weight", (("loaded_shard_id", "q"),))
+LoadKey = tuple[str, str, tuple[tuple[str, Hashable], ...]]
+
+# A multiset, because a quant config may load one key more than once
+# (CT_WNA16 loads `weight_shape` per QKV partition).
+LoadPlan = Counter[LoadKey]
+
+_NON_SELECTOR_ARGS = frozenset({"param", "self", "return_success"})
+
+_PLANS: WeakKeyDictionary[torch.nn.Module, LoadPlan] = WeakKeyDictionary()
+# Separate from _PLANS so a layer that arms itself mid-load (online
+# quantization does) cannot mistake an in-progress recording for a contract.
+_RECORDING: WeakKeyDictionary[torch.nn.Module, LoadPlan] = WeakKeyDictionary()
+_CURRENT_LOAD_SOURCE: ContextVar[str | None] = ContextVar(
+    "vllm_current_load_source", default=None
+)
+
+
+@contextmanager
+def load_source(source_name: str) -> Iterator[None]:
+    """Associate loader applications with one canonical checkpoint tensor."""
+    token = _CURRENT_LOAD_SOURCE.set(source_name)
+    try:
+        yield
+    finally:
+        _CURRENT_LOAD_SOURCE.reset(token)
+
+
+def install_load_source_dispatch(model: torch.nn.Module) -> None:
+    """Keep each checkpoint source active while the model consumes it."""
+    load_weights = getattr(model, "load_weights", None)
+    if not callable(load_weights):
+        return
+
+    @wraps(load_weights)
+    def dispatch(weights, *args, **kwargs):
+        return load_weights(_with_load_sources(weights), *args, **kwargs)
+
+    model.load_weights = dispatch
+
+
+def _with_load_sources(
+    weights: Iterable[tuple[str, torch.Tensor]],
+) -> Iterator[tuple[str, torch.Tensor]]:
+    for source_name, weight in weights:
+        with load_source(source_name):
+            yield source_name, weight
+
+
+def make_load_key(
+    tensor_name: str, bound_args: inspect.BoundArguments
+) -> LoadKey | None:
+    """Identify one loader application by its source, destination, and every
+    non-tensor argument, which is what selects the fragment being filled."""
+    source_name = _CURRENT_LOAD_SOURCE.get()
+    if source_name is None:
+        # Unkeyable, because this caller did not route through `load_weights`.
+        return None
+
+    selectors = tuple(
+        (name, _freeze_selector(value))
+        for name, value in bound_args.arguments.items()
+        if name not in _NON_SELECTOR_ARGS and not isinstance(value, torch.Tensor)
+    )
+    return source_name, tensor_name, selectors
+
+
+def _freeze_selector(value: object) -> Hashable:
+    """Reject a selector that cannot key the contract, with a clear reason."""
+    try:
+        hash(value)
+    except TypeError:
+        raise TypeError(
+            f"weight_loader argument of type {type(value).__qualname__} is not "
+            "hashable and cannot identify a load"
+        ) from None
+    return value  # type: ignore[return-value]
+
+
+def get_load_plan(layer: torch.nn.Module) -> LoadPlan | None:
+    return _PLANS.get(layer)
+
+
+def install_load_recorder(model: torch.nn.Module) -> None:
+    """Instrument loaders so the initial load becomes the contract, until
+    `freeze_load_plan` removes them again."""
+    for layer in model.modules():
+        _record_layer(layer)
+
+
+def _record_layer(layer: torch.nn.Module) -> None:
+    for name, tensor in get_loadable_layer_tensors(layer).items():
+        loader = getattr(tensor, "weight_loader", None)
+        if loader is None or not getattr(loader, "_is_load_recorder", False):
+            tensor.weight_loader = _make_recorder(layer, name, loader)
+
+
+def _make_recorder(
+    layer: torch.nn.Module, tensor_name: str, original: Callable | None
+) -> Callable:
+    from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+
+    inner = default_weight_loader if original is None else original
+    signature = inspect.signature(inner)
+
+    @wraps(inner, assigned=("__doc__", "__annotations__"))
+    def load_recorder(*args, **kwargs):
+        # Wrap parameters registered mid-load, e.g. a quant method adding `bias`.
+        _record_layer(layer)
+
+        bound_args = signature.bind(*args, **kwargs)
+        bound_args.apply_defaults()
+        if (key := make_load_key(tensor_name, bound_args)) is not None:
+            _RECORDING.setdefault(layer, Counter())[key] += 1
+        return inner(*args, **kwargs)
+
+    load_recorder._is_load_recorder = True  # type: ignore[attr-defined]
+    # `None` where the tensor had no loader, so unwrapping restores the absence
+    # rather than leaving `default_weight_loader` behind.
+    load_recorder._original_loader = original  # type: ignore[attr-defined]
+    return load_recorder
+
+
+def freeze_load_plan(model: torch.nn.Module) -> None:
+    """Freeze the recording as the contract and remove the recorders,
+    idempotently and safely on a model that was never instrumented."""
+    for layer in model.modules():
+        _unwrap_recorders(layer)
+        if plan := _RECORDING.pop(layer, None):
+            _PLANS[layer] = plan
+
+
+def _unwrap_recorders(layer: torch.nn.Module) -> None:
+    for tensor in get_loadable_layer_tensors(layer).values():
+        loader = getattr(tensor, "weight_loader", None)
+        if not getattr(loader, "_is_load_recorder", False):
+            continue
+        if loader._original_loader is None:
+            del tensor.weight_loader
+        else:
+            tensor.weight_loader = loader._original_loader

--- a/vllm/model_executor/model_loader/reload/plan.py
+++ b/vllm/model_executor/model_loader/reload/plan.py
@@ -44,6 +44,11 @@ def load_source(source_name: str) -> Iterator[None]:
         _CURRENT_LOAD_SOURCE.reset(token)
 
 
+def get_current_load_source() -> str | None:
+    """Return the checkpoint source currently being consumed."""
+    return _CURRENT_LOAD_SOURCE.get()
+
+
 def install_load_source_dispatch(model: torch.nn.Module) -> None:
     """Keep each checkpoint source active while the model consumes it."""
     load_weights = getattr(model, "load_weights", None)
@@ -66,7 +71,8 @@ def _with_load_sources(
 
 
 def make_load_key(
-    tensor_name: str, bound_args: inspect.BoundArguments
+    tensor_name: str,
+    bound_args: inspect.BoundArguments,
 ) -> LoadKey | None:
     """Identify one loader application by its source, destination, and every
     non-tensor argument, which is what selects the fragment being filled."""
@@ -85,6 +91,11 @@ def make_load_key(
 
 def get_load_plan(layer: torch.nn.Module) -> LoadPlan | None:
     return _PLANS.get(layer)
+
+
+def get_recorded_load_plan(layer: torch.nn.Module) -> LoadPlan | None:
+    """Return the in-progress initial-load recording for probe validation."""
+    return _RECORDING.get(layer)
 
 
 def install_load_recorder(model: torch.nn.Module) -> None:

--- a/vllm/model_executor/model_loader/reload/plan.py
+++ b/vllm/model_executor/model_loader/reload/plan.py
@@ -76,23 +76,11 @@ def make_load_key(
         return None
 
     selectors = tuple(
-        (name, _freeze_selector(value))
+        (name, value)
         for name, value in bound_args.arguments.items()
         if name not in _NON_SELECTOR_ARGS and not isinstance(value, torch.Tensor)
     )
     return source_name, tensor_name, selectors
-
-
-def _freeze_selector(value: object) -> Hashable:
-    """Reject a selector that cannot key the contract, with a clear reason."""
-    try:
-        hash(value)
-    except TypeError:
-        raise TypeError(
-            f"weight_loader argument of type {type(value).__qualname__} is not "
-            "hashable and cannot identify a load"
-        ) from None
-    return value  # type: ignore[return-value]
 
 
 def get_load_plan(layer: torch.nn.Module) -> LoadPlan | None:
@@ -126,11 +114,17 @@ def _make_recorder(
         # Wrap parameters registered mid-load, e.g. a quant method adding `bias`.
         _record_layer(layer)
 
+        ret = inner(*args, **kwargs)
+        if ret is False:
+            # Declined, e.g. an expert this rank does not own, so it wrote
+            # nothing and has not earned a place on the contract.
+            return ret
+
         bound_args = signature.bind(*args, **kwargs)
         bound_args.apply_defaults()
         if (key := make_load_key(tensor_name, bound_args)) is not None:
             _RECORDING.setdefault(layer, Counter())[key] += 1
-        return inner(*args, **kwargs)
+        return ret
 
     load_recorder._is_load_recorder = True  # type: ignore[attr-defined]
     # `None` where the tensor had no loader, so unwrapping restores the absence

--- a/vllm/model_executor/model_loader/reload/probe.py
+++ b/vllm/model_executor/model_loader/reload/probe.py
@@ -1,0 +1,396 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Metadata-only execution of model weight loaders."""
+
+from collections.abc import Iterable
+from contextlib import AbstractContextManager
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+from safetensors import safe_open
+from torch.utils._python_dispatch import TorchDispatchMode
+from torch.utils._pytree import tree_flatten
+
+from vllm.model_executor.model_loader.reload.plan import (
+    get_current_load_source,
+    get_recorded_load_plan,
+)
+
+__all__ = [
+    "LoadProbeError",
+    "LoadProbeFinding",
+    "LoadProbeMode",
+    "LoadProbeReport",
+    "probe_model_load",
+    "safetensors_meta_weights",
+    "safetensors_meta_weights_from_files",
+    "validate_probe_plan_coverage",
+]
+
+
+class LoadProbeError(RuntimeError):
+    """Raised when a loader cannot be executed without touching tensor data."""
+
+
+@dataclass(frozen=True)
+class LoadProbeFinding:
+    code: str
+    operation: str
+    detail: str
+
+    def format(self) -> str:
+        return f"{self.code}: {self.operation}: {self.detail}"
+
+
+@dataclass
+class LoadProbeReport:
+    """Result of one metadata-only ``model.load_weights`` execution."""
+
+    loaded_weights: set[str] = field(default_factory=set)
+    intercepted_writes: list[str] = field(default_factory=list)
+    write_sources: set[str | None] = field(default_factory=set)
+    restored_python_mutations: list[str] = field(default_factory=list)
+    findings: list[LoadProbeFinding] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.findings
+
+    def raise_for_error(self) -> None:
+        if self.findings:
+            raise LoadProbeError(
+                "Weight-loader probe is incomplete:\n  "
+                + "\n  ".join(finding.format() for finding in self.findings)
+            )
+
+
+def _tensor_values(args: tuple[Any, ...], kwargs: dict[str, Any]):
+    flat, _ = tree_flatten((args, kwargs))
+    return [value for value in flat if isinstance(value, torch.Tensor)]
+
+
+def _write_arguments(
+    func,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> list[torch.Tensor]:
+    writes: list[torch.Tensor] = []
+    for index, argument in enumerate(func._schema.arguments):
+        if index < len(args):
+            value = args[index]
+        elif argument.name in kwargs:
+            value = kwargs[argument.name]
+        else:
+            continue
+        alias = argument.alias_info
+        if alias is not None and alias.is_write and isinstance(value, torch.Tensor):
+            writes.append(value)
+    return writes
+
+
+def _has_meta_tensor(args: tuple[Any, ...], kwargs: dict[str, Any]) -> bool:
+    return any(tensor.is_meta for tensor in _tensor_values(args, kwargs))
+
+
+_FACTORY_OPS = {
+    "aten::arange",
+    "aten::empty",
+    "aten::empty_like",
+    "aten::empty_strided",
+    "aten::full",
+    "aten::full_like",
+    "aten::new_empty",
+    "aten::new_empty_strided",
+    "aten::new_full",
+    "aten::new_ones",
+    "aten::new_zeros",
+    "aten::ones",
+    "aten::ones_like",
+    "aten::rand",
+    "aten::rand_like",
+    "aten::randn",
+    "aten::randn_like",
+    "aten::zeros",
+    "aten::zeros_like",
+}
+
+_SAFETENSORS_DTYPES = {
+    "BOOL": "bool",
+    "BF16": "bfloat16",
+    "F16": "float16",
+    "F32": "float32",
+    "F64": "float64",
+    "F8_E4M3": "float8_e4m3fn",
+    "F8_E5M2": "float8_e5m2",
+    "I8": "int8",
+    "I16": "int16",
+    "I32": "int32",
+    "I64": "int64",
+    "U8": "uint8",
+    "U16": "uint16",
+    "U32": "uint32",
+    "U64": "uint64",
+}
+
+
+def safetensors_meta_weights_from_files(
+    filenames: Iterable[str],
+) -> list[tuple[str, torch.Tensor]]:
+    """Read safetensors schemas without materializing tensor data."""
+    weights = []
+    seen = set()
+    for filename in filenames:
+        with safe_open(filename, framework="pt", device="cpu") as handle:
+            for name in list(handle.keys()):
+                if name in seen:
+                    raise LoadProbeError(f"duplicate safetensors source key {name!r}")
+                seen.add(name)
+                tensor_slice = handle.get_slice(name)
+                dtype_name = tensor_slice.get_dtype()
+                torch_name = _SAFETENSORS_DTYPES.get(dtype_name)
+                dtype = getattr(torch, torch_name, None) if torch_name else None
+                if not isinstance(dtype, torch.dtype):
+                    raise LoadProbeError(
+                        "unsupported safetensors dtype "
+                        f"{dtype_name!r} for source {name!r}"
+                    )
+                weights.append(
+                    (
+                        name,
+                        torch.empty(
+                            tensor_slice.get_shape(),
+                            dtype=dtype,
+                            device="meta",
+                        ),
+                    )
+                )
+    return weights
+
+
+def safetensors_meta_weights(
+    model_path: str,
+) -> list[tuple[str, torch.Tensor]]:
+    """Read a local safetensors schema without materializing tensor data."""
+    from pathlib import Path
+
+    path = Path(model_path)
+    if not path.is_dir():
+        return []
+    filenames = sorted(str(filename) for filename in path.glob("*.safetensors"))
+    if not filenames:
+        return []
+    return safetensors_meta_weights_from_files(filenames)
+
+
+class LoadProbeMode(TorchDispatchMode):
+    """Suppress tensor mutations while preserving loader control flow.
+
+    Source weights must be meta tensors. Metadata/view operations execute
+    normally. Mutable dispatcher operations are recorded and return their
+    destination without running a kernel.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.report = LoadProbeReport()
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        kwargs = dict(kwargs or {})
+        writes = _write_arguments(func, args, kwargs)
+        if writes:
+            self.report.intercepted_writes.append(str(func))
+            self.report.write_sources.add(get_current_load_source())
+            if len(func._schema.returns) == 0:
+                return None
+            if len(func._schema.returns) == 1:
+                return writes[0]
+            finding = LoadProbeFinding(
+                code="PROBE_UNSUPPORTED_MUTATION_RETURN",
+                operation=str(func),
+                detail=f"mutable operator has {len(func._schema.returns)} returns",
+            )
+            self.report.findings.append(finding)
+            raise LoadProbeError(finding.format())
+
+        if func._schema.name in _FACTORY_OPS or (
+            _has_meta_tensor(args, kwargs) and func._schema.name == "aten::_to_copy"
+        ):
+            kwargs["device"] = torch.device("meta")
+
+        try:
+            return func(*args, **kwargs)
+        except Exception as exc:
+            finding = LoadProbeFinding(
+                code="PROBE_UNSUPPORTED_OPERATOR",
+                operation=str(func),
+                detail=f"{type(exc).__name__}: {exc}",
+            )
+            self.report.findings.append(finding)
+            raise LoadProbeError(finding.format()) from exc
+
+
+def _copy_attribute(value: Any) -> Any:
+    if isinstance(value, dict):
+        return value.copy()
+    if isinstance(value, list):
+        return value.copy()
+    if isinstance(value, set):
+        return value.copy()
+    return value
+
+
+def _same_attribute(current: Any, saved: Any) -> bool:
+    if isinstance(saved, dict):
+        return (
+            isinstance(current, dict)
+            and current.keys() == saved.keys()
+            and all(current[key] is value for key, value in saved.items())
+        )
+    if isinstance(saved, list):
+        return (
+            isinstance(current, list)
+            and len(current) == len(saved)
+            and all(left is right for left, right in zip(current, saved))
+        )
+    if isinstance(saved, set):
+        return isinstance(current, set) and current == saved
+    return current is saved
+
+
+class _ModelStateGuard(AbstractContextManager):
+    """Restore Python-side model bindings after a probe."""
+
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        report: LoadProbeReport,
+        *,
+        allow_binding_mutations: bool = False,
+    ):
+        self.model = model
+        self.report = report
+        self.allow_binding_mutations = allow_binding_mutations
+        self.module_state: dict[torch.nn.Module, dict[str, Any]] = {}
+        self.tensor_state: dict[torch.Tensor, dict[str, Any]] = {}
+
+    def __enter__(self):
+        for module in self.model.modules():
+            self.module_state[module] = {
+                key: _copy_attribute(value) for key, value in vars(module).items()
+            }
+            for tensor in (
+                *module.parameters(recurse=False),
+                *module.buffers(recurse=False),
+            ):
+                self.tensor_state[tensor] = {
+                    key: _copy_attribute(value) for key, value in vars(tensor).items()
+                }
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        mutated = []
+        binding_mutations = []
+        for module, state in self.module_state.items():
+            current = vars(module)
+            changed = {
+                key
+                for key in set(current) | set(state)
+                if key not in current
+                or key not in state
+                or not _same_attribute(current[key], state[key])
+            }
+            if changed:
+                mutated.append(type(module).__name__)
+                if changed & {"_parameters", "_buffers", "_modules"}:
+                    binding_mutations.append(
+                        f"{type(module).__name__}:{sorted(changed)}"
+                    )
+            current.clear()
+            current.update(state)
+        for tensor, state in self.tensor_state.items():
+            current = vars(tensor)
+            if set(current) != set(state):
+                mutated.append(f"{type(tensor).__name__}.__dict__")
+            current.clear()
+            current.update(state)
+        if binding_mutations and not self.allow_binding_mutations:
+            self.report.findings.append(
+                LoadProbeFinding(
+                    code="PROBE_TENSOR_BINDING_MUTATION",
+                    operation=f"{type(self.model).__name__}.load_weights",
+                    detail=f"restored {binding_mutations[:8]}",
+                )
+            )
+        if mutated:
+            self.report.restored_python_mutations.extend(sorted(set(mutated)))
+        return False
+
+
+@torch.no_grad()
+def probe_model_load(
+    model: torch.nn.Module,
+    weights: Iterable[tuple[str, torch.Tensor]],
+) -> LoadProbeReport:
+    """Run the model's real weight routing without copying tensor data.
+
+    Args:
+        model: Initialized model whose ``load_weights`` method is probed.
+        weights: Source-name and metadata-tensor pairs. Every tensor must be
+            on the meta device.
+
+    Returns:
+        The intercepted writes and the names returned by ``model.load_weights``.
+
+    Raises:
+        ValueError: If a source tensor owns real storage.
+        LoadProbeError: If an operator cannot be represented metadata-only.
+    """
+    materialized = [(name, tensor) for name, tensor in weights]
+    non_meta = [name for name, tensor in materialized if not tensor.is_meta]
+    if non_meta:
+        raise ValueError(
+            "Weight-loader probe requires meta source tensors; got real "
+            f"storage for {non_meta[:8]}"
+        )
+
+    mode = LoadProbeMode()
+    try:
+        with _ModelStateGuard(model, mode.report), mode:
+            loaded = model.load_weights(materialized)
+        if loaded is not None:
+            mode.report.loaded_weights = set(loaded)
+    except LoadProbeError:
+        raise
+    except Exception as exc:
+        finding = LoadProbeFinding(
+            code="PROBE_LOADER_EXCEPTION",
+            operation=f"{type(model).__name__}.load_weights",
+            detail=f"{type(exc).__name__}: {exc}",
+        )
+        mode.report.findings.append(finding)
+        raise LoadProbeError(finding.format()) from exc
+    return mode.report
+
+
+def validate_probe_plan_coverage(
+    model: torch.nn.Module,
+    report: LoadProbeReport,
+) -> None:
+    """Require every intercepted source write to have a recorded load key."""
+    recorded_sources = {
+        key[0]
+        for layer in model.modules()
+        for key in (get_recorded_load_plan(layer) or ())
+    }
+    missing_keys = {
+        source
+        for source in report.write_sources
+        if source is None or source not in recorded_sources
+    }
+    if missing_keys:
+        raise LoadProbeError(
+            "Weight-loader probe observed tensor writes without LoadPlan "
+            "coverage for source(s): "
+            f"{sorted(map(str, missing_keys))[:20]}"
+        )

--- a/vllm/model_executor/model_loader/reload/types.py
+++ b/vllm/model_executor/model_loader/reload/types.py
@@ -1,9 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from collections import Counter
 from dataclasses import dataclass, field
 from inspect import BoundArguments
+from typing import TYPE_CHECKING
 
 import torch
+
+if TYPE_CHECKING:
+    from .plan import LoadPlan
 
 __all__ = ["LayerTensors", "LayerReloadingInfo"]
 
@@ -19,9 +24,13 @@ class LayerReloadingInfo:
     # device to materialize layers with, recorded by `record_metadata_for_reloading`
     restore_device: torch.device
 
-    # track how many elements are ready for loading, used by `online_process_loader`
-    load_numel: int = 0
-    load_numel_total: int | None = None
+    # Whether layerwise loading is armed for this layer
+    active: bool = False
+
+    # The loader applications this layer expects, recorded during the initial
+    # checkpoint load and empty until one has been.
+    expected_loads: "LoadPlan" = field(default_factory=Counter)
+    observed_loads: "LoadPlan" = field(default_factory=Counter)
 
     # used by `online_process_loader` to buffer args and tensors until ready to load
     loaded_weights: list[tuple[str, BoundArguments]] = field(default_factory=list)
@@ -33,10 +42,27 @@ class LayerReloadingInfo:
     # persistence survives `_non_persistent_buffers_set` being mutated during reload
     kernel_non_persistent_buffers: set[str] = field(default_factory=set)
 
+    # Set once a layer publishes, which happens before the transaction ends.
+    applied: bool = False
+
     def reset(self):
+        expected_loads = self.expected_loads
         self.__init__(  # type: ignore[misc]
             restore_metadata=self.restore_metadata, restore_device=self.restore_device
         )
+        # The contract outlives a single transaction; only progress resets.
+        self.expected_loads = expected_loads
 
     def can_load(self) -> bool:
-        return self.load_numel_total is not None
+        return self.active
+
+    def received_any(self) -> bool:
+        return bool(self.loaded_weights)
+
+    def is_complete(self) -> bool:
+        """Whether every expected application has arrived, which is never true
+        without a contract, so such a layer defers to finalization."""
+        return bool(self.expected_loads) and all(
+            self.observed_loads[key] >= count
+            for key, count in self.expected_loads.items()
+        )

--- a/vllm/model_executor/model_loader/reload/utils.py
+++ b/vllm/model_executor/model_loader/reload/utils.py
@@ -10,7 +10,7 @@ from .types import LayerReloadingInfo, LayerTensors
 __all__ = [
     "get_layer_tensors",
     "get_layer_params_buffers",
-    "get_layer_size",
+    "get_loadable_layer_tensors",
     "has_device_tensors",
     "get_info_size",
 ]
@@ -30,19 +30,27 @@ def get_layer_params_buffers(layer: torch.nn.Module) -> LayerTensors:
     )
 
 
-def get_layer_size(layer: torch.nn.Module) -> int:
-    """Calculate total number of elements across loadable tensors in a layer.
+def get_loadable_layer_tensors(layer: torch.nn.Module) -> dict[str, torch.Tensor]:
+    """Get the tensors of a layer that a weight loader may write to, excluding
+    SKIP_TENSORS (e.g. _expert_map), which reload never moves to meta."""
+    from .meta import SKIP_TENSORS
 
-    Excludes SKIP_LOAD_TENSORS (e.g. _expert_map) which are never loaded via
-    weight_loader during layerwise reload.
-    """
-    from .meta import SKIP_LOAD_TENSORS
+    params, buffers = get_layer_params_buffers(layer)
+    non_persistent = getattr(layer, "_non_persistent_buffers_set", set())
 
-    return sum(
-        tensor.numel()
-        for name, tensor in get_layer_tensors(layer).items()
-        if name not in SKIP_LOAD_TENSORS
-    )
+    # A non-persistent buffer is absent from ``state_dict`` and so is derived
+    # state, not a checkpoint destination, unless it carries its own loader.
+    loadable_buffers = {
+        name: buffer
+        for name, buffer in buffers.items()
+        if name not in non_persistent
+        or getattr(buffer, "weight_loader", None) is not None
+    }
+    return {
+        name: tensor
+        for name, tensor in (params | loadable_buffers).items()
+        if name not in SKIP_TENSORS
+    }
 
 
 def has_device_tensors(bound_args: BoundArguments) -> bool:

--- a/vllm/model_executor/model_loader/tensorizer_loader.py
+++ b/vllm/model_executor/model_loader/tensorizer_loader.py
@@ -11,6 +11,7 @@ from vllm.config import ModelConfig, ParallelConfig, VllmConfig
 from vllm.config.load import LoadConfig
 from vllm.logger import init_logger
 from vllm.model_executor.model_loader.base_loader import BaseModelLoader
+from vllm.model_executor.model_loader.reload import freeze_load_plan
 from vllm.model_executor.model_loader.tensorizer import (
     TensorizerConfig,
     deserialize_tensorizer_model,
@@ -84,6 +85,7 @@ class TensorizerLoader(BaseModelLoader):
                 model = initialize_model(vllm_config=vllm_config, prefix=prefix)
 
             model.load_weights(self._get_weights_iterator())
+            freeze_load_plan(model)
         return model.eval()
 
     def download_model(self, model_config: ModelConfig) -> None:
@@ -135,6 +137,7 @@ class TensorizerLoader(BaseModelLoader):
                         tensorizer_config=tensorizer_config, vllm_config=vllm_config
                     )
             self.load_weights(model, model_config)
+            freeze_load_plan(model)
             return model
         return self._load_model_serialized_cpu(vllm_config=vllm_config, prefix=prefix)
 

--- a/vllm/model_executor/models/gpt_oss.py
+++ b/vllm/model_executor/models/gpt_oss.py
@@ -543,7 +543,8 @@ class GptOssModel(nn.Module, EagleModelMixin):
                 # Handle attention sinks (distributed across ranks)
                 param = params_dict[name]
                 narrow_weight = weight.narrow(0, head_start, heads_per_rank)
-                param.data.copy_(narrow_weight)
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, narrow_weight)
                 loaded_params.add(name)
                 continue
             for param_name, weight_name, shard_id in stacked_params_mapping:
@@ -901,7 +902,8 @@ class GptOssModel(nn.Module, EagleModelMixin):
                 # Handle attention sinks (distributed across ranks)
                 param = params_dict[name]
                 narrow_weight = loaded_weight.narrow(0, head_start, heads_per_rank)
-                param.data.copy_(narrow_weight)
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, narrow_weight)
                 loaded_params.add(name)
                 continue
 
@@ -1072,7 +1074,8 @@ class GptOssModel(nn.Module, EagleModelMixin):
                 # Handle attention sinks (distributed across ranks)
                 param = params_dict[name]
                 narrow_weight = weight.narrow(0, head_start, heads_per_rank)
-                param.data.copy_(narrow_weight)
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, narrow_weight)
                 loaded_params.add(name)
                 continue
             for param_name, weight_name, shard_id in stacked_params_mapping:


### PR DESCRIPTION
## Summary

- replace element-count based layerwise reload completion with the load application manifest introduced by the closed PR #50075
- keep declined and post-publish loader applications from corrupting the manifest contract
- add metadata-only dummy-load probing so checkpoint routing can build and validate manifests without materializing model weights
- preserve signature-based selector discovery and cover the probe behavior with focused unit tests

## Why this is not a duplicate

This supersedes the closed PR #50075 and ports that manifest work, plus metadata-only dummy-load probing, onto current `main`. Open PR #49789 focuses on preserving CUDA Graph-visible arena storage across reloads, while #49201 is a broader weight-loading lifecycle refactor; neither implements this manifest probe flow.

## Tests

Attempted:

```bash
.venv/bin/python -m pytest tests/model_executor/model_loader/test_load_probe.py -q
```

The test session could not start because the existing environment is missing `tblib`, imported by `tests/conftest.py`:

```text
ModuleNotFoundError: No module named 'tblib'
```

No dependencies were installed because the original worktree contains unrelated uncommitted changes that were required to remain untouched.

Model evaluation is not applicable: this changes reload planning/probing and does not alter inference math.

## AI assistance

AI assistance was used to implement and review this change. The human submitter must review every changed line and validate the behavior before merge.
