### PR TITLE
[Draft] [Bugfix] Clone safetensors tensors before H2D copy on Ascend NPU to fix DMA hang

### DIFF
--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -932,7 +932,7 @@ def safetensors_weights_iterator(
                 state_dict = load(f.read())
             for name, param in state_dict.items():
                 if not should_skip_weight(name, local_expert_ids):
-                    yield name, param
+                    yield name, param.clone()
         elif safetensors_load_strategy == "torchao":
             # we can't load flattened torchao tensor subclasses directly into the model
             # instead we reconstruct the subclasses here before returning
@@ -962,13 +962,13 @@ def safetensors_weights_iterator(
                 unflattened_state_dict, leftover_state_dict = (
                     unflatten_tensor_state_dict(state_dict, metadata)
                 )
-            yield from unflattened_state_dict.items()
+            yield from ((k, v.clone()) for k, v in unflattened_state_dict.items())
         else:
             with safe_open(st_file, framework="pt") as f:
                 for name in f.keys():  # noqa: SIM118
                     if should_skip_weight(name, local_expert_ids):
                         continue
-                    param = f.get_tensor(name)
+                    param = f.get_tensor(name).clone()
                     yield name, param
 
 
@@ -999,7 +999,8 @@ def multi_thread_safetensors_weights_iterator(
             state_dict = future.result()
             del future
             for key in list(state_dict):
-                yield key, state_dict.pop(key)
+                val = state_dict.pop(key).clone()
+                yield key, val
 
 
 def runai_safetensors_weights_iterator(


### PR DESCRIPTION


## Purpose
Fix for https://github.com/vllm-project/vllm-omni/issues/5122
Fix weight loading hang on Ascend NPU where `copy_()` from safetensors mmap tensors causes infinite spin-yield deadlock.

**Root Cause**: safetensors' `safe_open().get_tensor()` and `load_file()` return tensors backed by file-backed mmap pages. When these pages are not resident in the Linux page cache (PTE = not present), the Ascend CANN driver's `pin_user_pages_fast()` cannot obtain physical page frame numbers (it runs in RCU read-side critical section and cannot sleep to trigger page faults). This causes DMA transfer to never start, and `copy_()`'s internal `aclrtQueryEvent()` + `sched_yield()` loop spins forever.

**Fix**: Clone all tensors yielded from safetensors iterators before they are used for H2D copy. `clone()` copies data from file-backed mmap pages to anonymous pages (regular heap memory) via CPU, which can handle page faults normally. Anonymous pages are always resident (PTE = present), so `pin_user_pages_fast()` succeeds and DMA proceeds correctly.

**Why this only reproduces on some servers**: When sufficient RAM is available, safetensors files remain cached in the Linux page cache, mmap pages have PTE = present, and DMA works. When RAM is tight (or files are not cached), PTE = not present triggers the failure.


## Test Plan
On an Ascend NPU server where the hang reproduces (RAM insufficient to cache all safetensors files in page cache):
   - Launch vllm-omni with HunyuanImage-3.0-Instruct (8-card TP, 32×5GB safetensors = 160GB)
   - Observe weight loading progress and CPU utilization
 
```
vllm serve /model/HunyuanImage-3.0-Instruct/ --omni --port 9000 --deploy-config app/vllm-omni/vllm_omni/deploy/hunyuan_image_3_moe.yaml --trust-remote-code
```

## Test Result

**Before Fix**:
Weight loading gets stuck when waitting engine core process start on Ascend A3.

CPU utilization:
```
root        1945 91.6  0.1 9829297100 3274804 pts/2 Rl+ 11:22  12:12 vLLM-Omni::DiffusionWorker-0
root        1946 91.6  0.1 9834205456 3243944 pts/2 Rl+ 11:22  12:12 vLLM-Omni::DiffusionWorker-1
root        1947 91.9  0.1 9834369296 3269796 pts/2 Rl+ 11:22  12:14 vLLM-Omni::DiffusionWorker-2
root        1948 91.6  0.1 9828986092 3326800 pts/2 Rl+ 11:22  12:12 vLLM-Omni::DiffusionWorker-3
```

**After Fix**:
```
curl -X POST http://localhost:9000/v1/images/generations \
  -H "Content-Type: application/json" \
  -d '{
    "prompt": "generate a woman playing around on the beach",
    "model": "/home/models/lvjunmao/tencent/HunyuanImage-3.0-Instruct/",
    "use_system_prompt": "en_unified",
    "bot_task": "think",
    "num_inference_steps": 50,
    "n": 1,
    "seed": 42
  }' > /workspace/response.json
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1521k  100 1521k  100   266  11195      1  0:04:26  0:02:19  0:02:07  317k
```
```
[Overall Summary]
+-----------------------------+-------------+
| Field                       |       Value |
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:758] +-----------------------------+-------------+
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:758] | e2e_requests                |           1 |
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:758] | e2e_wall_time_ms            | 138,525.920 |
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:758] | e2e_total_tokens            |       4,190 |
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:758] | e2e_avg_time_per_request_ms | 138,525.920 |
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:758] | e2e_avg_tokens_per_s        |      30.247 |
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:758] | input_preprocess_time_ms    |      21.213 |
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:758] | e2e_stage_0_wall_time_ms    |  86,001.696 |
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:758] | e2e_stage_1_wall_time_ms    |  52,490.080 |
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:758] +-----------------------------+-------------+
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:784] 
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:784] [RequestE2EStats [request_id=img_gen-83b9e969681be83c-a1a59eab]]
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:784] +------------------+-------------+
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:784] | Field            |       Value |
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:784] +------------------+-------------+
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:784] | e2e_total_ms     | 138,492.283 |
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:784] | e2e_total_tokens |       4,190 |
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:784] +------------------+-------------+
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:825] [OmniTiming] req=img_gen-83b9e969681be83c-a1a59eab total=138.49s preprocess=0.02s engine=138.47s stages=[0:86.00s,0:86.00s,1:52.49s] transfers=[0->1=0.00ms] ar2diffusion=1.04ms
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:867] 
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:867] [StageRequestStats [request_id=img_gen-83b9e969681be83c-a1a59eab]]
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:867] +---------------------------------+----------------+----------------+-------------+
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:867] | Field                           |              0 |            0_2 |           1 |
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:867] +---------------------------------+----------------+----------------+-------------+
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:867] | batch_id                        |              1 |              1 |           1 |
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:867] | batch_size                      |              1 |              1 |           1 |
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:867] | denoise_step_latency_ms         |          0.000 |          0.000 |   1,049.793 |
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:867] | image_pixels                    |              0 |              0 |   1,048,576 |
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:867] | inter_output_latencies_ms       |                |                |             |
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:867] | num_tokens_in                   |          1,241 |          1,241 |           0 |
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:867] | num_tokens_out                  |            854 |            854 |           0 |
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:867] | output_unit_count               |            854 |            854 |           1 |
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:867] | output_unit_type                |           text |           text |       image |
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:867] | serving_time_to_first_output_ms |     86,034.257 |     86,034.257 | 138,525.478 |
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:867] | stage_gen_time_ms               |     86,000.394 |     86,000.394 |  52,489.669 |
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:867] | time_per_output_unit_ms         |          0.000 |          0.000 |       0.000 |
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:867] | vllm_itl_ms                     |         86.481 |         86.481 |       0.000 |
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:867] | vllm_itls_ms                    | 86.481 (n=853) | 86.481 (n=853) |             |
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:867] | vllm_tpot_ms                    |         86.481 |         86.481 |       0.000 |
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:867] | vllm_ttft_ms                    |     12,266.154 |     12,266.154 |       0.000 |
(APIServer pid=378) INFO 07-31 11:37:42 [stats.py:867] +---------------------------------+----------------+----------------+-------------+
(APIServer pid=378) INFO:     127.0.0.1:51922 - "POST /v1/images/generations HTTP/1.1" 200 OK
```
CPU utilization:
```
root         394 20.6  0.3 9677949876 6818000 pts/1 Sl+ 15:48   0:31 vLLM-Omni::DiffusionWorker-0
root         395 20.5  0.2 9677655356 6281404 pts/1 Sl+ 15:48   0:31 vLLM-Omni::DiffusionWorker-1
root         396 21.1  0.3 9677635836 6862100 pts/1 Sl+ 15:48   0:32 vLLM-Omni::DiffusionWorker-2
root         397 20.5  0.2 9677657912 5193032 pts/1 Sl+ 15:48   0:31 vLLM-Omni::DiffusionWorker-3
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
