### PR TITLE
[MoE] Align TRTLLM MXFP4 autotune buckets

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_mxfp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_mxfp4_moe.py
@@ -14,7 +14,10 @@ from vllm.model_executor.layers.fused_moe.config import (
 from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceNoOP,
 )
-from vllm.model_executor.layers.fused_moe.utils import trtllm_moe_pack_topk_ids_weights
+from vllm.model_executor.layers.fused_moe.utils import (
+    fi_moe_largest_bucket,
+    trtllm_moe_pack_topk_ids_weights,
+)
 from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
     activation_to_flashinfer_int,
     has_flashinfer_situ_activation,
@@ -112,8 +115,6 @@ class TrtLlmMxfp4ExpertsBase:
                 device=device,
             )
             self.gemm1_clamp_limit = None
-
-        self.max_capture_size = moe_config.max_capture_size
 
     @staticmethod
     def _supports_current_device() -> bool:
@@ -263,7 +264,7 @@ class TrtLlmMxfp4ExpertsMonolithic(
             routing_method_type=self.routing_method_type,
             do_finalize=True,
             activation_type=self._flashinfer_activation_type(activation),
-            tune_max_num_tokens=max(self.max_capture_size, 1),
+            tune_max_num_tokens=fi_moe_largest_bucket(self.moe_config),
             output=output,
             routing_replay_out=routing_replay_out,
         )
@@ -382,7 +383,7 @@ class TrtLlmMxfp4ExpertsModular(TrtLlmMxfp4ExpertsBase, mk.FusedMoEExpertsModula
             enable_pdl=True,
             activation_type=self._flashinfer_activation_type(activation),
             output=output,
-            tune_max_num_tokens=max(self.max_capture_size, 1),
+            tune_max_num_tokens=fi_moe_largest_bucket(self.moe_config),
         )
 
     def apply(


### PR DESCRIPTION
## Purpose

Use the shared FlashInfer MoE bucket helper so MXFP4 follows the same max-token and DP-aware convention as the other TRTLLM backends.

Align with https://github.com/vllm-project/vllm/pull/47427, so that it will autotune up to 8192 tokens. Without this change, MXFP4 TRTLLM sets `tune_max_num_tokens = moe_config.max_capture_size`, which is only 512 -> bad for prefill.

We can verify the behavior in vLLM logs. Before this PR, there are only 10 profiles

```
[AutoTuner]: Tuning flashinfer::trtllm_fp4_block_scale_moe:  90%|█████████ | 9/10 [01:46<00:11, 11.41s/profile]
```

After this PR, there are 21 profiles

```
[AutoTuner]: Tuning flashinfer::trtllm_fp4_block_scale_moe: 100%|██████████| 21/21 [01:47<00:00,  5.11s/profile]
```

## Test Plan

8k-1, prefill-only benchmark, SPEED-bench, low-entropy

Config | TPGS (before) | TPGS (after)
---|---|---
TP8 | 2,362.41 tok/s | 2,604.06 tok/s (+10%)
TEP8 | 2,816.06 tok/s | 2,734.19 tok/s (-2.9%)

Note: TEP8 worsens might be due to expert imbalance i.e. FlashInfer assumes uniform expert distribution during autotuning. Repeated runs show the same results.

## Test Result

TP8:
- GSM8K: 0.9655
- OCRBench: 88.8

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>