### PR TITLE
[Feature]: Consolidate performance benchmark datasets

### DIFF
--- a/benchmarks/benchmark_latency.py
+++ b/benchmarks/benchmark_latency.py
@@ -1,17 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import sys
+"""
+Benchmark latency script.
+"""
+
+from vllm.benchmarks.latency import add_cli_args, main
+from vllm.utils.argparse_utils import FlexibleArgumentParser
 
 if __name__ == "__main__":
-    print("""DEPRECATED: This script has been moved to the vLLM CLI.
-
-Please use the following command instead:
-    vllm bench latency
-
-For help with the new command, run:
-    vllm bench latency --help
-
-Alternatively, you can run the new command directly with:
-    python -m vllm.entrypoints.cli.main bench latency --help
-""")
-    sys.exit(1)
+    parser = FlexibleArgumentParser(description="Benchmark latency.")
+    add_cli_args(parser)
+    args = parser.parse_args()
+    main(args)

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -1,17 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import sys
+"""
+Benchmark serving throughput script.
+"""
+
+from vllm.benchmarks.serve import add_cli_args, main
+from vllm.utils.argparse_utils import FlexibleArgumentParser
 
 if __name__ == "__main__":
-    print("""DEPRECATED: This script has been moved to the vLLM CLI.
-
-Please use the following command instead:
-    vllm bench serve
-
-For help with the new command, run:
-    vllm bench serve --help
-
-Alternatively, you can run the new command directly with:
-    python -m vllm.entrypoints.cli.main bench serve --help
-""")
-    sys.exit(1)
+    parser = FlexibleArgumentParser(description="Benchmark online serving throughput.")
+    add_cli_args(parser)
+    args = parser.parse_args()
+    main(args)

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -1,17 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import sys
+"""
+Benchmark offline inference throughput script.
+"""
+
+from vllm.benchmarks.throughput import add_cli_args, main
+from vllm.utils.argparse_utils import FlexibleArgumentParser
 
 if __name__ == "__main__":
-    print("""DEPRECATED: This script has been moved to the vLLM CLI.
-
-Please use the following command instead:
-    vllm bench throughput
-
-For help with the new command, run:
-    vllm bench throughput --help
-
-Alternatively, you can run the new command directly with:
-    python -m vllm.entrypoints.cli.main bench throughput --help
-""")
-    sys.exit(1)
+    parser = FlexibleArgumentParser(description="Benchmark offline inference throughput.")
+    add_cli_args(parser)
+    args = parser.parse_args()
+    main(args)

