### PR TITLE
[Bugfix] Pad missing draft rows in the grammar bitmask

### DIFF
--- a/tests/v1/structured_output/test_backend_guidance.py
+++ b/tests/v1/structured_output/test_backend_guidance.py
@@ -245,7 +245,9 @@ def test_grammar_bitmask_pads_missing_drafts():
     vllm_config = VllmConfig(
         model_config=ModelConfig(tokenizer=TOKENIZER),
         structured_outputs_config=StructuredOutputsConfig(backend="guidance"),
-        speculative_config=SpeculativeConfig(model="[ngram]", num_speculative_tokens=num_spec),
+        speculative_config=SpeculativeConfig(
+            model="[ngram]", num_speculative_tokens=num_spec
+        ),
     )
     manager = StructuredOutputManager(vllm_config)
 
@@ -255,7 +257,12 @@ def test_grammar_bitmask_pads_missing_drafts():
         )
         sampling_params.structured_outputs._backend = "guidance"
         sampling_params.update_from_generation_config({}, tokenizer.eos_token_id)
-        req = Request(req_id, prompt_token_ids=prompt, sampling_params=sampling_params, pooling_params=None)
+        req = Request(
+            req_id,
+            prompt_token_ids=prompt,
+            sampling_params=sampling_params,
+            pooling_params=None,
+        )
         manager.grammar_init(req)
         return req
 

--- a/tests/v1/structured_output/test_backend_guidance.py
+++ b/tests/v1/structured_output/test_backend_guidance.py
@@ -231,3 +231,48 @@ def test_mistral_tokenizer_compile_grammar(
     grammar = backend.compile_grammar(request_type, grammar_spec)
     assert grammar is not None
     assert not grammar.is_terminated()
+
+
+def test_grammar_bitmask_pads_missing_drafts():
+    # Speculative methods can schedule fewer drafts than
+    # num_speculative_tokens for a step (e.g. dspark on its first decode).
+    # The bitmask must still emit exactly 1 + num_speculative_tokens rows per
+    # grammar request, or the runner's logit mapping goes out of sync and the
+    # engine dies (vllm#50924).
+    tokenizer = AutoTokenizer.from_pretrained(TOKENIZER)
+    prompt = tokenizer.encode('{"a": "b"}')
+    num_spec = 3
+    vllm_config = VllmConfig(
+        model_config=ModelConfig(tokenizer=TOKENIZER),
+        structured_outputs_config=StructuredOutputsConfig(backend="guidance"),
+        speculative_config=SpeculativeConfig(model="[ngram]", num_speculative_tokens=num_spec),
+    )
+    manager = StructuredOutputManager(vllm_config)
+
+    def make_req(req_id: str) -> Request:
+        sampling_params = SamplingParams(
+            structured_outputs=StructuredOutputsParams(json='{"type": "object"}'),
+        )
+        sampling_params.structured_outputs._backend = "guidance"
+        sampling_params.update_from_generation_config({}, tokenizer.eos_token_id)
+        req = Request(req_id, prompt_token_ids=prompt, sampling_params=sampling_params, pooling_params=None)
+        manager.grammar_init(req)
+        return req
+
+    req_full = make_req("req_full")
+    req_empty = make_req("req_empty")
+    for req in (req_full, req_empty):
+        while not req.structured_output_request._check_grammar_completion():
+            pass
+
+    bitmask = manager.grammar_bitmask(
+        requests={req_full.request_id: req_full, req_empty.request_id: req_empty},
+        structured_output_request_ids=[req_full.request_id, req_empty.request_id],
+        scheduled_spec_decode_tokens={
+            req_full.request_id: list(prompt[:num_spec]),
+            # req_empty scheduled zero drafts this step
+        },
+    )
+
+    assert bitmask is not None
+    assert bitmask.shape[0] == 2 * (1 + num_spec)

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -293,14 +293,27 @@ class StructuredOutputManager:
 
                 state_advancements = 0
                 post_reasoning_end_in_window = False
-                req_tokens = scheduled_spec_decode_tokens.get(req_id, ())
+                req_tokens = list(scheduled_spec_decode_tokens.get(req_id, ()))
+                # Speculative methods may schedule fewer drafts than
+                # num_speculative_tokens for a step (e.g. dspark on its first
+                # decode). Pad placeholders so every grammar request still
+                # occupies exactly 1 + max_num_spec_tokens rows, keeping the
+                # bitmask aligned with the runner's logit mapping.
+                if len(req_tokens) < max_num_spec_tokens:
+                    req_tokens += [-1] * (max_num_spec_tokens - len(req_tokens))
                 for i, token in enumerate(req_tokens):
-                    self._fill_bitmasks(((grammar, cumulative_index, apply_bitmask),))
-                    advance_grammar = apply_bitmask
                     if token == -1:
+                        # Placeholder for an unscheduled draft position: the
+                        # row stays unconstrained and the grammar does not
+                        # advance through it.
+                        self._fill_bitmasks(((grammar, cumulative_index, False),))
                         apply_bitmask = False
                         advance_grammar = False
-                    elif (
+                        cumulative_index += 1
+                        continue
+                    self._fill_bitmasks(((grammar, cumulative_index, apply_bitmask),))
+                    advance_grammar = apply_bitmask
+                    if (
                         detect_reasoning_end
                         and reasoner is not None
                         and not apply_bitmask


### PR DESCRIPTION
Fixes #50924.

With speculative decoding on, `StructuredOutputManager.grammar_bitmask` emits `len(scheduled_spec_decode_tokens[req]) + 1` rows per grammar request, but the GPU runner maps `1 + num_speculative_tokens` logits rows per grammar request. Any step that schedules fewer drafts than `num_speculative_tokens` (dspark's first decode is the reporter's case) makes the bitmask one row short per affected request, and the row-count invariant behind `_apply_grammar_bitmask_kernel` blows up: `The size of tensor a (4040) must match the size of tensor b (4041)`, taking the whole engine down.

The serial fill now pads placeholder rows for the missing draft positions, so every grammar request always occupies exactly `1 + max_num_spec_tokens` rows. Placeholders are filled unconstrained and never advance the grammar (the bonus/target row still gets its constraint from `should_fill_bitmask`). The parallel path is untouched since it only runs with `num_speculative_tokens == 0`.

Verification: a new manager-level test (`num_speculative_tokens=3`, one request with full drafts and one with zero drafts) asserts the bitmask always has `2 * (1 + num_spec)` rows. `tests/v1/structured_output/test_backend_guidance.py` runs 7/7 green locally against the real guidance backend (CPU). No GPU run here, so the dspark end-to-end path is left to CI.
