### PR TITLE
[Bugfix] Fix NVFP4 shape mismatch in flashinfer_scaled_fp4_mm #50557

### DIFF
--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -1205,7 +1205,7 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
             or torch.unique(layer.weight_scale_2).numel() != 1
         ):
             logger.warning_once(
-                "In NVFP4 linear, the global scale for input or weight are different"
+                "In NVFP4 linear, the global scale for input or weight are different "
                 " for parallel layers (e.g. q_proj, k_proj, v_proj). This "
                 " will likely results in reduce accuracy. Please verify the model"
                 " accuracy. Consider using a checkpoint with a shared global NVFP4"
@@ -1228,6 +1228,14 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
         layer.input_global_scale_inv = Parameter(
             (1.0 / layer.input_global_scale).to(torch.float32), requires_grad=False
         )
+
+        # Transpose weight if needed: checkpoints may store weights as
+        # (in_features // 2, out_features) but we expect
+        # (out_features, in_features // 2)
+        weight = layer.weight.data
+        if weight.shape[0] != layer.output_size_per_partition:
+            weight = weight.t()
+        layer.weight = Parameter(weight, requires_grad=False)
 
         # Convert layer to NVFP4 linear kernel format
         self.kernel.process_weights_after_loading(layer)


### PR DESCRIPTION
Fix issue #50557 
```
Fixes shape mismatch assertion error when loading NVFP4 checkpoints that store weights in transposed format (in_features // 2, out_features) instead of the expected (out_features, in_features // 2).

The fix adds conditional weight transpose in
ModelOptNvFp4LinearMethod.process_weights_after_loading(), matching the pattern used in FP8 methods. This resolves the assertion 'a.shape[1] == b.shape[1]' failure in flashinfer_scaled_fp4_mm for models like AxionML/Gemma-4-12B-NVFP4 on SM120+ hardware.

Fixes: #50577

## Purpose

Some NVFP4 checkpoints (e.g. AxionML/Gemma-4-12B-NVFP4) store weights in the
standard PyTorch layout `(in_features // 2, out_features)` rather than the
vLLM-expected `(out_features, in_features // 2)`. Unlike the FP8 linear methods
in `modelopt.py` (which transpose weights after loading), the NVFP4 method did
not perform this transpose, causing `flashinfer_scaled_fp4_mm` to hit the
assertion `a.shape[1] == b.shape[1]` during `profile_run()` on SM120+ hardware
(e.g. RTX 5060 Ti).

## Test Plan

Reproduce the original failure:

```bash
vllm serve AxionML/Gemma-4-12B-NVFP4 \
  --quantization modelopt \
  --max-model-len 8192 \
  --enforce-eager \
  --limit-mm-per-prompt '{"image": 0}' \
  --port 8000
```

Regression check that the previously-working model still loads:

```bash
vllm serve cosmicproc/gemma-4-E4B-it-NVFP4 \
  --quantization modelopt \
  --max-model-len 8192 \
  --enforce-eager \
  --limit-mm-per-prompt '{"image": 0}' \
  --port 8001
```

Unit tests (require SM100+ with FlashInfer):

```bash
.venv/bin/python -m pytest tests/kernels/quantization/test_flashinfer_nvfp4_scaled_mm.py -v
```

## Test Result

- Ruff linter: Passed
- Mypy type checker: Passed
- Syntax validation: Passed

Full end-to-end inference testing with `AxionML/Gemma-4-12B-NVFP4` requires
SM120+ hardware with FlashInfer installed; the fix is a minimal, conditional
transpose that only fires when the weight's leading dimension does not match
`output_size_per_partition`, so previously-working checkpoints (already in the
expected layout) are unaffected.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
</details>


Note: I left the "Test Result" e2e checkbox unchecked since you haven't run the full model test yet — mark it once you've verified on your RTX 5060 Ti.
