### PR TITLE
[Bugfix][CPU][RISC-V] Fix FP16 rounding and cross-compilation capability handling

### DIFF
--- a/cmake/cpu_extension.cmake
+++ b/cmake/cpu_extension.cmake
@@ -16,6 +16,7 @@ endif()
 set(ENABLE_X86_ISA $ENV{VLLM_CPU_X86})
 set(ENABLE_ARM_BF16 $ENV{VLLM_CPU_ARM_BF16})
 set(ENABLE_ARM_I8MM $ENV{VLLM_CPU_ARM_I8MM})
+set(ENABLE_RVV_FP16 $ENV{VLLM_CPU_RVV_FP16})
 set(ENABLE_RVV_BF16 $ENV{VLLM_CPU_RVV_BF16})
 
 include_directories("${CMAKE_SOURCE_DIR}/csrc")
@@ -57,15 +58,22 @@ else()
     endif()
 endif()
 
-if (NOT MACOSX_FOUND)
+set(VLLM_RISCV_CROSSCOMPILING OFF)
+if(CMAKE_CROSSCOMPILING AND CMAKE_SYSTEM_PROCESSOR MATCHES "riscv64")
+    set(VLLM_RISCV_CROSSCOMPILING ON)
+endif()
+
+if (NOT MACOSX_FOUND AND NOT VLLM_RISCV_CROSSCOMPILING)
     execute_process(COMMAND cat /proc/cpuinfo
                     RESULT_VARIABLE CPUINFO_RET
                     OUTPUT_VARIABLE CPUINFO)
     if (NOT CPUINFO_RET EQUAL 0)
         message(FATAL_ERROR "Failed to check CPU features via /proc/cpuinfo")
     endif()
+elseif(VLLM_RISCV_CROSSCOMPILING)
+    message(STATUS
+        "Cross-compiling for RISC-V: skipping CPU feature detection from /proc/cpuinfo")
 endif()
-
 
 function (find_isa CPUINFO TARGET OUT)
     string(FIND ${CPUINFO} ${TARGET} ISA_FOUND)
@@ -99,15 +107,20 @@ if (MACOSX_FOUND AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
     check_sysctl(hw.optional.arm.FEAT_BF16 ARM_BF16_FOUND)
     check_sysctl(hw.optional.arm.FEAT_I8MM ARM_I8MM_FOUND)
 else()
-    find_isa(${CPUINFO} "Power11" POWER11_FOUND)
-    find_isa(${CPUINFO} "POWER10" POWER10_FOUND)
-    find_isa(${CPUINFO} "POWER9" POWER9_FOUND)
-    find_isa(${CPUINFO} "asimd" ASIMD_FOUND) # Check for ARM NEON support
-    find_isa(${CPUINFO} "bf16" ARM_BF16_FOUND) # Check for ARM BF16 support
-    find_isa(${CPUINFO} "i8mm" ARM_I8MM_FOUND) # Check for ARM I8MM support
-    find_isa(${CPUINFO} "S390" S390_FOUND)
-    find_isa(${CPUINFO} "zvfhmin" RVV_FP16_FOUND) # Check for RISC-V Vector FP16 support
-    find_isa(${CPUINFO} "zvfbfmin" RVV_BF16_FOUND) # Check for RISC-V Vector BF16 support
+    if(VLLM_RISCV_CROSSCOMPILING)
+        set(RVV_FP16_FOUND OFF)
+        set(RVV_BF16_FOUND OFF)
+    else()
+        find_isa(${CPUINFO} "Power11" POWER11_FOUND)
+        find_isa(${CPUINFO} "POWER10" POWER10_FOUND)
+        find_isa(${CPUINFO} "POWER9" POWER9_FOUND)
+        find_isa(${CPUINFO} "asimd" ASIMD_FOUND) # Check for ARM NEON support
+        find_isa(${CPUINFO} "bf16" ARM_BF16_FOUND) # Check for ARM BF16 support
+        find_isa(${CPUINFO} "i8mm" ARM_I8MM_FOUND) # Check for ARM I8MM support
+        find_isa(${CPUINFO} "S390" S390_FOUND)
+        find_isa(${CPUINFO} "zvfhmin" RVV_FP16_FOUND) # Check for RISC-V Vector FP16 support
+        find_isa(${CPUINFO} "zvfbfmin" RVV_BF16_FOUND) # Check for RISC-V Vector BF16 support
+    endif()
 
     # Support cross-compilation by allowing override via environment variables
     if (ENABLE_ARM_BF16)
@@ -118,6 +131,10 @@ else()
         set(ARM_I8MM_FOUND ON)
         message(STATUS
             "ARM I8MM support enabled via VLLM_CPU_ARM_I8MM environment variable")
+    endif()
+    if (ENABLE_RVV_FP16)
+        set(RVV_FP16_FOUND ON)
+        message(STATUS "RVV FP16 support enabled via VLLM_CPU_RVV_FP16 environment variable")
     endif()
     # Some kernels (e.g. Bianbu on Spacemit X100) do not report zvfbfmin
     # in /proc/cpuinfo despite hardware support. VLLM_CPU_RVV_BF16=1
@@ -194,6 +211,13 @@ elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "riscv64")
         message(FATAL_ERROR
             "VLLM_RVV_VLEN must be zero or a positive integer; got '${VLLM_RVV_VLEN}'")
     endif()
