### PR TITLE
[PD] Emit inactive KV blocks for decode affinity

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -2580,6 +2580,136 @@ def test_emit_cached_block_events_zero_cached():
     assert pool.take_events() == []
 
 
+def test_emit_remote_recv_block_stored_when_caching_disabled():
+    """Decode remote-recv path emits BlockStored when prefix caching is off."""
+    block_size = 4
+    num_full_blocks = 3
+    num_tokens = block_size * num_full_blocks
+    kv_cache_config = make_kv_cache_config(block_size=block_size, num_blocks=16)
+    manager = make_kv_cache_manager(
+        kv_cache_config,
+        max_model_len=128,
+        enable_caching=False,
+        hash_block_size=block_size,
+        enable_kv_cache_events=True,
+    )
+    req = make_request(
+        "req_remote_recv",
+        prompt_token_ids=list(range(num_tokens)),
+        block_size=block_size,
+        hash_fn=sha256,
+    )
+
+    manager.emit_remote_recv_block_stored(req, num_tokens)
+
+    events = manager.take_events()
+    assert len(events) == 1
+    event = events[0]
+    assert isinstance(event, BlockStored)
+    assert event.medium == MEDIUM_GPU
+    assert event.group_idx == 0
+    assert event.block_size == block_size
+    assert len(event.block_hashes) == num_full_blocks
+    assert event.token_ids == list(req.all_token_ids[:num_tokens])
+
+
+def test_emit_remote_recv_block_stored_skipped_when_caching_enabled():
+    """Avoid double-emit: caching on already emits via cache_full_blocks."""
+    block_size = 4
+    num_tokens = block_size * 3
+    kv_cache_config = make_kv_cache_config(block_size=block_size, num_blocks=16)
+    manager = make_kv_cache_manager(
+        kv_cache_config,
+        max_model_len=128,
+        enable_caching=True,
+        hash_block_size=block_size,
+        enable_kv_cache_events=True,
+    )
+    req = make_request(
+        "req_remote_recv_cached",
+        prompt_token_ids=list(range(num_tokens)),
+        block_size=block_size,
+        hash_fn=sha256,
+    )
+
+    manager.emit_remote_recv_block_stored(req, num_tokens)
+    assert manager.take_events() == []
+
+
+def test_emit_remote_recv_block_stored_skipped_when_events_disabled():
+    block_size = 4
+    num_tokens = block_size * 2
+    kv_cache_config = make_kv_cache_config(block_size=block_size, num_blocks=16)
+    manager = make_kv_cache_manager(
+        kv_cache_config,
+        max_model_len=128,
+        enable_caching=False,
+        hash_block_size=block_size,
+        enable_kv_cache_events=False,
+    )
+    req = make_request(
+        "req_remote_recv_no_events",
+        prompt_token_ids=list(range(num_tokens)),
+        block_size=block_size,
+        hash_fn=sha256,
+    )
+
+    manager.emit_remote_recv_block_stored(req, num_tokens)
+    assert manager.take_events() == []
+
+
+def test_update_waiting_for_remote_kv_emits_for_consumer():
+    """Scheduler success path calls emit_remote_recv_block_stored on Decode."""
+    from unittest.mock import MagicMock
+
+    scheduler = object.__new__(Scheduler)
+    scheduler.connector = MagicMock()
+    scheduler.needs_kv_cache_zeroing = False
+    scheduler.kv_cache_manager = MagicMock()
+    scheduler.failed_recving_kv_req_ids = set()
+    scheduler.finished_recving_kv_req_ids = {"req-1"}
+    scheduler.vllm_config = SimpleNamespace(
+        kv_transfer_config=SimpleNamespace(is_kv_consumer=True)
+    )
+
+    request = MagicMock()
+    request.request_id = "req-1"
+    request.num_computed_tokens = 12
+    request.num_tokens = 16
+
+    scheduler._update_waiting_for_remote_kv(request)
+
+    scheduler.kv_cache_manager.cache_blocks.assert_called_once_with(request, 12)
+    scheduler.kv_cache_manager.emit_remote_recv_block_stored.assert_called_once_with(
+        request, 12
+    )
+    assert "req-1" not in scheduler.finished_recving_kv_req_ids
+
+
+def test_update_waiting_for_remote_kv_skips_emit_for_producer():
+    from unittest.mock import MagicMock
+
+    scheduler = object.__new__(Scheduler)
+    scheduler.connector = MagicMock()
+    scheduler.needs_kv_cache_zeroing = False
+    scheduler.kv_cache_manager = MagicMock()
+    scheduler.failed_recving_kv_req_ids = set()
+    scheduler.finished_recving_kv_req_ids = {"req-1"}
+    scheduler.vllm_config = SimpleNamespace(
+        kv_transfer_config=SimpleNamespace(is_kv_consumer=False)
+    )
+
+    request = MagicMock()
+    request.request_id = "req-1"
+    request.num_computed_tokens = 12
+    request.num_tokens = 16
+
+    scheduler._update_waiting_for_remote_kv(request)
+
+    scheduler.kv_cache_manager.cache_blocks.assert_called_once_with(request, 12)
+    scheduler.kv_cache_manager.emit_remote_recv_block_stored.assert_not_called()
+
+
 def test_free_blocks_emits_block_inactive_when_enabled():
     """BlockInactive is emitted on ref_cnt→0 when enable_block_inactive_events."""
     block_size = 4

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -15,6 +15,7 @@ import vllm.v1.core.kv_cache_utils as kv_cache_utils
 from vllm.distributed.kv_events import (
     MEDIUM_GPU,
     AllBlocksCleared,
+    BlockInactive,
     BlockRemoved,
     BlockStored,
 )
