### PR TITLE
[Bugfix][Model] Kimi-K3: capture the post-attn_res hidden state for aux layer id == num_hidden_layers

### DIFF
--- a/tests/models/kimi_k3/test_eagle3.py
+++ b/tests/models/kimi_k3/test_eagle3.py
@@ -126,5 +126,53 @@ def test_kimi_linear_forward_extracts_attn_res_aux_hidden_states(monkeypatch):
 
     torch.testing.assert_close(output, final_hidden_states)
     torch.testing.assert_close(aux_hidden_states[0], initial_hidden_states)
-    torch.testing.assert_close(aux_hidden_states[1], prefix_sum + layer_hidden_states)
+    # Aux id `end_layer` is the last layer's *output*, which under attn-res is
+    # produced by the post-loop combination, not by `prefix_sum + hidden_states`.
+    torch.testing.assert_close(aux_hidden_states[1], final_hidden_states)
     assert final_attn_res.call_args.args[2] is block_residual
+
+
+def test_kimi_linear_attn_res_intermediate_aux_uses_prefix_sum(monkeypatch):
+    """Only the final aux id moves; intermediate ids keep prefix_sum + delta."""
+    model = _make_kimi_linear_model()
+    initial_hidden_states = torch.tensor([[1.0, 2.0]])
+    layer_hidden_states = torch.tensor([[3.0, 4.0]])
+    prefix_sum = torch.tensor([[5.0, 6.0]])
+    block_residual = torch.tensor([[[7.0, 8.0]]])
+    final_hidden_states = torch.tensor([[9.0, 10.0]])
+
+    object.__setattr__(model, "start_layer", 0)
+    object.__setattr__(model, "end_layer", 2)
+    layer = Mock(return_value=(layer_hidden_states, prefix_sum, block_residual))
+    object.__setattr__(model, "layers", [layer, layer])
+    object.__setattr__(model, "aux_hidden_state_layers", (1, 2))
+    object.__setattr__(model, "use_attn_res", True)
+    object.__setattr__(model, "num_attn_res_blocks", 1)
+    object.__setattr__(
+        model,
+        "output_attn_res_norm",
+        SimpleNamespace(weight=torch.ones(2), variance_epsilon=1e-5),
+    )
+    object.__setattr__(
+        model,
+        "output_attn_res_proj",
+        SimpleNamespace(weight=torch.ones(1, 2)),
+    )
+    monkeypatch.setattr(
+        kimi_model,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=True),
+    )
+    monkeypatch.setattr(kimi_model, "attn_res", Mock(return_value=final_hidden_states))
+
+    output, aux_hidden_states = model.forward(
+        input_ids=None,
+        positions=torch.tensor([0]),
+        intermediate_tensors=None,
+        inputs_embeds=initial_hidden_states,
+    )
+
+    assert len(aux_hidden_states) == 2
+    torch.testing.assert_close(aux_hidden_states[0], prefix_sum + layer_hidden_states)
+    torch.testing.assert_close(aux_hidden_states[1], final_hidden_states)
+    torch.testing.assert_close(output, final_hidden_states)

--- a/vllm/models/kimi_k3/amd/linear.py
+++ b/vllm/models/kimi_k3/amd/linear.py
@@ -794,6 +794,14 @@ class KimiLinearModel(nn.Module, EagleModelMixin):
             block_residual[:, : residual.size(1), :].copy_(residual)
         residual = block_residual
 
+        # See the NVIDIA backend: `_apply_attn_res` below, not the loop, produces
+        # the model's output hidden state, so aux id `end_layer` is captured
+        # after it.
+        capture_final_after_attn_res = (
+            get_pp_group().is_last_rank
+            and self.end_layer in self.aux_hidden_state_layers
+        )
+
         for layer_idx, layer in enumerate(
             self.layers[self.start_layer : self.end_layer],
             start=self.start_layer,
@@ -803,7 +811,9 @@ class KimiLinearModel(nn.Module, EagleModelMixin):
                 hidden_states=hidden_states,
                 residual=residual,
             )
