### PR TITLE
[Superseded] [ROCm][Quark] Enable opt-in K3 SiTUv2 A8W4 routed MoE

### DIFF
--- a/tests/quantization/test_quark_k3_mxfp4.py
+++ b/tests/quantization/test_quark_k3_mxfp4.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import Mxfp4MoeBackend
+from vllm.model_executor.layers.quantization.quark import quark_moe
+
+
+@pytest.mark.parametrize(
+    ("scheme", "opt_in", "aiter_supported", "expected"),
+    [
+        ("w_mxfp4_a_mxfp4", True, True, True),
+        ("w_mxfp4_a_mxfp4", False, True, False),
+        ("w_mxfp4_a_mxfp4", True, False, False),
+        ("w_mxfp4", True, True, False),
+        ("w_mxfp4_a_fp8", True, True, False),
+    ],
+)
+def test_use_k3_situ_aiter_a8w4(monkeypatch, scheme, opt_in, aiter_supported, expected):
+    monkeypatch.setattr(quark_moe.envs, "AITER_SITUV2_A8W4", opt_in)
+    monkeypatch.setattr(quark_moe, "_use_k3_situ_aiter", lambda _moe: aiter_supported)
+
+    assert quark_moe._use_k3_situ_aiter_a8w4(MagicMock(), scheme) is expected
+
+
+def test_k3_situ_a8w4_keeps_tp8_intermediate_size():
+    method = object.__new__(quark_moe.QuarkOCP_MX_MoEMethod)
+    method.is_k3_situ_aiter_a8w4 = True
+    method.mxfp4_backend = Mxfp4MoeBackend.AITER_MXFP4_BF16
+
+    with patch.object(
+        quark_moe.QuarkMoEMethod,
+        "maybe_roundup_sizes",
+        return_value=(3584, 384),
+    ):
+        hidden_size, intermediate_size = method.maybe_roundup_sizes(
+            hidden_size=3584,
+            intermediate_size_per_partition=384,
+            act_dtype=MagicMock(),
+            moe_parallel_config=MagicMock(),
+        )
+
+    assert hidden_size == 3584
+    assert intermediate_size == 384

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -503,6 +503,45 @@ def _use_k3_situ_aiter(moe: FusedMoEConfig) -> bool:
     )
 
 
+def setup_k3_situ_aiter_weights(layer: RoutedExperts) -> None:
+    """Preshuffle K3 SiTU MXFP4 weights for AITER SiTUv2 kernels.
+
+    AITER's A8W4 SiTUv2 path uses an interleaved gate/up layout, while its
+    A16W4 path keeps gate and up blocks separated. Both consume the original
+    checkpoint's packed MXFP4 weights and E8M0 scales.
+    """
+    from aiter.utility.fp4_utils import e8m0_shuffle
+
+    from vllm._aiter_ops import rocm_aiter_ops
+
+    fp4_dtype = torch.float4_e2m1fn_x2
+    e8m0_dtype = torch.float8_e8m0fnu
+    num_experts = layer.w13_weight.shape[0]
+    guinterleave = envs.AITER_SITUV2_A8W4
+
+    w13 = rocm_aiter_ops.shuffle_weight_a16w4(
+        layer.w13_weight.data.view(fp4_dtype), 16, guinterleave
+    )
+    w2 = rocm_aiter_ops.shuffle_weight_a16w4(
+        layer.w2_weight.data.view(fp4_dtype), 16, False
+    )
+    w13_scale_raw = layer.w13_weight_scale.data.view(e8m0_dtype)
+    w2_scale_raw = layer.w2_weight_scale.data.view(e8m0_dtype)
+    w13_scale = rocm_aiter_ops.shuffle_scale_a16w4(
+        w13_scale_raw.view(-1, w13_scale_raw.shape[-1]),
+        num_experts,
+        guinterleave,
+    )
+    w2_scale = e8m0_shuffle(w2_scale_raw.view(-1, w2_scale_raw.shape[-1]))
+
+    replace_parameter(layer, "w13_weight", w13)
+    replace_parameter(layer, "w2_weight", w2)
+    replace_parameter(layer, "w13_weight_scale", w13_scale)
+    replace_parameter(layer, "w2_weight_scale", w2_scale)
+    layer.w13_weight.is_shuffled = True
+    layer.w2_weight.is_shuffled = True
+
+
 class Mxfp4MoEMethod(FusedMoEMethodBase):
     """MXFP4 MoE quantization method."""
 
