### PR TITLE
[Bugfix][V1][Spec Decode] Hybrid-Mamba P/D: unpad the first handoff step

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1577,6 +1577,65 @@ def test_spec_decode_padding_first_decode_step():
     assert out.scheduled_spec_decode_tokens[r2.request_id] == [-1] * num_spec
 
 
+@pytest.mark.parametrize(
+    ("kv_role", "expect_placeholder_drafts"),
+    [
+        pytest.param("kv_consumer", False, id="disagg-consumer"),
+        pytest.param("kv_both", True, id="aggregated-both"),
+    ],
+)
+def test_mamba_first_fallback_spec_padding_scope(
+    kv_role: str,
+    expect_placeholder_drafts: bool,
+):
+    """Only a P/D Mamba decoder's N-1 fallback skips spec padding.
+
+    The steady request still validates its actual drafts. The joining fallback
+    has no output yet and starts at prompt_len - 1, matching a decoder worker
+    after a hybrid-Mamba remote KV handoff. It must not be converted into fake
+    -1 speculative rows merely to preserve the uniform FULL cudagraph shape.
+    An aggregated (``kv_both``) worker retains the normal padding behavior.
+    """
+    num_spec = 3
+    block_size = 16
+    scheduler = create_scheduler(
+        num_speculative_tokens=num_spec,
+        enable_prefix_caching=True,
+        block_size=block_size,
+        use_kv_connector=mock_kv(0, False),
+        kv_role=kv_role,
+        kv_cache_spec=MambaSpec(
+            block_size=block_size,
+            shapes=((1, 1),),
+            dtypes=(torch.float32,),
+            mamba_cache_mode="all",
+        ),
+    )
+    r1, r2 = create_requests(
+        num_requests=2, num_tokens=33, same_prompt=True, max_tokens=16
+    )
+
+    scheduler.add_request(r1)
+    out = scheduler.schedule()
+    assert out.num_scheduled_tokens[r1.request_id] == 33
+    _model_output(scheduler, out, [[100]])
+    scheduler.update_draft_token_ids(DraftTokenIds([r1.request_id], [[1, 2, 3]]))
+
+    scheduler.add_request(r2)
+    out = scheduler.schedule()
+
+    assert out.scheduled_spec_decode_tokens[r1.request_id] == [1, 2, 3]
+    assert r2.num_output_tokens == 0
+    assert r2.num_computed_tokens == r2.num_prompt_tokens - 1
+    assert out.num_scheduled_tokens[r2.request_id] == (
+        1 + num_spec if expect_placeholder_drafts else 1
+    )
+    if expect_placeholder_drafts:
+        assert out.scheduled_spec_decode_tokens[r2.request_id] == [-1] * num_spec
+    else:
+        assert r2.request_id not in out.scheduled_spec_decode_tokens
+
+
 def test_spec_decode_padding_skipped_for_diffusion():
     """Diffusion spec tokens are the fixed-size denoising canvas, not
     rejectable drafts: a first-decode-step request must keep its 1-token span

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1587,22 +1587,19 @@ def test_spec_decode_padding_first_decode_step():
 def test_mamba_first_fallback_spec_padding_scope(
     kv_role: str,
     expect_placeholder_drafts: bool,
+    monkeypatch: pytest.MonkeyPatch,
 ):
-    """Only a P/D Mamba decoder's N-1 fallback skips spec padding.
+    """Only a P/D Mamba handoff skips speculative padding."""
+    from tests.v1.kv_connector.unit.utils import create_model_runner_output
 
