### PR TITLE
[Bugfix] Shard UniformTypeKVCacheSpecs block table width under DCP

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -1257,6 +1257,26 @@ def test_project_kv_cache_groups_to_worker():
     assert set(proj_spec.kv_cache_specs.keys()) == {"layer1", "layer3"}
 
 
+def test_uniform_type_spec_block_table_width_is_dcp_sharded():
+    # The runner sizes the block table from the group spec, the metadata
+    # builders from the per-layer spec; under DCP the two must agree.
+    vllm_config = VllmConfig(model_config=ModelConfig(max_model_len=1024))
+    vllm_config.parallel_config.decode_context_parallel_size = 2
+    layer_spec = MLAAttentionSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=64,
+        dtype=torch.bfloat16,
+    )
+    uniform_spec = UniformTypeKVCacheSpecs(
+        block_size=16,
+        kv_cache_specs={"layer1": layer_spec, "layer2": layer_spec},
+    )
+
+    assert layer_spec.max_num_blocks_per_req(vllm_config, 1024) == 32
+    assert uniform_spec.max_num_blocks_per_req(vllm_config, 1024) == 32
+
+
 def test_merge_kv_cache_spec():
     same_layer_specs = [
         new_kv_cache_spec(num_kv_heads=32),

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -1257,24 +1257,32 @@ def test_project_kv_cache_groups_to_worker():
     assert set(proj_spec.kv_cache_specs.keys()) == {"layer1", "layer3"}
 
 
-def test_uniform_type_spec_block_table_width_is_dcp_sharded():
-    # The runner sizes the block table from the group spec, the metadata
-    # builders from the per-layer spec; under DCP the two must agree.
+@pytest.mark.parametrize(
+    "layer_type,dcp_size,expected_width",
+    [
+        ("mla", 1, 64),
+        ("mla", 2, 32),
+        # Mamba state is replicated, not DCP-sharded, and its width is the
+        # resident state block count rather than cdiv(max_len, block_size).
+        ("mamba", 2, 3),
+    ],
+)
+def test_uniform_type_spec_block_table_width_matches_layer_spec(
+    layer_type, dcp_size, expected_width
+):
+    # The runner sizes the block table from the group spec while the metadata
+    # builders are constructed from the per-layer spec, so the aggregate must
+    # report the same width as the layers it wraps.
     vllm_config = VllmConfig(model_config=ModelConfig(max_model_len=1024))
-    vllm_config.parallel_config.decode_context_parallel_size = 2
-    layer_spec = MLAAttentionSpec(
-        block_size=16,
-        num_kv_heads=1,
-        head_size=64,
-        dtype=torch.bfloat16,
-    )
+    vllm_config.parallel_config.decode_context_parallel_size = dcp_size
+    layer_spec = new_mla_spec() if layer_type == "mla" else new_mamba_spec()
     uniform_spec = UniformTypeKVCacheSpecs(
-        block_size=16,
+        block_size=layer_spec.block_size,
         kv_cache_specs={"layer1": layer_spec, "layer2": layer_spec},
     )
 
-    assert layer_spec.max_num_blocks_per_req(vllm_config, 1024) == 32
-    assert uniform_spec.max_num_blocks_per_req(vllm_config, 1024) == 32
+    assert layer_spec.max_num_blocks_per_req(vllm_config, 1024) == expected_width
+    assert uniform_spec.max_num_blocks_per_req(vllm_config, 1024) == expected_width
 
 
 def test_merge_kv_cache_spec():

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -856,12 +856,18 @@ class UniformTypeKVCacheSpecs(KVCacheSpec):
         return max_num_pages * self.page_size_bytes
 
     def max_num_blocks_per_req(self, vllm_config: VllmConfig, max_len: int) -> int:
-        # The base implementation would drop the DCP sharding AttentionSpec
-        # applies, widening the block table past what the builders expect.
-        return max(
+        # Metadata builders are constructed from the per-layer spec, so the base
+        # cdiv(max_len, block_size) would drop its DCP sharding and size the
+        # block table wider than those builders expect.
+        widths = {
             spec.max_num_blocks_per_req(vllm_config, max_len)
             for spec in self.kv_cache_specs.values()
+        }
+        assert len(widths) == 1, (
+            "All layers in the same KV cache group must need the same number "
+            f"of block table entries, got {sorted(widths)}."
         )
+        return next(iter(widths))
 
     @classmethod
     def is_uniform_type(cls, kv_cache_specs: dict[str, KVCacheSpec]) -> bool:

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -855,6 +855,14 @@ class UniformTypeKVCacheSpecs(KVCacheSpec):
         )
         return max_num_pages * self.page_size_bytes
 
+    def max_num_blocks_per_req(self, vllm_config: VllmConfig, max_len: int) -> int:
+        # The base implementation would drop the DCP sharding AttentionSpec
+        # applies, widening the block table past what the builders expect.
+        return max(
+            spec.max_num_blocks_per_req(vllm_config, max_len)
+            for spec in self.kv_cache_specs.values()
+        )
+
     @classmethod
     def is_uniform_type(cls, kv_cache_specs: dict[str, KVCacheSpec]) -> bool:
         """


### PR DESCRIPTION
## Purpose

Fixes #50825.

`UniformTypeKVCacheSpecs` never overrode `max_num_blocks_per_req`, so it used the base `cdiv(max_len, block_size)` while `AttentionSpec` divides by `decode_context_parallel_size`. The two sides that must agree read different specs:

- the runner sizes the block table from the **group** spec (`gpu_model_runner.py`, `may_reinitialize_input_batch`), which for DSA models is `UniformTypeKVCacheSpecs` — not DCP-sharded;
- metadata builders are constructed from the **per-layer** spec (`worker/utils.py`, `create_metadata_builders` → `get_block_table_width`), which is `MLAAttentionSpec` — DCP-sharded.

Under DCP the block table is therefore `dcp_world_size` times wider than the indexer's `expanded_block_table_buffer`, and decode dies in `mla/indexer.py`:

```
RuntimeError: The expanded size of the tensor (8192) must match the existing size (16384)
at non-singleton dimension 1.  Target sizes: [30, 8192].  Tensor sizes: [30, 16384]
```

Reported by @Leoyzen on GLM-5.2, TP8/DCP2, `fp8_ds_mla`, MTP: https://github.com/vllm-project/vllm/pull/50302#issuecomment-5161430855

The gap predates #50302 and is not the alignment part it fixed: before #50302 the indexer buffer was sized with `get_kv_cache_shard_count()`, which is also DCP-sharded, so the same asymmetry existed. The new `gpu/model_runner.py` divides by `dcp_size` explicitly and is unaffected; only the classic runner path hits this. #48404 worked around the symptom by reallocating the buffer.

Delegating to the merged specs fixes the crash and also stops the runner from allocating a block table `dcp_world_size` times wider than needed.

Not a duplicate: #46794 fixes the same symptom from a different cause (`InputBatch` not rebuilt after `max_model_len` is auto-reduced), #43970's alignment part is superseded by #50302, and neither touches the DCP sharding of the group spec.

## Test

`tests/v1/core/test_kv_cache_utils.py::test_uniform_type_spec_block_table_width_is_dcp_sharded` — asserts the group spec and the per-layer spec return the same DCP-sharded width.

Verified fail→pass on an 4×H200 box (CPU-only test, run inside a vLLM container):

```
python3 -m pytest test_uniform_type_spec_block_table_width_is_dcp_sharded -q
# before: AssertionError: assert 64 == 32
# after:  1 passed
```

This change is config-level only and does not affect model output; no eval run.

AI assistance (Claude) was used for this work; all changes reviewed.

