### PR TITLE
[Core] Mix per-prompt seeds into seeded SamplingParams in the offline API

### DIFF
--- a/tests/entrypoints/unit_tests/test_offline_utils.py
+++ b/tests/entrypoints/unit_tests/test_offline_utils.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm import PoolingParams, SamplingParams
+from vllm.entrypoints.offline_utils import (
+    OfflineInferenceMixin,
+    _mix_prompt_seeds,
+)
+
+
+def _params_to_seq(params, num_requests):
+    return OfflineInferenceMixin._params_to_seq(
+        OfflineInferenceMixin(), params, num_requests
+    )
+
+
+def _mixed_seeds(params, prompts):
+    seq = _mix_prompt_seeds(_params_to_seq(params, len(prompts)), prompts)
+    return [p.seed for p in seq]
+
+
+def test_mixed_seeds_unique_and_deterministic():
+    """One seed shared over a batch must give each prompt an independent
+    noise stream, not one shared noise vector (#50440)."""
+    params = SamplingParams(seed=42)
+    prompts = ["a", "b", "c"]
+
+    seeds = _mixed_seeds(params, prompts)
+
+    assert len(set(seeds)) == len(prompts)
+    assert seeds == _mixed_seeds(params, prompts)
+    # Original object is not mutated; other fields are preserved.
+    assert params.seed == 42
+
+
+def test_single_params_and_list_give_identical_seeds():
+    """`generate([a], SamplingParams(seed=42))` and
+    `generate([a], [SamplingParams(seed=42)])` must give identical
+    results: mixing applies after expansion, uniformly to both forms."""
+    prompts = ["a", "b"]
+    broadcast = _mixed_seeds(SamplingParams(seed=42), prompts)
+    explicit = _mixed_seeds([SamplingParams(seed=42), SamplingParams(seed=42)], prompts)
+    assert broadcast == explicit
+
+
+def test_mixed_seed_independent_of_batch_composition():
+    """A prompt's seed depends on (seed, prompt), not on its batch position,
+    so results are reproducible across reordering and subsetting."""
+    params = SamplingParams(seed=7)
+
+    by_prompt = dict(zip(["a", "b", "c"], _mixed_seeds(params, ["a", "b", "c"])))
+    assert _mixed_seeds(params, ["c", "a", "b"]) == [
+        by_prompt[x] for x in ["c", "a", "b"]
+    ]
+    assert _mixed_seeds(params, ["b"]) == [by_prompt["b"]]
+
+
+def test_duplicate_prompts_share_seed():
+    """Same (seed, prompt) always produces the same derived seed, so
+    repeated identical prompts share their noise by construction; `n>1`
+    is the mechanism for multiple distinct samples of one prompt."""
+    seeds = _mixed_seeds(SamplingParams(seed=7), ["a", "a", "b"])
+
+    assert seeds[0] == seeds[1]
+    assert seeds[0] != seeds[2]
+
+
+def test_mixed_seed_uses_token_ids_fingerprint():
+    params = SamplingParams(seed=0)
+    tokens_a = {"prompt_token_ids": [1, 2, 3]}
+    tokens_b = {"prompt_token_ids": [1, 2, 4]}
+
+    assert _mixed_seeds(params, [dict(tokens_a)]) == _mixed_seeds(
+        params, [dict(tokens_a)]
+    )
+    assert _mixed_seeds(params, [tokens_a]) != _mixed_seeds(params, [tokens_b])
+
+
+def test_unseeded_sampling_params_pass_through_unchanged():
+    params = SamplingParams()
+    seq = _mix_prompt_seeds(_params_to_seq(params, 3), ["a", "b", "c"])
+    assert all(p is params for p in seq)
+
+
+def test_pooling_params_pass_through_unchanged():
+    params = PoolingParams()
+    seq = _mix_prompt_seeds(_params_to_seq(params, 3), ["a", "b", "c"])
+    assert all(p is params for p in seq)
+
+
+def test_params_sequence_passthrough():
+    params = [SamplingParams(seed=1), SamplingParams(seed=1)]
+    assert _params_to_seq(params, 2) is params
+    with pytest.raises(ValueError, match="must be the same"):
+        _params_to_seq(params, 3)

