### PR TITLE
[Bugfix][Frontend] Preserve Kimi native tool-call IDs across Responses API multi-turn round trip (Fixes #50768)

### DIFF
--- a/tests/entrypoints/openai/responses/test_responses_utils.py
+++ b/tests/entrypoints/openai/responses/test_responses_utils.py
@@ -16,12 +16,14 @@ from openai.types.responses.response_reasoning_item import (
     Summary,
 )
 
+from vllm.entrypoints.chat_utils import make_tool_call_id
 from vllm.entrypoints.openai.responses.utils import (
     _construct_message_from_response_item,
     construct_chat_messages_with_tool_call,
     construct_input_messages,
     should_continue_final_message,
 )
+from vllm.parser.utils import count_response_history_tool_calls
 
 
 def _single_chat_message(item):
@@ -900,3 +902,128 @@ class TestConstructInputMessagesInstructionsLeak:
         assert len(msgs) == 2
         assert msgs[0] == {"role": "system", "content": "be helpful"}
         assert msgs[1] == {"role": "user", "content": "hello"}
+
+
+def _tool_call_ids(messages):
+    return [
+        tool_call["id"]
+        for message in messages
+        for tool_call in message.get("tool_calls") or ()
+    ]
+
+
+class TestNativeToolCallIds:
+    """Regression tests for #50768.
+
+    Kimi's chat template renders a tool-call ID verbatim -- as the
+    ``<|tool_call_begin|>`` header and as the ``## Return of {id}`` tool-result
+    header -- and renders the function name nowhere else. The Responses API
+    hands clients ``call_<uuid>`` IDs, so history echoed back by the client must
+    be restored to ``functions.{name}:{idx}`` before it reaches the template.
+    """
+
+    def test_call_ids_rewritten_and_paired(self):
+        items = [
+            make_function_call(call_id="call_a", name="exec_command"),
+            make_function_call(call_id="call_b", name="read_file"),
+            make_function_call_output(call_id="call_a", output="ok"),
+            make_function_call_output(call_id="call_b", output="data"),
+        ]
+        assistant, first_result, second_result = construct_chat_messages_with_tool_call(
+            items, tool_call_id_type="kimi_k2"
+        )
+
+        assert _tool_call_ids([assistant]) == [
+            "functions.exec_command:0",
+            "functions.read_file:1",
+        ]
+        assert first_result["tool_call_id"] == "functions.exec_command:0"
+        assert second_result["tool_call_id"] == "functions.read_file:1"
+
+    def test_indices_run_across_assistant_turns(self):
+        """Numbering is a single counter over the whole input, matching
+        ``count_response_history_tool_calls`` -- which is what the parser uses
+        to number the *next* tool call, so history must not collide with it."""
+        items = [
+            make_function_call(call_id="call_a", name="exec_command"),
+            make_function_call_output(call_id="call_a", output="ok"),
+            make_function_call(call_id="call_b", name="exec_command"),
+            make_function_call_output(call_id="call_b", output="ok"),
+        ]
+        messages = construct_chat_messages_with_tool_call(
+            items, tool_call_id_type="kimi_k2"
+        )
+
+        assert _tool_call_ids(messages) == [
+            "functions.exec_command:0",
+            "functions.exec_command:1",
+        ]
+        next_id = make_tool_call_id(
+            id_type="kimi_k2",
+            func_name="exec_command",
+            idx=count_response_history_tool_calls(items),
+        )
+        assert next_id not in _tool_call_ids(messages)
+
+    def test_native_ids_pass_through(self):
+        items = [
+            make_function_call(call_id="functions.exec_command:0", name="exec_command"),
+            make_function_call_output(call_id="functions.exec_command:0", output="ok"),
+        ]
+        assistant, result = construct_chat_messages_with_tool_call(
+            items, tool_call_id_type="kimi_k2"
+        )
+
+        assert _tool_call_ids([assistant]) == ["functions.exec_command:0"]
+        assert result["tool_call_id"] == "functions.exec_command:0"
+
+    def test_dict_function_call_output_rewritten(self):
+        items = [
+            make_function_call(call_id="call_a", name="exec_command"),
+            {"type": "function_call_output", "call_id": "call_a", "output": "ok"},
+        ]
+        _, result = construct_chat_messages_with_tool_call(
+            items, tool_call_id_type="kimi_k2"
+        )
+
+        assert result["tool_call_id"] == "functions.exec_command:0"
+
+    def test_namespaced_tool_uses_flat_name(self):
+        item = ResponseFunctionToolCall(
+            type="function_call",
+            id="fc_1",
+            call_id="call_a",
+            name="exec",
+            namespace="shell",
+            arguments="{}",
+        )
+        messages = construct_chat_messages_with_tool_call(
+            [item], tool_call_id_type="kimi_k2"
+        )
+
+        assert _tool_call_ids(messages) == ["functions.shell__exec:0"]
+
+    def test_non_kimi_models_keep_call_ids(self):
+        items = [
+            make_function_call(call_id="call_a", name="exec_command"),
+            make_function_call_output(call_id="call_a", output="ok"),
+            {"type": "function_call_output", "call_id": "call_a", "output": "ok"},
+        ]
+
+        assert construct_chat_messages_with_tool_call(
+            items
+        ) == construct_chat_messages_with_tool_call(items, tool_call_id_type="random")
+        assistant, typed_result, dict_result = construct_chat_messages_with_tool_call(
+            items
+        )
+        assert _tool_call_ids([assistant]) == ["call_a"]
+        assert typed_result["tool_call_id"] == "call_a"
+        assert dict_result["tool_call_id"] == "call_a"
+
+    def test_construct_input_messages_threads_id_type(self):
+        msgs = construct_input_messages(
+            request_input=[make_function_call(call_id="call_a", name="exec_command")],
+            tool_call_id_type="kimi_k2",
+        )
+
+        assert _tool_call_ids(msgs) == ["functions.exec_command:0"]

--- a/tests/tool_parsers/test_kimi_k2_tool_parser.py
+++ b/tests/tool_parsers/test_kimi_k2_tool_parser.py
@@ -3,7 +3,7 @@
 # ruff: noqa: E501
 
 import json
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -174,6 +174,43 @@ class TestExtractToolCalls:
         content, tool_calls = run_tool_extraction(parser, model_output, streaming=False)
         assert len(tool_calls) == 1
         assert tool_calls[0].function.name == "valid"
+
+    @pytest.mark.parametrize("streaming", [False, True])
+    def test_openai_style_id_header_degrades_gracefully(self, parser, streaming):
+        """A ``call_<uuid>`` header (#50768) drops that call without leaking
+        special tokens, and leaves a sibling well-formed call parseable.
+
+        The malformed call is placed last on purpose: a dropped *leading* call
+        leaves the survivor on its raw slot index, so streaming emits index=1
+        with no index=0 before it. Renumbering that is a ParserEngine-wide
+        change, out of scope here.
+        """
+        model_output = (
+            "Working. "
+            + SECTION_BEGIN
+            + _tool("functions.exec_command:0", '{"cmd": "pwd"}')
+            + _tool("call_4144fac2c5e1f3e0", '{"cmd": "ls"}')
+            + SECTION_END
+        )
+        content, tool_calls = run_tool_extraction(
+            parser, model_output, streaming=streaming
+        )
+
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "exec_command"
+        for marker in (SECTION_BEGIN, SECTION_END, TOOL_BEGIN, TOOL_END, ARG_BEGIN):
+            assert marker not in (content or "")
+        assert "call_4144fac2c5e1f3e0" not in (content or "")
+
+    def test_malformed_header_is_logged(self, parser):
+        """The drop is silent to the client, so it must not be silent in logs."""
+        model_output = _wrap(_tool("call_9c1d3b7a2e5f", '{"cmd": "ls"}'))
+        with patch("vllm.parser.kimi_k2.logger") as mock_logger:
+            _, tool_calls = run_tool_extraction(parser, model_output, streaming=False)
+
+        assert tool_calls == []
+        mock_logger.warning_once.assert_called_once()
+        assert "call_9c1d3b7a2e5f" in str(mock_logger.warning_once.call_args)
 
     def test_native_id_extracted(self, parser):
         """Regression: parser extracts native ID onto ToolCall (PR #32768)."""

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -25,6 +25,7 @@ from typing import (
     get_origin,
 )
 
+import regex as re
 from openai.types.chat import (
     ChatCompletionAssistantMessageParam,
     ChatCompletionContentPartImageParam,
@@ -2064,3 +2065,20 @@ def make_tool_call_id(id_type: str = "random", func_name=None, idx=None):
     else:
         # by default return random
         return f"chatcmpl-tool-{random_uuid()}"
+
+
+# Mirrors ``KimiK2Parser._TOOL_ID_RE`` so that "already native" here means
+# exactly "the parser can recover a function name from this id".
+_NATIVE_TOOL_CALL_ID_RE = re.compile(r".+:\d+")
+
+
+def has_native_tool_call_ids(id_type: str) -> bool:
+    """Whether `id_type` encodes the function name inside the tool-call ID."""
+    return id_type == "kimi_k2"
+
+
+def is_native_tool_call_id(tool_call_id: str | None, id_type: str) -> bool:
+    """Whether `tool_call_id` is already in `id_type`'s native format."""
+    if not tool_call_id or not has_native_tool_call_ids(id_type):
+        return False
+    return _NATIVE_TOOL_CALL_ID_RE.match(tool_call_id) is not None

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -30,6 +30,7 @@ from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
     ChatTemplateContentFormatOption,
+    get_tool_call_id_type,
 )
 from vllm.entrypoints.generate.base.serving import (
     GenerateBaseServing,
@@ -191,6 +192,7 @@ class OpenAIServingResponses(GenerateBaseServing):
         )
         self.enable_prompt_tokens_details = enable_prompt_tokens_details
         self.enable_force_include_usage = enable_force_include_usage
+        self.tool_call_id_type = get_tool_call_id_type(self.model_config)
 
         self.default_sampling_params = self.model_config.get_diff_sampling_param()
         mc = self.model_config
@@ -623,6 +625,7 @@ class OpenAIServingResponses(GenerateBaseServing):
             request_input=request.input,
             prev_msg=self.msg_store.get(prev_response.id) if prev_response else None,
             prev_response_output=prev_response.output if prev_response else None,
+            tool_call_id_type=self.tool_call_id_type,
         )
         chat_template_kwargs = self._effective_chat_template_kwargs(request)
         _, engine_inputs = await self.online_renderer.preprocess_chat(
@@ -647,6 +650,7 @@ class OpenAIServingResponses(GenerateBaseServing):
     ):
         new_messages = construct_input_messages(
             request_input=messages,
+            tool_call_id_type=self.tool_call_id_type,
         )
         chat_template_kwargs = self._effective_chat_template_kwargs(request)
         _, engine_inputs = await self.online_renderer.preprocess_chat(

--- a/vllm/entrypoints/openai/responses/utils.py
+++ b/vllm/entrypoints/openai/responses/utils.py
@@ -30,7 +30,11 @@ from openai.types.responses.response_reasoning_item import (
 from openai.types.responses.tool import Tool
 
 from vllm import envs
-from vllm.entrypoints.chat_utils import make_tool_call_id
+from vllm.entrypoints.chat_utils import (
+    has_native_tool_call_ids,
+    is_native_tool_call_id,
+    make_tool_call_id,
+)
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionMessageParam,
     ChatCompletionToolsParam,
@@ -164,6 +168,7 @@ def construct_input_messages(
     request_input: str | list[ResponseInputOutputItem],
     prev_msg: list[ChatCompletionMessageParam] | None = None,
     prev_response_output: list[ResponseOutputItem] | None = None,
+    tool_call_id_type: str = "random",
 ):
     messages: list[ChatCompletionMessageParam] = []
     if request_instructions:
@@ -198,22 +203,68 @@ def construct_input_messages(
     if isinstance(request_input, str):
         messages.append({"role": "user", "content": request_input})
     else:
-        input_messages = construct_chat_messages_with_tool_call(request_input)
+        input_messages = construct_chat_messages_with_tool_call(
+            request_input, tool_call_id_type=tool_call_id_type
+        )
         messages.extend(input_messages)
     return messages
 
 
+class _NativeToolCallIds:
+    """Restore native tool-call IDs that a Responses round trip replaced.
+
+    The Responses API hands clients OpenAI-style ``call_<uuid>`` IDs, but Kimi's
+    chat template renders the ID verbatim as the ``<|tool_call_begin|>`` header
+    and as the ``## Return of {id}`` tool-result header -- and renders the
+    function name nowhere else. Echoing ``call_<uuid>`` back therefore both
+    hides which function a prior turn called and teaches the model to imitate an
+    ID shape its own parser rejects.
+
+    Numbering follows ``count_response_history_tool_calls``: a single counter
+    over the whole input, which is what the parser uses to number the *next*
+    tool call.
+    """
+
+    def __init__(self, id_type: str) -> None:
+        self.id_type = id_type
+        self.enabled = has_native_tool_call_ids(id_type)
+        self._next_idx = 0
+        self._rewritten: dict[str, str] = {}
+
+    def for_tool_call(self, call_id: str, tool_name: str) -> str:
+        if not self.enabled:
+            return call_id
+        idx = self._next_idx
+        self._next_idx += 1
+        if is_native_tool_call_id(call_id, self.id_type):
+            return call_id
+        native_id = make_tool_call_id(
+            id_type=self.id_type, func_name=tool_name, idx=idx
+        )
+        self._rewritten[call_id] = native_id
+        return native_id
+
+    def for_tool_output(self, call_id: str | None) -> str | None:
+        if not self.enabled or call_id is None:
+            return call_id
+        return self._rewritten.get(call_id, call_id)
+
+
 def construct_chat_messages_with_tool_call(
     input_messages: list[ResponseInputOutputItem],
+    tool_call_id_type: str = "random",
 ) -> list[ChatCompletionMessageParam]:
     """Build chat messages from response items.
 
     Some chat messages span multiple response items (e.g., reasoning + tool calls).
     """
     messages: list[ChatCompletionMessageParam] = []
+    native_ids = _NativeToolCallIds(tool_call_id_type)
     for item in input_messages:
         message = _construct_message_from_response_item(
-            item, prev_msg=messages[-1] if messages else None
+            item,
+            prev_msg=messages[-1] if messages else None,
+            native_ids=native_ids,
         )
         if message is not None:
             messages.append(message)
@@ -224,6 +275,7 @@ def construct_chat_messages_with_tool_call(
 def _construct_message_from_response_item(
     item: ResponseInputOutputItem,
     prev_msg: ChatCompletionMessageParam | None = None,
+    native_ids: _NativeToolCallIds | None = None,
 ) -> ChatCompletionMessageParam | None:
     """
     Returns a new message or None. If `None`, `prev_msg` might be updated.
@@ -232,13 +284,15 @@ def _construct_message_from_response_item(
     prev_assistant_msg = (
         prev_msg if prev_msg and prev_msg.get("role") == "assistant" else None
     )
+    if native_ids is None:
+        native_ids = _NativeToolCallIds("random")
 
     if isinstance(item, ResponseFunctionToolCall):
         tool_name = item.name
         if item.namespace:
             tool_name = flat_namespace_tool_name(item.namespace, item.name)
         tool_call = ChatCompletionMessageToolCallParam(
-            id=item.call_id,
+            id=native_ids.for_tool_call(item.call_id, tool_name),
             function=FunctionCallTool(
                 name=tool_name,
                 arguments=item.arguments,
@@ -309,14 +363,14 @@ def _construct_message_from_response_item(
         return ChatCompletionToolMessageParam(
             role="tool",
             content=item.output,
-            tool_call_id=item.call_id,
+            tool_call_id=native_ids.for_tool_output(item.call_id),
         )
     elif isinstance(item, dict) and item.get("type") == "function_call_output":
         # Append the function call output as a tool message.
         return ChatCompletionToolMessageParam(
             role="tool",
             content=item.get("output"),
-            tool_call_id=item.get("call_id"),
+            tool_call_id=native_ids.for_tool_output(item.get("call_id")),
         )
     elif isinstance(item, dict) and item.get("role") == "assistant":
         content = item.get("content")

--- a/vllm/parser/kimi_k2.py
+++ b/vllm/parser/kimi_k2.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 import regex as re
 
 from vllm.entrypoints.openai.engine.protocol import DeltaFunctionCall, DeltaToolCall
+from vllm.logger import init_logger
 from vllm.parser.engine.events import EventType
 from vllm.parser.engine.parser_engine import ParserEngine
 from vllm.parser.engine.parser_engine_config import (
@@ -45,6 +46,8 @@ TOOL_SECTION_END = "<|tool_calls_section_end|>"
 TOOL_CALL_START = "<|tool_call_begin|>"
 TOOL_CALL_END = "<|tool_call_end|>"
 TOOL_ARG_START = "<|tool_call_argument_begin|>"
+
+logger = init_logger(__name__)
 
 _TOOL_ID_RE = re.compile(r"(?P<id>.+:\d+)")
 
@@ -195,6 +198,16 @@ class KimiK2Parser(ParserEngine):
     ) -> None:
         tool_id, tool_name = self._extract_tool_id_and_name(name)
         if not tool_name:
+            if name and name.strip():
+                # The function name only exists inside the native id, so a
+                # header we cannot parse means the call is dropped entirely.
+                logger.warning_once(
+                    "Dropping Kimi tool call: header %r is not in the native "
+                    "`functions.{name}:{idx}` format. This usually means "
+                    "earlier-turn tool call IDs were rewritten before being "
+                    "rendered back into the prompt.",
+                    name.strip(),
+                )
             if 0 <= idx < len(self._tool_slots):
                 self._tool_slots[idx].name = ""
             return


### PR DESCRIPTION

## Purpose

Fixes #50768. On `/v1/responses` with a Kimi model and `--tool-call-parser kimi_k2`, multi-turn agentic sessions intermittently lose the model's tool call and the turn comes back empty — the reporter's "performs work but never answers", at a rate that climbs sharply with the number of turns (9/15 on short tasks, 0-3/15 on long ones).

Scope note on the issue: the reporter also captured a payload with raw `<|tool_call_begin|> call_...` markup inside `output_text`. This PR does **not** explain that half. On their exact build (`e2fa28594`, which is 5 commits behind
this base and byte-identical across `vllm/parser/`, `vllm/entrypoints/openai/responses/`, `vllm/entrypoints/chat_utils.py`,
`vllm/tool_parsers/`) a `call_<uuid>` header produces a *dropped* tool call with the markers consumed, not leaked. The leak is likely a second, separate problem — #48940 covers special-token leakage when `tools`/`tool_choice` are omitted on a
later agent-loop turn, which is a plausible candidate but unconfirmed here. I've asked the reporter for the detail that would separate the two.

### Root cause (verified on `main` @ `0055b8bfa`)

Kimi's chat template renders a tool-call ID **verbatim**, in two places, and renders the function name nowhere else:

```jinja
{%- set formatted_id = tool_call['id'] -%}
<|tool_call_begin|>{{ formatted_id }}<|tool_call_argument_begin|>...<|tool_call_end|>
...
{%- set tool_call_id = message.tool_call_id -%}
## Return of {{ tool_call_id }}
```

Verified identical on these two lines across `Kimi-K2-Instruct`, `Kimi-K2-Thinking`, `Kimi-K2.5` and `Kimi-K2.7-Code` (the last two are what the reporter runs). All of K2.5 / K2.6 / K2.7-Code report `model_type: kimi_k25` with `text_config.model_type: kimi_k2`, both of which are already in `_KIMI_MODEL_TYPES`, so `get_tool_call_id_type` gates them correctly. (Moonshot's own [`tool_call_guidance.md`](https://github.com/MoonshotAI/Kimi-K2/blob/main/docs/tool_call_guidance.md) documents the ID format as `functions.{func_name}:{idx}` "from which we can parse the function name".)

The chain:

1. **Output.** On the streaming Responses path,  `emit_simple_tool_call_open` (`vllm/entrypoints/openai/responses/streaming_events.py`)  sets `state.tool_call_id = f"call_{random_uuid()}"`, discarding the native ID  the parser put on the `DeltaToolCall` (`ParserEngine._emit_name_delta` → `_ensure_tool_id`). The client sees `call_<uuid>`.
2. **Input.** Next turn the client echoes that history back.  `construct_chat_messages_with_tool_call`
   (`vllm/entrypoints/openai/responses/utils.py`) passed `call_id` straight   through onto both `tool_calls[].id` and the tool message's `tool_call_id`.
3. **Prompt.** The template therefore renders `<|tool_call_begin|>call_<uuid>` and `## Return of call_<uuid>`. Because the function name lives only inside the ID, prior turns become unreadable to the model — it can see that *a* tool ran and what it returned, but not *which* tool. It also learns to imitate the  `call_<uuid>` header shape.
4. **Parse.** `KimiK2Parser._extract_tool_id_and_name` matches  `_TOOL_ID_RE = r"(?P<id>.+:\d+)"`. `call_4144fac2c5e1f3e0` has no `:N`, so it   returns `(None, None)` and `ParserEngine._build_extracted_result` skips the slot — the tool call is dropped silently. That silent drop is the "no answer" symptom, and it compounds with turn count because every extra turn adds more  contaminated history.

This is the Responses-path twin of #32768, which fixed chat completions via `make_tool_call_id(id_type="kimi_k2")` / `_KIMI_MODEL_TYPES` in `vllm/entrypoints/chat_utils.py`. Chat completions never needed a rewrite because they hand the native ID to the client and get it back unchanged; the Responses path substitutes its own ID, so the round trip has to be undone on the way in.

### Fix

Input side only. When the served model is Kimi-family, `construct_chat_messages_with_tool_call` renumbers any history tool-call ID that is not already native to `functions.{tool_name}:{idx}`, and applies the same `old -> new` mapping to the
matching tool message's `tool_call_id` so the pair stays consistent (the template needs both).

`idx` is a **single counter over the whole input array**, matching `count_response_history_tool_calls` in `vllm/parser/utils.py` — the same counter the parser uses to number the *next* tool call. Per-turn numbering would produce duplicate `## Return of functions.foo:0` headers and collide with the parser's next index; there is a test pinning the no-collision invariant.

Behaviour is idempotent (already-native IDs pass through untouched) and byte-for-byte unchanged for non-Kimi models — `get_tool_call_id_type` returns `"random"` for everything else and the rewriter is an identity function in that case.

Second commit: `KimiK2Parser` now logs a `warning_once` naming an unparseable `<|tool_call_begin|>` header before dropping the call, so this class of failure is diagnosable from server logs instead of silent. No change to the shared
`ParserEngine`.

### Why input-side rewrite, not preserving the native ID on the wire

The alternative is to stop minting `call_<uuid>` in `streaming_events.py` and emit `functions.exec_command:0` as the Responses `call_id`. Rejected here:

- It changes the public wire format for every Kimi Responses user, and OpenAI clients have varying expectations about `call_id` shape. Input-side rewriting  is invisible to clients.
- It only fixes histories that vLLM itself generated. A client that mints its own `call_id`s, or a proxy that rewrites them, would still poison the prompt. The input-side rewrite covers those too.
- The non-streaming Responses path already preserves the native ID (`build_response_output_items` uses `tool_call.id or ...`), so the wire format is currently *inconsistent* between streaming and non-streaming. The input-side fix makes both correct without having to pick a wire format first.

Worth doing separately: making the streaming and non-streaming wire IDs agree. Deliberately out of scope here.

### Scope note

This describes the mechanism as verified on current `main`. No bisect was run, so this makes no claim about which commit changed the behaviour relative to v0.26.0; the reporter's observation that v0.26.0 behaved differently is recorded as their observation only.

### Known limitation, not addressed here

When a tool call *is* dropped (malformed header, first in a section), the surviving calls keep their raw slot indices, so the stream emits e.g. `index=1` with no `index=0` before it. Renumbering slots is a `ParserEngine`-wide change; leaving it for a separate PR. The new parser test places the malformed call last and documents why.

## Test Plan

```bash
.venv/bin/python -m pytest tests/entrypoints/openai/responses/test_responses_utils.py -v
.venv/bin/python -m pytest tests/tool_parsers/test_kimi_k2_tool_parser.py -v
.venv/bin/python -m pytest tests/entrypoints/openai/responses/ tests/tool_parsers/ \
    tests/reasoning/test_kimi_k2_reasoning_parser.py \
    tests/entrypoints/unit_tests/test_chat_utils.py -q
pre-commit run --files vllm/entrypoints/chat_utils.py \
    vllm/entrypoints/openai/responses/utils.py \
    vllm/entrypoints/openai/responses/serving.py vllm/parser/kimi_k2.py \
    tests/entrypoints/openai/responses/test_responses_utils.py \
    tests/tool_parsers/test_kimi_k2_tool_parser.py
```

New coverage in `tests/entrypoints/openai/responses/test_responses_utils.py` (`TestNativeToolCallIds`):

- `call_<uuid>` history on a Kimi model → `functions.{name}:{idx}` on both the assistant `tool_calls[].id` and the paired tool message `tool_call_id`; two  calls in one turn get `:0` / `:1`.
- Indices run across assistant turns, and no history ID collides with the ID the parser will mint next (asserted against `count_response_history_tool_calls`).
- Idempotence: already-native IDs unchanged.
- Non-Kimi models: `call_<uuid>` preserved, output identical to the default.
- Dict-shaped `function_call_output` items rewritten (these are *not* coerced to typed items by `ResponsesRequest.input_item_parsing`, unlike `function_call`).
- Namespaced tools use the flattened `functions.{namespace}__{name}:{idx}` name.
- `construct_input_messages` threads the ID type through.

In `tests/tool_parsers/test_kimi_k2_tool_parser.py`: a `call_<uuid>` header drops only that call, leaks no `<|tool_call_*|>` markers into content, leaves a sibling well-formed call parseable (streaming and non-streaming), and is logged.

## Test Result

Focused suites:

```text
tests/entrypoints/openai/responses/test_responses_utils.py   47 passed
tests/tool_parsers/test_kimi_k2_tool_parser.py               53 passed
```

Regression sweep over everything that touches the changed code (`tests/entrypoints/openai/responses/`, `tests/tool_parsers/`, `tests/reasoning/test_kimi_k2_reasoning_parser.py`, `tests/entrypoints/unit_tests/test_chat_utils.py`):

| | passed | errors |
| --- | --- | --- |
| `main` (baseline) | 1101 | 120 |
| this branch | **1111** | 120 |

+10 = the new tests; the error count is unchanged. All 120 errors are pre-existing setup failures for tests that need a live server or a GPU (`test_simple.py`, `test_stateful.py`, `test_structured_output.py`, the multimodal `test_chat_utils.py` cases) — the run was on a CPU-only box.

`pre-commit run --files <the 6 changed files>` → all hooks pass, exit 0 (ruff check, ruff format, typos, mypy-3.10, SPDX, forbidden imports, …).

## Model evaluation

This changes what is rendered into the prompt for Kimi models, so it is output-affecting. I could not run a Kimi K2/K2.5 eval — the model needs an 8×B200-class host that I do not have. What is verified instead is deterministic and needs no GPU: the rendered prompt itself. Feeding the same two-turn `function_call` / `function_call_output` history through the real
`moonshotai/Kimi-K2.7-Code/chat_template.jinja` (the reporter's model):

```text
--- BEFORE (main)
    <|tool_call_begin|>call_4144fac2c5e1f3e0
    ## Return of call_4144fac2c5e1f3e0
    <|tool_call_begin|>call_9bd0e1a7c2
    ## Return of call_9bd0e1a7c2
--- AFTER  (this PR)
    <|tool_call_begin|>functions.exec_command:0
    ## Return of functions.exec_command:0
    <|tool_call_begin|>functions.read_file:1
    ## Return of functions.read_file:1
```

The "after" form is exactly what the chat-completions path (fixed in #32768) already produces and what `KimiK2Parser._TOOL_ID_RE` accepts; the "before" form returns `(None, None)` from `_extract_tool_id_and_name`.

**A reviewer with Kimi hardware should confirm the end-to-end fix** by running the reporter's scenario — Codex CLI against `/v1/responses`, streaming, `tool_choice: auto`, a multi-turn task — and checking that the "no answer" rate drops. @GeorgiaM-honestly, if you can retest with this patch, that would settle it.

## Duplicate check

Not a duplicate. As of 2026-08-02 there is no PR referencing #50768, no open PR touches `vllm/entrypoints/openai/responses/utils.py` or `vllm/parser/kimi_k2.py`, and none of the 30 open PRs matching "kimi tool call" addresses tool-call ID preservation on the Responses path. #32768 (merged) fixed the chat-completions half of this; the Responses path was missed.

## AI assistance

AI assistance was used to investigate and draft this change. Every claim above was checked against the code and against the upstream chat template, and the test commands were run locally.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update.
</details>