@@ -2577,6 +2578,81 @@ def test_emit_cached_block_events_zero_cached():
     )
 
     assert pool.take_events() == []
+
+
+def test_free_blocks_emits_block_inactive_when_enabled():
+    """BlockInactive is emitted on ref_cnt→0 when enable_block_inactive_events."""
+    block_size = 4
+    pool = BlockPool(
+        num_gpu_blocks=8,
+        enable_caching=True,
+        hash_block_size=block_size,
+        enable_kv_cache_events=True,
+        enable_block_inactive_events=True,
+    )
+    req = make_request(
+        "req_inactive",
+        prompt_token_ids=list(range(block_size)),
+        block_size=block_size,
+        hash_fn=sha256,
+    )
+    blocks = pool.get_new_blocks(1)
+    pool.cache_full_blocks(
+        request=req,
+        blocks=blocks,
+        num_cached_blocks=0,
+        num_full_blocks=1,
+        block_size=block_size,
+        kv_cache_group_id=0,
+    )
+    pool.take_events()  # drain BlockStored
+
+    pool.free_blocks(blocks)
+    events = pool.take_events()
+    assert len(events) == 1
+    assert isinstance(events[0], BlockInactive)
+    assert events[0].medium == MEDIUM_GPU
+
+
+def test_free_blocks_skips_block_inactive_when_disabled():
+    """Prefill-style gate: Stored still works; Inactive is suppressed."""
+    block_size = 4
+    pool = BlockPool(
+        num_gpu_blocks=8,
+        enable_caching=True,
+        hash_block_size=block_size,
+        enable_kv_cache_events=True,
+        enable_block_inactive_events=False,
+    )
+    req = make_request(
+        "req_no_inactive",
+        prompt_token_ids=list(range(block_size)),
+        block_size=block_size,
+        hash_fn=sha256,
+    )
+    blocks = pool.get_new_blocks(1)
+    pool.cache_full_blocks(
+        request=req,
+        blocks=blocks,
+        num_cached_blocks=0,
+        num_full_blocks=1,
+        block_size=block_size,
+        kv_cache_group_id=0,
+    )
+    stored = pool.take_events()
+    assert any(isinstance(e, BlockStored) for e in stored)
+
+    pool.free_blocks(blocks)
+    assert pool.take_events() == []
+
+
+def test_kv_transfer_should_emit_block_inactive():
+    from vllm.config.kv_transfer import KVTransferConfig
+
+    assert KVTransferConfig(kv_role="kv_producer").should_emit_block_inactive is False
+    assert KVTransferConfig(kv_role="kv_consumer").should_emit_block_inactive is True
+    assert KVTransferConfig(kv_role="kv_both").should_emit_block_inactive is True
+    assert KVTransferConfig().should_emit_block_inactive is True
 
 
 def test_eagle_enabled_removes_last_block():

