### PR TITLE
[Bugfix][Build] Restore DeepGEMM SM120 support while preserving SITU

### DIFF
--- a/cmake/external_projects/deepgemm.cmake
+++ b/cmake/external_projects/deepgemm.cmake
@@ -29,8 +29,8 @@ if(DEEPGEMM_SRC_DIR)
 else()
   # Keep in sync with tools/install_deepgemm.sh
   set(_DEEPGEMM_UPSTREAM_REPO "https://github.com/vllm-project/DeepGEMM.git")
-  # TODO: switch to nv_dev branch after it support situ
-  set(_DEEPGEMM_UPSTREAM_TAG "f5a76426fa084087169693fd0cd815223576d6e9")
+  # Merge nv-dev SM120 support with SITU activation support.
+  set(_DEEPGEMM_UPSTREAM_TAG "5f33a18079e96d26d5869c9759657eb6150f31b1")
 
   set(_deepgemm_fc_root "${FETCHCONTENT_BASE_DIR}")
   if(NOT _deepgemm_fc_root)

--- a/cmake/external_projects/deepgemm.cmake
+++ b/cmake/external_projects/deepgemm.cmake
@@ -29,8 +29,8 @@ if(DEEPGEMM_SRC_DIR)
 else()
   # Keep in sync with tools/install_deepgemm.sh
   set(_DEEPGEMM_UPSTREAM_REPO "https://github.com/vllm-project/DeepGEMM.git")
-  # TODO: switch to nv_dev branch after it support situ
-  set(_DEEPGEMM_UPSTREAM_TAG "e21c821f39a2056d68067a466c64ddc942200106")
+  # Merge nv-dev SM120 support with SITU activation support.
+  set(_DEEPGEMM_UPSTREAM_TAG "2fd67329ec2942f65ba35d561256ab6ed3b903cb")
 
   set(_deepgemm_fc_root "${FETCHCONTENT_BASE_DIR}")
   if(NOT _deepgemm_fc_root)

--- a/tools/install_deepgemm.sh
+++ b/tools/install_deepgemm.sh
@@ -7,8 +7,8 @@ set -e
 # Default values
 # Keep DEEPGEMM_GIT_REF in sync with cmake/external_projects/deepgemm.cmake
 DEEPGEMM_GIT_REPO="https://github.com/vllm-project/DeepGEMM.git"
-# NOTE: This is currently targeting nv-dev branch due to sm120 support
-DEEPGEMM_GIT_REF="e21c821f39a2056d68067a466c64ddc942200106"
+# Merge nv-dev SM120 support with SITU activation support.
+DEEPGEMM_GIT_REF="2fd67329ec2942f65ba35d561256ab6ed3b903cb"
 WHEEL_DIR=""
 
 # Parse command line arguments

--- a/tools/install_deepgemm.sh
+++ b/tools/install_deepgemm.sh
@@ -7,8 +7,8 @@ set -e
 # Default values
 # Keep DEEPGEMM_GIT_REF in sync with cmake/external_projects/deepgemm.cmake
 DEEPGEMM_GIT_REPO="https://github.com/vllm-project/DeepGEMM.git"
-# NOTE: This is currently targeting nv-dev branch due to sm120 support
-DEEPGEMM_GIT_REF="f5a76426fa084087169693fd0cd815223576d6e9"
+# Merge nv-dev SM120 support with SITU activation support.
+DEEPGEMM_GIT_REF="5f33a18079e96d26d5869c9759657eb6150f31b1"
 WHEEL_DIR=""
 
 # Parse command line arguments


### PR DESCRIPTION
## Purpose

Addresses the current-main regression reported in #47436 for block-scaled FP8 checkpoints on SM120.

The Kimi K3 integration changed the vendored DeepGEMM revision from the `nv-dev` commit used by vLLM v0.26.0 to `f5a76426`, which provides SITU support but does not contain the SM120 scale-factor layout dispatch. As a result, current nightly builds select `DeepGemmFp8BlockScaledMMKernel` and fail while post-processing weights:

```text
RuntimeError: Assertion error (.../deepgemm-src/csrc/apis/layout.hpp:60): Unknown SF transformation
```

This updates both DeepGEMM pins to `2fd67329`. Its direct parent is the previously validated `5f33a180` `nv_dev+situ` merge commit, which combines the SM120 support from `nv-dev` with the SITU activation support required by Kimi K3. The additional commit carries the CUDA 12.9 `cuda_fp8.h` include fix from #51003.

