### PR TITLE
[ROCm][Perf] Fuse Kimi-K3 MLA output gate

### DIFF
--- a/tests/models/kimi_k3/test_amd_mla_gate.py
+++ b/tests/models/kimi_k3/test_amd_mla_gate.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import patch
+
+import torch
+
+from vllm.model_executor.layers.mla import _apply_mla_output_gate
+from vllm.models.kimi_k3.amd.ops.mla_gate import kimi_k3_mla_output_gate
+
+
+class _GateProjection(torch.nn.Module):
+    def __init__(self, weight: torch.Tensor):
+        super().__init__()
+        self.weight = torch.nn.Parameter(weight)
+
+    def forward(self, hidden_states: torch.Tensor):
+        return torch.nn.functional.linear(hidden_states, self.weight), None
+
+
+def test_default_mla_output_gate_is_unchanged():
+    hidden_states = torch.tensor([[1.0, -2.0]])
+    attention_output = torch.tensor([[0.5, -0.25]])
+    gate_projection = _GateProjection(torch.tensor([[0.2, 0.3], [-0.4, 0.1]]))
+
+    actual = _apply_mla_output_gate(
+        hidden_states,
+        attention_output,
+        gate_projection,
+        output_gate=None,
+    )
+    expected = attention_output * gate_projection(hidden_states)[0].sigmoid()
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_amd_mla_output_gate_uses_aiter_specialization_in_place():
+    hidden_states = torch.tensor([[1.0, -2.0]])
+    attention_output = torch.tensor([[0.5, -0.25]])
+    gate_projection = _GateProjection(torch.ones((2, 2)))
+    expected = torch.tensor([[3.0, 4.0]])
+
+    def fused_gate(hidden, weight, attention, *, out):
+        assert hidden is hidden_states
+        assert weight is gate_projection.weight
+        assert attention is attention_output
+        assert out is attention_output
+        return out.copy_(expected)
+
+    with patch(
+        "vllm.models.kimi_k3.amd.ops.mla_gate._get_aiter_mla_gate",
+        return_value=(fused_gate, lambda *_: True),
+    ):
+        actual = kimi_k3_mla_output_gate(
+            hidden_states,
+            attention_output,
+            gate_projection,
+        )
+
+    assert actual is attention_output
+    torch.testing.assert_close(actual, expected)
+
+
+def test_amd_mla_output_gate_falls_back_when_shape_is_unsupported():
+    hidden_states = torch.tensor([[1.0, -2.0]])
+    attention_output = torch.tensor([[0.5, -0.25]])
+    gate_projection = _GateProjection(torch.tensor([[0.2, 0.3], [-0.4, 0.1]]))
+
+    with patch(
+        "vllm.models.kimi_k3.amd.ops.mla_gate._get_aiter_mla_gate",
+        return_value=(None, lambda *_: False),
+    ):
+        actual = kimi_k3_mla_output_gate(
+            hidden_states,
+            attention_output,
+            gate_projection,
+        )
+
+    expected = attention_output * gate_projection(hidden_states)[0].sigmoid()
+    torch.testing.assert_close(actual, expected)

--- a/vllm/model_executor/layers/mla.py
+++ b/vllm/model_executor/layers/mla.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from collections.abc import Callable
 from dataclasses import dataclass
 
 import torch
@@ -9,6 +10,11 @@ from vllm.model_executor.custom_op import PluggableLayer
 from vllm.model_executor.layers.attention import MLAAttention
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.platforms import current_platform
+
+MLAOutputGate = Callable[
+    [torch.Tensor, torch.Tensor, torch.nn.Module],
+    torch.Tensor,
+]
 
 
 @dataclass
@@ -29,6 +35,18 @@ class MLAModules:
     topk_indices_buffer: torch.Tensor | None
     indexer_rotary_emb: torch.nn.Module | None = None
     g_proj: torch.nn.Module | None = None
