### PR TITLE
[Bugfix] Guard mhc_pre_broadcast_tilelang on DeepGEMM support

### DIFF
--- a/tests/kernels/test_mhc_kernels.py
+++ b/tests/kernels/test_mhc_kernels.py
@@ -355,3 +355,83 @@ def test_hc_head_tilelang(num_tokens, hidden_size, hc_mult):
 
     out_ref = hc_head_ref(residual, fn, hc_scale, hc_base, rms_eps, hc_eps)
     torch.testing.assert_close(out, out_ref, atol=5e-2, rtol=1e-2)
+
+
+@pytest.mark.skipif(
+    not HAS_TILELANG_MHC,
+    reason="TileLang MHC support required",
+)
+@pytest.mark.parametrize("num_tokens", [1, 8, 128])
+@pytest.mark.parametrize("hidden_size", [4096])
+@pytest.mark.parametrize("hc_mult", [4])
+def test_mhc_pre_broadcast_tilelang_without_deep_gemm(
+    num_tokens, hidden_size, hc_mult, monkeypatch
+):
+    """The broadcast variant must fall back to the TileLang prenorm GEMM when
+    DeepGEMM is unsupported (pre-Hopper), like its guarded siblings, instead
+    of calling tf32_hc_prenorm_gemm unconditionally and asserting
+    "Unsupported architecture"."""
+    from vllm.model_executor.kernels.mhc.tilelang import mhc_pre_broadcast_tilelang
+
+    monkeypatch.setattr(
+        "vllm.utils.deep_gemm.is_deep_gemm_supported", lambda: False
+    )
+
+    torch.set_default_device(DEVICE)
+    set_random_seed(0)
+
+    residual = torch.randn((num_tokens, hidden_size), dtype=torch.bfloat16)
+    hc_mult2 = hc_mult * hc_mult
+    hc_mult3 = 2 * hc_mult + hc_mult2
+    fn = (
+        torch.randn((hc_mult3, hc_mult, hidden_size), dtype=torch.float)
+        * 1e-4
+        * (1 + torch.arange(hc_mult).mul(0.01).view(1, -1, 1))
+    )
+    fn_broadcast = fn.sum(1)
+    fn = fn.flatten(1, 2)
+    hc_scale = torch.randn((3,), dtype=torch.float) * 0.1
+    hc_base = torch.randn((hc_mult3,), dtype=torch.float) * 0.1
+    norm_weight = torch.randn((hidden_size,), dtype=torch.bfloat16) * 0.1 + 1.0
+
+    hc_sinkhorn_eps = hc_pre_eps = rms_eps = 1e-6
+    norm_eps = 1e-6
+    sinkhorn_repeat = 20
+    hc_post_alpha = 1.0
+
+    expanded = residual.unsqueeze(1).expand(num_tokens, hc_mult, hidden_size)
+    post_ref, comb_ref, layer_ref = mhc_pre_ref(
+        expanded,
+        fn,
+        hc_scale,
+        hc_base,
+        rms_eps,
+        hc_pre_eps,
+        hc_sinkhorn_eps,
+        hc_post_alpha,
+        sinkhorn_repeat,
+    )
+    x = layer_ref.float()
+    layer_ref_normed = (
+        x * torch.rsqrt(x.square().mean(-1, keepdim=True) + norm_eps)
+    ).bfloat16() * norm_weight
+
+    residual_out, post, comb, layer_input = mhc_pre_broadcast_tilelang(
+        residual,
+        fn,
+        hc_scale,
+        hc_base,
+        rms_eps,
+        hc_pre_eps,
+        hc_sinkhorn_eps,
+        hc_post_alpha,
+        sinkhorn_repeat,
+        norm_weight=norm_weight,
+        norm_eps=norm_eps,
+        fn_broadcast=fn_broadcast,
+    )
+
+    torch.testing.assert_close(residual_out, expanded.contiguous())
+    torch.testing.assert_close(post, post_ref, atol=5e-2, rtol=1e-2)
+    torch.testing.assert_close(comb, comb_ref, atol=5e-2, rtol=1e-2)
+    torch.testing.assert_close(layer_input, layer_ref_normed, atol=5e-2, rtol=1e-2)

