### PR TITLE
[Bugfix][LoRA] Fix Qwen3-ASR audio tower QKV adapters

### DIFF
--- a/tests/lora/test_lora_manager.py
+++ b/tests/lora/test_lora_manager.py
@@ -13,6 +13,7 @@ from vllm.config.lora import LoRAConfig
 from vllm.lora.layers import (
     ColumnParallelLinearWithLoRA,
     MergedColumnParallelLinearWithLoRA,
+    MergedQKVParallelLinearWithLoRA,
     ReplicatedLinearWithLoRA,
     RowParallelLinearWithLoRA,
 )
@@ -28,6 +29,8 @@ from vllm.lora.peft_helper import PEFTHelper
 from vllm.lora.request import LoRARequest
 from vllm.lora.worker_manager import LRUCacheWorkerLoRAManager, WorkerLoRAManager
 from vllm.model_executor.layers.fused_moe import GateLinear
+from vllm.model_executor.layers.linear import QKVParallelLinear
+from vllm.model_executor.models.qwen3_asr import Qwen3ASRForConditionalGeneration
 from vllm.platforms import current_platform
 
 from .utils import create_peft_lora
@@ -133,6 +136,39 @@ def test_replace_submodules(default_vllm_config, dist_init, dummy_model):
     )
     assert isinstance(model.get_submodule("dense2"), RowParallelLinearWithLoRA)
     assert isinstance(model.get_submodule("layer1.dense2"), RowParallelLinearWithLoRA)
+
+
+def test_wrap_qwen3_asr_audio_qkv(default_vllm_config, dist_init, dummy_model):
+    model = dummy_model
+    model.add_module(
+        "qkv",
+        QKVParallelLinear(
+            hidden_size=64,
+            head_size=8,
+            total_num_heads=8,
+            total_num_kv_heads=8,
+            bias=True,
+        ),
+    )
+    model.packed_modules_mapping = (
+        Qwen3ASRForConditionalGeneration.packed_modules_mapping
+    )
+
+    manager = LoRAModelManager(
+        model,
+        1,
+        1,
+        1,
+        LoRAConfig(
+            max_lora_rank=8, max_cpu_loras=8, max_loras=8, lora_dtype=DEFAULT_DTYPE
+        ),
+        torch.device(DEVICES[0]),
+        default_vllm_config,
+    )
+
+    assert isinstance(
+        manager.model.get_submodule("qkv"), MergedQKVParallelLinearWithLoRA
+    )
 
 
 def test_wrap_replicated_linear_subclasses(default_vllm_config, dist_init, dummy_model):

--- a/vllm/model_executor/models/qwen3_asr.py
+++ b/vllm/model_executor/models/qwen3_asr.py
@@ -348,6 +348,11 @@ class Qwen3ASRForConditionalGeneration(
 ):
     # LoRA support
     packed_modules_mapping = {
+        "qkv": [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+        ],
         "qkv_proj": [
             "q_proj",
             "k_proj",


### PR DESCRIPTION
## Purpose

Follow-up to #37247.

Qwen3-ASR's audio tower exposes attention Q/K/V as a fused
`QKVParallelLinear` named `qkv`, while PEFT checkpoints store separate
`q_proj`, `k_proj`, and `v_proj` LoRA weights. The model currently only
declares the `qkv_proj` packed mapping used by the language model, so the
LoRA manager receives an empty packed-module list for
`audio_tower.layers.*.self_attn.qkv` and ignores those adapters.

This PR adds the missing `qkv` packed mapping and a regression test that
checks the Qwen3-ASR audio QKV layer is wrapped with
`MergedQKVParallelLinearWithLoRA`.

User impact: all-linear Qwen3-ASR PEFT adapters can apply their audio tower
Q/K/V LoRAs instead of silently skipping them.

Duplicate check: searches for open Qwen3-ASR audio tower/QKV LoRA issues and
PRs found no existing fix. #49525 addresses text-only multimodal mapper
fallbacks, and #45944 targets Qwen2-Audio, so neither overlaps this change.

## Test Plan

```bash
.venv/bin/python -m pytest \
  tests/lora/test_lora_manager.py::test_wrap_qwen3_asr_audio_qkv -q
```

End-to-end validation uses Qwen3-ASR-1.7B with an all-linear rank-64 PEFT
adapter and `--enable-tower-connector-lora`, then calls
`/v1/audio/transcriptions` with a LibriSpeech dev-clean sample.

## Test Result

Static checks on the latest `main` checkout:

```text
.venv/bin/python -m py_compile ...  PASS
git diff --check                    PASS
```

End-to-end validation on vLLM 0.26.0:

- before the mapping change, all 24 audio encoder QKV layers logged
  `could not be wrapped ... It will be ignored`;
- after the change, all 24 warnings disappeared and the adapter loaded;
- `/v1/audio/transcriptions` returned HTTP 200;
- LibriSpeech sample `652-129742-0020` exactly matched the reference:
  `STRAIN AND BOTTLE AND PUT IN ICE BOX SHAKE BEFORE USING EACH TIME`.

The targeted pytest was not run in this checkout because installing the
current main-branch PyTorch 2.13/CUDA 12.9 test environment was stopped before
completion. The PR is opened as a draft so CI and reviewer feedback can cover
that remaining check.

No documentation update is needed because this corrects the existing
Qwen3-ASR tower LoRA behavior.

Developed with assistance from OpenAI Codex. I reviewed every changed line and
the validation evidence.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results.
- [x] Documentation impact considered; no update is required for this behavior fix.
</details>
