### PR TITLE
[Docs] Fix stale FusedMoE references in custom quantization guide

### DIFF
--- a/docs/features/quantization/README.md
+++ b/docs/features/quantization/README.md
@@ -91,7 +91,7 @@ from vllm.model_executor.layers.quantization.base_config import (
     QuantizeMethodBase,
 )
 from vllm.model_executor.layers.linear import LinearBase
-from vllm.model_executor.layers.fused_moe import FusedMoE
+from vllm.model_executor.layers.fused_moe import RoutedExperts
 
 @register_quantization_config("my_quant")
 class MyQuantConfig(QuantizationConfig):
@@ -125,7 +125,7 @@ class MyQuantConfig(QuantizationConfig):
         # NOTE: you only need to implement methods you care about
         if isinstance(layer, LinearBase):
             return MyQuantLinearMethod()
-        elif isinstance(layer, FusedMoE):
+        elif isinstance(layer, RoutedExperts):
             return MyQuantMoEMethod(layer.moe_config)
         return None
 ```
@@ -174,7 +174,11 @@ class MyQuantLinearMethod(UnquantizedLinearMethod):
 For Mixture of Experts (MoE) models, return a `FusedMoEMethodBase` subclass from `get_quant_method`. You can use `UnquantizedFusedMoEMethod` to skip MoE quantization:
 
 ```python
-from vllm.model_executor.layers.fused_moe.layer import UnquantizedFusedMoEMethod
+from vllm.model_executor.layers.fused_moe import (
+    RoutedExperts,
+    SharedExperts,
+    UnquantizedFusedMoEMethod,
+)
 from vllm.model_executor.layers.fused_moe.fused_moe_method_base import (
     FusedMoEMethodBase,
 )
@@ -185,7 +189,7 @@ class MyQuantMoEMethod(FusedMoEMethodBase):
 
     def create_weights(
         self,
-        layer: torch.nn.Module,
+        layer: RoutedExperts,
         num_experts: int,
         hidden_size: int,
         intermediate_size_per_partition: int,
@@ -197,16 +201,18 @@ class MyQuantMoEMethod(FusedMoEMethodBase):
 
     def apply(
         self,
-        layer: torch.nn.Module,
-        router: "FusedMoERouter",
+        layer: RoutedExperts,
         x: torch.Tensor,
-        router_logits: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        shared_experts: SharedExperts | None,
+        shared_experts_input: torch.Tensor | None,
     ) -> torch.Tensor:
         # Apply MoE computation with quantized weights
         ...
 
     def get_fused_moe_quant_config(
-        self, layer: torch.nn.Module
+        self, layer: RoutedExperts
     ) -> FusedMoEQuantConfig | None:
         # Return the MoE quantization configuration
         ...


### PR DESCRIPTION
## Purpose

The out-of-tree quantization plugin guide in `docs/features/quantization/README.md` is a copy-paste tutorial, and two of its imports no longer resolve on main:

- `from vllm.model_executor.layers.fused_moe import FusedMoE` — `FusedMoE` was replaced by `RoutedExperts` (`vllm/model_executor/layers/fused_moe/routed_experts.py`). The name survives only in comments; there is no class by that name anywhere in the tree.
- `from vllm.model_executor.layers.fused_moe.layer import UnquantizedFusedMoEMethod` — the class moved to `vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py` and is re-exported from the package `__init__`.

Both raise `ImportError` as written, so anyone following the guide is stopped at the first snippet.

Two related updates in the same section:

- `isinstance(layer, FusedMoE)` becomes `isinstance(layer, RoutedExperts)`. All in-tree `get_quant_method` implementations dispatch on `RoutedExperts` (see `Fp8Config.get_quant_method` in `vllm/model_executor/layers/quantization/fp8.py`). `layer.moe_config` on the following line is still valid, since `RoutedExperts` sets it in `__init__`.
- `MyQuantMoEMethod.apply` showed `(layer, router: "FusedMoERouter", x, router_logits)`, which matches neither `FusedMoEMethodBase.apply` nor `apply_monolithic`. It now matches `apply`: `(layer, x, topk_weights, topk_ids, shared_experts, shared_experts_input)`. The `layer` annotations on `create_weights` and `get_fused_moe_quant_config` are narrowed to `RoutedExperts` to match the base class.

Docs only, no behavior change.

## Test Plan

- `pre-commit run --files docs/features/quantization/README.md`
- Resolve every `from vllm...` import in the guide against an AST index of the tree, asserting each name is bound in the target module.
- Confirm `FusedMoE` is not defined anywhere: `grep -rnE '^\s*class FusedMoE\b' vllm/`
- Read `FusedMoEMethodBase` in `vllm/model_executor/layers/fused_moe/fused_moe_method_base.py` and compare each signature in the snippet against it.

## Test Result

- `pre-commit run`: `typos`, `markdownlint-cli2`, `Check for spaces in all filenames`, `Update Dockerfile dependency graph` and the config validation hook all Passed. `ruff check` and `ruff format` skipped, since the diff is markdown only.
- Import resolution after the change: `RoutedExperts`, `SharedExperts` and `UnquantizedFusedMoEMethod` are all bound in `vllm.model_executor.layers.fused_moe`; `FusedMoEMethodBase` in `...fused_moe.fused_moe_method_base`; `FusedMoEQuantConfig` in `...fused_moe.config`; `register_quantization_config` in `...quantization`; `QuantizationConfig` and `QuantizeMethodBase` in `...quantization.base_config`; `LinearBase` and `UnquantizedLinearMethod` in `...linear`. 10 of 10 resolve. Before the change, `FusedMoE` and `...fused_moe.layer.UnquantizedFusedMoEMethod` both failed.
- `grep` for `class FusedMoE\b`: no matches.

I do not have GPU access, so this was verified by static resolution against the source rather than by running a model.
