### PR TITLE
[Bugfix] Transformers backend: tokenize multimodal prompts once

### DIFF
--- a/tests/models/multimodal/processing/test_transformers_image.py
+++ b/tests/models/multimodal/processing/test_transformers_image.py
@@ -125,6 +125,50 @@ def test_renderer_defers_tokenization_to_hf_processor(model_id, prompt):
     assert direct_ids.count(bos_token_id) == 1
 
 
+@pytest.mark.parametrize("model_id", ["google/gemma-3-4b-it"])
+def test_renderer_chat_template_prompt_matches_hf(model_id):
+    """A chat template renders special tokens itself (gemma3's starts with
+    <bos>), so tokenization must not add them again, mirroring the fallback
+    in `ProcessorMixin.apply_chat_template`. The reference ids are the
+    processor's own chat-template tokenization."""
+    model_config = ModelConfig(model=model_id, model_impl="transformers")
+    renderer = HfRenderer(
+        VllmConfig(model_config=model_config),
+        cached_tokenizer_from_config(model_config),
+    )
+    hf_processor = renderer.get_mm_processor().info.get_hf_processor()
+
+    image_pil = ImageAsset("cherry_blossom").pil_image
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image", "image": image_pil},
+                {"type": "text", "text": "What is the content of this image?"},
+            ],
+        }
+    ]
+    rendered = hf_processor.apply_chat_template(
+        messages, add_generation_prompt=True, tokenize=False
+    )
+    assert rendered.startswith(hf_processor.tokenizer.bos_token)
+
+    (engine_input,) = renderer.render_cmpl(
+        [{"prompt": rendered, "multi_modal_data": {"image": image_pil}}]
+    )
+
+    reference = hf_processor.apply_chat_template(
+        messages, add_generation_prompt=True, tokenize=True, return_dict=True
+    )
+    reference_ids = reference["input_ids"]
+    if hasattr(reference_ids, "tolist"):
+        reference_ids = reference_ids.tolist()
+    reference_ids = reference_ids[0]
+
+    assert engine_input["prompt_token_ids"] == reference_ids
+    assert reference_ids.count(hf_processor.tokenizer.bos_token_id) == 1
+
+
 def test_image_multiple_inputs():
     """Multiple images per prompt are each detected as a separate placeholder
     and multi-modal item by the Transformers backend."""

--- a/tests/models/multimodal/processing/test_transformers_image.py
+++ b/tests/models/multimodal/processing/test_transformers_image.py
@@ -3,8 +3,10 @@
 import pytest
 
 from vllm.assets.image import ImageAsset
-from vllm.config import ModelConfig
+from vllm.config import ModelConfig, VllmConfig
 from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.renderers.hf import HfRenderer
+from vllm.tokenizers.registry import cached_tokenizer_from_config
 
 
 @pytest.mark.parametrize("model_id", ["llava-hf/llava-onevision-qwen2-0.5b-ov-hf"])
@@ -54,6 +56,73 @@ def test_multimodal_processor(model_id):
         str_processed_inputs["prompt_token_ids"]
         == ids_processed_inputs["prompt_token_ids"]
     )
