### PR TITLE
[Spec Decode] Enable fused non-causal TokenSpeed MLA for DSpark

### DIFF
--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -827,13 +827,25 @@ def test_mock_mla_dcp_fp8_decode_gathers_quantized_query(
     )
 
 
-def test_tokenspeed_mla_dcp_single_token_decode_contract(monkeypatch):
+def test_tokenspeed_mla_noncausal_capability():
+    builder = tokenspeed_mla_module.TokenspeedMLAMetadataBuilder
+    assert builder.supports_non_causal_multi_token_decode
+    assert tokenspeed_mla_module.TokenspeedMLABackend.supports_non_causal()
+
+
+@pytest.mark.parametrize(
+    ("causal", "tokens_per_decode", "dcp_world_size", "dcp_rank"),
+    [
+        pytest.param(True, 1, 2, 1, id="causal-dcp"),
+        pytest.param(False, 3, 1, 0, id="noncausal-multi-token"),
+    ],
+)
+def test_tokenspeed_mla_decode_contract(
+    monkeypatch, causal, tokens_per_decode, dcp_world_size, dcp_rank
+):
     decode_call = None
     num_decodes = 2
-    tokens_per_decode = 1
     num_decode_tokens = num_decodes * tokens_per_decode
-    dcp_world_size = 2
-    dcp_rank = 1
     num_heads = 128
     kv_lora_rank = 512
     qk_rope_head_dim = 64
@@ -879,6 +891,7 @@ def test_tokenspeed_mla_dcp_single_token_decode_contract(monkeypatch):
         num_decodes=num_decodes,
         num_decode_tokens=num_decode_tokens,
         max_seq_len=max_seq_len,
+        causal=causal,
         decode=SimpleNamespace(
             block_table=torch.empty((num_decodes, 1), dtype=torch.int32),
             seq_lens=torch.tensor([16, max_seq_len], dtype=torch.int32),
@@ -913,9 +926,13 @@ def test_tokenspeed_mla_dcp_single_token_decode_contract(monkeypatch):
     )
     torch.testing.assert_close(decode_call["seq_lens"], metadata.decode.seq_lens)
     torch.testing.assert_close(decode_call["block_tables"], metadata.decode.block_table)
-    torch.testing.assert_close(
-        decode_call["causal_seqs"], metadata.decode.dcp_tot_seq_lens
-    )
+    if dcp_world_size > 1:
+        torch.testing.assert_close(
+            decode_call["causal_seqs"], metadata.decode.dcp_tot_seq_lens
+        )
+    else:
+        assert decode_call["causal_seqs"] is None
+    assert decode_call["causal_mask"] is causal
     assert decode_call["return_lse"] is True
     assert decode_call["cp_world"] == dcp_world_size
     assert decode_call["cp_rank"] == dcp_rank

