### PR TITLE
[Superseded] [Quark] Cache dequantized MXFP4 fallback weights

### DIFF
--- a/tests/quantization/test_quark_ocp_mx_cache.py
+++ b/tests/quantization/test_quark_ocp_mx_cache.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from vllm.model_executor.kernels.linear.mxfp4.emulation import (
+    EmulationMxfp4LinearKernel,
+)
+from vllm.model_executor.layers.quantization.quark.schemes.quark_ocp_mx import (
+    QuarkOCP_MX,
+)
+
+
+def _make_method(cache: bool, dtype: torch.dtype = torch.bfloat16):
+    method = object.__new__(QuarkOCP_MX)
+    method.cache_dequant_weight = cache
+    method.dynamic_mxfp4_quant = False
+    method._dequant_dtype = dtype
+    kernel = object.__new__(EmulationMxfp4LinearKernel)
+    kernel.quant_dequant_func = MagicMock(side_effect=lambda x: x)
+    method.ocp_mx_linear = kernel
+    return method
+
+
+def _make_layer():
+    layer = torch.nn.Module()
+    layer.register_parameter(
+        "weight", torch.nn.Parameter(torch.ones((2, 2), dtype=torch.uint8), False)
+    )
+    layer.register_parameter(
+        "weight_scale",
+        torch.nn.Parameter(torch.ones((2, 1), dtype=torch.uint8), False),
+    )
+    return layer
+
+
+@pytest.mark.parametrize(("env_value", "expected"), [("0", False), ("1", True)])
+def test_cache_opt_in(monkeypatch, env_value, expected):
+    monkeypatch.setenv("VLLM_QUARK_MX_CACHE_DEQUANT_WEIGHT", env_value)
+    method = QuarkOCP_MX(
+        weight_quant_spec={"dtype": "fp4"},
+        input_quant_spec={"dtype": "fp4", "is_dynamic": True},
+    )
+
+    assert method.cache_dequant_weight is expected
+
+
+def test_cache_disabled_preserves_kernel_path():
+    method = _make_method(cache=False)
+    layer = _make_layer()
+    method.ocp_mx_linear.process_weights_after_loading = MagicMock()
+
+    method.process_weights_after_loading(layer)
+
+    method.ocp_mx_linear.process_weights_after_loading.assert_called_once_with(layer)
+    assert layer.weight_scale is not None
+
+
+def test_cache_dequantizes_once_and_releases_scale():
+    method = _make_method(cache=True)
+    layer = _make_layer()
+    dequantized = torch.ones((2, 4), dtype=torch.bfloat16)
+
+    with patch(
+        "vllm.model_executor.layers.quantization.quark.schemes.quark_ocp_mx.dequant_mxfp4",
+        return_value=dequantized,
+    ) as dequant:
+        method.process_weights_after_loading(layer)
+        method.process_weights_after_loading(layer)
+
+    dequant.assert_called_once()
+    assert layer.weight_scale is None
+    assert layer.weight.dtype == torch.bfloat16
+    assert layer.weight.device == dequantized.device
+    assert not layer.weight.requires_grad
+
+
+def test_cached_output_matches_uncached_and_keeps_activation_qdq():
+    cached = _make_method(cache=True)
+    uncached = _make_method(cache=False)
+    cached.ocp_mx_linear.quant_dequant_func.side_effect = lambda x: x * 0.5
+    uncached.ocp_mx_linear.quant_dequant_func.side_effect = lambda x: x * 0.5
+    cached_layer = _make_layer()
+    uncached_layer = _make_layer()
+    dequantized = torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.float32)
+    x = torch.tensor([[2.0, 4.0]], dtype=torch.float32)
+
+    with (
+        patch(
+            "vllm.model_executor.layers.quantization.quark.schemes.quark_ocp_mx.dequant_mxfp4",
+            return_value=dequantized,
+        ),
+        patch(
+            "vllm.model_executor.kernels.linear.mxfp4.emulation.dequant_mxfp4",
+            return_value=dequantized,
+        ),
+    ):
+        cached.process_weights_after_loading(cached_layer)
+        actual = cached.apply_weights(cached_layer, x)
+        expected = uncached.apply_weights(uncached_layer, x)
+
+    torch.testing.assert_close(actual, expected)
+    cached.ocp_mx_linear.quant_dequant_func.assert_called_once_with(x)
+    uncached.ocp_mx_linear.quant_dequant_func.assert_called_once_with(x)