-    The steady request still validates its actual drafts. The joining fallback
-    has no output yet and starts at prompt_len - 1, matching a decoder worker
-    after a hybrid-Mamba remote KV handoff. It must not be converted into fake
-    -1 speculative rows merely to preserve the uniform FULL cudagraph shape.
-    An aggregated (``kv_both``) worker retains the normal padding behavior.
-    """
     num_spec = 3
     block_size = 16
+    num_prompt_tokens = 33
     scheduler = create_scheduler(
         num_speculative_tokens=num_spec,
-        enable_prefix_caching=True,
+        enable_prefix_caching=False,
         block_size=block_size,
-        use_kv_connector=mock_kv(0, False),
+        use_kv_connector=mock_kv(num_prompt_tokens, True),
         kv_role=kv_role,
         kv_cache_spec=MambaSpec(
             block_size=block_size,
@@ -1612,21 +1609,42 @@ def test_mamba_first_fallback_spec_padding_scope(
         ),
     )
     r1, r2 = create_requests(
-        num_requests=2, num_tokens=33, same_prompt=True, max_tokens=16
+        num_requests=2, num_tokens=num_prompt_tokens, max_tokens=16
     )
 
+    # Promote r1 through its remote-KV handoff, then make it a steady MTP decode.
     scheduler.add_request(r1)
+    _step_until_kv_transfer_finished(scheduler, [r1.request_id])
     out = scheduler.schedule()
-    assert out.num_scheduled_tokens[r1.request_id] == 33
+    assert out.num_scheduled_tokens[r1.request_id] == 1
     _model_output(scheduler, out, [[100]])
     scheduler.update_draft_token_ids(DraftTokenIds([r1.request_id], [[1, 2, 3]]))
 
+    # Complete r2's full remote-KV transfer while r1 verifies real drafts.
     scheduler.add_request(r2)
     out = scheduler.schedule()
-
     assert out.scheduled_spec_decode_tokens[r1.request_id] == [1, 2, 3]
+    assert r2.status == RequestStatus.WAITING_FOR_REMOTE_KVS
+    scheduler.update_from_output(
+        out,
+        create_model_runner_output([r1], finished_recving={r2.request_id}),
+    )
+    scheduler.update_draft_token_ids(DraftTokenIds([r1.request_id], [[4, 5, 6]]))
+
+    post_handoff_computed_tokens: list[int] = []
+    update_waiting_for_remote_kv = scheduler._update_waiting_for_remote_kv
+
+    def capture_handoff(request: Request) -> None:
+        update_waiting_for_remote_kv(request)
+        if request is r2:
+            post_handoff_computed_tokens.append(request.num_computed_tokens)
+
+    monkeypatch.setattr(scheduler, "_update_waiting_for_remote_kv", capture_handoff)
+    out = scheduler.schedule()
+
     assert r2.num_output_tokens == 0
-    assert r2.num_computed_tokens == r2.num_prompt_tokens - 1
+    assert post_handoff_computed_tokens == [r2.num_prompt_tokens - 1]
+    assert out.scheduled_spec_decode_tokens[r1.request_id] == [4, 5, 6]
     assert out.num_scheduled_tokens[r2.request_id] == (
         1 + num_spec if expect_placeholder_drafts else 1
     )

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1578,16 +1578,18 @@ def test_spec_decode_padding_first_decode_step():
 
 
 @pytest.mark.parametrize(
-    ("kv_role", "mamba_cache_mode"),
+    ("kv_role", "mamba_cache_mode", "num_preemptions"),
     [
-        pytest.param("kv_consumer", "all", id="consumer-all"),
-        pytest.param("kv_both", "all", id="both-all"),
-        pytest.param("kv_both", "align", id="both-align"),
+        pytest.param("kv_consumer", "all", 0, id="consumer-all"),
+        pytest.param("kv_both", "all", 0, id="both-all"),
+        pytest.param("kv_both", "align", 0, id="both-align"),
+        pytest.param("kv_both", "align", 1, id="both-align-preempted"),
     ],
 )
 def test_mamba_first_fallback_spec_padding_scope(
     kv_role: str,
     mamba_cache_mode: str,
+    num_preemptions: int,
     monkeypatch: pytest.MonkeyPatch,
 ):
     """A remote-KV handoff step skips speculative padding for ANY kv_role.
