### PR TITLE
[UX] Reduce startup log noise

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1142,11 +1142,6 @@ class VllmConfig:
             else:
                 self.scheduler_config.async_scheduling = True
 
-        logger.info_once(
-            "Asynchronous scheduling is %s.",
-            "enabled" if self.scheduler_config.async_scheduling else "disabled",
-        )
-
         if self.parallel_config.disable_nccl_for_dp_synchronization is None:
             if self.scheduler_config.async_scheduling:
                 if self.parallel_config.data_parallel_size > 1 and (
@@ -1196,7 +1191,7 @@ class VllmConfig:
             )
 
         if self.model_config is not None and self.model_config.enforce_eager:
-            logger.warning(
+            logger.warning_once(
                 "Enforce eager set, disabling torch.compile and CUDAGraphs. "
                 "This is equivalent to setting -cc.mode=none -cc.cudagraph_mode=none"
             )
@@ -1204,7 +1199,7 @@ class VllmConfig:
             self.compilation_config.cudagraph_mode = CUDAGraphMode.NONE
 
         if os.environ.get("TORCH_COMPILE_DISABLE") == "1":
-            logger.warning(
+            logger.warning_once(
                 "TORCH_COMPILE_DISABLE is set, disabling torch.compile. "
                 "This is equivalent to setting -cc.mode=none"
             )
@@ -1249,7 +1244,7 @@ class VllmConfig:
             self.compilation_config.mode is not None
             and self.compilation_config.mode != CompilationMode.VLLM_COMPILE
         ):
-            logger.warning(
+            logger.warning_once(
                 "Inductor compilation was disabled by user settings, "
                 "optimizations settings that are only active during "
                 "inductor compilation will be ignored."
@@ -1317,7 +1312,7 @@ class VllmConfig:
             and self.compilation_config.mode != CompilationMode.VLLM_COMPILE
             and not envs.VLLM_USE_BREAKABLE_CUDAGRAPH
         ):
-            logger.info(
+            logger.info_once(
                 "Cudagraph mode %s is not compatible with compilation mode %s."
                 "Overriding to NONE.",
                 self.compilation_config.cudagraph_mode,
@@ -1331,7 +1326,7 @@ class VllmConfig:
             pass_config.enable_sp = True
         if pass_config.enable_sp:
             if self.parallel_config.tensor_parallel_size == 1:
-                logger.warning("Sequence Parallelism requires TP>1, disabling")
+                logger.warning_once("Sequence Parallelism requires TP>1, disabling")
                 pass_config.enable_sp = False
                 pass_config.fuse_gemm_comms = False
             else:
@@ -1349,7 +1344,7 @@ class VllmConfig:
                     )
 
                 if pass_config.sp_min_token_num is None:
-                    logger.warning(
+                    logger.warning_once(
                         "Model hidden_size too small for the SP "
                         "threshold heuristic, disabling. To force SP, "
                         "set pass_config.sp_min_token_num manually."
@@ -1428,7 +1423,7 @@ class VllmConfig:
 
             # disable cudagraph when enforce eager execution
             if self.model_config is not None and self.model_config.enforce_eager:
-                logger.info("Cudagraph is disabled under eager mode")
+                logger.info_once("Cudagraph is disabled under eager mode")
                 self.compilation_config.cudagraph_mode = CUDAGraphMode.NONE
                 # override related settings when enforce eager
                 self.compilation_config.max_cudagraph_capture_size = 0
@@ -1463,7 +1458,7 @@ class VllmConfig:
             and self.model_config.architecture == "WhisperForConditionalGeneration"
             and os.environ.get("VLLM_WORKER_MULTIPROC_METHOD") != "spawn"
         ):
-            logger.warning(
+            logger.warning_once(
                 "Whisper is known to have issues with "
                 "forked workers. If startup is hanging, "
                 "try setting 'VLLM_WORKER_MULTIPROC_METHOD' "
@@ -1475,7 +1470,7 @@ class VllmConfig:
             and self.kv_events_config.enable_kv_cache_events
             and not self.cache_config.enable_prefix_caching
         ):
-            logger.warning(
+            logger.warning_once(
                 "KV cache events are on, but prefix caching is not enabled. "
                 "Use --enable-prefix-caching to enable."
             )
@@ -1484,7 +1479,7 @@ class VllmConfig:
             and self.kv_events_config.publisher != "null"
             and not self.kv_events_config.enable_kv_cache_events
         ):
-            logger.warning(
+            logger.warning_once(
                 "KV cache events are disabled, "
                 "but the scheduler is configured to publish them. "
                 "Modify KVEventsConfig.enable_kv_cache_events "
@@ -1522,7 +1517,7 @@ class VllmConfig:
             # the pass will operate on higher-level IR to avoid the issue.
             # TODO: https://github.com/vllm-project/vllm/issues/27894
             if self.compilation_config.mode != CompilationMode.VLLM_COMPILE:
-                logger.warning(
+                logger.warning_once(
                     "Sequence parallelism is enabled, but running in wrong "
                     "vllm compile mode: %s.",
                     self.compilation_config.mode,

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -107,7 +107,7 @@ class CustomAllreduce:
         if not custom_ar:
             # disable because of missing custom allreduce library
             # e.g. in a non-GPU environment
-            logger.info(
+            logger.info_once(
                 "Custom allreduce is disabled because "
                 "of missing custom allreduce library"
             )
@@ -130,7 +130,7 @@ class CustomAllreduce:
             return
 
         if world_size not in CustomAllreduce._SUPPORTED_WORLD_SIZES:
-            logger.warning(
+            logger.warning_once(
                 "Custom allreduce is disabled due to an unsupported world"
                 " size: %d. Supported world sizes: %s. To silence this "
                 "warning, specify disable_custom_all_reduce=True explicitly.",
@@ -328,7 +328,7 @@ class CustomAllreduce:
 
     def register_graph_buffers(self):
         handle, offset = ops.get_graph_buffer_ipc_meta(self._ptr)
-        logger.info("Registering %d cuda graph addresses", len(offset))
+        logger.debug("Registering %d cuda graph addresses", len(offset))
         # We cannot directly use `dist.all_gather_object` here
         # because it is incompatible with `gloo` backend under inference mode.
         # see https://github.com/pytorch/pytorch/issues/126032 for details.

--- a/vllm/distributed/device_communicators/flashinfer_all_reduce.py
+++ b/vllm/distributed/device_communicators/flashinfer_all_reduce.py
@@ -121,7 +121,7 @@ def _resolve_fi_ar_backend() -> tuple[str, bool]:
     """
     backend = envs.VLLM_FLASHINFER_ALLREDUCE_BACKEND
     if backend != "auto":
-        logger.info_once(f"Using flashinfer allreduce backend: {backend}")
+        logger.debug_once("Using flashinfer allreduce backend: %s", backend)
         return backend, False
 
     # Default to mnnvl for both single- and multi-node setups. The mnnvl
@@ -134,7 +134,7 @@ def _resolve_fi_ar_backend() -> tuple[str, bool]:
     backend = "mnnvl"
     allow_trtllm_fallback = get_node_count() == 1
 
-    logger.info_once(f"Auto-selected flashinfer allreduce backend: {backend}")
+    logger.debug_once("Auto-selected flashinfer allreduce backend: %s", backend)
     return backend, allow_trtllm_fallback
 
 

--- a/vllm/model_executor/warmup/cutedsl_warmup.py
+++ b/vllm/model_executor/warmup/cutedsl_warmup.py
@@ -8,7 +8,6 @@
 
 from __future__ import annotations
 
-import time
 import weakref
 from collections.abc import Callable, Hashable, Iterable
 from dataclasses import dataclass
@@ -97,25 +96,17 @@ def _compile_cutedsl_warmup_units(
 def cutedsl_warmup() -> None:
     """Run CuTeDSL compile providers before serving."""
     if not current_platform.is_cuda():
-        logger.info("Skipping CuTeDSL warmup on non-CUDA platform.")
+        logger.debug("Skipping CuTeDSL warmup on non-CUDA platform.")
         return
 
     compile_units = _collect_unique_compile_units(_iter_cutedsl_warmup_compile_units())
     if not compile_units:
-        logger.info("Skipping CuTeDSL warmup because no compile units were requested.")
+        logger.debug("Skipping CuTeDSL warmup because no compile units were requested.")
         return
 
-    unit_names = list(dict.fromkeys(unit.name for unit in compile_units))
-    logger.info(
+    logger.info_once(
         "Warming up CuTeDSL compile_units=%d names=%s.",
         len(compile_units),
-        unit_names,
+        tuple(dict.fromkeys(unit.name for unit in compile_units)),
     )
-
-    start_time = time.perf_counter()
-    compiled_count = _compile_cutedsl_warmup_units(compile_units)
-    logger.info(
-        "CuTeDSL warmup compiled %d units in %.2f s.",
-        compiled_count,
-        time.perf_counter() - start_time,
-    )
+    _compile_cutedsl_warmup_units(compile_units)

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -84,12 +84,12 @@ def _warmup_ll_bf16_router_gemm(model: torch.nn.Module) -> None:
 
     shapes = _ll_bf16_router_shapes_from_model(model)
     if not shapes:
-        logger.info(
+        logger.debug_once(
             "Skipping ll_bf16 router GEMM warmup: no bf16 GateLinear shapes found."
         )
         return
 
-    logger.info("Warming up ll_bf16 router GEMM kernels for shapes: %s.", shapes)
+    logger.info_once("Warming up ll_bf16 router GEMM kernels for shapes: %s.", shapes)
     ll_bf16_gemm_kernel.warmup(
         shapes=shapes,
         m_values=_LL_BF16_WARMUP_M_RANGE,
@@ -163,7 +163,7 @@ def kernel_warmup(worker: "Worker", *, process_local_only: bool = False):
     )
     # FlashInfer autotune for Hopper (SM 9.0) and Blackwell (SM 10.0) GPUs
     if enable_flashinfer_autotune is False:
-        logger.info("Skipping FlashInfer autotune because it is disabled.")
+        logger.info_once("Skipping FlashInfer autotune because it is disabled.")
     elif has_flashinfer() and current_platform.has_device_capability(90):
         flashinfer_autotune(worker.model_runner)
 
@@ -188,7 +188,7 @@ def kernel_warmup(worker: "Worker", *, process_local_only: bool = False):
             for group in groups
         )
     ):
-        logger.info("Warming up FlashInfer attention.")
+        logger.info_once("Warming up FlashInfer attention.")
         # Warmup with mixed batch containing both prefill and decode tokens
         # This is to warm up both prefill and decode attention kernels
         worker.model_runner._dummy_run(
@@ -238,9 +238,9 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
     autotune_kwargs: dict = {}
     skip_ops = _flashinfer_autotune_skip_ops(runner)
     if skip_ops:
-        logger.info(
+        logger.info_once(
             "Skipping FlashInfer autotuning for ops %s",
-            sorted(skip_ops),
+            tuple(sorted(skip_ops)),
         )
         autotune_kwargs["skip_ops"] = skip_ops
 
@@ -265,7 +265,7 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
 
     cache_path = resolve_flashinfer_autotune_file(runner)
     if is_leader:
-        logger.info("Using FlashInfer autotune cache file: %s", cache_path)
+        logger.info_once("Using FlashInfer autotune cache file: %s", cache_path)
 
     # We skip EPLB here since we don't want to record dummy metrics.
     # When autotuning with number of tokens m, flashinfer will autotune
@@ -296,9 +296,9 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
     tune_results = world.broadcast_object(tune_results, src=0)
 
     if tune_results is None:
-        logger.warning(
-            "No FlashInfer autotune cache entries found."
-            "Falling back to default tactics."
+        logger.warning_once(
+            "No FlashInfer autotune cache entries found; "
+            "falling back to default tactics."
         )
     else:
         write_flashinfer_autotune_cache(cache_path, tune_results)
@@ -306,7 +306,7 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
         from flashinfer.autotuner import AutoTuner
 
         AutoTuner.get().load_configs(str(cache_path))
-        logger.info(
+        logger.info_once(
             "FlashInfer autotune cache loaded on rank %d from %s.",
             world.rank_in_group,
             cache_path,

--- a/vllm/utils/system_utils.py
+++ b/vllm/utils/system_utils.py
@@ -284,7 +284,7 @@ def kill_process_tree(pid: int):
 # Adapted from: https://github.com/sgl-project/sglang/blob/v0.4.1/python/sglang/srt/utils.py#L630
 def set_ulimit(target_soft_limit: int = 65535):
     if sys.platform.startswith("win"):
-        logger.info("Windows detected, skipping ulimit adjustment.")
+        logger.debug("Windows detected, skipping ulimit adjustment.")
         return
 
     import resource

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -87,7 +87,7 @@ def get_kv_cache_layout():
     cache_layout: Literal["NHD", "HND"] | None = None
     if _KV_CACHE_LAYOUT_OVERRIDE is not None:
         cache_layout = _KV_CACHE_LAYOUT_OVERRIDE
-        logger.info_once(
+        logger.debug_once(
             "`_KV_CACHE_LAYOUT_OVERRIDE` variable detected. "
             "Setting KV cache layout to %s.",
             cache_layout,

--- a/vllm/v1/attention/selector.py
+++ b/vllm/v1/attention/selector.py
@@ -199,7 +199,7 @@ def _cached_get_attn_backend(
         from vllm.v1.attention.backends.utils import set_kv_cache_layout
 
         set_kv_cache_layout(required_layout)
-        logger.info(
+        logger.info_once(
             "Using %s KV cache layout for %s backend.",
             required_layout,
             backend.get_name(),

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -292,7 +292,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         eplb_models_added = False
         with DeviceMemoryProfiler() as m:
             model_loader = get_model_loader(self.vllm_config.load_config)
-            logger.info("Loading model from scratch...")
+            logger.info_once("Loading model from scratch...")
 
             self.model = model_loader.load_model(
                 vllm_config=self.vllm_config, model_config=self.vllm_config.model_config


### PR DESCRIPTION
## Summary

- remove the default asynchronous-scheduling status log
- emit repeated configuration and warmup messages once per process
- move routine backend-selection, registration, and no-op details to DEBUG
- preserve warnings whose content may differ by rank

This only changes logging; serving behavior and model outputs are unchanged.

## Duplicate-work check

Searched open PRs for `startup logging`, `log noise`, and `GPU KV cache size`.

- #50462 overlaps with KV-cache capacity logging, so the local `kv_cache_utils.py` consolidation was intentionally excluded from this PR.
- #50174 restructures warmup infrastructure; this PR only adjusts existing log levels and repetition.
- #48133 adds component tags to `torch.compile` logs and does not overlap this scoped cleanup.

No linked issue was provided for this change.

## Validation

- `pre-commit run` via the commit hooks: passed (including Ruff, mypy, config validation, and sign-off validation)
- `.venv/bin/python -m pytest tests/test_config.py::test_async_scheduling_with_pipeline_parallelism_is_allowed tests/kernels/attention/test_attention_selector.py -q`: 30 passed, 10 skipped
- `git diff --cached --check`: passed before commit
- Model evaluation: not applicable; this is a logging-only change.

## AI assistance

This draft was prepared with OpenAI Codex assistance. Before marking it ready, the human submitter will review every changed line and be prepared to explain and maintain the change.
