### PR TITLE
[Bugfix] Encode special tokens in HF processors for transformers-native mistral-common tokenizers

### DIFF
--- a/tests/models/multimodal/processing/test_mistral3.py
+++ b/tests/models/multimodal/processing/test_mistral3.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for Mistral3's multimodal preprocessing."""
+
+import pytest
+
+from vllm.config import ModelConfig
+from vllm.multimodal import MULTIMODAL_REGISTRY
+
+
+@pytest.mark.parametrize(
+    ("model_id", "revision"),
+    [
+        (
+            "unsloth/Mistral-Small-3.2-24B-Instruct-2506",
+            "3ed8d341b53ea3d0e4194689905477688a6cf733",
+        ),
+    ],
+)
+def test_dummy_mm_inputs_with_dual_format_checkpoint(model_id: str, revision: str):
+    """
+    HF-format Mistral3 checkpoints that also ship mistral-common tokenizer
+    files (tekken.json) resolve to transformers' `MistralCommonBackend`
+    under the default tokenizer mode. Building the dummy multi-modal inputs
+    (run at engine startup to profile memory usage) must not crash.
+
+    Regression test for https://github.com/vllm-project/vllm/issues/50706
+    where the tokenizer handed to `PixtralProcessor` did not encode the
+    `[IMG]` placeholder to its special token id, so engine initialization
+    died in `_check_special_mm_tokens` with default arguments.
+    """
+    model_config = ModelConfig(
+        model_id,
+        tokenizer=model_id,
+        revision=revision,
+        tokenizer_revision=revision,
+        max_model_len=8192,
+    )
+
+    processor = MULTIMODAL_REGISTRY.create_processor(model_config)
+    tokenizer = processor.info.ctx.tokenizer
+
+    hf_processor = processor.info.get_hf_processor()
+    image_token_id = tokenizer.convert_tokens_to_ids(hf_processor.image_token)
+
+    mm_inputs = MULTIMODAL_REGISTRY.get_dummy_mm_inputs(
+        model_config,
+        mm_counts={"image": 1},
+        processor=processor,
+    )
+
+    # The image placeholder must have been encoded to its special token id
+    # and located by the placeholder search.
+    assert image_token_id in mm_inputs["prompt_token_ids"]
+    assert mm_inputs["mm_placeholders"]["image"]

--- a/tests/models/multimodal/processing/test_mistral3.py
+++ b/tests/models/multimodal/processing/test_mistral3.py
@@ -7,6 +7,7 @@ import torch
 from PIL import Image
 from transformers import BatchFeature
 
+from vllm.config import ModelConfig
 from vllm.model_executor.models.lightonocr import LightOnOCRProcessingInfo
 from vllm.model_executor.models.mistral3 import Mistral3HFEncoderInfo
 from vllm.model_executor.models.pixtral import PixtralHFEncoderInfo
@@ -141,3 +142,49 @@ def test_lightonocr_keeps_vision_config_image_size():
     assert encoder_info.get_image_size() == (
         processor.info.get_hf_config().vision_config.image_size
     )
+
+@pytest.mark.parametrize(
+    ("model_id", "revision"),
+    [
+        (
+            "unsloth/Mistral-Small-3.2-24B-Instruct-2506",
+            "3ed8d341b53ea3d0e4194689905477688a6cf733",
+        ),
+    ],
+)
+def test_dummy_mm_inputs_with_dual_format_checkpoint(model_id: str, revision: str):
+    """
+    HF-format Mistral3 checkpoints that also ship mistral-common tokenizer
+    files (tekken.json) resolve to transformers' `MistralCommonBackend`
+    under the default tokenizer mode. Building the dummy multi-modal inputs
+    (run at engine startup to profile memory usage) must not crash.
+
+    Regression test for https://github.com/vllm-project/vllm/issues/50706
+    where the tokenizer handed to `PixtralProcessor` did not encode the
+    `[IMG]` placeholder to its special token id, so engine initialization
+    died in `_check_special_mm_tokens` with default arguments.
+    """
+    model_config = ModelConfig(
+        model_id,
+        tokenizer=model_id,
+        revision=revision,
+        tokenizer_revision=revision,
+        max_model_len=8192,
+    )
+
+    processor = MULTIMODAL_REGISTRY.create_processor(model_config)
+    tokenizer = processor.info.ctx.tokenizer
+
+    hf_processor = processor.info.get_hf_processor()
+    image_token_id = tokenizer.convert_tokens_to_ids(hf_processor.image_token)
+
+    mm_inputs = MULTIMODAL_REGISTRY.get_dummy_mm_inputs(
+        model_config,
+        mm_counts={"image": 1},
+        processor=processor,
+    )
+
+    # The image placeholder must have been encoded to its special token id
+    # and located by the placeholder search.
+    assert image_token_id in mm_inputs["prompt_token_ids"]
+    assert mm_inputs["mm_placeholders"]["image"]