--- a/benchmarks/datasets.py
+++ b/benchmarks/datasets.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Unified module for dataset loading, parsing, and sampling logic across vLLM benchmark scripts.
+"""
 
-from vllm.benchmarks.datasets.datasets import (
+from vllm.benchmarks.datasets import (
     DEFAULT_NUM_PROMPTS,
     AIMODataset,
     ASRDataset,
@@ -25,6 +28,7 @@ from vllm.benchmarks.datasets.datasets import (
     RandomDataset,
     RandomDatasetForReranking,
     RandomMultiModalDataset,
+    RangeRatio,
     SampleRequest,
     ShareGPTDataset,
     SonnetDataset,
@@ -47,7 +51,6 @@ from vllm.benchmarks.datasets.datasets import (
     sample_sonnet_requests,
     zeta_prompt,
 )
-from vllm.benchmarks.datasets.utils import RangeRatio
 
 __all__ = [
     "DEFAULT_NUM_PROMPTS",
@@ -96,4 +99,3 @@ __all__ = [
     "RangeRatio",
     "zeta_prompt",
 ]
-

--- a/tests/benchmarks/test_datasets.py
+++ b/tests/benchmarks/test_datasets.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+from transformers import AutoTokenizer, PreTrainedTokenizerBase
+
+from benchmarks.datasets import (
+    SampleRequest,
+    add_dataset_parser,
+    get_samples,
+    is_valid_sequence,
+    sample_random_requests,
+    sample_sharegpt_requests,
+    sample_sonnet_requests,
+)
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+
+@pytest.fixture(scope="session")
+def tokenizer() -> PreTrainedTokenizerBase:
+    return AutoTokenizer.from_pretrained("openai-community/gpt2")
+
+
+def test_sample_request_dataclass():
+    req = SampleRequest(
+        prompt="Hello world",
+        prompt_len=2,
+        expected_output_len=10,
+        request_id="req_0",
+    )
+    assert req.prompt == "Hello world"
+    assert req.prompt_len == 2
+    assert req.expected_output_len == 10
+    assert req.request_id == "req_0"
+    assert req.multi_modal_data is None
+
+
+def test_is_valid_sequence():
+    # Valid sequence
+    assert is_valid_sequence(
+        prompt_len=100,
+        output_len=50,
+        min_len=4,
+        max_prompt_len=1024,
+        max_total_len=2048,
+    )
+
+    # Prompt too short
+    assert not is_valid_sequence(prompt_len=2, output_len=50, min_len=4)
+
+    # Output too short
+    assert not is_valid_sequence(prompt_len=100, output_len=2, min_len=4)
+
+    # Output too short but check skipped
+    assert is_valid_sequence(
+        prompt_len=100, output_len=2, min_len=4, skip_min_output_len_check=True
+    )
+
+    # Prompt too long
+    assert not is_valid_sequence(prompt_len=2000, output_len=50, max_prompt_len=1024)
+
+    # Combined sequence too long
+    assert not is_valid_sequence(prompt_len=1500, output_len=1000, max_total_len=2048)
+
+
+def test_sample_random_requests(tokenizer):
+    requests = sample_random_requests(
+        tokenizer=tokenizer,
+        num_requests=5,
+        input_len=32,
+        output_len=16,
+        random_seed=42,
+        request_id_prefix="random_",
+    )
+    assert len(requests) == 5
+    for i, req in enumerate(requests):
+        assert isinstance(req, SampleRequest)
+        assert req.request_id == f"random_{i}"
+        assert req.expected_output_len == 16
+        assert req.prompt_len > 0
+
+
+def test_sample_sharegpt_requests(tokenizer):
+    sharegpt_data = [
+        {
+            "conversations": [
+                {"from": "human", "value": "What is the capital of France?"},
+                {"from": "gpt", "value": "The capital of France is Paris."},
+            ]
+        },
+        {
+            "conversations": [
+                {"from": "human", "value": "Tell me a joke about programming."},
+                {
+                    "from": "gpt",
+                    "value": (
+                        "Why do programmers prefer dark mode? Because light attracts"
+                        " bugs."
+                    ),
+                },
+            ]
+        },
+        {
+            # Single turn conversation, should be filtered out
+            "conversations": [
+                {"from": "human", "value": "Single turn only"},
+            ]
+        },
+    ]
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(sharegpt_data, f)
+        temp_path = f.name
+
+    try:
+        requests = sample_sharegpt_requests(
+            dataset_path=temp_path,
+            tokenizer=tokenizer,
+            num_requests=2,
+            random_seed=42,
+            request_id_prefix="sharegpt_",
+        )
+        assert len(requests) == 2
+        assert requests[0].request_id == "sharegpt_0"
+        assert requests[1].request_id == "sharegpt_1"
+    finally:
+        Path(temp_path).unlink(missing_ok=True)
+
+
+def test_sample_sharegpt_requests_oversampling(tokenizer):
+    sharegpt_data = [
+        {
+            "conversations": [
+                {"from": "human", "value": "What is machine learning?"},
+                {
+                    "from": "gpt",
+                    "value": (
+                        "Machine learning is a field of artificial intelligence."
+                    ),
+                },
+            ]
+        },
+    ]
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(sharegpt_data, f)
+        temp_path = f.name
+
+    try:
+        requests = sample_sharegpt_requests(
+            dataset_path=temp_path,
+            tokenizer=tokenizer,
+            num_requests=3,
+            random_seed=42,
+            request_id_prefix="sg_",
+        )
+        assert len(requests) == 3
+        assert requests[0].request_id == "sg_0"
+        assert requests[1].request_id == "sg_1"
+        assert requests[2].request_id == "sg_2"
+    finally:
+        Path(temp_path).unlink(missing_ok=True)
+
+
+def test_sample_sonnet_requests(tokenizer):
+    if not getattr(tokenizer, "chat_template", None):
+        tokenizer.chat_template = (
+            "{% for message in messages %}{{ message['content'] }}{% endfor %}"
+        )
+
+    sonnet_content = """First line of poem
+Second line of poem
+Third line of poem
+Fourth line of poem
+Fifth line of poem
+Sixth line of poem
+Seventh line of poem
+Eighth line of poem
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write(sonnet_content)
+        temp_path = f.name
+
+    try:
+        requests = sample_sonnet_requests(
+            dataset_path=temp_path,
+            tokenizer=tokenizer,
+            num_requests=2,
+            input_len=50,
+            output_len=10,
+            random_seed=42,
+            request_id_prefix="sonnet_",
+        )
+
+        assert len(requests) == 2
+        assert requests[0].request_id == "sonnet_0"
+    finally:
+        Path(temp_path).unlink(missing_ok=True)
+
+
+
+def test_add_dataset_parser_and_get_samples(tokenizer):
+    parser = FlexibleArgumentParser()
+    add_dataset_parser(parser)
+    args = parser.parse_args(
+        ["--dataset-name", "random", "--num-prompts", "3", "--seed", "42"]
+    )
+    requests = get_samples(args, tokenizer)
+    assert len(requests) == 3

