### PR TITLE
[ROCm][Performance] Eliminate per-decode allocations and output copy …

### DIFF
--- a/vllm/models/deepseek_v4/amd/rocm.py
+++ b/vllm/models/deepseek_v4/amd/rocm.py
@@ -451,6 +451,46 @@ class DeepseekV4ROCMAiterMLAAttention(DeepseekV4Attention):
         # Block scale for the preshuffled weight; None = not preshuffled.
         self._wqa_wkv_scale: torch.Tensor | None = None
         self._wo_b_scale: torch.Tensor | None = None
+        # Pre-allocated split-K partition buffers for decode attention.
+        # Lazily initialized on first decode call to avoid device issues.
+        self._split_k_buffers: (
+            tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None
+        ) = None
+
+    def _get_split_k_buffers(
+        self, device: torch.device
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Lazily allocate and return reusable split-K partition buffers.
+
+        These buffers are sized to the maximum possible decode dimensions:
+        [max_num_batched_tokens, MAX_SPLITS=16, n_local_heads] for part_m/l
+        and [max_num_batched_tokens, MAX_SPLITS=16, n_local_heads, comb_dim]
+        for part_acc. Each decode call slices into these buffers, avoiding
+        per-step memory allocation overhead.
+        """
+        if self._split_k_buffers is not None:
+            return self._split_k_buffers
+        max_queries = self.max_num_batched_tokens
+        max_splits = 16  # Upper bound from _decode_num_splits search range.
+        num_heads = self.n_local_heads
+        comb_dim = self.nope_head_dim + self.rope_head_dim
+        part_m = torch.empty(
+            (max_queries, max_splits, num_heads),
+            dtype=torch.float32,
+            device=device,
+        )
+        part_l = torch.empty(
+            (max_queries, max_splits, num_heads),
+            dtype=torch.float32,
+            device=device,
+        )
+        part_acc = torch.empty(
+            (max_queries, max_splits, num_heads, comb_dim),
+            dtype=torch.float32,
+            device=device,
+        )
+        self._split_k_buffers = (part_m, part_l, part_acc)
+        return self._split_k_buffers
 
     @classmethod
     def get_padded_num_q_heads(cls, num_heads: int) -> int:
@@ -662,6 +702,7 @@ class DeepseekV4ROCMAiterMLAAttention(DeepseekV4Attention):
             nope_head_dim=self.nope_head_dim,
             rope_head_dim=self.rope_head_dim,
             output=output,
+            split_k_buffers=self._get_split_k_buffers(q.device),
         )
 
     def _forward_prefill(

--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -2005,6 +2005,10 @@ def _rocm_sparse_attn_decode_ragged_triton(
     extra_cache: torch.Tensor | None = None,
     extra_indices: torch.Tensor | None = None,
     extra_indptr: torch.Tensor | None = None,
+    out: torch.Tensor | None = None,
+    split_k_buffers: (
+        tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None
+    ) = None,
 ) -> torch.Tensor:
     assert q.ndim == 3, f"expected q=[b,h,d], got {q.shape}"
     assert main_cache.ndim == 3, (
@@ -2066,7 +2070,8 @@ def _rocm_sparse_attn_decode_ragged_triton(
         extra_indptr = torch.zeros(num_queries + 1, device=q.device, dtype=torch.int32)
 
     block_h = 16
-    out = torch.empty_like(q, dtype=torch.bfloat16)
+    if out is None:
+        out = torch.empty_like(q, dtype=torch.bfloat16)
     heads_blocks = triton.cdiv(num_heads, block_h)
     nope_block = triton.next_power_of_2(nope_head_dim)
     comb_dim = nope_head_dim + rope_head_dim
@@ -2120,15 +2125,24 @@ def _rocm_sparse_attn_decode_ragged_triton(
         num_queries, heads_blocks, avg_main_len, avg_extra_len, block_k
     )
 
-    part_m = torch.empty(
-        (num_queries, num_splits, num_heads), dtype=torch.float32, device=q.device
-    )
-    part_l = torch.empty_like(part_m)
-    part_acc = torch.empty(
-        (num_queries, num_splits, num_heads, comb_dim),
-        dtype=torch.float32,
-        device=q.device,
-    )
+    if split_k_buffers is not None:
+        # Reuse pre-allocated buffers, slicing to the actual dimensions needed.
+        part_m_buf, part_l_buf, part_acc_buf = split_k_buffers
+        part_m = part_m_buf[:num_queries, :num_splits, :num_heads]
+        part_l = part_l_buf[:num_queries, :num_splits, :num_heads]
+        part_acc = part_acc_buf[:num_queries, :num_splits, :num_heads, :]
+    else:
+        part_m = torch.empty(
+            (num_queries, num_splits, num_heads),
+            dtype=torch.float32,
+            device=q.device,
+        )
+        part_l = torch.empty_like(part_m)
+        part_acc = torch.empty(
+            (num_queries, num_splits, num_heads, comb_dim),
+            dtype=torch.float32,
+            device=q.device,
+        )
 
     _sparse_attn_decode_partial_kernel[(num_queries, num_splits, heads_blocks)](
         q,
@@ -2213,6 +2227,10 @@ def _rocm_sparse_attn_decode_triton(
     main_ragged_indptr: torch.Tensor | None = None,
     extra_ragged_indices: torch.Tensor | None = None,
     extra_ragged_indptr: torch.Tensor | None = None,
+    out: torch.Tensor | None = None,
+    split_k_buffers: (
+        tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None
+    ) = None,
 ) -> torch.Tensor:
     if main_ragged_indices is None or main_ragged_indptr is None:
         main_ragged_indices, main_ragged_indptr = build_ragged_indices_from_dense(
@@ -2248,6 +2266,8 @@ def _rocm_sparse_attn_decode_triton(
         extra_cache=extra_cache,
         extra_indices=extra_ragged_indices,
         extra_indptr=extra_ragged_indptr,
+        out=out,
+        split_k_buffers=split_k_buffers,
     )
 
 
@@ -2319,6 +2339,9 @@ def rocm_sparse_attn_decode(
     nope_head_dim: int,
     rope_head_dim: int,
     output: torch.Tensor,
+    split_k_buffers: (
+        tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None
+    ) = None,
 ) -> None:
     assert swa_k_cache.dtype == torch.uint8, (
         "ROCm Triton sparse decode expects uint8 fp8_ds_mla SWA cache, "
@@ -2348,7 +2371,7 @@ def rocm_sparse_attn_decode(
         if topk_indices is not None:
             extra_indices = topk_indices.reshape(topk_indices.shape[0], -1)
 
-    attn_out = _rocm_sparse_attn_decode_triton(
+    _rocm_sparse_attn_decode_triton(
         q=q,
         main_cache=swa_k_cache,
         main_indices=main_indices,
@@ -2364,5 +2387,6 @@ def rocm_sparse_attn_decode(
         main_ragged_indptr=swa_ragged_indptr,
         extra_ragged_indices=topk_ragged_indices,
         extra_ragged_indptr=topk_ragged_indptr,
+        out=output,
+        split_k_buffers=split_k_buffers,
     )
-    output.copy_(attn_out.to(output.dtype))


### PR DESCRIPTION
### Summary
  
  Reduce decode latency for DeepSeek V4 sparse MLA attention on ROCm by removing redundant memory allocations and a device-to-device copy on every decode forward pass.
  
  ### Changes
  
  **1. Eliminate output tensor allocation + copy** (`vllm/v1/attention/ops/rocm_aiter_mla_sparse.py`)
  
  Previously, `rocm_sparse_attn_decode()` allocated a fresh bf16 output tensor inside `_rocm_sparse_attn_decode_ragged_triton`, then copied it back to the caller's `output`
  buffer via `output.copy_(attn_out.to(output.dtype))`. Since both tensors are bf16 with identical shape and the Triton kernel uses explicit stride parameters, the caller's
  output buffer is now passed directly to the kernel, removing one `torch.empty_like` + one `.copy_()` per decode step.
  
  **2. Pre-allocate split-K partition buffers** (`vllm/models/deepseek_v4/amd/rocm.py` + `vllm/v1/attention/ops/rocm_aiter_mla_sparse.py`)
  
  On gfx942/gfx950, the split-K decode path allocates three scratch tensors (`part_m`, `part_l`, `part_acc`) on every forward call. These are now lazily allocated once at
  maximum size (`[max_num_batched_tokens, 16, n_local_heads, ...]`) and sliced per-call, eliminating 3× `torch.empty` per decode step.
  
  ### Backward Compatibility
  
  All new parameters (`out`, `split_k_buffers`) are `Optional` with `None` defaults. When `None`, the functions allocate internally as before. Existing tests and callers are
  unaffected.
  
  ### Testing
  
  - Verified buffer stride semantics and Triton kernel correctness on AMD MI210 (gfx90a)
  - Existing unit tests (`test_sparse_attn_decode_ragged_kernel`, `test_sparse_attn_decode_split_k_kernel`) pass unchanged (new parameters are optional)
  
  ### Expected Impact
  
  - Eliminates 4 `torch.empty` allocations per decode forward (1 output + 3 split-K)
  - Eliminates 1 D2D `.copy_()` per decode forward
  - Estimated ~50–150 μs/step savings on DeepSeek V4 with TP8 decode