### PR TITLE
[Bugfix] Refresh stale M-RoPE state when streaming re-feeds grow a RUNNING request's prompt

### DIFF
--- a/tests/v1/streaming_input/test_mrope_streaming_refeed.py
+++ b/tests/v1/streaming_input/test_mrope_streaming_refeed.py
@@ -1,0 +1,300 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression tests for stale state after an in-place streaming re-feed.
+
+vllm-project/vllm#50731: `NewRequestData` hands the runner the scheduler's own
+`prompt_token_ids` list object, and a streaming re-feed grows that list in
+place. A re-feed routed through WAITING is repaired by
+`_update_streaming_request`, but one that grows the prompt while the request
+stays RUNNING comes back through `scheduled_cached_reqs`, where the runner's
+derived state still described the pre-growth prompt: `mrope_positions` kept its
+old width (raising "Target sizes: [3, N]. Tensor sizes: [3, 0]"), and the
+persistent batch kept stale token ids and counters.
+
+A `SimpleNamespace` stands in for `self` so the cached-request path can be
+driven without a CUDA runner; `InputBatch` itself is real numpy/torch CPU state.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+import torch
+
+from vllm.model_executor.models.interfaces import SupportsMRoPE
+from vllm.sampling_params import SamplingParams
+from vllm.v1.core.sched.output import CachedRequestData
+from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
+from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+
+pytestmark = pytest.mark.cpu_test
+
+
+@pytest.fixture(autouse=True)
+def _unpinned_input_batch(monkeypatch):
+    """Pinned allocations need a device; InputBatch also forwards this to its
+    block table, so one patch keeps the whole batch host-only."""
+    monkeypatch.setattr("vllm.v1.worker.gpu_input_batch.PIN_MEMORY", False)
+
+
+MAX_REQS = 4
+MAX_TOKENS = 128
+BLOCK_SIZE = 16
+REQ_ID = "streaming-refeed-0"
+
+
+class _FakeMRoPEModel(SupportsMRoPE):
+    """Positions are just the token index, replicated over the 3 M-RoPE axes."""
+
+    def get_mrope_input_positions(self, input_tokens, mm_features):
+        seq_len = len(input_tokens)
+        return torch.arange(seq_len).unsqueeze(0).expand(3, -1).clone(), 0
+
+
+def _make_req_state(
+    *, prompt_token_ids=None, prompt_embeds=None, output_token_ids=None
+):
+    return CachedRequestState(
+        req_id=REQ_ID,
+        prompt_token_ids=prompt_token_ids,
+        prompt_embeds=prompt_embeds,
+        mm_features=[],
+        sampling_params=SamplingParams(),
+        pooling_params=None,
+        generator=None,
+        block_ids=([0],),
+        num_computed_tokens=0,
+        output_token_ids=output_token_ids if output_token_ids is not None else [],
+    )
+
+
+def _make_runner(req_state: CachedRequestState):
+    """Seats `req_state` in a real InputBatch and returns (runner, init_calls)."""
+    input_batch = InputBatch(
+        max_num_reqs=MAX_REQS,
+        max_model_len=MAX_TOKENS,
+        max_num_batched_tokens=MAX_TOKENS,
+        device=torch.device("cpu"),
+        vocab_size=32000,
+        block_sizes=[BLOCK_SIZE],
+        kernel_block_sizes=[BLOCK_SIZE],
+        max_num_blocks_per_req=[MAX_TOKENS // BLOCK_SIZE],
+        logitsprocs=None,
+        is_pooling_model=False,
+    )
+    input_batch.add_request(req_state)
+
+    init_calls: list[str] = []
+    runner = SimpleNamespace(
+        requests={req_state.req_id: req_state},
+        input_batch=input_batch,
+        uses_mrope=True,
+        uses_xdrope_dim=0,
+        speculative_config=None,
+        use_async_spec_decode=False,
+        use_async_scheduling=False,
+        num_prompt_logprobs={},
+        late_interaction_runner=SimpleNamespace(
+            on_requests_finished=lambda req_ids: None
+        ),
+        get_model=lambda: _FakeMRoPEModel(),
+        mrope_positions=SimpleNamespace(
+            cpu=torch.zeros(3, MAX_TOKENS, dtype=torch.int64)
+        ),
+        _process_encoder_cache_scheduler_output=lambda scheduler_output: None,
+        _may_reorder_batch=lambda scheduler_output: None,
+    )
+
+    def _init_mrope_positions(state):
+        init_calls.append(state.req_id)
+        GPUModelRunner._init_mrope_positions(runner, state)
+
+    runner._init_mrope_positions = _init_mrope_positions
+    runner._refresh_grown_prompt_state = (
+        lambda *args: GPUModelRunner._refresh_grown_prompt_state(runner, *args)
+    )
+    # Seed the pre-growth M-RoPE state the way the new-request path would.
+    runner._init_mrope_positions(req_state)
+    init_calls.clear()
+    return runner, init_calls
+
+
+def _scheduler_output(*, num_computed: int, num_scheduled: int, num_output: int = 0):
+    return SimpleNamespace(
+        finished_req_ids=[],
+        new_block_ids_to_zero=None,
+        kv_cache_block_copies=None,
+        num_scheduled_tokens={REQ_ID: num_scheduled},
+        scheduled_new_reqs=[],
+        scheduled_spec_decode_tokens={},
+        scheduled_cached_reqs=CachedRequestData(
+            req_ids=[REQ_ID],
+            resumed_req_ids=set(),
+            new_token_ids=[],
+            all_token_ids={},
+            new_block_ids=[None],
+            num_computed_tokens=[num_computed],
+            num_output_tokens=[num_output],
+        ),
+    )
+
+
+def _update_states(runner, scheduler_output):
+    with patch(
+        "vllm.v1.worker.gpu_model_runner.get_pp_group",
+        return_value=SimpleNamespace(is_last_rank=True),
+    ):
+        GPUModelRunner._update_states(runner, scheduler_output)
+
+
+def _grow_prompt_and_update(prompt_len: int, grow_by: int):
+    """Runs one cached-request step across an in-place prompt growth."""
+    req_state = _make_req_state(prompt_token_ids=list(range(1, prompt_len + 1)))
+    req_state.num_computed_tokens = prompt_len
+    runner, init_calls = _make_runner(req_state)
+    assert req_state.mrope_positions.shape == (3, prompt_len)
+
+    # What the scheduler does to the list object it shares with the runner.
+    req_state.prompt_token_ids.extend(range(100, 100 + grow_by))
+    scheduler_output = _scheduler_output(num_computed=prompt_len, num_scheduled=grow_by)
+    _update_states(runner, scheduler_output)
+    return runner, req_state, scheduler_output, init_calls
+
+
+def test_growth_does_not_break_mrope_calc():
+    """The crash from the issue: slicing a pre-growth M-RoPE tensor with
+    post-growth bookkeeping yields an empty source ([3, 0])."""
+    prompt_len, grow_by = 12, 7
+    runner, _, scheduler_output, _ = _grow_prompt_and_update(prompt_len, grow_by)
+
+    GPUModelRunner._calc_mrope_positions(runner, scheduler_output)
+
+    expected = torch.arange(prompt_len, prompt_len + grow_by).unsqueeze(0).expand(3, -1)
+    torch.testing.assert_close(runner.mrope_positions.cpu[:, :grow_by], expected)
+
+
+def test_growth_refreshes_mrope_state():
+    """A prompt grown in place while RUNNING must re-derive M-RoPE state."""
+    prompt_len, grow_by = 12, 7
+    _, req_state, _, init_calls = _grow_prompt_and_update(prompt_len, grow_by)
+
+    assert init_calls == [REQ_ID]
+    assert req_state.mrope_positions.shape == (3, prompt_len + grow_by)
+    assert req_state.num_prompt_tokens == prompt_len + grow_by
+
+
+def test_growth_mid_prefill_repairs_batch_token_state():
+    """Growth with no output tokens to discard: the realignment further down
+    in `_update_states` does not fire, so the batch row must be repaired here.
+
+    `num_tokens_no_spec` is the write index for sampled and draft tokens, so a
+    stale value lands them inside the grown prompt region.
+    """
+    prompt_len, grow_by = 12, 7
+    new_len = prompt_len + grow_by
+    req_state = _make_req_state(prompt_token_ids=list(range(1, prompt_len + 1)))
+    req_state.num_computed_tokens = 8  # mid chunked prefill
+    runner, _ = _make_runner(req_state)
+    batch = runner.input_batch
+    assert batch.num_tokens_no_spec[0] == prompt_len
+
+    grown_span = list(range(100, 100 + grow_by))
+    req_state.prompt_token_ids.extend(grown_span)
+    _update_states(runner, _scheduler_output(num_computed=8, num_scheduled=new_len - 8))
+
+    assert batch.num_prompt_tokens[0] == new_len
+    assert batch.num_tokens_no_spec[0] == new_len
+    np.testing.assert_array_equal(
+        batch.token_ids_cpu[0, prompt_len:new_len], np.array(grown_span)
+    )
+    assert batch.is_token_ids[0, prompt_len:new_len].all()
+
+
+def test_growth_after_output_fold_keeps_batch_consistent():
+    """The scheduler folds computed outputs into the prompt and clears them.
+
+    The folded span must keep its values (the rewrite is idempotent) and the
+    realignment below must land on the refreshed prompt length.
+    """
+    prompt_len, chunk = 12, 4
+    outputs = [901, 902, 903]
+    new_len = prompt_len + len(outputs) + chunk
+    req_state = _make_req_state(
+        prompt_token_ids=list(range(1, prompt_len + 1)),
+        output_token_ids=list(outputs),
+    )
+    req_state.num_computed_tokens = prompt_len + len(outputs)
+    runner, _ = _make_runner(req_state)
+    batch = runner.input_batch
+
+    # Scheduler-side fold: outputs become prompt, then the new chunk lands.
+    req_state.prompt_token_ids.extend(outputs)
+    req_state.prompt_token_ids.extend(range(200, 200 + chunk))
+    _update_states(
+        runner,
+        _scheduler_output(
+            num_computed=prompt_len + len(outputs), num_scheduled=chunk, num_output=0
+        ),
+    )
+
+    assert req_state.output_token_ids == []
+    assert batch.num_prompt_tokens[0] == new_len
+    assert batch.num_tokens_no_spec[0] == new_len
+    np.testing.assert_array_equal(
+        batch.token_ids_cpu[0, prompt_len : prompt_len + len(outputs)],
+        np.array(outputs),
+    )
+
+
+def test_growth_detected_when_mrope_tensor_is_wider_than_prompt():
+    """Implementations that precompute decode positions return a tensor wider
+    than the prompt; the growth check must not key off that width."""
+    prompt_len, grow_by = 12, 7
+    req_state = _make_req_state(prompt_token_ids=list(range(1, prompt_len + 1)))
+    req_state.num_computed_tokens = prompt_len
+    runner, init_calls = _make_runner(req_state)
+    req_state.mrope_positions = torch.zeros(3, prompt_len + 50, dtype=torch.int64)
+
+    req_state.prompt_token_ids.extend(range(100, 100 + grow_by))
+    _update_states(
+        runner, _scheduler_output(num_computed=prompt_len, num_scheduled=grow_by)
+    )
+
+    assert init_calls == [REQ_ID]
+    assert req_state.num_prompt_tokens == prompt_len + grow_by
+    assert runner.input_batch.num_prompt_tokens[0] == prompt_len + grow_by
+
+
+def test_unchanged_prompt_takes_the_fast_path():
+    """The common case must not pay for a re-init or touch the batch row."""
+    prompt_len = 12
+    req_state = _make_req_state(prompt_token_ids=list(range(1, prompt_len + 1)))
+    req_state.num_computed_tokens = prompt_len
+    runner, init_calls = _make_runner(req_state)
+    positions_before = req_state.mrope_positions
+    batch = runner.input_batch
+    tokens_before = batch.token_ids_cpu[0].copy()
+
+    _update_states(runner, _scheduler_output(num_computed=prompt_len, num_scheduled=1))
+
+    assert init_calls == []
+    assert req_state.mrope_positions is positions_before
+    assert req_state.num_prompt_tokens == prompt_len
+    assert batch.num_prompt_tokens[0] == prompt_len
+    np.testing.assert_array_equal(batch.token_ids_cpu[0], tokens_before)
+
+
+def test_prompt_embeds_request_is_not_treated_as_grown():
+    """Embeds-only requests have no token ids; the length check must use them."""
+    prompt_len = 9
+    req_state = _make_req_state(prompt_embeds=torch.randn(prompt_len, 16))
+    req_state.num_computed_tokens = prompt_len
+    runner, init_calls = _make_runner(req_state)
+    positions_before = req_state.mrope_positions
+    assert positions_before.shape == (3, prompt_len)
+
+    _update_states(runner, _scheduler_output(num_computed=prompt_len, num_scheduled=1))
+
+    assert init_calls == []
+    assert req_state.mrope_positions is positions_before

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1405,6 +1405,20 @@ class GPUModelRunner(
             # Update the cached states.
             req_state.num_computed_tokens = num_computed_tokens
 
+            # A streaming re-feed can grow this request's prompt in place; see
+            # `_refresh_grown_prompt_state`. Compare against the stored prompt
+            # length rather than the M-RoPE tensor width: implementations whose
+            # `get_mrope_input_positions` also covers decode positions return a
+            # tensor wider than the prompt, which would mask the growth.
+            if self.uses_mrope and req_state.mrope_positions is not None:
+                num_prompt_tokens = length_from_prompt_token_ids_or_embeds(
+                    req_state.prompt_token_ids, req_state.prompt_embeds
+                )
+                if num_prompt_tokens > req_state.num_prompt_tokens:
+                    self._refresh_grown_prompt_state(
+                        req_state, req_index, num_prompt_tokens
+                    )
+
             if not is_last_rank:
                 if not req_data.new_token_ids:
                     # Async scheduled PP: Sampled tokens propagated via GPU broadcast.
@@ -1657,6 +1671,53 @@ class GPUModelRunner(
             self._init_mrope_positions(req_state)
 
         return req_state
+
+    def _refresh_grown_prompt_state(
+        self,
+        req_state: CachedRequestState,
+        req_index: int | None,
+        num_prompt_tokens: int,
+    ) -> None:
+        """Re-derive the state that a request's prompt length feeds.
+
+        A streaming re-feed grows `prompt_token_ids` in place, and under
+        `uniproc_executor` the scheduler shares that list object with the runner
+        (multiproc serializes it, so this never runs there). Re-feeds routed
+        through WAITING are repaired by `_update_streaming_request`; one that
+        grows while the request stays RUNNING lands here instead.
+
+        Args:
+            req_state: Request whose prompt grew since it was last admitted.
+            req_index: Its slot in the persistent batch, or None if absent.
+            num_prompt_tokens: Post-growth prompt length.
+        """
+        prev_num_prompt_tokens = req_state.num_prompt_tokens
+        # Re-derived rather than extended: `get_mrope_input_positions` is not
+        # incremental, and the re-feed can add multimodal features.
+        self._init_mrope_positions(req_state)
+        req_state.num_prompt_tokens = num_prompt_tokens
+        if req_index is None:
+            # Not resident; `add_request` rebuilds the whole row further down.
+            return
+
+        self.input_batch.num_prompt_tokens[req_index] = num_prompt_tokens
+        if req_state.prompt_token_ids is not None:
+            # The leading part of this span rewrites the output tokens the
+            # scheduler folded into the prompt with identical values; the rest
+            # is prompt the batch has never seen. The prefill continuation
+            # gathers `input_ids` over exactly this span.
+            grown = slice(prev_num_prompt_tokens, num_prompt_tokens)
+            self.input_batch.token_ids_cpu[req_index, grown] = (
+                req_state.prompt_token_ids[grown]
+            )
+            self.input_batch.is_token_ids[req_index, grown] = True
+        # Growth folds prior outputs into the prompt, so the new prompt length
+        # is never below the previous count. Repaired here because the
+        # realignment below only runs when output tokens were dropped, while
+        # this is the write index for sampled and draft tokens.
+        self.input_batch.num_tokens_no_spec[req_index] = max(
+            int(self.input_batch.num_tokens_no_spec[req_index]), num_prompt_tokens
+        )
 
     def _init_mrope_positions(self, req_state: CachedRequestState):
         model = self.get_model()


### PR DESCRIPTION
## Purpose

Fixes #50731.

User impact: intermittent engine crash serving Qwen3-Omni realtime audio (`/v1/realtime` with `async_chunk: true`) — vllm-project/vllm-omni#5234:

```
RuntimeError: The expanded size of the tensor (74) must match the existing size (0) at non-singleton dimension 1.  Target sizes: [3, 74].  Tensor sizes: [3, 0]
```

### Mechanism

1. `NewRequestData.from_request` passes `request.prompt_token_ids` **by reference** (`vllm/v1/core/sched/output.py`). Under `uniproc_executor` the scheduler and the model runner therefore hold the *same* list object. Multiproc executors serialize the scheduler output, which deep-copies it — so this is a uniproc-only hazard.

2. Growing that list in place is core behaviour, not something only downstream code does: `Scheduler._update_request_as_session` extends `session.prompt_token_ids` with the kept output tokens and then with the new chunk, and updates `num_prompt_tokens`.

3. That core path is self-consistent because it also sets the request back to `WAITING`. It is then re-scheduled through `scheduled_new_reqs`, and `GPUModelRunner._update_streaming_request` re-derives everything downstream of the
   prompt — including `_init_mrope_positions` and `num_prompt_tokens`.

4. **The gap:** a request whose prompt grows while it is (or returns as) `RUNNING` is re-scheduled through `scheduled_cached_reqs`, where nothing refreshed that derived state.

`_calc_mrope_positions` reads the prompt length **live**:

```python
num_prompt_tokens = length_from_prompt_token_ids_or_embeds(
    req.prompt_token_ids, req.prompt_embeds)     # post-growth
...
src_start = num_computed_tokens                  # >= pre-growth length
self.mrope_positions.cpu[:, dst_start:dst_end] = req.mrope_positions[:, src_start:src_end]
```

but `req.mrope_positions` still has the pre-growth width. The two values come from different sources in the same function, so once `num_computed_tokens` reaches the old prompt length the source slice is empty and the copy fails with `[3, N]` vs `[3, 0]`.

The M-RoPE tensor is only the loudest symptom. The persistent batch is stale in the same way, and silently:

- `token_ids_cpu` / `is_token_ids` — on the last rank these are only refilled by `InputBatch.add_request`, so a request that stays resident across the growth keeps zeros where the new prompt should be, and the prefill continuation gathers
  `input_ids` from exactly that range.
- `num_tokens_no_spec` — the write index for sampled tokens (`token_ids_cpu[req_idx, start_idx:end_idx] = sampled_ids`) and for draft tokens (`InputBatch.update_req_spec_token_ids`). Left stale, sampled tokens land *inside* the grown prompt region and the next decode step gathers the wrong id. The existing realignment a few lines below only fires when output tokens were dropped (`num_output_tokens < len(req_state.output_token_ids)`), so a mid-prefill growth with no outputs to discard skips it entirely.

### Fix

Detect the growth where cached requests are updated (`_update_states`) and repair the whole set in `_refresh_grown_prompt_state`: re-run `_init_mrope_positions`, update `req_state.num_prompt_tokens`, and — when the request is resident in the persistent batch — refresh `num_prompt_tokens`, write the grown span into `token_ids_cpu` /
`is_token_ids`, and raise `num_tokens_no_spec`. State repair belongs in state update rather than in position calculation, and doing it here means every later consumer in the same pass already sees the corrected length.

- The growth check compares against the **stored prompt length**, not the M-RoPE tensor width: implementations whose `get_mrope_input_positions` also covers decode positions return a tensor wider than the prompt, which would mask the growth.
- Gated on `self.uses_mrope`; the check itself is `len()` vs an int, so non-M-RoPE models pay nothing and M-RoPE models pay O(1) per request per step.
- Uses `length_from_prompt_token_ids_or_embeds`, so `prompt_embeds`-only requests are handled rather than assumed to have token ids; the token-buffer write is skipped for them, matching `add_request`.
- Natural no-op under multiproc: the runner-side list never grows there.
- `output_token_ids` still needs no repair — the existing realignment handles it.

### Scope and non-goals

This makes core's cached-request path self-consistent for **any** in-place prompt growth producer, within the scope where that growth is observable: uniproc executors. Multiproc cannot reach this state by construction — serialization copies the list, so the growth is invisible to the runner rather than half-applied.

Making RUNNING re-feeds work under multiproc too is a different, larger change: it needs an explicit prompt-growth (or version) signal in `CachedRequestData` so the refresh can be driven from the scheduler side rather than inferred. Happy to write that up as an RFC if maintainers want it; it is deliberately out of scope here.

### Why not a defensive copy in `NewRequestData.from_request`

That was the other obvious option, and I think it is the wrong trade-off:

1. It adds an O(prompt_len) copy per new request on the scheduler hot path, taxing long-context serving to close a uniproc-only hazard.
2. It would blind the runner to *legitimate* streaming growth, converting a loud crash into silent state divergence — the runner would keep serving a prompt the scheduler no longer believes in.

### Relationship to vllm-project/vllm-omni#5684

@FayeSpica has a draft in vllm-omni that repairs the M-RoPE tensor in the omni subclass at the top of `_calc_mrope_positions`. That is a valid downstream mitigation and can stay as belt-and-suspenders.

Worth noting for reviewers that the two are complementary rather than redundant: the omni re-feed extends the prompt with **placeholder zeros** (`new_prompt = [0] * next_prompt_len` in `construct_next_stage_streaming_input_prompt`,
`vllm_omni/distributed/omni_connectors/adapter.py`) because the talker stage's real conditioning arrives as connector-transferred hidden states. Since `token_ids_cpu` is zero-initialised, the stale token buffer happens to be harmless *for that specific producer* — which is why an M-RoPE-only repair is sufficient downstream but not sufficient in core, where the next in-place-growth producer may carry real ids.

### Not a duplicate

Checked before opening (per `AGENTS.md`): #50731 has no assignee, no comments and no linked PRs; `gh pr list --search "mrope streaming in:title"` / `--search "prompt_token_ids"` / `--search "50731"` return no open core PR for this. The nearest open M-RoPE PRs (#48725 spec-decode headroom, #43832 draft-path M-RoPE mutation, #48835 chunked-prefill media mapping) touch different failure modes.

## Test Plan

New CPU-only regression test using a real `InputBatch` (host-only; the test unpins its allocations so it runs in the `cpu_test` lane) with a `SimpleNamespace` stub for the runner, mirroring the style of `tests/v1/worker/test_gpu_model_runner_mm_gather.py`:

```bash
pytest tests/v1/streaming_input/test_mrope_streaming_refeed.py -v
```

Each test seats a `CachedRequestState` in the batch, performs the scheduler-side in-place `extend` on the *same* list object, then drives `_update_states` over `scheduled_cached_reqs`:

| test | covers |
|---|---|
| `test_growth_does_not_break_mrope_calc` | the reported crash, via the real `_calc_mrope_positions` |
| `test_growth_refreshes_mrope_state` | positions re-derived, `num_prompt_tokens` updated |
| `test_growth_mid_prefill_repairs_batch_token_state` | k==0 growth: token span, mask and `num_tokens_no_spec` (the sampled-token write index) |
| `test_growth_after_output_fold_keeps_batch_consistent` | k>0 fold: outputs cleared, folded span values preserved, counters land on the new length |
| `test_growth_detected_when_mrope_tensor_is_wider_than_prompt` | growth inside a precomputed-decode tensor still detected |
| `test_unchanged_prompt_takes_the_fast_path` | no re-init, batch row untouched |
| `test_prompt_embeds_request_is_not_treated_as_grown` | embeds-only requests |

Adjacent suites run for regressions:

```bash
pytest tests/v1/streaming_input/test_scheduler_streaming.py tests/v1/worker/test_mrope_prompt_embeds.py
```

## Test Result

Before (this branch's tests against the parent commit) — the first failure reproduces the issue signature exactly, and the batch-state failures are the silent half:

```
FAILED test_growth_does_not_break_mrope_calc
E   RuntimeError: The expanded size of the tensor (7) must match the existing size (0)
    at non-singleton dimension 1.  Target sizes: [3, 7].  Tensor sizes: [3, 0]
    vllm/v1/worker/gpu_model_runner.py:2783
FAILED test_growth_refreshes_mrope_state
FAILED test_growth_mid_prefill_repairs_batch_token_state      E assert np.int32(12) == 19
FAILED test_growth_after_output_fold_keeps_batch_consistent   E assert np.int32(12) == 19
FAILED test_growth_detected_when_mrope_tensor_is_wider_than_prompt
5 failed, 2 passed
```

After:

```
tests/v1/streaming_input/test_mrope_streaming_refeed.py .......  7 passed
tests/v1/streaming_input/test_scheduler_streaming.py + tests/v1/worker/test_mrope_prompt_embeds.py  11 passed
```

`pre-commit run --files vllm/v1/worker/gpu_model_runner.py tests/v1/streaming_input/test_mrope_streaming_refeed.py`
passes (ruff check, ruff format, mypy, SPDX, forbidden-imports, …).

**Model evaluation:** not applicable — the new branch is unreachable unless a request's `prompt_token_ids` grows in place, which no core path does while the request is on the cached-request path. For every request core schedules today the check is false and behaviour is byte-identical, so decode output is unchanged.

**Verification status, split honestly:**

- *Done:* the CPU unit tests above, before/after, plus the adjacent suites.
- *Pending:* GPU end-to-end. Planned as Qwen3-Omni-30B-A3B on this branch + vllm-omni `main`, 32 concurrent `/v1/realtime` sessions per the issue, with transcript/audio diffed against a baseline run. I have **not** run it yet and make no e2e claim here.
- *Cannot run:* the reporter's Ascend NPU 910B2 configuration. I will ask for confirmation on vllm-omni#5234 once the GPU leg is green.

---

AI assistance was used in preparing this change: the trace, patch and tests were drafted with Claude. Opening as a **draft** while I review every changed line myself and run the GPU leg — I will mark it ready for review once that is done.

Fixes #50731
