### PR TITLE
[ROCm][Refactor] Split multi-stream launch/sync into CUDA and ROCm platform methods

### DIFF
--- a/tests/utils/test_multi_stream_utils.py
+++ b/tests/utils/test_multi_stream_utils.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.utils.multi_stream_utils import execute_in_parallel, maybe_execute_in_parallel
+
+
+def _device() -> str:
+    return current_platform.device_type
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="multi_stream_utils requires CUDA or ROCm",
+)
+def test_maybe_execute_in_parallel_matches_sequential():
+    x = torch.randn(1024, device=_device())
+    aux_stream = torch.cuda.Stream()
+    event0 = torch.cuda.Event()
+    event1 = torch.cuda.Event()
+
+    parallel = maybe_execute_in_parallel(
+        lambda: x * 2.0,
+        lambda: x * 3.0,
+        event0,
+        event1,
+        aux_stream,
+    )
+    sequential = maybe_execute_in_parallel(
+        lambda: x * 2.0,
+        lambda: x * 3.0,
+        event0,
+        event1,
+        None,
+    )
+
+    torch.accelerator.synchronize()
+    assert torch.equal(parallel[0], sequential[0])
+    assert torch.equal(parallel[1], sequential[1])
+    assert torch.equal(parallel[0], x * 2.0)
+    assert torch.equal(parallel[1], x * 3.0)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="multi_stream_utils requires CUDA or ROCm",
+)
+def test_execute_in_parallel_matches_sequential():
+    x = torch.randn(512, device=_device())
+    aux_streams = [torch.cuda.Stream(), torch.cuda.Stream()]
+    start_event = torch.cuda.Event()
+    done_events = [torch.cuda.Event(), torch.cuda.Event()]
+
+    parallel = execute_in_parallel(
+        lambda: x + 1.0,
+        [lambda: x * 2.0, lambda: x * 3.0],
+        start_event,
+        done_events,
+        aux_streams,
+        enable=True,
+    )
+    sequential = execute_in_parallel(
+        lambda: x + 1.0,
+        [lambda: x * 2.0, lambda: x * 3.0],
+        start_event,
+        done_events,
+        aux_streams,
+        enable=False,
+    )
+
+    torch.accelerator.synchronize()
+    assert torch.equal(parallel[0], sequential[0])
+    assert torch.equal(parallel[1][0], sequential[1][0])
+    assert torch.equal(parallel[1][1], sequential[1][1])
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="multi_stream_utils requires CUDA or ROCm",
+)
+def test_execute_in_parallel_skips_none_aux():
+    x = torch.randn(256, device=_device())
+    aux_streams = [torch.cuda.Stream(), torch.cuda.Stream(), torch.cuda.Stream()]
+    start_event = torch.cuda.Event()
+    done_events = [torch.cuda.Event(), torch.cuda.Event(), torch.cuda.Event()]
+
+    default_result, aux_results = execute_in_parallel(
+        lambda: x + 10.0,
+        [None, lambda: x * 4.0, None],
+        start_event,
+        done_events,
+        aux_streams,
+        enable=True,
+    )
+
+    torch.accelerator.synchronize()
+    assert torch.equal(default_result, x + 10.0)
+    assert aux_results[0] is None
+    assert torch.equal(aux_results[1], x * 4.0)
+    assert aux_results[2] is None
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="multi_stream_utils requires CUDA or ROCm",
+)
+def test_execute_in_parallel_aux_tensor_on_main_stream():
+    x = torch.randn(1024, device=_device())
+    aux_stream = torch.cuda.Stream()
+    start_event = torch.cuda.Event()
+    done_event = torch.cuda.Event()
+
+    _, aux_results = execute_in_parallel(
+        lambda: x * 2.0,
+        [lambda: x * 5.0],
+        start_event,
+        [done_event],
+        [aux_stream],
+        enable=True,
+    )
+
+    torch.accelerator.synchronize()
+    combined = aux_results[0] + x
+    torch.testing.assert_close(combined, x * 6.0)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="CUDA-specific launch ordering flag behavior",
+)
+def test_launch_multi_stream_queue_aux_before_default():
+    x = torch.randn(128, device=_device())
+    aux_stream = torch.cuda.Stream()
+    start_event = torch.cuda.Event()
+    done_event = torch.cuda.Event()
+    launch_order: list[str] = []
+
+    def default_fn() -> torch.Tensor:
+        launch_order.append("default")
+        return x + 1.0
+
+    def aux_fn() -> torch.Tensor:
+        launch_order.append("aux")
+        return x * 2.0
+
+    current_platform.launch_multi_stream(
+        default_fn,
+        [aux_fn],
+        start_event,
+        [done_event],
+        [aux_stream],
+        queue_aux_before_default=True,
+    )
+    torch.accelerator.synchronize()
+    assert launch_order == ["aux", "default"]
+
+    launch_order.clear()
+    current_platform.launch_multi_stream(
+        default_fn,
+        [aux_fn],
+        start_event,
+        [done_event],
+        [aux_stream],
+        queue_aux_before_default=False,
+    )
+    torch.accelerator.synchronize()
+    assert launch_order == ["default", "aux"]

--- a/tests/utils/test_multi_stream_utils.py
+++ b/tests/utils/test_multi_stream_utils.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+"""Tests for CUDA/ROCm multi-stream execution helpers."""
+
 import pytest
 import torch
 
@@ -8,163 +10,63 @@ from vllm.platforms import current_platform
 from vllm.utils.multi_stream_utils import execute_in_parallel, maybe_execute_in_parallel
 
 
-def _device() -> str:
-    return current_platform.device_type
-
-
 @pytest.mark.skipif(
     not current_platform.is_cuda_alike(),
-    reason="multi_stream_utils requires CUDA or ROCm",
+    reason="Multi-stream execution requires CUDA or ROCm",
 )
 def test_maybe_execute_in_parallel_matches_sequential():
