### PR TITLE
[Bugfix][Frontend] Reject empty gRPC stop strings

### DIFF
--- a/rust/src/server/src/grpc/convert.rs
+++ b/rust/src/server/src/grpc/convert.rs
@@ -57,6 +57,11 @@ pub fn to_text_request(
     let sampling = req.sampling.as_ref();
     let decoding = req.decoding.as_ref();
     let stopping = req.stopping.as_ref();
+    if let Some(stopping) = stopping {
+        if stopping.stop_strings.iter().any(|s| s.is_empty()) {
+            return Err(Status::invalid_argument("stop strings cannot be empty"));
+        }
+    }
     let response = req.response.as_ref();
     let kv = req.kv.as_ref();
 
@@ -584,6 +589,23 @@ mod tests {
         assert_eq!(text.sampling_params.skip_reading_prefix_cache, None);
         // Prompt conversion still succeeds and reaches the expected variant.
         assert!(matches!(text.prompt, Prompt::Text(s) if s == "hi"));
+    }
+
+    #[test]
+    fn empty_stop_string_is_rejected() {
+        let req = pb::GenerateRequest {
+            stopping: Some(pb::StoppingCriteria {
+                stop_strings: vec!["".to_string()],
+                ..Default::default()
+            }),
+            ..base_request()
+        };
+
+        let err = to_text_request(req, false, &["test-model".to_string()])
+            .expect_err("empty stop string should be rejected");
+
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("stop strings cannot be empty"));
     }
 
     fn finished(reason: FinishReason) -> Finished {

--- a/rust/src/server/src/grpc/tests.rs
+++ b/rust/src/server/src/grpc/tests.rs
@@ -652,6 +652,32 @@ async fn unary_generate_min_tokens_above_max_tokens_returns_invalid_argument() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
+async fn unary_generate_empty_stop_string_returns_invalid_argument() {
+    let (mut client, server_task, _engine_task) =
+        grpc_test_server(b"engine-grpc-empty-stop", default_stream_output_specs()).await;
+
+    let status = client
+        .generate(pb::GenerateRequest {
+            request_id: "test-empty-stop".to_string(),
+            model: "test-model".to_string(),
+            prompt: Some(pb::generate_request::Prompt::Text("hi".to_string())),
+            stopping: Some(pb::StoppingCriteria {
+                stop_strings: vec!["".to_string()],
+                ..Default::default()
+            }),
+            ..Default::default()
+        })
+        .await
+        .expect_err("should fail when stop_strings contains an empty string");
+
+    assert_eq!(status.code(), tonic::Code::InvalidArgument);
+    assert!(status.message().contains("stop strings cannot be empty"));
+
+    server_task.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
 async fn unary_generate_invalid_sampling_params_returns_invalid_argument() {
     let (mut client, server_task, _engine_task) = grpc_test_server(
         b"engine-grpc-invalid-sampling",


### PR DESCRIPTION
## Summary
- Reject empty `stopping.stop_strings` during gRPC request conversion.
- Return `InvalidArgument` before invalid stop strings reach the text decoder.
- Add conversion and unary gRPC regression coverage.

Fixes #50725

## Test Plan
- `cargo test -p vllm-server empty_stop_string_is_rejected -- --nocapture`
- `cargo test -p vllm-server unary_generate_empty_stop_string_returns_invalid_argument -- --nocapture`
- `cargo test -p vllm-server grpc::convert::tests -- --nocapture`
- `cargo test -p vllm-server grpc::tests -- --nocapture`
- `cargo fmt --check`