### PR TITLE
[PD][NixlPush][Bugfix] Notify D of NIXL writes that failed to post so it stops waiting

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_push_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_push_connector.py
@@ -26,18 +26,26 @@ import threading
 import time
 from collections import defaultdict
 from concurrent.futures import Future
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import msgspec
 import pytest
 
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker import (
+    NixlBaseConnectorWorker,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+    PUSH_FAIL_NOTIF_PREFIX,
     PUSH_REG_NOTIF_PREFIX,
     NixlAgentMetadata,
     NixlConnectorMetadata,
+    RemoteMeta,
+    ReqMeta,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.push_worker import (
+    _PUSH_FAIL_PREFIX_STR,
     NixlPushConnectorWorker,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.utils import (
@@ -337,6 +345,16 @@ class _StubWriterWorker(NixlPushConnectorWorker):
         w.world_size = 1
         w.engine_id = "test-decode-engine"
         w._remote_agents = {}
+        w._handshake_lock = threading.RLock()
+
+        # Failed-WRITE reporting state (_count_consumer_notif ->
+        # _fail_incomplete_push -> _handle_failed_transfer).
+        w._failed_write_reqs = set()
+        w._failed_recv_reqs = queue.Queue()
+        w._invalid_block_ids = queue.Queue()
+        w._is_hma_required = False
+        w.kv_cache_config = SimpleNamespace(kv_cache_groups=[object()])
+        w.xfer_stats = MagicMock()
         w._physical_blocks_per_logical_kv_block = 1
         # Single non-hybrid attention group, matching the stub block id lists.
         w._has_mamba = False
@@ -1077,47 +1095,57 @@ class TestPushPipelineParallel:
         assert meta.block_lens == [block_len, block_len]
 
 
+def _push_worker_writing_to(d_ranks, *, use_mla: bool = True):
+    """A producer worker handshook with consumer ranks ``d_ranks``.
+
+    ``use_mla`` selects which branch resolves the write ranks: MLA replicates
+    the latent to every handshaked rank, every other model writes the
+    tp-mapping's source ranks (which, in the push direction, are D's).
+    """
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.tp_mapping import (
+        TPMapping,
+    )
+
+    engine_id = "decode-engine"
+    w = _StubWriterWorker.fresh()
+    w.use_mla = use_mla
+    w.nixl_wrapper = MagicMock()
+    w.transfer_topo = MagicMock()
+    w.transfer_topo.get_engine_info.return_value = SimpleNamespace(
+        remote_tp_size=len(d_ranks),
+        remote_block_size=16,
+        remote_physical_blocks_per_logical=1,
+    )
+    # D_TP > P_TP => negative ratio (one P rank feeds |ratio| D ranks).
+    tp_ratio = -len(d_ranks)
+    w.transfer_topo.tp_ratio.return_value = tp_ratio
+    # The tp-mapping collapses MLA to a single source rank (correct for the
+    # pull/read direction); the push path must fan it back out.
+    source_ranks = (0,) if use_mla else tuple(d_ranks)
+    w.tp_mappings = {
+        engine_id: TPMapping(
+            source_ranks_per_group=(source_ranks,),
+            all_source_ranks=source_ranks,
+            rank_to_attention_slot={r: i for i, r in enumerate(source_ranks)},
+            rank_offset_factor=0,
+        )
+    }
+    w._logical_to_kernel_block_ids = lambda block_ids, ratio: block_ids
+    w.dst_xfer_side_handles = {engine_id: {r: 1000 + r for r in d_ranks}}
+    w.src_xfer_handles_by_block_size = {16: 2000}
+    # Non-MLA hetero TP chunks local memory per target rank.
+    w.src_xfer_handles_by_tp_ratio = {
+        (tp_ratio, 16): [3000 + i for i in range(len(d_ranks))]
+    }
+    w._remote_agents = {engine_id: {(0, r): f"agent-{r}" for r in d_ranks}}
+    return w, engine_id
+
+
 class TestPushWriterMlaReplication:
     """MLA latent KV is replicated across D's TP ranks, so when D_TP > P_TP
     (``tp_ratio < 0``) the producer must *WRITE* the latent into every D rank
     it handshook -- not write one and merely notify the rest, which would
     leave the un-written ranks decoding against stale KV."""
-
-    @staticmethod
-    def _mla_worker_writing_to(d_ranks):
-        from types import SimpleNamespace
-
-        from vllm.distributed.kv_transfer.kv_connector.v1.nixl.tp_mapping import (
-            TPMapping,
-        )
-
-        engine_id = "decode-engine"
-        w = _StubWriterWorker.fresh()
-        w.use_mla = True
-        w.nixl_wrapper = MagicMock()
-        w.transfer_topo = MagicMock()
-        w.transfer_topo.get_engine_info.return_value = SimpleNamespace(
-            remote_tp_size=len(d_ranks),
-            remote_block_size=16,
-            remote_physical_blocks_per_logical=1,
-        )
-        # D_TP > P_TP => negative ratio (one P rank feeds |ratio| D ranks).
-        w.transfer_topo.tp_ratio.return_value = -len(d_ranks)
-        # The tp-mapping collapses MLA to a single source rank (correct for
-        # the pull/read direction); the push path must fan it back out.
-        w.tp_mappings = {
-            engine_id: TPMapping(
-                source_ranks_per_group=((0,),),
-                all_source_ranks=(0,),
-                rank_to_attention_slot={0: 0},
-                rank_offset_factor=0,
-            )
-        }
-        w._logical_to_kernel_block_ids = lambda block_ids, ratio: block_ids
-        w.dst_xfer_side_handles = {engine_id: {r: 1000 + r for r in d_ranks}}
-        w.src_xfer_handles_by_block_size = {16: 2000}
-        w._remote_agents = {engine_id: {(0, r): f"agent-{r}" for r in d_ranks}}
-        return w, engine_id
 
     def test_mla_hetero_tp_writes_every_d_rank(self):
         from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
@@ -1125,7 +1153,7 @@ class TestPushWriterMlaReplication:
             ReqMeta,
         )
 
-        w, engine_id = self._mla_worker_writing_to(d_ranks=(0, 1))
+        w, engine_id = _push_worker_writing_to(d_ranks=(0, 1))
 
         written: list[int] = []
 
@@ -1248,3 +1276,213 @@ class TestPushPrefixCaching:
         local, remote = self._written_block_ids(w)
         assert local == [10, 11, 12]
         assert remote == [500, 501, 502]
+
+
+@pytest.fixture
+def quiet_worker_log(caplog):
+    """These paths log at ERROR by design; keep it out of the test report."""
+    caplog.set_level(
+        logging.CRITICAL,
+        logger="vllm.distributed.kv_transfer.kv_connector.v1.nixl.push_worker",
+    )
+
+
+class TestPushWriteFailureReporting:
+    """A WRITE that is never posted carries no completion notif, so without a
+    stand-in the consumer counts forever and the request hangs until its lease
+    expires. P reports the shortfall; D counts the report like any other notif
+    and only then fails the request."""
+
+    @staticmethod
+    def _consumer(*, producer_tp_size: int = 2, pp_size: int = 1):
+        w = _StubWriterWorker.fresh()
+        w.transfer_topo = MagicMock()
+        w._recving_metadata = {
+            "d-req": SimpleNamespace(pp_size=pp_size, local_block_ids=([100, 101],))
+        }
+        return w, producer_tp_size
+
+    @staticmethod
+    def _push_meta(engine_id: str) -> ReqMeta:
+        return ReqMeta(
+            local_block_ids=([100, 101],),
+            local_physical_block_ids=([100, 101],),
+            tp_size=1,
+            remote=RemoteMeta(
+                block_ids=([200, 201],),
+                host="",
+                port=0,
+                engine_id=engine_id,
+                request_id="d-req",
+            ),
+        )
+
+    @staticmethod
+    def _feed(w, req_id: str, producer_tp_size: int, *, failed: bool) -> None:
+        body = f"{req_id}:{producer_tp_size}"
+        msg = f"{_PUSH_FAIL_PREFIX_STR}{body}" if failed else body
+        w._pending_completion_notifs.put(msg.encode())
+        w._get_new_notifs()
+
+    @pytest.mark.parametrize("use_mla", [True, False])
+    def test_producer_reports_the_rank_whose_write_was_not_posted(self, use_mla):
+        """Both branches that resolve the write ranks must report: MLA's
+        fan-out to every handshaked rank, and the tp-mapping's source ranks
+        that every other model goes through."""
+        w, engine_id = _push_worker_writing_to(d_ranks=(0, 1), use_mla=use_mla)
+        # Rank 1's submission fails; rank 0's succeeds.
+        w._xfer_blocks = lambda **kw: (
+            None if kw["read_spec"].remote_rank == 1 else 1000
+        )
+
+        w._xfer_blocks_for_req(req_id="p-req", meta=self._push_meta(engine_id))
+
+        # The surviving WRITE is still tracked, so P's own accounting is intact.
+        assert w._sending_transfers["p-req"] == [1000]
+        # ...and only the failed rank is told.
+        w.nixl_wrapper.send_notif.assert_called_once()
+        call = w.nixl_wrapper.send_notif.call_args
+        assert call.args[0] == "agent-1"
+        assert call.kwargs["notif_msg"].startswith(PUSH_FAIL_NOTIF_PREFIX)
+        assert b"d-req" in call.kwargs["notif_msg"]
+
+    def test_report_is_sent_before_any_write_is_attempted(self):
+        """The write ranks are resolved before the setup that can raise, so a
+        failure between the two still reports every edge it owed. Resolving
+        them late leaves the original bug intact on that path."""
+        w, engine_id = _push_worker_writing_to(d_ranks=(0, 1))
+        w._logical_to_kernel_block_ids = MagicMock(side_effect=IndexError("no group"))
+        w._xfer_blocks = MagicMock()
+
+        with pytest.raises(IndexError):
+            w._xfer_blocks_for_req(req_id="p-req", meta=self._push_meta(engine_id))
+
+        assert w._xfer_blocks.call_count == 0
+        reported = [c.args[0] for c in w.nixl_wrapper.send_notif.call_args_list]
+        assert sorted(reported) == ["agent-0", "agent-1"]
+
+    def test_failure_does_not_land_until_sibling_writes_have(self):
+        """The property that makes this safe: failing on the first report
+        would free blocks while a sibling producer's RDMA WRITE is still in
+        flight, landing it in another request's KV."""
+        w, tp = self._consumer(producer_tp_size=2)
+
+        self._feed(w, "d-req", tp, failed=True)
+        # One of two edges reported. Nothing may be decided yet.
+        assert w._failed_recv_reqs.empty()
+        assert w.consumer_notification_counts_by_req["d-req"] == 1
+
+        self._feed(w, "d-req", tp, failed=False)
+        assert w._failed_recv_reqs.get_nowait() == "d-req"
+        assert "d-req" not in w.consumer_notification_counts_by_req
+        assert "d-req" not in w._failed_write_reqs
+        # The request must not also be reported as a successful receive.
+        assert "d-req" not in w._recving_transfers
+        # The blocks must be invalidated: an empty set makes the scheduler
+        # promote the request as a successful load over a cache that was
+        # never written.
+        assert w._invalid_block_ids.get_nowait() == {100, 101}
+        w.xfer_stats.record_failed_transfer.assert_called_once()
+
+    def test_all_writes_landing_still_completes_normally(self):
+        w, tp = self._consumer(producer_tp_size=2)
+
+        self._feed(w, "d-req", tp, failed=False)
+        self._feed(w, "d-req", tp, failed=False)
+
+        assert w._failed_recv_reqs.empty()
+        assert "d-req" in w._recving_transfers
+
+    def test_multi_group_models_are_left_to_the_lease(self, quiet_worker_log):
+        """``_handle_failed_transfer`` cannot invalidate blocks across groups,
+        and the scheduler would then promote a partially written cache as a
+        successful load. Hanging is the lesser evil."""
+        w, tp = self._consumer(producer_tp_size=1)
+        w._is_hma_required = True
+
+        self._feed(w, "d-req", tp, failed=True)
+
+        # The count completed, so this is a deliberate no-op rather than a
+        # notif we failed to recognise.
+        assert "d-req" not in w.consumer_notification_counts_by_req
+        assert w._failed_recv_reqs.empty()
+        assert "d-req" not in w._recving_transfers
+
+    def test_expired_request_does_not_leak_the_poison_flag(self):
+        w, tp = self._consumer(producer_tp_size=2)
+        self._feed(w, "d-req", tp, failed=True)
+        assert "d-req" in w._failed_write_reqs
+
+        # An unrelated request retiring in the same step must not clear it:
+        # a request that loses its flag mid-count completes as a *successful*
+        # load over KV that was never written.
+        self._retire(w, {"other-req"})
+        assert "d-req" in w._failed_write_reqs
+
+        # The lease expires and the base worker retires the request before
+        # its second notif ever arrives.
+        self._retire(w, {"d-req"})
+        assert w._failed_write_reqs == set()
+
+    @staticmethod
+    def _retire(w, done_recving: set[str]) -> None:
+        """Drive one ``get_finished`` where the base worker retires requests."""
+        with patch.object(
+            NixlBaseConnectorWorker,
+            "get_finished",
+            return_value=(set(), set(done_recving)),
+        ):
+            w.get_finished()
+
+    def test_report_travels_from_producer_to_consumer_unchanged(self):
+        """Round-trip the real bytes. A body the consumer parses differently
+        from what the producer wrote is silently catastrophic: too few fields
+        raises out of the engine step, and a wrong TP size shrinks the expected
+        count so the consumer acts while sibling WRITEs are still in flight."""
+        p, engine_id = _push_worker_writing_to(d_ranks=(0, 1))
+        p.world_size = 2
+        p._xfer_blocks = lambda **kw: None
+
+        p._xfer_blocks_for_req(req_id="p-req", meta=self._push_meta(engine_id))
+
+        sent = [c.kwargs["notif_msg"] for c in p.nixl_wrapper.send_notif.call_args_list]
+        assert len(sent) == 2
+
+        # A peer predating this change parses with rsplit(":", 1) alone, so the
+        # prefix must leave it an id matching nothing: it degrades to today's
+        # hang rather than counting the report and decoding over a gap.
+        assert sent[0].decode().rsplit(":", 1)[0] != "d-req"
+
+        # Feed exactly those bytes to a consumer whose producer has TP=2, so
+        # it expects one notif per producer rank.
+        d, _ = self._consumer(producer_tp_size=2)
+        d.world_size = 1
+        d._pending_completion_notifs.put(sent[0])
+        d._get_new_notifs()
+        assert d._failed_recv_reqs.empty(), "acted before both edges reported"
+
+        d._pending_completion_notifs.put(sent[1])
+        d._get_new_notifs()
+        assert d._failed_recv_reqs.get_nowait() == "d-req"
+
+    def test_multiple_groups_without_hma_are_also_gated(self, quiet_worker_log):
+        w, tp = self._consumer(producer_tp_size=1)
+        w._is_hma_required = False
+        w.kv_cache_config = SimpleNamespace(kv_cache_groups=[object(), object()])
+
+        self._feed(w, "d-req", tp, failed=True)
+
+        assert "d-req" not in w.consumer_notification_counts_by_req
+        assert w._failed_recv_reqs.empty()
+
+    def test_unattempted_ranks_are_reported_when_the_loop_unwinds(self):
+        """A raise mid-loop must still report the ranks it never reached, or
+        they are exactly as lost as the ones this fix exists to cover."""
+        w, engine_id = _push_worker_writing_to(d_ranks=(0, 1))
+        w._xfer_blocks = lambda **kw: (_ for _ in ()).throw(RuntimeError("boom"))
+
+        with pytest.raises(RuntimeError):
+            w._xfer_blocks_for_req(req_id="p-req", meta=self._push_meta(engine_id))
+
+        reported = [c.args[0] for c in w.nixl_wrapper.send_notif.call_args_list]
+        assert sorted(reported) == ["agent-0", "agent-1"]

--- a/tests/v1/kv_connector/unit/test_nixl_push_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_push_connector.py
@@ -26,18 +26,26 @@ import threading
 import time
 from collections import defaultdict
 from concurrent.futures import Future
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import msgspec
 import pytest
 
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker import (
+    NixlBaseConnectorWorker,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+    PUSH_FAIL_NOTIF_PREFIX,
     PUSH_REG_NOTIF_PREFIX,
     NixlAgentMetadata,
     NixlConnectorMetadata,
+    RemoteMeta,
+    ReqMeta,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.push_worker import (
+    _PUSH_FAIL_PREFIX_STR,
     NixlPushConnectorWorker,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.utils import (
@@ -337,6 +345,16 @@ class _StubWriterWorker(NixlPushConnectorWorker):
         w.world_size = 1
         w.engine_id = "test-decode-engine"
         w._remote_agents = {}
+        w._handshake_lock = threading.RLock()
+
+        # Failed-WRITE reporting state (_count_consumer_notif ->
+        # _fail_incomplete_push -> _handle_failed_transfer).
+        w._failed_write_reqs = set()
+        w._failed_recv_reqs = queue.Queue()
+        w._invalid_block_ids = queue.Queue()
+        w._is_hma_required = False
+        w.kv_cache_config = SimpleNamespace(kv_cache_groups=[object()])
+        w.xfer_stats = MagicMock()
         w._physical_blocks_per_logical_kv_block = 1
         # Single non-hybrid attention group, matching the stub block id lists.
         w._has_mamba = False
@@ -1021,47 +1039,57 @@ class TestPushPipelineParallel:
         assert meta.block_lens == [block_len, block_len]
 
 
+def _push_worker_writing_to(d_ranks, *, use_mla: bool = True):
+    """A producer worker handshook with consumer ranks ``d_ranks``.
+
+    ``use_mla`` selects which branch resolves the write ranks: MLA replicates
+    the latent to every handshaked rank, every other model writes the
+    tp-mapping's source ranks (which, in the push direction, are D's).
+    """
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.tp_mapping import (
+        TPMapping,
+    )
+
+    engine_id = "decode-engine"
+    w = _StubWriterWorker.fresh()
+    w.use_mla = use_mla
+    w.nixl_wrapper = MagicMock()
+    w.transfer_topo = MagicMock()
+    w.transfer_topo.get_engine_info.return_value = SimpleNamespace(
+        remote_tp_size=len(d_ranks),
+        remote_block_size=16,
+        remote_physical_blocks_per_logical=1,
+    )
+    # D_TP > P_TP => negative ratio (one P rank feeds |ratio| D ranks).
+    tp_ratio = -len(d_ranks)
+    w.transfer_topo.tp_ratio.return_value = tp_ratio
+    # The tp-mapping collapses MLA to a single source rank (correct for the
+    # pull/read direction); the push path must fan it back out.
+    source_ranks = (0,) if use_mla else tuple(d_ranks)
+    w.tp_mappings = {
+        engine_id: TPMapping(
+            source_ranks_per_group=(source_ranks,),
+            all_source_ranks=source_ranks,
+            rank_to_attention_slot={r: i for i, r in enumerate(source_ranks)},
+            rank_offset_factor=0,
+        )
+    }
+    w._logical_to_kernel_block_ids = lambda block_ids, ratio: block_ids
+    w.dst_xfer_side_handles = {engine_id: {r: 1000 + r for r in d_ranks}}
+    w.src_xfer_handles_by_block_size = {16: 2000}
+    # Non-MLA hetero TP chunks local memory per target rank.
+    w.src_xfer_handles_by_tp_ratio = {
+        (tp_ratio, 16): [3000 + i for i in range(len(d_ranks))]
+    }
+    w._remote_agents = {engine_id: {(0, r): f"agent-{r}" for r in d_ranks}}
+    return w, engine_id
+
+
 class TestPushWriterMlaReplication:
     """MLA latent KV is replicated across D's TP ranks, so when D_TP > P_TP
     (``tp_ratio < 0``) the producer must *WRITE* the latent into every D rank
     it handshook -- not write one and merely notify the rest, which would
     leave the un-written ranks decoding against stale KV."""
-
-    @staticmethod
-    def _mla_worker_writing_to(d_ranks):
-        from types import SimpleNamespace
-
-        from vllm.distributed.kv_transfer.kv_connector.v1.nixl.tp_mapping import (
-            TPMapping,
-        )
-
-        engine_id = "decode-engine"
-        w = _StubWriterWorker.fresh()
-        w.use_mla = True
-        w.nixl_wrapper = MagicMock()
-        w.transfer_topo = MagicMock()
-        w.transfer_topo.get_engine_info.return_value = SimpleNamespace(
-            remote_tp_size=len(d_ranks),
-            remote_block_size=16,
-            remote_physical_blocks_per_logical=1,
-        )
-        # D_TP > P_TP => negative ratio (one P rank feeds |ratio| D ranks).
-        w.transfer_topo.tp_ratio.return_value = -len(d_ranks)
-        # The tp-mapping collapses MLA to a single source rank (correct for
-        # the pull/read direction); the push path must fan it back out.
-        w.tp_mappings = {
-            engine_id: TPMapping(
-                source_ranks_per_group=((0,),),
-                all_source_ranks=(0,),
-                rank_to_attention_slot={0: 0},
-                rank_offset_factor=0,
-            )
-        }
-        w._logical_to_kernel_block_ids = lambda block_ids, ratio: block_ids
-        w.dst_xfer_side_handles = {engine_id: {r: 1000 + r for r in d_ranks}}
-        w.src_xfer_handles_by_block_size = {16: 2000}
-        w._remote_agents = {engine_id: {(0, r): f"agent-{r}" for r in d_ranks}}
-        return w, engine_id
 
     def test_mla_hetero_tp_writes_every_d_rank(self):
         from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
@@ -1069,7 +1097,7 @@ class TestPushWriterMlaReplication:
             ReqMeta,
         )
 
-        w, engine_id = self._mla_worker_writing_to(d_ranks=(0, 1))
+        w, engine_id = _push_worker_writing_to(d_ranks=(0, 1))
 
         written: list[int] = []
 
@@ -1102,3 +1130,213 @@ class TestPushWriterMlaReplication:
         # All of the request's WRITE handles must be tracked together, so the
         # engine thread never sees a partial set and double-frees the request.
         assert sorted(w._sending_transfers["p-req"]) == [1000, 1001]
+
+
+@pytest.fixture
+def quiet_worker_log(caplog):
+    """These paths log at ERROR by design; keep it out of the test report."""
+    caplog.set_level(
+        logging.CRITICAL,
+        logger="vllm.distributed.kv_transfer.kv_connector.v1.nixl.push_worker",
+    )
+
+
+class TestPushWriteFailureReporting:
+    """A WRITE that is never posted carries no completion notif, so without a
+    stand-in the consumer counts forever and the request hangs until its lease
+    expires. P reports the shortfall; D counts the report like any other notif
+    and only then fails the request."""
+
+    @staticmethod
+    def _consumer(*, producer_tp_size: int = 2, pp_size: int = 1):
+        w = _StubWriterWorker.fresh()
+        w.transfer_topo = MagicMock()
+        w._recving_metadata = {
+            "d-req": SimpleNamespace(pp_size=pp_size, local_block_ids=([100, 101],))
+        }
+        return w, producer_tp_size
+
+    @staticmethod
+    def _push_meta(engine_id: str) -> ReqMeta:
+        return ReqMeta(
+            local_block_ids=([100, 101],),
+            local_physical_block_ids=([100, 101],),
+            tp_size=1,
+            remote=RemoteMeta(
+                block_ids=([200, 201],),
+                host="",
+                port=0,
+                engine_id=engine_id,
+                request_id="d-req",
+            ),
+        )
+
+    @staticmethod
+    def _feed(w, req_id: str, producer_tp_size: int, *, failed: bool) -> None:
+        body = f"{req_id}:{producer_tp_size}"
+        msg = f"{_PUSH_FAIL_PREFIX_STR}{body}" if failed else body
+        w._pending_completion_notifs.put(msg.encode())
+        w._get_new_notifs()
+
+    @pytest.mark.parametrize("use_mla", [True, False])
+    def test_producer_reports_the_rank_whose_write_was_not_posted(self, use_mla):
+        """Both branches that resolve the write ranks must report: MLA's
+        fan-out to every handshaked rank, and the tp-mapping's source ranks
+        that every other model goes through."""
+        w, engine_id = _push_worker_writing_to(d_ranks=(0, 1), use_mla=use_mla)
+        # Rank 1's submission fails; rank 0's succeeds.
+        w._xfer_blocks = lambda **kw: (
+            None if kw["read_spec"].remote_rank == 1 else 1000
+        )
+
+        w._xfer_blocks_for_req(req_id="p-req", meta=self._push_meta(engine_id))
+
+        # The surviving WRITE is still tracked, so P's own accounting is intact.
+        assert w._sending_transfers["p-req"] == [1000]
+        # ...and only the failed rank is told.
+        w.nixl_wrapper.send_notif.assert_called_once()
+        call = w.nixl_wrapper.send_notif.call_args
+        assert call.args[0] == "agent-1"
+        assert call.kwargs["notif_msg"].startswith(PUSH_FAIL_NOTIF_PREFIX)
+        assert b"d-req" in call.kwargs["notif_msg"]
+
+    def test_report_is_sent_before_any_write_is_attempted(self):
+        """The write ranks are resolved before the setup that can raise, so a
+        failure between the two still reports every edge it owed. Resolving
+        them late leaves the original bug intact on that path."""
+        w, engine_id = _push_worker_writing_to(d_ranks=(0, 1))
+        w._logical_to_kernel_block_ids = MagicMock(side_effect=IndexError("no group"))
+        w._xfer_blocks = MagicMock()
+
+        with pytest.raises(IndexError):
+            w._xfer_blocks_for_req(req_id="p-req", meta=self._push_meta(engine_id))
+
+        assert w._xfer_blocks.call_count == 0
+        reported = [c.args[0] for c in w.nixl_wrapper.send_notif.call_args_list]
+        assert sorted(reported) == ["agent-0", "agent-1"]
+
+    def test_failure_does_not_land_until_sibling_writes_have(self):
+        """The property that makes this safe: failing on the first report
+        would free blocks while a sibling producer's RDMA WRITE is still in
+        flight, landing it in another request's KV."""
+        w, tp = self._consumer(producer_tp_size=2)
+
+        self._feed(w, "d-req", tp, failed=True)
+        # One of two edges reported. Nothing may be decided yet.
+        assert w._failed_recv_reqs.empty()
+        assert w.consumer_notification_counts_by_req["d-req"] == 1
+
+        self._feed(w, "d-req", tp, failed=False)
+        assert w._failed_recv_reqs.get_nowait() == "d-req"
+        assert "d-req" not in w.consumer_notification_counts_by_req
+        assert "d-req" not in w._failed_write_reqs
+        # The request must not also be reported as a successful receive.
+        assert "d-req" not in w._recving_transfers
+        # The blocks must be invalidated: an empty set makes the scheduler
+        # promote the request as a successful load over a cache that was
+        # never written.
+        assert w._invalid_block_ids.get_nowait() == {100, 101}
+        w.xfer_stats.record_failed_transfer.assert_called_once()
+
+    def test_all_writes_landing_still_completes_normally(self):
+        w, tp = self._consumer(producer_tp_size=2)
+
+        self._feed(w, "d-req", tp, failed=False)
+        self._feed(w, "d-req", tp, failed=False)
+
+        assert w._failed_recv_reqs.empty()
+        assert "d-req" in w._recving_transfers
+
+    def test_multi_group_models_are_left_to_the_lease(self, quiet_worker_log):
+        """``_handle_failed_transfer`` cannot invalidate blocks across groups,
+        and the scheduler would then promote a partially written cache as a
+        successful load. Hanging is the lesser evil."""
+        w, tp = self._consumer(producer_tp_size=1)
+        w._is_hma_required = True
+
+        self._feed(w, "d-req", tp, failed=True)
+
+        # The count completed, so this is a deliberate no-op rather than a
+        # notif we failed to recognise.
+        assert "d-req" not in w.consumer_notification_counts_by_req
+        assert w._failed_recv_reqs.empty()
+        assert "d-req" not in w._recving_transfers
+
+    def test_expired_request_does_not_leak_the_poison_flag(self):
+        w, tp = self._consumer(producer_tp_size=2)
+        self._feed(w, "d-req", tp, failed=True)
+        assert "d-req" in w._failed_write_reqs
+
+        # An unrelated request retiring in the same step must not clear it:
+        # a request that loses its flag mid-count completes as a *successful*
+        # load over KV that was never written.
+        self._retire(w, {"other-req"})
+        assert "d-req" in w._failed_write_reqs
+
+        # The lease expires and the base worker retires the request before
+        # its second notif ever arrives.
+        self._retire(w, {"d-req"})
+        assert w._failed_write_reqs == set()
+
+    @staticmethod
+    def _retire(w, done_recving: set[str]) -> None:
+        """Drive one ``get_finished`` where the base worker retires requests."""
+        with patch.object(
+            NixlBaseConnectorWorker,
+            "get_finished",
+            return_value=(set(), set(done_recving)),
+        ):
+            w.get_finished()
+
+    def test_report_travels_from_producer_to_consumer_unchanged(self):
+        """Round-trip the real bytes. A body the consumer parses differently
+        from what the producer wrote is silently catastrophic: too few fields
+        raises out of the engine step, and a wrong TP size shrinks the expected
+        count so the consumer acts while sibling WRITEs are still in flight."""
+        p, engine_id = _push_worker_writing_to(d_ranks=(0, 1))
+        p.world_size = 2
+        p._xfer_blocks = lambda **kw: None
+
+        p._xfer_blocks_for_req(req_id="p-req", meta=self._push_meta(engine_id))
+
+        sent = [c.kwargs["notif_msg"] for c in p.nixl_wrapper.send_notif.call_args_list]
+        assert len(sent) == 2
+
+        # A peer predating this change parses with rsplit(":", 1) alone, so the
+        # prefix must leave it an id matching nothing: it degrades to today's
+        # hang rather than counting the report and decoding over a gap.
+        assert sent[0].decode().rsplit(":", 1)[0] != "d-req"
+
+        # Feed exactly those bytes to a consumer whose producer has TP=2, so
+        # it expects one notif per producer rank.
+        d, _ = self._consumer(producer_tp_size=2)
+        d.world_size = 1
+        d._pending_completion_notifs.put(sent[0])
+        d._get_new_notifs()
+        assert d._failed_recv_reqs.empty(), "acted before both edges reported"
+
+        d._pending_completion_notifs.put(sent[1])
+        d._get_new_notifs()
+        assert d._failed_recv_reqs.get_nowait() == "d-req"
+
+    def test_multiple_groups_without_hma_are_also_gated(self, quiet_worker_log):
+        w, tp = self._consumer(producer_tp_size=1)
+        w._is_hma_required = False
+        w.kv_cache_config = SimpleNamespace(kv_cache_groups=[object(), object()])
+
+        self._feed(w, "d-req", tp, failed=True)
+
+        assert "d-req" not in w.consumer_notification_counts_by_req
+        assert w._failed_recv_reqs.empty()
+
+    def test_unattempted_ranks_are_reported_when_the_loop_unwinds(self):
+        """A raise mid-loop must still report the ranks it never reached, or
+        they are exactly as lost as the ones this fix exists to cover."""
+        w, engine_id = _push_worker_writing_to(d_ranks=(0, 1))
+        w._xfer_blocks = lambda **kw: (_ for _ in ()).throw(RuntimeError("boom"))
+
+        with pytest.raises(RuntimeError):
+            w._xfer_blocks_for_req(req_id="p-req", meta=self._push_meta(engine_id))
+
+        reported = [c.args[0] for c in w.nixl_wrapper.send_notif.call_args_list]
+        assert sorted(reported) == ["agent-0", "agent-1"]

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
@@ -24,6 +24,11 @@ GET_META_MSG = b"get_meta_msg"
 # Sent worker-to-worker over NIXL: D worker -> P worker, encoded as
 # PUSH_REG_NOTIF_PREFIX + msgpack(registration_data).
 PUSH_REG_NOTIF_PREFIX = b"PUSH_REG:"
+
+# Push-mode WRITE failure notification. Sent P worker -> D worker as
+# PUSH_FAIL_NOTIF_PREFIX + the completion notification body; stands in for a
+# WRITE that could not be posted so the consumer's count still adds up.
+PUSH_FAIL_NOTIF_PREFIX = b"PUSH_FAIL:"
 #
 # NIXL Connector Version
 #

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -45,6 +45,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker import (
     NixlBaseConnectorWorker,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+    PUSH_FAIL_NOTIF_PREFIX,
     PUSH_REG_NOTIF_PREFIX,
     NixlConnectorMetadata,
     RemoteMeta,
@@ -73,6 +74,9 @@ logger = init_logger(__name__)
 # while active, slightly more CPU.
 _PUSH_WRITER_POLL_INTERVAL_MS = 1.0
 
+# Notifs are decoded to str before dispatch; keep a str twin of the prefix.
+_PUSH_FAIL_PREFIX_STR = PUSH_FAIL_NOTIF_PREFIX.decode()
+
 
 class NixlPushConnectorWorker(NixlBaseConnectorWorker):
     """Push-specific (WRITE) worker logic. See module docstring."""
@@ -96,6 +100,10 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         # ``_sending_transfers_lock``.
         self._sending_transfers = defaultdict[ReqId, list[TransferHandle]](list)
         self._sending_transfers_lock = threading.Lock()
+
+        # D-side: requests where P reported a WRITE it could not post. Failed
+        # only once the count completes, by when posted WRITEs have landed.
+        self._failed_write_reqs: set[ReqId] = set()
 
         # Writer-thread owned matching state.
         # P-side: finished request blocks received from scheduler metadata
@@ -499,95 +507,167 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         """Issue WRITE transfers to one or more remote TP ranks."""
         assert meta.remote is not None and self.transfer_topo is not None
         engine_id = meta.remote.engine_id
-        plan = self.tp_mappings[engine_id]
-        remote_info = self.transfer_topo.get_engine_info(engine_id)
-        tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
-
-        # Expand D's logical IDs using the ratio learned during the
-        # NIXL handshake. ``meta`` is freshly built by
-        # ``_do_start_push_kv`` so mutating it here is safe.
-        meta.remote.block_ids = self._logical_to_kernel_block_ids(
-            meta.remote.block_ids,
-            remote_info.remote_physical_blocks_per_logical,
-        )
-        remote_block_ids = meta.remote.block_ids
-        local_block_ids = meta.local_physical_block_ids
-        num_groups = len(local_block_ids)
-
-        # MLA latent is replicated across D's TP ranks: the tp-mapping
-        # collapses it to one rank (fine for reads), but push must WRITE every
-        # D rank or the rest decode stale KV. For hybrid MLA+SSM the sharded
-        # SSM state already targets every covered D rank, so only the
-        # attention groups need widening; pure MLA writes to all handshaked
-        # ranks (only the dst differs per rank).
-        replicate_attn = self.use_mla and tp_ratio < 0
-        if replicate_attn and not self._has_mamba:
-            assert len(plan.all_source_ranks) == 1
-            write_ranks = sorted(self.dst_xfer_side_handles[engine_id])
-        else:
-            write_ranks = list(plan.all_source_ranks)
-
-        def group_ids(block_ids: BlockIds, rank: int) -> BlockIds:
-            return [
-                list(block_ids[g])
-                if (replicate_attn and _is_attention_spec(self._group_spec_types[g]))
-                or rank in plan.source_ranks_per_group[g]
-                else []
-                for g in range(num_groups)
-            ]
-
-        read_specs = [
-            ReadSpec(
-                remote_rank=rank,
-                local_block_ids=group_ids(local_block_ids, rank),
-                remote_block_ids=group_ids(remote_block_ids, rank),
-            )
-            for rank in write_ranks
-        ]
 
         handles: list[int] = []
-        for i, spec in enumerate(read_specs):
-            remote_block_size = remote_info.remote_block_size
-            logger.debug(
-                "Remote agent %s available, calling _xfer_blocks"
-                " on remote rank %s with remote block size %s for req %s",
-                meta.remote.engine_id,
-                spec.remote_rank,
-                remote_block_size,
-                req_id,
-            )
-            if tp_ratio < 0 and (not self.use_mla or len(plan.all_source_ranks) > 1):
-                # Multiple targets: write each rank its chunk of local memory.
-                # Hybrid MLA+SSM also lands here: its split handles replicate
-                # the attention descriptors and chunk only the SSM state.
-                split_key = (tp_ratio, remote_block_size)
-                local_xfer_side_handle = self.src_xfer_handles_by_tp_ratio[split_key][i]
+        # One notif per (producer rank -> consumer rank) edge, riding on the
+        # WRITE: unposted ranks must be reported, unresolvable ones must not
+        # (a spurious notif finishes D's count while siblings are in flight).
+        write_ranks: list[int] = []
+        posted_ranks: set[int] = set()
+        try:
+            plan = self.tp_mappings[engine_id]
+            remote_info = self.transfer_topo.get_engine_info(engine_id)
+            tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
+
+            # Resolved before anything that can raise, so the ``finally`` still
+            # knows which edges it owes a report.
+            # MLA latent is replicated across D's TP ranks: the tp-mapping
+            # collapses it to one rank (fine for reads), but push must WRITE
+            # every D rank or the rest decode stale KV. For hybrid MLA+SSM the
+            # sharded SSM state already targets every covered D rank, so only
+            # the attention groups need widening; pure MLA writes to all
+            # handshaked ranks (only the dst differs per rank).
+            replicate_attn = self.use_mla and tp_ratio < 0
+            if replicate_attn and not self._has_mamba:
+                write_ranks = sorted(self.dst_xfer_side_handles[engine_id])
+                assert len(plan.all_source_ranks) == 1
             else:
-                local_xfer_side_handle = self.src_xfer_handles_by_block_size[
-                    remote_block_size
+                write_ranks = list(plan.all_source_ranks)
+
+            if not write_ranks:
+                # ``dst_xfer_side_handles`` is a defaultdict, so an engine with
+                # no handshaked ranks yields an empty set rather than raising.
+                logger.error(
+                    "No remote ranks to push request %s to on engine %s; its "
+                    "consumer will hold its blocks until it is aborted",
+                    req_id,
+                    engine_id,
+                )
+
+            # Expand D's logical IDs using the ratio learned during the
+            # NIXL handshake. ``meta`` is freshly built by
+            # ``_do_start_push_kv`` so mutating it here is safe.
+            meta.remote.block_ids = self._logical_to_kernel_block_ids(
+                meta.remote.block_ids,
+                remote_info.remote_physical_blocks_per_logical,
+            )
+            remote_block_ids = meta.remote.block_ids
+            local_block_ids = meta.local_physical_block_ids
+            num_groups = len(local_block_ids)
+
+            def group_ids(block_ids: BlockIds, rank: int) -> BlockIds:
+                return [
+                    list(block_ids[g])
+                    if (
+                        replicate_attn and _is_attention_spec(self._group_spec_types[g])
+                    )
+                    or rank in plan.source_ranks_per_group[g]
+                    else []
+                    for g in range(num_groups)
                 ]
 
-            remote_xfer_side_handle = self.dst_xfer_side_handles[meta.remote.engine_id][
-                spec.remote_rank
+            read_specs = [
+                ReadSpec(
+                    remote_rank=rank,
+                    local_block_ids=group_ids(local_block_ids, rank),
+                    remote_block_ids=group_ids(remote_block_ids, rank),
+                )
+                for rank in write_ranks
             ]
 
-            handle = self._xfer_blocks(
-                read_spec=spec,
-                request_id=req_id,
-                dst_engine_id=meta.remote.engine_id,
-                remote_request_id=meta.remote.request_id,
-                local_xfer_side_handle=local_xfer_side_handle,
-                remote_xfer_side_handle=remote_xfer_side_handle,
-            )
-            if handle is not None:
-                handles.append(handle)
+            for i, spec in enumerate(read_specs):
+                remote_block_size = remote_info.remote_block_size
+                logger.debug(
+                    "Remote agent %s available, calling _xfer_blocks"
+                    " on remote rank %s with remote block size %s for req %s",
+                    engine_id,
+                    spec.remote_rank,
+                    remote_block_size,
+                    req_id,
+                )
+                if tp_ratio < 0 and (
+                    not self.use_mla or len(plan.all_source_ranks) > 1
+                ):
+                    # Multiple targets: write each rank its chunk of local memory.
+                    # Hybrid MLA+SSM also lands here: its split handles replicate
+                    # the attention descriptors and chunk only the SSM state.
+                    split_key = (tp_ratio, remote_block_size)
+                    local_xfer_side_handle = self.src_xfer_handles_by_tp_ratio[
+                        split_key
+                    ][i]
+                else:
+                    local_xfer_side_handle = self.src_xfer_handles_by_block_size[
+                        remote_block_size
+                    ]
 
-        # Publish all the request's WRITE handles in one locked update: a
-        # partial set would let ``_pop_done_transfers`` finish the request
-        # early, then double-report it as the remaining writes land.
-        if handles:
-            with self._sending_transfers_lock:
-                self._sending_transfers[req_id].extend(handles)
+                remote_xfer_side_handle = self.dst_xfer_side_handles[engine_id][
+                    spec.remote_rank
+                ]
+
+                handle = self._xfer_blocks(
+                    read_spec=spec,
+                    request_id=req_id,
+                    dst_engine_id=engine_id,
+                    remote_request_id=meta.remote.request_id,
+                    local_xfer_side_handle=local_xfer_side_handle,
+                    remote_xfer_side_handle=remote_xfer_side_handle,
+                )
+                if handle is not None:
+                    handles.append(handle)
+                    posted_ranks.add(spec.remote_rank)
+        finally:
+            # Publish all the request's WRITE handles in one locked update: a
+            # partial set would let ``_pop_done_transfers`` finish the request
+            # early, then double-report it as the remaining writes land.
+            if handles:
+                with self._sending_transfers_lock:
+                    self._sending_transfers[req_id].extend(handles)
+
+            failed_ranks = [r for r in write_ranks if r not in posted_ranks]
+            if failed_ranks:
+                self._notify_push_failure(
+                    req_id, engine_id, meta.remote.request_id, failed_ranks
+                )
+
+    def _notify_push_failure(
+        self,
+        req_id: str,
+        engine_id: str,
+        remote_request_id: str,
+        failed_ranks: list[int],
+    ) -> None:
+        """Tell D that some of this request's WRITEs were never posted.
+
+        Stands in for the completion notifs those WRITEs would have carried,
+        so D's count still completes. Best-effort: a report that cannot be
+        sent leaves D waiting, as it does today.
+        """
+        notif_msg = (
+            PUSH_FAIL_NOTIF_PREFIX + f"{remote_request_id}:{self.world_size}".encode()
+        )
+        for rank in failed_ranks:
+            with self._handshake_lock:
+                # Push targets always handshake with pp_size=1.
+                agent_name = (self._remote_agents.get(engine_id) or {}).get((0, rank))
+            if agent_name is None:
+                logger.error(
+                    "No agent for rank %d of engine %s; cannot report the failed "
+                    "WRITE for request %s, which will hold its blocks until it "
+                    "is aborted",
+                    rank,
+                    engine_id,
+                    req_id,
+                )
+                continue
+            try:
+                self.nixl_wrapper.send_notif(agent_name, notif_msg=notif_msg)
+            except Exception as e:
+                self._log_failure(
+                    failure_type="push_fail_notif_failed",
+                    req_id=req_id,
+                    error=e,
+                    remote_rank=rank,
+                )
 
     def _xfer_blocks(
         self,
@@ -718,32 +798,24 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                 self._handle_heartbeat(msg[3:])
                 continue
 
+            failed_write = msg.startswith(_PUSH_FAIL_PREFIX_STR)
+            if failed_write:
+                msg = msg[len(_PUSH_FAIL_PREFIX_STR) :]
+
             req_id, tp_size = msg.rsplit(":", 1)
 
             # Not tracked as a P-side send/process for this notif.
             if req_id not in self._reqs_to_send and req_id not in self._reqs_to_process:
-                if (meta := self._recving_metadata.get(req_id)) is not None:
-                    # Consumer waits for one notif per producer rank writing
-                    # here: pp_size stages * producers-per-consumer (>1 when
-                    # producer TP > consumer TP; tp_size is the producer TP).
-                    producers_per_consumer = max(1, int(tp_size) // self.world_size)
-                    expected_notifs = meta.pp_size * producers_per_consumer
-                    self.consumer_notification_counts_by_req[req_id] += 1
-                    notifs = self.consumer_notification_counts_by_req[req_id]
-                    if notifs < expected_notifs:
-                        continue
-                    del self.consumer_notification_counts_by_req[req_id]
-                    # P drove the transfer (we own no NIXL handle), so
-                    # materialise an empty ``_recving_transfers`` entry for
-                    # ``_pop_done_transfers`` to report done.
-                    self._recving_transfers.setdefault(req_id, [])
-                else:
-                    # Not tracked on either side (lease may have expired
-                    # before the notif arrived). Log and skip.
-                    logger.error(
-                        "Unrecognized request %s notif (may have expired).",
-                        req_id,
-                    )
+                self._count_consumer_notif(req_id, int(tp_size), failed_write)
+                continue
+
+            if failed_write:
+                # Counting it here would retire our own lease.
+                logger.error(
+                    "Ignoring failed-WRITE report for %s, which this worker is "
+                    "itself producing",
+                    req_id,
+                )
                 continue
 
             n_consumers = int(tp_size)
@@ -760,6 +832,70 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                 self._reqs_to_send.pop(req_id, None)
         return notified_req_ids
 
+    def _count_consumer_notif(
+        self, req_id: str, producer_tp_size: int, failed_write: bool
+    ) -> None:
+        """Count one notif for a request this node is receiving.
+
+        One notif is expected per producer rank writing here: pp_size stages
+        * producers-per-consumer, derived from ``producer_tp_size`` as carried
+        in the notif body. A failed WRITE reports in place of its completion,
+        so a failure never short-circuits the count and every posted WRITE has
+        landed by the time it finishes.
+        """
+        meta = self._recving_metadata.get(req_id)
+        if meta is None:
+            # Not tracked on either side (lease may have expired before the
+            # notif arrived). Log and skip.
+            logger.error("Unrecognized request %s notif (may have expired).", req_id)
+            return
+
+        if failed_write:
+            self._failed_write_reqs.add(req_id)
+
+        producers_per_consumer = max(1, producer_tp_size // self.world_size)
+        expected_notifs = meta.pp_size * producers_per_consumer
+        self.consumer_notification_counts_by_req[req_id] += 1
+        if self.consumer_notification_counts_by_req[req_id] < expected_notifs:
+            return
+
+        del self.consumer_notification_counts_by_req[req_id]
+        if req_id not in self._failed_write_reqs:
+            # P drove the transfer (we own no NIXL handle), so materialise an
+            # empty ``_recving_transfers`` entry for ``_pop_done_transfers``
+            # to report done.
+            self._recving_transfers.setdefault(req_id, [])
+            return
+
+        self._failed_write_reqs.discard(req_id)
+        self._fail_incomplete_push(req_id, meta)
+
+    def _fail_incomplete_push(self, req_id: str, meta: ReqMeta) -> None:
+        """Fail a request whose producer could not post every WRITE."""
+        # ``_handle_failed_transfer`` invalidates one group only. With no
+        # blocks recorded the scheduler promotes the request as a successful
+        # load over a cache that was never written, so leave it to its lease.
+        if self._is_hma_required or len(self.kv_cache_config.kv_cache_groups) > 1:
+            reason = "recovery is unsupported for hybrid or multi-group models"
+        elif not any(meta.local_block_ids):
+            reason = "it has no local blocks to invalidate"
+        else:
+            reason = None
+
+        if reason is not None:
+            logger.error(
+                "Producer could not write all KV for request %s and %s; it will "
+                "hold its blocks until it is aborted",
+                req_id,
+                reason,
+            )
+            return
+
+        logger.warning(
+            "Producer could not write all KV for request %s; failing it.", req_id
+        )
+        self._handle_failed_transfer(req_id, None)
+
     def get_finished(self) -> tuple[set[str], set[str]]:
         # Engine main thread asking for completions: also wake the writer
         # so it gets a chance to drain NIXL notifs (heartbeats, completion
@@ -767,6 +903,9 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         self._push_writer_wake.set()
 
         done_sending, done_recving = super().get_finished()
+
+        # A request retired before its count completed would leak its flag.
+        self._failed_write_reqs.difference_update(done_recving)
 
         # ``_pop_done_transfers`` mutates ``_sending_transfers``; the
         # writer thread also appends to it, so guard the pop.

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -505,130 +505,144 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         return block_ids
 
     def _xfer_blocks_for_req(self, req_id: str, meta: ReqMeta):
-        """Issue WRITE transfers to one or more remote TP ranks."""
+        """Issue WRITE transfers to one or more remote TP ranks.
+
+        Every rank resolved here owes D exactly one notif. The completion rides
+        along with the WRITE, so a rank whose WRITE never got posted is reported
+        instead -- otherwise D counts toward a total it can never reach.
+        """
         assert meta.remote is not None and self.transfer_topo is not None
         engine_id = meta.remote.engine_id
+        write_ranks = self._resolve_write_ranks(req_id, engine_id)
 
-        handles: list[int] = []
-        # One notif per (producer rank -> consumer rank) edge, riding on the
-        # WRITE: unposted ranks must be reported, unresolvable ones must not
-        # (a spurious notif finishes D's count while siblings are in flight).
-        write_ranks: list[int] = []
-        posted_ranks: set[int] = set()
+        posted: dict[int, TransferHandle] = {}
         try:
-            plan = self.tp_mappings[engine_id]
-            remote_info = self.transfer_topo.get_engine_info(engine_id)
-            tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
-
-            # Resolved before anything that can raise, so the ``finally`` still
-            # knows which edges it owes a report.
-            # MLA latent is replicated across D's TP ranks: the tp-mapping
-            # collapses it to one rank (fine for reads), but push must WRITE
-            # every D rank or the rest decode stale KV. For hybrid MLA+SSM the
-            # sharded SSM state already targets every covered D rank, so only
-            # the attention groups need widening; pure MLA writes to all
-            # handshaked ranks (only the dst differs per rank).
-            replicate_attn = self.use_mla and tp_ratio < 0
-            if replicate_attn and not self._has_mamba:
-                write_ranks = sorted(self.dst_xfer_side_handles[engine_id])
-                assert len(plan.all_source_ranks) == 1
-            else:
-                write_ranks = list(plan.all_source_ranks)
-
-            if not write_ranks:
-                # ``dst_xfer_side_handles`` is a defaultdict, so an engine with
-                # no handshaked ranks yields an empty set rather than raising.
-                logger.error(
-                    "No remote ranks to push request %s to on engine %s; its "
-                    "consumer will hold its blocks until it is aborted",
-                    req_id,
-                    engine_id,
-                )
-
-            # Expand D's logical IDs using the ratio learned during the
-            # NIXL handshake. ``meta`` is freshly built by
-            # ``_do_start_push_kv`` so mutating it here is safe.
-            meta.remote.block_ids = self._logical_to_kernel_block_ids(
-                meta.remote.block_ids,
-                remote_info.remote_physical_blocks_per_logical,
-            )
-            remote_block_ids = meta.remote.block_ids
-            local_block_ids = meta.local_physical_block_ids
-            num_groups = len(local_block_ids)
-
-            def group_ids(block_ids: BlockIds, rank: int) -> BlockIds:
-                return [
-                    list(block_ids[g])
-                    if (
-                        replicate_attn and _is_attention_spec(self._group_spec_types[g])
-                    )
-                    or rank in plan.source_ranks_per_group[g]
-                    else []
-                    for g in range(num_groups)
-                ]
-
-            read_specs = [
-                ReadSpec(
-                    remote_rank=rank,
-                    local_block_ids=group_ids(local_block_ids, rank),
-                    remote_block_ids=group_ids(remote_block_ids, rank),
-                )
-                for rank in write_ranks
-            ]
-
-            for i, spec in enumerate(read_specs):
-                remote_block_size = remote_info.remote_block_size
-                logger.debug(
-                    "Remote agent %s available, calling _xfer_blocks"
-                    " on remote rank %s with remote block size %s for req %s",
-                    engine_id,
-                    spec.remote_rank,
-                    remote_block_size,
-                    req_id,
-                )
-                if tp_ratio < 0 and (
-                    not self.use_mla or len(plan.all_source_ranks) > 1
-                ):
-                    # Multiple targets: write each rank its chunk of local memory.
-                    # Hybrid MLA+SSM also lands here: its split handles replicate
-                    # the attention descriptors and chunk only the SSM state.
-                    split_key = (tp_ratio, remote_block_size)
-                    local_xfer_side_handle = self.src_xfer_handles_by_tp_ratio[
-                        split_key
-                    ][i]
-                else:
-                    local_xfer_side_handle = self.src_xfer_handles_by_block_size[
-                        remote_block_size
-                    ]
-
-                remote_xfer_side_handle = self.dst_xfer_side_handles[engine_id][
-                    spec.remote_rank
-                ]
-
-                handle = self._xfer_blocks(
-                    read_spec=spec,
-                    request_id=req_id,
-                    dst_engine_id=engine_id,
-                    remote_request_id=meta.remote.request_id,
-                    local_xfer_side_handle=local_xfer_side_handle,
-                    remote_xfer_side_handle=remote_xfer_side_handle,
-                )
-                if handle is not None:
-                    handles.append(handle)
-                    posted_ranks.add(spec.remote_rank)
+            self._post_writes(req_id, meta, write_ranks, posted)
         finally:
             # Publish all the request's WRITE handles in one locked update: a
             # partial set would let ``_pop_done_transfers`` finish the request
             # early, then double-report it as the remaining writes land.
-            if handles:
+            if posted:
                 with self._sending_transfers_lock:
-                    self._sending_transfers[req_id].extend(handles)
+                    self._sending_transfers[req_id].extend(posted.values())
 
-            failed_ranks = [r for r in write_ranks if r not in posted_ranks]
+            failed_ranks = [rank for rank in write_ranks if rank not in posted]
             if failed_ranks:
                 self._notify_push_failure(
                     req_id, engine_id, meta.remote.request_id, failed_ranks
                 )
+
+    def _resolve_write_ranks(self, req_id: str, engine_id: str) -> list[int]:
+        """The remote TP ranks this rank must WRITE *req_id* to."""
+        assert self.transfer_topo is not None
+        plan = self.tp_mappings[engine_id]
+        remote_info = self.transfer_topo.get_engine_info(engine_id)
+        tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
+
+        # MLA latent is replicated across D's TP ranks: the tp-mapping
+        # collapses it to one rank (fine for reads), but push must WRITE every
+        # D rank or the rest decode stale KV. For hybrid MLA+SSM the sharded
+        # SSM state already targets every covered D rank, so only the attention
+        # groups need widening; pure MLA writes to all handshaked ranks (only
+        # the dst differs per rank).
+        replicate_attn = self.use_mla and tp_ratio < 0
+        if replicate_attn and not self._has_mamba:
+            assert len(plan.all_source_ranks) == 1
+            write_ranks = sorted(self.dst_xfer_side_handles[engine_id])
+        else:
+            write_ranks = list(plan.all_source_ranks)
+
+        if not write_ranks:
+            # ``dst_xfer_side_handles`` is a defaultdict, so an engine with no
+            # handshaked ranks yields an empty set rather than raising. There
+            # is nothing to report to either, so D falls back to its lease.
+            logger.error(
+                "No remote ranks to push request %s to on engine %s; its "
+                "consumer will hold its blocks until it is aborted",
+                req_id,
+                engine_id,
+            )
+        return write_ranks
+
+    def _post_writes(
+        self,
+        req_id: str,
+        meta: ReqMeta,
+        write_ranks: list[int],
+        posted: dict[int, TransferHandle],
+    ) -> None:
+        """Submit one WRITE per rank in *write_ranks*, recording those posted."""
+        assert meta.remote is not None and self.transfer_topo is not None
+        engine_id = meta.remote.engine_id
+        plan = self.tp_mappings[engine_id]
+        remote_info = self.transfer_topo.get_engine_info(engine_id)
+        tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
+        replicate_attn = self.use_mla and tp_ratio < 0
+
+        # Expand D's logical IDs using the ratio learned during the
+        # NIXL handshake. ``meta`` is freshly built by
+        # ``_do_start_push_kv`` so mutating it here is safe.
+        meta.remote.block_ids = self._logical_to_kernel_block_ids(
+            meta.remote.block_ids,
+            remote_info.remote_physical_blocks_per_logical,
+        )
+        remote_block_ids = meta.remote.block_ids
+        local_block_ids = meta.local_physical_block_ids
+        num_groups = len(local_block_ids)
+
+        def group_ids(block_ids: BlockIds, rank: int) -> BlockIds:
+            return [
+                list(block_ids[g])
+                if (replicate_attn and _is_attention_spec(self._group_spec_types[g]))
+                or rank in plan.source_ranks_per_group[g]
+                else []
+                for g in range(num_groups)
+            ]
+
+        read_specs = [
+            ReadSpec(
+                remote_rank=rank,
+                local_block_ids=group_ids(local_block_ids, rank),
+                remote_block_ids=group_ids(remote_block_ids, rank),
+            )
+            for rank in write_ranks
+        ]
+
+        for i, spec in enumerate(read_specs):
+            remote_block_size = remote_info.remote_block_size
+            logger.debug(
+                "Remote agent %s available, calling _xfer_blocks"
+                " on remote rank %s with remote block size %s for req %s",
+                engine_id,
+                spec.remote_rank,
+                remote_block_size,
+                req_id,
+            )
+            if tp_ratio < 0 and (not self.use_mla or len(plan.all_source_ranks) > 1):
+                # Multiple targets: write each rank its chunk of local memory.
+                # Hybrid MLA+SSM also lands here: its split handles replicate
+                # the attention descriptors and chunk only the SSM state.
+                split_key = (tp_ratio, remote_block_size)
+                local_xfer_side_handle = self.src_xfer_handles_by_tp_ratio[split_key][i]
+            else:
+                local_xfer_side_handle = self.src_xfer_handles_by_block_size[
+                    remote_block_size
+                ]
+
+            remote_xfer_side_handle = self.dst_xfer_side_handles[engine_id][
+                spec.remote_rank
+            ]
+
+            handle = self._xfer_blocks(
+                read_spec=spec,
+                request_id=req_id,
+                dst_engine_id=engine_id,
+                remote_request_id=meta.remote.request_id,
+                local_xfer_side_handle=local_xfer_side_handle,
+                remote_xfer_side_handle=remote_xfer_side_handle,
+            )
+            if handle is not None:
+                posted[spec.remote_rank] = handle
 
     def _notify_push_failure(
         self,
@@ -646,10 +660,11 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         notif_msg = (
             PUSH_FAIL_NOTIF_PREFIX + f"{remote_request_id}:{self.world_size}".encode()
         )
+        with self._handshake_lock:
+            agents = dict(self._remote_agents.get(engine_id) or {})
         for rank in failed_ranks:
-            with self._handshake_lock:
-                # Push targets always handshake with pp_size=1.
-                agent_name = (self._remote_agents.get(engine_id) or {}).get((0, rank))
+            # Push targets always handshake with pp_size=1.
+            agent_name = agents.get((0, rank))
             if agent_name is None:
                 logger.error(
                     "No agent for rank %d of engine %s; cannot report the failed "

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -45,6 +45,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker import (
     NixlBaseConnectorWorker,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+    PUSH_FAIL_NOTIF_PREFIX,
     PUSH_REG_NOTIF_PREFIX,
     NixlConnectorMetadata,
     RemoteMeta,
@@ -73,6 +74,9 @@ logger = init_logger(__name__)
 # while active, slightly more CPU.
 _PUSH_WRITER_POLL_INTERVAL_MS = 1.0
 
+# Notifs are decoded to str before dispatch; keep a str twin of the prefix.
+_PUSH_FAIL_PREFIX_STR = PUSH_FAIL_NOTIF_PREFIX.decode()
+
 
 class NixlPushConnectorWorker(NixlBaseConnectorWorker):
     """Push-specific (WRITE) worker logic. See module docstring."""
@@ -96,6 +100,10 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         # ``_sending_transfers_lock``.
         self._sending_transfers = defaultdict[ReqId, list[TransferHandle]](list)
         self._sending_transfers_lock = threading.Lock()
+
+        # D-side: requests where P reported a WRITE it could not post. Failed
+        # only once the count completes, by when posted WRITEs have landed.
+        self._failed_write_reqs: set[ReqId] = set()
 
         # Writer-thread owned matching state.
         # P-side: finished request blocks received from scheduler metadata
@@ -500,95 +508,167 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         """Issue WRITE transfers to one or more remote TP ranks."""
         assert meta.remote is not None and self.transfer_topo is not None
         engine_id = meta.remote.engine_id
-        plan = self.tp_mappings[engine_id]
-        remote_info = self.transfer_topo.get_engine_info(engine_id)
-        tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
-
-        # Expand D's logical IDs using the ratio learned during the
-        # NIXL handshake. ``meta`` is freshly built by
-        # ``_do_start_push_kv`` so mutating it here is safe.
-        meta.remote.block_ids = self._logical_to_kernel_block_ids(
-            meta.remote.block_ids,
-            remote_info.remote_physical_blocks_per_logical,
-        )
-        remote_block_ids = meta.remote.block_ids
-        local_block_ids = meta.local_physical_block_ids
-        num_groups = len(local_block_ids)
-
-        # MLA latent is replicated across D's TP ranks: the tp-mapping
-        # collapses it to one rank (fine for reads), but push must WRITE every
-        # D rank or the rest decode stale KV. For hybrid MLA+SSM the sharded
-        # SSM state already targets every covered D rank, so only the
-        # attention groups need widening; pure MLA writes to all handshaked
-        # ranks (only the dst differs per rank).
-        replicate_attn = self.use_mla and tp_ratio < 0
-        if replicate_attn and not self._has_mamba:
-            assert len(plan.all_source_ranks) == 1
-            write_ranks = sorted(self.dst_xfer_side_handles[engine_id])
-        else:
-            write_ranks = list(plan.all_source_ranks)
-
-        def group_ids(block_ids: BlockIds, rank: int) -> BlockIds:
-            return [
-                list(block_ids[g])
-                if (replicate_attn and _is_attention_spec(self._group_spec_types[g]))
-                or rank in plan.source_ranks_per_group[g]
-                else []
-                for g in range(num_groups)
-            ]
-
-        read_specs = [
-            ReadSpec(
-                remote_rank=rank,
-                local_block_ids=group_ids(local_block_ids, rank),
-                remote_block_ids=group_ids(remote_block_ids, rank),
-            )
-            for rank in write_ranks
-        ]
 
         handles: list[int] = []
-        for i, spec in enumerate(read_specs):
-            remote_block_size = remote_info.remote_block_size
-            logger.debug(
-                "Remote agent %s available, calling _xfer_blocks"
-                " on remote rank %s with remote block size %s for req %s",
-                meta.remote.engine_id,
-                spec.remote_rank,
-                remote_block_size,
-                req_id,
-            )
-            if tp_ratio < 0 and (not self.use_mla or len(plan.all_source_ranks) > 1):
-                # Multiple targets: write each rank its chunk of local memory.
-                # Hybrid MLA+SSM also lands here: its split handles replicate
-                # the attention descriptors and chunk only the SSM state.
-                split_key = (tp_ratio, remote_block_size)
-                local_xfer_side_handle = self.src_xfer_handles_by_tp_ratio[split_key][i]
+        # One notif per (producer rank -> consumer rank) edge, riding on the
+        # WRITE: unposted ranks must be reported, unresolvable ones must not
+        # (a spurious notif finishes D's count while siblings are in flight).
+        write_ranks: list[int] = []
+        posted_ranks: set[int] = set()
+        try:
+            plan = self.tp_mappings[engine_id]
+            remote_info = self.transfer_topo.get_engine_info(engine_id)
+            tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
+
+            # Resolved before anything that can raise, so the ``finally`` still
+            # knows which edges it owes a report.
+            # MLA latent is replicated across D's TP ranks: the tp-mapping
+            # collapses it to one rank (fine for reads), but push must WRITE
+            # every D rank or the rest decode stale KV. For hybrid MLA+SSM the
+            # sharded SSM state already targets every covered D rank, so only
+            # the attention groups need widening; pure MLA writes to all
+            # handshaked ranks (only the dst differs per rank).
+            replicate_attn = self.use_mla and tp_ratio < 0
+            if replicate_attn and not self._has_mamba:
+                write_ranks = sorted(self.dst_xfer_side_handles[engine_id])
+                assert len(plan.all_source_ranks) == 1
             else:
-                local_xfer_side_handle = self.src_xfer_handles_by_block_size[
-                    remote_block_size
+                write_ranks = list(plan.all_source_ranks)
+
+            if not write_ranks:
+                # ``dst_xfer_side_handles`` is a defaultdict, so an engine with
+                # no handshaked ranks yields an empty set rather than raising.
+                logger.error(
+                    "No remote ranks to push request %s to on engine %s; its "
+                    "consumer will hold its blocks until it is aborted",
+                    req_id,
+                    engine_id,
+                )
+
+            # Expand D's logical IDs using the ratio learned during the
+            # NIXL handshake. ``meta`` is freshly built by
+            # ``_do_start_push_kv`` so mutating it here is safe.
+            meta.remote.block_ids = self._logical_to_kernel_block_ids(
+                meta.remote.block_ids,
+                remote_info.remote_physical_blocks_per_logical,
+            )
+            remote_block_ids = meta.remote.block_ids
+            local_block_ids = meta.local_physical_block_ids
+            num_groups = len(local_block_ids)
+
+            def group_ids(block_ids: BlockIds, rank: int) -> BlockIds:
+                return [
+                    list(block_ids[g])
+                    if (
+                        replicate_attn and _is_attention_spec(self._group_spec_types[g])
+                    )
+                    or rank in plan.source_ranks_per_group[g]
+                    else []
+                    for g in range(num_groups)
                 ]
 
-            remote_xfer_side_handle = self.dst_xfer_side_handles[meta.remote.engine_id][
-                spec.remote_rank
+            read_specs = [
+                ReadSpec(
+                    remote_rank=rank,
+                    local_block_ids=group_ids(local_block_ids, rank),
+                    remote_block_ids=group_ids(remote_block_ids, rank),
+                )
+                for rank in write_ranks
             ]
 
-            handle = self._xfer_blocks(
-                read_spec=spec,
-                request_id=req_id,
-                dst_engine_id=meta.remote.engine_id,
-                remote_request_id=meta.remote.request_id,
-                local_xfer_side_handle=local_xfer_side_handle,
-                remote_xfer_side_handle=remote_xfer_side_handle,
-            )
-            if handle is not None:
-                handles.append(handle)
+            for i, spec in enumerate(read_specs):
+                remote_block_size = remote_info.remote_block_size
+                logger.debug(
+                    "Remote agent %s available, calling _xfer_blocks"
+                    " on remote rank %s with remote block size %s for req %s",
+                    engine_id,
+                    spec.remote_rank,
+                    remote_block_size,
+                    req_id,
+                )
+                if tp_ratio < 0 and (
+                    not self.use_mla or len(plan.all_source_ranks) > 1
+                ):
+                    # Multiple targets: write each rank its chunk of local memory.
+                    # Hybrid MLA+SSM also lands here: its split handles replicate
+                    # the attention descriptors and chunk only the SSM state.
+                    split_key = (tp_ratio, remote_block_size)
+                    local_xfer_side_handle = self.src_xfer_handles_by_tp_ratio[
+                        split_key
+                    ][i]
+                else:
+                    local_xfer_side_handle = self.src_xfer_handles_by_block_size[
+                        remote_block_size
+                    ]
 
-        # Publish all the request's WRITE handles in one locked update: a
-        # partial set would let ``_pop_done_transfers`` finish the request
-        # early, then double-report it as the remaining writes land.
-        if handles:
-            with self._sending_transfers_lock:
-                self._sending_transfers[req_id].extend(handles)
+                remote_xfer_side_handle = self.dst_xfer_side_handles[engine_id][
+                    spec.remote_rank
+                ]
+
+                handle = self._xfer_blocks(
+                    read_spec=spec,
+                    request_id=req_id,
+                    dst_engine_id=engine_id,
+                    remote_request_id=meta.remote.request_id,
+                    local_xfer_side_handle=local_xfer_side_handle,
+                    remote_xfer_side_handle=remote_xfer_side_handle,
+                )
+                if handle is not None:
+                    handles.append(handle)
+                    posted_ranks.add(spec.remote_rank)
+        finally:
+            # Publish all the request's WRITE handles in one locked update: a
+            # partial set would let ``_pop_done_transfers`` finish the request
+            # early, then double-report it as the remaining writes land.
+            if handles:
+                with self._sending_transfers_lock:
+                    self._sending_transfers[req_id].extend(handles)
+
+            failed_ranks = [r for r in write_ranks if r not in posted_ranks]
+            if failed_ranks:
+                self._notify_push_failure(
+                    req_id, engine_id, meta.remote.request_id, failed_ranks
+                )
+
+    def _notify_push_failure(
+        self,
+        req_id: str,
+        engine_id: str,
+        remote_request_id: str,
+        failed_ranks: list[int],
+    ) -> None:
+        """Tell D that some of this request's WRITEs were never posted.
+
+        Stands in for the completion notifs those WRITEs would have carried,
+        so D's count still completes. Best-effort: a report that cannot be
+        sent leaves D waiting, as it does today.
+        """
+        notif_msg = (
+            PUSH_FAIL_NOTIF_PREFIX + f"{remote_request_id}:{self.world_size}".encode()
+        )
+        for rank in failed_ranks:
+            with self._handshake_lock:
+                # Push targets always handshake with pp_size=1.
+                agent_name = (self._remote_agents.get(engine_id) or {}).get((0, rank))
+            if agent_name is None:
+                logger.error(
+                    "No agent for rank %d of engine %s; cannot report the failed "
+                    "WRITE for request %s, which will hold its blocks until it "
+                    "is aborted",
+                    rank,
+                    engine_id,
+                    req_id,
+                )
+                continue
+            try:
+                self.nixl_wrapper.send_notif(agent_name, notif_msg=notif_msg)
+            except Exception as e:
+                self._log_failure(
+                    failure_type="push_fail_notif_failed",
+                    req_id=req_id,
+                    error=e,
+                    remote_rank=rank,
+                )
 
     def _xfer_blocks(
         self,
@@ -707,32 +787,24 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                 self._handle_heartbeat(msg[3:])
                 continue
 
+            failed_write = msg.startswith(_PUSH_FAIL_PREFIX_STR)
+            if failed_write:
+                msg = msg[len(_PUSH_FAIL_PREFIX_STR) :]
+
             req_id, tp_size = msg.rsplit(":", 1)
 
             # Not tracked as a P-side send/process for this notif.
             if req_id not in self._reqs_to_send and req_id not in self._reqs_to_process:
-                if (meta := self._recving_metadata.get(req_id)) is not None:
-                    # Consumer waits for one notif per producer rank writing
-                    # here: pp_size stages * producers-per-consumer (>1 when
-                    # producer TP > consumer TP; tp_size is the producer TP).
-                    producers_per_consumer = max(1, int(tp_size) // self.world_size)
-                    expected_notifs = meta.pp_size * producers_per_consumer
-                    self.consumer_notification_counts_by_req[req_id] += 1
-                    notifs = self.consumer_notification_counts_by_req[req_id]
-                    if notifs < expected_notifs:
-                        continue
-                    del self.consumer_notification_counts_by_req[req_id]
-                    # P drove the transfer (we own no NIXL handle), so
-                    # materialise an empty ``_recving_transfers`` entry for
-                    # ``_pop_done_transfers`` to report done.
-                    self._recving_transfers.setdefault(req_id, [])
-                else:
-                    # Not tracked on either side (lease may have expired
-                    # before the notif arrived). Log and skip.
-                    logger.error(
-                        "Unrecognized request %s notif (may have expired).",
-                        req_id,
-                    )
+                self._count_consumer_notif(req_id, int(tp_size), failed_write)
+                continue
+
+            if failed_write:
+                # Counting it here would retire our own lease.
+                logger.error(
+                    "Ignoring failed-WRITE report for %s, which this worker is "
+                    "itself producing",
+                    req_id,
+                )
                 continue
 
             n_consumers = int(tp_size)
@@ -749,6 +821,70 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                 self._reqs_to_send.pop(req_id, None)
         return notified_req_ids
 
+    def _count_consumer_notif(
+        self, req_id: str, producer_tp_size: int, failed_write: bool
+    ) -> None:
+        """Count one notif for a request this node is receiving.
+
+        One notif is expected per producer rank writing here: pp_size stages
+        * producers-per-consumer, derived from ``producer_tp_size`` as carried
+        in the notif body. A failed WRITE reports in place of its completion,
+        so a failure never short-circuits the count and every posted WRITE has
+        landed by the time it finishes.
+        """
+        meta = self._recving_metadata.get(req_id)
+        if meta is None:
+            # Not tracked on either side (lease may have expired before the
+            # notif arrived). Log and skip.
+            logger.error("Unrecognized request %s notif (may have expired).", req_id)
+            return
+
+        if failed_write:
+            self._failed_write_reqs.add(req_id)
+
+        producers_per_consumer = max(1, producer_tp_size // self.world_size)
+        expected_notifs = meta.pp_size * producers_per_consumer
+        self.consumer_notification_counts_by_req[req_id] += 1
+        if self.consumer_notification_counts_by_req[req_id] < expected_notifs:
+            return
+
+        del self.consumer_notification_counts_by_req[req_id]
+        if req_id not in self._failed_write_reqs:
+            # P drove the transfer (we own no NIXL handle), so materialise an
+            # empty ``_recving_transfers`` entry for ``_pop_done_transfers``
+            # to report done.
+            self._recving_transfers.setdefault(req_id, [])
+            return
+
+        self._failed_write_reqs.discard(req_id)
+        self._fail_incomplete_push(req_id, meta)
+
+    def _fail_incomplete_push(self, req_id: str, meta: ReqMeta) -> None:
+        """Fail a request whose producer could not post every WRITE."""
+        # ``_handle_failed_transfer`` invalidates one group only. With no
+        # blocks recorded the scheduler promotes the request as a successful
+        # load over a cache that was never written, so leave it to its lease.
+        if self._is_hma_required or len(self.kv_cache_config.kv_cache_groups) > 1:
+            reason = "recovery is unsupported for hybrid or multi-group models"
+        elif not any(meta.local_block_ids):
+            reason = "it has no local blocks to invalidate"
+        else:
+            reason = None
+
+        if reason is not None:
+            logger.error(
+                "Producer could not write all KV for request %s and %s; it will "
+                "hold its blocks until it is aborted",
+                req_id,
+                reason,
+            )
+            return
+
+        logger.warning(
+            "Producer could not write all KV for request %s; failing it.", req_id
+        )
+        self._handle_failed_transfer(req_id, None)
+
     def get_finished(self) -> tuple[set[str], set[str]]:
         # Engine main thread asking for completions: also wake the writer
         # so it gets a chance to drain NIXL notifs (heartbeats, completion
@@ -756,6 +892,9 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         self._push_writer_wake.set()
 
         done_sending, done_recving = super().get_finished()
+
+        # A request retired before its count completed would leak its flag.
+        self._failed_write_reqs.difference_update(done_recving)
 
         # ``_pop_done_transfers`` mutates ``_sending_transfers``; the
         # writer thread also appends to it, so guard the pop.

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -504,130 +504,144 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         return block_ids
 
     def _xfer_blocks_for_req(self, req_id: str, meta: ReqMeta):
-        """Issue WRITE transfers to one or more remote TP ranks."""
+        """Issue WRITE transfers to one or more remote TP ranks.
+
+        Every rank resolved here owes D exactly one notif. The completion rides
+        along with the WRITE, so a rank whose WRITE never got posted is reported
+        instead -- otherwise D counts toward a total it can never reach.
+        """
         assert meta.remote is not None and self.transfer_topo is not None
         engine_id = meta.remote.engine_id
+        write_ranks = self._resolve_write_ranks(req_id, engine_id)
 
-        handles: list[int] = []
-        # One notif per (producer rank -> consumer rank) edge, riding on the
-        # WRITE: unposted ranks must be reported, unresolvable ones must not
-        # (a spurious notif finishes D's count while siblings are in flight).
-        write_ranks: list[int] = []
-        posted_ranks: set[int] = set()
+        posted: dict[int, TransferHandle] = {}
         try:
-            plan = self.tp_mappings[engine_id]
-            remote_info = self.transfer_topo.get_engine_info(engine_id)
-            tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
-
-            # Resolved before anything that can raise, so the ``finally`` still
-            # knows which edges it owes a report.
-            # MLA latent is replicated across D's TP ranks: the tp-mapping
-            # collapses it to one rank (fine for reads), but push must WRITE
-            # every D rank or the rest decode stale KV. For hybrid MLA+SSM the
-            # sharded SSM state already targets every covered D rank, so only
-            # the attention groups need widening; pure MLA writes to all
-            # handshaked ranks (only the dst differs per rank).
-            replicate_attn = self.use_mla and tp_ratio < 0
-            if replicate_attn and not self._has_mamba:
-                write_ranks = sorted(self.dst_xfer_side_handles[engine_id])
-                assert len(plan.all_source_ranks) == 1
-            else:
-                write_ranks = list(plan.all_source_ranks)
-
-            if not write_ranks:
-                # ``dst_xfer_side_handles`` is a defaultdict, so an engine with
-                # no handshaked ranks yields an empty set rather than raising.
-                logger.error(
-                    "No remote ranks to push request %s to on engine %s; its "
-                    "consumer will hold its blocks until it is aborted",
-                    req_id,
-                    engine_id,
-                )
-
-            # Expand D's logical IDs using the ratio learned during the
-            # NIXL handshake. ``meta`` is freshly built by
-            # ``_do_start_push_kv`` so mutating it here is safe.
-            meta.remote.block_ids = self._logical_to_kernel_block_ids(
-                meta.remote.block_ids,
-                remote_info.remote_physical_blocks_per_logical,
-            )
-            remote_block_ids = meta.remote.block_ids
-            local_block_ids = meta.local_physical_block_ids
-            num_groups = len(local_block_ids)
-
-            def group_ids(block_ids: BlockIds, rank: int) -> BlockIds:
-                return [
-                    list(block_ids[g])
-                    if (
-                        replicate_attn and _is_attention_spec(self._group_spec_types[g])
-                    )
-                    or rank in plan.source_ranks_per_group[g]
-                    else []
-                    for g in range(num_groups)
-                ]
-
-            read_specs = [
-                ReadSpec(
-                    remote_rank=rank,
-                    local_block_ids=group_ids(local_block_ids, rank),
-                    remote_block_ids=group_ids(remote_block_ids, rank),
-                )
-                for rank in write_ranks
-            ]
-
-            for i, spec in enumerate(read_specs):
-                remote_block_size = remote_info.remote_block_size
-                logger.debug(
-                    "Remote agent %s available, calling _xfer_blocks"
-                    " on remote rank %s with remote block size %s for req %s",
-                    engine_id,
-                    spec.remote_rank,
-                    remote_block_size,
-                    req_id,
-                )
-                if tp_ratio < 0 and (
-                    not self.use_mla or len(plan.all_source_ranks) > 1
-                ):
-                    # Multiple targets: write each rank its chunk of local memory.
-                    # Hybrid MLA+SSM also lands here: its split handles replicate
-                    # the attention descriptors and chunk only the SSM state.
-                    split_key = (tp_ratio, remote_block_size)
-                    local_xfer_side_handle = self.src_xfer_handles_by_tp_ratio[
-                        split_key
-                    ][i]
-                else:
-                    local_xfer_side_handle = self.src_xfer_handles_by_block_size[
-                        remote_block_size
-                    ]
-
-                remote_xfer_side_handle = self.dst_xfer_side_handles[engine_id][
-                    spec.remote_rank
-                ]
-
-                handle = self._xfer_blocks(
-                    read_spec=spec,
-                    request_id=req_id,
-                    dst_engine_id=engine_id,
-                    remote_request_id=meta.remote.request_id,
-                    local_xfer_side_handle=local_xfer_side_handle,
-                    remote_xfer_side_handle=remote_xfer_side_handle,
-                )
-                if handle is not None:
-                    handles.append(handle)
-                    posted_ranks.add(spec.remote_rank)
+            self._post_writes(req_id, meta, write_ranks, posted)
         finally:
             # Publish all the request's WRITE handles in one locked update: a
             # partial set would let ``_pop_done_transfers`` finish the request
             # early, then double-report it as the remaining writes land.
-            if handles:
+            if posted:
                 with self._sending_transfers_lock:
-                    self._sending_transfers[req_id].extend(handles)
+                    self._sending_transfers[req_id].extend(posted.values())
 
-            failed_ranks = [r for r in write_ranks if r not in posted_ranks]
+            failed_ranks = [rank for rank in write_ranks if rank not in posted]
             if failed_ranks:
                 self._notify_push_failure(
                     req_id, engine_id, meta.remote.request_id, failed_ranks
                 )
+
+    def _resolve_write_ranks(self, req_id: str, engine_id: str) -> list[int]:
+        """The remote TP ranks this rank must WRITE *req_id* to."""
+        assert self.transfer_topo is not None
+        plan = self.tp_mappings[engine_id]
+        remote_info = self.transfer_topo.get_engine_info(engine_id)
+        tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
+
+        # MLA latent is replicated across D's TP ranks: the tp-mapping
+        # collapses it to one rank (fine for reads), but push must WRITE every
+        # D rank or the rest decode stale KV. For hybrid MLA+SSM the sharded
+        # SSM state already targets every covered D rank, so only the attention
+        # groups need widening; pure MLA writes to all handshaked ranks (only
+        # the dst differs per rank).
+        replicate_attn = self.use_mla and tp_ratio < 0
+        if replicate_attn and not self._has_mamba:
+            assert len(plan.all_source_ranks) == 1
+            write_ranks = sorted(self.dst_xfer_side_handles[engine_id])
+        else:
+            write_ranks = list(plan.all_source_ranks)
+
+        if not write_ranks:
+            # ``dst_xfer_side_handles`` is a defaultdict, so an engine with no
+            # handshaked ranks yields an empty set rather than raising. There
+            # is nothing to report to either, so D falls back to its lease.
+            logger.error(
+                "No remote ranks to push request %s to on engine %s; its "
+                "consumer will hold its blocks until it is aborted",
+                req_id,
+                engine_id,
+            )
+        return write_ranks
+
+    def _post_writes(
+        self,
+        req_id: str,
+        meta: ReqMeta,
+        write_ranks: list[int],
+        posted: dict[int, TransferHandle],
+    ) -> None:
+        """Submit one WRITE per rank in *write_ranks*, recording those posted."""
+        assert meta.remote is not None and self.transfer_topo is not None
+        engine_id = meta.remote.engine_id
+        plan = self.tp_mappings[engine_id]
+        remote_info = self.transfer_topo.get_engine_info(engine_id)
+        tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
+        replicate_attn = self.use_mla and tp_ratio < 0
+
+        # Expand D's logical IDs using the ratio learned during the
+        # NIXL handshake. ``meta`` is freshly built by
+        # ``_do_start_push_kv`` so mutating it here is safe.
+        meta.remote.block_ids = self._logical_to_kernel_block_ids(
+            meta.remote.block_ids,
+            remote_info.remote_physical_blocks_per_logical,
+        )
+        remote_block_ids = meta.remote.block_ids
+        local_block_ids = meta.local_physical_block_ids
+        num_groups = len(local_block_ids)
+
+        def group_ids(block_ids: BlockIds, rank: int) -> BlockIds:
+            return [
+                list(block_ids[g])
+                if (replicate_attn and _is_attention_spec(self._group_spec_types[g]))
+                or rank in plan.source_ranks_per_group[g]
+                else []
+                for g in range(num_groups)
+            ]
+
+        read_specs = [
+            ReadSpec(
+                remote_rank=rank,
+                local_block_ids=group_ids(local_block_ids, rank),
+                remote_block_ids=group_ids(remote_block_ids, rank),
+            )
+            for rank in write_ranks
+        ]
+
+        for i, spec in enumerate(read_specs):
+            remote_block_size = remote_info.remote_block_size
+            logger.debug(
+                "Remote agent %s available, calling _xfer_blocks"
+                " on remote rank %s with remote block size %s for req %s",
+                engine_id,
+                spec.remote_rank,
+                remote_block_size,
+                req_id,
+            )
+            if tp_ratio < 0 and (not self.use_mla or len(plan.all_source_ranks) > 1):
+                # Multiple targets: write each rank its chunk of local memory.
+                # Hybrid MLA+SSM also lands here: its split handles replicate
+                # the attention descriptors and chunk only the SSM state.
+                split_key = (tp_ratio, remote_block_size)
+                local_xfer_side_handle = self.src_xfer_handles_by_tp_ratio[split_key][i]
+            else:
+                local_xfer_side_handle = self.src_xfer_handles_by_block_size[
+                    remote_block_size
+                ]
+
+            remote_xfer_side_handle = self.dst_xfer_side_handles[engine_id][
+                spec.remote_rank
+            ]
+
+            handle = self._xfer_blocks(
+                read_spec=spec,
+                request_id=req_id,
+                dst_engine_id=engine_id,
+                remote_request_id=meta.remote.request_id,
+                local_xfer_side_handle=local_xfer_side_handle,
+                remote_xfer_side_handle=remote_xfer_side_handle,
+            )
+            if handle is not None:
+                posted[spec.remote_rank] = handle
 
     def _notify_push_failure(
         self,
@@ -645,10 +659,11 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         notif_msg = (
             PUSH_FAIL_NOTIF_PREFIX + f"{remote_request_id}:{self.world_size}".encode()
         )
+        with self._handshake_lock:
+            agents = dict(self._remote_agents.get(engine_id) or {})
         for rank in failed_ranks:
-            with self._handshake_lock:
-                # Push targets always handshake with pp_size=1.
-                agent_name = (self._remote_agents.get(engine_id) or {}).get((0, rank))
+            # Push targets always handshake with pp_size=1.
+            agent_name = agents.get((0, rank))
             if agent_name is None:
                 logger.error(
                     "No agent for rank %d of engine %s; cannot report the failed "


### PR DESCRIPTION
## Summary

Fixes row **C2** of #48633.

**Problem:** In push mode the prefill node writes KV straight into the decode node's memory. The decode node knows it has everything by counting the notifications that come in. If the prefill node cannot start one of those transfers it just logs and moves on, so the decode node counts toward a number it never reaches. The request hangs until its lease expires while holding blocks over a half-written cache.

**Solution:** This PR introduces a new NIXL message that the prefill node sends when it cannot start a transfer. The decode node then still receives the number of messages it expects, so instead of waiting forever it can tell that one of the transfers failed. When that happens it falls back to the existing KV load failure policy, which either fails the request or recomputes the KV locally.

## Tested by

```bash
.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_nixl_push_connector.py -q
# 47 passed
```

```bash
.venv/bin/python -m pytest \
  tests/v1/kv_connector/unit/test_nixl_connector.py \
  tests/v1/kv_connector/unit/test_nixl_connector_hma.py \
  tests/v1/kv_connector/unit/test_nixl_heartbeat.py \
  tests/v1/kv_connector/unit/test_multi_connector.py -q
# 157 passed, 1 skipped, 4 failed
```

All 10 new tests pass. `test_abort_timeout_on_prefiller[ray]`, `test_abort_timeout_on_prefiller[None]`, `test_fewer_blocks_with_hma[google/gemma-3-1b-it-512]` and `test_multi_example_connector_consistency` also fail on main at the same commit this branch is rebased onto.

Also tested this on a real deployment: two RTX 4000 Ada GPUs running a prefill and a decode instance, with a small local modification that simulates a NIXL failure to provoke the bad path.

- **Good path:** output is the same as main.
- **Bad path:** the decode node is told, fails the request, recomputes locally and returns normally. On main the same fault produces no report at all and the request hangs.

Logs: [logs.zip](https://github.com/user-attachments/files/30635890/logs.zip)

Both instances ran on one host. This exercises the coordination logic rather than a real network transfer. The failure is simulated.

## Notes

AI assistance was used for this change. I reviewed every changed line and ran the tests myself.
