### PR TITLE
fix: Check all peers in _can_p2p when VLLM_SKIP_P2P_CHECK=1

### DIFF
--- a/tests/distributed/test_custom_all_reduce_unit.py
+++ b/tests/distributed/test_custom_all_reduce_unit.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock, call
+
+import pytest
+import torch
+
+from vllm.distributed.device_communicators import custom_all_reduce
+
+
+@pytest.mark.parametrize(
+    ("peer_access", "expected", "checked_peers"),
+    [
+        ({0: True, 2: True, 3: True}, True, [0, 2, 3]),
+        ({0: True, 2: False, 3: True}, False, [0, 2]),
+        ({0: False, 2: True, 3: True}, False, [0]),
+    ],
+)
+def test_can_p2p_skip_check_checks_each_peer(
+    monkeypatch: pytest.MonkeyPatch,
+    peer_access: dict[int, bool],
+    expected: bool,
+    checked_peers: list[int],
+):
+    can_device_access_peer = Mock(side_effect=lambda _src, dst: peer_access[dst - 10])
+    monkeypatch.setattr(
+        custom_all_reduce,
+        "envs",
+        SimpleNamespace(VLLM_SKIP_P2P_CHECK=True),
+    )
+    monkeypatch.setattr(
+        custom_all_reduce,
+        "current_platform",
+        SimpleNamespace(
+            logical_device_id_to_visible_device_id=lambda device: device + 10
+        ),
+    )
+    monkeypatch.setattr(torch.cuda, "can_device_access_peer", can_device_access_peer)
+
+    assert custom_all_reduce._can_p2p(rank=1, world_size=4) is expected
+    assert can_device_access_peer.call_args_list == [
+        call(11, peer + 10) for peer in checked_peers
+    ]

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -38,13 +38,17 @@ def _can_p2p(rank: int, world_size: int) -> bool:
         if i == rank:
             continue
         if envs.VLLM_SKIP_P2P_CHECK:
-            logger.debug("Skipping P2P check and trusting the driver's P2P report.")
+            logger.debug_once(
+                "Skipping P2P check and trusting the driver's P2P report."
+            )
             # can_device_access_peer takes visible device ordinals, while
             # rank and i are logical local IDs.
-            return torch.cuda.can_device_access_peer(
+            if not torch.cuda.can_device_access_peer(
                 current_platform.logical_device_id_to_visible_device_id(rank),
                 current_platform.logical_device_id_to_visible_device_id(i),
-            )
+            ):
+                return False
+            continue
         if not gpu_p2p_access_check(rank, i):
             return False
     return True


### PR DESCRIPTION
## Summary

With `VLLM_SKIP_P2P_CHECK=1` (the default), `_can_p2p()` returns the CUDA
driver's answer for the **first** non-self peer and ignores the rest. On
groups with more than two GPUs, a later inaccessible peer goes unchecked, so
custom all-reduce's P2P eligibility gate can pass on incomplete evidence —
e.g. rank 1 can access rank 0 but not rank 2, and `_can_p2p(1, 4)` still
returns `True`.

```python
# before (custom_all_reduce.py, _can_p2p) — returns after ONE peer:
if envs.VLLM_SKIP_P2P_CHECK:
    logger.debug("Skipping P2P check and trusting the driver's P2P report.")
    # can_device_access_peer takes visible device ordinals, while
    # rank and i are logical local IDs.
    return torch.cuda.can_device_access_peer(
        current_platform.logical_device_id_to_visible_device_id(rank),
        current_platform.logical_device_id_to_visible_device_id(i),
    )
```

This PR makes the loop check every non-self peer: return `False` on the
first inaccessible peer, `True` only after all peers pass — mirroring the
functional-probe loop immediately below it. The log line moves to
`debug_once` so it is not repeated per peer.

## Scope

- Preserves the existing `rank → peer` query direction and leaves the
  functional probe (`gpu_p2p_access_check`) unchanged — still skipped under
  the flag, as before.
- Still trusts the same driver query; this fix cannot detect drivers that
  falsely report access — that failure class is what #51513 discusses
  (related RFC, not superseded).

## Tests

`tests/distributed/test_custom_all_reduce_unit.py` — parametrized, mocked
driver queries, no multi-GPU hardware needed — calls the production
`_can_p2p(rank=1, world_size=4)`:

| scenario | result | peers actually queried |
|---|---|---|
| peers 0, 2, 3 all accessible | `True` | 0, 2, 3 |
| peer 2 inaccessible | `False` | 0, 2 (stops at failure) |
| peer 0 inaccessible | `False` | 0 (stops immediately) |

The test also asserts the exact sequence of `can_device_access_peer` calls
(including the logical→visible device-ID translation), so the old
short-circuit cannot silently regress.

Standard invocation in a built vLLM checkout:

```bash
.venv/bin/python -m pytest tests/distributed/test_custom_all_reduce_unit.py -v
```

The local run instead loaded the patched production module into an installed
vLLM environment (the development worktree lacks the compiled extension
artifacts); result: `3 passed`. The wrapper is preserved, collapsed, in the
verification details below.

## Non-duplicate

#50771 (withdrawn) covered SM120 probe policy when the flag is **off**;
#51513 is a broader RFC for one unified functional-P2P verdict; #47544 gates
a separate MiniMax fused collective. No other open PR fixes this loop
(searched `_can_p2p`, `can_device_access_peer`, `all peers`).

## AI assistance disclosure

AI tools were used in the development of this PR; all changed lines, claims,
and test results were reviewed and approved by the human submitter.

<details>
<summary>Verification detail</summary>

Local wrapper run (loads the patched module into an installed environment;
the worktree has no compiled extension artifacts):

```bash
/home/greg/vllm-pr/.venv/bin/python - <<'PY'
from pathlib import Path

import pytest
from vllm.distributed.device_communicators import custom_all_reduce

source = Path(
    "/home/greg/llm/.worktrees/pr-50775/"
    "vllm/distributed/device_communicators/custom_all_reduce.py"
)
exec(compile(source.read_bytes(), str(source), "exec"), custom_all_reduce.__dict__)
raise SystemExit(pytest.main([
    "/home/greg/llm/.worktrees/pr-50775/"
    "tests/distributed/test_custom_all_reduce_unit.py",
    "-v",
]))
PY
```

Result: `3 passed`.

- Mutation check: temporarily restoring the old early return →
  `2 failed, 1 passed`; restoring the fix → `3 passed`.
- `uvx pre-commit run --files` on both changed files: all applicable hooks
  passed (ruff, formatting, mypy, SPDX, forbidden-import/API checks).
- Limitation: the regression mocks the driver report; no real
  asymmetric-hardware failure was reproduced. Initialization failure or a
  hang is a plausible downstream effect of a wrong eligibility result, not
  one demonstrated here.

</details>
