### PR TITLE
[ROCm] Guard block-table indexing in Triton paged-attention decode (#48043)

### DIFF
--- a/vllm/v1/attention/ops/chunked_prefill_paged_decode.py
+++ b/vllm/v1/attention/ops/chunked_prefill_paged_decode.py
@@ -162,8 +162,16 @@ def kernel_paged_attention_2d(
         # them from the K/V loads too.
         kv_load_mask = abs_token_idx < seq_len
         l_block_idx = abs_token_idx // PHYSICAL_BLOCK_SIZE
-        # Vectorized loading of physical block IDs
-        p_block_idx = tl.load(block_tables_ptr + block_table_offset + l_block_idx)
+        # The last Triton tile can index logical blocks at or past seq_len.
+        # Clamp and mask block-table loads: on gfx950/HIP, unguarded gathers
+        # fault even when K/V loads are masked (#48043).
+        num_logical_blocks = cdiv_fn(seq_len, PHYSICAL_BLOCK_SIZE)
+        l_block_idx = tl.minimum(l_block_idx, num_logical_blocks - 1)
+        p_block_idx = tl.load(
+            block_tables_ptr + block_table_offset + l_block_idx,
+            mask=kv_load_mask,
+            other=0,
+        )
         internal_offsets = abs_token_idx % PHYSICAL_BLOCK_SIZE
 
         # 5D addressing logic of K


### PR DESCRIPTION
## Summary

Fixes #48043 — guards block-table indexing in Triton `kernel_paged_attention_2d` on ROCm/gfx950.

PR #47305 masked K/V loads past `seq_len` but left block-table gathers unguarded. On gfx950/HIP the gather can illegal-access even for slots that are score-masked later. This change clamps `l_block_idx` to valid logical blocks and masks the block-table `tl.load`.

## MI355X verification

- **Platform:** MI355X node, gfx950, ROCm 7.2.1
- **Test:** Triton paged-attention decode (`chunked_prefill_paged_decode.py`)
- **Result:** No `hipErrorLaunchFailure` on long-context decode path
- **Note:** Full end-to-end model repro still pending

## Changes

- `vllm/v1/attention/ops/chunked_prefill_paged_decode.py`: clamp logical block index and mask block-table gather load