+
+
+@pytest.mark.parametrize("model_id", ["llava-hf/llava-1.5-7b-hf"])
+def test_ids_prompt_does_not_duplicate_special_tokens(model_id):
+    """Token-ids prompts are decoded back to text and re-tokenized by the HF
+    processor; special tokens already present in the ids (e.g. BOS added by
+    the renderer) must not be added a second time."""
+    model_config = ModelConfig(
+        model=model_id,
+        model_impl="transformers",
+    )
+
+    mm_processor = MULTIMODAL_REGISTRY.create_processor(model_config)
+    tokenizer = mm_processor.info.get_tokenizer()
+
+    image_pil = ImageAsset("cherry_blossom").pil_image
+    mm_data = {"image": image_pil}
+    str_prompt = "USER: <image>\nWhat is the content of this image? ASSISTANT:"
+    ids_prompt = tokenizer.encode(str_prompt, add_special_tokens=True)
+    assert ids_prompt[0] == tokenizer.bos_token_id
+
+    ids_processed_inputs = mm_processor(
+        prompt=ids_prompt,
+        mm_items=mm_processor.info.parse_mm_data(mm_data),
+        hf_processor_mm_kwargs={},
+    )
+
+    ids_token_ids = ids_processed_inputs["prompt_token_ids"]
+    assert ids_token_ids.count(tokenizer.bos_token_id) == 1
+
+
+@pytest.mark.parametrize(
+    ("model_id", "prompt"),
+    [
+        (
+            "llava-hf/llava-1.5-7b-hf",
+            "USER: <image>\nWhat is the content of this image? ASSISTANT:",
+        ),
+        (
+            "google/gemma-3-4b-it",
+            "<start_of_image>What is the content of this image?",
+        ),
+    ],
+)
+def test_renderer_defers_tokenization_to_hf_processor(model_id, prompt):
+    """Text prompts with mm data are tokenized exactly once, by the HF
+    processor: the engine input ids must equal the HF processor's own output
+    (no duplicated BOS, no metaspace drift from a decode/re-encode round
+    trip)."""
+    model_config = ModelConfig(model=model_id, model_impl="transformers")
+    renderer = HfRenderer(
+        VllmConfig(model_config=model_config),
+        cached_tokenizer_from_config(model_config),
+    )
+
+    image_pil = ImageAsset("cherry_blossom").pil_image
+    (engine_input,) = renderer.render_cmpl(
+        [{"prompt": prompt, "multi_modal_data": {"image": image_pil}}]
+    )
+
+    hf_processor = renderer.get_mm_processor().info.get_hf_processor()
+    direct = hf_processor(text=prompt, images=image_pil)["input_ids"][0]
+    direct_ids = direct.tolist() if hasattr(direct, "tolist") else list(direct)
+
+    bos_token_id = renderer.get_tokenizer().bos_token_id
+    assert engine_input["prompt_token_ids"] == direct_ids
+    assert direct_ids.count(bos_token_id) == 1
 
 
 def test_image_multiple_inputs():

--- a/vllm/inputs/llm.py
+++ b/vllm/inputs/llm.py
@@ -95,6 +95,12 @@ class _PromptOptions(TypedDict):
     Optional cache salt to be used for prefix caching.
     """
 
+    tokenization_kwargs: NotRequired[dict[str, Any]]
+    """
+    Overrides for the tokenization performed by the multi-modal processor.
+    Set by the renderer when tokenization is deferred to the processor.
+    """
+
 
 class TextPrompt(_PromptOptions):
     """Schema for a text prompt."""

--- a/vllm/model_executor/models/transformers/multimodal.py
+++ b/vllm/model_executor/models/transformers/multimodal.py
@@ -395,6 +395,17 @@ class MultiModalProcessor(BaseMultiModalProcessor[MultiModalProcessingInfo]):
                     **tokenization_kwargs,
                     "add_special_tokens": False,
                 }
+            else:
+                # Chat templates render special tokens themselves; mirror the
+                # fallback in `ProcessorMixin.apply_chat_template`.
+                bos_token = getattr(
+                    getattr(hf_processor, "tokenizer", None), "bos_token", None
+                )
+                if bos_token is not None and prompt.startswith(bos_token):
+                    tokenization_kwargs = {
+                        **tokenization_kwargs,
+                        "add_special_tokens": False,
+                    }
 
             # Bypass cached processor and always apply to the full set of mm inputs
             # NOTE: we can't just set caching=False because base class method

--- a/vllm/model_executor/models/transformers/multimodal.py
+++ b/vllm/model_executor/models/transformers/multimodal.py
@@ -209,6 +209,8 @@ class MultiModalDummyInputsBuilder(BaseDummyInputsBuilder[MultiModalProcessingIn
 
 
 class MultiModalProcessor(BaseMultiModalProcessor[MultiModalProcessingInfo]):
+    prefers_prompt_text = True
+
     def _get_prompt_updates(
         self,
         mm_items: MultiModalDataItems,
@@ -387,6 +389,12 @@ class MultiModalProcessor(BaseMultiModalProcessor[MultiModalProcessingInfo]):
                 # by the hf_processor, which is why we would need to decode the ids
                 # into string
                 prompt = hf_processor.decode(prompt)
+                # Special tokens (e.g. BOS) added by the renderer are rendered
+                # as text by decode; re-adding them here would duplicate them.
+                tokenization_kwargs = {
+                    **tokenization_kwargs,
+                    "add_special_tokens": False,
+                }
 
             # Bypass cached processor and always apply to the full set of mm inputs
             # NOTE: we can't just set caching=False because base class method

--- a/vllm/multimodal/processing/processor.py
+++ b/vllm/multimodal/processing/processor.py
@@ -1029,6 +1029,17 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
     Not to be confused with `transformers.ProcessorMixin`.
     """
 
