### PR TITLE
[ROCm][Perf] Fuse Kimi-K3 AttnRes with RMSNorm

### DIFF
--- a/tests/models/kimi_k3/test_amd_attn_res.py
+++ b/tests/models/kimi_k3/test_amd_attn_res.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from vllm.models.kimi_k3.amd.ops.attn_res import attn_res
+from vllm.models.kimi_k3.amd.ops.attn_res import attn_res, attn_res_rmsnorm
 from vllm.platforms import current_platform
 
 pytestmark = pytest.mark.skipif(
@@ -92,6 +92,67 @@ def test_amd_attn_res_matches_reference(
         norm_weight,
         qk_weight,
         num_blocks,
+        eps,
+    )
+
+    torch.testing.assert_close(actual, expected, atol=8e-2, rtol=3e-2)
+    torch.testing.assert_close(prefix, original_prefix, atol=0, rtol=0)
+    torch.testing.assert_close(blocks, original_blocks, atol=0, rtol=0)
+    assert actual.shape == prefix.shape
+    assert actual.is_contiguous()
+
+
+@pytest.mark.parametrize(
+    ("num_tokens", "num_blocks", "hidden_size"),
+    [
+        pytest.param(0, 0, 128, id="empty"),
+        pytest.param(1, 0, 7168, id="decode-no-blocks"),
+        pytest.param(16, 2, 7168, id="decode-four-warps"),
+        pytest.param(1, 4, 7168, id="decode-eight-warps"),
+    ],
+)
+def test_amd_attn_res_rmsnorm_matches_reference(
+    num_tokens: int,
+    num_blocks: int,
+    hidden_size: int,
+) -> None:
+    eps = 1e-5
+    prefix = _randn_with_row_padding(num_tokens, hidden_size)
+    blocks = _randn_with_row_padding(num_tokens, 8, hidden_size)
+    norm_weight = 1 + 0.1 * torch.randn(
+        hidden_size, device="cuda", dtype=torch.bfloat16
+    )
+    qk_weight = (
+        torch.randn(hidden_size, device="cuda", dtype=torch.bfloat16) / hidden_size**0.5
+    )
+    output_norm_weight = 1 + 0.1 * torch.randn(
+        hidden_size, device="cuda", dtype=torch.bfloat16
+    )
+    mixed = _reference(
+        prefix,
+        blocks,
+        norm_weight,
+        qk_weight,
+        num_blocks,
+        eps,
+    ).to(torch.bfloat16)
+    expected = F.rms_norm(
+        mixed,
+        (hidden_size,),
+        output_norm_weight,
+        eps,
+    )
+    original_prefix = prefix.clone()
+    original_blocks = blocks.clone()
+
+    actual = attn_res_rmsnorm(
+        prefix,
+        blocks,
+        norm_weight,
+        qk_weight,
+        output_norm_weight,
+        num_blocks,
+        eps,
         eps,
     )
 

--- a/tests/models/kimi_k3/test_amd_attn_res.py
+++ b/tests/models/kimi_k3/test_amd_attn_res.py
@@ -103,22 +103,24 @@ def test_amd_attn_res_matches_reference(
 
 
 @pytest.mark.parametrize(
-    ("num_tokens", "num_blocks", "hidden_size"),
+    ("num_tokens", "num_blocks", "hidden_size", "row_padding"),
     [
-        pytest.param(0, 0, 128, id="empty"),
-        pytest.param(1, 0, 7168, id="decode-no-blocks"),
-        pytest.param(16, 2, 7168, id="decode-four-warps"),
-        pytest.param(1, 4, 7168, id="decode-eight-warps"),
+        pytest.param(0, 0, 128, 0, id="empty"),
+        pytest.param(1, 0, 7168, 0, id="decode-no-blocks"),
+        pytest.param(16, 2, 7168, 7, id="decode-four-warps-padded"),
+        pytest.param(1, 4, 7168, 0, id="decode-eight-warps"),
     ],
 )
 def test_amd_attn_res_rmsnorm_matches_reference(
     num_tokens: int,
     num_blocks: int,
     hidden_size: int,
+    row_padding: int,
 ) -> None:
     eps = 1e-5
-    prefix = _randn_with_row_padding(num_tokens, hidden_size)
-    blocks = _randn_with_row_padding(num_tokens, 8, hidden_size)
+    output_norm_eps = 1e-3
+    prefix = _randn_with_row_padding(num_tokens, hidden_size, padding=row_padding)
+    blocks = _randn_with_row_padding(num_tokens, 8, hidden_size, padding=row_padding)
     norm_weight = 1 + 0.1 * torch.randn(
         hidden_size, device="cuda", dtype=torch.bfloat16
     )
@@ -140,7 +142,7 @@ def test_amd_attn_res_rmsnorm_matches_reference(
         mixed,
         (hidden_size,),
         output_norm_weight,
-        eps,
+        output_norm_eps,
     )
     original_prefix = prefix.clone()
     original_blocks = blocks.clone()
@@ -153,7 +155,7 @@ def test_amd_attn_res_rmsnorm_matches_reference(
         output_norm_weight,
         num_blocks,
         eps,
-        eps,
+        output_norm_eps,
     )
 
     torch.testing.assert_close(actual, expected, atol=8e-2, rtol=3e-2)

--- a/vllm/models/kimi_k3/amd/linear.py
+++ b/vllm/models/kimi_k3/amd/linear.py
@@ -61,7 +61,8 @@ from vllm.model_executor.models.utils import (
     make_layers,
     maybe_prefix,
 )
-from vllm.models.kimi_k3.amd.ops.attn_res import attn_res
+from vllm.models.kimi_k3.amd.ops.attn_res import attn_res, attn_res_rmsnorm
+from vllm.platforms.rocm import on_gfx950
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
 from vllm.utils.math_utils import cdiv
@@ -141,18 +142,35 @@ def _apply_attn_res(
     proj: ReplicatedLinear,
     norm: RMSNorm,
     num_valid_blocks: int,
+    following_norm: RMSNorm | None = None,
 ) -> torch.Tensor:
-    if num_valid_blocks <= 0:
-        return prefix_sum
+    if following_norm is not None and on_gfx950():
+        return attn_res_rmsnorm(
+            prefix_sum,
+            block_residual,
+            norm.weight,
+            proj.weight.squeeze(0),
+            following_norm.weight,
+            num_valid_blocks,
+            norm.variance_epsilon,
+            following_norm.variance_epsilon,
+        )
 
-    return attn_res(
-        prefix_sum,
-        block_residual,
-        norm.weight,
-        proj.weight.squeeze(0),
-        num_valid_blocks,
-        norm.variance_epsilon,
-    )
+    if num_valid_blocks <= 0:
+        hidden_states = prefix_sum
+    else:
+        hidden_states = attn_res(
+            prefix_sum,
+            block_residual,
+            norm.weight,
+            proj.weight.squeeze(0),
+            num_valid_blocks,
+            norm.variance_epsilon,
+        )
+
+    if following_norm is not None:
+        hidden_states = following_norm(hidden_states)
+    return hidden_states
 
 
 class KimiMoE(nn.Module):
@@ -607,13 +625,13 @@ class KimiDecoderLayer(nn.Module):
             self.self_attention_res_proj,
             self.self_attention_res_norm,
             self.prev_valid_blocks,
+            self.input_layernorm,
         )
 
         if self.is_block_write_layer:
             block_residual[:, self.block_write_idx, :].copy_(prefix_sum)
             prefix_sum = None
 
-        hidden_states = self.input_layernorm(hidden_states)
         hidden_states = self._run_self_attn(positions, hidden_states)
 
         if prefix_sum is not None:
@@ -630,9 +648,9 @@ class KimiDecoderLayer(nn.Module):
             self.mlp_res_proj,
             self.mlp_res_norm,
             mlp_valid_blocks,
+            self.post_attention_layernorm,
         )
 
