### PR TITLE
[ROCm] Return Kimi-K3 MLA output directly

### DIFF
--- a/tests/models/kimi_k3/test_amd_mla_direct_return.py
+++ b/tests/models/kimi_k3/test_amd_mla_direct_return.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+from torch import nn
+
+from vllm.models.kimi_k3.amd.linear import KimiDecoderLayer, KimiMLAAttention
+
+
+class _DirectMLA(KimiMLAAttention):
+    def __init__(self, result: torch.Tensor):
+        nn.Module.__init__(self)
+        self.result = result
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        return self.result
+
+
+class _BufferedAttention(nn.Module):
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        output: torch.Tensor,
+    ) -> None:
+        output.copy_(hidden_states + positions[:, None])
+
+
+def _make_layer(self_attn: nn.Module) -> KimiDecoderLayer:
+    layer = KimiDecoderLayer.__new__(KimiDecoderLayer)
+    nn.Module.__init__(layer)
+    layer.self_attn = self_attn
+    return layer
+
+
+def test_mla_returns_projection_output_without_copy():
+    hidden_states = torch.randn(4, 8)
+    positions = torch.arange(4)
+    projected = torch.randn_like(hidden_states)
+    layer = _make_layer(_DirectMLA(projected))
+
+    output = layer._run_self_attn(positions, hidden_states)
+
+    assert output is projected
+
+
+def test_kda_keeps_caller_owned_output():
+    hidden_states = torch.randn(4, 8)
+    positions = torch.arange(4)
+    layer = _make_layer(_BufferedAttention())
+
+    output = layer._run_self_attn(positions, hidden_states)
+
+    torch.testing.assert_close(output, hidden_states + positions[:, None])

--- a/vllm/models/kimi_k3/amd/linear.py
+++ b/vllm/models/kimi_k3/amd/linear.py
@@ -449,9 +449,8 @@ class KimiMLAAttention(nn.Module):
         self,
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
-        output: torch.Tensor,
-    ) -> None:
-        output[:] = self.mla_attn(positions, hidden_states)
+    ) -> torch.Tensor:
+        return self.mla_attn(positions, hidden_states)
 
 
 class KimiDecoderLayer(nn.Module):
@@ -564,6 +563,12 @@ class KimiDecoderLayer(nn.Module):
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
+        if isinstance(self.self_attn, KimiMLAAttention):
+            return self.self_attn(
+                hidden_states=hidden_states,
+                positions=positions,
+            )
+
         attn_output = torch.empty_like(hidden_states)
         self.self_attn(
             hidden_states=hidden_states,


### PR DESCRIPTION
## Summary

- Return the AMD Kimi-K3 MLA projection result directly instead of allocating a second hidden-state tensor and copying into it.
- Preserve the caller-owned output buffer used by KDA layers.
- Add ownership-focused coverage for both dispatch paths.

Kimi-K3 has 24 MLA layers. For BF16 hidden states of width 7168, this removes 24 copies of `num_tokens * 7168 * 2` bytes per model forward. The returned values are unchanged; only tensor ownership changes.

This is intentionally separate from #50664, which owns output-gate fusion and explicitly leaves output-buffer ownership out of scope.

## Test plan

- [x] Fixed-image unit test: `2 passed` in `rocm/vllm-dev:gfx950_kimi_k3_20260727`.
- [x] Fixed image plus ROCm/aiter#4450 overlay: Kimi-K3 TP8 server boot and short serving smoke passed.
- [x] GSM8K subset: baseline `100/100`, candidate `100/100`; zero invalid responses in both arms.
- [x] Short random serving A/B, ISL 8192 / OSL 512 / concurrency 4 / 8 requests: all requests succeeded.
- [x] `git diff --check` and IDE diagnostics passed.

The one-shot serving measurement was neutral within noise: median TPOT was 25.53 ms baseline and 25.75 ms candidate. This PR therefore does not claim a measured end-to-end speedup from that short run; its deterministic effect is removal of the redundant MLA output allocation/copy.

## Tool assistance

Cursor assisted with implementation, tests, benchmarking, and drafting this description.

Made with [Cursor](https://cursor.com)