+    output_gate: MLAOutputGate | None = None
+
+
+def _apply_mla_output_gate(
+    hidden_states: torch.Tensor,
+    attention_output: torch.Tensor,
+    gate_projection: torch.nn.Module,
+    output_gate: MLAOutputGate | None,
+) -> torch.Tensor:
+    if output_gate is not None:
+        return output_gate(hidden_states, attention_output, gate_projection)
+    return attention_output * gate_projection(hidden_states)[0].sigmoid()
 
 
 # --8<-- [start:multi_head_latent_attention]
@@ -92,6 +110,7 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
         self.indexer_rope_emb = mla_modules.indexer_rotary_emb
         self.is_sparse = mla_modules.is_sparse
         self.g_proj = mla_modules.g_proj
+        self.output_gate = mla_modules.output_gate
 
         # Whether to skip top-k token selection computation in this layer.
         # When True, the indexer will not be called, and the layer will reuse
@@ -221,6 +240,11 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
         )
 
         if self.g_proj is not None:
-            attn_out = attn_out * self.g_proj(hidden_states)[0].sigmoid()
+            attn_out = _apply_mla_output_gate(
+                hidden_states,
+                attn_out,
+                self.g_proj,
+                self.output_gate,
+            )
 
         return self.o_proj(attn_out)[0]

--- a/vllm/models/kimi_k3/amd/linear.py
+++ b/vllm/models/kimi_k3/amd/linear.py
@@ -62,6 +62,7 @@ from vllm.model_executor.models.utils import (
     maybe_prefix,
 )
 from vllm.models.kimi_k3.amd.ops.attn_res import attn_res
+from vllm.models.kimi_k3.amd.ops.mla_gate import kimi_k3_mla_output_gate
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
 from vllm.utils.math_utils import cdiv
@@ -426,6 +427,7 @@ class KimiMLAAttention(nn.Module):
             is_sparse=False,
             topk_indices_buffer=None,
             g_proj=getattr(self, "g_proj", None),