@@ -775,40 +814,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             )
 
     def _setup_kernel_k3_situ(self, layer: RoutedExperts) -> None:
-        # K3's AITER A16W4 kernel wants the separated ([gate_all, up_all])
-        # stage-1 layout, unlike the interleaved gpt-oss/DeepSeek path in
-        # convert_weight_to_mxfp4_moe_kernel_format. Preshuffle once here.
-        from aiter.utility.fp4_utils import e8m0_shuffle
-
-        from vllm._aiter_ops import rocm_aiter_ops
-
-        fp4_dtype = torch.float4_e2m1fn_x2
-        e8m0_dtype = torch.float8_e8m0fnu
-        num_experts = layer.w13_weight.shape[0]
-
-        # a8w4 (AITER_SITUV2_A8W4=1) uses the gate/up-interleaved (_gui_) fp8
-        # flydsl kernels, which need w13 weight+scale in interleave layout.
-        # Default a16w4 keeps the separated layout.
-        guinterleave = envs.AITER_SITUV2_A8W4
-        w13 = rocm_aiter_ops.shuffle_weight_a16w4(
-            layer.w13_weight.data.view(fp4_dtype), 16, guinterleave
-        )
-        w2 = rocm_aiter_ops.shuffle_weight_a16w4(
-            layer.w2_weight.data.view(fp4_dtype), 16, False
-        )
-        w13_scale_raw = layer.w13_weight_scale.data.view(e8m0_dtype)
-        w2_scale_raw = layer.w2_weight_scale.data.view(e8m0_dtype)
-        w13_scale = rocm_aiter_ops.shuffle_scale_a16w4(
-            w13_scale_raw.view(-1, w13_scale_raw.shape[-1]), num_experts, guinterleave
-        )
-        w2_scale = e8m0_shuffle(w2_scale_raw.view(-1, w2_scale_raw.shape[-1]))
-
-        replace_parameter(layer, "w13_weight", w13)
-        replace_parameter(layer, "w2_weight", w2)
-        replace_parameter(layer, "w13_weight_scale", w13_scale)
-        replace_parameter(layer, "w2_weight_scale", w2_scale)
-        layer.w13_weight.is_shuffled = True
-        layer.w2_weight.is_shuffled = True
+        setup_k3_situ_aiter_weights(layer)
 
         self.moe_quant_config = self.get_fused_moe_quant_config(layer)
         if self.moe_quant_config is not None and self.experts_cls is not None:

--- a/vllm/model_executor/layers/quantization/quark/quark_moe.py
+++ b/vllm/model_executor/layers/quantization/quark/quark_moe.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
 from typing import Any
 
 import torch
 
+import vllm.envs as envs
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm import _custom_ops as ops
 from vllm._aiter_ops import rocm_aiter_ops
@@ -56,6 +58,10 @@ from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
     make_nvfp4_moe_quant_config,
     select_nvfp4_moe_backend,
 )