--- a/vllm/model_executor/layers/quantization/quark/schemes/quark_ocp_mx.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/quark_ocp_mx.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
 from collections.abc import Callable
 from fractions import Fraction
 from typing import Any
 
 import torch
+import torch.nn.functional as F
 
 from vllm.logger import init_logger
 from vllm.model_executor.kernels.linear import (
@@ -14,6 +16,10 @@ from vllm.model_executor.kernels.linear import (
     init_mxfp4_linear_kernel,
     init_mxfp6_linear_kernel,
 )
+from vllm.model_executor.kernels.linear.mxfp4.emulation import (
+    EmulationMxfp4LinearKernel,
+)
+from vllm.model_executor.layers.quantization.utils.mxfp4_utils import dequant_mxfp4
 from vllm.model_executor.layers.quantization.utils.ocp_mx_utils import (
     OCP_MX_BLOCK_SIZE,
 )
@@ -63,6 +69,10 @@ class QuarkOCP_MX(QuarkScheme):
         self.weight_quant_spec = weight_quant_spec
         self.input_quant_spec = input_quant_spec
         self.dynamic_mxfp4_quant = dynamic_mxfp4_quant
+        self.cache_dequant_weight = (
+            os.environ.get("VLLM_QUARK_MX_CACHE_DEQUANT_WEIGHT", "0") == "1"
+        )
+        self._dequant_dtype: torch.dtype | None = None
         self.weight_dtype = weight_quant_spec["dtype"].replace("fp", "mxfp")
         self.input_dtype: str | None = None
         if input_quant_spec is not None:
@@ -152,6 +162,24 @@ class QuarkOCP_MX(QuarkScheme):
         if self.dynamic_mxfp4_quant:
             self.process_dynamic_mxfp4_weights_after_loading(layer)
 
+        if self.cache_dequant_weight and isinstance(
+            self.ocp_mx_linear, EmulationMxfp4LinearKernel
+        ):
+            if layer.weight_scale is None:
+                return
+            assert self._dequant_dtype is not None
+            layer.weight = torch.nn.Parameter(
+                dequant_mxfp4(layer.weight, layer.weight_scale, self._dequant_dtype),
+                requires_grad=False,
+            )
+            layer.register_parameter("weight_scale", None)
+            logger.warning_once(
+                "VLLM_QUARK_MX_CACHE_DEQUANT_WEIGHT=1 caches dequantized "
+                "Quark MXFP4 linear weights at load time. This improves "
+                "emulation latency at the cost of additional device memory."
+            )
+            return
+
         self.ocp_mx_linear.process_weights_after_loading(layer)
 
     def create_weights(
@@ -163,6 +191,7 @@ class QuarkOCP_MX(QuarkScheme):
         weight_loader: Callable,
         **kwargs,
     ):
+        self._dequant_dtype = params_dtype
         if self.dynamic_mxfp4_quant:
             weight = ModelWeightParameter(
                 data=torch.empty(
@@ -225,4 +254,11 @@ class QuarkOCP_MX(QuarkScheme):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        if (
+            self.cache_dequant_weight
+            and isinstance(self.ocp_mx_linear, EmulationMxfp4LinearKernel)
+            and layer.weight_scale is None
+        ):
+            qdq_x = self.ocp_mx_linear.quant_dequant_func(x)
+            return F.linear(qdq_x, layer.weight, bias)
         return self.ocp_mx_linear.apply_weights(layer, x, bias)


### PR DESCRIPTION
> **Superseded by #50814. This PR is retained only for history.**

## Summary

- Add `VLLM_QUARK_MX_CACHE_DEQUANT_WEIGHT=1` as an explicit opt-in for Quark MXFP4 linear emulation.
- Dequantize packed MXFP4 weights once after loading instead of on every linear invocation.
- Preserve activation quantize/dequantize semantics.

## Motivation

The emulation backend normally performs the same packed-weight dequantization for every invocation. For decode workloads this repeated work can dominate the shared/dense linear path. Caching moves that work to model load time, trading device memory for lower inference latency.

## Technical approach

The optimization activates only when:

1. `VLLM_QUARK_MX_CACHE_DEQUANT_WEIGHT=1` is set; and
2. the selected backend is `EmulationMxfp4LinearKernel`.

At load time:

- dynamic MXFP4 weight quantization still runs first when applicable;
- the packed E2M1 weight and E8M0 scale are dequantized using the model parameter dtype;
- the result is installed as a non-trainable parameter on the original device;
- `weight_scale` is unregistered after it is no longer needed;
- a repeated processing call is a no-op, so dequantization occurs only once.

At apply time, the cached weight is passed to `F.linear`, but the emulation backend's activation QDQ function is still called for every invocation.

## Precision and semantic boundary

This PR changes only the lifetime of weight dequantization. It intentionally does not implement or enable `VLLM_QUARK_MX_SKIP_ACTIVATION_QDQ`.

Therefore:

- packed checkpoint weights are unchanged on disk;
- activation QDQ remains part of the numerical path;
- native MXFP4 backends are unchanged;
- switch-off behavior remains the existing per-call dequantization path.

## Tests

```bash
python3 -m pytest -q tests/quantization/test_quark_ocp_mx_cache.py

ruff check \
  vllm/model_executor/layers/quantization/quark/schemes/quark_ocp_mx.py \
  tests/quantization/test_quark_ocp_mx_cache.py

ruff format --check \
  vllm/model_executor/layers/quantization/quark/schemes/quark_ocp_mx.py \
  tests/quantization/test_quark_ocp_mx_cache.py
```

Coverage and results:

- switch off preserves the original kernel path;
- switch on dequantizes once;
- `weight_scale` is released;
- cached and uncached outputs are close;
- cached dtype/device and `requires_grad=False` are preserved;
- activation QDQ is retained;
- total: `5 passed`;
- Ruff check and format check: passed.

## Historical performance evidence

The following older-runtime five-tier measurements used the cached fallback:

- con1: `90.97 ms` mean TPOT, `10.11 tok/s`;
- con4: `109.98 ms`, `31.59 tok/s`;
- con16: `153.79 ms`, `68.71 tok/s`;
- con32: `273.65 ms`, `86.36 tok/s`;
- con128: `288.38 ms`, `88.82 tok/s`.

On that runtime, con1 improved from full emulation `402.43 ms` to `90.97 ms`. The previously recorded con4 comparison was `177.14 ms -> 109.98 ms`.

On the newer #4450 attention runtime, the combined routed-A8W4 plus cached shared/dense fallback measured:

- con1 mean TPOT: `22.551 ms`;
- output throughput: `33.123 tok/s`;
- successful requests: `3/3`;
- versus BF16 `22.995 ms`: `-1.93%` TPOT.

The old-runtime values and #4450 con1 are different runtime populations and are not presented as one strict A/B series.

## Historical GSM8K evidence

For the K3 integration configuration:

- official emulation: `96.36% flexible`, `96.36% strict`;
- routed A8W4 plus per-call dense emulation: `96.21% flexible`, `96.21% strict`;
- routed A8W4 plus cached dense fallback: `96.29% flexible`, `96.36% strict`.

The cached configuration changed accuracy by `-0.07/+0.00 percentage points` versus official emulation and stayed within the `<=0.5 percentage point` gate.

These are model-level integration results, not generic unit-test guarantees. They also must not be attributed to the separate native A4W4 path, whose complete GSM8K 8-shot run is still pending.

## Memory trade-off

Observed on the K3 workload:

- approximately `+1.5 GiB` resident dequantized-weight memory;
- approximately `3.43 GiB` less memory available for KV cache.

The exact increase depends on model dimensions, dtype, and the number of emulated layers.

## Risks

- Extra resident weight memory can reduce KV-cache capacity or cause OOM.
- The environment switch is currently read directly rather than registered in the central vLLM environment registry.
- State-dict and distributed lifecycle behavior should receive broader integration coverage beyond the focused unit tests.

## Reviewer notes

Please review the parameter lifecycle, idempotence, activation-QDQ preservation, and whether the environment switch should move into the central registry. This first change intentionally avoids the separate skip-activation-QDQ semantic change.