### PR TITLE
[Kimi-K3][AMD] Return KDA and MLA projection outputs directly

### DIFF
--- a/tests/models/kimi_k3/test_amd_kda_direct_return.py
+++ b/tests/models/kimi_k3/test_amd_kda_direct_return.py
@@ -1,9 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
+
 import torch
 from torch import nn
 
+from vllm.models.kimi_k3.amd.kda import KimiK3DeltaAttention
 from vllm.models.kimi_k3.amd.linear import KimiDecoderLayer
 
 
@@ -16,6 +19,15 @@ class _ReturningAttention(nn.Module):
         self, hidden_states: torch.Tensor, positions: torch.Tensor
     ) -> torch.Tensor:
         return self.result
+
+
+class _TupleProjection(nn.Module):
+    def __init__(self, result: torch.Tensor) -> None:
+        super().__init__()
+        self.result = result
+
+    def forward(self, _: torch.Tensor) -> tuple[torch.Tensor, None]:
+        return self.result, None
 
 
 def _make_layer(self_attn: nn.Module) -> KimiDecoderLayer:
@@ -31,6 +43,30 @@ def test_kda_self_attention_returns_projection_storage_directly() -> None:
     layer = _make_layer(_ReturningAttention(projected))
 
     output = layer._run_self_attn(torch.arange(4), hidden_states)
+
+    assert output is projected
+    assert output.data_ptr() == projected.data_ptr()
+
+
+def test_k3_kda_forward_returns_output_projection_storage() -> None:
+    hidden_states = torch.randn(4, 8)
+    projected = torch.randn_like(hidden_states)
+
+    def fill_core_output(**kwargs: torch.Tensor) -> None:
+        kwargs["core_attn_out"].fill_(1)
+
+    attention = SimpleNamespace(
+        local_projection_size=4,
+        head_dim=2,
+        local_num_heads=2,
+        in_proj_padding=0,
+        in_proj_qkvgfab=_TupleProjection(torch.randn(4, 20)),
+        f_b_proj=_TupleProjection(torch.randn(4, 4)),
+        o_proj=_TupleProjection(projected),
+        _forward=fill_core_output,
+    )
+
+    output = KimiK3DeltaAttention.forward(attention, hidden_states, torch.arange(4))
 
     assert output is projected
     assert output.data_ptr() == projected.data_ptr()

--- a/tests/models/kimi_k3/test_amd_kda_direct_return.py
+++ b/tests/models/kimi_k3/test_amd_kda_direct_return.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+from torch import nn
+
+from vllm.models.kimi_k3.amd.linear import KimiDecoderLayer
+
+
+class _ReturningAttention(nn.Module):
+    def __init__(self, result: torch.Tensor) -> None:
+        super().__init__()
+        self.result = result
+
+    def forward(
+        self, hidden_states: torch.Tensor, positions: torch.Tensor
+    ) -> torch.Tensor:
+        return self.result
+
+
+class _WritingAttention(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.output: torch.Tensor | None = None
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        output: torch.Tensor,
+    ) -> None:
+        self.output = output
+        output.copy_(hidden_states + 1)
+
+
+def _make_layer(self_attn: nn.Module, writes_output: bool) -> KimiDecoderLayer:
+    layer = object.__new__(KimiDecoderLayer)
+    nn.Module.__init__(layer)
+    layer.self_attn = self_attn
+    layer._self_attn_writes_output = writes_output
+    return layer
+
+
+def test_kda_self_attention_returns_projection_storage_directly() -> None:
+    hidden_states = torch.randn(4, 8)
+    projected = torch.randn_like(hidden_states)
+    layer = _make_layer(_ReturningAttention(projected), writes_output=False)
+
+    output = layer._run_self_attn(torch.arange(4), hidden_states)
+
+    assert output is projected
+    assert output.data_ptr() == projected.data_ptr()
+
+
+def test_mla_self_attention_keeps_explicit_output_buffer() -> None:
+    hidden_states = torch.randn(4, 8)
+    attention = _WritingAttention()
+    layer = _make_layer(attention, writes_output=True)
+
+    output = layer._run_self_attn(torch.arange(4), hidden_states)
+
+    torch.testing.assert_close(output, hidden_states + 1)
+    assert attention.output is output
+    assert output.data_ptr() != hidden_states.data_ptr()