--- a/vllm/config/kv_transfer.py
+++ b/vllm/config/kv_transfer.py
@@ -117,5 +117,15 @@ class KVTransferConfig:
     def is_kv_consumer(self) -> bool:
         return self.kv_connector is not None and self.kv_role in get_args(KVConsumer)
 
+    @property
+    def should_emit_block_inactive(self) -> bool:
+        """Whether this instance should emit BlockInactive KV events.
+
+        Prefill-only producers (``kv_role='kv_producer'``) skip BlockInactive
+        so decode affinity load signals are not driven by prefill frees.
+        Decode (``kv_consumer``), union (``kv_both``), and non-PD setups emit.
+        """
+        return self.kv_role != "kv_producer"
+
     def get_from_extra_config(self, key, default) -> Any:
         return self.kv_connector_extra_config.get(key, default)

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -112,12 +112,39 @@ class BlockRemoved(KVCacheEvent):
         )
 
 
+class BlockInactive(KVCacheEvent):
+    """Emitted when a block's ref_cnt drops to zero.
+
+    Distinct from BlockRemoved:
+    - BlockRemoved: the block is evicted/removed from GPU memory.
+    - BlockInactive: the block still exists in GPU memory but has zero active
+      references (all requests referencing it have completed).
+
+    This event is only emitted for GPU blocks (medium=MEDIUM_GPU).
+    """
+
+    block_hashes: list[ExternalBlockHash]
+    medium: str | None
+    group_idx: int | None = None
+    locality: str | None = None
+
+    def __hash__(self) -> int:
+        return hash(
+            (
+                tuple(self.block_hashes),
+                self.medium,
+                self.group_idx,
+                self.locality,
+            )
+        )
+
+
 class AllBlocksCleared(KVCacheEvent):
     pass
 
 
 class KVEventBatch(EventBatch):
