### PR TITLE
[Docs] Document cross-rank aggregation semantics of NIXL KV transfer metrics

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
@@ -69,6 +69,11 @@ class KVConnectorLogging:
         # Note that this is not the same as the logging interval.
         # We expect transfer_stats_data to be aggregated across all workers and
         # consist of observations from a single connector or a MultiConnector.
+        # The full pipeline is: observe() -> aggregate() -> reduce() -> log().
+        # Stats arrive here pre-aggregated across workers (each TP rank
+        # records its own per-transfer observations, which are concatenated
+        # upstream), so summaries computed later describe the combined pool of
+        # observations from every rank rather than a single rank.
         transfer_stats = self.connector_cls.build_kv_connector_stats(
             transfer_stats_data
         )
@@ -97,7 +102,11 @@ class KVConnectorLogging:
             and not self.transfer_stats_accumulator.is_empty()
         ):
             # Produce a single cumulative stats object for the last time
-            # interval from the recorded observations.
+            # interval from the recorded observations. The accumulator holds
+            # observations aggregated across all TP ranks, so the logged
+            # summary reflects the combined pool of all ranks' transfers (see
+            # the connector-specific stats class docstring, e.g.
+            # NixlKVConnectorStats, for the exact semantics of each metric).
             xfer_metrics = self.transfer_stats_accumulator.reduce()
             xfer_metrics_str = ", ".join(f"{k}={v}" for k, v in xfer_metrics.items())
             log_fn("KV Transfer metrics: %s", xfer_metrics_str)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py
@@ -23,7 +23,27 @@ if TYPE_CHECKING:
 
 @dataclass
 class NixlKVConnectorStats(KVConnectorStats):
-    """Container for transfer performance metrics"""
+    """Container for transfer performance metrics.
+
+    NOTE: All metrics in this class are aggregated across ALL TP ranks before
+    summary statistics are computed. Each rank independently records
+    per-transfer telemetry via :meth:`record_transfer`; the per-rank lists are
+    then concatenated by :meth:`aggregate` (``list.extend()``). As a result,
+    values reported by :meth:`reduce` describe the *combined* pool of
+    observations from every rank, not a single rank or the engine as a whole:
+
+    - "Num successful transfers" is the total count across all ranks.
+    - "Avg MB per transfer" is the average over all individual rank-level
+      transfers, not the total bytes moved for one KV cache transfer op.
+    - "Throughput (MB/s)" is ``total_MB_all_ranks / total_time_all_ranks``,
+      i.e. an average per-rank throughput rather than aggregate system
+      throughput.
+    - Percentiles (e.g. P90) are computed over the combined distribution of
+      all ranks' transfer times.
+
+    This is a deliberate design choice (workers fire-and-forget stats), but
+    should be kept in mind when interpreting the logged values.
+    """
 
     def __post_init__(self):
         if not self.data:
@@ -76,6 +96,10 @@ class NixlKVConnectorStats(KVConnectorStats):
         )
 
     def aggregate(self, other: KVConnectorStats) -> KVConnectorStats:
+        # Stats are aggregated across all TP ranks: each rank sends its own
+        # per-transfer observations and they are concatenated here. This means
+        # that later summaries are computed over the combined pool of
+        # observations from every rank (see NixlKVConnectorStats docstring).
         if not other.is_empty():
             for k, v in other.data.items():
                 accumulator = self.data[k]
@@ -84,7 +108,11 @@ class NixlKVConnectorStats(KVConnectorStats):
         return self
 
     def reduce(self) -> dict[str, int | float]:
-        # Compute compact representative stats suitable for CLI logging
+        # Compute compact representative stats suitable for CLI logging.
+        # NOTE: averages and percentiles are computed over the *combined*
+        # observation pool from all TP ranks (see NixlKVConnectorStats
+        # docstring), so "Throughput (MB/s)" is effectively an average
+        # per-rank throughput, not aggregate system throughput.
         if self.num_successful_transfers == 0:
             # CLI logging only reports successful transfers stats. If all requests in
             # the interval were unsuccessful, Prom will report failures stats instead.


### PR DESCRIPTION
Closes #41230.

## Summary

Documents the fact that NIXL KV connector transfer metrics are aggregated across all TP ranks before summary statistics are computed, so users can correctly interpret the logged \KV Transfer metrics\ line.

## Changes

- \llm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py\`n  - Expand the \NixlKVConnectorStats\ docstring to explain that metrics describe the combined pool of observations from all ranks, with concrete notes on \Num successful transfers\, \Avg MB per transfer\, \Throughput (MB/s)\ and percentiles.
  - Add inline comments to \ggregate()\ and \educe()\ clarifying the cross-rank concatenation and the per-rank throughput semantics.
- \llm/distributed/kv_transfer/kv_connector/v1/metrics.py\`n  - Document the \observe() -> aggregate() -> reduce() -> log()\ pipeline in \KVConnectorLogging.observe()\ and note that stats arrive pre-aggregated across workers.
  - Clarify in \log()\ that the accumulator holds observations from all TP ranks.

## Notes

Docs/comments only, no behavior change.