### PR TITLE
[ROCm][Perf] Fuse Kimi-K3 FP8 pre-route projections

### DIFF
--- a/tests/model_executor/layers/fused_moe/test_shared_experts.py
+++ b/tests/model_executor/layers/fused_moe/test_shared_experts.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+import vllm.model_executor.layers.fused_moe.runner.shared_experts as shared_module
+from vllm.model_executor.layers.fused_moe.runner.shared_experts import (
+    SharedExperts,
+    SharedExpertsOrder,
+)
+
+
+def _make_shared_experts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> SharedExperts:
+    monkeypatch.setattr(
+        shared_module,
+        "dbo_current_ubatch_id",
+        lambda: 0,
+    )
+    shared = SharedExperts.__new__(SharedExperts)
+    torch.nn.Module.__init__(shared)
+    shared.enable_dbo = False
+    shared._output = [None, None]
+    shared._precomputed_output = [None, None]
+    shared._layer = lambda tensor: tensor + 1
+    shared._determine_shared_experts_order = lambda _: SharedExpertsOrder.NO_OVERLAP
+    return shared
+
+
+def test_precomputed_output_bypasses_layer_and_is_consumed_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shared = _make_shared_experts(monkeypatch)
+    precomputed = torch.randn(2, 4)
+
+    with shared.use_precomputed_output(precomputed):
+        shared.maybe_sync_shared_experts_stream(torch.empty_like(precomputed))
+        shared(
+            torch.empty_like(precomputed),
+            SharedExpertsOrder.NO_OVERLAP,
+        )
+        assert shared.output is precomputed
+
+    assert shared._output == [None, None]
+    assert shared._precomputed_output == [None, None]
+
+
+def test_precomputed_output_rejects_collision_and_cleans_up_on_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shared = _make_shared_experts(monkeypatch)
+
+    with (
+        pytest.raises(RuntimeError, match="downstream failure"),
+        shared.use_precomputed_output(torch.zeros(1)),
+    ):
+        with (
+            pytest.raises(RuntimeError, match="already occupied"),
+            shared.use_precomputed_output(torch.ones(1)),
+        ):
+            pass
+        raise RuntimeError("downstream failure")
+
+    assert shared._output == [None, None]
+    assert shared._precomputed_output == [None, None]
+
+
+def test_normal_shared_expert_path_is_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shared = _make_shared_experts(monkeypatch)
+    hidden = torch.randn(2, 4)
+
+    shared(hidden, SharedExpertsOrder.NO_OVERLAP)
+
+    torch.testing.assert_close(shared.output, hidden + 1)

--- a/tests/models/kimi_k3/test_amd_moe_preroute.py
+++ b/tests/models/kimi_k3/test_amd_moe_preroute.py
@@ -279,9 +279,13 @@ def test_amd_moe_preroute_fp8_matches_weight_quantized_reference() -> None:
     assert _relative_rmse(routed, routed_reference) < 0.035
     assert _relative_rmse(shared, shared_reference) < 0.06
     assert _relative_rmse(router_logits, router_reference) < 0.01
+    router_topk = router_logits.topk(17, dim=-1)
+    reference_topk = router_reference.topk(17, dim=-1)
+    assert reference_topk.values[0, 15] > reference_topk.values[0, 16]
+    # torch.topk does not define the order of equal values within the result.
     torch.testing.assert_close(
-        router_logits.topk(16, dim=-1).indices,
-        router_reference.topk(16, dim=-1).indices,
+        router_topk.indices[:, :16].sort(dim=-1).values,
+        reference_topk.indices[:, :16].sort(dim=-1).values,
         atol=0,
         rtol=0,
     )

