### PR TITLE
[Bugfix] Pull a separate Run:ai tokenizer on every node

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,7 @@ import logging
 import os
 from dataclasses import MISSING, Field, asdict, dataclass, field
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pydantic
 import pytest
@@ -34,6 +34,7 @@ from vllm.config.vllm import (
     OptimizationLevel,
 )
 from vllm.platforms import current_platform
+from vllm.transformers_utils.runai_utils import ObjectStorageModel
 from vllm.v1.attention.backend import AttentionCGSupport
 
 DEVICE_TYPE = current_platform.device_type
@@ -828,7 +829,7 @@ class MockConfig:
     def __init__(self, model: str, tokenizer: str):
         self.model = model
         self.tokenizer = tokenizer
-        self.model_weights = None
+        self.model_weights: str | None = None
 
 
 @pytest.mark.parametrize(
@@ -954,6 +955,421 @@ def test_s3_url_different_model_and_tokenizer(mock_pull_files):
     assert mock_pull_files.call_args_list[0][0][0] == model_url
     # Second call: tokenizer URI with ignore_pattern
     assert mock_pull_files.call_args_list[1][0][0] == tokenizer_url
+
+
+# Tests for maybe_pull_model_files_for_runai_worker (worker-side repair pull).
+
+RUNAI_WORKER_S3_URL = "s3://example-bucket/model/"
+
+
+@pytest.fixture
+def runai_assets_cache(tmp_path, monkeypatch):
+    """Keep the Object Storage cache directory inside the test's tmp_path."""
+    monkeypatch.setenv("VLLM_ASSETS_CACHE", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture
+def mock_get_lock():
+    """Stub out the file lock guarding concurrent pulls on the same node."""
+    # weight_utils is imported lazily by the method under test, so make sure
+    # the module exists before patching a name inside it.
+    import vllm.model_executor.model_loader.weight_utils  # noqa: F401
+
+    with patch(
+        "vllm.model_executor.model_loader.weight_utils.get_lock"
+    ) as mock_get_lock:
+        yield mock_get_lock
+
+
+def _worker_config(model_dir: str, model_weights: str) -> MockConfig:
+    """A config as a worker receives it: local dirs plus the original URI."""
+    config = MockConfig(model=model_dir, tokenizer=model_dir)
+    config.model_weights = model_weights
+    return config
+
+
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_worker_pulls_files_when_node_local_dir_is_empty(
+    mock_pull_files, mock_get_lock, runai_assets_cache
+):
+    """A peer node must pull the non-tensor files it never received."""
+    mock_pull_files.return_value = None
+
+    # ObjectStorageModel resolves (and creates) the deterministic local
+    # directory. Leaving it empty reproduces the peer node's state.
+    local_dir = ObjectStorageModel(url=RUNAI_WORKER_S3_URL).dir
+    assert os.listdir(local_dir) == []
+
+    config = _worker_config(local_dir, RUNAI_WORKER_S3_URL)
+    ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    assert mock_pull_files.call_count == 2
+    # The weights URI is pulled, never the already-rewritten local path.
+    assert mock_pull_files.call_args_list[0][0][0] == RUNAI_WORKER_S3_URL
+    assert mock_pull_files.call_args_list[0][1]["allow_pattern"] == [
+        "*.model",
+        "*.py",
+        "*.json",
+    ]
+    # The pull is serialized against the other ranks on this node, keyed on
+    # the resolved directory being written rather than on the remote URI.
+    mock_get_lock.assert_called_once_with(os.path.realpath(local_dir))
+    # Weights themselves are streamed, not pulled.
+    assert config.model_weights == RUNAI_WORKER_S3_URL
+    # The successful pull leaves the cache directory in place.
+    assert os.path.exists(local_dir)
+
+
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_worker_pull_matches_driver_pull(
+    mock_pull_files, mock_get_lock, runai_assets_cache
+):
+    """The worker must reproduce the driver's pull calls verbatim."""
+    mock_pull_files.return_value = None
+
+    driver_config = MockConfig(model=RUNAI_WORKER_S3_URL, tokenizer=RUNAI_WORKER_S3_URL)
+    ModelConfig.maybe_pull_model_tokenizer_for_runai(
+        driver_config, RUNAI_WORKER_S3_URL, RUNAI_WORKER_S3_URL
+    )
+    driver_calls = mock_pull_files.call_args_list[:]
+    assert driver_calls, "driver is expected to pull files"
+    mock_pull_files.reset_mock()
+
+    # pull_files is mocked, so the directory the driver resolved is still
+    # empty - exactly what a worker on a peer node finds.
+    worker_config = _worker_config(driver_config.model, RUNAI_WORKER_S3_URL)
+    ModelConfig.maybe_pull_model_files_for_runai_worker(worker_config)
+
+    assert mock_pull_files.call_args_list == driver_calls
+    assert worker_config.model == driver_config.model
+    assert worker_config.tokenizer == driver_config.tokenizer
+
+
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_worker_does_not_disturb_an_unrepairable_tokenizer(
+    mock_pull_files, mock_get_lock, runai_assets_cache, tmp_path
+):
+    """A tokenizer pulled from its own URI is left untouched, not repointed."""
+    mock_pull_files.return_value = None
+
+    local_dir = ObjectStorageModel(url=RUNAI_WORKER_S3_URL).dir
+    tokenizer_dir = str(tmp_path / "separate-tokenizer")
+
+    config = MockConfig(model=local_dir, tokenizer=tokenizer_dir)
+    config.model_weights = RUNAI_WORKER_S3_URL
+    ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    # Mirrors the driver: a separate tokenizer means only the allow-pattern
+    # pull for the model directory.
+    assert mock_pull_files.call_count == 1
+    assert mock_pull_files.call_args_list[0][0][0] == RUNAI_WORKER_S3_URL
+    assert mock_pull_files.call_args_list[0][1]["allow_pattern"] == [
+        "*.model",
+        "*.py",
+        "*.json",
+    ]
+    assert config.tokenizer == tokenizer_dir
+
+
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_worker_pull_matches_driver_pull_with_separate_tokenizer(
+    mock_pull_files, mock_get_lock, runai_assets_cache
+):
+    """With a separate tokenizer, the worker must still mirror the driver's
+    pulls for the model URI: the allow-pattern pull only."""
+    mock_pull_files.return_value = None
+
+    tokenizer_url = "s3://example-bucket/tokenizer/"
+    driver_config = MockConfig(model=RUNAI_WORKER_S3_URL, tokenizer=tokenizer_url)
+    ModelConfig.maybe_pull_model_tokenizer_for_runai(
+        driver_config, RUNAI_WORKER_S3_URL, tokenizer_url
+    )
+    driver_model_calls = [
+        call
+        for call in mock_pull_files.call_args_list
+        if call[0][0] == RUNAI_WORKER_S3_URL
+    ]
+    assert len(driver_model_calls) == 1
+    mock_pull_files.reset_mock()
+
+    worker_config = _worker_config(driver_config.model, RUNAI_WORKER_S3_URL)
+    worker_config.tokenizer = driver_config.tokenizer
+    ModelConfig.maybe_pull_model_files_for_runai_worker(worker_config)
+
+    assert mock_pull_files.call_args_list == driver_model_calls
+
+
+@patch("vllm.config.model.ObjectStorageModel")
+def test_runai_worker_guard_accepts_a_symlinked_cache_directory(
+    mock_object_storage_model, mock_get_lock, runai_assets_cache, tmp_path
+):
+    """Paths resolving to the same physical directory must not be rejected."""
+    real_dir = tmp_path / "real-cache"
+    real_dir.mkdir()
+    link_dir = tmp_path / "alias-cache"
+    os.symlink(real_dir, link_dir, target_is_directory=True)
+
+    mock_object_storage_model.return_value.dir = str(real_dir)
+    config = _worker_config(str(link_dir), RUNAI_WORKER_S3_URL)
+    ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    assert mock_object_storage_model.return_value.pull_files.call_count == 2
+    # The lock is keyed on the canonical path, not on the alias spelling.
+    mock_get_lock.assert_called_once_with(os.path.realpath(str(link_dir)))
+
+
+@patch("vllm.config.model.ObjectStorageModel")
+def test_runai_worker_waits_for_lock_before_trusting_existing_files(
+    mock_object_storage_model, mock_get_lock, runai_assets_cache
+):
+    """Even a populated directory is only trusted after taking the lock."""
+    local_dir = ObjectStorageModel(url=RUNAI_WORKER_S3_URL).dir
+    with open(os.path.join(local_dir, "config.json"), "w") as f:
+        f.write("{}")
+
+    config = _worker_config(local_dir, RUNAI_WORKER_S3_URL)
+    ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    # A non-empty directory may be a pull still in progress on another rank.
+    mock_get_lock.assert_called_once_with(os.path.realpath(local_dir))
+    mock_object_storage_model.assert_not_called()
+    assert config.model == local_dir
+
+
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_worker_rechecks_after_acquiring_the_lock(
+    mock_pull_files, mock_get_lock, runai_assets_cache
+):
+    """A rank that waited for the lock must not repeat the winner's pull."""
+    mock_pull_files.return_value = None
+
+    local_dir = ObjectStorageModel(url=RUNAI_WORKER_S3_URL).dir
+
+    def win_race_while_blocked(*args, **kwargs):
+        # Simulates the rank holding the lock finishing its pull.
+        with open(os.path.join(local_dir, "config.json"), "w") as f:
+            f.write("{}")
+
+    lock = MagicMock()
+    lock.__enter__.side_effect = win_race_while_blocked
+    mock_get_lock.return_value = lock
+
+    config = _worker_config(local_dir, RUNAI_WORKER_S3_URL)
+    ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    mock_get_lock.assert_called_once()
+    mock_pull_files.assert_not_called()
+
+
+def _fail_after_writing_one_file(local_dir: str, exc_type: type = OSError):
+    """A pull that dies partway, leaving the directory half populated."""
+
+    def pull(*args, **kwargs):
+        os.makedirs(local_dir, exist_ok=True)
+        with open(os.path.join(local_dir, "config.json"), "w") as f:
+            f.write("{}")
+        raise exc_type("connection reset by peer")
+
+    return pull
+
+
+@pytest.mark.parametrize("failure", [OSError, KeyboardInterrupt])
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_worker_clears_the_directory_when_the_pull_fails(
+    mock_pull_files, mock_get_lock, runai_assets_cache, failure
+):
+    """A failed or interrupted pull removes its leftovers and propagates."""
+    local_dir = ObjectStorageModel(url=RUNAI_WORKER_S3_URL).dir
+    mock_pull_files.side_effect = _fail_after_writing_one_file(local_dir, failure)
+
+    config = _worker_config(local_dir, RUNAI_WORKER_S3_URL)
+    with pytest.raises(failure):
+        ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    assert not os.path.exists(local_dir)
+
+
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_worker_retries_after_a_failed_pull(
+    mock_pull_files, mock_get_lock, runai_assets_cache
+):
+    """A transient failure must not poison the cache for the next start."""
+    local_dir = ObjectStorageModel(url=RUNAI_WORKER_S3_URL).dir
+    mock_pull_files.side_effect = _fail_after_writing_one_file(local_dir)
+
+    config = _worker_config(local_dir, RUNAI_WORKER_S3_URL)
+    with pytest.raises(OSError):
+        ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    mock_pull_files.reset_mock()
+    mock_pull_files.side_effect = None
+    ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    assert mock_pull_files.call_count == 2
+    # The successful retry leaves the cache directory in place.
+    assert os.path.exists(local_dir)
+
+
+@patch("vllm.config.model.ObjectStorageModel")
+def test_runai_worker_fails_fast_on_a_cache_directory_mismatch(
+    mock_object_storage_model, mock_get_lock, runai_assets_cache, tmp_path
+):
+    """A node deriving a different cache directory fails fast, without pulling."""
+    mock_object_storage_model.return_value.dir = str(tmp_path / "worker-side-dir")
+
+    config = _worker_config(str(tmp_path / "driver-side-dir"), RUNAI_WORKER_S3_URL)
+    with (
+        patch("vllm.config.model.shutil.rmtree") as mock_rmtree,
+        pytest.raises(RuntimeError, match="VLLM_ASSETS_CACHE"),
+    ):
+        ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    mock_object_storage_model.return_value.pull_files.assert_not_called()
+    mock_rmtree.assert_not_called()
+
+
+@patch("vllm.config.model.ObjectStorageModel")
+def test_runai_worker_opts_out_of_signal_handlers(
+    mock_object_storage_model, mock_get_lock, runai_assets_cache, tmp_path
+):
+    """The worker-side pull must not install process-global signal handlers."""
+    local_dir = str(tmp_path / "node-local-dir")
+    mock_object_storage_model.return_value.dir = local_dir
+
+    config = _worker_config(local_dir, RUNAI_WORKER_S3_URL)
+    ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    mock_object_storage_model.assert_called_once_with(
+        url=RUNAI_WORKER_S3_URL, install_signal_handlers=False
+    )
+
+
+def test_runai_object_storage_model_signal_handler_opt_out(monkeypatch, tmp_path):
+    """`install_signal_handlers=False` skips registration; the default keeps it."""
+    monkeypatch.setenv("VLLM_ASSETS_CACHE_MODEL_CLEAN", "1")
+    monkeypatch.setenv("VLLM_ASSETS_CACHE", str(tmp_path))
+
+    with patch("vllm.transformers_utils.runai_utils.signal.signal") as mock_signal:
+        ObjectStorageModel(url=RUNAI_WORKER_S3_URL, install_signal_handlers=False)
+        mock_signal.assert_not_called()
+
+        ObjectStorageModel(url=RUNAI_WORKER_S3_URL)
+        assert mock_signal.call_count == 2  # SIGINT + SIGTERM
+
+
+@pytest.mark.parametrize(
+    "model_weights",
+    [None, "", "/local/path/to/model", "facebook/opt-125m"],
+)
+@patch("vllm.config.model.ObjectStorageModel")
+def test_runai_worker_noop_without_object_storage_weights(
+    mock_object_storage_model, mock_get_lock, model_weights
+):
+    """Models that never came from Object Storage must not be touched."""
+    config = MockConfig(model="/local/path/to/model", tokenizer="/local/tokenizer")
+    config.model_weights = model_weights
+
+    ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    mock_get_lock.assert_not_called()
+    mock_object_storage_model.assert_not_called()
+    assert config.model == "/local/path/to/model"
+    assert config.tokenizer == "/local/tokenizer"
+
+
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_worker_not_short_circuited_by_driver_guard(
+    mock_pull_files, mock_get_lock, runai_assets_cache
+):
+    """The driver's method silently no-ops on a worker; the new one must pull."""
+    mock_pull_files.return_value = None
+
+    local_dir = ObjectStorageModel(url=RUNAI_WORKER_S3_URL).dir
+    config = _worker_config(local_dir, RUNAI_WORKER_S3_URL)
+
+    # The driver's method no-ops on a worker...
+    ModelConfig.maybe_pull_model_tokenizer_for_runai(
+        config, config.model, config.tokenizer
+    )
+    mock_pull_files.assert_not_called()
+
+    # ...while the worker's method pulls.
+    ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+    assert mock_pull_files.call_count > 0
+
+
+def _init_worker_config(calls: list[str]) -> MagicMock:
+    """A VllmConfig that records when its model files would be pulled."""
+    vllm_config = MagicMock()
+    vllm_config.parallel_config.worker_cls = "fake.module.FakeWorker"
+    vllm_config.parallel_config.worker_extension_cls = None
+    vllm_config.speculative_config = None
+    vllm_config.model_config.maybe_pull_model_files_for_runai_worker.side_effect = (
+        lambda: calls.append("pull_runai_files")
+    )
+    return vllm_config
+
+
+def _run_init_worker(vllm_config: MagicMock, calls: list[str]) -> None:
+    """Drive init_worker with the worker class and mm registry stubbed out."""
+    from vllm.v1.worker import worker_base
+
+    class FakeWorker:
+        def __init__(self, **kwargs):
+            calls.append("construct_worker")
+
+    with (
+        patch.object(worker_base, "resolve_obj_by_qualname", return_value=FakeWorker),
+        patch.object(worker_base, "MULTIMODAL_REGISTRY") as mm_registry,
+    ):
+        mm_registry.worker_receiver_cache_from_config.side_effect = (
+            lambda *args, **kwargs: calls.append("create_mm_receiver_cache")
+        )
+        worker_base.WorkerWrapperBase(rpc_rank=0).init_worker(
+            [{"vllm_config": vllm_config, "shared_worker_lock": MagicMock()}]
+        )
+
+
+def test_init_worker_pulls_runai_files_before_the_directory_is_read():
+    """The pull must run before the mm receiver cache reads the directory."""
+    calls: list[str] = []
+    _run_init_worker(_init_worker_config(calls), calls)
+
+    assert calls == [
+        "pull_runai_files",
+        "create_mm_receiver_cache",
+        "construct_worker",
+    ]
+
+
+def test_init_worker_pulls_runai_files_for_the_draft_model():
+    """A distinct speculative draft config must be pulled as well."""
+    calls: list[str] = []
+    vllm_config = _init_worker_config(calls)
+    draft_config = MagicMock()
+    draft_config.maybe_pull_model_files_for_runai_worker.side_effect = (
+        lambda: calls.append("pull_draft_runai_files")
+    )
+    vllm_config.speculative_config = MagicMock(draft_model_config=draft_config)
+
+    _run_init_worker(vllm_config, calls)
+
+    assert calls.count("pull_runai_files") == 1
+    assert calls.count("pull_draft_runai_files") == 1
+
+
+def test_init_worker_pulls_once_when_the_draft_reuses_the_target_config():
+    """`draft_model_config` is often the target config itself; pull it once."""
+    calls: list[str] = []
+    vllm_config = _init_worker_config(calls)
+    vllm_config.speculative_config = MagicMock(
+        draft_model_config=vllm_config.model_config
+    )
+
+    _run_init_worker(vllm_config, calls)
+
+    assert calls.count("pull_runai_files") == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,9 +3,11 @@
 
 import logging
 import os
+import pickle
 from dataclasses import MISSING, Field, asdict, dataclass, field
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
+from unittest.mock import call as mock_call
 
 import pydantic
 import pytest
@@ -830,6 +832,7 @@ class MockConfig:
         self.model = model
         self.tokenizer = tokenizer
         self.model_weights: str | None = None
+        self.tokenizer_weights: str | None = None
 
 
 @pytest.mark.parametrize(
@@ -960,6 +963,15 @@ def test_s3_url_different_model_and_tokenizer(mock_pull_files):
 # Tests for maybe_pull_model_files_for_runai_worker (worker-side repair pull).
 
 RUNAI_WORKER_S3_URL = "s3://example-bucket/model/"
+RUNAI_WORKER_TOKENIZER_S3_URL = "s3://example-bucket/tokenizer/"
+# Spelled out rather than imported, so a change to the source is a failure.
+RUNAI_NON_WEIGHT_IGNORE_PATTERN = [
+    "*.pt",
+    "*.safetensors",
+    "*.bin",
+    "*.tensors",
+    "*.pth",
+]
 
 
 @pytest.fixture
@@ -986,6 +998,16 @@ def _worker_config(model_dir: str, model_weights: str) -> MockConfig:
     """A config as a worker receives it: local dirs plus the original URI."""
     config = MockConfig(model=model_dir, tokenizer=model_dir)
     config.model_weights = model_weights
+    return config
+
+
+def _separate_tokenizer_worker_config(
+    model: str, model_weights: str, tokenizer_dir: str
+) -> MockConfig:
+    """A worker config whose tokenizer came from a URI of its own."""
+    config = MockConfig(model=model, tokenizer=tokenizer_dir)
+    config.model_weights = model_weights
+    config.tokenizer_weights = RUNAI_WORKER_TOKENIZER_S3_URL
     return config
 
 
@@ -1297,6 +1319,254 @@ def test_runai_worker_not_short_circuited_by_driver_guard(
     # ...while the worker's method pulls.
     ModelConfig.maybe_pull_model_files_for_runai_worker(config)
     assert mock_pull_files.call_count > 0
+
+
+# Tests for the separate-tokenizer half of the worker-side repair pull.
+
+
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_worker_pulls_a_separate_tokenizer_when_its_dir_is_empty(
+    mock_pull_files, mock_get_lock, runai_assets_cache
+):
+    """A tokenizer with a URI of its own is repaired from that URI."""
+    mock_pull_files.return_value = None
+
+    model_dir = ObjectStorageModel(url=RUNAI_WORKER_S3_URL).dir
+    tokenizer_dir = ObjectStorageModel(url=RUNAI_WORKER_TOKENIZER_S3_URL).dir
+    assert os.listdir(tokenizer_dir) == []
+
+    config = _separate_tokenizer_worker_config(
+        model_dir, RUNAI_WORKER_S3_URL, tokenizer_dir
+    )
+    ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    # The model directory keeps its single allow-pattern pull; the tokenizer
+    # adds the ignore-pattern pull the driver would have made for it.
+    assert mock_pull_files.call_count == 2
+    assert mock_pull_files.call_args_list[0][0][0] == RUNAI_WORKER_S3_URL
+    assert mock_pull_files.call_args_list[0][1]["allow_pattern"] == [
+        "*.model",
+        "*.py",
+        "*.json",
+    ]
+    # The URI is pulled, never the already-rewritten local path.
+    assert mock_pull_files.call_args_list[1][0][0] == RUNAI_WORKER_TOKENIZER_S3_URL
+    assert (
+        mock_pull_files.call_args_list[1][1]["ignore_pattern"]
+        == RUNAI_NON_WEIGHT_IGNORE_PATTERN
+    )
+    assert config.tokenizer == tokenizer_dir
+    assert os.path.exists(tokenizer_dir)
+
+
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_worker_tokenizer_pull_matches_driver_pull(
+    mock_pull_files, mock_get_lock, runai_assets_cache
+):
+    """The worker must reproduce the driver's tokenizer pull verbatim."""
+    mock_pull_files.return_value = None
+
+    driver_config = MockConfig(
+        model=RUNAI_WORKER_S3_URL, tokenizer=RUNAI_WORKER_TOKENIZER_S3_URL
+    )
+    ModelConfig.maybe_pull_model_tokenizer_for_runai(
+        driver_config, RUNAI_WORKER_S3_URL, RUNAI_WORKER_TOKENIZER_S3_URL
+    )
+    driver_tokenizer_calls = [
+        call
+        for call in mock_pull_files.call_args_list
+        if call[0][0] == RUNAI_WORKER_TOKENIZER_S3_URL
+    ]
+    assert len(driver_tokenizer_calls) == 1
+    # The URI the worker needs is the one the driver recorded.
+    assert driver_config.model_weights == RUNAI_WORKER_S3_URL
+    assert driver_config.tokenizer_weights == RUNAI_WORKER_TOKENIZER_S3_URL
+    mock_pull_files.reset_mock()
+
+    worker_config = _separate_tokenizer_worker_config(
+        driver_config.model, RUNAI_WORKER_S3_URL, driver_config.tokenizer
+    )
+    ModelConfig.maybe_pull_model_files_for_runai_worker(worker_config)
+
+    worker_tokenizer_calls = [
+        call
+        for call in mock_pull_files.call_args_list
+        if call[0][0] == RUNAI_WORKER_TOKENIZER_S3_URL
+    ]
+    assert worker_tokenizer_calls == driver_tokenizer_calls
+    assert worker_config.tokenizer == driver_config.tokenizer
+
+
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_shared_tokenizer_records_no_tokenizer_uri(
+    mock_pull_files, mock_get_lock, runai_assets_cache
+):
+    """A tokenizer read from the model directory needs no URI of its own."""
+    mock_pull_files.return_value = None
+
+    driver_config = MockConfig(model=RUNAI_WORKER_S3_URL, tokenizer=RUNAI_WORKER_S3_URL)
+    ModelConfig.maybe_pull_model_tokenizer_for_runai(
+        driver_config, RUNAI_WORKER_S3_URL, RUNAI_WORKER_S3_URL
+    )
+    assert driver_config.model_weights == RUNAI_WORKER_S3_URL
+    assert not driver_config.tokenizer_weights
+    assert driver_config.tokenizer == driver_config.model
+    mock_pull_files.reset_mock()
+
+    worker_config = _worker_config(driver_config.model, RUNAI_WORKER_S3_URL)
+    ModelConfig.maybe_pull_model_files_for_runai_worker(worker_config)
+
+    # Unchanged by the tokenizer repair: two pulls of the model URI into the
+    # one directory, taken under one lock.
+    assert [call[0][0] for call in mock_pull_files.call_args_list] == [
+        RUNAI_WORKER_S3_URL,
+        RUNAI_WORKER_S3_URL,
+    ]
+    assert mock_pull_files.call_args_list[0][1]["allow_pattern"] == [
+        "*.model",
+        "*.py",
+        "*.json",
+    ]
+    assert (
+        mock_pull_files.call_args_list[1][1]["ignore_pattern"]
+        == RUNAI_NON_WEIGHT_IGNORE_PATTERN
+    )
+    mock_get_lock.assert_called_once_with(os.path.realpath(driver_config.model))
+
+
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_worker_repairs_the_tokenizer_of_a_hugging_face_model(
+    mock_pull_files, mock_get_lock, runai_assets_cache
+):
+    """An ordinary model id leaves `model_weights` unset; repair the tokenizer
+    from its own URI regardless."""
+    mock_pull_files.return_value = None
+
+    hf_model = "facebook/opt-125m"
+    driver_config = MockConfig(model=hf_model, tokenizer=RUNAI_WORKER_TOKENIZER_S3_URL)
+    ModelConfig.maybe_pull_model_tokenizer_for_runai(
+        driver_config, hf_model, RUNAI_WORKER_TOKENIZER_S3_URL
+    )
+    assert not driver_config.model_weights
+    assert driver_config.tokenizer_weights == RUNAI_WORKER_TOKENIZER_S3_URL
+    tokenizer_dir = driver_config.tokenizer
+    mock_pull_files.reset_mock()
+
+    worker_config = _separate_tokenizer_worker_config(hf_model, "", tokenizer_dir)
+    ModelConfig.maybe_pull_model_files_for_runai_worker(worker_config)
+
+    assert mock_pull_files.call_count == 1
+    assert mock_pull_files.call_args_list[0][0][0] == RUNAI_WORKER_TOKENIZER_S3_URL
+    assert (
+        mock_pull_files.call_args_list[0][1]["ignore_pattern"]
+        == RUNAI_NON_WEIGHT_IGNORE_PATTERN
+    )
+    mock_get_lock.assert_called_once_with(os.path.realpath(tokenizer_dir))
+    assert worker_config.model == hf_model
+
+
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_worker_repairs_the_tokenizer_beside_a_populated_model_dir(
+    mock_pull_files, mock_get_lock, runai_assets_cache
+):
+    """Each directory is checked on its own: a model another rank already
+    pulled must not skip the tokenizer."""
+    mock_pull_files.return_value = None
+
+    model_dir = ObjectStorageModel(url=RUNAI_WORKER_S3_URL).dir
+    with open(os.path.join(model_dir, "config.json"), "w") as f:
+        f.write("{}")
+    tokenizer_dir = ObjectStorageModel(url=RUNAI_WORKER_TOKENIZER_S3_URL).dir
+
+    config = _separate_tokenizer_worker_config(
+        model_dir, RUNAI_WORKER_S3_URL, tokenizer_dir
+    )
+    ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    assert mock_pull_files.call_count == 1
+    assert mock_pull_files.call_args_list[0][0][0] == RUNAI_WORKER_TOKENIZER_S3_URL
+    # The model directory was still locked and inspected, just left alone.
+    assert mock_get_lock.call_count == 2
+
+
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_worker_locks_the_model_and_tokenizer_directories_separately(
+    mock_pull_files, mock_get_lock, runai_assets_cache
+):
+    """One lock per directory, each keyed on the canonical path it writes."""
+    mock_pull_files.return_value = None
+
+    model_dir = ObjectStorageModel(url=RUNAI_WORKER_S3_URL).dir
+    tokenizer_dir = ObjectStorageModel(url=RUNAI_WORKER_TOKENIZER_S3_URL).dir
+
+    config = _separate_tokenizer_worker_config(
+        model_dir, RUNAI_WORKER_S3_URL, tokenizer_dir
+    )
+    ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    assert mock_get_lock.call_args_list == [
+        mock_call(os.path.realpath(model_dir)),
+        mock_call(os.path.realpath(tokenizer_dir)),
+    ]
+
+
+@patch("vllm.config.model.ObjectStorageModel")
+def test_runai_worker_fails_fast_on_a_tokenizer_directory_mismatch(
+    mock_object_storage_model, mock_get_lock, runai_assets_cache, tmp_path
+):
+    """A node deriving a different tokenizer directory fails fast, without
+    pulling."""
+    mock_object_storage_model.return_value.dir = str(tmp_path / "worker-side-dir")
+
+    config = _separate_tokenizer_worker_config(
+        "facebook/opt-125m", "", str(tmp_path / "driver-side-dir")
+    )
+    with (
+        patch("vllm.config.model.shutil.rmtree") as mock_rmtree,
+        pytest.raises(RuntimeError, match="VLLM_ASSETS_CACHE"),
+    ):
+        ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    mock_object_storage_model.return_value.pull_files.assert_not_called()
+    mock_rmtree.assert_not_called()
+
+
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_worker_clears_the_tokenizer_directory_when_the_pull_fails(
+    mock_pull_files, mock_get_lock, runai_assets_cache
+):
+    """A failed tokenizer pull removes its leftovers and propagates."""
+    tokenizer_dir = ObjectStorageModel(url=RUNAI_WORKER_TOKENIZER_S3_URL).dir
+    mock_pull_files.side_effect = _fail_after_writing_one_file(tokenizer_dir)
+
+    config = _separate_tokenizer_worker_config("facebook/opt-125m", "", tokenizer_dir)
+    with pytest.raises(OSError):
+        ModelConfig.maybe_pull_model_files_for_runai_worker(config)
+
+    assert not os.path.exists(tokenizer_dir)
+
+
+@patch("vllm.transformers_utils.runai_utils.ObjectStorageModel.pull_files")
+def test_runai_separate_tokenizer_uri_reaches_a_worker(
+    mock_pull_files, mock_get_lock, runai_assets_cache
+):
+    """The real config, not the mock, must carry the URI across the wire."""
+    mock_pull_files.return_value = None
+
+    driver_config = ModelConfig(
+        model="Qwen/Qwen3-0.6B", tokenizer=RUNAI_WORKER_TOKENIZER_S3_URL
+    )
+    assert driver_config.tokenizer_weights == RUNAI_WORKER_TOKENIZER_S3_URL
+    assert driver_config.tokenizer != RUNAI_WORKER_TOKENIZER_S3_URL
+    mock_pull_files.reset_mock()
+
+    # Workers receive the config pickled, so the field has to survive that.
+    worker_config = pickle.loads(pickle.dumps(driver_config))
+    assert worker_config.tokenizer_weights == RUNAI_WORKER_TOKENIZER_S3_URL
+    worker_config.maybe_pull_model_files_for_runai_worker()
+
+    assert mock_pull_files.call_count == 1
+    assert mock_pull_files.call_args_list[0][0][0] == RUNAI_WORKER_TOKENIZER_S3_URL
 
 
 def _init_worker_config(calls: list[str]) -> MagicMock:

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
+import shutil
 import warnings
 from collections.abc import Callable
 from dataclasses import InitVar, field
@@ -1008,6 +1010,76 @@ class ModelConfig:
                 ignore_pattern=["*.pt", "*.safetensors", "*.bin", "*.tensors", "*.pth"],
             )
             self.tokenizer = object_storage_tokenizer.dir
+
+    def maybe_pull_model_files_for_runai_worker(self) -> None:
+        """Pull non-tensor model files from Object Storage onto the local node.
+
+        Weights are streamed separately. Safe to call on every rank.
+        """
+        # Only set once the driver has pulled the model from Object Storage.
+        model_uri = self.model_weights
+        if not model_uri or not is_runai_obj_uri(model_uri):
+            return
+
+        # avoid circular import
+        from vllm.model_executor.model_loader.weight_utils import get_lock
+
+        # A general solution for concurrent Object Storage downloads is
+        # https://github.com/vllm-project/vllm/pull/36696.
+        # The canonical path, so two spellings of one directory share one lock.
+        with get_lock(os.path.realpath(self.model)):
+            # Content, not existence: an empty pre-created directory is the
+            # broken state this repairs; a populated one means another rank
+            # already completed the pull. Unsafe to read outside the lock —
+            # a non-empty directory may be a pull still in progress.
+            if os.path.isdir(self.model) and os.listdir(self.model):
+                return
+
+            # Workers must not install process-global signal handlers.
+            object_storage_model = ObjectStorageModel(
+                url=model_uri, install_signal_handlers=False
+            )
+            if os.path.realpath(object_storage_model.dir) != os.path.realpath(
+                self.model
+            ):
+                raise RuntimeError(
+                    "Run:ai model streamer cache directory mismatch on this "
+                    "node: the config resolved on the driver points at "
+                    f"{self.model!r}, but this node derives "
+                    f"{object_storage_model.dir!r} from the model URI. This "
+                    "usually means VLLM_ASSETS_CACHE (or XDG_CACHE_HOME / "
+                    "HOME) differs between the driver and this node; make it "
+                    "consistent across all nodes."
+                )
+            logger.info(
+                "Pulling non-tensor model files to %s on this node.", self.model
+            )
+            pull_succeeded = False
+            try:
+                object_storage_model.pull_files(
+                    model_uri, allow_pattern=["*.model", "*.py", "*.json"]
+                )
+                # Shared tokenizer: the driver rewrote both `model` and
+                # `tokenizer` to this directory, so pull the rest of the
+                # non-weight files it will need. A separate tokenizer is
+                # read from its own path and needs nothing more here.
+                if self.tokenizer == self.model:
+                    object_storage_model.pull_files(
+                        model_uri,
+                        ignore_pattern=[
+                            "*.pt",
+                            "*.safetensors",
+                            "*.bin",
+                            "*.tensors",
+                            "*.pth",
+                        ],
+                    )
+                pull_succeeded = True
+            finally:
+                if not pull_succeeded:
+                    # A partial pull must not survive: the in-lock check
+                    # would otherwise trust it on the next attempt.
+                    shutil.rmtree(object_storage_model.dir, ignore_errors=True)
 
     def _get_encoder_config(self) -> dict[str, Any] | None:
         return get_sentence_transformer_tokenizer_config(self.model, self.revision)

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -118,6 +118,9 @@ AttnTypeStr = Literal[
     "decoder", "encoder", "encoder_only", "encoder_decoder", "attention_free", "hybrid"
 ]
 
+# Weights are streamed straight from Object Storage, never mirrored to disk.
+_RUNAI_WEIGHT_PATTERNS = ["*.pt", "*.safetensors", "*.bin", "*.tensors", "*.pth"]
+
 
 @config(config=ConfigDict(arbitrary_types_allowed=True))
 class ModelConfig:
@@ -131,6 +134,10 @@ class ModelConfig:
     """Original model weights path. Used when the model is pulled from object
     storage (e.g., RunAI) to preserve the original URI while `model` points to
     the local directory."""
+    tokenizer_weights: str = ""
+    """Original tokenizer path. Used when a tokenizer separate from the model
+    is pulled from object storage (e.g., RunAI) to preserve the original URI
+    while `tokenizer` points to the local directory."""
     runner: RunnerOption = "auto"
     """The type of model runner to use. Each vLLM instance only supports one
     model runner, even if the same model can be used for multiple types."""
@@ -408,6 +415,7 @@ class ModelConfig:
         ignored_factors = {
             "convert",
             "tokenizer",
+            "tokenizer_weights",
             "tokenizer_mode",
             "seed",
             "hf_config_path",
@@ -1009,77 +1017,41 @@ class ModelConfig:
                 tokenizer,
                 ignore_pattern=["*.pt", "*.safetensors", "*.bin", "*.tensors", "*.pth"],
             )
+            self.tokenizer_weights = tokenizer
             self.tokenizer = object_storage_tokenizer.dir
 
     def maybe_pull_model_files_for_runai_worker(self) -> None:
-        """Pull non-tensor model files from Object Storage onto the local node.
+        """Pull non-tensor model and tokenizer files onto the local node.
 
-        Weights are streamed separately. Safe to call on every rank.
+        Repairs every directory the driver pulled from Object Storage but
+        only materialized on its own node. Weights are streamed separately.
+        Safe to call on every rank.
         """
-        # Only set once the driver has pulled the model from Object Storage.
+        # Only set once the driver has pulled that directory from Object
+        # Storage; the model and the tokenizer are recorded independently.
         model_uri = self.model_weights
-        if not model_uri or not is_runai_obj_uri(model_uri):
+        tokenizer_uri = self.tokenizer_weights
+        pull_model = bool(model_uri) and is_runai_obj_uri(model_uri)
+        pull_tokenizer = bool(tokenizer_uri) and is_runai_obj_uri(tokenizer_uri)
+        if not pull_model and not pull_tokenizer:
             return
 
-        # avoid circular import
-        from vllm.model_executor.model_loader.weight_utils import get_lock
+        if pull_model:
+            pulls = [{"allow_pattern": ["*.model", "*.py", "*.json"]}]
+            # Shared tokenizer: the driver rewrote both `model` and
+            # `tokenizer` to this directory, so pull the rest of the
+            # non-weight files it will need. A separate tokenizer has its
+            # own directory, repaired from its own URI below.
+            if self.tokenizer == self.model:
+                pulls.append({"ignore_pattern": _RUNAI_WEIGHT_PATTERNS})
+            _pull_runai_dir_for_worker(model_uri, self.model, pulls)
 
-        # A general solution for concurrent Object Storage downloads is
-        # https://github.com/vllm-project/vllm/pull/36696.
-        # The canonical path, so two spellings of one directory share one lock.
-        with get_lock(os.path.realpath(self.model)):
-            # Content, not existence: an empty pre-created directory is the
-            # broken state this repairs; a populated one means another rank
-            # already completed the pull. Unsafe to read outside the lock —
-            # a non-empty directory may be a pull still in progress.
-            if os.path.isdir(self.model) and os.listdir(self.model):
-                return
-
-            # Workers must not install process-global signal handlers.
-            object_storage_model = ObjectStorageModel(
-                url=model_uri, install_signal_handlers=False
+        if pull_tokenizer:
+            _pull_runai_dir_for_worker(
+                tokenizer_uri,
+                self.tokenizer,
+                [{"ignore_pattern": _RUNAI_WEIGHT_PATTERNS}],
             )
-            if os.path.realpath(object_storage_model.dir) != os.path.realpath(
-                self.model
-            ):
-                raise RuntimeError(
-                    "Run:ai model streamer cache directory mismatch on this "
-                    "node: the config resolved on the driver points at "
-                    f"{self.model!r}, but this node derives "
-                    f"{object_storage_model.dir!r} from the model URI. This "
-                    "usually means VLLM_ASSETS_CACHE (or XDG_CACHE_HOME / "
-                    "HOME) differs between the driver and this node; make it "
-                    "consistent across all nodes."
-                )
-            logger.info(
-                "Pulling non-tensor model files to %s on this node.", self.model
-            )
-            pull_succeeded = False
-            try:
-                object_storage_model.pull_files(
-                    model_uri, allow_pattern=["*.model", "*.py", "*.json"]
-                )
-                # Shared tokenizer: the driver rewrote both `model` and
-                # `tokenizer` to this directory, so pull the rest of the
-                # non-weight files it will need. A separate tokenizer is
-                # read from its own path and needs nothing more here.
-                if self.tokenizer == self.model:
-                    object_storage_model.pull_files(
-                        model_uri,
-                        ignore_pattern=[
-                            "*.pt",
-                            "*.safetensors",
-                            "*.bin",
-                            "*.tensors",
-                            "*.pth",
-                        ],
-                    )
-                pull_succeeded = True
-            finally:
-                if not pull_succeeded:
-                    # A partial pull must not survive: the in-lock check
-                    # would otherwise trust it on the next attempt.
-                    shutil.rmtree(object_storage_model.dir, ignore_errors=True)
 
     def _get_encoder_config(self) -> dict[str, Any] | None:
         return get_sentence_transformer_tokenizer_config(self.model, self.revision)
@@ -2092,6 +2064,58 @@ class ModelConfig:
             and quant_config is not None
             and "nvfp4" in quant_config.get("format", "").lower()
         )
+
+
+def _pull_runai_dir_for_worker(
+    uri: str, local_dir: str, pulls: list[dict[str, list[str]]]
+) -> None:
+    """Repair one node-local Object Storage directory on this node.
+
+    Args:
+        uri: Object Storage URI the driver pulled the directory from.
+        local_dir: Node-local path the driver rewrote the config to.
+        pulls: Keyword arguments of each `pull_files` call to replay.
+    """
+    # avoid circular import
+    from vllm.model_executor.model_loader.weight_utils import get_lock
+
+    # A general solution for concurrent Object Storage downloads is
+    # https://github.com/vllm-project/vllm/pull/36696.
+    # The canonical path, so two spellings of one directory share one lock.
+    with get_lock(os.path.realpath(local_dir)):
+        # Content, not existence: an empty pre-created directory is the
+        # broken state this repairs; a populated one means another rank
+        # already completed the pull. Unsafe to read outside the lock —
+        # a non-empty directory may be a pull still in progress.
+        if os.path.isdir(local_dir) and os.listdir(local_dir):
+            return
+
+        # Workers must not install process-global signal handlers.
+        object_storage_model = ObjectStorageModel(
+            url=uri, install_signal_handlers=False
+        )
+        if os.path.realpath(object_storage_model.dir) != os.path.realpath(local_dir):
+            raise RuntimeError(
+                "Run:ai model streamer cache directory mismatch on this node: "
+                f"the config resolved on the driver points at {local_dir!r}, "
+                f"but this node derives {object_storage_model.dir!r} from "
+                f"{uri!r}. This usually means VLLM_ASSETS_CACHE (or "
+                "XDG_CACHE_HOME / HOME) differs between the driver and this "
+                "node; make it consistent across all nodes."
+            )
+        logger.info(
+            "Pulling non-tensor files from %s to %s on this node.", uri, local_dir
+        )
+        pull_succeeded = False
+        try:
+            for pull_kwargs in pulls:
+                object_storage_model.pull_files(uri, **pull_kwargs)
+            pull_succeeded = True
+        finally:
+            if not pull_succeeded:
+                # A partial pull must not survive: the in-lock check would
+                # otherwise trust it on the next attempt.
+                shutil.rmtree(object_storage_model.dir, ignore_errors=True)
 
 
 def get_served_model_name(model: str, served_model_name: str | list[str] | None):

--- a/vllm/transformers_utils/runai_utils.py
+++ b/vllm/transformers_utils/runai_utils.py
@@ -53,8 +53,8 @@ class ObjectStorageModel:
         pull_files(): Pull model from object storage to the temporary directory.
     """
 
-    def __init__(self, url: str) -> None:
-        if envs.VLLM_ASSETS_CACHE_MODEL_CLEAN:
+    def __init__(self, url: str, install_signal_handlers: bool = True) -> None:
+        if envs.VLLM_ASSETS_CACHE_MODEL_CLEAN and install_signal_handlers:
             for sig in (signal.SIGINT, signal.SIGTERM):
                 existing_handler = signal.getsignal(sig)
                 signal.signal(sig, self._close_by_signal(existing_handler))

--- a/vllm/v1/worker/worker_base.py
+++ b/vllm/v1/worker/worker_base.py
@@ -246,6 +246,21 @@ class WorkerWrapperBase:
 
         load_general_plugins()
 
+        # Only the config-building process pulled non-tensor model files from
+        # Object Storage; pull them here before anything reads the model dir.
+        model_configs = [vllm_config.model_config]
+        spec_config = vllm_config.speculative_config
+        if spec_config is not None:
+            draft_config = spec_config.draft_model_config
+            if (
+                draft_config is not None
+                and draft_config is not vllm_config.model_config
+            ):
+                model_configs.append(draft_config)
+
+        for model_config in model_configs:
+            model_config.maybe_pull_model_files_for_runai_worker()
+
         parallel_config = vllm_config.parallel_config
         if isinstance(parallel_config.worker_cls, str):
             worker_class: type[WorkerBase] = resolve_obj_by_qualname(


### PR DESCRIPTION
> [!IMPORTANT]
> **Draft: stacked on #50633, which is still in review.**
> This branch is based on `fix-runai-streamer-multinode-aux-files`, so the diff
> against `main` currently shows **two** commits. Only the second one belongs to
> this PR:
>
> | commit | belongs to |
> |---|---|
> | `3890e9d` [Bugfix] Pull runai_streamer non-tensor model files on every node | #50633 |
> | `6ab94ee` [Bugfix] Pull a separate Run:ai tokenizer on every node | **this PR** |
>
> I will rebase and take this out of draft once #50633 lands. Please review #50633
> first — this change reuses the machinery that PR introduces.

Closes #50739

## Purpose

With `--load-format runai_streamer` and a tokenizer supplied as its own object-storage URI (`--tokenizer s3://...`, different from the model URI), peer nodes in a multi-node deployment cannot materialize the tokenizer directory.

On the driver, `maybe_pull_model_tokenizer_for_runai` pulls the separate tokenizer into a node-local hash directory and rewrites `ModelConfig.tokenizer` to that path. Unlike the model — whose original URI is preserved in `model_weights` — the tokenizer's URI is recorded nowhere. The rewritten config is serialized to every worker, so on a peer node the directory does not exist and no URI survives to re-pull it from; the worker-side repair added in #50633 has nothing to work with.

Every model that loads a tokenizer inside worker processes then fails on peer nodes: all multimodal models (`supports_multimodal_inputs` loads it during `GPUModelRunner.__init__`), models that load it in the model `__init__` (Voxtral, Qwen3-VL, Qwen3.5, GritLM's pooler), and draft-model speculative decoding with a heterogeneous vocabulary. A related shape has the same root cause: `--model` as an ordinary HF id combined with `--tokenizer s3://...` leaves `model_weights` unset, so the worker-side repair returns immediately and repairs nothing.

This PR:

- adds `ModelConfig.tokenizer_weights`, the tokenizer-side analog of `model_weights`, set in the separate-tokenizer branch of the driver pull (one line; the driver's pull behaviour is otherwise untouched);
- extracts the lock / in-lock content check / cache-directory guard / failure cleanup out of `maybe_pull_model_files_for_runai_worker` into `_pull_runai_dir_for_worker`, so the model directory and the tokenizer directory each go through that machinery independently, under their own lock;
- repairs the tokenizer directory from the recorded URI with the same `ignore_pattern` the driver uses;
- changes the early return to fire only when neither URI is an object-storage URI, which also covers the HF-id + `s3://` tokenizer shape.

The model directory's behaviour is unchanged, including the conditional `ignore_pattern` pull settled in #50633 review (`if self.tokenizer == self.model`). `tokenizer_weights` is added to `compute_hash`'s `ignored_factors` alongside `tokenizer`, since the tokenizer does not affect the computation graph.

## Test Plan

```bash
pytest tests/test_config.py -k runai
pytest tests/test_config.py
ruff check vllm/config/model.py tests/test_config.py
ruff format --check vllm/config/model.py tests/test_config.py
```

Nine tests added to `tests/test_config.py`, one behaviour each: tokenizer pulled when its directory is empty; driver-vs-worker call parity on the tokenizer URI; a shared tokenizer recording no URI and the model path behaving exactly as before (regression pin); the HF-id + `s3://` tokenizer shape; the tokenizer repaired next to an already-populated model directory; one lock per directory; the tokenizer directory's mismatch guard; failure cleanup; and the URI surviving a real `ModelConfig` through a pickle round-trip into the worker-side call.

## Test Result

`pytest tests/test_config.py -k runai` — 29 passed (20 pre-existing, unmodified, plus the 9 new).

`pytest tests/test_config.py` — 192 items, 12 failed / 179 passed / 1 skipped. The same 12 failures, by name, occur on the base commit (183 items, 12 failed / 170 passed / 1 skipped): Hugging Face network and gated-repo tests plus one environment-dependent compilation test. No new failures; the +9 passes are exactly the new tests.

Mutation-tested the new behaviour — each mutation applied on its own, all four killed:

| mutation | result |
|---|---|
| drop the driver-side `tokenizer_weights` assignment | 3 failed |
| invert the worker-side tokenizer repair condition | 19 failed |
| change the tokenizer pull's `ignore_pattern` | 3 failed |
| drop `tokenizer_weights` from the early return | 4 failed |

`ruff` 0.14.0 `check` and `format --check` both clean. `mypy` 1.20.2 clean on `tests/test_config.py`; on `vllm/config/model.py` the only findings are two pre-existing `dtype` errors in `_get_head_dtype`, verified identical on the base commit and untouched by this change.

Not covered by local testing: an actual multi-node run against object storage. The failing read paths are the same ones as #50616.
