### PR TITLE
[Feature] Add --rank-tp-ratio for uneven tensor parallelism on mismatched GPUs

### DIFF
--- a/tests/distributed/test_uneven_tp_partition.py
+++ b/tests/distributed/test_uneven_tp_partition.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU-only tests for the --rank-tp-ratio uneven-TP partition helpers."""
+
+import pytest
+
+from vllm.distributed.utils import (
+    get_tp_partition_ratios,
+    set_tp_partition_ratios,
+    tp_partition_offset,
+    tp_partition_size,
+    tp_partition_sizes,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_ratios():
+    set_tp_partition_ratios(None)
+    yield
+    set_tp_partition_ratios(None)
+
+
+def test_ratios_unset_by_default():
+    assert get_tp_partition_ratios() is None
+
+
+def test_set_and_get_ratios():
+    set_tp_partition_ratios([2, 1, 1])
+    assert get_tp_partition_ratios() == [2, 1, 1]
+    set_tp_partition_ratios(None)
+    assert get_tp_partition_ratios() is None
+
+
+def test_even_split_without_ratios():
+    assert tp_partition_sizes(32, 4) == [8, 8, 8, 8]
+    assert tp_partition_size(32, 4, 2) == 8
+    assert tp_partition_offset(32, 4, 2) == 16
+
+
+def test_even_split_requires_divisibility():
+    with pytest.raises(AssertionError):
+        tp_partition_sizes(10, 4)
+
+
+def test_ratio_split():
+    set_tp_partition_ratios([2, 1, 1])
+    assert tp_partition_sizes(32, 3) == [16, 8, 8]
+    assert [tp_partition_size(32, 3, r) for r in range(3)] == [16, 8, 8]
+    # Offsets are prefix sums of the per-rank sizes.
+    assert [tp_partition_offset(32, 3, r) for r in range(3)] == [0, 16, 24]
+
+
+def test_ratio_split_covers_dimension_exactly():
+    set_tp_partition_ratios([3, 2, 1])
+    sizes = tp_partition_sizes(48, 3)
+    assert sizes == [24, 16, 8]
+    assert sum(sizes) == 48
+    assert tp_partition_offset(48, 3, 2) + sizes[2] == 48
+
+
+def test_ratio_split_rejects_non_divisible():
+    set_tp_partition_ratios([2, 1, 1])
+    with pytest.raises(ValueError, match="not divisible by"):
+        tp_partition_sizes(30, 3)
+
+
+def test_ratio_length_mismatch_falls_back_to_even():
+    # Layers running with their own tp_size (e.g. disable_tp -> tp_size=1)
+    # must not be affected by an installed ratio vector.
+    set_tp_partition_ratios([2, 1, 1])
+    assert tp_partition_sizes(32, 1) == [32]
+    assert tp_partition_sizes(32, 4) == [8, 8, 8, 8]
+
+
+def test_arg_validation_ratio_rules():
+    from vllm.engine.arg_utils import EngineArgs
+
+    class _FakePlatform:
+        @staticmethod
+        def device_count() -> int:
+            return 3
+
+    def validate(**kwargs):
+        args = EngineArgs(model="facebook/opt-125m", **kwargs)
+        args._validate_rank_gpu_config(_FakePlatform())
+
+    # --rank-tp-ratio requires --rank-gpu-id.
+    with pytest.raises(ValueError, match="requires --rank-gpu-id"):
+        validate(tensor_parallel_size=3, rank_tp_ratio=[2, 1, 1])
+
+    common = dict(
+        tensor_parallel_size=3,
+        rank_gpu_id=[0, 1, 2],
+        rank_gpu_memory_mib=15000,
+    )
+    # Length must equal tensor_parallel_size.
+    with pytest.raises(ValueError, match="--rank-tp-ratio length"):
+        validate(rank_tp_ratio=[2, 1], **common)
+    # Entries must be positive.
+    with pytest.raises(ValueError, match="positive integers"):
+        validate(rank_tp_ratio=[2, 0, 1], **common)

--- a/tests/engine/test_rank_gpu_mapping.py
+++ b/tests/engine/test_rank_gpu_mapping.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU-only tests for --rank-gpu-id / --rank-gpu-memory-mib validation.
+
+NVML and platform lookups are mocked so the tests run without GPUs and
+independently of the host's real GPU inventory.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm.engine.arg_utils import EngineArgs
+
+MIB = 1024 * 1024
+
+# torch.cuda index -> NVML total MiB of the mocked inventory:
+# one 32 GiB card and two 20 GiB cards.
+GPU_TOTALS_MIB = {0: 32768, 1: 20480, 2: 20480}
+
+
+class _FakePlatform:
+    @staticmethod
+    def device_count() -> int:
+        return len(GPU_TOTALS_MIB)
+
+
+@pytest.fixture
+def mock_nvml(monkeypatch):
+    """Mock NVML totals and the torch->NVML index mapping."""
+    import vllm.utils.import_utils as import_utils
+    from vllm.platforms.cuda import CudaPlatform
+
+    pynvml = MagicMock()
+
+    def get_handle(nvml_idx):
+        return nvml_idx
+
+    def get_memory_info(handle):
+        info = MagicMock()
+        info.total = GPU_TOTALS_MIB[handle] * MIB
+        return info
+
+    pynvml.nvmlDeviceGetHandleByIndex.side_effect = get_handle
+    pynvml.nvmlDeviceGetMemoryInfo.side_effect = get_memory_info
+    monkeypatch.setattr(import_utils, "import_pynvml", lambda: pynvml)
+    monkeypatch.setattr(
+        CudaPlatform,
+        "get_torch_to_nvml_mapping",
+        classmethod(lambda cls: {i: i for i in GPU_TOTALS_MIB}),
+    )
+    return pynvml
+
+
+def _args(**kwargs) -> EngineArgs:
+    return EngineArgs(model="facebook/opt-125m", **kwargs)
+
+
+def _validate(args: EngineArgs) -> None:
+    args._validate_rank_gpu_config(_FakePlatform())
+
+
+def test_default_path_untouched():
+    # Neither flag set: validation is a no-op.
+    _validate(_args(tensor_parallel_size=2))
+
+
+def test_rank_gpu_id_requires_memory_mib():
+    with pytest.raises(ValueError, match="requires --rank-gpu-memory-mib"):
+        _validate(_args(tensor_parallel_size=2, rank_gpu_id=[0, 1]))
+
+
+def test_memory_mib_requires_rank_gpu_id():
+    with pytest.raises(ValueError, match="requires --rank-gpu-id"):
+        _validate(_args(tensor_parallel_size=2, rank_gpu_memory_mib=15000))
+
+
+def test_length_mismatch():
+    with pytest.raises(ValueError, match="must equal --tensor-parallel-size"):
+        _validate(
+            _args(
+                tensor_parallel_size=4,
+                rank_gpu_id=[0, 1],
+                rank_gpu_memory_mib=15000,
+            )
+        )
+
+
+def test_gpu_memory_utilization_conflict():
+    with pytest.raises(ValueError, match="--gpu-memory-utilization cannot be set"):
+        _validate(
+            _args(
+                tensor_parallel_size=2,
+                rank_gpu_id=[0, 1],
+                rank_gpu_memory_mib=15000,
+                gpu_memory_utilization=0.82,
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "field,value,match",
+    [
+        ("pipeline_parallel_size", 2, "pipeline-parallel-size"),
+        ("data_parallel_size", 2, "data-parallel-size"),
+        ("enable_expert_parallel", True, "expert parallelism"),
+    ],
+)
+def test_rejects_other_parallelism(field, value, match):
+    with pytest.raises(ValueError, match=match):
+        _validate(
+            _args(
+                tensor_parallel_size=2,
+                rank_gpu_id=[0, 1],
+                rank_gpu_memory_mib=15000,
+                **{field: value},
+            )
+        )
+
+
+def test_unknown_gpu_id(mock_nvml):
+    with pytest.raises(ValueError, match="out of range"):
+        _validate(
+            _args(
+                tensor_parallel_size=2,
+                rank_gpu_id=[0, 7],
+                rank_gpu_memory_mib=15000,
+            )
+        )
+
+
+def test_negative_gpu_id(mock_nvml):
+    with pytest.raises(ValueError, match="out of range"):
+        _validate(
+            _args(
+                tensor_parallel_size=2,
+                rank_gpu_id=[0, -1],
+                rank_gpu_memory_mib=15000,
+            )
+        )
+
+
+def test_colocation_fits(mock_nvml):
+    # 2 ranks x 15000 MiB = 30000 MiB on the 32768 MiB card: fits.
+    _validate(
+        _args(
+            tensor_parallel_size=4,
+            rank_gpu_id=[0, 0, 1, 2],
+            rank_gpu_memory_mib=15000,
+        )
+    )
+
+
+def test_colocation_physically_impossible(mock_nvml):
+    # 2 ranks x 15000 MiB = 30000 MiB on a 20480 MiB card: hard error.
+    with pytest.raises(ValueError, match="Physical impossibility"):
+        _validate(
+            _args(
+                tensor_parallel_size=4,
+                rank_gpu_id=[1, 1, 0, 2],
+                rank_gpu_memory_mib=15000,
+            )
+        )
+
+
+def test_single_rank_over_total(mock_nvml):
+    with pytest.raises(ValueError, match="Physical impossibility"):
+        _validate(
+            _args(
+                tensor_parallel_size=2,
+                rank_gpu_id=[1, 2],
+                rank_gpu_memory_mib=20481,
+            )
+        )
+
+
+def test_exact_total_is_allowed(mock_nvml):
+    # The check is a physical-impossibility bound, not a safety margin:
+    # exactly the NVML total must pass.
+    _validate(
+        _args(
+            tensor_parallel_size=2,
+            rank_gpu_id=[1, 2],
+            rank_gpu_memory_mib=20480,
+        )
+    )
+
+
+def test_mib_to_fraction_semantics():
+    # The documented conversion: the same MiB budget yields a different
+    # gpu_memory_utilization fraction per physical GPU, with no extra
+    # discount applied on top.
+    mib = 15000
+    fractions = {gpu: mib / total for gpu, total in GPU_TOTALS_MIB.items()}
+    assert fractions[0] == pytest.approx(15000 / 32768)
+    assert fractions[1] == pytest.approx(15000 / 20480)
+    # Heterogeneous totals must give different fractions for the same MiB.
+    assert fractions[0] != fractions[1]

--- a/vllm/compilation/caching.py
+++ b/vllm/compilation/caching.py
@@ -578,6 +578,16 @@ def aot_compile_hash_factors(vllm_config: VllmConfig) -> list[str]:
     if envs.VLLM_USE_MEGA_AOT_ARTIFACT:
         factors.extend(get_inductor_factors())
 
+    # 3. identity of the GPU this worker actually runs on. With
+    #    heterogeneous rank placement (--rank-gpu-id) different ranks of
+    #    the same job may sit on different architectures; sharing one AOT
+    #    artifact across them loads wrong-arch kernels (hard launch
+    #    failure on the older arch, silently mistuned PTX-JIT kernels on
+    #    the newer one). Homogeneous setups just gain a constant factor.
+    if torch.cuda.is_available():
+        factors.append(torch.cuda.get_device_name())
+        factors.append(str(torch.cuda.get_device_capability()))
+
     return factors
 
 

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1312,7 +1312,18 @@ class ModelConfig:
     ) -> None:
         total_num_attention_heads = self.model_arch_config.total_num_attention_heads
         tensor_parallel_size = parallel_config.tensor_parallel_size
-        if total_num_attention_heads % tensor_parallel_size != 0:
+        ratios = parallel_config.rank_tp_ratio
+        if ratios:
+            # Uneven TP: heads are partitioned proportionally; every
+            # sharded head count must be divisible by sum(ratios).
+            denom = sum(ratios)
+            if total_num_attention_heads % denom != 0:
+                raise ValueError(
+                    f"Total number of attention heads "
+                    f"({total_num_attention_heads}) must be divisible by "
+                    f"sum(--rank-tp-ratio)={denom} for uneven TP."
+                )
+        elif total_num_attention_heads % tensor_parallel_size != 0:
             raise ValueError(
                 f"Total number of attention heads ({total_num_attention_heads})"
                 " must be divisible by tensor parallel size "
@@ -1423,14 +1434,39 @@ class ModelConfig:
             return 1
 
         total_num_kv_heads = self.get_total_num_kv_heads()
+        ratios = parallel_config.rank_tp_ratio
+        if ratios:
+            # Uneven TP: rank-aware in worker processes; engine-level
+            # callers (no TP group initialized) get the smallest-ratio
+            # rank as a conservative basis.
+            return self._uneven_tp_heads(total_num_kv_heads, ratios)
         # If tensor parallelism is used, we divide the number of KV heads by
         # the tensor parallel size. We will replicate the KV heads in the
         # case where the number of KV heads is smaller than the tensor
         # parallel size so each GPU has at least one KV head.
         return max(1, total_num_kv_heads // parallel_config.tensor_parallel_size)
 
+    @staticmethod
+    def _uneven_tp_heads(total: int, ratios: list[int]) -> int:
+        denom = sum(ratios)
+        try:
+            from vllm.distributed.parallel_state import (
+                get_tensor_model_parallel_rank,
+            )
+
+            rank = get_tensor_model_parallel_rank()
+        except (AssertionError, ValueError):
+            # TP group not initialized (engine-level caller): use the
+            # smallest ratio as conservative basis.
+            rank = None
+        r = ratios[rank] if rank is not None else min(ratios)
+        return max(1, total * r // denom)
+
     def get_num_attention_heads(self, parallel_config: ParallelConfig) -> int:
         num_heads = self.model_arch_config.total_num_attention_heads
+        ratios = parallel_config.rank_tp_ratio
+        if ratios:
+            return self._uneven_tp_heads(num_heads, ratios)
         return num_heads // parallel_config.tensor_parallel_size
 
     def get_num_experts(self) -> int:

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -314,6 +314,14 @@ class ParallelConfig:
     checks, and final CUDA device selection when needed. When None,
     logical IDs map to visible device IDs in order."""
 
