### PR TITLE
[Doc] Align MkDocs TOC slugify with markdownlint

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -143,6 +143,9 @@ markdown_extensions:
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
   # For in page [TOC] (not sidebar)
   - toc:
+      slugify: !!python/object/apply:pymdownx.slugs.slugify
+        kwds:
+          case: lower
       permalink: true
   # For math rendering
   - pymdownx.arithmatex:

--- a/vllm/entrypoints/cli/benchmark/mm_processor.py
+++ b/vllm/entrypoints/cli/benchmark/mm_processor.py
@@ -51,7 +51,7 @@ class BenchmarkMMProcessorSubcommand(BenchmarkSubcommandBase):
     (default: p99) and `--output-json` to save results.
 
     For more examples (HF datasets, warmup, JSON output), see the
-    [multimodal processor benchmark guide](https://docs.vllm.ai/en/latest/benchmarking/cli/#multimodal-processor-benchmark).
+    [multimodal processor benchmark guide](https://docs.vllm.ai/en/latest/benchmarking/cli/#-multimodal-processor-benchmark).
     """
 
     name = "mm-processor"


### PR DESCRIPTION
## Purpose

Fixes #49662.

This PR aligns MkDocs' in-page TOC slug generation with the PyMdown slugifier already used elsewhere in the docs configuration. This makes rendered heading anchors match the anchor style validated by markdownlint MD051.

It also updates the generated CLI docs source link for the multimodal processor benchmark guide, since the heading contains an emoji and its rendered anchor changes under the aligned slugifier.

This PR was prepared with assistance from OpenAI Codex. I reviewed the changed lines and validation results.

## Test Plan

- Run vLLM pre-commit hooks on the staged changes.
- Run markdownlint on the docs files that exposed the slug mismatch.
- Run ruff on the touched Python file.
- Run a clean MkDocs build with API autonav excluded for local CPU-friendly docs validation.

## Test Result

- `.venv/bin/pre-commit run`
  - Passed
- `npx markdownlint-cli2@0.21.0 docs/design/fusions.md docs/features/speculative_decoding/draft_model.md docs/benchmarking/cli.md`
  - Passed: `Summary: 0 error(s)`
- `.venv/bin/ruff check vllm/entrypoints/cli/benchmark/mm_processor.py`
  - Passed: `All checks passed!`
- `API_AUTONAV_EXCLUDE=vllm .venv/bin/mkdocs build --site-dir /private/tmp/vllm-mkdocs-site-clean`
  - Passed: docs build completed successfully.
  - The issue-specific broken-anchor warnings are gone.
  - Four CPU installation anchor warnings remain and were pre-existing/unrelated to this change.
