### PR TITLE
[Bugfix] Handle single-shard FP8 Marlin MoE padding

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_fp8.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_fp8.py
@@ -220,15 +220,15 @@ def prepare_fp8_layer_for_marlin(
 
 
 def _moe_pad_shard_rows(x: torch.Tensor, n: int, padded_n: int) -> torch.Tensor:
-    """Zero-pad each gate/up shard of a ``(E, 2 * n, ...)`` tensor to padded_n
-    rows. FP8 zero decodes to 0.0, so the padded rows contribute nothing."""
+    """Zero-pad each shard of an ``(E, shards * n, ...)`` tensor to padded_n."""
     if padded_n == n:
         return x
     e = x.size(0)
     rest = x.shape[2:]
-    x = x.view(e, 2, n, *rest)
+    num_shards = x.size(1) // n
+    x = x.view(e, num_shards, n, *rest)
     x = torch.nn.functional.pad(x, (0, 0) * len(rest) + (0, padded_n - n))
-    return x.reshape(e, 2 * padded_n, *rest)
+    return x.reshape(e, num_shards * padded_n, *rest)
 
 
 def _moe_pad_last(x: torch.Tensor, n: int, padded_n: int) -> torch.Tensor:
@@ -347,10 +347,11 @@ def prepare_fp8_moe_layer_for_marlin(
         if padded_n != n:
             if "w13" in name:
                 g = scales.size(1)
-                scales = scales.view(e, g, 2, n)
+                num_shards = size_n // n
+                scales = scales.view(e, g, num_shards, n)
                 scales = torch.nn.functional.pad(scales, (0, padded_n - n))
-                scales = scales.reshape(e, g, 2 * padded_n)
-                size_n = 2 * padded_n
+                scales = scales.reshape(e, g, num_shards * padded_n)
+                size_n = num_shards * padded_n
             else:
                 if group_size > 0:
                     pad_groups = (padded_n - n) // group_size

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_fp8.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_fp8.py
@@ -216,15 +216,15 @@ def prepare_fp8_layer_for_marlin(
 
 
 def _moe_pad_shard_rows(x: torch.Tensor, n: int, padded_n: int) -> torch.Tensor:
-    """Zero-pad each gate/up shard of a ``(E, 2 * n, ...)`` tensor to padded_n
-    rows. FP8 zero decodes to 0.0, so the padded rows contribute nothing."""
+    """Zero-pad each shard of an ``(E, shards * n, ...)`` tensor to padded_n."""
     if padded_n == n:
         return x
     e = x.size(0)
     rest = x.shape[2:]
-    x = x.view(e, 2, n, *rest)
+    num_shards = x.size(1) // n
+    x = x.view(e, num_shards, n, *rest)
     x = torch.nn.functional.pad(x, (0, 0) * len(rest) + (0, padded_n - n))
-    return x.reshape(e, 2 * padded_n, *rest)
+    return x.reshape(e, num_shards * padded_n, *rest)
 
 
 def _moe_pad_last(x: torch.Tensor, n: int, padded_n: int) -> torch.Tensor:
@@ -342,10 +342,11 @@ def prepare_fp8_moe_layer_for_marlin(
         if padded_n != n:
             if "w13" in name:
                 g = scales.size(1)
-                scales = scales.view(e, g, 2, n)
+                num_shards = size_n // n
+                scales = scales.view(e, g, num_shards, n)
                 scales = torch.nn.functional.pad(scales, (0, padded_n - n))
-                scales = scales.reshape(e, g, 2 * padded_n)
-                size_n = 2 * padded_n
+                scales = scales.reshape(e, g, num_shards * padded_n)
+                size_n = num_shards * padded_n
             else:
                 if group_size > 0:
                     pad_groups = (padded_n - n) // group_size


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fix ModelOpt FP8 MoE weight preparation when the forced Marlin W8A16 path pads a non-gated MoE intermediate shard.

`ModelOptFp8MoEMethod` allocates one `w13` shard when `is_act_and_mul` is false and two gate/up shards when it is true. `_moe_pad_shard_rows` and the matching scale-padding path nevertheless reshaped every tensor as two shards. For NVIDIA Nemotron-3 Nano FP8 at TP4, the rank-local intermediate size is 464 rows and requires Marlin tile padding. The one-shard tensors therefore fail during model loading because they cannot be viewed as two 464-row shards.

This change derives the number of existing weight and scale shards from their tensor shapes, pads each shard independently, and restores the same number of shards. The existing two-shard gate/up path is unchanged.

## Test Plan

Run the following command on four NVIDIA H100 80GB GPUs with the parent commit, then run the identical command after applying this PR. `VLLM_TEST_FORCE_FP8_MARLIN=1` selects the FP8 weight-only Marlin W8A16 path that exposes the failure.

```bash
CUDA_VISIBLE_DEVICES=0,1,2,3 \
VLLM_TEST_FORCE_FP8_MARLIN=1 \
vllm serve nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8 \
  --revision f8dc1c0afee92f44417695b4f5ddca9afc95ea58 \
  --served-model-name nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8 \
  --tensor-parallel-size 4 \
  --max-num-seqs 512 \
  --trust-remote-code \
  --max-model-len 2200 \
  --kv-cache-dtype fp8 \
  --gpu-memory-utilization 0.90 \
  --block-size 128 \
  --no-enable-prefix-caching \
  --host 0.0.0.0 \
  --port 8000
```

No unit test is added; validation uses the real checkpoint and the complete four-GPU model-loading path.

## Test Result

Before this change, vLLM selected the intended kernel and loaded all nine checkpoint shards, then failed while padding the first affected MoE layer:

```text
Selected MarlinFP8ScaledMMLinearKernel for ModelOptFp8LinearMethod
Loading safetensors checkpoint shards: 100% | 9/9
File "vllm/model_executor/layers/quantization/utils/marlin_utils_fp8.py", line 227, in _moe_pad_shard_rows
    x = x.view(e, 2, n, *rest)
RuntimeError: shape '[128, 2, 464, 2688]' is invalid for input of size 159645696
```

## After Fix

The exact changes in this PR were applied to vLLM 0.26.0 and exercised with the real checkpoint on four NVIDIA H100 80GB GPUs. The same Marlin kernels were selected, all nine shards loaded, weight preparation completed, CUDA graphs were captured, and the server became healthy:

```text
Selected MarlinFP8ScaledMMLinearKernel for ModelOptFp8LinearMethod
Using MARLIN Fp8 MoE backend
Loading safetensors checkpoint shards: 100% Completed | 9/9
Loading weights took 4.91 seconds
Model loading took 8.39 GiB memory and 6.609813 seconds
Graph capturing finished in 13 secs, took 0.64 GiB
Model is ready. Have 0 prefills and 1 decodes.
Server is healthy - starting benchmark
```

The server then completed the full concurrency 1 through 512 serving sweep. The final point completed 1,536/1,536 requests and generated 1,412,958 tokens with no request failures:

```text
Maximum request concurrency: 512
Successful requests:                     1536
Benchmark duration (s):                  74.90
Output token throughput (tok/s):         18865.49
Total Token throughput (tok/s):          37809.97
Completed benchmark with concurrency: 512
SA-Bench complete.
```

A full 1,319-question, five-shot GSM8K run at TP4 completed with zero invalid responses. A matched forced-Marlin W8A16 TP1 run, where the intermediate does not require padding, produced essentially the same flexible exact-match accuracy:

| Configuration | Completed | Flexible exact match | Strict exact match | Invalid responses | Evaluation time |
|---|---:|---:|---:|---:|---:|
| TP1 W8A16, no intermediate padding | 1,319/1,319 | 0.183 | 0.227 | 0 | 144.052 s |
| TP4 W8A16, patched padding | 1,319/1,319 | 0.182 | 0.240 | 0 | 96.632 s |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)". The failing tensor geometry and root cause are described above; no separate issue has been filed.
- [x] The test plan, such as providing test command. The complete four-H100 `vllm serve` command is provided above.
- [x] The test results, such as pasting the results comparison before and after, or e2e results. The real four-H100 before/after output, serving sweep, and GSM8K comparison are included above.
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. No model, configuration option, or public API changes, so no documentation update is needed.
</details>