+    if(VLLM_RISCV_CROSSCOMPILING AND DEFINED VLLM_RVV_VLEN AND
+            VLLM_RVV_VLEN EQUAL 0 AND
+            (RVV_FP16_FOUND OR RVV_BF16_FOUND))
+        message(FATAL_ERROR
+            "VLLM_RVV_VLEN=0 requests a scalar RISC-V build and cannot be "
+            "combined with VLLM_CPU_RVV_FP16=1 or VLLM_CPU_RVV_BF16=1.")
+    endif()
     # VLLM_RVV_VLEN selects the target VLEN. Auto-detected from /proc/cpuinfo
     # by default; set -DVLLM_RVV_VLEN=0 to force scalar RISC-V build.
     # Override with -DVLLM_RVV_VLEN=128 or -DVLLM_RVV_VLEN=256 for RVV.
@@ -230,6 +254,14 @@ elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "riscv64")
                 "  CMAKE_ARGS='-DVLLM_RVV_VLEN=128'   (for VLEN=128 hardware)\n"
                 "  CMAKE_ARGS='-DVLLM_RVV_VLEN=256'   (for VLEN=256 hardware, e.g. Spacemit X100)")
         endif()
+    endif()
+    if(VLLM_RISCV_CROSSCOMPILING AND VLLM_RVV_VLEN AND
+            VLLM_RVV_VLEN GREATER 0 AND
+            NOT (RVV_FP16_FOUND OR RVV_BF16_FOUND))
+        message(FATAL_ERROR
+            "RISC-V cross-compilation with VLLM_RVV_VLEN>0 requires "
+            "explicit target capability information. Set "
+            "VLLM_CPU_RVV_FP16=1 or VLLM_CPU_RVV_BF16=1.")
     endif()
     if(VLLM_RVV_VLEN AND VLLM_RVV_VLEN GREATER 0)
         message(STATUS "RISC-V RVV VLEN=${VLLM_RVV_VLEN}")

