### PR TITLE
[Model][Kimi K3] Project DSpark aux states before SP all-gather

### DIFF
--- a/benchmarks/kernels/benchmark_kimi_k3_sp_collectives.py
+++ b/benchmarks/kernels/benchmark_kimi_k3_sp_collectives.py
@@ -16,8 +16,15 @@ from vllm.distributed.device_communicators.custom_all_reduce import CustomAllred
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--mode",
+        choices=("collectives", "dspark", "both"),
+        default="collectives",
+    )
     parser.add_argument("--tokens", type=int, nargs="+", default=[8, 32, 128, 1024])
     parser.add_argument("--hidden-size", type=int, default=7168)
+    parser.add_argument("--draft-hidden-size", type=int, default=7168)
+    parser.add_argument("--num-aux-hidden-states", type=int, default=5)
     parser.add_argument("--graph-repeats", type=int, default=20)
     parser.add_argument("--warmup-replays", type=int, default=5)
     parser.add_argument("--samples", type=int, default=15)
@@ -197,6 +204,143 @@ def benchmark_shape(
     }
 
 
+@torch.inference_mode()
+def benchmark_dspark_aux_projection(
+    comm: CustomAllreduce,
+    global_tokens: int,
+    target_hidden_size: int,
+    draft_hidden_size: int,
+    num_aux_hidden_states: int,
+    context_weight: torch.Tensor,
+    norm_weight: torch.Tensor,
+    graph_repeats: int,
+    warmup_replays: int,
+    samples: int,
+    device_group: dist.ProcessGroup,
+    cpu_group: dist.ProcessGroup,
+) -> dict[str, float | int]:
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    padded_tokens = (global_tokens + world_size - 1) // world_size * world_size
+    local_tokens = padded_tokens // world_size
+    device = torch.accelerator.current_device_index()
+
+    local_aux = [
+        torch.full(
+            (local_tokens, target_hidden_size),
+            rank + i / num_aux_hidden_states,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        for i in range(num_aux_hidden_states)
+    ]
+    gathered_aux = [
+        torch.empty(
+            (padded_tokens, target_hidden_size),
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        for _ in range(num_aux_hidden_states)
+    ]
+    full_cat = torch.empty(
+        (padded_tokens, num_aux_hidden_states * target_hidden_size),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    local_cat = torch.empty(
+        (local_tokens, num_aux_hidden_states * target_hidden_size),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    before_projected = torch.empty(
+        (padded_tokens, draft_hidden_size),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    before_output = torch.empty_like(before_projected)
+    local_projected = torch.empty(
+        (local_tokens, draft_hidden_size),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    local_output = torch.empty_like(local_projected)
+    after_output = torch.empty_like(before_projected)
+
+    def custom_all_gather(input_: torch.Tensor, output: torch.Tensor) -> None:
+        ops.mnnvl_lamport_all_gather(
+            comm._ptr,
+            input_,
+            output,
+            comm.mnnvl_lamport_ag_local_ptr,
+            comm.mnnvl_lamport_ag_multicast_ptr,
+            comm.mnnvl_lamport_ag_epoch_ptr,
+            comm.mnnvl_buffer_size,
+        )
+
+    def before() -> None:
+        for local, gathered in zip(local_aux, gathered_aux, strict=True):
+            custom_all_gather(local, gathered)
+        torch.cat(gathered_aux, dim=-1, out=full_cat)
+        torch.mm(full_cat, context_weight.t(), out=before_projected)
+        ops.rms_norm(before_output, before_projected, norm_weight, 1e-6)
+
+    def after() -> None:
+        torch.cat(local_aux, dim=-1, out=local_cat)
+        torch.mm(local_cat, context_weight.t(), out=local_projected)
+        ops.rms_norm(local_output, local_projected, norm_weight, 1e-6)
+        custom_all_gather(local_output, after_output)
+
+    before_graph = capture_graph(before, graph_repeats)
+    after_graph = capture_graph(after, graph_repeats)
+    before_us = (
+        max_rank_graph_time(
+            before_graph,
+            graph_repeats,
+            warmup_replays,
+            samples,
+            device_group,
+            cpu_group,
+        )
+        * 1000
+    )
+    after_us = (
+        max_rank_graph_time(
+            after_graph,
+            graph_repeats,
+            warmup_replays,
+            samples,
+            device_group,
+            cpu_group,
+        )
+        * 1000
+    )
+    before_graph.replay()
+    after_graph.replay()
+    torch.accelerator.synchronize()
+    torch.testing.assert_close(before_output, after_output, rtol=2e-2, atol=2e-2)
+
+    element_size = local_aux[0].element_size()
+    local_aux_bytes = local_tokens * target_hidden_size * element_size
+    local_projected_bytes = local_tokens * draft_hidden_size * element_size
+    return {
+        "global_tokens": global_tokens,
+        "padded_tokens": padded_tokens,
+        "world_size": world_size,
+        "target_hidden_size": target_hidden_size,
+        "draft_hidden_size": draft_hidden_size,
+        "num_aux_hidden_states": num_aux_hidden_states,
+        "before_collectives": num_aux_hidden_states,
+        "after_collectives": 1,
+        "before_received_bytes_per_rank": (
+            num_aux_hidden_states * local_aux_bytes * (world_size - 1)
+        ),
+        "after_received_bytes_per_rank": (local_projected_bytes * (world_size - 1)),
+        "before_us": before_us,
+        "after_us": after_us,
+        "speedup": before_us / after_us,
+    }
+
+
 def main() -> None:
     args = parse_args()
     local_rank = int(os.environ["LOCAL_RANK"])
@@ -214,21 +358,68 @@ def main() -> None:
     assert comm.mnnvl_only
     assert comm.mnnvl_multicast_ptr
 
-    results = [
-        benchmark_shape(
-            comm,
-            tokens,
-            args.hidden_size,
-            args.graph_repeats,
-            args.warmup_replays,
-            args.samples,
-            device_group,
-            cpu_group,
+    collective_results = None
+    if args.mode in ("collectives", "both"):
+        collective_results = [
+            benchmark_shape(
+                comm,
+                tokens,
+                args.hidden_size,
+                args.graph_repeats,
+                args.warmup_replays,
+                args.samples,
+                device_group,
+                cpu_group,
+            )
+            for tokens in args.tokens
+        ]
+
+    dspark_results = None
+    if args.mode in ("dspark", "both"):
+        torch.manual_seed(0)
+        context_weight = torch.empty(
+            (
+                args.draft_hidden_size,
+                args.num_aux_hidden_states * args.hidden_size,
+            ),
+            dtype=torch.bfloat16,
+            device=local_rank,
         )
-        for tokens in args.tokens
-    ]
+        context_weight.normal_(std=0.01)
+        norm_weight = torch.ones(
+            args.draft_hidden_size,
+            dtype=torch.bfloat16,
+            device=local_rank,
+        )
+        dspark_results = [
+            benchmark_dspark_aux_projection(
+                comm,
+                tokens,
+                args.hidden_size,
+                args.draft_hidden_size,
+                args.num_aux_hidden_states,
+                context_weight,
+                norm_weight,
+                args.graph_repeats,
+                args.warmup_replays,
+                args.samples,
+                device_group,
+                cpu_group,
+            )
+            for tokens in args.tokens
+        ]
+
     if dist.get_rank() == 0:
-        print(json.dumps(results, indent=2), flush=True)
+        if args.mode == "collectives":
+            output = collective_results
+        elif args.mode == "dspark":
+            output = dspark_results
+        else:
+            output = {
+                "collectives": collective_results,
+                "dspark": dspark_results,
+            }
+        print(json.dumps(output, indent=2), flush=True)
 
     comm.close()
     dist.destroy_process_group(cpu_group)

--- a/tests/models/kimi_k3/test_sequence_parallel.py
+++ b/tests/models/kimi_k3/test_sequence_parallel.py
@@ -214,6 +214,101 @@ def test_kimi_attn_residual_states_stay_sequence_sharded(monkeypatch):
     assert layer.mlp.num_tokens == 2
 
 
+def _make_sequence_parallel_target_model(
+    *,
+    aux_hidden_state_layers: tuple[int, ...],
+) -> kimi_model.KimiLinearModel:
+    model = object.__new__(kimi_model.KimiLinearModel)
+    nn.Module.__init__(model)
+    model.use_sequence_parallel = True
+    model._keep_aux_hidden_states_sequence_sharded = False
+    model.use_attn_res = False
+    model.start_layer = 0
+    model.end_layer = 1
+    model.aux_hidden_state_layers = aux_hidden_state_layers
+
+    def layer_forward(**kwargs):
+        hidden_states = kwargs["hidden_states"]
+        return hidden_states * 2, None, hidden_states * 3
+
+    object.__setattr__(model, "layers", [Mock(side_effect=layer_forward)])
+    return model
+
+
+def test_kimi_start_layer_aux_stays_full_by_default(monkeypatch):
+    model = _make_sequence_parallel_target_model(aux_hidden_state_layers=(0,))
+    full_hidden_states = torch.arange(6, dtype=torch.float32).view(3, 2)
+    padded_hidden_states = torch.nn.functional.pad(full_hidden_states, (0, 0, 0, 1))
+    local_hidden_states = padded_hidden_states[:2]
+
+    monkeypatch.setattr(kimi_model.envs, "VLLM_MOE_SKIP_PADDING", False)
+    monkeypatch.setattr(
+        kimi_model,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=True),
+    )
+    monkeypatch.setattr(kimi_model, "sp_shard", Mock(return_value=local_hidden_states))
+    all_gather = Mock(return_value=padded_hidden_states * 5)
+    monkeypatch.setattr(kimi_model, "sp_all_gather", all_gather)
+
+    output, aux_hidden_states = model.forward(
+        input_ids=None,
+        positions=torch.arange(3),
+        intermediate_tensors=None,
+        inputs_embeds=full_hidden_states,
+    )
+
+    torch.testing.assert_close(output, full_hidden_states * 5)
+    assert len(aux_hidden_states) == 1
+    torch.testing.assert_close(aux_hidden_states[0], full_hidden_states)
+    all_gather.assert_called_once()
+    torch.testing.assert_close(all_gather.call_args.args[0], local_hidden_states * 5)
+
+
+def test_kimi_can_keep_raw_aux_sequence_sharded_with_padding(monkeypatch):
+    model = _make_sequence_parallel_target_model(aux_hidden_state_layers=(0, 1))
+    assert model.enable_sequence_sharded_raw_aux_hidden_states()
+
+    full_hidden_states = torch.arange(6, dtype=torch.float32).view(3, 2)
+    padded_hidden_states = torch.nn.functional.pad(full_hidden_states, (0, 0, 0, 1))
+    local_hidden_states = padded_hidden_states[2:]
+
+    monkeypatch.setattr(kimi_model.envs, "VLLM_MOE_SKIP_PADDING", False)
+    monkeypatch.setattr(
+        kimi_model,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=True),
+    )
+    monkeypatch.setattr(kimi_model, "sp_shard", Mock(return_value=local_hidden_states))
+    all_gather = Mock(return_value=padded_hidden_states * 5)
+    monkeypatch.setattr(kimi_model, "sp_all_gather", all_gather)
+
+    output, aux_hidden_states = model.forward(
+        input_ids=None,
+        positions=torch.arange(3),
+        intermediate_tensors=None,
+        inputs_embeds=full_hidden_states,
+    )
+
+    torch.testing.assert_close(output, full_hidden_states * 5)
+    assert len(aux_hidden_states) == 2
+    torch.testing.assert_close(aux_hidden_states[0], local_hidden_states)
+    torch.testing.assert_close(aux_hidden_states[1], local_hidden_states * 5)
+    assert aux_hidden_states[0].shape[0] == 2
+    torch.testing.assert_close(aux_hidden_states[0][-1], torch.zeros(2))
+    all_gather.assert_called_once()
+
+
+def test_kimi_raw_aux_capability_is_noop_without_sequence_parallel():
+    model = object.__new__(kimi_model.KimiLinearModel)
+    nn.Module.__init__(model)
+    model.use_sequence_parallel = False
+    model._keep_aux_hidden_states_sequence_sharded = False
+
+    assert not model.enable_sequence_sharded_raw_aux_hidden_states()
+    assert not model._keep_aux_hidden_states_sequence_sharded
+
+
 def test_kimi_mtp_restores_sequence_parallel_output(monkeypatch):
     layer = object.__new__(kimi_mtp.KimiK3MultiTokenPredictorLayer)
     nn.Module.__init__(layer)

--- a/tests/models/test_dspark_mla.py
+++ b/tests/models/test_dspark_mla.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 import torch
@@ -13,6 +14,7 @@ from vllm.model_executor.models.qwen3_dspark import DSparkMarkovHead
 from vllm.model_executor.models.registry import ModelRegistry
 from vllm.models.kimi_k3.nvidia import dspark_mla
 from vllm.models.kimi_k3.nvidia.dspark_mla import K3DSparkForCausalLM, K3DSparkModel
+from vllm.v1.worker.gpu.spec_decode.dspark import speculator as dspark_speculator
 
 
 def test_dspark_mla_uses_compile_free_model_entrypoint():
@@ -60,6 +62,129 @@ def test_dspark_mla_shares_frozen_target_weights_and_skips_training_head():
         "embed_tokens",
         "lm_head",
     }
+
+
+@pytest.mark.cpu_test
+def test_dspark_enables_sequence_sharded_target_aux_after_draft_load(monkeypatch):
+    class TargetInner:
+        def __init__(self):
+            self.enable_calls = 0
+            self.gather_calls = 0
+
+        def enable_sequence_sharded_raw_aux_hidden_states(self) -> bool:
+            self.enable_calls += 1
+            return True
+
+        def gather_sequence_sharded_aux_hidden_states(
+            self, hidden_states: torch.Tensor
+        ) -> torch.Tensor:
+            self.gather_calls += 1
+            return hidden_states
+
+    target_inner = TargetInner()
+    target_model = SimpleNamespace(model=target_inner)
+    draft_model = SimpleNamespace(
+        combine_hidden_states=Mock(),
+        draft_id_to_target_id=None,
+    )
+    monkeypatch.setattr(
+        dspark_speculator,
+        "load_dspark_model",
+        Mock(return_value=draft_model),
+    )
+
+    speculator = object.__new__(dspark_speculator.DSparkSpeculator)
+    speculator.vllm_config = SimpleNamespace()
+    speculator.draft_logits = None
+    speculator._sequence_sharded_aux_gather = None
+
+    loaded_model = speculator.load_draft_model(target_model, set())
+
+    assert loaded_model is draft_model
+    assert target_inner.enable_calls == 1
+    hidden_states = torch.ones(2, 3)
+    assert speculator._sequence_sharded_aux_gather is not None
+    torch.testing.assert_close(
+        speculator._sequence_sharded_aux_gather(hidden_states),
+        hidden_states,
+    )
+    assert target_inner.gather_calls == 1
+
+
+@pytest.mark.cpu_test
+def test_dspark_projects_local_aux_before_single_gather_and_crops_padding():
+    local_aux_0 = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    local_aux_1 = torch.tensor([[5.0, 6.0], [7.0, 8.0]])
+    local_projected = local_aux_0 + local_aux_1
+    gathered_with_padding = torch.cat(
+        [local_projected, local_projected + 10],
+        dim=0,
+    )
+
+    combine_hidden_states = Mock(
+        side_effect=lambda hidden_states: hidden_states[:, :2] + hidden_states[:, 2:]
+    )
+    gather = Mock(return_value=gathered_with_padding)
+    speculator = object.__new__(dspark_speculator.DSparkSpeculator)
+    speculator.model = SimpleNamespace(combine_hidden_states=combine_hidden_states)
+    speculator._sequence_sharded_aux_gather = gather
+
+    output = speculator._prepare_target_hidden_states(
+        last_hidden_states=torch.full((3, 2), -1.0),
+        aux_hidden_states=[local_aux_0, local_aux_1],
+        num_target_tokens=3,
+    )
+
+    torch.testing.assert_close(output, gathered_with_padding[:3])
+    combine_hidden_states.assert_called_once()
+    torch.testing.assert_close(
+        combine_hidden_states.call_args.args[0],
+        torch.cat([local_aux_0, local_aux_1], dim=-1),
+    )
+    gather.assert_called_once()
+    torch.testing.assert_close(gather.call_args.args[0], local_projected)
+
+
+@pytest.mark.cpu_test
+def test_dspark_target_aux_preparation_is_noop_without_aux():
+    gather = Mock(side_effect=AssertionError("unexpected gather"))
+    combine_hidden_states = Mock(side_effect=AssertionError("unexpected projection"))
+    speculator = object.__new__(dspark_speculator.DSparkSpeculator)
+    speculator.model = SimpleNamespace(combine_hidden_states=combine_hidden_states)
+    speculator._sequence_sharded_aux_gather = gather
+    last_hidden_states = torch.arange(6, dtype=torch.float32).view(3, 2)
+
+    output = speculator._prepare_target_hidden_states(
+        last_hidden_states=last_hidden_states,
+        aux_hidden_states=None,
+        num_target_tokens=3,
+    )
+
+    assert output is last_hidden_states
+    combine_hidden_states.assert_not_called()
+    gather.assert_not_called()
+
+
+@pytest.mark.cpu_test
+def test_dspark_target_aux_preparation_keeps_unsharded_path():
+    aux_hidden_states = [
+        torch.tensor([[1.0, 2.0]]),
+        torch.tensor([[3.0, 4.0]]),
+    ]
+    expected = torch.tensor([[4.0, 6.0]])
+    combine_hidden_states = Mock(return_value=expected)
+    speculator = object.__new__(dspark_speculator.DSparkSpeculator)
+    speculator.model = SimpleNamespace(combine_hidden_states=combine_hidden_states)
+    speculator._sequence_sharded_aux_gather = None
+
+    output = speculator._prepare_target_hidden_states(
+        last_hidden_states=torch.zeros_like(expected),
+        aux_hidden_states=aux_hidden_states,
+        num_target_tokens=1,
+    )
+
+    torch.testing.assert_close(output, expected)
+    combine_hidden_states.assert_called_once()
 
 
 @pytest.mark.cpu_test

--- a/tests/v1/cudagraph/test_cudagraph_manager.py
+++ b/tests/v1/cudagraph/test_cudagraph_manager.py
@@ -109,3 +109,57 @@ def test_full_capture_sets_graph_pool_id_before_cuda_graph(monkeypatch):
         manager.capture(create_forward_fn)
 
     mock_cuda_graph.assert_called_once()
+
+
+def test_fullgraph_aux_outputs_use_per_descriptor_leading_dims(monkeypatch):
+    large_desc = BatchExecutionDescriptor(
+        cg_mode=CUDAGraphMode.FULL,
+        num_tokens=8,
+        num_reqs=8,
+        uniform_token_count=1,
+    )
+    small_desc = BatchExecutionDescriptor(
+        cg_mode=CUDAGraphMode.FULL,
+        num_tokens=4,
+        num_reqs=4,
+        uniform_token_count=1,
+    )
+
+    manager = object.__new__(gpu_cudagraph_utils.ModelCudaGraphManager)
+    manager.aux_hidden_states = []
+    manager.aux_hidden_state_leading_dims = {}
+
+    large_aux = [
+        torch.full((4, 2), 1.0),
+        torch.full((3, 3), 2.0),
+    ]
+    manager._copy_aux_hidden_state_outputs(large_desc, large_aux)
+    small_aux = [
+        torch.full((2, 2), 3.0),
+        torch.full((1, 3), 4.0),
+    ]
+    manager._copy_aux_hidden_state_outputs(small_desc, small_aux)
+
+    assert manager.aux_hidden_state_leading_dims == {
+        large_desc: (4, 3),
+        small_desc: (2, 1),
+    }
+    assert [x.shape[0] for x in manager.aux_hidden_states] == [4, 3]
+    torch.testing.assert_close(manager.aux_hidden_states[0][:2], small_aux[0])
+    torch.testing.assert_close(manager.aux_hidden_states[1][:1], small_aux[1])
+
+    manager.is_last_pp_rank = True
+    manager.use_aux_hidden_state_outputs = True
+    manager.hidden_states = torch.arange(16, dtype=torch.float32).view(8, 2)
+    graph = MagicMock()
+    manager.graphs = {small_desc: graph}
+    offloader = MagicMock()
+    monkeypatch.setattr(gpu_cudagraph_utils, "get_offloader", lambda: offloader)
+
+    hidden_states, aux_hidden_states = manager.run_fullgraph(small_desc)
+
+    torch.testing.assert_close(hidden_states, manager.hidden_states[:4])
+    assert [x.shape[0] for x in aux_hidden_states] == [2, 1]
+    torch.testing.assert_close(aux_hidden_states[0], small_aux[0])
+    torch.testing.assert_close(aux_hidden_states[1], small_aux[1])
+    graph.replay.assert_called_once_with()

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -973,6 +973,7 @@ class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
             and parallel_config.tensor_parallel_size > 1
             and (use_mega_moe or parallel_config.data_parallel_size > 1)
         )
+        self._keep_aux_hidden_states_sequence_sharded = False
 
         self.vocab_size = config.vocab_size
 
@@ -1059,6 +1060,18 @@ class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
 
+    def enable_sequence_sharded_raw_aux_hidden_states(self) -> bool:
+        if not self.use_sequence_parallel:
+            return False
+        self._keep_aux_hidden_states_sequence_sharded = True
+        return True
+
+    def gather_sequence_sharded_aux_hidden_states(
+        self, hidden_states: torch.Tensor
+    ) -> torch.Tensor:
+        assert self._keep_aux_hidden_states_sequence_sharded
+        return sp_all_gather(hidden_states)
+
     def forward(
         self,
         input_ids: torch.Tensor | None,
@@ -1079,8 +1092,19 @@ class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
             residual = intermediate_tensors["residual"]
         assert hidden_states is not None
 
+        keep_aux_hidden_states_sequence_sharded = (
+            self.use_sequence_parallel
+            and getattr(self, "_keep_aux_hidden_states_sequence_sharded", False)
+        )
         aux_hidden_states: list[torch.Tensor] = []
-        if self.start_layer in self.aux_hidden_state_layers:
+        keep_initial_aux_hidden_state_sharded = (
+            keep_aux_hidden_states_sequence_sharded
+            and self.start_layer in self.aux_hidden_state_layers
+        )
+        if (
+            self.start_layer in self.aux_hidden_state_layers
+            and not keep_initial_aux_hidden_state_sharded
+        ):
             if self.use_attn_res or residual is None:
                 aux_hidden_states.append(hidden_states)
             else:
@@ -1095,6 +1119,9 @@ class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
                 )
             hidden_states = sp_shard(hidden_states)
             assert residual is None, "Currently, SP is not supported with PP"
+
+        if keep_initial_aux_hidden_state_sharded:
+            aux_hidden_states.append(hidden_states)
 
         prefix_sum = None
         if self.use_attn_res:
@@ -1127,9 +1154,11 @@ class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
                     assert residual is not None
                     aux_hidden_state = hidden_states + residual
 
-                if self.use_sequence_parallel:
+                if (
+                    self.use_sequence_parallel
+                    and not keep_aux_hidden_states_sequence_sharded
+                ):
                     # Gather SP-sharded aux hidden states.
-                    # TODO: Optimize this.
                     aux_hidden_state = sp_all_gather(aux_hidden_state)
                     aux_hidden_state = aux_hidden_state[:full_num_tokens]
                 aux_hidden_states.append(aux_hidden_state)

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -439,8 +439,33 @@ class ModelCudaGraphManager(CudaGraphManager):
         )
         self.hidden_states: torch.Tensor | None = None
         self.aux_hidden_states: list[torch.Tensor] = []
+        self.aux_hidden_state_leading_dims: dict[
+            BatchExecutionDescriptor, tuple[int, ...]
+        ] = {}
         self.use_aux_hidden_state_outputs = False
         self.intermediate_tensors: IntermediateTensors | None = None
+
+    def _copy_aux_hidden_state_outputs(
+        self,
+        desc: BatchExecutionDescriptor,
+        aux_hidden_states: list[torch.Tensor],
+    ) -> None:
+        leading_dims = tuple(x.shape[0] for x in aux_hidden_states)
+        previous_leading_dims = self.aux_hidden_state_leading_dims.setdefault(
+            desc, leading_dims
+        )
+        assert previous_leading_dims == leading_dims
+
+        if not self.aux_hidden_states:
+            # capture() starts with the largest PIECEWISE descriptor, then processes
+            # each mode largest-first, so this follows self.hidden_states' capacity
+            # contract. The assertions below fail closed if that ordering changes.
+            self.aux_hidden_states = [torch.empty_like(x) for x in aux_hidden_states]
+        assert len(self.aux_hidden_states) == len(aux_hidden_states)
+        for output, aux in zip(self.aux_hidden_states, aux_hidden_states, strict=True):
+            assert output.shape[0] >= aux.shape[0]
+            assert output.shape[1:] == aux.shape[1:]
+            output[: aux.shape[0]] = aux
 
     def capture(
         self,
@@ -544,12 +569,8 @@ class ModelCudaGraphManager(CudaGraphManager):
                     if self.hidden_states is None:
                         self.hidden_states = torch.empty_like(hidden_states)
                     self.hidden_states[:num_tokens] = hidden_states
-                    if self.use_aux_hidden_state_outputs and not self.aux_hidden_states:
-                        self.aux_hidden_states = [
-                            torch.empty_like(x) for x in aux_hidden_states
-                        ]
-                    for i, aux in enumerate(aux_hidden_states):
-                        self.aux_hidden_states[i][:num_tokens] = aux
+                    if self.use_aux_hidden_state_outputs:
+                        self._copy_aux_hidden_state_outputs(desc, aux_hidden_states)
                 else:
                     # Non-last PP rank.
                     assert isinstance(model_output, IntermediateTensors)
@@ -578,7 +599,11 @@ class ModelCudaGraphManager(CudaGraphManager):
         hidden_states = self.hidden_states[: desc.num_tokens]
         if not self.use_aux_hidden_state_outputs:
             return hidden_states
-        return hidden_states, [x[: desc.num_tokens] for x in self.aux_hidden_states]
+        leading_dims = self.aux_hidden_state_leading_dims[desc]
+        return hidden_states, [
+            x[:num_rows]
+            for x, num_rows in zip(self.aux_hidden_states, leading_dims, strict=True)
+        ]
 
 
 def prepare_inputs_to_capture(

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -299,6 +299,19 @@ class DFlashSpeculator(DraftModelSpeculator):
             query_start_loc_np=query_start_loc_np,
         )
 
+    def _prepare_target_hidden_states(
+        self,
+        last_hidden_states: torch.Tensor,
+        aux_hidden_states: list[torch.Tensor] | None,
+        num_target_tokens: int,
+    ) -> torch.Tensor:
+        if not aux_hidden_states:
+            return last_hidden_states
+        hidden_states = self.model.combine_hidden_states(
+            torch.cat(aux_hidden_states, dim=-1)
+        )
+        return hidden_states[:num_target_tokens]
+
     @torch.inference_mode()
     def propose(
         self,
@@ -339,12 +352,11 @@ class DFlashSpeculator(DraftModelSpeculator):
         # number of rejected tokens, we maintain the size of input_ids and
         # hidden_states the same as the target model's. This means, we pad each
         # request's query length to include any rejected positions.
-        if aux_hidden_states:
-            hidden_states = self.model.combine_hidden_states(
-                torch.cat(aux_hidden_states, dim=-1)
-            )
-        else:
-            hidden_states = last_hidden_states
+        hidden_states = self._prepare_target_hidden_states(
+            last_hidden_states,
+            aux_hidden_states,
+            num_target_tokens,
+        )
         self.hidden_states[:num_target_tokens].copy_(hidden_states[:num_target_tokens])
 
         if dummy_run and skip_attn_for_dummy_run:

--- a/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
@@ -23,7 +23,8 @@ CUDA graphs (FULL, mirroring DFlash) cover the whole draft step: the parallel
 backbone forward AND the sequential Markov sampling.
 """
 
-from typing import Any
+from collections.abc import Callable
+from typing import Any, Protocol, runtime_checkable
 
 import torch
 
@@ -32,6 +33,15 @@ from vllm.config.compilation import CUDAGraphMode
 from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample
 from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
 from vllm.v1.worker.gpu.spec_decode.dspark.utils import load_dspark_model
+
+
+@runtime_checkable
+class _SequenceShardedRawAuxHiddenStateTarget(Protocol):
+    def enable_sequence_sharded_raw_aux_hidden_states(self) -> bool: ...
+
+    def gather_sequence_sharded_aux_hidden_states(
+        self, hidden_states: torch.Tensor
+    ) -> torch.Tensor: ...
 
 
 class DSparkSpeculator(DFlashSpeculator):
@@ -72,6 +82,9 @@ class DSparkSpeculator(DFlashSpeculator):
         # Reduced-vocab probabilistic drafting only; set in load_draft_model.
         self._d2t_scatter_index: torch.Tensor | None = None
         self._draft_scatter_buf: torch.Tensor | None = None
+        self._sequence_sharded_aux_gather: (
+            Callable[[torch.Tensor], torch.Tensor] | None
+        ) = None
 
     def load_draft_model(
         self,
@@ -79,6 +92,20 @@ class DSparkSpeculator(DFlashSpeculator):
         target_attn_layer_names: set[str],
     ) -> torch.nn.Module:
         model = load_dspark_model(target_model, self.vllm_config)
+        target_language_model = (
+            target_model.get_language_model()
+            if hasattr(target_model, "get_language_model")
+            else target_model
+        )
+        target_inner = target_language_model.model
+        if (
+            isinstance(target_inner, _SequenceShardedRawAuxHiddenStateTarget)
+            and target_inner.enable_sequence_sharded_raw_aux_hidden_states()
+        ):
+            self._sequence_sharded_aux_gather = (
+                target_inner.gather_sequence_sharded_aux_hidden_states
+            )
+
         # Reduced draft vocab: probabilistic rejection sampling indexes draft
         # logits by target id, so precompute the draft->target column map and a
         # scratch buffer to scatter logits into target vocab before sampling.
@@ -96,6 +123,25 @@ class DSparkSpeculator(DFlashSpeculator):
                 device=self.device,
             )
         return model
+
+    def _prepare_target_hidden_states(
+        self,
+        last_hidden_states: torch.Tensor,
+        aux_hidden_states: list[torch.Tensor] | None,
+        num_target_tokens: int,
+    ) -> torch.Tensor:
+        if not aux_hidden_states or self._sequence_sharded_aux_gather is None:
+            return super()._prepare_target_hidden_states(
+                last_hidden_states,
+                aux_hidden_states,
+                num_target_tokens,
+            )
+
+        local_hidden_states = self.model.combine_hidden_states(
+            torch.cat(aux_hidden_states, dim=-1)
+        )
+        hidden_states = self._sequence_sharded_aux_gather(local_hidden_states)
+        return hidden_states[:num_target_tokens]
 
     def _sample_sequential(self, num_reqs: int, head_hidden: torch.Tensor) -> None:
         # Sequential Markov sampling over the backbone's output hidden states.


### PR DESCRIPTION
## Purpose

This optimizes the Kimi K3 DSpark target-to-draft hidden-state path when the
target uses sequence parallelism (SP) with PP=1.

Today, the target gathers each raw auxiliary hidden state before concatenation
and the draft projection. This change lets the Kimi target retain raw auxiliary
states on their local SP shards, applies the already-loaded draft
`combine_hidden_states` projection locally, then gathers the single projected
representation. The target capability is opt-in; models without it retain the
existing DFlash behavior.

It also records the actual leading dimension of each auxiliary CUDA-graph
buffer so replay does not expose stale padded rows when local SP shard lengths
vary by descriptor.

The included benchmark compares five raw-state collective operations with the
one projected-state collective operation, including the byte count. It is not
presented as a measured speedup here.

### Duplicate-work check

This is related to the Kimi K3 tracker #50001 and complements #50138. #50138
implements pipeline-parallel K3/DSpark support; this PR changes the
sequence-parallel communication path for PP=1. The approaches are materially
different, although both touch K3 DSpark files and may need a rebase if #50138
lands first.

## Test Plan

On a supported Linux CUDA host:

```bash
.venv/bin/python -m pytest \
  tests/models/kimi_k3/test_sequence_parallel.py \
  tests/models/test_dspark_mla.py \
  tests/v1/cudagraph/test_cudagraph_manager.py -v

torchrun --nproc-per-node=16 \
  benchmarks/kernels/benchmark_kimi_k3_sp_collectives.py \
  --mode dspark --tokens 8 32 128 1024
```

The intended end-to-end follow-up is Kimi K3 + DSpark on TP8 and TP16 with
PP=1, BF16 and supported quantization backends, in EAGER/PIECEWISE/FULL CUDA
graph modes. It should compare deterministic outputs, acceptance rate, NCCL
bytes, and throughput before and after this change.

## Test Result

- Passed after the final no-conflict rebase: `git diff --check`.
- Passed after the final rebase: `SKIP=update-dockerfile-graph pre-commit run
  --files <all eight changed files>` (ruff, mypy, SPDX, lazy imports,
  forbidden-import, CUDA-API, and configuration hooks passed). The Dockerfile
  graph hook was skipped because this Windows host has no `/bin/bash`.
- Attempted the targeted pytest command on the local CUDA host. Test collection
  is blocked by vLLM's dependency `uvloop==0.22.1`, whose build reports
  `uvloop does not support Windows at the moment`. vLLM's editable install is
  likewise unsupported on Windows. Therefore no pytest pass/fail result is
  claimed.
- The 16-rank benchmark and Kimi K3 model evaluation were not run: this host
  has one 6 GB RTX 3060 and cannot run the required K3 TP8/TP16 configuration.

No public documentation update is needed for this internal optimization.

## AI assistance and accountability

This PR was developed with assistance from OpenAI Codex. I, Jiahua Chen,
reviewed every changed line, understand the implementation and its remaining
Linux multi-GPU validation risks, and take responsibility for this submission.

---
<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] Purpose and duplicate-work check included.
- [x] Test plan included.
- [x] Test commands and their actual results included.
- [x] Model-evaluation status disclosed.
- [x] AI assistance disclosed.
</details>
