### PR TITLE
[Helion] Require Helion for CUDA builds

### DIFF
--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -4,6 +4,7 @@
 numba == 0.65.0 # Required for N-gram speculative decoding
 
 # Dependencies for NVIDIA GPUs
+helion==1.4.0
 torch==2.13.0
 torchaudio==2.11.0
 # These must be updated alongside torch

--- a/setup.py
+++ b/setup.py
@@ -1287,8 +1287,9 @@ setup(
         # only; also needs system GStreamer + libv4l (see docs).
         "deepstream": ["nvidia-deepstream-videodecode-cu13>=9.0.2"],
         "flashinfer": [],  # Kept for backwards compatibility
-        # Optional deps for Helion kernel development
-        # NOTE: When updating helion version, also update CI files:
+        # CUDA builds require Helion; keep this extra for other platforms.
+        # NOTE: When updating the Helion version, also update:
+        #   - requirements/cuda.txt
         #   - .buildkite/test_areas/kernels.yaml
         #   - .buildkite/test-amd.yaml
         "helion": ["helion==1.4.0"],


### PR DESCRIPTION
## Summary

- make Helion 1.4.0 an unconditional dependency of CUDA builds
- retain the `vllm[helion]` extra for non-CUDA builds and document the version-sync locations
- ensure #48995 can route Helion kernels without requiring users to install an extra

## Duplicate-work check

This does not duplicate an existing PR. Searches for open PRs matching `helion dependency`, `helion CUDA dependency`, and `helion in:body` found Helion kernel work, including #48995, but no PR making Helion a required CUDA dependency.

## Test plan

- `git diff --check` (passed)
- `LD_LIBRARY_PATH=/opt/miniconda3/lib .venv/bin/pre-commit run --files setup.py requirements/cuda.txt` (all applicable hooks passed, including `pip-compile`)
- `LD_LIBRARY_PATH=/opt/miniconda3/lib VLLM_TARGET_DEVICE=cuda .venv/bin/python setup.py egg_info --egg-base /tmp/vllm-require-helion-egginfo/cuda` (passed; generated base requirements contain `helion==1.4.0`)
- `LD_LIBRARY_PATH=/opt/miniconda3/lib VLLM_TARGET_DEVICE=cpu .venv/bin/python setup.py egg_info --egg-base /tmp/vllm-require-helion-egginfo/cpu` (passed; Helion remains extra-only)

## Model evaluation

Not applicable. This is a packaging-only dependency change and does not alter model output, accuracy, or serving behavior.

## AI assistance

OpenAI Codex was used to prepare this change. The human submitter must review every changed line and the test results before marking this PR ready for review.
