### PR TITLE
[Bugfix][Spec Decode] Support hybrid-attention DFlash drafters spanning multiple KV cache groups

### DIFF
--- a/tests/v1/spec_decode/test_llm_base_proposer.py
+++ b/tests/v1/spec_decode/test_llm_base_proposer.py
@@ -14,8 +14,11 @@ processes, so anything derived from iteration order must not leak into
 from types import SimpleNamespace
 
 import pytest
+import torch
 
 import vllm.v1.spec_decode.llm_base_proposer as llm_base_proposer
+from vllm.v1.kv_cache_interface import SlidingWindowSpec, UniformTypeKVCacheSpecs
+from vllm.v1.spec_decode.dflash import DFlashProposer
 from vllm.v1.spec_decode.eagle import EagleProposer
 
 SCHEDULER_BLOCK_SIZE = 256
@@ -110,3 +113,108 @@ def test_draft_layer_iteration_is_deterministic(monkeypatch: pytest.MonkeyPatch)
         assert len(proposer.draft_attn_groups) == 1
         assert proposer.draft_attn_groups[0].layer_names == expected_order
         assert proposer.block_size == KERNEL_BLOCK_SIZE
+
+
+SLIDING_LAYER = "draft.0.self_attn.attn"
+FULL_LAYER = "draft.5.self_attn.attn"
+
+
+def _make_hybrid_kv_cache_config() -> SimpleNamespace:
+    """Two KV cache groups, as a drafter mixing sliding and full attention
+    produces: separate specs with different head dimensions."""
+    sliding_spec = SimpleNamespace(block_size=SCHEDULER_BLOCK_SIZE, head_size=128)
+    full_spec = SimpleNamespace(block_size=SCHEDULER_BLOCK_SIZE, head_size=256)
+    return SimpleNamespace(
+        kv_cache_groups=[
+            SimpleNamespace(layer_names=[SLIDING_LAYER], kv_cache_spec=sliding_spec),
+            SimpleNamespace(layer_names=[FULL_LAYER], kv_cache_spec=full_spec),
+        ]
+    )
+
+
+def _make_dflash_proposer(
+    monkeypatch: pytest.MonkeyPatch, layer_names: set[str]
+) -> DFlashProposer:
+    proposer = _make_proposer(monkeypatch, layer_names)
+    proposer.__class__ = DFlashProposer
+    return proposer
+
+
+def test_dflash_hybrid_drafter_gets_one_group_per_spec(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A DFlash drafter mixing sliding and full attention spans two KV cache
+    groups (issue #50710).
+
+    Sharing one AttentionGroup across both would hand every draft layer the
+    same AttentionMetadata, which is only valid for one of the head
+    dimensions; the other reaches the kernel malformed.
+    """
+    layer_names = {SLIDING_LAYER, FULL_LAYER}
+    proposer = _make_dflash_proposer(monkeypatch, layer_names)
+
+    proposer.initialize_attn_backend(
+        _make_hybrid_kv_cache_config(), kernel_block_sizes=[KERNEL_BLOCK_SIZE] * 2
+    )
+
+    assert len(proposer.draft_attn_groups) == 2
+    grouped = {g.layer_names[0]: g for g in proposer.draft_attn_groups}
+    assert grouped[SLIDING_LAYER].kv_cache_spec.head_size == 128
+    assert grouped[FULL_LAYER].kv_cache_spec.head_size == 256
+    # Each group must carry its own KV cache group id for slot-mapping math.
+    assert grouped[SLIDING_LAYER].kv_cache_group_id == 0
+    assert grouped[FULL_LAYER].kv_cache_group_id == 1
+
+
+def test_dflash_single_group_drafter_is_unchanged(monkeypatch: pytest.MonkeyPatch):
+    """The common case — one KV cache group — must still yield one group."""
+    layer_names = {SLIDING_LAYER}
+    proposer = _make_dflash_proposer(monkeypatch, layer_names)
+
+    proposer.initialize_attn_backend(
+        _make_kv_cache_config(layer_names), kernel_block_sizes=[KERNEL_BLOCK_SIZE]
+    )
+
+    assert len(proposer.draft_attn_groups) == 1
+    assert proposer.block_size == KERNEL_BLOCK_SIZE
+
+
+def _make_sliding_spec() -> SlidingWindowSpec:
+    """A fresh spec object, as each layer's get_kv_cache_spec() builds."""
+    return SlidingWindowSpec(
+        block_size=SCHEDULER_BLOCK_SIZE,
+        num_kv_heads=8,
+        head_size=128,
+        head_size_v=128,
+        dtype=torch.float16,
+        sliding_window=512,
+    )
+
+
+def test_layers_with_equal_specs_share_one_group(monkeypatch: pytest.MonkeyPatch):
+    """Layers are grouped by spec value, not by spec object identity.
+
+    Each layer builds its own spec object, so grouping on identity would give
+    a drafter with many identical sliding layers one AttentionGroup — and one
+    metadata builder — per layer instead of one for all of them.
+    """
+    layer_names = {f"draft.{i}.self_attn.attn" for i in range(4)}
+    proposer = _make_dflash_proposer(monkeypatch, layer_names)
+
+    per_layer = {name: _make_sliding_spec() for name in sorted(layer_names)}
+    assert len({id(spec) for spec in per_layer.values()}) == len(per_layer)
+    assert len(set(per_layer.values())) == 1, "specs must be equal but distinct"
+
+    group = SimpleNamespace(
+        layer_names=sorted(layer_names),
+        kv_cache_spec=UniformTypeKVCacheSpecs(
+            block_size=SCHEDULER_BLOCK_SIZE, kv_cache_specs=per_layer
+        ),
+    )
+    proposer.initialize_attn_backend(
+        SimpleNamespace(kv_cache_groups=[group]),
+        kernel_block_sizes=[KERNEL_BLOCK_SIZE],
+    )
+
+    assert len(proposer.draft_attn_groups) == 1
+    assert proposer.draft_attn_groups[0].layer_names == sorted(layer_names)

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -11,6 +11,7 @@ from vllm.config import VllmConfig
 from vllm.forward_context import set_forward_context
 from vllm.logger import init_logger
 from vllm.v1.attention.backend import CommonAttentionMetadata
+from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.spec_decode.llm_base_proposer import SpecDecodeBaseProposer
 from vllm.v1.spec_decode.utils import (
     copy_and_expand_dflash_inputs_kernel,
@@ -292,6 +293,20 @@ class DFlashProposer(SpecDecodeBaseProposer):
         )
 
     @override
+    def validate_same_kv_cache_group(self, kv_cache_config: KVCacheConfig) -> None:
+        """DFlash drafters may mix sliding and full attention layers, which
+        land in different KV cache groups, so skip the base class single-group
+        assertion."""
+
+    def initialize_attn_backend(
+        self,
+        kv_cache_config: KVCacheConfig,
+        kernel_block_sizes: list[int] | None = None,
+    ) -> None:
+        """One AttentionGroup per KV cache spec, so a drafter that mixes
+        sliding and full attention gets a metadata builder per variant."""
+        self._initialize_multi_group_attn_backend(kv_cache_config, kernel_block_sizes)
+
     def build_per_group_and_layer_attn_metadata(
         self, cad: CommonAttentionMetadata, draft_index: int = 0
     ) -> tuple[list[object], dict[str, object]]:

--- a/vllm/v1/spec_decode/gemma4.py
+++ b/vllm/v1/spec_decode/gemma4.py
@@ -20,11 +20,8 @@ from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
-    KVCacheSpec,
-    UniformTypeKVCacheSpecs,
 )
 from vllm.v1.spec_decode.llm_base_proposer import SpecDecodeBaseProposer
-from vllm.v1.worker.utils import AttentionGroup
 
 logger = init_logger(__name__)
 
@@ -226,80 +223,9 @@ class Gemma4Proposer(SpecDecodeBaseProposer):
         kv_cache_config: KVCacheConfig,
         kernel_block_sizes: list[int] | None = None,
     ) -> None:
-        """Create separate AttentionGroup objects per KV cache spec
-        so that each head-dim variant gets its own metadata builder."""
-        all_attn_layers = get_layers_from_vllm_config(
-            self.vllm_config,
-            AttentionLayerBase,  # type: ignore[type-abstract]
-        )
-
-        layer_to_gid: dict[str, int] = {}
-        layer_to_spec: dict[str, KVCacheSpec] = {}
-        for gid, group in enumerate(kv_cache_config.kv_cache_groups):
-            group_spec = group.kv_cache_spec
-            for ln in group.layer_names:
-                layer_to_gid[ln] = gid
-                if isinstance(group_spec, UniformTypeKVCacheSpecs):
-                    if ln in group_spec.kv_cache_specs:
-                        layer_to_spec[ln] = group_spec.kv_cache_specs[ln]
-                    else:
-                        tgt = getattr(
-                            all_attn_layers.get(ln),
-                            "kv_sharing_target_layer_name",
-                            None,
-                        )
-                        if tgt and tgt in group_spec.kv_cache_specs:
-                            layer_to_spec[ln] = group_spec.kv_cache_specs[tgt]
-                        else:
-                            layer_to_spec[ln] = group_spec
-                else:
-                    layer_to_spec[ln] = group_spec
-
-        attention_groups: dict[tuple[tuple[str, str], KVCacheSpec], AttentionGroup] = {}
-        for layer_name in self._draft_attn_layer_names:
-            if layer_name not in layer_to_spec:
-                continue
-            attn_layer = all_attn_layers[layer_name]
-            attn_backend = attn_layer.get_attn_backend()
-            spec = layer_to_spec[layer_name]
-            gid = layer_to_gid[layer_name]
-            group_key = (attn_backend.full_cls_name(), spec)
-
-            if group_key not in attention_groups:
-                kernel_block_size = (
-                    kernel_block_sizes[gid]
-                    if kernel_block_sizes is not None and gid < len(kernel_block_sizes)
-                    else None
-                )
-                attn_group = AttentionGroup(
-                    backend=attn_backend,
-                    layer_names=[layer_name],
-                    kv_cache_spec=spec,
-                    kv_cache_group_id=gid,
-                )
-                attn_group.create_metadata_builders(
-                    self.vllm_config,
-                    self.device,
-                    kernel_block_size=kernel_block_size,
-                )
-                attention_groups[group_key] = attn_group
-            else:
-                attention_groups[group_key].layer_names.append(layer_name)
-
-        self.draft_attn_groups = list(attention_groups.values())
-        if self.draft_attn_groups:
-            self.kv_cache_gid = self.draft_attn_groups[0].kv_cache_group_id
-            self.block_size = (
-                self.draft_attn_groups[0]
-                .get_metadata_builder()
-                .kv_cache_spec.block_size
-            )
-        else:
-            self.kv_cache_gid = 0
-            self.block_size = kv_cache_config.kv_cache_groups[
-                0
-            ].kv_cache_spec.block_size
-        logger.debug("Using block size %d for drafting layers", self.block_size)
+        """One AttentionGroup per KV cache spec, so each head-dim
+        variant gets its own metadata builder."""
+        self._initialize_multi_group_attn_backend(kv_cache_config, kernel_block_sizes)
 
     def _setup_gemma4_kv_sharing(
         self,

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -39,7 +39,11 @@ from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.attention.backends.triton_attn import TritonAttentionMetadata
 from vllm.v1.cudagraph_dispatcher import CudagraphDispatcher
-from vllm.v1.kv_cache_interface import KVCacheConfig, UniformTypeKVCacheSpecs
+from vllm.v1.kv_cache_interface import (
+    KVCacheConfig,
+    KVCacheSpec,
+    UniformTypeKVCacheSpecs,
+)
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.ops.topk_topp_sampler import (
     empty_exponential_noise_like,
@@ -63,6 +67,47 @@ from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 from vllm.v1.worker.utils import AttentionGroup
 
 logger = init_logger(__name__)
+
+
+def _spec_group_key(spec: KVCacheSpec) -> Any:
+    """Hashable key identifying the attention group a spec belongs to.
+
+    Specs are frozen dataclasses, so layers whose specs are equal share one
+    group even though each layer builds its own object. Some specs are not
+    hashable — ``UniformTypeKVCacheSpecs`` holds a dict — and those only reach
+    here as the enclosing group spec, one object shared by every unresolved
+    layer of that group, so identity groups them the same way.
+    """
+    try:
+        hash(spec)
+    except TypeError:
+        return id(spec)
+    return spec
+
+
+def _resolve_layer_kv_cache_spec(
+    layer_name: str,
+    group_spec: KVCacheSpec,
+    all_attn_layers: dict[str, Any],
+) -> KVCacheSpec:
+    """Resolve the per-layer KV cache spec within a KV cache group.
+
+    ``UniformTypeKVCacheSpecs`` bundles several layers whose specs need the
+    same number of token slots but may still differ (e.g. in head dimension),
+    so the per-layer entry is preferred. A layer that shares another layer's
+    KV cache resolves through its target; groups rebuilt for a subset of
+    layers may not list it at all, in which case the group spec stands in.
+    """
+    if not isinstance(group_spec, UniformTypeKVCacheSpecs):
+        return group_spec
+    if layer_name in group_spec.kv_cache_specs:
+        return group_spec.kv_cache_specs[layer_name]
+    target_layer_name = getattr(
+        all_attn_layers.get(layer_name), "kv_sharing_target_layer_name", None
+    )
+    if target_layer_name and target_layer_name in group_spec.kv_cache_specs:
+        return group_spec.kv_cache_specs[target_layer_name]
+    return group_spec
 
 
 class SpecDecodeBaseProposer:
@@ -1717,6 +1762,98 @@ class SpecDecodeBaseProposer:
             )
             == 1
         ), "All drafting layers should belong to the same kv cache group"
