### PR TITLE
[Bugfix][Benchmarks] Count tokens, not chunks, in peak output throughput

### DIFF
--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -675,7 +675,10 @@ def calculate_metrics(
         tokens_per_second = np.zeros(duration_seconds)
         concurrent_requests_per_second = np.zeros(duration_seconds)
 
-        for i, output in enumerate(successful_outputs):
+        for i, output in enumerate(outputs):
+            if not output.success:
+                continue
+
             # Calculate token generation timestamp using
             # start_time, ttft, and itl
             token_times = [output.start_time + output.ttft]
@@ -684,11 +687,15 @@ def calculate_metrics(
                 current_time += itl_value
                 token_times.append(current_time)
 
+            # A chunk can bundle several tokens under speculative decoding,
+            # so weight it by the request's tokens per chunk.
+            tokens_per_chunk = actual_output_lens[i] / len(token_times)
+
             # Add tokens to second buckets
             for token_time in token_times:
                 second_bucket = int(token_time - min_start_time)
                 if 0 <= second_bucket < duration_seconds:
-                    tokens_per_second[second_bucket] += 1
+                    tokens_per_second[second_bucket] += tokens_per_chunk
 
             # Track concurrent requests for each second this request was active
             request_start_second = int(output.start_time - min_start_time)


### PR DESCRIPTION
## Purpose

`vllm bench serve` reports a **peak output token throughput far below the average output token throughput**, which is impossible by definition. With speculative decoding enabled:

```
Output token throughput (tok/s):         410.61
Peak output token throughput (tok/s):    113.00   <-- 28% of the average
```

The two metrics count different units. `output_throughput` uses the token counts the server reports in `usage.completion_tokens`. The peak metric instead rebuilds a token timeline from `output.itl` and adds **one token per entry**:

```python
for itl_value in output.itl:
    current_time += itl_value
    token_times.append(current_time)
...
tokens_per_second[second_bucket] += 1
```

The OpenAI endpoint request functions append one `itl` entry per SSE chunk (`endpoint_request_func.py:240`, `:412`, `:528`), and a chunk can bundle several tokens — which is exactly what speculative decoding produces. `calculate_metrics` already accounts for this when deriving `output_len` ("multiple output tokens may be bundled together", `serve.py:595-599`), but the peak metric does not, so it measures chunks per second rather than tokens per second.

This PR weights each chunk by the request's tokens per chunk, so the per-second buckets sum to the reported output token count instead of the chunk count.

Limitation. The weight is the request's mean tokens per chunk, because the OpenAI streaming protocol reports token counts only once at the end of the stream, never per chunk. Acceptance length varies from step to step, so a real 1, 4, 1, 4 pattern is attributed as 2.5 to every chunk. Aggregate throughput is exact either way, but a genuine burst gets flattened, which in practice makes the reported peak a conservative estimate of the true instantaneous peak. Recovering the exact value needs per-chunk token counts — that is the place to revisit if they become available.

## Test Plan

**Unit-level check.** Synthesize streamed outputs where each chunk carries 4 tokens (8 concurrent requests, 41 chunks each, 30 ms chunk gap) and pass them through `calculate_metrics`. The analytic steady-state rate is `8 × 4 / 0.03 = 1066.67 tok/s`.

**End-to-end.** 480 requests × 256 output tokens at `--max-concurrency 1`, against an OpenAI-compatible endpoint with speculative decoding enabled, before and after the patch.

```bash
vllm bench serve \
  --backend openai-chat \
  --endpoint /v1/chat/completions \
  --model <model> \
  --dataset-name spec_bench \
  --dataset-path ./question.jsonl \
  --spec-bench-output-len 256 \
  --num-prompts 480 \
  --max-concurrency 1
```

**Lint and existing tests.**

```bash
pre-commit run ruff-check --files vllm/benchmarks/serve.py
pre-commit run ruff-format --files vllm/benchmarks/serve.py
pre-commit run mypy-3.12 --files vllm/benchmarks/serve.py --hook-stage manual
python -m pytest tests/benchmarks/test_plot_filters.py tests/benchmarks/test_sampling_params.py
```

## Test Result

**Unit-level check**: peak goes from 256.00 tok/s (exactly the chunk count) to 1024.00 tok/s, tracking the 1066.67 tok/s analytic rate. Before the patch it sat below the 1009.23 tok/s average.

**End-to-end**: only the peak metric moves; everything else is within run-to-run noise.

| Metric | Before | After |
|---|---|---|
| **Peak output token throughput (tok/s)** | **113.00** | **544.46** |
| Output token throughput (tok/s) | 410.61 | 410.22 |
| Total generated tokens | 122880 | 122880 |
| Benchmark duration (s) | 299.26 | 299.55 |
| Mean / Median TPOT (ms) | 1.96 / 1.96 | 1.96 / 1.96 |
| Mean / Median ITL (ms) | 7.93 / 8.16 | 7.93 / 8.15 |
| Mean / Median TTFT (ms) | 123.01 / 121.42 | 123.53 / 121.58 |

The peak now sits above the average instead of at 28% of it, confirming the fix. 

**Lint and existing tests**: `ruff-check`, `ruff-format` and `mypy-3.12` all pass; 51 existing tests in `tests/benchmarks/` pass.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.