### PR TITLE
fix(deepseek_v4): merge consecutive assistant messages in prompt enco…

### DIFF
--- a/tests/tokenizers_/test_deepseek_v4.py
+++ b/tests/tokenizers_/test_deepseek_v4.py
@@ -288,3 +288,103 @@ def test_deepseek_v4_matches_reference_golden_fixtures(case_id, kwargs):
 
     expected = (FIXTURES_DIR / f"test_output_{case_id}.txt").read_text()
     assert prompt == expected
+
+
+def _split_turn_messages():
+    """One logical assistant turn replayed as consecutive messages."""
+    return [
+        {"role": "user", "content": "Check the server"},
+        {"role": "assistant", "content": "Let me check the server status."},
+        {
+            "role": "assistant",
+            "reasoning": "The user wants a health check. I should run uptime.",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "shell_exec",
+                        "arguments": '{"command": "uptime"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": "up 5 days",
+        },
+    ]
+
+
+def test_deepseek_v4_merges_consecutive_assistant_messages():
+    messages = _split_turn_messages()
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "shell_exec",
+                "description": "Run a shell command",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"command": {"type": "string"}},
+                    "required": ["command"],
+                },
+            },
+        }
+    ]
+    conversation, _, _ = parse_chat_messages(
+        messages,
+        _model_config(),
+        content_format="string",
+    )
+
+    prompt = _tokenizer().apply_chat_template(
+        conversation=conversation,
+        messages=messages,
+        tools=tools,
+        tokenize=False,
+        thinking=True,
+    )
+
+    # The split turn renders as one canonical turn:
+    # reasoning, then content, then tool calls.
+    assert (
+        "<｜Assistant｜><think>"
+        "The user wants a health check. I should run uptime."
+        "</think>Let me check the server status.\n\n<｜DSML｜tool_calls>"
+    ) in prompt
+    # No orphaned reasoning blocks: the only dangling <think> opener is the
+    # generation prompt.
+    assert prompt.count("<think>") - 1 == prompt.count("</think>")
+    # The merged turn ends with a single EOS.
+    assert prompt.count("<｜end▁of▁sentence｜>") == 1
+    assert prompt.endswith("<｜Assistant｜><think>")
+
+
+def test_deepseek_v4_merges_consecutive_assistant_messages_drop_thinking():
+    messages = _split_turn_messages()
+    conversation, _, _ = parse_chat_messages(
+        messages,
+        _model_config(),
+        content_format="string",
+    )
+
+    prompt = _tokenizer().apply_chat_template(
+        conversation=conversation,
+        messages=messages,
+        tokenize=False,
+        thinking=True,
+    )
+
+    # Without request tools, reasoning from earlier turns is dropped, but the
+    # split turn still renders as a single assistant turn (one EOS).
+    assert prompt == (
+        "<｜begin▁of▁sentence｜><｜User｜>Check the server<｜Assistant｜></think>"
+        "Let me check the server status.\n\n<｜DSML｜tool_calls>\n"
+        '<｜DSML｜invoke name="shell_exec">\n'
+        '<｜DSML｜parameter name="command" string="true">'
+        "uptime</｜DSML｜parameter>\n"
+        "</｜DSML｜invoke>\n</｜DSML｜tool_calls><｜end▁of▁sentence｜>"
+        "<｜User｜><tool_result>up 5 days</tool_result><｜Assistant｜><think>"
+    )