--- a/tests/models/kimi_k3/test_amd_mla_direct_return.py
+++ b/tests/models/kimi_k3/test_amd_mla_direct_return.py
@@ -4,16 +4,18 @@
 import torch
 from torch import nn
 
-from vllm.models.kimi_k3.amd.linear import KimiDecoderLayer
+from vllm.models.kimi_k3.amd.linear import KimiDecoderLayer, KimiMLAAttention
 
 
-class _ReturningAttention(nn.Module):
+class _DirectMLA(KimiMLAAttention):
     def __init__(self, result: torch.Tensor) -> None:
-        super().__init__()
+        nn.Module.__init__(self)
         self.result = result
 
     def forward(
-        self, hidden_states: torch.Tensor, positions: torch.Tensor
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
     ) -> torch.Tensor:
         return self.result
 
@@ -25,10 +27,10 @@ def _make_layer(self_attn: nn.Module) -> KimiDecoderLayer:
     return layer
 
 
-def test_kda_self_attention_returns_projection_storage_directly() -> None:
+def test_mla_self_attention_returns_projection_storage_directly() -> None:
     hidden_states = torch.randn(4, 8)
     projected = torch.randn_like(hidden_states)
-    layer = _make_layer(_ReturningAttention(projected))
+    layer = _make_layer(_DirectMLA(projected))
 
     output = layer._run_self_attn(torch.arange(4), hidden_states)
 

--- a/tests/models/kimi_k3/test_nvidia_kda_direct_return.py
+++ b/tests/models/kimi_k3/test_nvidia_kda_direct_return.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+from torch import nn
+
+from vllm.models.kimi_k3.nvidia.model import KimiDecoderLayer
+
+
+class _ReturningSharedKDA(nn.Module):
+    def __init__(self, result: torch.Tensor) -> None:
+        super().__init__()
+        self.result = result
+
+    def forward(
+        self, hidden_states: torch.Tensor, positions: torch.Tensor
+    ) -> torch.Tensor:
+        return self.result
+
+
+def test_low_rank_kda_caller_returns_projection_storage_directly() -> None:
+    hidden_states = torch.randn(4, 8)
+    projected = torch.randn_like(hidden_states)
+    layer = object.__new__(KimiDecoderLayer)
+    nn.Module.__init__(layer)
+    layer.self_attn = _ReturningSharedKDA(projected)
+
+    output = layer._run_self_attn(torch.arange(4), hidden_states)
+
+    assert output is projected
+    assert output.data_ptr() == projected.data_ptr()

--- a/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
@@ -328,8 +328,7 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
         self,
         hidden_states: torch.Tensor,
         positions: torch.Tensor,
-        output: torch.Tensor,
-    ) -> None:
+    ) -> torch.Tensor:
         num_tokens = hidden_states.size(0)
         projected_qkvgfab = self.in_proj_qkvgfab(hidden_states)[0]
         if self.use_full_rank_gate:
@@ -374,7 +373,7 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
             core_attn_out=core_attn_out,
         )
         core_attn_out = rearrange(core_attn_out, "1 n h d -> n (h d)")
-        output[:] = self.o_proj(core_attn_out)[0]
+        return self.o_proj(core_attn_out)[0]
 
     @eager_break_during_capture
     def _forward(

--- a/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
@@ -329,8 +329,7 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
         self,
         hidden_states: torch.Tensor,
         positions: torch.Tensor,
-        output: torch.Tensor,
-    ) -> None:
+    ) -> torch.Tensor:
         num_tokens = hidden_states.size(0)
         projected_qkvgfab = self.in_proj_qkvgfab(hidden_states)[0]
         if self.use_full_rank_gate:
@@ -375,7 +374,7 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
             core_attn_out=core_attn_out,
         )
         core_attn_out = rearrange(core_attn_out, "1 n h d -> n (h d)")