--- a/vllm/multimodal/processing/context.py
+++ b/vllm/multimodal/processing/context.py
@@ -24,7 +24,7 @@ from vllm.tokenizers import TokenizerLike
 from vllm.transformers_utils.processor import cached_processor_from_config
 from vllm.utils.func_utils import get_allowed_kwarg_only_overrides
 from vllm.utils.jsontree import JSONTree, json_map_leaves
-from vllm.utils.mistral import is_mistral_tokenizer
+from vllm.utils.mistral import is_mistral_common_backend, is_mistral_tokenizer
 
 if TYPE_CHECKING:
     from transformers.configuration_utils import PretrainedConfig
@@ -198,6 +198,17 @@ class InputProcessingContext:
         tokenizer = self.tokenizer
         if is_mistral_tokenizer(tokenizer):
             tokenizer = tokenizer.transformers_tokenizer  # type: ignore[union-attr]
+        elif is_mistral_common_backend(tokenizer):
+            # `AutoTokenizer` resolves dual-format checkpoints (HF tokenizer
+            # files + tekken.json) to transformers' mistral-common backend,
+            # which never encodes special placeholder tokens (e.g. "[IMG]")
+            # from text. HF processors rely on that encoding, so swap in a
+            # variant that performs it.
+            from vllm.tokenizers.mistral import (
+                mistral_common_backend_with_special_tokens,
+            )
+
+            tokenizer = mistral_common_backend_with_special_tokens(tokenizer)
 
         merged_kwargs = self.get_merged_mm_kwargs(kwargs)
         merged_kwargs.pop("tokenizer", None)

--- a/vllm/multimodal/processing/context.py
+++ b/vllm/multimodal/processing/context.py
@@ -23,7 +23,7 @@ from vllm.tokenizers import TokenizerLike
 from vllm.transformers_utils.processor import cached_processor_from_config
 from vllm.utils.func_utils import get_allowed_kwarg_only_overrides
 from vllm.utils.jsontree import JSONTree, json_map_leaves
-from vllm.utils.mistral import is_mistral_tokenizer
+from vllm.utils.mistral import is_mistral_common_backend, is_mistral_tokenizer
 
 if TYPE_CHECKING:
     from transformers.configuration_utils import PretrainedConfig
@@ -197,6 +197,17 @@ class InputProcessingContext:
         tokenizer = self.tokenizer
         if is_mistral_tokenizer(tokenizer):
             tokenizer = tokenizer.transformers_tokenizer  # type: ignore[union-attr]
+        elif is_mistral_common_backend(tokenizer):
+            # `AutoTokenizer` resolves dual-format checkpoints (HF tokenizer
+            # files + tekken.json) to transformers' mistral-common backend,
+            # which never encodes special placeholder tokens (e.g. "[IMG]")
+            # from text. HF processors rely on that encoding, so swap in a
+            # variant that performs it.
+            from vllm.tokenizers.mistral import (
+                mistral_common_backend_with_special_tokens,
+            )
+
+            tokenizer = mistral_common_backend_with_special_tokens(tokenizer)
 
         merged_kwargs = self.get_merged_mm_kwargs(kwargs)
         merged_kwargs.pop("tokenizer", None)

--- a/vllm/tokenizers/mistral.py
+++ b/vllm/tokenizers/mistral.py
@@ -5,6 +5,7 @@ from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast, overload
 
