### PR TITLE
[Bugfix][MoE] Bound expert_map gathers on data-derived expert ids

### DIFF
--- a/csrc/libtorch_stable/moe/moe_align_sum_kernels.cu
+++ b/csrc/libtorch_stable/moe/moe_align_sum_kernels.cu
@@ -363,9 +363,17 @@ constexpr int MOE_SUM_VEC = 16 / sizeof(scalar_t);
 template <typename idx_t>
 __device__ __forceinline__ bool moe_sum_pad_aware_skip(
     const idx_t* __restrict__ topk_ids, const int32_t* __restrict__ expert_map,
-    int64_t idx) {
+    int64_t idx, int32_t num_experts) {
   int64_t expert_id = static_cast<int64_t>(topk_ids[idx]);
-  if (expert_id < 0) return true;
+  // expert_id is data, not a loop bound: routers allocate topk_ids with
+  // torch.empty and do not always overwrite every slot, so it can hold an
+  // arbitrary positive value. Bound it before indexing expert_map -- checking
+  // only `< 0` let a stale slot gather past the end of the map, an illegal
+  // access that takes down every TP rank. `get_local_expert_id()` above
+  // already applies exactly this bound.
+  if (expert_id < 0 || expert_id >= static_cast<int64_t>(num_experts)) {
+    return true;
+  }
   if (expert_map != nullptr && expert_map[expert_id] < 0) return true;
   return false;
 }
