### PR TITLE
fix: fuse weightless RMSNorms at their declared width

### DIFF
--- a/tests/models/transformers/fusers/test_rms_norm.py
+++ b/tests/models/transformers/fusers/test_rms_norm.py
@@ -12,8 +12,6 @@ import torch.nn.functional as F
 from vllm.model_executor.models.transformers.fuser import get_fuser
 from vllm.model_executor.models.transformers.fusers import RMSNormFuser
 
-pytestmark = pytest.mark.skip_global_cleanup
-
 
 class RMSNorm(nn.Module):
     """The canonical HF RMSNorm: `weight * x * rsqrt(mean(x**2) + eps)`."""
@@ -148,56 +146,39 @@ def test_rms_norm_builds_vllm_class(cls, expected, zero_centered, default_vllm_c
     from vllm.model_executor.layers.layernorm import GemmaRMSNorm as VLLMGemmaRMSNorm
     from vllm.model_executor.layers.layernorm import RMSNorm as VLLMRMSNorm
 
-    # `default_vllm_config` supplies the config context the CustomOp needs; the
-    # weightless path reads hidden size from the model config, so stub it.
-    vllm_config = SimpleNamespace(
-        model_config=SimpleNamespace(get_hidden_size=lambda: 16)
-    )
     with torch.device("meta"):
         module = cls()
         fuser = get_fuser(module)
-        built = fuser.fuse(module, "norm", vllm_config)
+        built = fuser.fuse(module, "norm", default_vllm_config)
     from vllm.model_executor.models.transformers.fusers.rms_norm import (
         TPAwareNormMixin,
     )
 
     types_by_name = {"RMSNorm": VLLMRMSNorm, "GemmaRMSNorm": VLLMGemmaRMSNorm}
     assert isinstance(built, types_by_name[expected])
-    assert isinstance(built, TPAwareNormMixin)  # fused norms self-correct under TP
+    assert isinstance(built, TPAwareNormMixin)
     assert built.variance_epsilon == module.variance_epsilon
-    assert isinstance(built.weight, nn.Parameter) == (
-        getattr(module, "weight", None) is not None
-    )
+    # The weight states the hidden size (and is what the TP check reads); a norm
+    # without one has none to state.
+    weight = getattr(module, "weight", None)
+    assert isinstance(built.weight, nn.Parameter) == (weight is not None)
+    assert built.weight.shape[0] == (weight.size(0) if weight is not None else 0)
 
 
-def test_weightless_norm_keeps_its_own_width(default_vllm_config):
-    """A weightless norm fuses at its declared width, not the model's (LM)
-    hidden size — the mismatch reported in #39061 (5376 vs 72)."""
-    from vllm.model_executor.layers.layernorm import RMSNorm as VLLMRMSNorm
+def test_weightless_norm_has_no_hidden_size(default_vllm_config):
+    """A weightless norm states no hidden size, and the model's (LM) hidden size
+    would be wrong for one on a sub-dimension: Llama 4's `qk_norm` normalizes
+    head_dim, so sizing it at hidden_size made the TP gather reject its input.
+    It fuses with none, and so normalizes the width it is given at any TP size,
+    matching the unfused norm and vLLM's native `RMSNorm(hidden_size=head_dim)`.
+    """
+    module = WeightlessRMSNorm(72)
+    built = get_fuser(module).fuse(module, "norm", default_vllm_config)
+    assert built.hidden_size == 0
 
-    class WeightlessNorm(nn.Module):
-        def __init__(self, width: int, eps: float = 1e-6):
-            super().__init__()
-            self.normalized_shape = (width,)
-            self.variance_epsilon = eps
-
-        def forward(self, x):
-            return x * torch.rsqrt(
-                x.pow(2).mean(-1, keepdim=True) + self.variance_epsilon
-            )
-
-    # Model config reports the LM hidden size (5376); the norm is a sub-dim.
-    vllm_config = SimpleNamespace(
-        model_config=SimpleNamespace(get_hidden_size=lambda: 5376)
-    )
-    with torch.device("meta"):
-        module = WeightlessNorm(72)
-        fuser = get_fuser(module)
-        assert isinstance(fuser, RMSNormFuser)
-        built = fuser.fuse(module, "norm", vllm_config)
-    assert isinstance(built, VLLMRMSNorm)
-    assert built.hidden_size == 72
-    assert not isinstance(built.weight, nn.Parameter)
+    built.tp_size = 2  # emulate TP=2 without a real process group
+    x = torch.randn(4, 72)
+    torch.testing.assert_close(built(x), module(x))
 
 
 def test_fused_rms_norm_op_default_eps(default_vllm_config):
@@ -210,8 +191,7 @@ def test_fused_rms_norm_op_default_eps(default_vllm_config):
         fuser = get_fuser(module)
         assert isinstance(fuser, RMSNormFuser)
         assert not fuser.zero_centered
-        mc = SimpleNamespace(get_hidden_size=lambda: 16, dtype=torch.float32)
-        vllm_config = SimpleNamespace(model_config=mc)
+        vllm_config = SimpleNamespace(model_config=SimpleNamespace(dtype=torch.float32))
         built = fuser.fuse(module, "norm", vllm_config)
     assert isinstance(built, VLLMRMSNorm)
     assert built.variance_epsilon == torch.finfo(torch.float32).eps
@@ -220,18 +200,15 @@ def test_fused_rms_norm_op_default_eps(default_vllm_config):
 def test_eps_is_derived_per_instance(default_vllm_config):
     """Two instances of the same norm class with different eps must fuse to their
     own eps: the type-cached fuser holds only structure, not this value."""
-    vllm_config = SimpleNamespace(
-        model_config=SimpleNamespace(get_hidden_size=lambda: 16)
-    )
     with torch.device("meta"):
         for eps in (1e-5, 1e-6):
             module = RMSNorm(16, eps=eps)
-            built = get_fuser(module).fuse(module, "norm", vllm_config)
+            built = get_fuser(module).fuse(module, "norm", default_vllm_config)
             assert built.variance_epsilon == eps
 
 
 def test_fused_norm_is_gather_capable(default_vllm_config):
-    """Every fused norm is emitted gather-capable, so a norm on a head-sharded
+    """Every weighted fused norm is emitted gather-capable, so a norm on a head-sharded
     projection (OLMoE-style) self-corrects at runtime with no QKV-specific
     plumbing. A full-width input skips the gather and equals a plain norm."""
     from vllm.model_executor.layers.layernorm import GemmaRMSNorm, RMSNorm

--- a/tests/models/transformers/fusers/test_rms_norm.py
+++ b/tests/models/transformers/fusers/test_rms_norm.py
@@ -12,6 +12,8 @@ import torch.nn.functional as F
 from vllm.model_executor.models.transformers.fuser import get_fuser
 from vllm.model_executor.models.transformers.fusers import RMSNormFuser
 
+pytestmark = pytest.mark.skip_global_cleanup
+
 
 class RMSNorm(nn.Module):
     """The canonical HF RMSNorm: `weight * x * rsqrt(mean(x**2) + eps)`."""
@@ -166,6 +168,36 @@ def test_rms_norm_builds_vllm_class(cls, expected, zero_centered, default_vllm_c
     assert isinstance(built.weight, nn.Parameter) == (
         getattr(module, "weight", None) is not None
     )
+
+
+def test_weightless_norm_keeps_its_own_width(default_vllm_config):
+    """A weightless norm fuses at its declared width, not the model's (LM)
+    hidden size — the mismatch reported in #39061 (5376 vs 72)."""
+    from vllm.model_executor.layers.layernorm import RMSNorm as VLLMRMSNorm
+
+    class WeightlessNorm(nn.Module):
+        def __init__(self, width: int, eps: float = 1e-6):
+            super().__init__()
+            self.normalized_shape = (width,)
+            self.variance_epsilon = eps
+
+        def forward(self, x):
+            return x * torch.rsqrt(
+                x.pow(2).mean(-1, keepdim=True) + self.variance_epsilon
+            )
+
+    # Model config reports the LM hidden size (5376); the norm is a sub-dim.
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(get_hidden_size=lambda: 5376)
+    )
+    with torch.device("meta"):
+        module = WeightlessNorm(72)
+        fuser = get_fuser(module)
+        assert isinstance(fuser, RMSNormFuser)
+        built = fuser.fuse(module, "norm", vllm_config)
+    assert isinstance(built, VLLMRMSNorm)
+    assert built.hidden_size == 72
+    assert not isinstance(built.weight, nn.Parameter)
 
 
 def test_fused_rms_norm_op_default_eps(default_vllm_config):

