### PR TITLE
[Bugfix][Attention] Guard sparse MLA masked MHA workspace

### DIFF
--- a/tests/v1/attention/test_sparse_mla_backends.py
+++ b/tests/v1/attention/test_sparse_mla_backends.py
@@ -864,9 +864,6 @@ def test_split_prefill_chunks(seq_lens, max_buf, expected):
     assert out == expected
 
 
-DEFAULT_TOPK_MASK_WORKSPACE_NUMEL = GLOBAL_TOPK_MASK_MAX_BYTES // torch.int32.itemsize
-
-
 @pytest.mark.parametrize(
     ("max_query_len", "expected"),
     [(32768, True), (33024, False)],
@@ -879,7 +876,7 @@ def test_masked_mha_workspace_fits_single_request_boundary(max_query_len, expect
             batch_size=1,
             max_query_len=max_query_len,
             context_chunk_max_seq_lens=None,
-            workspace_numel=DEFAULT_TOPK_MASK_WORKSPACE_NUMEL,
+            workspace_numel=GLOBAL_TOPK_MASK_MAX_BYTES // torch.int32.itemsize,
         )
         is expected
     )

--- a/tests/v1/attention/test_sparse_mla_backends.py
+++ b/tests/v1/attention/test_sparse_mla_backends.py
@@ -21,6 +21,9 @@ from tests.v1.attention.utils import (
 )
 from vllm import _custom_ops as ops
 from vllm.config import set_current_vllm_config
+from vllm.model_executor.layers.attention.sparse_mla_attention import (
+    _masked_mha_workspace_fits,
+)
 from vllm.model_executor.layers.linear import ColumnParallelLinear
 from vllm.platforms import current_platform
 
@@ -857,6 +860,67 @@ def test_flashmla_forward_bf16_kv_slices_req_id_to_mqa_tokens():
 def test_split_prefill_chunks(seq_lens, max_buf, expected):
     out = split_prefill_chunks(seq_lens, max_buf)
     assert out == expected
