### PR TITLE
[Bugfix] Fix DeepSeek MoE sequence-parallel layout tracking

### DIFF
--- a/tests/model_executor/test_deepseek_v2_sequence_parallel.py
+++ b/tests/model_executor/test_deepseek_v2_sequence_parallel.py
@@ -1,0 +1,237 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Layout tracking for MoE sequence parallelism in ``DeepseekV2Model``.
+
+``hidden_states.shape[0]`` cannot tell a full input apart from a padded
+sequence-parallel shard: with TP=2 and a single decode token, both have one
+row. These tests pin the explicit layout state that replaced the shape check.
+"""
+
+import math
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from vllm.config.compilation import CompilationMode
+from vllm.model_executor.models import deepseek_v2 as deepseek_mod
+
+TP_SIZE = 2
+HIDDEN_SIZE = 8
+
+
+def sp_rows(num_tokens: int) -> int:
+    """Row count of one shard after padding to a multiple of TP_SIZE."""
+    return math.ceil(num_tokens / TP_SIZE)
+
+
+class DummyPPGroup:
+    world_size = 1
+    rank_in_group = 0
+    is_first_rank = True
+    is_last_rank = True
+
+
+class DummyEmbedding(nn.Module):
+    def __init__(self, vocab_size, hidden_size, *args, **kwargs):
+        super().__init__()
+        self.hidden_size = hidden_size
+
+    def forward(self, input_ids):
+        return torch.zeros((*input_ids.shape, self.hidden_size))
+
+
+class DummyNorm(nn.Module):
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+
+    def forward(self, hidden_states, residual=None):
+        return hidden_states, residual
+
+
+class RecordingLayer(nn.Module):
+    """Records the layout it is handed and reproduces a real layer's shapes.
+
+    A sequence-parallel layer all-gathers its input, runs attention on the
+    full sequence and reduce-scatters, so its output always has ``sp_rows``
+    rows no matter which layout came in.
+    """
+
+    def __init__(self, use_sequence_parallel_moe, calls):
+        super().__init__()
+        self.use_sequence_parallel_moe = use_sequence_parallel_moe
+        self.calls = calls
+
+    def forward(
+        self,
+        positions,
+        hidden_states,
+        residual,
+        llama_4_scaling=None,
+        input_is_sequence_parallel=False,
+    ):
+        full_num_tokens = positions.shape[0]
+        self.calls.append(
+            SimpleNamespace(
+                input_is_sequence_parallel=input_is_sequence_parallel,
+                rows=hidden_states.shape[0],
+                expected_rows=(
+                    sp_rows(full_num_tokens)
+                    if input_is_sequence_parallel
+                    else full_num_tokens
+                ),
+            )
+        )
+        out_rows = (
+            sp_rows(full_num_tokens)
+            if self.use_sequence_parallel_moe
+            else full_num_tokens
+        )
+        shape = (out_rows, HIDDEN_SIZE)
+        return hidden_states.new_zeros(shape), hidden_states.new_zeros(shape)
+
+
+def make_vllm_config(num_hidden_layers):
+    hf_config = SimpleNamespace(
+        model_type="deepseek_v3",
+        first_k_dense_replace=0,
+        vocab_size=32,
+        hidden_size=HIDDEN_SIZE,
+        num_hidden_layers=num_hidden_layers,
+        rms_norm_eps=1e-5,
+        qk_nope_head_dim=128,
+        qk_rope_head_dim=64,
+    )
+    return SimpleNamespace(
+        model_config=SimpleNamespace(hf_config=hf_config),
+        quant_config=None,
+        parallel_config=SimpleNamespace(
+            eplb_config=SimpleNamespace(num_redundant_experts=0),
+        ),
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=8),
+        cache_config=None,
+        compilation_config=SimpleNamespace(mode=CompilationMode.NONE),
+    )
+
+
+def build_model(monkeypatch, sp_flags, calls, gathered_rows):
+    layer_flags = iter(sp_flags)
+
+    def fake_layer(*args, **kwargs):
+        return RecordingLayer(next(layer_flags), calls)
+
+    def fake_make_layers(num_hidden_layers, layer_fn, prefix):
+        layers = [layer_fn(prefix=f"{prefix}.{i}") for i in range(num_hidden_layers)]
+        return 0, num_hidden_layers, nn.ModuleList(layers)
+
+    def fake_all_gather(x, dim):
+        gathered_rows.append(x.shape[0])
+        return torch.cat([x] * TP_SIZE, dim=dim)
+
+    monkeypatch.setattr(deepseek_mod, "get_pp_group", lambda: DummyPPGroup())
+    monkeypatch.setattr(deepseek_mod, "VocabParallelEmbedding", DummyEmbedding)
+    monkeypatch.setattr(deepseek_mod, "RMSNorm", DummyNorm)
+    monkeypatch.setattr(deepseek_mod, "DeepseekV2DecoderLayer", fake_layer)
+    monkeypatch.setattr(deepseek_mod, "make_layers", fake_make_layers)
+    monkeypatch.setattr(
+        deepseek_mod, "tensor_model_parallel_all_gather", fake_all_gather
+    )
+
+    return deepseek_mod.DeepseekV2Model(vllm_config=make_vllm_config(len(sp_flags)))
+
+
+def run_forward(monkeypatch, num_tokens, sp_flags, aux_layers=()):
+    calls: list = []
+    gathered_rows: list = []
+    model = build_model(monkeypatch, sp_flags, calls, gathered_rows)
+    model.aux_hidden_state_layers = aux_layers
+
+    output = model(
+        torch.zeros(num_tokens, dtype=torch.long),
+        torch.arange(num_tokens),
+        None,
+    )
+    return output, calls, gathered_rows
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize("num_tokens", [1, 2, 7, 8])
+@pytest.mark.parametrize(
+    "sp_flags",
+    [
+        # Pure dense stack.
+        [False, False],
+        # first_k_dense_replace: dense prefix then MoE layers.
+        [False, True, True],
+        # MoE layers only.
+        [True, True, True],
+        # moe_layer_freq > 1: a dense layer between MoE layers must restore
+        # the full layout.
+        [True, False, True],
+        # Ends on a dense layer, so no trailing all-gather is needed.
+        [True, True, False],
+    ],
+)
+def test_layer_inputs_match_the_declared_layout(monkeypatch, num_tokens, sp_flags):
+    output, calls, _ = run_forward(monkeypatch, num_tokens, sp_flags)
+
+    assert len(calls) == len(sp_flags)
+    for idx, call in enumerate(calls):
+        assert call.rows == call.expected_rows, (
+            f"layer {idx} was told input_is_sequence_parallel="
+            f"{call.input_is_sequence_parallel} but received {call.rows} rows"
+        )
+    # The model must hand back the full sequence.
+    assert output.shape == (num_tokens, HIDDEN_SIZE)
+
+
+@pytest.mark.cpu_test
+def test_single_token_decode_keeps_tracking_sequence_parallel_layout(monkeypatch):
+    """Regression test for the shape-inference bug.
+
+    With one token and TP=2 every tensor has a single row, so the previous
+    ``hidden_states.shape[0] != full_num_tokens`` check reported "not
+    sequence parallel" for shards and skipped the all-gathers.
+    """
+    output, calls, gathered_rows = run_forward(
+        monkeypatch, num_tokens=1, sp_flags=[False, True, True]
+    )
+
+    assert all(call.rows == 1 for call in calls), (
+        "shapes are ambiguous here, which is the whole point of the test"
+    )
+    # The dense layer and the first MoE layer see the full input; only the
+    # second MoE layer receives a shard produced by the first one.
+    assert [call.input_is_sequence_parallel for call in calls] == [False, False, True]
+    # The trailing shard must still be gathered before the final norm.
+    assert gathered_rows == [1]
+    assert output.shape == (1, HIDDEN_SIZE)
+
+
+@pytest.mark.cpu_test
+def test_dense_layer_after_moe_restores_full_layout(monkeypatch):
+    _, calls, gathered_rows = run_forward(
+        monkeypatch, num_tokens=1, sp_flags=[True, False, True]
+    )
+
+    assert [call.input_is_sequence_parallel for call in calls] == [False, False, False]
+    # One gather before the dense layer, one after the trailing MoE layer.
+    assert gathered_rows == [1, 1]
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize("num_tokens", [1, 8])
+def test_aux_hidden_states_are_gathered(monkeypatch, num_tokens):
+    """EAGLE aux hidden states must be full-length even when captured
+    between two sequence-parallel layers."""
+    _, _, gathered_rows = run_forward(
+        monkeypatch,
+        num_tokens,
+        sp_flags=[True, True, True],
+        aux_layers=(1,),
+    )
+
+    # Layer 1 is fed a shard, so its aux capture needs its own all-gather on
+    # top of the trailing one.
+    assert gathered_rows == [sp_rows(num_tokens), sp_rows(num_tokens)]

--- a/tests/model_executor/test_mistral_large_3_eagle.py
+++ b/tests/model_executor/test_mistral_large_3_eagle.py
@@ -55,8 +55,16 @@ class DummyNorm(nn.Module):
 class DummyDecoderLayer(nn.Module):
     def __init__(self, *args, **kwargs):
         super().__init__()
+        self.use_sequence_parallel_moe = False
 
-    def forward(self, positions, hidden_states, residual, llama_4_scaling=None):
+    def forward(
+        self,
+        positions,
+        hidden_states,
+        residual,
+        llama_4_scaling=None,
+        input_is_sequence_parallel=False,
+    ):
         return hidden_states, residual
 
 

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -1295,13 +1295,9 @@ class DeepseekV2DecoderLayer(nn.Module):
         hidden_states: torch.Tensor,
         residual: torch.Tensor | None,
         llama_4_scaling: torch.Tensor | None = None,
+        input_is_sequence_parallel: bool = False,
     ) -> torch.Tensor:
         full_num_tokens = positions.shape[0]
-        input_is_sequence_parallel = (
-            self.use_sequence_parallel_moe
-            and residual is not None
-            and hidden_states.shape[0] != full_num_tokens
-        )
 
         # Self Attention
         if residual is None:
@@ -1468,13 +1464,17 @@ class DeepseekV2Model(nn.Module):
             llama_4_scaling = None
 
         aux_hidden_states = []
+        # Track the layout explicitly: shapes cannot distinguish a full input
+        # from a padded sequence-parallel shard (e.g. single-token decode,
+        # where both have one row).
+        hidden_states_are_sequence_parallel = False
         for idx, layer in enumerate(
             islice(self.layers, self.start_layer, self.end_layer),
             start=self.start_layer,
         ):
             # all gather if we need to use the whole states
             if (
-                hidden_states.shape[0] != positions.shape[0]
+                hidden_states_are_sequence_parallel
                 and not layer.use_sequence_parallel_moe
             ):
                 combined_states = torch.cat([hidden_states, residual], dim=-1)
@@ -1483,24 +1483,30 @@ class DeepseekV2Model(nn.Module):
                 hidden_states, residual = combined_states.split(
                     [self.hidden_size, self.hidden_size], dim=-1
                 )
+                hidden_states_are_sequence_parallel = False
             if idx in self.aux_hidden_state_layers:
                 aux_hidden_state = hidden_states + residual
-                if aux_hidden_state.shape[0] != positions.shape[0]:
+                if hidden_states_are_sequence_parallel:
                     aux_hidden_state = tensor_model_parallel_all_gather(
                         aux_hidden_state, 0
                     )
                     aux_hidden_state = aux_hidden_state[: positions.shape[0]]
                 aux_hidden_states.append(aux_hidden_state)
             hidden_states, residual = layer(
-                positions, hidden_states, residual, llama_4_scaling
+                positions,
+                hidden_states,
+                residual,
+                llama_4_scaling,
+                input_is_sequence_parallel=hidden_states_are_sequence_parallel,
             )
+            hidden_states_are_sequence_parallel = layer.use_sequence_parallel_moe
 
         if not get_pp_group().is_last_rank:
             return IntermediateTensors(
                 {"hidden_states": hidden_states, "residual": residual}
             )
 
-        if hidden_states.shape[0] != positions.shape[0]:
+        if hidden_states_are_sequence_parallel:
             combined_states = torch.cat([hidden_states, residual], dim=-1)
             combined_states = tensor_model_parallel_all_gather(combined_states, 0)
             combined_states = combined_states[: positions.shape[0]]


### PR DESCRIPTION
## Purpose

`deepseek_v2.py` decides whether `hidden_states` are sequence-parallel by comparing the first dimension against the full token count. That inference is ambiguous, and single-token decode is exactly where it breaks.

With TP=2 and one decode token, `ceil(1 / 2) == 1`, so a full input and a padded local shard both have one row:

| Value | First dimension | Data represented |
| --- | ---: | --- |
| Full decode input | 1 | Real token |
| TP rank 0 local shard | 1 | Real token |
| TP rank 1 local shard | 1 | Padding row |

When the check misfires, the layer skips its entry all-gather. Each TP rank then runs attention on a different row — rank > 0 holds padding — and the following `reduce_scatter` sums misaligned partials, so decode output is corrupted.

This is the same root cause as #50681 / #50685, which fix `qwen3_next.py`. `deepseek_v2.py` carries an independent copy of the pattern, introduced earlier by #46635, so #50685 does not cover it. This PR mirrors that fix so the two read the same way.

### Sites fixed

All four shape comparisons on `main` (`63e78ce`):

1. Layer-entry inference — [`deepseek_v2.py#L1300-L1304`](https://github.com/vllm-project/vllm/blob/63e78ce3652f4f94e9f484f40db71ca4cf019f21/vllm/model_executor/models/deepseek_v2.py#L1300-L1304)
2. All-gather that restores the full layout before a non-SP layer — [`#L1476-L1479`](https://github.com/vllm-project/vllm/blob/63e78ce3652f4f94e9f484f40db71ca4cf019f21/vllm/model_executor/models/deepseek_v2.py#L1476-L1479)
3. Aux hidden state capture (EAGLE) — [`#L1488`](https://github.com/vllm-project/vllm/blob/63e78ce3652f4f94e9f484f40db71ca4cf019f21/vllm/model_executor/models/deepseek_v2.py#L1488)
4. Trailing all-gather before the final norm — [`#L1503`](https://github.com/vllm-project/vllm/blob/63e78ce3652f4f94e9f484f40db71ca4cf019f21/vllm/model_executor/models/deepseek_v2.py#L1503)

### Approach

Track the layout explicitly instead of inferring it, following #50685:

- `DeepseekV2Model.forward` carries a `hidden_states_are_sequence_parallel` flag.
- It is passed to each layer as `input_is_sequence_parallel`, replacing the in-layer inference.
- It is set from `layer.use_sequence_parallel_moe` after each layer, and cleared wherever an all-gather restores the full layout.

The reduce-scatter optimization itself is unchanged; only the layout bookkeeping moves from shapes to explicit state. DeepSeek's dense/MoE interleave (`first_k_dense_replace`, `moe_layer_freq`) is what site 2 exists for, and it stays correct: a dense layer after a MoE layer still gathers first and hands the layer a full input.

Sequence-parallel MoE already requires `pipeline_parallel_size == 1`, so the `IntermediateTensors` PP path always carries full states and needs no change.

### Affected models

Everything routed through `DeepseekV2Model` / `DeepseekV2DecoderLayer`:

- `DeepseekForCausalLM`
- `DeepseekV2ForCausalLM`
- `DeepseekV3ForCausalLM`, `DeepseekV32ForCausalLM`
- `GlmMoeDsaForCausalLM`
- `MistralLarge3ForCausalLM` (subclasses `DeepseekV3ForCausalLM`)
- `EagleMistralLarge3Model` (inherits `DeepseekV2Model.forward`)

`input_is_sequence_parallel` is a trailing keyword argument defaulting to `False`, so the other callers of `DeepseekV2DecoderLayer` are unaffected:

- `deepseek_mtp.py` and `longcat_flash_mtp.py` run a single `mtp_block` with `residual=None`, which the old code also evaluated as not sequence-parallel. Both already handle their own trailing all-gather.
- `deepseek_eagle.py` keeps its own layer loop. It has no sequence-parallel handling at all — no all-gather anywhere, including before its final norm — so MoE SP is not functional on that draft path before or after this change. For the usual single-layer EAGLE draft the behaviour is identical either way. Left alone deliberately to keep this PR to the bug; happy to fold in a follow-up if maintainers prefer.

Models that only borrow submodules from `deepseek_v2.py` (`AXK1`, `glm4_moe_lite`, `longcat_flash`, `deepseek_eagle3`) have their own model loops and are untouched.

## Test Plan

New CPU unit test, `tests/model_executor/test_deepseek_v2_sequence_parallel.py`, drives `DeepseekV2Model.forward` with recording stub layers and a fake all-gather, so the layout state machine is checked without GPUs:

```bash
pytest tests/model_executor/test_deepseek_v2_sequence_parallel.py
```

It asserts, over `num_tokens` in `{1, 2, 7, 8}` and five dense/MoE layer arrangements, that every layer receives a row count consistent with the layout flag it was handed, that the model returns the full sequence, and that the all-gathers happen exactly where they should. The single-token cases assert on all-gather counts rather than shapes, since shapes are ambiguous there — which is the bug.

End-to-end, on 4 GPUs (default `--all2all-backend` selects `allgather_reducescatter`, which enables `use_sequence_parallel_moe`):

```bash
vllm serve deepseek-ai/DeepSeek-V2-Lite \
  --tensor-parallel-size 2 --data-parallel-size 2 --enable-expert-parallel \
  --enforce-eager --trust-remote-code --max-model-len 2048 --max-num-seqs 4
```

then a single greedy request (`temperature: 0`, `max_tokens: 64`), one at a time so every decode step is a single-token batch.

`tests/model_executor/test_mistral_large_3_eagle.py` needed two lines: its `DummyDecoderLayer` now accepts the new keyword argument and declares `use_sequence_parallel_moe`, which the model loop previously only read behind a short-circuit.

## Test Result

The new unit test fails on `main` and passes with this change. On `main` the single-token cases show the trailing all-gather being skipped entirely, which is the corruption path.

```text
tests/model_executor/test_deepseek_v2_sequence_parallel.py .................. 24 passed
tests/model_executor/test_mistral_large_3_eagle.py ......................... 4 passed
```

GPU verification in progress.
