### PR TITLE
[Feature] Uneven decode context parallelism for heterogeneous TP ranks

### DIFF
--- a/tests/distributed/test_uneven_dcp_split.py
+++ b/tests/distributed/test_uneven_dcp_split.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU-only tests for the uneven-DCP token-axis split helpers."""
+
+import pytest
+import torch
+
+from vllm.distributed.utils import (
+    cp_rank_ratio_prefix,
+    cp_token_split_factor,
+    set_cp_token_ratios,
+    set_tp_partition_ratios,
+    uneven_cp_ratios,
+)
+from vllm.v1.attention.backends.utils import get_dcp_local_seq_lens
+
+
+@pytest.fixture(autouse=True)
+def clean_ratios():
+    set_tp_partition_ratios(None)
+    set_cp_token_ratios(None)
+    yield
+    set_tp_partition_ratios(None)
+    set_cp_token_ratios(None)
+
+
+def test_even_split_is_default():
+    assert uneven_cp_ratios(3) is None
+    assert cp_token_split_factor(3) == 3
+    assert cp_rank_ratio_prefix(3, 1) == (1, 1, 3)
+
+
+def test_uniform_ratios_degenerate_to_even():
+    set_cp_token_ratios([2, 2, 2])
+    assert uneven_cp_ratios(3) is None
+    assert cp_token_split_factor(3) == 3
+
+
+def test_ratio_vector_size_mismatch_is_even():
+    set_cp_token_ratios([2, 1, 1])
+    assert uneven_cp_ratios(2) is None
+    assert uneven_cp_ratios(4) is None
+
+
+def test_uneven_split_parameters():
+    set_cp_token_ratios([2, 1, 1])
+    assert uneven_cp_ratios(3) == [2, 1, 1]
+    assert cp_token_split_factor(3) == 4
+    # (ratio, prefix, sum) per rank.
+    assert cp_rank_ratio_prefix(3, 0) == (2, 0, 4)
+    assert cp_rank_ratio_prefix(3, 1) == (1, 2, 4)
+    assert cp_rank_ratio_prefix(3, 2) == (1, 3, 4)
+
+
+def test_tp_ratio_fallback_for_token_vector():
+    # Without an explicit token vector, the --rank-tp-ratio weights apply.
+    set_tp_partition_ratios([3, 1])
+    assert uneven_cp_ratios(2) == [3, 1]
+    assert cp_token_split_factor(2) == 4
+
+
+@pytest.mark.parametrize("interleave", [1, 16])
+@pytest.mark.parametrize(
+    "seq_lens",
+    [[0], [1], [7], [64], [65], [255], [256], [1000], [4096], [63, 129, 4097]],
+)
+def test_local_seq_lens_even_partition_sums(seq_lens, interleave):
+    dcp_size = 4
+    lens = torch.tensor(seq_lens, dtype=torch.int32)
+    local = get_dcp_local_seq_lens(
+        lens, dcp_size=dcp_size, cp_kv_cache_interleave_size=interleave
+    )
+    assert local.shape == (len(seq_lens), dcp_size)
+    # Every token is owned by exactly one rank.
+    assert torch.equal(local.sum(dim=-1), lens.to(local.dtype))
+
+
+@pytest.mark.parametrize("interleave", [1, 16])
+@pytest.mark.parametrize(
+    "seq_lens",
+    [[0], [1], [7], [64], [65], [255], [256], [1000], [4096], [63, 129, 4097]],
+)
+def test_local_seq_lens_uneven_partition_sums(seq_lens, interleave):
+    dcp_size = 3
+    ratios = [2, 1, 1]
+    set_cp_token_ratios(ratios)
+    lens = torch.tensor(seq_lens, dtype=torch.int32)
+    local = get_dcp_local_seq_lens(
+        lens, dcp_size=dcp_size, cp_kv_cache_interleave_size=interleave
+    )
+    assert local.shape == (len(seq_lens), dcp_size)
+    # Every token is owned by exactly one rank.
+    assert torch.equal(local.sum(dim=-1), lens.to(local.dtype))
+    # Per-rank result matches the all-ranks column.
+    for rank in range(dcp_size):
+        per_rank = get_dcp_local_seq_lens(
+            lens,
+            dcp_size=dcp_size,
+            dcp_rank=rank,
+            cp_kv_cache_interleave_size=interleave,
+        )
+        assert torch.equal(per_rank, local[:, rank])
+
+
+def test_local_seq_lens_uneven_proportionality():
+    # For sequence lengths that are a multiple of a full round
+    # (sum(ratios) * interleave), the split is exactly proportional.
+    ratios = [2, 1, 1]
+    set_cp_token_ratios(ratios)
+    interleave = 16
+    round_size = sum(ratios) * interleave  # 64
+    lens = torch.tensor([10 * round_size], dtype=torch.int32)
+    local = get_dcp_local_seq_lens(
+        lens, dcp_size=3, cp_kv_cache_interleave_size=interleave
+    )
+    assert local.tolist() == [[10 * ratios[r] * interleave for r in range(3)]]

--- a/tests/distributed/test_uneven_tp_partition.py
+++ b/tests/distributed/test_uneven_tp_partition.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU-only tests for the --rank-tp-ratio uneven-TP partition helpers."""
+
+import pytest
+
+from vllm.distributed.utils import (
+    get_tp_partition_ratios,
+    set_tp_partition_ratios,
+    tp_partition_offset,
+    tp_partition_size,
+    tp_partition_sizes,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_ratios():
+    set_tp_partition_ratios(None)
+    yield
+    set_tp_partition_ratios(None)
+
+
+def test_ratios_unset_by_default():
+    assert get_tp_partition_ratios() is None
+
+
+def test_set_and_get_ratios():
+    set_tp_partition_ratios([2, 1, 1])
+    assert get_tp_partition_ratios() == [2, 1, 1]
+    set_tp_partition_ratios(None)
+    assert get_tp_partition_ratios() is None
+
+
+def test_even_split_without_ratios():
+    assert tp_partition_sizes(32, 4) == [8, 8, 8, 8]
+    assert tp_partition_size(32, 4, 2) == 8
+    assert tp_partition_offset(32, 4, 2) == 16
+
+
+def test_even_split_requires_divisibility():
+    with pytest.raises(AssertionError):
+        tp_partition_sizes(10, 4)
+
+
+def test_ratio_split():
+    set_tp_partition_ratios([2, 1, 1])
+    assert tp_partition_sizes(32, 3) == [16, 8, 8]
+    assert [tp_partition_size(32, 3, r) for r in range(3)] == [16, 8, 8]
+    # Offsets are prefix sums of the per-rank sizes.
+    assert [tp_partition_offset(32, 3, r) for r in range(3)] == [0, 16, 24]
+
+
+def test_ratio_split_covers_dimension_exactly():
+    set_tp_partition_ratios([3, 2, 1])
+    sizes = tp_partition_sizes(48, 3)
+    assert sizes == [24, 16, 8]
+    assert sum(sizes) == 48
+    assert tp_partition_offset(48, 3, 2) + sizes[2] == 48
+
+
+def test_ratio_split_rejects_non_divisible():
+    set_tp_partition_ratios([2, 1, 1])
+    with pytest.raises(ValueError, match="not divisible by"):
+        tp_partition_sizes(30, 3)
+
+
+def test_ratio_length_mismatch_falls_back_to_even():
+    # Layers running with their own tp_size (e.g. disable_tp -> tp_size=1)
+    # must not be affected by an installed ratio vector.
+    set_tp_partition_ratios([2, 1, 1])
+    assert tp_partition_sizes(32, 1) == [32]
+    assert tp_partition_sizes(32, 4) == [8, 8, 8, 8]
+
+
+def test_arg_validation_ratio_rules():
+    from vllm.engine.arg_utils import EngineArgs
+
+    class _FakePlatform:
+        @staticmethod
+        def device_count() -> int:
+            return 3
+
+    def validate(**kwargs):
+        args = EngineArgs(model="facebook/opt-125m", **kwargs)
+        args._validate_rank_gpu_config(_FakePlatform())
+
+    # --rank-tp-ratio requires --rank-gpu-id.
+    with pytest.raises(ValueError, match="requires --rank-gpu-id"):
+        validate(tensor_parallel_size=3, rank_tp_ratio=[2, 1, 1])
+
+    common = dict(
+        tensor_parallel_size=3,
+        rank_gpu_id=[0, 1, 2],
+        rank_gpu_memory_mib=15000,
+    )
+    # Length must equal tensor_parallel_size.
+    with pytest.raises(ValueError, match="--rank-tp-ratio length"):
+        validate(rank_tp_ratio=[2, 1], **common)
+    # Entries must be positive.
+    with pytest.raises(ValueError, match="positive integers"):
+        validate(rank_tp_ratio=[2, 0, 1], **common)

--- a/tests/engine/test_rank_gpu_mapping.py
+++ b/tests/engine/test_rank_gpu_mapping.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU-only tests for --rank-gpu-id / --rank-gpu-memory-mib validation.
+
+NVML and platform lookups are mocked so the tests run without GPUs and
+independently of the host's real GPU inventory.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm.engine.arg_utils import EngineArgs
+
+MIB = 1024 * 1024
+
+# torch.cuda index -> NVML total MiB of the mocked inventory:
+# one 32 GiB card and two 20 GiB cards.
+GPU_TOTALS_MIB = {0: 32768, 1: 20480, 2: 20480}
+
+
+class _FakePlatform:
+    @staticmethod
+    def device_count() -> int:
+        return len(GPU_TOTALS_MIB)
+
+
+@pytest.fixture
+def mock_nvml(monkeypatch):
+    """Mock NVML totals and the torch->NVML index mapping."""
+    import vllm.utils.import_utils as import_utils
+    from vllm.platforms.cuda import CudaPlatform
+
+    pynvml = MagicMock()
+
+    def get_handle(nvml_idx):
+        return nvml_idx
+
+    def get_memory_info(handle):
+        info = MagicMock()
+        info.total = GPU_TOTALS_MIB[handle] * MIB
+        return info
+
+    pynvml.nvmlDeviceGetHandleByIndex.side_effect = get_handle
+    pynvml.nvmlDeviceGetMemoryInfo.side_effect = get_memory_info
+    monkeypatch.setattr(import_utils, "import_pynvml", lambda: pynvml)
+    monkeypatch.setattr(
+        CudaPlatform,
+        "get_torch_to_nvml_mapping",
+        classmethod(lambda cls: {i: i for i in GPU_TOTALS_MIB}),
+    )
+    return pynvml
+
+
+def _args(**kwargs) -> EngineArgs:
+    return EngineArgs(model="facebook/opt-125m", **kwargs)
+
+
+def _validate(args: EngineArgs) -> None:
+    args._validate_rank_gpu_config(_FakePlatform())
+
+
+def test_default_path_untouched():
+    # Neither flag set: validation is a no-op.
+    _validate(_args(tensor_parallel_size=2))
+
+
+def test_rank_gpu_id_requires_memory_mib():
+    with pytest.raises(ValueError, match="requires --rank-gpu-memory-mib"):
+        _validate(_args(tensor_parallel_size=2, rank_gpu_id=[0, 1]))
+
+
+def test_memory_mib_requires_rank_gpu_id():
+    with pytest.raises(ValueError, match="requires --rank-gpu-id"):
+        _validate(_args(tensor_parallel_size=2, rank_gpu_memory_mib=15000))
+
+
+def test_length_mismatch():
+    with pytest.raises(ValueError, match="must equal --tensor-parallel-size"):
+        _validate(
+            _args(
+                tensor_parallel_size=4,
+                rank_gpu_id=[0, 1],
+                rank_gpu_memory_mib=15000,
+            )
+        )
+
+
+def test_gpu_memory_utilization_conflict():
+    with pytest.raises(ValueError, match="--gpu-memory-utilization cannot be set"):
+        _validate(
+            _args(
+                tensor_parallel_size=2,
+                rank_gpu_id=[0, 1],
+                rank_gpu_memory_mib=15000,
+                gpu_memory_utilization=0.82,
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "field,value,match",
+    [
+        ("pipeline_parallel_size", 2, "pipeline-parallel-size"),
+        ("data_parallel_size", 2, "data-parallel-size"),
+        ("enable_expert_parallel", True, "expert parallelism"),
+    ],
+)
+def test_rejects_other_parallelism(field, value, match):
+    with pytest.raises(ValueError, match=match):
+        _validate(
+            _args(
+                tensor_parallel_size=2,
+                rank_gpu_id=[0, 1],
+                rank_gpu_memory_mib=15000,
+                **{field: value},
+            )
+        )
+
+
+def test_unknown_gpu_id(mock_nvml):
+    with pytest.raises(ValueError, match="out of range"):
+        _validate(
+            _args(
+                tensor_parallel_size=2,
+                rank_gpu_id=[0, 7],
+                rank_gpu_memory_mib=15000,
+            )
+        )
+
+
+def test_negative_gpu_id(mock_nvml):
+    with pytest.raises(ValueError, match="out of range"):
+        _validate(
+            _args(
+                tensor_parallel_size=2,
+                rank_gpu_id=[0, -1],
+                rank_gpu_memory_mib=15000,
+            )
+        )
+
+
+def test_colocation_fits(mock_nvml):
+    # 2 ranks x 15000 MiB = 30000 MiB on the 32768 MiB card: fits.
+    _validate(
+        _args(
+            tensor_parallel_size=4,
+            rank_gpu_id=[0, 0, 1, 2],
+            rank_gpu_memory_mib=15000,
+        )
+    )
+
+
+def test_colocation_physically_impossible(mock_nvml):
+    # 2 ranks x 15000 MiB = 30000 MiB on a 20480 MiB card: hard error.
+    with pytest.raises(ValueError, match="Physical impossibility"):
+        _validate(
+            _args(
+                tensor_parallel_size=4,
+                rank_gpu_id=[1, 1, 0, 2],
+                rank_gpu_memory_mib=15000,
+            )
+        )
+
+
+def test_single_rank_over_total(mock_nvml):
+    with pytest.raises(ValueError, match="Physical impossibility"):
+        _validate(
+            _args(
+                tensor_parallel_size=2,
+                rank_gpu_id=[1, 2],
+                rank_gpu_memory_mib=20481,
+            )
+        )
+
+
+def test_exact_total_is_allowed(mock_nvml):
+    # The check is a physical-impossibility bound, not a safety margin:
+    # exactly the NVML total must pass.
+    _validate(
+        _args(
+            tensor_parallel_size=2,
+            rank_gpu_id=[1, 2],
+            rank_gpu_memory_mib=20480,
+        )
+    )
+
+
+def test_mib_to_fraction_semantics():
+    # The documented conversion: the same MiB budget yields a different
+    # gpu_memory_utilization fraction per physical GPU, with no extra
+    # discount applied on top.
+    mib = 15000
+    fractions = {gpu: mib / total for gpu, total in GPU_TOTALS_MIB.items()}
+    assert fractions[0] == pytest.approx(15000 / 32768)
+    assert fractions[1] == pytest.approx(15000 / 20480)
+    # Heterogeneous totals must give different fractions for the same MiB.
+    assert fractions[0] != fractions[1]

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2165,6 +2165,10 @@ def _grouping_config():
     return SimpleNamespace(
         scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False),
         speculative_config=None,
+        parallel_config=SimpleNamespace(
+            rank_tp_ratio=None,
+            decode_context_parallel_size=1,
+        ),
     )
 
 

--- a/vllm/compilation/caching.py
+++ b/vllm/compilation/caching.py
@@ -578,6 +578,16 @@ def aot_compile_hash_factors(vllm_config: VllmConfig) -> list[str]:
     if envs.VLLM_USE_MEGA_AOT_ARTIFACT:
         factors.extend(get_inductor_factors())
 
+    # 3. identity of the GPU this worker actually runs on. With
+    #    heterogeneous rank placement (--rank-gpu-id) different ranks of
+    #    the same job may sit on different architectures; sharing one AOT
+    #    artifact across them loads wrong-arch kernels (hard launch
+    #    failure on the older arch, silently mistuned PTX-JIT kernels on
+    #    the newer one). Homogeneous setups just gain a constant factor.
+    if torch.cuda.is_available():
+        factors.append(torch.cuda.get_device_name())
+        factors.append(str(torch.cuda.get_device_capability()))
+
     return factors
 
 

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1314,15 +1314,29 @@ class ModelConfig:
         tensor_parallel_size = parallel_config.tensor_parallel_size
         ratios = parallel_config.rank_tp_ratio
         if ratios:
-            # Uneven TP: heads are partitioned proportionally; every
-            # sharded head count must be divisible by sum(ratios).
-            denom = sum(ratios)
-            if total_num_attention_heads % denom != 0:
-                raise ValueError(
-                    f"Total number of attention heads "
-                    f"({total_num_attention_heads}) must be divisible by "
-                    f"sum(--rank-tp-ratio)={denom} for uneven TP."
-                )
+            if parallel_config.decode_context_parallel_size > 1:
+                # Uneven DCP (v4 free partitioning): heads are rounded to
+                # whole units per rank; only feasibility is required
+                # (at least one head per rank).
+                if total_num_attention_heads < tensor_parallel_size:
+                    raise ValueError(
+                        f"Total number of attention heads "
+                        f"({total_num_attention_heads}) must be >= "
+                        f"tensor parallel size ({tensor_parallel_size})."
+                    )
+            else:
+                # Uneven TP without DCP: heads are partitioned exactly
+                # proportionally; every sharded head count must be
+                # divisible by sum(ratios) (GQA group alignment).
+                denom = sum(ratios)
+                if total_num_attention_heads % denom != 0:
+                    raise ValueError(
+                        f"Total number of attention heads "
+                        f"({total_num_attention_heads}) must be divisible by "
+                        f"sum(--rank-tp-ratio)={denom} for uneven TP "
+                        "(add --decode-context-parallel-size == tp for free "
+                        "per-dimension partitioning)."
+                    )
         elif total_num_attention_heads % tensor_parallel_size != 0:
             raise ValueError(
                 f"Total number of attention heads ({total_num_attention_heads})"
@@ -1343,7 +1357,28 @@ class ModelConfig:
             )
 
         decode_context_parallel_size = parallel_config.decode_context_parallel_size
-        if decode_context_parallel_size > 1 and not self.use_mla:
+        if (
+            decode_context_parallel_size > 1
+            and not self.use_mla
+            and parallel_config.rank_tp_ratio
+        ):
+            # Uneven DCP: kv heads are fully replicated per rank and the
+            # KV cache is split along the token axis by --rank-tp-ratio,
+            # so the classic GQA gates (which require tp > num_kv_heads)
+            # do not apply. The DCP group must span the whole TP group.
+            if decode_context_parallel_size != tensor_parallel_size:
+                raise ValueError(
+                    "Uneven DCP (--rank-tp-ratio with "
+                    "decode_context_parallel_size > 1) requires "
+                    f"dcp_size == tp_size, got dcp="
+                    f"{decode_context_parallel_size}, tp={tensor_parallel_size}."
+                )
+            if parallel_config.prefill_context_parallel_size > 1:
+                raise ValueError(
+                    "Uneven DCP does not support prefill context "
+                    "parallelism (pcp_size > 1)."
+                )
+        elif decode_context_parallel_size > 1 and not self.use_mla:
             total_num_kv_heads = self.get_total_num_kv_heads()
             if tensor_parallel_size <= total_num_kv_heads:
                 raise ValueError(
@@ -1435,6 +1470,10 @@ class ModelConfig:
 
         total_num_kv_heads = self.get_total_num_kv_heads()
         ratios = parallel_config.rank_tp_ratio
+        if ratios and parallel_config.decode_context_parallel_size > 1:
+            # Uneven DCP: kv heads are fully replicated on every rank
+            # (the KV cache is split along the token axis instead).
+            return total_num_kv_heads
         if ratios:
             # Uneven TP: rank-aware in worker processes; engine-level
             # callers (no TP group initialized) get the smallest-ratio
@@ -1448,7 +1487,9 @@ class ModelConfig:
 
     @staticmethod
     def _uneven_tp_heads(total: int, ratios: list[int]) -> int:
-        denom = sum(ratios)
+        from vllm.distributed.utils import partition_units
+
+        part = partition_units(total, ratios)
         try:
             from vllm.distributed.parallel_state import (
                 get_tensor_model_parallel_rank,
@@ -1457,10 +1498,9 @@ class ModelConfig:
             rank = get_tensor_model_parallel_rank()
         except (AssertionError, ValueError):
             # TP group not initialized (engine-level caller): use the
-            # smallest ratio as conservative basis.
+            # smallest share as conservative basis.
             rank = None
-        r = ratios[rank] if rank is not None else min(ratios)
-        return max(1, total * r // denom)
+        return part[rank] if rank is not None else min(part)
 
     def get_num_attention_heads(self, parallel_config: ParallelConfig) -> int:
         num_heads = self.model_arch_config.total_num_attention_heads

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1312,7 +1312,18 @@ class ModelConfig:
     ) -> None:
         total_num_attention_heads = self.model_arch_config.total_num_attention_heads
         tensor_parallel_size = parallel_config.tensor_parallel_size
-        if total_num_attention_heads % tensor_parallel_size != 0:
+        ratios = parallel_config.rank_tp_ratio
+        if ratios:
+            # Uneven TP: heads are partitioned proportionally; every
+            # sharded head count must be divisible by sum(ratios).
+            denom = sum(ratios)
+            if total_num_attention_heads % denom != 0:
+                raise ValueError(
+                    f"Total number of attention heads "
+                    f"({total_num_attention_heads}) must be divisible by "
+                    f"sum(--rank-tp-ratio)={denom} for uneven TP."
+                )
+        elif total_num_attention_heads % tensor_parallel_size != 0:
             raise ValueError(
                 f"Total number of attention heads ({total_num_attention_heads})"
                 " must be divisible by tensor parallel size "
@@ -1423,14 +1434,39 @@ class ModelConfig:
             return 1
 
         total_num_kv_heads = self.get_total_num_kv_heads()
+        ratios = parallel_config.rank_tp_ratio
+        if ratios:
+            # Uneven TP: rank-aware in worker processes; engine-level
+            # callers (no TP group initialized) get the smallest-ratio
+            # rank as a conservative basis.
+            return self._uneven_tp_heads(total_num_kv_heads, ratios)
         # If tensor parallelism is used, we divide the number of KV heads by
         # the tensor parallel size. We will replicate the KV heads in the
         # case where the number of KV heads is smaller than the tensor
         # parallel size so each GPU has at least one KV head.
         return max(1, total_num_kv_heads // parallel_config.tensor_parallel_size)
 
+    @staticmethod
+    def _uneven_tp_heads(total: int, ratios: list[int]) -> int:
+        denom = sum(ratios)
+        try:
+            from vllm.distributed.parallel_state import (
+                get_tensor_model_parallel_rank,
+            )
+
+            rank = get_tensor_model_parallel_rank()
+        except (AssertionError, ValueError):
+            # TP group not initialized (engine-level caller): use the
+            # smallest ratio as conservative basis.
+            rank = None
+        r = ratios[rank] if rank is not None else min(ratios)
+        return max(1, total * r // denom)
+
     def get_num_attention_heads(self, parallel_config: ParallelConfig) -> int:
         num_heads = self.model_arch_config.total_num_attention_heads
+        ratios = parallel_config.rank_tp_ratio
+        if ratios:
+            return self._uneven_tp_heads(num_heads, ratios)
         return num_heads // parallel_config.tensor_parallel_size
 
     def get_num_experts(self) -> int:

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -314,6 +314,14 @@ class ParallelConfig:
     checks, and final CUDA device selection when needed. When None,
     logical IDs map to visible device IDs in order."""
 
+    rank_gpu_memory_mib: int | None = None
+    """Absolute MiB memory budget per rank when using --rank-gpu-id.
+
+    This value applies uniformly to every rank. The value is converted
+    to a per-GPU fraction at runtime based on each physical GPU's
+    NVML-reported total memory, so the same MiB value represents a
+    DIFFERENT fraction on different physical GPUs."""
+
     distributed_timeout_seconds: int | None = None
     """Timeout in seconds for distributed operations (e.g., init_process_group).
     If set, this value is passed to torch.distributed.init_process_group as the
@@ -923,6 +931,9 @@ class ParallelConfig:
             elif (
                 current_platform.is_cuda()
                 and current_platform.device_count() < self.world_size
+                # rank_gpu_memory_mib set means --rank-gpu-id is in use,
+                # which allows more ranks than physical GPUs (co-location).
+                and self.rank_gpu_memory_mib is None
             ):
                 gpu_count = current_platform.device_count()
                 raise ValueError(
@@ -930,7 +941,8 @@ class ParallelConfig:
                     f"available GPUs ({gpu_count}) in this node. If this is "
                     "intentional and you are using:\n"
                     "- ray, set '--distributed-executor-backend ray'.\n"
-                    "- multiprocessing, set '--nnodes' appropriately."
+                    "- multiprocessing, set '--nnodes' appropriately.\n"
+                    "- --rank-gpu-id with --rank-gpu-memory-mib to share GPUs."
                 )
             elif self.data_parallel_backend == "ray":
                 logger.info(

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -314,13 +314,25 @@ class ParallelConfig:
     checks, and final CUDA device selection when needed. When None,
     logical IDs map to visible device IDs in order."""
 
-    rank_gpu_memory_mib: int | None = None
+    rank_gpu_memory_mib: int | list[int] | None = None
     """Absolute MiB memory budget per rank when using --rank-gpu-id.
 
-    This value applies uniformly to every rank. The value is converted
-    to a per-GPU fraction at runtime based on each physical GPU's
-    NVML-reported total memory, so the same MiB value represents a
-    DIFFERENT fraction on different physical GPUs."""
+    A single int applies uniformly to every rank (the natural fit for
+    even TP, where all shards are structurally equal). With
+    --rank-tp-ratio (uneven TP) a per-rank list may be given instead,
+    since ranks then carry differently sized shards. The value is
+    converted to a per-GPU fraction at runtime based on each physical
+    GPU's NVML-reported total memory."""
+
+    rank_tp_ratio: list[int] | None = None
+    """Uneven tensor-parallel shard ratios, one positive integer per rank.
+
+    Example: ``[2, 1, 1]`` with TP=3 gives rank 0 half of every sharded
+    dimension and ranks 1/2 a quarter each - e.g. one large GPU plus two
+    smaller ones, one rank per GPU, no co-location needed. Every sharded
+    dimension (attention heads, KV heads, GDN v/k heads, hidden and
+    intermediate sizes) must be divisible by sum(ratios). Vocab/LM-head
+    stay evenly split. Requires --rank-gpu-id; pure TP only."""
 
     distributed_timeout_seconds: int | None = None
     """Timeout in seconds for distributed operations (e.g., init_process_group).

--- a/vllm/distributed/utils.py
+++ b/vllm/distributed/utils.py
@@ -106,12 +106,53 @@ def get_tp_partition_ratios() -> list[int] | None:
     return _TP_PARTITION_RATIOS
 
 
-def tp_partition_sizes(total: int, tp_size: int) -> list[int]:
+def partition_units(units: int, weights: list[int]) -> list[int]:
+    """Split `units` indivisible units over ranks proportionally to
+    `weights` (largest-remainder rounding, every rank gets >= 1 unit).
+
+    Deterministic pure function of (units, weights) so every process
+    computes the identical partition. Ties in the fractional parts are
+    broken toward the lower rank index.
+    """
+    n = len(weights)
+    if units < n:
+        raise ValueError(
+            f"Cannot give each of {n} ranks at least one of {units} units."
+        )
+    total_w = sum(weights)
+    quotas = [units * w / total_w for w in weights]
+    sizes = [int(q) for q in quotas]
+    # Reserve a minimum of one unit per rank before distributing the rest.
+    sizes = [max(s, 1) for s in sizes]
+    remaining = units - sum(sizes)
+    if remaining < 0:
+        # Minimum-1 bumping overshot: take back from the largest shares.
+        for _ in range(-remaining):
+            i = max(range(n), key=lambda r: (sizes[r], -r))
+            sizes[i] -= 1
+        remaining = 0
+    order = sorted(
+        range(n), key=lambda r: (quotas[r] - int(quotas[r]), -r), reverse=True
+    )
+    for k in range(remaining):
+        sizes[order[k % n]] += 1
+    assert sum(sizes) == units and all(s >= 1 for s in sizes)
+    return sizes
+
+
+def tp_partition_sizes(total: int, tp_size: int, units: int | None = None) -> list[int]:
     """Per-rank sizes of a dimension of `total` elements.
 
-    With ratios active, every sharded dimension must be divisible by
-    sum(ratios) so all per-rank sizes are exact integers; otherwise this
-    raises with the offending dimension size.
+    `units` is the master unit count of the dimension FAMILY (v4 free
+    partitioning): e.g. attention q heads (24), GDN k heads (16),
+    intermediate/quant_group. All dimensions derived from the same family
+    pass the same `units`, so they round identically and stay mutually
+    consistent (qkv columns = 2 x q heads, GDN v dim = 3 x k heads, ...).
+    total must be a multiple of units.
+
+    Without `units` (un-migrated call sites), the v1 rule applies: every
+    sharded dimension must be divisible by sum(ratios) so per-rank sizes
+    are exact; otherwise this raises with the offending dimension size.
     """
     ratios = _TP_PARTITION_RATIOS
     if not ratios or len(ratios) != tp_size:
@@ -119,6 +160,14 @@ def tp_partition_sizes(total: int, tp_size: int) -> list[int]:
         # (disable_tp layers use tp_size=1): classic even split.
         ensure_divisibility(total, tp_size)
         return [total // tp_size] * tp_size
+    if units is not None:
+        if total % units != 0:
+            raise ValueError(
+                f"Dimension of size {total} is not a multiple of its "
+                f"family unit count {units}."
+            )
+        scale = total // units
+        return [s * scale for s in partition_units(units, ratios)]
     denom = sum(ratios)
     if total % denom != 0:
         raise ValueError(
@@ -126,20 +175,260 @@ def tp_partition_sizes(total: int, tp_size: int) -> list[int]:
             f"--rank-tp-ratio {ratios}: {total} is not divisible by "
             f"sum(ratios)={denom}. Choose ratios whose sum divides every "
             "sharded dimension (attention heads, kv heads, GDN heads, "
-            "hidden/intermediate sizes)."
+            "hidden/intermediate sizes), or migrate this call site to "
+            "unit-based partitioning (v4)."
         )
     unit = total // denom
     return [unit * r for r in ratios]
 
 
-def tp_partition_size(total: int, tp_size: int, rank: int) -> int:
+def tp_partition_size(
+    total: int, tp_size: int, rank: int, units: int | None = None
+) -> int:
     """This rank's size of a sharded dimension."""
-    return tp_partition_sizes(total, tp_size)[rank]
+    return tp_partition_sizes(total, tp_size, units)[rank]
 
 
-def tp_partition_offset(total: int, tp_size: int, rank: int) -> int:
+def tp_partition_offset(
+    total: int, tp_size: int, rank: int, units: int | None = None
+) -> int:
     """This rank's start offset (prefix sum) in a sharded dimension."""
-    return sum(tp_partition_sizes(total, tp_size)[:rank])
+    return sum(tp_partition_sizes(total, tp_size, units)[:rank])
+
+
+_CP_TOKEN_RATIOS: list[int] | None = None
+
+
+def set_cp_token_ratios(ratios: list[int] | None) -> None:
+    """Install the token-axis split vector for uneven DCP (v4: derived
+    from the GDN k-head partition so the align invariant holds; v3:
+    identical to the weight vector)."""
+    global _CP_TOKEN_RATIOS
+    _CP_TOKEN_RATIOS = list(ratios) if ratios else None
+
+
+def get_cp_token_ratios() -> list[int] | None:
+    return _CP_TOKEN_RATIOS
+
+
+def gdn_family_units(vllm_config) -> int | None:
+    """Master unit count of the GDN head family, respecting the
+    quantization block granularity: shard cuts of the GDN out_proj INPUT
+    (value dim) must land on quant-block boundaries. E.g. Qwen3.6 Q6_K:
+    one k-head spans 3*128=384 value elements but K-quant superblocks are
+    256 -> units of 2 k-heads (768 = 3*256), i.e. 8 family units instead
+    of 16. None for non-hybrid models."""
+    import math
+
+    hf_config = vllm_config.model_config.hf_config
+    text_config = getattr(hf_config, "text_config", hf_config) or hf_config
+    num_k_heads = getattr(text_config, "linear_num_key_heads", None)
+    if not num_k_heads:
+        return None
+    num_v_heads = getattr(text_config, "linear_num_value_heads", num_k_heads)
+    head_v_dim = getattr(text_config, "linear_value_head_dim", 128)
+    unit_v_elems = head_v_dim * (num_v_heads // num_k_heads)
+    group = getattr(vllm_config.quant_config, "group_size", None) or 1
+    if group > 1 and unit_v_elems % group:
+        k_per_unit = math.lcm(unit_v_elems, group) // unit_v_elems
+        if num_k_heads % k_per_unit:
+            raise ValueError(
+                f"GDN k heads ({num_k_heads}) cannot be partitioned in "
+                f"steps of {k_per_unit} (quant group {group} vs "
+                f"{unit_v_elems} value elements per k head)."
+            )
+        return num_k_heads // k_per_unit
+    return num_k_heads
+
+
+def gdn_head_partition(vllm_config, weights: list[int]) -> list[int]:
+    """Per-rank GDN k-head counts under the quant-aware family units
+    (whole units are partitioned, then scaled back to heads)."""
+    units = gdn_family_units(vllm_config)
+    assert units is not None
+    hf_config = vllm_config.model_config.hf_config
+    text_config = getattr(hf_config, "text_config", hf_config) or hf_config
+    num_k_heads = text_config.linear_num_key_heads
+    scale = num_k_heads // units
+    return [u * scale for u in partition_units(units, list(weights))]
+
+
+def resolve_cp_token_ratios(vllm_config) -> list[int] | None:
+    """Token-axis split vector for uneven DCP, derived from the config.
+
+    Hybrid models (GDN/linear attention): the GDN k-head partition - the
+    mamba state on rank r scales with its k-head share, and the align
+    invariant (mamba page == attention bytes per virtual block, per rank)
+    requires the token split to be proportional to exactly that. Dense
+    models: the raw --rank-tp-ratio weights.
+    """
+    parallel_config = vllm_config.parallel_config
+    weights = parallel_config.rank_tp_ratio
+    if (
+        not weights
+        or parallel_config.decode_context_parallel_size <= 1
+        or len(set(weights)) == 1
+    ):
+        return None
+    import math
+
+    import vllm.envs as envs
+
+    override = envs.VLLM_UNEVEN_TOKEN_VECTOR
+    if override:
+        # Manual override (see the imbalance warning in
+        # kv_cache_utils.get_kv_cache_configs): a token vector measured
+        # from a previous run's per-worker free memory. Must be set for
+        # ALL processes (inherited env), one entry per rank.
+        vector = [int(x) for x in override.split(",")]
+        if len(vector) != len(weights) or any(v <= 0 for v in vector):
+            raise ValueError(
+                f"VLLM_UNEVEN_TOKEN_VECTOR={override!r} must name "
+                f"{len(weights)} positive integers (one per rank)."
+            )
+        g = math.gcd(*vector)
+        return [v // g for v in vector]
+
+    budgets = parallel_config.rank_gpu_memory_mib
+    if isinstance(budgets, list) and len(budgets) == len(weights):
+        # Split the KV cache proportionally to each rank's FREE
+        # memory (budget minus its weight share minus a fixed overhead),
+        # so every card fills up. The mamba pages are padded per rank to
+        # the attention bytes-per-virtual-block (align solver), so the
+        # token vector no longer needs to be proportional to the GDN
+        # head partition. Integerized to 32 units (>= 1 per rank).
+        w_mib = _checkpoint_size_mib(vllm_config)
+        if w_mib > 0:
+            total_w = sum(weights)
+            avail = [
+                max(
+                    b - w_mib * w / total_w - _AUTO_TOKEN_OVERHEAD_MIB,
+                    1.0,
+                )
+                for b, w in zip(budgets, weights)
+            ]
+            token_vector = partition_units(
+                _TOKEN_VECTOR_UNITS, [max(int(a), 1) for a in avail]
+            )
+            g = math.gcd(*token_vector)
+            return [t // g for t in token_vector]
+
+    hf_config = vllm_config.model_config.hf_config
+    text_config = getattr(hf_config, "text_config", hf_config) or hf_config
+    gdn_k_heads = getattr(text_config, "linear_num_key_heads", None)
+    if gdn_k_heads:
+        part = gdn_head_partition(vllm_config, list(weights))
+        # Reduce by the gcd: smaller entries keep the virtual scheduler
+        # blocks (block_size * sum(token ratios)) as fine as possible.
+        # For divisible weights like (2,1,1) this reproduces the v3
+        # vector exactly ([8,4,4] -> [2,1,1]).
+        g = math.gcd(*part)
+        return [p // g for p in part]
+    return list(weights)
+
+
+#: Token-vector resolution (units) and assumed weight-independent
+#: per-rank overhead for the free-memory split.
+_TOKEN_VECTOR_UNITS = 64
+_AUTO_TOKEN_OVERHEAD_MIB = 1536
+
+
+def _checkpoint_size_mib(vllm_config) -> int:
+    """Total checkpoint size of the model on disk (MiB), 0 if unknown.
+    Deterministic in every process - the token vector derived from it
+    must be identical everywhere."""
+    import glob
+    import os
+
+    path = vllm_config.model_config.model
+    if os.path.isfile(path):
+        # Single-file checkpoints (e.g. GGUF).
+        return os.path.getsize(path) // 2**20
+    if not os.path.isdir(path):
+        return 0
+    total = sum(
+        os.path.getsize(f) for f in glob.glob(os.path.join(path, "*.safetensors"))
+    )
+    if total == 0:
+        total = sum(os.path.getsize(f) for f in glob.glob(os.path.join(path, "*.gguf")))
+    return total // 2**20
+
+
+def uneven_cp_ratios(cp_world_size: int) -> list[int] | None:
+    """Ratio vector for uneven (token-axis) context parallelism.
+
+    Uneven DCP splits the KV cache of the full-attention layers along
+    the TOKEN axis (dcp group == tp group, so len(ratios) ==
+    cp_world_size). The token vector is the installed CP token ratio
+    vector when set (v4: the GDN k-head partition, which keeps the
+    mamba/attention align invariant), else the --rank-tp-ratio weights
+    (v3). Returns None when the classic even split applies.
+    """
+    ratios = _CP_TOKEN_RATIOS or _TP_PARTITION_RATIOS
+    if not ratios or len(ratios) != cp_world_size or cp_world_size <= 1:
+        return None
+    if all(r == ratios[0] for r in ratios):
+        # Uniform ratios degenerate to the even split; keep default path.
+        return None
+    return ratios
+
+
+def cp_q_head_counts(total_q_heads: int, cp_world_size: int) -> list[int] | None:
+    """Per-rank q-head counts across the DCP group under uneven ratios
+    (v4: units-based partition, which need not be proportional to the
+    token vector). None when no ratios are installed for this group
+    size. Deterministic pure function - identical in every process."""
+    ratios = _TP_PARTITION_RATIOS
+    if not ratios or len(ratios) != cp_world_size or cp_world_size <= 1:
+        return None
+    return tp_partition_sizes(total_q_heads, cp_world_size, units=total_q_heads)
+
+
+def uneven_dcp_active() -> bool:
+    """True when uneven DCP runs in this process: non-uniform
+    --rank-tp-ratio weights are installed and the DCP group spans the
+    whole TP group. Attention KV heads are then fully replicated per
+    rank and the KV cache is split along the token axis (whose vector
+    may itself be uniform after budget balancing)."""
+    try:
+        from vllm.distributed.parallel_state import get_dcp_group
+
+        dcp_world_size = get_dcp_group().world_size
+    except (AssertionError, ImportError):
+        return False
+    weights = _TP_PARTITION_RATIOS
+    return (
+        dcp_world_size > 1
+        and bool(weights)
+        and len(weights) == dcp_world_size
+        and len(set(weights)) > 1
+    )
+
+
+def cp_token_split_factor(dcp_world_size: int, pcp_world_size: int = 1) -> int:
+    """Number of block_size-units one "virtual" scheduler block spans.
+
+    Even CP: dcp * pcp (each rank owns exactly one physical block per
+    virtual block). Uneven DCP: sum(ratios) - rank r owns a contiguous
+    "superblock" of ratios[r] physical blocks per virtual block, so the
+    scheduler stays CP-agnostic while ranks store token counts
+    proportional to their ratio.
+    """
+    ratios = uneven_cp_ratios(dcp_world_size)
+    if ratios is not None:
+        return sum(ratios) * pcp_world_size
+    return dcp_world_size * pcp_world_size
+
+
+def cp_rank_ratio_prefix(cp_world_size: int, cp_rank: int) -> tuple[int, int, int]:
+    """(ratio, prefix, sum) of this rank's token-axis share under uneven
+    DCP; (1, cp_rank, cp_world_size) for the classic even split (the
+    generalized slot-mapping formulas reduce exactly to the even ones
+    with these values)."""
+    ratios = uneven_cp_ratios(cp_world_size)
+    if ratios is None:
+        return 1, cp_rank, cp_world_size
+    return ratios[cp_rank], sum(ratios[:cp_rank]), sum(ratios)
 
 
 def is_weak_contiguous(inp: torch.Tensor) -> bool:

--- a/vllm/distributed/utils.py
+++ b/vllm/distributed/utils.py
@@ -82,6 +82,66 @@ def verify_group_size_divides_partition(
     )
 
 
+# --------------------------------------------------------------------------
+# Uneven tensor-parallel partitioning (--rank-tp-ratio).
+#
+# When a ratio vector like (2, 1, 1) is active, TP rank r owns
+# total * ratio[r] / sum(ratio) of every sharded dimension instead of
+# total / tp_size. Offsets become prefix sums (same pattern as
+# VLLM_PP_LAYER_PARTITION for pipeline parallel). The ratio vector is
+# process-global state set once per worker before the model is built;
+# when unset, all helpers reproduce the classic even split exactly.
+# --------------------------------------------------------------------------
+
+_TP_PARTITION_RATIOS: list[int] | None = None
+
+
+def set_tp_partition_ratios(ratios: list[int] | None) -> None:
+    """Install the uneven-TP ratio vector for this process (or None)."""
+    global _TP_PARTITION_RATIOS
+    _TP_PARTITION_RATIOS = list(ratios) if ratios else None
+
+
+def get_tp_partition_ratios() -> list[int] | None:
+    return _TP_PARTITION_RATIOS
+
+
+def tp_partition_sizes(total: int, tp_size: int) -> list[int]:
+    """Per-rank sizes of a dimension of `total` elements.
+
+    With ratios active, every sharded dimension must be divisible by
+    sum(ratios) so all per-rank sizes are exact integers; otherwise this
+    raises with the offending dimension size.
+    """
+    ratios = _TP_PARTITION_RATIOS
+    if not ratios or len(ratios) != tp_size:
+        # No ratios installed, or this layer runs with its own tp_size
+        # (disable_tp layers use tp_size=1): classic even split.
+        ensure_divisibility(total, tp_size)
+        return [total // tp_size] * tp_size
+    denom = sum(ratios)
+    if total % denom != 0:
+        raise ValueError(
+            f"Cannot partition dimension of size {total} with "
+            f"--rank-tp-ratio {ratios}: {total} is not divisible by "
+            f"sum(ratios)={denom}. Choose ratios whose sum divides every "
+            "sharded dimension (attention heads, kv heads, GDN heads, "
+            "hidden/intermediate sizes)."
+        )
+    unit = total // denom
+    return [unit * r for r in ratios]
+
+
+def tp_partition_size(total: int, tp_size: int, rank: int) -> int:
+    """This rank's size of a sharded dimension."""
+    return tp_partition_sizes(total, tp_size)[rank]
+
+
+def tp_partition_offset(total: int, tp_size: int, rank: int) -> int:
+    """This rank's start offset (prefix sum) in a sharded dimension."""
+    return sum(tp_partition_sizes(total, tp_size)[:rank])
+
+
 def is_weak_contiguous(inp: torch.Tensor) -> bool:
     """Check that *inp* occupies a single contiguous block of memory.
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -477,7 +477,8 @@ class EngineArgs:
     device_ids: list[int | str] | None = None
     rank_gpu_id: list[int] | None = None
     rank_gpu_memory_mib: int | list[int] | None = None
-    rank_tp_ratio: list[int] | None = None
+    rank_tp_ratio: list[int] | str | None = None
+    rank_auto_reserve_mib: str | int = 1024
     tensor_parallel_size: int = ParallelConfig.tensor_parallel_size
     prefill_context_parallel_size: int = ParallelConfig.prefill_context_parallel_size
     decode_context_parallel_size: int = ParallelConfig.decode_context_parallel_size
@@ -1070,22 +1071,51 @@ class EngineArgs:
             "instead (e.g. 26000,17000,17000), since shards then differ in "
             "size. Values are converted to per-GPU fractions at runtime via "
             "each physical GPU's NVML-reported total memory. "
-            "Required when --rank-gpu-id is set. "
+            "Required when --rank-gpu-id is set, except with "
+            "--rank-tp-ratio auto, which derives the budgets from the "
+            "NVML totals (minus a small per-GPU reserve) to fill the "
+            "complete VRAM. "
             "Mutually exclusive with --gpu-memory-utilization "
             "(setting both is a hard error).",
         )
         parallel_group.add_argument(
             "--rank-tp-ratio",
-            type=lambda s: [int(r) for r in s.split(",")],
+            type=lambda s: s if s.strip() == "auto" else [int(r) for r in s.split(",")],
             default=None,
             help="UNEVEN tensor parallelism: comma-separated positive integer "
-            "ratios, one per rank (length must equal tensor-parallel-size). "
-            "Example: 2,1,1 gives rank 0 half of every sharded dimension and "
-            "ranks 1/2 a quarter each - one large GPU plus two smaller ones, "
-            "one rank per GPU, no MPS/co-location required. Every sharded "
-            "dimension (attention heads, KV heads, GDN heads, hidden and "
-            "intermediate sizes) must be divisible by sum(ratios); vocab and "
-            "LM head stay evenly split. Requires --rank-gpu-id.",
+            "weights, one per rank (length must equal tensor-parallel-size), "
+            "or 'auto'. Example: 2,1,1 gives rank 0 half of every sharded "
+            "dimension and ranks 1/2 a quarter each - one large GPU plus two "
+            "smaller ones, one rank per GPU, no MPS/co-location required. "
+            "With --decode-context-parallel-size == tp (free per-dimension "
+            "partitioning) any weights work: every dimension family is "
+            "rounded to its own granularity (whole attention/GDN heads, "
+            "quant-group-aligned MLP columns) and the KV cache follows the "
+            "token axis. Without it, sum(weights) must divide every sharded "
+            "dimension. 'auto' derives the weights from the "
+            "--rank-gpu-memory-mib list (capacity is maximized when each "
+            "rank's share is proportional to its memory budget) and enables "
+            "decode context parallelism automatically. Requires "
+            "--rank-gpu-id.",
+        )
+        parallel_group.add_argument(
+            "--rank-auto-reserve-mib",
+            type=str,
+            default="1024",
+            help="Headroom (MiB) subtracted from the NVML total when "
+            "--rank-tp-ratio auto derives the memory budgets itself. "
+            "Either a single value applied to every GPU, or a "
+            "comma-separated list with one value per rank (aligned with "
+            "--rank-gpu-id), e.g. '2048,2048,10240' to keep 10 GiB free "
+            "on the third rank's GPU only. When several ranks share one "
+            "physical GPU, the largest reserve among them applies to that "
+            "GPU. Covers CUDA context plus allocations that appear lazily "
+            "after the KV sizing (NCCL collective buffers for long "
+            "prefills, attention-backend split workspaces) - observed "
+            "~0.5-0.7 GiB on top of the budget after the first long "
+            "prefill. Raise this if nvidia-smi shows an uncomfortably "
+            "small margin; each additional MiB costs KV-cache capacity "
+            "1:1 per rank.",
         )
         parallel_group.add_argument(
             "--tensor-parallel-size", "-tp", **parallel_kwargs["tensor_parallel_size"]
@@ -2241,7 +2271,7 @@ class EngineArgs:
             logger.info("Skipping tokenizer initialization for tokens-only mode.")
 
         # Validate --rank-gpu-id and --rank-gpu-memory-mib
-        self._validate_rank_gpu_config(current_platform)
+        self._validate_rank_gpu_config(current_platform, model_config)
 
         parallel_config = ParallelConfig(
             pipeline_parallel_size=self.pipeline_parallel_size,
@@ -2548,7 +2578,138 @@ class EngineArgs:
 
         return config
 
-    def _validate_rank_gpu_config(self, current_platform) -> None:
+    #: NVML-total headroom (MiB) reserved per GPU when --rank-tp-ratio
+    #: auto derives the budgets itself (CUDA context, fragmentation).
+    AUTO_RANK_MEMORY_RESERVE_MIB = 1024
+
+    def _resolve_auto_rank_tp_ratio(self, model_config=None) -> None:
+        """--rank-tp-ratio auto: fill the complete VRAM as well as
+        possible. Budgets default to each assigned GPU's NVML total minus
+        a fixed reserve (shared between co-located ranks); the weights are
+        the gcd-reduced budgets - capacity is maximized when each rank's
+        share of every dimension is proportional to its memory budget
+        (weights, activations and, via the token vector, KV cache all
+        scale linearly with the share). Per-family unit rounding happens
+        downstream. Explicit integer weights keep working unchanged."""
+        import math
+
+        if self.rank_gpu_id is None:
+            raise ValueError("--rank-tp-ratio auto requires --rank-gpu-id.")
+
+        if self.rank_gpu_memory_mib is None:
+            from collections import Counter
+
+            from vllm.platforms.cuda import CudaPlatform
+            from vllm.utils.import_utils import import_pynvml
+
+            torch_to_nvml = CudaPlatform.get_torch_to_nvml_mapping()
+
+            # --rank-auto-reserve-mib: single value for every GPU, or one
+            # value per rank (aligned with --rank-gpu-id).
+            try:
+                reserve_per_rank = [
+                    int(part) for part in str(self.rank_auto_reserve_mib).split(",")
+                ]
+            except ValueError as e:
+                raise ValueError(
+                    "--rank-auto-reserve-mib must be an integer or a "
+                    "comma-separated list of integers, got "
+                    f"{self.rank_auto_reserve_mib!r}."
+                ) from e
+            if len(reserve_per_rank) == 1:
+                reserve_per_rank *= len(self.rank_gpu_id)
+            if len(reserve_per_rank) != len(self.rank_gpu_id):
+                raise ValueError(
+                    f"--rank-auto-reserve-mib has {len(reserve_per_rank)} "
+                    f"entries but --rank-gpu-id names "
+                    f"{len(self.rank_gpu_id)} ranks; pass one value or "
+                    "exactly one per rank."
+                )
+            if any(r < 0 for r in reserve_per_rank):
+                raise ValueError(
+                    "--rank-auto-reserve-mib values must be >= 0, got "
+                    f"{reserve_per_rank}."
+                )
+            # Reserve is a per-physical-GPU property: if co-located ranks
+            # disagree, the largest requested headroom wins for that GPU.
+            reserve_per_gpu: dict[int, int] = {}
+            for gpu_id, res in zip(self.rank_gpu_id, reserve_per_rank):
+                reserve_per_gpu[gpu_id] = max(reserve_per_gpu.get(gpu_id, 0), res)
+
+            pynvml = import_pynvml()
+            pynvml.nvmlInit()
+            try:
+                counts = Counter(self.rank_gpu_id)
+                budgets = []
+                for gpu_id in self.rank_gpu_id:
+                    handle = pynvml.nvmlDeviceGetHandleByIndex(
+                        torch_to_nvml.get(gpu_id, gpu_id)
+                    )
+                    mem = pynvml.nvmlDeviceGetMemoryInfo(handle)
+                    total_mib = mem.total // 2**20
+                    free_mib = mem.free // 2**20
+                    # The budget can never exceed what is actually free
+                    # when the worker checks it - and the worker checks
+                    # AFTER creating its own CUDA context (~0.5-1.3 GiB),
+                    # so cap at "free now minus a context allowance".
+                    # Without the cap, small reserves derive a budget the
+                    # worker's free-memory check must reject. reserve=0
+                    # therefore means "use everything that is free now,
+                    # minus the worker's own context".
+                    budget = (
+                        min(
+                            total_mib - reserve_per_gpu[gpu_id],
+                            free_mib - 1024,
+                        )
+                        // counts[gpu_id]
+                    )
+                    if budget <= 0:
+                        raise ValueError(
+                            f"--rank-auto-reserve-mib "
+                            f"{reserve_per_gpu[gpu_id]} MiB leaves no "
+                            f"budget on GPU {gpu_id} "
+                            f"(NVML total {total_mib} MiB, "
+                            f"{counts[gpu_id]} rank(s))."
+                        )
+                    budgets.append(budget)
+            finally:
+                pynvml.nvmlShutdown()
+            self.rank_gpu_memory_mib = budgets
+            logger.info(
+                "--rank-tp-ratio auto: derived memory budgets %s MiB from "
+                "NVML totals (reserve per GPU: %s MiB).",
+                budgets,
+                {g: r for g, r in sorted(reserve_per_gpu.items())},
+            )
+        budgets = (
+            list(self.rank_gpu_memory_mib)
+            if isinstance(self.rank_gpu_memory_mib, list)
+            else [self.rank_gpu_memory_mib] * self.tensor_parallel_size
+        )
+        g = math.gcd(*budgets)
+        weights = [b // g for b in budgets]
+        if len(set(weights)) == 1:
+            logger.info(
+                "--rank-tp-ratio auto: budgets are uniform, using the "
+                "classic even split."
+            )
+            self.rank_tp_ratio = None
+            return
+        self.rank_tp_ratio = weights
+        if self.decode_context_parallel_size <= 1:
+            self.decode_context_parallel_size = self.tensor_parallel_size
+            logger.info(
+                "--rank-tp-ratio auto: enabling decode context parallelism "
+                "(dcp=%d) for free per-dimension partitioning.",
+                self.decode_context_parallel_size,
+            )
+        logger.info(
+            "--rank-tp-ratio auto: derived weights %s from memory budgets %s MiB.",
+            weights,
+            budgets,
+        )
+
+    def _validate_rank_gpu_config(self, current_platform, model_config=None) -> None:
         """
         Validate --rank-gpu-id and --rank-gpu-memory-mib consistency.
 
@@ -2561,6 +2722,16 @@ class EngineArgs:
         6. Physical impossibility: (rank_count on GPU) * MiB <= NVML total
         """
         from collections import Counter
+
+        # Autoconfig: derive missing budgets and/or weights BEFORE the
+        # mutual-exclusivity checks (auto may omit the memory list).
+        if self.rank_tp_ratio == "auto":
+            self._resolve_auto_rank_tp_ratio(model_config)
+        elif isinstance(self.rank_tp_ratio, str):
+            raise ValueError(
+                f"Invalid --rank-tp-ratio value {self.rank_tp_ratio!r}: "
+                "expected a comma-separated integer list or 'auto'."
+            )
 
         # Mutual exclusivity check
         if self.rank_gpu_id is None and self.rank_gpu_memory_mib is not None:
@@ -2590,6 +2761,28 @@ class EngineArgs:
                 )
             if any(r <= 0 for r in self.rank_tp_ratio):
                 raise ValueError("--rank-tp-ratio entries must be positive integers.")
+            if len(set(self.rank_tp_ratio)) == 1:
+                raise ValueError(
+                    "--rank-tp-ratio with identical entries is the even "
+                    "split - omit the flag instead."
+                )
+
+        # Uneven DCP checks (--rank-tp-ratio + decode context parallelism:
+        # kv heads fully replicated per rank, KV cache split along the
+        # token axis by the ratio vector)
+        if self.rank_tp_ratio is not None and self.decode_context_parallel_size > 1:
+            if self.decode_context_parallel_size != self.tensor_parallel_size:
+                raise ValueError(
+                    "Uneven DCP requires --decode-context-parallel-size == "
+                    f"--tensor-parallel-size, got "
+                    f"{self.decode_context_parallel_size} vs "
+                    f"{self.tensor_parallel_size}."
+                )
+            if self.prefill_context_parallel_size > 1:
+                raise ValueError(
+                    "Uneven DCP does not support prefill context "
+                    "parallelism (--prefill-context-parallel-size > 1)."
+                )
 
         # Per-rank MiB list checks
         if isinstance(self.rank_gpu_memory_mib, list):

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -476,7 +476,8 @@ class EngineArgs:
     numa_bind_cpus: list[str] | None = ParallelConfig.numa_bind_cpus
     device_ids: list[int | str] | None = None
     rank_gpu_id: list[int] | None = None
-    rank_gpu_memory_mib: int | None = None
+    rank_gpu_memory_mib: int | list[int] | None = None
+    rank_tp_ratio: list[int] | None = None
     tensor_parallel_size: int = ParallelConfig.tensor_parallel_size
     prefill_context_parallel_size: int = ParallelConfig.prefill_context_parallel_size
     decode_context_parallel_size: int = ParallelConfig.decode_context_parallel_size
@@ -1052,19 +1053,39 @@ class EngineArgs:
             "Requires --rank-gpu-memory-mib to be set. "
             "Mutually exclusive with --gpu-memory-utilization.",
         )
+
+        def _mib_scalar_or_list(value: str):
+            if "," in value:
+                return [int(v) for v in value.split(",")]
+            return int(value)
+
         parallel_group.add_argument(
             "--rank-gpu-memory-mib",
-            type=int,
+            type=_mib_scalar_or_list,
             default=None,
             help="Absolute memory budget in MiB per rank when using "
-            "--rank-gpu-id. This is a single scalar value (not a list) "
-            "that applies uniformly to every rank. "
-            "The value is converted to a per-GPU fraction at runtime based on "
-            "each physical GPU's NVML-reported total memory, so the same MiB "
-            "value represents a DIFFERENT fraction on different physical GPUs. "
+            "--rank-gpu-id. A single scalar applies uniformly to every rank "
+            "(even TP: all shards are structurally equal). With "
+            "--rank-tp-ratio a comma-separated per-rank list may be given "
+            "instead (e.g. 26000,17000,17000), since shards then differ in "
+            "size. Values are converted to per-GPU fractions at runtime via "
+            "each physical GPU's NVML-reported total memory. "
             "Required when --rank-gpu-id is set. "
             "Mutually exclusive with --gpu-memory-utilization "
             "(setting both is a hard error).",
+        )
+        parallel_group.add_argument(
+            "--rank-tp-ratio",
+            type=lambda s: [int(r) for r in s.split(",")],
+            default=None,
+            help="UNEVEN tensor parallelism: comma-separated positive integer "
+            "ratios, one per rank (length must equal tensor-parallel-size). "
+            "Example: 2,1,1 gives rank 0 half of every sharded dimension and "
+            "ranks 1/2 a quarter each - one large GPU plus two smaller ones, "
+            "one rank per GPU, no MPS/co-location required. Every sharded "
+            "dimension (attention heads, KV heads, GDN heads, hidden and "
+            "intermediate sizes) must be divisible by sum(ratios); vocab and "
+            "LM head stay evenly split. Requires --rank-gpu-id.",
         )
         parallel_group.add_argument(
             "--tensor-parallel-size", "-tp", **parallel_kwargs["tensor_parallel_size"]
@@ -2275,6 +2296,7 @@ class EngineArgs:
                 else self._resolve_device_ids()
             ),
             rank_gpu_memory_mib=self.rank_gpu_memory_mib,
+            rank_tp_ratio=self.rank_tp_ratio,
             enable_fault_tolerance=self.enable_fault_tolerance,
             fault_tolerance_config=self.fault_tolerance_config,
             numa_bind=self.numa_bind,
@@ -2546,6 +2568,9 @@ class EngineArgs:
         if self.rank_gpu_memory_mib is None and self.rank_gpu_id is not None:
             raise ValueError("--rank-gpu-id requires --rank-gpu-memory-mib to be set.")
 
+        if self.rank_tp_ratio is not None and self.rank_gpu_id is None:
+            raise ValueError("--rank-tp-ratio requires --rank-gpu-id to be set.")
+
         if self.rank_gpu_id is None:
             return
 
@@ -2554,6 +2579,39 @@ class EngineArgs:
             raise ValueError(
                 f"--rank-gpu-id length ({len(self.rank_gpu_id)}) must equal "
                 f"--tensor-parallel-size ({self.tensor_parallel_size})."
+            )
+
+        # Uneven-TP ratio checks
+        if self.rank_tp_ratio is not None:
+            if len(self.rank_tp_ratio) != self.tensor_parallel_size:
+                raise ValueError(
+                    f"--rank-tp-ratio length ({len(self.rank_tp_ratio)}) must "
+                    f"equal --tensor-parallel-size ({self.tensor_parallel_size})."
+                )
+            if any(r <= 0 for r in self.rank_tp_ratio):
+                raise ValueError("--rank-tp-ratio entries must be positive integers.")
+
+        # Per-rank MiB list checks
+        if isinstance(self.rank_gpu_memory_mib, list):
+            if self.rank_tp_ratio is None:
+                raise ValueError(
+                    "--rank-gpu-memory-mib as a list requires "
+                    "--rank-tp-ratio (with even TP all ranks are "
+                    "structurally equal - use a single scalar)."
+                )
+            if len(self.rank_gpu_memory_mib) != self.tensor_parallel_size:
+                raise ValueError(
+                    f"--rank-gpu-memory-mib list length "
+                    f"({len(self.rank_gpu_memory_mib)}) must equal "
+                    f"--tensor-parallel-size ({self.tensor_parallel_size})."
+                )
+            if any(m <= 0 for m in self.rank_gpu_memory_mib):
+                raise ValueError("--rank-gpu-memory-mib entries must be positive.")
+
+        if self.rank_tp_ratio is not None and self.enable_lora:
+            raise ValueError(
+                "--rank-tp-ratio is not compatible with LoRA "
+                "(LoRA layers assume evenly sized TP shards)."
             )
 
         # PP/DP/EP not supported
@@ -2613,14 +2671,24 @@ class EngineArgs:
                 nvml_total_bytes = pynvml.nvmlDeviceGetMemoryInfo(handle).total
                 nvml_total_mib = nvml_total_bytes // (1024 * 1024)
                 count_on_gpu = gpu_counts[gpu_id]
-                required_mib = count_on_gpu * self.rank_gpu_memory_mib
+                if isinstance(self.rank_gpu_memory_mib, list):
+                    required_mib = sum(
+                        mib
+                        for r, mib in enumerate(self.rank_gpu_memory_mib)
+                        if self.rank_gpu_id[r] == gpu_id
+                    )
+                    budget_desc = "per-rank budgets"
+                else:
+                    required_mib = count_on_gpu * self.rank_gpu_memory_mib
+                    budget_desc = (
+                        f"{count_on_gpu} ranks x {self.rank_gpu_memory_mib} MiB"
+                    )
 
                 if required_mib > nvml_total_mib:
                     raise ValueError(
                         f"Physical impossibility: torch.cuda:{gpu_id} "
                         f"(NVML:{nvml_idx}, {nvml_total_mib} MiB total) cannot fit "
-                        f"{count_on_gpu} ranks x {self.rank_gpu_memory_mib} MiB "
-                        f"= {required_mib} MiB requested. "
+                        f"{budget_desc} = {required_mib} MiB requested. "
                         f"Reduce --rank-gpu-memory-mib or use fewer ranks on this GPU."
                     )
         finally:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -475,6 +475,8 @@ class EngineArgs:
     numa_bind_nodes: list[int] | None = ParallelConfig.numa_bind_nodes
     numa_bind_cpus: list[str] | None = ParallelConfig.numa_bind_cpus
     device_ids: list[int | str] | None = None
+    rank_gpu_id: list[int] | None = None
+    rank_gpu_memory_mib: int | None = None
     tensor_parallel_size: int = ParallelConfig.tensor_parallel_size
     prefill_context_parallel_size: int = ParallelConfig.prefill_context_parallel_size
     decode_context_parallel_size: int = ParallelConfig.decode_context_parallel_size
@@ -1034,6 +1036,35 @@ class EngineArgs:
             "visibility for GPU-NIC affinity and DeepGEMM. "
             "Note: has no effect with Ray executors; use Ray "
             "placement groups for GPU selection instead.",
+        )
+        parallel_group.add_argument(
+            "--rank-gpu-id",
+            type=lambda s: [int(x) for x in (part.strip() for part in s.split(","))],
+            default=None,
+            help="Comma-separated GPU indices for each tensor parallel rank. "
+            "IMPORTANT: these are PyTorch device indices (the ordering behind "
+            "'cuda:N'), NOT nvidia-smi/NVML indices, which can enumerate "
+            "differently. "
+            "Duplicates mean multiple ranks share that GPU. "
+            "Length must equal tensor-parallel-size. "
+            "Example: --rank-gpu-id 0,1 (two GPUs, one rank each). "
+            "Example: --rank-gpu-id 0,0,1,2 (TP=4, first GPU shared by two ranks). "
+            "Requires --rank-gpu-memory-mib to be set. "
+            "Mutually exclusive with --gpu-memory-utilization.",
+        )
+        parallel_group.add_argument(
+            "--rank-gpu-memory-mib",
+            type=int,
+            default=None,
+            help="Absolute memory budget in MiB per rank when using "
+            "--rank-gpu-id. This is a single scalar value (not a list) "
+            "that applies uniformly to every rank. "
+            "The value is converted to a per-GPU fraction at runtime based on "
+            "each physical GPU's NVML-reported total memory, so the same MiB "
+            "value represents a DIFFERENT fraction on different physical GPUs. "
+            "Required when --rank-gpu-id is set. "
+            "Mutually exclusive with --gpu-memory-utilization "
+            "(setting both is a hard error).",
         )
         parallel_group.add_argument(
             "--tensor-parallel-size", "-tp", **parallel_kwargs["tensor_parallel_size"]
@@ -2188,6 +2219,9 @@ class EngineArgs:
             model_config.skip_tokenizer_init = True
             logger.info("Skipping tokenizer initialization for tokens-only mode.")
 
+        # Validate --rank-gpu-id and --rank-gpu-memory-mib
+        self._validate_rank_gpu_config(current_platform)
+
         parallel_config = ParallelConfig(
             pipeline_parallel_size=self.pipeline_parallel_size,
             tensor_parallel_size=self.tensor_parallel_size,
@@ -2233,7 +2267,14 @@ class EngineArgs:
             cp_kv_cache_interleave_size=self.cp_kv_cache_interleave_size,
             _api_process_count=self._api_process_count,
             _api_process_rank=self._api_process_rank,
-            assigned_physical_gpu_ids=self._resolve_device_ids(),
+            # When --rank-gpu-id is set, use it as the physical GPU mapping
+            # Otherwise use --device-ids if provided
+            assigned_physical_gpu_ids=(
+                self.rank_gpu_id
+                if self.rank_gpu_id is not None
+                else self._resolve_device_ids()
+            ),
+            rank_gpu_memory_mib=self.rank_gpu_memory_mib,
             enable_fault_tolerance=self.enable_fault_tolerance,
             fault_tolerance_config=self.fault_tolerance_config,
             numa_bind=self.numa_bind,
@@ -2484,6 +2525,106 @@ class EngineArgs:
         )
 
         return config
+
+    def _validate_rank_gpu_config(self, current_platform) -> None:
+        """
+        Validate --rank-gpu-id and --rank-gpu-memory-mib consistency.
+
+        This validates:
+        1. Mutual exclusivity: both or neither must be set
+        2. Length vs tensor_parallel_size
+        3. PP/DP/EP not supported with --rank-gpu-id
+        4. --gpu-memory-utilization not allowed with --rank-gpu-id
+        5. Physical GPU existence via NVML
+        6. Physical impossibility: (rank_count on GPU) * MiB <= NVML total
+        """
+        from collections import Counter
+
+        # Mutual exclusivity check
+        if self.rank_gpu_id is None and self.rank_gpu_memory_mib is not None:
+            raise ValueError("--rank-gpu-memory-mib requires --rank-gpu-id to be set.")
+        if self.rank_gpu_memory_mib is None and self.rank_gpu_id is not None:
+            raise ValueError("--rank-gpu-id requires --rank-gpu-memory-mib to be set.")
+
+        if self.rank_gpu_id is None:
+            return
+
+        # Length vs tensor_parallel_size
+        if len(self.rank_gpu_id) != self.tensor_parallel_size:
+            raise ValueError(
+                f"--rank-gpu-id length ({len(self.rank_gpu_id)}) must equal "
+                f"--tensor-parallel-size ({self.tensor_parallel_size})."
+            )
+
+        # PP/DP/EP not supported
+        if self.pipeline_parallel_size > 1:
+            raise ValueError(
+                f"--rank-gpu-id is not compatible with pipeline-parallel-size > 1 "
+                f"(current: {self.pipeline_parallel_size}). "
+                "Only pure Tensor Parallelism is supported."
+            )
+        if self.data_parallel_size > 1:
+            raise ValueError(
+                f"--rank-gpu-id is not compatible with data-parallel-size > 1 "
+                f"(current: {self.data_parallel_size}). "
+                "Only pure Tensor Parallelism is supported."
+            )
+        if self.enable_expert_parallel:
+            raise ValueError("--rank-gpu-id is not compatible with expert parallelism.")
+
+        # --gpu-memory-utilization must not be set
+        if self.gpu_memory_utilization != CacheConfig.gpu_memory_utilization:
+            raise ValueError(
+                "--gpu-memory-utilization cannot be set when --rank-gpu-id is used. "
+                "Use --rank-gpu-memory-mib instead to specify absolute MiB budget."
+            )
+
+        # Get torch -> NVML mapping for validation
+        from vllm.platforms.cuda import CudaPlatform
+        from vllm.utils.import_utils import import_pynvml
+
+        torch_to_nvml = CudaPlatform.get_torch_to_nvml_mapping()
+        pynvml = import_pynvml()
+        pynvml.nvmlInit()
+
+        try:
+            # NVML-based physical existence check and sum validation
+            device_count = current_platform.device_count()
+            gpu_counts = Counter(self.rank_gpu_id)
+
+            for gpu_id in self.rank_gpu_id:
+                if gpu_id < 0 or gpu_id >= device_count:
+                    raise ValueError(
+                        f"Physical GPU ID {gpu_id} is out of range. "
+                        f"Available GPUs: 0-{device_count - 1}"
+                    )
+
+                # Map torch.cuda index to NVML physical index for memory query
+                if gpu_id not in torch_to_nvml:
+                    raise ValueError(
+                        f"Could not map torch.cuda:{gpu_id} to a physical GPU. "
+                        f"Available torch.cuda indices: 0-{device_count - 1}"
+                    )
+                nvml_idx = torch_to_nvml[gpu_id]
+
+                # Physical impossibility check using NVML directly
+                # (get_device_total_memory() uses torch.cuda props, not NVML)
+                handle = pynvml.nvmlDeviceGetHandleByIndex(nvml_idx)
+                nvml_total_bytes = pynvml.nvmlDeviceGetMemoryInfo(handle).total
+                nvml_total_mib = nvml_total_bytes // (1024 * 1024)
+                count_on_gpu = gpu_counts[gpu_id]
+                required_mib = count_on_gpu * self.rank_gpu_memory_mib
+
+                if required_mib > nvml_total_mib:
+                    raise ValueError(
+                        f"Physical impossibility: torch.cuda:{gpu_id} "
+                        f"(NVML:{nvml_idx}, {nvml_total_mib} MiB total) cannot fit "
+                        f"{count_on_gpu} ranks x {self.rank_gpu_memory_mib} MiB "
+                        f"= {required_mib} MiB requested. "
+                        f"Reduce --rank-gpu-memory-mib or use fewer ranks on this GPU."
+                    )
+        finally:
+            pynvml.nvmlShutdown()
 
     def _check_feature_supported(self):
         """Raise an error if the feature is not supported."""

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -161,6 +161,7 @@ if TYPE_CHECKING:
     VLLM_MLA_DISABLE: bool = False
     VLLM_RAY_PER_WORKER_GPUS: float = 1.0
     VLLM_RAY_BUNDLE_INDICES: str = ""
+    VLLM_UNEVEN_TOKEN_VECTOR: str = ""
     VLLM_CUDART_SO_PATH: str | None = None
     VLLM_DP_RANK: int = 0
     VLLM_DP_RANK_LOCAL: int = -1
@@ -1383,6 +1384,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # which indices are used for the Ray bundle, for every worker.
     # Format: comma-separated list of integers, e.g. "0,1,2,3"
     "VLLM_RAY_BUNDLE_INDICES": lambda: os.getenv("VLLM_RAY_BUNDLE_INDICES", ""),
+    # Override for the uneven decode-context-parallel token split, one
+    # positive integer per rank. Only read when --rank-tp-ratio is set and
+    # decode_context_parallel_size > 1; must be exported for every worker
+    # process. Format: comma-separated list of integers, e.g. "5,3,3".
+    "VLLM_UNEVEN_TOKEN_VECTOR": lambda: os.getenv("VLLM_UNEVEN_TOKEN_VECTOR", ""),
     # In some system, find_loaded_library() may not work. So we allow users to
     # specify the path through environment variable VLLM_CUDART_SO_PATH.
     "VLLM_CUDART_SO_PATH": lambda: os.getenv("VLLM_CUDART_SO_PATH", None),

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -327,7 +327,15 @@ class Attention(nn.Module, AttentionLayerBase):
         self.calculate_kv_scales = calculate_kv_scales
         if num_kv_heads is None:
             num_kv_heads = num_heads
-        assert num_heads % num_kv_heads == 0, (
+        from vllm.distributed.utils import uneven_dcp_active
+
+        # Uneven DCP: num_heads is this rank's ratio share of the q heads
+        # while num_kv_heads is the FULL (replicated) count, so the local
+        # quotient need not divide. All attention kernels then run on the
+        # DCP-gathered full q head set (context and suffix), where the
+        # total quotient is exact; the local share only sizes this rank's
+        # output slice.
+        assert num_heads % num_kv_heads == 0 or uneven_dcp_active(), (
             f"num_heads ({num_heads}) is not divisible by num_kv_heads ({num_kv_heads})"
         )
         self.quant_config = quant_config

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -24,6 +24,7 @@ from vllm.distributed.utils import (
     get_tp_partition_ratios,
     tp_partition_size,
     tp_partition_sizes,
+    uneven_dcp_active,
 )
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import PluggableLayer
@@ -78,19 +79,29 @@ def register_weight_loader_v2_supported_method(cls):
 
 
 def tp_loaded_shard_start(
-    loaded_full: int, tp_size: int, rank: int, shard_size: int
+    loaded_full: int,
+    tp_size: int,
+    rank: int,
+    shard_size: int,
+    units: int | None = None,
 ) -> int:
     """Start offset when narrowing a full checkpoint dimension to this
     rank's shard. Even TP: rank * shard_size (classic). Uneven TP
-    (--rank-tp-ratio): prefix sum of the per-rank partition sizes; the
-    given shard_size must match this rank's partition (consistency
-    check against mis-sized parameters)."""
+    (--rank-tp-ratio): prefix sum of the per-rank partition sizes (with
+    `units` = the dimension family's master unit count under v4 free
+    partitioning); the given shard_size must match this rank's partition
+    (consistency check against mis-sized parameters)."""
     if not get_tp_partition_ratios():
         return rank * shard_size
-    sizes = tp_partition_sizes(loaded_full, tp_size)
+    if shard_size == loaded_full:
+        # Fully replicated component (kv heads under uneven DCP): every
+        # rank loads the whole checkpoint dimension.
+        return 0
+    sizes = tp_partition_sizes(loaded_full, tp_size, units)
     assert sizes[rank] == shard_size, (
         f"uneven-TP shard mismatch: expected {sizes[rank]} for rank "
-        f"{rank} of dim {loaded_full}, parameter has {shard_size}"
+        f"{rank} of dim {loaded_full} (units={units}), parameter has "
+        f"{shard_size}"
     )
     return sum(sizes[:rank])
 
@@ -485,6 +496,7 @@ class ColumnParallelLinear(LinearBase):
         disable_tp: bool = False,
         tp_rank: int | None = None,
         tp_size: int | None = None,
+        tp_units: int | None = None,
     ):
         # Divide the weight matrix along the last dimension.
         if disable_tp:
@@ -499,16 +511,31 @@ class ColumnParallelLinear(LinearBase):
                 else get_tensor_model_parallel_world_size()
             )
         self.input_size_per_partition = input_size
-        self.output_size_per_partition = tp_partition_size(
-            output_size, self.tp_size, self.tp_rank
-        )
-        self.output_partition_sizes = [self.output_size_per_partition]
-        # If QKV or MergedColumn, use output size of each partition.
-        if hasattr(self, "output_sizes"):
-            self.output_partition_sizes = [
-                tp_partition_size(output_size, self.tp_size, self.tp_rank)
-                for output_size in self.output_sizes
-            ]
+        # v4 free partitioning: master unit count of this layer's output
+        # dimension family (e.g. attention heads, GDN k-heads,
+        # intermediate/quant_group). None keeps the v1 divisibility rule.
+        if not hasattr(self, "tp_units"):
+            self.tp_units = tp_units
+        custom_partition_sizes = getattr(self, "custom_output_partition_sizes", None)
+        if custom_partition_sizes is not None:
+            # Subclass supplied explicit per-rank partition sizes (QKV with
+            # replicated kv heads under uneven DCP): the per-rank output is
+            # not a plain ratio split of the fused total.
+            self.output_partition_sizes = list(custom_partition_sizes)
+            self.output_size_per_partition = sum(custom_partition_sizes)
+        else:
+            self.output_size_per_partition = tp_partition_size(
+                output_size, self.tp_size, self.tp_rank, self.tp_units
+            )
+            self.output_partition_sizes = [self.output_size_per_partition]
+            # If QKV or MergedColumn, use output size of each partition.
+            if hasattr(self, "output_sizes"):
+                self.output_partition_sizes = [
+                    tp_partition_size(
+                        output_size, self.tp_size, self.tp_rank, self.tp_units
+                    )
+                    for output_size in self.output_sizes
+                ]
 
         super().__init__(
             input_size,
@@ -523,7 +550,6 @@ class ColumnParallelLinear(LinearBase):
             tp_rank=self.tp_rank,
             tp_size=self.tp_size,
         )
-
         self._maybe_allow_fp8_block_shape_mismatch()
         self.gather_output = gather_output
 
@@ -540,6 +566,11 @@ class ColumnParallelLinear(LinearBase):
                 else self.weight_loader
             ),
         )
+        if self.tp_units is not None:
+            # Expose the family unit count to the v2 weight loaders -
+            # AFTER create_weights, which registers the parameters.
+            for p in self.parameters():
+                set_weight_attrs(p, {"tp_units": self.tp_units})
 
         if bias:
             self.bias = Parameter(
@@ -596,7 +627,11 @@ class ColumnParallelLinear(LinearBase):
         if output_dim is not None and not is_sharded_weight:
             shard_size = param_data.shape[output_dim]
             start_idx = tp_loaded_shard_start(
-                loaded_weight.shape[output_dim], self.tp_size, self.tp_rank, shard_size
+                loaded_weight.shape[output_dim],
+                self.tp_size,
+                self.tp_rank,
+                shard_size,
+                self.tp_units,
             )
             loaded_weight = loaded_weight.narrow(output_dim, start_idx, shard_size)
 
@@ -725,14 +760,17 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         *,
         return_bias: bool = True,
         disable_tp: bool = False,
+        tp_units: int | None = None,
     ):
         self.output_sizes = output_sizes
         self.tp_size = get_tensor_model_parallel_world_size() if not disable_tp else 1
         self.tp_rank = get_tensor_model_parallel_rank() if not disable_tp else 0
+        self.tp_units = tp_units
 
         for output_size in output_sizes:
-            # Validates divisibility (even: % tp == 0, uneven: % sum(ratios))
-            tp_partition_sizes(output_size, self.tp_size)
+            # Validates divisibility (even: % tp == 0, uneven: % sum(ratios)
+            # or the family unit count under v4 free partitioning)
+            tp_partition_sizes(output_size, self.tp_size, tp_units)
         super().__init__(
             input_size=input_size,
             output_size=sum(output_sizes),
@@ -859,11 +897,14 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         assert loaded_shard_id < len(self.output_sizes)
         if output_dim is not None:
             shard_offset = sum(
-                tp_partition_size(sz, self.tp_size, self.tp_rank)
+                tp_partition_size(sz, self.tp_size, self.tp_rank, self.tp_units)
                 for sz in self.output_sizes[:loaded_shard_id]
             )
             shard_size = tp_partition_size(
-                self.output_sizes[loaded_shard_id], self.tp_size, self.tp_rank
+                self.output_sizes[loaded_shard_id],
+                self.tp_size,
+                self.tp_rank,
+                self.tp_units,
             )
 
             if isinstance(param, BlockQuantScaleParameter):
@@ -901,7 +942,11 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
                 )
             param_data = param_data.narrow(output_dim, shard_offset, shard_size)
             start_idx = tp_loaded_shard_start(
-                loaded_weight.shape[output_dim], self.tp_size, self.tp_rank, shard_size
+                loaded_weight.shape[output_dim],
+                self.tp_size,
+                self.tp_rank,
+                shard_size,
+                self.tp_units,
             )
             if not is_sharded_weight:
                 loaded_weight = loaded_weight.narrow(output_dim, start_idx, shard_size)
@@ -1011,11 +1056,14 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         assert loaded_shard_id < len(self.output_sizes)
 
         shard_offset = sum(
-            tp_partition_size(sz, self.tp_size, self.tp_rank)
+            tp_partition_size(sz, self.tp_size, self.tp_rank, self.tp_units)
             for sz in self.output_sizes[:loaded_shard_id]
         )
         shard_size = tp_partition_size(
-            self.output_sizes[loaded_shard_id], self.tp_size, self.tp_rank
+            self.output_sizes[loaded_shard_id],
+            self.tp_size,
+            self.tp_rank,
+            self.tp_units,
         )
 
         if isinstance(param, BlockQuantScaleParameter):
@@ -1100,6 +1148,7 @@ class QKVParallelLinear(ColumnParallelLinear):
         return_bias: bool = True,
         disable_tp: bool = False,
         v_head_size: int | None = None,
+        tp_units: int | None = None,
     ):
         self.hidden_size = hidden_size
         self.head_size = head_size
@@ -1111,7 +1160,60 @@ class QKVParallelLinear(ColumnParallelLinear):
         # Divide the weight matrix along the last dimension.
         tp_size = get_tensor_model_parallel_world_size() if not disable_tp else 1
         tp_rank = get_tensor_model_parallel_rank() if not disable_tp else 0
-        if get_tp_partition_ratios():
+        # v4 free partitioning: master q-head unit count (WITHOUT any
+        # fused gate doubling). Kept on a separate field - the base class
+        # must not partition the (differently ruled) kv columns by it.
+        self.tp_head_units = tp_units
+        self.tp_units = None
+        if (
+            get_tp_partition_ratios()
+            and not disable_tp
+            and uneven_dcp_active()
+            and self.total_num_kv_heads < self.total_num_heads
+        ):
+            # Uneven DCP: the KV cache is split along the token axis, so
+            # every rank computes and stores ALL kv heads (fully
+            # replicated k/v projections); only q heads are
+            # ratio-partitioned. Restricted to GQA layers (kv < q): MHA
+            # QKV layers (e.g. vision towers) have no paged KV cache and
+            # keep the plain ratio split.
+            self.num_heads = tp_partition_size(
+                self.total_num_heads, tp_size, tp_rank, self.tp_head_units
+            )
+            self.num_kv_heads = self.total_num_kv_heads
+            self.num_kv_head_replicas = 1
+            # Per-rank partition sizes are not a ratio split of the fused
+            # total (kv is full-width); hand them to the base class
+            # explicitly.
+            self.custom_output_partition_sizes = [
+                self.num_heads * self.head_size,
+                self.total_num_kv_heads * self.head_size,
+                self.total_num_kv_heads * self.v_head_size,
+            ]
+        elif (
+            get_tp_partition_ratios()
+            and self.tp_head_units is not None
+            and self.total_num_kv_heads == self.total_num_heads
+        ):
+            # MHA under free partitioning (v4): q and kv have identical
+            # unit counts, so both shards stay aligned per rank.
+            self.num_heads = tp_partition_size(
+                self.total_num_heads, tp_size, tp_rank, self.tp_head_units
+            )
+            self.num_kv_heads = tp_partition_size(
+                self.total_num_kv_heads, tp_size, tp_rank, self.tp_head_units
+            )
+            self.num_kv_head_replicas = 1
+            self.custom_output_partition_sizes = [
+                self.num_heads * self.head_size,
+                self.num_kv_heads * self.head_size,
+                self.num_kv_heads * self.v_head_size,
+            ]
+        elif get_tp_partition_ratios():
+            # Uneven TP without DCP: kv is split by the divisibility rule,
+            # not by unit rounding - head units must not be applied to
+            # the fused loader offsets (e.g. the kv component).
+            self.tp_head_units = None
             # Uneven TP: every rank must own at least one whole kv head;
             # the replicated-kv path is not supported with ratios.
             if self.total_num_kv_heads % sum(get_tp_partition_ratios()) != 0:
@@ -1119,7 +1221,8 @@ class QKVParallelLinear(ColumnParallelLinear):
                     f"--rank-tp-ratio: total_num_kv_heads "
                     f"({self.total_num_kv_heads}) must be divisible by "
                     f"sum(ratios) ({sum(get_tp_partition_ratios())}); "
-                    "kv-head replication is not supported with uneven TP."
+                    "kv-head replication is not supported with uneven TP "
+                    "(use uneven DCP for tp < num_kv_heads)."
                 )
             self.num_heads = tp_partition_size(self.total_num_heads, tp_size, tp_rank)
             self.num_kv_heads = tp_partition_size(
@@ -1127,10 +1230,12 @@ class QKVParallelLinear(ColumnParallelLinear):
             )
             self.num_kv_head_replicas = 1
         elif tp_size >= self.total_num_kv_heads:
+            self.tp_head_units = None
             self.num_heads = divide(self.total_num_heads, tp_size)
             self.num_kv_heads = 1
             self.num_kv_head_replicas = divide(tp_size, self.total_num_kv_heads)
         else:
+            self.tp_head_units = None
             self.num_heads = divide(self.total_num_heads, tp_size)
             self.num_kv_heads = divide(self.total_num_kv_heads, tp_size)
             self.num_kv_head_replicas = 1
@@ -1174,6 +1279,11 @@ class QKVParallelLinear(ColumnParallelLinear):
             return_bias=return_bias,
             disable_tp=disable_tp,
         )
+        if self.tp_head_units is not None:
+            # v2 loaders compute the q-component prefix offset with this;
+            # replicated kv components short-circuit to offset 0 first.
+            for p in self.parameters():
+                set_weight_attrs(p, {"tp_units": self.tp_head_units})
 
     def validate_shard_id(self, shard_id: Any) -> TypeIs[str | None]:
         if shard_id in {"q", "k", "v"} or shard_id is None:
@@ -1449,13 +1559,19 @@ class QKVParallelLinear(ColumnParallelLinear):
 
             param_data = param_data.narrow(output_dim, shard_offset, shard_size)
             if get_tp_partition_ratios():
-                # Uneven TP (no kv replication): prefix-sum offset into the
-                # full q/k/v component of the checkpoint.
+                # Uneven TP: prefix-sum offset into the full q/k/v
+                # component of the checkpoint (q uses the head units;
+                # replicated kv resolves to offset 0 via the
+                # shard_size == full early-out).
+                # q and (MHA-partitioned) k/v share the head units; a
+                # replicated kv component short-circuits to offset 0 via
+                # the shard_size == full early-out before units apply.
                 start_idx = tp_loaded_shard_start(
                     loaded_weight.shape[output_dim],
                     self.tp_size,
                     self.tp_rank,
                     shard_size,
+                    self.tp_head_units,
                 )
             else:
                 if loaded_shard_id == "q":
@@ -1744,12 +1860,16 @@ class RowParallelLinear(LinearBase):
         *,
         return_bias: bool = True,
         disable_tp: bool = False,
+        tp_units: int | None = None,
     ):
         # Divide the weight matrix along the first dimension.
         self.tp_rank = get_tensor_model_parallel_rank() if not disable_tp else 0
         self.tp_size = get_tensor_model_parallel_world_size() if not disable_tp else 1
+        # Family unit count of the INPUT dimension (matches the paired
+        # column-parallel layer's tp_units under v4 free partitioning).
+        self.tp_units = tp_units
         self.input_size_per_partition = tp_partition_size(
-            input_size, self.tp_size, self.tp_rank
+            input_size, self.tp_size, self.tp_rank, tp_units
         )
         self.output_size_per_partition = output_size
         self.output_partition_sizes = [output_size]
@@ -1765,7 +1885,6 @@ class RowParallelLinear(LinearBase):
             return_bias=return_bias,
             disable_tp=disable_tp,
         )
-
         self.input_is_parallel = input_is_parallel
         self.reduce_results = reduce_results
 
@@ -1782,6 +1901,10 @@ class RowParallelLinear(LinearBase):
                 else self.weight_loader
             ),
         )