--- a/vllm/benchmarks/datasets/datasets.py
+++ b/vllm/benchmarks/datasets/datasets.py
@@ -4801,3 +4801,131 @@ class SpeedBench(CustomDataset):
         random.seed(self.random_seed)
         if not getattr(self, "disable_shuffle", False):
             random.shuffle(self.data)
+
+
+# -----------------------------------------------------------------------------
+# Standalone Dataset Sampling Functions
+# -----------------------------------------------------------------------------
+
+
+def sample_sharegpt_requests(
+    dataset_path: str,
+    tokenizer: TokenizerLike,
+    num_requests: int,
+    output_len: int | None = None,
+    random_seed: int = 0,
+    disable_shuffle: bool = False,
+    request_id_prefix: str = "",
+    no_oversample: bool = False,
+    lora_path: str | None = None,
+    max_loras: int | None = None,
+    enable_multimodal_chat: bool = False,
+    lora_assignment: str = "random",
+) -> list[SampleRequest]:
+    """Sample requests from a ShareGPT dataset."""
+    dataset = ShareGPTDataset(
+        dataset_path=dataset_path,
+        random_seed=random_seed,
+        disable_shuffle=disable_shuffle,
+    )
+    return dataset.sample(
+        tokenizer=tokenizer,
+        num_requests=num_requests,
+        request_id_prefix=request_id_prefix,
+        no_oversample=no_oversample,
+        lora_path=lora_path,
+        max_loras=max_loras,
+        output_len=output_len,
+        enable_multimodal_chat=enable_multimodal_chat,
+        lora_assignment=lora_assignment,
+    )
+
+
+def sample_random_requests(
+    tokenizer: TokenizerLike,
+    num_requests: int,
+    input_len: int = 1024,
+    output_len: int = 128,
+    prefix_len: int = 0,
+    range_ratio: RangeRatio = 0.0,
+    random_seed: int = 0,
+    request_id_prefix: str = "",
+    no_oversample: bool = False,
+    max_loras: int | None = None,
+    lora_path: str | None = None,
+    lora_assignment: str = "random",
+) -> list[SampleRequest]:
+    """Generate synthetic random sample requests."""
+    dataset = RandomDataset(random_seed=random_seed)
+    return dataset.sample(
+        tokenizer=tokenizer,
+        num_requests=num_requests,
+        input_len=input_len,
+        output_len=output_len,
+        prefix_len=prefix_len,
+        range_ratio=range_ratio,
+        request_id_prefix=request_id_prefix,
+        no_oversample=no_oversample,
+        max_loras=max_loras,
+        lora_path=lora_path,
+        lora_assignment=lora_assignment,
+    )
+
+
+def sample_sonnet_requests(
+    dataset_path: str,
+    tokenizer: TokenizerLike,
+    num_requests: int,
+    input_len: int = 550,
+    output_len: int = 150,
+    prefix_len: int = 0,
+    return_prompt_formatted: bool = False,
+    random_seed: int = 0,
+    disable_shuffle: bool = False,
+    request_id_prefix: str = "",
+    no_oversample: bool = False,
+) -> list[SampleRequest]:
+    """Sample requests from a Sonnet dataset."""
+    dataset = SonnetDataset(
+        dataset_path=dataset_path,
+        random_seed=random_seed,
+        disable_shuffle=disable_shuffle,
+    )
+    return dataset.sample(
+        tokenizer=tokenizer,
+        num_requests=num_requests,
+        input_len=input_len,
+        output_len=output_len,
+        prefix_len=prefix_len,
+        return_prompt_formatted=return_prompt_formatted,
+        request_id_prefix=request_id_prefix,
+        no_oversample=no_oversample,
+    )
+
+
+def sample_hf_requests(
+    dataset_path: str,
+    tokenizer: TokenizerLike,
+    num_requests: int,
+    dataset_subset: str | None = None,
+    dataset_split: str | None = None,
+    random_seed: int = 0,
+    disable_shuffle: bool = False,
+    request_id_prefix: str = "",
+    no_oversample: bool = False,
+) -> list[SampleRequest]:
+    """Sample requests from a HuggingFace dataset."""
+    dataset = HuggingFaceDataset(
+        dataset_path=dataset_path,
+        dataset_subset=dataset_subset,
+        dataset_split=dataset_split or "train",
+        random_seed=random_seed,
+        disable_shuffle=disable_shuffle,
+    )
+    return dataset.sample(
+        tokenizer=tokenizer,
+        num_requests=num_requests,
+        request_id_prefix=request_id_prefix,
+        no_oversample=no_oversample,
+    )
+


