### PR TITLE
[Bugfix][KV Offloading] Fix CPU offload block count mismatch across PP ranks

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -11,7 +11,14 @@ import pytest
 import torch
 
 import vllm.v1.core.kv_cache_utils as kv_cache_utils
-from vllm.config import ModelConfig, SchedulerConfig, VllmConfig
+from vllm.config import (
+    CacheConfig,
+    KVTransferConfig,
+    ModelConfig,
+    ParallelConfig,
+    SchedulerConfig,
+    VllmConfig,
+)
 from vllm.config.kv_events import KVEventsConfig
 from vllm.lora.request import LoRARequest
 from vllm.multimodal.inputs import (
@@ -1216,6 +1223,53 @@ def test_get_kv_cache_configs_pp_sharding(asymmetric_memory):
             kv_cache_groups=[KVCacheGroupSpec(["layer2"], ref_kv_cache_spec)],
         ),
     ]
+
+
+def test_get_kv_cache_configs_unifies_cpu_offload_blocks_across_pp_stages():
+    model_config = SimpleNamespace(
+        max_model_len=512,
+        original_max_model_len=512,
+        use_mla=False,
+    )
+    vllm_config = SimpleNamespace(
+        model_config=model_config,
+        cache_config=CacheConfig(block_size=16),
+        scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False),
+        parallel_config=ParallelConfig(pipeline_parallel_size=2),
+        speculative_config=None,
+        kv_transfer_config=KVTransferConfig(
+            kv_connector="OffloadingConnector",
+            kv_role="kv_both",
+            kv_connector_extra_config={
+                "cpu_bytes_to_use": 10 * GiB_bytes,
+            },
+        ),
+    )
+
+    ref_kv_cache_spec = new_kv_cache_spec()
+    pp_kv_cache_specs = [
+        {f"layer{i}": ref_kv_cache_spec for i in range(5)},
+        {f"layer{i}": ref_kv_cache_spec for i in range(5, 8)},
+    ]
+
+    num_gpu_blocks = 1000
+    available_memory = [
+        ref_kv_cache_spec.page_size_bytes * 5 * num_gpu_blocks,
+        ref_kv_cache_spec.page_size_bytes * 3 * num_gpu_blocks,
+    ]
+
+    kv_cache_configs = get_kv_cache_configs(
+        vllm_config,
+        pp_kv_cache_specs,
+        available_memory,
+    )
+
+    expected_num_cpu_blocks = 10 * GiB_bytes // (
+        ref_kv_cache_spec.page_size_bytes * 5 * vllm_config.parallel_config.world_size
+    )
+    assert [
+        kv_cache_config.num_cpu_blocks for kv_cache_config in kv_cache_configs
+    ] == [expected_num_cpu_blocks, expected_num_cpu_blocks]
 
 
 def test_project_kv_cache_groups_to_worker():

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/config.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/config.py
@@ -179,4 +179,5 @@ def build_offloading_config(
             is_parallelism_agnostic=is_parallelism_agnostic,
         ),
         replicated_layout=replicated_layout,
+        num_cpu_blocks=kv_cache_config.num_cpu_blocks,
     )

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -5,6 +5,7 @@
 import copy
 import hashlib
 import math