+    prefers_prompt_text: bool = False
+    """
+    Whether `apply` should be given the prompt text instead of token ids
+    whenever possible.
+
+    Set by processors that tokenize the prompt themselves (e.g. the
+    Transformers backend), so that the renderer defers tokenization to them
+    instead of tokenizing first and forcing a lossy decode/re-encode
+    round trip.
+    """
+
     def __init__(
         self,
         info: _I,

--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -448,6 +448,23 @@ class BaseRenderer(ABC, Generic[_T]):
             and not prompt.get("multi_modal_uuids")
         )
 
+    def _defers_tokenization(
+        self,
+        prompt: "TextPrompt",
+        params: "TokenizeParams",
+    ) -> bool:
+        """Whether to skip renderer tokenization and let the multi-modal
+        processor tokenize the prompt text itself, so that the prompt is
+        tokenized exactly once."""
+        mm_processor = self.mm_processor
+        return (
+            mm_processor is not None
+            and mm_processor.prefers_prompt_text
+            and bool(prompt.get("multi_modal_data"))
+            and params.truncate_prompt_tokens is None
+            and params.pad_prompt_tokens is None
+        )
+
     @staticmethod
     def _build_tokens_prompt(
         token_ids: Sequence[int],
@@ -525,6 +542,11 @@ class BaseRenderer(ABC, Generic[_T]):
                     "use 'prompt_token_ids' for token ID inputs"
                 )
             prompt = params.apply_pre_tokenization(self.tokenizer, prompt)  # type: ignore[arg-type]
+            if self._defers_tokenization(prompt, params):  # type: ignore[arg-type]
+                prompt["tokenization_kwargs"] = {  # type: ignore[typeddict-unknown-key]
+                    "add_special_tokens": params.add_special_tokens
+                }
+                return prompt  # type: ignore[return-value]
             prompt = self._tokenize_prompt(prompt, params)
 
         if params.needs_detokenization and "prompt" not in prompt:
@@ -561,6 +583,11 @@ class BaseRenderer(ABC, Generic[_T]):
                     "use 'prompt_token_ids' for token ID inputs"
                 )
             prompt = params.apply_pre_tokenization(self.tokenizer, prompt)  # type: ignore[arg-type]
+            if self._defers_tokenization(prompt, params):  # type: ignore[arg-type]
+                prompt["tokenization_kwargs"] = {  # type: ignore[typeddict-unknown-key]
+                    "add_special_tokens": params.add_special_tokens
+                }
+                return prompt  # type: ignore[return-value]
             prompt = await self._tokenize_prompt_async(prompt, params)
 
         if params.needs_detokenization and "prompt" not in prompt:
@@ -725,7 +752,19 @@ class BaseRenderer(ABC, Generic[_T]):
 
         return mm_uuid_items
 
