### PR TITLE
[TPU] Exempt TPU from the V2 model runner PCP and Triton gates

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2140,12 +2140,22 @@ class VllmConfig:
 
     def _get_v2_model_runner_unsupported_features(self) -> list[str]:
         """Collect features not yet supported by the V2 model runner."""
+        from vllm.platforms import current_platform
+
         unsupported: list[str] = []
         model_config = self.model_config
         speculative_config = self.speculative_config
 
-        if self.parallel_config.prefill_context_parallel_size > 1 and not (
-            model_config is not None and model_config.use_mla
+        # TPU substitutes its own worker and model runner, so the V1/V2 model
+        # runners in this repo never execute there and PCP is implemented by
+        # the platform. Without this exemption a non-MLA model cannot be
+        # configured with PCP at all: use_v2_model_runner forces V2 when
+        # prefill_context_parallel_size > 1, and V2 then reports PCP as
+        # unsupported.
+        if (
+            self.parallel_config.prefill_context_parallel_size > 1
+            and not (model_config is not None and model_config.use_mla)
+            and not current_platform.is_tpu()
         ):
             unsupported.append("prefill context parallelism")
         if self.compilation_config.mode == CompilationMode.STOCK_TORCH_COMPILE:
@@ -2229,7 +2239,12 @@ class VllmConfig:
 
     def _validate_v2_model_runner(self) -> None:
         """Check for features not yet supported by the V2 model runner."""
-        if not HAS_TRITON:
+        from vllm.platforms import current_platform
+
+        # TPU never dispatches Triton kernels, and vllm disables Triton on TPU
+        # hosts (installed, but no active driver), so this requirement does not
+        # apply there.
+        if not HAS_TRITON and not current_platform.is_tpu():
             raise ValueError("Model Runner V2 requires Triton.")
 
         unsupported = self._get_v2_model_runner_unsupported_features()


### PR DESCRIPTION
## Problem

A non-MLA model cannot currently be configured with
`prefill_context_parallel_size > 1` on TPU, because two rules contradict each
other:

- `VllmConfig.use_v2_model_runner` forces the V2 model runner whenever
  `prefill_context_parallel_size > 1` — *"PCP runtime support is implemented
  only by the V2 model runner"*
- `_get_v2_model_runner_unsupported_features()` reports `"prefill context
  parallelism"` as **unsupported by V2** unless `model_config.use_mla`

so config validation raises:

```
ValueError: Model Runner V2 does not yet support: prefill context parallelism
```

`VLLM_USE_V2_MODEL_RUNNER=0` is rejected too (*"Prefill context parallelism
requires Model Runner V2. Remove VLLM_USE_V2_MODEL_RUNNER=0."*), so there is no
configuration-level way to run PCP on TPU.

## Why TPU is different

The TPU platform substitutes its own worker in `check_and_update_config`
(`parallel_config.worker_cls`), so the V1/V2 model runners in this repo never
execute there — PCP is implemented by the platform itself. The gate is a
config-validation artifact on that path.

## The Triton gate

`_validate_v2_model_runner` also hard-requires Triton. On the PCP path this is
a **hard error**, not the usual soft fallback: `use_v2_model_runner` returns
`True` at the PCP check *before* reaching the `if not HAS_TRITON: return False`
branch, so validation raises instead of falling back to V1. TPU never
dispatches Triton kernels, and vllm itself disables Triton on TPU hosts
(installed, but no active driver).

## Change

Exempt TPU from both gates. Every other V2 feature check is unchanged, and
non-TPU platforms are unaffected.

## Testing

v6e-8, `Qwen/Qwen3-8B-Base`, `--tensor-parallel-size=4
--prefill-context-parallel-size 2` via `examples/offline_inference.py`
(tpu-inference): configuration succeeds and generation is correct —

```
Prompt: 'The capital of France is'
Generated text: ' Paris. This is a well-known fact among most people.'
```

Without this change the same command fails at config time. Verified with no
downstream workaround in place.
