### PR TITLE
[Bugfix] Skip MoE padding across router paths

### DIFF
--- a/tests/kernels/moe/test_topk_softplus_sqrt.py
+++ b/tests/kernels/moe/test_topk_softplus_sqrt.py
@@ -202,16 +202,20 @@ def test_fused_topk_softplus_sqrt_hash(
         (17, 384, torch.int64),
     ],
 )
+@pytest.mark.parametrize("use_padding_mask", [False, True])
 def test_dsv4_fast_topk(
     num_tokens: int,
     num_experts: int,
     indices_type: torch.dtype,
+    use_padding_mask: bool,
 ):
     torch.manual_seed(0)
     gating_output = torch.randn(
         (num_tokens, num_experts), dtype=torch.float32, device="cuda"
     )
     correction_bias = torch.randn(num_experts, dtype=torch.float32, device="cuda")
+    is_padding = torch.zeros(num_tokens, dtype=torch.bool, device="cuda")
+    is_padding[1::2] = use_padding_mask
 
     topk_weights_ref, topk_ids_ref = _torch_topk_softplus_sqrt(
         gating_output=gating_output,
@@ -221,8 +225,15 @@ def test_dsv4_fast_topk(
         e_score_correction_bias=correction_bias,
     )
     topk_weights, topk_ids = dsv4_topk(
-        gating_output, correction_bias, indices_type, 1.5
+        gating_output,
+        correction_bias,
+        indices_type,
+        1.5,
+        is_padding=is_padding if use_padding_mask else None,
     )
+
+    topk_weights_ref[is_padding] = 0.0
+    topk_ids_ref[is_padding] = -1
 
     assert topk_ids.dtype == indices_type
     torch.testing.assert_close(topk_ids_ref.to(indices_type), topk_ids, atol=0, rtol=0)

--- a/tests/model_executor/test_routed_experts_capture.py
+++ b/tests/model_executor/test_routed_experts_capture.py
@@ -91,6 +91,39 @@ def test_base_router_capture_pre_eplb_mapping():
     assert torch.equal(topk_ids, torch.tensor([[11, 12], [13, 14]]))
 
 
+def test_base_router_masks_padding_before_capture_and_eplb():
+    router = _make_router()
+    captured = []
+    is_padding = torch.tensor([False, True])
+
+    router.set_capture_fn(lambda ids: captured.append(ids.clone()))
+    with (
+        patch(
+            "vllm.model_executor.layers.fused_moe.router.base_router."
+            "is_forward_context_available",
+            return_value=True,
+        ),
+        patch(
+            "vllm.model_executor.layers.fused_moe.router.base_router."
+            "get_forward_context",
+            return_value=SimpleNamespace(is_padding=is_padding),
+        ),
+        patch(
+            "vllm.model_executor.layers.fused_moe.router.base_router."
+            "envs.VLLM_MOE_SKIP_PADDING",
+            True,
+        ),
+    ):
+        topk_weights, topk_ids = router.select_experts(
+            hidden_states=torch.empty(1),
+            router_logits=torch.empty(1),
+        )
+
+    assert torch.equal(captured[0], torch.tensor([[1, 2], [-1, -1]]))
+    assert torch.equal(topk_ids, torch.tensor([[11, 12], [9, 9]]))
+    assert torch.equal(topk_weights, torch.tensor([[1.0, 1.0], [0.0, 0.0]]))
+
+
 def test_base_router_capture_with_eplb_enabled():
     eplb_state = EplbLayerState()
     eplb_state.expert_load_view = torch.zeros(32, dtype=torch.int64)

--- a/vllm/model_executor/layers/fused_moe/router/base_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/base_router.py
@@ -5,7 +5,9 @@ from collections.abc import Callable
 
 import torch
 
+import vllm.envs as envs
 from vllm.distributed.eplb.eplb_state import EplbLayerState
+from vllm.forward_context import get_forward_context, is_forward_context_available
 from vllm.model_executor.layers.fused_moe.router.fused_moe_router import (
     FusedMoERouter,
 )
@@ -232,6 +234,33 @@ class BaseRouter(FusedMoERouter):
         assert topk_ids.dtype == indices_type or indices_type is None
         return topk_ids
 
+    def _handles_padding(self) -> bool:
+        return False
+
+    def _apply_padding_mask(
+        self, topk_weights: torch.Tensor, topk_ids: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if (
+            self._handles_padding()
+            or not envs.VLLM_MOE_SKIP_PADDING
+            or not is_forward_context_available()
+        ):
+            return topk_weights, topk_ids
+
+        is_padding = get_forward_context().is_padding
+        if is_padding is None:
+            return topk_weights, topk_ids
+
+        is_padding = is_padding[: topk_ids.shape[0]].unsqueeze(1)
+        topk_weights = torch.where(is_padding, 0.0, topk_weights)
+        if topk_ids.dtype == torch.uint32:
+            topk_ids = torch.where(is_padding, -1, topk_ids.to(torch.int64)).to(
+                torch.uint32
+            )
+        else:
+            topk_ids = torch.where(is_padding, -1, topk_ids)
+        return topk_weights, topk_ids
+
     @abstractmethod
     def _compute_routing(
         self,
@@ -291,6 +320,7 @@ class BaseRouter(FusedMoERouter):
         topk_weights, topk_ids = self._compute_routing(
             hidden_states, router_logits, topk_indices_dtype, input_ids=input_ids
         )
+        topk_weights, topk_ids = self._apply_padding_mask(topk_weights, topk_ids)
 
         # Capture logical ids before EPLB mapping.
         if self.capture_fn is not None:

--- a/vllm/model_executor/layers/fused_moe/router/dsv4_topk.py
+++ b/vllm/model_executor/layers/fused_moe/router/dsv4_topk.py
@@ -41,14 +41,17 @@ if current_platform.is_cuda():
     def _dsv4_topk_kernel(
         gating_output_ptr,
         correction_bias_ptr,
+        is_padding_ptr,
         topk_weights_ptr,
         topk_ids_ptr,
         routed_scaling_factor,
         NUM_EXPERTS: tl.constexpr,
         BLOCK_N: tl.constexpr,
+        HAS_PADDING: tl.constexpr,
         launch_pdl: tl.constexpr,
     ):
         row = tl.program_id(0)
+        is_padding = tl.load(is_padding_ptr + row) if HAS_PADDING else False
         expert_offsets = tl.arange(0, BLOCK_N)
         expert_mask = expert_offsets < NUM_EXPERTS
         bias = tl.load(
@@ -92,6 +95,8 @@ if current_platform.is_cuda():
         if launch_pdl:
             tl.extra.cuda.gdc_launch_dependents()
 
+        selected_weights = tl.where(is_padding, 0.0, selected_weights)
+        selected_ids = tl.where(is_padding, -1, selected_ids)
         tl.store(topk_weights_ptr + output_offsets, selected_weights, mask=output_mask)
         tl.store(topk_ids_ptr + output_offsets, selected_ids, mask=output_mask)
 
@@ -101,20 +106,24 @@ def dsv4_topk(
     correction_bias: torch.Tensor,
     indices_dtype: torch.dtype,
     routed_scaling_factor: float,
+    is_padding: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     num_tokens, num_experts = gating_output.shape
     shape = (num_tokens, _TOPK)
     topk_weights = gating_output.new_empty(shape, dtype=torch.float32)
     topk_ids = gating_output.new_empty(shape, dtype=indices_dtype)
     if num_tokens > 0:
+        is_padding_ptr = gating_output if is_padding is None else is_padding
         _dsv4_topk_kernel[(num_tokens,)](
             gating_output,
             correction_bias,
+            is_padding_ptr,
             topk_weights,
             topk_ids,
             routed_scaling_factor,
             NUM_EXPERTS=num_experts,
             BLOCK_N=triton.next_power_of_2(num_experts),
+            HAS_PADDING=is_padding is not None,
             num_warps=1,
             launch_pdl=current_platform.is_arch_support_pdl(),
         )

--- a/vllm/model_executor/layers/fused_moe/router/fused_topk_bias_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/fused_topk_bias_router.py
@@ -19,6 +19,7 @@ from vllm.model_executor.layers.fused_moe.router.dsv4_topk import (
     can_use_dsv4_topk,
     dsv4_topk,
 )
+from vllm.platforms import current_platform
 
 
 def _get_padding_mask(num_tokens: int) -> torch.Tensor | None:
@@ -211,6 +212,7 @@ def fused_topk_bias(
                 e_score_correction_bias,
                 output_indices_dtype,
                 routed_scaling_factor,
+                is_padding=_get_padding_mask(gating_output.shape[0]),
             )
 
         M, _ = hidden_states.size()
@@ -385,6 +387,13 @@ class FusedTopKBiasRouter(BaseRouter):
         # ``shared_expert_weight``, AFTER the routed top-k is renormalized.
         self.num_fused_shared_experts = num_fused_shared_experts
         self.shared_expert_weight = shared_expert_weight
+
+    def _handles_padding(self) -> bool:
+        return (
+            current_platform.is_cuda()
+            and not rocm_aiter_ops.is_fused_moe_enabled()
+            and self.num_fused_shared_experts == 0
+        )
 
     @property
     def routing_method_type(self) -> RoutingMethodType:

--- a/vllm/model_executor/layers/fused_moe/router/fused_topk_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/fused_topk_router.py
@@ -143,6 +143,9 @@ class FusedTopKRouter(BaseRouter):
         self.renormalize = renormalize
         self.scoring_func = scoring_func
 
+    def _handles_padding(self) -> bool:
+        return not rocm_aiter_ops.is_fused_moe_enabled()
+
     @property
     def routing_method_type(self) -> RoutingMethodType:
         return get_routing_method_type(


### PR DESCRIPTION
## Purpose

`VLLM_MOE_SKIP_PADDING` is enabled by default, but DSV4, grouped top-k, and custom routers can still assign experts to padding rows.

Apply a common fallback mask for routers without native support and handle padding inside the DSV4 top-k kernel. Padding-aware fused routers keep their existing fast path.

Duplicate checks found no open PR or issue covering this fix.

## Test Plan

```bash
.venv/bin/python -m pytest tests/model_executor/test_routed_experts_capture.py -q
.venv/bin/python -m pytest tests/kernels/moe/test_topk_softplus_sqrt.py -k dsv4_fast_topk
.venv/bin/pre-commit run --files <changed files>
```

## Test Result

- Router tests: `11 passed`
- Pre-commit hooks: passed
- CUDA cases: collected locally; execution requires a CUDA runner
- 8×B200: before 0/24 padded routes skipped; after 24/24 skipped and zeroed; full model smoke passed

AI assistance was used. This remains draft pending human line-by-line review.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] Purpose
- [x] Test plan and current results
- [x] No documentation change required
</details>