### PR TITLE
[CI/Release] Add XPU wheel release build

### DIFF
--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -100,6 +100,20 @@ steps:
         env:
           DOCKER_BUILDKIT: "1"
 
+      - label: "Build wheel - x86_64 - XPU"
+        depends_on: ~
+        id: build-wheel-x86-xpu
+        agents:
+          queue: cpu_queue_release
+        commands:
+          - "DOCKER_BUILDKIT=1 docker build --build-arg GIT_REPO_CHECK=1 --tag vllm-ci:xpu-build-image --target export_vllm_wheel_release --progress plain -f docker/Dockerfile.xpu ."
+          - "mkdir artifacts"
+          - "docker run --rm -v $(pwd)/artifacts:/artifacts_host vllm-ci:xpu-build-image bash -c 'cp -r dist /artifacts_host && chmod -R a+rw /artifacts_host'"
+          - "bash .buildkite/scripts/upload-nightly-wheels.sh"
+          - 'bash .buildkite/scripts/annotate-build-artifact.sh "$$BUILDKITE_LABEL" "s3://vllm-wheels/$$BUILDKITE_COMMIT/$(cd artifacts/dist && echo *.whl)" release-wheels'
+        env:
+          DOCKER_BUILDKIT: "1"
+
       - label: "Build wheel - macOS arm64 - CPU"
         depends_on: ~
         id: build-wheel-macos-arm64-cpu

--- a/.buildkite/scripts/generate-nightly-index.py
+++ b/.buildkite/scripts/generate-nightly-index.py
@@ -91,9 +91,9 @@ def parse_from_filename(file: str) -> WheelFileInfo:
     else:
         if "+" in version:
             version_part, suffix = version.split("+", 1)
-            # Only treat known patterns as variants (rocmXXX, cuXXX, cpu)
+            # Only treat known patterns as variants (rocmXXX, cuXXX, cpu, xpu)
             # Git hashes and other suffixes are NOT variants
-            if suffix.startswith(("rocm", "cu", "cpu")):
+            if suffix.startswith(("rocm", "cu", "cpu", "xpu")):
                 variant = suffix
                 version = version_part
             # Otherwise keep the full version string (variant stays None)

--- a/docker/Dockerfile.xpu
+++ b/docker/Dockerfile.xpu
@@ -210,3 +210,11 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install -e tests/vllm_test_utils
 
 ENTRYPOINT ["vllm", "serve"]
+
+FROM vllm-openai AS export_vllm_wheel_release
+
+ENTRYPOINT []
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=.git,target=.git \
+    python3 setup.py bdist_wheel --dist-dir=dist --py-limited-api=cp38


### PR DESCRIPTION
## Summary

This PR adds XPU wheel support to the release Buildkite pipeline.

Changes included:

- Add a new Buildkite release job to build and upload the x86_64 XPU wheel.
- Add an `export_vllm_wheel_release` target in `docker/Dockerfile.xpu` for producing the XPU wheel artifact.
- Update nightly wheel index parsing so `+xpu` local-version suffixes are recognized as an XPU wheel variant.

## Details

The new release job builds the XPU image target from `docker/Dockerfile.xpu`, copies `dist/` into `artifacts/`, then reuses the existing nightly wheel upload flow:

- `.buildkite/scripts/upload-nightly-wheels.sh`
- `.buildkite/scripts/annotate-build-artifact.sh`

The XPU wheel is built with:

```bash
python3 setup.py bdist_wheel --dist-dir=dist --py-limited-api=cp38