--- a/vllm/model_executor/models/transformers/fusers/rms_norm.py
+++ b/vllm/model_executor/models/transformers/fusers/rms_norm.py
@@ -75,18 +75,6 @@ def _has_trailing_compute(graph: fx.Graph, node: fx.Node) -> bool:
     return value is not None and peel(value) is not node
 
 
-def _declared_hidden_size(module: nn.Module) -> int | None:
-    """Hidden size a weightless norm declares on itself, or `None`."""
-    for attr in ("normalized_shape", "hidden_size", "dim"):
-        value = getattr(module, attr, None)
-        if isinstance(value, (tuple, list)):
-            if value:
-                return int(value[-1])
-        elif isinstance(value, int) and value > 0:
-            return value
-    return None
-
-
 class TPAwareNormMixin(nn.Module):
     """Mixin for RMSNorms that reconstructs a TP-sharded input before normalizing."""
 
@@ -202,25 +190,17 @@ class RMSNormFuser(BaseFuser):
         self, module: nn.Module, prefix: str, vllm_config: "VllmConfig"
     ) -> nn.Module:
         """Fuse the matched RMSNorm pattern into a vLLM fused RMSNorm CustomOp."""
-        model_config = vllm_config.model_config
         weight = getattr(module, "weight", None)
-        if weight is not None:
-            hidden_size = weight.size(0)
-        else:
-            hidden_size = _declared_hidden_size(module)
-            if hidden_size is None:
-                # Last resort: the LM hidden size is wrong for norms on a
-                # sub-dimension (e.g. a vision encoder's head-dim norm).
-                hidden_size = model_config.get_hidden_size()
+        has_weight = weight is not None
+        hidden_size = weight.size(0) if has_weight else 0
         graph = trace(module)
         eps = self._eps_from_graph(graph) if graph is not None else None
         if eps is None:
             # If eps not in graph, match torch behaviour.
