### PR TITLE
[Bugfix][KV Connector][Mooncake] Avoid stale recv completion after early abort

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector.py
@@ -17,6 +17,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector im
     KVConnectorRole,
     MooncakeConnector,
     MooncakeConnectorMetadata,
+    MooncakeConnectorScheduler,
     MooncakeConnectorWorker,
     MooncakeXferMetadata,
     MooncakeXferResponse,
@@ -652,6 +653,82 @@ def test_scheduler_request_finished():
     assert delay_free is False
     assert len(scheduler_connector._reqs_need_send) == 0
     assert "id-1" in scheduler_connector._reqs_not_processed
+
+
+def test_aborted_remote_prefill_cleanup_does_not_finish_recv():
+    """Cleanup-only pulls notify P without completing a freed D request."""
+
+    scheduler_connector = MooncakeConnectorScheduler.__new__(MooncakeConnectorScheduler)
+    scheduler_connector.is_kv_producer = False
+    scheduler_connector.is_kv_consumer = True
+    scheduler_connector._reqs_need_recv = {}
+    scheduler_connector._reqs_need_send = {}
+    scheduler_connector._reqs_not_processed = set()
+    request = SimpleNamespace(
+        request_id="d-req-1",
+        status=RequestStatus.FINISHED_ABORTED,
+        kv_transfer_params=dict(
+            do_remote_prefill=True,
+            do_remote_decode=False,
+            remote_engine_id="p-engine",
+            remote_bootstrap_addr="http://bootstrap:33333",
+            transfer_id="xfer-1",
+        ),
+    )
+
+    delay_free, _ = scheduler_connector.request_finished(request, block_ids=([],))
+    assert delay_free is False
+
+    metadata = scheduler_connector.build_connector_meta(MagicMock())
+    pull_meta = metadata.reqs_to_recv["p-engine"][request.request_id]
+    assert pull_meta.local_block_ids == []
+    assert pull_meta.notify_scheduler is False
+
+    pull_meta.pull_tasks_count = 1
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.shutdown = MagicMock()
+    worker.finished_recving_reqs = set()
+    worker.process_pulling_result(
+        MooncakeXferResponse(
+            status=MooncakeXferResponseStatus.FINISH,
+            ok_reqs=[request.request_id],
+        ),
+        {request.request_id: pull_meta},
+    )
+
+    assert pull_meta.pull_tasks_count == 0
+    assert worker.finished_recving_reqs == set()
+
+
+def test_empty_remote_prefill_load_still_finishes_recv():
+    """A normal full-prefix hit still completes despite having no local blocks."""
+
+    metadata = MooncakeConnectorMetadata()
+    metadata.add_new_req(
+        request_id="d-req-1",
+        local_block_ids=[],
+        kv_transfer_params={
+            "remote_engine_id": "p-engine",
+            "remote_bootstrap_addr": "http://bootstrap:33333",
+            "transfer_id": "xfer-1",
+        },
+    )
+    pull_meta = metadata.reqs_to_recv["p-engine"]["d-req-1"]
+    assert pull_meta.notify_scheduler is True
+
+    pull_meta.pull_tasks_count = 1
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.shutdown = MagicMock()
+    worker.finished_recving_reqs = set()
+    worker.process_pulling_result(
+        MooncakeXferResponse(
+            status=MooncakeXferResponseStatus.FINISH,
+            ok_reqs=["d-req-1"],
+        ),
+        {"d-req-1": pull_meta},
+    )
+
+    assert worker.finished_recving_reqs == {"d-req-1"}
 
 
 @contextlib.contextmanager

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -419,6 +419,8 @@ class PullReqMeta:
     local_block_ids: list[list[int]]
     remote_engine_id: EngineId
     remote_bootstrap_addr: str
+    # Cleanup-only pulls release producer blocks without completing a D request.
+    notify_scheduler: bool = True
     # Set expire time to avoid infinitely sending requests.
     expire_time: float = float("inf")
     # Designed for one D pairing to multiple P
@@ -451,6 +453,7 @@ class MooncakeConnectorMetadata(KVConnectorMetadata):
         local_block_ids: list[list[int]],
         kv_transfer_params: dict[str, Any],
         load_remote_cache: bool = True,
+        notify_scheduler: bool = True,
     ):
         transfer_id = kv_transfer_params["transfer_id"]
         if load_remote_cache:
@@ -461,6 +464,7 @@ class MooncakeConnectorMetadata(KVConnectorMetadata):
                 remote_engine_id=remote_engine_id,
                 remote_bootstrap_addr=kv_transfer_params["remote_bootstrap_addr"],
                 transfer_id=transfer_id,
+                notify_scheduler=notify_scheduler,
             )
         else:
             self.reqs_to_send[request_id] = (transfer_id, local_block_ids)
@@ -645,7 +649,7 @@ class MooncakeConnectorScheduler:
         # Requests that need to start recv/send.
         # New requests are added by update_state_after_alloc in
         # the scheduler. Used to make metadata passed to Worker.
-        self._reqs_need_recv: dict[ReqId, tuple[Request, list[list[int]]]] = {}
+        self._reqs_need_recv: dict[ReqId, tuple[Request, list[list[int]], bool]] = {}
         self._reqs_need_send: dict[ReqId, tuple[Request, list[list[int]]]] = {}
         # Reqs to remove from processed set because they're not to send after
         # remote prefill or aborted.
@@ -785,7 +789,11 @@ class MooncakeConnectorScheduler:
                 )
                 local_block_ids = self.get_sw_clipped_blocks(unhashed_block_ids)
                 # Get unhashed blocks to pull from remote.