-    events: list[BlockStored | BlockRemoved | AllBlocksCleared]
+    events: list[BlockStored | BlockRemoved | BlockInactive | AllBlocksCleared]
 
 
 class KVEventAggregator:

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -6,6 +6,7 @@ from typing import Any
 from vllm.distributed.kv_events import (
     MEDIUM_GPU,
     AllBlocksCleared,
+    BlockInactive,
     BlockRemoved,
     BlockStored,
     KVCacheEvent,
@@ -156,6 +157,10 @@ class BlockPool:
             where different KV cache groups have different block sizes, the
             actual block size can be a multiple of hash_block_size.
         enable_kv_cache_events: Whether to enable kv cache events.
+        enable_block_inactive_events: Whether to emit BlockInactive when a
+            block's ref_cnt drops to 0. Prefill-only (kv_producer) instances
+            should disable this so decode load signals are not driven by
+            prefill free_blocks; BlockStored/BlockRemoved are unaffected.
         metrics_collector: Optional metrics collector for tracking block residency.
     """
 
@@ -166,6 +171,7 @@ class BlockPool:
         hash_block_size: int,
         enable_kv_cache_events: bool = False,
         metrics_collector: KVCacheMetricsCollector | None = None,
+        enable_block_inactive_events: bool = True,
     ):
         assert isinstance(num_gpu_blocks, int) and num_gpu_blocks > 0
         self.num_gpu_blocks = num_gpu_blocks
@@ -191,6 +197,9 @@ class BlockPool:
         self.null_block.is_null = True
 
         self.enable_kv_cache_events = enable_kv_cache_events
+        # Gated separately from enable_kv_cache_events so prefill can still
+        # publish Stored/Removed while omitting Inactive.
+        self.enable_block_inactive_events = enable_block_inactive_events
         self.kv_event_queue: list[KVCacheEvent] = []
 
         self.metrics_collector = metrics_collector
@@ -727,15 +736,37 @@ class BlockPool:
         # Identify blocks with hash (LRU cache) and without it (never match APC)
         blocks_with_hash = []
         blocks_without_hash = []
+        inactive_block_hashes: list[ExternalBlockHash] = []
         for block in ordered_blocks:
             block.ref_cnt -= 1
             if block.ref_cnt == 0 and not block.is_null:
+                # Emit BlockInactive for GPU blocks that had a hash
+                # (prefix-cached blocks) when ref_cnt drops to zero.
+                # Prefill-only (kv_producer) disables enable_block_inactive_events.
+                if (
+                    self.enable_kv_cache_events
+                    and self.enable_block_inactive_events
+                    and block.block_hash is not None
+                ):
+                    inactive_block_hashes.append(
+                        maybe_convert_block_hash(
+                            get_block_hash(block.block_hash)
+                        )
+                    )
                 # When caching is disabled we always append for better
                 # GPU cache locality from reusing recently used blocks
                 if block.block_hash is None and self.enable_caching:
                     blocks_without_hash.append(block)
                 else:
                     blocks_with_hash.append(block)
+
+        if inactive_block_hashes:
+            self.kv_event_queue.append(
+                BlockInactive(
+                    block_hashes=inactive_block_hashes,
+                    medium=MEDIUM_GPU,
+                )
+            )
 
         # Blocks without hash get evicted first - prepend them last to the tail
         self.free_block_queue.prepend_n(blocks_without_hash)

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -75,6 +75,7 @@ class KVCacheCoordinator(ABC):
         scheduler_block_size: int,
         hash_block_size: int,
         metrics_collector: KVCacheMetricsCollector | None = None,
+        enable_block_inactive_events: bool = True,
     ):
         self.kv_cache_config = kv_cache_config
         self.max_model_len = max_model_len
@@ -93,6 +94,7 @@ class KVCacheCoordinator(ABC):
             hash_block_size=hash_block_size,
             enable_kv_cache_events=enable_kv_cache_events,
             metrics_collector=metrics_collector,
+            enable_block_inactive_events=enable_block_inactive_events,
         )
 
         # KV cache group indices that get the EAGLE last-block drop.
@@ -402,6 +404,7 @@ class KVCacheCoordinatorNoPrefixCache(KVCacheCoordinator):
         scheduler_block_size: int,
         hash_block_size: int,
         metrics_collector: KVCacheMetricsCollector | None = None,
+        enable_block_inactive_events: bool = True,
     ):
         super().__init__(
             kv_cache_config,
@@ -415,6 +418,7 @@ class KVCacheCoordinatorNoPrefixCache(KVCacheCoordinator):
             scheduler_block_size=scheduler_block_size,
             hash_block_size=hash_block_size,
             metrics_collector=metrics_collector,
+            enable_block_inactive_events=enable_block_inactive_events,
         )
         self.num_single_type_manager = len(self.single_type_managers)
 
@@ -452,6 +456,7 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
         scheduler_block_size: int,
         hash_block_size: int,
         metrics_collector: KVCacheMetricsCollector | None = None,
+        enable_block_inactive_events: bool = True,
     ):
         super().__init__(
             kv_cache_config,
@@ -465,6 +470,7 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
             scheduler_block_size=scheduler_block_size,
             hash_block_size=hash_block_size,
             metrics_collector=metrics_collector,
+            enable_block_inactive_events=enable_block_inactive_events,
         )
         self.kv_cache_spec = self.kv_cache_config.kv_cache_groups[0].kv_cache_spec
         self.block_size = self.kv_cache_spec.block_size
@@ -537,6 +543,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         scheduler_block_size: int,
         hash_block_size: int,
         metrics_collector: KVCacheMetricsCollector | None = None,
+        enable_block_inactive_events: bool = True,
     ):
         super().__init__(
             kv_cache_config,
@@ -550,6 +557,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             scheduler_block_size=scheduler_block_size,
             hash_block_size=hash_block_size,
             metrics_collector=metrics_collector,
+            enable_block_inactive_events=enable_block_inactive_events,
         )
         # hash_block_size: the block size used to compute block hashes.
         # The actual block size usually equals hash_block_size, but in cases where
@@ -860,6 +868,7 @@ def get_kv_cache_coordinator(
     scheduler_block_size: int,
     hash_block_size: int,
     metrics_collector: KVCacheMetricsCollector | None = None,
+    enable_block_inactive_events: bool = True,
 ) -> KVCacheCoordinator:
     if not enable_caching:
         return KVCacheCoordinatorNoPrefixCache(
@@ -873,6 +882,7 @@ def get_kv_cache_coordinator(
             scheduler_block_size=scheduler_block_size,
             hash_block_size=hash_block_size,
             metrics_collector=metrics_collector,
+            enable_block_inactive_events=enable_block_inactive_events,
         )
     if len(kv_cache_config.kv_cache_groups) == 1:
         return UnitaryKVCacheCoordinator(
@@ -887,6 +897,7 @@ def get_kv_cache_coordinator(
             scheduler_block_size=scheduler_block_size,
             hash_block_size=hash_block_size,
             metrics_collector=metrics_collector,
+            enable_block_inactive_events=enable_block_inactive_events,
         )
     return HybridKVCacheCoordinator(
         kv_cache_config,
@@ -900,4 +911,5 @@ def get_kv_cache_coordinator(
         scheduler_block_size=scheduler_block_size,
         hash_block_size=hash_block_size,
         metrics_collector=metrics_collector,
+        enable_block_inactive_events=enable_block_inactive_events,
     )

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -770,6 +770,39 @@ class KVCacheManager:
         if self.enable_caching:
             self.coordinator.cache_blocks(request, num_computed_tokens)
 
+    def emit_remote_recv_block_stored(
+        self, request: Request, num_tokens: int
+    ) -> None:
+        """Emit BlockStored for blocks filled by a finished remote KV recv.
+
+        When prefix caching is disabled, ``cache_blocks`` is a no-op and does
+        not emit events, so Decode ``active_blocks`` on external consumers
+        (e.g. KV-Conductor) stays at 0 after PD transfer. This helper emits
+        GPU ``BlockStored`` events without mutating block state.
+
+        Skips when events are disabled, prefix caching is enabled (events
+        already come from ``cache_full_blocks``), or ``num_tokens`` covers no
+        full blocks.
+        """
+        if (
+            not self.enable_kv_cache_events
+            or self.enable_caching
+            or num_tokens <= 0
+        ):
+            return
+
+        for group_idx, group in enumerate(self.kv_cache_config.kv_cache_groups):
+            block_size = group.kv_cache_spec.block_size
+            num_blocks = num_tokens // block_size
+            if num_blocks <= 0:
+                continue
+            self.block_pool.emit_cached_block_events(
+                request,
+                num_blocks,
+                block_size,
+                group_idx,
+            )
+
     def create_kv_cache_blocks(
         self, blocks: tuple[list[KVCacheBlock], ...]
     ) -> KVCacheBlocks:

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -130,6 +130,7 @@ class KVCacheManager:
         pcp_world_size: int = 1,
         metrics_collector: KVCacheMetricsCollector | None = None,
         watermark: float = 0.0,
+        enable_block_inactive_events: bool = True,
     ) -> None:
         self.max_model_len = max_model_len
         # When unset, fall back to `max_model_len` so the recycling-aware cap
@@ -160,6 +161,7 @@ class KVCacheManager:
             scheduler_block_size=scheduler_block_size,
             hash_block_size=hash_block_size,
             metrics_collector=self.metrics_collector,
+            enable_block_inactive_events=enable_block_inactive_events,
         )
         self.num_kv_cache_groups = len(kv_cache_config.kv_cache_groups)
         self.block_pool = self.coordinator.block_pool

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2667,6 +2667,17 @@ class Scheduler(SchedulerInterface):
             # This will cache the blocks iff caching is enabled.
             self.kv_cache_manager.cache_blocks(request, request.num_computed_tokens)
 
+            # When prefix caching is off, cache_blocks is a no-op and does not
+            # emit BlockStored. Decode (kv_consumer) still occupies HBM after
+            # remote recv; emit events so external consumers (e.g. Conductor)
+            # can update active_blocks. Skip when caching is on to avoid
+            # double-emitting with cache_full_blocks.
+            ktc = self.vllm_config.kv_transfer_config
+            if ktc is not None and ktc.is_kv_consumer:
+                self.kv_cache_manager.emit_remote_recv_block_stored(
+                    request, request.num_computed_tokens
+                )
+
             # on a full prompt hit, we need to re-compute the last token
             # in order to be able to sample the next token
             if request.num_computed_tokens == request.num_tokens:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -117,6 +117,11 @@ class Scheduler(SchedulerInterface):
             self.kv_events_config is not None
             and self.kv_events_config.enable_kv_cache_events
         )
+        # Prefill-only (kv_producer) skips BlockInactive; decode/both/non-PD emit.
+        ktc = self.vllm_config.kv_transfer_config
+        self.enable_block_inactive_events = (
+            True if ktc is None else ktc.should_emit_block_inactive
+        )
         # Diffusion models may not sample any tokens for a denoising step.
         self.num_sampled_tokens_per_step = (
             1 if not vllm_config.model_config.is_diffusion else 0
@@ -287,6 +292,7 @@ class Scheduler(SchedulerInterface):
             hash_block_size=hash_block_size,
             metrics_collector=self.kv_metrics_collector,
             watermark=self.scheduler_config.watermark,
+            enable_block_inactive_events=self.enable_block_inactive_events,
         )
         # Bind GPU block pool to the KV connector. This must happen after
         # kv_cache_manager is constructed so block_pool is available.


### PR DESCRIPTION
Publish GPU block inactivity when the last request reference is released so external schedulers can maintain accurate decode load signals.


## Purpose

Add a new KV cache event, `BlockInactive`, so external PD schedulers can track when a GPU prefix-cached block is no longer actively referenced.

Today, KV event consumers can observe `BlockStored` and `BlockRemoved`, but cannot reliably detect that the last request released a block while it may still remain in the prefix cache. Without a refcount-zero signal, decode-affinity load accounting (`active_blocks`) tends to only increase or needs fragile heuristics.

This PR:

- Adds `BlockInactive` to `KVEventBatch`, emitted from `BlockPool.free_blocks()` when `ref_cnt` drops to 0 for a hashed GPU block (`medium=MEDIUM_GPU`).
- Publishes it through the existing KV event path (`take_events()` / ZMQ). No new scheduler-loop wiring.
- Gates emission for Prefill-only instances: `kv_role == "kv_producer"` still emits `BlockStored` / `BlockRemoved`, but does **not** emit `BlockInactive`, so Prefill frees do not pollute decode load signals.
- Decode (`kv_consumer`), union (`kv_both`), and non-PD setups continue to emit Inactive via `KVTransferConfig.should_emit_block_inactive` (`kv_role != "kv_producer"`).

Related issue: #50730 

## Test Plan


pytest tests/v1/core/test_prefix_caching.py \
  -k "free_blocks_emits_block_inactive or free_blocks_skips_block_inactive or kv_transfer_should_emit_block_inactive" \
  -q

Coverage:

free_blocks emits BlockInactive when enable_block_inactive_events=True.
Prefill-style gate (enable_block_inactive_events=False) still emits BlockStored, but not BlockInactive.
KVTransferConfig.should_emit_block_inactive is False for kv_producer, True for kv_consumer / kv_both / default.

## Test Result
Unit tests above pass locally.
Existing BlockStored / BlockRemoved behavior is unchanged.
Old KV event consumers can ignore the unknown BlockInactive type.
Validated end-to-end in a 1P1D (one Prefill + one Decode) setup. Additional tests are still in progress.
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