+from vllm.model_executor.layers.quantization.mxfp4 import (
+    _use_k3_situ_aiter,
+    setup_k3_situ_aiter_weights,
+)
 from vllm.model_executor.layers.quantization.utils.ocp_mx_utils import (
     OCP_MX_BLOCK_SIZE,
     OCP_MX_Scheme,
@@ -90,6 +96,17 @@ __all__ = [
     "QuarkOCP_MX_MoEMethod",
     "QuarkNvfp4MoEMethod",
 ]
+
+
+def _use_k3_situ_aiter_a8w4(
+    moe: FusedMoEConfig, ocp_mx_scheme: OCP_MX_Scheme | str
+) -> bool:
+    """Whether Quark K3 should override A4 activations with native A8."""
+    return (
+        ocp_mx_scheme == "w_mxfp4_a_mxfp4"
+        and envs.AITER_SITUV2_A8W4
+        and _use_k3_situ_aiter(moe)
+    )
 
 
 class QuarkMoEMethod(FusedMoEMethodBase):
@@ -1093,8 +1110,19 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
         else:
             self.static_input_scales = False
 
+        self.is_k3_situ_aiter_a8w4 = _use_k3_situ_aiter_a8w4(moe, self.ocp_mx_scheme)
+
         # Select backend based on OCP MX scheme
-        if self.ocp_mx_scheme == "w_mxfp4":
+        if self.is_k3_situ_aiter_a8w4:
+            # The checkpoint declares dynamic MXFP4 activations. This explicit
+            # opt-in keeps its packed MXFP4 weights/scales but quantizes SiTU
+            # activations to FP8 in AITER's native SiTUv2 A8W4 kernels.
+            self.mxfp4_backend = Mxfp4MoeBackend.AITER_MXFP4_BF16
+            self.experts_cls = backend_to_kernel_cls(self.mxfp4_backend)[0]
+            # Keep all token buckets on A8W4 so layout and compute semantics
+            # cannot silently switch back to A16W4 at low token counts.
+            os.environ["AITER_BF16_FP8_MOE_BOUND"] = "0"
+        elif self.ocp_mx_scheme == "w_mxfp4":
             # W4A16: weight-only MXFP4
             self.mxfp4_backend, self.experts_cls = select_mxfp4_moe_backend(moe)
         elif self.ocp_mx_scheme == "w_mxfp4_a_fp8" and self.static_input_scales:
@@ -1139,6 +1167,12 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
         logger.info_once(
             f"Using {self.mxfp4_backend.value} backend for {self.ocp_mx_scheme}"
         )
+        if self.is_k3_situ_aiter_a8w4:
+            logger.warning_once(
+                "Kimi-K3 Quark checkpoint declares dynamic MXFP4 activations; "
+                "AITER_SITUV2_A8W4=1 explicitly overrides routed-MoE activations "
+                "to FP8 and uses native AITER SiTUv2 A8W4 with MXFP4 weights."
+            )
 
     def maybe_roundup_sizes(
         self,
@@ -1155,6 +1189,10 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
         )
         # Round per-partition sizes up to each backend's requirement. Emulation is
         # handled inside the helper too (OCP MX block alignment), so no special-case.
+        if self.is_k3_situ_aiter_a8w4:
+            # K3's TP8 intermediate size is 384. AITER SiTUv2 handles it
+            # natively; generic MXFP4 rounding to 512 wastes memory and can OOM.
+            return hidden_size, intermediate_size_per_partition
         if self.mxfp4_backend is not None:
             hidden_size, intermediate_size_per_partition = (
                 mxfp4_round_up_hidden_size_and_intermediate_size(
@@ -1280,7 +1318,25 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
             layer.w2_input_scale = None
 
     def process_weights_after_loading(self, layer):
+        if self.is_k3_situ_aiter_a8w4:
+            self._setup_kernel_k3_situ(layer)
+            return
         self._setup_kernel(layer)
+
+    def _setup_kernel_k3_situ(self, layer: RoutedExperts) -> None:
+        setup_k3_situ_aiter_weights(layer)
+        torch.accelerator.empty_cache()
+
+        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
+        if self.moe_quant_config is not None and self.experts_cls is not None:
+            self.moe_kernel = make_mxfp4_moe_kernel(
+                moe_quant_config=self.moe_quant_config,
+                moe_config=self.moe,
+                mxfp4_backend=self.mxfp4_backend,
+                experts_cls=self.experts_cls,
+                routing_tables=layer._expert_routing_tables(),
+                layer=layer,
+            )
 
     def _setup_kernel(self, layer: RoutedExperts):
         """Setup kernel using oracle functions for MXFP4 schemes (W4A16, W4A8)."""


### PR DESCRIPTION
> **Superseded by #50813. This PR is retained only for history.**

## Summary

- Add an explicit opt-in route for K3 Quark `w_mxfp4_a_mxfp4` routed experts to the existing AITER SiTUv2 A8W4 path on gfx950.
- Share K3 MXFP4 weight/E8M0-scale preshuffle logic between the existing A16W4 path and the opt-in A8W4 path.
- Preserve K3's native TP8 intermediate size of 384 instead of rounding it to 512.

## Motivation

The checkpoint declares dynamic MXFP4 activations. K3 routed experts can instead use the existing AITER SiTUv2 implementation with packed MXFP4 weights and dynamically quantized FP8 activations. Because this changes activation precision, it must be explicit and narrowly capability-gated rather than silently selected for all Quark models.

## Enablement conditions

The override is selected only when all conditions hold:

1. the checkpoint scheme is exactly `w_mxfp4_a_mxfp4`;
2. `AITER_SITUV2_A8W4=1` is explicitly enabled;
3. ROCm AITER fused MoE is enabled;
4. the device is gfx950;
5. the MoE activation is SiTU with the required linear-beta metadata;
6. the existing AITER SiTU activation implementation is available.

The default path is unchanged when any condition is false.

## Technical approach

The checkpoint's packed E2M1 weights and E8M0 scales are retained. At load time:

- stage-1 gate/up weights are preshuffled with gate/up interleaving for the A8W4 SiTUv2 layout;
- stage-2 down weights use the non-interleaved layout;
- gate/up E8M0 scales are preshuffled with the same interleave decision;
- down scales use the AITER E8M0 shuffle;
- transformed tensors replace the original non-trainable parameters and are marked shuffled.

The routed-MoE backend then uses the existing AITER kernel class with FP8 activations. `AITER_BF16_FP8_MOE_BOUND=0` keeps every token bucket on the A8W4 path so layout and compute semantics do not switch at small token counts.

K3's TP8 intermediate size is 384. SiTUv2 supports this size directly, so the generic MXFP4 roundup to 512 is bypassed to avoid unnecessary weight growth and possible OOM.

## Precision and semantic boundary

This path is:

- MXFP4/E2M1 packed weight;
- E8M0 weight scales;
- FP8 activation in routed MoE;
- existing AITER SiTUv2 compute.

It is not strict A4W4, not full-model A4W4, and does not introduce a new AITER kernel. Shared and dense linear paths are outside this PR.

## Tests

```bash
python3 -m pytest -q tests/quantization/test_quark_k3_mxfp4.py

ruff check \
  vllm/model_executor/layers/quantization/mxfp4.py \
  vllm/model_executor/layers/quantization/quark/quark_moe.py \
  tests/quantization/test_quark_k3_mxfp4.py

ruff format --check \
  vllm/model_executor/layers/quantization/mxfp4.py \
  vllm/model_executor/layers/quantization/quark/quark_moe.py \
  tests/quantization/test_quark_k3_mxfp4.py
```

Results:

- Five routing/opt-in cases plus TP8 no-padding coverage: `6 passed`.
- Ruff check: passed.
- Ruff format check: passed.

## Historical end-to-end evidence

These are combined K3-path measurements, not isolated benchmarks of this PR.

On the #4450 attention runtime:

- BF16 con1 mean TPOT: `22.995 ms`;
- routed A8W4 plus cached-BF16 shared/dense fallback: `22.551 ms`;
- relative TPOT change: `-1.93%`;
- successful requests: `3/3`.

Historical GSM8K 8-shot results:

- official emulation: `96.36% flexible`, `96.36% strict`;
- routed A8W4 plus per-call dense emulation: `96.21% flexible`, `96.21% strict` (`-0.15 pp`);
- routed A8W4 plus cached dense fallback: `96.29% flexible`, `96.36% strict` (`-0.07/+0.00 pp`).

All measured routed-A8W4 combinations stayed within the `<=0.5 percentage point` accuracy-regression gate.

The repaired routed-A8W4 plus shared/dense native A4W4 configuration has not completed full GSM8K 8-shot. The cached-fallback score must not be attributed to native A4W4.

## Risks

- Opting in changes routed-expert activation precision from dynamic MXFP4 to FP8.
- Forcing the threshold to zero affects all token buckets for this explicitly selected path.
- Incorrect gate/up interleave or scale layout would cause silent numerical errors.
- This capability gate is intentionally K3 SiTU/gfx950-specific.

## Reviewer notes

Please review the opt-in boundary, weight/scale layout contract, all-bucket A8W4 behavior, and TP8 384 no-padding handling. The wording intentionally distinguishes this implementation from strict A4W4.