### PR DESCRIPTION
### Description
Consolidates performance benchmark dataset loading, parsing, and sampling logic across vLLM benchmark scripts into a unified module to improve maintainability and consistency.

### Key Changes
- **Unified Datasets Module (`benchmarks/datasets.py`)**: Created a centralized module re-exporting `SampleRequest`, `add_dataset_parser`, `get_samples`, `is_valid_sequence`, `BenchmarkDataset`, `ShareGPTDataset`, `RandomDataset`, `SonnetDataset`, and `HuggingFaceDataset`.
- **Standalone Dataset Handlers**: Added standard helper functions `sample_sharegpt_requests`, `sample_random_requests`, `sample_sonnet_requests`, and `sample_hf_requests` in `vllm/benchmarks/datasets/datasets.py` and exported them in `vllm/benchmarks/datasets/__init__.py`.
- **Refactored Legacy Entrypoints**: Updated `benchmarks/benchmark_serving.py`, `benchmarks/benchmark_throughput.py`, and `benchmarks/benchmark_latency.py` to delegate to their respective CLI benchmark modules (`vllm.benchmarks.serve`, `vllm.benchmarks.throughput`, `vllm.benchmarks.latency`).
- **Comprehensive Unit Tests (`tests/benchmarks/test_datasets.py`)**: Added unit tests covering `SampleRequest`, `is_valid_sequence`, dataset sampling handlers (`sample_random_requests`, `sample_sharegpt_requests`, `sample_sonnet_requests`), oversampling logic, and argument parsing.

Closes #13351