+        if tp_units is not None:
+            # AFTER create_weights, which registers the parameters.
+            for p in self.parameters():
+                set_weight_attrs(p, {"tp_units": tp_units})
         if not reduce_results and (bias and not skip_bias_add):
             raise ValueError(
                 "When not reduce the results, adding bias to the "
@@ -1813,7 +1936,11 @@ class RowParallelLinear(LinearBase):
         if input_dim is not None and not is_sharded_weight:
             shard_size = param_data.shape[input_dim]
             start_idx = tp_loaded_shard_start(
-                loaded_weight.shape[input_dim], self.tp_size, self.tp_rank, shard_size
+                loaded_weight.shape[input_dim],
+                self.tp_size,
+                self.tp_rank,
+                shard_size,
+                self.tp_units,
             )
             loaded_weight = loaded_weight.narrow(input_dim, start_idx, shard_size)
 

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -20,6 +20,11 @@ from vllm.distributed import (
     tensor_model_parallel_all_gather,
     tensor_model_parallel_all_reduce,
 )
+from vllm.distributed.utils import (
+    get_tp_partition_ratios,
+    tp_partition_size,
+    tp_partition_sizes,
+)
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import PluggableLayer
 from vllm.model_executor.layers.batch_invariant import (
@@ -70,6 +75,24 @@ def register_weight_loader_v2_supported_method(cls):
     """Decorator to register a LinearMethod as supporting weight_loader_v2."""
     WEIGHT_LOADER_V2_SUPPORTED.append(cls.__name__)
     return cls
+
+
+def tp_loaded_shard_start(
+    loaded_full: int, tp_size: int, rank: int, shard_size: int
+) -> int:
+    """Start offset when narrowing a full checkpoint dimension to this
+    rank's shard. Even TP: rank * shard_size (classic). Uneven TP
+    (--rank-tp-ratio): prefix sum of the per-rank partition sizes; the
+    given shard_size must match this rank's partition (consistency
+    check against mis-sized parameters)."""
+    if not get_tp_partition_ratios():
+        return rank * shard_size
+    sizes = tp_partition_sizes(loaded_full, tp_size)
+    assert sizes[rank] == shard_size, (
+        f"uneven-TP shard mismatch: expected {sizes[rank]} for rank "
+        f"{rank} of dim {loaded_full}, parameter has {shard_size}"
+    )
+    return sum(sizes[:rank])
 
 
 def adjust_marlin_shard(
@@ -476,12 +499,15 @@ class ColumnParallelLinear(LinearBase):
                 else get_tensor_model_parallel_world_size()
             )
         self.input_size_per_partition = input_size
-        self.output_size_per_partition = divide(output_size, self.tp_size)
+        self.output_size_per_partition = tp_partition_size(
+            output_size, self.tp_size, self.tp_rank
+        )
         self.output_partition_sizes = [self.output_size_per_partition]
         # If QKV or MergedColumn, use output size of each partition.
         if hasattr(self, "output_sizes"):
             self.output_partition_sizes = [
-                divide(output_size, self.tp_size) for output_size in self.output_sizes
+                tp_partition_size(output_size, self.tp_size, self.tp_rank)
+                for output_size in self.output_sizes
             ]
 
         super().__init__(
@@ -569,7 +595,9 @@ class ColumnParallelLinear(LinearBase):
         param_data = param.data
         if output_dim is not None and not is_sharded_weight:
             shard_size = param_data.shape[output_dim]
-            start_idx = self.tp_rank * shard_size
+            start_idx = tp_loaded_shard_start(
+                loaded_weight.shape[output_dim], self.tp_size, self.tp_rank, shard_size
+            )
             loaded_weight = loaded_weight.narrow(output_dim, start_idx, shard_size)
 
         # Special case for loading scales off disk, which often do not
@@ -702,7 +730,9 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         self.tp_size = get_tensor_model_parallel_world_size() if not disable_tp else 1
         self.tp_rank = get_tensor_model_parallel_rank() if not disable_tp else 0
 
-        assert all(output_size % self.tp_size == 0 for output_size in output_sizes)
+        for output_size in output_sizes:
+            # Validates divisibility (even: % tp == 0, uneven: % sum(ratios))
+            tp_partition_sizes(output_size, self.tp_size)
         super().__init__(
             input_size=input_size,
             output_size=sum(output_sizes),
@@ -828,10 +858,13 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
 
         assert loaded_shard_id < len(self.output_sizes)
         if output_dim is not None:
-            shard_offset = sum(self.output_sizes[:loaded_shard_id])
-            shard_size = self.output_sizes[loaded_shard_id]
-            shard_offset //= self.tp_size
-            shard_size //= self.tp_size
+            shard_offset = sum(
+                tp_partition_size(sz, self.tp_size, self.tp_rank)
+                for sz in self.output_sizes[:loaded_shard_id]
+            )
+            shard_size = tp_partition_size(
+                self.output_sizes[loaded_shard_id], self.tp_size, self.tp_rank
+            )
 
             if isinstance(param, BlockQuantScaleParameter):
                 weight_block_size = getattr(self, "weight_block_size", None)
@@ -867,7 +900,9 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
                     param, orig_offsets, str(loaded_shard_id)
                 )
             param_data = param_data.narrow(output_dim, shard_offset, shard_size)
-            start_idx = self.tp_rank * shard_size
+            start_idx = tp_loaded_shard_start(
+                loaded_weight.shape[output_dim], self.tp_size, self.tp_rank, shard_size
+            )
             if not is_sharded_weight:
                 loaded_weight = loaded_weight.narrow(output_dim, start_idx, shard_size)
         # Special case for per-tensor scales in fused case.
@@ -975,10 +1010,13 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
 
         assert loaded_shard_id < len(self.output_sizes)
 
-        shard_offset = sum(self.output_sizes[:loaded_shard_id])
-        shard_size = self.output_sizes[loaded_shard_id]
-        shard_offset //= self.tp_size
-        shard_size //= self.tp_size
+        shard_offset = sum(
+            tp_partition_size(sz, self.tp_size, self.tp_rank)
+            for sz in self.output_sizes[:loaded_shard_id]
+        )
+        shard_size = tp_partition_size(
+            self.output_sizes[loaded_shard_id], self.tp_size, self.tp_rank
+        )
 
         if isinstance(param, BlockQuantScaleParameter):
             weight_block_size = getattr(self, "weight_block_size", None)
@@ -1072,20 +1110,57 @@ class QKVParallelLinear(ColumnParallelLinear):
         self.total_num_kv_heads = total_num_kv_heads
         # Divide the weight matrix along the last dimension.
         tp_size = get_tensor_model_parallel_world_size() if not disable_tp else 1
-        self.num_heads = divide(self.total_num_heads, tp_size)
-        if tp_size >= self.total_num_kv_heads:
+        tp_rank = get_tensor_model_parallel_rank() if not disable_tp else 0
+        if get_tp_partition_ratios():
+            # Uneven TP: every rank must own at least one whole kv head;
+            # the replicated-kv path is not supported with ratios.
+            if self.total_num_kv_heads % sum(get_tp_partition_ratios()) != 0:
+                raise ValueError(
+                    f"--rank-tp-ratio: total_num_kv_heads "
+                    f"({self.total_num_kv_heads}) must be divisible by "
+                    f"sum(ratios) ({sum(get_tp_partition_ratios())}); "
+                    "kv-head replication is not supported with uneven TP."
+                )
+            self.num_heads = tp_partition_size(self.total_num_heads, tp_size, tp_rank)
+            self.num_kv_heads = tp_partition_size(
+                self.total_num_kv_heads, tp_size, tp_rank
+            )
+            self.num_kv_head_replicas = 1
+        elif tp_size >= self.total_num_kv_heads:
+            self.num_heads = divide(self.total_num_heads, tp_size)
             self.num_kv_heads = 1
             self.num_kv_head_replicas = divide(tp_size, self.total_num_kv_heads)
         else:
+            self.num_heads = divide(self.total_num_heads, tp_size)
             self.num_kv_heads = divide(self.total_num_kv_heads, tp_size)
             self.num_kv_head_replicas = 1
         input_size = self.hidden_size
-        self.output_sizes = [
-            self.num_heads * self.head_size * tp_size,  # q_proj
-            self.num_kv_heads * self.head_size * tp_size,  # k_proj
-            self.num_kv_heads * self.v_head_size * tp_size,  # v_proj
-        ]
-        output_size = sum(self.output_sizes)
+        # Pre-partition totals; the base class partitions them per rank.
+        # With kv-head replication the "total" seen by the base class is
+        # num_kv_heads(=1) * tp_size (each rank holds a full replica), so
+        # keep the classic per-rank*tp formula in that branch.
+        if self.num_kv_head_replicas > 1:
+            output_size = (
+                self.num_heads * self.head_size
+                + self.num_kv_heads * self.head_size
+                + self.num_kv_heads * self.v_head_size
+            ) * tp_size
+            self.output_sizes = [
+                self.num_heads * self.head_size * tp_size,  # q_proj
+                self.num_kv_heads * self.head_size * tp_size,  # k_proj
+                self.num_kv_heads * self.v_head_size * tp_size,  # v_proj
+            ]
+        else:
+            output_size = (
+                self.total_num_heads * self.head_size
+                + self.total_num_kv_heads * self.head_size
+                + self.total_num_kv_heads * self.v_head_size
+            )
+            self.output_sizes = [
+                self.total_num_heads * self.head_size,  # q_proj
+                self.total_num_kv_heads * self.head_size,  # k_proj
+                self.total_num_kv_heads * self.v_head_size,  # v_proj
+            ]
 
         super().__init__(
             input_size=input_size,
@@ -1373,11 +1448,21 @@ class QKVParallelLinear(ColumnParallelLinear):
                 )
 
             param_data = param_data.narrow(output_dim, shard_offset, shard_size)
-            if loaded_shard_id == "q":
-                shard_rank = self.tp_rank
+            if get_tp_partition_ratios():
+                # Uneven TP (no kv replication): prefix-sum offset into the
+                # full q/k/v component of the checkpoint.
+                start_idx = tp_loaded_shard_start(
+                    loaded_weight.shape[output_dim],
+                    self.tp_size,
+                    self.tp_rank,
+                    shard_size,
+                )
             else:
-                shard_rank = self.tp_rank // self.num_kv_head_replicas
-            start_idx = shard_rank * shard_size
+                if loaded_shard_id == "q":
+                    shard_rank = self.tp_rank
+                else:
+                    shard_rank = self.tp_rank // self.num_kv_head_replicas
+                start_idx = shard_rank * shard_size
 
             if not is_sharded_weight:
                 loaded_weight = loaded_weight.narrow(output_dim, start_idx, shard_size)
@@ -1663,7 +1748,9 @@ class RowParallelLinear(LinearBase):
         # Divide the weight matrix along the first dimension.
         self.tp_rank = get_tensor_model_parallel_rank() if not disable_tp else 0
         self.tp_size = get_tensor_model_parallel_world_size() if not disable_tp else 1
-        self.input_size_per_partition = divide(input_size, self.tp_size)
+        self.input_size_per_partition = tp_partition_size(
+            input_size, self.tp_size, self.tp_rank
+        )
         self.output_size_per_partition = output_size
         self.output_partition_sizes = [output_size]
 
@@ -1725,7 +1812,9 @@ class RowParallelLinear(LinearBase):
         param_data = param.data
         if input_dim is not None and not is_sharded_weight:
             shard_size = param_data.shape[input_dim]
-            start_idx = self.tp_rank * shard_size
+            start_idx = tp_loaded_shard_start(
+                loaded_weight.shape[input_dim], self.tp_size, self.tp_rank, shard_size
+            )
             loaded_weight = loaded_weight.narrow(input_dim, start_idx, shard_size)
 
         # Special case for loading scales off disk, which often do not

--- a/vllm/model_executor/layers/mamba/abstract.py
+++ b/vllm/model_executor/layers/mamba/abstract.py
@@ -64,6 +64,27 @@ class MambaBase(AttentionLayerBase):
         mamba_block_size = vllm_config.cache_config.mamba_block_size
         assert mamba_block_size is not None
         page_size_padded = vllm_config.cache_config.mamba_page_size_padded
+        if page_size_padded is not None:
+            from vllm.distributed.utils import (
+                resolve_cp_token_ratios,
+                uneven_dcp_active,
+            )
+
+            if uneven_dcp_active():
+                # Uneven DCP: the config value is the padded page of ONE
+                # token-vector unit (solved engine-side in
+                # _align_hybrid_block_size); this rank's state and its
+                # attention allocation per virtual block both scale with
+                # its token share, so the padding target does too.
+                from vllm.distributed.parallel_state import (
+                    get_tensor_model_parallel_rank,
+                )
+
+                token_vector = resolve_cp_token_ratios(vllm_config)
+                assert token_vector is not None
+                page_size_padded = (
+                    page_size_padded * token_vector[get_tensor_model_parallel_rank()]
+                )
         return MambaSpec(
             shapes=tuple(self.get_state_shape()),
             dtypes=self.get_state_dtype(),

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -373,11 +373,30 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         # Per-rank (local) shard sizes. Even TP: total // tp_size (with
         # divisibility assert, exactly the previous behavior). Uneven TP
         # (--rank-tp-ratio): this rank's ratio share.
+        # Quant-aware family units: shard cuts of the out_proj INPUT
+        # (value dim) must land on quant-block boundaries - e.g. GGUF
+        # K-quant superblocks (256) force units of 2 k-heads (2*384 =
+        # 3*256), i.e. 8 units instead of 16.
+        import math as _math
+
+        _unit_v_elems = self.head_v_dim * (self.num_v_heads // self.num_k_heads)
+        _group = getattr(self.quant_config, "group_size", None) or 1
+        if _group > 1 and _unit_v_elems % _group:
+            _k_per_unit = _math.lcm(_unit_v_elems, _group) // _unit_v_elems
+            if self.num_k_heads % _k_per_unit:
+                raise ValueError(
+                    f"GDN k heads ({self.num_k_heads}) cannot be "
+                    f"partitioned in steps of {_k_per_unit} (quant group "
+                    f"{_group} vs {_unit_v_elems} value elems per head)."
+                )
+            self.tp_family_units = self.num_k_heads // _k_per_unit
+        else:
+            self.tp_family_units = self.num_k_heads
         self.local_num_k_heads = tp_partition_size(
-            self.num_k_heads, self.tp_size, self.tp_rank
+            self.num_k_heads, self.tp_size, self.tp_rank, self.tp_family_units
         )
         self.local_num_v_heads = tp_partition_size(
-            self.num_v_heads, self.tp_size, self.tp_rank
+            self.num_v_heads, self.tp_size, self.tp_rank, self.tp_family_units
         )
         self.local_key_dim = self.head_k_dim * self.local_num_k_heads
         self.local_value_dim = self.head_v_dim * self.local_num_v_heads
@@ -403,6 +422,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             output_size=self.conv_dim,
             bias=False,
             prefix=f"{prefix}.conv1d",
+            tp_units=self.tp_family_units,
         )
         self.conv1d.weight.data = self.conv1d.weight.data.unsqueeze(1)
 
@@ -441,6 +461,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             ],
             self.tp_size,
             self.tp_rank,
+            tp_units=self.tp_family_units,
         )
 
         # selective projection used to make dt, B and C input dependent
@@ -457,8 +478,14 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             )
         )
 