--- a/tests/entrypoints/unit_tests/test_offline_utils.py
+++ b/tests/entrypoints/unit_tests/test_offline_utils.py
@@ -3,8 +3,8 @@
 
 import pytest
 
-from vllm import SamplingParams
-from vllm.entrypoints.offline_utils import OfflineInferenceMixin
+from vllm import PoolingParams, SamplingParams
+from vllm.entrypoints.offline_utils import OfflineInferenceMixin, _mix_prompt_seeds
 from vllm.exceptions import VLLMValidationError
 from vllm.lora.request import LoRARequest
 
@@ -55,3 +55,101 @@ def test_matching_lengths_pass_through(mixin: OfflineInferenceMixin):
     ]
     assert mixin._lora_request_to_seq([lora], num_requests=1) == [lora]
     assert mixin._priority_to_seq([3], num_requests=1) == [3]
+
+
+def _mixed_seeds(params, prompts):
+    mixin = object.__new__(OfflineInferenceMixin)
+    seq = _mix_prompt_seeds(mixin._params_to_seq(params, len(prompts)), prompts)
+    return [p.seed for p in seq]
+
+
+def test_mixed_seeds_unique_and_deterministic():
+    """One seed shared over a batch must give each prompt an independent
+    noise stream, not one shared noise vector (#50440)."""
+    params = SamplingParams(seed=42)
+    prompts = ["a", "b", "c"]
+
+    seeds = _mixed_seeds(params, prompts)
+
+    assert len(set(seeds)) == len(prompts)
+    assert seeds == _mixed_seeds(params, prompts)
+    # Original object is not mutated.
+    assert params.seed == 42
+
+
+def test_single_params_and_list_give_identical_seeds():
+    """`generate([a], SamplingParams(seed=42))` and
+    `generate([a], [SamplingParams(seed=42)])` must give identical
+    results: mixing applies after expansion, uniformly to both forms."""
+    prompts = ["a", "b"]
+    broadcast = _mixed_seeds(SamplingParams(seed=42), prompts)
+    explicit = _mixed_seeds([SamplingParams(seed=42), SamplingParams(seed=42)], prompts)
+    assert broadcast == explicit
+
+
+def test_mixed_seed_independent_of_batch_composition():
+    """A prompt's seed depends on (seed, prompt), not on its batch position,
+    so results are reproducible across reordering and subsetting."""
+    params = SamplingParams(seed=7)
+
+    by_prompt = dict(zip(["a", "b", "c"], _mixed_seeds(params, ["a", "b", "c"])))
+    assert _mixed_seeds(params, ["c", "a", "b"]) == [
+        by_prompt[x] for x in ["c", "a", "b"]
+    ]
+    assert _mixed_seeds(params, ["b"]) == [by_prompt["b"]]
+
+
+def test_duplicate_prompts_share_seed():
+    """Same (seed, prompt) always produces the same derived seed, so
+    repeated identical prompts share their noise by construction; `n>1`
+    is the mechanism for multiple distinct samples of one prompt."""
+    seeds = _mixed_seeds(SamplingParams(seed=7), ["a", "a", "b"])
+
+    assert seeds[0] == seeds[1]
+    assert seeds[0] != seeds[2]
+
+
+def test_mixed_seed_uses_token_ids_fingerprint():
+    params = SamplingParams(seed=0)
+    tokens_a = {"prompt_token_ids": [1, 2, 3]}
+    tokens_b = {"prompt_token_ids": [1, 2, 4]}
+
+    assert _mixed_seeds(params, [dict(tokens_a)]) == _mixed_seeds(
+        params, [dict(tokens_a)]
+    )
+    assert _mixed_seeds(params, [tokens_a]) != _mixed_seeds(params, [tokens_b])
+
+
+def test_mixed_seed_uses_image_content():
+    """Prompts with the same text but different image content must derive
+    different seeds; identical pixels hash identically."""
+    from PIL import Image
+
+    params = SamplingParams(seed=0)
+    black = Image.new("RGB", (4, 4), color=0)
+    white = Image.new("RGB", (4, 4), color=(255, 255, 255))
+    black2 = Image.new("RGB", (4, 4), color=0)
+
+    def mm_prompt(image):
+        return {"prompt": "describe", "multi_modal_data": {"image": image}}
+
+    assert _mixed_seeds(params, [mm_prompt(black)]) == _mixed_seeds(
+        params, [mm_prompt(black2)]
+    )
+    assert _mixed_seeds(params, [mm_prompt(black)]) != _mixed_seeds(
+        params, [mm_prompt(white)]
+    )
+
+
+def test_unseeded_sampling_params_pass_through_unchanged():
+    mixin = object.__new__(OfflineInferenceMixin)
+    params = SamplingParams()
+    seq = _mix_prompt_seeds(mixin._params_to_seq(params, 3), ["a", "b", "c"])
+    assert all(p is params for p in seq)
+
+
+def test_pooling_params_pass_through_unchanged():
+    mixin = object.__new__(OfflineInferenceMixin)
+    params = PoolingParams()
+    seq = _mix_prompt_seeds(mixin._params_to_seq(params, 3), ["a", "b", "c"])
+    assert all(p is params for p in seq)

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -437,6 +437,10 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
                 When it is a single value, it is applied to every prompt.
                 When it is a list, the list must have the same length as the
                 prompts and it is paired one by one with the prompt.
