### PR TITLE
docs(serving): note OpenAI client base_url for multi-model gateways

### DIFF
--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -309,6 +309,9 @@ Alternatively, you can use the `openai` Python package:
     print("Chat response:", chat_response)
     ```
 
+!!! tip
+    The same OpenAI Python client `base_url` pattern works with any OpenAI-compatible multi-model gateway when you are not self-hosting vLLM — for example [DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1`.
+
 ## On Attention Backends
 
 Currently, vLLM supports multiple backends for efficient Attention computation across different platforms and accelerator architectures. It automatically selects the most performant backend compatible with your system and model specifications.

--- a/docs/serving/online_serving/openai_compatible_server.md
+++ b/docs/serving/online_serving/openai_compatible_server.md
@@ -58,6 +58,8 @@ To call the server, in your preferred text editor, create a script that uses an 
     vLLM supports some parameters that are not supported by OpenAI, `top_k` for example.
     You can pass these parameters to vLLM using the OpenAI client in the `extra_body` parameter of your requests, i.e. `extra_body={"top_k": 50}` for `top_k`.
 
+> **Note:** The same client also works with OpenAI-compatible multi-model gateways when you are not self-hosting — for example [DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1`.
+
 !!! important
     By default, the server applies `generation_config.json` from the Hugging Face model repository if it exists. This means the default values of certain sampling parameters can be overridden by those recommended by the model creator.
 


### PR DESCRIPTION
## Summary

The OpenAI-compatible server docs already show the OpenAI Python client via `base_url`.

This PR adds a one-line tip that the same client pattern works with OpenAI-compatible multi-model gateways when not running vLLM locally, using [DaoXE](https://daoxe.com) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only — no runtime behavior changes.

## Test plan
- [ ] Serving docs render
- [ ] Local vLLM client example unchanged
- [ ] Tip is clearly optional

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>