### PR TITLE
fix(security): classify DeepStream as GPU backend and enforce pixel limits

### DIFF
--- a/tests/multimodal/media/test_video.py
+++ b/tests/multimodal/media/test_video.py
@@ -470,3 +470,31 @@ class TestMergeKwargsGpuBackendPolicy:
         )
         assert result.get("backend") != "pynvvideocodec"
         assert result["video_backend"] == "pynvvideocodec"
+
+    def test_deepstream_requires_gpu(self):
+        assert VIDEO_LOADER_REGISTRY.backend_requires_gpu("deepstream")
+
+    def test_strips_backend_deepstream_when_not_static(self):
+        result = VideoMediaIO.merge_kwargs(
+            default_kwargs=None,
+            runtime_kwargs={"backend": "deepstream"},
+        )
+        assert result.get("backend") != "deepstream"
+
+    def test_preserves_backend_deepstream_when_static(self):
+        result = VideoMediaIO.merge_kwargs(
+            default_kwargs={"backend": "deepstream"},
+            runtime_kwargs={"backend": "deepstream", "num_frames": 8},
+        )
+        assert result["backend"] == "deepstream"
+        assert result["num_frames"] == 8
+
+    def test_strips_pool_size_from_runtime(self):
+        result = VideoMediaIO.merge_kwargs(
+            default_kwargs={"backend": "deepstream"},
+            runtime_kwargs={"backend": "deepstream", "pool_size": 4},
+        )
+        assert "pool_size" not in result
+
+    def test_unknown_backend_treated_as_gpu(self):
+        assert VIDEO_LOADER_REGISTRY.backend_requires_gpu("totally_unknown")

--- a/tests/multimodal/media/test_video.py
+++ b/tests/multimodal/media/test_video.py
@@ -496,5 +496,5 @@ class TestMergeKwargsGpuBackendPolicy:
         )
         assert "pool_size" not in result
 
-    def test_unknown_backend_treated_as_gpu(self):
-        assert VIDEO_LOADER_REGISTRY.backend_requires_gpu("totally_unknown")
+    def test_unknown_backend_not_treated_as_gpu(self):
+        assert not VIDEO_LOADER_REGISTRY.backend_requires_gpu("totally_unknown")

--- a/vllm/multimodal/media/video.py
+++ b/vllm/multimodal/media/video.py
@@ -35,6 +35,7 @@ class VideoMediaIO(MediaIO[MediaWithBytes[tuple[npt.NDArray, dict[str, Any]]]]):
             # Decoder GPU memory is reserved from the startup value.
             runtime_kwargs = dict(runtime_kwargs)
             runtime_kwargs.pop("hw_decoders", None)
+            runtime_kwargs.pop("pool_size", None)
 
             # Block request-level selection of GPU video backends that
             # were not configured (and VRAM-reserved) at startup.

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -97,7 +97,7 @@ class VideoLoaderRegistry(ExtensionManager):
         self._requires_gpu[name] = True
 
     def backend_requires_gpu(self, name: str) -> bool:
-        return self._requires_gpu.get(name, True)
+        return self._requires_gpu.get(name, False)
 
 
 def get_video_loader_backend_for_processor(

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -92,8 +92,12 @@ class VideoLoaderRegistry(ExtensionManager):
 
         return self.processor2backend.get(video_processor)
 
+    def register_gpu_codec(self, name: str) -> None:
+        """Mark a codec name as requiring GPU without registering a loader."""
+        self._requires_gpu[name] = True
+
     def backend_requires_gpu(self, name: str) -> bool:
-        return self._requires_gpu.get(name, False)
+        return self._requires_gpu.get(name, True)
 
 
 def get_video_loader_backend_for_processor(
@@ -208,6 +212,7 @@ class VideoLoader:
 
 
 VIDEO_LOADER_REGISTRY = VideoLoaderRegistry()
+VIDEO_LOADER_REGISTRY.register_gpu_codec("deepstream")
 
 PYNVVIDEOCODEC_VIDEO_BACKEND: Literal["pynvvideocodec"] = "pynvvideocodec"
 # Per-decoder upper bound reserved for persistent PyNvVideoCodec surfaces.
@@ -1136,6 +1141,7 @@ class VideoBackend(
             from nvidia.deepstream_videodecode import probe_metadata
 
             total_frames, original_fps, duration, _w, _h, codec = probe_metadata(data)
+            _check_frame_pixel_limit(_w, _h)
             source = cls._prepare_source(
                 VideoSourceMetadata(
                     total_frames_num=total_frames,


### PR DESCRIPTION
DeepStream was not registered as a GPU-requiring codec, allowing request-level activation of NVDEC decoding without startup configuration or VRAM reservation. The decode path also skipped VLLM_MAX_IMAGE_PIXELS enforcement and accepted request-controlled pool_size for the process-wide DecodePool singleton.

- Register "deepstream" as a GPU codec in VIDEO_LOADER_REGISTRY so merge_kwargs strips it from request overrides unless statically configured.
- Default backend_requires_gpu to True for unknown names (fail-closed).
- Call _check_frame_pixel_limit after probe_metadata in the DeepStream branch, matching all other codec paths.
- Strip pool_size from runtime kwargs alongside hw_decoders so only the startup value controls the DecodePool.


