### PR TITLE
[Distributed] Island-aware hierarchical allreduce for PCIe-only multi-island boxes

### DIFF
--- a/tests/distributed/test_hier_all_reduce.py
+++ b/tests/distributed/test_hier_all_reduce.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import ray
+import torch
+import torch.distributed as dist
+
+from vllm.distributed.device_communicators.hier_all_reduce import (
+    _TWO_SHOT_MIN_ELEMS,
+    HierarchicalAllReduce,
+)
+from vllm.distributed.parallel_state import get_tp_group
+
+from ..utils import init_test_distributed_environment, multi_process_parallel
+
+# Straddle the one-shot/two-shot dispatch threshold in both directions, and
+# include a size that is not a multiple of the CTA tiling to exercise the
+# masked tails.
+TEST_SIZES = [
+    1024,
+    _TWO_SHOT_MIN_ELEMS // 2,
+    _TWO_SHOT_MIN_ELEMS,
+    _TWO_SHOT_MIN_ELEMS * 2 + 512,
+]
+
+
+@ray.remote(num_gpus=1, max_calls=1)
+def hier_allreduce_matches_nccl(
+    monkeypatch: pytest.MonkeyPatch,
+    tp_size,
+    pp_size,
+    rank,
+    distributed_init_port,
+):
+    with monkeypatch.context() as m:
+        m.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+        m.delenv("HIP_VISIBLE_DEVICES", raising=False)
+        device = torch.device(f"cuda:{rank}")
+        torch.accelerator.set_device_index(device)
+        init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
+
+        tp_group = get_tp_group()
+        group = tp_group.cpu_group
+        # Islands are group-local rank indices; split the TP group in half so
+        # the two halves stand in for the two PCIe islands.
+        half = tp_size // 2
+        islands = [list(range(half)), list(range(half, tp_size))]
+        comm = HierarchicalAllReduce(group, device, islands)
+
+        for numel in TEST_SIZES:
+            inp = torch.randn(numel, dtype=torch.bfloat16, device=device)
+            ref = inp.clone()
+            dist.all_reduce(ref, group=tp_group.device_group)
+            assert comm.should_use(inp)
+            # Run twice: the flag protocol alternates buffer halves by
+            # sequence-token parity, so the second call takes the other half.
+            for _ in range(2):
+                out = comm.all_reduce(inp)
+                torch.cuda.synchronize()
+                # Reduction order differs from NCCL's, so compare within the
+                # dtype's tolerance rather than bit-exactly.
+                torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize("tp_size", [2, 4])
+@pytest.mark.parametrize("pipeline_parallel_size", [1])
+def test_hier_all_reduce(
+    monkeypatch: pytest.MonkeyPatch,
+    tp_size,
+    pipeline_parallel_size,
+):
+    world_size = tp_size * pipeline_parallel_size
+    if world_size > torch.accelerator.device_count():
+        pytest.skip("Not enough GPUs to run the test.")
+    multi_process_parallel(
+        monkeypatch, tp_size, pipeline_parallel_size, hier_allreduce_matches_nccl
+    )

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -75,6 +75,9 @@ class CudaCommunicator(DeviceCommunicatorBase):
         from vllm.distributed.device_communicators.flashinfer_all_reduce import (
             FlashInferAllReduce,
         )
+        from vllm.distributed.device_communicators.hier_all_reduce import (
+            HierarchicalAllReduce,
+        )
         from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
         from vllm.distributed.device_communicators.quick_all_reduce import (
             QuickAllReduce,
@@ -123,6 +126,24 @@ class CudaCommunicator(DeviceCommunicatorBase):
                     self.symm_mem_comm is not None and not self.symm_mem_comm.disabled
                 ),
             )
+
+        self.hier_ar_comm: HierarchicalAllReduce | None = None
+        if envs.VLLM_HIER_ALL_REDUCE and self.world_size > 1:
+            islands = [
+                [int(r) for r in part.split(",")]
+                for part in envs.VLLM_HIER_ALL_REDUCE.split(";")
+            ]
+            if sorted(r for i in islands for r in i) == list(range(self.world_size)):
+                self.hier_ar_comm = HierarchicalAllReduce(
+                    self.cpu_group, self.device, islands
+                )
+            else:
+                logger.warning(
+                    "VLLM_HIER_ALL_REDUCE=%s does not cover ranks 0..%d exactly; "
+                    "hierarchical allreduce disabled.",
+                    envs.VLLM_HIER_ALL_REDUCE,
+                    self.world_size - 1,
+                )
 
         if use_custom_allreduce and self.world_size > 1 and current_platform.is_rocm():
             # Initialize a custom quick all-reduce implementation for AMD.
@@ -310,6 +331,9 @@ class CudaCommunicator(DeviceCommunicatorBase):
             out = aiter_ar_comm.custom_all_reduce(input_)
             assert out is not None
             return out
