### PR TITLE
[INC]  fix w4a4 model

### DIFF
--- a/tests/quantization/test_auto_round.py
+++ b/tests/quantization/test_auto_round.py
@@ -496,7 +496,7 @@ def test_qwen3_1p7b_mxfp4_autoround_uses_mxfp4_linear_scheme(
     monkeypatch.setattr(
         "vllm.model_executor.layers.quantization.inc.schemes."
         "inc_mxfp4_linear.init_mxfp4_linear_kernel",
-        lambda: DummyKernel(),
+        lambda **kwargs: DummyKernel(),
     )
 
     from vllm.model_executor.layers.quantization.inc.schemes.inc_mxfp4_linear import (  # noqa: E501
@@ -614,7 +614,7 @@ def test_inc_mxfp4_linear_method_registers_and_processes_weights(
     monkeypatch.setattr(
         "vllm.model_executor.layers.quantization.inc.schemes."
         "inc_mxfp4_linear.init_mxfp4_linear_kernel",
-        lambda: DummyKernel(),
+        lambda **kwargs: DummyKernel(),
     )
     monkeypatch.setattr(
         "vllm.model_executor.parameter.get_tensor_model_parallel_rank",

--- a/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_linear.py
+++ b/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_linear.py
@@ -7,6 +7,7 @@ import torch
 from torch.nn.parameter import Parameter
 
 from vllm.model_executor.kernels.linear import init_mxfp4_linear_kernel
+from vllm.model_executor.layers.quantization.utils.quant_utils import kMxfp4Dynamic
 from vllm.model_executor.parameter import (
     GroupQuantScaleParameter,
     ModelWeightParameter,
@@ -29,7 +30,7 @@ class INCMxfp4LinearMethod(INCLinearScheme):
 
     def __init__(self, layer_config: "INCLayerConfig") -> None:
         self.group_size = layer_config.group_size or 32
-        self.kernel = init_mxfp4_linear_kernel()
+        self.kernel = init_mxfp4_linear_kernel(activation_quant_key=kMxfp4Dynamic)
 
     @classmethod
     def get_min_capability(cls) -> int:


### PR DESCRIPTION
INCMxfp4LinearMethod called init_mxfp4_linear_kernel() without an activation_quant_key, leaving it as None. This caused platform-specific failures:

**XPU (hard crash)**: XPUMxFp4LinearKernel.can_implement strictly requires activation_quant_key == kMxfp4Dynamic and rejects None, causing model loading to fail with:
```
ValueError: Failed to find a kernel that can implement the MXFP4 linear layer.
XPUMxFp4LinearKernel: only supports MXFP4 dynamic activation
```
**CUDA (silent regression)**: MarlinMxFp4LinearKernel.can_implement accepts None as a valid config, but silently falls back to weight-only W4A16 inference, completely ignoring activation quantization. For a W4A4 model, this means the activation quantization intended by the checkpoint is never applied, resulting in incorrect behavior with no error or warning emitted.

**Fix**: Pass activation_quant_key=kMxfp4Dynamic when calling init_mxfp4_linear_kernel(), which correctly reflects that activations are quantized dynamically at runtime. This ensures the XPU kernel is selected on XPU, and the FlashInfer (Blackwell) kernel is preferred on CUDA instead of degrading to Marlin W4A16.