### PR TITLE
[Doc] Troubleshooting: add a WSL2 section (pinned memory gates, lingering workers)

### DIFF
--- a/docs/usage/troubleshooting.md
+++ b/docs/usage/troubleshooting.md
@@ -369,6 +369,29 @@ export TRITON_PTXAS_PATH="${CUDA_HOME}/bin/ptxas"
 export PATH="${CUDA_HOME}/bin:$PATH"
 ```
 
+## Running under WSL2
+
+Two vLLM-specific behaviors under WSL2 (Windows Subsystem for Linux) are easy to
+miss:
+
+- **Pinned host memory is off by default, behind two separate gates.** If the
+  startup log says `Using 'pin_memory=False' as WSL is detected`, performance may
+  suffer. On CUDA, pinned memory is only usable on WSL2 kernels `>= 4.19.121`; on
+  older kernels it is unavailable and `VLLM_WSL2_ENABLE_PIN_MEMORY` has no effect,
+  so run `wsl --update` first. On a new enough kernel it is supported but still
+  disabled by default, so opt in explicitly with
+  `export VLLM_WSL2_ENABLE_PIN_MEMORY=1`.
+- **Worker processes can linger after shutdown.** After Ctrl+C the engine may
+  report a clean shutdown while worker processes keep holding the GPU and port,
+  so a restart fails with the address already in use. Clear them with
+  `pkill -f -9 vllm` (tracked in [#39093](https://github.com/vllm-project/vllm/issues/39093)).
+
+General WSL2 notes that also affect vLLM: a server bound to `0.0.0.0` is normally
+reachable from Windows at `localhost` only in mirrored networking mode (otherwise
+use the WSL VM address from `ip addr`); guest RAM and build parallelism are capped
+by `.wslconfig` (`memory=`) and `MAX_JOBS` respectively (see the installation
+guide for the build-memory note).
+
 ## Known Issues
 
 - In `v0.5.2`, `v0.5.3`, and `v0.5.3.post1`, there is a bug caused by [zmq](https://github.com/zeromq/pyzmq/issues/2000) , which can occasionally cause vLLM to hang depending on the machine configuration. The solution is to upgrade to the latest version of `vllm` to include the [fix](https://github.com/vllm-project/vllm/pull/6759).


### PR DESCRIPTION
## Purpose

Adds a short WSL2 section to the troubleshooting guide covering two
vLLM-specific behaviors that are currently undocumented, plus brief pointers to
the general WSL caveats that come up in vLLM reports (#31124, #49861, #41933,
#41619, #39093).

**Pinned host memory.** `VLLM_WSL2_ENABLE_PIN_MEMORY` is defined in
`vllm/envs.py` but appears nowhere in the docs, and the behavior behind it has
two separate gates that are easy to conflate. In
`CudaPlatformBase.is_pin_memory_available()`, pinned memory is refused outright
on WSL2 kernels below `4.19.121` — the environment variable has no effect there
and the fix is `wsl --update` — while on newer kernels it is supported but left
disabled by default, so it needs an explicit opt-in. A user who sees
`Using 'pin_memory=False' as WSL is detected` currently has no documented way to
tell which of the two situations they are in.

**Lingering workers after shutdown.** Reported in #39093: Ctrl+C prints a clean
shutdown while worker processes keep holding the GPU and port, so the next start
fails with the address already in use. The section records `pkill -f -9 vllm` as
the workaround and links the open issue rather than presenting it as intended
behavior.

The closing paragraph is deliberately brief: mirrored networking for reaching a
`0.0.0.0` server from Windows, and `.wslconfig` `memory=` / `MAX_JOBS` limiting
guest RAM and build parallelism.

Docs-only; no code or behavior changes.

## Test Plan

- `pre-commit run --files docs/usage/troubleshooting.md`.
- Claims checked against the source on this branch rather than from memory: the
  `4.19.121` gate and the default-off behavior are read from
  `vllm/platforms/cuda.py::is_pin_memory_available`, and the env var default
  from `vllm/envs.py`.

## Test Result

`pre-commit` passes on the changed file (markdownlint Passed; code hooks report
no files to check, as expected for a docs-only change).

---

This PR was developed with AI assistance (Claude); I reviewed, adapted, and
verified the change myself.
