### PR TITLE
[Bugfix] Fix NVFP4 shape mismatch in flashinfer_scaled_fp4_mm #50557

### DIFF
--- a/tests/models/inkling/test_moe_weight_layout.py
+++ b/tests/models/inkling/test_moe_weight_layout.py
@@ -112,6 +112,44 @@ def test_inkling_mapper_maps_modelopt_exclusions() -> None:
     assert not quant_config.is_layer_excluded("model.layers.3.mlp.experts")
 
 
+def test_gemma4_mapper_maps_modelopt_exclusions() -> None:
+    """NVFP4 exclude_modules written in checkpoint naming (``model.language_model.*``)
+    must map onto the vLLM module paths of both Gemma4 model classes. Regression:
+    a hand-rolled prefix translation stripped ``model.`` before the mapper ran,
+    breaking model-aware rules like Inkling's ``model.llm.*``."""
+
+    def map_exclusions(mapper) -> ModelOptNvFp4Config:
+        quant_config = ModelOptNvFp4Config.from_config(
+            {
+                "quantization": {
+                    "quant_algo": "NVFP4",
+                    "group_size": 16,
+                    "kv_cache_quant_algo": None,
+                    "exclude_modules": [
+                        "model.language_model.layers.0.self_attn.qkv_proj",
+                    ],
+                }
+            }
+        )
+        quant_config.apply_vllm_mapper(mapper.get_unstacked_mapper())
+        return quant_config
+
+    from vllm.model_executor.models.gemma4 import Gemma4ForCausalLM
+    from vllm.model_executor.models.gemma4_mm import Gemma4ForConditionalGeneration
+
+    causal_lm = map_exclusions(Gemma4ForCausalLM.hf_to_vllm_mapper)
+    assert causal_lm.is_layer_excluded("model.layers.0.self_attn.qkv_proj")
+    assert not causal_lm.is_layer_excluded("model.layers.1.self_attn.qkv_proj")
+
+    conditional = map_exclusions(Gemma4ForConditionalGeneration.hf_to_vllm_mapper)
+    assert conditional.is_layer_excluded(
+        "language_model.model.layers.0.self_attn.qkv_proj"
+    )
+    assert not conditional.is_layer_excluded(
+        "language_model.model.layers.1.self_attn.qkv_proj"
+    )
+
+
 @pytest.mark.parametrize("projection", ["w13", "w2"])
 @pytest.mark.parametrize("nested", [False, True])
 @pytest.mark.parametrize(

--- a/tests/models/inkling/test_moe_weight_layout.py
+++ b/tests/models/inkling/test_moe_weight_layout.py
@@ -89,6 +89,7 @@ def test_custom_embedding_is_not_a_lora_target() -> None:
 
 
 def test_inkling_mapper_maps_modelopt_exclusions() -> None:
+    """Inkling NVFP4 exclude_modules must map onto vLLM module paths."""
     quant_config = ModelOptNvFp4Config.from_config(
         {
             "quantization": {
@@ -110,6 +111,45 @@ def test_inkling_mapper_maps_modelopt_exclusions() -> None:
     assert quant_config.is_layer_excluded("model.layers.2.mlp.experts")
     assert quant_config.is_layer_excluded("model.layers.2.mlp.shared_experts")
     assert not quant_config.is_layer_excluded("model.layers.3.mlp.experts")
+
+
+def test_gemma4_mapper_maps_modelopt_exclusions() -> None:
+    """NVFP4 exclude_modules written in checkpoint naming (``model.language_model.*``)
+    must map onto the vLLM module paths of both Gemma4 model classes. Regression:
+    a hand-rolled prefix translation stripped ``model.`` before the mapper ran,
+    breaking model-aware rules like Inkling's ``model.llm.*``."""
+
+    def map_exclusions(mapper) -> ModelOptNvFp4Config:
+        """Build the NVFP4 config with mapped exclude_modules for a mapper."""
+        quant_config = ModelOptNvFp4Config.from_config(
+            {
+                "quantization": {
+                    "quant_algo": "NVFP4",
+                    "group_size": 16,
+                    "kv_cache_quant_algo": None,
+                    "exclude_modules": [
+                        "model.language_model.layers.0.self_attn.qkv_proj",
+                    ],
+                }
+            }
+        )
+        quant_config.apply_vllm_mapper(mapper.get_rename_mapper())
+        return quant_config
+
+    from vllm.model_executor.models.gemma4 import Gemma4ForCausalLM
+    from vllm.model_executor.models.gemma4_mm import Gemma4ForConditionalGeneration
+
+    causal_lm = map_exclusions(Gemma4ForCausalLM.hf_to_vllm_mapper)
+    assert causal_lm.is_layer_excluded("model.layers.0.self_attn.qkv_proj")
+    assert not causal_lm.is_layer_excluded("model.layers.1.self_attn.qkv_proj")
+
+    conditional = map_exclusions(Gemma4ForConditionalGeneration.hf_to_vllm_mapper)
+    assert conditional.is_layer_excluded(
+        "language_model.model.layers.0.self_attn.qkv_proj"
+    )
+    assert not conditional.is_layer_excluded(
+        "language_model.model.layers.1.self_attn.qkv_proj"
+    )
 
 
 @pytest.mark.parametrize("projection", ["w13", "w2"])

--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -27,6 +27,7 @@ from vllm.model_executor.layers.quantization.modelopt import (
     ModelOptNvFp4Config,
     ModelOptNvFp4LinearMethod,
     ModelOptNvFp4W4A16LinearMethod,
+    _wrap_weight_loader_for_transpose,
 )
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
@@ -97,6 +98,48 @@ def _mixed_precision_config(quantized_layers: dict) -> ModelOptMixedPrecisionCon
             exclude_modules=[],
         ),
     )
+
+
+def _recording_loader(loaded_weights: list) -> Any:
+    def loader(param, loaded_weight, *args, **kwargs):
+        loaded_weights.append(loaded_weight)
+
+    return loader
+
+
+@pytest.mark.parametrize(
+    ("param_shape", "loaded_shape", "packed_input_dim", "expected_shape"),
+    [
+        # Correctly oriented fused gate_up shard: (out_partition, packed_in).
+        # Regression: gate_up shard [15360, 1920] was falsely transposed at TP=1.
+        ((30720, 1920), (15360, 1920), 1920, (15360, 1920)),
+        # Misoriented checkpoint: (packed_in, out_partition).
+        ((30720, 1920), (1920, 15360), 1920, (15360, 1920)),
+        # 2D per-block weight scale in expected orientation.
+        ((15360, 240), (15360, 240), 240, (15360, 240)),
+        # 2D per-block weight scale, misoriented.
+        ((15360, 240), (240, 15360), 240, (15360, 240)),
+        # TP>1: global column weight vs TP-sharded param dim-0.
+        ((1920, 1920), (3840, 1920), 1920, (3840, 1920)),
+    ],
+)
+def test_modelopt_nvfp4_transpose_wrapper(
+    param_shape, loaded_shape, packed_input_dim, expected_shape
+):
+    """The transpose wrapper must key off the expected checkpoint dims, not
+    loaded-vs-param dim-0 equality (which corrupts fused shards and TP>1)."""
+    loaded_weights: list[Any] = []
+    wrapped = _wrap_weight_loader_for_transpose(
+        _recording_loader(loaded_weights), packed_input_dim
+    )
+
+    loaded = torch.empty(*loaded_shape)
+    wrapped(torch.empty(*param_shape), loaded)
+
+    assert len(loaded_weights) == 1
+    assert loaded_weights[0].shape == expected_shape
+    if loaded_shape == expected_shape:
+        assert loaded_weights[0] is loaded
 
 
 def test_modelopt_nvfp4_quantizes_parallel_lm_head():

--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -159,6 +159,44 @@ def test_modelopt_nvfp4_transpose_wrapper(
         assert loaded_weights[0] is loaded
 
 
+def test_modelopt_nvfp4_transpose_guard_uses_global_input_for_row_parallel():
+    """For a row-parallel (input-parallel) NVFP4 layer at TP>1 the input dim is
+    sharded, but a transposed checkpoint stores the full packed input width.
+    The transpose guard must key off the global input size, not the local
+    partition width, or the wrapper misses the transpose and the loader later
+    fails shape validation while sharding."""
+    from vllm.model_executor.layers.quantization.modelopt import (
+        WEIGHT,
+        CkptCtx,
+        KNvfp4Static,
+        Shapes,
+    )
+
+    scheme = KNvfp4Static()
+    # Row-parallel layer at TP=2: global input 4096, partition 2048, output 1536.
+    shapes = Shapes([1536], 2048, torch.bfloat16, input_size=4096)
+
+    loaded_weights: list[Any] = []
+    layer = torch.nn.Module()
+
+    def recording_loader(param, loaded_weight, *args, **kwargs):
+        loaded_weights.append(loaded_weight)
+
+    scheme.create_weights(
+        layer, WEIGHT, CkptCtx(group_size=16), shapes, recording_loader
+    )
+
+    # Transposed checkpoint weight: (packed_in=global//2=2048, out=1536).
+    loaded_weight = torch.empty(2048, 1536)
+    layer.weight.weight_loader(layer.weight, loaded_weight)
+    assert loaded_weights[-1].shape == (1536, 2048)
+
+    # Transposed per-block scale: (packed_in//group=256, out=1536).
+    loaded_scale = torch.empty(256, 1536)
+    layer.weight_scale.weight_loader(layer.weight_scale, loaded_scale)
+    assert loaded_weights[-1].shape == (1536, 256)
+
+
 def test_modelopt_nvfp4_quantizes_parallel_lm_head():
     config = ModelOptNvFp4Config(
         is_checkpoint_nvfp4_serialized=True,

--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -33,6 +33,7 @@ from vllm.model_executor.layers.quantization.modelopt import (
     ModelOptMixedPrecisionConfig,
     ModelOptMxFp8Config,
     ModelOptNvFp4Config,
+    _wrap_weight_loader_for_transpose,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8StaticTensorSym,
@@ -83,6 +84,7 @@ def _mock_lm_head() -> Mock:
 
 
 def _mixed_precision_config(quantized_layers: dict) -> ModelOptMixedPrecisionConfig:
+    """Build a ModelOptMixedPrecisionConfig covering every linear algo."""
     return ModelOptMixedPrecisionConfig(
         kv_cache_quant_method=None,
         exclude_modules=[],
@@ -110,6 +112,51 @@ def _mixed_precision_config(quantized_layers: dict) -> ModelOptMixedPrecisionCon
             exclude_modules=[],
         ),
     )
+
+
+def _recording_loader(loaded_weights: list) -> Any:
+    """Return a loader that records every loaded weight into a list."""
+
+    def loader(param, loaded_weight, *args, **kwargs):
+        """Record the loaded weight then forward to the original loader."""
+        loaded_weights.append(loaded_weight)
+
+    return loader
+
+
+@pytest.mark.parametrize(
+    ("param_shape", "loaded_shape", "packed_input_dim", "expected_shape"),
+    [
+        # Correctly oriented fused gate_up shard: (out_partition, packed_in).
+        # Regression: gate_up shard [15360, 1920] was falsely transposed at TP=1.
+        ((30720, 1920), (15360, 1920), 1920, (15360, 1920)),
+        # Misoriented checkpoint: (packed_in, out_partition).
+        ((30720, 1920), (1920, 15360), 1920, (15360, 1920)),
+        # 2D per-block weight scale in expected orientation.
+        ((15360, 240), (15360, 240), 240, (15360, 240)),
+        # 2D per-block weight scale, misoriented.
+        ((15360, 240), (240, 15360), 240, (15360, 240)),
+        # TP>1: global column weight vs TP-sharded param dim-0.
+        ((1920, 1920), (3840, 1920), 1920, (3840, 1920)),
+    ],
+)
+def test_modelopt_nvfp4_transpose_wrapper(
+    param_shape, loaded_shape, packed_input_dim, expected_shape
+):
+    """The transpose wrapper must key off the expected checkpoint dims, not
+    loaded-vs-param dim-0 equality (which corrupts fused shards and TP>1)."""
+    loaded_weights: list[Any] = []
+    wrapped = _wrap_weight_loader_for_transpose(
+        _recording_loader(loaded_weights), packed_input_dim
+    )
+
+    loaded = torch.empty(*loaded_shape)
+    wrapped(torch.empty(*param_shape), loaded)
+
+    assert len(loaded_weights) == 1
+    assert loaded_weights[0].shape == expected_shape
+    if loaded_shape == expected_shape:
+        assert loaded_weights[0] is loaded
 
 
 def test_modelopt_nvfp4_quantizes_parallel_lm_head():

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -97,6 +97,34 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
+
+def _wrap_weight_loader_for_transpose(weight_loader, packed_input_dim):
+    """Wrap weight_loader to handle transposed NVFP4 checkpoints.
+
+    Some NVFP4 checkpoints store weights as (packed_in_features, out_features)
+    instead of the expected (out_features, packed_in_features). This wrapper
+    detects the mismatch against the expected checkpoint dimensions and
+    transposes before the original loader runs, preventing shape validation
+    failures during TP sharding.
+
+    Args:
+        weight_loader: The original weight loader to wrap.
+        packed_input_dim: Expected checkpoint dim of the input dimension,
+            i.e. the packed width of the layer this parameter belongs to.
+    """
+
+    def wrapped(param, loaded_weight, *args, **kwargs):
+        if (
+            loaded_weight.ndim == 2
+            and loaded_weight.shape[0] == packed_input_dim
+            and loaded_weight.shape[1] != packed_input_dim
+        ):
+            loaded_weight = loaded_weight.t()
+        return weight_loader(param, loaded_weight, *args, **kwargs)
+
+    return wrapped
+
+
 QUANT_ALGOS = [
     # FP8 (per-tensor weight + optional static activation scale).
     "FP8",
@@ -1133,6 +1161,8 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
         params_dtype: torch.dtype,
         **extra_weight_attrs,
     ):
+        packed_input_dim = input_size // 2
+        packed_scale_input_dim = input_size // self.quant_config.group_size
         del input_size, output_size
         if not self.quant_config.is_checkpoint_nvfp4_serialized:
             raise ValueError(
@@ -1165,7 +1195,9 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
             ),
             input_dim=1,
             output_dim=0,
-            weight_loader=weight_loader,
+            weight_loader=_wrap_weight_loader_for_transpose(
+                weight_loader, packed_input_dim
+            ),
         )
         layer.register_parameter("weight", weight)
 
@@ -1192,7 +1224,9 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
             ),
             input_dim=1,
             output_dim=0,
-            weight_loader=weight_loader,
+            weight_loader=_wrap_weight_loader_for_transpose(
+                weight_loader, packed_scale_input_dim
+            ),
         )
 
         layer.register_parameter("weight_scale", weight_scale)
@@ -1282,6 +1316,8 @@ class ModelOptNvFp4W4A16LinearMethod(LinearMethodBase):
         params_dtype: torch.dtype,
         **extra_weight_attrs,
     ):