-        output[:] = self.o_proj(core_attn_out)[0]
+        return self.o_proj(core_attn_out)[0]
 
     @eager_break_during_capture
     def _forward(

--- a/vllm/models/kimi_k3/amd/kda.py
+++ b/vllm/models/kimi_k3/amd/kda.py
@@ -202,8 +202,7 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
         self,
         hidden_states: torch.Tensor,
         positions: torch.Tensor,
-        output: torch.Tensor,
-    ) -> None:
+    ) -> torch.Tensor:
         num_tokens = hidden_states.size(0)
         projected_qkvgfab = self.in_proj_qkvgfab(hidden_states)[0]
 
@@ -237,7 +236,7 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
             core_attn_out=core_attn_out,
         )
         core_attn_out = rearrange(core_attn_out, "1 n h d -> n (h d)")
-        output[:] = self.o_proj(core_attn_out)[0]
+        return self.o_proj(core_attn_out)[0]
 
     @eager_break_during_capture
     def _forward(

--- a/vllm/models/kimi_k3/amd/kda.py
+++ b/vllm/models/kimi_k3/amd/kda.py
@@ -260,8 +260,7 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
         self,
         hidden_states: torch.Tensor,
         positions: torch.Tensor,
-        output: torch.Tensor,
-    ) -> None:
+    ) -> torch.Tensor:
         num_tokens = hidden_states.size(0)
         projected_qkvgfab = self.in_proj_qkvgfab(hidden_states)[0]
 
@@ -295,7 +294,7 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
             core_attn_out=core_attn_out,
         )
         core_attn_out = rearrange(core_attn_out, "1 n h d -> n (h d)")
-        output[:] = self.o_proj(core_attn_out)[0]
+        return self.o_proj(core_attn_out)[0]
 
     @eager_break_during_capture
     def _forward(

--- a/vllm/models/kimi_k3/amd/linear.py
+++ b/vllm/models/kimi_k3/amd/linear.py
@@ -455,9 +455,8 @@ class KimiMLAAttention(nn.Module):
         self,
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
-        output: torch.Tensor,
-    ) -> None:
-        output[:] = self.mla_attn(positions, hidden_states)
+    ) -> torch.Tensor:
+        return self.mla_attn(positions, hidden_states)
 
 
 class KimiDecoderLayer(nn.Module):
@@ -494,7 +493,6 @@ class KimiDecoderLayer(nn.Module):
                     vllm_config,
                     prefix=f"{prefix}.self_attn",
                 )
-            self._self_attn_writes_output = False
         else:
             qk_nope_head_dim = config.qk_nope_head_dim
             qk_rope_head_dim = config.qk_rope_head_dim
@@ -522,7 +520,6 @@ class KimiDecoderLayer(nn.Module):
                 kv_lora_rank=kv_lora_rank,
                 use_nope=mla_use_nope,
             )
-            self._self_attn_writes_output = True
 
         if (
             self.is_moe
@@ -583,14 +580,6 @@ class KimiDecoderLayer(nn.Module):
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
-        if self._self_attn_writes_output:
-            output = torch.empty_like(hidden_states)
-            self.self_attn(
-                hidden_states=hidden_states,
-                positions=positions,
-                output=output,
-            )
-            return output
         return self.self_attn(
             hidden_states=hidden_states,
             positions=positions,

--- a/vllm/models/kimi_k3/amd/linear.py
+++ b/vllm/models/kimi_k3/amd/linear.py
@@ -494,6 +494,7 @@ class KimiDecoderLayer(nn.Module):
                     vllm_config,
                     prefix=f"{prefix}.self_attn",
                 )
+            self._self_attn_writes_output = False
         else:
             qk_nope_head_dim = config.qk_nope_head_dim
             qk_rope_head_dim = config.qk_rope_head_dim
@@ -521,6 +522,7 @@ class KimiDecoderLayer(nn.Module):
                 kv_lora_rank=kv_lora_rank,
                 use_nope=mla_use_nope,
             )
