### PR TITLE
[Rust Frontend] add media_urls to completions for multimodal input

### DIFF
--- a/rust/src/chat/src/lib.rs
+++ b/rust/src/chat/src/lib.rs
@@ -261,6 +261,32 @@ impl ChatLlm {
         self.processor.backend.multimodal_model_info().is_some()
     }
 
+    /// Resolve multimodal media URLs for a completions request.
+    ///
+    /// Converts a `media_urls` map (keyed by modality) into
+    /// [`MediaContentPart`]s, runs the full multimodal pipeline (fetch,
+    /// preprocess, placeholder expansion), and returns the resulting
+    /// [`MmFeatures`]. `prompt_token_ids` is mutated in place to expand
+    /// placeholder tokens.
+    pub async fn resolve_completion_media(
+        &self,
+        media_urls: &std::collections::HashMap<String, Vec<String>>,
+        prompt_token_ids: &mut Vec<u32>,
+    ) -> Result<MmFeatures> {
+        let info = self
+            .processor
+            .backend
+            .multimodal_model_info()
+            .ok_or(Error::UnsupportedMultimodalRenderer)?;
+        let model_dtype = self
+            .processor
+            .model_dtype
+            .ok_or(Error::UnsupportedMultimodalRenderer)?;
+        let media_parts = multimodal::media_urls_to_parts(media_urls)?;
+        info.prepare_multimodal(media_parts, prompt_token_ids, model_dtype)
+            .await
+    }
+
     /// Effective tool-call parser name for this model, if parsing is enabled.
     pub fn tool_call_parser_name(&self) -> Option<&str> {
         match &self.tool_call_parser {

--- a/rust/src/chat/src/multimodal.rs
+++ b/rust/src/chat/src/multimodal.rs
@@ -630,6 +630,39 @@ fn extract_media_parts(request: &ChatRequest) -> Result<Vec<MediaContentPart>> {
     Ok(all_parts)
 }
 
+/// Convert a `media_urls` map (keyed by modality) into [`MediaContentPart`]s.
+pub(crate) fn media_urls_to_parts(
+    media_urls: &std::collections::HashMap<String, Vec<String>>,
+) -> Result<Vec<MediaContentPart>> {
+    let mut parts = Vec::new();
+    for (modality, urls) in media_urls {
+        for url in urls {
+            match modality.as_str() {
+                "image" => parts.push(MediaContentPart::ImageUrl {
+                    url: url.clone(),
+                    detail: None,
+                    uuid: None,
+                }),
+                "video" => parts.push(MediaContentPart::VideoUrl {
+                    url: url.clone(),
+                    uuid: None,
+                }),
+                "audio" => parts.push(MediaContentPart::AudioUrl {
+                    url: url.clone(),
+                    uuid: None,
+                }),
+                other => {
+                    bail_multimodal!(
+                        "unsupported modality in media_urls: {other}; \
+                         supported: image, video, audio"
+                    );
+                }
+            }
+        }
+    }
+    Ok(parts)
+}
+
 /// Wrap OpenAI base64 audio in a data URL consumed by `MediaConnector`.
 fn input_audio_data_url(data: &str, format: Option<&str>) -> Result<String> {
     let mime_type = match format {
@@ -696,7 +729,7 @@ impl MultimodalModelInfo {
     /// `prompt_token_ids` is mutated in place because placeholder expansion
     /// changes both the final prompt and the offsets recorded in
     /// `PlaceholderRange`.
-    async fn prepare_multimodal(
+    pub(crate) async fn prepare_multimodal(
         &self,
         media_parts: Vec<MediaContentPart>,
         prompt_token_ids: &mut Vec<u32>,

--- a/rust/src/server/src/routes/openai/completions.rs
+++ b/rust/src/server/src/routes/openai/completions.rs
@@ -49,11 +49,50 @@ use crate::utils::{resolve_request_context, unix_timestamp};
 pub async fn completions(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
-    ValidatedJson(body): ValidatedJson<CompletionRequest>,
+    ValidatedJson(mut body): ValidatedJson<CompletionRequest>,
 ) -> Response {
     let stream = body.stream;
     let request_context = resolve_request_context(&headers, body.request_id.as_deref());
     let lora_resolution = state.resolve_model_with_loras(Some(&body.model)).await;
+
+    // Resolve multimodal media URLs before lowering to text request.
+    let mm_features = if let Some(media_urls) = body.media_urls.take() {
+        let tokenizer = state.chat.text().tokenizer();
+        let mut token_ids = match &body.prompt {
+            vllm_text::Prompt::Text(text) => {
+                match tokenizer.encode(text, body.add_special_tokens) {
+                    Ok(ids) => ids,
+                    Err(e) => {
+                        return ApiError::invalid_request(
+                            format!("failed to tokenize prompt for media resolution: {e}"),
+                            Some("prompt"),
+                        )
+                        .into_response();
+                    }
+                }
+            }
+            vllm_text::Prompt::TokenIds(ids) => ids.clone(),
+        };
+        match state
+            .chat
+            .resolve_completion_media(&media_urls, &mut token_ids)
+            .await
+        {
+            Ok(features) => {
+                body.prompt = vllm_text::Prompt::TokenIds(token_ids);
+                Some(features)
+            }
+            Err(e) => {
+                return ApiError::invalid_request(
+                    format!("failed to resolve media_urls: {}", e.as_report()),
+                    Some("media_urls"),
+                )
+                .into_response();
+            }
+        }
+    } else {
+        None
+    };
 
     let tokenizer = state.chat.text().tokenizer();
     let prepared = match prepare_completion_request(
@@ -61,6 +100,7 @@ pub async fn completions(
         &lora_resolution,
         request_context,
         tokenizer.as_ref(),
+        mm_features,
     ) {
         Ok(prepared) => prepared,
         Err(error) => return error.into_response(),

--- a/rust/src/server/src/routes/openai/completions/convert.rs
+++ b/rust/src/server/src/routes/openai/completions/convert.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 use thiserror_ext::AsReport as _;
+use vllm_engine_core_client::protocol::multimodal::MmFeatures;
 use vllm_text::tokenizer::Tokenizer;
 use vllm_text::{Prompt, SamplingParams, TextDecodeOptions, TextRequest};
 
@@ -58,6 +59,7 @@ pub(super) fn prepare_completion_request(
     lora_resolution: &LoraModelResolution,
     ctx: ResolvedRequestContext,
     tokenizer: &dyn Tokenizer,
+    mm_features: Option<MmFeatures>,
 ) -> Result<PreparedRequest, ApiError> {
     validate::validate_request_compat(&request, &lora_resolution.model_names)?;
 
@@ -107,7 +109,7 @@ pub(super) fn prepare_completion_request(
     let text_request = TextRequest {
         request_id: request_id.clone(),
         prompt: request.prompt,
-        mm_features: None,
+        mm_features,
         sampling_params: SamplingParams {
             temperature: request.temperature,
             top_p: request.top_p,
@@ -304,6 +306,7 @@ mod tests {
             &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
             ResolvedRequestContext::default(),
             &test_tokenizer(),
+        None,
         )
         .expect("prepare");
 
@@ -347,6 +350,7 @@ mod tests {
                 &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
                 ResolvedRequestContext::default(),
                 &test_tokenizer(),
+                None,
             )
             .expect("prepare")
             .text_request
@@ -381,6 +385,7 @@ mod tests {
             &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
             ResolvedRequestContext::default(),
             &test_tokenizer(),
+        None,
         )
         .expect("prepare");
 
@@ -406,6 +411,7 @@ mod tests {
             &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
             ResolvedRequestContext::default(),
             &test_tokenizer(),
+        None,
         )
         .expect("prepare");
 
@@ -429,6 +435,7 @@ mod tests {
             &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
             ResolvedRequestContext::default(),
             &test_tokenizer(),
+        None,
         )
         .expect("prepare");
 
@@ -453,6 +460,7 @@ mod tests {
             &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
             ResolvedRequestContext::default(),
             &test_tokenizer(),
+        None,
         )
         .expect("prepare");
 
@@ -478,6 +486,7 @@ mod tests {
             &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
             ResolvedRequestContext::default(),
             &test_tokenizer(),
+        None,
         )
         .expect("prepare");
 
@@ -505,6 +514,7 @@ mod tests {
             &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
             ResolvedRequestContext::default(),
             &test_tokenizer(),
+        None,
         )
         .expect("prepare");
 
@@ -530,6 +540,7 @@ mod tests {
             &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
             ResolvedRequestContext::default(),
             &test_tokenizer(),
+        None,
         )
         .expect("prepare");
 
@@ -556,6 +567,7 @@ mod tests {
             &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
             ResolvedRequestContext::default(),
             &test_tokenizer(),
+        None,
         )
         .expect("prepare");
         assert_eq!(prepared.text_request.sampling_params.logprobs, Some(1));
@@ -581,6 +593,7 @@ mod tests {
             &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
             request_context(&headers, None),
             &test_tokenizer(),
+        None,
         )
         .expect("prepare");
         assert_eq!(prepared.text_request.data_parallel_rank, Some(3));
@@ -600,6 +613,7 @@ mod tests {
             &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
             ResolvedRequestContext::default(),
             &test_tokenizer(),
+        None,
         )
         .expect("prepare");
         assert_eq!(prepared.text_request.data_parallel_rank, None);

--- a/rust/src/server/src/routes/openai/completions/types.rs
+++ b/rust/src/server/src/routes/openai/completions/types.rs
@@ -184,6 +184,11 @@ pub struct CompletionRequest {
     /// extensions
     pub vllm_xargs: Option<HashMap<String, Value>>,
 
+    /// Multimodal media URLs keyed by modality (image, video, audio).
+    /// Each value is a list of URLs (http/https, base64 data URL, or
+    /// file:// URL). The prompt must contain placeholder tokens.
+    pub media_urls: Option<HashMap<String, Vec<String>>>,
+
     /// Additional fields
     #[serde(flatten)]
     pub other: Map<String, Value>,


### PR DESCRIPTION
## Purpose

The Rust `/v1/completions` endpoint currently has no way to accept
multimodal inputs — `mm_features` is hardcoded to `None` in
`prepare_completion_request`. This mirrors the same gap that exists
in the Python frontend (addressed separately in #50489).

This PR adds a `media_urls` sidecar field to the Rust `CompletionRequest`,
using the existing multimodal pipeline (`MediaConnector` → preprocess →
placeholder expansion → `MmFeatures`).

### Usage

```json
{
  "prompt": "<image_1>\nDescribe this image",
  "media_urls": {
    "image": ["https://example.com/photo.jpg"]
  }
}
```

### Changes

| File | Change |
|---|---|
| `completions/types.rs` | Add `media_urls` field |
| `chat/lib.rs` | Expose `resolve_completion_media()` |
| `chat/multimodal.rs` | Add `media_urls_to_parts()`, make `prepare_multimodal` pub(crate) |
| `completions.rs` | Resolve media before building `TextRequest` |
| `completions/convert.rs` | Thread `MmFeatures` through `prepare_completion_request` |

Companion to the Python-side change that adds `media_urls` to
`CompletionRequest` in the Python frontend.

## Test Plan

```bash
cd rust && cargo test -p vllm-server -- completions
cd rust && cargo test -p vllm-chat
```

## Test Result

- `vllm-server`: 111 passed, 0 failed ✅
- `vllm-chat`: 15 passed, 1 failed (pre-existing permission issue downloading GLM-4.7 tokenizer) ✅

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- AI assistance was used for implementation
- Not duplicating an existing PR — this is the Rust companion to the Python media_urls change