### PR TITLE
[Spec Decode][Perf] Optimize DSpark Markov head with addmm

### DIFF
--- a/benchmarks/kernels/benchmark_dspark_markov_head.py
+++ b/benchmarks/kernels/benchmark_dspark_markov_head.py
@@ -1,0 +1,379 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Benchmark DSpark's sequential Markov-head sampling loop.
+
+The baseline materializes the Markov bias before adding it to request-major
+draft backbone logits. The two addmm variants model DSpark's step-major
+sampling layout and use either out-of-place ``addmm`` or in-place ``addmm_``.
+All variants include the embedding and argmax dependency between speculative
+positions. Logit-buffer resets model a fresh LM-head output and occur outside
+the measured interval.
+
+Example:
+
+.. code-block:: console
+
+    .venv/bin/python benchmarks/kernels/benchmark_dspark_markov_head.py \
+        --batch-sizes 1 2 4 8 16 32 64 --output results.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+DTYPES = {
+    "bfloat16": torch.bfloat16,
+    "float16": torch.float16,
+}
+
+
+@dataclass
+class BenchmarkRunner:
+    run: Callable[[], torch.Tensor]
+    reset: Callable[[], None]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--batch-sizes", type=int, nargs="+", default=[1, 2, 4, 8])
+    parser.add_argument("--vocab-size", type=int, default=163840)
+    parser.add_argument("--markov-rank", type=int, default=256)
+    parser.add_argument("--num-speculative-tokens", type=int, default=7)
+    parser.add_argument("--dtype", choices=DTYPES, default="bfloat16")
+    parser.add_argument(
+        "--mode", choices=("eager", "cudagraph", "both"), default="both"
+    )
+    parser.add_argument("--warmups", type=int, default=20)
+    parser.add_argument("--samples", type=int, default=51)
+    parser.add_argument("--replays-per-sample", type=int, default=10)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def percentile(samples: Sequence[float], fraction: float) -> float:
+    ordered = sorted(samples)
+    position = fraction * (len(ordered) - 1)
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    upper_weight = position - lower
+    return ordered[lower] * (1.0 - upper_weight) + ordered[upper] * upper_weight
+
+
+def summarize(samples_us: Sequence[float]) -> dict[str, Any]:
+    mean_us = statistics.mean(samples_us)
+    return {
+        "median_us": statistics.median(samples_us),
+        "p10_us": percentile(samples_us, 0.1),
+        "p90_us": percentile(samples_us, 0.9),
+        "mean_us": mean_us,
+        "cv_pct": statistics.pstdev(samples_us) / mean_us * 100.0,
+        "samples_us": list(samples_us),
+    }
+
+
+def make_inputs(
+    batch_size: int,
+    vocab_size: int,
+    markov_rank: int,
+    num_speculative_tokens: int,
+    dtype: torch.dtype,
+    seed: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(seed)
+    padded_vocab_size = math.ceil(vocab_size / 64) * 64
+    base_logits = torch.randn(
+        (batch_size, num_speculative_tokens, vocab_size),
+        dtype=dtype,
+        device="cuda",
+        generator=generator,
+    )
+    markov_w1 = torch.randn(
+        (vocab_size, markov_rank),
+        dtype=dtype,
+        device="cuda",
+        generator=generator,
+    )
+    markov_w2 = torch.randn(
+        (padded_vocab_size, markov_rank),
+        dtype=dtype,
+        device="cuda",
+        generator=generator,
+    )
+    anchors = torch.randint(
+        vocab_size,
+        (batch_size,),
+        dtype=torch.int64,
+        device="cuda",
+        generator=generator,
+    )
+    return base_logits, markov_w1, markov_w2, anchors
+
+
+def make_runner(
+    implementation: str,
+    base_logits: torch.Tensor,
+    markov_w1: torch.Tensor,
+    markov_w2: torch.Tensor,
+    anchors: torch.Tensor,
+) -> BenchmarkRunner:
+    vocab_size = base_logits.shape[-1]
+    num_speculative_tokens = base_logits.shape[1]
+
+    if implementation == "baseline":
+        pristine_logits = base_logits
+        working_logits = torch.empty_like(pristine_logits)
+
+        def runner() -> torch.Tensor:
+            previous = anchors
+            for step in range(num_speculative_tokens):
+                markov_embed = F.embedding(previous, markov_w1)
+                bias = F.linear(markov_embed, markov_w2)[..., :vocab_size]
+                logits = working_logits[:, step] + bias
+                previous = logits.argmax(dim=-1)
+            return previous
+
+    elif implementation in ("addmm", "addmm_inplace"):
+        # Production obtains this layout by writing DSpark's sample indices in
+        # step-major order before the LM head. The one-time conversion here is
+        # benchmark setup and deliberately outside the timed sequential loop.
+        pristine_logits = base_logits.transpose(0, 1).contiguous()
+        working_logits = torch.empty_like(pristine_logits)
+
+        def runner() -> torch.Tensor:
+            previous = anchors
+            for step in range(num_speculative_tokens):
+                markov_embed = F.embedding(previous, markov_w1)
+                if implementation == "addmm":
+                    logits = torch.addmm(
+                        working_logits[step],
+                        markov_embed,
+                        markov_w2[:vocab_size].t(),
+                    )
+                else:
+                    logits = working_logits[step].addmm_(
+                        markov_embed,
+                        markov_w2[:vocab_size].t(),
+                    )
+                previous = logits.argmax(dim=-1)
+            return previous
+
+    else:
+        raise ValueError(f"Unknown implementation: {implementation}")
+
+    def reset() -> None:
+        working_logits.copy_(pristine_logits)
+
+    return BenchmarkRunner(runner, reset)
+
+
+def capture_runner(
+    runner: BenchmarkRunner,
+) -> tuple[torch.cuda.CUDAGraph, torch.Tensor]:
+    for _ in range(3):
+        runner.reset()
+        output = runner.run()
+    torch.accelerator.synchronize()
+
+    runner.reset()
+    torch.accelerator.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        output = runner.run()
+    torch.accelerator.synchronize()
+    return graph, output
+
+
+def measure_replays(
+    run: Callable[[], object],
+    reset: Callable[[], None],
+    samples: int,
+    replays_per_sample: int,
+) -> list[float]:
+    starts = [torch.cuda.Event(enable_timing=True) for _ in range(replays_per_sample)]
+    ends = [torch.cuda.Event(enable_timing=True) for _ in range(replays_per_sample)]
+    samples_us = []
+    for _ in range(samples):
+        for replay, (start, end) in enumerate(zip(starts, ends)):
+            reset()
+            start.record()
+            run()
+            end.record()
+        ends[-1].synchronize()
+        elapsed_us = [
+            starts[replay].elapsed_time(ends[replay]) * 1000.0
+            for replay in range(replays_per_sample)
+        ]
+        samples_us.append(statistics.mean(elapsed_us))
+    return samples_us
+
+
+def benchmark_eager(
+    runner: BenchmarkRunner,
+    warmups: int,
+    samples: int,
+    replays_per_sample: int,
+) -> dict[str, Any]:
+    for _ in range(warmups):
+        runner.reset()
+        runner.run()
+    torch.accelerator.synchronize()
+
+    samples_us = measure_replays(
+        runner.run,
+        runner.reset,
+        samples,
+        replays_per_sample,
+    )
+    return summarize(samples_us)
+
+
+def benchmark_cudagraph(
+    runner: BenchmarkRunner,
+    warmups: int,
+    samples: int,
+    replays_per_sample: int,
+) -> tuple[dict[str, Any], torch.Tensor]:
+    graph, output = capture_runner(runner)
+    for _ in range(warmups):
+        runner.reset()
+        graph.replay()
+    torch.accelerator.synchronize()
+
+    samples_us = measure_replays(
+        graph.replay,
+        runner.reset,
+        samples,
+        replays_per_sample,
+    )
+    return summarize(samples_us), output
+
+
+def check_outputs(
+    runners: dict[str, BenchmarkRunner],
+) -> dict[str, Any]:
+    outputs = {}
+    for implementation, runner in runners.items():
+        runner.reset()
+        outputs[implementation] = runner.run()
+    torch.accelerator.synchronize()
+    baseline_tokens = outputs["baseline"]
+    addmm_matches = baseline_tokens == outputs["addmm"]
+    inplace_matches = baseline_tokens == outputs["addmm_inplace"]
+    return {
+        "tokens": baseline_tokens.numel(),
+        "matching_tokens": inplace_matches.sum().item(),
+        "match_rate": inplace_matches.float().mean().item(),
+        "out_of_place_matching_tokens": addmm_matches.sum().item(),
+        "out_of_place_match_rate": addmm_matches.float().mean().item(),
+    }
+
+
+def benchmark_case(args: argparse.Namespace, batch_size: int) -> dict[str, Any]:
+    inputs = make_inputs(
+        batch_size=batch_size,
+        vocab_size=args.vocab_size,
+        markov_rank=args.markov_rank,
+        num_speculative_tokens=args.num_speculative_tokens,
+        dtype=DTYPES[args.dtype],
+        seed=args.seed + batch_size,
+    )
+    runners = {
+        implementation: make_runner(
+            implementation,
+            *inputs,
+        )
+        for implementation in ("baseline", "addmm", "addmm_inplace")
+    }
+    result: dict[str, Any] = {
+        "batch_size": batch_size,
+        "correctness": check_outputs(runners),
+        "timings": {},
+    }
+
+    modes = ("eager", "cudagraph") if args.mode == "both" else (args.mode,)
+    for mode in modes:
+        mode_result = {}
+        for implementation, runner in runners.items():
+            if mode == "eager":
+                timing = benchmark_eager(
+                    runner,
+                    args.warmups,
+                    args.samples,
+                    args.replays_per_sample,
+                )
+            else:
+                timing, _ = benchmark_cudagraph(
+                    runner,
+                    args.warmups,
+                    args.samples,
+                    args.replays_per_sample,
+                )
+            mode_result[implementation] = timing
+        baseline_us = mode_result["baseline"]["median_us"]
+        addmm_us = mode_result["addmm"]["median_us"]
+        inplace_us = mode_result["addmm_inplace"]["median_us"]
+        mode_result["out_of_place_speedup"] = baseline_us / addmm_us
+        mode_result["out_of_place_latency_reduction_pct"] = (
+            (baseline_us - addmm_us) / baseline_us * 100.0
+        )
+        mode_result["speedup"] = baseline_us / inplace_us
+        mode_result["latency_reduction_pct"] = (
+            (baseline_us - inplace_us) / baseline_us * 100.0
+        )
+        mode_result["inplace_vs_out_of_place_reduction_pct"] = (
+            (addmm_us - inplace_us) / addmm_us * 100.0
+        )
+        result["timings"][mode] = mode_result
+
+    del inputs, runners
+    torch.cuda.empty_cache()
+    return result
+
+
+def main() -> None:
+    args = parse_args()
+    torch.set_grad_enabled(False)
+    if not torch.cuda.is_available():
+        raise RuntimeError("This benchmark requires a CUDA GPU.")
+
+    results = {
+        "device": torch.cuda.get_device_name(),
+        "torch_version": torch.__version__,
+        "config": {
+            "batch_sizes": args.batch_sizes,
+            "vocab_size": args.vocab_size,
+            "markov_rank": args.markov_rank,
+            "num_speculative_tokens": args.num_speculative_tokens,
+            "dtype": args.dtype,
+            "logit_scale": 1.0,
+            "mode": args.mode,
+            "warmups": args.warmups,
+            "samples": args.samples,
+            "replays_per_sample": args.replays_per_sample,
+            "seed": args.seed,
+        },
+        "cases": [benchmark_case(args, batch_size) for batch_size in args.batch_sizes],
+    }
+    rendered = json.dumps(results, indent=2)
+    print(rendered)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/models/test_dspark_mla.py
+++ b/tests/models/test_dspark_mla.py
@@ -9,6 +9,7 @@ import torch.nn as nn
 
 from vllm.compilation.wrapper import TorchCompileWithNoGuardsWrapper
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.models import qwen3_dspark
 from vllm.model_executor.models.qwen3_dspark import DSparkMarkovHead
 from vllm.model_executor.models.registry import ModelRegistry
 from vllm.models.kimi_k3.nvidia import dspark_mla
@@ -102,6 +103,73 @@ def test_dspark_markov_head_is_replicated(
     bias = head.bias(markov_embed, logits_processor)
     assert markov_embed.shape == (2, 8)
     assert bias.shape == (2, 128)
+
+
+@pytest.mark.cpu_test
+def test_dspark_markov_head_fuses_projection_and_bias_add_in_place(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from vllm.model_executor.layers import logits_processor
+
+    monkeypatch.setattr(
+        logits_processor,
+        "get_current_vllm_config",
+        lambda: SimpleNamespace(model_config=None),
+    )
+    monkeypatch.setattr(qwen3_dspark.current_platform, "is_cuda", lambda: True)
+
+    head = DSparkMarkovHead(130, 130, 8, prefix="markov_head")
+    with torch.no_grad():
+        head.markov_w1.weight.normal_()
+        head.markov_w2.weight.normal_()
+    processor = LogitsProcessor(130)
+    markov_embed = head.embed(torch.tensor([1, 2]))
+    base_logits = torch.randn(2, 130)
+    expected = base_logits + head.bias(markov_embed, processor)
+    base_logits_ptr = base_logits.data_ptr()
+    actual = head.add_bias(base_logits, markov_embed, processor)
+
+    assert actual.data_ptr() == base_logits_ptr
+    torch.testing.assert_close(actual, expected)
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize(
+    ("scale", "soft_cap", "noncontiguous"),
+    [(1.0, 10.0, False), (0.75, None, False), (1.0, None, True)],
+)
+def test_dspark_markov_head_falls_back_when_inplace_is_not_safe(
+    monkeypatch: pytest.MonkeyPatch,
+    scale: float,
+    soft_cap: float | None,
+    noncontiguous: bool,
+):
+    from vllm.model_executor.layers import logits_processor
+
+    monkeypatch.setattr(
+        logits_processor,
+        "get_current_vllm_config",
+        lambda: SimpleNamespace(model_config=None),
+    )
+    monkeypatch.setattr(qwen3_dspark.current_platform, "is_cuda", lambda: True)
+
+    head = DSparkMarkovHead(128, 128, 8, prefix="markov_head")
+    with torch.no_grad():
+        head.markov_w1.weight.normal_()
+        head.markov_w2.weight.normal_()
+    processor = LogitsProcessor(128, scale=scale, soft_cap=soft_cap)
+    markov_embed = head.embed(torch.tensor([1, 2]))
+    if noncontiguous:
+        base_logits = torch.randn(128, 2).t()
+        assert not base_logits.is_contiguous()
+    else:
+        base_logits = torch.randn(2, 128)
+    original_base_logits = base_logits.clone()
+    expected = base_logits + head.bias(markov_embed, processor)
+    actual = head.add_bias(base_logits, markov_embed, processor)
+
+    torch.testing.assert_close(base_logits, original_base_logits)
+    torch.testing.assert_close(actual, expected)
 
 
 @pytest.mark.cpu_test

--- a/tests/v1/spec_decode/test_dspark_sample_layout.py
+++ b/tests/v1/spec_decode/test_dspark_sample_layout.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+
+if not current_platform.is_cuda():
+    pytest.skip(
+        "DSpark sample layout test requires CUDA.",
+        allow_module_level=True,
+    )
+
+from vllm.v1.worker.gpu.spec_decode.dflash.speculator import (
+    _prepare_dflash_inputs_kernel,
+)
+
+
+@pytest.mark.parametrize(
+    (
+        "sample_from_anchor",
+        "sample_step_major",
+        "expected_sample_indices",
+    ),
+    [
+        (True, True, [0, 3, 6, 1, 4, 7, 2, 5, 8]),
+        (False, True, [1, 5, 9, 2, 6, 10, 3, 7, 11]),
+        (False, False, [1, 2, 3, 5, 6, 7, 9, 10, 11]),
+    ],
+)
+def test_sample_indices_layout(
+    sample_from_anchor: bool,
+    sample_step_major: bool,
+    expected_sample_indices: list[int],
+):
+    device = "cuda"
+    num_reqs = 3
+    num_speculative_steps = 3
+    num_query_per_req = 3 if sample_from_anchor else 4
+    max_num_reqs = 4
+    max_num_tokens = max_num_reqs * num_query_per_req
+    num_samples = max_num_reqs * num_speculative_steps
+
+    out_input_ids = torch.zeros(max_num_tokens, dtype=torch.int32, device=device)
+    out_query_positions = torch.zeros(max_num_tokens, dtype=torch.int64, device=device)
+    out_query_start_loc = torch.zeros(
+        max_num_reqs + 1, dtype=torch.int32, device=device
+    )
+    out_seq_lens = torch.zeros(max_num_reqs, dtype=torch.int32, device=device)
+    out_query_slot_mapping = torch.zeros(
+        max_num_tokens, dtype=torch.int64, device=device
+    )
+    out_context_positions = torch.zeros(num_reqs, dtype=torch.int64, device=device)
+    out_context_slot_mapping = torch.zeros(num_reqs, dtype=torch.int64, device=device)
+    out_sample_indices = torch.zeros(num_samples, dtype=torch.int64, device=device)
+    out_sample_pos = torch.zeros(num_samples, dtype=torch.int64, device=device)
+    out_sample_idx_mapping = torch.zeros(num_samples, dtype=torch.int32, device=device)
+    out_temperature = torch.zeros(max_num_reqs, dtype=torch.float32, device=device)
+    out_seeds = torch.zeros(max_num_reqs, dtype=torch.int64, device=device)
+
+    target_positions = torch.tensor([10, 20, 30], dtype=torch.int64, device=device)
+    target_query_start_loc = torch.tensor(
+        [0, 1, 2, 3], dtype=torch.int32, device=device
+    )
+    idx_mapping = torch.tensor([2, 0, 1], dtype=torch.int32, device=device)
+    last_sampled = torch.tensor([100, 101, 102, 0], dtype=torch.int32, device=device)
+    next_prefill_tokens = torch.zeros(max_num_reqs, dtype=torch.int32, device=device)
+    num_sampled = torch.ones(num_reqs, dtype=torch.int32, device=device)
+    num_rejected = torch.zeros(num_reqs, dtype=torch.int32, device=device)
+    temperature = torch.ones(max_num_reqs, dtype=torch.float32, device=device)
+    seeds = torch.arange(max_num_reqs, dtype=torch.int64, device=device)
+    block_table = torch.zeros((num_reqs, 16), dtype=torch.int32, device=device)
+
+    _prepare_dflash_inputs_kernel[(num_reqs, 1)](
+        out_input_ids,
+        out_query_positions,
+        out_query_start_loc,
+        out_seq_lens,
+        out_query_slot_mapping,
+        out_context_positions,
+        out_context_slot_mapping,
+        out_sample_indices,
+        out_sample_pos,
+        out_sample_idx_mapping,
+        out_temperature,
+        out_seeds,
+        target_positions,
+        target_query_start_loc,
+        idx_mapping,
+        last_sampled,
+        next_prefill_tokens,
+        num_sampled,
+        num_rejected,
+        temperature,
+        seeds,
+        block_table,
+        block_table.stride(0),
+        999,
+        16,
+        num_query_per_req,
+        num_speculative_steps,
+        max_num_reqs,
+        max_num_tokens,
+        1024,
+        SAMPLE_FROM_ANCHOR=sample_from_anchor,
+        SAMPLE_STEP_MAJOR=sample_step_major,
+        PAD_SLOT_ID=-1,
+        BLOCK_SIZE=8,
+    )
+
+    active = num_reqs * num_speculative_steps
+    if sample_step_major:
+        sample_indices = out_sample_indices.view(num_speculative_steps, max_num_reqs)[
+            :, :num_reqs
+        ].reshape(active)
+        padded_indices = out_sample_indices.view(num_speculative_steps, max_num_reqs)[
+            :, num_reqs:
+        ]
+        assert padded_indices.eq(0).all()
+    else:
+        sample_indices = out_sample_indices[:active]
+    assert sample_indices.cpu().tolist() == expected_sample_indices
+    assert out_sample_pos[:active].cpu().tolist() == [
+        12,
+        13,
+        14,
+        22,
+        23,
+        24,
+        32,
+        33,
+        34,
+    ]
+    assert out_sample_idx_mapping[:active].cpu().tolist() == [
+        2,
+        2,
+        2,
+        0,
+        0,
+        0,
+        1,
+        1,
+        1,
+    ]

--- a/vllm/model_executor/models/qwen3_dspark.py
+++ b/vllm/model_executor/models/qwen3_dspark.py
@@ -24,7 +24,9 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
+    UnquantizedEmbeddingMethod,
 )
+from vllm.platforms import current_platform
 
 from .qwen3_dflash import DFlashQwen3ForCausalLM, DFlashQwen3Model
 from .utils import AutoWeightsLoader, maybe_prefix, process_eagle_weight
@@ -73,6 +75,42 @@ class DSparkMarkovHead(nn.Module):
     ) -> torch.Tensor:
         """Vocab-size transition bias from a Markov embedding ([B, r] -> [B, V])."""
         return logits_processor(self.markov_w2, markov_embed)
+
+    def add_bias(
+        self,
+        base_logits: torch.Tensor,
+        markov_embed: torch.Tensor,
+        logits_processor: LogitsProcessor,
+    ) -> torch.Tensor:
+        """Add the transition bias to ``base_logits``.
+
+        On CUDA, fuse the replicated Markov projection and addition into an
+        in-place ``addmm_``. Fall back to the regular logits processor whenever
+        it has semantics that ``addmm_`` cannot preserve. The fast path
+        consumes and overwrites ``base_logits``.
+        """
+        can_fuse = (
+            current_platform.is_cuda()
+            and isinstance(
+                self.markov_w2.quant_method,
+                UnquantizedEmbeddingMethod,
+            )
+            and logits_processor.soft_cap is None
+            and logits_processor.scale == 1.0
+            and (
+                logits_processor.head_dtype is None
+                or logits_processor.head_dtype == markov_embed.dtype
+            )
+            and base_logits.is_contiguous()
+            and base_logits.dtype == markov_embed.dtype
+            and markov_embed.dtype == self.markov_w2.weight.dtype
+        )
+        if not can_fuse:
+            return base_logits + self.bias(markov_embed, logits_processor)
+
+        vocab_size = base_logits.shape[-1]
+        weight = self.markov_w2.weight[:vocab_size]
+        return base_logits.addmm_(markov_embed, weight.t())
 
 
 class Qwen3DSparkModel(DFlashQwen3Model):
@@ -151,8 +189,14 @@ class Qwen3DSparkForCausalLM(DFlashQwen3ForCausalLM):
     def markov_embed(self, token_ids: torch.Tensor) -> torch.Tensor:
         return self.model.markov_head.embed(token_ids)
 
-    def markov_bias(self, markov_embed: torch.Tensor) -> torch.Tensor:
-        return self.model.markov_head.bias(markov_embed, self.logits_processor)
+    def add_markov_bias(
+        self,
+        base_logits: torch.Tensor,
+        markov_embed: torch.Tensor,
+    ) -> torch.Tensor:
+        return self.model.markov_head.add_bias(
+            base_logits, markov_embed, self.logits_processor
+        )
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
         model_weights = {}

--- a/vllm/models/deepseek_v4/amd/dspark.py
+++ b/vllm/models/deepseek_v4/amd/dspark.py
@@ -353,8 +353,14 @@ class DSparkDeepseekV4ForCausalLM(nn.Module):
     def markov_embed(self, token_ids: torch.Tensor) -> torch.Tensor:
         return self.model.markov_head.embed(token_ids)
 
-    def markov_bias(self, markov_embed: torch.Tensor) -> torch.Tensor:
-        return self.model.markov_head.bias(markov_embed, self.logits_processor)
+    def add_markov_bias(
+        self,
+        base_logits: torch.Tensor,
+        markov_embed: torch.Tensor,
+    ) -> torch.Tensor:
+        return self.model.markov_head.add_bias(
+            base_logits, markov_embed, self.logits_processor
+        )
 
     # --- Weight loading ----------------------------------------------------
 

--- a/vllm/models/deepseek_v4/nvidia/dspark.py
+++ b/vllm/models/deepseek_v4/nvidia/dspark.py
@@ -366,8 +366,14 @@ class DSparkDeepseekV4ForCausalLM(nn.Module):
     def markov_embed(self, token_ids: torch.Tensor) -> torch.Tensor:
         return self.model.markov_head.embed(token_ids)
 
-    def markov_bias(self, markov_embed: torch.Tensor) -> torch.Tensor:
-        return self.model.markov_head.bias(markov_embed, self.logits_processor)
+    def add_markov_bias(
+        self,
+        base_logits: torch.Tensor,
+        markov_embed: torch.Tensor,
+    ) -> torch.Tensor:
+        return self.model.markov_head.add_bias(
+            base_logits, markov_embed, self.logits_processor
+        )
 
     # --- Weight loading ----------------------------------------------------
 

--- a/vllm/models/deepseek_v4/xpu/dspark.py
+++ b/vllm/models/deepseek_v4/xpu/dspark.py
@@ -285,8 +285,14 @@ class DSparkDeepseekV4ForCausalLM(nn.Module):
     def markov_embed(self, token_ids: torch.Tensor) -> torch.Tensor:
         return self.model.markov_head.embed(token_ids)
 
-    def markov_bias(self, markov_embed: torch.Tensor) -> torch.Tensor:
-        return self.model.markov_head.bias(markov_embed, self.logits_processor)
+    def add_markov_bias(
+        self,
+        base_logits: torch.Tensor,
+        markov_embed: torch.Tensor,
+    ) -> torch.Tensor:
+        return self.model.markov_head.add_bias(
+            base_logits, markov_embed, self.logits_processor
+        )
 
     # --- Weight loading ---
 

--- a/vllm/models/kimi_k3/nvidia/dspark_mla.py
+++ b/vllm/models/kimi_k3/nvidia/dspark_mla.py
@@ -506,8 +506,14 @@ class K3DSparkForCausalLM(nn.Module):
     def markov_embed(self, token_ids: torch.Tensor) -> torch.Tensor:
         return self.model.markov_head.embed(token_ids)
 
-    def markov_bias(self, markov_embed: torch.Tensor) -> torch.Tensor:
-        return self.model.markov_head.bias(markov_embed, self.logits_processor)
+    def add_markov_bias(
+        self,
+        base_logits: torch.Tensor,
+        markov_embed: torch.Tensor,
+    ) -> torch.Tensor:
+        return self.model.markov_head.add_bias(
+            base_logits, markov_embed, self.logits_processor
+        )
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         # confidence_head is training-only. The frozen target embedding and LM

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -76,7 +76,11 @@ class DFlashSpeculator(DraftModelSpeculator):
             self.max_num_tokens, dtype=torch.int64, device=device
         )
 