### Duplicate-work check

No open PR addressed this regression when this PR was opened. Draft #51382 was opened later as a materially different alternative: it minimizes the DeepGEMM dependency delta by cherry-picking SITU onto the earlier SM120 revision, while this PR uses the later `nv_dev+situ` merge and its CUDA 12.9 follow-up. The other related PRs are also not duplicates:

- #47988 and #48588 improve CUTLASS/Triton fallback behavior; they do not restore the DeepGEMM SM120 path.
- #41834 is a broader DeepSeek V4 SM12x enablement branch and does not currently modify either DeepGEMM pin file.
- #47304 previously moved the pin to `nv-dev` for SM120 support. This change restores that support after the later SITU pin update, while preserving SITU.

## Test Plan

Build a CUDA 13 production image for SM120 from vLLM main with the updated pin, then serve the real `DeepSeek-V4-Flash-0731` checkpoint on six RTX 5090 GPUs:

```text
model: DeepSeek-V4-Flash-0731
vLLM: 0.26.1rc1.dev251+g0033211c0.d20260803
GPU: 6x NVIDIA RTX 5090 (SM120)
parallelism: TP=2, PP=3
checkpoint size: 155.43 GiB, 48 safetensors shards
```

```bash
vllm serve /model \
  --trust-remote-code \
  --kv-cache-dtype fp8 \
  --max-model-len 524288 \
  --tensor-parallel-size 2 \
  --pipeline-parallel-size 3 \
  --gpu-memory-utilization 0.97 \
  --max-num-seqs 1 \
  --enable-prefix-caching \
  --disable-log-stats \
  --enable-auto-tool-choice \
  --tool-call-parser deepseek_v4
```

Additional checks:

```bash
bash -n tools/install_deepgemm.sh
git diff --check
```

After startup, send repeated OpenAI-compatible chat-completion requests, followed by a request with a `get_weather` function schema. Scan the serving log for `Unknown SF transformation`, `illegal memory access`, engine failures, and CUDA errors.

## Test Result

The original pre-rebase candidate (`5f33a180`) built successfully with CUDA architecture `12.0f`; the build log checked out that merge revision:

```text
5f33a18 Merge branch 'situ-activation' into nv_dev+situ
DeepGEMM CUDA architectures: 12.0f
```

The model loaded all real checkpoint shards and selected the intended kernels:

```text
Loading safetensors checkpoint shards: 100% Completed | 48/48
DeepGEMM E8M0 enabled on current platform.
Using 'DEEPGEMM_MXFP4' Mxfp4 MoE backend.
Using DeepGemmFP4Experts
Application startup complete.
```

Runtime results after one-time per-shape JIT warmup:

| Check | Result |
| --- | --- |
| Weight loading | 48/48 shards loaded; no SF-layout assertion |
| Chat completion | Correct Chinese responses returned |
| Warmed decode | 84.1-100.6 output tok/s across repeated 83/90-token responses |
| Tool calling | `finish_reason=tool_calls`, `get_weather({"city":"北京"})` |
| Error scan | No `Unknown SF transformation`, illegal memory access, engine failure, or CUDA error |

The first request for a new shape was slower because current main performs one-time TileLang/DeepGEMM JIT compilation; repeated requests used the cached kernels. The performance figures above are warmed single-request measurements, not aggregate throughput.

After rebasing, static validation confirmed that `2fd67329` is a direct child of the hardware-tested `5f33a180` and differs only by the CUDA FP8 header include from #51003. `bash -n tools/install_deepgemm.sh`, pin-consistency validation, and `git diff --check` pass. An exact-pin SM120 rebuild and long-context run have not yet been completed.

No model-quality change is expected from this pin update. As a runtime sanity check, generated Chinese responses were coherent, and the tool-call name and JSON arguments matched the supplied schema.

---

AI assistance was used for root-cause analysis, patch preparation, validation scripting, and PR drafting with GPT-5.6-sol (low). I reviewed the complete two-file diff and validated the patched image end-to-end on the hardware described above.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, including the related issue.
- [x] The test plan and commands are provided.
- [x] Before/after behavior and end-to-end results are provided.
- [x] Duplicate work was checked.

</details>
