### PR TITLE
[Bugfix] Honour VLLM_MQ_MAX_CHUNK_BYTES_MB at every MessageQueue call site

### DIFF
--- a/tests/distributed/test_mq_max_chunk_bytes.py
+++ b/tests/distributed/test_mq_max_chunk_bytes.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Test that VLLM_MQ_MAX_CHUNK_BYTES_MB bounds every shm ring buffer an executor
+creates, not just the broadcast queue.
+
+The bug: `multiproc_executor` read the env var for `rpc_broadcast_mq` but built
+`worker_response_mq` with `MessageQueue(1, 1)`, falling back to the 24 MiB
+signature default. That queue is created once PER WORKER, so at TP=2 it asks
+for 2 x 24 MiB x 10 chunks = 480 MiB regardless of the env var, and the env var
+cannot bring total usage under a small /dev/shm. Since #48879 added
+`check_shm_free_space`, that is a hard boot failure rather than a latent SIGBUS.
+
+The fix: pass the env-derived chunk size at every construction site.
+"""
+
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+import vllm.envs as envs
+from vllm.distributed.device_communicators.shm_broadcast import MessageQueue
+from vllm.v1.executor import multiproc_executor
+
+
+@pytest.mark.parametrize("chunk_mb", [1, 4])
+def test_worker_response_mq_honours_env(
+    monkeypatch: pytest.MonkeyPatch, chunk_mb: int
+) -> None:
+    """The per-worker response queue must use VLLM_MQ_MAX_CHUNK_BYTES_MB."""
+    monkeypatch.setattr(envs, "VLLM_MQ_MAX_CHUNK_BYTES_MB", chunk_mb)
+
+    captured: dict[str, Any] = {}
+
+    class RecordingMessageQueue:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+        @staticmethod
+        def create_from_handle(handle: Any, rank: Any) -> Any:
+            return MagicMock()
+
+    monkeypatch.setattr(multiproc_executor, "MessageQueue", RecordingMessageQueue)
+
+    worker_proc = SimpleNamespace(worker=SimpleNamespace(rank=0))
+    vllm_config = SimpleNamespace(parallel_config=SimpleNamespace(nnodes_within_dp=1))
+
+    # Unbound call with a stand-in `self`: the queues are all we want to build.
+    init_message_queues = cast(Any, multiproc_executor.WorkerProc._init_message_queues)
+    init_message_queues(
+        worker_proc, input_shm_handle=MagicMock(), vllm_config=vllm_config
+    )
+
+    assert captured["max_chunk_bytes"] == chunk_mb * 1024 * 1024
+
+
+def test_ring_buffer_scales_with_chunk_bytes() -> None:
+    """A smaller chunk size must actually shrink the shm allocation.
+
+    Guards the assumption the fix relies on: that bounding max_chunk_bytes
+    bounds what check_shm_free_space sees.
+    """
+    small = MessageQueue(1, 1, max_chunk_bytes=1024 * 1024)
+    try:
+        # 1 MiB x 10 chunks plus per-chunk metadata, far below the 240 MiB the
+        # 24 MiB default would request.
+        assert small.buffer.total_bytes_of_buffer < 16 * 1024 * 1024
+        assert small.buffer.max_chunk_bytes == 1024 * 1024
+    finally:
+        del small

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -613,8 +613,14 @@ class WorkerProc:
                 input_shm_handle, self.worker.rank
             )
 
-            # Initializes a message queue for sending the model output
-            self.worker_response_mq = MessageQueue(1, 1)
+            # Initializes a message queue for sending the model output.
+            # This queue is created once per worker, so its ring buffer must be
+            # bounded by VLLM_MQ_MAX_CHUNK_BYTES_MB too -- otherwise the default
+            # dominates total /dev/shm usage and capping the broadcast queue has
+            # no effect on hosts with a small /dev/shm.
+            self.worker_response_mq = MessageQueue(
+                1, 1, max_chunk_bytes=envs.VLLM_MQ_MAX_CHUNK_BYTES_MB * 1024 * 1024
+            )
             self.peer_response_handles = []
         else:
             # Initialize remote MessageQueue for receiving SchedulerOutput across nodes

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -581,8 +581,14 @@ class WorkerProc:
                 input_shm_handle, self.worker.rank
             )
 
-            # Initializes a message queue for sending the model output
-            self.worker_response_mq = MessageQueue(1, 1)
+            # Initializes a message queue for sending the model output.
+            # This queue is created once per worker, so its ring buffer must be
+            # bounded by VLLM_MQ_MAX_CHUNK_BYTES_MB too -- otherwise the default
+            # dominates total /dev/shm usage and capping the broadcast queue has
+            # no effect on hosts with a small /dev/shm.
+            self.worker_response_mq = MessageQueue(
+                1, 1, max_chunk_bytes=envs.VLLM_MQ_MAX_CHUNK_BYTES_MB * 1024 * 1024
+            )
             self.peer_response_handles = []
         else:
             # Initialize remote MessageQueue for receiving SchedulerOutput across nodes

--- a/vllm/v1/executor/ray_executor_v2.py
+++ b/vllm/v1/executor/ray_executor_v2.py
@@ -188,6 +188,7 @@ class RayWorkerProc(WorkerProc):
         self.worker_response_mq = MessageQueue(
             n_reader=1,
             n_local_reader=n_local,
+            max_chunk_bytes=envs.VLLM_MQ_MAX_CHUNK_BYTES_MB * 1024 * 1024,
             connect_ip=ray.util.get_node_ip_address(),
         )
         self.peer_response_handles: list[dict] = []

--- a/vllm/v1/executor/ray_executor_v2.py
+++ b/vllm/v1/executor/ray_executor_v2.py
@@ -206,6 +206,7 @@ class RayWorkerProc(WorkerProc):
         self.worker_response_mq = MessageQueue(
             n_reader=1,
             n_local_reader=n_local,
+            max_chunk_bytes=envs.VLLM_MQ_MAX_CHUNK_BYTES_MB * 1024 * 1024,
             connect_ip=ray.util.get_node_ip_address(),
         )
         self.peer_response_handles: list[dict] = []


### PR DESCRIPTION
## Purpose

`VLLM_MQ_MAX_CHUNK_BYTES_MB` exists to bound the `/dev/shm` ring buffers, but only `rpc_broadcast_mq` reads it. `worker_response_mq` falls back to the 24 MiB signature default in both the multiproc and Ray v2 executors — and that queue is created once **per worker**, so at TP=2 it requests `2 × 24 MiB × 10 chunks = 480 MiB` regardless of the env var.

On the common 64 MiB `/dev/shm`, the knob therefore cannot bring total usage under the limit. Since #48879 added `check_shm_free_space`, this is now a hard startup failure rather than a latent SIGBUS:

```
File "vllm/v1/executor/multiproc_executor.py", line 585, in _init_message_queues
    self.worker_response_mq = MessageQueue(1, 1)
RuntimeError: Insufficient space in /dev/shm: 240 MiB required, 64 MiB free.
```

Setting `VLLM_MQ_MAX_CHUNK_BYTES_MB=4` moves the broadcast queue from 160 → 40 MiB but leaves the 480 MiB untouched, so the boot still fails:

| `VLLM_MQ_MAX_CHUNK_BYTES_MB` | `rpc_broadcast_mq` | `worker_response_mq` × 2 | total | fits 64 MiB? |
|---|---|---|---|---|
| 16 (default) | 160 MiB | 480 MiB | 640 MiB | no |
| 4, before this PR | 40 MiB | 480 MiB | 520 MiB | no |
| 4, with this PR | 40 MiB | 80 MiB | 120 MiB | no |
| 1, with this PR | 10 MiB | 20 MiB | 30 MiB | **yes** |

This matters most where `/dev/shm` cannot be resized. A plain Kubernetes Pod needs an `emptyDir{medium: Memory}` mount to raise it, and some managed platforms do not expose that. #49568 makes it configurable in the Helm chart; this change gives deployments that *cannot* mount volumes a way to fit inside what they have.

Reducing the chunk size is safe for these queues: an oversized message is not fatal, `shm_broadcast` sets an overflow flag and falls back to a local socket. The 24 MiB default is sized (per the comment on `MessageQueue.__init__`) for grammar bitmask tensors at 1024 requests, which is a property of the *broadcast* queue rather than the per-worker response queue.

Discovered while running DeepSeek-V4 at TP=2 on a platform with a fixed 64 MiB `/dev/shm`. Note this over-commit predates `check_shm_free_space` — it only ever worked because tmpfs allocates lazily, exactly the failure mode #48879 set out to make visible.

## Alternative considered

Making `MessageQueue.__init__` default `max_chunk_bytes` to the env var would guarantee no call site can bypass the cap, at the cost of changing the effective default for `worker_response_mq` from 24 → 16 MiB. I went with explicit pass-through to keep the change minimal and behaviour-preserving at default settings, but I'm happy to switch if maintainers prefer the stronger guarantee.

## Duplicate check

Searched issues and PRs for `worker_response_mq`, `max_chunk_bytes`, `VLLM_MQ_MAX_CHUNK_BYTES_MB`, `shm_broadcast`, `dev/shm` and the error string before writing this. #48879 added `check_shm_free_space` (its discussion does not raise the per-worker queue) and #49568 makes `/dev/shm` configurable in the Helm chart, which helps deployments that *can* mount volumes. Nothing merged or open addresses the env var being ignored at these two call sites, and `worker_response_mq = MessageQueue(1, 1)` is still unbounded on `main` today.

## Test Plan

```bash
pytest tests/distributed/test_mq_max_chunk_bytes.py -v
```

New test asserts the per-worker response queue picks up `VLLM_MQ_MAX_CHUNK_BYTES_MB` (parametrised over 1 and 4 MiB) by recording the kwargs passed at construction, plus a guard that a smaller chunk size actually shrinks `total_bytes_of_buffer` — the assumption the fix depends on.

Manual reproduction: `--tensor-parallel-size 2` in a container with `--shm-size=64m`. On `main` this fails with the error above (confirmed); with this change and `VLLM_MQ_MAX_CHUNK_BYTES_MB=1` the requested buffers total 30 MiB, which should clear the check — confirmation pending, see Test Result.

## Test Result

**Unit tests: not yet run.** I have no built vLLM/torch in my environment, so I am not pasting results I have not seen. CI is the gate for those.

**End-to-end: confirmed.** On the affected deployment (DeepSeek-V4-Flash, TP=2, fixed 64 MiB `/dev/shm`):

*Before* — fails at `_init_message_queues`, after a ~32 minute weight load:

```
Model loading took 79.03 GiB and 1904.426086 seconds
RuntimeError: Insufficient space in /dev/shm: 240 MiB required, 64 MiB free.
```

*After* (same base, this change, `VLLM_MQ_MAX_CHUNK_BYTES_MB=1`) — both queues initialise and startup proceeds past them:

```
Loading safetensors using Runai Model Streamer: 100% Completed | 72317/72317 [16:08<00:00, 74.68it/s]
INFO [dspark.py:465] DSpark draft model loaded: 96 params
INFO [model_runner.py:328] Model loading took 79.03 GiB and 1916.294725 seconds
INFO [topk_topp_sampler.py:62] Using FlashInfer for top-p & top-k sampling.
```

Startup then reached memory profiling and kernel warmup. (That run later failed for an unrelated reason in the draft model's attention — no message queues involved. Reporting it for completeness rather than claiming a fully clean boot.)

Intermediate evidence that isolates the cause: with `VLLM_MQ_MAX_CHUNK_BYTES_MB=4` and *without* this change, the first failure moved from `multiproc_executor.py:151` (160 MiB) to `:585` (240 MiB) — the env var works where it is read, and is ignored where it is not.

## AI assistance disclosure

AI assistance (Claude) was used to develop this change, and the commit carries a `Co-authored-by:` trailer accordingly.

Per the "Be involved" requirement: the submitting author has reviewed every changed line, and the fix is validated end-to-end on the affected deployment (see Test Result). The unit tests added here have not yet been executed locally — that is the one outstanding item, and CI is the gate for it.
