### PR TITLE
[Core] Add FLy speculative verification

### DIFF
--- a/docs/features/speculative_decoding/README.md
+++ b/docs/features/speculative_decoding/README.md
@@ -84,8 +84,11 @@ only apply to model-based methods such as `draft_model`, `mtp`, `eagle3`, and
 | `draft_tensor_parallel_size` | `integer >= 1` | `None` | Tensor parallel size for the draft model. |
 | `max_model_len` | `integer >= 1` | `None` | Maximum context length for the draft model. |
 | `parallel_drafting` | `boolean` | `false` | Enable parallel draft token generation. Only compatible with EAGLE and draft-model methods. |
-| `rejection_sample_method` | `string` | `strict` | `strict`, `probabilistic`, or `synthetic`. |
+| `rejection_sample_method` | `string` | `standard` | `standard`, `synthetic`, `block`, or the lossy `fly` verifier. |
+| `draft_sample_method` | `string` | `greedy` | `greedy` uses target-only acceptance for random requests; `probabilistic` retains the full draft distribution for probability-ratio acceptance. |
 | `synthetic_acceptance_rate` | `float` | `None` | Average acceptance rate to target when `rejection_sample_method` is `synthetic`. Valid range is `[0, 1]`. |
+| `fly_window_size` | `integer >= 1` | `6` | Number of subsequent native acceptance decisions checked by FLy. Must be smaller than `num_speculative_tokens`. |
+| `fly_entropy_threshold` | `float >= 0` | `0.3` | Minimum target top-3 entropy required for FLy to retain a native rejection. |
  | `use_heterogeneous_vocab` | `boolean` | `false` | Allow draft and target models with different vocabularies. Builds a token-level intersection at initialisation and constrains draft logits to shared tokens only. Only compatible with `method=draft_model`. Probabilistic draft sampling (`draft_sample_method='probabilistic'`) is not yet supported when this option is enabled. |
 
 !!! note
@@ -184,6 +187,10 @@ vllm serve <target-model> \
 - `use_heterogeneous_vocab` currently supports greedy draft sampling only. Probabilistic acceptance (temperature > 0 draft sampling) is not yet supported and will be added in a future release.
 
 ## Lossless guarantees of Speculative Decoding
+
+!!! warning
+    These guarantees apply to the standard rejection sampler. FLy deliberately
+    relaxes verification and is not distribution preserving.
 
 In vLLM, speculative decoding aims to enhance inference efficiency while maintaining accuracy. This section addresses the lossless guarantees of
 speculative decoding, breaking down the guarantees into three key areas:

