### PR TITLE
[ROCm][Perf] Select wvSplitK only in measured-profitable gfx950 regions

### DIFF
--- a/benchmarks/kernels/benchmark_rocm_wvsplitk.py
+++ b/benchmarks/kernels/benchmark_rocm_wvsplitk.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Compare ROCm wvSplitK with the unquantized GEMM fallbacks on Kimi-K3."""
+
+import argparse
+import math
+import statistics
+from collections.abc import Callable
+from functools import partial
+
+import torch
+
+from vllm import _custom_ops as ops
+from vllm.platforms import current_platform
+from vllm.platforms.rocm import on_gfx950
+from vllm.utils.platform_utils import num_compute_units
+
+KIMI_K3_TP8_SHAPES = (
+    (163840, 256),
+    (20480, 7168),
+    (8448, 7168),
+    (7168, 7168),
+    (7168, 1536),
+    (1536, 7168),
+    (3584, 7168),
+    (2112, 7168),
+)
+TOKEN_COUNTS = range(1, 6)
+BOUNDARY_SHAPES = (
+    *((m, 7168, (4, 5)) for m in (7168, 8191, 8192, 8193, 8448)),
+    *((m, 256, TOKEN_COUNTS) for m in (20480, 32768, 65536, 98304, 131072, 163840)),
+)
+LLMM1_BOUNDARY_SHAPES = tuple(
+    (m, 256, (1,))
+    for m in (32768, 40960, 49152, 57344, 61440, 65536, 98304, 131072, 163840)
+)
+
+
+def _device_times_us(
+    operations: tuple[tuple[str, Callable[[], object]], ...],
+    iters: int,
+    repeats: int,
+) -> dict[str, float]:
+    if iters < 1 or repeats < 1:
+        raise ValueError("iters and repeats must be positive")
+
+    for warmup in range(20):
+        ordered = operations if warmup % 2 == 0 else operations[::-1]
+        for _, fn in ordered:
+            fn()
+    torch.accelerator.synchronize()
+
+    samples: dict[str, list[float]] = {name: [] for name, _ in operations}
+    for repeat in range(repeats):
+        ordered = operations if repeat % 2 == 0 else operations[::-1]
+        for name, fn in ordered:
+            start = torch.Event(enable_timing=True)
+            end = torch.Event(enable_timing=True)
+            start.record()
+            for _ in range(iters):
+                fn()
+            end.record()
+            torch.accelerator.synchronize()
+            samples[name].append(start.elapsed_time(end) * 1000 / iters)
+    return {name: statistics.median(values) for name, values in samples.items()}
+
+
+@torch.inference_mode()
+def main(iters: int, repeats: int, shape_set: str) -> None:
+    if iters < 1 or repeats < 1:
+        raise ValueError("iters and repeats must be positive")
+    if not torch.accelerator.is_available() or not current_platform.is_rocm():
+        raise RuntimeError("this benchmark requires a ROCm GPU")
+
+    try:
+        from aiter.tuned_gemm import tgemm
+    except ImportError:
+        tgemm = None
+
+    device = torch.device("cuda:0")
+    dtype = torch.bfloat16
+    if not on_gfx950():
+        raise RuntimeError("this benchmark requires gfx950")
+    cu_count = num_compute_units(device.index or 0)
+    print(
+        f"# device={current_platform.get_device_name()} gfx=gfx950 "
+        f"cu_count={cu_count} dtype={dtype} "
+        f"iters={iters} repeats={repeats}"
+    )
+    print(
+        f"{'M':>7} {'K':>6} {'N':>2} {'wvSplitK':>10} {'LLMM1':>10} "
+        f"{'tgemm':>10} {'torch':>10} {'ll/wv':>7} {'tg/wv':>7} "
+        f"{'pt/wv':>7} {'max_err':>9}"
+    )
+    print(
+        "# speedup columns are fallback latency / wvSplitK latency; >1 favors wvSplitK"
+    )
+
+    if shape_set == "kimi-k3":
+        shapes = ((m, k, TOKEN_COUNTS) for m, k in KIMI_K3_TP8_SHAPES)
+    elif shape_set == "llmm1-boundary":
+        shapes = iter(LLMM1_BOUNDARY_SHAPES)
+    else:
+        shapes = iter(BOUNDARY_SHAPES)
+
+    for m, k, token_counts in shapes:
+        scale = math.sqrt(2 / k)
+        weight = torch.randn(m, k, dtype=dtype, device=device) * scale
+        for n in token_counts:
+            x = torch.randn(n, k, dtype=dtype, device=device) * scale
+            ref = torch.nn.functional.linear(x, weight)
+            actual = ops.wvSplitK(weight, x, cu_count, None)
+            atol = torch.finfo(dtype).eps * math.sqrt(k)
+            torch.testing.assert_close(actual, ref, atol=atol, rtol=1e-2)
+            max_error = (actual - ref).abs().max().item()
+
+            operations: list[tuple[str, Callable[[], object]]] = [
+                ("wvsplitk", partial(ops.wvSplitK, weight, x, cu_count, None)),
+                ("torch", partial(torch.nn.functional.linear, x, weight)),
+            ]
+            if tgemm is not None:
+                aiter_actual = tgemm.mm(x, weight, None)
+                torch.testing.assert_close(aiter_actual, ref, atol=atol, rtol=1e-2)
+                operations.append(("tgemm", partial(tgemm.mm, x, weight, None)))
+            if n == 1 and m % 4 == 0 and k <= 8192:
+                llmm1_actual = ops.LLMM1(weight, x, 4)
+                torch.testing.assert_close(llmm1_actual, ref, atol=atol, rtol=1e-2)
+                operations.append(("llmm1", partial(ops.LLMM1, weight, x, 4)))
+
+            timings = _device_times_us(tuple(operations), iters, repeats)
+            wvsplitk = timings["wvsplitk"]
+            torch_gemm = timings["torch"]
+            aiter_gemm = timings.get("tgemm", float("nan"))
+            llmm1 = timings.get("llmm1", float("nan"))
+            print(
+                f"{m:>7} {k:>6} {n:>2} {wvsplitk:>10.2f} {llmm1:>10.2f} "
+                f"{aiter_gemm:>10.2f} {torch_gemm:>10.2f} "
+                f"{llmm1 / wvsplitk:>7.2f} {aiter_gemm / wvsplitk:>7.2f} "
+                f"{torch_gemm / wvsplitk:>7.2f} {max_error:>9.4f}"
+            )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--iters", type=int, default=200)
+    parser.add_argument("--repeats", type=int, default=5)
+    parser.add_argument(
+        "--shape-set",
+        choices=("kimi-k3", "boundary", "llmm1-boundary"),
+        default="kimi-k3",
+    )
+    args = parser.parse_args()
+    main(args.iters, args.repeats, args.shape_set)

--- a/tests/model_executor/layers/test_rocm_unquantized_gemm.py
+++ b/tests/model_executor/layers/test_rocm_unquantized_gemm.py
@@ -17,6 +17,55 @@ if current_platform.is_cuda():
 from vllm.model_executor.layers import utils
 
 
+@pytest.mark.parametrize(
+    ("m", "n", "k", "has_bias", "expected"),
+    [
+        (8192, 5, 7168, False, True),
+        (8193, 5, 7168, False, False),
+        (8193, 4, 7168, False, True),
+        (65536, 3, 256, False, True),
+        (98304, 3, 256, False, False),
+        (98304, 2, 256, False, True),
+        (65536, 1, 256, False, True),
+        (98304, 1, 256, False, False),
+        (98304, 1, 256, True, True),
+        (98305, 1, 256, False, True),
+        (131072, 2, 256, False, False),
+        (163840, 2, 512, False, True),
+    ],
+)
+def test_wvsplitk_gfx950_profitability_boundaries(m, n, k, has_bias, expected):
+    assert utils._use_wvsplitk_gfx950(m, n, k, has_bias=has_bias) is expected
+
+
+def test_rocm_unquantized_gemm_gfx950_n1_uses_llmm1(monkeypatch):
+    x = torch.empty(1, 256, dtype=torch.bfloat16)
+    weight = torch.empty(98304, 256, dtype=torch.bfloat16)
+
+    monkeypatch.setattr(utils, "use_aiter_triton_gemm", lambda *args: False)
+    monkeypatch.setattr(utils.envs, "VLLM_ROCM_USE_SKINNY_GEMM", True)
+    monkeypatch.setattr("vllm.platforms.rocm.on_gfx1x", lambda: False)
+    monkeypatch.setattr("vllm.platforms.rocm.on_gfx9", lambda: True)
+    monkeypatch.setattr("vllm.platforms.rocm.on_gfx950", lambda: True)
+    monkeypatch.setattr("vllm.platforms.rocm.on_gfx1250", lambda: False)
+
+    wvsplitk_mock = MagicMock()
+    monkeypatch.setattr(utils.ops, "wvSplitK", wvsplitk_mock)
+    llmm1_mock = MagicMock(return_value=torch.empty(1, 98304, dtype=torch.bfloat16))
+    monkeypatch.setattr(utils.ops, "LLMM1", llmm1_mock)
+
+    out = utils.rocm_unquantized_gemm_impl(x, weight, None)
+
+    wvsplitk_mock.assert_not_called()
+    llmm1_mock.assert_called_once()
+    call_weight, call_x, rows_per_block = llmm1_mock.call_args.args
+    assert call_weight is weight
+    assert call_x.data_ptr() == x.data_ptr()
+    assert call_x.shape == x.shape
+    assert rows_per_block == 4
+    assert out.shape == (1, 98304)
+
+
 def test_rocm_unquantized_gemm_gfx1x_wvsplitk_path(monkeypatch):
     x = torch.randn(1, 64, dtype=torch.float16)
     weight = torch.randn(128, 64, dtype=torch.float16)

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -184,11 +184,10 @@ def rocm_unquantized_gemm_impl(
 
     if use_skinny:
         x_view = x.reshape(-1, x.size(-1))
-        # wvSplitK has no cost model, and two shape regimes measured on gfx950
-        # lose to the fallback GEMM: n == 5 at large m (0.27x at m=20480
-        # k=7168) and tall-skinny m from n >= 2 (0.07x at m=163840 k=256).
-        wvsplitk_regresses = on_gfx950() and ((n >= 5 and m >= 8192) or (m >= 100000))
-        if m > 8 and 0 < n <= 5 and not wvsplitk_regresses:
+        wvsplitk_profitable = not on_gfx950() or _use_wvsplitk_gfx950(
+            m, n, k, has_bias=bias is not None
+        )
+        if m > 8 and 0 < n <= 5 and wvsplitk_profitable:
             cu_count = num_compute_units()
             out = ops.wvSplitK(weight, x_view, cu_count, bias)
             return out.reshape(*x.shape[:-1], weight.shape[0])
@@ -202,6 +201,14 @@ def rocm_unquantized_gemm_impl(
         return tgemm.mm(x, weight, bias)
 
     return torch.nn.functional.linear(x, weight, bias)
+
+
+def _use_wvsplitk_gfx950(m: int, n: int, k: int, *, has_bias: bool) -> bool:
+    # Boundaries measured by benchmark_rocm_wvsplitk.py on gfx950.
+    n5_cliff = n == 5 and m > 8192
+    llmm1_wins = n == 1 and k == 256 and m >= 98304 and m % 4 == 0 and not has_bias
+    tall_skinny = k == 256 and ((n >= 3 and m >= 98304) or (n == 2 and m >= 131072))
+    return not (n5_cliff or llmm1_wins or tall_skinny)
 
 
 def rocm_unquantized_gemm_fake(

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -184,7 +184,11 @@ def rocm_unquantized_gemm_impl(
 
     if use_skinny:
         x_view = x.reshape(-1, x.size(-1))
-        if m > 8 and 0 < n <= 5:
+        # wvSplitK has no cost model, and two shape regimes measured on gfx950
+        # lose to the fallback GEMM: n == 5 at large m (0.27x at m=20480
+        # k=7168) and tall-skinny m from n >= 2 (0.07x at m=163840 k=256).
+        wvsplitk_regresses = on_gfx950() and ((n >= 5 and m >= 8192) or (m >= 100000))
+        if m > 8 and 0 < n <= 5 and not wvsplitk_regresses:
             cu_count = num_compute_units()
             out = ops.wvSplitK(weight, x_view, cu_count, bias)
             return out.reshape(*x.shape[:-1], weight.shape[0])


### PR DESCRIPTION
## Purpose

`wvSplitK` has no profitability model on ROCm. On gfx950 it wins for most
small-token GEMMs, but loses to the existing fallback at four measured
boundaries:

- `N=5, M>8192`;
- bias-free `K=256, N=1, M>=98304`, where `LLMM1` is available;
- `K=256, N>=3, M>=98304`; and
- `K=256, N=2, M>=131072`.

This PR names that policy, keeps `wvSplitK` outside those regions, and adds
boundary tests plus a public benchmark. It replaces the draft's broad inline
threshold: `(8192,5,7168)` is 1.19x faster with `wvSplitK`, while
`(8193,5,7168)` is slower. Other architectures, NVIDIA, and GEMM paths outside
the existing skinny dispatch are unchanged.

## Test plan

Tested on one MI355X for the kernel sweep and eight for TP8, using the public
Kimi-K3 image and `moonshotai/Kimi-K3@9f62e4e9`. The command pins the PR head.

Focused test and benchmark:

```bash
IMAGE='vllm/vllm-openai-rocm:kimi-k3@sha256:5aa7e626ff73672f5ca7aae46754570488c23d33ca1ac90756a1d2d1a3fe099b'
docker run --rm --ipc host --shm-size 16g \
  --device /dev/kfd --device /dev/dri \
  --group-add video --group-add render --security-opt label=disable \
  -e HIP_VISIBLE_DEVICES=0 --entrypoint bash "$IMAGE" -lc '
set -euxo pipefail
git clone --filter=blob:none https://github.com/vllm-project/vllm.git /tmp/vllm
git -C /tmp/vllm fetch --no-tags origin pull/50636/head
git -C /tmp/vllm checkout --detach FETCH_HEAD
test "$(git -C /tmp/vllm rev-parse HEAD)" = 4a49191106a328d6676d9a3a65c6eb056c021578
cp -a /tmp/vllm/vllm/. /usr/local/lib/python3.12/dist-packages/vllm/
cp /tmp/vllm/tests/model_executor/layers/test_rocm_unquantized_gemm.py /tmp/test_gemm.py
cd /tmp
uv run --no-project --offline python -m pytest -q test_gemm.py
uv run --no-project --offline python \
  /tmp/vllm/benchmarks/kernels/benchmark_rocm_wvsplitk.py \
  --shape-set boundary --iters 200 --repeats 5
uv run --no-project --offline python \
  /tmp/vllm/benchmarks/kernels/benchmark_rocm_wvsplitk.py \
  --shape-set llmm1-boundary --iters 200 --repeats 9
'
```

Both TP8 arms used the same public image, #50619 FP8-KV stack, and AITER #4480
serving fixes. The control was vLLM `e3be8967`; the candidate added only this
PR. Exact composition manifests are retained in the campaign artifacts.

Server command for each arm:

```bash
ARM=control  # repeat with ARM=candidate
JIT_DIR=$(mktemp -d "/tmp/aiter-jit-${ARM}.XXXXXX")
AITER_JIT_DIR="$JIT_DIR" \
VLLM_ROCM_USE_AITER=1 \
VLLM_ROCM_USE_AITER_FP4BMM=1 \
AITER_SITUV2_A8W4=1 \
AITER_BF16_FP8_MOE_BOUND=0 \
VLLM_USE_BREAKABLE_CUDAGRAPH=0 \
VLLM_ROCM_USE_SKINNY_GEMM=1 \
vllm serve /model \
  --served-model-name moonshotai/Kimi-K3 \
  --tensor-parallel-size 8 --trust-remote-code --moe-backend auto \
  --gpu-memory-utilization 0.95 --mm-encoder-tp-mode data \
  --max-num-seqs 128 --max-num-batched-tokens 4096 \
  --max-model-len 1048576 --enable-prefix-caching \
  --kv-cache-dtype fp8 --reasoning-parser kimi_k3
```

Run one 8K/128 warmup followed by three fixed-seed 8K/1K measurements:

```bash
run_bench() {
  vllm bench serve --backend vllm --base-url http://127.0.0.1:8000 \
    --endpoint /v1/completions --model moonshotai/Kimi-K3 \
    --tokenizer /model --trust-remote-code --dataset-name random \
    --num-prompts 1 --random-input-len 8192 --random-output-len "$2" \
    --random-range-ratio 0 --ignore-eos --request-rate inf \
    --temperature 0 --seed "$1" \
    --percentile-metrics ttft,tpot,itl,e2el \
    --metric-percentiles 50,90,99
}
run_bench 0 128
for seed in 1 2 3; do run_bench "$seed" 1024; done
```

Single-request decode throughput is `1000 / mean_tpot_ms` for the TP8 replica.

## Test results

Focused dispatch tests: `16 passed`. All applicable file-scoped pre-commit
hooks passed.

Representative kernel results (fallback latency / `wvSplitK`; below 1 favors
the fallback):

| `(M,N,K)` | `wvSplitK` | fallback | relative |
|---|---:|---:|---:|
| `(8192,5,7168)` | 19.83 us | 23.58 us Torch | 1.19x |
| `(8193,5,7168)` | 27.36 us | 23.28 us Torch | 0.85x |
| `(98304,3,256)` | 19.49 us | 16.22 us AITER | 0.83x |
| `(131072,2,256)` | 19.33 us | 16.22 us AITER | 0.84x |
| `(163840,1,256)` | 20.40 us | 17.93 us `LLMM1` | 0.88x |

TP8, batch one, 8K input / 1K output, FP8 KV, no speculative decoding:

| Arm | TPOT trials (ms) | Median decode tok/s | Median p50 ITL |
|---|---|---:|---:|
| parent | 27.7617, 27.7697, 27.7516 | 36.0209 | 27.7325 ms |
| PR | 27.6841, 27.6836, 27.7405 | **36.1218 (+0.280%)** | **27.6352 ms** |

All six requests generated 1,024 tokens. The endpoint gain is deliberately
reported as small; the shape sweep is the primary evidence for the dispatch
policy.

The source-isolated full GSM8K run for the prior heuristic evaluated all 1,319
items with `lm_eval==0.4.12`, five shots, greedy decoding, 2,048 maximum output
tokens, concurrency 128, seed 42, FP8 KV, and no speculative decoding. It
used this command against each arm:

```bash
lm_eval --model local-completions \
  --model_args model=moonshotai/Kimi-K3,base_url=http://127.0.0.1:8000/v1/completions,tokenizer=/model,tokenizer_backend=huggingface,tokenized_requests=False,num_concurrent=128,max_retries=10,max_gen_toks=2048,timeout=60000,trust_remote_code=True \
  --batch_size auto --tasks gsm8k --num_fewshot 5 --seed 42 \
  --log_samples --output_path /results
```

The parent scored 1,274/1,319 and the candidate 1,272/1,319, with zero invalid
responses and 9 paired wins/11 losses (`p=0.8238`). The repaired predicate
makes the same decisions for every shape in the benchmark's
`KIMI_K3_TP8_SHAPES`, so this result provides no statistically detectable
model-quality difference for the affected workload.

#50618 is complementary: it fixes unsupported strided activation storage,
while this PR changes only gfx950 profitability selection.

**Tool assistance:** OpenAI Codex assisted with implementation, tests,
benchmarking, and drafting this description.
