### PR TITLE
[Bugfix][Model] Kimi K3: pad the MoE intermediate by the effective shard count, on both backends

### DIFF
--- a/tests/models/kimi_k3/test_moe_intermediate_padding.py
+++ b/tests/models/kimi_k3/test_moe_intermediate_padding.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MoE intermediate padding of the Kimi K3 model.
+
+The intermediate is padded so that every MoE shard is at least
+``min_moe_intermediate_per_partition`` wide. The number of shards is not the
+tensor-parallel world size: ``FusedMoEParallelConfig.make()`` shards the
+experts over ``dp * pcp * tp`` devices, and with expert parallelism it does not
+shard the intermediate at all, so padding it there would allocate the padding
+in full on every rank.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from vllm.config import ParallelConfig
+from vllm.model_executor.layers.fused_moe import config as moe_config
+from vllm.models.kimi_k3.common.moe_padding import (
+    effective_moe_tp_size,
+    padded_moe_intermediate_size,
+)
+from vllm.models.kimi_k3.nvidia import model as kimi_model
+from vllm.platforms import current_platform
+
+# Kimi K3: moe_intermediate_size=3072, min_moe_intermediate_per_partition=256.
+MOE_INTERMEDIATE_SIZE = 3072
+MIN_PER_PARTITION = 256
+
+
+@pytest.mark.parametrize(
+    ("moe_tp_size", "expected"),
+    [
+        (1, 3072),  # not sharded
+        (8, 3072),  # 3072 // 8 == 384, already >= 256
+        (16, 4096),  # 3072 // 16 == 192 -> pad to 256 * 16
+        (32, 8192),  # 3072 // 32 == 96 -> pad to 256 * 32
+    ],
+)
+def test_pads_narrow_shards(moe_tp_size: int, expected: int) -> None:
+    assert (
+        padded_moe_intermediate_size(
+            MOE_INTERMEDIATE_SIZE, moe_tp_size, MIN_PER_PARTITION
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("tp_size", "dp_size", "enable_expert_parallel", "expected"),
+    [
+        (16, 1, False, 16),  # plain tensor parallel
+        (8, 4, False, 32),  # data parallel also shards the experts
+        (16, 4, True, 1),  # expert parallel: whole experts per rank
+        (1, 1, True, 1),  # single device: no sharding either way
+    ],
+)
+def test_effective_moe_tp_size(
+    tp_size: int, dp_size: int, enable_expert_parallel: bool, expected: int
+) -> None:
+    vllm_config = SimpleNamespace(
+        parallel_config=ParallelConfig(
+            tensor_parallel_size=tp_size,
+            data_parallel_size=dp_size,
+            enable_expert_parallel=enable_expert_parallel,
+        )
+    )
+    assert effective_moe_tp_size(vllm_config) == expected
+
+
+def test_expert_parallel_makes_moe_tp_size_one(monkeypatch) -> None:
+    """The core invariant ``effective_moe_tp_size`` mirrors.
+
+    ``FusedMoEParallelConfig.make()`` collapses the MoE tensor parallel size to
+    1 under expert parallelism, so ``intermediate_size_per_partition`` is the
+    whole (padded) intermediate on every rank.
+    """
+    monkeypatch.setattr(current_platform, "device_count", lambda: 2)
+    monkeypatch.setattr(moe_config, "get_tensor_model_parallel_rank", lambda: 0)
+    parallel_config = ParallelConfig(
+        tensor_parallel_size=2,
+        enable_expert_parallel=True,
+        all2all_backend="allgather_reducescatter",
+    )
+
+    moe_parallel_config = moe_config.FusedMoEParallelConfig.make(
+        tp_size_=2,
+        pcp_size_=1,
+        dp_size_=1,
+        sp_size_=1,
+        vllm_parallel_config=parallel_config,
+    )
+
+    assert moe_parallel_config.tp_size == 1
+    assert moe_parallel_config.ep_size == 2
+
+
+class _Stub(nn.Module):
+    """Stands in for a layer whose construction needs a real device."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__()
+        self.e_score_correction_bias = None
+        self.moe_config = SimpleNamespace(intermediate_size_per_partition_unpadded=None)
+
+
+def build_moe(monkeypatch, *, tp_size: int, enable_expert_parallel: bool):
+    """Construct a ``KimiMoE`` on stubbed layers and report its padding."""
+    for name in (
+        "GateLinear",
+        "ReplicatedLinear",
+        "RMSNorm",
+        "KimiRoutedOutputTransform",
+        "KimiMLP",
+        "FusedMoEFactory",
+    ):
+        monkeypatch.setattr(kimi_model, name, _Stub)
+    monkeypatch.setattr(kimi_model, "aux_stream", lambda: None)
+    monkeypatch.setattr(torch.cuda, "Event", _Stub)
+    monkeypatch.setattr(
+        kimi_model, "get_tensor_model_parallel_world_size", lambda: tp_size
+    )
+
+    config = SimpleNamespace(
+        hidden_size=16,
+        moe_intermediate_size=MOE_INTERMEDIATE_SIZE,
+        min_moe_intermediate_per_partition=MIN_PER_PARTITION,
+        num_experts=8,
+        num_experts_per_token=2,
+        num_shared_experts=1,
+        moe_renormalize=True,
+        routed_expert_hidden_size=16,
+        latent_moe_use_norm=False,
+        routed_scaling_factor=1.0,
+        use_grouped_topk=True,
+        num_expert_group=1,
+        topk_group=1,
+        moe_router_activation_func="sigmoid",
+        hidden_act="silu",
+        activation_situ_beta=1.0,
+        activation_situ_linear_beta=None,
+        rms_norm_eps=1e-5,
+    )
+    return kimi_model.KimiMoE(
+        config=config,
+        vllm_config=SimpleNamespace(
+            kernel_config=SimpleNamespace(moe_backend="auto"),
+            parallel_config=ParallelConfig(
+                tensor_parallel_size=tp_size,
+                enable_expert_parallel=enable_expert_parallel,
+            ),
+        ),
+        prefix="mlp",
+    )
+
+
+def test_expert_parallel_leaves_the_intermediate_unpadded(monkeypatch) -> None:
+    """Under EP the experts are not intermediate-sharded, so 3072 is enough.
+
+    Padding to ``256 * tp_size`` here would allocate 4096 (TP16) on every rank
+    instead of 3072, in full, because the MoE tensor-parallel size is 1.
+    """
+    monkeypatch.setattr(current_platform, "device_count", lambda: 16)
+
+    moe = build_moe(monkeypatch, tp_size=16, enable_expert_parallel=True)
+
+    assert moe.moe_tp_size == 1
+    assert moe.padded_moe_intermediate_size == MOE_INTERMEDIATE_SIZE
+
+
+def test_tensor_parallel_still_pads_narrow_shards(monkeypatch) -> None:
+    """Without EP the experts really are sharded by TP, so padding applies."""
+    monkeypatch.setattr(current_platform, "device_count", lambda: 16)
+
+    moe = build_moe(monkeypatch, tp_size=16, enable_expert_parallel=False)
+
+    assert moe.moe_tp_size == 16
+    assert moe.padded_moe_intermediate_size == MIN_PER_PARTITION * 16

--- a/vllm/models/kimi_k3/amd/linear.py
+++ b/vllm/models/kimi_k3/amd/linear.py
@@ -63,6 +63,10 @@ from vllm.model_executor.models.utils import (
 )
 from vllm.models.kimi_k3.amd.kda import KimiK3DeltaAttention
 from vllm.models.kimi_k3.amd.ops.attn_res import attn_res
+from vllm.models.kimi_k3.common.moe_padding import (
+    effective_moe_tp_size,
+    padded_moe_intermediate_size,
+)
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
 from vllm.utils.math_utils import cdiv
@@ -165,6 +169,7 @@ class KimiMoE(nn.Module):
     def __init__(
         self,
         config: KimiLinearConfig,
+        vllm_config: VllmConfig,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
         layer_idx: int = 0,
@@ -190,16 +195,12 @@ class KimiMoE(nn.Module):
         self.routed_scaling_factor = config.routed_scaling_factor
         self.num_shared_experts = config.num_shared_experts
         self.layer_idx = layer_idx
-        self.padded_moe_intermediate_size = moe_intermediate_size
-        min_moe_intermediate_per_partition = getattr(
-            config, "min_moe_intermediate_per_partition", 256
+        self.moe_tp_size = effective_moe_tp_size(vllm_config)
+        self.padded_moe_intermediate_size = padded_moe_intermediate_size(
+            moe_intermediate_size,
+            self.moe_tp_size,
+            getattr(config, "min_moe_intermediate_per_partition", 256),
         )
-        if self.tp_size > 1:
-            moe_intermediate_per_partition = moe_intermediate_size // self.tp_size
-            if moe_intermediate_per_partition < min_moe_intermediate_per_partition:
-                self.padded_moe_intermediate_size = (
-                    min_moe_intermediate_per_partition * self.tp_size
-                )
         activation_situ_beta = (
             config.activation_situ_beta if config.hidden_act == "situ" else None
         )
@@ -300,7 +301,7 @@ class KimiMoE(nn.Module):
             w13_weight.data.zero_()
             w2_weight.data.zero_()
             self.experts.moe_config.intermediate_size_per_partition_unpadded = (
-                moe_intermediate_size // self.tp_size
+                moe_intermediate_size // self.moe_tp_size
             )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
@@ -530,6 +531,7 @@ class KimiDecoderLayer(nn.Module):
         ):
             self.block_sparse_moe = KimiMoE(
                 config=config,
+                vllm_config=vllm_config,
                 quant_config=quant_config,
                 prefix=f"{prefix}.block_sparse_moe",
                 layer_idx=layer_idx,

--- a/vllm/models/kimi_k3/amd/linear.py
+++ b/vllm/models/kimi_k3/amd/linear.py
@@ -64,6 +64,10 @@ from vllm.model_executor.models.utils import (
 from vllm.models.kimi_k3.amd.kda import KimiK3DeltaAttention
 from vllm.models.kimi_k3.amd.latent_moe_runner import ROCmLatentMoERunner
 from vllm.models.kimi_k3.amd.ops.attn_res import attn_res
+from vllm.models.kimi_k3.common.moe_padding import (
+    effective_moe_tp_size,
+    padded_moe_intermediate_size,
+)
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
 from vllm.utils.math_utils import cdiv
@@ -166,6 +170,7 @@ class KimiMoE(nn.Module):
     def __init__(
         self,
         config: KimiLinearConfig,
+        vllm_config: VllmConfig,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
         layer_idx: int = 0,
@@ -191,16 +196,12 @@ class KimiMoE(nn.Module):
         self.routed_scaling_factor = config.routed_scaling_factor
         self.num_shared_experts = config.num_shared_experts
         self.layer_idx = layer_idx
-        self.padded_moe_intermediate_size = moe_intermediate_size
-        min_moe_intermediate_per_partition = getattr(
-            config, "min_moe_intermediate_per_partition", 256
+        self.moe_tp_size = effective_moe_tp_size(vllm_config)
+        self.padded_moe_intermediate_size = padded_moe_intermediate_size(
+            moe_intermediate_size,
+            self.moe_tp_size,
+            getattr(config, "min_moe_intermediate_per_partition", 256),
         )
-        if self.tp_size > 1:
-            moe_intermediate_per_partition = moe_intermediate_size // self.tp_size
-            if moe_intermediate_per_partition < min_moe_intermediate_per_partition:
-                self.padded_moe_intermediate_size = (
-                    min_moe_intermediate_per_partition * self.tp_size
-                )
         activation_situ_beta = (
             config.activation_situ_beta if config.hidden_act == "situ" else None
         )
@@ -302,7 +303,7 @@ class KimiMoE(nn.Module):
             w13_weight.data.zero_()
             w2_weight.data.zero_()
             self.experts.moe_config.intermediate_size_per_partition_unpadded = (
-                moe_intermediate_size // self.tp_size
+                moe_intermediate_size // self.moe_tp_size
             )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
@@ -532,6 +533,7 @@ class KimiDecoderLayer(nn.Module):
         ):
             self.block_sparse_moe = KimiMoE(
                 config=config,
+                vllm_config=vllm_config,
                 quant_config=quant_config,
                 prefix=f"{prefix}.block_sparse_moe",
                 layer_idx=layer_idx,

--- a/vllm/models/kimi_k3/common/moe_padding.py
+++ b/vllm/models/kimi_k3/common/moe_padding.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Shared MoE intermediate sizing for the Kimi K3 model."""
+
+from vllm.config import VllmConfig
+
+
+def effective_moe_tp_size(vllm_config: VllmConfig) -> int:
+    """Number of ways the MoE intermediate dimension is actually sharded.
+
+    Mirrors ``FusedMoEParallelConfig.make()``: the experts are sharded over
+    ``dp_size * pcp_size * tp_size`` devices, unless expert parallelism is
+    enabled, in which case each device owns whole experts and the intermediate
+    is not split at all.
+    """
+    parallel_config = vllm_config.parallel_config
+    flatten_tp_size = (
+        parallel_config.data_parallel_size
+        * parallel_config.prefill_context_parallel_size
+        * parallel_config.tensor_parallel_size
+    )
+    if flatten_tp_size > 1 and parallel_config.enable_expert_parallel:
+        return 1
+    return flatten_tp_size
+
+
+def padded_moe_intermediate_size(
+    moe_intermediate_size: int,
+    moe_tp_size: int,
+    min_moe_intermediate_per_partition: int,
+) -> int:
+    """Round the MoE intermediate size up to the minimum shard width.
+
+    The MoE kernels want at least ``min_moe_intermediate_per_partition``
+    columns per shard, so a narrow intermediate is padded before it is split.
+    ``moe_tp_size`` must be the effective MoE shard count from
+    :func:`effective_moe_tp_size`, not the tensor-parallel world size: with
+    expert parallelism the intermediate is never split, so padding it would
+    allocate the padding in full on every rank (3072 -> 4096 at TP16,
+    3072 -> 8192 at TP32) for no benefit.
+
+    Args:
+        moe_intermediate_size: Unpadded MoE intermediate size from the config.
+        moe_tp_size: Number of shards the intermediate is split into.
+        min_moe_intermediate_per_partition: Minimum columns per shard.
+
+    Returns:
+        The intermediate size the expert weights are allocated with.
+    """
+    if moe_tp_size <= 1:
+        return moe_intermediate_size
+    if moe_intermediate_size // moe_tp_size >= min_moe_intermediate_per_partition:
+        return moe_intermediate_size
+    return min_moe_intermediate_per_partition * moe_tp_size

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -93,6 +93,10 @@ from vllm.models.common.ops.sequence_parallel import (
 )
 from vllm.models.deepseek_v4.nvidia.model import DeepseekV4MegaMoEExperts
 from vllm.models.deepseek_v4.nvidia.ops.prepare_megamoe import prepare_megamoe_inputs
+from vllm.models.kimi_k3.common.moe_padding import (
+    effective_moe_tp_size,
+    padded_moe_intermediate_size,
+)
 from vllm.models.kimi_k3.nvidia.kda import KimiK3DeltaAttention
 from vllm.models.kimi_k3.nvidia.latent_moe_runner import (
     LatentMoERunner,
@@ -490,16 +494,12 @@ class KimiMoE(nn.Module):
             raise NotImplementedError(
                 "Kimi K3 MegaMoE currently requires one expert group."
             )
-        self.padded_moe_intermediate_size = moe_intermediate_size
-        min_moe_intermediate_per_partition = getattr(
-            config, "min_moe_intermediate_per_partition", 256
+        self.moe_tp_size = effective_moe_tp_size(vllm_config)
+        self.padded_moe_intermediate_size = padded_moe_intermediate_size(
+            moe_intermediate_size,
+            self.moe_tp_size,
+            getattr(config, "min_moe_intermediate_per_partition", 256),
         )
-        if self.tp_size > 1 and not vllm_config.parallel_config.enable_expert_parallel:
-            moe_intermediate_per_partition = moe_intermediate_size // self.tp_size
-            if moe_intermediate_per_partition < min_moe_intermediate_per_partition:
-                self.padded_moe_intermediate_size = (
-                    min_moe_intermediate_per_partition * self.tp_size
-                )
         activation_situ_beta = (
             config.activation_situ_beta if config.hidden_act == "situ" else None
         )
@@ -643,7 +643,7 @@ class KimiMoE(nn.Module):
             if w2_weight is not None:
                 w2_weight.data.zero_()
             self.experts.moe_config.intermediate_size_per_partition_unpadded = (
-                moe_intermediate_size // self.tp_size
+                moe_intermediate_size // self.moe_tp_size
             )
 
     def _maybe_overlap_router_and_down_proj(

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -98,6 +98,10 @@ from vllm.models.deepseek_v4.nvidia.model import (
     DeepseekV4MLP,
 )
 from vllm.models.deepseek_v4.nvidia.ops.prepare_megamoe import prepare_megamoe_inputs
+from vllm.models.kimi_k3.common.moe_padding import (
+    effective_moe_tp_size,
+    padded_moe_intermediate_size,
+)
 from vllm.models.kimi_k3.nvidia.kda import KimiK3DeltaAttention
 from vllm.models.kimi_k3.nvidia.latent_moe_runner import (
     LatentMoERunner,
@@ -595,16 +599,12 @@ class KimiMoE(nn.Module):
             raise NotImplementedError(
                 "Kimi K3 MegaMoE currently requires one expert group."
             )
-        self.padded_moe_intermediate_size = moe_intermediate_size
-        min_moe_intermediate_per_partition = getattr(
-            config, "min_moe_intermediate_per_partition", 256
+        self.moe_tp_size = effective_moe_tp_size(vllm_config)
+        self.padded_moe_intermediate_size = padded_moe_intermediate_size(
+            moe_intermediate_size,
+            self.moe_tp_size,
+            getattr(config, "min_moe_intermediate_per_partition", 256),
         )
-        if self.tp_size > 1 and not vllm_config.parallel_config.enable_expert_parallel:
-            moe_intermediate_per_partition = moe_intermediate_size // self.tp_size
-            if moe_intermediate_per_partition < min_moe_intermediate_per_partition:
-                self.padded_moe_intermediate_size = (
-                    min_moe_intermediate_per_partition * self.tp_size
-                )
         activation_situ_beta = (
             config.activation_situ_beta if config.hidden_act == "situ" else None
         )
@@ -753,7 +753,7 @@ class KimiMoE(nn.Module):
             if w2_weight is not None:
                 w2_weight.data.zero_()
             self.experts.moe_config.intermediate_size_per_partition_unpadded = (
-                moe_intermediate_size // self.tp_size
+                moe_intermediate_size // self.moe_tp_size
             )
 
     def _maybe_overlap_router_and_down_proj(


### PR DESCRIPTION
## What changed since this PR was opened

This PR was opened on Aug 3 against `main` @ `1c0d207`. On Aug 5, **#51131**
("Skip moe_intermediate padding when EP is enabled", fixing #51124) landed a
one-line guard for the expert-parallel case:

```python
-        if self.tp_size > 1:
+        if self.tp_size > 1 and not vllm_config.parallel_config.enable_expert_parallel:
```

That resolves the largest symptom — the `deep_gemm_mega_moe` crash and the
per-GPU weight memory pinned by padding under EP — and I am not re-litigating
it. This PR is rebased on top of it and rescoped to three things that guard does
not cover. If you would rather see them as separate PRs, say so and I will split.

## What this PR still covers

### 1. Without EP, the shard count is not `tp_size`

`FusedMoEParallelConfig.make()` shards the experts over
`dp_size * pcp_size * tp_size` devices
(`vllm/model_executor/layers/fused_moe/config.py:1113`). The padding decision
still divides by `tp_size` alone, so the non-EP path goes through with the wrong
divisor:

| topology | real shards | `3072 // tp_size` | padded? | correct? |
|---|---|---|---|---|
| TP16, no DP, no EP | 16 | 192 | yes -> 4096 | yes |
| **TP8 x DP4, no EP** | **32** | **384** | **no** | **no — real shard is 96** |
| TP16 x DP4 + EP | 1 | — | skipped by #51131 | yes |

The middle row is the gap: 384 clears the 256 floor so nothing is padded, but
each device actually holds 96 columns.

### 2. `intermediate_size_per_partition_unpadded` still divides by `tp_size`

`vllm/models/kimi_k3/nvidia/model.py:643`. This value is consumed only by the
ROCm paths — `rocm_aiter_moe.py:344,349` and `aiter_mxfp4_w4a8_moe.py:295,308,311`
— where AITER derives its pad width from
`intermediate_size_per_partition - intermediate_size_per_partition_unpadded`. A
wrong unpadded value is a wrong pad width, not merely wasted memory. I have no
MI300 to confirm the runtime effect, so please treat this as a code-path
argument; an AMD reviewer can settle it quickly.

### 3. The AMD model still carries the original block

`vllm/models/kimi_k3/amd/linear.py:197` carries a byte-identical copy of the
pre-#51131 block, including the missing EP guard:

```python
if self.tp_size > 1:
    moe_intermediate_per_partition = moe_intermediate_size // self.tp_size
    ...
```

So on ROCm, expert parallelism still pays the full padding that #51131 removed
for NVIDIA.

## Approach

One helper, `vllm/models/kimi_k3/common/moe_padding.py`, used by both models:

- `effective_moe_tp_size(vllm_config)` — how many ways the intermediate is
  actually split: `1` under EP, `dp * pcp * tp` otherwise.
- `padded_moe_intermediate_size(...)` — round up only when a shard would fall
  below the floor.

Because the effective count is `1` under EP, the explicit
`and not enable_expert_parallel` guard from #51131 becomes redundant and the
diff removes it. That is not a revert: EP behaviour is unchanged (no padding),
it is now implied by the shard count instead of special-cased, and the same
expression fixes the non-EP DP case the guard cannot see.

### Why a small helper instead of asking `FusedMoEParallelConfig`

Calling `FusedMoEParallelConfig.make()` and reading `.tp_size` needs
`get_dp_group()` and `get_pcp_group()`, which would stop the sizing being a pure
function of the config and make the test require an initialised distributed
environment. The mirroring has precedent:
`vllm/model_executor/model_loader/default_loader.py:381` derives the flattened
EP size inline under the comment "EP size/rank computation mirrors
`FusedMoEParallelConfig.make()`". Drift risk is covered by item 3 of the test
plan, which asserts the invariant against the real `make()`.

## Test Plan

```bash
pytest -q tests/models/kimi_k3/test_moe_intermediate_padding.py
```

Pins four things: the padding table; `effective_moe_tp_size()` across TP / DP /
EP; the invariant that `FusedMoEParallelConfig.make()` collapses the MoE
`tp_size` to 1 under EP; and the size a real `KimiMoE` ends up with, built on
stubbed layers.

## Test Result

```
$ pytest -q tests/models/kimi_k3/test_moe_intermediate_padding.py
11 passed
```

Reverting the fix turns `test_expert_parallel_leaves_the_intermediate_unpadded`
red and leaves the other ten green. `tests/models/kimi_k3/` reports the same 59
failures before and after on my host (they need a GPU; `test_latent_moe_tail.py`
also needs `ray`), with the 11 new tests as the only difference. `ruff check`
and `ruff format --check` are clean on all four files.

Measured on 64x NVIDIA H100 80GB (8 nodes x 8, SM90), Kimi-K3 MXFP4,
TP16 x DP4 + EP64, before #51131 existed. These numbers are what the EP guard
now also achieves; they are kept because they are the only end-to-end evidence
in this PR:

| | intermediate | weights / rank | single-user decode |
|---|---|---|---|
| before | 3072 -> 4096 | 45.5 GiB | 22.7 tok/s |
| after | 3072 | 38.5 GiB | 22.7 tok/s |

7 GiB/rank freed at TP16, 35 GiB/rank at TP32 x DP2, same throughput. Confirmed
with real weights on the same deployment: `Model loading took 38.54 GiB`, decode
23.82 / 23.99 / 23.89 tok/s over three runs, `847*236` -> `199892`, and a tool
call returning `{"name": "get_weather", "arguments": {"city": "Seoul"}}`.

Throughput is unchanged because padding inflates *resident* expert weights, not
bytes read per step: Kimi-K3 activates 16 of 896 experts per token, so with EP64
roughly 0.25 experts per rank are touched per step, while the dense and
shared-expert weights read every step are never padded.

**Items 1 and 3 above are not measured.** The DP-without-EP topology and the
ROCm path are code-path arguments; I have no MI300, and our cluster runs EP.

## Why this is not duplicating an existing PR

Checked against `main` @ `66b3c0e` on 2026-08-05:

```
gh pr list --state open --search "moe_intermediate"                         0
gh pr list --state open --search "padded_moe_intermediate"                  0
gh pr list --state open --search "effective_moe_tp_size"                    0
gh pr list --state open --search "intermediate_size_per_partition_unpadded" 0
```

- **#51131** (merged) is the direct predecessor; the overlap and what remains
  are spelled out above.
- **#50656** / **#50912** shard the *shared* expert under sequence parallelism.
  Different tensor.
- **#50383** shards the Latent-MoE up-projection. Different projection.

---

### AI assistance disclosure

This pull request was written with AI assistance (Claude): tracing the padding
and `FusedMoEParallelConfig` interaction, factoring the helper, and drafting the
tests and this description. I reviewed every changed line, ran the tests, and
produced the 64-GPU measurements myself. The commit carries a
`Co-authored-by:` trailer.

