### PR TITLE
[Bugfix][Test] Fix monolithic routing replay test buffer capacity

### DIFF
--- a/tests/kernels/moe/test_routed_experts_capture_monolithic.py
+++ b/tests/kernels/moe/test_routed_experts_capture_monolithic.py
@@ -100,7 +100,7 @@ def _make_bf16_monolithic_experts(
         activation=MoEActivation.SILU,
         device=device,
         routing_method=routing_method,
-        max_num_tokens=max(8, 1),
+        max_num_tokens=16,
     )
     quant_config = FusedMoEQuantConfig.make(
         quant_dtype=None,
@@ -518,7 +518,7 @@ def _make_fp8_block_scale_monolithic_experts(
         activation=MoEActivation.SILU,
         device=device,
         routing_method=RoutingMethodType.DeepSeekV3,
-        max_num_tokens=max(8, 1),
+        max_num_tokens=16,
     )
 
     # Random fp8 weights + ones-block scales (the kernel decoder only cares
@@ -703,7 +703,7 @@ def _make_nvfp4_monolithic_experts(
         activation=MoEActivation.SILU,
         device=device,
         routing_method=RoutingMethodType.DeepSeekV3,
-        max_num_tokens=max(8, 1),
+        max_num_tokens=16,
     )
 
     gemm1 = torch.randn(


### PR DESCRIPTION



## Purpose

The test fixtures allocate routing replay buffers for 8 tokens, but some cases use up to 16 tokens. Set max_num_tokens=16 in all three fixtures to match the largest test case and prevent false failures.

## Test Plan
```bash
uv run --no-project python -m pytest \
  tests/kernels/moe/test_routed_experts_capture_monolithic.py \
  -vv -ra
```
## Test Result
```bash
28 passed, 16 warnings in 9.86s
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