-        set_weight_attrs(self.A_log, {"weight_loader": sharded_weight_loader(0)})
-        set_weight_attrs(self.dt_bias, {"weight_loader": sharded_weight_loader(0)})
+        set_weight_attrs(
+            self.A_log,
+            {"weight_loader": sharded_weight_loader(0, self.tp_family_units)},
+        )
+        set_weight_attrs(
+            self.dt_bias,
+            {"weight_loader": sharded_weight_loader(0, self.tp_family_units)},
+        )
 
         output_gate_type = getattr(config, "output_gate_type", "silu")
         if output_gate_type == "swish":
@@ -484,6 +511,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             reduce_results=reduce_results,
             quant_config=self.quant_config,
             prefix=f"{prefix}.out_proj",
+            tp_units=self.tp_family_units,
         )
 
         self.chunk_gated_delta_rule = ChunkGatedDeltaRule()
@@ -522,6 +550,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             bias=False,
             quant_config=quant_config,
             prefix=prefix,
+            tp_units=self.tp_family_units,
         )
 
     def create_ba_proj(
@@ -546,6 +575,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             quant_config=quant_config,
             prefix=prefix,
             disable_tp=self.maybe_disable_tp(quant_config),
+            tp_units=self.tp_family_units,
         )
 
     def maybe_disable_tp(self, quant_config: QuantizationConfig | None) -> bool:
@@ -571,7 +601,9 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         if self.disable_tp_for_ba_proj and self.tp_size > 1:
             # ba_proj is replicated for Marlin; slice b/a to local TP rank.
             ba_chunk = self.local_num_v_heads
-            ba_start = tp_partition_offset(self.num_v_heads, self.tp_size, self.tp_rank)
+            ba_start = tp_partition_offset(
+                self.num_v_heads, self.tp_size, self.tp_rank, self.tp_family_units
+            )
             b = b[:, ba_start : ba_start + ba_chunk]
             a = a[:, ba_start : ba_start + ba_chunk]
         return b, a

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -14,9 +14,7 @@ from vllm.config import (
     VllmConfig,
     get_current_vllm_config,
 )
-from vllm.distributed import (
-    divide,
-)
+from vllm.distributed.utils import tp_partition_offset, tp_partition_size
 from vllm.forward_context import ForwardContext, get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import CustomOp, PluggableLayer
@@ -343,10 +341,12 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
     def get_state_shape(
         self,
     ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+        # Per-rank state shape: pass tp=1 with this rank's local head
+        # counts so uneven TP produces the correct per-rank cache size.
         return MambaStateShapeCalculator.gated_delta_net_state_shape(
-            self.tp_size,
-            self.num_k_heads,
-            self.num_v_heads,
+            1,
+            self.local_num_k_heads,
+            self.local_num_v_heads,
             self.head_k_dim,
             self.head_v_dim,
             self.conv_kernel_size,
@@ -370,6 +370,17 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         self.conv_kernel_size = config.linear_conv_kernel_dim
         self.key_dim = self.head_k_dim * self.num_k_heads
         self.value_dim = self.head_v_dim * self.num_v_heads
+        # Per-rank (local) shard sizes. Even TP: total // tp_size (with
+        # divisibility assert, exactly the previous behavior). Uneven TP
+        # (--rank-tp-ratio): this rank's ratio share.
+        self.local_num_k_heads = tp_partition_size(
+            self.num_k_heads, self.tp_size, self.tp_rank
+        )
+        self.local_num_v_heads = tp_partition_size(
+            self.num_v_heads, self.tp_size, self.tp_rank
+        )
+        self.local_key_dim = self.head_k_dim * self.local_num_k_heads
+        self.local_value_dim = self.head_v_dim * self.local_num_v_heads
         self.gqa_interleaved_layout = gqa_interleaved_layout
         if current_platform.is_xpu():
             self._forward_method = self.forward_xpu
@@ -437,11 +448,11 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         # time step projection (discretization)
         # instantiate once and copy inv_dt in init_weights of PretrainedModel
         self.dt_bias = nn.Parameter(
-            torch.ones(self.num_v_heads // self.tp_size),
+            torch.ones(self.local_num_v_heads),
         )
         self.A_log = nn.Parameter(
             torch.empty(
-                divide(self.num_v_heads, self.tp_size),
+                self.local_num_v_heads,
                 dtype=torch.float32,
             )
         )
@@ -559,8 +570,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         b, a = ba.chunk(2, dim=-1)
         if self.disable_tp_for_ba_proj and self.tp_size > 1:
             # ba_proj is replicated for Marlin; slice b/a to local TP rank.
-            ba_chunk = self.num_v_heads // self.tp_size
-            ba_start = self.tp_rank * ba_chunk
+            ba_chunk = self.local_num_v_heads
+            ba_start = tp_partition_offset(self.num_v_heads, self.tp_size, self.tp_rank)
             b = b[:, ba_start : ba_start + ba_chunk]
             a = a[:, ba_start : ba_start + ba_chunk]
         return b, a
@@ -574,7 +585,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         Derives `query`, `key` and `value` tensors from `mixed_qkvzba`.
         """
         new_tensor_shape_qkvz = mixed_qkvz.size()[:-1] + (
-            self.num_k_heads // self.tp_size,
+            self.local_num_k_heads,
             (
                 self.head_k_dim
                 + self.head_k_dim
@@ -584,7 +595,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             ),
         )
         new_tensor_shape_ba = mixed_ba.size()[:-1] + (
-            self.num_k_heads // self.tp_size,
+            self.local_num_k_heads,
             2 * self.num_v_heads // self.num_k_heads,
         )
 
@@ -611,8 +622,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         # [b, sq, ng, np/ng * hn] -> [b, sq, np, hn]
         value = value.reshape(value.size(0), -1, self.head_v_dim)
         z = z.reshape(z.size(0), -1, self.head_v_dim)
-        b = b.reshape(b.size(0), self.num_v_heads // self.tp_size)
-        a = a.reshape(a.size(0), self.num_v_heads // self.tp_size)
+        b = b.reshape(b.size(0), self.local_num_v_heads)
+        a = a.reshape(a.size(0), self.local_num_v_heads)
 
         return query, key, value, z, b, a
 
@@ -633,8 +644,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         if not self.gqa_interleaved_layout:
             # Qwen3.5: weights are in [q, k, v, z] order
             assert num_tokens == mixed_qkvz.shape[0]
-            qkv_size = (self.key_dim * 2 + self.value_dim) // self.tp_size
-            z_size = self.value_dim // self.tp_size
+            qkv_size = self.local_key_dim * 2 + self.local_value_dim
+            z_size = self.local_value_dim
             mixed_qkv, z_flat = mixed_qkvz.split([qkv_size, z_size], dim=-1)
             n = mixed_qkvz.shape[0]
             z_out = z_flat.reshape(n, -1, self.head_v_dim)
@@ -644,7 +655,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         # Qwen3-Next: interleaved GQA layout
         base_shape_qkvz = mixed_qkvz.size()[:-1]
         base_shape_ba = mixed_ba.size()[:-1]
-        ng = self.num_k_heads // self.tp_size
+        ng = self.local_num_k_heads
 
         new_tensor_shape_qkvz = base_shape_qkvz + (
             ng,
@@ -714,18 +725,14 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         curr += qkv_numel
 
         z_out = fused[curr : curr + z_numel].view(
-            num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim
+            num_tokens, self.local_num_v_heads, self.head_v_dim
         )
         curr += z_numel
 
-        b_out = fused[curr : curr + b_numel].view(
-            num_tokens, self.num_v_heads // self.tp_size
-        )
+        b_out = fused[curr : curr + b_numel].view(num_tokens, self.local_num_v_heads)
         curr += b_numel
 
-        a_out = fused[curr : curr + a_numel].view(
-            num_tokens, self.num_v_heads // self.tp_size
-        )
+        a_out = fused[curr : curr + a_numel].view(num_tokens, self.local_num_v_heads)
 
         return mixed_qkv_out, z_out, b_out, a_out
 
@@ -742,9 +749,9 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             return None, None, None
 
         seq_len = mixed_qkv.shape[0]
-        q_dim = self.key_dim // self.tp_size
-        k_dim = self.key_dim // self.tp_size
-        v_dim = self.value_dim // self.tp_size
+        q_dim = self.local_key_dim
+        k_dim = self.local_key_dim
+        v_dim = self.local_value_dim
 
         query, key, value = torch.split(mixed_qkv, [q_dim, k_dim, v_dim], dim=-1)
 
@@ -803,12 +810,12 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             projected_states_qkvz = projected_states_qkvz.view(num_tokens, -1)
             projected_states_ba = projected_states_ba.view(num_tokens, -1)
             core_attn_out = torch.empty(
-                (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
+                (num_tokens, self.local_num_v_heads, self.head_v_dim),
                 dtype=hidden_states.dtype,
                 device=hidden_states.device,
             )
             z = torch.empty(
-                (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
+                (num_tokens, self.local_num_v_heads, self.head_v_dim),
                 dtype=projected_states_qkvz.dtype,
                 device=projected_states_qkvz.device,
             )
@@ -854,8 +861,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             mixed_qkv = torch.cat((query, key, value), dim=-1)
         else:
             # Qwen3.5: weights are already in [q, k, v, z] and [b, a] order
-            qkv_size = (self.key_dim * 2 + self.value_dim) // self.tp_size
-            z_size = self.value_dim // self.tp_size
+            qkv_size = self.local_key_dim * 2 + self.local_value_dim
+            z_size = self.local_value_dim
             mixed_qkv, z = mixed_qkvz.split([qkv_size, z_size], dim=-1)
             z = z.reshape(z.size(0), -1, self.head_v_dim)
             b, a = self.split_ba(ba)
@@ -868,7 +875,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         # Note: we should not use torch.empty here like other attention backends,
         # see discussions in https://github.com/vllm-project/vllm/pull/28182
         core_attn_out = torch.zeros(
-            (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
+            (num_tokens, self.local_num_v_heads, self.head_v_dim),
             dtype=hidden_states.dtype,
             device=hidden_states.device,
         )
@@ -908,7 +915,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         # Part 2: Core Attention
         # ============================================================
         core_attn_out = torch.zeros(
-            (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
+            (num_tokens, self.local_num_v_heads, self.head_v_dim),
             dtype=hidden_states.dtype,
             device=hidden_states.device,
         )
@@ -955,15 +962,15 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             mixed_qkv = torch.cat((query, key, value), dim=-1)
         else:
             # Qwen3.5: weights are already in [q, k, v, z] and [b, a] order
-            qkv_size = (self.key_dim * 2 + self.value_dim) // self.tp_size
-            z_size = self.value_dim // self.tp_size
+            qkv_size = self.local_key_dim * 2 + self.local_value_dim
+            z_size = self.local_value_dim
             mixed_qkv, z = mixed_qkvz.split([qkv_size, z_size], dim=-1)
             z = z.reshape(z.size(0), -1, self.head_v_dim)
             b, a = ba.chunk(2, dim=-1)
 
         num_tokens = hidden_states.size(0)
         core_attn_out = torch.zeros(
-            (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
+            (num_tokens, self.local_num_v_heads, self.head_v_dim),
             dtype=hidden_states.dtype,
             device=hidden_states.device,
         )
@@ -1016,8 +1023,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
 
         device = qkv_or_qkvz.device
         dtype = qkv_or_qkvz.dtype
-        num_k_heads = self.num_k_heads // self.tp_size
-        num_v_heads = self.num_v_heads // self.tp_size
+        num_k_heads = self.local_num_k_heads
+        num_v_heads = self.local_num_v_heads
         _, state_dtype = self.get_state_dtype()
 
         # All kernels use BT = chunk_size, so a single pass with T = chunk_size
@@ -1351,7 +1358,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 b=b_prefill,
                 A_log=self.A_log,
                 dt_bias=self.dt_bias,
-                num_k_heads=self.num_k_heads // self.tp_size,
+                num_k_heads=self.local_num_k_heads,
                 head_k_dim=self.head_k_dim,
                 head_v_dim=self.head_v_dim,
                 apply_l2norm=True,
@@ -1524,8 +1531,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             gdn_aiter_fused_reshape_causal_conv1d_update_single_token(
                 qkvz,
                 attn_metadata.num_actual_tokens,
-                self.num_k_heads // self.tp_size,
-                self.num_v_heads // self.tp_size,
+                self.local_num_k_heads,
+                self.local_num_v_heads,
                 self.head_k_dim,
                 self.head_v_dim,
                 ba,
@@ -1549,8 +1556,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             b=b,
             dt_bias=self.dt_bias,
             qkv=mixed_qkv_non_spec,
-            key_dim=self.key_dim // self.tp_size,
-            value_dim=self.value_dim // self.tp_size,
+            key_dim=self.local_key_dim,
+            value_dim=self.local_value_dim,
             head_k_dim=self.head_k_dim,
             head_v_dim=self.head_v_dim,
             initial_state=ssm_state,

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -176,6 +176,7 @@ def mamba_v2_sharded_weight_loader(
     shard_spec: list[tuple[int, int, float]],
     tp_size: int,
     tp_rank: int,
+    tp_units: int | None = None,
 ) -> LoaderFunction:
     """Create a weight loader for mamba v2. This ensures that the projections
     are correctly sharded so that they can be split into x, B, C. It also
@@ -207,7 +208,7 @@ def mamba_v2_sharded_weight_loader(
                     "--rank-tp-ratio does not support duplicated mamba "
                     "groups (n_groups replication)"
                 )
-                shard_size = tp_partition_size(full_dim, tp_size, tp_rank)
+                shard_size = tp_partition_size(full_dim, tp_size, tp_rank, tp_units)
             else:
                 shard_size = full_dim // tp_size
 
@@ -221,7 +222,7 @@ def mamba_v2_sharded_weight_loader(
             if duplicate_groups:
                 loaded_skip = 0
             elif get_tp_partition_ratios():
-                loaded_skip = tp_partition_offset(full_dim, tp_size, tp_rank)
+                loaded_skip = tp_partition_offset(full_dim, tp_size, tp_rank, tp_units)
             else:
                 loaded_skip = tp_rank * shard_size
             loaded_start_idx = loaded_boundary + loaded_skip

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -13,6 +13,7 @@ from vllm.distributed import (
     tensor_model_parallel_all_gather,
     tensor_model_parallel_all_reduce,
 )
+from vllm.distributed.utils import tp_partition_offset, tp_partition_size
 from vllm.forward_context import ForwardContext, get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import CustomOp, PluggableLayer
@@ -195,18 +196,34 @@ def mamba_v2_sharded_weight_loader(
             #   rank. This is useful when there is replication of
             #   groups to accompany head shards.
 
-            # - size of the loaded shard
-            shard_size = full_dim // tp_size
+            # - size of the loaded shard. Ratio-aware only without
+            #   group duplication (a duplicated group is one full copy
+            #   per rank and must not be ratio-partitioned); the even
+            #   path keeps the historic unchecked floor division.
+            from vllm.distributed.utils import get_tp_partition_ratios
+
+            if get_tp_partition_ratios():
+                assert not duplicate_groups, (
+                    "--rank-tp-ratio does not support duplicated mamba "
+                    "groups (n_groups replication)"
+                )
+                shard_size = tp_partition_size(full_dim, tp_size, tp_rank)
+            else:
+                shard_size = full_dim // tp_size
 
             # - compute the rank into the loaded shard.
             # - if there is replication, different TP shards will
             #   take from the same rank.
             # NOTE: currently we only support duplication
             # in the case where num_groups == 1
-            rank = 0 if duplicate_groups else tp_rank
-
-            # - leftmost boundary index into loaded weight.
-            loaded_skip = rank * shard_size
+            # - leftmost boundary index into loaded weight
+            #   (prefix sum for uneven TP; rank*size for even TP).
+            if duplicate_groups:
+                loaded_skip = 0
+            elif get_tp_partition_ratios():
+                loaded_skip = tp_partition_offset(full_dim, tp_size, tp_rank)
+            else:
+                loaded_skip = tp_rank * shard_size
             loaded_start_idx = loaded_boundary + loaded_skip
 
             # - take these many dims from the loaded weight.
@@ -267,6 +284,13 @@ class MambaMixer2(MambaBase, PluggableLayer):
         prefix: str = "",
     ):
         super().__init__()
+        from vllm.distributed.utils import get_tp_partition_ratios
+
+        if get_tp_partition_ratios():
+            raise NotImplementedError(
+                "--rank-tp-ratio (uneven TP) is not supported for "
+                "MambaMixer2-based models yet (only Qwen3.5/3.6 GDN)."
+            )
 
         # For TP, the sharding plan is as follows:
         # - for the conv modules, since

--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import math
 from collections.abc import Sequence
 from dataclasses import dataclass
 
@@ -260,6 +261,12 @@ class VocabParallelEmbedding(PluggableLayer):
             self.tp_size = get_tensor_model_parallel_world_size()
         self.tp_rank = tp_rank
         self.num_embeddings = num_embeddings
+        # Vocab must split evenly across TP ranks. The default padding
+        # (64) only guarantees that for power-of-two TP sizes; with e.g.
+        # TP=3 (uneven-TP setups keep the vocab evenly split) pad to a
+        # multiple of lcm(padding, tp_size) instead.
+        if self.tp_size > 1:
+            padding_size = math.lcm(padding_size, self.tp_size)
         self.padding_size = padding_size
         self.org_vocab_size = org_num_embeddings or num_embeddings
         num_added_embeddings = num_embeddings - self.org_vocab_size

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -1271,10 +1271,23 @@ def sharded_weight_loader(shard_axis: int) -> LoaderFunction:
     """Create a weight loader that shards the weights along the given axis"""
 
     def loader(param: torch.Tensor, loaded_weight: torch.Tensor) -> None:
+        from vllm.distributed import get_tensor_model_parallel_world_size
+        from vllm.distributed.utils import (
+            get_tp_partition_ratios,
+            tp_partition_offset,
+        )
+
         tp_rank = get_tensor_model_parallel_rank()
 
         shard_size = param.data.shape[shard_axis]
-        start_idx = tp_rank * shard_size
+        if get_tp_partition_ratios():
+            start_idx = tp_partition_offset(
+                loaded_weight.shape[shard_axis],
+                get_tensor_model_parallel_world_size(),
+                tp_rank,
+            )
+        else:
+            start_idx = tp_rank * shard_size
         loaded_weight = loaded_weight.narrow(shard_axis, start_idx, shard_size)
 
         return default_weight_loader(param, loaded_weight)

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -1267,8 +1267,13 @@ def row_parallel_weight_loader(
 LoaderFunction = Callable[[torch.Tensor, torch.Tensor], None]
 
 
-def sharded_weight_loader(shard_axis: int) -> LoaderFunction:
-    """Create a weight loader that shards the weights along the given axis"""
+def sharded_weight_loader(
+    shard_axis: int, tp_units: int | None = None
+) -> LoaderFunction:
+    """Create a weight loader that shards the weights along the given axis.
+
+    tp_units: master unit count of the dimension family (v4 free
+    partitioning); None keeps the v1 sum(ratios)-divisibility rule."""
 
     def loader(param: torch.Tensor, loaded_weight: torch.Tensor) -> None:
         from vllm.distributed import get_tensor_model_parallel_world_size
@@ -1285,6 +1290,7 @@ def sharded_weight_loader(shard_axis: int) -> LoaderFunction:
                 loaded_weight.shape[shard_axis],
                 get_tensor_model_parallel_world_size(),
                 tp_rank,
+                tp_units,
             )
         else:
             start_idx = tp_rank * shard_size

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -367,6 +367,7 @@ class Qwen2_5_VisionAttention(nn.Module):
             num_heads,
             self.tp_size,
             0 if use_data_parallel else self.tp_rank,
+            num_heads,
         )
 
         self.qkv = QKVParallelLinear(
@@ -378,9 +379,11 @@ class Qwen2_5_VisionAttention(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.qkv",
             disable_tp=use_data_parallel,
+            tp_units=num_heads,
         )
 
         self.proj = RowParallelLinear(
+            tp_units=num_heads,
             input_size=projection_size,
             output_size=embed_dim,
             quant_config=quant_config,

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -363,8 +363,10 @@ class Qwen2_5_VisionAttention(nn.Module):
         self.hidden_size_per_attention_head = dist_utils.divide(
             projection_size, num_heads
         )
-        self.num_attention_heads_per_partition = dist_utils.divide(
-            num_heads, self.tp_size
+        self.num_attention_heads_per_partition = dist_utils.tp_partition_size(
+            num_heads,
+            self.tp_size,
+            0 if use_data_parallel else self.tp_rank,
         )
 
         self.qkv = QKVParallelLinear(

--- a/vllm/model_executor/models/qwen2_moe.py
+++ b/vllm/model_executor/models/qwen2_moe.py
@@ -81,6 +81,7 @@ class Qwen2MoeMLP(nn.Module):
         expert_gate: torch.nn.Linear | None = None,
         is_sequence_parallel: bool = False,
         prefix: str = "",
+        tp_units: int | None = None,
     ) -> None:
         super().__init__()
         self.gate_up_proj = MergedColumnParallelLinear(
@@ -90,6 +91,7 @@ class Qwen2MoeMLP(nn.Module):
             quant_config=quant_config,
             disable_tp=is_sequence_parallel,
             prefix=f"{prefix}.gate_up_proj",
+            tp_units=tp_units,
         )
         self.down_proj = RowParallelLinear(
             intermediate_size,
@@ -99,6 +101,7 @@ class Qwen2MoeMLP(nn.Module):
             reduce_results=reduce_results,
             disable_tp=is_sequence_parallel,
             prefix=f"{prefix}.down_proj",
+            tp_units=tp_units,
         )
         if hidden_act != "silu":
             raise ValueError(

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -384,6 +384,29 @@ class Qwen3_5ForCausalLMBase(
         parallel_config = vllm_config.parallel_config
         hf_config = vllm_config.model_config.hf_text_config
         tp_size = parallel_config.tensor_parallel_size
+        num_k_heads = hf_config.linear_num_key_heads
+        num_v_heads = hf_config.linear_num_value_heads
+        ratios = parallel_config.rank_tp_ratio
+        if ratios:
+            # Uneven TP: rank-aware in worker processes (matches the
+            # rank-aware get_num_kv_heads, so the derived block size
+            # mamba_page / attn_page is identical on every rank - the
+            # ratio factor cancels). Engine-level callers without an
+            # initialized TP group fall back to the smallest ratio,
+            # consistent with the same fallback in get_num_kv_heads.
+            denom = sum(ratios)
+            try:
+                from vllm.distributed.parallel_state import (
+                    get_tensor_model_parallel_rank,
+                )
+
+                rank = get_tensor_model_parallel_rank()
+            except (AssertionError, ValueError):
+                rank = None
+            unit = ratios[rank] if rank is not None else min(ratios)
+            num_k_heads = num_k_heads * unit // denom
+            num_v_heads = num_v_heads * unit // denom
+            tp_size = 1
         num_spec = (
             vllm_config.speculative_config.num_speculative_tokens
             if vllm_config.speculative_config
@@ -391,8 +414,8 @@ class Qwen3_5ForCausalLMBase(
         )
         return MambaStateShapeCalculator.gated_delta_net_state_shape(
             tp_size,
-            hf_config.linear_num_key_heads,
-            hf_config.linear_num_value_heads,
+            num_k_heads,
+            num_v_heads,
             hf_config.linear_key_head_dim,
             hf_config.linear_value_head_dim,
             hf_config.linear_conv_kernel_dim,
@@ -588,6 +611,29 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
         parallel_config = vllm_config.parallel_config
         hf_config = vllm_config.model_config.hf_text_config
         tp_size = parallel_config.tensor_parallel_size
+        num_k_heads = hf_config.linear_num_key_heads
+        num_v_heads = hf_config.linear_num_value_heads
+        ratios = parallel_config.rank_tp_ratio
+        if ratios:
+            # Uneven TP: rank-aware in worker processes (matches the
+            # rank-aware get_num_kv_heads, so the derived block size
+            # mamba_page / attn_page is identical on every rank - the
+            # ratio factor cancels). Engine-level callers without an
+            # initialized TP group fall back to the smallest ratio,
+            # consistent with the same fallback in get_num_kv_heads.
+            denom = sum(ratios)
+            try:
+                from vllm.distributed.parallel_state import (
+                    get_tensor_model_parallel_rank,
+                )
+
+                rank = get_tensor_model_parallel_rank()
+            except (AssertionError, ValueError):
+                rank = None
+            unit = ratios[rank] if rank is not None else min(ratios)
+            num_k_heads = num_k_heads * unit // denom
+            num_v_heads = num_v_heads * unit // denom
+            tp_size = 1
         num_spec = (
             vllm_config.speculative_config.num_speculative_tokens
             if vllm_config.speculative_config
@@ -595,8 +641,8 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
         )
         return MambaStateShapeCalculator.gated_delta_net_state_shape(
             tp_size,
-            hf_config.linear_num_key_heads,
-            hf_config.linear_num_value_heads,
+            num_k_heads,
+            num_v_heads,
             hf_config.linear_key_head_dim,
             hf_config.linear_value_head_dim,
             hf_config.linear_conv_kernel_dim,

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -78,6 +78,7 @@ from .qwen3_next import (
     Qwen3NextSparseMoeBlock,
     QwenNextMixtureOfExperts,
     _is_shared_expert_fse_compatible,
+    _mlp_tp_units,
 )
 from .qwen3_vl import (
     Qwen3_VisionTransformer,
@@ -172,6 +173,7 @@ class Qwen3_5DecoderLayer(Qwen3NextDecoderLayer):
                 intermediate_size=config.intermediate_size,
                 hidden_act=config.hidden_act,
                 quant_config=quant_config,
+                tp_units=_mlp_tp_units(config.intermediate_size, quant_config),
                 prefix=f"{prefix}.mlp",
             )
         else:
@@ -388,13 +390,17 @@ class Qwen3_5ForCausalLMBase(
         num_v_heads = hf_config.linear_num_value_heads
         ratios = parallel_config.rank_tp_ratio
         if ratios:
-            # Uneven TP: rank-aware in worker processes (matches the
-            # rank-aware get_num_kv_heads, so the derived block size
-            # mamba_page / attn_page is identical on every rank - the
-            # ratio factor cancels). Engine-level callers without an
-            # initialized TP group fall back to the smallest ratio,
-            # consistent with the same fallback in get_num_kv_heads.
-            denom = sum(ratios)
+            # Free partitioning (v4): local head counts come from the GDN
+            # k-head partition (largest-remainder over the weights); the
+            # v-heads follow at their fixed v-per-k multiple so both stay
+            # consistent with the GDN layer's own shards. Engine-level
+            # callers without an initialized TP group fall back to the
+            # smallest share, matching the align solver's per-share
+            # normalization.
+            from vllm.distributed.utils import gdn_head_partition
+
+            k_part = gdn_head_partition(vllm_config, list(ratios))
+            v_per_k = num_v_heads // num_k_heads
             try:
                 from vllm.distributed.parallel_state import (
                     get_tensor_model_parallel_rank,
@@ -403,9 +409,9 @@ class Qwen3_5ForCausalLMBase(
                 rank = get_tensor_model_parallel_rank()
             except (AssertionError, ValueError):
                 rank = None
-            unit = ratios[rank] if rank is not None else min(ratios)
-            num_k_heads = num_k_heads * unit // denom
-            num_v_heads = num_v_heads * unit // denom
+            local_k = k_part[rank] if rank is not None else min(k_part)
+            num_k_heads = local_k
+            num_v_heads = local_k * v_per_k
             tp_size = 1
         num_spec = (
             vllm_config.speculative_config.num_speculative_tokens
@@ -615,13 +621,17 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
         num_v_heads = hf_config.linear_num_value_heads
         ratios = parallel_config.rank_tp_ratio
         if ratios:
-            # Uneven TP: rank-aware in worker processes (matches the
-            # rank-aware get_num_kv_heads, so the derived block size
-            # mamba_page / attn_page is identical on every rank - the
-            # ratio factor cancels). Engine-level callers without an
-            # initialized TP group fall back to the smallest ratio,
-            # consistent with the same fallback in get_num_kv_heads.
-            denom = sum(ratios)
+            # Free partitioning (v4): local head counts come from the GDN
+            # k-head partition (largest-remainder over the weights); the
+            # v-heads follow at their fixed v-per-k multiple so both stay
+            # consistent with the GDN layer's own shards. Engine-level
+            # callers without an initialized TP group fall back to the
+            # smallest share, matching the align solver's per-share
+            # normalization.
+            from vllm.distributed.utils import gdn_head_partition
+
+            k_part = gdn_head_partition(vllm_config, list(ratios))
+            v_per_k = num_v_heads // num_k_heads
             try:
                 from vllm.distributed.parallel_state import (
                     get_tensor_model_parallel_rank,
@@ -630,9 +640,9 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
                 rank = get_tensor_model_parallel_rank()
             except (AssertionError, ValueError):
                 rank = None
-            unit = ratios[rank] if rank is not None else min(ratios)
-            num_k_heads = num_k_heads * unit // denom
-            num_v_heads = num_v_heads * unit // denom
+            local_k = k_part[rank] if rank is not None else min(k_part)
+            num_k_heads = local_k
+            num_v_heads = local_k * v_per_k
             tp_size = 1
         num_spec = (
             vllm_config.speculative_config.num_speculative_tokens

--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -93,15 +93,33 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
             if (quant_config and quant_config.get_name() == "modelopt_fp4")
             else quant_config
         )
-        self.fc = ColumnParallelLinear(
-            self.config.hidden_size * 2,
-            self.config.hidden_size,
-            gather_output=True,
-            bias=False,
-            return_bias=False,
-            quant_config=fc_quant,
-            prefix=f"{prefix}.fc",
-        )
+        from vllm.distributed.utils import get_tp_partition_ratios
+
+        if get_tp_partition_ratios():
+            # Uneven TP: gather_output=True would all-gather unevenly
+            # sized shards, which plain all_gather cannot do. This
+            # projection is small (2*hidden -> hidden, draft model only),
+            # so replicate it instead.
+            from vllm.model_executor.layers.linear import ReplicatedLinear
+
+            self.fc = ReplicatedLinear(
+                self.config.hidden_size * 2,
+                self.config.hidden_size,
+                bias=False,
+                return_bias=False,
+                quant_config=fc_quant,
+                prefix=f"{prefix}.fc",
+            )
+        else:
+            self.fc = ColumnParallelLinear(
+                self.config.hidden_size * 2,
+                self.config.hidden_size,
+                gather_output=True,
+                bias=False,
+                return_bias=False,
+                quant_config=fc_quant,
+                prefix=f"{prefix}.fc",
+            )
 
         # GPTQ: quantized checkpoints may exclude MTP from quantization via
         # quantization_config.dynamic with "-:pattern" entries. When detected,

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -14,10 +14,12 @@ from vllm.config import CacheConfig, ModelConfig, VllmConfig
 from vllm.distributed import (
     get_ep_group,
     get_pp_group,
+    get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
     tensor_model_parallel_all_gather,
     tensor_model_parallel_reduce_scatter,
 )
+from vllm.distributed.utils import get_tp_partition_ratios, tp_partition_size
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import FusedMoEFactory
@@ -240,20 +242,37 @@ class Qwen3NextAttention(nn.Module):
         self.config = config
         self.hidden_size = config.hidden_size
         tp_size = get_tensor_model_parallel_world_size()
+        tp_rank = get_tensor_model_parallel_rank()
         self.total_num_heads = config.num_attention_heads
-        assert self.total_num_heads % tp_size == 0
-        self.num_heads = self.total_num_heads // tp_size
         self.total_num_kv_heads = config.num_key_value_heads
-        if self.total_num_kv_heads >= tp_size:
-            # Number of KV heads is greater than TP size, so we partition
-            # the KV heads across multiple tensor parallel GPUs.
-            assert self.total_num_kv_heads % tp_size == 0
+        if get_tp_partition_ratios():
+            # Uneven TP: partition q/kv heads by the ratio vector.
+            # KV-head replication is not supported with ratios (each rank
+            # must own at least one whole kv head); tp_partition_size
+            # raises with a clear message if a count is not partitionable.
+            self.num_heads = tp_partition_size(self.total_num_heads, tp_size, tp_rank)
+            self.num_kv_heads = tp_partition_size(
+                self.total_num_kv_heads, tp_size, tp_rank
+            )
         else:
-            # Number of KV heads is less than TP size, so we replicate
-            # the KV heads across multiple tensor parallel GPUs.
-            assert tp_size % self.total_num_kv_heads == 0
-        self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
-        self.head_dim = config.head_dim or (self.hidden_size // self.num_heads)
+            assert self.total_num_heads % tp_size == 0
+            self.num_heads = self.total_num_heads // tp_size
+            if self.total_num_kv_heads >= tp_size:
+                # Number of KV heads is greater than TP size, so we partition
+                # the KV heads across multiple tensor parallel GPUs.
+                assert self.total_num_kv_heads % tp_size == 0
+            else:
+                # Number of KV heads is less than TP size, so we replicate
+                # the KV heads across multiple tensor parallel GPUs.
+                assert tp_size % self.total_num_kv_heads == 0
+            self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
+        if get_tp_partition_ratios():
+            # Uneven TP: the fallback must not depend on per-rank heads.
+            self.head_dim = config.head_dim or (
+                self.hidden_size // self.total_num_heads
+            )
+        else:
+            self.head_dim = config.head_dim or (self.hidden_size // self.num_heads)
         self.q_size = self.num_heads * self.head_dim
         self.kv_size = self.num_kv_heads * self.head_dim
         self.scaling = self.head_dim**-0.5

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -19,7 +19,11 @@ from vllm.distributed import (
     tensor_model_parallel_all_gather,
     tensor_model_parallel_reduce_scatter,
 )
-from vllm.distributed.utils import get_tp_partition_ratios, tp_partition_size
+from vllm.distributed.utils import (
+    get_tp_partition_ratios,
+    tp_partition_size,
+    uneven_dcp_active,
+)
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import FusedMoEFactory
@@ -100,6 +104,17 @@ def _is_shared_expert_fse_compatible(quant_config) -> bool:
     return not any("shared_expert." in str(e) for e in exclude)
 
 
+def _mlp_tp_units(intermediate_size: int, quant_config) -> int | None:
+    """Master unit count of the MLP intermediate dimension: shard cuts
+    must land on quantization-group boundaries (v4 free partitioning)."""
+    if not get_tp_partition_ratios():
+        return None
+    granule = getattr(quant_config, "group_size", None) or 128
+    if granule <= 0 or intermediate_size % granule:
+        granule = 1
+    return intermediate_size // granule
+
+
 class Qwen3NextSparseMoeBlock(nn.Module):
     def __init__(self, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
@@ -172,6 +187,9 @@ class Qwen3NextSparseMoeBlock(nn.Module):
                 reduce_results=False,
                 expert_gate=self.shared_expert_gate,
                 is_sequence_parallel=self.is_sequence_parallel,
+                tp_units=_mlp_tp_units(
+                    config.shared_expert_intermediate_size, quant_config
+                ),
                 prefix=f"{prefix}.shared_expert",
             )
 
@@ -245,7 +263,15 @@ class Qwen3NextAttention(nn.Module):
         tp_rank = get_tensor_model_parallel_rank()
         self.total_num_heads = config.num_attention_heads
         self.total_num_kv_heads = config.num_key_value_heads
-        if get_tp_partition_ratios():
+        if get_tp_partition_ratios() and uneven_dcp_active():
+            # Uneven DCP: q heads are ratio-partitioned (v4: freely, in
+            # whole heads), kv heads are fully replicated on every rank
+            # (the KV cache is split along the token axis instead).
+            self.num_heads = tp_partition_size(
+                self.total_num_heads, tp_size, tp_rank, self.total_num_heads
+            )
+            self.num_kv_heads = self.total_num_kv_heads
+        elif get_tp_partition_ratios():
             # Uneven TP: partition q/kv heads by the ratio vector.
             # KV-head replication is not supported with ratios (each rank
             # must own at least one whole kv head); tp_partition_size
@@ -289,6 +315,7 @@ class Qwen3NextAttention(nn.Module):
             bias=getattr(config, "qkv_bias", False),
             quant_config=quant_config,
             prefix=f"{prefix}.qkv_proj",
+            tp_units=self.total_num_heads,
         )
 
         self.o_proj = RowParallelLinear(
@@ -298,6 +325,7 @@ class Qwen3NextAttention(nn.Module):
             reduce_results=reduce_results,
             quant_config=quant_config,
             prefix=f"{prefix}.o_proj",
+            tp_units=self.total_num_heads,
         )
 
         self.rotary_emb = get_rope(
@@ -479,6 +507,7 @@ class Qwen3NextDecoderLayer(nn.Module):
                 intermediate_size=config.intermediate_size,
                 hidden_act=config.hidden_act,
                 quant_config=quant_config,
+                tp_units=_mlp_tp_units(config.intermediate_size, quant_config),
                 prefix=f"{prefix}.mlp",
             )
 

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -404,6 +404,7 @@ class Qwen3_VisionMLP(nn.Module):
             return_bias=False,
             prefix=f"{prefix}.linear_fc1",
             disable_tp=use_data_parallel,
+            tp_units=hidden_features,
         )
         self.linear_fc2 = RowParallelLinear(
             hidden_features,
@@ -413,6 +414,7 @@ class Qwen3_VisionMLP(nn.Module):
             return_bias=False,
             prefix=f"{prefix}.linear_fc2",
             disable_tp=use_data_parallel,
+            tp_units=hidden_features,
         )
         self.act_fn = act_fn
 
@@ -504,6 +506,7 @@ class Qwen3_VisionPatchMerger(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.linear_fc1",
             disable_tp=use_data_parallel,
+            tp_units=self.hidden_size,
         )
         self.act_fn = nn.GELU()
         self.linear_fc2 = RowParallelLinear(
@@ -513,6 +516,7 @@ class Qwen3_VisionPatchMerger(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.linear_fc2",
             disable_tp=use_data_parallel,
+            tp_units=self.hidden_size,
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/vllm/model_executor/parameter.py
+++ b/vllm/model_executor/parameter.py
@@ -13,7 +13,29 @@ from vllm.distributed import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
+from vllm.distributed.utils import get_tp_partition_ratios, tp_partition_sizes
 from vllm.logger import init_logger
+
+
+def _tp_shard_start(
+    loaded_full: int, rank: int, shard_size: int, tp_size: int | None = None
+) -> int:
+    """Loader-side narrow offset: classic rank*shard_size for even TP,
+    prefix sum of per-rank partition sizes for uneven TP. Pass the
+    parameter's own tp_size so disable_tp layers (tp_size=1) keep the
+    classic path even when process-global ratios are installed."""
+    if tp_size is None:
+        tp_size = get_tensor_model_parallel_world_size()
+    ratios = get_tp_partition_ratios()
+    if not ratios or len(ratios) != tp_size:
+        return rank * shard_size
+    sizes = tp_partition_sizes(loaded_full, tp_size)
+    assert sizes[rank] == shard_size, (
+        f"uneven-TP shard mismatch: expected {sizes[rank]} for rank {rank} "
+        f"of dim {loaded_full}, parameter has {shard_size}"
+    )
+    return sum(sizes[:rank])
+
 
 __all__ = [
     "BasevLLMParameter",
@@ -148,7 +170,14 @@ class _ColumnvLLMParameter(BasevLLMParameter):
     def load_column_parallel_weight(self, loaded_weight: torch.Tensor):
         shard_size = self.data.shape[self.output_dim]
         loaded_weight = loaded_weight.narrow(
-            self.output_dim, self.tp_rank * shard_size, shard_size
+            self.output_dim,
+            _tp_shard_start(
+                loaded_weight.shape[self.output_dim],
+                self.tp_rank,
+                shard_size,
+                getattr(self, "tp_size", None),
+            ),
+            shard_size,
         )
         assert self.data.shape == loaded_weight.shape
         self.data.copy_(loaded_weight)
@@ -170,7 +199,14 @@ class _ColumnvLLMParameter(BasevLLMParameter):
 
         param_data = param_data.narrow(self.output_dim, shard_offset, shard_size)
         loaded_weight = loaded_weight.narrow(
-            self.output_dim, self.tp_rank * shard_size, shard_size
+            self.output_dim,
+            _tp_shard_start(
+                loaded_weight.shape[self.output_dim],
+                self.tp_rank,
+                shard_size,
+                getattr(self, "tp_size", None),
+            ),
+            shard_size,
         )
         assert param_data.shape == loaded_weight.shape
         param_data.copy_(loaded_weight)
@@ -191,11 +227,20 @@ class _ColumnvLLMParameter(BasevLLMParameter):
             )
 
         param_data = self.data
-        shard_id_int = self.tp_rank if shard_id == "q" else self.tp_rank // num_heads
+        if get_tp_partition_ratios():
+            start_idx = _tp_shard_start(
+                loaded_weight.shape[self.output_dim],
+                self.tp_rank,
+                shard_size,
+                getattr(self, "tp_size", None),
+            )
+        else:
+            shard_id_int = (
+                self.tp_rank if shard_id == "q" else self.tp_rank // num_heads
+            )
+            start_idx = shard_id_int * shard_size
         param_data = param_data.narrow(self.output_dim, shard_offset, shard_size)
-        loaded_weight = loaded_weight.narrow(
-            self.output_dim, shard_id_int * shard_size, shard_size
-        )
+        loaded_weight = loaded_weight.narrow(self.output_dim, start_idx, shard_size)
 
         assert param_data.shape == loaded_weight.shape
         param_data.copy_(loaded_weight)
@@ -220,7 +265,14 @@ class RowvLLMParameter(BasevLLMParameter):
     def load_row_parallel_weight(self, loaded_weight: torch.Tensor):
         shard_size = self.data.shape[self.input_dim]
         loaded_weight = loaded_weight.narrow(
-            self.input_dim, self.tp_rank * shard_size, shard_size
+            self.input_dim,
+            _tp_shard_start(
+                loaded_weight.shape[self.input_dim],
+                self.tp_rank,
+                shard_size,
+                getattr(self, "tp_size", None),
+            ),
+            shard_size,
         )
 
         if len(loaded_weight.shape) == 0:

--- a/vllm/model_executor/parameter.py
+++ b/vllm/model_executor/parameter.py
@@ -18,7 +18,11 @@ from vllm.logger import init_logger
 
 
 def _tp_shard_start(
-    loaded_full: int, rank: int, shard_size: int, tp_size: int | None = None
+    loaded_full: int,
+    rank: int,
+    shard_size: int,
+    tp_size: int | None = None,
+    units: int | None = None,
 ) -> int:
     """Loader-side narrow offset: classic rank*shard_size for even TP,
     prefix sum of per-rank partition sizes for uneven TP. Pass the
@@ -29,7 +33,7 @@ def _tp_shard_start(
     ratios = get_tp_partition_ratios()
     if not ratios or len(ratios) != tp_size:
         return rank * shard_size
-    sizes = tp_partition_sizes(loaded_full, tp_size)
+    sizes = tp_partition_sizes(loaded_full, tp_size, units)
     assert sizes[rank] == shard_size, (
         f"uneven-TP shard mismatch: expected {sizes[rank]} for rank {rank} "
         f"of dim {loaded_full}, parameter has {shard_size}"
@@ -176,6 +180,7 @@ class _ColumnvLLMParameter(BasevLLMParameter):
                 self.tp_rank,
                 shard_size,
                 getattr(self, "tp_size", None),
+                getattr(self, "tp_units", None),
             ),
             shard_size,
         )
@@ -205,6 +210,7 @@ class _ColumnvLLMParameter(BasevLLMParameter):
                 self.tp_rank,
                 shard_size,
                 getattr(self, "tp_size", None),
+                getattr(self, "tp_units", None),
             ),
             shard_size,
         )
@@ -228,12 +234,19 @@ class _ColumnvLLMParameter(BasevLLMParameter):
 
         param_data = self.data
         if get_tp_partition_ratios():
-            start_idx = _tp_shard_start(
-                loaded_weight.shape[self.output_dim],
-                self.tp_rank,
-                shard_size,
-                getattr(self, "tp_size", None),
-            )
+            loaded_full = loaded_weight.shape[self.output_dim]
+            if shard_size == loaded_full:
+                # Fully replicated component (kv heads under uneven DCP):
+                # every rank loads the whole checkpoint dimension.
+                start_idx = 0
+            else:
+                start_idx = _tp_shard_start(
+                    loaded_full,
+                    self.tp_rank,
+                    shard_size,
+                    getattr(self, "tp_size", None),
+                    getattr(self, "tp_units", None),
+                )
         else:
             shard_id_int = (
                 self.tp_rank if shard_id == "q" else self.tp_rank // num_heads
@@ -271,6 +284,7 @@ class RowvLLMParameter(BasevLLMParameter):
                 self.tp_rank,
                 shard_size,
                 getattr(self, "tp_size", None),
+                getattr(self, "tp_units", None),
             ),
             shard_size,
         )

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -948,6 +948,42 @@ class NvmlCudaPlatform(CudaPlatformBase):
 
     @classmethod
     @with_nvml_context
+    def get_torch_to_nvml_mapping(cls) -> dict[int, int]:
+        """
+        Build a mapping from torch.cuda device indices to NVML physical indices.
+
+        torch.cuda and NVML/nvidia-smi can enumerate GPUs in different orders.
+        This function resolves the mapping using PCI bus IDs as the bridge.
+
+        Returns:
+            Dict mapping torch.cuda index -> NVML physical index
+        """
+        import torch
+
+        # Build NVML index -> PCI bus ID mapping (extract just the bus number)
+        nvml_bus_to_idx: dict[int, int] = {}
+        for nvml_idx in range(pynvml.nvmlDeviceGetCount()):
+            handle = pynvml.nvmlDeviceGetHandleByIndex(nvml_idx)
+            pci_info = pynvml.nvmlDeviceGetPciInfo(handle)
+            bus_id = pci_info.busId
+            if isinstance(bus_id, bytes):
+                bus_id = bus_id.decode("utf-8")
+            # Extract bus number (format: "00000000:BB:00.0")
+            bus_num = int(bus_id.split(":")[1], 16)
+            nvml_bus_to_idx[bus_num] = nvml_idx
+
+        # Map torch.cuda indices to NVML indices via PCI bus ID
+        result: dict[int, int] = {}
+        for torch_idx in range(torch.cuda.device_count()):
+            props = torch.cuda.get_device_properties(torch_idx)
+            bus_num = props.pci_bus_id
+            if bus_num in nvml_bus_to_idx:
+                result[torch_idx] = nvml_bus_to_idx[bus_num]
+
+        return result
+
+    @classmethod
+    @with_nvml_context
     def log_warnings(cls):
         device_ids: int = pynvml.nvmlDeviceGetCount()
         if device_ids > 1:

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -864,6 +864,57 @@ class Platform:
         if mamba_page_size == 0:
             return
 
+        # Uneven DCP (--rank-tp-ratio + dcp == tp): solve on a PER-RATIO-
+        # SHARE basis. The engine-side state shape above used the smallest
+        # ratio as fallback, so divide it down to one share; each rank's
+        # mamba page is share * its_ratio, and its attention allocation
+        # per virtual block is attn_page * its_ratio - the ratio cancels,
+        # so one global block size satisfies every rank. The per-rank
+        # padding is re-applied in MambaBase.get_kv_cache_spec.
+        ratios = parallel_config.rank_tp_ratio
+        uneven_dcp = (
+            bool(ratios)
+            and parallel_config.decode_context_parallel_size > 1
+            and len(set(ratios)) > 1
+        )
+        if uneven_dcp:
+            # The token vector follows the FREE memory per rank and
+            # is decoupled from the GDN head partition. The attention
+            # block size must therefore satisfy EVERY rank:
+            # attn_page_1_token * bs * t_r >= state_r = unit_state * g_r.
+            # Normalize the (rank-resolved) mamba page to one GDN k-head
+            # (unit_state), take the max over ranks of
+            # ceil(unit_state * g_r / t_r) as the per-token-unit page,
+            # and let the generic solve below derive bs from it. The
+            # per-rank padding target stays "padded_scalar * t_r"
+            # (mamba/abstract.py), which by construction covers state_r.
+            from math import ceil
+
+            from vllm.distributed.utils import (
+                gdn_head_partition,
+                resolve_cp_token_ratios,
+            )
+
+            token_vector = resolve_cp_token_ratios(vllm_config)
+            assert token_vector is not None
+            gdn_part = gdn_head_partition(vllm_config, list(ratios))
+            try:
+                from vllm.distributed.parallel_state import (
+                    get_tensor_model_parallel_rank,
+                )
+
+                g_res = gdn_part[get_tensor_model_parallel_rank()]
+            except (AssertionError, ValueError):
+                g_res = min(gdn_part)
+            assert mamba_page_size % g_res == 0, (
+                f"mamba page size {mamba_page_size} not divisible by "
+                f"resolved GDN share {g_res}"
+            )
+            unit_state = mamba_page_size // g_res
+            mamba_page_size = max(
+                ceil(unit_state * g / t) for g, t in zip(gdn_part, token_vector)
+            )
+
         # mamba_block_size here should either be user specified value or None
         mamba_block_size = (
             cache_config.mamba_block_size

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -881,6 +881,19 @@ class AttentionImplBase(ABC, Generic[T]):
             self.pcp_world_size = 1
             self.pcp_rank = 0
         self.total_cp_world_size = self.dcp_world_size
+        # Token-axis share of this rank under uneven DCP; the identity
+        # values (1, dcp_rank, dcp_world_size) for the classic even split.
+        from vllm.distributed.utils import cp_rank_ratio_prefix
+
+        (
+            self.cp_rank_ratio,
+            self.cp_rank_prefix,
+            self.cp_split_factor,
+        ) = cp_rank_ratio_prefix(self.dcp_world_size, self.dcp_rank)
+        self.cp_uneven = (self.cp_rank_ratio, self.cp_split_factor) != (
+            1,
+            self.dcp_world_size,
+        )
         self.total_cp_rank = self.dcp_rank
 
         self.need_to_return_lse_for_decode = (

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -9,6 +9,7 @@ from typing import ClassVar
 import numpy as np
 import torch
 
+from vllm.distributed.utils import cp_rank_ratio_prefix
 from vllm.model_executor.layers.attention import Attention
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import (
@@ -29,7 +30,7 @@ from vllm.v1.attention.backends.fa_utils import (
     is_flash_attn_varlen_func_available,
 )
 from vllm.v1.attention.backends.utils import get_dcp_local_seq_lens
-from vllm.v1.attention.ops.common import cp_lse_ag_out_rs
+from vllm.v1.attention.ops.common import cp_lse_ag_out_ar_uneven, cp_lse_ag_out_rs
 from vllm.v1.attention.ops.dcp_alltoall import dcp_a2a_lse_reduce
 from vllm.v1.attention.ops.merge_attn_states import merge_attn_states
 from vllm.v1.worker.workspace import current_workspace_manager
@@ -381,6 +382,20 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
         self.num_heads_q = self.model_config.get_num_attention_heads(
             self.parallel_config
         )
+        from vllm.distributed.utils import cp_q_head_counts as _cp_qhc
+
+        _counts = _cp_qhc(
+            self.model_config.hf_text_config.num_attention_heads,
+            self.dcp_world_size,
+        )
+        # Total q heads across the DCP group (v4: sum of the per-rank
+        # head partition, which need not be proportional to the token
+        # vector; even split: num_heads_q * dcp_world_size).
+        self.num_heads_q_across_dcp = (
+            sum(_counts)
+            if _counts is not None
+            else self.num_heads_q * self.dcp_world_size
+        )
         self.num_heads_kv = self.model_config.get_num_kv_heads(self.parallel_config)
         self.kv_cache_dtype = kv_cache_spec.dtype
         self.headdim = self.model_config.get_head_size()
@@ -398,6 +413,13 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
             # DCP might not be initialized in testing
             self.dcp_world_size = 1
             self.dcp_rank = 0
+        # Token-axis share of this rank: (ratio, prefix, split_sum) is
+        # (1, rank, world_size) for even DCP, ratio-derived under uneven DCP.
+        (
+            self.cp_rank_ratio,
+            self.cp_rank_prefix,
+            self.cp_split_factor,
+        ) = cp_rank_ratio_prefix(self.dcp_world_size, self.dcp_rank)
 
         self.cp_kv_cache_interleave_size = (
             self.parallel_config.cp_kv_cache_interleave_size
@@ -525,7 +547,7 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
                     batch_size=batch_size,
                     max_seqlen_q=max_query_len,
                     max_seqlen_k=max_seq_len,
-                    num_heads_q=self.num_heads_q * self.dcp_world_size,
+                    num_heads_q=self.num_heads_q_across_dcp,
                     num_heads_kv=self.num_heads_kv,
                     headdim=self.headdim,
                     cache_seqlens=seqlens,
@@ -593,18 +615,21 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
                     num_actual_tokens,
                 )
 
-            # After DCP distribution, the maximum number of tokens for any rank is
-            # ceil(L / (N * I)) * I, where L is max_seq_len, N is dcp_world_size,
-            # and I is cp_kv_cache_interleave_size.
-            # This eliminates GPU->CPU sync while minimizing workspace over-allocation.
+            # This eliminates GPU->CPU sync while minimizing workspace
+            # over-allocation.
             if skip_dcp_context_attention:
                 max_dcp_context_kv_len = 0
                 scheduler_metadata = None
             else:
-                num_partitions = self.dcp_world_size * self.cp_kv_cache_interleave_size
+                # After DCP distribution, the maximum number of tokens on
+                # this rank is ceil(L / (S * I)) * R * I, where L is
+                # max_seq_len, S is the token-split factor (dcp_world_size,
+                # or sum(ratios) under uneven DCP), R is this rank's ratio
+                # (1 when even), and I is cp_kv_cache_interleave_size.
+                num_partitions = self.cp_split_factor * self.cp_kv_cache_interleave_size
                 max_dcp_context_kv_len = (
                     (max_seq_len + num_partitions - 1) // num_partitions
-                ) * self.cp_kv_cache_interleave_size
+                ) * (self.cp_rank_ratio * self.cp_kv_cache_interleave_size)
 
                 scheduler_metadata = schedule(
                     batch_size=num_reqs,
@@ -825,7 +850,49 @@ class FlashAttentionImpl(AttentionImpl):
             and vllm_config.parallel_config.decode_context_parallel_size > 1
             and vllm_config.parallel_config.dcp_comm_backend == "a2a"
         )
-        self.dcp_combine = dcp_a2a_lse_reduce if dcp_a2a else cp_lse_ag_out_rs
+        if self.cp_uneven:
+            # Ratio-proportional head shards: reduce-scatter / all-to-all
+            # assume equal shards per rank, so combine via all-reduce +
+            # local head slice.
+            if dcp_a2a:
+                raise ValueError(
+                    "dcp_comm_backend='a2a' is not supported together with "
+                    "--rank-tp-ratio (uneven DCP); use the default backend."
+                )
+            from functools import partial
+
+            from vllm.distributed.utils import cp_q_head_counts
+
+            assert vllm_config is not None
+            total_q = vllm_config.model_config.hf_text_config.num_attention_heads
+            self.cp_head_counts = cp_q_head_counts(total_q, self.dcp_world_size)
+            assert self.cp_head_counts is not None
+            assert self.cp_head_counts[self.dcp_rank] == self.num_heads, (
+                self.cp_head_counts,
+                self.num_heads,
+            )
+            import os
+
+            from vllm.v1.attention.ops.dcp_alltoall import (
+                dcp_a2a_lse_reduce_uneven,
+            )
+
+            # Fused single-collective combine by default; AR fallback for
+            # A/B testing via VLLM_UNEVEN_DCP_COMBINE=ar.
+            if os.environ.get("VLLM_UNEVEN_DCP_COMBINE", "a2a") == "ar":
+                self.dcp_combine = partial(
+                    cp_lse_ag_out_ar_uneven, head_counts=self.cp_head_counts
+                )
+            else:
+                self.dcp_combine = partial(
+                    dcp_a2a_lse_reduce_uneven, head_counts=self.cp_head_counts
+                )
+            self.num_heads_across_dcp = sum(self.cp_head_counts)
+        else:
+            self.dcp_combine = dcp_a2a_lse_reduce if dcp_a2a else cp_lse_ag_out_rs
+            self.cp_head_counts = None
+            # Total q heads across the DCP group (even split).
+            self.num_heads_across_dcp = self.num_heads * self.dcp_world_size
 
         self._dcp_dtype: torch.dtype | None = None
         self._dcp_max_num_tokens: int = 0
@@ -1131,6 +1198,11 @@ class FlashAttentionImpl(AttentionImpl):
             layer._v_scale,
         )
 
+    def _all_gather_query_uneven(self, query: torch.Tensor) -> torch.Tensor:
+        from vllm.v1.attention.ops.common import cp_all_gather_heads_uneven
+
+        return cp_all_gather_heads_uneven(query, get_dcp_group(), self.cp_head_counts)
+
     def _forward_with_dcp(
         self,
         query: torch.Tensor,
@@ -1179,7 +1251,10 @@ class FlashAttentionImpl(AttentionImpl):
             )
             return output
 
-        query_across_dcp = get_dcp_group().all_gather(query, dim=1)
+        if self.cp_uneven:
+            query_across_dcp = self._all_gather_query_uneven(query)
+        else:
+            query_across_dcp = get_dcp_group().all_gather(query, dim=1)
         sliding_window_size = (
             list(self.sliding_window) if self.sliding_window is not None else None
         )
@@ -1200,7 +1275,7 @@ class FlashAttentionImpl(AttentionImpl):
         dcp_context_out_spec = (
             (
                 dcp_context_out_tokens,
-                self.num_heads * self.dcp_world_size,
+                self.num_heads_across_dcp,
                 self.head_size,
             ),
             self._dcp_dtype,
@@ -1276,11 +1351,30 @@ class FlashAttentionImpl(AttentionImpl):
         )
         context_lse_cor = context_lse_cor.transpose(0, 1).contiguous()
 
+        # Uneven DCP: this rank's local q head count need not be divisible
+        # by the (fully replicated) kv head count - e.g. 6 q heads over 4
+        # kv heads under ratios (2,1,1). Run the suffix attention on the
+        # already-gathered FULL q head set (where the GQA quotient is
+        # exact) and slice this rank's head range afterwards. The suffix
+        # only covers the new tokens, so the redundant compute is
+        # negligible. It cannot write into `output` (sized for the local
+        # heads), so it goes through a workspace buffer instead.
+        if self.cp_uneven:
+            suffix_query = query_across_dcp
+            (dcp_query_out,) = current_workspace_manager().get_simultaneous(
+                (
+                    (query.shape[0], self.num_heads_across_dcp, self.head_size),
+                    self._dcp_dtype,
+                ),
+            )
+        else:
+            suffix_query = query
+            dcp_query_out = output
         query_attn_out, query_lse = flash_attn_varlen_func(
-            q=query,
+            q=suffix_query,
             k=key,
             v=value,
-            out=output,
+            out=dcp_query_out,
             cu_seqlens_q=cu_seqlens_q,
             max_seqlen_q=max_seqlen_q,
             cu_seqlens_k=cu_seqlens_q,
@@ -1297,6 +1391,14 @@ class FlashAttentionImpl(AttentionImpl):
             v_descale=v_descale,
             num_splits=attn_metadata.max_num_splits,
         )
+        if self.cp_uneven:
+            # Slice this rank's head range out of the full-head suffix
+            # result (ratio shards are contiguous prefix-sum slices).
+            head_start = sum(self.cp_head_counts[: self.dcp_rank])
+            query_attn_out = query_attn_out[
+                :, head_start : head_start + self.num_heads
+            ].contiguous()
+            query_lse = query_lse[head_start : head_start + self.num_heads].contiguous()
         assert context_attn_out_cor.shape == query_attn_out.shape
         assert context_lse_cor.shape == query_lse.shape
         merge_attn_states(

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -71,8 +71,16 @@ from vllm.v1.attention.backends.utils import (
     infer_global_hyperparameters,
     split_decodes_and_prefills,
 )
-from vllm.v1.attention.ops.common import cp_lse_ag_out_rs
-from vllm.v1.attention.ops.dcp_alltoall import dcp_a2a_lse_reduce
+from vllm.v1.attention.ops.common import (
+    cp_all_gather_heads_uneven,
+    cp_local_head_bounds,
+    cp_lse_ag_out_ar_uneven,
+    cp_lse_ag_out_rs,
+)
+from vllm.v1.attention.ops.dcp_alltoall import (
+    dcp_a2a_lse_reduce,
+    dcp_a2a_lse_reduce_uneven,
+)
 from vllm.v1.attention.ops.merge_attn_states import merge_attn_states
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
@@ -233,8 +241,39 @@ class BatchDCPPrefillWrapper:
         self,
         workspace_buffer: torch.Tensor | None = None,
         dcp_a2a: bool = False,
+        cp_uneven: bool = False,
+        cp_head_counts: list[int] | None = None,
     ):
-        if dcp_a2a:
+        self._cp_uneven = cp_uneven
+        self._cp_head_counts = cp_head_counts
+        if cp_uneven:
+            # Ratio-proportional head shards (--rank-tp-ratio):
+            # reduce-scatter/all-to-all assume equal shards, so combine
+            # via all-reduce + local head slice. The new-tokens (suffix)
+            # attention also runs on the gathered FULL head set, because
+            # a rank's local q head count need not divide the (fully
+            # replicated) kv head count.
+            if dcp_a2a:
+                raise ValueError(
+                    "dcp_comm_backend='a2a' is not supported with "
+                    "--rank-tp-ratio (uneven DCP)."
+                )
+            assert cp_head_counts is not None
+            import os
+
+            if os.environ.get("VLLM_UNEVEN_DCP_COMBINE", "a2a") == "ar":
+                self._dcp_combine = partial(
+                    cp_lse_ag_out_ar_uneven,
+                    is_lse_base_on_e=False,
+                    head_counts=cp_head_counts,
+                )
+            else:
+                self._dcp_combine = partial(
+                    dcp_a2a_lse_reduce_uneven,
+                    is_lse_base_on_e=False,
+                    head_counts=cp_head_counts,
+                )
+        elif dcp_a2a:
             self._dcp_combine = partial(dcp_a2a_lse_reduce, is_lse_base_on_e=False)
         else:
             self._dcp_combine = partial(cp_lse_ag_out_rs, is_lse_base_on_e=False)
@@ -261,14 +300,17 @@ class BatchDCPPrefillWrapper:
         kv_cache_dtype: torch.dtype,
         prefill_fixed_split_size: int,
         disable_split_kv: bool,
+        num_qo_heads_across_dcp: int | None = None,
     ):
         """Plan the prefill operation with given parameters."""
+        if num_qo_heads_across_dcp is None:
+            num_qo_heads_across_dcp = num_qo_heads * dcp_world_size
         self._context.plan(
             qo_indptr=qo_indptr_cpu,
             paged_kv_indptr=paged_kv_indptr_cpu,
             paged_kv_indices=paged_kv_indices,
             paged_kv_last_page_len=paged_kv_last_page_len_cpu,
-            num_qo_heads=num_qo_heads * dcp_world_size,
+            num_qo_heads=num_qo_heads_across_dcp,
             num_kv_heads=num_kv_heads,
             head_dim_qk=head_dim,
             page_size=page_size,
@@ -284,7 +326,9 @@ class BatchDCPPrefillWrapper:
         self._new_tokens.plan(
             qo_indptr=qo_indptr_cpu,
             kv_indptr=qo_indptr_cpu,
-            num_qo_heads=num_qo_heads,
+            # Uneven DCP: suffix attention runs on the gathered full head
+            # set (local q heads need not divide the replicated kv heads).
+            num_qo_heads=num_qo_heads_across_dcp if self._cp_uneven else num_qo_heads,
             num_kv_heads=num_kv_heads,
             head_dim_qk=head_dim,
             head_dim_vo=head_dim,
@@ -304,9 +348,14 @@ class BatchDCPPrefillWrapper:
         value: torch.Tensor,
         out: torch.Tensor,
     ):
-        prefill_query_across_dcp = get_dcp_group().all_gather(
-            prefill_query.contiguous(), dim=1
-        )
+        if self._cp_uneven:
+            prefill_query_across_dcp = cp_all_gather_heads_uneven(
+                prefill_query.contiguous(), get_dcp_group(), self._cp_head_counts
+            )
+        else:
+            prefill_query_across_dcp = get_dcp_group().all_gather(
+                prefill_query.contiguous(), dim=1
+            )
         output_context_tmp, lse_context_tmp = self._context.run(
             prefill_query_across_dcp,
             kv_cache_tuple,
@@ -323,11 +372,17 @@ class BatchDCPPrefillWrapper:
         lse_context = lse_context.transpose(0, 1).contiguous()
 
         output_query, lse_query = self._new_tokens.run(
-            prefill_query,
+            prefill_query_across_dcp if self._cp_uneven else prefill_query,
             key,
             value,
             return_lse=True,
         )
+        if self._cp_uneven:
+            # Slice this rank's head range out of the full-head suffix
+            # result (lse is [tokens, heads] before the transpose below).
+            start, stop = cp_local_head_bounds(get_dcp_group(), self._cp_head_counts)
+            output_query = output_query[:, start:stop].contiguous()
+            lse_query = lse_query[:, start:stop]
         lse_query = lse_query.transpose(0, 1).contiguous()
 
         merge_attn_states(
@@ -695,11 +750,37 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         self.dcp_a2a = (
             self.use_dcp and vllm_config.parallel_config.dcp_comm_backend == "a2a"
         )
+        # Token-axis share of this rank under uneven DCP; identity values
+        # (1, rank, world_size) for the classic even split.
+        from vllm.distributed.utils import cp_rank_ratio_prefix
+
+        (
+            self.cp_rank_ratio,
+            self.cp_rank_prefix,
+            self.cp_split_factor,
+        ) = cp_rank_ratio_prefix(self.dcp_world_size, self.dcp_rank)
+        self.cp_uneven = (self.cp_rank_ratio, self.cp_split_factor) != (
+            1,
+            self.dcp_world_size,
+        )
 
         # Compatible with models with non-uniform per-layer head counts.
         self.num_qo_heads = get_num_attention_heads_from_layers(
             vllm_config, layer_names
         ) or self.model_config.get_num_attention_heads(self.vllm_config.parallel_config)
+        from vllm.distributed.utils import cp_q_head_counts
+
+        # Per-rank q-head partition across the DCP group (v4: need not be
+        # proportional to the token vector); None for the even split.
+        self.cp_head_counts = cp_q_head_counts(
+            self.model_config.hf_text_config.num_attention_heads,
+            self.dcp_world_size,
+        )
+        self.num_qo_heads_across_dcp = (
+            sum(self.cp_head_counts)
+            if self.cp_head_counts is not None
+            else self.num_qo_heads * self.dcp_world_size
+        )
 
         self.num_kv_heads = self.kv_cache_spec.num_kv_heads
         self.head_dim = self.kv_cache_spec.head_size
@@ -841,6 +922,40 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         )  # Extra buffer for mutable paged_kv_indptr.cpu in cuda graph mode
         self.paged_kv_indices = self._make_buffer(max_num_pages)
         self.paged_kv_last_page_len = self._make_buffer(max_num_reqs)
+        if self.cp_uneven:
+            # Uneven DCP runs with MTP drafting: this builder's build()
+            # executes several times per model step, and each build
+            # rewrites the pinned CPU buffers above while the previous
+            # build's non-blocking H2D copies may still be in flight
+            # (observed as illegal memory accesses from garbage indptr).
+            # Rotate through buffer slots and wait (via event) only if a
+            # slot's old copy is somehow still pending.
+            self._pkv_num_slots = 8
+            self._pkv_slots = [
+                (
+                    self._make_buffer(max_num_reqs + 1),
+                    torch.zeros_like(
+                        self.paged_kv_indptr.cpu, pin_memory=self.pin_memory
+                    ),
+                    self._make_buffer(max_num_reqs),
+                )
+                for _ in range(self._pkv_num_slots)
+            ]
+            self._pkv_events = [torch.cuda.Event() for _ in range(self._pkv_num_slots)]
+            self._pkv_slot_idx = 0
+
+    def _rotate_paged_kv_buffers(self) -> None:
+        """Uneven DCP: switch to the next pinned-buffer slot before this
+        build rewrites them (see comment at slot allocation)."""
+        s = self._pkv_slot_idx
+        self._pkv_slot_idx = (s + 1) % self._pkv_num_slots
+        self._pkv_events[s].synchronize()
+        (
+            self.paged_kv_indptr,
+            self.paged_kv_indptr_cpu_buffer,
+            self.paged_kv_last_page_len,
+        ) = self._pkv_slots[s]
+        self._pkv_pending_event = self._pkv_events[s]
 
     # Keep SM90 prefill/decode Q dtype selection in one place.
     def get_q_data_type(self, is_prefill: bool) -> torch.dtype:
@@ -997,6 +1112,8 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 self._prefill_wrapper = BatchDCPPrefillWrapper(
                     workspace_buffer=self._get_workspace_buffer(),
                     dcp_a2a=self.dcp_a2a,
+                    cp_uneven=self.cp_uneven,
+                    cp_head_counts=self.cp_head_counts,
                 )
             else:
                 # NVFP4 KV cache requires the trtllm-gen backend inside
@@ -1120,6 +1237,8 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         common_attn_metadata: CommonAttentionMetadata,
         fast_build: bool = False,
     ) -> FlashInferMetadata:
+        if self.cp_uneven:
+            self._rotate_paged_kv_buffers()
         num_reqs = common_attn_metadata.num_reqs
         num_actual_tokens = common_attn_metadata.num_actual_tokens
         causal = common_attn_metadata.causal
@@ -1249,6 +1368,11 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 query_lens_prefill_cpu = (
                     qo_indptr_prefill_cpu[1:] - qo_indptr_prefill_cpu[:-1]
                 )
+                # NEVER modify common_attn_metadata.seq_lens_cpu in place:
+                # with multiple attention groups (hybrid models, MTP draft)
+                # this builder runs several times on the same metadata and
+                # the subtraction would compound, yielding negative lens.
+                seq_lens_cpu = seq_lens_cpu.clone()
                 seq_lens_cpu[num_decodes:] = (
                     seq_lens_cpu[num_decodes:] - query_lens_prefill_cpu
                 )
@@ -1259,6 +1383,14 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 self.dcp_rank,
                 self.dcp_kv_cache_interleave_size,
             )
+            if self.cp_uneven:
+                # Uneven DCP: this rank's block-table columns are its
+                # LOCAL pages, dense in local-token order (cp_rank_ratio
+                # pages per virtual block). Page counts and last-page
+                # lengths must therefore come from the LOCAL sequence
+                # lengths, not the global ones computed above.
+                seq_lens_np = seq_lens_cpu.numpy()
+                num_blocks_np = (seq_lens_np + (page_size - 1)) // page_size
 
         # Adjust num_block_np for cascade attention
         if use_cascade:
@@ -1339,6 +1471,8 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 q_data_type=self.q_data_type_prefill,
                 kv_data_type=self.kv_cache_dtype,
             )
+            if self.cp_uneven:
+                self._pkv_pending_event.record()
             return attn_metadata
 
         # Step 3: Handle prefill and decode pathways case by case
@@ -1409,6 +1543,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                         num_qo_heads=self.num_qo_heads,
                         dcp_world_size=self.dcp_world_size,
                         num_kv_heads=self.num_kv_heads,
+                        num_qo_heads_across_dcp=self.num_qo_heads_across_dcp,
                         head_dim=self.head_dim,
                         sm_scale=self.sm_scale,
                         window_left=self.window_left,
@@ -1499,7 +1634,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     last_page_len_cpu=self.paged_kv_last_page_len.cpu[
                         :num_input_tokens
                     ],
-                    num_qo_heads=self.num_qo_heads * self.dcp_world_size,
+                    num_qo_heads=self.num_qo_heads_across_dcp,
                     num_kv_heads=self.num_kv_heads,
                     head_dim=self.head_dim,
                     page_size=self.page_size,
@@ -1515,6 +1650,8 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     disable_split_kv=self.disable_split_kv,
                 )
                 attn_metadata.decode = FIDecode(wrapper=decode_wrapper)
+        if self.cp_uneven:
+            self._pkv_pending_event.record()
         return attn_metadata
 
     def use_cascade_attention(self, *args, **kwargs) -> bool:
@@ -1620,7 +1757,37 @@ class FlashInferImpl(AttentionImpl):
             and vllm_config.parallel_config.decode_context_parallel_size > 1
             and vllm_config.parallel_config.dcp_comm_backend == "a2a"
         )
-        if dcp_a2a:
+        if self.cp_uneven:
+            # Ratio-proportional head shards: all-reduce + local head
+            # slice instead of the equal-shard reduce-scatter/a2a.
+            if dcp_a2a:
+                raise ValueError(
+                    "dcp_comm_backend='a2a' is not supported with "
+                    "--rank-tp-ratio (uneven DCP)."
+                )
+            from vllm.distributed.utils import cp_q_head_counts
+
+            assert vllm_config is not None
+            self.cp_head_counts = cp_q_head_counts(
+                vllm_config.model_config.hf_text_config.num_attention_heads,
+                self.dcp_world_size,
+            )
+            assert self.cp_head_counts is not None
+            import os
+
+            if os.environ.get("VLLM_UNEVEN_DCP_COMBINE", "a2a") == "ar":
+                self.dcp_combine = partial(
+                    cp_lse_ag_out_ar_uneven,
+                    is_lse_base_on_e=False,
+                    head_counts=self.cp_head_counts,
+                )
+            else:
+                self.dcp_combine = partial(
+                    dcp_a2a_lse_reduce_uneven,
+                    is_lse_base_on_e=False,
+                    head_counts=self.cp_head_counts,
+                )
+        elif dcp_a2a:
             self.dcp_combine = partial(dcp_a2a_lse_reduce, is_lse_base_on_e=False)
         else:
             self.dcp_combine = partial(cp_lse_ag_out_rs, is_lse_base_on_e=False)
@@ -2081,9 +2248,16 @@ class FlashInferImpl(AttentionImpl):
                     out_decode = output[:num_decode_tokens]
 
                 if use_dcp:
-                    decode_query = get_dcp_group().all_gather(
-                        decode_query.contiguous(), dim=-2
-                    )
+                    if self.cp_uneven:
+                        decode_query = cp_all_gather_heads_uneven(
+                            decode_query.contiguous(),
+                            get_dcp_group(),
+                            self.cp_head_counts,
+                        )
+                    else:
+                        decode_query = get_dcp_group().all_gather(
+                            decode_query.contiguous(), dim=-2
+                        )
                     output_tmp = torch.empty_like(decode_query)
                     lse = torch.empty(
                         (decode_query.size(0), decode_query.size(1)),

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -16,6 +16,7 @@ import torch
 from typing_extensions import runtime_checkable
 
 from vllm.config import VllmConfig, get_layers_from_vllm_config
+from vllm.distributed.utils import uneven_cp_ratios
 from vllm.utils.math_utils import cdiv
 from vllm.utils.torch_utils import PIN_MEMORY, async_tensor_h2d, np_to_pinned_tensor
 from vllm.v1.kv_cache_interface import KVCacheSpec, MambaSpec
@@ -893,7 +894,47 @@ def get_dcp_local_seq_lens(
     """While using dcp, kv_cache size stored on each rank may be different,
     use this function to calculate split decode seq_lens of each dcp rank.
     Only consider dcp now, we can extend the case of cp based on this.
+
+    Under uneven DCP (--rank-tp-ratio installed for this process), tokens
+    are distributed proportionally: within every round of
+    sum(ratios) * interleave tokens, rank r owns ratios[r] * interleave
+    tokens starting at prefix(r) * interleave. The even split below is the
+    special case ratios == (1, ..., 1).
     """
+    cp_ratios = uneven_cp_ratios(dcp_size)
+    if cp_ratios is not None:
+        split_sum = sum(cp_ratios)
+        prefixes = [sum(cp_ratios[:r]) for r in range(dcp_size)]
+        if dcp_rank is None:
+            ratio_t = torch.tensor(
+                cp_ratios, dtype=torch.int32, device=seq_lens.device
+            ).unsqueeze(0)
+            prefix_t = torch.tensor(
+                prefixes, dtype=torch.int32, device=seq_lens.device
+            ).unsqueeze(0)
+            num_cols = dcp_size
+        else:
+            ratio_t = torch.tensor(
+                [[cp_ratios[dcp_rank]]], dtype=torch.int32, device=seq_lens.device
+            )
+            prefix_t = torch.tensor(
+                [[prefixes[dcp_rank]]], dtype=torch.int32, device=seq_lens.device
+            )
+            num_cols = 1
+        seq_lens_tiled = seq_lens.to(torch.int32).unsqueeze(-1).repeat(1, num_cols)
+        round_size = split_sum * cp_kv_cache_interleave_size
+        full_rounds = seq_lens_tiled // round_size
+        remainder = seq_lens_tiled - full_rounds * round_size
+        local_remainder = torch.clip(
+            remainder - prefix_t * cp_kv_cache_interleave_size,
+            torch.zeros_like(ratio_t),
+            ratio_t * cp_kv_cache_interleave_size,
+        )
+        dcp_local_seq_lens = (
+            full_rounds * ratio_t * cp_kv_cache_interleave_size + local_remainder
+        )
+        return dcp_local_seq_lens.squeeze(1)
+
     seq_lens_i32 = seq_lens.to(torch.int32)
     if dcp_rank is None:
         rank_offsets = torch.arange(

--- a/vllm/v1/attention/ops/common.py
+++ b/vllm/v1/attention/ops/common.py
@@ -19,6 +19,7 @@ def _correct_attn_cp_out_kernel(
     lses_stride_B,
     lses_stride_H,
     lse_idx,
+    n_ranks,
     HEAD_DIM: tl.constexpr,
     N_ROUNDED: tl.constexpr,
     IS_BASE_E: tl.constexpr,
@@ -50,8 +51,11 @@ def _correct_attn_cp_out_kernel(
         + head_idx * lses_stride_H
     )
 
-    # calc final lse
-    lse = tl.load(lses_ptr + lse_offsets)
+    # calc final lse (mask the power-of-2 padding with -inf, which is
+    # neutral for both the max and the exp-sum)
+    lse = tl.load(
+        lses_ptr + lse_offsets, mask=num_n_offsets < n_ranks, other=-float("inf")
+    )
     lse = tl.where((lse != lse) | (lse == float("inf")), -float("inf"), lse)
     lse_max = tl.max(lse, axis=0)
     lse_max = tl.where(lse_max == -float("inf"), 0, lse_max)
@@ -173,8 +177,15 @@ def correct_attn_out(
         l_sB,
         l_sH,
         cp_rank,
+        N,
     )
-    const_args = {"HEAD_DIM": D, "N_ROUNDED": N, "IS_BASE_E": is_lse_base_on_e}
+    # tl.arange needs a power-of-2 extent; pad and mask (relevant for
+    # non-power-of-2 CP group sizes, e.g. dcp=3 under uneven DCP).
+    const_args = {
+        "HEAD_DIM": D,
+        "N_ROUNDED": triton.next_power_of_2(N),
+        "IS_BASE_E": is_lse_base_on_e,
+    }
     ctx.call_kernel(_correct_attn_cp_out_kernel, grid, *regular_args, **const_args)
     return out, lse
 
@@ -254,6 +265,78 @@ def cp_lse_ag_out_ar(
 
     if return_lse:
         return out, lse
+    return out
+
+
+def cp_all_gather_heads_uneven(
+    x: torch.Tensor, cp_group: GroupCoordinator, head_counts: list[int]
+) -> torch.Tensor:
+    """All-gather along the head dim (-2) when per-rank head counts
+    differ (--rank-tp-ratio): torch's all_gather needs equal shapes, so
+    pad each rank's heads to the maximum count, gather, and
+    re-concatenate the true head slices in rank order (which is the
+    global head order - head shards are contiguous prefix-sum slices).
+    head_counts is the per-rank q-head partition (cp_q_head_counts) -
+    under v4 free partitioning it need not be proportional to the token
+    vector. Shapes are static per rank, so this stays CUDA-graph
+    friendly; the padding garbage is sliced away before any compute.
+    """
+    counts = head_counts
+    local_heads = x.shape[-2]
+    assert counts[cp_group.rank_in_group] == local_heads, (counts, local_heads)
+    max_heads = max(counts)
+    pad_shape = list(x.shape)
+    pad_shape[-2] = max_heads
+    padded = x.new_empty(pad_shape)
+    padded[..., :local_heads, :].copy_(x)
+    gathered = cp_group.all_gather(padded, dim=-2)
+    parts = [
+        gathered[..., r * max_heads : r * max_heads + counts[r], :]
+        for r in range(cp_group.world_size)
+    ]
+    return torch.cat(parts, dim=-2)
+
+
+def cp_local_head_bounds(
+    cp_group: GroupCoordinator, head_counts: list[int]
+) -> tuple[int, int]:
+    """(start, stop) of this rank's head slice in the gathered full head
+    set under uneven DCP (head_counts = per-rank q-head partition)."""
+    rank = cp_group.rank_in_group
+    start = sum(head_counts[:rank])
+    return start, start + head_counts[rank]
+
+
+def cp_lse_ag_out_ar_uneven(
+    cp_attn_out: torch.Tensor,
+    cp_attn_lse: torch.Tensor,
+    cp_group: GroupCoordinator,
+    ctx: CPTritonContext | None = None,
+    return_lse: bool = False,
+    is_lse_base_on_e=True,
+    head_counts: list[int] | None = None,
+):
+    """Uneven-DCP combine: like cp_lse_ag_out_rs, but per-rank head
+    shards differ (--rank-tp-ratio), so the equal-shard reduce-scatter
+    cannot be used. All-reduce the corrected partial outputs and slice
+    this rank's head shard (from head_counts = per-rank q-head
+    partition) instead.
+
+    cp_attn_out: [ B, H_total, D ]  (H_total = sum of all ranks' q heads)
+    cp_attn_lse: [ B, H_total ]
+    """
+    out, lse = _cp_lse_common(
+        cp_attn_out, cp_attn_lse, cp_group, ctx=ctx, is_lse_base_on_e=is_lse_base_on_e
+    )
+    out = cp_group.all_reduce(out)
+
+    assert head_counts is not None, (
+        "cp_lse_ag_out_ar_uneven requires the per-rank head partition"
+    )
+    start, stop = cp_local_head_bounds(cp_group, head_counts)
+    out = out[:, start:stop].contiguous()
+    if return_lse:
+        return out, lse[:, start:stop].contiguous()
     return out
 
 

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -459,3 +459,159 @@ def dcp_a2a_lse_reduce(
     return _dcp_a2a_unpack_combine(
         recv_buffer, D, lse_pack_dim, return_lse, is_lse_base_on_e
     )
+
+
+def dcp_a2a_lse_reduce_uneven(
+    cp_attn_out: torch.Tensor,
+    cp_attn_lse: torch.Tensor,
+    cp_group: GroupCoordinator,
+    ctx: CPTritonContext | None = None,
+    return_lse: bool = False,
+    is_lse_base_on_e: bool = True,
+    head_counts: list[int] | None = None,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    """Uneven-head variant of dcp_a2a_lse_reduce: ONE all_to_all_single
+    (native uneven splits) carries every rank's partial output plus the
+    bit-packed fp32 LSE for the destination's head slice; the receiver
+    combines the N partials locally with exact LSE weighting. Replaces
+    the LSE-all-gather + all-reduce + slice combine (3 collectives, 2x
+    volume) of cp_lse_ag_out_ar_uneven.
+
+    cp_attn_out: [B, H_total, D]; cp_attn_lse: [B, H_total] (fp32);
+    head_counts: per-rank q-head partition (sums to H_total).
+    Returns [B, h_r, D] (and [B, h_r] LSE if requested).
+    """
+    world_size = cp_group.world_size
+    if world_size == 1:
+        if return_lse:
+            return cp_attn_out, cp_attn_lse
+        return cp_attn_out
+    assert head_counts is not None and len(head_counts) == world_size
+    rank = cp_group.rank_in_group
+    B, H, D = cp_attn_out.shape
+    assert sum(head_counts) == H, (head_counts, H)
+    h_r = head_counts[rank]
+    lse_pack_dim = _dcp_a2a_lse_pack_dim(cp_attn_out.dtype)
+
+    # Plain torch.empty (not the shared workspace) for cudagraph safety -
+    # see _dcp_a2a_send_recv_buffers. Shapes differ: send carries all H
+    # heads, recv carries world_size chunks of this rank's h_r heads.
+    send_buffer = torch.empty(
+        (H, B, D + lse_pack_dim),
+        device=cp_attn_out.device,
+        dtype=cp_attn_out.dtype,
+    )
+    recv_buffer = torch.empty(
+        (world_size, h_r, B, D + lse_pack_dim),
+        device=cp_attn_out.device,
+        dtype=cp_attn_out.dtype,
+    )
+
+    _dcp_a2a_pack_send_uneven_kernel[(B, H, 1)](
+        cp_attn_out,
+        cp_attn_lse,
+        send_buffer,
+        cp_attn_out.stride(0),
+        cp_attn_out.stride(1),
+        cp_attn_out.stride(2),
+        cp_attn_lse.stride(0),
+        cp_attn_lse.stride(1),
+        send_buffer.stride(0),
+        send_buffer.stride(1),
+        send_buffer.stride(2),
+        HEAD_DIM=D,
+        LSE_PACK_DIM=lse_pack_dim,
+    )
+
+    work = dist.all_to_all_single(
+        recv_buffer.view(world_size * h_r, -1),
+        send_buffer.view(H, -1),
+        output_split_sizes=[h_r] * world_size,
+        input_split_sizes=list(head_counts),
+        group=cp_group.device_group,
+        async_op=True,
+    )
+    work.wait()
+
+    out = torch.empty((B, h_r, D), device=recv_buffer.device, dtype=recv_buffer.dtype)
+    out_lse = torch.empty(
+        (B, h_r) if return_lse else (1, 1),
+        device=recv_buffer.device,
+        dtype=torch.float32 if return_lse else recv_buffer.dtype,
+    )
+    # Reuse the even unpack/combine kernel: it is layout-agnostic via
+    # strides (our recv is [N, h, B, D+p] instead of [N, B, h, D+p]).
+    _dcp_a2a_unpack_combine_kernel[(B, h_r, 1)](
+        recv_buffer,
+        out,
+        out_lse,
+        recv_buffer.stride(0),
+        recv_buffer.stride(2),
+        recv_buffer.stride(1),
+        recv_buffer.stride(3),
+        out.stride(0),
+        out.stride(1),
+        out.stride(2),
+        out_lse.stride(0),
+        out_lse.stride(1),
+        N=world_size,
+        HEAD_DIM=D,
+        IS_BASE_E=is_lse_base_on_e,
+        RETURN_LSE=return_lse,
+        LSE_PACK_DIM=lse_pack_dim,
+    )
+    if return_lse:
+        return out, out_lse
+    return out
+
+
+@triton.jit
+def _dcp_a2a_pack_send_uneven_kernel(
+    out_ptr,
+    lse_ptr,
+    send_ptr,
+    out_stride_B,
+    out_stride_H,
+    out_stride_D,
+    lse_stride_B,
+    lse_stride_H,
+    send_stride_H,
+    send_stride_B,
+    send_stride_D,
+    HEAD_DIM: tl.constexpr,
+    LSE_PACK_DIM: tl.constexpr,
+):
+    """Head-major transpose-pack for the uneven a2a: heads are already
+    in global order, so destination chunks are contiguous prefix slices
+    of the send buffer - no per-destination logic needed."""
+    batch_idx = tl.program_id(0).to(tl.int64)
+    head_idx = tl.program_id(1).to(tl.int64)
+    d_offsets = tl.arange(0, HEAD_DIM)
+
+    send_base = head_idx * send_stride_H + batch_idx * send_stride_B
+    out_offsets = (
+        batch_idx * out_stride_B + head_idx * out_stride_H + d_offsets * out_stride_D
+    )
+    tl.store(
+        send_ptr + send_base + d_offsets * send_stride_D,
+        tl.load(out_ptr + out_offsets),
+    )
+
+    lse_val = tl.load(lse_ptr + batch_idx * lse_stride_B + head_idx * lse_stride_H)
+    if LSE_PACK_DIM == 1:
+        tl.store(
+            send_ptr + send_base + HEAD_DIM * send_stride_D,
+            lse_val.to(send_ptr.dtype.element_ty),
+        )
+    else:
+        lse_bits = lse_val.to(tl.uint32, bitcast=True)
+        lo = (lse_bits & 0xFFFF).to(tl.uint16)
+        hi = ((lse_bits >> 16) & 0xFFFF).to(tl.uint16)
+        tl.store(
+            send_ptr + send_base + HEAD_DIM * send_stride_D,
+            lo.to(send_ptr.dtype.element_ty, bitcast=True),
+        )
+        tl.store(
+            send_ptr + send_base + (HEAD_DIM + 1) * send_stride_D,
+            hi.to(send_ptr.dtype.element_ty, bitcast=True),
+        )

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 from typing import NamedTuple
 
 from vllm import envs
+from vllm.distributed.utils import cp_token_split_factor
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
@@ -471,7 +472,10 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
         self.dcp_world_size = dcp_world_size
         self.pcp_world_size = pcp_world_size
         if dcp_world_size > 1:
-            self.block_size *= dcp_world_size
+            # Virtual scheduler blocks span cp_token_split_factor physical
+            # blocks (dcp, or sum(--rank-tp-ratio) under uneven DCP); the
+            # single-type manager scales its block_size identically.
+            self.block_size *= cp_token_split_factor(dcp_world_size, 1)
         # For models using only Mamba, block_size is set to max_model_len when
         # prefix caching is disabled, and hash_block_size validation is skipped.
         assert not enable_caching or (hash_block_size == self.block_size), (

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -2052,6 +2052,7 @@ def _auto_fit_max_model_len(
 def _project_kv_cache_groups_to_worker(
     global_kv_cache_groups: list[KVCacheGroupSpec],
     worker_spec: dict[str, KVCacheSpec],
+    use_worker_specs: bool = False,
 ) -> list[KVCacheGroupSpec]:
     """
     Projects global KV cache groups onto a single worker's assigned layers.
@@ -2074,13 +2075,17 @@ def _project_kv_cache_groups_to_worker(
         ]
         group_spec = group.kv_cache_spec
         if worker_layer_names and isinstance(group_spec, UniformTypeKVCacheSpecs):
+            source = worker_spec if use_worker_specs else group_spec.kv_cache_specs
             group_spec = UniformTypeKVCacheSpecs(
                 block_size=group_spec.block_size,
                 kv_cache_specs={
-                    layer_name: group_spec.kv_cache_specs[layer_name]
-                    for layer_name in worker_layer_names
+                    layer_name: source[layer_name] for layer_name in worker_layer_names
                 },
             )
+        elif worker_layer_names and use_worker_specs:
+            # Uneven TP: size this worker's config with its OWN spec
+            # (per-rank page size), not the canonical merged one.
+            group_spec = worker_spec[worker_layer_names[0]]
         projected_groups.append(
             KVCacheGroupSpec(
                 worker_layer_names,
@@ -2129,11 +2134,27 @@ def get_kv_cache_configs(
     # Merge the KV cache specs of all workers. Different PP stages may have
     # different layer names, and different TP ranks of the same PP stage should
     # have the same KV cache spec.
+    uneven_tp = bool(vllm_config.parallel_config.rank_tp_ratio)
     merged_kv_cache_specs: dict[str, KVCacheSpec] = {}
     for kv_cache_spec_one_worker in kv_cache_specs:
         for layer_name, layer_spec in kv_cache_spec_one_worker.items():
             if layer_name not in merged_kv_cache_specs:
                 merged_kv_cache_specs[layer_name] = layer_spec
+            elif uneven_tp:
+                # Uneven TP (--rank-tp-ratio): ranks legitimately hold
+                # differently sized shards of the same layer (different
+                # num_kv_heads / state shapes -> page_size_bytes). Require
+                # structural compatibility only; worker 0's spec stays the
+                # canonical structure for global grouping, per-worker page
+                # sizes are re-injected during projection below.
+                canonical = merged_kv_cache_specs[layer_name]
+                assert type(canonical) is type(layer_spec) and (
+                    canonical.block_size == layer_spec.block_size
+                ), (
+                    "Uneven TP: KV cache specs for the same layer are "
+                    "structurally incompatible across workers: "
+                    f"{canonical} vs {layer_spec}"
+                )
             else:
                 assert merged_kv_cache_specs[layer_name] == layer_spec, (
                     "The KV cache specs for the same layer are different "
@@ -2152,7 +2173,9 @@ def get_kv_cache_configs(
     # determine the maximum model length that fits in available GPU memory.
     # We use per-worker projected groups to account for PP sharding.
     projected_groups_per_worker = [
-        _project_kv_cache_groups_to_worker(global_kv_cache_groups, worker_spec)
+        _project_kv_cache_groups_to_worker(
+            global_kv_cache_groups, worker_spec, use_worker_specs=uneven_tp
+        )
         for worker_spec in kv_cache_specs
     ]
 

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -646,12 +646,22 @@ def resolve_kv_cache_block_sizes(
     dcp = vllm_config.parallel_config.decode_context_parallel_size
     groups = kv_cache_config.kv_cache_groups
 
+    ratios = vllm_config.parallel_config.rank_tp_ratio
+    uneven_dcp = bool(ratios) and dcp > 1 and len(set(ratios)) > 1
+    # Token-split factor of one scheduler block: dcp for the classic even
+    # split, sum(--rank-tp-ratio) under uneven DCP.
+    split_factor = sum(ratios) if uneven_dcp else dcp
+
     if len(groups) <= 1:
-        bs = cache_config.block_size * dcp
+        bs = cache_config.block_size * split_factor
         return bs, bs
 
+    # Effective per-group token span of one scheduler block: attention
+    # groups span block_size * split_factor tokens ("virtual" blocks under
+    # CP); mamba groups keep their full per-sequence state on every rank
+    # and span their raw block_size.
     group_block_sizes = [
-        g.kv_cache_spec.block_size * dcp
+        g.kv_cache_spec.block_size * split_factor
         if isinstance(g.kv_cache_spec, AttentionSpec)
         else g.kv_cache_spec.block_size
         for g in groups
@@ -1067,8 +1077,30 @@ def is_kv_cache_page_size_uniform(kv_cache_spec: dict[str, KVCacheSpec]) -> bool
     return len(page_sizes) == 1
 
 
+def _local_uneven_dcp_ratio(vllm_config: VllmConfig) -> int:
+    """This process's token-vector entry under uneven DCP, else 1 -
+    the number of physical pages this rank stores per virtual block.
+
+    Worker processes resolve their own TP rank; engine-side callers (no TP
+    group) get worker 0's share, matching the merged specs' provenance.
+    """
+    from vllm.distributed.utils import resolve_cp_token_ratios
+
+    token_vector = resolve_cp_token_ratios(vllm_config)
+    if token_vector is None:
+        return 1
+    try:
+        from vllm.distributed.parallel_state import get_tensor_model_parallel_rank
+
+        rank = get_tensor_model_parallel_rank()
+    except (AssertionError, ValueError):
+        rank = 0
+    return token_vector[rank]
+
+
 def unify_kv_cache_spec_page_size(
     kv_cache_spec: dict[str, KVCacheSpec],
+    cp_rank_ratio: int = 1,
 ) -> dict[str, KVCacheSpec]:
     """
     Unify the page size of the given KVCacheSpec. If the page size of all layers
@@ -1088,7 +1120,20 @@ def unify_kv_cache_spec_page_size(
     Returns:
         The updated KVCacheSpec with the same page_size_bytes.
     """
-    page_sizes = {layer.page_size_bytes for layer in kv_cache_spec.values()}
+
+    def effective_page_size(spec: KVCacheSpec) -> int:
+        # Uneven DCP: comparison must happen per scheduler block - a
+        # token-split (attention) group stores cp_rank_ratio physical
+        # pages per virtual block, a mamba group stores one full state
+        # page. The --rank-tp-ratio dependence cancels between the two
+        # (mamba pages scale with the ratio, attention effective pages
+        # pick it up via the factor), so the resulting unified block
+        # sizes are identical on every rank.
+        if cp_rank_ratio == 1 or isinstance(spec, MambaSpec):
+            return spec.page_size_bytes
+        return spec.page_size_bytes * cp_rank_ratio
+
+    page_sizes = {effective_page_size(layer) for layer in kv_cache_spec.values()}
     if len(page_sizes) <= 1:
         # All layers have the same page size, no need to unify.
         return kv_cache_spec
@@ -1096,7 +1141,7 @@ def unify_kv_cache_spec_page_size(
     max_page_size = max(page_sizes)
     new_kv_cache_spec = {}
     for layer_name, layer_spec in kv_cache_spec.items():
-        if layer_spec.page_size_bytes == max_page_size:
+        if effective_page_size(layer_spec) == max_page_size:
             new_kv_cache_spec[layer_name] = layer_spec
         elif isinstance(layer_spec, MambaSpec):
             # MambaSpec's page size is determined by its state shapes and does
@@ -1109,7 +1154,7 @@ def unify_kv_cache_spec_page_size(
             assert new_spec.page_size_bytes == max_page_size
             new_kv_cache_spec[layer_name] = new_spec
         else:
-            layer_page_size = layer_spec.page_size_bytes
+            layer_page_size = effective_page_size(layer_spec)
             if max_page_size % layer_page_size == 0:
                 ratio = max_page_size // layer_page_size
                 new_block_size = layer_spec.block_size * ratio
@@ -1117,6 +1162,7 @@ def unify_kv_cache_spec_page_size(
             elif (
                 isinstance(layer_spec, AttentionSpec)
                 and layer_spec.indexes_kv_by_block_stride
+                and cp_rank_ratio == 1
             ):
                 new_spec = replace(layer_spec, page_size_padded=max_page_size)
             else:
@@ -1125,9 +1171,19 @@ def unify_kv_cache_spec_page_size(
                     "maximum page size and cannot be padded. Padding is only "
                     "supported for attention layers whose backend indexes KV "
                     "pages by the block stride (indexes_kv_by_block_stride is "
-                    "True)."
+                    "True) and not under uneven DCP."
                 )
-            assert new_spec.page_size_bytes == max_page_size
+            if effective_page_size(new_spec) != max_page_size:
+                raise ValueError(
+                    f"Page-size unification failed for layer {layer_name} "
+                    f"({type(layer_spec).__name__}): effective page "
+                    f"{effective_page_size(new_spec)} != target "
+                    f"{max_page_size} (raw page {layer_spec.page_size_bytes}, "
+                    f"block_size {layer_spec.block_size}, "
+                    f"cp_rank_ratio {cp_rank_ratio}). Under uneven DCP this "
+                    "usually means the mamba page padding and the attention "
+                    "block size were solved inconsistently."
+                )
             new_kv_cache_spec[layer_name] = new_spec
     return new_kv_cache_spec
 
@@ -1362,6 +1418,7 @@ def get_kv_cache_config_from_groups(
     vllm_config: VllmConfig,
     kv_cache_groups: list[KVCacheGroupSpec],
     available_memory: int,
+    cp_rank_ratio: int | None = None,
 ) -> KVCacheConfig:
     """
     Generate the KV cache configuration from the KV cache groups and spec
@@ -1371,9 +1428,20 @@ def get_kv_cache_config_from_groups(
         vllm_config: The global VllmConfig
         kv_cache_groups: The KV cache groups
         available_memory: Memory available for KV cache in bytes
+        cp_rank_ratio: Uneven DCP only - this worker's --rank-tp-ratio
+            entry. Token-split groups store cp_rank_ratio physical pages
+            per scheduler ("virtual") block, so num_blocks is counted in
+            virtual blocks and tensors are sized with the per-group
+            effective page size (page * ratio for token-split groups,
+            page * 1 for mamba groups, whose state is not token-split).
+            None (default) resolves this process's own ratio - correct
+            for worker-side callers; the engine passes it explicitly per
+            worker.
     Returns:
         The generated KVCacheConfig
     """
+    if cp_rank_ratio is None:
+        cp_rank_ratio = _local_uneven_dcp_ratio(vllm_config)
     if len(kv_cache_groups) == 0:
         # Attention free models do not have KV cache.
         # Return num_blocks=1 as BlockPool always needs a null_block.
@@ -1383,6 +1451,15 @@ def get_kv_cache_config_from_groups(
             kv_cache_groups=kv_cache_groups,
         )
 
+    def group_block_factor(spec: KVCacheSpec) -> int:
+        # Physical pages this rank stores per scheduler block: uneven DCP
+        # stores cp_rank_ratio pages per virtual block for token-split
+        # groups; mamba groups keep one full state page per block on
+        # every rank (their state has no token axis).
+        if cp_rank_ratio == 1 or isinstance(spec, MambaSpec):
+            return 1
+        return cp_rank_ratio
+
     # Determine how model runners should initialize the KV cache tensors.
     if len(kv_cache_groups) == 1 and isinstance(
         kv_cache_groups[0].kv_cache_spec, UniformTypeKVCacheSpecs
@@ -1390,14 +1467,17 @@ def get_kv_cache_config_from_groups(
         # Special case: all layers have the same type of KV cache but with
         # different hidden sizes. Allocate different amount of memory for each
         # layer based on its hidden size.
-        num_blocks = (
-            available_memory // kv_cache_groups[0].kv_cache_spec.page_size_bytes
+        uniform_factor = group_block_factor(kv_cache_groups[0].kv_cache_spec)
+        num_blocks = available_memory // (
+            kv_cache_groups[0].kv_cache_spec.page_size_bytes * uniform_factor
         )
         num_blocks = may_override_num_blocks(vllm_config, num_blocks)
         per_layer_specs = kv_cache_groups[0].kv_cache_spec.kv_cache_specs
         kv_cache_tensors = [
             KVCacheTensor(
-                size=per_layer_specs[layer_name].page_size_bytes * num_blocks,
+                size=per_layer_specs[layer_name].page_size_bytes
+                * uniform_factor
+                * num_blocks,
                 shared_by=[layer_name],
             )
             for layer_name in kv_cache_groups[0].layer_names
@@ -1405,6 +1485,11 @@ def get_kv_cache_config_from_groups(
     elif _use_packed_kv_cache_config(vllm_config, kv_cache_groups):
         # DeepSeek V4 uses the packed layout by default. Other multi-group
         # layouts can opt in with --enable-cross-layers.
+        if cp_rank_ratio > 1:
+            raise NotImplementedError(
+                "Uneven DCP does not support the packed KV cache layout "
+                "(DeepSeek V4 / --enable-cross-layers)."
+            )
         num_blocks, kv_cache_tensors = _get_kv_cache_config_packed(
             vllm_config, kv_cache_groups, available_memory
         )
@@ -1419,9 +1504,31 @@ def get_kv_cache_config_from_groups(
         # full.1, sw.2: share another Tensor with size=available_memory//2
         group_size = max(len(group.layer_names) for group in kv_cache_groups)
 
-        page_size = get_uniform_page_size(
-            [group.kv_cache_spec for group in kv_cache_groups]
-        )
+        if cp_rank_ratio > 1:
+            # Uneven DCP: uniformity must hold for the EFFECTIVE page size
+            # (bytes per scheduler block on this rank). For hybrid models
+            # the --rank-tp-ratio dependence cancels between the two group
+            # types: attention pages are ratio-independent (full kv heads)
+            # but counted cp_rank_ratio times per virtual block, while
+            # mamba pages scale with the ratio directly and are counted
+            # once.
+            effective_pages = {
+                g.kv_cache_spec.page_size_bytes * group_block_factor(g.kv_cache_spec)
+                for g in kv_cache_groups
+            }
+            if len(effective_pages) != 1:
+                raise ValueError(
+                    "Uneven DCP requires a uniform effective page size per "
+                    "scheduler block across KV cache groups "
+                    f"(got {sorted(effective_pages)} bytes). For hybrid "
+                    "models use --mamba-cache-mode align so the attention "
+                    "block size matches the mamba state page."
+                )
+            page_size = effective_pages.pop()
+        else:
+            page_size = get_uniform_page_size(
+                [group.kv_cache_spec for group in kv_cache_groups]
+            )
         assert group_size > 0, "group_size must be greater than 0"
         num_blocks = get_num_blocks(
             vllm_config, group_size, available_memory, page_size
@@ -1831,8 +1938,16 @@ def get_kv_cache_groups(
 
     # Prefer preserving each layer's cache semantics. If physical pages cannot
     # be unified, try a supported allocation-only fallback before failing.
+    # Uneven DCP: page sizes in the specs are rank-specific (mamba states
+    # scale with the ratio), so unify with the ratio of the rank the specs
+    # came from - the local TP rank in worker processes, worker 0 for the
+    # merged engine-side specs. The resulting block sizes are
+    # rank-invariant (the ratio cancels between mamba pages and attention
+    # effective pages).
     try:
-        filtered_spec = unify_kv_cache_spec_page_size(filtered_spec)
+        filtered_spec = unify_kv_cache_spec_page_size(
+            filtered_spec, cp_rank_ratio=_local_uneven_dcp_ratio(vllm_config)
+        )
     except NotImplementedError:
         fallback_groups = _try_get_full_allocation_fallback_groups(kv_cache_spec)
         if fallback_groups is None:
@@ -1890,6 +2005,7 @@ def get_kv_cache_capacity(
 def _max_memory_usage_bytes_from_groups(
     vllm_config: VllmConfig,
     kv_cache_groups: list[KVCacheGroupSpec],
+    cp_rank_ratio: int | None = None,
 ) -> int:
     """
     Calculate maximum memory usage in bytes from KV cache groups.
@@ -1939,6 +2055,38 @@ def _max_memory_usage_bytes_from_groups(
     # General case: group_size pools, each shared by one layer per group
     # Memory = group_size * page_size * blocks_for_max_len
     group_size = max(len(group.layer_names) for group in kv_cache_groups)
+    if cp_rank_ratio is None:
+        cp_rank_ratio = _local_uneven_dcp_ratio(vllm_config)
+    from vllm.distributed.utils import resolve_cp_token_ratios as _resolve_tv
+
+    if cp_rank_ratio > 1 or _resolve_tv(vllm_config) is not None:
+        # Uneven DCP: count in scheduler ("virtual") blocks with the
+        # per-worker effective page size. Token-split groups span
+        # sum(ratios) physical blocks of full-sequence accounting per
+        # virtual block; mamba groups keep one state page per block.
+        from vllm.distributed.utils import resolve_cp_token_ratios as _rtr
+
+        _tv = _rtr(vllm_config)
+        token_split = sum(_tv) if _tv else 1
+
+        def pool_blocks(spec: KVCacheSpec) -> int:
+            per_block = spec.page_size_bytes * (
+                1 if isinstance(spec, MambaSpec) else token_split
+            )
+            return cdiv(spec.max_memory_usage_bytes(vllm_config), per_block)
+
+        effective_pages = {
+            g.kv_cache_spec.page_size_bytes
+            * (1 if isinstance(g.kv_cache_spec, MambaSpec) else cp_rank_ratio)
+            for g in kv_cache_groups
+        }
+        assert len(effective_pages) == 1, (
+            f"non-uniform effective pages {sorted(effective_pages)}"
+        )
+        page_size = effective_pages.pop()
+        blocks_needed = sum(pool_blocks(g.kv_cache_spec) for g in kv_cache_groups)
+        return group_size * page_size * blocks_needed
+
     page_size = get_uniform_page_size(
         [group.kv_cache_spec for group in kv_cache_groups]
     )
@@ -1954,6 +2102,7 @@ def _estimate_max_model_len_from_groups(
     vllm_config: VllmConfig,
     kv_cache_groups: list[KVCacheGroupSpec],
     available_memory: int,
+    cp_rank_ratio: int | None = None,
 ) -> int:
     """
     Binary search for the maximum model length that fits in available memory.
@@ -1964,7 +2113,9 @@ def _estimate_max_model_len_from_groups(
     def fits(model_len: int) -> bool:
         vllm_config.model_config.max_model_len = model_len
         return (
-            _max_memory_usage_bytes_from_groups(vllm_config, kv_cache_groups)
+            _max_memory_usage_bytes_from_groups(
+                vllm_config, kv_cache_groups, cp_rank_ratio
+            )
             <= available_memory
         )
 
@@ -2014,12 +2165,25 @@ def _auto_fit_max_model_len(
         return
 
     # Find the max_model_len that fits across all workers.
+    # Uneven DCP: each worker's specs carry its own ratio-scaled pages;
+    # worker index == TP rank in the pure-TP topology this mode requires.
+    from vllm.distributed.utils import resolve_cp_token_ratios
+
+    token_vector = resolve_cp_token_ratios(vllm_config)
+    uneven_dcp = token_vector is not None
     auto_fit_max = original_max
     limiting_worker_mem = available_memory[0]
-    for groups, avail_mem in zip(projected_groups_per_worker, available_memory):
+    for worker_idx, (groups, avail_mem) in enumerate(
+        zip(projected_groups_per_worker, available_memory)
+    ):
         if not groups:
             continue
-        worker_max = _estimate_max_model_len_from_groups(vllm_config, groups, avail_mem)
+        worker_max = _estimate_max_model_len_from_groups(
+            vllm_config,
+            groups,
+            avail_mem,
+            cp_rank_ratio=token_vector[worker_idx] if uneven_dcp else None,
+        )
         if worker_max < auto_fit_max:
             auto_fit_max = worker_max
             limiting_worker_mem = avail_mem
@@ -2084,8 +2248,15 @@ def _project_kv_cache_groups_to_worker(
             )
         elif worker_layer_names and use_worker_specs:
             # Uneven TP: size this worker's config with its OWN spec
-            # (per-rank page size), not the canonical merged one.
+            # (per-rank page size), not the canonical merged one. Keep the
+            # group's unified block_size though - page-size unification
+            # (mamba-cache-mode align) may have raised the attention block
+            # size after the worker reported its spec.
             group_spec = worker_spec[worker_layer_names[0]]
+            if group_spec.block_size != group.kv_cache_spec.block_size:
+                group_spec = replace(
+                    group_spec, block_size=group.kv_cache_spec.block_size
+                )
         projected_groups.append(
             KVCacheGroupSpec(
                 worker_layer_names,
@@ -2207,26 +2378,58 @@ def get_kv_cache_configs(
         )
 
     # Check if the available memory is enough per worker.
-    for groups, avail_mem in zip(projected_groups_per_worker, available_memory):
+    # Uneven DCP: worker w stores ratios[w] physical pages per scheduler
+    # ("virtual") block for token-split groups, so its num_blocks must be
+    # counted in virtual blocks. Worker index == TP rank for the pure-TP
+    # single-node topology this mode is restricted to.
+    from vllm.distributed.utils import resolve_cp_token_ratios
+
+    token_vector = resolve_cp_token_ratios(vllm_config)
+    uneven_dcp = token_vector is not None
+
+    for worker_idx, (groups, avail_mem) in enumerate(
+        zip(projected_groups_per_worker, available_memory)
+    ):
         if not groups:
             continue
+        worker_ratio = token_vector[worker_idx] if uneven_dcp else None
         _check_enough_kv_cache_memory(
             avail_mem,
-            partial(_max_memory_usage_bytes_from_groups, vllm_config, groups),
+            partial(
+                _max_memory_usage_bytes_from_groups,
+                vllm_config,
+                groups,
+                worker_ratio,
+            ),
             vllm_config.model_config.max_model_len,
-            partial(_estimate_max_model_len_from_groups, vllm_config, groups),
+            partial(
+                _estimate_max_model_len_from_groups,
+                vllm_config,
+                groups,
+                cp_rank_ratio=worker_ratio,
+            ),
+        )
+    if uneven_dcp and len(kv_cache_specs) != len(token_vector):
+        raise ValueError(
+            f"Uneven DCP expects one worker per TP rank "
+            f"({len(token_vector)}), got {len(kv_cache_specs)} workers."
         )
 
     kv_cache_configs: list[KVCacheConfig] = []
-    for projected_groups, kv_cache_spec_one_worker, available_memory_one_worker in zip(
-        projected_groups_per_worker, kv_cache_specs, available_memory
-    ):
+    for worker_idx, (
+        projected_groups,
+        kv_cache_spec_one_worker,
+        available_memory_one_worker,
+    ) in enumerate(zip(projected_groups_per_worker, kv_cache_specs, available_memory)):
         assert sum(len(group.layer_names) for group in projected_groups) == len(
             kv_cache_spec_one_worker
         ), "Some layers are not assigned to any group."
         kv_cache_configs.append(
             get_kv_cache_config_from_groups(
-                vllm_config, projected_groups, available_memory_one_worker
+                vllm_config,
+                projected_groups,
+                available_memory_one_worker,
+                cp_rank_ratio=token_vector[worker_idx] if uneven_dcp else 1,
             )
         )
 
@@ -2236,6 +2439,36 @@ def get_kv_cache_configs(
     min_num_blocks = min(
         kv_cache_config.num_blocks for kv_cache_config in kv_cache_configs
     )
+    if uneven_dcp and len(kv_cache_configs) > 1:
+        # Re-tuning hint: the token vector was derived from an
+        # ESTIMATE of each rank's free-for-KV memory (checkpoint share +
+        # fixed overhead). The per-worker block counts now reflect the
+        # MEASURED free memory; if they diverge, the smallest rank pins
+        # the shared pool and the surplus on the other ranks is wasted.
+        # Suggest a vector proportional to measured blocks x current
+        # share, which equalizes block counts on the next start.
+        all_blocks = [c.num_blocks for c in kv_cache_configs]
+        if max(all_blocks) > min_num_blocks * 1.15:
+            from vllm.distributed.utils import _TOKEN_VECTOR_UNITS  # noqa
+            from vllm.distributed.utils import partition_units
+
+            measured = [b * token_vector[i] for i, b in enumerate(all_blocks)]
+            suggested = partition_units(_TOKEN_VECTOR_UNITS, measured)
+            import math as _math
+
+            g = _math.gcd(*suggested)
+            suggested = [s // g for s in suggested]
+            logger.warning(
+                "Uneven DCP: per-worker KV block capacities %s are "
+                "imbalanced (pool is pinned to %d); the token vector %s "
+                "over-allocates the smallest rank. Restart with "
+                "VLLM_UNEVEN_TOKEN_VECTOR=%s to redistribute the KV "
+                "cache to the measured free memory.",
+                all_blocks,
+                min_num_blocks,
+                token_vector,
+                ",".join(str(s) for s in suggested),
+            )
     for kv_cache_config in kv_cache_configs:
         num_blocks_old = kv_cache_config.num_blocks
         kv_cache_config.num_blocks = min_num_blocks

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -384,6 +384,30 @@ class Scheduler(SchedulerInterface):
         if start >= max(request.num_prompt_tokens, request.num_tokens - 1):
             return num_new_tokens
 
+        if self.block_size != self.cache_config.block_size:
+            # Uneven context parallelism: the prefix cache operates on
+            # virtual scheduler blocks (cache block_size x token-vector
+            # sum), so mamba states are only hittable when a prefill
+            # step ends exactly on a scheduler-block boundary. The
+            # token budget may be smaller than one scheduler block, so
+            # instead of rounding the chunk down (which could yield 0
+            # and starve the request), clip the step at the next
+            # boundary it would cross; steps between boundaries run
+            # unaligned and a later step lands the checkpoint.
+            block_size = self.block_size
+            last_cache_position = request.num_tokens - request.num_tokens % block_size
+            if self.use_eagle:
+                last_cache_position = max(last_cache_position - block_size, 0)
+            after = start + num_new_tokens
+            if after < last_cache_position:
+                boundary = after // block_size * block_size
+                if boundary > start:
+                    num_new_tokens = boundary - start
+            elif start < last_cache_position < after:
+                # force the step to end on the last cacheable boundary
+                num_new_tokens = last_cache_position - start
+            return num_new_tokens
+
         block_size = self.cache_config.block_size
         # The last block-aligned position whose state can be cached. With
         # Eagle, FullAttn prunes the last matching block, so back off one

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from collections.abc import Sequence
 from typing import ClassVar
 
+from vllm.distributed.utils import cp_token_split_factor, uneven_cp_ratios
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_utils import (
@@ -76,7 +77,11 @@ class SingleTypeKVCacheManager(ABC):
         self.dcp_world_size = dcp_world_size
         self.pcp_world_size = pcp_world_size
         if dcp_world_size > 1:
-            self.block_size *= dcp_world_size
+            # Token-split groups use "virtual" scheduler blocks spanning
+            # cp_token_split_factor physical blocks (sum(--rank-tp-ratio)
+            # under uneven DCP, dcp otherwise). MambaManager undoes this
+            # scaling (full per-rank recurrent state, not token-split).
+            self.block_size *= cp_token_split_factor(dcp_world_size, 1)
         self.kv_cache_spec = kv_cache_spec
         self.block_pool = block_pool
         self.enable_caching = enable_caching
@@ -700,8 +705,9 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         block_size = kv_cache_spec.block_size
         if dcp_world_size > 1:
             # DCP shards each block's KV across ranks; hashes must be viewed at
-            # the sharded block size.
-            block_size *= dcp_world_size
+            # the sharded block size (sum(--rank-tp-ratio) shares per block
+            # under uneven DCP, dcp equal shares otherwise).
+            block_size *= cp_token_split_factor(dcp_world_size, 1)
         block_hashes = resolve_block_hashes(
             block_hashes,
             block_pool.hash_block_size,
@@ -1292,7 +1298,12 @@ class MambaManager(SingleTypeKVCacheManager):
         assert isinstance(kv_cache_spec, MambaSpec), (
             "MambaManager can only be used for mamba groups"
         )
-        assert dcp_world_size == 1, "DCP not support mamba now."
+        # Mamba state has no token axis: under uneven DCP the mamba groups
+        # simply stay outside the token split (full state per rank), so
+        # only classic even DCP/PCP remains unsupported.
+        assert dcp_world_size == 1 or uneven_cp_ratios(dcp_world_size) is not None, (
+            "DCP not support mamba now."
+        )
         assert pcp_world_size == 1, "PCP not support mamba now."
         block_hashes = resolve_block_hashes(
             block_hashes,
@@ -1437,6 +1448,23 @@ class MambaManager(SingleTypeKVCacheManager):
                 last_state_block_idx is not None
                 and last_state_block_idx
                 < cdiv(processed_computed_tokens, self.block_size) - 1
+                # Under uneven context parallelism (virtual scheduler
+                # blocks, scheduler_block_size > block_size) keep
+                # scheduler-aligned checkpoint blocks alive until the
+                # request finishes: freed checkpoints only survive as
+                # evictable cache entries, and the virtual-block factor
+                # shrinks the pool ID space so much that a single long
+                # prefill recycles (and evicts) its own checkpoints before
+                # any follow-up request can hit them. In the default path
+                # (scheduler_block_size == block_size) every block is
+                # "aligned", so this must not suppress the free.
+                and (
+                    self.scheduler_block_size == self.block_size
+                    or (last_state_block_idx + 1)
+                    * self.block_size
+                    % self.scheduler_block_size
+                    != 0
+                )
             ):
                 blocks = self.req_to_blocks[request_id]
                 if blocks[last_state_block_idx] != self._null_block:

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -117,6 +117,19 @@ class EngineCore:
         load_general_plugins()
 
         self.vllm_config = vllm_config
+        if vllm_config.parallel_config.rank_tp_ratio:
+            # Uneven TP/DCP: the scheduler process also needs the ratio
+            # vectors (virtual block sizing uses sum(token ratios) instead
+            # of dcp_world_size); workers install them in
+            # gpu_worker.init_device.
+            from vllm.distributed.utils import (
+                resolve_cp_token_ratios,
+                set_cp_token_ratios,
+                set_tp_partition_ratios,
+            )
+
+            set_tp_partition_ratios(vllm_config.parallel_config.rank_tp_ratio)
+            set_cp_token_ratios(resolve_cp_token_ratios(vllm_config))
         if not vllm_config.parallel_config.data_parallel_rank_local:
             logger.info(
                 "Initializing a V1 LLM engine (v%s) with config: %s",

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -701,6 +701,50 @@ class WorkerProc:
             # Have the worker close parent end of this worker's pipes too
             "inherited_fds": inherited_fds if inherited_fds is not None else [],
         }
+
+        # Device isolation for --rank-gpu-id mode is handled by setting the
+        # accelerator device index inside the worker process, NOT via
+        # CUDA_VISIBLE_DEVICES. Setting CUDA_VISIBLE_DEVICES would break
+        # logical_device_id_to_visible_device_id(), which expects PyTorch
+        # device indices, not NVML physical indices.
+        #
+        # The worker selects assigned_physical_gpu_ids[local_rank] as its own
+        # device, so each worker uses the correct GPU regardless of what is
+        # visible in CUDA_VISIBLE_DEVICES.
+
+        # Configure NCCL for multi-rank-per-GPU if duplicates detected
+        assigned_ids = vllm_config.parallel_config.assigned_physical_gpu_ids
+        if assigned_ids is not None and len(assigned_ids) != len(set(assigned_ids)):
+            from collections import Counter
+
+            os.environ["NCCL_MULTI_RANK_GPU_ENABLE"] = "1"
+            os.environ["NCCL_NVLS_ENABLE"] = "0"
+            gpu_counts = Counter(assigned_ids)
+            max_colocated = max(gpu_counts.values())
+            if max_colocated > 1:
+                suggested_max_ctas = max(1, 8 // max_colocated)
+                os.environ.setdefault("NCCL_MAX_CTAS", str(suggested_max_ctas))
+            logger.warning_once(
+                "Detected multiple ranks sharing physical GPUs. "
+                "Setting NCCL_MULTI_RANK_GPU_ENABLE=1, NCCL_NVLS_ENABLE=0, "
+                "NCCL_MAX_CTAS=%s for multi-rank-per-GPU.",
+                os.environ.get("NCCL_MAX_CTAS", "default"),
+            )
+            # Without CUDA MPS, processes sharing a GPU are TIME-SLICED:
+            # their kernels never run concurrently, but NCCL collectives
+            # busy-spin waiting for the peer rank. Observed impact on this
+            # feature during development was well over an order of
+            # magnitude in achievable decode throughput.
+            mps_pipe_dir = os.environ.get("CUDA_MPS_PIPE_DIRECTORY", "/tmp/nvidia-mps")
+            if not os.path.exists(mps_pipe_dir):
+                logger.warning_once(
+                    "Multiple ranks share a physical GPU but the CUDA MPS "
+                    "control pipe (%s) was not found. Without MPS, co-located "
+                    "ranks are time-sliced and NCCL collectives become "
+                    "extremely slow (>20x slowdown). Start MPS with "
+                    "'nvidia-cuda-mps-control -d' before launching vLLM.",
+                    mps_pipe_dir,
+                )
         # Run EngineCore busy loop in background process.
         proc = context.Process(
             target=WorkerProc.worker_main,

--- a/vllm/v1/spec_decode/utils.py
+++ b/vllm/v1/spec_decode/utils.py
@@ -38,6 +38,10 @@ def eagle_step_slot_mapping_metadata_kernel(
     n_blocks_per_req: tl.constexpr,
     PAD_ID: tl.constexpr,
     batch_size,
+    CP_RANK_RATIO: tl.constexpr,
+    CP_RANK_PREFIX: tl.constexpr,
+    CP_SPLIT_FACTOR: tl.constexpr,
+    CP_INTERLEAVE: tl.constexpr,
 ):
     """
     Fused kernel for EAGLE autoregressive step: updates positions, slot mapping,
@@ -65,14 +69,30 @@ def eagle_step_slot_mapping_metadata_kernel(
     exceeds_max = new_position >= max_model_len
     clamped_position = tl.where(exceeds_max, 0, new_position)
 
-    # Block table lookup: block_number = position // block_size
+    # Token-axis CP ownership (see _compute_slot_mapping_kernel in
+    # block_table.py): within every round of CP_SPLIT_FACTOR * interleave
+    # tokens this rank owns [prefix, prefix + ratio) * interleave. The
+    # no-CP case (ratio=1, prefix=0, split=1) reduces exactly to the
+    # classic block_number = pos // block_size formula.
+    virtual_block_size = block_size * CP_SPLIT_FACTOR
+    virtual_block = clamped_position // virtual_block_size
+    virtual_offset = clamped_position - virtual_block * virtual_block_size
+    segment = (virtual_offset // CP_INTERLEAVE) % CP_SPLIT_FACTOR
+    is_local = (segment >= CP_RANK_PREFIX) & (segment < CP_RANK_PREFIX + CP_RANK_RATIO)
+    local_offset = (
+        (virtual_offset // (CP_SPLIT_FACTOR * CP_INTERLEAVE))
+        * (CP_RANK_RATIO * CP_INTERLEAVE)
+        + (segment - CP_RANK_PREFIX) * CP_INTERLEAVE
+        + (virtual_offset % CP_INTERLEAVE)
+    )
+    local_offset = tl.where(is_local, local_offset, 0)
+    block_number = virtual_block * CP_RANK_RATIO + local_offset // block_size
     # Clamp block_number to avoid OOB when position is at max
-    block_number = clamped_position // block_size
     block_number = tl.minimum(block_number, n_blocks_per_req - 1)
 
     block_id = tl.load(block_table_ptr + req_idx * block_table_stride + block_number)
-    slot_id = block_id * block_size + (clamped_position % block_size)
-    slot_id = tl.where(exceeds_max, PAD_ID, slot_id)
+    slot_id = block_id * block_size + (local_offset % block_size)
+    slot_id = tl.where(exceeds_max | (is_local == 0), PAD_ID, slot_id)
 
     # Update seq_lens: +1 normally, or 1 if exceeded
     seq_len = tl.load(seq_lens_ptr + req_idx)
@@ -83,6 +103,27 @@ def eagle_step_slot_mapping_metadata_kernel(
     tl.store(out_clamped_positions_ptr + req_idx, clamped_position)
     tl.store(out_slot_mapping_ptr + req_idx, slot_id)
     tl.store(seq_lens_ptr + req_idx, new_seq_len)
+
+
+def _draft_cp_params() -> tuple[int, int, int, int]:
+    """(ratio, prefix, split_factor, interleave) of this rank's token-axis
+    share for draft KV writes under decode context parallelism; the
+    identity (1, 0, 1, 1) without DCP reduces the slot formulas exactly to
+    the classic pos // block_size form. Interleave is fixed to 1: MTP with
+    cp_kv_cache_interleave_size > 1 is rejected at startup
+    (check_attention_cp_compatibility)."""
+    try:
+        from vllm.distributed.parallel_state import get_dcp_group
+
+        group = get_dcp_group()
+    except (AssertionError, ImportError):
+        return 1, 0, 1, 1
+    if group.world_size <= 1:
+        return 1, 0, 1, 1
+    from vllm.distributed.utils import cp_rank_ratio_prefix
+
+    ratio, prefix, split = cp_rank_ratio_prefix(group.world_size, group.rank_in_group)
+    return ratio, prefix, split, 1
 
 
 def eagle_step_update_slot_mapping_and_metadata(
@@ -118,6 +159,7 @@ def eagle_step_update_slot_mapping_and_metadata(
         input_batch_size = batch_size
 
     n_blocks_per_req = block_table_tensor.shape[1]
+    cp_ratio, cp_prefix, cp_split, cp_interleave = _draft_cp_params()
     eagle_step_slot_mapping_metadata_kernel[(input_batch_size,)](
         positions_1d,
         block_table_tensor,
@@ -130,6 +172,10 @@ def eagle_step_update_slot_mapping_and_metadata(
         n_blocks_per_req=n_blocks_per_req,
         PAD_ID=PADDING_SLOT_ID,
         batch_size=batch_size,
+        CP_RANK_RATIO=cp_ratio,
+        CP_RANK_PREFIX=cp_prefix,
+        CP_SPLIT_FACTOR=cp_split,
+        CP_INTERLEAVE=cp_interleave,
     )
 
 
@@ -256,12 +302,39 @@ def compute_new_slot_mapping(
     # Clamp the positions to prevent an out-of-bounds error when indexing
     # into block_table_tensor.
     clamped_positions = torch.clamp(new_positions, max=max_model_len - 1)
-    block_table_indices = (
-        req_indices * n_blocks_per_req + clamped_positions // block_size
-    )
-    block_nums = cad.block_table_tensor.view(-1)[block_table_indices]
-    block_offsets = clamped_positions % block_size
-    new_slot_mapping = block_nums * block_size + block_offsets
+    cp_ratio, cp_prefix, cp_split, cp_interleave = _draft_cp_params()
+    if cp_split > 1:
+        # Token-axis CP: this rank stores only its share of the tokens;
+        # block-table columns are its local pages (cp_ratio per virtual
+        # block). Mirrors _compute_slot_mapping_kernel in block_table.py.
+        virtual_block_size = block_size * cp_split
+        virtual_block = clamped_positions // virtual_block_size
+        virtual_offset = clamped_positions - virtual_block * virtual_block_size
+        segment = (virtual_offset // cp_interleave) % cp_split
+        is_local = (segment >= cp_prefix) & (segment < cp_prefix + cp_ratio)
+        local_offset = (
+            (virtual_offset // (cp_split * cp_interleave)) * (cp_ratio * cp_interleave)
+            + (segment - cp_prefix) * cp_interleave
+            + (virtual_offset % cp_interleave)
+        )
+        local_offset = torch.where(
+            is_local, local_offset, torch.zeros_like(local_offset)
+        )
+        block_table_indices = (
+            req_indices * n_blocks_per_req
+            + virtual_block * cp_ratio
+            + local_offset // block_size
+        )
+        block_nums = cad.block_table_tensor.view(-1)[block_table_indices]
+        new_slot_mapping = block_nums * block_size + local_offset % block_size
+        new_slot_mapping.masked_fill_(~is_local, PADDING_SLOT_ID)
+    else:
+        block_table_indices = (
+            req_indices * n_blocks_per_req + clamped_positions // block_size
+        )
+        block_nums = cad.block_table_tensor.view(-1)[block_table_indices]
+        block_offsets = clamped_positions % block_size
+        new_slot_mapping = block_nums * block_size + block_offsets
     # Mask out the position ids that exceed the max model length.
     exceeds_max_model_len = new_positions >= max_model_len
     new_slot_mapping.masked_fill_(exceeds_max_model_len, PADDING_SLOT_ID)

--- a/vllm/v1/worker/block_table.py
+++ b/vllm/v1/worker/block_table.py
@@ -8,6 +8,7 @@ import numpy as np
 import torch
 
 from vllm.distributed import get_dcp_group, get_pcp_group
+from vllm.distributed.utils import cp_rank_ratio_prefix
 from vllm.logger import init_logger
 from vllm.triton_utils import tl, triton
 from vllm.utils.math_utils import cdiv
@@ -57,6 +58,7 @@ class BlockTable:
         kernel_block_size: int,
         cp_kv_cache_interleave_size: int,
         slot_mapping_mode: SlotMappingMode = SlotMappingMode.TOKEN_TO_KV_SLOT,
+        cp_split: bool = True,
     ):
         """
         Args:
@@ -72,12 +74,47 @@ class BlockTable:
             slot_mapping_mode: How this cache group maps scheduled tokens to
                 cache slots. Mamba-like state caches do not use token slot
                 mappings and should use SlotMappingMode.NONE.
+            cp_split: Whether this KV cache group is split along the token
+                axis under context parallelism. Mamba/linear-attention
+                groups keep their full per-sequence state on every rank
+                and must pass False.
         """
         self.max_num_reqs = max_num_reqs
         self.max_num_batched_tokens = max_num_batched_tokens
         self.pin_memory = pin_memory
         self.device = device
         self.kv_cache_block_size = block_size
+
+        try:
+            self.pcp_world_size = get_pcp_group().world_size
+            self.pcp_rank = get_pcp_group().rank_in_group
+        except AssertionError:
+            # PCP might not be initialized in testing
+            self.pcp_world_size = 1
+            self.pcp_rank = 0
+        try:
+            self.dcp_world_size = get_dcp_group().world_size
+            self.dcp_rank = get_dcp_group().rank_in_group
+        except AssertionError:
+            # DCP might not be initialized in testing
+            self.dcp_world_size = 1
+            self.dcp_rank = 0
+        self.cp_kv_cache_interleave_size = cp_kv_cache_interleave_size
+
+        # Token-axis split parameters of this rank: within every round of
+        # (split_factor * interleave) tokens, this rank owns the segment
+        # [prefix * interleave, (prefix + ratio) * interleave). The even
+        # split is the special case (ratio=1, prefix=dcp_rank,
+        # split_factor=dcp_world_size); uneven DCP takes the values from
+        # --rank-tp-ratio.
+        if not cp_split:
+            self.cp_rank_ratio, self.cp_rank_prefix, self.cp_split_factor = 1, 0, 1
+        else:
+            (
+                self.cp_rank_ratio,
+                self.cp_rank_prefix,
+                self.cp_split_factor,
+            ) = cp_rank_ratio_prefix(self.dcp_world_size, self.dcp_rank)
 
         if kernel_block_size == block_size:
             # Standard case: allocation and computation use same block size
@@ -100,6 +137,17 @@ class BlockTable:
             self.blocks_per_kv_block = block_size // kernel_block_size
             self.use_hybrid_blocks = True
 
+        if self.cp_rank_ratio > 1:
+            # Uneven DCP: the scheduler allocates "virtual" blocks spanning
+            # block_size * cp_split_factor tokens; this rank owns a
+            # contiguous superblock of cp_rank_ratio physical blocks per
+            # virtual block. Reuse the kernel-block expansion to map each
+            # scheduler block ID to its cp_rank_ratio physical block IDs,
+            # so attention backends see a dense, ordinary per-rank block
+            # table of the locally stored tokens.
+            self.blocks_per_kv_block *= self.cp_rank_ratio
+            self.use_hybrid_blocks = True
+
         self.max_num_blocks_per_req = max_num_blocks_per_req * self.blocks_per_kv_block
 
         self.block_table = self._make_buffer(
@@ -118,21 +166,6 @@ class BlockTable:
         else:
             self._kernel_block_arange = None
 
-        try:
-            self.pcp_world_size = get_pcp_group().world_size
-            self.pcp_rank = get_pcp_group().rank_in_group
-        except AssertionError:
-            # PCP might not be initialized in testing
-            self.pcp_world_size = 1
-            self.pcp_rank = 0
-        try:
-            self.dcp_world_size = get_dcp_group().world_size
-            self.dcp_rank = get_dcp_group().rank_in_group
-        except AssertionError:
-            # DCP might not be initialized in testing
-            self.dcp_world_size = 1
-            self.dcp_rank = 0
-        self.cp_kv_cache_interleave_size = cp_kv_cache_interleave_size
         self.slot_mapping_mode = slot_mapping_mode
 
     def append_row(
@@ -203,8 +236,9 @@ class BlockTable:
             self.slot_mapping.gpu,
             KV_CACHE_BLOCK_SIZE=self.kv_cache_block_size,
             BLOCKS_PER_KV_BLOCK=self.blocks_per_kv_block,
-            TOTAL_CP_WORLD_SIZE=self.dcp_world_size,
-            TOTAL_CP_RANK=self.dcp_rank,
+            CP_RANK_RATIO=self.cp_rank_ratio,
+            CP_RANK_PREFIX=self.cp_rank_prefix,
+            CP_SPLIT_FACTOR=self.cp_split_factor,
             CP_KV_CACHE_INTERLEAVE_SIZE=self.cp_kv_cache_interleave_size,
             PAD_ID=PAD_SLOT_ID,
             BLOCK_SIZE=1024,
@@ -281,6 +315,7 @@ class MultiGroupBlockTable:
         max_num_blocks: list[int],
         cp_kv_cache_interleave_size: int = 1,
         slot_mapping_modes: list[SlotMappingMode] | None = None,
+        cp_split_per_group: list[bool] | None = None,
     ) -> None:
         if len(kernel_block_sizes) != len(block_sizes):
             raise ValueError(
@@ -292,6 +327,17 @@ class MultiGroupBlockTable:
         if len(slot_mapping_modes) != len(block_sizes):
             raise ValueError(
                 f"slot_mapping_modes length ({len(slot_mapping_modes)}) "
+                f"must match block_sizes length ({len(block_sizes)})"
+            )
+        if cp_split_per_group is None:
+            # Mamba/linear-attention groups keep their full per-sequence
+            # state on every rank - no token-axis split under CP.
+            cp_split_per_group = [
+                mode != SlotMappingMode.NONE for mode in slot_mapping_modes
+            ]
+        if len(cp_split_per_group) != len(block_sizes):
+            raise ValueError(
+                f"cp_split_per_group length ({len(cp_split_per_group)}) "
                 f"must match block_sizes length ({len(block_sizes)})"
             )
 
@@ -323,14 +369,20 @@ class MultiGroupBlockTable:
                 kernel_block_size,
                 cp_kv_cache_interleave_size,
                 slot_mapping_mode=slot_mapping_mode,
+                cp_split=cp_split,
             )
             for (
                 block_size,
                 kernel_block_size,
                 max_num_blocks_per_req,
                 slot_mapping_mode,
+                cp_split,
             ) in zip(
-                block_sizes, kernel_block_sizes, max_num_blocks, slot_mapping_modes
+                block_sizes,
+                kernel_block_sizes,
+                max_num_blocks,
+                slot_mapping_modes,
+                cp_split_per_group,
             )
         ]
 
@@ -388,8 +440,9 @@ def _compute_slot_mapping_kernel(
     slot_mapping_ptr,  # [max_num_tokens], int64
     KV_CACHE_BLOCK_SIZE: tl.constexpr,
     BLOCKS_PER_KV_BLOCK: tl.constexpr,
-    TOTAL_CP_WORLD_SIZE: tl.constexpr,
-    TOTAL_CP_RANK: tl.constexpr,
+    CP_RANK_RATIO: tl.constexpr,
+    CP_RANK_PREFIX: tl.constexpr,
+    CP_SPLIT_FACTOR: tl.constexpr,
     CP_KV_CACHE_INTERLEAVE_SIZE: tl.constexpr,
     PAD_ID: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
@@ -410,7 +463,7 @@ def _compute_slot_mapping_kernel(
     start_idx = tl.load(query_start_loc_ptr + req_idx).to(tl.int64)
     end_idx = tl.load(query_start_loc_ptr + req_idx + 1).to(tl.int64)
 
-    virtual_block_size = KV_CACHE_BLOCK_SIZE * TOTAL_CP_WORLD_SIZE
+    virtual_block_size = KV_CACHE_BLOCK_SIZE * CP_SPLIT_FACTOR
     row_offset = req_idx * block_table_stride
     for i in range(start_idx, end_idx, BLOCK_SIZE):
         offsets = i + tl.arange(0, BLOCK_SIZE)
@@ -418,14 +471,31 @@ def _compute_slot_mapping_kernel(
         pos = tl.load(positions_ptr + offsets, mask=mask, other=0)
         virtual_block_indices = pos // virtual_block_size
         virtual_block_offsets = pos - virtual_block_indices * virtual_block_size
-        is_local = (
+        # Token-axis ownership: within every round of
+        # CP_SPLIT_FACTOR * interleave tokens, this rank owns the segment
+        # [CP_RANK_PREFIX * interleave, (CP_RANK_PREFIX + CP_RANK_RATIO) *
+        # interleave). Even CP is the special case (ratio=1,
+        # prefix=dcp_rank, split=dcp_world_size) - the formulas below then
+        # reduce exactly to the classic round-robin mapping. Under uneven
+        # DCP the rank owns CP_RANK_RATIO physical blocks per virtual
+        # block, exposed as consecutive block-table columns via the
+        # blocks_per_kv_block expansion in BlockTable.
+        segment = (
             virtual_block_offsets // CP_KV_CACHE_INTERLEAVE_SIZE
-        ) % TOTAL_CP_WORLD_SIZE == TOTAL_CP_RANK
-        local_block_offsets = (
-            virtual_block_offsets // (TOTAL_CP_WORLD_SIZE * CP_KV_CACHE_INTERLEAVE_SIZE)
-        ) * CP_KV_CACHE_INTERLEAVE_SIZE + (
-            virtual_block_offsets % CP_KV_CACHE_INTERLEAVE_SIZE
+        ) % CP_SPLIT_FACTOR
+        is_local = (segment >= CP_RANK_PREFIX) & (
+            segment < CP_RANK_PREFIX + CP_RANK_RATIO
         )
+        local_block_offsets = (
+            (virtual_block_offsets // (CP_SPLIT_FACTOR * CP_KV_CACHE_INTERLEAVE_SIZE))
+            * (CP_RANK_RATIO * CP_KV_CACHE_INTERLEAVE_SIZE)
+            + (segment - CP_RANK_PREFIX) * CP_KV_CACHE_INTERLEAVE_SIZE
+            + (virtual_block_offsets % CP_KV_CACHE_INTERLEAVE_SIZE)
+        )
+        # Non-local tokens can yield negative offsets (segment < prefix);
+        # zero them so the derived column index stays non-negative (the
+        # loaded value is discarded via the is_local mask).
+        local_block_offsets = tl.where(is_local, local_block_offsets, 0)
 
         block_indices = (
             virtual_block_indices * BLOCKS_PER_KV_BLOCK

--- a/vllm/v1/worker/cp_utils.py
+++ b/vllm/v1/worker/cp_utils.py
@@ -6,7 +6,8 @@ from typing import TYPE_CHECKING, Any, cast
 import torch
 
 from vllm.config import VllmConfig, get_layers_from_vllm_config
-from vllm.distributed import get_dcp_group
+from vllm.distributed import get_dcp_group, get_pcp_group
+from vllm.distributed.utils import cp_token_split_factor
 from vllm.logger import init_logger
 from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.attention.backends.utils import split_decodes_prefills_and_extends
@@ -288,3 +289,20 @@ def run_split_fa2_dcp_context_attention(
         context_lse[:, prefill_start:prefill_end] = prefill_context_lse
 
     return dcp_context_out, context_lse
+
+
+def get_cp_token_split_factor() -> int:
+    """Number of block_size units one virtual scheduler block spans.
+
+    Equals get_total_cp_world_size() for the classic even split and
+    sum(--rank-tp-ratio) under uneven DCP.
+    """
+    try:
+        pcp_world_size = get_pcp_group().world_size
+    except AssertionError:
+        pcp_world_size = 1
+    try:
+        dcp_world_size = get_dcp_group().world_size
+    except AssertionError:
+        dcp_world_size = 1
+    return cp_token_split_factor(dcp_world_size, pcp_world_size)

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -105,6 +105,7 @@ class InputBatch:
         num_spec_tokens: int = 0,
         is_pooling_model: bool = False,
         cp_kv_cache_interleave_size: int = 1,
+        cp_split_per_group: list[bool] | None = None,
         reasoning_config: ReasoningConfig | None = None,
         use_replayssm: bool = False,
         slot_mapping_modes: list[SlotMappingMode] | None = None,
@@ -193,6 +194,7 @@ class InputBatch:
             max_num_blocks=max_num_blocks_per_req,
             cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
             slot_mapping_modes=slot_mapping_modes,
+            cp_split_per_group=cp_split_per_group,
         )
 
         # Sampling-related.

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -214,6 +214,7 @@ from vllm.v1.worker import mamba_utils
 from vllm.v1.worker.block_table import SlotMappingMode
 from vllm.v1.worker.cp_utils import (
     check_attention_cp_compatibility,
+    get_cp_token_split_factor,
     get_dcp_dummy_context_len,
     prepare_dcp_dummy_context_metadata,
 )
@@ -7292,6 +7293,7 @@ class GPUModelRunner(
         block_sizes = []
         max_num_blocks = []
         slot_mapping_modes = []
+        cp_split_per_group = []
         max_model_len = max(self.max_model_len, self.max_encoder_len)
         for kv_cache_group in kv_cache_config.kv_cache_groups:
             kv_cache_spec = kv_cache_group.kv_cache_spec
@@ -7304,9 +7306,26 @@ class GPUModelRunner(
                 slot_mapping_modes.append(SlotMappingMode.NONE)
             else:
                 slot_mapping_modes.append(SlotMappingMode.TOKEN_TO_KV_SLOT)
-            max_num_blocks_per_req = kv_cache_spec.max_num_blocks_per_req(
-                self.vllm_config, max_model_len
+            # Mamba/linear-attention groups keep their full per-sequence
+            # state on every rank - no token-axis split under CP.
+            cp_split = not isinstance(kv_cache_group.kv_cache_spec, MambaSpec)
+            cp_split_per_group.append(cp_split)
+            ratios = self.parallel_config.rank_tp_ratio
+            uneven_dcp = (
+                bool(ratios)
+                and self.parallel_config.decode_context_parallel_size > 1
+                and len(set(ratios)) > 1
             )
+            if cp_split and uneven_dcp:
+                # Virtual scheduler blocks span
+                # block_size * sum(--rank-tp-ratio) tokens.
+                max_num_blocks_per_req = cdiv(
+                    max_model_len, block_size * get_cp_token_split_factor()
+                )
+            else:
+                max_num_blocks_per_req = kv_cache_spec.max_num_blocks_per_req(
+                    self.vllm_config, max_model_len
+                )
             max_num_blocks.append(max_num_blocks_per_req)
 
         if (
@@ -7328,6 +7347,7 @@ class GPUModelRunner(
                 block_sizes=block_sizes,
                 kernel_block_sizes=kernel_block_sizes,
                 max_num_blocks_per_req=max_num_blocks,
+                cp_split_per_group=cp_split_per_group,
                 num_spec_tokens=self.num_spec_tokens,
                 logitsprocs=self.input_batch.logitsprocs,
                 logitsprocs_need_output_token_ids=self.input_batch.logitsprocs_need_output_token_ids,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -546,6 +546,9 @@ class GPUModelRunner(
             logprobs_mode=self.model_config.logprobs_mode,
             use_fp64_gumbel=self.model_config.use_fp64_gumbel,
         )
+        # Lazily detected in _hetero_tp_active(): TP ranks on differing GPU
+        # models (--rank-gpu-id) need sampled/draft ids broadcast from rank 0.
+        self._hetero_tp: bool | None = None
 
         self.eplb_state: EplbState | None = None
         self._moe_model: MixtureOfExperts | None = None
@@ -3689,6 +3692,42 @@ class GPUModelRunner(
             ec_connector_output,
         )
 
+    def _hetero_tp_active(self) -> bool:
+        """True if TP ranks run on different GPU models (only possible with
+        --rank-gpu-id). vLLM samples redundantly on every TP rank and relies
+        on bitwise-identical logits across ranks; different architectures
+        (kernel selection, reduction order) break that, so near-tie sampling
+        decisions can diverge between ranks and silently corrupt generation.
+        Detected once via an all-gather of device names over the TP CPU
+        group; all ranks call this at the same point in _sample."""
+        if self._hetero_tp is None:
+            tp = get_tp_group()
+            if (
+                tp.world_size == 1
+                or self.parallel_config.assigned_physical_gpu_ids is None
+            ):
+                self._hetero_tp = False
+            else:
+                names: list[str | None] = [None] * tp.world_size
+                torch.distributed.all_gather_object(
+                    names, torch.cuda.get_device_name(), group=tp.cpu_group
+                )
+                self._hetero_tp = len(set(names)) > 1
+                if self._hetero_tp and tp.rank_in_group == 0:
+                    logger.info(
+                        "Heterogeneous TP detected (%s): broadcasting "
+                        "sampled/draft token ids from rank 0 to keep "
+                        "rank states identical.",
+                        ", ".join(sorted(set(str(n) for n in names))),
+                    )
+        return self._hetero_tp
+
+    def _sync_token_ids_across_tp(self, token_ids: torch.Tensor) -> None:
+        """Broadcast token ids from TP rank 0 so all ranks continue with
+        identical sequences (heterogeneous TP only; a few KiB per step)."""
+        if self._hetero_tp_active():
+            get_tp_group().broadcast(token_ids, src=0)
+
     def _sample(
         self,
         logits: torch.Tensor | None,
@@ -3700,10 +3739,12 @@ class GPUModelRunner(
         # if async scheduling and required by current sampling params.
         self.input_batch.update_async_output_token_ids()
         if spec_decode_metadata is None:
-            return self.sampler(
+            sampler_output = self.sampler(
                 logits=logits,
                 sampling_metadata=sampling_metadata,
             )
+            self._sync_token_ids_across_tp(sampler_output.sampled_token_ids)
+            return sampler_output
 
         # Update spec_token_ids with real draft tokens from pre step only when
         # output_token_ids is needed (penalties or bad_words are in use).
@@ -3718,6 +3759,7 @@ class GPUModelRunner(
             logits,
             sampling_metadata,
         )
+        self._sync_token_ids_across_tp(sampler_output.sampled_token_ids)
         return sampler_output
 
     def _bookkeeping_sync(
@@ -4622,6 +4664,10 @@ class GPUModelRunner(
                     spec_decode_common_attn_metadata,
                     slot_mappings,
                 )
+                # Heterogeneous TP: draft proposals are sampled per rank
+                # and must stay identical across ranks like sampled ids.
+                if isinstance(self._draft_token_ids, torch.Tensor):
+                    self._sync_token_ids_across_tp(self._draft_token_ids)
                 self._copy_draft_token_ids_to_cpu(scheduler_output)
 
         spec_config = self.speculative_config

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -61,6 +61,7 @@ from vllm.tasks import SupportedTask
 from vllm.tracing import instrument
 from vllm.utils.gc_utils import freeze_gc_heap, maybe_attach_gc_debug_callback
 from vllm.utils.gpu_sync_debug import enable_gpu_sync_check, with_gpu_sync_check
+from vllm.utils.import_utils import import_pynvml
 from vllm.utils.mem_constants import GiB_bytes
 from vllm.utils.mem_utils import MemorySnapshot, format_gib, memory_profiling
 from vllm.utils.torch_utils import set_random_seed
@@ -355,15 +356,70 @@ class Worker(WorkerBase):
                         " exceeds assigned_physical_gpu_ids count "
                         f"({len(assigned_physical_gpu_ids)})"
                     )
+
+                # Convert the absolute --rank-gpu-memory-mib value to a
+                # per-rank fraction. The same MiB value maps to a different
+                # fraction depending on which physical GPU this rank landed
+                # on (heterogeneous setups can mix different VRAM sizes).
+                rank_gpu_memory_mib = parallel_config.rank_gpu_memory_mib
+                if rank_gpu_memory_mib is not None:
+                    torch_cuda_idx = assigned_physical_gpu_ids[self.local_rank]
+                    # Map torch.cuda index to NVML physical index for memory query
+                    # torch.cuda and NVML enumerate GPUs in different orders
+                    from vllm.platforms.cuda import CudaPlatform
+
+                    torch_to_nvml = CudaPlatform.get_torch_to_nvml_mapping()
+                    if torch_cuda_idx in torch_to_nvml:
+                        nvml_idx = torch_to_nvml[torch_cuda_idx]
+                    else:
+                        nvml_idx = torch_cuda_idx  # Fallback
+                    # Query NVML directly (bypasses device_id_to_physical_device_id).
+                    pynvml = import_pynvml()
+                    pynvml.nvmlInit()
+                    handle = pynvml.nvmlDeviceGetHandleByIndex(nvml_idx)
+                    nvml_total_bytes = pynvml.nvmlDeviceGetMemoryInfo(handle).total
+                    pynvml.nvmlShutdown()
+                    nvml_total_mib = nvml_total_bytes // (1024 * 1024)
+                    # CRITICAL: do not apply any additional percentage
+                    # reduction here. This is the rank's entire memory
+                    # budget on this GPU - 100% of the assigned MiB value,
+                    # not a fraction of it subject to further discounting.
+                    fraction = rank_gpu_memory_mib / nvml_total_mib
+                    logger.info(
+                        "Rank %d on torch.cuda:%d (NVML:%d): Using "
+                        "--rank-gpu-memory-mib=%d MiB "
+                        "(%s/%s GiB total = %.4f fraction)",
+                        self.rank,
+                        torch_cuda_idx,
+                        nvml_idx,
+                        rank_gpu_memory_mib,
+                        format_gib(rank_gpu_memory_mib * 1024 * 1024),
+                        format_gib(nvml_total_bytes),
+                        fraction,
+                    )
+                    # Store the fraction in cache_config for downstream use
+                    # (request_memory, determine_available_memory).
+                    self.cache_config.gpu_memory_utilization = fraction
+                    # Keep the NVML index around for per-process memory
+                    # accounting in determine_available_memory().
+                    self._rank_gpu_nvml_idx = nvml_idx
             else:
                 assert self.local_rank < torch.accelerator.device_count(), (
                     f"DP adjusted local rank {self.local_rank} is out of "
                     f"bounds for {torch.accelerator.device_count()} devices."
                 )
 
-            visible_device_index = (
-                current_platform.logical_device_id_to_visible_device_id(self.local_rank)
-            )
+            # Device isolation via --rank-gpu-id: each worker uses the torch.cuda
+            # index from assigned_physical_gpu_ids. This is the actual GPU device.
+            if parallel_config.rank_gpu_memory_mib is not None:
+                torch_cuda_idx = assigned_physical_gpu_ids[self.local_rank]
+                visible_device_index = torch_cuda_idx
+            else:
+                visible_device_index = (
+                    current_platform.logical_device_id_to_visible_device_id(
+                        self.local_rank
+                    )
+                )
             self.device = torch.device(f"cuda:{visible_device_index}")
             torch.accelerator.set_device_index(self.device)
 
@@ -495,6 +551,41 @@ class Worker(WorkerBase):
                 getattr(self.parallel_config, "_api_process_count", 1),
             )
 
+        # When multiple ranks share a physical GPU (via --rank-gpu-id), they
+        # execute determine_available_memory() concurrently. The default
+        # profiling path measures memory via the driver's mem_get_info, which
+        # is GPU-GLOBAL: each rank would see the other co-located rank's
+        # allocations (weights, activations, CUDA graphs) as its own
+        # "non-torch" overhead, roughly doubling non_kv_cache_memory and
+        # producing negative available-KV-cache estimates.
+        #
+        # NOTE: Serializing the profiling with a barrier is NOT possible:
+        # profile_run() executes a forward pass containing TP collectives
+        # (all-reduce), so ALL ranks must run it simultaneously - holding
+        # back one rank deadlocks the whole TP group.
+        #
+        # Solution: for co-located ranks, replace the mem_get_info-based
+        # non-torch measurement with a PER-PROCESS measurement from NVML
+        # (nvmlDeviceGetComputeRunningProcesses), which reports each
+        # process's own GPU memory usage independently.
+        assigned_ids = self.vllm_config.parallel_config.assigned_physical_gpu_ids
+        co_located_count = 1
+        if (
+            assigned_ids is not None
+            and self.vllm_config.parallel_config.rank_gpu_memory_mib is not None
+        ):
+            physical_gpu_id = assigned_ids[self.local_rank]
+            co_located_count = sum(1 for gid in assigned_ids if gid == physical_gpu_id)
+            if co_located_count > 1:
+                logger.info(
+                    "Rank %d shares torch.cuda:%d with %d ranks total; using "
+                    "per-process NVML memory accounting instead of global "
+                    "mem_get_info for KV cache sizing.",
+                    self.local_rank,
+                    physical_gpu_id,
+                    co_located_count,
+                )
+
         # Execute a forward pass with dummy inputs to profile the memory usage
         # of the model.
         with memory_profiling(
@@ -516,6 +607,58 @@ class Worker(WorkerBase):
         ):
             cudagraph_memory_estimate = self.model_runner.profile_cudagraph_memory()
 
+        if co_located_count > 1:
+            # Replace the polluted GPU-global measurement with a per-process
+            # one: total_consumed comes from mem_get_info(), which would
+            # count a co-located peer's allocations as ours. NVML reports
+            # this process's own GPU memory; subtracting torch's reserved
+            # pool leaves the true non-torch overhead (CUDA context, NCCL
+            # buffers, cuBLAS workspaces, ...).
+            nvml_idx = getattr(self, "_rank_gpu_nvml_idx", None)
+            my_pid = os.getpid()
+            proc_used_bytes = 0
+            if nvml_idx is not None:
+                pynvml = import_pynvml()
+                pynvml.nvmlInit()
+                try:
+                    handle = pynvml.nvmlDeviceGetHandleByIndex(nvml_idx)
+                    for proc in pynvml.nvmlDeviceGetComputeRunningProcesses(handle):
+                        if proc.pid == my_pid and proc.usedGpuMemory is not None:
+                            proc_used_bytes = proc.usedGpuMemory
+                            break
+                finally:
+                    pynvml.nvmlShutdown()
+            torch_reserved = torch.accelerator.memory_reserved(self.device)
+            non_torch_local = max(0, proc_used_bytes - torch_reserved)
+            # CUDA graph estimates via mem_get_info are also polluted by the
+            # co-located rank (can even go negative); clamp to non-negative.
+            cudagraph_memory_estimate = max(0, cudagraph_memory_estimate)
+            logger.info(
+                "Co-located memory accounting (rank %d, pid %d, NVML:%s): "
+                "nvml_proc_used=%s GiB, torch_reserved=%s GiB, "
+                "non_torch_local=%s GiB (global measurement was %s GiB), "
+                "weights=%s GiB, torch_peak_increase=%s GiB, "
+                "cudagraph_estimate=%s GiB, budget=%s GiB",
+                self.local_rank,
+                my_pid,
+                nvml_idx,
+                format_gib(proc_used_bytes),
+                format_gib(torch_reserved),
+                format_gib(non_torch_local),
+                format_gib(profile_result.non_torch_increase),
+                format_gib(profile_result.weights_memory),
+                format_gib(profile_result.torch_peak_increase),
+                format_gib(cudagraph_memory_estimate),
+                format_gib(self.requested_memory),
+            )
+            profile_result.non_torch_increase = non_torch_local
+            profile_result.total_consumed = proc_used_bytes
+            profile_result.non_kv_cache_memory = (
+                non_torch_local
+                + profile_result.torch_peak_increase
+                + profile_result.weights_memory
+            )
+
         # Respect the opt-in flag as originally designed.
         cudagraph_memory_estimate_applied = (
             cudagraph_memory_estimate
@@ -532,7 +675,11 @@ class Worker(WorkerBase):
         free_gpu_memory = profile_result.after_profile.free_memory
         # NOTE(woosuk): Here we assume that the other processes using the same
         # GPU did not change their memory usage during the profiling.
-        assert self.init_snapshot.free_memory >= free_gpu_memory, (
+        # With --rank-gpu-id co-location this assumption does not hold (the
+        # co-located rank allocates/frees concurrently), so skip the check.
+        assert co_located_count > 1 or (
+            self.init_snapshot.free_memory >= free_gpu_memory
+        ), (
             "Error in memory profiling. "
             f"Initial free memory {format_gib(self.init_snapshot.free_memory)} GiB, "
             f"current free memory {format_gib(free_gpu_memory)} GiB. "

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -306,9 +306,16 @@ class Worker(WorkerBase):
         # Uneven TP: install the ratio vector process-globally BEFORE any
         # layer computes shard sizes - independent of device backend paths.
         if self.vllm_config.parallel_config.rank_tp_ratio is not None:
-            from vllm.distributed.utils import set_tp_partition_ratios
+            from vllm.distributed.utils import (
+                resolve_cp_token_ratios,
+                set_cp_token_ratios,
+                set_tp_partition_ratios,
+            )
 
             set_tp_partition_ratios(self.vllm_config.parallel_config.rank_tp_ratio)
+            # Uneven DCP: token-axis vector (v4: GDN k-head partition for
+            # hybrids, raw weights for dense models).
+            set_cp_token_ratios(resolve_cp_token_ratios(self.vllm_config))
             logger.info(
                 "Uneven TP active: rank %d owns ratio %d/%d of every "
                 "sharded dimension.",

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -303,6 +303,19 @@ class Worker(WorkerBase):
 
     @instrument(span_name="Init device")
     def init_device(self):
+        # Uneven TP: install the ratio vector process-globally BEFORE any
+        # layer computes shard sizes - independent of device backend paths.
+        if self.vllm_config.parallel_config.rank_tp_ratio is not None:
+            from vllm.distributed.utils import set_tp_partition_ratios
+
+            set_tp_partition_ratios(self.vllm_config.parallel_config.rank_tp_ratio)
+            logger.info(
+                "Uneven TP active: rank %d owns ratio %d/%d of every "
+                "sharded dimension.",
+                self.rank,
+                self.vllm_config.parallel_config.rank_tp_ratio[self.rank],
+                sum(self.vllm_config.parallel_config.rank_tp_ratio),
+            )
         if self.device_config.device_type == "cuda":
             # This env var set by Ray causes exceptions with graph building.
             os.environ.pop("NCCL_ASYNC_ERROR_HANDLING", None)
@@ -362,6 +375,11 @@ class Worker(WorkerBase):
                 # fraction depending on which physical GPU this rank landed
                 # on (heterogeneous setups can mix different VRAM sizes).
                 rank_gpu_memory_mib = parallel_config.rank_gpu_memory_mib
+                if isinstance(rank_gpu_memory_mib, list):
+                    # Per-node list; with pure single-node TP (enforced)
+                    # local_rank == rank, kept consistent with
+                    # assigned_physical_gpu_ids indexing below.
+                    rank_gpu_memory_mib = rank_gpu_memory_mib[self.local_rank]
                 if rank_gpu_memory_mib is not None:
                     torch_cuda_idx = assigned_physical_gpu_ids[self.local_rank]
                     # Map torch.cuda index to NVML physical index for memory query


### PR DESCRIPTION
> Stacked on #50735 (which is itself stacked on #50733). Only the top commit is new here.

## What

Lets decode context parallelism split the token axis proportionally across ranks instead of assuming equal shares, so DCP can be used on the same mismatched GPUs that `--rank-tp-ratio` targets. It activates only when a rank ratio vector is configured; the even-split CP/DCP path is untouched otherwise.

## Motivation

DCP currently gives each CP rank the same number of KV tokens. Combined with uneven TP shards that is the wrong pairing: the rank holding the largest weight shard also has the least memory left for KV, so the shared pool ends up pinned by the smallest capacity and the surplus on the other ranks is unusable.

## How

- `vllm/v1/attention/ops/dcp_alltoall.py` (new): a fused uneven all-to-all combine for the CP output gather, replacing separate gather/reduce steps.
- FlashAttention and FlashInfer backends: per-rank KV metadata and LSE correction accept unequal rank shares.
- KV-cache coordinator, single-type KV-cache manager and `block_table`: per-rank capacity is derived from the rank's assigned share instead of an even split.
- Hybrid GDN/mamba models: mamba state groups are kept out of the token-axis split — they are replicated, not sharded — with prefix caching kept coherent under the uneven layout.
- Scheduler batching decisions follow the per-rank uneven KV capacity.
- The token vector itself is derived from each rank's estimated free-for-KV memory. `VLLM_UNEVEN_TOKEN_VECTOR` (registered in `vllm/envs.py`) overrides it with a measured vector; when the resulting per-worker block counts are more than 15% apart, a warning prints the vector that would equalise them on the next start.

## Verification

Run against this branch:

- `pytest tests/distributed/test_uneven_dcp_split.py` — 46 passed (new file, CPU only).
- `pytest tests/distributed/test_uneven_tp_partition.py tests/engine/test_rank_gpu_mapping.py` — 24 passed.
- `pytest tests/v1/core/test_kv_cache_utils.py tests/engine/test_arg_utils.py` — passed. `_grouping_config()` in `test_kv_cache_utils.py` gained a `parallel_config` stub: the grouping path now consults the rank ratio vector, and the existing fixture was a `SimpleNamespace` without that attribute.
- `ruff check` / `ruff format --check` plus the repo's `check_spdx_header`, `check_init_lazy_imports`, `check_forbidden_imports`, `check_torch_cuda`, `check_boolean_context_manager` and `validate_config` hooks.

## Limits

- Only reachable with a rank ratio vector set and `decode_context_parallel_size > 1`; without that the code returns early and nothing changes.
- The hybrid path is implemented for the Qwen3.5/3.6 GDN models.
- The token vector is an estimate at startup; the re-tuning warning exists precisely because the first choice can be off. Getting it right in one pass is not claimed.
- Multi-GPU end-to-end validation was done earlier on my own hardware and is not re-run for this PR. Everything reported above is CPU-only.
