### PR TITLE
[Bugfix] serving_llama70B_tp4 benchmark was silently running at tensor_parallel_size=1

### DIFF
--- a/.buildkite/performance-benchmarks/tests/serving-tests.json
+++ b/.buildkite/performance-benchmarks/tests/serving-tests.json
@@ -76,6 +76,7 @@
       "test_name": "serving_llama70B_tp4_random_128_128",
       "server_parameters": {
         "model": "meta-llama/Llama-3.3-70B-Instruct",
+        "tensor_parallel_size": 4,
         "async_scheduling": "",
 	"no_enable_prefix_caching": "",
         "max_num_batched_tokens": 8192


### PR DESCRIPTION
## Purpose

While building an AMD-specific variant of the performance-benchmark test configs (`serving-tests-rocm.json`, mirroring `serving-tests.json`), verifying the copied `serving_llama70B_tp4_random_128_128` entry through the actual `merge_serving_tests_stream` merge logic in `run-performance-benchmarks.sh` surfaced that its `server_parameters` never sets `tensor_parallel_size`. It silently inherits `tensor_parallel_size: 1` from the file's `defaults` block instead.

This test has presumably been running as `tp1`, not `tp4`, on the continuous `perf.vllm.ai` benchmark this whole time — the test name and the fixed 8192 `max_num_batched_tokens`/`async_scheduling` server args are set up for a 4-GPU run, but the actual TP degree silently defaulted to 1.

## Changes

- `.buildkite/performance-benchmarks/tests/serving-tests.json`: add `"tensor_parallel_size": 4` to `serving_llama70B_tp4_random_128_128`'s `server_parameters`.

## Why not duplicate

Searched open PRs touching this file. #46870 ("fix: remove stray duplicate from serving benchmark config") also touches `serving-tests.json`, but at a different, unrelated entry (`serving_llama8B_tp1_sharegpt`, ~line 28) — removes a stray duplicate JSON fragment causing invalid JSON. That PR's new `check-json` pre-commit hook validates JSON syntax only, so it wouldn't catch this bug either (this file is, and was, syntactically valid — just semantically wrong on one field). No line-range or content overlap with this change.

No open issue or PR references `serving_llama70B_tp4` or a missing `tensor_parallel_size` in this file.

## Test Plan / Result

Verified through the actual merge logic the runner script uses (`merge_serving_tests_stream`, which applies the `defaults` → per-test override merge), not just visual inspection:

```bash
# before the fix:
$ merge_serving_tests_stream tests/serving-tests.json | jq -c 'select(.test_name=="serving_llama70B_tp4_random_128_128") | .server_parameters.tensor_parallel_size'
1

# after the fix:
$ merge_serving_tests_stream tests/serving-tests.json | jq -c 'select(.test_name=="serving_llama70B_tp4_random_128_128") | .server_parameters.tensor_parallel_size'
4
```

Also confirmed:
- `jq . tests/serving-tests.json` — still valid JSON.
- All 7 test names in the file still present and merge cleanly after the change (no regression to the other entries).
- `pre-commit run --files .buildkite/performance-benchmarks/tests/serving-tests.json` passes.

---

*AI assistance disclosure: found and fixed with Claude Code, surfaced as a side effect of validating a separate AMD-specific benchmark config change against the actual merge/parsing logic in `run-performance-benchmarks.sh` rather than by inspection. I reviewed the one-line change and independently re-ran the before/after verification myself.*