+
+
+@pytest.mark.parametrize(
+    (
+        "batch_size",
+        "max_query_len",
+        "context_chunk_max_seq_lens",
+        "workspace_numel",
+        "expected",
+    ),
+    [
+        pytest.param(
+            1,
+            32768,
+            None,
+            128 * 1024 * 1024 // torch.int32.itemsize,
+            True,
+            id="single-32k-fits-128-mib",
+        ),
+        pytest.param(
+            5,
+            16384,
+            None,
+            128 * 1024 * 1024 // torch.int32.itemsize,
+            False,
+            id="mixed-prefill-exceeds-128-mib",
+        ),
+        pytest.param(
+            1,
+            16,
+            [16],
+            128,
+            True,
+            id="per-chunk-mask-fits-when-global-mask-does-not",
+        ),
+        pytest.param(
+            2,
+            256,
+            [512],
+            7000,
+            False,
+            id="context-chunk-mask-exceeds-workspace",
+        ),
+    ],
+)
+def test_masked_mha_workspace_fits(
+    batch_size,
+    max_query_len,
+    context_chunk_max_seq_lens,
+    workspace_numel,
+    expected,
+):
+    assert (
+        _masked_mha_workspace_fits(
+            batch_size=batch_size,
+            max_query_len=max_query_len,
+            context_chunk_max_seq_lens=context_chunk_max_seq_lens,
+            workspace_numel=workspace_numel,
+        )
+        is expected
+    )
 
 
 PREFILL_BATCH_SPECS = {

--- a/tests/v1/attention/test_sparse_mla_backends.py
+++ b/tests/v1/attention/test_sparse_mla_backends.py
@@ -22,7 +22,9 @@ from tests.v1.attention.utils import (
 from vllm import _custom_ops as ops
 from vllm.config import set_current_vllm_config
 from vllm.model_executor.layers.attention.sparse_mla_attention import (
+    GLOBAL_TOPK_MASK_MAX_BYTES,
     _masked_mha_workspace_fits,
+    _topk_mask_shape,
 )
 from vllm.model_executor.layers.linear import ColumnParallelLinear
 from vllm.platforms import current_platform
@@ -862,64 +864,38 @@ def test_split_prefill_chunks(seq_lens, max_buf, expected):
     assert out == expected
 
 
+DEFAULT_TOPK_MASK_WORKSPACE_NUMEL = GLOBAL_TOPK_MASK_MAX_BYTES // torch.int32.itemsize
+
+
 @pytest.mark.parametrize(
-    (
-        "batch_size",
-        "max_query_len",
-        "context_chunk_max_seq_lens",
-        "workspace_numel",
-        "expected",
-    ),
-    [
-        pytest.param(
-            1,
-            32768,
-            None,
-            128 * 1024 * 1024 // torch.int32.itemsize,
-            True,
-            id="single-32k-fits-128-mib",
-        ),
-        pytest.param(
-            5,
-            16384,
-            None,
-            128 * 1024 * 1024 // torch.int32.itemsize,
-            False,
-            id="mixed-prefill-exceeds-128-mib",
-        ),
-        pytest.param(
-            1,
-            16,
-            [16],
-            128,
-            True,
-            id="per-chunk-mask-fits-when-global-mask-does-not",
-        ),
-        pytest.param(
-            2,
-            256,
-            [512],
-            7000,
-            False,
-            id="context-chunk-mask-exceeds-workspace",
-        ),
-    ],
+    ("max_query_len", "expected"),
+    [(32768, True), (33024, False)],
 )
-def test_masked_mha_workspace_fits(
-    batch_size,
-    max_query_len,
-    context_chunk_max_seq_lens,
-    workspace_numel,
-    expected,
-):
+def test_masked_mha_workspace_fits_single_request_boundary(max_query_len, expected):
+    """A 32K prefill needs the default workspace exactly; shrinking it would
+    push a supported request onto MQA."""
     assert (
         _masked_mha_workspace_fits(
-            batch_size=batch_size,
+            batch_size=1,
             max_query_len=max_query_len,
-            context_chunk_max_seq_lens=context_chunk_max_seq_lens,
-            workspace_numel=workspace_numel,
+            context_chunk_max_seq_lens=None,
+            workspace_numel=DEFAULT_TOPK_MASK_WORKSPACE_NUMEL,
         )
         is expected
+    )
+
+
+def test_masked_mha_workspace_fits_accounts_for_batch_and_context():
+    """Request count and context chunk length are independent multipliers."""
+    base = dict(batch_size=2, max_query_len=2048, context_chunk_max_seq_lens=[2048])
+    exact = math.prod(_topk_mask_shape(2, 2048, 2048))
+
+    assert _masked_mha_workspace_fits(**base, workspace_numel=exact)
+    assert not _masked_mha_workspace_fits(
+        **{**base, "batch_size": 3}, workspace_numel=exact
+    )
+    assert not _masked_mha_workspace_fits(
+        **{**base, "context_chunk_max_seq_lens": [4096]}, workspace_numel=exact
     )
 
 

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -763,6 +763,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 and self.impl.masked_mha_available  # type: ignore[attr-defined]
                 and self.impl.dcp_world_size <= 1
                 and prefill is not None
+                and prefill.masked_mha_workspace_fits
                 and _use_masked_mha(
                     backend_name=self.attn_backend.get_name(),
                     tensor_parallel_size=self._vllm_config.parallel_config.tensor_parallel_size,
@@ -1393,6 +1394,7 @@ class MLACommonPrefillMetadata:
     query_lens_cpu: torch.Tensor | None = None
     use_dense_mha: bool = False
     topk_mask_workspace: torch.Tensor | None = None
+    masked_mha_workspace_fits: bool = False
 
 
 @dataclass

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -763,13 +763,13 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 and self.impl.masked_mha_available  # type: ignore[attr-defined]
                 and self.impl.dcp_world_size <= 1
                 and prefill is not None
-                and prefill.masked_mha_workspace_fits
                 and _use_masked_mha(
                     backend_name=self.attn_backend.get_name(),
                     tensor_parallel_size=self._vllm_config.parallel_config.tensor_parallel_size,
                     query_len=prefill.max_query_len,
                     seq_len=prefill_max_seq_len,
                 )
+                and self.impl.masked_mha_workspace_fits(prefill)  # type: ignore[attr-defined]
             )
             use_mha = (use_dense_mha or use_masked_mha) and not (
                 self._vllm_config.attention_config.sparse_mla_force_mqa
@@ -1394,7 +1394,6 @@ class MLACommonPrefillMetadata:
     query_lens_cpu: torch.Tensor | None = None
     use_dense_mha: bool = False
     topk_mask_workspace: torch.Tensor | None = None
-    masked_mha_workspace_fits: bool = False
 
 
 @dataclass

--- a/vllm/model_executor/layers/attention/sparse_mla_attention.py
+++ b/vllm/model_executor/layers/attention/sparse_mla_attention.py
@@ -273,25 +273,6 @@ class SparseMLACommonMetadataBuilder(AttentionMetadataBuilder[T]):
                 num_prefills,
                 prefill_query_lens_cpu,
             )
-            workspace = self.topk_mask_workspace
-            masked_mha_workspace_fits = workspace is not None and (
-                _masked_mha_workspace_fits(
-                    batch_size=num_prefills,
-                    max_query_len=prefill_max_query_len,
-                    context_chunk_max_seq_lens=(
-                        None
-                        if chunked_context is None
-                        else chunked_context.max_seq_lens
-                    ),
-                    workspace_numel=workspace.numel(),
-                )
-            )
-            if workspace is not None and not masked_mha_workspace_fits:
-                logger.warning_once(
-                    "Sparse MLA top-k mask workspace (%d MiB) is too small for "
-                    "some prefill batches; those fall back to slower sparse MQA.",
-                    workspace.numel() * torch.int32.itemsize // (1024 * 1024),
-                )
             prefill = MLACommonPrefillMetadata(
                 block_table=common_attn_metadata.block_table_tensor[num_decodes:, ...],
                 query_start_loc=prefill_query_start_loc,
@@ -305,8 +286,7 @@ class SparseMLACommonMetadataBuilder(AttentionMetadataBuilder[T]):
                     prefill_max_seq_len <= self.topk_tokens
                     and not self.vllm_config.attention_config.sparse_mla_force_mqa
                 ),
-                topk_mask_workspace=workspace,
-                masked_mha_workspace_fits=masked_mha_workspace_fits,
+                topk_mask_workspace=self.topk_mask_workspace,
             )
             self._prefill_backend.prepare_metadata(prefill)
 
@@ -556,6 +536,30 @@ class SparseMLACommonImpl(MLACommonBaseImpl[T], Generic[T]):
             v_head_dim=v_head_dim,
             kv_cache_dtype=kv_cache_dtype,
         )
