### PR TITLE
[CPU] Optimize routed FP8/MXFP4 MoE GEMM dispatch

### DIFF
--- a/csrc/cpu/sgl-kernels/gemm.h
+++ b/csrc/cpu/sgl-kernels/gemm.h
@@ -24,8 +24,6 @@ constexpr int block_size_n() {
   return 2 * TILE_N;
 }
 
-constexpr int MOE_TINY_GEMM_MAX_M = 4;
-
 constexpr bool brgemm_supported() {
 #if defined(CPU_CAPABILITY_AVX512)
   return true;
@@ -33,37 +31,6 @@ constexpr bool brgemm_supported() {
   return false;
 #endif
 }
-
-enum class PackedGemmBackend {
-  TinyGemm,
-  Brgemm,
-};
-
-template <typename scalar_t>
-constexpr PackedGemmBackend select_moe_packed_gemm_backend() {
-  if constexpr (std::is_same_v<scalar_t, at::BFloat16>) {
-    return brgemm_supported() ? PackedGemmBackend::Brgemm : PackedGemmBackend::TinyGemm;
-  } else {
-    return PackedGemmBackend::TinyGemm;
-  }
-}
-
-constexpr bool moe_uses_brgemm(PackedGemmBackend backend, int64_t M, int64_t N) {
-  return M > 0 && backend == PackedGemmBackend::Brgemm &&
-      (M > MOE_TINY_GEMM_MAX_M || N != block_size_n());
-}
-
-static_assert(
-    select_moe_packed_gemm_backend<at::BFloat16>() ==
-    (brgemm_supported() ? PackedGemmBackend::Brgemm : PackedGemmBackend::TinyGemm));
-static_assert(select_moe_packed_gemm_backend<at::Half>() == PackedGemmBackend::TinyGemm);
-static_assert(select_moe_packed_gemm_backend<at::Float8_e4m3fn>() == PackedGemmBackend::TinyGemm);
-static_assert(!moe_uses_brgemm(PackedGemmBackend::Brgemm, 0, block_size_n()));
-static_assert(!moe_uses_brgemm(PackedGemmBackend::Brgemm, MOE_TINY_GEMM_MAX_M, block_size_n()));
-static_assert(
-    moe_uses_brgemm(PackedGemmBackend::Brgemm, MOE_TINY_GEMM_MAX_M + 1, block_size_n()));
-static_assert(
-    moe_uses_brgemm(PackedGemmBackend::Brgemm, MOE_TINY_GEMM_MAX_M, block_size_n() - 1));
 
 // define threshold using brgemm (intel AMX)
 template <typename T>
@@ -90,6 +57,11 @@ inline bool can_use_brgemm<uint8_t>(int M) {
 template <>
 inline bool can_use_brgemm<at::Float8_e4m3fn>(int M) {
   return brgemm_supported() && M > 4;
+}
+
+template <typename T>
+inline bool can_use_brgemm(int M, int N) {
+  return brgemm_supported() && (can_use_brgemm<T>(M) || N != block_size_n());
 }
 
 // work around compiler internal error
@@ -344,7 +316,7 @@ void tinygemm_kernel(
     int64_t lda,
     int64_t ldb,
     int64_t ldc,
-    PackedGemmBackend backend,
+    bool brg,
     int64_t block_size_K,
     bool do_unpack = true);
 
@@ -381,7 +353,7 @@ void tinygemm_kernel(
     int64_t lda,
     int64_t ldb,
     int64_t ldc,
-    PackedGemmBackend backend,
+    bool brg,
     int64_t block_size_K,
     bool do_unpack = true);
 
@@ -420,6 +392,6 @@ void tinygemm_kernel(
     int64_t lda,
     int64_t ldb,
     int64_t ldc,
-    PackedGemmBackend backend,
+    bool brg,
     int64_t block_size_K,
     bool do_unpack = true);

--- a/csrc/cpu/sgl-kernels/gemm.h
+++ b/csrc/cpu/sgl-kernels/gemm.h
@@ -24,6 +24,8 @@ constexpr int block_size_n() {
   return 2 * TILE_N;
 }
 
+constexpr int MOE_TINY_GEMM_MAX_M = 4;
+
 constexpr bool brgemm_supported() {
 #if defined(CPU_CAPABILITY_AVX512)
   return true;

--- a/csrc/cpu/sgl-kernels/gemm.h
+++ b/csrc/cpu/sgl-kernels/gemm.h
@@ -48,6 +48,11 @@ constexpr PackedGemmBackend select_moe_packed_gemm_backend() {
   }
 }
 
+constexpr bool moe_uses_brgemm(PackedGemmBackend backend, int64_t M, int64_t N) {
+  return backend == PackedGemmBackend::Brgemm &&
+      (M > MOE_TINY_GEMM_MAX_M || N != block_size_n());
+}
+
 // define threshold using brgemm (intel AMX)
 template <typename T>
 inline bool can_use_brgemm(int M);

--- a/csrc/cpu/sgl-kernels/gemm.h
+++ b/csrc/cpu/sgl-kernels/gemm.h
@@ -49,9 +49,21 @@ constexpr PackedGemmBackend select_moe_packed_gemm_backend() {
 }
 
 constexpr bool moe_uses_brgemm(PackedGemmBackend backend, int64_t M, int64_t N) {
-  return backend == PackedGemmBackend::Brgemm &&
+  return M > 0 && backend == PackedGemmBackend::Brgemm &&
       (M > MOE_TINY_GEMM_MAX_M || N != block_size_n());
 }
+
+static_assert(
+    select_moe_packed_gemm_backend<at::BFloat16>() ==
+    (brgemm_supported() ? PackedGemmBackend::Brgemm : PackedGemmBackend::TinyGemm));
+static_assert(select_moe_packed_gemm_backend<at::Half>() == PackedGemmBackend::TinyGemm);
+static_assert(select_moe_packed_gemm_backend<at::Float8_e4m3fn>() == PackedGemmBackend::TinyGemm);
+static_assert(!moe_uses_brgemm(PackedGemmBackend::Brgemm, 0, block_size_n()));
+static_assert(!moe_uses_brgemm(PackedGemmBackend::Brgemm, MOE_TINY_GEMM_MAX_M, block_size_n()));
+static_assert(
+    moe_uses_brgemm(PackedGemmBackend::Brgemm, MOE_TINY_GEMM_MAX_M + 1, block_size_n()));
+static_assert(
+    moe_uses_brgemm(PackedGemmBackend::Brgemm, MOE_TINY_GEMM_MAX_M, block_size_n() - 1));
 
 // define threshold using brgemm (intel AMX)
 template <typename T>

--- a/csrc/cpu/sgl-kernels/gemm.h
+++ b/csrc/cpu/sgl-kernels/gemm.h
@@ -32,6 +32,20 @@ constexpr bool brgemm_supported() {
 #endif
 }
 
+enum class PackedGemmBackend {
+  TinyGemm,
+  Brgemm,
+};
+
+template <typename scalar_t>
+constexpr PackedGemmBackend select_moe_packed_gemm_backend() {
+  if constexpr (std::is_same_v<scalar_t, at::BFloat16>) {
+    return brgemm_supported() ? PackedGemmBackend::Brgemm : PackedGemmBackend::TinyGemm;
+  } else {
+    return PackedGemmBackend::TinyGemm;
+  }
+}
+
 // define threshold using brgemm (intel AMX)
 template <typename T>
 inline bool can_use_brgemm(int M);
@@ -311,7 +325,7 @@ void tinygemm_kernel(
     int64_t lda,
     int64_t ldb,
     int64_t ldc,
-    bool brg,
+    PackedGemmBackend backend,
     int64_t block_size_K,
     bool do_unpack = true);
 
@@ -348,7 +362,7 @@ void tinygemm_kernel(
     int64_t lda,
     int64_t ldb,
     int64_t ldc,
-    bool brg,
+    PackedGemmBackend backend,
     int64_t block_size_K,
     bool do_unpack = true);
 
@@ -387,6 +401,6 @@ void tinygemm_kernel(
     int64_t lda,
     int64_t ldb,
     int64_t ldc,
-    bool brg,
+    PackedGemmBackend backend,
     int64_t block_size_K,
     bool do_unpack = true);

--- a/csrc/cpu/sgl-kernels/gemm_fp8.cpp
+++ b/csrc/cpu/sgl-kernels/gemm_fp8.cpp
@@ -562,57 +562,12 @@ struct brgemm {
       int lda,
       int ldb,
       int ldc,
-      int /* block_size_K */,
       bool do_unpack = true) {
     TORCH_CHECK(false, "struct brgemm: primary template not implemented!");
   }
 };
 template <typename scalar_t>
 struct brgemm2 {};
-
-template <typename scalar_t, typename packed_t, typename param_t, bool has_bias>
-inline bool tinygemm_for_small_m(
-    const scalar_t* __restrict__ A,
-    const packed_t* __restrict__ B,
-    scalar_t* __restrict__ C,
-    const float* __restrict__ bias,
-    const param_t* __restrict__ scale,
-    int64_t M,
-    int64_t N,
-    int64_t K,
-    int64_t lda,
-    int64_t ldb,
-    int64_t ldc,
-    int64_t block_size_K) {
-  if constexpr (!std::is_same_v<scalar_t, at::BFloat16>) {
-    return false;
-  } else {
-    if (M < 1 || moe_uses_brgemm(PackedGemmBackend::Brgemm, M, N)) {
-      return false;
-    }
-
-    switch (M) {
-      case 1:
-        tinygemm_kernel_nn<scalar_t, packed_t, param_t, has_bias, 1, 32>::apply(
-            A, B, C, bias, scale, K, lda, ldb, ldc, block_size_K);
-        return true;
-      case 2:
-        tinygemm_kernel_nn<scalar_t, packed_t, param_t, has_bias, 2, 32>::apply(
-            A, B, C, bias, scale, K, lda, ldb, ldc, block_size_K);
-        return true;
-      case 3:
-        tinygemm_kernel_nn<scalar_t, packed_t, param_t, has_bias, 3, 32>::apply(
-            A, B, C, bias, scale, K, lda, ldb, ldc, block_size_K);
-        return true;
-      case 4:
-        tinygemm_kernel_nn<scalar_t, packed_t, param_t, has_bias, 4, 32>::apply(
-            A, B, C, bias, scale, K, lda, ldb, ldc, block_size_K);
-        return true;
-      default:
-        return false;
-    }
-  }
-}
 
 template <bool has_bias>
 struct brgemm<at::BFloat16, at::Float8_e4m3fn, float, has_bias> {
@@ -630,13 +585,7 @@ struct brgemm<at::BFloat16, at::Float8_e4m3fn, float, has_bias> {
       int lda,
       int ldb,
       int ldc,
-      int block_size_K,
       bool do_unpack = true) {
-    if (tinygemm_for_small_m<at::BFloat16, at::Float8_e4m3fn, float, has_bias>(
-            A, B, C, bias, scale, M, N, K, lda, ldb, ldc, block_size_K)) {
-      return;
-    }
-
     constexpr int BLOCK_N = block_size_n();
 
     // [K, BLOCK_N] -> [K / 2, BLOCK_N * 2]
@@ -716,13 +665,7 @@ struct brgemm<at::BFloat16, uint8_t, uint8_t, has_bias> {
       int lda,
       int ldb,
       int ldc,
-      int block_size_K,
       bool do_unpack = true) {
-    if (tinygemm_for_small_m<at::BFloat16, uint8_t, uint8_t, has_bias>(
-            A, B, C, bias, scale, M, N, K, lda, ldb, ldc, block_size_K)) {
-      return;
-    }
-
     constexpr int BLOCK_N = block_size_n();
 
     // [K, BLOCK_N] -> [K / 2, BLOCK_N * 2]
@@ -763,12 +706,12 @@ void tinygemm_kernel(
     int64_t lda,
     int64_t ldb,
     int64_t ldc,
-    PackedGemmBackend backend,
+    bool brg,
     int64_t block_size_K,
     bool do_unpack = true) {
-  if (backend == PackedGemmBackend::Brgemm) {
+  if (brg) {
     brgemm<scalar_t, packed_t, param_t, has_bias>::apply(
-        A, B, C, Btmp, Ctmp, bias, scale, M, N, K, lda, ldb, ldc, block_size_K, do_unpack);
+        A, B, C, Btmp, Ctmp, bias, scale, M, N, K, lda, ldb, ldc, do_unpack);
     return;
   }
 
@@ -967,7 +910,7 @@ void fp_scaled_mm_kernel_impl(
             /*   lda          */ mat1_strideM,
             /*   ldb          */ nb_size,
             /*   ldc          */ out_strideM,
-            /*   backend      */ use_brgemm ? PackedGemmBackend::Brgemm : PackedGemmBackend::TinyGemm,
+            /*   brg          */ use_brgemm,
             /*   block_size_K */ block_size_K,
             /*   do_unpack    */ do_unpack);
       });
@@ -997,16 +940,16 @@ void tinygemm_kernel(
     int64_t lda,
     int64_t ldb,
     int64_t ldc,
-    PackedGemmBackend backend,
+    bool brg,
     int64_t block_size_K,
     bool do_unpack) {
   if (Bbias != nullptr) {
     tinygemm_kernel<scalar_t, at::Float8_e4m3fn, float, true>(
-        A, B, C, Btmp, Ctmp, scale, Bbias, M, N, K, lda, ldb, ldc, backend, block_size_K, do_unpack);
+        A, B, C, Btmp, Ctmp, scale, Bbias, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
     return;
   }
   tinygemm_kernel<scalar_t, at::Float8_e4m3fn, float, false>(
-      A, B, C, Btmp, Ctmp, scale, nullptr, M, N, K, lda, ldb, ldc, backend, block_size_K, do_unpack);
+      A, B, C, Btmp, Ctmp, scale, nullptr, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
 }
 
 template <typename scalar_t>
@@ -1041,16 +984,16 @@ void tinygemm_kernel(
     int64_t lda,
     int64_t ldb,
     int64_t ldc,
-    PackedGemmBackend backend,
+    bool brg,
     int64_t block_size_K,
     bool do_unpack) {
   if (Bbias != nullptr) {
     tinygemm_kernel<scalar_t, uint8_t, uint8_t, true>(
-        A, B, C, Btmp, Ctmp, scale, Bbias, M, N, K, lda, ldb, ldc, backend, block_size_K, do_unpack);
+        A, B, C, Btmp, Ctmp, scale, Bbias, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
     return;
   }
   tinygemm_kernel<scalar_t, uint8_t, uint8_t, false>(
-      A, B, C, Btmp, Ctmp, scale, nullptr, M, N, K, lda, ldb, ldc, backend, block_size_K, do_unpack);
+      A, B, C, Btmp, Ctmp, scale, nullptr, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
 }
 
 // tinygemm interface
@@ -1068,16 +1011,16 @@ void tinygemm_kernel(
     int64_t lda,
     int64_t ldb,
     int64_t ldc,
-    PackedGemmBackend backend,
+    bool brg,
     int64_t block_size_K,
     bool do_unpack) {
   if (Bbias != nullptr) {
     tinygemm_kernel<scalar_t, at::Float8_e4m3fn, float, true>(
-        A, B, C, Btmp, scale, Bbias, M, N, K, lda, ldb, ldc, backend, block_size_K, do_unpack);
+        A, B, C, Btmp, scale, Bbias, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
     return;
   }
   tinygemm_kernel<scalar_t, at::Float8_e4m3fn, float, false>(
-      A, B, C, Btmp, scale, nullptr, M, N, K, lda, ldb, ldc, backend, block_size_K, do_unpack);
+      A, B, C, Btmp, scale, nullptr, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
 }
 
 template <typename scalar_t>
@@ -1094,16 +1037,16 @@ void tinygemm_kernel(
     int64_t lda,
     int64_t ldb,
     int64_t ldc,
-    PackedGemmBackend backend,
+    bool brg,
     int64_t block_size_K,
     bool do_unpack) {
   if (Bbias != nullptr) {
     tinygemm_kernel<scalar_t, uint8_t, uint8_t, true>(
-        A, B, C, Btmp, scale, Bbias, M, N, K, lda, ldb, ldc, backend, block_size_K, do_unpack);
+        A, B, C, Btmp, scale, Bbias, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
     return;
   }
   tinygemm_kernel<scalar_t, uint8_t, uint8_t, false>(
-      A, B, C, Btmp, scale, nullptr, M, N, K, lda, ldb, ldc, backend, block_size_K, do_unpack);
+      A, B, C, Btmp, scale, nullptr, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
 }
 
 #define INSTANTIATE_TINYGEMM_TEMPLATE(TYPE_A, TYPE_B, TYPE_S) \
@@ -1121,7 +1064,7 @@ void tinygemm_kernel(
       int64_t lda,                                            \
       int64_t ldb,                                            \
       int64_t ldc,                                            \
-      PackedGemmBackend backend,                              \
+      bool brg,                                               \
       int64_t block_size_K,                                   \
       bool do_unpack)
 

--- a/csrc/cpu/sgl-kernels/gemm_fp8.cpp
+++ b/csrc/cpu/sgl-kernels/gemm_fp8.cpp
@@ -663,7 +663,7 @@ inline bool brgemm_small_m(
   if constexpr (!std::is_same_v<scalar_t, at::BFloat16>) {
     return false;
   } else {
-    if (N != block_size_n() || M < 1 || M > 8) {
+    if (N != block_size_n() || M < 1 || M > MOE_TINY_GEMM_MAX_M) {
       return false;
     }
 

--- a/csrc/cpu/sgl-kernels/gemm_fp8.cpp
+++ b/csrc/cpu/sgl-kernels/gemm_fp8.cpp
@@ -570,34 +570,8 @@ struct brgemm {
 template <typename scalar_t>
 struct brgemm2 {};
 
-template <typename scalar_t, typename packed_t, typename param_t, bool has_bias, int Rows>
-inline void tinygemm_rows(
-    const scalar_t* __restrict__ A,
-    const packed_t* __restrict__ B,
-    scalar_t* __restrict__ C,
-    const float* __restrict__ bias,
-    const param_t* __restrict__ scale,
-    int64_t row_offset,
-    int64_t K,
-    int64_t lda,
-    int64_t ldb,
-    int64_t ldc,
-    int64_t block_size_K) {
-  tinygemm_kernel_nn<scalar_t, packed_t, param_t, has_bias, Rows, 32>::apply(
-      A + row_offset * lda,
-      B,
-      C + row_offset * ldc,
-      bias,
-      scale,
-      K,
-      lda,
-      ldb,
-      ldc,
-      block_size_K);
-}
-
 template <typename scalar_t, typename packed_t, typename param_t, bool has_bias>
-inline bool brgemm_small_m(
+inline bool tinygemm_for_small_m(
     const scalar_t* __restrict__ A,
     const packed_t* __restrict__ B,
     scalar_t* __restrict__ C,
@@ -619,20 +593,20 @@ inline bool brgemm_small_m(
 
     switch (M) {
       case 1:
-        tinygemm_rows<scalar_t, packed_t, param_t, has_bias, 1>(
-            A, B, C, bias, scale, 0, K, lda, ldb, ldc, block_size_K);
+        tinygemm_kernel_nn<scalar_t, packed_t, param_t, has_bias, 1, 32>::apply(
+            A, B, C, bias, scale, K, lda, ldb, ldc, block_size_K);
         return true;
       case 2:
-        tinygemm_rows<scalar_t, packed_t, param_t, has_bias, 2>(
-            A, B, C, bias, scale, 0, K, lda, ldb, ldc, block_size_K);
+        tinygemm_kernel_nn<scalar_t, packed_t, param_t, has_bias, 2, 32>::apply(
+            A, B, C, bias, scale, K, lda, ldb, ldc, block_size_K);
         return true;
       case 3:
-        tinygemm_rows<scalar_t, packed_t, param_t, has_bias, 3>(
-            A, B, C, bias, scale, 0, K, lda, ldb, ldc, block_size_K);
+        tinygemm_kernel_nn<scalar_t, packed_t, param_t, has_bias, 3, 32>::apply(
+            A, B, C, bias, scale, K, lda, ldb, ldc, block_size_K);
         return true;
       case 4:
-        tinygemm_rows<scalar_t, packed_t, param_t, has_bias, 4>(
-            A, B, C, bias, scale, 0, K, lda, ldb, ldc, block_size_K);
+        tinygemm_kernel_nn<scalar_t, packed_t, param_t, has_bias, 4, 32>::apply(
+            A, B, C, bias, scale, K, lda, ldb, ldc, block_size_K);
         return true;
       default:
         return false;
@@ -658,7 +632,7 @@ struct brgemm<at::BFloat16, at::Float8_e4m3fn, float, has_bias> {
       int ldc,
       int block_size_K,
       bool do_unpack = true) {
-    if (brgemm_small_m<at::BFloat16, at::Float8_e4m3fn, float, has_bias>(
+    if (tinygemm_for_small_m<at::BFloat16, at::Float8_e4m3fn, float, has_bias>(
             A, B, C, bias, scale, M, N, K, lda, ldb, ldc, block_size_K)) {
       return;
     }
@@ -744,7 +718,7 @@ struct brgemm<at::BFloat16, uint8_t, uint8_t, has_bias> {
       int ldc,
       int block_size_K,
       bool do_unpack = true) {
-    if (brgemm_small_m<at::BFloat16, uint8_t, uint8_t, has_bias>(
+    if (tinygemm_for_small_m<at::BFloat16, uint8_t, uint8_t, has_bias>(
             A, B, C, bias, scale, M, N, K, lda, ldb, ldc, block_size_K)) {
       return;
     }

--- a/csrc/cpu/sgl-kernels/gemm_fp8.cpp
+++ b/csrc/cpu/sgl-kernels/gemm_fp8.cpp
@@ -570,56 +570,6 @@ struct brgemm {
 template <typename scalar_t>
 struct brgemm2 {};
 
-template <bool has_bias, int Rows>
-inline void store_brgemm_rows(
-    at::BFloat16* __restrict__ C,
-    const float* __restrict__ Ctmp,
-    const float* __restrict__ bias,
-    int N,
-    int ldc) {
-  for (int m = 0; m < Rows; ++m) {
-    if constexpr (has_bias) {
-      copy_add_stub(C + m * ldc, Ctmp + m * block_size_n(), bias, N);
-    } else {
-      copy_stub(C + m * ldc, Ctmp + m * block_size_n(), N);
-    }
-  }
-}
-
-template <bool has_bias>
-inline void store_brgemm_output(
-    at::BFloat16* __restrict__ C,
-    const float* __restrict__ Ctmp,
-    const float* __restrict__ bias,
-    int M,
-    int N,
-    int ldc) {
-  switch (M) {
-    case 0:
-      return;
-    case 1:
-      store_brgemm_rows<has_bias, 1>(C, Ctmp, bias, N, ldc);
-      return;
-    case 2:
-      store_brgemm_rows<has_bias, 2>(C, Ctmp, bias, N, ldc);
-      return;
-    case 3:
-      store_brgemm_rows<has_bias, 3>(C, Ctmp, bias, N, ldc);
-      return;
-    case 4:
-      store_brgemm_rows<has_bias, 4>(C, Ctmp, bias, N, ldc);
-      return;
-    default:
-      for (int m = 0; m < M; ++m) {
-        if constexpr (has_bias) {
-          copy_add_stub(C + m * ldc, Ctmp + m * block_size_n(), bias, N);
-        } else {
-          copy_stub(C + m * ldc, Ctmp + m * block_size_n(), N);
-        }
-      }
-  }
-}
-
 template <typename scalar_t, typename packed_t, typename param_t, bool has_bias, int Rows>
 inline void tinygemm_rows(
     const scalar_t* __restrict__ A,
@@ -663,7 +613,7 @@ inline bool brgemm_small_m(
   if constexpr (!std::is_same_v<scalar_t, at::BFloat16>) {
     return false;
   } else {
-    if (N != block_size_n() || M < 1 || M > MOE_TINY_GEMM_MAX_M) {
+    if (M < 1 || moe_uses_brgemm(PackedGemmBackend::Brgemm, M, N)) {
       return false;
     }
 
@@ -683,30 +633,6 @@ inline bool brgemm_small_m(
       case 4:
         tinygemm_rows<scalar_t, packed_t, param_t, has_bias, 4>(
             A, B, C, bias, scale, 0, K, lda, ldb, ldc, block_size_K);
-        return true;
-      case 5:
-        tinygemm_rows<scalar_t, packed_t, param_t, has_bias, 4>(
-            A, B, C, bias, scale, 0, K, lda, ldb, ldc, block_size_K);
-        tinygemm_rows<scalar_t, packed_t, param_t, has_bias, 1>(
-            A, B, C, bias, scale, 4, K, lda, ldb, ldc, block_size_K);
-        return true;
-      case 6:
-        tinygemm_rows<scalar_t, packed_t, param_t, has_bias, 4>(
-            A, B, C, bias, scale, 0, K, lda, ldb, ldc, block_size_K);
-        tinygemm_rows<scalar_t, packed_t, param_t, has_bias, 2>(
-            A, B, C, bias, scale, 4, K, lda, ldb, ldc, block_size_K);
-        return true;
-      case 7:
-        tinygemm_rows<scalar_t, packed_t, param_t, has_bias, 4>(
-            A, B, C, bias, scale, 0, K, lda, ldb, ldc, block_size_K);
-        tinygemm_rows<scalar_t, packed_t, param_t, has_bias, 3>(
-            A, B, C, bias, scale, 4, K, lda, ldb, ldc, block_size_K);
-        return true;
-      case 8:
-        tinygemm_rows<scalar_t, packed_t, param_t, has_bias, 4>(
-            A, B, C, bias, scale, 0, K, lda, ldb, ldc, block_size_K);
-        tinygemm_rows<scalar_t, packed_t, param_t, has_bias, 4>(
-            A, B, C, bias, scale, 4, K, lda, ldb, ldc, block_size_K);
         return true;
       default:
         return false;
@@ -753,7 +679,14 @@ struct brgemm<at::BFloat16, at::Float8_e4m3fn, float, has_bias> {
 
     at::native::cpublas::brgemm(M, N, K, lda, ldb_tmp, BLOCK_N, /* add_C */ false, A, Btmp, Ctmp);
 
-    store_brgemm_output<has_bias>(C, Ctmp, bias, M, N, ldc);
+    // copy from Ctmp to C
+    for (int m = 0; m < M; ++m) {
+      if constexpr (has_bias) {
+        copy_add_stub(C + m * ldc, Ctmp + m * BLOCK_N, bias, N);
+      } else {
+        copy_stub(C + m * ldc, Ctmp + m * BLOCK_N, N);
+      }
+    }
   }
 };
 
@@ -830,7 +763,14 @@ struct brgemm<at::BFloat16, uint8_t, uint8_t, has_bias> {
 
     at::native::cpublas::brgemm(M, N, K, lda, ldb_tmp, BLOCK_N, /* add_C */ false, A, Btmp, Ctmp);
 
-    store_brgemm_output<has_bias>(C, Ctmp, bias, M, N, ldc);
+    // copy from Ctmp to C
+    for (int m = 0; m < M; ++m) {
+      if constexpr (has_bias) {
+        copy_add_stub(C + m * ldc, Ctmp + m * BLOCK_N, bias, N);
+      } else {
+        copy_stub(C + m * ldc, Ctmp + m * BLOCK_N, N);
+      }
+    }
   }
 };
 

--- a/csrc/cpu/sgl-kernels/gemm_fp8.cpp
+++ b/csrc/cpu/sgl-kernels/gemm_fp8.cpp
@@ -562,12 +562,157 @@ struct brgemm {
       int lda,
       int ldb,
       int ldc,
+      int /* block_size_K */,
       bool do_unpack = true) {
     TORCH_CHECK(false, "struct brgemm: primary template not implemented!");
   }
 };
 template <typename scalar_t>
 struct brgemm2 {};
+
+template <bool has_bias, int Rows>
+inline void store_brgemm_rows(
+    at::BFloat16* __restrict__ C,
+    const float* __restrict__ Ctmp,
+    const float* __restrict__ bias,
+    int N,
+    int ldc) {
+  for (int m = 0; m < Rows; ++m) {
+    if constexpr (has_bias) {
+      copy_add_stub(C + m * ldc, Ctmp + m * block_size_n(), bias, N);
+    } else {
+      copy_stub(C + m * ldc, Ctmp + m * block_size_n(), N);
+    }
+  }
+}
+
+template <bool has_bias>
+inline void store_brgemm_output(
+    at::BFloat16* __restrict__ C,
+    const float* __restrict__ Ctmp,
+    const float* __restrict__ bias,
+    int M,
+    int N,
+    int ldc) {
+  switch (M) {
+    case 0:
+      return;
+    case 1:
+      store_brgemm_rows<has_bias, 1>(C, Ctmp, bias, N, ldc);
+      return;
+    case 2:
+      store_brgemm_rows<has_bias, 2>(C, Ctmp, bias, N, ldc);
+      return;
+    case 3:
+      store_brgemm_rows<has_bias, 3>(C, Ctmp, bias, N, ldc);
+      return;
+    case 4:
+      store_brgemm_rows<has_bias, 4>(C, Ctmp, bias, N, ldc);
+      return;
+    default:
+      for (int m = 0; m < M; ++m) {
+        if constexpr (has_bias) {
+          copy_add_stub(C + m * ldc, Ctmp + m * block_size_n(), bias, N);
+        } else {
+          copy_stub(C + m * ldc, Ctmp + m * block_size_n(), N);
+        }
+      }
+  }
+}
+
+template <typename scalar_t, typename packed_t, typename param_t, bool has_bias, int Rows>
+inline void tinygemm_rows(
+    const scalar_t* __restrict__ A,
+    const packed_t* __restrict__ B,
+    scalar_t* __restrict__ C,
+    const float* __restrict__ bias,
+    const param_t* __restrict__ scale,
+    int64_t row_offset,
+    int64_t K,
+    int64_t lda,
+    int64_t ldb,
+    int64_t ldc,
+    int64_t block_size_K) {
+  tinygemm_kernel_nn<scalar_t, packed_t, param_t, has_bias, Rows, 32>::apply(
+      A + row_offset * lda,
+      B,
+      C + row_offset * ldc,
+      bias,
+      scale,
+      K,
+      lda,
+      ldb,
+      ldc,
+      block_size_K);
+}
+
+template <typename scalar_t, typename packed_t, typename param_t, bool has_bias>
+inline bool brgemm_small_m(
+    const scalar_t* __restrict__ A,
+    const packed_t* __restrict__ B,
+    scalar_t* __restrict__ C,
+    const float* __restrict__ bias,
+    const param_t* __restrict__ scale,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    int64_t lda,
+    int64_t ldb,
+    int64_t ldc,
+    int64_t block_size_K) {
+  if constexpr (!std::is_same_v<scalar_t, at::BFloat16>) {
+    return false;
+  } else {
+    if (N != block_size_n() || M < 1 || M > 8) {
+      return false;
+    }
+
+    switch (M) {
+      case 1:
+        tinygemm_rows<scalar_t, packed_t, param_t, has_bias, 1>(
+            A, B, C, bias, scale, 0, K, lda, ldb, ldc, block_size_K);
+        return true;
+      case 2:
+        tinygemm_rows<scalar_t, packed_t, param_t, has_bias, 2>(
+            A, B, C, bias, scale, 0, K, lda, ldb, ldc, block_size_K);
+        return true;
+      case 3:
+        tinygemm_rows<scalar_t, packed_t, param_t, has_bias, 3>(
+            A, B, C, bias, scale, 0, K, lda, ldb, ldc, block_size_K);
+        return true;
+      case 4:
+        tinygemm_rows<scalar_t, packed_t, param_t, has_bias, 4>(
+            A, B, C, bias, scale, 0, K, lda, ldb, ldc, block_size_K);
+        return true;
+      case 5:
+        tinygemm_rows<scalar_t, packed_t, param_t, has_bias, 4>(
+            A, B, C, bias, scale, 0, K, lda, ldb, ldc, block_size_K);
+        tinygemm_rows<scalar_t, packed_t, param_t, has_bias, 1>(
+            A, B, C, bias, scale, 4, K, lda, ldb, ldc, block_size_K);
+        return true;
+      case 6:
+        tinygemm_rows<scalar_t, packed_t, param_t, has_bias, 4>(
+            A, B, C, bias, scale, 0, K, lda, ldb, ldc, block_size_K);
+        tinygemm_rows<scalar_t, packed_t, param_t, has_bias, 2>(
+            A, B, C, bias, scale, 4, K, lda, ldb, ldc, block_size_K);
+        return true;
+      case 7:
+        tinygemm_rows<scalar_t, packed_t, param_t, has_bias, 4>(
+            A, B, C, bias, scale, 0, K, lda, ldb, ldc, block_size_K);
+        tinygemm_rows<scalar_t, packed_t, param_t, has_bias, 3>(
+            A, B, C, bias, scale, 4, K, lda, ldb, ldc, block_size_K);
+        return true;
+      case 8:
+        tinygemm_rows<scalar_t, packed_t, param_t, has_bias, 4>(
+            A, B, C, bias, scale, 0, K, lda, ldb, ldc, block_size_K);
+        tinygemm_rows<scalar_t, packed_t, param_t, has_bias, 4>(
+            A, B, C, bias, scale, 4, K, lda, ldb, ldc, block_size_K);
+        return true;
+      default:
+        return false;
+    }
+  }
+}
 
 template <bool has_bias>
 struct brgemm<at::BFloat16, at::Float8_e4m3fn, float, has_bias> {
@@ -585,7 +730,13 @@ struct brgemm<at::BFloat16, at::Float8_e4m3fn, float, has_bias> {
       int lda,
       int ldb,
       int ldc,
+      int block_size_K,
       bool do_unpack = true) {
+    if (brgemm_small_m<at::BFloat16, at::Float8_e4m3fn, float, has_bias>(
+            A, B, C, bias, scale, M, N, K, lda, ldb, ldc, block_size_K)) {
+      return;
+    }
+
     constexpr int BLOCK_N = block_size_n();
 
     // [K, BLOCK_N] -> [K / 2, BLOCK_N * 2]
@@ -602,14 +753,7 @@ struct brgemm<at::BFloat16, at::Float8_e4m3fn, float, has_bias> {
 
     at::native::cpublas::brgemm(M, N, K, lda, ldb_tmp, BLOCK_N, /* add_C */ false, A, Btmp, Ctmp);
 
-    // copy from Ctmp to C
-    for (int m = 0; m < M; ++m) {
-      if constexpr (has_bias) {
-        copy_add_stub(C + m * ldc, Ctmp + m * BLOCK_N, bias, N);
-      } else {
-        copy_stub(C + m * ldc, Ctmp + m * BLOCK_N, N);
-      }
-    }
+    store_brgemm_output<has_bias>(C, Ctmp, bias, M, N, ldc);
   }
 };
 
@@ -665,7 +809,13 @@ struct brgemm<at::BFloat16, uint8_t, uint8_t, has_bias> {
       int lda,
       int ldb,
       int ldc,
+      int block_size_K,
       bool do_unpack = true) {
+    if (brgemm_small_m<at::BFloat16, uint8_t, uint8_t, has_bias>(
+            A, B, C, bias, scale, M, N, K, lda, ldb, ldc, block_size_K)) {
+      return;
+    }
+
     constexpr int BLOCK_N = block_size_n();
 
     // [K, BLOCK_N] -> [K / 2, BLOCK_N * 2]
@@ -680,14 +830,7 @@ struct brgemm<at::BFloat16, uint8_t, uint8_t, has_bias> {
 
     at::native::cpublas::brgemm(M, N, K, lda, ldb_tmp, BLOCK_N, /* add_C */ false, A, Btmp, Ctmp);
 
-    // copy from Ctmp to C
-    for (int m = 0; m < M; ++m) {
-      if constexpr (has_bias) {
-        copy_add_stub(C + m * ldc, Ctmp + m * BLOCK_N, bias, N);
-      } else {
-        copy_stub(C + m * ldc, Ctmp + m * BLOCK_N, N);
-      }
-    }
+    store_brgemm_output<has_bias>(C, Ctmp, bias, M, N, ldc);
   }
 };
 
@@ -706,12 +849,12 @@ void tinygemm_kernel(
     int64_t lda,
     int64_t ldb,
     int64_t ldc,
-    bool brg,
+    PackedGemmBackend backend,
     int64_t block_size_K,
     bool do_unpack = true) {
-  if (brg) {
+  if (backend == PackedGemmBackend::Brgemm) {
     brgemm<scalar_t, packed_t, param_t, has_bias>::apply(
-        A, B, C, Btmp, Ctmp, bias, scale, M, N, K, lda, ldb, ldc, do_unpack);
+        A, B, C, Btmp, Ctmp, bias, scale, M, N, K, lda, ldb, ldc, block_size_K, do_unpack);
     return;
   }
 
@@ -910,7 +1053,7 @@ void fp_scaled_mm_kernel_impl(
             /*   lda          */ mat1_strideM,
             /*   ldb          */ nb_size,
             /*   ldc          */ out_strideM,
-            /*   brg          */ use_brgemm,
+            /*   backend      */ use_brgemm ? PackedGemmBackend::Brgemm : PackedGemmBackend::TinyGemm,
             /*   block_size_K */ block_size_K,
             /*   do_unpack    */ do_unpack);
       });
@@ -940,16 +1083,16 @@ void tinygemm_kernel(
     int64_t lda,
     int64_t ldb,
     int64_t ldc,
-    bool brg,
+    PackedGemmBackend backend,
     int64_t block_size_K,
     bool do_unpack) {
   if (Bbias != nullptr) {
     tinygemm_kernel<scalar_t, at::Float8_e4m3fn, float, true>(
-        A, B, C, Btmp, Ctmp, scale, Bbias, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
+        A, B, C, Btmp, Ctmp, scale, Bbias, M, N, K, lda, ldb, ldc, backend, block_size_K, do_unpack);
     return;
   }
   tinygemm_kernel<scalar_t, at::Float8_e4m3fn, float, false>(
-      A, B, C, Btmp, Ctmp, scale, nullptr, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
+      A, B, C, Btmp, Ctmp, scale, nullptr, M, N, K, lda, ldb, ldc, backend, block_size_K, do_unpack);
 }
 
 template <typename scalar_t>
@@ -984,16 +1127,16 @@ void tinygemm_kernel(
     int64_t lda,
     int64_t ldb,
     int64_t ldc,
-    bool brg,
+    PackedGemmBackend backend,
     int64_t block_size_K,
     bool do_unpack) {
   if (Bbias != nullptr) {
     tinygemm_kernel<scalar_t, uint8_t, uint8_t, true>(
-        A, B, C, Btmp, Ctmp, scale, Bbias, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
+        A, B, C, Btmp, Ctmp, scale, Bbias, M, N, K, lda, ldb, ldc, backend, block_size_K, do_unpack);
     return;
   }
   tinygemm_kernel<scalar_t, uint8_t, uint8_t, false>(
-      A, B, C, Btmp, Ctmp, scale, nullptr, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
+      A, B, C, Btmp, Ctmp, scale, nullptr, M, N, K, lda, ldb, ldc, backend, block_size_K, do_unpack);
 }
 
 // tinygemm interface
@@ -1011,16 +1154,16 @@ void tinygemm_kernel(
     int64_t lda,
     int64_t ldb,
     int64_t ldc,
-    bool brg,
+    PackedGemmBackend backend,
     int64_t block_size_K,
     bool do_unpack) {
   if (Bbias != nullptr) {
     tinygemm_kernel<scalar_t, at::Float8_e4m3fn, float, true>(
-        A, B, C, Btmp, scale, Bbias, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
+        A, B, C, Btmp, scale, Bbias, M, N, K, lda, ldb, ldc, backend, block_size_K, do_unpack);
     return;
   }
   tinygemm_kernel<scalar_t, at::Float8_e4m3fn, float, false>(
-      A, B, C, Btmp, scale, nullptr, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
+      A, B, C, Btmp, scale, nullptr, M, N, K, lda, ldb, ldc, backend, block_size_K, do_unpack);
 }
 
 template <typename scalar_t>
@@ -1037,16 +1180,16 @@ void tinygemm_kernel(
     int64_t lda,
     int64_t ldb,
     int64_t ldc,
-    bool brg,
+    PackedGemmBackend backend,
     int64_t block_size_K,
     bool do_unpack) {
   if (Bbias != nullptr) {
     tinygemm_kernel<scalar_t, uint8_t, uint8_t, true>(
-        A, B, C, Btmp, scale, Bbias, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
+        A, B, C, Btmp, scale, Bbias, M, N, K, lda, ldb, ldc, backend, block_size_K, do_unpack);
     return;
   }
   tinygemm_kernel<scalar_t, uint8_t, uint8_t, false>(
-      A, B, C, Btmp, scale, nullptr, M, N, K, lda, ldb, ldc, brg, block_size_K, do_unpack);
+      A, B, C, Btmp, scale, nullptr, M, N, K, lda, ldb, ldc, backend, block_size_K, do_unpack);
 }
 
 #define INSTANTIATE_TINYGEMM_TEMPLATE(TYPE_A, TYPE_B, TYPE_S) \
@@ -1064,7 +1207,7 @@ void tinygemm_kernel(
       int64_t lda,                                            \
       int64_t ldb,                                            \
       int64_t ldc,                                            \
-      bool brg,                                               \
+      PackedGemmBackend backend,                              \
       int64_t block_size_K,                                   \
       bool do_unpack)
 

--- a/csrc/cpu/sgl-kernels/moe_fp8.cpp
+++ b/csrc/cpu/sgl-kernels/moe_fp8.cpp
@@ -60,8 +60,6 @@ void fused_experts_fp_kernel_impl(
   const int64_t stride_e = 2 * N * packed_K;
   const int64_t stride_n = packed_K;
 
-  const PackedGemmBackend backend = select_moe_packed_gemm_backend<scalar_t>();
-
   int64_t B_tmp_size_per_thread = MAX_CACHE_BLOCK_SIZE * BLOCK_N * std::max(K, N);
 
   // here we only parallel on half of 2N to fuse silu_and_mul with gemm
@@ -89,7 +87,8 @@ void fused_experts_fp_kernel_impl(
       if (m_size == 0) {
         return;
       }
-      used_brgemm |= moe_uses_brgemm(backend, m_size, n_size);
+      const bool brg = can_use_brgemm<packed_t>(m_size, n_size);
+      used_brgemm |= brg;
 
       if (nb_offset == 0) {
         // 1.a load A
@@ -115,7 +114,7 @@ void fused_experts_fp_kernel_impl(
           /*   lda          */ K,
           /*   ldb          */ n_size,
           /*   ldc          */ 2 * N,
-          /*   backend      */ backend,
+          /*   brg          */ brg,
           /*   block_size_K */ block_size_K,
           /*   do_unpack    */ do_unpack);
     });
@@ -164,7 +163,8 @@ void fused_experts_fp_kernel_impl(
         return;
       }
       int64_t n_size = std::min(OC - nb * BLOCK_N, BLOCK_N);
-      used_brgemm |= moe_uses_brgemm(backend, m_size, n_size);
+      const bool brg = can_use_brgemm<packed_t>(m_size, n_size);
+      used_brgemm |= brg;
 
       // A ptr from ic1 of [M * topk, N] in sorted order
       // so as to avoid copy A to tmp buffer again
@@ -196,7 +196,7 @@ void fused_experts_fp_kernel_impl(
           /*   lda          */ IC,
           /*   ldb          */ n_size,
           /*   ldc          */ BLOCK_N,
-          /*   backend      */ backend,
+          /*   brg          */ brg,
           /*   block_size_K */ block_size_K,
           /*   do_unpack    */ do_unpack);
 
@@ -289,8 +289,6 @@ void shared_expert_fp8_kernel_impl(
   int64_t blocks_n_per_group = block_size_N / BLOCK_N;
 
   const bool use_brgemm = can_use_brgemm<at::Float8_e4m3fn>(M);
-  const PackedGemmBackend backend =
-      use_brgemm ? PackedGemmBackend::Brgemm : PackedGemmBackend::TinyGemm;
   const bool apply_scaling_factor = fused_experts_out != nullptr;
 
   int64_t B_tmp_size_per_thread = MAX_CACHE_BLOCK_SIZE * BLOCK_N * std::max(K, N);
@@ -319,7 +317,7 @@ void shared_expert_fp8_kernel_impl(
           /*   lda          */ K,
           /*   ldb          */ n_size,
           /*   ldc          */ 2 * N,
-          /*   backend      */ backend,
+          /*   brg          */ use_brgemm,
           /*   block_size_K */ block_size_K,
           /*   do_unpack    */ do_unpack);
     });
@@ -371,7 +369,7 @@ void shared_expert_fp8_kernel_impl(
           /*   lda          */ IC,
           /*   ldb          */ n_size,
           /*   ldc          */ BLOCK_N,
-          /*   backend      */ backend,
+          /*   brg          */ use_brgemm,
           /*   block_size_K */ block_size_K,
           /*   do_unpack    */ do_unpack);
 

--- a/csrc/cpu/sgl-kernels/moe_fp8.cpp
+++ b/csrc/cpu/sgl-kernels/moe_fp8.cpp
@@ -67,7 +67,7 @@ void fused_experts_fp_kernel_impl(
     // get local pointers
     int tid = get_thread_num();
     scalar_t* __restrict__ A = A_tmp + tid * BLOCK_M * K;
-    bool used_brgemm = false;
+    bool use_brgemm = false;
 
     loop_2d<packed_t>(mb0, mb1, nb0, nb1, BLOCK_N * K, [&](int64_t mb, int64_t nb, int64_t nb_offset) {
       int64_t n_size = std::min(2 * N - nb * BLOCK_N, BLOCK_N);
@@ -88,7 +88,7 @@ void fused_experts_fp_kernel_impl(
         return;
       }
       const bool brg = can_use_brgemm<packed_t>(m_size, n_size);
-      used_brgemm |= brg;
+      use_brgemm |= brg;
 
       if (nb_offset == 0) {
         // 1.a load A
@@ -119,7 +119,7 @@ void fused_experts_fp_kernel_impl(
           /*   do_unpack    */ do_unpack);
     });
 
-    if (used_brgemm) {
+    if (use_brgemm) {
       at::native::cpublas::brgemm_release();
     }
   });
@@ -155,7 +155,7 @@ void fused_experts_fp_kernel_impl(
   parallel_2d(MB2, NB2, [&](int64_t mb0, int64_t mb1, int64_t nb0, int64_t nb1) {
     int tid = get_thread_num();
     alignas(64) scalar_t C[BLOCK_M * BLOCK_K];
-    bool used_brgemm = false;
+    bool use_brgemm = false;
 
     loop_2d<packed_t>(mb0, mb1, nb0, nb1, BLOCK_N * IC, [&](int64_t mb, int64_t nb, int64_t nb_offset) {
       int64_t m_size = offsets[mb + 1] - offsets[mb];
@@ -164,7 +164,7 @@ void fused_experts_fp_kernel_impl(
       }
       int64_t n_size = std::min(OC - nb * BLOCK_N, BLOCK_N);
       const bool brg = can_use_brgemm<packed_t>(m_size, n_size);
-      used_brgemm |= brg;
+      use_brgemm |= brg;
 
       // A ptr from ic1 of [M * topk, N] in sorted order
       // so as to avoid copy A to tmp buffer again
@@ -209,7 +209,7 @@ void fused_experts_fp_kernel_impl(
       }
     });
 
-    if (used_brgemm) {
+    if (use_brgemm) {
       at::native::cpublas::brgemm_release();
     }
   });

--- a/csrc/cpu/sgl-kernels/moe_fp8.cpp
+++ b/csrc/cpu/sgl-kernels/moe_fp8.cpp
@@ -90,7 +90,7 @@ void fused_experts_fp_kernel_impl(
         return;
       }
       used_brgemm |= backend == PackedGemmBackend::Brgemm &&
-          (m_size > 8 || n_size != BLOCK_N);
+          (m_size > MOE_TINY_GEMM_MAX_M || n_size != BLOCK_N);
 
       if (nb_offset == 0) {
         // 1.a load A
@@ -166,7 +166,7 @@ void fused_experts_fp_kernel_impl(
       }
       int64_t n_size = std::min(OC - nb * BLOCK_N, BLOCK_N);
       used_brgemm |= backend == PackedGemmBackend::Brgemm &&
-          (m_size > 8 || n_size != BLOCK_N);
+          (m_size > MOE_TINY_GEMM_MAX_M || n_size != BLOCK_N);
 
       // A ptr from ic1 of [M * topk, N] in sorted order
       // so as to avoid copy A to tmp buffer again

--- a/csrc/cpu/sgl-kernels/moe_fp8.cpp
+++ b/csrc/cpu/sgl-kernels/moe_fp8.cpp
@@ -60,8 +60,7 @@ void fused_experts_fp_kernel_impl(
   const int64_t stride_e = 2 * N * packed_K;
   const int64_t stride_n = packed_K;
 
-  int64_t avg_M = std::max(int64_t(1), M * topk / E);
-  const bool use_brgemm = can_use_brgemm<packed_t>(avg_M);
+  const PackedGemmBackend backend = select_moe_packed_gemm_backend<scalar_t>();
 
   int64_t B_tmp_size_per_thread = MAX_CACHE_BLOCK_SIZE * BLOCK_N * std::max(K, N);
 
@@ -70,6 +69,7 @@ void fused_experts_fp_kernel_impl(
     // get local pointers
     int tid = get_thread_num();
     scalar_t* __restrict__ A = A_tmp + tid * BLOCK_M * K;
+    bool used_brgemm = false;
 
     loop_2d<packed_t>(mb0, mb1, nb0, nb1, BLOCK_N * K, [&](int64_t mb, int64_t nb, int64_t nb_offset) {
       int64_t n_size = std::min(2 * N - nb * BLOCK_N, BLOCK_N);
@@ -86,6 +86,11 @@ void fused_experts_fp_kernel_impl(
       bool do_unpack = (mb == mb0) || (expert_id != pre_expert_id);
 
       int64_t m_size = offsets[mb + 1] - offsets[mb];
+      if (m_size == 0) {
+        return;
+      }
+      used_brgemm |= backend == PackedGemmBackend::Brgemm &&
+          (m_size > 8 || n_size != BLOCK_N);
 
       if (nb_offset == 0) {
         // 1.a load A
@@ -111,12 +116,12 @@ void fused_experts_fp_kernel_impl(
           /*   lda          */ K,
           /*   ldb          */ n_size,
           /*   ldc          */ 2 * N,
-          /*   brg          */ use_brgemm,
+          /*   backend      */ backend,
           /*   block_size_K */ block_size_K,
           /*   do_unpack    */ do_unpack);
     });
 
-    if (use_brgemm) {
+    if (used_brgemm) {
       at::native::cpublas::brgemm_release();
     }
   });
@@ -152,10 +157,16 @@ void fused_experts_fp_kernel_impl(
   parallel_2d(MB2, NB2, [&](int64_t mb0, int64_t mb1, int64_t nb0, int64_t nb1) {
     int tid = get_thread_num();
     alignas(64) scalar_t C[BLOCK_M * BLOCK_K];
+    bool used_brgemm = false;
 
     loop_2d<packed_t>(mb0, mb1, nb0, nb1, BLOCK_N * IC, [&](int64_t mb, int64_t nb, int64_t nb_offset) {
       int64_t m_size = offsets[mb + 1] - offsets[mb];
+      if (m_size == 0) {
+        return;
+      }
       int64_t n_size = std::min(OC - nb * BLOCK_N, BLOCK_N);
+      used_brgemm |= backend == PackedGemmBackend::Brgemm &&
+          (m_size > 8 || n_size != BLOCK_N);
 
       // A ptr from ic1 of [M * topk, N] in sorted order
       // so as to avoid copy A to tmp buffer again
@@ -187,7 +198,7 @@ void fused_experts_fp_kernel_impl(
           /*   lda          */ IC,
           /*   ldb          */ n_size,
           /*   ldc          */ BLOCK_N,
-          /*   brg          */ use_brgemm,
+          /*   backend      */ backend,
           /*   block_size_K */ block_size_K,
           /*   do_unpack    */ do_unpack);
 
@@ -200,7 +211,7 @@ void fused_experts_fp_kernel_impl(
       }
     });
 
-    if (use_brgemm) {
+    if (used_brgemm) {
       at::native::cpublas::brgemm_release();
     }
   });
@@ -280,6 +291,8 @@ void shared_expert_fp8_kernel_impl(
   int64_t blocks_n_per_group = block_size_N / BLOCK_N;
 
   const bool use_brgemm = can_use_brgemm<at::Float8_e4m3fn>(M);
+  const PackedGemmBackend backend =
+      use_brgemm ? PackedGemmBackend::Brgemm : PackedGemmBackend::TinyGemm;
   const bool apply_scaling_factor = fused_experts_out != nullptr;
 
   int64_t B_tmp_size_per_thread = MAX_CACHE_BLOCK_SIZE * BLOCK_N * std::max(K, N);
@@ -308,7 +321,7 @@ void shared_expert_fp8_kernel_impl(
           /*   lda          */ K,
           /*   ldb          */ n_size,
           /*   ldc          */ 2 * N,
-          /*   brg          */ use_brgemm,
+          /*   backend      */ backend,
           /*   block_size_K */ block_size_K,
           /*   do_unpack    */ do_unpack);
     });
@@ -360,7 +373,7 @@ void shared_expert_fp8_kernel_impl(
           /*   lda          */ IC,
           /*   ldb          */ n_size,
           /*   ldc          */ BLOCK_N,
-          /*   brg          */ use_brgemm,
+          /*   backend      */ backend,
           /*   block_size_K */ block_size_K,
           /*   do_unpack    */ do_unpack);
 

--- a/csrc/cpu/sgl-kernels/moe_fp8.cpp
+++ b/csrc/cpu/sgl-kernels/moe_fp8.cpp
@@ -89,8 +89,7 @@ void fused_experts_fp_kernel_impl(
       if (m_size == 0) {
         return;
       }
-      used_brgemm |= backend == PackedGemmBackend::Brgemm &&
-          (m_size > MOE_TINY_GEMM_MAX_M || n_size != BLOCK_N);
+      used_brgemm |= moe_uses_brgemm(backend, m_size, n_size);
 
       if (nb_offset == 0) {
         // 1.a load A
@@ -165,8 +164,7 @@ void fused_experts_fp_kernel_impl(
         return;
       }
       int64_t n_size = std::min(OC - nb * BLOCK_N, BLOCK_N);
-      used_brgemm |= backend == PackedGemmBackend::Brgemm &&
-          (m_size > MOE_TINY_GEMM_MAX_M || n_size != BLOCK_N);
+      used_brgemm |= moe_uses_brgemm(backend, m_size, n_size);
 
       // A ptr from ic1 of [M * topk, N] in sorted order
       // so as to avoid copy A to tmp buffer again

--- a/tests/kernels/moe/test_cpu_quant_fused_moe.py
+++ b/tests/kernels/moe/test_cpu_quant_fused_moe.py
@@ -31,6 +31,21 @@ def _prepack_experts(w: torch.Tensor) -> torch.Tensor:
     return torch.ops._C.convert_weight_packed(w)
 
 
+def _deterministic_expert_routes(
+    block_sizes: tuple[int, ...],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Create top-1 routes with exact per-expert block occupancies."""
+    topk_ids = torch.cat(
+        [
+            torch.full((size,), expert, dtype=torch.int32)
+            for expert, size in enumerate(block_sizes)
+        ]
+    )
+    topk_ids = topk_ids.view(-1, 1)
+    topk_weights = torch.ones(topk_ids.shape, dtype=torch.float32)
+    return topk_weights, topk_ids
+
+
 # ===========================================================================
 # FP8 W8A16 MoE
 # ===========================================================================
@@ -217,6 +232,40 @@ def test_w8a16_block_fp8_cpu_fused_moe(M, N, K, E, topk, seed):
         is_vnni=True,
     )
     torch.testing.assert_close(out_inplace, out, atol=0, rtol=0)
+
+
+def test_w8a16_block_fp8_cpu_fused_moe_small_expert_blocks():
+    """Test FP8 BRGEMM for expert blocks spanning the TinyGEMM boundary."""
+    set_random_seed(0)
+    block_sizes = (1, 2, 3, 4, 5, 8, 16, 32)
+    N, K, E = 128, 128, len(block_sizes)
+    M = sum(block_sizes)
+
+    a = torch.randn(M, K, dtype=torch.bfloat16) / math.sqrt(K)
+    w1, w2, w1_s, w2_s = _make_fp8_moe_weights(E, N, K, BLOCK_SIZE)
+    topk_weight, topk_ids = _deterministic_expert_routes(block_sizes)
+
+    ref_out = ref_w8a16_block_fp8_moe(
+        a, w1, w2, w1_s, w2_s, topk_weight, topk_ids, BLOCK_SIZE
+    )
+    pw1, pw2 = _prepack_experts(w1), _prepack_experts(w2)
+    out = ops.fused_experts_cpu(
+        a,
+        pw1,
+        pw2,
+        topk_weight,
+        topk_ids,
+        False,
+        ops.CPUQuantMethod.FP8_W8A16,
+        w1_s,
+        w2_s,
+        None,
+        None,
+        BLOCK_SIZE,
+        is_vnni=True,
+    )
+
+    torch.testing.assert_close(ref_out.bfloat16(), out, atol=1e-2, rtol=1e-2)
 
 
 # ===========================================================================
@@ -433,6 +482,48 @@ def test_mxfp4_cpu_fused_moe(M, N, K, E, topk, seed):
         None,  # w1_zero
         None,  # w2_zero
         None,  # block_size
+    )
+
+    torch.testing.assert_close(ref_out.bfloat16(), out, atol=1e-2, rtol=1e-2)
+
+
+def test_mxfp4_cpu_fused_moe_small_expert_blocks():
+    """Test MXFP4 BRGEMM for expert blocks spanning the TinyGEMM boundary."""
+    set_random_seed(0)
+    block_sizes = (1, 2, 3, 4, 5, 8, 16, 32)
+    N, K, E = 128, 128, len(block_sizes)
+    M = sum(block_sizes)
+    dtype = torch.bfloat16
+
+    a = torch.randn(M, K, dtype=dtype) / 10
+    w1_bf16 = torch.randn(E, 2 * N, K, dtype=dtype) / 10
+    w1q, w1s = MXFP4QuantizeUtil.quantize(w1_bf16)
+    w1s = w1s.reshape(E, 2 * N, K // 32)
+    w1dq = MXFP4QuantizeUtil.dequantize(w1q, dtype, w1s)
+
+    w2_bf16 = torch.randn(E, K, N, dtype=dtype) / 10
+    w2q, w2s = MXFP4QuantizeUtil.quantize(w2_bf16)
+    w2s = w2s.reshape(E, K, N // 32)
+    w2dq = MXFP4QuantizeUtil.dequantize(w2q, dtype, w2s)
+
+    topk_weight, topk_ids = _deterministic_expert_routes(block_sizes)
+    ref_out = ref_mxfp4_fused_moe(a, w1dq, w2dq, topk_weight, topk_ids, 1)
+
+    pw1, pw1s = _prepack_mxfp4_experts(w1q, w1s)
+    pw2, pw2s = _prepack_mxfp4_experts(w2q, w2s)
+    out = ops.fused_experts_cpu(
+        a,
+        pw1,
+        pw2,
+        topk_weight,
+        topk_ids,
+        False,
+        ops.CPUQuantMethod.MXFP4,
+        pw1s,
+        pw2s,
+        None,
+        None,
+        None,
     )
 
     torch.testing.assert_close(ref_out.bfloat16(), out, atol=1e-2, rtol=1e-2)

--- a/tests/kernels/moe/test_cpu_quant_fused_moe.py
+++ b/tests/kernels/moe/test_cpu_quant_fused_moe.py
@@ -235,9 +235,9 @@ def test_w8a16_block_fp8_cpu_fused_moe(M, N, K, E, topk, seed):
 
 
 def test_w8a16_block_fp8_cpu_fused_moe_small_expert_blocks():
-    """Test FP8 BRGEMM for expert blocks spanning the TinyGEMM boundary."""
+    """Test FP8 BRGEMM at exact and multi-block expert boundaries."""
     set_random_seed(0)
-    block_sizes = (1, 2, 3, 4, 5, 8, 16, 32)
+    block_sizes = (4, 5, 33)
     N, K, E = 128, 128, len(block_sizes)
     M = sum(block_sizes)
 
@@ -488,9 +488,9 @@ def test_mxfp4_cpu_fused_moe(M, N, K, E, topk, seed):
 
 
 def test_mxfp4_cpu_fused_moe_small_expert_blocks():
-    """Test MXFP4 BRGEMM for expert blocks spanning the TinyGEMM boundary."""
+    """Test MXFP4 BRGEMM at exact and multi-block expert boundaries."""
     set_random_seed(0)
-    block_sizes = (1, 2, 3, 4, 5, 8, 16, 32)
+    block_sizes = (4, 5, 33)
     N, K, E = 128, 128, len(block_sizes)
     M = sum(block_sizes)
     dtype = torch.bfloat16


### PR DESCRIPTION


## Purpose
Remove the fixed global crossover from routed CPU FP8/MXFP4 MoE dispatch so that concentrated moe routing can benefit from brgemm.
Select BRGEMM from each expert block's actual `M` and `N` and cover small expert blocks with the existing fixed-row TinyGEMM kernels. Dense and shared-expert dispatch remains unchanged.

This is separate from #49942, which adds broader CPU FP8 W8A8 support through different APIs.

## Test Plan

```bash
# Correctness
.venv/bin/python -m pytest tests/kernels/moe/test_cpu_quant_fused_moe.py -v -k small_expert_blocks
.venv/bin/python -m pytest tests/kernels/moe/test_cpu_quant_fused_moe.py -v

# Serving benchmark for Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8 (TP=1),
# Qwen/Qwen3.6-35B-A3B-FP8 (TP=2), and openai/gpt-oss-20b (TP=4);
# repeated for each model and concurrency
vllm serve MODEL --dtype bfloat16 --tensor-parallel-size TP --max-model-len 4096
vllm bench serve --backend openai --endpoint /v1/completions --model MODEL \
  --dataset-name sonnet --dataset-path benchmarks/sonnet.txt \
  --sonnet-input-len 256 --sonnet-output-len 256 \
  --max-concurrency CONCURRENCY --num-prompts NUM_PROMPTS
```

## Test Result

The branch candidate was compared with the baseline using Sonnet `256/256`, concurrency `1,2,4,8,16,32,64,128,256`, one warmup and one measured run per point.

- Per-model throughput geomean: Qwen3-Coder `1.1061x`, Qwen3.6 `1.0674x`, GPT-OSS `1.0865x`; aggregate `1.0866x` over 27 points.
- Best: GPT-OSS-20B at concurrency 32, `1.5954x`  (`975.9` vs `611.7` output tok/s).
- Worst: GPT-OSS-20B at concurrency 64, `0.9867x`  (`1436.7` vs `1456.1` output tok/s).

AI assistance was used. The human submitter reviewed the changes and ran the
validation above.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

