### PR TITLE
[Bugfix][LoRA] Respect output offsets in LoRA metadata cache

### DIFF
--- a/tests/lora/test_punica_ops.py
+++ b/tests/lora/test_punica_ops.py
@@ -461,6 +461,78 @@ def test_kernels(
         )
 
 
+@pytest.mark.parametrize("device", DEVICES)
+def test_lora_expand_cache_respects_offset_start(device: str):
+    """The cached slice offsets must match each expand invocation."""
+    torch.set_default_device(device)
+    torch.accelerator.set_device_index(device)
+    set_random_seed(0)
+
+    batches = num_loras = nslices = 2
+    rank, hidden_size, seq_length = 8, 16, 4
+    offset_start = 7
+    data = generate_data_for_nslices(
+        batches,
+        hidden_size,
+        num_loras,
+        rank,
+        seq_length,
+        nslices,
+        torch.float16,
+        "expand",
+        device,
+    )
+    _, token_nums = data.meta()
+    lora_meta = LoRAKernelMeta.make(
+        max_loras=num_loras,
+        max_num_tokens=token_nums,
+        device=DEVICE_TYPE,
+    )
+    lora_meta.prepare_tensors(data.token_lora_mapping)
+    meta_args = lora_meta.meta_args(token_nums=token_nums, specialize_active_lora=False)
+
+    output_shape = (token_nums, offset_start + hidden_size * nslices)
+    with _dict_lock:
+        _LORA_B_PTR_DICT.clear()
+        # Populate the cache with a different offset for the same weights.
+        triton_ops.lora_expand(
+            data.inputs_tensor,
+            data.lora_weights,
+            torch.zeros(output_shape, dtype=torch.float16, device=device),
+            *meta_args,
+            offset_start=0,
+            add_inputs=False,
+        )
+
+        out_tensor = torch.zeros(output_shape, dtype=torch.float16, device=device)
+        triton_ops.lora_expand(
+            data.inputs_tensor,
+            data.lora_weights,
+            out_tensor,
+            *meta_args,
+            offset_start=offset_start,
+            add_inputs=False,
+        )
+
+    ref_out_tensor = torch.zeros_like(out_tensor)
+    seq_cpu = data.seq_len_tensor.cpu()
+    mapping_cpu = data.prompt_lora_mapping.cpu()
+    ref_cpu = ref_out_tensor.cpu()
+    for index in range(nslices):
+        _cpu_bgmv_expand(
+            data.inputs_tensor[index].cpu(),
+            data.lora_weights[index].cpu(),
+            ref_cpu,
+            seq_cpu,
+            mapping_cpu,
+            offset=offset_start + hidden_size * index,
+            add_inputs=False,
+        )
+    ref_out_tensor.copy_(ref_cpu)
+
+    assert_close(out_tensor, ref_out_tensor)
+
+
 @pytest.mark.parametrize("batches", hs_test_params["batches"])
 @pytest.mark.parametrize("num_loras", hs_test_params["num_loras"])
 @pytest.mark.parametrize("rank", hs_test_params["max_ranks"])

--- a/vllm/lora/ops/triton_ops/utils.py
+++ b/vllm/lora/ops/triton_ops/utils.py
@@ -19,7 +19,7 @@ logger = init_logger(__name__)
 is_batch_invariant = envs.VLLM_BATCH_INVARIANT
 
 _LORA_A_PTR_DICT: dict[tuple[int, ...], tuple[torch.tensor, ...]] = {}
-_LORA_B_PTR_DICT: dict[tuple[int, ...], tuple[torch.tensor, ...]] = {}
+_LORA_B_PTR_DICT: dict[tuple[tuple[int, ...], int], tuple[torch.tensor, ...]] = {}
 
 
 def _get_lora_a_ptr(lora_a_weights: list[torch.Tensor], device: torch.device):
@@ -83,7 +83,8 @@ def _get_lora_b_ptr(
 
     """
 
-    key = tuple(lora_weight.data_ptr() for lora_weight in lora_weights)
+    weight_ptrs = tuple(lora_weight.data_ptr() for lora_weight in lora_weights)
+    key = (weight_ptrs, offset_start)
     if values := _LORA_B_PTR_DICT.get(key):
         return values
     slice_offset_lst = []


### PR DESCRIPTION
## Purpose

`_get_lora_b_ptr` caches slice locations calculated from `offset_start`, but `_LORA_B_PTR_DICT` previously keyed entries only by the LoRA weight addresses. Reusing the same LoRA B tensors with a different output offset therefore returned stale slice locations and caused later expand calls to write into the columns used by the first call.

This change scopes cache entries by both the weight addresses and `offset_start`. The regression test primes the cache at offset 0, reuses the same two-slice weights at offset 7, and compares the result with the CPU reference.

Duplicate-work check: searched open and closed vLLM issues and pull requests for `offset_start`, `_LORA_B_PTR_DICT`, and LoRA expand offset caching. No existing report or fix for this cache-key issue was found.

## Test Plan

```bash
python -m pytest -q tests/lora/test_punica_ops.py::test_lora_expand_cache_respects_offset_start
python -m pytest -q "tests/lora/test_punica_ops.py::test_kernels[expand-0-cuda:0-dtype0-3-2049-256-128-32]"
python -m pytest -q "tests/lora/test_punica_ops_fp8.py::test_lora_expand_fp8[per_tensor-0-cuda:0-dtype0-1-512-8-1-1]"
python -m pytest -q tests/lora/test_qwen3_unembed.py::test_qwen3_unembed_lora
```

Representative per-channel and blockwise FP8 expand configurations were also invoked through `check_lora_expand_fp8_kernel`.

## Test Result

Baseline on commit `f5bb701fa` with an NVIDIA H20 reproduced the stale offset: the second invocation requested offset 7 but wrote at offset 0, with a maximum absolute error of 6.3671875 against the reference.

Fixed commit `e28f007f3`:

- Node1, NVIDIA H20: regression test passed; four representative FP16/BF16 expand boundary configurations passed; per-tensor, per-channel, and blockwise FP8 configurations passed.
- Node2, NVIDIA H20: regression test and two independent expand boundary configurations passed (`3 passed`).
- Qwen3-0.6B base and synthetic LoRA end-to-end generation passed (`1 passed`).
- Ruff, formatting, type checks, DCO, and all applicable pre-commit hooks passed.

## AI assistance

AI assistance was used for test execution, and validated the results on NVIDIA H20 GPUs.