### PR TITLE
[Elastic EP] Fix non-contiguous weight transfers

### DIFF
--- a/vllm/distributed/elastic_ep/elastic_execute.py
+++ b/vllm/distributed/elastic_ep/elastic_execute.py
@@ -85,16 +85,26 @@ def batch_transfer_weights(
     assert len(all_params) > 0
     p2p_ops = []
     for param in all_params:
+        transfer_param = param
+        if not param.is_contiguous():
+            # PyNccl transfers flat memory and does not honor tensor strides.
+            transfer_param = (
+                param.contiguous()
+                if is_sender
+                else torch.empty_like(param, memory_format=torch.contiguous_format)
+            )
         op = object.__new__(P2POp)
-        if is_sender:
-            op.op = torch.distributed.isend
-            op.tensor = param
-        else:
-            op.op = torch.distributed.irecv
-            op.tensor = param
+        op.op = torch.distributed.isend if is_sender else torch.distributed.irecv
+        op.tensor = transfer_param
         op.group_peer = peer_rank
         p2p_ops.append(op)
-    device_comm.batch_isend_irecv(p2p_ops)
+        if transfer_param is not param:
+            device_comm.batch_isend_irecv(p2p_ops)
+            p2p_ops.clear()
+            if not is_sender:
+                param.copy_(transfer_param)
+    if p2p_ops:
+        device_comm.batch_isend_irecv(p2p_ops)
 
 
 def broadcast_expert_mapping(

--- a/vllm/distributed/elastic_ep/elastic_execute.py
+++ b/vllm/distributed/elastic_ep/elastic_execute.py
@@ -85,14 +85,8 @@ def batch_transfer_weights(
     assert len(all_params) > 0
     p2p_ops = []
     for param in all_params:
-        transfer_param = param
-        if not param.is_contiguous():
-            # PyNccl transfers flat memory and does not honor tensor strides.
-            transfer_param = (
-                param.contiguous()
-                if is_sender
-                else torch.empty_like(param, memory_format=torch.contiguous_format)
-            )
+        # PyNccl transfers flat memory and does not honor tensor strides.
+        transfer_param = param.contiguous()
         op = object.__new__(P2POp)
         op.op = torch.distributed.isend if is_sender else torch.distributed.irecv
         op.tensor = transfer_param


### PR DESCRIPTION
Elastic EP weight transfer passed each weight tensor directly to PyNccl send API, but PyNccl transfers each tensor as a flat contiguous memory and does not account for tensor strides. For non-contiguous tensor views, such as some DeepSeek-V3 weights, this caused new workers to receive incorrect weights during scale-up.

Instead, pack non-contiguous weights into a temporary contiguous buffer before sending them, then copy the received values into the original tensor view.

To limit temporary HBM usage, non-contiguous tensors are transferred one at a time rather than batched. Across 10 full size DeepSeek V3 16->24 scale-up comparisons, there was no measurable degradation to weight transfer performance (in fact both mean and median were slightly better with the fix)

cc @tlrmchlsmth @SageMoore 