### PR TITLE
[ROCm][Bugfix] Populate AiterMLADecodeMetadata.min_kv_seq_len for Gluon decode

### DIFF
--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -583,6 +583,20 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
             self.num_heads, int(max_qo_len)
         )
 
+        # Gluon sizes its split count from this hint: it must not split a request
+        # into more pieces than it has blocks, so it needs the shortest row the
+        # kernel will actually see. That is seq_lens_for_kernel rather than
+        # seq_lens_device, because the uniform-MTP padding above rewrites the
+        # empty rows. Left at the field default of 1 the kernel computes
+        # cdiv(1, BLOCK_N) == 1 split and launches a single workgroup per
+        # request, which badly underfills the GPU at long context.
+        #
+        # This is a device-to-host sync, so only the Gluon path pays it; the ASM
+        # decode path does not read the field.
+        min_kv_seq_len = 1
+        if use_gluon_decode and num_kernel_reqs:
+            min_kv_seq_len = int(seq_lens_for_kernel.min())
+
         if self.compilation_config.cudagraph_mode.has_full_cudagraphs():
             self.paged_kv_indices.fill_(-1)
 
@@ -697,6 +711,7 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
             qo_indptr=qo_indptr,
             dcp_tot_seq_lens=dcp_tot_seq_lens_device,
             max_qo_len=max_qo_len,
+            min_kv_seq_len=min_kv_seq_len,
             use_gluon_decode=use_gluon_decode,
             attn_out_dtype=self.decode_attn_out_dtype,
             has_persistent_metadata=has_persistent_metadata,


### PR DESCRIPTION
## Purpose

`AiterMLADecodeMetadata` declares

```python
# Minimum KV length used by Gluon to choose a safe split count.
min_kv_seq_len: int = 1
```

but `AiterMLAMetadataBuilder._build_decode()` never assigns it — the metadata is constructed with 11
fields and this is not one of them, so it keeps the dataclass default. The only other writer is the
separate multi-token branch, which the ordinary decode path does not take. Decode therefore always
forwards `1` into `mla_gluon(...)`.

aiter bounds its split count by `cdiv(min_kv_seq_len, BLOCK_N)`. With the field left at 1 that is
`cdiv(1, 64) == 1`, so `NUM_KV_SPLITS` collapses to 1 and stage-1 launches a **single workgroup per
request**, each serially walking its entire sequence.

On Kimi-K3 TP8 / MI355X (12 heads per rank, batch 8, 327,600-token context) that is 8 workgroups on a
256-CU part: 3.1% occupancy, with `_mla_gluon` holding 85.9% of decode GPU time. Populating the field
restores the intended split count and measures **32.48 → 155.85 tok/s end to end (4.80x)**, median
TPOT 234.9 → 43.0 ms, GSM8K unchanged at 0.9250.

The fix:

```python
min_kv_seq_len = 1
if use_gluon_decode and num_kernel_reqs:
    min_kv_seq_len = int(seq_lens_for_kernel.min())
```

Three details are deliberate:

- **`seq_lens_for_kernel`, not `seq_lens_device`.** The uniform-MTP padding immediately above
  rewrites the empty rows, and the hint must describe the shortest row the kernel will actually see
  or aiter's "every split holds at least one block" invariant can be violated.
- **Guarded on `use_gluon_decode`.** The read is a device-to-host sync. `_build_decode()` currently
  has none — the existing `.item()` nearby is on `query_start_loc_cpu`, a CPU tensor — so an
  unguarded read would add a sync to every decode build, including the ASM path that never consults
  the field.
- **In `_build_decode()`, not at the attention call.** The split count becomes a kernel `constexpr`
  baked at graph-capture time, so it must be host-known during metadata build and must not be
  computed on the decode hot path.

Note this is a caller-side fix. aiter treats `min_kv_seq_len` as an optional hint whose default
silently degrades the launch, so the more robust fix belongs there — deriving the split count from
the page-table shape, which needs no host sync and cannot be defeated by a caller that forgets the
hint. That change is up as ROCm/aiter#4507. If it lands this PR becomes redundant but remains correct
and harmless, and it is still the only fix available to anyone pinned to an older aiter.

## Test Plan

