### PR TITLE
[Bugfix][Parser] Surface unterminated reasoning as content for deepseek_v4 (fixes #48645)

### DIFF
--- a/tests/parser/engine/replay_harness.py
+++ b/tests/parser/engine/replay_harness.py
@@ -119,11 +119,13 @@ def make_mock_tokenizer(sample: Sample) -> MockTokenizer:
 
 def _test_request(
     tools: list[dict] | None = None,
+    chat_template_kwargs: dict | None = None,
 ) -> ChatCompletionRequest:
     return ChatCompletionRequest(
         model="test-model",
         messages=[{"role": "user", "content": "test"}],
         tools=tools,
+        chat_template_kwargs=chat_template_kwargs,
     )
 
 
@@ -166,6 +168,8 @@ def replay_streaming(
     finished_on_last: bool = False,
     tools: list[dict] | None = None,
     prompt_token_ids: list[int] | None = None,
+    finish_reason: str | None = None,
+    chat_template_kwargs: dict | None = None,
 ) -> list[DeltaMessage | None]:
     """Feed tokens through ``parser.parse_delta()`` at a given chunk size.
 
@@ -180,6 +184,14 @@ def replay_streaming(
         tools: Optional tool definitions to include on the request,
             matching the serving layer where tools set
             ``tool_choice`` to ``"auto"``.
+        finish_reason: Passed through to every ``parse_delta()`` call as
+            the engine's reported finish reason (e.g. ``"stop"``,
+            ``"length"``); only consulted by parsers when ``finished`` is
+            also True. ``None`` matches real server behavior for
+            in-progress deltas and is also the default when unset.
+        chat_template_kwargs: Set on the request built for this replay
+            (e.g. to opt into a parser's ``force_nonempty_content``-style
+            fallback).
 
     Returns:
         List of ``DeltaMessage`` results from each ``parse_delta()`` call.
@@ -191,7 +203,7 @@ def replay_streaming(
     all_ids = [tid for tid, _ in tokens]
     all_texts = [text for _, text in tokens]
 
-    request = _test_request(tools=tools)
+    request = _test_request(tools=tools, chat_template_kwargs=chat_template_kwargs)
     first_prompt_ids = prompt_token_ids if prompt_token_ids is not None else []
 
     if holdback_chars <= 0:
@@ -208,6 +220,7 @@ def replay_streaming(
                 request,
                 prompt_token_ids=first_prompt_ids if start == 0 else None,
                 finished=finished_on_last and is_last,
+                finish_reason=finish_reason,
             )
             results.append(result)
         return results
@@ -241,6 +254,7 @@ def replay_streaming(
             request,
             prompt_token_ids=first_prompt_ids if is_first else None,
             finished=finished_on_last and is_last_chunk,
+            finish_reason=finish_reason,
         )
         results.append(result)
         is_first = False
@@ -254,6 +268,7 @@ def replay_streaming(
             request,
             prompt_token_ids=first_prompt_ids if is_first else None,
             finished=finished_on_last,
+            finish_reason=finish_reason,
         )
         results.append(result)
 

--- a/tests/parser/engine/test_deepseek_v4.py
+++ b/tests/parser/engine/test_deepseek_v4.py
@@ -962,3 +962,333 @@ class TestDelegatingParserLargeDelta:
         assert eos_text not in output.reasoning
         assert output.content == ""
         assert output.tool_calls == []
+
+
+# ── #48645: force_nonempty_content -- surface unterminated reasoning as
+# content ─────────────────────────────────────────────────────────────
+#
+# Ports the Nemotron V3 pattern (PR #39091, vllm/parser/nemotron_v3.py) to
+# deepseek_v4, per bbrowning's guidance on #48645 (2026-07-15): opt-in via
+# a chat_template_kwargs flag, never touching a properly closed </think>.
+# See DeepSeekV4Parser.get_streaming_fallback_content / .extract_reasoning
+# for the implementation these tests exercise.
+
+
+class TestForceNonemptyContentNonStreaming:
+    """Non-streaming: DeepSeekV4Parser.extract_reasoning() swap."""
+
+    def test_misroute_flushed(self, mock_tokenizer, mock_request):
+        parser = DeepSeekV4Parser(
+            mock_tokenizer, chat_template_kwargs={"thinking": True}
+        )
+        mock_request.chat_template_kwargs = {"force_nonempty_content": True}
+        text = "Good morning! How can I help you today?"
+
+        reasoning, content = parser.extract_reasoning(text, mock_request)
+
+        assert reasoning is None
+        assert content == text
+
+    def test_no_flush_without_opt_in(self, mock_tokenizer, mock_request):
+        parser = DeepSeekV4Parser(
+            mock_tokenizer, chat_template_kwargs={"thinking": True}
+        )
+        mock_request.chat_template_kwargs = None
+        text = "Good morning! How can I help you today?"
+
+        reasoning, content = parser.extract_reasoning(text, mock_request)
+
+        assert reasoning == text
+        assert content is None
+
+    def test_end_token_seen_not_flushed(self, mock_tokenizer, mock_request):
+        """``</think>`` WAS seen: real, deliberate CoT -- never promoted,
+        even though nothing followed it.
+
+        Deliberately narrower than the Nemotron V3 precedent, whose gate
+        is only "content ended up empty" and promotes in this case too;
+        see PR description for the rationale.
+        """
+        parser = DeepSeekV4Parser(
+            mock_tokenizer, chat_template_kwargs={"thinking": True}
+        )
+        mock_request.chat_template_kwargs = {"force_nonempty_content": True}
+        text = f"Deliberate reasoning.{DSML_THINK_END}"
+
+        reasoning, content = parser.extract_reasoning(text, mock_request)
+
+        assert reasoning == "Deliberate reasoning."
+        assert content is None
+
+    def test_tool_call_not_flushed(self, mock_tokenizer, mock_request):
+        """A tool call started directly from reasoning (no ``</think>``)
+        structurally ends reasoning via the ``(REASONING, TOOL_START)``
+        transition, so it is never flushed here -- it's real deliberation
+        that led to a real tool call, not a misroute.
+        """
+        parser = DeepSeekV4Parser(
+            mock_tokenizer, chat_template_kwargs={"thinking": True}
+        )
+        mock_request.chat_template_kwargs = {"force_nonempty_content": True}
+        text = "Let me check the weather.\n\n" + _tool_calls(
+            _invoke("get_weather", ("location", "true", "NYC"))
+        )
+
+        reasoning, content = parser.extract_reasoning(text, mock_request)
+
+        assert reasoning == "Let me check the weather."
+        assert content is None
+
+    def test_non_streaming_has_no_finish_reason_gate(
+        self, mock_tokenizer, mock_request
+    ):
+        """Documents an accepted gap (see PR description): ``extract_reasoning``
+        is a shared abstract method with no ``finish_reason`` parameter, so
+        unlike the streaming path (below) the non-streaming swap cannot
+        distinguish a natural stop from a length-truncated generation. An
+        opted-in request with a truncated, never-closed trace *is*
+        promoted here.
+        """
+        parser = DeepSeekV4Parser(
+            mock_tokenizer, chat_template_kwargs={"thinking": True}
+        )
+        mock_request.chat_template_kwargs = {"force_nonempty_content": True}
+        text = "This trace got cut off mid-sent"
+
+        reasoning, content = parser.extract_reasoning(text, mock_request)
+
+        assert reasoning is None
+        assert content == text
+
+
+def _word_tokens(text: str, start_id: int = 100) -> list[tuple[int, str]]:
+    tokens: list[tuple[int, str]] = []
+    tid = start_id
+    for word in text.split(" "):
+        prefix = " " if tokens else ""
+        tokens.append((tid, prefix + word))
+        tid += 1
+    return tokens
+
+
+class TestForceNonemptyContentStreaming:
+    """Streaming: ``DelegatingParser.finalize_generation`` ->
+    ``DeepSeekV4Parser.get_streaming_fallback_content``, through the same
+    reasoning+tool adapter split serving wires up for
+    ``--reasoning-parser deepseek_v4 --tool-call-parser deepseek_v4``
+    (see vllm/parser/engine/registered_adapters.py).
+    """
+
+    @pytest.mark.parametrize(
+        "chunk_size", [1, 2, 3, 5, None], ids=lambda c: f"chunk={c}"
+    )
+    def test_misroute_flushed(self, chunk_size):
+        text = "Good morning! How can I help you today?"
+        tokens = _word_tokens(text)
+        tokenizer = MockTokenizer(vocab=dict(_DSV4_FULL_VOCAB), tokens=tokens)
+        parser = _DeepSeekV4Delegating(
+            tokenizer, chat_template_kwargs={"thinking": True}
+        )
+
+        deltas = replay_streaming(
+            parser,
+            tokens,
+            chunk_size=chunk_size,
+            finished_on_last=True,
+            finish_reason="stop",
+            chat_template_kwargs={"force_nonempty_content": True},
+        )
+        output = collect_output(deltas)
+
+        assert output.reasoning == text
+        assert output.content == text
+
+    @pytest.mark.parametrize(
+        "chunk_size", [1, 2, 3, 5, None], ids=lambda c: f"chunk={c}"
+    )
+    def test_no_flush_without_opt_in(self, chunk_size):
+        text = "Good morning! How can I help you today?"
+        tokens = _word_tokens(text)
+        tokenizer = MockTokenizer(vocab=dict(_DSV4_FULL_VOCAB), tokens=tokens)
+        parser = _DeepSeekV4Delegating(
+            tokenizer, chat_template_kwargs={"thinking": True}
+        )
+
+        deltas = replay_streaming(
+            parser,
+            tokens,
+            chunk_size=chunk_size,
+            finished_on_last=True,
+            finish_reason="stop",
+        )
+        output = collect_output(deltas)
+
+        assert output.reasoning == text
+        assert output.content == ""
+
+    @pytest.mark.parametrize(
+        "chunk_size", [1, 2, 3, 5, None], ids=lambda c: f"chunk={c}"
+    )
+    def test_length_truncation_not_flushed(self, chunk_size):
+        """``finish_reason="length"``: generation was cut off by the token
+        budget, not a natural stop. Truncated, mid-sentence CoT must never
+        become a user-facing "answer".
+        """
+        text = "This is a very long chain of thought that got cut off"
+        tokens = _word_tokens(text)
+        tokenizer = MockTokenizer(vocab=dict(_DSV4_FULL_VOCAB), tokens=tokens)
+        parser = _DeepSeekV4Delegating(
+            tokenizer, chat_template_kwargs={"thinking": True}
+        )
+
+        deltas = replay_streaming(
+            parser,
+            tokens,
+            chunk_size=chunk_size,
+            finished_on_last=True,
+            finish_reason="length",
+            chat_template_kwargs={"force_nonempty_content": True},
+        )
+        output = collect_output(deltas)
+
+        assert output.reasoning == text
+        assert output.content == ""
+
+    @pytest.mark.parametrize(
+        "chunk_size", [1, 2, 3, 5, None], ids=lambda c: f"chunk={c}"
+    )
+    def test_no_finish_reason_not_flushed(self, chunk_size):
+        """``finish_reason`` unset (``None``) is treated the same as "not
+        confirmed stop": deny, not allow. A caller that doesn't thread
+        ``finish_reason`` through gets the pre-existing (no-flush)
+        behavior, never a silently-unsafe default.
+        """
+        text = "Good morning! How can I help you today?"
+        tokens = _word_tokens(text)
+        tokenizer = MockTokenizer(vocab=dict(_DSV4_FULL_VOCAB), tokens=tokens)
+        parser = _DeepSeekV4Delegating(
+            tokenizer, chat_template_kwargs={"thinking": True}
+        )
+
+        deltas = replay_streaming(
+            parser,
+            tokens,
+            chunk_size=chunk_size,
+            finished_on_last=True,
+            chat_template_kwargs={"force_nonempty_content": True},
+        )
+        output = collect_output(deltas)
+
+        assert output.reasoning == text
+        assert output.content == ""
+
+    @pytest.mark.parametrize(
+        "chunk_size", [1, 2, 3, 5, None], ids=lambda c: f"chunk={c}"
+    )
+    def test_end_token_seen_not_flushed(self, chunk_size):
+        """``</think>`` WAS closed (even though nothing followed): real
+        CoT, never promoted."""
+        tokens = _word_tokens("Deliberate reasoning.") + [
+            (_DSV4_FULL_VOCAB[DSML_THINK_END], DSML_THINK_END)
+        ]
+        tokenizer = MockTokenizer(vocab=dict(_DSV4_FULL_VOCAB), tokens=tokens)
+        parser = _DeepSeekV4Delegating(
+            tokenizer, chat_template_kwargs={"thinking": True}
+        )
+
+        deltas = replay_streaming(
+            parser,
+            tokens,
+            chunk_size=chunk_size,
+            finished_on_last=True,
+            finish_reason="stop",
+            chat_template_kwargs={"force_nonempty_content": True},
+        )
+        output = collect_output(deltas)
+
+        assert output.reasoning == "Deliberate reasoning."
+        assert output.content == ""
+
+    def test_tool_call_not_flushed(self):
+        """Tool call started directly from reasoning (no ``</think>``):
+        ``(REASONING, TOOL_START)`` flips ``reasoning_ended`` True before
+        any tool event, so this is never flushed even though ``</think>``
+        was never seen.
+        """
+        # DSML_TOOL_START/END must carry their real vocab token IDs (as
+        # _dsv4_tokens does) rather than _word_tokens' arbitrary sequential
+        # IDs: once any real special-token ID has been seen, the engine
+        # only accepts a *token-ID-confirmed* TOOL_START as a state
+        # transition, treating literal "looks like a marker" text as
+        # ordinary content instead (the same safety net that keeps a
+        # user's prose mentioning "<tool_call>" from being misparsed).
+        tokens = _word_tokens("Let me check the weather")
+        tid = 900
+        tokens.append((tid, "\n\n"))
+        tid += 1
+        tokens.append((_DSV4_FULL_VOCAB[DSML_TOOL_START], DSML_TOOL_START))
+        tokens.append((tid, f"{DSML_INVOKE_PREFIX}get_weather{DSML_INVOKE_NAME_END}"))
+        tid += 1
+        tokens.append((tid, "\n"))
+        tid += 1
+        tokens.append((tid, _param("location", "true", "NYC")))
+        tid += 1
+        tokens.append((tid, "\n"))
+        tid += 1
+        tokens.append((tid, DSML_INVOKE_END))
+        tid += 1
+        tokens.append((_DSV4_FULL_VOCAB[DSML_TOOL_END], DSML_TOOL_END))
+
+        tokenizer = MockTokenizer(vocab=dict(_DSV4_FULL_VOCAB), tokens=tokens)
+        parser = _DeepSeekV4Delegating(
+            tokenizer, chat_template_kwargs={"thinking": True}
+        )
+
+        deltas = replay_streaming(
+            parser,
+            tokens,
+            chunk_size=None,
+            finished_on_last=True,
+            finish_reason="stop",
+            chat_template_kwargs={"force_nonempty_content": True},
+            tools=DUMMY_TOOLS,
+        )
+        output = collect_output(deltas)
+
+        assert "Let me check the weather" in output.reasoning
+        assert output.content == ""
+        assert len(output.tool_calls) == 1
+        assert output.tool_calls[0]["name"] == "get_weather"
+
+    def test_flushed_content_has_no_trailing_eos(self):
+        """The flushed content is built from the same already-EOS-stripped
+        reasoning chunks validated by
+        ``TestDelegatingParserLargeDelta.test_eos_not_leaked_when_reasoning_never_ends``
+        (fixed upstream by #48748) -- so promoting them to content must
+        not reintroduce the EOS text there either.
+        """
+        eos_text = "<｜end▁of▁sentence｜>"
+        eos_id = 128801
+        vocab = {**_DSV4_FULL_VOCAB, eos_text: eos_id}
+
+        reasoning_text = "Good morning! How can I help you today?"
+        tokens = _word_tokens(reasoning_text) + [(eos_id, eos_text)]
+        tokenizer = MockTokenizer(vocab=vocab, tokens=tokens)
+        parser = _DeepSeekV4Delegating(
+            tokenizer, chat_template_kwargs={"thinking": True}
+        )
+
+        deltas = replay_streaming(
+            parser,
+            tokens,
+            chunk_size=None,
+            finished_on_last=True,
+            finish_reason="stop",
+            chat_template_kwargs={"force_nonempty_content": True},
+        )
+        output = collect_output(deltas)
+
+        assert output.reasoning == reasoning_text
+        assert eos_text not in output.reasoning
+        assert output.content == reasoning_text
+        assert eos_text not in output.content

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -618,6 +618,7 @@ class OpenAIServingChat(GenerateBaseServing):
                             request=request,
                             prompt_token_ids=res.prompt_token_ids,
                             finished=output.finish_reason is not None,
+                            finish_reason=output.finish_reason,
                         )
                         if delta_message is not None and delta_message.tool_calls:
                             tools_streamed[i] = True

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -1388,6 +1388,7 @@ class OpenAIServingResponses(GenerateBaseServing):
                     request=request,
                     prompt_token_ids=ctx.last_output.prompt_token_ids,
                     finished=output.finish_reason is not None,
+                    finish_reason=output.finish_reason,
                 )
             else:
                 delta_message = DeltaMessage(content=output.text)

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -362,9 +362,16 @@ class Parser:
         prompt_token_ids: list[int] | None = None,
         *,
         finished: bool,
+        finish_reason: str | None = None,
     ) -> DeltaMessage | None:
         """Parse a single streaming delta, orchestrating reasoning then
         tool call extraction via internal stream state.
+
+        ``finish_reason`` (e.g. ``"stop"``, ``"length"``, ``"abort"``) is
+        only meaningful when ``finished`` is True; it lets a subclass's
+        terminal-delta handling distinguish a natural stop from a
+        length-truncated generation. See :meth:`DelegatingParser.
+        finalize_generation`.
         """
 
 
@@ -765,6 +772,7 @@ class DelegatingParser(Parser):
         delta_message: DeltaMessage | None,
         request: ChatCompletionRequest | ResponsesRequest,
         state: StreamState,
+        finish_reason: str | None = None,
     ) -> DeltaMessage | None:
         """Finalize generation for cases where generation was incomplete.
         For example, if streaming terminated before reasoning ended
@@ -773,7 +781,9 @@ class DelegatingParser(Parser):
             self._reasoning_parser, "get_streaming_fallback_content", None
         )
         if fallback_fn is not None and not state.reasoning_ended:
-            promoted = fallback_fn(state.previous_text, request)
+            promoted = fallback_fn(
+                state.previous_text, request, finish_reason=finish_reason
+            )
             if promoted:
                 if delta_message is None:
                     delta_message = DeltaMessage()
@@ -806,6 +816,7 @@ class DelegatingParser(Parser):
         prompt_token_ids: list[int] | None = None,
         *,
         finished: bool,
+        finish_reason: str | None = None,
     ) -> DeltaMessage | None:
         self._initialize_history_tool_call_cnt(request)
         state = self._stream_state
