### PR TITLE
fix(model): ensure cpu tensor contiguity during Llama4 ModelOpt weight loading

### DIFF
--- a/tests/models/test_llama4_moe.py
+++ b/tests/models/test_llama4_moe.py
@@ -1,0 +1,48 @@
+import torch
+from unittest.mock import MagicMock
+
+from vllm.model_executor.models.llama4 import Llama4ForCausalLM
+
+
+def test_llama4_moe_weight_loading_contiguity():
+    """Verify that non-contiguous CPU tensors become contiguous before weight_loader is called."""
+    # Create non-contiguous CPU tensor via transpose
+    raw_tensor = torch.randn(4, 32, 64, device="cpu")
+    non_contiguous_weight = raw_tensor.transpose(-1, -2)
+    assert not non_contiguous_weight.is_contiguous()
+
+    received_tensors = []
+
+    def mock_weight_loader(param, loaded_weight, param_name, shard_id=None, expert_id=None):
+        received_tensors.append(loaded_weight)
+
+    param = torch.nn.Parameter(torch.empty(32, 64, device="cpu"))
+    param.weight_loader = mock_weight_loader
+
+    params_dict = {
+        "model.layers.0.feed_forward.experts.0.gate_up_proj.weight": param
+    }
+
+    expert_params_mapping = [
+        ("model.layers.0.feed_forward.experts.0.gate_up_proj.", "experts.0.gate_up_proj.", 0, "w1")
+    ]
+
+    model_stub = MagicMock(spec=Llama4ForCausalLM)
+    model_stub.layers = [MagicMock()]
+    model_stub.layers[0].feed_forward.experts.expert_map = None
+
+    loaded_params = set()
+    result = Llama4ForCausalLM._load_moe_matrix(
+        model_stub,
+        name="model.layers.0.feed_forward.experts.0.gate_up_proj.weight",
+        loaded_weight=non_contiguous_weight,
+        params_dict=params_dict,
+        expert_params_mapping=expert_params_mapping,
+        loaded_params=loaded_params,
+        fused=True,
+    )
+
+    assert result is True
+    assert len(received_tensors) > 0
+    for weight in received_tensors:
+        assert weight.is_contiguous(), "Loaded weight passed to weight_loader must be contiguous"

--- a/vllm/model_executor/models/llama4.py
+++ b/vllm/model_executor/models/llama4.py
@@ -525,6 +525,9 @@ class Llama4Model(LlamaModel):
                 # TODO: add EP support for non fused weights
                 pass
 
+            if not new_loaded_weight.is_contiguous():
+                new_loaded_weight = new_loaded_weight.contiguous()
+
             # Load the weight into the module parameter with corresponding
             # shard id and expert id.
             weight_loader(


### PR DESCRIPTION
Fixes #31624

### Motivation and Context
When loading ModelOpt fused MoE weights in `Llama4ForCausalLM._load_moe_matrix`, calling `loaded_weight.transpose(-1, -2)`, `chunk()`, or slicing creates non-contiguous CPU tensors. As reported by @robertgshaw2-redhat in #31624, copying non-contiguous CPU tensors to GPU parameters via `_copy()` causes PyTorch to fall back to strided CPU element copying taking 3-4s per weight, resulting in 5+ minute model loading times.

### Description of Changes
Ensures `new_loaded_weight` is contiguous (`new_loaded_weight.contiguous()`) before calling `weight_loader(...)`. This matches the contiguity handling in `bitsandbytes_loader.py` and `sharded_state_loader.py`, restoring fast contiguous DMA memory transfer during CPU to GPU parameter copying.