### PR TITLE
[Bugfix][R3] Size monolithic routing replay buffer for DP

### DIFF
--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -1030,15 +1030,11 @@ class FusedMoEExpertsMonolithic(FusedMoEExperts):
         if capture_fn is None:
             self._routing_replay_buffer = None
             return
-        # Naive DP and DP+EP prepare paths all-gather per-rank batches before
-        # invoking the monolithic kernel. ``max_num_tokens`` is the scheduler
-        # limit for one rank, so the replay output must cover the largest
-        # dispatch group rather than only the local batch. Under EP that group
-        # can also contain sequence-parallel shards flattened into the EP
-        # group, including padding.
-        dispatch_group_size = max(
-            self.moe_config.dp_size,
-            self.moe_config.ep_size,
+        # Allocate for per-rank batches gathered across the DP or EP group.
+        dispatch_group_size = (
+            self.moe_config.ep_size
+            if self.moe_config.use_ep
+            else self.moe_config.dp_size
         )
         max_num_replay_tokens = self.moe_config.max_num_tokens * dispatch_group_size
         self._routing_replay_buffer = torch.empty(

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -1031,7 +1031,10 @@ class FusedMoEExpertsMonolithic(FusedMoEExperts):
             self._routing_replay_buffer = None
             return
         self._routing_replay_buffer = torch.empty(
-            (self.moe_config.max_num_tokens, self.moe_config.experts_per_token),
+            (
+                self.moe_config.max_num_tokens * self.moe_config.dp_size,
+                self.moe_config.experts_per_token,
+            ),
             dtype=torch.int16,
             device=self.moe_config.device,
         )

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -1030,11 +1030,19 @@ class FusedMoEExpertsMonolithic(FusedMoEExperts):
         if capture_fn is None:
             self._routing_replay_buffer = None
             return
+        # Naive DP and DP+EP prepare paths all-gather per-rank batches before
+        # invoking the monolithic kernel. ``max_num_tokens`` is the scheduler
+        # limit for one rank, so the replay output must cover the largest
+        # dispatch group rather than only the local batch. Under EP that group
+        # can also contain sequence-parallel shards flattened into the EP
+        # group, including padding.
+        dispatch_group_size = max(
+            self.moe_config.dp_size,
+            self.moe_config.ep_size,
+        )
+        max_num_replay_tokens = self.moe_config.max_num_tokens * dispatch_group_size
         self._routing_replay_buffer = torch.empty(
-            (
-                self.moe_config.max_num_tokens * self.moe_config.dp_size,
-                self.moe_config.experts_per_token,
-            ),
+            (max_num_replay_tokens, self.moe_config.experts_per_token),
             dtype=torch.int16,
             device=self.moe_config.device,
         )

--- a/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py
@@ -120,15 +120,20 @@ class RoutedExpertsCapturer:
     def capture(self, layer_id: int, topk_ids: torch.Tensor) -> None:
         """Capture expert routing decisions for a specific layer.
 
-        Under data parallelism, ``topk_ids`` may have three different batch
+        Under data parallelism, ``topk_ids`` may have four different batch
         layouts depending on where the DP combine happens and whether
-        Sequence Parallelism (SP) is active for the MoE layer:
+        Expert Parallelism (EP) or Sequence Parallelism (SP) is active for the
+        MoE layer:
           - ``n == total`` (naive dispatch): all DP ranks' tokens are
             concatenated before routing; we slice out this rank's span
             using the cumulative per-rank counts.
           - ``n == token_num_per_dp`` (modular-kernel path): DP combine
             happens inside ``quant_method.apply``; ``select_experts`` only
             ever sees this rank's tokens, so we take the whole tensor.
+          - ``n == sum(dp_metadata.local_sizes)`` (naive DP+EP dispatch):
+            sequence-parallel shards from every DP rank are gathered through
+            the flattened EP group. The shard sizes include CUDA-graph / SP
+            padding, so we use them to locate this DP rank's unpadded rows.
           - ``n == ceil(token_num_per_dp / tp_size)`` (SP + modular-kernel
             path): tokens were split along dim=0 across the TP group by
             ``_sequence_parallel_context``
@@ -155,6 +160,8 @@ class RoutedExpertsCapturer:
             token_num_per_dp = int(num_tokens_dp[self.dp_rank].item())
             total = int(num_tokens_dp.sum().item())
             n = topk_ids.shape[0]
+            shard_sizes = getattr(ctx.dp_metadata, "local_sizes", None)
+            gathered_size = sum(shard_sizes) if shard_sizes is not None else -1
 
             if n == total:
                 # Naive dispatch: all DP ranks' tokens concatenated
@@ -169,6 +176,17 @@ class RoutedExpertsCapturer:
                 # rank's tokens, take the whole tensor.
                 start_loc = 0
                 end_loc = token_num_per_dp
+            elif shard_sizes is not None and n == gathered_size:
+                # Naive DP+EP dispatch gathers the sequence-parallel shards in
+                # flattened DP-then-TP order. ``local_sizes`` is the exact
+                # all-gatherv layout, including padding. Select this DP rank's
+                # contiguous shard group, then trim its trailing padding.
+                num_dp_ranks = len(num_tokens_dp)
+                assert len(shard_sizes) % num_dp_ranks == 0
+                shards_per_dp_rank = len(shard_sizes) // num_dp_ranks
+                first_shard = self.dp_rank * shards_per_dp_rank
+                start_loc = sum(shard_sizes[:first_shard])
+                end_loc = start_loc + token_num_per_dp
             elif (
                 self.tp_size > 1
                 and n != token_num_per_dp
@@ -201,8 +219,8 @@ class RoutedExpertsCapturer:
                 raise AssertionError(
                     "RoutedExpertsCapturer: unexpected topk_ids batch "
                     f"dim {n} (expected {total}, {token_num_per_dp}, "
-                    f"or {sp_expected} for dp_rank={self.dp_rank}, "
-                    f"tp_size={self.tp_size})"
+                    f"{gathered_size}, or {sp_expected} for "
+                    f"dp_rank={self.dp_rank}, tp_size={self.tp_size})"
                 )
 
         # Defensive: model may expose more layers than the capture buffer


### PR DESCRIPTION
## Purpose

Fix routing-replay capture for the FlashInfer monolithic MoE kernel under naive
data parallelism, including padded sequence-parallel shards when expert
parallelism is enabled.

Two related assumptions fail in a TP2/DP2 deployment:

1. **Replay buffer capacity.** `max_num_tokens` is a per-rank scheduler limit,
   while the naive dispatch path all-gathers rank-local batches before invoking
   the monolithic kernel. This produced an 8192-row replay buffer for a
   16384-row kernel input and failed during warmup. The buffer is now sized for
   the larger of the DP and EP dispatch groups, since under EP the gathered
   batch is the flattened EP group rather than the DP group.

2. **Gathered shard layout.** Under DP+EP, `topk_ids` can contain gathered
   sequence-parallel shards whose `dp_metadata.local_sizes` include
   CUDA-graph/SP padding. Those rows do not match the unpadded per-DP token
   counts used by the existing capture paths, so the batch-dimension assertion
   fired. When the gathered tensor matches `sum(local_sizes)`, we locate the
   current DP rank's contiguous shard group using that exact all-gatherv layout
   and copy only its real token count, trimming trailing padding.

Existing naive-DP, modular-local, and modular-SP layouts are unchanged, and no
routing or model-output semantics change.

## Duplicate check

I searched open upstream PRs for `routing replay buffer`, `routed experts
capture`, `routing replay all-gather`, and `local_sizes routing`; none fixes
this allocation or the padded-shard capture:

- #48698 scales a separate FlashInfer B12x MoE workspace and does not touch the
  routing replay output added by #44214.
- #50940 also edits `routed_experts_capturer.py`, but only the shape
  configuration; it leaves the `capture()` batch-layout branches alone.
- #50759 skips MoE padding inside the router implementations, upstream of the
  gathered-batch layout handled here.

## Validation

- `git diff --check`: passed
- vLLM pre-commit on the changed files, run in the repo's Python 3.12 venv:
  Ruff check/format, `mypy-3.10`, typos, SPDX, root-lazy-import,
  forbidden-import, torch-CUDA-API, config-validation, and sign-off hooks all
  passed. (Under a host Python 3.9 two of these hooks crash on 3.10+ syntax;
  that is an environment artifact, not a finding.)
- Runtime validation of the exact TP2/DP2+EP default-backend configuration was
  run on the corresponding branch of my fork on GB200: mixed and decode
  CUDA-graph capture completed, both API servers started, and a
  `/v1/completions` request was served with routed-experts capture enabled. The
  original routing batch-dimension assertion did not fire.
- Model evaluation: not applicable; routing decisions and model outputs are
  unchanged by this fix.

AI assistance was used. As the human submitter I have reviewed every changed
line and the recorded runtime validation.