+import mmap
 import os
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, Sequence
@@ -2091,6 +2092,142 @@ def _project_kv_cache_groups_to_worker(
     return projected_groups
 
 
+def _get_cpu_offload_blocks_per_chunk(
+    vllm_config: VllmConfig, kv_cache_config: KVCacheConfig
+) -> int:
+    kv_transfer_config = vllm_config.kv_transfer_config
+    assert kv_transfer_config is not None
+    extra_config = kv_transfer_config.kv_connector_extra_config
+
+    blocks_per_chunk_config = extra_config.get("blocks_per_chunk")
+    tokens_per_chunk = extra_config.get("block_size")
+
+    if blocks_per_chunk_config is not None and tokens_per_chunk is not None:
+        raise ValueError(
+            "Specify only one of 'block_size' or 'blocks_per_chunk' "
+            "in kv_connector_extra_config."
+        )
+
+    if blocks_per_chunk_config is not None:
+        blocks_per_chunk = int(blocks_per_chunk_config)
+        if blocks_per_chunk <= 0:
+            raise ValueError("'blocks_per_chunk' must be greater than 0.")
+        return blocks_per_chunk
+
+    if tokens_per_chunk is None:
+        return 1
+
+    tokens_per_chunk_int = int(tokens_per_chunk)
+    _, tokens_per_block = resolve_kv_cache_block_sizes(kv_cache_config, vllm_config)
+    assert tokens_per_chunk_int % tokens_per_block == 0
+    return tokens_per_chunk_int // tokens_per_block
+
+
+def _uses_replicated_cpu_offload_layout(
+    vllm_config: VllmConfig,
+    kv_cache_config: KVCacheConfig,
+    worker_kv_bytes_per_block: int,
+) -> bool:
+    parallel_config = vllm_config.parallel_config
+    single_group_spec = (
+        kv_cache_config.kv_cache_groups[0].kv_cache_spec
+        if len(kv_cache_config.kv_cache_groups) == 1
+        else None
+    )
+
+    return (
+        vllm_config.model_config.use_mla
+        and type(single_group_spec) is MLAAttentionSpec
+        and worker_kv_bytes_per_block > 0
+        and worker_kv_bytes_per_block
+        == single_group_spec.page_size_bytes
+        * len(kv_cache_config.kv_cache_groups[0].layer_names)
+        and parallel_config.tensor_parallel_size > 1
+        and parallel_config.pipeline_parallel_size == 1
+        and parallel_config.prefill_context_parallel_size == 1
+        and parallel_config.decode_context_parallel_size == 1
+        and parallel_config.world_size == parallel_config.tensor_parallel_size
+        and parallel_config.distributed_executor_backend == "mp"
+        and parallel_config.nnodes_within_dp == 1
+    )
+
+
+def get_cpu_offload_num_blocks(
+    vllm_config: VllmConfig, kv_cache_config: KVCacheConfig
+) -> int:
+    kv_transfer_config = vllm_config.kv_transfer_config
+    assert kv_transfer_config is not None
+
+    cpu_bytes_to_use = kv_transfer_config.kv_connector_extra_config.get(
+        "cpu_bytes_to_use"
+    )
+    if not cpu_bytes_to_use:
+        raise Exception(
+            "cpu_bytes_to_use must be specified in kv_connector_extra_config"
+        )
+
+    worker_kv_bytes_per_block = 0
+    if kv_cache_config.num_blocks > 0:
+        packed_tensors = tuple(
+            bool(tensor.block_stride) for tensor in kv_cache_config.kv_cache_tensors
+        )
+        is_packed = any(packed_tensors)
+        assert not is_packed or all(packed_tensors)
+        total_gpu_kv_bytes = (
+            kv_cache_config.kv_cache_tensors[0].size
+            if is_packed
+            else sum(tensor.size for tensor in kv_cache_config.kv_cache_tensors)
+        )
+        worker_kv_bytes_per_block = total_gpu_kv_bytes // kv_cache_config.num_blocks
+
+    world_size = vllm_config.parallel_config.world_size
+    if worker_kv_bytes_per_block <= 0 or world_size <= 0:
+        return 0
+
+    num_copies = (
+        1
+        if _uses_replicated_cpu_offload_layout(
+            vllm_config, kv_cache_config, worker_kv_bytes_per_block
+        )
+        else world_size
+    )
+    kv_bytes_per_block = worker_kv_bytes_per_block * num_copies
+    kv_bytes_per_chunk = (
+        kv_bytes_per_block
+        * _get_cpu_offload_blocks_per_chunk(vllm_config, kv_cache_config)
+    )
+    aligned_kv_bytes_per_chunk = round_up(kv_bytes_per_chunk, mmap.PAGESIZE)
+    return int(cpu_bytes_to_use) // aligned_kv_bytes_per_chunk
+
+
+def _uses_cpu_offloading_spec(vllm_config: VllmConfig) -> bool:
+    kv_transfer_config = vllm_config.kv_transfer_config
+    if (
+        kv_transfer_config is None
+        or kv_transfer_config.kv_connector != "OffloadingConnector"
+    ):
+        return False
+
+    spec_name = kv_transfer_config.kv_connector_extra_config.get(
+        "spec_name", "CPUOffloadingSpec"
+    )
+    return spec_name == "CPUOffloadingSpec"
+
+
+def _unify_cpu_offload_num_blocks(
+    vllm_config: VllmConfig, kv_cache_configs: list[KVCacheConfig]
+) -> None:
+    if not _uses_cpu_offloading_spec(vllm_config):
+        return
+
+    min_num_cpu_blocks = min(
+        get_cpu_offload_num_blocks(vllm_config, kv_cache_config)
+        for kv_cache_config in kv_cache_configs
+    )
+    for kv_cache_config in kv_cache_configs:
+        kv_cache_config.num_cpu_blocks = min_num_cpu_blocks
+
+
 def get_kv_cache_configs(
     vllm_config: VllmConfig,
     kv_cache_specs: list[dict[str, KVCacheSpec]],
@@ -2115,6 +2252,8 @@ def get_kv_cache_configs(
        different PP stages are similar.)
     5. Change the num_blocks of each worker to the smallest among all workers
        and shrink tensor sizes proportionally to avoid allocating unused memory.
+    6. If native CPU offloading is enabled, set the CPU offload num_blocks to
+       the smallest value supported by any worker.
 
     Args:
         vllm_config: The global VllmConfig
@@ -2222,6 +2361,9 @@ def get_kv_cache_configs(
             assert tensor.size % num_blocks_old == 0
             tensor.size = tensor.size // num_blocks_old * min_num_blocks
 
+    _unify_cpu_offload_num_blocks(vllm_config, kv_cache_configs)
+
+    for kv_cache_config in kv_cache_configs:
         if len(kv_cache_config.kv_cache_groups) > 0:
             max_model_len = vllm_config.model_config.max_model_len
             # GPU KV cache size in tokens = max_concurrency * max_model_len:

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -979,6 +979,8 @@ class KVCacheConfig:
     For models with multiple types of attention, there will be multiple groups,
     see `_get_kv_cache_config_uniform_page_size` for more details.
     """
+    num_cpu_blocks: int | None = None
+    """The unified number of CPU offload blocks, if CPU offloading is enabled."""
 
     @property
     def has_mamba_layers(self) -> bool:

--- a/vllm/v1/kv_offload/config.py
+++ b/vllm/v1/kv_offload/config.py
@@ -74,3 +74,5 @@ class OffloadingConfig:
     # support it. Aggregate layout decision; per-layer replication metadata
     # is planned for CanonicalKVCacheRef (#48408).
     replicated_layout: bool = False
+    # Unified number of CPU offload blocks across all workers, if precomputed.
+    num_cpu_blocks: int | None = None

--- a/vllm/v1/kv_offload/cpu/spec.py
+++ b/vllm/v1/kv_offload/cpu/spec.py
@@ -100,7 +100,12 @@ class CPUOffloadingSpec(OffloadingSpec):
             aligned_kv_bytes_per_chunk = round_up(
                 kv_bytes_per_chunk, self.BLOCK_SIZE_ALIGNMENT
             )
-            self.num_blocks = int(cpu_bytes_to_use) // aligned_kv_bytes_per_chunk
+            computed_num_blocks = int(cpu_bytes_to_use) // aligned_kv_bytes_per_chunk
+            self.num_blocks = (
+                config.num_cpu_blocks
+                if config.num_cpu_blocks is not None
+                else computed_num_blocks
+            )
 
             # Expose aligned_kv_bytes_per_chunk as
             # kv_bytes_per_chunk. Note that this might contain


### PR DESCRIPTION
### Motivation

Native CPU offloading computes CPU cache capacity from each worker's KV cache tensors. Under pipeline parallelism, workers may own different numbers or types of layers, so different PP ranks can derive different CPU offload block counts.

The scheduler uses the first worker's KV cache config, while workers build offloading specs from their local configs. If the scheduler-side CPU block count is larger than a worker's local CPU buffer capacity, offloaded block IDs can exceed that worker's allocated CPU cache range.

### Runtime Validation

  I reproduced the issue with vLLM v0.26.0 using:

  - Model: `GLM-5.2-NVFP4`
  - `pipeline_parallel_size=4`
  - `tensor_parallel_size=1`
  - Native CPU offloading via `OffloadingConnector`
  - Prefix caching enabled
  - No SSD offloading

  Before the fix, different PP ranks computed different CPU offload block counts from their local KV cache tensors:

  ```text
  scheduler/rank0 CPU num_blocks: 35341
  worker/rank0 CPU num_blocks: 35341
  worker/rank1 CPU num_blocks: 34435
  worker/rank2 CPU num_blocks: 34435
  worker/rank3 CPU num_blocks: 36561
  ```
  This confirms the mismatch. Since the scheduler allocates CPU block IDs based on its own CPU block count, rank1/rank2 only had capacity for 34435 blocks while the scheduler could allocate IDs up to 35340. Those IDs would be outside rank1/rank2's CPU buffer range.

  After applying the fix, all PP ranks used the same unified minimum CPU block count:
  ```text
  scheduler CPU num_blocks: 34435
  worker/rank0 CPU num_blocks: 34435
  worker/rank1 CPU num_blocks: 34435
  worker/rank2 CPU num_blocks: 34435
  worker/rank3 CPU num_blocks: 34435
  ```
  The fixed server also started successfully and returned successful responses:

  GET /health -> 200
  POST /v1/completions -> 200

  ### Proposed Changes

  - Add `num_cpu_blocks` to `KVCacheConfig` and `OffloadingConfig`.
  - Compute CPU offload block capacity for every worker KV cache config.
  - Store the minimum CPU offload block count across workers on every config.
  - Propagate the unified value into `CPUOffloadingSpec`.
  - Add a PP regression test with uneven layer counts.
  - Keep the regression test offline-friendly by using a lightweight config object instead of `ModelConfig(max_model_len=512)`, which can trigger default `Qwen/Qwen3-0.6B`
  Hugging Face validation.

  ### Test Plan

  ```bash
  /home/huangxinyi/vllm/.venv/bin/python -m pytest \
    tests/v1/core/test_kv_cache_utils.py::test_get_kv_cache_configs_unifies_cpu_offload_blocks_across_pp_stages -v

  Result:

  1 passed, 15 warnings in 0.94s

  git diff --check

  Result: passed.

  .venv/bin/python -m ruff check \
    tests/v1/core/test_kv_cache_utils.py \
    vllm/v1/core/kv_cache_utils.py \
    vllm/v1/kv_cache_interface.py \
    vllm/v1/kv_offload/config.py \
    vllm/v1/kv_offload/cpu/spec.py \
    vllm/distributed/kv_transfer/kv_connector/v1/offloading/config.py

  Result:

  All checks passed!

  Manual serving validation was also performed on vLLM v0.26.0 with GLM-5.2-NVFP4, pipeline_parallel_size=4, tensor_parallel_size=1, native CPU offloading, and prefix caching. Before the fix, worker CPU block counts differed across PP ranks. After the fix, all ranks used the unified CPU block count and the server returned successful /health and /v1/completions responses.

  ### Duplicate Work Check

  I searched open vLLM PRs/issues for CPU offload, pipeline parallelism, OffloadingConnector, and num_blocks mismatch. I did not find an existing open PR that fixes this PP native CPU offload num_cpu_blocks consistency issue.

