### PR TITLE
[Bugfix] Bound Gemma4 parser nesting depth

### DIFF
--- a/rust/src/parser/src/unified/gemma4.rs
+++ b/rust/src/parser/src/unified/gemma4.rs
@@ -389,30 +389,81 @@ fn parse_gemma4_args(args: &str) -> ModalResult<Map<String, Value>> {
 
 /// Check that nested Gemma4 containers stay within the parser's stack budget.
 fn gemma4_nesting_is_within_limit(mut input: &str) -> bool {
-    let mut depth = 0;
-    let mut in_string = false;
+    enum Container {
+        Args,
+        Array,
+    }
 
-    while !input.is_empty() {
-        if let Some(rest) = input.strip_prefix(STRING_DELIM) {
-            in_string = !in_string;
+    let mut depth = 0;
+    let mut containers = vec![Container::Args];
+
+    while let Some(container) = containers.last() {
+        input = input.trim_start();
+        if let Some(rest) = input.strip_prefix(',') {
             input = rest;
             continue;
         }
 
-        let character = input.chars().next().unwrap();
-        if !in_string {
-            match character {
-                '{' | '[' => {
-                    depth += 1;
-                    if depth > MAX_GEMMA4_NESTING_DEPTH {
-                        return false;
-                    }
+        match container {
+            Container::Args if input.strip_prefix('}').is_some() => {
+                if containers.len() > 1 {
+                    depth -= 1;
                 }
-                '}' | ']' => depth = depth.saturating_sub(1),
-                _ => {}
+                containers.pop();
+                input = &input[1..];
+                continue;
             }
+            Container::Array if input.strip_prefix(']').is_some() => {
+                if containers.len() > 1 {
+                    depth -= 1;
+                }
+                containers.pop();
+                input = &input[1..];
+                continue;
+            }
+            Container::Args => {
+                let Some(key_end) = input.find(':') else {
+                    return true;
+                };
+                input = &input[key_end + 1..];
+            }
+            Container::Array => {}
         }
-        input = &input[character.len_utf8()..];
+
+        input = input.trim_start();
+        if let Some(rest) = input.strip_prefix(STRING_DELIM) {
+            let Some(string_end) = rest.find(STRING_DELIM) else {
+                return true;
+            };
+            input = &rest[string_end + STRING_DELIM.len()..];
+            continue;
+        }
+
+        match input.chars().next() {
+            Some('{') => {
+                depth += 1;
+                if depth > MAX_GEMMA4_NESTING_DEPTH {
+                    return false;
+                }
+                containers.push(Container::Args);
+                input = &input[1..];
+            }
+            Some('[') => {
+                depth += 1;
+                if depth > MAX_GEMMA4_NESTING_DEPTH {
+                    return false;
+                }
+                containers.push(Container::Array);
+                input = &input[1..];
+            }
+            Some(_) => {
+                let Some(value_end) = input.find([',', '}', ']']) else {
+                    return true;
+                };
+                input = &input[value_end..];
+            }
+            None => return true,
+        }
     }
 
     true
@@ -753,15 +804,15 @@ mod tests {
     #[test]
     fn gemma4_nesting_limit_accepts_128_and_rejects_129() {
         let nested_value = format!(
-            "{}1{}",
-            "nested:{".repeat(super::MAX_GEMMA4_NESTING_DEPTH),
+            "value:{}1{}",
+            "{nested:".repeat(super::MAX_GEMMA4_NESTING_DEPTH),
             "}".repeat(super::MAX_GEMMA4_NESTING_DEPTH),
         );
         assert!(super::gemma4_nesting_is_within_limit(&nested_value));
 
         assert!(!super::gemma4_nesting_is_within_limit(&format!(
-            "{}1{}",
-            "nested:{".repeat(super::MAX_GEMMA4_NESTING_DEPTH + 1),
+            "value:{}1{}",
+            "{nested:".repeat(super::MAX_GEMMA4_NESTING_DEPTH + 1),
             "}".repeat(super::MAX_GEMMA4_NESTING_DEPTH + 1),
         )));
     }
@@ -770,7 +821,7 @@ mod tests {
     fn gemma4_parse_args_rejects_excessive_nesting() {
         let nested_value = format!(
             "{}1{}",
-            "nested:{".repeat(super::MAX_GEMMA4_NESTING_DEPTH + 1),
+            "{nested:".repeat(super::MAX_GEMMA4_NESTING_DEPTH + 1),
             "}".repeat(super::MAX_GEMMA4_NESTING_DEPTH + 1),
         );
 
@@ -786,6 +837,29 @@ mod tests {
         let parsed = parse_gemma4_args(&format!("value:<|\"|>{value}<|\"|>")).unwrap();
 
         assert_eq!(Value::Object(parsed), json!({ "value": value }));
+    }
+
+    #[test]
+    fn gemma4_nesting_limit_ignores_string_delimiters_inside_keys() {
+        let args = format!(
+            "key{}:{}1{}{}",
+            super::STRING_DELIM,
+            "{nested:".repeat(super::MAX_GEMMA4_NESTING_DEPTH + 1),
+            "}".repeat(super::MAX_GEMMA4_NESTING_DEPTH + 1),
+            super::STRING_DELIM,
+        );
+
+        assert!(!super::gemma4_nesting_is_within_limit(&args));
+    }
+
+    #[test]
+    fn gemma4_nesting_limit_allows_many_sibling_containers() {
+        let args = std::iter::repeat("value:{}")
+            .take(super::MAX_GEMMA4_NESTING_DEPTH + 1)
+            .collect::<Vec<_>>()
+            .join(",");
+
+        assert!(super::gemma4_nesting_is_within_limit(&args));
     }
 
     #[test]
@@ -824,7 +898,7 @@ mod tests {
     fn gemma4_parse_complete_rejects_excessive_nesting() {
         let nested_value = format!(
             "{}1{}",
-            "nested:{".repeat(super::MAX_GEMMA4_NESTING_DEPTH + 1),
+            "{nested:".repeat(super::MAX_GEMMA4_NESTING_DEPTH + 1),
             "}".repeat(super::MAX_GEMMA4_NESTING_DEPTH + 1),
         );
         let input = format!("<|tool_call>call:tool{{value:{nested_value}}}<tool_call|>");

--- a/rust/src/parser/src/unified/gemma4.rs
+++ b/rust/src/parser/src/unified/gemma4.rs
@@ -421,6 +421,11 @@ fn gemma4_nesting_is_within_limit(mut input: &str) -> bool {
                 input = &input[1..];
                 continue;
             }
+            // A closing delimiter for the wrong container would otherwise be
+            // treated as a bare-value delimiter below. At offset zero that
+            // would leave `input` unchanged and spin forever.
+            Container::Args if input.strip_prefix(']').is_some() => return false,
+            Container::Array if input.strip_prefix('}').is_some() => return false,
             Container::Args => {
                 let Some(key_end) = input.find(':') else {
                     return true;
@@ -460,6 +465,12 @@ fn gemma4_nesting_is_within_limit(mut input: &str) -> bool {
                 let Some(value_end) = input.find([',', '}', ']']) else {
                     return true;
                 };
+                // Every successful iteration must consume input. A delimiter
+                // at the current position is either a mismatched closer (caught
+                // above) or otherwise malformed input.
+                if value_end == 0 {
+                    return false;
+                }
                 input = &input[value_end..];
             }
             None => return true,
@@ -860,6 +871,21 @@ mod tests {
             .join(",");
 
         assert!(super::gemma4_nesting_is_within_limit(&args));
+    }
+
+    #[test]
+    fn gemma4_nesting_limit_rejects_mismatched_closing_delimiters() {
+        for args in [
+            "value:[1}",
+            "value:{a:[1}",
+            "value:[{a:[1}]}",
+        ] {
+            assert!(
+                !super::gemma4_nesting_is_within_limit(args),
+                "expected mismatched delimiters to be rejected: {args}",
+            );
+            assert!(matches!(parse_gemma4_args(args), Err(ErrMode::Cut(_))));
+        }
     }
 
     #[test]

--- a/rust/src/parser/src/unified/gemma4.rs
+++ b/rust/src/parser/src/unified/gemma4.rs
@@ -23,6 +23,7 @@ const TOOL_CALL_START: &str = "<|tool_call>";
 const TOOL_CALL_END: &str = "<tool_call|>";
 const STRING_DELIM: &str = "<|\"|>";
 const CALL_PREFIX: &str = "call:";
+const MAX_GEMMA4_NESTING_DEPTH: usize = 128;
 
 type Gemma4Input<'i> = Partial<&'i str>;
 
@@ -378,8 +379,43 @@ fn safe_scan_len(text: &str, start: usize, markers: &[&str]) -> usize {
 
 /// Parse complete Gemma4 custom key-value arguments.
 fn parse_gemma4_args(args: &str) -> ModalResult<Map<String, Value>> {
+    if !gemma4_nesting_is_within_limit(args) {
+        return Err(ErrMode::Cut(ContextError::new()));
+    }
+
     let mut input = args;
     terminated(gemma4_args, eof).parse_next(&mut input)
+}
+
+/// Check that nested Gemma4 containers stay within the parser's stack budget.
+fn gemma4_nesting_is_within_limit(mut input: &str) -> bool {
+    let mut depth = 0;
+    let mut in_string = false;
+
+    while !input.is_empty() {
+        if let Some(rest) = input.strip_prefix(STRING_DELIM) {
+            in_string = !in_string;
+            input = rest;
+            continue;
+        }
+
+        let character = input.chars().next().unwrap();
+        if !in_string {
+            match character {
+                '{' | '[' => {
+                    depth += 1;
+                    if depth > MAX_GEMMA4_NESTING_DEPTH {
+                        return false;
+                    }
+                }
+                '}' | ']' => depth = depth.saturating_sub(1),
+                _ => {}
+            }
+        }
+        input = &input[character.len_utf8()..];
+    }
+
+    true
 }
 
 /// Parse Gemma4's custom key-value argument object content.
@@ -715,6 +751,28 @@ mod tests {
     }
 
     #[test]
+    fn gemma4_parse_args_rejects_excessive_nesting() {
+        let nested_value = format!(
+            "{}1{}",
+            "nested:{".repeat(super::MAX_GEMMA4_NESTING_DEPTH + 1),
+            "}".repeat(super::MAX_GEMMA4_NESTING_DEPTH + 1),
+        );
+
+        assert!(matches!(
+            parse_gemma4_args(&format!("value:{nested_value}")),
+            Err(ErrMode::Cut(_))
+        ));
+    }
+
+    #[test]
+    fn gemma4_parse_args_ignores_brackets_inside_strings_for_nesting_limit() {
+        let value = "{".repeat(super::MAX_GEMMA4_NESTING_DEPTH + 1);
+        let parsed = parse_gemma4_args(&format!("value:<|\"|>{value}<|\"|>")).unwrap();
+
+        assert_eq!(Value::Object(parsed), json!({ "value": value }));
+    }
+
+    #[test]
     fn gemma4_parse_array_handles_bare_values() {
         let parsed = parse_gemma4_array("42,true,114.514").unwrap();
         assert_eq!(Value::Array(parsed), json!([42, true, 114.514]));
@@ -744,6 +802,20 @@ mod tests {
             .unwrap_err();
 
         assert!(error.to_report_string().contains("incomplete Gemma4 tool call"));
+    }
+
+    #[test]
+    fn gemma4_parse_complete_rejects_excessive_nesting() {
+        let nested_value = format!(
+            "{}1{}",
+            "nested:{".repeat(super::MAX_GEMMA4_NESTING_DEPTH + 1),
+            "}".repeat(super::MAX_GEMMA4_NESTING_DEPTH + 1),
+        );
+        let input = format!("<|tool_call>call:tool{{value:{nested_value}}}<tool_call|>");
+        let mut parser = test_parser();
+
+        assert!(parser.parse_complete(&input).is_err());
+        assert_eq!(parser.reset(), input);
     }
 
     #[test]

--- a/rust/src/parser/src/unified/gemma4.rs
+++ b/rust/src/parser/src/unified/gemma4.rs
@@ -751,6 +751,22 @@ mod tests {
     }
 
     #[test]
+    fn gemma4_nesting_limit_accepts_128_and_rejects_129() {
+        let nested_value = format!(
+            "{}1{}",
+            "nested:{".repeat(super::MAX_GEMMA4_NESTING_DEPTH),
+            "}".repeat(super::MAX_GEMMA4_NESTING_DEPTH),
+        );
+        assert!(super::gemma4_nesting_is_within_limit(&nested_value));
+
+        assert!(!super::gemma4_nesting_is_within_limit(&format!(
+            "{}1{}",
+            "nested:{".repeat(super::MAX_GEMMA4_NESTING_DEPTH + 1),
+            "}".repeat(super::MAX_GEMMA4_NESTING_DEPTH + 1),
+        )));
+    }
+
+    #[test]
     fn gemma4_parse_args_rejects_excessive_nesting() {
         let nested_value = format!(
             "{}1{}",


### PR DESCRIPTION
## Purpose

Fixes #50927.

Gemma4 tool-call argument parsing used a mutually recursive grammar without a depth bound. Deeply nested model output could therefore exhaust a worker thread's stack and terminate the process. This change rejects arguments nested deeper than 128 containers before entering the recursive parser.

The pre-scan recognizes Gemma4's `<|"|>` string delimiters, so brackets inside string values do not count toward the nesting limit.

### Why 128 is safe

The limit is inclusive: 128 container opens pass the guard, while the 129th is rejected. The reported crash required roughly 1,500 nested containers, so the parser is stopped more than an order of magnitude (about 11.7x) before the observed stack-exhaustion depth. The guard itself is a single linear scan with a constant-size counter, and it runs before recursive parsing.

Duplicate-work checks found no open PR referencing #50927 and no open PR for the Gemma4 parser recursion issue.

Model evaluation: not applicable. This is a parser-safety guard; valid tool calls within the supported nesting limit retain their existing behavior.

AI assistance: Codex was used to implement and test this change. The human submitter reviewed every changed line.

## Test Plan

```bash
cd rust
cargo fmt --check
cargo test -p vllm-parser gemma4_
```

## Test Result

Passed:

```text
running 33 tests
test result: ok. 33 passed; 0 failed; 0 ignored; 0 measured; 387 filtered out
```

The focused suite covers the precise guard boundary (128 accepted; 129 rejected), rejection through both the argument parser and complete tool-call parser, and brackets inside Gemma4 string delimiters.