### PR TITLE
[ROCm][Test] Use BF16 for Jina v5 nano MTEB test

### DIFF
--- a/tests/models/language/pooling_mteb_test/test_jina.py
+++ b/tests/models/language/pooling_mteb_test/test_jina.py
@@ -14,6 +14,7 @@ from tests.models.utils import (
     RerankModelInfo,
 )
 from vllm import PoolingParams
+from vllm.platforms import current_platform
 
 from .mteb_embed_utils import mteb_test_embed_models
 from .mteb_score_utils import mteb_test_rerank_models
@@ -41,6 +42,7 @@ EMBEDDING_MODELS = [
     EmbedModelInfo(
         "jinaai/jina-embeddings-v5-text-nano",
         architecture="JinaEmbeddingsV5Model",
+        dtype="bfloat16" if current_platform.is_rocm() else "auto",
         seq_pooling_type="LAST",
         attn_type="encoder_only",
         is_prefix_caching_supported=False,


### PR DESCRIPTION
- Run `jinaai/jina-embeddings-v5-text-nano` in BF16 only on ROCm while retaining the existing automatic FP16 selection on NVIDIA.
- Keep the Hugging Face FP32 baseline and long-context embedding comparison active instead of bypassing them with a cached MTEB score.

The failure in [AMD Buildkite build 11591](https://buildkite.com/vllm/amd-ci/builds/11591/list?sid=019fc6dc-f089-4ffc-8f61-9b6d0b5cb54f&tab=output) motivated this change after the newly added Jina nano case exposed long-context FP16 numerical drift on MI250. This preserves NVIDIA FP16 coverage while using BF16 on ROCm without removing the test's Hugging Face correctness oracle.