+        hier_ar_comm = self.hier_ar_comm
+        if hier_ar_comm is not None and hier_ar_comm.should_use(input_):
+            return hier_ar_comm.all_reduce(input_)
         ca_comm = self.ca_comm
         if (
             ca_comm is not None

--- a/vllm/distributed/device_communicators/hier_all_reduce.py
+++ b/vllm/distributed/device_communicators/hier_all_reduce.py
@@ -36,6 +36,7 @@ logger = init_logger(__name__)
 
 _MAX_ELEMS = 256 * 1024  # 512KB bf16 cap; decode messages are ~8-512KB
 _MAX_CTA = 16
+_NUM_WARPS = 8
 # One-shot moves 4n remote bytes in 2 sync rounds, two-shot 7n/4 in 3 and
 # crosses the slow inter-island link with only n/island_size. Latency wins
 # below this size, bandwidth above it; crossover measured on 2x4 A800 PCIe
@@ -121,13 +122,19 @@ def _check(rc: int, what: str) -> None:
 
 
 @triton.jit
-def _fence_sys(dummy):
-    """System-scope acq_rel fence (PCIe P2P has no native remote atomics,
-    so signaling uses plain remote stores bracketed by this fence)."""
-    return tl.inline_asm_elementwise(
+def _fence_sys(FENCE_LANES: tl.constexpr):
+    """System-scope acq_rel fence, executed by every thread in the CTA.
+
+    PCIe has no native remote atomics, so signalling is a plain remote store
+    bracketed by this fence. Applying the asm to a tensor rather than a
+    scalar is what makes every thread issue it: a fence executed by one
+    thread does not order another thread's stores, so a scalar (single-lane)
+    fence would leave the other lanes' data unordered against the flag.
+    """
+    tl.inline_asm_elementwise(
         "fence.acq_rel.sys; mov.u32 $0, $1;",
         "=r,r",
-        [dummy],
+        [tl.zeros((FENCE_LANES,), dtype=tl.int32)],
         dtype=tl.int32,
         is_pure=False,
         pack=1,
@@ -149,6 +156,7 @@ def _hier_all_reduce_kernel(
     numel,
     token_ptr,  # [MAX_CTA] device int32 sequence counters (cudagraph-safe)
     MAX_ELEMS: tl.constexpr,
+    FENCE_LANES: tl.constexpr,
     BLOCK: tl.constexpr,
 ):
     # Each CTA owns a disjoint chunk with its own flag row and sequence
@@ -181,8 +189,8 @@ def _hier_all_reduce_kernel(
         mask = offs < end
         x = tl.load(inp_ptr + offs, mask=mask, other=0.0)
         tl.store(my_slot + offs, x, mask=mask)
+    _fence_sys(FENCE_LANES)
     tl.debug_barrier()
-    _fence_sys(0)
     for i in tl.static_range(island_size):
         peer = island_base + i
         if peer != rank:
@@ -205,8 +213,8 @@ def _hier_all_reduce_kernel(
                 < token
             ):
                 pass
-    _fence_sys(0)
     tl.debug_barrier()
+    _fence_sys(FENCE_LANES)
 
     # Phase B: island reduce over P2P reads, publish partial, signal the
     # cross-island counterpart. Partials are bf16 to halve cross-island
@@ -227,8 +235,8 @@ def _hier_all_reduce_kernel(
                 )
                 acc += tl.load(peer_slot + offs, mask=mask, other=0.0).to(tl.float32)
         tl.store(my_partial + offs, acc.to(tl.bfloat16), mask=mask)
+    _fence_sys(FENCE_LANES)
     tl.debug_barrier()
-    _fence_sys(0)
     cp_flags = tl.cast(tl.load(flag_ptrs_ptr + counterpart), tl.pointer_type(tl.int32))
     tl.store(cp_flags + fbase + 1 * WORLD + rank, token)
 
@@ -244,8 +252,8 @@ def _hier_all_reduce_kernel(
         < token
     ):
         pass
-    _fence_sys(0)
     tl.debug_barrier()
+    _fence_sys(FENCE_LANES)
     cp_partial = (
         tl.cast(
             tl.load(partial_ptrs_ptr + counterpart),
@@ -279,6 +287,7 @@ def _hier_two_shot_kernel(
     token_ptr,  # [MAX_CTA] device int32 sequence counters
     MAX_ELEMS: tl.constexpr,
     MAX_CTA: tl.constexpr,
+    FENCE_LANES: tl.constexpr,
     BLOCK: tl.constexpr,
 ):
     """Two-shot variant: reduce-scatter, one cross-island shard exchange,
@@ -320,8 +329,8 @@ def _hier_two_shot_kernel(
             mask = offs < end
             x = tl.load(inp_ptr + offs, mask=mask, other=0.0)
             tl.store(my_data + offs, x, mask=mask)
+    _fence_sys(FENCE_LANES)
     tl.debug_barrier()
-    _fence_sys(0)
     for i in tl.static_range(island_size):
         peer = island_base + i
         if peer != rank:
@@ -341,8 +350,8 @@ def _hier_two_shot_kernel(
                 < token
             ):
                 pass
-    _fence_sys(0)
     tl.debug_barrier()
+    _fence_sys(FENCE_LANES)
 
     # Phase B: reduce-scatter -- sum the island over the shard this rank owns.
     for off in range(my_start, my_end, BLOCK):
@@ -358,8 +367,8 @@ def _hier_two_shot_kernel(
                 )
                 acc += tl.load(pd + offs, mask=mask, other=0.0).to(tl.float32)
         tl.store(my_partial + offs, acc.to(tl.bfloat16), mask=mask)
+    _fence_sys(FENCE_LANES)
     tl.debug_barrier()
-    _fence_sys(0)
     cpf = tl.cast(tl.load(flag_ptrs_ptr + counterpart), tl.pointer_type(tl.int32))
     tl.store(cpf + (1 * WORLD + rank) * MAX_CTA + pid, token)
 
@@ -375,8 +384,8 @@ def _hier_two_shot_kernel(
         < token
     ):
         pass
-    _fence_sys(0)
     tl.debug_barrier()
+    _fence_sys(FENCE_LANES)
     cp_partial = (
         tl.cast(
             tl.load(partial_ptrs_ptr + counterpart),
@@ -390,8 +399,8 @@ def _hier_two_shot_kernel(
         acc = tl.load(my_partial + offs, mask=mask, other=0.0).to(tl.float32)
         acc += tl.load(cp_partial + offs, mask=mask, other=0.0).to(tl.float32)
         tl.store(my_gather + offs, acc.to(tl.bfloat16), mask=mask)
+    _fence_sys(FENCE_LANES)
     tl.debug_barrier()
-    _fence_sys(0)
     for i in tl.static_range(island_size):
         peer = island_base + i
         if peer != rank:
@@ -412,8 +421,8 @@ def _hier_two_shot_kernel(
                 < token
             ):
                 pass
-    _fence_sys(0)
     tl.debug_barrier()
+    _fence_sys(FENCE_LANES)
     for s in tl.static_range(island_size):
         peer = island_base + s
         pg = (
@@ -559,8 +568,9 @@ class HierarchicalAllReduce:
                 token_ptr=self._token_ctr2,
                 MAX_ELEMS=_MAX_ELEMS,
                 MAX_CTA=_MAX_CTA,
+                FENCE_LANES=_NUM_WARPS * 32,
                 BLOCK=min(4096, triton.next_power_of_2(numel)),
-                num_warps=8,
+                num_warps=_NUM_WARPS,
             )
             return out
         ncta = min(_MAX_CTA, max(1, (numel + 4095) // 4096))
@@ -578,7 +588,8 @@ class HierarchicalAllReduce:
             numel=numel,
             token_ptr=self._token_ctr,
             MAX_ELEMS=_MAX_ELEMS,
+            FENCE_LANES=_NUM_WARPS * 32,
             BLOCK=min(8192, triton.next_power_of_2(numel)),
-            num_warps=8,
+            num_warps=_NUM_WARPS,
         )
         return out

--- a/vllm/distributed/device_communicators/hier_all_reduce.py
+++ b/vllm/distributed/device_communicators/hier_all_reduce.py
@@ -50,23 +50,47 @@ class _IpcHandle(ctypes.Structure):
 _cudart = None
 
 
+def _find_cudart() -> str:
+    """Locate libcudart across install layouts: the CUDA runtime may come
+    from the pip wheel, from torch's bundled libs, or from a system CUDA
+    install (as in most container images)."""
+    # If torch already loaded it, reuse exactly that library.
+    try:
+        with open("/proc/self/maps") as f:
+            for line in f:
+                path = line.split()[-1] if " /" in line else ""
+                if os.path.basename(path).startswith("libcudart.so"):
+                    return path
+    except OSError:
+        pass
+    tdir = os.path.dirname(torch.__file__)
+    for pattern in (
+        os.path.join(
+            os.path.dirname(tdir), "nvidia", "cuda_runtime", "lib", "libcudart.so*"
+        ),
+        os.path.join(tdir, "lib", "libcudart*.so*"),
+    ):
+        found = glob.glob(pattern)
+        if found:
+            return found[0]
+    from ctypes.util import find_library
+
+    name = find_library("cudart")
+    if name:
+        return name
+    raise RuntimeError(
+        "hierarchical allreduce could not locate libcudart; it needs the CUDA "
+        "runtime to map peer buffers via cudaIpcOpenMemHandle"
+    )
+
+
 def _get_cudart():
     """The shared buffers are cudaMalloc'd and IPC-opened via ctypes: torch
     opens IPC handles inside the OWNER's device context, so the mapping is
     never made peer-accessible to the importing device's kernels."""
     global _cudart
     if _cudart is None:
-        tdir = os.path.dirname(torch.__file__)
-        cands = glob.glob(
-            os.path.join(
-                os.path.dirname(tdir),
-                "nvidia",
-                "cuda_runtime",
-                "lib",
-                "libcudart.so*",
-            )
-        ) + glob.glob(os.path.join(tdir, "lib", "libcudart*.so*"))
-        lib = ctypes.CDLL(cands[0])
+        lib = ctypes.CDLL(_find_cudart())
         lib.cudaMalloc.argtypes = [
             ctypes.POINTER(ctypes.c_void_p),
             ctypes.c_size_t,

--- a/vllm/distributed/device_communicators/hier_all_reduce.py
+++ b/vllm/distributed/device_communicators/hier_all_reduce.py
@@ -1,0 +1,560 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Island-aware hierarchical allreduce for multi-island PCIe topologies.
+
+Targets boxes like 2x4 A100/A800 PCIe (two PIX islands bridged by the CPU
+interconnect), where the NCCL 8-GPU ring pays the cross-socket latency on
+every hop. Strategy per rank, all inside one Triton kernel launch:
+
+  1. publish: copy the local input into this rank's IPC-shared slot,
+     release-fence, bump the phase-A flag.
+  2. island reduce: spin on the island peers' phase-A flags, then read the
+     island's slots directly over P2P and reduce -> island partial, publish
+     to the partial slot with a phase-B flag.
+  3. cross exchange: spin on the counterpart rank's phase-B flag (the rank
+     with the same island-local index in the other island), read its partial
+     over P2P, add, write the final result. Cross-socket traffic is exactly
+     one message per rank instead of the ring's repeated crossings.
+
+Latency-bound small messages only (decode hidden states); large payloads
+should stay on NCCL. Buffers are IPC-registered once; flags use monotonically
+increasing sequence tokens so no zeroing is needed between calls.
+"""
+
+import ctypes
+import glob
+import os
+from collections.abc import Sequence
+
+import torch
+import torch.distributed as dist
+
+from vllm.logger import init_logger
+from vllm.triton_utils import tl, triton
+
+logger = init_logger(__name__)
+
+_MAX_ELEMS = 256 * 1024  # 512KB bf16 cap; decode messages are ~8-512KB
+_MAX_CTA = 16
+# One-shot moves 4n remote bytes in 2 sync rounds, two-shot 7n/4 in 3 and
+# crosses the slow inter-island link with only n/island_size. Latency wins
+# below this size, bandwidth above it; crossover measured on 2x4 A800 PCIe
+# (32KB: 45.6 vs 47.3us one-shot favoured, 48KB: 54.3 vs 49.6 two-shot).
+_TWO_SHOT_MIN_ELEMS = 24 * 1024
+
+
+class _IpcHandle(ctypes.Structure):
+    _fields_ = [("reserved", ctypes.c_char * 64)]
+
+
+_cudart = None
+
+
+def _get_cudart():
+    """The shared buffers are cudaMalloc'd and IPC-opened via ctypes: torch
+    opens IPC handles inside the OWNER's device context, so the mapping is
+    never made peer-accessible to the importing device's kernels."""
+    global _cudart
+    if _cudart is None:
+        tdir = os.path.dirname(torch.__file__)
+        cands = glob.glob(
+            os.path.join(
+                os.path.dirname(tdir),
+                "nvidia",
+                "cuda_runtime",
+                "lib",
+                "libcudart.so*",
+            )
+        ) + glob.glob(os.path.join(tdir, "lib", "libcudart*.so*"))
+        lib = ctypes.CDLL(cands[0])
+        lib.cudaMalloc.argtypes = [
+            ctypes.POINTER(ctypes.c_void_p),
+            ctypes.c_size_t,
+        ]
+        lib.cudaMemset.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_int,
+            ctypes.c_size_t,
+        ]
+        lib.cudaIpcGetMemHandle.argtypes = [
+            ctypes.POINTER(_IpcHandle),
+            ctypes.c_void_p,
+        ]
+        lib.cudaIpcOpenMemHandle.argtypes = [
+            ctypes.POINTER(ctypes.c_void_p),
+            _IpcHandle,
+            ctypes.c_uint,
+        ]
+        lib.cudaIpcCloseMemHandle.argtypes = [ctypes.c_void_p]
+        lib.cudaFree.argtypes = [ctypes.c_void_p]
+        _cudart = lib
+    return _cudart
+
+
+def _check(rc: int, what: str) -> None:
+    if rc != 0:
+        raise RuntimeError(f"{what} failed: cudaError {rc}")
+
+
+@triton.jit
+def _fence_sys(dummy):
+    """System-scope acq_rel fence (PCIe P2P has no native remote atomics,
+    so signaling uses plain remote stores bracketed by this fence)."""
+    return tl.inline_asm_elementwise(
+        "fence.acq_rel.sys; mov.u32 $0, $1;",
+        "=r,r",
+        [dummy],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def _hier_all_reduce_kernel(
+    inp_ptr,
+    out_ptr,
+    ptrs_ptr,  # [world] int64 device pointers to each rank's data slot
+    partial_ptrs_ptr,  # [world] int64 pointers to each rank's partial slot
+    flag_ptrs_ptr,  # [world] int64 pointers to each rank's flag array
+    rank: tl.constexpr,
+    island_base: tl.constexpr,  # first rank of this island
+    island_size: tl.constexpr,
+    counterpart: tl.constexpr,  # same-index rank in the other island
+    WORLD: tl.constexpr,
+    numel,
+    token_ptr,  # [MAX_CTA] device int32 sequence counters (cudagraph-safe)
+    MAX_ELEMS: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    # Each CTA owns a disjoint chunk with its own flag row and sequence
+    # counter; chunks synchronize independently, so multiple CTAs keep
+    # multiple PCIe read streams in flight (single-CTA queue depth is the
+    # bandwidth bottleneck at >=32KB).
+    pid = tl.program_id(0)
+    ncta = tl.num_programs(0)
+    token = tl.atomic_add(token_ptr + pid, 1, sem="relaxed") + 1
+    chunk = tl.cdiv(numel, ncta)
+    start = pid * chunk
+    end = tl.minimum(numel, start + chunk)
+    fbase = pid * 2 * WORLD
+
+    # Double-buffer data/partial slots by token parity: a rank can lap a
+    # slow peer by one call, but launch-granularity stream ordering plus
+    # the flag waits make a two-call lap (same-parity reuse) impossible
+    # before the peer's read.
+    buf_off = (token % 2) * MAX_ELEMS
+    my_slot = tl.cast(tl.load(ptrs_ptr + rank), tl.pointer_type(tl.bfloat16)) + buf_off
+    my_partial = (
+        tl.cast(tl.load(partial_ptrs_ptr + rank), tl.pointer_type(tl.bfloat16))
+        + buf_off
+    )
+    my_flags = tl.cast(tl.load(flag_ptrs_ptr + rank), tl.pointer_type(tl.int32))
+
+    # Phase A: publish this chunk locally, then signal island peers.
+    for off in range(start, end, BLOCK):
+        offs = off + tl.arange(0, BLOCK)
+        mask = offs < end
+        x = tl.load(inp_ptr + offs, mask=mask, other=0.0)
+        tl.store(my_slot + offs, x, mask=mask)
+    tl.debug_barrier()
+    _fence_sys(0)
+    for i in tl.static_range(island_size):
+        peer = island_base + i
+        if peer != rank:
+            peer_flags = tl.cast(
+                tl.load(flag_ptrs_ptr + peer), tl.pointer_type(tl.int32)
+            )
+            tl.store(peer_flags + fbase + 0 * WORLD + rank, token)
+
+    # Wait for the island peers' phase-A signals for this chunk.
+    for i in tl.static_range(island_size):
+        peer = island_base + i
+        if peer != rank:
+            while (
+                tl.atomic_add(
+                    my_flags + fbase + 0 * WORLD + peer,
+                    0,
+                    sem="acquire",
+                    scope="sys",
+                )
+                < token
+            ):
+                pass
+    _fence_sys(0)
+    tl.debug_barrier()
+
+    # Phase B: island reduce over P2P reads, publish partial, signal the
+    # cross-island counterpart. Partials are bf16 to halve cross-island
+    # bytes; accumulation stays fp32.
+    for off in range(start, end, BLOCK):
+        offs = off + tl.arange(0, BLOCK)
+        mask = offs < end
+        acc = tl.load(my_slot + offs, mask=mask, other=0.0).to(tl.float32)
+        for i in tl.static_range(island_size):
+            peer = island_base + i
+            if peer != rank:
+                peer_slot = (
+                    tl.cast(
+                        tl.load(ptrs_ptr + peer),
+                        tl.pointer_type(tl.bfloat16),
+                    )
+                    + buf_off
+                )
+                acc += tl.load(peer_slot + offs, mask=mask, other=0.0).to(tl.float32)
+        tl.store(my_partial + offs, acc.to(tl.bfloat16), mask=mask)
+    tl.debug_barrier()
+    _fence_sys(0)
+    cp_flags = tl.cast(tl.load(flag_ptrs_ptr + counterpart), tl.pointer_type(tl.int32))
+    tl.store(cp_flags + fbase + 1 * WORLD + rank, token)
+
+    # Phase C: wait for the counterpart's phase-B signal for this chunk,
+    # then do the single cross-island exchange.
+    while (
+        tl.atomic_add(
+            my_flags + fbase + 1 * WORLD + counterpart,
+            0,
+            sem="acquire",
+            scope="sys",
+        )
+        < token
+    ):
+        pass
+    _fence_sys(0)
+    tl.debug_barrier()
+    cp_partial = (
+        tl.cast(
+            tl.load(partial_ptrs_ptr + counterpart),
+            tl.pointer_type(tl.bfloat16),
+        )
+        + buf_off
+    )
+    for off in range(start, end, BLOCK):
+        offs = off + tl.arange(0, BLOCK)
+        mask = offs < end
+        acc = tl.load(my_partial + offs, mask=mask, other=0.0).to(tl.float32)
+        acc += tl.load(cp_partial + offs, mask=mask, other=0.0).to(tl.float32)
+        tl.store(out_ptr + offs, acc.to(tl.bfloat16), mask=mask)
+
+
+@triton.jit
+def _hier_two_shot_kernel(
+    inp_ptr,
+    out_ptr,
+    ptrs_ptr,  # [world] int64 pointers to each rank's data slot
+    partial_ptrs_ptr,  # [world] pointers to each rank's island-partial slot
+    gather_ptrs_ptr,  # [world] pointers to each rank's global-shard slot
+    flag_ptrs_ptr,  # [world] pointers to each rank's flag array
+    rank: tl.constexpr,
+    island_base: tl.constexpr,
+    island_idx: tl.constexpr,  # this rank's index inside its island
+    island_size: tl.constexpr,
+    counterpart: tl.constexpr,
+    WORLD: tl.constexpr,
+    numel,
+    token_ptr,  # [MAX_CTA] device int32 sequence counters
+    MAX_ELEMS: tl.constexpr,
+    MAX_CTA: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    """Two-shot variant: reduce-scatter, one cross-island shard exchange,
+    then allgather. Moves 7n/4 remote bytes against the one-shot kernel's
+    4n, and only n/island_size of that crosses the slow inter-island link
+    (vs n) -- the win grows with message size.
+
+    Partitioning is a stripe: CTA k owns slice k of *every* shard, so a
+    reader CTA always waits on the same CTA index of its peers and no
+    cross-CTA barrier is needed.
+    """
+    pid = tl.program_id(0)
+    ncta = tl.num_programs(0)
+    token = tl.atomic_add(token_ptr + pid, 1, sem="relaxed") + 1
+    buf_off = (token % 2) * MAX_ELEMS
+
+    shard = tl.cdiv(numel, island_size)
+    ss = tl.cdiv(shard, ncta)
+    my_start = island_idx * shard + pid * ss
+    my_end = tl.minimum(tl.minimum(island_idx * shard + shard, my_start + ss), numel)
+
+    my_data = tl.cast(tl.load(ptrs_ptr + rank), tl.pointer_type(tl.bfloat16)) + buf_off
+    my_partial = (
+        tl.cast(tl.load(partial_ptrs_ptr + rank), tl.pointer_type(tl.bfloat16))
+        + buf_off
+    )
+    my_gather = (
+        tl.cast(tl.load(gather_ptrs_ptr + rank), tl.pointer_type(tl.bfloat16)) + buf_off
+    )
+    my_flags = tl.cast(tl.load(flag_ptrs_ptr + rank), tl.pointer_type(tl.int32))
+
+    # Phase A: publish this CTA's stripe of every shard -- exactly the bytes
+    # each island peer reads for the shard it owns.
+    for s in tl.static_range(island_size):
+        start = s * shard + pid * ss
+        end = tl.minimum(tl.minimum(s * shard + shard, start + ss), numel)
+        for off in range(start, end, BLOCK):
+            offs = off + tl.arange(0, BLOCK)
+            mask = offs < end
+            x = tl.load(inp_ptr + offs, mask=mask, other=0.0)
+            tl.store(my_data + offs, x, mask=mask)
+    tl.debug_barrier()
+    _fence_sys(0)
+    for i in tl.static_range(island_size):
+        peer = island_base + i
+        if peer != rank:
+            pf = tl.cast(tl.load(flag_ptrs_ptr + peer), tl.pointer_type(tl.int32))
+            tl.store(pf + (0 * WORLD + rank) * MAX_CTA + pid, token)
+
+    for i in tl.static_range(island_size):
+        peer = island_base + i
+        if peer != rank:
+            while (
+                tl.atomic_add(
+                    my_flags + (0 * WORLD + peer) * MAX_CTA + pid,
+                    0,
+                    sem="acquire",
+                    scope="sys",
+                )
+                < token
+            ):
+                pass
+    _fence_sys(0)
+    tl.debug_barrier()
+
+    # Phase B: reduce-scatter -- sum the island over the shard this rank owns.
+    for off in range(my_start, my_end, BLOCK):
+        offs = off + tl.arange(0, BLOCK)
+        mask = offs < my_end
+        acc = tl.load(my_data + offs, mask=mask, other=0.0).to(tl.float32)
+        for i in tl.static_range(island_size):
+            peer = island_base + i
+            if peer != rank:
+                pd = (
+                    tl.cast(tl.load(ptrs_ptr + peer), tl.pointer_type(tl.bfloat16))
+                    + buf_off
+                )
+                acc += tl.load(pd + offs, mask=mask, other=0.0).to(tl.float32)
+        tl.store(my_partial + offs, acc.to(tl.bfloat16), mask=mask)
+    tl.debug_barrier()
+    _fence_sys(0)
+    cpf = tl.cast(tl.load(flag_ptrs_ptr + counterpart), tl.pointer_type(tl.int32))
+    tl.store(cpf + (1 * WORLD + rank) * MAX_CTA + pid, token)
+
+    # Phase C: single cross-island exchange, shard-sized. The counterpart
+    # holds the same island-local index, hence the same shard offsets.
+    while (
+        tl.atomic_add(
+            my_flags + (1 * WORLD + counterpart) * MAX_CTA + pid,
+            0,
+            sem="acquire",
+            scope="sys",
+        )
+        < token
+    ):
+        pass
+    _fence_sys(0)
+    tl.debug_barrier()
+    cp_partial = (
+        tl.cast(
+            tl.load(partial_ptrs_ptr + counterpart),
+            tl.pointer_type(tl.bfloat16),
+        )
+        + buf_off
+    )
+    for off in range(my_start, my_end, BLOCK):
+        offs = off + tl.arange(0, BLOCK)
+        mask = offs < my_end
+        acc = tl.load(my_partial + offs, mask=mask, other=0.0).to(tl.float32)
+        acc += tl.load(cp_partial + offs, mask=mask, other=0.0).to(tl.float32)
+        tl.store(my_gather + offs, acc.to(tl.bfloat16), mask=mask)
+    tl.debug_barrier()
+    _fence_sys(0)
+    for i in tl.static_range(island_size):
+        peer = island_base + i
+        if peer != rank:
+            pf = tl.cast(tl.load(flag_ptrs_ptr + peer), tl.pointer_type(tl.int32))
+            tl.store(pf + (2 * WORLD + rank) * MAX_CTA + pid, token)
+
+    # Phase D: allgather the finished shards from the island.
+    for i in tl.static_range(island_size):
+        peer = island_base + i
+        if peer != rank:
+            while (
+                tl.atomic_add(
+                    my_flags + (2 * WORLD + peer) * MAX_CTA + pid,
+                    0,
+                    sem="acquire",
+                    scope="sys",
+                )
+                < token
+            ):
+                pass
+    _fence_sys(0)
+    tl.debug_barrier()
+    for s in tl.static_range(island_size):
+        peer = island_base + s
+        pg = (
+            tl.cast(tl.load(gather_ptrs_ptr + peer), tl.pointer_type(tl.bfloat16))
+            + buf_off
+        )
+        start = s * shard + pid * ss
+        end = tl.minimum(tl.minimum(s * shard + shard, start + ss), numel)
+        for off in range(start, end, BLOCK):
+            offs = off + tl.arange(0, BLOCK)
+            mask = offs < end
+            tl.store(
+                out_ptr + offs,
+                tl.load(pg + offs, mask=mask, other=0.0),
+                mask=mask,
+            )
+
+
+class HierarchicalAllReduce:
+    """Two-level island-aware allreduce over IPC-shared buffers.
+
+    Args:
+        group: torch.distributed group covering all ranks on this node.
+        device: this rank's CUDA device.
+        islands: rank partition, e.g. [[0,1,2,3],[4,5,6,7]]. Exactly two
+            islands of equal size are supported.
+    """
+
+    def __init__(
+        self,
+        group: dist.ProcessGroup,
+        device: torch.device,
+        islands: Sequence[Sequence[int]],
+    ) -> None:
+        self.group = group
+        self.device = device
+        self.rank = dist.get_rank(group)
+        self.world_size = dist.get_world_size(group)
+        assert len(islands) == 2 and len(islands[0]) == len(islands[1]), (
+            "HierarchicalAllReduce supports exactly two equal islands"
+        )
+        self.islands = [list(i) for i in islands]
+        me = self.rank
+        self.island_idx = 0 if me in self.islands[0] else 1
+        island = self.islands[self.island_idx]
+        other = self.islands[1 - self.island_idx]
+        self.island_base = min(island)
+        self.island_size = len(island)
+        self.counterpart = other[island.index(me)]
+
+        rt = _get_cudart()
+        _check(rt.cudaSetDevice(ctypes.c_int(device.index)), "cudaSetDevice")
+        self._own = []
+        self._opened = []
+        # data slots (bf16), partial slots (fp32) — double-buffered; flags
+        # [phase(2) x writer(world)] int32
+        data_ptr = self._alloc(rt, 2 * _MAX_ELEMS * 2)
+        partial_ptr = self._alloc(rt, 2 * _MAX_ELEMS * 2)
+        gather_ptr = self._alloc(rt, 2 * _MAX_ELEMS * 2)
+        flags_ptr = self._alloc(rt, _MAX_CTA * 2 * self.world_size * 4)
+        flags2_ptr = self._alloc(rt, 3 * self.world_size * _MAX_CTA * 4)
+        self._token_ctr = torch.zeros(_MAX_CTA, dtype=torch.int32, device=device)
+        self._token_ctr2 = torch.zeros(_MAX_CTA, dtype=torch.int32, device=device)
+
+        self._data_ptrs = self._exchange_ptrs(rt, data_ptr)
+        self._partial_ptrs = self._exchange_ptrs(rt, partial_ptr)
+        self._gather_ptrs = self._exchange_ptrs(rt, gather_ptr)
+        self._flag_ptrs = self._exchange_ptrs(rt, flags_ptr)
+        self._flag2_ptrs = self._exchange_ptrs(rt, flags2_ptr)
+
+    def _alloc(self, rt, nbytes: int) -> int:
+        ptr = ctypes.c_void_p()
+        _check(rt.cudaMalloc(ctypes.byref(ptr), nbytes), "cudaMalloc")
+        _check(rt.cudaMemset(ptr, 0, nbytes), "cudaMemset")
+        self._own.append(ptr.value)
+        return ptr.value
+
+    def _exchange_ptrs(self, rt, local_ptr: int) -> torch.Tensor:
+        """Share a raw device allocation with all ranks via CUDA IPC and
+        return a device tensor of every rank's pointer. Handles are opened
+        with the importing device current so lazy peer access covers our
+        kernels' direct loads/stores."""
+        handle = _IpcHandle()
+        _check(
+            rt.cudaIpcGetMemHandle(ctypes.byref(handle), ctypes.c_void_p(local_ptr)),
+            "cudaIpcGetMemHandle",
+        )
+        objs: list = [None] * self.world_size
+        dist.all_gather_object(objs, (self.rank, bytes(handle)), group=self.group)
+        ptrs = torch.zeros(self.world_size, dtype=torch.int64, device=self.device)
+        for rank, hbytes in objs:
+            if rank == self.rank:
+                ptrs[rank] = local_ptr
+                continue
+            h = _IpcHandle.from_buffer_copy(hbytes)
+            peer_ptr = ctypes.c_void_p()
+            _check(
+                rt.cudaIpcOpenMemHandle(ctypes.byref(peer_ptr), h, ctypes.c_uint(1)),
+                "cudaIpcOpenMemHandle",
+            )
+            self._opened.append(peer_ptr.value)
+            ptrs[rank] = peer_ptr.value
+        return ptrs
+
+    def __del__(self):
+        try:
+            rt = _get_cudart()
+            for ptr in getattr(self, "_opened", []):
+                rt.cudaIpcCloseMemHandle(ctypes.c_void_p(ptr))
+            for ptr in getattr(self, "_own", []):
+                rt.cudaFree(ctypes.c_void_p(ptr))
+        except Exception:
+            pass
+
+    def should_use(self, inp: torch.Tensor) -> bool:
+        return (
+            inp.dtype == torch.bfloat16
+            and inp.is_contiguous()
+            and inp.numel() <= _MAX_ELEMS
+            and inp.numel() % self.island_size == 0
+        )
+
+    def all_reduce(self, inp: torch.Tensor, out: torch.Tensor | None = None):
+        if out is None:
+            out = torch.empty_like(inp)
+        numel = inp.numel()
+        if numel >= _TWO_SHOT_MIN_ELEMS:
+            ncta = min(_MAX_CTA, max(1, numel // (self.island_size * 1024)))
+            _hier_two_shot_kernel[(ncta,)](
+                inp.view(-1),
+                out.view(-1),
+                self._data_ptrs,
+                self._partial_ptrs,
+                self._gather_ptrs,
+                self._flag2_ptrs,
+                rank=self.rank,
+                island_base=self.island_base,
+                island_idx=self.rank - self.island_base,
+                island_size=self.island_size,
+                counterpart=self.counterpart,
+                WORLD=self.world_size,
+                numel=numel,
+                token_ptr=self._token_ctr2,
+                MAX_ELEMS=_MAX_ELEMS,
+                MAX_CTA=_MAX_CTA,
+                BLOCK=min(4096, triton.next_power_of_2(numel)),
+                num_warps=8,
+            )
+            return out
+        ncta = min(_MAX_CTA, max(1, (numel + 4095) // 4096))
+        _hier_all_reduce_kernel[(ncta,)](
+            inp.view(-1),
+            out.view(-1),
+            self._data_ptrs,
+            self._partial_ptrs,
+            self._flag_ptrs,
+            rank=self.rank,
+            island_base=self.island_base,
+            island_size=self.island_size,
+            counterpart=self.counterpart,
+            WORLD=self.world_size,
+            numel=numel,
+            token_ptr=self._token_ctr,
+            MAX_ELEMS=_MAX_ELEMS,
+            BLOCK=min(8192, triton.next_power_of_2(numel)),
+            num_warps=8,
+        )
+        return out

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -292,6 +292,7 @@ if TYPE_CHECKING:
     VLLM_ELASTIC_EP_SCALE_UP_LAUNCH: bool = False
     VLLM_ELASTIC_EP_DRAIN_REQUESTS: bool = False
     VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS: bool = True
+    VLLM_HIER_ALL_REDUCE: str = ""
     VLLM_NIXL_EP_MAX_NUM_RANKS: int = 32
     VLLM_XPU_ENABLE_XPU_GRAPH: bool = False
     VLLM_XPU_USE_SAMPLER_KERNEL: bool = True
@@ -2010,6 +2011,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS": lambda: bool(
         int(os.getenv("VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS", "1"))
     ),
+    # Island partition for the hierarchical allreduce, e.g. "0,1,2,3;4,5,6,7"
+    # for a 2x4 PCIe box. Empty disables it.
+    "VLLM_HIER_ALL_REDUCE": lambda: os.getenv("VLLM_HIER_ALL_REDUCE", ""),
     # NIXL EP environment variables
     "VLLM_NIXL_EP_MAX_NUM_RANKS": lambda: int(
         os.getenv("VLLM_NIXL_EP_MAX_NUM_RANKS", "32")


### PR DESCRIPTION
## Purpose

On PCIe-only boxes whose GPUs form multiple islands — e.g. 2×4 A100/A800, where GPU0-3 and GPU4-7 are each PIX-connected and the two halves are bridged by the CPU interconnect — `CustomAllreduce` is unavailable (`is_fully_connected` is false) and every allreduce falls to the NCCL ring, which crosses the slow inter-island link repeatedly. Profiling DeepSeek-V4-Flash-0731 decode on an 8×A800 box put **allreduce at 68.6% of decode GPU time** (292 µs/call at decode shapes), far ahead of attention (2.3%) or the MoE GEMMs.

This adds an opt-in island-aware communicator. It is off unless the operator supplies an explicit island partition, so nothing changes for existing deployments.

## Design

Enabled with `VLLM_HIER_ALL_REDUCE="0,1,2,3;4,5,6,7"`. Two Triton kernels share one set of IPC-registered buffers and dispatch on message size:

- **one-shot** (< 24576 elements): publish the input, reduce the island over direct P2P reads, then one cross-island exchange. Two sync rounds, 4n remote bytes.
- **two-shot** (≥ 24576): reduce-scatter within the island, exchange only the `1/island_size` shard across islands, allgather. Three sync rounds, 7n/4 remote bytes — and only `n/island_size` crosses the slow link instead of `n`.

Three details are load-bearing and worth calling out for review:

1. **Push-based signalling.** PCIe has no native remote atomics, and having a reader poll a remote flag costs a PCIe round trip per spin. Writers instead store sequence tokens into the *reader's* local flag array and readers spin on local memory only, with `fence.acq_rel.sys` for ordering. Same shape as the existing CUDA custom-allreduce kernels.
2. **Device-side sequence counters.** A host-supplied token would be baked into a CUDA graph and replay out of order, so the token comes from a device-side fetch-and-increment. Buffers then alternate by token parity, which makes it impossible for a rank that has lapped a slow peer to overwrite data the peer is still reading (a two-call lap is blocked by the flag waits).
3. **Stripe CTA partitioning in the two-shot kernel.** CTA *k* owns slice *k* of *every* shard rather than one contiguous range, so a reader CTA always waits on the same CTA index of its peers across all three phases. That removes the need for a grid-wide barrier, which Triton has no primitive for.

Note the IPC buffers are allocated and mapped through `cudaIpcOpenMemHandle` with the importing device current, rather than via torch's `_new_shared_cuda`: torch opens IPC handles inside the *owner's* device context, so the mapping is never made peer-accessible to the importing device's kernels — `copy_()` works but a kernel dereference is an immediate IMA, and `cudaDeviceEnablePeerAccess` does not retroactively fix an already-imported handle.

## Not a duplicate of

- **#36834 (Added Hierarchical all reduce)** — that is a *node-level* hierarchy for multi-node inference: intra-node NVLink custom allreduce plus inter-node RDMA through UCCL-EP. This PR is single-node and hierarchical *within* the box, over PCIe islands, on hardware that has no NVLink at all. No overlap in code or target.
- **#44891 (push-based allreduce for small tensor reductions)** — shares the push/poll idea but is a flat (non-hierarchical) protocol in CUDA C++ targeting NVLink (threshold tuned on B200). This is a two-level algorithm in Triton for PCIe-island topologies. They compose: that PR's dispatch entry is above `CustomAllreduce`, this one is likewise independent and gated behind an explicit env.
- **#39633 (Fix PCIe custom-allreduce eligibility on >2 GPU topologies)** — that reuses the *existing* barrier-based kernel on PCIe. I tried exactly that on this hardware first (the P2P access matrix is fully connected here, so the NVLink-only gate looked like policy rather than capability). It runs at 21 µs but returns **numerically wrong results** at `world_size=8` (max error 1.5 to `inf` against an NCCL reference), so I abandoned that route and wrote a separate kernel instead. Details posted on that PR — it may be worth verifying on SM120 before enabling.

## Test plan

New `tests/distributed/test_hier_all_reduce.py` checks the communicator against `torch.distributed.all_reduce` across sizes that straddle the one-shot/two-shot threshold in both directions, plus a size that is not a multiple of the CTA tiling to exercise the masked tails. Each size runs twice so both parity buffers are used.

```
$ pytest tests/distributed/test_hier_all_reduce.py -q
2 passed, 14 warnings in 64.69s
```
(`tp_size` 2 and 4 on an 8×A800 node.)

Standalone correctness/latency sweep against NCCL, bf16, 8×A800, max error ≤ 0.016 at every size (bf16 reduction-order tolerance), µs/call:

| size | NCCL | one-shot | two-shot |
|---:|---:|---:|---:|
| 8KB | 56.9 | **46.5** | 47.5 |
| 32KB | 95.8 | **45.6** | 47.3 |
| 48KB | 64.7 | 54.3 | **49.6** |
| 64KB | **49.8** | 64.5 | 52.9 |
| 128KB | 132.2 | 102.2 | **66.7** |
| 256KB | 169.4 | 174.8 | **91.2** |
| 512KB | 160.4 | 324.2 | **143.0** |

64KB is the one point where NCCL still wins; I left the dispatch alone rather than special-casing around a single measurement.

## Serving results

DeepSeek-V4-Flash-0731, 8×A800, TP=8, EP, fp8 KV, `vllm bench serve` with in 2048 / out 512, toggling only `VLLM_HIER_ALL_REDUCE`:

| config | concurrency | on | off | gain |
|---|---:|---:|---:|---:|
| DSpark spec decode, `max_num_seqs=16` | 1 | 101.3 | 90.2 tok/s | **+12.4%** |
| | 8 | 356.2 | 315.5 tok/s | **+12.9%** |
| no spec decode, `max_num_seqs=64` | 16 | 402.9 | 384.0 tok/s | +4.9% |
| | 32 | 690.6 | 609.1 tok/s | **+13.4%** |
| | 64 | 911.1 | 845.8 tok/s | +7.7% |

Peak output throughput goes 846 → 911 tok/s. The gain tracks message size: the payload is `batch × hidden × 2` bytes, so concurrency 16/32/64 lands near 128/256/512KB, matching the kernel table above.

Accuracy is unaffected (the op is a drop-in allreduce). As an end-to-end sanity run, the same stack completed Terminal-Bench 2.1 (89 tasks, 18.4 hours, 13,264 requests, 200.7M prompt + 5.5M generated tokens) with no crashes and no numerical corruption.

## Notes

- Opt-in only; when `VLLM_HIER_ALL_REDUCE` is unset the dispatch chain is unchanged.
- Requires exactly two equal islands and bf16 input; anything else falls through to the existing backends.
- AI assistance (Claude) was used for this change.