-    x = torch.randn(1024, device=_device())
-    aux_stream = torch.cuda.Stream()
-    event0 = torch.cuda.Event()
-    event1 = torch.cuda.Event()
+    x = torch.randn(1024, device=current_platform.device_type)
+    start_event = torch.cuda.Event()
+    done_event = torch.cuda.Event()
 
     parallel = maybe_execute_in_parallel(
-        lambda: x * 2.0,
-        lambda: x * 3.0,
-        event0,
-        event1,
-        aux_stream,
+        lambda: x + 1,
+        lambda: x * 2,
+        start_event,
+        done_event,
+        torch.cuda.Stream(),
     )
     sequential = maybe_execute_in_parallel(
-        lambda: x * 2.0,
-        lambda: x * 3.0,
-        event0,
-        event1,
+        lambda: x + 1,
+        lambda: x * 2,
+        start_event,
+        done_event,
         None,
     )
 
-    torch.accelerator.synchronize()
-    assert torch.equal(parallel[0], sequential[0])
-    assert torch.equal(parallel[1], sequential[1])
-    assert torch.equal(parallel[0], x * 2.0)
-    assert torch.equal(parallel[1], x * 3.0)
+    torch.testing.assert_close(parallel[0], sequential[0])
+    torch.testing.assert_close(parallel[1], sequential[1])
 
 
 @pytest.mark.skipif(
     not current_platform.is_cuda_alike(),
-    reason="multi_stream_utils requires CUDA or ROCm",
+    reason="Multi-stream execution requires CUDA or ROCm",
 )
 def test_execute_in_parallel_matches_sequential():
-    x = torch.randn(512, device=_device())
-    aux_streams = [torch.cuda.Stream(), torch.cuda.Stream()]
+    x = torch.randn(1024, device=current_platform.device_type)
     start_event = torch.cuda.Event()
-    done_events = [torch.cuda.Event(), torch.cuda.Event()]
+    done_events = [torch.cuda.Event() for _ in range(3)]
+    aux_streams = [torch.cuda.Stream() for _ in range(3)]
+    aux_fns = [lambda: x * 2, None, lambda: x * 3]
 
     parallel = execute_in_parallel(
-        lambda: x + 1.0,
-        [lambda: x * 2.0, lambda: x * 3.0],
+        lambda: x + 1,
+        aux_fns,
         start_event,
         done_events,
         aux_streams,
         enable=True,
     )
     sequential = execute_in_parallel(
-        lambda: x + 1.0,
-        [lambda: x * 2.0, lambda: x * 3.0],
+        lambda: x + 1,
+        aux_fns,
         start_event,
         done_events,
         aux_streams,
         enable=False,
     )
 
-    torch.accelerator.synchronize()
-    assert torch.equal(parallel[0], sequential[0])
-    assert torch.equal(parallel[1][0], sequential[1][0])
-    assert torch.equal(parallel[1][1], sequential[1][1])
-
-
-@pytest.mark.skipif(
-    not current_platform.is_cuda_alike(),
-    reason="multi_stream_utils requires CUDA or ROCm",
-)
-def test_execute_in_parallel_skips_none_aux():
-    x = torch.randn(256, device=_device())
-    aux_streams = [torch.cuda.Stream(), torch.cuda.Stream(), torch.cuda.Stream()]
-    start_event = torch.cuda.Event()
-    done_events = [torch.cuda.Event(), torch.cuda.Event(), torch.cuda.Event()]
-
-    default_result, aux_results = execute_in_parallel(
-        lambda: x + 10.0,
-        [None, lambda: x * 4.0, None],
-        start_event,
-        done_events,
-        aux_streams,
-        enable=True,
-    )
-
-    torch.accelerator.synchronize()
-    assert torch.equal(default_result, x + 10.0)
-    assert aux_results[0] is None
-    assert torch.equal(aux_results[1], x * 4.0)
-    assert aux_results[2] is None
-
-
-@pytest.mark.skipif(
-    not current_platform.is_cuda_alike(),
-    reason="multi_stream_utils requires CUDA or ROCm",
-)
-def test_execute_in_parallel_aux_tensor_on_main_stream():
-    x = torch.randn(1024, device=_device())
-    aux_stream = torch.cuda.Stream()
-    start_event = torch.cuda.Event()
-    done_event = torch.cuda.Event()
-
-    _, aux_results = execute_in_parallel(
-        lambda: x * 2.0,
-        [lambda: x * 5.0],
-        start_event,
-        [done_event],
-        [aux_stream],
-        enable=True,
-    )
-
-    torch.accelerator.synchronize()
-    combined = aux_results[0] + x
-    torch.testing.assert_close(combined, x * 6.0)
-
-
-@pytest.mark.skipif(
-    not current_platform.is_cuda(),
-    reason="CUDA-specific launch ordering flag behavior",
-)
-def test_launch_multi_stream_queue_aux_before_default():
-    x = torch.randn(128, device=_device())
-    aux_stream = torch.cuda.Stream()
-    start_event = torch.cuda.Event()
-    done_event = torch.cuda.Event()
-    launch_order: list[str] = []
-
-    def default_fn() -> torch.Tensor:
-        launch_order.append("default")
-        return x + 1.0
-
-    def aux_fn() -> torch.Tensor:
-        launch_order.append("aux")
-        return x * 2.0
-
-    current_platform.launch_multi_stream(
-        default_fn,
-        [aux_fn],
-        start_event,
-        [done_event],
-        [aux_stream],
-        queue_aux_before_default=True,
-    )
-    torch.accelerator.synchronize()
-    assert launch_order == ["aux", "default"]
-
-    launch_order.clear()
-    current_platform.launch_multi_stream(
-        default_fn,
-        [aux_fn],
-        start_event,
-        [done_event],
-        [aux_stream],
-        queue_aux_before_default=False,
-    )
-    torch.accelerator.synchronize()
-    assert launch_order == ["default", "aux"]
+    torch.testing.assert_close(parallel[0], sequential[0])
+    assert parallel[1][1] is sequential[1][1] is None
+    torch.testing.assert_close(parallel[1][0], sequential[1][0])
+    torch.testing.assert_close(parallel[1][2], sequential[1][2])

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -12,7 +12,7 @@ import platform
 from collections.abc import Callable
 from datetime import timedelta
 from functools import cache, lru_cache, wraps
