### PR TITLE
[Bugfix] Honor per-model DeepGEMM auto-disable in FP8 MoE backend selection and warmup

### DIFF
--- a/tests/kernels/moe/test_fp8_moe_backend_deep_gemm_disable.py
+++ b/tests/kernels/moe/test_fp8_moe_backend_deep_gemm_disable.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""FP8 MoE backend selection honors the per-model DeepGEMM auto-disable.
+
+Regression test for https://github.com/vllm-project/vllm/issues/47169: when
+``quant_config.use_deep_gemm`` is explicitly ``False`` (set by
+:func:`vllm.utils.deep_gemm.should_auto_disable_deep_gemm` for Qwen3.5/3.6
+hybrid models on Blackwell, where DeepGEMM's E8M0 scale format degrades
+accuracy), the oracle must never select the DeepGEMM FP8 MoE backends, even
+when they would otherwise be the top priority.
+
+GPU-free: the backend priority list and kernel ``is_supported_config`` checks
+are mocked, so selection is deterministic on every platform.
+"""
+
+from tests.kernels.moe.utils import make_dummy_moe_config
+from vllm.model_executor.layers.fused_moe.oracle.fp8 import (
+    Fp8MoeBackend,
+    select_fp8_moe_backend,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kFp8Dynamic128Sym,
+    kFp8Static128BlockSym,
+)
+
+
+class _FakeKernel:
+    """A kernel class whose is_supported_config always succeeds."""
+
+    @classmethod
+    def is_supported_config(
+        cls, k_cls, config, weight_key, activation_key, activation_format
+    ):
+        return True, None
+
+
+def _dummy_config():
+    return make_dummy_moe_config(
+        num_experts=8,
+        experts_per_token=2,
+        hidden_dim=512,
+        intermediate_size=1024,
+    )
+
+
+def _install_fake_selection(monkeypatch):
+    """Force DeepGEMM to be the top-priority backend with fake kernels."""
+    monkeypatch.delenv("VLLM_USE_DEEP_GEMM", raising=False)
+    monkeypatch.delenv("VLLM_MOE_USE_DEEP_GEMM", raising=False)
+
+    def fake_priority(config, weight_key, activation_key):
+        return [
+            Fp8MoeBackend.DEEPGEMM,
+            Fp8MoeBackend.TRITON,
+            Fp8MoeBackend.VLLM_CUTLASS,
+            Fp8MoeBackend.BATCHED_VLLM_CUTLASS,
+        ]
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.fused_moe.oracle.fp8._get_priority_backends",
+        fake_priority,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.fused_moe.oracle.fp8.backend_to_kernel_cls",
+        lambda backend: [_FakeKernel],
+    )
+
+
+def test_select_fp8_moe_backend_excludes_deepgemm_when_disabled(monkeypatch):
+    _install_fake_selection(monkeypatch)
+    backend, _ = select_fp8_moe_backend(
+        config=_dummy_config(),
+        weight_key=kFp8Static128BlockSym,
+        activation_key=kFp8Dynamic128Sym,
+        use_deep_gemm=False,
+    )
+    assert backend == Fp8MoeBackend.TRITON
+    assert backend not in (
+        Fp8MoeBackend.DEEPGEMM,
+        Fp8MoeBackend.BATCHED_DEEPGEMM,
+    )
+
+
+def test_select_fp8_moe_backend_keeps_deepgemm_by_default(monkeypatch):
+    _install_fake_selection(monkeypatch)
+    backend, _ = select_fp8_moe_backend(
+        config=_dummy_config(),
+        weight_key=kFp8Static128BlockSym,
+        activation_key=kFp8Dynamic128Sym,
+    )
+    assert backend == Fp8MoeBackend.DEEPGEMM
+
+
+def test_select_fp8_moe_backend_keeps_deepgemm_when_explicitly_enabled(
+    monkeypatch,
+):
+    _install_fake_selection(monkeypatch)
+    backend, _ = select_fp8_moe_backend(
+        config=_dummy_config(),
+        weight_key=kFp8Static128BlockSym,
+        activation_key=kFp8Dynamic128Sym,
+        use_deep_gemm=True,
+    )
+    assert backend == Fp8MoeBackend.DEEPGEMM
+
+
+def test_select_fp8_moe_backend_env_override_wins_over_disable(monkeypatch):
+    _install_fake_selection(monkeypatch)
+    # Explicitly setting the DeepGEMM env vars is a user override that must
+    # win over the per-model auto-disable.
+    monkeypatch.setenv("VLLM_USE_DEEP_GEMM", "1")
+    monkeypatch.setenv("VLLM_MOE_USE_DEEP_GEMM", "1")
+    backend, _ = select_fp8_moe_backend(
+        config=_dummy_config(),
+        weight_key=kFp8Static128BlockSym,
+        activation_key=kFp8Dynamic128Sym,
+        use_deep_gemm=False,
+    )
+    assert backend == Fp8MoeBackend.DEEPGEMM

--- a/tests/model_executor/warmup/test_deep_gemm_warmup_autodisable.py
+++ b/tests/model_executor/warmup/test_deep_gemm_warmup_autodisable.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""DeepGEMM warmup honors the per-model auto-disable.
+
+Regression test for https://github.com/vllm-project/vllm/issues/47169: when
+``quant_config.use_deep_gemm`` is explicitly ``False`` (set by
+:func:`vllm.utils.deep_gemm.should_auto_disable_deep_gemm` for Qwen3.5/3.6
+hybrid models on Blackwell), the fused-MoE warmup gate must not JIT-compile
+DeepGEMM kernels for those modules.
+
+GPU-free: the module and quant method are mocked.
+"""
+
+from unittest.mock import Mock
+
+from vllm.model_executor.warmup import deep_gemm_warmup
+
+
+class _FakeMoERunner:
+    """Stand-in for MoERunner so plain mocks pass isinstance checks."""
+
+
+def _mock_moe_module(monkeypatch, use_deep_gemm=None, has_attr=True):
+    monkeypatch.setattr(deep_gemm_warmup, "MoERunner", _FakeMoERunner)
+    monkeypatch.delenv("VLLM_USE_DEEP_GEMM", raising=False)
+    monkeypatch.delenv("VLLM_MOE_USE_DEEP_GEMM", raising=False)
+    quant_method = Mock()
+    if has_attr:
+        quant_config = Mock()
+        quant_config.use_deep_gemm = use_deep_gemm
+        quant_method.quant_config = quant_config
+    else:
+        # Some non-FP8 quant methods have a quant_config without the field.
+        quant_method.quant_config = Mock()
+    module = Mock()
+    module._quant_method = quant_method
+    return module
+
+
+def test_fused_moe_grouped_gemm_may_use_deep_gemm_false_when_disabled(
+    monkeypatch,
+):
+    module = _mock_moe_module(monkeypatch, use_deep_gemm=False)
+    assert deep_gemm_warmup._fused_moe_grouped_gemm_may_use_deep_gemm(module) is False
+
+
+def test_fused_moe_grouped_gemm_may_use_deep_gemm_no_attribute_error(
+    monkeypatch,
+):
+    # quant_config without a use_deep_gemm attribute must not raise.
+    module = _mock_moe_module(monkeypatch, has_attr=False)
+    result = deep_gemm_warmup._fused_moe_grouped_gemm_may_use_deep_gemm(module)
+    assert result is False
+
+
+def test_fused_moe_grouped_gemm_may_use_deep_gemm_env_override_wins(
+    monkeypatch,
+):
+    # Explicit env overrides take precedence over the per-model disable.
+    monkeypatch.setattr(deep_gemm_warmup, "MoERunner", _FakeMoERunner)
+    monkeypatch.setenv("VLLM_USE_DEEP_GEMM", "1")
+    monkeypatch.setenv("VLLM_MOE_USE_DEEP_GEMM", "1")
+    quant_method = Mock()
+    quant_config = Mock()
+    quant_config.use_deep_gemm = False
+    quant_method.quant_config = quant_config
+    module = Mock()
+    module._quant_method = quant_method
+    # The gate should not bail out on the flag; it falls through to the
+    # existing checks (which return False here because the mock has no
+    # matching quant config) without raising.
+    result = deep_gemm_warmup._fused_moe_grouped_gemm_may_use_deep_gemm(module)
+    assert result is False

