### PR TITLE
fix(config): serialize remote lazy config mappings

### DIFF
--- a/tests/config/test_mp_reducer.py
+++ b/tests/config/test_mp_reducer.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import importlib.util
+import multiprocessing
 import sys
+import types
 from unittest.mock import patch
 
-from vllm.config import VllmConfig
-from vllm.engine.arg_utils import AsyncEngineArgs
-from vllm.v1.engine.async_llm import AsyncLLM
+from vllm.config import DeviceConfig, VllmConfig
+from vllm.transformers_utils.config import maybe_register_config_serialize_by_value
 
 
 def test_mp_reducer():
@@ -18,6 +20,9 @@ def test_mp_reducer():
     # Ensure transformers_modules is not in sys.modules
     if "transformers_modules" in sys.modules:
         del sys.modules["transformers_modules"]
+
+    from vllm.engine.arg_utils import AsyncEngineArgs
+    from vllm.v1.engine.async_llm import AsyncLLM
 
     with patch("multiprocessing.reducer.register") as mock_register:
         engine_args = AsyncEngineArgs(
@@ -51,3 +56,46 @@ def test_mp_reducer():
         )
 
         async_llm.shutdown()
+
+
+def test_mp_reducer_serializes_remote_config_with_config_mapping(tmp_path):
+    module_name = "transformers_modules.synthetic.configuration_remote"
+    module_path = tmp_path / "configuration_remote.py"
+    module_path.write_text(
+        "from transformers.models.auto import CONFIG_MAPPING\n"
+        "class RemoteConfig:\n"
+        "    def __init__(self):\n"
+        "        self.value = 'original'\n"
+        "    def mapping(self):\n"
+        "        return CONFIG_MAPPING\n"
+    )
+
+    modules = {}
+    for package_name in ("transformers_modules", "transformers_modules.synthetic"):
+        package = types.ModuleType(package_name)
+        package.__path__ = []
+        modules[package_name] = package
+
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    remote_module = importlib.util.module_from_spec(spec)
+    modules[module_name] = remote_module
+
+    with patch.dict(sys.modules, modules):
+        spec.loader.exec_module(remote_module)
+        try:
+            maybe_register_config_serialize_by_value()
+
+            vllm_config = VllmConfig(device_config=DeviceConfig("cpu"))
+            vllm_config.model_config = remote_module.RemoteConfig()  # type: ignore[assignment]
+            payload = multiprocessing.reduction.ForkingPickler.dumps(vllm_config)
+            restored = multiprocessing.reduction.ForkingPickler.loads(payload)
+
+            assert restored.model_config.value == "original"
+            assert restored.model_config.mapping()["llama"].model_type == "llama"
+        finally:
+            cloudpickle_module = sys.modules["cloudpickle"]
+            cloudpickle_module.unregister_pickle_by_value(  # type: ignore[attr-defined]
+                modules["transformers_modules"]
+            )

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -1018,6 +1018,18 @@ def maybe_register_config_serialize_by_value() -> None:
 
         # Register transformers_modules with cloudpickle if available
         if transformers_modules_available:
+            import copyreg
+
+            from transformers.models.auto import CONFIG_MAPPING
+
+            def _reduce_lazy_config_mapping(mapping):
+                return (
+                    type(mapping),
+                    (mapping._mapping,),
+                    {"_extra_content": mapping._extra_content},
+                )
+
+            copyreg.pickle(type(CONFIG_MAPPING), _reduce_lazy_config_mapping)
             cloudpickle.register_pickle_by_value(transformers_modules)
 
             # ray vendors its own version of cloudpickle


### PR DESCRIPTION
## Summary

- register a targeted reducer for Transformers' lazy config mapping when remote-code modules are serialized by value
- reconstruct the mapping from its source mapping, preserve explicit registrations, and omit only the reloadable module cache
- add a multiprocessing regression test that round-trips a synthetic remote config through the same `ForkingPickler` path used by engine-core spawn

Fixes #50495.

## Root cause

When a trusted remote config module imports `CONFIG_MAPPING` at module scope, vLLM's by-value cloudpickle serialization captures the `_LazyConfigMapping` instance. Its default pickle reconstruction calls the constructor without the required mapping argument, so the engine-core subprocess fails before model loading.

## Duplicate check

The open PR #50536 addresses the separate, earlier `hf_config.pooling` failure mentioned in #50495. It does not address the `_LazyConfigMapping` multiprocessing serialization failure. No other open PR was found for this failure.

## Validation

- `PYTHONFAULTHANDLER=1 .venv/bin/python -X faulthandler -m pytest tests/config/test_mp_reducer.py::test_mp_reducer_serializes_remote_config_with_config_mapping -q --confcutdir=tests/config` - 1 passed
- `PRE_COMMIT_HOME=/private/tmp/vllm-50495-precommit .venv/bin/pre-commit run --files vllm/transformers_utils/config.py tests/config/test_mp_reducer.py` - all applicable hooks passed
- standalone before/after reproducer - baseline raised the reported `TypeError`; the patched reducer round-tripped and resolved the `llama` config

Normal full test collection could not be completed on macOS because the installed `xgrammar` native extension segfaults during static initialization before pytest collection. No model evaluation was run because this change affects configuration transport during process startup, not model outputs or accuracy.

