### PR TITLE
[Bugfix] Pull runai_streamer non-tensor model files on every node

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,7 @@ import logging
 import os
 from dataclasses import MISSING, Field, asdict, dataclass, field
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pydantic
 import pytest
@@ -32,6 +32,7 @@ from vllm.config.load import LoadConfig
 from vllm.config.utils import get_field
 from vllm.config.vllm import OPTIMIZATION_LEVEL_TO_CONFIG, OptimizationLevel
 from vllm.platforms import current_platform
+from vllm.transformers_utils.runai_utils import ObjectStorageModel
 from vllm.v1.attention.backend import AttentionCGSupport
 
 DEVICE_TYPE = current_platform.device_type
@@ -889,7 +890,7 @@ class MockConfig:
     def __init__(self, model: str, tokenizer: str):
         self.model = model
         self.tokenizer = tokenizer
-        self.model_weights = None
+        self.model_weights: str | None = None
 
 
 @pytest.mark.parametrize(
@@ -1015,6 +1016,421 @@ def test_s3_url_different_model_and_tokenizer(mock_pull_files):
     assert mock_pull_files.call_args_list[0][0][0] == model_url
     # Second call: tokenizer URI with ignore_pattern
     assert mock_pull_files.call_args_list[1][0][0] == tokenizer_url
+
+
+# Tests for maybe_pull_model_files_for_runai_worker (worker-side repair pull).
+
+RUNAI_WORKER_S3_URL = "s3://example-bucket/model/"
+
+
+@pytest.fixture
+def runai_assets_cache(tmp_path, monkeypatch):
+    """Keep the Object Storage cache directory inside the test's tmp_path."""
+    monkeypatch.setenv("VLLM_ASSETS_CACHE", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture
+def mock_get_lock():
+    """Stub out the file lock guarding concurrent pulls on the same node."""
+    # weight_utils is imported lazily by the method under test, so make sure
+    # the module exists before patching a name inside it.
+    import vllm.model_executor.model_loader.weight_utils  # noqa: F401
+
+    with patch(
+        "vllm.model_executor.model_loader.weight_utils.get_lock"
+    ) as mock_get_lock:
+        yield mock_get_lock
+
+
+def _worker_config(model_dir: str, model_weights: str) -> MockConfig:
+    """A config as a worker receives it: local dirs plus the original URI."""
+    config = MockConfig(model=model_dir, tokenizer=model_dir)
+    config.model_weights = model_weights
+    return config
+
+
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_worker_pulls_files_when_node_local_dir_is_empty(
+    mock_pull_files, mock_get_lock, runai_assets_cache
+):
+    """A peer node must pull the non-tensor files it never received."""
+    mock_pull_files.return_value = None
+
+    # ObjectStorageModel resolves (and creates) the deterministic local
+    # directory. Leaving it empty reproduces the peer node's state.
+    local_dir = ObjectStorageModel(url=RUNAI_WORKER_S3_URL).dir
+    assert os.listdir(local_dir) == []
+
+    config = _worker_config(local_dir, RUNAI_WORKER_S3_URL)
+    ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    assert mock_pull_files.call_count == 2
+    # The weights URI is pulled, never the already-rewritten local path.
+    assert mock_pull_files.call_args_list[0][0][0] == RUNAI_WORKER_S3_URL
+    assert mock_pull_files.call_args_list[0][1]["allow_pattern"] == [
+        "*.model",
+        "*.py",
+        "*.json",
+    ]
+    # The pull is serialized against the other ranks on this node, keyed on
+    # the resolved directory being written rather than on the remote URI.
+    mock_get_lock.assert_called_once_with(os.path.realpath(local_dir))
+    # Weights themselves are streamed, not pulled.
+    assert config.model_weights == RUNAI_WORKER_S3_URL
+    # The successful pull leaves the cache directory in place.
+    assert os.path.exists(local_dir)
+
+
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_worker_pull_matches_driver_pull(
+    mock_pull_files, mock_get_lock, runai_assets_cache
+):
+    """The worker must reproduce the driver's pull calls verbatim."""
+    mock_pull_files.return_value = None
+
+    driver_config = MockConfig(model=RUNAI_WORKER_S3_URL, tokenizer=RUNAI_WORKER_S3_URL)
+    ModelConfig.maybe_pull_model_tokenizer_for_runai(
+        driver_config, RUNAI_WORKER_S3_URL, RUNAI_WORKER_S3_URL
+    )
+    driver_calls = mock_pull_files.call_args_list[:]
+    assert driver_calls, "driver is expected to pull files"
+    mock_pull_files.reset_mock()
+
+    # pull_files is mocked, so the directory the driver resolved is still
+    # empty - exactly what a worker on a peer node finds.
+    worker_config = _worker_config(driver_config.model, RUNAI_WORKER_S3_URL)
+    ModelConfig.maybe_pull_model_files_for_runai_worker(worker_config)
+
+    assert mock_pull_files.call_args_list == driver_calls
+    assert worker_config.model == driver_config.model
+    assert worker_config.tokenizer == driver_config.tokenizer
+
+
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_worker_does_not_disturb_an_unrepairable_tokenizer(
+    mock_pull_files, mock_get_lock, runai_assets_cache, tmp_path
+):
+    """A tokenizer pulled from its own URI is left untouched, not repointed."""
+    mock_pull_files.return_value = None
+
+    local_dir = ObjectStorageModel(url=RUNAI_WORKER_S3_URL).dir
+    tokenizer_dir = str(tmp_path / "separate-tokenizer")
+
+    config = MockConfig(model=local_dir, tokenizer=tokenizer_dir)
+    config.model_weights = RUNAI_WORKER_S3_URL
+    ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    # Mirrors the driver: a separate tokenizer means only the allow-pattern
+    # pull for the model directory.
+    assert mock_pull_files.call_count == 1
+    assert mock_pull_files.call_args_list[0][0][0] == RUNAI_WORKER_S3_URL
+    assert mock_pull_files.call_args_list[0][1]["allow_pattern"] == [
+        "*.model",
+        "*.py",
+        "*.json",
+    ]
+    assert config.tokenizer == tokenizer_dir
+
+
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_worker_pull_matches_driver_pull_with_separate_tokenizer(
+    mock_pull_files, mock_get_lock, runai_assets_cache
+):
+    """With a separate tokenizer, the worker must still mirror the driver's
+    pulls for the model URI: the allow-pattern pull only."""
+    mock_pull_files.return_value = None
+
+    tokenizer_url = "s3://example-bucket/tokenizer/"
+    driver_config = MockConfig(model=RUNAI_WORKER_S3_URL, tokenizer=tokenizer_url)
+    ModelConfig.maybe_pull_model_tokenizer_for_runai(
+        driver_config, RUNAI_WORKER_S3_URL, tokenizer_url
+    )
+    driver_model_calls = [
+        call
+        for call in mock_pull_files.call_args_list
+        if call[0][0] == RUNAI_WORKER_S3_URL
+    ]
+    assert len(driver_model_calls) == 1
+    mock_pull_files.reset_mock()
+
+    worker_config = _worker_config(driver_config.model, RUNAI_WORKER_S3_URL)
+    worker_config.tokenizer = driver_config.tokenizer
+    ModelConfig.maybe_pull_model_files_for_runai_worker(worker_config)
+
+    assert mock_pull_files.call_args_list == driver_model_calls
+
+
+@patch("vllm.config.model.ObjectStorageModel")
+def test_runai_worker_guard_accepts_a_symlinked_cache_directory(
+    mock_object_storage_model, mock_get_lock, runai_assets_cache, tmp_path
+):
+    """Paths resolving to the same physical directory must not be rejected."""
+    real_dir = tmp_path / "real-cache"
+    real_dir.mkdir()
+    link_dir = tmp_path / "alias-cache"
+    os.symlink(real_dir, link_dir, target_is_directory=True)
+
+    mock_object_storage_model.return_value.dir = str(real_dir)
+    config = _worker_config(str(link_dir), RUNAI_WORKER_S3_URL)
+    ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    assert mock_object_storage_model.return_value.pull_files.call_count == 2
+    # The lock is keyed on the canonical path, not on the alias spelling.
+    mock_get_lock.assert_called_once_with(os.path.realpath(str(link_dir)))
+
+
+@patch("vllm.config.model.ObjectStorageModel")
+def test_runai_worker_waits_for_lock_before_trusting_existing_files(
+    mock_object_storage_model, mock_get_lock, runai_assets_cache
+):
+    """Even a populated directory is only trusted after taking the lock."""
+    local_dir = ObjectStorageModel(url=RUNAI_WORKER_S3_URL).dir
+    with open(os.path.join(local_dir, "config.json"), "w") as f:
+        f.write("{}")
+
+    config = _worker_config(local_dir, RUNAI_WORKER_S3_URL)
+    ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    # A non-empty directory may be a pull still in progress on another rank.
+    mock_get_lock.assert_called_once_with(os.path.realpath(local_dir))
+    mock_object_storage_model.assert_not_called()
+    assert config.model == local_dir
+
+
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_worker_rechecks_after_acquiring_the_lock(
+    mock_pull_files, mock_get_lock, runai_assets_cache
+):
+    """A rank that waited for the lock must not repeat the winner's pull."""
+    mock_pull_files.return_value = None
+
+    local_dir = ObjectStorageModel(url=RUNAI_WORKER_S3_URL).dir
+
+    def win_race_while_blocked(*args, **kwargs):
+        # Simulates the rank holding the lock finishing its pull.
+        with open(os.path.join(local_dir, "config.json"), "w") as f:
+            f.write("{}")
+
+    lock = MagicMock()
+    lock.__enter__.side_effect = win_race_while_blocked
+    mock_get_lock.return_value = lock
+
+    config = _worker_config(local_dir, RUNAI_WORKER_S3_URL)
+    ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    mock_get_lock.assert_called_once()
+    mock_pull_files.assert_not_called()
+
+
+def _fail_after_writing_one_file(local_dir: str, exc_type: type = OSError):
+    """A pull that dies partway, leaving the directory half populated."""
+
+    def pull(*args, **kwargs):
+        os.makedirs(local_dir, exist_ok=True)
+        with open(os.path.join(local_dir, "config.json"), "w") as f:
+            f.write("{}")
+        raise exc_type("connection reset by peer")
+
+    return pull
+
+
+@pytest.mark.parametrize("failure", [OSError, KeyboardInterrupt])
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_worker_clears_the_directory_when_the_pull_fails(
+    mock_pull_files, mock_get_lock, runai_assets_cache, failure
+):
+    """A failed or interrupted pull removes its leftovers and propagates."""
+    local_dir = ObjectStorageModel(url=RUNAI_WORKER_S3_URL).dir
+    mock_pull_files.side_effect = _fail_after_writing_one_file(local_dir, failure)
+
+    config = _worker_config(local_dir, RUNAI_WORKER_S3_URL)
+    with pytest.raises(failure):
+        ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    assert not os.path.exists(local_dir)
+
+
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_worker_retries_after_a_failed_pull(
+    mock_pull_files, mock_get_lock, runai_assets_cache
+):
+    """A transient failure must not poison the cache for the next start."""
+    local_dir = ObjectStorageModel(url=RUNAI_WORKER_S3_URL).dir
+    mock_pull_files.side_effect = _fail_after_writing_one_file(local_dir)
+
+    config = _worker_config(local_dir, RUNAI_WORKER_S3_URL)
+    with pytest.raises(OSError):
+        ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    mock_pull_files.reset_mock()
+    mock_pull_files.side_effect = None
+    ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    assert mock_pull_files.call_count == 2
+    # The successful retry leaves the cache directory in place.
+    assert os.path.exists(local_dir)
+
+
+@patch("vllm.config.model.ObjectStorageModel")
+def test_runai_worker_fails_fast_on_a_cache_directory_mismatch(
+    mock_object_storage_model, mock_get_lock, runai_assets_cache, tmp_path
+):
+    """A node deriving a different cache directory fails fast, without pulling."""
+    mock_object_storage_model.return_value.dir = str(tmp_path / "worker-side-dir")
+
+    config = _worker_config(str(tmp_path / "driver-side-dir"), RUNAI_WORKER_S3_URL)
+    with (
+        patch("vllm.config.model.shutil.rmtree") as mock_rmtree,
+        pytest.raises(RuntimeError, match="VLLM_ASSETS_CACHE"),
+    ):
+        ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    mock_object_storage_model.return_value.pull_files.assert_not_called()
+    mock_rmtree.assert_not_called()
+
+
+@patch("vllm.config.model.ObjectStorageModel")
+def test_runai_worker_opts_out_of_signal_handlers(
+    mock_object_storage_model, mock_get_lock, runai_assets_cache, tmp_path
+):
+    """The worker-side pull must not install process-global signal handlers."""
+    local_dir = str(tmp_path / "node-local-dir")
+    mock_object_storage_model.return_value.dir = local_dir
+
+    config = _worker_config(local_dir, RUNAI_WORKER_S3_URL)
+    ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    mock_object_storage_model.assert_called_once_with(
+        url=RUNAI_WORKER_S3_URL, install_signal_handlers=False
+    )
+
+
+def test_runai_object_storage_model_signal_handler_opt_out(monkeypatch, tmp_path):
+    """`install_signal_handlers=False` skips registration; the default keeps it."""
+    monkeypatch.setenv("VLLM_ASSETS_CACHE_MODEL_CLEAN", "1")
+    monkeypatch.setenv("VLLM_ASSETS_CACHE", str(tmp_path))
+
+    with patch("vllm.transformers_utils.runai_utils.signal.signal") as mock_signal:
+        ObjectStorageModel(url=RUNAI_WORKER_S3_URL, install_signal_handlers=False)
+        mock_signal.assert_not_called()
+
+        ObjectStorageModel(url=RUNAI_WORKER_S3_URL)
+        assert mock_signal.call_count == 2  # SIGINT + SIGTERM
+
+
+@pytest.mark.parametrize(
+    "model_weights",
+    [None, "", "/local/path/to/model", "facebook/opt-125m"],
+)
+@patch("vllm.config.model.ObjectStorageModel")
+def test_runai_worker_noop_without_object_storage_weights(
+    mock_object_storage_model, mock_get_lock, model_weights
+):
+    """Models that never came from Object Storage must not be touched."""
+    config = MockConfig(model="/local/path/to/model", tokenizer="/local/tokenizer")
+    config.model_weights = model_weights
+
+    ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    mock_get_lock.assert_not_called()
+    mock_object_storage_model.assert_not_called()
+    assert config.model == "/local/path/to/model"
+    assert config.tokenizer == "/local/tokenizer"
+
+
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_worker_not_short_circuited_by_driver_guard(
+    mock_pull_files, mock_get_lock, runai_assets_cache
+):
+    """The driver's method silently no-ops on a worker; the new one must pull."""
+    mock_pull_files.return_value = None
+
+    local_dir = ObjectStorageModel(url=RUNAI_WORKER_S3_URL).dir
+    config = _worker_config(local_dir, RUNAI_WORKER_S3_URL)
+
+    # The driver's method no-ops on a worker...
+    ModelConfig.maybe_pull_model_tokenizer_for_runai(
+        config, config.model, config.tokenizer
+    )
+    mock_pull_files.assert_not_called()
+
+    # ...while the worker's method pulls.
+    ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+    assert mock_pull_files.call_count > 0
+
+
+def _init_worker_config(calls: list[str]) -> MagicMock:
+    """A VllmConfig that records when its model files would be pulled."""
+    vllm_config = MagicMock()
+    vllm_config.parallel_config.worker_cls = "fake.module.FakeWorker"
+    vllm_config.parallel_config.worker_extension_cls = None
+    vllm_config.speculative_config = None
+    vllm_config.model_config.maybe_pull_model_files_for_runai_worker.side_effect = (
+        lambda: calls.append("pull_runai_files")
+    )
+    return vllm_config
+
+
+def _run_init_worker(vllm_config: MagicMock, calls: list[str]) -> None:
+    """Drive init_worker with the worker class and mm registry stubbed out."""
+    from vllm.v1.worker import worker_base
+
+    class FakeWorker:
+        def __init__(self, **kwargs):
+            calls.append("construct_worker")
+
+    with (
+        patch.object(worker_base, "resolve_obj_by_qualname", return_value=FakeWorker),
+        patch.object(worker_base, "MULTIMODAL_REGISTRY") as mm_registry,
+    ):
+        mm_registry.worker_receiver_cache_from_config.side_effect = (
+            lambda *args, **kwargs: calls.append("create_mm_receiver_cache")
+        )
+        worker_base.WorkerWrapperBase(rpc_rank=0).init_worker(
+            [{"vllm_config": vllm_config, "shared_worker_lock": MagicMock()}]
+        )
+
+
+def test_init_worker_pulls_runai_files_before_the_directory_is_read():
+    """The pull must run before the mm receiver cache reads the directory."""
+    calls: list[str] = []
+    _run_init_worker(_init_worker_config(calls), calls)
+
+    assert calls == [
+        "pull_runai_files",
+        "create_mm_receiver_cache",
+        "construct_worker",
+    ]
+
+
+def test_init_worker_pulls_runai_files_for_the_draft_model():
+    """A distinct speculative draft config must be pulled as well."""
+    calls: list[str] = []
+    vllm_config = _init_worker_config(calls)
+    draft_config = MagicMock()
+    draft_config.maybe_pull_model_files_for_runai_worker.side_effect = (
+        lambda: calls.append("pull_draft_runai_files")
+    )
+    vllm_config.speculative_config = MagicMock(draft_model_config=draft_config)
+
+    _run_init_worker(vllm_config, calls)
+
+    assert calls.count("pull_runai_files") == 1
+    assert calls.count("pull_draft_runai_files") == 1
+
+
+def test_init_worker_pulls_once_when_the_draft_reuses_the_target_config():
+    """`draft_model_config` is often the target config itself; pull it once."""
+    calls: list[str] = []
+    vllm_config = _init_worker_config(calls)
+    vllm_config.speculative_config = MagicMock(
+        draft_model_config=vllm_config.model_config
+    )
+
+    _run_init_worker(vllm_config, calls)
+
+    assert calls.count("pull_runai_files") == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,7 @@ import logging
 import os
 from dataclasses import MISSING, Field, asdict, dataclass, field
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pydantic
 import pytest
@@ -34,6 +34,7 @@ from vllm.config.vllm import (
     OptimizationLevel,
 )
 from vllm.platforms import current_platform
+from vllm.transformers_utils.runai_utils import ObjectStorageModel
 from vllm.v1.attention.backend import AttentionCGSupport
 
 DEVICE_TYPE = current_platform.device_type
@@ -828,7 +829,7 @@ class MockConfig:
     def __init__(self, model: str, tokenizer: str):
         self.model = model
         self.tokenizer = tokenizer
-        self.model_weights = None
+        self.model_weights: str | None = None
 
 
 @pytest.mark.parametrize(
@@ -954,6 +955,421 @@ def test_s3_url_different_model_and_tokenizer(mock_pull_files):
     assert mock_pull_files.call_args_list[0][0][0] == model_url
     # Second call: tokenizer URI with ignore_pattern
     assert mock_pull_files.call_args_list[1][0][0] == tokenizer_url
+
+
+# Tests for maybe_pull_model_files_for_runai_worker (worker-side repair pull).
+
+RUNAI_WORKER_S3_URL = "s3://example-bucket/model/"
+
+
+@pytest.fixture
+def runai_assets_cache(tmp_path, monkeypatch):
+    """Keep the Object Storage cache directory inside the test's tmp_path."""
+    monkeypatch.setenv("VLLM_ASSETS_CACHE", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture
+def mock_get_lock():
+    """Stub out the file lock guarding concurrent pulls on the same node."""
+    # weight_utils is imported lazily by the method under test, so make sure
+    # the module exists before patching a name inside it.
+    import vllm.model_executor.model_loader.weight_utils  # noqa: F401
+
+    with patch(
+        "vllm.model_executor.model_loader.weight_utils.get_lock"
+    ) as mock_get_lock:
+        yield mock_get_lock
+
+
+def _worker_config(model_dir: str, model_weights: str) -> MockConfig:
+    """A config as a worker receives it: local dirs plus the original URI."""
+    config = MockConfig(model=model_dir, tokenizer=model_dir)
+    config.model_weights = model_weights
+    return config
+
+
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_worker_pulls_files_when_node_local_dir_is_empty(
+    mock_pull_files, mock_get_lock, runai_assets_cache
+):
+    """A peer node must pull the non-tensor files it never received."""
+    mock_pull_files.return_value = None
+
+    # ObjectStorageModel resolves (and creates) the deterministic local
+    # directory. Leaving it empty reproduces the peer node's state.
+    local_dir = ObjectStorageModel(url=RUNAI_WORKER_S3_URL).dir
+    assert os.listdir(local_dir) == []
+
+    config = _worker_config(local_dir, RUNAI_WORKER_S3_URL)
+    ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    assert mock_pull_files.call_count == 2
+    # The weights URI is pulled, never the already-rewritten local path.
+    assert mock_pull_files.call_args_list[0][0][0] == RUNAI_WORKER_S3_URL
+    assert mock_pull_files.call_args_list[0][1]["allow_pattern"] == [
+        "*.model",
+        "*.py",
+        "*.json",
+    ]
+    # The pull is serialized against the other ranks on this node, keyed on
+    # the resolved directory being written rather than on the remote URI.
+    mock_get_lock.assert_called_once_with(os.path.realpath(local_dir))
+    # Weights themselves are streamed, not pulled.
+    assert config.model_weights == RUNAI_WORKER_S3_URL
+    # The successful pull leaves the cache directory in place.
+    assert os.path.exists(local_dir)
+
+
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_worker_pull_matches_driver_pull(
+    mock_pull_files, mock_get_lock, runai_assets_cache
+):
+    """The worker must reproduce the driver's pull calls verbatim."""
+    mock_pull_files.return_value = None
+
+    driver_config = MockConfig(model=RUNAI_WORKER_S3_URL, tokenizer=RUNAI_WORKER_S3_URL)
+    ModelConfig.maybe_pull_model_tokenizer_for_runai(
+        driver_config, RUNAI_WORKER_S3_URL, RUNAI_WORKER_S3_URL
+    )
+    driver_calls = mock_pull_files.call_args_list[:]
+    assert driver_calls, "driver is expected to pull files"
+    mock_pull_files.reset_mock()
+
+    # pull_files is mocked, so the directory the driver resolved is still
+    # empty - exactly what a worker on a peer node finds.
+    worker_config = _worker_config(driver_config.model, RUNAI_WORKER_S3_URL)
+    ModelConfig.maybe_pull_model_files_for_runai_worker(worker_config)
+
+    assert mock_pull_files.call_args_list == driver_calls
+    assert worker_config.model == driver_config.model
+    assert worker_config.tokenizer == driver_config.tokenizer
+
+
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_worker_does_not_disturb_an_unrepairable_tokenizer(
+    mock_pull_files, mock_get_lock, runai_assets_cache, tmp_path
+):
+    """A tokenizer pulled from its own URI is left untouched, not repointed."""
+    mock_pull_files.return_value = None
+
+    local_dir = ObjectStorageModel(url=RUNAI_WORKER_S3_URL).dir
+    tokenizer_dir = str(tmp_path / "separate-tokenizer")
+
+    config = MockConfig(model=local_dir, tokenizer=tokenizer_dir)
+    config.model_weights = RUNAI_WORKER_S3_URL
+    ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    # Mirrors the driver: a separate tokenizer means only the allow-pattern
+    # pull for the model directory.
+    assert mock_pull_files.call_count == 1
+    assert mock_pull_files.call_args_list[0][0][0] == RUNAI_WORKER_S3_URL
+    assert mock_pull_files.call_args_list[0][1]["allow_pattern"] == [
+        "*.model",
+        "*.py",
+        "*.json",
+    ]
+    assert config.tokenizer == tokenizer_dir
+
+
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_worker_pull_matches_driver_pull_with_separate_tokenizer(
+    mock_pull_files, mock_get_lock, runai_assets_cache
+):
+    """With a separate tokenizer, the worker must still mirror the driver's
+    pulls for the model URI: the allow-pattern pull only."""
+    mock_pull_files.return_value = None
+
+    tokenizer_url = "s3://example-bucket/tokenizer/"
+    driver_config = MockConfig(model=RUNAI_WORKER_S3_URL, tokenizer=tokenizer_url)
+    ModelConfig.maybe_pull_model_tokenizer_for_runai(
+        driver_config, RUNAI_WORKER_S3_URL, tokenizer_url
+    )
+    driver_model_calls = [
+        call
+        for call in mock_pull_files.call_args_list
+        if call[0][0] == RUNAI_WORKER_S3_URL
+    ]
+    assert len(driver_model_calls) == 1
+    mock_pull_files.reset_mock()
+
+    worker_config = _worker_config(driver_config.model, RUNAI_WORKER_S3_URL)
+    worker_config.tokenizer = driver_config.tokenizer
+    ModelConfig.maybe_pull_model_files_for_runai_worker(worker_config)
+
+    assert mock_pull_files.call_args_list == driver_model_calls
+
+
+@patch("vllm.config.model.ObjectStorageModel")
+def test_runai_worker_guard_accepts_a_symlinked_cache_directory(
+    mock_object_storage_model, mock_get_lock, runai_assets_cache, tmp_path
+):
+    """Paths resolving to the same physical directory must not be rejected."""
+    real_dir = tmp_path / "real-cache"
+    real_dir.mkdir()
+    link_dir = tmp_path / "alias-cache"
+    os.symlink(real_dir, link_dir, target_is_directory=True)
+
+    mock_object_storage_model.return_value.dir = str(real_dir)
+    config = _worker_config(str(link_dir), RUNAI_WORKER_S3_URL)
+    ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    assert mock_object_storage_model.return_value.pull_files.call_count == 2
+    # The lock is keyed on the canonical path, not on the alias spelling.
+    mock_get_lock.assert_called_once_with(os.path.realpath(str(link_dir)))
+
+
+@patch("vllm.config.model.ObjectStorageModel")
+def test_runai_worker_waits_for_lock_before_trusting_existing_files(
+    mock_object_storage_model, mock_get_lock, runai_assets_cache
+):
+    """Even a populated directory is only trusted after taking the lock."""
+    local_dir = ObjectStorageModel(url=RUNAI_WORKER_S3_URL).dir
+    with open(os.path.join(local_dir, "config.json"), "w") as f:
+        f.write("{}")
+
+    config = _worker_config(local_dir, RUNAI_WORKER_S3_URL)
+    ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    # A non-empty directory may be a pull still in progress on another rank.
+    mock_get_lock.assert_called_once_with(os.path.realpath(local_dir))
+    mock_object_storage_model.assert_not_called()
+    assert config.model == local_dir
+
+
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_worker_rechecks_after_acquiring_the_lock(
+    mock_pull_files, mock_get_lock, runai_assets_cache
+):
+    """A rank that waited for the lock must not repeat the winner's pull."""
+    mock_pull_files.return_value = None
+
+    local_dir = ObjectStorageModel(url=RUNAI_WORKER_S3_URL).dir
+
+    def win_race_while_blocked(*args, **kwargs):
+        # Simulates the rank holding the lock finishing its pull.
+        with open(os.path.join(local_dir, "config.json"), "w") as f:
+            f.write("{}")
+
+    lock = MagicMock()
+    lock.__enter__.side_effect = win_race_while_blocked
+    mock_get_lock.return_value = lock
+
+    config = _worker_config(local_dir, RUNAI_WORKER_S3_URL)
+    ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    mock_get_lock.assert_called_once()
+    mock_pull_files.assert_not_called()
+
+
+def _fail_after_writing_one_file(local_dir: str, exc_type: type = OSError):
+    """A pull that dies partway, leaving the directory half populated."""
+
+    def pull(*args, **kwargs):
+        os.makedirs(local_dir, exist_ok=True)
+        with open(os.path.join(local_dir, "config.json"), "w") as f:
+            f.write("{}")
+        raise exc_type("connection reset by peer")
+
+    return pull
+
+
+@pytest.mark.parametrize("failure", [OSError, KeyboardInterrupt])
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_worker_clears_the_directory_when_the_pull_fails(
+    mock_pull_files, mock_get_lock, runai_assets_cache, failure
+):
+    """A failed or interrupted pull removes its leftovers and propagates."""
+    local_dir = ObjectStorageModel(url=RUNAI_WORKER_S3_URL).dir
+    mock_pull_files.side_effect = _fail_after_writing_one_file(local_dir, failure)
+
+    config = _worker_config(local_dir, RUNAI_WORKER_S3_URL)
+    with pytest.raises(failure):
+        ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    assert not os.path.exists(local_dir)
+
+
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_worker_retries_after_a_failed_pull(
+    mock_pull_files, mock_get_lock, runai_assets_cache
+):
+    """A transient failure must not poison the cache for the next start."""
+    local_dir = ObjectStorageModel(url=RUNAI_WORKER_S3_URL).dir
+    mock_pull_files.side_effect = _fail_after_writing_one_file(local_dir)
+
+    config = _worker_config(local_dir, RUNAI_WORKER_S3_URL)
+    with pytest.raises(OSError):
+        ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    mock_pull_files.reset_mock()
+    mock_pull_files.side_effect = None
+    ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    assert mock_pull_files.call_count == 2
+    # The successful retry leaves the cache directory in place.
+    assert os.path.exists(local_dir)
+
+
+@patch("vllm.config.model.ObjectStorageModel")
+def test_runai_worker_fails_fast_on_a_cache_directory_mismatch(
+    mock_object_storage_model, mock_get_lock, runai_assets_cache, tmp_path
+):
+    """A node deriving a different cache directory fails fast, without pulling."""
+    mock_object_storage_model.return_value.dir = str(tmp_path / "worker-side-dir")
+
+    config = _worker_config(str(tmp_path / "driver-side-dir"), RUNAI_WORKER_S3_URL)
+    with (
+        patch("vllm.config.model.shutil.rmtree") as mock_rmtree,
+        pytest.raises(RuntimeError, match="VLLM_ASSETS_CACHE"),
+    ):
+        ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    mock_object_storage_model.return_value.pull_files.assert_not_called()
+    mock_rmtree.assert_not_called()
+
+
+@patch("vllm.config.model.ObjectStorageModel")
+def test_runai_worker_opts_out_of_signal_handlers(
+    mock_object_storage_model, mock_get_lock, runai_assets_cache, tmp_path
+):
+    """The worker-side pull must not install process-global signal handlers."""
+    local_dir = str(tmp_path / "node-local-dir")
+    mock_object_storage_model.return_value.dir = local_dir
+
+    config = _worker_config(local_dir, RUNAI_WORKER_S3_URL)
+    ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    mock_object_storage_model.assert_called_once_with(
+        url=RUNAI_WORKER_S3_URL, install_signal_handlers=False
+    )
+
+
+def test_runai_object_storage_model_signal_handler_opt_out(monkeypatch, tmp_path):
+    """`install_signal_handlers=False` skips registration; the default keeps it."""
+    monkeypatch.setenv("VLLM_ASSETS_CACHE_MODEL_CLEAN", "1")
+    monkeypatch.setenv("VLLM_ASSETS_CACHE", str(tmp_path))
+
+    with patch("vllm.transformers_utils.runai_utils.signal.signal") as mock_signal:
+        ObjectStorageModel(url=RUNAI_WORKER_S3_URL, install_signal_handlers=False)
+        mock_signal.assert_not_called()
+
+        ObjectStorageModel(url=RUNAI_WORKER_S3_URL)
+        assert mock_signal.call_count == 2  # SIGINT + SIGTERM
+
+
+@pytest.mark.parametrize(
+    "model_weights",
+    [None, "", "/local/path/to/model", "facebook/opt-125m"],
+)
+@patch("vllm.config.model.ObjectStorageModel")
+def test_runai_worker_noop_without_object_storage_weights(
+    mock_object_storage_model, mock_get_lock, model_weights
+):
+    """Models that never came from Object Storage must not be touched."""
+    config = MockConfig(model="/local/path/to/model", tokenizer="/local/tokenizer")
+    config.model_weights = model_weights
+
+    ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    mock_get_lock.assert_not_called()
+    mock_object_storage_model.assert_not_called()
+    assert config.model == "/local/path/to/model"
+    assert config.tokenizer == "/local/tokenizer"
+
+
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_worker_not_short_circuited_by_driver_guard(
+    mock_pull_files, mock_get_lock, runai_assets_cache
+):
+    """The driver's method silently no-ops on a worker; the new one must pull."""
+    mock_pull_files.return_value = None
+
+    local_dir = ObjectStorageModel(url=RUNAI_WORKER_S3_URL).dir
+    config = _worker_config(local_dir, RUNAI_WORKER_S3_URL)
+
+    # The driver's method no-ops on a worker...
+    ModelConfig.maybe_pull_model_tokenizer_for_runai(
+        config, config.model, config.tokenizer
+    )
+    mock_pull_files.assert_not_called()
+
+    # ...while the worker's method pulls.
+    ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+    assert mock_pull_files.call_count > 0
+
+
+def _init_worker_config(calls: list[str]) -> MagicMock:
+    """A VllmConfig that records when its model files would be pulled."""
+    vllm_config = MagicMock()
+    vllm_config.parallel_config.worker_cls = "fake.module.FakeWorker"
+    vllm_config.parallel_config.worker_extension_cls = None
+    vllm_config.speculative_config = None
+    vllm_config.model_config.maybe_pull_model_files_for_runai_worker.side_effect = (
+        lambda: calls.append("pull_runai_files")
+    )
+    return vllm_config
+
+
+def _run_init_worker(vllm_config: MagicMock, calls: list[str]) -> None:
+    """Drive init_worker with the worker class and mm registry stubbed out."""
+    from vllm.v1.worker import worker_base
+
+    class FakeWorker:
+        def __init__(self, **kwargs):
+            calls.append("construct_worker")
+
+    with (
+        patch.object(worker_base, "resolve_obj_by_qualname", return_value=FakeWorker),
+        patch.object(worker_base, "MULTIMODAL_REGISTRY") as mm_registry,
+    ):
+        mm_registry.worker_receiver_cache_from_config.side_effect = (
+            lambda *args, **kwargs: calls.append("create_mm_receiver_cache")
+        )
+        worker_base.WorkerWrapperBase(rpc_rank=0).init_worker(
+            [{"vllm_config": vllm_config, "shared_worker_lock": MagicMock()}]
+        )
+
+
+def test_init_worker_pulls_runai_files_before_the_directory_is_read():
+    """The pull must run before the mm receiver cache reads the directory."""
+    calls: list[str] = []
+    _run_init_worker(_init_worker_config(calls), calls)
+
+    assert calls == [
+        "pull_runai_files",
+        "create_mm_receiver_cache",
+        "construct_worker",
+    ]
+
+
+def test_init_worker_pulls_runai_files_for_the_draft_model():
+    """A distinct speculative draft config must be pulled as well."""
+    calls: list[str] = []
+    vllm_config = _init_worker_config(calls)
+    draft_config = MagicMock()
+    draft_config.maybe_pull_model_files_for_runai_worker.side_effect = (
+        lambda: calls.append("pull_draft_runai_files")
+    )
+    vllm_config.speculative_config = MagicMock(draft_model_config=draft_config)
+
+    _run_init_worker(vllm_config, calls)
+
+    assert calls.count("pull_runai_files") == 1
+    assert calls.count("pull_draft_runai_files") == 1
+
+
+def test_init_worker_pulls_once_when_the_draft_reuses_the_target_config():
+    """`draft_model_config` is often the target config itself; pull it once."""
+    calls: list[str] = []
+    vllm_config = _init_worker_config(calls)
+    vllm_config.speculative_config = MagicMock(
+        draft_model_config=vllm_config.model_config
+    )
+
+    _run_init_worker(vllm_config, calls)
+
+    assert calls.count("pull_runai_files") == 1
 
 
 @pytest.mark.parametrize(

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
+import shutil
 import warnings
 from collections.abc import Callable
 from dataclasses import InitVar, field
@@ -1097,6 +1099,76 @@ class ModelConfig:
                 ignore_pattern=["*.pt", "*.safetensors", "*.bin", "*.tensors", "*.pth"],
             )
             self.tokenizer = object_storage_tokenizer.dir
+
+    def maybe_pull_model_files_for_runai_worker(self) -> None:
+        """Pull non-tensor model files from Object Storage onto the local node.
+
+        Weights are streamed separately. Safe to call on every rank.
+        """
+        # Only set once the driver has pulled the model from Object Storage.
+        model_uri = self.model_weights
+        if not model_uri or not is_runai_obj_uri(model_uri):
+            return
+
+        # avoid circular import
+        from vllm.model_executor.model_loader.weight_utils import get_lock
+
+        # A general solution for concurrent Object Storage downloads is
+        # https://github.com/vllm-project/vllm/pull/36696.
+        # The canonical path, so two spellings of one directory share one lock.
+        with get_lock(os.path.realpath(self.model)):
+            # Content, not existence: an empty pre-created directory is the
+            # broken state this repairs; a populated one means another rank
+            # already completed the pull. Unsafe to read outside the lock —
+            # a non-empty directory may be a pull still in progress.
+            if os.path.isdir(self.model) and os.listdir(self.model):
+                return
+
+            # Workers must not install process-global signal handlers.
+            object_storage_model = ObjectStorageModel(
+                url=model_uri, install_signal_handlers=False
+            )
+            if os.path.realpath(object_storage_model.dir) != os.path.realpath(
+                self.model
+            ):
+                raise RuntimeError(
+                    "Run:ai model streamer cache directory mismatch on this "
+                    "node: the config resolved on the driver points at "
+                    f"{self.model!r}, but this node derives "
+                    f"{object_storage_model.dir!r} from the model URI. This "
+                    "usually means VLLM_ASSETS_CACHE (or XDG_CACHE_HOME / "
+                    "HOME) differs between the driver and this node; make it "
+                    "consistent across all nodes."
+                )
+            logger.info(
+                "Pulling non-tensor model files to %s on this node.", self.model
+            )
+            pull_succeeded = False
+            try:
+                object_storage_model.pull_files(
+                    model_uri, allow_pattern=["*.model", "*.py", "*.json"]
+                )
+                # Shared tokenizer: the driver rewrote both `model` and
+                # `tokenizer` to this directory, so pull the rest of the
+                # non-weight files it will need. A separate tokenizer is
+                # read from its own path and needs nothing more here.
+                if self.tokenizer == self.model:
+                    object_storage_model.pull_files(
+                        model_uri,
+                        ignore_pattern=[
+                            "*.pt",
+                            "*.safetensors",
+                            "*.bin",
+                            "*.tensors",
+                            "*.pth",
+                        ],
+                    )
+                pull_succeeded = True
+            finally:
+                if not pull_succeeded:
+                    # A partial pull must not survive: the in-lock check
+                    # would otherwise trust it on the next attempt.
+                    shutil.rmtree(object_storage_model.dir, ignore_errors=True)
 
     def _get_encoder_config(self) -> dict[str, Any] | None:
         return get_sentence_transformer_tokenizer_config(self.model, self.revision)

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
+import shutil
 import warnings
 from collections.abc import Callable
 from dataclasses import InitVar, field
@@ -1008,6 +1010,76 @@ class ModelConfig:
                 ignore_pattern=["*.pt", "*.safetensors", "*.bin", "*.tensors", "*.pth"],
             )
             self.tokenizer = object_storage_tokenizer.dir
+
+    def maybe_pull_model_files_for_runai_worker(self) -> None:
+        """Pull non-tensor model files from Object Storage onto the local node.
+
+        Weights are streamed separately. Safe to call on every rank.
+        """
+        # Only set once the driver has pulled the model from Object Storage.
+        model_uri = self.model_weights
+        if not model_uri or not is_runai_obj_uri(model_uri):
+            return
+
+        # avoid circular import
+        from vllm.model_executor.model_loader.weight_utils import get_lock
+
+        # A general solution for concurrent Object Storage downloads is
+        # https://github.com/vllm-project/vllm/pull/36696.
+        # The canonical path, so two spellings of one directory share one lock.
+        with get_lock(os.path.realpath(self.model)):
+            # Content, not existence: an empty pre-created directory is the
+            # broken state this repairs; a populated one means another rank
+            # already completed the pull. Unsafe to read outside the lock —
+            # a non-empty directory may be a pull still in progress.
+            if os.path.isdir(self.model) and os.listdir(self.model):
+                return
+
+            # Workers must not install process-global signal handlers.
+            object_storage_model = ObjectStorageModel(
+                url=model_uri, install_signal_handlers=False
+            )
+            if os.path.realpath(object_storage_model.dir) != os.path.realpath(
+                self.model
+            ):
+                raise RuntimeError(
+                    "Run:ai model streamer cache directory mismatch on this "
+                    "node: the config resolved on the driver points at "
+                    f"{self.model!r}, but this node derives "
+                    f"{object_storage_model.dir!r} from the model URI. This "
+                    "usually means VLLM_ASSETS_CACHE (or XDG_CACHE_HOME / "
+                    "HOME) differs between the driver and this node; make it "
+                    "consistent across all nodes."
+                )
+            logger.info(
+                "Pulling non-tensor model files to %s on this node.", self.model
+            )
+            pull_succeeded = False
+            try:
+                object_storage_model.pull_files(
+                    model_uri, allow_pattern=["*.model", "*.py", "*.json"]
+                )
+                # Shared tokenizer: the driver rewrote both `model` and
+                # `tokenizer` to this directory, so pull the rest of the
+                # non-weight files it will need. A separate tokenizer is
+                # read from its own path and needs nothing more here.
+                if self.tokenizer == self.model:
+                    object_storage_model.pull_files(
+                        model_uri,
+                        ignore_pattern=[
+                            "*.pt",
+                            "*.safetensors",
+                            "*.bin",
+                            "*.tensors",
+                            "*.pth",
+                        ],
+                    )
+                pull_succeeded = True
+            finally:
+                if not pull_succeeded:
+                    # A partial pull must not survive: the in-lock check
+                    # would otherwise trust it on the next attempt.
+                    shutil.rmtree(object_storage_model.dir, ignore_errors=True)
 
     def _get_encoder_config(self) -> dict[str, Any] | None:
         return get_sentence_transformer_tokenizer_config(self.model, self.revision)

--- a/vllm/transformers_utils/runai_utils.py
+++ b/vllm/transformers_utils/runai_utils.py
@@ -53,8 +53,8 @@ class ObjectStorageModel:
         pull_files(): Pull model from object storage to the temporary directory.
     """
 
-    def __init__(self, url: str) -> None:
-        if envs.VLLM_ASSETS_CACHE_MODEL_CLEAN:
+    def __init__(self, url: str, install_signal_handlers: bool = True) -> None:
+        if envs.VLLM_ASSETS_CACHE_MODEL_CLEAN and install_signal_handlers:
             for sig in (signal.SIGINT, signal.SIGTERM):
                 existing_handler = signal.getsignal(sig)
                 signal.signal(sig, self._close_by_signal(existing_handler))

--- a/vllm/v1/worker/worker_base.py
+++ b/vllm/v1/worker/worker_base.py
@@ -246,6 +246,21 @@ class WorkerWrapperBase:
 
         load_general_plugins()
 
+        # Only the config-building process pulled non-tensor model files from
+        # Object Storage; pull them here before anything reads the model dir.
+        model_configs = [vllm_config.model_config]
+        spec_config = vllm_config.speculative_config
+        if spec_config is not None:
+            draft_config = spec_config.draft_model_config
+            if (
+                draft_config is not None
+                and draft_config is not vllm_config.model_config
+            ):
+                model_configs.append(draft_config)
+
+        for model_config in model_configs:
+            model_config.maybe_pull_model_files_for_runai_worker()
+
         parallel_config = vllm_config.parallel_config
         if isinstance(parallel_config.worker_cls, str):
             worker_class: type[WorkerBase] = resolve_obj_by_qualname(


### PR DESCRIPTION
﻿## Purpose

With `--load-format runai_streamer` and a model hosted in object storage (`s3://`, `gs://`, `az://`), a multi-node deployment crashes on every node except the one that built the config, because the small non-tensor model files were only ever downloaded there.

Closes #50616

## Root cause

`ModelConfig.__post_init__` calls `maybe_pull_model_tokenizer_for_runai`, which pulls the non-tensor files (HF config, tokenizer, `*.model`, and `*.py` for `trust_remote_code`) into a node-local directory and then rewrites `self.model` to point at it, keeping the original URI in `self.model_weights`:

https://github.com/vllm-project/vllm/blob/main/vllm/config/model.py#L983-L1000

That happens exactly once, in the process that constructs the `ModelConfig`. The config is then serialized and shipped to the workers. The local directory name is `sha256(url)[:8]`, so it is identical on every node — but on a peer node nothing ever downloaded into it. Weights are unaffected: each rank streams them straight from `model_weights`.

The result is that any worker-side consumer of `model_config.model` on a peer node reads an empty directory. Multimodal processors and `trust_remote_code` tokenizers are the ones that surface it.

Single-node deployments are unaffected, since every rank shares the directory the driver populated.

Note that `maybe_pull_model_tokenizer_for_runai` cannot simply be re-run on the worker: its first statement is `if self.model_weights: return`, and `model_weights` is always set by the time the config reaches a worker, so it would silently no-op. This PR therefore adds a separate method rather than reusing that one, and there is a regression test pinning exactly that.

## Changes

- `ModelConfig.maybe_pull_model_files_for_runai_worker()` — re-pulls the non-tensor files on the local node, mirroring the driver's `pull_files` calls for the model URI in both tokenizer configurations, and never touches weights: the `allow_pattern` pull always, and the driver's full non-weight `ignore_pattern` pull only when the tokenizer shares the model directory. A separate tokenizer is read from its own path and needs nothing more from the model directory, so within one configuration every node materializes the same file set. Both patterns are shared verbatim with the driver; widening either is a change for both sides and out of scope here. Because every node derives the same directory from the URI, it only fills in missing files; it does not rewrite any configured path.
- `WorkerWrapperBase.init_worker()` calls it once per rank, for the target `ModelConfig` and for `speculative_config.draft_model_config` when that is a distinct config. A draft model given as its own `s3://` URI has its own directory and the same problem.
- `ObjectStorageModel.__init__` gains an `install_signal_handlers: bool = True` parameter, and the worker-side pull passes `False`. Signal handlers are process-global and may only be installed from the main thread; worker processes are neither the right owner of them nor guaranteed to be on the main thread. The default keeps the driver-side behavior exactly as it was.
- If the directory this node derives from the URI differs from the one the driver resolved (heterogeneous `VLLM_ASSETS_CACHE` across nodes), the method raises a `RuntimeError` naming both paths and the variable to fix, instead of downloading into a directory nothing would read. The comparison is on `os.path.realpath`, so a symlink alias of one physical directory is not a mismatch, and the lock is keyed on the canonical path for the same reason. The guard runs only when a pull is needed: a directory already populated at the configured path is served as-is — the same trust the in-lock check extends on any node, with wrong or stale contents covered by the cache-trust limitation below. In the only state where the guard fires, the configured path holds no files on this node, so that configuration cannot have worked; the guard converts an obscure downstream failure into an actionable one rather than removing anything that works today.

The method returns immediately unless `model_weights` holds an object-storage URI, so non-runai deployments pay one attribute read and one string check. The deferred `weight_utils` import sits after that guard so it is never paid on the normal path.

## Why `WorkerWrapperBase.init_worker`

- It is platform-agnostic, so one call site covers GPU / TPU / XPU / CPU instead of patching each platform's worker.
- Every in-tree executor reaches it: `UniProcExecutor` and `ExecutorWithExternalLauncher` (`uniproc_executor.py`), `MultiprocExecutor` (`multiproc_executor.py`), `RayDistributedExecutor` and `RayExecutorV2` (both via `collective_rpc("init_worker")`). `init_worker` is a real attribute on the wrapper, so `__getattr__` delegation to the concrete worker never shadows it.
- It runs before anything in the worker process reads the model directory. In particular it dominates `MULTIMODAL_REGISTRY.worker_receiver_cache_from_config(...)`, which is called later in the same `init_worker` body and reaches `cached_tokenizer_from_config` via `supports_multimodal_inputs` — that path only catches `ValueError`, so an `OSError` from an empty directory would kill the worker. `init_device` would also work today (that branch needs a non-`None` `shared_worker_lock`, which the Ray executors do not pass), but `init_worker` dominates it at no extra cost.
- The call is placed after `load_general_plugins()` so plugin-provided object-storage credentials are in place before the pull.

## Concurrency and failure handling

All ranks on a node target the same directory, so the pull is wrapped in the existing `get_lock` filelock from `weight_utils`, keyed on the resolved destination directory rather than the remote URI. Every cache decision happens inside the lock: `pull_files` writes file by file, so a non-empty directory observed from outside the lock may be a pull still in progress on another rank, and trusting it would let a rank proceed into a half-populated directory — the very failure this PR fixes. Observed *under* the lock, a populated directory means the rank holding the lock completed its pull. The check tests that the directory has *content*, not that it exists, because `ObjectStorageModel.__init__` creates it eagerly with `exist_ok=True` — an existing empty directory is precisely the broken state being repaired. The trade-off is one local flock per rank on the cache-hit path; `filelock` is fcntl-based, so the kernel releases it on process death (SIGKILL included) and a stale lock cannot wedge later starts. A microsecond-scale flock in exchange for a pull-length race window.

Because of that, a pull that fails partway would otherwise turn a transient error into a permanently poisoned cache entry: every later start would skip the half-populated directory and fail somewhere unrelated, such as a missing tokenizer file. The `pull_files` calls are therefore wrapped in a `try`/`finally` that removes the directory on any non-successful exit before the exception propagates, so the next attempt starts clean. `finally` with a success flag rather than `except Exception` because the most common interruption of a slow download is a user's Ctrl-C, and `KeyboardInterrupt` does not derive from `Exception`. This failure handling is only needed because the new cache check exists; the driver-side path has no such check and simply re-downloads.

This is deliberately just a reuse of the existing helper at one call site. A general solution for protecting object-storage downloads across processes is #36696, and this PR does not attempt to overlap with it — in particular it adds no completion marker or transactional download; completion semantics beyond non-emptiness are that PR's ground. Once #36696 lands, the manual lock, the in-lock check, and the failure cleanup here should be removed in favor of that protocol, so the two never coexist.

## Known limitations

- A tokenizer supplied as a *separate* object-storage URI is not repaired. The driver pulls it into a second directory but does not record its URI in any field, so a worker cannot reconstruct it without adding new state to `ModelConfig`. The common case where `--tokenizer` defaults to `--model` is fully covered, since both point at the same directory. Widening this would mean changing `__post_init__` and the existing driver-side method, which felt out of proportion for a bugfix. Tracked separately in a follow-up issue.
- Relatedly, `--model` as an ordinary HF path combined with `--tokenizer` as an `s3://` URI leaves `model_weights` unset, so this method returns immediately and does nothing. That combination is not covered here for the same reason.
- The failure cleanup cannot cover exits that never unwind the stack: SIGKILL, SIGTERM under its default disposition, a node crash, a container hard-stop, or `shutil.rmtree` itself failing (`ignore_errors=True` — as it silently does when the final path component is itself a symlink, which `rmtree` refuses to remove). Any of these can leave a partially populated directory that the in-lock check mistakes for a usable cache on the next start. Closing that window needs a completion marker or a transactional download, which is exactly the ground #36696 covers. More generally, any pre-existing content at the configured path — left by an earlier deployment or an earlier role of this node — is trusted the same way; validating or refreshing cached content is the completion-protocol ground of #36696.
- The same applies on the driver side: if the node acting as driver is killed mid-pull and comes back as a worker-only node in the next deployment, the leftovers from its driver-side pull (which has no cleanup) hit the previous point, closed by the same completion semantics.
- A directory populated under a separate-tokenizer configuration — by the driver or by a worker, which make the same calls — contains only the `*.model`/`*.py`/`*.json` subset. A later shared-tokenizer run on a node holding such a directory trusts any non-empty directory and can miss files only the full non-weight pull fetches (`merges.txt`, `vocab.txt`, chat templates). The driver self-heals by re-downloading unconditionally on every start; a worker cannot tell that state from a completed pull, because "the extra files are missing" and "the repository never had them" look identical. Detecting it takes completion semantics richer than non-emptiness — #36696's marker is the natural carrier, though as proposed it certifies that a download finished, not which file set it covered.
- With `VLLM_ASSETS_CACHE_MODEL_CLEAN=1`, directories pulled by workers are not removed on process exit, since workers do not install the cleanup signal handlers. Cache lifecycle management across processes is likewise #36696's territory.

## Test plan

No multi-node hardware was available to me, so the fix is covered by unit tests in `tests/test_config.py`, next to the existing `runai` config tests and reusing their `MockConfig` helper. They need no network, GPU, or object storage.

- `test_runai_worker_pulls_files_when_node_local_dir_is_empty` — the core regression: a config whose `model` points at an empty node-local directory (a peer node's state) pulls, using the weights URI and the driver's `allow_pattern`, under a lock keyed on the destination — and the cache directory survives the successful pull.
- `test_runai_worker_pull_matches_driver_pull` — runs the driver's method and the worker's method against the same mock in the shared-tokenizer configuration and asserts the `pull_files` call lists are identical, so the two cannot drift apart.
- `test_runai_worker_pull_matches_driver_pull_with_separate_tokenizer` — the same parity in the separate-tokenizer configuration: the worker's calls equal the driver's calls for the model URI, which is the `allow_pattern` pull only.
- `test_runai_worker_does_not_disturb_an_unrepairable_tokenizer` — a separately-pulled tokenizer cannot be repaired here, so its path is left as it was rather than repointed, and the model directory gets the driver's separate-tokenizer treatment: the `allow_pattern` pull only.
- `test_runai_worker_guard_accepts_a_symlinked_cache_directory` — two paths resolving to the same physical directory pass the mismatch guard, since the comparison is on `os.path.realpath`.
- `test_runai_worker_waits_for_lock_before_trusting_existing_files` — a populated directory is honored only after acquiring the lock, without constructing the cache helper or pulling.
- `test_runai_worker_rechecks_after_acquiring_the_lock` — a rank that waited for the lock does not repeat the pull the winner completed.
- `test_runai_worker_clears_the_directory_when_the_pull_fails` — parametrized over `OSError` and `KeyboardInterrupt`: either exit removes the partial directory and still propagates.
- `test_runai_worker_retries_after_a_failed_pull` — the attempt after a failure downloads again instead of trusting the leftovers, and the cache directory survives the successful retry.
- `test_runai_worker_fails_fast_on_a_cache_directory_mismatch` — a node deriving a different directory raises the actionable error without pulling and without removing anything.
- `test_runai_worker_opts_out_of_signal_handlers` and `test_runai_object_storage_model_signal_handler_opt_out` — the worker passes `install_signal_handlers=False`, and the parameter actually suppresses registration while the default preserves it.
- `test_runai_worker_noop_without_object_storage_weights` — parametrized over `None` / `""` / a local path / an HF repo id; asserts `ObjectStorageModel` is never even constructed.
- `test_runai_worker_not_short_circuited_by_driver_guard` — pins the early-return trap described above: the driver's method no-ops on a worker while the new one pulls.
- `test_init_worker_pulls_runai_files_before_the_directory_is_read` — asserts the call order inside `init_worker`: the pull happens before the multimodal receiver cache is built and before the worker is constructed.
- `test_init_worker_pulls_runai_files_for_the_draft_model` and `test_init_worker_pulls_once_when_the_draft_reuses_the_target_config` — a distinct draft config is pulled too, and a draft that *is* the target config is pulled once.

Running the full `tests/test_config.py` before and after produces an identical set of results, so nothing else in the file is affected.