+                Seeded params use a seed derived from the seed and the
+                prompt content, so that sampling noise is independent
+                across prompts and a prompt's result depends only on the
+                (seed, prompt) pair, not on batch composition or order.
             use_tqdm: If `True`, shows a tqdm progress bar.
                 If a callable (e.g., `functools.partial(tqdm, leave=False)`),
                 it is used to create the progress bar.
@@ -642,6 +646,10 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
                 is a single value, it is applied to every prompt. When it
                 is a list, the list must have the same length as the
                 prompts and it is paired one by one with the prompt.
+                Seeded params use a seed derived from the seed and the
+                conversation content, so that sampling noise is independent
+                across prompts and a prompt's result depends only on the
+                (seed, prompt) pair, not on batch composition or order.
             use_tqdm: If `True`, shows a tqdm progress bar.
                 If a callable (e.g., `functools.partial(tqdm, leave=False)`),
                 it is used to create the progress bar.

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -441,6 +441,10 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
                 When it is a single value, it is applied to every prompt.
                 When it is a list, the list must have the same length as the
                 prompts and it is paired one by one with the prompt.
+                Seeded params use a seed derived from the seed and the
+                prompt content, so that sampling noise is independent
+                across prompts and a prompt's result depends only on the
+                (seed, prompt) pair, not on batch composition or order.
             use_tqdm: If `True`, shows a tqdm progress bar.
                 If a callable (e.g., `functools.partial(tqdm, leave=False)`),
                 it is used to create the progress bar.
@@ -646,6 +650,10 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
                 is a single value, it is applied to every prompt. When it
                 is a list, the list must have the same length as the
                 prompts and it is paired one by one with the prompt.
+                Seeded params use a seed derived from the seed and the
+                conversation content, so that sampling noise is independent
+                across prompts and a prompt's result depends only on the
+                (seed, prompt) pair, not on batch composition or order.
             use_tqdm: If `True`, shows a tqdm progress bar.
                 If a callable (e.g., `functools.partial(tqdm, leave=False)`),
                 it is used to create the progress bar.

--- a/vllm/entrypoints/offline_utils.py
+++ b/vllm/entrypoints/offline_utils.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import json
 from collections.abc import Callable, Iterable, Sequence
+from copy import copy
+from hashlib import sha256
 from typing import Any
 
 from tqdm import tqdm
@@ -36,7 +39,6 @@ from vllm.v1.engine.llm_engine import LLMEngine
 
 logger = init_logger(__name__)
 
