### PR TITLE
[ROCm][Perf] Fuse and FP8-pack Kimi-K3 latent MoE output tail

### DIFF
--- a/tests/models/kimi_k3/test_amd_latent_moe_tail.py
+++ b/tests/models/kimi_k3/test_amd_latent_moe_tail.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import importlib
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from vllm._aiter_ops import rocm_aiter_ops
+from vllm.models.kimi_k3.amd.linear import (
+    KimiAMDLatentMoERunner,
+    KimiRoutedOutputTransform,
+)
+from vllm.platforms import current_platform
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_rocm(),
+    reason="Kimi-K3 AITER latent-MoE tail requires ROCm",
+)
+
+
+def _transform(
+    latent_size: int = 3584,
+    output_size: int = 7168,
+) -> KimiRoutedOutputTransform:
+    transform = object.__new__(KimiRoutedOutputTransform)
+    nn.Module.__init__(transform)
+    transform.norm = SimpleNamespace(
+        weight=torch.empty(latent_size, device="meta"),
+        variance_epsilon=1.0e-6,
+    )
+    transform.up_proj = SimpleNamespace(
+        weight=torch.empty(output_size, latent_size, device="meta")
+    )
+    return transform
+
+
+def test_forward_with_shared_delegates_to_supported_aiter_kernel(monkeypatch):
+    latent_moe_tail_module = importlib.import_module("aiter.ops.flydsl.latent_moe_tail")
+
+    transform = _transform()
+    routed = torch.empty(1, 3584)
+    shared = torch.empty(1, 7168)
+    expected = torch.empty_like(shared)
+    calls = []
+
+    monkeypatch.setattr(rocm_aiter_ops, "is_enabled", lambda: True)
+    monkeypatch.setattr(
+        latent_moe_tail_module,
+        "supports_latent_moe_tail",
+        lambda *args: True,
+    )
+
+    def fused_tail(*args):
+        calls.append(args)
+        return expected
+
+    monkeypatch.setattr(latent_moe_tail_module, "latent_moe_tail", fused_tail)
+
+    assert transform.forward_with_shared(routed, shared) is expected
+    assert len(calls) == 1
+    assert calls[0][0] is routed
+    assert calls[0][1] is shared
+    assert calls[0][2] is transform.norm.weight
+    assert calls[0][3] is transform.up_proj.weight
+    assert calls[0][4] == transform.norm.variance_epsilon
+
+
+def test_forward_with_shared_preserves_fallbacks(monkeypatch):
+    transform = _transform()
+    routed = torch.empty(8, 3584)
+    shared = torch.empty(8, 7168)
+
+    monkeypatch.setattr(rocm_aiter_ops, "is_enabled", lambda: False)
+    assert transform.forward_with_shared(routed, shared) is None
+
+    monkeypatch.setattr(rocm_aiter_ops, "is_enabled", lambda: True)
+    latent_moe_tail_module = importlib.import_module("aiter.ops.flydsl.latent_moe_tail")
+
+    monkeypatch.setattr(
+        latent_moe_tail_module,
+        "supports_latent_moe_tail",
+        lambda *args: False,
+    )
+    monkeypatch.setattr(
+        latent_moe_tail_module,
+        "latent_moe_tail",
+        lambda *args: pytest.fail("unsupported inputs must use the fallback"),
+    )
+    assert transform.forward_with_shared(routed, shared) is None
+
+
+def test_runner_fuses_supported_tail_and_preserves_fallback(monkeypatch):
+    runner = object.__new__(KimiAMDLatentMoERunner)
+    nn.Module.__init__(runner)
+    runner.routed_scaling_factor = 1.0
+    transform = _transform(latent_size=2, output_size=4)
+    runner.routed_output_transform = transform
+
+    routed = torch.tensor([[1.0, 2.0]])
+    shared = torch.tensor([[3.0, 4.0, 5.0, 6.0]])
+    fused_result = torch.tensor([[7.0, 8.0, 9.0, 10.0]])
+
+    monkeypatch.setattr(
+        transform,
+        "forward_with_shared",
+        lambda routed, shared: fused_result,
+    )
+    result = runner.apply_routed_output_transform_and_add_shared(shared, routed)
+    assert result is fused_result
+
+    fallback_result = torch.tensor([[11.0, 12.0, 13.0, 14.0]])
+    monkeypatch.setattr(
+        transform,
+        "forward_with_shared",
+        lambda routed, shared: None,
+    )
+    monkeypatch.setattr(transform, "forward", lambda routed: fallback_result)
+    result = runner.apply_routed_output_transform_and_add_shared(shared, routed)
+    torch.testing.assert_close(result, shared + fallback_result)

