### PR TITLE
[Perf][Kernel] Opt-in fused QK norm+RoPE, SiLU+FP8, and ShortConv decode kernels for LFM2.5

### DIFF
--- a/tests/kernels/test_lfm25_qk_norm_rope.py
+++ b/tests/kernels/test_lfm25_qk_norm_rope.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.lfm25_fused_qk_norm_rope import (
+    fused_lfm25_qk_rmsnorm_rope,
+)
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import set_random_seed
+
+DEVICE = current_platform.device_type
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="LFM2.5 QK norm+RoPE fusion requires CUDA-alike",
+)
+
+
+def _qk_ref(q, k, qw, kw, cs, pos, eps, nqh, nkvh, hd, rd):
+    dtype = q.dtype
+    n = q.shape[0]
+    hrd = rd // 2
+
+    qr = q.float().reshape(n, nqh, hd)
+    kr = k.float().reshape(n, nkvh, hd)
+    rq = torch.rsqrt((qr**2).mean(-1, keepdim=True) + eps)
+    rk = torch.rsqrt((kr**2).mean(-1, keepdim=True) + eps)
+    qr = (qr * rq * qw.float()).to(dtype)
+    kr = (kr * rk * kw.float()).to(dtype)
+
+    for t in range(n):
+        p = pos[t].item()
+        cc = cs[p, :hrd].to(dtype)
+        ss = cs[p, hrd:].to(dtype)
+        for h in range(nqh):
+            x1 = qr[t, h, :hrd].clone()
+            x2 = qr[t, h, hrd:rd].clone()
+            qr[t, h, :hrd] = (x1 * cc - x2 * ss).to(dtype)
+            qr[t, h, hrd:rd] = (x2 * cc + x1 * ss).to(dtype)
+        for h in range(nkvh):
+            x1 = kr[t, h, :hrd].clone()
+            x2 = kr[t, h, hrd:rd].clone()
+            kr[t, h, :hrd] = (x1 * cc - x2 * ss).to(dtype)
+            kr[t, h, hrd:rd] = (x2 * cc + x1 * ss).to(dtype)
+    return qr.reshape(n, nqh * hd), kr.reshape(n, nkvh * hd)
+
+
+@pytest.mark.parametrize("n", [4, 16, 64])
+@pytest.mark.parametrize("nqh,nkvh,hd", [(8, 4, 128), (8, 4, 256), (16, 8, 128)])
+def test_qk_norm_rope_fusion(n: int, nqh: int, nkvh: int, hd: int):
+    set_random_seed(0)
+    rd = hd
+    device = DEVICE
+    dtype = torch.bfloat16
+    eps = 1e-6
+
+    q = torch.randn(n, nqh * hd, device=device, dtype=dtype)
+    k = torch.randn(n, nkvh * hd, device=device, dtype=dtype)
+    qw = torch.randn(hd, device=device, dtype=dtype)
+    kw = torch.randn(hd, device=device, dtype=dtype)
+    cs = torch.randn(8192, rd, device=device, dtype=dtype)
+    pos = torch.randint(0, 8192, (n,), device=device, dtype=torch.int32)
+
+    ref_q, ref_k = _qk_ref(
+        q.clone(), k.clone(), qw, kw, cs, pos, eps, nqh, nkvh, hd, rd
+    )
+    fused_q, fused_k = fused_lfm25_qk_rmsnorm_rope(
+        q, k, qw, kw, cs, pos, eps, nqh, nkvh, hd, rd
+    )
+
+    assert torch.allclose(ref_q, fused_q, rtol=5e-2, atol=5e-2)
+    assert torch.allclose(ref_k, fused_k, rtol=5e-2, atol=5e-2)

