### PR TITLE
[Spec Decode] Fix FA3 AOT scheduler head count mismatch for DFlash/DSpark

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1393,7 +1393,7 @@ class SpeculativeConfig:
         return self.method in ("eagle", "eagle3", "mtp", "dflash", "dspark")
 
     def use_dflash(self) -> bool:
-        return self.method == "dflash"
+        return self.method in ("dflash", "dspark")
 
     def use_dspark(self) -> bool:
         return self.method == "dspark"

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -28,7 +28,7 @@ class DFlashProposer(SpecDecodeBaseProposer):
         runner=None,
     ):
         assert vllm_config.speculative_config is not None
-        assert vllm_config.speculative_config.method == "dflash"
+        assert vllm_config.speculative_config.method in ("dflash", "dspark")
         super().__init__(
             vllm_config=vllm_config,
             device=device,

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -354,6 +354,8 @@ class SpecDecodeBaseProposer:
         dflash_config = getattr(model_hf_config, "dflash_config", None)
         if dflash_config and "mask_token_id" in dflash_config:
             self.parallel_drafting_token_id = dflash_config["mask_token_id"]
+        elif hasattr(model_hf_config, "mask_token_id"):
+            self.parallel_drafting_token_id = model_hf_config.mask_token_id
         elif hasattr(model_hf_config, "pard_token"):
             self.parallel_drafting_token_id = model_hf_config.pard_token
         elif hasattr(model_hf_config, "ptd_token_id"):

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -360,7 +360,6 @@ class SpecDecodeBaseProposer:
             self.parallel_drafting_token_id = model_hf_config.ptd_token_id
         else:
             self.parallel_drafting_token_id = 0
-            self.pass_hidden_states_to_model = False
 
         if self.pass_hidden_states_to_model:
             self.parallel_drafting_hidden_state_tensor = torch.empty(

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -359,11 +359,8 @@ class SpecDecodeBaseProposer:
         elif hasattr(model_hf_config, "ptd_token_id"):
             self.parallel_drafting_token_id = model_hf_config.ptd_token_id
         else:
-            raise ValueError(
-                "For parallel drafting, the draft model config must have "
-                "`pard_token`, `ptd_token_id`, or "
-                "`dflash_config.mask_token_id` specified in its config.json."
-            )
+            self.parallel_drafting_token_id = 0
+            self.pass_hidden_states_to_model = False
 
         if self.pass_hidden_states_to_model:
             self.parallel_drafting_hidden_state_tensor = torch.empty(
@@ -523,7 +520,7 @@ class SpecDecodeBaseProposer:
         self._last_draft_probs = None
         batch_size = common_attn_metadata.batch_size()
 
-        if self.method in ("eagle3", "dflash"):
+        if self.method in ("eagle3", "dflash", "dspark"):
             model = self.model
             if isinstance(model, BreakableCUDAGraphWrapper):
                 model = model.unwrap()
@@ -1012,7 +1009,7 @@ class SpecDecodeBaseProposer:
             return bool(
                 {"DeepSeekMTPModel", "KimiK3MTPModel"}.intersection(architectures)
             )
-        return self.method not in ("mtp", "draft_model", "dflash")
+        return self.method not in ("mtp", "draft_model", "dflash", "dspark")
 
     def prepare_next_token_ids_cpu(
         self,

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -354,8 +354,6 @@ class SpecDecodeBaseProposer:
         dflash_config = getattr(model_hf_config, "dflash_config", None)
         if dflash_config and "mask_token_id" in dflash_config:
             self.parallel_drafting_token_id = dflash_config["mask_token_id"]
-        elif hasattr(model_hf_config, "mask_token_id"):
-            self.parallel_drafting_token_id = model_hf_config.mask_token_id
         elif hasattr(model_hf_config, "pard_token"):
             self.parallel_drafting_token_id = model_hf_config.pard_token
         elif hasattr(model_hf_config, "ptd_token_id"):

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import copy
 from collections.abc import Mapping
 from typing import Any
 
@@ -98,14 +99,14 @@ class DFlashSpeculator(DraftModelSpeculator):
 
     @property
     def attn_vllm_config(self) -> VllmConfig:
-        # The draft's attention differs from the target's in causality.
-        return replace(
-            self.vllm_config,
-            attention_config=replace(
-                self.vllm_config.attention_config,
-                use_non_causal=self.requires_non_causal,
-            ),
+        # Shallow copy to avoid re-running VllmConfig's pydantic validators
+        # (which reject expert-parallel with non-MoE draft model_config).
+        cfg = copy.copy(self.vllm_config)
+        cfg.attention_config = replace(
+            self.vllm_config.attention_config,
+            use_non_causal=self.requires_non_causal,
         )
+        return cfg
 
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
         wants_full = cudagraph_mode.decode_mode() == CUDAGraphMode.FULL
@@ -174,6 +175,22 @@ class DFlashSpeculator(DraftModelSpeculator):
             target_input_buffers,
             target_attn_groups,
         )
+
+        # FA3 AOT scheduling reads num_heads_q/kv/headdim from model_config
+        # (the TARGET model). When GQA ratios differ between target and draft,
+        # pack_gqa decisions diverge causing scheduler_metadata shape mismatch.
+        # Patch the draft metadata builders to use draft head counts.
+        pc = self.vllm_config.parallel_config
+        draft_heads_q = self.draft_model_config.get_num_attention_heads(pc)
+        draft_heads_kv = self.draft_model_config.get_num_kv_heads(pc)
+        draft_headdim = self.draft_model_config.get_head_size()
+        for groups in self.attn_groups:
+            for group in groups:
+                builder = group.get_metadata_builder(0)
+                if hasattr(builder, 'num_heads_q'):
+                    builder.num_heads_q = draft_heads_q
+                    builder.num_heads_kv = draft_heads_kv
+                    builder.headdim = draft_headdim
 
         self.draft_kv_cache_group_ids = [
             gid for gid, g in enumerate(self.attn_groups) if g


### PR DESCRIPTION
## Summary

Fix DSpark speculative decoding, which is completely broken on current main. Two categories of bugs:

1. **FA3 AOT scheduler head count mismatch** — `RuntimeError: scheduler_metadata must have shape (metadata_size)` when draft and target models have different GQA ratios.

2. **DSpark not routed through DFlashProposer** — multiple code paths only check for `"dflash"` and exclude `"dspark"`, even though `DSparkSpeculator` extends `DFlashSpeculator` and both use `DFlashProposer`. This causes `ValueError` crashes at inference time.

## Root Causes & Fixes

### FA3 AOT scheduler (original commit)

`FlashAttentionMetadataBuilder` reads head counts from the **target** model config, but `fwd()` derives them from draft Q/K/V tensor shapes. When GQA ratios differ, `pack_gqa` decisions diverge and the shape check fails.

**Fix:** Patch draft metadata builders' `num_heads_q`, `num_heads_kv`, `headdim` to match the draft model after creation in `set_attn()`. Also replace `replace(self.vllm_config, ...)` in `attn_vllm_config` with `copy.copy()` to avoid re-triggering pydantic validators.

### DSpark routing (second commit)

1. **`use_dflash()`** returns `self.method == "dflash"` — excludes DSpark, so model runner never creates `DFlashProposer` or sets `use_aux_hidden_state_outputs = True`
2. **`DFlashProposer.__init__`** asserts `method == "dflash"` — rejects DSpark even if routing is fixed
3. **`llm_base_proposer.py`**: `model_returns_tuple()` and `combine_hidden_states` gate don't include `"dspark"` — causes `ValueError: too many values to unpack` and dimension mismatches
4. **`parallel_drafting_token_id`** raises `ValueError` for models without `pard_token`/`ptd_token_id` — DSpark speculators may not have these

**Fix:** Include `"dspark"` alongside `"dflash"` in all relevant checks. Fall back to default `parallel_drafting_token_id = 0` instead of crashing.

Fixes #50851

## Test plan

- [x] Tested with GLM-5.2-FP8 + `RedHatAI/GLM-5.2-speculator.dspark` (DSpark, 5 speculative tokens) on multi-node Wide-EP (H200, 8 GPUs/node, DP=16, EP enabled)
- [x] Verified no `scheduler_metadata` shape mismatch errors
- [x] Verified no pydantic validation errors at startup
- [x] Verified DSpark engine starts successfully with `Using auxiliary layers from speculative config: (2, 20, 39, 58, 75)`
- [x] Verified smoke test (chat completions) passes with DSpark speculative decoding
- [x] GSM8K eval in progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)