### PR TITLE
Fix ROCm AITER MXFP4 W4A16 gate mode for SILU MoEs (#40008)

### DIFF
--- a/tests/model_executor/layers/test_mxfp4_aiter_gfx950_dispatch.py
+++ b/tests/model_executor/layers/test_mxfp4_aiter_gfx950_dispatch.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for AITER MXFP4 W4A16 gate/up interleave dispatch (GFX950)."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import (
+    _aiter_mxfp4_w4a16_gu_interleaved,
+)
+
+
+@pytest.mark.parametrize(
+    ("activation", "expected"),
+    [
+        (MoEActivation.SWIGLUOAI, True),
+        (MoEActivation.SILU, False),
+        (MoEActivation.GELU, False),
+        (MoEActivation.SWIGLUOAI_UNINTERLEAVE, False),
+        (None, False),
+    ],
+)
+def test_aiter_mxfp4_w4a16_gu_interleaved(activation, expected):
+    layer = SimpleNamespace(activation=activation)
+    assert _aiter_mxfp4_w4a16_gu_interleaved(layer) is expected
+
+
+def test_aiter_mxfp4_w4a16_gu_interleaved_missing_activation_attr():
+    layer = SimpleNamespace()
+    assert _aiter_mxfp4_w4a16_gu_interleaved(layer) is False

--- a/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
@@ -383,7 +383,7 @@ def rocm_aiter_fused_experts(
                 if envs.AITER_SITUV2_A8W4
                 else GateMode.SEPARATED.value
             )
-        elif quant_config.use_mxfp4_w4a16:
+        elif quant_config.use_mxfp4_w4a16 and getattr(w1, "gu_interleaved", False):
             gate_mode = GateMode.INTERLEAVE.value
         elif activation_interleave is not None:
             gate_mode = (

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -674,6 +674,21 @@ def mxfp4_round_up_hidden_size_and_intermediate_size(
     return hidden_size, intermediate_size
 
 
+def _aiter_mxfp4_w4a16_gu_interleaved(layer: torch.nn.Module) -> bool:
+    """Return whether AITER MXFP4 W4A16 weights use gpt-oss gate/up interleaving.
+
+    Only ``MoEActivation.SWIGLUOAI`` (gpt-oss) stores w13 as
+    [gate0, up0, gate1, up1, ...] and requires interleaved shuffle plus
+    ``GateMode.INTERLEAVE``. Standard gated activations (e.g. SILU) use
+    separated gate/up layout and must keep separated shuffle + SEPARATED mode.
+    """
+    from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+
+    activation = getattr(layer, "activation", None)
+    return activation == MoEActivation.SWIGLUOAI
+
+
+
 def convert_gpt_oss_weight_to_mxfp4_moe_kernel_format(
     mxfp4_backend: Mxfp4MoeBackend,
     layer: torch.nn.Module,
@@ -1459,10 +1474,12 @@ def convert_weight_to_mxfp4_moe_kernel_format(
         # Necessary for AITER side from crashing
         os.environ["AITER_BF16_FP8_MOE_BOUND"] = "0"
 
+        gu_interleaved = _aiter_mxfp4_w4a16_gu_interleaved(layer)
+
         w13_weight = torch.nn.Parameter(
             _shuf_w(
                 w13_weight.data.view(torch.float4_e2m1fn_x2),
-                is_guinterleave=True,
+                is_guinterleave=gu_interleaved,
                 gate_up=True,
             ),
             requires_grad=False,
@@ -1471,13 +1488,13 @@ def convert_weight_to_mxfp4_moe_kernel_format(
             w13_weight_scale.reshape(-1, w13_weight_scale.shape[-1]),
             num_experts,
             True,
-            True,
+            gu_interleaved,
         )
 
         w2_weight = torch.nn.Parameter(
             _shuf_w(
                 w2_weight.data.view(torch.float4_e2m1fn_x2),
-                is_guinterleave=True,
+                is_guinterleave=gu_interleaved,
                 gate_up=False,
             ),
             requires_grad=False,
@@ -1489,6 +1506,11 @@ def convert_weight_to_mxfp4_moe_kernel_format(
             True,
             False,
         )
+
+        w13_weight.is_shuffled = True
+        w2_weight.is_shuffled = True
+        w13_weight.gu_interleaved = gu_interleaved
+        w2_weight.gu_interleaved = gu_interleaved
 
         return (
             w13_weight,


### PR DESCRIPTION
﻿## Summary
- Gate AITER MXFP4 W4A16 interleaved weight shuffle and GateMode.INTERLEAVE on MoEActivation.SWIGLUOAI (gpt-oss) only; SILU and other MoEs keep separated shuffle and SEPARATED mode.
- Tag shuffled w13/w2 with gu_interleaved so rocm_aiter_moe dispatch matches weight layout.
- Fixes AITER CK unsupported moe heuristic dispatch for Quark w_mxfp4 on MI355X gfx950.

Fixes #40008

## Test plan
- [x] Unit tests: tests/model_executor/layers/test_mxfp4_aiter_gfx950_dispatch.py
- [ ] On MI355X with AITER: pytest tests/model_executor/layers/test_mxfp4_aiter_gfx950_dispatch.py tests/quantization/test_gfx950_moe.py
- [ ] Optional kernel smoke: subset of tests/kernels/moe/test_ocp_mx_moe.py
