### PR TITLE
perf: skip re-validating reused sampling params in streaming input loop

### DIFF
--- a/tests/v1/engine/test_input_processor.py
+++ b/tests/v1/engine/test_input_processor.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vllm.sampling_params import SamplingParams
+from vllm.v1.engine.input_processor import InputProcessor
+
+
+def test_process_inputs_validates_params_by_default():
+    """_validate_params is called when skip_params_validation is False."""
+    with patch.object(InputProcessor, "_validate_params") as mock_validate, \
+         patch.object(InputProcessor, "_validate_lora"), \
+         patch.object(InputProcessor, "__init__", return_value=None):
+        processor = object.__new__(InputProcessor)
+        processor.vllm_config = MagicMock()
+        processor.vllm_config.parallel_config.data_parallel_size = 1
+        processor.vllm_config.parallel_config.data_parallel_size_local = 1
+        processor.vllm_config.parallel_config.local_engines_only = False
+
+        sp = SamplingParams()
+        tasks = ("generate",)
+
+        # process_inputs will fail after the validation section due to missing
+        # real infrastructure — that's fine; we only care about validate calls.
+        with pytest.raises(Exception):
+            processor.process_inputs(
+                request_id="r1",
+                prompt={"type": "token_ids", "prompt_token_ids": [1, 2, 3]},
+                params=sp,
+                supported_tasks=tasks,
+                skip_params_validation=False,
+            )
+
+        mock_validate.assert_called_once_with(sp, tasks)
+
+
+def test_process_inputs_skips_validation_when_flag_set():
+    """_validate_params is NOT called when skip_params_validation is True."""
+    with patch.object(InputProcessor, "_validate_params") as mock_validate, \
+         patch.object(InputProcessor, "_validate_lora"), \
+         patch.object(InputProcessor, "__init__", return_value=None):
+        processor = object.__new__(InputProcessor)
+        processor.vllm_config = MagicMock()
+        processor.vllm_config.parallel_config.data_parallel_size = 1
+        processor.vllm_config.parallel_config.data_parallel_size_local = 1
+        processor.vllm_config.parallel_config.local_engines_only = False
+
+        sp = SamplingParams()
+        tasks = ("generate",)
+
+        with pytest.raises(Exception):
+            processor.process_inputs(
+                request_id="r1",
+                prompt={"type": "token_ids", "prompt_token_ids": [1, 2, 3]},
+                params=sp,
+                supported_tasks=tasks,
+                skip_params_validation=True,
+            )
+
+        mock_validate.assert_not_called()

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -484,12 +484,12 @@ class AsyncLLM(EngineClient):
                         self._validate_streaming_input_sampling_params(sp)
                     else:
                         sp = sampling_params
-                    # TODO(nick): Avoid re-validating reused sampling parameters
                     req = self.input_processor.process_inputs(
                         request_id=internal_req_id,
                         prompt=input_chunk.prompt,
                         params=sp,
                         resumable=True,
+                        skip_params_validation=(sp is sampling_params),
                         **inputs,  # type: ignore[arg-type]
                     )
                     req.external_req_id = request_id

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -261,8 +261,10 @@ class InputProcessor:
         priority: int = 0,
         data_parallel_rank: int | None = None,
         resumable: bool = False,
+        skip_params_validation: bool = False,
     ) -> EngineCoreRequest:
-        self._validate_params(params, supported_tasks)
+        if not skip_params_validation:
+            self._validate_params(params, supported_tasks)
         self._validate_lora(lora_request)
 
         parallel_config = self.vllm_config.parallel_config


### PR DESCRIPTION
## Summary

In `generate_from_stream()`, each input chunk calls `process_inputs()`, which unconditionally runs `_validate_params()` → `params.verify(...)`. When the chunk carries no per-chunk `sampling_params`, it reuses the same object that was already fully validated for the `final_req` at stream open time. The repeated `verify()` call is pure overhead with no correctness benefit.

**Fix:** add `skip_params_validation: bool = False` to `process_inputs()` and pass `skip_params_validation=(sp is sampling_params)` from the chunk loop. Per-chunk params supplied by the caller still go through the full validation path.

This resolves the `TODO(nick): Avoid re-validating reused sampling parameters` comment at `async_llm.py:487`.

## Changes

- `vllm/v1/engine/input_processor.py`: add `skip_params_validation` parameter to `process_inputs()`
- `vllm/v1/engine/async_llm.py`: pass `skip_params_validation=True` when reusing base sampling params in chunk loop, remove resolved TODO comment

## Why this is not a duplicate

No open PR addresses this TODO. Searched:
```
gh pr list --repo vllm-project/vllm --state open --search "streaming sampling params re-validate"
```

## Test plan

- `tests/v1/e2e/general/test_streaming_input.py` — requires GPU, skipped locally; covered by CI
- Manual verification: the `skip_params_validation` flag is only set when `sp is sampling_params` (identity check), meaning per-chunk params always validate normally

## Note

AI assistance was used in drafting this PR. All changes reviewed and understood by the submitter.