### PR TITLE
[GLM Perf] DSv32/glm use skip topk for MTP case, 2.0x kernel performance improvement

### DIFF
--- a/vllm/models/deepseek_v32/amd/rocm.py
+++ b/vllm/models/deepseek_v32/amd/rocm.py
@@ -167,7 +167,7 @@ class DeepseekV32MLAAttention(DeepseekV32Attention):
         assert isinstance(slot_mapping, dict)
         mla_slot = slot_mapping.get(self.layer_name)
 
-        if self.indexer is not None:
+        if self.indexer is not None and not self.skip_topk:
             has_indexer = True
             indexer_k_norm_w = self.indexer.k_norm.weight
             indexer_k_norm_bias = self.indexer.k_norm.bias
@@ -222,7 +222,7 @@ class DeepseekV32MLAAttention(DeepseekV32Attention):
 
         ql_nope, q_pe = self._compute_ql_nope(q_c)
 
-        if self.indexer is not None:
+        if self.indexer is not None and not self.skip_topk:
             index_q = self.indexer.wq_b(q_c)[0]
             index_q = index_q.view(-1, self.indexer.n_head, self.indexer.head_dim)
         else:
@@ -244,7 +244,8 @@ class DeepseekV32MLAAttention(DeepseekV32Attention):
             quantize_mqa=self._fp8_kv,
         )
 
-        self._run_indexer(q_c, index_q_fp8, index_weights_out)
+        if self.indexer is not None and not self.skip_topk:
+            self._run_indexer(q_c, index_q_fp8, index_weights_out)
 
         if attn_metadata is None:
             output.zero_()

--- a/vllm/models/deepseek_v32/attention.py
+++ b/vllm/models/deepseek_v32/attention.py
@@ -372,7 +372,7 @@ class DeepseekV32Attention(MLAAttention):
         assert isinstance(slot_mapping, dict)
         mla_slot = slot_mapping.get(self.layer_name)
 
-        if self.indexer is not None:
+        if self.indexer is not None and not self.skip_topk:
             has_indexer = True
             indexer_k_norm_w = self.indexer.k_norm.weight
             indexer_k_norm_bias = self.indexer.k_norm.bias
@@ -430,7 +430,7 @@ class DeepseekV32Attention(MLAAttention):
         q_nope = q_nope.transpose(0, 1)
         ql_nope = torch.bmm(q_nope, self.W_UK_T).transpose(0, 1)
 
-        if self.indexer is not None:
+        if self.indexer is not None and not self.skip_topk:
             index_q = self.indexer.wq_b(q_c)[0]
             index_q = index_q.view(-1, self.indexer.n_head, self.indexer.head_dim)
         else:
@@ -452,7 +452,7 @@ class DeepseekV32Attention(MLAAttention):
             quantize_mqa=self._fp8_query,
         )
 
