### PR TITLE
[CI][Test] Seed the DeepEP v2 MoE workers, not just the parent

### DIFF
--- a/tests/kernels/moe/test_deepep_v2_moe.py
+++ b/tests/kernels/moe/test_deepep_v2_moe.py
@@ -235,6 +235,10 @@ def _deep_ep_v2_moe(
         w2_scale = w2_scale.to(device=device_idx)
 
     pg = torch.distributed.new_group(list(range(pgi.world_size)))
+    # The caller's set_random_seed() only seeds the parent; spawn() gives each
+    # worker a fresh unseeded RNG, so seed here too or the inputs below differ
+    # every run. Offset by rank to keep the ranks' data distinct.
+    set_random_seed(7 + pgi.rank)
     test_tensors = TestTensors.make(config)
 
     with set_current_vllm_config(VllmConfig()):
@@ -373,6 +377,7 @@ def _deep_ep_v2_moe_cudagraph(
     init_workspace_manager(device)
 
     pg = torch.distributed.new_group(list(range(pgi.world_size)))
+    set_random_seed(7 + pgi.rank)
     test_tensors = TestTensors.make(config)
     num_local_experts = config.num_experts // pgi.world_size
     hidden_size = config.k


### PR DESCRIPTION

## Purpose

Fixes the nondeterminism behind #50184, where
`kernels/moe/test_deepep_v2_moe.py::test_deep_ep_v2_moe` fails intermittently
with:

```
AssertionError: Only 98.2% of FP8 outputs are within tolerance
```

**The test seeds the wrong process.** `test_deep_ep_v2_moe` calls
`set_random_seed(7)` at line 328, which runs in the parent and covers
`make_test_weights()`. But the tensors the assertion actually depends on are
built in the worker — `_deep_ep_v2_moe()` calls `TestTensors.make(config)` at
line 238, which uses `torch.randn` for `rank_tokens`/`topk_weights` and
`torch.randperm` for `topk`. `parallel_launch()` starts workers with
`torch.multiprocessing.spawn`, and neither `parallel_utils.py` nor the worker
seeds anything, so each worker begins with a fresh unseeded RNG.

So the inputs differ on every run while the weights stay fixed, and
`assert_fp8_close` is a hard threshold (`close_fraction > 0.99` at
`atol=rtol=2e-1`). Marginal runs land just under it.

This seeds inside both worker entry points, offset by `pgi.rank` so the ranks
still get distinct data rather than identical copies.

I deliberately did **not** widen the tolerance or lower the 0.99 floor — that
would hide the signal rather than fix it.

## Test Plan

The mechanism reproduces without a GPU or DeepEP, using the same primitives the
test uses (parent seeded with 7 before each of 3 runs):

```
parent-only (main today)     -> 3 runs identical: False
seeded in worker (this PR)   -> 3 runs identical: True
```

with `rank0 != rank1` preserved in both modes, and the seeded values stable
across separate invocations.

`pre-commit run --files tests/kernels/moe/test_deepep_v2_moe.py` — all hooks
pass.

## Test Result

**I have not been able to run the test itself.** It requires 2 GPUs *and* DeepEP
v2 (`ElasticBuffer`), which is not available in my environment, so
`requires_deep_ep_v2` skips it.

That means this PR makes the test **reproducible**, which is a precondition for
diagnosing #50184 — but it does not by itself prove the numerics are fine on the
failing configuration
(`world_dp_size0-6-32-3-1024-2048-dtype1`). If CI shows the seeded run failing
consistently, that is a far better bug report than the current intermittent one,
and the right follow-up is to look at the FP8 path rather than the test.

I would appreciate a reviewer with B200 access confirming the seeded run's
behaviour.

## Notes

- Not a duplicate: #50184 has no comments and no open PR references it or touches
  `test_deepep_v2_moe.py`.
- AI assistance was used for the root-cause analysis and the reproduction script;
  I have reviewed every changed line.
