### PR TITLE
[V1][Scheduler] Clamp KV connector match to the prompt suffix

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1100,6 +1100,94 @@ def test_prefix_cache_query_not_inflated_by_connector_defer():
     assert stats.queries == request.num_tokens
 
 
+def _run_to_finished(scheduler: Scheduler, request: Request) -> None:
+    from tests.v1.kv_connector.unit.utils import create_model_runner_output
+
+    for _ in range(100):
+        output = scheduler.schedule()
+        if request.request_id not in output.num_scheduled_tokens:
+            break
+        scheduler.update_from_output(output, create_model_runner_output([request]))
+        if request.is_finished():
+            break
+    assert request.is_finished()
+    scheduler.finish_requests(request.request_id, RequestStatus.FINISHED_STOPPED)
+
+
+def test_connector_match_clamped_to_prompt_suffix():
+    """A KV connector reporting more matched tokens than the prompt suffix not
+    locally cached must be clamped to leave at least one token of local
+    prefill: the last token is always recomputed to obtain logits (the local
+    lookup applies the same num_tokens - 1 cap). Without the clamp a match
+    that reaches the end of the prompt schedules zero local tokens and
+    triggers `assert num_new_tokens > 0`."""
+    from tests.v1.kv_connector.unit.utils import create_model_runner_output
+
+    scheduler = create_scheduler(
+        enable_prefix_caching=True,
+        use_kv_connector=mock_kv(matched_tokens=16, is_async=False),
+        block_size=16,
+    )
+    r1, r2 = create_requests(
+        num_requests=2,
+        num_tokens=32,
+        max_tokens=16,
+        same_prompt=True,
+        req_ids=["r1", "r2"],
+    )
+    scheduler.add_request(r1)
+    _run_to_finished(scheduler, r1)
+    scheduler.add_request(r2)
+    output = scheduler.schedule()
+    assert r2.request_id in output.num_scheduled_tokens
+    # r2 hits the locally cached prefix block (16 tokens); the connector
+    # match of 16 is clamped to the 15 remaining suffix tokens, so exactly
+    # one local token is scheduled.
+    assert output.num_scheduled_tokens[r2.request_id] == 1
+    scheduler.update_from_output(output, create_model_runner_output([r2]))
+    assert r2.num_computed_tokens == 32
+
+    # The request is now fully prefilled: the next schedule is a decode.
+    output = scheduler.schedule()
+    assert output.num_scheduled_tokens[r2.request_id] == 1
+    assert not r2.is_prefill_chunk
+
+
+def test_connector_match_exceeding_prompt_clamped():
+    """A connector match that would push the computed token count past the
+    prompt length (local block-aligned hit plus a longer match) must be
+    clamped instead of tripping `assert num_computed_tokens <=
+    request.num_tokens`. The local hit is truncated to block alignment, the
+    match covers the remaining suffix minus the last token."""
+    from tests.v1.kv_connector.unit.utils import create_model_runner_output
+
+    scheduler = create_scheduler(
+        enable_prefix_caching=True,
+        use_kv_connector=mock_kv(matched_tokens=16, is_async=False),
+        block_size=16,
+    )
+    r1, r2 = create_requests(
+        num_requests=2,
+        num_tokens=40,
+        max_tokens=16,
+        same_prompt=True,
+        req_ids=["r1", "r2"],
+    )
+    scheduler.add_request(r1)
+    _run_to_finished(scheduler, r1)
+
+    scheduler.add_request(r2)
+    output = scheduler.schedule()
+    assert r2.request_id in output.num_scheduled_tokens
+    assert output.num_scheduled_tokens[r2.request_id] == 1
+    scheduler.update_from_output(output, create_model_runner_output([r2]))
+    assert r2.num_computed_tokens == 40
+
+    output = scheduler.schedule()
+    assert output.num_scheduled_tokens[r2.request_id] == 1
+    assert not r2.is_prefill_chunk
+
+
 def test_preemption_re_records_prefix_cache_query():
     """A preempted request re-enters the lookup on resume, so its recomputation
     is counted again into the preempted stats."""

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -820,6 +820,24 @@ class Scheduler(SchedulerInterface):
                                 request.shared_prefix_boundary,
                             ) = self.kv_cache_manager.get_computed_blocks(request)
 
