### PR TITLE
[Spec Decode] perf: precompute draft-to-target index mapping in eagle/dflash models

### DIFF
--- a/vllm/model_executor/models/deepseek_eagle3.py
+++ b/vllm/model_executor/models/deepseek_eagle3.py
@@ -406,7 +406,9 @@ class Eagle3DeepseekV2ForCausalLM(LocalArgmaxMixin, DeepseekV2ForCausalLM):
         )
         loader.load_weights(model_weights.items())
         self._draft_targets.data = (
-            torch.arange(self.config.draft_vocab_size, device=self.draft_id_to_target_id.device)
+            torch.arange(
+                self.config.draft_vocab_size, device=self.draft_id_to_target_id.device
+            )
             + self.draft_id_to_target_id
         )
 

--- a/vllm/model_executor/models/deepseek_eagle3.py
+++ b/vllm/model_executor/models/deepseek_eagle3.py
@@ -318,6 +318,10 @@ class Eagle3DeepseekV2ForCausalLM(LocalArgmaxMixin, DeepseekV2ForCausalLM):
             torch.zeros(self.config.draft_vocab_size, dtype=torch.long),
             requires_grad=False,
         )
+        self._draft_targets = nn.Parameter(
+            torch.arange(self.config.draft_vocab_size, dtype=torch.long),
+            requires_grad=False,
+        )
 
     def embed_input_ids(
         self,
@@ -348,8 +352,6 @@ class Eagle3DeepseekV2ForCausalLM(LocalArgmaxMixin, DeepseekV2ForCausalLM):
             )
             return logits
 
-        base = torch.arange(self.config.draft_vocab_size, device=logits.device)
-        targets = base + self.draft_id_to_target_id
         logits_new = logits.new_full(
             (
                 logits.shape[0],
@@ -357,7 +359,7 @@ class Eagle3DeepseekV2ForCausalLM(LocalArgmaxMixin, DeepseekV2ForCausalLM):
             ),
             float("-inf"),
         )
-        logits_new[:, targets] = logits
+        logits_new[:, self._draft_targets] = logits
         return logits_new
 
     def combine_hidden_states(
@@ -391,7 +393,7 @@ class Eagle3DeepseekV2ForCausalLM(LocalArgmaxMixin, DeepseekV2ForCausalLM):
             model_weights[name] = loaded_weight
             process_eagle_weight(self, name)
 
-        skip_substrs = []
+        skip_substrs = ["_draft_targets"]
         if not includes_draft_id_mapping:
             skip_substrs.append("draft_id_to_target_id")
         if not includes_embed_tokens:
@@ -403,6 +405,10 @@ class Eagle3DeepseekV2ForCausalLM(LocalArgmaxMixin, DeepseekV2ForCausalLM):
             skip_substrs=skip_substrs,
         )
         loader.load_weights(model_weights.items())
+        self._draft_targets.data = (
+            torch.arange(self.config.draft_vocab_size, device=self.draft_id_to_target_id.device)
+            + self.draft_id_to_target_id
+        )
 
 
 # Aliases for compatibility

--- a/vllm/model_executor/models/llama_eagle3.py
+++ b/vllm/model_executor/models/llama_eagle3.py
@@ -305,6 +305,10 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
             torch.zeros(self.config.draft_vocab_size, dtype=torch.long),
             requires_grad=False,
         )
+        self._draft_targets = nn.Parameter(
+            torch.arange(self.config.draft_vocab_size, dtype=torch.long),
+            requires_grad=False,
+        )
 
         self.use_parallel_drafting = vllm_config.speculative_config.parallel_drafting
 
@@ -344,8 +348,6 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
             )
             return logits
 
-        base = torch.arange(self.config.draft_vocab_size, device=logits.device)
-        targets = base + self.draft_id_to_target_id
         logits_new = logits.new_full(
             (
                 logits.shape[0],
@@ -353,7 +355,7 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
             ),
             float("-inf"),
         )
-        logits_new[:, targets] = logits
+        logits_new[:, self._draft_targets] = logits
         return logits_new
 
     def combine_hidden_states(
@@ -415,7 +417,7 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
                 "Please provide mask_hidden in the weights."
             )
 
-        skip_substrs = ["mask_hidden"]
+        skip_substrs = ["mask_hidden", "_draft_targets"]
         if not includes_draft_id_mapping:
             skip_substrs.append("draft_id_to_target_id")
         if not includes_embed_tokens:
@@ -430,3 +432,7 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
             skip_substrs=skip_substrs,
         )
         loader.load_weights(model_weights.items())
+        self._draft_targets.data = (
+            torch.arange(self.config.draft_vocab_size, device=self.draft_id_to_target_id.device)
+            + self.draft_id_to_target_id
+        )

--- a/vllm/model_executor/models/llama_eagle3.py
+++ b/vllm/model_executor/models/llama_eagle3.py
@@ -433,6 +433,8 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
         )
         loader.load_weights(model_weights.items())
         self._draft_targets.data = (
-            torch.arange(self.config.draft_vocab_size, device=self.draft_id_to_target_id.device)
+            torch.arange(
+                self.config.draft_vocab_size, device=self.draft_id_to_target_id.device
+            )
             + self.draft_id_to_target_id
         )

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -692,8 +692,14 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
                 torch.zeros(self.config.draft_vocab_size, dtype=torch.long),
                 requires_grad=False,
             )
