### PR TITLE
[Bugfix] Fix MiniMax M3 prompt reasoning initialization

### DIFF
--- a/tests/entrypoints/llm/test_offline_reasoning_state.py
+++ b/tests/entrypoints/llm/test_offline_reasoning_state.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from vllm.entrypoints.offline_utils import OfflineInferenceMixin
+from vllm.inputs import tokens_input
+from vllm.reasoning import ReasoningParserManager
+from vllm.sampling_params import SamplingParams, StructuredOutputsParams
+from vllm.utils.counter import Counter
+
+
+def test_chat_forwards_reasoning_state_to_sync_engine(monkeypatch):
+    captured: dict = {}
+
+    class FakeReasoner:
+        def __init__(self, tokenizer, chat_template_kwargs, model_config):
+            captured["tokenizer"] = tokenizer
+            captured["chat_template_kwargs"] = chat_template_kwargs
+            captured["model_config"] = model_config
+
+        def is_reasoning_end_from_prompt(self, prompt_token_ids):
+            captured["prompt_token_ids"] = prompt_token_ids
+            return False
+
+    monkeypatch.setattr(
+        ReasoningParserManager,
+        "get_reasoning_parser",
+        staticmethod(lambda name: FakeReasoner),
+    )
+
+    mixin = OfflineInferenceMixin()
+    tokenizer = object()
+    mixin.renderer = SimpleNamespace(
+        tokenizer=tokenizer,
+        get_tokenizer=lambda: tokenizer,
+    )
+    mixin.model_config = SimpleNamespace(
+        enable_prompt_embeds=False,
+        is_encoder_decoder=False,
+    )
+    structured_config = SimpleNamespace(
+        reasoning_parser="minimax_m3",
+        reasoning_parser_plugin=None,
+    )
+    mixin.llm_engine = Mock()
+    mixin.llm_engine.vllm_config = SimpleNamespace(
+        structured_outputs_config=structured_config
+    )
+    mixin.llm_engine.add_request.return_value = "0"
+    mixin.request_counter = Counter()
+    prompt = tokens_input([1, 2, 3])
+    mixin._preprocess_chat_one = Mock(return_value=prompt)
+    params = SamplingParams(
+        max_tokens=8,
+        structured_outputs=StructuredOutputsParams(json_object=True),
+    )
+
+    request_ids = mixin._add_chat_requests(
+        messages=[{"role": "user", "content": "hi"}],
+        params=params,
+        use_tqdm=False,
+        chat_template_kwargs={"thinking_mode": "enabled"},
+    )
+
+    assert request_ids == ["0"]
+    assert captured["tokenizer"] is tokenizer
+    assert captured["prompt_token_ids"] == [1, 2, 3]
+    assert captured["chat_template_kwargs"]["thinking_mode"] == "enabled"
+    mixin.llm_engine.add_request.assert_called_once()
+    add_request_kwargs = mixin.llm_engine.add_request.call_args.kwargs
+    assert add_request_kwargs["reasoning_ended"] is False
+    assert add_request_kwargs["reasoning_parser_kwargs"] == {
+        "chat_template_kwargs": captured["chat_template_kwargs"]
+    }

--- a/tests/entrypoints/openai/chat_completion/test_batched_chat_completions.py
+++ b/tests/entrypoints/openai/chat_completion/test_batched_chat_completions.py
@@ -1,15 +1,109 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import asyncio
 import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
 
 from tests.utils import RemoteOpenAIServer
+from vllm.entrypoints.openai.chat_completion import batch_serving
+from vllm.entrypoints.openai.chat_completion.batch_serving import (
+    OpenAIServingChatBatch,
+)
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    BatchChatCompletionRequest,
+)
 
 # any model with a chat template defined in tokenizer_config should work here
 MODEL_NAME = "Qwen/Qwen2.5-1.5B-Instruct"
+
+
+@pytest.mark.parametrize(
+    ("thinking_mode", "expected_reasoning_ended"),
+    [
+        ("adaptive", None),
+        ("enabled", False),
+        ("disabled", True),
+    ],
+)
+def test_batch_forwards_prompt_reasoning_state(
+    monkeypatch,
+    thinking_mode: str,
+    expected_reasoning_ended: bool | None,
+) -> None:
+    """Batch requests initialize reasoning like standard chat requests."""
+
+    class BatchParser:
+        def __init__(self, tokenizer, tools, chat_template_kwargs, **kwargs):
+            self.reasoning_parser = object()
+            self.thinking_mode = chat_template_kwargs["thinking_mode"]
+
+        def is_reasoning_end_from_prompt(self, prompt_token_ids):
+            return {
+                "adaptive": None,
+                "enabled": False,
+                "disabled": True,
+            }[self.thinking_mode]
+
+    serving = OpenAIServingChatBatch.__new__(OpenAIServingChatBatch)
+    serving.renderer = SimpleNamespace(tokenizer=MagicMock())
+    serving.parser_cls = BatchParser
+    serving.model_config = SimpleNamespace(max_model_len=128)
+    serving.default_sampling_params = {}
+    serving.override_max_tokens = None
+    serving.engine_client = MagicMock()
+    serving.engine_client.generate.return_value = MagicMock()
+    serving.models = MagicMock()
+    serving.models.model_name.return_value = "test-model"
+    serving._effective_chat_template_kwargs = MagicMock(
+        return_value={"thinking_mode": thinking_mode}
+    )
+    engine_prompt = {"type": "tokens", "prompt_token_ids": [1, 2, 3]}
+    serving.render_batch_chat_request = AsyncMock(
+        return_value=([[], []], [engine_prompt, engine_prompt])
+    )
+    serving._base_request_id = MagicMock(return_value="batch-test")
+    serving._maybe_get_adapters = MagicMock(return_value=None)
+    serving._get_data_parallel_rank = MagicMock(return_value=None)
+    serving._extract_prompt_components = MagicMock(
+        return_value=SimpleNamespace(token_ids=[1, 2, 3])
+    )
+    serving._extract_prompt_len = MagicMock(return_value=3)
+    serving._log_inputs = MagicMock()
+    serving.chat_completion_full_generator_batch = AsyncMock(return_value=MagicMock())
+    monkeypatch.setattr(batch_serving, "get_max_tokens", lambda *args, **kwargs: 8)
+
+    request = BatchChatCompletionRequest(
+        model="test-model",
+        messages=[
+            [{"role": "user", "content": "Return JSON."}],
+            [{"role": "user", "content": "Return JSON."}],
+        ],
+        response_format={"type": "json_object"},
+        chat_template_kwargs={"thinking_mode": thinking_mode},
+        max_tokens=8,
+    )
+
+    asyncio.run(serving.create_batch_chat_completion(request))
+
+    assert serving.engine_client.generate.call_count == 2
+    for generate_call in serving.engine_client.generate.call_args_list:
+        generate_kwargs = generate_call.kwargs
+        assert generate_kwargs["reasoning_ended"] is expected_reasoning_ended
+        assert generate_kwargs["reasoning_parser_kwargs"] == {
+            "chat_template_kwargs": {
+                "thinking_mode": thinking_mode,
+                "_vllm_continue_final_message": False,
+            }
+        }
+
+    parsers = serving.chat_completion_full_generator_batch.call_args.args[-1]
+    assert len(parsers) == 2
+    assert parsers[0] is not parsers[1]
 
 
 @pytest.fixture(scope="module")

--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -151,7 +151,11 @@ async def test_builtin_tool_turn_clears_reasoning_continuation_context() -> None
         available_tools=[],
         chat_template=None,
         chat_template_content_format="auto",
+        response_parser=MagicMock(),
     )
+    initial_response_parser = context.response_parser
+    refreshed_response_parser = MagicMock()
+    serving._make_response_parser = MagicMock(return_value=refreshed_response_parser)
     context.append_output = MagicMock()
     context.need_builtin_tool_call = MagicMock(side_effect=[True, False])
     context.call_tool = AsyncMock(return_value=[])
@@ -191,6 +195,16 @@ async def test_builtin_tool_turn_clears_reasoning_continuation_context() -> None
             "_vllm_continue_final_message": False,
         }
     }
+    assert context.response_parser is refreshed_response_parser
+    assert context.response_parser is not initial_response_parser
+    serving._make_response_parser.assert_called_once_with(
+        context.request,
+        context.tokenizer,
+        {
+            "thinking_mode": "adaptive",
+            "_vllm_continue_final_message": False,
+        },
+    )
 
 
 @pytest.fixture

--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from contextlib import AsyncExitStack
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import pytest_asyncio
@@ -34,7 +34,11 @@ from vllm.entrypoints.openai.engine.protocol import (
     ErrorResponse,
     RequestResponseMetadata,
 )