+            output_gate=kimi_k3_mla_output_gate,
         )
         self.mla_attn = MultiHeadLatentAttentionWrapper(
             self.hidden_size,

--- a/vllm/models/kimi_k3/amd/ops/mla_gate.py
+++ b/vllm/models/kimi_k3/amd/ops/mla_gate.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""AMD dispatch for the Kimi-K3 MLA output gate."""
+
+import functools
+from collections.abc import Callable
+
+import torch
+
+_AITER_GATE_MODULE = "aiter.ops.flydsl.kimi_k3_mla_gate"
+_AiterGate = Callable[..., torch.Tensor]
+_AiterGateSupport = Callable[
+    [torch.Tensor, torch.Tensor, torch.Tensor],
+    bool,
+]
+
+
+@functools.lru_cache(maxsize=1)
+def _get_aiter_mla_gate() -> tuple[_AiterGate, _AiterGateSupport] | None:
+    try:
+        from aiter.ops.flydsl.kimi_k3_mla_gate import (
+            kimi_k3_mla_gate,
+            supports_kimi_k3_mla_gate,
+        )
+    except ModuleNotFoundError as error:
+        if not _AITER_GATE_MODULE.startswith(error.name or ""):
+            raise
+        return None
+    return kimi_k3_mla_gate, supports_kimi_k3_mla_gate
+
+
+def kimi_k3_mla_output_gate(
+    hidden_states: torch.Tensor,
+    attention_output: torch.Tensor,
+    gate_projection: torch.nn.Module,
+) -> torch.Tensor:
+    """Use the fused gfx950 gate when supported, otherwise preserve PyTorch."""
+
+    aiter_gate = _get_aiter_mla_gate()
+    gate_weight = getattr(gate_projection, "weight", None)
+    if aiter_gate is not None and gate_weight is not None:
+        gate, supports_gate = aiter_gate
+        if supports_gate(hidden_states, gate_weight, attention_output):
+            return gate(
+                hidden_states,
+                gate_weight,
+                attention_output,
+                out=attention_output,
+            )
+
+    projected_gate = gate_projection(hidden_states)[0]
+    return attention_output * projected_gate.sigmoid()


### PR DESCRIPTION
## Purpose

Wire the AITER Kimi-K3 MLA output-gate fusion into the AMD model path while
preserving the generic implementation.

`MLAModules` gains an optional output-gate callback. Its default remains the
existing projection, sigmoid, and multiply expression; only the Kimi-K3 AMD
adapter installs the AITER callback. Unsupported AITER installations, devices,
shapes, dtypes, or layouts use the existing expression. NVIDIA dispatch and
generic MLA split policy are unchanged.

Depends on ROCm/aiter#4497.

## Test plan

Tested on 8x MI355X (`gfx950`) with the public Kimi-K3 image and
`moonshotai/Kimi-K3@9f62e4e9`. The AITER #4497 kernel head is `d2f4c61f`; the
command below pins the vLLM base and PR revisions.

Fetch and verify the vLLM source:

```bash
git clone https://github.com/vllm-project/vllm.git vllm
git -C vllm fetch origin refs/pull/50664/head:pr-50664
test "$(git -C vllm rev-parse pr-50664)" = \
  d367e2727440ee838c2035883e6a1a0b6c8755a7
git -C vllm checkout --detach 6c91de36897932ba9b5adb11992235a2a789e009
git -C vllm diff 6c91de36897932ba9b5adb11992235a2a789e009..pr-50664 \
  --binary | git -C vllm apply -
git -C vllm diff --check
```

Use complete verified vLLM/AITER trees as overlays on the public image,
including AITER `csrc/` and `hsa/`; do not copy individual files. Verify
`import vllm, vllm._C, aiter` before testing.

```bash
python -m pytest -q \
  ../aiter/op_tests/flydsl_tests/test_kimi_k3_mla_gate_epilogue.py \
  tests/models/kimi_k3/test_amd_mla_gate.py
```

Serve both source-isolated arms with identical flags:

```bash
VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_FP4BMM=1 \
AITER_SITUV2_A8W4=1 AITER_BF16_FP8_MOE_BOUND=0 \
VLLM_USE_BREAKABLE_CUDAGRAPH=0 \
vllm serve /model --served-model-name moonshotai/Kimi-K3 \
  --tensor-parallel-size 8 --trust-remote-code --moe-backend auto \
  --gpu-memory-utilization 0.95 --max-num-seqs 128 \
  --max-num-batched-tokens 4096 --max-model-len 1048576 \
  --enable-prefix-caching --kv-cache-dtype fp8 --reasoning-parser kimi_k3
```

After one 8K/128 warmup, run three 8K/1K batch-one trials with seeds 1--3,
temperature zero, and `--ignore-eos`. Run full `lm-eval==0.4.12` GSM8K on both
arms: 1,319 questions, 5-shot, greedy completion, 2,048 generated tokens,
concurrency 128, and seed 42.

## Test results

- Combined focused suite: **11/11 passed**.
- Changed-file pre-commit, `git diff --check`, and DCO passed.

| Measurement | Control | Candidate | Change |
| --- | ---: | ---: | ---: |
| AITER gate microbenchmark | 12.7591 us | 5.4204 us | **2.3539x** |
| TP8 decode throughput | 36.0500 tok/s/GPU | 36.3890 tok/s/GPU | **+0.940%** |
| TPOT | 27.7393 ms | 27.4808 ms | **-0.2585 ms** |

Endpoint values are medians of three fixed-seed 8K/1K trials after warmup.

Full GSM8K: control **1277/1319**, candidate **1273/1319**, zero invalid or
transport failures; 8 wins/12 losses (`p=0.5034`). This paired run found no
statistically detectable accuracy difference.

## Limits

ROCm/aiter#4497 owns the kernel; this PR owns only the generic callback seam and Kimi-K3
AMD adapter. Output-buffer ownership is intentionally outside this change.
Operator tests establish the fused BF16 numerical contract; GSM8K is the
model-quality gate.

## Tool assistance

OpenAI Codex assisted with implementation, tests, benchmarking, and drafting
this description.