+    rank_gpu_memory_mib: int | None = None
+    """Absolute MiB memory budget per rank when using --rank-gpu-id.
+
+    This value applies uniformly to every rank. The value is converted
+    to a per-GPU fraction at runtime based on each physical GPU's
+    NVML-reported total memory, so the same MiB value represents a
+    DIFFERENT fraction on different physical GPUs."""
+
     distributed_timeout_seconds: int | None = None
     """Timeout in seconds for distributed operations (e.g., init_process_group).
     If set, this value is passed to torch.distributed.init_process_group as the
@@ -923,6 +931,9 @@ class ParallelConfig:
             elif (
                 current_platform.is_cuda()
                 and current_platform.device_count() < self.world_size
+                # rank_gpu_memory_mib set means --rank-gpu-id is in use,
+                # which allows more ranks than physical GPUs (co-location).
+                and self.rank_gpu_memory_mib is None
             ):
                 gpu_count = current_platform.device_count()
                 raise ValueError(
@@ -930,7 +941,8 @@ class ParallelConfig:
                     f"available GPUs ({gpu_count}) in this node. If this is "
                     "intentional and you are using:\n"
                     "- ray, set '--distributed-executor-backend ray'.\n"
-                    "- multiprocessing, set '--nnodes' appropriately."
+                    "- multiprocessing, set '--nnodes' appropriately.\n"
+                    "- --rank-gpu-id with --rank-gpu-memory-mib to share GPUs."
                 )
             elif self.data_parallel_backend == "ray":
                 logger.info(

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -314,13 +314,25 @@ class ParallelConfig:
     checks, and final CUDA device selection when needed. When None,
     logical IDs map to visible device IDs in order."""
 