+
+    @staticmethod
+    def masked_mha_workspace_fits(prefill: MLACommonPrefillMetadata) -> bool:
+        """Whether this prefill batch's top-k masks fit the workspace."""
+        workspace = prefill.topk_mask_workspace
+        if workspace is None or prefill.query_lens_cpu is None:
+            return False
+        fits = _masked_mha_workspace_fits(
+            batch_size=len(prefill.query_lens_cpu),
+            max_query_len=prefill.max_query_len,
+            context_chunk_max_seq_lens=(
+                None
+                if prefill.chunked_context is None
+                else prefill.chunked_context.max_seq_lens
+            ),
+            workspace_numel=workspace.numel(),
+        )
+        if not fits:
+            logger.warning_once(
+                "Sparse MLA top-k mask workspace (%d MiB) is too small for some "
+                "prefill batches; those fall back to slower sparse MQA.",
+                workspace.numel() * torch.int32.itemsize // (1024 * 1024),
+            )
+        return fits
 
     @staticmethod
     def _slice_topk_per_req(

--- a/vllm/model_executor/layers/attention/sparse_mla_attention.py
+++ b/vllm/model_executor/layers/attention/sparse_mla_attention.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Shared MHA implementation and metadata builder for sparse MLA backends."""
 
+import math
 from shutil import which
 from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar, cast
 
@@ -43,25 +44,34 @@ T = TypeVar("T", bound=AttentionMetadata)
 GLOBAL_TOPK_MASK_MAX_BYTES = 128 * 1024 * 1024  # 128 MiB
 
 
+def _topk_mask_shape(
+    batch_size: int,
+    max_query_len: int,
+    max_key_len: int,
+    reserve_key_starts_word: bool = False,
+) -> tuple[int, int, int]:
+    """Shape of a bit-packed top-k mask, shared by every site that builds one."""
+    tile_m = 128 if max_query_len <= 128 else 256
+    padded_q_len = triton.cdiv(max_query_len, tile_m) * tile_m
+    num_words = triton.cdiv(max_key_len, 32) + int(reserve_key_starts_word)
+    return batch_size, padded_q_len, num_words
+
+
 def _masked_mha_workspace_fits(
     batch_size: int,
     max_query_len: int,
     context_chunk_max_seq_lens: list[int] | None,
     workspace_numel: int,
 ) -> bool:
-    """Return whether every required per-run mask fits the workspace.
+    """Return whether the suffix and per-context-chunk masks fit the workspace.
 
-    The optional full-sequence mask has its own capacity check and falls back
-    to suffix and per-context-chunk masks when it is too large.
+    The global mask is excluded: it always needs more, and has its own check.
     """
     max_key_len = max(
         max_query_len,
         max(context_chunk_max_seq_lens or (), default=0),
     )
-    tile_m = 128 if max_query_len <= 128 else 256
-    padded_q_len = (max_query_len + tile_m - 1) // tile_m * tile_m
-    num_words = (max_key_len + 31) // 32
-    needed = batch_size * padded_q_len * num_words
+    needed = math.prod(_topk_mask_shape(batch_size, max_query_len, max_key_len))
     return needed <= workspace_numel
 
 
@@ -276,6 +286,12 @@ class SparseMLACommonMetadataBuilder(AttentionMetadataBuilder[T]):
                     workspace_numel=workspace.numel(),
                 )
             )
