### PR TITLE
[Bugfix] Bound tile-local argmax to vocab_size in samplers

### DIFF
--- a/tests/v1/spec_decode/test_rejection_sampler_utils.py
+++ b/tests/v1/spec_decode/test_rejection_sampler_utils.py
@@ -298,24 +298,23 @@ def test_synthetic_rejection_sample(
 
 
 @pytest.mark.parametrize("temperature", [0.0, 1.0])
-def test_all_nan_target_logits_in_range(temperature: float):
-    """Regression test for NaN breaking tl.argmax index bounds.
+@pytest.mark.parametrize("vocab_size", [999, 20000])
+def test_all_nan_target_logits_in_range(temperature: float, vocab_size: int):
+    """Degenerate tiles and padded block reductions must emit in-range IDs.
 
     An all-NaN target logits row makes every per-block local max NaN.
-    tl.argmax over such a block returns an index into the padded region
-    (>= num_blocks), causing an OOB read of the local-argmax tensors in
-    _compute_global_target_argmax (greedy) and _insert_resampled_kernel
-    (stochastic). The vocab size below gives a non-power-of-2 block count
-    (3 blocks of 8192, padded to 4) so the padded region exists. Post-fix,
-    NaN is mapped to -inf, so the kernels must complete without error and
-    emit in-range token ids.
+    vocab_size=999 is smaller than both the 8192-lane stats tile and the
+    1024-lane resampling tile, exposing an out-of-vocab tile-local argmax.
+    vocab_size=20000 retains coverage for a global argmax choosing a padded
+    fourth block after the three real 8192-lane blocks. The fallback is only
+    required to be addressable; it does not define a semantically correct token
+    or repair the source of the non-finite logits. For stochastic sampling, a
+    placeholder draft token forces the recovered-token resampling path.
     """
     torch.manual_seed(0)
     device = "cuda"
     num_trials = 4
     K = 1
-    vocab_size = 20000  # 3 vocab blocks of 8192, padded to 4
-
     target_logits_1d = torch.full(
         (vocab_size,), float("nan"), device=device, dtype=torch.float32
     )
@@ -328,6 +327,8 @@ def test_all_nan_target_logits_in_range(temperature: float):
         temperature=temperature,
         num_trials=num_trials,
     )
+    if temperature > 0:
+        inputs["draft_sampled"].view(num_trials, K + 1)[:, 1:] = -1
 
     sampled, num_sampled = rejection_sample(**inputs, num_speculative_steps=K)
 

--- a/tests/v1/worker/test_gpu_gumbel_sample.py
+++ b/tests/v1/worker/test_gpu_gumbel_sample.py
@@ -183,6 +183,24 @@ def test_greedy_temperature_zero_returns_argmax():
     assert torch.equal(sampled, logits.argmax(dim=-1))
 
 
+@pytest.mark.parametrize("temperature", [0.0, 1.0])
+def test_all_nan_logits_return_in_range_fallback(temperature: float):
+    """A degenerate tile must still emit an addressable token ID.
+
+    With vocab_size smaller than the 1024-lane sampling tile, an all-NaN row
+    can make the tile-local argmax settle on an out-of-vocab tail lane. The
+    fallback is only required to be in range; it does not define a semantically
+    correct token or repair the source of the non-finite logits.
+    """
+    vocab_size = 999
+    logits = torch.full((vocab_size,), float("nan"), device=DEVICE)
+
+    sampled = _sample(logits, 4, temperature=temperature)
+
+    assert sampled.min() >= 0
+    assert sampled.max() < vocab_size
+
+
 def test_zero_count_tokens_are_never_sampled():
     """Count 0 -> -inf logit -> probability 0; must never be selected."""
     counts = _make_heavy_tailed_counts(seed=7)

--- a/vllm/v1/worker/gpu/sample/gumbel.py
+++ b/vllm/v1/worker/gpu/sample/gumbel.py
@@ -207,7 +207,14 @@ def _gumbel_sample_kernel(
         USE_FP64=USE_FP64,
         PER_TOKEN_COL=PER_TOKEN_COL,
     )
-    token_id = block_idx * BLOCK_SIZE + idx
+    # `idx` is the argmax over a BLOCK_SIZE-wide tile whose out-of-vocab tail
+    # lanes are loaded as -inf. When every in-vocab lane of the tile is also
+    # -inf (or NaN) the reduction can settle on one of those tail lanes, giving
+    # token_id >= vocab_size. Nothing downstream bounds a sampled token id, and
+    # DeepSeek-V4's hash-MoE router indexes tid2eid[token_id * topk] directly,
+    # so such an id reads past the table and faults the context. Clamp: in that
+    # degenerate all--inf tile any index is equally arbitrary.
+    token_id = tl.minimum(block_idx * BLOCK_SIZE + idx, vocab_size - 1)
     tl.store(local_argmax_ptr + token_idx * local_argmax_stride + block_idx, token_id)
     tl.store(local_max_ptr + token_idx * local_max_stride + block_idx, value)
 

--- a/vllm/v1/worker/gpu/sample/gumbel.py
+++ b/vllm/v1/worker/gpu/sample/gumbel.py
@@ -230,7 +230,12 @@ def _gumbel_sample_kernel(
         USE_FP64=USE_FP64,
         PER_TOKEN_COL=PER_TOKEN_COL,
     )
-    token_id = block_idx * BLOCK_SIZE + idx
+    # `idx` is the argmax over a BLOCK_SIZE-wide tile whose out-of-vocab tail
+    # lanes are loaded as -inf. If the in-vocab lanes are all non-finite, the
+    # reduction can settle on a tail lane and yield token_id >= vocab_size.
+    # Clamp to provide an addressable in-vocabulary fallback. This does not
+    # define a semantically correct token or fix the source of non-finite logits.
+    token_id = tl.minimum(block_idx * BLOCK_SIZE + idx, vocab_size - 1)
     tl.store(local_argmax_ptr + token_idx * local_argmax_stride + block_idx, token_id)
     tl.store(local_max_ptr + token_idx * local_max_stride + block_idx, value)
 

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
@@ -240,7 +240,12 @@ def _compute_local_logits_stats_kernel(
             other=float("-inf"),
         ).to(tl.float32)
         value, idx = tl.max(target_logits, axis=0, return_indices=True)
-        token_id = block_idx * BLOCK_SIZE + idx
+        # Out-of-vocab tail lanes of this tile are loaded as -inf; when every
+        # in-vocab lane is also -inf/NaN the reduction can settle on one of
+        # them, yielding token_id >= vocab_size. Nothing downstream bounds a
+        # sampled token id. Clamp -- in that degenerate tile any index is
+        # equally arbitrary.
+        token_id = tl.minimum(block_idx * BLOCK_SIZE + idx, vocab_size - 1)
         tl.store(
             target_local_argmax_ptr
             + logit_idx * target_local_argmax_stride
@@ -789,7 +794,9 @@ def _resample_kernel(
         APPLY_TEMPERATURE=False,
         USE_FP64=USE_FP64,
     )
-    token_id = block_idx * BLOCK_SIZE + idx
+    # See the note in _compute_local_logits_stats_kernel: bound the tile-local
+    # argmax so an all--inf tile cannot produce an out-of-vocab token id.
+    token_id = tl.minimum(block_idx * BLOCK_SIZE + idx, vocab_size - 1)
     tl.store(
         resampled_local_argmax_ptr
         + req_idx * resampled_local_argmax_stride

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
@@ -246,7 +246,12 @@ def _compute_local_logits_stats_kernel(
             other=float("-inf"),
         ).to(tl.float32)
         value, idx = tl.max(target_logits, axis=0, return_indices=True)
-        token_id = block_idx * BLOCK_SIZE + idx
+        # Out-of-vocab tail lanes are loaded as -inf. If the in-vocab lanes are
+        # all non-finite, the reduction can settle on a tail lane and yield
+        # token_id >= vocab_size. Clamp to provide an addressable in-vocabulary
+        # fallback; this neither chooses a semantically correct token nor fixes
+        # the source of non-finite logits.
+        token_id = tl.minimum(block_idx * BLOCK_SIZE + idx, vocab_size - 1)
         tl.store(
             target_local_argmax_ptr
             + logit_idx * target_local_argmax_stride
@@ -840,7 +845,9 @@ def _resample_kernel(
         APPLY_TEMPERATURE=False,
         USE_FP64=USE_FP64,
     )
-    token_id = block_idx * BLOCK_SIZE + idx
+    # Preserve the bounded-fallback contract from
+    # _compute_local_logits_stats_kernel for the resampling path.
+    token_id = tl.minimum(block_idx * BLOCK_SIZE + idx, vocab_size - 1)
     tl.store(
         resampled_local_argmax_ptr
         + req_idx * resampled_local_argmax_stride


### PR DESCRIPTION
## Summary

The sampling kernels reduce over a `BLOCK_SIZE`-wide tile of the logits row and
form the token id as `block_idx * BLOCK_SIZE + idx`. The out-of-vocab tail lanes
of the last tile are loaded as `-inf`, so when every in-vocab lane of that tile
is also `-inf`, the reduction can settle on a tail lane and emit
`token_id >= vocab_size`.

Nothing downstream bounds a sampled token id.

Three sites share the pattern:

| Site | Path |
|---|---|
| `vllm/v1/worker/gpu/sample/gumbel.py` | non-greedy sampling |
| `vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py` (`_compute_local_logits_stats_kernel`) | greedy |
| `vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py` (resample) | recovered-token resampling |

## Impact

On most models the bad id is absorbed by `VocabParallelEmbedding`, which masks
out-of-range ids to a zero embedding — so it degrades silently into a garbage
output token rather than failing loudly.

On DeepSeek-V4 it is fatal. The hash-MoE router indexes
`tid2eid[token_id * topk]` directly; an out-of-vocab id reads past the
`[vocab_size, topk]` table and the resulting garbage expert id faults the
context on **every** rank with a Warp MMU fault.

## Evidence

Reproduced in production on DeepSeek-V4-Flash (TP2, expert parallelism,
speculative decoding) under bursty concurrency, in 90 s – 5.5 min.

`vocab_size` is 129280, which is not a multiple of the 8192 tile, so the last
tile has 1792 masked lanes. The emitted id was exactly

    15 * 8192 + 6400 == 129280

i.e. the first out-of-vocab lane of the last tile. A check on `input_ids` right
after `combine_sampled_and_draft_tokens` reported this on real scheduled rows
(not cudagraph padding) at ~78 occurrences/minute; after the fix, 0 over a
40-minute run at the same load.

**What I could not reproduce synthetically.** I have not built a minimal input
that makes the argmax select a tail lane. Feeding a fully `-inf` row, or a fully
NaN row, does not do it (they select lane 0 and the last lane of tile 0
respectively). So the exact condition that steers `idx` onto the first
out-of-vocab lane is not established, and I would rather say so than invent a
mechanism.

What is established is the causal link, via a clean A/B under identical
production load:

| Clamped sites | out-of-range `input_ids` |
|---|---|
| none | ~78/min |
| `gumbel.py` only | 4 over ~15 min |
| all three | **0 over 30 min** (1322 requests) |

The middle row is what identified the greedy rejection-sampler site as the
active path.

## Fix

Clamp the tile-local argmax to `vocab_size - 1`. In a fully `-inf` tile no
in-vocab lane is a valid answer anyway, so any index is equally arbitrary — the
clamp only guarantees the result is addressable.

## Test

No unit test: as noted above I could not construct a synthetic input that
reproduces the tail-lane selection, and I did not want to ship a test that passes
with and without the fix. Validation is the end-to-end A/B table above, plus a
30-minute randomized-concurrency run with zero faults where the same load
previously killed the engine in 90 s - 5.5 min.

If a reviewer knows the condition that steers the tile argmax off the end, I am
happy to add a focused test for it.
