### PR TITLE
perf: Use fast driver P2P check on compute capability 12.x

### DIFF
--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -45,6 +45,24 @@ def _can_p2p(rank: int, world_size: int) -> bool:
                 current_platform.logical_device_id_to_visible_device_id(rank),
                 current_platform.logical_device_id_to_visible_device_id(i),
             )
+        # On compute capability 12.x (consumer Blackwell), the
+        # gpu_p2p_access_check subprocess probe is expensive and has not
+        # been observed to succeed without NVLink. Use the fast
+        # driver-level can_device_access_peer query instead.
+        if (
+            current_platform.is_cuda()
+            and current_platform.is_device_capability_family(120)
+        ):
+            logger.debug(
+                "Using fast driver P2P check for compute capability 12.x"
+                " instead of the subprocess probe."
+            )
+            if not torch.cuda.can_device_access_peer(
+                current_platform.logical_device_id_to_visible_device_id(rank),
+                current_platform.logical_device_id_to_visible_device_id(i),
+            ):
+                return False
+            continue
         if not gpu_p2p_access_check(rank, i):
             return False
     return True


### PR DESCRIPTION
> **Closed.** Author withdrawal: SM12x should not skip the functional P2P probe. Default startup already uses the driver query. See the closing comment.

## Problem

On consumer Blackwell GPUs (compute capability 12.x, e.g. RTX 5090) without
NVLink, `gpu_p2p_access_check()` spawns subprocesses to functionally test
PCIe P2P access. This probe is expensive (several seconds of startup time)
and has not been observed to succeed on these GPUs.

## Solution

When `VLLM_SKIP_P2P_CHECK=0` (the subprocess probe path) and the device is
compute capability 12.x, use the fast driver-level `can_device_access_peer()`
query instead of spawning subprocesses.

This change:
- Only affects the `VLLM_SKIP_P2P_CHECK=0` path (the default `=1` path is
  unchanged — it already uses `can_device_access_peer`)
- Checks all peers (uses `return False` / `continue` pattern, not early return)
- Preserves correct behavior: if the driver reports P2P is available, custom
  allreduce is still enabled
- Falls through to the existing subprocess probe for all other architectures

## Testing

- Verified on 2× RTX 5090 (SM120): startup P2P check uses fast path instead
  of subprocess probe, custom allreduce correctly disabled (no PCIe P2P
  without NVLink)
- Confirmed identical inference performance vs. manual `--disable-custom-all-reduce`
- `py_compile` and `ruff check` pass
- Logic unit tests: 8/8 pass (2-GPU, 4-GPU, mixed-arch, single-GPU, non-CUDA)

## AI Assistance Disclosure

AI tools were used in the development of this PR. All changes were reviewed and tested by the human submitter (Greg Weyer).