### PR TITLE
[Bugfix][Frontend] Default null Responses background and truncation

### DIFF
--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -156,6 +156,44 @@ def test_extract_tool_types(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.skip_global_cleanup
+def test_response_created_event_defaults_explicit_nulls() -> None:
+    request = ResponsesRequest.model_validate(
+        {
+            "model": "test-model",
+            "input": "hello",
+            "background": None,
+            "truncation": None,
+        }
+    )
+    sampling_params = request.to_sampling_params(default_max_tokens=16)
+
+    response = ResponsesResponse.from_request(
+        request=request,
+        sampling_params=sampling_params,
+        model_name="test-model",
+        created_time=0,
+        output=[],
+        status="completed",
+    )
+
+    assert response.background is False
+    assert response.truncation == "disabled"
+
+
+@pytest.mark.skip_global_cleanup
+def test_build_tok_params_treats_explicit_null_truncation_as_disabled() -> None:
+    request = ResponsesRequest.model_validate(
+        {"model": "test-model", "input": "hello", "truncation": None}
+    )
+    model_config = MagicMock()
+    model_config.max_model_len = 128
+
+    tok_params = request.build_tok_params(model_config)
+
+    assert tok_params.truncate_prompt_tokens is None
+
+
+@pytest.mark.skip_global_cleanup
 def test_response_created_event_uses_public_json_schema_alias() -> None:
     schema = {
         "type": "object",

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -345,7 +345,7 @@ class ResponsesRequest(OpenAIBaseModel):
         return TokenizeParams(
             max_total_tokens=model_config.max_model_len,
             max_output_tokens=self.max_output_tokens or 0,
-            truncate_prompt_tokens=-1 if self.truncation != "disabled" else None,
+            truncate_prompt_tokens=-1 if self.truncation == "auto" else None,
             max_total_tokens_param="max_model_len",
             max_output_tokens_param="max_output_tokens",
         )
@@ -733,6 +733,16 @@ class ResponsesResponse(OpenAIBaseModel):
         # TODO: implement the other reason for incomplete_details,
         # which is content_filter
         # incomplete_details = IncompleteDetails(reason='content_filter')
+        background = (
+            request.background
+            if request.background is not None
+            else ResponsesRequest.model_fields["background"].default
+        )
+        truncation = (
+            request.truncation
+            if request.truncation is not None
+            else ResponsesRequest.model_fields["truncation"].default
+        )
         return cls(
             id=request.request_id,
             created_at=created_time,
@@ -750,7 +760,7 @@ class ResponsesResponse(OpenAIBaseModel):
             tool_choice=request.tool_choice,
             tools=request.tools,
             top_p=sampling_params.top_p,
-            background=request.background,
+            background=background,
             max_output_tokens=sampling_params.max_tokens,
             max_tool_calls=request.max_tool_calls,
             previous_response_id=request.previous_response_id,
@@ -762,7 +772,7 @@ class ResponsesResponse(OpenAIBaseModel):
             status=status,
             text=request.text,
             top_logprobs=sampling_params.logprobs,
-            truncation=request.truncation,
+            truncation=truncation,
             user=request.user,
             usage=usage,
             kv_transfer_params=kv_transfer_params,

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -438,7 +438,7 @@ class OpenAIServingResponses(GenerateBaseServing):
                 self.default_sampling_params,
                 self.override_max_tokens,
                 truncate_prompt_tokens=(
-                    -1 if request.truncation != "disabled" else None
+                    -1 if request.truncation == "auto" else None
                 ),
             )
 
@@ -736,7 +736,7 @@ class OpenAIServingResponses(GenerateBaseServing):
                     self.default_sampling_params,  # type: ignore
                     self.override_max_tokens,  # type: ignore
                     truncate_prompt_tokens=(
-                        -1 if context.request.truncation != "disabled" else None
+                        -1 if context.request.truncation == "auto" else None
                     ),
                 )
 


### PR DESCRIPTION
## Summary
- Treat explicit `background: null` as the Responses API default `false` when building responses.
- Treat explicit `truncation: null` as `disabled`, including prompt-token truncation decisions.
- Add regression tests for response construction and tokenization params.

Fixes #48319

## Test Plan
- `pytest tests/entrypoints/openai/responses/test_serving_responses.py::test_response_created_event_defaults_explicit_nulls tests/entrypoints/openai/responses/test_serving_responses.py::test_build_tok_params_treats_explicit_null_truncation_as_disabled tests/entrypoints/openai/responses/test_serving_responses.py::test_response_created_event_uses_public_json_schema_alias -q`
- `python -m ruff check vllm/entrypoints/openai/responses/protocol.py vllm/entrypoints/openai/responses/serving.py tests/entrypoints/openai/responses/test_serving_responses.py`
- `python -m py_compile vllm/entrypoints/openai/responses/protocol.py vllm/entrypoints/openai/responses/serving.py tests/entrypoints/openai/responses/test_serving_responses.py`
- `git diff --check`