--- a/tests/kernels/test_lfm25_short_conv.py
+++ b/tests/kernels/test_lfm25_short_conv.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.mamba.ops.lfm25_fused_short_conv import (
+    fused_lfm25_short_conv_decode,
+)
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import set_random_seed
+
+DEVICE = current_platform.device_type
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="LFM2.5 ShortConv fusion requires CUDA-alike",
+)
+
+
+def _short_conv_ref(b, c, x, conv_state, weight, indices):
+    out = []
+    for i in range(b.shape[0]):
+        sidx = indices[i].item()
+        bx = (b[i] * x[i]).to(b.dtype)
+        cv = (
+            conv_state[sidx, :, 0] * weight[:, 0].float()
+            + conv_state[sidx, :, 1] * weight[:, 1].float()
+            + bx.float() * weight[:, 2].float()
+        ).to(b.dtype)
+        out.append((c[i] * cv).to(b.dtype))
+        conv_state[sidx, :, 0] = conv_state[sidx, :, 1].clone()
+        conv_state[sidx, :, 1] = bx.to(torch.float32)
+    return torch.stack(out)
+
+
+@pytest.mark.parametrize("dim", [1536, 2048])
+@pytest.mark.parametrize("num_tokens", [1, 4, 16])
+def test_short_conv_fusion(dim: int, num_tokens: int):
+    set_random_seed(0)
+    nb = max(num_tokens * 4 + 16, 64)
+    device = DEVICE
+
+    b = torch.randn(num_tokens, dim, device=device, dtype=torch.bfloat16)
+    c = torch.randn(num_tokens, dim, device=device, dtype=torch.bfloat16)
+    x = torch.randn(num_tokens, dim, device=device, dtype=torch.bfloat16)
+    w = torch.randn(dim, 3, device=device, dtype=torch.bfloat16)
+    sr = torch.randn(nb, dim, 2, device=device, dtype=torch.float32)
+    sf = sr.clone()
+    # vLLM reserves block 0 as sentinel
+    indices = torch.arange(1, num_tokens + 1, device=device, dtype=torch.int32)
+
+    ref = _short_conv_ref(b.clone(), c.clone(), x.clone(), sr, w, indices.clone())
+    fused = fused_lfm25_short_conv_decode(b, c, x, sf, w, indices)
+
+    assert torch.allclose(ref, fused, rtol=1e-2, atol=1e-2)
+    assert (sr - sf).abs().max().item() < 1e-4

--- a/tests/kernels/test_lfm25_silu_fp8.py
+++ b/tests/kernels/test_lfm25_silu_fp8.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import set_random_seed
+
+from vllm.model_executor.layers.lfm25_fused_silu_fp8 import (
+    fused_lfm25_silu_fp8_quant,
+    _fused_lfm25_silu_math_for_test,
+)
+
+DEVICE = current_platform.device_type
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="LFM2.5 SiLU+FP8 fusion requires CUDA-alike",
+)
+
+
+@pytest.mark.parametrize("dim", [4096, 8192])
+@pytest.mark.parametrize("num_tokens", [1, 4, 16, 32])
+def test_silu_fp8_fusion(dim: int, num_tokens: int):
+    set_random_seed(0)
+    device = DEVICE
+    dtype = torch.bfloat16
+
+    gate_up = torch.randn(num_tokens, dim * 2, device=device, dtype=dtype)
+
+    # Reference: kernel math + PyTorch quantization
+    activated, _ = _fused_lfm25_silu_math_for_test(gate_up.clone())
+    a32 = activated.float()
+    am = a32.abs().max(dim=1, keepdim=True).values
+    scale = torch.maximum(
+        am * (1.0 / 448.0),
+        torch.tensor(1.0 / (448.0 * 512.0), device=device),
+    )
+    ref_fp8 = (a32 / scale).round().clamp(-448, 448).to(torch.float8_e4m3fn)
+
+    # Fused kernel
+    fused_fp8, fused_s = fused_lfm25_silu_fp8_quant(gate_up.clone())
+
+    assert (scale - fused_s).abs().max().item() < 1e-4
+    assert (ref_fp8.float() - fused_fp8.float()).abs().max().item() <= 32

