### PR TITLE
[Bugfix] Include disabled multimodal modalities in the model config hash (#50891)

### DIFF
--- a/tests/config/test_multimodal_config.py
+++ b/tests/config/test_multimodal_config.py
@@ -54,6 +54,24 @@ def test_language_model_only_affects_model_hash():
     assert base_hash != lm_only_hash
 
 
+def test_disabled_modality_limit_affects_model_hash():
+    """A modality limit of 0 disables that modality's code path just like
+    language_model_only does, so it must change the model config hash."""
+    model = "llava-hf/llava-1.5-7b-hf"
+    enabled_hash = ModelConfig(model, limit_mm_per_prompt={"image": 1}).compute_hash()
+    disabled_hash = ModelConfig(model, limit_mm_per_prompt={"image": 0}).compute_hash()
+    assert enabled_hash != disabled_hash
+
+
+def test_nonzero_modality_limits_do_not_affect_model_hash():
+    """Non-zero limits only bound request validation, not the computation
+    graph, so they must not change the model config hash."""
+    model = "llava-hf/llava-1.5-7b-hf"
+    one_hash = ModelConfig(model, limit_mm_per_prompt={"image": 1}).compute_hash()
+    many_hash = ModelConfig(model, limit_mm_per_prompt={"image": 8}).compute_hash()
+    assert one_hash == many_hash
+
+
 @pytest.mark.parametrize("backend_arg", ["video_backend", "backend"])
 def test_use_gpu_video_backend_from_media_io_kwargs(backend_arg: str):
     config = MultiModalConfig(

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -452,6 +452,17 @@ class ModelConfig:
         # here early.
         if self.multimodal_config:
             factors["language_model_only"] = self.multimodal_config.language_model_only
+            # Setting a modality's limit to 0 disables that modality exactly the
+            # way `language_model_only` disables all of them (see
+            # `MultiModalRegistry.supports_multimodal_inputs`), so it likewise
+            # affects the language model's computation graph. Only which
+            # modalities are disabled matters; the non-zero counts bound request
+            # validation rather than the graph and stay ignored.
+            factors["disabled_mm_modalities"] = sorted(
+                modality
+                for modality, options in self.multimodal_config.limit_per_prompt.items()
+                if options.count == 0
+            )
         return hash_factors(factors)
 
     def _update_nested(


### PR DESCRIPTION
## Purpose

Fixes #50891.

`ModelConfig.compute_hash()` lists both `multimodal_config` and `limit_mm_per_prompt` in `ignored_factors`, so the AOT compile cache key does not distinguish a run with a modality enabled from one with the same modality set to `0`.

But a zero limit is not inert: `MultiModalRegistry.supports_multimodal_inputs()` returns `False` when every supported modality's limit is `0`, which puts the model on the text-only path — the language model is called with a real `input_ids` tensor instead of `inputs_embeds`. Two different forward signatures, one cache entry.

Because `CompilationConfig.evaluate_guards` defaults to `False`, `decorators.py` calls `disable_guard_check()` on disk-loaded artifacts, so the mismatch is never detected. The stale artifact's pre-graph bytecode then calls `.size()` on `None`:

```
vllm/compilation/decorators.py:573    __call__
torch/_dynamo/aot_compile.py:224      __call__
  -> gemma4.py:1283 forward            (mistral.py:217 for Mistral3)
AttributeError: 'NoneType' object has no attribute 'size'
```

The failure is bidirectional, which is what makes it more than a startup annoyance: an `image:1` run poisons the entry for a subsequent `image:0` run *and* vice versa, so a previously working text-only deployment can be broken by an unrelated image-enabled launch of the same model. The reporter verified both directions on two unrelated families (`nvidia/Gemma-4-31B-IT-NVFP4`, `cyankiwi/Ministral-3-14B-Instruct-2512-AWQ-4bit`); wiping `~/.cache/vllm/torch_compile_cache` fixes it every time, which isolates the cache rather than multimodal-plus-compile in general.

## Fix

`compute_hash()` already folds `language_model_only` back in, with a note that "whether the MM code path is enabled affects the computation graph of the language model". A zero limit disables a modality by exactly that mechanism, so this adds the set of disabled modalities next to it:

```python
factors["disabled_mm_modalities"] = sorted(
    modality
    for modality, options in self.multimodal_config.limit_per_prompt.items()
    if options.count == 0
)
```

Deliberately narrow:

- **Only the zero/non-zero distinction enters the key.** The non-zero counts bound request validation, not the computation graph, so `image:1` and `image:8` keep sharing a cache entry — no extra recompiles for the common case of tuning limits.
- **Only explicitly-specified modalities are considered.** Unspecified modalities default to 999 (non-zero) and contribute nothing.
- `options.count` is read directly rather than via `get_limit_per_prompt()`, so `language_model_only` is not double-counted — it remains its own factor.
- Nothing else moves out of `ignored_factors`; `mm_processor_kwargs`, cache sizing, and the rest genuinely do not affect the graph.

## Test Plan

Two regression tests in `tests/config/test_multimodal_config.py`, siblings of the existing `test_language_model_only_affects_model_hash`:

- `test_disabled_modality_limit_affects_model_hash` — `{"image": 0}` and `{"image": 1}` must hash differently (the bug: they did not).
- `test_nonzero_modality_limits_do_not_affect_model_hash` — `{"image": 1}` and `{"image": 8}` must still hash identically, pinning the narrow scope so a future change cannot quietly turn every limit tweak into a recompile.

Both are pure config-hash assertions: no GPU, no compilation.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