-from typing import TYPE_CHECKING, NamedTuple, TypeVar
+from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
 import torch
 from torch.distributed import PrefixStore, ProcessGroup
@@ -712,6 +712,66 @@ class CudaPlatformBase(Platform):
         except Exception:
             return False
         return major >= 9
+
+    @classmethod
+    def launch_multi_stream(
+        cls,
+        default_fn: Callable[[], Any],
+        aux_fns: list[Callable[[], Any] | None],
+        start_event: torch.cuda.Event,
+        done_events: list[torch.cuda.Event],
+        aux_streams: list[torch.cuda.Stream] | None = None,
+        queue_aux_before_default: bool = False,
+    ) -> tuple[Any, list[Any]]:
+        """Launch default and auxiliary work on separate CUDA streams.
+
+        Runs ``default_fn`` on the current stream and each non-None
+        ``aux_fns[i]`` on ``aux_streams[i]``, synchronizing via CUDA events.
+        ``start_event`` must be recorded before default work begins; each
+        ``done_events[i]`` joins the corresponding aux stream back to the
+        current stream before returning.
+
+        Args:
+            default_fn: Callable for the current (default) stream.
+            aux_fns: Per-aux callables; entries may be None to skip.
+            start_event: Recorded on the current stream to fan out to aux
+                streams.
+            done_events: One event per aux slot, recorded after the aux fn.
+            aux_streams: Per-aux CUDA streams. Length must match ``aux_fns``.
+            queue_aux_before_default: When True, queue aux kernels before
+                ``default_fn`` (``execute_in_parallel`` overlap pattern).
+                When False, run ``default_fn`` first, then queue aux
+                (``maybe_execute_in_parallel`` / LoRA pattern).
+
+        Returns:
+            Tuple of (default_result, aux_results).
+        """
+        assert aux_streams is not None
+        aux_results = [None] * len(aux_fns)
+        pending: list[torch.cuda.Event] = []
+
+        def _launch_aux() -> None:
+            for i, fn in enumerate(aux_fns):
+                if fn is None:
+                    continue
+                with torch.cuda.stream(aux_streams[i]):
+                    start_event.wait()
+                    aux_results[i] = fn()
+                    done_events[i].record()
+                pending.append(done_events[i])
+
+        start_event.record()
+        if queue_aux_before_default:
+            _launch_aux()
+            default_result = default_fn()
+        else:
+            default_result = default_fn()
+            _launch_aux()
+
+        for ev in pending:
+            ev.wait()
+
+        return default_result, aux_results
 
 
 # NVML utils

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -12,7 +12,7 @@ import platform
 from collections.abc import Callable
 from datetime import timedelta
 from functools import cache, lru_cache, wraps
-from typing import TYPE_CHECKING, NamedTuple, TypeVar
+from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
 import torch
 from torch.distributed import PrefixStore, ProcessGroup
@@ -716,6 +716,66 @@ class CudaPlatformBase(Platform):
         except Exception:
             return False
         return major >= 9
+
+    @classmethod
+    def launch_multi_stream(
+        cls,
+        default_fn: Callable[[], Any],
+        aux_fns: list[Callable[[], Any] | None],
+        start_event: torch.cuda.Event,
+        done_events: list[torch.cuda.Event],
+        aux_streams: list[torch.cuda.Stream] | None = None,
+        queue_aux_before_default: bool = False,
+    ) -> tuple[Any, list[Any]]:
+        """Launch default and auxiliary work on separate CUDA streams.
+
+        Runs ``default_fn`` on the current stream and each non-None
+        ``aux_fns[i]`` on ``aux_streams[i]``, synchronizing via CUDA events.
+        ``start_event`` must be recorded before default work begins; each
+        ``done_events[i]`` joins the corresponding aux stream back to the
+        current stream before returning.
+
+        Args:
+            default_fn: Callable for the current (default) stream.
+            aux_fns: Per-aux callables; entries may be None to skip.
+            start_event: Recorded on the current stream to fan out to aux
+                streams.
+            done_events: One event per aux slot, recorded after the aux fn.
+            aux_streams: Per-aux CUDA streams. Length must match ``aux_fns``.
+            queue_aux_before_default: When True, queue aux kernels before
+                ``default_fn`` (``execute_in_parallel`` overlap pattern).
+                When False, run ``default_fn`` first, then queue aux
+                (``maybe_execute_in_parallel`` / LoRA pattern).
+
+        Returns:
+            Tuple of (default_result, aux_results).
+        """
+        assert aux_streams is not None
+        aux_results = [None] * len(aux_fns)
+        pending: list[torch.cuda.Event] = []
+
+        def _launch_aux() -> None:
+            for i, fn in enumerate(aux_fns):
+                if fn is None:
+                    continue
+                with torch.cuda.stream(aux_streams[i]):
+                    start_event.wait()
+                    aux_results[i] = fn()
+                    done_events[i].record()
+                pending.append(done_events[i])
+
+        start_event.record()
+        if queue_aux_before_default:
+            _launch_aux()
+            default_result = default_fn()
+        else:
+            default_result = default_fn()
+            _launch_aux()
+
+        for ev in pending:
+            ev.wait()
+
+        return default_result, aux_results
 
 
 # NVML utils

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -2,9 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import os
+from collections.abc import Callable
 from datetime import timedelta
 from functools import cache, lru_cache, wraps
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import regex as re
 import torch
@@ -1108,3 +1109,78 @@ class RocmPlatform(Platform):
         except Exception as e:
             logger.warning("Failed to get NUMA nodes for GPUs: %s", e)
             return None