+            if workspace is not None and not masked_mha_workspace_fits:
+                logger.warning_once(
+                    "Sparse MLA top-k mask workspace (%d MiB) is too small for "
+                    "some prefill batches; those fall back to slower sparse MQA.",
+                    workspace.numel() * torch.int32.itemsize // (1024 * 1024),
+                )
             prefill = MLACommonPrefillMetadata(
                 block_table=common_attn_metadata.block_table_tensor[num_decodes:, ...],
                 query_start_loc=prefill_query_start_loc,
@@ -591,12 +607,14 @@ class SparseMLACommonImpl(MLACommonBaseImpl[T], Generic[T]):
         mask is too large, signalling the caller to fall back to per-chunk
         index remapping.
         """
-        batch_size = len(q_lens)
-        tile_m = 128 if max_query_len <= 128 else 256
-        padded_q_len = triton.cdiv(max_query_len, tile_m) * tile_m
-        num_words_padded = (max_seq_len + 31) // 32 + 1
+        batch_size, padded_q_len, num_words_padded = _topk_mask_shape(
+            len(q_lens),
+            max_query_len,
+            max_seq_len,
+            reserve_key_starts_word=True,
+        )
         needed = batch_size * padded_q_len * num_words_padded
-        if needed * torch.int32.itemsize > GLOBAL_TOPK_MASK_MAX_BYTES:
+        if needed > topk_mask_workspace.numel():
             return None
 
         mask = topk_mask_workspace[:needed].view(
@@ -634,15 +652,21 @@ class SparseMLACommonImpl(MLACommonBaseImpl[T], Generic[T]):
         )
         from vllm.vllm_flash_attn import flash_attn_varlen_func
 
-        tile_m = 128 if max_seqlen_q <= 128 else 256
-        padded_q_len = triton.cdiv(max_seqlen_q, tile_m) * tile_m
         if dense_mask is None:
-            batch_size = len(q_lens)
-            num_words = (max_seqlen_k + 31) // 32
             assert topk_mask_workspace is not None
-            workspace_3d = topk_mask_workspace[
-                : batch_size * padded_q_len * num_words
-            ].view(batch_size, padded_q_len, num_words)
+            batch_size, padded_q_len, num_words = _topk_mask_shape(
+                len(q_lens), max_seqlen_q, max_seqlen_k
+            )
+            words_needed = batch_size * padded_q_len * num_words
+            if words_needed > topk_mask_workspace.numel():
+                raise ValueError(
+                    f"Sparse MLA top-k mask needs {words_needed} int32 words (batch="
+                    f"{len(q_lens)}, q={max_seqlen_q}, k={max_seqlen_k}) but the "
+                    f"workspace holds {topk_mask_workspace.numel()}."
+                )
+            workspace_3d = topk_mask_workspace[:words_needed].view(
+                batch_size, padded_q_len, num_words
+            )
             dense_mask = _build_topk_mask(
                 topk_per_req,
                 q_lens,

--- a/vllm/model_executor/layers/attention/sparse_mla_attention.py
+++ b/vllm/model_executor/layers/attention/sparse_mla_attention.py
@@ -40,7 +40,29 @@ logger = init_logger(__name__)
 
 T = TypeVar("T", bound=AttentionMetadata)
 
-GLOBAL_TOPK_MASK_MAX_BYTES = 64 * 1024 * 1024  # 64 MiB
+GLOBAL_TOPK_MASK_MAX_BYTES = 128 * 1024 * 1024  # 128 MiB
+
+
+def _masked_mha_workspace_fits(
+    batch_size: int,
+    max_query_len: int,
+    context_chunk_max_seq_lens: list[int] | None,
+    workspace_numel: int,
+) -> bool:
+    """Return whether every required per-run mask fits the workspace.
+
+    The optional full-sequence mask has its own capacity check and falls back
+    to suffix and per-context-chunk masks when it is too large.
+    """
+    max_key_len = max(
+        max_query_len,
+        max(context_chunk_max_seq_lens or (), default=0),
+    )
+    tile_m = 128 if max_query_len <= 128 else 256
+    padded_q_len = (max_query_len + tile_m - 1) // tile_m * tile_m
+    num_words = (max_key_len + 31) // 32
+    needed = batch_size * padded_q_len * num_words
+    return needed <= workspace_numel
 
 
 def _is_masked_mha_available(
@@ -235,17 +257,31 @@ class SparseMLACommonMetadataBuilder(AttentionMetadataBuilder[T]):
             prefill_max_seq_len = int(
                 seq_lens_cpu[num_decodes : num_decodes + num_prefills].max().item()
             )
+            chunked_context = self._build_chunked_context_fields(
+                common_attn_metadata,
+                num_decodes,
+                num_prefills,
+                prefill_query_lens_cpu,
+            )
+            workspace = self.topk_mask_workspace
+            masked_mha_workspace_fits = workspace is not None and (
+                _masked_mha_workspace_fits(
+                    batch_size=num_prefills,
+                    max_query_len=prefill_max_query_len,
+                    context_chunk_max_seq_lens=(
+                        None
+                        if chunked_context is None
+                        else chunked_context.max_seq_lens
+                    ),
+                    workspace_numel=workspace.numel(),
+                )
+            )
             prefill = MLACommonPrefillMetadata(
                 block_table=common_attn_metadata.block_table_tensor[num_decodes:, ...],
                 query_start_loc=prefill_query_start_loc,
                 max_query_len=prefill_max_query_len,
                 query_lens_cpu=prefill_query_lens_cpu,
-                chunked_context=self._build_chunked_context_fields(
-                    common_attn_metadata,
-                    num_decodes,
-                    num_prefills,
-                    prefill_query_lens_cpu,
-                ),
+                chunked_context=chunked_context,
                 q_data_type=self.model_config.dtype,
                 output_dtype=self.model_config.dtype,
                 prefill_backend=self._prefill_backend,
@@ -253,7 +289,8 @@ class SparseMLACommonMetadataBuilder(AttentionMetadataBuilder[T]):
                     prefill_max_seq_len <= self.topk_tokens
                     and not self.vllm_config.attention_config.sparse_mla_force_mqa
                 ),
-                topk_mask_workspace=self.topk_mask_workspace,
+                topk_mask_workspace=workspace,
+                masked_mha_workspace_fits=masked_mha_workspace_fits,
             )
             self._prefill_backend.prepare_metadata(prefill)
 

--- a/vllm/model_executor/layers/attention/sparse_mla_attention.py
+++ b/vllm/model_executor/layers/attention/sparse_mla_attention.py
@@ -267,18 +267,17 @@ class SparseMLACommonMetadataBuilder(AttentionMetadataBuilder[T]):
             prefill_max_seq_len = int(
                 seq_lens_cpu[num_decodes : num_decodes + num_prefills].max().item()
             )
-            chunked_context = self._build_chunked_context_fields(
-                common_attn_metadata,
-                num_decodes,
-                num_prefills,
-                prefill_query_lens_cpu,
-            )
             prefill = MLACommonPrefillMetadata(
                 block_table=common_attn_metadata.block_table_tensor[num_decodes:, ...],
                 query_start_loc=prefill_query_start_loc,
                 max_query_len=prefill_max_query_len,
                 query_lens_cpu=prefill_query_lens_cpu,
-                chunked_context=chunked_context,
+                chunked_context=self._build_chunked_context_fields(
+                    common_attn_metadata,
+                    num_decodes,
+                    num_prefills,
+                    prefill_query_lens_cpu,
+                ),
                 q_data_type=self.model_config.dtype,
                 output_dtype=self.model_config.dtype,
                 prefill_backend=self._prefill_backend,


### PR DESCRIPTION
## Purpose

Sparse MLA masked-MHA builds a bit-packed top-k mask whose size is approximately:

```text
num_prefills × round_up(max_query_len, tile_m) × ceil(max_key_len / 32)
    × sizeof(int32)
```

The existing workspace was fixed at 64 MiB, while the routing matrix allows a
single 32K prefill to enter masked-MHA. Such a request requires exactly 128 MiB.
Heterogeneous batches can require even more despite staying within
`max_num_batched_tokens`.

Attempting to reshape the fixed workspace for an oversized mask can cause a CUDA
runtime error. Because CUDA execution is asynchronous, the API may have already
returned HTTP 200 before the worker reports the failure.

This PR:

- increases the top-k mask workspace from 64 MiB to 128 MiB, allowing the
  supported single-request 32K boundary to continue using masked-MHA;
- computes whether the actual workspace can hold every required suffix/context
  mask for the current prefill batch;
- includes that capacity check in the masked-MHA routing decision;
- falls back to the existing sparse MQA path when the mask does not fit;
- preserves the existing global-mask/per-context-chunk optimization behavior.

The workspace allocation increases by 64 MiB on workers where sparse masked-MHA
is available. Oversized batches do not trigger additional allocation.

### Duplicate-work check

No open PR was found that addresses this masked-MHA top-k mask overflow.

Commands checked:

```bash
gh pr list --repo vllm-project/vllm --state open \
  --search "masked MHA workspace"

gh pr list --repo vllm-project/vllm --state open \
  --search "topk mask workspace"

gh pr list --repo vllm-project/vllm --state open \
  --search "sparse MLA workspace"
```

Related work is different in scope:

- #50791 sizes the FlashInfer sparse-MLA decode workspace for DCP LSE.
- #50668 adds FlashMLA grid/workspace guardrails.
- #50613 changes MLA chunked-context scheduling but does not guard this top-k
  mask allocation.

## Test Plan

Run the workspace sizing and adjacent chunk-splitting tests:

```bash
.venv/bin/python -m pytest \
  tests/v1/attention/test_sparse_mla_backends.py \
  -k 'masked_mha_workspace_fits or split_prefill_chunks' -q
```

Run existing sparse prefill correctness coverage:

```bash
.venv/bin/python -m pytest \
  tests/v1/attention/test_sparse_mla_backends.py \
  -k sparse_backend_prefill_correctness -q
```

Run staged pre-commit hooks:

```bash
.venv/bin/pre-commit run
```

Hardware serving validation:

- 8× NVIDIA B300 SXM6
- `nvidia/DeepSeek-V3.2-NVFP4`
- tensor parallel size 8
- BF16 KV cache
- prefix caching disabled
- eager mode
- `max_num_batched_tokens=32768`

Cases:

1. A single 32,768-token prompt requiring exactly 128 MiB.
2. Eight heterogeneous prompts totaling 32,764 tokens, with a theoretical
   256 MiB batch mask.
3. A queued heterogeneous batch
   `[16384, 4096, 4096, 4096, 4095]` behind a 32K blocker, forcing an
   approximately 160 MiB masked-MHA candidate while the blocker remains active.
4. A normal chat-completion request to check generated output, not only HTTP
   status.
5. Service health and CUDA error log checks after every boundary case.

## Test Result

```text
8 passed, 533 deselected
```

for the workspace and chunk-splitting tests.

```text
4 passed, 537 deselected
```

for sparse prefill correctness, covering:

- dense MHA;
- dense MHA with context;
- masked MHA;
- masked MHA with chunked context.

All staged pre-commit hooks passed.

Hardware serving results:

| Case | Result |
| --- | --- |
| Single 32K / 128 MiB boundary | HTTP 200 |
| Heterogeneous 256 MiB candidate | HTTP 200 |
| Queued 160 MiB candidate | HTTP 200 |
| Health after requests | HTTP 200 |
| Semantic smoke test | Returned exactly `REGRESSION_OK` |
| CUDA/worker errors | None |

The final server state reported `Running: 0` and `Waiting: 0`.

No full model evaluation was run because this change does not alter attention
math for batches that fit. Oversized batches are redirected to the existing MQA
implementation instead of entering an invalid masked-MHA launch. Numerical
coverage is provided by the existing sparse prefill correctness tests, and
end-to-end output was validated on B300 hardware.

## AI Assistance

OpenAI Codex was used.