### PR TITLE
[Bugfix] Fix CUDA graph profiling for long GDN warmups

### DIFF
--- a/tests/kernels/mamba/test_gdn_profile_warmup.py
+++ b/tests/kernels/mamba/test_gdn_profile_warmup.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU-only checks for the GDN profile warmup input sizing."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from vllm.model_executor.layers.mamba.gdn import qwen_gdn_linear_attn
+from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
+    QwenGatedDeltaNetAttention,
+)
+
+
+def test_profile_warmup_reuses_projected_tokens():
+    num_tokens = 7
+    num_k_heads = 2
+    num_v_heads = 3
+    head_k_dim = 4
+    head_v_dim = 5
+    qkv_dim = 2 * num_k_heads * head_k_dim + num_v_heads * head_v_dim
+    z_dim = num_v_heads * head_v_dim
+    projected = torch.empty(num_tokens, qkv_dim + z_dim, dtype=torch.bfloat16)
+    prep_calls = []
+    chunk_calls = []
+
+    layer = SimpleNamespace(
+        _prefill_kernels_warmed_up=False,
+        num_k_heads=num_k_heads,
+        num_v_heads=num_v_heads,
+        head_k_dim=head_k_dim,
+        head_v_dim=head_v_dim,
+        tp_size=1,
+        A_log=torch.zeros(num_v_heads),
+        dt_bias=torch.zeros(num_v_heads),
+        prefix="test.gdn",
+        gdn_prefill_backend="triton",
+        get_state_dtype=lambda: (None, torch.float32),
+    )
+
+    def fake_prep(**kwargs):
+        prep_calls.append(kwargs)
+        assert kwargs["conv_output"].data_ptr() == projected.data_ptr()
+        assert kwargs["conv_output"].shape == (num_tokens, qkv_dim)
+        return (
+            torch.empty(num_tokens, num_k_heads, head_k_dim),
+            torch.empty(num_tokens, num_k_heads, head_k_dim),
+            torch.empty(num_tokens, num_v_heads, head_v_dim),
+            torch.empty(num_tokens, num_v_heads),
+            torch.empty(num_tokens, num_v_heads),
+        )
+
+    def fake_chunk(**kwargs):
+        chunk_calls.append(kwargs)
+        return kwargs["q"], kwargs["initial_state"]
+
+    layer.chunk_gated_delta_rule = fake_chunk
+    with patch.object(
+        qwen_gdn_linear_attn, "fused_post_conv_prep", side_effect=fake_prep
+    ):
+        QwenGatedDeltaNetAttention._warmup_prefill_kernels(
+            layer,  # type: ignore[arg-type]
+            projected,
+            z_dim,
+        )
+
+    assert len(prep_calls) == 1
+    assert len(chunk_calls) == 1
+    assert chunk_calls[0]["q"].shape[1] == num_tokens
+    assert chunk_calls[0]["cu_seqlens"].tolist() == [0, num_tokens]

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from contextlib import contextmanager, nullcontext
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import numpy as np
 import pytest
@@ -18,6 +19,7 @@ from vllm.config import (
     VllmConfig,
     set_current_vllm_config,
 )
