### PR TITLE
[Bugfix] Resolve seq-cls `num_labels` from the top-level config for multimodal checkpoints

### DIFF
--- a/tests/models/test_adapters.py
+++ b/tests/models/test_adapters.py
@@ -4,8 +4,12 @@
 
 import pytest
 import torch
+from transformers import Gemma3Config, PretrainedConfig, Qwen2Config
 
-from vllm.model_executor.models.adapters import _create_pooling_model_cls
+from vllm.model_executor.models.adapters import (
+    _create_pooling_model_cls,
+    _resolve_num_labels,
+)
 from vllm.model_executor.models.utils import AutoWeightsLoader, StageMissingLayer
 
 pytestmark = pytest.mark.cpu_test
@@ -146,3 +150,45 @@ def test_pooling_load_weights_clones_probed_weights():
     expected = {n: p.data.clone() for n, p in ground_truth.named_parameters()}
 
     _load_and_compare(_make_pooling_model(PackedWeightModel), ref, expected)
+
+
+def _composite_config(outer_labels=None, inner_labels=None):
+    """Build a multimodal-style config whose text_config is a separate object."""
+    config = Gemma3Config(text_config={"num_hidden_layers": 1})
+    if outer_labels is not None:
+        config.num_labels = outer_labels
+    if inner_labels is not None:
+        config.get_text_config().num_labels = inner_labels
+    return config
+
+
+def test_resolve_num_labels_text_only_config():
+    config = Qwen2Config(num_labels=7)
+    assert config.get_text_config() is config
+    assert _resolve_num_labels(config, config.get_text_config()) == 7
+
+
+def test_resolve_num_labels_defaults_when_undeclared():
+    config = _composite_config()
+    assert (
+        _resolve_num_labels(config, config.get_text_config())
+        == PretrainedConfig().num_labels
+    )
+
+
+def test_resolve_num_labels_declared_on_outer_config():
+    """Multimodal checkpoints keep id2label/problem_type on the top-level config."""
+    config = _composite_config(outer_labels=20)
+    assert config.get_text_config().num_labels == PretrainedConfig().num_labels
+    assert _resolve_num_labels(config, config.get_text_config()) == 20
+
+
+def test_resolve_num_labels_declared_on_text_config():
+    """Overrides written into text_config keep working."""
+    config = _composite_config(inner_labels=5)
+    assert _resolve_num_labels(config, config.get_text_config()) == 5
+
+
+def test_resolve_num_labels_outer_wins_when_both_declared():
+    config = _composite_config(outer_labels=20, inner_labels=5)
+    assert _resolve_num_labels(config, config.get_text_config()) == 20

--- a/vllm/model_executor/models/adapters.py
+++ b/vllm/model_executor/models/adapters.py
@@ -261,6 +261,29 @@ def as_embedding_model(cls: _T) -> _T:
     return ModelForEmbedding  # type: ignore
 
 
