### PR TITLE
[WIP][Bugfix] Guard KeyError in update_from_output for PP>1

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -5730,3 +5730,59 @@ def test_hybrid_per_group_hit_divergence_fa_deeper_no_external():
     num_scheduled = output.num_scheduled_tokens[replay.request_id]
     # Must resume at the convergent boundary (block 0), not the deep FA hit.
     assert replay.num_tokens - num_scheduled == block_size
+
+
+def test_update_from_output_missing_req_id_no_crash():
+    """With PP>1, a request may be scheduled but absent from the model
+    runner output (e.g. preemption/abort race between scheduling and
+    execution).  The scheduler must not raise a KeyError and should
+    roll back num_computed_tokens so the request can be retried.
+
+    Regression test for https://github.com/vllm-project/vllm/issues/32701
+    """
+    scheduler = create_scheduler()
+
+    [req] = create_requests(num_requests=1, num_tokens=10)
+    scheduler.add_request(req)
+
+    num_computed_before = req.num_computed_tokens
+    scheduler_output = scheduler.schedule()
+    assert req.request_id in scheduler_output.num_scheduled_tokens
+
+    model_runner_output = ModelRunnerOutput(
+        req_ids=[],
+        req_id_to_index={},
+        sampled_token_ids=[],
+    )
+
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+
+    assert req.num_computed_tokens == num_computed_before
+    assert req.request_id in scheduler._pp_missing_count
+    assert scheduler._pp_missing_count[req.request_id] == 1
+
+
+def test_update_from_output_missing_req_id_force_terminate():
+    """After 3 consecutive misses from the model runner output, the
+    scheduler should force-terminate the request to prevent infinite retry.
+    """
+    scheduler = create_scheduler()
+
+    [req] = create_requests(num_requests=1, num_tokens=10)
+    scheduler.add_request(req)
+
+    for attempt in range(4):
+        scheduler_output = scheduler.schedule()
+        if req.request_id not in scheduler_output.num_scheduled_tokens:
+            break
+
+        model_runner_output = ModelRunnerOutput(
+            req_ids=[],
+            req_id_to_index={},
+            sampled_token_ids=[],
+        )
+
+        scheduler.update_from_output(scheduler_output, model_runner_output)
+
+    assert req.is_finished()
+    assert req.request_id not in scheduler._pp_missing_count

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -294,6 +294,7 @@ class Scheduler(SchedulerInterface):
             self.connector.bind_gpu_block_pool(self.kv_cache_manager.block_pool)
 
         self.use_pp = self.parallel_config.pipeline_parallel_size > 1
+        self._pp_missing_count: dict[str, int] = {}
         self.use_v2_model_runner = vllm_config.use_v2_model_runner
         # Scheduler iteration counter. Drives the V2+PP+async decode-throttle
         # cadence (`next_decode_eligible_step`).
@@ -1758,7 +1759,55 @@ class Scheduler(SchedulerInterface):
             if output_is_stale and request.drop_stale_output:
                 continue
 
-            req_index = model_runner_output.req_id_to_index[req_id]
+            req_index = model_runner_output.req_id_to_index.get(req_id)
+            if req_index is None:
+                miss_count = self._pp_missing_count.get(req_id, 0) + 1
+                self._pp_missing_count[req_id] = miss_count
+
+                if miss_count <= 3:
+                    request.num_computed_tokens -= num_tokens_scheduled
+                    logger.warning(
+                        "PP output missing req %s (attempt %d/3), "
+                        "rolling back num_computed_tokens",
+                        req_id, miss_count)
+                    continue
+
+                del self._pp_missing_count[req_id]
+                logger.warning(
+                    "PP output missing req %s after 3 retries, "
+                    "force-terminating request", req_id)
+                if request.has_encoder_inputs:
+                    self._free_encoder_inputs(request)
+                status_before_stop = request.status
+                request.status = RequestStatus.FINISHED_STOPPED
+                finish_reason = request.get_finished_reason()
+                finished = self._handle_stopped_request(request)
+                kv_transfer_params = None
+                ec_transfer_params = None
+                if finished:
+                    kv_transfer_params, ec_transfer_params = (
+                        self._free_request(request))
+                if status_before_stop == RequestStatus.RUNNING:
+                    stopped_running_reqs.add(request)
+                else:
+                    stopped_preempted_reqs.add(request)
+                outputs[request.client_index].append(
+                    EngineCoreOutput(
+                        request_id=req_id,
+                        new_token_ids=[],
+                        finish_reason=finish_reason,
+                        new_logprobs=None,
+                        new_prompt_logprobs_tensors=None,
+                        pooling_output=None,
+                        stop_reason=request.stop_reason,
+                        events=request.take_events(),
+                        kv_transfer_params=kv_transfer_params,
+                        ec_transfer_params=ec_transfer_params,
+                        trace_headers=request.trace_headers,
+                    )
+                )
+                continue
+            self._pp_missing_count.pop(req_id, None)
             generated_token_ids = (
                 sampled_token_ids[req_index] if sampled_token_ids else []
             )


### PR DESCRIPTION
## Summary

**Work in progress — not ready for review.**

When pipeline parallelism causes a request to be missing from `req_id_to_index` in `update_from_output`, the previous approach (`.get() + continue`) prevented the KeyError crash but left `num_computed_tokens` in an inconsistent state. This caused `_make_cached_request_data` to read past the end of `all_token_ids`, sending empty token slices to PP0 and permanently corrupting output.

This updated patch:
1. **Rolls back** `num_computed_tokens -= num_tokens_scheduled` on transient misses, so the request retries with correct token state on the next scheduler step
2. **Force-terminates** after 3 consecutive misses for the same request to prevent infinite retry loops
3. **Resets** the miss counter when a request is successfully found in output

### Root cause

`_update_after_schedule` optimistically advances `request.num_computed_tokens` before model execution. When the guard fires and skips the request, the generated token is never appended to `request._output_token_ids`. Now `num_computed_tokens > len(all_token_ids)`, and `_make_cached_request_data` produces empty slices permanently.

Fixes #32701

## Test plan

- [x] `test_update_from_output_missing_req_id_no_crash` — verifies `num_computed_tokens` rollback and `_pp_missing_count` tracking
- [x] `test_update_from_output_missing_req_id_force_terminate` — verifies retry-then-terminate path after 3 consecutive misses
- [ ] End-to-end validation with PP=2 deployment (in progress)