+            # Precomputed draft→target index mapping; updated after weight load.
+            self._draft_targets = nn.Parameter(
+                torch.arange(self.config.draft_vocab_size, dtype=torch.long),
+                requires_grad=False,
+            )
         else:
             self.draft_id_to_target_id = None
+            self._draft_targets = None
 
     def embed_input_ids(
         self,
@@ -727,13 +733,11 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
         if self.draft_id_to_target_id is None:
             return logits
 
-        base = torch.arange(self.config.draft_vocab_size, device=logits.device)
-        targets = base + self.draft_id_to_target_id
         logits_new = logits.new_full(
             (logits.shape[0], self.config.vocab_size),
             float("-inf"),
         )
-        logits_new[:, targets] = logits
+        logits_new[:, self._draft_targets] = logits
         return logits_new
 
     def precompute_and_store_context_kv(
@@ -814,6 +818,11 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
         )
         loader.load_weights(model_weights.items())
         self.model._build_fused_kv_buffers()
+        if self.draft_id_to_target_id is not None:
+            self._draft_targets.data = (
+                torch.arange(self.config.draft_vocab_size, device=self.draft_id_to_target_id.device)
+                + self.draft_id_to_target_id
+            )
 
     def _read_mask_embedding(self) -> torch.Tensor | None:
         """Checks for an override mask embedding in `mask_embedding.pt` and returns it.

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -820,7 +820,10 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
         self.model._build_fused_kv_buffers()
         if self.draft_id_to_target_id is not None:
             self._draft_targets.data = (
-                torch.arange(self.config.draft_vocab_size, device=self.draft_id_to_target_id.device)
+                torch.arange(
+                    self.config.draft_vocab_size,
+                    device=self.draft_id_to_target_id.device,
+                )
                 + self.draft_id_to_target_id
             )
 

--- a/vllm/model_executor/models/qwen3_eagle3.py
+++ b/vllm/model_executor/models/qwen3_eagle3.py
@@ -315,6 +315,10 @@ class Eagle3Qwen3ForCausalLM(Qwen3ForCausalLM):
             torch.zeros(self.config.draft_vocab_size, dtype=torch.long),
             requires_grad=False,
         )
+        self._draft_targets = nn.Parameter(
+            torch.arange(self.config.draft_vocab_size, dtype=torch.long),
+            requires_grad=False,
+        )
 
         self.use_parallel_drafting = vllm_config.speculative_config.parallel_drafting
 
@@ -354,8 +358,6 @@ class Eagle3Qwen3ForCausalLM(Qwen3ForCausalLM):
             )
             return logits
 
-        base = torch.arange(self.config.draft_vocab_size, device=logits.device)
-        targets = base + self.draft_id_to_target_id
         logits_new = logits.new_full(
             (
                 logits.shape[0],
@@ -363,7 +365,7 @@ class Eagle3Qwen3ForCausalLM(Qwen3ForCausalLM):
             ),
             float("-inf"),
         )
-        logits_new[:, targets] = logits
+        logits_new[:, self._draft_targets] = logits
         return logits_new
 
     def combine_hidden_states(
@@ -425,7 +427,7 @@ class Eagle3Qwen3ForCausalLM(Qwen3ForCausalLM):
                 "Please provide mask_hidden in the weights."
             )
 
-        skip_substrs = ["mask_hidden"]
+        skip_substrs = ["mask_hidden", "_draft_targets"]
         if not includes_draft_id_mapping:
             skip_substrs.append("draft_id_to_target_id")
         if not includes_embed_tokens:
@@ -440,3 +442,7 @@ class Eagle3Qwen3ForCausalLM(Qwen3ForCausalLM):
             skip_substrs=skip_substrs,
         )
         loader.load_weights(model_weights.items())
+        self._draft_targets.data = (
+            torch.arange(self.config.draft_vocab_size, device=self.draft_id_to_target_id.device)
+            + self.draft_id_to_target_id
+        )

--- a/vllm/model_executor/models/qwen3_eagle3.py
+++ b/vllm/model_executor/models/qwen3_eagle3.py
@@ -443,6 +443,8 @@ class Eagle3Qwen3ForCausalLM(Qwen3ForCausalLM):
         )
         loader.load_weights(model_weights.items())
         self._draft_targets.data = (
-            torch.arange(self.config.draft_vocab_size, device=self.draft_id_to_target_id.device)
+            torch.arange(
+                self.config.draft_vocab_size, device=self.draft_id_to_target_id.device
+            )
             + self.draft_id_to_target_id
         )


### PR DESCRIPTION
## Purpose
find some potential perf issue when I go through code. ask copilot provide a fix. 

Avoid recomputing torch.arange + draft_id_to_target_id on every compute_logits call by caching the result in _draft_targets (an nn.Parameter with requires_grad=False). The mapping is computed once in load_weights after weights are loaded and reused for all subsequent forward passes.

Affected models: deepseek_eagle3, llama_eagle3, qwen3_dflash, qwen3_eagle3

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

