### PR TITLE
[Bugfix][Reasoning] kimi_k3: O(delta) reasoning-end check on the decode path

### DIFF
--- a/tests/reasoning/test_kimi_k3_reasoning_parser.py
+++ b/tests/reasoning/test_kimi_k3_reasoning_parser.py
@@ -248,3 +248,98 @@ def test_adjust_request_keeps_xtml_markers_contiguous():
     assert adjusted.skip_special_tokens is False
     if hasattr(adjusted, "spaces_between_special_tokens"):
         assert adjusted.spaces_between_special_tokens is False
+
+
+OPEN_IDS = [1, 2, 3]
+CLOSE_IDS = [4, 2, 3]
+
+
+def _reference_is_reasoning_end(input_ids: list[int]) -> bool:
+    """Full-sequence reference for the streaming check to be measured against.
+
+    Two independent last-occurrence scans, i.e. the straightforward reading of
+    "reasoning ended iff the newest think marker is a close marker".
+    """
+
+    def last(needle: list[int]) -> int:
+        for i in range(len(input_ids) - len(needle), -1, -1):
+            if input_ids[i : i + len(needle)] == needle:
+                return i
+        return -1
+
+    last_close, last_open = last(CLOSE_IDS), last(OPEN_IDS)
+    if last_open == -1:
+        return last_close != -1
+    return last_close > last_open
+
+
+def test_is_reasoning_end_streaming_only_scans_the_step_window():
+    """The decode-step check must not re-derive the answer from the whole
+    sequence: an already-closed think block earlier in the sequence is the
+    engine's business (it latches `reasoning_ended`), not this call's."""
+    parser = KimiK3ReasoningParser(DummyTokenizer())
+    prompt = [*CLOSE_IDS, *OPEN_IDS, 9, 9, 9]
+
+    assert not parser.is_reasoning_end_streaming([*prompt, 7], [7])
+    assert parser.is_reasoning_end_streaming([*prompt, *CLOSE_IDS], CLOSE_IDS)
+
+
+def test_is_reasoning_end_streaming_detects_marker_across_step_boundary():
+    """A 3-token marker can be split over decode steps; the check carries the
+    preceding len(marker)-1 tokens so the final token still completes it."""
+    parser = KimiK3ReasoningParser(DummyTokenizer())
+    history = [*OPEN_IDS, 5, *CLOSE_IDS[:2]]
+
+    assert not parser.is_reasoning_end_streaming(history, [CLOSE_IDS[1]])
+    assert parser.is_reasoning_end_streaming([*history, CLOSE_IDS[2]], [CLOSE_IDS[2]])
+
+
+def test_is_reasoning_end_streaming_reopened_block_is_not_ended():
+    """Kimi K3 may close and immediately reopen the think channel inside one
+    window (speculative decoding lands several tokens per step). The newest
+    marker wins, matching is_reasoning_end."""
+    parser = KimiK3ReasoningParser(DummyTokenizer())
+    window = [*CLOSE_IDS, *OPEN_IDS]
+
+    assert not parser.is_reasoning_end_streaming([*OPEN_IDS, 5, *window], window)
+
+
+def test_is_reasoning_end_streaming_accepts_an_iterator_delta():
+    """`should_advance` may hand over an islice rather than a list."""
+    parser = KimiK3ReasoningParser(DummyTokenizer())
+    full = [*OPEN_IDS, 5, *CLOSE_IDS]
+
+    assert parser.is_reasoning_end_streaming(full, iter(CLOSE_IDS))
+
+
+def test_is_reasoning_end_streaming_thinking_disabled():
+    parser = KimiK3ReasoningParser(
+        DummyTokenizer(), chat_template_kwargs={"thinking": False}
+    )
+
+    assert parser.is_reasoning_end_streaming([1], [1])
+
+
+@pytest.mark.parametrize("seed", range(24))
+def test_reasoning_end_matches_reference_over_marker_dense_sequences(seed):
+    """Both the full-sequence check and the per-step check must agree with the
+    two-scan reference, on sequences where the markers (which share the suffix
+    [2, 3]) collide and overlap constantly."""
+    import random
+
+    rnd = random.Random(seed)
+    parser = KimiK3ReasoningParser(DummyTokenizer())
+
+    for _ in range(200):
+        head = [rnd.choice([1, 2, 3, 4]) for _ in range(rnd.randrange(0, 14))]
+        delta = [rnd.choice([1, 2, 3, 4]) for _ in range(rnd.randrange(1, 5))]
+        full = [*head, *delta]
+
+        assert parser.is_reasoning_end(full) == _reference_is_reasoning_end(full)
+
+        # The engine only calls the streaming check while reasoning is still
+        # open, so that is the only case it has to agree on.
+        if not _reference_is_reasoning_end(head):
+            assert parser.is_reasoning_end_streaming(
+                full, delta
+            ) == _reference_is_reasoning_end(full), (head, delta)