-            dtype = weight.dtype if weight is not None else model_config.dtype
+            dtype = weight.dtype if has_weight else vllm_config.model_config.dtype
             eps = torch.finfo(dtype).eps
         if self.zero_centered:
             return TPAwareGemmaRMSNorm(hidden_size=hidden_size, eps=eps)
-        has_weight = weight is not None
         return TPAwareRMSNorm(
             hidden_size=hidden_size,
             eps=eps,

--- a/vllm/model_executor/models/transformers/fusers/rms_norm.py
+++ b/vllm/model_executor/models/transformers/fusers/rms_norm.py
@@ -75,6 +75,18 @@ def _has_trailing_compute(graph: fx.Graph, node: fx.Node) -> bool:
     return value is not None and peel(value) is not node
 
 
+def _declared_hidden_size(module: nn.Module) -> int | None:
+    """Hidden size a weightless norm declares on itself, or `None`."""
+    for attr in ("normalized_shape", "hidden_size", "dim"):
+        value = getattr(module, attr, None)
+        if isinstance(value, (tuple, list)):
+            if value:
+                return int(value[-1])
+        elif isinstance(value, int) and value > 0:
+            return value
+    return None
+
+
 class TPAwareNormMixin(nn.Module):
     """Mixin for RMSNorms that reconstructs a TP-sharded input before normalizing."""
 
@@ -192,9 +204,14 @@ class RMSNormFuser(BaseFuser):
         """Fuse the matched RMSNorm pattern into a vLLM fused RMSNorm CustomOp."""
         model_config = vllm_config.model_config
         weight = getattr(module, "weight", None)
-        hidden_size = (
-            weight.size(0) if weight is not None else model_config.get_hidden_size()
-        )
+        if weight is not None:
+            hidden_size = weight.size(0)
+        else:
+            hidden_size = _declared_hidden_size(module)
+            if hidden_size is None:
+                # Last resort: the LM hidden size is wrong for norms on a
+                # sub-dimension (e.g. a vision encoder's head-dim norm).
+                hidden_size = model_config.get_hidden_size()
         graph = trace(module)
         eps = self._eps_from_graph(graph) if graph is not None else None
         if eps is None:


### PR DESCRIPTION
## Summary

`RMSNormFuser.fuse()` sizes a weightless norm (one without a `weight`
parameter) from `model_config.get_hidden_size()`. That is the LM hidden
size and is wrong for norms on a sub-dimension — the exact mismatch in
#39061, where a 72-wide vision-encoder norm was fused at 5376.

The fused norm's `weight` buffer is only used to size the norm and to
drive the TP-shard gather in `TPAwareNormMixin`. With the wrong width:
- a dead buffer of the wrong size is allocated, and
- under TP>1, `forward` rejects the valid shard with
  "Cannot gather norm of width 5376..." (because `shard*TP != 5376`).

## Change

In `RMSNormFuser.fuse()`, a weightless norm now reads the width the
module declares on itself (`normalized_shape`, `hidden_size`, or `dim`)
before falling back to the model config as the last resort.

No model output changes at TP=1: when `has_weight=False` the op is
passed `weight=None` (layernorm.py) and normalizes over the input's
last dim regardless of the buffer. This only corrects the buffer width
and makes the TP>1 gather correct for sub-dimension norms.

## Why not a duplicate

Searched open PRs for `39061` and weightless-RMSNorm fuser fixes: none.
#39061 is still open; this fixes the latent form of the reported
mismatch in the shared transformers-backend fuser.

## Tests

- `pytest tests/models/transformers/fusers/test_rms_norm.py -q`
  -> `19 passed` (18 existing + new `test_weightless_norm_keeps_its_own_width`).
- `ruff check` and `ruff format --check` clean on both changed files.
- mypy: only pre-existing errors (verified against unmodified HEAD).

No end-to-end model eval was run: the fix touches no numerics at TP=1
and requires GPU + weights not available here; the regression test
guards the reported mismatch directly.

AI assistance was used to draft this PR.