+            self._self_attn_writes_output = True
 
         if (
             self.is_moe
@@ -581,13 +583,18 @@ class KimiDecoderLayer(nn.Module):
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
-        attn_output = torch.empty_like(hidden_states)
-        self.self_attn(
+        if self._self_attn_writes_output:
+            output = torch.empty_like(hidden_states)
+            self.self_attn(
+                hidden_states=hidden_states,
+                positions=positions,
+                output=output,
+            )
+            return output
+        return self.self_attn(
             hidden_states=hidden_states,
             positions=positions,
-            output=attn_output,
         )
-        return attn_output
 
     def forward(
         self,

--- a/vllm/models/kimi_k3/amd/linear.py
+++ b/vllm/models/kimi_k3/amd/linear.py
@@ -592,12 +592,18 @@ class KimiDecoderLayer(nn.Module):
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
         residual: torch.Tensor | None,
+        prefix_delta: torch.Tensor | None = None,
         **kwargs,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor] | tuple[
+        torch.Tensor, torch.Tensor, torch.Tensor
+    ]:
         if self.use_attn_residuals:
             assert residual is not None
-            return self.forward_attn_residual(positions, hidden_states, residual)
+            return self.forward_attn_residual(
+                positions, hidden_states, residual, prefix_delta
+            )
 
+        assert prefix_delta is None
         # Self Attention
         if residual is None:
             residual = hidden_states
@@ -617,7 +623,8 @@ class KimiDecoderLayer(nn.Module):
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
         block_residual: torch.Tensor,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+        prefix_delta: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         prefix_sum = hidden_states
         hidden_states = _apply_attn_res(
             prefix_sum,
@@ -625,6 +632,7 @@ class KimiDecoderLayer(nn.Module):
             self.self_attention_res_proj,
             self.self_attention_res_norm,
             self.prev_valid_blocks,
+            delta=prefix_delta,
             output_norm=self.input_layernorm,
             block_write_idx=(self.block_write_idx if self.is_block_write_layer else -1),
         )
@@ -654,8 +662,7 @@ class KimiDecoderLayer(nn.Module):
         )
 
         hidden_states = self.mlp(hidden_states)
-        prefix_sum = prefix_sum + hidden_states
-        return prefix_sum, block_residual
+        return prefix_sum, block_residual, hidden_states
 
 
 class KimiLinearModel(nn.Module, EagleModelMixin):
@@ -810,24 +817,28 @@ class KimiLinearModel(nn.Module, EagleModelMixin):
         if residual is not None:
             block_residual[:, : residual.size(1), :].copy_(residual)
         residual = block_residual
+        prefix_delta = None
 
         for layer_idx, layer in enumerate(
             self.layers[self.start_layer : self.end_layer],
             start=self.start_layer,
         ):
-            hidden_states, residual = layer(
+            hidden_states, residual, prefix_delta = layer(
                 positions=positions,
                 hidden_states=hidden_states,
                 residual=residual,
+                prefix_delta=prefix_delta,
             )
             if (layer_idx + 1) in self.aux_hidden_state_layers:
-                # AMD attn-res layer already returns prefix_sum + MLP delta as
-                # hidden_states; the override drops the block bank in residual.
                 self._maybe_add_hidden_state(
-                    aux_hidden_states, layer_idx + 1, hidden_states, residual
+                    aux_hidden_states,
+                    layer_idx + 1,
+                    hidden_states + prefix_delta,
+                    residual,
                 )
 
         if not get_pp_group().is_last_rank:
+            hidden_states = hidden_states + prefix_delta
             return IntermediateTensors(
                 {"hidden_states": hidden_states, "residual": residual}
             )
@@ -838,6 +849,7 @@ class KimiLinearModel(nn.Module, EagleModelMixin):
             self.output_attn_res_proj,
             self.output_attn_res_norm,
             attn_res_block_num,
+            delta=prefix_delta,
         )
         # NOTE: the final norm is applied in compute_logits instead of here, so
         # the MTP draft model receives the pre-norm hidden states.

--- a/vllm/models/kimi_k3/amd/linear.py
+++ b/vllm/models/kimi_k3/amd/linear.py
@@ -457,9 +457,8 @@ class KimiMLAAttention(nn.Module):
         self,
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
-        output: torch.Tensor,
-    ) -> None:
-        output[:] = self.mla_attn(positions, hidden_states)
+    ) -> torch.Tensor:
+        return self.mla_attn(positions, hidden_states)
 
 
 class KimiDecoderLayer(nn.Module):
@@ -496,7 +495,6 @@ class KimiDecoderLayer(nn.Module):
                     vllm_config,
                     prefix=f"{prefix}.self_attn",
                 )
