### PR TITLE
[Bugfix][Frontend] Reject empty gRPC stop strings

### DIFF
--- a/rust/src/server/src/grpc/convert.rs
+++ b/rust/src/server/src/grpc/convert.rs
@@ -57,11 +57,6 @@ pub fn to_text_request(
     let sampling = req.sampling.as_ref();
     let decoding = req.decoding.as_ref();
     let stopping = req.stopping.as_ref();
-    if let Some(stopping) = stopping {
-        if stopping.stop_strings.iter().any(|s| s.is_empty()) {
-            return Err(Status::invalid_argument("stop strings cannot be empty"));
-        }
-    }
     let response = req.response.as_ref();
     let kv = req.kv.as_ref();
 
@@ -589,23 +584,6 @@ mod tests {
         assert_eq!(text.sampling_params.skip_reading_prefix_cache, None);
         // Prompt conversion still succeeds and reaches the expected variant.
         assert!(matches!(text.prompt, Prompt::Text(s) if s == "hi"));
-    }
-
-    #[test]
-    fn empty_stop_string_is_rejected() {
-        let req = pb::GenerateRequest {
-            stopping: Some(pb::StoppingCriteria {
-                stop_strings: vec!["".to_string()],
-                ..Default::default()
-            }),
-            ..base_request()
-        };
-
-        let err = to_text_request(req, false, &["test-model".to_string()])
-            .expect_err("empty stop string should be rejected");
-
-        assert_eq!(err.code(), tonic::Code::InvalidArgument);
-        assert!(err.message().contains("stop strings cannot be empty"));
     }
 
     fn finished(reason: FinishReason) -> Finished {

--- a/rust/src/server/src/grpc/convert.rs
+++ b/rust/src/server/src/grpc/convert.rs
@@ -57,6 +57,11 @@ pub fn to_text_request(
     let sampling = req.sampling.as_ref();
     let decoding = req.decoding.as_ref();
     let stopping = req.stopping.as_ref();
+    if let Some(stopping) = stopping {
+        if stopping.stop_strings.iter().any(|s| s.is_empty()) {
+            return Err(Status::invalid_argument("stop strings cannot be empty"));
+        }
+    }
     let response = req.response.as_ref();
     let kv = req.kv.as_ref();
 
@@ -584,6 +589,23 @@ mod tests {
         assert_eq!(text.sampling_params.skip_reading_prefix_cache, None);
         // Prompt conversion still succeeds and reaches the expected variant.
         assert!(matches!(text.prompt, Prompt::Text(s) if s == "hi"));
+    }
+
+    #[test]
+    fn empty_stop_string_is_rejected() {
+        let req = pb::GenerateRequest {
+            stopping: Some(pb::StoppingCriteria {
+                stop_strings: vec!["".to_string()],
+                ..Default::default()
+            }),
+            ..base_request()
+        };
+
+        let err = to_text_request(req, false, &["test-model".to_string()])
+            .expect_err("empty stop string should be rejected");
+
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("stop strings cannot be empty"));
     }
 
     fn finished(reason: FinishReason) -> Finished {

--- a/rust/src/server/src/grpc/tests.rs
+++ b/rust/src/server/src/grpc/tests.rs
@@ -652,6 +652,32 @@ async fn unary_generate_min_tokens_above_max_tokens_returns_invalid_argument() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
+async fn unary_generate_empty_stop_string_returns_invalid_argument() {
+    let (mut client, server_task, _engine_task) =
+        grpc_test_server(b"engine-grpc-empty-stop", default_stream_output_specs()).await;
+
+    let status = client
+        .generate(pb::GenerateRequest {
+            request_id: "test-empty-stop".to_string(),
+            model: "test-model".to_string(),
+            prompt: Some(pb::generate_request::Prompt::Text("hi".to_string())),
+            stopping: Some(pb::StoppingCriteria {
+                stop_strings: vec!["".to_string()],
+                ..Default::default()
+            }),
+            ..Default::default()
+        })
+        .await
+        .expect_err("should fail when stop_strings contains an empty string");
+
+    assert_eq!(status.code(), tonic::Code::InvalidArgument);
+    assert!(status.message().contains("stop strings cannot be empty"));
+
+    server_task.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
 async fn unary_generate_invalid_sampling_params_returns_invalid_argument() {
     let (mut client, server_task, _engine_task) = grpc_test_server(
         b"engine-grpc-invalid-sampling",

--- a/rust/src/text/src/error.rs
+++ b/rust/src/text/src/error.rs
@@ -15,6 +15,8 @@ pub enum Error {
     Tokenizer(String),
     #[error("text request `{request_id}` must contain at least one prompt token ID")]
     EmptyPromptTokenIds { request_id: String },
+    #[error("text request `{request_id}` stop strings cannot be empty")]
+    EmptyStopString { request_id: String },
     #[error(
         "this model's maximum context length is {max_model_len} tokens, \
          but the prompt contains {prompt_len} input tokens"
@@ -51,6 +53,7 @@ impl Error {
         match self {
             Self::PromptTooLong { .. }
             | Self::EmptyPromptTokenIds { .. }
+            | Self::EmptyStopString { .. }
             | Self::Logprobs(_)
             | Self::TokenIds(_)
             | Self::SamplingParams(_)

--- a/rust/src/text/src/output/decoded.rs
+++ b/rust/src/text/src/output/decoded.rs
@@ -126,14 +126,12 @@ pub async fn decoded_text_event_stream(
                 // when streaming the outputs.
                 match decode_options.include_stop_str_in_output {
                     true => 0,
-                    false => {
-                        decode_options
-                            .stop_strings
-                            .as_ref()
-                            .and_then(|stops| stops.iter().map(|ss| ss.len()).max())
-                            .unwrap_or(1)
-                            - 1
-                    }
+                    false => decode_options
+                        .stop_strings
+                        .as_ref()
+                        .and_then(|stops| stops.iter().map(|ss| ss.len()).max())
+                        .unwrap_or(1)
+                        .saturating_sub(1),
                 },
             );
             decoder = Some(dec);
@@ -321,6 +319,9 @@ fn matches_stop_string(stops: &[String], output: &str, new_bytes: usize) -> Opti
         .map(|ss| (ss.as_bytes(), ss.len(), next_off.saturating_sub(ss.len())))
         .enumerate()
         .filter_map(|(ss_idx, (ss, len, start_off))| {
+            if len == 0 {
+                return None;
+            }
             output[start_off..]
                 .windows(len)
                 .position(|w| w == ss)
@@ -455,6 +456,13 @@ mod tests {
     #[tokio::test]
     async fn stream_stop_string_no_match_runs_to_completion() {
         let output = run_to_completion(ascii_tokens("hello"), opts(&["z"], 0)).await;
+        assert_eq!(output.text, "hello");
+        assert_eq!(output.finish_reason, FinishReason::Length);
+    }
+
+    #[tokio::test]
+    async fn stream_empty_stop_string_does_not_underflow_buffer() {
+        let output = run_to_completion(ascii_tokens("hello"), opts(&[""], 0)).await;
         assert_eq!(output.text, "hello");
         assert_eq!(output.finish_reason, FinishReason::Length);
     }
@@ -632,6 +640,13 @@ mod tests {
     #[test]
     fn stop_string_empty_list() {
         let stops: Vec<String> = vec![];
+        let result = matches_stop_string(&stops, "hello", 1);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn empty_stop_string_is_ignored_by_matcher() {
+        let stops = vec!["".to_string(), "world".to_string()];
         let result = matches_stop_string(&stops, "hello", 1);
         assert_eq!(result, None);
     }

--- a/rust/src/text/src/request.rs
+++ b/rust/src/text/src/request.rs
@@ -225,6 +225,34 @@ impl TextRequest {
                 request_id: self.request_id.clone(),
             });
         }
+        if self
+            .decode_options
+            .stop_strings
+            .as_ref()
+            .is_some_and(|stops| stops.iter().any(String::is_empty))
+        {
+            return Err(Error::EmptyStopString {
+                request_id: self.request_id.clone(),
+            });
+        }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_rejects_empty_stop_string_at_shared_chokepoint() {
+        let mut request = TextRequest::for_test();
+        request.request_id = "req-empty-stop".to_string();
+        request.decode_options.stop_strings = Some(vec!["valid".to_string(), String::new()]);
+
+        let err = request.validate().expect_err("empty stop strings should be rejected");
+
+        assert!(err.is_request_validation_error());
+        assert!(err.to_string().contains("stop strings cannot be empty"));
+        assert!(err.to_string().contains("req-empty-stop"));
     }
 }


### PR DESCRIPTION
## Summary
- Reject empty `stopping.stop_strings` during gRPC request conversion.
- Return `InvalidArgument` before invalid stop strings reach the text decoder.
- Add conversion and unary gRPC regression coverage.

Fixes #50725

## Test Plan
- `cargo test -p vllm-server empty_stop_string_is_rejected -- --nocapture`
- `cargo test -p vllm-server unary_generate_empty_stop_string_returns_invalid_argument -- --nocapture`
- `cargo test -p vllm-server grpc::convert::tests -- --nocapture`
- `cargo test -p vllm-server grpc::tests -- --nocapture`
- `cargo fmt --check`