+
+    def _initialize_multi_group_attn_backend(
+        self,
+        kv_cache_config: KVCacheConfig,
+        kernel_block_sizes: list[int] | None = None,
+    ) -> None:
+        """Build one AttentionGroup per (backend, KV cache spec) of the draft.
+
+        For drafters whose layers span several KV cache groups — sliding plus
+        full attention, typically with different head dimensions — a single
+        group would hand every layer the same AttentionMetadata, which is only
+        valid for one of them. Splitting by spec gives each variant its own
+        metadata builder.
+
+        Layers are keyed by the *identity* of their resolved spec rather than
+        the spec itself: ``UniformTypeKVCacheSpecs`` holds a dict and is
+        therefore unhashable, so it cannot be a dict key on the fallback path
+        where a layer has no per-layer entry.
+        """
+        all_attn_layers = get_layers_from_vllm_config(
+            self.vllm_config,
+            AttentionLayerBase,  # type: ignore[type-abstract]
+        )
+
+        layer_to_gid: dict[str, int] = {}
+        layer_to_spec: dict[str, KVCacheSpec] = {}
+        for gid, group in enumerate(kv_cache_config.kv_cache_groups):
+            group_spec = group.kv_cache_spec
+            for layer_name in group.layer_names:
+                layer_to_gid[layer_name] = gid
+                layer_to_spec[layer_name] = _resolve_layer_kv_cache_spec(
+                    layer_name, group_spec, all_attn_layers
+                )
+
+        # _draft_attn_layer_names is a set; iterate in sorted order so the
+        # resulting groups (and anything derived from the first one) are
+        # deterministic across processes.
+        attention_groups: dict[tuple[tuple[str, str], int, Any], AttentionGroup] = {}
+        for layer_name in sorted(self._draft_attn_layer_names):
+            if layer_name not in layer_to_spec:
+                continue
+            attn_backend = all_attn_layers[layer_name].get_attn_backend()
+            spec = layer_to_spec[layer_name]
+            gid = layer_to_gid[layer_name]
+            group_key = (
+                attn_backend.full_cls_name(),
+                gid,
+                _spec_group_key(spec),
+            )
+
+            if group_key in attention_groups:
+                attention_groups[group_key].layer_names.append(layer_name)
+                continue
+
+            kernel_block_size = (
+                kernel_block_sizes[gid]
+                if kernel_block_sizes is not None and gid < len(kernel_block_sizes)
+                else None
+            )
+            attn_group = AttentionGroup(
+                backend=attn_backend,
+                layer_names=[layer_name],
+                kv_cache_spec=spec,
+                kv_cache_group_id=gid,
+            )
+            attn_group.create_metadata_builders(
+                self.vllm_config,
+                self.device,
+                kernel_block_size=kernel_block_size,
+            )
+            attention_groups[group_key] = attn_group
+
+        self.draft_attn_groups = list(attention_groups.values())
+        if self.draft_attn_groups:
+            self.kv_cache_gid = self.draft_attn_groups[0].kv_cache_group_id
+            kernel_block_size = (
+                kernel_block_sizes[self.kv_cache_gid]
+                if kernel_block_sizes is not None
+                and self.kv_cache_gid < len(kernel_block_sizes)
+                else None
+            )
+            self.block_size = kernel_block_size or (
+                self.draft_attn_groups[0]
+                .get_metadata_builder()
+                .kv_cache_spec.block_size
+            )
+        else:
+            self.kv_cache_gid = 0
+            self.block_size = kv_cache_config.kv_cache_groups[
+                0
+            ].kv_cache_spec.block_size
+        logger.debug("Using block size %d for drafting layers", self.block_size)
 
     def initialize_attn_backend(
         self,

--- a/vllm/v1/spec_decode/step3p5.py
+++ b/vllm/v1/spec_decode/step3p5.py
@@ -5,20 +5,16 @@ from copy import copy
 
 import torch
 
-from vllm.config import VllmConfig, get_layers_from_vllm_config, replace
+from vllm.config import VllmConfig, replace
 from vllm.forward_context import set_forward_context
-from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.models.utils import get_draft_quant_config
 from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
-    KVCacheSpec,
-    UniformTypeKVCacheSpecs,
 )
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.spec_decode.eagle import EagleProposer
 from vllm.v1.spec_decode.utils import PADDING_SLOT_ID