-
 _P = TypeVar("_P", bound=SamplingParams | PoolingParams | None)
 _O = TypeVar(
     "_O",
@@ -44,6 +46,59 @@ _O = TypeVar(
     default=RequestOutput | PoolingRequestOutput,
 )
 _R = TypeVar("_R", default=Any)
+
+
+_SEED_SPACE = 2**63
+
+
+def _prompt_fingerprint(prompt: object) -> bytes:
+    """Deterministic, process-independent fingerprint of a prompt.
+
+    Non-serializable values (e.g. multi-modal data) are reduced to their
+    type name.
+    """
+    if isinstance(prompt, str):
+        return prompt.encode("utf-8")
+    try:
+        return json.dumps(
+            prompt, sort_keys=True, default=lambda o: type(o).__name__
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        return b""
+
+
+def _mix_prompt_seeds(
+    seq_params: Sequence[_P],
+    seq_prompts: Sequence[object],
+) -> Sequence[_P]:
+    """Mix each seeded request's seed with its prompt content.
+
+    Sharing one seed across a batch would make every request draw an
+    identical sampling noise vector, correlating tokens across the batch
+    and biasing the marginal token distribution.
+
+    Mixing applies uniformly after params are expanded to one per prompt,
+    so `generate([a], SamplingParams(seed=42))` and
+    `generate([a], [SamplingParams(seed=42)])` give identical results.
+    Deriving from the prompt content rather than the batch index keeps a
+    prompt's result independent of batch composition and order: the same
+    (seed, prompt) pair always produces the same result, so repeated
+    identical prompts share their noise by construction. Use `n>1` to draw
+    multiple distinct samples of one prompt; its per-child seeds derived in
+    `ParentRequest` stay distinct within each request.
+    """
+    mixed = []
+    for request_params, prompt in zip(seq_params, seq_prompts, strict=True):
+        if (
+            isinstance(request_params, SamplingParams)
+            and (seed := request_params.seed) is not None
+        ):
+            fingerprint = _prompt_fingerprint(prompt)
+            digest = int.from_bytes(sha256(fingerprint).digest()[:8], "little")
+            request_params = copy(request_params)
+            request_params.seed = (seed + digest) % _SEED_SPACE
+        mixed.append(request_params)
+    return mixed
 
 
 class OfflineInferenceMixin:
@@ -301,7 +356,9 @@ class OfflineInferenceMixin:
         mm_processor_kwargs: dict[str, Any] | None = None,
     ) -> list[str]:
         seq_prompts = prompt_to_seq(prompts)
-        seq_params = self._params_to_seq(params, len(seq_prompts))
+        seq_params = _mix_prompt_seeds(
+            self._params_to_seq(params, len(seq_prompts)), seq_prompts
+        )
         seq_lora_requests = self._lora_request_to_seq(lora_request, len(seq_prompts))
         seq_priority = self._priority_to_seq(priority, len(seq_prompts))
 
@@ -405,7 +462,9 @@ class OfflineInferenceMixin:
         mm_processor_kwargs: dict[str, Any] | None = None,
     ) -> list[str]:
         seq_convs = conversation_to_seq(messages)
-        seq_params = self._params_to_seq(params, len(seq_convs))
+        seq_params = _mix_prompt_seeds(
+            self._params_to_seq(params, len(seq_convs)), seq_convs
+        )
         seq_lora_requests = self._lora_request_to_seq(lora_request, len(seq_convs))
         seq_priority = self._priority_to_seq(priority, len(seq_convs))
 

--- a/vllm/entrypoints/offline_utils.py
+++ b/vllm/entrypoints/offline_utils.py
@@ -1,7 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import hashlib
+import json
+import struct
 from collections.abc import Callable, Iterable, Sequence
+from copy import copy
+from hashlib import sha256
 from typing import Any
 
 from tqdm import tqdm
@@ -37,7 +42,6 @@ from vllm.v1.engine.llm_engine import LLMEngine
 
 logger = init_logger(__name__)
 
