### PR TITLE
[Bugfix] Reject --renderer-num-workers > 1 with mm cache for generation models

### DIFF
--- a/tests/config/test_multimodal_config.py
+++ b/tests/config/test_multimodal_config.py
@@ -173,3 +173,20 @@ def test_sticky_cache_survives_text_subconfig_regeneration():
         side_effect=AssertionError("must not re-query registry"),
     ):
         assert text_config._supports_multimodal_for_mm_prefix() is False
+
+
+@pytest.mark.parametrize("model", ["llava-hf/llava-1.5-7b-hf"])
+def test_renderer_workers_with_mm_cache_rejected(model: str):
+    """The mm processor cache is not thread-safe, so combining
+    ``--renderer-num-workers > 1`` with the cache must be rejected for
+    generation models too (not only pooling): the raw-prompt preprocessing
+    offload runs ``_process_multimodal`` on the multi-worker renderer pool,
+    bypassing the single-worker executor that otherwise serializes cache
+    access.
+    """
+    with pytest.raises(ValueError, match="renderer-num-workers"):
+        ModelConfig(
+            model,
+            renderer_num_workers=2,
+            mm_processor_cache_gb=4,
+        )

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -783,13 +783,12 @@ class ModelConfig:
             if (
                 self.renderer_num_workers > 1
                 and self.multimodal_config.mm_processor_cache_gb > 0
-                and self.runner_type == "pooling"
             ):
                 raise ValueError(
                     "Cannot use --renderer-num-workers > 1 with the "
-                    "multimodal processor cache enabled for pooling models. "
-                    "Pooling preprocessing runs on the renderer workers, and "
-                    "the cache is not thread-safe. Please set "
+                    "multimodal processor cache enabled. Multimodal "
+                    "preprocessing runs on the renderer workers, and the "
+                    "cache is not thread-safe. Please set "
                     "--renderer-num-workers 1 (the default), or "
                     "disable the cache with --mm-processor-cache-gb 0."
                 )


### PR DESCRIPTION
## Purpose

The multimodal processor cache is **not thread-safe**. `ModelConfig` already
rejected `--renderer-num-workers > 1` together with the cache — but the guard
only fired for **pooling** models (`vllm/config/model.py`, `runner_type == "pooling"`).

Since #49608 ("Offload raw-prompt preprocessing to renderer thread pool in
AsyncLLM"), generation raw-prompt requests are handled by
`InputProcessor.process_inputs_async = make_async(self.process_inputs, executor=self.renderer._executor)`
— i.e. `process_inputs` (and the synchronous `_process_multimodal` it calls via
`InputPreprocessor` → `renderer._process_multimodal`) now runs on the
**multi-worker** `renderer._executor`.

Everywhere else, `mm_processor_cache` access is funneled through the
**single-worker** `renderer._mm_executor` (`_process_multimodal_async`,
`_clear_mm_cache_async`). `clear_mm_cache_async`'s own docstring states it is
serialized "to avoid races with concurrent process_inputs on the
mm_processor_cache". After #49608, generation `process_inputs` no longer runs on
that single-worker executor, so with:

- a multimodal **generation** model,
- `--renderer-num-workers > 1`,
- the mm processor cache enabled (`--mm-processor-cache-gb > 0`), and
- concurrent raw-multimodal requests,

two requests mutate the shared, non-thread-safe cache from different renderer
worker threads → cache corruption / wrong-request embeddings / crashes. The
existing pooling-only guard did not cover this generation path.

## Fix

Drop the `runner_type == "pooling"` condition so the guard fails fast for **any**
runner type when `--renderer-num-workers > 1` is combined with the cache. This
mirrors the policy already accepted for pooling and turns silent cache
corruption into a clear startup `ValueError`, while `--renderer-num-workers 1`
(the default) and `--mm-processor-cache-gb 0` remain unaffected.

A follow-up could instead *preserve* this configuration by routing the
raw-prompt MM preprocessing offload through the single-worker `_mm_executor`
(as the rest of the cache path already does), rather than rejecting the combo —
left to maintainers as a design choice.

## Not a duplicate

- `gh pr list --search "renderer-num-workers mm cache"` / `"mm_processor_cache thread"` / `"49608 in:body"` — no open PR addresses this guard gap.
- #44786 ("Reduce multimodal preprocessing cache contention") is a June pre-#49608 head-of-line-blocking/single-flight perf change and does not touch the generation guard.

## Test plan

Added `tests/config/test_multimodal_config.py::test_renderer_workers_with_mm_cache_rejected`, which builds a multimodal **generation** model config with `renderer_num_workers=2` + `mm_processor_cache_gb=4` and asserts a `ValueError`.

```
.venv/bin/python -m pytest tests/config/test_multimodal_config.py::test_renderer_workers_with_mm_cache_rejected -q
# 1 passed
```

Fix-absent/fix-present verified: the test **fails** on `upstream/main` (config is accepted) and **passes** with this change. `pre-commit run ruff-check/ruff-format/mypy` on the changed files: clean.

No model-output/accuracy behavior changes (config-validation only), so no evals apply.

## AI assistance

AI assistance (Claude Code) was used to help locate and analyze this issue; every changed line was reviewed and the tests were run locally by the submitter.
