### PR TITLE
[Sampler] Add DRY (Don't Repeat Yourself) sampling

### DIFF
--- a/tests/v1/sample/test_dry.py
+++ b/tests/v1/sample/test_dry.py
@@ -248,6 +248,12 @@ def test_sampling_params_validation():
         SamplingParams(dry_allowed_length=-1)
     with pytest.raises((VLLMValidationError, ValueError)):
         SamplingParams(dry_sequence_breakers=[1, 2])
+    with pytest.raises((VLLMValidationError, ValueError)):
+        SamplingParams(dry_allowed_length=1.5)
+    with pytest.raises((VLLMValidationError, ValueError)):
+        SamplingParams(dry_penalty_last_n=2.5)
+    with pytest.raises((VLLMValidationError, ValueError)):
+        SamplingParams(dry_sequence_breakers=[f"b{i}" for i in range(65)])
     # Valid corner values pass.
     SamplingParams(dry_multiplier=0.0)
     SamplingParams(dry_multiplier=1.0, dry_penalty_last_n=-1)
@@ -712,10 +718,11 @@ def test_breaker_resolution_covers_added_tokens():
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
 def test_batched_peak_memory_bounded():
     # base=1.1 gives max_exponent=930, a large J for the batched path
-    # (the cap is allowed_length + max_exponent <= _J_BUDGET = 2048). The chunk budget is denominated in bytes and the gather is
-    # int32, so peak transient memory stays near _CHUNK_BYTE_BUDGET even
-    # at large batch x window; an element-denominated budget with an
-    # int64 gather allocated ~8x more and OOMed 8 GB GPUs.
+    # (the cap is allowed_length + max_exponent <= _J_BUDGET = 2048).
+    # The chunk budget is denominated in bytes and the gather is int32,
+    # so peak transient memory stays near _CHUNK_BYTE_BUDGET even at
+    # large batch x window; an element-denominated budget with an int64
+    # gather allocated ~8x more and OOMed 8 GB GPUs.
     from vllm.v1.sample.logits_processor.dry_batched import _CHUNK_BYTE_BUDGET
 
     device = torch.device("cuda")

--- a/tests/v1/sample/test_dry.py
+++ b/tests/v1/sample/test_dry.py
@@ -1,0 +1,744 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the DRY (Don't Repeat Yourself) logits processor.
+
+Covers the penalty computation (against llama.cpp's own worked example and
+a brute-force oracle), the exponent-clamp float32 semantics, breaker
+containment resolution, batch state management, and parameter validation.
+"""
+
+import math
+import random
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from vllm.exceptions import VLLMValidationError
+from vllm.sampling_params import SamplingParams
+from vllm.v1.sample.dry_utils import max_exponent as _max_exponent
+from vllm.v1.sample.logits_processor import dry_batched
+from vllm.v1.sample.logits_processor.dry import (
+    DryLogitsProcessor,
+    _dry_penalties,
+    _DryState,
+)
+from vllm.v1.sample.logits_processor.interface import (
+    BatchUpdate,
+    MoveDirectionality,
+)
+
+DEVICE = torch.device("cpu")
+
+
+def _penalties(window, multiplier=1.0, base=2.0, allowed_length=1, breakers=()):
+    return _dry_penalties(
+        window,
+        frozenset(breakers),
+        multiplier,
+        base,
+        allowed_length,
+        _max_exponent(base),
+    )
+
+
+def test_worked_example():
+    # llama.cpp's own commented example (src/llama-sampler.cpp): tokens
+    # "a b c c b c y a b c" -> per-position repeat counts
+    # [0,0,3,1,0,2,0,0,0,0]; extenders: c (len 3), b (len 1), y (len 2).
+    # With multiplier=1, base=2, allowed_length=1: c -> 4, b -> 1, y -> 2.
+    got = _penalties([1, 2, 3, 3, 2, 3, 9, 1, 2, 3])
+    assert got == {3: 4.0, 2: 1.0, 9: 2.0}
+
+
+def test_z_box_equality_boundary():
+    # The Z-algorithm's copy-vs-extend equality boundary: when
+    # cnt[last - p] == right_part_len the match may extend past the Z-box
+    # and must be re-scanned, not copied. Copying here drops
+    # token 0's penalty on this input.
+    got = _penalties([0, 0, 0, 1, 0, 0], allowed_length=2)
+    assert got == {0: 1.0, 1: 1.0}
+
+
+def test_exponent_clamp_float32_semantics():
+    # llama.cpp computes FLOAT_MAX_LOG / log(base) in float32. At base=2.0
+    # that is exactly 128.0; float64 gives 127.99999998 -> 127. The clamp
+    # must land on 128 or long-repeat penalties come out half of
+    # llama.cpp's and never saturate to -inf.
+    assert _max_exponent(2.0) == 128
+    assert _max_exponent(1.75) == 158
+    assert _max_exponent(1.0) == 0  # disabled guard
+    assert _max_exponent(1.0000005) == 0  # llama.cpp's 1.000001 guard
+
+
+def test_long_repeat_saturates_to_neg_inf():
+    # 200 identical tokens at base=2.0: clamped exponent 128 ->
+    # 2**128 overflows float32 -> logit must land at exactly -inf,
+    # matching llama.cpp.
+    proc = _make_processor()
+    params = SamplingParams(
+        dry_multiplier=1.0,
+        dry_base=2.0,
+        dry_allowed_length=0,
+        dry_sequence_breakers=[],
+    )
+    _add_request(proc, index=0, params=params, prompt=[7] * 200, output=[])
+    logits = torch.zeros(1, 16, device=DEVICE)
+    out = proc.apply(logits)
+    assert out[0, 7].item() == -float("inf")
+
+
+def test_allowed_length_threshold():
+    # Match of length 2 is penalized at allowed_length=2, not at 3.
+    window = [1, 2, 3, 1, 2]
+    assert _penalties(window, allowed_length=3) == {}
+    assert _penalties(window, allowed_length=2) == {3: 1.0}
+
+
+def test_breakers_cap_and_exclude():
+    # An unbroken run is penalized; making that token a breaker
+    # collapses rep_limit to 0 and produces nothing.
+    assert _penalties([7] * 6, allowed_length=2) == {7: 8.0}
+    assert _penalties([7] * 6, allowed_length=2, breakers=[7]) == {}
+
+
+def test_short_windows_are_safe():
+    assert _penalties([]) == {}
+    assert _penalties([5]) == {}
+
+
+def _make_processor() -> DryLogitsProcessor:
+    return DryLogitsProcessor(
+        SimpleNamespace(model_config=None), DEVICE, is_pin_memory=False
+    )
+
+
+def _add_request(proc, index, params, prompt, output):
+    update = BatchUpdate(
+        batch_size=index + 1,
+        removed=[],
+        added=[(index, params, prompt, output)],
+        moved=[],
+    )
+    proc.update_state(update)
+
+
+def test_state_windowing_spans_prompt_and_output():
+    # penalty_last_n window must cross the prompt/output boundary.
+    proc = _make_processor()
+    params = SamplingParams(
+        dry_multiplier=1.0,
+        dry_base=2.0,
+        dry_allowed_length=1,
+        dry_sequence_breakers=[],
+    )
+    # worked example split across prompt and live output list
+    output = [9, 1, 2, 3]
+    _add_request(proc, 0, params, prompt=[1, 2, 3, 3, 2, 3], output=output)
+    logits = torch.zeros(1, 16, device=DEVICE)
+    out = proc.apply(logits)
+    assert out[0, 3].item() == -4.0
+    assert out[0, 2].item() == -1.0
+    assert out[0, 9].item() == -2.0
+
+    # The output list reference is live: appending tokens changes the
+    # next apply() with no update_state call. The suffix is now
+    # "... 3 3 3", whose longest earlier match has length 2, so token 3's
+    # penalty is -2.0; a stale window would still give -4.0.
+    output.extend([3, 3])
+    out2 = proc.apply(torch.zeros(1, 16, device=DEVICE))
+    assert out2[0, 3].item() == -2.0
+    assert out2[0, 2].item() == -2.0
+    assert out2[0, 9].item() == -1.0
+
+
+def test_state_disabled_requests_not_tracked():
+    proc = _make_processor()
+    for params in (
+        SamplingParams(),  # dry_multiplier defaults to 0
+        SamplingParams(dry_multiplier=1.0, dry_base=0.5),  # base<1 disables
+        SamplingParams(dry_multiplier=1.0, dry_penalty_last_n=0),
+    ):
+        _add_request(proc, 0, params, prompt=[1, 1, 1, 1], output=[])
+        assert not proc.reqs
+    logits = torch.zeros(1, 8, device=DEVICE)
+    assert proc.apply(logits) is logits  # zero-cost passthrough
+
+
+def test_state_remove_and_move():
+    proc = _make_processor()
+    params = SamplingParams(
+        dry_multiplier=1.0,
+        dry_base=2.0,
+        dry_allowed_length=1,
+        dry_sequence_breakers=[],
+    )
+    _add_request(proc, 0, params, prompt=[7] * 8, output=[])
+    assert 0 in proc.reqs
+
+    # Move 0 -> 2 (unidirectional): penalties must follow the request.
+    proc.update_state(
+        BatchUpdate(
+            batch_size=3,
+            removed=[],
+            added=[],
+            moved=[(0, 2, MoveDirectionality.UNIDIRECTIONAL)],
+        )
+    )
+    assert 2 in proc.reqs and 0 not in proc.reqs
+    logits = torch.zeros(3, 16, device=DEVICE)
+    out = proc.apply(logits)
+    assert out[2, 7].item() < 0
+    assert out[0, 7].item() == 0
+
+    # Remove.
+    proc.update_state(BatchUpdate(batch_size=3, removed=[2], added=[], moved=[]))
+    assert not proc.reqs
+
+
+class _StubTokenizer:
+    """Minimal tokenizer for breaker-resolution tests."""
+
+    _TEXTS = ["a", "\n", "b:\n", "hello", ":", "x:y", "*", "**"]
+
+    vocab_size = len(_TEXTS)
+
+    def batch_decode(self, ids_lists):
+        return [self._TEXTS[ids[0]] for ids in ids_lists]
+
+
+def test_breaker_containment_resolution():
+    # Resolution must match every token whose text CONTAINS the breaker
+    # string (llama.cpp get_overlapping_token_sequences), not just exact
+    # encodings. Shared between both sampler stacks via dry_utils.
+    from vllm.v1.sample.dry_utils import resolve_dry_breakers
+
+    tok = _StubTokenizer()
+    assert resolve_dry_breakers(tok, ("\n",)) == [1, 2]
+    assert resolve_dry_breakers(tok, (":",)) == [2, 4, 5]
+    assert resolve_dry_breakers(tok, ("*",)) == [6, 7]
+    assert resolve_dry_breakers(tok, ()) == []
+    # Repeat resolution is consistent, and callers get their own copy
+    # (mutating a result must not poison the cache).
+    first = resolve_dry_breakers(tok, ("\n",))
+    first.append(999)
+    assert resolve_dry_breakers(tok, ("\n",)) == [1, 2]
+
+
+def test_sampling_params_rejects_json_booleans():
+    # bool is an int subclass; JSON true/false must 400, not crash the
+    # engine at apply time.
+    for name in (
+        "dry_multiplier",
+        "dry_base",
+        "dry_allowed_length",
+        "dry_penalty_last_n",
+    ):
+        with pytest.raises((VLLMValidationError, ValueError)):
+            SamplingParams(**{name: True})
+
+
+def test_sampling_params_validation():
+    with pytest.raises((VLLMValidationError, ValueError)):
+        SamplingParams(dry_multiplier=-1.0)
+    with pytest.raises((VLLMValidationError, ValueError)):
+        SamplingParams(dry_penalty_last_n=-7)
+    with pytest.raises((VLLMValidationError, ValueError)):
+        SamplingParams(dry_allowed_length=-1)
+    with pytest.raises((VLLMValidationError, ValueError)):
+        SamplingParams(dry_sequence_breakers=[1, 2])
+    # Valid corner values pass.
+    SamplingParams(dry_multiplier=0.0)
+    SamplingParams(dry_multiplier=1.0, dry_penalty_last_n=-1)
+    SamplingParams(dry_multiplier=1.0, dry_sequence_breakers=[])
+
+
+def _oracle(window, breakers, multiplier, base, allowed_length, max_exponent):
+    """Brute-force oracle: computes the same penalties by exhaustive
+    comparison instead of the Z-algorithm, so it cannot share the fast
+    path's bugs. Steps mirror llama_sampler_dry_apply directly."""
+    m = len(window)
+    rep_limit = m
+    for i in range(m):
+        if window[m - 1 - i] in breakers:
+            rep_limit = i
+            break
+    if rep_limit < allowed_length:
+        return {}
+    cnt = [0] * m
+    for i in range(m - 1):
+        length = 0
+        while (
+            length < m
+            and i - length >= 0
+            and window[i - length] == window[m - 1 - length]
+        ):
+            length += 1
+        cnt[i] = min(length, rep_limit)
+    max_tok: dict[int, int] = {}
+    for i in range(m - 1):
+        if cnt[i] >= allowed_length:
+            tok = window[i + 1]
+            if max_tok.get(tok, -1) < cnt[i]:
+                max_tok[tok] = cnt[i]
+    penalties = {}
+    for tok, repeat_len in max_tok.items():
+        if tok in breakers:
+            continue
+        exponent = repeat_len - allowed_length
+        if max_exponent and exponent > max_exponent:
+            exponent = max_exponent
+        penalties[tok] = multiplier * (base**exponent)
+    return penalties
+
+
+def test_differential_against_oracle():
+    rng = random.Random(0)
+    for case in range(400):
+        if case % 10 == 0:
+            # Long, highly repetitive: the only way to reach the clamp.
+            alphabet, n = rng.randint(1, 2), rng.randint(200, 320)
+        else:
+            alphabet, n = rng.randint(2, 6), rng.randint(0, 48)
+        window = [rng.randrange(alphabet) for _ in range(n)]
+        multiplier = rng.choice([0.5, 0.8, 1.0, 2.0])
+        base = rng.choice([1.1, 1.75, 2.0, 3.0])
+        allowed = rng.randint(0, 4)
+        breakers = frozenset(
+            rng.sample(range(alphabet), rng.randint(0, min(2, alphabet)))
+        )
+        max_exp = _max_exponent(base)
+        want = _oracle(window, breakers, multiplier, base, allowed, max_exp)
+        got = _dry_penalties(window, breakers, multiplier, base, allowed, max_exp)
+        assert set(want) == set(got), f"case {case}: keys {want} vs {got}"
+        for tok in want:
+            a, b = want[tok], got[tok]
+            assert math.isclose(a, b, rel_tol=1e-9), (
+                f"case {case} token {tok}: {a} vs {b}"
+            )
+
+
+def _rand_state(rng, alphabet):
+    n = rng.randint(3, 120)
+
+    base = rng.choice([1.1, 1.75, 2.0, 3.0])
+    return _DryState(
+        multiplier=rng.choice([0.5, 0.8, 1.0, 2.0]),
+        base=base,
+        allowed_length=rng.randint(0, 3),
+        penalty_last_n=rng.choice([-1, 5, 50]),
+        breakers=frozenset(
+            rng.sample(range(alphabet), rng.randint(0, min(2, alphabet)))
+        ),
+        max_exponent=_max_exponent(base),
+        prompt_tok_ids=[rng.randrange(alphabet) for _ in range(n)],
+        output_tok_ids=[],
+    )
+
+
+def test_batched_matches_reference_fuzz():
+    # Mixed-parameter multi-row batches through the vectorized path must
+    # reproduce the sequential reference exactly (inf included).
+    vocab = 32
+    rng = random.Random(1)
+    total_rows = 0
+    for _ in range(40):
+        entries: list[tuple[int, _DryState, list[int]]] = []
+        for row in range(rng.randint(1, 8)):
+            state = _rand_state(rng, alphabet=rng.randint(1, 6))
+            if state.window() is None or not dry_batched.eligible(state):
+                continue
+            entries.append((len(entries), state, state.window()))
+        if not entries:
+            continue
+        total_rows += len(entries)
+        logits = torch.zeros(len(entries), vocab)
+        out = dry_batched.apply_dry_batched(logits, entries)
+        for row, state, window in entries:
+            want = _dry_penalties(
+                window,
+                state.breakers,
+                state.multiplier,
+                state.base,
+                state.allowed_length,
+                state.max_exponent,
+            )
+            for tok in range(vocab):
+                expected = -want.get(tok, 0.0)
+                got = out[row, tok].item()
+                if math.isinf(expected) or math.isinf(got):
+                    assert math.isinf(expected) == math.isinf(got), (
+                        f"row {row} tok {tok}: {expected} vs {got}"
+                    )
+                else:
+                    assert math.isclose(expected, got, rel_tol=1e-6, abs_tol=1e-6), (
+                        f"row {row} tok {tok}: {expected} vs {got}"
+                    )
+    assert total_rows > 50  # the fuzz actually exercised batches
+
+
+def test_batched_double_pow_saturation():
+    # llama.cpp's std::pow(float, int) computes in double: 0.8 * 2**128
+    # is finite in float32 (-2.72e38) while 1.0 * 2**128 saturates to
+    # -inf. A float32 pow gets the first case wrong.
+    for mult, expect_inf in ((0.8, False), (1.0, True)):
+        state = _DryState(
+            multiplier=mult,
+            base=2.0,
+            allowed_length=0,
+            penalty_last_n=-1,
+            breakers=frozenset(),
+            max_exponent=_max_exponent(2.0),
+            prompt_tok_ids=[7] * 200,
+            output_tok_ids=[],
+        )
+        logits = torch.zeros(1, 16)
+        out = dry_batched.apply_dry_batched(logits, [(0, state, state.window())])
+        val = out[0, 7].item()
+        if expect_inf:
+            assert val == -float("inf")
+        else:
+            assert math.isfinite(val) and math.isclose(
+                val, -0.8 * 2.0**128, rel_tol=1e-6
+            )
+
+
+def test_processor_dispatch_batched():
+    # Forcing the batched path through the processor must give the same
+    # worked-example result as the reference path.
+    proc = _make_processor()
+    proc.use_batched = True
+    params = SamplingParams(
+        dry_multiplier=1.0,
+        dry_base=2.0,
+        dry_allowed_length=1,
+        dry_sequence_breakers=[],
+    )
+    _add_request(proc, 0, params, prompt=[1, 2, 3, 3, 2, 3, 9, 1, 2, 3], output=[])
+    out = proc.apply(torch.zeros(1, 16, device=DEVICE))
+    assert out[0, 3].item() == -4.0
+    assert out[0, 2].item() == -1.0
+    assert out[0, 9].item() == -2.0
+
+
+# ---------------------------------------------------------------------------
+# V2-runner DryState module
+# ---------------------------------------------------------------------------
+
+
+def _make_v2_state(max_num_reqs=8, vocab=32, max_model_len=256):
+    from vllm.v1.worker.gpu.sample.dry import DryState
+
+    all_tokens = torch.zeros(max_num_reqs, max_model_len, dtype=torch.int32)
+    req_states = SimpleNamespace(
+        max_num_reqs=max_num_reqs,
+        vocab_size=vocab,
+        device=DEVICE,
+        all_token_ids=SimpleNamespace(gpu=all_tokens),
+    )
+    return DryState(req_states), all_tokens
+
+
+def test_v2_worked_example_and_pos_semantics():
+    # ``pos`` is the position of the last INPUT token; the window is
+    # [0, pos + 1). Without the + 1 the window drops the final context
+    # token and every penalty lands on the continuation of the previous
+    # suffix instead of the token being sampled.
+    state, all_tokens = _make_v2_state()
+    params = SamplingParams(
+        dry_multiplier=1.0,
+        dry_base=2.0,
+        dry_allowed_length=1,
+        dry_sequence_breakers=[],
+    )
+    state.add_request(3, params)
+    seq = [1, 2, 3, 3, 2, 3, 9, 1, 2, 3]
+    all_tokens[3, : len(seq)] = torch.tensor(seq, dtype=torch.int32)
+
+    logits = torch.zeros(1, 32, device=DEVICE)
+    idx_mapping = np.array([3])
+    # last input token sits at position len(seq)-1
+    pos = torch.tensor([len(seq) - 1], device=DEVICE)
+    state.apply_dry(logits, idx_mapping, pos, expanded_logits=False)
+    assert logits[0, 3].item() == -4.0
+    assert logits[0, 2].item() == -1.0
+    assert logits[0, 9].item() == -2.0
+
+
+def test_v2_disabled_and_gating():
+    state, _ = _make_v2_state()
+    state.add_request(0, SamplingParams())  # dry off by default
+    state.add_request(1, SamplingParams(dry_multiplier=1.0, dry_base=0.5))
+    state.add_request(2, SamplingParams(dry_multiplier=1.0, dry_penalty_last_n=0))
+    assert not state.use_dry[:3].any()
+    # Re-adding a slot with DRY off after one with DRY on must clear it.
+    on = SamplingParams(dry_multiplier=0.8, dry_sequence_breakers=[])
+    state.add_request(4, on)
+    assert state.use_dry[4]
+    state.add_request(4, SamplingParams())
+    assert not state.use_dry[4]
+
+
+def test_v2_penalty_last_n_window():
+    # A cap smaller than the history must limit the visible window.
+    state, all_tokens = _make_v2_state()
+    params = SamplingParams(
+        dry_multiplier=1.0,
+        dry_base=2.0,
+        dry_allowed_length=1,
+        dry_penalty_last_n=4,
+        dry_sequence_breakers=[],
+    )
+    state.add_request(0, params)
+    seq = [7] * 20
+    all_tokens[0, : len(seq)] = torch.tensor(seq, dtype=torch.int32)
+    logits = torch.zeros(1, 32, device=DEVICE)
+    state.apply_dry(
+        logits, np.array([0]), torch.tensor([19], device=DEVICE), expanded_logits=False
+    )
+    # window = last 4 tokens of an identical run: longest match ending
+    # before the suffix is 3 (rep-limited by the window), penalty 2**(3-1).
+    assert logits[0, 7].item() == -4.0
+
+
+def test_v2_spec_decode_skipped_with_warning():
+    state, all_tokens = _make_v2_state()
+    state.add_request(0, SamplingParams(dry_multiplier=0.8, dry_sequence_breakers=[]))
+    all_tokens[0, :8] = 7
+    logits = torch.zeros(3, 32, device=DEVICE)  # expanded: 3 rows, 1 req
+    state.apply_dry(
+        logits, np.array([0]), torch.tensor([7], device=DEVICE), expanded_logits=True
+    )
+    assert (logits == 0).all()
+    assert state._warned_spec_decode
+
+
+def test_v2_matches_reference_fuzz():
+    # The V2 window-gather + routing path must agree with the sequential
+    # reference on randomized histories, including degenerate bases that
+    # route through the slow path.
+    state, all_tokens = _make_v2_state(max_num_reqs=8, vocab=16, max_model_len=200)
+    rng = random.Random(7)
+    for trial in range(60):
+        n_reqs = rng.randint(1, 5)
+        histories = {}
+        pos_list = []
+        idx_list = []
+        for r in range(n_reqs):
+            params = SamplingParams(
+                dry_multiplier=rng.choice([0.8, 1.0, 2.0]),
+                dry_base=rng.choice([1.0000005, 1.1, 1.75, 2.0]),
+                dry_allowed_length=rng.randint(0, 3),
+                dry_penalty_last_n=rng.choice([-1, 5, 50]),
+                dry_sequence_breakers=[],
+            )
+            state.add_request(r, params)
+            n = rng.randint(2, 180)
+            hist = [rng.randrange(rng.randint(1, 4) + 1) for _ in range(n)]
+            all_tokens[r, :n] = torch.tensor(hist, dtype=torch.int32)
+            histories[r] = (params, hist)
+            idx_list.append(r)
+            pos_list.append(n - 1)
+
+        logits = torch.zeros(n_reqs, 16, device=DEVICE)
+        state.apply_dry(
+            logits,
+            np.array(idx_list),
+            torch.tensor(pos_list, device=DEVICE),
+            expanded_logits=False,
+        )
+        for r in range(n_reqs):
+            params, hist = histories[r]
+            base32 = float(np.float32(params.dry_base))
+            if base32 < 1.0 or not params.dry_multiplier:
+                want: dict[int, float] = {}
+            else:
+                last_n = params.dry_penalty_last_n
+                w = len(hist) if last_n == -1 else min(len(hist), last_n)
+                window = hist[-w:] if w > params.dry_allowed_length else None
+                want = (
+                    _dry_penalties(
+                        window,
+                        frozenset(),
+                        float(np.float32(params.dry_multiplier)),
+                        base32,
+                        params.dry_allowed_length,
+                        _max_exponent(base32),
+                    )
+                    if window is not None
+                    else {}
+                )
+            for tok in range(16):
+                expected = -want.get(tok, 0.0)
+                got = logits[r, tok].item()
+                assert math.isclose(expected, got, rel_tol=1e-5, abs_tol=1e-6), (
+                    f"trial {trial} req {r} tok {tok}: {expected} vs {got}"
+                )
+
+
+def test_needs_output_token_ids_tracks_dry_requests():
+    # Async scheduling only backfills the output token id lists when a
+    # processor in the batch reports needing them; see
+    # LogitsProcessor.needs_output_token_ids.
+    proc = _make_processor()
+    assert not proc.needs_output_token_ids()
+    params = SamplingParams(dry_multiplier=0.8, dry_sequence_breakers=[])
+    _add_request(proc, 0, params, prompt=[1, 2, 3], output=[])
+    assert proc.needs_output_token_ids()
+    proc.update_state(BatchUpdate(batch_size=1, removed=[0], added=[], moved=[]))
+    assert not proc.needs_output_token_ids()
+
+
+def test_window_boundary_last_n_equals_output_len():
+    # penalty_last_n == len(output) with a nonempty prompt: the window
+    # must be exactly the last penalty_last_n tokens, not prompt+output
+    # (the <= boundary in window()).
+    st = _DryState(
+        multiplier=1.0,
+        base=2.0,
+        allowed_length=1,
+        penalty_last_n=2,
+        breakers=frozenset(),
+        max_exponent=_max_exponent(2.0),
+        prompt_tok_ids=[7, 9],
+        output_tok_ids=[7, 7],
+    )
+    assert st.window() == [7, 7]
+
+
+def test_processor_honors_frontend_resolved_breaker_ids():
+    # The engine frontend resolves breaker strings to ids and stores them
+    # on the request (_dry_breaker_ids); the processor must consume them.
+    proc = _make_processor()
+    params = SamplingParams(
+        dry_multiplier=1.0,
+        dry_base=2.0,
+        dry_allowed_length=1,
+        dry_sequence_breakers=["x"],
+    )
+    params._dry_breaker_ids = [7]
+    _add_request(proc, 0, params, prompt=[7] * 6, output=[])
+    out = proc.apply(torch.zeros(1, 16, device=DEVICE))
+    assert out[0, 7].item() == 0.0
+
+
+def test_v2_breaker_ids_reach_dry_core():
+    # Resolved breaker ids must flow through V2 add_request into the
+    # penalty computation (and be cleared when the slot is reused).
+    state, all_tokens = _make_v2_state()
+    params = SamplingParams(
+        dry_multiplier=1.0,
+        dry_base=2.0,
+        dry_allowed_length=1,
+        dry_sequence_breakers=["x"],
+    )
+    params._dry_breaker_ids = [7]
+    state.add_request(0, params)
+    all_tokens[0, :8] = 7
+    logits = torch.zeros(1, 32, device=DEVICE)
+    state.apply_dry(
+        logits,
+        np.array([0]),
+        torch.tensor([7], device=DEVICE),
+        expanded_logits=False,
+    )
+    assert logits[0, 7].item() == 0.0
+
+    # Slot reuse with a breaker-less request must not inherit the mask.
+    fresh = SamplingParams(
+        dry_multiplier=1.0,
+        dry_base=2.0,
+        dry_allowed_length=1,
+        dry_sequence_breakers=[],
+    )
+    state.add_request(0, fresh)
+    logits2 = torch.zeros(1, 32, device=DEVICE)
+    state.apply_dry(
+        logits2,
+        np.array([0]),
+        torch.tensor([7], device=DEVICE),
+        expanded_logits=False,
+    )
+    assert logits2[0, 7].item() < 0.0
+
+
+def test_v2_degenerate_base_routes_to_unclamped_slow_path():
+    # base <= 1.000001 gives max_exponent == 0, which in the sequential
+    # reference means "no clamp"; the vectorized path would clamp the
+    # exponent to 0, so such requests must route to the reference scan.
+    state, all_tokens = _make_v2_state()
+    params = SamplingParams(
+        dry_multiplier=1.0,
+        dry_base=1.0000005,
+        dry_allowed_length=0,
+        dry_sequence_breakers=[],
+    )
+    state.add_request(0, params)
+    all_tokens[0, :150] = 7
+    logits = torch.zeros(1, 32, device=DEVICE)
+    state.apply_dry(
+        logits,
+        np.array([0]),
+        torch.tensor([149], device=DEVICE),
+        expanded_logits=False,
+    )
+    base32 = float(np.float32(1.0000005))
+    want = -1.0 * base32**149
+    got = logits[0, 7].item()
+    assert math.isclose(got, want, rel_tol=1e-6)
+    assert got != -1.0
+
+
+def test_breaker_resolution_covers_added_tokens():
+    # Added/special tokens (chat markers) live above vocab_size on many
+    # tokenizers; llama.cpp's containment scan covers the full id range,
+    # so ours must too (max_token_id, not vocab_size).
+    class AddedTokenTokenizer:
+        _TEXTS = ["a", "\n", "b", "<|im_start|>"]
+        vocab_size = 3  # the added token sits above vocab_size
+        max_token_id = 3
+
+        def batch_decode(self, ids_lists):
+            return [self._TEXTS[ids[0]] for ids in ids_lists]
+
+    from vllm.v1.sample.dry_utils import resolve_dry_breakers
+
+    tok = AddedTokenTokenizer()
+    assert resolve_dry_breakers(tok, ("<|im_start|>",)) == [3]
+    assert resolve_dry_breakers(tok, ("\n",)) == [1]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_batched_peak_memory_bounded():
+    # base=1.1 gives max_exponent=930, a large J for the batched path
+    # (the cap is allowed_length + max_exponent <= _J_BUDGET = 2048). The chunk budget is denominated in bytes and the gather is
+    # int32, so peak transient memory stays near _CHUNK_BYTE_BUDGET even
+    # at large batch x window; an element-denominated budget with an
+    # int64 gather allocated ~8x more and OOMed 8 GB GPUs.
+    from vllm.v1.sample.logits_processor.dry_batched import _CHUNK_BYTE_BUDGET
+
+    device = torch.device("cuda")
+    rng = random.Random(3)
+    entries = []
+    for r in range(32):
+        state = _DryState(
+            multiplier=0.8,
+            base=1.1,
+            allowed_length=2,
+            penalty_last_n=-1,
+            breakers=frozenset(),
+            max_exponent=_max_exponent(1.1),
+            prompt_tok_ids=[rng.randrange(1000) for _ in range(2048)],
+            output_tok_ids=[],
+        )
+        entries.append((r, state, state.window()))
+    logits = torch.zeros(32, 128256, device=device)
+    torch.cuda.synchronize()
+    torch.cuda.reset_peak_memory_stats()
+    base_alloc = torch.cuda.memory_allocated()
+    dry_batched.apply_dry_batched(logits, entries)
+    torch.cuda.synchronize()
+    peak = torch.cuda.max_memory_allocated() - base_alloc
+    # generous headroom over the budget for l_max, W and allocator slack
+    assert peak < 2 * _CHUNK_BYTE_BUDGET, f"peak transient {peak / 2**20:.0f} MiB"

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -250,6 +250,11 @@ class ChatCompletionRequest(OpenAIBaseModel):
     top_k: int | None = None
     min_p: float | None = None
     repetition_penalty: float | None = None
+    dry_multiplier: float | None = None
+    dry_base: float | None = None
+    dry_allowed_length: int | None = None
+    dry_penalty_last_n: int | None = None
+    dry_sequence_breakers: list[str] | None = None
     length_penalty: float = 1.0
     stop_token_ids: list[int] | None = []
     include_stop_str_in_output: bool = False
@@ -683,6 +688,11 @@ class ChatCompletionRequest(OpenAIBaseModel):
             presence_penalty=self.presence_penalty,
             frequency_penalty=self.frequency_penalty,
             repetition_penalty=repetition_penalty,
+            dry_multiplier=self.dry_multiplier,
+            dry_base=self.dry_base,
+            dry_allowed_length=self.dry_allowed_length,
+            dry_penalty_last_n=self.dry_penalty_last_n,
+            dry_sequence_breakers=self.dry_sequence_breakers,
             temperature=temperature,
             top_p=top_p,
             top_k=top_k,

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -74,6 +74,11 @@ class CompletionRequest(OpenAIBaseModel):
     top_k: int | None = None
     min_p: float | None = None
     repetition_penalty: float | None = None
+    dry_multiplier: float | None = None
+    dry_base: float | None = None
+    dry_allowed_length: int | None = None
+    dry_penalty_last_n: int | None = None
+    dry_sequence_breakers: list[str] | None = None
     length_penalty: float = 1.0
     stop_token_ids: list[int] | None = []
     include_stop_str_in_output: bool = False
@@ -356,6 +361,11 @@ class CompletionRequest(OpenAIBaseModel):
             presence_penalty=self.presence_penalty,
             frequency_penalty=self.frequency_penalty,
             repetition_penalty=repetition_penalty,
+            dry_multiplier=self.dry_multiplier,
+            dry_base=self.dry_base,
+            dry_allowed_length=self.dry_allowed_length,
+            dry_penalty_last_n=self.dry_penalty_last_n,
+            dry_sequence_breakers=self.dry_sequence_breakers,
             temperature=temperature,
             top_p=top_p,
             top_k=top_k,

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -31,6 +31,14 @@ MAX_LOGPROB_TOKEN_IDS = 128
 """Upper bound on `SamplingParams.logprob_token_ids` list length. Must match
 the per-request row width allocated by the sampler's `LogprobTokenIdsState`."""
 
+DEFAULT_DRY_SEQUENCE_BREAKERS = ["\n", ":", '"', "*"]
+"""llama.cpp's default DRY sequence breakers."""
+
+MAX_DRY_SEQUENCE_BREAKERS = 64
+"""Upper bound on `SamplingParams.dry_sequence_breakers` list length. Each
+previously-unseen breaker string costs a containment scan over the
+vocabulary (cached afterwards)."""
+
 
 def validate_thinking_token_budget(value: int | float | bool | None) -> int | None:
     """Validate ``thinking_token_budget``; return ``None`` if unset."""
@@ -233,6 +241,28 @@ class SamplingParams(
     """Penalizes new tokens based on whether they appear in the prompt and the
     generated text so far. Values > 1 encourage the model to use new tokens,
     while values < 1 encourage the model to repeat tokens."""
+    dry_multiplier: float = 0.0
+    """DRY (Don't Repeat Yourself) penalty multiplier. Penalizes tokens that
+    would extend a token sequence already present in the context, with a
+    penalty growing exponentially in the repetition length. Set to 0 (the
+    default) to disable. A typical enabled value is 0.8. Parameter names,
+    defaults and matching semantics follow llama.cpp."""
+    dry_base: float = 1.75
+    """Exponential base for the DRY penalty. Values below 1.0 disable DRY,
+    matching llama.cpp."""
+    dry_allowed_length: int = 2
+    """Repetitions up to this length are not penalized by DRY."""
+    dry_penalty_last_n: int = -1
+    """How many tokens of context DRY scans for repetitions. -1 (the
+    default) scans the whole context; 0 disables. The scan cost is linear
+    in this window."""
+    dry_sequence_breakers: list[str] = msgspec.field(
+        default_factory=lambda: list(DEFAULT_DRY_SEQUENCE_BREAKERS)
+    )
+    """Strings that interrupt DRY's sequence matching, so repetition is not
+    tracked across structural boundaries such as lines or chat turns. Every
+    vocabulary token whose text contains one of these strings acts as a
+    breaker, following llama.cpp."""
     temperature: float = 1.0
     """Controls the randomness of the sampling. Lower values make the model
     more deterministic, while higher values make the model more random. Zero
@@ -344,6 +374,12 @@ class SamplingParams(
     last token of a corresponding token sequence is not allowed when the next
     generated token can complete the sequence."""
     _bad_words_token_ids: list[list[int]] | None = None
+    # DRY sequence breakers resolved to token ids by update_from_tokenizer
+    # in the engine frontend (llama.cpp containment semantics; see
+    # vllm/v1/sample/dry_utils.py). None until resolved; when unresolved
+    # (e.g. skip_tokenizer_init or direct library use) the sampler-side
+    # DRY implementations warn once and proceed without breakers.
+    _dry_breaker_ids: list[int] | None = None
 
     skip_reading_prefix_cache: bool | None = None
     thinking_token_budget: int | None = None
@@ -363,6 +399,11 @@ class SamplingParams(
         presence_penalty: float | None = 0.0,
         frequency_penalty: float | None = 0.0,
         repetition_penalty: float | None = 1.0,
+        dry_multiplier: float | None = 0.0,
+        dry_base: float | None = 1.75,
+        dry_allowed_length: int | None = 2,
+        dry_penalty_last_n: int | None = -1,
+        dry_sequence_breakers: list[str] | None = None,
         temperature: float | None = 1.0,
         top_p: float | None = 1.0,
         top_k: int = 0,
@@ -425,6 +466,13 @@ class SamplingParams(
             repetition_penalty=1.0
             if repetition_penalty is None
             else repetition_penalty,
+            dry_multiplier=0.0 if dry_multiplier is None else dry_multiplier,
+            dry_base=1.75 if dry_base is None else dry_base,
+            dry_allowed_length=2 if dry_allowed_length is None else dry_allowed_length,
+            dry_penalty_last_n=-1 if dry_penalty_last_n is None else dry_penalty_last_n,
+            dry_sequence_breakers=list(DEFAULT_DRY_SEQUENCE_BREAKERS)
+            if dry_sequence_breakers is None
+            else dry_sequence_breakers,
             temperature=1.0 if temperature is None else temperature,
             top_p=1.0 if top_p is None else top_p,
             top_k=top_k,
@@ -543,6 +591,69 @@ class SamplingParams(
             raise VLLMValidationError(
                 "repetition_penalty must be greater than zero, got "
                 f"{self.repetition_penalty}."
+            )
+        # bool is an int subclass, so isinstance-based numeric checks alone
+        # would accept JSON true/false for the dry_* numeric parameters.
+        for _dry_name in (
+            "dry_multiplier",
+            "dry_base",
+            "dry_allowed_length",
+            "dry_penalty_last_n",
+        ):
+            _dry_value = getattr(self, _dry_name)
+            if isinstance(_dry_value, bool) or not isinstance(_dry_value, (int, float)):
+                raise VLLMValidationError(
+                    f"{_dry_name} must be a number, got {type(_dry_value).__name__}.",
+                    parameter=_dry_name,
+                    value=_dry_value,
+                )
+        if not math.isfinite(self.dry_multiplier) or self.dry_multiplier < 0.0:
+            raise VLLMValidationError(
+                "dry_multiplier must be non-negative and finite, got "
+                f"{self.dry_multiplier}.",
+                parameter="dry_multiplier",
+                value=self.dry_multiplier,
+            )
+        if not math.isfinite(self.dry_base) or self.dry_base < 0.0:
+            raise VLLMValidationError(
+                f"dry_base must be non-negative and finite, got {self.dry_base}.",
+                parameter="dry_base",
+                value=self.dry_base,
+            )
+        if not isinstance(self.dry_allowed_length, int) or self.dry_allowed_length < 0:
+            raise VLLMValidationError(
+                "dry_allowed_length must be a non-negative integer, got "
+                f"{self.dry_allowed_length}.",
+                parameter="dry_allowed_length",
+                value=self.dry_allowed_length,
+            )
+        if not isinstance(self.dry_penalty_last_n, int) or self.dry_penalty_last_n < -1:
+            raise VLLMValidationError(
+                "dry_penalty_last_n must be an integer: -1 (whole context), "
+                f"0 (disable), or positive, got {self.dry_penalty_last_n}.",
+                parameter="dry_penalty_last_n",
+                value=self.dry_penalty_last_n,
+            )
+        if self.dry_sequence_breakers is not None and (
+            not isinstance(self.dry_sequence_breakers, (list, tuple))
+            or any(not isinstance(s, str) for s in self.dry_sequence_breakers)
+        ):
+            raise VLLMValidationError(
+                "dry_sequence_breakers must be a list of strings, got "
+                f"{self.dry_sequence_breakers!r}.",
+                parameter="dry_sequence_breakers",
+                value=self.dry_sequence_breakers,
+            )
+        if (
+            self.dry_sequence_breakers is not None
+            and len(self.dry_sequence_breakers) > MAX_DRY_SEQUENCE_BREAKERS
+        ):
+            raise VLLMValidationError(
+                f"dry_sequence_breakers supports at most "
+                f"{MAX_DRY_SEQUENCE_BREAKERS} entries, got "
+                f"{len(self.dry_sequence_breakers)}.",
+                parameter="dry_sequence_breakers",
+                value=len(self.dry_sequence_breakers),
             )
         if not math.isfinite(self.temperature):
             raise VLLMValidationError(
@@ -674,6 +785,13 @@ class SamplingParams(
                     self.stop_token_ids = list(eos_ids)
 
     def update_from_tokenizer(self, tokenizer: TokenizerLike) -> None:
+        if self.dry_multiplier and self.dry_sequence_breakers:
+            # Deferred import: sampling_params is imported nearly everywhere.
+            from vllm.v1.sample.dry_utils import resolve_dry_breakers
+
+            self._dry_breaker_ids = resolve_dry_breakers(
+                tokenizer, tuple(self.dry_sequence_breakers)
+            )
         if not self.bad_words:
             return
         self._bad_words_token_ids = []

--- a/vllm/v1/sample/dry_utils.py
+++ b/vllm/v1/sample/dry_utils.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Shared helpers for the DRY (Don't Repeat Yourself) penalty.
+
+Used by both sampler stacks: the V1-runner builtin logits processor
+(vllm/v1/sample/logits_processor/dry.py) and the V2-runner native module
+(vllm/v1/worker/gpu/sample/dry.py).
+"""
+
+import weakref
+from typing import Any
+
+import numpy as np
+
+# llama.cpp's FLOAT_MAX_LOG (src/llama-sampler.cpp): ln(float32 max).
+_FLOAT_MAX_LOG = 88.7228391
+
+# llama.cpp truncates sequence breaker strings to this many characters
+# before matching them against the vocabulary.
+_MAX_BREAKER_CHAR_LEN = 40
+
+# Upper bound on distinct breaker sets cached per tokenizer; evicted sets
+# re-resolve in a few ms.
+_MAX_CACHED_BREAKER_SETS = 64
+
+
+def max_exponent(base: float) -> int:
+    """Exponent clamp, mirroring llama.cpp bit-for-bit.
+
+    llama.cpp computes ``FLOAT_MAX_LOG / std::log(dry_base)`` entirely in
+    float32. Computing the quotient in float64 lands on the wrong side of
+    the integer truncation for some bases: at ``base=2.0`` float64 gives
+    127.99999998 -> 127 while float32 gives exactly 128.0 -> 128.
+    """
+    if base <= 1.000001:
+        return 0
+    return int(np.float32(_FLOAT_MAX_LOG) / np.log(np.float32(base)))
+
+
+# Per-tokenizer caches, weakly keyed so tokenizers can be collected:
+# tokenizer -> decoded text of every vocab id, and
+# tokenizer -> {breaker string tuple -> resolved breaker ids}.
+_BreakerIdsPerTokenizer = dict[tuple[str, ...], list[int]]
+_vocab_texts_cache: "weakref.WeakKeyDictionary[Any, list[str]]" = (
+    weakref.WeakKeyDictionary()
+)
+_breaker_ids_cache: "weakref.WeakKeyDictionary[Any, _BreakerIdsPerTokenizer]" = (
+    weakref.WeakKeyDictionary()
+)
+
+
+def resolve_dry_breakers(tokenizer: Any, breaker_strs: tuple[str, ...]) -> list[int]:
+    """Resolve breaker strings to single-token breaker ids.
+
+    llama.cpp parity (``get_overlapping_token_sequences``): every
+    vocabulary token whose decoded text contains a breaker string acts
+    as a single-token breaker, not just exact encodings (~3.9k of 128k
+    ids for the default set on a Llama-3 tokenizer). llama.cpp
+    additionally builds multi-token restart sequences from
+    partially-overlapping tokens; those are not supported here.
+
+    The O(vocab) decode runs once per tokenizer and the containment scan
+    once per (tokenizer, breaker set), both cached. Breaker strings are
+    truncated to ``_MAX_BREAKER_CHAR_LEN`` code points before caching and
+    matching, bounding the cache key space (llama.cpp truncates to the
+    same count of bytes; identical for ASCII breakers).
+    """
+    breaker_strs = tuple(s[:_MAX_BREAKER_CHAR_LEN] for s in breaker_strs if s)
+    if not breaker_strs:
+        return []
+    per_tok = _breaker_ids_cache.setdefault(tokenizer, {})
+    cached = per_tok.get(breaker_strs)
+    if cached is not None:
+        return list(cached)
+
+    texts = _vocab_texts_cache.get(tokenizer)
+    if texts is None:
+        # The full id range, not vocab_size: added/special tokens (chat
+        # markers like <|im_start|>) live above vocab_size on many
+        # tokenizers, and llama.cpp's containment scan covers them too.
+        n_ids = getattr(tokenizer, "max_token_id", tokenizer.vocab_size - 1) + 1
+        texts = tokenizer.batch_decode([[i] for i in range(n_ids)])
+        _vocab_texts_cache[tokenizer] = texts
+
+    ids: set[int] = set()
+    for s in breaker_strs:
+        ids.update(i for i, text in enumerate(texts) if s in text)
+    result = sorted(ids)
+    if len(per_tok) >= _MAX_CACHED_BREAKER_SETS:
+        # Evict the oldest entry (dict preserves insertion order).
+        per_tok.pop(next(iter(per_tok)))
+    per_tok[breaker_strs] = result
+    return list(result)

--- a/vllm/v1/sample/logits_processor/__init__.py
+++ b/vllm/v1/sample/logits_processor/__init__.py
@@ -21,6 +21,7 @@ from vllm.v1.sample.logits_processor.builtin import (
     MinTokensLogitsProcessor,
     process_dict_updates,
 )
+from vllm.v1.sample.logits_processor.dry import DryLogitsProcessor
 from vllm.v1.sample.logits_processor.interface import (
     BatchUpdate,
     LogitsProcessor,
@@ -51,6 +52,7 @@ BUILTIN_LOGITS_PROCESSORS: list[type[LogitsProcessor]] = [
     MinTokensLogitsProcessor,
     LogitBiasLogitsProcessor,
     MinPLogitsProcessor,
+    DryLogitsProcessor,
 ]
 
 
@@ -203,7 +205,8 @@ def build_logitsprocs(
         if custom_logitsprocs:
             raise ValueError(STR_SPEC_DEC_REJECTS_LOGITSPROCS)
         logger.warning(
-            "min_p and logit_bias parameters won't work with speculative decoding."
+            "min_p, logit_bias and dry_* parameters won't work with "
+            "speculative decoding."
         )
         return LogitsProcessors(
             [MinTokensLogitsProcessor(vllm_config, device, is_pin_memory)]
@@ -349,6 +352,7 @@ class AdapterLogitsProcessor(LogitsProcessor):
 
 __all__ = [
     "LogitsProcessor",
+    "DryLogitsProcessor",
     "LogitBiasLogitsProcessor",
     "MinPLogitsProcessor",
     "MinTokensLogitsProcessor",

--- a/vllm/v1/sample/logits_processor/dry.py
+++ b/vllm/v1/sample/logits_processor/dry.py
@@ -1,0 +1,284 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""DRY (Don't Repeat Yourself) repetition penalty.
+
+Penalizes tokens that would extend a token sequence already present in the
+context, with a penalty growing exponentially in the length of the repeated
+sequence: ``multiplier * base ** (repeat_length - allowed_length)`` is
+subtracted from the logit. ``repetition_penalty`` scales individual
+tokens regardless of context; DRY targets verbatim loops.
+
+The matching semantics follow llama.cpp's ``llama_sampler_dry_apply``
+(itself ported from the koboldcpp implementation by pi6am; the DRY scheme
+was designed by p-e-w for text-generation-webui), so identical settings
+produce identical behavior in both runtimes. Parameter names and defaults
+also follow llama.cpp.
+"""
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import numpy as np
+import torch
+
+from vllm import SamplingParams
+from vllm.logger import init_logger
+from vllm.utils.torch_utils import async_tensor_h2d
+from vllm.v1.sample.dry_utils import max_exponent
+from vllm.v1.sample.logits_processor import dry_batched
+from vllm.v1.sample.logits_processor.builtin import process_dict_updates
+from vllm.v1.sample.logits_processor.interface import (
+    BatchUpdate,
+    LogitsProcessor,
+)
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+
+logger = init_logger(__name__)
+
+
+def _dry_penalties(
+    window: list[int],
+    breakers: frozenset[int],
+    multiplier: float,
+    base: float,
+    allowed_length: int,
+    max_exp: int,
+) -> dict[int, float]:
+    """Compute DRY penalties for one request.
+
+    Port of the scan in ``llama_sampler_dry_apply``: a reverse-direction
+    Z-algorithm finds, for each position, the length of the match between
+    the window suffix and the sequence ending at that position; each
+    match's follower token is charged the penalty for the longest repeat
+    it would extend.
+
+    Returns a dict mapping token id -> penalty to subtract from its logit.
+    """
+    m = len(window)
+
+    def rat(i: int) -> int:  # reverse access: rat(0) == last token
+        return window[m - 1 - i]
+
+    # Step 1: the nearest breaker from the end caps the match length.
+    rep_limit = m
+    for i in range(m):
+        if rat(i) in breakers:
+            rep_limit = i
+            break
+    if rep_limit < allowed_length:
+        return {}
+
+    # Step 2: reverse-direction Z-algorithm -> per-position repeat counts
+    # (forward-indexed into ``window`` via cnt[last - k]).
+    cnt = [0] * m
+    last = m - 1
+    lt = rt = 0
+    for k in range(1, m):
+        if k > rt:
+            # Outside the current Z-box: extend naively.
+            z = 0
+            while z + k < m and rat(z) == rat(z + k):
+                z += 1
+            cnt[last - k] = min(z, rep_limit)
+            if z > 0:
+                lt, rt = k, k + z - 1
+        else:
+            p = k - lt
+            right_part_len = rt - k + 1
+            if cnt[last - p] < right_part_len:
+                # Fully inside the Z-box: copy.
+                cnt[last - k] = min(cnt[last - p], rep_limit)
+            else:
+                # Touches the right edge: extend past it.
+                j = rt + 1
+                while j < m and rat(j) == rat(j - k):
+                    j += 1
+                cnt[last - k] = min(j - k, rep_limit)
+                lt, rt = k, j - 1
+
+    # Step 3: map each repeat's follower token to the longest repeat that
+    # it would extend.
+    max_token_repeat: dict[int, int] = {}
+    for i in range(m - 1):
+        repeat_len = cnt[i]
+        if repeat_len >= allowed_length:
+            tok = window[i + 1]
+            if max_token_repeat.get(tok, -1) < repeat_len:
+                max_token_repeat[tok] = repeat_len
+
+    # Step 4: exponential penalty, exponent clamped for float32 safety.
+    # Breaker tokens are never penalized. A value overflowing float32
+    # saturates the logit to -inf downstream, as in llama.cpp.
+    penalties: dict[int, float] = {}
+    for tok, repeat_len in max_token_repeat.items():
+        if tok in breakers:
+            continue
+        exponent = repeat_len - allowed_length
+        if max_exp and exponent > max_exp:
+            exponent = max_exp
+        penalties[tok] = multiplier * (base**exponent)
+    return penalties
+
+
+@dataclass
+class _DryState:
+    multiplier: float
+    base: float
+    allowed_length: int
+    penalty_last_n: int
+    breakers: frozenset[int]
+    max_exponent: int
+    prompt_tok_ids: list[int]
+    # Live reference to the request's running output list (see the
+    # BatchUpdate contract in interface.py); grows every step.
+    output_tok_ids: list[int] = field(default_factory=list)
+    # Lazily built by dry_batched._breaker_vocab_mask.
+    _breaker_mask: torch.Tensor | None = None
+
+    def __post_init__(self):
+        # llama.cpp stores dry_multiplier and dry_base as float32 and the
+        # penalty is computed from those rounded values (promoted to
+        # double inside std::pow). Round once here so the sequential and
+        # batched paths both match llama.cpp bit-for-bit (e.g. base=1.1
+        # is 1.10000002384... in float32).
+        self.multiplier = float(np.float32(self.multiplier))
+        self.base = float(np.float32(self.base))
+
+    def window(self) -> list[int] | None:
+        """Trailing ``penalty_last_n`` tokens of prompt + output.
+
+        Returns None when the effective window cannot produce a penalty.
+        llama.cpp additionally caps the window at the model context size;
+        vLLM's history cannot exceed the model context, so the cap is
+        implicit here.
+        """
+        n_out = len(self.output_tok_ids)
+        hist_len = len(self.prompt_tok_ids) + n_out
+        if self.penalty_last_n == -1:
+            last_n = hist_len
+        else:
+            last_n = min(hist_len, self.penalty_last_n)
+        if last_n <= self.allowed_length:
+            return None
+        if last_n <= n_out:
+            return self.output_tok_ids[-last_n:]
+        return self.prompt_tok_ids[n_out - last_n :] + self.output_tok_ids
+
+
+class DryLogitsProcessor(LogitsProcessor):
+    """Builtin DRY penalty processor.
+
+    Sparse per-request state (only requests with ``dry_multiplier > 0``);
+    no-op when no request in the batch enables DRY.
+    """
+
+    def __init__(
+        self, vllm_config: "VllmConfig", device: torch.device, is_pin_memory: bool
+    ):
+        self.device = device
+        self.reqs: dict[int, _DryState] = {}
+        # Batched-vs-sequential dispatch: None = auto (batched on CUDA),
+        # True/False force one path (used by tests and benchmarks).
+        self.use_batched: bool | None = None
+        self._warned_unresolved = False
+
+    def is_argmax_invariant(self) -> bool:
+        """DRY moves logits and can change the greedy argmax."""
+        return False
+
+    def needs_output_token_ids(self) -> bool:
+        """DRY scans generation history, so the output token id lists must
+        be kept fresh (see the base class: under async scheduling they are
+        otherwise one token stale)."""
+        return bool(self.reqs)
+
+    def _new_state(
+        self,
+        params: SamplingParams,
+        prompt_tok_ids: list[int] | None,
+        output_tok_ids: list[int],
+    ) -> _DryState | None:
+        multiplier = params.dry_multiplier
+        base = params.dry_base
+        penalty_last_n = params.dry_penalty_last_n
+        # Same gate as llama_sampler_dry_apply: disabled configurations
+        # are not tracked.
+        if not multiplier or base < 1.0 or penalty_last_n == 0:
+            return None
+        # Breaker strings are resolved to token ids by the engine frontend
+        # (SamplingParams.update_from_tokenizer). If that step was skipped
+        # (e.g. skip_tokenizer_init or direct library use), proceed without
+        # breakers rather than loading a tokenizer in the worker.
+        resolved = params._dry_breaker_ids
+        if (
+            resolved is None
+            and params.dry_sequence_breakers
+            and not self._warned_unresolved
+        ):
+            logger.warning(
+                "DRY sequence breakers were not resolved to token ids; "
+                "proceeding without breakers."
+            )
+            self._warned_unresolved = True
+        return _DryState(
+            multiplier=multiplier,
+            base=base,
+            allowed_length=params.dry_allowed_length,
+            penalty_last_n=penalty_last_n,
+            breakers=frozenset(resolved or ()),
+            max_exponent=max_exponent(base),
+            prompt_tok_ids=prompt_tok_ids or [],
+            output_tok_ids=output_tok_ids,
+        )
+
+    def update_state(self, batch_update: BatchUpdate | None):
+        process_dict_updates(self.reqs, batch_update, self._new_state)
+
+    def apply(self, logits: torch.Tensor) -> torch.Tensor:
+        if not self.reqs:
+            return logits
+        candidates: list[tuple[int, _DryState, list[int] | None]] = [
+            (req_index, state, state.window()) for req_index, state in self.reqs.items()
+        ]
+        if self.use_batched is not None:
+            use_batched = self.use_batched
+        else:
+            # The vectorized path has ~0.5 ms of fixed launch/H2D cost; the
+            # sequential scan wins below ~2k total window tokens (measured
+            # on an RTX PRO 6000; the crossover is flat across batch shapes).
+            total_window = sum(len(w) for _, _, w in candidates if w is not None)
+            use_batched = logits.device.type == "cuda" and total_window >= 2048
+        batched_entries: list[tuple[int, _DryState, list[int]]] = []
+        rows: list[int] = []
+        cols: list[int] = []
+        vals: list[float] = []
+        for req_index, state, window in candidates:
+            if window is None:
+                continue
+            if use_batched and dry_batched.eligible(state):
+                batched_entries.append((req_index, state, window))
+                continue
+            penalties = _dry_penalties(
+                window,
+                state.breakers,
+                state.multiplier,
+                state.base,
+                state.allowed_length,
+                state.max_exponent,
+            )
+            for tok, val in penalties.items():
+                rows.append(req_index)
+                cols.append(tok)
+                vals.append(val)
+        if batched_entries:
+            logits = dry_batched.apply_dry_batched(logits, batched_entries)
+        if rows:
+            # float32 conversion saturates oversized penalties to inf, so
+            # the logit lands at -inf, as in llama.cpp.
+            logits[
+                async_tensor_h2d(rows, self.device, torch.int64),
+                async_tensor_h2d(cols, self.device, torch.int64),
+            ] -= async_tensor_h2d(vals, self.device, torch.float32)
+        return logits

--- a/vllm/v1/sample/logits_processor/dry_batched.py
+++ b/vllm/v1/sample/logits_processor/dry_batched.py
@@ -1,0 +1,259 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Batched torch implementation of the DRY penalty.
+
+Computes the same per-position match lengths as the sequential
+Z-algorithm in ``dry.py``, but vectorized across every DRY request in the
+batch. The comparisons that determine the match length ending at
+position ``i`` all lie along one fixed diagonal: for offset ``k = n-1-i``
+they compare ``window[n-1-j-k] == window[n-1-j]`` for ``j = 0, 1, 2, ...``
+until the first mismatch. Evaluating those comparisons as an ``[R, K, J]``
+tensor and taking a cumprod-sum along ``j`` yields every match length
+with no sequential scan.
+
+Capping ``J`` at ``allowed_length + max_exponent`` is exact: the exponent
+clamp maps every longer match to the same penalty. Requests whose cap is
+unusable (``max_exponent == 0``, i.e. ``base <= 1.000001``, or a cap
+beyond ``_J_BUDGET``) are routed to the sequential reference
+implementation instead.
+
+``dry_core`` is the tensor-level entry point, shared by both sampler
+stacks: the V1-runner logits processor wraps it with list-of-ints window
+building (``apply_dry_batched``); the V2-runner module gathers windows
+directly from its GPU-resident token history.
+"""
+
+from collections.abc import Sequence
+from typing import Protocol
+
+import torch
+
+
+class _DryParams(Protocol):
+    """Per-request DRY parameters (structurally, dry._DryState)."""
+
+    multiplier: float
+    base: float
+    allowed_length: int
+    max_exponent: int
+    breakers: frozenset[int]
+    _breaker_mask: "torch.Tensor | None"
+
+
+# Requests needing a longer match cap than this are handled by the
+# sequential reference path; beyond it the [R, K, J] tensors stop being
+# cheap. base=1.1 needs 930; base=1.05 needs 1818.
+_J_BUDGET = 2048
+
+# Byte budget for the per-chunk transients of the match scan. The gather
+# W32[:, idx1] materializes [R, chunk, J] int32 (4 B/elem) before the
+# comparison reduces it to bool; with the masks, the int8 cumprod and
+# the int16 row sums, the marginal transient cost is ~8 B/elem. 24 keeps
+# headroom for the fixed R*vocab int64 l_max floor and allocator slack
+# (and, measured, slightly better wall time than tighter chunking).
+_CHUNK_BYTE_BUDGET = 256 * 1024 * 1024
+_CHUNK_PEAK_BYTES_PER_ELEM = 24
+
+
+def eligible(state: _DryParams) -> bool:
+    """Whether the batched path computes this request exactly."""
+    return (
+        state.max_exponent > 0
+        and state.allowed_length + state.max_exponent <= _J_BUDGET
+    )
+
+
+def _breaker_vocab_mask(
+    state: _DryParams, vocab_size: int, device: torch.device
+) -> torch.Tensor:
+    """Cached [vocab] bool mask of this request's breaker token ids."""
+    cached = state._breaker_mask
+    if cached is not None and cached.shape[0] == vocab_size:
+        return cached
+    mask = torch.zeros(vocab_size, dtype=torch.bool, device=device)
+    if state.breakers:
+        ids = torch.tensor(sorted(state.breakers), dtype=torch.int64, device=device)
+        mask[ids[ids < vocab_size]] = True
+    state._breaker_mask = mask
+    return mask
+
+
+def dry_core(
+    logits: torch.Tensor,
+    row_idx: torch.Tensor,
+    W: torch.Tensor,
+    n_r: torch.Tensor,
+    allowed: torch.Tensor,
+    max_exp: torch.Tensor,
+    mult: torch.Tensor,
+    base: torch.Tensor,
+    breaker_masks: list[torch.Tensor | None],
+) -> torch.Tensor:
+    """Apply DRY penalties in place given batched window tensors.
+
+    Args:
+      logits: [B, vocab] float tensor, modified in place.
+      row_idx: [R] int64, row of ``logits`` for each DRY request.
+      W: [R, N] int64 windows, RIGHT-aligned (window tokens occupy the
+        trailing ``n_r`` columns; leading padding is ignored via masks).
+      n_r: [R] int64 window lengths.
+      allowed / max_exp: [R] int64 per-request parameters.
+      mult / base: [R] float32 per-request parameters (already rounded
+        through float32, as llama.cpp stores them).
+      breaker_masks: per-request [vocab] bool masks (or None for no
+        breakers).
+    """
+    device = logits.device
+    vocab = logits.shape[-1]
+    R, N = W.shape
+
+    # Per-request rep_limit: distance from the end of the nearest breaker
+    # (llama.cpp step 1). A breaker at column c is j = N-1-c tokens from
+    # the end.
+    rep_limit = n_r.clone()
+    any_breakers = any(bm is not None and bool(bm.any()) for bm in breaker_masks)
+    if any_breakers:
+        Bwin = torch.stack(
+            [
+                bm[W[r].clamp(min=0)]
+                if bm is not None
+                else torch.zeros(N, dtype=torch.bool, device=device)
+                for r, bm in enumerate(breaker_masks)
+            ]
+        )
+        valid_cols = torch.arange(N, device=device)[None, :] >= (N - n_r)[:, None]
+        Bwin &= valid_cols
+        has_breaker = Bwin.any(dim=1)
+        # max breaker column -> nearest to the end.
+        max_col = torch.where(
+            has_breaker,
+            (Bwin * torch.arange(1, N + 1, device=device)[None, :]).max(dim=1).values
+            - 1,
+            torch.zeros_like(n_r),
+        )
+        rep_limit = torch.where(has_breaker, (N - 1) - max_col, n_r)
+
+    # llama.cpp: if rep_limit < allowed_length, the request produces
+    # nothing this step.
+    active = rep_limit >= allowed
+
+    # Match lengths per offset k, chunked to bound memory. Token ids fit
+    # int32 (as does the -1 padding), and gathering int32 instead of int64
+    # halves the dominant per-chunk transient.
+    W32 = W.to(torch.int32)
+    J = int(min(int((allowed + max_exp).max()), N))
+    J = max(J, 1)
+    idx2 = torch.arange(N - 1, N - 1 - J, -1, device=device)  # [J]
+    suffix = W32.gather(1, idx2.expand(R, J))  # [R, J]
+    K = N - 1  # offsets 1..N-1
+    chunk = max(1, _CHUNK_BYTE_BUDGET // (_CHUNK_PEAK_BYTES_PER_ELEM * max(1, R * J)))
+
+    # Scatter target: per-(row, token) longest charged match.
+    l_max = torch.full((R * vocab,), -1, dtype=torch.int64, device=device)
+
+    for k0 in range(1, K + 1, chunk):
+        k1 = min(k0 + chunk, K + 1)
+        ks = torch.arange(k0, k1, device=device)  # [C]
+        C = ks.shape[0]
+        # idx1[c, j] = N-1-j-k ; invalid (out of window) entries masked.
+        idx1 = idx2[None, :] - ks[:, None]  # [C, J]
+        invalid = idx1 < (N - n_r)[:, None, None]  # [R, C, J]
+        eq = W32[:, idx1.clamp(min=0)] == suffix[:, None, :]  # [R, C, J]
+        eq &= ~invalid
+        del invalid
+        # Run length of leading True along j = the match length. Explicit
+        # dtypes matter: integral cumprod otherwise accumulates in int64,
+        # materializing two [R, C, J] int64 copies. Values are 0/1 and the
+        # run length is <= J <= _J_BUDGET, so int8/int16 are exact.
+        L = eq.cumprod(dim=2, dtype=torch.int8).sum(dim=2, dtype=torch.int16)
+        del eq
+        L = torch.minimum(L, rep_limit[:, None])
+
+        # Follower token of offset k lives at column N-k; the offset is
+        # meaningful only while position i = N-1-k is inside the window
+        # (k <= n_r - 1).
+        valid_k = ks[None, :] <= (n_r - 1)[:, None]  # [R, C]
+        charge = (allowed[:, None] <= L) & valid_k & active[:, None]
+        if charge.any():
+            followers = W.gather(1, (N - ks).clamp(max=N - 1).expand(R, C))
+            rows = torch.arange(R, device=device)[:, None].expand(R, C) * vocab
+            flat = (rows + followers.clamp(min=0))[charge]
+            l_max.scatter_reduce_(0, flat, L[charge], reduce="amax", include_self=True)
+
+    # Penalties: multiplier * base ** min(L - allowed, max_exp). llama.cpp's
+    # std::pow promotes its float base with an int exponent to double, so
+    # the penalty is computed in double precision and saturates only when
+    # stored into the float32 logit. Mirror that: pow in float64, saturate
+    # on the final cast. A float32 pow saturates too early: 0.8 * 2**128
+    # must remain a finite logit (-2.72e38), not -inf.
+    l_max = l_max.view(R, vocab)
+    charged = l_max >= 0
+    if not bool(charged.any()):
+        return logits
+    exponent = torch.minimum(l_max - allowed[:, None], max_exp[:, None])
+    penalty = mult[:, None].double() * torch.pow(
+        base[:, None].double(), exponent.to(torch.float64)
+    )
+    penalty = torch.where(charged, penalty, torch.zeros_like(penalty))
+    for r, bm in enumerate(breaker_masks):
+        if bm is not None and bool(bm.any()):
+            penalty[r] = torch.where(bm, torch.zeros_like(penalty[r]), penalty[r])
+
+    logits.index_put_(
+        (row_idx,), logits[row_idx] - penalty.to(logits.dtype), accumulate=False
+    )
+    return logits
+
+
+def apply_dry_batched(
+    logits: torch.Tensor,
+    entries: Sequence[tuple[int, _DryParams, list[int]]],
+) -> torch.Tensor:
+    """Apply DRY for ``entries`` = [(row_index, state, window)] where the
+    windows are Python lists (the V1-runner path).
+
+    Every entry must satisfy ``eligible(state)`` and have a non-None
+    window. Modifies ``logits`` in place and returns it.
+    """
+    if not entries:
+        return logits
+    device = logits.device
+    vocab = logits.shape[-1]
+    R = len(entries)
+    lens = [len(w) for _, _, w in entries]
+    N = max(lens)
+
+    # Right-aligned padded windows; -1 never matches a real token because
+    # the validity mask excludes padded columns from every comparison.
+    W = torch.full((R, N), -1, dtype=torch.int64)
+    for r, (_, _, w) in enumerate(entries):
+        W[r, N - len(w) :] = torch.tensor(w, dtype=torch.int64)
+    W = W.to(device, non_blocking=True)
+
+    return dry_core(
+        logits,
+        row_idx=torch.tensor(
+            [row for row, _, _ in entries], dtype=torch.int64, device=device
+        ),
+        W=W,
+        n_r=torch.tensor(lens, dtype=torch.int64, device=device),
+        allowed=torch.tensor(
+            [s.allowed_length for _, s, _ in entries],
+            dtype=torch.int64,
+            device=device,
+        ),
+        max_exp=torch.tensor(
+            [s.max_exponent for _, s, _ in entries],
+            dtype=torch.int64,
+            device=device,
+        ),
+        mult=torch.tensor(
+            [s.multiplier for _, s, _ in entries],
+            dtype=torch.float32,
+            device=device,
+        ),
+        base=torch.tensor(
+            [s.base for _, s, _ in entries], dtype=torch.float32, device=device
+        ),
+        breaker_masks=[_breaker_vocab_mask(s, vocab, device) for _, s, _ in entries],
+    )

--- a/vllm/v1/sample/logits_processor/interface.py
+++ b/vllm/v1/sample/logits_processor/interface.py
@@ -93,6 +93,18 @@ class LogitsProcessor(ABC):
         """
         raise NotImplementedError
 
+    def needs_output_token_ids(self) -> bool:
+        """True if this processor currently reads request output token ids.
+
+        Under async scheduling, the per-request ``output_tok_ids`` lists are
+        only kept up to date (the placeholder for the in-flight token is
+        backfilled with the real sampled token before logits processors run)
+        when something in the batch needs them. A processor that inspects
+        generation history must return True while it is tracking at least
+        one request, or it will see history that is one token stale.
+        """
+        return False
+
     @abstractmethod
     def update_state(
         self,

--- a/vllm/v1/worker/gpu/sample/dry.py
+++ b/vllm/v1/worker/gpu/sample/dry.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""DRY (Don't Repeat Yourself) penalty for the V2 model runner.
+
+State module following the ``PenaltiesState`` pattern. The match
+computation is shared with the V1-runner logits processor
+(``vllm.v1.sample.logits_processor.dry_batched.dry_core``); windows are
+gathered directly from the GPU-resident ``req_states.all_token_ids``, so
+no per-step host-to-device copy of token history is needed.
+
+Speculative decoding is not supported yet (matching min_p/logit_bias in
+the V1 runner): with expanded draft logits DRY is skipped with a one-time
+warning.
+"""
+
+import numpy as np
+import torch
+
+from vllm.logger import init_logger
+from vllm.sampling_params import SamplingParams
+from vllm.v1.sample.dry_utils import max_exponent
+from vllm.v1.sample.logits_processor.dry import _dry_penalties
+from vllm.v1.sample.logits_processor.dry_batched import _J_BUDGET, dry_core
+from vllm.v1.worker.gpu.states import RequestState
+
+logger = init_logger(__name__)
+
+
+class DryState:
+    def __init__(self, req_states: RequestState):
+        self.req_states = req_states
+        max_num_reqs = req_states.max_num_reqs
+        self.vocab_size = req_states.vocab_size
+        self.device = req_states.device
+
+        # float32 storage rounds multiplier/base exactly as llama.cpp's
+        # float members do; the penalty math promotes to double from the
+        # rounded values (see dry_batched).
+        self.multiplier = np.zeros(max_num_reqs, dtype=np.float32)
+        self.base = np.zeros(max_num_reqs, dtype=np.float32)
+        self.allowed_length = np.zeros(max_num_reqs, dtype=np.int64)
+        self.penalty_last_n = np.zeros(max_num_reqs, dtype=np.int64)
+        self.max_exponent = np.zeros(max_num_reqs, dtype=np.int64)
+        self.use_dry = np.zeros(max_num_reqs, dtype=bool)
+
+        # req_idx -> breaker token ids / cached [vocab] bool GPU mask.
+        self.breaker_ids: dict[int, list[int]] = {}
+        self._breaker_masks: dict[int, torch.Tensor] = {}
+
+        self._warned_spec_decode = False
+        self._warned_unresolved = False
+
+    def add_request(self, req_idx: int, sampling_params: SamplingParams) -> None:
+        # Same gate as llama_sampler_dry_apply.
+        enabled = use_dry(sampling_params)
+        self.use_dry[req_idx] = enabled
+        self.breaker_ids.pop(req_idx, None)
+        self._breaker_masks.pop(req_idx, None)
+        if not enabled:
+            return
+        self.multiplier[req_idx] = sampling_params.dry_multiplier
+        self.base[req_idx] = sampling_params.dry_base
+        self.allowed_length[req_idx] = sampling_params.dry_allowed_length
+        self.penalty_last_n[req_idx] = sampling_params.dry_penalty_last_n
+        self.max_exponent[req_idx] = max_exponent(float(self.base[req_idx]))
+
+        ids = sampling_params._dry_breaker_ids
+        if ids:
+            self.breaker_ids[req_idx] = list(ids)
+        elif (
+            ids is None
+            and sampling_params.dry_sequence_breakers
+            and not self._warned_unresolved
+        ):
+            # The engine frontend resolves breaker strings to ids
+            # (SamplingParams.update_from_tokenizer). Reaching here means
+            # that step was skipped (e.g. skip_tokenizer_init).
+            logger.warning(
+                "DRY sequence breakers were not resolved to token ids; "
+                "proceeding without breakers."
+            )
+            self._warned_unresolved = True
+
+    def apply_staged_writes(self) -> None:
+        # All state is CPU-side numpy; nothing to stage.
+        pass
+
+    def _breaker_mask(self, req_idx: int) -> torch.Tensor | None:
+        ids = self.breaker_ids.get(req_idx)
+        if not ids:
+            return None
+        mask = self._breaker_masks.get(req_idx)
+        if mask is None:
+            mask = torch.zeros(self.vocab_size, dtype=torch.bool, device=self.device)
+            ids_t = torch.tensor(ids, dtype=torch.int64, device=self.device)
+            mask[ids_t[ids_t < self.vocab_size]] = True
+            self._breaker_masks[req_idx] = mask
+        return mask
+
+    def apply_dry(
+        self,
+        logits: torch.Tensor,
+        idx_mapping_np: np.ndarray,
+        pos: torch.Tensor,
+        expanded_logits: bool,
+    ) -> None:
+        req_indices = idx_mapping_np
+        active_rows = np.flatnonzero(self.use_dry[req_indices])
+        if active_rows.size == 0:
+            return
+        if expanded_logits:
+            if not self._warned_spec_decode:
+                logger.warning(
+                    "DRY is not applied with speculative decoding yet; "
+                    "requests with dry_multiplier set are unaffected."
+                )
+                self._warned_spec_decode = True
+            return
+
+        # ``pos`` holds the position of the last input token of each logits
+        # row; the context visible to the token being sampled is
+        # [0, pos + 1). Using ``pos`` alone drops the final context token
+        # and shifts every match by one: the penalty lands on the
+        # continuation of the previous suffix instead of the token being
+        # sampled. Single small D2H sync, only when DRY is in use.
+        active_t = torch.from_numpy(active_rows).to(self.device)
+        cur_len = pos[active_t].cpu().numpy().astype(np.int64) + 1
+
+        reqs = req_indices[active_rows]
+        last_n = self.penalty_last_n[reqs]
+        window_len = np.where(last_n == -1, cur_len, np.minimum(cur_len, last_n))
+        allowed = self.allowed_length[reqs]
+        keep = window_len > allowed
+        if not np.any(keep):
+            return
+        active_rows = active_rows[keep]
+        reqs = reqs[keep]
+        cur_len = cur_len[keep]
+        window_len = window_len[keep]
+        allowed = allowed[keep]
+        max_exp = self.max_exponent[reqs]
+
+        # Route degenerate-clamp requests (base <= 1.000001 or oversized
+        # cap) through the sequential reference implementation.
+        fast = (max_exp > 0) & (allowed + max_exp <= _J_BUDGET)
+        all_tokens = self.req_states.all_token_ids.gpu
+
+        if np.any(fast):
+            f_rows = active_rows[fast]
+            f_reqs = reqs[fast]
+            f_len = window_len[fast]
+            N = int(f_len.max())
+            reqs_t = torch.from_numpy(f_reqs).to(self.device)
+            cur_t = torch.from_numpy(cur_len[fast]).to(self.device)
+            j = torch.arange(N, device=self.device)
+            # Right-aligned gather: column j holds token (cur_len - N + j);
+            # out-of-window columns are masked inside dry_core via n_r.
+            gather_idx = (cur_t[:, None] - N + j[None, :]).clamp(min=0)
+            W = all_tokens[reqs_t[:, None], gather_idx].long()
+            dry_core(
+                logits,
+                row_idx=torch.from_numpy(f_rows).to(self.device),
+                W=W,
+                n_r=torch.from_numpy(f_len).to(self.device),
+                allowed=torch.from_numpy(allowed[fast]).to(self.device),
+                max_exp=torch.from_numpy(max_exp[fast]).to(self.device),
+                mult=torch.from_numpy(self.multiplier[f_reqs]).to(self.device),
+                base=torch.from_numpy(self.base[f_reqs]).to(self.device),
+                breaker_masks=[self._breaker_mask(r) for r in f_reqs],
+            )
+
+        slow = ~fast
+        if np.any(slow):
+            rows_list = []
+            cols_list = []
+            vals_list = []
+            for row, req, w_len, cur in zip(
+                active_rows[slow], reqs[slow], window_len[slow], cur_len[slow]
+            ):
+                window = (
+                    all_tokens[int(req), int(cur) - int(w_len) : int(cur)]
+                    .cpu()
+                    .tolist()
+                )
+                penalties = _dry_penalties(
+                    window,
+                    frozenset(self.breaker_ids.get(int(req), ())),
+                    float(self.multiplier[req]),
+                    float(self.base[req]),
+                    int(self.allowed_length[req]),
+                    int(self.max_exponent[req]),
+                )
+                for tok, val in penalties.items():
+                    rows_list.append(int(row))
+                    cols_list.append(tok)
+                    vals_list.append(val)
+            if rows_list:
+                logits[
+                    torch.tensor(rows_list, dtype=torch.int64, device=self.device),
+                    torch.tensor(cols_list, dtype=torch.int64, device=self.device),
+                ] -= torch.tensor(vals_list, dtype=torch.float32, device=self.device)
+
+
+def use_dry(sampling_params: SamplingParams) -> bool:
+    return (
+        bool(sampling_params.dry_multiplier)
+        and sampling_params.dry_base >= 1.0
+        and sampling_params.dry_penalty_last_n != 0
+    )

--- a/vllm/v1/worker/gpu/sample/sampler.py
+++ b/vllm/v1/worker/gpu/sample/sampler.py
@@ -15,6 +15,7 @@ from vllm.v1.sample.ops.topk_topp_sampler import (
 from vllm.v1.worker.gpu.input_batch import InputBatch, get_num_sampled_and_rejected
 from vllm.v1.worker.gpu.metrics.logits import get_num_nans
 from vllm.v1.worker.gpu.sample.bad_words import BadWordsState
+from vllm.v1.worker.gpu.sample.dry import DryState
 from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample
 from vllm.v1.worker.gpu.sample.logit_bias import LogitBiasState
 from vllm.v1.worker.gpu.sample.logprob import (
@@ -45,6 +46,7 @@ class Sampler:
         self.req_states = req_states
         self.sampling_states = SamplingStates(max_num_reqs, vocab_size)
         self.penalties_state = PenaltiesState(req_states)
+        self.dry_state = DryState(req_states)
         self.logit_bias_state = LogitBiasState(max_num_reqs, device)
         self.bad_words_state = BadWordsState(req_states)
         self.logprob_token_ids_state = LogprobTokenIdsState(max_num_reqs, device)
@@ -56,6 +58,7 @@ class Sampler:
     ) -> None:
         self.sampling_states.add_request(req_idx, sampling_params)
         self.penalties_state.add_request(req_idx, sampling_params)
+        self.dry_state.add_request(req_idx, sampling_params)
         self.logit_bias_state.add_request(req_idx, prompt_len, sampling_params)
         self.bad_words_state.add_request(req_idx, sampling_params)
         self.logprob_token_ids_state.add_request(req_idx, sampling_params)
@@ -63,6 +66,7 @@ class Sampler:
     def apply_staged_writes(self) -> None:
         self.sampling_states.apply_staged_writes()
         self.penalties_state.apply_staged_writes()
+        self.dry_state.apply_staged_writes()
         self.logit_bias_state.apply_staged_writes()
         self.bad_words_state.apply_staged_writes()
         self.logprob_token_ids_state.apply_staged_writes()
@@ -172,6 +176,15 @@ class Sampler:
             expanded_local_pos,
         )
 
+        # Apply the DRY penalty in place after the standard penalties
+        # (llama.cpp's sampler-chain order).
+        self.dry_state.apply_dry(
+            logits,
+            idx_mapping_np,
+            pos,
+            expanded_logits=logits.shape[0] != idx_mapping_np.shape[0],
+        )
+
         # Apply bad words masking in place.
         self.bad_words_state.apply_bad_words(
             logits,
@@ -201,6 +214,8 @@ class Sampler:
         if np.any(self.logit_bias_state.use_logit_bias[idx_mapping_np]):
             return True
         if np.any(self.penalties_state.use_penalty[idx_mapping_np]):
+            return True
+        if np.any(self.dry_state.use_dry[idx_mapping_np]):
             return True
         if np.any(self.bad_words_state.num_bad_words.np[idx_mapping_np] > 0):
             return True

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -914,6 +914,9 @@ class InputBatch:
             or bool(self.bad_words_token_ids)
             or self.logitsprocs_need_output_token_ids
             or thinking_budget_tracks_reqs
+            # Builtin processors report dynamically, e.g. DRY only while
+            # a request in the batch enables it.
+            or any(p.needs_output_token_ids() for p in self.logitsprocs.all)
         )
         output_token_ids = (
             cast(list[list[int]], self.req_output_token_ids)


### PR DESCRIPTION
## Purpose

Fixes #8581

DRY penalizes tokens that would extend a token sequence already present in the context, with a penalty that grows exponentially in the repetition length. It targets loops directly, which `repetition_penalty` (a flat per-token scale) does not. It is a standard sampler in llama.cpp, koboldcpp and text-generation-webui (designed by p-e-w, koboldcpp implementation by pi6am, per llama.cpp's credit line). It complements `RepetitionDetectionParams`, which stops a request once a loop is detected; DRY makes the loop less likely to form.

Parameters follow llama.cpp: `dry_multiplier`, `dry_base`, `dry_allowed_length`, `dry_penalty_last_n`, `dry_sequence_breakers`, disabled by default. One default deliberately differs: `dry_penalty_last_n` is `-1` here (scan the whole context) against llama.cpp's `64`. llama.cpp has no equivalent: libllama clamps a negative `dry_penalty_last_n` to 0 (`src/llama-sampler.cpp:3640`) and llama-server rejects one (`server-schema.cpp:153-155`, hard limits `[0, INT32_MAX]`). Every other default matches `common/common.h:243-259` at llama.cpp `ec928150`, the revision every llama.cpp line number here is against. Four validation rules also differ from llama.cpp's, three of them llama-server's and the fourth libllama's:

- A `dry_base` below 1.0. llama-server replaces it with the default (`server-schema.cpp:142-147`); this accepts it and warns, which leaves DRY inert (`sampling_params.py:643-653`).
- An empty breaker array. llama-server rejects it (`server-schema.cpp:242-249`); this accepts it.
- Breaker count. llama-server has no cap; this rejects more than 64 (`sampling_params.py:703-711`), since each unseen breaker costs a containment scan over the vocabulary.
- Breaker string length. libllama truncates to 40 bytes (`MAX_CHAR_LEN`, `src/llama-sampler.cpp:3642`, compared against `std::string::size()` at `:3665-3668`); this truncates to 40 code points (`dry_utils.py:68`).

**Rebased onto the V2 `LogitsProcessor` pipeline.** #56497 (`5302d1fe40`) turned the V2 sampler into a `list[LogitsProcessor]`, which made this a port, not a merge. DRY adds no gpu<->cpu synchronization to the sampler hot path: a live engine is clean under `VLLM_GPU_SYNC_CHECK=error`, the strict mode of the check njhill asked for here (`envs.py:646-650`: `warn` warns on each sync, `error` raises), and the two degenerate parameter regions that do synchronize are declared in the source, not left to trip the check. The branch is now 13 commits, 12 files, +1872/-4 against `5302d1fe40`. It had already been rewritten once before that: it used to carry two implementations, one per model runner, plus a change to the V1 logits-processor interface, and all of it is gone. A request that enables DRY on an engine that has fallen back to the V1 runner is rejected in `input_processor.py:160-166`.

### Implementation

Line numbers are against `3b51f6ab0c` on this branch, or against `5302d1fe40` for files this PR does not touch.

- `DryState` (`vllm/v1/worker/gpu/sample/dry.py:39`) subclasses `LogitsProcessor` and is one entry in `Sampler.logits_processors`, between `penalties_state` and `bad_words_state` (`sampler.py:76-81`). Penalties first is llama.cpp's chain order: `common/common.h:261-263` lists `COMMON_SAMPLER_TYPE_PENALTIES` then `COMMON_SAMPLER_TYPE_DRY`. Bad words after, so that mask wins over DRY's edits. DRY only subtracts, so it cannot re-inflate a grammar-masked token, which `interface.py:99-103` requires of a processor.
- `apply()` takes its window widths from `ctx.seq_lens_upper_bound_np` (`dry.py:126`, used at `dry.py:153`), so it does no device read. The interface supplies that host-side bound and documents it as exact when speculative decoding is not in use (`interface.py:86-89`), which is the condition DRY already requires. The field is not from this PR: `0e0c7af89d` added it on the #56497 branch, for #57620's DRY processor and #57618's n-gram processor.
- Windows are gathered from the GPU-resident `req_states.all_token_ids` (`dry.py:181-194`), so there is no per-step host copy of token history.
- Match lengths are computed as diagonal comparisons capped at `allowed_length + max_exponent`, which is exact because the exponent clamp maps every longer match to the same penalty. The scan is chunked against a byte budget. The accumulator holds the penalty rather than the match length, so the charged entries go in with one `index_add_` and no post-scan `nonzero()`.
- Breaker strings are resolved to token ids once in the frontend, in `SamplingParams.update_from_tokenizer` (`sampling_params.py:862`), where `bad_words` is resolved, using llama.cpp's containment rule: every vocabulary token whose decoded text contains a breaker string is a breaker. Resolution is cached per tokenizer and per breaker set.
- Speculative decoding is refused at admission. `SamplingParams._validate_spec_decode` rejects `dry_multiplier` next to `min_p` and `logit_bias` (`sampling_params.py:1208-1213`). `DryState` backstops that gate on `vllm_config.speculative_config` (`dry.py:45`) and on a draft-expanded row count, returning the logits untouched with a one-time warning (`dry.py:134-141`). The row-count check alone is false on any step where no request happens to carry drafts, so by itself it applied DRY on some steps and not others.
- Outside the new files the diff is small: `sampler.py` is 9 added lines against 1 removed, and `batch_shard.py` is untouched, because upstream localises `seq_lens_cpu_upper_bound` itself (`batch_shard.py:203` and `:275`).
- Three sampler test doubles gained `speculative_config=None`: those suites build their config as a `SimpleNamespace` carrying `reasoning_config` alone, and `DryState.__init__` is the first entry in `Sampler.logits_processors` to read a field off the `VllmConfig` it is handed. That is why a DRY PR edits `test_gpu_thinking_budget.py`.

### Why built-in fields rather than a custom logits processor

#57620 implements DRY as an example custom logits processor against the #56497 interface, to check that the interface gives a real processor what it needs. @sawsa307 opened and closed it on 2026-09-18, and its description says that if the maintainers prefer DRY as a built-in, #50584 is the right vehicle. It carries `dry_core.py` and `dry_utils.py` from this PR under a `Co-authored-by` line on `1f071830f4`, so a reviewer can read a working plugin version of this sampler that changes no core code. That exercise is one of the two reasons the interface carries `seq_lens_upper_bound_np`: the DRY processor needed a per-request window width on the host, and so does #57618's n-gram processor. What the five `SamplingParams` fields, mirrored on two request classes, buy over the plugin route:

- Request surface. A built-in takes `"dry_multiplier": 0.8` beside `repetition_penalty` in `CompletionRequest` (`completion/protocol.py:79-83`) and `ChatCompletionRequest` (`chat_completion/protocol.py:271-275`). The plugin takes `"vllm_xargs": {"dry_multiplier": 0.8}` and needs the processor named in `--logits-processors` at server start (`docs/features/custom_arguments.md`, `vllm/config/model.py:370`). llama.cpp, koboldcpp and text-generation-webui all expose DRY as first-class parameters, so a client written against any of them needs rewriting for the `vllm_xargs` form and no change for the field form.
- Refusal at admission. `_validate_spec_decode` refuses `dry_multiplier` when the engine has a speculative config, because it runs with that config in hand (`sampling_params.py:1179-1213`). The plugin route's admission hook is `LogitsProcessor.validate_params`, a classmethod over `SamplingParams` alone (`interface.py:118-119`), so it cannot fail a request on the engine's configuration: #57620 warns at apply time instead, and the operator learns at decode time. Validation of the per-request arguments themselves is open to both, through that hook.
- No install step. Two years of #8581, 23 upvotes and 32 comments, is demand for a sampler a caller turns on per request, not for one the deployment has to load first.

Any one of these alone would be a thin case; the three together are the case for built-in fields.

### Known limitations

- Speculative decoding is refused at admission rather than skipped in the sampler.
- V2 model runner only. A V1-runner engine rejects the request.
- llama.cpp additionally expands multi-token restart sequences for breakers; not implemented here. Containment resolution handles single-token breakers only.
- Two parameter regions fall back to a sequential scan in Python, which holds the GIL and has to bring the window to the host: a `dry_base` at or below `1.000001`, where the exponent clamp collapses to zero, and an `allowed_length + max_exponent` above the vectorized path's budget of 2048, which at the default `dry_allowed_length` means a `dry_base` below about `1.044`. That body is wrapped in `gpu_sync_allowed()` (`dry.py:218`), so `VLLM_GPU_SYNC_CHECK` does not fire on it silently.
- Resolving a breaker set decodes the vocabulary once per tokenizer, synchronously on the API server's event loop.
- There is no early-out for a DRY request whose context never repeats: finding that out needs a device read, so such a request pays the full-width accumulator and `index_add_` on every step.

## Test Plan

- `pytest tests/v1/sample/test_dry.py`, included in the PR.
- `pytest` over the three sampler suites whose test doubles this PR edits.
- A live engine under `VLLM_GPU_SYNC_CHECK=error`, in eager and in cudagraph mode, with a DRY arm, a breaker arm, a DRY-off control and a batch-of-5 arm.
- `ruff check` and `ruff format --check` over every file the PR touches.

## Test Result

All local, on one RTX 5050 (sm_120) with torch 2.13.0+cu130. vLLM's test CI has not run, because the PR carries no `ready` label. Six check-runs are attached to the head and one is red: `pre-run-check`, which fails unless a PR carries `verified`, `ready` or `ready-run-all-tests`, or its author has four merged PRs.

- `tests/v1/sample/test_dry.py`: **38 passed**. `test_gpu_sampler_flags.py`, `test_gpu_logits_processors.py` and `test_gpu_thinking_budget.py`: **29 passed**.
- Live engine on Qwen2.5-0.5B-Instruct under `VLLM_GPU_SYNC_CHECK=error`, eager and `cudagraph_mode=FULL_AND_PIECEWISE`: both exit 0, no sync fired. The cudagraph engine captures twice, 51 piecewise and 2 full during CUDA graph memory profiling, then 51 piecewise and 35 full once the KV cache is sized. In both engines, DRY at the default breaker set (`\n`, `:`, `"`, `*`) breaks the prompt's repeated sentence while the control repeats it verbatim, and five copies of the prompt in one batch each match the batch-of-1 text. With `.`, `,` and newline as breakers the output is byte-identical to the control, since no match survives a sentence boundary. The two DRY arms differ only in the breaker set, so the set changed the output. What is still to do is an arm where two breaker sets both leave DRY active and produce different text.
- The eager and cudagraph DRY continuations agree through `The cat was` and then diverge (`sitting on the mat.` against `on the mat. What`). Same prefix at greedy decoding, so the two engines' logits differ at that step. The DRY-off controls do not diverge, and this run does not establish why the DRY arm does. Each engine's batch of 5 matches its own batch of 1, which is intra-engine determinism, not agreement between the engines.
- `ruff check` and `ruff format --check` clean on all 12 files under main's current config, which now selects the pydocstyle `D` rules (`pyproject.toml:66-88`).
- llama.cpp fidelity is checked in the suite. `test_worked_example` reproduces llama.cpp's own commented example from `src/llama-sampler.cpp`. `test_v2_matches_reference_fuzz` agrees with the sequential reference implementation, which shares no code with the vectorized path, over randomized histories at two chunk budgets. `test_differential_against_oracle` agrees with a brute-force reimplementation. `test_exponent_clamp_float32_semantics` and `test_double_pow_saturation` pin the float32 exponent clamp and the `std::pow(float, int)`-in-double behaviour that a naive port loses. An earlier revision also ran a differential against the llama.cpp binary with no disagreements, but that harness and its logs no longer exist and it is not offered as evidence.
- No serving path has been exercised. Every run above drives the offline `LLM` API, so `/v1/chat/completions`, concurrent and mixed batches, and end-to-end throughput are unmeasured.
- Four things are not measured on this code: step cost per batch size, peak GPU memory of the penalty path, a two-arm control over nine sampler suites against pristine main, and a cross-build check that a request without DRY produces token ids identical to an unpatched engine. All four were last run at base `4be3dcf0fc`, against the pre-#56497 sampler. Re-running the nine-suite control and the cross-build opt-out check against `5302d1fe40` is machine time rather than design, and it is what remains before this PR asks for `ready`. Inside the suite, `test_v2_disabled_and_gating` pins the disabled path and `test_peak_memory_bounded` bounds the scan's transient.
- This box has one 8 GB consumer card, so there is no large-model or throughput evidence here.

An older snapshot of this work, with its documentation and verification scripts, is published as a standalone patch pinned to an older base, for operators who want the feature before this is reviewed: https://github.com/sashko-zakharchuk/vllm/tree/dry-sampling-410f6da5c4/dry-patch . It predates both the synchronization removal and this port.
