### PR TITLE
[Frontend] add media_urls to completions for multimodal input

### DIFF
--- a/tests/entrypoints/multimodal/openai/chat_completion/test_vision.py
+++ b/tests/entrypoints/multimodal/openai/chat_completion/test_vision.py
@@ -678,3 +678,38 @@ async def test_completions_with_image_with_incorrect_uuid_format(
             messages,
             context=f"incorrect uuid format url={image_url}",
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_name", [MODEL_NAME])
+@pytest.mark.parametrize("image_url", [TEST_IMAGE_ASSETS[0]], indirect=True)
+async def test_completion_api_with_media_urls(
+    client: openai.AsyncOpenAI, model_name: str, image_url: str
+):
+    completion = await client.completions.create(
+        model=model_name,
+        prompt="<|user|>\n<|image_1|>\nWhat's in this image?<|end|>\n<|assistant|>\n",
+        max_tokens=32,
+        temperature=0.0,
+        extra_body={"media_urls": {"image": [image_url]}},
+    )
+    assert len(completion.choices[0].text) > 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_name", [MODEL_NAME])
+@pytest.mark.parametrize("raw_image_url", [TEST_IMAGE_ASSETS[0]])
+async def test_completion_api_with_base64_media_urls(
+    client: openai.AsyncOpenAI,
+    model_name: str,
+    raw_image_url: str,
+    url_encoded_image: dict[str, str],
+):
+    completion = await client.completions.create(
+        model=model_name,
+        prompt="<|user|>\n<|image_1|>\nWhat's in this image?<|end|>\n<|assistant|>\n",
+        max_tokens=32,
+        temperature=0.0,
+        extra_body={"media_urls": {"image": [url_encoded_image[raw_image_url]]}},
+    )
+    assert len(completion.choices[0].text) > 0

--- a/tests/entrypoints/openai/completion/test_completion_error.py
+++ b/tests/entrypoints/openai/completion/test_completion_error.py
@@ -476,6 +476,73 @@ def test_negative_prompt_token_ids_flat():
         )
 
 
+class TestCompletionMediaUrls:
+    """`media_urls` validation: rejected with prompt_embeds, multiple
+    prompts, or unsupported modalities."""
+
+    MEDIA_URLS = {"image": ["https://example.com/image.png"]}
+
+    def test_media_urls_with_single_prompt_allowed(self):
+        request = CompletionRequest(
+            model=MODEL_NAME,
+            prompt="<image>\nDescribe the image.",
+            media_urls=self.MEDIA_URLS,
+            max_tokens=10,
+        )
+        assert request.media_urls == self.MEDIA_URLS
+
+    def test_media_urls_with_token_ids_prompt_allowed(self):
+        request = CompletionRequest(
+            model=MODEL_NAME,
+            prompt=[1, 2, 3],
+            media_urls=self.MEDIA_URLS,
+            max_tokens=10,
+        )
+        assert request.media_urls == self.MEDIA_URLS
+
+    def test_media_urls_with_prompt_embeds_rejected(self):
+        with pytest.raises(
+            VLLMValidationError, match="not supported with `prompt_embeds`"
+        ):
+            CompletionRequest(
+                model=MODEL_NAME,
+                prompt_embeds=b"\x00",
+                media_urls=self.MEDIA_URLS,
+                max_tokens=10,
+            )
+
+    def test_media_urls_with_multiple_prompts_rejected(self):
+        with pytest.raises(VLLMValidationError, match="single prompt"):
+            CompletionRequest(
+                model=MODEL_NAME,
+                prompt=["Prompt one", "Prompt two"],
+                media_urls=self.MEDIA_URLS,
+                max_tokens=10,
+            )
+
+    def test_media_urls_unsupported_modality_rejected(self):
+        with pytest.raises(VLLMValidationError, match="Unsupported modalities"):
+            CompletionRequest(
+                model=MODEL_NAME,
+                prompt="test",
+                media_urls={"lidar": ["https://example.com/scan.bin"]},
+                max_tokens=10,
+            )
+
+    def test_media_urls_multiple_modalities_allowed(self):
+        multi = {
+            "image": ["https://example.com/img.jpg"],
+            "audio": ["https://example.com/clip.wav"],
+        }
+        request = CompletionRequest(
+            model=MODEL_NAME,
+            prompt="<image>\n<audio>\nDescribe.",
+            media_urls=multi,
+            max_tokens=10,
+        )
+        assert request.media_urls == multi
+
+
 class TestCompletionPromptListLimit:
     """Regression tests for CVE: unbounded prompt list fan-out."""
 

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -243,6 +243,19 @@ class CompletionRequest(OpenAIBaseModel):
         ),
     )
 