+def _resolve_num_labels(hf_config: Any, text_config: Any) -> int:
+    """Resolve the label count for a sequence classification head.
+
+    ``PretrainedConfig.num_labels`` is derived from ``id2label``, which always
+    carries a default of two entries. Composite configs (such as multimodal
+    checkpoints) declare their label space on the top-level config, so reading
+    ``num_labels`` from ``get_text_config()`` silently returns that default and
+    builds a score head of the wrong size.
+
+    Prefer the top-level config whenever it declares a label space of its own,
+    mirroring the ``classifier_from_token`` / ``method`` lookups in
+    ``as_seq_cls_model``.
+    """
+    if text_config is hf_config:
+        return hf_config.num_labels
+
+    from transformers import PretrainedConfig
+
+    if hf_config.num_labels != PretrainedConfig().num_labels:
+        return hf_config.num_labels
+    return text_config.num_labels
+
+
 def as_seq_cls_model(cls: _T) -> _T:
     """
     Subclass an existing vLLM model to support classify and score tasks.
@@ -320,7 +343,7 @@ def as_seq_cls_model(cls: _T) -> _T:
 
             self.score = ReplicatedLinear(
                 model_config.get_hidden_size(),
-                text_config.num_labels,
+                _resolve_num_labels(hf_config, text_config),
                 bias=False,
                 params_dtype=model_config.head_dtype,
                 quant_config=quant_config,


### PR DESCRIPTION
## Purpose

Multimodal sequence-classification checkpoints cannot be served: the score head
is built with the wrong number of labels, so weight loading fails with

    AssertionError: Tried to load weights of size torch.Size([20, 2560])
    to a parameter of size torch.Size([2, 2560])

Reported against vLLM in #47956 (Qwen3-VL, 20 labels) and downstream as
modelscope/ms-swift#9704.

## Root cause

`as_seq_cls_model._init_pooler` sizes the head from
`hf_config.get_text_config().num_labels`. `PretrainedConfig.num_labels` is
derived from `id2label`, which always carries a default of two entries.
Composite configs declare their label space on the top-level config -
`id2label`, `label2id` and `problem_type` are top-level fields by HF convention
- so `get_text_config()` reports the default of 2 and the head is allocated as
`[2, hidden]`.

This is the only place in vLLM that reads `num_labels` from the text config.
Every other read uses the top-level config:

| site | reads |
|---|---|
| `layers/pooler/activations.py` `resolve_classifier_act_fn` -> `get_act_fn` | `model_config.hf_config` |
| `entrypoints/pooling/utils.py` (scoring API gate) | `model_config.hf_config` |
| `entrypoints/pooling/offline.py` (scoring API gate) | `model_config.hf_config` |
| `models/adapters.py` (score head) | `get_text_config()` |

So in the multimodal case the pooler activation already assumes 20 labels while
the score head is built for 2; they disagree before the assertion is even hit.

It is also a regression. The head was sized from the top-level config from
#11469 (Dec 2024) until #27338 (Oct 2025), which moved this read to
`text_config` while fixing the Transformers backend. Its description gives the
reasoning: "the Gemma 3 MM classification test writes the overrides to
`text_config`, so this appears to be the correct location to do this". That
holds for overrides written into `text_config`, but not for checkpoints that
declare their labels at the top level. #31890 later had to start assigning
`hf_config.num_labels` alongside `text_config.num_labels` in
`SequenceClassificationConfig.verify_and_update_config` for the Qwen3-VL
reranker; the score head is the last read that was never revisited.

Only the checkpoint-based path is affected. The online-conversion path
(`classifier_from_token` / `method`) goes through `verify_and_update_config`,
which already writes `num_labels` to both configs - which is why
`tests/models/language/pooling/test_mm_classifier_conversion.py` is unaffected.

## Fix

Resolve the label count from the top-level config when it declares one, falling
back to the text config otherwise, mirroring the `classifier_from_token` /
`method` lookups directly above the call site.

Two things I would like reviewer input on:

1. Since every other `num_labels` read in vLLM uses the top-level config
   unconditionally, the fallback arguably makes this *less* consistent. Reading
   `hf_config.num_labels` unconditionally would be a one-line change, is the
   pre-#27338 behaviour, and passes every existing test. I kept the fallback so
   that a config declaring labels only on the text config keeps working. Happy
   to simplify.
2. I kept the resolution local to `adapters.py` rather than moving it next to
   `ModelConfig.get_hidden_size()`: `ModelArchConfigConvertor` resolves
   *architecture* fields and deliberately defaults to `hf_text_config`, whereas
   a label space belongs to the top-level config, and this ambiguity is not
   architecture-specific. Happy to move it if you prefer.

## Not a duplicate

- #47956 reported the same failure. It was closed once the reporter was
  unblocked by forcing `text_config.num_labels` through `--hf-overrides`; the
  read itself was never changed, and the issue has no cross-references. @noooop
  noted there that "you need to find a way to make text_config.num_labels equal
  to 20 [...] the code here may need some optimization to be compatible with
  more models".
- All 50 commits that have ever touched `adapters.py` were reviewed; none
  changes this resolution.
- No open PR does this either: all 4232 open PR titles plus 2000 PR bodies were
  scanned for `num_labels`, `text_config`, `seq_cls` and `47956` - no hits.
- #24501 fixed the sibling argument of this very `ReplicatedLinear` call
  (`hidden_size`) for multimodal classification models; that helper was later
  absorbed into the config layer by #28454. `num_labels` never got the same
  treatment.
- #50890 touches the same two files but a different function
  (`ModelForPooling.load_weights`); no semantic overlap, only a trivial rebase.

## Test Plan

New CPU-only unit tests in `tests/models/test_adapters.py` covering the
resolution matrix (text-only config; neither level declares labels; only the
top-level declares; only the text config declares; both declare):

    pytest tests/models/test_adapters.py -k resolve_num_labels

End-to-end with a Qwen3-VL sequence-classification checkpoint that declares 20
labels at the top level of `config.json`:

    vllm serve <ckpt> --runner pooling \
      --hf-overrides '{"architectures": ["Qwen3VLForSequenceClassification"], "problem_type": "multi_label_classification"}' \
      --max-model-len 8192

    curl -X POST http://127.0.0.1:8000/classify \
      -H 'Content-Type: application/json' \
      -d '{"model": "<ckpt>", "input": "a photo of a dog and a person"}'

## Test Result

Unit tests: 7 passed (2 pre-existing + 5 new), no GPU required.

End-to-end on v0.26.0, single A100-40GB, fail -> pass:

| | before | after |
|---|---|---|
| weight loading | `AssertionError: Tried to load weights of size torch.Size([20, 2560]) to a parameter of size torch.Size([2, 2560])` | loads |
| server startup | `Engine core initialization failed` | `Application startup complete.` |
| `POST /classify` | unreachable | 20 probabilities, e.g. `[0.6438, 0.1038, 0.0013, 0.8443, 0.8057, ...]`, summing to 9.77 - independent per-label sigmoids, as expected for `multi_label_classification` |

`vllm/model_executor/models/adapters.py` is byte-identical between v0.26.0 and
`main`, so the end-to-end result carries over to `main`.

## Model evaluation

This change is config-level only: it changes how the label count is resolved
when building the sequence-classification head. It touches no compute path and
does not affect the output of any model that loads today - for text-only models
`get_text_config()` returns the config itself, so the resolved value is
unchanged, and the online-conversion path already writes `num_labels` to both
configs. The only behavioural difference is that a multimodal checkpoint which
previously failed to load now loads with a correctly sized head. No accuracy
evaluation run.

## AI assistance

AI assistance was used for this work; all changes reviewed.
