### PR TITLE
[BugFix][KV Connector] Handle DeepSeek-V4 hybrid KV load failures

### DIFF
--- a/tests/v1/kv_connector/unit/test_kv_load_failure_recovery.py
+++ b/tests/v1/kv_connector/unit/test_kv_load_failure_recovery.py
@@ -2,12 +2,21 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from collections.abc import Callable
-from unittest.mock import Mock
+from typing import Literal
+from unittest.mock import Mock, patch
 
 import pytest
+import torch
 
+from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.core.sched.scheduler import Scheduler
-from vllm.v1.request import Request, RequestStatus
+from vllm.v1.kv_cache_interface import (
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MLAAttentionSpec,
+    SlidingWindowMLASpec,
+)
+from vllm.v1.request import FinishReason, Request, RequestStatus
 
 from .utils import (
     create_model_runner_output,
@@ -337,3 +346,225 @@ def test_async_progressive_load_failure(
         assert request.status == RequestStatus.WAITING_FOR_REMOTE_KVS
         assert scheduler.failed_recving_kv_req_ids == {request.request_id}
         assert scheduler.connector.get_num_new_matched_tokens.call_count == 1
+
+
+def _make_deepseek_v4_five_group_config(num_blocks: int) -> KVCacheConfig:
+    """Build the scheduler-side projection of V4-Flash's packed KV layout."""
+
+    def mla_spec() -> MLAAttentionSpec:
+        return MLAAttentionSpec(
+            block_size=256,
+            num_kv_heads=1,
+            head_size=512,
+            dtype=torch.bfloat16,
+            compress_ratio=4,
+            model_version="deepseek_v4",
+        )
+
+    def swa_spec(
+        *, block_size: int, sliding_window: int, head_size: int
+    ) -> SlidingWindowMLASpec:
+        return SlidingWindowMLASpec(
+            block_size=block_size,
+            num_kv_heads=1,
+            head_size=head_size,
+            dtype=torch.float32,
+            sliding_window=sliding_window,
+            model_version="deepseek_v4",
+        )
+
+    # DeepSeek-V4 packs these into five physical groups. The two SWA groups
+    # have identical scheduling semantics but are split to align layer tuples.
+    groups = [
+        KVCacheGroupSpec(["full_mla_and_indexer"], mla_spec()),
+        KVCacheGroupSpec(
+            ["c4_state"],
+            swa_spec(block_size=4, sliding_window=8, head_size=2048),
+        ),
+        KVCacheGroupSpec(
+            ["c128_state"],
+            swa_spec(block_size=8, sliding_window=128, head_size=2048),
+        ),
+        KVCacheGroupSpec(
+            ["swa.0"],
+            swa_spec(block_size=64, sliding_window=512, head_size=512),
+        ),
+        KVCacheGroupSpec(
+            ["swa.1"],
+            swa_spec(block_size=64, sliding_window=512, head_size=512),
+        ),
+    ]
+    return KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=groups,
+    )
+
+
+def _create_deepseek_v4_scheduler(
+    kv_load_failure_policy: Literal["recompute", "fail"] = "recompute",
+) -> Scheduler:
+    num_blocks = 10000
+    vllm_config = create_vllm_config(
+        block_size=256,
+        max_num_batched_tokens=4096,
+        max_model_len=8192,
+        kv_load_failure_policy=kv_load_failure_policy,
+    )
+    return create_scheduler(
+        vllm_config,
+        num_blocks=num_blocks,
+        kv_cache_config=_make_deepseek_v4_five_group_config(num_blocks),
+        hash_block_size=4,
+    )
+
+
+@pytest.fixture
+def deepseek_v4_scheduler() -> Scheduler:
+    return _create_deepseek_v4_scheduler()
+
+
+def _schedule_deepseek_v4_async_load(
+    scheduler: Scheduler,
+) -> tuple[Request, SchedulerOutput]:
+    num_external_tokens = 8 * scheduler.block_size
+    request = create_request(num_tokens=9 * scheduler.block_size, block_size=4)
+    scheduler.add_request(request)
+
+    scheduler.connector = Mock()
+    scheduler.connector.get_num_new_matched_tokens.side_effect = (
+        _make_get_num_new_matched_tokens(
+            {request.request_id: num_external_tokens}, async_load=True
+        )
+    )
+    scheduler.connector.take_events.return_value = ()
+    return request, scheduler.schedule()
+
+
+@pytest.mark.parametrize("failed_group_idx", range(5))
+def test_deepseek_v4_load_failure_recomputes_whole_request(
+    deepseek_v4_scheduler: Scheduler, failed_group_idx: int
+):
+    """A failed load in any V4-Flash KV group must not kill EngineCore."""
+    request, scheduler_output = _schedule_deepseek_v4_async_load(deepseek_v4_scheduler)
+
+    block_ids_per_group = deepseek_v4_scheduler.kv_cache_manager.get_block_ids(
+        request.request_id
+    )
+    assert len(block_ids_per_group) == 5
+    null_block_id = (
+        deepseek_v4_scheduler.kv_cache_manager.block_pool.null_block.block_id
+    )
+    failed_block_id = next(
+        block_id
+        for block_id in block_ids_per_group[failed_group_idx]
+        if block_id != null_block_id
+    )
+
+    deepseek_v4_scheduler.update_from_output(
+        scheduler_output,
+        create_model_runner_output(
+            reqs=[],
+            finished_recving=set(),
+            invalid_block_ids={failed_block_id},
+            use_eos=True,
+        ),
+    )
+
+    assert request.num_computed_tokens == 0
+    assert request.status == RequestStatus.WAITING_FOR_REMOTE_KVS
+    assert deepseek_v4_scheduler.failed_recving_kv_req_ids == {request.request_id}
+
+
+def test_deepseek_v4_load_failure_ignores_shared_null_block(
+    deepseek_v4_scheduler: Scheduler,
+):
+    """The shared null block contains no request KV and cannot fail a load."""
+    request, scheduler_output = _schedule_deepseek_v4_async_load(deepseek_v4_scheduler)
+    null_block_id = (
+        deepseek_v4_scheduler.kv_cache_manager.block_pool.null_block.block_id
+    )
+    block_ids_per_group = deepseek_v4_scheduler.kv_cache_manager.get_block_ids(
+        request.request_id
+    )
+    assert any(null_block_id in group for group in block_ids_per_group[1:])
+    num_computed_tokens = request.num_computed_tokens
+
+    deepseek_v4_scheduler.update_from_output(
+        scheduler_output,
+        create_model_runner_output(
+            reqs=[],
+            finished_recving=set(),
+            invalid_block_ids={null_block_id},
+            use_eos=True,
+        ),
+    )
+
+    assert request.num_computed_tokens == num_computed_tokens
+    assert not deepseek_v4_scheduler.failed_recving_kv_req_ids
+
+
+def test_deepseek_v4_sync_load_failure_fails_and_evicts_real_blocks():
+    """Fail policy must terminate cleanly and never evict the null block."""
+    scheduler = _create_deepseek_v4_scheduler(kv_load_failure_policy="fail")
+    num_external_tokens = 8 * scheduler.block_size
+    request = create_request(num_tokens=9 * scheduler.block_size, block_size=4)
+    scheduler.add_request(request)
+
+    scheduler.connector = Mock()
+    scheduler.connector.get_num_new_matched_tokens.side_effect = (
+        _make_get_num_new_matched_tokens(
+            {request.request_id: num_external_tokens}, async_load=False
+        )
+    )
+    scheduler.connector.request_finished.return_value = (False, None)
+    scheduler.connector.take_events.return_value = ()
+    scheduler_output = scheduler.schedule()
+
+    block_ids_per_group = scheduler.kv_cache_manager.get_block_ids(request.request_id)
+    assert len(block_ids_per_group) == 5
+    null_block_id = scheduler.kv_cache_manager.block_pool.null_block.block_id
+    real_block_ids = {
+        block_id
+        for group_block_ids in block_ids_per_group
+        for block_id in group_block_ids
+        if block_id != null_block_id
+    }
+    failed_block_id = next(
+        block_id for block_id in block_ids_per_group[2] if block_id != null_block_id
+    )
+
+    evicted_block_ids: list[set[int]] = []
+    original_evict_blocks = scheduler.kv_cache_manager.evict_blocks
+
+    def evict_blocks_spy(block_ids: set[int]) -> None:
+        evicted_block_ids.append(set(block_ids))
+        original_evict_blocks(block_ids)
+
+    with (
+        patch.object(
+            scheduler.kv_cache_manager,
+            "evict_blocks",
+            side_effect=evict_blocks_spy,
+        ),
+        patch.object(scheduler, "_connector_finished", return_value=(False, None)),
+    ):
+        outputs = scheduler.update_from_output(
+            scheduler_output,
+            create_model_runner_output(
+                [request],
+                invalid_block_ids={failed_block_id},
+                use_eos=True,
+            ),
+        )
+
+    assert request.status == RequestStatus.FINISHED_ERROR
+    assert request.get_finished_reason() == FinishReason.ERROR
+    assert request.request_id not in scheduler.requests
+    assert evicted_block_ids == [real_block_ids]
+    assert null_block_id not in evicted_block_ids[0]
+
+    engine_outputs = next(iter(outputs.values()))
+    assert len(engine_outputs.outputs) == 1
+    assert engine_outputs.outputs[0].request_id == request.request_id
+    assert engine_outputs.outputs[0].finish_reason == FinishReason.ERROR

--- a/tests/v1/kv_connector/unit/utils.py
+++ b/tests/v1/kv_connector/unit/utils.py
@@ -153,6 +153,7 @@ def create_scheduler(
     vllm_config: VllmConfig,
     num_blocks: int = 10000,
     kv_cache_config: KVCacheConfig | None = None,
+    hash_block_size: int | None = None,
 ) -> Scheduler | AsyncScheduler:
     """Initialize Scheduler For Testing."""
     block_size = vllm_config.cache_config.block_size
@@ -183,6 +184,7 @@ def create_scheduler(
         log_stats=True,
         structured_output_manager=StructuredOutputManager(vllm_config),
         block_size=block_size,
+        hash_block_size=hash_block_size,
     )
 
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2755,6 +2755,11 @@ class Scheduler(SchedulerInterface):
         For observability, it also accumulates the total number of tokens that
         will need to be recomputed across all affected requests.
 
+        Hybrid KV cache groups can use different block grids, so a block index
+        does not identify one common token boundary across all groups. Affected
+        hybrid requests therefore restart from the beginning instead of trying
+        to derive an unsafe partial prefix.
+
         Args:
             requests: The set of requests to scan for invalid blocks.
             invalid_block_ids: IDs of invalid blocks.
@@ -2774,21 +2779,44 @@ class Scheduler(SchedulerInterface):
         affected_req_ids: set[str] = set()
         total_affected_tokens = 0
         blocks_to_evict: set[int] = set()
-        # If a block is invalid and shared by multiple requests in the batch,
-        # these requests must be rescheduled, but only the first will recompute
-        # it. This set tracks blocks already marked for recomputation.
+        # For a single cache group, shared invalid blocks need only be
+        # recomputed by the first affected request in the batch.
         marked_invalid_block_ids: set[int] = set()
+        # Windowed groups use one shared null block for token positions that do
+        # not retain KV. It contains no request data and must never make a
+        # request look affected or be evicted on a request's behalf.
+        null_block_id = self.kv_cache_manager.block_pool.null_block.block_id
         for request in requests:
             is_affected = False
             marked_invalid_block = False
             req_id = request.request_id
-            # TODO (davidb): add support for hybrid memory allocator
-            (req_block_ids,) = self.kv_cache_manager.get_block_ids(req_id)
+            req_block_ids_per_group = self.kv_cache_manager.get_block_ids(req_id)
             # We iterate only over blocks that may contain externally computed
             # tokens
             req_num_computed_tokens = (
                 request.num_computed_tokens - num_scheduled_tokens.get(req_id, 0)
             )
+
+            if len(req_block_ids_per_group) > 1:
+                has_invalid_block = any(
+                    block_id != null_block_id and block_id in invalid_block_ids
+                    for req_block_ids in req_block_ids_per_group
+                    for block_id in req_block_ids
+                )
+                if has_invalid_block:
+                    total_affected_tokens += req_num_computed_tokens
+                    request.num_computed_tokens = 0
+                    if evict_blocks:
+                        blocks_to_evict.update(
+                            block_id
+                            for req_block_ids in req_block_ids_per_group
+                            for block_id in req_block_ids
+                            if block_id != null_block_id
+                        )
+                    affected_req_ids.add(req_id)
+                continue
+
+            (req_block_ids,) = req_block_ids_per_group
 
             req_num_computed_blocks = (
                 req_num_computed_tokens + self.block_size - 1


### PR DESCRIPTION
## Purpose

Fixes #50687.

`Scheduler._update_requests_with_invalid_blocks()` currently assumes that
`get_block_ids()` returns exactly one block-id list. DeepSeek-V4-Flash-0731
uses five physical KV cache groups with different block grids, so the first
connector load failure raises:

```text
ValueError: too many values to unpack (expected 1)
```

That exception escapes the scheduler and terminates EngineCore.

This change:

- keeps the existing precise block-level rewind for single-group models;
- conservatively restarts an affected multi-group request from token zero,
  because one block index cannot identify a safe common token boundary across
  groups with different block sizes;
- ignores the shared null block, which contains no request KV;
- collects every non-null request block for eviction under
  `kv_load_failure_policy="fail"`.

The regression fixture models the five-group DeepSeek-V4 scheduler layout:
full MLA/indexer, C4 state, C128 state, and two split SWA groups. It injects a
load failure into every group independently and also covers null-block and
fail-policy behavior.

Related work: #50388 validates the same conservative recovery direction on a
Kimi/Mamba two-group layout, while #48216 explores group-aware partial
recovery. Thanks @kebe7jun and @ClockOfDestiny for the prior investigation.
This PR adds the DeepSeek-V4-Flash-0731-specific five-group regression and
fail-policy coverage requested in #50687.

## Test Plan

```bash
python3 -m pytest \
  tests/v1/kv_connector/unit/test_kv_load_failure_recovery.py \
  tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py -q

ruff check \
  vllm/v1/core/sched/scheduler.py \
  tests/v1/kv_connector/unit/test_kv_load_failure_recovery.py \
  tests/v1/kv_connector/unit/utils.py

ruff format --check \
  vllm/v1/core/sched/scheduler.py \
  tests/v1/kv_connector/unit/test_kv_load_failure_recovery.py \
  tests/v1/kv_connector/unit/utils.py
```

The scheduler tests were run in an isolated B300 test pod with Python 3.12.
For runtime parity, the test harness resolved the cached
DeepSeek-V4-Flash-0731 snapshot; startup logs confirmed
`DeepseekV4ForCausalLM` and its 1,048,576-token model limit. These are CPU
scheduler tests and do not depend on GPU kernels.

## Test Result

Before this change, all seven new DeepSeek-V4 cases fail at the tuple unpack:

```text
7 failed, 11 deselected
ValueError: too many values to unpack (expected 1)
```

After this change:

```text
.....................                                                    [100%]
21 passed, 16 warnings in 8.61s
```

The seven focused DeepSeek-V4 cases also pass independently:

```text
.......                                                                  [100%]
7 passed, 11 deselected in 8.24s
```

Ruff lint and format checks pass for all modified files.

No documentation update is required because this fixes scheduler recovery
behavior without changing a public API or configuration.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, including the issue it resolves.
- [x] The test plan, including exact commands.
- [x] The before/after test results.
- [x] Documentation impact considered; no update is required.
</details>
