### PR TITLE
Fix OverflowError in prompt_logprobs when external KV pre-fills prompt

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5650,7 +5650,8 @@ class GPUModelRunner(
 
             # Set up target LogprobsTensors object.
             logprobs_tensors = request.in_progress_prompt_logprobs_cpu
-            if logprobs_tensors is None:
+            is_new = logprobs_tensors is None
+            if is_new:
                 # Create empty logprobs CPU tensors for the entire prompt.
                 # If chunked, we'll copy in slice by slice.
                 logprobs_tensors = LogprobsTensors.empty_cpu(
@@ -5672,7 +5673,14 @@ class GPUModelRunner(
                 # This is the last chunk of prompt tokens to return.
                 num_logits = num_remaining_tokens
                 completed_prefill_reqs.append(req_id)
-                prompt_logprobs_dict[req_id] = logprobs_tensors
+                if not is_new or num_logits > 0:
+                    # Ship the tensor only when there is something to fill now,
+                    # or a prior chunk already filled it. When this is the first
+                    # entry (is_new) with num_logits <= 0, the prompt was
+                    # externally pre-filled (e.g. PD disagg / LMCache) and no
+                    # local logits exist; shipping the unfilled empty_cpu tensor
+                    # would OverflowError in tokenizer.decode (see vllm#21951).
+                    prompt_logprobs_dict[req_id] = logprobs_tensors
 
             if num_logits <= 0:
                 # This can happen for the final chunk if we prefilled exactly


### PR DESCRIPTION
When an external KV connector (PD disagg / LMCache / NIXL) advances num_computed_tokens past local-computed, _get_prompt_logprobs_dict ships an unfilled LogprobsTensors.empty_cpu tensor; the stale int32 then overflows u32 in tokenizer.decode -> OverflowError, crashing the engine.

Only ship the logprobs tensor when there is something to fill (num_logits > 0).

Closes #50792




## Purpose

In a PD-disaggregated (or any external-KV-connector) setup, a request with `prompt_logprobs` crashes the decode engine with `OverflowError: out of range integral type conversion attempted`.

`prompt_logprobs` needs per-position logits, which come from running the prompt forward. When an external KV connector (Mooncake / NIXL / LMCache) pre-fills the prompt KV, `num_computed_tokens` advances to `prompt_len`, so the engine skips the prompt forward and has no logits for the prompt positions.

In `_get_prompt_logprobs_dict` (`vllm/v1/worker/gpu_model_runner.py`), the last-chunk branch ships the logprobs tensor *before* checking whether there is anything to fill:

```python
else:  # last-chunk branch
    num_logits = num_remaining_tokens          # 0 / -1 because num_computed >= N-1
    completed_prefill_reqs.append(req_id)
    prompt_logprobs_dict[req_id] = logprobs_tensors   # ships the tensor
if num_logits <= 0:
    continue                                   # skips the copy_ that fills it
```

The tensor is created by `LogprobsTensors.empty_cpu` with `torch.empty(dtype=torch.int32)` (uninitialized). Since the request is remote-prefilled, this is the first and only entry into the function, so the tensor is shipped without a single `copy_`. The API server then decodes every id via `tokenizer.decode`, and a negative stale int32 overflows the `u32` conversion in the Rust tokenizer, raising `OverflowError`.

The local prefix-cache path is not affected because `skip_reading_prefix_cache=True` (auto-set when `prompt_logprobs` is enabled) forces a local recompute from position 0; the external connector path does not honor this flag, so `num_computed_tokens` still jumps to `prompt_len`.

Fix: only add the tensor to `prompt_logprobs_dict` when `num_logits > 0`:

```diff
             else:
                 # This is the last chunk of prompt tokens to return.
                 num_logits = num_remaining_tokens
                 completed_prefill_reqs.append(req_id)
-                prompt_logprobs_dict[req_id] = logprobs_tensors
+                if num_logits > 0:
+                    prompt_logprobs_dict[req_id] = logprobs_tensors
```

## Test Plan

Manual reproduction on a PD-disaggregated setup (1 prefiller + 1 decoder + example proxy) with a `prompt_logprobs=1` non-streaming request.

## Test Result

| Setup | `prompt_logprobs` | Before | After |
|---|---|---|---|
| PD disagg (P+D) | yes | `OverflowError`, engine crash | no crash, request returns |
| PD disagg (P+D) | no | no crash | no crash (unchanged) |
| Single engine, no external connector | yes | no crash | no crash (unchanged) |

Before the fix, the decoder logs:

```
ERROR [async_llm.py:704] AsyncLLM output_handler failed.
File ".../vllm/v1/engine/async_llm.py", line 675, in output_handler
File ".../vllm/v1/engine/output_processor.py", line 648, in process_outputs
File ".../vllm/v1/engine/logprobs.py", line 352, in update_from_output
    self._update_prompt_logprobs(output.new_prompt_logprobs_tensors)
File ".../vllm/v1/engine/logprobs.py", line 147, in _update_prompt_logprobs
    else convert_ids_list_to_tokens(
File ".../vllm/v1/tokenizers/detokenizer_utils.py", line 100, in convert_ids_list_to_tokens
    token_str = tokenizer.decode([token_id])
File ".../vllm/v1/tokenizers/hf.py", line 86, in decode
File ".../transformers/tokenization_utils_tokenizers.py", line 1032, in _decode
    text = self._tokenizer.decode(token_ids, skip_special_tokens=...)
OverflowError: out of range integral type conversion attempted
```

After the fix, the decoder no longer ships the unfilled tensor; `new_prompt_logprobs_tensors` is absent so `_update_prompt_logprobs` skips it, the engine stays alive, and the request returns normally.

A companion proxy-side change (to return real prompt_logprobs by harvesting them from the prefiller) will be filed separately against `vllm-ascend`, since that logic lives in the disagg example there.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

