### PR TITLE
[ROCm][Bugfix] Hoist tt.addptr out of scf.if in fused_qk_rmsnorm

### DIFF
--- a/vllm/models/common/ops/fused_qk_rmsnorm.py
+++ b/vllm/models/common/ops/fused_qk_rmsnorm.py
@@ -33,15 +33,18 @@ def _fused_q_kv_rmsnorm_kernel(
     pid_task = tl.program_id(1)
 
     if pid_task == 0:
-        SIZE = Q_SIZE
-        row_in = q_ptr + token_idx * q_in_stride
-        weight_ptr = q_weight_ptr
-        row_out = q_out_ptr + token_idx * q_out_stride
+        SIZE, base_in, base_out, weight_ptr = Q_SIZE, q_ptr, q_out_ptr, q_weight_ptr
+        in_stride, out_stride = q_in_stride, q_out_stride
     else:
-        SIZE = KV_SIZE
-        row_in = kv_ptr + token_idx * kv_in_stride
-        weight_ptr = kv_weight_ptr
-        row_out = kv_out_ptr + token_idx * kv_out_stride
+        SIZE, base_in, base_out, weight_ptr = KV_SIZE, kv_ptr, kv_out_ptr, kv_weight_ptr
+        in_stride, out_stride = kv_in_stride, kv_out_stride
+
+    # addptr must stay outside the branch: per-arm offsets make the two scf.if
+    # results fat pointers with mismatched canNarrow, tripping an assert in
+    # Triton's TritonAMDGPUCanonicalizePointers on gfx908. Do not re-inline.
+    # https://github.com/vllm-project/vllm/issues/50679
+    row_in = base_in + token_idx * in_stride
+    row_out = base_out + token_idx * out_stride
 
     if launch_pdl:
         tl.extra.cuda.gdc_wait()


### PR DESCRIPTION
## Purpose

On gfx908, `_fused_q_kv_rmsnorm_kernel` computes `row_in` and `row_out` inside the `pid_task` branch. This causes both arms of the resulting `scf.if` to yield already-offset pointers whose fat-pointer `canNarrow` flags disagree, triggering an assertion in Triton's `TritonAMDGPUCanonicalizePointers` pass.

This change hoists the two `tt.addptr` operations out of the branch. The branch now selects only the base pointer and stride, and the offset is applied once afterwards.

The norm computation, stores, `launch_pdl` handling, kernel signature, and launch site are unchanged. The change is also a no-op semantically on NVIDIA.

Fixes #50679.

## Test Plan

* `pre-commit` passes locally on the changed file.
* The issue reporter verified the patch on an AMD Instinct MI100 / gfx908 system and confirmed that the original Triton compilation crash is resolved.
* Existing tests in `tests/kernels/core/test_fused_q_kv_rmsnorm.py` cover numerical correctness and the large-token-count launch path.