-
 _P = TypeVar("_P", bound=SamplingParams | PoolingParams | None)
 _O = TypeVar(
     "_O",
@@ -45,6 +49,116 @@ _O = TypeVar(
     default=RequestOutput | PoolingRequestOutput,
 )
 _R = TypeVar("_R", default=Any)
+
+
+_SEED_SPACE = 2**63
+
+
+def _hash_fallback(hasher: "hashlib._Hash", value: object) -> None:
+    try:
+        hasher.update(
+            json.dumps(
+                value, sort_keys=True, default=lambda o: type(o).__name__
+            ).encode("utf-8")
+        )
+    except (TypeError, ValueError):
+        hasher.update(type(value).__name__.encode("utf-8"))
+
+
+def _hash_mm_item(hasher: "hashlib._Hash", item: object) -> None:
+    size = getattr(item, "size", None)
+    tobytes = getattr(item, "tobytes", None)
+    if isinstance(size, tuple) and len(size) == 2 and callable(tobytes):
+        # PIL-style image: hash decoded pixels so the digest depends on
+        # content, not on the source encoding.
+        hasher.update(struct.pack(">QQ", *size))
+        hasher.update(tobytes())
+    elif callable(tobytes) and hasattr(item, "shape"):
+        # Array-style data (e.g. numpy).
+        hasher.update(repr(item.shape).encode("utf-8"))
+        hasher.update(tobytes())
+    else:
+        hasher.update(type(item).__name__.encode("utf-8"))
+
+
+def _prompt_digest(prompt: object) -> bytes:
+    """Deterministic, process-independent digest of a prompt's content.
+
+    Text and explicit token IDs are hashed with distinct type tags so they
+    cannot collide. Multi-modal items are hashed by decoded content where
+    possible (PIL images, arrays) and reduced to their type name otherwise.
+    """
+    hasher = sha256()
+    if isinstance(prompt, str):
+        hasher.update(b"T")
+        hasher.update(prompt.encode("utf-8"))
+        return hasher.digest()
+
+    if isinstance(prompt, dict):
+        token_ids = prompt.get("prompt_token_ids")
+        text = prompt.get("prompt")
+        if token_ids is not None:
+            hasher.update(b"I")
+            for token_id in token_ids:
+                hasher.update(struct.pack(">Q", token_id))
+        elif isinstance(text, str):
+            hasher.update(b"T")
+            hasher.update(text.encode("utf-8"))
+        else:
+            _hash_fallback(hasher, prompt)
+            return hasher.digest()
+
+        multi_modal_data = prompt.get("multi_modal_data")
+        if multi_modal_data:
+            for modality in sorted(multi_modal_data):
+                items = multi_modal_data[modality]
+                if not isinstance(items, list):
+                    items = [items]
+                hasher.update(b"M")
+                hasher.update(str(modality).encode("utf-8"))
+                for item in items:
+                    _hash_mm_item(hasher, item)
+        mm_processor_kwargs = prompt.get("mm_processor_kwargs")
+        if mm_processor_kwargs:
+            hasher.update(b"K")
+            _hash_fallback(hasher, mm_processor_kwargs)
+        return hasher.digest()
+
+    _hash_fallback(hasher, prompt)
+    return hasher.digest()
+
+
+def _mix_prompt_seeds(
+    seq_params: Sequence[_P],
+    seq_prompts: Sequence[object],
+) -> Sequence[_P]:
+    """Mix each seeded request's seed with its prompt content.
+
+    Sharing one seed across a batch would make every request draw an
+    identical sampling noise vector, correlating tokens across the batch
+    and biasing the marginal token distribution.
+
+    Mixing applies uniformly after params are expanded to one per prompt,
+    so `generate([a], SamplingParams(seed=42))` and
+    `generate([a], [SamplingParams(seed=42)])` give identical results.
+    Deriving from the prompt content rather than the batch index keeps a
+    prompt's result independent of batch composition and order: the same
+    (seed, prompt) pair always produces the same result, so repeated
+    identical prompts share their noise by construction. Use `n>1` to draw
+    multiple distinct samples of one prompt; its per-child seeds derived in
+    `ParentRequest` stay distinct within each request.
+    """
+    mixed = []
+    for request_params, prompt in zip(seq_params, seq_prompts, strict=True):
+        if (
+            isinstance(request_params, SamplingParams)
+            and (seed := request_params.seed) is not None
+        ):
+            digest = int.from_bytes(_prompt_digest(prompt)[:8], "little")
+            request_params = copy(request_params)
+            request_params.seed = (seed + digest) % _SEED_SPACE
+        mixed.append(request_params)
+    return mixed
 
 
 class OfflineInferenceMixin:
@@ -302,7 +416,9 @@ class OfflineInferenceMixin:
         mm_processor_kwargs: dict[str, Any] | None = None,
     ) -> list[str]:
         seq_prompts = prompt_to_seq(prompts)
