### PR TITLE
Revert "K3 DSpark AR fusion" (#50242)

### DIFF
--- a/vllm/models/common/ops/__init__.py
+++ b/vllm/models/common/ops/__init__.py
@@ -2,10 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Ops shared across model implementations."""
 
-from .fused_allreduce_rms_norm import fused_allreduce_rms_norm
 from .fused_qk_rmsnorm import fused_q_kv_rmsnorm
 
 __all__ = [
-    "fused_allreduce_rms_norm",
     "fused_q_kv_rmsnorm",
 ]

--- a/vllm/models/deepseek_v32/amd/model.py
+++ b/vllm/models/deepseek_v32/amd/model.py
@@ -34,7 +34,7 @@ from vllm.model_executor.models.utils import (
     make_empty_intermediate_tensors_factory,
     make_layers,
 )
-from vllm.models.common.ops import fused_allreduce_rms_norm
+from vllm.models.deepseek_v32.common.fused_ops import fused_allreduce_rms_norm
 from vllm.sequence import IntermediateTensors
 
 from .rocm import DeepseekV32MLAAttention

--- a/vllm/models/deepseek_v32/common/fused_ops.py
+++ b/vllm/models/deepseek_v32/common/fused_ops.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Fused all-reduce + residual-add + RMSNorm for eager model paths.
+"""Fused ops for deepseek_v32 (eager / breakable-cudagraph path).
 
-This recovers a fusion that vLLM's torch.compile passes would normally do but
-that doesn't fire for models running eager (or under a breakable CUDA graph).
+These recover fusions that vLLM's torch.compile passes would normally do but
+that don't fire when running eager under the breakable CUDA graph.
 """
 
 import torch

--- a/vllm/models/deepseek_v32/nvidia/model.py
+++ b/vllm/models/deepseek_v32/nvidia/model.py
@@ -38,8 +38,8 @@ from vllm.model_executor.models.utils import (
     make_layers,
     sequence_parallel_chunk,
 )
-from vllm.models.common.ops import fused_allreduce_rms_norm
 from vllm.models.deepseek_v32.attention import DeepseekV32Attention
+from vllm.models.deepseek_v32.common.fused_ops import fused_allreduce_rms_norm
 from vllm.sequence import IntermediateTensors
 
 

--- a/vllm/models/kimi_k3/nvidia/dspark_mla.py
+++ b/vllm/models/kimi_k3/nvidia/dspark_mla.py
@@ -20,7 +20,6 @@ from vllm.model_executor.models.utils import (
     get_draft_quant_config,
     maybe_prefix,
 )
-from vllm.models.common.ops import fused_allreduce_rms_norm
 from vllm.models.kimi_k3.nvidia.mla import MultiHeadLatentAttention
 from vllm.models.kimi_k3.nvidia.model import KimiMLP
 from vllm.utils.torch_utils import is_quantized_kv_cache
@@ -55,15 +54,11 @@ class K3DSparkDecoderLayer(nn.Module):
             use_rope=True,
             non_causal_multi_token_decode=True,
         )
-        # Both row-parallel outputs stay un-reduced; their all-reduces are fused
-        # into the RMSNorm that follows via fused_allreduce_rms_norm.
-        self.self_attn.o_proj.reduce_results = False
         self.mlp = KimiMLP(
             hidden_size=config.hidden_size,
             intermediate_size=config.intermediate_size,
             hidden_act=config.hidden_act,
             quant_config=quant_config,
-            reduce_results=False,
             prefix=maybe_prefix(prefix, f"layers.{start_layer_id + layer_idx}.mlp"),
         )
         self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
@@ -78,23 +73,16 @@ class K3DSparkDecoderLayer(nn.Module):
         residual: torch.Tensor | None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         if residual is None:
-            # First layer: hidden_states is the (already reduced) embedding.
             residual = hidden_states
             hidden_states = self.input_layernorm(hidden_states)
         else:
-            hidden_states, residual = fused_allreduce_rms_norm(
-                hidden_states, residual, self.input_layernorm
-            )
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
 
         hidden_states = self.self_attn(
             positions=positions,
             hidden_states=hidden_states,
         )
-        hidden_states, residual = fused_allreduce_rms_norm(
-            hidden_states, residual, self.post_attention_layernorm
-        )
-        # The MLP output is reduced by the next layer's input_layernorm (or by
-        # the model's final_norm).
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
         hidden_states = self.mlp(hidden_states)
         return hidden_states, residual
 
@@ -422,9 +410,7 @@ class K3DSparkModel(nn.Module):
                 hidden_states=hidden_states,
                 residual=residual,
             )
-        hidden_states, _ = fused_allreduce_rms_norm(
-            hidden_states, residual, self.final_norm
-        )
+        hidden_states, _ = self.final_norm(hidden_states, residual)
         return hidden_states
 
 


### PR DESCRIPTION
Auto-generated by CI failure analyzer.

Reverts vllm-project/vllm#50242 ("K3 DSpark AR fusion", merge commit `92643d68f551fe36c35a26b4a2e3bfd894d7d92a`).

### Why
Nightly build [#81716](https://buildkite.com/vllm/ci/builds/81716) had **3 new hard failures** that all trace to this commit:

| Job | Symptom |
|---|---|
| `PyTorch Fullgraph` | 23/23 real tests → `RuntimeError: Cannot re-initialize CUDA in forked subprocess` at `vllm/v1/worker/gpu_worker.py:368` |
| `Basic Models Tests (Extra Initialization) 2` | `test_can_initialize_large_subset[Eagle3DeepseekV3ForCausalLM]` → `ValueError: too many values to unpack (expected 2)` at `vllm/v1/worker/gpu_model_runner.py:6157` |
| `Basic Models Tests (Extra Initialization) 3` | same, `Eagle3DeepseekV2ForCausalLM` |

### Mechanism
#50242 added an eager package-level re-export of `fused_allreduce_rms_norm` to `vllm/models/common/ops/__init__.py`. A lightweight common-op import now pulls in model/config dependencies and **initializes CUDA before EngineCore process creation**:

- In `PyTorch Fullgraph`, CUDA is initialized after `_maybe_force_spawn()` has already run, so EngineCore is still forked → `Cannot re-initialize CUDA in forked subprocess`.
- In `Basic Models Tests (Extra Initialization)`, `system_utils.py:157` logs `We must use the 'spawn' multiprocessing start method ... Reasons: CUDA is initialized`. The spawned EngineCore loses `test_can_initialize_*`'s in-process KV-cache monkeypatch, so a real `profile_run()` executes and trips the unpack error.

This attribution matches the independent `git bisect` reported in #50639, which also identified `92643d68` as the first bad commit for both jobs.

### Note for reviewers
[#50639](https://github.com/vllm-project/vllm/pull/50639) is an open, **surgical** fix for the same defect (drop the eager re-export, import the helper directly in the three consuming model files). **If #50639 lands, prefer it and close this revert** — it keeps the AR-fusion feature. This PR exists as the mechanical fallback to unblock the nightly.

The revert applied cleanly with no conflicts (5 files, +8/-24, exact mirror of the original) and leaves no dangling imports.