--- a/csrc/cpu/cpu_types_riscv_impl.hpp
+++ b/csrc/cpu/cpu_types_riscv_impl.hpp
@@ -937,10 +937,12 @@ inline void storeFP32<c10::Half>(float v, c10::Half* ptr) {
 }
 
 inline FP16Vec16::FP16Vec16(const FP32Vec16& v) {
-  reg = RVVI(__riscv_vfncvt_f_f_w_f16, LMUL_256)(v.reg, VEC_ELEM_NUM);
+  reg = RVVI3(__riscv_vfncvt_f_f_w_f16, LMUL_256, _rm)(
+      v.reg, __RISCV_FRM_RNE, VEC_ELEM_NUM);
 }
 inline FP16Vec8::FP16Vec8(const FP32Vec8& v) {
-  reg = RVVI(__riscv_vfncvt_f_f_w_f16, LMUL_128)(v.reg, VEC_ELEM_NUM);
+  reg = RVVI3(__riscv_vfncvt_f_f_w_f16, LMUL_128, _rm)(
+      v.reg, __RISCV_FRM_RNE, VEC_ELEM_NUM);
 }
 inline FP32Vec16::FP32Vec16(const FP16Vec16& v) {
   reg = RVVI(__riscv_vfwcvt_f_f_v_f32, LMUL_512)(v.reg, VEC_ELEM_NUM);

--- a/csrc/cpu/cpu_types_riscv_impl.hpp
+++ b/csrc/cpu/cpu_types_riscv_impl.hpp
@@ -937,12 +937,12 @@ inline void storeFP32<c10::Half>(float v, c10::Half* ptr) {
 }
 
 inline FP16Vec16::FP16Vec16(const FP32Vec16& v) {
-  reg = RVVI3(__riscv_vfncvt_f_f_w_f16, LMUL_256, _rm)(
-      v.reg, __RISCV_FRM_RNE, VEC_ELEM_NUM);
+  reg = RVVI3(__riscv_vfncvt_f_f_w_f16, LMUL_256, _rm)(v.reg, __RISCV_FRM_RNE,
+                                                       VEC_ELEM_NUM);
 }
 inline FP16Vec8::FP16Vec8(const FP32Vec8& v) {
-  reg = RVVI3(__riscv_vfncvt_f_f_w_f16, LMUL_128, _rm)(
-      v.reg, __RISCV_FRM_RNE, VEC_ELEM_NUM);
+  reg = RVVI3(__riscv_vfncvt_f_f_w_f16, LMUL_128, _rm)(v.reg, __RISCV_FRM_RNE,
+                                                       VEC_ELEM_NUM);
 }
 inline FP32Vec16::FP32Vec16(const FP16Vec16& v) {
   reg = RVVI(__riscv_vfwcvt_f_f_v_f32, LMUL_512)(v.reg, VEC_ELEM_NUM);


### PR DESCRIPTION


## Purpose

This PR fixes two RISC-V CPU correctness issues.

First, the FP32-to-FP16 constructors used the implicit-rounding form of the
`vfncvt.f.f.w` intrinsic. The generated narrowing operation therefore used
the current dynamic floating-point rounding mode in `frm`, making its results
dependent on the caller's floating-point environment.

The
[RISC-V V specification](https://docs.riscv.org/reference/isa/unpriv/v-st-ext)
states:

> All vector floating-point operations use the dynamic rounding mode in the
> `frm` register.

The
[RISC-V Vector C Intrinsic specification](https://docs.riscv.org/reference/vector-c-intrinsics/rvv-intrinsic-spec.html)
provides an explicit-rounding interface for controlling this state:

> The floating-point intrinsics with the `frm` argument are followed by an
> `_rm` suffix in the function name.

It defines `__RISCV_FRM_RNE` as the explicit intrinsic argument for RNE. The
[RISC-V F specification](https://docs.riscv.org/reference/isa/unpriv/f-st-ext.html)
defines RNE (`000`) as “Round to Nearest, ties to Even.”

This PR therefore uses the explicit `_rm` intrinsic with
`__RISCV_FRM_RNE`. This makes the FP32-to-FP16 result independent of the
incoming rounding mode while preserving the caller-visible value of `frm`.

This is related to
[#47983](https://github.com/vllm-project/vllm/pull/47983), which proposes
explicit RNE for float-to-integer conversions. However, #47983 remains open
at the time of writing, so there is not yet a clear maintainer decision that
the related RISC-V conversion paths should uniformly use RNE.

The justification for this change is narrower and specific to FP32-to-FP16
conversion. The existing x86 implementation in
[`csrc/cpu/cpu_types_x86.hpp`](https://github.com/vllm-project/vllm/blob/main/csrc/cpu/cpu_types_x86.hpp)
passes `_MM_FROUND_TO_NEAREST_INT` explicitly, while the generic scalar
fallback uses `float_to_fp16()` from
[`csrc/cpu/float_convert.hpp`](https://github.com/vllm-project/vllm/blob/main/csrc/cpu/float_convert.hpp),
whose software conversion implements round-to-nearest-even. This PR aligns
the RISC-V FP32-to-FP16 path with those existing implementations without
assuming a broader project-wide rounding policy.

Second, riscv64 cross-compilation used the build host's `/proc/cpuinfo` to
infer target FP16/BF16 capabilities.

The RISC-V V specification describes VLEN as a property defined by each
vector-capable hart:

> Each hart supporting a vector extension defines two parameters,

including VLEN. The target VLEN and supported vector floating-point
extensions therefore cannot be inferred from the build host's
`/proc/cpuinfo` during cross-compilation.

The CMake changes:

* skip host capability detection only when cross-compiling for riscv64;
* add `VLLM_CPU_RVV_FP16=1`, matching the existing BF16 override;
* require an FP16 or BF16 capability to be detected or explicitly enabled
  when `VLLM_RVV_VLEN > 0`;
* reject an explicit RVV capability override combined with scalar
  `VLLM_RVV_VLEN=0`.

This is a follow-up to
[#47532](https://github.com/vllm-project/vllm/pull/47532), which guards VLEN
auto-detection but does not guard the earlier FP16/BF16 capability detection.

The changes intentionally do not modify BF16 conversion semantics, other
architectures' cross-compilation logic, or oneDNN sub-build ISA selection.

AI assistance was used for investigation, implementation, and drafting. The
author manually reviewed every changed line and the validation results.

## Test Plan

### FP32-to-FP16 conversion

Cross-compile an out-of-tree harness against vLLM's production RISC-V headers
using Clang 18, at both `-O2` and `-O3 -DNDEBUG`:

```bash
clang++ --target=riscv64-linux-gnu --gcc-toolchain=/usr \
  -march=rv64gcv_zvfh_zvl128b -mrvv-vector-bits=zvl -mabi=lp64d \
  -std=c++20 -O2 -I csrc/cpu \
  -isystem "${TORCH_INCLUDE}" -isystem "${TORCH_API_INCLUDE}" \
  test_vllm_fp16_path_fixed.cpp -o test_vllm_fp16_path
```

Run the binaries on riscv64 hardware under RNE, RTZ, RDN, and RUP, using both
direct `frm` writes and `std::fesetround`. Compare `FP16Vec8` and `FP16Vec16`
against an explicit-RNE RVV oracle and a scalar RNE oracle.

### Cross-compilation configuration

Use a fresh build directory for each case. Set or unset
`VLLM_CPU_RVV_FP16` and `VLLM_CPU_RVV_BF16` in the environment as required
for each test case:

```bash
cmake -S . -B "${BUILD_DIR}" -G Ninja \
  -DVLLM_TARGET_DEVICE=cpu \
  -DVLLM_PYTHON_EXECUTABLE="${PYTHON}" \
  -DCMAKE_TOOLCHAIN_FILE="${RISCV_TOOLCHAIN}" \
  -DCMAKE_BUILD_TYPE=Release \
  -DVLLM_RVV_VLEN="${VLEN}"
```

Omit `-DVLLM_RVV_VLEN` for the missing-VLEN case.

Test scalar, missing-capability, FP16, BF16, missing-VLEN, and conflicting
scalar/RVV inputs. Also run a native x86_64 configuration and inspect the
generated `_C` commands in `compile_commands.json`.

## Test Result

FP32-to-FP16 runtime results on riscv64 hardware:

```text
-O2:          96 cases, 0 failures, PASS
-O3 -DNDEBUG: 96 cases, 0 failures, PASS
```

The results matched RNE under all tested caller rounding modes, and the
caller's `frm` was preserved. Disassembly showed explicit RNE setup,
narrowing, and `frm` restoration in both constructor implementations.

Cross-compilation configuration results:

| Input                                           | Result                                                     |
| ----------------------------------------------- | ---------------------------------------------------------- |
| `VLLM_RVV_VLEN=0`                               | Success; `_C` uses `-march=rv64gc`                         |
| `VLLM_RVV_VLEN=128`, no capability override     | Expected failure requesting the target capability          |
| `VLLM_RVV_VLEN=128`, `VLLM_CPU_RVV_FP16=1`      | Success; `_C` uses `rv64gcv_zvfh_zvl128b`                  |
| `VLLM_RVV_VLEN=128`, `VLLM_CPU_RVV_BF16=1`      | Success; `_C` uses `rv64gcv_zvfh_zfbfmin_zvfbfmin_zvl128b` |
| BF16 capability override without VLEN           | Expected failure requesting an explicit VLEN               |
| `VLLM_RVV_VLEN=0` with FP16 capability override | Expected scalar/RVV conflict failure                       |
| Native x86_64                                   | Success; existing AVX detection unchanged                  |

```text
git diff --check: PASS
```

Not run: a complete vLLM cross-build, model evaluation, the full pre-commit
suite, or VLEN=256 validation. The PR should remain a draft until the required
model evaluation is added or maintainers confirm that the targeted numerical
validation is sufficient.

No user-facing documentation change is included. The new FP16 override is
described by the CMake diagnostics and this PR, and no existing user-facing
documentation was found for the sibling BF16 override. Maintainer guidance is
welcome on whether both overrides should be added to the CPU build
documentation.

---

<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

* [x] The purpose of the PR, including related upstream work.
* [x] The test plan and commands.
* [x] The test results and before/after behavior.
* [x] Documentation impact was considered.

</details>