-        seq_params = self._params_to_seq(params, len(seq_prompts))
+        seq_params = _mix_prompt_seeds(
+            self._params_to_seq(params, len(seq_prompts)), seq_prompts
+        )
         seq_lora_requests = self._lora_request_to_seq(lora_request, len(seq_prompts))
         seq_priority = self._priority_to_seq(priority, len(seq_prompts))
 
@@ -406,7 +522,9 @@ class OfflineInferenceMixin:
         mm_processor_kwargs: dict[str, Any] | None = None,
     ) -> list[str]:
         seq_convs = conversation_to_seq(messages)
-        seq_params = self._params_to_seq(params, len(seq_convs))
+        seq_params = _mix_prompt_seeds(
+            self._params_to_seq(params, len(seq_convs)), seq_convs
+        )
         seq_lora_requests = self._lora_request_to_seq(lora_request, len(seq_convs))
         seq_priority = self._priority_to_seq(priority, len(seq_convs))
 


### PR DESCRIPTION
## Purpose

Fixes #50440.

When requests in an offline-API batch (`LLM.generate` / `LLM.chat`) share a `SamplingParams` seed, every request draws an identical Exp(1) noise vector in `random_sample`, so sampled tokens are correlated across the whole batch: any token the shared noise vector suppresses (or favors) is suppressed/favored for every prompt simultaneously, biasing the marginal token distribution over the population rather than averaging out.

This PR mixes each seeded request's seed with its **prompt content**, after params are expanded to one per prompt:

```
request_seed = (seed + sha256_digest(prompt_content)[:8]) % 2**63
```

- **Uniform across call forms**: mixing applies after expansion, so `generate([a], SamplingParams(seed=42))` and `generate([a], [SamplingParams(seed=42)])` give identical results.
- **Content-based, not index-based**: a prompt's derived seed — and therefore its output — depends only on the `(seed, prompt)` pair, independent of batch composition and order. Re-running any prompt alone reproduces its in-batch result. (An index-based scheme like `seed + i` would reintroduce a dependence on batch position, the same class of problem as #17524.)
- **Same (seed, prompt) → same result, always**: repeated identical prompts in a batch share their noise by construction. Drawing multiple distinct samples of one prompt is what `n>1` is for — `ParentRequest._get_child_sampling_params` derives distinct per-child seeds (`seed + child_index`) within each request.
- The digest tags text and token-ID prompts with distinct type bytes (no cross-type collisions) and hashes multi-modal items by decoded content where possible — PIL image pixels (encoding-independent) and array buffers — falling back to type names for anything else. Prompts with the same text but different images therefore derive different seeds. Residual limitation: multi-modal items that expose neither pixels nor an array buffer reduce to their type name and can still share a digest.

Behavior notes:
- Same call → same results: full determinism is preserved.
- Unseeded and pooling params keep the existing shared-object fast path; the OpenAI-compatible server path is untouched (it builds per-request params).
- **Outputs of seeded offline generation change relative to previous releases** (including single-prompt calls, since the seed is now mixed with the prompt digest). The previous behavior — one shared noise stream for the whole batch — is exactly the bug being fixed; any golden outputs recorded under a seed will need re-recording.
- Deliberately giving *different* prompts identical noise (common-random-numbers comparisons) is no longer possible; that capability was incidental, undocumented, and is the same mechanism that produces the population-level bias.

