### PR TITLE
Expose offline engine iteration statistics

### DIFF
--- a/tests/v1/engine/test_llm_engine_step.py
+++ b/tests/v1/engine/test_llm_engine_step.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.v1.engine.llm_engine import LLMEngine
+from vllm.v1.metrics.stats import SchedulerIterationDetails
+
+
+def test_step_with_stats_returns_existing_iteration_details(monkeypatch):
+    engine = object.__new__(LLMEngine)
+    details = SchedulerIterationDetails(
+        iteration_index=4,
+        num_ctx_requests=1,
+        num_ctx_tokens=512,
+        num_generation_requests=8,
+        num_generation_tokens=8,
+        elapsed_ms=3.5,
+    )
+    monkeypatch.setattr(engine, "has_unfinished_requests", lambda: True)
+
+    def step():
+        engine._last_scheduler_stats = SimpleNamespace(
+            iteration_details=details, kv_cache_usage=0.25
+        )
+        return []
+
+    monkeypatch.setattr(engine, "step", step)
+    result = engine.step_with_stats()
+
+    assert result.outputs == []
+    assert result.stats is details
+    assert result.kv_cache_usage == 0.25
+
+
+def test_step_with_stats_skips_frontend_only_outputs(monkeypatch):
+    engine = object.__new__(LLMEngine)
+    details = SchedulerIterationDetails(
+        iteration_index=1,
+        num_ctx_requests=0,
+        num_ctx_tokens=0,
+        num_generation_requests=1,
+        num_generation_tokens=1,
+        elapsed_ms=1.0,
+    )
+    monkeypatch.setattr(engine, "has_unfinished_requests", lambda: True)
+    calls = 0
+
+    def step():
+        nonlocal calls
+        calls += 1
+        engine._last_scheduler_stats = (
+            None
+            if calls == 1
+            else SimpleNamespace(iteration_details=details, kv_cache_usage=0.5)
+        )
+        return [f"output-{calls}"]
+
+    monkeypatch.setattr(engine, "step", step)
+    result = engine.step_with_stats()
+
+    assert result.outputs == ["output-1", "output-2"]
+    assert result.stats is details
+
+
+def test_step_with_stats_requires_iteration_details(monkeypatch):
+    engine = object.__new__(LLMEngine)
+    monkeypatch.setattr(engine, "has_unfinished_requests", lambda: True)
+
+    def step():
+        engine._last_scheduler_stats = SimpleNamespace(
+            iteration_details=None, kv_cache_usage=0.0
+        )
+        return []
+
+    monkeypatch.setattr(engine, "step", step)
+    with pytest.raises(RuntimeError, match="iteration details are disabled"):
+        engine.step_with_stats()
+
+
+def test_step_with_stats_requires_model_iteration(monkeypatch):
+    engine = object.__new__(LLMEngine)
+    monkeypatch.setattr(engine, "has_unfinished_requests", lambda: False)
+    with pytest.raises(RuntimeError, match="no model iteration"):
+        engine.step_with_stats()

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -52,7 +52,7 @@ from vllm.tokenizers import TokenizerLike
 from vllm.usage.usage_lib import UsageContext
 from vllm.utils.counter import Counter
 from vllm.v1.engine import PauseMode
-from vllm.v1.engine.llm_engine import LLMEngine
+from vllm.v1.engine.llm_engine import EngineStepResult, LLMEngine
 from vllm.v1.sample.logits_processor import LogitsProcessor
 
 from ..renderers import ChatParams
@@ -785,6 +785,10 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
                            If not provided, default naming will be used.
         """
         self.llm_engine.start_profile(profile_prefix)
+
+    def step_with_stats(self) -> EngineStepResult:
+        """Consume one queued offline model iteration and return its statistics."""
+        return self.llm_engine.step_with_stats()
 
     def stop_profile(self) -> None:
         self.llm_engine.stop_profile()

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -5,6 +5,7 @@ import time
 import weakref
 from collections.abc import Callable, Mapping
 from copy import copy
+from dataclasses import dataclass
 from typing import Any
 
 import torch.nn as nn
@@ -36,13 +37,22 @@ from vllm.v1.engine.parallel_sampling import ParentRequest
 from vllm.v1.executor import Executor
 from vllm.v1.metrics.loggers import StatLoggerFactory, StatLoggerManager
 from vllm.v1.metrics.reader import Metric, get_metrics_snapshot
-from vllm.v1.metrics.stats import IterationStats
+from vllm.v1.metrics.stats import IterationStats, SchedulerIterationDetails
 from vllm.v1.utils import record_function_or_nullcontext
 from vllm.v1.worker.worker_base import WorkerBase
 
 logger = init_logger(__name__)
 
 _R = TypeVar("_R", default=Any)
+
+
+@dataclass(frozen=True)
+class EngineStepResult:
+    """Public measurements for one offline engine iteration."""
+
+    outputs: list[RequestOutput | PoolingRequestOutput]
+    stats: SchedulerIterationDetails
+    kv_cache_usage: float
 
 
 class LLMEngine:
@@ -294,6 +304,7 @@ class LLMEngine:
         return req_id
 
     def step(self) -> list[RequestOutput | PoolingRequestOutput]:
+        self._last_scheduler_stats = None
         if self.should_execute_dummy_batch:
             self.should_execute_dummy_batch = False
             self.engine_core.execute_dummy_batch()
@@ -312,6 +323,7 @@ class LLMEngine:
                 iteration_stats=iteration_stats,
             )
             self.output_processor.update_scheduler_stats(outputs.scheduler_stats)
+            self._last_scheduler_stats = outputs.scheduler_stats
 
         # 3) Abort any reqs that finished due to stop strings.
         with record_function_or_nullcontext("llm_engine step: abort_requests"):
@@ -332,6 +344,26 @@ class LLMEngine:
                 self.do_log_stats_with_interval()
 
         return processed_outputs.request_outputs
+
+    def step_with_stats(self) -> EngineStepResult:
+        """Consume the next model iteration and return its existing statistics."""
+        outputs = []
+        while self.has_unfinished_requests():
+            outputs.extend(self.step())
+            scheduler_stats = self._last_scheduler_stats
+            if scheduler_stats is not None:
+                details = scheduler_stats.iteration_details
+                if details is None:
+                    raise RuntimeError(
+                        "iteration details are disabled; set "
+                        "enable_logging_iteration_details=True"
+                    )
+                return EngineStepResult(
+                    outputs=outputs,
+                    stats=details,
+                    kv_cache_usage=scheduler_stats.kv_cache_usage,
+                )
+        raise RuntimeError("no model iteration was executed")
 
     def start_profile(self, profile_prefix: str | None = None):
         self.engine_core.profile(True, profile_prefix)


### PR DESCRIPTION
## Purpose

Expose the scheduler statistics that vLLM already computes for an offline engine iteration through a small LLM.step_with_stats() API.

The change does not alter scheduling, request lifecycle, model execution, or profiling. It only retains SchedulerStats while LLMEngine.step() processes an output and returns the existing iteration details and KV-cache usage to the caller.

## Test Plan

Run the focused unit tests and Ruff on the touched files.

## Test Result

- 4 focused tests passed
- Ruff passed
- git diff --check passed

No documentation update is needed because this is a narrowly scoped offline API.