+    media_urls: dict[str, list[Annotated[str, Field(min_length=1)]]] | None = Field(
+        default=None,
+        description=(
+            "Multimodal media URLs keyed by modality. Each value is a list "
+            "of URLs (http/https, base64 data URL, or file:// URL). "
+            "The input prompt must contain the correct placeholder tokens "
+            "(one per item). Supported modalities: image, video, audio. "
+            "Not supported for multiple prompts or `prompt_embeds`. "
+            'Example: {"image": ["https://example.com/photo.jpg"], '
+            '"audio": ["data:audio/wav;base64,..."]}'
+        ),
+    )
+
     # --8<-- [end:completion-extra-params]
 
     def build_tok_params(self, model_config: ModelConfig) -> TokenizeParams:
@@ -539,6 +552,38 @@ class CompletionRequest(OpenAIBaseModel):
             raise VLLMValidationError(
                 "Either prompt or prompt_embeds must be provided and non-empty.",
                 parameter="prompt",
+            )
+
+        return data
+
+    _FETCHABLE_MODALITIES = frozenset({"image", "video", "audio"})
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_media_urls(cls, data):
+        media_urls = data.get("media_urls")
+        if not media_urls:
+            return data
+
+        if data.get("prompt_embeds") is not None:
+            raise VLLMValidationError(
+                "`media_urls` is not supported with `prompt_embeds`.",
+                parameter="media_urls",
+            )
+
+        prompt = data.get("prompt")
+        if isinstance(prompt, list) and len(prompt) > 1 and not is_list_of(prompt, int):
+            raise VLLMValidationError(
+                "`media_urls` is only supported with a single prompt.",
+                parameter="media_urls",
+            )
+
+        unknown = set(media_urls.keys()) - cls._FETCHABLE_MODALITIES
+        if unknown:
+            raise VLLMValidationError(
+                f"Unsupported modalities in `media_urls`: {unknown}. "
+                f"Supported: {sorted(cls._FETCHABLE_MODALITIES)}",
+                parameter="media_urls",
             )
 
         return data

--- a/vllm/renderers/online_renderer.py
+++ b/vllm/renderers/online_renderer.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import asyncio
 from collections.abc import Sequence
 from http import HTTPStatus
 from typing import Any
 
 from openai_harmony import Message as OpenAIMessage
 
+from vllm import envs
 from vllm.config import ModelConfig
 from vllm.entrypoints.chat_utils import (
     ChatTemplateContentFormatOption,
@@ -30,6 +32,7 @@ from vllm.entrypoints.serve.utils.error_response import create_error_response
 from vllm.entrypoints.serve.utils.request_logger import RequestLogger
 from vllm.inputs import (
     EngineInput,
+    MultiModalDataDict,
     PromptType,
     SingletonPrompt,
     tokens_input,
@@ -354,6 +357,13 @@ class OnlineRenderer:
             )
             for prompt in prompts
         ]
