### PR TITLE
[Bugfix][CI] Prevent common ops imports from initializing CUDA

### DIFF
--- a/vllm/models/common/ops/__init__.py
+++ b/vllm/models/common/ops/__init__.py
@@ -2,10 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Ops shared across model implementations."""
 
-from .fused_allreduce_rms_norm import fused_allreduce_rms_norm
 from .fused_qk_rmsnorm import fused_q_kv_rmsnorm
 
 __all__ = [
-    "fused_allreduce_rms_norm",
     "fused_q_kv_rmsnorm",
 ]

--- a/vllm/models/deepseek_v32/amd/model.py
+++ b/vllm/models/deepseek_v32/amd/model.py
@@ -34,7 +34,7 @@ from vllm.model_executor.models.utils import (
     make_empty_intermediate_tensors_factory,
     make_layers,
 )
-from vllm.models.common.ops import fused_allreduce_rms_norm
+from vllm.models.common.ops.fused_allreduce_rms_norm import fused_allreduce_rms_norm
 from vllm.sequence import IntermediateTensors
 
 from .rocm import DeepseekV32MLAAttention

--- a/vllm/models/deepseek_v32/nvidia/model.py
+++ b/vllm/models/deepseek_v32/nvidia/model.py
@@ -38,7 +38,7 @@ from vllm.model_executor.models.utils import (
     make_layers,
     sequence_parallel_chunk,
 )
-from vllm.models.common.ops import fused_allreduce_rms_norm
+from vllm.models.common.ops.fused_allreduce_rms_norm import fused_allreduce_rms_norm
 from vllm.models.deepseek_v32.attention import DeepseekV32Attention
 from vllm.sequence import IntermediateTensors
 

--- a/vllm/models/kimi_k3/nvidia/dspark_mla.py
+++ b/vllm/models/kimi_k3/nvidia/dspark_mla.py
@@ -20,7 +20,7 @@ from vllm.model_executor.models.utils import (
     get_draft_quant_config,
     maybe_prefix,
 )
-from vllm.models.common.ops import fused_allreduce_rms_norm
+from vllm.models.common.ops.fused_allreduce_rms_norm import fused_allreduce_rms_norm
 from vllm.models.kimi_k3.nvidia.mla import MultiHeadLatentAttention
 from vllm.models.kimi_k3.nvidia.model import KimiMLP
 from vllm.utils.torch_utils import is_quantized_kv_cache


### PR DESCRIPTION
The [PyTorch Fullgraph job](https://buildkite.com/vllm/ci/builds/81692/summary?jid=019fb955-8175-4d2d-ac07-a66e527c95b1&tab=output) started failing with `Cannot re-initialize CUDA in forked subprocess`, while the [Extra Initialization job](https://buildkite.com/vllm/ci/builds/81692/summary?jid=019fb955-8143-4e3d-84b2-1ce20e29275e&tab=output) failed when the Kimi initialization test unexpectedly ran a model profile. I ran `git bisect` between the failing commit `fe33a3ed` and the known-good commit `5d7647a1`. It identified `92643d68` from [#50242](https://github.com/vllm-project/vllm/pull/50242) as the first bad commit. That commit added a package-level re-export which made a lightweight common-op import pull in model/config dependencies and initialize CUDA before EngineCore process creation. So this is one import-time regression behind both failures, not a Kimi runtime bug.

- Remove the eager `fused_allreduce_rms_norm` re-export from the common-ops package.
- Import the fused helper directly in the three model files that use it.
- Run `can_initialize`'s EngineCore in-process so its KV-cache patch is retained even if a later import forces spawn.