+
+    @classmethod
+    def launch_multi_stream(
+        cls,
+        default_fn: Callable[[], Any],
+        aux_fns: list[Callable[[], Any] | None],
+        start_event: torch.cuda.Event,
+        done_events: list[torch.cuda.Event],
+        aux_streams: list[torch.cuda.Stream] | None = None,
+        queue_aux_before_default: bool = False,
+    ) -> tuple[Any, list[Any]]:
+        """Launch default and auxiliary work on separate HIP streams.
+
+        ROCm uses a different sync path than CUDA because the HIP backend is
+        sensitive to cross-stream ordering via bare ``Event.wait()``. DSV4 CSA
+        multistream decode experiments (#43718, #41820) observed deadlocks and
+        hangs with the CUDA-style path; this implementation avoids them by:
+
+        * Using ``Stream.wait_event()`` and stream-qualified ``Event.record()``
+          instead of bare ``Event.wait()`` / ``Event.record()``.
+        * Calling ``Tensor.record_stream()`` on aux results so tensors
+          produced on aux streams remain valid when consumed on the main
+          stream (required under graph capture on ROCm).
+        * Always scheduling ``default_fn`` before aux work. The
+          ``queue_aux_before_default`` flag is accepted for API compatibility
+          with CUDA but ignored on ROCm because aux-first ordering caused
+          hangs in upstream multistream experiments.
+
+        Args:
+            default_fn: Callable for the current (default) stream.
+            aux_fns: Per-aux callables; entries may be None to skip.
+            start_event: Recorded on the current stream to fan out to aux
+                streams.
+            done_events: One event per aux slot, recorded after the aux fn.
+            aux_streams: Per-aux HIP streams. Length must match ``aux_fns``.
+            queue_aux_before_default: Ignored on ROCm; kept for a uniform
+                platform API.
+
+        Returns:
+            Tuple of (default_result, aux_results).
+        """
+        del queue_aux_before_default
+        assert aux_streams is not None
+        aux_results = [None] * len(aux_fns)
+        current_stream = torch.cuda.current_stream()
+        pending: list[tuple[torch.cuda.Event, Any]] = []
+
+        def _record_result_stream(result: Any, stream: torch.cuda.Stream) -> None:
+            if isinstance(result, torch.Tensor):
+                result.record_stream(stream)
+            elif isinstance(result, (tuple, list)):
+                for item in result:
+                    _record_result_stream(item, stream)
+            elif isinstance(result, dict):
+                for item in result.values():
+                    _record_result_stream(item, stream)
+
+        start_event.record(current_stream)
+        default_result = default_fn()
+
+        for i, fn in enumerate(aux_fns):
+            if fn is None:
+                continue
+            aux_stream = aux_streams[i]
+            with torch.cuda.stream(aux_stream):
+                aux_stream.wait_event(start_event)
+                aux_results[i] = fn()
+                done_events[i].record(aux_stream)
+            pending.append((done_events[i], aux_results[i]))
+
+        for ev, result in pending:
+            current_stream.wait_event(ev)
+            _record_result_stream(result, current_stream)
+
+        return default_result, aux_results

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -1122,29 +1122,15 @@ class RocmPlatform(Platform):
     ) -> tuple[Any, list[Any]]:
         """Launch default and auxiliary work on separate HIP streams.
 
-        ROCm uses ``Stream.wait_stream()`` fork-join instead of the CUDA Event
-        sync used by ``CudaPlatformBase.launch_multi_stream``. On HIP, bare
-        ``Event.wait()`` / ``Event.wait_event()`` cross-stream ordering was
-        observed to deadlock during DeepSeek-V4 CSA multistream decode; ATOM's
-        validated DSV4 path (``maybe_compressors_async``,
-        ``dual_stream_moe_forward`` in ``atom/models/deepseek_v4.py``)
-        synchronizes exclusively via ``wait_stream``.
+        Uses ``Stream.wait_stream()`` fork-join instead of CUDA events.
+        On HIP, ``Event.wait()`` / ``Event.wait_event()`` cross-stream
+        ordering is not reliably enforced and can deadlock or hang under
+        multistream overlap, especially during HIP graph capture/replay.
+        Stream-level waits express dependencies directly and are the
+        supported synchronization path on ROCm.
 
-        Why ROCm differs from CUDA:
-
-        * **CUDA** records ``start_event`` on the main stream and joins each
-          aux stream back via ``done_events[i].wait()`` on the main stream.
-        * **ROCm** calls ``aux_stream.wait_stream(current_stream)`` before aux
-          work and ``current_stream.wait_stream(aux_stream)`` before return.
-          ``start_event`` and ``done_events`` are kept for a uniform platform
-          API but are not used on ROCm.
-        * Neither platform needs ``record_stream()`` on aux **outputs** here:
-          both join back to the main stream before returning results. ATOM DSV4
-          and vLLM ``shared_experts`` follow the same rule.
-
-        Side-stream launches should be gated at the call site (for example
-        ATOM's ``forward_context.in_hipgraph``); this method only implements
-        the fork-join primitives.
+        ``start_event`` and ``done_events`` are kept for API compatibility
+        with CUDA but are unused here.
 
         Args:
             default_fn: Callable for the current (default) stream.
@@ -1152,16 +1138,14 @@ class RocmPlatform(Platform):
             start_event: Unused on ROCm; CUDA-path fan-out event.
             done_events: Unused on ROCm; CUDA-path per-aux join events.
             aux_streams: Per-aux HIP streams. Length must match ``aux_fns``.
-            queue_aux_before_default: When True, queue aux before
-                ``default_fn`` (``execute_in_parallel`` / ATOM CSA compressor
-                pattern). When False, run ``default_fn`` first
-                (``maybe_execute_in_parallel`` / ATOM MoE dual-stream
+            queue_aux_before_default: When True, queue aux kernels before
+                ``default_fn`` (``execute_in_parallel`` pattern). When False,
+                run ``default_fn`` first (``maybe_execute_in_parallel``
                 pattern).
 
         Returns:
             Tuple of (default_result, aux_results).
         """
