### PR TITLE
[Docs] Explain entry-point registration and checkpoint-driven selection for OOT quantization

### DIFF
--- a/docs/design/plugin_system.md
+++ b/docs/design/plugin_system.md
@@ -45,7 +45,7 @@ Every plugin has three parts:
 
 ## Types of supported plugins
 
-- **General plugins** (with group name `vllm.general_plugins`): The primary use case for these plugins is to register custom, out-of-the-tree models into vLLM. This is done by calling `ModelRegistry.register_model` to register the model inside the plugin function. For an example of an official model plugin, see the [bart-plugin](https://github.com/vllm-project/bart-plugin) which adds support for `BartForConditionalGeneration`.
+- **General plugins** (with group name `vllm.general_plugins`): The primary use case for these plugins is to register custom, out-of-the-tree models into vLLM. This is done by calling `ModelRegistry.register_model` to register the model inside the plugin function. For an example of an official model plugin, see the [bart-plugin](https://github.com/vllm-project/bart-plugin) which adds support for `BartForConditionalGeneration`. Out-of-tree quantization methods are registered from this group as well, since they must be present in the process that builds the model; see [Out-of-Tree Quantization Plugins](../features/quantization/README.md#out-of-tree-quantization-plugins).
 
 - **Platform plugins** (with group name `vllm.platform_plugins`): The primary use case for these plugins is to register custom, out-of-the-tree platforms into vLLM. The plugin function should return `None` when the platform is not supported in the current environment, or the platform class's fully qualified name when the platform is supported.
 

--- a/docs/features/quantization/README.md
+++ b/docs/features/quantization/README.md
@@ -228,4 +228,42 @@ from vllm import LLM
 llm = LLM(model="your-model", quantization="my_quant")
 ```
 
+#### Registering from an entry point
+
+The import above registers the method only where it runs, which leaves out `vllm serve` and any other path where you do not own the code that builds the engine. Declaring a general plugin instead makes vLLM load it in every process it creates:
+
+```toml
+# pyproject.toml
+[project.entry-points."vllm.general_plugins"]
+register_my_quant = "my_quant_plugin:register"
+```
+
+```python
+# my_quant_plugin/__init__.py
+def register():
+    from my_quant_plugin.config import MyQuantConfig  # noqa: F401
+```
+
+`@register_quantization_config` runs at import time, so `register()` only has to import the module that defines the config. Keep it re-entrant: it can be called more than once in a process.
+
+#### Selecting the method from the checkpoint
+
+When the model's `config.json` contains a `quantization_config` whose `quant_method` matches your registered name, vLLM resolves the method from it and `quantization` does not have to be passed:
+
+```json
+{
+  "quantization_config": {
+    "quant_method": "my_quant"
+  }
+}
+```
+
+```bash
+vllm serve /path/to/my-quantized-model
+```
+
+The whole `quantization_config` dict is handed to your `from_config` classmethod, so per-checkpoint settings such as bit widths or group sizes belong there. Passing `--quantization my_quant` as well is accepted, but a value that disagrees with the checkpoint is rejected rather than treated as an override.
+
+For a worked implementation of the entry point and the config together, see [DynQuant](https://github.com/kambojvikram/dynquant), which serves mixed-bit-width checkpoints this way.
+
 For more information on the plugin system, see the [Plugin System documentation](../../design/plugin_system.md).


### PR DESCRIPTION
## Purpose

The "Out-of-Tree Quantization Plugins" guide is a copy-paste tutorial that stops one step short of a working deployment. Its final section shows exactly one way to activate a custom method:

```python
import my_quant_plugin
llm = LLM(model="your-model", quantization="my_quant")
```

Two things are missing from that.

**There is no `import` to place under `vllm serve`.** The manual import works for the in-process `LLM(...)` path, but the CLI and API server construct the engine themselves, so a plugin author following this guide has no way to register their method for serving. The mechanism that does work — declaring the config under `vllm.general_plugins` so it is loaded in every process — is documented in `docs/design/plugin_system.md`, but that page describes the group as being for registering *models*, and neither page links to the other.

**The guide never says a checkpoint can select the method itself.** `ModelConfig._verify_quantization` (`vllm/config/model.py`) already reads `quant_method` out of the checkpoint's `quantization_config` and assigns it to `self.quantization`, and `get_quant_config` (`vllm/model_executor/model_loader/weight_utils.py:291`) passes that whole dict to `from_config`. Custom methods land in `QUANTIZATION_METHODS` on registration, so this path works for them exactly as it does for in-tree ones. Because the guide always passes `quantization="my_quant"` explicitly, it reads as though that argument is required, and `from_config` appears to have no source of per-checkpoint settings.

This adds two subsections to "Using the Plugin" covering both, and one sentence to the general-plugins bullet in the plugin system docs pointing at the quantization guide.

Docs only, no behavior change.

### Not a duplicate

`#50598` is the only other open PR touching this file. It repairs stale imports inside the code snippets (`FusedMoE` → `RoutedExperts`, the moved `UnquantizedFusedMoEMethod`, the `apply` signature). This PR does not touch those snippets; it appends to the "Using the Plugin" section, which `#50598` leaves alone. The two apply cleanly in either order. Searches run: `gh pr list --repo vllm-project/vllm --state open --search` for "out-of-tree quantization plugin docs", "quantization plugin entry point in:title", and "register_quantization_config".

## Test Plan

Docs are only worth changing if the thing they describe actually behaves that way, so both claims were exercised end to end on an A100 against vLLM 0.26.0, using an out-of-tree quantization plugin that follows the guide.

1. Register the config through a `vllm.general_plugins` entry point, export a checkpoint whose `config.json` names the method in `quantization_config.quant_method`, and start `vllm serve` on it with **no** `--quantization` flag.
2. Check the resolved `quantization` in the engine config and request a completion over HTTP.
3. Separately confirm the currently-documented manual-import path, to be sure this PR is describing a gap rather than a defect.
4. `markdownlint-cli2` v0.21.0 and `typos` v1.43.5 on both changed files, matching `.pre-commit-config.yaml`.

## Test Result

`vllm serve <checkpoint> --enforce-eager` with no `--quantization` argument:

```
Initializing a V1 LLM engine (v0.26.0) with config: model='.../ckpt', ..., quantization=dynquant, ...
```

```console
$ curl -s localhost:8199/v1/completions -H 'Content-Type: application/json' \
    -d '{"model":"dq","prompt":"The capital of France is","max_tokens":12,"temperature":0}'
{"id":"cmpl-a717e4997de4aebd","object":"text_completion","model":"dq","choices":[{"index":0,
 "text":": ____\nA. Paris\nB. London\nC","finish_reason":"length"}],
 "system_fingerprint":"vllm-0.26.0-8a1df4fc","usage":{"prompt_tokens":5,"completion_tokens":12}}
```

So the method is resolved from the checkpoint and the entry point is sufficient to serve without any user-side import.

On point 3: the documented manual import **does** work for `LLM(...)`, including with `VLLM_WORKER_MULTIPROC_METHOD=spawn` — I checked both before writing, because "the documented approach is broken" and "the documented approach does not cover serving" call for different edits. It is the latter. The existing snippet is therefore left exactly as it is, and the new text is additive.

Linters, both files, `docs/features/quantization/README.md` and `docs/design/plugin_system.md`:

```console
$ npx markdownlint-cli2@0.21.0 docs/features/quantization/README.md docs/design/plugin_system.md
markdownlint-cli2 v0.21.0 (markdownlint v0.40.0)
Linting: 2 file(s)
Summary: 0 error(s)

$ typos --force-exclude docs/features/quantization/README.md docs/design/plugin_system.md
(no output)
```

No model evaluation is included because the change is documentation only and alters no code path; the serving run above is evidence for the documented behavior, not a performance or accuracy claim.

One judgement call to flag for reviewers: the new text ends with a pointer to an out-of-tree implementation as a worked example, in the spirit of the `bart-plugin` link in `plugin_system.md`. It is my own project, so I have a conflict of interest in including it — happy to drop that one line if you would rather the guide stay free of third-party links. Nothing else in the PR depends on it.

AI assistance was used in preparing this change. I have reviewed every line and ran the tests above myself.
