### PR TITLE
[Feature] Enable AITER MXFP4 MoE on gfx942 and optimize tile configurations for MI325X Target Kimi K3 running on MI325X

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -1580,6 +1580,7 @@ steps:
   - vllm/models/kimi_k3/nvidia/kda.py
   - vllm/models/kimi_k3/nvidia/kda_metadata.py
   - vllm/models/kimi_k3/nvidia/ops/third_party/kda/
+  - vllm/models/kimi_k3/amd/ops/third_party/kda/
   - tests/models/kimi_k3/test_kda.py
   - tests/models/kimi_k3/test_kda_metadata.py
   - vllm/platforms/rocm.py

--- a/benchmarks/kernels/benchmark_moe_a16w4_tiles.py
+++ b/benchmarks/kernels/benchmark_moe_a16w4_tiles.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tile-shape sweep for AITER's a16w4 MXFP4 MoE GEMM.
+
+AITER's ``get_kernel_config`` picks one tile shape for every AMD architecture.
+Its constants (``block_k=256``, ``block_n=512``, ``num_stages=1``) assume
+CDNA4's 160 KiB LDS; CDNA3 has 64 KiB, so the prefill tile leaves a large
+amount of throughput on the table there.
+
+This sweeps the tile shape for a given MoE geometry and reports the best
+config against the stock one. Defaults describe Kimi-K3 at TP=8.
+
+Example:
+    python benchmarks/kernels/benchmark_moe_a16w4_tiles.py \
+        --num-experts 896 --topk 16 --tokens 4096 \
+        --hidden 3584 --intermediate 768
+"""
+
+import argparse
+import itertools
+
+import torch
+
+from vllm.triton_utils import triton
+
+
+def _import_aiter():
+    import aiter.ops.triton.moe.moe_op_gemm_a16w4 as a16w4
+    from aiter.ops.triton.moe.moe_routing import routing as routing_mod
+    from triton_kernels.tensor import FP4, convert_layout, wrap_torch_tensor
+    from triton_kernels.tensor_details.layout import StridedLayout
+
+    return a16w4, routing_mod, (FP4, convert_layout, wrap_torch_tensor, StridedLayout)
+
+
+def _raw(t):
+    return t.storage.data if hasattr(t, "storage") else t
+
+
+def main(args: argparse.Namespace) -> None:
+    a16w4, routing_mod, (FP4, convert_layout, wrap, StridedLayout) = _import_aiter()
+    stock_config = a16w4.get_kernel_config
+    device = "cuda"
+    e, topk, m = args.num_experts, args.topk, args.tokens
+    k, n = args.hidden, args.intermediate
+
+    torch.manual_seed(args.seed)
+    x = torch.randn(m * topk, k, dtype=torch.bfloat16, device=device)
+    # Packed MXFP4: two values per byte, one e8m0 scale per 32 values. Values
+    # are irrelevant to timing, so build them directly to keep the footprint
+    # small enough to run alongside a loaded model.
+    w = torch.randint(0, 255, (e, n, k // 2), dtype=torch.uint8, device=device)
+    s = torch.randint(120, 134, (e, n, k // 32), dtype=torch.uint8, device=device)
+    wt = convert_layout(wrap(w.transpose(-2, -1), dtype=FP4), StridedLayout)
+    st = convert_layout(wrap(s.transpose(-2, -1)), StridedLayout)
+
+    logits = torch.randn(m, e, dtype=torch.bfloat16, device=device)
+    routing_data, gather_indx, _ = routing_mod.routing(logits, topk, sm_first=False)
+
+    def run():
+        return a16w4.moe_gemm_a16w4(
+            x, _raw(wt), None, _raw(st), None, None, None, routing_data,
+            gather_indx=gather_indx, swizzle_mx_scale=None, apply_swiglu=False,
+            unpadded_N=n, unpadded_K=k,
+        )
+
+    def bench() -> float:
+        for _ in range(3):
+            run()
+        torch.cuda.synchronize()
+        return triton.testing.do_bench(run, warmup=25, rep=100)
+
+    baseline = bench()
+    cfg = stock_config(m * topk, n, k, routing_data)
+    print(
+        f"stock: block_m={cfg['block_m']} block_n={cfg['block_n']} "
+        f"block_k={cfg['block_k']} warps={cfg['num_warps']} "
+        f"stages={cfg['num_stages']}  {baseline:.3f} ms"
+    )
+
+    def override(block_n, block_k, num_stages, num_warps):
+        def picker(m_, n_, k_, rd):
+            out = stock_config(m_, n_, k_, rd)
+            if out["block_m"] >= args.min_block_m:
+                out.update(
+                    block_n=block_n, block_k=block_k,
+                    num_stages=num_stages, num_warps=num_warps,
+                )
+            return out
+
+        return picker
+
+    best = (baseline, "stock")
+    grid = itertools.product(args.block_n, args.block_k, args.stages, args.warps)
+    for block_n, block_k, num_stages, num_warps in grid:
+        a16w4.get_kernel_config = override(block_n, block_k, num_stages, num_warps)
+        try:
+            elapsed = bench()
+        except Exception as exc:  # noqa: BLE001 - OOM on LDS is an expected outcome
+            print(
+                f"  block_n={block_n:3d} block_k={block_k:3d} stages={num_stages} "
+                f"warps={num_warps}: skipped ({type(exc).__name__})"
+            )
+            continue
+        finally:
+            a16w4.get_kernel_config = stock_config
+        label = (
+            f"block_n={block_n} block_k={block_k} "
+            f"stages={num_stages} warps={num_warps}"
+        )
+        if elapsed < best[0]:
+            best = (elapsed, label)
+        if elapsed < baseline:
+            print(f"  {label}: {elapsed:7.3f} ms  {baseline / elapsed:.2f}x")
+
+    print(f"best: {best[1]}  {best[0]:.3f} ms  ({baseline / best[0]:.2f}x vs stock)")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--num-experts", type=int, default=896)
+    parser.add_argument("--topk", type=int, default=16)
+    parser.add_argument("--tokens", type=int, default=4096)
+    parser.add_argument("--hidden", type=int, default=3584, help="GEMM K")
+    parser.add_argument("--intermediate", type=int, default=768, help="GEMM N")
+    parser.add_argument("--min-block-m", type=int, default=64,
+                        help="only override tiles at or above this block_m")
+    parser.add_argument("--block-n", type=int, nargs="+", default=[128, 256, 512])
+    parser.add_argument("--block-k", type=int, nargs="+", default=[64, 128, 256])
+    parser.add_argument("--stages", type=int, nargs="+", default=[1, 2])
+    parser.add_argument("--warps", type=int, nargs="+", default=[4, 8])
+    parser.add_argument("--seed", type=int, default=0)
+    main(parser.parse_args())

--- a/tests/kernels/attention/test_rocm_aiter_mla_small_head_pad.py
+++ b/tests/kernels/attention/test_rocm_aiter_mla_small_head_pad.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""AITER MLA decode with fewer than 16 query heads on non-CDNA4 ROCm.
+
+AITER's small-head decode kernel (``mla_gluon``) asserts gfx950, so elsewhere
+the backend pads q up to 16 heads and drops the filler from the output. Head
+counts that divide 16 are widened by whole repeats; the rest (e.g. Kimi-K3's
+96 heads at TP=8 -> 12) are zero-padded. Both must round-trip exactly, which
+holds only because the decode kernel treats query heads independently.
+"""
+
+import pytest
+import torch
+
+from vllm._aiter_ops import is_aiter_found, rocm_aiter_ops
+from vllm.platforms import current_platform
+
+KV_LORA_RANK = 512
+QK_ROPE_HEAD_DIM = 64
+HEAD_DIM = KV_LORA_RANK + QK_ROPE_HEAD_DIM
+
+
+def _on_rocm_aiter() -> bool:
+    return current_platform.is_rocm() and is_aiter_found()
+
+
+pytestmark = pytest.mark.skipif(
+    not _on_rocm_aiter(),
+    reason="AITER MLA small-head padding is ROCm-only",
+)
+
+
+@pytest.mark.parametrize("num_heads", [1, 4, 5, 8, 9, 12])
+def test_pad_unpad_round_trip(num_heads: int):
+    from vllm.v1.attention.backends.mla.rocm_aiter_mla import AiterMLAHelper
+
+    q = torch.randn(4, num_heads, HEAD_DIM, dtype=torch.bfloat16, device="cuda")
+    padded = AiterMLAHelper.get_mla_padded_q(num_heads, q)
+
+    assert padded.shape[1] == AiterMLAHelper._AITER_MIN_MLA_HEADS
+    assert torch.equal(AiterMLAHelper.get_mla_unpadded_o(num_heads, padded), q)
+
+
+def test_gluon_decode_only_on_gfx950():
+    """Small-head decode must not select Gluon where the kernel cannot run."""
+    from vllm.platforms.rocm import on_gfx950
+    from vllm.v1.attention.backends.mla.rocm_aiter_mla import AiterMLAHelper
+
+    assert AiterMLAHelper.use_gluon_decode(12, 1) is on_gfx950()
+
+
+@pytest.mark.parametrize("num_heads", [1, 5, 9, 12])
+@torch.inference_mode()
+def test_decode_ignores_padded_heads(num_heads: int):
+    """Zeroing heads >= num_heads must not perturb the retained head outputs."""
+    torch.manual_seed(0)
+    batch, seq_len = 4, 128
+    device = "cuda"
+    scale = HEAD_DIM**-0.5
+    min_heads = 16
+
+    q = torch.randn(batch, min_heads, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    kv = torch.randn(batch * seq_len, 1, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    kv_indptr = torch.arange(
+        0, (batch + 1) * seq_len, seq_len, dtype=torch.int32, device=device
+    )
+    kv_indices = torch.arange(batch * seq_len, dtype=torch.int32, device=device)
+    last_page_len = torch.ones(batch, dtype=torch.int32, device=device)
+    qo_indptr = torch.arange(batch + 1, dtype=torch.int32, device=device)
+
+    def decode(query: torch.Tensor) -> torch.Tensor:
+        out = torch.empty(
+            batch, min_heads, KV_LORA_RANK, dtype=query.dtype, device=device
+        )
+        rocm_aiter_ops.mla_decode_fwd(
+            query,
+            kv.unsqueeze(2),
+            out,
+            scale,
+            qo_indptr,
+            1,
+            kv_indptr,
+            kv_indices,
+            last_page_len,
+            q_scale=None,
+            kv_scale=None,
+        )
+        return out
+
+    reference = decode(q)
+    zero_filled = q.clone()
+    zero_filled[:, num_heads:, :] = 0
+
+    assert torch.equal(reference[:, :num_heads], decode(zero_filled)[:, :num_heads])

--- a/tests/kernels/moe/test_ocp_mx_moe.py
+++ b/tests/kernels/moe/test_ocp_mx_moe.py
@@ -29,13 +29,15 @@ ROCM_AVAILABLE = current_platform.is_rocm()
 ROCM_TRITON_KERNELS_AVAILABLE = False
 ROCM_AITER_AVAILABLE = is_aiter_found()
 ROCM_GFX950 = False
+ROCM_MI3XX = False
 
 if ROCM_AVAILABLE:
-    from vllm.platforms.rocm import on_gfx950
+    from vllm.platforms.rocm import on_gfx950, on_mi3xx
     from vllm.utils.import_utils import has_triton_kernels
 
     ROCM_TRITON_KERNELS_AVAILABLE = has_triton_kernels()
     ROCM_GFX950 = on_gfx950()
+    ROCM_MI3XX = on_mi3xx()
 
     if ROCM_AITER_AVAILABLE:
         from aiter.ops.triton.moe.quant_moe import upcast_from_mxfp
@@ -1207,7 +1209,9 @@ ROCM_BACKEND_CONFIGS = {
         "rtol": 1.0,
         "percent": 0.7,
         "requires_aiter": True,
-        "requires_gfx950": True,
+        # gfx950 runs the CK kernel, gfx942 the Triton a16w4 kernel.
+        "requires_gfx950": False,
+        "requires_mi3xx": True,
     },
     "AITER_MXFP4_FP8": {
         "activation": "SWIGLUOAI",
@@ -1256,6 +1260,8 @@ def test_rocm_mxfp4_moe_oracle(
         pytest.skip(f"Backend {backend_name} requires AITER")
     if config["requires_gfx950"] and not ROCM_GFX950:
         pytest.skip(f"Backend {backend_name} requires GFX950")
+    if config.get("requires_mi3xx") and not ROCM_MI3XX:
+        pytest.skip(f"Backend {backend_name} requires MI3xx")
 
     import vllm.distributed.parallel_state as ps
     from vllm.config import VllmConfig, set_current_vllm_config
@@ -1266,6 +1272,9 @@ def test_rocm_mxfp4_moe_oracle(
         convert_gpt_oss_weight_to_mxfp4_moe_kernel_format,
         make_mxfp4_moe_kernel,
         make_mxfp4_moe_quant_config,
+    )
+    from vllm.model_executor.layers.quantization.utils.mxfp4_utils import (
+        use_aiter_mxfp4_triton_moe,
     )
     from vllm.v1.worker.workspace import init_workspace_manager
 
@@ -1286,8 +1295,14 @@ def test_rocm_mxfp4_moe_oracle(
     if experts_cls_list is None or len(experts_cls_list) == 0:
         pytest.skip(f"Backend {backend_name} not available")
 
-    # Use first experts class
-    experts_cls = experts_cls_list[0]
+    # Mirror production selection: AITER_MXFP4_BF16 exposes the CK experts
+    # first and the Triton a16w4 experts second; only the latter runs on gfx942.
+    aiter_uses_triton_kernel = (
+        backend == Mxfp4MoeBackend.AITER_MXFP4_BF16 and use_aiter_mxfp4_triton_moe()
+    )
+    experts_cls = (
+        experts_cls_list[-1] if aiter_uses_triton_kernel else experts_cls_list[0]
+    )
 
     torch.manual_seed(42)
     dtype = torch.bfloat16
@@ -1463,6 +1478,12 @@ def test_rocm_mxfp4_moe_oracle(
     # SWIGLUOAI uses interleaved layout (gate/up alternating)
     # SILU uses chunked layout (first half gate, second half up)
     use_interleaved = activation == MoEActivation.SWIGLUOAI
+    ref_limit = 7.0 if activation == MoEActivation.SWIGLUOAI else None
+    if aiter_uses_triton_kernel:
+        # The Triton a16w4 kernel keeps the checkpoint's interleaved gate/up
+        # layout (the CK path de-interleaves it) and always clamps swiglu.
+        use_interleaved = True
+        ref_limit = 7.0
     if activation in [MoEActivation.SWIGLUOAI, MoEActivation.SILU]:
         act_name = "swiglu"
     else:
@@ -1479,7 +1500,7 @@ def test_rocm_mxfp4_moe_oracle(
         w2_bias.to(torch.float32),
         alpha=1.702 if activation == MoEActivation.SWIGLUOAI else 1.0,
         beta=1.0 if activation == MoEActivation.SWIGLUOAI else 0.0,
-        limit=7.0 if activation == MoEActivation.SWIGLUOAI else None,
+        limit=ref_limit,
         act_type="bf16",
         activation=act_name,
         use_interleaved_layout=use_interleaved,

--- a/tools/vllm-rocm/README_kimi_k3_mi325x.md
+++ b/tools/vllm-rocm/README_kimi_k3_mi325x.md
@@ -1,0 +1,80 @@
+# Serving Kimi-K3 on 8x MI325X (gfx942)
+
+Notes from bringing `moonshotai/Kimi-K3` up on CDNA3. The model is
+~2.75 T parameters, MXFP4 (`mxfp4-pack-quantized`), ~1.5 TB on disk.
+
+## Parallelism is forced
+
+K3 has 96 attention heads and 1.5 TB of weights against 2 TB of HBM.
+
+| TP | heads/rank | weights/GPU | viable |
+| -- | ---------- | ----------- | ------ |
+| 8  | 12         | ~195 GB     | yes    |
+| 6  | 16         | ~260 GB     | no, exceeds 256 GB (and 7168 % 6 != 0) |
+| 4  | 24         | ~390 GB     | no     |
+
+TP=8 is the only configuration that fits, and it puts fewer than 16 heads
+per rank, which is why the AITER MLA small-head padding path matters here.
+
+## Serving
+
+```bash
+export VLLM_ROCM_USE_AITER=1
+export VLLM_ROCM_USE_AITER_MOE=1
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+
+vllm serve moonshotai/Kimi-K3 \
+  --served-model-name kimi-k3 \
+  --tensor-parallel-size 8 \
+  --trust-remote-code \
+  --max-model-len 131072 \
+  --gpu-memory-utilization 0.97 \
+  --max-num-seqs 512 \
+  --limit-mm-per-prompt.image 1 \
+  --reasoning-parser kimi_k3 \
+  --tool-call-parser kimi_k3 \
+  --enable-auto-tool-choice
+```
+
+`--max-num-seqs` must stay under the number of available Mamba/KDA state
+blocks. K3 has 69 KDA layers and every concurrent decode sequence needs one
+state block, so the default 1024 fails CUDA graph capture:
+
+```
+ValueError: max_num_seqs (1024) exceeds available Mamba cache blocks (854)
+```
+
+At `--gpu-memory-utilization 0.97` this yields ~1.39 M tokens of KV cache,
+about 10.6x concurrency at 128 k context.
+
+## Client-side settings that matter for quality
+
+K3 is a reasoning model. The `kimi_k3` reasoning parser *strips* the think
+channel rather than surfacing it, and it strips on the closing marker. If
+`max_tokens` truncates generation before that marker is emitted, the raw
+chain-of-thought is returned as `content` instead of an answer.
+
+The template defaults to `thinking_effort=max`, which is both the most
+expensive and the least reliable setting for tool calls. Measured tool-call
+emission, 6 trials per cell:
+
+| schema  | default (max) | low | high | thinking off |
+| ------- | ------------- | --- | ---- | ------------ |
+| 1-param | 6/6           | 6/6 | 6/6  | 0/6          |
+| 2-param | 3/6           | 6/6 | 6/6  | 3/6          |
+| 3-param | 6/6           | 6/6 | 6/6  | 0/6          |
+
+Recommended: `chat_template_kwargs={"thinking_effort": "low"}`. It is 18/18
+on tool calls and ~3.5x cheaper in tokens than the default (44 vs 167 tokens
+for `17 * 23`; 115 vs 432 for a two-sentence comparison).
+
+Do **not** set `{"thinking": false}` if you use tools -- it is the worst
+configuration measured. Valid efforts are `low`, `high`, `max`; the template
+advertises `medium` in its own system message but the validator rejects it.
+
+## CDNA3 MoE tile shapes
+
+AITER's a16w4 tile selection is architecture-blind and sized for CDNA4's
+160 KiB LDS. On gfx942 (64 KiB) that costs ~1.9x end-to-end prefill. See
+`patch_aiter_cdna3_moe_tiles.py` in this directory and
+`benchmarks/kernels/benchmark_moe_a16w4_tiles.py`.

--- a/tools/vllm-rocm/patch_aiter_cdna3_moe_tiles.py
+++ b/tools/vllm-rocm/patch_aiter_cdna3_moe_tiles.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Make AITER's a16w4 MXFP4 MoE tile selection LDS-aware on CDNA3 (gfx942).
+
+AITER's ``get_kernel_config`` picks one tile shape for every AMD architecture:
+``block_k=256``, ``block_n=512``, ``num_stages=1``. Those suit CDNA4's 160 KiB
+of LDS. CDNA3 has 64 KiB, so the prefill tile runs at very low occupancy there.
+
+``aiter.ops.triton.utils._triton.arch_info._LDS_CAP_BYTES`` already records the
+per-arch capacity and is consulted by pa_decode_sparse, gemm_config_utils and
+sparse_attention_dsv4 -- the MoE GEMM is the one kernel that skips it.
+
+Measured on MI325X with Kimi-K3 shapes (E=896, topk=16, TP=8, 4096 tokens):
+
+    gemm1 K=3584 N=768  : 8.208 ms -> 1.303 ms  (6.30x)
+    gemm2 K=384  N=7168 : 8.019 ms -> 1.701 ms  (4.72x)
+
+End to end that is ~1.9x prefill throughput on a served Kimi-K3. Decode is
+untouched: at block_m 16/32 the staging is 12-32 KiB, already well inside
+64 KiB, so only tiles at or above block_m=64 are overridden.
+
+This is a stopgap. The durable fix is upstream in ROCm/aiter, deriving
+block_k from _LDS_CAP_BYTES instead of hardcoding it. Re-derive the constants
+for other geometries with benchmarks/kernels/benchmark_moe_a16w4_tiles.py.
+
+Usage:
+    python tools/vllm-rocm/patch_aiter_cdna3_moe_tiles.py
+    python tools/vllm-rocm/patch_aiter_cdna3_moe_tiles.py --revert
+"""
+
+import argparse
+import importlib.util
+import shutil
+import sys
+
+MODULE = "aiter.ops.triton.moe.moe_op_gemm_a16w4"
+MARKER = "# --- CDNA3 (gfx942) LDS-aware tile override"
+
+OVERRIDE = f'''
+
+{MARKER} ---
+# Appended by tools/vllm-rocm/patch_aiter_cdna3_moe_tiles.py. The stock
+# function is left intact and still reachable as _stock_get_kernel_config.
+_stock_get_kernel_config = get_kernel_config
+
+
+def _cdna3_get_kernel_config(m, n, k, routing_data):
+    cfg = _stock_get_kernel_config(m, n, k, routing_data)
+    if cfg["block_m"] >= 64:
+        # Halving block_k is the dominant win: it shrinks the A and B LDS
+        # tiles together, restoring occupancy and making 2 stages viable.
+        cfg["block_k"] = 128
+        if n <= 1024:
+            cfg["block_n"], cfg["num_warps"], cfg["num_stages"] = 128, 4, 1
+        else:
+            cfg["block_n"], cfg["num_warps"], cfg["num_stages"] = 512, 8, 2
+    return cfg
+
+
+try:
+    from aiter.ops.triton.utils._triton import arch_info as _arch_info
+
+    if _arch_info.get_arch() == "gfx942":
+        get_kernel_config = _cdna3_get_kernel_config
+except Exception:  # noqa: BLE001 - never break import on a probe failure
+    pass
+'''
+
+
+def locate() -> str:
+    spec = importlib.util.find_spec(MODULE)
+    if spec is None or not spec.origin:
+        raise SystemExit(f"cannot locate {MODULE}; is aiter installed?")
+    return spec.origin
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--revert", action="store_true")
+    args = parser.parse_args()
+
+    target = locate()
+    backup = target + ".orig"
+
+    if args.revert:
+        try:
+            shutil.copyfile(backup, target)
+        except FileNotFoundError:
+            print("no backup found; nothing to revert")
+            return 0
+        print("reverted", target)
+        return 0
+
+    source = open(target).read()
+    if MARKER in source:
+        print("already patched:", target)
+        return 0
+
+    try:
+        open(backup).close()
+    except FileNotFoundError:
+        shutil.copyfile(target, backup)
+        print("backed up to", backup)
+
+    open(target, "w").write(source + OVERRIDE)
+    print("patched", target)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vllm/model_executor/layers/fused_moe/experts/aiter_mxfp4_w4a8_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/aiter_mxfp4_w4a8_moe.py
@@ -426,6 +426,8 @@ def aiter_triton_kernel_w4a16_moe_forward(
     e_score_correction_bias: torch.Tensor | None = None,
     routed_scaling_factor: float | None = None,
     score_mode: str | None = None,
+    situ_beta: float | None = None,
+    situ_linear_beta: float | None = None,
 ):
     assert quant_config is not None and rocm_aiter_ops.is_enabled()
     from vllm.platforms.rocm import on_gfx1250
@@ -509,6 +511,9 @@ def aiter_triton_kernel_w4a16_moe_forward(
 
     # SILU: silu(gate) * up — same kernel, just no "+1" residual in swiglu.
     swiglu_add_residual = activation != MoEActivation.SILU
+    # SiTU has no in-kernel form, so run gemm1 unfused and apply it in between.
+    # Only the activations round-trip through HBM, never the expert weights.
+    fuse_activation = activation != MoEActivation.SITU
 
     intermediate = moe_gemm_a16w4(
         hidden_states,
@@ -522,13 +527,30 @@ def aiter_triton_kernel_w4a16_moe_forward(
         gather_indx=gather_idx,
         gammas=gammas if apply_router_weight_on_input else None,
         swizzle_mx_scale=None,
-        apply_swiglu=True,
+        apply_swiglu=fuse_activation,
         alpha=swiglu_alpha,
         limit=swiglu_limit,
         swiglu_add_residual=swiglu_add_residual,
         unpadded_N=unpadded_N_w1,
         unpadded_K=unpadded_K_w1,
     )
+
+    if not fuse_activation:
+        assert situ_beta is not None, (
+            "SITU requires activation_situ_beta from FusedMoEConfig"
+        )
+        gated = torch.empty(
+            (*intermediate.shape[:-1], intermediate.shape[-1] // 2),
+            dtype=intermediate.dtype,
+            device=intermediate.device,
+        )
+        torch.ops._C.situ_and_mul(
+            gated,
+            intermediate.contiguous(),
+            situ_beta,
+            -1.0 if situ_linear_beta is None else situ_linear_beta,
+        )
+        intermediate = gated
 
     out = moe_gemm_a16w4(
         intermediate,
@@ -562,6 +584,8 @@ class AiterW4A16ExpertsMonolithic(mk.FusedMoEExpertsMonolithic):
             RoutingMethodType.RenormalizeNaive,
             RoutingMethodType.DeepseekV4,
         )
+        self.situ_beta = moe_config.activation_situ_beta
+        self.situ_linear_beta = moe_config.activation_situ_linear_beta
 
     @staticmethod
     def activation_format() -> mk.FusedMoEActivationFormat:
@@ -588,7 +612,11 @@ class AiterW4A16ExpertsMonolithic(mk.FusedMoEExpertsMonolithic):
 
     @staticmethod
     def _supports_activation(activation: MoEActivation) -> bool:
-        return activation in (MoEActivation.SWIGLUOAI, MoEActivation.SILU)
+        return activation in (
+            MoEActivation.SWIGLUOAI,
+            MoEActivation.SILU,
+            MoEActivation.SITU,
+        )
 
     @staticmethod
     def _supports_parallel_config(
@@ -667,4 +695,6 @@ class AiterW4A16ExpertsMonolithic(mk.FusedMoEExpertsMonolithic):
             e_score_correction_bias=e_score_correction_bias,
             routed_scaling_factor=routed_scaling_factor,
             score_mode=score_mode,
+            situ_beta=self.situ_beta,
+            situ_linear_beta=self.situ_linear_beta,
         )

--- a/vllm/model_executor/layers/fused_moe/experts/aiter_mxfp4_w4a8_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/aiter_mxfp4_w4a8_moe.py
@@ -12,6 +12,9 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
     RoutingMethodType,
 )
+from vllm.model_executor.layers.quantization.utils.mxfp4_utils import (
+    use_aiter_mxfp4_triton_moe,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
     kFp8StaticTensorSym,
@@ -568,9 +571,9 @@ class AiterW4A16ExpertsMonolithic(mk.FusedMoEExpertsMonolithic):
     def _supports_current_device() -> bool:
         if not rocm_aiter_ops.is_enabled():
             return False
-        from vllm.platforms.rocm import on_gfx950, on_gfx1250
+        from vllm.platforms.rocm import on_gfx950
 
-        return on_gfx950() or on_gfx1250()
+        return on_gfx950() or use_aiter_mxfp4_triton_moe()
 
     @staticmethod
     def _supports_no_act_and_mul() -> bool:

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -26,7 +26,10 @@ from vllm.model_executor.layers.fused_moe.config import (
     mxfp4_w4a16_moe_quant_config,
     ocp_mx_moe_quant_config,
 )
-from vllm.model_executor.layers.quantization.utils.mxfp4_utils import _swizzle_mxfp4
+from vllm.model_executor.layers.quantization.utils.mxfp4_utils import (
+    _swizzle_mxfp4,
+    use_aiter_mxfp4_triton_moe,
+)
 from vllm.model_executor.layers.quantization.utils.ocp_mx_utils import (
     OCP_MX_BLOCK_SIZE,
 )
@@ -1015,12 +1018,34 @@ def convert_gpt_oss_weight_to_mxfp4_moe_kernel_format(
         )
 
     elif mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16:
-        from vllm._aiter_ops import rocm_aiter_ops
-
         if w13_bias is not None:
             w13_bias = w13_bias.data.to(torch.float32)
         if w2_bias is not None:
             w2_bias = w2_bias.data.to(torch.float32)
+
+        if use_aiter_mxfp4_triton_moe():
+            # The Triton a16w4 kernel consumes the checkpoint's interleaved
+            # gate/up layout directly, like the other Triton backends.
+            from triton_kernels.matmul_ogs import FlexCtx, PrecisionConfig
+
+            w13_weight, w13_flex, w13_scale = _swizzle_mxfp4(
+                w13_weight, w13_weight_scale
+            )
+            w2_weight, w2_flex, w2_scale = _swizzle_mxfp4(w2_weight, w2_weight_scale)
+            return (
+                w13_weight,
+                w2_weight,
+                PrecisionConfig(
+                    weight_scale=w13_scale, flex_ctx=FlexCtx(rhs_data=w13_flex)
+                ),
+                PrecisionConfig(
+                    weight_scale=w2_scale, flex_ctx=FlexCtx(rhs_data=w2_flex)
+                ),
+                w13_bias,
+                w2_bias,
+            )
+
+        from vllm._aiter_ops import rocm_aiter_ops
 
         e, n, k = w13_weight.shape
 
@@ -1269,8 +1294,6 @@ def convert_weight_to_mxfp4_moe_kernel_format(
 
     Supports DeepGEMM, TRTLLM MXFP8, Triton and Marlin backends.
     """
-    from vllm.platforms.rocm import on_gfx1250
-
     if mxfp4_backend == Mxfp4MoeBackend.DEEPGEMM_MXFP4:
         w13_weight_scale, w2_weight_scale = _pack_deepgemm_mxfp4_scales(
             w13_weight,
@@ -1442,7 +1465,10 @@ def convert_weight_to_mxfp4_moe_kernel_format(
             w2_bias,
         )
 
-    elif mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16 and not on_gfx1250():
+    elif (
+        mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16
+        and not use_aiter_mxfp4_triton_moe()
+    ):
         # Initially introduced for DeepSeekV4
 
         if w13_bias is not None:
@@ -1500,7 +1526,8 @@ def convert_weight_to_mxfp4_moe_kernel_format(
         )
 
     elif mxfp4_backend in TRITON_BACKENDS or (
-        mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16 and on_gfx1250()
+        mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16
+        and use_aiter_mxfp4_triton_moe()
     ):
         from triton_kernels.matmul_ogs import FlexCtx, PrecisionConfig
 

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -36,6 +36,9 @@ from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig,
     QuantizeMethodBase,
 )
+from vllm.model_executor.layers.quantization.utils.mxfp4_utils import (
+    use_aiter_mxfp4_triton_moe,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import is_layer_skipped
 from vllm.model_executor.utils import replace_parameter, set_weight_attrs
 
@@ -354,7 +357,11 @@ class GptOssMxfp4MoEMethod(FusedMoEMethodBase):
 
         # For TRITON backends, weights are wrapped tensors from triton_kernels
         # that don't support .detach(). Manually assign parameters.
-        if self.mxfp4_backend not in TRITON_BACKENDS:
+        uses_triton_weight_format = self.mxfp4_backend in TRITON_BACKENDS or (
+            self.mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16
+            and use_aiter_mxfp4_triton_moe()
+        )
+        if not uses_triton_weight_format:
             replace_parameter(layer, "w13_weight", w13)
             replace_parameter(layer, "w2_weight", w2)
             replace_parameter(layer, "w13_weight_scale", w13_scale)
@@ -365,8 +372,11 @@ class GptOssMxfp4MoEMethod(FusedMoEMethodBase):
             self.w13_precision_config = w13_scale
             self.w2_precision_config = w2_scale
 
-        # AITER backend requires weights to be marked as shuffled.
-        if self.mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16:
+        # AITER's CK kernel requires weights to be marked as shuffled.
+        if (
+            self.mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16
+            and not uses_triton_weight_format
+        ):
             layer.w13_weight.is_shuffled = True
             layer.w2_weight.is_shuffled = True
 
@@ -407,7 +417,10 @@ class GptOssMxfp4MoEMethod(FusedMoEMethodBase):
         w1_bias = getattr(layer, "w13_bias", None)
         w2_bias = getattr(layer, "w2_bias", None)
 
-        if self.mxfp4_backend in TRITON_BACKENDS:
+        if self.mxfp4_backend in TRITON_BACKENDS or (
+            self.mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16
+            and use_aiter_mxfp4_triton_moe()
+        ):
             # TRITON backends free w13/w2_weight_scale after swizzling; the
             # swizzled scales live inside the precision configs instead.
             assert self.w13_precision_config is not None
@@ -484,7 +497,8 @@ def _use_k3_situ_aiter(moe: FusedMoEConfig) -> bool:
     """Whether Kimi-K3's SiTU MXFP4 MoE should use the AITER A16W4 kernel.
 
     K3 is weight-only MXFP4 (W4A16) with SiTU activation, which the generic
-    MXFP4 backend selector does not cover; route it to AITER on gfx950.
+    MXFP4 backend selector does not cover; route it to AITER on gfx950. gfx942
+    cannot use this path: its Triton a16w4 fallback has no SiTU support.
     """
     from vllm.platforms import current_platform
 
@@ -732,10 +746,9 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
 
         # For TRITON backends, weights are wrapped tensors from triton_kernels
         # that don't support .detach(). Manually assign parameters.
-        from vllm.platforms.rocm import on_gfx1250
-
         uses_triton_weight_format = self.mxfp4_backend in TRITON_BACKENDS or (
-            self.mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16 and on_gfx1250()
+            self.mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16
+            and use_aiter_mxfp4_triton_moe()
         )
         if not uses_triton_weight_format:
             replace_parameter(layer, "w13_weight", w13)
@@ -846,10 +859,9 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         w2_bias = getattr(layer, "w2_bias", None)
         swiglu_limit = getattr(layer, "swiglu_limit", None)
 
-        from vllm.platforms.rocm import on_gfx1250
-
         if self.mxfp4_backend in TRITON_BACKENDS or (
-            self.mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16 and on_gfx1250()
+            self.mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16
+            and use_aiter_mxfp4_triton_moe()
         ):
             # TRITON backends free w13/w2_weight_scale after swizzling; the
             # swizzled scales live inside the precision configs instead.

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -37,6 +37,7 @@ from vllm.model_executor.layers.quantization.base_config import (
     QuantizeMethodBase,
 )
 from vllm.model_executor.layers.quantization.utils.mxfp4_utils import (
+    _swizzle_mxfp4,
     use_aiter_mxfp4_triton_moe,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import is_layer_skipped
@@ -497,8 +498,9 @@ def _use_k3_situ_aiter(moe: FusedMoEConfig) -> bool:
     """Whether Kimi-K3's SiTU MXFP4 MoE should use the AITER A16W4 kernel.
 
     K3 is weight-only MXFP4 (W4A16) with SiTU activation, which the generic
-    MXFP4 backend selector does not cover; route it to AITER on gfx950. gfx942
-    cannot use this path: its Triton a16w4 fallback has no SiTU support.
+    MXFP4 backend selector does not cover; route it to AITER on MI3xx. gfx950
+    fuses SiTU into the CK kernel, gfx942 applies it between the two Triton
+    a16w4 GEMMs.
     """
     from vllm.platforms import current_platform
 
@@ -506,11 +508,11 @@ def _use_k3_situ_aiter(moe: FusedMoEConfig) -> bool:
         return False
     from vllm._aiter_ops import rocm_aiter_ops
     from vllm.model_executor.layers.fused_moe.activation import MoEActivation
-    from vllm.platforms.rocm import on_gfx950
+    from vllm.platforms.rocm import on_mi3xx
 
     return (
         rocm_aiter_ops.is_fused_moe_enabled()
-        and on_gfx950()
+        and on_mi3xx()
         and moe.activation == MoEActivation.SITU
         and moe.activation_situ_linear_beta is not None
         and rocm_aiter_ops.get_aiter_activation_type("situ") is not None
@@ -527,8 +529,14 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         self.experts_cls: type[mk.FusedMoEExperts] | None
         if self.is_k3_situ_aiter:
             self.mxfp4_backend = Mxfp4MoeBackend.AITER_MXFP4_BF16
-            self.experts_cls = backend_to_kernel_cls(self.mxfp4_backend)[0]
-            logger.info_once("Using AITER_MXFP4_BF16 for Kimi-K3 SiTU MXFP4 MoE.")
+            ck_experts, triton_experts = backend_to_kernel_cls(self.mxfp4_backend)
+            self.experts_cls = (
+                triton_experts if use_aiter_mxfp4_triton_moe() else ck_experts
+            )
+            logger.info_once(
+                "Using AITER_MXFP4_BF16 (%s) for Kimi-K3 SiTU MXFP4 MoE.",
+                self.experts_cls.__name__,
+            )
         else:
             self.mxfp4_backend, self.experts_cls = select_deepseek_v4_mxfp4_moe_backend(
                 moe
@@ -791,6 +799,32 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         # K3's AITER A16W4 kernel wants the separated ([gate_all, up_all])
         # stage-1 layout, unlike the interleaved gpt-oss/DeepSeek path in
         # convert_weight_to_mxfp4_moe_kernel_format. Preshuffle once here.
+        if use_aiter_mxfp4_triton_moe():
+            # The Triton a16w4 kernel takes the plain (unswizzled) layout and
+            # its scales through a PrecisionConfig, not the CK shuffle below.
+            from triton_kernels.matmul_ogs import FlexCtx, PrecisionConfig
+
+            w13, w13_flex, w13_scale = _swizzle_mxfp4(
+                layer.w13_weight, layer.w13_weight_scale
+            )
+            w2, w2_flex, w2_scale = _swizzle_mxfp4(
+                layer.w2_weight, layer.w2_weight_scale
+            )
+            # The swizzled tensors are triton_kernels wrappers, not Parameters,
+            # so the registered parameters have to go before rebinding.
+            del layer.w13_weight
+            del layer.w2_weight
+            layer.w13_weight = w13
+            layer.w2_weight = w2
+            self.w13_precision_config = PrecisionConfig(
+                weight_scale=w13_scale, flex_ctx=FlexCtx(rhs_data=w13_flex)
+            )
+            self.w2_precision_config = PrecisionConfig(
+                weight_scale=w2_scale, flex_ctx=FlexCtx(rhs_data=w2_flex)
+            )
+            self._finalize_k3_situ_kernel(layer)
+            return
+
         from aiter.utility.fp4_utils import e8m0_shuffle
 
         from vllm._aiter_ops import rocm_aiter_ops
@@ -823,6 +857,9 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         layer.w13_weight.is_shuffled = True
         layer.w2_weight.is_shuffled = True
 
+        self._finalize_k3_situ_kernel(layer)
+
+    def _finalize_k3_situ_kernel(self, layer: RoutedExperts) -> None:
         self.moe_quant_config = self.get_fused_moe_quant_config(layer)
         if self.moe_quant_config is not None and self.experts_cls is not None:
             self.moe_kernel = make_mxfp4_moe_kernel(

--- a/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
@@ -33,6 +33,21 @@ def should_use_cdna4_mx_scale_swizzle() -> bool:
     return on_gfx950() and get_tensor_model_parallel_world_size() <= 2
 
 
+def use_aiter_mxfp4_triton_moe() -> bool:
+    """Whether AITER MXFP4 MoE runs the Triton a16w4 kernel, not the CK kernel.
+
+    AITER's CK MXFP4 MoE kernel requires CDNA4 (gfx950) native FP4 MFMA. On
+    gfx942 and gfx1250 the Triton ``moe_gemm_a16w4`` kernel is used instead,
+    which consumes the plain (unswizzled) weight layout produced by
+    `_swizzle_mxfp4` and therefore needs `triton_kernels`. Weight preparation
+    and kernel selection must agree on this predicate; when it is False the
+    backend selector falls through to the next candidate.
+    """
+    from vllm.platforms.rocm import on_gfx942, on_gfx1250
+
+    return (on_gfx942() or on_gfx1250()) and has_triton_kernels()
+
+
 def _swizzle_mxfp4(quant_tensor, scale, num_warps=8):
     """weight swizzle for mxfp4 moe, used for OAI mxfp4 kernel"""
     assert has_triton_kernels()

--- a/vllm/models/kimi_k3/amd/ops/third_party/kda/__init__.py
+++ b/vllm/models/kimi_k3/amd/ops/third_party/kda/__init__.py
@@ -15,10 +15,18 @@
 #   - AMD autotune configs: present (is_amd num_warps/num_stages branches),
 #   - OOB-mask correctness fix: present (all tl.load use mask=..., other=0).
 # Validated on gfx950: no core-dump, gsm8k 94.1%.
+# Validated on gfx942 (MI325X): tests/models/kimi_k3/test_kda.py and
+# test_kda_metadata.py pass (45 passed, 6 skipped).
 #
-# AMD-specific deltas vs the NVIDIA copy: NONE yet (byte-identical). Keep in sync
-# with the NVIDIA copy on FLA updates; any divergence should be an intentional,
-# documented gfx950-specific change (a #869-style AMD-only fix).
+# Deltas vs the NVIDIA copy, which has since diverged forward:
+#   - no PDL: the NVIDIA fused_recurrent kernels gate on
+#     `current_platform.is_arch_support_pdl()` and issue gdc_wait /
+#     gdc_launch_dependents, which have no ROCm equivalent,
+#   - fused_recurrent decode launch config is a flat `BV = 32 if
+#     use_gate_in_kernel else 8` rather than the NVIDIA GB300-tuned
+#     BV/num_stages ladder; it has not been retuned for CDNA.
+# Keep in sync with the NVIDIA copy on FLA updates; any further divergence
+# should be an intentional, documented AMD-only change (a #869-style fix).
 
 from .chunk import (
     chunk_kda,

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -808,26 +808,53 @@ class AiterMLAHelper:
         return max(num_heads, AiterMLAHelper._AITER_MIN_MLA_HEADS)
 
     @staticmethod
+    def _whole_head_repeats(num_heads: int) -> int | None:
+        """Repeat factor that expands ``num_heads`` to exactly 16, else None."""
+        min_heads = AiterMLAHelper._AITER_MIN_MLA_HEADS
+        repeats = min_heads // num_heads
+        return repeats if repeats * num_heads == min_heads else None
+
+    @staticmethod
     def get_mla_padded_q(num_heads: int, q: torch.Tensor) -> torch.Tensor:
-        return (
-            q
-            if num_heads >= AiterMLAHelper._AITER_MIN_MLA_HEADS
-            else q.repeat_interleave(
-                AiterMLAHelper._AITER_MIN_MLA_HEADS // num_heads, dim=1
-            )
+        if num_heads >= AiterMLAHelper._AITER_MIN_MLA_HEADS:
+            return q
+        repeats = AiterMLAHelper._whole_head_repeats(num_heads)
+        if repeats is not None:
+            return q.repeat_interleave(repeats, dim=1)
+        # Head counts that do not divide 16 (e.g. 12 with TP=8) cannot be
+        # expanded by whole repeats. Pad the head dim with zero queries and
+        # drop the filler heads from the output instead.
+        return torch.nn.functional.pad(
+            q, (0, 0, 0, AiterMLAHelper._AITER_MIN_MLA_HEADS - num_heads)
         )
 
     @staticmethod
     def get_mla_unpadded_o(num_heads: int, o: torch.Tensor) -> torch.Tensor:
-        return (
-            o
-            if num_heads >= AiterMLAHelper._AITER_MIN_MLA_HEADS
-            else o[:, :: AiterMLAHelper._AITER_MIN_MLA_HEADS // num_heads, :]
-        )
+        if num_heads >= AiterMLAHelper._AITER_MIN_MLA_HEADS:
+            return o
+        repeats = AiterMLAHelper._whole_head_repeats(num_heads)
+        if repeats is not None:
+            return o[:, ::repeats, :]
+        return o[:, :num_heads, :]
+
+    @staticmethod
+    def gluon_decode_available() -> bool:
+        """Whether AITER's small-head Gluon MLA kernels run on this device.
+
+        ``mla_gluon`` asserts CDNA4. Elsewhere small-head decode pads to 16
+        heads and uses the regular AITER decode kernel instead.
+        """
+        from vllm.platforms.rocm import on_gfx950
+
+        return on_gfx950()
 
     @staticmethod
     def use_gluon_decode(num_heads: int, max_qo_len: int) -> bool:
-        return num_heads < AiterMLAHelper._AITER_MIN_MLA_HEADS and max_qo_len == 1
+        return (
+            num_heads < AiterMLAHelper._AITER_MIN_MLA_HEADS
+            and max_qo_len == 1
+            and AiterMLAHelper.gluon_decode_available()
+        )
 
 
 class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
@@ -1116,6 +1143,7 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
         if (
             self.num_heads < AiterMLAHelper._AITER_MIN_MLA_HEADS
             and int(decode.max_qo_len) > 1
+            and AiterMLAHelper.gluon_decode_available()
         ):
             qlen = int(decode.max_qo_len)
             if type(q) is tuple:


### PR DESCRIPTION
## Summary

Makes Kimi-K3 run on AMD MI325X (gfx942 / CDNA3). The model loaded but
aborted in MLA decode; once past that it fell back to a dequantise-to-BF16
MoE emulation path. Both are fixed, and a third change addresses AITER MoE
tile shapes being sized for CDNA4 on all architectures.

Measured on 8x MI325X with the real 2.75T-parameter MXFP4 checkpoint:

| | before | after |
| --- | --- | --- |
| Kimi-K3 decode (TP=8, CUDA graphs, warm) | 4.27 tok/s | **99.67 tok/s** (23x) |
| Prefill throughput (36k prompt) | 3,522 tok/s | **6,537 tok/s** (1.9x) |
| MLA decode at 12 heads/rank | `AssertionError` | works, bit-exact |

## Motivation

Three independent blockers, in the order they surfaced.

**1. MLA decode aborted on any model with <16 heads per rank.**

```
AssertionError: mla_gluon requires gfx950 (CDNA4), got gfx942
```

AITER's small-head MLA decode kernel asserts CDNA4, but the backend selected
it on head count alone. Kimi-K3 has 96 attention heads, so TP=8 gives 12 per
rank — and TP=8 is the *only* viable parallelism: 1.5 TB of weights against
2 TB of HBM rules out TP=6 (260 GB/GPU, and 7168 % 6 != 0) and TP=4 (390
GB/GPU).

The existing pad-to-16 fallback only handled head counts dividing 16;
`repeat_interleave(16 // num_heads)` is a silent no-op for 12, leaving q at
12 heads while the output was allocated for 16.

**2. MXFP4 MoE fell through to BF16 emulation on gfx942.**

AITER's CK MXFP4 kernel needs CDNA4 native FP4 MFMA, so gfx942 landed on
`OCP_MXQuantizationEmulationTritonExperts`, which dequantises the *entire*
weight tensor every forward:

```python
w1_dequant = self._dequantize_weights(w1, ...)   # all 896 experts
w2_dequant = self._dequantize_weights(w2, ...)   # 16 are routed to
```

That is 56x the required work. For K3: 896 experts x 33.0M params / 8 GPUs
x 2 bytes ~= 7.4 GB per layer, x 93 layers ~= 688 GB materialised per token,
written then read back ~= 1.4 TB of HBM traffic, / ~6 TB/s ~= 229 ms/token.
Predicted ~4.4 tok/s; measured 4.27. That was the entire performance story.

AITER *does* ship a Triton `moe_gemm_a16w4` kernel which dequantises
in-register during the GEMM. It runs correctly on gfx942 — the arch gate
simply never admitted it. The ROCm base image already builds AITER with
`AITER_ROCM_ARCH="gfx942;gfx950"`, so these kernels were compiled and
present all along.

**3. AITER MoE tile selection is architecture-blind.**

`get_kernel_config` hardcodes `block_k=256`, `block_n=512`, `num_stages=1`
for every AMD part. Those suit CDNA4's 160 KiB LDS; CDNA3 has 64 KiB.
`arch_info._LDS_CAP_BYTES` already records the per-arch capacity and is
consulted by `pa_decode_sparse`, `gemm_config_utils` and
`sparse_attention_dsv4` — the MoE GEMM is the one kernel that skips it.

## Changes

### MLA small-head decode (`vllm/v1/attention/backends/mla/rocm_aiter_mla.py`)

- Add `AiterMLAHelper.gluon_decode_available()` (gfx950) and require it in
  `use_gluon_decode()` and in the multi-token verify branch, so non-CDNA4
  falls through to the padded path instead of asserting.
- `get_mla_padded_q` / `get_mla_unpadded_o` keep whole-repeat expansion where
  the head count divides 16, and zero-pad the head dimension otherwise.

Zero-padding is exact, not approximate: the decode kernel treats query heads
independently, so filler heads cannot perturb retained ones. The new test
pins that property — running 16 real heads, then the same tensor with heads
>= N zeroed, gives **bit-identical** outputs for heads 0..N-1.

### MXFP4 MoE on gfx942

- `mxfp4_utils.py`: new `use_aiter_mxfp4_triton_moe()` — a single predicate
  for "AITER MXFP4 runs the Triton kernel", replacing scattered `on_gfx1250()`
  checks that independently decided weight-preparation format. It also
  requires `has_triton_kernels()`, so a build without that package falls
  through to previous behaviour instead of asserting at weight load.
- `aiter_mxfp4_w4a8_moe.py`: admit gfx942 in
  `AiterW4A16ExpertsMonolithic._supports_current_device`.
- `oracle/mxfp4.py`: split the `AITER_MXFP4_BF16` weight-prep branch — the
  Triton path swizzles and returns `PrecisionConfig`s, the CK path keeps the
  de-interleave plus aiter shuffle.
- `quantization/mxfp4.py`: route parameter-vs-wrapped-tensor assignment, the
  `is_shuffled` marking, and the quant-config scale source through the same
  predicate.

The **de-interleave of w13 gate/up pairs is CK-only.** A first attempt applied
it to the Triton path and produced uncorrelated output (cosine 0.034 vs the
TRITON backend). The Triton kernel consumes the checkpoint's interleaved
layout like every other Triton backend.

### SiTU activation support

K3's MoE uses SiTU — `beta*tanh(gate/beta)*sigmoid(gate)*up` — which cannot
be expressed through the a16w4 kernel's `alpha`/`limit`/`add_residual` knobs.

`aiter_triton_kernel_w4a16_moe_forward` now runs gemm1 unfused for SiTU and
applies the existing compiled `torch.ops._C.situ_and_mul` between the two
GEMMs. Only activations round-trip through HBM (a few hundred KB); weights
never do. K3 already stores w13 as `[gate_all, up_all]`, exactly what
`situ_and_mul` splits on, so no reshuffling is needed.

`_setup_kernel_k3_situ` emits the Triton layout on gfx942 rather than the CK
shuffle, and drops the registered Parameters before rebinding since the
swizzled tensors are `triton_kernels` wrappers.

### Tooling and CI

- `benchmarks/kernels/benchmark_moe_a16w4_tiles.py` — sweeps MoE tile shapes
  and reports the best against stock. Overrides only tiles at/above
  `--min-block-m` (default 64), leaving decode alone.
- `tools/vllm-rocm/patch_aiter_cdna3_moe_tiles.py` — LDS-aware override for
  AITER's tile selector on gfx942, with `--revert`.
- `tools/vllm-rocm/README_kimi_k3_mi325x.md` — serving recipe and two
  operational traps (below).
- `.buildkite/test-amd.yaml` — add
  `vllm/models/kimi_k3/amd/ops/third_party/kda/` to the KDA job's source
  dependencies; edits to the AMD kernel copies did not trigger the AMD job.
- `kimi_k3/amd/.../kda/__init__.py` — correct a provenance note claiming
  byte-identity with a NVIDIA copy that has since diverged.

## Results

All on 8x MI325X (gfx942), ROCm 7.2.3 container, AITER v0.1.19, real
`moonshotai/Kimi-K3` weights, TP=8, CUDA graphs, `max_num_seqs=512`,
`gpu_memory_utilization=0.97`.

**Decode**

| backend | tok/s |
| --- | --- |
| EMULATION (before) | 4.27 |
| Triton a16w4 + SiTU, cold | 65.66 |
| Triton a16w4 + SiTU, warm | **99.67** |

Cold carries ~18 Triton JIT compilations inside the timed window.

**MoE GEMM tile shapes** (4096 tokens; stock = `block_n=512 block_k=256
warps=8 stages=1`)

| GEMM | stock | best gfx942 | |
| --- | --- | --- | --- |
| gemm1 K=3584 N=768 | 8.208 ms | 1.303 ms (`bn=128 bk=128 s=1 w=4`) | 6.30x |
| gemm2 K=384 N=7168 | 8.019 ms | 1.701 ms (`bn=512 bk=128 s=2 w=8`) | 4.72x |

`block_k` is the dominant variable — halving it shrinks both LDS tiles at
once. Triton names the constraint when it does not fit:
`OutOfResources: shared memory, Required: 100352, Hardware limit: 65536`.

**End-to-end prefill**

| prompt tokens | before | after | |
| --- | --- | --- | --- |
| 3,697 | 2,268 tok/s | 4,459 | 1.97x |
| 14,497 | 3,156 tok/s | 5,910 | 1.87x |
| 36,097 | 3,522 tok/s | 6,537 | 1.86x |
| 72,098 | 3,427 tok/s | 6,585 | 1.92x |

Smaller than the kernel-level 5-6x because prefill also pays for MLA, 69 KDA
layers, norms and TP collectives.

## Testing

```bash
pytest -v -s tests/kernels/attention/test_rocm_aiter_mla_small_head_pad.py
# 11 passed

VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_MOE=1 \
  pytest -v -s tests/kernels/moe/test_ocp_mx_moe.py -k test_rocm_mxfp4_moe_oracle
# 3 passed, 1 skipped (AITER_MXFP4_FP8 still requires gfx950)

VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_MOE=1 \
  pytest -v -s tests/kernels/moe/test_ocp_mx_moe.py \
              tests/kernels/moe/test_mxfp8_aiter_backend_selection.py
# 22 passed, 117 skipped, 0 failed

pytest -v -s tests/models/kimi_k3/test_amd_attn_res.py
# 4 passed

pytest -v -s tests/models/kimi_k3/test_kda.py tests/models/kimi_k3/test_kda_metadata.py
# 45 passed, 6 skipped
```

Additional verification beyond the suites:

- Isolated a16w4 kernel vs dequantised reference GEMM: max rel err **5.7e-4**
- Full MoE vs the trusted TRITON backend, identical weights: cosine **0.999906**
- MLA head padding: **bit-identical** outputs for retained heads

## Model evaluation

Greedy decode (`temperature=0`) through the OpenAI-compatible server on real
weights returns identical text to the EMULATION baseline, including
`17 * 23 = 17 * 20 + 17 * 3 = 340 + 51 = 391`. Post-tile-patch spot checks:
4/4 correct, including `4839 * 271 = 1311369`.

I did **not** run a formal lm-eval / gsm8k harness. Given the change is
kernel-path only and matches the reference backend to cosine 0.999906, I
consider that proportionate, but I will run one if a reviewer wants it.

## Not included / known limitations

- **The AITER tile fix is a runtime patch**, not a vLLM change. It modifies a
  third-party package and does not survive an AITER upgrade. The durable fix
  is upstream in ROCm/aiter, deriving `block_k` from `_LDS_CAP_BYTES`. Its
  constants are tuned to K3's two GEMM shapes; the `n <= 1024` split is a
  coarse proxy that lands on both measured optima but is not a general
  autotuner.
- **Speculative decoding on gfx942 with <16 heads is untested.** Gating the
  Gluon multi-token branch means that case now falls through to the padded
  path. It is dormant for K3 (`num_nextn_predict_layers=0`), but anyone
  enabling MTP/EAGLE3 would be on an unvalidated causality path.
- **`AITER_SITUV2_A8W4` is ignored by the new Triton path.** The CK branch
  reads it to select a gate/up-interleaved layout; the Triton path always
  assumes separated. Default-off, but a silent trap if set.
- **No tuned MoE configs for MI325X** at K3's shapes
  (`E=896,N=384,device_name=AMD_Instinct_MI325X.json` is absent).
- `AITER_MXFP4_FP8` (W4A8) remains gfx950-only — it needs the CDNA4 swizzle.

## Operational notes for anyone serving Kimi-K3 on MI325X

Two traps that look like model corruption and are not:

- **`max_num_seqs` must stay below the Mamba/KDA state block count.** K3 has
  69 KDA layers and needs one state block per concurrent decode sequence, so
  the default 1024 fails CUDA graph capture at 854 available blocks.
- **The `kimi_k3` reasoning parser strips the think channel on its closing
  marker.** If `max_tokens` truncates before that marker, raw chain-of-thought
  is returned as `content` instead of an answer. Combined with the template's
  `thinking_effort=max` default this reads as garbage output.

Measured tool-call emission, 6 trials per cell:

| schema | default (max) | low | high | thinking off |
| --- | --- | --- | --- | --- |
| 1-param | 6/6 | 6/6 | 6/6 | 0/6 |
| 2-param | 3/6 | 6/6 | 6/6 | 3/6 |
| 3-param | 6/6 | 6/6 | 6/6 | 0/6 |

`thinking_effort: low` is 18/18 and ~3.5x cheaper in tokens than the default.
`thinking: false` must not be used with tools.