-    rank_gpu_memory_mib: int | None = None
+    rank_gpu_memory_mib: int | list[int] | None = None
     """Absolute MiB memory budget per rank when using --rank-gpu-id.
 
-    This value applies uniformly to every rank. The value is converted
-    to a per-GPU fraction at runtime based on each physical GPU's
-    NVML-reported total memory, so the same MiB value represents a
-    DIFFERENT fraction on different physical GPUs."""
+    A single int applies uniformly to every rank (the natural fit for
+    even TP, where all shards are structurally equal). With
+    --rank-tp-ratio (uneven TP) a per-rank list may be given instead,
+    since ranks then carry differently sized shards. The value is
+    converted to a per-GPU fraction at runtime based on each physical
+    GPU's NVML-reported total memory."""
+
+    rank_tp_ratio: list[int] | None = None
+    """Uneven tensor-parallel shard ratios, one positive integer per rank.
+
+    Example: ``[2, 1, 1]`` with TP=3 gives rank 0 half of every sharded
+    dimension and ranks 1/2 a quarter each - e.g. one large GPU plus two
+    smaller ones, one rank per GPU, no co-location needed. Every sharded
+    dimension (attention heads, KV heads, GDN v/k heads, hidden and
+    intermediate sizes) must be divisible by sum(ratios). Vocab/LM-head
+    stay evenly split. Requires --rank-gpu-id; pure TP only."""
 
     distributed_timeout_seconds: int | None = None
     """Timeout in seconds for distributed operations (e.g., init_process_group).

--- a/vllm/distributed/utils.py
+++ b/vllm/distributed/utils.py
@@ -82,6 +82,66 @@ def verify_group_size_divides_partition(
     )
 
 
+# --------------------------------------------------------------------------
+# Uneven tensor-parallel partitioning (--rank-tp-ratio).
+#
+# When a ratio vector like (2, 1, 1) is active, TP rank r owns
+# total * ratio[r] / sum(ratio) of every sharded dimension instead of
+# total / tp_size. Offsets become prefix sums (same pattern as
+# VLLM_PP_LAYER_PARTITION for pipeline parallel). The ratio vector is
+# process-global state set once per worker before the model is built;
+# when unset, all helpers reproduce the classic even split exactly.
+# --------------------------------------------------------------------------
+
+_TP_PARTITION_RATIOS: list[int] | None = None
+
+
+def set_tp_partition_ratios(ratios: list[int] | None) -> None:
+    """Install the uneven-TP ratio vector for this process (or None)."""
+    global _TP_PARTITION_RATIOS
+    _TP_PARTITION_RATIOS = list(ratios) if ratios else None
+
+
+def get_tp_partition_ratios() -> list[int] | None:
+    return _TP_PARTITION_RATIOS
+
+
+def tp_partition_sizes(total: int, tp_size: int) -> list[int]:
+    """Per-rank sizes of a dimension of `total` elements.
+
+    With ratios active, every sharded dimension must be divisible by
+    sum(ratios) so all per-rank sizes are exact integers; otherwise this
+    raises with the offending dimension size.
+    """
+    ratios = _TP_PARTITION_RATIOS
+    if not ratios or len(ratios) != tp_size:
+        # No ratios installed, or this layer runs with its own tp_size
+        # (disable_tp layers use tp_size=1): classic even split.
+        ensure_divisibility(total, tp_size)
+        return [total // tp_size] * tp_size
+    denom = sum(ratios)
+    if total % denom != 0:
+        raise ValueError(
+            f"Cannot partition dimension of size {total} with "
+            f"--rank-tp-ratio {ratios}: {total} is not divisible by "
+            f"sum(ratios)={denom}. Choose ratios whose sum divides every "
+            "sharded dimension (attention heads, kv heads, GDN heads, "
+            "hidden/intermediate sizes)."
+        )
+    unit = total // denom
+    return [unit * r for r in ratios]
+
+
+def tp_partition_size(total: int, tp_size: int, rank: int) -> int:
+    """This rank's size of a sharded dimension."""
+    return tp_partition_sizes(total, tp_size)[rank]
+
+
+def tp_partition_offset(total: int, tp_size: int, rank: int) -> int:
+    """This rank's start offset (prefix sum) in a sharded dimension."""
+    return sum(tp_partition_sizes(total, tp_size)[:rank])
+
+
 def is_weak_contiguous(inp: torch.Tensor) -> bool:
     """Check that *inp* occupies a single contiguous block of memory.
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -476,7 +476,8 @@ class EngineArgs:
     numa_bind_cpus: list[str] | None = ParallelConfig.numa_bind_cpus
     device_ids: list[int | str] | None = None
     rank_gpu_id: list[int] | None = None
-    rank_gpu_memory_mib: int | None = None
+    rank_gpu_memory_mib: int | list[int] | None = None
+    rank_tp_ratio: list[int] | None = None
     tensor_parallel_size: int = ParallelConfig.tensor_parallel_size
     prefill_context_parallel_size: int = ParallelConfig.prefill_context_parallel_size
     decode_context_parallel_size: int = ParallelConfig.decode_context_parallel_size
@@ -1052,19 +1053,39 @@ class EngineArgs:
             "Requires --rank-gpu-memory-mib to be set. "
             "Mutually exclusive with --gpu-memory-utilization.",
         )
+
+        def _mib_scalar_or_list(value: str):
+            if "," in value:
+                return [int(v) for v in value.split(",")]
+            return int(value)
+
         parallel_group.add_argument(
             "--rank-gpu-memory-mib",
-            type=int,
+            type=_mib_scalar_or_list,
             default=None,
             help="Absolute memory budget in MiB per rank when using "
-            "--rank-gpu-id. This is a single scalar value (not a list) "
-            "that applies uniformly to every rank. "
-            "The value is converted to a per-GPU fraction at runtime based on "
-            "each physical GPU's NVML-reported total memory, so the same MiB "
-            "value represents a DIFFERENT fraction on different physical GPUs. "
+            "--rank-gpu-id. A single scalar applies uniformly to every rank "
+            "(even TP: all shards are structurally equal). With "
+            "--rank-tp-ratio a comma-separated per-rank list may be given "
+            "instead (e.g. 26000,17000,17000), since shards then differ in "
+            "size. Values are converted to per-GPU fractions at runtime via "
+            "each physical GPU's NVML-reported total memory. "
             "Required when --rank-gpu-id is set. "
             "Mutually exclusive with --gpu-memory-utilization "
             "(setting both is a hard error).",
+        )
+        parallel_group.add_argument(
+            "--rank-tp-ratio",
+            type=lambda s: [int(r) for r in s.split(",")],
+            default=None,
+            help="UNEVEN tensor parallelism: comma-separated positive integer "
+            "ratios, one per rank (length must equal tensor-parallel-size). "
+            "Example: 2,1,1 gives rank 0 half of every sharded dimension and "
+            "ranks 1/2 a quarter each - one large GPU plus two smaller ones, "
+            "one rank per GPU, no MPS/co-location required. Every sharded "
+            "dimension (attention heads, KV heads, GDN heads, hidden and "
+            "intermediate sizes) must be divisible by sum(ratios); vocab and "
+            "LM head stay evenly split. Requires --rank-gpu-id.",
         )
         parallel_group.add_argument(
             "--tensor-parallel-size", "-tp", **parallel_kwargs["tensor_parallel_size"]
@@ -2275,6 +2296,7 @@ class EngineArgs:
                 else self._resolve_device_ids()
             ),
             rank_gpu_memory_mib=self.rank_gpu_memory_mib,
+            rank_tp_ratio=self.rank_tp_ratio,
             enable_fault_tolerance=self.enable_fault_tolerance,
             fault_tolerance_config=self.fault_tolerance_config,
             numa_bind=self.numa_bind,
@@ -2546,6 +2568,9 @@ class EngineArgs:
         if self.rank_gpu_memory_mib is None and self.rank_gpu_id is not None:
             raise ValueError("--rank-gpu-id requires --rank-gpu-memory-mib to be set.")
 
+        if self.rank_tp_ratio is not None and self.rank_gpu_id is None:
+            raise ValueError("--rank-tp-ratio requires --rank-gpu-id to be set.")
+
         if self.rank_gpu_id is None:
             return
 
@@ -2554,6 +2579,39 @@ class EngineArgs:
             raise ValueError(
                 f"--rank-gpu-id length ({len(self.rank_gpu_id)}) must equal "
                 f"--tensor-parallel-size ({self.tensor_parallel_size})."
+            )
+
+        # Uneven-TP ratio checks
+        if self.rank_tp_ratio is not None:
+            if len(self.rank_tp_ratio) != self.tensor_parallel_size:
+                raise ValueError(
+                    f"--rank-tp-ratio length ({len(self.rank_tp_ratio)}) must "
+                    f"equal --tensor-parallel-size ({self.tensor_parallel_size})."
+                )
+            if any(r <= 0 for r in self.rank_tp_ratio):
+                raise ValueError("--rank-tp-ratio entries must be positive integers.")
+
+        # Per-rank MiB list checks
+        if isinstance(self.rank_gpu_memory_mib, list):
+            if self.rank_tp_ratio is None:
+                raise ValueError(
+                    "--rank-gpu-memory-mib as a list requires "
+                    "--rank-tp-ratio (with even TP all ranks are "
+                    "structurally equal - use a single scalar)."
+                )
+            if len(self.rank_gpu_memory_mib) != self.tensor_parallel_size:
+                raise ValueError(
+                    f"--rank-gpu-memory-mib list length "
+                    f"({len(self.rank_gpu_memory_mib)}) must equal "
+                    f"--tensor-parallel-size ({self.tensor_parallel_size})."
+                )
+            if any(m <= 0 for m in self.rank_gpu_memory_mib):
+                raise ValueError("--rank-gpu-memory-mib entries must be positive.")
+
+        if self.rank_tp_ratio is not None and self.enable_lora:
+            raise ValueError(
+                "--rank-tp-ratio is not compatible with LoRA "
+                "(LoRA layers assume evenly sized TP shards)."
             )
 
         # PP/DP/EP not supported
@@ -2613,14 +2671,24 @@ class EngineArgs:
                 nvml_total_bytes = pynvml.nvmlDeviceGetMemoryInfo(handle).total
                 nvml_total_mib = nvml_total_bytes // (1024 * 1024)
                 count_on_gpu = gpu_counts[gpu_id]
-                required_mib = count_on_gpu * self.rank_gpu_memory_mib
+                if isinstance(self.rank_gpu_memory_mib, list):
+                    required_mib = sum(
+                        mib
+                        for r, mib in enumerate(self.rank_gpu_memory_mib)
+                        if self.rank_gpu_id[r] == gpu_id
+                    )
+                    budget_desc = "per-rank budgets"
+                else:
+                    required_mib = count_on_gpu * self.rank_gpu_memory_mib
+                    budget_desc = (
+                        f"{count_on_gpu} ranks x {self.rank_gpu_memory_mib} MiB"
+                    )
 
                 if required_mib > nvml_total_mib:
                     raise ValueError(
                         f"Physical impossibility: torch.cuda:{gpu_id} "
                         f"(NVML:{nvml_idx}, {nvml_total_mib} MiB total) cannot fit "
-                        f"{count_on_gpu} ranks x {self.rank_gpu_memory_mib} MiB "
-                        f"= {required_mib} MiB requested. "
+                        f"{budget_desc} = {required_mib} MiB requested. "
                         f"Reduce --rank-gpu-memory-mib or use fewer ranks on this GPU."
                     )
         finally:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -475,6 +475,8 @@ class EngineArgs:
     numa_bind_nodes: list[int] | None = ParallelConfig.numa_bind_nodes
     numa_bind_cpus: list[str] | None = ParallelConfig.numa_bind_cpus
     device_ids: list[int | str] | None = None
+    rank_gpu_id: list[int] | None = None
+    rank_gpu_memory_mib: int | None = None
     tensor_parallel_size: int = ParallelConfig.tensor_parallel_size
     prefill_context_parallel_size: int = ParallelConfig.prefill_context_parallel_size
     decode_context_parallel_size: int = ParallelConfig.decode_context_parallel_size
@@ -1034,6 +1036,35 @@ class EngineArgs:
             "visibility for GPU-NIC affinity and DeepGEMM. "
             "Note: has no effect with Ray executors; use Ray "
             "placement groups for GPU selection instead.",
+        )
+        parallel_group.add_argument(
+            "--rank-gpu-id",
+            type=lambda s: [int(x) for x in (part.strip() for part in s.split(","))],
+            default=None,
+            help="Comma-separated GPU indices for each tensor parallel rank. "
+            "IMPORTANT: these are PyTorch device indices (the ordering behind "
+            "'cuda:N'), NOT nvidia-smi/NVML indices, which can enumerate "
+            "differently. "
+            "Duplicates mean multiple ranks share that GPU. "
+            "Length must equal tensor-parallel-size. "
+            "Example: --rank-gpu-id 0,1 (two GPUs, one rank each). "
+            "Example: --rank-gpu-id 0,0,1,2 (TP=4, first GPU shared by two ranks). "
+            "Requires --rank-gpu-memory-mib to be set. "
+            "Mutually exclusive with --gpu-memory-utilization.",
+        )
+        parallel_group.add_argument(
+            "--rank-gpu-memory-mib",
+            type=int,
+            default=None,
+            help="Absolute memory budget in MiB per rank when using "
+            "--rank-gpu-id. This is a single scalar value (not a list) "
+            "that applies uniformly to every rank. "
+            "The value is converted to a per-GPU fraction at runtime based on "
+            "each physical GPU's NVML-reported total memory, so the same MiB "
+            "value represents a DIFFERENT fraction on different physical GPUs. "
+            "Required when --rank-gpu-id is set. "
+            "Mutually exclusive with --gpu-memory-utilization "
+            "(setting both is a hard error).",
         )
         parallel_group.add_argument(
             "--tensor-parallel-size", "-tp", **parallel_kwargs["tensor_parallel_size"]
@@ -2188,6 +2219,9 @@ class EngineArgs:
             model_config.skip_tokenizer_init = True
             logger.info("Skipping tokenizer initialization for tokens-only mode.")
 
+        # Validate --rank-gpu-id and --rank-gpu-memory-mib
+        self._validate_rank_gpu_config(current_platform)
+
         parallel_config = ParallelConfig(
             pipeline_parallel_size=self.pipeline_parallel_size,
             tensor_parallel_size=self.tensor_parallel_size,
@@ -2233,7 +2267,14 @@ class EngineArgs:
             cp_kv_cache_interleave_size=self.cp_kv_cache_interleave_size,
             _api_process_count=self._api_process_count,
             _api_process_rank=self._api_process_rank,
-            assigned_physical_gpu_ids=self._resolve_device_ids(),
+            # When --rank-gpu-id is set, use it as the physical GPU mapping
+            # Otherwise use --device-ids if provided
+            assigned_physical_gpu_ids=(
+                self.rank_gpu_id
+                if self.rank_gpu_id is not None
+                else self._resolve_device_ids()
+            ),
+            rank_gpu_memory_mib=self.rank_gpu_memory_mib,
             enable_fault_tolerance=self.enable_fault_tolerance,
             fault_tolerance_config=self.fault_tolerance_config,
             numa_bind=self.numa_bind,
@@ -2484,6 +2525,106 @@ class EngineArgs:
         )
 
         return config
+
+    def _validate_rank_gpu_config(self, current_platform) -> None:
+        """
+        Validate --rank-gpu-id and --rank-gpu-memory-mib consistency.
+
+        This validates:
+        1. Mutual exclusivity: both or neither must be set
+        2. Length vs tensor_parallel_size
+        3. PP/DP/EP not supported with --rank-gpu-id
+        4. --gpu-memory-utilization not allowed with --rank-gpu-id
+        5. Physical GPU existence via NVML
+        6. Physical impossibility: (rank_count on GPU) * MiB <= NVML total
+        """
+        from collections import Counter
+
+        # Mutual exclusivity check
+        if self.rank_gpu_id is None and self.rank_gpu_memory_mib is not None:
+            raise ValueError("--rank-gpu-memory-mib requires --rank-gpu-id to be set.")
+        if self.rank_gpu_memory_mib is None and self.rank_gpu_id is not None:
+            raise ValueError("--rank-gpu-id requires --rank-gpu-memory-mib to be set.")
+
+        if self.rank_gpu_id is None:
+            return
+
+        # Length vs tensor_parallel_size
+        if len(self.rank_gpu_id) != self.tensor_parallel_size:
+            raise ValueError(
+                f"--rank-gpu-id length ({len(self.rank_gpu_id)}) must equal "
+                f"--tensor-parallel-size ({self.tensor_parallel_size})."
+            )
+
+        # PP/DP/EP not supported
+        if self.pipeline_parallel_size > 1:
+            raise ValueError(
+                f"--rank-gpu-id is not compatible with pipeline-parallel-size > 1 "
+                f"(current: {self.pipeline_parallel_size}). "
+                "Only pure Tensor Parallelism is supported."
+            )
+        if self.data_parallel_size > 1:
+            raise ValueError(
+                f"--rank-gpu-id is not compatible with data-parallel-size > 1 "
+                f"(current: {self.data_parallel_size}). "
+                "Only pure Tensor Parallelism is supported."
+            )
+        if self.enable_expert_parallel:
+            raise ValueError("--rank-gpu-id is not compatible with expert parallelism.")
+
+        # --gpu-memory-utilization must not be set
+        if self.gpu_memory_utilization != CacheConfig.gpu_memory_utilization:
+            raise ValueError(
+                "--gpu-memory-utilization cannot be set when --rank-gpu-id is used. "
+                "Use --rank-gpu-memory-mib instead to specify absolute MiB budget."
+            )
+
+        # Get torch -> NVML mapping for validation
+        from vllm.platforms.cuda import CudaPlatform
+        from vllm.utils.import_utils import import_pynvml
+
+        torch_to_nvml = CudaPlatform.get_torch_to_nvml_mapping()
+        pynvml = import_pynvml()
+        pynvml.nvmlInit()
+
+        try:
+            # NVML-based physical existence check and sum validation
+            device_count = current_platform.device_count()
+            gpu_counts = Counter(self.rank_gpu_id)
+
+            for gpu_id in self.rank_gpu_id:
+                if gpu_id < 0 or gpu_id >= device_count:
+                    raise ValueError(
+                        f"Physical GPU ID {gpu_id} is out of range. "
+                        f"Available GPUs: 0-{device_count - 1}"
+                    )
+
+                # Map torch.cuda index to NVML physical index for memory query
+                if gpu_id not in torch_to_nvml:
+                    raise ValueError(
+                        f"Could not map torch.cuda:{gpu_id} to a physical GPU. "
+                        f"Available torch.cuda indices: 0-{device_count - 1}"
+                    )
+                nvml_idx = torch_to_nvml[gpu_id]
+
+                # Physical impossibility check using NVML directly
+                # (get_device_total_memory() uses torch.cuda props, not NVML)
+                handle = pynvml.nvmlDeviceGetHandleByIndex(nvml_idx)
+                nvml_total_bytes = pynvml.nvmlDeviceGetMemoryInfo(handle).total
+                nvml_total_mib = nvml_total_bytes // (1024 * 1024)
+                count_on_gpu = gpu_counts[gpu_id]
+                required_mib = count_on_gpu * self.rank_gpu_memory_mib
+
+                if required_mib > nvml_total_mib:
+                    raise ValueError(
+                        f"Physical impossibility: torch.cuda:{gpu_id} "
+                        f"(NVML:{nvml_idx}, {nvml_total_mib} MiB total) cannot fit "
+                        f"{count_on_gpu} ranks x {self.rank_gpu_memory_mib} MiB "
+                        f"= {required_mib} MiB requested. "
+                        f"Reduce --rank-gpu-memory-mib or use fewer ranks on this GPU."
+                    )
+        finally:
+            pynvml.nvmlShutdown()
 
     def _check_feature_supported(self):
         """Raise an error if the feature is not supported."""

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -20,6 +20,11 @@ from vllm.distributed import (
     tensor_model_parallel_all_gather,
     tensor_model_parallel_all_reduce,
 )
+from vllm.distributed.utils import (
+    get_tp_partition_ratios,
+    tp_partition_size,
+    tp_partition_sizes,
+)
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import PluggableLayer
 from vllm.model_executor.layers.batch_invariant import (
@@ -70,6 +75,24 @@ def register_weight_loader_v2_supported_method(cls):
     """Decorator to register a LinearMethod as supporting weight_loader_v2."""
     WEIGHT_LOADER_V2_SUPPORTED.append(cls.__name__)
     return cls
+
+
+def tp_loaded_shard_start(
+    loaded_full: int, tp_size: int, rank: int, shard_size: int
+) -> int:
+    """Start offset when narrowing a full checkpoint dimension to this
+    rank's shard. Even TP: rank * shard_size (classic). Uneven TP
+    (--rank-tp-ratio): prefix sum of the per-rank partition sizes; the
+    given shard_size must match this rank's partition (consistency
+    check against mis-sized parameters)."""
+    if not get_tp_partition_ratios():
+        return rank * shard_size
+    sizes = tp_partition_sizes(loaded_full, tp_size)
+    assert sizes[rank] == shard_size, (
+        f"uneven-TP shard mismatch: expected {sizes[rank]} for rank "
+        f"{rank} of dim {loaded_full}, parameter has {shard_size}"
+    )
+    return sum(sizes[:rank])
 
 
 def adjust_marlin_shard(
@@ -476,12 +499,15 @@ class ColumnParallelLinear(LinearBase):
                 else get_tensor_model_parallel_world_size()
             )
         self.input_size_per_partition = input_size
-        self.output_size_per_partition = divide(output_size, self.tp_size)
+        self.output_size_per_partition = tp_partition_size(
+            output_size, self.tp_size, self.tp_rank
+        )
         self.output_partition_sizes = [self.output_size_per_partition]
         # If QKV or MergedColumn, use output size of each partition.
         if hasattr(self, "output_sizes"):
             self.output_partition_sizes = [
-                divide(output_size, self.tp_size) for output_size in self.output_sizes
+                tp_partition_size(output_size, self.tp_size, self.tp_rank)
+                for output_size in self.output_sizes
             ]
 
         super().__init__(
@@ -569,7 +595,9 @@ class ColumnParallelLinear(LinearBase):
         param_data = param.data
         if output_dim is not None and not is_sharded_weight:
             shard_size = param_data.shape[output_dim]
-            start_idx = self.tp_rank * shard_size
+            start_idx = tp_loaded_shard_start(
+                loaded_weight.shape[output_dim], self.tp_size, self.tp_rank, shard_size
+            )
             loaded_weight = loaded_weight.narrow(output_dim, start_idx, shard_size)
 
         # Special case for loading scales off disk, which often do not
@@ -702,7 +730,9 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         self.tp_size = get_tensor_model_parallel_world_size() if not disable_tp else 1
         self.tp_rank = get_tensor_model_parallel_rank() if not disable_tp else 0
 
-        assert all(output_size % self.tp_size == 0 for output_size in output_sizes)
+        for output_size in output_sizes:
+            # Validates divisibility (even: % tp == 0, uneven: % sum(ratios))
+            tp_partition_sizes(output_size, self.tp_size)
         super().__init__(
             input_size=input_size,
             output_size=sum(output_sizes),
@@ -828,10 +858,13 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
 
         assert loaded_shard_id < len(self.output_sizes)
         if output_dim is not None:
-            shard_offset = sum(self.output_sizes[:loaded_shard_id])
-            shard_size = self.output_sizes[loaded_shard_id]
-            shard_offset //= self.tp_size
-            shard_size //= self.tp_size
+            shard_offset = sum(
+                tp_partition_size(sz, self.tp_size, self.tp_rank)
+                for sz in self.output_sizes[:loaded_shard_id]
+            )
+            shard_size = tp_partition_size(
+                self.output_sizes[loaded_shard_id], self.tp_size, self.tp_rank
+            )
 
             if isinstance(param, BlockQuantScaleParameter):
                 weight_block_size = getattr(self, "weight_block_size", None)
@@ -867,7 +900,9 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
                     param, orig_offsets, str(loaded_shard_id)
                 )
             param_data = param_data.narrow(output_dim, shard_offset, shard_size)
-            start_idx = self.tp_rank * shard_size
+            start_idx = tp_loaded_shard_start(
+                loaded_weight.shape[output_dim], self.tp_size, self.tp_rank, shard_size
+            )
             if not is_sharded_weight:
                 loaded_weight = loaded_weight.narrow(output_dim, start_idx, shard_size)
         # Special case for per-tensor scales in fused case.
@@ -975,10 +1010,13 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
 
         assert loaded_shard_id < len(self.output_sizes)
 
-        shard_offset = sum(self.output_sizes[:loaded_shard_id])
-        shard_size = self.output_sizes[loaded_shard_id]
-        shard_offset //= self.tp_size
-        shard_size //= self.tp_size
+        shard_offset = sum(
+            tp_partition_size(sz, self.tp_size, self.tp_rank)
+            for sz in self.output_sizes[:loaded_shard_id]
+        )
+        shard_size = tp_partition_size(
+            self.output_sizes[loaded_shard_id], self.tp_size, self.tp_rank
+        )
 
         if isinstance(param, BlockQuantScaleParameter):
             weight_block_size = getattr(self, "weight_block_size", None)
@@ -1072,20 +1110,57 @@ class QKVParallelLinear(ColumnParallelLinear):
         self.total_num_kv_heads = total_num_kv_heads
         # Divide the weight matrix along the last dimension.
         tp_size = get_tensor_model_parallel_world_size() if not disable_tp else 1
-        self.num_heads = divide(self.total_num_heads, tp_size)
-        if tp_size >= self.total_num_kv_heads:
+        tp_rank = get_tensor_model_parallel_rank() if not disable_tp else 0
+        if get_tp_partition_ratios():
+            # Uneven TP: every rank must own at least one whole kv head;
+            # the replicated-kv path is not supported with ratios.
+            if self.total_num_kv_heads % sum(get_tp_partition_ratios()) != 0:
+                raise ValueError(
+                    f"--rank-tp-ratio: total_num_kv_heads "
+                    f"({self.total_num_kv_heads}) must be divisible by "
+                    f"sum(ratios) ({sum(get_tp_partition_ratios())}); "
+                    "kv-head replication is not supported with uneven TP."
+                )
+            self.num_heads = tp_partition_size(self.total_num_heads, tp_size, tp_rank)
+            self.num_kv_heads = tp_partition_size(
+                self.total_num_kv_heads, tp_size, tp_rank
+            )
+            self.num_kv_head_replicas = 1
+        elif tp_size >= self.total_num_kv_heads:
+            self.num_heads = divide(self.total_num_heads, tp_size)
             self.num_kv_heads = 1
             self.num_kv_head_replicas = divide(tp_size, self.total_num_kv_heads)
         else:
+            self.num_heads = divide(self.total_num_heads, tp_size)
             self.num_kv_heads = divide(self.total_num_kv_heads, tp_size)
             self.num_kv_head_replicas = 1
         input_size = self.hidden_size
-        self.output_sizes = [
-            self.num_heads * self.head_size * tp_size,  # q_proj
-            self.num_kv_heads * self.head_size * tp_size,  # k_proj
-            self.num_kv_heads * self.v_head_size * tp_size,  # v_proj
-        ]
-        output_size = sum(self.output_sizes)
+        # Pre-partition totals; the base class partitions them per rank.
+        # With kv-head replication the "total" seen by the base class is
+        # num_kv_heads(=1) * tp_size (each rank holds a full replica), so
+        # keep the classic per-rank*tp formula in that branch.
+        if self.num_kv_head_replicas > 1:
+            output_size = (
+                self.num_heads * self.head_size
+                + self.num_kv_heads * self.head_size
+                + self.num_kv_heads * self.v_head_size
+            ) * tp_size
+            self.output_sizes = [
+                self.num_heads * self.head_size * tp_size,  # q_proj
+                self.num_kv_heads * self.head_size * tp_size,  # k_proj
+                self.num_kv_heads * self.v_head_size * tp_size,  # v_proj
+            ]
+        else:
+            output_size = (
+                self.total_num_heads * self.head_size
+                + self.total_num_kv_heads * self.head_size
+                + self.total_num_kv_heads * self.v_head_size
+            )
+            self.output_sizes = [
+                self.total_num_heads * self.head_size,  # q_proj
+                self.total_num_kv_heads * self.head_size,  # k_proj
+                self.total_num_kv_heads * self.v_head_size,  # v_proj
+            ]
 
         super().__init__(
             input_size=input_size,
@@ -1373,11 +1448,21 @@ class QKVParallelLinear(ColumnParallelLinear):
                 )
 
             param_data = param_data.narrow(output_dim, shard_offset, shard_size)
-            if loaded_shard_id == "q":
-                shard_rank = self.tp_rank
+            if get_tp_partition_ratios():
+                # Uneven TP (no kv replication): prefix-sum offset into the
+                # full q/k/v component of the checkpoint.
+                start_idx = tp_loaded_shard_start(
+                    loaded_weight.shape[output_dim],
+                    self.tp_size,
+                    self.tp_rank,
+                    shard_size,
+                )
             else:
-                shard_rank = self.tp_rank // self.num_kv_head_replicas
-            start_idx = shard_rank * shard_size
+                if loaded_shard_id == "q":
+                    shard_rank = self.tp_rank
+                else:
+                    shard_rank = self.tp_rank // self.num_kv_head_replicas
+                start_idx = shard_rank * shard_size
 
             if not is_sharded_weight:
                 loaded_weight = loaded_weight.narrow(output_dim, start_idx, shard_size)
@@ -1663,7 +1748,9 @@ class RowParallelLinear(LinearBase):
         # Divide the weight matrix along the first dimension.
         self.tp_rank = get_tensor_model_parallel_rank() if not disable_tp else 0
         self.tp_size = get_tensor_model_parallel_world_size() if not disable_tp else 1
-        self.input_size_per_partition = divide(input_size, self.tp_size)
+        self.input_size_per_partition = tp_partition_size(
+            input_size, self.tp_size, self.tp_rank
+        )
         self.output_size_per_partition = output_size
         self.output_partition_sizes = [output_size]
 
@@ -1725,7 +1812,9 @@ class RowParallelLinear(LinearBase):
         param_data = param.data
         if input_dim is not None and not is_sharded_weight:
             shard_size = param_data.shape[input_dim]
-            start_idx = self.tp_rank * shard_size
+            start_idx = tp_loaded_shard_start(
+                loaded_weight.shape[input_dim], self.tp_size, self.tp_rank, shard_size
+            )
             loaded_weight = loaded_weight.narrow(input_dim, start_idx, shard_size)
 
         # Special case for loading scales off disk, which often do not

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -14,9 +14,7 @@ from vllm.config import (
     VllmConfig,
     get_current_vllm_config,
 )
-from vllm.distributed import (
-    divide,
-)
+from vllm.distributed.utils import tp_partition_offset, tp_partition_size
 from vllm.forward_context import ForwardContext, get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import CustomOp, PluggableLayer
@@ -343,10 +341,12 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
     def get_state_shape(
         self,
     ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+        # Per-rank state shape: pass tp=1 with this rank's local head
+        # counts so uneven TP produces the correct per-rank cache size.
         return MambaStateShapeCalculator.gated_delta_net_state_shape(
-            self.tp_size,
-            self.num_k_heads,
-            self.num_v_heads,
+            1,
+            self.local_num_k_heads,
+            self.local_num_v_heads,
             self.head_k_dim,
             self.head_v_dim,
             self.conv_kernel_size,
@@ -370,6 +370,17 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         self.conv_kernel_size = config.linear_conv_kernel_dim
         self.key_dim = self.head_k_dim * self.num_k_heads
         self.value_dim = self.head_v_dim * self.num_v_heads
+        # Per-rank (local) shard sizes. Even TP: total // tp_size (with
+        # divisibility assert, exactly the previous behavior). Uneven TP
+        # (--rank-tp-ratio): this rank's ratio share.
+        self.local_num_k_heads = tp_partition_size(
+            self.num_k_heads, self.tp_size, self.tp_rank
+        )
+        self.local_num_v_heads = tp_partition_size(
+            self.num_v_heads, self.tp_size, self.tp_rank
+        )
+        self.local_key_dim = self.head_k_dim * self.local_num_k_heads
+        self.local_value_dim = self.head_v_dim * self.local_num_v_heads
         self.gqa_interleaved_layout = gqa_interleaved_layout
         if current_platform.is_xpu():
             self._forward_method = self.forward_xpu
@@ -437,11 +448,11 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         # time step projection (discretization)
         # instantiate once and copy inv_dt in init_weights of PretrainedModel
         self.dt_bias = nn.Parameter(
-            torch.ones(self.num_v_heads // self.tp_size),
+            torch.ones(self.local_num_v_heads),
         )
         self.A_log = nn.Parameter(
             torch.empty(
-                divide(self.num_v_heads, self.tp_size),
+                self.local_num_v_heads,
                 dtype=torch.float32,
             )
         )
@@ -559,8 +570,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         b, a = ba.chunk(2, dim=-1)
         if self.disable_tp_for_ba_proj and self.tp_size > 1:
             # ba_proj is replicated for Marlin; slice b/a to local TP rank.
-            ba_chunk = self.num_v_heads // self.tp_size
-            ba_start = self.tp_rank * ba_chunk
+            ba_chunk = self.local_num_v_heads
+            ba_start = tp_partition_offset(self.num_v_heads, self.tp_size, self.tp_rank)
             b = b[:, ba_start : ba_start + ba_chunk]
             a = a[:, ba_start : ba_start + ba_chunk]
         return b, a
@@ -574,7 +585,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         Derives `query`, `key` and `value` tensors from `mixed_qkvzba`.
         """
         new_tensor_shape_qkvz = mixed_qkvz.size()[:-1] + (
-            self.num_k_heads // self.tp_size,
+            self.local_num_k_heads,
             (
                 self.head_k_dim
                 + self.head_k_dim
@@ -584,7 +595,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             ),
         )
         new_tensor_shape_ba = mixed_ba.size()[:-1] + (
-            self.num_k_heads // self.tp_size,
+            self.local_num_k_heads,
             2 * self.num_v_heads // self.num_k_heads,
         )
 
