### PR TITLE
[CI][Bugfix] Fix flaky `test_store_orders_after_compute_write`

### DIFF
--- a/tests/v1/simple_kv_offload/test_worker.py
+++ b/tests/v1/simple_kv_offload/test_worker.py
@@ -100,6 +100,13 @@ def _drive_store(
 
         if int((cpu[:, 0].to(torch.int32) != val).sum().item()):
             corrupt += 1
+
+    # Drain the compute stream before returning: in the no-barrier control
+    # phase the store never waits on compute, so the host loop runs far ahead
+    # and leaves a backlog of sleep+fill kernels in flight. Without this, the
+    # leftover control-phase fills race the barrier phase's fill->copy window
+    # on the shared gpu tensor and flakily corrupt one iteration.
+    compute_stream.synchronize()
     return corrupt
 
 


### PR DESCRIPTION
The no-barrier control phase leaves a ~800ms backlog of sleep+fill kernels in flight on its compute stream (the host loop only waits on the store-copy events). Those leftover fills race the barrier phase's fill->copy window on the shared gpu tensor and flakily corrupt one iteration, tripping the 'store raced compute even with the barrier' assertion. Drain the compute stream before returning from _drive_store so each phase is self-contained.

Example failure: https://buildkite.com/vllm/ci/builds/82045/list?jid=019fc8ca-5a18-4833-85ea-6eb15cc0f759&tab=output
```
>       assert fixed == 0, f"store raced compute even with the barrier: {fixed} corrupt"
E       AssertionError: store raced compute even with the barrier: 1 corrupt
E       assert 1 == 0
v1/simple_kv_offload/test_worker.py:124: AssertionError
```