--- a/tests/models/kimi_k3/test_amd_latent_moe_tail_fp8.py
+++ b/tests/models/kimi_k3/test_amd_latent_moe_tail_fp8.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+import vllm.envs as envs
+from vllm.models.kimi_k3.amd import linear
+from vllm.platforms import current_platform
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_rocm(),
+    reason="Kimi-K3 FP8 latent-MoE tail requires ROCm",
+)
+
+
+def _transform() -> linear.KimiRoutedOutputTransform:
+    transform = object.__new__(linear.KimiRoutedOutputTransform)
+    nn.Module.__init__(transform)
+    transform.norm = SimpleNamespace(
+        weight=torch.empty(1),
+        variance_epsilon=1.0e-6,
+    )
+    transform.up_proj = SimpleNamespace(weight=torch.empty(1))
+    transform.register_buffer("_latent_tail_fp8_weight", None, persistent=False)
+    transform.register_buffer("_latent_tail_fp8_scale", None, persistent=False)
+    return transform
+
+
+def test_finalize_fp8_weight_owns_prepacked_tensors(monkeypatch):
+    transform = _transform()
+    packed = torch.empty(1, dtype=torch.float8_e4m3fn)
+    scale = torch.empty(1, dtype=torch.float32)
+    fake_module = ModuleType("aiter.ops.flydsl.latent_moe_tail_fp8")
+    vars(fake_module)["quantize_latent_moe_tail_weight"] = lambda weight: (
+        packed,
+        scale,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter.ops.flydsl.latent_moe_tail_fp8",
+        fake_module,
+    )
+    monkeypatch.setattr(envs, "VLLM_ROCM_USE_KIMI_K3_LATENT_TAIL_FP8", True)
+
+    transform.finalize_fp8_weight()
+
+    assert transform._latent_tail_fp8_weight is packed
+    assert transform._latent_tail_fp8_scale is scale
+
+
+def test_fp8_dispatch_uses_prepacked_weight(monkeypatch):
+    transform = _transform()
+    packed = torch.empty(1, dtype=torch.float8_e4m3fn)
+    scale = torch.empty(1, dtype=torch.float32)
+    transform._latent_tail_fp8_weight = packed
+    transform._latent_tail_fp8_scale = scale
+    monkeypatch.setattr(envs, "VLLM_ROCM_USE_KIMI_K3_LATENT_TAIL_FP8", True)
+    monkeypatch.setattr(linear.rocm_aiter_ops, "is_enabled", lambda: True)
+
+    expected = torch.empty(1)
+    calls = []
+    fake_module = ModuleType("aiter.ops.flydsl.latent_moe_tail_fp8")
+    vars(fake_module)["supports_latent_moe_tail_fp8"] = lambda *args: True
+
+    def fake_tail(*args):
+        calls.append(args)
+        return expected
+
+    vars(fake_module)["latent_moe_tail_fp8"] = fake_tail
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter.ops.flydsl.latent_moe_tail_fp8",
+        fake_module,
+    )
+    hidden = torch.empty(1)
+    shared = torch.empty(1)
+
+    assert transform.forward_with_shared(hidden, shared) is expected
+    assert calls == [
+        (
+            hidden,
+            shared,
+            transform.norm.weight,
+            packed,
+            scale,
+            transform.norm.variance_epsilon,
+        )
+    ]
+
+
+def test_fp8_unsupported_contract_falls_back_to_bf16(monkeypatch):
+    transform = _transform()
+    transform._latent_tail_fp8_weight = torch.empty(1, dtype=torch.float8_e4m3fn)
+    transform._latent_tail_fp8_scale = torch.empty(1, dtype=torch.float32)
+    monkeypatch.setattr(envs, "VLLM_ROCM_USE_KIMI_K3_LATENT_TAIL_FP8", True)
+    monkeypatch.setattr(linear.rocm_aiter_ops, "is_enabled", lambda: True)
+
+    fake_fp8 = ModuleType("aiter.ops.flydsl.latent_moe_tail_fp8")
+    vars(fake_fp8)["supports_latent_moe_tail_fp8"] = lambda *args: False
+    vars(fake_fp8)["latent_moe_tail_fp8"] = lambda *args: pytest.fail(
+        "unexpected FP8 call"
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter.ops.flydsl.latent_moe_tail_fp8",
+        fake_fp8,
+    )
+    expected = torch.empty(1)
+    fake_bf16 = ModuleType("aiter.ops.flydsl.latent_moe_tail")
+    vars(fake_bf16)["supports_latent_moe_tail"] = lambda *args: True
+    vars(fake_bf16)["latent_moe_tail"] = lambda *args: expected
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter.ops.flydsl.latent_moe_tail",
+        fake_bf16,
+    )
+
+    assert transform.forward_with_shared(torch.empty(1), torch.empty(1)) is expected

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -270,6 +270,7 @@ if TYPE_CHECKING:
     VLLM_NCCL_INCLUDE_PATH: str | None = None
     VLLM_GC_DEBUG: str = ""
     VLLM_DEBUG_WORKSPACE: bool = False
