### PR TITLE
[Bugfix] Preflight FlashInfer sampler JIT compilability instead of crashing engine warmup

### DIFF
--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -59,6 +59,26 @@ def flashinfer_sampler_supported() -> bool:
         )
 
     if unsupported_reason is None:
+        # FlashInfer sampling kernels are JIT-compiled on first use. Verify up
+        # front that its JIT can target this GPU, otherwise the first sampling
+        # call raises deep inside engine warmup and takes the engine down with
+        # a misleading error (e.g. a local CUDA toolkit too old for the GPU
+        # architecture; see #50705, and #49497 for the undiscoverable-nvcc
+        # variant).
+        try:
+            from flashinfer.jit.core import check_cuda_arch
+        except ImportError:
+            check_cuda_arch = None
+        if check_cuda_arch is not None:
+            try:
+                check_cuda_arch()
+            except Exception as e:
+                unsupported_reason = (
+                    f"FlashInfer JIT cannot compile for this GPU "
+                    f"({type(e).__name__}: {e})"
+                )
+
+    if unsupported_reason is None:
         logger.info_once("Using FlashInfer for top-p & top-k sampling.", scope="global")
         return True
     if envs.is_set("VLLM_USE_FLASHINFER_SAMPLER"):


### PR DESCRIPTION
## Purpose

The FlashInfer top-p/top-k sampler is enabled by default whenever the GPU's
compute capability is supported, but its kernels are JIT-compiled on first use,
and `flashinfer_sampler_supported()` never checks whether the local CUDA
toolchain can actually compile for the GPU. When it can't — observed on an RTX
PRO 6000 Blackwell Server Edition (sm_120) with a local CUDA 12.8 toolkit
(flashinfer 0.6.14 requires >= 12.9 for SM 12.x) — the first sampling call
raises during engine warmup and takes down the engine with a doubly misleading
error:

```
RuntimeError: FlashInfer requires GPUs with sm75 or higher
```

(the GPU is sm_120, and the real blocker is the toolkit version), even though
the native sampler works fine on the same machine.

This PR adds a JIT-compilability preflight to the existing
`unsupported_reason` fallback ladder in `flashinfer_sampler_supported()`:

- default settings: warn and fall back to the native sampler — the engine
  boots;
- explicit `VLLM_USE_FLASHINFER_SAMPLER=1`: fail fast at sampler selection with
  the real reason, instead of a deep warmup crash;
- if `flashinfer.jit.core.check_cuda_arch` is ever unavailable (API move),
  the ImportError guard preserves today's behavior.

Part of #50705 (sampler path). Likely also relevant to #49497, where an
undiscoverable nvcc reaches the same JIT path with no fallback.

## Test Plan

On the affected hardware (Colab, RTX PRO 6000 Blackwell SE, sm_120, local nvcc
12.8, flashinfer 0.6.14, driver 580.82.07; vLLM 0.26.0, whose
`flashinfer_sampler_supported()` is structurally identical to main), boot
`LLM(model="Qwen/Qwen2.5-0.5B-Instruct", max_model_len=1024, enforce_eager=True)`
under four configurations, with this exact change applied to the installed
package.

## Test Result

| Scenario | Result |
|---|---|
| stock, default env | rc=1 — warmup crash: `RuntimeError: FlashInfer requires GPUs with sm75 or higher` |
| **patched, default env** | **rc=0 — engine boots**; log: `FlashInfer top-p/top-k sampling unavailable: FlashInfer JIT cannot compile for this GPU (RuntimeError: FlashInfer requires GPUs with sm75 or higher); falling back. Set VLLM_USE_FLASHINFER_SAMPLER=0 to silence.` |
| patched, `VLLM_USE_FLASHINFER_SAMPLER=1` | rc=1 — fails fast at selection: `RuntimeError: FlashInfer top-p/top-k sampling unavailable: FlashInfer JIT cannot compile for this GPU (...). Unset VLLM_USE_FLASHINFER_SAMPLER=1.` |
| patched, `VLLM_USE_FLASHINFER_SAMPLER=0` | rc=0 — unchanged opt-out path |

`pre-commit` (ruff, mypy-3.10, SPDX, sign-off) passes on the changed file.

---

This PR was developed with AI assistance (Claude); I reviewed, adapted, and
validated the change and the measurements myself.