-        hidden_states = self.post_attention_layernorm(hidden_states)
         hidden_states = self.mlp(hidden_states)
         prefix_sum = prefix_sum + hidden_states
         return prefix_sum, block_residual

--- a/vllm/models/kimi_k3/amd/ops/attn_res.py
+++ b/vllm/models/kimi_k3/amd/ops/attn_res.py
@@ -18,79 +18,6 @@ def _attn_res_kernel(
     blocks_ptr,
     norm_weight_ptr,
     qk_weight_ptr,
-    output_ptr,
-    stride_prefix_m: tl.constexpr,
-    stride_block_m: tl.constexpr,
-    stride_block_r: tl.constexpr,
-    stride_output_m: tl.constexpr,
-    num_blocks: tl.constexpr,
-    hidden_size: tl.constexpr,
-    eps: tl.constexpr,
-    BLOCK_L: tl.constexpr,
-    BLOCK_D: tl.constexpr,
-):
-    row_idx = tl.program_id(0).to(tl.int64)
-    d_offsets = tl.max_contiguous(tl.arange(0, BLOCK_D), BLOCK_D)
-    d_mask = d_offsets < hidden_size
-
-    prefix = tl.load(
-        prefix_ptr + row_idx * stride_prefix_m + d_offsets,
-        mask=d_mask,
-        other=0.0,
-    ).to(tl.float32)
-    input_qk_weight = tl.load(norm_weight_ptr + d_offsets, mask=d_mask, other=0.0).to(
-        tl.float32
-    ) * tl.load(qk_weight_ptr + d_offsets, mask=d_mask, other=0.0).to(tl.float32)
-
-    max_logit = tl.full((), -float("inf"), tl.float32)
-    denominator = tl.zeros((), tl.float32)
-    mixed = tl.zeros((BLOCK_D,), tl.float32)
-    num_sources = num_blocks + 1
-
-    for source_tile in range(tl.cdiv(num_sources, BLOCK_L)):
-        source_offsets = source_tile * BLOCK_L + tl.arange(0, BLOCK_L)
-        source_mask = source_offsets < num_sources
-        is_prefix = source_offsets == num_blocks
-        block_ptrs = (
-            blocks_ptr
-            + row_idx * stride_block_m
-            + source_offsets[:, None] * stride_block_r
-            + d_offsets[None, :]
-        )
-        block_values = tl.load(
-            block_ptrs,
-            mask=(source_mask[:, None] & ~is_prefix[:, None] & d_mask[None, :]),
-            other=0.0,
-            eviction_policy="evict_first",
-        ).to(tl.float32)
-        values = tl.where(is_prefix[:, None], prefix[None, :], block_values)
-        reciprocal_std = tl.rsqrt(
-            tl.sum(values * values, axis=1) * (1.0 / hidden_size) + eps
-        )
-        logits = tl.sum(values * input_qk_weight[None, :], axis=1) * reciprocal_std
-        scores = tl.where(source_mask, logits, -float("inf"))
-
-        new_max_logit = tl.maximum(max_logit, tl.max(scores, axis=0))
-        old_scale = tl.exp(max_logit - new_max_logit)
-        block_scales = tl.exp(scores - new_max_logit)
-        denominator = denominator * old_scale + tl.sum(block_scales, axis=0)
-        mixed = mixed * old_scale + tl.sum(block_scales[:, None] * values, axis=0)
-        max_logit = new_max_logit
-
-    output = mixed / denominator
-    tl.store(
-        output_ptr + row_idx * stride_output_m + d_offsets,
-        output,
-        mask=d_mask,
-    )
-
-
-@triton.jit
-def _attn_res_rmsnorm_kernel(
-    prefix_ptr,
-    blocks_ptr,
-    norm_weight_ptr,
-    qk_weight_ptr,
     output_norm_weight_ptr,
     output_ptr,
     stride_prefix_m: tl.constexpr,
@@ -101,6 +28,7 @@ def _attn_res_rmsnorm_kernel(
     hidden_size: tl.constexpr,
     eps: tl.constexpr,
     output_norm_eps: tl.constexpr,
+    FUSE_OUTPUT_NORM: tl.constexpr,
     BLOCK_L: tl.constexpr,
     BLOCK_D: tl.constexpr,
 ):
@@ -114,17 +42,14 @@ def _attn_res_rmsnorm_kernel(
         other=0.0,
     ).to(tl.float32)
     if num_blocks == 0:
-        mixed = prefix
+        output = prefix
     else:
         input_qk_weight = tl.load(
-            norm_weight_ptr + d_offsets,
-            mask=d_mask,
-            other=0.0,
+            norm_weight_ptr + d_offsets, mask=d_mask, other=0.0
         ).to(tl.float32) * tl.load(
-            qk_weight_ptr + d_offsets,
-            mask=d_mask,
-            other=0.0,
+            qk_weight_ptr + d_offsets, mask=d_mask, other=0.0
         ).to(tl.float32)
+
         max_logit = tl.full((), -float("inf"), tl.float32)
         denominator = tl.zeros((), tl.float32)
         mixed = tl.zeros((BLOCK_D,), tl.float32)
@@ -158,25 +83,22 @@ def _attn_res_rmsnorm_kernel(
             old_scale = tl.exp(max_logit - new_max_logit)
             block_scales = tl.exp(scores - new_max_logit)
             denominator = denominator * old_scale + tl.sum(block_scales, axis=0)
-            mixed = mixed * old_scale + tl.sum(
-                block_scales[:, None] * values,
-                axis=0,
-            )
+            mixed = mixed * old_scale + tl.sum(block_scales[:, None] * values, axis=0)
             max_logit = new_max_logit
 
-        mixed /= denominator
-
-    mixed = mixed.to(prefix_ptr.dtype.element_ty).to(tl.float32)
-    output_reciprocal_std = tl.rsqrt(
-        tl.sum(tl.where(d_mask, mixed * mixed, 0.0), axis=0) * (1.0 / hidden_size)
-        + output_norm_eps
-    )
-    output_norm_weight = tl.load(
-        output_norm_weight_ptr + d_offsets,
-        mask=d_mask,
-        other=0.0,
-    ).to(tl.float32)
-    output = mixed * output_reciprocal_std * output_norm_weight
+        output = mixed / denominator
+    if FUSE_OUTPUT_NORM:
+        output = output.to(prefix_ptr.dtype.element_ty).to(tl.float32)
+        output_reciprocal_std = tl.rsqrt(
+            tl.sum(tl.where(d_mask, output * output, 0.0), axis=0) * (1.0 / hidden_size)
+            + output_norm_eps
+        )
+        output_norm_weight = tl.load(
+            output_norm_weight_ptr + d_offsets,
+            mask=d_mask,
+            other=0.0,
+        ).to(tl.float32)
+        output *= output_reciprocal_std * output_norm_weight
     tl.store(
         output_ptr + row_idx * stride_output_m + d_offsets,
         output,
@@ -215,6 +137,7 @@ def attn_res(
         blocks,
         norm_weight,
         qk_weight,
+        norm_weight,
         output,
         prefix.stride(0),
         blocks.stride(0),
@@ -223,6 +146,8 @@ def attn_res(
         num_blocks,
         hidden_size,
         eps,
+        eps,
+        FUSE_OUTPUT_NORM=False,
         BLOCK_L=block_l,
         BLOCK_D=triton.next_power_of_2(hidden_size),
         num_warps=num_warps,
@@ -259,7 +184,7 @@ def attn_res_rmsnorm(
 
     block_l = 1 if num_blocks <= 1 else 4
     num_warps = 4 if num_blocks <= 2 else 8
-    _attn_res_rmsnorm_kernel[(num_tokens,)](
+    _attn_res_kernel[(num_tokens,)](
         prefix,
         blocks,
         norm_weight,
@@ -274,6 +199,7 @@ def attn_res_rmsnorm(
         hidden_size,
         eps,
         output_norm_eps,
+        FUSE_OUTPUT_NORM=True,
         BLOCK_L=block_l,
         BLOCK_D=triton.next_power_of_2(hidden_size),
         num_warps=num_warps,

--- a/vllm/models/kimi_k3/amd/ops/attn_res.py
+++ b/vllm/models/kimi_k3/amd/ops/attn_res.py
@@ -85,6 +85,105 @@ def _attn_res_kernel(
     )
 
 
+@triton.jit
+def _attn_res_rmsnorm_kernel(
+    prefix_ptr,
+    blocks_ptr,
+    norm_weight_ptr,
+    qk_weight_ptr,
+    output_norm_weight_ptr,
+    output_ptr,
+    stride_prefix_m: tl.constexpr,
+    stride_block_m: tl.constexpr,
+    stride_block_r: tl.constexpr,
+    stride_output_m: tl.constexpr,
+    num_blocks: tl.constexpr,
+    hidden_size: tl.constexpr,
+    eps: tl.constexpr,
+    output_norm_eps: tl.constexpr,
+    BLOCK_L: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    d_offsets = tl.max_contiguous(tl.arange(0, BLOCK_D), BLOCK_D)
+    d_mask = d_offsets < hidden_size
+
+    prefix = tl.load(
+        prefix_ptr + row_idx * stride_prefix_m + d_offsets,
+        mask=d_mask,
+        other=0.0,
+    ).to(tl.float32)
+    if num_blocks == 0:
+        mixed = prefix
+    else:
+        input_qk_weight = tl.load(
+            norm_weight_ptr + d_offsets,
+            mask=d_mask,
+            other=0.0,
+        ).to(tl.float32) * tl.load(
+            qk_weight_ptr + d_offsets,
+            mask=d_mask,
+            other=0.0,
+        ).to(tl.float32)
+        max_logit = tl.full((), -float("inf"), tl.float32)
+        denominator = tl.zeros((), tl.float32)
+        mixed = tl.zeros((BLOCK_D,), tl.float32)
+        num_sources = num_blocks + 1
+
+        for source_tile in range(tl.cdiv(num_sources, BLOCK_L)):
+            source_offsets = source_tile * BLOCK_L + tl.arange(0, BLOCK_L)
+            source_mask = source_offsets < num_sources
+            is_prefix = source_offsets == num_blocks
+            block_offsets = tl.where(source_mask & ~is_prefix, source_offsets, 0)
+            block_ptrs = (
+                blocks_ptr
+                + row_idx * stride_block_m
+                + block_offsets[:, None] * stride_block_r
+                + d_offsets[None, :]
+            )
+            block_values = tl.load(
+                block_ptrs,
+                mask=(source_mask[:, None] & ~is_prefix[:, None] & d_mask[None, :]),
+                other=0.0,
+                eviction_policy="evict_first",
+            ).to(tl.float32)
+            values = tl.where(is_prefix[:, None], prefix[None, :], block_values)
+            reciprocal_std = tl.rsqrt(
+                tl.sum(values * values, axis=1) * (1.0 / hidden_size) + eps
+            )
+            logits = tl.sum(values * input_qk_weight[None, :], axis=1) * reciprocal_std
+            scores = tl.where(source_mask, logits, -float("inf"))
+
+            new_max_logit = tl.maximum(max_logit, tl.max(scores, axis=0))
+            old_scale = tl.exp(max_logit - new_max_logit)
+            block_scales = tl.exp(scores - new_max_logit)
+            denominator = denominator * old_scale + tl.sum(block_scales, axis=0)
+            mixed = mixed * old_scale + tl.sum(
+                block_scales[:, None] * values,
+                axis=0,
+            )
+            max_logit = new_max_logit
+
+        mixed /= denominator
+
+    mixed = mixed.to(prefix_ptr.dtype.element_ty).to(tl.float32)
+    output_reciprocal_std = tl.rsqrt(
+        tl.sum(tl.where(d_mask, mixed * mixed, 0.0), axis=0) * (1.0 / hidden_size)
+        + output_norm_eps
+    )
+    output_norm_weight = tl.load(
+        output_norm_weight_ptr + d_offsets,
+        mask=d_mask,
+        other=0.0,
+    ).to(tl.float32)
+    output = mixed * output_reciprocal_std * output_norm_weight
+    tl.store(
+        output_ptr + row_idx * stride_output_m + d_offsets,
+        output,
+        mask=d_mask,
+    )
+
+
 def attn_res(
     prefix: torch.Tensor,
     blocks: torch.Tensor,
@@ -124,6 +223,57 @@ def attn_res(
         num_blocks,
         hidden_size,
         eps,
+        BLOCK_L=block_l,
+        BLOCK_D=triton.next_power_of_2(hidden_size),
+        num_warps=num_warps,
+        num_stages=2,
+    )
+    return output
+
+
+def attn_res_rmsnorm(
+    prefix: torch.Tensor,
+    blocks: torch.Tensor,
+    norm_weight: torch.Tensor,
+    qk_weight: torch.Tensor,
+    output_norm_weight: torch.Tensor,
+    num_blocks: int,
+    eps: float,
+    output_norm_eps: float,
+) -> torch.Tensor:
+    num_tokens, hidden_size = prefix.shape
+    assert 0 <= num_blocks <= blocks.shape[1]
+    assert blocks.shape[0] == num_tokens
+    assert norm_weight.numel() == hidden_size
+    assert qk_weight.numel() == hidden_size
+    assert output_norm_weight.numel() == hidden_size
+    assert prefix.stride(-1) == 1
+    assert blocks.stride(-1) == 1
+    assert norm_weight.stride(-1) == 1
+    assert qk_weight.stride(-1) == 1
+    assert output_norm_weight.stride(-1) == 1
+
+    output = prefix.new_empty(prefix.shape)
+    if num_tokens == 0:
+        return output
+
+    block_l = 1 if num_blocks <= 1 else 4
+    num_warps = 4 if num_blocks <= 2 else 8
+    _attn_res_rmsnorm_kernel[(num_tokens,)](
+        prefix,
+        blocks,
+        norm_weight,
+        qk_weight,
+        output_norm_weight,
+        output,
+        prefix.stride(0),
+        blocks.stride(0),
+        blocks.stride(1),
+        output.stride(0),
+        num_blocks,
+        hidden_size,
+        eps,
+        output_norm_eps,
         BLOCK_L=block_l,
         BLOCK_D=triton.next_power_of_2(hidden_size),
         num_warps=num_warps,


### PR DESCRIPTION
## Purpose

Fuse Kimi-K3's AMD attention-residual update and immediately following RMSNorm
into one Triton kernel. The model-level ownership boundary is unchanged, and
the production precision contract is preserved: the mixed AttnRes value is
materialized to BF16 before RMSNorm. Only Kimi-K3 on ROCm is affected; NVIDIA
and other models are unchanged.

This remains draft pending maintainer agreement on the overlapping ownership
boundary described below.

## Test plan

Tested on 8x MI355X (`gfx950`) with the public Kimi-K3 image and
`moonshotai/Kimi-K3@9f62e4e9`. FP8-KV uses vLLM `6e6a889a` and AITER #4480;
the command below pins the base and PR revisions.

Fetch and verify the candidate:

```bash
git clone https://github.com/vllm-project/vllm.git vllm
git -C vllm fetch origin refs/pull/50637/head:pr-50637
test "$(git -C vllm rev-parse pr-50637)" = \
  3b0fc66f182ad5f6c16958d7f3b9d0efb7a64fdc
git -C vllm checkout --detach e3be89673db6143c1f9c8689d853b9c7c7a5eb29
git -C vllm diff e3be89673db6143c1f9c8689d853b9c7c7a5eb29..pr-50637 \
  --binary | git -C vllm apply -
git -C vllm diff --check
```

Use complete verified vLLM/AITER trees as overlays on the public image and
verify `import vllm, vllm._C, aiter` before testing.

```bash
python -m pytest -q tests/models/kimi_k3/test_amd_attn_res.py
```

Serve both source-isolated arms with identical flags:

```bash
VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_FP4BMM=1 \
AITER_SITUV2_A8W4=1 AITER_BF16_FP8_MOE_BOUND=0 \
VLLM_USE_BREAKABLE_CUDAGRAPH=0 \
vllm serve /model --served-model-name moonshotai/Kimi-K3 \
  --tensor-parallel-size 8 --trust-remote-code --moe-backend auto \
  --gpu-memory-utilization 0.95 --max-num-seqs 128 \
  --max-num-batched-tokens 4096 --max-model-len 1048576 \
  --enable-prefix-caching --kv-cache-dtype fp8 --reasoning-parser kimi_k3
```

After one 8K/128 warmup, run three 8K/1K batch-one trials with seeds 1--3,
temperature zero, and `--ignore-eos`. Run full `lm-eval==0.4.12` GSM8K on both
arms: 1,319 questions, 5-shot, greedy completion, 2,048 generated tokens,
concurrency 128, and seed 42.

For the long-prefix serving sweep, use official `aiperf==0.11.0`:

```bash
aiperf profile --model moonshotai/Kimi-K3 --tokenizer moonshotai/Kimi-K3 \
  --tokenizer-trust-remote-code --url http://127.0.0.1:8000 --api-key EMPTY \
  --endpoint-type chat --streaming --use-server-token-count \
  --num-prefix-prompts 8 --prompt-prefix-length 63240 \
  --synthetic-input-tokens-mean 4760 --synthetic-input-tokens-stddev 0 \
  --output-tokens-mean 350 --output-tokens-stddev 0 \
  --extra-inputs ignore_eos:true --extra-inputs min_tokens:350 \
  --extra-inputs max_tokens:350 --warmup-request-count 3 --sweep-type zip \
  --concurrency 1,8,16,24,48 --request-count 5,40,80,120,240 \
  --random-seed 42 --ui simple
```

## Test results

- Focused suite: **8/8 passed**, covering empty, boundary, decode, multi-token,
  non-contiguous-input, and model-dispatch contracts.
- Changed-file pre-commit, `git diff --check`, and DCO passed.

| TP8 measurement | Parent | This PR | Change |
| --- | ---: | ---: | ---: |
| 185 AttnRes+RMSNorm calls/token | 2.040--2.047 ms | 1.083--1.087 ms | **1.88x** |
| Decode throughput | 35.8923 tok/s/GPU | 36.9352 tok/s/GPU | **+2.906%** |
| TPOT | 27.8611 ms | 27.0744 ms | **-0.7867 ms** |

The fusion removes 185 launches per generated token. Endpoint values are
medians of three fixed-seed trials after warmup.

### Agentic long-context serving

The matched parent/candidate sweep used public image
`vllm/vllm-openai-rocm:kimi-k3@sha256:5aa7e626ff73672f5ca7aae46754570488c23d33ca1ac90756a1d2d1a3fe099b`,
vLLM parent `e3be89673d`, and this PR at `3b0fc66f18`. Both arms had the same
FP8-MLA correctness dependencies, byte-identical AITER source, fresh AITER JIT
cache, and generated inputs.

| Concurrency | Output tok/s, parent -> PR | Mean ITL, ms, parent -> PR | Mean TTFT, ms, parent -> PR | Mean E2E, ms, parent -> PR |
|---:|---:|---:|---:|---:|
| 1 | 14.10 -> 14.25 (+1.07%) | 51.68 -> 51.07 (-1.18%) | 6,785 -> 6,735 | 24,821 -> 24,559 |
| 8 | 83.39 -> 84.71 (+1.59%) | 77.77 -> 77.58 (-0.24%) | 5,992 -> 5,710 | 33,133 -> 32,785 |
| 16 | 145.14 -> 146.24 (+0.75%) | 85.66 -> 85.07 (-0.68%) | 8,252 -> 8,201 | 38,146 -> 37,891 |
| 24 | 191.74 -> 192.51 (+0.40%) | 94.73 -> 95.15 (+0.45%) | 10,028 -> 9,622 | 43,087 -> 42,831 |
| 48 | 296.30 -> 297.90 (+0.54%) | 124.35 -> 123.89 (-0.37%) | 12,544 -> 12,367 | 55,943 -> 55,606 |

All 485 requests succeeded in each arm. Output throughput, TTFT, and E2E
latency improve at every concurrency. Mean ITL improves at four points and
regresses 0.45% at concurrency 24. Each cell is one profile trial and is a
point estimate; these serving results are independent of the batch-one decode
measurement above.

Full GSM8K: parent **1274/1319**, candidate **1272/1319**, both with zero
invalid responses; 12 wins/14 losses (`p=0.8450`). This paired run found no
statistically detectable accuracy difference.

## Overlap and limits

#50593 proposes a broader AMD AttnRes-plus-norm fusion, but its current oracle
normalizes the FP32 intermediate. Production materializes AttnRes to BF16
first. On the public image, 24 seeded `(H=7168, blocks=4)` comparisons found
1,783--1,939 differing BF16 output elements per seed, worst relative RMSE
`0.002981`, and maximum absolute difference `0.03125`.

The PRs are therefore not numerically interchangeable today. Keep this draft
until maintainers choose the ownership boundary or #50593 adopts and tests the
same BF16 materialization contract. #50185 and #50567 are NVIDIA-only.

## Tool assistance

OpenAI Codex assisted with implementation, tests, benchmarking, and drafting
this description.