--- a/tests/models/kimi_k3/test_amd_moe_preroute.py
+++ b/tests/models/kimi_k3/test_amd_moe_preroute.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from vllm.platforms import current_platform
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_rocm(),
+    reason="Kimi-K3 BF16 pre-route fusion requires ROCm",
+)
+
+
+def test_preroute_factory_owns_model_eligibility(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm.models.kimi_k3.amd.ops.moe_preroute import (
+        KimiK3PrerouteBf16,
+    )
+
+    monkeypatch.setattr(
+        KimiK3PrerouteBf16,
+        "is_backend_available",
+        staticmethod(lambda: True),
+    )
+    supported = {
+        "use_latent_moe": True,
+        "tensor_parallel_size": 8,
+        "shared_experts": object(),
+        "routed_projection": object(),
+        "situ_beta": 4.0,
+        "situ_linear_beta": 25.0,
+        "lora_enabled": False,
+    }
+    assert KimiK3PrerouteBf16.create_if_supported(**supported) is not None
+
+    unsupported = (
+        {"use_latent_moe": False},
+        {"tensor_parallel_size": 4},
+        {"shared_experts": None},
+        {"routed_projection": None},
+        {"situ_beta": None},
+        {"situ_linear_beta": None},
+        {"lora_enabled": True},
+    )
+    for override in unsupported:
+        config = supported | override
+        assert KimiK3PrerouteBf16.create_if_supported(**config) is None
+
+
+def _relative_rmse(
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+) -> float:
+    error = (actual.float() - expected.float()).square().mean().sqrt()
+    reference = expected.float().square().mean().sqrt().clamp_min(1e-12)
+    return (error / reference).item()
+
+
+def test_amd_moe_preroute_bf16_matches_reference() -> None:
+    from aiter.jit.utils.chip_info import get_gfx_runtime
+    from aiter.ops.flydsl.utils import is_flydsl_available
+
+    from vllm.models.kimi_k3.amd.ops.moe_preroute import (
+        KimiK3PrerouteBf16,
+    )
+
+    if not is_flydsl_available() or get_gfx_runtime() != "gfx950":
+        pytest.skip("requires FlyDSL on gfx950")
+
+    torch.manual_seed(20260729)
+    hidden = torch.randn(
+        (1, 7168),
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    routed_weight = torch.randn(
+        (3584, 7168),
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    shared_gate_up_weight = torch.randn(
+        (1536, 7168),
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    shared_down_weight = torch.randn(
+        (7168, 768),
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    original_hidden = hidden.clone()
+
+    preroute = KimiK3PrerouteBf16(
+        situ_beta=4.0,
+        situ_linear_beta=25.0,
+    )
+    output = preroute(
+        hidden,
+        routed_weight,
+        shared_gate_up_weight,
+        shared_down_weight,
+    )
+    assert output is not None
+    routed, shared = output
+
+    routed_reference = F.linear(
+        hidden.float(),
+        routed_weight.float(),
+    ).to(torch.bfloat16)
+    gate_up_reference = F.linear(
+        hidden.float(),
+        shared_gate_up_weight.float(),
+    ).to(torch.bfloat16)
+    gate, up = gate_up_reference.float().chunk(2, dim=-1)
+    activated = (
+        4.0
+        * torch.tanh(gate / 4.0)
+        * torch.sigmoid(gate)
+        * 25.0
+        * torch.tanh(up / 25.0)
+    ).to(torch.bfloat16)
+    shared_reference = F.linear(
+        activated.float(),
+        shared_down_weight.float(),
+    ).to(torch.bfloat16)
+
+    assert _relative_rmse(routed, routed_reference) < 2e-4
+    assert _relative_rmse(shared, shared_reference) < 2e-4
+    torch.testing.assert_close(
+        hidden,
+        original_hidden,
+        atol=0,
+        rtol=0,
+    )
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = preroute(
+            hidden,
+            routed_weight,
+            shared_gate_up_weight,
+            shared_down_weight,
+        )
+    assert captured is not None
+    captured_routed, captured_shared = captured
+    graph.replay()
+    expected_routed = captured_routed.clone()
+    expected_shared = captured_shared.clone()
+    graph.replay()
+    torch.testing.assert_close(
+        captured_routed,
+        expected_routed,
+        atol=0,
+        rtol=0,
+    )
+    torch.testing.assert_close(
+        captured_shared,
+        expected_shared,
+        atol=0,
+        rtol=0,
+    )

--- a/tests/models/kimi_k3/test_amd_moe_preroute.py
+++ b/tests/models/kimi_k3/test_amd_moe_preroute.py
@@ -230,6 +230,11 @@ def test_amd_moe_preroute_fp8_matches_weight_quantized_reference() -> None:
         device="cuda",
         dtype=torch.bfloat16,
     )
+    router_weight = torch.randn(
+        (896, 7168),
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
     original_hidden = hidden.clone()
 
     weights = KimiK3PrerouteFp8Weights(
@@ -237,11 +242,12 @@ def test_amd_moe_preroute_fp8_matches_weight_quantized_reference() -> None:
         shared_gate_up_weight,
         shared_down_weight,
     )
-    assert weights.supports_input(hidden)
-    assert not weights.supports_input(hidden.expand(8, -1))
+    assert weights.supports_inputs(hidden, router_weight)
+    assert not weights.supports_inputs(hidden.expand(8, -1), router_weight)
 
-    routed, shared = weights(
+    routed, shared, router_logits = weights(
         hidden,
+        router_weight,
         situ_beta=4.0,
         situ_linear_beta=25.0,
     )
@@ -268,8 +274,16 @@ def test_amd_moe_preroute_fp8_matches_weight_quantized_reference() -> None:
         .float()
     )
     shared_reference = F.linear(activated, shared_down_dequant)
+    router_reference = F.linear(hidden, router_weight).float()
 
     assert _relative_rmse(routed, routed_reference) < 0.035
     assert _relative_rmse(shared, shared_reference) < 0.06
+    assert _relative_rmse(router_logits, router_reference) < 0.01
+    torch.testing.assert_close(
+        router_logits.topk(16, dim=-1).indices,
+        router_reference.topk(16, dim=-1).indices,
+        atol=0,
+        rtol=0,
+    )
     assert F.cosine_similarity(shared.float(), shared_reference.float()).item() > 0.998
     torch.testing.assert_close(hidden, original_hidden, atol=0, rtol=0)

--- a/tests/models/kimi_k3/test_amd_moe_preroute.py
+++ b/tests/models/kimi_k3/test_amd_moe_preroute.py
@@ -9,7 +9,7 @@ from vllm.platforms import current_platform
 
 pytestmark = pytest.mark.skipif(
     not current_platform.is_rocm(),
-    reason="Kimi-K3 BF16 pre-route fusion requires ROCm",
+    reason="Kimi-K3 pre-route fusion requires ROCm",
 )
 
 
@@ -162,3 +162,114 @@ def test_amd_moe_preroute_bf16_matches_reference() -> None:
         atol=0,
         rtol=0,
     )
+
+
+def test_fp8_factory_rejects_incomplete_model_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm.models.kimi_k3.amd.ops.moe_preroute import (
+        KimiK3PrerouteFp8Weights,
+    )
+
+    monkeypatch.setattr(
+        KimiK3PrerouteFp8Weights,
+        "is_backend_available",
+        staticmethod(lambda: True),
+    )
+    monkeypatch.setattr(
+        KimiK3PrerouteFp8Weights,
+        "supports_weights",
+        staticmethod(lambda *_: True),
+    )
+    source_weights = (torch.empty(1), torch.empty(1), torch.empty(1))
+    unsupported = (
+        {"use_latent_moe": False},
+        {"tensor_parallel_size": 4},
+        {"source_weights": None},
+        {"situ_beta": None},
+        {"situ_linear_beta": None},
+        {"lora_enabled": True},
+    )
+    base = {
+        "use_latent_moe": True,
+        "tensor_parallel_size": 8,
+        "source_weights": source_weights,
+        "situ_beta": 4.0,
+        "situ_linear_beta": 25.0,
+        "lora_enabled": False,
+    }
+    for override in unsupported:
+        assert KimiK3PrerouteFp8Weights.create_if_supported(**(base | override)) is None
+
+
+def test_amd_moe_preroute_fp8_matches_weight_quantized_reference() -> None:
+    from aiter.jit.utils.chip_info import get_gfx_runtime
+    from aiter.ops.flydsl.utils import is_flydsl_available
+
+    from vllm.models.kimi_k3.amd.ops.moe_preroute import (
+        KimiK3PrerouteFp8Weights,
+    )
+
+    if not is_flydsl_available() or get_gfx_runtime() != "gfx950":
+        pytest.skip("requires FlyDSL on gfx950")
+
+    torch.manual_seed(20260729)
+    hidden = torch.randn((1, 7168), device="cuda", dtype=torch.bfloat16)
+    routed_weight = torch.randn(
+        (3584, 7168),
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    shared_gate_up_weight = torch.randn(
+        (1536, 7168),
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    shared_down_weight = torch.randn(
+        (7168, 768),
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    original_hidden = hidden.clone()
+
+    weights = KimiK3PrerouteFp8Weights(
+        routed_weight,
+        shared_gate_up_weight,
+        shared_down_weight,
+    )
+    assert weights.supports_input(hidden)
+    assert not weights.supports_input(hidden.expand(8, -1))
+
+    routed, shared = weights(
+        hidden,
+        situ_beta=4.0,
+        situ_linear_beta=25.0,
+    )
+
+    routed_dequant = weights.routed_weight.float() * weights.routed_scale[:, None]
+    shared_gate_up_dequant = (
+        weights.shared_gate_up_weight.float() * weights.shared_gate_up_scale[:, None]
+    )
+    shared_down_dequant = (
+        weights.shared_down_weight.float() * weights.shared_down_scale[:, None]
+    )
+    routed_reference = F.linear(hidden.float(), routed_dequant)
+    gate_up_reference = F.linear(hidden.float(), shared_gate_up_dequant)
+    gate, up = gate_up_reference.to(torch.bfloat16).float().chunk(2, dim=-1)
+    activated = (
+        (
+            4.0
+            * torch.tanh(gate / 4.0)
+            * torch.sigmoid(gate)
+            * 25.0
+            * torch.tanh(up / 25.0)
+        )
+        .to(torch.bfloat16)
+        .float()
+    )
+    shared_reference = F.linear(activated, shared_down_dequant)
+
+    assert _relative_rmse(routed, routed_reference) < 0.035
+    assert _relative_rmse(shared, shared_reference) < 0.06
+    assert F.cosine_similarity(shared.float(), shared_reference.float()).item() > 0.998
+    torch.testing.assert_close(hidden, original_hidden, atol=0, rtol=0)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -270,6 +270,7 @@ if TYPE_CHECKING:
     VLLM_NCCL_INCLUDE_PATH: str | None = None
     VLLM_GC_DEBUG: str = ""
     VLLM_DEBUG_WORKSPACE: bool = False
+    VLLM_ROCM_USE_KIMI_K3_PREROUTE_BF16: bool = False
     VLLM_DISABLE_SHARED_EXPERTS_STREAM: bool = False
     VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD: int = 256
     VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD: int = 1024
@@ -1900,6 +1901,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Debug workspace allocations.
     # logging of workspace resize operations.
     "VLLM_DEBUG_WORKSPACE": lambda: bool(int(os.getenv("VLLM_DEBUG_WORKSPACE", "0"))),
+    # Enable the exact-BF16 Kimi-K3 B1 pre-route fusion on gfx950.
+    "VLLM_ROCM_USE_KIMI_K3_PREROUTE_BF16": lambda: bool(
+        int(os.getenv("VLLM_ROCM_USE_KIMI_K3_PREROUTE_BF16", "0"))
+    ),
     # Disables parallel execution of shared_experts via separate cuda stream
     "VLLM_DISABLE_SHARED_EXPERTS_STREAM": lambda: bool(
         int(os.getenv("VLLM_DISABLE_SHARED_EXPERTS_STREAM", "0"))

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -271,6 +271,7 @@ if TYPE_CHECKING:
     VLLM_GC_DEBUG: str = ""
     VLLM_DEBUG_WORKSPACE: bool = False
     VLLM_ROCM_USE_KIMI_K3_PREROUTE_BF16: bool = False
+    VLLM_ROCM_USE_KIMI_K3_PREROUTE_FP8: bool = False
     VLLM_DISABLE_SHARED_EXPERTS_STREAM: bool = False
     VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD: int = 256
     VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD: int = 1024
@@ -1904,6 +1905,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Enable the exact-BF16 Kimi-K3 B1 pre-route fusion on gfx950.
     "VLLM_ROCM_USE_KIMI_K3_PREROUTE_BF16": lambda: bool(
         int(os.getenv("VLLM_ROCM_USE_KIMI_K3_PREROUTE_BF16", "0"))
+    ),
+    # Enable row-scaled FP8 weights for the Kimi-K3 B1 pre-route fusion.
+    "VLLM_ROCM_USE_KIMI_K3_PREROUTE_FP8": lambda: bool(
+        int(os.getenv("VLLM_ROCM_USE_KIMI_K3_PREROUTE_FP8", "0"))
     ),
     # Disables parallel execution of shared_experts via separate cuda stream
     "VLLM_DISABLE_SHARED_EXPERTS_STREAM": lambda: bool(

--- a/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
+++ b/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from collections.abc import Callable
+from collections.abc import Callable, Generator
+from contextlib import contextmanager
 from enum import IntEnum
 
 import torch
@@ -52,6 +53,7 @@ class SharedExperts(torch.nn.Module):
         # index is always 0 and the second output list element is ignored.
         self.enable_dbo = enable_dbo
         self._output: list[torch.Tensor | None] = [None, None]
+        self._precomputed_output: list[torch.Tensor | None] = [None, None]
         self._layer = layer
         self._moe_config = moe_config
 
@@ -112,6 +114,8 @@ class SharedExperts(torch.nn.Module):
         self,
         shared_experts_input: torch.Tensor,
     ):
+        if self._precomputed_output[self._output_idx] is not None:
+            return
         experts_order = self._determine_shared_experts_order(shared_experts_input)
 
         if experts_order == SharedExpertsOrder.MULTI_STREAM_OVERLAPPED:
@@ -147,16 +151,43 @@ class SharedExperts(torch.nn.Module):
 
     @property
     def output(self) -> torch.Tensor:
-        assert self._output[self._output_idx] is not None
-        output = self._output[self._output_idx]
-        self._output[self._output_idx] = None
+        output_idx = self._output_idx
+        precomputed_output = self._precomputed_output[output_idx]
+        if precomputed_output is not None:
+            self._precomputed_output[output_idx] = None
+            return precomputed_output
+
+        assert self._output[output_idx] is not None
+        output = self._output[output_idx]
+        self._output[output_idx] = None
         return output
+
+    @contextmanager
+    def use_precomputed_output(
+        self,
+        output: torch.Tensor,
+    ) -> Generator[None, None, None]:
+        """Use a shared-expert output produced by an enclosing fusion."""
+
+        output_idx = self._output_idx
+        if (
+            self._output[output_idx] is not None
+            or self._precomputed_output[output_idx] is not None
+        ):
+            raise RuntimeError("shared expert output slot is already occupied")
+        self._precomputed_output[output_idx] = output
+        try:
+            yield
+        finally:
+            self._precomputed_output[output_idx] = None
 
     def forward(
         self,
         shared_experts_input: torch.Tensor,
         order: SharedExpertsOrder,
     ):
+        if self._precomputed_output[self._output_idx] is not None:
+            return None
         experts_order = self._determine_shared_experts_order(shared_experts_input)
 
         if order != experts_order:

--- a/vllm/models/kimi_k3/amd/linear.py
+++ b/vllm/models/kimi_k3/amd/linear.py
@@ -65,6 +65,7 @@ from vllm.model_executor.models.utils import (
 from vllm.models.kimi_k3.amd.ops.attn_res import attn_res
 from vllm.models.kimi_k3.amd.ops.moe_preroute import (
     KimiK3PrerouteBf16,
+    KimiK3PrerouteFp8Weights,
 )
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
@@ -301,6 +302,7 @@ class KimiMoE(nn.Module):
             )
 
         self._preroute_bf16: KimiK3PrerouteBf16 | None = None
+        self._preroute_fp8: KimiK3PrerouteFp8Weights | None = None
         if envs.VLLM_ROCM_USE_KIMI_K3_PREROUTE_BF16:
             self._preroute_bf16 = KimiK3PrerouteBf16.create_if_supported(
                 use_latent_moe=self.use_latent_moe,
@@ -317,12 +319,57 @@ class KimiMoE(nn.Module):
                     "configuration; using the existing projection path."
                 )
 
+    def finalize_preroute_fp8_weights(self) -> None:
+        """Create the opt-in FP8 representation after checkpoint loading."""
+
+        if not envs.VLLM_ROCM_USE_KIMI_K3_PREROUTE_FP8:
+            return
+
+        source_weights = None
+        if self.routed_expert_down_proj is not None and self.shared_experts is not None:
+            source_weights = (
+                self.routed_expert_down_proj.weight,
+                self.shared_experts.gate_up_proj.weight,
+                self.shared_experts.down_proj.weight,
+            )
+        self._preroute_fp8 = KimiK3PrerouteFp8Weights.create_if_supported(
+            use_latent_moe=self.use_latent_moe,
+            tensor_parallel_size=self.tp_size,
+            source_weights=source_weights,
+            situ_beta=self.activation_situ_beta,
+            situ_linear_beta=self.activation_situ_linear_beta,
+            lora_enabled=self.experts.moe_config.is_lora_enabled,
+        )
+        if self._preroute_fp8 is None:
+            logger.warning_once(
+                "Kimi-K3 FP8 pre-route fusion is unavailable for this "
+                "configuration; using the existing projection path."
+            )
+
+    def _apply_preroute_fp8(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor] | None:
+        preroute_fp8 = self._preroute_fp8
+        if preroute_fp8 is None or not preroute_fp8.supports_input(hidden_states):
+            return None
+
+        assert self.activation_situ_beta is not None
+        assert self.activation_situ_linear_beta is not None
+        return preroute_fp8(
+            hidden_states,
+            self.activation_situ_beta,
+            self.activation_situ_linear_beta,
+        )
+
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         num_tokens, hidden_size = hidden_states.shape
         hidden_states = hidden_states.view(-1, hidden_size)
         router_logits, _ = self.gate(hidden_states)
-        preroute_output = None
-        if self._preroute_bf16 is not None:
+        # The explicitly enabled FP8 representation takes precedence when both
+        # pre-route flags are set. Unsupported inputs fall back to exact BF16.
+        preroute_output = self._apply_preroute_fp8(hidden_states)
+        if preroute_output is None and self._preroute_bf16 is not None:
             assert self.routed_expert_down_proj is not None
             assert self.shared_experts is not None
             preroute_output = self._preroute_bf16(
@@ -1006,6 +1053,13 @@ class KimiLinearModel(nn.Module, EagleModelMixin):
             loaded_params.add(name)
         return loaded_params
 
+    def finalize_preroute_fp8_weights(self) -> None:
+        """Finalize every local Kimi MoE layer after checkpoint loading."""
+
+        for module in self.modules():
+            if isinstance(module, KimiMoE):
+                module.finalize_preroute_fp8_weights()
+
 
 class KimiLinearForCausalLM(
     nn.Module, HasInnerState, SupportsPP, MixtureOfExperts, IsHybrid
@@ -1107,4 +1161,6 @@ class KimiLinearForCausalLM(
             self,
             skip_prefixes=(["lm_head."] if self.config.tie_word_embeddings else None),
         )
-        return loader.load_weights(weights)
+        loaded_weights = loader.load_weights(weights)
+        self.model.finalize_preroute_fp8_weights()
+        return loaded_weights

--- a/vllm/models/kimi_k3/amd/linear.py
+++ b/vllm/models/kimi_k3/amd/linear.py
@@ -349,15 +349,18 @@ class KimiMoE(nn.Module):
     def _apply_preroute_fp8(
         self,
         hidden_states: torch.Tensor,
-    ) -> tuple[torch.Tensor, torch.Tensor] | None:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None:
         preroute_fp8 = self._preroute_fp8
-        if preroute_fp8 is None or not preroute_fp8.supports_input(hidden_states):
+        if preroute_fp8 is None or not preroute_fp8.supports_inputs(
+            hidden_states, self.gate.weight
+        ):
             return None
 
         assert self.activation_situ_beta is not None
         assert self.activation_situ_linear_beta is not None
         return preroute_fp8(
             hidden_states,
+            self.gate.weight,
             self.activation_situ_beta,
             self.activation_situ_linear_beta,
         )
@@ -365,10 +368,15 @@ class KimiMoE(nn.Module):
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         num_tokens, hidden_size = hidden_states.shape
         hidden_states = hidden_states.view(-1, hidden_size)
-        router_logits, _ = self.gate(hidden_states)
         # The explicitly enabled FP8 representation takes precedence when both
         # pre-route flags are set. Unsupported inputs fall back to exact BF16.
-        preroute_output = self._apply_preroute_fp8(hidden_states)
+        router_logits = None
+        preroute_fp8 = self._apply_preroute_fp8(hidden_states)
+        if preroute_fp8 is None:
+            preroute_output = None
+        else:
+            routed_hidden_states, shared_output, router_logits = preroute_fp8
+            preroute_output = (routed_hidden_states, shared_output)
         if preroute_output is None and self._preroute_bf16 is not None:
             assert self.routed_expert_down_proj is not None
             assert self.shared_experts is not None
@@ -378,6 +386,8 @@ class KimiMoE(nn.Module):
                 self.shared_experts.gate_up_proj.weight,
                 self.shared_experts.down_proj.weight,
             )
+        if router_logits is None:
+            router_logits, _ = self.gate(hidden_states)
         if preroute_output is None:
             final_hidden_states = self.experts(
                 hidden_states=hidden_states,

--- a/vllm/models/kimi_k3/amd/linear.py
+++ b/vllm/models/kimi_k3/amd/linear.py
@@ -7,6 +7,7 @@ from typing import Any
 import torch
 from torch import nn
 
+import vllm.envs as envs
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import (
     get_pp_group,
@@ -62,6 +63,9 @@ from vllm.model_executor.models.utils import (
     maybe_prefix,
 )
 from vllm.models.kimi_k3.amd.ops.attn_res import attn_res
+from vllm.models.kimi_k3.amd.ops.moe_preroute import (
+    KimiK3PrerouteBf16,
+)
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
 from vllm.utils.math_utils import cdiv
@@ -200,6 +204,8 @@ class KimiMoE(nn.Module):
         activation_situ_linear_beta = (
             config.activation_situ_linear_beta if config.hidden_act == "situ" else None
         )
+        self.activation_situ_beta = activation_situ_beta
+        self.activation_situ_linear_beta = activation_situ_linear_beta
 
         # Route with fp32 logits for numerically stable expert selection.
         self.gate = GateLinear(
@@ -294,13 +300,52 @@ class KimiMoE(nn.Module):
                 moe_intermediate_size // self.tp_size
             )
 
+        self._preroute_bf16: KimiK3PrerouteBf16 | None = None
+        if envs.VLLM_ROCM_USE_KIMI_K3_PREROUTE_BF16:
+            self._preroute_bf16 = KimiK3PrerouteBf16.create_if_supported(
+                use_latent_moe=self.use_latent_moe,
+                tensor_parallel_size=self.tp_size,
+                shared_experts=self.shared_experts,
+                routed_projection=self.routed_expert_down_proj,
+                situ_beta=activation_situ_beta,
+                situ_linear_beta=activation_situ_linear_beta,
+                lora_enabled=self.experts.moe_config.is_lora_enabled,
+            )
+            if self._preroute_bf16 is None:
+                logger.warning_once(
+                    "Kimi-K3 BF16 pre-route fusion is unavailable for this "
+                    "configuration; using the existing projection path."
+                )
+
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         num_tokens, hidden_size = hidden_states.shape
         hidden_states = hidden_states.view(-1, hidden_size)
         router_logits, _ = self.gate(hidden_states)
-        final_hidden_states = self.experts(
-            hidden_states=hidden_states, router_logits=router_logits
-        )
+        preroute_output = None
+        if self._preroute_bf16 is not None:
+            assert self.routed_expert_down_proj is not None
+            assert self.shared_experts is not None
+            preroute_output = self._preroute_bf16(
+                hidden_states,
+                self.routed_expert_down_proj.weight,
+                self.shared_experts.gate_up_proj.weight,
+                self.shared_experts.down_proj.weight,
+            )
+        if preroute_output is None:
+            final_hidden_states = self.experts(
+                hidden_states=hidden_states,
+                router_logits=router_logits,
+            )
+        else:
+            routed_hidden_states, shared_output = preroute_output
+            shared_experts = self.experts.shared_experts
+            assert shared_experts is not None
+            with shared_experts.use_precomputed_output(shared_output):
+                final_hidden_states = self.experts(
+                    hidden_states=routed_hidden_states,
+                    router_logits=router_logits,
+                    shared_experts_input=hidden_states,
+                )
         return final_hidden_states.view(num_tokens, hidden_size)
 
 

--- a/vllm/models/kimi_k3/amd/ops/moe_preroute.py
+++ b/vllm/models/kimi_k3/amd/ops/moe_preroute.py
@@ -9,6 +9,31 @@ from torch import nn
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import direct_register_custom_op
 
+_FP8_MAX = 448.0
+
+
+def _quantize_weight_rows(
+    weight: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize a BF16 matrix to OCP E4M3 with one FP32 scale per row."""
+
+    if not weight.is_cuda or weight.dtype != torch.bfloat16 or weight.dim() != 2:
+        raise ValueError("source weight must be a CUDA BF16 matrix")
+    weight_f32 = weight.float()
+    amax = weight_f32.abs().amax(dim=1)
+    scale = torch.where(
+        amax > 0,
+        amax / _FP8_MAX,
+        torch.ones_like(amax),
+    )
+    quantized = (
+        (weight_f32 / scale[:, None])
+        .clamp(min=-_FP8_MAX, max=_FP8_MAX)
+        .to(torch.float8_e4m3fn)
+        .contiguous()
+    )
+    return quantized, scale.contiguous()
+
 
 def supports_kimi_k3_preroute_bf16(
     hidden_states: torch.Tensor,
@@ -75,6 +100,106 @@ direct_register_custom_op(
     op_func=_kimi_k3_preroute_bf16_impl,
     mutates_args=[],
     fake_impl=_kimi_k3_preroute_bf16_fake,
+    dispatch_key=current_platform.dispatch_key,
+)
+
+
+def supports_kimi_k3_preroute_fp8(
+    hidden_states: torch.Tensor,
+    routed_weight: torch.Tensor,
+    routed_scale: torch.Tensor,
+    shared_gate_up_weight: torch.Tensor,
+    shared_gate_up_scale: torch.Tensor,
+    shared_down_weight: torch.Tensor,
+    shared_down_scale: torch.Tensor,
+) -> bool:
+    """Return whether both fixed-shape AITER FP8 primitives are available."""
+
+    try:
+        from aiter.ops.flydsl.kimi_k3_moe_preroute_fp8 import (
+            supports_kimi_k3_moe_dual_projection_fp8,
+            supports_kimi_k3_shared_down_fp8_weight,
+        )
+    except (ImportError, ModuleNotFoundError):
+        return False
+
+    return supports_kimi_k3_moe_dual_projection_fp8(
+        hidden_states,
+        routed_weight,
+        routed_scale,
+        shared_gate_up_weight,
+        shared_gate_up_scale,
+    ) and supports_kimi_k3_shared_down_fp8_weight(
+        shared_down_weight,
+        shared_down_scale,
+        device=hidden_states.device,
+    )
+
+
+def _kimi_k3_preroute_fp8_impl(
+    hidden_states: torch.Tensor,
+    routed_weight: torch.Tensor,
+    routed_scale: torch.Tensor,
+    shared_gate_up_weight: torch.Tensor,
+    shared_gate_up_scale: torch.Tensor,
+    shared_down_weight: torch.Tensor,
+    shared_down_scale: torch.Tensor,
+    situ_beta: float,
+    situ_linear_beta: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    from aiter.ops.flydsl.kimi_k3_moe_preroute_fp8 import (
+        kimi_k3_moe_dual_projection_fp8,
+        kimi_k3_shared_down_fp8,
+    )
+
+    routed, shared_gate_up = kimi_k3_moe_dual_projection_fp8(
+        hidden_states,
+        routed_weight,
+        routed_scale,
+        shared_gate_up_weight,
+        shared_gate_up_scale,
+    )
+    shared_output = kimi_k3_shared_down_fp8(
+        shared_gate_up,
+        shared_down_weight,
+        shared_down_scale,
+        situ_beta=situ_beta,
+        situ_linear_beta=situ_linear_beta,
+    )
+    return routed, shared_output
+
+
+def _kimi_k3_preroute_fp8_fake(
+    hidden_states: torch.Tensor,
+    routed_weight: torch.Tensor,
+    routed_scale: torch.Tensor,
+    shared_gate_up_weight: torch.Tensor,
+    shared_gate_up_scale: torch.Tensor,
+    shared_down_weight: torch.Tensor,
+    shared_down_scale: torch.Tensor,
+    situ_beta: float,
+    situ_linear_beta: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del (
+        routed_scale,
+        shared_gate_up_weight,
+        shared_gate_up_scale,
+        shared_down_weight,
+        shared_down_scale,
+        situ_beta,
+        situ_linear_beta,
+    )
+    return (
+        hidden_states.new_empty((hidden_states.shape[0], routed_weight.shape[0])),
+        hidden_states.new_empty(hidden_states.shape),
+    )
+
+
+direct_register_custom_op(
+    op_name="kimi_k3_preroute_fp8",
+    op_func=_kimi_k3_preroute_fp8_impl,
+    mutates_args=[],
+    fake_impl=_kimi_k3_preroute_fp8_fake,
     dispatch_key=current_platform.dispatch_key,
 )
 
@@ -153,4 +278,134 @@ class KimiK3PrerouteBf16(nn.Module):
             shared_down_weight,
             self.situ_beta,
             self.situ_linear_beta,
+        )
+
+
+class KimiK3PrerouteFp8Weights(nn.Module):
+    """Model-load-time FP8 representation for the fused B1 decode path."""
+
+    def __init__(
+        self,
+        routed_weight: torch.Tensor,
+        shared_gate_up_weight: torch.Tensor,
+        shared_down_weight: torch.Tensor,
+    ) -> None:
+        super().__init__()
+        routed_weight, routed_scale = _quantize_weight_rows(routed_weight)
+        shared_gate_up_weight, shared_gate_up_scale = _quantize_weight_rows(
+            shared_gate_up_weight
+        )
+        shared_down_weight, shared_down_scale = _quantize_weight_rows(
+            shared_down_weight
+        )
+        self.register_buffer("routed_weight", routed_weight, persistent=False)
+        self.register_buffer("routed_scale", routed_scale, persistent=False)
+        self.register_buffer(
+            "shared_gate_up_weight",
+            shared_gate_up_weight,
+            persistent=False,
+        )
+        self.register_buffer(
+            "shared_gate_up_scale",
+            shared_gate_up_scale,
+            persistent=False,
+        )
+        self.register_buffer(
+            "shared_down_weight",
+            shared_down_weight,
+            persistent=False,
+        )
+        self.register_buffer(
+            "shared_down_scale",
+            shared_down_scale,
+            persistent=False,
+        )
+
+    @staticmethod
+    def is_backend_available() -> bool:
+        from vllm._aiter_ops import rocm_aiter_ops
+
+        if not rocm_aiter_ops.is_enabled():
+            return False
+        try:
+            from aiter.ops.flydsl.kimi_k3_moe_preroute_fp8 import (
+                is_kimi_k3_moe_preroute_fp8_available,
+            )
+        except (ImportError, ModuleNotFoundError):
+            return False
+        return is_kimi_k3_moe_preroute_fp8_available()
+
+    @staticmethod
+    def supports_weights(
+        routed_weight: torch.Tensor,
+        shared_gate_up_weight: torch.Tensor,
+        shared_down_weight: torch.Tensor,
+    ) -> bool:
+        weights = (
+            routed_weight,
+            shared_gate_up_weight,
+            shared_down_weight,
+        )
+        return (
+            tuple(weight.shape for weight in weights)
+            == ((3584, 7168), (1536, 7168), (7168, 768))
+            and all(weight.is_cuda for weight in weights)
+            and all(weight.dtype == torch.bfloat16 for weight in weights)
+            and all(weight.is_contiguous() for weight in weights)
+            and len({weight.device for weight in weights}) == 1
+        )
+
+    @classmethod
+    def create_if_supported(
+        cls,
+        *,
+        use_latent_moe: bool,
+        tensor_parallel_size: int,
+        source_weights: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None,
+        situ_beta: float | None,
+        situ_linear_beta: float | None,
+        lora_enabled: bool,
+    ) -> "KimiK3PrerouteFp8Weights | None":
+        """Create FP8 weights only for the complete fixed-shape contract."""
+
+        if not (
+            use_latent_moe
+            and tensor_parallel_size == 8
+            and source_weights is not None
+            and situ_beta is not None
+            and situ_linear_beta is not None
+            and not lora_enabled
+            and cls.is_backend_available()
+            and cls.supports_weights(*source_weights)
+        ):
+            return None
+        return cls(*source_weights)
+
+    def supports_input(self, hidden_states: torch.Tensor) -> bool:
+        return supports_kimi_k3_preroute_fp8(
+            hidden_states,
+            self.routed_weight,
+            self.routed_scale,
+            self.shared_gate_up_weight,
+            self.shared_gate_up_scale,
+            self.shared_down_weight,
+            self.shared_down_scale,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        situ_beta: float,
+        situ_linear_beta: float,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return torch.ops.vllm.kimi_k3_preroute_fp8(
+            hidden_states,
+            self.routed_weight,
+            self.routed_scale,
+            self.shared_gate_up_weight,
+            self.shared_gate_up_scale,
+            self.shared_down_weight,
+            self.shared_down_scale,
+            situ_beta,
+            situ_linear_beta,
         )

--- a/vllm/models/kimi_k3/amd/ops/moe_preroute.py
+++ b/vllm/models/kimi_k3/amd/ops/moe_preroute.py
@@ -112,23 +112,25 @@ def supports_kimi_k3_preroute_fp8(
     shared_gate_up_scale: torch.Tensor,
     shared_down_weight: torch.Tensor,
     shared_down_scale: torch.Tensor,
+    router_weight: torch.Tensor,
 ) -> bool:
-    """Return whether both fixed-shape AITER FP8 primitives are available."""
+    """Return whether the fixed-shape AITER FP8 primitives are available."""
 
     try:
         from aiter.ops.flydsl.kimi_k3_moe_preroute_fp8 import (
-            supports_kimi_k3_moe_dual_projection_fp8,
+            supports_kimi_k3_moe_tri_projection_fp8,
             supports_kimi_k3_shared_down_fp8_weight,
         )
     except (ImportError, ModuleNotFoundError):
         return False
 
-    return supports_kimi_k3_moe_dual_projection_fp8(
+    return supports_kimi_k3_moe_tri_projection_fp8(
         hidden_states,
         routed_weight,
         routed_scale,
         shared_gate_up_weight,
         shared_gate_up_scale,
+        router_weight,
     ) and supports_kimi_k3_shared_down_fp8_weight(
         shared_down_weight,
         shared_down_scale,
@@ -144,20 +146,22 @@ def _kimi_k3_preroute_fp8_impl(
     shared_gate_up_scale: torch.Tensor,
     shared_down_weight: torch.Tensor,
     shared_down_scale: torch.Tensor,
+    router_weight: torch.Tensor,
     situ_beta: float,
     situ_linear_beta: float,
-) -> tuple[torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     from aiter.ops.flydsl.kimi_k3_moe_preroute_fp8 import (
-        kimi_k3_moe_dual_projection_fp8,
+        kimi_k3_moe_tri_projection_fp8,
         kimi_k3_shared_down_fp8,
     )
 
-    routed, shared_gate_up = kimi_k3_moe_dual_projection_fp8(
+    routed, shared_gate_up, router_logits = kimi_k3_moe_tri_projection_fp8(
         hidden_states,
         routed_weight,
         routed_scale,
         shared_gate_up_weight,
         shared_gate_up_scale,
+        router_weight,
     )
     shared_output = kimi_k3_shared_down_fp8(
         shared_gate_up,
@@ -166,7 +170,7 @@ def _kimi_k3_preroute_fp8_impl(
         situ_beta=situ_beta,
         situ_linear_beta=situ_linear_beta,
     )
-    return routed, shared_output
+    return routed, shared_output, router_logits
 
 
 def _kimi_k3_preroute_fp8_fake(
@@ -177,9 +181,10 @@ def _kimi_k3_preroute_fp8_fake(
     shared_gate_up_scale: torch.Tensor,
     shared_down_weight: torch.Tensor,
     shared_down_scale: torch.Tensor,
+    router_weight: torch.Tensor,
     situ_beta: float,
     situ_linear_beta: float,
-) -> tuple[torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     del (
         routed_scale,
         shared_gate_up_weight,
@@ -192,6 +197,10 @@ def _kimi_k3_preroute_fp8_fake(
     return (
         hidden_states.new_empty((hidden_states.shape[0], routed_weight.shape[0])),
         hidden_states.new_empty(hidden_states.shape),
+        hidden_states.new_empty(
+            (hidden_states.shape[0], router_weight.shape[0]),
+            dtype=torch.float32,
+        ),
     )
 
 
@@ -381,7 +390,11 @@ class KimiK3PrerouteFp8Weights(nn.Module):
             return None
         return cls(*source_weights)
 
-    def supports_input(self, hidden_states: torch.Tensor) -> bool:
+    def supports_inputs(
+        self,
+        hidden_states: torch.Tensor,
+        router_weight: torch.Tensor,
+    ) -> bool:
         return supports_kimi_k3_preroute_fp8(
             hidden_states,
             self.routed_weight,
@@ -390,14 +403,16 @@ class KimiK3PrerouteFp8Weights(nn.Module):
             self.shared_gate_up_scale,
             self.shared_down_weight,
             self.shared_down_scale,
+            router_weight,
         )
 
     def forward(
         self,
         hidden_states: torch.Tensor,
+        router_weight: torch.Tensor,
         situ_beta: float,
         situ_linear_beta: float,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         return torch.ops.vllm.kimi_k3_preroute_fp8(
             hidden_states,
             self.routed_weight,
@@ -406,6 +421,7 @@ class KimiK3PrerouteFp8Weights(nn.Module):
             self.shared_gate_up_scale,
             self.shared_down_weight,
             self.shared_down_scale,
+            router_weight,
             situ_beta,
             situ_linear_beta,
         )

--- a/vllm/models/kimi_k3/amd/ops/moe_preroute.py
+++ b/vllm/models/kimi_k3/amd/ops/moe_preroute.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Kimi-K3 AMD pre-route projection fusion."""
+
+import torch
+from torch import nn
+
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import direct_register_custom_op
+
+
+def supports_kimi_k3_preroute_bf16(
+    hidden_states: torch.Tensor,
+    routed_weight: torch.Tensor,
+    shared_gate_up_weight: torch.Tensor,
+    shared_down_weight: torch.Tensor,
+) -> bool:
+    """Return whether AITER supports the exact-BF16 B1 projection cluster."""
+
+    try:
+        from aiter.ops.flydsl.kimi_k3_moe_preroute_bf16 import (
+            supports_kimi_k3_moe_preroute_bf16,
+        )
+    except (ImportError, ModuleNotFoundError):
+        return False
+
+    return supports_kimi_k3_moe_preroute_bf16(
+        hidden_states,
+        routed_weight,
+        shared_gate_up_weight,
+        shared_down_weight,
+    )
+
+
+def _kimi_k3_preroute_bf16_impl(
+    hidden_states: torch.Tensor,
+    routed_weight: torch.Tensor,
+    shared_gate_up_weight: torch.Tensor,
+    shared_down_weight: torch.Tensor,
+    situ_beta: float,
+    situ_linear_beta: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    from aiter.ops.flydsl.kimi_k3_moe_preroute_bf16 import (
+        kimi_k3_moe_preroute_bf16,
+    )
+
+    return kimi_k3_moe_preroute_bf16(
+        hidden_states,
+        routed_weight,
+        shared_gate_up_weight,
+        shared_down_weight,
+        situ_beta,
+        situ_linear_beta,
+    )
+
+
+def _kimi_k3_preroute_bf16_fake(
+    hidden_states: torch.Tensor,
+    routed_weight: torch.Tensor,
+    shared_gate_up_weight: torch.Tensor,
+    shared_down_weight: torch.Tensor,
+    situ_beta: float,
+    situ_linear_beta: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del shared_gate_up_weight, shared_down_weight, situ_beta, situ_linear_beta
+    return (
+        hidden_states.new_empty((hidden_states.shape[0], routed_weight.shape[0])),
+        hidden_states.new_empty(hidden_states.shape),
+    )
+
+
+direct_register_custom_op(
+    op_name="kimi_k3_preroute_bf16",
+    op_func=_kimi_k3_preroute_bf16_impl,
+    mutates_args=[],
+    fake_impl=_kimi_k3_preroute_bf16_fake,
+    dispatch_key=current_platform.dispatch_key,
+)
+
+
+class KimiK3PrerouteBf16(nn.Module):
+    """Compile-safe wrapper for the fixed-shape AITER fusion."""
+
+    def __init__(
+        self,
+        situ_beta: float,
+        situ_linear_beta: float,
+    ) -> None:
+        super().__init__()
+        self.situ_beta = situ_beta
+        self.situ_linear_beta = situ_linear_beta
+
+    @staticmethod
+    def is_backend_available() -> bool:
+        from vllm._aiter_ops import rocm_aiter_ops
+
+        if not rocm_aiter_ops.is_enabled():
+            return False
+        try:
+            from aiter.ops.flydsl.kimi_k3_moe_preroute_bf16 import (
+                is_kimi_k3_moe_preroute_bf16_available,
+            )
+        except (ImportError, ModuleNotFoundError):
+            return False
+        return is_kimi_k3_moe_preroute_bf16_available()
+
+    @classmethod
+    def create_if_supported(
+        cls,
+        *,
+        use_latent_moe: bool,
+        tensor_parallel_size: int,
+        shared_experts: object | None,
+        routed_projection: object | None,
+        situ_beta: float | None,
+        situ_linear_beta: float | None,
+        lora_enabled: bool,
+    ) -> "KimiK3PrerouteBf16 | None":
+        """Create the specialization only for its complete model contract."""
+
+        if not (
+            cls.is_backend_available()
+            and use_latent_moe
+            and tensor_parallel_size == 8
+            and shared_experts is not None
+            and routed_projection is not None
+            and situ_beta is not None
+            and situ_linear_beta is not None
+            and not lora_enabled
+        ):
+            return None
+        return cls(situ_beta, situ_linear_beta)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        routed_weight: torch.Tensor,
+        shared_gate_up_weight: torch.Tensor,
+        shared_down_weight: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor] | None:
+        if not supports_kimi_k3_preroute_bf16(
+            hidden_states,
+            routed_weight,
+            shared_gate_up_weight,
+            shared_down_weight,
+        ):
+            return None
+        return torch.ops.vllm.kimi_k3_preroute_bf16(
+            hidden_states,
+            routed_weight,
+            shared_gate_up_weight,
+            shared_down_weight,
+            self.situ_beta,
+            self.situ_linear_beta,
+        )


### PR DESCRIPTION
## Purpose

Integrate the Kimi-K3 gfx950 pre-route primitives through one AMD-only,
fail-closed ownership boundary:

- prepack routed-down and shared-expert weights after checkpoint loading;
- produce routed inputs, shared-expert output, and FP32 router logits in the
  AITER mixed-precision grid; and
- pass the precomputed shared output through a scoped seam so the generic
  shared-expert lifecycle does not repeat the work.

FP8 is opt-in with `VLLM_ROCM_USE_KIMI_K3_PREROUTE_FP8=1`; the exact BF16 path
is separately opt-in, and FP8 takes precedence when both are enabled.
Unsupported shapes, dtypes, devices, architectures, LoRA configurations, or
AITER installations use the existing implementation. NVIDIA and other models
are unchanged.

Review map:

- `amd/ops/moe_preroute.py`: checked AITER adapter and weight packing;
- `amd/linear.py`: Kimi-K3 lifecycle and dispatch;
- `shared_experts.py`: scoped precomputed-output ownership seam;
- tests: operator contract, fallback, graph replay, and equal-logit behavior.

Depends on ROCm/aiter#4498 and ROCm/aiter#4504.

## Test plan

Tested on 8x MI355X (`gfx950`) with the public Kimi-K3 image and
`moonshotai/Kimi-K3@9f62e4e9`. Kernel heads: AITER #4498 `0d755fe1` and #4504
`3d1208d4`; the command below pins the vLLM base and PR revisions.

Fetch and verify the vLLM source:

```bash
git clone https://github.com/vllm-project/vllm.git vllm
git -C vllm fetch origin refs/pull/50665/head:pr-50665
test "$(git -C vllm rev-parse pr-50665)" = \
  84a9b03c803421804eb3062de43022edce6a8992
git -C vllm checkout --detach 6c91de36897932ba9b5adb11992235a2a789e009
git -C vllm diff 6c91de36897932ba9b5adb11992235a2a789e009..pr-50665 \
  --binary | git -C vllm apply -
git -C vllm diff --check
```

Construct both arms from the public image using the complete verified vLLM and
AITER trees above, including AITER `csrc/` and `hsa/`; do not copy individual
files. Verify `import vllm, vllm._C, aiter` in the GPU container before testing
to prevent a stale or missing overlay.

Focused tests and companion microbenchmarks:

```bash
python -m pytest -q \
  ../aiter/op_tests/flydsl_tests/test_kimi_k3_moe_preroute_bf16.py \
  ../aiter/op_tests/flydsl_tests/test_kimi_k3_moe_preroute_fp8.py \
  tests/model_executor/layers/fused_moe/test_shared_experts.py \
  tests/models/kimi_k3/test_amd_moe_preroute.py
```

Serve each arm with the same exact model and flags; set both pre-route variables
to `0` for control:

```bash
VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_FP4BMM=1 \
AITER_SITUV2_A8W4=1 AITER_BF16_FP8_MOE_BOUND=0 \
VLLM_ROCM_USE_KIMI_K3_PREROUTE_BF16=1 \
VLLM_ROCM_USE_KIMI_K3_PREROUTE_FP8=1 \
vllm serve /model --served-model-name moonshotai/Kimi-K3 \
  --tensor-parallel-size 8 --trust-remote-code --moe-backend auto \
  --gpu-memory-utilization 0.95 --max-num-seqs 128 \
  --max-num-batched-tokens 4096 --max-model-len 1048576 \
  --enable-prefix-caching --kv-cache-dtype fp8 --reasoning-parser kimi_k3
```

After one 8K/128 warmup, run three 8K/1K batch-one trials with seeds 1--3,
temperature zero, and `--ignore-eos`. Run full `lm-eval==0.4.12` GSM8K on both
arms: 1,319 questions, 5-shot, greedy completion, 2,048 generated tokens,
concurrency 128, and seed 42.

## Test results

- Combined focused suite: **21/21 passed**.
- Changed-file pre-commit, `git diff --check`, and DCO passed.

| MI355X microbenchmark | Control | Candidate | Speedup |
| --- | ---: | ---: | ---: |
| BF16 pre-route | 21.9358 us | 17.0914 us | **1.2834x** |
| FP8 routed/shared output | 17.6833 us | 13.8263 us | **1.2790x** |
| FP8 tri-projection | 20.3035 us | 10.6829 us | **1.9006x** |

| TP8 8K/1K median | Control | Candidate | Change |
| --- | ---: | ---: | ---: |
| Decode throughput | 36.0596 tok/s/GPU | 38.2324 tok/s/GPU | **+6.026%** |
| TPOT | 27.7319 ms | 26.1558 ms | **-1.5760 ms** |

Full GSM8K: control **1270/1319**, candidate **1272/1319**, zero invalid or
transport failures; 14 wins/12 losses (`p=0.8450`). This paired run found no
statistically detectable accuracy difference.

The public suite also exposed two exactly tied router logits (experts 111 and
184 at 189.0). The test requires the exact selected top-16 set and a strict
16/17 boundary (174.0 versus 167.0), without imposing undefined tie order.

## Overlap and limits

- Operator tests establish the stated BF16/FP8 numerical contracts; GSM8K is
  the model-quality gate.
- ROCm/aiter#4498 and ROCm/aiter#4504 own the kernels; this PR only owns vLLM lifecycle and
  dispatch. The two paths share one weight lifecycle, so splitting them would
  duplicate the model integration and shared-output ownership seam.

## Tool assistance
OpenAI Codex assisted with implementation, tests, benchmarking, and drafting.




## Long-prefix agentic serving gate (2026-08-02)

The exact user-requested serving sweep was run with official `aiperf==0.11.0`
on 8x MI355X (TP8), FP8 KV cache, prefix caching, and no speculative decoding:

```bash
aiperf profile --model moonshotai/Kimi-K3 --tokenizer moonshotai/Kimi-K3 \
  --tokenizer-trust-remote-code --url http://127.0.0.1:8000 --api-key EMPTY \
  --endpoint-type chat --streaming --use-server-token-count \
  --num-prefix-prompts 8 --prompt-prefix-length 63240 \
  --synthetic-input-tokens-mean 4760 --synthetic-input-tokens-stddev 0 \
  --output-tokens-mean 350 --output-tokens-stddev 0 \
  --extra-inputs ignore_eos:true --extra-inputs min_tokens:350 \
  --extra-inputs max_tokens:350 --warmup-request-count 3 --sweep-type zip \
  --concurrency 1,8,16,24,48 --request-count 5,40,80,120,240 \
  --random-seed 42 --ui simple
```

The parent, BF16 intermediate, and FP8 candidate each completed **485/485**
requests (**1,455/1,455 total**) with byte-identical generated inputs, exactly
350 output tokens per request, and zero errors, cancellations, output-size
mismatches, or endpoint fatal signatures.

| Concurrency | Requests/arm | Output tok/s, parent -> BF16 -> FP8 | FP8 vs parent | Mean ITL, ms, parent -> FP8 | Mean TTFT, ms, parent -> FP8 | Mean E2E, ms, parent -> FP8 |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 5 | 14.12 -> 14.27 -> 14.41 | **+2.07%** | 51.70 -> 50.13 (**-3.02%**) | 6,743 -> 6,785 (+0.62%) | 24,785 -> 24,281 (**-2.03%**) |
| 8 | 40 | 84.02 -> 83.23 -> 84.38 | +0.43% | 78.43 -> 78.02 (-0.53%) | 5,701 -> 5,714 (+0.23%) | 33,074 -> 32,941 (-0.40%) |
| 16 | 80 | 145.22 -> 145.03 -> 145.36 | +0.09% | 85.87 -> 87.01 (+1.33%) | 7,776 -> 7,632 (-1.85%) | 37,744 -> 37,999 (+0.68%) |
| 24 | 120 | 191.53 -> 191.62 -> 191.44 | -0.05% | 97.16 -> 94.91 (-2.32%) | 9,078 -> 10,069 (+10.92%) | 42,988 -> 43,191 (+0.47%) |
| 48 | 240 | 296.30 -> 296.46 -> 296.51 | +0.07% | 124.75 -> 125.15 (+0.32%) | 12,306 -> 12,154 (-1.24%) | 55,845 -> 55,830 (-0.03%) |

The FP8 path provides a clear concurrency-one benefit; c8-c48 is neutral.
Both optimized support predicates require activation shape `(1, 7168)`, so
larger scheduler batches are expected to use the existing fallback. This
dispatch explanation is inferred from the source contract; no dispatch counter
was collected. TTFT is queueing-sensitive, so the mixed TTFT deltas—especially
c24—are reported without an improvement claim. Each cell is one profile trial
and therefore a point estimate.

Provenance: public image
`vllm/vllm-openai-rocm:kimi-k3@sha256:5aa7e626ff73672f5ca7aae46754570488c23d33ca1ac90756a1d2d1a3fe099b`,
model `moonshotai/Kimi-K3@9f62e4e9`, and random seed 42. The four runtime files
at current PR head `84a9b03c803421804eb3062de43022edce6a8992` are SHA-256-identical to the
measured candidate. The seven runtime files at AITER #4498 head `0d755fe1` and
#4504 head `3d1208d4` are likewise byte-identical to the measured AITER stack.