-            self._self_attn_writes_output = False
         else:
             qk_nope_head_dim = config.qk_nope_head_dim
             qk_rope_head_dim = config.qk_rope_head_dim
@@ -524,7 +522,6 @@ class KimiDecoderLayer(nn.Module):
                 kv_lora_rank=kv_lora_rank,
                 use_nope=mla_use_nope,
             )
-            self._self_attn_writes_output = True
 
         if (
             self.is_moe
@@ -585,14 +582,6 @@ class KimiDecoderLayer(nn.Module):
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
-        if self._self_attn_writes_output:
-            output = torch.empty_like(hidden_states)
-            self.self_attn(
-                hidden_states=hidden_states,
-                positions=positions,
-                output=output,
-            )
-            return output
         return self.self_attn(
             hidden_states=hidden_states,
             positions=positions,

--- a/vllm/models/kimi_k3/amd/linear.py
+++ b/vllm/models/kimi_k3/amd/linear.py
@@ -594,9 +594,10 @@ class KimiDecoderLayer(nn.Module):
         residual: torch.Tensor | None,
         prefix_delta: torch.Tensor | None = None,
         **kwargs,
-    ) -> tuple[torch.Tensor, torch.Tensor] | tuple[
-        torch.Tensor, torch.Tensor, torch.Tensor
-    ]:
+    ) -> (
+        tuple[torch.Tensor, torch.Tensor]
+        | tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+    ):
         if self.use_attn_residuals:
             assert residual is not None
             return self.forward_attn_residual(

--- a/vllm/models/kimi_k3/amd/linear.py
+++ b/vllm/models/kimi_k3/amd/linear.py
@@ -496,6 +496,7 @@ class KimiDecoderLayer(nn.Module):
                     vllm_config,
                     prefix=f"{prefix}.self_attn",
                 )
+            self._self_attn_writes_output = False
         else:
             qk_nope_head_dim = config.qk_nope_head_dim
             qk_rope_head_dim = config.qk_rope_head_dim
@@ -523,6 +524,7 @@ class KimiDecoderLayer(nn.Module):
                 kv_lora_rank=kv_lora_rank,
                 use_nope=mla_use_nope,
             )
