### PR TITLE
[Docs][KV Connector][NIXL] Document NIXL KV connector stats semantics

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
@@ -63,12 +63,16 @@ class KVConnectorLogging:
         self.transfer_stats_accumulator: KVConnectorStats | None = None
 
     def observe(self, transfer_stats_data: dict[str, Any]):
+        """Accumulate connector stats received from the scheduler.
+
+        Called whenever the connector syncs with the scheduler, which
+        is not necessarily the logging interval. The incoming data is
+        rebuilt into a stats object and merged into the running
+        accumulator via :meth:`KVConnectorStats.aggregate`, so the
+        accumulator spans all observations since the last :meth:`log`.
+        """
         # Should not be called when a KVConnector is not configured.
         assert self.connector_cls is not None
-        # Called periodically when connector syncs with the scheduler.
-        # Note that this is not the same as the logging interval.
-        # We expect transfer_stats_data to be aggregated across all workers and
-        # consist of observations from a single connector or a MultiConnector.
         transfer_stats = self.connector_cls.build_kv_connector_stats(
             transfer_stats_data
         )
@@ -91,13 +95,18 @@ class KVConnectorLogging:
             )
 
     def log(self, log_fn=logger.info):
-        """Log transfer metrics periodically, similar to throughput logging"""
+        """Log the accumulated transfer metrics for the last interval.
+
+        Reduces the accumulator to a summary line (see
+        :meth:`KVConnectorStats.reduce`) and resets it for the next
+        interval. Intervals with failures but no successful transfers
+        still produce a log line (zero values) so they are not silently
+        dropped — the failures are surfaced through Prometheus.
+        """
         if (
             self.transfer_stats_accumulator
             and not self.transfer_stats_accumulator.is_empty()
         ):
-            # Produce a single cumulative stats object for the last time
-            # interval from the recorded observations.
             xfer_metrics = self.transfer_stats_accumulator.reduce()
             xfer_metrics_str = ", ".join(f"{k}={v}" for k, v in xfer_metrics.items())
             log_fn("KV Transfer metrics: %s", xfer_metrics_str)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py
@@ -23,7 +23,18 @@ if TYPE_CHECKING:
 
 @dataclass
 class NixlKVConnectorStats(KVConnectorStats):
-    """Container for transfer performance metrics"""
+    """Per-interval telemetry for NIXL KV cache transfers.
+
+    Each successful transfer contributes one observation to the
+    ``transfer_duration``, ``post_duration``, ``bytes_transferred``
+    and ``num_descriptors`` lists; failures and expired-KV events
+    each append ``1`` to their counter lists. Observations are pooled,
+    never averaged per rank: :meth:`aggregate` extends the lists in
+    place so every statistic in :meth:`reduce` covers the combined
+    pool from all TP ranks and accumulated intervals. The container
+    must remain serializable — stats are shipped from workers to the
+    logger process between ranks.
+    """
 
     def __post_init__(self):
         if not self.data:
@@ -43,7 +54,16 @@ class NixlKVConnectorStats(KVConnectorStats):
         }
 
     def record_transfer(self, res: "nixlXferTelemetry"):
-        # Keep metrics units consistent with rest of the code: time us->s
+        """Record one successful transfer from NIXL telemetry.
+
+        Args:
+            res: Per-transfer telemetry. ``xferDuration`` is the
+                end-to-end duration (posting plus data movement) and
+                ``postDuration`` is the time to submit the transfer to
+                the RDMA backend; both are converted from microseconds
+                to seconds. ``totalBytes`` (bytes) and ``descCount``
+                (descriptors) are stored as-is.
+        """
         self.data["transfer_duration"].append(res.xferDuration / 1e6)
         self.data["post_duration"].append(res.postDuration / 1e6)
         self.data["bytes_transferred"].append(res.totalBytes)
@@ -62,12 +82,25 @@ class NixlKVConnectorStats(KVConnectorStats):
         self.data["num_kv_expired_reqs"].append(1)
 
     def clone_and_reset(self) -> "NixlKVConnectorStats":
+        """Return a snapshot of the observations collected so far.
+
+        The returned copy holds every observation since the last call,
+        and the collector is reset so the next snapshot only covers
+        fresh observations. The snapshot is handed to the scheduler
+        each step and later merged across ranks via :meth:`aggregate`.
+        """
         old = copy.copy(self)
         self.reset()
         return old
 
     def is_empty(self) -> bool:
-        # Do not discard metrics update that are entirely failures related.
+        """Return True when no observations of any kind were recorded.
+
+        Intervals that contain failures but no successful transfers
+        are not empty so they still reach the logger; their log line
+        reports zeros while failures are surfaced through Prometheus
+        counters.
+        """
         return (
             self.num_successful_transfers == 0
             and len(self.data["num_failed_transfers"]) == 0
@@ -76,6 +109,14 @@ class NixlKVConnectorStats(KVConnectorStats):
         )
 
     def aggregate(self, other: KVConnectorStats) -> KVConnectorStats:
+        """Merge another stats object into this one, in place.
+
+        Each observation list is extended with the other object's
+        entries, so statistics in :meth:`reduce` are taken over the
+        combined pool from all ranks and intervals rather than
+        per-rank averages. Empty objects are skipped so idle ranks
+        do not dilute the counts.
+        """
         if not other.is_empty():
             for k, v in other.data.items():
                 accumulator = self.data[k]
