### PR TITLE
[Frontend][Voxtral] Add opt-in segment timestamps to /v1/realtime

### DIFF
--- a/docs/serving/online_serving/speech_to_text.md
+++ b/docs/serving/online_serving/speech_to_text.md
@@ -181,7 +181,8 @@ Audio must be sent as base64-encoded PCM16 audio at 16kHz sample rate, mono chan
 
 1. Client connects to `ws://host/v1/realtime`
 2. Server sends `session.created` event
-3. Client optionally sends `session.update` with model/params
+3. Client optionally sends `session.update` with model/params, and the server
+    acknowledges with `session.updated`
 4. Client sends `input_audio_buffer.commit` when ready
 5. Client sends `input_audio_buffer.append` events with base64 PCM16 chunks
 6. Server sends `transcription.delta` events with incremental text
@@ -196,16 +197,60 @@ Audio must be sent as base64-encoded PCM16 audio at 16kHz sample rate, mono chan
 | ----- | ----------- |
 | `input_audio_buffer.append` | Send base64-encoded audio chunk: `{"type": "input_audio_buffer.append", "audio": "<base64>"}` |
 | `input_audio_buffer.commit` | Trigger transcription processing or end: `{"type": "input_audio_buffer.commit", "final": bool}` |
-| `session.update` | Configure session: `{"type": "session.update", "model": "model-name"}` |
+| `session.update` | Configure session: `{"type": "session.update", "model": "model-name", "timestamp_granularities": ["segment"]}` |
 
 ### Server → Client Events
 
 | Event | Description |
 | ----- | ----------- |
 | `session.created` | Connection established with session ID and timestamp |
+| `session.updated` | Acknowledgement of `session.update`, echoing the configuration that took effect |
 | `transcription.delta` | Incremental transcription text: `{"type": "transcription.delta", "delta": "text"}` |
 | `transcription.done` | Final transcription with usage stats |
 | `error` | Error notification with message and optional code |
+
+#### Segment-level timestamps
+
+Models that emit one output token per audio frame can report when each piece
+of transcribed audio ended. Opt in per connection:
+
+```json
+{"type": "session.update", "model": "mistralai/Voxtral-Mini-4B-Realtime-2602", "timestamp_granularities": ["segment"]}
+```
+
+If the request was honoured the server replies with `session.updated`, echoing
+`"timestamp_granularities": ["segment"]`. If it cannot be, the server replies
+with `error` instead and the session stays unconfigured, so the opt-in is
+never silently dropped. Once enabled, `transcription.delta` and
+`transcription.done` carry a `segments` array:
+
+```json
+{"type": "transcription.done", "text": " Mary had a little lamb", "segments": [{"text": " Mary had", "end": 1.36}, {"text": " a little lamb", "end": 2.08}]}
+```
+
+Points worth knowing before building on this:
+
+- **End only.** The model marks where a group of audio ends, not where it
+  starts. Deriving a start from the previous `end` is wrong across pauses.
+- **Segments are emission groups, not words.** The model may commit several
+  words at once, and then they share one entry. Expect at most one entry per
+  spoken word.
+- **Granularity is one audio frame**, 80 ms for Voxtral realtime.
+- **The clock is relative to the utterance**, and restarts on every non-final
+  `input_audio_buffer.commit`.
+- **Timestamps trail their text by one event.** The boundary marker itself
+  decodes to no text, so a delta carrying `segments` has an empty `delta`. A
+  client that skips events with empty text will drop them.
+- `transcription.done` repeats every segment of the utterance, including the
+  trailing one, which no delta can carry because generation ends first.
+- Requires `--stream-interval 1` (the default), and the opt-in is rejected
+  otherwise. Batched streaming stalls realtime transcription entirely - the
+  server withholds an output until `stream-interval` tokens accumulate, but
+  the next token cannot be generated until the previous one is fed back - so
+  omitting `timestamp_granularities` is not a way to keep such a server
+  usable.
+- Clients that do not opt in see byte-identical payloads: the `segments` key
+  is omitted entirely.
 
 #### Example Clients
 

--- a/examples/speech_to_text/realtime/openai_realtime_client.py
+++ b/examples/speech_to_text/realtime/openai_realtime_client.py
@@ -45,7 +45,13 @@ def audio_to_pcm16_base64(audio_path: str) -> str:
     return base64.b64encode(pcm16.tobytes()).decode("utf-8")
 
 
-async def realtime_transcribe(audio_path: str, host: str, port: int, model: str):
+async def realtime_transcribe(
+    audio_path: str,
+    host: str,
+    port: int,
+    model: str,
+    segment_timestamps: bool = False,
+):
     """
     Connect to the Realtime API and transcribe an audio file.
     """
@@ -60,8 +66,21 @@ async def realtime_transcribe(audio_path: str, host: str, port: int, model: str)
             print(f"Unexpected response: {response}")
             return
 
-        # Validate model
-        await ws.send(json.dumps({"type": "session.update", "model": model}))
+        # Validate model, and opt in to segment timestamps if asked
+        session_update = {"type": "session.update", "model": model}
+        if segment_timestamps:
+            session_update["timestamp_granularities"] = ["segment"]
+        await ws.send(json.dumps(session_update))
+
+        # The server echoes the configuration that took effect, so a request
+        # the model cannot honour is never silently dropped.
+        response = json.loads(await ws.recv())
+        if response["type"] == "error":
+            print(f"Session update rejected: {response['error']}")
+            return
+        if segment_timestamps and not response.get("timestamp_granularities"):
+            print("Server did not enable segment timestamps.")
+            return
 
         # Signal ready to start
         await ws.send(json.dumps({"type": "input_audio_buffer.commit"}))
@@ -99,6 +118,10 @@ async def realtime_transcribe(audio_path: str, host: str, port: int, model: str)
                 print(response["delta"], end="", flush=True)
             elif response["type"] == "transcription.done":
                 print(f"\n\nFinal transcription: {response['text']}")
+                for segment in response.get("segments") or []:
+                    # End times only: the model marks where a group of audio
+                    # ends, not where it starts.
+                    print(f"  ends at {segment['end']:>7.2f}s  {segment['text']!r}")
                 if response.get("usage"):
                     print(f"Usage: {response['usage']}")
                 break
@@ -115,7 +138,11 @@ def main(args):
         audio_path = str(AudioAsset("mary_had_lamb").get_local_path())
         print(f"No audio path provided, using default: {audio_path}")
 
-    asyncio.run(realtime_transcribe(audio_path, args.host, args.port, args.model))
+    asyncio.run(
+        realtime_transcribe(
+            audio_path, args.host, args.port, args.model, args.segment_timestamps
+        )
+    )
 
 
 if __name__ == "__main__":
@@ -133,6 +160,11 @@ if __name__ == "__main__":
         type=str,
         default=None,
         help="Path to the audio file to transcribe.",
