### PR TITLE
[Kernel] Move Marlin lock storage to WorkspaceManager

### DIFF
--- a/tests/model_executor/model_loader/test_reload.py
+++ b/tests/model_executor/model_loader/test_reload.py
@@ -250,10 +250,9 @@ def _random_g_idx(generator):
     )
 
 
-def test_marlin_post_load_preserves_runtime_tensor_addresses(monkeypatch, dist_init):
-    """Marlin workspace and act-order sort indices must be recomputed into
-    the same storage when weights are reloaded (RL weight sync), so device
-    addresses captured by CUDA graphs remain valid."""
+def test_marlin_post_load_preserves_sort_indices_address(monkeypatch, dist_init):
+    """Act-order sort indices must be recomputed into the same storage when
+    weights are reloaded so CUDA graphs keep a valid device address."""
     from vllm.model_executor.layers.quantization.utils import marlin_utils
 
     _stub_marlin_ops(monkeypatch)
@@ -267,15 +266,12 @@ def test_marlin_post_load_preserves_runtime_tensor_addresses(monkeypatch, dist_i
     _load_marlin_checkpoint_format_weights(layer, first_g_idx)
     kernel.process_weights_after_loading(layer)
 
-    workspace_ptr = kernel.workspace.data_ptr()
     sort_indices_ptr = layer.g_idx_sort_indices.data_ptr()
 
     # Reload: fresh checkpoint-format tensors with a different act-order
     _load_marlin_checkpoint_format_weights(layer, second_g_idx)
     kernel.process_weights_after_loading(layer)
 
-    assert kernel.workspace.data_ptr() == workspace_ptr
-    assert torch.all(kernel.workspace == 0)
     assert layer.g_idx_sort_indices.data_ptr() == sort_indices_ptr
     expected_sort_indices = marlin_utils.marlin_sort_g_idx(second_g_idx)[1]
     assert torch.equal(layer.g_idx_sort_indices.data, expected_sort_indices)
@@ -284,19 +280,16 @@ def test_marlin_post_load_preserves_runtime_tensor_addresses(monkeypatch, dist_i
 
 
 @pytest.mark.parametrize("variant", ["fp8", "mxfp8", "nvfp4"])
-def test_marlin_prepare_layer_preserves_workspace_address(monkeypatch, variant):
-    """The Marlin fallback prepare_* functions rerun on weight reload and must
-    reuse the workspace storage whose address captured CUDA graphs hold."""
+def test_marlin_prepare_layer_does_not_own_workspace(monkeypatch, variant):
+    """Weight preparation must not attach runtime workspace to model layers."""
     from vllm import _custom_ops as ops
     from vllm.model_executor.layers.quantization.utils import (
-        marlin_utils,
         marlin_utils_fp4,
         marlin_utils_fp8,
     )
 
     size_k, size_n = 128, 64
 
-    monkeypatch.setattr(marlin_utils, "num_compute_units", lambda _: 4)
     monkeypatch.setattr(
         ops,
         "gptq_marlin_repack",
@@ -352,34 +345,43 @@ def test_marlin_prepare_layer_preserves_workspace_address(monkeypatch, variant):
 
     load_checkpoint_format_weights()
     prepare(layer)
-    workspace_ptr = layer.workspace.data_ptr()
+    assert not hasattr(layer, "workspace")
 
     # Reload: fresh checkpoint-format tensors, prepare runs again
     load_checkpoint_format_weights()
     prepare(layer)
-
-    assert layer.workspace.data_ptr() == workspace_ptr
-    assert torch.all(layer.workspace == 0)
+    assert not hasattr(layer, "workspace")
 
 
-def test_marlin_make_workspace_new_rejects_incompatible_existing(monkeypatch):
-    """An incompatible existing workspace means the address captured by CUDA
-    graphs is already unusable; allocating a replacement would hide that."""
+def test_marlin_workspace_uses_persistent_workspace_manager(monkeypatch):
+    """Marlin borrows maximum-sized graph-stable storage from the manager."""
     from vllm.model_executor.layers.quantization.utils import marlin_utils
+    from vllm.utils import torch_utils
+    from vllm.v1.worker import workspace as workspace_module
 
     monkeypatch.setattr(marlin_utils, "num_compute_units", lambda _: 4)
     device = torch.device("cpu")
+    manager = workspace_module.WorkspaceManager(device)
+    monkeypatch.setattr(
+        workspace_module, "is_workspace_manager_initialized", lambda: True
+    )
+    monkeypatch.setattr(workspace_module, "current_workspace_manager", lambda: manager)
+    stream = "main"
+    monkeypatch.setattr(torch_utils, "current_stream", lambda: stream)
 
-    workspace = marlin_utils.marlin_make_workspace_new(device)
-    reused = marlin_utils.marlin_make_workspace_new(device, existing=workspace)
-    assert reused is workspace
+    workspace = marlin_utils.get_marlin_workspace(device)
+    assert workspace.shape == (4 * marlin_utils.MARLIN_MAX_BLOCKS_PER_SM,)
+    assert workspace.dtype == torch.int32
+    assert torch.count_nonzero(workspace) == 0
 
-    with pytest.raises(ValueError, match="incompatible"):
-        marlin_utils.marlin_make_workspace_new(device, 4, existing=workspace)
-    with pytest.raises(ValueError, match="incompatible"):
-        marlin_utils.marlin_make_workspace_new(
-            device, existing=workspace.to(torch.int64)
-        )
+    workspace.fill_(1)
+    assert marlin_utils.get_marlin_workspace(device) is workspace
+    assert torch.all(workspace == 1)
+
+    stream = "aux"
+    aux_workspace = marlin_utils.get_marlin_workspace(device)
+    assert aux_workspace is not workspace
+    assert torch.count_nonzero(aux_workspace) == 0
 
 
 def test_marlin_act_order_layerwise_reload_accounting(monkeypatch, dist_init):

--- a/tests/v1/worker/test_workspace.py
+++ b/tests/v1/worker/test_workspace.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.v1.worker import workspace as workspace_module
+
+
+def test_persistent_workspace_is_stable_and_isolated(monkeypatch):
+    ubatch_id = 0
+    monkeypatch.setattr(workspace_module, "dbo_current_ubatch_id", lambda: ubatch_id)
+    manager = workspace_module.WorkspaceManager(torch.device("cpu"), num_ubatches=2)
+
+    key = ("locks", "main")
+    first = manager.get_persistent(key, (8,), torch.int32, zero_init=True)
+    assert torch.count_nonzero(first) == 0
+    first.fill_(1)
+    assert manager.get_persistent(key, (8,), torch.int32) is first
+
+    manager.get_simultaneous(((1024,), torch.uint8))
+    assert manager.get_persistent(key, (8,), torch.int32) is first
+
+    other = manager.get_persistent(("locks", "aux"), (8,), torch.int32)
+    assert other is not first
+
+    ubatch_id = 1
+    second = manager.get_persistent(key, (8,), torch.int32, zero_init=True)
+    assert second is not first
+    assert torch.count_nonzero(second) == 0
+
+
+def test_persistent_workspace_rejects_changes_after_allocation():
+    manager = workspace_module.WorkspaceManager(torch.device("cpu"))
+    workspace = manager.get_persistent("locks", (8,), torch.int32)
+
+    with pytest.raises(ValueError, match="requested shape"):
+        manager.get_persistent("locks", (16,), torch.int32)
+    with pytest.raises(ValueError, match="requested shape"):
+        manager.get_persistent("locks", (8,), torch.int64)
+
+    manager.lock()
+    assert manager.get_persistent("locks", (8,), torch.int32) is workspace
+    with pytest.raises(AssertionError, match="was not allocated during warmup"):
+        manager.get_persistent("new", (8,), torch.int32)

--- a/vllm/model_executor/kernels/linear/mixed_precision/marlin.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/marlin.py
@@ -9,10 +9,10 @@ from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     MARLIN_SUPPORTED_GROUP_SIZES,
     apply_gptq_marlin_linear,
     check_marlin_supports_shape,
+    get_marlin_workspace,
     marlin_act_int8_process_scales,
     marlin_is_k_full,
     marlin_make_empty_g_idx,
-    marlin_make_workspace_new,
     marlin_pad_dim,
     marlin_pad_qweight,
     marlin_pad_scales,
@@ -111,11 +111,6 @@ class MarlinLinearKernel(MPLinearKernel):
             padded_n, padded_k = size_n, size_k
         else:
             padded_n, padded_k = marlin_padded_nk(size_n, size_k, c.group_size)
-
-        # Allocate marlin workspace, reusing existing storage on reload.
-        self.workspace = marlin_make_workspace_new(
-            device, existing=getattr(self, "workspace", None)
-        )
 
         # Default names since marlin requires empty parameters for these,
         # TODO: remove this requirement from marlin (allow optional tensors)
@@ -239,7 +234,7 @@ class MarlinLinearKernel(MPLinearKernel):
             weight_zp=w_zp,  # type: ignore
             g_idx=w_gidx,  # type: ignore
             g_idx_sort_indices=layer.g_idx_sort_indices,
-            workspace=self.workspace,
+            workspace=get_marlin_workspace(x.device),
             wtype=c.weight_type,
             input_size_per_partition=c.partition_weight_shape[0],
             output_size_per_partition=c.partition_weight_shape[1],

--- a/vllm/model_executor/kernels/linear/mxfp4/marlin.py
+++ b/vllm/model_executor/kernels/linear/mxfp4/marlin.py
@@ -4,6 +4,9 @@
 import torch
 
 from vllm.logger import init_logger
+from vllm.model_executor.layers.quantization.utils.marlin_utils import (
+    get_marlin_workspace,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import kMxfp4Dynamic
 
 from .base import MxFp4LinearKernel, MxFp4LinearLayerConfig
@@ -58,7 +61,7 @@ class MarlinMxFp4LinearKernel(MxFp4LinearKernel):
             weight=layer.weight,
             weight_scale=layer.weight_scale,
             weight_global_scale=None,
-            workspace=layer.workspace,
+            workspace=get_marlin_workspace(x.device),
             size_n=layer.output_size_per_partition,
             size_k=layer.input_size_per_partition,
             bias=bias,

--- a/vllm/model_executor/kernels/linear/mxfp8/marlin.py
+++ b/vllm/model_executor/kernels/linear/mxfp8/marlin.py
@@ -3,6 +3,10 @@
 
 import torch
 
+from vllm.model_executor.layers.quantization.utils.marlin_utils import (
+    get_marlin_workspace,
+)
+
 from .Mxfp8LinearKernel import Mxfp8LinearKernel, Mxfp8LinearLayerConfig
 
 
@@ -46,7 +50,7 @@ class MarlinMxfp8LinearKernel(Mxfp8LinearKernel):
             input=x,
             weight=layer.weight,
             weight_scale=layer.weight_scale,
-            workspace=layer.workspace,
+            workspace=get_marlin_workspace(x.device),
             size_n=layer.output_size_per_partition,
             size_k=layer.input_size_per_partition,
             bias=bias,

--- a/vllm/model_executor/kernels/linear/nvfp4/marlin.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/marlin.py
@@ -4,6 +4,9 @@
 import torch
 
 from vllm.logger import init_logger
+from vllm.model_executor.layers.quantization.utils.marlin_utils import (
+    get_marlin_workspace,
+)
 from vllm.model_executor.layers.quantization.utils.marlin_utils_fp4 import (
     apply_fp4_marlin_linear,
     is_fp4_marlin_supported,
@@ -50,7 +53,7 @@ class MarlinNvFp4LinearKernel(NvFp4LinearKernel):
             weight=layer.weight,
             weight_scale=layer.weight_scale,
             weight_global_scale=layer.weight_global_scale,
-            workspace=layer.workspace,
+            workspace=get_marlin_workspace(x.device),
             size_n=layer.output_size_per_partition,
             size_k=layer.input_size_per_partition,
             bias=bias,

--- a/vllm/model_executor/kernels/linear/scaled_mm/marlin.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/marlin.py
@@ -9,6 +9,9 @@ import vllm.envs as envs
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     process_fp8_weight_block_strategy,
 )
+from vllm.model_executor.layers.quantization.utils.marlin_utils import (
+    get_marlin_workspace,
+)
 from vllm.model_executor.layers.quantization.utils.marlin_utils_fp8 import (
     apply_fp8_marlin_linear,
     is_fp8_marlin_supported,
@@ -97,7 +100,7 @@ class MarlinFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
             input=x,
             weight=layer.weight,
             weight_scale=weight_scale,
-            workspace=layer.workspace,
+            workspace=get_marlin_workspace(x.device),
             size_n=layer.output_size_per_partition,
             size_k=layer.input_size_per_partition,
             input_dtype=self.marlin_input_dtype,

--- a/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
@@ -32,7 +32,7 @@ from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
 from vllm.model_executor.layers.fused_moe.utils import _resize_cache
 from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     get_marlin_input_dtype,
-    marlin_make_workspace_new,
+    get_marlin_workspace,
     marlin_moe_intermediate_size,
     marlin_quant_input,
 )
@@ -101,7 +101,7 @@ def _fused_marlin_moe(
     N = marlin_moe_intermediate_size(w1, w2)
     w13_num_shards = 2 if activation.is_gated else 1
     if workspace is None:
-        workspace = marlin_make_workspace_new(hidden_states.device, 4)
+        workspace = get_marlin_workspace(hidden_states.device)
 
     if intermediate_cache13 is None:
         intermediate_cache13 = torch.empty(

--- a/vllm/model_executor/layers/quantization/auto_awq.py
+++ b/vllm/model_executor/layers/quantization/auto_awq.py
@@ -48,7 +48,6 @@ from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     check_marlin_supports_layer,
     check_moe_marlin_supports_layer,
     get_marlin_input_dtype,
-    marlin_make_workspace_new,
     verify_marlin_supported,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
@@ -662,9 +661,6 @@ class AutoAWQMoEMethod(FusedMoEMethodBase):
         )
         layer.register_parameter("w2_qzeros", w2_qzeros)
         set_weight_attrs(w2_qzeros, extra_weight_attrs)
-
-        device = layer.w13_qweight.device
-        layer.workspace = marlin_make_workspace_new(device, 4)
 
     def process_weights_after_loading(self, layer: RoutedExperts) -> None:
         converted = convert_to_wna16_moe_kernel_format(

--- a/vllm/model_executor/layers/quantization/auto_gptq.py
+++ b/vllm/model_executor/layers/quantization/auto_gptq.py
@@ -16,7 +16,6 @@ from vllm.model_executor.kernels.linear import (
 )
 from vllm.model_executor.layers.fused_moe import (
     FusedMoEConfig,
-    FusedMoEExpertsModular,
     FusedMoEMethodBase,
     FusedMoEQuantConfig,
     FusedMoeWeightScaleSupported,
@@ -45,7 +44,6 @@ from vllm.model_executor.layers.quantization.utils.gptq_utils import (
 from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     check_moe_marlin_supports_layer,
     get_marlin_input_dtype,
-    marlin_make_workspace_new,
     marlin_repeat_scales_on_all_ranks,
     verify_marlin_supported,
 )
@@ -666,12 +664,6 @@ class AutoGPTQMoEMethod(FusedMoEMethodBase):
         )
         layer.register_parameter("w2_bias", w2_bias)
         set_weight_attrs(w2_bias, extra_weight_attrs)
-
-        if self.experts_cls is not None and issubclass(
-            self.experts_cls, FusedMoEExpertsModular
-        ):
-            device = layer.w13_qweight.device
-            layer.workspace = marlin_make_workspace_new(device, 4)
 
     def process_weights_after_loading(self, layer: RoutedExperts) -> None:
         def replace_or_register(name: str, val: torch.Tensor | None):

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16_marlin.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16_marlin.py
@@ -10,7 +10,6 @@ from compressed_tensors.quantization import (
 
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe import (
-    FusedMoEExpertsModular,
     RoutedExperts,
     SharedExperts,
 )
@@ -34,7 +33,6 @@ from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compress
 )
 from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     get_marlin_input_dtype,
-    marlin_make_workspace_new,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
@@ -495,18 +493,6 @@ class CompressedTensorsWNA16MarlinMoEMethod(CompressedTensorsMoEMethod):
                 layer.register_parameter(
                     "w2_input_global_scale",
                     torch.nn.Parameter(w2_input_global_scale, requires_grad=False),
-                )
-
-            # Marlin workspace — only needed for Marlin-family backends, not emulation.
-            if (
-                self.experts_cls is not None
-                and issubclass(self.experts_cls, FusedMoEExpertsModular)
-                and self.wna16_backend != WNA16MoEBackend.EMULATION
-            ):
-                layer.workspace = marlin_make_workspace_new(
-                    layer.w13_weight_g_idx.device,
-                    4,
-                    existing=getattr(layer, "workspace", None),
                 )
 
         # Alias packed weights to w13_weight/w2_weight for the modular kernel interface

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils.py
@@ -31,6 +31,7 @@ GPTQ_MARLIN_TILE = 16
 GPTQ_MARLIN_MIN_THREAD_N = 64
 GPTQ_MARLIN_MIN_THREAD_K = 128
 GPTQ_MARLIN_MAX_PARALLEL = 16
+MARLIN_MAX_BLOCKS_PER_SM = 4
 
 MARLIN_SUPPORTED_GROUP_SIZES = [-1, 32, 64, 128]
 
@@ -399,29 +400,36 @@ def marlin_moe_intermediate_size(w1_packed: torch.Tensor, w2_packed: torch.Tenso
 def marlin_make_workspace_new(
     device: torch.device,
     max_blocks_per_sm: int = 1,
-    existing: torch.Tensor | None = None,
 ) -> torch.Tensor:
     # In the new marlin kernel, we use the num of threadblocks as workspace
     # size. The num of threadblocks is sms_count * max_blocks_per_sm.
     sms = num_compute_units(device.index)
-    size = sms * max_blocks_per_sm
-    # On weight reload, reuse the existing storage so the workspace address
-    # captured by CUDA graphs stays valid.
-    if existing is not None:
-        if (
-            existing.device != device
-            or existing.dtype != torch.int
-            or existing.numel() != size
-        ):
-            raise ValueError(
-                f"Existing Marlin workspace is incompatible "
-                f"(device={existing.device}, dtype={existing.dtype}, "
-                f"numel={existing.numel()}; expected device={device}, "
-                f"dtype={torch.int}, numel={size}). Reload must reuse the "
-                f"workspace storage captured by CUDA graphs."
-            )
-        return existing.zero_()
-    return torch.zeros(size, dtype=torch.int, device=device, requires_grad=False)
+    return torch.zeros(
+        sms * max_blocks_per_sm,
+        dtype=torch.int,
+        device=device,
+        requires_grad=False,
+    )
+
+
+def get_marlin_workspace(device: torch.device) -> torch.Tensor:
+    """Get the Marlin lock workspace for the current stream and ubatch."""
+    from vllm.v1.worker.workspace import (
+        current_workspace_manager,
+        is_workspace_manager_initialized,
+    )
+
+    if not is_workspace_manager_initialized():
+        return marlin_make_workspace_new(device, MARLIN_MAX_BLOCKS_PER_SM)
+
+    from vllm.utils.torch_utils import current_stream
+
+    return current_workspace_manager().get_persistent(
+        ("marlin_locks", current_stream()),
+        (num_compute_units(device.index) * MARLIN_MAX_BLOCKS_PER_SM,),
+        torch.int,
+        zero_init=True,
+    )
 
 
 def marlin_is_k_full(act_order: bool, is_row_parallel: bool) -> bool:

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
@@ -10,7 +10,6 @@ from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
 from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     USE_FP32_REDUCE_DEFAULT,
     get_marlin_input_dtype,
-    marlin_make_workspace_new,
     marlin_pad_dim,
     marlin_pad_qweight,
     marlin_pad_scales,
@@ -239,11 +238,6 @@ def prepare_fp4_layer_for_marlin(
 
     device = layer.weight.device
 
-    # WORKSPACE
-    layer.workspace = marlin_make_workspace_new(
-        device, existing=getattr(layer, "workspace", None)
-    )
-
     # WEIGHT
     # Repack weights to marlin format
     perm = torch.empty(0, dtype=torch.int, device=device)
@@ -397,10 +391,6 @@ def prepare_nvfp4_moe_layer_for_marlin(
     param_dtype = layer.params_dtype
     is_a_8bit = input_dtype is not None and input_dtype.itemsize == 1
 
-    # WORKSPACE
-    layer.workspace = marlin_make_workspace_new(
-        device, 4, existing=getattr(layer, "workspace", None)
-    )
     perm = torch.empty(0, dtype=torch.int, device=device)
 
     # WEIGHT
@@ -486,12 +476,8 @@ def prepare_moe_fp4_layer_for_marlin(
     k = layer.moe_config.hidden_dim
     n = layer.moe_config.intermediate_size_per_partition
 
-    # WORKSPACE
     device = layer.w13_weight.device
     param_dtype = layer.params_dtype
-    layer.workspace = marlin_make_workspace_new(
-        device, 4, existing=getattr(layer, "workspace", None)
-    )
     perm = torch.empty(0, dtype=torch.int, device=device)
     is_a_8bit = input_dtype is not None and input_dtype.itemsize == 1
 

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_fp8.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_fp8.py
@@ -9,7 +9,6 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     USE_FP32_REDUCE_DEFAULT,
     get_marlin_input_dtype,
-    marlin_make_workspace_new,
     marlin_moe_padded_intermediate,
     marlin_pad_dim,
     marlin_pad_qweight,
@@ -131,11 +130,6 @@ def prepare_fp8_layer_for_marlin(
 
     device = layer.weight.device
 
-    # WORKSPACE
-    layer.workspace = marlin_make_workspace_new(
-        device, existing=getattr(layer, "workspace", None)
-    )
-
     # WEIGHT
     # Repack weights to marlin format
     perm = torch.empty(0, dtype=torch.int, device=device)
@@ -245,13 +239,7 @@ def prepare_fp8_moe_layer_for_marlin(
     w13_weight_scale: torch.Tensor,
     w2_weight_scale: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    """
-    Shuffle weights and scales into marlin format.
-
-    Note that this function has the side effect of adding a `workspace`
-    attribute to the layer. This `workspace` does not need to be
-    registered as a Parameter as it is not used during weight reloading.
-    """
+    """Shuffle weights and scales into marlin format."""
 
     logger.warning_once(
         "Your GPU does not have native support for FP8 computation but "
@@ -278,11 +266,7 @@ def prepare_fp8_moe_layer_for_marlin(
         w13_weight = _moe_pad_shard_rows(w13_weight, n, padded_n)
         w2_weight = _moe_pad_last(w2_weight, n, padded_n)
 
-    # WORKSPACE
     device = layer.w13_weight.device
-    layer.workspace = marlin_make_workspace_new(
-        device, 4, existing=getattr(layer, "workspace", None)
-    )
     perm = torch.empty(0, dtype=torch.int, device=device)
 
     # WEIGHT
@@ -464,11 +448,6 @@ def prepare_mxfp8_layer_for_marlin(layer: torch.nn.Module) -> None:
 
     device = layer.weight.device
 
-    # WORKSPACE
-    layer.workspace = marlin_make_workspace_new(
-        device, existing=getattr(layer, "workspace", None)
-    )
-
     # WEIGHT - repack FP8 weights to Marlin format
     perm = torch.empty(0, dtype=torch.int, device=device)
     qweight = pack_fp8_to_int32(layer.weight, size_k_first=False)
@@ -525,7 +504,7 @@ def prepare_mxfp8_moe_layer_for_marlin(
     """Repack MXFP8 MoE weights and scales into Marlin kernel format.
 
     Args:
-        layer: MoE layer (used to read params_dtype and attach workspace).
+        layer: MoE layer used to read params_dtype.
         w13: [E, 2*N, K] float8_e4m3fn weights.
         w2:  [E, K, N] float8_e4m3fn weights.
         w13_scale: [E, 2*N, K//32] uint8 e8m0 scales.
@@ -552,10 +531,6 @@ def prepare_mxfp8_moe_layer_for_marlin(
     device = w13.device
     param_dtype = torch.get_default_dtype()
     perm = torch.empty(0, dtype=torch.int, device=device)
-
-    layer.workspace = marlin_make_workspace_new(
-        device, 4, existing=getattr(layer, "workspace", None)
-    )
 
     def repack_weight(weight: torch.Tensor, name: str) -> torch.Tensor:
         if "w13" in name:

--- a/vllm/v1/worker/workspace.py
+++ b/vllm/v1/worker/workspace.py
@@ -3,6 +3,7 @@
 
 import inspect
 import os
+from collections.abc import Hashable
 from itertools import accumulate
 from math import prod
 
@@ -31,8 +32,8 @@ _manager: "WorkspaceManager | None" = None
 class WorkspaceManager:
     """Manager for workspace allocation.
 
-    Manages one workspace buffer per active ubatch slot.
-    Can be locked to prevent further growth during execution.
+    Manages shared and persistent workspace buffers per active ubatch slot.
+    Can be locked to prevent further allocation during execution.
     """
 
     def __init__(self, device: torch.device, num_ubatches: int | None = None):
@@ -42,6 +43,7 @@ class WorkspaceManager:
         self._current_workspaces: list[torch.Tensor | None] = [
             None
         ] * self._num_ubatches
+        self._persistent_workspaces: dict[Hashable, list[torch.Tensor]] = {}
         self._locked: bool = False
 
     @staticmethod
@@ -52,10 +54,9 @@ class WorkspaceManager:
         return workspace.numel() * workspace.element_size()
 
     def lock(self) -> None:
-        """Lock the workspace to prevent further growth.
+        """Lock the workspace to prevent growth or new persistent allocations.
 
-        After locking, any attempt to allocate a larger workspace will raise
-        an assertion error. This ensures workspace size is fixed during execution.
+        This ensures workspace storage is fixed during execution.
         """
         self._locked = True
         if envs.VLLM_DEBUG_WORKSPACE:
@@ -115,6 +116,46 @@ class WorkspaceManager:
             .reshape(shapes_and_dtypes[i][0])
             for i in range(len(shapes_and_dtypes))
         ]
+
+    def get_persistent(
+        self,
+        key: Hashable,
+        shape: tuple[int, ...],
+        dtype: torch.dtype,
+        *,
+        zero_init: bool = False,
+    ) -> torch.Tensor:
+        """Get a keyed workspace with stable storage.
+
+        Args:
+            key: Workspace identifier.
+            shape: Tensor shape.
+            dtype: Tensor dtype.
+            zero_init: Whether to zero newly allocated tensors.
+
+        Returns:
+            The workspace for the current ubatch slot.
+        """
+        workspaces = self._persistent_workspaces.get(key)
+        if workspaces is None:
+            if self._locked:
+                raise AssertionError(
+                    f"Workspace is locked but {key!r} was not allocated during warmup."
+                )
+            factory = torch.zeros if zero_init else torch.empty
+            workspaces = [
+                factory(shape, dtype=dtype, device=self._device)
+                for _ in range(self._num_ubatches)
+            ]
+            self._persistent_workspaces[key] = workspaces
+
+        workspace = workspaces[dbo_current_ubatch_id()]
+        if workspace.shape != shape or workspace.dtype != dtype:
+            raise ValueError(
+                f"Persistent workspace {key!r} has shape={workspace.shape}, "
+                f"dtype={workspace.dtype}; requested shape={shape}, dtype={dtype}."
+            )
+        return workspace
 
     def _ensure_workspace_size(self, required_bytes: int) -> torch.Tensor:
         """Ensure workspace is allocated and large enough, return current workspace.


### PR DESCRIPTION
## Summary

Marlin workspaces are runtime lock storage, but they are currently allocated and owned by individual kernels or layers during weight preparation. That couples graph-visible scratch storage to weight reload and requires every Marlin backend to preserve its workspace allocation independently.

This change adds keyed persistent allocations to `WorkspaceManager` and moves Marlin lock ownership there:

- `WorkspaceManager.get_persistent` returns stable per-ubatch storage and rejects shape/dtype changes or new allocations after workspace locking.
- Marlin uses one maximum-sized lock buffer per `(current CUDA stream, ubatch)`. Calls on one stream reuse storage; concurrent streams cannot share synchronization counters.
- Dense and MoE Marlin call sites acquire workspace at execution time.
- Weight preparation no longer attaches workspace tensors to kernels or layers.

The buffer is zero-initialized once. Marlin kernels restore their lock counters to zero after successful execution, so repeated calls on the same ordered stream do not require host-side zeroing.

## Impact

This removes Marlin workspace handling from reload-sensitive backend code while preserving CUDA graph address stability. It does not change weights, kernel arithmetic, or output numerics.

Standalone callers without an initialized workspace manager retain the existing zero-initialized allocation fallback. Explicit workspaces passed to the Marlin MoE API remain supported.

## Related work / duplicate check

This is not a duplicate of:

- #48438, which preserves each existing Marlin workspace allocation across reload. This PR removes workspace ownership from weight processing entirely.
- #49789, which introduces a layer-owned reload arena for graph-visible runtime tensors. Marlin lock storage is execution scratch here and is owned by the existing worker workspace lifecycle instead.
- #50521 and #50538, which stabilize non-Marlin FlashInfer backend state.

Open-PR searches for `marlin workspace`, `Marlin WorkspaceManager`, and `workspace manager persistent workspace` found no PR implementing this structure. The ownership distinction is also recorded in #48312.

## Validation

```bash
.venv/bin/python -m pytest tests/v1/worker/test_workspace.py tests/model_executor/model_loader/test_reload.py -k 'persistent_workspace or marlin_prepare_layer or marlin_workspace_uses' -v
```

Result: 6 passed.

```bash
.venv/bin/pre-commit run --from-ref origin/main --to-ref HEAD
```

Result: all applicable hooks passed, including Ruff, formatting, mypy, SPDX, forbidden imports, and sign-off checks.

Model evaluation was not run because this change does not alter model weights or arithmetic. GPU capture/replay and shared-expert multi-stream validation were not available locally and remain the primary runtime validation requested for review.

## AI assistance

AI assistance (OpenAI Codex) was used for investigation, implementation, testing, and drafting this PR.