+                    # Bound the connector-reported match by the prompt suffix
+                    # not locally cached. A match reaching the end of the
+                    # prompt would leave no local work for this step; the last
+                    # token must be recomputed to obtain logits (the local
+                    # lookup applies the same `num_tokens - 1` cap in
+                    # get_computed_blocks).
+                    num_external_computed_tokens = min(
+                        num_external_computed_tokens,
+                        max(
+                            request.num_tokens - num_new_local_computed_tokens - 1,
+                            0,
+                        ),
+                    )
+                    if num_external_computed_tokens == 0:
+                        # Clamped to nothing: there is no load to run async.
+                        load_kv_async = False
+
+                    if self.connector is not None:
                         connector_prefix_cache_queries = (
                             request.num_tokens - num_new_local_computed_tokens
                         )


### PR DESCRIPTION
## Summary

`Scheduler.schedule()` can crash with a bare `AssertionError` when a KV connector is attached and prefix caching produced a local hit:

- `assert num_new_tokens > 0` (scheduler.py ~914) when the connector's match plus the local hit reaches the end of the prompt (zero local tokens left for the prefill step), or
- `assert num_computed_tokens <= request.num_tokens` (scheduler.py ~832) when the match plus the local hit *exceeds* the prompt length.

The local prefix lookup already caps hits at `num_tokens - 1` (`get_computed_blocks`, kv_cache_manager.py:259) because the last token must always be recomputed to obtain logits — and the async-load promotion path applies the same rule ("on a full prompt hit, we need to re-compute the last token", scheduler.py ~2671). The connector-reported external match was the only unbounded input: it is added to the local hit without being clamped to the remaining prompt suffix.

This is reachable through vLLM's own test connector: `MockKVConnector` returns a fixed `matched_tokens` regardless of the local hit (tests/v1/kv_connector/unit/utils.py), and any connector match of `M` tokens on top of a local hit `L` trips the asserts whenever `L + M >= num_tokens`. The same code exists in upstream `main` (both asserts, no clamp).

## Fix

In the prefill branch of `Scheduler.schedule()`, clamp the connector match to the prompt suffix that is not locally cached, mirroring the `num_tokens - 1` cap of the local lookup:

```python
num_external_computed_tokens = min(
    num_external_computed_tokens,
    max(request.num_tokens - num_new_local_computed_tokens - 1, 0),
)
if num_external_computed_tokens == 0:
    load_kv_async = False
```

- At least one token of local prefill remains, so `num_new_tokens > 0` holds.
- `num_computed_tokens <= num_tokens` holds; the `num_tokens - 1` bound matches the documented "recompute the last token" rule.
- When the clamp leaves nothing to load, `load_kv_async` is cleared so the async-load assert (`num_external_computed_tokens > 0`) stays satisfiable.
- `connector_prefix_cache_hits` (stats) now records the clamped value actually used.

No behavior change when the connector reports a legal match: the clamp only reduces matches that would overrun the prompt.

## Tests

Two regression tests in `tests/v1/core/test_scheduler.py` cover both failure faces (each fails with `AssertionError` before the fix, passes after):

- `test_connector_match_clamped_to_prompt_suffix` — a match that reaches the end of the prompt (zero local tokens) is clamped to the remaining suffix minus one; the request then decodes normally.
- `test_connector_match_exceeding_prompt_clamped` — a block-aligned local hit plus a longer match would exceed the prompt; the match is clamped and the request finishes prefill.

Commands and results:

```
# regression tests fail without the fix (stashed scheduler.py):
.venv/bin/python -m pytest tests/v1/core/test_scheduler.py::test_connector_match_clamped_to_prompt_suffix tests/v1/core/test_scheduler.py::test_connector_match_exceeding_prompt_clamped -q
# -> 2 failed (AssertionError inside Scheduler.schedule())

# with the fix:
# -> 2 passed

# full scheduler test file (incl. 66 connector/kv/prefix-cache/throttle tests):
.venv/bin/python -m pytest tests/v1/core/test_scheduler.py -q -p no:cacheprovider
# -> 139 passed, 16 warnings in 229.93s
```

No model-affecting change: this only bounds token accounting at scheduling time; sampling/output paths are untouched, so no model eval is needed.

## AI assistance

This change was developed with AI assistance (opencode). The submitting author reviewed every line and ran the tests above.

Not a duplicate: searched open PRs/issues for connector match clamping / `get_num_new_matched_tokens` bounds / the two asserts — nothing open addresses this.