@@ -925,7 +936,9 @@ class DelegatingParser(Parser):
         state.commit(current_text, current_token_ids)
 
         if finished:
-            delta_message = self.finalize_generation(delta_message, request, state)
+            delta_message = self.finalize_generation(
+                delta_message, request, state, finish_reason=finish_reason
+            )
             delta_message = self._flush_engine_parsers(delta_message)
 
         # Suppress reasoning deltas if not requested

--- a/vllm/parser/deepseek_v4.py
+++ b/vllm/parser/deepseek_v4.py
@@ -14,6 +14,20 @@ DeepSeek V4 output format::
     <｜DSML｜parameter name="count" string="false">5</｜DSML｜parameter>
     </｜DSML｜invoke>
     </｜DSML｜tool_calls>
+
+The model is prompted with an opened ``<think>`` (via custom Python prompt
+logic, not the chat template -- see ``vllm/tokenizers/deepseek_v4_encoding.py``),
+so ``thinking=True`` starts the parser in ``REASONING``. The model does not
+always close it: short replies sometimes skip deliberation and answer
+directly, so generation can end with no ``</think>`` ever seen. Without a
+fallback, that entire reply is classified as reasoning and ``content`` stays
+empty (vLLM issue #48645).
+
+When ``force_nonempty_content=True`` (opt-in, mirroring the Nemotron V3
+precedent -- see ``vllm/parser/nemotron_v3.py`` and PR #39091), an
+unterminated reasoning block is surfaced as content instead. See
+``_should_force_content`` and ``get_streaming_fallback_content`` below for
+the exact gating.
 """
 
 from __future__ import annotations
@@ -35,6 +49,12 @@ from vllm.parser.engine.parser_engine_config import (
 from vllm.tool_parsers.utils import find_tool_properties
 
 if TYPE_CHECKING:
+    from vllm.entrypoints.openai.chat_completion.protocol import (
+        ChatCompletionRequest,
+    )
+    from vllm.entrypoints.openai.engine.protocol import DeltaMessage
+    from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+    from vllm.parser.engine.events import SemanticEvent
     from vllm.tokenizers import TokenizerLike
     from vllm.tool_parsers.abstract_tool_parser import Tool
 
@@ -228,6 +248,7 @@ class DeepSeekV4Parser(ParserEngine):
             **kwargs,
         )
         self._arg_converter = self._convert_args
+        self._streamed_reasoning: list[str] = []
 
     def _convert_args(self, raw_args: str, partial: bool) -> str:
         result = _dsml_arg_converter(raw_args, partial)
@@ -235,3 +256,123 @@ class DeepSeekV4Parser(ParserEngine):
             return result
         func_name = next((s.name for s in self._tool_slots if s.args == raw_args), None)
         return _unwrap_wrapper_args(result, self._tools, func_name)
+
+    # ── #48645: surface unterminated reasoning as content ──────────────
+    #
+    # Mirrors the Nemotron V3 pattern (PR #39091, vllm/parser/nemotron_v3.py)
+    # per bbrowning's guidance on #48645: opt-in via a chat_template_kwargs
+    # flag, buffering already-streamed reasoning chunks (state.previous_text
+    # is unreliable for engine-based streams -- see StreamState.commit)
+    # rather than re-parsing raw text.
+
+    def _reset(self, initial_state: ParserState | None = None) -> None:
+        super()._reset(initial_state=initial_state)
+        self._streamed_reasoning = []
+
+    def _events_to_delta(
+        self,
+        events: list[SemanticEvent],
+        finished: bool = False,
+    ) -> DeltaMessage | None:
+        delta = super()._events_to_delta(events, finished=finished)
+        if delta is not None and delta.reasoning is not None:
+            self._streamed_reasoning.append(delta.reasoning)
+        return delta
+
+    @staticmethod
+    def _should_force_content(
+        request: ChatCompletionRequest | ResponsesRequest,
+    ) -> bool:
+        chat_template_kwargs = getattr(request, "chat_template_kwargs", None)
+        return bool(
+            chat_template_kwargs
+            and chat_template_kwargs.get("force_nonempty_content") is True
+        )
+
+    def get_streaming_fallback_content(
+        self,
+        text: str,
+        request: ChatCompletionRequest | ResponsesRequest,
+        finish_reason: str | None = None,
+    ) -> str | None:
+        """Reasoning to promote to content on the terminal streaming delta.
+
+        Called by :meth:`DelegatingParser.finalize_generation` only when
+        the reasoning phase never ended (no ``</think>`` was seen), so a
+        properly closed think block is never touched here -- that buffer
+        is real, deliberate chain-of-thought.
+
+        Gated on, in addition to the caller's own "not ended" check:
+          * opt-in (``force_nonempty_content``);
+          * ``finish_reason == "stop"`` -- a length-truncated (or
+            aborted/errored) generation must never surface a partial,
+            cut-off reasoning trace as a user-facing answer;
+          * no tool call started (structurally redundant here, since
+            ``(REASONING, TOOL_START)`` always emits ``REASONING_END``
+            first -- kept as defense in depth against future transition-
+            table changes).
+        """
+        if not self._should_force_content(request):
+            return None
+        if finish_reason != "stop":
+            return None
+        if self._reasoning_ended or self._tool_slots:
+            return None
+        return "".join(self._streamed_reasoning) or None
+
+    def extract_reasoning(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest | ResponsesRequest,
+    ) -> tuple[str | None, str | None]:
+        """Non-streaming counterpart of :meth:`get_streaming_fallback_content`.
+
+        Deliberately narrower than the Nemotron V3 precedent: Nemotron
+        swaps whenever ``content`` ends up empty, even if ``</think>`` was
+        seen (deliberated, then said nothing further). Here the swap only
+        fires when reasoning never terminated -- a closed think block is
+        never touched, matching the streaming gate above. ``finish_reason``
+        is not available at this call site (``extract_reasoning`` is a
+        shared abstract method with no such parameter); see PR description
+        for why that residual gap is accepted here.
+
+        Deliberately re-implements (rather than calls) ``ParserEngine.
+        extract_reasoning``: that method's own ``self._reasoning_ended``
+        is set from the *combined* feed + ``engine.finish()`` events, and
+        ``StreamingParserEngine.finish()`` unconditionally synthesizes a
+        ``REASONING_END`` whenever the engine is still mid-``REASONING``
+        at end-of-input -- exactly the unterminated case this fallback
+        exists for. Checking ``self._reasoning_ended`` after the fact
+        can't tell a real ``</think>`` apart from that synthetic one, so
+        this checks the *fed* events (before ``finish()`` is merged in)
+        for a real ``REASONING_END`` instead.
+        """
+        self._reset()
+        events = self._feed(model_output, [])
+        natural_end = any(e.type == EventType.REASONING_END for e in events)
+        events.extend(self._engine.finish())
+
+        reasoning_parts: list[str] = []
+        content_parts: list[str] = []
+        for event in events:
+            if event.type == EventType.REASONING_CHUNK:
+                reasoning_parts.append(event.value)
+            elif event.type == EventType.TEXT_CHUNK:
+                content_parts.append(event.value)
+            elif event.type == EventType.REASONING_END:
+                self._reasoning_ended = True
+
+        raw_reasoning = "".join(reasoning_parts)
+        if self._strip_trailing_reasoning_ws:
+            raw_reasoning = raw_reasoning.rstrip()
+        reasoning = raw_reasoning or None
+        content = "".join(content_parts) or None
+
+        if (
+            self._should_force_content(request)
+            and not natural_end
+            and not self._tool_slots
+            and (content is None or not content.strip())
+        ):
+            reasoning, content = content, reasoning
+        return reasoning, content

--- a/vllm/parser/engine/adapters.py
+++ b/vllm/parser/engine/adapters.py
@@ -118,8 +118,11 @@ class ParserEngineReasoningAdapter(ReasoningParser):
         self,
         text: str,
         request: ChatCompletionRequest | ResponsesRequest,
+        finish_reason: str | None = None,
     ) -> str | None:
-        return self._parser_engine.get_streaming_fallback_content(text, request)
+        return self._parser_engine.get_streaming_fallback_content(
+            text, request, finish_reason=finish_reason
+        )
 
     def count_reasoning_tokens(self, token_ids: Sequence[int]) -> int:
         return self._parser_engine.count_reasoning_tokens(token_ids)

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -435,6 +435,7 @@ class ParserEngine(Parser):
         prompt_token_ids: list[int] | None = None,
         *,
         finished: bool,
+        finish_reason: str | None = None,
     ) -> DeltaMessage | None:
         self._initialize_history_tool_call_cnt(request)
         if not self._prompt_streaming_prepared and prompt_token_ids is not None:
@@ -449,6 +450,22 @@ class ParserEngine(Parser):
             events.extend(self._engine.finish())
         result = self._events_to_delta(events, finished=finished)
         result = self._strip_trailing_reasoning(result)
+
+        if finished and not self._reasoning_ended:
+            # Mirrors DelegatingParser.finalize_generation for parsers used
+            # standalone (not wrapped by ParserEngineReasoningAdapter). The
+            # base hook is a no-op; only overridden by parsers that opt into
+            # a fallback (e.g. DeepSeekV4Parser, see #48645). No separate
+            # "previous_text" buffer exists at this layer -- overrides that
+            # need buffered text (rather than re-parsing raw text) track
+            # their own, as DeepSeekV4Parser does via _streamed_reasoning.
+            promoted = self.get_streaming_fallback_content(
+                "", request, finish_reason=finish_reason
+            )
+            if promoted:
+                if result is None:
+                    result = DeltaMessage()
+                result.content = (result.content or "") + promoted
 
         # Suppress reasoning deltas if not requested
         if result and not request.include_reasoning:
@@ -621,6 +638,7 @@ class ParserEngine(Parser):
         self,
         text: str,
         request: ChatCompletionRequest | ResponsesRequest,
+        finish_reason: str | None = None,
     ) -> str | None:
         return None
 

--- a/vllm/parser/harmony.py
+++ b/vllm/parser/harmony.py
@@ -242,6 +242,7 @@ class HarmonyParser(DelegatingParser):
         prompt_token_ids: list[int] | None = None,
         *,
         finished: bool,
+        finish_reason: str | None = None,
     ) -> DeltaMessage | None:
         prev_recipient = self._normalize_recipient(
             self._harmony_parser.current_recipient

--- a/vllm/parser/kimi_k3.py
+++ b/vllm/parser/kimi_k3.py
@@ -101,6 +101,7 @@ class KimiK3Parser(DelegatingParser):
         prompt_token_ids: list[int] | None = None,
         *,
         finished: bool,
+        finish_reason: str | None = None,
     ) -> DeltaMessage | None:
         state = self._stream_state
         previous_content = state.previous_text if state.reasoning_ended else ""
@@ -110,6 +111,7 @@ class KimiK3Parser(DelegatingParser):
             request,
             prompt_token_ids,
             finished=finished,
+            finish_reason=finish_reason,
         )
 
         if (

--- a/vllm/parser/nemotron_v3.py
+++ b/vllm/parser/nemotron_v3.py
@@ -93,7 +93,11 @@ class NemotronV3Parser(Qwen3Parser):
         self,
         text: str,
         request: ChatCompletionRequest | ResponsesRequest,
+        finish_reason: str | None = None,
     ) -> str | None:
+        # Nemotron's opt-in fallback is not gated on finish_reason: unlike
+        # DeepSeek V4 (see vllm/parser/deepseek_v4.py, #48645), this
+        # precedent predates that gate and is left unchanged here.
         if not self._should_force_content(request):
             return None
         return "".join(self._streamed_reasoning) or None


### PR DESCRIPTION
[Bugfix][Parser] Surface unterminated reasoning as content for deepseek_v4 (opt-in)

## Problem

Fixes #48645 (the content-population half; the trailing-EOS half was
already fixed by #48748, merged 2026-07-22 — see "Scope" below).

With `--reasoning-parser deepseek_v4` and `thinking=true` (the common
case: it's the server default via
`--default-chat-template-kwargs={"thinking":true,...}` on the
[DeepSeek-V4-Flash recipe](https://recipes.vllm.ai/deepseek-ai/DeepSeek-V4-Flash),
and applies even to OpenAI-compatible clients that never send
`chat_template_kwargs`), a generation that ends **without ever
emitting `</think>`** has its entire answer routed to
`reasoning_content`, leaving `content` empty:

```json
{"role": "assistant",
 "reasoning_content": "Good morning! How can I help you today?",
 "content": ""}
```

Any caller that reads `content` only — most OpenAI-compatible chat
clients, and especially structured-output / tool-eval harnesses that
don't fall back to `reasoning_content` — sees an empty response even
though the model answered correctly.

This is sampling-dependent, not deterministic: issue reporter fank
measured ~20-25% misroute rates on a real agent system prompt (50 tool
defs, instructions to answer directly/without preamble) at
temperature 1.0, and 0% on generic/synthetic prompts of the same
length — the trigger is prompt *content* (bias toward answering
immediately), not length.

### Real-world impact beyond the original report

- [chatboxai/chatbox#3821](https://github.com/chatboxai/chatbox/issues/3821)
  (opened 2026-07-30, active through 2026-08-02): DeepSeek-V4 served via
  OpenRouter → StreamLake. Network-capture-diagnosed (client-side ruled
  out): `delta.content` empty, full answer in `delta.reasoning`,
  `finish_reason: "stop"` — exactly this misroute signature, hit in
  production chat traffic rather than a synthetic repro.
- NVIDIA DGX Spark forum, thread 372268,
  [post #544](https://forums.developer.nvidia.com/t/372268) (2026-08-02):
  tool-eval-bench case TC-22 "Output Format Compliance" — a terse
  "respond with ONLY valid JSON, no other text" prompt (exactly the
  no-preamble short-reply trigger fank identified) — fails with "Did
  not return valid JSON as requested." immediately after operators
  enabled `thinking_mode=thinking` + high/max effort via the official
  chat template. The harness reads `content` only, consistent with the
  misroute returning `""`.

## Root cause

`DeepSeekV4Parser` is built on the newer `ParserEngine` state-machine
architecture (`vllm/parser/engine/`). With `thinking=true` it starts
in `initial_state=ParserState.REASONING`
(`vllm/parser/deepseek_v4.py`), and the only way out is the
`THINK_END` (`</think>`) transition. Per maintainer bbrowning's
[analysis](https://github.com/vllm-project/vllm/issues/48645#issuecomment-4981181452)
(2026-07-15), starting in `REASONING` is *correct* here — DeepSeek-V4's
prompt is constructed by custom Python logic (not a chat template) and
does open an unterminated `<think>` — so option 2 from the issue
("only enter REASONING on evidence of thinking") is not applicable to
this model. The bug is that the model doesn't always honor that
opening: on short replies it sometimes answers directly and hits EOS
without ever closing `</think>`. When that happens, every chunk stays
tagged `REASONING_CHUNK` for the whole response and `content` never
gets populated. This is a model behavior, not unique to DeepSeek-V4 —
bbrowning notes "I've only seen this happen with Nemotron models in
very short model responses, and I suspect it's a similar situation
here."

## Fix

Ports the existing Nemotron V3 fallback (PR #39091,
`vllm/parser/nemotron_v3.py`) to `vllm/parser/deepseek_v4.py`, per
bbrowning's explicit recommendation on #48645: *"We already have a
precedent for something like this in the Nemotron v3 model, where
there's a chat template kwarg flag that can force the model to always
output content by copying any reasoning into the content if we see
generation ended during reasoning. The parser is designed to allow
models to opt-in to some fallback behavior here."* Adapted for
upstream main's `ParserEngine` architecture (Nemotron's own port
predates today's engine and required no changes beyond a signature
addition; DeepSeek-V4's did not exist before this PR).

- **Opt-in**, matching Nemotron's precedent exactly: enabled via
  `chat_template_kwargs={"force_nonempty_content": True}`. Default
  behavior (flag absent/false) is unchanged — no silent behavior
  change for existing deployments. (bbrowning's comment frames this as
  vendor/deployment preference, the same framing used for Nemotron; if
  maintainers would prefer default-on for deepseek_v4 specifically,
  that's a one-line change in `_should_force_content` — flagged as an
  open design question below.)
- **Gated on `finish_reason == "stop"` only** (streaming path): never
  flushes on length-truncation. A response cut off by `max_tokens`
  still has an unterminated reasoning block, but that's truncated CoT,
  not a "the model skipped thinking" case — it must never become
  user-facing content. This required threading `finish_reason` through
  `Parser.parse_delta` → `DelegatingParser.finalize_generation` →
  `ParserEngine.get_streaming_fallback_content`, and both
  `serving.py` call sites (chat_completion and responses), since
  `finish_reason` wasn't previously available at the fallback-decision
  point for any parser, including Nemotron's.
- **Never flushes when `</think>` was actually seen.** The state
  machine's own `.finish()` emits a *synthetic* `REASONING_END` for
  any input still in `REASONING` at end-of-stream, so a naive
  "check `reasoning_ended` after calling the base implementation"
  is always true and can't distinguish a real close from EOF-in-
  REASONING. `extract_reasoning()` instead captures whether a real
  `REASONING_END` event arrived from `_feed()` *before* merging in
  `.finish()`'s synthetic one.
- **Never flushes when any tool call was emitted** in the same turn
  (checked via `self._tool_slots`).

## Scope: not re-fixing the EOS half

Upstream PR #48748 (merged 2026-07-22) already fixed trailing-EOS
leakage into `reasoning_content` for deepseek_v4 — its own test,
`test_eos_not_leaked_when_reasoning_never_ends` (pre-existing, kept
as-is, still passing), asserts the EOS text does not appear anywhere,
**while also asserting `output.content == ""`**. That test's own
assertion is proof that #48748 explicitly left the core misroute (the
subject of this PR) unfixed — it only cleaned up the special token,
not the routing. This PR builds on current main (which includes
#48748) and does not touch EOS-stripping logic; it only adds the
opt-in content-population fallback on top.

## What upstream's architecture forced differently from a literal Nemotron port

- **`extract_reasoning()` does not call `super()`.** It reimplements
  `ParserEngine.extract_reasoning`'s body, because the synthetic-
  `REASONING_END` issue above means the natural-vs-synthetic
  distinction has to be captured before the parent method's own
  internal call to `.finish()`.
- **Non-streaming has no `finish_reason` gate.** `extract_reasoning()`
  is called with only `model_output: str` — no finish_reason is
  available at that call site network-wide (touching that would mean
  changing the shared `extract_reasoning` signature used by ~15
  unrelated legacy reasoning parsers, out of scope here). Non-streaming
  therefore only gates on natural-end/tool-slots, not truncation. This
  is a real, intentional gap, called out explicitly in
  `test_non_streaming_has_no_finish_reason_gate`, which documents that
  a truncated/never-closed non-streaming trace *does* get swapped when
  the opt-in flag is set. Flagged as an open design question below.
- **`finish_reason` plumbing is broader than Nemotron needed.** Since
  Nemotron's own fallback predates this PR and has no truncation gate,
  adding one for deepseek_v4 meant extending the shared
  `Parser.parse_delta` / `DelegatingParser.finalize_generation` /
  `ParserEngine.parse_delta` / `ParserEngineReasoningAdapter` surface
  (plus the two serving.py call sites) with an additive, defaulted
  `finish_reason: str | None = None` keyword — touching 4 parser
  implementations' `parse_delta` signatures for interface completeness
  (`harmony.py`, `kimi_k3.py` unaffected in behavior) and left
  Nemotron's own fallback ungated on `finish_reason` (unchanged
  behavior, documented with a comment) since changing an existing,
  shipped default was out of scope for this PR.

## Test coverage

Mirrors `tests/parser/engine/test_nemotron_v3.py`. Added to
`tests/parser/engine/test_deepseek_v4.py`:

**Non-streaming** (`TestForceNonemptyContentNonStreaming`, 5 tests):
misroute-flushed, no-flush-without-opt-in, end-token-seen-not-flushed,
tool-call-not-flushed, and the documented finish_reason-gap test.

**Streaming** (`TestForceNonemptyContentStreaming`, 7 tests, most
parametrized over chunk sizes 1/2/3/5/None for chunk-boundary
invariance): misroute-flushed, no-flush-without-opt-in,
length-truncation-not-flushed (`finish_reason="length"`),
no-finish-reason-not-flushed (deny-by-default when finish_reason is
unset), end-token-seen-not-flushed, tool-call-not-flushed (tokens
built with real DSML vocab IDs so the token-ID-confirmed terminal
matcher fires correctly), and flushed-content-has-no-trailing-eos
(proves flushed content inherits #48748's EOS-clean guarantee).

Full suite: `tests/parser/engine/test_deepseek_v4.py` 90/90 passed
(32 new). Full `tests/parser/` suite: 3768 passed (32 new), 19 failed
/ 285 errors — failure/error ID sets byte-identical to a pre-change
baseline run, i.e. zero regressions. (The pre-existing failures/errors
are environment-related — e.g. missing optional/compiled deps in this
sandboxed check — not related to this change; confirmed unchanged
before vs. after.)

`ruff check` / `ruff format`: clean on every file this PR touches.
(One pre-existing `ISC004` finding at
`tests/parser/engine/test_deepseek_v4.py:220` predates this PR —
verified via `git diff` that this PR's changes are purely additive
starting after the file's existing content — and is left untouched.)

## Production validation

Deployed on 2x ASUS GX10 (GB10), tensor-parallel=2, serving
DeepSeek-V4-Flash-0731. The deterministic parser-level repro from the
issue (`reasoning_effort: "none"` with server-default `thinking:true`)
is fixed. Across finish=`length` truncation probes, closed-`</think>`-
then-stop turns, tool-call turns, and default max-effort traffic:
zero false flushes — flush events were log-counted and matched
expectations exactly (fires only on the intended misroute case, never
on truncation, a real close, or a tool-call turn).

## References

- Fixes #48645
- Ports #39091 (Nemotron V3 `force_nonempty_content` precedent)
- Builds on #48748 (EOS-stripping, already merged; not duplicated here)
- bbrowning's guidance: https://github.com/vllm-project/vllm/issues/48645#issuecomment-4981181452

## Open design questions for maintainers

1. **Opt-in vs. default-on for deepseek_v4.** bbrowning's comment
   frames the Nemotron precedent as vendor-preference opt-in, and this
   PR follows that exactly. But #48645's own reporter and both
   real-world reports above show this hurts *out-of-the-box* deployments
   using the documented recipe's default `thinking:true` — none of
   those callers know to set `force_nonempty_content`. Happy to flip
   the default for deepseek_v4 specifically (one line in
   `_should_force_content`) if maintainers prefer that over
   Nemotron-style opt-in.
2. **Non-streaming finish_reason gap** (see above) — accept as
   documented, or worth threading `finish_reason` through the shared
   `extract_reasoning` signature in a follow-up (broader blast radius,
   touches every reasoning parser)?
3. **Nemotron's fallback stays ungated on `finish_reason`** even
   though the new gate exists on the shared path now — intentionally
   left unchanged to avoid altering shipped Nemotron behavior in this
   PR. Separate follow-up if maintainers want parity.
