### PR TITLE
fix(config): apply presence_penalty/frequency_penalty from override-generation-config

### DIFF
--- a/tests/config/test_config_generation.py
+++ b/tests/config/test_config_generation.py
@@ -138,3 +138,31 @@ def test_get_diff_sampling_param_includes_penalties():
     assert diff["presence_penalty"] == 1.5
     assert diff["frequency_penalty"] == 0.5
     assert diff["temperature"] == 0.6
+
+
+def test_generation_config_penalties_survive_diff_sampling_filter():
+    """``generation_config.json`` penalties must survive the diff-sampling
+    whitelist (regression for #50767, auto path).
+
+    Covers the ``generation_config="auto"`` branch, where the override
+    dict is empty and the values come from ``try_get_generation_config``.
+    """
+    from types import SimpleNamespace
+
+    from vllm.config.model import ModelConfig
+
+    fake = SimpleNamespace(
+        generation_config="auto",
+        override_generation_config={},
+        try_get_generation_config=lambda: {
+            "presence_penalty": 1.1,
+            "frequency_penalty": 0.7,
+            "temperature": 0.9,
+        },
+    )
+
+    diff = ModelConfig.get_diff_sampling_param(fake)
+
+    assert diff["presence_penalty"] == 1.1
+    assert diff["frequency_penalty"] == 0.7
+    assert diff["temperature"] == 0.9

--- a/tests/config/test_config_generation.py
+++ b/tests/config/test_config_generation.py
@@ -109,3 +109,32 @@ def test_unrecognized_env(monkeypatch):
         fail_on_environ_validation=True,
     )
     engine_args.create_engine_config()
+
+
+def test_get_diff_sampling_param_includes_penalties():
+    """``--override-generation-config`` must apply presence_penalty and
+    frequency_penalty as server-side defaults, like the other sampling
+    params. Regression test for the whitelist silently dropping them.
+
+    Called unbound with a lightweight stand-in so no model is loaded:
+    generation_config="vllm" makes the method skip try_get_generation_config
+    and read only override_generation_config.
+    """
+    from types import SimpleNamespace
+
+    from vllm.config.model import ModelConfig
+
+    fake = SimpleNamespace(
+        generation_config="vllm",
+        override_generation_config={
+            "presence_penalty": 1.5,
+            "frequency_penalty": 0.5,
+            "temperature": 0.6,
+        },
+    )
+
+    diff = ModelConfig.get_diff_sampling_param(fake)
+
+    assert diff["presence_penalty"] == 1.5
+    assert diff["frequency_penalty"] == 0.5
+    assert diff["temperature"] == 0.6