@@ -1598,7 +1600,13 @@ def test_mamba_first_fallback_spec_padding_scope(
     kv_role == "kv_consumer" is False on both. A disaggregated deployment may
     configure "kv_both" on BOTH roles, and is then indistinguishable from an
     aggregated one by role alone -- so the handoff must be detected per request
-    and every case here expects the same unpadded step."""
+    and every case here expects the same unpadded step.
+
+    num_preemptions > 0 makes promotion leave the request PREEMPTED rather than
+    WAITING. That is a true handoff too -- a request can be preempted, put back
+    into a fresh async remote-KV load, and promoted when that load finishes -- so
+    it must also skip the padding. It does, because the predicate keys on the
+    per-request marker rather than on the request status."""
     from tests.v1.kv_connector.unit.utils import create_model_runner_output
 
     num_spec = 3
@@ -1649,6 +1657,7 @@ def test_mamba_first_fallback_spec_padding_scope(
             post_handoff_computed_tokens.append(request.num_computed_tokens)
 
     monkeypatch.setattr(scheduler, "_update_waiting_for_remote_kv", capture_handoff)
+    r2.num_preemptions = num_preemptions
     out = scheduler.schedule()
 
     assert r2.num_output_tokens == 0
@@ -1658,6 +1667,63 @@ def test_mamba_first_fallback_spec_padding_scope(
     assert r2.received_remote_kv is True
     assert out.num_scheduled_tokens[r2.request_id] == 1
     assert r2.request_id not in out.scheduled_spec_decode_tokens
+
+
+def test_mamba_spec_padding_kept_without_remote_kv_handoff():
+    """Scope control: on a hybrid-Mamba model a LOCAL first decode step still pads.
+
+    Same shape as the handoff step (whole prompt already computed, one real
+    query, a co-batched neighbour verifying real drafts) and same
+    has_mamba_layers, but the prompt came from the local prefix cache rather
+    than a remote prefill. Dropping the per-request conjunct would widen the
+    gate to this step and cost every hybrid model its FULL decode graph replay,
+    so this pins the gate to the handoff itself.
+    """
+    num_spec = 3
+    block_size = 16
+    scheduler = create_scheduler(
+        num_speculative_tokens=num_spec,
+        enable_prefix_caching=True,
+        block_size=block_size,
+        kv_cache_spec=MambaSpec(
+            block_size=block_size,
+            shapes=((1, 1),),
+            dtypes=(torch.float32,),
+            mamba_cache_mode="all",
+        ),
+    )
+    # Two identical 33-token prompts: r2 then arrives at
+    # num_computed == num_prompt_tokens - 1 -- the handoff step's shape, locally.
+    r1, r2 = create_requests(
+        num_requests=2, num_tokens=33, same_prompt=True, max_tokens=16
+    )
+    # Mamba's block-aligned split chunks the prompt at the last cacheable block
+    # boundary, so drive the prefill to the end rather than assuming one step.
+    scheduler.add_request(r1)
+    while True:
+        out = scheduler.schedule()
+        last = (
+            r1.num_computed_tokens + out.num_scheduled_tokens[r1.request_id]
+            >= r1.num_prompt_tokens
+        )
+        _model_output(scheduler, out, [[100]] if last else [[]])
+        if last:
+            break
+    scheduler.update_draft_token_ids(DraftTokenIds([r1.request_id], [[1, 2, 3]]))
+
+    scheduler.add_request(r2)
+    out = scheduler.schedule()
+
+    # getattr, not attribute access: this control must also run against an
+    # engine that does not define the marker at all.
+    assert getattr(r2, "received_remote_kv", False) is False
+    assert r2.num_output_tokens == 0
+    # NB: assert on the scheduler OUTPUT, not request.num_computed_tokens --
+    # schedule() advances that optimistically before returning.
+    assert out.scheduled_spec_decode_tokens[r1.request_id] == [1, 2, 3]
+    # Still padded: no remote-KV handoff, so the gate must not fire.
+    assert out.num_scheduled_tokens[r2.request_id] == 1 + num_spec
+    assert out.scheduled_spec_decode_tokens[r2.request_id] == [-1] * num_spec
 
 
 def test_spec_decode_padding_skipped_for_diffusion():

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1578,18 +1578,27 @@ def test_spec_decode_padding_first_decode_step():
 
 
 @pytest.mark.parametrize(
-    ("kv_role", "expect_placeholder_drafts"),
+    ("kv_role", "mamba_cache_mode"),
     [
-        pytest.param("kv_consumer", False, id="disagg-consumer"),
-        pytest.param("kv_both", True, id="aggregated-both"),
+        pytest.param("kv_consumer", "all", id="consumer-all"),
+        pytest.param("kv_both", "all", id="both-all"),
+        pytest.param("kv_both", "align", id="both-align"),
     ],
 )
 def test_mamba_first_fallback_spec_padding_scope(
     kv_role: str,
-    expect_placeholder_drafts: bool,
+    mamba_cache_mode: str,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """Only a P/D Mamba handoff skips speculative padding."""
+    """A remote-KV handoff step skips speculative padding for ANY kv_role.
+
+    kv_role is parametrized because it is an INSTANCE-level knob that cannot
+    identify the decode side: "kv_both" is a member of both KVProducer and
+    KVConsumer, so is_kv_consumer() is True on the prefill instance too, while
+    kv_role == "kv_consumer" is False on both. A disaggregated deployment may
+    configure "kv_both" on BOTH roles, and is then indistinguishable from an
+    aggregated one by role alone -- so the handoff must be detected per request
+    and every case here expects the same unpadded step."""
     from tests.v1.kv_connector.unit.utils import create_model_runner_output
 
     num_spec = 3
@@ -1605,7 +1614,7 @@ def test_mamba_first_fallback_spec_padding_scope(
             block_size=block_size,
             shapes=((1, 1),),
             dtypes=(torch.float32,),
-            mamba_cache_mode="all",
+            mamba_cache_mode=mamba_cache_mode,
         ),
     )
     r1, r2 = create_requests(
@@ -1645,13 +1654,10 @@ def test_mamba_first_fallback_spec_padding_scope(
     assert r2.num_output_tokens == 0
     assert post_handoff_computed_tokens == [r2.num_prompt_tokens - 1]
     assert out.scheduled_spec_decode_tokens[r1.request_id] == [4, 5, 6]
-    assert out.num_scheduled_tokens[r2.request_id] == (
-        1 + num_spec if expect_placeholder_drafts else 1
-    )
-    if expect_placeholder_drafts:
-        assert out.scheduled_spec_decode_tokens[r2.request_id] == [-1] * num_spec
-    else:
-        assert r2.request_id not in out.scheduled_spec_decode_tokens
+    # The handoff was identified per request, not from the instance-level role.
+    assert r2.received_remote_kv is True
+    assert out.num_scheduled_tokens[r2.request_id] == 1
+    assert r2.request_id not in out.scheduled_spec_decode_tokens
 
 
 def test_spec_decode_padding_skipped_for_diffusion():

--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -55,6 +55,7 @@ def create_scheduler(
     long_prefill_token_threshold: int = 0,
     disable_chunked_mm_input: bool = False,
     use_kv_connector: None | bool | str | MockKVConfig = None,
+    kv_role: str = "kv_both",
     num_blocks: int = 10000,
     block_size: int = 16,
     max_model_len: int | None = None,
@@ -115,7 +116,7 @@ def create_scheduler(
     if isinstance(use_kv_connector, MockKVConfig):
         kv_transfer_config = KVTransferConfig(
             kv_connector="MockKVConnector",
-            kv_role="kv_both",
+            kv_role=kv_role,
             kv_connector_extra_config={
                 "matched_tokens": use_kv_connector.matched_tokens,
                 "is_async": use_kv_connector.is_async,
@@ -127,12 +128,12 @@ def create_scheduler(
     elif isinstance(use_kv_connector, str):
         kv_transfer_config = KVTransferConfig(
             kv_connector=use_kv_connector,
-            kv_role="kv_both",
+            kv_role=kv_role,
         )
     elif use_kv_connector:
         kv_transfer_config = KVTransferConfig(
             kv_connector="ExampleConnector",
-            kv_role="kv_both",
+            kv_role=kv_role,
             kv_connector_extra_config={"shared_storage_path": "local_storage"},
         )
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -851,6 +851,17 @@ class Scheduler(SchedulerInterface):
                     # requests, which have output tokens.
                     num_new_tokens = request.num_tokens - num_computed_tokens
 
+                    # Hybrid-Mamba P/D decoders recompute the final prompt token.
+                    # Keep that one-token handoff step out of speculative padding.
+                    kv_transfer_config = self.vllm_config.kv_transfer_config
+                    is_disagg_mamba_first_fallback = (
+                        self.has_mamba_layers
+                        and kv_transfer_config is not None
+                        and kv_transfer_config.kv_role == "kv_consumer"
+                        and request.num_output_tokens == 0
+                        and num_computed_tokens == request.num_prompt_tokens - 1
+                    )
+
                     # Pad new decode requests to uniform spec decoding size to
                     # preserve full cudagraph for this step.
                     # Not for diffusion where draft tokens can't be padded.
@@ -859,6 +870,7 @@ class Scheduler(SchedulerInterface):
                         and self.num_sampled_tokens_per_step > 0
                         and num_new_tokens == 1
                         and (scheduled_running_reqs and not prefill_scheduled)
+                        and not is_disagg_mamba_first_fallback
                     ):
                         num_new_tokens = 1 + self.num_spec_tokens
                         if (

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -852,12 +852,23 @@ class Scheduler(SchedulerInterface):
                     num_new_tokens = request.num_tokens - num_computed_tokens
 
                     # Hybrid-Mamba P/D decoders recompute the final prompt token.
-                    # Keep that one-token handoff step out of speculative padding.
-                    kv_transfer_config = self.vllm_config.kv_transfer_config
+                    # Keep that one-token handoff step out of speculative padding:
+                    # padding it to 1 + num_spec with placeholder drafts makes it
+                    # look like a uniform decode batch, so it is replayed through
+                    # the captured FULL decode graph where the placeholder slots
+                    # read recurrent state belonging to co-batched neighbours.
+                    #
+                    # Keyed on the PER-REQUEST handoff marker rather than the
+                    # instance-level kv_role: "kv_both" is a member of both
+                    # KVProducer and KVConsumer, so a role check either fires on
+                    # the prefill instance too (is_kv_consumer) or never fires at
+                    # all (kv_role == "kv_consumer"). A disaggregated deployment
+                    # may configure "kv_both" on BOTH roles, which would make a
+                    # role-keyed predicate silently no-op on the real decode
+                    # worker.
                     is_disagg_mamba_first_fallback = (
                         self.has_mamba_layers
-                        and kv_transfer_config is not None
-                        and kv_transfer_config.kv_role == "kv_consumer"
+                        and request.received_remote_kv
                         and request.num_output_tokens == 0
                         and num_computed_tokens == request.num_prompt_tokens - 1
                     )
@@ -2647,6 +2658,12 @@ class Scheduler(SchedulerInterface):
             if request.request_id not in self.finished_recving_kv_req_ids:
                 return False
             self._update_waiting_for_remote_kv(request)
+            # Mark the decode side per request. The instance-level kv_role
+            # cannot do this: "kv_both" is a member of both KVProducer and
+            # KVConsumer, so is_kv_consumer is True on the prefill instance too
+            # and kv_role == "kv_consumer" is False on both. Only an instance
+            # that actually waited for remote KV reaches this point.
+            request.received_remote_kv = True
             if request.num_preemptions:
                 request.status = RequestStatus.PREEMPTED
             else:

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -102,6 +102,11 @@ class Request:
         self.kv_transfer_params: dict[str, Any] | None = None
         # E/P/D: Connector-specific encoder-cache transfer parameters.
         self.ec_transfer_params: dict[str, Any] | None = None
+        # P/D: set once this request's prompt KV arrived from a remote prefill
+        # instance (i.e. it left WAITING_FOR_REMOTE_KVS). Identifies the decode
+        # side per request, which the instance-level kv_role cannot do: kv_both
+        # satisfies both the producer and the consumer predicates.
+        self.received_remote_kv: bool = False
 
         if pooling_params is not None:
             # Pooling models.


### PR DESCRIPTION
## Purpose

Fix hybrid-Mamba P/D MTP's first decode step after a remote-KV handoff.

The connector rewinds the cursor one token so the final prompt token's SSM state is recomputed locally, so that step has **exactly one real query**. The scheduler padded it to `1 + num_spec` with synthetic `-1` drafts to keep a uniform shape for the captured **FULL** decode CUDA graph — and those placeholder slots then execute, reading recurrent state belonging to **co-batched neighbours**. Harmless at concurrency 1 (no neighbour); wrong at concurrency ≥ 2.

**Detected per request, not from `kv_role`.** `vllm/config/kv_transfer.py` has `KVProducer = ["kv_producer", "kv_both"]` and `KVConsumer = ["kv_consumer", "kv_both"]`, so under `kv_role="kv_both"` `is_kv_consumer()` is `True` on **prefill** too, while `kv_role == "kv_consumer"` matches **neither** role. A disaggregated deployment may set `kv_both` on **both** roles (the shipped Dynamo recipe does), so a role-keyed predicate silently no-ops on the real decode worker. The engine now warns that `kv_both` is deprecated in favour of per-role values; a per-request marker is correct both before and after that migration.

The request *status* cannot be used: `_try_promote_blocked_waiting_request()` clears `WAITING_FOR_REMOTE_KVS` **before** the padding decision in the same `schedule()` pass.

## Test Plan

**Unit**

```bash
pytest tests/v1/core/test_scheduler.py -k "mamba_first_fallback_spec_padding_scope or mamba_spec_padding_kept_without_remote_kv_handoff" -v
```

`test_mamba_first_fallback_spec_padding_scope` is parametrized over `(kv_role, mamba_cache_mode, num_preemptions)` — `consumer-all`, `both-all`, `both-align`, `both-align-preempted` — all expecting the same unpadded step, with a co-batched neighbour verifying **real** drafts. The `kv_both` cases fail against a `kv_role`-keyed predicate; the preempted case covers a promotion that lands in `PREEMPTED` rather than `WAITING`.
`test_mamba_spec_padding_kept_without_remote_kv_handoff` is the complement: a **local** prefix-cache-hit first decode step, same shape and same `has_mamba_layers`, must still be padded.

**End-to-end** — NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4 on GB200, disaggregated 1P1D over NIXL/MNNVL:

```bash
# both roles (identical except --disaggregation-mode); DS conv layout and symmetric
# spec are both required — asymmetric spec fails the NIXL handshake outright
export VLLM_SSM_CONV_STATE_LAYOUT=DS VLLM_ALLREDUCE_USE_SYMM_MEM=0 \
       VLLM_DISABLED_KERNELS=FlashInferFP8ScaledMMLinearKernel \
       VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE=1 \
       VLLM_WORKER_MULTIPROC_METHOD=spawn \
       NCCL_CUMEM_ENABLE=1 NCCL_NVLS_ENABLE=1 UCX_TLS=tcp,cuda_copy,cuda_ipc
ulimit -l unlimited
# NOTE: this UCX_TLS is for a single MNNVL/NVLink domain, where cuda_ipc carries the
# P->D transfer. On a MULTI-NODE cluster it excludes the RDMA verbs transports and forces
# every KV block onto TCP -- correctness is unaffected (this bug is transport-independent),
# but TTFT is not. Cross-node, use e.g. UCX_TLS=rc_x,rc,cuda_copy,cuda_ipc.

python3 -m dynamo.vllm \
  --model nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4 \
  --served-model-name nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4 \
  --tensor-parallel-size 4 --trust-remote-code --kv-cache-dtype fp8 \
  --max-model-len 32768 --max-num-seqs 64 --max-num-batched-tokens 32768 \
  --gpu-memory-utilization 0.9 --no-enable-flashinfer-autotune --block-size 64 \
  --no-enable-expert-parallel --enable-prefix-caching --no-async-scheduling \
  --mamba-cache-mode align --mamba-ssm-cache-dtype bfloat16 --mamba-backend triton \
  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' \
  --no-disable-hybrid-kv-cache-manager \
  --spec-method nemotron_h_mtp --spec-tokens 5 \
  --disaggregation-mode prefill        # <-- decode worker: --disaggregation-mode decode

# frontend
python3 -m dynamo.frontend --router-mode kv --router-kv-events \
  --kv-cache-block-size 64 --http-host 0.0.0.0 --http-port 8000
```

Then drive **concurrency 8** (2048-token prompts, 256-token outputs) and count empty completions. `--enable-prefix-caching` + `--mamba-cache-mode align` + FULL decode CUDA graphs (i.e. **not** `--enforce-eager`) are all required for the defect to appear. Repeat at concurrency 1, and aggregated, as controls.

## Test Result

**Unit.** Against the unpatched scheduler the handoff cases fail on every parameter; with the fix they pass, the scope
control passes on both, and no other test in the module changes state (152 tests, pinned nightly container). The failure against the unpatched engine is the point — it shows the test detects the defect rather than restating the patch.

**End-to-end**, empty completions:

| shape | handoff | neighbour | empty responses |
|---|---|---|---|
| aggregated, cc=8 | ✗ | ✓ | **0 / 496** |
| disaggregated, cc=1 | ✓ | ✗ | **0 / 24** |
| disaggregated, cc=8 | ✓ | ✓ | **16 / 48 (33.3%)** |
| disaggregated, cc=8 **+ fix** | ✓ | ✓ | **0 / 24** |

**Task-level accuracy (gsm8k)** — measured on **B200 / amd64, cross-node** `lm_eval` 0.4.9, `gsm8k`, `num_fewshot=0`, chat template applied, `limit=300`, `max_gen_toks=2048`, `num_concurrent=16`:

| arm | `exact_match,flexible-extract` | empty (`content: null`) responses |
|---|---|---|
| disaggregated, **without** the fix | **0.3633** ±0.0278 | **127 / 300 (42.3%)** |
| disaggregated, **with** the fix | **0.8333** ±0.0216 | **0 / 300** |
| aggregated (reference) | 0.8267 ±0.0219 | 0 / 300 |


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>