@@ -611,8 +622,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         # [b, sq, ng, np/ng * hn] -> [b, sq, np, hn]
         value = value.reshape(value.size(0), -1, self.head_v_dim)
         z = z.reshape(z.size(0), -1, self.head_v_dim)
-        b = b.reshape(b.size(0), self.num_v_heads // self.tp_size)
-        a = a.reshape(a.size(0), self.num_v_heads // self.tp_size)
+        b = b.reshape(b.size(0), self.local_num_v_heads)
+        a = a.reshape(a.size(0), self.local_num_v_heads)
 
         return query, key, value, z, b, a
 
@@ -633,8 +644,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         if not self.gqa_interleaved_layout:
             # Qwen3.5: weights are in [q, k, v, z] order
             assert num_tokens == mixed_qkvz.shape[0]
-            qkv_size = (self.key_dim * 2 + self.value_dim) // self.tp_size
-            z_size = self.value_dim // self.tp_size
+            qkv_size = self.local_key_dim * 2 + self.local_value_dim
+            z_size = self.local_value_dim
             mixed_qkv, z_flat = mixed_qkvz.split([qkv_size, z_size], dim=-1)
             n = mixed_qkvz.shape[0]
             z_out = z_flat.reshape(n, -1, self.head_v_dim)
@@ -644,7 +655,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         # Qwen3-Next: interleaved GQA layout
         base_shape_qkvz = mixed_qkvz.size()[:-1]
         base_shape_ba = mixed_ba.size()[:-1]
-        ng = self.num_k_heads // self.tp_size
+        ng = self.local_num_k_heads
 
         new_tensor_shape_qkvz = base_shape_qkvz + (
             ng,
@@ -714,18 +725,14 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         curr += qkv_numel
 
         z_out = fused[curr : curr + z_numel].view(
-            num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim
+            num_tokens, self.local_num_v_heads, self.head_v_dim
         )
         curr += z_numel
 
-        b_out = fused[curr : curr + b_numel].view(
-            num_tokens, self.num_v_heads // self.tp_size
-        )
+        b_out = fused[curr : curr + b_numel].view(num_tokens, self.local_num_v_heads)
         curr += b_numel
 
-        a_out = fused[curr : curr + a_numel].view(
-            num_tokens, self.num_v_heads // self.tp_size
-        )
+        a_out = fused[curr : curr + a_numel].view(num_tokens, self.local_num_v_heads)
 
         return mixed_qkv_out, z_out, b_out, a_out
 
@@ -742,9 +749,9 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             return None, None, None
 
         seq_len = mixed_qkv.shape[0]
-        q_dim = self.key_dim // self.tp_size
-        k_dim = self.key_dim // self.tp_size
-        v_dim = self.value_dim // self.tp_size
+        q_dim = self.local_key_dim
+        k_dim = self.local_key_dim
+        v_dim = self.local_value_dim
 
         query, key, value = torch.split(mixed_qkv, [q_dim, k_dim, v_dim], dim=-1)
 
@@ -803,12 +810,12 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             projected_states_qkvz = projected_states_qkvz.view(num_tokens, -1)
             projected_states_ba = projected_states_ba.view(num_tokens, -1)
             core_attn_out = torch.empty(
-                (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
+                (num_tokens, self.local_num_v_heads, self.head_v_dim),
                 dtype=hidden_states.dtype,
                 device=hidden_states.device,
             )
             z = torch.empty(
-                (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
+                (num_tokens, self.local_num_v_heads, self.head_v_dim),
                 dtype=projected_states_qkvz.dtype,
                 device=projected_states_qkvz.device,
             )
@@ -854,8 +861,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             mixed_qkv = torch.cat((query, key, value), dim=-1)
         else:
             # Qwen3.5: weights are already in [q, k, v, z] and [b, a] order
-            qkv_size = (self.key_dim * 2 + self.value_dim) // self.tp_size
-            z_size = self.value_dim // self.tp_size
+            qkv_size = self.local_key_dim * 2 + self.local_value_dim
+            z_size = self.local_value_dim
             mixed_qkv, z = mixed_qkvz.split([qkv_size, z_size], dim=-1)
             z = z.reshape(z.size(0), -1, self.head_v_dim)
             b, a = self.split_ba(ba)
@@ -868,7 +875,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         # Note: we should not use torch.empty here like other attention backends,
         # see discussions in https://github.com/vllm-project/vllm/pull/28182
         core_attn_out = torch.zeros(
-            (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
+            (num_tokens, self.local_num_v_heads, self.head_v_dim),
             dtype=hidden_states.dtype,
             device=hidden_states.device,
         )
@@ -908,7 +915,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         # Part 2: Core Attention
         # ============================================================
         core_attn_out = torch.zeros(
-            (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
+            (num_tokens, self.local_num_v_heads, self.head_v_dim),
             dtype=hidden_states.dtype,
             device=hidden_states.device,
         )
@@ -955,15 +962,15 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             mixed_qkv = torch.cat((query, key, value), dim=-1)
         else:
             # Qwen3.5: weights are already in [q, k, v, z] and [b, a] order
-            qkv_size = (self.key_dim * 2 + self.value_dim) // self.tp_size
-            z_size = self.value_dim // self.tp_size
+            qkv_size = self.local_key_dim * 2 + self.local_value_dim
+            z_size = self.local_value_dim
             mixed_qkv, z = mixed_qkvz.split([qkv_size, z_size], dim=-1)
             z = z.reshape(z.size(0), -1, self.head_v_dim)
             b, a = ba.chunk(2, dim=-1)
 
         num_tokens = hidden_states.size(0)
         core_attn_out = torch.zeros(
-            (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
+            (num_tokens, self.local_num_v_heads, self.head_v_dim),
             dtype=hidden_states.dtype,
             device=hidden_states.device,
         )
@@ -1016,8 +1023,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
 
         device = qkv_or_qkvz.device
         dtype = qkv_or_qkvz.dtype
-        num_k_heads = self.num_k_heads // self.tp_size
-        num_v_heads = self.num_v_heads // self.tp_size
+        num_k_heads = self.local_num_k_heads
+        num_v_heads = self.local_num_v_heads
         _, state_dtype = self.get_state_dtype()
 
         # All kernels use BT = chunk_size, so a single pass with T = chunk_size
@@ -1351,7 +1358,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 b=b_prefill,
                 A_log=self.A_log,
                 dt_bias=self.dt_bias,
-                num_k_heads=self.num_k_heads // self.tp_size,
+                num_k_heads=self.local_num_k_heads,
                 head_k_dim=self.head_k_dim,
                 head_v_dim=self.head_v_dim,
                 apply_l2norm=True,
@@ -1524,8 +1531,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             gdn_aiter_fused_reshape_causal_conv1d_update_single_token(
                 qkvz,
                 attn_metadata.num_actual_tokens,
-                self.num_k_heads // self.tp_size,
-                self.num_v_heads // self.tp_size,
+                self.local_num_k_heads,
+                self.local_num_v_heads,
                 self.head_k_dim,
                 self.head_v_dim,
                 ba,
@@ -1549,8 +1556,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             b=b,
             dt_bias=self.dt_bias,
             qkv=mixed_qkv_non_spec,
-            key_dim=self.key_dim // self.tp_size,
-            value_dim=self.value_dim // self.tp_size,
+            key_dim=self.local_key_dim,
+            value_dim=self.local_value_dim,
             head_k_dim=self.head_k_dim,
             head_v_dim=self.head_v_dim,
             initial_state=ssm_state,

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -13,6 +13,7 @@ from vllm.distributed import (
     tensor_model_parallel_all_gather,
     tensor_model_parallel_all_reduce,
 )
+from vllm.distributed.utils import tp_partition_offset, tp_partition_size
 from vllm.forward_context import ForwardContext, get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import CustomOp, PluggableLayer
@@ -195,18 +196,34 @@ def mamba_v2_sharded_weight_loader(
             #   rank. This is useful when there is replication of
             #   groups to accompany head shards.
 
-            # - size of the loaded shard
-            shard_size = full_dim // tp_size
+            # - size of the loaded shard. Ratio-aware only without
+            #   group duplication (a duplicated group is one full copy
+            #   per rank and must not be ratio-partitioned); the even
+            #   path keeps the historic unchecked floor division.
+            from vllm.distributed.utils import get_tp_partition_ratios
+
+            if get_tp_partition_ratios():
+                assert not duplicate_groups, (
+                    "--rank-tp-ratio does not support duplicated mamba "
+                    "groups (n_groups replication)"
+                )
+                shard_size = tp_partition_size(full_dim, tp_size, tp_rank)
+            else:
+                shard_size = full_dim // tp_size
 
             # - compute the rank into the loaded shard.
             # - if there is replication, different TP shards will
             #   take from the same rank.
             # NOTE: currently we only support duplication
             # in the case where num_groups == 1
-            rank = 0 if duplicate_groups else tp_rank
-
-            # - leftmost boundary index into loaded weight.
-            loaded_skip = rank * shard_size
+            # - leftmost boundary index into loaded weight
+            #   (prefix sum for uneven TP; rank*size for even TP).
+            if duplicate_groups:
+                loaded_skip = 0
+            elif get_tp_partition_ratios():
+                loaded_skip = tp_partition_offset(full_dim, tp_size, tp_rank)
+            else:
+                loaded_skip = tp_rank * shard_size
             loaded_start_idx = loaded_boundary + loaded_skip
 
             # - take these many dims from the loaded weight.
@@ -267,6 +284,13 @@ class MambaMixer2(MambaBase, PluggableLayer):
         prefix: str = "",
     ):
         super().__init__()
+        from vllm.distributed.utils import get_tp_partition_ratios
+
+        if get_tp_partition_ratios():
+            raise NotImplementedError(
+                "--rank-tp-ratio (uneven TP) is not supported for "
+                "MambaMixer2-based models yet (only Qwen3.5/3.6 GDN)."
+            )
 
         # For TP, the sharding plan is as follows:
         # - for the conv modules, since

--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import math
 from collections.abc import Sequence
 from dataclasses import dataclass
 
@@ -260,6 +261,12 @@ class VocabParallelEmbedding(PluggableLayer):
             self.tp_size = get_tensor_model_parallel_world_size()
         self.tp_rank = tp_rank
         self.num_embeddings = num_embeddings
+        # Vocab must split evenly across TP ranks. The default padding
+        # (64) only guarantees that for power-of-two TP sizes; with e.g.
+        # TP=3 (uneven-TP setups keep the vocab evenly split) pad to a
+        # multiple of lcm(padding, tp_size) instead.
+        if self.tp_size > 1:
+            padding_size = math.lcm(padding_size, self.tp_size)
         self.padding_size = padding_size
         self.org_vocab_size = org_num_embeddings or num_embeddings
         num_added_embeddings = num_embeddings - self.org_vocab_size

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -1271,10 +1271,23 @@ def sharded_weight_loader(shard_axis: int) -> LoaderFunction:
     """Create a weight loader that shards the weights along the given axis"""
 
     def loader(param: torch.Tensor, loaded_weight: torch.Tensor) -> None:
+        from vllm.distributed import get_tensor_model_parallel_world_size
+        from vllm.distributed.utils import (
+            get_tp_partition_ratios,
+            tp_partition_offset,
+        )
+
         tp_rank = get_tensor_model_parallel_rank()
 
         shard_size = param.data.shape[shard_axis]
-        start_idx = tp_rank * shard_size
+        if get_tp_partition_ratios():
+            start_idx = tp_partition_offset(
+                loaded_weight.shape[shard_axis],
+                get_tensor_model_parallel_world_size(),
+                tp_rank,
+            )
+        else:
+            start_idx = tp_rank * shard_size
         loaded_weight = loaded_weight.narrow(shard_axis, start_idx, shard_size)
 
         return default_weight_loader(param, loaded_weight)

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -363,8 +363,10 @@ class Qwen2_5_VisionAttention(nn.Module):
         self.hidden_size_per_attention_head = dist_utils.divide(
             projection_size, num_heads
         )
-        self.num_attention_heads_per_partition = dist_utils.divide(
-            num_heads, self.tp_size
+        self.num_attention_heads_per_partition = dist_utils.tp_partition_size(
+            num_heads,
+            self.tp_size,
+            0 if use_data_parallel else self.tp_rank,
         )
 
         self.qkv = QKVParallelLinear(

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -384,6 +384,29 @@ class Qwen3_5ForCausalLMBase(
         parallel_config = vllm_config.parallel_config
         hf_config = vllm_config.model_config.hf_text_config
         tp_size = parallel_config.tensor_parallel_size
+        num_k_heads = hf_config.linear_num_key_heads
+        num_v_heads = hf_config.linear_num_value_heads
+        ratios = parallel_config.rank_tp_ratio
+        if ratios:
+            # Uneven TP: rank-aware in worker processes (matches the
+            # rank-aware get_num_kv_heads, so the derived block size
+            # mamba_page / attn_page is identical on every rank - the
+            # ratio factor cancels). Engine-level callers without an
+            # initialized TP group fall back to the smallest ratio,
+            # consistent with the same fallback in get_num_kv_heads.
+            denom = sum(ratios)
+            try:
+                from vllm.distributed.parallel_state import (
+                    get_tensor_model_parallel_rank,
+                )
+
+                rank = get_tensor_model_parallel_rank()
+            except (AssertionError, ValueError):
+                rank = None
+            unit = ratios[rank] if rank is not None else min(ratios)
+            num_k_heads = num_k_heads * unit // denom
+            num_v_heads = num_v_heads * unit // denom
+            tp_size = 1
         num_spec = (
             vllm_config.speculative_config.num_speculative_tokens
             if vllm_config.speculative_config
@@ -391,8 +414,8 @@ class Qwen3_5ForCausalLMBase(
         )
         return MambaStateShapeCalculator.gated_delta_net_state_shape(
             tp_size,
-            hf_config.linear_num_key_heads,
-            hf_config.linear_num_value_heads,
+            num_k_heads,
+            num_v_heads,
             hf_config.linear_key_head_dim,
             hf_config.linear_value_head_dim,
             hf_config.linear_conv_kernel_dim,
@@ -588,6 +611,29 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
         parallel_config = vllm_config.parallel_config
         hf_config = vllm_config.model_config.hf_text_config
         tp_size = parallel_config.tensor_parallel_size
+        num_k_heads = hf_config.linear_num_key_heads
+        num_v_heads = hf_config.linear_num_value_heads
+        ratios = parallel_config.rank_tp_ratio
+        if ratios:
+            # Uneven TP: rank-aware in worker processes (matches the
+            # rank-aware get_num_kv_heads, so the derived block size
+            # mamba_page / attn_page is identical on every rank - the
+            # ratio factor cancels). Engine-level callers without an
+            # initialized TP group fall back to the smallest ratio,
+            # consistent with the same fallback in get_num_kv_heads.
+            denom = sum(ratios)
+            try:
+                from vllm.distributed.parallel_state import (
+                    get_tensor_model_parallel_rank,
+                )
+
+                rank = get_tensor_model_parallel_rank()
+            except (AssertionError, ValueError):
+                rank = None
+            unit = ratios[rank] if rank is not None else min(ratios)
+            num_k_heads = num_k_heads * unit // denom
+            num_v_heads = num_v_heads * unit // denom
+            tp_size = 1
         num_spec = (
             vllm_config.speculative_config.num_speculative_tokens
             if vllm_config.speculative_config
@@ -595,8 +641,8 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
         )
         return MambaStateShapeCalculator.gated_delta_net_state_shape(
             tp_size,
-            hf_config.linear_num_key_heads,
-            hf_config.linear_num_value_heads,
+            num_k_heads,
+            num_v_heads,
             hf_config.linear_key_head_dim,
             hf_config.linear_value_head_dim,
             hf_config.linear_conv_kernel_dim,

--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -93,15 +93,33 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
             if (quant_config and quant_config.get_name() == "modelopt_fp4")
             else quant_config
         )
-        self.fc = ColumnParallelLinear(
-            self.config.hidden_size * 2,
-            self.config.hidden_size,
-            gather_output=True,
-            bias=False,
-            return_bias=False,
-            quant_config=fc_quant,
-            prefix=f"{prefix}.fc",
-        )
+        from vllm.distributed.utils import get_tp_partition_ratios
+
+        if get_tp_partition_ratios():
+            # Uneven TP: gather_output=True would all-gather unevenly
+            # sized shards, which plain all_gather cannot do. This
+            # projection is small (2*hidden -> hidden, draft model only),
+            # so replicate it instead.
+            from vllm.model_executor.layers.linear import ReplicatedLinear
+
+            self.fc = ReplicatedLinear(
+                self.config.hidden_size * 2,
+                self.config.hidden_size,
+                bias=False,
+                return_bias=False,
+                quant_config=fc_quant,
+                prefix=f"{prefix}.fc",
+            )
+        else:
+            self.fc = ColumnParallelLinear(
+                self.config.hidden_size * 2,
+                self.config.hidden_size,
+                gather_output=True,
+                bias=False,
+                return_bias=False,
+                quant_config=fc_quant,
+                prefix=f"{prefix}.fc",
+            )
 
         # GPTQ: quantized checkpoints may exclude MTP from quantization via
         # quantization_config.dynamic with "-:pattern" entries. When detected,

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -14,10 +14,12 @@ from vllm.config import CacheConfig, ModelConfig, VllmConfig
 from vllm.distributed import (
     get_ep_group,
     get_pp_group,
+    get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
     tensor_model_parallel_all_gather,
     tensor_model_parallel_reduce_scatter,
 )
+from vllm.distributed.utils import get_tp_partition_ratios, tp_partition_size
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import FusedMoEFactory
@@ -240,20 +242,37 @@ class Qwen3NextAttention(nn.Module):
         self.config = config
         self.hidden_size = config.hidden_size
         tp_size = get_tensor_model_parallel_world_size()
+        tp_rank = get_tensor_model_parallel_rank()
         self.total_num_heads = config.num_attention_heads
-        assert self.total_num_heads % tp_size == 0
-        self.num_heads = self.total_num_heads // tp_size
         self.total_num_kv_heads = config.num_key_value_heads
-        if self.total_num_kv_heads >= tp_size:
-            # Number of KV heads is greater than TP size, so we partition
-            # the KV heads across multiple tensor parallel GPUs.
-            assert self.total_num_kv_heads % tp_size == 0
+        if get_tp_partition_ratios():
+            # Uneven TP: partition q/kv heads by the ratio vector.
+            # KV-head replication is not supported with ratios (each rank
+            # must own at least one whole kv head); tp_partition_size
+            # raises with a clear message if a count is not partitionable.
+            self.num_heads = tp_partition_size(self.total_num_heads, tp_size, tp_rank)
+            self.num_kv_heads = tp_partition_size(
+                self.total_num_kv_heads, tp_size, tp_rank
+            )
         else:
-            # Number of KV heads is less than TP size, so we replicate
-            # the KV heads across multiple tensor parallel GPUs.
-            assert tp_size % self.total_num_kv_heads == 0
-        self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
-        self.head_dim = config.head_dim or (self.hidden_size // self.num_heads)
+            assert self.total_num_heads % tp_size == 0
+            self.num_heads = self.total_num_heads // tp_size
+            if self.total_num_kv_heads >= tp_size:
+                # Number of KV heads is greater than TP size, so we partition
+                # the KV heads across multiple tensor parallel GPUs.
+                assert self.total_num_kv_heads % tp_size == 0
+            else:
+                # Number of KV heads is less than TP size, so we replicate
+                # the KV heads across multiple tensor parallel GPUs.
+                assert tp_size % self.total_num_kv_heads == 0
+            self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
+        if get_tp_partition_ratios():
+            # Uneven TP: the fallback must not depend on per-rank heads.
+            self.head_dim = config.head_dim or (
+                self.hidden_size // self.total_num_heads
+            )
+        else:
+            self.head_dim = config.head_dim or (self.hidden_size // self.num_heads)
         self.q_size = self.num_heads * self.head_dim
         self.kv_size = self.num_kv_heads * self.head_dim
         self.scaling = self.head_dim**-0.5

--- a/vllm/model_executor/parameter.py
+++ b/vllm/model_executor/parameter.py
@@ -13,7 +13,29 @@ from vllm.distributed import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
+from vllm.distributed.utils import get_tp_partition_ratios, tp_partition_sizes
 from vllm.logger import init_logger
+
+
+def _tp_shard_start(
+    loaded_full: int, rank: int, shard_size: int, tp_size: int | None = None
+) -> int:
+    """Loader-side narrow offset: classic rank*shard_size for even TP,
+    prefix sum of per-rank partition sizes for uneven TP. Pass the
+    parameter's own tp_size so disable_tp layers (tp_size=1) keep the
+    classic path even when process-global ratios are installed."""
+    if tp_size is None:
+        tp_size = get_tensor_model_parallel_world_size()
+    ratios = get_tp_partition_ratios()
+    if not ratios or len(ratios) != tp_size:
+        return rank * shard_size
+    sizes = tp_partition_sizes(loaded_full, tp_size)
+    assert sizes[rank] == shard_size, (
+        f"uneven-TP shard mismatch: expected {sizes[rank]} for rank {rank} "
+        f"of dim {loaded_full}, parameter has {shard_size}"
+    )
+    return sum(sizes[:rank])
+
 
 __all__ = [
     "BasevLLMParameter",
@@ -148,7 +170,14 @@ class _ColumnvLLMParameter(BasevLLMParameter):
     def load_column_parallel_weight(self, loaded_weight: torch.Tensor):
         shard_size = self.data.shape[self.output_dim]
         loaded_weight = loaded_weight.narrow(
-            self.output_dim, self.tp_rank * shard_size, shard_size
+            self.output_dim,
+            _tp_shard_start(
+                loaded_weight.shape[self.output_dim],
+                self.tp_rank,
+                shard_size,
+                getattr(self, "tp_size", None),
+            ),
+            shard_size,
         )
         assert self.data.shape == loaded_weight.shape
         self.data.copy_(loaded_weight)
@@ -170,7 +199,14 @@ class _ColumnvLLMParameter(BasevLLMParameter):
 
         param_data = param_data.narrow(self.output_dim, shard_offset, shard_size)
         loaded_weight = loaded_weight.narrow(
-            self.output_dim, self.tp_rank * shard_size, shard_size
+            self.output_dim,
+            _tp_shard_start(
+                loaded_weight.shape[self.output_dim],
+                self.tp_rank,
+                shard_size,
+                getattr(self, "tp_size", None),
+            ),
+            shard_size,
         )
         assert param_data.shape == loaded_weight.shape
         param_data.copy_(loaded_weight)
@@ -191,11 +227,20 @@ class _ColumnvLLMParameter(BasevLLMParameter):
             )
 
         param_data = self.data
-        shard_id_int = self.tp_rank if shard_id == "q" else self.tp_rank // num_heads
+        if get_tp_partition_ratios():
+            start_idx = _tp_shard_start(
+                loaded_weight.shape[self.output_dim],
+                self.tp_rank,
+                shard_size,
+                getattr(self, "tp_size", None),
+            )
+        else:
+            shard_id_int = (
+                self.tp_rank if shard_id == "q" else self.tp_rank // num_heads
+            )
+            start_idx = shard_id_int * shard_size
         param_data = param_data.narrow(self.output_dim, shard_offset, shard_size)
-        loaded_weight = loaded_weight.narrow(
-            self.output_dim, shard_id_int * shard_size, shard_size
-        )
+        loaded_weight = loaded_weight.narrow(self.output_dim, start_idx, shard_size)
 
         assert param_data.shape == loaded_weight.shape
         param_data.copy_(loaded_weight)
@@ -220,7 +265,14 @@ class RowvLLMParameter(BasevLLMParameter):
     def load_row_parallel_weight(self, loaded_weight: torch.Tensor):
         shard_size = self.data.shape[self.input_dim]
         loaded_weight = loaded_weight.narrow(
-            self.input_dim, self.tp_rank * shard_size, shard_size
+            self.input_dim,
+            _tp_shard_start(
+                loaded_weight.shape[self.input_dim],
+                self.tp_rank,
+                shard_size,
+                getattr(self, "tp_size", None),
+            ),
+            shard_size,
         )
 
         if len(loaded_weight.shape) == 0:

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -948,6 +948,42 @@ class NvmlCudaPlatform(CudaPlatformBase):
 
     @classmethod
     @with_nvml_context
+    def get_torch_to_nvml_mapping(cls) -> dict[int, int]:
+        """
+        Build a mapping from torch.cuda device indices to NVML physical indices.
+
+        torch.cuda and NVML/nvidia-smi can enumerate GPUs in different orders.
+        This function resolves the mapping using PCI bus IDs as the bridge.
+
+        Returns:
+            Dict mapping torch.cuda index -> NVML physical index
+        """
+        import torch
+
+        # Build NVML index -> PCI bus ID mapping (extract just the bus number)
+        nvml_bus_to_idx: dict[int, int] = {}
+        for nvml_idx in range(pynvml.nvmlDeviceGetCount()):
+            handle = pynvml.nvmlDeviceGetHandleByIndex(nvml_idx)
+            pci_info = pynvml.nvmlDeviceGetPciInfo(handle)
+            bus_id = pci_info.busId
+            if isinstance(bus_id, bytes):
+                bus_id = bus_id.decode("utf-8")
+            # Extract bus number (format: "00000000:BB:00.0")
+            bus_num = int(bus_id.split(":")[1], 16)
+            nvml_bus_to_idx[bus_num] = nvml_idx
+
+        # Map torch.cuda indices to NVML indices via PCI bus ID
+        result: dict[int, int] = {}
+        for torch_idx in range(torch.cuda.device_count()):
+            props = torch.cuda.get_device_properties(torch_idx)
+            bus_num = props.pci_bus_id
+            if bus_num in nvml_bus_to_idx:
+                result[torch_idx] = nvml_bus_to_idx[bus_num]
+
+        return result
+
+    @classmethod
+    @with_nvml_context
     def log_warnings(cls):
         device_ids: int = pynvml.nvmlDeviceGetCount()
         if device_ids > 1:

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -2052,6 +2052,7 @@ def _auto_fit_max_model_len(
 def _project_kv_cache_groups_to_worker(
     global_kv_cache_groups: list[KVCacheGroupSpec],
     worker_spec: dict[str, KVCacheSpec],
+    use_worker_specs: bool = False,
 ) -> list[KVCacheGroupSpec]:
     """
     Projects global KV cache groups onto a single worker's assigned layers.
@@ -2074,13 +2075,17 @@ def _project_kv_cache_groups_to_worker(
         ]
         group_spec = group.kv_cache_spec
         if worker_layer_names and isinstance(group_spec, UniformTypeKVCacheSpecs):
+            source = worker_spec if use_worker_specs else group_spec.kv_cache_specs
             group_spec = UniformTypeKVCacheSpecs(
                 block_size=group_spec.block_size,
                 kv_cache_specs={
-                    layer_name: group_spec.kv_cache_specs[layer_name]
-                    for layer_name in worker_layer_names
+                    layer_name: source[layer_name] for layer_name in worker_layer_names
                 },
             )
+        elif worker_layer_names and use_worker_specs:
+            # Uneven TP: size this worker's config with its OWN spec
+            # (per-rank page size), not the canonical merged one.
+            group_spec = worker_spec[worker_layer_names[0]]
         projected_groups.append(
             KVCacheGroupSpec(
                 worker_layer_names,
@@ -2129,11 +2134,27 @@ def get_kv_cache_configs(
     # Merge the KV cache specs of all workers. Different PP stages may have
     # different layer names, and different TP ranks of the same PP stage should
     # have the same KV cache spec.
+    uneven_tp = bool(vllm_config.parallel_config.rank_tp_ratio)
     merged_kv_cache_specs: dict[str, KVCacheSpec] = {}
     for kv_cache_spec_one_worker in kv_cache_specs:
         for layer_name, layer_spec in kv_cache_spec_one_worker.items():
             if layer_name not in merged_kv_cache_specs:
                 merged_kv_cache_specs[layer_name] = layer_spec
+            elif uneven_tp:
+                # Uneven TP (--rank-tp-ratio): ranks legitimately hold
+                # differently sized shards of the same layer (different
+                # num_kv_heads / state shapes -> page_size_bytes). Require
+                # structural compatibility only; worker 0's spec stays the
+                # canonical structure for global grouping, per-worker page
+                # sizes are re-injected during projection below.
+                canonical = merged_kv_cache_specs[layer_name]
+                assert type(canonical) is type(layer_spec) and (
+                    canonical.block_size == layer_spec.block_size
+                ), (
+                    "Uneven TP: KV cache specs for the same layer are "
+                    "structurally incompatible across workers: "
+                    f"{canonical} vs {layer_spec}"
+                )
             else:
                 assert merged_kv_cache_specs[layer_name] == layer_spec, (
                     "The KV cache specs for the same layer are different "
@@ -2152,7 +2173,9 @@ def get_kv_cache_configs(
     # determine the maximum model length that fits in available GPU memory.
     # We use per-worker projected groups to account for PP sharding.
     projected_groups_per_worker = [
-        _project_kv_cache_groups_to_worker(global_kv_cache_groups, worker_spec)
+        _project_kv_cache_groups_to_worker(
+            global_kv_cache_groups, worker_spec, use_worker_specs=uneven_tp
+        )
         for worker_spec in kv_cache_specs
     ]
 

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -701,6 +701,50 @@ class WorkerProc:
             # Have the worker close parent end of this worker's pipes too
             "inherited_fds": inherited_fds if inherited_fds is not None else [],
         }
+
+        # Device isolation for --rank-gpu-id mode is handled by setting the
+        # accelerator device index inside the worker process, NOT via
+        # CUDA_VISIBLE_DEVICES. Setting CUDA_VISIBLE_DEVICES would break
+        # logical_device_id_to_visible_device_id(), which expects PyTorch
+        # device indices, not NVML physical indices.
+        #
+        # The worker selects assigned_physical_gpu_ids[local_rank] as its own
+        # device, so each worker uses the correct GPU regardless of what is
+        # visible in CUDA_VISIBLE_DEVICES.
+
+        # Configure NCCL for multi-rank-per-GPU if duplicates detected
+        assigned_ids = vllm_config.parallel_config.assigned_physical_gpu_ids
+        if assigned_ids is not None and len(assigned_ids) != len(set(assigned_ids)):
+            from collections import Counter
+
+            os.environ["NCCL_MULTI_RANK_GPU_ENABLE"] = "1"
+            os.environ["NCCL_NVLS_ENABLE"] = "0"
+            gpu_counts = Counter(assigned_ids)
+            max_colocated = max(gpu_counts.values())
+            if max_colocated > 1:
+                suggested_max_ctas = max(1, 8 // max_colocated)
+                os.environ.setdefault("NCCL_MAX_CTAS", str(suggested_max_ctas))
+            logger.warning_once(
+                "Detected multiple ranks sharing physical GPUs. "
+                "Setting NCCL_MULTI_RANK_GPU_ENABLE=1, NCCL_NVLS_ENABLE=0, "
+                "NCCL_MAX_CTAS=%s for multi-rank-per-GPU.",
+                os.environ.get("NCCL_MAX_CTAS", "default"),
+            )
+            # Without CUDA MPS, processes sharing a GPU are TIME-SLICED:
+            # their kernels never run concurrently, but NCCL collectives
+            # busy-spin waiting for the peer rank. Observed impact on this
+            # feature during development was well over an order of
+            # magnitude in achievable decode throughput.
+            mps_pipe_dir = os.environ.get("CUDA_MPS_PIPE_DIRECTORY", "/tmp/nvidia-mps")
+            if not os.path.exists(mps_pipe_dir):
+                logger.warning_once(
+                    "Multiple ranks share a physical GPU but the CUDA MPS "
+                    "control pipe (%s) was not found. Without MPS, co-located "
+                    "ranks are time-sliced and NCCL collectives become "
+                    "extremely slow (>20x slowdown). Start MPS with "
+                    "'nvidia-cuda-mps-control -d' before launching vLLM.",
+                    mps_pipe_dir,
+                )
         # Run EngineCore busy loop in background process.
         proc = context.Process(
             target=WorkerProc.worker_main,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -546,6 +546,9 @@ class GPUModelRunner(
             logprobs_mode=self.model_config.logprobs_mode,
             use_fp64_gumbel=self.model_config.use_fp64_gumbel,
         )
+        # Lazily detected in _hetero_tp_active(): TP ranks on differing GPU
+        # models (--rank-gpu-id) need sampled/draft ids broadcast from rank 0.
+        self._hetero_tp: bool | None = None
 
         self.eplb_state: EplbState | None = None
         self._moe_model: MixtureOfExperts | None = None
@@ -3689,6 +3692,42 @@ class GPUModelRunner(
             ec_connector_output,
         )
 
+    def _hetero_tp_active(self) -> bool:
+        """True if TP ranks run on different GPU models (only possible with
+        --rank-gpu-id). vLLM samples redundantly on every TP rank and relies
+        on bitwise-identical logits across ranks; different architectures
+        (kernel selection, reduction order) break that, so near-tie sampling
+        decisions can diverge between ranks and silently corrupt generation.
+        Detected once via an all-gather of device names over the TP CPU
+        group; all ranks call this at the same point in _sample."""
+        if self._hetero_tp is None:
+            tp = get_tp_group()
+            if (
+                tp.world_size == 1
+                or self.parallel_config.assigned_physical_gpu_ids is None
+            ):
+                self._hetero_tp = False
+            else:
+                names: list[str | None] = [None] * tp.world_size
+                torch.distributed.all_gather_object(
+                    names, torch.cuda.get_device_name(), group=tp.cpu_group
+                )
+                self._hetero_tp = len(set(names)) > 1
+                if self._hetero_tp and tp.rank_in_group == 0:
+                    logger.info(
+                        "Heterogeneous TP detected (%s): broadcasting "
+                        "sampled/draft token ids from rank 0 to keep "
+                        "rank states identical.",
+                        ", ".join(sorted(set(str(n) for n in names))),
+                    )
+        return self._hetero_tp
+
+    def _sync_token_ids_across_tp(self, token_ids: torch.Tensor) -> None:
+        """Broadcast token ids from TP rank 0 so all ranks continue with
+        identical sequences (heterogeneous TP only; a few KiB per step)."""
+        if self._hetero_tp_active():
+            get_tp_group().broadcast(token_ids, src=0)
+
     def _sample(
         self,
         logits: torch.Tensor | None,
@@ -3700,10 +3739,12 @@ class GPUModelRunner(
         # if async scheduling and required by current sampling params.
         self.input_batch.update_async_output_token_ids()
         if spec_decode_metadata is None:
-            return self.sampler(
+            sampler_output = self.sampler(
                 logits=logits,
                 sampling_metadata=sampling_metadata,
             )
+            self._sync_token_ids_across_tp(sampler_output.sampled_token_ids)
+            return sampler_output
 
         # Update spec_token_ids with real draft tokens from pre step only when
         # output_token_ids is needed (penalties or bad_words are in use).
@@ -3718,6 +3759,7 @@ class GPUModelRunner(
             logits,
             sampling_metadata,
         )
+        self._sync_token_ids_across_tp(sampler_output.sampled_token_ids)
         return sampler_output
 
     def _bookkeeping_sync(
@@ -4622,6 +4664,10 @@ class GPUModelRunner(
                     spec_decode_common_attn_metadata,
                     slot_mappings,
                 )
+                # Heterogeneous TP: draft proposals are sampled per rank
+                # and must stay identical across ranks like sampled ids.
+                if isinstance(self._draft_token_ids, torch.Tensor):
+                    self._sync_token_ids_across_tp(self._draft_token_ids)
                 self._copy_draft_token_ids_to_cpu(scheduler_output)
 
         spec_config = self.speculative_config

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -61,6 +61,7 @@ from vllm.tasks import SupportedTask
 from vllm.tracing import instrument
 from vllm.utils.gc_utils import freeze_gc_heap, maybe_attach_gc_debug_callback
 from vllm.utils.gpu_sync_debug import enable_gpu_sync_check, with_gpu_sync_check
+from vllm.utils.import_utils import import_pynvml
 from vllm.utils.mem_constants import GiB_bytes
 from vllm.utils.mem_utils import MemorySnapshot, format_gib, memory_profiling
 from vllm.utils.torch_utils import set_random_seed
@@ -355,15 +356,70 @@ class Worker(WorkerBase):
                         " exceeds assigned_physical_gpu_ids count "
                         f"({len(assigned_physical_gpu_ids)})"
                     )
+
+                # Convert the absolute --rank-gpu-memory-mib value to a
+                # per-rank fraction. The same MiB value maps to a different
+                # fraction depending on which physical GPU this rank landed
+                # on (heterogeneous setups can mix different VRAM sizes).
+                rank_gpu_memory_mib = parallel_config.rank_gpu_memory_mib
+                if rank_gpu_memory_mib is not None:
+                    torch_cuda_idx = assigned_physical_gpu_ids[self.local_rank]
+                    # Map torch.cuda index to NVML physical index for memory query
+                    # torch.cuda and NVML enumerate GPUs in different orders
+                    from vllm.platforms.cuda import CudaPlatform
+
+                    torch_to_nvml = CudaPlatform.get_torch_to_nvml_mapping()
+                    if torch_cuda_idx in torch_to_nvml:
+                        nvml_idx = torch_to_nvml[torch_cuda_idx]
+                    else:
+                        nvml_idx = torch_cuda_idx  # Fallback
+                    # Query NVML directly (bypasses device_id_to_physical_device_id).
+                    pynvml = import_pynvml()
+                    pynvml.nvmlInit()
+                    handle = pynvml.nvmlDeviceGetHandleByIndex(nvml_idx)
+                    nvml_total_bytes = pynvml.nvmlDeviceGetMemoryInfo(handle).total
+                    pynvml.nvmlShutdown()
+                    nvml_total_mib = nvml_total_bytes // (1024 * 1024)
+                    # CRITICAL: do not apply any additional percentage
+                    # reduction here. This is the rank's entire memory
+                    # budget on this GPU - 100% of the assigned MiB value,
+                    # not a fraction of it subject to further discounting.
+                    fraction = rank_gpu_memory_mib / nvml_total_mib
+                    logger.info(
+                        "Rank %d on torch.cuda:%d (NVML:%d): Using "
+                        "--rank-gpu-memory-mib=%d MiB "
+                        "(%s/%s GiB total = %.4f fraction)",
+                        self.rank,
+                        torch_cuda_idx,
+                        nvml_idx,
+                        rank_gpu_memory_mib,
+                        format_gib(rank_gpu_memory_mib * 1024 * 1024),
+                        format_gib(nvml_total_bytes),
+                        fraction,
+                    )
+                    # Store the fraction in cache_config for downstream use
+                    # (request_memory, determine_available_memory).
+                    self.cache_config.gpu_memory_utilization = fraction
+                    # Keep the NVML index around for per-process memory
+                    # accounting in determine_available_memory().
+                    self._rank_gpu_nvml_idx = nvml_idx
             else:
                 assert self.local_rank < torch.accelerator.device_count(), (
                     f"DP adjusted local rank {self.local_rank} is out of "
                     f"bounds for {torch.accelerator.device_count()} devices."
                 )
 
-            visible_device_index = (
-                current_platform.logical_device_id_to_visible_device_id(self.local_rank)
-            )
+            # Device isolation via --rank-gpu-id: each worker uses the torch.cuda
+            # index from assigned_physical_gpu_ids. This is the actual GPU device.
+            if parallel_config.rank_gpu_memory_mib is not None:
+                torch_cuda_idx = assigned_physical_gpu_ids[self.local_rank]
+                visible_device_index = torch_cuda_idx
+            else:
+                visible_device_index = (
+                    current_platform.logical_device_id_to_visible_device_id(
+                        self.local_rank
+                    )
+                )
             self.device = torch.device(f"cuda:{visible_device_index}")
             torch.accelerator.set_device_index(self.device)
 
@@ -495,6 +551,41 @@ class Worker(WorkerBase):
                 getattr(self.parallel_config, "_api_process_count", 1),
             )
 
+        # When multiple ranks share a physical GPU (via --rank-gpu-id), they
+        # execute determine_available_memory() concurrently. The default
+        # profiling path measures memory via the driver's mem_get_info, which
+        # is GPU-GLOBAL: each rank would see the other co-located rank's
+        # allocations (weights, activations, CUDA graphs) as its own
+        # "non-torch" overhead, roughly doubling non_kv_cache_memory and
+        # producing negative available-KV-cache estimates.
+        #
+        # NOTE: Serializing the profiling with a barrier is NOT possible:
+        # profile_run() executes a forward pass containing TP collectives
+        # (all-reduce), so ALL ranks must run it simultaneously - holding
+        # back one rank deadlocks the whole TP group.
+        #
+        # Solution: for co-located ranks, replace the mem_get_info-based
+        # non-torch measurement with a PER-PROCESS measurement from NVML
+        # (nvmlDeviceGetComputeRunningProcesses), which reports each
+        # process's own GPU memory usage independently.
+        assigned_ids = self.vllm_config.parallel_config.assigned_physical_gpu_ids
+        co_located_count = 1
+        if (
+            assigned_ids is not None
+            and self.vllm_config.parallel_config.rank_gpu_memory_mib is not None
+        ):
+            physical_gpu_id = assigned_ids[self.local_rank]
+            co_located_count = sum(1 for gid in assigned_ids if gid == physical_gpu_id)
+            if co_located_count > 1:
+                logger.info(
+                    "Rank %d shares torch.cuda:%d with %d ranks total; using "
+                    "per-process NVML memory accounting instead of global "
+                    "mem_get_info for KV cache sizing.",
+                    self.local_rank,
+                    physical_gpu_id,
+                    co_located_count,
+                )
+
         # Execute a forward pass with dummy inputs to profile the memory usage
         # of the model.
         with memory_profiling(
@@ -516,6 +607,58 @@ class Worker(WorkerBase):
         ):
             cudagraph_memory_estimate = self.model_runner.profile_cudagraph_memory()
 
+        if co_located_count > 1:
+            # Replace the polluted GPU-global measurement with a per-process
+            # one: total_consumed comes from mem_get_info(), which would
+            # count a co-located peer's allocations as ours. NVML reports
+            # this process's own GPU memory; subtracting torch's reserved
+            # pool leaves the true non-torch overhead (CUDA context, NCCL
+            # buffers, cuBLAS workspaces, ...).
+            nvml_idx = getattr(self, "_rank_gpu_nvml_idx", None)
+            my_pid = os.getpid()
+            proc_used_bytes = 0
+            if nvml_idx is not None:
+                pynvml = import_pynvml()
+                pynvml.nvmlInit()
+                try:
+                    handle = pynvml.nvmlDeviceGetHandleByIndex(nvml_idx)
+                    for proc in pynvml.nvmlDeviceGetComputeRunningProcesses(handle):
+                        if proc.pid == my_pid and proc.usedGpuMemory is not None:
+                            proc_used_bytes = proc.usedGpuMemory
+                            break
+                finally:
+                    pynvml.nvmlShutdown()
+            torch_reserved = torch.accelerator.memory_reserved(self.device)
+            non_torch_local = max(0, proc_used_bytes - torch_reserved)
+            # CUDA graph estimates via mem_get_info are also polluted by the
+            # co-located rank (can even go negative); clamp to non-negative.
+            cudagraph_memory_estimate = max(0, cudagraph_memory_estimate)
+            logger.info(
+                "Co-located memory accounting (rank %d, pid %d, NVML:%s): "
+                "nvml_proc_used=%s GiB, torch_reserved=%s GiB, "
+                "non_torch_local=%s GiB (global measurement was %s GiB), "
+                "weights=%s GiB, torch_peak_increase=%s GiB, "
+                "cudagraph_estimate=%s GiB, budget=%s GiB",
+                self.local_rank,
+                my_pid,
+                nvml_idx,
+                format_gib(proc_used_bytes),
+                format_gib(torch_reserved),
+                format_gib(non_torch_local),
+                format_gib(profile_result.non_torch_increase),
+                format_gib(profile_result.weights_memory),
+                format_gib(profile_result.torch_peak_increase),
+                format_gib(cudagraph_memory_estimate),
+                format_gib(self.requested_memory),
+            )
+            profile_result.non_torch_increase = non_torch_local
+            profile_result.total_consumed = proc_used_bytes
+            profile_result.non_kv_cache_memory = (
+                non_torch_local
+                + profile_result.torch_peak_increase
+                + profile_result.weights_memory
+            )
+
         # Respect the opt-in flag as originally designed.
         cudagraph_memory_estimate_applied = (
             cudagraph_memory_estimate
@@ -532,7 +675,11 @@ class Worker(WorkerBase):
         free_gpu_memory = profile_result.after_profile.free_memory
         # NOTE(woosuk): Here we assume that the other processes using the same
         # GPU did not change their memory usage during the profiling.
-        assert self.init_snapshot.free_memory >= free_gpu_memory, (
+        # With --rank-gpu-id co-location this assumption does not hold (the
+        # co-located rank allocates/frees concurrently), so skip the check.
+        assert co_located_count > 1 or (
+            self.init_snapshot.free_memory >= free_gpu_memory
+        ), (
             "Error in memory profiling. "
             f"Initial free memory {format_gib(self.init_snapshot.free_memory)} GiB, "
             f"current free memory {format_gib(free_gpu_memory)} GiB. "

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -303,6 +303,19 @@ class Worker(WorkerBase):
 
     @instrument(span_name="Init device")
     def init_device(self):
+        # Uneven TP: install the ratio vector process-globally BEFORE any
+        # layer computes shard sizes - independent of device backend paths.
+        if self.vllm_config.parallel_config.rank_tp_ratio is not None:
+            from vllm.distributed.utils import set_tp_partition_ratios
+
+            set_tp_partition_ratios(self.vllm_config.parallel_config.rank_tp_ratio)
+            logger.info(
+                "Uneven TP active: rank %d owns ratio %d/%d of every "
+                "sharded dimension.",
+                self.rank,
+                self.vllm_config.parallel_config.rank_tp_ratio[self.rank],
+                sum(self.vllm_config.parallel_config.rank_tp_ratio),
+            )
         if self.device_config.device_type == "cuda":
             # This env var set by Ray causes exceptions with graph building.
             os.environ.pop("NCCL_ASYNC_ERROR_HANDLING", None)
@@ -362,6 +375,11 @@ class Worker(WorkerBase):
                 # fraction depending on which physical GPU this rank landed
                 # on (heterogeneous setups can mix different VRAM sizes).
                 rank_gpu_memory_mib = parallel_config.rank_gpu_memory_mib
+                if isinstance(rank_gpu_memory_mib, list):
+                    # Per-node list; with pure single-node TP (enforced)
+                    # local_rank == rank, kept consistent with
+                    # assigned_physical_gpu_ids indexing below.
+                    rank_gpu_memory_mib = rank_gpu_memory_mib[self.local_rank]
                 if rank_gpu_memory_mib is not None:
                     torch_cuda_idx = assigned_physical_gpu_ids[self.local_rank]
                     # Map torch.cuda index to NVML physical index for memory query


### PR DESCRIPTION
> Stacked on #50733. This branch contains that commit too; only the top commit (`--rank-tp-ratio`) is new here. Placement and uneven shards are normally used together on mismatched GPUs.

## What

`--rank-tp-ratio 2,1,1`: a per-rank integer weight vector of length `tensor_parallel_size` that makes every TP-sharded dimension proportional to the weight instead of an equal `dim // tp_size` split. With `2,1,1`, rank 0 takes half of each sharded dimension and ranks 1 and 2 a quarter each.

## Motivation

TP sharding assumes uniform ranks: `divide()` and `split_tensor_along_last_dim` in `vllm/distributed/utils.py` give every rank `dim // world_size`. A TP group is therefore only as large as its smallest GPU — pairing one 32 GB card with two 20 GB cards leaves roughly 12 GB unusable. A ratio vector lets shard sizes follow the actual VRAM instead.

## How

- Prefix-sum partition helpers in `vllm/distributed/utils.py`. Every sharded dimension must be divisible by `sum(ratios)`; violations raise an explicit error naming the dimension.
- Ratio-aware shard sizes and offsets through `linear.py`, `vocab_parallel_embedding.py`, `parameter.py` and the weight loaders.
- Per-rank KV-cache specs: ranks are checked for structural compatibility rather than exact equality.
- Per-rank GDN/mamba state shapes for the Qwen3.5 hybrid models. `MambaMixer2`-based models reject the flag rather than silently mis-sizing state.
- TP ranks on differing GPU models broadcast sampled and drafted token ids from rank 0. vLLM samples redundantly on every rank and relies on the logits being bitwise identical; different SM generations disagree on near-ties, which desynchronises rank state silently until output degenerates. Overhead is a few KiB per step and it is only enabled when the ranks report different devices.
- The AOT compile-cache key gains the device name and capability, so ranks on different architectures cannot load each other's artifacts. This is also relevant for homogeneous clusters that share a cache directory over NFS.

## Relation to #47759

#47759 (@s0l) addresses an overlapping target — Qwen3.5/Qwen3Next at TP=3 — through a different mechanism: it pads the uneven attention/GDN/MLP dimensions up to a multiple of the world size, so each rank still holds an equal, partly padded shard, and the layer geometry stays uniform. That is the right tool when the problem is "this dimension does not divide by 3".

This PR takes the other axis: shards stay unpadded but become deliberately *different* sizes, driven by a user-supplied ratio, so the split can follow per-GPU capacity. The problem it solves is "the GPUs are not the same size", which padding does not address — a padded equal split still sizes the group by its weakest member.

The two look complementary rather than competing, and I would expect them to compose (pad to a unit, then partition units unevenly). I have not tried stacking them, so that is a conjecture, not a result.

## Verification

Run against this branch:

- `pytest tests/distributed/test_uneven_tp_partition.py` — 9 passed (new file, CPU only).
- `pytest tests/engine/test_rank_gpu_mapping.py` — 15 passed.
- `pytest tests/engine/test_arg_utils.py tests/v1/core/test_kv_cache_utils.py` — passed, unchanged from `main`.
- `ruff check` / `ruff format --check` plus the repo's `check_spdx_header`, `check_init_lazy_imports`, `check_forbidden_imports`, `check_torch_cuda`, `check_boolean_context_manager` and `validate_config` hooks.

## Limits

- Default behaviour is unchanged: the ratio path is entered only when `--rank-tp-ratio` is set.
- Per-rank mamba state is implemented for the Qwen3.5/3.6 GDN hybrids only.
- Multi-GPU end-to-end runs on mismatched consumer cards were done earlier on my own hardware; they are not re-run for this PR, and everything reported above is CPU-only.