+        packed_input_dim = input_size // 2
+        packed_scale_input_dim = input_size // self.quant_config.group_size
         del input_size, output_size
         if not self.quant_config.is_checkpoint_nvfp4_serialized:
             raise ValueError(
@@ -1309,7 +1345,9 @@ class ModelOptNvFp4W4A16LinearMethod(LinearMethodBase):
             ),
             input_dim=1,
             output_dim=0,
-            weight_loader=weight_loader,
+            weight_loader=_wrap_weight_loader_for_transpose(
+                weight_loader, packed_input_dim
+            ),
         )
         layer.register_parameter("weight", weight)
 
@@ -1331,7 +1369,9 @@ class ModelOptNvFp4W4A16LinearMethod(LinearMethodBase):
             ),
             input_dim=1,
             output_dim=0,
-            weight_loader=weight_loader,
+            weight_loader=_wrap_weight_loader_for_transpose(
+                weight_loader, packed_scale_input_dim
+            ),
         )
         layer.register_parameter("weight_scale", weight_scale)
 

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -1842,6 +1842,7 @@ class Shapes:
     output_partition_sizes: list[int]
     input_size_per_partition: int
     params_dtype: torch.dtype
+    input_size: int = 0
 
     @property
     def output_size_per_partition(self) -> int:
@@ -1900,12 +1901,15 @@ class KNvfp4Static(QuantKeyScheme):
             raise ValueError(
                 "Unsupported model when in features size is not multiple of 16"
             )
-        # Input dim is not TP-sharded for these column-parallel params, so
-        # input_size_per_partition is the full packed checkpoint dim. Some
-        # checkpoints store the NVFP4 weights/scales transposed as
+        # The input dim is not TP-sharded for column-parallel params, but IS
+        # sharded for row-parallel (input-parallel) layers. A transposed
+        # checkpoint stores the full packed input width regardless of TP
+        # sharding, so key the transpose guard off the global input size.
+        # Some checkpoints store the NVFP4 weights/scales transposed as
         # (packed_in, out); wrap the loader to transpose those back.
-        packed_input_dim = shapes.input_size_per_partition // 2
-        packed_scale_input_dim = shapes.input_size_per_partition // ctx.group_size
+        global_input_size = shapes.input_size or shapes.input_size_per_partition
+        packed_input_dim = global_input_size // 2
+        packed_scale_input_dim = global_input_size // ctx.group_size
         weight_loader = _wrap_weight_loader_for_transpose(wl, packed_input_dim)
         weight_scale_loader = _wrap_weight_loader_for_transpose(
             wl, packed_scale_input_dim
@@ -2442,7 +2446,7 @@ class ModelOptLinearMethod(LinearMethodBase):
         params_dtype: torch.dtype,
         **extra_weight_attrs,
     ) -> None:
-        del input_size, output_size
+        del output_size
         weight_loader = extra_weight_attrs.get("weight_loader")
         layer.logical_widths = output_partition_sizes
         layer.input_size_per_partition = input_size_per_partition
@@ -2453,7 +2457,9 @@ class ModelOptLinearMethod(LinearMethodBase):
         layer.output_partition_sizes = output_partition_sizes
         if not hasattr(layer, "has_bias"):
             layer.has_bias = getattr(layer, "bias", None) is not None
-        shapes = Shapes(output_partition_sizes, input_size_per_partition, params_dtype)
+        shapes = Shapes(
+            output_partition_sizes, input_size_per_partition, params_dtype, input_size
+        )
 
         self.wkey.create_weights(layer, WEIGHT, self.ctx, shapes, weight_loader)
         if self.akey:

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -141,6 +141,34 @@ def algos_owned_by(config_name: str) -> tuple[str, ...]:
     return tuple(a for a, (owner, _) in LINEAR_ALGOS.items() if owner == config_name)
 
 
+def _wrap_weight_loader_for_transpose(weight_loader, packed_input_dim):
+    """Wrap weight_loader to handle transposed NVFP4 checkpoints.
+
+    Some NVFP4 checkpoints store weights as (packed_in_features, out_features)
+    instead of the expected (out_features, packed_in_features). This wrapper
+    detects the mismatch against the expected checkpoint dimensions and
+    transposes before the original loader runs, preventing shape validation
+    failures during TP sharding.
+
+    Args:
+        weight_loader: The original weight loader to wrap.
+        packed_input_dim: Expected checkpoint dim of the input dimension,
+            i.e. the packed width of the layer this parameter belongs to.
+    """
+
+    def wrapped(param, loaded_weight, *args, **kwargs):
+        """Transpose the loaded weight when it is in checkpoint (packed_in, out)."""
+        if (
+            loaded_weight.ndim == 2
+            and loaded_weight.shape[0] == packed_input_dim
+            and loaded_weight.shape[1] != packed_input_dim
+        ):
+            loaded_weight = loaded_weight.t()
+        return weight_loader(param, loaded_weight, *args, **kwargs)
+
+    return wrapped
+
+
 class ModelOptKVCacheMethod(BaseKVCacheMethod):
     """
     Supports loading kv-cache scaling factors from FP8 or NVFP4 checkpoints.
@@ -1861,12 +1889,27 @@ class KNvfp4Static(QuantKeyScheme):
     key = kNvfp4Static
 
     def create_weights(self, layer, role, ctx, shapes, wl) -> None:
+        """Register the packed NVFP4 weight and scale params.
+
+        The weight and per-block scale loaders are wrapped to transpose
+        checkpoints that store those tensors as (packed_in, out_features).
+        """
         if role is not WEIGHT:
             self.reject(role)
         if shapes.input_size_per_partition % 16 != 0:
             raise ValueError(
                 "Unsupported model when in features size is not multiple of 16"
             )
+        # Input dim is not TP-sharded for these column-parallel params, so
+        # input_size_per_partition is the full packed checkpoint dim. Some
+        # checkpoints store the NVFP4 weights/scales transposed as
+        # (packed_in, out); wrap the loader to transpose those back.
+        packed_input_dim = shapes.input_size_per_partition // 2
+        packed_scale_input_dim = shapes.input_size_per_partition // ctx.group_size
+        weight_loader = _wrap_weight_loader_for_transpose(wl, packed_input_dim)
+        weight_scale_loader = _wrap_weight_loader_for_transpose(
+            wl, packed_scale_input_dim
+        )
         # Packed NVFP4 weight: 2 fp4 items per byte along the input dim.
         self.register_params(
             layer,
@@ -1874,7 +1917,7 @@ class KNvfp4Static(QuantKeyScheme):
             (shapes.output_size_per_partition, shapes.input_size_per_partition // 2),
             torch.uint8,
             ModelWeightParameter,
-            wl,
+            weight_loader,
             input_dim=1,
             output_dim=0,
         )
@@ -1897,7 +1940,7 @@ class KNvfp4Static(QuantKeyScheme):
             ),
             torch.float8_e4m3fn,
             ModelWeightParameter,
-            wl,
+            weight_scale_loader,
             input_dim=1,
             output_dim=0,
         )


### PR DESCRIPTION
Fixes: #50577

Fixes shape mismatch assertion error when loading NVFP4 checkpoints that store weights in transposed format (in_features Fixes shape mismatch assertion error when loading NVFP4 checkpoints that store weights in transposed format (in_features // 2, out_features) instead of the expected (out_features, in_features // 2).

The fix adds conditional weight transpose in
ModelOptNvFp4LinearMethod.process_weights_after_loading(), matching the pattern used in FP8 methods. This resolves the assertion 'a.shape[1] == b.shape[1]' failure in flashinfer_scaled_fp4_mm for models like AxionML/Gemma-4-12B-NVFP4 on SM120+ hardware.

Fixes: #50577

## Purpose

Some NVFP4 checkpoints (e.g. AxionML/Gemma-4-12B-NVFP4) store weights in the
standard PyTorch layout `(in_features // 2, out_features)` rather than the
vLLM-expected `(out_features, in_features // 2)`. Unlike the FP8 linear methods
in `modelopt.py` (which transpose weights after loading), the NVFP4 method did
not perform this transpose, causing `flashinfer_scaled_fp4_mm` to hit the
assertion `a.shape[1] == b.shape[1]` during `profile_run()` on SM120+ hardware
(e.g. RTX 5060 Ti).

## Test Plan

Reproduce the original failure:

```bash
vllm serve AxionML/Gemma-4-12B-NVFP4 \
  --quantization modelopt \
  --max-model-len 8192 \
  --enforce-eager \
  --limit-mm-per-prompt '{"image": 0}' \
  --port 8000