### PR TITLE
feat: allow shared expert overlapping for FlashInfer one-sided all-to-all

### DIFF
--- a/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
+++ b/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
@@ -78,15 +78,22 @@ class SharedExperts(torch.nn.Module):
     @property
     def _disable_shared_experts_overlap(self) -> bool:
         # Disable shared expert overlap if:
-        #   - we are using eplb with non-default backend, because of correctness issues
+        #   - we are using eplb with non-safe backend, because of correctness issues
         #   - we are using flashinfer with DP, since there nothing to gain
+
+        # Both these comm backends have been shown to be safe for shared expert overlap.
+        _EPLB_OVERLAP_SAFE_BACKENDS = (
+            "allgather_reducescatter",
+            "flashinfer_nvlink_one_sided",
+        )
+
         parallel_config = self._moe_config.moe_parallel_config
         if getattr(self._layer, "shard_sequence_parallel", False):
             # TODO: we may enable this to optimize further
             return True
         return (
             parallel_config.enable_eplb
-            and parallel_config.all2all_backend != "allgather_reducescatter"
+            and parallel_config.all2all_backend not in _EPLB_OVERLAP_SAFE_BACKENDS
         ) or parallel_config.use_fi_nvl_two_sided_kernels
 
     def _determine_shared_experts_order(


### PR DESCRIPTION
## Purpose

Allow shared expert overlap when using EPLB with the `flashinfer_nvlink_one_sided` all2all backend. Previously, PR #28377 disabled shared expert overlap for all non-`allgather_reducescatter` backends under EPLB due to correctness issues observed with `deepep_low_latency`. This PR exempts `flashinfer_nvlink_one_sided` from that restriction after verifying it produces correct results with overlap enabled.

## Test Plan

Served `deepseek-ai/DeepSeek-V2-Lite` with TP=1, DP=4, EP=4, EPLB enabled, `--all2all-backend flashinfer_nvlink_one_sided`, on 4× NVIDIA GB300.

Accuracy check:
```bash
vllm serve deepseek-ai/DeepSeek-V2-Lite \
  --tensor-parallel-size 1 --data-parallel-size 4 \
  --enable-expert-parallel --enable-eplb \
  --eplb-config '{"use_async": false}' \
  --trust-remote-code --max-model-len 2048 \
  --all2all-backend flashinfer_nvlink_one_sided

python tests/evals/gsm8k/gsm8k_eval.py \
  --host http://127.0.0.1 --port 8000 --num-questions 200
```

Performance check:
```bash
vllm bench serve \
  --dataset-name random --input-len 1000 --output-len 1000 \
  --max-concurrency 1 --num-warmups 3 --num-prompts 30 \
  --backend openai
```

## Test Result

| | With overlap (this PR) | Without overlap (baseline) |
|---|---|---|
| GSM8K accuracy (200q) | 0.330 | 0.350 |
| Output throughput (tok/s) | 227.96 | 223.80 |
| Mean TPOT (ms) | 4.15 | 4.39 |
| Median TPOT (ms) | 3.18 | 3.42 |

Accuracy difference (0.330 vs 0.350) is within sampling noise at 200 questions. No correctness regression. TPOT improves by ~5-7%.