--- a/vllm/model_executor/kernels/mhc/tilelang.py
+++ b/vllm/model_executor/kernels/mhc/tilelang.py
@@ -348,7 +348,13 @@ def mhc_pre_broadcast_tilelang(
     residual_flat = residual
     num_tokens = residual.shape[0]
 
-    n_splits = compute_num_split(64, hidden_size, cdiv(num_tokens, 64))
+    from vllm.utils.deep_gemm import is_deep_gemm_supported
+
+    use_deep_gemm = is_deep_gemm_supported()
+    if use_deep_gemm:
+        n_splits = compute_num_split(64, hidden_size, cdiv(num_tokens, 64))
+    else:
+        n_splits = 1
 
     residual_out = torch.empty(
         num_tokens, hc_mult, hidden_size, dtype=torch.bfloat16, device=residual.device
@@ -369,15 +375,30 @@ def mhc_pre_broadcast_tilelang(
         n_splits, num_tokens, dtype=torch.float32, device=residual.device
     )
 
-    from vllm.utils.deep_gemm import tf32_hc_prenorm_gemm
+    if use_deep_gemm:
+        from vllm.utils.deep_gemm import tf32_hc_prenorm_gemm
 
-    tf32_hc_prenorm_gemm(
-        residual_flat,
-        fn_broadcast,
-        gemm_out_mul,
-        gemm_out_sqrsum,
-        n_splits,
-    )
+        tf32_hc_prenorm_gemm(
+            residual_flat,
+            fn_broadcast,
+            gemm_out_mul,
+            gemm_out_sqrsum,
+            n_splits,
+        )
+    else:
+        # Match the guarded siblings (mhc_pre_tilelang and
+        # mhc_fused_post_pre_tilelang): DeepGEMM is Hopper+-only, so fall back
+        # to the TileLang prenorm GEMM. The broadcast residual is hc_mult
+        # copies of residual_flat, so the GEMM runs against the pre-summed
+        # fn_broadcast with a single hidden-size-wide block.
+        _tilelang_hc_prenorm_gemm(
+            residual_flat,
+            fn_broadcast,
+            gemm_out_mul,
+            gemm_out_sqrsum,
+            hidden_size,
+            1,
+        )
     mhc_pre_big_fuse_broadcast_with_norm_tilelang(
         gemm_out_mul,
         gemm_out_sqrsum,


### PR DESCRIPTION
## Purpose

`mhc_pre_tilelang` and `mhc_fused_post_pre_tilelang` both guard their prenorm GEMM on `is_deep_gemm_supported()` and fall back to the TileLang implementation, but `mhc_pre_broadcast_tilelang` (the first-layer broadcast variant) calls DeepGEMM's `tf32_hc_prenorm_gemm` unconditionally. On any pre-Hopper CUDA device this dies on the first decoder layer with DeepGEMM's `hyperconnection.hpp: Unsupported architecture` assertion — the exact error reported by multiple users in #40851 (and part of the SM8x enablement tracked in #50576).

This applies the same guard as the siblings: when DeepGEMM is unsupported, run `_tilelang_hc_prenorm_gemm` against the pre-summed `fn_broadcast` with a single hidden-size-wide block and `n_splits=1`.

## Not a duplicate

Checked open PRs for `mhc`/`hyperconnection`/`deep_gemm` guards — no open PR touches `mhc_pre_broadcast_tilelang`. The sibling guards landed earlier; this variant was simply missed.

## Test Plan

New test `test_mhc_pre_broadcast_tilelang_without_deep_gemm` monkeypatches `is_deep_gemm_supported() -> False` and checks the fallback path against the file's existing `mhc_pre_ref` reference (plus the fused RMSNorm), mirroring `test_mhc_pre_tilelang`'s structure and tolerances. Without the fix the test dies in DeepGEMM's architecture assertion on pre-Hopper and exercises the guard on Hopper CI.

## Test Result

On 8x A800 (SM80, the architecture that hits the bug):

```
$ pytest tests/kernels/test_mhc_kernels.py -q
46 passed, 8 skipped in 147s
```

(3 new test cases pass; the fallback output matches the reference within the file's standard tolerances. Previously the function was uncallable on this hardware.)

## Disclosure

Authored with AI assistance (Claude); I have reviewed every changed line and run the tests above on the target hardware.

Related: #40851, #50576.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