--- a/vllm/model_executor/layers/fused_moe/oracle/fp8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/fp8.py
@@ -273,6 +273,7 @@ def select_fp8_moe_backend(
     weight_key: QuantKey | None,
     activation_key: QuantKey | None,
     allow_vllm_cutlass: bool = False,
+    use_deep_gemm: bool | None = None,
 ) -> tuple[Fp8MoeBackend, type[mk.FusedMoEExperts] | None]:
     """
     Select the primary FP8 MoE backend
@@ -281,6 +282,25 @@ def select_fp8_moe_backend(
 
     # NOTE: the kernels are selected in the following order.
     AVAILABLE_BACKENDS = _get_priority_backends(config, weight_key, activation_key)
+
+    # Honor the per-model DeepGEMM auto-disable (see
+    # vllm/utils/deep_gemm.py::should_auto_disable_deep_gemm): if the
+    # quantization config explicitly disabled DeepGEMM, never select the
+    # DeepGEMM MoE backends (e.g. Qwen3.5/3.6 hybrid models on Blackwell,
+    # where the E8M0 scale format causes accuracy degradation). Explicit
+    # VLLM_USE_DEEP_GEMM / VLLM_MOE_USE_DEEP_GEMM env overrides take
+    # precedence and are handled below.
+    if (
+        use_deep_gemm is False
+        and not envs.is_set("VLLM_USE_DEEP_GEMM")
+        and not envs.is_set("VLLM_MOE_USE_DEEP_GEMM")
+    ):
+        for backend in (
+            Fp8MoeBackend.DEEPGEMM,
+            Fp8MoeBackend.BATCHED_DEEPGEMM,
+        ):
+            if backend in AVAILABLE_BACKENDS:
+                AVAILABLE_BACKENDS.remove(backend)
 
     # NOTE(rob): We need to peak into the P/F selection to determine
     # if we are using the batched or standard expert format, which

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -519,6 +519,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             weight_key=weight_key,
             activation_key=activation_key,
             allow_vllm_cutlass=False,
+            use_deep_gemm=self.quant_config.use_deep_gemm,
         )
 
     def create_weights(

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -767,6 +767,7 @@ class ModelOptFp8MoEMethod(FusedMoEMethodBase):
             config=self.moe,
             weight_key=kFp8StaticTensorSym,
             activation_key=kFp8StaticTensorSym,
+            use_deep_gemm=getattr(self.quant_config, "use_deep_gemm", None),
         )
 
     def maybe_make_prepare_finalize(

--- a/vllm/model_executor/warmup/deep_gemm_warmup.py
+++ b/vllm/model_executor/warmup/deep_gemm_warmup.py
@@ -182,6 +182,20 @@ def _fused_moe_grouped_gemm_may_use_deep_gemm(module: torch.nn.Module) -> bool:
         return False
 
     quant_method = module._quant_method
+
+    # Honor the per-model DeepGEMM auto-disable (see
+    # vllm/utils/deep_gemm.py::should_auto_disable_deep_gemm): skip the
+    # module when its quantization config explicitly disabled DeepGEMM.
+    # Explicit VLLM_USE_DEEP_GEMM / VLLM_MOE_USE_DEEP_GEMM env overrides
+    # take precedence (they are handled by the caller/environment).
+    quant_config = getattr(quant_method, "quant_config", None)
+    if (
+        not envs.is_set("VLLM_USE_DEEP_GEMM")
+        and not envs.is_set("VLLM_MOE_USE_DEEP_GEMM")
+        and getattr(quant_config, "use_deep_gemm", None) is False
+    ):
+        return False
+
     moe_quant_config = quant_method.get_fused_moe_quant_config(module.routed_experts)
 
     if (


### PR DESCRIPTION
## Summary

`should_auto_disable_deep_gemm()` (vllm/utils/deep_gemm.py) disables DeepGEMM for models known to suffer accuracy degradation from DeepGEMM's E8M0 scale format on Blackwell (e.g. Qwen3.5/3.6 hybrid models) by setting `quant_config.use_deep_gemm = False`. The dense block-FP8 path already honors this (`DeepGemmFp8BlockScaledMMKernel.can_implement` rejects auto-disabled model types), but **the FP8 MoE path ignores the flag**:

1. `select_fp8_moe_backend()` can still select the DeepGEMM FP8 MoE backends, so Qwen3.6-35B-A3B-FP8-style MoE models run DeepGEMM on Blackwell despite the auto-disable.
2. The DeepGEMM warmup gate for fused MoE (`_fused_moe_grouped_gemm_may_use_deep_gemm`) still JIT-compiles DeepGEMM kernels during startup for such models (the startup-crash variant of this is #47169 / #47130).

## Changes

- **`vllm/model_executor/layers/fused_moe/oracle/fp8.py`**: `select_fp8_moe_backend()` gains a `use_deep_gemm: bool | None = None` parameter; when explicitly `False`, the DeepGEMM backends (`DEEPGEMM`, `BATCHED_DEEPGEMM`) are removed from the candidate set. Explicit `VLLM_USE_DEEP_GEMM=1` / `VLLM_MOE_USE_DEEP_GEMM=1` env overrides still win (unchanged behavior).
- **`vllm/model_executor/layers/quantization/fp8.py`** (`Fp8MoEMethod`) and **`modelopt.py`** (`ModelOptFp8MoEMethod`): pass `quant_config.use_deep_gemm` through to the oracle.
- **`vllm/model_executor/warmup/deep_gemm_warmup.py`**: `_fused_moe_grouped_gemm_may_use_deep_gemm()` skips modules whose quantization config explicitly disabled DeepGEMM.

## Verification (real hardware: 2x NVIDIA RTX 6000D, SM120 / cc 12.0, vLLM 0.26.0)

Oracle behavior for the Qwen3.6-35B-A3B-FP8 quant scheme (`kFp8Static128BlockSym` / `kFp8Dynamic128Sym`, 256 experts) on SM120:

| | result |
|---|---|
| before | `Fp8MoeBackend.DEEPGEMM` / `TritonOrDeepGemmExperts` (bug) |
| after (`use_deep_gemm=False`) | `Fp8MoeBackend.TRITON` / `TritonExperts` |

End-to-end: `Qwen/Qwen3.6-27B-FP8` starts cleanly (auto-disable warning + `CutlassFp8BlockScaledMMKernel` selected) and generates correctly.

## Tests

GPU-free unit tests:
- `tests/kernels/moe/test_fp8_moe_backend_deep_gemm_disable.py` — oracle excludes DeepGEMM when disabled, keeps it by default and when explicitly enabled.
- `tests/model_executor/warmup/test_deep_gemm_warmup_autodisable.py` — fused-MoE warmup gate skips modules with `use_deep_gemm=False`.

All 4 pass locally.

## Related

- Fixes #47169 (also referenced by #47130)
- Related/alternative: #47258, #47261, #41851