--- a/vllm/reasoning/kimi_k3_reasoning_parser.py
+++ b/vllm/reasoning/kimi_k3_reasoning_parser.py
@@ -22,7 +22,7 @@ When thinking is disabled (``chat_template_kwargs={"thinking": False}`` or
 delta as normal content; there is simply no think channel to extract.
 """
 
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING
 
 import regex as re
@@ -36,14 +36,44 @@ if TYPE_CHECKING:
     from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 
 
+def _match_at(haystack: Sequence[int], i: int, needle: Sequence[int]) -> bool:
+    """Whether *needle* occurs in *haystack* starting at *i*.
+
+    Compares element by element rather than slicing: ``haystack`` is usually a
+    ``ConstantList``, whose slices cost a Python ``__getitem__`` plus a list
+    allocation on every probe.
+    """
+    return all(haystack[i + k] == needle[k] for k in range(len(needle)))
+
+
 def _subseq_index(haystack: Sequence[int], needle: Sequence[int]) -> int:
     """Return start index of the last occurrence of needle in haystack, or -1."""
     n = len(needle)
     if n == 0:
         return -1
+    first = needle[0]
     for i in range(len(haystack) - n, -1, -1):
-        if list(haystack[i : i + n]) == list(needle):
+        if haystack[i] == first and _match_at(haystack, i, needle):
             return i
+    return -1
+
+
+def _newest_marker(haystack: Sequence[int], a: Sequence[int], b: Sequence[int]) -> int:
+    """Report which of *a* / *b* occurs last in *haystack*.
+
+    Returns 0 if *a* is the newest marker, 1 if *b* is, -1 if neither occurs.
+    Equivalent to comparing two ``_subseq_index`` results, but a single backward
+    pass that stops at the first hit instead of walking to index 0 twice.
+    """
+    if not a or not b:
+        return -1
+    a0, b0 = a[0], b[0]
+    for i in range(len(haystack) - min(len(a), len(b)), -1, -1):
+        head = haystack[i]
+        if head == a0 and i + len(a) <= len(haystack) and _match_at(haystack, i, a):
+            return 0
+        if head == b0 and i + len(b) <= len(haystack) and _match_at(haystack, i, b):
+            return 1
     return -1
 
 
@@ -133,14 +163,36 @@ class KimiK3ReasoningParser(ReasoningParser):
         # agent continuations, where the chat template keeps a prior turn's
         # think channel (with its <|close|>think<|sep|>) in the prompt while the
         # current turn is still reasoning (its <|open|>think<|sep|> is the newest
-        # marker). See _subseq_index (returns the last occurrence).
-        last_close = _subseq_index(input_ids, self._think_close_ids)
-        last_open = _subseq_index(input_ids, self._think_open_ids)
-        if last_open == -1:
-            # No open marker in scope (e.g. the open was consumed as the
-            # generation prefix): a close marker means reasoning has ended.
-            return last_close != -1
-        return last_close > last_open
+        # marker). A missing open marker (e.g. it was consumed as the generation
+        # prefix) means a close marker alone ends reasoning, which is what
+        # "close is the newest marker" already encodes.
+        return (
+            _newest_marker(input_ids, self._think_close_ids, self._think_open_ids) == 0
+        )
+
+    def is_reasoning_end_streaming(
+        self, input_ids: Sequence[int], delta_ids: Iterable[int]
+    ) -> bool:
+        """Reasoning-end check for a single decode step.
+
+        The engine calls this once per structured-output request per decode step
+        while the request is still inside the think channel, so it only has to
+        look at the tokens generated this step, plus ``len(marker) - 1`` tokens
+        of context in case a marker straddles the step boundary.
+
+        The inherited default re-runs the full-sequence ``is_reasoning_end``,
+        which makes the scheduler O(context) per request per step and starves the
+        GPU on long agentic contexts.
+        """
+        if not self._thinking_enabled:
+            return True
+        delta = list(delta_ids)
+        if not delta:
+            return False
+        carry = max(len(self._think_close_ids), len(self._think_open_ids)) - 1
+        head = len(input_ids) - len(delta)
+        window = list(input_ids[max(0, head - carry) : head]) + delta
+        return _newest_marker(window, self._think_close_ids, self._think_open_ids) == 0
 
     def _extract_content_ids(self, input_ids: list[int]) -> list[int]:
         if not self._thinking_enabled:


### PR DESCRIPTION
## Summary

`KimiK3ReasoningParser` never overrode `is_reasoning_end_streaming`, so it inherits the base implementation — `return self.is_reasoning_end(input_ids)` — which throws `delta_ids` away and re-derives the answer from the entire sequence. `is_reasoning_end` then runs **two** backward subsequence scans over `request.all_token_ids`, allocating two lists per probed position (`list(haystack[i:i+n]) == list(needle)`) and never exiting early.

The scheduler calls this **once per structured-output request per decode step**, from `update_from_output`, in the EngineCore main thread, for every request still inside the think channel (`vllm/v1/structured_output/__init__.py` → `should_advance`). Under async scheduling a structured-output request also sets `pending_structured_output_tokens`, so sampling is deferred and the scan lands between `execute_model(N)` and `sample_tokens(N)`; the worker cannot proceed past the forward pass until the host finishes scanning. GPU idle per step is therefore `max(0, T_python − T_forward)`, and since `T_python` grows with the context, a long agentic turn degrades until the host — not the GPU — sets the step time.

`kimi_k3` appears to be the only multi-token-marker reasoning parser without the override; `basic_parsers`, `step3`, `step3p5` and `minimax_m3` all have it. This is the same bug class as #31969 (Step3) and #35745 (GptOss).

## Fix

Two parser-local changes, no engine changes:

1. **Override `is_reasoning_end_streaming`** to inspect only the step's new tokens plus `len(marker) - 1` tokens of carry-over, so a marker split across decode steps is still detected.
2. **Fold the two full scans in `is_reasoning_end`** into one backward pass that stops at whichever marker it meets first, and stop allocating a list per probed position. The "newest marker wins" rule is unchanged — including the multi-turn case the existing comment and `test_is_reasoning_end_ignores_stale_close_from_prior_turn` describe, where a prior turn's close marker is still in the prompt.

## Performance

Grace (Neoverse-V2) with the real Kimi-K3 tokenizer (`moonshotai/Kimi-K3` @ `9f62e4e`, markers are 3 tokens each) and a `ConstantList` haystack — an 8k-token prompt that retains a prior turn's `<|close|>think<|sep|>` and ends with `<|open|>think<|sep|>` as the generation prefix:

| output tokens | before, per call | after `is_reasoning_end` | after `is_reasoning_end_streaming` | speedup | ×16 concurrent, per step |
| --- | --- | --- | --- | --- | --- |
| 1,000 | 0.435 ms | 0.053 ms | **0.95 µs** | 457× | 7.0 ms → **0.015 ms** |
| 5,000 | 2.165 ms | 0.257 ms | **0.94 µs** | 2,300× | 34.6 ms → **0.015 ms** |
| 20,000 | 8.560 ms | 1.020 ms | **0.94 µs** | 9,105× | 137.0 ms → **0.015 ms** |
| 20,000 (80k prompt) | 8.693 ms | 1.018 ms | **0.95 µs** | 9,108× | 139.1 ms → **0.015 ms** |

End-to-end on one GB300, 16 concurrent structured-output requests with `--structured-outputs-config '{"reasoning_parser":"kimi_k3"}'`, `--max-num-seqs 16`, prefix caching off, `FULL_DECODE_ONLY` graphs, 8k-token prompts, against a model sized so the decode step is 22 ms:

| mean output tokens | structured outputs off | on, before | on, after |
| --- | --- | --- | --- |
| 0–2k | 100% GPU / 22.1 ms | 100% GPU / 22.1 ms | 100% GPU / 22.1 ms |
| 2–4k | 100% / 22.5 ms | 86% / 25.9 ms | 100% / 22.6 ms |
| 4–6k | 100% / 23.2 ms | 59% / 39.3 ms | 100% / 23.1 ms |
| 6–8k | 100% / 23.7 ms | 45% / 52.8 ms | 100% / 23.7 ms |
| 8–10k | — | 37% / 67.9 ms | 100% / 24.3 ms |

Whole-run throughput at `max_tokens=10000`: **376 → 660 tok/s (+75%)**, matching the structured-outputs-off control (663 tok/s) to within noise. An in-process timer on the unpatched path attributed **91–95% of EngineCore main-thread wall time** to this one function at 6k output tokens.

## Tests

```
$ pytest tests/reasoning/test_kimi_k3_reasoning_parser.py -q
41 passed                                     # 35 existing + 6 new

$ pytest tests/reasoning --ignore=tests/reasoning/test_cohere_command_reasoning_parser.py -q
416 passed                                    # cohere file is skipped: pre-existing
                                              # ModuleNotFoundError: 'cohere_melody'

$ pytest tests/tool_use/test_kimi_k3_tool_parser.py tests/renderers/test_kimi_k3.py \
         tests/tool_parsers/test_kimi_k3_named_tool_choice.py \
         tests/tool_parsers/test_structural_tag_registry.py -q
127 passed

$ pytest tests/v1/structured_output -q
42 passed                                     # identical to the same run on unpatched main
```

New tests cover the step window, a marker split across the step boundary, close-then-reopen inside one window (the speculative-decoding case), an iterator `delta_ids` (`should_advance` can pass an `islice`), and `thinking=False`. The last one is a property test that checks both `is_reasoning_end` and `is_reasoning_end_streaming` against a two-scan reference over marker-dense random sequences — the two markers share the suffix `[2, 3]` in the test tokenizer, so overlaps are exercised constantly. Separately, an exhaustive comparison against the previous implementation over all sequences of length ≤ 8 on the 4-symbol marker alphabet, plus 377k randomized streaming cases and 2k realistic prompt+output shapes, found zero behavioural differences.

Lint: `ruff check` and `ruff format` clean; no line exceeds 88 characters.

## Not a duplicate

Searched `vllm-project/vllm` open PRs for `is_reasoning_end_streaming`, `kimi_k3 reasoning parser`, and reasoning-parser/structured-output performance. Nothing touches this path. The two nearest:

- #47656 — same class of concern (streaming vs non-streaming reasoning-end state) but confined to `step3p5_reasoning_parser.py`.
- #48116 — replaces vLLM's reasoning gate with xgrammar's; a different approach that does not touch `kimi_k3`. If that lands, this becomes redundant for the structured-output path, but `is_reasoning_end_streaming` would still be the wrong complexity for any other caller.

`vllm/reasoning/kimi_k3_reasoning_parser.py` has one commit in its history (#50093), and no open issue describes this.

## Caveats for reviewers

- This changes **when `reasoning_ended` flips**, which is when the grammar starts constraining, so it is behaviour-affecting even though it is intended to be behaviour-preserving. The equivalence argument and the property test above are the evidence; a second pair of eyes on `_newest_marker` is the thing I would most like reviewed.
- No end-to-end accuracy eval on the real Kimi-K3 weights yet — the performance and utilization measurements above used the real tokenizer and parser but a stand-in model. Happy to add a tool-calling eval if reviewers want one before merge.

AI assistance was used to investigate, implement and measure this change. I have reviewed every changed line and run the tests listed above.
