### PR TITLE
Fix DSpark warmup without sparse index buffer

### DIFF
--- a/tests/kernels/attention/test_flashmla_sparse.py
+++ b/tests/kernels/attention/test_flashmla_sparse.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from types import SimpleNamespace
-
 import pytest
 import torch
 

--- a/tests/kernels/attention/test_flashmla_sparse.py
+++ b/tests/kernels/attention/test_flashmla_sparse.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from types import SimpleNamespace
+
 import pytest
 import torch
 
@@ -70,6 +72,55 @@ def test_sparse_flashmla_metadata_smoke():
     assert tile_md.tile_scheduler_metadata is None
     assert tile_md.num_splits is None
     assert num_splits is None
+
+
+def test_deepseek_v4_dspark_warmup_without_topk_buffer(monkeypatch):
+    from vllm.models.deepseek_v4.nvidia import flashmla as flashmla_mod
+
+    workspace_calls = []
+
+    class FakeWorkspaceManager:
+        def get_simultaneous(self, *shapes_and_dtypes):
+            workspace_calls.append(shapes_and_dtypes)
+
+    monkeypatch.setattr(
+        flashmla_mod,
+        "get_forward_context",
+        lambda: SimpleNamespace(attn_metadata=None),
+    )
+    monkeypatch.setattr(
+        flashmla_mod,
+        "current_workspace_manager",
+        lambda: FakeWorkspaceManager(),
+    )
+
+    attn = SimpleNamespace(
+        compress_ratio=1,
+        max_model_len=1024,
+        window_size=128,
+        max_num_batched_tokens=16,
+        topk_indices_buffer=None,
+        PREFILL_CHUNK_SIZE=4,
+    )
+    q = torch.ones((2, 1, 16), dtype=torch.bfloat16)
+    output = torch.ones_like(q)
+
+    flashmla_mod.DeepseekV4FlashMLAAttention.forward_mqa(
+        attn,
+        q,
+        torch.empty_like(q),
+        torch.arange(2),
+        output,
+    )
+
+    torch.testing.assert_close(output, torch.zeros_like(output))
+    assert workspace_calls == [
+        (
+            ((4, 144, 16), torch.bfloat16),
+            ((16, 128), torch.int32),
+            ((16,), torch.int32),
+        )
+    ]
 
 
 def test_sparse_flashmla_decode_smoke():

--- a/tests/kernels/attention/test_flashmla_sparse.py
+++ b/tests/kernels/attention/test_flashmla_sparse.py
@@ -74,55 +74,6 @@ def test_sparse_flashmla_metadata_smoke():
     assert num_splits is None
 
 
-def test_deepseek_v4_dspark_warmup_without_topk_buffer(monkeypatch):
-    from vllm.models.deepseek_v4.nvidia import flashmla as flashmla_mod
-
-    workspace_calls = []
-
-    class FakeWorkspaceManager:
-        def get_simultaneous(self, *shapes_and_dtypes):
-            workspace_calls.append(shapes_and_dtypes)
-
-    monkeypatch.setattr(
-        flashmla_mod,
-        "get_forward_context",
-        lambda: SimpleNamespace(attn_metadata=None),
-    )
-    monkeypatch.setattr(
-        flashmla_mod,
-        "current_workspace_manager",
-        lambda: FakeWorkspaceManager(),
-    )
-
-    attn = SimpleNamespace(
-        compress_ratio=1,
-        max_model_len=1024,
-        window_size=128,
-        max_num_batched_tokens=16,
-        topk_indices_buffer=None,
-        PREFILL_CHUNK_SIZE=4,
-    )
-    q = torch.ones((2, 1, 16), dtype=torch.bfloat16)
-    output = torch.ones_like(q)
-
-    flashmla_mod.DeepseekV4FlashMLAAttention.forward_mqa(
-        attn,
-        q,
-        torch.empty_like(q),
-        torch.arange(2),
-        output,
-    )
-
-    torch.testing.assert_close(output, torch.zeros_like(output))
-    assert workspace_calls == [
-        (
-            ((4, 144, 16), torch.bfloat16),
-            ((16, 128), torch.int32),
-            ((16,), torch.int32),
-        )
-    ]
-
-
 def test_sparse_flashmla_decode_smoke():
     import vllm.v1.attention.ops.flashmla as fm
 

--- a/vllm/models/deepseek_v4/nvidia/flashmla.py
+++ b/vllm/models/deepseek_v4/nvidia/flashmla.py
@@ -96,8 +96,11 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
                 // self.compress_ratio
             )
             M = N + self.window_size + self.max_num_batched_tokens