+    VLLM_ROCM_USE_KIMI_K3_LATENT_TAIL_FP8: bool = False
     VLLM_DISABLE_SHARED_EXPERTS_STREAM: bool = False
     VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD: int = 256
     VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD: int = 1024
@@ -1215,6 +1216,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Shared with the AITER runtime, which reads the same env var directly.
     "AITER_SITUV2_A8W4": lambda: (
         os.getenv("AITER_SITUV2_A8W4", "0").lower() in ("true", "1")
+    ),
+    # Use rowwise OCP-E4M3 weights in the gfx950 Kimi-K3 B1 latent-MoE tail.
+    "VLLM_ROCM_USE_KIMI_K3_LATENT_TAIL_FP8": lambda: (
+        os.getenv("VLLM_ROCM_USE_KIMI_K3_LATENT_TAIL_FP8", "0").lower() in ("true", "1")
     ),
     # MoE sorting dispatch policy for AITER fused MoE kernels.
     #   0 = auto (default): single-pass for small batches, multi-pass

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -388,6 +388,15 @@ class MoERunner(MoERunnerInterface):
             fused_output = r[0] if isinstance(r, tuple) else r
         return fused_output
 
+    def apply_routed_output_transform_and_add_shared(
+        self,
+        shared_output: torch.Tensor | None,
+        fused_output: torch.Tensor,
+    ) -> torch.Tensor:
+        """Apply the routed transform, then combine the shared output."""
+        fused_output = self.apply_routed_output_transform(fused_output)
+        return fused_output if shared_output is None else shared_output + fused_output
+
     def _maybe_apply_routed_scale_to_output(
         self,
         shared_output: torch.Tensor | None,
@@ -399,6 +408,7 @@ class MoERunner(MoERunnerInterface):
         Scale the fused expert output by routed_scaling_factor. For FP16,
         avoid overflow by dividing shared_output by the scale instead
         (the decoder layer compensates with matching divisions).
+
         """
         if self.routed_scaling_factor != 1.0:
             if fused_output.dtype != torch.float16 or shared_output is None:
@@ -765,13 +775,9 @@ class MoERunner(MoERunnerInterface):
             shared_output, fused_output
         )
 
-        # Apply output transform (e.g. latent -> full dim)
-        fused_output = self.apply_routed_output_transform(fused_output)
-
-        if shared_output is not None:
-            result = shared_output + fused_output
-        else:
-            result = fused_output
+        result = self.apply_routed_output_transform_and_add_shared(
+            shared_output, fused_output
+        )
 
         result = self._maybe_reduce_final_output(
             result, og_hidden_dim_post_xform, fused_output_is_reduced

--- a/vllm/models/kimi_k3/amd/linear.py
+++ b/vllm/models/kimi_k3/amd/linear.py
@@ -7,6 +7,7 @@ from typing import Any
 import torch
 from torch import nn
 
+from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import (
     get_pp_group,
@@ -19,6 +20,7 @@ from vllm.model_executor.layers.fused_moe import (
     fused_moe_make_expert_params_mapping,
 )
 from vllm.model_executor.layers.fused_moe.router.gate_linear import GateLinear
+from vllm.model_executor.layers.fused_moe.runner.moe_runner import MoERunner
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
@@ -133,6 +135,60 @@ class KimiRoutedOutputTransform(nn.Module):
             hidden_states = self.norm(hidden_states)
         hidden_states, _ = self.up_proj(hidden_states)
         return hidden_states
+
+    def forward_with_shared(
+        self,
+        hidden_states: torch.Tensor,
+        shared_output: torch.Tensor,
+    ) -> torch.Tensor | None:
+        """Fuse the supported local tail, or return ``None`` for fallback."""
+
+        if self.norm is None or not rocm_aiter_ops.is_enabled():
+            return None
+        try:
+            from aiter.ops.flydsl.latent_moe_tail import (
+                latent_moe_tail,
+                supports_latent_moe_tail,
+            )
+        except (ImportError, ModuleNotFoundError):
+            return None
+
+        up_weight = self.up_proj.weight
+        if not supports_latent_moe_tail(
+            hidden_states,
+            shared_output,
+            self.norm.weight,
+            up_weight,
+            self.norm.variance_epsilon,
+        ):
+            return None
+        return latent_moe_tail(
+            hidden_states,
+            shared_output,
+            self.norm.weight,
+            up_weight,
+            self.norm.variance_epsilon,
+        )
+
+
+class KimiAMDLatentMoERunner(MoERunner):
+    """Use the AMD local-tail primitive after routed/shared reductions."""
+
+    def apply_routed_output_transform_and_add_shared(
+        self,
+        shared_output: torch.Tensor | None,
+        fused_output: torch.Tensor,
+    ) -> torch.Tensor:
+        transform = self.routed_output_transform
+        if shared_output is not None and isinstance(
+            transform, KimiRoutedOutputTransform
+        ):
+            result = transform.forward_with_shared(fused_output, shared_output)
+            if result is not None:
+                return result
+        return super().apply_routed_output_transform_and_add_shared(
+            shared_output, fused_output
+        )
 
 
 def _apply_attn_res(
@@ -280,6 +336,7 @@ class KimiMoE(nn.Module):
             routed_scaling_factor=self.routed_scaling_factor,
             routed_input_transform=self.routed_expert_down_proj,
             routed_output_transform=self.routed_output_transform,
+            runner_cls=KimiAMDLatentMoERunner if self.use_latent_moe else None,
         )
         if self.padded_moe_intermediate_size != moe_intermediate_size:
             w13_weight = getattr(self.experts, "w13_weight", None)

--- a/vllm/models/kimi_k3/amd/linear.py
+++ b/vllm/models/kimi_k3/amd/linear.py
@@ -7,6 +7,7 @@ from typing import Any
 import torch
 from torch import nn
 
+import vllm.envs as envs
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import (
@@ -129,6 +130,35 @@ class KimiRoutedOutputTransform(nn.Module):
         super().__init__()
         self.norm = norm
         self.up_proj = up_proj
+        self.register_buffer("_latent_tail_fp8_weight", None, persistent=False)
+        self.register_buffer("_latent_tail_fp8_scale", None, persistent=False)
+
+    @torch.no_grad()
+    def finalize_fp8_weight(self) -> None:
+        if not envs.VLLM_ROCM_USE_KIMI_K3_LATENT_TAIL_FP8:
+            return
+        try:
+            from aiter.ops.flydsl.latent_moe_tail_fp8 import (
+                quantize_latent_moe_tail_weight,
+            )
+        except (ImportError, ModuleNotFoundError):
+            logger.warning_once(
+                "AITER does not provide the Kimi-K3 FP8 latent-tail kernel; "
+                "using the BF16 latent-tail path."
+            )
+            return
+
+        try:
+            (
+                self._latent_tail_fp8_weight,
+                self._latent_tail_fp8_scale,
+            ) = quantize_latent_moe_tail_weight(self.up_proj.weight)
+        except ValueError as error:
+            logger.warning_once(
+                "Kimi-K3 FP8 latent-tail prepack is unsupported (%s); "
+                "using the BF16 latent-tail path.",
+                error,
+            )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         if self.norm is not None:
@@ -145,6 +175,35 @@ class KimiRoutedOutputTransform(nn.Module):
 
         if self.norm is None or not rocm_aiter_ops.is_enabled():
             return None
+        if (
+            envs.VLLM_ROCM_USE_KIMI_K3_LATENT_TAIL_FP8
+            and self._latent_tail_fp8_weight is not None
+            and self._latent_tail_fp8_scale is not None
+        ):
+            try:
+                from aiter.ops.flydsl.latent_moe_tail_fp8 import (
+                    latent_moe_tail_fp8,
+                    supports_latent_moe_tail_fp8,
+                )
+            except (ImportError, ModuleNotFoundError):
+                pass
+            else:
+                if supports_latent_moe_tail_fp8(
+                    hidden_states,
+                    shared_output,
+                    self.norm.weight,
+                    self._latent_tail_fp8_weight,
+                    self._latent_tail_fp8_scale,
+                    self.norm.variance_epsilon,
+                ):
+                    return latent_moe_tail_fp8(
+                        hidden_states,
+                        shared_output,
+                        self.norm.weight,
+                        self._latent_tail_fp8_weight,
+                        self._latent_tail_fp8_scale,
+                        self.norm.variance_epsilon,
+                    )
         try:
             from aiter.ops.flydsl.latent_moe_tail import (
                 latent_moe_tail,
@@ -1018,6 +1077,16 @@ class KimiLinearModel(nn.Module, EagleModelMixin):
             loaded_params.add(name)
         return loaded_params
 
+    def finalize_latent_tail_fp8_weights(self) -> None:
+        if not envs.VLLM_ROCM_USE_KIMI_K3_LATENT_TAIL_FP8:
+            return
+        for layer in self.layers[self.start_layer : self.end_layer]:
+            if not isinstance(layer, KimiDecoderLayer):
+                continue
+            mlp = layer.mlp
+            if isinstance(mlp, KimiMoE) and mlp.routed_output_transform is not None:
+                mlp.routed_output_transform.finalize_fp8_weight()
+
 
 class KimiLinearForCausalLM(
     nn.Module, HasInnerState, SupportsPP, MixtureOfExperts, IsHybrid
@@ -1119,4 +1188,6 @@ class KimiLinearForCausalLM(
             self,
             skip_prefixes=(["lm_head."] if self.config.tie_word_embeddings else None),
         )
-        return loader.load_weights(weights)
+        loaded = loader.load_weights(weights)
+        self.model.finalize_latent_tail_fp8_weights()
+        return loaded


### PR DESCRIPTION
## Purpose

Fuse the Kimi-K3 AMD latent-MoE output boundary and optionally store its
up-projection weight in row-scaled OCP E4M3:

- expose one MoE-runner hook for the routed-output transform plus shared add;
- use the AITER BF16 fused tail only for its exact supported contract; and
- with `VLLM_ROCM_USE_KIMI_K3_LATENT_TAIL_FP8=1`, prepack the local tail weight
  after loading and select the AITER FP8 variant.

The hook defaults to the previous operation order. Packed tensors are
nonpersistent buffers; no allocation or quantization occurs during graph
capture. Missing kernels and unsupported devices, shapes, dtypes, or layouts
use the existing path. NVIDIA is unchanged.

Depends on ROCm/aiter#4496 (BF16) and ROCm/aiter#4503 (FP8). The former child
#50663 was folded into this ownership parent.

## Test plan

Tested on 8x MI355X (`gfx950`) with the public Kimi-K3 image and
`moonshotai/Kimi-K3@9f62e4e9`. Kernel heads: AITER #4496 `ae0e0e12` and #4503
`a9f06c1f`; the command below pins the vLLM base and PR revisions.

Fetch and verify the vLLM source:

```bash
git clone https://github.com/vllm-project/vllm.git vllm
git -C vllm fetch origin refs/pull/50657/head:pr-50657
test "$(git -C vllm rev-parse pr-50657)" = \
  1e3156f2f429400cc07b2696f1cf4d4dd1afdad4
git -C vllm checkout --detach 6c91de36897932ba9b5adb11992235a2a789e009
git -C vllm diff 62195e9784ebec1ece42b88a861734e0702cc2d5..pr-50657 \
  --binary | git -C vllm apply -
git -C vllm diff --check
```

Use complete verified vLLM/AITER trees as overlays on the public image,
including AITER `csrc/` and `hsa/`; do not copy individual files. Verify
`import vllm, vllm._C, aiter` before testing.

```bash
python -m pytest -q \
  ../aiter/op_tests/flydsl_tests/test_latent_moe_tail.py \
  ../aiter/op_tests/flydsl_tests/test_latent_moe_tail_fp8.py \
  tests/models/kimi_k3/test_amd_latent_moe_tail.py \
  tests/models/kimi_k3/test_amd_latent_moe_tail_fp8.py
```

Serve `parent`, `bf16`, and `candidate` arms; enable the FP8 variable only for
the candidate:

```bash
VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_FP4BMM=1 \
AITER_SITUV2_A8W4=1 AITER_BF16_FP8_MOE_BOUND=0 \
VLLM_ROCM_USE_KIMI_K3_LATENT_TAIL_FP8=1 \
vllm serve /model --served-model-name moonshotai/Kimi-K3 \
  --tensor-parallel-size 8 --trust-remote-code --moe-backend auto \
  --gpu-memory-utilization 0.95 --max-num-seqs 128 \
  --max-num-batched-tokens 4096 --max-model-len 1048576 \
  --enable-prefix-caching --kv-cache-dtype fp8 --reasoning-parser kimi_k3
```

After one 8K/128 warmup, run three 8K/1K batch-one trials with seeds 1--3,
temperature zero, and `--ignore-eos`. Run full `lm-eval==0.4.12` GSM8K on
parent and candidate: 1,319 questions, 5-shot, greedy completion, 2,048
generated tokens, concurrency 128, and seed 42.

## Test results

- Combined focused suite: **19/19 passed**.
- Changed-file pre-commit, `git diff --check`, and DCO passed.

| MI355X microbenchmark | Control | Candidate | Speedup |
| --- | ---: | ---: | ---: |
| BF16 fused tail | 13.6019 us | 9.9237 us | **1.3706x** |
| FP8 fused tail | 13.7860 us | 7.1394 us | **1.9310x** |

| TP8 8K/1K median | Control | Candidate | Change |
| --- | ---: | ---: | ---: |
| BF16 fusion | 35.8923 tok/s/GPU | 36.9206 tok/s/GPU | **+2.865%** |
| Optional FP8 increment | 37.1627 tok/s/GPU | 37.3209 tok/s/GPU | **+0.426%** |

The BF16 fusion saved 0.7760 ms/token; the optional FP8 increment saved a
further 0.1140 ms/token.

Full GSM8K: parent **1278/1319**, candidate **1276/1319**, zero invalid or
transport failures; 11 wins/13 losses (`p=0.8388`). This paired run found no
statistically detectable accuracy difference.

## Limits

The 35.8923-to-36.9206 BF16 pair used the earlier frozen vLLM base
`e3be89673db6143c1f9c8689d853b9c7c7a5eb29`; its three BF16 runtime files are
byte-identical to this PR. The FP8 increment and full accuracy pair use the
current source contract above. The two endpoint eras are not combined into one
absolute-stack claim.

## Tool assistance

OpenAI Codex assisted with implementation, tests, benchmarking, and drafting
this description.

