### PR TITLE
[Bugfix][NIXL] Preserve block geometry for packed MLA caches

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
@@ -97,6 +97,46 @@ def test_logical_to_kernel_block_ids_with_hma():
 
 
 @pytest.mark.cpu_test
+def test_packed_hma_keeps_scheduler_block_size():
+    """Packed HMA transfers must not find one kernel size for all groups.
+
+    DeepSeek-V4 has cache groups with different block sizes. Its packed cache
+    transfers one complete scheduler block slab, while each attention backend
+    uses the kernel block size selected for its own group. The scheduler's
+    global block size can therefore be smaller than an attention backend's
+    minimum supported size.
+    """
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl import base_worker as bw
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.worker import (
+        NixlConnectorWorker,
+    )
+    from vllm.v1.kv_cache_interface import KVCacheTensor
+
+    num_blocks = 8
+    worker = object.__new__(NixlConnectorWorker)
+    worker.block_size = 4
+    worker.num_blocks = num_blocks
+    worker._physical_blocks_per_logical_kv_block = 1
+    worker.kv_cache_config = make_kv_cache_config(block_size=4, num_blocks=num_blocks)
+    worker.kv_cache_config.kv_cache_tensors = [
+        KVCacheTensor(
+            size=num_blocks * 4096,
+            shared_by=["layer0", "layer2"],
+            block_stride=4096,
+        )
+    ]
+
+    with patch.object(bw, "select_common_block_size") as select_common_block_size:
+        worker._sync_block_size_with_kernel()
+
+    select_common_block_size.assert_not_called()
+    assert worker.block_size == 4
+    assert worker.num_blocks == num_blocks
+    assert worker._logical_num_blocks == num_blocks
+    assert worker._physical_blocks_per_logical_kv_block == 1
+
+
+@pytest.mark.cpu_test
 @pytest.mark.parametrize(
     "is_rocm,has_mamba,use_host_buffer,done_recving,failed_recving,expected_syncs",
     [

--- a/tests/v1/kv_connector/unit/test_nixl_desc_geometry.py
+++ b/tests/v1/kv_connector/unit/test_nixl_desc_geometry.py
@@ -12,6 +12,7 @@ mid-decode (silent corruption of an unrelated request).
 """
 
 from collections import defaultdict
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -187,6 +188,7 @@ def test_overlaid_transfer_groups_share_region_geometry():
     worker._physical_blocks_per_logical_kv_block = 1
     worker._logical_num_blocks = num_blocks
     worker.region_mem_types = []
+    worker._transfer_packed_mla_blocks = False
     worker.region_group_ids = []
     worker.region_mem_types = []
     worker._mixed_mem_types = False
@@ -247,6 +249,217 @@ def test_overlaid_transfer_groups_share_region_geometry():
     assert metadata.region_group_ids == [-1]
     assert metadata.region_num_blocks == [num_blocks]
     assert worker._block_ids_by_region(([0], [2]), worker.region_group_ids) == [[0, 2]]
+
+
+def _make_packed_mla_worker():
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl import base_worker as bw
+    from vllm.v1.kv_cache_interface import (
+        KVCacheConfig,
+        KVCacheGroupSpec,
+        KVCacheLayout,
+        KVCacheTensor,
+        MLAAttentionSpec,
+        SlidingWindowMLASpec,
+        create_kv_cache_views,
+    )
+
+    specs = {
+        "mla": MLAAttentionSpec(
+            block_size=256, num_kv_heads=1, head_size=2, dtype=torch.float16
+        ),
+        "indexer": MLAAttentionSpec(
+            block_size=256, num_kv_heads=1, head_size=1, dtype=torch.float16
+        ),
+        "compressor": SlidingWindowMLASpec(
+            block_size=4,
+            num_kv_heads=1,
+            head_size=128,
+            dtype=torch.float16,
+            sliding_window=4,
+        ),
+    }
+    stride = specs["mla"].page_size_bytes + specs["indexer"].page_size_bytes
+    tensors = [
+        KVCacheTensor(
+            size=8 * stride,
+            layers=[name],
+            block_stride=stride,
+            layer_stride=spec.page_size_bytes,
+            offset=specs["mla"].page_size_bytes if name == "indexer" else 0,
+        )
+        for name, spec in specs.items()
+    ]
+    layout = KVCacheLayout.BLHNC
+    raw = torch.zeros(8 * stride, dtype=torch.int8)
+    caches = {
+        tensor.layers[0]: create_kv_cache_views(
+            raw, specs[tensor.layers[0]], 8, layout, tensor
+        )[0]
+        for tensor in tensors
+    }
+    worker = object.__new__(bw.NixlBaseConnectorWorker)
+    worker.kv_cache_config = KVCacheConfig(
+        8, tensors, [KVCacheGroupSpec([name], spec) for name, spec in specs.items()]
+    )
+    worker._layer_specs = specs
+    worker.vllm_config = SimpleNamespace(
+        cache_config=SimpleNamespace(get_resolved_kv_cache_layout=lambda: layout)
+    )
+    worker.block_size, worker.num_blocks = 4, 8
+    worker._physical_blocks_per_logical_kv_block = 1
+    worker.use_mla = True
+    worker.use_host_buffer = worker._has_mamba = worker._is_csa_linear = False
+    worker.pp_size = worker.pcp_size = worker.dcp_size = worker.world_size = 1
+    worker.tp_rank = 0
+    worker.device_id = 0
+    worker.engine_id, worker.backend_name = "local", "DEEPSEEK_SPARSE_SWA"
+    worker.kv_cache_layout = layout.name
+    worker.kv_buffer_device, worker.nixl_memory_type = "cuda", "VRAM"
+    worker.nixl_backends = ["UCX"]
+    worker.nixl_wrapper = _RecordingNixl()
+    worker.host_xfer_buffers = {}
+    worker.attn_backends = []
+    worker._mamba_ssm_size = (0, 0)
+    worker.block_len_per_layer, worker.block_stride_per_layer = [], []
+    worker._region_is_mla, worker._registered_descs = [], []
+    worker.region_group_ids, worker.region_names, worker.region_num_blocks = [], [], []
+    worker.kv_caches_base_addr = defaultdict(dict)
+    worker.src_xfer_handles_by_block_size, worker.dst_num_blocks = {}, {}
+    worker.dst_region_num_blocks, worker.dst_region_group_ids = {}, {}
+    worker.dst_uses_region_group_mapping, worker.dst_region_mem_types = {}, {}
+    worker._remote_agents = {}
+    return worker, caches
+
+
+@pytest.mark.cpu_test
+def test_packed_mla_registers_whole_scheduler_blocks():
+    """Compressor block size 4 must not be passed to the 256-token MLA kernel."""
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl import base_worker as bw
+
+    worker, caches = _make_packed_mla_worker()
+    with (
+        patch.object(bw, "get_current_attn_backends", side_effect=AssertionError),
+        patch.object(bw, "TransferTopology"),
+        patch.object(bw, "compute_nixl_compatibility_hash", return_value="test"),
+    ):
+        worker._sync_block_size_with_kernel()
+        worker.register_kv_caches(caches)
+
+    assert worker.block_size == 4 and worker.num_blocks == 8
+    assert worker._logical_num_blocks == 8
+    assert worker._physical_blocks_per_logical_kv_block == 1
+    assert worker.num_regions == 1
+    storage = caches["mla"].untyped_storage()
+    stride = storage.nbytes() // 8
+    assert worker.block_len_per_layer == worker.block_stride_per_layer == [stride]
+    np.testing.assert_array_equal(
+        worker.src_blocks_data[:, 0], storage.data_ptr() + np.arange(8) * stride
+    )
+    assert (worker.src_blocks_data[:, 1] == stride).all()
+    assert int(worker.src_blocks_data[-1, 0]) + stride == (
+        storage.data_ptr() + storage.nbytes()
+    )
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize(
+    "case",
+    ["host", "non_mla", "layer_outer", "ssm", "empty", "pp", "stride", "uniform"],
+)
+def test_non_packed_mla_path_keeps_kernel_block_splitting(case):
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl import base_worker as bw
+    from vllm.v1.kv_cache_interface import KVCacheLayout
+
+    worker, _ = _make_packed_mla_worker()
+    worker.block_size = 512
+    if case == "host":
+        worker.use_host_buffer = True
+    elif case == "non_mla":
+        worker.use_mla = False
+    elif case == "layer_outer":
+        worker.vllm_config.cache_config.get_resolved_kv_cache_layout = lambda: (
+            KVCacheLayout.LBHNC
+        )
+    elif case == "ssm":
+        worker._layer_specs["ssm"] = object()
+    elif case == "empty":
+        worker.kv_cache_config.kv_cache_tensors = []
+    elif case == "pp":
+        worker.pp_size = 2
+    elif case == "stride":
+        worker.kv_cache_config.kv_cache_tensors[0].block_stride //= 2
+    elif case == "uniform":
+        worker._layer_specs = {"mla": worker._layer_specs["mla"]}
+    backend = MagicMock()
+    backend.get_supported_kernel_block_sizes.return_value = [256]
+    with patch.object(bw, "get_current_attn_backends", return_value=[backend]):
+        worker._sync_block_size_with_kernel()
+    assert not worker._transfer_packed_mla_blocks
+    assert worker.block_size == 256 and worker.num_blocks == 16
+    assert worker._logical_num_blocks == 8
+    assert worker._physical_blocks_per_logical_kv_block == 2
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize("remote_tp_size", [1, 2, 4])
+@pytest.mark.parametrize(
+    "mismatch",
+    [
+        None,
+        "block_size",
+        "block_strides",
+        "block_lens",
+        "kv_cache_layout",
+        "physical_blocks_per_logical_kv_block",
+    ],
+)
+def test_packed_mla_rejects_incompatible_geometry_before_registering_peer(
+    remote_tp_size, mismatch
+):
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl import base_worker as bw
+
+    worker, caches = _make_packed_mla_worker()
+    with (
+        patch.object(bw, "TransferTopology"),
+        patch.object(bw, "compute_nixl_compatibility_hash", return_value="test"),
+    ):
+        worker._sync_block_size_with_kernel()
+        worker.register_kv_caches(caches)
+    meta = SimpleNamespace(
+        engine_id="remote",
+        block_size=4,
+        physical_blocks_per_logical_kv_block=1,
+        kv_cache_layout=worker.kv_cache_layout,
+        block_lens=worker.block_len_per_layer[:],
+        block_strides=worker.block_stride_per_layer[:],
+    )
+    worker._remote_agents = {"remote": {(0, 0): "existing-peer"}}
+    if mismatch is None:
+        assert (
+            worker.add_remote_agent(meta, remote_tp_size=remote_tp_size)
+            == "existing-peer"
+        )
+    else:
+        setattr(meta, mismatch, None)
+        with pytest.raises(ValueError, match="identical P/D block geometry"):
+            worker.add_remote_agent(meta, remote_tp_size=remote_tp_size)
+
+
+@pytest.mark.cpu_test
+def test_packed_mla_rejects_nonshared_runtime_views():
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl import base_worker as bw
+
+    worker, caches = _make_packed_mla_worker()
+    caches["indexer"] = caches["indexer"].clone()
+    worker._sync_block_size_with_kernel()
+    with (
+        patch.object(bw, "TransferTopology"),
+        patch.object(bw, "compute_nixl_compatibility_hash", return_value="test"),
+        pytest.raises(ValueError, match="shared whole-block cache views"),
+    ):
+        worker.register_kv_caches(caches)
+    assert worker.nixl_wrapper.dlists == {}
+    assert worker._registered_descs == []
 
 
 def _make_mla_hybrid_worker(local_block_size, kernel_block_size, num_logical_blocks):

--- a/tests/v1/kv_connector/unit/test_nixl_push_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_push_connector.py
@@ -368,6 +368,7 @@ class _StubWriterWorker(NixlPushConnectorWorker):
         w.dst_region_group_ids = {}
         w.dst_uses_region_group_mapping = {}
         w.dst_region_mem_types = {}
+        w._transfer_packed_mla_blocks = False
         # Single non-hybrid attention group, matching the stub block id lists.
         w._has_mamba = False
         w._is_csa_linear = False

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -556,10 +556,24 @@ class NixlBaseConnectorWorker:
         )
 
     def _sync_block_size_with_kernel(self) -> None:
+        # Packed caches already encode each cache group's page geometry in a
+        # single per-block slab. The global cache_config.block_size is the
+        # scheduler's allocation granularity (often the minimum across hybrid
+        # groups), not a kernel block size shared by every attention backend.
+        # NIXL transfers the whole slab, so virtually splitting it here would
+        # corrupt its descriptor geometry and can fail when the scheduler
+        # granularity is smaller than a backend's required block size.
+        self._logical_num_blocks = self.num_blocks
+        if any(t.block_stride > 0 for t in self.kv_cache_config.kv_cache_tensors):
+            logger.info_once(
+                "Packed KV cache detected; keeping scheduler block size %s "
+                "for NIXL whole-slab transfers.",
+                self.block_size,
+            )
+            return
+
         backends = get_current_attn_backends(self.vllm_config)
         kernel_block_size = select_common_block_size(self.block_size, backends)
-        # Number of blocks not accounting for kernel block mismatches
-        self._logical_num_blocks = self.num_blocks
         if self.block_size != kernel_block_size:
             logger.info_once(
                 "User-specified logical block size (%s) does not match"

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -792,10 +792,36 @@ class NixlBaseConnectorWorker:
             )
 
     def _sync_block_size_with_kernel(self) -> None:
+        self._logical_num_blocks = self.num_blocks
+        tensors = self.kv_cache_config.kv_cache_tensors
+        layout = self.vllm_config.cache_config.get_resolved_kv_cache_layout()
+        # A packed MLA allocation transfers whole scheduler-owned storage rows.
+        # Its groups may count different units (e.g. compressed KV and compressor
+        # state), so their minimum block size is not a common kernel block size.
+        self._transfer_packed_mla_blocks = bool(
+            self.use_mla
+            and not self.use_host_buffer
+            and self.pp_size == self.pcp_size == self.dcp_size == 1
+            and layout.is_block_outermost
+            and self._layer_specs
+            and all(
+                isinstance(spec, (MLAAttentionSpec, SlidingWindowMLASpec))
+                for spec in self._layer_specs.values()
+            )
+            and len({spec.block_size for spec in self._layer_specs.values()}) > 1
+            and tensors
+            and len({tensor.block_stride for tensor in tensors}) == 1
+            and all(
+                tensor.block_stride > 0
+                and tensor.size == self.num_blocks * tensor.block_stride
+                for tensor in tensors
+            )
+        )
+        if self._transfer_packed_mla_blocks:
+            return
+
         backends = get_current_attn_backends(self.vllm_config)
         kernel_block_size = select_common_block_size(self.block_size, backends)
-        # Number of blocks not accounting for kernel block mismatches
-        self._logical_num_blocks = self.num_blocks
         if self.block_size != kernel_block_size:
             logger.info_once(
                 "User-specified logical block size (%s) does not match"
@@ -1270,6 +1296,18 @@ class NixlBaseConnectorWorker:
         # CSA-linear needs separate logical regions for attention and state
         # aliases even though every view shares one block-major allocation.
         packed_storage = packed_storage and not self._is_csa_linear
+        if self._transfer_packed_mla_blocks and not (
+            packed_storage
+            and all(
+                cache.shape[0] == self.num_blocks
+                and cache.stride(0) * cache.element_size() * self.num_blocks
+                == cache.untyped_storage().nbytes()
+                for cache in xfer_buffers.values()
+            )
+        ):
+            raise ValueError(
+                "Packed MLA transfer requires shared whole-block cache views."
+            )
 
         layer_specs: dict[str, KVCacheSpec] = {}
         compressed_region_owners: dict[int, torch.Tensor] = {}
@@ -2001,6 +2039,16 @@ class NixlBaseConnectorWorker:
         tp_ratio < 0 (P_TP > D_TP) are supported by the 3-read transfer.
         """  # noqa: E501
         engine_id = nixl_agent_meta.engine_id
+        if self._transfer_packed_mla_blocks and (
+            nixl_agent_meta.block_size != self.block_size
+            or nixl_agent_meta.physical_blocks_per_logical_kv_block != 1
+            or nixl_agent_meta.kv_cache_layout != self.kv_cache_layout
+            or nixl_agent_meta.block_lens != self.block_len_per_layer
+            or nixl_agent_meta.block_strides != self.block_stride_per_layer
+        ):
+            raise ValueError(
+                "Packed MLA transfer requires identical P/D block geometry."
+            )
         # TODO re-evaluate refreshing for scaling/recovery
         if (0, remote_tp_rank) in self._remote_agents.get(engine_id, {}):
             logger.debug(


### PR DESCRIPTION
## Purpose

Fixes #50714. Allow TP1 DeepSeek-V4-Flash NIXL P/D engines to initialize with mixed-granularity packed MLA caches, without disabling block-size synchronization for ordinary caches.

HMA puts the minimum cache-group block size into the global cache config. For this model it is **4**, while attention kernels require **256**. These groups count different units: compressor state and compressed attention KV. Requiring a common kernel block size from that global minimum raises `ValueError: No common block size for 4` before NIXL registration. Setting `--block-size 256` does not fix the later HMA rewrite.

## Design And Compatibility

- Reuse the existing **whole-storage-row transfer** for mixed-block-size, block-outermost MLA allocations. Keep their scheduler-owned blocks intact instead of virtually splitting them using the global minimum.
- Restrict this branch to MLA-only specs, device buffers, PP/PCP/DCP=1, and consistent declared strides. Validate actual shared storage and whole-row coverage before registration, and matching P/D block geometry before accepting a peer.
- Ordinary caches, uniform-block MLA, MLA/Mamba, host-staged buffers and other excluded configurations retain the existing kernel block-size selection and virtual splitting. Model computation, scheduling policy and NIXL wire fields are unchanged.

This replaces the earlier broad `block_stride > 0` guard: a positive stride alone no longer identifies packed storage on main. It fixes this initialization path, not general heterogeneous block-size support. Different TP sizes are not rejected solely because TP differs, but actual heterogeneous-TP transfer remains unverified.

Related work: #49845 selects kernel block sizes before the HMA rewrite; #50499 addresses packed pipeline-parallel push routing; #53780 adds general per-region transfer geometry. This PR is the narrower post-HMA initialization fix and does not add their routing or metadata changes.

## Validation

### Rebase validation (2026-09-20)

Rebased onto main `1c3ef2ad4`. The original initialization failure still reproduces on this base; the merged per-region geometry work does not remove the post-HMA block-size synchronization failure.

Updated the test fixtures for upstream transfer-rank and layer-routing fields. Also explicitly retained whole-row descriptors for the validated mixed-granularity packed MLA branch: upstream now allows contiguous member pages to use separate strided regions, so skipping block-size synchronization alone no longer preserves this PR's whole-row transfer invariant. Other registration paths retain main's behavior.

- **28 source-isolated CPU checks passed** using real CPU tensor views and mocked NIXL boundaries. The unmodified main negative control still reproduced `No common block size for 4`.
- Ruff check/format, Python compilation and diff checks passed.
- Full pytest collection was blocked by missing `tblib`. Full pre-commit was not rerun; the individual checks above were executed directly.
- GPU/NIXL serving tests were **not rerun** after this rebase. The results below are from the earlier validation against `8369affa5`, not the current base. The isolated CPU checks do not replace full pytest or native transport validation.

### Original validation

Tested against main `8369affa5`, using `deepseek-ai/DeepSeek-V4-Flash-0731` and two isolated B300 GPUs, one per TP1 engine in a single Pod. The same model snapshot and launch arguments were used before/after; only `base_worker.py` was replaced for the serving check.

| Check | Result |
|---|---|
| Stock main startup | Reproduced `No common block size for 4` |
| Patched TP1 producer + consumer | Both healthy; NIXL KV transfer succeeded |
| Four existing CPU-marked NIXL test suites | **307 passed**, 152 deselected |
| Serving smoke checks | **8/8** expected arithmetic answers, including streaming/nonstreaming, C4 and post-cancel recovery |
| Stream/nonstream disconnect | Both requests aborted in engine logs; running/waiting returned to zero |
| Bounded long-request check | **24/24** completed: 65,536 input / 1,024 output tokens, C8 x 3 rounds; no reported NIXL transfer failures |

The regression tests cover whole-row descriptors and bounds, preservation of ordinary 512-to-256 splitting, invalid runtime views and incompatible peer geometry. The remote-TP parameters exercise metadata validation, not end-to-end heterogeneous TP.

Local Ruff check/format and SPDX checks passed. The full pre-commit invocation did not complete: hook-repository downloads were stopped after several minutes. It is not included in the passed checks above.

These are serving correctness checks, not a model-accuracy benchmark. This run used eager execution and `UCX_TLS=tcp,cuda_copy`; no NVLink or performance improvement is claimed.

<details>
<summary>Test commands and TP1 startup reproduction</summary>

In the vLLM test environment, from the repository root:

```bash
OMP_NUM_THREADS=4 OPENBLAS_NUM_THREADS=4 .venv/bin/python -m pytest \
  tests/v1/kv_connector/unit/test_nixl_desc_geometry.py \
  tests/v1/kv_connector/unit/test_nixl_connector_hma.py \
  tests/v1/kv_connector/unit/test_nixl_connector.py \
  tests/v1/kv_connector/unit/test_nixl_push_connector.py \
  -m cpu_test -q
```

The isolated Pod used `/work/venv/bin/python` for this environment. Actual output:

```text
307 passed, 152 deselected, 14 warnings in 92.63s (0:01:32)
```

Run one role in each of two containers sharing a Pod network, with one distinct GPU allocated to each. Set `ROLE=prefill` or `ROLE=decode`, and `POD_IP` to that Pod's IP. Use the same model revision on both ends. This is the serving command used, with the local model-cache path replaced by its public model ID and revision:

```bash
export OMP_NUM_THREADS=4 MKL_NUM_THREADS=4 OPENBLAS_NUM_THREADS=4
export PYTHONHASHSEED=0 VLLM_LOG_STATS_INTERVAL=1 UCX_TLS=tcp,cuda_copy
export VLLM_NIXL_SIDE_CHANNEL_HOST="${POD_IP:?Set the Pod IP}"
case "${ROLE:?Set prefill or decode}" in
  prefill) PORT=18000; KVROLE=kv_producer
           export VLLM_NIXL_SIDE_CHANNEL_PORT=18100 ;;
  decode)  PORT=18001; KVROLE=kv_consumer
           export VLLM_NIXL_SIDE_CHANNEL_PORT=18101 ;;
  *) exit 1 ;;
esac

.venv/bin/python -m vllm.entrypoints.openai.api_server \
  --model deepseek-ai/DeepSeek-V4-Flash-0731 \
  --revision 7872f01b1d1fe23eabc4c98b48bffcef5a386062 \
  --served-model-name deepseek-ai/DeepSeek-V4-Flash-0731 \
  --trust-remote-code --tensor-parallel-size 1 \
  --host 0.0.0.0 --port "$PORT" \
  --tokenizer-mode deepseek_v4 --tool-call-parser deepseek_v4 \
  --enable-auto-tool-choice --reasoning-parser deepseek_v4 \
  --kv-cache-dtype fp8 --gpu-memory-utilization 0.7 \
  --max-model-len 131072 --max-num-batched-tokens 8192 --max-num-seqs 8 \
  --enable-prefix-caching --enable-chunked-prefill \
  --no-disable-hybrid-kv-cache-manager \
  --enable-expert-parallel --moe-backend deep_gemm_mega_moe \
  --attention-config '{"use_fp4_indexer_cache":true}' \
  --enable-prompt-tokens-details --enable-request-id-headers --enable-log-requests \
  --kv-transfer-config "{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"$KVROLE\",\"kv_buffer_device\":\"cuda\",\"kv_connector_extra_config\":{\"backends\":[\"UCX\"],\"num_threads\":8}}" \
  --enforce-eager --seed 2026
```

Stock main fails in `_sync_block_size_with_kernel()`. With this change, both engines initialize and expose `/health`. The serving checks then sent a `max_tokens=1`, `do_remote_decode=true` prefill request and forwarded its returned `kv_transfer_params` with the original request to decode. Successful decode-side cached tokens were treated as transferred KV, not as prefill prefix-cache hits.

</details>

## AI Assistance

The submitter supplied the failure case, deployment constraints and test requirements, directed the design and isolated B300 validation, and authorized this update. AI assistance was used for implementation, tests, review and documentation. The human submitter remains responsible for reviewing and defending the change.