+            self._self_attn_writes_output = True
 
         if (
             self.is_moe
@@ -583,13 +585,18 @@ class KimiDecoderLayer(nn.Module):
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
-        attn_output = torch.empty_like(hidden_states)
-        self.self_attn(
+        if self._self_attn_writes_output:
+            output = torch.empty_like(hidden_states)
+            self.self_attn(
+                hidden_states=hidden_states,
+                positions=positions,
+                output=output,
+            )
+            return output
+        return self.self_attn(
             hidden_states=hidden_states,
             positions=positions,
-            output=attn_output,
         )
-        return attn_output
 
     def forward(
         self,

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -870,14 +870,12 @@ class KimiDecoderLayer(nn.Module):
                     prefix=f"{prefix}.self_attn",
                     run_gemm_rs=run_gemm_rs,
                 )
-                self._self_attn_writes_output = False
             else:
                 self.self_attn = KimiLinearGatedDeltaNetAttention(
                     config,
                     vllm_config,
                     prefix=f"{prefix}.self_attn",
                 )
-                self._self_attn_writes_output = True
         else:
             qk_nope_head_dim = config.qk_nope_head_dim
             qk_rope_head_dim = config.qk_rope_head_dim
@@ -907,7 +905,6 @@ class KimiDecoderLayer(nn.Module):
                 aux_stream=aux_stream,
                 run_gemm_rs=run_gemm_rs,
             )
-            self._self_attn_writes_output = False
 
         if self.use_sequence_parallel:
             self.self_attn.o_proj.reduce_results = False
@@ -973,14 +970,6 @@ class KimiDecoderLayer(nn.Module):
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
-        if self._self_attn_writes_output:
-            output = torch.empty_like(hidden_states)
-            self.self_attn(
-                hidden_states=hidden_states,
-                positions=positions,
-                output=output,
-            )
-            return output
         return self.self_attn(
             hidden_states=hidden_states,
             positions=positions,


### PR DESCRIPTION
## Purpose

Kimi-K3's AMD attention paths copied each output projection into a caller-owned buffer even though the projection already returns a tensor with the required shape, dtype, layout, and lifetime.

This PR removes that redundant post-projection allocation and copy from both attention families:

- 69 KDA layers
- 24 MLA layers
- 93 post-attention-projection copies per model step in total

The functionality from #50847 is now folded into this PR. #50654 is separate and complementary: it optimizes the earlier KDA recurrent/conv/RMSNorm path, while this PR removes the later copy after the output projection.

## Implementation

- Return KDA output-projection storage directly from both the shared KDA implementation and the dedicated full-rank Kimi-K3 implementation selected by current `main`.
- Return MLA output-projection storage directly.
- Use one return-value contract in `KimiDecoderLayer` for KDA and MLA.
- Preserve attention arithmetic, state updates, normalization, projection, tensor-parallel communication, and HIP-graph replay behavior.

## Validation

```text
Targeted ownership tests:  3 passed
Ruff 0.14.0 check:         passed
Ruff 0.14.0 format check:  passed
git diff --check:          passed
DCO:                       passed
```

The tests cover KDA dispatch ownership, the concrete full-rank Kimi-K3 KDA forward path, and MLA dispatch ownership. In each case, the returned tensor is the exact projection tensor and has the same `data_ptr()`.

## Fixed-cohort decode A/B

### Setup

```text
GPU:                 8 x AMD Instinct MI355X (gfx950)
Parallelism:         TP8
Model:               Kimi-K3, BF16 activations / MXFP4 weights
Decode:              non-speculative
Prefix caching:      enabled
Prompt:              63,911-token shared prefix + 4,089-token suffix
Output:              1,024 tokens per request, ignore EOS
Concurrency:         C16 and C24 fixed cohorts
HIP graph:           FULL, capture sizes 1/16/24
Sampling:            greedy, seed 42
Runs:                1 warmup + 3 measured runs per concurrency and variant
Success rate:        240/240 measured requests
```

Both variants used image `localhost/kimi-pp8-upstream-clean` (vLLM `beca88e59`, AITER `99733dc00`). The baseline was the unmodified image. The candidate mounted only this PR's AMD runtime files from `43d81ba3e`. The relevant AMD Kimi-K3 files in the image are identical to the rebased `main` baseline before this PR.

### Results

Means over three measured runs. TPOT and ITL are end-to-end serving metrics, not the reviewer's pure-GPU trace period.

| Cohort | Metric | Baseline | Combined PR | Delta |
|---|---|---:|---:|---:|
| C16 | Mean TPOT | 73.141 ms | 72.428 ms | **-0.713 ms (-0.97%)** |
| C16 | Median ITL | 70.488 ms | 70.186 ms | **-0.302 ms** |
| C16 | Output throughput | 193.575 tok/s | 195.555 tok/s | **+1.02%** |
| C24 | Mean TPOT | 74.958 ms | 74.457 ms | **-0.501 ms (-0.67%)** |
| C24 | Median ITL | 71.311 ms | 70.916 ms | **-0.396 ms** |
| C24 | Output throughput | 278.245 tok/s | 280.452 tok/s | **+0.79%** |

Mean-TPOT standard deviation across the three runs was 0.184 ms / 0.348 ms for baseline C16/C24 and 0.019 ms / 0.122 ms for candidate C16/C24.

### Interpretation

The reviewer's trace found that the complete 93-copy group costs approximately 0.495 ms at C16 and 0.563 ms at C24. The combined A/B removes all 93 copies and measures a 0.713 ms C16 and 0.501 ms C24 TPOT reduction. C24 closely matches the trace-derived removable cost. C16 is modestly larger, which is plausible because returning projection storage directly also changes allocator and lifetime behavior; the baseline's run-to-run variance is also higher.

The absolute TPOT values should not be compared directly with the reviewer's 32.82/35.98 ms pure-GPU periods because TPOT includes serving and scheduling overhead. The A/B delta is the relevant same-harness comparison.

## Scope summary

```text
#50592: remove 69 KDA + 24 MLA post-projection copies
#50847: functionality absorbed by this PR
#50654: separate earlier KDA recurrent-output/fusion optimization
```