### PR TITLE
[Rust Frontend][Perf]  Avoid copying logprobs auxiliary frames

### DIFF
--- a/rust/src/engine-core-client/src/protocol/logprobs/array.rs
+++ b/rust/src/engine-core-client/src/protocol/logprobs/array.rs
@@ -31,6 +31,20 @@ pub(super) struct DecodedArray2<T> {
     pub data: Vec<T>,
 }
 
+pub(super) enum ResolvedArrayBytes<'a> {
+    Owned(Bytes),
+    Borrowed(&'a [u8]),
+}
+
+impl AsRef<[u8]> for ResolvedArrayBytes<'_> {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            Self::Owned(bytes) => bytes.as_ref(),
+            Self::Borrowed(bytes) => bytes,
+        }
+    }
+}
+
 pub(super) fn decode_array2_u32<Frame>(
     value: WireNdArray,
     field: &str,
@@ -49,11 +63,11 @@ where
     }
 
     let data = match scalar {
-        ScalarType::I32 => decode_i32_vec(&bytes, endianness, field)?
+        ScalarType::I32 => decode_i32_vec(bytes.as_ref(), endianness, field)?
             .into_iter()
             .map(|value| convert_to_u32(value, field))
             .try_collect()?,
-        ScalarType::I64 => decode_i64_vec(&bytes, endianness, field)?
+        ScalarType::I64 => decode_i64_vec(bytes.as_ref(), endianness, field)?
             .into_iter()
             .map(|value| convert_to_u32(value, field))
             .try_collect()?,
@@ -84,11 +98,11 @@ where
     }
 
     let data = match scalar {
-        ScalarType::I32 => decode_i32_vec(&bytes, endianness, field)?
+        ScalarType::I32 => decode_i32_vec(bytes.as_ref(), endianness, field)?
             .into_iter()
             .map(|value| convert_to_u32(value, field))
             .try_collect()?,
-        ScalarType::I64 => decode_i64_vec(&bytes, endianness, field)?
+        ScalarType::I64 => decode_i64_vec(bytes.as_ref(), endianness, field)?
             .into_iter()
             .map(|value| convert_to_u32(value, field))
             .try_collect()?,
@@ -114,7 +128,7 @@ where
         ));
     }
 
-    let data = decode_f32_vec(&bytes, endianness, field)?;
+    let data = decode_f32_vec(bytes.as_ref(), endianness, field)?;
     Ok(DecodedArray2 {
         rows: shape[0],
         cols: shape[1],
@@ -122,12 +136,12 @@ where
     })
 }
 
-pub(super) fn decode_array_metadata<Frame>(
+pub(super) fn decode_array_metadata<'a, Frame>(
     value: WireNdArray,
     field: &str,
-    frames: &[Frame],
+    frames: &'a [Frame],
     expected_scalars: &[ScalarType],
-) -> Result<(Vec<usize>, Bytes, ScalarType, Endianness)>
+) -> Result<(Vec<usize>, ResolvedArrayBytes<'a>, ScalarType, Endianness)>
 where
     Frame: AsRef<[u8]>,
 {
@@ -141,7 +155,7 @@ where
     }
 
     let bytes = resolve_array_bytes(data, field, frames)?;
-    validate_byte_length(shape.as_slice(), bytes.len(), field, scalar)?;
+    validate_byte_length(shape.as_slice(), bytes.as_ref().len(), field, scalar)?;
     Ok((shape, bytes, scalar, endianness))
 }
 
@@ -168,16 +182,16 @@ pub(super) fn parse_dtype(dtype: &str, field: &str) -> Result<(ScalarType, Endia
     Ok((scalar, endianness))
 }
 
-pub(super) fn resolve_array_bytes<Frame>(
+pub(super) fn resolve_array_bytes<'a, Frame>(
     value: WireArrayData,
     field: &str,
-    frames: &[Frame],
-) -> Result<Bytes>
+    frames: &'a [Frame],
+) -> Result<ResolvedArrayBytes<'a>>
 where
     Frame: AsRef<[u8]>,
 {
     match value {
-        WireArrayData::RawView(bytes) => Ok(bytes),
+        WireArrayData::RawView(bytes) => Ok(ResolvedArrayBytes::Owned(bytes)),
         WireArrayData::AuxIndex(index) => {
             let frame = frames.get(index).ok_or_else(|| {
                 decode_error(
@@ -188,7 +202,7 @@ where
                     ),
                 )
             })?;
-            Ok(Bytes::copy_from_slice(frame.as_ref()))
+            Ok(ResolvedArrayBytes::Borrowed(frame.as_ref()))
         }
     }
 }

--- a/rust/src/engine-core-client/src/protocol/logprobs/tests.rs
+++ b/rust/src/engine-core-client/src/protocol/logprobs/tests.rs
@@ -8,6 +8,7 @@ use rmpv::Value;
 
 use super::{Logprobs, PositionLogprobs, TokenLogprob};
 use crate::protocol::output::{EngineCoreFinishReason, decode_engine_core_outputs};
+use crate::protocol::tensor::WireArrayData;
 
 fn encode_value(value: &Value) -> Vec<u8> {
     let mut out = Vec::new();
@@ -221,6 +222,19 @@ fn decodes_multipart_new_logprobs() {
 
     let logprobs = decoded.outputs[0].new_logprobs.clone().unwrap().into_direct().unwrap();
     assert_eq!(logprobs, expected_sample_logprobs());
+}
+
+#[test]
+fn resolves_aux_frame_without_copying() {
+    let aux_frame = Bytes::from_static(&[1, 2, 3, 4]);
+    let expected_ptr = aux_frame.as_ptr();
+    let frames = vec![Bytes::new(), aux_frame];
+
+    let resolved =
+        super::array::resolve_array_bytes(WireArrayData::AuxIndex(1), "logprobs", &frames).unwrap();
+
+    assert_eq!(resolved.as_ref(), [1, 2, 3, 4]);
+    assert_eq!(resolved.as_ref().as_ptr(), expected_ptr);
 }
 
 #[test]


### PR DESCRIPTION



## Purpose

The Rust frontend copies each logprobs auxiliary array into a new buffer before decoding it into typed vectors. The copy is redundant because the source frame remains alive throughout decoding, and its cost scales with the number of scored positions and requested logprobs.

Borrow auxiliary-frame bytes during decoding while keeping inline `RawView` data owned. This removes one full-buffer
allocation and copy per auxiliary array without changing the wire format, public API, validation, error handling, or decoded
output.

## Test Plan

```
  cargo test  -p vllm-engine-core-client protocol::logprobs --all-features --locked -- --nocapture

  cargo test -p vllm-engine-core-client client_decodes_multipart_logprob_outputs --all-features --locked -- --nocapture
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