--- a/vllm/tokenizers/deepseek_v4_encoding.py
+++ b/vllm/tokenizers/deepseek_v4_encoding.py
@@ -368,6 +368,78 @@ def render_message(index: int, messages: List[Dict[str, Any]], thinking_mode: st
 # Preprocessing
 # ============================================================
 
+def _merge_assistant_run(run: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Combine a run of consecutive assistant messages into one message."""
+    if len(run) == 1:
+        return run[0]
+    combined = copy.deepcopy(run[0])
+    contents = [m["content"] for m in run if m.get("content")]
+    reasonings = [m["reasoning"] for m in run if m.get("reasoning")]
+    tool_calls = [tc for m in run for tc in (m.get("tool_calls") or [])]
+    if contents:
+        combined["content"] = "\n\n".join(contents)
+    else:
+        combined.pop("content", None)
+    if reasonings:
+        combined["reasoning"] = "\n\n".join(reasonings)
+    else:
+        combined.pop("reasoning", None)
+    if tool_calls:
+        combined["tool_calls"] = tool_calls
+    else:
+        combined.pop("tool_calls", None)
+    # End-of-turn markers come from the last message of the run.
+    for key in ("task", "wo_eos", "mask"):
+        if key in run[-1]:
+            combined[key] = run[-1][key]
+        else:
+            combined.pop(key, None)
+    return combined
+
+
+def merge_consecutive_assistant_messages(
+    messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """
+    Merge runs of consecutive assistant messages into single assistant messages.
+
+    Some clients replay one logical assistant turn as several consecutive
+    assistant messages (e.g. a content-only message followed by a separate
+    tool_calls + reasoning message). DeepSeek-V4 renders one assistant turn as
+    a single unit: reasoning + content + tool calls. Rendering consecutive
+    assistant messages individually produces malformed prompts, because the
+    Assistant transition tokens are only emitted after user/developer messages:
+    the follow-up message is glued onto the previous one with no separator and
+    its reasoning renders as free text terminated by a stray thinking end token.
+
+    Merge rules for a run of consecutive assistant messages:
+    - content: non-empty parts joined with "\n\n" (order preserved)
+    - reasoning: non-empty parts joined with "\n\n" (order preserved)
+    - tool_calls: concatenated (order preserved)
+    - task / wo_eos / mask: taken from the last message of the run
+      (end-of-turn semantics, mirroring merge_tool_messages)
+
+    Args:
+        messages: Message list in OpenAI format.
+
+    Returns:
+        Message list with consecutive assistant messages merged.
+    """
+    merged: List[Dict[str, Any]] = []
+    run: List[Dict[str, Any]] = []
+    for msg in messages:
+        if msg.get("role") == "assistant":
+            run.append(msg)
+            continue
+        if run:
+            merged.append(_merge_assistant_run(run))
+            run = []
+        merged.append(msg)
+    if run:
+        merged.append(_merge_assistant_run(run))
+    return merged
+
+
 def merge_tool_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """
     Merge tool messages into the preceding user message using content_blocks format.
@@ -486,6 +558,7 @@ def encode_messages(
 
     This is the main entry point for encoding conversations. It handles:
     - BOS token insertion
+    - Consecutive assistant message merging (split turns)
     - Thinking mode with optional reasoning content dropping
     - Tool message merging into user messages
     - Multi-turn conversation context
@@ -504,10 +577,13 @@ def encode_messages(
     """
     context = context if context else []
 
-    # Preprocess: merge tool messages and sort tool results
+    # Preprocess: merge split assistant turns, merge tool messages,
+    # and sort tool results
+    messages = merge_consecutive_assistant_messages(messages)
     messages = merge_tool_messages(messages)
     messages = sort_tool_results_by_call_order(context + messages)[len(context):]
     if context:
+        context = merge_consecutive_assistant_messages(context)
         context = merge_tool_messages(context)
         context = sort_tool_results_by_call_order(context)
 


### PR DESCRIPTION
# fix(deepseek_v4): merge consecutive assistant messages in prompt encoding

## Problem

Chat clients that persist agentic tool-calling sessions (e.g. LLM gateways replaying
conversation history) commonly split one logical assistant turn into **two consecutive
assistant messages**: a content-only message (the visible preamble) followed by a separate
message carrying `tool_calls` + `reasoning` with empty content.

`encode_messages()` / `render_message()` in `vllm/tokenizers/deepseek_v4_encoding.py`
only emit the Assistant transition tokens (`<｜Assistant｜>` + `<think>`/`</think>`) after
`user`/`developer` messages. When an assistant message is followed by another assistant
message, **no transition is emitted**, so the second message is glued onto the first with
no separator:

- its `reasoning` renders as **free text with no `<think>` opener** (orphaned thinking),
- terminated by a **stray `</think>`** (unbalanced think tags),
- with a **missing `<｜Assistant｜>` marker** for that turn,
- and the turn's content and tool calls end up in **separate EOS-terminated blocks** in
  the wrong order (content before reasoning).

The corruption accumulates with every tool round in the replayed history. In production
(DeepSeek-V4-Flash, agentic health-check sessions with ~20–55 tool rounds) we measured
**679 stray `</think>` tokens across 55 consecutive requests** (one per split turn), with
the model increasingly spilling paraphrased inner-monologue text into the content channel
("padding": the same sentence rephrased up to ~400 times before a tool call) as sessions
grew past ~35–70K prompt tokens.

### Reproduction (no GPU needed)

```python
from vllm.tokenizers.deepseek_v4_encoding import encode_messages

messages = [
    {"role": "user", "content": "Check the server"},
    {"role": "assistant", "content": "Let me check the server status."},
    {"role": "assistant",
     "reasoning": "The user wants a health check. I should run uptime.",
     "tool_calls": [{"id": "call_1", "type": "function", "function": {
         "name": "shell_exec", "arguments": '{"command": "uptime"}'}}]},
    {"role": "tool", "tool_call_id": "call_1", "content": "up 5 days"},
]
print(encode_messages(messages, thinking_mode="thinking"))
```

Before (note the missing `<｜Assistant｜>`/`<think>` before the reasoning, and the stray
`</think>` after it):

```
...<｜Assistant｜></think>Let me check the server status.<｜end▁of▁sentence｜>
The user wants a health check. I should run uptime.</think>

<｜DSML｜tool_calls>...
```

After (single canonical turn):

```
...<｜Assistant｜><think>The user wants a health check. I should run uptime.</think>
Let me check the server status.

<｜DSML｜tool_calls>...
```

## Fix

Add a preprocessing step `merge_consecutive_assistant_messages()` that merges runs of
consecutive assistant messages into one message before tool-message merging:

- `content`: non-empty parts joined with `"\n\n"` (order preserved)
- `reasoning`: non-empty parts joined with `"\n\n"` (order preserved)
- `tool_calls`: concatenated (order preserved)
- `task` / `wo_eos` / `mask`: taken from the **last** message of the run
  (end-of-turn semantics, mirroring `merge_tool_messages`)

This restores the canonical single-turn rendering (`reasoning + content + tool calls`
under one `<｜Assistant｜>` marker and one EOS), matching the reference golden fixtures.

## Testing

- **Golden fixtures**: all 4 existing reference fixtures render **byte-identical** before
  and after the change (they contain no consecutive assistant messages — no regression).
- **New unit tests** (`tests/tokenizers_/test_deepseek_v4.py`):
  - `test_deepseek_v4_merges_consecutive_assistant_messages` — split turn with request
    tools + thinking: canonical turn structure, balanced think tags (one dangling opener
    for the generation prompt), single EOS.
  - `test_deepseek_v4_merges_consecutive_assistant_messages_drop_thinking` — same input
    without request tools (drop-thinking path): exact prompt comparison.
- **Production replay**: re-encoded 77 real captured requests from two affected sessions;
  stray `</think>` count goes from 208 + 679 to **0**, and output is byte-identical to
  rendering the same history with pre-merged single assistant messages.

## Notes / possible follow-ups (not changed here)

- `encode_messages` force-disables `drop_thinking` whenever any message defines `tools`,
  so full historical reasoning is rendered for all tool-calling traffic (by design for
  interleaved thinking, but worth documenting).
- `apply_chat_template` inserts a synthetic `{"role": "system", "tools": ...}` message at
  index 0 even when the conversation already has a system message, so tool-calling prompts
  contain two rendered system blocks. Behavior unchanged by this PR.
