### PR TITLE
[Bugfix][Frontend] Coerce non-dict tool_call arguments to `{}` and return 400 on malformed JSON

### DIFF
--- a/tests/entrypoints/unit_tests/test_chat_utils.py
+++ b/tests/entrypoints/unit_tests/test_chat_utils.py
@@ -2772,6 +2772,115 @@ def test_postprocess_messages_null_arguments_string():
     assert tool_calls[0]["function"]["arguments"] == {}
 
 
+def test_postprocess_messages_list_arguments_string():
+    """arguments="[]" must be coerced to {} since downstream expects a dict."""
+    messages: list[ConversationMessage] = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": "[]"},
+                }
+            ],
+        }
+    ]
+    _postprocess_messages(messages)
+    tool_calls = messages[0]["tool_calls"]
+    assert tool_calls is not None
+    assert tool_calls[0]["function"]["arguments"] == {}
+
+
+def test_postprocess_messages_invalid_json_arguments():
+    """Non-JSON arguments string must raise VLLMValidationError (400)."""
+    messages: list[ConversationMessage] = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "do_thing", "arguments": "{invalid"},
+                }
+            ],
+        }
+    ]
+    with pytest.raises(VLLMValidationError, match="not valid JSON"):
+        _postprocess_messages(messages)
+
+
+def test_postprocess_messages_non_dict_parsed_arguments():
+    """arguments that parse to a non-dict JSON value (int, string, true)
+    must be coerced to {}."""
+    for args_str in ['"hello"', "42", "true"]:
+        messages: list[ConversationMessage] = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "fn", "arguments": args_str},
+                    }
+                ],
+            }
+        ]
+        _postprocess_messages(messages)
+        tool_calls = messages[0]["tool_calls"]
+        assert tool_calls is not None
+        assert tool_calls[0]["function"]["arguments"] == {}, (
+            f"arguments={args_str!r} should be coerced to {{}}"
+        )
+
+
+def test_postprocess_messages_dict_arguments_passthrough():
+    """arguments already a dict should be left unchanged."""
+    messages: list[ConversationMessage] = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "fn",
+                        "arguments": {"key": "value"},
+                    },
+                }
+            ],
+        }
+    ]
+    _postprocess_messages(messages)
+    assert messages[0]["tool_calls"][0]["function"]["arguments"] == {"key": "value"}
+
+
+def test_postprocess_messages_valid_json_dict_string():
+    """arguments='{"a":1}' should be parsed into a dict."""
+    messages: list[ConversationMessage] = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "fn",
+                        "arguments": '{"a": 1}',
+                    },
+                }
+            ],
+        }
+    ]
+    _postprocess_messages(messages)
+    assert messages[0]["tool_calls"][0]["function"]["arguments"] == {"a": 1}
+
+
 @pytest.mark.asyncio
 async def test_resolve_items_does_not_leak_tasks_on_partial_failure():
     """Regression test: one failing media fetch must not abandon the other

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1942,11 +1942,20 @@ def _postprocess_messages(messages: list[ConversationMessage]) -> None:
                         parameter="tool_calls",
                     )
 
-                # if arguments is None or empty string, set to {}
-                if content := function.get("arguments"):
-                    if not isinstance(content, (dict, list)):
-                        parsed = json.loads(content)
-                        function["arguments"] = parsed if parsed is not None else {}
+                # normalize arguments to a dict
+                arguments = function.get("arguments")
+                if isinstance(arguments, dict):
+                    pass
+                elif isinstance(arguments, str) and arguments:
+                    try:
+                        parsed = json.loads(arguments)
+                    except json.JSONDecodeError as e:
+                        raise VLLMValidationError(
+                            "assistant tool_calls function arguments is not "
+                            "valid JSON.",
+                            parameter="tool_calls",
+                        ) from e
+                    function["arguments"] = parsed if isinstance(parsed, dict) else {}
                 else:
                     function["arguments"] = {}
 


### PR DESCRIPTION
## Purpose

We've observed 500 errors in production caused by requests where `tool_calls[].function.arguments` contains non-dict JSON values. A minimal reproducer:

```bash
curl http://<host>/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "deepseek-v4-flash",
    "messages": [
      {"role": "user", "content": "How is the weather today?"},
      {"role": "assistant", "content": null, "tool_calls": [
        {"id": "call_1", "type": "function", "function": {"name": "get_weather", "arguments": "[]"}}
      ]},
      {"role": "tool", "tool_call_id": "call_1", "content": "Sunny 25°C"}
    ]
  }'
```

When `tool_calls[].function.arguments` is a JSON string that does not decode to a dict (e.g. `"[]"`, `"null"`, `"42"`), `_postprocess_messages` passes the decoded non-dict value downstream, causing an unhandled exception and a 500 response. Similarly, malformed JSON (e.g. `"{invalid"`) triggers an uncaught `json.JSONDecodeError` that also results in a 500.

This PR fixes the argument parsing logic to:
1. Coerce any parsed non-dict value to `{}`.
2. Raise `VLLMValidationError` (HTTP 400) on invalid JSON instead of surfacing an internal 500.

## Test Plan

Added unit tests in `tests/entrypoints/unit_tests/test_chat_utils.py` covering:
- `"[]"` → coerced to `{}`
- `"{invalid"` → raises `VLLMValidationError`
- `"42"`, `'"hello"'`, `"true"` → coerced to `{}`
- `{"key": "value"}` (already dict) → passthrough
- `'{"a": 1}'` (valid dict string) → parsed normally

## Test Result

```
tests/.../test_chat_utils.py::test_postprocess_messages_null_arguments_string PASSED
tests/.../test_chat_utils.py::test_postprocess_messages_list_arguments_string PASSED
tests/.../test_chat_utils.py::test_postprocess_messages_invalid_json_arguments PASSED
tests/.../test_chat_utils.py::test_postprocess_messages_non_dict_parsed_arguments PASSED
tests/.../test_chat_utils.py::test_postprocess_messages_dict_arguments_passthrough PASSED
tests/.../test_chat_utils.py::test_postprocess_messages_valid_json_dict_string PASSED
```