Duplicate-work check (per AGENTS.md): `gh issue view 50440 --comments` shows no assigned work and no linked PR; `gh pr list --state open` searches for "50440 in:body", "seed trajectory sampling", and "per-request seed generator" return no PR addressing this. The only related merged work is the `n>1` child-seed derivation (#2514 lineage), which this PR complements at the batch level.

## Test Plan

New unit tests added to the existing `tests/entrypoints/unit_tests/test_offline_utils.py` (CPU-only, no GPU required; the 4 pre-existing validation tests in that file still pass):

```bash
pytest tests/entrypoints/unit_tests/test_offline_utils.py -v
```

Covers: mixed seeds are unique per prompt, deterministic, and don't mutate the caller's object; single-params and explicit-list forms produce identical seeds; batch-composition/order independence (reorder + singleton subset reproduce the same per-prompt seeds); repeated identical prompts share their derived seed; token-ids digests; image-content digests (identical pixels share a seed, different pixels don't); unseeded `SamplingParams` and `PoolingParams` pass through unchanged.

Lint: `pre-commit run --files vllm/entrypoints/offline_utils.py vllm/entrypoints/llm.py tests/entrypoints/unit_tests/test_offline_utils.py` (includes mypy) — all hooks pass.

## Test Result

```
tests/entrypoints/unit_tests/test_offline_utils.py::test_rejects_mismatched_params PASSED
tests/entrypoints/unit_tests/test_offline_utils.py::test_rejects_mismatched_lora_requests PASSED
tests/entrypoints/unit_tests/test_offline_utils.py::test_rejects_mismatched_priority PASSED
tests/entrypoints/unit_tests/test_offline_utils.py::test_matching_lengths_pass_through PASSED
tests/entrypoints/unit_tests/test_offline_utils.py::test_mixed_seeds_unique_and_deterministic PASSED
tests/entrypoints/unit_tests/test_offline_utils.py::test_single_params_and_list_give_identical_seeds PASSED
tests/entrypoints/unit_tests/test_offline_utils.py::test_mixed_seed_independent_of_batch_composition PASSED
tests/entrypoints/unit_tests/test_offline_utils.py::test_duplicate_prompts_share_seed PASSED
tests/entrypoints/unit_tests/test_offline_utils.py::test_mixed_seed_uses_token_ids_fingerprint PASSED
tests/entrypoints/unit_tests/test_offline_utils.py::test_mixed_seed_uses_image_content PASSED
tests/entrypoints/unit_tests/test_offline_utils.py::test_unseeded_sampling_params_pass_through_unchanged PASSED
tests/entrypoints/unit_tests/test_offline_utils.py::test_pooling_params_pass_through_unchanged PASSED

12 passed
```

End-to-end comparison (CPU backend, `facebook/opt-125m`, source build; re-verified after rebase onto current `main`): 64 distinct prompts (`"Item {i}:"`), one shared `SamplingParams(seed=1234, temperature=2.0, max_tokens=1)`:

| | `main` | this PR |
|---|---|---|
| distinct first sampled tokens across the 64 prompts | **1** (all 64 prompts sampled token 11944) | **64** (independent draws) |
| identical results on rerun of the same call | yes | yes |

On `main` the shared noise vector dominates the near-identical next-token distributions and every prompt in the batch samples the same token — the population-level collapse described in #50440. With this PR the draws are independent while remaining fully deterministic.

---

AI assistance disclosure: this change was developed with AI assistance (Claude Code). The submitting human has reviewed every changed line and run the tests above. Model quality evals beyond the end-to-end comparison above were not run: the change does not alter model forward passes or the sampler kernels — it only decorrelates the RNG seed assignment across batched seeded requests, and greedy/unseeded paths are untouched.
