### PR TITLE
[Bugfix] [CI Stabilization] Force spawn when CUDA is in a bad fork state

### DIFF
--- a/tests/utils_/test_system_utils.py
+++ b/tests/utils_/test_system_utils.py
@@ -5,6 +5,9 @@ import os
 import tempfile
 from pathlib import Path
 
+import pytest
+
+from vllm.platforms import current_platform
 from vllm.utils.system_utils import _maybe_force_spawn, unique_filepath
 
 
@@ -25,3 +28,28 @@ def test_numa_bind_forces_spawn(monkeypatch):
     monkeypatch.setattr("sys.argv", ["vllm", "serve", "--numa-bind"])
     _maybe_force_spawn()
     assert os.environ["VLLM_WORKER_MULTIPROC_METHOD"] == "spawn"
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="requires CUDA")
+def test_bad_fork_forces_spawn():
+    """A child forked from a CUDA-initialized parent must not fork again.
+
+    ``torch.cuda.is_initialized()`` reports False in such a child even though
+    CUDA is unusable there, so the check must key off the bad-fork state.
+    """
+    import torch
+
+    torch.zeros(1, device="cuda")
+
+    pid = os.fork()
+    if pid == 0:
+        os.environ.pop("VLLM_WORKER_MULTIPROC_METHOD", None)
+        try:
+            _maybe_force_spawn()
+            forced = os.environ.get("VLLM_WORKER_MULTIPROC_METHOD") == "spawn"
+        except Exception:
+            forced = False
+        os._exit(0 if forced else 1)
+
+    _, status = os.waitpid(pid, 0)
+    assert os.waitstatus_to_exitcode(status) == 0

--- a/vllm/utils/platform_utils.py
+++ b/vllm/utils/platform_utils.py
@@ -15,6 +15,12 @@ def cuda_is_initialized() -> bool:
     """Check if CUDA is initialized."""
     if not torch.cuda._is_compiled():
         return False
+    # A forked child of a CUDA-initialized parent reports is_initialized()
+    # as False, yet CUDA is unusable there: any attempt to initialize it
+    # raises "Cannot re-initialize CUDA in forked subprocess". Report it as
+    # initialized so callers fall back to spawn instead of forking again.
+    if torch.cuda._is_in_bad_fork():
+        return True
     return torch.cuda.is_initialized()
 
 


### PR DESCRIPTION
## Purpose

A process forked from a CUDA-initialized parent cannot use CUDA — any initialization attempt raises `Cannot re-initialize CUDA in forked subprocess`. vLLM guards against this in `_maybe_force_spawn()`, but the guard never fires in that situation: `torch.cuda.is_initialized()` reports `False` in such a child, so `cuda_is_initialized()` returns `False` and the worker start method stays `fork`. EngineCore is then forked a second time and dies in `init_device()`. This keys the check off `torch.cuda._is_in_bad_fork()` as well.

**Example failure:** [PyTorch Fullgraph, build 81724](https://buildkite.com/vllm/ci/builds/81724#019fba35-8bfb-475a-aa69-3e2b95062c42)
 - `23 failed, 3 passed`. Every test that constructs an engine failed with this error; the 3 "passed" are early-exit skips (`int8 support removed on Blackwell`) that never build one. `pytest` collection initializes CUDA, and `create_new_process_for_each_test()` defaults to `fork` on CUDA, so the whole job fails deterministically. Reproduced locally on non-MIG hardware.

## AI assistance

AI assistance (Claude Code) was used to diagnose the failure and write the fix.

