### PR TITLE
[Bugfix][Models] Accept Qwen3_5MoeTextConfig in Qwen3_5MoeProcessingInfo for transformers 5.x compatibility

### DIFF
--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -108,7 +108,11 @@ class Qwen3_5ProcessingInfo(Qwen3VLProcessingInfo):
 
 class Qwen3_5MoeProcessingInfo(Qwen3VLProcessingInfo):
     def get_hf_config(self):
-        return self.ctx.get_hf_config(Qwen3_5MoeConfig)
+        # transformers 5.x renames the top-level Qwen3.5-MoE config class to
+        # Qwen3_5MoeTextConfig for text-only models, while transformers ≤4.x
+        # returns Qwen3_5MoeConfig (the multimodal wrapper).  Accept both so
+        # that vLLM works regardless of which transformers version is installed.
+        return self.ctx.get_hf_config((Qwen3_5MoeConfig, Qwen3_5MoeTextConfig))
 
 
 class Qwen3_5DecoderLayer(Qwen3NextDecoderLayer):


### PR DESCRIPTION
## Purpose

Fix #50428: vLLM fails to load Qwen3.5-MoE text-only models (e.g. `Qwen3.6-35B-A3B`) when transformers 5.x is installed.

In transformers 5.x, the top-level config class for Qwen3.5-MoE text-only models was renamed from `Qwen3_5MoeConfig` (the multimodal VL wrapper) to `Qwen3_5MoeTextConfig`. `Qwen3_5MoeProcessingInfo.get_hf_config()` hardcoded the wrapper type, so loading any Qwen3.5-MoE text-only model with transformers 5.x raised:

```
TypeError: Invalid type of HuggingFace config.
Expected type: <class 'vllm.transformers_utils.configs.qwen3_5_moe.Qwen3_5MoeConfig'>
but found type: <class 'transformers.models.qwen3_5_moe.configuration_qwen3_5_moe.Qwen3_5MoeTextConfig'>
```

**Root cause:** `Qwen3_5MoeProcessingInfo.get_hf_config()` passes a single type `Qwen3_5MoeConfig` to `ctx.get_hf_config()`, which performs `isinstance(hf_config, typ)`. When transformers 5.x returns `Qwen3_5MoeTextConfig`, which is not a subclass of `Qwen3_5MoeConfig`, the check fails.

**Fix:** `ctx.get_hf_config()` already accepts a `tuple[type, ...]" via the existing `isinstance` check and its method signature. Passing `(Qwen3_5MoeConfig, Qwen3_5MoeTextConfig)` covers both transformers generations with no other changes.

## Test Plan

The bug requires a Qwen3.5-MoE model checkpoint and a GPU env; a dedicated CI test against both transformers 4.x and 5.x is not currently in scope for this PR. The fix has been verified by:

1. Static analysis: the existing `get_hf_config` overloads in `context.py` explicitly type the `typ` parameter as `type[_C] | tuple[type[_C], ...]`, confirming tuple input is the intended API.
2. Python built-in behaviour: `isinstance(obj, (TypeA, TypeB))` is idiomatic and well-tested — no change in semantics for transformers 4.x paths (where the actual config is `Qwen3_5MoeConfig` and remains in the tuple).
3. Syntax-only local check: `python3 -c "import ast; ast.parse(open('vllm/model_executor/models/qwen3_5.py').read())"` passes.

## Test Result

Local syntax OK; runtime test requires GPU + model checkpoint (Qwen3.6-35B-A3B or similar) with transformers>=5.0 installed.