### PR TITLE
[Multimodal] Add RTSP live-stream captioning via DeepStream backend

### DIFF
--- a/deepstream_video_stream/Dockerfile
+++ b/deepstream_video_stream/Dockerfile
@@ -1,0 +1,76 @@
+# DeepStream backend extension for vLLM
+# ======================================
+# Adds GStreamer + DeepStream 9.0 to an existing vLLM image so the
+# `VLLM_VIDEO_LOADER_BACKEND=deepstream` path can decode video on GPU
+# (NVDEC) through the OpenAI chat-completions API.
+#
+# Prerequisites (place next to this Dockerfile before building):
+#   - deepstream-libs-minimal_<version>-1_amd64.deb
+#       Get it from https://developer.nvidia.com/deepstream-getting-started
+#       (DeepStream 9.0 — adjust DS_DEB build-arg if your filename differs)
+#
+# Build the underlying vLLM image first (only once):
+#   docker build \
+#       --build-arg UBUNTU_VERSION=24.04 \
+#       --build-arg BUILD_BASE_IMAGE=nvidia/cuda:13.0.2-devel-ubuntu24.04 \
+#       --build-arg torch_cuda_arch_list="9.0" \
+#       --build-arg max_jobs=40 \
+#       --build-arg nvcc_threads=2 \
+#       --build-arg RUN_WHEEL_CHECK=false \
+#       --target vllm-openai \
+#       -f docker/Dockerfile \
+#       -t forked_vllm:latest \
+#       .
+#
+# Then build this DS layer:
+#   docker build \
+#       --build-arg VLLM_BASE=forked_vllm:latest \
+#       --build-arg DS_DEB=deepstream-libs-minimal_9.0.0-1_amd64.deb \
+#       -t vllm-deepstream:0.1 \
+#       -f examples/online_serving/deepstream_video_stream/Dockerfile \
+#       examples/online_serving/deepstream_video_stream
+#
+# Run:
+#   docker run --rm -it --gpus all --ipc=host \
+#       -e NVIDIA_DRIVER_CAPABILITIES=all \
+#       -p 8000:8000 \
+#       -v /path/to/videos:/data/video \
+#       --name vllm-ds vllm-deepstream:0.1 \
+#       --model <hf-model-id>
+
+ARG VLLM_BASE=forked_vllm:latest
+ARG DS_DEB=deepstream-libs-minimal_9.0.0-1_amd64.deb
+FROM ${VLLM_BASE}
+ARG DS_DEB
+
+# 1. CUDA 13 runtime libs (NPP, cuBLAS, NVJPEG, cuFFT, cuSPARSE, ...)
+#    + GStreamer 1.24 + Python bindings (PyGObject pulled transitively
+#    by python3-gi).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        cuda-libraries-13-0 \
+        gstreamer1.0-tools \
+        gstreamer1.0-plugins-base \
+        gstreamer1.0-plugins-good \
+        gstreamer1.0-plugins-bad \
+        gstreamer1.0-plugins-ugly \
+        gstreamer1.0-libav \
+        libgstreamer1.0-dev \
+        libgstreamer-plugins-base1.0-dev \
+        libgstreamer-plugins-bad1.0-dev \
+        python3-gi \
+        python3-gst-1.0 \
+        gir1.2-gstreamer-1.0 \
+        gir1.2-gst-plugins-base-1.0 \
+    && rm -rf /var/lib/apt/lists/*
+
+# 2. DeepStream 9.0 SDK (minimal runtime — provides libnvbufsurface,
+#    libnvbufsurftransform, DS GStreamer plugins). The .deb must be
+#    downloaded by the user from NVIDIA's developer portal — it is not
+#    bundled in this repo due to license terms.
+COPY ${DS_DEB} /tmp/
+RUN dpkg -i /tmp/${DS_DEB} \
+    && rm /tmp/${DS_DEB}
+
+# 3. Expose all GPU capabilities so NVDEC / NVENC / GL are accessible
+#    from inside the container. Can be overridden at `docker run` time.
+ENV NVIDIA_DRIVER_CAPABILITIES=all

--- a/deepstream_video_stream/README.md
+++ b/deepstream_video_stream/README.md
@@ -1,0 +1,176 @@
+# DeepStream Backend for vLLM Video Inference
+
+GPU-resident video decoding via NVIDIA DeepStream 9.0 for the vLLM
+OpenAI-compatible server. Adds the `VLLM_VIDEO_LOADER_BACKEND=deepstream`
+option which decodes video chunks directly in GPU memory via NVDEC +
+GStreamer.
+
+## Prerequisites
+
+- NVIDIA GPU with NVDEC support (H100, H200, A100, L40, etc.)
+- Host NVIDIA driver: CUDA 13.0+ compatible (R570+)
+- Docker with `nvidia-container-toolkit`
+- Ubuntu 24.04 base
+- Python 3.12
+
+## Files in this directory
+
+| File | Purpose |
+|---|---|
+| `Dockerfile` | Build the DeepStream-enabled vLLM image |
+| `start_server.sh` | Launch vLLM server with the DS video loader |
+| `run_bench_client.sh` | Throughput benchmark client wrapper |
+| `bench_h264_client.py` | H.264 multi-prompt benchmark client |
+
+## 1. Build the base vLLM image
+
+```bash
+# From the repo root
+docker build \
+    --build-arg UBUNTU_VERSION=24.04 \
+    --build-arg BUILD_BASE_IMAGE=nvidia/cuda:13.0.2-devel-ubuntu24.04 \
+    --build-arg torch_cuda_arch_list="9.0" \
+    --build-arg max_jobs=40 \
+    --build-arg nvcc_threads=2 \
+    --build-arg RUN_WHEEL_CHECK=false \
+    --target vllm-openai \
+    -f docker/Dockerfile \
+    -t forked_vllm:latest \
+    .
+```
+
+Adjust `torch_cuda_arch_list` for your GPU (`9.0` H100/H200, `8.0` A100,
+`8.9` L40, `8.6` A6000/RTX 30xx). Multi-arch is supported (e.g. `"8.0 9.0"`)
+at the cost of longer build times.
+
+## 2. Download the DeepStream runtime
+
+From <https://developer.nvidia.com/deepstream-getting-started> (NVIDIA
+developer account required, license must be accepted):
+
+- `deepstream-libs-minimal_9.0.0-1_amd64.deb` (or whatever 9.0 build you have — pass via `--build-arg DS_DEB=<filename>` if it differs)
+
+Place the file in this directory before the next step.
+
+Note: the DeepStream Python bindings (`pyds`) are **not** required —
+this backend talks to GStreamer via PyGObject (`python3-gi` +
+`python3-gst-1.0`, already installed in step 3) and to CUDA via raw
+`ctypes` bindings to `libcudart.so`. There are no `import pyds` calls
+anywhere in the new code.
+
+## 3. Build the DeepStream-enabled image
+
+```bash
+docker build \
+    --build-arg VLLM_BASE=forked_vllm:latest \
+    --build-arg DS_DEB=deepstream-libs-minimal_9.0.0-1_amd64.deb \
+    -t vllm-deepstream:0.1 \
+    -f examples/online_serving/deepstream_video_stream/Dockerfile \
+    examples/online_serving/deepstream_video_stream
+```
+
+## 4. Launch the container
+
+```bash
+docker run --rm -it --gpus all --ipc=host \
+    -e NVIDIA_DRIVER_CAPABILITIES=all \
+    -p 8000:8000 \
+    -v /path/to/videos:/data/video \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    -v /path/to/forked_vllm:/work/forked_vllm \
+    --entrypoint bash \
+    --name vllm-ds \
+    vllm-deepstream:0.1
+```
+
+The `-v /path/to/forked_vllm:/work/forked_vllm` mount lets the example
+scripts find the vLLM source tree they reference; adjust the host path
+to wherever you cloned the repo.
+
+## 5. Inside the container
+
+### Start the server (single GPU, DS backend)
+
+```bash
+GPU_MEM=0.7 ./vllm/examples/online_serving/deepstream_video_stream/start_server.sh deepstream
+```
+
+Environment overrides:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `MODEL` | `Qwen2-VL-2B-Instruct` | HF model id or local path |
+| `PORT` | `8000` | API port |
+| `GPU_MEM` | `0.8` | vLLM `--gpu-memory-utilization` |
+| `NUM_FRAMES` | `8` | Frames sampled per video request |
+
+### Throughput benchmark on a file input
+
+```bash
+VIDEO="/data/video/sample_1080p_h264_10s_gop30.mp4" \
+    vllm/examples/online_serving/deepstream_video_stream/run_bench_client.sh \
+    --num-prompts 1000 --request-rate inf
+```
+
+## Architecture
+
+```
+HTTP request (OpenAI /v1/chat/completions)
+    │
+    │  video_url: file:///data/video/...
+    │
+    ▼
+VideoMediaIO  (vllm/multimodal/media/video.py)
+    │  dispatches on VLLM_VIDEO_LOADER_BACKEND
+    ▼
+DeepStream loader  (vllm/multimodal/video.py)
+    │
+    ├─ load_bytes()           single file decode
+    └─ stream_file_chunked()  large file in chunks (parallel ThreadPool)
+    │
+    ▼
+DecodePool  (vllm/multimodal/ds_decode_pool.py)
+    │  N GStreamer pipelines (default 8, max 16), NVDEC → CUDA buffers
+    ▼
+CUDA tensor (uint8 NHWC, GPU-resident)
+    │
+    │  .cpu().numpy() at the DS exit point
+    │  (boundary chosen so upstream multimodal parser stays unchanged)
+    ▼
+Standard vLLM multimodal preprocessor  (unchanged)
+    ▼
+ViT vision tower → LLM forward → text response
+```
+
+## Environment variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `VLLM_VIDEO_LOADER_BACKEND` | `opencv` | Set to `deepstream` to enable DS |
+| `VLLM_MEDIA_LOADING_THREAD_COUNT` | `8` | DS decode pool worker count (clamped to `[1, 16]`) |
+| `VLLM_MULTIMODAL_TENSOR_IPC` | `0` | Use shared-memory IPC for multimodal tensors |
+| `NVIDIA_DRIVER_CAPABILITIES` | (image default) | Must include `video` for NVDEC; `all` is the safest catch-all |
+
+## Troubleshooting
+
+- **`libnppig.so.13 => not found` / `libnppidei.so.13 => not found`**
+  The base CUDA image is stripped of NPP. The Dockerfile installs
+  `cuda-libraries-13-0` which pulls in NPP and the other CUDA runtime libs.
+  Verify with `ldconfig -p | grep nppig` inside the container.
+
+- **`ImportError: libcudart.so.12: cannot open shared object file`**
+  Stale `.so` files were copied into the container from a different
+  build. Don't overlay host-built `.so` files; let the image's own
+  CUDA-13 extensions stand.
+
+- **GPU SM% low during file benchmark**
+  vLLM's prefix-cache + multimodal-cache may be hitting 99%+ on a
+  same-video benchmark (look for `Prefix cache hit rate` / `MM cache hit
+  rate` in server logs). Use a directory of distinct videos to bypass
+  the cache and measure real ViT throughput.
+
+## License notice
+
+The DeepStream SDK is NVIDIA proprietary. By downloading it you accept
+NVIDIA's license terms. This PR does **not** redistribute the SDK; users
+must obtain it directly from NVIDIA.

--- a/deepstream_video_stream/bench_h264_client.py
+++ b/deepstream_video_stream/bench_h264_client.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""
+Benchmark client for vLLM serving with real H.264 video files.
+
+Supports two modes:
+  --use-file-url   Send a file:// URL (tiny JSON payload, server reads from disk)
+  (default)        Send base64-encoded video over HTTP (legacy, large payload)
+
+Measures:
+  - TTFT  (Time To First Token)
+  - TPOT  (Time Per Output Token)
+  - ITL   (Inter-Token Latency)
+  - E2EL  (End-to-End Latency)
+  - Request throughput, output-token throughput
+
+Unlike `vllm bench serve --dataset-name random-mm`, this script uses a
+*real* H.264 file so that NVDEC hardware decoding is exercised when the
+server's video backend is set to DeepStream.
+
+Usage:
+    # File-URL mode (recommended — tiny payload, server reads from disk):
+    python3 bench_h264_client.py \
+        --video /data/video/drivesim.mp4 --use-file-url \
+        --num-prompts 30 --request-rate inf \
+        --base-url http://localhost:8000 \
+        --model bench-model
+
+    # Base64 mode (legacy — 31MB payload per request):
+    python3 bench_h264_client.py \
+        --video /path/to/1080p.mp4 \
+        --num-prompts 30 --request-rate inf \
+        --base-url http://localhost:8000 \
+        --model bench-model
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import aiohttp
+import numpy as np
+
+
+# ── Data classes ──────────────────────────────────────────────────────
+
+@dataclass
+class RequestResult:
+    success: bool = False
+    ttft: float = 0.0          # seconds
+    e2el: float = 0.0          # seconds
+    token_timestamps: list[float] = field(default_factory=list)
+    output_tokens: int = 0
+    error: str = ""
+    generated_text: str = ""
+    request_id: int = -1
+
+
+@dataclass
+class BenchmarkMetrics:
+    completed: int = 0
+    failed: int = 0
+    total_duration: float = 0.0
+
+    mean_ttft_ms: float = 0.0
+    median_ttft_ms: float = 0.0
+    std_ttft_ms: float = 0.0
+    p99_ttft_ms: float = 0.0
+
+    mean_tpot_ms: float = 0.0
+    median_tpot_ms: float = 0.0
+    std_tpot_ms: float = 0.0
+    p99_tpot_ms: float = 0.0
+
+    mean_itl_ms: float = 0.0
+    median_itl_ms: float = 0.0
+    std_itl_ms: float = 0.0
+    p99_itl_ms: float = 0.0
+
+    mean_e2el_ms: float = 0.0
+    median_e2el_ms: float = 0.0
+    std_e2el_ms: float = 0.0
+    p99_e2el_ms: float = 0.0
+
+    request_throughput: float = 0.0
+    output_throughput: float = 0.0
+
+
+def compute_metrics(
+    results: list[RequestResult], total_duration: float
+) -> BenchmarkMetrics:
+    m = BenchmarkMetrics()
+    good = [r for r in results if r.success]
+    m.completed = len(good)
+    m.failed = len(results) - len(good)
+    m.total_duration = total_duration
+
+    if not good:
+        return m
+
+    ttfts = np.array([r.ttft * 1000 for r in good])
+    e2els = np.array([r.e2el * 1000 for r in good])
+
+    m.mean_ttft_ms = float(np.mean(ttfts))
+    m.median_ttft_ms = float(np.median(ttfts))
+    m.std_ttft_ms = float(np.std(ttfts))
+    m.p99_ttft_ms = float(np.percentile(ttfts, 99))
+
+    m.mean_e2el_ms = float(np.mean(e2els))
+    m.median_e2el_ms = float(np.median(e2els))
+    m.std_e2el_ms = float(np.std(e2els))
+    m.p99_e2el_ms = float(np.percentile(e2els, 99))
+
+    # TPOT = (e2el - ttft) / (output_tokens - 1) for each request
+    tpots: list[float] = []
+    for r in good:
+        if r.output_tokens > 1:
+            tpots.append((r.e2el - r.ttft) / (r.output_tokens - 1) * 1000)
+    if tpots:
+        tpot_arr = np.array(tpots)
+        m.mean_tpot_ms = float(np.mean(tpot_arr))
+        m.median_tpot_ms = float(np.median(tpot_arr))
+        m.std_tpot_ms = float(np.std(tpot_arr))
+        m.p99_tpot_ms = float(np.percentile(tpot_arr, 99))
+
+    # ITL from per-token timestamps
+    all_itls: list[float] = []
+    for r in good:
+        ts = r.token_timestamps
+        for i in range(1, len(ts)):
+            all_itls.append((ts[i] - ts[i - 1]) * 1000)
+    if all_itls:
+        itl_arr = np.array(all_itls)
+        m.mean_itl_ms = float(np.mean(itl_arr))
+        m.median_itl_ms = float(np.median(itl_arr))
+        m.std_itl_ms = float(np.std(itl_arr))
+        m.p99_itl_ms = float(np.percentile(itl_arr, 99))
+
+    total_tokens = sum(r.output_tokens for r in good)
+    m.request_throughput = m.completed / total_duration if total_duration > 0 else 0
+    m.output_throughput = total_tokens / total_duration if total_duration > 0 else 0
+
+    return m
+
+
+# ── Single-request sender ────────────────────────────────────────────
+
+async def send_request(
+    session: aiohttp.ClientSession,
+    url: str,
+    model: str,
+    video_url: str,
+    prompt: str,
+    max_tokens: int,
+    request_id: int,
+) -> RequestResult:
+    result = RequestResult()
+
+    payload = {
+        "model": model,
+        "max_tokens": max_tokens,
+        "stream": True,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "video_url",
+                        "video_url": {"url": video_url},
+                    },
+                    {"type": "text", "text": prompt},
+                ],
+            }
+        ],
+    }
+
+    result.request_id = request_id
+    t_start = time.monotonic()
+    first_token_time = None
+    text_parts: list[str] = []
+
+    try:
+        async with session.post(url, json=payload) as resp:
+            if resp.status != 200:
+                body = await resp.text()
+                result.error = f"HTTP {resp.status}: {body[:300]}"
+                return result
+
+            async for raw_line in resp.content:
+                line = raw_line.decode("utf-8").strip()
+                if not line.startswith("data: "):
+                    continue
+                data_str = line[len("data: "):]
+                if data_str == "[DONE]":
+                    break
+                try:
+                    chunk = json.loads(data_str)
+                except json.JSONDecodeError:
+                    continue
+
+                choices = chunk.get("choices", [])
+                if not choices:
+                    continue
+                delta = choices[0].get("delta", {})
+                content = delta.get("content")
+                if content is not None and len(content) > 0:
+                    now = time.monotonic()
+                    if first_token_time is None:
+                        first_token_time = now
+                    result.token_timestamps.append(now)
+                    result.output_tokens += 1
+                    text_parts.append(content)
+
+    except Exception as exc:
+        result.error = str(exc)
+        return result
+
+    t_end = time.monotonic()
+    result.generated_text = "".join(text_parts)
+
+    if first_token_time is not None:
+        result.success = True
+        result.ttft = first_token_time - t_start
+        result.e2el = t_end - t_start
+
+        tpot = 0.0
+        if result.output_tokens > 1:
+            tpot = (result.e2el - result.ttft) / (result.output_tokens - 1) * 1000
+        print(f"  [req {request_id:>3}] TTFT={result.ttft*1000:7.1f}ms  "
+              f"E2EL={result.e2el*1000:7.1f}ms  "
+              f"TPOT={tpot:6.1f}ms  "
+              f"tokens={result.output_tokens}")
+    else:
+        print(f"  [req {request_id:>3}] FAILED: {result.error[:80]}")
+
+    return result
+
+
+# ── Request dispatcher ────────────────────────────────────────────────
+
+def _resolve_video_paths(video_args: list[str]) -> list[Path]:
+    """Expand directories and glob patterns into a flat list of video files."""
+    paths: list[Path] = []
+    for v in video_args:
+        p = Path(v)
+        if p.is_dir():
+            for ext in ("*.mp4", "*.mkv", "*.avi", "*.ts", "*.mov"):
+                paths.extend(sorted(p.glob(ext)))
+        elif p.exists():
+            paths.append(p)
+        else:
+            print(f"WARNING: Video path not found, skipping: {v}",
+                  file=sys.stderr)
+    return paths
+
+
+async def run_benchmark(
+    args: argparse.Namespace,
+) -> tuple[BenchmarkMetrics, list[RequestResult]]:
+    video_paths = _resolve_video_paths(args.video)
+    if not video_paths:
+        print("ERROR: No video files found.", file=sys.stderr)
+        sys.exit(1)
+
+    video_urls: list[str] = []
+    for vp in video_paths:
+        if args.use_file_url:
+            abs_path = str(vp.resolve())
+            video_urls.append(f"file://{abs_path}")
+            print(f"  Video file  : {abs_path} "
+                  f"({vp.stat().st_size / 1024:.0f} KB)")
+        else:
+            video_b64 = base64.b64encode(vp.read_bytes()).decode("ascii")
+            video_urls.append(f"data:video/mp4;base64,{video_b64}")
+            print(f"  Video file  : {vp} "
+                  f"({vp.stat().st_size / 1024:.0f} KB, base64)")
+
+    n_videos = len(video_urls)
+    print(f"  Mode        : {'file:// URL' if args.use_file_url else 'base64 inline'}")
+    print(f"  Videos      : {n_videos} file(s)")
+
+    url = f"{args.base_url}/v1/chat/completions"
+    prompt = args.prompt
+    num = args.num_prompts
+    rate = args.request_rate
+
+    reqs_per_video = num // n_videos
+    remainder = num % n_videos
+    print(f"  Target URL  : {url}")
+    print(f"  Model       : {args.model}")
+    print(f"  Num prompts : {num} ({reqs_per_video} per video"
+          f"{f', +1 for first {remainder}' if remainder else ''})")
+    print(f"  Request rate: {'inf (all at once)' if rate == float('inf') else f'{rate} req/s'}")
+    print(f"  Max tokens  : {args.max_tokens}")
+    print()
+
+    timeout = aiohttp.ClientTimeout(total=600)
+    conn = aiohttp.TCPConnector(limit=num + 10)
+    async with aiohttp.ClientSession(timeout=timeout, connector=conn) as session:
+        if not args.skip_warmup:
+            print("  Sending warm-up request...")
+            warm = await send_request(
+                session, url, args.model, video_urls[0], prompt, 5, -1
+            )
+            if warm.success:
+                print(f"  Warm-up done (TTFT={warm.ttft*1000:.0f}ms, "
+                      f"E2EL={warm.e2el*1000:.0f}ms)")
+            else:
+                print(f"  Warm-up FAILED: {warm.error}")
+                if not args.force:
+                    print("  Aborting. Use --force to run anyway.")
+                    sys.exit(1)
+            print()
+
+        tasks: list[asyncio.Task] = []
+        print(f"  Launching {num} requests...")
+        bench_start = time.monotonic()
+
+        for i in range(num):
+            vid_url = video_urls[i % n_videos]
+            task = asyncio.create_task(
+                send_request(
+                    session, url, args.model, vid_url,
+                    prompt, args.max_tokens, i,
+                )
+            )
+            tasks.append(task)
+            if rate != float("inf") and i < num - 1:
+                await asyncio.sleep(1.0 / rate)
+
+        results = await asyncio.gather(*tasks)
+        bench_end = time.monotonic()
+
+    total_duration = bench_end - bench_start
+    result_list = list(results)
+    metrics = compute_metrics(result_list, total_duration)
+
+    return metrics, result_list
+
+
+# ── Display & save ────────────────────────────────────────────────────
+
+def print_metrics(m: BenchmarkMetrics) -> None:
+    print()
+    print("  ╔══════════════════════════════════════════════════════╗")
+    print("  ║              Benchmark Results                      ║")
+    print("  ╠══════════════════════════════════════════════════════╣")
+    print(f"  ║  Completed requests    : {m.completed:>8}                 ║")
+    print(f"  ║  Failed requests       : {m.failed:>8}                 ║")
+    print(f"  ║  Benchmark duration    : {m.total_duration:>8.2f}s                ║")
+    print(f"  ║  Request throughput    : {m.request_throughput:>8.2f} req/s           ║")
+    print(f"  ║  Output throughput     : {m.output_throughput:>8.2f} tok/s           ║")
+    print("  ╠══════════════════════════════════════════════════════╣")
+    print(f"  ║  Mean   TTFT           : {m.mean_ttft_ms:>10.2f} ms             ║")
+    print(f"  ║  Median TTFT           : {m.median_ttft_ms:>10.2f} ms             ║")
+    print(f"  ║  P99    TTFT           : {m.p99_ttft_ms:>10.2f} ms             ║")
+    print("  ╠══════════════════════════════════════r═══════════════╣")
+    print(f"  ║  Mean   TPOT           : {m.mean_tpot_ms:>10.2f} ms             ║")
+    print(f"  ║  Median TPOT           : {m.median_tpot_ms:>10.2f} ms             ║")
+    print(f"  ║  P99    TPOT           : {m.p99_tpot_ms:>10.2f} ms             ║")
+    print("  ╠══════════════════════════════════════════════════════╣")
+    print(f"  ║  Mean   ITL            : {m.mean_itl_ms:>10.2f} ms             ║")
+    print(f"  ║  Median ITL            : {m.median_itl_ms:>10.2f} ms             ║")
+    print(f"  ║  P99    ITL            : {m.p99_itl_ms:>10.2f} ms             ║")
+    print("  ╠══════════════════════════════════════════════════════╣")
+    print(f"  ║  Mean   E2EL           : {m.mean_e2el_ms:>10.2f} ms             ║")
+    print(f"  ║  Median E2EL           : {m.median_e2el_ms:>10.2f} ms             ║")
+    print(f"  ║  P99    E2EL           : {m.p99_e2el_ms:>10.2f} ms             ║")
+    print("  ╚══════════════════════════════════════════════════════╝")
+
+
+def print_vlm_outputs(results: list[RequestResult], max_show: int = 5) -> None:
+    good = [r for r in results if r.success]
+    good.sort(key=lambda r: r.request_id)
+    print()
+    print(f"  ── VLM Text Output (showing {min(max_show, len(good))}"
+          f" of {len(good)} responses) ──")
+    for r in good[:max_show]:
+        tokens = r.output_tokens
+        text = r.generated_text.replace("\n", " ").strip()
+        print(f"  [req {r.request_id:>3}] ({tokens:>3} tokens) {text}")
+    if len(good) > max_show:
+        lengths = [r.output_tokens for r in good]
+        print(f"  ...")
+        print(f"  Token counts: min={min(lengths)}, max={max(lengths)}, "
+              f"mean={np.mean(lengths):.1f}, total={sum(lengths)}")
+    print()
+
+
+def save_results(m: BenchmarkMetrics, path: str,
+                 results: list[RequestResult] | None = None) -> None:
+    d = {k: v for k, v in m.__dict__.items()}
+    with open(path, "w") as f:
+        json.dump(d, f, indent=2)
+    print(f"  Results saved to: {path}")
+
+    if results:
+        txt_path = path.rsplit(".", 1)[0] + "_vlm_outputs.txt"
+        with open(txt_path, "w") as f:
+            for r in sorted(results, key=lambda r: r.request_id):
+                if r.success:
+                    f.write(f"[req {r.request_id}] ({r.output_tokens} tokens) "
+                            f"{r.generated_text}\n")
+        print(f"  VLM outputs saved to: {txt_path}")
+
+
+# ── Main ──────────────────────────────────────────────────────────────
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Benchmark vLLM serving with real H.264 video"
+    )
+    p.add_argument("--video", required=True, nargs="+",
+                   help="Path(s) to H.264 MP4 video file(s), or a directory. "
+                        "Requests are distributed round-robin across files.")
+    p.add_argument("--base-url", default="http://localhost:8000")
+    p.add_argument("--model", default="bench-model")
+    p.add_argument("--num-prompts", type=int, default=30)
+    p.add_argument("--request-rate", type=float, default=float("inf"),
+                   help="Requests per second (default: inf = all at once)")
+    p.add_argument("--max-tokens", type=int, default=50)
+    p.add_argument("--prompt", default="Describe what is happening in this video in detail.")
+    p.add_argument("--save-result", action="store_true")
+    p.add_argument("--result-filename", default="bench_result.json")
+    p.add_argument("--skip-warmup", action="store_true")
+    p.add_argument("--force", action="store_true",
+                   help="Continue even if warm-up fails")
+    p.add_argument("--chunk-duration", type=float, default=10.0,
+                   help="Seconds of video per chunk (default: 10)")
+    p.add_argument("--use-file-url", action="store_true",
+                   help="Send file:// URL instead of base64. "
+                        "Server must have --allowed-local-media-path set.")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    if args.request_rate <= 0:
+        print("ERROR: --request-rate must be positive or 'inf'",
+              file=sys.stderr)
+        sys.exit(1)
+
+    metrics, results = asyncio.run(run_benchmark(args))
+    print_metrics(metrics)
+    print_vlm_outputs(results)
+
+    if args.save_result:
+        save_results(metrics, args.result_filename, results)
+
+
+if __name__ == "__main__":
+    main()

--- a/deepstream_video_stream/run_bench_client.sh
+++ b/deepstream_video_stream/run_bench_client.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# ============================================================================
+# Run bench_h264_client.py against a running vLLM server.
+# Start the server first with start_server.sh.
+#
+# Usage:
+#   ./run_bench_client.sh                           # defaults
+#   ./run_bench_client.sh --num-prompts 50          # override prompts
+#   ./run_bench_client.sh --request-rate inf        # all at once
+#
+# All arguments are passed through to bench_h264_client.py.
+# If no --video is given, defaults to /data/video/drivesim.mp4.
+#
+# VIDEO can be:
+#   - A single file:   VIDEO=/data/video/drivesim.mp4
+#   - A directory:      VIDEO=/data/video/        (all mp4/mkv/avi/ts/mov)
+#   - Multiple files:   VIDEO="/data/video/a.mp4 /data/video/b.mp4"
+#
+# With multiple videos, requests are distributed round-robin.
+#
+# Environment overrides:
+#   PORT=8000  VIDEO=/data/video/  BACKEND_LABEL=deepstream
+#   NUM_PROMPTS=100  REQUEST_RATE=16  MAX_TOKENS=16
+# ============================================================================
+set -euo pipefail
+
+ulimit -n 65535
+
+PORT="${PORT:-8000}"
+VIDEO="${VIDEO:-/data/video/}"
+BACKEND_LABEL="${BACKEND_LABEL:-unknown}"
+NUM_PROMPTS="${NUM_PROMPTS:-100}"
+REQUEST_RATE="${REQUEST_RATE:-16}"
+MAX_TOKENS="${MAX_TOKENS:-16}"
+CHUNK_DURATION="${CHUNK_DURATION:-10}"
+BENCH_CLIENT="$(dirname "$0")/bench_h264_client.py"
+RESULTS_DIR="/work/deepstream_9.0_vllm/bench_results"
+RESULT_FILE="${RESULTS_DIR}/bench_serve_${BACKEND_LABEL}.json"
+LOG_FILE="${RESULTS_DIR}/bench_serve_${BACKEND_LABEL}.log"
+
+mkdir -p "$RESULTS_DIR"
+
+# Check server is running
+echo "  Checking server at http://localhost:$PORT ..."
+if ! curl -s --max-time 5 http://localhost:$PORT/health > /dev/null 2>&1; then
+    echo "  ERROR: Server not reachable at http://localhost:$PORT"
+    echo "  Start it first:  ./start_server.sh deepstream"
+    exit 1
+fi
+echo "  Server is healthy."
+echo ""
+
+echo "============================================================"
+echo "  Benchmark Client"
+echo "============================================================"
+echo "  Video          : $VIDEO"
+echo "  Server         : http://localhost:$PORT"
+echo "  Backend label  : $BACKEND_LABEL"
+echo "  Num prompts    : $NUM_PROMPTS"
+echo "  Request rate   : $REQUEST_RATE"
+echo "  Max tokens     : $MAX_TOKENS"
+echo "  Chunk duration : ${CHUNK_DURATION}s"
+echo "  Result file    : $RESULT_FILE"
+echo "============================================================"
+echo ""
+
+# Build default args, then allow overrides via "$@"
+# shellcheck disable=SC2086
+DEFAULT_ARGS=(
+    --video $VIDEO
+    --base-url "http://localhost:$PORT"
+    --model bench-model
+    --num-prompts "$NUM_PROMPTS"
+    --request-rate "$REQUEST_RATE"
+    --max-tokens "$MAX_TOKENS"
+    --chunk-duration "$CHUNK_DURATION"
+    --force
+    --use-file-url
+    --save-result
+    --result-filename "$RESULT_FILE"
+)
+
+python3 "$BENCH_CLIENT" "${DEFAULT_ARGS[@]}" "$@" 2>&1 | tee "$LOG_FILE"
+
+echo ""
+echo "  Results saved to: $RESULT_FILE"
+echo "  Log saved to:     $LOG_FILE"
+echo ""

--- a/deepstream_video_stream/start_server.sh
+++ b/deepstream_video_stream/start_server.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# ============================================================================
+# Start vLLM server with a chosen video backend (deepstream or opencv).
+# Run this first, then use run_bench_client.sh in another terminal.
+#
+# Usage:
+#   ./start_server.sh                  # defaults: deepstream backend
+#   ./start_server.sh opencv           # opencv backend
+#   ./start_server.sh deepstream       # deepstream backend
+#
+# Environment overrides:
+#   PORT=8000  MODEL=/path/to/model  GPU_MEM=0.8  NUM_FRAMES=8  POOL_SIZE=8
+# ============================================================================
+set -euo pipefail
+
+# Run from / so `import vllm` resolves to the installed compiled package in
+# dist-packages, not the /work/vllm source tree (which has no compiled C
+# extensions and fails with "No module named 'vllm._C_stable_libtorch'").
+cd /
+
+BACKEND="${1:-deepstream}"
+MODEL="${MODEL:-/work/deepstream_9.0_vllm/Qwen2-VL-2B-Instruct}"
+#MODEL="${MODEL:-/work/deepstream_9.0_vllm/Qwen3-VL-2B-Instruct}"
+#MODEL="${MODEL:-/work/deepstream_9.0_vllm/InternVL3_5-1B}"
+#MODEL="${MODEL:-/work/deepstream_9.0_vllm/Qwen3-VL-4B-Instruct}"
+PORT="${PORT:-8000}"
+GPU_MEM="${GPU_MEM:-0.8}"
+NUM_FRAMES="${NUM_FRAMES:-8}"
+# deepstream decode-pool size (worker threads); passed via media-io-kwargs.
+POOL_SIZE="${POOL_SIZE:-8}"
+# export VLLM_ATTENTION_BACKEND=FLASHINFER
+# Pre-computed KV cache block count — skips the 2+ min GPU memory profiling step.
+# Calibrated at GPU_MEM=0.7 on H200 (91 GiB free → 3,412,496 tokens / 16 = 213,281 blocks).
+# Clear this (set to "") when changing GPU_MEM or the model so it re-profiles once.
+#NUM_GPU_BLOCKS="${NUM_GPU_BLOCKS:-213281}"
+LOG_DIR="/work/deepstream_9.0_vllm/bench_results"
+SERVER_LOG="${LOG_DIR}/server_${BACKEND}.log"
+
+mkdir -p "$LOG_DIR"
+
+# Stage video if needed
+mkdir -p /data/video 2>/dev/null || true
+VIDEO_SRC="/work/via-engine/tests/alerts/verifyAlerts_clips/verifyAlerts_raw/drive_sim_collision_1080p_2025-08-01T04-18-22.000752Z_clip_5.mp4"
+VIDEO="/data/video/drivesim.mp4"
+if [ ! -f "$VIDEO" ] && [ -f "$VIDEO_SRC" ]; then
+    echo "Staging video: $VIDEO_SRC -> $VIDEO"
+    cp "$VIDEO_SRC" "$VIDEO"
+fi
+
+export HF_HUB_OFFLINE=1
+export VLLM_MULTIMODAL_TENSOR_IPC=1
+export TRANSFORMERS_OFFLINE=1
+export CUDA_MODULE_LOADING=LAZY
+export VLLM_MEDIA_LOADING_THREAD_COUNT=16
+# H200 is SM 9.0 — vLLM's default is FLASH_ATTN (FlashAttention-3 with Hopper TMA/wgmma).
+# FlashInfer is only preferred on SM 10.0 (Blackwell). Don't override unless benchmarking.
+# export VLLM_ATTENTION_BACKEND=FLASHINFER
+# deepstream/opencv/pyav are now codecs of the default "opencv"
+# VideoBackend, selected via the media-io-kwargs "backend" key (no separate
+# loader class). Force that loader; the codec is passed in MEDIA_IO_KWARGS.
+export VLLM_VIDEO_LOADER_BACKEND=opencv
+
+# Persistent kernel caches — survives container restarts, avoids Triton JIT recompile
+export TRITON_CACHE_DIR=/work/deepstream_9.0_vllm/.triton_cache
+export VLLM_CACHE_ROOT=/work/deepstream_9.0_vllm/.vllm_cache
+
+MEDIA_IO_KWARGS="{\"video\": {\"num_frames\": ${NUM_FRAMES}, \"backend\": \"${BACKEND}\", \"pool_size\": ${POOL_SIZE}}}"
+
+echo "============================================================"
+echo "  vLLM Server"
+echo "============================================================"
+echo "  Backend        : $BACKEND"
+echo "  Model          : $MODEL"
+echo "  Port           : $PORT"
+echo "  GPU mem util   : $GPU_MEM"
+echo "  Frames/video   : $NUM_FRAMES"
+echo "  Pool size      : $POOL_SIZE (deepstream decode workers)"
+echo "  Server log     : $SERVER_LOG"
+echo "============================================================"
+echo ""
+
+# Kill any existing server on this port
+if curl -s --max-time 1 http://localhost:$PORT/health > /dev/null 2>&1; then
+    echo "  Killing existing server on port $PORT..."
+    pkill -f "vllm serve" 2>/dev/null || true
+    pkill -f "EngineCore" 2>/dev/null || true
+    sleep 3
+fi
+
+echo "  Starting vLLM server..."
+echo "  (logs → $SERVER_LOG)"
+echo ""
+
+GPU_BLOCKS_ARG=""
+if [ -n "${NUM_GPU_BLOCKS:-}" ]; then
+    GPU_BLOCKS_ARG="--num-gpu-blocks-override $NUM_GPU_BLOCKS"
+fi
+
+vllm serve "$MODEL" \
+    --limit-mm-per-prompt '{"video": 1}' \
+    --media-io-kwargs "$MEDIA_IO_KWARGS" \
+    --gpu-memory-utilization $GPU_MEM \
+    --host 0.0.0.0 \
+    --port $PORT \
+    --dtype bfloat16 \
+    --enforce-eager \
+    --served-model-name bench-model \
+    --max-model-len ${MAX_MODEL_LEN:-32768} \
+    --max-num-seqs 16 \
+    --trust-remote-code \
+    --allowed-local-media-path /data \
+    --skip-mm-profiling \
+    $GPU_BLOCKS_ARG \
+    2>&1 | tee "$SERVER_LOG"

--- a/deepstream_video_stream/test_rtsp_stream.py
+++ b/deepstream_video_stream/test_rtsp_stream.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""
+Test the /v1/chat/completions SSE endpoint with an RTSP source.
+
+The DeepStream-backed vLLM server detects rtsp:// URLs in the
+``messages`` content and emits one chat.completion.chunk per decoded
+segment caption. The wire format mirrors RTVI's bend on chat/completions:
+
+  - One id, one created across all chunks in a single stream.
+  - Each data chunk: ``delta.content = "<full caption for one segment>"``,
+    ``finish_reason: null``.
+  - Terminal chunk: ``delta: {}``, ``finish_reason: "stop"``.
+  - Then literal ``[DONE]``.
+
+Usage:
+    python3 test_rtsp_stream.py [rtsp_url] [options]
+
+Examples:
+    python3 test_rtsp_stream.py rtsp://10.24.217.130:8554/
+    python3 test_rtsp_stream.py rtsp://10.24.217.130:8554/ --segments 3
+    python3 test_rtsp_stream.py file:///data/video/drivesim.mp4
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+
+import requests
+
+
+def stream_captions(
+    rtsp_url: str,
+    server: str = "http://localhost:8000",
+    model: str = "bench-model",
+    prompt: str = "Describe what is happening in this video segment.",
+    chunk_duration: float = 10.0,
+    num_frames: int = 8,
+    max_tokens: int = 256,
+    temperature: float = 0.0,
+    max_segments: int | None = None,
+) -> None:
+    url = f"{server}/v1/chat/completions"
+    payload = {
+        "model": model,
+        "stream": True,
+        "messages": [{
+            "role": "user",
+            "content": [
+                {"type": "video_url", "video_url": {"url": rtsp_url}},
+                {"type": "text", "text": prompt},
+            ],
+        }],
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        # Custom extras tolerated by OpenAIBaseModel(extra="allow"):
+        "chunk_duration": chunk_duration,
+        "num_frames_per_chunk": num_frames,
+    }
+
+    print(f"Connecting to: {url}")
+    print(f"RTSP source  : {rtsp_url}")
+    print(f"Chunk        : {chunk_duration}s per segment, {num_frames} frames")
+    print("-" * 60)
+
+    t_connect = time.monotonic()
+    segments_received = 0
+
+    try:
+        with requests.post(url, json=payload, stream=True, timeout=None) as resp:
+            resp.raise_for_status()
+
+            for raw_line in resp.iter_lines():
+                if not raw_line:
+                    continue
+
+                line = (
+                    raw_line.decode("utf-8")
+                    if isinstance(raw_line, bytes)
+                    else raw_line
+                )
+                if not line.startswith("data: "):
+                    continue
+
+                data = line[len("data: "):]
+                if data == "[DONE]":
+                    print("\n[DONE] — stream ended")
+                    break
+
+                try:
+                    chunk = json.loads(data)
+                except json.JSONDecodeError:
+                    print(f"[WARN] Could not parse: {data!r}")
+                    continue
+
+                choices = chunk.get("choices") or []
+                if not choices:
+                    continue
+                choice0 = choices[0]
+                delta = choice0.get("delta") or {}
+                finish_reason = choice0.get("finish_reason")
+
+                content = delta.get("content")
+                if content:
+                    segments_received += 1
+                    elapsed = time.monotonic() - t_connect
+                    print(
+                        f"\n[Segment {segments_received - 1}]  "
+                        f"id={chunk.get('id', '?')}  "
+                        f"(wall +{elapsed:.1f}s)"
+                    )
+                    print(f"  {content}")
+
+                    if max_segments is not None and segments_received >= max_segments:
+                        print(
+                            f"\nReached --segments {max_segments} limit, "
+                            "disconnecting."
+                        )
+                        break
+
+                if finish_reason == "stop":
+                    print("\n[finish_reason=stop] — terminal chunk")
+
+    except KeyboardInterrupt:
+        print("\nInterrupted by user.")
+    except requests.exceptions.ConnectionError as e:
+        print(f"\n[ERROR] Could not connect to {server}: {e}")
+        sys.exit(1)
+    except requests.exceptions.HTTPError as e:
+        print(f"\n[ERROR] HTTP {e.response.status_code}: {e.response.text}")
+        sys.exit(1)
+
+    total = time.monotonic() - t_connect
+    print(f"\n{segments_received} segment(s) received in {total:.1f}s")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Test /v1/chat/completions SSE endpoint with an RTSP source"
+    )
+    parser.add_argument(
+        "rtsp_url",
+        nargs="?",
+        default="rtsp://10.24.217.130:8554/",
+        help="RTSP or file:// URI (default: rtsp://10.24.217.130:8554/)",
+    )
+    # Default server URL honors $PORT (and $HOST) env vars so the script
+    # works with `PORT=8001 python3 test_rtsp_stream.py ...` without
+    # needing --server. Explicit --server still overrides.
+    default_server = (
+        f"http://{os.environ.get('HOST', 'localhost')}"
+        f":{os.environ.get('PORT', '8000')}"
+    )
+    parser.add_argument("--server", default=default_server,
+                        help=f"Server base URL (default: {default_server}, "
+                             f"override via $HOST/$PORT or --server)")
+    parser.add_argument("--model",    default="bench-model")
+    parser.add_argument(
+        "--prompt",
+        default="Describe what is happening in this video segment.",
+    )
+    parser.add_argument(
+        "--chunk-duration", type=float, default=10.0,
+        help="Seconds per chunk/segment",
+    )
+    parser.add_argument(
+        "--frames", type=int, default=8, help="Frames per segment",
+    )
+    parser.add_argument(
+        "--tokens", type=int, default=256, help="Max output tokens",
+    )
+    parser.add_argument(
+        "--segments", type=int, default=None, help="Stop after N segments",
+    )
+    args = parser.parse_args()
+
+    stream_captions(
+        rtsp_url=args.rtsp_url,
+        server=args.server,
+        model=args.model,
+        prompt=args.prompt,
+        chunk_duration=args.chunk_duration,
+        num_frames=args.frames,
+        max_tokens=args.tokens,
+        max_segments=args.segments,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -463,6 +463,13 @@ async def init_app_state(
 
         init_scale_out_state(state, args, engine_client, request_logger)
 
+    from vllm.entrypoints.openai.streaming.api_router import init_streaming_state
+
+    init_streaming_state(engine_client, state, args, request_logger, supported_tasks)
+
+    if state.video_streaming_serving is not None:
+        await state.video_streaming_serving.prewarm()
+
     if "transcription" in supported_tasks or "realtime" in supported_tasks:
         from vllm.entrypoints.speech_to_text.factories import init_speech_to_text_state
 

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -70,6 +70,34 @@ from vllm.utils.mistral import is_mistral_tool_parser
 logger = init_logger(__name__)
 
 
+_RTSP_SCHEMES = ("rtsp://", "rtsps://", "rtmp://")
+
+
+def _find_rtsp_video_url(messages) -> str | None:
+    """Return the first rtsp/rtsps/rtmp video_url found in user messages."""
+    for msg in messages:
+        content = (
+            msg.get("content")
+            if isinstance(msg, dict)
+            else getattr(msg, "content", None)
+        )
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            url = None
+            if isinstance(part, dict):
+                if part.get("type") == "video_url":
+                    vu = part.get("video_url") or {}
+                    url = vu.get("url") if isinstance(vu, dict) else None
+            else:
+                if getattr(part, "type", None) == "video_url":
+                    vu = getattr(part, "video_url", None)
+                    url = getattr(vu, "url", None) if vu is not None else None
+            if isinstance(url, str) and url.startswith(_RTSP_SCHEMES):
+                return url
+    return None
+
+
 def _get_mm_token_counts(engine_input: EngineInput) -> dict[str, int]:
     """Sum per-modality placeholder tokens from ``mm_placeholders``.
 
@@ -248,6 +276,38 @@ class OpenAIServingChat(GenerateBaseServing):
         for the API specification. This API mimics the OpenAI
         Chat Completion API.
         """
+        # Streaming requests carrying a stream-scheme video_url are served by
+        # the streaming layer, which owns the DeepStream RTSP pipeline.
+        if request.stream and raw_request is not None:
+            rtsp_url = _find_rtsp_video_url(request.messages)
+            if rtsp_url is not None:
+                streaming_serving = getattr(
+                    raw_request.app.state, "video_streaming_serving", None
+                )
+                if streaming_serving is None:
+                    try:
+                        from vllm.entrypoints.openai.streaming.serving import (
+                            VideoStreamingServing,
+                        )
+
+                        streaming_serving = VideoStreamingServing(
+                            self.engine_client,
+                            self.models,
+                            request_logger=None,
+                        )
+                        raw_request.app.state.video_streaming_serving = (
+                            streaming_serving
+                        )
+                    except Exception as e:
+                        return self.create_error_response(
+                            f"Failed to initialize RTSP streaming: {e}"
+                        )
+                return await streaming_serving.create_video_chat_stream(
+                    request,
+                    raw_request,
+                    rtsp_url=rtsp_url,
+                )
+
         return await self._with_kv_transfer_rejection_cleanup(
             self._create_chat_completion(request, raw_request), request, raw_request
         )

--- a/vllm/entrypoints/openai/streaming/__init__.py
+++ b/vllm/entrypoints/openai/streaming/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/entrypoints/openai/streaming/api_router.py
+++ b/vllm/entrypoints/openai/streaming/api_router.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""State setup for video streaming serving.
+
+Exposed via ``/v1/chat/completions``: the chat handler dispatches streaming
+requests carrying a stream-scheme ``video_url`` to
+:class:`VideoStreamingServing`, so there is no route to register.
+"""
+
+from typing import TYPE_CHECKING
+
+from vllm.entrypoints.openai.streaming.serving import VideoStreamingServing
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+if TYPE_CHECKING:
+    from argparse import Namespace
+
+    from starlette.datastructures import State
+
+    from vllm.engine.protocol import EngineClient
+    from vllm.entrypoints.serve.utils.request_logger import RequestLogger
+    from vllm.tasks import SupportedTask
+else:
+    RequestLogger = object
+
+
+def init_streaming_state(
+    engine_client: "EngineClient",
+    state: "State",
+    args: "Namespace",
+    request_logger: "RequestLogger | None",
+    supported_tasks: "tuple[SupportedTask, ...]",
+) -> None:
+    state.video_streaming_serving = (
+        VideoStreamingServing(
+            engine_client,
+            state.openai_serving_models,
+            request_logger=request_logger,
+        )
+        if "generate" in supported_tasks
+        else None
+    )

--- a/vllm/entrypoints/openai/streaming/serving.py
+++ b/vllm/entrypoints/openai/streaming/serving.py
@@ -1,0 +1,304 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""SSE serving for continuous video-stream captioning.
+
+Per segment from the persistent DeepStream pipeline: build a video prompt,
+run inference, emit one ``chat.completion.chunk``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import numpy.typing as npt
+from fastapi import Request
+
+from vllm.engine.protocol import EngineClient
+from vllm.entrypoints.generate.base.serving import GenerateBaseServing
+from vllm.entrypoints.openai.engine.protocol import ErrorResponse
+from vllm.entrypoints.openai.models.serving import OpenAIServingModels
+from vllm.entrypoints.serve.utils.request_logger import RequestLogger
+from vllm.logger import init_logger
+from vllm.multimodal.rtsp_stream_manager import (
+    DEFAULT_CHUNK_DURATION,
+    DEFAULT_NUM_FRAMES,
+    RTSPStreamManager,
+)
+from vllm.sampling_params import SamplingParams
+from vllm.utils import random_uuid
+
+logger = init_logger(__name__)
+
+# How often to wake while waiting for a segment, to check for disconnect.
+_DISCONNECT_POLL_INTERVAL = 1.0
+
+# Optional local video used to warm the pipeline at startup.
+_PREWARM_ENV_VAR = "VLLM_RTSP_PREWARM_VIDEO"
+
+
+def _extract_user_text(messages) -> str:
+    """Pull concatenated text from the most recent user message."""
+    default = "Describe what is happening in this video segment."
+    for msg in reversed(list(messages)):
+        role = msg.get("role") if isinstance(msg, dict) else getattr(msg, "role", None)
+        if role != "user":
+            continue
+        content = (
+            msg.get("content")
+            if isinstance(msg, dict)
+            else getattr(msg, "content", None)
+        )
+        if isinstance(content, str):
+            return content or default
+        if isinstance(content, list):
+            texts: list[str] = []
+            for part in content:
+                if isinstance(part, dict):
+                    if part.get("type") == "text" and isinstance(part.get("text"), str):
+                        texts.append(part["text"])
+                else:
+                    if getattr(part, "type", None) == "text":
+                        text = getattr(part, "text", None)
+                        if isinstance(text, str):
+                            texts.append(text)
+            if texts:
+                return "\n".join(texts)
+        return default
+    return default
+
+
+class VideoStreamingServing(GenerateBaseServing):
+    """Continuous video-stream captioning via SSE."""
+
+    def __init__(
+        self,
+        engine_client: EngineClient,
+        models: OpenAIServingModels,
+        *,
+        request_logger: RequestLogger | None,
+    ):
+        super().__init__(
+            engine_client=engine_client,
+            models=models,
+            request_logger=request_logger,
+        )
+        self._stream_manager = RTSPStreamManager()
+
+    def _build_video_prompt(self, user_text: str) -> str:
+        """Apply the model's chat template for a single-turn video+text message."""
+        tokenizer = self.renderer.tokenizer
+        messages: list[dict[str, Any]] = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "video"},
+                    {"type": "text", "text": user_text},
+                ],
+            },
+        ]
+        return tokenizer.apply_chat_template(
+            messages,
+            add_generation_prompt=True,
+            tokenize=False,
+        )
+
+    async def prewarm(
+        self,
+        sample_path: str | None = None,
+        num_frames: int = DEFAULT_NUM_FRAMES,
+        chunk_duration: float = DEFAULT_CHUNK_DURATION,
+    ) -> None:
+        """Warm the pipeline from a local video, if one is configured."""
+        sample_path = sample_path or os.environ.get(_PREWARM_ENV_VAR)
+        if not sample_path:
+            return
+        if not os.path.exists(sample_path):
+            logger.warning(
+                "Prewarm sample video not found at %s, skipping pipeline pre-warm",
+                sample_path,
+            )
+            return
+
+        uri = f"file://{sample_path}"
+        logger.info("Pre-warming pipeline with %s", sample_path)
+        consumer_id, seg_queue = await self._stream_manager.subscribe(
+            uri=uri,
+            chunk_duration=chunk_duration,
+            num_frames=num_frames,
+        )
+
+        async def _drain() -> None:
+            try:
+                while True:
+                    item = await seg_queue.get()
+                    if item is None:
+                        break
+            finally:
+                await self._stream_manager.unsubscribe(
+                    uri=uri,
+                    chunk_duration=chunk_duration,
+                    num_frames=num_frames,
+                    consumer_id=consumer_id,
+                )
+            logger.info("Pipeline prewarm complete")
+
+        asyncio.create_task(_drain(), name="pipeline-prewarm")
+
+    async def create_video_chat_stream(
+        self,
+        request,
+        raw_request: Request,
+        rtsp_url: str,
+    ) -> AsyncGenerator[str, None] | ErrorResponse:
+        """Validate and return a chat.completion.chunk SSE generator."""
+        if not self._is_model_supported(request.model):
+            return self.create_error_response(
+                message=f"The model {request.model!r} is not available.",
+            )
+        return self._stream_chat_segments(request, raw_request, rtsp_url)
+
+    async def _stream_chat_segments(
+        self,
+        request,
+        raw_request: Request,
+        rtsp_url: str,
+    ) -> AsyncGenerator[str, None]:
+        """Yield ``data: {chat.completion.chunk}\\n\\n`` SSE events."""
+        extras = getattr(request, "model_extra", None) or {}
+        chunk_duration_raw = extras.get("chunk_duration")
+        try:
+            chunk_duration = (
+                DEFAULT_CHUNK_DURATION
+                if chunk_duration_raw is None
+                else float(chunk_duration_raw)
+            )
+        except (TypeError, ValueError):
+            chunk_duration = DEFAULT_CHUNK_DURATION
+        num_frames_raw = extras.get("num_frames_per_chunk")
+        if num_frames_raw is None:
+            num_frames_raw = extras.get("num_frames", DEFAULT_NUM_FRAMES)
+        try:
+            num_frames = int(num_frames_raw)
+        except (TypeError, ValueError):
+            num_frames = DEFAULT_NUM_FRAMES
+
+        prompt_text = _extract_user_text(request.messages)
+        request_id = f"chatcmpl-{random_uuid()}"
+        created = int(time.time())
+        model_name = request.model or ""
+
+        consumer_id: str | None = None
+        try:
+            consumer_id, segment_queue = await self._stream_manager.subscribe(
+                uri=rtsp_url,
+                chunk_duration=chunk_duration,
+                num_frames=num_frames,
+            )
+
+            while True:
+                # Poll: a live source may go quiet, and a disconnect has to
+                # be noticed so the pipeline is released.
+                try:
+                    segment = await asyncio.wait_for(
+                        segment_queue.get(), timeout=_DISCONNECT_POLL_INTERVAL
+                    )
+                except asyncio.TimeoutError:
+                    if await raw_request.is_disconnected():
+                        break
+                    continue
+
+                if segment is None:
+                    break
+                if await raw_request.is_disconnected():
+                    break
+
+                frames: npt.NDArray = segment[0]
+                metadata: dict[str, Any] = segment[1]
+                seg_request_id = f"vseg-{random_uuid()}"
+
+                try:
+                    caption = await self._infer_chat_caption(
+                        frames,
+                        request,
+                        prompt_text,
+                        seg_request_id,
+                    )
+                except Exception:
+                    logger.exception(
+                        "Error inferring segment %d",
+                        metadata.get("segment_index", -1),
+                    )
+                    continue
+
+                chunk = {
+                    "id": request_id,
+                    "object": "chat.completion.chunk",
+                    "created": created,
+                    "model": model_name,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"content": caption},
+                            "finish_reason": None,
+                        }
+                    ],
+                }
+                yield f"data: {json.dumps(chunk)}\n\n"
+
+            terminal = {
+                "id": request_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": model_name,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {},
+                        "finish_reason": "stop",
+                    }
+                ],
+            }
+            yield f"data: {json.dumps(terminal)}\n\n"
+            yield "data: [DONE]\n\n"
+
+        finally:
+            if consumer_id is not None:
+                await self._stream_manager.unsubscribe(
+                    uri=rtsp_url,
+                    chunk_duration=chunk_duration,
+                    num_frames=num_frames,
+                    consumer_id=consumer_id,
+                )
+
+    async def _infer_chat_caption(
+        self,
+        frames: npt.NDArray,
+        request,
+        prompt_text: str,
+        request_id: str,
+    ) -> str:
+        """Run VLM inference on one segment and return the caption text."""
+        full_prompt = self._build_video_prompt(prompt_text)
+
+        sampling_params = SamplingParams(
+            temperature=request.temperature if request.temperature is not None else 0.0,
+            max_tokens=(request.max_completion_tokens or request.max_tokens or 256),
+        )
+        engine_prompt: dict[str, Any] = {
+            "prompt": full_prompt,
+            "multi_modal_data": {"video": frames},
+        }
+        caption = ""
+        async for output in self.engine_client.generate(
+            engine_prompt,
+            sampling_params,
+            request_id,
+        ):
+            if output.outputs:
+                caption = output.outputs[0].text
+        return caption

--- a/vllm/multimodal/rtsp_stream_manager.py
+++ b/vllm/multimodal/rtsp_stream_manager.py
@@ -1,0 +1,288 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Persistent DeepStream RTSP pipelines, one daemon thread per stream.
+
+Each ``(uri, chunk_duration, num_frames)`` maps to one thread running
+``stream_uri``, so consumers of the same stream share an NVDEC pipeline.
+Segments cross the thread boundary as numpy arrays via a sync queue; an
+asyncio bridge fans them out to bounded per-consumer queues, dropping the
+oldest segment when a consumer falls behind.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import queue
+import threading
+import uuid
+from contextlib import suppress
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+_SENTINEL = None
+
+# Shared by the serving layer, the manager and the decode generator.
+DEFAULT_CHUNK_DURATION = 10.0
+DEFAULT_NUM_FRAMES = 8
+
+# Log every Nth drop so a slow consumer is visible without flooding the log.
+_DROP_LOG_INTERVAL = 10
+
+# Seconds to wait for the decode thread to notice ``stop_event`` and exit.
+_THREAD_JOIN_TIMEOUT = 5.0
+
+
+@dataclass
+class _StreamState:
+    thread: threading.Thread
+    sync_queue: queue.Queue  # type: ignore[type-arg]
+    stop_event: threading.Event
+    consumers: dict[str, asyncio.Queue]
+    bridge_task: asyncio.Task[None] | None = None
+    dropped_segments: int = field(default=0, init=False)
+    _closed: bool = field(default=False, init=False)
+
+    def add_consumer(self) -> tuple[str, asyncio.Queue]:
+        cid = uuid.uuid4().hex
+        q: asyncio.Queue = asyncio.Queue(maxsize=4)
+        self.consumers[cid] = q
+        return cid, q
+
+    def remove_consumer(self, cid: str) -> int:
+        self.consumers.pop(cid, None)
+        return len(self.consumers)
+
+
+def _worker(
+    uri: str,
+    num_frames: int,
+    chunk_duration: float,
+    sync_q: queue.Queue,  # type: ignore[type-arg]
+    stop_event: threading.Event,
+) -> None:
+    logger.info(
+        "[stream worker] started for %s  num_frames=%d buffer_sec=%.1f",
+        uri,
+        num_frames,
+        chunk_duration,
+    )
+    try:
+        from vllm.multimodal.video import DeepStreamVideoBackendMixin
+
+        stream_gen = DeepStreamVideoBackendMixin.stream_uri(
+            uri,
+            num_frames=num_frames,
+            chunk_duration=chunk_duration,
+        )
+
+        try:
+            for frames, metadata in stream_gen:
+                if stop_event.is_set():
+                    break
+                try:
+                    sync_q.put((frames, metadata), timeout=5)
+                except queue.Full:
+                    logger.warning("[stream worker] sync queue full, dropping segment")
+        finally:
+            # Release the GStreamer pipeline now, not at GC time.
+            stream_gen.close()
+    except Exception:
+        logger.exception("[stream worker] error for %s", uri)
+    finally:
+        sync_q.put(_SENTINEL)
+    logger.info("[stream worker] exiting for %s", uri)
+
+
+class RTSPStreamManager:
+    _instance: RTSPStreamManager | None = None
+
+    def __new__(cls) -> RTSPStreamManager:
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance._streams = {}
+            cls._instance._lock = asyncio.Lock()
+        return cls._instance
+
+    _streams: dict[tuple[str, float, int], _StreamState]
+    _lock: asyncio.Lock
+
+    async def subscribe(
+        self,
+        uri: str,
+        chunk_duration: float = DEFAULT_CHUNK_DURATION,
+        num_frames: int = DEFAULT_NUM_FRAMES,
+    ) -> tuple[str, asyncio.Queue]:
+        key = (uri, chunk_duration, num_frames)
+
+        async with self._lock:
+            state = self._streams.get(key)
+            if state is not None and state._closed:
+                # Teardown began: this stream will never yield again.
+                self._streams.pop(key, None)
+                state = None
+            if state is None:
+                state = self._spawn(uri, num_frames, chunk_duration)
+                self._streams[key] = state
+                loop = asyncio.get_running_loop()
+                state.bridge_task = loop.create_task(
+                    self._bridge(key, state),
+                    name=f"rtsp-bridge-{uri}",
+                )
+            cid, q = state.add_consumer()
+
+        logger.info(
+            "RTSP subscribe: consumer=%s uri=%s consumers=%d",
+            cid,
+            uri,
+            len(state.consumers),
+        )
+        return cid, q
+
+    async def unsubscribe(
+        self,
+        uri: str,
+        chunk_duration: float,
+        num_frames: int,
+        consumer_id: str,
+    ) -> None:
+        key = (uri, chunk_duration, num_frames)
+        async with self._lock:
+            state = self._streams.get(key)
+            if state is None:
+                return
+            remaining = state.remove_consumer(consumer_id)
+            logger.info(
+                "RTSP unsubscribe: consumer=%s remaining=%d",
+                consumer_id,
+                remaining,
+            )
+            if remaining == 0:
+                await self._teardown(key, state)
+
+    def _spawn(
+        self,
+        uri: str,
+        num_frames: int,
+        chunk_duration: float,
+    ) -> _StreamState:
+        stop_ev = threading.Event()
+        sync_q: queue.Queue = queue.Queue(maxsize=8)
+        t = threading.Thread(
+            target=_worker,
+            args=(uri, num_frames, chunk_duration, sync_q, stop_ev),
+            daemon=True,
+            name=f"rtsp-{uri[:40]}",
+        )
+        t.start()
+        logger.info("Spawned RTSP thread for %s", uri)
+        return _StreamState(
+            thread=t,
+            sync_queue=sync_q,
+            stop_event=stop_ev,
+            consumers={},
+        )
+
+    async def _bridge(
+        self,
+        key: tuple[str, float, int],
+        state: _StreamState,
+    ) -> None:
+        loop = asyncio.get_running_loop()
+        uri = key[0]
+        seg = 0
+        logger.info("[RTSP bridge] started for %s", uri)
+
+        cumulative_frames: int = 0
+        while True:
+            item = await loop.run_in_executor(None, state.sync_queue.get)
+            if item is _SENTINEL:
+                logger.info("[RTSP bridge] sentinel received for %s", uri)
+                for q in list(state.consumers.values()):
+                    await q.put(None)
+                break
+
+            frames, raw_metadata = item
+            fps = raw_metadata.get("fps", 0.0)
+            n_frames = raw_metadata.get("total_num_frames", 0)
+            pts_start = cumulative_frames / fps if fps > 0 else 0.0
+            pts_end = (cumulative_frames + n_frames) / fps if fps > 0 else 0.0
+            metadata = {
+                **raw_metadata,
+                "segment_index": seg,
+                "pts_start": pts_start,
+                "pts_end": pts_end,
+                "duration": pts_end - pts_start,
+            }
+            cumulative_frames += n_frames
+
+            for q in list(state.consumers.values()):
+                try:
+                    q.put_nowait((frames, metadata))
+                except asyncio.QueueFull:
+                    # Drop the oldest rather than stall the pipeline.
+                    with suppress(asyncio.QueueEmpty):
+                        q.get_nowait()
+                    with suppress(asyncio.QueueFull):
+                        q.put_nowait((frames, metadata))
+                    state.dropped_segments += 1
+                    if state.dropped_segments % _DROP_LOG_INTERVAL == 1:
+                        logger.warning(
+                            "[RTSP bridge] consumer behind on %s, dropped %d "
+                            "segment(s) so far",
+                            uri,
+                            state.dropped_segments,
+                        )
+            seg += 1
+
+        logger.info("[RTSP bridge] exiting for %s", uri)
+        async with self._lock:
+            if key in self._streams:
+                await self._teardown(key, state)
+
+    async def _teardown(self, key: tuple, state: _StreamState) -> None:
+        if state._closed:
+            return
+        state._closed = True
+        state.stop_event.set()
+
+        # Cancelling ourselves would raise CancelledError at the join below.
+        bridge_task = state.bridge_task
+        state.bridge_task = None
+        if (
+            bridge_task is not None
+            and bridge_task is not asyncio.current_task()
+            and not bridge_task.done()
+        ):
+            bridge_task.cancel()
+
+        # Drop the entry before any await: teardown runs from a finally block
+        # in an already-cancelling task, so the await below may never return,
+        # and a surviving entry would strand the next subscriber on a dead
+        # stream.
+        self._streams.pop(key, None)
+        if state.dropped_segments:
+            logger.info(
+                "Torn down RTSP stream for %s (%d segment(s) dropped)",
+                key[0],
+                state.dropped_segments,
+            )
+        else:
+            logger.info("Torn down RTSP stream for %s", key[0])
+
+        # The worker only checks stop_event between segments, so this join can
+        # take a full decode timeout. Off the loop, and best-effort only.
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, state.thread.join, _THREAD_JOIN_TIMEOUT)
+        if state.thread.is_alive():
+            logger.warning(
+                "RTSP worker thread still alive after %.0fs for %s",
+                _THREAD_JOIN_TIMEOUT,
+                key[0],
+            )
+
+    async def shutdown_all(self) -> None:
+        async with self._lock:
+            for key, state in list(self._streams.items()):
+                await self._teardown(key, state)

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -852,6 +852,15 @@ class PyNvVideoCodecVideoBackendMixin:
         return frames, source, frame_idx, valid_frame_indices
 
 
+# Assumed for the first segment only, before the decoder reports the real rate.
+_ASSUMED_FPS = 30.0
+
+# A live source cannot deliver a segment faster than real time, so the decode
+# timeout is derived from the span it covers, with a floor for short segments.
+_MIN_SEGMENT_TIMEOUT_SEC = 30.0
+_SEGMENT_TIMEOUT_HEADROOM_SEC = 10.0
+
+
 class DeepStreamVideoBackendMixin:
     """NVIDIA DeepStream (NVDEC) GPU-decode codec utilities.
 
@@ -958,6 +967,108 @@ class DeepStreamVideoBackendMixin:
         else:
             arr = gpu.numpy()
         return arr, valid
+
+    # ----------------------------------------------------------------
+    # RTSP / URI streaming (per-stream worker)
+    # ----------------------------------------------------------------
+    @classmethod
+    def stream_uri(
+        cls,
+        uri: str,
+        num_frames: int = 8,
+        chunk_duration: float = 0.0,
+        timeout_sec: float | None = None,
+    ):
+        """Stream an RTSP/URI source via a dedicated pipeline.
+
+        One :class:`StreamHandle` per call, so contention scales independently
+        of stream count. Yields ``(frames, metadata)`` indefinitely, ``frames``
+        being a host-side numpy array.
+
+        Args:
+            uri: Stream URI (``rtsp://``, ``rtmp://``, ``file://``, ...).
+            num_frames: Frames sampled from each segment.
+            chunk_duration: Seconds of video per segment; ``0`` disables
+                buffering. The first segment is sized with ``_ASSUMED_FPS``,
+                later ones with the measured rate.
+            timeout_sec: Per-segment decode timeout. Derived from
+                ``chunk_duration`` when omitted.
+        """
+        import torch as _torch
+        from nvidia.deepstream_videodecode import StreamHandle
+
+        if timeout_sec is None:
+            timeout_sec = max(
+                _MIN_SEGMENT_TIMEOUT_SEC,
+                chunk_duration + _SEGMENT_TIMEOUT_HEADROOM_SEC,
+            )
+
+        handle = StreamHandle(uri, drop_interval=0)
+        logger.info(
+            "[DeepStream] Opened RTSP stream uri=%s chunk_duration=%.1fs timeout=%.1fs",
+            uri,
+            chunk_duration,
+            timeout_sec,
+        )
+        try:
+            detected_fps = 0.0
+            while True:
+                if chunk_duration > 0:
+                    fps_estimate = detected_fps if detected_fps > 0 else _ASSUMED_FPS
+                    raw_keep = max(num_frames, round(chunk_duration * fps_estimate))
+                else:
+                    raw_keep = num_frames
+
+                target_indices: list[int] | None = (
+                    np.linspace(0, raw_keep - 1, num_frames, dtype=int).tolist()
+                    if raw_keep > num_frames
+                    else None
+                )
+
+                res = handle.decode_segment(
+                    target_indices=target_indices,
+                    max_frames=num_frames,
+                    timeout_sec=timeout_sec,
+                )
+
+                if res.error:
+                    logger.error(
+                        "[DeepStream RTSP] decode error after %.1fs timeout "
+                        "(chunk_duration=%.1fs): %s",
+                        timeout_sec,
+                        chunk_duration,
+                        res.error,
+                    )
+                    break
+
+                if res.fps > 0:
+                    detected_fps = res.fps
+
+                if (
+                    res.frames is None
+                    or not isinstance(res.frames, _torch.Tensor)
+                    or res.frames.shape[0] == 0
+                ):
+                    break
+
+                logger.info(
+                    "[RTSP stream_uri] segment: raw_keep=%d yielding=%d "
+                    "fps=%.2f buffer_sec=%.1f",
+                    raw_keep,
+                    res.frames.shape[0],
+                    detected_fps,
+                    chunk_duration,
+                )
+
+                metadata: dict = {
+                    "total_num_frames": res.n_total,
+                    "fps": res.fps,
+                    "video_backend": "deepstream_rtsp",
+                }
+                yield res.frames.cpu().numpy(), metadata
+        finally:
+            handle.close()
+            logger.info("[DeepStream] Closed RTSP stream uri=%s", uri)
 
 
 @VIDEO_LOADER_REGISTRY.register("opencv")


### PR DESCRIPTION
## Summary

Adds **live RTSP stream captioning** on top of the DeepStream (NVDEC) video-decode
backend merged in #42424. A client sends an `rtsp://` (or `rtsps://` / `rtmp://`)
`video_url` to `/v1/chat/completions` with `stream=true`; the server opens a
persistent GStreamer pipeline, decodes the live stream into fixed-duration
segments, and emits one `chat.completion.chunk` SSE event per segment caption.

This PR adds a persistent-pipeline path alongside the existing one; the
file path is untouched.

## Design

| Component | Role |
| --- | --- |
| `DeepStreamVideoBackendMixin.stream_uri()` (`multimodal/video.py`) | Generator over a persistent `uridecodebin` pipeline; yields `(frames, metadata)` chunks indefinitely |
| `RTSPStreamManager` (`multimodal/rtsp_stream_manager.py`) | Singleton; one daemon thread per `(uri, chunk_duration, num_frames)`, fanning segments out to N asyncio consumers via a sync `queue.Queue` + bridge task |
| `VideoStreamingServing` (`entrypoints/openai/streaming/serving.py`) | SSE inference loop: segment → generate → emit chunk |
| `init_streaming_state()` (`entrypoints/openai/streaming/api_router.py`) | App state init; no route is registered — the feature reuses `/v1/chat/completions` |
| `_find_rtsp_video_url()` (`entrypoints/openai/chat_completion/serving.py`) | Detects a stream URL in message content and dispatches to `VideoStreamingServing` |
| `api_server.py` | Initializes streaming state at startup, optional pipeline pre-warm |

**No new endpoint.** The generator returned by `VideoStreamingServing` is handed
to the existing `StreamingResponse(..., media_type="text/event-stream")` in
`chat_completion/api_router.py`, so all SSE plumbing, disconnect handling and
chunked transfer are reused unchanged.

**Multiple clients on one camera share a single decode pipeline** — the manager
keys on `(uri, chunk_duration, num_frames)`, so N viewers of the same stream cost
one NVDEC pipeline, not N. Subscriptions are refcounted; the last consumer to
leave tears the pipeline down.

**Threading model.** Two daemon threads per stream: one driving the `stream_uri`
generator, plus the `StreamHandle` thread inside the decode package that owns the
GStreamer pipeline. The GStreamer pipeline stays in `PLAYING` for the life of the
stream; a "segment" is a collection window over a continuously running pipeline,
not a start/stop cycle. Blocking calls (`queue.Queue.get`, `Thread.join`) are
dispatched via `run_in_executor` so the event loop is never blocked.

**Wire format** — one id/created across the stream; each event carries
`delta.content` = the full caption for one segment with `finish_reason: null`;
terminated by `delta: {}` + `finish_reason: "stop"`, then `[DONE]`.

**Per-request tuning** via request extras (accepted because `OpenAIBaseModel` is
`extra="allow"`): `chunk_duration` (seconds of video per caption, default 10.0)
and `num_frames_per_chunk` (frames sampled per segment, default 8).
`chunk_duration` does not affect token count — it only changes how much video
the sampled frames span.

## Scope / compatibility

- **Purely additive**: 13 files, +1921 / −0 — 7 core files (+816) and 6
  example-app files (+1105). Four core files are new; three are modified with
  additions only (+111 / +60 / +7).
- **No schema changes.** `ChatCompletionRequest`, `ChatCompletionStreamResponse`
  and `chat_utils.py` are untouched; the `video_url` content part already exists
  and only the URL *scheme* is newly meaningful.
- **No behavior change for existing requests.** The dispatch fires only when
  `stream=true` *and* a message carries a stream-scheme `video_url`. Everything
  else takes the unmodified chat path.
- **No new dependencies.** Reuses the DeepStream stack already required
  by #42424.
- The change is split into two commits: the core feature (7 files) and the
  `deepstream_video_stream/` example app + benchmark tooling (6 files). Happy to
  drop the second commit if it is preferred the core change land alone.

## Testing

```bash
# Server (DeepStream/NVDEC backend)
PORT=9090 GPU_MEM=0.7 deepstream_video_stream/start_server.sh deepstream

# Live RTSP, bounded run
PORT=9090 python3 deepstream_video_stream/test_rtsp_stream.py \
    rtsp://<camera>:8554/ --chunk-duration 10 --segments 3
```

## Notes

- AI assistance was used in developing this change (see `Co-authored-by` trailers
  on both commits). I have reviewed every changed line and can defend the design
  and implementation end to end.
