### PR TITLE
[KV Offload] Allow replicated MLA layout for multi-group caches

### DIFF
--- a/tests/v1/kv_offload/test_factory.py
+++ b/tests/v1/kv_offload/test_factory.py
@@ -6,7 +6,18 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+import torch
 
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.config import (
+    _all_groups_are_mla,
+    _expected_mla_bytes_per_block,
+)
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheGroupSpec,
+    MLAAttentionSpec,
+    UniformTypeKVCacheSpecs,
+)
 from vllm.v1.kv_offload.base import (
     CanonicalKVCaches,
     OffloadingHistogramMetadata,
@@ -588,3 +599,56 @@ def test_build_metric_definitions_returns_counter_at_threshold():
     metrics = spec_cls.build_metric_definitions(extra_config)
 
     assert CPUOffloadingMetrics.STORES_SKIPPED in metrics
+
+
+def _mla_spec(page_size_bytes: int = 512) -> MLAAttentionSpec:
+    return MLAAttentionSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=page_size_bytes // 16 // 2,
+        dtype=torch.bfloat16,
+    )
+
+
+def _group(spec, layers: int) -> KVCacheGroupSpec:
+    return KVCacheGroupSpec(
+        layer_names=[f"layer.{i}" for i in range(layers)], kv_cache_spec=spec
+    )
+
+
+def test_replicated_layout_accepts_all_mla_multi_group():
+    """The gate used to require exactly one group, which excluded the
+    multi-group all-MLA shapes (for example DeepSeek V3.2)."""
+    groups = [_group(_mla_spec(), 2), _group(_mla_spec(), 3)]
+
+    assert _all_groups_are_mla(groups)
+    # One MLA page per layer, summed across groups.
+    assert _expected_mla_bytes_per_block(groups) == (
+        groups[0].kv_cache_spec.page_size_bytes * 5
+    )
+
+
+def test_replicated_layout_unwraps_uniform_type_specs():
+    inner = {f"layer.{i}": _mla_spec() for i in range(3)}
+    groups = [_group(UniformTypeKVCacheSpecs(block_size=16, kv_cache_specs=inner), 3)]
+
+    assert _all_groups_are_mla(groups)
+    # UniformTypeKVCacheSpecs.page_size_bytes already sums its layers, so it
+    # must not be multiplied by the layer count again.
+    assert _expected_mla_bytes_per_block(groups) == (
+        groups[0].kv_cache_spec.page_size_bytes
+    )
+
+
+def test_replicated_layout_fails_closed_on_non_mla():
+    full = FullAttentionSpec(
+        block_size=16, num_kv_heads=8, head_size=64, dtype=torch.bfloat16
+    )
+
+    assert not _all_groups_are_mla([_group(full, 1)])
+    # One non-MLA group among MLA groups is enough to refuse.
+    assert not _all_groups_are_mla([_group(_mla_spec(), 1), _group(full, 1)])
+    assert not _all_groups_are_mla([])
+    assert not _all_groups_are_mla(
+        [_group(UniformTypeKVCacheSpecs(block_size=16, kv_cache_specs={}), 0)]
+    )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/config.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/config.py
@@ -8,7 +8,9 @@ from vllm.v1.core.kv_cache_utils import resolve_kv_cache_block_sizes
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     FullAttentionSpec,
+    KVCacheSpec,
     MLAAttentionSpec,
