### PR TITLE
[Kernel][Kimi K3] Fuse mixed-batch KDA boundary operations

### DIFF
--- a/benchmarks/kernels/benchmark_kimi_k3_kda_mixed.py
+++ b/benchmarks/kernels/benchmark_kimi_k3_kda_mixed.py
@@ -1,0 +1,208 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import argparse
+from collections.abc import Callable
+
+import torch
+
+from vllm.models.kimi_k3.nvidia.ops.kda_mixed import (
+    pack_kda_mixed_inputs,
+    scatter_rms_norm_kda_mixed_outputs,
+)
+from vllm.third_party.flash_linear_attention.ops.kda import FusedRMSNormGated
+from vllm.triton_utils import triton
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Benchmark Kimi-K3 mixed KDA boundary fusion."
+    )
+    parser.add_argument("--num-tokens", type=int, default=128)
+    parser.add_argument("--num-heads", type=int, default=12)
+    parser.add_argument("--spec-fraction", type=float, default=0.5)
+    parser.add_argument(
+        "--dtype",
+        choices=("float16", "bfloat16"),
+        default="bfloat16",
+    )
+    parser.add_argument("--warmup-ms", type=int, default=100)
+    parser.add_argument("--rep-ms", type=int, default=500)
+    return parser.parse_args()
+
+
+def _bench(
+    fn: Callable[[], object],
+    warmup_ms: int,
+    rep_ms: int,
+) -> float:
+    return float(
+        triton.testing.do_bench(
+            fn,
+            warmup=warmup_ms,
+            rep=rep_ms,
+        )
+    )
+
+
+@torch.inference_mode()
+def main() -> None:
+    args = _parse_args()
+    if args.num_tokens < 1:
+        raise ValueError("--num-tokens must be positive")
+    if not 0.0 < args.spec_fraction < 1.0:
+        raise ValueError("--spec-fraction must be strictly between 0 and 1")
+
+    dtype = getattr(torch, args.dtype)
+    T, H, D = args.num_tokens, args.num_heads, 128
+    num_spec = round(T * args.spec_fraction)
+    num_non_spec = T - num_spec
+    if not num_spec or not num_non_spec:
+        raise ValueError("The rounded benchmark partition must contain both groups")
+    torch.manual_seed(17)
+
+    is_spec = torch.zeros(T, dtype=torch.bool)
+    if num_spec:
+        is_spec[torch.randperm(T)[:num_spec]] = True
+    indices = torch.argsort(is_spec, stable=True).to(device="cuda")
+    non_spec_indices = indices[:num_non_spec]
+    spec_indices = indices[num_non_spec:]
+
+    qkv_width = 3 * H * D
+    mixed_qkv = torch.randn(
+        T,
+        qkv_width + 7,
+        dtype=dtype,
+        device="cuda",
+    )[:, :qkv_width]
+    g1 = torch.randn(
+        1,
+        T,
+        H,
+        D + 3,
+        dtype=dtype,
+        device="cuda",
+    )[..., :D]
+    beta = torch.randn(
+        1,
+        T,
+        H + 3,
+        dtype=dtype,
+        device="cuda",
+    )[..., :H]
+
+    non_spec_output = torch.randn(
+        1,
+        num_non_spec,
+        H,
+        D,
+        dtype=dtype,
+        device="cuda",
+    )
+    spec_output = torch.randn(
+        1,
+        num_spec,
+        H,
+        D,
+        dtype=dtype,
+        device="cuda",
+    )
+    gate = torch.randn(T, H, D, dtype=dtype, device="cuda")
+    norm = FusedRMSNormGated(
+        D,
+        activation="sigmoid",
+        device=torch.device("cuda"),
+        dtype=dtype,
+    )
+    torch.nn.init.normal_(norm.weight)
+    baseline_output = torch.empty(1, T, H, D, dtype=dtype, device="cuda")
+    fused_output = torch.empty_like(baseline_output)
+
+    def before_pack() -> tuple[torch.Tensor, ...]:
+        return (
+            mixed_qkv.index_select(0, spec_indices),
+            g1.index_select(1, spec_indices),
+            beta.index_select(1, spec_indices),
+            mixed_qkv.index_select(0, non_spec_indices),
+            g1.index_select(1, non_spec_indices),
+            beta.index_select(1, non_spec_indices),
+        )
+
+    def after_pack() -> tuple[torch.Tensor, ...]:
+        return pack_kda_mixed_inputs(
+            mixed_qkv,
+            g1,
+            beta,
+            non_spec_indices,
+            spec_indices,
+        )
+
+    def before_scatter_norm() -> None:
+        baseline_output.index_copy_(1, spec_indices, spec_output)
+        baseline_output.index_copy_(1, non_spec_indices, non_spec_output)
+        baseline_output.copy_(norm.forward_cuda(baseline_output, gate))
+
+    def after_scatter_norm() -> None:
+        scatter_rms_norm_kda_mixed_outputs(
+            non_spec_output,
+            spec_output,
+            non_spec_indices,
+            spec_indices,
+            gate,
+            norm.weight,
+            fused_output,
+            norm.eps,
+        )
+
+    def before_combined() -> None:
+        before_pack()
+        before_scatter_norm()
+
+    def after_combined() -> None:
+        after_pack()
+        after_scatter_norm()
+
+    before_combined()
+    after_combined()
+    torch.accelerator.synchronize()
+
+    rows = [
+        (
+            "input pack",
+            _bench(before_pack, args.warmup_ms, args.rep_ms),
+            _bench(after_pack, args.warmup_ms, args.rep_ms),
+            6,
+            1,
+        ),
+        (
+            "scatter + gated RMSNorm",
+            _bench(before_scatter_norm, args.warmup_ms, args.rep_ms),
+            _bench(after_scatter_norm, args.warmup_ms, args.rep_ms),
+            3,
+            1,
+        ),
+        (
+            "combined boundary",
+            _bench(before_combined, args.warmup_ms, args.rep_ms),
+            _bench(after_combined, args.warmup_ms, args.rep_ms),
+            9,
+            2,
+        ),
+    ]
+
+    print(
+        f"Kimi-K3 mixed KDA: T={T}, H={H}, D={D}, "
+        f"non-spec={num_non_spec}, spec={num_spec}, dtype={args.dtype}"
+    )
+    print("| stage | before (ms) | after (ms) | speedup | launches |")
+    print("|---|---:|---:|---:|---:|")
+    for stage, before_ms, after_ms, before_launches, after_launches in rows:
+        print(
+            f"| {stage} | {before_ms:.4f} | {after_ms:.4f} | "
+            f"{before_ms / after_ms:.2f}x | "
+            f"{before_launches} -> {after_launches} |"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/models/kimi_k3/test_kda.py
+++ b/tests/models/kimi_k3/test_kda.py
@@ -10,6 +10,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
+from tests.kernels.utils import opcheck
 from vllm import _custom_ops as ops
 from vllm.model_executor.layers.mamba.ops.causal_conv1d import causal_conv1d_update
 from vllm.model_executor.layers.mamba.ops.gather_initial_states import (
@@ -19,6 +20,10 @@ from vllm.models.kimi_k3.nvidia.kda import (
     is_flashkda_supported,
     is_fused_kda_decode_supported,
 )
+from vllm.models.kimi_k3.nvidia.ops.kda_mixed import (
+    pack_kda_mixed_inputs,
+    scatter_rms_norm_kda_mixed_outputs,
+)
 from vllm.models.kimi_k3.nvidia.ops.third_party.kda import (
     chunk_kda,
     chunk_kda_with_fused_gate,
@@ -27,6 +32,7 @@ from vllm.models.kimi_k3.nvidia.ops.third_party.kda import (
     fused_recurrent_kda_fwd,
     fused_recurrent_kda_packed_decode,
 )
+from vllm.third_party.flash_linear_attention.ops.kda import FusedRMSNormGated
 from vllm.third_party.flash_linear_attention.ops.l2norm import l2norm_fwd
 
 DEVICE = "cuda"
@@ -755,3 +761,265 @@ def test_flashkda_correctness():
 
     assert_close("o", expected_out, actual_out, 0.01)
     assert_close("ht", expected_state, actual_state, 0.01)
+
+
+def _stable_kda_partition(
+    num_tokens: int,
+    num_non_spec: int,
+    index_dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    generator = torch.Generator().manual_seed(23)
+    is_spec = torch.ones(num_tokens, dtype=torch.bool)
+    if num_non_spec:
+        non_spec_positions = torch.randperm(num_tokens, generator=generator)[
+            :num_non_spec
+        ]
+        is_spec[non_spec_positions] = False
+    indices = torch.argsort(is_spec, stable=True).to(
+        device=DEVICE,
+        dtype=index_dtype,
+    )
+    return indices[:num_non_spec], indices[num_non_spec:]
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("index_dtype", [torch.int32, torch.int64])
+@pytest.mark.parametrize(
+    ("num_tokens", "num_non_spec"),
+    [(0, 0), (17, 0), (17, 17), (17, 8), (32, 13)],
+)
+@torch.inference_mode()
+def test_kda_mixed_boundary_ops_match_existing_cuda_path(
+    default_vllm_config,
+    dtype: torch.dtype,
+    index_dtype: torch.dtype,
+    num_tokens: int,
+    num_non_spec: int,
+):
+    torch.manual_seed(11)
+    H, D = 6, 128
+    qkv_width = 3 * H * D
+    eps = 1e-5
+    non_spec_indices, spec_indices = _stable_kda_partition(
+        num_tokens,
+        num_non_spec,
+        index_dtype,
+    )
+    packed_indices = torch.cat((non_spec_indices, spec_indices))
+
+    mixed_qkv = torch.randn(
+        num_tokens,
+        qkv_width + 7,
+        dtype=dtype,
+        device=DEVICE,
+    )[:, :qkv_width]
+    g1 = torch.randn(
+        1,
+        num_tokens,
+        H,
+        D + 3,
+        dtype=dtype,
+        device=DEVICE,
+    )[..., :D]
+    beta = torch.randn(
+        1,
+        num_tokens,
+        H + 3,
+        dtype=dtype,
+        device=DEVICE,
+    )[..., :H]
+    packed_qkv, packed_g1, packed_beta = pack_kda_mixed_inputs(
+        mixed_qkv,
+        g1,
+        beta,
+        non_spec_indices,
+        spec_indices,
+    )
+    torch.testing.assert_close(
+        packed_qkv,
+        mixed_qkv.index_select(0, packed_indices),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        packed_g1,
+        g1.index_select(1, packed_indices),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        packed_beta,
+        beta.index_select(1, packed_indices),
+        rtol=0,
+        atol=0,
+    )
+    assert packed_qkv.is_contiguous()
+    assert packed_g1.is_contiguous()
+    assert packed_beta.is_contiguous()
+
+    num_spec = num_tokens - num_non_spec
+    non_spec_output = torch.randn(
+        1,
+        num_non_spec,
+        H,
+        D + 5,
+        dtype=dtype,
+        device=DEVICE,
+    )[..., :D]
+    spec_output = torch.randn(
+        1,
+        num_spec,
+        H,
+        D + 5,
+        dtype=dtype,
+        device=DEVICE,
+    )[..., :D]
+    num_padding = 3
+    gate = torch.randn(
+        num_tokens + num_padding,
+        H,
+        D + 5,
+        dtype=dtype,
+        device=DEVICE,
+    )[..., :D]
+    norm = FusedRMSNormGated(
+        D,
+        activation="sigmoid",
+        device=torch.device(DEVICE),
+        dtype=dtype,
+    )
+    torch.nn.init.normal_(norm.weight)
+    output = torch.full(
+        (1, num_tokens + num_padding, H, D + 5),
+        17.0,
+        dtype=dtype,
+        device=DEVICE,
+    )[..., :D]
+    expected = output.clone()
+    expected.index_copy_(1, non_spec_indices, non_spec_output)
+    expected.index_copy_(1, spec_indices, spec_output)
+    if num_tokens:
+        expected[:, :num_tokens].copy_(
+            norm.forward_cuda(expected[:, :num_tokens].clone(), gate[:num_tokens])
+        )
+    output_ptr = output.data_ptr()
+
+    scatter_rms_norm_kda_mixed_outputs(
+        non_spec_output,
+        spec_output,
+        non_spec_indices,
+        spec_indices,
+        gate,
+        norm.weight,
+        output,
+        eps,
+    )
+
+    assert output.data_ptr() == output_ptr
+    torch.testing.assert_close(output, expected, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(
+        output[:, num_tokens:],
+        torch.full_like(output[:, num_tokens:], 17.0),
+        rtol=0,
+        atol=0,
+    )
+
+
+@torch.inference_mode()
+def test_kda_mixed_boundary_ops_float32_fallback(default_vllm_config):
+    T, N, H, D = 9, 4, 2, 128
+    non_spec_indices, spec_indices = _stable_kda_partition(T, N, torch.int64)
+    packed_indices = torch.cat((non_spec_indices, spec_indices))
+    mixed_qkv = torch.randn(T, 3 * H * D, device=DEVICE)
+    g1 = torch.randn(1, T, H, D, device=DEVICE)
+    beta = torch.randn(1, T, H, device=DEVICE)
+
+    packed_qkv, packed_g1, packed_beta = pack_kda_mixed_inputs(
+        mixed_qkv,
+        g1,
+        beta,
+        non_spec_indices,
+        spec_indices,
+    )
+    torch.testing.assert_close(packed_qkv, mixed_qkv.index_select(0, packed_indices))
+    torch.testing.assert_close(packed_g1, g1.index_select(1, packed_indices))
+    torch.testing.assert_close(packed_beta, beta.index_select(1, packed_indices))
+
+    non_spec_output = torch.randn(1, N, H, D, device=DEVICE)
+    spec_output = torch.randn(1, T - N, H, D, device=DEVICE)
+    gate = torch.randn(T, H, D, device=DEVICE)
+    norm = FusedRMSNormGated(
+        D,
+        activation="sigmoid",
+        device=torch.device(DEVICE),
+        dtype=torch.float32,
+    )
+    torch.nn.init.normal_(norm.weight)
+    output = torch.empty(1, T, H, D, device=DEVICE)
+    expected = torch.empty_like(output)
+    expected.index_copy_(1, non_spec_indices, non_spec_output)
+    expected.index_copy_(1, spec_indices, spec_output)
+    expected.copy_(norm.forward_cuda(expected.clone(), gate))
+
+    scatter_rms_norm_kda_mixed_outputs(
+        non_spec_output,
+        spec_output,
+        non_spec_indices,
+        spec_indices,
+        gate,
+        norm.weight,
+        output,
+        norm.eps,
+    )
+    torch.testing.assert_close(output, expected)
+
+
+@torch.inference_mode()
+def test_kda_mixed_boundary_custom_op_registration():
+    T, N, H, D = 7, 3, 2, 128
+    non_spec_indices, spec_indices = _stable_kda_partition(T, N, torch.int64)
+    mixed_qkv = torch.randn(
+        T,
+        3 * H * D,
+        dtype=torch.float16,
+        device=DEVICE,
+    )
+    g1 = torch.randn(1, T, H, D, dtype=torch.float16, device=DEVICE)
+    beta = torch.randn(1, T, H, dtype=torch.float16, device=DEVICE)
+    opcheck(
+        torch.ops.vllm.kimi_k3_pack_kda_mixed_inputs,
+        (mixed_qkv, g1, beta, non_spec_indices, spec_indices),
+    )
+
+    non_spec_output = torch.randn(
+        1,
+        N,
+        H,
+        D,
+        dtype=torch.float16,
+        device=DEVICE,
+    )
+    spec_output = torch.randn(
+        1,
+        T - N,
+        H,
+        D,
+        dtype=torch.float16,
+        device=DEVICE,
+    )
+    gate = torch.randn(T, H, D, dtype=torch.float16, device=DEVICE)
+    weight = torch.randn(D, dtype=torch.float16, device=DEVICE)
+    output = torch.empty(1, T, H, D, dtype=torch.float16, device=DEVICE)
+    opcheck(
+        torch.ops.vllm.kimi_k3_scatter_rms_norm_kda_mixed_outputs,
+        (
+            non_spec_output,
+            spec_output,
+            non_spec_indices,
+            spec_indices,
+            gate,
+            weight,
+            output,
+            1e-5,
+        ),
+    )

--- a/tests/models/kimi_k3/test_kda_metadata.py
+++ b/tests/models/kimi_k3/test_kda_metadata.py
@@ -281,6 +281,8 @@ def test_mixed_one_token_prefill_and_spec_decode_uses_prefill_metadata(
         actual.non_spec_query_start_loc,
         torch.tensor([0, 1], dtype=torch.int32),
     )
+    torch.testing.assert_close(actual.non_spec_token_indx, torch.tensor([0]))
+    torch.testing.assert_close(actual.spec_token_indx, torch.tensor([1, 2, 3]))
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")

--- a/vllm/models/kimi_k3/nvidia/kda.py
+++ b/vllm/models/kimi_k3/nvidia/kda.py
@@ -42,6 +42,10 @@ from vllm.models.kimi_k3.nvidia.kda_metadata import (
     KimiK3KDAAttentionBackend,
     KimiK3KDAMetadata,
 )
+from vllm.models.kimi_k3.nvidia.ops.kda_mixed import (
+    pack_kda_mixed_inputs,
+    scatter_rms_norm_kda_mixed_outputs,
+)
 from vllm.platforms import current_platform
 from vllm.third_party.flash_linear_attention.ops.kda import FusedRMSNormGated
 from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
@@ -594,12 +598,20 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
             else:
                 assert spec_token_indx is not None
                 assert non_spec_token_indx is not None
-                mixed_qkv_spec = mixed_qkv.index_select(0, spec_token_indx)
-                g1_spec = g1.index_select(1, spec_token_indx)
-                beta_spec = beta.index_select(1, spec_token_indx)
-                mixed_qkv_ns = mixed_qkv.index_select(0, non_spec_token_indx)
-                g1_ns = g1.index_select(1, non_spec_token_indx)
-                beta_ns = beta.index_select(1, non_spec_token_indx)
+                packed_qkv, packed_g1, packed_beta = pack_kda_mixed_inputs(
+                    mixed_qkv,
+                    g1,
+                    beta,
+                    non_spec_token_indx,
+                    spec_token_indx,
+                )
+                num_non_spec_tokens = non_spec_token_indx.numel()
+                mixed_qkv_ns = packed_qkv[:num_non_spec_tokens]
+                g1_ns = packed_g1[:, :num_non_spec_tokens]
+                beta_ns = packed_beta[:, :num_non_spec_tokens]
+                mixed_qkv_spec = packed_qkv[num_non_spec_tokens:]
+                g1_spec = packed_g1[:, num_non_spec_tokens:]
+                beta_spec = packed_beta[:, num_non_spec_tokens:]
         else:
             mixed_qkv_spec = g1_spec = beta_spec = None
             mixed_qkv_ns, g1_ns, beta_ns = mixed_qkv, g1, beta
@@ -763,8 +775,19 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
 
         # Restore the scheduler's original token order for mixed batches.
         if core_attn_out_spec is not None and core_attn_out_non_spec is not None:
-            core_attn_out.index_copy_(1, spec_token_indx, core_attn_out_spec)
-            core_attn_out.index_copy_(1, non_spec_token_indx, core_attn_out_non_spec)
+            assert spec_token_indx is not None
+            assert non_spec_token_indx is not None
+            scatter_rms_norm_kda_mixed_outputs(
+                core_attn_out_non_spec,
+                core_attn_out_spec,
+                non_spec_token_indx,
+                spec_token_indx,
+                g2,
+                self.o_norm.weight,
+                core_attn_out,
+                self.o_norm.eps,
+            )
+            return
         elif core_attn_out_non_spec is not None:
             # TODO: prefill and decode kernels write directly to core_attn_out
             core_attn_out[0, :num_actual_tokens] = core_attn_out_non_spec[

--- a/vllm/models/kimi_k3/nvidia/ops/kda_mixed.py
+++ b/vllm/models/kimi_k3/nvidia/ops/kda_mixed.py
@@ -1,0 +1,560 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.triton_utils import tl, triton
+from vllm.utils.math_utils import cdiv, next_power_of_2
+from vllm.utils.torch_utils import direct_register_custom_op
+
+
+@triton.jit
+def _pack_kda_mixed_inputs_kernel(
+    mixed_qkv,
+    g1,
+    beta,
+    non_spec_indices,
+    spec_indices,
+    packed_mixed_qkv,
+    packed_g1,
+    packed_beta,
+    num_non_spec,
+    mixed_qkv_stride_token,
+    mixed_qkv_stride_dim,
+    g1_stride_token,
+    g1_stride_head,
+    g1_stride_dim,
+    beta_stride_token,
+    beta_stride_head,
+    QKV_WIDTH: tl.constexpr,
+    NUM_HEADS: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    packed_token = tl.program_id(0)
+    offsets = tl.program_id(1) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+
+    is_non_spec = packed_token < num_non_spec
+    non_spec_token = tl.load(
+        non_spec_indices + packed_token,
+        mask=is_non_spec,
+        other=0,
+    )
+    spec_token = tl.load(
+        spec_indices + packed_token - num_non_spec,
+        mask=~is_non_spec,
+        other=0,
+    )
+    source_token = tl.where(is_non_spec, non_spec_token, spec_token)
+
+    qkv_mask = offsets < QKV_WIDTH
+    qkv = tl.load(
+        mixed_qkv
+        + source_token * mixed_qkv_stride_token
+        + offsets * mixed_qkv_stride_dim,
+        mask=qkv_mask,
+    )
+    tl.store(
+        packed_mixed_qkv + packed_token * QKV_WIDTH + offsets,
+        qkv,
+        mask=qkv_mask,
+    )
+
+    g1_width: tl.constexpr = NUM_HEADS * HEAD_DIM
+    g1_mask = offsets < g1_width
+    g1_head = offsets // HEAD_DIM
+    g1_dim = offsets % HEAD_DIM
+    g1_values = tl.load(
+        g1
+        + source_token * g1_stride_token
+        + g1_head * g1_stride_head
+        + g1_dim * g1_stride_dim,
+        mask=g1_mask,
+    )
+    tl.store(
+        packed_g1 + packed_token * g1_width + offsets,
+        g1_values,
+        mask=g1_mask,
+    )
+
+    beta_mask = offsets < NUM_HEADS
+    beta_values = tl.load(
+        beta + source_token * beta_stride_token + offsets * beta_stride_head,
+        mask=beta_mask,
+    )
+    tl.store(
+        packed_beta + packed_token * NUM_HEADS + offsets,
+        beta_values,
+        mask=beta_mask,
+    )
+
+
+def _pack_kda_mixed_inputs_impl(
+    mixed_qkv: torch.Tensor,
+    g1: torch.Tensor,
+    beta: torch.Tensor,
+    non_spec_indices: torch.Tensor,
+    spec_indices: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    num_non_spec = non_spec_indices.numel()
+    num_tokens = num_non_spec + spec_indices.numel()
+    num_heads, head_dim = g1.shape[-2:]
+    qkv_width = mixed_qkv.size(1)
+    packed_mixed_qkv = torch.empty(
+        (num_tokens, qkv_width),
+        dtype=mixed_qkv.dtype,
+        device=mixed_qkv.device,
+    )
+    packed_g1 = torch.empty(
+        (1, num_tokens, num_heads, head_dim),
+        dtype=g1.dtype,
+        device=g1.device,
+    )
+    packed_beta = torch.empty(
+        (1, num_tokens, num_heads),
+        dtype=beta.dtype,
+        device=beta.device,
+    )
+    if num_tokens == 0:
+        return packed_mixed_qkv, packed_g1, packed_beta
+
+    max_width = max(qkv_width, num_heads * head_dim)
+    block_size = 256
+    _pack_kda_mixed_inputs_kernel[(num_tokens, cdiv(max_width, block_size))](
+        mixed_qkv,
+        g1,
+        beta,
+        non_spec_indices,
+        spec_indices,
+        packed_mixed_qkv,
+        packed_g1,
+        packed_beta,
+        num_non_spec,
+        mixed_qkv.stride(0),
+        mixed_qkv.stride(1),
+        g1.stride(1),
+        g1.stride(2),
+        g1.stride(3),
+        beta.stride(1),
+        beta.stride(2),
+        QKV_WIDTH=qkv_width,
+        NUM_HEADS=num_heads,
+        HEAD_DIM=head_dim,
+        BLOCK_SIZE=block_size,
+        num_warps=4,
+    )
+    return packed_mixed_qkv, packed_g1, packed_beta
+
+
+def _pack_kda_mixed_inputs_fake(
+    mixed_qkv: torch.Tensor,
+    g1: torch.Tensor,
+    beta: torch.Tensor,
+    non_spec_indices: torch.Tensor,
+    spec_indices: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    num_tokens = non_spec_indices.numel() + spec_indices.numel()
+    return (
+        torch.empty(
+            (num_tokens, mixed_qkv.size(1)),
+            dtype=mixed_qkv.dtype,
+            device=mixed_qkv.device,
+        ),
+        torch.empty(
+            (1, num_tokens, g1.size(2), g1.size(3)),
+            dtype=g1.dtype,
+            device=g1.device,
+        ),
+        torch.empty(
+            (1, num_tokens, beta.size(2)),
+            dtype=beta.dtype,
+            device=beta.device,
+        ),
+    )
+
+
+direct_register_custom_op(
+    op_name="kimi_k3_pack_kda_mixed_inputs",
+    op_func=_pack_kda_mixed_inputs_impl,
+    fake_impl=_pack_kda_mixed_inputs_fake,
+)
+
+
+@triton.jit
+def _scatter_rms_norm_kda_mixed_outputs_kernel(
+    non_spec_output,
+    spec_output,
+    non_spec_indices,
+    spec_indices,
+    gate,
+    weight,
+    output,
+    num_non_spec,
+    eps,
+    non_spec_stride_token,
+    non_spec_stride_head,
+    non_spec_stride_dim,
+    spec_stride_token,
+    spec_stride_head,
+    spec_stride_dim,
+    gate_stride_token,
+    gate_stride_head,
+    gate_stride_dim,
+    output_stride_token,
+    output_stride_head,
+    output_stride_dim,
+    NUM_HEADS: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    packed_token = row // NUM_HEADS
+    head = row % NUM_HEADS
+    offsets = tl.arange(0, BLOCK_SIZE)
+    mask = offsets < HEAD_DIM
+
+    is_non_spec = packed_token < num_non_spec
+    non_spec_token = packed_token
+    spec_token = packed_token - num_non_spec
+    destination_token_non_spec = tl.load(
+        non_spec_indices + non_spec_token,
+        mask=is_non_spec,
+        other=0,
+    )
+    destination_token_spec = tl.load(
+        spec_indices + spec_token,
+        mask=~is_non_spec,
+        other=0,
+    )
+    destination_token = tl.where(
+        is_non_spec,
+        destination_token_non_spec,
+        destination_token_spec,
+    )
+
+    non_spec_values = tl.load(
+        non_spec_output
+        + non_spec_token * non_spec_stride_token
+        + head * non_spec_stride_head
+        + offsets * non_spec_stride_dim,
+        mask=is_non_spec & mask,
+        other=0.0,
+    )
+    spec_values = tl.load(
+        spec_output
+        + spec_token * spec_stride_token
+        + head * spec_stride_head
+        + offsets * spec_stride_dim,
+        mask=(~is_non_spec) & mask,
+        other=0.0,
+    )
+    values = tl.where(is_non_spec, non_spec_values, spec_values).to(tl.float32)
+    squared_values = tl.where(mask, values * values, 0.0)
+    reciprocal_std = 1.0 / tl.sqrt(tl.sum(squared_values, axis=0) / HEAD_DIM + eps)
+
+    norm_weight = tl.load(weight + offsets, mask=mask).to(tl.float32)
+    gate_values = tl.load(
+        gate
+        + destination_token * gate_stride_token
+        + head * gate_stride_head
+        + offsets * gate_stride_dim,
+        mask=mask,
+    ).to(tl.float32)
+    normalized = values * reciprocal_std * norm_weight * tl.sigmoid(gate_values)
+    tl.store(
+        output
+        + destination_token * output_stride_token
+        + head * output_stride_head
+        + offsets * output_stride_dim,
+        normalized,
+        mask=mask,
+    )
+
+
+def _scatter_rms_norm_kda_mixed_outputs_impl(
+    non_spec_output: torch.Tensor,
+    spec_output: torch.Tensor,
+    non_spec_indices: torch.Tensor,
+    spec_indices: torch.Tensor,
+    gate: torch.Tensor,
+    weight: torch.Tensor,
+    output: torch.Tensor,
+    eps: float,
+) -> None:
+    num_non_spec = non_spec_indices.numel()
+    num_tokens = num_non_spec + spec_indices.numel()
+    if num_tokens == 0:
+        return
+
+    num_heads, head_dim = output.shape[-2:]
+    block_size = next_power_of_2(head_dim)
+    _scatter_rms_norm_kda_mixed_outputs_kernel[(num_tokens * num_heads,)](
+        non_spec_output,
+        spec_output,
+        non_spec_indices,
+        spec_indices,
+        gate,
+        weight,
+        output,
+        num_non_spec,
+        eps,
+        non_spec_output.stride(1),
+        non_spec_output.stride(2),
+        non_spec_output.stride(3),
+        spec_output.stride(1),
+        spec_output.stride(2),
+        spec_output.stride(3),
+        gate.stride(0),
+        gate.stride(1),
+        gate.stride(2),
+        output.stride(1),
+        output.stride(2),
+        output.stride(3),
+        NUM_HEADS=num_heads,
+        HEAD_DIM=head_dim,
+        BLOCK_SIZE=block_size,
+        num_warps=4,
+    )
+
+
+def _scatter_rms_norm_kda_mixed_outputs_fake(
+    non_spec_output: torch.Tensor,
+    spec_output: torch.Tensor,
+    non_spec_indices: torch.Tensor,
+    spec_indices: torch.Tensor,
+    gate: torch.Tensor,
+    weight: torch.Tensor,
+    output: torch.Tensor,
+    eps: float,
+) -> None:
+    return
+
+
+direct_register_custom_op(
+    op_name="kimi_k3_scatter_rms_norm_kda_mixed_outputs",
+    op_func=_scatter_rms_norm_kda_mixed_outputs_impl,
+    mutates_args=["output"],
+    fake_impl=_scatter_rms_norm_kda_mixed_outputs_fake,
+)
+
+
+def _pack_kda_mixed_inputs_native(
+    mixed_qkv: torch.Tensor,
+    g1: torch.Tensor,
+    beta: torch.Tensor,
+    non_spec_indices: torch.Tensor,
+    spec_indices: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    indices = torch.cat((non_spec_indices, spec_indices))
+    return (
+        mixed_qkv.index_select(0, indices),
+        g1.index_select(1, indices),
+        beta.index_select(1, indices),
+    )
+
+
+def _can_pack_with_triton(
+    mixed_qkv: torch.Tensor,
+    g1: torch.Tensor,
+    beta: torch.Tensor,
+    non_spec_indices: torch.Tensor,
+    spec_indices: torch.Tensor,
+) -> bool:
+    tensors = (mixed_qkv, g1, beta, non_spec_indices, spec_indices)
+    return (
+        mixed_qkv.device.type == "cuda"
+        and all(tensor.device == mixed_qkv.device for tensor in tensors)
+        and mixed_qkv.dtype in (torch.float16, torch.bfloat16)
+        and g1.dtype == mixed_qkv.dtype
+        and beta.dtype == mixed_qkv.dtype
+        and non_spec_indices.dtype in (torch.int32, torch.int64)
+        and spec_indices.dtype == non_spec_indices.dtype
+        and g1.size(3) == 128
+        and mixed_qkv.size(1) == 3 * g1.size(2) * g1.size(3)
+        and mixed_qkv.stride(1) == 1
+        and g1.stride(3) == 1
+        and beta.stride(2) == 1
+        and non_spec_indices.stride(0) == 1
+        and spec_indices.stride(0) == 1
+    )
+
+
+def pack_kda_mixed_inputs(
+    mixed_qkv: torch.Tensor,
+    g1: torch.Tensor,
+    beta: torch.Tensor,
+    non_spec_indices: torch.Tensor,
+    spec_indices: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Pack stable non-spec/spec partitions with one device launch.
+
+    The returned tensors contain the non-spec partition first. Each partition
+    preserves the scheduler's original token order. The index tensors must be
+    a disjoint partition of all input rows.
+    """
+    num_tokens = non_spec_indices.numel() + spec_indices.numel()
+    if (
+        mixed_qkv.ndim != 2
+        or g1.ndim != 4
+        or beta.ndim != 3
+        or non_spec_indices.ndim != 1
+        or spec_indices.ndim != 1
+        or g1.size(0) != 1
+        or beta.size(0) != 1
+        or mixed_qkv.size(0) != num_tokens
+        or g1.size(1) != num_tokens
+        or beta.size(1) != num_tokens
+        or beta.size(2) != g1.size(2)
+    ):
+        raise ValueError("Invalid KDA mixed-input shapes")
+    if _can_pack_with_triton(
+        mixed_qkv,
+        g1,
+        beta,
+        non_spec_indices,
+        spec_indices,
+    ):
+        return torch.ops.vllm.kimi_k3_pack_kda_mixed_inputs(
+            mixed_qkv,
+            g1,
+            beta,
+            non_spec_indices,
+            spec_indices,
+        )
+    return _pack_kda_mixed_inputs_native(
+        mixed_qkv,
+        g1,
+        beta,
+        non_spec_indices,
+        spec_indices,
+    )
+
+
+def _scatter_rms_norm_kda_mixed_outputs_native(
+    non_spec_output: torch.Tensor,
+    spec_output: torch.Tensor,
+    non_spec_indices: torch.Tensor,
+    spec_indices: torch.Tensor,
+    gate: torch.Tensor,
+    weight: torch.Tensor,
+    output: torch.Tensor,
+    eps: float,
+) -> None:
+    indices = torch.cat((non_spec_indices, spec_indices))
+    output.index_copy_(1, non_spec_indices, non_spec_output)
+    output.index_copy_(1, spec_indices, spec_output)
+    selected = output.index_select(1, indices)
+    selected_gate = gate.index_select(0, indices)
+    selected_float = selected.float()
+    variance = selected_float.square().mean(dim=-1, keepdim=True)
+    normalized = selected_float * torch.rsqrt(variance + eps)
+    normalized *= weight.float()
+    normalized *= torch.sigmoid(selected_gate.float())
+    output.index_copy_(1, indices, normalized.to(output.dtype))
+
+
+def _can_scatter_rms_norm_with_triton(
+    non_spec_output: torch.Tensor,
+    spec_output: torch.Tensor,
+    non_spec_indices: torch.Tensor,
+    spec_indices: torch.Tensor,
+    gate: torch.Tensor,
+    weight: torch.Tensor,
+    output: torch.Tensor,
+) -> bool:
+    tensors = (
+        non_spec_output,
+        spec_output,
+        non_spec_indices,
+        spec_indices,
+        gate,
+        weight,
+        output,
+    )
+    return (
+        output.device.type == "cuda"
+        and all(tensor.device == output.device for tensor in tensors)
+        and output.dtype in (torch.float16, torch.bfloat16)
+        and non_spec_output.dtype == output.dtype
+        and spec_output.dtype == output.dtype
+        and gate.dtype == output.dtype
+        and weight.dtype in (torch.float16, torch.bfloat16, torch.float32)
+        and non_spec_indices.dtype in (torch.int32, torch.int64)
+        and spec_indices.dtype == non_spec_indices.dtype
+        and non_spec_output.stride(3) == 1
+        and spec_output.stride(3) == 1
+        and gate.stride(2) == 1
+        and weight.stride(0) == 1
+        and output.stride(3) == 1
+        and non_spec_indices.stride(0) == 1
+        and spec_indices.stride(0) == 1
+        and output.size(3) == 128
+    )
+
+
+def scatter_rms_norm_kda_mixed_outputs(
+    non_spec_output: torch.Tensor,
+    spec_output: torch.Tensor,
+    non_spec_indices: torch.Tensor,
+    spec_indices: torch.Tensor,
+    gate: torch.Tensor,
+    weight: torch.Tensor,
+    output: torch.Tensor,
+    eps: float,
+) -> None:
+    """Scatter and normalize indexed mixed-KDA rows in ``output``.
+
+    Rows absent from both index tensors, including CUDA-graph padding, are
+    intentionally left untouched. The index tensors must be disjoint and
+    in-bounds.
+    """
+    num_non_spec = non_spec_indices.numel()
+    num_spec = spec_indices.numel()
+    if (
+        non_spec_output.ndim != 4
+        or spec_output.ndim != 4
+        or non_spec_indices.ndim != 1
+        or spec_indices.ndim != 1
+        or gate.ndim != 3
+        or output.ndim != 4
+        or non_spec_output.size(0) != 1
+        or spec_output.size(0) != 1
+        or output.size(0) != 1
+        or non_spec_output.size(1) != num_non_spec
+        or spec_output.size(1) != num_spec
+        or non_spec_output.shape[2:] != output.shape[2:]
+        or spec_output.shape[2:] != output.shape[2:]
+        or gate.shape != output.shape[1:]
+        or weight.shape != (output.size(3),)
+    ):
+        raise ValueError("Invalid KDA mixed-output shapes")
+    if _can_scatter_rms_norm_with_triton(
+        non_spec_output,
+        spec_output,
+        non_spec_indices,
+        spec_indices,
+        gate,
+        weight,
+        output,
+    ):
+        torch.ops.vllm.kimi_k3_scatter_rms_norm_kda_mixed_outputs(
+            non_spec_output,
+            spec_output,
+            non_spec_indices,
+            spec_indices,
+            gate,
+            weight,
+            output,
+            eps,
+        )
+        return
+    _scatter_rms_norm_kda_mixed_outputs_native(
+        non_spec_output,
+        spec_output,
+        non_spec_indices,
+        spec_indices,
+        gate,
+        weight,
+        output,
+        eps,
+    )


### PR DESCRIPTION
## Purpose

This reduces launch and intermediate-tensor overhead in the NVIDIA Kimi K3 KDA
mixed speculative/non-speculative branch.

- A direct custom op stably packs QKV, `g1`, and `beta` for both partitions in
  one launch rather than six `index_select` calls.
- A second direct custom op scatters the two grouped outputs back to scheduler
  order and applies the K3 FP32 sigmoid-gated RMSNorm directly into the
  caller-owned output buffer, rather than two `index_copy_` calls followed by
  a normalization operation.

The fast path is deliberately limited to K3's validated FP16/BF16,
head-dimension-128 geometry and compatible layouts. Other cases use the native
PyTorch fallback. Pure speculative and pure non-speculative paths are
unchanged. The benchmark reports the static boundary count (six to one for
input packing, three to one for output handling); it does not claim a measured
speedup.

### Duplicate-work check

I checked open Kimi K3/KDA mixed-batch and scatter/RMSNorm PRs before opening
this PR. In particular, #50649 fixes ROCm KDA NaNs and a ROCm autotune race;
it changes neither this NVIDIA mixed-batch pack path nor indexed
scatter-plus-norm fusion. This PR is therefore materially distinct.

## Test Plan

On a supported Linux CUDA host:

```bash
.venv/bin/python -m pytest \
  tests/models/kimi_k3/test_kda.py \
  tests/models/kimi_k3/test_kda_metadata.py -v

.venv/bin/python benchmarks/kernels/benchmark_kimi_k3_kda_mixed.py \
  --num-tokens 128 --num-heads 12 --dtype bfloat16
```

The intended end-to-end follow-up runs Kimi K3 on TP8 and TP16 with a scheduler
step that genuinely mixes prefill/decode and speculative tokens, across
EAGER/PIECEWISE/FULL CUDA-graph modes. It should compare outputs/logprobs,
acceptance rate, profiler launch counts, and latency/throughput before and
after the change.

## Test Result

- Passed after the final no-conflict rebase: `git diff --check`.
- Passed after the final rebase: `SKIP=update-dockerfile-graph pre-commit run
  --files <all five changed files>` (ruff, mypy, SPDX, lazy imports,
  forbidden-import, CUDA-API, and configuration hooks passed). The Dockerfile
  graph hook was skipped because this Windows host has no `/bin/bash`.
- The CUDA KDA tests, `opcheck`, and Triton benchmark were not run. The required
  Triton distribution has no Windows wheel, and vLLM's test entry point also
  depends on `uvloop==0.22.1`, whose build reports that Windows is unsupported.
  No dynamic-test pass/fail result is claimed.
- Kimi K3 model evaluation was not run: this host has one 6 GB RTX 3060 and
  cannot run the required K3 TP8/TP16 configuration.

No public documentation update is needed for this internal optimization.

## AI assistance and accountability

This PR was developed with assistance from OpenAI Codex. I, Jiahua Chen,
reviewed every changed line, understand the implementation and its remaining
Linux multi-GPU validation risks, and take responsibility for this submission.

---
<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] Purpose and duplicate-work check included.
- [x] Test plan included.
- [x] Test commands and their actual results included.
- [x] Model-evaluation status disclosed.
- [x] AI assistance disclosed.
</details>
