### PR TITLE
[Bugfix][Kimi-K3] Enforce packed rows and op availability in AttnRes dispatch

### DIFF
--- a/csrc/libtorch_stable/kimi_k3/attn_res_kernel.cu
+++ b/csrc/libtorch_stable/kimi_k3/attn_res_kernel.cu
@@ -914,6 +914,13 @@ void kimi_k3_attn_res(torch::stable::Tensor& prefix,
   cudaDeviceProp const* properties = get_device_prop();
   STD_TORCH_CHECK(properties->major == 10,
                   "Kimi K3 AttnRes requires the SM100 family");
+  int64_t const hidden_size = prefix.size(1);
+  STD_TORCH_CHECK(prefix.stride(0) == hidden_size &&
+                      delta.stride(0) == hidden_size &&
+                      output.stride(0) == hidden_size,
+                  "Kimi K3 AttnRes requires densely packed rows; got strides ",
+                  prefix.stride(0), ", ", delta.stride(0), ", ",
+                  output.stride(0), " for hidden_size ", hidden_size);
 
   using namespace sm100::fwd_prod_v2;
   // Two-source chunks and two resident CTAs are beneficial once setup is

--- a/vllm/models/kimi_k3/nvidia/ops/attn_res.py
+++ b/vllm/models/kimi_k3/nvidia/ops/attn_res.py
@@ -187,7 +187,9 @@ def attn_res(
     assert qk_weight.stride(-1) == 1
     assert output_norm_weight is None or output_norm_weight.stride(-1) == 1
     # The in-tree NVIDIA kernel covers the common fused-add + output-norm path;
-    # Triton handles block boundaries and final pre-norm output.
+    # Triton handles block boundaries and final pre-norm output. The native op
+    # is only compiled for SM100 under CUDA >= 13, so a device check alone is
+    # not enough to know it exists.
     if (
         hidden_size == 7168
         and delta is not None
@@ -195,6 +197,7 @@ def attn_res(
         and num_blocks > 0
         and block_write_idx < 0
         and current_platform.is_device_capability_family(100)
+        and hasattr(torch.ops._C, "kimi_k3_attn_res")
     ):
         return ops.kimi_k3_attn_res(
             prefix,


### PR DESCRIPTION
## Summary

Follow-up to #50090 and #50000

1. The kernel hardcodes row stride `H`, but the dispatch only checked    `stride(-1) == 1`, not `stride(0) == hidden_size`. A row-padded input silently corrupts output instead of failing (`max|out - ref| = 6.66` vs. the suite' `8e-2` tolerance on a repro case). Packed rows are an intended precondition (per @gau-nernst), so this adds a `STD_TORCH_CHECK` to fail loudly.

2. `torch.ops._C.kimi_k3_attn_res` only exists under `VLLM_ENABLE_KIMI_K3_ATTN_RES` (CUDA >= 13.0), but the dispatch guard was a device check, not an op-existence check — a CUDA 12.x Blackwell build (e.g. cu129, #50102) raises `AttributeError`. Now also checks `hasattr(torch.ops._C, "kimi_k3_attn_res")`. No duplicate open work (searched `kimi_k3`/`AttnRes`/`attn_res`).

## Test plan

Verified on B200 (sm_100); no test changes:

```
pytest tests/models/kimi_k3/test_attn_res.py   # 19 passed, before and after
```

Padded rows now raise instead of silently corrupting:

```
RuntimeError: Kimi K3 AttnRes requires densely packed rows; got strides 7175, 7175, 7168 for hidden_size 7168
```