### PR TITLE
[Bugfix] benchmark_moe: do not abort tuning when a candidate config fails Triton compilation

### DIFF
--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -650,6 +650,16 @@ class BenchmarkWorker:
                 except triton.runtime.autotuner.OutOfResources:
                     # Some configurations may be invalid and fail to compile.
                     continue
+                except Exception as e:
+                    # Compilation can also fail with other exception types
+                    # (e.g. Triton MLIR pass errors on newer architectures).
+                    # These are candidate-local: skip them instead of aborting
+                    # the entire tuning run.
+                    print(
+                        f"Skipping config {config}: {type(e).__name__}",
+                        flush=True,
+                    )
+                    continue
 
                 if kernel_time < best_time:
                     best_time = kernel_time


### PR DESCRIPTION
## Purpose

`benchmark_moe.py --tune` catches only `triton.runtime.autotuner.OutOfResources`
in its per-candidate loop, with the comment "Some configurations may be invalid
and fail to compile." But invalid candidates can also fail compilation with
other exception types. On an RTX PRO 6000 Blackwell Server Edition (sm_120,
triton 3.6.0), one candidate crashed the Triton compiler:

```
vllm/model_executor/layers/fused_moe/fused_moe.py:295:0: error: Failures have
been detected while processing an MLIR pass pipeline
note: Pipeline failed while executing [`TritonGPURemoveLayoutConversions` on
'builtin.module' operation]
```

That exception escaped the handler ~2.5 hours into a tune and aborted the whole
run with zero configs saved. This PR broadens the per-candidate boundary so such
failures are skipped (with a log line naming the config and exception class),
matching the intent the existing comment already states.

The `try` block wraps exactly one `benchmark_config(...)` call — best-config
bookkeeping is outside it — and `KeyboardInterrupt`/`SystemExit` still propagate
(`Exception` excludes `BaseException` subclasses). `OutOfResources` keeps its
existing silent-skip behavior. If every candidate for a key fails, the existing
`assert best_config is not None` still fires.

This PR does not claim the resulting tuned config improves end-to-end
performance; the claim is only that candidate-local compile failures no longer
destroy the tuning run.

## Test Plan

Re-run the sweep that previously crashed, on the same hardware, from this
branch:

```
for bs in 1 4 16 64 128 256; do
  python benchmarks/kernels/benchmark_moe.py \
    --model Qwen/Qwen3-30B-A3B --tune --trust-remote-code \
    --dtype auto -tp 1 --save-dir <dir> --batch-size "$bs"
done
```

## Test Result

Environment: NVIDIA RTX PRO 6000 Blackwell Server Edition (sm_120), driver
580.82.07, torch 2.11.0+cu130, vLLM 0.26.0 runtime, triton 3.6.0.

Validation rerun of the six-key sweep from this branch (cae1f8d0b):

| batch-size key | exit code | elapsed | candidates skipped by the new handler |
|---:|---:|---:|---:|
| 1 | 0 | 26.3 min | 0 |
| 4 | 0 | 27.8 min | 0 |
| 16 | 0 | 28.0 min | 48 |
| 64 | 0 | 7.9 min | 48 |
| 128 | 0 | 8.0 min | 48 |
| 256 | 0 | 8.3 min | 48 |

All six sweeps completed and produced
`E=128,N=768,device_name=NVIDIA_RTX_PRO_6000_Blackwell_Server_Edition.json`.
Under the unpatched tuner, the first of those 192 failing candidates aborts the
entire run — which is how the original ~2.5 h sweep was lost.

---

This PR was developed with AI assistance (Claude); I reviewed, adapted, and
validated the change and the measurements myself.