-from vllm.v1.worker.utils import AttentionGroup
 
 
 class Step3p5MTPProposer(EagleProposer):
@@ -177,84 +173,9 @@ class Step3p5MTPProposer(EagleProposer):
         kv_cache_config: KVCacheConfig,
         kernel_block_sizes: list[int] | None = None,
     ) -> None:
-        all_attn_layers = get_layers_from_vllm_config(
-            self.vllm_config,
-            AttentionLayerBase,  # type: ignore[type-abstract]
-        )
-
-        layer_to_gid: dict[str, int] = {}
-        layer_to_spec: dict[str, KVCacheSpec] = {}
-        for gid, group in enumerate(kv_cache_config.kv_cache_groups):
-            group_spec = group.kv_cache_spec
-            for layer_name in group.layer_names:
-                layer_to_gid[layer_name] = gid
-                if isinstance(group_spec, UniformTypeKVCacheSpecs):
-                    if layer_name in group_spec.kv_cache_specs:
-                        layer_to_spec[layer_name] = group_spec.kv_cache_specs[
-                            layer_name
-                        ]
-                    else:
-                        target_layer_name = getattr(
-                            all_attn_layers.get(layer_name),
-                            "kv_sharing_target_layer_name",
-                            None,
-                        )
-                        if (
-                            target_layer_name
-                            and target_layer_name in group_spec.kv_cache_specs
-                        ):
-                            layer_to_spec[layer_name] = group_spec.kv_cache_specs[
-                                target_layer_name
-                            ]
-                        else:
-                            layer_to_spec[layer_name] = group_spec
-                else:
-                    layer_to_spec[layer_name] = group_spec
-
-        attention_groups: dict[tuple[tuple[str, str], int], AttentionGroup] = {}
-        for layer_name in sorted(self._draft_attn_layer_names):
-            if layer_name not in layer_to_spec:
-                continue
-            attn_layer = all_attn_layers[layer_name]
-            attn_backend = attn_layer.get_attn_backend()
-            spec = layer_to_spec[layer_name]
-            gid = layer_to_gid[layer_name]
-            group_key = (attn_backend.full_cls_name(), gid)
-
-            if group_key not in attention_groups:
-                kernel_block_size = (
-                    kernel_block_sizes[gid]
-                    if kernel_block_sizes is not None and gid < len(kernel_block_sizes)
-                    else None
-                )
-                attn_group = AttentionGroup(
-                    backend=attn_backend,
-                    layer_names=[layer_name],
-                    kv_cache_spec=spec,
-                    kv_cache_group_id=gid,
-                )
-                attn_group.create_metadata_builders(
-                    self.vllm_config,
-                    self.device,
-                    kernel_block_size=kernel_block_size,
-                )
-                attention_groups[group_key] = attn_group
-            else:
-                attention_groups[group_key].layer_names.append(layer_name)
-
-        self.draft_attn_groups = list(attention_groups.values())
-        if self.draft_attn_groups:
-            self.kv_cache_gid = self.draft_attn_groups[0].kv_cache_group_id
-            self.block_size = (
-                self.draft_attn_groups[0]
-                .get_metadata_builder()
-                .kv_cache_spec.block_size
-            )
-        else:
-            self.kv_cache_gid = 0
-            self.block_size = kv_cache_config.kv_cache_groups[
-                0
-            ].kv_cache_spec.block_size
+        """One AttentionGroup per KV cache spec, so each head-dim
+        variant gets its own metadata builder."""
+        self._initialize_multi_group_attn_backend(kv_cache_config, kernel_block_sizes)
 
     def _sample_draft_tokens_for_step(
         self,


### PR DESCRIPTION
## Purpose

Fixes #50710. `DFlashProposer` inherits `SpecDecodeBaseProposer`'s assumption that every draft layer belongs to a single KV cache group. A DFlash drafter whose `config.json` mixes `sliding_attention` and `full_attention` layers produces two KV cache specs, so it trips the base class assertion:

```
AssertionError: All drafting layers should belong to the same kv cache group
```

Even past that assertion, a single `AttentionGroup` hands every draft layer the same `AttentionMetadata`, which is only valid for one of the two head dimensions — the reporter saw this reach the kernel as a CUDA device-side assert inside `varlen_fwd` on the first request.

## Root cause

`SpecDecodeBaseProposer.initialize_attn_backend` picks the *first* group the draft layers intersect (`break`) and keys its attention groups on the backend alone, so all draft layers collapse into one group.

Two proposers already needed the multi-group behaviour and each grew its own override: `Gemma4Proposer` ("draft layers span multiple KV cache groups (sliding + full attention with different head dimensions)") and `Step3P5Proposer`. Those two overrides are ~80 lines each and near-identical: diffing them shows only variable renames, one using `sorted()` and the other not, a different group key, and a trailing debug log. `DFlashProposer` has neither override, which is the bug.

## Fix

Rather than add a third copy, this hoists the shared logic into `SpecDecodeBaseProposer._initialize_multi_group_attn_backend()` and has all three proposers use it:

- `dflash.py` — overrides `validate_same_kv_cache_group` (no-op) and `initialize_attn_backend` (delegates). **This is the actual fix for #50710.**
- `gemma4.py`, `step3p5.py` — 80-line implementations replaced with the same delegation.
- `llm_base_proposer.py` — the shared implementation, plus two small helpers: `_resolve_layer_kv_cache_spec()` for the per-layer lookup inside `UniformTypeKVCacheSpecs`, and `_spec_group_key()` for a hashable grouping key.

Net −1 line across the four source files, with one implementation instead of three. The base `build_per_group_and_layer_attn_metadata` already iterates `self.draft_attn_groups`, so nothing downstream needed changing — the only gap was that no more than one group was ever built.

### Behaviours the shared implementation pins down

**Unhashable dict key.** `gemma4.py` keyed its group dict on the resolved spec object. Layers do reach the resolver without a per-layer entry — `add_kv_sharing_layers_to_kv_cache_groups` appends a KV-sharing layer to the target group's `layer_names` without adding it to `kv_cache_specs` — and those resolve through `kv_sharing_target_layer_name` to a normal, hashable spec. If the final defensive branch is ever taken, though, the value is the enclosing `UniformTypeKVCacheSpecs`, which holds a `dict` and is unhashable, so the key would raise `TypeError`. I could not construct a configuration that reaches it today, so this is hardening rather than a fix for an observed crash. The shared version routes the key through a helper that falls back to identity for unhashable specs. (`step3p5.py` sidesteps the issue by keying on the group id, which also merges layers the finer key keeps apart.)

**Grouping is by spec value, not object identity.** Each layer builds its own spec object via `get_kv_cache_spec()`, so a drafter with many identical sliding layers holds many distinct-but-equal specs. Specs are frozen dataclasses, so keying on the spec merges them into one group; keying on identity would create one `AttentionGroup`, and one metadata builder, per layer. `test_layers_with_equal_specs_share_one_group` pins this.

**Nondeterministic group order.** `gemma4.py` iterated `self._draft_attn_layer_names` — a set — so group ordering varied across processes. The shared version sorts, which is what the base class already does and what the existing `test_draft_layer_iteration_is_deterministic` pins.

## Testing

Extended `tests/v1/spec_decode/test_llm_base_proposer.py`, the existing suite for this method (it fakes `AttentionGroup` and sets `device = None`, so it needs no GPU):

- `test_dflash_hybrid_drafter_gets_one_group_per_spec` — a two-group hybrid drafter yields two attention groups, each with its own head dim and KV cache group id.
- `test_dflash_single_group_drafter_is_unchanged` — the single-group case still yields one group.
- `test_layers_with_equal_specs_share_one_group` — distinct-but-equal per-layer specs collapse to a single group.

```
pytest -q tests/v1/spec_decode/test_llm_base_proposer.py
# 6 passed
```

**Mutation-checked, twice.** Reverting only `dflash.py` (leaving the refactor in place) fails the new test with the exact assertion from the issue:

```
AssertionError: All drafting layers should belong to the same kv cache group
FAILED test_llm_base_proposer.py::test_dflash_hybrid_drafter_gets_one_group_per_spec
1 failed, 5 passed
```

Making the group key identity-based instead of value-based fails the other new test, confirming it detects the over-splitting rather than passing vacuously:

```
FAILED test_llm_base_proposer.py::test_layers_with_equal_specs_share_one_group
1 failed, 5 passed
```

**No regressions in the surrounding suite.** Running every CPU-collectable test under `tests/v1/spec_decode/` (excluding `test_eagle.py`, `test_max_len.py`, `test_ngram.py`, which need a GPU platform to collect):

| | failed | passed |
| --- | --- | --- |
| clean `main` | 40 | 59 |
| this PR | **39** | **61** |

Diffing the two failure sets, the only difference is the hybrid test moving from failed to passed (the other pass is the newly added test); no test regressed. The remaining failures are pre-existing and environmental (no accelerator, structured-output backends).

`pre-commit run --files ...` clean, including `mypy-3.10` and `mypy-3.12 --hook-stage manual`.

## What is not covered

I do not have a hybrid DFlash drafter checkpoint or the reporter's GB10 hardware, so the end-to-end CUDA assert in #50710 is not reproduced here — the coverage is at the `initialize_attn_backend` level, which is where the malformed grouping originates. The reporter notes the fault is built before backend selection, which matches what the unit test exercises.

## Not a duplicate

No open PR references #50710, touches `initialize_attn_backend`, or addresses DFlash KV cache grouping (checked with `gh pr list --search` on all three).

## Model evaluation

N/A — no change to model outputs or numerics for any currently-working configuration. Single-KV-cache-group drafters take the same path as before (pinned by `test_dflash_single_group_drafter_is_unchanged` and the unchanged base-class tests). The change makes a configuration work that previously asserted at startup.

## AI assistance

AI assistance (Claude Code) was used to trace the proposer hierarchy, write the tests, and draft this description. I reviewed every changed line, and ran the tests, the mutation check, and the before/after suite comparison myself.