**End-to-end.** 8x MI355X (gfx950), Kimi-K3 TP8, bf16 KV, 12 heads/rank. vLLM serving benchmark: ISL
18,264 plus a 308,736-token shared random prefix (327,600-token prompts), OSL 1,200, concurrency 8,
16 prompts, seed 42, prefix caching on, `cudagraph_mode=FULL_AND_PIECEWISE`. Reference and candidate
legs ran on the same node in the same container, serialized on a GPU lock, both to completion. A
separately locked baseline measured 34.897 tok/s over 3 timed rounds with 0.06% spread.

**Kernel-level.** The underlying kernel change was additionally validated against a frozen,
implementation-independent fp32 online-softmax reference at tol 2e-2 under capture-once /
replay-many, including ragged batches
(`seq_lens = [1, 63, 64, 65, 4096, 4097, 65536, 327600]`) and prefix-boundary batches
(`[308736, 308737, 312831, 312832, 312833, 320000, 327599, 327600]`).

**Accuracy.** GSM8K, 200 problems, on both legs of the same paired session.

**Existing tests.** `tests/kernels/attention/test_rocm_aiter_mla_causal_verify_mask.py` asserts this
hint on the multi-token path, which already computed it locally and is unaffected by this change.
`ruff check` and `ruff format` pass on the changed file.

## Test Result

```
NUM_KV_SPLITS handed to Gluon   1            ->  32
stage-1 launch grid             (8, 1) = 8 WGs on 256 CUs -> (8, 32) = 256 WGs
CU utilisation                  3.1%         ->  100%
_mla_gluon per call, in situ    8241.6 us    ->  270.7 us      (30.4x) *
share of decode GPU time        85.9%        ->  16.7%         *
end-to-end throughput           32.48        ->  155.85 tok/s  (4.80x)
median TPOT                     234.9 ms     ->  43.0 ms
GSM8K (200 problems)            0.9250       ->  0.9250        unchanged
```

\* the two in-situ rows come from a profile that also carried a follow-up aiter grid/epilogue change,
so they are not attributable to this one-line fix alone. Every other row is this change by itself.

Engagement was verified binary rather than inferred: `_mla_softmax_reducev_kernel` is provably
**absent** from the baseline trace (aiter's `NUM_KV_SPLITS == 1` fast path skips stage-2 entirely)
and present on all 8 workers afterwards.

Splitting changes the KV reduction order, so bitwise equality is not expected; 1 of 12 greedy probes
matched byte-for-byte and GSM8K was unchanged.

One caveat worth stating: with a 308,736-token shared prefix, run 1 of a leg pays a cold prefix fill
and run 2 hits a warm cache, so a single leg spreads up to 53% in throughput while TPOT stays stable.
The same ~22 s of cold prefill is ~7% of a 287 s reference run but ~30% of a 47 s candidate run, so
the artifact penalises the **faster** arm. The comparison above is position-matched (cold vs cold,
warm vs warm); the ranges do not overlap ([30.59, 34.36] vs [114.52, 197.18]) and even the worst
candidate against the best reference is 3.33x.

## AI assistance

This was found by [GEAK](https://github.com/AMD-AGI/GEAK), AMD's agentic GPU-kernel optimization
framework, running an end-to-end optimization pass against a live Kimi-K3 TP8 server on 8x MI355X.
GEAK produced the decode profile that identified `_mla_gluon` as 85.9% of decode GPU time, and ran
the paired A/B legs and the GSM8K accuracy gate reported above. Drafting of this description was
AI-assisted.

Verified before submitting, rather than taken from the tool's output:

- The defect was read directly out of the source on current `main` (`c67fe497a`), not inferred from
  timing: `min_kv_seq_len: int = 1` is declared on `AiterMLADecodeMetadata`, `_build_decode()`
  constructs the metadata with 11 fields and that is not one of them, and the only other assignment
  in the file is on the multi-token path.
- The choice of `seq_lens_for_kernel` over `seq_lens_device` was checked against the uniform-MTP
  padding immediately above it, which rewrites the empty rows.
- The sync cost was checked rather than assumed: the existing `.item()` in `_build_decode()` is on a
  CPU tensor, so this read would be the first device-to-host sync in that function — hence the
  `use_gluon_decode` guard, so the ASM path does not pay for a field it never reads.
- `ruff check` and `ruff format` pass on the changed file.
- The engagement claim rests on a binary, timing-independent signal: `_mla_softmax_reducev_kernel` is
  absent from the baseline trace and present on all 8 workers afterwards.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. — n/a, no user-facing behaviour or supported-model change.
</details>
