### PR TITLE
[Bugfix] Copy packed_modules_mapping onto the instance before mutating it

### DIFF
--- a/vllm/model_executor/models/AXK1.py
+++ b/vllm/model_executor/models/AXK1.py
@@ -1052,6 +1052,10 @@ class AXK1ForCausalLM(
         qk_rope_head_dim = config.qk_rope_head_dim
         self.use_mha = all(dim == 0 for dim in (qk_nope_head_dim, qk_rope_head_dim))
 
+        # `packed_modules_mapping` is a class attribute, so mutating it in place would
+        # leak this instance's fused-layer entries into every later instance of the same
+        # class. Copy it onto the instance first.
+        self.packed_modules_mapping = dict(self.packed_modules_mapping)
         if self.use_mha:
             self.packed_modules_mapping["qkv_proj"] = ["q_proj", "k_proj", "v_proj"]
 

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -1822,6 +1822,10 @@ class DeepseekV2ForCausalLM(
             dim == 0 for dim in (qk_nope_head_dim, qk_rope_head_dim)
         )
 
+        # `packed_modules_mapping` is a class attribute, so mutating it in place would
+        # leak this instance's fused-layer entries into every later instance of the same
+        # class. Copy it onto the instance first.
+        self.packed_modules_mapping = dict(self.packed_modules_mapping)
         if self.use_mha:
             self.packed_modules_mapping["qkv_proj"] = ["q_proj", "k_proj", "v_proj"]
 

--- a/vllm/model_executor/models/glm4_moe_lite.py
+++ b/vllm/model_executor/models/glm4_moe_lite.py
@@ -535,6 +535,10 @@ class Glm4MoeLiteForCausalLM(
             dim == 0 for dim in (qk_nope_head_dim, qk_rope_head_dim)
         )
 
+        # `packed_modules_mapping` is a class attribute, so mutating it in place would
+        # leak this instance's fused-layer entries into every later instance of the same
+        # class. Copy it onto the instance first.
+        self.packed_modules_mapping = dict(self.packed_modules_mapping)
         if self.use_mha:
             self.packed_modules_mapping["qkv_proj"] = ["q_proj", "k_proj", "v_proj"]
 

--- a/vllm/model_executor/models/openpangu.py
+++ b/vllm/model_executor/models/openpangu.py
@@ -1115,6 +1115,10 @@ class OpenPanguModelBase(nn.Module, SupportsPP, SupportsLoRA):
         self.fuse_qkv_a_proj = (
             hasattr(config, "q_lora_rank") and config.q_lora_rank is not None
         )
+        # `packed_modules_mapping` is a class attribute, so mutating it in place would
+        # leak this instance's fused-layer entries into every later instance of the same
+        # class. Copy it onto the instance first.
+        self.packed_modules_mapping = dict(self.packed_modules_mapping)
         if self.fuse_qkv_a_proj:
             self.packed_modules_mapping["fused_qkv_a_proj"] = [
                 "q_a_proj",

--- a/vllm/model_executor/models/qwen2_moe.py
+++ b/vllm/model_executor/models/qwen2_moe.py
@@ -445,6 +445,10 @@ class Qwen2MoeForCausalLM(nn.Module, SupportsPP, SupportsLoRA):
         self.config = config
         self.quant_config = quant_config
         # Only perform the following mapping when Qwen2MoeMLP exists
+        # `packed_modules_mapping` is a class attribute, so mutating it in place would
+        # leak this instance's fused-layer entries into every later instance of the same
+        # class. Copy it onto the instance first.
+        self.packed_modules_mapping = dict(self.packed_modules_mapping)
         if (
             getattr(config, "mlp_only_layers", [])
             or config.shared_expert_intermediate_size > 0

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -570,6 +570,10 @@ class Qwen3MoeForCausalLM(
         self.config = config
         self.quant_config = quant_config
         # Only perform the following mapping when Qwen3MoeMLP exists
+        # `packed_modules_mapping` is a class attribute, so mutating it in place would
+        # leak this instance's fused-layer entries into every later instance of the same
+        # class. Copy it onto the instance first.
+        self.packed_modules_mapping = dict(self.packed_modules_mapping)
         if getattr(config, "mlp_only_layers", []):
             self.packed_modules_mapping["gate_up_proj"] = ["gate_proj", "up_proj"]
         self.model = Qwen3MoeModel(


### PR DESCRIPTION
## Purpose

Six model classes declare `packed_modules_mapping` as a class attribute and then write into it from `__init__`:

```python
class DeepseekV2ForCausalLM(...):
    packed_modules_mapping = {...}

    def __init__(self, ...):
        if self.use_mha:
            self.packed_modules_mapping["qkv_proj"] = ["q_proj", "k_proj", "v_proj"]
```

`self.packed_modules_mapping[k] = v` doesn't create an instance attribute — it mutates the dict the class holds. Entries added for one instance stay on the class for every later instance:

```
initial class dict:                    {'gate_up_proj': [...]}
after instance 1 (use_mha, fuse_qkv):  ['fused_qkv_a_proj', 'gate_up_proj', 'qkv_proj']
instance 2 (neither flag set) sees:    ['fused_qkv_a_proj', 'gate_up_proj', 'qkv_proj']
  instance_2.packed_modules_mapping is Class.packed_modules_mapping -> True
```

This isn't cosmetic, because the mapping feeds quantization. It's handed to `is_layer_skipped` as `fused_mapping` (`compressed_tensors.py:941,951`) and reaches `get_quant_method`. In `is_layer_skipped`, a `proj_name in fused_mapping` hit takes the shard-consistency branch instead of the plain match, so a stale `qkv_proj` entry changes which scheme a later model resolves — on a model whose own config never asked for that fusion. The comment already in `deepseek_v2.py` says as much: *"`packed_modules_mapping` needs to be modified before initializing ... as it is passed inplace to quantization config init and may be used to select the quant_method for relevant layers."*

Affected: `deepseek_v2.py`, `AXK1.py`, `glm4_moe_lite.py`, `qwen3_moe.py`, `qwen2_moe.py`, `openpangu.py`.

Two models in the same directory already do it correctly, rebinding instead of mutating:

```python
# interns1_pro.py:590 and qwen3_vl_moe.py:270
self.packed_modules_mapping = self.packed_modules_mapping | self.language_model.packed_modules_mapping
```

so this isn't a new convention, it's the existing one applied to the remaining six.

## Test Plan

One line per file, `self.packed_modules_mapping = dict(self.packed_modules_mapping)`, placed before the first mutation in each `__init__`.

To confirm nothing else moved, I parsed both revisions of each file, dropped the newly added assignment from the tree, and compared:

```
deepseek_v2      identical apart from the added line: True
AXK1             identical apart from the added line: True
glm4_moe_lite    identical apart from the added line: True
qwen3_moe        identical apart from the added line: True
qwen2_moe        identical apart from the added line: True
openpangu        identical apart from the added line: True
```

## Test Result

`ruff format --check` reports all six already formatted. `ruff check` reports `I001` on four of them, and reports the same six errors on an unmodified `origin/main` checkout, so they are pre-existing and untouched here.

No behaviour changes for a single model instance — the copy has the same contents, and every subsequent write goes to the instance dict instead of the class dict. The difference only shows when more than one instance of the same class is built in one process.