--- a/vllm/v1/attention/backends/mla/tokenspeed_mla.py
+++ b/vllm/v1/attention/backends/mla/tokenspeed_mla.py
@@ -58,6 +58,9 @@ def _get_workspace(
 class TokenspeedMLAMetadataBuilder(MLACommonMetadataBuilder[MLACommonMetadata]):
     _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
     query_len_support: ClassVar[QueryLenSupport] = QueryLenSupport.UNIFORM
+    # The kernel accepts an explicit causal mask, so a non-causal DSpark
+    # block can remain fused instead of being flattened to single tokens.
+    supports_non_causal_multi_token_decode: ClassVar[bool] = True
 
     def __init__(
         self,
@@ -102,6 +105,10 @@ class TokenspeedMLABackend(MLACommonBackend):
     @classmethod
     def supports_compute_capability(cls, capability: DeviceCapability) -> bool:
         return capability.major == 10
+
+    @classmethod
+    def supports_non_causal(cls) -> bool:
+        return True
 
     @classmethod
     def supports_combination(
@@ -302,6 +309,7 @@ class TokenspeedMLAImpl(MLACommonImpl[MLACommonMetadata]):
             output_scale=self.output_scale,
             enable_pdl=False,
             return_lse=return_lse,
+            causal_mask=attn_metadata.causal,
             causal_seqs=causal_seqs if self.dcp_world_size > 1 else None,
             cp_world=self.dcp_world_size,
             cp_rank=self.dcp_rank,


### PR DESCRIPTION
## Purpose

Enable the TokenSpeed MLA backend for DSpark's non-causal multi-token draft
blocks. DSpark produces its draft positions in one non-causal forward pass, but
TokenSpeed did not advertise that capability and vLLM did not forward the
metadata's causal mode to the kernel. This prevented the draft model from using
TokenSpeed's fused multi-token path.

This PR:

- advertises non-causal and non-causal multi-token support for TokenSpeed MLA;
- forwards `attn_metadata.causal` to `tokenspeed_mla_decode`; and
- extends the existing backend contract test to cover capability selection,
  causal DCP decode, and non-causal multi-token decode.

The TokenSpeed kernel already accepts `causal_mask`; no kernel change is
required. Existing causal requests continue to pass `True`.

### Motivation and results

Kernel measurements used Kimi-K3 MLA shapes on one B200 with FP8 KV cache,
64K context, seven draft tokens, and CUDA graphs. The fused non-causal path
reduced per-layer draft attention time relative to the shipped flattened
FlashInfer path:

| Concurrency | Shipped flattened path | TokenSpeed fused path | Speedup |
|---:|---:|---:|---:|
| 1 | 51.6 us | 22.6 us | 2.3x |
| 8 | 337 us | 57.7 us | 5.8x |
| 32 | 1.35 ms | 202 us | 6.7x |
| 64 | 2.81 ms | 386 us | 7.3x |
| 128 | 5.11 ms | 789 us | 6.5x |

Numerical checks against the flattened non-causal reference were bit-exact at
2, 64, and 128 requests and at sequence length 256. Other tested shapes had a
maximum absolute difference of 0.023, consistent with different split-K
reduction orders. A causal control differed by up to 0.257, confirming that the
test detects the mask semantics. The causal performance regression check was
787 us after versus 784 us before at concurrency 128.

An end-to-end Kimi-K3 TP8 64K/400 sweep used three draft tokens and synthetic
acceptance lengths derived from MTBench. At concurrency 8:

| Configuration | Aggregate output tok/s | Output tok/s/user | Mean TTFT |
|---|---:|---:|---:|
| No SpecDec, FlashInfer target | 267.06 | 56.93 | 4.751 s |
| TokenSpeed target, FlashInfer draft | 287.44 | 63.79 | 4.458 s |
| TokenSpeed target, TokenSpeed draft | 296.23 | 69.96 | 4.673 s |

The TokenSpeed/TokenSpeed configuration improved aggregate throughput by 3.1%
and per-user throughput by 9.7% over the same TokenSpeed target with a
FlashInfer draft backend. Versus no SpecDec, it improved those metrics by 10.9%
and 22.9%, respectively, while retaining mean TTFT below five seconds.

For model quality, a full 1,319-example GSM8K 5-shot run used real block
rejection, not synthetic acceptance. TokenSpeed target plus TokenSpeed draft
scored 0.9651 +/- 0.0051 versus 0.9666 +/- 0.0049 for no SpecDec, with zero
request errors. The 0.0015 absolute difference is smaller than the reported
uncertainty.

### Duplicate-work check

No open vLLM PR was found for `Tokenspeed MLA non-causal` or `causal_mask
Tokenspeed`, and no open issue describing this change was found. This does not
duplicate an identified open contribution.

## Test Plan

- Exercise both causal DCP and non-causal multi-token kernel contracts with a
  mocked TokenSpeed decode call.
- Verify both non-causal capability gates.
- Run the shared MLA non-causal metadata suite.
- Run pre-commit hooks for the full PR diff.
- Use prior B200 kernel, Kimi-K3 end-to-end, and GSM8K evaluations as GPU and
  model-level validation.

## Test Result

- `python -m pytest tests/v1/attention/test_mla_backends.py -k 'tokenspeed_mla_noncausal_capability or tokenspeed_mla_decode_contract' -q`
  - 3 passed, 2,886 deselected.
- `python -m pytest tests/v1/attention/test_mla_noncausal.py -q`
  - 6 passed.
- `pre-commit run --from-ref upstream/main --to-ref HEAD`
  - all hooks passed.
- GPU-only TokenSpeed matrix cases skip on the local CPU development host; the
  B200 kernel and end-to-end results above provide hardware validation.

AI assistance was used to isolate the prepared backend change, extend unit
coverage, run validation, and draft this description. The submitter prepared
the backend change and benchmark campaign.

<details>
<summary>Trim review</summary>

| # | Proposed | Disposition |
|---:|---|---|
| 1 | Remove unrelated `max()` normalization of DCP world/rank and preserve direct pass-through | APPLIED: normal execution guarantees valid values, and masking invalid state is outside this PR's scope. |

</details>

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results.
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. No documentation update is required for this backend capability fix.
</details>