-            if (layer_idx + 1) in self.aux_hidden_state_layers:
+            if (layer_idx + 1) in self.aux_hidden_state_layers and not (
+                capture_final_after_attn_res and layer_idx + 1 == self.end_layer
+            ):
                 # AMD attn-res layer already returns prefix_sum + MLP delta as
                 # hidden_states; the override drops the block bank in residual.
                 self._maybe_add_hidden_state(
@@ -822,6 +832,10 @@ class KimiLinearModel(nn.Module, EagleModelMixin):
             self.output_attn_res_norm,
             attn_res_block_num,
         )
+        if capture_final_after_attn_res:
+            # `end_layer` is the largest aux id, so appending here keeps
+            # aux_hidden_states ordered by layer id.
+            aux_hidden_states.append(hidden_states)
         # NOTE: the final norm is applied in compute_logits instead of here, so
         # the MTP draft model receives the pre-norm hidden states.
         if aux_hidden_states:

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -1109,6 +1109,18 @@ class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
             hidden_states = None
             residual = block_residual
 
+        # Under attn-res the model's output hidden state is not `prefix_sum +
+        # hidden_states`: it is produced after the loop by `attn_res`, which
+        # folds the block-residual bank in through `output_attn_res_norm` /
+        # `output_attn_res_proj`. Aux layer id `end_layer` is documented as the
+        # last layer's output, so on the last PP rank capture it after that
+        # combination instead of inside the loop.
+        capture_final_after_attn_res = (
+            self.use_attn_res
+            and get_pp_group().is_last_rank
+            and self.end_layer in self.aux_hidden_state_layers
+        )
+
         for layer_idx, layer in enumerate(
             self.layers[self.start_layer : self.end_layer],
             start=self.start_layer,
@@ -1119,7 +1131,9 @@ class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
                 prefix_sum=prefix_sum,
                 residual=residual,
             )
-            if (layer_idx + 1) in self.aux_hidden_state_layers:
+            if (layer_idx + 1) in self.aux_hidden_state_layers and not (
+                capture_final_after_attn_res and layer_idx + 1 == self.end_layer
+            ):
                 if self.use_attn_res:
                     assert prefix_sum is not None
                     aux_hidden_state = prefix_sum + hidden_states
@@ -1167,6 +1181,11 @@ class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
             # Gather SP-sharded hidden states.
             hidden_states = sp_all_gather(hidden_states)
             hidden_states = hidden_states[:full_num_tokens]
+
+        if capture_final_after_attn_res:
+            # `end_layer` is the largest aux id, so appending here keeps
+            # aux_hidden_states ordered by layer id.
+            aux_hidden_states.append(hidden_states)
 
         # NOTE: the final norm is applied in compute_logits instead of here, so
         # the MTP draft model receives the pre-norm hidden states.


### PR DESCRIPTION
## Purpose

Kimi-K3 uses a block-residual backbone (`attn_res_block_size`). Its output hidden state is **not** `prefix_sum + hidden_states` — it is produced after the layer loop by `attn_res`, which folds the block-residual bank in through `output_attn_res_norm` / `output_attn_res_proj`:

```python
# vllm/models/kimi_k3/nvidia/model.py
for layer_idx, layer in enumerate(...):
    hidden_states, prefix_sum, residual = layer(...)
    if (layer_idx + 1) in self.aux_hidden_state_layers:
        aux_hidden_state = prefix_sum + hidden_states     # <- also runs for layer_idx + 1 == end_layer
        aux_hidden_states.append(aux_hidden_state)
...
hidden_states = attn_res(prefix_sum, hidden_states, residual,
                         self.output_attn_res_norm.weight,
                         self.output_attn_res_proj.weight.squeeze(0), ...)
...
return hidden_states, aux_hidden_states                   # <- returned hidden != aux[-1]
```

So when `num_hidden_layers` is requested as an aux layer id, the captured tensor is missing the block-residual combination that the model's own output — and the MTP head — actually carries.