+    UniformTypeKVCacheSpecs,
 )
 from vllm.v1.kv_offload.config import (
     OffloadingCacheConfig,
@@ -26,6 +28,45 @@ if TYPE_CHECKING:
 def is_kv_cache_tensor_packed(kv_cache_tensor: "KVCacheTensor") -> bool:
     """Return whether a KV cache tensor uses a packed block stride."""
     return bool(kv_cache_tensor.block_stride)
+
+
+def _mla_layer_specs(spec: KVCacheSpec) -> list[KVCacheSpec] | None:
+    """Per-layer specs of an all-MLA group, or ``None`` if it is not all-MLA.
+
+    ``UniformTypeKVCacheSpecs`` groups several layers of one attention type,
+    so unwrap it and check each layer. Exact type checks keep wrappers and
+    sliding-window variants out.
+    """
+    if isinstance(spec, UniformTypeKVCacheSpecs):
+        layer_specs = list(spec.kv_cache_specs.values())
+        if not layer_specs:
+            return None
+        return (
+            layer_specs
+            if all(type(s) is MLAAttentionSpec for s in layer_specs)
+            else None
+        )
+    return [spec] if type(spec) is MLAAttentionSpec else None
+
+
+def _all_groups_are_mla(groups) -> bool:
+    """Whether every KV cache group holds only MLA layers."""
+    return bool(groups) and all(
+        _mla_layer_specs(group.kv_cache_spec) is not None for group in groups
+    )
+
+
+def _expected_mla_bytes_per_block(groups) -> int:
+    """Bytes one block occupies across all groups, one MLA page per layer."""
+    total = 0
+    for group in groups:
+        spec = group.kv_cache_spec
+        if isinstance(spec, UniformTypeKVCacheSpecs):
+            # Already the sum over the layers it wraps.
+            total += spec.page_size_bytes
+        else:
+            total += spec.page_size_bytes * len(group.layer_names)
+    return total
 
 
 def build_offloading_config(
@@ -117,13 +158,13 @@ def build_offloading_config(
     )
     replicated_layout = (
         vllm_config.model_config.use_mla
-        # Exact type: fail closed on wrappers and sliding-window variants.
-        and type(single_group_spec) is MLAAttentionSpec
+        # Every group must be MLA. Exact type per layer, so wrappers and
+        # sliding-window variants still fail closed.
+        and _all_groups_are_mla(kv_cache_config.kv_cache_groups)
         # Page accounting: one MLA page per layer, no packed/mixed rows.
         and worker_kv_bytes_per_block > 0
         and worker_kv_bytes_per_block
-        == single_group_spec.page_size_bytes
-        * len(kv_cache_config.kv_cache_groups[0].layer_names)
+        == _expected_mla_bytes_per_block(kv_cache_config.kv_cache_groups)
         # Safe MVP boundary: TP-only, no other parallel axes.
         and parallel_config.tensor_parallel_size > 1
         and parallel_config.pipeline_parallel_size == 1


### PR DESCRIPTION
## Purpose

Draft, for the interim relaxation discussed in #48414.

The `replicated_layout` gate added in #48906 requires exactly one KV cache group:

```python
single_group_spec = (
    kv_cache_config.kv_cache_groups[0].kv_cache_spec
    if len(kv_cache_config.kv_cache_groups) == 1
    else None
)
```

All-MLA models that end up with several groups (V3.2 style shapes) therefore fall back to one host copy per TP rank, even though every rank holds the same latent KV and the existing whole-row single copy already covers them.

## What this does

Accepts a cache whose groups are all MLA, instead of exactly one MLA group. No new layout machinery, no change to how a row is written or read.

- `UniformTypeKVCacheSpecs` is unwrapped and each layer checked with an exact `type(...) is MLAAttentionSpec`, so wrappers and sliding-window variants still fail closed, as does a mix of MLA and non-MLA groups.
- Page accounting sums one MLA page per layer across groups. `UniformTypeKVCacheSpecs.page_size_bytes` already covers the layers it wraps, so it is not multiplied by the layer count again.
- Every other condition (TP-only, `mp` backend, single node, packed-row accounting) is untouched.

This is strictly subsumed by the canonical layout in #48414 once that lands, so it is meant as an interim step rather than a competing path.

## Test

New cases in `tests/v1/kv_offload/test_factory.py` cover a multi-group all-MLA cache, a `UniformTypeKVCacheSpecs` group (asserting page bytes are not double counted), and the fail-closed paths: a non-MLA group, a mixed MLA/non-MLA cache, an empty group list, and an empty uniform spec.

Draft because it needs a review call on whether the interim step is wanted at all, or whether it is better to wait for the canonical layout.

AI assistance was used for this change.