@@ -84,10 +125,30 @@ class NixlKVConnectorStats(KVConnectorStats):
         return self
 
     def reduce(self) -> dict[str, int | float]:
-        # Compute compact representative stats suitable for CLI logging
+        """Summarize the pooled observations for CLI logging.
+
+        Computed over the combined observations from all TP ranks and
+        accumulated intervals:
+
+        - ``Num successful transfers``: number of successful transfers.
+        - ``Avg xfer time (ms)`` / ``P90 xfer time (ms)``: mean and
+          90th percentile of end-to-end transfer durations (posting
+          plus data movement), in milliseconds.
+        - ``Avg post time (ms)`` / ``P90 post time (ms)``: mean and
+          90th percentile of the time to submit a transfer to the
+          RDMA backend, in milliseconds.
+        - ``Avg MB per transfer``: mean payload size in MiB (bytes
+          divided by 2**20).
+        - ``Throughput (MB/s)``: total MiB transferred divided by
+          the sum of transfer durations. Aggregate bandwidth, not
+          wall-clock or per-request bandwidth.
+        - ``Avg number of descriptors``: mean descriptor count per
+          transfer.
+
+        When no successful transfers were recorded all values are
+        zero and failures are reported through Prometheus instead.
+        """
         if self.num_successful_transfers == 0:
-            # CLI logging only reports successful transfers stats. If all requests in
-            # the interval were unsuccessful, Prom will report failures stats instead.
             return {
                 "Num successful transfers": 0,
                 "Avg xfer time (ms)": 0,
@@ -126,6 +187,7 @@ class NixlKVConnectorStats(KVConnectorStats):
 
     @property
     def num_successful_transfers(self) -> int:
+        """Number of successful transfers recorded (one per observation)."""
         return len(self.data["transfer_duration"])
 
 
@@ -238,6 +300,14 @@ class NixlPromMetrics(KVConnectorPromMetrics):
         )
 
     def observe(self, transfer_stats_data: dict[str, Any], engine_idx: int = 0):
+        """Record pooled transfer stats into Prometheus metrics.
+
+        Each per-transfer observation is recorded into its
+        corresponding histogram (transfer time, post time, bytes
+        transferred, descriptor count); failure and expired-KV events
+        increment their counters. All observations are recorded
+        against the metric instance labeled with ``engine_idx``.
+        """
         for prom_obj, list_item_key in zip(
             [
                 self.nixl_histogram_xfer_time,


### PR DESCRIPTION
## Summary

Completes the remaining source-level documentation items (1-3) of #41230: explain what the NIXL \`KV Transfer metrics\` log line and the NIXL Prometheus metrics mean, with a focus on the multi-rank (TP > 1) aggregation semantics that previously caused user confusion.

Covers:

- \`NixlKVConnectorStats\` - per-interval telemetry container: what each \`data\` key holds, its units, and the pooling (never per-rank averaging) semantics of \`aggregate\`.
- \`record_transfer\` - per-transfer telemetry from NIXL: \`xferDuration\` (end-to-end, posting + data movement) and \`postDuration\` (time to submit the transfer to the RDMA backend), both converted from microseconds to seconds; bytes and descriptor counts stored as-is.
- \`clone_and_reset\` / \`is_empty\` / \`num_successful_transfers\` - the snapshot-and-reset contract, and why failure-only intervals are intentionally kept so they still reach the logger and Prometheus.
- \`reduce\` - definitions of every field in the log line: mean/P90 durations in ms, MiB conversion (bytes / 2**20), aggregate throughput (total MiB / sum of transfer durations, not wall-clock), descriptor mean, and the all-zeros path when no transfer succeeded.
- \`NixlPromMetrics.observe\` - histogram vs counter recording per engine.
- \`KVConnectorLogging.observe\` / \`log\` - the scheduler-sync vs logging-interval distinction and the accumulator lifecycle.

## Why this is not duplicating an existing PR

- #44055 (merged) covered item 4 only - the user-facing docs page (\`docs/features/nixl_connector_usage.md\`); its changed files were limited to that page. Maintainer markmc confirmed items 1-3 (source-level documentation in \`stats.py\` / \`metrics.py\`) remain open (2026-06-12).
- No open PR touches these two files for documentation purposes. Commenters on #41230 (ammmanism, kritikagarg, dhariskhan1275) expressed interest, but no PR had been opened for items 1-3.

## Test commands and results

Docs-only change - no behavior change, so no model evaluation applies (no effect on output, accuracy, or serving).

- \`ruff check\` on both changed files: all checks passed.
- \`git diff --check\`: clean; all lines within the 88-char limit.
- \`python -m compileall\` on both files: OK.
- Documented semantics verified against the actual \`reduce\` / \`aggregate\` / \`is_empty\` logic with a standalone script: pooled mean/P90 math, MiB conversion, the \`num_successful_transfers == 0\` guard, and the failure-only zero path - all assertions passed.

## AI assistance disclosure

This PR was developed with AI assistance (opencode) and reviewed by a human. The AI helped draft the docstrings; every documented statement was then traced to its code path (\`_pop_done_transfers\` -> \`record_transfer\` -> \`get_kv_connector_stats\`/clone_and_reset -> \`KVOutputAggregator.aggregate\` -> scheduler merge -> \`KVConnectorLogging.observe\`/log + \`NixlPromMetrics.observe\`) and cross-checked against the semantics documented in #44055. The human submitter reviewed every changed line and verified the claims before submission.