+
+        if media_urls := getattr(request, "media_urls", None):
+            mm_data = await self._resolve_media_urls(media_urls)
+            for p in parsed_prompts:
+                if not isinstance(p, bytes):
+                    p["multi_modal_data"] = mm_data
+
         tok_params = request.build_tok_params(model_config)
 
         return await renderer.render_cmpl_async(
@@ -366,6 +376,35 @@ class OnlineRenderer:
             },
             skip_mm_cache=skip_mm_cache,
         )
+
+    async def _resolve_media_urls(
+        self, media_urls: dict[str, list[str]]
+    ) -> MultiModalDataDict:
+        from vllm.multimodal.media import MEDIA_CONNECTOR_REGISTRY
+
+        connector = MEDIA_CONNECTOR_REGISTRY.load(
+            envs.VLLM_MEDIA_CONNECTOR,
+            media_io_kwargs=(
+                self.model_config.multimodal_config.media_io_kwargs
+                if self.model_config.multimodal_config
+                else None
+            ),
+            allowed_local_media_path=(self.model_config.allowed_local_media_path),
+        )
+
+        fetchers = {
+            "image": connector.fetch_image_async,
+            "video": connector.fetch_video_async,
+            "audio": connector.fetch_audio_async,
+        }
+
+        mm_data: dict[str, list[object]] = {}
+        for modality, urls in media_urls.items():
+            fetch_fn = fetchers[modality]
+            mm_data[modality] = list(
+                await asyncio.gather(*(fetch_fn(url) for url in urls))
+            )
+        return mm_data
 
     async def preprocess_chat(
         self,


### PR DESCRIPTION
## Purpose

The `/v1/completions` and `/v1/completions/render` endpoints currently have
no way to accept multimodal inputs. The renderer layer fully supports
multimodal processing (`_process_multimodal` / `MediaConnector`), but
`CompletionRequest` has no field to carry media data in — unlike chat
completions, which use message content parts.

This is a gap for multi-modal RL workloads that need raw prompting (no chat
template) with image/video/audio inputs.

This PR adds a `media_urls` sidecar field to `CompletionRequest`:

```json
{
  "prompt": "<image_1>\n<audio_1>\nDescribe what you see and hear",
  "media_urls": {
    "image": ["https://example.com/photo.jpg"],
    "audio": ["data:audio/wav;base64,UklGR..."]
  }
}
```

### Design

- `media_urls` is a dict keyed by modality (`image`, `video`, `audio`)
- URLs are resolved via `MediaConnector` (supports http/https, base64 data
  URLs, and `file://` URLs)
- Resolution happens in `OnlineRenderer.preprocess_cmpl`, the shared code
  path for both `/v1/completions` and `/v1/completions/render` — both
  endpoints benefit with zero changes to the renderer or scale-out layer
- Users manage placeholder tokens in their prompt; no chat template involved

### Comparison with chat completions

| | Chat completions | Completions (this PR) |
|---|---|---|
| Multimodal entry | message content parts | `media_urls` sidecar |
| Placeholder mgmt | renderer + chat template | user-managed |
| Template processing | required | none |

Supersedes #50489 (which only supported `image_urls`).

## Test Plan

- CPU validation tests for `media_urls` field validation (prompt_embeds
  rejection, multi-prompt rejection, unsupported modality rejection,
  multi-modality allowed)
- GPU integration tests with Phi-3.5-vision-instruct (HTTP URL + base64
  data URL)

```bash
# CPU tests
pytest tests/entrypoints/openai/completion/test_completion_error.py::TestCompletionMediaUrls -v

# GPU tests (requires GPU)
pytest tests/entrypoints/multimodal/openai/chat_completion/test_vision.py::test_completion_api_with_media_urls -v
pytest tests/entrypoints/multimodal/openai/chat_completion/test_vision.py::test_completion_api_with_base64_media_urls -v
```

## Test Result

CPU validation tests: ✅ (pending CI)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- AI assistance was used for implementation
- This is not duplicating an existing PR — it supersedes #50489 with broader
  modality support