-        if self.indexer is not None:
+        if self.indexer is not None and not self.skip_topk:
             sparse_attn_indexer(
                 q_c,
                 self.indexer.k_cache.prefix,


### PR DESCRIPTION
## Purpose

Part of https://github.com/vllm-project/vllm/issues/46654

Now we can use skip_topk attribute to skip some redundant calculation

In main:
```bash
proposer.set_skip_topk(True)
-> MTP Indexer is still preserved
-> eager _fused_attention checks only indexer != None
-> has_indexer=True
-> fused_norm_rope receives index_k=None
-> recomputeNow
```

Now
```bash
proposer.set_skip_topk(True)
-> MTP Indexer is still preserved
-> eager _fused_attention checks indexer != None and not skip_topk
-> has_indexer=False
-> skip Indexer Q/K processing
-> skip sparse_attn_indexer and Top-K computation
-> reuse the Top-K buffer produced by step 0
-> continue normal MLA attention
```

## Test

Acc covered in current unit test

Perf can be seen in this AI generated script

```bash
import os
import statistics
from pathlib import Path

os.environ.setdefault("VLLM_USE_DEEP_GEMM", "1")

import torch
import torch.nn.functional as F
from safetensors import safe_open

from vllm.models.deepseek_v32.common.kernels import fused_norm_rope, fused_q
from vllm.utils.deep_gemm import (
    fp8_fp4_paged_mqa_logits,
    get_num_sms,
    get_paged_mqa_logits_metadata,
)


# Change this one path if the checkpoint is stored elsewhere.
CHECKPOINT = Path(
    "/data/playground/engine/hub_cache/"
    "models--nvidia--GLM-5.2-NVFP4/snapshots/"
    "aec724e8c7b8ee9db3b48c01c320f63f9cdaf8aa/"
    "model-00047-of-00047.safetensors"
)

# One representative decode case. These are GLM-5.2 TP=8 dimensions.
BATCH_SIZE = 1
CONTEXT_LEN = 8192
WARMUP = 100
ITERATIONS = 1000
TRIALS = 7

HIDDEN_SIZE = 6144
Q_LORA_RANK = 2048
KV_LORA_RANK = 512
ROPE_DIM = 64
LOCAL_Q_HEADS = 8
INDEX_HEADS = 32
INDEX_DIM = 128
TOPK = 2048
BLOCK_SIZE = 64


def load_weights() -> dict[str, torch.Tensor]:
    prefix = "model.layers.78.self_attn."
    names = {
        "wk": prefix + "indexer.wk.weight",
        "weights": prefix + "indexer.weights_proj.weight",
        "wq": prefix + "indexer.wq_b.weight",
        "index_norm_w": prefix + "indexer.k_norm.weight",
        "index_norm_b": prefix + "indexer.k_norm.bias",
        "q_norm_w": prefix + "q_a_layernorm.weight",
        "kv_norm_w": prefix + "kv_a_layernorm.weight",
    }
    with safe_open(CHECKPOINT, framework="pt", device="cpu") as checkpoint:
        weights = {
            key: checkpoint.get_tensor(name).cuda() for key, name in names.items()
        }
    weights["wk_weights"] = torch.cat(
        [weights.pop("wk"), weights.pop("weights")], dim=0
    ).contiguous()
    return weights


def make_cos_sin() -> torch.Tensor:
    half = ROPE_DIM // 2
    inv_freq = 1.0 / (
        8_000_000.0
        ** (torch.arange(half, device="cuda", dtype=torch.float32) / half)
    )
    positions = torch.arange(
        CONTEXT_LEN + 1, device="cuda", dtype=torch.float32
    )
    freqs = torch.outer(positions, inv_freq)
    return torch.cat([freqs.cos(), freqs.sin()], dim=-1)


def benchmark(fn) -> float:
    for _ in range(WARMUP):
        fn()
    torch.cuda.synchronize()

    samples = []
    for _ in range(TRIALS):
        start = torch.cuda.Event(enable_timing=True)
        end = torch.cuda.Event(enable_timing=True)
        start.record()
        for _ in range(ITERATIONS):
            fn()
        end.record()
        end.synchronize()
        samples.append(start.elapsed_time(end) * 1000 / ITERATIONS)
    return statistics.median(samples)


@torch.inference_mode()
def main() -> None:
    assert torch.cuda.is_available()
    assert CHECKPOINT.exists(), CHECKPOINT
    torch.manual_seed(0)
    weights = load_weights()

    batch = BATCH_SIZE
    num_blocks = (CONTEXT_LEN + BLOCK_SIZE - 1) // BLOCK_SIZE
    num_physical_blocks = num_blocks + batch

    hidden = torch.randn(batch, HIDDEN_SIZE, device="cuda", dtype=torch.bfloat16)
    q_c = torch.randn(batch, Q_LORA_RANK, device="cuda", dtype=torch.bfloat16)
    kv_c = torch.randn(batch, KV_LORA_RANK, device="cuda", dtype=torch.bfloat16)
    k_pe = torch.randn(batch, ROPE_DIM, device="cuda", dtype=torch.bfloat16)
    q_pe = torch.randn(
        batch, LOCAL_Q_HEADS, ROPE_DIM, device="cuda", dtype=torch.bfloat16
    )
    ql_nope = torch.randn(
        batch, LOCAL_Q_HEADS, KV_LORA_RANK, device="cuda", dtype=torch.bfloat16
    )
    positions = torch.full(
        (batch,), CONTEXT_LEN - 1, device="cuda", dtype=torch.int64
    )
    cos_sin = make_cos_sin()
    q_scale = torch.ones(1, device="cuda", dtype=torch.float32)
    topk_indices = torch.zeros(batch, TOPK, device="cuda", dtype=torch.int32)

    # FP8 Indexer cache: 128 value bytes + one fp32 scale per token.
    index_cache = torch.empty(
        num_physical_blocks,
        BLOCK_SIZE,
        INDEX_DIM + 4,
        device="cuda",
        dtype=torch.uint8,
    )
    index_values = torch.randn(
        num_physical_blocks,
        BLOCK_SIZE,
        INDEX_DIM,
        device="cuda",
        dtype=torch.bfloat16,
    ).to(torch.float8_e4m3fn)
    index_cache[..., :INDEX_DIM].copy_(index_values.view(torch.uint8))
    index_cache[..., INDEX_DIM:].view(torch.float32).fill_(1.0)

    # The common MLA cache write remains active in both paths.
    mla_cache = torch.zeros(
        num_physical_blocks,
        BLOCK_SIZE,
        656,
        device="cuda",
        dtype=torch.uint8,
    )
    block_tables = torch.arange(
        num_blocks, device="cuda", dtype=torch.int32
    ).repeat(batch, 1)
    block_tables[:, -1] = torch.arange(
        num_blocks, num_blocks + batch, device="cuda", dtype=torch.int32
    )
    slot_mapping = (
        block_tables[:, -1].to(torch.int64) * BLOCK_SIZE
        + (CONTEXT_LEN - 1) % BLOCK_SIZE
    )
    context_lens = torch.full(
        (batch, 1), CONTEXT_LEN, device="cuda", dtype=torch.int32
    )
    schedule = get_paged_mqa_logits_metadata(
        context_lens, BLOCK_SIZE, get_num_sms()
    )
    topk_workspace = torch.empty(1024 * 1024, device="cuda", dtype=torch.uint8)

    def before() -> None:
        """Old behavior: recompute the complete Indexer on this draft step."""
        index_k_and_weights = F.linear(hidden, weights["wk_weights"])
        normalized_q = fused_norm_rope(
            positions,
            q_c,
            weights["q_norm_w"],
            1e-5,
            kv_c,
            weights["kv_norm_w"],
            1e-5,
            k_pe,
            cos_sin,
            index_k_and_weights[:, :INDEX_DIM],
            weights["index_norm_w"],
            weights["index_norm_b"],
            1e-6,
            cos_sin,
            topk_indices,
            slot_mapping=slot_mapping,
            indexer_k_cache=index_cache,
            mla_kv_cache=mla_cache,
            mla_kv_cache_dtype="fp8_ds_mla",
            has_indexer=True,
            index_rope_interleave=True,
        )
        index_q = F.linear(normalized_q, weights["wq"]).view(
            batch, INDEX_HEADS, INDEX_DIM
        )
        index_q_fp8, index_weights, _ = fused_q(
            positions,
            q_pe,
            cos_sin,
            index_q,
            cos_sin,
            ql_nope,
            q_scale,
            index_k_and_weights[:, INDEX_DIM:],
            INDEX_DIM**-0.5,
            INDEX_HEADS**-0.5,
            has_indexer=True,
            index_rope_interleave=True,
            quantize_mqa=False,
        )
        logits = fp8_fp4_paged_mqa_logits(
            (index_q_fp8.view(batch, 1, INDEX_HEADS, INDEX_DIM), None),
            index_cache.unsqueeze(-2),
            index_weights,
            context_lens,
            block_tables,
            schedule,
            max_model_len=CONTEXT_LEN,
            clean_logits=False,
        )
        torch.ops._C.cooperative_topk(
            logits,
            context_lens,
            topk_indices,
            topk_workspace,
            TOPK,
            CONTEXT_LEN,
        )

    def after() -> None:
        """New behavior: keep the common work, but reuse existing Top-K."""
        fused_norm_rope(
            positions,
            q_c,
            weights["q_norm_w"],
            1e-5,
            kv_c,
            weights["kv_norm_w"],
            1e-5,
            k_pe,
            cos_sin,
            None,
            None,
            None,
            1e-6,
            None,
            topk_indices,
            slot_mapping=slot_mapping,
            indexer_k_cache=None,
            mla_kv_cache=mla_cache,
            mla_kv_cache_dtype="fp8_ds_mla",
            has_indexer=False,
            index_rope_interleave=True,
        )
        fused_q(
            positions,
            q_pe,
            cos_sin,
            None,
            None,
            ql_nope,
            q_scale,
            None,
            0.0,
            0.0,
            has_indexer=False,
            index_rope_interleave=True,
            quantize_mqa=False,
        )

    # Trigger Triton/DeepGEMM JIT before measuring.
    before()
    after()
    torch.cuda.synchronize()

    before_us = benchmark(before)
    after_us = benchmark(after)
    saved_us = before_us - after_us

    print(f"GPU: {torch.cuda.get_device_name()}")
    print(f"case: batch={batch}, context={CONTEXT_LEN}, TP=8, BF16 query")
    print(f"before (compute Indexer): {before_us:.2f} us")
    print(f"after  (reuse Top-K):     {after_us:.2f} us")
    print(f"saved:                   {saved_us:.2f} us")
    print(f"speedup:                 {before_us / after_us:.2f}x")
    print(f"latency reduction:       {saved_us / before_us:.1%}")


if __name__ == "__main__":
    main()

```

And we can get

```bash
GPU: NVIDIA H200
case: batch=1, context=8192, TP=8, BF16 query
before (compute Indexer): 168.33 us
after  (reuse Top-K):     84.22 us
saved:                   84.11 us
speedup:                 2.00x
latency reduction:       50.0%
```