-        _ = (start_event, done_events)
         assert aux_streams is not None
         aux_results = [None] * len(aux_fns)
         current_stream = torch.cuda.current_stream()

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -1122,65 +1122,69 @@ class RocmPlatform(Platform):
     ) -> tuple[Any, list[Any]]:
         """Launch default and auxiliary work on separate HIP streams.
 
-        ROCm uses a different sync path than CUDA because the HIP backend is
-        sensitive to cross-stream ordering via bare ``Event.wait()``. DSV4 CSA
-        multistream decode experiments (#43718, #41820) observed deadlocks and
-        hangs with the CUDA-style path; this implementation avoids them by:
+        ROCm uses ``Stream.wait_stream()`` fork-join instead of the CUDA Event
+        sync used by ``CudaPlatformBase.launch_multi_stream``. On HIP, bare
+        ``Event.wait()`` / ``Event.wait_event()`` cross-stream ordering was
+        observed to deadlock during DeepSeek-V4 CSA multistream decode; ATOM's
+        validated DSV4 path (``maybe_compressors_async``,
+        ``dual_stream_moe_forward`` in ``atom/models/deepseek_v4.py``)
+        synchronizes exclusively via ``wait_stream``.
 
-        * Using ``Stream.wait_event()`` and stream-qualified ``Event.record()``
-          instead of bare ``Event.wait()`` / ``Event.record()``.
-        * Calling ``Tensor.record_stream()`` on aux results so tensors
-          produced on aux streams remain valid when consumed on the main
-          stream (required under graph capture on ROCm).
-        * Always scheduling ``default_fn`` before aux work. The
-          ``queue_aux_before_default`` flag is accepted for API compatibility
-          with CUDA but ignored on ROCm because aux-first ordering caused
-          hangs in upstream multistream experiments.
+        Why ROCm differs from CUDA:
+
+        * **CUDA** records ``start_event`` on the main stream and joins each
+          aux stream back via ``done_events[i].wait()`` on the main stream.
+        * **ROCm** calls ``aux_stream.wait_stream(current_stream)`` before aux
+          work and ``current_stream.wait_stream(aux_stream)`` before return.
+          ``start_event`` and ``done_events`` are kept for a uniform platform
+          API but are not used on ROCm.
+        * Neither platform needs ``record_stream()`` on aux **outputs** here:
+          both join back to the main stream before returning results. ATOM DSV4
+          and vLLM ``shared_experts`` follow the same rule.
+
+        Side-stream launches should be gated at the call site (for example
+        ATOM's ``forward_context.in_hipgraph``); this method only implements
+        the fork-join primitives.
 
         Args:
             default_fn: Callable for the current (default) stream.
             aux_fns: Per-aux callables; entries may be None to skip.
-            start_event: Recorded on the current stream to fan out to aux
-                streams.
-            done_events: One event per aux slot, recorded after the aux fn.
+            start_event: Unused on ROCm; CUDA-path fan-out event.
+            done_events: Unused on ROCm; CUDA-path per-aux join events.
             aux_streams: Per-aux HIP streams. Length must match ``aux_fns``.
-            queue_aux_before_default: Ignored on ROCm; kept for a uniform
-                platform API.
+            queue_aux_before_default: When True, queue aux before
+                ``default_fn`` (``execute_in_parallel`` / ATOM CSA compressor
+                pattern). When False, run ``default_fn`` first
+                (``maybe_execute_in_parallel`` / ATOM MoE dual-stream
+                pattern).
 
         Returns:
             Tuple of (default_result, aux_results).
         """
-        del queue_aux_before_default
+        _ = (start_event, done_events)
         assert aux_streams is not None
         aux_results = [None] * len(aux_fns)
         current_stream = torch.cuda.current_stream()
-        pending: list[tuple[torch.cuda.Event, Any]] = []
+        pending: list[torch.cuda.Stream] = []
 
-        def _record_result_stream(result: Any, stream: torch.cuda.Stream) -> None:
-            if isinstance(result, torch.Tensor):
-                result.record_stream(stream)
-            elif isinstance(result, (tuple, list)):
-                for item in result:
-                    _record_result_stream(item, stream)
-            elif isinstance(result, dict):
-                for item in result.values():
-                    _record_result_stream(item, stream)
+        def _launch_aux() -> None:
+            for i, fn in enumerate(aux_fns):
+                if fn is None:
+                    continue
+                aux_stream = aux_streams[i]
+                aux_stream.wait_stream(current_stream)
+                with torch.cuda.stream(aux_stream):
+                    aux_results[i] = fn()
+                pending.append(aux_stream)
 
-        start_event.record(current_stream)
-        default_result = default_fn()
+        if queue_aux_before_default:
+            _launch_aux()
+            default_result = default_fn()
+        else:
+            default_result = default_fn()
+            _launch_aux()
 
-        for i, fn in enumerate(aux_fns):
-            if fn is None:
-                continue
-            aux_stream = aux_streams[i]
-            with torch.cuda.stream(aux_stream):
-                aux_stream.wait_event(start_event)
-                aux_results[i] = fn()
-                done_events[i].record(aux_stream)
-            pending.append((done_events[i], aux_results[i]))
-
-        for ev, result in pending:
-            current_stream.wait_event(ev)
-            _record_result_stream(result, current_stream)
+        for aux_stream in pending:
+            current_stream.wait_stream(aux_stream)
 
         return default_result, aux_results

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -3,9 +3,10 @@
 
 import os
 import platform
+from collections.abc import Callable
 from datetime import timedelta
 from functools import cache, lru_cache, wraps
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import regex as re
 import torch
@@ -1153,3 +1154,78 @@ class RocmPlatform(Platform):
         except Exception as e:
             logger.warning("Failed to get NUMA nodes for GPUs: %s", e)
             return None
