### PR TITLE
[Feature] Add --rank-gpu-id / --rank-gpu-memory-mib for explicit TP rank placement

### DIFF
--- a/tests/engine/test_rank_gpu_mapping.py
+++ b/tests/engine/test_rank_gpu_mapping.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU-only tests for --rank-gpu-id / --rank-gpu-memory-mib validation.
+
+NVML and platform lookups are mocked so the tests run without GPUs and
+independently of the host's real GPU inventory.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm.engine.arg_utils import EngineArgs
+
+MIB = 1024 * 1024
+
+# torch.cuda index -> NVML total MiB of the mocked inventory:
+# one 32 GiB card and two 20 GiB cards.
+GPU_TOTALS_MIB = {0: 32768, 1: 20480, 2: 20480}
+
+
+class _FakePlatform:
+    @staticmethod
+    def device_count() -> int:
+        return len(GPU_TOTALS_MIB)
+
+
+@pytest.fixture
+def mock_nvml(monkeypatch):
+    """Mock NVML totals and the torch->NVML index mapping."""
+    import vllm.utils.import_utils as import_utils
+    from vllm.platforms.cuda import CudaPlatform
+
+    pynvml = MagicMock()
+
+    def get_handle(nvml_idx):
+        return nvml_idx
+
+    def get_memory_info(handle):
+        info = MagicMock()
+        info.total = GPU_TOTALS_MIB[handle] * MIB
+        return info
+
+    pynvml.nvmlDeviceGetHandleByIndex.side_effect = get_handle
+    pynvml.nvmlDeviceGetMemoryInfo.side_effect = get_memory_info
+    monkeypatch.setattr(import_utils, "import_pynvml", lambda: pynvml)
+    monkeypatch.setattr(
+        CudaPlatform,
+        "get_torch_to_nvml_mapping",
+        classmethod(lambda cls: {i: i for i in GPU_TOTALS_MIB}),
+    )
+    return pynvml
+
+
+def _args(**kwargs) -> EngineArgs:
+    return EngineArgs(model="facebook/opt-125m", **kwargs)
+
+
+def _validate(args: EngineArgs) -> None:
+    args._validate_rank_gpu_config(_FakePlatform())
+
+
+def test_default_path_untouched():
+    # Neither flag set: validation is a no-op.
+    _validate(_args(tensor_parallel_size=2))
+
+
+def test_rank_gpu_id_requires_memory_mib():
+    with pytest.raises(ValueError, match="requires --rank-gpu-memory-mib"):
+        _validate(_args(tensor_parallel_size=2, rank_gpu_id=[0, 1]))
+
+
+def test_memory_mib_requires_rank_gpu_id():
+    with pytest.raises(ValueError, match="requires --rank-gpu-id"):
+        _validate(_args(tensor_parallel_size=2, rank_gpu_memory_mib=15000))
+
+
+def test_length_mismatch():
+    with pytest.raises(ValueError, match="must equal --tensor-parallel-size"):
+        _validate(
+            _args(
+                tensor_parallel_size=4,
+                rank_gpu_id=[0, 1],
+                rank_gpu_memory_mib=15000,
+            )
+        )
+
+
+def test_gpu_memory_utilization_conflict():
+    with pytest.raises(ValueError, match="--gpu-memory-utilization cannot be set"):
+        _validate(
+            _args(
+                tensor_parallel_size=2,
+                rank_gpu_id=[0, 1],
+                rank_gpu_memory_mib=15000,
+                gpu_memory_utilization=0.82,
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "field,value,match",
+    [
+        ("pipeline_parallel_size", 2, "pipeline-parallel-size"),
+        ("data_parallel_size", 2, "data-parallel-size"),
+        ("enable_expert_parallel", True, "expert parallelism"),
+    ],
+)
+def test_rejects_other_parallelism(field, value, match):
+    with pytest.raises(ValueError, match=match):
+        _validate(
+            _args(
+                tensor_parallel_size=2,
+                rank_gpu_id=[0, 1],
+                rank_gpu_memory_mib=15000,
+                **{field: value},
+            )
+        )
+
+
+def test_unknown_gpu_id(mock_nvml):
+    with pytest.raises(ValueError, match="out of range"):
+        _validate(
+            _args(
+                tensor_parallel_size=2,
+                rank_gpu_id=[0, 7],
+                rank_gpu_memory_mib=15000,
+            )
+        )
+
+
+def test_negative_gpu_id(mock_nvml):
+    with pytest.raises(ValueError, match="out of range"):
+        _validate(
+            _args(
+                tensor_parallel_size=2,
+                rank_gpu_id=[0, -1],
+                rank_gpu_memory_mib=15000,
+            )
+        )
+
+
+def test_colocation_fits(mock_nvml):
+    # 2 ranks x 15000 MiB = 30000 MiB on the 32768 MiB card: fits.
+    _validate(
+        _args(
+            tensor_parallel_size=4,
+            rank_gpu_id=[0, 0, 1, 2],
+            rank_gpu_memory_mib=15000,
+        )
+    )
+
+
+def test_colocation_physically_impossible(mock_nvml):
+    # 2 ranks x 15000 MiB = 30000 MiB on a 20480 MiB card: hard error.
+    with pytest.raises(ValueError, match="Physical impossibility"):
+        _validate(
+            _args(
+                tensor_parallel_size=4,
+                rank_gpu_id=[1, 1, 0, 2],
+                rank_gpu_memory_mib=15000,
+            )
+        )
+
+
+def test_single_rank_over_total(mock_nvml):
+    with pytest.raises(ValueError, match="Physical impossibility"):
+        _validate(
+            _args(
+                tensor_parallel_size=2,
+                rank_gpu_id=[1, 2],
+                rank_gpu_memory_mib=20481,
+            )
+        )
+
+
+def test_exact_total_is_allowed(mock_nvml):
+    # The check is a physical-impossibility bound, not a safety margin:
+    # exactly the NVML total must pass.
+    _validate(
+        _args(
+            tensor_parallel_size=2,
+            rank_gpu_id=[1, 2],
+            rank_gpu_memory_mib=20480,
+        )
+    )
+
+
+def test_mib_to_fraction_semantics():
+    # The documented conversion: the same MiB budget yields a different
+    # gpu_memory_utilization fraction per physical GPU, with no extra
+    # discount applied on top.
+    mib = 15000
+    fractions = {gpu: mib / total for gpu, total in GPU_TOTALS_MIB.items()}
+    assert fractions[0] == pytest.approx(15000 / 32768)
+    assert fractions[1] == pytest.approx(15000 / 20480)
+    # Heterogeneous totals must give different fractions for the same MiB.
+    assert fractions[0] != fractions[1]

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -314,6 +314,14 @@ class ParallelConfig:
     checks, and final CUDA device selection when needed. When None,
     logical IDs map to visible device IDs in order."""
 
+    rank_gpu_memory_mib: int | None = None
+    """Absolute MiB memory budget per rank when using --rank-gpu-id.
+
+    This value applies uniformly to every rank. The value is converted
+    to a per-GPU fraction at runtime based on each physical GPU's
+    NVML-reported total memory, so the same MiB value represents a
+    DIFFERENT fraction on different physical GPUs."""
+
     distributed_timeout_seconds: int | None = None
     """Timeout in seconds for distributed operations (e.g., init_process_group).
     If set, this value is passed to torch.distributed.init_process_group as the
@@ -923,6 +931,9 @@ class ParallelConfig:
             elif (
                 current_platform.is_cuda()
                 and current_platform.device_count() < self.world_size
+                # rank_gpu_memory_mib set means --rank-gpu-id is in use,
+                # which allows more ranks than physical GPUs (co-location).
+                and self.rank_gpu_memory_mib is None
             ):
                 gpu_count = current_platform.device_count()
                 raise ValueError(
@@ -930,7 +941,8 @@ class ParallelConfig:
                     f"available GPUs ({gpu_count}) in this node. If this is "
                     "intentional and you are using:\n"
                     "- ray, set '--distributed-executor-backend ray'.\n"
-                    "- multiprocessing, set '--nnodes' appropriately."
+                    "- multiprocessing, set '--nnodes' appropriately.\n"
+                    "- --rank-gpu-id with --rank-gpu-memory-mib to share GPUs."
                 )
             elif self.data_parallel_backend == "ray":
                 logger.info(

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -475,6 +475,8 @@ class EngineArgs:
     numa_bind_nodes: list[int] | None = ParallelConfig.numa_bind_nodes
     numa_bind_cpus: list[str] | None = ParallelConfig.numa_bind_cpus
     device_ids: list[int | str] | None = None
+    rank_gpu_id: list[int] | None = None
+    rank_gpu_memory_mib: int | None = None
     tensor_parallel_size: int = ParallelConfig.tensor_parallel_size
     prefill_context_parallel_size: int = ParallelConfig.prefill_context_parallel_size
     decode_context_parallel_size: int = ParallelConfig.decode_context_parallel_size
@@ -1034,6 +1036,35 @@ class EngineArgs:
             "visibility for GPU-NIC affinity and DeepGEMM. "
             "Note: has no effect with Ray executors; use Ray "
             "placement groups for GPU selection instead.",
+        )
+        parallel_group.add_argument(
+            "--rank-gpu-id",
+            type=lambda s: [int(x) for x in (part.strip() for part in s.split(","))],
+            default=None,
+            help="Comma-separated GPU indices for each tensor parallel rank. "
+            "IMPORTANT: these are PyTorch device indices (the ordering behind "
+            "'cuda:N'), NOT nvidia-smi/NVML indices, which can enumerate "
+            "differently. "
+            "Duplicates mean multiple ranks share that GPU. "
+            "Length must equal tensor-parallel-size. "
+            "Example: --rank-gpu-id 0,1 (two GPUs, one rank each). "
+            "Example: --rank-gpu-id 0,0,1,2 (TP=4, first GPU shared by two ranks). "
+            "Requires --rank-gpu-memory-mib to be set. "
+            "Mutually exclusive with --gpu-memory-utilization.",
+        )
+        parallel_group.add_argument(
+            "--rank-gpu-memory-mib",
+            type=int,
+            default=None,
+            help="Absolute memory budget in MiB per rank when using "
+            "--rank-gpu-id. This is a single scalar value (not a list) "
+            "that applies uniformly to every rank. "
+            "The value is converted to a per-GPU fraction at runtime based on "
+            "each physical GPU's NVML-reported total memory, so the same MiB "
+            "value represents a DIFFERENT fraction on different physical GPUs. "
+            "Required when --rank-gpu-id is set. "
+            "Mutually exclusive with --gpu-memory-utilization "
+            "(setting both is a hard error).",
         )
         parallel_group.add_argument(
             "--tensor-parallel-size", "-tp", **parallel_kwargs["tensor_parallel_size"]
@@ -2188,6 +2219,9 @@ class EngineArgs:
             model_config.skip_tokenizer_init = True
             logger.info("Skipping tokenizer initialization for tokens-only mode.")
 
+        # Validate --rank-gpu-id and --rank-gpu-memory-mib
+        self._validate_rank_gpu_config(current_platform)
+
         parallel_config = ParallelConfig(
             pipeline_parallel_size=self.pipeline_parallel_size,
             tensor_parallel_size=self.tensor_parallel_size,
@@ -2233,7 +2267,14 @@ class EngineArgs:
             cp_kv_cache_interleave_size=self.cp_kv_cache_interleave_size,
             _api_process_count=self._api_process_count,
             _api_process_rank=self._api_process_rank,
-            assigned_physical_gpu_ids=self._resolve_device_ids(),
+            # When --rank-gpu-id is set, use it as the physical GPU mapping
+            # Otherwise use --device-ids if provided
+            assigned_physical_gpu_ids=(
+                self.rank_gpu_id
+                if self.rank_gpu_id is not None
+                else self._resolve_device_ids()
+            ),
+            rank_gpu_memory_mib=self.rank_gpu_memory_mib,
             enable_fault_tolerance=self.enable_fault_tolerance,
             fault_tolerance_config=self.fault_tolerance_config,
             numa_bind=self.numa_bind,
@@ -2484,6 +2525,106 @@ class EngineArgs:
         )
 
         return config
+
+    def _validate_rank_gpu_config(self, current_platform) -> None:
+        """
+        Validate --rank-gpu-id and --rank-gpu-memory-mib consistency.
+
+        This validates:
+        1. Mutual exclusivity: both or neither must be set
+        2. Length vs tensor_parallel_size
+        3. PP/DP/EP not supported with --rank-gpu-id
+        4. --gpu-memory-utilization not allowed with --rank-gpu-id
+        5. Physical GPU existence via NVML
+        6. Physical impossibility: (rank_count on GPU) * MiB <= NVML total
+        """
+        from collections import Counter
+
+        # Mutual exclusivity check
+        if self.rank_gpu_id is None and self.rank_gpu_memory_mib is not None:
+            raise ValueError("--rank-gpu-memory-mib requires --rank-gpu-id to be set.")
+        if self.rank_gpu_memory_mib is None and self.rank_gpu_id is not None:
+            raise ValueError("--rank-gpu-id requires --rank-gpu-memory-mib to be set.")
+
+        if self.rank_gpu_id is None:
+            return
+
+        # Length vs tensor_parallel_size
+        if len(self.rank_gpu_id) != self.tensor_parallel_size:
+            raise ValueError(
+                f"--rank-gpu-id length ({len(self.rank_gpu_id)}) must equal "
+                f"--tensor-parallel-size ({self.tensor_parallel_size})."
+            )
+
+        # PP/DP/EP not supported
+        if self.pipeline_parallel_size > 1:
+            raise ValueError(
+                f"--rank-gpu-id is not compatible with pipeline-parallel-size > 1 "
+                f"(current: {self.pipeline_parallel_size}). "
+                "Only pure Tensor Parallelism is supported."
+            )
+        if self.data_parallel_size > 1:
+            raise ValueError(
+                f"--rank-gpu-id is not compatible with data-parallel-size > 1 "
+                f"(current: {self.data_parallel_size}). "
+                "Only pure Tensor Parallelism is supported."
+            )
+        if self.enable_expert_parallel:
+            raise ValueError("--rank-gpu-id is not compatible with expert parallelism.")
+
+        # --gpu-memory-utilization must not be set
+        if self.gpu_memory_utilization != CacheConfig.gpu_memory_utilization:
+            raise ValueError(
+                "--gpu-memory-utilization cannot be set when --rank-gpu-id is used. "
+                "Use --rank-gpu-memory-mib instead to specify absolute MiB budget."
+            )
+
+        # Get torch -> NVML mapping for validation
+        from vllm.platforms.cuda import CudaPlatform
+        from vllm.utils.import_utils import import_pynvml
+
+        torch_to_nvml = CudaPlatform.get_torch_to_nvml_mapping()
+        pynvml = import_pynvml()
+        pynvml.nvmlInit()
+
+        try:
+            # NVML-based physical existence check and sum validation
+            device_count = current_platform.device_count()
+            gpu_counts = Counter(self.rank_gpu_id)
+
+            for gpu_id in self.rank_gpu_id:
+                if gpu_id < 0 or gpu_id >= device_count:
+                    raise ValueError(
+                        f"Physical GPU ID {gpu_id} is out of range. "
+                        f"Available GPUs: 0-{device_count - 1}"
+                    )
+
+                # Map torch.cuda index to NVML physical index for memory query
+                if gpu_id not in torch_to_nvml:
+                    raise ValueError(
+                        f"Could not map torch.cuda:{gpu_id} to a physical GPU. "
+                        f"Available torch.cuda indices: 0-{device_count - 1}"
+                    )
+                nvml_idx = torch_to_nvml[gpu_id]
+
+                # Physical impossibility check using NVML directly
+                # (get_device_total_memory() uses torch.cuda props, not NVML)
+                handle = pynvml.nvmlDeviceGetHandleByIndex(nvml_idx)
+                nvml_total_bytes = pynvml.nvmlDeviceGetMemoryInfo(handle).total
+                nvml_total_mib = nvml_total_bytes // (1024 * 1024)
+                count_on_gpu = gpu_counts[gpu_id]
+                required_mib = count_on_gpu * self.rank_gpu_memory_mib
+
+                if required_mib > nvml_total_mib:
+                    raise ValueError(
+                        f"Physical impossibility: torch.cuda:{gpu_id} "
+                        f"(NVML:{nvml_idx}, {nvml_total_mib} MiB total) cannot fit "
+                        f"{count_on_gpu} ranks x {self.rank_gpu_memory_mib} MiB "
+                        f"= {required_mib} MiB requested. "
+                        f"Reduce --rank-gpu-memory-mib or use fewer ranks on this GPU."
+                    )
+        finally:
+            pynvml.nvmlShutdown()
 
     def _check_feature_supported(self):
         """Raise an error if the feature is not supported."""

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -948,6 +948,42 @@ class NvmlCudaPlatform(CudaPlatformBase):
 
     @classmethod
     @with_nvml_context
+    def get_torch_to_nvml_mapping(cls) -> dict[int, int]:
+        """
+        Build a mapping from torch.cuda device indices to NVML physical indices.
+
+        torch.cuda and NVML/nvidia-smi can enumerate GPUs in different orders.
+        This function resolves the mapping using PCI bus IDs as the bridge.
+
+        Returns:
+            Dict mapping torch.cuda index -> NVML physical index
+        """
+        import torch
+
+        # Build NVML index -> PCI bus ID mapping (extract just the bus number)
+        nvml_bus_to_idx: dict[int, int] = {}
+        for nvml_idx in range(pynvml.nvmlDeviceGetCount()):
+            handle = pynvml.nvmlDeviceGetHandleByIndex(nvml_idx)
+            pci_info = pynvml.nvmlDeviceGetPciInfo(handle)
+            bus_id = pci_info.busId
+            if isinstance(bus_id, bytes):
+                bus_id = bus_id.decode("utf-8")
+            # Extract bus number (format: "00000000:BB:00.0")
+            bus_num = int(bus_id.split(":")[1], 16)
+            nvml_bus_to_idx[bus_num] = nvml_idx
+
+        # Map torch.cuda indices to NVML indices via PCI bus ID
+        result: dict[int, int] = {}
+        for torch_idx in range(torch.cuda.device_count()):
+            props = torch.cuda.get_device_properties(torch_idx)
+            bus_num = props.pci_bus_id
+            if bus_num in nvml_bus_to_idx:
+                result[torch_idx] = nvml_bus_to_idx[bus_num]
+
+        return result
+
+    @classmethod
+    @with_nvml_context
     def log_warnings(cls):
         device_ids: int = pynvml.nvmlDeviceGetCount()
         if device_ids > 1:

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -701,6 +701,50 @@ class WorkerProc:
             # Have the worker close parent end of this worker's pipes too
             "inherited_fds": inherited_fds if inherited_fds is not None else [],
         }
+
+        # Device isolation for --rank-gpu-id mode is handled by setting the
+        # accelerator device index inside the worker process, NOT via
+        # CUDA_VISIBLE_DEVICES. Setting CUDA_VISIBLE_DEVICES would break
+        # logical_device_id_to_visible_device_id(), which expects PyTorch
+        # device indices, not NVML physical indices.
+        #
+        # The worker selects assigned_physical_gpu_ids[local_rank] as its own
+        # device, so each worker uses the correct GPU regardless of what is
+        # visible in CUDA_VISIBLE_DEVICES.
+
+        # Configure NCCL for multi-rank-per-GPU if duplicates detected
+        assigned_ids = vllm_config.parallel_config.assigned_physical_gpu_ids
+        if assigned_ids is not None and len(assigned_ids) != len(set(assigned_ids)):
+            from collections import Counter
+
+            os.environ["NCCL_MULTI_RANK_GPU_ENABLE"] = "1"
+            os.environ["NCCL_NVLS_ENABLE"] = "0"
+            gpu_counts = Counter(assigned_ids)
+            max_colocated = max(gpu_counts.values())
+            if max_colocated > 1:
+                suggested_max_ctas = max(1, 8 // max_colocated)
+                os.environ.setdefault("NCCL_MAX_CTAS", str(suggested_max_ctas))
+            logger.warning_once(
+                "Detected multiple ranks sharing physical GPUs. "
+                "Setting NCCL_MULTI_RANK_GPU_ENABLE=1, NCCL_NVLS_ENABLE=0, "
+                "NCCL_MAX_CTAS=%s for multi-rank-per-GPU.",
+                os.environ.get("NCCL_MAX_CTAS", "default"),
+            )
+            # Without CUDA MPS, processes sharing a GPU are TIME-SLICED:
+            # their kernels never run concurrently, but NCCL collectives
+            # busy-spin waiting for the peer rank. Observed impact on this
+            # feature during development was well over an order of
+            # magnitude in achievable decode throughput.
+            mps_pipe_dir = os.environ.get("CUDA_MPS_PIPE_DIRECTORY", "/tmp/nvidia-mps")
+            if not os.path.exists(mps_pipe_dir):
+                logger.warning_once(
+                    "Multiple ranks share a physical GPU but the CUDA MPS "
+                    "control pipe (%s) was not found. Without MPS, co-located "
+                    "ranks are time-sliced and NCCL collectives become "
+                    "extremely slow (>20x slowdown). Start MPS with "
+                    "'nvidia-cuda-mps-control -d' before launching vLLM.",
+                    mps_pipe_dir,
+                )
         # Run EngineCore busy loop in background process.
         proc = context.Process(
             target=WorkerProc.worker_main,

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -61,6 +61,7 @@ from vllm.tasks import SupportedTask
 from vllm.tracing import instrument
 from vllm.utils.gc_utils import freeze_gc_heap, maybe_attach_gc_debug_callback
 from vllm.utils.gpu_sync_debug import enable_gpu_sync_check, with_gpu_sync_check
+from vllm.utils.import_utils import import_pynvml
 from vllm.utils.mem_constants import GiB_bytes
 from vllm.utils.mem_utils import MemorySnapshot, format_gib, memory_profiling
 from vllm.utils.torch_utils import set_random_seed
@@ -355,15 +356,70 @@ class Worker(WorkerBase):
                         " exceeds assigned_physical_gpu_ids count "
                         f"({len(assigned_physical_gpu_ids)})"
                     )
+
+                # Convert the absolute --rank-gpu-memory-mib value to a
+                # per-rank fraction. The same MiB value maps to a different
+                # fraction depending on which physical GPU this rank landed
+                # on (heterogeneous setups can mix different VRAM sizes).
+                rank_gpu_memory_mib = parallel_config.rank_gpu_memory_mib
+                if rank_gpu_memory_mib is not None:
+                    torch_cuda_idx = assigned_physical_gpu_ids[self.local_rank]
+                    # Map torch.cuda index to NVML physical index for memory query
+                    # torch.cuda and NVML enumerate GPUs in different orders
+                    from vllm.platforms.cuda import CudaPlatform
+
+                    torch_to_nvml = CudaPlatform.get_torch_to_nvml_mapping()
+                    if torch_cuda_idx in torch_to_nvml:
+                        nvml_idx = torch_to_nvml[torch_cuda_idx]
+                    else:
+                        nvml_idx = torch_cuda_idx  # Fallback
+                    # Query NVML directly (bypasses device_id_to_physical_device_id).
+                    pynvml = import_pynvml()
+                    pynvml.nvmlInit()
+                    handle = pynvml.nvmlDeviceGetHandleByIndex(nvml_idx)
+                    nvml_total_bytes = pynvml.nvmlDeviceGetMemoryInfo(handle).total
+                    pynvml.nvmlShutdown()
+                    nvml_total_mib = nvml_total_bytes // (1024 * 1024)
+                    # CRITICAL: do not apply any additional percentage
+                    # reduction here. This is the rank's entire memory
+                    # budget on this GPU - 100% of the assigned MiB value,
+                    # not a fraction of it subject to further discounting.
+                    fraction = rank_gpu_memory_mib / nvml_total_mib
+                    logger.info(
+                        "Rank %d on torch.cuda:%d (NVML:%d): Using "
+                        "--rank-gpu-memory-mib=%d MiB "
+                        "(%s/%s GiB total = %.4f fraction)",
+                        self.rank,
+                        torch_cuda_idx,
+                        nvml_idx,
+                        rank_gpu_memory_mib,
+                        format_gib(rank_gpu_memory_mib * 1024 * 1024),
+                        format_gib(nvml_total_bytes),
+                        fraction,
+                    )
+                    # Store the fraction in cache_config for downstream use
+                    # (request_memory, determine_available_memory).
+                    self.cache_config.gpu_memory_utilization = fraction
+                    # Keep the NVML index around for per-process memory
+                    # accounting in determine_available_memory().
+                    self._rank_gpu_nvml_idx = nvml_idx
             else:
                 assert self.local_rank < torch.accelerator.device_count(), (
                     f"DP adjusted local rank {self.local_rank} is out of "
                     f"bounds for {torch.accelerator.device_count()} devices."
                 )
 
-            visible_device_index = (
-                current_platform.logical_device_id_to_visible_device_id(self.local_rank)
-            )
+            # Device isolation via --rank-gpu-id: each worker uses the torch.cuda
+            # index from assigned_physical_gpu_ids. This is the actual GPU device.
+            if parallel_config.rank_gpu_memory_mib is not None:
+                torch_cuda_idx = assigned_physical_gpu_ids[self.local_rank]
+                visible_device_index = torch_cuda_idx
+            else:
+                visible_device_index = (
+                    current_platform.logical_device_id_to_visible_device_id(
+                        self.local_rank
+                    )
+                )
             self.device = torch.device(f"cuda:{visible_device_index}")
             torch.accelerator.set_device_index(self.device)
 
@@ -495,6 +551,41 @@ class Worker(WorkerBase):
                 getattr(self.parallel_config, "_api_process_count", 1),
             )
 
+        # When multiple ranks share a physical GPU (via --rank-gpu-id), they
+        # execute determine_available_memory() concurrently. The default
+        # profiling path measures memory via the driver's mem_get_info, which
+        # is GPU-GLOBAL: each rank would see the other co-located rank's
+        # allocations (weights, activations, CUDA graphs) as its own
+        # "non-torch" overhead, roughly doubling non_kv_cache_memory and
+        # producing negative available-KV-cache estimates.
+        #
+        # NOTE: Serializing the profiling with a barrier is NOT possible:
+        # profile_run() executes a forward pass containing TP collectives
+        # (all-reduce), so ALL ranks must run it simultaneously - holding
+        # back one rank deadlocks the whole TP group.
+        #
+        # Solution: for co-located ranks, replace the mem_get_info-based
+        # non-torch measurement with a PER-PROCESS measurement from NVML
+        # (nvmlDeviceGetComputeRunningProcesses), which reports each
+        # process's own GPU memory usage independently.
+        assigned_ids = self.vllm_config.parallel_config.assigned_physical_gpu_ids
+        co_located_count = 1
+        if (
+            assigned_ids is not None
+            and self.vllm_config.parallel_config.rank_gpu_memory_mib is not None
+        ):
+            physical_gpu_id = assigned_ids[self.local_rank]
+            co_located_count = sum(1 for gid in assigned_ids if gid == physical_gpu_id)
+            if co_located_count > 1:
+                logger.info(
+                    "Rank %d shares torch.cuda:%d with %d ranks total; using "
+                    "per-process NVML memory accounting instead of global "
+                    "mem_get_info for KV cache sizing.",
+                    self.local_rank,
+                    physical_gpu_id,
+                    co_located_count,
+                )
+
         # Execute a forward pass with dummy inputs to profile the memory usage
         # of the model.
         with memory_profiling(
@@ -516,6 +607,58 @@ class Worker(WorkerBase):
         ):
             cudagraph_memory_estimate = self.model_runner.profile_cudagraph_memory()
 
+        if co_located_count > 1:
+            # Replace the polluted GPU-global measurement with a per-process
+            # one: total_consumed comes from mem_get_info(), which would
+            # count a co-located peer's allocations as ours. NVML reports
+            # this process's own GPU memory; subtracting torch's reserved
+            # pool leaves the true non-torch overhead (CUDA context, NCCL
+            # buffers, cuBLAS workspaces, ...).
+            nvml_idx = getattr(self, "_rank_gpu_nvml_idx", None)
+            my_pid = os.getpid()
+            proc_used_bytes = 0
+            if nvml_idx is not None:
+                pynvml = import_pynvml()
+                pynvml.nvmlInit()
+                try:
+                    handle = pynvml.nvmlDeviceGetHandleByIndex(nvml_idx)
+                    for proc in pynvml.nvmlDeviceGetComputeRunningProcesses(handle):
+                        if proc.pid == my_pid and proc.usedGpuMemory is not None:
+                            proc_used_bytes = proc.usedGpuMemory
+                            break
+                finally:
+                    pynvml.nvmlShutdown()
+            torch_reserved = torch.accelerator.memory_reserved(self.device)
+            non_torch_local = max(0, proc_used_bytes - torch_reserved)
+            # CUDA graph estimates via mem_get_info are also polluted by the
+            # co-located rank (can even go negative); clamp to non-negative.
+            cudagraph_memory_estimate = max(0, cudagraph_memory_estimate)
+            logger.info(
+                "Co-located memory accounting (rank %d, pid %d, NVML:%s): "
+                "nvml_proc_used=%s GiB, torch_reserved=%s GiB, "
+                "non_torch_local=%s GiB (global measurement was %s GiB), "
+                "weights=%s GiB, torch_peak_increase=%s GiB, "
+                "cudagraph_estimate=%s GiB, budget=%s GiB",
+                self.local_rank,
+                my_pid,
+                nvml_idx,
+                format_gib(proc_used_bytes),
+                format_gib(torch_reserved),
+                format_gib(non_torch_local),
+                format_gib(profile_result.non_torch_increase),
+                format_gib(profile_result.weights_memory),
+                format_gib(profile_result.torch_peak_increase),
+                format_gib(cudagraph_memory_estimate),
+                format_gib(self.requested_memory),
+            )
+            profile_result.non_torch_increase = non_torch_local
+            profile_result.total_consumed = proc_used_bytes
+            profile_result.non_kv_cache_memory = (
+                non_torch_local
+                + profile_result.torch_peak_increase
+                + profile_result.weights_memory
+            )
+
         # Respect the opt-in flag as originally designed.
         cudagraph_memory_estimate_applied = (
             cudagraph_memory_estimate
@@ -532,7 +675,11 @@ class Worker(WorkerBase):
         free_gpu_memory = profile_result.after_profile.free_memory
         # NOTE(woosuk): Here we assume that the other processes using the same
         # GPU did not change their memory usage during the profiling.
-        assert self.init_snapshot.free_memory >= free_gpu_memory, (
+        # With --rank-gpu-id co-location this assumption does not hold (the
+        # co-located rank allocates/frees concurrently), so skip the check.
+        assert co_located_count > 1 or (
+            self.init_snapshot.free_memory >= free_gpu_memory
+        ), (
             "Error in memory profiling. "
             f"Initial free memory {format_gib(self.init_snapshot.free_memory)} GiB, "
             f"current free memory {format_gib(free_gpu_memory)} GiB. "


### PR DESCRIPTION
## What

Two engine arguments that let a single-node, pure-TP deployment choose which GPU each tensor-parallel rank runs on, including putting several ranks on the same physical GPU:

```bash
vllm serve MODEL \
  --tensor-parallel-size 4 \
  --rank-gpu-id 0,0,1,2 \        # duplicates: rank 0 and rank 1 share GPU 0
  --rank-gpu-memory-mib 14000    # absolute per-rank budget
```

## Motivation

Rank placement is currently implicit. `Worker.init_device` maps `local_rank` straight onto a device index via `current_platform.logical_device_id_to_visible_device_id(self.local_rank)` (`vllm/v1/worker/gpu_worker.py`), and `ParallelConfig` refuses to start on the multiprocessing backend when `world_size > device_count` — "World size (...) is larger than the number of available GPUs (...)" (`vllm/config/parallel.py`). So there is no way to express "run TP=4 on 3 GPUs" or "rank 0 belongs on the big card", short of `CUDA_VISIBLE_DEVICES` gymnastics that only reorder, never duplicate.

`--rank-gpu-id` takes one PyTorch device index per rank and reuses the existing `ParallelConfig.assigned_physical_gpu_ids` field, which until now was only populated from the engine-core path.

`--rank-gpu-memory-mib` is a single absolute MiB budget applied to every rank. Under pure TP each rank holds structurally equal-sized weight shards, activation buffers and KV-cache share, so one number per rank matches the actual symmetry rather than losing information. Each rank converts it to its own fraction from the NVML-reported total of the GPU it landed on, so the same MiB value becomes a different `gpu_memory_utilization` on a 20 GB and a 32 GB card. From there the existing sizing pipeline runs unmodified. No implicit ceiling or safety factor is layered on top of the supplied value — leaving headroom for CUDA context and fragmentation is the caller's decision.

The two flags are mandatory together, and either of them together with `--gpu-memory-utilization` is a hard error rather than a silent precedence rule.

## Implementation notes

- Validation is fail-fast at argument-parsing time: the list length must equal `tensor_parallel_size`, the indices must exist, and `ranks_on_gpu * rank_gpu_memory_mib` must not exceed that GPU's NVML total. The error names the GPU, the ranks on it, the requested product and the actual total.
- NVML is used *only* to read a device's memory total. Device selection stays on PyTorch's own indices. Those two orderings can disagree, which is why the help text says so explicitly.
- Co-located ranks get `NCCL_MULTI_RANK_GPU_ENABLE=1`, `NCCL_NVLS_ENABLE=0` and a lowered `NCCL_MAX_CTAS` set automatically, with a log line stating what was set.
- KV-cache profiling for co-located ranks switches from the GPU-global `mem_get_info` to a per-process NVML query. The global reading counts a co-located peer's weights, activations and graphs as this rank's non-torch overhead, which roughly doubles the estimate and can drive the available-KV-cache figure negative. Serialising with a barrier is not an option here: `profile_run()` contains TP collectives, so all ranks must be inside it at the same time.

## Scope and limits

- Pure TP, single node. Any combination with pipeline, data or expert parallelism aborts with an explicit message instead of attempting a generic solution.
- Without CUDA MPS, ranks sharing a GPU are time-sliced and NCCL collectives busy-wait on a peer that is not running. The code warns when the MPS control pipe is missing but does not refuse to start.
- The default path is gated: every new block sits behind `rank_gpu_memory_mib is not None`. The only difference visible without the flags is one extra sentence appended to the existing "world size larger than available GPUs" error.

## Verification

Run against this branch:

- `pytest tests/engine/test_rank_gpu_mapping.py` — 15 passed (new file, CPU only).
- `pytest tests/engine/test_arg_utils.py tests/v1/core/test_kv_cache_utils.py` — passed, unchanged from `main`.
- `ruff check` / `ruff format --check`, plus the repo's `check_spdx_header`, `check_init_lazy_imports`, `check_forbidden_imports`, `check_torch_cuda`, `check_boolean_context_manager` and `validate_config` hooks.

End-to-end serving with these flags (TP=2 one rank per card, and TP=4 with two ranks co-located on the largest card, across mismatched consumer GPUs) was validated earlier on my own hardware. I did not re-run those on this rebase, so treat the multi-GPU behaviour as previously observed rather than freshly reproduced here. The tests above are CPU-only by construction.
