### PR TITLE
[Kernel][Helion] Reset mutated inputs between benchmark repetitions

### DIFF
--- a/scripts/benchmark_helion_kernels.py
+++ b/scripts/benchmark_helion_kernels.py
@@ -48,6 +48,7 @@ Usage:
 import argparse
 import copy
 import gc
+import inspect
 import json
 import statistics
 import sys
@@ -299,6 +300,27 @@ def _reduce(times: list[float], return_mode: str) -> float:
     return _REDUCERS[return_mode](times)
 
 
+def _make_mutated_arg_reset(kernel: Any, inputs: tuple[Any, ...]) -> Callable[[], None]:
+    """Snapshot declared mutable tensor arguments and return a reset hook."""
+    parameter_names = tuple(inspect.signature(kernel.raw_kernel_func).parameters)
+    parameter_indices = {name: index for index, name in enumerate(parameter_names)}
+    snapshots: list[tuple[torch.Tensor, torch.Tensor]] = []
+
+    for name in kernel._mutates_args or ():
+        index = parameter_indices[name]
+        value = inputs[index]
+        if isinstance(value, torch.Tensor):
+            snapshots.append(
+                (value, value.detach().clone(memory_format=torch.preserve_format))
+            )
+
+    def reset_inputs() -> None:
+        for value, snapshot in snapshots:
+            value.copy_(snapshot)
+
+    return reset_inputs
+
+
 def _assert_close(actual: object, expected: object, atol: float, rtol: float) -> None:
     """Compare pytrees, allowing the one-ULP FP8 variance used by kernel tests."""
     actual_flat, actual_spec = tree_flatten(actual)
