### PR TITLE
docs: fix broken link in docs/benchmarking/cli.md

### DIFF
--- a/docs/benchmarking/cli.md
+++ b/docs/benchmarking/cli.md
@@ -1321,7 +1321,7 @@ vllm bench mm-processor \
   --output-json results.json
 ```
 
-See [`vllm bench mm-processor`](../cli/bench/mm_processor.md) for the full argument reference.
+See [`vllm bench mm-processor`](https://docs.vllm.ai/en/latest/cli/bench/mm_processor/) for the full argument reference.
 
 </details>
 


### PR DESCRIPTION
Replaced a broken relative link to ../cli/bench/mm_processor.md with the canonical online reference (https://docs.vllm.ai/en/latest/cli/bench/mm_processor/). Ran scan_docs.py to verify the original broken-link finding is gone. No other files changed.