-            assert self.topk_indices_buffer is not None
-            top_k = 0 if swa_only else self.topk_indices_buffer.shape[-1]
+            if swa_only:
+                top_k = 0
+            else:
+                assert self.topk_indices_buffer is not None
+                top_k = self.topk_indices_buffer.shape[-1]
             combined_topk = round_up(top_k + self.window_size, 128)
             current_workspace_manager().get_simultaneous(
                 ((self.PREFILL_CHUNK_SIZE, M, q.shape[-1]), torch.bfloat16),


### PR DESCRIPTION
## Purpose

Fixes #50615.

During DSpark startup, `profile_run` calls `forward_mqa` without attention
metadata to size the warmup workspace. For the SWA-only draft layer
(`compress_ratio <= 1`), `topk_indices_buffer` is intentionally not allocated,
but the warmup path asserted that the buffer existed before setting `top_k` to
zero. This makes the engine fail after loading the full target and draft model.

This change handles the SWA-only case before accessing the sparse top-k buffer:

- SWA-only warmup uses `top_k = 0` without requiring a sparse index buffer.
- The assertion remains in the sparse path, where the buffer is required.

Thanks to @fank for the clear reproduction and root-cause analysis. This PR
implements the minimal fix suggested in the issue.

Following reviewer feedback, the dedicated regression test used during
validation was removed from the final diff. The submitted change is now limited
to the production source file.

### Duplicate-work check

I checked the issue discussion and open PRs referencing #50615 and the DSpark
warmup path. No open PR addresses this failure. The nearby #41834 is a broader
SM12x enablement branch; its current head still contains the same SWA-only
buffer assumption, so it does not provide this fix on current `main`.

## Test Plan

### 1. Focused regression validation

Before removing the dedicated test from the submitted diff, I used it to
construct the exact state seen during DSpark warmup:

```text
compress_ratio=1
attn_metadata=None
topk_indices_buffer=None
```

It called `DeepseekV4FlashMLAAttention.forward_mqa` and verified that the
output was zeroed and that workspace allocation was requested with the
expected shapes. The run also included the two existing sparse FlashMLA smoke
tests:

```bash
pytest tests/kernels/attention/test_flashmla_sparse.py \
  -k 'deepseek_v4_dspark_warmup_without_topk_buffer or sparse_flashmla_metadata_smoke or sparse_flashmla_decode_smoke' \
  -q
```

Result before removing the temporary regression test:

```text
3 passed, 15 warnings in 2.39s
```

### 2. Static checks

The final source-only head and the cleanup commit were checked with:

```bash
ruff check \
  vllm/models/deepseek_v4/nvidia/flashmla.py \
  tests/kernels/attention/test_flashmla_sparse.py

ruff format --check \
  vllm/models/deepseek_v4/nvidia/flashmla.py \
  tests/kernels/attention/test_flashmla_sparse.py

git diff --check
```

All checks passed. The final PR diff contains only
`vllm/models/deepseek_v4/nvidia/flashmla.py`.

### 3. End-to-end B300 A/B startup test

The end-to-end test ran in an isolated Kubernetes test deployment, not a
production service.

| Item | Value |
| --- | --- |
| GPU | 1 x NVIDIA B300 |
| GPU memory | 275,040 MiB |
| GPU architecture | `sm_100f` |
| Tensor parallelism | TP1 |
| Image | `vllm/vllm-openai:nightly-0f17394564fa2fccd332cf63321314884c15ee37` |
| Reported vLLM version | `0.26.1rc1.dev181+g0f1739456` |
| Model | `deepseek-ai/DeepSeek-V4-Flash-0731` |
| Model revision | `7872f01b1d1fe23eabc4c98b48bffcef5a386062` |

Relevant engine configuration:

```bash
VLLM_USE_V2_MODEL_RUNNER=1 vllm serve \
  deepseek-ai/DeepSeek-V4-Flash-0731 \
  --revision 7872f01b1d1fe23eabc4c98b48bffcef5a386062 \
  --served-model-name deepseek-ai/DeepSeek-V4-Flash-0731 \
  --tensor-parallel-size 1 \
  --trust-remote-code \
  --tokenizer-mode deepseek_v4 \
  --kv-cache-dtype fp8 \
  --block-size 256 \
  --gpu-memory-utilization 0.9 \
  --max-model-len 1048576 \
  --max-num-batched-tokens 8192 \
  --max-num-seqs 64 \
  --enable-chunked-prefill \
  --enable-prefix-caching \
  --no-disable-hybrid-kv-cache-manager \
  --attention-config '{"use_fp4_indexer_cache":true}' \
  --speculative-config '{"method":"dspark","num_speculative_tokens":7}' \
  --enforce-eager
```

The unpatched and patched runs used the same image, model, GPU, and launch
configuration. The only B-group change was mounting the patched `flashmla.py`
over the image copy.

### 4. Functional generation tests

After the patched engine became healthy, I exercised:

1. A non-streaming arithmetic request.
2. A non-streaming Chinese response with `finish_reason=stop`.
3. A streaming request with usage reporting and the final `[DONE]` marker.

DSpark Prometheus counters were collected after the requests to verify that
the speculative path was actually used.

## Test Result

### Before the fix

The exact nightly image loaded all 48 target-model shards and the DSpark draft
weights, then failed during startup profiling:

```text
model_runner.profile_run()
flashmla.py:99: assert self.topk_indices_buffer is not None
AssertionError
```

The API server never became healthy.

### After the fix

The same deployment completed model profiling, KV-cache creation, kernel
warmup, and API startup:

| Result | Value |
| --- | --- |
| API health | HTTP 200 |
| Main + draft model memory after load | 156.32 GiB |
| Available KV-cache memory | 81.01 GiB |
| KV-cache capacity | 9,222,468 tokens |
| Reported 1M-context concurrency | 8.80x |
| Engine initialization time | 420.82 s, including first-run B300 JIT |
| Target assertion occurrences | 0 |
| Chat completion HTTP 200 responses | 3/3 |

Functional results:

- The arithmetic response computed `17 * 19 = 323`.
- The Chinese request returned a coherent one-sentence response and stopped
  normally.
- The streaming request emitted `1,2,3,4,5`, included the final usage chunk,
  and terminated with `[DONE]`.

DSpark metrics after these requests:

```text
vllm:spec_decode_num_drafts_total                  20
vllm:spec_decode_num_draft_tokens_total            140
vllm:spec_decode_num_accepted_tokens_total         51
```

These counters confirm that the patched service did not merely start; it also
executed DSpark speculative decoding successfully.

OpenAI Codex assisted with implementation, isolated test automation, B300
validation, and PR drafting.

I reviewed every changed line and the reported test evidence, and I understand
and can explain the change end to end.