-        # Per-mask-token sampling buffers. Flattened from (num_reqs, num_spec_tokens).
+        # Per-mask-token sampling buffers. DFlash stores all three in
+        # request-major order. DSpark stores sample_indices in step-major order
+        # so its full-vocab LM-head output is contiguous for each sequential
+        # Markov step; sample_pos and sample_idx_mapping remain request-major.
+        self.sample_step_major = False
         max_num_sampled_tokens = self.max_num_reqs * self.num_speculative_steps
         self.sample_indices = torch.zeros(
             max_num_sampled_tokens, dtype=torch.int64, device=device
@@ -399,6 +403,7 @@ class DFlashSpeculator(DraftModelSpeculator):
                 self.max_num_tokens,
                 self.max_model_len,
                 self.sample_from_anchor,
+                self.sample_step_major,
             )
 
         # Pre-insert context K/V into the cache. Runs eagerly outside the captured graph
@@ -507,6 +512,7 @@ def _prepare_dflash_inputs_kernel(
     max_num_tokens,
     max_model_len,
     SAMPLE_FROM_ANCHOR: tl.constexpr,
+    SAMPLE_STEP_MAJOR: tl.constexpr,
     PAD_SLOT_ID: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
@@ -579,8 +585,13 @@ def _prepare_dflash_inputs_kernel(
     sample_off = 0 if SAMPLE_FROM_ANCHOR else 1
     is_sample = is_query & (query_off >= sample_off)
     sample_idx = req_idx * num_speculative_steps + (query_off - sample_off)
+    sample_hidden_idx = tl.where(
+        SAMPLE_STEP_MAJOR,
+        (query_off - sample_off) * max_num_reqs + req_idx,
+        sample_idx,
+    )
     sample_pos = query_pos + 1 if SAMPLE_FROM_ANCHOR else query_pos
-    tl.store(out_sample_indices_ptr + sample_idx, query_idx, mask=is_sample)
+    tl.store(out_sample_indices_ptr + sample_hidden_idx, query_idx, mask=is_sample)
     tl.store(out_sample_pos_ptr + sample_idx, sample_pos, mask=is_sample)
     tl.store(out_sample_idx_mapping_ptr + sample_idx, req_state_idx, mask=is_sample)
 
@@ -608,15 +619,26 @@ def _prepare_dflash_inputs_kernel(
                 mask = block < max_num_reqs
                 tl.store(out_seq_lens_ptr + block, 0, mask=mask)
             # Padded sample slots point at query index 0 (a valid row in
-            # last_hidden_states) so CG replay never reads OOB. Padded
-            # sample idx mappings point to -1, which is ignored during
-            # sampling to prevent writing stale values to draft logits.
+            # last_hidden_states) so CG replay never reads OOB. Step-major
+            # indices use a fixed max_num_reqs stride so a graph captured for
+            # a padded batch interprets the same rows as the preparation
+            # kernel. Padded sample idx mappings point to -1, which is ignored
+            # during sampling to prevent writing stale values to draft logits.
             pad_start = num_reqs * num_speculative_steps
             pad_end = max_num_reqs * num_speculative_steps
+            if SAMPLE_STEP_MAJOR:
+                for i in range(0, pad_end, BLOCK_SIZE):
+                    block = i + tl.arange(0, BLOCK_SIZE)
+                    mask = (block < pad_end) & (block % max_num_reqs >= num_reqs)
+                    tl.store(out_sample_indices_ptr + block, 0, mask=mask)
+            else:
+                for i in range(pad_start, pad_end, BLOCK_SIZE):
+                    block = i + tl.arange(0, BLOCK_SIZE)
+                    mask = block < pad_end
+                    tl.store(out_sample_indices_ptr + block, 0, mask=mask)
             for i in range(pad_start, pad_end, BLOCK_SIZE):
                 block = i + tl.arange(0, BLOCK_SIZE)
                 mask = block < pad_end
-                tl.store(out_sample_indices_ptr + block, 0, mask=mask)
                 tl.store(out_sample_pos_ptr + block, 0, mask=mask)
                 tl.store(out_sample_idx_mapping_ptr + block, -1, mask=mask)
             # Pad query slot mappings past num_query_tokens with PAD so the
@@ -662,6 +684,7 @@ def prepare_dflash_inputs(
     max_num_tokens: int,
     max_model_len: int,
     sample_from_anchor: bool = False,
+    sample_step_major: bool = False,
 ) -> None:
     num_reqs = input_batch.num_reqs
     assert num_reqs > 0
@@ -703,6 +726,7 @@ def prepare_dflash_inputs(
         max_num_tokens,
         max_model_len,
         SAMPLE_FROM_ANCHOR=sample_from_anchor,
+        SAMPLE_STEP_MAJOR=sample_step_major,
         PAD_SLOT_ID=PAD_SLOT_ID,
         BLOCK_SIZE=BLOCK_SIZE,
     )

--- a/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
@@ -50,6 +50,7 @@ class DSparkSpeculator(DFlashSpeculator):
             self.num_query_per_req = self.num_speculative_steps
         else:
             self.num_query_per_req = 1 + self.num_speculative_steps
+        self.sample_step_major = True
 
         # DSpark consumes mean-pooled target aux hidden states at the target
         # layers, combined to hidden_size via main_proj. Store that combined
@@ -101,12 +102,16 @@ class DSparkSpeculator(DFlashSpeculator):
         # Sequential Markov sampling over the backbone's output hidden states.
         n_spec = self.num_speculative_steps
         num_sample = num_reqs * n_spec
-        # Per-(req, position) head hidden, ordered (req, step).
-        sample_hidden = head_hidden[self.sample_indices[:num_sample]]
+        # sample_indices is step-major for DSpark, so the LM-head output is
+        # born contiguous for each sequential Markov step.
+        sample_indices = self.sample_indices.view(n_spec, self.max_num_reqs)[
+            :, :num_reqs
+        ].reshape(num_sample)
+        sample_hidden = head_hidden[sample_indices]
         # Draft-vocab logits; sampled ids are remapped to target vocab below.
         base_logits = self.model.compute_draft_logits(sample_hidden)
         vocab_size = base_logits.shape[-1]
-        base_logits = base_logits.view(num_reqs, n_spec, vocab_size)
+        base_logits = base_logits.view(n_spec, num_reqs, vocab_size)
 
         idx_map = self.sample_idx_mapping[:num_sample].view(num_reqs, n_spec)
         sample_pos = self.sample_pos[:num_sample].view(num_reqs, n_spec)
@@ -118,8 +123,7 @@ class DSparkSpeculator(DFlashSpeculator):
         for i in range(n_spec):
             # Sequential stage: Markov bias from the previously sampled token.
             markov_embed = self.model.markov_embed(prev)
-            bias = self.model.markov_bias(markov_embed)
-            logits_i = base_logits[:, i] + bias
+            logits_i = self.model.add_markov_bias(base_logits[i], markov_embed)
             if self.draft_logits is not None:
                 # Probabilistic: sample in target vocab (a reduced draft vocab is
                 # scattered into its target columns; full vocab is already there).


### PR DESCRIPTION
## Purpose

DSpark produces the base logits for all speculative positions in one LM-head
call, then applies the dense Markov projection sequentially for each draft
step. The existing path launches a projection and a separate elementwise add
for every step.

This PR makes the DSpark sample layout step-major, so each step owns a
contiguous `[request, vocab]` base-logits slice, and adds the Markov bias with:

```python
base_logits.addmm_(markov_embed, weight.t())
```

The beta=1 GEMM writes directly into the LM-head output after its final read.
This removes the separate add kernel without allocating an out-of-place
result. The fast path is limited to NVIDIA CUDA, an unquantized replicated
Markov head, compatible dtypes, contiguous logits, unit logit scale, and no
soft cap. All other configurations keep the existing non-mutating path.

The fixed `max_num_reqs` step stride also keeps the layout valid when full CUDA
Graphs pad the request batch. DFlash remains request-major.

### Duplicate-work check

I searched open vLLM PRs for DSpark, Markov head, addmm, in-place, and
step-major changes. I did not find another PR implementing this dense
step-major/in-place path.

- #49969 is an opt-in top-k Markov projection that restricts the candidate
  rows. This PR keeps the exact dense projection and optimizes its memory and
  kernel sequence. The approaches are conceptually complementary, although
  they touch two of the same files and may need a rebase if both land.
- #50424 adds quantization plumbing to the Markov head; this PR deliberately
  falls back for quantized heads.
- #47584 adds an opt-in FP8 draft LM head, not a Markov-bias addmm path.

No documentation or public configuration changes are required.

## Test Plan

1. Run focused Markov-head tests covering replication, in-place pointer and
   numerical equivalence, and soft-cap/scale/non-contiguous fallbacks.
2. Run CUDA layout tests covering anchor DSpark, fill-in DSpark, DFlash, and
   full-graph request padding.
3. Compare the original loop, out-of-place `torch.addmm`, and in-place
   `addmm_` with eager and CUDA Graph microbenchmarks on H20, BF16 and FP16,
   batch sizes 1 through 64.
4. Inspect an H20 CUDA timeline to verify the kernel and memcpy sequence.
5. Serve Qwen3-8B with `dspark_qwen3_8b_block7`, TP=1, BF16, default
   `torch.compile`, and FULL_AND_PIECEWISE CUDA Graphs. Compare upstream main
   and this PR with repeated greedy serving benchmarks, fixed outputs, and the
   full GSM8K test split.

Focused commands, run inside the project runtime container:

```bash
pytest -q --confcutdir=tests/models \
  tests/models/test_dspark_mla.py::test_dspark_markov_head_is_replicated \
  tests/models/test_dspark_mla.py::test_dspark_markov_head_fuses_projection_and_bias_add_in_place \
  tests/models/test_dspark_mla.py::test_dspark_markov_head_falls_back_when_inplace_is_not_safe

pytest -q --confcutdir=tests/v1/spec_decode \
  tests/v1/spec_decode/test_dspark_sample_layout.py
```

Ruff check, Ruff format check, `py_compile`, and `git diff --check` were also
run on the changed Python sources after rebasing onto main.

## Test Result

### Focused correctness

- Markov-head tests: 5 passed.
- DSpark/DFlash CUDA layout tests: 3 passed.
- All 14 BF16/FP16 microbenchmark cases had 100% final-token agreement.
- Fixed real-checkpoint greedy outputs: main and this PR were exactly equal on
  all 16 prompts.
- Both main and this PR completed backbone/DSpark-head compilation and
  PIECEWISE, FULL, and DSpark CUDA Graph capture.

### H20 microbenchmark

The CUDA Graph benchmark used 20 warmups, 51 samples, and 10 replays per
sample. Across batch sizes 1, 2, 4, 8, 16, 32, and 64:

- BF16 in-place versus original: 4.68% to 35.65% lower latency.
- FP16 in-place versus original: 4.74% to 35.64% lower latency.
- In-place versus out-of-place addmm: 4.16% to 13.56% lower latency.

At BF16 batch 16, the seven-step timeline changed from:

```text
7 x (embedding -> GEMM beta=0 -> add -> argmax)
```

to:

```text
7 x (embedding -> GEMM beta=1 -> argmax)
```

The out-of-place addmm trace contained seven D2D initialization copies. The
in-place trace contained zero.

### Repeated checkpoint E2E

`vllm bench serve` used temperature 0, seed 0, 128 input tokens, 128 output
tokens, and ignored EOS. Each arm ran three repetitions. Concurrency 1 used 64
prompts per repetition; the other levels used 256. All requests completed with
zero failures.

| Concurrency | Main output tok/s | This PR output tok/s | Delta | Main acceptance | This PR acceptance |
|---:|---:|---:|---:|---:|---:|
| 1 | 350.09 +/- 10.01 | 363.46 +/- 0.21 | +3.82% | 26.54% | 26.17% |
| 8 | 1658.19 +/- 108.51 | 1732.38 +/- 6.01 | +4.47% | 25.41% | 25.39% |
| 32 | 1982.21 +/- 9.46 | 1989.71 +/- 16.44 | +0.38% | 25.38% | 25.51% |
| 64 | 2052.04 +/- 35.42 | 2087.94 +/- 10.09 | +1.75% | 25.16% | 25.45% |

Values are mean +/- sample standard deviation. The concurrency-32 difference
is within run-to-run noise and should be read as neutral. Acceptance stayed
aligned, with a maximum absolute difference of 0.37 percentage points.

### GSM8K

All 1,319 test examples used five-shot prompting, temperature 0, at most 256
new tokens, and concurrency 64. There were no invalid answers.

| Configuration | Correct | Accuracy |
|---|---:|---:|
| Target only | 1170 / 1319 | 88.704% |
| Main DSpark | 1168 / 1319 | 88.552% |
| This PR DSpark | 1171 / 1319 | 88.779% |

There is no model-quality regression signal.

### AI-assistance disclosure

This change was developed with OpenAI Codex assistance. I reviewed every
changed line, understand the implementation and validation, and accept
responsibility for explaining and maintaining the contribution.

---
<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR is described.
- [x] The test plan and commands are included.
- [x] Correctness, performance, and model-evaluation results are included.
- [x] Documentation changes are not required because there is no public API or
  configuration change.

</details>