@@ -411,15 +433,67 @@ def check_kernel_correctness(
     return results
 
 
+def do_bench_l2_clear_with_reset(
+    fn: Callable,
+    reset_inputs: Callable[[], None],
+    warmup: int = 25,
+    rep: int = 100,
+    return_mode: str = "mean",
+) -> float:
+    """Benchmark ``fn`` with mutable inputs reset outside the timed interval."""
+    driver = triton.runtime.driver.active
+    device_interface = driver.get_device_interface()
+    cache = driver.get_empty_cache_for_benchmark()
+
+    reset_inputs()
+    driver.clear_cache(cache)
+    start_event = device_interface.Event(enable_timing=True)
+    end_event = device_interface.Event(enable_timing=True)
+    start_event.record()
+    fn()
+    end_event.record()
+    device_interface.synchronize()
+    estimate_ms = start_event.elapsed_time(end_event)
+
+    duration = estimate_ms if estimate_ms > 0 else 1e-3
+    n_warmup = max(1, int(warmup / duration))
+    n_repeat = max(1, int(rep / duration))
+
+    for _ in range(n_warmup):
+        reset_inputs()
+        driver.clear_cache(cache)
+        fn()
+
+    start_events = [device_interface.Event(enable_timing=True) for _ in range(n_repeat)]
+    end_events = [device_interface.Event(enable_timing=True) for _ in range(n_repeat)]
+    for start_event, end_event in zip(start_events, end_events, strict=True):
+        reset_inputs()
+        driver.clear_cache(cache)
+        start_event.record()
+        fn()
+        end_event.record()
+
+    device_interface.synchronize()
+    times = [
+        start.elapsed_time(end)
+        for start, end in zip(start_events, end_events, strict=True)
+    ]
+    return _reduce(times, return_mode)
+
+
 def do_bench_cudagraph_l2_clear(
-    fn: Callable, rep: int = 100, return_mode: str = "mean"
+    fn: Callable,
+    reset_inputs: Callable[[], None],
+    rep: int = 100,
+    return_mode: str = "mean",
 ) -> float:
     """CUDA-graph benchmark that flushes the L2 cache before every call.
 
     ``triton.testing.do_bench_cudagraph`` captures back-to-back kernel launches
     with a warm L2 cache, which over-estimates performance for memory-bound
-    kernels. This clears L2 (via triton's benchmark cache buffer) before each
-    call and subtracts the isolated cache-clear cost from the measured time.
+    kernels. This restores mutable inputs and clears L2 (via triton's benchmark
+    cache buffer) before each call, then subtracts those setup costs from the
+    measured time.
 
     Adapted from tritonbench's ``_do_bench_cudagraph_with_cache_clear`` using
     only triton/torch primitives so no extra dependency is introduced.
@@ -429,6 +503,7 @@ def do_bench_cudagraph_l2_clear(
 
     s = torch.Stream()
     with s:
+        reset_inputs()
         clear_cache()
         fn()
 
@@ -436,6 +511,7 @@ def do_bench_cudagraph_l2_clear(
         end_event = torch.Event(enable_timing=True)
         start_event.record()
         for _ in range(5):
+            reset_inputs()
             clear_cache()
             fn()
         end_event.record()
@@ -446,12 +522,14 @@ def do_bench_cudagraph_l2_clear(
         graph = torch.cuda.CUDAGraph()
         with torch.cuda.graph(graph):
             for _ in range(n_repeat):
+                reset_inputs()
                 clear_cache()
                 fn()
 
         clear_graph = torch.cuda.CUDAGraph()
         with torch.cuda.graph(clear_graph):
             for _ in range(n_repeat):
+                reset_inputs()
                 clear_cache()
         torch.accelerator.synchronize()
 
@@ -488,9 +566,9 @@ def benchmark(
     return_mode: str,
 ) -> list[Row]:
     kernel = get_kernel_by_name(kernel_name)
-    # do_bench already flushes L2 per call; do_bench_cudagraph does not, so use
-    # the cache-clearing variant to avoid warm-L2 over-estimates.
-    benchmark_fn = do_bench_cudagraph_l2_clear if cudagraph else triton.testing.do_bench
+    benchmark_fn = (
+        do_bench_cudagraph_l2_clear if cudagraph else do_bench_l2_clear_with_reset
+    )
 
     inputs_dict = kernel.get_inputs()
     rows: list[Row] = []
@@ -504,14 +582,18 @@ def benchmark(
         # Kernels may mutate their inputs in place; give each side its own copy.
         kernel_inputs = copy.deepcopy(inputs)
         baseline_inputs = copy.deepcopy(inputs)
+        reset_kernel_inputs = _make_mutated_arg_reset(kernel, kernel_inputs)
+        reset_baseline_inputs = _make_mutated_arg_reset(kernel, baseline_inputs)
 
         kernel_latency = benchmark_fn(
             lambda kernel_inputs=kernel_inputs: kernel(*kernel_inputs),
+            reset_inputs=reset_kernel_inputs,
             rep=repeat,
             return_mode=return_mode,
         )
         baseline_latency = benchmark_fn(
             lambda baseline_inputs=baseline_inputs: baseline_fn(*baseline_inputs),
+            reset_inputs=reset_baseline_inputs,
             rep=repeat,
             return_mode=return_mode,
         )

--- a/tests/kernels/helion/test_benchmark_script.py
+++ b/tests/kernels/helion/test_benchmark_script.py
@@ -12,10 +12,17 @@ if not has_helion():
 from scripts import benchmark_helion_kernels
 
 check_correctness = benchmark_helion_kernels.check_correctness
+make_mutated_arg_reset = benchmark_helion_kernels._make_mutated_arg_reset
+
+
+def _raw_kernel(output: torch.Tensor, input: torch.Tensor) -> torch.Tensor:
+    return input * 2
 
 
 class _FakeKernel:
     helion_settings = None
+    _mutates_args = ["output"]
+    raw_kernel_func = staticmethod(_raw_kernel)
 
     def __init__(self, offset: float):
         self.calls = 0
@@ -71,6 +78,20 @@ def test_check_correctness_reports_return_value_mismatch():
 
     with pytest.raises(AssertionError, match="Numerics check failed for case bad"):
         check_correctness(kernel, baseline, inputs, "bad")
+
+
+def test_make_mutated_arg_reset_restores_only_declared_tensor_arguments():
+    kernel = _FakeKernel(offset=1)
+    output = torch.zeros(4)
+    input = torch.arange(4)
+    reset_inputs = make_mutated_arg_reset(kernel, (output, input))
+
+    output.fill_(2)
+    input.fill_(3)
+    reset_inputs()
+
+    torch.testing.assert_close(output, torch.zeros(4))
+    torch.testing.assert_close(input, torch.full((4,), 3))
 
 
 def test_log_versions(monkeypatch):


### PR DESCRIPTION
## Summary

- Snapshot tensor arguments declared in each Helion kernel's `mutates_args` metadata.
- Restore those arguments before every warmup and measured launch so each repetition sees the same inputs.
- Exclude reset and L2-cache-clear setup from event timings, and subtract the equivalent setup graph from CUDA-graph timings.

## Dependency

This PR is stacked on #48968. The reset-specific change is commit `a25ead35fe`; the branch will be rebased onto `main` after #48968 merges. Do not merge this PR before #48968.

## Duplicate check

Searched open `vllm-project/vllm` PRs for `Helion benchmark reset input`, `benchmark_helion_kernels mutated inputs`, `CUDA graph input reset benchmark`, and `Helion input mutation benchmark`. No PR addressing this change was found.

## Performance

Measured on GB200 with the CUDA baseline and CUDA graphs. Each result is the median of five trial means, with reset/no-reset and CUDA/Helion execution order alternated between trials. Both variants use the same timing implementation; the no-reset control passes a no-op callback.

Representative shapes use `num_tokens=128` and `group_size=128`; hidden size is 4096 for per-token quant and RMSNorm, and intermediate size is 6144 for SiLU.

| Kernel | CUDA, no reset (ms) | CUDA, reset (ms) | Helion, no reset (ms) | Helion, reset (ms) | Speedup, no reset | Speedup, reset | Delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `per_token_group_fp8_quant` | 0.003845 | 0.003886 | 0.002285 | 0.002305 | 1.683x | 1.686x | +0.2% |
| `silu_and_mul_per_block_quant` | 0.006130 | 0.006078 | 0.002813 | 0.002702 | 2.179x | 2.249x | +3.2% |
| `rms_norm_per_block_quant` | 0.006803 | 0.006998 | 0.003712 | 0.003634 | 1.833x | 1.926x | +5.1% |

The output-only per-token kernel is effectively unchanged. RMSNorm changes because its residual is read and updated in place: without reset, repetitions accumulate the residual and benchmark progressively different inputs. The reset version consistently benchmarks the original input state. Differences for these microsecond-scale kernels also include normal run-to-run measurement variance.

## Testing

- `uv run --python /home/shangdiy/.conda/envs/vllm-release/bin/python --no-project python -m pytest tests/kernels/helion/test_benchmark_script.py -q`: 5 passed.
- `uvx ruff@0.14.0 check scripts/benchmark_helion_kernels.py tests/kernels/helion/test_benchmark_script.py`: passed.
- `uvx ruff@0.14.0 format --check scripts/benchmark_helion_kernels.py tests/kernels/helion/test_benchmark_script.py`: passed.
- All commit-time pre-commit hooks passed, including ruff, mypy, typos, SPDX, sign-off, and repository policy hooks.
- GB200 RMSNorm integration with both event and CUDA-graph timing verified that Helion and CUDA leave the residual at exactly one fused-add update after repeated benchmarking; all measured latencies were positive.

Model evaluation is not applicable because this changes a standalone developer benchmark and does not affect serving or model outputs.

AI assistance was used to implement, test, benchmark, and draft this change. The human submitter must review every changed line and the reported results before marking this PR ready.