+from vllm.config.compilation import CUDAGraphMode
 from vllm.config.reasoning import ReasoningConfig
 from vllm.distributed.parallel_state import (
     init_distributed_environment,
@@ -1753,3 +1755,144 @@ class TestInitFp8KvScalesHybridModels:
         assert (t1 == 0).all()
         assert (t2 == 0).all()
         assert all((t == 0).all() for t in list_entry)
+
+
+def test_profile_cudagraph_memory_flushes_before_retained_measurements():
+    """Graph estimates use post-flush pool residency, not warmup transients."""
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.cudagraph_dispatcher = SimpleNamespace(
+        get_capture_descs=lambda: [
+            (
+                CUDAGraphMode.FULL,
+                [SimpleNamespace(num_tokens=8, uniform=True, num_active_loras=0)] * 2,
+            )
+        ],
+        cudagraph_keys={},
+        keys_initialized=True,
+    )
+    runner.vllm_config = SimpleNamespace()
+    runner.compilation_config = SimpleNamespace(cudagraph_num_of_warmups=1)
+    runner.device = "cpu"
+    runner.max_model_len = 128
+    runner.max_num_tokens = 32
+    runner.lora_config = None
+    events: list[str] = []
+    runner._dummy_run = Mock(
+        side_effect=lambda *_args, **_kwargs: events.append("warmup")
+    )
+    encoder = Mock(token_budgets=[8])
+    encoder.get_num_graphs_to_capture.return_value = 1
+    free_memory = iter(enumerate((1000, 900, 900, 850, 850, 800)))
+
+    accelerator = Mock()
+    accelerator.synchronize.side_effect = lambda: events.append("sync")
+    accelerator.empty_cache.side_effect = lambda: events.append("flush")
+
+    def get_memory_info():
+        index, free = next(free_memory)
+        events.append(f"info:{index}")
+        return free, 2000
+
+    @contextmanager
+    def fake_graph_capture(**_kwargs):
+        events.append("enter")
+        yield
+        events.append("exit")
+
+    accelerator.get_memory_info.side_effect = get_memory_info
+    fake_platform = SimpleNamespace(
+        graph_pool_handle=lambda: object(),
+        is_rocm=lambda: False,
+    )
+
+    with (
+        patch.object(
+            GPUModelRunner,
+            "_init_minimal_kv_cache_for_profiling",
+            Mock(),
+        ),
+        patch.object(
+            GPUModelRunner,
+            "_create_encoder_cudagraph_manager",
+            Mock(return_value=encoder),
+        ),
+        patch.object(GPUModelRunner, "_freeze_gc", return_value=nullcontext()),
+        patch.object(GPUModelRunner, "_warmup_and_capture", Mock()),
+        patch.object(GPUModelRunner, "_cleanup_profiling_kv_cache", Mock()),
+        patch.object(GPUModelRunner, "maybe_remove_all_loras", Mock()),
+        patch.object(gpu_model_runner_module, "graph_capture", fake_graph_capture),
+        patch.object(gpu_model_runner_module, "current_platform", fake_platform),
+        patch.object(gpu_model_runner_module, "set_cudagraph_capturing_enabled"),
+        patch.object(gpu_model_runner_module, "CUDAGraphWrapper") as decoder_wrapper,
+        patch.object(
+            gpu_model_runner_module, "BreakableCUDAGraphWrapper"
+        ) as breakable_wrapper,
+        patch.object(gpu_model_runner_module.torch, "accelerator", accelerator),
+    ):
+        decoder_wrapper._all_instances = []
+        breakable_wrapper._all_instances = []
+        decoder_wrapper.clear_all_graphs = Mock()
+        breakable_wrapper.clear_all_graphs = Mock()
+        total = GPUModelRunner.profile_cudagraph_memory(runner)
+
+    assert total > 0
+    assert "warmup" in events[: events.index("info:0")]
+    assert events[events.index("info:0") - 3 : events.index("info:0")] == [
+        "exit",
+        "sync",
+        "flush",
+    ]
+    for index in (1, 3, 5):
+        position = events.index(f"info:{index}")
+        assert events[position - 3 : position] == ["exit", "sync", "flush"]
+
+
+def test_capture_model_measures_runtime_pool_after_flush():
+    """The runtime graph size excludes allocator blocks released after capture."""
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.compilation_config = SimpleNamespace(cudagraph_mode=CUDAGraphMode.FULL)
+    runner.model_config = SimpleNamespace(enforce_eager=False)
+    runner.vllm_config = SimpleNamespace(
+        profiler_config=SimpleNamespace(capture_torch_profiler=False)
+    )
+    runner.device = "cpu"
+    runner.encoder_cudagraph_manager = None
+    runner.cudagraph_dispatcher = SimpleNamespace(
+        get_capture_descs=lambda: [],
+    )
+    events: list[str] = []
+    free_memory = iter((1000, 800))
+    accelerator = Mock()
+    accelerator.synchronize.side_effect = lambda: events.append("sync")
+    accelerator.empty_cache.side_effect = lambda: events.append("flush")
+
+    def get_runtime_memory_info():
+        events.append("info")
+        return next(free_memory), 2000
+
+    accelerator.get_memory_info.side_effect = get_runtime_memory_info
+
+    @contextmanager
+    def fake_graph_capture(**_kwargs):
+        events.append("enter")
+        yield
+        events.append("exit")
+
+    with (
+        patch.object(GPUModelRunner, "_maybe_init_encoder_cudagraph_manager"),
+        patch.object(GPUModelRunner, "_freeze_gc", return_value=nullcontext()),
+        patch.object(GPUModelRunner, "_capture_cudagraphs", Mock()),
+        patch.object(gpu_model_runner_module, "graph_capture", fake_graph_capture),
+        patch.object(gpu_model_runner_module, "set_cudagraph_capturing_enabled"),
+        patch.object(gpu_model_runner_module, "lock_workspace"),
+        patch(
+            "vllm.distributed.parallel_state.get_world_group",
+            return_value=SimpleNamespace(local_rank=1),
+        ),
+        patch.object(gpu_model_runner_module.torch, "accelerator", accelerator),
+    ):
+        size = GPUModelRunner.capture_model(runner)
+
+    assert size == 200
+    assert events[-3:] == ["sync", "flush", "info"]
+    assert events.index("exit") < len(events) - 3

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -2,9 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import gc
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import numpy as np
 import pytest
@@ -20,6 +20,7 @@ from vllm.config import (
     VllmConfig,
     set_current_vllm_config,
 )
+from vllm.config.compilation import CUDAGraphMode
 from vllm.config.reasoning import ReasoningConfig
 from vllm.distributed.parallel_state import (
     init_distributed_environment,
@@ -1823,3 +1824,144 @@ def test_mamba_cache_raises_when_max_num_seqs_exceeds_blocks():
 
         with pytest.raises(ValueError, match="max_num_seqs"):
             runner.initialize_kv_cache(kv_cache_config)
+
+
+def test_profile_cudagraph_memory_flushes_before_retained_measurements():
+    """Graph estimates use post-flush pool residency, not warmup transients."""
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.cudagraph_dispatcher = SimpleNamespace(
+        get_capture_descs=lambda: [
+            (
+                CUDAGraphMode.FULL,
+                [SimpleNamespace(num_tokens=8, uniform=True, num_active_loras=0)] * 2,
+            )
+        ],
+        cudagraph_keys={},
+        keys_initialized=True,
+    )
+    runner.vllm_config = SimpleNamespace()
+    runner.compilation_config = SimpleNamespace(cudagraph_num_of_warmups=1)
+    runner.device = "cpu"
+    runner.max_model_len = 128
+    runner.max_num_tokens = 32
+    runner.lora_config = None
+    events: list[str] = []
+    runner._dummy_run = Mock(
+        side_effect=lambda *_args, **_kwargs: events.append("warmup")
+    )
+    encoder = Mock(token_budgets=[8])
+    encoder.get_num_graphs_to_capture.return_value = 1
+    free_memory = iter(enumerate((1000, 900, 900, 850, 850, 800)))
+
+    accelerator = Mock()
+    accelerator.synchronize.side_effect = lambda: events.append("sync")
+    accelerator.empty_cache.side_effect = lambda: events.append("flush")
+
+    def get_memory_info():
+        index, free = next(free_memory)
+        events.append(f"info:{index}")
+        return free, 2000
+
+    @contextmanager
+    def fake_graph_capture(**_kwargs):
+        events.append("enter")
+        yield
+        events.append("exit")
+
+    accelerator.get_memory_info.side_effect = get_memory_info
+    fake_platform = SimpleNamespace(
+        graph_pool_handle=lambda: object(),
+        is_rocm=lambda: False,
+    )
+
+    with (
+        patch.object(
+            GPUModelRunner,
+            "_init_minimal_kv_cache_for_profiling",
+            Mock(),
+        ),
+        patch.object(
+            GPUModelRunner,
+            "_create_encoder_cudagraph_manager",
+            Mock(return_value=encoder),
+        ),
+        patch.object(GPUModelRunner, "_freeze_gc", return_value=nullcontext()),
+        patch.object(GPUModelRunner, "_warmup_and_capture", Mock()),
+        patch.object(GPUModelRunner, "_cleanup_profiling_kv_cache", Mock()),
+        patch.object(GPUModelRunner, "maybe_remove_all_loras", Mock()),
+        patch.object(gpu_model_runner_module, "graph_capture", fake_graph_capture),
+        patch.object(gpu_model_runner_module, "current_platform", fake_platform),
+        patch.object(gpu_model_runner_module, "set_cudagraph_capturing_enabled"),
+        patch.object(gpu_model_runner_module, "CUDAGraphWrapper") as decoder_wrapper,
+        patch.object(
+            gpu_model_runner_module, "BreakableCUDAGraphWrapper"
+        ) as breakable_wrapper,
+        patch.object(gpu_model_runner_module.torch, "accelerator", accelerator),
+    ):
+        decoder_wrapper._all_instances = []
+        breakable_wrapper._all_instances = []
+        decoder_wrapper.clear_all_graphs = Mock()
+        breakable_wrapper.clear_all_graphs = Mock()
+        total = GPUModelRunner.profile_cudagraph_memory(runner)
+
+    assert total > 0
+    assert "warmup" in events[: events.index("info:0")]
+    assert events[events.index("info:0") - 3 : events.index("info:0")] == [
+        "exit",
+        "sync",
+        "flush",
+    ]
+    for index in (1, 3, 5):
+        position = events.index(f"info:{index}")
+        assert events[position - 3 : position] == ["exit", "sync", "flush"]
+
+
+def test_capture_model_measures_runtime_pool_after_flush():
+    """The runtime graph size excludes allocator blocks released after capture."""
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.compilation_config = SimpleNamespace(cudagraph_mode=CUDAGraphMode.FULL)
+    runner.model_config = SimpleNamespace(enforce_eager=False)
+    runner.vllm_config = SimpleNamespace(
+        profiler_config=SimpleNamespace(capture_torch_profiler=False)
+    )
+    runner.device = "cpu"
+    runner.encoder_cudagraph_manager = None
+    runner.cudagraph_dispatcher = SimpleNamespace(
+        get_capture_descs=lambda: [],
+    )
+    events: list[str] = []
+    free_memory = iter((1000, 800))
+    accelerator = Mock()
+    accelerator.synchronize.side_effect = lambda: events.append("sync")
+    accelerator.empty_cache.side_effect = lambda: events.append("flush")
+
+    def get_runtime_memory_info():
+        events.append("info")
+        return next(free_memory), 2000
+
+    accelerator.get_memory_info.side_effect = get_runtime_memory_info
+
+    @contextmanager
+    def fake_graph_capture(**_kwargs):
+        events.append("enter")
+        yield
+        events.append("exit")
+
+    with (
+        patch.object(GPUModelRunner, "_maybe_init_encoder_cudagraph_manager"),
+        patch.object(GPUModelRunner, "_freeze_gc", return_value=nullcontext()),
+        patch.object(GPUModelRunner, "_capture_cudagraphs", Mock()),
+        patch.object(gpu_model_runner_module, "graph_capture", fake_graph_capture),
+        patch.object(gpu_model_runner_module, "set_cudagraph_capturing_enabled"),
+        patch.object(gpu_model_runner_module, "lock_workspace"),
+        patch(
+            "vllm.distributed.parallel_state.get_world_group",
+            return_value=SimpleNamespace(local_rank=1),
+        ),
+        patch.object(gpu_model_runner_module.torch, "accelerator", accelerator),
+    ):
+        size = GPUModelRunner.capture_model(runner)
+
+    assert size == 200
+    assert events[-3:] == ["sync", "flush", "info"]
+    assert events.index("exit") < len(events) - 3

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -54,7 +54,6 @@ from vllm.third_party.flash_linear_attention.ops import (
     fused_sigmoid_gating_delta_rule_update,
 )
 from vllm.third_party.flash_linear_attention.ops.chunk import l2norm_fwd
-from vllm.third_party.flash_linear_attention.ops.utils import FLA_CHUNK_SIZE
 from vllm.transformers_utils.configs.qwen3_next import Qwen3NextConfig
 from vllm.triton_utils import tl, triton
 from vllm.utils.torch_utils import (
@@ -996,15 +995,15 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         When the first real inference triggers the autotuner it OOMs
         because there is not enough memory left for benchmarking.
 
-        This method runs minimal forward passes through
-        ``chunk_gated_delta_rule`` with small dummy tensors to force
-        autotuning while GPU memory is still plentiful.  The autotuner
-        results are cached globally, so only the first layer incurs
-        actual benchmarking cost.
+        This method runs a profile-sized forward pass through
+        ``chunk_gated_delta_rule`` to force autotuning while GPU memory is
+        still plentiful. The autotuner results are cached globally, so only
+        the first layer incurs actual benchmarking cost. The projected input
+        is reused for the profile-sized pass to avoid an extra input copy.
 
-        All kernels including ``chunk_fwd_kernel_o`` now use a fixed
-        ``BT = chunk_size`` (64).  A single warmup pass with T = 64
-        is sufficient to populate the autotuner cache.
+        All kernels including ``chunk_fwd_kernel_o`` use a fixed
+        ``BT = chunk_size`` (64), so the full-token pass still exercises the
+        same autotuned kernel family.
 
         The decode path uses ``gdn_aiter_fused_rearrange_sigmoid_gated_delta_rule``
         which has fixed kernel parameters (no autotuning), so only the
@@ -1020,18 +1019,18 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         num_v_heads = self.num_v_heads // self.tp_size
         _, state_dtype = self.get_state_dtype()
 
-        # All kernels use BT = chunk_size, so a single pass with T = chunk_size
-        # is sufficient to populate every autotuner cache. Mirror the real
-        # prefill path here: build q/k/v/g/beta via fused_post_conv_prep and
-        # then run chunk_gated_delta_rule with in-kernel L2 norm disabled.
-        T = FLA_CHUNK_SIZE
-        dummy_mixed_qkv = torch.randn(
-            T, qkv_or_qkvz.shape[-1] - v_dim, device=device, dtype=dtype
-        )
+        # Profile with the full projected token extent. This keeps the profile
+        # run's activation peak representative of a long GDN prefill without
+        # building full attention metadata or executing quadratic attention.
+        T = qkv_or_qkvz.shape[0]
+        mixed_qkv = qkv_or_qkvz[..., :-v_dim] if v_dim else qkv_or_qkvz
+        # Mirror the real prefill path: build q/k/v/g/beta via
+        # fused_post_conv_prep and then run chunk_gated_delta_rule with
+        # in-kernel L2 norm disabled.
         dummy_a = torch.randn(T, num_v_heads, device=device, dtype=dtype)
         dummy_b = torch.randn(T, num_v_heads, device=device, dtype=dtype)
         q, k, v, g, beta = fused_post_conv_prep(
-            conv_output=dummy_mixed_qkv,
+            conv_output=mixed_qkv,
             a=dummy_a,
             b=dummy_b,
             A_log=self.A_log,
@@ -1098,7 +1097,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             )
         finally:
             del (
-                dummy_mixed_qkv,
+                mixed_qkv,
                 q,
                 k,
                 v,

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -56,7 +56,6 @@ from vllm.third_party.flash_linear_attention.ops import (
     fused_sigmoid_gating_delta_rule_update,
 )
 from vllm.third_party.flash_linear_attention.ops.chunk import l2norm_fwd
-from vllm.third_party.flash_linear_attention.ops.utils import FLA_CHUNK_SIZE
 from vllm.transformers_utils.configs.qwen3_next import Qwen3NextConfig
 from vllm.triton_utils import tl, triton
 from vllm.utils.torch_utils import (
@@ -1060,15 +1059,15 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         When the first real inference triggers the autotuner it OOMs
         because there is not enough memory left for benchmarking.
 
-        This method runs minimal forward passes through
-        ``chunk_gated_delta_rule`` with small dummy tensors to force
-        autotuning while GPU memory is still plentiful.  The autotuner
-        results are cached globally, so only the first layer incurs
-        actual benchmarking cost.
+        This method runs a profile-sized forward pass through
+        ``chunk_gated_delta_rule`` to force autotuning while GPU memory is
+        still plentiful. The autotuner results are cached globally, so only
+        the first layer incurs actual benchmarking cost. The projected input
+        is reused for the profile-sized pass to avoid an extra input copy.
 
-        All kernels including ``chunk_fwd_kernel_o`` now use a fixed
-        ``BT = chunk_size`` (64).  A single warmup pass with T = 64
-        is sufficient to populate the autotuner cache.
+        All kernels including ``chunk_fwd_kernel_o`` use a fixed
+        ``BT = chunk_size`` (64), so the full-token pass still exercises the
+        same autotuned kernel family.
 
         The decode path uses ``gdn_aiter_fused_rearrange_sigmoid_gated_delta_rule``
         which has fixed kernel parameters (no autotuning), so only the
@@ -1084,18 +1083,18 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         num_v_heads = self.num_v_heads // self.tp_size
         _, state_dtype = self.get_state_dtype()
 
-        # All kernels use BT = chunk_size, so a single pass with T = chunk_size
-        # is sufficient to populate every autotuner cache. Mirror the real
-        # prefill path here: build q/k/v/g/beta via fused_post_conv_prep and
-        # then run chunk_gated_delta_rule with in-kernel L2 norm disabled.
-        T = FLA_CHUNK_SIZE
-        dummy_mixed_qkv = torch.randn(
-            T, qkv_or_qkvz.shape[-1] - v_dim, device=device, dtype=dtype
-        )
+        # Profile with the full projected token extent. This keeps the profile
+        # run's activation peak representative of a long GDN prefill without
+        # building full attention metadata or executing quadratic attention.
+        T = qkv_or_qkvz.shape[0]
+        mixed_qkv = qkv_or_qkvz[..., :-v_dim] if v_dim else qkv_or_qkvz
+        # Mirror the real prefill path: build q/k/v/g/beta via
+        # fused_post_conv_prep and then run chunk_gated_delta_rule with
+        # in-kernel L2 norm disabled.
         dummy_a = torch.randn(T, num_v_heads, device=device, dtype=dtype)
         dummy_b = torch.randn(T, num_v_heads, device=device, dtype=dtype)
         q, k, v, g, beta = fused_post_conv_prep(
-            conv_output=dummy_mixed_qkv,
+            conv_output=mixed_qkv,
             a=dummy_a,
             b=dummy_b,
             A_log=self.A_log,
@@ -1162,7 +1161,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             )
         finally:
             del (
-                dummy_mixed_qkv,
+                mixed_qkv,
                 q,
                 k,
                 v,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6708,10 +6708,7 @@ class GPUModelRunner(
         # because encoder graph capture is opt-in.
         try:
             set_cudagraph_capturing_enabled(True)
-            with (
-                self._freeze_gc(),
-                graph_capture(device=self.device, graph_capture_context=cap_ctx),
-            ):
+            with self._freeze_gc():
                 torch.accelerator.synchronize()
                 torch.accelerator.empty_cache()
 
@@ -6720,20 +6717,48 @@ class GPUModelRunner(
                     mem_samples: list[int] = []
 
                     for i, desc in enumerate(profile_descs):
-                        mem_before = torch.accelerator.get_memory_info()[0]
-                        self._warmup_and_capture(
-                            desc,
-                            cudagraph_runtime_mode=mode,
-                            profile_seq_lens=(
-                                min(
-                                    self.max_model_len,
-                                    self.max_num_tokens // desc.num_tokens,
-                                )
-                                if mode == CUDAGraphMode.FULL and i == 0
-                                else None
-                            ),
+                        profile_seq_lens = (
+                            min(
+                                self.max_model_len,
+                                self.max_num_tokens // desc.num_tokens,
+                            )
+                            if mode == CUDAGraphMode.FULL and i == 0
+                            else None
                         )
+                        with graph_capture(
+                            device=self.device,
+                            graph_capture_context=cap_ctx,
+                        ):
+                            for _ in range(
+                                self.compilation_config.cudagraph_num_of_warmups
+                            ):
+                                self._dummy_run(
+                                    desc.num_tokens,
+                                    cudagraph_runtime_mode=CUDAGraphMode.NONE,
+                                    force_attention=mode == CUDAGraphMode.FULL,
+                                    uniform_decode=desc.uniform,
+                                    allow_microbatching=False,
+                                    skip_eplb=True,
+                                    remove_lora=False,
+                                    num_active_loras=desc.num_active_loras,
+                                    profile_seq_lens=profile_seq_lens,
+                                )
                         torch.accelerator.synchronize()
+                        torch.accelerator.empty_cache()
+                        mem_before = torch.accelerator.get_memory_info()[0]
+                        with graph_capture(
+                            device=self.device,
+                            graph_capture_context=cap_ctx,
+                        ):
+                            self._warmup_and_capture(
+                                desc,
+                                cudagraph_runtime_mode=mode,
+                                num_warmups=0,
+                            )
+                        torch.accelerator.synchronize()
+                        # The capture stream must be restored before the cache
+                        # can release capture-only allocator blocks.
+                        torch.accelerator.empty_cache()
                         free_after = torch.accelerator.get_memory_info()[0]
                         mem_samples.append(mem_before - free_after)
 
@@ -6757,8 +6782,15 @@ class GPUModelRunner(
 
                 if encoder_cudagraph_manager is not None:
                     mem_before = torch.accelerator.get_memory_info()[0]
-                    encoder_cudagraph_manager.capture(graph_pool=encoder_profiling_pool)
+                    with graph_capture(
+                        device=self.device,
+                        graph_capture_context=cap_ctx,
+                    ):
+                        encoder_cudagraph_manager.capture(
+                            graph_pool=encoder_profiling_pool
+                        )
                     torch.accelerator.synchronize()
+                    torch.accelerator.empty_cache()
                     free_after = torch.accelerator.get_memory_info()[0]
                     encoder_memory_estimate = max(mem_before - free_after, 0)
 
@@ -6882,7 +6914,6 @@ class GPUModelRunner(
                 self.encoder_cudagraph_manager.capture(graph_pool=encoder_graph_pool)
 
             torch.accelerator.synchronize()
-            end_free_gpu_memory = torch.accelerator.get_memory_info()[0]
 
         # Disable cudagraph capturing globally, so any unexpected cudagraph
         # capturing will be detected and raise an error after here.
@@ -6892,7 +6923,10 @@ class GPUModelRunner(
         set_cudagraph_capturing_enabled(False)
 
         torch.accelerator.synchronize()
+        # Measure only memory retained by runtime graph pools, not freed
+        # allocator blocks from warmups and capture setup.
         torch.accelerator.empty_cache()
+        end_free_gpu_memory = torch.accelerator.get_memory_info()[0]
 
         # Lock workspace to prevent resizing during execution.
         # Max workspace sizes should have been captured during warmup/profiling.
@@ -6913,7 +6947,6 @@ class GPUModelRunner(
         self,
         desc: BatchDescriptor,
         cudagraph_runtime_mode: CUDAGraphMode,
-        profile_seq_lens: int | None = None,
         allow_microbatching: bool = False,
         num_warmups: int | None = None,
         profiler: AbstractContextManager[Any] | None = None,
@@ -6933,7 +6966,6 @@ class GPUModelRunner(
                 skip_eplb=True,
                 remove_lora=False,
                 num_active_loras=desc.num_active_loras,
-                profile_seq_lens=profile_seq_lens,
             )
         if num_warmups > 0:
             # Warmups may use auxiliary streams. Ensure all of their work has
@@ -6954,7 +6986,6 @@ class GPUModelRunner(
                 remove_lora=False,
                 num_active_loras=desc.num_active_loras,
                 is_graph_capturing=True,
-                profile_seq_lens=profile_seq_lens,
             )
 
     def _capture_cudagraphs(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6793,10 +6793,7 @@ class GPUModelRunner(
         # because encoder graph capture is opt-in.
         try:
             set_cudagraph_capturing_enabled(True)
-            with (
-                self._freeze_gc(),
-                graph_capture(device=self.device, graph_capture_context=cap_ctx),
-            ):
+            with self._freeze_gc():
                 torch.accelerator.synchronize()
                 torch.accelerator.empty_cache()
 
@@ -6805,20 +6802,48 @@ class GPUModelRunner(
                     mem_samples: list[int] = []
 
                     for i, desc in enumerate(profile_descs):
-                        mem_before = torch.accelerator.get_memory_info()[0]
-                        self._warmup_and_capture(
-                            desc,
-                            cudagraph_runtime_mode=mode,
-                            profile_seq_lens=(
-                                min(
-                                    self.max_model_len,
-                                    self.max_num_tokens // desc.num_tokens,
-                                )
-                                if mode == CUDAGraphMode.FULL and i == 0
-                                else None
-                            ),
+                        profile_seq_lens = (
+                            min(
+                                self.max_model_len,
+                                self.max_num_tokens // desc.num_tokens,
+                            )
+                            if mode == CUDAGraphMode.FULL and i == 0
+                            else None
                         )
+                        with graph_capture(
+                            device=self.device,
+                            graph_capture_context=cap_ctx,
+                        ):
+                            for _ in range(
+                                self.compilation_config.cudagraph_num_of_warmups
+                            ):
+                                self._dummy_run(
+                                    desc.num_tokens,
+                                    cudagraph_runtime_mode=CUDAGraphMode.NONE,
+                                    force_attention=mode == CUDAGraphMode.FULL,
+                                    uniform_decode=desc.uniform,
+                                    allow_microbatching=False,
+                                    skip_eplb=True,
+                                    remove_lora=False,
+                                    num_active_loras=desc.num_active_loras,
+                                    profile_seq_lens=profile_seq_lens,
+                                )
                         torch.accelerator.synchronize()
+                        torch.accelerator.empty_cache()
+                        mem_before = torch.accelerator.get_memory_info()[0]
+                        with graph_capture(
+                            device=self.device,
+                            graph_capture_context=cap_ctx,
+                        ):
+                            self._warmup_and_capture(
+                                desc,
+                                cudagraph_runtime_mode=mode,
+                                num_warmups=0,
+                            )
+                        torch.accelerator.synchronize()
+                        # The capture stream must be restored before the cache
+                        # can release capture-only allocator blocks.
+                        torch.accelerator.empty_cache()
                         free_after = torch.accelerator.get_memory_info()[0]
                         mem_samples.append(mem_before - free_after)
 
@@ -6842,8 +6867,15 @@ class GPUModelRunner(
 
                 if encoder_cudagraph_manager is not None:
                     mem_before = torch.accelerator.get_memory_info()[0]
-                    encoder_cudagraph_manager.capture(graph_pool=encoder_profiling_pool)
+                    with graph_capture(
+                        device=self.device,
+                        graph_capture_context=cap_ctx,
+                    ):
+                        encoder_cudagraph_manager.capture(
+                            graph_pool=encoder_profiling_pool
+                        )
                     torch.accelerator.synchronize()
+                    torch.accelerator.empty_cache()
                     free_after = torch.accelerator.get_memory_info()[0]
                     encoder_memory_estimate = max(mem_before - free_after, 0)
 
@@ -6967,7 +6999,6 @@ class GPUModelRunner(
                 self.encoder_cudagraph_manager.capture(graph_pool=encoder_graph_pool)
 
             torch.accelerator.synchronize()
-            end_free_gpu_memory = torch.accelerator.get_memory_info()[0]
 
         # Disable cudagraph capturing globally, so any unexpected cudagraph
         # capturing will be detected and raise an error after here.
@@ -6977,7 +7008,10 @@ class GPUModelRunner(
         set_cudagraph_capturing_enabled(False)
 
         torch.accelerator.synchronize()
+        # Measure only memory retained by runtime graph pools, not freed
+        # allocator blocks from warmups and capture setup.
         torch.accelerator.empty_cache()
+        end_free_gpu_memory = torch.accelerator.get_memory_info()[0]
 
         # Lock workspace to prevent resizing during execution.
         # Max workspace sizes should have been captured during warmup/profiling.
@@ -6998,7 +7032,6 @@ class GPUModelRunner(
         self,
         desc: BatchDescriptor,
         cudagraph_runtime_mode: CUDAGraphMode,
-        profile_seq_lens: int | None = None,
         allow_microbatching: bool = False,
         num_warmups: int | None = None,
         profiler: AbstractContextManager[Any] | None = None,
@@ -7018,7 +7051,6 @@ class GPUModelRunner(
                 skip_eplb=True,
                 remove_lora=False,
                 num_active_loras=desc.num_active_loras,
-                profile_seq_lens=profile_seq_lens,
             )
         if num_warmups > 0:
             # Warmups may use auxiliary streams. Ensure all of their work has
@@ -7039,7 +7071,6 @@ class GPUModelRunner(
                 remove_lora=False,
                 num_active_loras=desc.num_active_loras,
                 is_graph_capturing=True,
-                profile_seq_lens=profile_seq_lens,
             )
 
     def _capture_cudagraphs(


### PR DESCRIPTION
## Purpose

Fixes #50780.

The CUDA graph estimator sampled the first FULL capture around a long-context profiling run, so transient GDN activations were charged as retained graph memory. This change runs that long warmup separately, flushes allocator-only blocks, captures the normal runtime shape with zero internal warmups, and samples retained memory after leaving the capture stream context.

The GDN warmup now consumes the full projected token extent, keeping the long-prefill activation peak in model profiling without placing the long-context shape inside the captured graph. Runtime and encoder graph measurements use the same retained-memory boundary.

## Test Plan

- `.venv/bin/pytest -q tests/kernels/mamba/test_gdn_profile_warmup.py tests/v1/worker/test_gpu_model_runner.py -k "profile_cudagraph_memory_flushes_before_retained_measurements or capture_model_measures_runtime_pool_after_flush or profile_warmup_reuses_projected_tokens"`
- `.venv/bin/pre-commit run --files tests/kernels/mamba/test_gdn_profile_warmup.py tests/v1/worker/test_gpu_model_runner.py vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py vllm/v1/worker/gpu_model_runner.py`
- Single-GPU Qwen/Qwen3.5-0.8B reproduction with `max_num_batched_tokens=32768`, followed by a 32,768-token prompt and one generated token.

## Test Result

- 3 focused tests passed; 44 unrelated tests deselected.
- All exact-file pre-commit hooks passed.
- RTX PRO 6000 Blackwell, Qwen/Qwen3.5-0.8B:
  - before: graph estimate 1.05 GiB, available KV 41.66 GiB, 7,093,553 KV tokens
  - after: graph estimate 0.39 GiB, available KV 42.32 GiB, 7,205,304 KV tokens
  - runtime capture retained pool: 1.12 GiB, measured after capture cleanup
  - `LONG_PREFILL_DONE prompt_tokens=32768 output_tokens=1`
  - `REPRO_DONE mnbt=32768`

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR.
- [x] The test plan.
- [x] The test results.
- [x] No documentation update is required for this internal accounting fix.
</details>
