### PR TITLE
[ROCm] Add AMD test config selection to performance-benchmarks

### DIFF
--- a/.buildkite/performance-benchmarks/README.md
+++ b/.buildkite/performance-benchmarks/README.md
@@ -36,7 +36,7 @@ See [performance-benchmarks-descriptions.md](performance-benchmarks-descriptions
 > NOTE: For Intel® Xeon® Processors, use `tests/latency-tests-cpu.json`, `tests/throughput-tests-cpu.json`, `tests/serving-tests-cpu.json` instead.
 > For Intel® Gaudi® 3 Accelerators, use `tests/latency-tests-hpu.json`, `tests/throughput-tests-hpu.json`, `tests/serving-tests-hpu.json` instead.
 > For Arm® Neoverse™, use `tests/latency-tests-arm64-cpu.json`, `tests/throughput-tests-arm64-cpu.json`, `tests/serving-tests-arm64-cpu.json` instead.
-> For AMD Instinct® Accelerators, use `tests/latency-tests-rocm.json`, `tests/throughput-tests-rocm.json`, `tests/serving-tests-rocm.json` instead (selected automatically when `amd-smi` is detected).
+> For AMD Instinct® Accelerators, use `tests/latency-tests-rocm.json`, `tests/throughput-tests-rocm.json`, `tests/serving-tests-rocm.json` instead.
 
 ### Latency test
 

--- a/.buildkite/performance-benchmarks/README.md
+++ b/.buildkite/performance-benchmarks/README.md
@@ -36,6 +36,7 @@ See [performance-benchmarks-descriptions.md](performance-benchmarks-descriptions
 > NOTE: For Intel® Xeon® Processors, use `tests/latency-tests-cpu.json`, `tests/throughput-tests-cpu.json`, `tests/serving-tests-cpu.json` instead.
 > For Intel® Gaudi® 3 Accelerators, use `tests/latency-tests-hpu.json`, `tests/throughput-tests-hpu.json`, `tests/serving-tests-hpu.json` instead.
 > For Arm® Neoverse™, use `tests/latency-tests-arm64-cpu.json`, `tests/throughput-tests-arm64-cpu.json`, `tests/serving-tests-arm64-cpu.json` instead.
+> For AMD Instinct® Accelerators, use `tests/latency-tests-rocm.json`, `tests/throughput-tests-rocm.json`, `tests/serving-tests-rocm.json` instead (selected automatically when `amd-smi` is detected).
 
 ### Latency test
 

--- a/.buildkite/performance-benchmarks/scripts/run-performance-benchmarks.sh
+++ b/.buildkite/performance-benchmarks/scripts/run-performance-benchmarks.sh
@@ -42,6 +42,7 @@ check_gpus() {
     declare -g gpu_type=$(nvidia-smi --query-gpu=name --format=csv,noheader | awk '{print $2}')
   elif command -v amd-smi; then
     declare -g gpu_type=$(amd-smi static -g 0 -a | grep 'MARKET_NAME' | awk '{print $2}')
+    arch_suffix='-rocm'
   elif command -v hl-smi; then
     declare -g gpu_type=$(hl-smi -q | grep "Product Name" | head -n 1 | awk -F ':' '{print $2}' | sed 's/^ *//')
     arch_suffix='-hpu'

--- a/.buildkite/performance-benchmarks/tests/latency-tests-rocm.json
+++ b/.buildkite/performance-benchmarks/tests/latency-tests-rocm.json
@@ -1,0 +1,32 @@
+[
+    {
+        "test_name": "latency_llama8B_tp1",
+        "parameters": {
+            "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",
+            "tensor_parallel_size": 1,
+            "load_format": "dummy",
+            "num_iters_warmup": 5,
+            "num_iters": 15
+        }
+    },
+    {
+        "test_name": "latency_llama70B_tp4",
+        "parameters": {
+            "model": "meta-llama/Meta-Llama-3.1-70B-Instruct",
+            "tensor_parallel_size": 4,
+            "load_format": "dummy",
+            "num-iters-warmup": 5,
+            "num-iters": 15
+        }
+    },
+    {
+        "test_name": "latency_mixtral8x7B_tp2",
+        "parameters": {
+            "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+            "tensor_parallel_size": 2,
+            "load_format": "dummy",
+            "num-iters-warmup": 5,
+            "num-iters": 15
+        }
+    }
+]

--- a/.buildkite/performance-benchmarks/tests/latency-tests-rocm.json
+++ b/.buildkite/performance-benchmarks/tests/latency-tests-rocm.json
@@ -1,6 +1,9 @@
 [
     {
         "test_name": "latency_llama8B_tp1",
+        "environment_variables": {
+            "VLLM_ROCM_USE_AITER": 1
+        },
         "parameters": {
             "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",
             "tensor_parallel_size": 1,
@@ -11,6 +14,9 @@
     },
     {
         "test_name": "latency_llama70B_tp4",
+        "environment_variables": {
+            "VLLM_ROCM_USE_AITER": 1
+        },
         "parameters": {
             "model": "meta-llama/Meta-Llama-3.1-70B-Instruct",
             "tensor_parallel_size": 4,
@@ -21,6 +27,9 @@
     },
     {
         "test_name": "latency_mixtral8x7B_tp2",
+        "environment_variables": {
+            "VLLM_ROCM_USE_AITER": 1
+        },
         "parameters": {
             "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
             "tensor_parallel_size": 2,

--- a/.buildkite/performance-benchmarks/tests/serving-tests-rocm.json
+++ b/.buildkite/performance-benchmarks/tests/serving-tests-rocm.json
@@ -4,6 +4,9 @@
       "inf"
     ],
     "max_concurrency_list": [12, 16, 24, 32, 64, 128, 200],
+    "server_environment_variables": {
+      "VLLM_ROCM_USE_AITER": 1
+    },
     "server_parameters": {
       "model": "meta-llama/Llama-3.1-8B-Instruct",
       "tensor_parallel_size": 1,

--- a/.buildkite/performance-benchmarks/tests/serving-tests-rocm.json
+++ b/.buildkite/performance-benchmarks/tests/serving-tests-rocm.json
@@ -76,6 +76,7 @@
       "test_name": "serving_llama70B_tp4_random_128_128",
       "server_parameters": {
         "model": "meta-llama/Llama-3.3-70B-Instruct",
+        "tensor_parallel_size": 4,
         "async_scheduling": "",
         "no_enable_prefix_caching": "",
         "max_num_batched_tokens": 8192

--- a/.buildkite/performance-benchmarks/tests/serving-tests-rocm.json
+++ b/.buildkite/performance-benchmarks/tests/serving-tests-rocm.json
@@ -1,0 +1,91 @@
+{
+  "defaults": {
+    "qps_list": [
+      "inf"
+    ],
+    "max_concurrency_list": [12, 16, 24, 32, 64, 128, 200],
+    "server_parameters": {
+      "model": "meta-llama/Llama-3.1-8B-Instruct",
+      "tensor_parallel_size": 1,
+      "dtype": "bfloat16"
+    },
+    "client_parameters": {
+      "model": "meta-llama/Llama-3.1-8B-Instruct",
+      "backend": "vllm",
+      "ignore-eos": "",
+      "temperature": 0,
+      "num_prompts": 200
+    }
+  },
+  "tests": [
+    {
+      "test_name": "serving_llama8B_tp1_sharegpt",
+      "server_parameters": {
+        "tensor_parallel_size": 1
+      },
+      "client_parameters": {
+        "dataset_name": "sharegpt",
+        "dataset_path": "./ShareGPT_V3_unfiltered_cleaned_split.json"
+      }
+    },
+    {
+      "test_name": "serving_llama8B_tp1_random_128_128",
+      "server_parameters": {
+        "tensor_parallel_size": 1
+      },
+      "client_parameters": {
+        "dataset_name": "random",
+        "random-input-len": 128,
+        "random-output-len": 128
+      }
+    },
+    {
+      "test_name": "serving_llama8B_tp1_random_128_2048",
+      "server_parameters": {
+        "tensor_parallel_size": 1
+      },
+      "client_parameters": {
+        "dataset_name": "random",
+        "random-input-len": 128,
+        "random-output-len": 2048
+      }
+    },
+    {
+      "test_name": "serving_llama8B_tp1_random_2048_128",
+      "server_parameters": {
+        "tensor_parallel_size": 1
+      },
+      "client_parameters": {
+        "dataset_name": "random",
+        "random-input-len": 2048,
+        "random-output-len": 128
+      }
+    },
+    {
+      "test_name": "serving_llama8B_tp1_random_2048_2048",
+      "server_parameters": {
+        "tensor_parallel_size": 1
+      },
+      "client_parameters": {
+        "dataset_name": "random",
+        "random-input-len": 2048,
+        "random-output-len": 2048
+      }
+    },
+    {
+      "test_name": "serving_llama70B_tp4_random_128_128",
+      "server_parameters": {
+        "model": "meta-llama/Llama-3.3-70B-Instruct",
+        "async_scheduling": "",
+        "no_enable_prefix_caching": "",
+        "max_num_batched_tokens": 8192
+      },
+      "client_parameters": {
+        "model": "meta-llama/Llama-3.3-70B-Instruct",
+        "dataset_name": "random",
+        "random-input-len": 128,
+        "random-output-len": 128
+      }
+    }
+  ]
+}

--- a/.buildkite/performance-benchmarks/tests/throughput-tests-rocm.json
+++ b/.buildkite/performance-benchmarks/tests/throughput-tests-rocm.json
@@ -1,0 +1,35 @@
+[
+    {
+        "test_name": "throughput_llama8B_tp1",
+        "parameters": {
+            "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",
+            "tensor_parallel_size": 1,
+            "load_format": "dummy",
+            "dataset": "./ShareGPT_V3_unfiltered_cleaned_split.json",
+            "num_prompts": 200,
+            "backend": "vllm"
+        }
+    },
+    {
+        "test_name": "throughput_llama70B_tp4",
+        "parameters": {
+            "model": "meta-llama/Meta-Llama-3.1-70B-Instruct",
+            "tensor_parallel_size": 4,
+            "load_format": "dummy",
+            "dataset": "./ShareGPT_V3_unfiltered_cleaned_split.json",
+            "num_prompts": 200,
+            "backend": "vllm"
+        }
+    },
+    {
+        "test_name": "throughput_mixtral8x7B_tp2",
+        "parameters": {
+            "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+            "tensor_parallel_size": 2,
+            "load_format": "dummy",
+            "dataset": "./ShareGPT_V3_unfiltered_cleaned_split.json",
+            "num_prompts": 200,
+            "backend": "vllm"
+        }
+    }
+]

--- a/.buildkite/performance-benchmarks/tests/throughput-tests-rocm.json
+++ b/.buildkite/performance-benchmarks/tests/throughput-tests-rocm.json
@@ -1,6 +1,9 @@
 [
     {
         "test_name": "throughput_llama8B_tp1",
+        "environment_variables": {
+            "VLLM_ROCM_USE_AITER": 1
+        },
         "parameters": {
             "model": "meta-llama/Meta-Llama-3.1-8B-Instruct",
             "tensor_parallel_size": 1,
@@ -12,6 +15,9 @@
     },
     {
         "test_name": "throughput_llama70B_tp4",
+        "environment_variables": {
+            "VLLM_ROCM_USE_AITER": 1
+        },
         "parameters": {
             "model": "meta-llama/Meta-Llama-3.1-70B-Instruct",
             "tensor_parallel_size": 4,
@@ -23,6 +29,9 @@
     },
     {
         "test_name": "throughput_mixtral8x7B_tp2",
+        "environment_variables": {
+            "VLLM_ROCM_USE_AITER": 1
+        },
         "parameters": {
             "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
             "tensor_parallel_size": 2,


### PR DESCRIPTION
## Purpose

`.buildkite/performance-benchmarks/run-performance-benchmarks.sh` already has an `amd-smi` branch in `check_gpus()` for AMD hardware detection, and `launch-server.sh` has no CUDA-specific code — the runner is mostly ROCm-aware already. But the `amd-smi` branch never set `arch_suffix`, unlike the existing `-hpu`/`-cpu`/`-arm64-cpu` branches. So on an AMD Instinct box, the script silently fell through to the NVIDIA-tuned default `latency-tests.json`/`throughput-tests.json`/`serving-tests.json` instead of anything AMD-specific — there was no way to run this suite with ROCm-appropriate test parameters at all.

This surfaced while investigating [#40827 (comment)](https://github.com/vllm-project/vllm/pull/40827#issuecomment-4781164623), where tjtanaa asked for MI300X/MI355X perf validation on a ROCm kernel PR — there's currently no path to produce that data through this suite.

## Changes

- `run-performance-benchmarks.sh`: set `arch_suffix='-rocm'` in the existing `amd-smi` detection branch, mirroring the `-hpu`/`-cpu`/`-arm64-cpu` pattern.
- Added starter `tests/latency-tests-rocm.json`, `tests/throughput-tests-rocm.json`, `tests/serving-tests-rocm.json`, mirroring the NVIDIA defaults' core models (llama8B, llama70B tp4, mixtral8x7B tp2 where applicable). Deliberately left out `serving_gemma4-e4b_*` (tool-calling serving test) — ROCm/aiter support for that path is unconfirmed.
- `README.md`: documented the new `-rocm` file selection alongside the existing CPU/HPU/ARM notes.

## Why not duplicate

Checked #34994 (ROCm CI infra roadmap) and searched open PRs touching `.buildkite/performance-benchmarks/` or matching `arch_suffix`/`serving-tests-rocm` — no open PR addresses this gap.

## Test Plan / Result

```bash
# JSON validity
$ jq . tests/latency-tests-rocm.json tests/throughput-tests-rocm.json tests/serving-tests-rocm.json
# all valid

# Merge logic sanity (same check used in #50766) — confirms every -rocm serving
# test's tensor_parallel_size matches its name after defaults merge:
$ merge_serving_tests_stream tests/serving-tests-rocm.json | jq -c '{test_name, tp: .server_parameters.tensor_parallel_size}'
{"test_name":"serving_llama8B_tp1_sharegpt","tp":1}
{"test_name":"serving_llama8B_tp1_random_128_128","tp":1}
{"test_name":"serving_llama8B_tp1_random_128_2048","tp":1}
{"test_name":"serving_llama8B_tp1_random_2048_128","tp":1}
{"test_name":"serving_llama8B_tp1_random_2048_2048","tp":1}
{"test_name":"serving_llama70B_tp4_random_128_128","tp":4}

# arch_suffix resolution, verified live on an AMD box with amd-smi present
# (Radeon RX 9070 XT, RDNA4 — no MI300X/MI355X available to me personally):
$ check_gpus  # amd-smi branch now correctly sets arch_suffix=-rocm

# pre-commit on changed files: markdownlint, typos, spaces-in-filenames, etc. all pass.
# `pre-commit run --files .buildkite/performance-benchmarks/scripts/run-performance-benchmarks.sh`
# does not flag this file under shellcheck (the repo's shellcheck hook has a known
# separate whole-repo-rescan bug, tracked independently in #37743 — unrelated to this diff).
```

I don't have MI300X/MI355X hardware myself, so I can't produce actual serving/latency/throughput numbers on Instinct GPUs from this PR. The intent is to unblock that: once merged, this makes it possible for someone with access to a real MI300X/MI355X Buildkite agent to manually trigger `run-performance-benchmarks.sh` against a ROCm kernel PR's branch and get numbers using ROCm-appropriate configs, instead of silently falling back to NVIDIA-tuned defaults or having no path at all. Concretely, this is a direct prerequisite for the MI300X/MI355X validation requested on #40827.

---

*AI assistance disclosure: written and verified with Claude Code. I reviewed every changed line, ran the merge-logic and JSON-validity checks above myself, and independently confirmed `arch_suffix` resolution on the AMD hardware I do have access to.*