--- a/tests/entrypoints/openai/test_penalty_default_resolution.py
+++ b/tests/entrypoints/openai/test_penalty_default_resolution.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""
+Unit tests for presence_penalty / frequency_penalty resolution from
+default_sampling_params in ChatCompletionRequest and CompletionRequest.
+
+Regression test for https://github.com/vllm-project/vllm/issues/50767:
+these two penalties defaulted to 0.0 (not None) and to_sampling_params()
+forwarded them straight through, so server-side defaults coming from
+--override-generation-config / generation_config.json were silently
+discarded on the /v1/chat/completions and /v1/completions endpoints.
+"""
+
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+)
+from vllm.entrypoints.openai.completion.protocol import (
+    CompletionRequest,
+)
+
+_DEFAULTS = {"presence_penalty": 1.5, "frequency_penalty": 0.5}
+
+
+def _chat(**kwargs):
+    return ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "hi"}],
+        **kwargs,
+    )
+
+
+class TestChatCompletionPenaltyDefaults:
+    def test_defaults_applied_when_client_omits(self):
+        """Server-default penalties are applied when the client sends none."""
+        sp = _chat().to_sampling_params(100, _DEFAULTS)
+        assert sp.presence_penalty == 1.5
+        assert sp.frequency_penalty == 0.5
+
+    def test_client_value_overrides_default(self):
+        """An explicit client penalty wins over the server default."""
+        sp = _chat(presence_penalty=0.2).to_sampling_params(100, _DEFAULTS)
+        assert sp.presence_penalty == 0.2
+        assert sp.frequency_penalty == 0.5
+
+    def test_falls_back_to_zero_without_default(self):
+        """Without a server default the neutral 0.0 is used (no regression)."""
+        sp = _chat().to_sampling_params(100, {})
+        assert sp.presence_penalty == 0.0
+        assert sp.frequency_penalty == 0.0
+
+
+class TestCompletionPenaltyDefaults:
+    def test_defaults_applied_when_client_omits(self):
+        sp = CompletionRequest(model="test-model", prompt="hi").to_sampling_params(
+            16, _DEFAULTS
+        )
+        assert sp.presence_penalty == 1.5
+        assert sp.frequency_penalty == 0.5
+
+    def test_client_value_overrides_default(self):
+        sp = CompletionRequest(
+            model="test-model", prompt="hi", frequency_penalty=0.9
+        ).to_sampling_params(16, _DEFAULTS)
+        assert sp.presence_penalty == 1.5
+        assert sp.frequency_penalty == 0.9

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1614,6 +1614,8 @@ class ModelConfig:
 
         available_params = [
             "repetition_penalty",
+            "presence_penalty",
+            "frequency_penalty",
             "temperature",
             "top_k",
             "top_p",

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -214,7 +214,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
     # https://platform.openai.com/docs/api-reference/chat/create
     messages: list[ChatCompletionMessageParam]
     model: str | None = None
-    frequency_penalty: float | None = 0.0
+    frequency_penalty: float | None = None
     logit_bias: dict[str, float] | None = None
     logprobs: bool | None = False
     top_logprobs: int | None = 0
@@ -225,7 +225,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
     )
     max_completion_tokens: int | None = None
     n: int | None = 1
-    presence_penalty: float | None = 0.0
+    presence_penalty: float | None = None
     response_format: AnyResponseFormat | None = None
     seed: int | None = Field(None, ge=_INT64_MIN, le=_INT64_MAX)
     stop: str | list[str] | None = []
@@ -612,6 +612,8 @@ class ChatCompletionRequest(OpenAIBaseModel):
     # Default sampling parameters for chat completion requests
     _DEFAULT_SAMPLING_PARAMS: dict = {
         "repetition_penalty": 1.0,
+        "presence_penalty": 0.0,
+        "frequency_penalty": 0.0,
         "temperature": 1.0,
         "top_p": 1.0,
         "top_k": 0,
@@ -670,6 +672,16 @@ class ChatCompletionRequest(OpenAIBaseModel):
             min_p = default_sampling_params.get(
                 "min_p", self._DEFAULT_SAMPLING_PARAMS["min_p"]
             )
+        if (presence_penalty := self.presence_penalty) is None:
+            presence_penalty = default_sampling_params.get(
+                "presence_penalty",
+                self._DEFAULT_SAMPLING_PARAMS["presence_penalty"],
+            )
+        if (frequency_penalty := self.frequency_penalty) is None:
+            frequency_penalty = default_sampling_params.get(
+                "frequency_penalty",
+                self._DEFAULT_SAMPLING_PARAMS["frequency_penalty"],
+            )
 
         # Merge server-default stop_token_ids (e.g., model-specific tokens
         # like </call> for gpt-oss) with any request-specified ones
@@ -696,8 +708,8 @@ class ChatCompletionRequest(OpenAIBaseModel):
             extra_args["ec_transfer_params"] = self.ec_transfer_params
         return SamplingParams.from_optional(
             n=self.n,
-            presence_penalty=self.presence_penalty,
-            frequency_penalty=self.frequency_penalty,
+            presence_penalty=presence_penalty,
+            frequency_penalty=frequency_penalty,
             repetition_penalty=repetition_penalty,
             temperature=temperature,
             top_p=top_p,

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -54,12 +54,12 @@ class CompletionRequest(OpenAIBaseModel):
         | None
     ) = None
     echo: bool | None = False
-    frequency_penalty: float | None = 0.0
+    frequency_penalty: float | None = None
     logit_bias: dict[str, float] | None = None
     logprobs: int | None = None
     max_tokens: int | None = 16
     n: int = 1
-    presence_penalty: float | None = 0.0
+    presence_penalty: float | None = None
     seed: int | None = Field(None, ge=_INT64_MIN, le=_INT64_MAX)
     stop: str | list[str] | None = []
     stream: bool | None = False
@@ -261,6 +261,8 @@ class CompletionRequest(OpenAIBaseModel):
     # Default sampling parameters for completion requests
     _DEFAULT_SAMPLING_PARAMS: dict = {
         "repetition_penalty": 1.0,
+        "presence_penalty": 0.0,
+        "frequency_penalty": 0.0,
         "temperature": 1.0,
         "top_p": 1.0,
         "top_k": 0,
@@ -325,6 +327,16 @@ class CompletionRequest(OpenAIBaseModel):
             min_p = default_sampling_params.get(
                 "min_p", self._DEFAULT_SAMPLING_PARAMS["min_p"]
             )
+        if (presence_penalty := self.presence_penalty) is None:
+            presence_penalty = default_sampling_params.get(
+                "presence_penalty",
+                self._DEFAULT_SAMPLING_PARAMS["presence_penalty"],
+            )
+        if (frequency_penalty := self.frequency_penalty) is None:
+            frequency_penalty = default_sampling_params.get(
+                "frequency_penalty",
+                self._DEFAULT_SAMPLING_PARAMS["frequency_penalty"],
+            )
 
         # Merge server-default stop_token_ids (e.g., model-specific tokens
         # like </call> for gpt-oss) with any request-specified ones
@@ -353,8 +365,8 @@ class CompletionRequest(OpenAIBaseModel):
             extra_args["ec_transfer_params"] = self.ec_transfer_params
         return SamplingParams.from_optional(
             n=self.n,
-            presence_penalty=self.presence_penalty,
-            frequency_penalty=self.frequency_penalty,
+            presence_penalty=presence_penalty,
+            frequency_penalty=frequency_penalty,
             repetition_penalty=repetition_penalty,
             temperature=temperature,
             top_p=top_p,


### PR DESCRIPTION
`get_diff_sampling_param()`'s `available_params` whitelist omits `presence_penalty` and `frequency_penalty`, so `--override-generation-config` silently drops them — the sampler falls back to 0.0 with no warning while `temperature`/`top_p` from the same flag are applied. Both are standard sampling params with a direct client value path (no rename like `max_new_tokens`).

Fix: add them to the whitelist. Same silent-drop class as #45591 (`eos_token_id`).

Fixes #50767

Test: added a CPU unit test (calls the method unbound with `generation_config="vllm"` so no model loads).
```
tests/config/test_config_generation.py::test_get_diff_sampling_param_includes_penalties  1 passed in 0.17s
```