### PR TITLE
[Bugfix] Fix DeepSeek-V4 reasoning_effort "high" tier and message-level tools preservation

### DIFF
--- a/tests/entrypoints/unit_tests/test_chat_utils.py
+++ b/tests/entrypoints/unit_tests/test_chat_utils.py
@@ -710,6 +710,30 @@ def test_parse_chat_messages_empty_system(
     ]
 
 
+@pytest.mark.parametrize("role", ["system", "developer"])
+def test_parse_chat_messages_preserves_message_level_tools(
+    mistral_model_config,
+    role,
+):
+    # Message-level `tools` (as opposed to the request-level `tools`
+    # parameter) must be preserved on both "system" and "developer" role
+    # messages: chat template/encoders such as DeepSeek-V4 and DeepSeek-V3.2
+    # read message-level tools for either role.
+    tools = [{"type": "function", "function": {"name": "get_weather"}}]
+    conversation, _, _ = parse_chat_messages(
+        [
+            {"role": role, "content": "you have tools", "tools": tools},
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "Hi"}],
+            },
+        ],
+        mistral_model_config,
+        content_format="string",
+    )
+    assert conversation[0]["tools"] == tools
+
+
 @pytest.mark.asyncio
 async def test_text_only_chat_does_not_initialize_media_connector(
     mistral_model_config,

--- a/tests/tokenizers_/test_deepseek_v4.py
+++ b/tests/tokenizers_/test_deepseek_v4.py
@@ -297,8 +297,23 @@ def test_deepseek_v4_maps_xhigh_to_high_reasoning_effort():
     )
 
     assert prompt.startswith(
+        "<｜begin▁of▁sentence｜>Reasoning Effort: Beyond maximum"
+    )
+
+
+def test_deepseek_v4_high_reasoning_effort_prepends_high_prompt():
+    prompt = _tokenizer().apply_chat_template(
+        [{"role": "user", "content": "Hello"}],
+        tokenize=False,
+        enable_thinking=True,
+        reasoning_effort="high",
+    )
+
+    assert prompt.startswith(
         "<｜begin▁of▁sentence｜>Reasoning Effort: Absolute maximum"
     )
+    # "high" and "max" must use distinct prompts.
+    assert "Beyond maximum" not in prompt
 
 
 @pytest.mark.parametrize(

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -359,7 +359,12 @@ class CustomChatCompletionMessageParam(TypedDict, total=False):
     """The reasoning content for interleaved thinking."""
 
     tools: list[ChatCompletionFunctionToolParam] | None
-    """The tools for developer role."""
+    """Message-level tools, preserved for "system" and "developer" roles.
+
+    Used by chat templates/encoders (e.g. DeepSeek-V4, DeepSeek-V3.2) that
+    accept tools attached directly to a system or developer message, as
+    opposed to (or in addition to) the request-level `tools` parameter.
+    """
 
     task: str | None
     """Model-specific task marker. Currently passed through for DeepSeek V4."""
@@ -396,7 +401,12 @@ class ConversationMessage(TypedDict, total=False):
     """Deprecated: The reasoning content for interleaved thinking."""
 
     tools: list[ChatCompletionFunctionToolParam] | None
-    """The tools for developer role."""
+    """Message-level tools, preserved for "system" and "developer" roles.
+
+    Used by chat templates/encoders (e.g. DeepSeek-V4, DeepSeek-V3.2) that
+    accept tools attached directly to a system or developer message, as
+    opposed to (or in addition to) the request-level `tools` parameter.
+    """
 
     task: str | None
     """Model-specific task marker. Currently passed through for DeepSeek V4."""
@@ -1903,7 +1913,7 @@ def _parse_chat_message_content(
         if "task" in message and isinstance(message["task"], str):
             result_msg["task"] = message["task"]
 
-        if role == "developer":
+        if role in ("system", "developer"):
             result_msg["tools"] = message.get("tools", None)
     return result
 


### PR DESCRIPTION
## Summary

Two bugs found in DeepSeek-V4's native chat encoding path while deploying
deepseek-ai/DeepSeek-V4-Flash-0731 on a real GPU box, and compared against
the model's own reference encoder (encoding_dsv4.py, published on the
model's HF repo).

### 1. Missing/mislabeled "high" reasoning_effort prefix

`vllm/tokenizers/deepseek_v4_encoding.py` only inserted a reasoning-effort
prompt prefix for `reasoning_effort == "max"`; `"high"` silently produced no
prefix, making it indistinguishable from `"low"`/`None`.

Comparing against the reference `REASONING_EFFORT_PROMPTS` dict byte-for-byte,
vLLM's existing `REASONING_EFFORT_MAX` constant is actually the reference's
"high" text, not "max" — so this wasn't just a missing branch, the existing
text was mislabeled. The real "max" prompt (longer, more emphatic) was
entirely absent from vLLM.

Fix: split into `REASONING_EFFORT_HIGH` (existing text, correctly relabeled)
and a new `REASONING_EFFORT_MAX` (reference's actual "max" text), and add the
missing branch in `render_message()`.

Since several existing tests had encoded the buggy behavior as the expected
result, they're updated to match corrected behavior, plus one new test
asserting "high" and "max" now produce distinct prefixes.

### 2. Message-level `tools` dropped for role=="system"

`_parse_chat_message_content()` in `chat_utils.py` only preserved a message's
`tools` field on the resulting `ConversationMessage` for `role == "developer"`,
silently dropping it for `role == "system"`.

Both DeepSeek-V4's and DeepSeek-V3.2's `render_message()` read
`msg.get("tools")` for `role == "system"` (and separately for `"developer"`) to
render an inline tool-schema block — this is independent of the
request-level `tools` parameter, which DeepSeek-V4's `apply_chat_template`
already handles correctly via a synthetic system message. A caller
attaching tools directly to a system-role message via vLLM's
`CustomChatCompletionMessageParam.tools` extension field had them silently
discarded before reaching the encoder.

Fix: preserve tools for `role in ("system", "developer")`, and correct the
"The tools for developer role" docstring, which was inaccurate/incomplete.

## Test plan
- New/updated unit tests in `tests/tokenizers_/test_deepseek_v4.py` and
  `tests/entrypoints/unit_tests/test_chat_utils.py`
- Manually verified the reasoning_effort fix by exercising `encode_messages()`
  directly against all three tiers (None/"high"/"max")