### PR TITLE
[Bugfix] Drop the -1 dcp_world_size sentinel in MLACommonImpl

### DIFF
--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -22,6 +22,7 @@ from tests.v1.attention.utils import (
 )
 from vllm import _custom_ops as ops
 from vllm.config.vllm import set_current_vllm_config
+from vllm.distributed.parallel_state import get_dcp_group
 from vllm.model_executor.layers.attention import mla_attention as mla_attention_module
 from vllm.model_executor.layers.attention.mla_attention import (
     MLAAttention,
@@ -44,6 +45,7 @@ from vllm.v1.attention.backends.mla.prefill.base import MLADimensions
 from vllm.v1.attention.backends.mla.prefill.selector import (
     MLAPrefillSelectorConfig,
 )
+from vllm.v1.attention.backends.mla.triton_mla import TritonMLAImpl
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.attention.ops.flashmla import is_flashmla_dense_supported
 from vllm.v1.kv_cache_interface import (
@@ -151,6 +153,36 @@ def test_mla_post_load_preserves_runtime_weight_addresses(monkeypatch):
     assert layer.W_UK_T.data_ptr() == w_uk_t_ptr
     torch.testing.assert_close(layer.W_UV, old_w_uv + 100)
     torch.testing.assert_close(layer.W_UK_T, old_w_uk_t + 100)
+
+
+def test_mla_impl_reports_dcp_world_size_at_construction(dist_init):
+    """Models that drive the impl directly (e.g. Kimi-K3's
+    MultiHeadLatentAttention) never go through MLAAttention.forward_impl, so every
+    MLACommonImpl must report a usable CP world size as soon as it is built:
+    FLASH_ATTN_MLA passes it to FA3 as `cp_world_size`, which rejects
+    non-positive values.
+    """
+    impl = TritonMLAImpl(
+        num_heads=16,
+        head_size=576,
+        scale=1.0,
+        num_kv_heads=1,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype="auto",
+        logits_soft_cap=None,
+        attn_type="decoder",
+        kv_sharing_target_layer_name=None,
+        q_lora_rank=None,
+        kv_lora_rank=512,
+        qk_nope_head_dim=128,
+        qk_rope_head_dim=64,
+        qk_head_dim=192,
+        v_head_dim=128,
+        kv_b_proj=None,
+    )
+
+    assert impl.dcp_world_size == get_dcp_group().world_size
 
 
 # Validate parameter combinations during collection, before GPU fixtures run.
@@ -1078,11 +1110,6 @@ def run_attention_backend(
         # Process weights on the impl
         act_dtype = _convert_dtype_to_torch(vllm_config.model_config.dtype)
         impl.process_weights_after_loading(act_dtype)
-
-        # Initialize DCP attributes (normally set by MLAAttention.forward
-        # before calling forward_mha, see mla_attention.py:511-512)
-        if impl.dcp_world_size == -1:
-            impl.dcp_world_size = 1
 
         # Create mock MLA layer
         mock_layer = MockMLAAttentionLayer(

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -740,9 +740,6 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 return quant_output.fill_(0)
             return output.fill_(0)
 
-        if self.impl.dcp_world_size == -1:
-            self.impl.dcp_world_size = get_dcp_group().world_size
-
         fp8_attention = is_quantized_kv_cache(self.kv_cache_dtype)
 
         num_actual_toks = attn_metadata.num_actual_tokens
@@ -2531,7 +2528,6 @@ class MLACommonBaseImpl(MLAAttentionImpl[A], Generic[A]):
         output_scale: torch.Tensor | None = None,
     ) -> None:
         assert attn_metadata.prefill is not None
-        assert self.dcp_world_size != -1
 
         prefill_metadata = attn_metadata.prefill
         assert prefill_metadata.prefill_backend is not None
@@ -2676,8 +2672,6 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
             and (self.qk_nope_head_dim == 128)
             and (self.qk_rope_head_dim == 64)
         )
-
-        self.dcp_world_size: int = -1
 
         self.cp_kv_cache_interleave_size: int = (
             get_current_vllm_config().parallel_config.cp_kv_cache_interleave_size


### PR DESCRIPTION
Fixes #50446

`MLACommonImpl.__init__` overwrote the `dcp_world_size` that
`AttentionImplBase.__new__` had already read from the DCP group with a `-1`
sentinel, and left `MLAAttention.forward_impl` to repair it on the first forward.
Kimi-K3's `MultiHeadLatentAttention` is a plain `nn.Module` that calls
`self.impl.forward_mqa()` directly, so that repair never runs and
`FlashAttnMLAImpl.forward_mqa` passes `cp_world_size=-1` to FA3, which rejects it
with "cp_world_size must be positive, required by downstream unified code path."

The sentinel was the odd one out. `dcp_rank`, passed to the same FA3 call one line
later, has always come from `__new__`. The sparse base `MLACommonBaseImpl` never
set `-1`, so the sparse impls that DeepSeek-V3.2/V4 drive directly have always used
`__new__`'s value. So this deletes the sentinel and the two sites that only existed
to service it: the lazy repair in `MLAAttention.forward_impl` and
`assert self.dcp_world_size != -1` in `forward_mha`. `__new__` sets both
`dcp_world_size` and `dcp_rank` from `get_dcp_group()`, falling back to 1 and 0 when
no group is initialized.

New test: `test_mla_impl_reports_dcp_world_size_at_construction` asserts a dense MLA
impl reports the DCP group's world size right after construction. It fails with
`assert -1 == 1` on main. Also drops the workaround in `run_attention_backend` that
rewrote `-1` to `1`, which was this same bug papered over in the test suite.

## Overlap with #50404

#50404 fixes the same crash in the Kimi-K3 wrapper: after building the impl it
rewrites `dcp_world_size` to 1 and `dcp_rank` to 0 when the value is below 1. Same
diagnosis, different layer. Its author validated K3 end to end on 8x H200, which
corroborates the diagnosis. This one removes the sentinel instead, so no caller has
to normalize it and the next model that drives an impl directly does not hit the
same trap. Pick one. If #50404 lands first, the remainder here is the sentinel
cleanup plus the test.

## Testing

Verified on 8x A40 (sm_86), driver 560.35.03, CUDA 12.6, torch 2.13.0+cu129:

- New test fails before the change (`assert -1 == 1`), passes after.
- A standalone repro that calls `forward_mqa` the way K3's layer does, with the FA3
  kernel stubbed to capture its kwargs, shows `cp_world_size` going from -1 to 1.
- `tests/v1/attention/test_mla_backends.py -k "not backend_correctness"`: 8 passed.
  `test_mla_noncausal`, `test_sparse_mla_backends`, `test_mla_prefill_registry`,
  `test_mla_prefill_selector`, `test_mla_prefill_quant_output`,
  `test_dspark_noncausal_sparse_mla`: 70 passed, 547 skipped.
- `test_backend_correctness` fails identically before and after on this box
  (TRITON_MLA vs SDPA, max diff 0.785156); pre-existing, checked against a clean
  tree.
- pre-commit on both changed files: all hooks pass.

Not verified, since sm_86 has no FA3 and K3 does not fit here: the FA3 `TORCH_CHECK`
firing for real, a Kimi-K3 run end to end, and any `--decode-context-parallel-size >
1` configuration. All checks ran with a single-rank DCP group.

Also worth a second opinion: nothing on this path depends on pipeline parallelism,
so the patch should fix K3 with plain TP too. The linked HF report suggests the
TP-only runs there died during weight loading before ever reaching CUDA graph
capture, which would explain why PP is what people noticed, but I could not confirm
that and cannot rule out a separate PP-specific problem behind the same symptom.

Thanks to @conceptofmind for the report.

AI assistance was used to write this patch.