@@ -377,7 +385,7 @@ __global__ void moe_sum_vec_kernel(
     const int64_t num_tokens, const int d, const int64_t stride_token,
     const int64_t stride_topk, const idx_t* __restrict__ topk_ids,
     const int32_t* __restrict__ expert_map, const int64_t stride_tk_token,
-    const int64_t stride_tk_k) {
+    const int64_t stride_tk_k, const int32_t num_experts) {
   using vec_t = vllm::vec_n_t<scalar_t, MOE_SUM_VEC<scalar_t>>;  // 16-byte pack
   constexpr int VEC = MOE_SUM_VEC<scalar_t>;
   const int64_t n_vec = d / VEC;
@@ -399,7 +407,8 @@ __global__ void moe_sum_vec_kernel(
 #pragma unroll
     for (int k = 0; k < TOPK; ++k) {
       if constexpr (PAD_AWARE) {
-        if (moe_sum_pad_aware_skip(tk_tok, expert_map, k * stride_tk_k)) {
+        if (moe_sum_pad_aware_skip(tk_tok, expert_map, k * stride_tk_k,
+                                   num_experts)) {
           continue;
         }
       }
@@ -424,7 +433,8 @@ __global__ void moe_sum_vec_dynamic_kernel(
     const int64_t num_tokens, const int d, const int topk,
     const int64_t stride_token, const int64_t stride_topk,
     const idx_t* __restrict__ topk_ids, const int32_t* __restrict__ expert_map,
-    const int64_t stride_tk_token, const int64_t stride_tk_k) {
+    const int64_t stride_tk_token, const int64_t stride_tk_k,
+    const int32_t num_experts) {
   using vec_t = vllm::vec_n_t<scalar_t, MOE_SUM_VEC<scalar_t>>;
   constexpr int VEC = MOE_SUM_VEC<scalar_t>;
   const int64_t n_vec = d / VEC;
@@ -445,7 +455,8 @@ __global__ void moe_sum_vec_dynamic_kernel(
 
     for (int k = 0; k < topk; ++k) {
       if constexpr (PAD_AWARE) {
-        if (moe_sum_pad_aware_skip(tk_tok, expert_map, k * stride_tk_k)) {
+        if (moe_sum_pad_aware_skip(tk_tok, expert_map, k * stride_tk_k,
+                                   num_experts)) {
           continue;
         }
       }
@@ -470,7 +481,8 @@ __global__ void moe_sum_scalar_kernel(
     const int d, const int topk, const int64_t stride_token,
     const int64_t stride_topk, const int64_t stride_hidden,
     const idx_t* __restrict__ topk_ids, const int32_t* __restrict__ expert_map,
-    const int64_t stride_tk_token, const int64_t stride_tk_k) {
+    const int64_t stride_tk_token, const int64_t stride_tk_k,
+    const int32_t num_experts) {
   const int64_t token_idx = blockIdx.x;
   const scalar_t* in_tok = input + token_idx * stride_token;
   const idx_t* tk_tok = nullptr;
@@ -481,7 +493,8 @@ __global__ void moe_sum_scalar_kernel(
     float x = 0.f;
     for (int k = 0; k < topk; ++k) {
       if constexpr (PAD_AWARE) {
-        if (moe_sum_pad_aware_skip(tk_tok, expert_map, k * stride_tk_k)) {
+        if (moe_sum_pad_aware_skip(tk_tok, expert_map, k * stride_tk_k,
+                                   num_experts)) {
           continue;
         }
       }
@@ -785,19 +798,22 @@ void moe_sum(torch::stable::Tensor& input,   // [num_tokens, topk, hidden_size]
     const int64_t stride_tk_k = tk.stride(1);
 
     const int32_t* expert_map_ptr = nullptr;
+    int32_t num_experts = 0;
     if (expert_map.has_value()) {
       STD_TORCH_CHECK(
           expert_map->scalar_type() == torch::headeronly::ScalarType::Int,
           "moe_sum: expert_map must be int32");
       expert_map_ptr =
           reinterpret_cast<const int32_t*>(expert_map->const_data_ptr());
+      num_experts = static_cast<int32_t>(expert_map->numel());
     }
 
 #define LAUNCH_MOE_SUM_PAD_AWARE_VEC(TOPK)                                     \
   vllm::moe::moe_sum_vec_kernel<scalar_t, idx_t, TOPK, true>                   \
       <<<grid, dim3(block), 0, stream>>>(                                      \
           out_ptr, in_ptr, num_tokens, hidden_size, stride_token, stride_topk, \
-          topk_ids_ptr, expert_map_ptr, stride_tk_token, stride_tk_k)
+          topk_ids_ptr, expert_map_ptr, stride_tk_token, stride_tk_k,          \
+          num_experts)
 
     VLLM_STABLE_DISPATCH_FLOATING_TYPES(
         input.scalar_type(), "moe_sum_pad_aware", [&] {
@@ -849,7 +865,8 @@ void moe_sum(torch::stable::Tensor& input,   // [num_tokens, topk, hidden_size]
                           <<<grid, dim3(block), 0, stream>>>(
                               out_ptr, in_ptr, num_tokens, hidden_size, topk,
                               stride_token, stride_topk, topk_ids_ptr,
-                              expert_map_ptr, stride_tk_token, stride_tk_k);
+                              expert_map_ptr, stride_tk_token, stride_tk_k,
+                              num_experts);
                       break;
                   }
                 } else {
@@ -859,7 +876,8 @@ void moe_sum(torch::stable::Tensor& input,   // [num_tokens, topk, hidden_size]
                       <<<grid, block, 0, stream>>>(
                           out_ptr, in_ptr, hidden_size, topk, stride_token,
                           stride_topk, stride_hidden, topk_ids_ptr,
-                          expert_map_ptr, stride_tk_token, stride_tk_k);
+                          expert_map_ptr, stride_tk_token, stride_tk_k,
+                          num_experts);
                 }
               });
         });
@@ -867,11 +885,11 @@ void moe_sum(torch::stable::Tensor& input,   // [num_tokens, topk, hidden_size]
     return;
   }
 
-#define LAUNCH_MOE_SUM_VEC(TOPK)                                      \
-  vllm::moe::moe_sum_vec_kernel<scalar_t, int32_t, TOPK, false>       \
-      <<<grid, dim3(block), 0, stream>>>(out_ptr, in_ptr, num_tokens, \
-                                         hidden_size, stride_token,   \
-                                         stride_topk, nullptr, nullptr, 0, 0)
+#define LAUNCH_MOE_SUM_VEC(TOPK)                                               \
+  vllm::moe::moe_sum_vec_kernel<scalar_t, int32_t, TOPK, false>                \
+      <<<grid, dim3(block), 0, stream>>>(                                      \
+          out_ptr, in_ptr, num_tokens, hidden_size, stride_token, stride_topk, \
+          nullptr, nullptr, 0, 0, 0)
 
   VLLM_STABLE_DISPATCH_FLOATING_TYPES(input.scalar_type(), "moe_sum", [&] {
     constexpr int VEC = vllm::moe::MOE_SUM_VEC<scalar_t>;
@@ -914,7 +932,7 @@ void moe_sum(torch::stable::Tensor& input,   // [num_tokens, topk, hidden_size]
           vllm::moe::moe_sum_vec_dynamic_kernel<scalar_t, int32_t, false>
               <<<grid, dim3(block), 0, stream>>>(
                   out_ptr, in_ptr, num_tokens, hidden_size, topk, stride_token,
-                  stride_topk, nullptr, nullptr, 0, 0);
+                  stride_topk, nullptr, nullptr, 0, 0, 0);
           break;
       }
     } else {
@@ -923,7 +941,7 @@ void moe_sum(torch::stable::Tensor& input,   // [num_tokens, topk, hidden_size]
       vllm::moe::moe_sum_scalar_kernel<scalar_t, int32_t, false>
           <<<grid, block, 0, stream>>>(out_ptr, in_ptr, hidden_size, topk,
                                        stride_token, stride_topk, stride_hidden,
-                                       nullptr, nullptr, 0, 0);
+                                       nullptr, nullptr, 0, 0, 0);
     }
   });
 #undef LAUNCH_MOE_SUM_VEC

--- a/tests/kernels/core/test_activation.py
+++ b/tests/kernels/core/test_activation.py
@@ -197,6 +197,39 @@ def test_silu_and_mul_with_clamp(
     opcheck(torch.ops._C.silu_and_mul_with_clamp, (out_buf, x, swiglu_limit))
 
 
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@torch.inference_mode()
+def test_swiglu_limit_pad_aware_bounds_expert_map_gather(dtype: torch.dtype):
+    """Out-of-range topk_ids must not index expert_map.
+
+    topk_ids is data, not a loop bound: routers allocate it with torch.empty
+    and do not always overwrite every slot, so a stale slot can hold an
+    arbitrary positive value. Masking the gather on `expert_id >= 0` alone
+    read past the end of expert_map -- a fault that takes down every rank.
+    """
+    from vllm.model_executor.layers.fused_moe.utils import swiglu_limit_func
+
+    d, rows = 64, 6
+    x = torch.randn((rows, 2 * d), device="cuda", dtype=dtype)
+    out = torch.zeros((rows, d), device="cuda", dtype=dtype)
+
+    topk_ids = torch.zeros(rows, device="cuda", dtype=torch.int32)
+    topk_ids[1] = 0x3F988A43
+    topk_ids[2] = 1 << 30
+    topk_ids[3] = -1
+
+    expert_map = torch.tensor([0, -1, 1, -1], device="cuda", dtype=torch.int32)
+
+    swiglu_limit_func(out, x, 0.0, topk_ids, expert_map)
+
+    computed = out.abs().sum(dim=-1) > 0
+    # Only rows whose id is in range and maps to a local expert may compute.
+    assert bool(computed[0])
+    assert not bool(computed[1]), "float-bit-pattern id must not compute"
+    assert not bool(computed[2]), "far out-of-range id must not compute"
+    assert not bool(computed[3]), "-1 id must not compute"
+
+
 @pytest.mark.parametrize("linear_beta", [-1.0, 2.0])
 @pytest.mark.parametrize("dtype", [torch.half, torch.bfloat16])
 @torch.inference_mode()

--- a/tests/kernels/moe/test_count_expert_num_tokens.py
+++ b/tests/kernels/moe/test_count_expert_num_tokens.py
@@ -141,3 +141,61 @@ def test_compute_expert_num_tokens_from_numel(
         ep_size=ep_size,
         topk_ids_dtype=topk_ids_dtype,
     )
+
+
+@pytest.mark.parametrize("topk_ids_dtype", [torch.int32, torch.int64])
+def test_count_expert_num_tokens_bounds_expert_map_gather(
+    topk_ids_dtype: torch.dtype,
+):
+    """Out-of-range topk_ids must not index expert_map.
+
+    topk_ids is data, not a loop bound: routers allocate it with torch.empty
+    and do not always overwrite every slot, so a stale slot can hold an
+    arbitrary positive value. Masking the expert_map gather on `>= 0` alone
+    read past the end of the map and faulted the context.
+    """
+    num_experts, num_local = 32, 16
+    expert_map = torch.full((num_experts,), -1, dtype=torch.int32, device="cuda")
+    expert_map[:num_local] = torch.arange(num_local, dtype=torch.int32, device="cuda")
+
+    topk_ids = torch.randint(0, num_local, (16, 2), dtype=topk_ids_dtype, device="cuda")
+    topk_ids[0, 0] = 0x3F988A43
+    topk_ids[1, 1] = 1 << 30
+
+    actual = count_expert_num_tokens(topk_ids, num_local, expert_map)
+
+    in_range = (topk_ids >= 0) & (topk_ids < num_experts)
+    local = expert_map[topk_ids.clamp(0, num_experts - 1).long()]
+    valid = in_range & (local >= 0)
+    expected = torch.zeros(num_local, dtype=actual.dtype, device="cuda")
+    for e in range(num_local):
+        expected[e] = ((local == e) & valid).sum()
+
+    torch.testing.assert_close(actual, expected)
+
+
+@pytest.mark.parametrize("topk_ids_dtype", [torch.int32, torch.int64])
+def test_count_expert_num_tokens_bound_is_global_expert_count(
+    topk_ids_dtype: torch.dtype,
+):
+    """The gather bound must be expert_map's length, not the local count.
+
+    On a non-zero EP shard every routed global id is >= num_local_experts, so
+    bounding against the local count would drop all of them.
+    """
+    num_experts, num_local = 32, 16
+    expert_map = torch.full((num_experts,), -1, dtype=torch.int32, device="cuda")
+    expert_map[num_local:] = torch.arange(num_local, dtype=torch.int32, device="cuda")
+
+    topk_ids = torch.randint(
+        num_local, num_experts, (16, 2), dtype=topk_ids_dtype, device="cuda"
+    )
+
+    actual = count_expert_num_tokens(topk_ids, num_local, expert_map)
+
+    local = expert_map[topk_ids.long()]
+    expected = torch.zeros(num_local, dtype=actual.dtype, device="cuda")
+    for e in range(num_local):
+        expected[e] = ((local == e) & (local >= 0)).sum()
+
+    torch.testing.assert_close(actual, expected)

--- a/tests/kernels/moe/test_moe.py
+++ b/tests/kernels/moe/test_moe.py
@@ -1482,6 +1482,41 @@ def test_moe_sum_pad_aware(topk: int, dtype: torch.dtype, topk_ids_dtype: torch.
     opcheck(torch.ops._moe_C.moe_sum, (input, actual, topk_ids, expert_map))
 
 
+@pytest.mark.parametrize("topk_ids_dtype", [torch.int32, torch.int64])
+def test_moe_sum_pad_aware_bounds_expert_map_gather(topk_ids_dtype: torch.dtype):
+    """Out-of-range expert ids must be skipped, not gathered from expert_map.
+
+    topk_ids is data, not a loop bound: the routers allocate it with
+    torch.empty and do not always overwrite every slot, so a stale slot can
+    hold an arbitrary positive value (in practice the bit pattern of whatever
+    float tensor previously owned the allocation). Guarding the expert_map
+    lookup with `expert_id < 0` alone made that an illegal access that takes
+    down every rank.
+    """
+    m, topk, k = 8, 4, 128
+    dtype = torch.bfloat16
+    input = torch.randn((m, topk, k), device="cuda", dtype=dtype)
+
+    topk_ids = torch.randint(0, 4, (m, topk), device="cuda", dtype=topk_ids_dtype)
+    # 0x3F988A43 is a float bit pattern observed in an unwritten slot in the
+    # wild; 1 << 30 is a generic far-out-of-range id.
+    topk_ids[0, 0] = 0x3F988A43
+    topk_ids[1, 1] = 1 << 30
+    topk_ids[2, 2] = -1
+
+    expert_map = torch.tensor([0, -1, 1, -1], device="cuda", dtype=torch.int32)
+
+    actual = torch.empty((m, k), device="cuda", dtype=dtype)
+    torch.ops._moe_C.moe_sum(input, actual, topk_ids, expert_map)
+
+    n_experts = expert_map.numel()
+    in_range = (topk_ids >= 0) & (topk_ids < n_experts)
+    routed = in_range & (expert_map[topk_ids.clamp(0, n_experts - 1).long()] >= 0)
+    expected = (input.float() * routed.unsqueeze(-1)).sum(dim=1).to(dtype)
+
+    torch.testing.assert_close(actual, expected, atol=2e-2, rtol=0)
+
+
 def _batched_fused_marlin_moe_cases() -> list[Any]:
     cases = [
         pytest.param(

--- a/vllm/model_executor/layers/fused_moe/moe_fused_mul_sum.py
+++ b/vllm/model_executor/layers/fused_moe/moe_fused_mul_sum.py
@@ -14,6 +14,7 @@ def moe_fused_mul_sum_kernel(
     outputs_ptr,
     top_ids_ptr,
     expert_map_ptr,
+    num_experts,
     num_tokens,
     stride_m,
     has_expert_map: tl.constexpr,
@@ -41,7 +42,18 @@ def moe_fused_mul_sum_kernel(
         b_val = tl.load(b_base + n, mask=m_mask, other=0.0).to(tl.float32)
         if has_expert_map:
             id_val = tl.load(top_ids_ptr + offs_m * top_k + n, mask=m_mask, other=0)
-            expert_mask = tl.load(expert_map_ptr + id_val) >= 0
+            # id_val is data from topk_ids and can be stale/out-of-range on rows
+            # the router did not overwrite; bound it before indexing expert_map
+            # (an unbounded gather here faults the whole context).
+            id_in_range = (id_val >= 0) & (id_val < num_experts)
+            expert_mask = (
+                tl.load(
+                    expert_map_ptr + tl.where(id_in_range, id_val, 0),
+                    mask=id_in_range,
+                    other=-1,
+                )
+                >= 0
+            )
             a_vec = tl.load(
                 a_base + n * size,
                 mask=mask & expert_mask[:, None],
@@ -188,6 +200,7 @@ def moe_fused_mul_sum(
             outputs,
             topk_ids,
             expert_map,
+            expert_map.numel() if expert_map is not None else 0,
             num_tokens,
             top_k * size,
             expert_map is not None,

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -49,6 +49,7 @@ def _count_expert_num_tokens(
     topk_ids_ptr,
     expert_num_tokens_ptr,
     num_experts,
+    num_global_experts,
     topk_numel,
     expert_map,
     HAS_EXPERT_MAP: tl.constexpr,
@@ -64,8 +65,13 @@ def _count_expert_num_tokens(
         mask = offsets < (topk_numel - x * BLOCK_SIZE)
         expert_ids = tl.load(topk_ids_ptrs, mask=mask, other=-1)
         if HAS_EXPERT_MAP:
+            # Bound the gather: expert_ids come from topk_ids, which is data and
+            # can hold stale out-of-range values on rows the router did not
+            # overwrite. Masking on `>= 0` alone reads past expert_map. Note the
+            # bound is the GLOBAL expert count (expert_map's length), not
+            # num_experts, which is this rank's local expert count.
             expert_map_ptrs = expert_map + expert_ids
-            expert_map_mask = expert_ids >= 0
+            expert_map_mask = (expert_ids >= 0) & (expert_ids < num_global_experts)
             expert_ids = tl.load(expert_map_ptrs, mask=expert_map_mask, other=-1)
 
         has_curr_expert = tl.where(expert_ids == curr_expert, 1, 0)
@@ -107,6 +113,7 @@ def count_expert_num_tokens(
         topk_ids,
         expert_num_tokens,
         num_local_experts,
+        expert_map.numel() if expert_map is not None else 0,
         topk_ids.numel(),
         expert_map,
         HAS_EXPERT_MAP=expert_map is not None,
@@ -490,6 +497,7 @@ def _swiglu_limit_pad_aware_kernel(
     input_row_stride,
     num_tokens,
     swiglu_limit,
+    num_experts,
     HAS_LIMIT: tl.constexpr,
     HAS_EXPERT_MAP: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
@@ -505,12 +513,23 @@ def _swiglu_limit_pad_aware_kernel(
         expert_id = tl.load(topk_ids_ptr + row)
         should_compute = expert_id != -1
         if HAS_EXPERT_MAP:
+            # expert_id is data, not a loop bound: it is read from topk_ids,
+            # which the routers allocate with torch.empty and, on the padded
+            # rows of a CUDA-graph batch, do not always overwrite. Such a slot
+            # can hold an arbitrary positive value (in practice the bit pattern
+            # of whatever float tensor previously owned the allocation), so
+            # masking on `expert_id >= 0` alone let it gather past the end of
+            # expert_map -- a Warp MMU fault that takes down every TP rank.
+            # Bound the row offset as well; out-of-range ids fall out as
+            # not-computed, so a producer bug degrades one token slot instead
+            # of killing the engine.
+            in_range = (expert_id >= 0) & (expert_id < num_experts)
             local_expert_id = tl.load(
                 expert_map_ptr + expert_id,
-                mask=expert_id >= 0,
+                mask=in_range,
                 other=-1,
             )
-            should_compute = should_compute & (local_expert_id != -1)
+            should_compute = should_compute & in_range & (local_expert_id != -1)
 
         if should_compute:
             gate_offsets = row.to(tl.int64) * input_row_stride + column_tile
@@ -559,6 +578,7 @@ def _swiglu_limit_pad_aware(
         gate_up_size,
         num_tokens,
         swiglu_limit,
+        expert_map.numel() if expert_map is not None else 0,
         HAS_LIMIT=swiglu_limit > 0,
         HAS_EXPERT_MAP=expert_map is not None,
         BLOCK_SIZE=BLOCK_SIZE,


### PR DESCRIPTION
## Summary

Four MoE kernels index `expert_map` with an expert id taken from `topk_ids`,
guarding the gather with a sign check only (`expert_id >= 0` / `expert_id < 0`).
`topk_ids` is data, not a loop bound: the routers allocate it with
`torch.empty` and do not always overwrite every slot, so a stale slot can hold
an arbitrary positive value. When that happens the gather reads far past the
end of `expert_map` and the context dies with a Warp MMU fault on **every** rank.

`get_local_expert_id()` in `csrc/libtorch_stable/moe/moe_align_sum_kernels.cu`
already applies exactly the missing bound:

```cpp
int expert_id = topk_ids[idx];
if (expert_id >= num_experts || expert_id < 0) {
  return -1;
}
```

This PR makes the other four consumers consistent with it. Out-of-range ids
fall out as not-routed, so a producer bug degrades one token slot instead of
killing the engine.

## Relationship to the root cause

These gathers were the *victims*, not the cause. The garbage expert ids
originated upstream: the sampler could emit a token id equal to `vocab_size`,
and DeepSeek-V4's hash-MoE router turned that into a garbage expert id by
gathering past its lookup table. Both are fixed separately in #50843 (sampler) and #50844 (DSv4 hash router). This PR is the
defence-in-depth layer — it keeps a producer bug anywhere upstream from
escalating into an engine kill, and it fixes one gather that was unguarded
outright.

## Evidence

Hit in production on DeepSeek-V4-Flash (TP2 + `--enable-expert-parallel`,
so `expert_map` is non-null), reproducible under bursty concurrency in
90 s – 5 min. CUDA core dump, both TP ranks:

```
CUDA Exception: Warp MMU Fault
errorpc  _swiglu_limit_pad_aware_kernel
         vllm/model_executor/layers/fused_moe/utils.py:545
```

SASS at `errorpc` is the `expert_map` gather, and the index register holds the
bad id:

```
IMAD.SHL.U32 R6,R4,0x4,RZ     ; expert_id * 4
IADD.64      R6,R6,R8         ; expert_map_ptr + expert_id*4
@!P0 BRA ...                  ; skip if !(expert_id >= 0)
*> LDG.E R8,desc[UR10][R6.64] ; <-- FAULT

R4 = 0x66E65F78 = 1726373752
R4 = 0x3F988A43 = 1066961475   (as float32: 1.1917)
```

The model has 256 experts. Both observed ids are float bit patterns — the
allocation's previous tenant — which is what an unwritten `torch.empty` slot
looks like.

Bounding only the Triton kernel moved the fault to `moe_sum_vec_kernel`
(`moe_sum_pad_aware_skip`, same unguarded pattern), which is why all four
sites are fixed together.

Note `moe_fused_mul_sum_kernel`'s gather was not merely missing an upper
bound — it was entirely unmasked, with no sign check either, so it would also
fault on the ordinary `-1` unrouted sentinel on any model taking that path.

## Changes

- `csrc/libtorch_stable/moe/moe_align_sum_kernels.cu` — `moe_sum_pad_aware_skip()`
  bounds `expert_id` against `num_experts`, threaded through the vec / dynamic /
  scalar `moe_sum` kernels from `expert_map->numel()`.
- `vllm/model_executor/layers/fused_moe/utils.py` — `_swiglu_limit_pad_aware_kernel()`
  and `_count_expert_num_tokens()` bound the gather.
- `vllm/model_executor/layers/fused_moe/moe_fused_mul_sum.py` —
  `moe_fused_mul_sum_kernel()` bounds the gather (it was previously entirely
  unmasked).

No legitimate id is rejected: valid ids live in `[0, expert_map.numel())` by
construction, which is the new bound.

`gpt_oss_triton_kernels_moe.py` already clamps its gather and is unchanged.

## Test

Three regression tests, each feeding the observed `0x3F988A43` bit pattern and a
generic far-out-of-range id through the guarded path:

- `tests/kernels/moe/test_moe.py::test_moe_sum_pad_aware_bounds_expert_map_gather`
- `tests/kernels/core/test_activation.py::test_swiglu_limit_pad_aware_bounds_expert_map_gather`
- `tests/kernels/moe/test_count_expert_num_tokens.py::test_count_expert_num_tokens_bounds_expert_map_gather`

Without the fix these fault the CUDA context; with it they assert the
out-of-range slots are skipped and the in-range results are unchanged.
