### PR TITLE
[Bugfix][ROCm] Resolve tuned configs across device-name aliases

### DIFF
--- a/tests/test_platform_utils.py
+++ b/tests/test_platform_utils.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+import vllm
+from vllm.utils.platform_utils import resolve_rocm_device_config_file_path
+
+
+def _config_path(directory: Path, device_name: str, *, experts: int = 128) -> Path:
+    return directory / (
+        f"E={experts},N=768,device_name={device_name},dtype=int4_w4a16.json"
+    )
+
+
+@pytest.mark.parametrize(
+    "requested_name", ["AMD_Radeon_8060S", "AMD_Radeon_8060S_Graphics"]
+)
+def test_resolve_device_config_file_path_uses_equivalent_device_name(
+    monkeypatch,
+    tmp_path: Path,
+    requested_name: str,
+) -> None:
+    monkeypatch.setattr("vllm.platforms.current_platform.is_rocm", lambda: True)
+    requested = _config_path(tmp_path, requested_name)
+    existing = _config_path(tmp_path, "Radeon_8060S_Graphics")
+    existing.write_text("{}")
+
+    assert resolve_rocm_device_config_file_path(str(requested)) == str(existing)
+
+
+def test_resolve_device_config_file_path_finds_shipped_gfx1151_config(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr("vllm.platforms.current_platform.is_rocm", lambda: True)
+    config_dir = (
+        Path(vllm.__file__).parent
+        / "model_executor"
+        / "layers"
+        / "fused_moe"
+        / "configs"
+    )
+    requested = _config_path(config_dir, "AMD_Radeon_8060S")
+    existing = _config_path(config_dir, "Radeon_8060S_Graphics")
+
+    assert existing.is_file()
+    assert resolve_rocm_device_config_file_path(str(requested)) == str(existing)
+
+
+def test_resolve_device_config_file_path_prefers_exact_name(
+    monkeypatch, tmp_path: Path
+) -> None:
+    is_rocm = Mock(return_value=True)
+    monkeypatch.setattr("vllm.platforms.current_platform.is_rocm", is_rocm)
+    requested = _config_path(tmp_path, "AMD_Radeon_8060S")
+    equivalent = _config_path(tmp_path, "Radeon_8060S_Graphics")
+    requested.write_text("exact")
+    equivalent.write_text("equivalent")
+
+    assert resolve_rocm_device_config_file_path(str(requested)) == str(requested)
+    is_rocm.assert_not_called()
+
+
+def test_resolve_device_config_file_path_preserves_other_selectors(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr("vllm.platforms.current_platform.is_rocm", lambda: True)
+    requested = _config_path(tmp_path, "AMD_Radeon_8060S")
+    _config_path(tmp_path, "Radeon_8060S_Graphics", experts=256).write_text("{}")
+
+    assert resolve_rocm_device_config_file_path(str(requested)) == str(requested)
+
+
+def test_resolve_device_config_file_path_rejects_ambiguous_aliases(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr("vllm.platforms.current_platform.is_rocm", lambda: True)
+    requested = _config_path(tmp_path, "AMD_Radeon_8060S")
+    _config_path(tmp_path, "Radeon_8060S_Graphics").write_text("first")
+    _config_path(tmp_path, "AMD-Radeon-8060S-Graphics").write_text("second")
+
+    assert resolve_rocm_device_config_file_path(str(requested)) == str(requested)
+
+
+def test_resolve_device_config_file_path_rejects_empty_device_name(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr("vllm.platforms.current_platform.is_rocm", lambda: True)
+    requested = _config_path(tmp_path, "AMD_Graphics")
+    _config_path(tmp_path, "Graphics").write_text("{}")
+
+    assert resolve_rocm_device_config_file_path(str(requested)) == str(requested)
+
+
+def test_resolve_device_config_file_path_does_not_alias_non_rocm(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr("vllm.platforms.current_platform.is_rocm", lambda: False)
+    requested = _config_path(tmp_path, "AMD_Radeon_8060S")
+    _config_path(tmp_path, "Radeon_8060S_Graphics").write_text("{}")
+
+    assert resolve_rocm_device_config_file_path(str(requested)) == str(requested)

--- a/tests/test_platform_utils.py
+++ b/tests/test_platform_utils.py
@@ -2,18 +2,84 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 
 import vllm
-from vllm.utils.platform_utils import resolve_rocm_device_config_file_path
+from vllm.utils.platform_utils import (
+    get_device_name_as_file_name,
+    resolve_rocm_device_config_file_path,
+)
 
 
 def _config_path(directory: Path, device_name: str, *, experts: int = 128) -> Path:
     return directory / (
         f"E={experts},N=768,device_name={device_name},dtype=int4_w4a16.json"
     )
+
+
+@pytest.mark.parametrize(
+    ("torch_name", "expected_file_name"),
+    [
+        ("Radeon 8060S Graphics", "Radeon_8060S_Graphics"),
+        ("AMD Radeon 8060S Graphics", "AMD_Radeon_8060S_Graphics"),
+    ],
+)
+def test_magicmock_device_name_falls_back_to_torch_and_resolves_config(
+    monkeypatch,
+    tmp_path: Path,
+    torch_name: str,
+    expected_file_name: str,
+) -> None:
+    from vllm.platforms import current_platform
+
+    monkeypatch.setattr(
+        current_platform, "get_device_name", Mock(return_value=MagicMock())
+    )
+    monkeypatch.setattr(current_platform, "is_rocm", Mock(return_value=True))
+    torch_get_device_name = Mock(return_value=torch_name)
+    monkeypatch.setattr(
+        "vllm.utils.platform_utils.torch.cuda.get_device_name",
+        torch_get_device_name,
+    )
+    existing = _config_path(tmp_path, "Radeon_8060S_Graphics")
+    existing.write_text("{}")
+    get_device_name_as_file_name.cache_clear()
+
+    try:
+        requested_name = get_device_name_as_file_name()
+        requested = _config_path(tmp_path, requested_name)
+        assert requested_name == expected_file_name
+        assert resolve_rocm_device_config_file_path(str(requested)) == str(existing)
+    finally:
+        get_device_name_as_file_name.cache_clear()
+
+    torch_get_device_name.assert_called_once_with(0)
+
+
+def test_get_device_name_as_file_name_keeps_valid_platform_name(monkeypatch) -> None:
+    from vllm.platforms import current_platform
+
+    monkeypatch.setattr(
+        current_platform, "get_device_name", Mock(return_value="AMD_Radeon_8060S")
+    )
+    is_rocm = Mock(return_value=True)
+    monkeypatch.setattr(current_platform, "is_rocm", is_rocm)
+    torch_get_device_name = Mock()
+    monkeypatch.setattr(
+        "vllm.utils.platform_utils.torch.cuda.get_device_name",
+        torch_get_device_name,
+    )
+    get_device_name_as_file_name.cache_clear()
+
+    try:
+        assert get_device_name_as_file_name() == "AMD_Radeon_8060S"
+    finally:
+        get_device_name_as_file_name.cache_clear()
+
+    is_rocm.assert_not_called()
+    torch_get_device_name.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/vllm/model_executor/layers/fused_moe/fused_flydsl_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_flydsl_moe.py
@@ -16,7 +16,10 @@ from aiter.ops.flydsl.kernels.moe_gemm_2stage import (
 )
 
 from vllm.logger import init_logger
-from vllm.utils.platform_utils import get_device_name_as_file_name
+from vllm.utils.platform_utils import (
+    get_device_name_as_file_name,
+    resolve_rocm_device_config_file_path,
+)
 from vllm.utils.torch_utils import direct_register_custom_op
 
 logger = init_logger(__name__)
@@ -121,6 +124,7 @@ def try_get_optimal_config(num_experts, inter_dim):
     config_file_path = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "configs", json_file_name
     )
+    config_file_path = resolve_rocm_device_config_file_path(config_file_path)
     if os.path.exists(config_file_path):
         with open(config_file_path) as f:
             logger.info_once(

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -35,7 +35,10 @@ from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.triton_utils.allocation import set_triton_allocator
 from vllm.utils.math_utils import next_power_of_2
-from vllm.utils.platform_utils import get_device_name_as_file_name
+from vllm.utils.platform_utils import (
+    get_device_name_as_file_name,
+    resolve_rocm_device_config_file_path,
+)
 from vllm.utils.torch_utils import direct_register_custom_op
 
 logger = init_logger(__name__)
@@ -1135,12 +1138,16 @@ def get_moe_configs(
         user_defined_config_file_path = os.path.join(
             user_defined_config_folder, json_file_name
         )
-        config_file_paths.append(user_defined_config_file_path)
+        config_file_paths.append(
+            resolve_rocm_device_config_file_path(user_defined_config_file_path)
+        )
 
     default_config_file_path = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "configs", json_file_name
     )
-    config_file_paths.append(default_config_file_path)
+    config_file_paths.append(
+        resolve_rocm_device_config_file_path(default_config_file_path)
+    )
 
     for config_file_path in config_file_paths:
         if os.path.exists(config_file_path):

--- a/vllm/model_executor/layers/mamba/ops/mamba_ssm.py
+++ b/vllm/model_executor/layers/mamba/ops/mamba_ssm.py
@@ -19,7 +19,10 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.mamba.ops.triton_helpers import fast_exp
 from vllm.platforms import current_platform
 from vllm.triton_utils import HAS_TRITON, tl, triton
-from vllm.utils.platform_utils import get_device_name_as_file_name
+from vllm.utils.platform_utils import (
+    get_device_name_as_file_name,
+    resolve_rocm_device_config_file_path,
+)
 from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
 
 if current_platform.is_xpu():
@@ -85,11 +88,15 @@ def get_ssm_configs(
     user_defined_config_folder = envs.VLLM_TUNED_CONFIG_FOLDER
     if user_defined_config_folder is not None:
         config_file_paths.append(
-            os.path.join(user_defined_config_folder, json_file_name)
+            resolve_rocm_device_config_file_path(
+                os.path.join(user_defined_config_folder, json_file_name)
+            )
         )
 
     # Bundled default
-    config_file_paths.append(os.path.join(_CONFIGS_DIR, json_file_name))
+    config_file_paths.append(
+        resolve_rocm_device_config_file_path(os.path.join(_CONFIGS_DIR, json_file_name))
+    )
 
     for path in config_file_paths:
         if os.path.exists(path):

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -33,7 +33,10 @@ from vllm.utils.deep_gemm import (
     is_deep_gemm_e8m0_used,
     transform_sf_into_required_layout,
 )
-from vllm.utils.platform_utils import get_device_name_as_file_name
+from vllm.utils.platform_utils import (
+    get_device_name_as_file_name,
+    resolve_rocm_device_config_file_path,
+)
 
 logger = init_logger(__name__)
 
@@ -837,6 +840,7 @@ def get_w8a8_block_fp8_configs(
     config_file_path = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "configs", json_file_name
     )
+    config_file_path = resolve_rocm_device_config_file_path(config_file_path)
     if os.path.exists(config_file_path):
         with open(config_file_path) as f:
             logger.info(

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -34,7 +34,10 @@ from vllm.utils.deep_gemm import (
     is_deep_gemm_e8m0_used,
     transform_sf_into_required_layout,
 )
-from vllm.utils.platform_utils import get_device_name_as_file_name
+from vllm.utils.platform_utils import (
+    get_device_name_as_file_name,
+    resolve_rocm_device_config_file_path,
+)
 
 logger = init_logger(__name__)
 
@@ -838,6 +841,7 @@ def get_w8a8_block_fp8_configs(
     config_file_path = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "configs", json_file_name
     )
+    config_file_path = resolve_rocm_device_config_file_path(config_file_path)
     if os.path.exists(config_file_path):
         with open(config_file_path) as f:
             logger.info(

--- a/vllm/model_executor/layers/quantization/utils/int8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/int8_utils.py
@@ -12,7 +12,10 @@ import torch
 
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
-from vllm.utils.platform_utils import get_device_name_as_file_name
+from vllm.utils.platform_utils import (
+    get_device_name_as_file_name,
+    resolve_rocm_device_config_file_path,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -336,6 +339,7 @@ def get_w8a8_block_int8_configs(
     config_file_path = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "configs", json_file_name
     )
+    config_file_path = resolve_rocm_device_config_file_path(config_file_path)
     if os.path.exists(config_file_path):
         with open(config_file_path) as f:
             logger.info(

--- a/vllm/utils/platform_utils.py
+++ b/vllm/utils/platform_utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import multiprocessing
+import os
 from collections.abc import Sequence
 from concurrent.futures.process import ProcessPoolExecutor
 from functools import cache
@@ -72,3 +73,49 @@ def get_device_name_as_file_name(device_id: int = 0) -> str:
     name = current_platform.get_device_name(device_id)
     name = re.sub(r"[\s/]+", "_", name)
     return name
+
+
+def _normalize_config_device_name(name: str) -> str:
+    name = re.sub(r"[^a-z0-9]", "", name.lower())
+    return name.removeprefix("amd").removesuffix("graphics")
+
+
+def resolve_rocm_device_config_file_path(config_file_path: str) -> str:
+    """Resolve a tuned config written under an equivalent device name."""
+    if os.path.exists(config_file_path):
+        return config_file_path
+
+    from vllm.platforms import current_platform
+
+    if not current_platform.is_rocm():
+        return config_file_path
+
+    config_dir, config_file_name = os.path.split(config_file_path)
+    match = re.search(r"device_name=([^,]+?)(?=,|\.json$)", config_file_name)
+    if match is None:
+        return config_file_path
+
+    prefix = config_file_name[: match.start(1)]
+    suffix = config_file_name[match.end(1) :]
+    normalized_name = _normalize_config_device_name(match.group(1))
+    if not normalized_name:
+        return config_file_path
+    matching_paths: list[str] = []
+
+    try:
+        entries = os.scandir(config_dir or ".")
+    except OSError:
+        return config_file_path
+
+    with entries:
+        for entry in entries:
+            if not entry.is_file():
+                continue
+            if not entry.name.startswith(prefix) or not entry.name.endswith(suffix):
+                continue
+            end = len(entry.name) - len(suffix) if suffix else len(entry.name)
+            candidate_name = entry.name[len(prefix) : end]
+            if _normalize_config_device_name(candidate_name) == normalized_name:
+                matching_paths.append(entry.path)
+
+    return matching_paths[0] if len(matching_paths) == 1 else config_file_path

--- a/vllm/utils/platform_utils.py
+++ b/vllm/utils/platform_utils.py
@@ -71,6 +71,8 @@ def get_device_name_as_file_name(device_id: int = 0) -> str:
     from vllm.platforms import current_platform
 
     name = current_platform.get_device_name(device_id)
+    if not isinstance(name, str) and current_platform.is_rocm():
+        name = torch.cuda.get_device_name(device_id)
     name = re.sub(r"[\s/]+", "_", name)
     return name
 


### PR DESCRIPTION
## Summary

Fixes #50436.

ROCm can report the same device under different names. This change keeps exact
config lookup first, then falls back to a single equivalent device name after an
exact miss. Empty or ambiguous matches still use the existing default path.
If ROCm platform detection returns a non-string device name, configuration lookup
falls back to `torch.cuda.get_device_name()` before applying the same resolver.
Valid platform-provided string names remain unchanged.

The shared resolver is used by the MoE, FlyDSL MoE, block INT8/FP8, and Mamba
config loaders. Non-ROCm behavior and user-config priority are unchanged.

## Not a duplicate

PR #44331 adds a gfx1151 config, and PR #44332 proposes a broader platform-name
fallback. This PR keeps the fallback local to the tuned-config filename boundary
and does not depend on #44332.

## Validation

Validated on Radeon 8060S / gfx1151:

- 11 focused platform/config tests and 6 existing Mamba config tests passed.
- All six shipped Qwen3 W4A16 MoE configs matched the torch reference.
- Tuned configs were 3.20x-4.52x faster than the current default.
- Full-model Qwen3 A/B produced identical 32-token greedy output.
- Ruff format/check passed.

Commands:

```bash
.venv/bin/python -m pytest \
	tests/test_platform_utils.py \
	tests/kernels/mamba/test_mamba_ssm_configs.py -q
changed=$(git diff --name-only origin/main...HEAD -- '*.py')
.venv/bin/ruff format --check $changed
.venv/bin/ruff check $changed
```

## AI assistance

This change was prepared with GitHub Copilot assistance. The implementation,
tests, and PR text were AI-assisted. Validation was executed on physical AMD
hardware, and publication was explicitly approved after vLLM's AI contribution
and accountability requirements were reviewed.