+
+    @classmethod
+    def launch_multi_stream(
+        cls,
+        default_fn: Callable[[], Any],
+        aux_fns: list[Callable[[], Any] | None],
+        start_event: torch.cuda.Event,
+        done_events: list[torch.cuda.Event],
+        aux_streams: list[torch.cuda.Stream] | None = None,
+        queue_aux_before_default: bool = False,
+    ) -> tuple[Any, list[Any]]:
+        """Launch default and auxiliary work on separate HIP streams.
+
+        ROCm uses a different sync path than CUDA because the HIP backend is
+        sensitive to cross-stream ordering via bare ``Event.wait()``. DSV4 CSA
+        multistream decode experiments (#43718, #41820) observed deadlocks and
+        hangs with the CUDA-style path; this implementation avoids them by:
+
+        * Using ``Stream.wait_event()`` and stream-qualified ``Event.record()``
+          instead of bare ``Event.wait()`` / ``Event.record()``.
+        * Calling ``Tensor.record_stream()`` on aux results so tensors
+          produced on aux streams remain valid when consumed on the main
+          stream (required under graph capture on ROCm).
+        * Always scheduling ``default_fn`` before aux work. The
+          ``queue_aux_before_default`` flag is accepted for API compatibility
+          with CUDA but ignored on ROCm because aux-first ordering caused
+          hangs in upstream multistream experiments.
+
+        Args:
+            default_fn: Callable for the current (default) stream.
+            aux_fns: Per-aux callables; entries may be None to skip.
+            start_event: Recorded on the current stream to fan out to aux
+                streams.
+            done_events: One event per aux slot, recorded after the aux fn.
+            aux_streams: Per-aux HIP streams. Length must match ``aux_fns``.
+            queue_aux_before_default: Ignored on ROCm; kept for a uniform
+                platform API.
+
+        Returns:
+            Tuple of (default_result, aux_results).
+        """
+        del queue_aux_before_default
+        assert aux_streams is not None
+        aux_results = [None] * len(aux_fns)
+        current_stream = torch.cuda.current_stream()
+        pending: list[tuple[torch.cuda.Event, Any]] = []
+
+        def _record_result_stream(result: Any, stream: torch.cuda.Stream) -> None:
+            if isinstance(result, torch.Tensor):
+                result.record_stream(stream)
+            elif isinstance(result, (tuple, list)):
+                for item in result:
+                    _record_result_stream(item, stream)
+            elif isinstance(result, dict):
+                for item in result.values():
+                    _record_result_stream(item, stream)
+
+        start_event.record(current_stream)
+        default_result = default_fn()
+
+        for i, fn in enumerate(aux_fns):
+            if fn is None:
+                continue
+            aux_stream = aux_streams[i]
+            with torch.cuda.stream(aux_stream):
+                aux_stream.wait_event(start_event)
+                aux_results[i] = fn()
+                done_events[i].record(aux_stream)
+            pending.append((done_events[i], aux_results[i]))
+
+        for ev, result in pending:
+            current_stream.wait_event(ev)
+            _record_result_stream(result, current_stream)
+
+        return default_result, aux_results

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -1167,65 +1167,69 @@ class RocmPlatform(Platform):
     ) -> tuple[Any, list[Any]]:
         """Launch default and auxiliary work on separate HIP streams.
 
-        ROCm uses a different sync path than CUDA because the HIP backend is
-        sensitive to cross-stream ordering via bare ``Event.wait()``. DSV4 CSA
-        multistream decode experiments (#43718, #41820) observed deadlocks and
-        hangs with the CUDA-style path; this implementation avoids them by:
+        ROCm uses ``Stream.wait_stream()`` fork-join instead of the CUDA Event
+        sync used by ``CudaPlatformBase.launch_multi_stream``. On HIP, bare
+        ``Event.wait()`` / ``Event.wait_event()`` cross-stream ordering was
+        observed to deadlock during DeepSeek-V4 CSA multistream decode; ATOM's
+        validated DSV4 path (``maybe_compressors_async``,
+        ``dual_stream_moe_forward`` in ``atom/models/deepseek_v4.py``)
+        synchronizes exclusively via ``wait_stream``.
 
-        * Using ``Stream.wait_event()`` and stream-qualified ``Event.record()``
-          instead of bare ``Event.wait()`` / ``Event.record()``.
-        * Calling ``Tensor.record_stream()`` on aux results so tensors
-          produced on aux streams remain valid when consumed on the main
-          stream (required under graph capture on ROCm).
-        * Always scheduling ``default_fn`` before aux work. The
-          ``queue_aux_before_default`` flag is accepted for API compatibility
-          with CUDA but ignored on ROCm because aux-first ordering caused
-          hangs in upstream multistream experiments.
+        Why ROCm differs from CUDA:
+
+        * **CUDA** records ``start_event`` on the main stream and joins each
+          aux stream back via ``done_events[i].wait()`` on the main stream.
+        * **ROCm** calls ``aux_stream.wait_stream(current_stream)`` before aux
+          work and ``current_stream.wait_stream(aux_stream)`` before return.
+          ``start_event`` and ``done_events`` are kept for a uniform platform
+          API but are not used on ROCm.
+        * Neither platform needs ``record_stream()`` on aux **outputs** here:
+          both join back to the main stream before returning results. ATOM DSV4
+          and vLLM ``shared_experts`` follow the same rule.
+
+        Side-stream launches should be gated at the call site (for example
+        ATOM's ``forward_context.in_hipgraph``); this method only implements
+        the fork-join primitives.
 
         Args:
             default_fn: Callable for the current (default) stream.
             aux_fns: Per-aux callables; entries may be None to skip.
-            start_event: Recorded on the current stream to fan out to aux
-                streams.
-            done_events: One event per aux slot, recorded after the aux fn.
+            start_event: Unused on ROCm; CUDA-path fan-out event.
+            done_events: Unused on ROCm; CUDA-path per-aux join events.
             aux_streams: Per-aux HIP streams. Length must match ``aux_fns``.
-            queue_aux_before_default: Ignored on ROCm; kept for a uniform
-                platform API.
+            queue_aux_before_default: When True, queue aux before
+                ``default_fn`` (``execute_in_parallel`` / ATOM CSA compressor
+                pattern). When False, run ``default_fn`` first
+                (``maybe_execute_in_parallel`` / ATOM MoE dual-stream
+                pattern).
 
         Returns:
             Tuple of (default_result, aux_results).
         """