-                self._reqs_need_recv[request.request_id] = (request, local_block_ids)
+                self._reqs_need_recv[request.request_id] = (
+                    request,
+                    local_block_ids,
+                    True,
+                )
             else:
                 logger.warning(
                     "Got invalid KVTransferParams: %s. This "
@@ -811,12 +819,17 @@ class MooncakeConnectorScheduler:
 
         # Loop through scheduled reqs and convert to PullReqMeta.
         if not self.is_kv_producer:
-            for req_id, (req, block_ids) in self._reqs_need_recv.items():
+            for req_id, (
+                req,
+                block_ids,
+                notify_scheduler,
+            ) in self._reqs_need_recv.items():
                 assert req.kv_transfer_params is not None
                 meta.add_new_req(
                     request_id=req_id,
                     local_block_ids=block_ids,
                     kv_transfer_params=req.kv_transfer_params,
+                    notify_scheduler=notify_scheduler,
                 )
             self._reqs_need_recv.clear()
 
@@ -864,7 +877,7 @@ class MooncakeConnectorScheduler:
             # we must add empty block_ids to _reqs_need_recv so that our
             # worker side will notify and free blocks in the prefill instance.
             assert not self.is_kv_producer
-            self._reqs_need_recv[request.request_id] = (request, [])
+            self._reqs_need_recv[request.request_id] = (request, [], False)
             params["do_remote_prefill"] = False
             return False, None
 
@@ -1889,7 +1902,7 @@ class MooncakeConnectorWorker:
             pull_meta = pull_metas[req_id]
             # No race because we are in async loop.
             pull_meta.pull_tasks_count -= 1
-            if pull_meta.pull_tasks_count == 0:
+            if pull_meta.pull_tasks_count == 0 and pull_meta.notify_scheduler:
                 self.finished_recving_reqs.add(pull_meta.d_req_id)
 
         if ok_reqs:


### PR DESCRIPTION
## Purpose

When a Decode-side remote-prefill request is aborted before it is first
scheduled (for example, after an upstream client disconnects while the request
is queued), Mooncake enqueues an empty pull so the Prefill side can release its
producer blocks.

The Decode scheduler frees this unscheduled request immediately. However, when
the cleanup pull later completes, the Mooncake worker reports the request in
`finished_recving`. The scheduler then handles a completion for a request ID
that no longer exists and hits the ownership assertion in
`_update_from_kv_xfer_finished`, terminating the EngineCore.

This PR adds an explicit `notify_scheduler` flag to Mooncake pull metadata:

- cleanup-only pulls still notify the Prefill side and retain their existing
  TP/PP pull-task accounting, but do not report Decode scheduler completion;
- normal pulls keep the existing completion behavior by default;
- empty-block full-prefix hits remain normal pulls and still report completion.

This keeps the scheduler ownership assertion intact so it can continue to catch
unexpected connector lifecycle violations.

Related to #43226. This PR addresses the Mooncake early-abort cleanup variant
rather than the connector-agnostic cases described by that issue.

## Duplicate check

I searched open issues and PRs for Mooncake early aborts, remote-prefill
cleanup, and stale `finished_recving` events. I did not find another PR that
addresses this cleanup-only pull path.

- #43226 covers late completion from a real in-flight asynchronous transfer;
  this PR prevents a cleanup-only pull from emitting a scheduler completion in
  the first place.
- #46289 covers requests aborted in `WAITING_FOR_REMOTE_KVS` when the expected
  completion never arrives and blocks must be reclaimed after a deadline.
- #50425 covers client disconnects before a Decode request enters EngineCore,
  so no Decode scheduler request or Mooncake cleanup pull exists yet.

## Test Plan

```bash
pre-commit run --files \
  vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py \
  tests/v1/kv_connector/unit/test_mooncake_connector.py

python -m pytest -q --noconftest \
  tests/v1/kv_connector/unit/test_mooncake_connector.py::test_aborted_remote_prefill_cleanup_does_not_finish_recv \
  tests/v1/kv_connector/unit/test_mooncake_connector.py::test_empty_remote_prefill_load_still_finishes_recv \
  tests/v1/kv_connector/unit/test_mooncake_connector.py::test_resolve_need_send_accounts_for_remote_tp_fanout

python -m py_compile \
  vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py \
  tests/v1/kv_connector/unit/test_mooncake_connector.py

git diff --check github/main..HEAD
```

End-to-end reproduction:

1. Launch a disaggregated Prefill/Decode deployment with the Mooncake connector
   and a routing proxy. The Decode side uses TP=4 and DP=2, with a larger TP
   size than the Prefill side.
2. Drive enough requests through the proxy to leave a large number of requests
   in the Decode engine's running and waiting queues.
3. Kill the proxy process directly. This closes all upstream connections to
   Decode at once and aborts the outstanding requests.
4. Check whether the Decode EngineCore remains healthy after the outstanding KV
   cleanup pulls complete.

## Test Result

- Changed-file pre-commit suite: passed, including Ruff check/format and mypy.
- `py_compile` and `git diff --check github/main..HEAD`: passed.
- Targeted Mooncake tests on the deployment branch containing the same fix:
  **3 passed, 22 warnings in 11.03s**. The warnings are unrelated Torch JIT
  deprecations and unregistered async marks under `--noconftest`.
- Before this change, killing the proxy with many Decode requests in running
  and waiting consistently caused the Decode EngineCore to hit the stale
  `finished_recving` ownership assertion and crash.
- With this change applied, the same workload and forced proxy termination no
  longer crash Decode; the Decode service remains healthy after the bulk abort.
- No documentation update is needed because this changes only internal
  connector completion bookkeeping.

## AI assistance

This PR was prepared with OpenAI Codex assistance. I reviewed and understand
the changed lines and validation results, and I am responsible for the
contribution.

---

<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR.
- [x] The test plan.
- [x] The test results and end-to-end evaluation.
- [x] Documentation impact considered.

</details>