This contradicts the documented contract in [`docs/features/speculative_decoding/extract_hidden_states.md`](https://github.com/vllm-project/vllm/blob/main/docs/features/speculative_decoding/extract_hidden_states.md):

> It is possible to save the last-layer's output hidden states by passing `num_hidden_layers` as a layer id. Note that these are _not_ normalized using the output norm.

For every non-`attn_res` model that contract holds, because the in-loop `hidden_states + residual` is bit-identical to the post-loop `hidden_states + residual`. Kimi-K3 is the only model where the two diverge, which is why this went unnoticed.

**Who this affects.** This id is used as the KD target when training draft models against hidden states extracted from vLLM: trainers capture `num_hidden_layers` for `last_hidden_states`, apply the model's final norm themselves, and compute target logits from it. Today that teacher distribution is computed from the wrong tensor on Kimi-K3 — measurably so, see Test Result.

### Fix

Capture aux id `end_layer` after `attn_res` instead of inside the loop, on the last PP rank. Placement is after the SP all-gather so the sharding convention matches the in-loop captures, and appending last keeps `aux_hidden_states` ordered by layer id.

Guarded by three conditions, so nothing else changes:

- `use_attn_res` — non-attn-res paths are already correct and are untouched.
- `get_pp_group().is_last_rank` — on other PP ranks `end_layer` is a local boundary, `attn_res` does not run, and `prefix_sum + hidden_states` remains correct there.
- `end_layer in aux_hidden_state_layers` — zero cost and zero behavior change when the final layer is not requested.

**Intermediate aux ids are deliberately unchanged** — `prefix_sum + hidden_states` is the correct full activation at those depths.

Both backends have the identical gap, so `nvidia/model.py` and `amd/linear.py` get the same change.

> [!NOTE]
> **The `amd/linear.py` change is not hardware-validated.** It mirrors the NVIDIA backend structurally (in-loop `_maybe_add_hidden_state` guarded the same way, capture appended after `_apply_attn_res`), but all of my testing was on NVIDIA GB300. A ROCm reviewer's eyes on that half would be very welcome — and I am happy to drop it into a follow-up PR if maintainers would rather land the NVIDIA fix alone.

### Compatibility

`tests/models/kimi_k3/test_eagle3.py` asserted the old value, so this PR updates that assertion. I do not believe this breaks published checkpoints: draft models consume a fixed aux set at inference, and the Kimi-K3 draft published so far ([`Inferact/Kimi-K3-DSpark`](https://huggingface.co/Inferact/Kimi-K3-DSpark)) uses `target_layer_ids = [2, 23, 47, 71, 89]` → aux ids `[3, 24, 48, 72, 90]`, which never includes `93`. Serving behavior is therefore unchanged; only hidden-state *extraction* for training changes, and it changes toward the documented contract.

## Test Plan

Unit:

```bash
pytest tests/models/kimi_k3/test_eagle3.py
```

- `test_kimi_linear_forward_extracts_attn_res_aux_hidden_states` — updated: aux id `end_layer` must now equal the returned output hidden state, not `prefix_sum + hidden_states`.
- `test_kimi_linear_attn_res_intermediate_aux_uses_prefix_sum` — new: a 2-layer model with aux ids `(1, 2)` pins that the intermediate id still uses `prefix_sum + hidden_states` while only the final id moves.
- `test_kimi_linear_forward_extracts_standard_aux_hidden_states` — unchanged, covers the non-attn-res path.

Numerical, on a real Kimi-K3: capture aux id `num_hidden_layers` and check that it reconstructs the model's own next-token distribution. Run it twice, patched vs unpatched, changing nothing else.

## Test Result

Hardware: AWS GB300 NVL72 (aarch64), Kimi-K3 at TP8 across 2 nodes.

To keep the comparison honest about *what code ran*, the container was built from the nightly whose tree matches this PR's base exactly — `vllm/vllm-openai:nightly-e2fa28594f7baad142a426b0b6a2cfe2c79201c7` — whose `vllm/models/kimi_k3/nvidia/model.py` has sha256 `29d6e8d709180e35cf0a150735d6c36697b3342aae504f6ed4b65b122024cf2d`, byte-identical to `main`. The **only** difference between the two runs below is whether the patched file is bind-mounted over that path.

Serve config in both runs:

```
--speculative-config '{"method": "extract_hidden_states", "num_speculative_tokens": 1,
  "draft_model_config": {"hf_config": {"eagle_aux_hidden_state_layer_ids": [2,19,36,52,69,86,93]}}}'
```

`93 == num_hidden_layers` for Kimi-K3, i.e. exactly the id this PR changes.

### Does `aux[num_hidden_layers]` reconstruct the model output?

For a single request I dumped the captured hidden states (stock `ExampleHiddenStatesConnector`) *and* read the model's own next-token distribution back from the same request via `prompt_logprobs`. If that aux id really is the model's final hidden state, then applying the checkpoint's own `language_model.model.norm.weight` and `language_model.lm_head.weight` to it must reproduce those logprobs:

```
logprobs_reconstructed = log_softmax(lm_head(rms_norm(aux[:, -1, :])))
```

75 prompt tokens, `hidden_states` shape `(75, 7, 7168)`, 74 comparable positions:

| | `main` (unpatched) | **this PR** |
| --- | --- | --- |
| mean abs logprob error | 0.1127 | **3.12e-09** |
| median abs logprob error | 0.0292 | **0.0** |
| max abs logprob error | 0.6434 | **2.31e-07** |
| top-1 agreement | 0.9595 | **1.0000** |

With the patch the reconstruction is exact to float32 rounding. Without it, the captured tensor is demonstrably **not** the model's final hidden state — including the `attn_res` combination drops the mean error by ~7 orders of magnitude.

The unpatched numbers also explain why this went unnoticed: at ~96% top-1 agreement the captured tensor is a *perturbation* of the right one rather than garbage, so a draft model distilled against it still trains and still reaches non-trivial acceptance. It is simply being distilled against the wrong teacher distribution.

### End-to-end training

The patched build also ran a real draft-model training job (ModelOpt DSpark streaming, hidden states shipped to the trainer over NIXL/libfabric, same capture ids), 3 nodes, 30 steps: loss 15.03 → 11.34, `train_acc` 0.0099 → 0.0375, draft checkpoint exported. Serve came up clean and shut down clean; nothing downstream chokes on the moved tensor.

### Unit tests

Not yet executed locally — I do not have a built vLLM matching `main` on hand, and these tests are pure-mock so CI is the natural place to run them. Relying on CI for the first signal; will confirm before marking ready.

---

<details>
<summary>Unrelated issue found while testing: <code>extract_hidden_states</code> is broken with the default Ray executor on multi-node TP</summary>

Not part of this PR and not caused by it — recording it here because anyone reproducing the tests above will hit it immediately, and I could not find an existing report.

`extract_hidden_states` forces the V1 model runner:

```
WARNING [vllm.py:616] Model Runner V2 does not yet support speculative method
  'extract_hidden_states'; using the V1 model runner instead.
```

With `--distributed-executor-backend ray` and the default `VLLM_USE_RAY_V2_EXECUTOR_BACKEND=1`, engine init then dies:

```
ray.exceptions.ActorHandleNotFoundError: ActorHandle objects are not valid across Ray sessions.
  The actor handle was created in job 02000000, but the current job is 03000000.
...
RuntimeError: Engine core initialization failed.
```

Setting `VLLM_USE_RAY_V2_EXECUTOR_BACKEND=0` (selecting `RayDistributedExecutor`) makes it work. Since Kimi-K3 needs TP8 and GB300 nodes have 4 GPUs each, Ray is unavoidable there, so the default configuration is unusable for this workload. Happy to open a separate issue with the full trace if that is preferred.

</details>