+    )
+    parser.add_argument(
+        "--segment-timestamps",
+        action="store_true",
+        help="Ask the server for the end time of each transcribed segment.",
     )
     parser.add_argument(
         "--host",

--- a/tests/entrypoints/speech_to_text/realtime/test_realtime_validation.py
+++ b/tests/entrypoints/speech_to_text/realtime/test_realtime_validation.py
@@ -3,7 +3,6 @@
 
 import asyncio
 import json
-import warnings
 
 import numpy as np
 import pybase64 as base64
@@ -70,6 +69,138 @@ def mary_had_lamb_audio_chunks() -> list[str]:
     return chunks
 
 
+async def _start_session(
+    ws, model_name: str, timestamp_granularities: list[str] | None = None
+) -> dict:
+    """Open a session and return the session.updated acknowledgement."""
+    event = await receive_event(ws, timeout=30.0)
+    assert event["type"] == "session.created"
+
+    update: dict = {"type": "session.update", "model": model_name}
+    if timestamp_granularities is not None:
+        update["timestamp_granularities"] = timestamp_granularities
+    await send_event(ws, update)
+
+    event = await receive_event(ws, timeout=10.0)
+    assert event["type"] == "session.updated"
+    return event
+
+
+async def _stream_utterance(ws, chunks: list[str], timeout: float = 60.0) -> list[dict]:
+    """Stream one utterance and return every event up to transcription.done."""
+    await send_event(ws, {"type": "input_audio_buffer.commit"})
+    for chunk in chunks:
+        await send_event(ws, {"type": "input_audio_buffer.append", "audio": chunk})
+    await send_event(ws, {"type": "input_audio_buffer.commit", "final": True})
+
+    events = []
+    while True:
+        event = await receive_event(ws, timeout=timeout)
+        if event["type"] == "error":
+            pytest.fail(f"Received error: {event}")
+        events.append(event)
+        if event["type"] == "transcription.done":
+            return events
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_name", [MODEL_NAME])
+async def test_segment_timestamps(
+    model_name, mary_had_lamb_audio_chunks, rocm_aiter_fa_attention
+):
+    """Segment timestamps are opt-in, aligned, and invisible when not asked for.
+
+    The alignment bound is the point of this test: the token index of a
+    generated token leads the audio it describes by the streaming prefix
+    minus the left pad minus the transcription delay. Subtracting only the
+    delay - as https://github.com/vllm-project/vllm/issues/39735 proposes -
+    leaves the 32-frame left pad in and puts every timestamp 2.56 s late,
+    which the upper bound catches.
+    """
+    server_args = ["--enforce-eager", "--max-model-len", "2048"]
+
+    if model_name.startswith("mistralai"):
+        server_args += MISTRAL_FORMAT_ARGS
+
+    add_attention_backend(server_args, rocm_aiter_fa_attention)
+
+    chunk_duration_s = 1600 / 16000
+    duration_s = len(mary_had_lamb_audio_chunks) * chunk_duration_s
+
+    with RemoteOpenAIServer(
+        model_name, server_args, env_dict=REALTIME_ENV_OVERRIDES
+    ) as remote_server:
+        ws_url = _get_websocket_url(remote_server)
+
+        # --- Not opted in: the wire must be byte-identical to before ------
+        async with websockets.connect(ws_url) as ws:
+            ack = await _start_session(ws, model_name)
+            assert ack["timestamp_granularities"] == []
+
+            # (ROCm) generous timeout: first use triggers aiter JIT.
+            events = await _stream_utterance(
+                ws, mary_had_lamb_audio_chunks, timeout=600.0
+            )
+            done = events[-1]
+            assert set(done) == {"type", "text", "usage"}
+            assert all("segments" not in event for event in events)
+            baseline_text = done["text"]
+
+        # --- Opted in: same text, plus timestamps -------------------------
+        async with websockets.connect(ws_url) as ws:
+            ack = await _start_session(ws, model_name, ["segment"])
+            assert ack["timestamp_granularities"] == ["segment"]
+
+            events = await _stream_utterance(ws, mary_had_lamb_audio_chunks)
+            done = events[-1]
+            segments = done["segments"]
+
+            # Opting in must not change what was transcribed.
+            assert done["text"] == baseline_text
+            assert segments
+
+            # done repeats the deltas' segments, plus the trailing segment
+            # that generation ended before any delta could carry.
+            streamed = [
+                segment
+                for event in events
+                if event["type"] == "transcription.delta"
+                for segment in event["segments"]
+            ]
+            assert segments[: len(streamed)] == streamed
+            assert 0 <= len(segments) - len(streamed) <= 1
+
+            ends = [segment["end"] for segment in segments]
+            assert ends == sorted(ends)
+            assert all(end >= 0.08 for end in ends)
+            assert all(abs(end / 0.08 - round(end / 0.08)) < 1e-6 for end in ends)
+
+            # Bounded on both sides: +32 frames of left pad would overshoot,
+            # a negative offset would undershoot.
+            assert 0.5 * duration_s <= ends[-1] <= duration_s + 0.5
+
+            # Entries are emission groups, so there are at most as many as
+            # there are words, and together they reconstruct the transcript.
+            assert len(segments) <= len(baseline_text.split())
+            reconstructed = "".join(segment["text"] for segment in segments)
+            assert baseline_text.endswith(reconstructed)
+            assert len(reconstructed) >= 0.9 * len(baseline_text)
+
+        # --- The clock restarts on every utterance ------------------------
+        async with websockets.connect(ws_url) as ws:
+            await _start_session(ws, model_name, ["segment"])
+            short_chunks = mary_had_lamb_audio_chunks[:40]
+
+            first = await _stream_utterance(ws, short_chunks)
+            second = await _stream_utterance(ws, short_chunks)
+
+            assert first[-1]["segments"]
+            assert second[-1]["segments"]
+            # Not "greater than the first utterance's last end": each commit
+            # is a new engine request with a fresh prompt and left pad.
+            assert second[-1]["segments"][0]["end"] < 1.0
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("model_name", [MODEL_NAME])
 async def test_multi_chunk_streaming(
@@ -95,17 +226,8 @@ async def test_multi_chunk_streaming(
             await send_event(ws, {"type": "session.update", "model": model_name})
 
             # Wait for the server to acknowledge the session update.
-            try:
-                while True:
-                    event = await receive_event(ws, timeout=5.0)
-                    if event["type"] == "session.updated":
-                        break
-            except TimeoutError:
-                warnings.warn(
-                    f"session.updated not received within {5.0}s after "
-                    "session.update. The server may not implement this event.",
-                    stacklevel=2,
-                )
+            event = await receive_event(ws, timeout=10.0)
+            assert event["type"] == "session.updated"
 
             # (ROCm) Warm-up: send a non-final commit (required to start
             # transcription) with a small audio chunk to trigger aiter
@@ -203,17 +325,8 @@ async def test_empty_commit_does_not_crash_engine(
 
             await send_event(ws, {"type": "session.update", "model": model_name})
 
-            try:
-                while True:
-                    event = await receive_event(ws, timeout=5.0)
-                    if event["type"] == "session.updated":
-                        break
-            except TimeoutError:
-                warnings.warn(
-                    f"session.updated not received within {5.0}s after "
-                    "session.update. The server may not implement this event.",
-                    stacklevel=2,
-                )
+            event = await receive_event(ws, timeout=10.0)
+            assert event["type"] == "session.updated"
 
             # Start generation without sending any audio
             await send_event(ws, {"type": "input_audio_buffer.commit"})
@@ -239,17 +352,8 @@ async def test_empty_commit_does_not_crash_engine(
 
             await send_event(ws, {"type": "session.update", "model": model_name})
 
-            try:
-                while True:
-                    event = await receive_event(ws, timeout=5.0)
-                    if event["type"] == "session.updated":
-                        break
-            except TimeoutError:
-                warnings.warn(
-                    f"session.updated not received within {5.0}s after "
-                    "session.update. The server may not implement this event.",
-                    stacklevel=2,
-                )
+            event = await receive_event(ws, timeout=10.0)
+            assert event["type"] == "session.updated"
 
             # Start transcription
             await send_event(ws, {"type": "input_audio_buffer.commit"})

--- a/tests/entrypoints/speech_to_text/realtime/test_segment_timestamps.py
+++ b/tests/entrypoints/speech_to_text/realtime/test_segment_timestamps.py
@@ -1,0 +1,448 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for realtime segment timestamps.
+
+The timestamper turns output-token positions into audio time, which only
+works because Voxtral realtime emits exactly one token per 80 ms frame. Two
+things can silently produce plausible-but-wrong timestamps, and both are
+pinned here:
+
+- the boundary marker precedes the subwords of its own emission group
+  (arXiv 2602.11298 section 3.1), so pairing it with the text that follows it
+  shifts every segment by one full group;
+- the frame offset is derived from the *audio* length of the left pad, not
+  from the pad token count, so a tokenizer change cannot shift every
+  timestamp by the pad duration without failing loud.
+"""
+
+import json
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import regex as re
+from mistral_common.tokens.tokenizers.base import SpecialTokens
+
+from vllm.entrypoints.speech_to_text.realtime.connection import RealtimeConnection
+from vllm.entrypoints.speech_to_text.realtime.protocol import (
+    SessionUpdate,
+    TranscriptionDone,
+    TranscriptionSegmentTimestamp,
+)
+from vllm.model_executor.models import voxtral_realtime
+from vllm.model_executor.models.voxtral_realtime import (
+    VoxtralRealtimeGeneration,
+    VoxtralRealtimeSegmentTimestamper,
+)
+
+BOUNDARY = 33  # [STREAMING_WORD]
+PAD = 32  # [STREAMING_PAD]
+FRAME_MS = 80.0
+
+# Stands in for `tokenizer.decode(ids, skip_special_tokens=True)`: real
+# words for real ids, and nothing at all for control tokens.
+VOCAB = {1: "Mary", 2: " had", 4: " lit", 5: "tle", 6: " lamb"}
+
+
+def _decode(token_ids: list[int]) -> str:
+    return "".join(VOCAB.get(token_id, "") for token_id in token_ids)
+
+
+def _timestamper(offset_frames: int = 1) -> VoxtralRealtimeSegmentTimestamper:
+    return VoxtralRealtimeSegmentTimestamper(
+        boundary_token_id=BOUNDARY,
+        frame_duration_ms=FRAME_MS,
+        offset_frames=offset_frames,
+        decode=_decode,
+    )
+
+
+def _feed(
+    timestamper: VoxtralRealtimeSegmentTimestamper,
+    deltas: list[list[int]],
+) -> list[tuple[str, float]]:
+    segments: list[tuple[str, float]] = []
+    for delta in deltas:
+        segments.extend(timestamper.process_token_ids(delta))
+    return segments
+
+
+@pytest.mark.parametrize(
+    ("deltas", "expected"),
+    [
+        # A boundary opens a segment, it does not close one.
+        pytest.param([[BOUNDARY]], [], id="boundary-opens-nothing"),
+        pytest.param([[BOUNDARY], [1], [BOUNDARY]], [("Mary", 0.08)], id="single"),
+        pytest.param(
+            [[BOUNDARY], [4], [5], [BOUNDARY]],
+            [(" little", 0.08)],
+            id="multi-token",
+        ),
+        # One boundary per emission group, so words the model emitted
+        # together stay together (arXiv 2602.11298 section 3.1).
+        pytest.param(
+            [[BOUNDARY], [1], [2], [BOUNDARY]],
+            [("Mary had", 0.08)],
+            id="grouped-words",
+        ),
+        # Padding before the first boundary belongs to no segment, but still
+        # advances the clock.
+        pytest.param(
+            [[PAD], [PAD], [BOUNDARY], [1], [BOUNDARY]],
+            [("Mary", 0.24)],
+            id="leading-pads-dropped",
+        ),
+        pytest.param([[BOUNDARY], [BOUNDARY]], [], id="empty-segment-skipped"),
+        # Silence inside an utterance decodes to nothing and is not reported.
+        pytest.param(
+            [[BOUNDARY], [PAD], [PAD], [BOUNDARY]],
+            [],
+            id="silence-segment-skipped",
+        ),
+        pytest.param([[1]], [], id="text-before-first-boundary"),
+        pytest.param(
+            [[BOUNDARY], [1], [BOUNDARY], [2], [BOUNDARY]],
+            [("Mary", 0.08), (" had", 0.24)],
+            id="inverted-pairing-guard",
+        ),
+    ],
+)
+def test_segments(deltas, expected):
+    assert _feed(_timestamper(), deltas) == expected
+
+
+def test_trailing_segment_is_flushed():
+    timestamper = _timestamper()
+    assert _feed(timestamper, [[BOUNDARY], [1], [6]]) == []
+    assert timestamper.flush() == [("Mary lamb", 0.08)]
+
+
+def test_flush_does_not_re_emit_a_closed_segment():
+    timestamper = _timestamper()
+    assert _feed(timestamper, [[BOUNDARY], [1], [BOUNDARY]]) == [("Mary", 0.08)]
+    assert timestamper.flush() == []
+    assert timestamper.flush() == []
+
+
+def test_merged_delta_matches_token_at_a_time():
+    """Defensive: identical results however tokens are batched into deltas.
+
+    Unreachable today because ``realtime_max_tokens = 1`` and the lockstep
+    stops the producer from running ahead, so ``RequestOutputCollector`` has
+    nothing to merge. Segmenting on token ids rather than on delta text keeps
+    it that way if the lockstep is ever relaxed.
+    """
+    one_at_a_time = _feed(
+        _timestamper(), [[BOUNDARY], [1], [BOUNDARY], [2], [BOUNDARY]]
+    )
+    merged = _feed(_timestamper(), [[BOUNDARY, 1, BOUNDARY, 2], [BOUNDARY]])
+    assert merged == one_at_a_time
+
+
+def test_offset_frames_shifts_every_segment():
+    assert _feed(_timestamper(offset_frames=0), [[BOUNDARY], [1], [BOUNDARY]]) == [
+        ("Mary", 0.0)
+    ]
+
+
+class _FakeTokenizer:
+    """The slice of the Mistral tokenizer the timestamper reads."""
+
+    def __init__(self, n_pad_audio_frames: int = 32, has_boundary: bool = True):
+        audio_config = SimpleNamespace(
+            frame_rate=12.5,
+            raw_audio_length_per_tok=1280,
+            n_left_pad_tokens=32,
+            get_num_delay_tokens=lambda: 6,
+        )
+        left_pad = SimpleNamespace(
+            audio_array=np.zeros(n_pad_audio_frames * 1280, dtype=np.float32)
+        )
+        audio_encoder = SimpleNamespace(
+            audio_config=audio_config,
+            get_padding_audio=lambda: (left_pad, left_pad),
+            # 1 BOS + 32 left pad + 6 delay = 39
+            encode_streaming_tokens=lambda: [PAD] * 32 + [0] * 6,
+        )
+        self.instruct = SimpleNamespace(
+            start=lambda: [1],
+            audio_encoder=audio_encoder,
+        )
+        self.tokenizer = SimpleNamespace(
+            is_special=lambda token: has_boundary,
+            get_special_token=lambda token: BOUNDARY,
+        )
+
+    def decode(self, token_ids, skip_special_tokens=False):
+        return _decode(list(token_ids))
+
+
+@pytest.fixture
+def fake_tokenizer(monkeypatch):
+    def _install(**kwargs):
+        tokenizer = _FakeTokenizer(**kwargs)
+        monkeypatch.setattr(
+            voxtral_realtime, "cached_tokenizer_from_config", lambda _: tokenizer
+        )
+        return tokenizer
+
+    return _install
+
+
+def test_offset_frames_tracks_the_pad_audio(fake_tokenizer):
+    """The left pad is audio; the delay tokens are not.
+
+    Subtracting only the delay - as the issue's formula does - leaves the
+    32-frame left pad inside the prompt length and puts every timestamp
+    2.56 s late.
+    """
+    fake_tokenizer()
+    timestamper = VoxtralRealtimeGeneration.get_realtime_segment_timestamper(
+        SimpleNamespace(model="fake-model")
+    )
+    assert timestamper._offset_frames == 1
+    assert timestamper.process_token_ids([BOUNDARY, 1, BOUNDARY]) == [("Mary", 0.08)]
+
+
+def test_pad_audio_diverging_from_pad_tokens_fails_loud(fake_tokenizer):
+    """Never silently keep an offset the pad audio no longer justifies."""
+    fake_tokenizer(n_pad_audio_frames=38)
+    with pytest.raises(ValueError, match="38 frames"):
+        VoxtralRealtimeGeneration.get_realtime_segment_timestamper(
+            SimpleNamespace(model="fake-model")
+        )
+
+
+def test_missing_boundary_token_fails_loud(fake_tokenizer):
+    fake_tokenizer(has_boundary=False)
+    with pytest.raises(ValueError, match=re.escape(SpecialTokens.streaming_word.value)):
+        VoxtralRealtimeGeneration.get_realtime_segment_timestamper(
+            SimpleNamespace(model="fake-model")
+        )
+
+
+@pytest.mark.parametrize(
+    "key", ["timestamp_granularities", "timestamp_granularities[]"]
+)
+def test_session_update_accepts_both_granularity_spellings(key):
+    """`POST /v1/audio/transcriptions` uses the bracketed form."""
+    session = SessionUpdate(
+        **{"type": "session.update", "model": "m", key: ["segment"]}
+    )
+    assert session.timestamp_granularities == ["segment"]
+
+
+class _FakeWebSocket:
+    def __init__(self):
+        self.sent: list[dict] = []
+
+    async def send_text(self, data: str) -> None:
+        self.sent.append(json.loads(data))
+
+
+def _connection(
+    supports: bool,
+    stream_interval: int = 1,
+    outputs: list[list[int]] | None = None,
+) -> RealtimeConnection:
+    """A connection over a fake engine that replays ``outputs`` as deltas."""
+    model_cls = SimpleNamespace(
+        supports_realtime_segment_timestamps=supports,
+        get_realtime_segment_timestamper=lambda _: _timestamper(),
+        realtime_max_tokens=1,
+    )
+
+    async def generate(prompt=None, sampling_params=None, request_id=None):
+        for index, token_ids in enumerate(outputs or []):
+            yield SimpleNamespace(
+                prompt_token_ids=[0] * 39 if index == 0 else None,
+                outputs=[SimpleNamespace(text=_decode(token_ids), token_ids=token_ids)],
+            )
+
+    serving = SimpleNamespace(
+        model_cls=model_cls,
+        model_config=SimpleNamespace(model="fake-model"),
+        engine_client=SimpleNamespace(
+            generate=generate,
+            vllm_config=SimpleNamespace(
+                scheduler_config=SimpleNamespace(stream_interval=stream_interval)
+            ),
+        ),
+        transcribe_realtime=lambda audio_stream, input_stream: None,
+        _is_model_supported=lambda model: model == "fake-model",
+    )
+    return RealtimeConnection(_FakeWebSocket(), serving)
+
+
+@pytest.mark.asyncio
+async def test_opt_in_is_acknowledged():
+    conn = _connection(supports=True)
+    await conn.handle_event(
+        {
+            "type": "session.update",
+            "model": "fake-model",
+            "timestamp_granularities": ["segment"],
+        }
+    )
+    ack = conn.websocket.sent[-1]
+    assert ack["type"] == "session.updated"
+    assert ack["timestamp_granularities"] == ["segment"]
+    assert conn._segment_timestamps
+
+    # A later plain update turns it back off, rather than accumulating.
+    await conn.handle_event({"type": "session.update", "model": "fake-model"})
+    assert conn.websocket.sent[-1]["timestamp_granularities"] == []
+    assert not conn._segment_timestamps
+
+
+@pytest.mark.asyncio
+async def test_unsupported_model_rejects_and_explains_at_commit():
+    """Covers realtime models without a token-per-frame lockstep."""
+    conn = _connection(supports=False)
+    await conn.handle_event(
+        {
+            "type": "session.update",
+            "model": "fake-model",
+            "timestamp_granularities": ["segment"],
+        }
+    )
+    error = conn.websocket.sent[-1]
+    assert error["code"] == "unsupported_timestamp_granularity"
+    assert not conn._is_model_validated
+    assert not conn._segment_timestamps
+
+    await conn.handle_event({"type": "input_audio_buffer.commit"})
+    commit_error = conn.websocket.sent[-1]
+    assert commit_error["code"] == "model_not_validated"
+    assert "does not support segment timestamps" in commit_error["error"]
+
+
+@pytest.mark.asyncio
+async def test_word_granularity_is_rejected():
+    conn = _connection(supports=True)
+    await conn.handle_event(
+        {
+            "type": "session.update",
+            "model": "fake-model",
+            "timestamp_granularities": ["word"],
+        }
+    )
+    assert conn.websocket.sent[-1]["code"] == "invalid_timestamp_granularity"
+
+
+@pytest.mark.asyncio
+async def test_model_advertising_support_without_implementing_it_is_rejected():
+    """Rejected at negotiation, not unwound to the connection loop.
+
+    The `SupportsRealtime` default raises a bare `NotImplementedError`, and a
+    duck-typed out-of-tree model raises `AttributeError`. Either escaping
+    would leave the session configured behind the client's back.
+    """
+
+    def _unimplemented(_):
+        raise NotImplementedError
+
+    conn = _connection(supports=True)
+    conn.serving.model_cls.get_realtime_segment_timestamper = _unimplemented
+    await conn.handle_event(
+        {
+            "type": "session.update",
+            "model": "fake-model",
+            "timestamp_granularities": ["segment"],
+        }
+    )
+
+    error = conn.websocket.sent[-1]
+    assert error["code"] == "segment_timestamps_unavailable"
+    assert "cannot build a segment timestamper" in error["error"]
+    assert not conn._is_model_validated
+    assert not conn._segment_timestamps
+
+
+@pytest.mark.asyncio
+async def test_batched_streaming_is_rejected():
+    """`--stream-interval > 1` stalls the realtime lockstep entirely.
+
+    Rejected at negotiation so the opt-in fails loud instead of hanging. The
+    server is unusable for realtime either way, which is why the error must
+    not offer dropping the opt-in as a workaround.
+    """
+    conn = _connection(supports=True, stream_interval=4)
+    await conn.handle_event(
+        {
+            "type": "session.update",
+            "model": "fake-model",
+            "timestamp_granularities": ["segment"],
+        }
+    )
+    error = conn.websocket.sent[-1]
+    assert error["code"] == "unsupported_timestamp_granularity"
+    assert "stream-interval" in error["error"]
+
+    # The gate is scoped to the opt-in: a plain session.update on the same
+    # server is still accepted, exactly as before this feature.
+    conn = _connection(supports=True, stream_interval=4)
+    await conn.handle_event({"type": "session.update", "model": "fake-model"})
+    assert conn.websocket.sent[-1]["type"] == "session.updated"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("opted_in", [True, False])
+async def test_generation_streams_segments_and_flushes_the_trailing_one(opted_in):
+    """The delta/done wiring, which the unit tests above cannot reach.
+
+    ``done`` must repeat what the deltas already sent, in order, and add
+    exactly the trailing segment that generation ended before any delta could
+    carry - no duplicate, no drop.
+    """
+    conn = _connection(
+        supports=True, outputs=[[BOUNDARY], [1], [2], [BOUNDARY], [4], [5], [6]]
+    )
+    conn._is_connected = True
+
+    update: dict = {"type": "session.update", "model": "fake-model"}
+    if opted_in:
+        update["timestamp_granularities"] = ["segment"]
+    await conn.handle_event(update)
+
+    await conn.start_generation()
+    await conn.generation_task
+
+    events = [e for e in conn.websocket.sent if e["type"].startswith("transcription")]
+    deltas, done = events[:-1], events[-1]
+    assert done["type"] == "transcription.done"
+    assert done["text"] == "Mary had little lamb"
+
+    if not opted_in:
+        assert all("segments" not in event for event in events)
+        return
+
+    streamed = [segment for delta in deltas for segment in delta["segments"]]
+    assert streamed == [{"text": "Mary had", "end": 0.08}]
+    assert done["segments"] == streamed + [{"text": " little lamb", "end": 0.32}]
+
+    # The segment rides the delta *after* the text it describes, and that
+    # delta carries no text of its own.
+    assert deltas[3]["delta"] == ""
+    assert "".join(s["text"] for s in done["segments"]) == done["text"]
+
+
+def test_transcription_done_keys_unchanged_without_opt_in():
+    """A client that did not opt in must see byte-identical payloads.
+
+    ``segments`` defaults to ``None`` and would otherwise serialize as
+    ``"segments": null``, adding a key to every event. Removing or adding
+    keys breaks statically typed clients.
+    """
+    done = TranscriptionDone(text=" Mary had a little lamb", usage=None)
+    payload = json.loads(done.model_dump_json(exclude={"segments"}))
+    assert set(payload) == {"type", "text", "usage"}
+
+    opted_in = TranscriptionDone(
+        text=" Mary had a little lamb",
+        usage=None,
+        segments=[TranscriptionSegmentTimestamp(text="Mary", end=0.08)],
+    )
+    assert json.loads(opted_in.model_dump_json())["segments"] == [
+        {"text": "Mary", "end": 0.08}
+    ]

--- a/vllm/entrypoints/speech_to_text/realtime/connection.py
+++ b/vllm/entrypoints/speech_to_text/realtime/connection.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 import numpy as np
 import pybase64 as base64
 from fastapi import WebSocket
+from pydantic import ValidationError
 from starlette.websockets import WebSocketDisconnect
 
 from vllm import envs
@@ -17,14 +18,18 @@ from vllm.entrypoints.openai.engine.protocol import ErrorResponse, UsageInfo
 from vllm.entrypoints.serve.utils.api_utils import sanitize_message
 from vllm.exceptions import VLLMValidationError
 from vllm.logger import init_logger
+from vllm.model_executor.models.interfaces import RealtimeSegmentTimestamper
 
 from .protocol import (
     ErrorEvent,
     InputAudioBufferAppend,
     InputAudioBufferCommit,
     SessionCreated,
+    SessionUpdate,
+    SessionUpdated,
     TranscriptionDelta,
     TranscriptionDone,
+    TranscriptionSegmentTimestamp,
 )
 from .serving import OpenAIServingRealtime
 
@@ -51,6 +56,8 @@ class RealtimeConnection:
 
         self._is_connected = False
         self._is_model_validated = False
+        self._segment_timestamps = False
+        self._validation_error: str | None = None
 
         self._max_audio_filesize_mb = envs.VLLM_MAX_AUDIO_CLIP_FILESIZE_MB
 
@@ -104,15 +111,7 @@ class RealtimeConnection:
         event_type = event.get("type")
         if event_type == "session.update":
             logger.debug("Session updated: %s", event)
-            model = event.get("model")
-            if model is None:
-                await self.send_error("Missing required field: model", "invalid_event")
-                return
-            err = self._check_model(model)
-            if err is not None:
-                await self.send_error(err.error.message, "model_not_found")
-                return
-            self._is_model_validated = True
+            await self._handle_session_update(event)
         elif event_type == "input_audio_buffer.append":
             append_event = InputAudioBufferAppend(**event)
             try:
@@ -141,7 +140,7 @@ class RealtimeConnection:
 
         elif event_type == "input_audio_buffer.commit":
             if not self._is_model_validated:
-                err_msg = (
+                err_msg = self._validation_error or (
                     "Model not validated. Make sure to validate the"
                     " model by sending a session.update event."
                 )
@@ -159,6 +158,112 @@ class RealtimeConnection:
                 await self.start_generation()
         else:
             await self.send_error(f"Unknown event type: {event_type}", "unknown_event")
+
+    async def _reject_session_update(self, message: str, code: str) -> None:
+        """Refuse a session.update and remember why.
+
+        The session is left unconfigured so a later commit cannot run under a
+        configuration the client did not get, and reports this reason instead
+        of the generic "you never sent session.update".
+        """
+        self._is_model_validated = False
+        self._validation_error = message
+        await self.send_error(message, code)
+
+    def _check_segment_timestamps(self) -> str | None:
+        """Return why segment timestamps cannot be enabled, or None."""
+        model_cls = self.serving.model_cls
+        # `supports_realtime` is itself a duck-check, so an out-of-tree
+        # realtime model need not define this attribute at all.
+        if not getattr(model_cls, "supports_realtime_segment_timestamps", False):
+            return (
+                f"The model `{self.serving.model_config.model}` does not support "
+                "segment timestamps. Omit `timestamp_granularities` from "
+                "session.update, or serve a model that supports them."
+            )
+
+        vllm_config = getattr(self.serving.engine_client, "vllm_config", None)
+        scheduler_config = getattr(vllm_config, "scheduler_config", None)
+        stream_interval = getattr(scheduler_config, "stream_interval", 1)
+        if stream_interval > 1:
+            return (
+                f"Segment timestamps require `--stream-interval 1`, but this "
+                f"server runs with {stream_interval}. Batched streaming stalls "
+                "realtime transcription outright, because the next token "
+                "cannot be generated until the previous one is streamed back, "
+                "so omitting `timestamp_granularities` will not help. Restart "
+                "the server with `--stream-interval 1`."
+            )
+        return None
+
+    async def _handle_session_update(self, event: dict) -> None:
+        """Validate the model and negotiate optional features."""
+        if event.get("model") is None:
+            await self._reject_session_update(
+                "Missing required field: model", "invalid_event"
+            )
+            return
+
+        try:
+            session = SessionUpdate(**event)
+        except ValidationError as e:
+            if any("timestamp_granularities" in str(err["loc"]) for err in e.errors()):
+                await self._reject_session_update(
+                    "Only `segment` is a valid timestamp granularity on "
+                    "/v1/realtime. `word` granularity is available on "
+                    "POST /v1/audio/transcriptions.",
+                    "invalid_timestamp_granularity",
+                )
+            else:
+                await self._reject_session_update(
+                    sanitize_message(str(e)), "invalid_event"
+                )
+            return
+
+        err = self._check_model(session.model)
+        if err is not None:
+            await self._reject_session_update(err.error.message, "model_not_found")
+            return
+
+        # Assign rather than accumulate, so a later plain session.update turns
+        # the feature back off.
+        want_segments = "segment" in session.timestamp_granularities
+        if want_segments:
+            if (reason := self._check_segment_timestamps()) is not None:
+                await self._reject_session_update(
+                    reason, "unsupported_timestamp_granularity"
+                )
+                return
+            try:
+                # Built and discarded: surfaces a checkpoint whose tokenizer
+                # cannot mark segments now, rather than mid-utterance. A model
+                # advertising support without implementing it lands here too,
+                # so catch that rather than unwinding to the connection loop
+                # with the session left half-configured.
+                self.serving.model_cls.get_realtime_segment_timestamper(
+                    self.serving.model_config
+                )
+            except (ValueError, NotImplementedError, AttributeError) as e:
+                # `raise NotImplementedError` carries no message of its own.
+                reason = sanitize_message(str(e)) or (
+                    f"The model `{self.serving.model_config.model}` cannot "
+                    "build a segment timestamper."
+                )
+                await self._reject_session_update(
+                    reason, "segment_timestamps_unavailable"
+                )
+                return
+
+        self._segment_timestamps = want_segments
+        self._is_model_validated = True
+        self._validation_error = None
+
+        await self.send(
+            SessionUpdated(
+                model=session.model,
+                timestamp_granularities=["segment"] if want_segments else [],
+            )
+        )
 
     async def audio_stream_generator(self) -> AsyncGenerator[np.ndarray, None]:
         """Generator that yields audio chunks from the queue."""
@@ -183,15 +288,28 @@ class RealtimeConnection:
             audio_stream, input_stream
         )
 
+        # One timestamper per utterance: each commit starts a new engine
+        # request whose token index restarts at 0. Resolving it here also
+        # freezes the event schema for this utterance, so a session.update
+        # arriving mid-generation cannot change it.
+        segment_timestamper: RealtimeSegmentTimestamper | None = None
+        if self._segment_timestamps:
+            segment_timestamper = (
+                self.serving.model_cls.get_realtime_segment_timestamper(
+                    self.serving.model_config
+                )
+            )
+
         # Start generation task
         self.generation_task = asyncio.create_task(
-            self._run_generation(streaming_input_gen, input_stream)
+            self._run_generation(streaming_input_gen, input_stream, segment_timestamper)
         )
 
     async def _run_generation(
         self,
         streaming_input_gen: AsyncGenerator,
         input_stream: asyncio.Queue[list[int]],
+        segment_timestamper: RealtimeSegmentTimestamper | None = None,
     ):
         """Run the generation and stream results back to the client.
 
@@ -202,12 +320,22 @@ class RealtimeConnection:
         4. Sends final transcription.done event with usage stats
         5. Feeds generated token IDs back to input_stream for next iteration
         6. Cleans up the audio queue
+
+        When ``segment_timestamper`` is set, every event also carries the
+        segments closed so far. The trailing segment is only known once
+        generation ends, so it appears in ``transcription.done`` alone. On the
+        exception path no ``done`` is sent, so no flush happens either and the
+        trailing segment is dropped along with the rest of the utterance.
         """
         request_id = f"rt-{self.connection_id}-{uuid4()}"
         full_text = ""
 
         prompt_token_ids_len: int = 0
         completion_tokens_len: int = 0
+        all_segments: list[TranscriptionSegmentTimestamp] = []
+        # Omit the field entirely for clients that did not opt in, so their
+        # payloads stay byte-identical.
+        exclude = None if segment_timestamper is not None else {"segments"}
 
         try:
             # Create sampling params
@@ -232,17 +360,31 @@ class RealtimeConnection:
             # Stream results back to client as they're generated
             async for output in result_gen:
                 if output.outputs and len(output.outputs) > 0:
+                    completion = output.outputs[0]
                     if not prompt_token_ids_len and output.prompt_token_ids:
                         prompt_token_ids_len = len(output.prompt_token_ids)
 
-                    delta = output.outputs[0].text
+                    delta = completion.text
                     full_text += delta
 
-                    # append output to input
-                    input_stream.put_nowait(list(output.outputs[0].token_ids))
-                    await self.send(TranscriptionDelta(delta=delta))
+                    segments: list[TranscriptionSegmentTimestamp] | None = None
+                    if segment_timestamper is not None:
+                        segments = [
+                            TranscriptionSegmentTimestamp(text=text, end=end)
+                            for text, end in segment_timestamper.process_token_ids(
+                                completion.token_ids
+                            )
+                        ]
+                        all_segments.extend(segments)
 
-                    completion_tokens_len += len(output.outputs[0].token_ids)
+                    # append output to input
+                    input_stream.put_nowait(list(completion.token_ids))
+                    await self.send(
+                        TranscriptionDelta(delta=delta, segments=segments),
+                        exclude=exclude,
+                    )
+
+                    completion_tokens_len += len(completion.token_ids)
 
                 if not self._is_connected:
                     # finish because websocket connection was killed
@@ -254,8 +396,21 @@ class RealtimeConnection:
                 total_tokens=prompt_token_ids_len + completion_tokens_len,
             )
 
+            if segment_timestamper is not None:
+                all_segments.extend(
+                    TranscriptionSegmentTimestamp(text=text, end=end)
+                    for text, end in segment_timestamper.flush()
+                )
+
             # Send final completion event
-            await self.send(TranscriptionDone(text=full_text, usage=usage))
+            await self.send(
+                TranscriptionDone(
+                    text=full_text,
+                    usage=usage,
+                    segments=all_segments if segment_timestamper is not None else None,
+                ),
+                exclude=exclude,
+            )
 
             # Clear queue for next utterance
             while not self.audio_queue.empty():
@@ -266,10 +421,12 @@ class RealtimeConnection:
             await self.send_error(sanitize_message(str(e)), "processing_error")
 
     async def send(
-        self, event: SessionCreated | TranscriptionDelta | TranscriptionDone
+        self,
+        event: SessionCreated | SessionUpdated | TranscriptionDelta | TranscriptionDone,
+        exclude: set[str] | None = None,
     ):
         """Send event to client."""
-        data = event.model_dump_json()
+        data = event.model_dump_json(exclude=exclude)
         await self.websocket.send_text(data)
 
     async def send_error(self, message: str, code: str | None = None):

--- a/vllm/entrypoints/speech_to_text/realtime/protocol.py
+++ b/vllm/entrypoints/speech_to_text/realtime/protocol.py
@@ -4,7 +4,7 @@
 import time
 from typing import Literal
 
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 from vllm.entrypoints.openai.engine.protocol import (
     OpenAIBaseModel,
@@ -29,14 +29,24 @@ class InputAudioBufferCommit(OpenAIBaseModel):
     final: bool = False
 
 
-# Server -> Client Events
 class SessionUpdate(OpenAIBaseModel):
     """Configure session parameters"""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     type: Literal["session.update"] = "session.update"
     model: str | None = None
+    timestamp_granularities: list[Literal["segment"]] = Field(
+        alias="timestamp_granularities[]", default_factory=list
+    )
+    """Timestamp granularities to populate on transcription events.
+
+    Only `segment` is supported here; `word` timestamps are available on
+    `POST /v1/audio/transcriptions` but not on this endpoint.
+    """
 
 
+# Server -> Client Events
 class SessionCreated(OpenAIBaseModel):
     """Connection established notification"""
 
@@ -45,11 +55,43 @@ class SessionCreated(OpenAIBaseModel):
     created: int = Field(default_factory=lambda: int(time.time()))
 
 
+class SessionUpdated(OpenAIBaseModel):
+    """Acknowledgement echoing the configuration that took effect."""
+
+    type: Literal["session.updated"] = "session.updated"
+    model: str | None = None
+    timestamp_granularities: list[str] = Field(default_factory=list)
+
+
+class TranscriptionSegmentTimestamp(OpenAIBaseModel):
+    """A transcribed emission group and its end time within the utterance.
+
+    One entry per boundary marker emitted by the model; words the model chose
+    to emit together share one entry. End only: the model marks where a group
+    of audio ends, not where it starts. Granularity is one audio frame (80 ms
+    for Voxtral realtime). The clock restarts on every non-final
+    `input_audio_buffer.commit`.
+    """
+
+    text: str
+    """The transcribed text of the emission group."""
+
+    end: float
+    """End time of the group in seconds, relative to the current utterance."""
+
+
 class TranscriptionDelta(OpenAIBaseModel):
     """Incremental transcription text"""
 
     type: Literal["transcription.delta"] = "transcription.delta"
     delta: str  # Incremental text
+    segments: list[TranscriptionSegmentTimestamp] | None = None
+    """Segments closed by this delta, when segment timestamps are enabled.
+
+    Because the boundary marker itself decodes to no text, the segments
+    describing a piece of text arrive on the delta *after* the one that
+    carried it, and that delta's `delta` is the empty string.
+    """
 
 
 class TranscriptionDone(OpenAIBaseModel):
@@ -58,6 +100,8 @@ class TranscriptionDone(OpenAIBaseModel):
     type: Literal["transcription.done"] = "transcription.done"
     text: str  # Complete transcription
     usage: UsageInfo | None = None
+    segments: list[TranscriptionSegmentTimestamp] | None = None
+    """Every segment of the utterance, repeating what the deltas already sent."""
 
 
 class ErrorEvent(OpenAIBaseModel):

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -89,6 +89,23 @@ class StreamingTranscriptionPostProcessor:
         return text_delta
 
 
+class RealtimeSegmentTimestamper:
+    """Per-utterance mapper from realtime output tokens to segment end times.
+
+    A segment is one *emission group*: the run of text the model commits at a
+    single boundary marker. Instances are stateful and must not be shared
+    across utterances, since the token index restarts at 0 on every commit.
+    """
+
+    def process_token_ids(self, token_ids: Sequence[int]) -> list[tuple[str, float]]:
+        """Return ``(text, end_seconds)`` for segments closed by this delta."""
+        return []
+
+    def flush(self) -> list[tuple[str, float]]:
+        """Return the trailing segment, if it was not closed by a boundary."""
+        return []
+
+
 def _require_is_multimodal(is_multimodal: Tensor | None) -> Tensor:
     """
     A helper function to be used in the context of
@@ -1100,6 +1117,12 @@ class SupportsRealtime(Protocol):
     """Maximum tokens to generate per streaming audio segment.
     Override in subclasses based on the model's expected output length."""
 
+    supports_realtime_segment_timestamps: ClassVar[bool] = False
+    """Enables opt-in segment timestamps on `/v1/realtime` events.
+
+    Only meaningful for models that emit one output token per audio frame, so
+    that a token index maps back to a position in the audio."""
+
     @classmethod
     async def buffer_realtime_audio(
         cls,
@@ -1107,6 +1130,21 @@ class SupportsRealtime(Protocol):
         input_stream: asyncio.Queue[list[int]],
         model_config: "ModelConfig",
     ) -> AsyncGenerator["PromptType", None]: ...
+
+    @classmethod
+    def get_realtime_segment_timestamper(
+        cls, model_config: "ModelConfig"
+    ) -> RealtimeSegmentTimestamper:
+        """Build a timestamper for one utterance.
+
+        Only models that set ``supports_realtime_segment_timestamps`` must
+        override this method.
+
+        Raises:
+            ValueError: The checkpoint cannot support segment timestamps, e.g.
+                its tokenizer has no boundary marker.
+        """
+        raise NotImplementedError
 
 
 @overload

--- a/vllm/model_executor/models/voxtral_realtime.py
+++ b/vllm/model_executor/models/voxtral_realtime.py
@@ -3,7 +3,14 @@
 
 import asyncio
 import math
-from collections.abc import AsyncGenerator, Iterable, Iterator, Mapping
+from collections.abc import (
+    AsyncGenerator,
+    Callable,
+    Iterable,
+    Iterator,
+    Mapping,
+    Sequence,
+)
 
 import numpy as np
 import torch
@@ -12,6 +19,7 @@ from mistral_common.protocol.transcription.request import (
     TranscriptionRequest,
 )
 from mistral_common.tokens.tokenizers.audio import Audio, AudioConfig
+from mistral_common.tokens.tokenizers.base import SpecialTokens
 
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import ModelConfig, SpeechToTextConfig, VllmConfig
@@ -19,7 +27,11 @@ from vllm.config.speech_to_text import SpeechToTextParams
 from vllm.engine.protocol import StreamingInput
 from vllm.inputs import PromptType, TokensPrompt
 from vllm.logger import init_logger
-from vllm.model_executor.models.interfaces import MultiModalEmbeddings, SupportsRealtime
+from vllm.model_executor.models.interfaces import (
+    MultiModalEmbeddings,
+    RealtimeSegmentTimestamper,
+    SupportsRealtime,
+)
 from vllm.model_executor.models.voxtral import (
     VoxtralDummyInputsBuilder,
     VoxtralForConditionalGeneration,
@@ -125,6 +137,74 @@ def _expand_tensor(input_tensor: torch.Tensor, scaling: int) -> torch.Tensor:
     return (base.unsqueeze(1) + offsets).view(-1)
 
 
+def _realtime_prompt_tokens(tokenizer) -> list[int]:
+    """Streaming prefix fed before any real audio: BOS + left pad + delay."""
+    return (
+        tokenizer.instruct.start()
+        + tokenizer.instruct.audio_encoder.encode_streaming_tokens()
+    )
+
+
+class VoxtralRealtimeSegmentTimestamper(RealtimeSegmentTimestamper):
+    """Maps `[STREAMING_WORD]` positions in the output stream to audio time.
+
+    Voxtral realtime generates exactly one token per 80 ms audio frame, so the
+    index of an output token is an index into the audio. `[STREAMING_WORD]`
+    marks the *onset* of a text emission and is followed by that emission's
+    subwords (arXiv 2602.11298 section 3.1). So a boundary closes the segment
+    accumulated since the previous boundary, timed at the previous boundary's
+    frame.
+
+    That frame is not itself the end of the audio: the marker is emitted once
+    the group has been observed *and* the target delay has elapsed, so the end
+    time is `n_delay` frames earlier. `offset_frames` carries that subtraction
+    - it is not a constant to be simplified away.
+    """
+
+    def __init__(
+        self,
+        boundary_token_id: int,
+        frame_duration_ms: float,
+        offset_frames: int,
+        decode: Callable[[list[int]], str],
+    ) -> None:
+        self._boundary_token_id = boundary_token_id
+        self._frame_duration_ms = frame_duration_ms
+        self._offset_frames = offset_frames
+        self._decode = decode
+
+        self._index = 0
+        self._pending_ids: list[int] = []
+        self._pending_index: int | None = None
+
+    def _end_s(self, index: int) -> float:
+        return (self._offset_frames + index) * self._frame_duration_ms / 1000
+
+    def _close_pending(self) -> list[tuple[str, float]]:
+        if not self._pending_ids or self._pending_index is None:
+            return []
+        text = self._decode(self._pending_ids)
+        self._pending_ids = []
+        if not text:
+            return []
+        return [(text, self._end_s(self._pending_index))]
+
+    def process_token_ids(self, token_ids: Sequence[int]) -> list[tuple[str, float]]:
+        segments: list[tuple[str, float]] = []
+        for token_id in token_ids:
+            if token_id == self._boundary_token_id:
+                segments.extend(self._close_pending())
+                self._pending_index = self._index
+            elif self._pending_index is not None:
+                # Tokens before the first boundary belong to no segment.
+                self._pending_ids.append(token_id)
+            self._index += 1
+        return segments
+
+    def flush(self) -> list[tuple[str, float]]:
+        return self._close_pending()
+
+
 class VoxtralRealtimeBuffer:
     def __init__(self, config: AudioConfig, prompt_tokens: list[int]) -> None:
         self._config = config
@@ -214,6 +294,7 @@ class VoxtralRealtimeGeneration(VoxtralForConditionalGeneration, SupportsRealtim
     # transformers' currently has limited support for MistralCommon backend
     # and cached_get_processor. Let's skip until fixed
     skip_warmup_audio_preprocessing = True
+    supports_realtime_segment_timestamps = True
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__(vllm_config=vllm_config, prefix=prefix)
@@ -229,6 +310,54 @@ class VoxtralRealtimeGeneration(VoxtralForConditionalGeneration, SupportsRealtim
         audio_config = self.tokenizer.instruct.audio_encoder.audio_config
         self.n_delay_tokens = audio_config.get_num_delay_tokens()
 
+    @classmethod
+    def get_realtime_segment_timestamper(
+        cls, model_config: ModelConfig
+    ) -> RealtimeSegmentTimestamper:
+        tokenizer = cached_tokenizer_from_config(model_config)
+        audio_encoder = tokenizer.instruct.audio_encoder
+        config = audio_encoder.audio_config
+
+        if not tokenizer.tokenizer.is_special(SpecialTokens.streaming_word):
+            raise ValueError(
+                f"Tokenizer of `{model_config.model}` has no "
+                f"`{SpecialTokens.streaming_word.value}` token, so segment "
+                "boundaries cannot be located in the output stream."
+            )
+        boundary_token_id = tokenizer.tokenizer.get_special_token(
+            SpecialTokens.streaming_word
+        )
+
+        # The left pad is audio, the delay tokens are not, so the token index
+        # of a generated token leads its content frame by
+        # `len(prompt) - n_pad_frames - n_delay`. Derive the pad from the pad
+        # audio rather than from `n_left_pad_tokens`: mistral-common builds one
+        # from the other today, and a change that decoupled them would silently
+        # shift every timestamp by the pad duration.
+        left_pad, _ = audio_encoder.get_padding_audio()
+        n_pad_frames = len(left_pad.audio_array) // config.raw_audio_length_per_tok
+        if n_pad_frames != config.n_left_pad_tokens:
+            raise ValueError(
+                f"Left padding audio is {n_pad_frames} frames but the prompt "
+                f"reserves {config.n_left_pad_tokens} pad tokens. Realtime "
+                "segment timestamps would be misaligned."
+            )
+        offset_frames = (
+            len(_realtime_prompt_tokens(tokenizer))
+            - n_pad_frames
+            - config.get_num_delay_tokens()
+        )
+
+        def decode(token_ids: list[int]) -> str:
+            return tokenizer.decode(token_ids, skip_special_tokens=True)
+
+        return VoxtralRealtimeSegmentTimestamper(
+            boundary_token_id=boundary_token_id,
+            frame_duration_ms=1000 / config.frame_rate,
+            offset_frames=offset_frames,
+            decode=decode,
+        )
+
     # for realtime transcription
     @classmethod
     async def buffer_realtime_audio(
@@ -242,9 +371,7 @@ class VoxtralRealtimeGeneration(VoxtralForConditionalGeneration, SupportsRealtim
         config = audio_encoder.audio_config
 
         # Get prompt tokens (streaming prefix tokens) without encoding audio
-        prompt_tokens = (
-            tokenizer.instruct.start() + audio_encoder.encode_streaming_tokens()
-        )
+        prompt_tokens = _realtime_prompt_tokens(tokenizer)
 
         # Get left/right padding audio
         left_pad, right_pad = audio_encoder.get_padding_audio()


### PR DESCRIPTION
## Purpose

Relates to #39735. `/v1/realtime` streams transcription text with no timing, so clients doing diarization or subtitling have to guess word timing from message arrival.

Voxtral realtime emits one token per 80 ms frame, so a token's index is an index into the audio and `[STREAMING_WORD]` marks where an emission group ends. Clients opt in with `timestamp_granularities: ["segment"]` on `session.update` and get a `segments` array of `{text, end}` on `transcription.delta` and `transcription.done`.

```text
end_s(k) = (len(prompt_tokens) - n_pad_frames - n_delay + k) * 0.08
```

The left pad is audio and the delay tokens are not, so both come out of the prompt length; the formula proposed on the issue subtracts only the delay and lands every timestamp 2.56 s late.

Segments, not words: the model omits the marker for words sharing an emission frame, by design (arXiv 2602.11298 §3.1, §6.2), so `word` granularity is rejected at negotiation rather than approximated. The marker precedes its own group's subwords, so a boundary closes the segment before it.

Also adds the `session.updated` ack, and `supports_realtime_segment_timestamps` for model opt-in (Qwen3-ASR realtime inherits `False`). Clients that don't opt in see byte-identical payloads — the key is omitted, not `null`.

## Test Plan

```bash
.venv/bin/python -m pytest tests/entrypoints/speech_to_text/realtime/test_segment_timestamps.py -v
.venv/bin/python -m pytest tests/entrypoints/speech_to_text/realtime/test_realtime_validation.py -v  # needs GPU
pre-commit run --from-ref origin/main --to-ref HEAD
```

## Test Result

`test_segment_timestamps.py`: **26 passed** in 2.81s. pre-commit: all hooks pass.

`test_realtime_validation.py` not run locally — it spawns `vllm serve` and needs a GPU; my machine is an ARM Mac, so it fails with `FileNotFoundError: 'vllm'` before any assertion. Relying on CI's GPU lane.

No weights, kernels or sampling paths are touched, so existing output is unchanged; the payload-identity claim is asserted directly in the new tests.

---

Not a duplicate: `gh pr list --search "39735 in:body"` returns nothing, and no open Voxtral/realtime PR (#44364, #45833, #47615, #45022, #39229, #45697, #49658) touches timestamps or the realtime schema. AI assistance was used; I have reviewed every line, run the tests above, and can defend the design.