-    # TODO: Remove str and tokenization_kwargs after deprecating InputPreprocessor
+    @staticmethod
+    def _extract_mm_prompt(
+        prompt: TokensPrompt,
+    ) -> tuple[list[int] | str, dict[str, Any] | None]:
+        """Return the prompt to pass to the multi-modal processor along with
+        its tokenization kwargs: token ids when Step 2 tokenized the prompt,
+        otherwise the prompt text whose tokenization was deferred."""
+        if "prompt_token_ids" in prompt:
+            # Tokenization already done in Step 2
+            return prompt["prompt_token_ids"], None
+
+        return prompt["prompt"], prompt.get("tokenization_kwargs")  # type: ignore[typeddict-item]
+
     def _process_multimodal(
         self,
         prompt: list[int] | str,
@@ -775,20 +814,19 @@ class BaseRenderer(ABC, Generic[_T]):
         """Process token inputs, with multimodal preprocessing offloaded
         to the shared thread pool in the async variant.
         """
-        prompt_token_ids = prompt["prompt_token_ids"]
-
         engine_input: TokensInput | MultiModalInput
         if multi_modal_data := prompt.get("multi_modal_data"):
+            mm_prompt, tokenization_kwargs = self._extract_mm_prompt(prompt)
             engine_input = self._process_multimodal(
-                prompt_token_ids,
+                mm_prompt,
                 multi_modal_data,
                 mm_processor_kwargs=prompt.get("mm_processor_kwargs"),
-                tokenization_kwargs=None,  # Tokenization already done in Step 2
+                tokenization_kwargs=tokenization_kwargs,
                 mm_uuids=prompt.get("multi_modal_uuids"),
                 skip_mm_cache=skip_mm_cache,
             )
         else:
-            engine_input = tokens_input(prompt_token_ids)
+            engine_input = tokens_input(prompt["prompt_token_ids"])
 
         if prompt_text := prompt.get("prompt"):
             engine_input["prompt"] = prompt_text
@@ -838,20 +876,19 @@ class BaseRenderer(ABC, Generic[_T]):
         *,
         skip_mm_cache: bool = False,
     ) -> TokensInput | MultiModalInput:
-        prompt_token_ids = prompt["prompt_token_ids"]
-
         engine_input: TokensInput | MultiModalInput
         if multi_modal_data := prompt.get("multi_modal_data"):
+            mm_prompt, tokenization_kwargs = self._extract_mm_prompt(prompt)
             engine_input = await self._process_multimodal_async(
-                prompt_token_ids,
+                mm_prompt,
                 multi_modal_data,
                 mm_processor_kwargs=prompt.get("mm_processor_kwargs"),
-                tokenization_kwargs=None,
+                tokenization_kwargs=tokenization_kwargs,
                 mm_uuids=prompt.get("multi_modal_uuids"),
                 skip_mm_cache=skip_mm_cache,
             )
         else:
-            engine_input = tokens_input(prompt_token_ids)
+            engine_input = tokens_input(prompt["prompt_token_ids"])
 
         if prompt_text := prompt.get("prompt"):
             engine_input["prompt"] = prompt_text


### PR DESCRIPTION


## Purpose

Multimodal requests on the Transformers backend tokenize twice and duplicate special tokens.

Current flow: the renderer tokenizes the text and adds BOS. The backend gets ids, but HF processors want text, so it decodes back to text. Then the HF processor tokenizes again with add_special_tokens=True: second BOS. decode→encode is also not an identity op for SentencePiece tokenizers, it inserts an extra ▁ after `<s>` for instance. So every request has  one decode + one extra encode and can get a corrupted prompt.

Fix: tokenize once in the processor.

- Add ` BaseMultiModalProcessor.prefers_prompt_text`, always `True` on the Transformers backend. The renderer then skips its own tokenization for mm prompts and hands the text to the processor. Engine ids are now exactly processor(text=..., images=...) output. Same pattern as the existing `EncDecMultiModalProcessor.skip_decoder_start_token` flag.
- TokensPrompt + images has no text, so it keeps the decode path, but with `add_special_tokens=False` so BOS is not added twice.
- `truncate_prompt_tokens/pad_prompt_tokens` keep the old path. Native models unaffected (flag is False).

No open PR covers this AFAIK. Will also open a sibling PR on transformers side to test the backend e2e.


## Test Plan
`pytest tests/models/multimodal/processing/test_transformers_image.py`


## Test Result
Before patch, test flags a double BOS token for 2 test models:

```bash
    def test_ids_prompt_does_not_duplicate_special_tokens(model_id):
        ...
        ids_token_ids = ids_processed_inputs["prompt_token_ids"]
>       assert ids_token_ids.count(tokenizer.bos_token_id) == 1
E       assert 2 == 1

```

After patch: passes. 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