-        del queue_aux_before_default
+        _ = (start_event, done_events)
         assert aux_streams is not None
         aux_results = [None] * len(aux_fns)
         current_stream = torch.cuda.current_stream()
-        pending: list[tuple[torch.cuda.Event, Any]] = []
+        pending: list[torch.cuda.Stream] = []
 
-        def _record_result_stream(result: Any, stream: torch.cuda.Stream) -> None:
-            if isinstance(result, torch.Tensor):
-                result.record_stream(stream)
-            elif isinstance(result, (tuple, list)):
-                for item in result:
-                    _record_result_stream(item, stream)
-            elif isinstance(result, dict):
-                for item in result.values():
-                    _record_result_stream(item, stream)
+        def _launch_aux() -> None:
+            for i, fn in enumerate(aux_fns):
+                if fn is None:
+                    continue
+                aux_stream = aux_streams[i]
+                aux_stream.wait_stream(current_stream)
+                with torch.cuda.stream(aux_stream):
+                    aux_results[i] = fn()
+                pending.append(aux_stream)
 
-        start_event.record(current_stream)
-        default_result = default_fn()
+        if queue_aux_before_default:
+            _launch_aux()
+            default_result = default_fn()
+        else:
+            default_result = default_fn()
+            _launch_aux()
 
-        for i, fn in enumerate(aux_fns):
-            if fn is None:
-                continue
-            aux_stream = aux_streams[i]
-            with torch.cuda.stream(aux_stream):
-                aux_stream.wait_event(start_event)
-                aux_results[i] = fn()
-                done_events[i].record(aux_stream)
-            pending.append((done_events[i], aux_results[i]))
-
-        for ev, result in pending:
-            current_stream.wait_event(ev)
-            _record_result_stream(result, current_stream)
+        for aux_stream in pending:
+            current_stream.wait_stream(aux_stream)
 
         return default_result, aux_results

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -1167,29 +1167,15 @@ class RocmPlatform(Platform):
     ) -> tuple[Any, list[Any]]:
         """Launch default and auxiliary work on separate HIP streams.
 
-        ROCm uses ``Stream.wait_stream()`` fork-join instead of the CUDA Event
-        sync used by ``CudaPlatformBase.launch_multi_stream``. On HIP, bare
-        ``Event.wait()`` / ``Event.wait_event()`` cross-stream ordering was
-        observed to deadlock during DeepSeek-V4 CSA multistream decode; ATOM's
-        validated DSV4 path (``maybe_compressors_async``,
-        ``dual_stream_moe_forward`` in ``atom/models/deepseek_v4.py``)
-        synchronizes exclusively via ``wait_stream``.
+        Uses ``Stream.wait_stream()`` fork-join instead of CUDA events.
+        On HIP, ``Event.wait()`` / ``Event.wait_event()`` cross-stream
+        ordering is not reliably enforced and can deadlock or hang under
+        multistream overlap, especially during HIP graph capture/replay.
+        Stream-level waits express dependencies directly and are the
+        supported synchronization path on ROCm.
 
-        Why ROCm differs from CUDA:
-
-        * **CUDA** records ``start_event`` on the main stream and joins each
-          aux stream back via ``done_events[i].wait()`` on the main stream.
-        * **ROCm** calls ``aux_stream.wait_stream(current_stream)`` before aux
-          work and ``current_stream.wait_stream(aux_stream)`` before return.
-          ``start_event`` and ``done_events`` are kept for a uniform platform
-          API but are not used on ROCm.
-        * Neither platform needs ``record_stream()`` on aux **outputs** here:
-          both join back to the main stream before returning results. ATOM DSV4
-          and vLLM ``shared_experts`` follow the same rule.
-
-        Side-stream launches should be gated at the call site (for example
-        ATOM's ``forward_context.in_hipgraph``); this method only implements
-        the fork-join primitives.
+        ``start_event`` and ``done_events`` are kept for API compatibility
+        with CUDA but are unused here.
 
         Args:
             default_fn: Callable for the current (default) stream.
@@ -1197,16 +1183,14 @@ class RocmPlatform(Platform):
             start_event: Unused on ROCm; CUDA-path fan-out event.
             done_events: Unused on ROCm; CUDA-path per-aux join events.
             aux_streams: Per-aux HIP streams. Length must match ``aux_fns``.
-            queue_aux_before_default: When True, queue aux before
-                ``default_fn`` (``execute_in_parallel`` / ATOM CSA compressor
-                pattern). When False, run ``default_fn`` first
-                (``maybe_execute_in_parallel`` / ATOM MoE dual-stream
+            queue_aux_before_default: When True, queue aux kernels before
+                ``default_fn`` (``execute_in_parallel`` pattern). When False,
+                run ``default_fn`` first (``maybe_execute_in_parallel``
                 pattern).
 
         Returns:
             Tuple of (default_result, aux_results).
         """
-        _ = (start_event, done_events)
         assert aux_streams is not None
         aux_results = [None] * len(aux_fns)
         current_stream = torch.cuda.current_stream()

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -1156,6 +1156,21 @@ class RocmPlatform(Platform):
             return None
 
     @classmethod
