### PR TITLE
[Core] fused_moe: let an enclosing fusion supply the shared-expert output

### DIFF
--- a/tests/model_executor/layers/fused_moe/test_shared_experts.py
+++ b/tests/model_executor/layers/fused_moe/test_shared_experts.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+import vllm.model_executor.layers.fused_moe.runner.shared_experts as shared_module
+from vllm.model_executor.layers.fused_moe.runner.shared_experts import (
+    SharedExperts,
+    SharedExpertsOrder,
+)
+
+
+def _make_shared_experts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> SharedExperts:
+    monkeypatch.setattr(
+        shared_module,
+        "dbo_current_ubatch_id",
+        lambda: 0,
+    )
+    shared = SharedExperts.__new__(SharedExperts)
+    torch.nn.Module.__init__(shared)
+    shared.enable_dbo = False
+    shared._output = [None, None]
+    shared._precomputed_output = [None, None]
+    shared._layer = lambda tensor: tensor + 1
+    shared._determine_shared_experts_order = lambda _: SharedExpertsOrder.NO_OVERLAP
+    return shared
+
+
+def test_precomputed_output_bypasses_layer_and_is_consumed_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shared = _make_shared_experts(monkeypatch)
+    precomputed = torch.randn(2, 4)
+
+    with shared.use_precomputed_output(precomputed):
+        shared.maybe_sync_shared_experts_stream(torch.empty_like(precomputed))
+        shared(
+            torch.empty_like(precomputed),
+            SharedExpertsOrder.NO_OVERLAP,
+        )
+        assert shared.output is precomputed
+
+    assert shared._output == [None, None]
+    assert shared._precomputed_output == [None, None]
+
+
+def test_precomputed_output_rejects_collision_and_cleans_up_on_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shared = _make_shared_experts(monkeypatch)
+
+    with (
+        pytest.raises(RuntimeError, match="downstream failure"),
+        shared.use_precomputed_output(torch.zeros(1)),
+    ):
+        with (
+            pytest.raises(RuntimeError, match="already occupied"),
+            shared.use_precomputed_output(torch.ones(1)),
+        ):
+            pass
+        raise RuntimeError("downstream failure")
+
+    assert shared._output == [None, None]
+    assert shared._precomputed_output == [None, None]
+
+
+def test_normal_shared_expert_path_is_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shared = _make_shared_experts(monkeypatch)
+    hidden = torch.randn(2, 4)
+
+    shared(hidden, SharedExpertsOrder.NO_OVERLAP)
+
+    torch.testing.assert_close(shared.output, hidden + 1)

--- a/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
+++ b/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from collections.abc import Callable
+from collections.abc import Callable, Generator
+from contextlib import contextmanager
 from enum import IntEnum
 
 import torch
@@ -52,6 +53,7 @@ class SharedExperts(torch.nn.Module):
         # index is always 0 and the second output list element is ignored.
         self.enable_dbo = enable_dbo
         self._output: list[torch.Tensor | None] = [None, None]
+        self._precomputed_output: list[torch.Tensor | None] = [None, None]
         self._layer = layer
         self._moe_config = moe_config
 
@@ -112,6 +114,8 @@ class SharedExperts(torch.nn.Module):
         self,
         shared_experts_input: torch.Tensor,
     ):
+        if self._precomputed_output[self._output_idx] is not None:
+            return
         experts_order = self._determine_shared_experts_order(shared_experts_input)
 
         if experts_order == SharedExpertsOrder.MULTI_STREAM_OVERLAPPED:
@@ -147,16 +151,43 @@ class SharedExperts(torch.nn.Module):
 
     @property
     def output(self) -> torch.Tensor:
-        assert self._output[self._output_idx] is not None
-        output = self._output[self._output_idx]
-        self._output[self._output_idx] = None
+        output_idx = self._output_idx
+        precomputed_output = self._precomputed_output[output_idx]
+        if precomputed_output is not None:
+            self._precomputed_output[output_idx] = None
+            return precomputed_output
+
+        assert self._output[output_idx] is not None
+        output = self._output[output_idx]
+        self._output[output_idx] = None
         return output
+
+    @contextmanager
+    def use_precomputed_output(
+        self,
+        output: torch.Tensor,
+    ) -> Generator[None, None, None]:
+        """Use a shared-expert output produced by an enclosing fusion."""
+
+        output_idx = self._output_idx
+        if (
+            self._output[output_idx] is not None
+            or self._precomputed_output[output_idx] is not None
+        ):
+            raise RuntimeError("shared expert output slot is already occupied")
+        self._precomputed_output[output_idx] = output
+        try:
+            yield
+        finally:
+            self._precomputed_output[output_idx] = None
 
     def forward(
         self,
         shared_experts_input: torch.Tensor,
         order: SharedExpertsOrder,
     ):
+        if self._precomputed_output[self._output_idx] is not None:
+            return None
         experts_order = self._determine_shared_experts_order(shared_experts_input)
 
         if order != experts_order:


### PR DESCRIPTION
## Purpose

`SharedExperts` always computes its output through `self._layer`. A fused
pre-route kernel that already produces the shared-expert output alongside the
routed inputs has no way to hand it back, so the work is repeated.

This adds a `_precomputed_output` slot and a `use_precomputed_output()` context
manager. While a value is installed:

- `maybe_sync_shared_experts_stream()` returns early instead of scheduling the
  layer, and
- `.output` yields the precomputed tensor once, then clears it.

The slot is per-ubatch, refuses to overwrite an occupied slot, and is cleared on
the way out even if the body raises.

**No behaviour change when the context manager is unused.** Both new branches
are guarded on `_precomputed_output[output_idx]` being `None`, so the existing
path is byte-for-byte the same.


## Test plan

`tests/model_executor/layers/fused_moe/test_shared_experts.py` covers the seam
directly. It is CPU-only and needs no GPU, no ROCm, and no AITER.

```bash
python -m pytest -q tests/model_executor/layers/fused_moe/test_shared_experts.py
```

Cases:

- a precomputed output bypasses `_layer` and is consumed exactly once, leaving
  both `_output` and `_precomputed_output` cleared;
- installing into an occupied slot raises, and the slot is still cleaned up when
  the context body raises.

## Test result

Ran against an unmodified vLLM as a control, then with this change applied:

| tree | result |
|---|---|
| unmodified `main` | 2 failed, 1 passed |
| with this PR | **3 passed** |

The control matters: without it a passing test proves nothing, since the two new
cases must fail when `use_precomputed_output` does not exist.

Ruff clean on both files.

## Note on AI assistance

Per the contributing guidelines: this change was prepared with AI assistance and
the commit carries an `Assisted-by:` trailer. I reviewed every changed line, ran
the tests above myself, and am responsible for the content.