+import regex as re
 from mistral_common.guidance.grammar_factory import GrammarFactory
 from mistral_common.guidance.tokenizer import from_mistral_tokenizer
 from mistral_common.protocol.instruct.request import (
@@ -204,6 +205,83 @@ def tekken_convert_tokens_to_string(
         ids = [_tekken_token_to_id(tokenizer, t) for t in tokens]
         return tokenizer.decode(ids, SpecialTokenPolicy.KEEP)
     return "".join(cast(Sequence[str], tokens))
+
+
+class _MistralCommonBackendWithSpecialTokens(MistralCommonBackend):
+    """`MistralCommonBackend` that encodes special tokens found in text.
+
+    mistral-common deliberately never encodes special tokens from text:
+    `encode("[IMG]")` tokenizes the literal string instead of returning the id
+    of the `[IMG]` token. HF processors (such as `PixtralProcessor`) insert
+    special placeholder tokens into the prompt text and rely on the tokenizer
+    to encode them back to their token ids, like HF tokenizers do for added
+    tokens.
+
+    This backend implements that behavior so HF processors can be used with
+    mistral-common tokenizers. It must only be used to tokenize trusted text,
+    not user-provided prompts.
+    """
+
+    @cached_property
+    def _special_token_to_id(self) -> dict[str, int]:
+        # `all_special_tokens` is aligned with `all_special_ids`.
+        return dict(zip(self.all_special_tokens, self.all_special_ids))
+
+    @cached_property
+    def _special_token_pattern(self) -> re.Pattern[str]:
+        # Longest match first, so a special token that is a prefix of another
+        # does not shadow it.
+        special_tokens = sorted(self.all_special_tokens, key=len, reverse=True)
+        return re.compile(f"({'|'.join(map(re.escape, special_tokens))})")
+
+    def _text_to_ids(self, text: str, add_special_tokens: bool) -> list[int]:
+        tokenizer = self.tokenizer.instruct_tokenizer.tokenizer
+
+        token_ids = list[int]()
+        # Segments at odd indices are the special tokens the pattern matched.
+        for i, segment in enumerate(self._special_token_pattern.split(text)):
+            if i % 2:
+                token_ids.append(self._special_token_to_id[segment])
+            elif segment:
+                token_ids.extend(tokenizer.encode(segment, bos=False, eos=False))
+
+        if add_special_tokens:
+            token_ids.insert(0, tokenizer.bos_id)
+            if self._mode == ValidationMode.finetuning:
+                token_ids.append(tokenizer.eos_id)
+
+        return token_ids
+
+
+def mistral_common_backend_with_special_tokens(
+    backend: MistralCommonBackend,
+) -> MistralCommonBackend:
+    """Variant of `backend` that encodes special tokens found in text,
+    which mistral-common never does.
+
+    HF processors insert special placeholder tokens (e.g. `"[IMG]"`) into the
+    prompt text and rely on the tokenizer to encode them back to their ids.
+    Only use the variant to tokenize trusted text, not user-provided prompts.
+    """
+    if isinstance(backend, _MistralCommonBackendWithSpecialTokens):
+        return backend
+
+    # Cache on the instance: callers (e.g. `cached_processor_from_config`)
+    # key their own caches on the tokenizer object, so returning a fresh
+    # instance per call would defeat them.
+    variant = getattr(backend, "_with_special_tokens_variant", None)
+    if variant is None:
+        variant = _MistralCommonBackendWithSpecialTokens(
+            tokenizer_path=backend._tokenizer_path,
+            mode=backend.mode,
+            model_max_length=backend.model_max_length,
+            padding_side=backend.padding_side,
+            truncation_side=backend.truncation_side,
+            model_input_names=backend.model_input_names,
+            clean_up_tokenization_spaces=backend.clean_up_tokenization_spaces,
+        )
+        backend._with_special_tokens_variant = variant
+    return variant
 
 
 class MistralTokenizer(TokenizerLike):

--- a/vllm/utils/mistral.py
+++ b/vllm/utils/mistral.py
@@ -11,6 +11,8 @@ from vllm.utils.import_utils import LazyLoader
 
 if TYPE_CHECKING:
     # if type checking, eagerly import the module
+    from transformers.tokenization_mistral_common import MistralCommonBackend
+
     import vllm.tokenizers.mistral as mt
 else:
     mt = LazyLoader("mt", globals(), "vllm.tokenizers.mistral")
@@ -26,6 +28,17 @@ def is_mistral_tokenizer(obj: TokenizerLike | None) -> TypeGuard[mt.MistralToken
         getattr(cls, "IS_MISTRAL_TOKENIZER", False)
         and isinstance(obj, mt.MistralTokenizer)
     )
+
+
+def is_mistral_common_backend(
+    obj: TokenizerLike | None,
+) -> TypeGuard[MistralCommonBackend]:
+    """Return true if the tokenizer is a transformers-native
+    `MistralCommonBackend` instance (`AutoTokenizer` returns one for
+    checkpoints that ship mistral-common tokenizer files)."""
+    from transformers.tokenization_mistral_common import MistralCommonBackend
+
+    return isinstance(obj, MistralCommonBackend)
 
 
 def is_mistral_tool_parser(cls: type | None) -> bool:


### PR DESCRIPTION
## Purpose

FIX #50706

Default initialization of HF-format Mistral3 checkpoints that also ship
mistral-common tokenizer files (e.g. `unsloth/Mistral-Small-3.2-24B-Instruct-2506`,
which contains both `tokenizer.json` and `tekken.json`) crashes during
multimodal memory profiling, before any user request:

```
ValueError: Failed to apply PixtralProcessor on data={'text': '[IMG]'} with
kwargs={'truncation': False, 'return_tensors': 'pt'}
```

Root cause (full analysis in
https://github.com/vllm-project/vllm/issues/50706#issuecomment-5159139617):
for such dual-format repos, transformers 5.x `AutoTokenizer` returns its native
mistral-common backend (`MistralCommonBackend`) — verified on 5.13.1 and 5.14.1 —
and mistral-common deliberately never encodes special tokens found in text, so
`encode("[IMG]")` yields the literal string tokens rather than the `[IMG]`
special token id. `InputProcessingContext.get_hf_processor` hands that tokenizer
to `PixtralProcessor`, whose `_check_special_mm_tokens` then counts 1 image
placeholder in the text but 0 in `input_ids` and raises. Engine init dies with
default arguments; no `--tokenizer-mode` opt-in is involved.

This PR adds a second branch next to the existing vLLM-`MistralTokenizer`
handling in `get_hf_processor`: when the context tokenizer is a
transformers-native `MistralCommonBackend`, it is swapped for a variant that
encodes special tokens found in text (the behavior HF processors rely on, and
what HF tokenizers do for added tokens). Plain-text tokenization is unchanged —
verified byte-identical against the stock backend — and the user-facing
tokenizer is untouched; only the processor-internal tokenizer is affected.

Relationship to #45289 / #45525: same underlying mechanism, complementary path.
#45525 (credit to @discobot — the `_text_to_ids` special-token encoding here
mirrors its approach so the two branches converge) fixes the crash for vLLM's
`MistralTokenizer` (`--tokenizer-mode mistral`); its `is_mistral_tokenizer()`
guard does not match the transformers-native backend that arrives under the
default tokenizer mode, which is the case this PR fixes. If #45525 lands, the
duplicated backend subclass can be trivially unified (happy to rebase either
way; heads-up that its `import re` will need `import regex as re` to pass the
current pre-commit hooks).

## Test Plan

New CPU-only regression test (no GPU needed):
`tests/models/multimodal/processing/test_mistral3.py` builds the multimodal
processor for the affected checkpoint (pinned revision) with default arguments
and runs `MULTIMODAL_REGISTRY.get_dummy_mm_inputs` — the exact profiling entry
that crashes at engine startup — then asserts the `[IMG]` placeholder is
encoded to its special token id and located by the placeholder search.

## Test Result

On this branch:

- `pytest tests/models/multimodal/processing/test_mistral3.py` — **1 passed** (~10 s, CPU).
- With only the `vllm/` changes reverted (test kept), the same test **fails**
  with the reported `Failed to apply PixtralProcessor` error, on both the
  text-only path and `get_dummy_mm_inputs` with an image.
- Direct check of the swapped backend: `encode("[IMG]")` → `[10]` (the `[IMG]`
  special id, matching `AutoProcessor`'s own tokenizer), and
  `encode("Hello world !")` is byte-identical to the stock
  `MistralCommonBackend`.
- `pre-commit` (ruff, mypy-3.10, SPDX, forbidden-imports) passes on all
  changed files.

---

This PR was developed with AI assistance (Claude); I reviewed, adapted, and
validated the change and the measurements myself.