+    def set_additional_forward_context(cls, *args, **kwargs) -> dict[str, Any]:
+        """Cache the current HIP stream once per forward pass.
+
+        Called once per ``set_forward_context()`` invocation (i.e. once per
+        forward) while the ambient current stream is that forward's logical
+        "main" stream: the worker compute stream at runtime, and the capture
+        stream inside ``graph_capture()``. ``launch_multi_stream`` reads
+        this cached handle so every fork/join edge binds to the same stream
+        object, keeping the stream DAG statically reason-able and avoiding
+        per-call ``torch.cuda.current_stream()`` queries that widen the HIP
+        stream handle pool.
+        """
+        return {"main_stream": torch.cuda.current_stream()}
+
+    @classmethod
     def launch_multi_stream(
         cls,
         default_fn: Callable[[], Any],
@@ -1173,6 +1188,14 @@ class RocmPlatform(Platform):
         multistream overlap, especially during HIP graph capture/replay.
         Stream-level waits express dependencies directly and are the
         supported synchronization path on ROCm.
+
+        The main stream is fetched from the forward context cache
+        (``additional_kwargs["main_stream"]``, populated once per forward
+        by ``set_additional_forward_context``) so all fork/join edges bind
+        to a single stream handle. During HIP graph capture the cached
+        stream equals the capture stream, so the fork/join edges are
+        recorded into the graph correctly. Falls back to
+        ``torch.cuda.current_stream()`` when no forward context is set.
 
         ``start_event`` and ``done_events`` are kept for API compatibility
         with CUDA but are unused here.
@@ -1193,7 +1216,18 @@ class RocmPlatform(Platform):
         """
         assert aux_streams is not None
         aux_results = [None] * len(aux_fns)
-        current_stream = torch.cuda.current_stream()
+
+        from vllm.forward_context import (
+            get_forward_context,
+            is_forward_context_available,
+        )
+
+        current_stream = None
+        if is_forward_context_available():
+            current_stream = get_forward_context().additional_kwargs.get("main_stream")
+        if current_stream is None:
+            current_stream = torch.cuda.current_stream()
+
         pending: list[torch.cuda.Stream] = []
 
         def _launch_aux() -> None:

--- a/vllm/utils/multi_stream_utils.py
+++ b/vllm/utils/multi_stream_utils.py
@@ -7,6 +7,8 @@ from typing import Any
 
 import torch
 
+from vllm.platforms import current_platform
+
 
 class EventType(Enum):
     Main = 0
@@ -49,16 +51,20 @@ def maybe_execute_in_parallel(
             aux_stream = None
 
     if aux_stream is not None:
-        event0.record()
-        result0 = fn0()
-        with torch.cuda.stream(aux_stream):
-            event0.wait()
-            result1 = fn1()
-            event1.record()
-        event1.wait()
+        default_result, aux_results = current_platform.launch_multi_stream(
+            default_fn=fn0,
+            aux_fns=[fn1],
+            start_event=event0,
+            done_events=[event1],
+            aux_streams=[aux_stream],
+            queue_aux_before_default=False,
+        )
+        result0 = default_result
+        result1 = aux_results[0]
     else:
         result0 = fn0()
         result1 = fn1()
+
     return (result0, result1)
 
 
@@ -111,22 +117,13 @@ def execute_in_parallel(
         "aux_fns, aux_streams, and done_events must be the same length"
     )
 
-    aux_results = [None] * len(aux_fns)
-    pending: list[torch.cuda.Event] = []
-
-    start_event.record()
-    for i, fn in enumerate(aux_fns):
-        if fn is None:
-            continue
-        with torch.cuda.stream(aux_streams[i]):
-            start_event.wait()
-            aux_results[i] = fn()
-            done_events[i].record()
-        pending.append(done_events[i])
-
-    default_result = default_fn()
-
-    for ev in pending:
-        ev.wait()
+    default_result, aux_results = current_platform.launch_multi_stream(
+        default_fn,
+        aux_fns,
+        start_event,
+        done_events,
+        aux_streams,
+        queue_aux_before_default=True,
+    )
 
     return default_result, aux_results


### PR DESCRIPTION
## Purpose

> Part of https://github.com/vllm-project/vllm/issues/41820, continue working on https://github.com/vllm-project/vllm/pull/43718.

Split multi-stream launch and sync semantics out of `vllm/utils/multi_stream_utils.py` into platform-specific `launch_multi_stream()` implementations on `CudaPlatformBase` and `RocmPlatform`. This addresses [#43718 comment by @zyongye](https://github.com/vllm-project/vllm/pull/43718) to avoid embedding CUDA/ROCm divergence in shared utility code.

- **CUDA** (`CudaPlatformBase.launch_multi_stream`): Uses standard `Event.wait()` / `Event.record()` with configurable launch ordering via `queue_aux_before_default`. `execute_in_parallel` queues aux work before the default callable (preserving the original DeepSeek-V4 input-GEMM overlap pattern); `maybe_execute_in_parallel` runs the default callable first (LoRA / two-way overlap pattern).
- **ROCm** (`RocmPlatform.launch_multi_stream`): Uses `Stream.wait_stream()` fork-join instead of CUDA Event-based cross-stream ordering. This follows the validated ATOM DeepSeek-V4 CSA pattern (`maybe_compressors_async`, `dual_stream_moe_forward` in `atom/models/deepseek_v4.py`), which avoids deadlocks/hangs observed with bare `Event.wait()` / `Event.wait_event()` on HIP during DSV4 multistream decode ([#41820](https://github.com/vllm-project/vllm/issues/41820)). `start_event` and `done_events` are kept for a uniform platform API but are unused on ROCm.

This PR is a **platform refactor only**; it does not re-enable DSV4 ROCm multistream in `deepseek_v4/amd/model.py` (follow-up PR).

## Test Plan

```bash
pytest -sv tests/utils/test_multi_stream_utils.py
pytest -sv tests/v1/cudagraph/test_breakable_cudagraph.py::test_eager_attention_inside_multistream_overlap
```

## Test Result

```bash
# tests/utils/test_multi_stream_utils.py
2 passed, 14 warnings in 1.51s

# tests/v1/cudagraph/test_breakable_cudagraph.py::test_eager_attention_inside_multistream_overlap
1 passed, 14 warnings in 1.19s
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

