### PR TITLE
[Bugfix] Update ExaoneMoEForCausalLM arch name to ExaoneMoeForCausalLM

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -364,7 +364,7 @@ th {
 | `Ernie4_5ForCausalLM` | Ernie4.5 | `baidu/ERNIE-4.5-0.3B-PT`, etc. | ✅︎ | ✅︎ |
 | `Ernie4_5_MoeForCausalLM` | Ernie4.5MoE | `baidu/ERNIE-4.5-21B-A3B-PT`, `baidu/ERNIE-4.5-300B-A47B-PT`, etc. | ✅︎ | ✅︎ |
 | `ExaoneForCausalLM` | EXAONE-3 | `LGAI-EXAONE/EXAONE-3.0-7.8B-Instruct`, etc. | ✅︎ | ✅︎ |
-| `ExaoneMoEForCausalLM` | K-EXAONE | `LGAI-EXAONE/K-EXAONE-236B-A23B`, etc. | | |
+| `ExaoneMoeForCausalLM` | K-EXAONE | `LGAI-EXAONE/K-EXAONE-236B-A23B`, etc. | | |
 | `Exaone4ForCausalLM` | EXAONE-4 | `LGAI-EXAONE/EXAONE-4.0-32B`, etc. | ✅︎ | ✅︎ |
 | `Fairseq2LlamaForCausalLM` | Llama (fairseq2 format) | `mgleize/fairseq2-dummy-Llama-3.2-1B`, etc. | ✅︎ | ✅︎ |
 | `FalconForCausalLM` | Falcon | `tiiuae/falcon-7b`, `tiiuae/falcon-40b`, `tiiuae/falcon-rw-7b`, etc. | | ✅︎ |

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -267,7 +267,7 @@ _TEXT_GENERATION_EXAMPLE_MODELS = {
         "LGAI-EXAONE/EXAONE-3.0-7.8B-Instruct", trust_remote_code=True
     ),
     "Exaone4ForCausalLM": _HfExamplesInfo("LGAI-EXAONE/EXAONE-4.0-32B"),
-    "ExaoneMoEForCausalLM": _HfExamplesInfo(
+    "ExaoneMoeForCausalLM": _HfExamplesInfo(
         "LGAI-EXAONE/K-EXAONE-236B-A23B", min_transformers_version="5.1.0"
     ),
     "Fairseq2LlamaForCausalLM": _HfExamplesInfo("mgleize/fairseq2-dummy-Llama-3.2-1B"),

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -97,7 +97,7 @@ _TEXT_GENERATION_MODELS = {
     "Ernie4_5_MoeForCausalLM": ("ernie45_moe", "Ernie4_5_MoeForCausalLM"),
     "ExaoneForCausalLM": ("exaone", "ExaoneForCausalLM"),
     "Exaone4ForCausalLM": ("exaone4", "Exaone4ForCausalLM"),
-    "ExaoneMoEForCausalLM": ("exaone_moe", "ExaoneMoeForCausalLM"),
+    "ExaoneMoeForCausalLM": ("exaone_moe", "ExaoneMoeForCausalLM"),
     "Fairseq2LlamaForCausalLM": ("fairseq2_llama", "Fairseq2LlamaForCausalLM"),
     "FalconForCausalLM": ("falcon", "FalconForCausalLM"),
     "FalconMambaForCausalLM": ("mamba", "MambaForCausalLM"),


### PR DESCRIPTION
## Purpose
AMD CI suffered a failure in [Basic Models Tests (Extra Initialization)](https://buildkite.com/vllm/amd-ci/builds/11591/list?jid=019fc6dc-f199-4f89-bd00-a11e357e0faa&tab=output)

The failing tests utilize the ExaoneMoEForCausalLM architecture, which had its spelling changed  in the HF config from [ExaoneMoEForCausalLM -> ExaoneMoeForCausalLM](https://huggingface.co/LGAI-EXAONE/K-EXAONE-236B-A23B/commit/61e6d578eb102b578e5704e2916ac841df9eca0a)

The PR updates the registry keys for this arch to the new spelling.

## Test Plan
Before change:
pytest -v -s models/test_initialization.py::test_can_initialize_large_subset[ExaoneMoEForCausalLM] \
models/test_initialization.py::test_can_initialize_large_subset[ExaoneMoeMTP]

After change:
pytest -v -s models/test_initialization.py::test_can_initialize_large_subset[ExaoneMoeForCausalLM] \
models/test_initialization.py::test_can_initialize_large_subset[ExaoneMoeMTP]

## Test Result
Tests previously failed with
```
RuntimeError: Test subprocess 'can_initialize' failed (exit code 1):
--
  | Traceback (most recent call last):
  | File "<string>", line 12, in <module>
  | File "/vllm-workspace/tests/utils.py", line 1873, in wrapper
  | return f(*args, **kwargs)
  | ^^^^^^^^^^^^^^^^^^
  | File "/vllm-workspace/tests/models/test_initialization.py", line 154, in can_initialize
  | LLM(
  | File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/llm.py", line 339, in __init__
  | self.llm_engine = LLMEngine.from_engine_args(
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/llm_engine.py", line 171, in from_engine_args
  | vllm_config = engine_args.create_engine_config(usage_context)
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | File "/usr/local/lib/python3.12/dist-packages/vllm/engine/arg_utils.py", line 1925, in create_engine_config
  | model_config = self.create_model_config()
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^
  | File "/usr/local/lib/python3.12/dist-packages/quark/online_quantization/vllm/plugin.py", line 193, in patched_create_model_config
  | return orig_create_model_config(self, *args, **kwargs)
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | File "/usr/local/lib/python3.12/dist-packages/vllm/engine/arg_utils.py", line 1682, in create_model_config
  | return ModelConfig(
  | ^^^^^^^^^^^^
  | File "/usr/local/lib/python3.12/dist-packages/pydantic/_internal/_dataclasses.py", line 121, in __init__
  | s.__pydantic_validator__.validate_python(ArgsKwargs(args, kwargs), self_instance=s)
  | pydantic_core._pydantic_core.ValidationError: 1 validation error for ModelConfig
  | Value error, Model architectures ['ExaoneMoeForCausalLM'] are not supported for now. 
Supported architectures: dict_keys(['AfmoeForCausalLM', 'ApertusForCausalLM', 'ArceeForCausalLM', ...]) [type=value_error, input_value=ArgsKwargs((), {'model': ...nderer_num_workers': 1}), input_type=ArgsKwargs]
```