-from vllm.entrypoints.openai.responses.context import ConversationContext, SimpleContext
+from vllm.entrypoints.openai.responses.context import (
+    ConversationContext,
+    ParsableContext,
+    SimpleContext,
+)
 from vllm.entrypoints.openai.responses.protocol import (
     ResponseCreatedEvent,
     ResponseRawMessageAndToken,
@@ -123,6 +127,70 @@ def test_reasoning_continuation_context_is_forwarded_to_parser() -> None:
     assert kwargs["_vllm_continue_final_message"] is True
     assert kwargs["_vllm_continue_final_message_content"] == ""
     assert kwargs["_vllm_continue_final_message_reasoning"] == "partial plan"
+
+
+@pytest.mark.asyncio
+async def test_builtin_tool_turn_clears_reasoning_continuation_context() -> None:
+    serving = _make_serving_instance_with_reasoning()
+
+    async def result_generator():
+        yield MagicMock()
+
+    serving.engine_client.generate.side_effect = lambda *args, **kwargs: (
+        result_generator()
+    )
+    serving._render_next_turn = AsyncMock(return_value=[tokens_input([4, 5])])
+    serving._extract_prompt_len = MagicMock(return_value=2)
+
+    request = ResponsesRequest(input="hi", tools=[], max_output_tokens=8)
+    context = ParsableContext(
+        response_messages=[],
+        tokenizer=MagicMock(),
+        parser_cls=None,
+        request=request,
+        available_tools=[],
+        chat_template=None,
+        chat_template_content_format="auto",
+    )
+    context.append_output = MagicMock()
+    context.need_builtin_tool_call = MagicMock(side_effect=[True, False])
+    context.call_tool = AsyncMock(return_value=[])
+    context.append_tool_output = MagicMock()
+
+    reasoning_parser_kwargs = {
+        "chat_template_kwargs": {
+            "thinking_mode": "adaptive",
+            "_vllm_continue_final_message": True,
+            "_vllm_continue_final_message_content": "",
+            "_vllm_continue_final_message_reasoning": "partial plan",
+            "_vllm_continue_final_message_reasoning_ended": False,
+        }
+    }
+
+    outputs = [
+        output
+        async for output in serving._generate_with_builtin_tools(
+            request_id="resp-test",
+            engine_input=tokens_input([1, 2, 3]),
+            sampling_params=SamplingParams(max_tokens=8),
+            context=context,
+            reasoning_ended=False,
+            reasoning_parser_kwargs=reasoning_parser_kwargs,
+        )
+    ]
+
+    assert len(outputs) == 2
+    assert serving.engine_client.generate.call_count == 2
+    first_call, second_call = serving.engine_client.generate.call_args_list
+    assert first_call.kwargs["reasoning_ended"] is False
+    assert first_call.kwargs["reasoning_parser_kwargs"] == reasoning_parser_kwargs
+    assert second_call.kwargs["reasoning_ended"] is None
+    assert second_call.kwargs["reasoning_parser_kwargs"] == {
+        "chat_template_kwargs": {
+            "thinking_mode": "adaptive",
+            "_vllm_continue_final_message": False,
+        }
+    }
 
 
 @pytest.fixture

--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -17,6 +17,7 @@ from openai.types.responses import (
 from openai.types.responses.response_format_text_json_schema_config import (
     ResponseFormatTextJSONSchemaConfig,
 )
+from openai.types.responses.response_reasoning_item import Content
 from openai.types.responses.tool import (
     CodeInterpreterContainerCodeInterpreterToolAuto,
     LocalShell,
@@ -49,6 +50,7 @@ from vllm.entrypoints.openai.responses.serving import (
 from vllm.entrypoints.openai.responses.streaming_events import (
     StreamingState,
 )
+from vllm.entrypoints.openai.responses.utils import construct_input_messages
 from vllm.inputs import tokens_input
 from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.parser.harmony import Segment
@@ -94,6 +96,33 @@ def test_serialize_message_pydantic_model_returns_dict() -> None:
     assert isinstance(serialized, dict)
     assert serialized["type"] == "raw_message_tokens"
     assert serialized["message"] == "hello"
+
+
+def test_reasoning_continuation_context_is_forwarded_to_parser() -> None:
+    reasoning_item = ResponseReasoningItem(
+        id="reasoning_1",
+        summary=[],
+        type="reasoning",
+        content=[Content(text="partial plan", type="reasoning_text")],
+        encrypted_content=None,
+        status="in_progress",
+    )
+    request = ResponsesRequest(
+        input=[reasoning_item],
+        tools=[],
+        chat_template_kwargs={"thinking_mode": "adaptive"},
+    )
+    messages = construct_input_messages(request_input=request.input)
+    serving = OpenAIServingResponses.__new__(OpenAIServingResponses)
+    serving.chat_template = None
+    serving.chat_template_content_format = "auto"
+    serving.chat_template_kwargs = {}
+
+    kwargs = serving._reasoning_parser_chat_template_kwargs(request, messages)
+
+    assert kwargs["_vllm_continue_final_message"] is True
+    assert kwargs["_vllm_continue_final_message_content"] == ""
+    assert kwargs["_vllm_continue_final_message_reasoning"] == "partial plan"
 
 
 @pytest.fixture

--- a/tests/reasoning/test_minimax_m3_reasoning_parser.py
+++ b/tests/reasoning/test_minimax_m3_reasoning_parser.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 
 import pytest
 
+from vllm.entrypoints.chat_utils import make_reasoning_parser_chat_template_kwargs
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.parser.abstract_parser import DelegatingParser
 from vllm.reasoning import ReasoningParserManager
@@ -420,6 +421,34 @@ def test_adaptive_continuation_resumes_separate_reasoning_content():
 
     assert (reasoning or "") == " more"
     assert (content or "") == ""
+
+
+@pytest.mark.parametrize(("closed", "expected"), [(False, False), (True, True)])
+def test_continuation_preserves_thinking_content_part_state(closed, expected):
+    final_message = {
+        "role": "assistant",
+        "content": [
+            {
+                "type": "thinking",
+                "thinking": "partial plan",
+                "closed": closed,
+            }
+        ],
+    }
+    chat_template_kwargs = make_reasoning_parser_chat_template_kwargs(
+        {"thinking_mode": "adaptive"},
+        continue_final_message=True,
+        final_message=final_message,
+    )
+    parser, tokenizer = make_parser(chat_template_kwargs=chat_template_kwargs)
+
+    assert chat_template_kwargs["_vllm_continue_final_message_content"] == ""
+    assert (
+        chat_template_kwargs["_vllm_continue_final_message_reasoning"] == "partial plan"
+    )
+    assert parser.is_reasoning_end_from_prompt(tokenizer.encode("partial plan")) is (
+        expected
+    )
 
 
 def test_streaming_boundary_can_emit_reasoning_and_content():

--- a/tests/reasoning/test_minimax_m3_reasoning_parser.py
+++ b/tests/reasoning/test_minimax_m3_reasoning_parser.py
@@ -396,6 +396,32 @@ def test_continuation_ignores_reasoning_markers_before_final_message(thinking_mo
     assert (delta.content or "") == " more"
 
 
+def test_adaptive_continuation_resumes_separate_reasoning_content():
+    tokenizer = MiniMaxM3Tokenizer()
+    parser = MiniMaxM3DelegatingParser(
+        tokenizer,
+        chat_template_kwargs={
+            "thinking_mode": "adaptive",
+            "_vllm_continue_final_message": True,
+            "_vllm_continue_final_message_content": "",
+            "_vllm_continue_final_message_reasoning": "plan",
+        },
+    )
+
+    assert parser.is_reasoning_end_from_prompt(tokenizer.encode("plan")) is False
+
+    request = ChatCompletionRequest(
+        messages=[{"role": "assistant", "content": ""}],
+        model="test-model",
+        add_generation_prompt=False,
+        continue_final_message=True,
+    )
+    reasoning, content, _ = parser.parse(" more", request)
+
+    assert (reasoning or "") == " more"
+    assert (content or "") == ""
+
+
 def test_streaming_boundary_can_emit_reasoning_and_content():
     parser, tokenizer = make_parser()
 

--- a/tests/reasoning/test_minimax_m3_reasoning_parser.py
+++ b/tests/reasoning/test_minimax_m3_reasoning_parser.py
@@ -301,6 +301,7 @@ def test_enabled_continuation_respects_prompt_reasoning_state(
         chat_template_kwargs={
             "thinking_mode": "enabled",
             "_vllm_continue_final_message": True,
+            "_vllm_continue_final_message_content": prompt_suffix,
         },
     )
     request = ChatCompletionRequest(
@@ -342,6 +343,7 @@ def test_enabled_non_streaming_continuation_respects_prompt_reasoning_state(
         chat_template_kwargs={
             "thinking_mode": "enabled",
             "_vllm_continue_final_message": True,
+            "_vllm_continue_final_message_content": prompt_suffix,
         },
     )
     request = ChatCompletionRequest(
@@ -356,6 +358,42 @@ def test_enabled_non_streaming_continuation_respects_prompt_reasoning_state(
 
     assert (reasoning or "") == expected_reasoning
     assert (content or "") == expected_content
+
+
+@pytest.mark.parametrize("thinking_mode", ["adaptive", "enabled"])
+def test_continuation_ignores_reasoning_markers_before_final_message(thinking_mode):
+    tokenizer = MiniMaxM3Tokenizer()
+    parser = MiniMaxM3DelegatingParser(
+        tokenizer,
+        chat_template_kwargs={
+            "thinking_mode": thinking_mode,
+            "_vllm_continue_final_message": True,
+            "_vllm_continue_final_message_content": "answer",
+        },
+    )
+    prompt_token_ids = tokenizer.encode(
+        "system message with unmatched <mm:think>\nassistant\nanswer"
+    )
+
+    assert parser.is_reasoning_end_from_prompt(prompt_token_ids) is True
+
+    request = ChatCompletionRequest(
+        messages=[{"role": "assistant", "content": "answer"}],
+        model="test-model",
+        add_generation_prompt=False,
+        continue_final_message=True,
+    )
+    delta = parser.parse_delta(
+        " more",
+        tokenizer.encode(" more"),
+        request,
+        prompt_token_ids=prompt_token_ids,
+        finished=True,
+    )
+
+    assert delta is not None
+    assert (delta.reasoning or "") == ""
+    assert (delta.content or "") == " more"
 
 
 def test_streaming_boundary_can_emit_reasoning_and_content():

--- a/tests/reasoning/test_minimax_m3_reasoning_parser.py
+++ b/tests/reasoning/test_minimax_m3_reasoning_parser.py
@@ -673,6 +673,15 @@ def test_token_id_helpers():
     assert parser.count_reasoning_tokens(output_ids) == len(tokenizer.encode("abc"))
 
 
+def test_reasoning_marker_token_ids():
+    parser, tokenizer = make_parser()
+
+    assert parser.reasoning_marker_token_ids == (
+        tuple(tokenizer.encode("<mm:think>")),
+        tuple(tokenizer.encode("</mm:think>")),
+    )
+
+
 def test_token_id_helpers_enabled_mode():
     parser, tokenizer = make_parser(chat_template_kwargs={"thinking_mode": "enabled"})
     output_ids = tokenizer.encode("abc</mm:think>def", add_special_tokens=False)

--- a/tests/reasoning/test_minimax_m3_reasoning_parser.py
+++ b/tests/reasoning/test_minimax_m3_reasoning_parser.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 import pytest
 
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.parser.abstract_parser import DelegatingParser
 from vllm.reasoning import ReasoningParserManager
 from vllm.reasoning.minimax_m3_reasoning_parser import MiniMaxM3ReasoningParser
 
@@ -97,8 +98,12 @@ class RuntimeSplitMiniMaxM3Tokenizer(MiniMaxM3Tokenizer):
         return [self._add_token(token) for token in list(text)]
 
 
+class MiniMaxM3DelegatingParser(DelegatingParser):
+    reasoning_parser_cls = MiniMaxM3ReasoningParser
+
+
 def make_parser(
-    chat_template_kwargs: dict[str, str] | None = None,
+    chat_template_kwargs: dict[str, object] | None = None,
 ) -> tuple[MiniMaxM3ReasoningParser, MiniMaxM3Tokenizer]:
     tokenizer = MiniMaxM3Tokenizer()
     return (
@@ -233,6 +238,126 @@ def test_streaming_reasoning_tags_are_not_returned():
     assert end_states == [False, False, True, True]
 
 
+@pytest.mark.parametrize(
+    ("thinking_mode", "prompt_suffix", "chunks", "expected_reasoning"),
+    [
+        ("adaptive", "", ["</mm:think>", "answer"], ""),
+        (
+            "adaptive",
+            "",
+            ["<mm:think>", "plan", "</mm:think>", "answer"],
+            "plan",
+        ),
+        ("enabled", "<mm:think>", ["plan", "</mm:think>", "answer"], "plan"),
+        ("disabled", "</mm:think>", ["answer"], ""),
+    ],
+)
+def test_prompt_instructions_do_not_end_new_reasoning(
+    thinking_mode, prompt_suffix, chunks, expected_reasoning
+):
+    tokenizer = MiniMaxM3Tokenizer()
+    parser = MiniMaxM3DelegatingParser(
+        tokenizer, chat_template_kwargs={"thinking_mode": thinking_mode}
+    )
+    request = ChatCompletionRequest(messages=[], model="test-model")
+    prompt_token_ids = tokenizer.encode(
+        "Wrap reasoning in <mm:think></mm:think> tags.\nai\n" + prompt_suffix
+    )
+    reasoning_parts: list[str] = []
+    content_parts: list[str] = []
+
+    for index, chunk in enumerate(chunks):
+        delta = parser.parse_delta(
+            chunk,
+            tokenizer.encode(chunk),
+            request,
+            prompt_token_ids=prompt_token_ids if index == 0 else None,
+            finished=index == len(chunks) - 1,
+        )
+        if delta is not None and delta.reasoning is not None:
+            reasoning_parts.append(delta.reasoning)
+        if delta is not None and delta.content is not None:
+            content_parts.append(delta.content)
+
+    assert "".join(reasoning_parts) == expected_reasoning
+    assert "".join(content_parts) == "answer"
+
+
+@pytest.mark.parametrize(
+    ("prompt_suffix", "expected_reasoning", "expected_content"),
+    [
+        ("<mm:think>plan", " more", ""),
+        ("<mm:think>plan</mm:think>answer", "", " more"),
+    ],
+)
+def test_enabled_continuation_respects_prompt_reasoning_state(
+    prompt_suffix,
+    expected_reasoning,
+    expected_content,
+):
+    tokenizer = MiniMaxM3Tokenizer()
+    parser = MiniMaxM3DelegatingParser(
+        tokenizer,
+        chat_template_kwargs={
+            "thinking_mode": "enabled",
+            "_vllm_continue_final_message": True,
+        },
+    )
+    request = ChatCompletionRequest(
+        messages=[{"role": "assistant", "content": prompt_suffix}],
+        model="test-model",
+        add_generation_prompt=False,
+        continue_final_message=True,
+    )
+    prompt_token_ids = tokenizer.encode(prompt_suffix)
+
+    delta = parser.parse_delta(
+        " more",
+        tokenizer.encode(" more"),
+        request,
+        prompt_token_ids=prompt_token_ids,
+        finished=True,
+    )
+
+    assert delta is not None
+    assert (delta.reasoning or "") == expected_reasoning
+    assert (delta.content or "") == expected_content
+
+
+@pytest.mark.parametrize(
+    ("prompt_suffix", "expected_reasoning", "expected_content"),
+    [
+        ("<mm:think>plan", " more", ""),
+        ("<mm:think>plan</mm:think>answer", "", " more"),
+    ],
+)
+def test_enabled_non_streaming_continuation_respects_prompt_reasoning_state(
+    prompt_suffix,
+    expected_reasoning,
+    expected_content,
+):
+    tokenizer = MiniMaxM3Tokenizer()
+    parser = MiniMaxM3DelegatingParser(
+        tokenizer,
+        chat_template_kwargs={
+            "thinking_mode": "enabled",
+            "_vllm_continue_final_message": True,
+        },
+    )
+    request = ChatCompletionRequest(
+        messages=[{"role": "assistant", "content": prompt_suffix}],
+        model="test-model",
+        add_generation_prompt=False,
+        continue_final_message=True,
+    )
+
+    parser.is_reasoning_end_from_prompt(tokenizer.encode(prompt_suffix))
+    reasoning, content, _ = parser.parse(" more", request)
+
+    assert (reasoning or "") == expected_reasoning
+    assert (content or "") == expected_content
+
+
 def test_streaming_boundary_can_emit_reasoning_and_content():
     parser, tokenizer = make_parser()
 
@@ -287,6 +412,15 @@ def test_streaming_enabled_mode_starts_in_reasoning():
     assert reasoning == "plan"
     assert content == "answer"
     assert end_states == [False, True, True]
+
+
+def test_enabled_mode_engine_detection_observes_end_marker():
+    """Structured output detects the boundary without running extraction."""
+    parser, tokenizer = make_parser(chat_template_kwargs={"thinking_mode": "enabled"})
+    output_ids = tokenizer.encode("plan</mm:think>")
+    delta_ids = tokenizer.encode("</mm:think>")
+
+    assert parser.is_reasoning_end_streaming(output_ids, delta_ids) is True
 
 
 def test_streaming_plain_content_ends_reasoning_phase():
@@ -459,3 +593,24 @@ def test_token_id_helpers_enabled_mode():
     assert parser.count_reasoning_tokens(open_reasoning_ids) == len(
         tokenizer.encode("abc")
     )
+
+
+@pytest.mark.parametrize(
+    ("thinking_mode", "expected"),
+    [
+        (None, None),
+        ("adaptive", None),
+        ("enabled", False),
+        ("disabled", True),
+    ],
+)
+def test_prompt_reasoning_state_follows_thinking_mode(thinking_mode, expected):
+    chat_template_kwargs = (
+        None if thinking_mode is None else {"thinking_mode": thinking_mode}
+    )
+    parser, tokenizer = make_parser(chat_template_kwargs=chat_template_kwargs)
+    prompt_token_ids = tokenizer.encode(
+        "Instructions may contain <mm:think></mm:think> examples.\nai\n"
+    )
+
+    assert parser.is_reasoning_end_from_prompt(prompt_token_ids) is expected

--- a/tests/reasoning/test_minimax_m3_reasoning_parser.py
+++ b/tests/reasoning/test_minimax_m3_reasoning_parser.py
@@ -682,6 +682,29 @@ def test_reasoning_marker_token_ids():
     )
 
 
+def test_reasoning_marker_state_admits_runtime_split_tokens():
+    tokenizer = RuntimeSplitMiniMaxM3Tokenizer()
+    parser = MiniMaxM3ReasoningParser(tokenizer)
+    split_start_ids = tokenizer.encode_runtime("<mm:think>")
+
+    marker_complete, next_token_ids = parser.reasoning_marker_token_state([])
+    assert marker_complete is False
+    assert split_start_ids[0] in next_token_ids
+
+    for index in range(1, len(split_start_ids)):
+        marker_complete, next_token_ids = parser.reasoning_marker_token_state(
+            split_start_ids[:index]
+        )
+        assert marker_complete is False
+        assert split_start_ids[index] in next_token_ids
+
+    marker_complete, next_token_ids = parser.reasoning_marker_token_state(
+        split_start_ids
+    )
+    assert marker_complete is True
+    assert next_token_ids == ()
+
+
 def test_token_id_helpers_enabled_mode():
     parser, tokenizer = make_parser(chat_template_kwargs={"thinking_mode": "enabled"})
     output_ids = tokenizer.encode("abc</mm:think>def", add_special_tokens=False)
@@ -716,3 +739,30 @@ def test_prompt_reasoning_state_follows_thinking_mode(thinking_mode, expected):
     )
 
     assert parser.is_reasoning_end_from_prompt(prompt_token_ids) is expected
+
+
+@pytest.mark.parametrize(
+    "continuation_kwargs",
+    [
+        {"_vllm_continue_final_message_content": "<mm:think>partial plan"},
+        {
+            "_vllm_continue_final_message_content": "",
+            "_vllm_continue_final_message_reasoning": "partial plan",
+            "_vllm_continue_final_message_reasoning_ended": False,
+        },
+    ],
+)
+def test_disabled_mode_preserves_open_reasoning_continuation(continuation_kwargs):
+    parser, tokenizer = make_parser(
+        chat_template_kwargs={
+            "thinking_mode": "disabled",
+            "_vllm_continue_final_message": True,
+            **continuation_kwargs,
+        }
+    )
+
+    assert (
+        parser.is_reasoning_end_from_prompt(tokenizer.encode("partial plan")) is False
+    )
+    assert parser._initial_in_reasoning is True
+    assert parser._reasoning_active_streaming is True

--- a/tests/v1/structured_output/test_reasoning_structured_output.py
+++ b/tests/v1/structured_output/test_reasoning_structured_output.py
@@ -6,6 +6,7 @@
 from unittest.mock import Mock
 
 import pytest
+import torch
 
 from vllm.config import ModelConfig, SchedulerConfig, VllmConfig
 from vllm.v1.request import Request
@@ -16,7 +17,9 @@ from vllm.v1.structured_output.backend_types import StructuredOutputOptions
 class MockReasoner:
     def __init__(self, tokenizer):
         self.is_reasoning_end = Mock(return_value=False)
+        self.is_reasoning_end_from_prompt = Mock(return_value=False)
         self.is_reasoning_end_streaming = Mock(return_value=False)
+        self.extract_content_ids = Mock(return_value=[])
 
 
 class TestReasoningStructuredOutput:
@@ -62,6 +65,9 @@ class TestReasoningStructuredOutput:
         request = Mock(spec=Request)
         request.structured_output_request = Mock()
         request.structured_output_request.reasoning_ended = None
+        request.structured_output_request.reasoning_end_token_index = None
+        request.structured_output_request.deferred_grammar_start_index = None
+        request.structured_output_request.reasoning_prompt_state_initialized = False
         request.structured_output_request.grammar = Mock()
         request.structured_output_request.reasoning_parser_kwargs = None
         request.structured_output_request.reasoner = None
@@ -70,6 +76,7 @@ class TestReasoningStructuredOutput:
         )
         request.use_structured_output = True
         request.prompt_token_ids = [1, 2, 3, 4, 5]
+        request.num_prompt_tokens = 5
         request.all_token_ids = [1, 2, 3, 4, 5, 6, 7, 8]
         request.num_computed_tokens = 5
         request.num_output_placeholders = 0
@@ -117,6 +124,53 @@ class TestReasoningStructuredOutput:
         )
         assert result is False
 
+        reasoner = (
+            mock_request_with_structured_output.structured_output_request.reasoner
+        )
+        reasoner.is_reasoning_end_from_prompt.assert_called_once_with([1, 2, 3, 4, 5])
+        reasoner.is_reasoning_end.assert_not_called()
+
+    def test_should_fill_bitmask_preserves_deferred_prompt_state(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """Test adaptive reasoning remains deferred after prompt inspection."""
+        reasoner = MockReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end.return_value = True
+        reasoner.is_reasoning_end_from_prompt.return_value = None
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoner = reasoner
+
+        result = manager_with_reasoner.should_fill_bitmask(
+            mock_request_with_structured_output
+        )
+
+        assert result is False
+        assert structured_req.reasoning_ended is None
+        reasoner.is_reasoning_end_from_prompt.assert_called_once_with([1, 2, 3, 4, 5])
+        reasoner.is_reasoning_end.assert_not_called()
+
+    def test_should_fill_bitmask_initializes_forwarded_open_state(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """Engine parsers inspect open continuations despite a forwarded state."""
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = False
+
+        result = manager_with_reasoner.should_fill_bitmask(
+            mock_request_with_structured_output
+        )
+
+        assert result is False
+        assert structured_req.reasoning_ended is False
+        assert structured_req.reasoning_prompt_state_initialized is True
+        structured_req.reasoner.is_reasoning_end_from_prompt.assert_called_once_with(
+            [1, 2, 3, 4, 5]
+        )
+
     def test_should_fill_bitmask_no_reasoner(
         self, mock_vllm_config, mock_request_with_structured_output
     ):
@@ -139,6 +193,9 @@ class TestReasoningStructuredOutput:
 
             def is_reasoning_end(self, input_ids):
                 return not self.chat_template_kwargs.get("enable_thinking", False)
+
+            def is_reasoning_end_from_prompt(self, prompt_token_ids):
+                return self.is_reasoning_end(prompt_token_ids)
 
         manager = StructuredOutputManager(mock_vllm_config)
         manager.reasoner_cls = KwargReasoner
@@ -189,6 +246,210 @@ class TestReasoningStructuredOutput:
 
         # Should return False since reasoning hasn't ended
         assert result is False
+
+    def test_should_advance_ignores_prompt_reasoning_markers(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """Adaptive reasoning detection only inspects generated tokens."""
+        start_marker = 101
+        end_marker = 102
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = None
+
+        reasoner = MockReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_from_prompt.return_value = None
+        reasoner.is_reasoning_end_streaming = Mock(
+            side_effect=lambda input_ids, delta_ids: end_marker in list(input_ids)
+        )
+        structured_req.reasoner = reasoner
+
+        mock_request_with_structured_output.prompt_token_ids = [
+            start_marker,
+            end_marker,
+        ]
+        mock_request_with_structured_output.num_prompt_tokens = 2
+        mock_request_with_structured_output.all_token_ids = [
+            start_marker,
+            end_marker,
+            start_marker,
+        ]
+
+        result = manager_with_reasoner.should_advance(
+            mock_request_with_structured_output,
+            new_token_ids=[start_marker],
+        )
+
+        assert result is False
+        assert structured_req.reasoning_ended is None
+        input_ids, delta_ids = reasoner.is_reasoning_end_streaming.call_args.args
+        assert list(input_ids) == [start_marker]
+        assert list(delta_ids) == [start_marker]
+
+    def test_should_advance_replays_adaptive_direct_content(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """The token that resolves adaptive mode as content reaches the grammar."""
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = None
+
+        reasoner = MockReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_from_prompt.return_value = None
+        reasoner.is_reasoning_end_streaming.return_value = True
+        reasoner.extract_content_ids.side_effect = lambda token_ids: list(token_ids)
+        structured_req.reasoner = reasoner
+
+        prompt_token_ids = [1, 2, 3]
+        direct_content_token = 400
+        mock_request_with_structured_output.prompt_token_ids = prompt_token_ids
+        mock_request_with_structured_output.num_prompt_tokens = len(prompt_token_ids)
+        mock_request_with_structured_output.all_token_ids = [
+            *prompt_token_ids,
+            direct_content_token,
+        ]
+
+        assert manager_with_reasoner.should_advance(
+            mock_request_with_structured_output,
+            new_token_ids=[direct_content_token],
+        )
+        assert structured_req.reasoning_ended is True
+        assert structured_req.reasoning_end_token_index is None
+        assert structured_req.deferred_grammar_start_index == len(prompt_token_ids)
+        assert manager_with_reasoner.trim_reasoning_for_advance(
+            mock_request_with_structured_output, [direct_content_token]
+        ) == [direct_content_token]
+        assert structured_req.deferred_grammar_start_index is None
+
+    def test_should_advance_replays_ambiguous_adaptive_prefix(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """Earlier unconstrained prefix tokens are replayed with direct content."""
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = None
+
+        reasoner = MockReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_from_prompt.return_value = None
+        reasoner.is_reasoning_end_streaming.return_value = True
+        reasoner.extract_content_ids.side_effect = lambda token_ids: list(token_ids)
+        structured_req.reasoner = reasoner
+
+        prompt_token_ids = [1, 2, 3]
+        output_token_ids = [401, 402]
+        mock_request_with_structured_output.prompt_token_ids = prompt_token_ids
+        mock_request_with_structured_output.num_prompt_tokens = len(prompt_token_ids)
+        mock_request_with_structured_output.all_token_ids = [
+            *prompt_token_ids,
+            *output_token_ids,
+        ]
+
+        assert manager_with_reasoner.should_advance(
+            mock_request_with_structured_output,
+            new_token_ids=[output_token_ids[-1]],
+        )
+        assert (
+            manager_with_reasoner.trim_reasoning_for_advance(
+                mock_request_with_structured_output, [output_token_ids[-1]]
+            )
+            == output_token_ids
+        )
+
+    def test_speculative_reasoning_detection_ignores_prompt_markers(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """Speculative draft simulation starts after the prompt boundary."""
+        start_marker = 101
+        end_marker = 102
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = None
+
+        reasoner = MockReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_from_prompt.return_value = None
+        reasoner.is_reasoning_end_streaming = Mock(
+            side_effect=lambda input_ids, delta_ids: end_marker in list(input_ids)
+        )
+        structured_req.reasoner = reasoner
+
+        mock_request_with_structured_output.prompt_token_ids = [
+            start_marker,
+            end_marker,
+        ]
+        mock_request_with_structured_output.num_prompt_tokens = 2
+        mock_request_with_structured_output.all_token_ids = [
+            start_marker,
+            end_marker,
+        ]
+
+        manager_with_reasoner.vllm_config.num_speculative_tokens = 1
+        manager_with_reasoner.vllm_config.model_config.is_diffusion = False
+        manager_with_reasoner.backend = Mock()
+        manager_with_reasoner.backend.allocate_token_bitmask.return_value = torch.zeros(
+            (2, 1), dtype=torch.int32
+        )
+
+        request_id = mock_request_with_structured_output.request_id
+        manager_with_reasoner.grammar_bitmask(
+            requests={request_id: mock_request_with_structured_output},
+            structured_output_request_ids=[request_id],
+            scheduled_spec_decode_tokens={request_id: [start_marker]},
+        )
+
+        input_ids, delta_ids = reasoner.is_reasoning_end_streaming.call_args.args
+        assert list(input_ids) == [start_marker]
+        assert list(delta_ids) == [start_marker]
+        structured_req.grammar.fill_bitmask.assert_not_called()
+
+    def test_speculative_adaptive_direct_content_advances_grammar(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """Later speculative rows include direct adaptive content state."""
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = None
+
+        reasoner = MockReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_from_prompt.return_value = None
+        reasoner.is_reasoning_end_streaming.return_value = True
+        reasoner.extract_content_ids.side_effect = lambda token_ids: list(token_ids)
+        structured_req.reasoner = reasoner
+        structured_req.grammar.validate_tokens.side_effect = lambda token_ids: list(
+            token_ids
+        )
+        structured_req.grammar.accept_tokens.return_value = True
+
+        prompt_token_ids = [1, 2, 3]
+        mock_request_with_structured_output.prompt_token_ids = prompt_token_ids
+        mock_request_with_structured_output.num_prompt_tokens = len(prompt_token_ids)
+        mock_request_with_structured_output.all_token_ids = prompt_token_ids
+
+        manager_with_reasoner.vllm_config.num_speculative_tokens = 2
+        manager_with_reasoner.vllm_config.model_config.is_diffusion = False
+        manager_with_reasoner.backend = Mock()
+        manager_with_reasoner.backend.allocate_token_bitmask.return_value = torch.zeros(
+            (3, 1), dtype=torch.int32
+        )
+
+        request_id = mock_request_with_structured_output.request_id
+        direct_tokens = [501, 502]
+        manager_with_reasoner.grammar_bitmask(
+            requests={request_id: mock_request_with_structured_output},
+            structured_output_request_ids=[request_id],
+            scheduled_spec_decode_tokens={request_id: direct_tokens},
+        )
+
+        accepted_token_batches = [
+            mock_call.args[1]
+            for mock_call in structured_req.grammar.accept_tokens.call_args_list
+        ]
+        assert accepted_token_batches == [[direct_tokens[0]], [direct_tokens[1]]]
+        structured_req.grammar.rollback.assert_called_once_with(len(direct_tokens))
 
     def test_should_advance_reasoning_just_ended(
         self,
@@ -247,12 +508,16 @@ class TestReasoningStructuredOutput:
         structured_req.reasoning_ended = False
 
         end_token_id = 248069
+        seen_delta_ids: list[list[int]] = []
+
+        def detects_reasoning_end(input_ids, delta_ids):
+            delta_ids = list(delta_ids)
+            seen_delta_ids.append(delta_ids)
+            return end_token_id in delta_ids
 
         reasoner = MockReasoner(tokenizer=Mock())
         # Detection mirrors the real Qwen3 parser: end token in the delta.
-        reasoner.is_reasoning_end_streaming = Mock(
-            side_effect=lambda input_ids, delta_ids: end_token_id in list(delta_ids)
-        )
+        reasoner.is_reasoning_end_streaming = Mock(side_effect=detects_reasoning_end)
         structured_req.reasoner = reasoner
 
         # Scenario from #43388: async + spec decode K=4, 4 tokens accepted
@@ -277,9 +542,7 @@ class TestReasoningStructuredOutput:
 
         # First call to is_reasoning_end_streaming was with the full
         # new_token_ids (not the truncated placeholder window).
-        first_call = reasoner.is_reasoning_end_streaming.call_args_list[0]
-        _, called_delta = first_call.args
-        assert list(called_delta) == new_token_ids
+        assert seen_delta_ids[0] == new_token_ids
 
         assert structured_req.reasoning_ended is True
         assert result is True
@@ -298,17 +561,17 @@ class TestReasoningStructuredOutput:
         reasoner.is_reasoning_end_streaming.return_value = False
         structured_req.reasoner = reasoner
 
-        mock_request_with_structured_output.all_token_ids = [1, 2, 3, 4, 5]
-        mock_request_with_structured_output.num_computed_tokens = 5
+        mock_request_with_structured_output.all_token_ids = [1, 2, 3, 4, 5, 6, 7]
+        mock_request_with_structured_output.num_computed_tokens = 7
         mock_request_with_structured_output.num_output_placeholders = 2
 
         result = manager_with_reasoner.should_advance(
             mock_request_with_structured_output
         )
 
-        # placeholder window: start = 5 - 2 = 3, delta = [4, 5]
+        # placeholder window: start = 7 - 2 = 5, delta = [6, 7]
         _, called_delta = reasoner.is_reasoning_end_streaming.call_args[0]
-        assert list(called_delta) == [4, 5]
+        assert list(called_delta) == [6, 7]
         assert result is False
 
     def test_should_advance_trims_reasoning_prefix_for_json(
@@ -330,12 +593,17 @@ class TestReasoningStructuredOutput:
             def __init__(self, *_, **__):
                 pass
 
+            def is_reasoning_end_from_prompt(self, prompt_token_ids):
+                return False
+
             def is_reasoning_end_streaming(self, input_ids, delta_ids):
                 return marker in list(delta_ids)
 
         structured_req.reasoner = MarkerReasoner()
 
         new_token_ids = [9, 198, marker, 271, 5005]
+        mock_request_with_structured_output.prompt_token_ids = [1, 2, 3]
+        mock_request_with_structured_output.num_prompt_tokens = 3
         mock_request_with_structured_output.all_token_ids = [1, 2, 3] + new_token_ids
 
         result = manager_with_reasoner.should_advance(

--- a/tests/v1/structured_output/test_reasoning_structured_output.py
+++ b/tests/v1/structured_output/test_reasoning_structured_output.py
@@ -26,6 +26,15 @@ class AdaptiveMarkerReasoner(MockReasoner):
     reasoning_marker_token_ids = ((5, 6), (7, 8))
 
 
+class RuntimeSplitAdaptiveMarkerReasoner(AdaptiveMarkerReasoner):
+    def reasoning_marker_token_state(self, output_token_ids):
+        if not output_token_ids:
+            return False, (5, 7, 9)
+        if tuple(output_token_ids) == (9,):
+            return False, (10,)
+        return False, ()
+
+
 def _bitmask_allows(bitmask, token_id: int) -> bool:
     word_index, bit_index = divmod(token_id, 32)
     return bool((int(bitmask[word_index]) >> bit_index) & 1)
@@ -234,6 +243,42 @@ class TestReasoningStructuredOutput:
 
         assert _bitmask_allows(bitmask, 6)
         assert not _bitmask_allows(bitmask, 10)
+        structured_req.grammar.fill_bitmask.assert_not_called()
+
+    def test_adaptive_bitmask_admits_runtime_split_marker_tokens(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """Decoded marker alternatives are included in the adaptive mask."""
+        structured_req = mock_request_with_structured_output.structured_output_request
+        reasoner = RuntimeSplitAdaptiveMarkerReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_from_prompt.return_value = None
+        structured_req.reasoner = reasoner
+        structured_req.reasoning_ended = None
+        structured_req.grammar.validate_tokens.return_value = []
+
+        prompt_token_ids = [1, 2, 3]
+        mock_request_with_structured_output.prompt_token_ids = prompt_token_ids
+        mock_request_with_structured_output.num_prompt_tokens = len(prompt_token_ids)
+        mock_request_with_structured_output.all_token_ids = [*prompt_token_ids, 9]
+
+        manager_with_reasoner.vllm_config.num_speculative_tokens = 0
+        manager_with_reasoner.vllm_config.model_config.is_diffusion = False
+        manager_with_reasoner.backend = Mock()
+        manager_with_reasoner.backend.allocate_token_bitmask.return_value = torch.zeros(
+            (1, 2), dtype=torch.int32
+        )
+
+        request_id = mock_request_with_structured_output.request_id
+        (bitmask,) = manager_with_reasoner.grammar_bitmask(
+            requests={request_id: mock_request_with_structured_output},
+            structured_output_request_ids=[request_id],
+            scheduled_spec_decode_tokens={},
+        )
+
+        assert _bitmask_allows(bitmask, 10)
+        assert not _bitmask_allows(bitmask, 5)
         structured_req.grammar.fill_bitmask.assert_not_called()
 
     def test_should_fill_bitmask_initializes_forwarded_open_state(

--- a/tests/v1/structured_output/test_reasoning_structured_output.py
+++ b/tests/v1/structured_output/test_reasoning_structured_output.py
@@ -22,6 +22,15 @@ class MockReasoner:
         self.extract_content_ids = Mock(return_value=[])
 
 
+class AdaptiveMarkerReasoner(MockReasoner):
+    reasoning_marker_token_ids = ((5, 6), (7, 8))
+
+
+def _bitmask_allows(bitmask, token_id: int) -> bool:
+    word_index, bit_index = divmod(token_id, 32)
+    return bool((int(bitmask[word_index]) >> bit_index) & 1)
+
+
 class TestReasoningStructuredOutput:
     """Test reasoning-aware structured output functionality."""
 
@@ -150,6 +159,82 @@ class TestReasoningStructuredOutput:
         assert structured_req.reasoning_ended is None
         reasoner.is_reasoning_end_from_prompt.assert_called_once_with([1, 2, 3, 4, 5])
         reasoner.is_reasoning_end.assert_not_called()
+
+    def test_adaptive_initial_bitmask_unions_grammar_and_reasoning_markers(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """Illegal direct tokens are masked before adaptive mode is resolved."""
+        structured_req = mock_request_with_structured_output.structured_output_request
+        reasoner = AdaptiveMarkerReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_from_prompt.return_value = None
+        structured_req.reasoner = reasoner
+        structured_req.reasoning_ended = None
+
+        prompt_token_ids = [1, 2, 3]
+        mock_request_with_structured_output.prompt_token_ids = prompt_token_ids
+        mock_request_with_structured_output.num_prompt_tokens = len(prompt_token_ids)
+        mock_request_with_structured_output.all_token_ids = prompt_token_ids
+
+        grammar_token = 10
+        structured_req.grammar.fill_bitmask.side_effect = lambda bitmask, index: (
+            bitmask[index, 0].bitwise_or_(1 << grammar_token)
+        )
+        manager_with_reasoner.vllm_config.num_speculative_tokens = 0
+        manager_with_reasoner.vllm_config.model_config.is_diffusion = False
+        manager_with_reasoner.backend = Mock()
+        manager_with_reasoner.backend.allocate_token_bitmask.return_value = torch.zeros(
+            (1, 2), dtype=torch.int32
+        )
+
+        request_id = mock_request_with_structured_output.request_id
+        (bitmask,) = manager_with_reasoner.grammar_bitmask(
+            requests={request_id: mock_request_with_structured_output},
+            structured_output_request_ids=[request_id],
+            scheduled_spec_decode_tokens={},
+        )
+
+        assert _bitmask_allows(bitmask, grammar_token)
+        assert _bitmask_allows(bitmask, 5)
+        assert _bitmask_allows(bitmask, 7)
+        assert not _bitmask_allows(bitmask, 11)
+
+    def test_adaptive_invalid_grammar_prefix_only_allows_marker_continuation(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """A grammar-invalid marker prefix cannot branch into direct content."""
+        structured_req = mock_request_with_structured_output.structured_output_request
+        reasoner = AdaptiveMarkerReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_from_prompt.return_value = None
+        structured_req.reasoner = reasoner
+        structured_req.reasoning_ended = None
+        structured_req.grammar.validate_tokens.return_value = []
+
+        prompt_token_ids = [1, 2, 3]
+        mock_request_with_structured_output.prompt_token_ids = prompt_token_ids
+        mock_request_with_structured_output.num_prompt_tokens = len(prompt_token_ids)
+        mock_request_with_structured_output.all_token_ids = [*prompt_token_ids, 5]
+
+        manager_with_reasoner.vllm_config.num_speculative_tokens = 0
+        manager_with_reasoner.vllm_config.model_config.is_diffusion = False
+        manager_with_reasoner.backend = Mock()
+        manager_with_reasoner.backend.allocate_token_bitmask.return_value = torch.zeros(
+            (1, 2), dtype=torch.int32
+        )
+
+        request_id = mock_request_with_structured_output.request_id
+        (bitmask,) = manager_with_reasoner.grammar_bitmask(
+            requests={request_id: mock_request_with_structured_output},
+            structured_output_request_ids=[request_id],
+            scheduled_spec_decode_tokens={},
+        )
+
+        assert _bitmask_allows(bitmask, 6)
+        assert not _bitmask_allows(bitmask, 10)
+        structured_req.grammar.fill_bitmask.assert_not_called()
 
     def test_should_fill_bitmask_initializes_forwarded_open_state(
         self,

--- a/tests/v1/structured_output/test_reasoning_structured_output.py
+++ b/tests/v1/structured_output/test_reasoning_structured_output.py
@@ -22,6 +22,15 @@ class MockReasoner:
         self.extract_content_ids = Mock(return_value=[])
 
 
+class AdaptiveMarkerReasoner(MockReasoner):
+    reasoning_marker_token_ids = ((5, 6), (7, 8))
+
+
+def _bitmask_allows(bitmask, token_id: int) -> bool:
+    word_index, bit_index = divmod(token_id, 32)
+    return bool((int(bitmask[word_index]) >> bit_index) & 1)
+
+
 class TestReasoningStructuredOutput:
     """Test reasoning-aware structured output functionality."""
 
@@ -195,6 +204,82 @@ class TestReasoningStructuredOutput:
         assert structured_req.reasoning_ended is None
         reasoner.is_reasoning_end_from_prompt.assert_called_once_with([1, 2, 3, 4, 5])
         reasoner.is_reasoning_end.assert_not_called()
+
+    def test_adaptive_initial_bitmask_unions_grammar_and_reasoning_markers(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """Illegal direct tokens are masked before adaptive mode is resolved."""
+        structured_req = mock_request_with_structured_output.structured_output_request
+        reasoner = AdaptiveMarkerReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_from_prompt.return_value = None
+        structured_req.reasoner = reasoner
+        structured_req.reasoning_ended = None
+
+        prompt_token_ids = [1, 2, 3]
+        mock_request_with_structured_output.prompt_token_ids = prompt_token_ids
+        mock_request_with_structured_output.num_prompt_tokens = len(prompt_token_ids)
+        mock_request_with_structured_output.all_token_ids = prompt_token_ids
+
+        grammar_token = 10
+        structured_req.grammar.fill_bitmask.side_effect = lambda bitmask, index: (
+            bitmask[index, 0].bitwise_or_(1 << grammar_token)
+        )
+        manager_with_reasoner.vllm_config.num_speculative_tokens = 0
+        manager_with_reasoner.vllm_config.model_config.is_diffusion = False
+        manager_with_reasoner.backend = Mock()
+        manager_with_reasoner.backend.allocate_token_bitmask.return_value = torch.zeros(
+            (1, 2), dtype=torch.int32
+        )
+
+        request_id = mock_request_with_structured_output.request_id
+        (bitmask,) = manager_with_reasoner.grammar_bitmask(
+            requests={request_id: mock_request_with_structured_output},
+            structured_output_request_ids=[request_id],
+            scheduled_spec_decode_tokens={},
+        )
+
+        assert _bitmask_allows(bitmask, grammar_token)
+        assert _bitmask_allows(bitmask, 5)
+        assert _bitmask_allows(bitmask, 7)
+        assert not _bitmask_allows(bitmask, 11)
+
+    def test_adaptive_invalid_grammar_prefix_only_allows_marker_continuation(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """A grammar-invalid marker prefix cannot branch into direct content."""
+        structured_req = mock_request_with_structured_output.structured_output_request
+        reasoner = AdaptiveMarkerReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_from_prompt.return_value = None
+        structured_req.reasoner = reasoner
+        structured_req.reasoning_ended = None
+        structured_req.grammar.validate_tokens.return_value = []
+
+        prompt_token_ids = [1, 2, 3]
+        mock_request_with_structured_output.prompt_token_ids = prompt_token_ids
+        mock_request_with_structured_output.num_prompt_tokens = len(prompt_token_ids)
+        mock_request_with_structured_output.all_token_ids = [*prompt_token_ids, 5]
+
+        manager_with_reasoner.vllm_config.num_speculative_tokens = 0
+        manager_with_reasoner.vllm_config.model_config.is_diffusion = False
+        manager_with_reasoner.backend = Mock()
+        manager_with_reasoner.backend.allocate_token_bitmask.return_value = torch.zeros(
+            (1, 2), dtype=torch.int32
+        )
+
+        request_id = mock_request_with_structured_output.request_id
+        (bitmask,) = manager_with_reasoner.grammar_bitmask(
+            requests={request_id: mock_request_with_structured_output},
+            structured_output_request_ids=[request_id],
+            scheduled_spec_decode_tokens={},
+        )
+
+        assert _bitmask_allows(bitmask, 6)
+        assert not _bitmask_allows(bitmask, 10)
+        structured_req.grammar.fill_bitmask.assert_not_called()
 
     def test_should_fill_bitmask_initializes_forwarded_open_state(
         self,

--- a/tests/v1/structured_output/test_reasoning_structured_output.py
+++ b/tests/v1/structured_output/test_reasoning_structured_output.py
@@ -6,6 +6,7 @@
 from unittest.mock import Mock
 
 import pytest
+import torch
 
 from vllm.config import ModelConfig, SchedulerConfig, VllmConfig
 from vllm.v1.request import Request
@@ -16,7 +17,9 @@ from vllm.v1.structured_output.backend_types import StructuredOutputOptions
 class MockReasoner:
     def __init__(self, tokenizer):
         self.is_reasoning_end = Mock(return_value=False)
+        self.is_reasoning_end_from_prompt = Mock(return_value=False)
         self.is_reasoning_end_streaming = Mock(return_value=False)
+        self.extract_content_ids = Mock(return_value=[])
 
 
 class TestReasoningStructuredOutput:
@@ -62,6 +65,9 @@ class TestReasoningStructuredOutput:
         request = Mock(spec=Request)
         request.structured_output_request = Mock()
         request.structured_output_request.reasoning_ended = None
+        request.structured_output_request.reasoning_end_token_index = None
+        request.structured_output_request.deferred_grammar_start_index = None
+        request.structured_output_request.reasoning_prompt_state_initialized = False
         request.structured_output_request.grammar = Mock()
         request.structured_output_request.reasoning_parser_kwargs = None
         request.structured_output_request.reasoner = None
@@ -70,6 +76,7 @@ class TestReasoningStructuredOutput:
         )
         request.use_structured_output = True
         request.prompt_token_ids = [1, 2, 3, 4, 5]
+        request.num_prompt_tokens = 5
         request.all_token_ids = [1, 2, 3, 4, 5, 6, 7, 8]
         request.num_computed_tokens = 5
         request.num_output_placeholders = 0
@@ -162,6 +169,53 @@ class TestReasoningStructuredOutput:
         )
         assert result is False
 
+        reasoner = (
+            mock_request_with_structured_output.structured_output_request.reasoner
+        )
+        reasoner.is_reasoning_end_from_prompt.assert_called_once_with([1, 2, 3, 4, 5])
+        reasoner.is_reasoning_end.assert_not_called()
+
+    def test_should_fill_bitmask_preserves_deferred_prompt_state(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """Test adaptive reasoning remains deferred after prompt inspection."""
+        reasoner = MockReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end.return_value = True
+        reasoner.is_reasoning_end_from_prompt.return_value = None
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoner = reasoner
+
+        result = manager_with_reasoner.should_fill_bitmask(
+            mock_request_with_structured_output
+        )
+
+        assert result is False
+        assert structured_req.reasoning_ended is None
+        reasoner.is_reasoning_end_from_prompt.assert_called_once_with([1, 2, 3, 4, 5])
+        reasoner.is_reasoning_end.assert_not_called()
+
+    def test_should_fill_bitmask_initializes_forwarded_open_state(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """Engine parsers inspect open continuations despite a forwarded state."""
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = False
+
+        result = manager_with_reasoner.should_fill_bitmask(
+            mock_request_with_structured_output
+        )
+
+        assert result is False
+        assert structured_req.reasoning_ended is False
+        assert structured_req.reasoning_prompt_state_initialized is True
+        structured_req.reasoner.is_reasoning_end_from_prompt.assert_called_once_with(
+            [1, 2, 3, 4, 5]
+        )
+
     def test_should_fill_bitmask_no_reasoner(
         self, mock_vllm_config, mock_request_with_structured_output
     ):
@@ -184,6 +238,9 @@ class TestReasoningStructuredOutput:
 
             def is_reasoning_end(self, input_ids):
                 return not self.chat_template_kwargs.get("enable_thinking", False)
+
+            def is_reasoning_end_from_prompt(self, prompt_token_ids):
+                return self.is_reasoning_end(prompt_token_ids)
 
         manager = StructuredOutputManager(mock_vllm_config)
         manager.reasoner_cls = KwargReasoner
@@ -238,6 +295,210 @@ class TestReasoningStructuredOutput:
 
         # Should return False since reasoning hasn't ended
         assert result is False
+
+    def test_should_advance_ignores_prompt_reasoning_markers(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """Adaptive reasoning detection only inspects generated tokens."""
+        start_marker = 101
+        end_marker = 102
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = None
+
+        reasoner = MockReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_from_prompt.return_value = None
+        reasoner.is_reasoning_end_streaming = Mock(
+            side_effect=lambda input_ids, delta_ids: end_marker in list(input_ids)
+        )
+        structured_req.reasoner = reasoner
+
+        mock_request_with_structured_output.prompt_token_ids = [
+            start_marker,
+            end_marker,
+        ]
+        mock_request_with_structured_output.num_prompt_tokens = 2
+        mock_request_with_structured_output.all_token_ids = [
+            start_marker,
+            end_marker,
+            start_marker,
+        ]
+
+        result = manager_with_reasoner.should_advance(
+            mock_request_with_structured_output,
+            new_token_ids=[start_marker],
+        )
+
+        assert result is False
+        assert structured_req.reasoning_ended is None
+        input_ids, delta_ids = reasoner.is_reasoning_end_streaming.call_args.args
+        assert list(input_ids) == [start_marker]
+        assert list(delta_ids) == [start_marker]
+
+    def test_should_advance_replays_adaptive_direct_content(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """The token that resolves adaptive mode as content reaches the grammar."""
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = None
+
+        reasoner = MockReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_from_prompt.return_value = None
+        reasoner.is_reasoning_end_streaming.return_value = True
+        reasoner.extract_content_ids.side_effect = lambda token_ids: list(token_ids)
+        structured_req.reasoner = reasoner
+
+        prompt_token_ids = [1, 2, 3]
+        direct_content_token = 400
+        mock_request_with_structured_output.prompt_token_ids = prompt_token_ids
+        mock_request_with_structured_output.num_prompt_tokens = len(prompt_token_ids)
+        mock_request_with_structured_output.all_token_ids = [
+            *prompt_token_ids,
+            direct_content_token,
+        ]
+
+        assert manager_with_reasoner.should_advance(
+            mock_request_with_structured_output,
+            new_token_ids=[direct_content_token],
+        )
+        assert structured_req.reasoning_ended is True
+        assert structured_req.reasoning_end_token_index is None
+        assert structured_req.deferred_grammar_start_index == len(prompt_token_ids)
+        assert manager_with_reasoner.trim_reasoning_for_advance(
+            mock_request_with_structured_output, [direct_content_token]
+        ) == [direct_content_token]
+        assert structured_req.deferred_grammar_start_index is None
+
+    def test_should_advance_replays_ambiguous_adaptive_prefix(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """Earlier unconstrained prefix tokens are replayed with direct content."""
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = None
+
+        reasoner = MockReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_from_prompt.return_value = None
+        reasoner.is_reasoning_end_streaming.return_value = True
+        reasoner.extract_content_ids.side_effect = lambda token_ids: list(token_ids)
+        structured_req.reasoner = reasoner
+
+        prompt_token_ids = [1, 2, 3]
+        output_token_ids = [401, 402]
+        mock_request_with_structured_output.prompt_token_ids = prompt_token_ids
+        mock_request_with_structured_output.num_prompt_tokens = len(prompt_token_ids)
+        mock_request_with_structured_output.all_token_ids = [
+            *prompt_token_ids,
+            *output_token_ids,
+        ]
+
+        assert manager_with_reasoner.should_advance(
+            mock_request_with_structured_output,
+            new_token_ids=[output_token_ids[-1]],
+        )
+        assert (
+            manager_with_reasoner.trim_reasoning_for_advance(
+                mock_request_with_structured_output, [output_token_ids[-1]]
+            )
+            == output_token_ids
+        )
+
+    def test_speculative_reasoning_detection_ignores_prompt_markers(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """Speculative draft simulation starts after the prompt boundary."""
+        start_marker = 101
+        end_marker = 102
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = None
+
+        reasoner = MockReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_from_prompt.return_value = None
+        reasoner.is_reasoning_end_streaming = Mock(
+            side_effect=lambda input_ids, delta_ids: end_marker in list(input_ids)
+        )
+        structured_req.reasoner = reasoner
+
+        mock_request_with_structured_output.prompt_token_ids = [
+            start_marker,
+            end_marker,
+        ]
+        mock_request_with_structured_output.num_prompt_tokens = 2
+        mock_request_with_structured_output.all_token_ids = [
+            start_marker,
+            end_marker,
+        ]
+
+        manager_with_reasoner.vllm_config.num_speculative_tokens = 1
+        manager_with_reasoner.vllm_config.model_config.is_diffusion = False
+        manager_with_reasoner.backend = Mock()
+        manager_with_reasoner.backend.allocate_token_bitmask.return_value = torch.zeros(
+            (2, 1), dtype=torch.int32
+        )
+
+        request_id = mock_request_with_structured_output.request_id
+        manager_with_reasoner.grammar_bitmask(
+            requests={request_id: mock_request_with_structured_output},
+            structured_output_request_ids=[request_id],
+            scheduled_spec_decode_tokens={request_id: [start_marker]},
+        )
+
+        input_ids, delta_ids = reasoner.is_reasoning_end_streaming.call_args.args
+        assert list(input_ids) == [start_marker]
+        assert list(delta_ids) == [start_marker]
+        structured_req.grammar.fill_bitmask.assert_not_called()
+
+    def test_speculative_adaptive_direct_content_advances_grammar(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """Later speculative rows include direct adaptive content state."""
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = None
+
+        reasoner = MockReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_from_prompt.return_value = None
+        reasoner.is_reasoning_end_streaming.return_value = True
+        reasoner.extract_content_ids.side_effect = lambda token_ids: list(token_ids)
+        structured_req.reasoner = reasoner
+        structured_req.grammar.validate_tokens.side_effect = lambda token_ids: list(
+            token_ids
+        )
+        structured_req.grammar.accept_tokens.return_value = True
+
+        prompt_token_ids = [1, 2, 3]
+        mock_request_with_structured_output.prompt_token_ids = prompt_token_ids
+        mock_request_with_structured_output.num_prompt_tokens = len(prompt_token_ids)
+        mock_request_with_structured_output.all_token_ids = prompt_token_ids
+
+        manager_with_reasoner.vllm_config.num_speculative_tokens = 2
+        manager_with_reasoner.vllm_config.model_config.is_diffusion = False
+        manager_with_reasoner.backend = Mock()
+        manager_with_reasoner.backend.allocate_token_bitmask.return_value = torch.zeros(
+            (3, 1), dtype=torch.int32
+        )
+
+        request_id = mock_request_with_structured_output.request_id
+        direct_tokens = [501, 502]
+        manager_with_reasoner.grammar_bitmask(
+            requests={request_id: mock_request_with_structured_output},
+            structured_output_request_ids=[request_id],
+            scheduled_spec_decode_tokens={request_id: direct_tokens},
+        )
+
+        accepted_token_batches = [
+            mock_call.args[1]
+            for mock_call in structured_req.grammar.accept_tokens.call_args_list
+        ]
+        assert accepted_token_batches == [[direct_tokens[0]], [direct_tokens[1]]]
+        structured_req.grammar.rollback.assert_called_once_with(len(direct_tokens))
 
     def test_should_advance_reasoning_just_ended(
         self,
@@ -300,12 +561,16 @@ class TestReasoningStructuredOutput:
         structured_req.reasoning_ended = False
 
         end_token_id = 248069
+        seen_delta_ids: list[list[int]] = []
+
+        def detects_reasoning_end(input_ids, delta_ids):
+            delta_ids = list(delta_ids)
+            seen_delta_ids.append(delta_ids)
+            return end_token_id in delta_ids
 
         reasoner = MockReasoner(tokenizer=Mock())
         # Detection mirrors the real Qwen3 parser: end token in the delta.
-        reasoner.is_reasoning_end_streaming = Mock(
-            side_effect=lambda input_ids, delta_ids: end_token_id in list(delta_ids)
-        )
+        reasoner.is_reasoning_end_streaming = Mock(side_effect=detects_reasoning_end)
         structured_req.reasoner = reasoner
 
         # Scenario from #43388: async + spec decode K=4, 4 tokens accepted
@@ -330,9 +595,7 @@ class TestReasoningStructuredOutput:
 
         # First call to is_reasoning_end_streaming was with the full
         # new_token_ids (not the truncated placeholder window).
-        first_call = reasoner.is_reasoning_end_streaming.call_args_list[0]
-        _, called_delta = first_call.args
-        assert list(called_delta) == new_token_ids
+        assert seen_delta_ids[0] == new_token_ids
 
         assert structured_req.reasoning_ended is True
         assert result is True
@@ -351,17 +614,17 @@ class TestReasoningStructuredOutput:
         reasoner.is_reasoning_end_streaming.return_value = False
         structured_req.reasoner = reasoner
 
-        mock_request_with_structured_output.all_token_ids = [1, 2, 3, 4, 5]
-        mock_request_with_structured_output.num_computed_tokens = 5
+        mock_request_with_structured_output.all_token_ids = [1, 2, 3, 4, 5, 6, 7]
+        mock_request_with_structured_output.num_computed_tokens = 7
         mock_request_with_structured_output.num_output_placeholders = 2
 
         result = manager_with_reasoner.should_advance(
             mock_request_with_structured_output
         )
 
-        # placeholder window: start = 5 - 2 = 3, delta = [4, 5]
+        # placeholder window: start = 7 - 2 = 5, delta = [6, 7]
         _, called_delta = reasoner.is_reasoning_end_streaming.call_args[0]
-        assert list(called_delta) == [4, 5]
+        assert list(called_delta) == [6, 7]
         assert result is False
 
     def test_should_advance_trims_reasoning_prefix_for_json(
@@ -383,12 +646,17 @@ class TestReasoningStructuredOutput:
             def __init__(self, *_, **__):
                 pass
 
+            def is_reasoning_end_from_prompt(self, prompt_token_ids):
+                return False
+
             def is_reasoning_end_streaming(self, input_ids, delta_ids):
                 return marker in list(delta_ids)
 
         structured_req.reasoner = MarkerReasoner()
 
         new_token_ids = [9, 198, marker, 271, 5005]
+        mock_request_with_structured_output.prompt_token_ids = [1, 2, 3]
+        mock_request_with_structured_output.num_prompt_tokens = 3
         mock_request_with_structured_output.all_token_ids = [1, 2, 3] + new_token_ids
 
         result = manager_with_reasoner.should_advance(

--- a/tests/v1/structured_output/test_reasoning_structured_output.py
+++ b/tests/v1/structured_output/test_reasoning_structured_output.py
@@ -26,6 +26,15 @@ class AdaptiveMarkerReasoner(MockReasoner):
     reasoning_marker_token_ids = ((5, 6), (7, 8))
 
 
+class RuntimeSplitAdaptiveMarkerReasoner(AdaptiveMarkerReasoner):
+    def reasoning_marker_token_state(self, output_token_ids):
+        if not output_token_ids:
+            return False, (5, 7, 9)
+        if tuple(output_token_ids) == (9,):
+            return False, (10,)
+        return False, ()
+
+
 def _bitmask_allows(bitmask, token_id: int) -> bool:
     word_index, bit_index = divmod(token_id, 32)
     return bool((int(bitmask[word_index]) >> bit_index) & 1)
@@ -279,6 +288,42 @@ class TestReasoningStructuredOutput:
 
         assert _bitmask_allows(bitmask, 6)
         assert not _bitmask_allows(bitmask, 10)
+        structured_req.grammar.fill_bitmask.assert_not_called()
+
+    def test_adaptive_bitmask_admits_runtime_split_marker_tokens(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """Decoded marker alternatives are included in the adaptive mask."""
+        structured_req = mock_request_with_structured_output.structured_output_request
+        reasoner = RuntimeSplitAdaptiveMarkerReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_from_prompt.return_value = None
+        structured_req.reasoner = reasoner
+        structured_req.reasoning_ended = None
+        structured_req.grammar.validate_tokens.return_value = []
+
+        prompt_token_ids = [1, 2, 3]
+        mock_request_with_structured_output.prompt_token_ids = prompt_token_ids
+        mock_request_with_structured_output.num_prompt_tokens = len(prompt_token_ids)
+        mock_request_with_structured_output.all_token_ids = [*prompt_token_ids, 9]
+
+        manager_with_reasoner.vllm_config.num_speculative_tokens = 0
+        manager_with_reasoner.vllm_config.model_config.is_diffusion = False
+        manager_with_reasoner.backend = Mock()
+        manager_with_reasoner.backend.allocate_token_bitmask.return_value = torch.zeros(
+            (1, 2), dtype=torch.int32
+        )
+
+        request_id = mock_request_with_structured_output.request_id
+        (bitmask,) = manager_with_reasoner.grammar_bitmask(
+            requests={request_id: mock_request_with_structured_output},
+            structured_output_request_ids=[request_id],
+            scheduled_spec_decode_tokens={},
+        )
+
+        assert _bitmask_allows(bitmask, 10)
+        assert not _bitmask_allows(bitmask, 5)
         structured_req.grammar.fill_bitmask.assert_not_called()
 
     def test_should_fill_bitmask_initializes_forwarded_open_state(

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -402,6 +402,37 @@ class ConversationMessage(TypedDict, total=False):
     """Model-specific task marker. Currently passed through for DeepSeek V4."""
 
 
+def make_reasoning_parser_chat_template_kwargs(
+    chat_template_kwargs: dict[str, Any],
+    continue_final_message: bool,
+    final_message: ChatCompletionMessageParam | None,
+) -> dict[str, Any]:
+    kwargs = {
+        **chat_template_kwargs,
+        "_vllm_continue_final_message": continue_final_message,
+    }
+    if not continue_final_message or final_message is None:
+        return kwargs
+
+    content = final_message.get("content")
+    if isinstance(content, str):
+        final_content = content
+    elif isinstance(content, list):
+        final_content = "\n".join(
+            text
+            for part in content
+            if isinstance(part, dict) and isinstance((text := part.get("text")), str)
+        )
+    else:
+        final_content = ""
+
+    kwargs["_vllm_continue_final_message_content"] = final_content
+    reasoning = final_message.get("reasoning")
+    if isinstance(reasoning, str):
+        kwargs["_vllm_continue_final_message_reasoning"] = reasoning
+    return kwargs
+
+
 # Passed in by user
 ChatTemplateContentFormatOption = Literal["auto", "string", "openai"]
 

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -408,9 +408,11 @@ def make_reasoning_parser_chat_template_kwargs(
     final_message: ChatCompletionMessageParam | None,
 ) -> dict[str, Any]:
     kwargs = {
-        **chat_template_kwargs,
-        "_vllm_continue_final_message": continue_final_message,
+        key: value
+        for key, value in chat_template_kwargs.items()
+        if not key.startswith("_vllm_continue_final_message")
     }
+    kwargs["_vllm_continue_final_message"] = continue_final_message
     if not continue_final_message or final_message is None:
         return kwargs
 

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -418,11 +418,30 @@ def make_reasoning_parser_chat_template_kwargs(
     if isinstance(content, str):
         final_content = content
     elif isinstance(content, list):
-        final_content = "\n".join(
-            text
-            for part in content
-            if isinstance(part, dict) and isinstance((text := part.get("text")), str)
-        )
+        text_parts: list[str] = []
+        thinking_parts: list[str] = []
+        reasoning_ended: bool | None = None
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            if part.get("type") == "thinking":
+                thinking = part.get("thinking")
+                if isinstance(thinking, str):
+                    thinking_parts.append(thinking)
+                closed = part.get("closed")
+                if isinstance(closed, bool):
+                    reasoning_ended = closed
+                continue
+            text = part.get("text")
+            if isinstance(text, str):
+                text_parts.append(text)
+                if text:
+                    reasoning_ended = True
+        final_content = "\n".join(text_parts)
+        if thinking_parts:
+            kwargs["_vllm_continue_final_message_reasoning"] = "\n".join(thinking_parts)
+        if reasoning_ended is not None:
+            kwargs["_vllm_continue_final_message_reasoning_ended"] = reasoning_ended
     else:
         final_content = ""
 

--- a/vllm/entrypoints/offline_utils.py
+++ b/vllm/entrypoints/offline_utils.py
@@ -18,13 +18,16 @@ from vllm.config import ModelConfig
 from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
     ChatTemplateContentFormatOption,
+    make_reasoning_parser_chat_template_kwargs,
 )
 from vllm.inputs import EngineInput
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
+from vllm.reasoning import ReasoningParserManager
 from vllm.renderers import BaseRenderer, ChatParams, merge_kwargs
 from vllm.renderers.inputs.preprocess import (
     conversation_to_seq,
+    extract_prompt_components,
     parse_model_prompt,
     prompt_to_seq,
 )
@@ -181,17 +184,11 @@ class OfflineInferenceMixin:
         chat_params = ChatParams(
             chat_template=chat_template,
             chat_template_content_format=chat_template_content_format,
-            chat_template_kwargs=merge_kwargs(
+            chat_template_kwargs=self._build_chat_template_kwargs(
                 chat_template_kwargs,
-                dict(
-                    add_generation_prompt=add_generation_prompt,
-                    continue_final_message=continue_final_message,
-                    tools=tools,
-                    tokenize=(
-                        is_mistral_tokenizer(renderer.tokenizer)
-                        or self.model_config.enable_prompt_embeds
-                    ),
-                ),
+                add_generation_prompt=add_generation_prompt,
+                continue_final_message=continue_final_message,
+                tools=tools,
             ),
             mm_processor_kwargs=mm_processor_kwargs,
         )
@@ -212,6 +209,59 @@ class OfflineInferenceMixin:
         )
 
         return engine_inputs
+
+    def _build_chat_template_kwargs(
+        self,
+        chat_template_kwargs: dict[str, Any] | None,
+        *,
+        add_generation_prompt: bool,
+        continue_final_message: bool,
+        tools: list[dict[str, Any]] | None,
+    ) -> dict[str, Any]:
+        return merge_kwargs(
+            chat_template_kwargs,
+            dict(
+                add_generation_prompt=add_generation_prompt,
+                continue_final_message=continue_final_message,
+                tools=tools,
+                tokenize=(
+                    is_mistral_tokenizer(self.renderer.tokenizer)
+                    or self.model_config.enable_prompt_embeds
+                ),
+            ),
+        )
+
+    def _reasoning_parser_request_options(
+        self,
+        prompt: EngineInput,
+        params: SamplingParams | PoolingParams,
+        chat_template_kwargs: dict[str, Any],
+    ) -> tuple[bool | None, dict[str, Any] | None]:
+        if not isinstance(params, SamplingParams) or params.structured_outputs is None:
+            return None, None
+
+        structured_config = self.llm_engine.vllm_config.structured_outputs_config
+        reasoning_parser = structured_config.reasoning_parser
+        if not reasoning_parser:
+            return None, None
+
+        reasoning_parser_plugin = structured_config.reasoning_parser_plugin
+        if reasoning_parser_plugin and len(reasoning_parser_plugin) > 3:
+            ReasoningParserManager.import_reasoning_parser(reasoning_parser_plugin)
+
+        reasoner_cls = ReasoningParserManager.get_reasoning_parser(reasoning_parser)
+        reasoner = reasoner_cls(
+            tokenizer=self.renderer.get_tokenizer(),
+            chat_template_kwargs=chat_template_kwargs,
+            model_config=self.model_config,
+        )
+        prompt_token_ids = extract_prompt_components(
+            self.model_config, prompt
+        ).token_ids
+        return (
+            reasoner.is_reasoning_end_from_prompt(prompt_token_ids or []),
+            {"chat_template_kwargs": chat_template_kwargs},
+        )
 
     def _preprocess_chat_one(
         self,
@@ -420,6 +470,26 @@ class OfflineInferenceMixin:
         if needs_parsing:
             self._adjust_params_for_parsing(seq_params)
 
+        effective_chat_template_kwargs = self._build_chat_template_kwargs(
+            chat_template_kwargs,
+            add_generation_prompt=add_generation_prompt,
+            continue_final_message=continue_final_message,
+            tools=tools,
+        )
+
+        def reasoning_parser_options(prompt: EngineInput, index: int):
+            conversation = seq_convs[index]
+            parser_chat_template_kwargs = make_reasoning_parser_chat_template_kwargs(
+                effective_chat_template_kwargs,
+                continue_final_message,
+                conversation[-1] if conversation else None,
+            )
+            return self._reasoning_parser_request_options(
+                prompt,
+                seq_params[index],
+                parser_chat_template_kwargs,
+            )
+
         return self._render_and_add_requests(
             prompts=(
                 self._preprocess_chat_one(
@@ -442,6 +512,7 @@ class OfflineInferenceMixin:
             params=seq_params,
             lora_requests=seq_lora_requests,
             priorities=seq_priority,
+            reasoning_parser_options=reasoning_parser_options,
         )
 
     def _adjust_params_for_parsing(
@@ -527,11 +598,20 @@ class OfflineInferenceMixin:
         *,
         lora_requests: Sequence[LoRARequest | None] | None = None,
         priorities: Sequence[int] | None = None,
+        reasoning_parser_options: Callable[
+            [EngineInput, int], tuple[bool | None, dict[str, Any] | None]
+        ]
+        | None = None,
     ) -> list[str]:
         added_request_ids: list[str] = []
 
         try:
             for i, prompt in enumerate(prompts):
+                reasoning_ended, reasoning_parser_kwargs = (
+                    (None, None)
+                    if reasoning_parser_options is None
+                    else reasoning_parser_options(prompt, i)
+                )
                 request_id = self._add_request(
                     prompt,
                     params[i],
@@ -540,6 +620,8 @@ class OfflineInferenceMixin:
                         None if lora_requests is None else lora_requests[i],
                     ),
                     priority=0 if priorities is None else priorities[i],
+                    reasoning_ended=reasoning_ended,
+                    reasoning_parser_kwargs=reasoning_parser_kwargs,
                 )
                 added_request_ids.append(request_id)
         except Exception as e:
@@ -555,6 +637,8 @@ class OfflineInferenceMixin:
         params: SamplingParams | PoolingParams,
         lora_request: LoRARequest | None = None,
         priority: int = 0,
+        reasoning_ended: bool | None = None,
+        reasoning_parser_kwargs: dict[str, Any] | None = None,
     ) -> str:
         if isinstance(params, SamplingParams):
             # We only care about the final output
@@ -568,6 +652,8 @@ class OfflineInferenceMixin:
             params,
             lora_request=lora_request,
             priority=priority,
+            reasoning_ended=reasoning_ended,
+            reasoning_parser_kwargs=reasoning_parser_kwargs,
         )
 
     def _run_engine(

--- a/vllm/entrypoints/openai/chat_completion/batch_serving.py
+++ b/vllm/entrypoints/openai/chat_completion/batch_serving.py
@@ -119,16 +119,22 @@ class OpenAIServingChatBatch(OpenAIServingChat):
             for messages in request.messages
         ]
 
-        parser: Parser | None = None
+        chat_template_kwargs = {
+            **self._effective_chat_template_kwargs(single_requests[0]),
+            "_vllm_continue_final_message": single_requests[0].continue_final_message,
+        }
+        parsers: list[Parser | None]
         if self.parser_cls is not None:
-            chat_template_kwargs = self._effective_chat_template_kwargs(
-                single_requests[0]
-            )
-            parser = self.parser_cls(
-                tokenizer,
-                None,  # tools
-                chat_template_kwargs=chat_template_kwargs,
-            )
+            parsers = [
+                self.parser_cls(
+                    tokenizer,
+                    None,  # tools
+                    chat_template_kwargs=chat_template_kwargs,
+                )
+                for _ in single_requests
+            ]
+        else:
+            parsers = [None] * len(single_requests)
 
         render_result = await self.render_batch_chat_request(request)
         if isinstance(render_result, ErrorResponse):
@@ -149,6 +155,7 @@ class OpenAIServingChatBatch(OpenAIServingChat):
 
         generators: list[AsyncGenerator[RequestOutput, None]] = []
         for i, engine_prompt in enumerate(engine_prompts):
+            prompt_token_ids = self._extract_prompt_components(engine_prompt).token_ids
             sub_request_id = f"{request_id}_{i}"
             max_tokens = get_max_tokens(
                 max_model_len,
@@ -160,6 +167,7 @@ class OpenAIServingChatBatch(OpenAIServingChat):
                 self.override_max_tokens,
             )
             single_request = single_requests[i]
+            parser = parsers[i]
             sampling_params = single_request.to_sampling_params(
                 max_tokens, self.default_sampling_params
             )
@@ -175,6 +183,17 @@ class OpenAIServingChatBatch(OpenAIServingChat):
                 else await self._get_trace_headers(raw_request.headers)
             )
             session_id = self._get_session_id(single_request, raw_request)
+            if (
+                not single_request.include_reasoning
+                or single_request._grammar_from_parser
+            ):
+                reasoning_ended = True
+            elif parser is not None and parser.reasoning_parser is not None:
+                reasoning_ended = parser.is_reasoning_end_from_prompt(
+                    prompt_token_ids or []
+                )
+            else:
+                reasoning_ended = None
             generators.append(
                 self.engine_client.generate(
                     engine_prompt,
@@ -185,7 +204,12 @@ class OpenAIServingChatBatch(OpenAIServingChat):
                     priority=request.priority,
                     data_parallel_rank=data_parallel_rank,
                     session_id=session_id,
-                    reasoning_ended=None,
+                    reasoning_ended=reasoning_ended,
+                    reasoning_parser_kwargs={
+                        "chat_template_kwargs": chat_template_kwargs,
+                    }
+                    if parser is not None and parser.reasoning_parser is not None
+                    else None,
                 )
             )
 
@@ -197,7 +221,7 @@ class OpenAIServingChatBatch(OpenAIServingChat):
             all_conversations,
             tokenizer,
             request_metadata,
-            parser,
+            parsers,
         )
 
     async def chat_completion_full_generator_batch(
@@ -209,7 +233,7 @@ class OpenAIServingChatBatch(OpenAIServingChat):
         all_conversations: list[list[ConversationMessage]],
         tokenizer: TokenizerLike,
         request_metadata: RequestResponseMetadata,
-        parser: Parser | None = None,
+        parsers: list[Parser | None] | None = None,
     ) -> ErrorResponse | ChatCompletionResponse:
         """Handle batched (non-streaming) chat completions.
 
@@ -233,6 +257,7 @@ class OpenAIServingChatBatch(OpenAIServingChat):
         total_completion_tokens = 0
 
         for prompt_idx in range(len(generators)):
+            parser = parsers[prompt_idx] if parsers is not None else None
             final_res = final_results.get(prompt_idx)
             if final_res is None:
                 return self.create_error_response(

--- a/vllm/entrypoints/openai/chat_completion/batch_serving.py
+++ b/vllm/entrypoints/openai/chat_completion/batch_serving.py
@@ -119,10 +119,10 @@ class OpenAIServingChatBatch(OpenAIServingChat):
             for messages in request.messages
         ]
 
-        chat_template_kwargs = {
-            **self._effective_chat_template_kwargs(single_requests[0]),
-            "_vllm_continue_final_message": single_requests[0].continue_final_message,
-        }
+        parser_chat_template_kwargs = [
+            self._reasoning_parser_chat_template_kwargs(single_request)
+            for single_request in single_requests
+        ]
         parsers: list[Parser | None]
         if self.parser_cls is not None:
             parsers = [
@@ -131,7 +131,7 @@ class OpenAIServingChatBatch(OpenAIServingChat):
                     None,  # tools
                     chat_template_kwargs=chat_template_kwargs,
                 )
-                for _ in single_requests
+                for chat_template_kwargs in parser_chat_template_kwargs
             ]
         else:
             parsers = [None] * len(single_requests)
@@ -168,6 +168,7 @@ class OpenAIServingChatBatch(OpenAIServingChat):
             )
             single_request = single_requests[i]
             parser = parsers[i]
+            chat_template_kwargs = parser_chat_template_kwargs[i]
             sampling_params = single_request.to_sampling_params(
                 max_tokens, self.default_sampling_params
             )

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -17,6 +17,7 @@ from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.chat_utils import (
     ChatTemplateContentFormatOption,
     ConversationMessage,
+    make_reasoning_parser_chat_template_kwargs,
     make_tool_call_id,
 )
 from vllm.entrypoints.generate.base.serving import (
@@ -192,32 +193,11 @@ class OpenAIServingChat(GenerateBaseServing):
     def _reasoning_parser_chat_template_kwargs(
         self, request: ChatCompletionRequest
     ) -> dict[str, Any]:
-        kwargs = {
-            **self._effective_chat_template_kwargs(request),
-            "_vllm_continue_final_message": request.continue_final_message,
-        }
-        if not request.continue_final_message:
-            return kwargs
-
-        final_message = request.messages[-1]
-        content = final_message.get("content")
-        if isinstance(content, str):
-            final_content = content
-        elif isinstance(content, list):
-            final_content = "\n".join(
-                text
-                for part in content
-                if isinstance(part, dict)
-                and isinstance((text := part.get("text")), str)
-            )
-        else:
-            final_content = ""
-
-        kwargs["_vllm_continue_final_message_content"] = final_content
-        reasoning = final_message.get("reasoning")
-        if isinstance(reasoning, str):
-            kwargs["_vllm_continue_final_message_reasoning"] = reasoning
-        return kwargs
+        return make_reasoning_parser_chat_template_kwargs(
+            self._effective_chat_template_kwargs(request),
+            request.continue_final_message,
+            request.messages[-1] if request.messages else None,
+        )
 
     async def render_chat_request(
         self,

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -189,6 +189,36 @@ class OpenAIServingChat(GenerateBaseServing):
             .chat_template_kwargs
         )
 
+    def _reasoning_parser_chat_template_kwargs(
+        self, request: ChatCompletionRequest
+    ) -> dict[str, Any]:
+        kwargs = {
+            **self._effective_chat_template_kwargs(request),
+            "_vllm_continue_final_message": request.continue_final_message,
+        }
+        if not request.continue_final_message:
+            return kwargs
+
+        final_message = request.messages[-1]
+        content = final_message.get("content")
+        if isinstance(content, str):
+            final_content = content
+        elif isinstance(content, list):
+            final_content = "\n".join(
+                text
+                for part in content
+                if isinstance(part, dict)
+                and isinstance((text := part.get("text")), str)
+            )
+        else:
+            final_content = ""
+
+        kwargs["_vllm_continue_final_message_content"] = final_content
+        reasoning = final_message.get("reasoning")
+        if isinstance(reasoning, str):
+            kwargs["_vllm_continue_final_message_reasoning"] = reasoning
+        return kwargs
+
     async def render_chat_request(
         self,
         request: ChatCompletionRequest,
@@ -240,10 +270,7 @@ class OpenAIServingChat(GenerateBaseServing):
         # Streaming response
         tokenizer = self.renderer.tokenizer
         assert tokenizer is not None
-        chat_template_kwargs = {
-            **self._effective_chat_template_kwargs(request),
-            "_vllm_continue_final_message": request.continue_final_message,
-        }
+        chat_template_kwargs = self._reasoning_parser_chat_template_kwargs(request)
         parser: Parser | None = None
         if self.parser_cls is not None:
             parser = self.parser_cls(

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -240,7 +240,10 @@ class OpenAIServingChat(GenerateBaseServing):
         # Streaming response
         tokenizer = self.renderer.tokenizer
         assert tokenizer is not None
-        chat_template_kwargs = self._effective_chat_template_kwargs(request)
+        chat_template_kwargs = {
+            **self._effective_chat_template_kwargs(request),
+            "_vllm_continue_final_message": request.continue_final_message,
+        }
         parser: Parser | None = None
         if self.parser_cls is not None:
             parser = self.parser_cls(
@@ -338,7 +341,9 @@ class OpenAIServingChat(GenerateBaseServing):
                     # non-reasoning outputs.
                     reasoning_ended = True
                 elif parser is not None and parser.reasoning_parser is not None:
-                    reasoning_ended = parser.is_reasoning_end(prompt_token_ids or [])
+                    reasoning_ended = parser.is_reasoning_end_from_prompt(
+                        prompt_token_ids or []
+                    )
                 else:
                     reasoning_ended = None
 

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -246,7 +246,10 @@ class OpenAIServingChat(GenerateBaseServing):
         # Streaming response
         tokenizer = self.renderer.tokenizer
         assert tokenizer is not None
-        chat_template_kwargs = self._effective_chat_template_kwargs(request)
+        chat_template_kwargs = {
+            **self._effective_chat_template_kwargs(request),
+            "_vllm_continue_final_message": request.continue_final_message,
+        }
         parser: Parser | None = None
         if self.parser_cls is not None:
             parser = self.parser_cls(
@@ -344,7 +347,9 @@ class OpenAIServingChat(GenerateBaseServing):
                     # non-reasoning outputs.
                     reasoning_ended = True
                 elif parser is not None and parser.reasoning_parser is not None:
-                    reasoning_ended = parser.is_reasoning_end(prompt_token_ids or [])
+                    reasoning_ended = parser.is_reasoning_end_from_prompt(
+                        prompt_token_ids or []
+                    )
                 else:
                     reasoning_ended = None
 

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -14,6 +14,7 @@ from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.chat_utils import (
     ChatTemplateContentFormatOption,
     ConversationMessage,
+    make_reasoning_parser_chat_template_kwargs,
     make_tool_call_id,
 )
 from vllm.entrypoints.generate.base.serving import (
@@ -198,32 +199,11 @@ class OpenAIServingChat(GenerateBaseServing):
     def _reasoning_parser_chat_template_kwargs(
         self, request: ChatCompletionRequest
     ) -> dict[str, Any]:
-        kwargs = {
-            **self._effective_chat_template_kwargs(request),
-            "_vllm_continue_final_message": request.continue_final_message,
-        }
-        if not request.continue_final_message:
-            return kwargs
-
-        final_message = request.messages[-1]
-        content = final_message.get("content")
-        if isinstance(content, str):
-            final_content = content
-        elif isinstance(content, list):
-            final_content = "\n".join(
-                text
-                for part in content
-                if isinstance(part, dict)
-                and isinstance((text := part.get("text")), str)
-            )
-        else:
-            final_content = ""
-
-        kwargs["_vllm_continue_final_message_content"] = final_content
-        reasoning = final_message.get("reasoning")
-        if isinstance(reasoning, str):
-            kwargs["_vllm_continue_final_message_reasoning"] = reasoning
-        return kwargs
+        return make_reasoning_parser_chat_template_kwargs(
+            self._effective_chat_template_kwargs(request),
+            request.continue_final_message,
+            request.messages[-1] if request.messages else None,
+        )
 
     async def render_chat_request(
         self,

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -195,6 +195,36 @@ class OpenAIServingChat(GenerateBaseServing):
             .chat_template_kwargs
         )
 
+    def _reasoning_parser_chat_template_kwargs(
+        self, request: ChatCompletionRequest
+    ) -> dict[str, Any]:
+        kwargs = {
+            **self._effective_chat_template_kwargs(request),
+            "_vllm_continue_final_message": request.continue_final_message,
+        }
+        if not request.continue_final_message:
+            return kwargs
+
+        final_message = request.messages[-1]
+        content = final_message.get("content")
+        if isinstance(content, str):
+            final_content = content
+        elif isinstance(content, list):
+            final_content = "\n".join(
+                text
+                for part in content
+                if isinstance(part, dict)
+                and isinstance((text := part.get("text")), str)
+            )
+        else:
+            final_content = ""
+
+        kwargs["_vllm_continue_final_message_content"] = final_content
+        reasoning = final_message.get("reasoning")
+        if isinstance(reasoning, str):
+            kwargs["_vllm_continue_final_message_reasoning"] = reasoning
+        return kwargs
+
     async def render_chat_request(
         self,
         request: ChatCompletionRequest,
@@ -246,10 +276,7 @@ class OpenAIServingChat(GenerateBaseServing):
         # Streaming response
         tokenizer = self.renderer.tokenizer
         assert tokenizer is not None
-        chat_template_kwargs = {
-            **self._effective_chat_template_kwargs(request),
-            "_vllm_continue_final_message": request.continue_final_message,
-        }
+        chat_template_kwargs = self._reasoning_parser_chat_template_kwargs(request)
         parser: Parser | None = None
         if self.parser_cls is not None:
             parser = self.parser_cls(

--- a/vllm/entrypoints/openai/responses/context.py
+++ b/vllm/entrypoints/openai/responses/context.py
@@ -316,6 +316,7 @@ class ParsableContext(ConversationContext):
         self.response_parser = response_parser or (
             parser_cls(tokenizer, request.tools) if parser_cls is not None else None
         )
+        self.tokenizer = tokenizer
         self.parser_cls = parser_cls
         self.request = request
 

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -757,6 +757,22 @@ class OpenAIServingResponses(GenerateBaseServing):
                     context.chat_template_content_format,
                 )
 
+                if reasoning_parser_kwargs is not None:
+                    parser_chat_template_kwargs = reasoning_parser_kwargs.get(
+                        "chat_template_kwargs"
+                    )
+                    if isinstance(parser_chat_template_kwargs, dict):
+                        reasoning_parser_kwargs = {
+                            **reasoning_parser_kwargs,
+                            "chat_template_kwargs": (
+                                make_reasoning_parser_chat_template_kwargs(
+                                    parser_chat_template_kwargs,
+                                    continue_final_message=False,
+                                    final_message=None,
+                                )
+                            ),
+                        }
+
                 sampling_params.max_tokens = get_max_tokens(
                     max_model_len,
                     context.request.max_output_tokens,

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -30,6 +30,7 @@ from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
     ChatTemplateContentFormatOption,
+    make_reasoning_parser_chat_template_kwargs,
 )
 from vllm.entrypoints.generate.base.serving import (
     GenerateBaseServing,
@@ -269,6 +270,18 @@ class OpenAIServingResponses(GenerateBaseServing):
             model_config=self.model_config,
         )
 
+    def _reasoning_parser_chat_template_kwargs(
+        self,
+        request: ResponsesRequest,
+        messages: list[ChatCompletionMessageParam],
+    ) -> dict[str, Any]:
+        kwargs = self._effective_chat_template_kwargs(request)
+        return make_reasoning_parser_chat_template_kwargs(
+            kwargs,
+            bool(kwargs.get("continue_final_message")),
+            messages[-1] if messages else None,
+        )
+
     def _validate_generator_input(
         self,
         engine_input: EngineInput,
@@ -453,7 +466,9 @@ class OpenAIServingResponses(GenerateBaseServing):
             )
             session_id = self._get_session_id(request, raw_request)
 
-            chat_template_kwargs = self._effective_chat_template_kwargs(request)
+            chat_template_kwargs = self._reasoning_parser_chat_template_kwargs(
+                request, messages
+            )
             response_parser = self._make_response_parser(
                 request, tokenizer, chat_template_kwargs
             )
@@ -487,10 +502,18 @@ class OpenAIServingResponses(GenerateBaseServing):
                         response_parser=response_parser,
                     )
 
+            reasoning_ended = None
+            reasoning_parser_kwargs = None
             if (
                 context.response_parser is not None
                 and context.response_parser.reasoning_parser is not None
             ):
+                prompt_token_ids = self._extract_prompt_components(
+                    engine_input
+                ).token_ids
+                reasoning_ended = context.response_parser.is_reasoning_end_from_prompt(
+                    prompt_token_ids or []
+                )
                 reasoning_parser_kwargs = {
                     "chat_template_kwargs": chat_template_kwargs,
                 }
@@ -518,9 +541,8 @@ class OpenAIServingResponses(GenerateBaseServing):
                 priority=request.priority,
                 trace_headers=trace_headers,
                 session_id=session_id,
-                reasoning_parser_kwargs=reasoning_parser_kwargs
-                if self.parser and self.parser.reasoning_parser_cls is not None
-                else None,
+                reasoning_ended=reasoning_ended,
+                reasoning_parser_kwargs=reasoning_parser_kwargs,
             )
             generators.append(generator)
 
@@ -672,6 +694,7 @@ class OpenAIServingResponses(GenerateBaseServing):
         priority: int = 0,
         trace_headers: Mapping[str, str] | None = None,
         session_id: str | None = None,
+        reasoning_ended: bool | None = None,
         reasoning_parser_kwargs: dict[str, Any] | None = None,
     ):
         max_model_len = self.model_config.max_model_len
@@ -697,6 +720,7 @@ class OpenAIServingResponses(GenerateBaseServing):
                 trace_headers=trace_headers,
                 priority=priority,
                 session_id=session_id,
+                reasoning_ended=reasoning_ended,
                 reasoning_parser_kwargs=reasoning_parser_kwargs,
             )
 
@@ -746,6 +770,7 @@ class OpenAIServingResponses(GenerateBaseServing):
 
             # OPTIMIZATION
             priority = orig_priority - 1
+            reasoning_ended = None
             sub_request += 1
 
     def _make_request_with_harmony(

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -762,16 +762,23 @@ class OpenAIServingResponses(GenerateBaseServing):
                         "chat_template_kwargs"
                     )
                     if isinstance(parser_chat_template_kwargs, dict):
+                        next_chat_template_kwargs = (
+                            make_reasoning_parser_chat_template_kwargs(
+                                parser_chat_template_kwargs,
+                                continue_final_message=False,
+                                final_message=None,
+                            )
+                        )
                         reasoning_parser_kwargs = {
                             **reasoning_parser_kwargs,
-                            "chat_template_kwargs": (
-                                make_reasoning_parser_chat_template_kwargs(
-                                    parser_chat_template_kwargs,
-                                    continue_final_message=False,
-                                    final_message=None,
-                                )
-                            ),
+                            "chat_template_kwargs": next_chat_template_kwargs,
                         }
+                        if context.response_parser is not None:
+                            context.response_parser = self._make_response_parser(
+                                context.request,
+                                context.tokenizer,
+                                next_chat_template_kwargs,
+                            )
 
                 sampling_params.max_tokens = get_max_tokens(
                     max_model_len,

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -30,6 +30,7 @@ from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
     ChatTemplateContentFormatOption,
+    make_reasoning_parser_chat_template_kwargs,
 )
 from vllm.entrypoints.generate.base.serving import (
     GenerateBaseServing,
@@ -269,6 +270,18 @@ class OpenAIServingResponses(GenerateBaseServing):
             model_config=self.model_config,
         )
 
+    def _reasoning_parser_chat_template_kwargs(
+        self,
+        request: ResponsesRequest,
+        messages: list[ChatCompletionMessageParam],
+    ) -> dict[str, Any]:
+        kwargs = self._effective_chat_template_kwargs(request)
+        return make_reasoning_parser_chat_template_kwargs(
+            kwargs,
+            bool(kwargs.get("continue_final_message")),
+            messages[-1] if messages else None,
+        )
+
     def _validate_generator_input(
         self,
         engine_input: EngineInput,
@@ -453,7 +466,9 @@ class OpenAIServingResponses(GenerateBaseServing):
             )
             session_id = self._get_session_id(request, raw_request)
 
-            chat_template_kwargs = self._effective_chat_template_kwargs(request)
+            chat_template_kwargs = self._reasoning_parser_chat_template_kwargs(
+                request, messages
+            )
             response_parser = self._make_response_parser(
                 request, tokenizer, chat_template_kwargs
             )
@@ -487,11 +502,18 @@ class OpenAIServingResponses(GenerateBaseServing):
                         response_parser=response_parser,
                     )
 
+            reasoning_ended = None
             reasoning_parser_kwargs = None
             if (
                 context.response_parser is not None
                 and context.response_parser.reasoning_parser is not None
             ):
+                prompt_token_ids = self._extract_prompt_components(
+                    engine_input
+                ).token_ids
+                reasoning_ended = context.response_parser.is_reasoning_end_from_prompt(
+                    prompt_token_ids or []
+                )
                 reasoning_parser_kwargs = {
                     "chat_template_kwargs": chat_template_kwargs,
                 }
@@ -519,6 +541,7 @@ class OpenAIServingResponses(GenerateBaseServing):
                 priority=self._get_priority(request, raw_request),
                 trace_headers=trace_headers,
                 session_id=session_id,
+                reasoning_ended=reasoning_ended,
                 reasoning_parser_kwargs=reasoning_parser_kwargs,
             )
             generators.append(generator)
@@ -671,6 +694,7 @@ class OpenAIServingResponses(GenerateBaseServing):
         priority: int = 0,
         trace_headers: Mapping[str, str] | None = None,
         session_id: str | None = None,
+        reasoning_ended: bool | None = None,
         reasoning_parser_kwargs: dict[str, Any] | None = None,
     ):
         max_model_len = self.model_config.max_model_len
@@ -696,6 +720,7 @@ class OpenAIServingResponses(GenerateBaseServing):
                 trace_headers=trace_headers,
                 priority=priority,
                 session_id=session_id,
+                reasoning_ended=reasoning_ended,
                 reasoning_parser_kwargs=reasoning_parser_kwargs,
             )
 
@@ -745,6 +770,7 @@ class OpenAIServingResponses(GenerateBaseServing):
 
             # OPTIMIZATION
             priority = orig_priority - 1
+            reasoning_ended = None
             sub_request += 1
 
     def _make_request_with_harmony(

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -193,6 +193,10 @@ class Parser:
             True if the reasoning content ends in the input_ids.
         """
 
+    def is_reasoning_end_from_prompt(self, prompt_token_ids: list[int]) -> bool | None:
+        """Check whether reasoning has ended at the generation boundary."""
+        return self.is_reasoning_end(prompt_token_ids)
+
     def is_reasoning_end_streaming(
         self, input_ids: list[int], delta_ids: list[int]
     ) -> bool:
@@ -723,6 +727,11 @@ class DelegatingParser(Parser):
             return False
         return self._reasoning_parser.is_reasoning_end(input_ids)
 
+    def is_reasoning_end_from_prompt(self, prompt_token_ids: list[int]) -> bool | None:
+        if self._reasoning_parser is None:
+            return False
+        return self._reasoning_parser.is_reasoning_end_from_prompt(prompt_token_ids)
+
     def is_reasoning_end_streaming(
         self, input_ids: list[int], delta_ids: list[int]
     ) -> bool:
@@ -812,7 +821,7 @@ class DelegatingParser(Parser):
 
         if not state.prompt_reasoning_checked and prompt_token_ids is not None:
             state.prompt_reasoning_checked = True
-            if self._reasoning_parser is None or self.is_reasoning_end(
+            if self._reasoning_parser is None or self.is_reasoning_end_from_prompt(
                 prompt_token_ids
             ):
                 state.reasoning_ended = True

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -193,6 +193,10 @@ class Parser:
             True if the reasoning content ends in the input_ids.
         """
 
+    def is_reasoning_end_from_prompt(self, prompt_token_ids: list[int]) -> bool | None:
+        """Check whether reasoning has ended at the generation boundary."""
+        return self.is_reasoning_end(prompt_token_ids)
+
     def is_reasoning_end_streaming(
         self, input_ids: list[int], delta_ids: list[int]
     ) -> bool:
@@ -727,6 +731,11 @@ class DelegatingParser(Parser):
             return False
         return self._reasoning_parser.is_reasoning_end(input_ids)
 
+    def is_reasoning_end_from_prompt(self, prompt_token_ids: list[int]) -> bool | None:
+        if self._reasoning_parser is None:
+            return False
+        return self._reasoning_parser.is_reasoning_end_from_prompt(prompt_token_ids)
+
     def is_reasoning_end_streaming(
         self, input_ids: list[int], delta_ids: list[int]
     ) -> bool:
@@ -816,7 +825,7 @@ class DelegatingParser(Parser):
 
         if not state.prompt_reasoning_checked and prompt_token_ids is not None:
             state.prompt_reasoning_checked = True
-            if self._reasoning_parser is None or self.is_reasoning_end(
+            if self._reasoning_parser is None or self.is_reasoning_end_from_prompt(
                 prompt_token_ids
             ):
                 state.reasoning_ended = True

--- a/vllm/reasoning/abs_reasoning_parsers.py
+++ b/vllm/reasoning/abs_reasoning_parsers.py
@@ -87,6 +87,12 @@ class ReasoningParser:
             True if the reasoning content ends in the input_ids.
         """
 
+    def is_reasoning_end_from_prompt(
+        self, prompt_token_ids: Sequence[int]
+    ) -> bool | None:
+        """Check whether reasoning has ended at the generation boundary."""
+        return self.is_reasoning_end(prompt_token_ids)
+
     def is_reasoning_end_streaming(
         self, input_ids: Sequence[int], delta_ids: Iterable[int]
     ) -> bool:

--- a/vllm/reasoning/abs_reasoning_parsers.py
+++ b/vllm/reasoning/abs_reasoning_parsers.py
@@ -59,6 +59,23 @@ class ReasoningParser:
         """
         return None
 
+    @cached_property
+    def reasoning_marker_token_ids(self) -> tuple[tuple[int, ...], ...]:
+        """Token sequences that may open or close a reasoning block."""
+        marker_ids: list[tuple[int, ...]] = []
+        for marker in (self.reasoning_start_str, self.reasoning_end_str):
+            if not marker:
+                continue
+            try:
+                token_ids = tuple(
+                    self.model_tokenizer.encode(marker, add_special_tokens=False)
+                )
+            except TypeError:
+                token_ids = tuple(self.model_tokenizer.encode(marker))
+            if token_ids and token_ids not in marker_ids:
+                marker_ids.append(token_ids)
+        return tuple(marker_ids)
+
     def has_engine_confirmed_reasoning_end(self) -> bool:
         """Whether the engine has confirmed the reasoning end transition.
 

--- a/vllm/reasoning/minimax_m3_reasoning_parser.py
+++ b/vllm/reasoning/minimax_m3_reasoning_parser.py
@@ -50,6 +50,9 @@ class MiniMaxM3ReasoningParser(BaseThinkingReasoningParser):
         self._continue_final_message_reasoning = chat_kwargs.get(
             "_vllm_continue_final_message_reasoning"
         )
+        self._continue_final_message_reasoning_ended = chat_kwargs.get(
+            "_vllm_continue_final_message_reasoning_ended"
+        )
         self._initial_in_reasoning = self._thinking_mode == "enabled"
         self._reasoning_ended_streaming = False
         self._reasoning_active_streaming = self._initial_in_reasoning
@@ -335,7 +338,9 @@ class MiniMaxM3ReasoningParser(BaseThinkingReasoningParser):
             return True
         if self._continue_final_message:
             content = self._continue_final_message_content
-            if isinstance(content, str):
+            if isinstance(self._continue_final_message_reasoning_ended, bool):
+                reasoning_ended = self._continue_final_message_reasoning_ended
+            elif isinstance(content, str):
                 start_index = content.rfind(self.start_token)
                 end_index = content.rfind(self.end_token)
                 if start_index >= 0 or end_index >= 0:

--- a/vllm/reasoning/minimax_m3_reasoning_parser.py
+++ b/vllm/reasoning/minimax_m3_reasoning_parser.py
@@ -44,6 +44,12 @@ class MiniMaxM3ReasoningParser(BaseThinkingReasoningParser):
         self._continue_final_message = bool(
             chat_kwargs.get("_vllm_continue_final_message", False)
         )
+        self._continue_final_message_content = chat_kwargs.get(
+            "_vllm_continue_final_message_content"
+        )
+        self._continue_final_message_reasoning = chat_kwargs.get(
+            "_vllm_continue_final_message_reasoning"
+        )
         self._initial_in_reasoning = self._thinking_mode == "enabled"
         self._reasoning_ended_streaming = False
         self._reasoning_active_streaming = self._initial_in_reasoning
@@ -328,15 +334,26 @@ class MiniMaxM3ReasoningParser(BaseThinkingReasoningParser):
         if self._thinking_mode == "disabled":
             return True
         if self._continue_final_message:
-            start_index = self._rfind_token_sequence(
-                prompt_token_ids, self._start_token_ids
-            )
-            end_index = self._rfind_token_sequence(
-                prompt_token_ids, self._end_token_ids
-            )
-            reasoning_ended = not (start_index >= 0 and start_index > end_index)
-            self._initial_in_reasoning = not reasoning_ended
-            self._reasoning_active_streaming = self._initial_in_reasoning
+            content = self._continue_final_message_content
+            if isinstance(content, str):
+                start_index = content.rfind(self.start_token)
+                end_index = content.rfind(self.end_token)
+                if start_index >= 0 or end_index >= 0:
+                    reasoning_ended = not (start_index >= 0 and start_index > end_index)
+                elif content:
+                    reasoning_ended = True
+                elif (
+                    isinstance(self._continue_final_message_reasoning, str)
+                    and self._continue_final_message_reasoning
+                ):
+                    reasoning_ended = False
+                else:
+                    reasoning_ended = self._thinking_mode != "enabled"
+            else:
+                reasoning_ended = False if self._thinking_mode == "enabled" else None
+            if reasoning_ended is not None:
+                self._initial_in_reasoning = not reasoning_ended
+                self._reasoning_active_streaming = self._initial_in_reasoning
             return reasoning_ended
         if self._thinking_mode == "enabled":
             return False

--- a/vllm/reasoning/minimax_m3_reasoning_parser.py
+++ b/vllm/reasoning/minimax_m3_reasoning_parser.py
@@ -40,7 +40,11 @@ class MiniMaxM3ReasoningParser(BaseThinkingReasoningParser):
         self._start_token_ids = self._encode_marker(self.start_token)
         self._end_token_ids = self._encode_marker(self.end_token)
         chat_kwargs = kwargs.get("chat_template_kwargs", {}) or {}
-        self._initial_in_reasoning = chat_kwargs.get("thinking_mode") == "enabled"
+        self._thinking_mode = chat_kwargs.get("thinking_mode", "adaptive")
+        self._continue_final_message = bool(
+            chat_kwargs.get("_vllm_continue_final_message", False)
+        )
+        self._initial_in_reasoning = self._thinking_mode == "enabled"
         self._reasoning_ended_streaming = False
         self._reasoning_active_streaming = self._initial_in_reasoning
         self._pending_marker_streaming = False
@@ -200,14 +204,13 @@ class MiniMaxM3ReasoningParser(BaseThinkingReasoningParser):
         if self._reasoning_ended_streaming:
             return True
 
-        if self._reasoning_active_streaming or self._pending_marker_streaming:
-            return False
-
         delta_ids = tuple(delta_ids)
         if self._contains_token_sequence(delta_ids, self._end_token_ids):
             return True
         if self._contains_token_sequence(input_ids, self._end_token_ids):
             return True
+        if self._reasoning_active_streaming or self._pending_marker_streaming:
+            return False
         if self._initial_in_reasoning:
             return False
         if self._ends_with_token_sequence_prefix(input_ids, self._start_token_ids):
@@ -318,3 +321,23 @@ class MiniMaxM3ReasoningParser(BaseThinkingReasoningParser):
         if start_index < 0:
             return True
         return end_index > start_index
+
+    def is_reasoning_end_from_prompt(
+        self, prompt_token_ids: Sequence[int]
+    ) -> bool | None:
+        if self._thinking_mode == "disabled":
+            return True
+        if self._continue_final_message:
+            start_index = self._rfind_token_sequence(
+                prompt_token_ids, self._start_token_ids
+            )
+            end_index = self._rfind_token_sequence(
+                prompt_token_ids, self._end_token_ids
+            )
+            reasoning_ended = not (start_index >= 0 and start_index > end_index)
+            self._initial_in_reasoning = not reasoning_ended
+            self._reasoning_active_streaming = self._initial_in_reasoning
+            return reasoning_ended
+        if self._thinking_mode == "enabled":
+            return False
+        return None

--- a/vllm/reasoning/minimax_m3_reasoning_parser.py
+++ b/vllm/reasoning/minimax_m3_reasoning_parser.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from collections.abc import Iterable, Sequence
+from threading import Lock
 from typing import TYPE_CHECKING
 
 from vllm.entrypoints.openai.engine.protocol import DeltaMessage
@@ -10,6 +11,13 @@ from vllm.reasoning.basic_parsers import BaseThinkingReasoningParser
 if TYPE_CHECKING:
     from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
     from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+
+
+_MARKER_TOKEN_TEXT_CACHE: dict[
+    tuple[int, tuple[str, str]],
+    tuple[object, tuple[tuple[int, str], ...]],
+] = {}
+_MARKER_TOKEN_TEXT_CACHE_LOCK = Lock()
 
 
 class MiniMaxM3ReasoningParser(BaseThinkingReasoningParser):
@@ -76,6 +84,67 @@ class MiniMaxM3ReasoningParser(BaseThinkingReasoningParser):
             )
         except TypeError:
             return self.model_tokenizer.decode(list(token_ids))
+
+    def reasoning_marker_token_state(
+        self, output_token_ids: Sequence[int]
+    ) -> tuple[bool, tuple[int, ...]]:
+        """Return decoded marker completion state and valid next token IDs.
+
+        The tokenizer exposes atomic marker encodings, but runtime output can
+        use smaller vocabulary tokens. Cache the vocabulary fragments shared
+        by this tokenizer so every decoded marker tokenization is admitted
+        without repeating the vocabulary scan for each request.
+        """
+        output_prefix = tuple(output_token_ids)
+        marker_sequences = (self._start_token_ids, self._end_token_ids)
+        marker_complete = any(
+            len(output_prefix) >= len(marker) and output_prefix[: len(marker)] == marker
+            for marker in marker_sequences
+        )
+        next_token_ids = {
+            marker[len(output_prefix)]
+            for marker in marker_sequences
+            if len(output_prefix) < len(marker)
+            and output_prefix == marker[: len(output_prefix)]
+        }
+
+        markers = (self.start_token, self.end_token)
+        prefix_text = self._decode_text(output_prefix)
+        if any(prefix_text.startswith(marker) for marker in markers):
+            return True, ()
+
+        cache_key = (id(self.model_tokenizer), markers)
+        with _MARKER_TOKEN_TEXT_CACHE_LOCK:
+            cached = _MARKER_TOKEN_TEXT_CACHE.get(cache_key)
+            if cached is not None and cached[0] is self.model_tokenizer:
+                marker_token_texts = cached[1]
+            else:
+                marker_token_texts_list: list[tuple[int, str]] = []
+                for token_id in set(self.vocab.values()):
+                    try:
+                        token_text = self._decode_text([token_id])
+                    except Exception:
+                        continue
+                    if token_text and any(
+                        token_text in marker or token_text.startswith(marker)
+                        for marker in markers
+                    ):
+                        marker_token_texts_list.append((token_id, token_text))
+                marker_token_texts = tuple(marker_token_texts_list)
+                _MARKER_TOKEN_TEXT_CACHE[cache_key] = (
+                    self.model_tokenizer,
+                    marker_token_texts,
+                )
+
+        for token_id, _token_text in marker_token_texts:
+            candidate_text = self._decode_text([*output_prefix, token_id])
+            if any(
+                marker.startswith(candidate_text) or candidate_text.startswith(marker)
+                for marker in markers
+            ):
+                next_token_ids.add(token_id)
+
+        return marker_complete, tuple(sorted(next_token_ids))
 
     def _content_suffix_token_ids(
         self,
@@ -334,8 +403,6 @@ class MiniMaxM3ReasoningParser(BaseThinkingReasoningParser):
     def is_reasoning_end_from_prompt(
         self, prompt_token_ids: Sequence[int]
     ) -> bool | None:
-        if self._thinking_mode == "disabled":
-            return True
         if self._continue_final_message:
             content = self._continue_final_message_content
             if isinstance(self._continue_final_message_reasoning_ended, bool):
@@ -360,6 +427,8 @@ class MiniMaxM3ReasoningParser(BaseThinkingReasoningParser):
                 self._initial_in_reasoning = not reasoning_ended
                 self._reasoning_active_streaming = self._initial_in_reasoning
             return reasoning_ended
+        if self._thinking_mode == "disabled":
+            return True
         if self._thinking_mode == "enabled":
             return False
         return None

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -227,6 +227,8 @@ class LLMEngine:
         priority: int = 0,
         session_id: str | None = None,
         prompt_text: str | None = None,
+        reasoning_ended: bool | None = None,
+        reasoning_parser_kwargs: dict[str, Any] | None = None,
     ) -> str:
         # Validate the request_id type.
         if not isinstance(request_id, str):
@@ -261,6 +263,11 @@ class LLMEngine:
                 session_id=session_id,
             )
             prompt_text, _, _ = extract_prompt_components(self.model_config, prompt)
+
+        if reasoning_ended is not None:
+            request.reasoning_ended = reasoning_ended
+        if reasoning_parser_kwargs is not None:
+            request.reasoning_parser_kwargs = reasoning_parser_kwargs
 
         self.input_processor.assign_request_id(request)
 

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -227,21 +227,28 @@ class StructuredOutputManager:
             return
 
         output_prefix = tuple(output_token_ids)
-        if any(
-            len(output_prefix) >= len(marker) and output_prefix[: len(marker)] == marker
-            for marker in marker_sequences
-        ):
+        marker_token_state = getattr(reasoner, "reasoning_marker_token_state", None)
+        if marker_token_state is not None:
+            marker_complete, next_marker_token_ids = marker_token_state(output_prefix)
+            next_marker_token_ids = set(next_marker_token_ids)
+        else:
+            marker_complete = any(
+                len(output_prefix) >= len(marker)
+                and output_prefix[: len(marker)] == marker
+                for marker in marker_sequences
+            )
+            next_marker_token_ids = {
+                marker[len(output_prefix)]
+                for marker in marker_sequences
+                if len(output_prefix) < len(marker)
+                and output_prefix == marker[: len(output_prefix)]
+            }
+
+        if marker_complete:
             # A complete marker means generated reasoning has started (or a
             # leading closer is being discarded). Leave reasoning unconstrained.
             self._grammar_bitmask[index].fill_(self._full_mask)
             return
-
-        next_marker_token_ids = {
-            marker[len(output_prefix)]
-            for marker in marker_sequences
-            if len(output_prefix) < len(marker)
-            and output_prefix == marker[: len(output_prefix)]
-        }
 
         row = self._grammar_bitmask[index]
         grammar_advanced = 0

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -211,6 +211,70 @@ class StructuredOutputManager:
                 # requests here.
                 self._grammar_bitmask[index].fill_(self._full_mask)
 
+    def _fill_undetermined_reasoning_bitmask(
+        self,
+        grammar: StructuredOutputGrammar,
+        index: int,
+        request_id: str,
+        reasoner: "ReasoningParser",
+        output_token_ids: Sequence[int],
+    ) -> None:
+        """Allow grammar tokens plus tokens that can continue a marker."""
+        assert self._grammar_bitmask is not None
+        marker_sequences = getattr(reasoner, "reasoning_marker_token_ids", ())
+        if not marker_sequences:
+            self._grammar_bitmask[index].fill_(self._full_mask)
+            return
+
+        output_prefix = tuple(output_token_ids)
+        if any(
+            len(output_prefix) >= len(marker) and output_prefix[: len(marker)] == marker
+            for marker in marker_sequences
+        ):
+            # A complete marker means generated reasoning has started (or a
+            # leading closer is being discarded). Leave reasoning unconstrained.
+            self._grammar_bitmask[index].fill_(self._full_mask)
+            return
+
+        next_marker_token_ids = {
+            marker[len(output_prefix)]
+            for marker in marker_sequences
+            if len(output_prefix) < len(marker)
+            and output_prefix == marker[: len(output_prefix)]
+        }
+
+        row = self._grammar_bitmask[index]
+        grammar_advanced = 0
+        grammar_prefix_is_valid = not output_prefix
+        if output_prefix:
+            prefix = list(output_prefix)
+            grammar_prefix_is_valid = grammar.validate_tokens(prefix) == prefix
+            if grammar_prefix_is_valid and grammar.accept_tokens(request_id, prefix):
+                grammar_advanced = len(prefix)
+            else:
+                grammar_prefix_is_valid = False
+
+        try:
+            if grammar_prefix_is_valid:
+                if grammar.is_terminated():
+                    row.fill_(self._full_mask)
+                else:
+                    grammar.fill_bitmask(self._grammar_bitmask, index)
+            else:
+                row.zero_()
+
+            for token_id in next_marker_token_ids:
+                if token_id < 0 or token_id >= row.numel() * 32:
+                    continue
+                word_index, bit_index = divmod(token_id, 32)
+                bit = 1 << bit_index
+                if bit_index == 31:
+                    bit = -(1 << 31)
+                row[word_index] |= bit
+        finally:
+            if grammar_advanced:
+                grammar.rollback(grammar_advanced)
+
     @staticmethod
     def _output_start_index(request: "Request") -> int:
         return min(request.num_prompt_tokens, len(request.all_token_ids))
@@ -278,7 +342,25 @@ class StructuredOutputManager:
                     assert isinstance(grammar, StructuredOutputGrammar)
 
                 apply_bitmask = self.should_fill_bitmask(request)
-                batch.append((grammar, cumulative_index, apply_bitmask))
+                structured_req = request.structured_output_request
+                reasoner = self._get_reasoner(request)
+                if (
+                    not apply_bitmask
+                    and reasoner is not None
+                    and structured_req is not None
+                    and structured_req.reasoning_ended is None
+                    and not self.enable_in_reasoning
+                ):
+                    output_start = self._output_start_index(request)
+                    self._fill_undetermined_reasoning_bitmask(
+                        grammar,
+                        cumulative_index,
+                        req_id,
+                        reasoner,
+                        request.all_token_ids[output_start:],
+                    )
+                else:
+                    batch.append((grammar, cumulative_index, apply_bitmask))
                 if len(batch) == self.fill_bitmask_parallel_batch_size:
                     promises.append(self._async_submit_fill_bitmask(batch))
                     batch = []
@@ -319,7 +401,31 @@ class StructuredOutputManager:
                 post_reasoning_end_in_window = False
                 req_tokens = scheduled_spec_decode_tokens.get(req_id, ())
                 for i, token in enumerate(req_tokens):
-                    self._fill_bitmasks(((grammar, cumulative_index, apply_bitmask),))
+                    if (
+                        not apply_bitmask
+                        and detect_reasoning_end
+                        and reasoning_was_undetermined
+                        and reasoner is not None
+                    ):
+                        if simulated_buf is None:
+                            output_start = self._output_start_index(request)
+                            history = list(request.all_token_ids[output_start:])
+                            history_len = len(history)
+                            simulated_buf = history + list(req_tokens)
+                        simulated_prefix = history + [
+                            draft for draft in req_tokens[:i] if draft != -1
+                        ]
+                        self._fill_undetermined_reasoning_bitmask(
+                            grammar,
+                            cumulative_index,
+                            req_id,
+                            reasoner,
+                            simulated_prefix,
+                        )
+                    else:
+                        self._fill_bitmasks(
+                            ((grammar, cumulative_index, apply_bitmask),)
+                        )
                     advance_grammar = apply_bitmask
                     if token == -1:
                         apply_bitmask = False
@@ -379,7 +485,27 @@ class StructuredOutputManager:
                     #   reasoning_ended is only persisted later by
                     #   should_advance.
                     bonus_apply = self.should_fill_bitmask(request) or apply_bitmask
-                    self._fill_bitmasks(((grammar, cumulative_index, bonus_apply),))
+                    if (
+                        not bonus_apply
+                        and detect_reasoning_end
+                        and reasoning_was_undetermined
+                        and reasoner is not None
+                    ):
+                        if simulated_buf is None:
+                            output_start = self._output_start_index(request)
+                            history = list(request.all_token_ids[output_start:])
+                        bonus_prefix = history + [
+                            draft for draft in req_tokens if draft != -1
+                        ]
+                        self._fill_undetermined_reasoning_bitmask(
+                            grammar,
+                            cumulative_index,
+                            req_id,
+                            reasoner,
+                            bonus_prefix,
+                        )
+                    else:
+                        self._fill_bitmasks(((grammar, cumulative_index, bonus_apply),))
                     cumulative_index += 1
                 if state_advancements > 0:
                     grammar.rollback(state_advancements)

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -109,6 +109,13 @@ class StructuredOutputManager:
                 tokenizer=self.tokenizer,
                 **parser_kwargs,
             )
+        if not structured_req.reasoning_prompt_state_initialized:
+            prompt_state = structured_req.reasoner.is_reasoning_end_from_prompt(
+                request.prompt_token_ids or []
+            )
+            if structured_req.reasoning_ended is None:
+                structured_req.reasoning_ended = prompt_state
+            structured_req.reasoning_prompt_state_initialized = True
         return structured_req.reasoner
 
     def grammar_init(self, request: "Request") -> None:
@@ -204,6 +211,20 @@ class StructuredOutputManager:
                 # requests here.
                 self._grammar_bitmask[index].fill_(self._full_mask)
 
+    @staticmethod
+    def _output_start_index(request: "Request") -> int:
+        return min(request.num_prompt_tokens, len(request.all_token_ids))
+
+    @staticmethod
+    def _accept_validated_tokens(
+        grammar: StructuredOutputGrammar,
+        request_id: str,
+        token_ids: list[int],
+    ) -> int:
+        if grammar.validate_tokens(token_ids) != token_ids:
+            return 0
+        return len(token_ids) if grammar.accept_tokens(request_id, token_ids) else 0
+
     def _async_submit_fill_bitmask(
         self, batch: list[tuple[StructuredOutputGrammar, int, bool]]
     ) -> Future:
@@ -288,6 +309,9 @@ class StructuredOutputManager:
                     and reasoner is not None
                     and not self.enable_in_reasoning
                 )
+                reasoning_was_undetermined = (
+                    structured_output_request.reasoning_ended is None
+                )
                 simulated_buf: list[int] | None = None
                 history_len = 0
 
@@ -306,7 +330,8 @@ class StructuredOutputManager:
                         and not apply_bitmask
                     ):
                         if simulated_buf is None:
-                            history = list(request.all_token_ids)
+                            output_start = self._output_start_index(request)
+                            history = list(request.all_token_ids[output_start:])
                             history_len = len(history)
                             simulated_buf = history + list(req_tokens)
                         simulated = simulated_buf[: history_len + i + 1]
@@ -321,6 +346,16 @@ class StructuredOutputManager:
                             apply_bitmask = True
                             advance_grammar = False
                             post_reasoning_end_in_window = True
+                            if reasoning_was_undetermined:
+                                content_ids = reasoner.extract_content_ids(simulated)
+                                if (
+                                    content_ids == simulated
+                                    and not grammar.is_terminated()
+                                ):
+                                    state_advancements += self._accept_validated_tokens(
+                                        grammar, req_id, content_ids
+                                    )
+                                reasoning_was_undetermined = False
                     if advance_grammar and not grammar.is_terminated():
                         accepted = grammar.accept_tokens(req_id, [token])
                         if accepted:
@@ -367,15 +402,7 @@ class StructuredOutputManager:
             if self.enable_in_reasoning:
                 return True
             assert request.structured_output_request is not None
-            if request.structured_output_request.reasoning_ended is None:
-                # This should be removed here, but since `openai_gptoss`
-                # is an independent code path, it is kept for now.
-                # After unifying the `openai_gptoss` and non-`openai_gptoss` styles,
-                # it can be removed.
-                request.structured_output_request.reasoning_ended = (
-                    reasoner.is_reasoning_end(request.prompt_token_ids or [])
-                )
-            return request.structured_output_request.reasoning_ended
+            return request.structured_output_request.reasoning_ended is True
         return True
 
     def should_advance(
@@ -405,6 +432,8 @@ class StructuredOutputManager:
         if structured_req.reasoning_ended:
             return True
 
+        reasoning_was_undetermined = structured_req.reasoning_ended is None
+
         # Check if reasoning ends in *this* step.
         # When the caller passes new_token_ids (the tokens that were just
         # appended this step), use it directly as the delta window. The
@@ -418,7 +447,6 @@ class StructuredOutputManager:
             # The tokens were already appended this step, so the step window
             # starts exactly len(new_token_ids) from the end.
             start = len(all_token_ids) - len(new_token_ids)
-            delta_ids: Iterable[int] = new_token_ids
         else:
             delta_from = request.num_computed_tokens - request.num_output_placeholders
             start = (
@@ -426,12 +454,28 @@ class StructuredOutputManager:
                 if delta_from >= 0
                 else max(len(all_token_ids) + delta_from, 0)
             )
-            delta_ids = itertools.islice(all_token_ids, start, None)
-        if reasoner.is_reasoning_end_streaming(all_token_ids, delta_ids):
+        output_start = self._output_start_index(request)
+        output_token_ids = all_token_ids[output_start:]
+        step_start = max(start, output_start)
+        output_delta_start = step_start - output_start
+        if reasoner.is_reasoning_end_streaming(
+            output_token_ids,
+            itertools.islice(output_token_ids, output_delta_start, None),
+        ):
             structured_req.reasoning_ended = True
 
+            if reasoning_was_undetermined:
+                content_ids = reasoner.extract_content_ids(list(output_token_ids))
+                if content_ids == output_token_ids:
+                    structured_req.reasoning_end_token_index = None
+                    structured_req.deferred_grammar_start_index = output_start
+                    return True
+                structured_req.deferred_grammar_start_index = None
+
             # Record the boundary so the scheduler can exclude reasoning tokens.
-            end_index = self._find_reasoning_end_index(reasoner, all_token_ids, start)
+            end_index = self._find_reasoning_end_index(
+                reasoner, all_token_ids, output_start, step_start
+            )
 
             structured_req.reasoning_end_token_index = end_index
             return True
@@ -440,7 +484,10 @@ class StructuredOutputManager:
 
     @staticmethod
     def _find_reasoning_end_index(
-        reasoner: "ReasoningParser", all_token_ids: Sequence[int], start: int
+        reasoner: "ReasoningParser",
+        all_token_ids: Sequence[int],
+        output_start: int,
+        start: int,
     ) -> int:
         """Locates the last reasoning token within ``all_token_ids[start:]``.
 
@@ -451,7 +498,7 @@ class StructuredOutputManager:
             a multi-token marker only recognized on the full delta), which
             conservatively treats the whole step as reasoning content.
         """
-        prefix = list(itertools.islice(all_token_ids, start))
+        prefix = list(itertools.islice(all_token_ids, output_start, start))
         for idx in range(start, len(all_token_ids)):
             token = all_token_ids[idx]
             prefix.append(token)
@@ -476,6 +523,10 @@ class StructuredOutputManager:
         structured_req = request.structured_output_request
         if structured_req is None:
             return new_token_ids
+        deferred_start = structured_req.deferred_grammar_start_index
+        if deferred_start is not None:
+            structured_req.deferred_grammar_start_index = None
+            return list(request.all_token_ids[deferred_start:])
         end_idx = structured_req.reasoning_end_token_index
         if end_idx is None:
             return new_token_ids

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -234,21 +234,28 @@ class StructuredOutputManager:
             return
 
         output_prefix = tuple(output_token_ids)
-        if any(
-            len(output_prefix) >= len(marker) and output_prefix[: len(marker)] == marker
-            for marker in marker_sequences
-        ):
+        marker_token_state = getattr(reasoner, "reasoning_marker_token_state", None)
+        if marker_token_state is not None:
+            marker_complete, next_marker_token_ids = marker_token_state(output_prefix)
+            next_marker_token_ids = set(next_marker_token_ids)
+        else:
+            marker_complete = any(
+                len(output_prefix) >= len(marker)
+                and output_prefix[: len(marker)] == marker
+                for marker in marker_sequences
+            )
+            next_marker_token_ids = {
+                marker[len(output_prefix)]
+                for marker in marker_sequences
+                if len(output_prefix) < len(marker)
+                and output_prefix == marker[: len(output_prefix)]
+            }
+
+        if marker_complete:
             # A complete marker means generated reasoning has started (or a
             # leading closer is being discarded). Leave reasoning unconstrained.
             self._grammar_bitmask[index].fill_(self._full_mask)
             return
-
-        next_marker_token_ids = {
-            marker[len(output_prefix)]
-            for marker in marker_sequences
-            if len(output_prefix) < len(marker)
-            and output_prefix == marker[: len(output_prefix)]
-        }
 
         row = self._grammar_bitmask[index]
         grammar_advanced = 0

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -218,6 +218,70 @@ class StructuredOutputManager:
                 # requests here.
                 self._grammar_bitmask[index].fill_(self._full_mask)
 
+    def _fill_undetermined_reasoning_bitmask(
+        self,
+        grammar: StructuredOutputGrammar,
+        index: int,
+        request_id: str,
+        reasoner: "ReasoningParser",
+        output_token_ids: Sequence[int],
+    ) -> None:
+        """Allow grammar tokens plus tokens that can continue a marker."""
+        assert self._grammar_bitmask is not None
+        marker_sequences = getattr(reasoner, "reasoning_marker_token_ids", ())
+        if not marker_sequences:
+            self._grammar_bitmask[index].fill_(self._full_mask)
+            return
+
+        output_prefix = tuple(output_token_ids)
+        if any(
+            len(output_prefix) >= len(marker) and output_prefix[: len(marker)] == marker
+            for marker in marker_sequences
+        ):
+            # A complete marker means generated reasoning has started (or a
+            # leading closer is being discarded). Leave reasoning unconstrained.
+            self._grammar_bitmask[index].fill_(self._full_mask)
+            return
+
+        next_marker_token_ids = {
+            marker[len(output_prefix)]
+            for marker in marker_sequences
+            if len(output_prefix) < len(marker)
+            and output_prefix == marker[: len(output_prefix)]
+        }
+
+        row = self._grammar_bitmask[index]
+        grammar_advanced = 0
+        grammar_prefix_is_valid = not output_prefix
+        if output_prefix:
+            prefix = list(output_prefix)
+            grammar_prefix_is_valid = grammar.validate_tokens(prefix) == prefix
+            if grammar_prefix_is_valid and grammar.accept_tokens(request_id, prefix):
+                grammar_advanced = len(prefix)
+            else:
+                grammar_prefix_is_valid = False
+
+        try:
+            if grammar_prefix_is_valid:
+                if grammar.is_terminated():
+                    row.fill_(self._full_mask)
+                else:
+                    grammar.fill_bitmask(self._grammar_bitmask, index)
+            else:
+                row.zero_()
+
+            for token_id in next_marker_token_ids:
+                if token_id < 0 or token_id >= row.numel() * 32:
+                    continue
+                word_index, bit_index = divmod(token_id, 32)
+                bit = 1 << bit_index
+                if bit_index == 31:
+                    bit = -(1 << 31)
+                row[word_index] |= bit
+        finally:
+            if grammar_advanced:
+                grammar.rollback(grammar_advanced)
+
     @staticmethod
     def _output_start_index(request: "Request") -> int:
         return min(request.num_prompt_tokens, len(request.all_token_ids))
@@ -285,7 +349,25 @@ class StructuredOutputManager:
                     assert isinstance(grammar, StructuredOutputGrammar)
 
                 apply_bitmask = self.should_fill_bitmask(request)
-                batch.append((grammar, cumulative_index, apply_bitmask))
+                structured_req = request.structured_output_request
+                reasoner = self._get_reasoner(request)
+                if (
+                    not apply_bitmask
+                    and reasoner is not None
+                    and structured_req is not None
+                    and structured_req.reasoning_ended is None
+                    and not self.enable_in_reasoning
+                ):
+                    output_start = self._output_start_index(request)
+                    self._fill_undetermined_reasoning_bitmask(
+                        grammar,
+                        cumulative_index,
+                        req_id,
+                        reasoner,
+                        request.all_token_ids[output_start:],
+                    )
+                else:
+                    batch.append((grammar, cumulative_index, apply_bitmask))
                 if len(batch) == self.fill_bitmask_parallel_batch_size:
                     promises.append(self._async_submit_fill_bitmask(batch))
                     batch = []
@@ -322,7 +404,31 @@ class StructuredOutputManager:
                 post_reasoning_end_in_window = False
                 req_tokens = scheduled_spec_decode_tokens.get(req_id, ())
                 for i, token in enumerate(req_tokens):
-                    self._fill_bitmasks(((grammar, cumulative_index, apply_bitmask),))
+                    if (
+                        not apply_bitmask
+                        and detect_reasoning_end
+                        and reasoning_was_undetermined
+                        and reasoner is not None
+                    ):
+                        if simulated_buf is None:
+                            output_start = self._output_start_index(request)
+                            history = list(request.all_token_ids[output_start:])
+                            history_len = len(history)
+                            simulated_buf = history + list(req_tokens)
+                        simulated_prefix = history + [
+                            draft for draft in req_tokens[:i] if draft != -1
+                        ]
+                        self._fill_undetermined_reasoning_bitmask(
+                            grammar,
+                            cumulative_index,
+                            req_id,
+                            reasoner,
+                            simulated_prefix,
+                        )
+                    else:
+                        self._fill_bitmasks(
+                            ((grammar, cumulative_index, apply_bitmask),)
+                        )
                     advance_grammar = apply_bitmask
                     if token == -1:
                         apply_bitmask = False
@@ -382,7 +488,27 @@ class StructuredOutputManager:
                     #   reasoning_ended is only persisted later by
                     #   should_advance.
                     bonus_apply = self.should_fill_bitmask(request) or apply_bitmask
-                    self._fill_bitmasks(((grammar, cumulative_index, bonus_apply),))
+                    if (
+                        not bonus_apply
+                        and detect_reasoning_end
+                        and reasoning_was_undetermined
+                        and reasoner is not None
+                    ):
+                        if simulated_buf is None:
+                            output_start = self._output_start_index(request)
+                            history = list(request.all_token_ids[output_start:])
+                        bonus_prefix = history + [
+                            draft for draft in req_tokens if draft != -1
+                        ]
+                        self._fill_undetermined_reasoning_bitmask(
+                            grammar,
+                            cumulative_index,
+                            req_id,
+                            reasoner,
+                            bonus_prefix,
+                        )
+                    else:
+                        self._fill_bitmasks(((grammar, cumulative_index, bonus_apply),))
                     cumulative_index += 1
                 if state_advancements > 0:
                     grammar.rollback(state_advancements)

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -109,6 +109,13 @@ class StructuredOutputManager:
                 tokenizer=self.tokenizer,
                 **parser_kwargs,
             )
+        if not structured_req.reasoning_prompt_state_initialized:
+            prompt_state = structured_req.reasoner.is_reasoning_end_from_prompt(
+                request.prompt_token_ids or []
+            )
+            if structured_req.reasoning_ended is None:
+                structured_req.reasoning_ended = prompt_state
+            structured_req.reasoning_prompt_state_initialized = True
         return structured_req.reasoner
 
     def grammar_init(self, request: "Request") -> None:
@@ -211,6 +218,20 @@ class StructuredOutputManager:
                 # requests here.
                 self._grammar_bitmask[index].fill_(self._full_mask)
 
+    @staticmethod
+    def _output_start_index(request: "Request") -> int:
+        return min(request.num_prompt_tokens, len(request.all_token_ids))
+
+    @staticmethod
+    def _accept_validated_tokens(
+        grammar: StructuredOutputGrammar,
+        request_id: str,
+        token_ids: list[int],
+    ) -> int:
+        if grammar.validate_tokens(token_ids) != token_ids:
+            return 0
+        return len(token_ids) if grammar.accept_tokens(request_id, token_ids) else 0
+
     def _async_submit_fill_bitmask(
         self, batch: list[tuple[StructuredOutputGrammar, int, bool]]
     ) -> Future:
@@ -291,6 +312,9 @@ class StructuredOutputManager:
 
                 reasoner = None if apply_bitmask else self._get_reasoner(request)
                 detect_reasoning_end = reasoner is not None
+                reasoning_was_undetermined = (
+                    structured_output_request.reasoning_ended is None
+                )
                 simulated_buf: list[int] | None = None
                 history_len = 0
 
@@ -309,7 +333,8 @@ class StructuredOutputManager:
                         and not apply_bitmask
                     ):
                         if simulated_buf is None:
-                            history = list(request.all_token_ids)
+                            output_start = self._output_start_index(request)
+                            history = list(request.all_token_ids[output_start:])
                             history_len = len(history)
                             simulated_buf = history + list(req_tokens)
                         simulated = simulated_buf[: history_len + i + 1]
@@ -324,6 +349,16 @@ class StructuredOutputManager:
                             apply_bitmask = True
                             advance_grammar = False
                             post_reasoning_end_in_window = True
+                            if reasoning_was_undetermined:
+                                content_ids = reasoner.extract_content_ids(simulated)
+                                if (
+                                    content_ids == simulated
+                                    and not grammar.is_terminated()
+                                ):
+                                    state_advancements += self._accept_validated_tokens(
+                                        grammar, req_id, content_ids
+                                    )
+                                reasoning_was_undetermined = False
                     if advance_grammar and not grammar.is_terminated():
                         accepted = grammar.accept_tokens(req_id, [token])
                         if accepted:
@@ -374,15 +409,7 @@ class StructuredOutputManager:
         reasoner = self._get_reasoner(request)
         if reasoner is not None:
             assert structured_req is not None
-            if structured_req.reasoning_ended is None:
-                # This should be removed here, but since `openai_gptoss`
-                # is an independent code path, it is kept for now.
-                # After unifying the `openai_gptoss` and non-`openai_gptoss` styles,
-                # it can be removed.
-                structured_req.reasoning_ended = reasoner.is_reasoning_end(
-                    request.prompt_token_ids or []
-                )
-            return structured_req.reasoning_ended
+            return structured_req.reasoning_ended is True
         return True
 
     def should_advance(
@@ -412,6 +439,8 @@ class StructuredOutputManager:
 
         assert structured_req is not None
 
+        reasoning_was_undetermined = structured_req.reasoning_ended is None
+
         # Check if reasoning ends in *this* step.
         # When the caller passes new_token_ids (the tokens that were just
         # appended this step), use it directly as the delta window. The
@@ -425,7 +454,6 @@ class StructuredOutputManager:
             # The tokens were already appended this step, so the step window
             # starts exactly len(new_token_ids) from the end.
             start = len(all_token_ids) - len(new_token_ids)
-            delta_ids: Iterable[int] = new_token_ids
         else:
             delta_from = request.num_computed_tokens - request.num_output_placeholders
             start = (
@@ -433,12 +461,28 @@ class StructuredOutputManager:
                 if delta_from >= 0
                 else max(len(all_token_ids) + delta_from, 0)
             )
-            delta_ids = itertools.islice(all_token_ids, start, None)
-        if reasoner.is_reasoning_end_streaming(all_token_ids, delta_ids):
+        output_start = self._output_start_index(request)
+        output_token_ids = all_token_ids[output_start:]
+        step_start = max(start, output_start)
+        output_delta_start = step_start - output_start
+        if reasoner.is_reasoning_end_streaming(
+            output_token_ids,
+            itertools.islice(output_token_ids, output_delta_start, None),
+        ):
             structured_req.reasoning_ended = True
 
+            if reasoning_was_undetermined:
+                content_ids = reasoner.extract_content_ids(list(output_token_ids))
+                if content_ids == output_token_ids:
+                    structured_req.reasoning_end_token_index = None
+                    structured_req.deferred_grammar_start_index = output_start
+                    return True
+                structured_req.deferred_grammar_start_index = None
+
             # Record the boundary so the scheduler can exclude reasoning tokens.
-            end_index = self._find_reasoning_end_index(reasoner, all_token_ids, start)
+            end_index = self._find_reasoning_end_index(
+                reasoner, all_token_ids, output_start, step_start
+            )
 
             structured_req.reasoning_end_token_index = end_index
             return True
@@ -447,7 +491,10 @@ class StructuredOutputManager:
 
     @staticmethod
     def _find_reasoning_end_index(
-        reasoner: "ReasoningParser", all_token_ids: Sequence[int], start: int
+        reasoner: "ReasoningParser",
+        all_token_ids: Sequence[int],
+        output_start: int,
+        start: int,
     ) -> int:
         """Locates the last reasoning token within ``all_token_ids[start:]``.
 
@@ -458,7 +505,7 @@ class StructuredOutputManager:
             a multi-token marker only recognized on the full delta), which
             conservatively treats the whole step as reasoning content.
         """
-        prefix = list(itertools.islice(all_token_ids, start))
+        prefix = list(itertools.islice(all_token_ids, output_start, start))
         for idx in range(start, len(all_token_ids)):
             token = all_token_ids[idx]
             prefix.append(token)
@@ -483,6 +530,10 @@ class StructuredOutputManager:
         structured_req = request.structured_output_request
         if structured_req is None:
             return new_token_ids
+        deferred_start = structured_req.deferred_grammar_start_index
+        if deferred_start is not None:
+            structured_req.deferred_grammar_start_index = None
+            return list(request.all_token_ids[deferred_start:])
         end_idx = structured_req.reasoning_end_token_index
         if end_idx is None:
             return new_token_ids

--- a/vllm/v1/structured_output/request.py
+++ b/vllm/v1/structured_output/request.py
@@ -31,10 +31,15 @@ class StructuredOutputRequest:
     # reasoning ends in a step whose tokens the scheduler advances immediately
     # (structural tags + speculative decoding, see #42452).
     reasoning_end_token_index: int | None = None
+    # Absolute index into all_token_ids where grammar content began while an
+    # adaptive reasoning prefix was still ambiguous. Once direct content is
+    # confirmed, all tokens from this index must be replayed into the grammar.
+    deferred_grammar_start_index: int | None = None
     reasoning_parser_kwargs: dict[str, Any] | None = None
     # Cached per request; do not share reasoning parsers across requests because
     # their behavior can depend on reasoning_parser_kwargs.
     reasoner: "ReasoningParser | None" = None
+    reasoning_prompt_state_initialized: bool = False
 
     @staticmethod
     def from_sampling_params(


### PR DESCRIPTION
## Purpose

Fixes #46042.
Fixes #50549.

MiniMax-M3 adaptive reasoning can leak `<mm:think>` or `</mm:think>` into streaming `content` because parser initialization scans the entire rendered prompt. Instructional or example marker pairs can therefore make the parser conclude that reasoning already ended before generation starts.

This PR adds a prompt-boundary state hook and initializes MiniMax-M3 from `thinking_mode`: `enabled` starts in reasoning, `disabled` starts after reasoning, and `adaptive` lets generated output markers determine the state.

## Implementation summary

- preserves the existing reasoner behavior by default, with MiniMax-M3 overriding only prompt-boundary initialization
- carries the request-local reasoning state through Chat Completions, Responses, streaming parsing, structured output, offline chat, and batched serving
- keeps unresolved adaptive state deferred until generated tokens establish a boundary
- handles structured-output masks, alternative marker tokenizations, direct-content replay, continuation state, and parser reset after built-in tool turns

Although the visible symptom is parser-level, the state has to cross each place that creates or reuses a reasoning parser. Otherwise one serving path can fall back to the old full-prompt scan or leak continuation state between requests.

<details>
<summary>Detailed implementation scope</summary>

- uses `is_reasoning_end_from_prompt()` in online, offline, Responses, streaming, and structured-output initialization
- scopes deferred adaptive marker checks to generated tokens so prompt examples cannot activate the grammar
- allows grammar-valid tokens plus every decoded reasoning-marker tokenization while adaptive state is unresolved
- replays direct adaptive content through the grammar, including ambiguous prefixes and speculative draft state
- derives continuation state from the final assistant message only and preserves open or closed `thinking` content parts
- propagates incomplete Responses reasoning items to frontend and engine parsers
- clears continuation-only state and refreshes the frontend parser after Responses built-in tool turns rerender the prompt
- keeps batch parsers request-local and initializes each engine-side structured-output parser from its prompt once

</details>

## Review focus

1. Default compatibility of `is_reasoning_end_from_prompt()` and the MiniMax-M3 `thinking_mode` override
2. Deferred adaptive transitions in structured output, including generated-token-only checks and marker tokenization boundaries
3. Request isolation and continuation reset across Responses, batch, offline chat, and built-in tool turns

## Validation

Local focused validation:

- MiniMax-M3 reasoning parser: 44 passed
- reasoning-aware structured output: 21 passed
- offline chat prompt-state forwarding: 1 passed
- batch prompt-state forwarding: 3 passed
- Responses serving: 23 passed, 1 expected xfail
- `ruff check`, `ruff format`, Python `compileall`, and `git diff --check` passed

The 92 focused tests ran in a CPU-only temporary environment with `VLLM_TARGET_DEVICE=empty`.

External MiniMax-M3 validation:

- [Parser validation on aarch64](https://github.com/vllm-project/vllm/pull/50594#issuecomment-5281778580): 44/44 parser tests passed and the deployed prompt-state failure was reproduced and confirmed
- [Production end-to-end validation](https://github.com/vllm-project/vllm/pull/50594#issuecomment-5290659689): the streaming marker leak was fixed on both OpenAI and Anthropic-compatible APIs, Anthropic streaming `thinking` blocks were restored, and tool calls remained working

The production deployment backported the parser, chat utility, and serving call-site changes rather than running the complete 17-file branch. The remaining Responses, batch, offline, and structured-output paths are covered by the focused CPU tests above and still need repository CI.

## Current CI status

The current `pre-run-check` is stopped by the first-contributor authorization gate, and the pre-commit job was skipped. CI requires a `verified`, `ready`, or `ready-run-all-tests` label, or a trusted reviewer action such as `/ci run`. Repository-wide GPU CI has not run yet.

## Related work

- #45718 fixed split-token MiniMax-M3 marker parsing, but not prompt-boundary state initialization.
- #50152 identified the same full-prompt scan failure and demonstrated the production symptom, but closed without merging.
- #48550 also addresses prompt-mode initialization while adding broader speculative-decoding and tool-parser changes.
- This PR is limited to prompt-boundary reasoning initialization and the state propagation needed to preserve it across supported serving paths.

<details>
<summary>Focused test commands</summary>

```bash
uv run pytest -q tests/reasoning/test_minimax_m3_reasoning_parser.py tests/v1/structured_output/test_reasoning_structured_output.py
uv run pytest -q tests/entrypoints/llm/test_offline_reasoning_state.py
uv run pytest -q tests/entrypoints/openai/chat_completion/test_batched_chat_completions.py -k batch_forwards_prompt_reasoning_state
uv run pytest -q tests/entrypoints/openai/responses/test_serving_responses.py
```

</details>

## AI assistance

OpenAI Codex assisted with implementation and regression-test drafting. The commits include `Assisted-by` trailers. The submitter requested the changes after reviewing the proposed scope.