--- a/docs/features/speculative_decoding/draft_model.md
+++ b/docs/features/speculative_decoding/draft_model.md
@@ -76,6 +76,37 @@ The code used to request as completions as a client remains unchanged:
         print(completion)
     ```
 
+## FLy verification
+
+[FLy](https://arxiv.org/abs/2511.22972) is an approximate verification policy
+that can override a native rejection at an ambiguous position when the following
+native acceptance decisions remain aligned. It is intentionally lossy: unlike
+standard speculative decoding, it does not preserve the target distribution.
+
+```python
+llm = LLM(
+    model="Qwen/Qwen3-8B",
+    speculative_config={
+        "method": "draft_model",
+        "model": "Qwen/Qwen3-0.6B",
+        "num_speculative_tokens": 8,
+        "rejection_sample_method": "fly",
+        "fly_window_size": 6,
+        "fly_entropy_threshold": 0.3,
+    },
+)
+```
+
+`fly_window_size` is the number of subsequent tokens checked and must be
+smaller than `num_speculative_tokens`. The entropy gate uses the top three
+probabilities after target-side temperature, top-k, and top-p processing. FLy
+supports greedy requests, target-only acceptance with the default greedy draft
+sampling, and probability-ratio acceptance with
+`draft_sample_method="probabilistic"`.
+
+FLy currently requires a GPU, a shared vocabulary, and serial drafting. It is
+not available with parallel drafting or heterogeneous vocabularies.
+
 ## Draft Model Method with heterogeneous vocabs
 
   By default, vLLM requires the draft and target models to share the same vocabulary. Setting `use_heterogeneous_vocab: true` enables the **Token-Level Intersection (TLI)** algorithm, which allows draft models from a different model family with a different tokenizer.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1648,6 +1648,50 @@ def test_draft_sample_method_gumbel_is_rejected():
         )
 
 
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"method": "ngram"}, "FLy currently requires"),
+        (
+            {"method": "draft_model", "fly_window_size": 8},
+            "fly_window_size to be smaller",
+        ),
+        (
+            {"method": "draft_model", "use_heterogeneous_vocab": True},
+            "shared target/draft vocabulary",
+        ),
+        (
+            {"method": "draft_model", "parallel_drafting": True},
+            "linear serial drafting",
+        ),
+    ],
+)
+def test_fly_rejects_unsupported_configurations(kwargs: dict[str, object], match: str):
+    with (
+        patch.object(SpeculativeConfig, "__post_init__", lambda self: None),
+        pytest.raises(ValidationError, match=match),
+    ):
+        SpeculativeConfig(
+            num_speculative_tokens=8,
+            rejection_sample_method="fly",
+            **kwargs,
+        )
+
+
+def test_fly_accepts_plain_draft_model():
+    with patch.object(SpeculativeConfig, "__post_init__", lambda self: None):
+        config = SpeculativeConfig(
+            method="draft_model",
+            num_speculative_tokens=8,
+            rejection_sample_method="fly",
+            fly_window_size=6,
+            fly_entropy_threshold=0.3,
+        )
+
+    assert config.fly_window_size == 6
+    assert config.fly_entropy_threshold == 0.3
+
+
 def test_ir_op_priority_default():
     """Test that IR op priority defaults are set correctly."""
     from vllm.config.kernel import IrOpPriorityConfig

--- a/tests/v1/sample/test_rejection_sampler.py
+++ b/tests/v1/sample/test_rejection_sampler.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import Mock
 
@@ -1088,6 +1089,187 @@ def test_sample_recovered_tokens_vocab_boundary(vocab_size: int, no_draft_probs:
     assert (recovered < vocab_size).all(), (
         f"Recovered token IDs >= vocab_size ({vocab_size}): "
         f"{recovered[recovered >= vocab_size].tolist()}"
+    )
+
+
+########################### Tests for FLy Verification ##################
+
+
+def _make_fly_sampler(
+    window_size: int = 2, entropy_threshold: float = 0.0
+) -> RejectionSampler:
+    mock_sampler = Mock(spec=Sampler)
+    mock_sampler.logprobs_mode = "raw_logprobs"
+    spec_config = SimpleNamespace(
+        rejection_sample_method="fly",
+        fly_window_size=window_size,
+        fly_entropy_threshold=entropy_threshold,
+    )
+    return RejectionSampler(mock_sampler, spec_config)
+
+
+def _patch_uniform_probs(monkeypatch: pytest.MonkeyPatch, values: list[float]) -> None:
+    def fixed_uniform_probs(num_tokens, num_draft_tokens, generators, device):
+        assert num_tokens == len(values)
+        return torch.tensor(values, dtype=torch.float64, device=device)
+
+    monkeypatch.setattr(
+        "vllm.v1.sample.rejection_sampler.generate_uniform_probs",
+        fixed_uniform_probs,
+    )
+
+
+def test_fly_greedy_rescues_mismatch_after_native_acceptance_window(
+    rejection_sampler,
+):
+    spec_tokens = [[1, 2, 3, 4]]
+    target_tokens = [[9, 2, 3, 4, 5]]
+    logits = create_logits_tensor(target_tokens)
+    metadata = create_sampling_metadata(all_greedy=True)
+    spec_metadata = create_spec_decode_metadata(spec_tokens, logits)
+    bonus = torch.tensor([5], device=logits.device)
+
+    mock_sampler_output(rejection_sampler, bonus)
+    standard_output = rejection_sampler(spec_metadata, None, logits, metadata)
+    assert torch.equal(
+        standard_output.sampled_token_ids,
+        torch.tensor([[9, -1, -1, -1, -1]], dtype=torch.int, device=logits.device),
+    )
+
+    fly_sampler = _make_fly_sampler(window_size=2)
+    mock_sampler_output(fly_sampler, bonus)
+    fly_output = fly_sampler(spec_metadata, None, logits, metadata)
+    assert torch.equal(
+        fly_output.sampled_token_ids,
+        torch.tensor([[1, 2, 3, 4, 5]], dtype=torch.int, device=logits.device),
+    )
+
+
+def test_fly_requires_full_lookahead_and_passes_entropy_gate():
+    spec_tokens = [[1, 2, 3, 4, 5]]
+    target_tokens = [[9, 2, 3, 8, 5, 6]]
+    logits = create_logits_tensor(target_tokens, vocab_size=10)
+    metadata = create_sampling_metadata(all_greedy=True)
+    spec_metadata = create_spec_decode_metadata(spec_tokens, logits)
+    bonus = torch.tensor([6], device=logits.device)
+
+    fly_sampler = _make_fly_sampler(window_size=2, entropy_threshold=0.3)
+    mock_sampler_output(fly_sampler, bonus)
+    low_entropy_output = fly_sampler(spec_metadata, None, logits, metadata)
+    assert low_entropy_output.sampled_token_ids[0, 0].item() == 9
+
+    logits[0].fill_(-100.0)
+    logits[0, 9] = 1.0
+    logits[0, 1] = 0.9
+    logits[0, 0] = 0.8
+    high_entropy_output = fly_sampler(spec_metadata, None, logits, metadata)
+    assert high_entropy_output.sampled_token_ids[0, 0].item() == 1
+
+    assert high_entropy_output.sampled_token_ids[0, 3].item() == 8
+
+
+def test_fly_does_not_override_target_constraint():
+    spec_tokens = [[1, 2, 3]]
+    target_tokens = [[9, 2, 3, 4]]
+    logits = create_logits_tensor(target_tokens, vocab_size=10)
+    logits[0].fill_(-100.0)
+    logits[0, 9] = 1.0
+    logits[0, 0] = 0.9
+    logits[0, 8] = 0.8
+    logits[0, 1] = float("-inf")
+    metadata = create_sampling_metadata(all_greedy=True)
+    spec_metadata = create_spec_decode_metadata(spec_tokens, logits)
+    bonus = torch.tensor([4], device=logits.device)
+
+    fly_sampler = _make_fly_sampler(window_size=1, entropy_threshold=0.3)
+    mock_sampler_output(fly_sampler, bonus)
+    output = fly_sampler(spec_metadata, None, logits, metadata)
+    assert output.sampled_token_ids[0, 0].item() == 9
+
+
+def test_fly_target_only_sampling_uses_native_acceptance(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _patch_uniform_probs(monkeypatch, [0.5, 0.5, 0.5, 0.5])
+    draft_tokens = [[1, 2, 3, 4]]
+    target_probs = torch.zeros((4, 8), dtype=torch.float32, device=DEVICE_TYPE)
+    target_probs[0, 0], target_probs[0, 1] = 0.6, 0.4
+    for row, token_id in enumerate(draft_tokens[0][1:], start=1):
+        target_probs[row, 0] = 0.2
+        target_probs[row, token_id] = 0.8
+    logits = target_probs.log()
+    metadata = create_sampling_metadata(
+        all_greedy=False,
+        temperature=torch.ones(1, dtype=torch.float32, device=DEVICE_TYPE),
+    )
+    spec_metadata = create_spec_decode_metadata(draft_tokens, logits)
+    bonus = torch.tensor([7], device=logits.device)
+
+    fly_sampler = _make_fly_sampler(window_size=2)
+    mock_sampler_output(fly_sampler, bonus)
+    output = fly_sampler(spec_metadata, None, logits, metadata)
+    assert torch.equal(
+        output.sampled_token_ids,
+        torch.tensor([[1, 2, 3, 4, 7]], dtype=torch.int, device=logits.device),
+    )
+
+
+def test_fly_probabilistic_draft_sampling_uses_probability_ratio(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _patch_uniform_probs(monkeypatch, [0.9, 0.9, 0.9, 0.9])
+    draft_tokens = [[1, 2, 3, 4]]
+    target_probs = torch.zeros((4, 8), dtype=torch.float32, device=DEVICE_TYPE)
+    draft_probs = torch.zeros_like(target_probs)
+    target_probs[0, 0], target_probs[0, 1] = 0.6, 0.4
+    draft_probs[0, 0], draft_probs[0, 1] = 0.5, 0.5
+    for row, token_id in enumerate(draft_tokens[0][1:], start=1):
+        target_probs[row, 0], target_probs[row, token_id] = 0.4, 0.6
+        draft_probs[row, 0], draft_probs[row, token_id] = 0.5, 0.5
+    logits = target_probs.log()
+    metadata = create_sampling_metadata(
+        all_greedy=False,
+        temperature=torch.ones(1, dtype=torch.float32, device=DEVICE_TYPE),
+    )
+    spec_metadata = create_spec_decode_metadata(draft_tokens, logits)
+    bonus = torch.tensor([7], device=logits.device)
+
+    fly_sampler = _make_fly_sampler(window_size=2)
+    mock_sampler_output(fly_sampler, bonus)
+    output = fly_sampler(spec_metadata, draft_probs, logits, metadata)
+    assert torch.equal(
+        output.sampled_token_ids,
+        torch.tensor([[1, 2, 3, 4, 7]], dtype=torch.int, device=logits.device),
+    )
+
+
+def test_fly_mixed_greedy_and_random_batch(monkeypatch: pytest.MonkeyPatch):
+    _patch_uniform_probs(monkeypatch, [0.5] * 6)
+    draft_tokens = [[1, 2, 3], [4, 5, 6]]
+    target_probs = torch.zeros((6, 10), dtype=torch.float32, device=DEVICE_TYPE)
+    target_probs[0, 9], target_probs[0, 1] = 0.6, 0.4
+    target_probs[1, 2] = target_probs[2, 3] = 1.0
+    target_probs[3, 0], target_probs[3, 4] = 0.6, 0.4
+    target_probs[4, 5] = target_probs[5, 6] = 1.0
+    logits = target_probs.log()
+    metadata = create_sampling_metadata(
+        all_greedy=False,
+        temperature=torch.tensor([0.0, 1.0], device=DEVICE_TYPE),
+    )
+    metadata.all_random = False
+    spec_metadata = create_spec_decode_metadata(draft_tokens, logits)
+    bonus = torch.tensor([7, 8], device=logits.device)
+
+    fly_sampler = _make_fly_sampler(window_size=1)
+    mock_sampler_output(fly_sampler, bonus)
+    output = fly_sampler(spec_metadata, None, logits, metadata)
+    assert torch.equal(
+        output.sampled_token_ids,
+        torch.tensor(
+            [[1, 2, 3, 7], [4, 5, 6, 8]],
+            dtype=torch.int,
+            device=logits.device,
+        ),
     )
 
 

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -75,7 +75,7 @@ SpeculativeMethod = Literal[
     NgramGPUTypes,
     DSparkModelTypes,
 ]
-RejectionSampleMethod = Literal["standard", "synthetic", "block"]
+RejectionSampleMethod = Literal["standard", "synthetic", "block", "fly"]
 DraftSampleMethod = Literal["greedy", "probabilistic"]
 
 
@@ -220,7 +220,8 @@ class SpeculativeConfig:
     draft_sample_method). 'synthetic' accepts draft tokens with a decaying
     probability calibrated to synthetic_acceptance_rate. 'block' uses block
     verification (Sun et al.), which jointly verifies the draft tokens as a
-    block instead of one at a time."""
+    block instead of one at a time. 'fly' applies FLy's lossy, entropy-gated
+    deferred window to the native per-token acceptance decisions."""
 
     synthetic_acceptance_rates: list[float] | None = None
     """Per-position *unconditional* acceptance rates for synthetic rejection
@@ -288,6 +289,12 @@ class SpeculativeConfig:
     distribution and uses the full draft logits for the probability ratio test
     during rejection sampling. This comes at the cost of additional GPU memory
     usage."""
+
+    fly_window_size: int = Field(default=6, ge=1)
+    """Number of subsequent native acceptance decisions checked by FLy."""
+
+    fly_entropy_threshold: float = Field(default=0.3, ge=0)
+    """Target top-3 entropy lower bound for FLy loose acceptance."""
 
     def compute_hash(self) -> str:
         """
@@ -1332,6 +1339,21 @@ class SpeculativeConfig:
                 "sampling. Set draft_sample_method='greedy' (the default) or "
                 "omit it."
             )
+
+        if self.rejection_sample_method == "fly":
+            if not self.uses_draft_model():
+                raise ValueError("FLy currently requires method='draft_model'.")
+            if self.fly_window_size >= self.num_speculative_tokens:
+                raise ValueError(
+                    "FLy requires fly_window_size to be smaller than "
+                    "num_speculative_tokens."
+                )
+            if self.use_heterogeneous_vocab:
+                raise ValueError(
+                    "FLy currently requires a shared target/draft vocabulary."
+                )
+            if self.parallel_drafting:
+                raise ValueError("FLy currently supports only linear serial drafting.")
 
         if not self.use_heterogeneous_vocab:
             self.verify_equal_vocab_size_if_draft_model()

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -20,6 +20,11 @@ from vllm.v1.sample.ops.bad_words import apply_bad_words_with_drafts
 from vllm.v1.sample.ops.penalties import apply_all_penalties
 from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p
 from vllm.v1.sample.sampler import Sampler
+from vllm.v1.spec_decode.fly import (
+    apply_fly_greedy_acceptance_kernel,
+    apply_fly_random_acceptance_kernel,
+    compute_fly_entropy,
+)
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 from vllm.v1.spec_decode.utils import unconditional_to_conditional_rates
 
@@ -66,6 +71,17 @@ class RejectionSampler(nn.Module):
     ):
         super().__init__()
         self.sampler = sampler
+        self.use_fly = bool(
+            spec_config is not None and spec_config.rejection_sample_method == "fly"
+        )
+        self.fly_window_size: int | None = None
+        self.fly_entropy_threshold: float | None = None
+        if self.use_fly:
+            assert spec_config is not None
+            self.fly_window_size = spec_config.fly_window_size
+            self.fly_entropy_threshold = spec_config.fly_entropy_threshold
+            if device is not None and device.type == "cpu":
+                raise NotImplementedError("FLy verification is not supported on CPU.")
         self.use_fp64_gumbel = getattr(sampler, "use_fp64_gumbel", False)
         logprobs_mode = self.sampler.logprobs_mode
         self.is_processed_logprobs_mode = logprobs_mode in PROCESSED_LOGPROBS_MODES
@@ -182,6 +198,8 @@ class RejectionSampler(nn.Module):
             synthetic_mode=self.synthetic_mode,
             synthetic_conditional_rates=self.synthetic_conditional_rates,
             use_fp64_gumbel=self.use_fp64_gumbel,
+            fly_window_size=self.fly_window_size,
+            fly_entropy_threshold=self.fly_entropy_threshold,
         )
 
         logprobs_tensors = None
@@ -409,6 +427,8 @@ def rejection_sample(
     synthetic_mode: bool = False,
     synthetic_conditional_rates: torch.Tensor | None = None,
     use_fp64_gumbel: bool = False,
+    fly_window_size: int | None = None,
+    fly_entropy_threshold: float | None = None,
 ) -> torch.Tensor:
     assert draft_token_ids.ndim == 1
     assert draft_probs is None or draft_probs.ndim == 2
@@ -423,6 +443,11 @@ def rejection_sample(
     assert draft_probs is None or draft_probs.is_contiguous()
     assert bonus_token_ids.is_contiguous()
     assert target_logits.shape == (num_tokens, vocab_size)
+    fly_enabled = fly_window_size is not None
+    if fly_enabled:
+        assert fly_entropy_threshold is not None
+        if synthetic_mode:
+            raise ValueError("FLy is incompatible with synthetic rejection sampling")
 
     # Create output buffer.
     output_token_ids = torch.full(
@@ -450,9 +475,30 @@ def rejection_sample(
             device,
         )
 
+    target_probs: torch.Tensor | None = None
+    fly_entropy: torch.Tensor | None = None
+    if fly_enabled:
+        if not sampling_metadata.all_greedy:
+            target_probs = target_logits.softmax(dim=-1, dtype=torch.float32)
+            assert target_probs.is_contiguous()
+        fly_entropy = compute_fly_entropy(target_logits, target_probs)
+
     if not sampling_metadata.all_random:
         # Rejection sampling for greedy sampling requests.
         target_argmax = target_logits.argmax(dim=-1)
+        if fly_enabled:
+            assert fly_entropy is not None and fly_window_size is not None
+            apply_fly_greedy_acceptance_kernel[(batch_size,)](
+                cu_num_draft_tokens,
+                draft_token_ids,
+                target_argmax,
+                target_logits,
+                fly_entropy,
+                is_greedy,
+                vocab_size,
+                fly_entropy_threshold,
+                FLY_WINDOW_SIZE=fly_window_size,
+            )
         rejection_greedy_sample_kernel[(batch_size,)](
             output_token_ids,
             cu_num_draft_tokens,
@@ -469,7 +515,8 @@ def rejection_sample(
             return output_token_ids
 
     # Compute probability distribution from target logits.
-    target_probs = target_logits.softmax(dim=-1, dtype=torch.float32)
+    if target_probs is None:
+        target_probs = target_logits.softmax(dim=-1, dtype=torch.float32)
     assert target_probs.is_contiguous()
 
     # Sample recovered tokens for each position.
@@ -488,6 +535,21 @@ def rejection_sample(
 
     # Rejection sampling for random sampling requests.
     assert uniform_probs is not None
+    if fly_enabled:
+        assert fly_entropy is not None and fly_window_size is not None
+        apply_fly_random_acceptance_kernel[(batch_size,)](
+            cu_num_draft_tokens,
+            draft_token_ids,
+            draft_probs,
+            target_probs,
+            uniform_probs,
+            fly_entropy,
+            is_greedy,
+            vocab_size,
+            fly_entropy_threshold,
+            NO_DRAFT_PROBS=draft_probs is None,
+            FLY_WINDOW_SIZE=fly_window_size,
+        )
     rejection_random_sample_kernel[(batch_size,)](
         output_token_ids,
         cu_num_draft_tokens,

--- a/vllm/v1/spec_decode/fly.py
+++ b/vllm/v1/spec_decode/fly.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""FLy speculative-token verification policy."""
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+_FLY_ENTROPY_TOP_K = 3
+
+
+@torch.no_grad()
+def compute_fly_entropy(
+    target_logits: torch.Tensor,
+    target_probs: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Compute FLy's fixed top-3 entropy from processed target scores."""
+
+    if target_logits.ndim != 2:
+        raise ValueError("FLy expects 2-D target logits")
+    if target_logits.shape[-1] == 0:
+        raise ValueError("FLy requires a non-empty target vocabulary")
+    if target_probs is not None and target_probs.shape != target_logits.shape:
+        raise ValueError("FLy target probabilities must match target logits")
+
+    top_k = min(_FLY_ENTROPY_TOP_K, target_logits.shape[-1])
+    if target_probs is None:
+        logits = target_logits.to(torch.float32)
+        top_logits = torch.topk(logits, k=top_k, dim=-1).values
+        top_log_probs = top_logits - torch.logsumexp(logits, dim=-1, keepdim=True)
+        top_probs = top_log_probs.exp()
+    else:
+        top_probs = torch.topk(target_probs.to(torch.float32), k=top_k, dim=-1).values
+        top_log_probs = top_probs.log()
+
+    entropy_terms = torch.where(
+        top_probs > 0,
+        top_probs * top_log_probs,
+        torch.zeros_like(top_probs),
+    )
+    return -entropy_terms.sum(dim=-1)
+
+
+# Encode FLy overrides in inputs consumed by the unchanged native kernels.
+@triton.jit
+def apply_fly_greedy_acceptance_kernel(
+    cu_num_draft_tokens_ptr,
+    draft_token_ids_ptr,
+    target_argmax_ptr,
+    target_logits_ptr,
+    fly_entropy_ptr,
+    is_greedy_ptr,
+    vocab_size,
+    fly_entropy_threshold,
+    FLY_WINDOW_SIZE: tl.constexpr,
+):
+    req_idx = tl.program_id(0)
+    is_greedy = True if is_greedy_ptr is None else tl.load(is_greedy_ptr + req_idx)
+    if not is_greedy:
+        return
+
+    start_idx = (
+        tl.zeros([], dtype=cu_num_draft_tokens_ptr.dtype.element_ty)
+        if req_idx == 0
+        else tl.load(cu_num_draft_tokens_ptr + req_idx - 1)
+    )
+    end_idx = tl.load(cu_num_draft_tokens_ptr + req_idx)
+    num_draft_tokens = end_idx - start_idx
+
+    for pos in range(num_draft_tokens):
+        token_idx = start_idx + pos
+        draft_token_id = tl.load(draft_token_ids_ptr + token_idx)
+        target_token_id = tl.load(target_argmax_ptr + token_idx)
+        can_defer = (
+            draft_token_id != target_token_id
+            and draft_token_id >= 0
+            and draft_token_id < vocab_size
+            and pos + FLY_WINDOW_SIZE < num_draft_tokens
+            and tl.load(fly_entropy_ptr + token_idx) >= fly_entropy_threshold
+        )
+        draft_logit = tl.load(
+            target_logits_ptr + token_idx * vocab_size + draft_token_id,
+            mask=can_defer,
+            other=float("-inf"),
+        )
+        can_defer = can_defer and draft_logit > float("-inf")
+        for offset in range(1, FLY_WINDOW_SIZE + 1):
+            future_idx = token_idx + offset
+            in_bounds = pos + offset < num_draft_tokens
+            future_draft_id = tl.load(
+                draft_token_ids_ptr + future_idx, mask=in_bounds, other=-1
+            )
+            future_target_id = tl.load(
+                target_argmax_ptr + future_idx, mask=in_bounds, other=-2
+            )
+            can_defer = can_defer and future_draft_id == future_target_id
+        tl.store(target_argmax_ptr + token_idx, draft_token_id, mask=can_defer)
+
+
+# Setting u=0 forces native p/q acceptance after p>0 and q>0 are verified.
+@triton.jit
+def apply_fly_random_acceptance_kernel(
+    cu_num_draft_tokens_ptr,
+    draft_token_ids_ptr,
+    draft_probs_ptr,
+    target_probs_ptr,
+    uniform_probs_ptr,
+    fly_entropy_ptr,
+    is_greedy_ptr,
+    vocab_size,
+    fly_entropy_threshold,
+    NO_DRAFT_PROBS: tl.constexpr,
+    FLY_WINDOW_SIZE: tl.constexpr,
+):
+    req_idx = tl.program_id(0)
+    if tl.load(is_greedy_ptr + req_idx):
+        return
+
+    start_idx = (
+        tl.zeros([], dtype=cu_num_draft_tokens_ptr.dtype.element_ty)
+        if req_idx == 0
+        else tl.load(cu_num_draft_tokens_ptr + req_idx - 1)
+    )
+    end_idx = tl.load(cu_num_draft_tokens_ptr + req_idx)
+    num_draft_tokens = end_idx - start_idx
+
+    for pos in range(num_draft_tokens):
+        token_idx = start_idx + pos
+        draft_token_id = tl.load(draft_token_ids_ptr + token_idx)
+        valid_draft = draft_token_id >= 0 and draft_token_id < vocab_size
+        if NO_DRAFT_PROBS:
+            draft_prob = 1.0
+        else:
+            draft_prob = tl.load(
+                draft_probs_ptr + token_idx * vocab_size + draft_token_id,
+                mask=valid_draft,
+                other=0.0,
+            )
+        target_prob = tl.load(
+            target_probs_ptr + token_idx * vocab_size + draft_token_id,
+            mask=valid_draft,
+            other=0.0,
+        )
+        uniform_prob = tl.load(uniform_probs_ptr + token_idx)
+        native_accepted = (
+            valid_draft and draft_prob > 0 and target_prob / draft_prob >= uniform_prob
+        )
+        can_defer = (
+            not native_accepted
+            and valid_draft
+            and draft_prob > 0
+            and target_prob > 0
+            and pos + FLY_WINDOW_SIZE < num_draft_tokens
+            and tl.load(fly_entropy_ptr + token_idx) >= fly_entropy_threshold
+        )
+        for offset in range(1, FLY_WINDOW_SIZE + 1):
+            future_idx = token_idx + offset
+            in_bounds = pos + offset < num_draft_tokens
+            future_draft_id = tl.load(
+                draft_token_ids_ptr + future_idx, mask=in_bounds, other=-1
+            )
+            future_valid = (
+                in_bounds and future_draft_id >= 0 and future_draft_id < vocab_size
+            )
+            if NO_DRAFT_PROBS:
+                future_draft_prob = 1.0
+            else:
+                future_draft_prob = tl.load(
+                    draft_probs_ptr + future_idx * vocab_size + future_draft_id,
+                    mask=future_valid,
+                    other=0.0,
+                )
+            future_target_prob = tl.load(
+                target_probs_ptr + future_idx * vocab_size + future_draft_id,
+                mask=future_valid,
+                other=0.0,
+            )
+            future_uniform_prob = tl.load(
+                uniform_probs_ptr + future_idx, mask=in_bounds, other=1.0
+            )
+            future_accepted = (
+                future_valid
+                and future_draft_prob > 0
+                and future_target_prob / future_draft_prob >= future_uniform_prob
+            )
+            can_defer = can_defer and future_accepted
+        tl.store(uniform_probs_ptr + token_idx, 0.0, mask=can_defer)

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -247,7 +247,7 @@ class SpecDecodeBaseProposer:
             with_numpy=True,
         )
         self._enable_probabilistic_draft_probs = (
-            self.speculative_config.rejection_sample_method == "standard"
+            self.speculative_config.rejection_sample_method in ("standard", "fly")
             and self.speculative_config.draft_sample_method == "probabilistic"
         )
         self._last_draft_probs: torch.Tensor | None = None

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6311,7 +6311,7 @@ class GPUModelRunner(
             num_tokens = sum(len(ids) for ids in draft_token_ids)
             draft_probs = None
             if (
-                self.speculative_config.rejection_sample_method == "standard"
+                self.speculative_config.rejection_sample_method in ("standard", "fly")
                 and self.speculative_config.draft_sample_method == "probabilistic"
             ):
                 draft_probs = torch.rand(


### PR DESCRIPTION
## Purpose

This PR adds **FLy** ([arXiv:2511.22972](https://arxiv.org/abs/2511.22972)), an
opt-in approximate verification policy for draft-model speculative decoding.

Standard rejection sampling stops at the first rejected draft token, so a single
ambiguous position truncates the whole draft and wastes the remaining tokens the
target has already verified. FLy observes that when the *following* acceptance
decisions all still agree, an isolated rejection at a high-entropy (i.e. genuinely
ambiguous) position is usually not worth paying a full truncation for. At such a
position FLy defers to the draft token instead of rejecting, which lets the rest
of the window be accepted.

Concretely, a native rejection at position `i` is overridden only if all of the
following hold:

- the target's top-3 entropy at `i` is at least `fly_entropy_threshold` — the
  target is genuinely uncertain here, not confidently disagreeing;
- the next `fly_window_size` positions would all be accepted natively;
- the draft token has non-zero target probability, and a full window fits inside
  the remaining draft.

FLy is **lossy by design and disabled by default**: it does not preserve the
target distribution, and nothing changes unless
`rejection_sample_method="fly"` is set.

## Design

The two Triton kernels do not re-implement acceptance. They rewrite the *inputs*
of the existing native kernels so the unchanged native logic produces the
deferred decision:

- **Greedy path** (`apply_fly_greedy_acceptance_kernel`): overwrites the target
  argmax at position `i` with the draft token id.
- **Random path** (`apply_fly_random_acceptance_kernel`): sets the uniform sample
  at position `i` to `0`, which forces the native `p/q >= u` test to accept after
  `p > 0` and `q > 0` have been checked.

This keeps the acceptance code paths, per-position accounting, and metrics
untouched, so FLy adds one pre-pass rather than a second verifier.

The entropy gate uses the top-3 probabilities *after* the target-side temperature,
top-k, and top-p processing, so the gate reflects the distribution actually being
sampled from.

## Usage

```python
llm = LLM(
    model="Qwen/Qwen3-8B",
    speculative_config={
        "method": "draft_model",
        "model": "Qwen/Qwen3-0.6B",
        "num_speculative_tokens": 8,
        "rejection_sample_method": "fly",
        "fly_window_size": 6,          # default 6, must be < num_speculative_tokens
        "fly_entropy_threshold": 0.3,  # default 0.3
    },
)
```

Config validation rejects unsupported combinations up front: FLy requires
`method="draft_model"`, a shared target/draft vocabulary, serial drafting, and
`fly_window_size < num_speculative_tokens`. It works with both the default
target-only acceptance and `draft_sample_method="probabilistic"`.

## Drive-by doc fix

The `rejection_sample_method` row in the speculative decoding docs was stale, so
this PR corrects it in passing. It listed the default as `strict` and the options
as `strict`, `probabilistic`, or `synthetic` — but `strict` is not a valid value,
the default is `standard`, `block` was missing, and `probabilistic` belongs to
`draft_sample_method`, not this option. The missing `draft_sample_method` row is
added too; the `use_heterogeneous_vocab` row right below it already referenced
`draft_sample_method='probabilistic'` without the table ever defining it.

## Why this is not a duplicate

Several open PRs touch the verification step, but they change *how many* draft
tokens are verified, while FLy changes *the accept/reject decision itself*:

- [#47808](https://github.com/vllm-project/vllm/pull/47808) (DSpark
  confidence-scheduled verification) and
  [#47131](https://github.com/vllm-project/vllm/pull/47131) (D-Cut) size or prune
  the verification budget from draft confidence, *before* verification, and leave
  the acceptance test itself intact. FLy leaves the budget alone and instead
  overrides individual rejections. The two are complementary and can compose.
- [#50246](https://github.com/vllm-project/vllm/pull/50246) proposes **DFly**,
  which despite the similar name is a *drafting* method (a draft-model
  architecture, like DFlash/DSpark), not a verification policy. No overlap with
  this PR beyond the name.

I found no open PR that modifies the acceptance decision in
`rejection_sampler.py`.

## Test Plan / Test Result

Unit tests (11 new cases, all passing):

```bash
pytest tests/v1/sample/test_rejection_sampler.py -k fly   # 6 passed
pytest tests/test_config.py -k fly                        # 5 passed
```

They cover the greedy and random deferral paths, the entropy gate, window
boundary conditions, and rejection of invalid configs.

## Model evaluation

Measured on **AMD Instinct MI355X (gfx950)**, ROCm 7.2.3, torch 2.11, TP=1,
torch.compile + HIP graph enabled. τ = mean accepted length.

**deepseek-coder-33B / deepseek-coder-1.3B, HumanEval (164), T=0 greedy, batch=1**

| Mode | K | pass@1 | tok/s | τ | Accept | vs standard SD |
| --- | --- | --- | --- | --- | --- | --- |
| target only | – | 62.8% | 78.5 | – | – | – |
| standard SD | 10 | 62.2% | 152.8 | 6.99 | 59.9% | – |
| FLy | 10 | 67.7% | 189.0 | 8.79 | 77.9% | **1.24×** |
| standard SD | 15 | 61.6% | 136.9 | 8.32 | 48.8% | – |
| FLy | 15 | 67.1% | 193.3 | 12.06 | 73.7% | **1.41×** |

**Qwen2.5-72B / Qwen2.5-7B, GSM8K (200), T=0 greedy, batch=16**

| Mode | K | Accuracy | tok/s | τ | Accept | vs standard SD |
| --- | --- | --- | --- | --- | --- | --- |
| target only | – | 94.0% | 507.6 | – | – | – |
| standard SD | 15 | 94.0% | 1109.8 | 10.99 | 66.6% | – |
| FLy | 15 | 93.5% | 1328.6 | 13.19 | 81.3% | **1.20×** |

The same configurations on NVIDIA hardware reproduce the effect: on A100,
deepseek-coder at K=15 goes from 79.5 to 92.6 tok/s (τ 10.79 → 12.83, 1.16×); on
B300, Qwen2.5-72B/7B on GSM8K goes from 935.6 to 1203.2 tok/s (τ 9.8 → 12.8,
1.29×) at unchanged 91.4% accuracy. A batch sweep on B300 (fixed 256 output
tokens, batch 1 → 32) shows a consistent 1.15–1.22× over standard SD with τ
around 13.5 at every batch size.

On accuracy: FLy is lossy, and GSM8K loses 0.5 points (1 problem out of 200),
while HumanEval happens to come out above the target model. Note that standard SD
— which is lossless in theory — also lands 1–2 problems away from target-only on
HumanEval, so this measurement carries roughly one problem of greedy
tie-breaking jitter; differences at that scale should not be over-read.

Scope of validation: the change is pure Python, so no kernel rebuild is needed,
and the Triton kernels JIT-compile and run unmodified on ROCm. All numbers above
are TP=1; multi-GPU TP has not been exercised yet.

## AI assistance

AI assistance was used for this change (recorded as `Assisted-by:` in the commit
trailer). I have reviewed every changed line, and ran the unit tests and the
end-to-end evaluations above myself.