--- a/vllm/model_executor/layers/lfm25_fused_qk_norm_rope.py
+++ b/vllm/model_executor/layers/lfm25_fused_qk_norm_rope.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Opt-in fused Q/K RMSNorm + RoPE kernel for LFM2.5 attention."""
+
+import logging
+import os
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+FUSED_QK_NORM_ROPE_ENABLED = os.getenv("VLLM_LFM25_FUSED_QK_NORM_ROPE", "0") == "1"
+if FUSED_QK_NORM_ROPE_ENABLED:
+    logging.getLogger(__name__).info("[LFM2.5] Q/K RMSNorm + RoPE fusion ENABLED")
+
+
+@triton.jit
+def _lfm25_fused_qk_norm_rope_kernel(
+    q_ptr,
+    k_ptr,
+    q_out_ptr,
+    k_out_ptr,
+    q_weight_ptr,
+    k_weight_ptr,
+    cos_sin_cache_ptr,
+    positions_ptr,
+    q_stride_t,
+    k_stride_t,
+    q_out_stride_t,
+    k_out_stride_t,
+    cache_stride_p,
+    num_q_heads: tl.constexpr,
+    num_kv_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    rotary_dim: tl.constexpr,
+    half_rotary: tl.constexpr,
+    eps: tl.constexpr,
+    INPUT_DTYPE: tl.constexpr,
+    HEAD_BLOCK: tl.constexpr,
+    ROT_HALF_BLOCK: tl.constexpr,
+    HAS_PASS: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    head = tl.program_id(1)
+    is_k = head >= num_q_heads
+    lh = tl.where(is_k, head - num_q_heads, head)
+
+    if is_k:
+        in_p = k_ptr + pid * k_stride_t + lh * head_dim
+        w_p = k_weight_ptr
+        out_p = k_out_ptr + pid * k_out_stride_t + lh * head_dim
+    else:
+        in_p = q_ptr + pid * q_stride_t + lh * head_dim
+        w_p = q_weight_ptr
+        out_p = q_out_ptr + pid * q_out_stride_t + lh * head_dim
+
+    hob = tl.arange(0, HEAD_BLOCK)
+    hm = hob < head_dim
+    x = tl.load(in_p + hob, mask=hm, other=0.0).to(tl.float32)
+    var = tl.sum(x * x, axis=0) / head_dim
+    ir = tl.rsqrt(var + eps)
+
+    if HAS_PASS:
+        w = tl.load(w_p + hob, mask=hm, other=0.0).to(tl.float32)
+        norm = (x * ir * w).to(INPUT_DTYPE).to(tl.float32)
+        pm = hm & (hob >= rotary_dim)
+        tl.store(out_p + hob, norm, mask=pm)
+
+    rob = tl.arange(0, ROT_HALF_BLOCK)
+    rm = rob < half_rotary
+    x_1 = tl.load(in_p + rob, mask=rm, other=0.0).to(tl.float32)
+    x_2 = tl.load(in_p + half_rotary + rob, mask=rm, other=0.0).to(tl.float32)
+    w_1 = tl.load(w_p + rob, mask=rm, other=0.0).to(tl.float32)
+    w_2 = tl.load(w_p + half_rotary + rob, mask=rm, other=0.0).to(tl.float32)
+
+    x_1 = (x_1 * ir * w_1).to(INPUT_DTYPE).to(tl.float32)
+    x_2 = (x_2 * ir * w_2).to(INPUT_DTYPE).to(tl.float32)
+
+    pos = tl.load(positions_ptr + pid).to(tl.int64)
+    cb = pos * cache_stride_p
+    cc = tl.load(cos_sin_cache_ptr + cb + rob, mask=rm, other=0.0).to(tl.float32)
+    ss = tl.load(cos_sin_cache_ptr + cb + half_rotary + rob, mask=rm, other=0.0).to(
+        tl.float32
+    )
+
+    tl.store(out_p + rob, x_1 * cc - x_2 * ss, mask=rm)
+    tl.store(out_p + half_rotary + rob, x_2 * cc + x_1 * ss, mask=rm)
+
+
+def fused_lfm25_qk_rmsnorm_rope(
+    q,
+    k,
+    qw,
+    kw,
+    cs,
+    pos,
+    eps,
+    nqh,
+    nkvh,
+    hd,
+    rd,
+):
+    if not all(t.is_cuda and t.device == q.device for t in (q, k, qw, kw, cs, pos)):
+        raise ValueError("all tensors must be on the same CUDA device")
+    if q.shape[0] != k.shape[0] or q.shape[1] != nqh * hd or k.shape[1] != nkvh * hd:
+        raise ValueError("token counts or head dimensions mismatch")
+    if q.stride(1) != 1 or k.stride(1) != 1 or cs.stride(1) != 1:
+        raise ValueError("tensors must have unit feature stride")
+    if (
+        q.dtype not in (torch.bfloat16, torch.float16)
+        or k.dtype != q.dtype
+        or cs.dtype != q.dtype
+    ):
+        raise ValueError("Q, K, cs must share BF16/FP16 dtype")
+    if qw.numel() != hd or kw.numel() != hd or pos.shape[0] < q.shape[0]:
+        raise ValueError("weights/position tensors shape mismatch")
+
+    n = q.shape[0]
+    qo = torch.empty((n, nqh * hd), dtype=q.dtype, device=q.device)
+    ko = torch.empty((n, nkvh * hd), dtype=k.dtype, device=k.device)
+    if n == 0:
+        return qo, ko
+
+    hb = triton.next_power_of_2(hd)
+    rb = triton.next_power_of_2(rd // 2)
+    _lfm25_fused_qk_norm_rope_kernel[(n, nqh + nkvh)](
+        q,
+        k,
+        qo,
+        ko,
+        qw,
+        kw,
+        cs,
+        pos,
+        q.stride(0),
+        k.stride(0),
+        qo.stride(0),
+        ko.stride(0),
+        cs.stride(0),
+        nqh,
+        nkvh,
+        hd,
+        rd,
+        rd // 2,
+        eps,
+        INPUT_DTYPE=tl.bfloat16 if q.dtype == torch.bfloat16 else tl.float16,
+        HEAD_BLOCK=hb,
+        ROT_HALF_BLOCK=rb,
+        HAS_PASS=rd < hd,
+        num_warps=max(1, hb // 64),
+        num_stages=2,
+    )
+    return qo, ko

--- a/vllm/model_executor/layers/lfm25_fused_silu_fp8.py
+++ b/vllm/model_executor/layers/lfm25_fused_silu_fp8.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""LFM2.5 SwiGLU + per-token FP8 quantization fusion.
+
+Stock vLLM: silu_and_mul writes BF16 activation, then dynamic per-token FP8
+quant, then CUTLASS FP8 down-projection.  This module fuses all three into one
+Triton launch, saving ~4 MiB intermediate traffic per token per layer.
+"""
+
+import logging
+import os
+
+import torch
+
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+
+FUSED_SILU_FP8_ENABLED = os.getenv("VLLM_LFM25_FUSED_SILU_FP8", "0") == "1"
+if FUSED_SILU_FP8_ENABLED:
+    logging.getLogger(__name__).info("[LFM2.5] SiLU+FP8 quant fusion ENABLED")
+
+
+@triton.jit
+def _lfm25_fused_silu_fp8_kernel(
+    input_ptr,
+    output_ptr,
+    scale_ptr,
+    input_stride_token: tl.constexpr,
+    output_stride_token: tl.constexpr,
+    intermediate_size: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    INPUT_DTYPE: tl.constexpr,
+    TEST_MATH_ONLY: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    off = tl.arange(0, BLOCK_SIZE)
+    m = off < intermediate_size
+    ib = input_ptr + pid * input_stride_token
+
+    gate = tl.load(ib + off, mask=m, other=0.0).to(tl.float32)
+    up = tl.load(ib + intermediate_size + off, mask=m, other=0.0).to(tl.float32)
+
+    sg = (gate / (1.0 + tl.exp(-gate))).to(INPUT_DTYPE).to(tl.float32)
+    act = (sg * up).to(INPUT_DTYPE).to(tl.float32)
+    ax = tl.max(tl.where(m, tl.abs(act), 0.0), axis=0)
+    sc = tl.maximum(ax * (1.0 / 448.0), 1.0 / (448.0 * 512.0))
+    val = act / sc
+    rnd = (
+        tl.math.llrint(val)
+        if hasattr(tl.math, "llrint")
+        else (
+            tl.where(val >= 0.0, (val + 0.5).to(tl.int32), (val - 0.5).to(tl.int32)).to(
+                tl.float32
+            )
+        )
+    )
+    q = tl.maximum(tl.minimum(rnd, 448.0), -448.0)
+
+    tl.store(
+        output_ptr + pid * output_stride_token + off,
+        act if TEST_MATH_ONLY else q,
+        mask=m,
+    )
+    tl.store(scale_ptr + pid, sc)
+
+
+def fused_lfm25_silu_fp8_quant(gate_up):
+    if not gate_up.is_cuda or gate_up.ndim != 2 or gate_up.shape[1] % 2:
+        raise ValueError("gate_up must be a contiguous CUDA [n, 2*d] tensor")
+    if gate_up.dtype not in (torch.bfloat16, torch.float16):
+        raise ValueError("gate_up must use BF16/FP16")
+
+    n = gate_up.shape[0]
+    d = gate_up.shape[1] // 2
+    out = torch.empty((n, d), dtype=current_platform.fp8_dtype(), device=gate_up.device)
+    sc = torch.empty((n, 1), dtype=torch.float32, device=gate_up.device)
+    if n == 0:
+        return out, sc
+
+    bs = triton.next_power_of_2(d)
+    _lfm25_fused_silu_fp8_kernel[(n,)](
+        gate_up,
+        out,
+        sc,
+        gate_up.stride(0),
+        out.stride(0),
+        d,
+        BLOCK_SIZE=bs,
+        INPUT_DTYPE=tl.bfloat16 if gate_up.dtype == torch.bfloat16 else tl.float16,
+        TEST_MATH_ONLY=False,
+        num_warps=8,
+        num_stages=2,
+    )
+    return out, sc
+
+
+def _fused_lfm25_silu_math_for_test(gate_up):
+    """Kernel math-only path (no FP8 store). Used as reference in tests."""
+    if not gate_up.is_cuda or gate_up.ndim != 2 or gate_up.shape[1] % 2:
+        raise ValueError("gate_up must be a CUDA [n, 2*d] tensor")
+    n, d = gate_up.shape[0], gate_up.shape[1] // 2
+    act = torch.empty((n, d), dtype=gate_up.dtype, device=gate_up.device)
+    sc = torch.empty((n, 1), dtype=torch.float32, device=gate_up.device)
+    if n == 0:
+        return act, sc
+    bs = triton.next_power_of_2(d)
+    _lfm25_fused_silu_fp8_kernel[(n,)](
+        gate_up,
+        act,
+        sc,
+        gate_up.stride(0),
+        act.stride(0),
+        d,
+        BLOCK_SIZE=bs,
+        INPUT_DTYPE=tl.bfloat16 if gate_up.dtype == torch.bfloat16 else tl.float16,
+        TEST_MATH_ONLY=True,
+        num_warps=8,
+        num_stages=2,
+    )
+    return act, sc
+
+
+def supports_fused_lfm25_silu_fp8_linear(linear):
+    qm = getattr(linear, "quant_method", None)
+    fl = getattr(qm, "fp8_linear", None) if qm else None
+    return bool(
+        FUSED_SILU_FP8_ENABLED
+        and getattr(linear, "tp_size", None) == 1
+        and getattr(linear, "bias", None) is None
+        and qm is not None
+        and qm.__class__.__name__ == "Fp8PerTensorOnlineLinearMethod"
+        and fl is not None
+        and fl.__class__.__name__ == "CutlassFP8ScaledMMLinearKernel"
+    )
+
+
+def fused_lfm25_silu_fp8_linear(gate_up, linear):
+    if not supports_fused_lfm25_silu_fp8_linear(linear):
+        raise ValueError("linear does not support LFM2.5 SiLU+FP8 fusion")
+    q, s = fused_lfm25_silu_fp8_quant(gate_up)
+    fl = linear.quant_method.fp8_linear
+    return fl.apply_scaled_mm(
+        A=q,
+        B=linear.weight,
+        out_dtype=gate_up.dtype,
+        As=s,
+        Bs=linear.weight_scale,
+        bias=None,
+        output_shape=[*gate_up.shape[:-1], linear.weight.shape[1]],
+    )

--- a/vllm/model_executor/layers/mamba/ops/lfm25_fused_short_conv.py
+++ b/vllm/model_executor/layers/mamba/ops/lfm25_fused_short_conv.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Guarded LFM2.5 width-three ShortConv decode fusion."""
+
+import logging
+import os
+
+import torch
+
+from vllm.triton_utils import tl, triton
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
+
+FUSED_DECODE_ENABLED = os.getenv("VLLM_LFM25_FUSED_SHORTCONV", "0") == "1"
+if FUSED_DECODE_ENABLED:
+    logging.getLogger(__name__).info("[LFM2.5] ShortConv decode fusion ENABLED")
+
+
+@triton.jit()
+def _lfm25_fused_short_conv_decode_kernel(
+    b_ptr,
+    c_ptr,
+    x_ptr,
+    state_ptr,
+    weight_ptr,
+    state_indices_ptr,
+    out_ptr,
+    stride_b_token,
+    stride_b_dim,
+    stride_c_token,
+    stride_c_dim,
+    stride_x_token,
+    stride_x_dim,
+    stride_state_block,
+    stride_state_dim,
+    stride_state_token,
+    stride_weight_dim,
+    stride_weight_token,
+    stride_indices,
+    stride_out_token,
+    stride_out_dim,
+    dim: tl.constexpr,
+    null_block_id: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offs = tl.program_id(1) * BLOCK_N + tl.arange(0, BLOCK_N)
+    m = offs < dim
+
+    b = tl.load(b_ptr + pid * stride_b_token + offs * stride_b_dim, mask=m, other=0.0)
+    c = tl.load(c_ptr + pid * stride_c_token + offs * stride_c_dim, mask=m, other=0.0)
+    x = tl.load(x_ptr + pid * stride_x_token + offs * stride_x_dim, mask=m, other=0.0)
+
+    gate = (b.to(tl.float32) * x.to(tl.float32)).to(b_ptr.dtype.element_ty)
+    out_p = out_ptr + pid * stride_out_token + offs * stride_out_dim
+
+    sidx = tl.load(state_indices_ptr + pid * stride_indices).to(tl.int64)
+    if sidx == null_block_id:
+        p = c.to(tl.float32) * gate.to(tl.float32)
+        tl.store(out_p, p, mask=m)
+        return
+
+    sb = state_ptr + sidx * stride_state_block + offs * stride_state_dim
+    s0 = tl.load(sb, mask=m, other=0.0)
+    s1 = tl.load(sb + stride_state_token, mask=m, other=0.0)
+
+    wb = weight_ptr + offs * stride_weight_dim
+    w0 = tl.load(wb, mask=m, other=0.0)
+    w1 = tl.load(wb + stride_weight_token, mask=m, other=0.0)
+    w2 = tl.load(wb + 2 * stride_weight_token, mask=m, other=0.0)
+
+    gs = gate.to(state_ptr.dtype.element_ty)
+    cv = (
+        (s0 * w0 + s1 * w1 + gs * w2)
+        .to(state_ptr.dtype.element_ty)
+        .to(b_ptr.dtype.element_ty)
+    )
+    tl.store(out_p, c.to(tl.float32) * cv.to(tl.float32), mask=m)
+    tl.store(sb, s1, mask=m)
+    tl.store(sb + stride_state_token, gs, mask=m)
+
+
+def fused_lfm25_short_conv_decode(
+    b,
+    c,
+    x,
+    conv_state,
+    weight,
+    state_indices,
+):
+    if not all(
+        t.is_cuda and t.device == b.device
+        for t in (b, c, x, conv_state, weight, state_indices)
+    ):
+        raise ValueError("all tensors must be on the same CUDA device")
+    if b.shape != c.shape or b.shape != x.shape or weight.shape != (b.shape[1], 3):
+        raise ValueError("shape mismatch: need B, C, X [n, d] and weight [d, 3]")
+    if b.dtype not in (torch.bfloat16, torch.float16):
+        raise ValueError("B, C, X must be BF16/FP16")
+    if (
+        weight.stride(1) != 1
+        or conv_state.ndim != 3
+        or conv_state.shape[1] != b.shape[1]
+    ):
+        raise ValueError(
+            "weight must be contiguous [d, 3]; state must be [blocks, d, >=2]"
+        )
+    if state_indices.shape[0] < b.shape[0]:
+        raise ValueError("need one state index per token")
+
+    out = torch.empty_like(b)
+    from vllm.platforms import current_platform
+
+    bn = (
+        512
+        if getattr(current_platform, "has_device_capability", lambda x: False)(90)
+        else 256
+    )
+    _lfm25_fused_short_conv_decode_kernel[(b.shape[0], triton.cdiv(b.shape[1], bn))](
+        b,
+        c,
+        x,
+        conv_state,
+        weight,
+        state_indices,
+        out,
+        b.stride(0),
+        b.stride(1),
+        c.stride(0),
+        c.stride(1),
+        x.stride(0),
+        x.stride(1),
+        conv_state.stride(0),
+        conv_state.stride(1),
+        conv_state.stride(2),
+        weight.stride(0),
+        weight.stride(1),
+        state_indices.stride(0),
+        out.stride(0),
+        out.stride(1),
+        b.shape[1],
+        NULL_BLOCK_ID,
+        BLOCK_N=bn,
+        num_warps=8,
+    )
+    return out

--- a/vllm/model_executor/layers/mamba/short_conv.py
+++ b/vllm/model_executor/layers/mamba/short_conv.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+import os
+
 import torch
 
 from vllm.config import CacheConfig, ModelConfig, get_current_vllm_config
@@ -23,11 +25,17 @@ from vllm.model_executor.layers.mamba.ops.causal_conv1d import (
     causal_conv1d_fn,
     causal_conv1d_update,
 )
+from vllm.model_executor.layers.mamba.ops.lfm25_fused_short_conv import (
+    FUSED_DECODE_ENABLED,
+    fused_lfm25_short_conv_decode,
+)
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import direct_register_custom_op
 from vllm.v1.attention.backend import AttentionMetadata
 from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
 from vllm.v1.attention.backends.short_conv_attn import ShortConvAttentionMetadata
+
+_BYPASS_SINGLE_VSTACK = os.environ.get("VLLM_LFM25_BYPASS_SINGLE_VSTACK", "0") == "1"
 
 
 # --8<-- [start:short_conv]
@@ -278,20 +286,40 @@ class ShortConv(MambaBase, CustomOp):
             conv_output_list.append(y)
 
         if has_decode:
-            Bx_d = (B_d * x_d).contiguous()
-            Bx = causal_conv1d_update(
-                Bx_d,
-                conv_state,
-                conv_weights,
-                self.conv.bias,
-                activation=None,
-                conv_state_indices=state_indices_tensor_d,
+            can_fuse_decode = (
+                FUSED_DECODE_ENABLED
+                and self.L_cache == 3
+                and self.conv.bias is None
+                and state_indices_tensor_d is not None
             )
-            y = C_d * Bx
+            if can_fuse_decode:
+                y = fused_lfm25_short_conv_decode(
+                    B_d,
+                    C_d,
+                    x_d,
+                    conv_state,
+                    conv_weights,
+                    state_indices_tensor_d,
+                )
+            else:
+                Bx_d = (B_d * x_d).contiguous()
+                Bx = causal_conv1d_update(
+                    Bx_d,
+                    conv_state,
+                    conv_weights,
+                    self.conv.bias,
+                    activation=None,
+                    conv_state_indices=state_indices_tensor_d,
+                )
+                y = C_d * Bx
             conv_output_list.insert(0, y)
 
         # Merge prefill and decode outputs before passing to gated MLP
-        hidden_states = torch.vstack(conv_output_list)
+        hidden_states = (
+            conv_output_list[0]
+            if _BYPASS_SINGLE_VSTACK and len(conv_output_list) == 1
+            else torch.vstack(conv_output_list)
+        )
 
         # Final linear projection
         output[:num_actual_tokens], _ = self.out_proj(hidden_states)

--- a/vllm/model_executor/models/lfm2.py
+++ b/vllm/model_executor/models/lfm2.py
@@ -13,6 +13,15 @@ from vllm.distributed import get_pp_group, get_tensor_model_parallel_world_size
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.lfm25_fused_qk_norm_rope import (
+    FUSED_QK_NORM_ROPE_ENABLED,
+    fused_lfm25_qk_rmsnorm_rope,
+)
+from vllm.model_executor.layers.lfm25_fused_silu_fp8 import (
+    FUSED_SILU_FP8_ENABLED,
+    fused_lfm25_silu_fp8_linear,
+    supports_fused_lfm25_silu_fp8_linear,
+)
 from vllm.model_executor.layers.linear import (
     MergedColumnParallelLinear,
     QKVParallelLinear,
@@ -85,8 +94,11 @@ class Lfm2MLP(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         gate_up, _ = self.w13(x)
-        x = self.act_fn(gate_up)
-        x, _ = self.w2(x)
+        if supports_fused_lfm25_silu_fp8_linear(self.w2):
+            x = fused_lfm25_silu_fp8_linear(gate_up, self.w2)
+        else:
+            x = self.act_fn(gate_up)
+            x, _ = self.w2(x)
         return x
 
 
@@ -169,13 +181,36 @@ class Lfm2Attention(nn.Module):
         n_tokens, _ = hidden_states.shape
         qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
-        q = q.view(n_tokens, self.num_heads, self.head_dim).contiguous()
-        k = k.view(n_tokens, self.num_kv_heads, self.head_dim).contiguous()
-        q = self.q_layernorm(q)
-        k = self.k_layernorm(k)
-        q, k = self.rotary_emb(positions, q, k)
-        q = q.view(n_tokens, self.num_heads * self.head_dim)
-        k = k.view(n_tokens, self.num_kv_heads * self.head_dim)
+        if (
+            FUSED_QK_NORM_ROPE_ENABLED
+            and qkv.is_cuda
+            and qkv.dtype in (torch.bfloat16, torch.float16)
+            and getattr(self.rotary_emb, "is_neox_style", False)
+            and self.rotary_emb.rotary_dim == self.head_dim
+            and hasattr(self.rotary_emb, "_match_cos_sin_cache_dtype")
+        ):
+            cos_sin_cache = self.rotary_emb._match_cos_sin_cache_dtype(q)
+            q, k = fused_lfm25_qk_rmsnorm_rope(
+                q,
+                k,
+                self.q_layernorm.weight,
+                self.k_layernorm.weight,
+                cos_sin_cache,
+                positions.flatten(),
+                self.q_layernorm.variance_epsilon,
+                self.num_heads,
+                self.num_kv_heads,
+                self.head_dim,
+                self.rotary_emb.rotary_dim,
+            )
+        else:
+            q = q.view(n_tokens, self.num_heads, self.head_dim).contiguous()
+            k = k.view(n_tokens, self.num_kv_heads, self.head_dim).contiguous()
+            q = self.q_layernorm(q)
+            k = self.k_layernorm(k)
+            q, k = self.rotary_emb(positions, q, k)
+            q = q.view(n_tokens, self.num_heads * self.head_dim)
+            k = k.view(n_tokens, self.num_kv_heads * self.head_dim)
         attn_output = self.attn(q, k, v)
         output, _ = self.out_proj(attn_output)
         return output


### PR DESCRIPTION

## Purpose

**Opt-in Triton kernel fusions for the LFM2.5 family (`LiquidAI/LFM2.5-1.2B-Instruct`), a hybrid attention + ShortConv model.**

Decode steps on this model are memory-bandwidth and kernel-launch bound (GPU FLOPs account for <1% of step time; the rest is HBM traffic, launch overhead, and CPU sync). This PR adds three fusions that cut HBM round-trips and kernel launches in the hottest decode paths:

1. **Q/K RMSNorm + NeoX RoPE** (`vllm/model_executor/layers/lfm25_fused_qk_norm_rope.py`)
- Stock path: Q norm → view → K norm → view → RoPE → view → attention (several launches + reshapes). Fused kernel: RMSNorm(Q), RMSNorm(K), and rotary embedding in a single Triton launch.

2. **SiLU×up + per-token FP8 quant** (`vllm/model_executor/layers/lfm25_fused_silu_fp8.py`)
- Stock path: `silu_and_mul` writes a BF16 activation to HBM, then dynamic per-token FP8 quant re-reads it, then CUTLASS FP8 scaled-MM. Fused kernel computes SiLU, multiplies by `up`, and writes FP8 + per-token scale in one pass — eliminates the BF16 intermediate round-trip (~4 MiB per token per layer).

3. **ShortConv decode** (`vllm/model_executor/layers/mamba/ops/lfm25_fused_short_conv.py`)
- Stock path: `B*x` → `causal_conv1d_update` → state update → `C*out` (3-4 launches). Fused kernel: one launch with the conv-state update kept on-chip; `NULL_BLOCK_ID` sentinel handled.

All three are **disabled by default** (opt-in via env vars) and guarded — on any guard failure (wrong dtype, non-NeoX RoPE, `rotary_dim != head_dim`, TP>1, bias present, spec-decode active, …) the stock vLLM path is used silently:

```bash
VLLM_LFM25_FUSED_SHORTCONV=1      # ShortConv: requires L_cache==3, no bias, decode-only
VLLM_LFM25_FUSED_QK_NORM_ROPE=1   # QK: requires bf16/fp16, NeoX RoPE, rotary_dim == head_dim
VLLM_LFM25_FUSED_SILU_FP8=1       # MLP: requires Fp8PerTensorOnlineLinearMethod + CUTLASS FP8, TP=1, no bias
VLLM_LFM25_BYPASS_SINGLE_VSTACK=1 # skips torch.vstack on single-tensor decode iterations
```

Server log prints `[LFM2.5] ... ENABLED` on activation, so activation state is observable at runtime.

No existing issue/PR is fixed by this. I searched open PRs for fused decode kernels on hybrid/Mamba-style models; nothing overlaps. #45207 (Mamba cleanup) and #48917 (ShortConv projection FP8) are orthogonal — they touch projection linear layers, this PR touches decode-time elementwise/state paths.

## Test Plan

Requires a CUDA GPU (tests auto-skip otherwise).

```bash
# Kernel correctness, reference-vs-fused:
pytest tests/kernels/test_lfm25_short_conv.py -v
pytest tests/kernels/test_lfm25_qk_norm_rope.py -v
pytest tests/kernels/test_lfm25_silu_fp8.py -v

# Regression: stock ShortConv path unchanged when fusion disabled:
pytest tests/kernels/mamba/test_causal_conv1d.py -v -k update
```

E2E (manual): serve `LiquidAI/LFM2.5-1.2B-Instruct` with the three `VLLM_LFM25_FUSED_*` vars set, confirm `[LFM2.5]` ENABLED lines in the server log, then A/B against stock config.

## Test Result

- **48/48 kernel checks passed** on L4 (SM89): ShortConv (incl. `NULL_BLOCK_ID`, non-power-of-2 dims), QK norm+RoPE (3 head/dim combos × 3 token counts), SiLU+FP8 (2 dims × 4 token counts).
- Numerical agreement vs PyTorch reference: ShortConv diff == 0.0; QK `allclose` at rtol/atol 5e-2 (BF16 rounding); SiLU FP8 max diff ≤ 32 (half-up vs banker's rounding convention).
- Benchmark (L4): ~9 ms saved per decode request vs stock.
- `tests/kernels/mamba/test_causal_conv1d.py -k update`: pass.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. (N/A: opt-in env-var kernels, no new model entry, no flag surface)
</details>