### PR TITLE
[ROCm][Test] Fix AITER MXFP4 oracle contract

### DIFF
--- a/tests/kernels/moe/test_ocp_mx_moe.py
+++ b/tests/kernels/moe/test_ocp_mx_moe.py
@@ -1204,7 +1204,7 @@ ROCM_BACKEND_CONFIGS = {
     },
     "AITER_MXFP4_BF16": {
         "activation": "SWIGLUOAI",
-        "rtol": 1.0,
+        "rtol": 0.1,
         "percent": 0.7,
         "requires_aiter": True,
         "requires_gfx950": True,

--- a/tests/kernels/moe/test_ocp_mx_moe.py
+++ b/tests/kernels/moe/test_ocp_mx_moe.py
@@ -1203,7 +1203,7 @@ ROCM_BACKEND_CONFIGS = {
         "requires_gfx950": False,
     },
     "AITER_MXFP4_BF16": {
-        "activation": "SILU",
+        "activation": "SWIGLUOAI",
         "rtol": 1.0,
         "percent": 0.7,
         "requires_aiter": True,
@@ -1337,6 +1337,13 @@ def test_rocm_mxfp4_moe_oracle(
     w2_quant = w2_quant_2d.reshape(num_experts, hidden_size, -1)
     w2_scale = w2_scale_2d.reshape(num_experts, hidden_size, -1)
 
+    # AITER conversion mutates checkpoint-format weights and scales in place.
+    # Preserve their original layout for the reference calculation below.
+    w13_quant_ref = w13_quant.clone()
+    w13_scale_ref = w13_scale.clone()
+    w2_quant_ref = w2_quant.clone()
+    w2_scale_ref = w2_scale.clone()
+
     w13_bias = torch.randn(
         num_experts, 2 * intermediate_size, dtype=dtype, device=device
     )
@@ -1453,10 +1460,10 @@ def test_rocm_mxfp4_moe_oracle(
 
     # Dequantize weights for reference computation
     w13_dq = upcast_from_mxfp(
-        w13_quant.view(torch.uint8), w13_scale, torch.bfloat16, axis=-1
+        w13_quant_ref.view(torch.uint8), w13_scale_ref, torch.bfloat16, axis=-1
     )
     w2_dq = upcast_from_mxfp(
-        w2_quant.view(torch.uint8), w2_scale, torch.bfloat16, axis=-1
+        w2_quant_ref.view(torch.uint8), w2_scale_ref, torch.bfloat16, axis=-1
     )
 
     # Determine activation type and layout


### PR DESCRIPTION
[PR #46298](https://github.com/vllm-project/vllm/pull/46298) switched this test to the GPT-OSS MXFP4 converter but left it configured for ordinary `SILU`, and the reference calculation reused tensors after the converter had modified their layout in place. The newer AITER version from [PR #49361](https://github.com/vllm-project/vllm/pull/49361) exposed that inconsistent setup as an [unsupported small-M kernel configuration](https://buildkite.com/vllm/amd-ci/builds/11556/list?jid=019fbc8d-6ce5-44ee-9235-947e18569711&tab=output). 

- Use `SWIGLUOAI` for the `AITER_MXFP4_BF16` test case, matching the activation and gate/up layout expected by the GPT-OSS converter.
- Clone the checkpoint-format weights and scales before conversion so the reference dequantizes the original data rather than the reordered tensors.