### PR TITLE
[Bugfix][Attention] Size FlashInfer sparse MLA workspace for decode-context-parallel

### DIFF
--- a/tests/v1/attention/test_flashinfer_sparse_mla_workspace.py
+++ b/tests/v1/attention/test_flashinfer_sparse_mla_workspace.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU-only tests for the FlashInfer sparse MLA workspace sizing (#50781)."""
+
+from unittest.mock import patch
+
+from vllm.v1.attention.backends.mla.flashinfer_mla_sparse import (
+    _DEFAULT_WORKSPACE_BUFFER_SIZE,
+    _required_workspace_bytes,
+    compute_trtllm_sparse_mla_workspace_bytes,
+)
+
+# Reporter config from vllm#50781: GLM-5.2 (64 q heads), TP=8, DCP=8,
+# max_num_batched_tokens=16384, FlashInfer 0.6.14.
+_REPORTER_HEADS_PER_RANK = 64 // 8
+_REPORTER_DCP = 8
+_REPORTER_MAX_TOKENS = 16384
+# From the reported crash: trtllm-gen requested exactly this many bytes for
+# trtllm_gen_softmax_workspace after an 8 MiB counter carve had left
+# 404,750,336 of the 413,138,944-byte default buffer.
+_REPORTER_OBSERVED_SOFTMAX_BYTES = 1_611_661_312
+_REPORTER_OBSERVED_PRECARVE_BYTES = 8_388_608
+
+
+def test_reporter_softmax_carve_is_reproduced_byte_exactly():
+    # The crashing step scheduled 12288 tokens (a single 12K-token request);
+    # the softmax slab formula must reproduce the kernel's request exactly:
+    # 8 * (8 heads/rank * 8 dcp) * 12288 tokens * 256 + 1 MiB guard.
+    softmax_bytes = compute_trtllm_sparse_mla_workspace_bytes(
+        base_workspace_bytes=0,
+        dcp_world_size=_REPORTER_DCP,
+        num_heads_per_rank=_REPORTER_HEADS_PER_RANK,
+        max_num_batched_tokens=12288,
+    )
+    assert softmax_bytes == _REPORTER_OBSERVED_SOFTMAX_BYTES
+
+
+def test_reporter_config_covers_observed_overflow():
+    computed = compute_trtllm_sparse_mla_workspace_bytes(
+        base_workspace_bytes=_DEFAULT_WORKSPACE_BUFFER_SIZE,
+        dcp_world_size=_REPORTER_DCP,
+        num_heads_per_rank=_REPORTER_HEADS_PER_RANK,
+        max_num_batched_tokens=_REPORTER_MAX_TOKENS,
+    )
+    assert computed >= (
+        _REPORTER_OBSERVED_SOFTMAX_BYTES + _REPORTER_OBSERVED_PRECARVE_BYTES
+    )
+
+
+def test_non_dcp_size_is_unchanged():
+    computed = compute_trtllm_sparse_mla_workspace_bytes(
+        base_workspace_bytes=_DEFAULT_WORKSPACE_BUFFER_SIZE,
+        dcp_world_size=1,
+        num_heads_per_rank=128,
+        max_num_batched_tokens=65536,
+    )
+    assert computed == _DEFAULT_WORKSPACE_BUFFER_SIZE
+
+
+def test_default_constant_matches_envs_default(monkeypatch):
+    from vllm import envs
+
+    monkeypatch.delenv("VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE", raising=False)
+    assert _DEFAULT_WORKSPACE_BUFFER_SIZE == envs.VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE
+
+
+def test_env_unset_returns_computed(monkeypatch):
+    monkeypatch.delenv("VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE", raising=False)
+    required = _required_workspace_bytes(
+        dcp_world_size=_REPORTER_DCP,
+        num_heads_per_rank=_REPORTER_HEADS_PER_RANK,
+        max_num_batched_tokens=_REPORTER_MAX_TOKENS,
+    )
+    assert required == compute_trtllm_sparse_mla_workspace_bytes(
+        _DEFAULT_WORKSPACE_BUFFER_SIZE,
+        _REPORTER_DCP,
+        _REPORTER_HEADS_PER_RANK,
+        _REPORTER_MAX_TOKENS,
+    )
+
+
+def test_env_override_below_computed_is_respected_with_warning(monkeypatch):
+    override = 100 * 1024 * 1024
+    monkeypatch.setenv("VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE", str(override))
+    with patch(
+        "vllm.v1.attention.backends.mla.flashinfer_mla_sparse.logger"
+    ) as mock_logger:
+        required = _required_workspace_bytes(
+            dcp_world_size=_REPORTER_DCP,
+            num_heads_per_rank=_REPORTER_HEADS_PER_RANK,
+            max_num_batched_tokens=_REPORTER_MAX_TOKENS,
+        )
+    assert required == override
+    mock_logger.warning_once.assert_called_once()
+
+
+def test_env_override_above_computed_is_respected_without_warning(monkeypatch):
+    override = 8 * 1024 * 1024 * 1024
+    monkeypatch.setenv("VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE", str(override))
+    with patch(
+        "vllm.v1.attention.backends.mla.flashinfer_mla_sparse.logger"
+    ) as mock_logger:
+        required = _required_workspace_bytes(
+            dcp_world_size=_REPORTER_DCP,
+            num_heads_per_rank=_REPORTER_HEADS_PER_RANK,
+            max_num_batched_tokens=_REPORTER_MAX_TOKENS,
+        )
+    assert required == override
+    mock_logger.warning_once.assert_not_called()

--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
@@ -292,18 +292,115 @@ class FlashInferMLASparseMetadataBuilder(
             supports_dcp_with_varlen=True,
         )
 
+        # Under DCP the workspace must hold the trtllm-gen softmax-stats slab.
+        # The buffer address is baked into CUDA graphs, so it has to reach its
+        # final size here, before the first forward/capture (no lazy regrow).
+        if self.dcp_world_size > 1:
+            _get_workspace_buffer(
+                device,
+                _required_workspace_bytes(
+                    self.dcp_world_size,
+                    num_q_heads,
+                    vllm_config.scheduler_config.max_num_batched_tokens,
+                ),
+            )
+
 
 # Global workspace buffer (lazily initialized)
 _fi_sparse_workspace: torch.Tensor | None = None
 
+# trtllm-gen carves a softmax-stats slab from the workspace whenever LSE is
+# requested (FlashInfer csrc/trtllm_fmha_kernel_launcher.cu, unchanged from
+# v0.6.14 through current main):
+#   sizeof(float2) * num_qo_heads * batch_size * round_up(max_q_len, 256)
+#   + 1 MiB guard
+# forward_mqa always passes q_len == 1, so each (head, token) pair costs
+# round_up(1, 256) == 256 slots.
+_TRTLLM_GEN_SOFTMAX_STAT_BYTES = 8  # sizeof(float2)
+_TRTLLM_GEN_SOFTMAX_SLOTS_PER_TOKEN = 256  # round_up(q_len=1, 256)
+_TRTLLM_GEN_SOFTMAX_GUARD_BYTES = 1024 * 1024
 
-def _get_workspace_buffer(device: torch.device) -> torch.Tensor:
+# Keep in sync with the VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE default in
+# vllm/envs.py.
+_DEFAULT_WORKSPACE_BUFFER_SIZE = 394 * 1024 * 1024
+
+
+def compute_trtllm_sparse_mla_workspace_bytes(
+    base_workspace_bytes: int,
+    dcp_world_size: int,
+    num_heads_per_rank: int,
+    max_num_batched_tokens: int,
+) -> int:
+    """Workspace bytes needed by the trtllm-gen sparse MLA decode kernel.
+
+    Under DCP the query is all-gathered across the DCP group in the head dim
+    and the kernel is asked for LSE, so trtllm-gen carves the softmax-stats
+    slab described above from the workspace before its (batch-independent)
+    counter and scratch regions. ``base_workspace_bytes`` must stay available
+    for those regions, so the slab is added on top of it (see #50781).
+
+    Without DCP no LSE is requested, no slab is carved, and the base size is
+    returned unchanged.
+    """
+    if dcp_world_size <= 1:
+        return base_workspace_bytes
+    softmax_bytes = (
+        _TRTLLM_GEN_SOFTMAX_STAT_BYTES
+        * (num_heads_per_rank * dcp_world_size)
+        * max_num_batched_tokens
+        * _TRTLLM_GEN_SOFTMAX_SLOTS_PER_TOKEN
+        + _TRTLLM_GEN_SOFTMAX_GUARD_BYTES
+    )
+    return base_workspace_bytes + softmax_bytes
+
+
+def _required_workspace_bytes(
+    dcp_world_size: int,
+    num_heads_per_rank: int,
+    max_num_batched_tokens: int,
+) -> int:
+    """Resolve the workspace size, honoring an explicit env override."""
+    computed = compute_trtllm_sparse_mla_workspace_bytes(
+        _DEFAULT_WORKSPACE_BUFFER_SIZE,
+        dcp_world_size,
+        num_heads_per_rank,
+        max_num_batched_tokens,
+    )
+    if not envs.is_set("VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE"):
+        return computed
+    env_bytes = envs.VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE
+    if env_bytes < computed:
+        logger.warning_once(
+            "VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE=%d is below the %d bytes "
+            "computed for the sparse MLA workspace with dcp_world_size=%d, "
+            "%d heads/rank and max_num_batched_tokens=%d. Respecting the "
+            "override, but the trtllm-gen kernel may crash with a workspace "
+            "overflow; set VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE=%d or unset "
+            "it to use the computed size.",
+            env_bytes,
+            computed,
+            dcp_world_size,
+            num_heads_per_rank,
+            max_num_batched_tokens,
+            computed,
+        )
+    return env_bytes
+
+
+def _get_workspace_buffer(
+    device: torch.device, min_bytes: int | None = None
+) -> torch.Tensor:
     global _fi_sparse_workspace
-    if _fi_sparse_workspace is None:
+    required = (
+        min_bytes
+        if min_bytes is not None
+        else envs.VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE
+    )
+    if _fi_sparse_workspace is None or _fi_sparse_workspace.numel() < required:
         # FlashInfer's CuteDSL MLA-decode tactic requires an int8 workspace;
         # the trtllm-gen path views it as uint8, so int8 is safe for all backends.
         _fi_sparse_workspace = torch.zeros(
-            envs.VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE,
+            required,
             dtype=torch.int8,
             device=device,
         )


### PR DESCRIPTION
## Purpose

Fixes #50781.

With `--decode-context-parallel-size > 1`, the FlashInfer sparse MLA backend (`FLASHINFER_MLA_SPARSE`, B200/SM100) crashes inside FlashInfer's trtllm-gen launcher with a workspace buffer overflow — a single request with a moderately long prompt is enough to bring down every DCP worker and the API server.

## Root cause

The workspace handed to `trtllm_batch_decode_with_kv_cache_mla` is a static default, `VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE = 394 MiB` (413,138,944 bytes), with no awareness of DCP, head count, or batch size.

Whenever the caller requests LSE, FlashInfer's trtllm-gen launcher carves a softmax-stats slab out of that workspace (`csrc/trtllm_fmha_kernel_launcher.cu`, identical from v0.6.14 through current main):

```text
softmax_bytes = sizeof(float2) * num_qo_heads * batch_size * round_up(max_q_len, 256)
                + 1 MiB guard
```

vLLM's sparse MQA path (`forward_mqa`) passes `q_len == 1` per token, so `round_up(1, 256) == 256` slots per (head, token). Three factors combine under DCP to blow this up:

1. **LSE is only requested under DCP.** `need_to_return_lse_for_decode = dcp_world_size > 1 and can_return_lse_for_decode` (the shared DCP reducer needs LSE). Without DCP the slab is never carved, which is why this only reproduces with `--decode-context-parallel-size > 1`.
2. **DCP all-gathers the query in the head dim.** Before `forward_mqa`, the decode query is all-gathered across the DCP group (`mla_attention.py`), so the kernel sees `num_heads_per_rank * dcp_world_size` heads per rank — for the reporter's GLM-5.2 (64 q heads) at TP=8, DCP=8 that is 8 × 8 = 64 heads instead of 8.
3. **`batch_size` is the full per-step token count, not just decodes.** The sparse backend routes prefill tokens through the same MQA kernel (each token carries its own top-k row, so the sparse mask is fully per-token), which is why "a single request" is enough: the reporter's single ~12K prompt lands as a 12,288-row batch. Whether that routing is the right long-term design is an upstream question and out of scope here — the workspace has to be sized for what the kernel is actually handed today.

### Byte-exact validation against the reported crash

The reporter's crashing step scheduled 12,288 tokens (a single ~12K-token prompt). Plugging into the formula:

```text
8 bytes * (8 heads/rank * 8 DCP) * 12288 tokens * 256 + 1 MiB = 1,611,661,312
```

which matches the reported allocation request **exactly**. The reported "only 404,750,336 bytes available" is also exact: FlashInfer ≤ 0.6.14 first carves an 8 MiB multi-CTA-KV counter slab (`8192 * 256 * sizeof(uint32) = 8,388,608`) from the same buffer, and `413,138,944 − 8,388,608 = 404,750,336`. (FlashInfer ≥ 0.6.15 moved the counter to a separate buffer — flashinfer-ai/flashinfer#3582 — which is the version vLLM currently pins; the fix keeps the 8 MiB inside the preserved baseline either way.)

The overflow threshold for this config is 3,081 tokens in a step (`8 * 64 * 3080 * 256 + 1 MiB` exactly fills the remaining 404,750,336 bytes), i.e. any prompt longer than ~3K tokens crashes the server.

## Fix

Add a pure-Python sizing function `compute_trtllm_sparse_mla_workspace_bytes()` colocated with the backend, and pre-allocate the shared workspace in `FlashInferMLASparseMetadataBuilder.__init__`:

```text
required = base (394 MiB default) + 8 * (heads/rank * dcp) * max_num_batched_tokens * 256 + 1 MiB
```

* **The DCP delta is exactly the derived softmax slab — no arbitrary margin.** The base stays reserved for trtllm-gen's counter + multi-CTA-KV scratch regions, which are batch/DCP-independent (scratch parallelism is clamped by SM count; multi-CTA-KV is disabled outright once the CTA grid covers the device) and demonstrably fit in today's default — non-DCP serving exercises exactly those regions.
* **Sizing happens before the first forward/capture.** Cudagraph support here is `UNIFORM_BATCH`; the buffer address is baked into captured graphs, so the buffer must reach its final size up front — the metadata builder constructor runs before warmup/capture. No lazy regrow, no catch-and-retry.
* **`max_num_batched_tokens` is a hard upper bound for the kernel's batch dim**: scheduler steps are capped by it, and cudagraph capture sizes are clamped to it (`max_cudagraph_capture_size = min(max_num_tokens, ...)`).
* **Explicit env override is respected.** If `VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE` is explicitly set, that value is used as-is; if it is below the computed requirement a prominent warning logs both numbers and the exact value to set.
* **Sizing is validated against the pinned FlashInfer version.** The slab formula is byte-identical in `csrc/trtllm_fmha_kernel_launcher.cu` at the reporter's `0.6.14.dev20260705`, at `v0.6.15.post1` (what `requirements/cuda.txt` pins today), and on FlashInfer main. The only layout change in that range is the multi-CTA-KV counter moving to a caller-supplied buffer in 0.6.15 (flashinfer-ai/flashinfer#3582); since the fix preserves the existing default as the base and adds the slab on top, it is correct on both sides of that change. No version-specific constant is hard-coded beyond the slab's own alignment/guard terms, which are named and commented with their upstream source.

### Memory impact

* **Non-DCP configs: zero change.** Without DCP no LSE is requested, the computed size equals the existing default, and the allocation still happens lazily on first use. The other three readers of `VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE` (dense FlashInfer backend, MLA prefill backends) are untouched.
* **DCP configs:** the workspace grows by the exact slab the kernel was already trying to carve, e.g. the reporter's config allocates 394 MiB + 2,148,532,224 bytes ≈ 2.39 GiB per rank (vs. crashing today); a default 8192-token config with the same gathered head count is ≈ 1.07 GiB.
* Like the existing lazy allocation (and the base class's DCP-enlarged chunked-prefill workspace), this buffer lives outside the KV-cache memory profiling budget. Under DCP it is larger than before, so a deployment with very little post-KV-cache headroom would now OOM at builder init instead of crashing mid-serving — the failure moves to startup and becomes actionable (lower `--max-num-batched-tokens` or `gpu_memory_utilization`).
* PCP+DCP combinations (`dcp ∈ {pcp, tp*pcp}` per config validation) gather fewer or differently-grouped heads than plain DCP; the formula upper-bounds those layouts (never under-allocates).

## Test plan

New CPU-only tests (no GPU markers) in `tests/v1/attention/test_flashinfer_sparse_mla_workspace.py`:

* byte-exact reproduction of the reported 1,611,661,312-byte request,
* reporter config coverage (computed ≥ observed request + 8 MiB pre-carve),
* non-DCP size identical to today's default (regression guard),
* env-override semantics (explicit-set respected, warning on undersize, no warning on oversize),
* sync guard between the local default constant and `vllm/envs.py`.

```console
$ pytest tests/v1/attention/test_flashinfer_sparse_mla_workspace.py -v
...
7 passed, 14 warnings in 6.45s

$ pre-commit run --files vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py \
    tests/v1/attention/test_flashinfer_sparse_mla_workspace.py
ruff check ....... Passed
ruff format ...... Passed
typos ............ Passed
Run mypy for Python 3.10 ... Passed
```

GPU-only sparse MLA tests (`tests/v1/attention/test_sparse_mla_backends.py`) were not run — no B200 available to me. This change is sizing-only and does not alter kernel inputs or numerics, so no model-eval results are included; happy to run any suite a reviewer wants that does not need SM100 hardware.

**Hardware verification request:** @flexwang could you validate on your 8×B200 rig? Expected behavior with this patch on your exact command line: startup logs unchanged, per-rank extra VRAM ≈ 2.0 GiB for the workspace, and the >3K-token single-request crash gone. My prior FlashInfer buffer sizing fix #50022 followed the same size-up-front pattern and was GPU-verified there.

## Follow-up (FlashInfer side, not this PR)

trtllm-gen exposes no public workspace-size API for its MLA decode path (the CuteDSL path has `_get_split_kv_and_workspace_size`; trtllm-gen sizes are only discoverable by reading the C++ launcher). I plan to file a FlashInfer issue requesting a sizing contract mirroring the CuteDSL one, so callers can stop re-deriving these constants.

---

*This PR is AI-assisted (analysis and draft authored with Claude Code); I have reviewed every line and the derivation. Duplicate-work check at submission time: #50781 had no comments, no linked PRs, and no open PRs touching sparse-MLA/DCP/workspace sizing.*

FIX #50781