### PR TITLE
[Bugfix] Preserve Qwen3 structured output content

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import asyncio
 import json
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from contextlib import suppress
 from dataclasses import dataclass, field
 from typing import Any
@@ -595,6 +595,7 @@ def _build_serving_chat(
     reasoning_parser: str = "",
     tool_parser: str | None = None,
     enable_auto_tools: bool = False,
+    structured_outputs_enable_in_reasoning: bool = False,
 ) -> OpenAIServingChat:
     models = OpenAIServingModels(
         engine_client=engine,
@@ -613,9 +614,86 @@ def _build_serving_chat(
         reasoning_parser=reasoning_parser,
         tool_parser=tool_parser,
         enable_auto_tools=enable_auto_tools,
+        structured_outputs_enable_in_reasoning=structured_outputs_enable_in_reasoning,
     )
 
     return serving_chat
+
+
+@pytest.mark.parametrize(
+    (
+        "response_format",
+        "use_beam_search",
+        "model_output",
+        "expected_reasoning",
+        "expected_content",
+    ),
+    [
+        (
+            {"type": "json_object"},
+            False,
+            '{"reasoning":"</think>","tool":"<tool_call>"}',
+            None,
+            '{"reasoning":"</think>","tool":"<tool_call>"}',
+        ),
+        (
+            {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "answer",
+                    "schema": {"type": "object"},
+                },
+            },
+            False,
+            '{"value":"content"}',
+            None,
+            '{"value":"content"}',
+        ),
+        (
+            {"type": "json_object"},
+            True,
+            "thinking</think>answer",
+            "thinking",
+            "answer",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_structured_output_in_reasoning(
+    response_format: dict[str, Any] | None,
+    use_beam_search: bool,
+    model_output: str,
+    expected_reasoning: str | None,
+    expected_content: str,
+):
+    engine = MockEngine()
+    engine.renderer = _build_renderer(engine.model_config)
+
+    async def result_generator(*args, **kwargs):
+        yield _make_metrics_request_output(
+            text=model_output,
+            token_ids=(4, 5, 6),
+        )
+
+    engine.generate = result_generator
+    serving_chat = _build_serving_chat(
+        engine,
+        reasoning_parser="qwen3",
+        structured_outputs_enable_in_reasoning=True,
+    )
+    serving_chat.beam_search = result_generator
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "test"}],
+        response_format=response_format,
+        use_beam_search=use_beam_search,
+    )
+
+    response = await serving_chat.create_chat_completion(request)
+
+    assert isinstance(response, ChatCompletionResponse)
+    assert response.choices[0].message.reasoning == expected_reasoning
+    assert response.choices[0].message.content == expected_content
 
 
 def _build_minimal_metrics_serving_chat(
@@ -639,6 +717,7 @@ def _build_minimal_metrics_serving_chat(
 def _make_metrics_request_output(
     metrics: RequestStateStats | None = _PER_REQUEST_STATS,
     token_ids: tuple[int, ...] = (100, 101),
+    text: str = "Hello",
 ) -> RequestOutput:
     return RequestOutput(
         request_id="test-id",
@@ -648,7 +727,7 @@ def _make_metrics_request_output(
         outputs=[
             CompletionOutput(
                 index=0,
-                text="Hello",
+                text=text,
                 token_ids=list(token_ids),
                 cumulative_logprob=None,
                 logprobs=None,
@@ -786,6 +865,9 @@ class MockEngine:
     model_config: MockModelConfig = field(default_factory=MockModelConfig)
     input_processor: MagicMock = field(default_factory=MagicMock)
     renderer: MagicMock = field(default_factory=MagicMock)
+    generate: Callable[..., AsyncIterator[RequestOutput]] = field(
+        default_factory=MagicMock
+    )
     errored: bool = False
 
 

--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import asyncio
 import json
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from contextlib import suppress
 from dataclasses import dataclass, field
 from typing import Any
@@ -599,6 +599,7 @@ def _build_serving_chat(
     reasoning_parser: str = "",
     tool_parser: str | None = None,
     enable_auto_tools: bool = False,
+    structured_outputs_enable_in_reasoning: bool = False,
 ) -> OpenAIServingChat:
     models = OpenAIServingModels(
         engine_client=engine,
@@ -617,9 +618,86 @@ def _build_serving_chat(
         reasoning_parser=reasoning_parser,
         tool_parser=tool_parser,
         enable_auto_tools=enable_auto_tools,
+        structured_outputs_enable_in_reasoning=structured_outputs_enable_in_reasoning,
     )
 
     return serving_chat
+
+
+@pytest.mark.parametrize(
+    (
+        "response_format",
+        "use_beam_search",
+        "model_output",
+        "expected_reasoning",
+        "expected_content",
+    ),
+    [
+        (
+            {"type": "json_object"},
+            False,
+            '{"reasoning":"</think>","tool":"<tool_call>"}',
+            None,
+            '{"reasoning":"</think>","tool":"<tool_call>"}',
+        ),
+        (
+            {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "answer",
+                    "schema": {"type": "object"},
+                },
+            },
+            False,
+            '{"value":"content"}',
+            None,
+            '{"value":"content"}',
+        ),
+        (
+            {"type": "json_object"},
+            True,
+            "thinking</think>answer",
+            "thinking",
+            "answer",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_structured_output_in_reasoning(
+    response_format: dict[str, Any] | None,
+    use_beam_search: bool,
+    model_output: str,
+    expected_reasoning: str | None,
+    expected_content: str,
+):
+    engine = MockEngine()
+    engine.renderer = _build_renderer(engine.model_config)
+
+    async def result_generator(*args, **kwargs):
+        yield _make_metrics_request_output(
+            text=model_output,
+            token_ids=(4, 5, 6),
+        )
+
+    engine.generate = result_generator
+    serving_chat = _build_serving_chat(
+        engine,
+        reasoning_parser="qwen3",
+        structured_outputs_enable_in_reasoning=True,
+    )
+    serving_chat.beam_search = result_generator
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "test"}],
+        response_format=response_format,
+        use_beam_search=use_beam_search,
+    )
+
+    response = await serving_chat.create_chat_completion(request)
+
+    assert isinstance(response, ChatCompletionResponse)
+    assert response.choices[0].message.reasoning == expected_reasoning
+    assert response.choices[0].message.content == expected_content
 
 
 def _build_minimal_metrics_serving_chat(
@@ -644,6 +722,7 @@ def _build_minimal_metrics_serving_chat(
 def _make_metrics_request_output(
     metrics: RequestStateStats | None = _PER_REQUEST_STATS,
     token_ids: tuple[int, ...] = (100, 101),
+    text: str = "Hello",
 ) -> RequestOutput:
     return RequestOutput(
         request_id="test-id",
@@ -653,7 +732,7 @@ def _make_metrics_request_output(
         outputs=[
             CompletionOutput(
                 index=0,
-                text="Hello",
+                text=text,
                 token_ids=list(token_ids),
                 cumulative_logprob=None,
                 logprobs=None,
@@ -848,6 +927,9 @@ class MockEngine:
     model_config: MockModelConfig = field(default_factory=MockModelConfig)
     input_processor: MagicMock = field(default_factory=MagicMock)
     renderer: MagicMock = field(default_factory=MagicMock)
+    generate: Callable[..., AsyncIterator[RequestOutput]] = field(
+        default_factory=MagicMock
+    )
     errored: bool = False
 
     def check_admission(self, n: int = 1, request_id: str | None = None) -> None:

--- a/tests/parser/engine/test_qwen3_reasoning.py
+++ b/tests/parser/engine/test_qwen3_reasoning.py
@@ -79,6 +79,17 @@ class TestNonStreaming:
         assert reasoning == "Hello, no reasoning here."
         assert content is None
 
+    def test_grammar_constrained_output_is_content(self, mock_tokenizer):
+        """A grammar that starts at token one suppresses Qwen's think block."""
+        parser = Qwen3Parser(
+            mock_tokenizer,
+            structured_output_in_reasoning=True,
+        )
+        text = '{"reasoning":"</think>","tool":"<tool_call>"}'
+        reasoning, content = parser.extract_reasoning(text, None)
+        assert reasoning is None
+        assert content == text
+
     def test_multiline_reasoning(self, parser):
         text = (
             "<think>Step 1: parse.\nStep 2: compute.\nStep 3: output.</think>Result: 7."
@@ -213,6 +224,32 @@ class TestDelegatingPromptDetection:
 
 
 class TestStreaming:
+    def test_grammar_constrained_output_is_content(self, mock_tokenizer):
+        """Grammar-constrained JSON must stream in the content channel."""
+        parser = Qwen3Parser(
+            mock_tokenizer,
+            structured_output_in_reasoning=True,
+        )
+        reasoning, content = simulate_reasoning_streaming(
+            parser,
+            [
+                '{"reasoning":"',
+                "</think>",
+                '","tool":"',
+                "<tool_call>",
+                '"}',
+            ],
+            [
+                (_TEXT_ID,),
+                (_THINK_END_ID,),
+                (_TEXT_ID,),
+                (_TOOL_CALL_ID,),
+                (_TEXT_ID,),
+            ],
+        )
+        assert reasoning == ""
+        assert content == '{"reasoning":"</think>","tool":"<tool_call>"}'
+
     def test_basic_streaming(self, parser):
         reasoning, content = simulate_reasoning_streaming(
             parser,

--- a/tests/parser/engine/test_qwen3_reasoning.py
+++ b/tests/parser/engine/test_qwen3_reasoning.py
@@ -83,6 +83,17 @@ class TestNonStreaming:
         assert reasoning == "Hello, no reasoning here."
         assert content is None
 
+    def test_grammar_constrained_output_is_content(self, mock_tokenizer):
+        """A grammar that starts at token one suppresses Qwen's think block."""
+        parser = Qwen3Parser(
+            mock_tokenizer,
+            structured_output_in_reasoning=True,
+        )
+        text = '{"reasoning":"</think>","tool":"<tool_call>"}'
+        reasoning, content = parser.extract_reasoning(text, None)
+        assert reasoning is None
+        assert content == text
+
     def test_multiline_reasoning(self, parser):
         text = (
             "<think>Step 1: parse.\nStep 2: compute.\nStep 3: output.</think>Result: 7."
@@ -333,6 +344,32 @@ class TestDelegatingPromptDetection:
 
 
 class TestStreaming:
+    def test_grammar_constrained_output_is_content(self, mock_tokenizer):
+        """Grammar-constrained JSON must stream in the content channel."""
+        parser = Qwen3Parser(
+            mock_tokenizer,
+            structured_output_in_reasoning=True,
+        )
+        reasoning, content = simulate_reasoning_streaming(
+            parser,
+            [
+                '{"reasoning":"',
+                "</think>",
+                '","tool":"',
+                "<tool_call>",
+                '"}',
+            ],
+            [
+                (_TEXT_ID,),
+                (_THINK_END_ID,),
+                (_TEXT_ID,),
+                (_TOOL_CALL_ID,),
+                (_TEXT_ID,),
+            ],
+        )
+        assert reasoning == ""
+        assert content == '{"reasoning":"</think>","tool":"<tool_call>"}'
+
     def test_basic_streaming(self, parser):
         reasoning, content = simulate_reasoning_streaming(
             parser,

--- a/vllm/entrypoints/generate/api_router.py
+++ b/vllm/entrypoints/generate/api_router.py
@@ -169,6 +169,9 @@ async def init_generate_state(
         enable_log_outputs=args.enable_log_outputs,
         enable_log_deltas=args.enable_log_deltas,
         enable_per_request_metrics=args.enable_per_request_metrics,
+        structured_outputs_enable_in_reasoning=(
+            args.structured_outputs_config.enable_in_reasoning
+        ),
     )
     state.openai_serving_chat = (
         OpenAIServingChat(**_chat_kwargs) if "generate" in supported_tasks else None

--- a/vllm/entrypoints/openai/chat_completion/batch_serving.py
+++ b/vllm/entrypoints/openai/chat_completion/batch_serving.py
@@ -128,6 +128,9 @@ class OpenAIServingChatBatch(OpenAIServingChat):
                 tokenizer,
                 None,  # tools
                 chat_template_kwargs=chat_template_kwargs,
+                structured_output_in_reasoning=self._structured_output_in_reasoning(
+                    single_requests[0]
+                ),
             )
 
         render_result = await self.render_batch_chat_request(request)

--- a/vllm/entrypoints/openai/chat_completion/batch_serving.py
+++ b/vllm/entrypoints/openai/chat_completion/batch_serving.py
@@ -124,6 +124,9 @@ class OpenAIServingChatBatch(OpenAIServingChat):
                 tokenizer,
                 None,  # tools
                 chat_template_kwargs=chat_template_kwargs,
+                structured_output_in_reasoning=self._structured_output_in_reasoning(
+                    single_requests[0]
+                ),
             )
 
         render_result = await self.render_batch_chat_request(request)

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -130,6 +130,7 @@ class OpenAIServingChat(GenerateBaseServing):
         enable_log_deltas: bool = True,
         default_chat_template_kwargs: dict[str, Any] | None = None,
         enable_per_request_metrics: bool = False,
+        structured_outputs_enable_in_reasoning: bool = False,
     ) -> None:
         super().__init__(
             engine_client=engine_client,
@@ -146,6 +147,9 @@ class OpenAIServingChat(GenerateBaseServing):
         self.default_chat_template_kwargs = default_chat_template_kwargs or {}
         self.enable_log_outputs = enable_log_outputs
         self.enable_log_deltas = enable_log_deltas
+        self.structured_outputs_enable_in_reasoning = (
+            structured_outputs_enable_in_reasoning
+        )
 
         self.enable_auto_tools: bool = enable_auto_tools
         self.parser_cls = ParserManager.get_parser(
@@ -176,6 +180,15 @@ class OpenAIServingChat(GenerateBaseServing):
         # Please use the Responses API instead.
         self.supports_code_interpreter = False
         self.python_tool = None
+
+    def _structured_output_in_reasoning(self, request: ChatCompletionRequest) -> bool:
+        structured_outputs = request.extract_structured_outputs()
+        return (
+            self.structured_outputs_enable_in_reasoning
+            and not request.use_beam_search
+            and structured_outputs is not None
+            and structured_outputs.structural_tag is None
+        )
 
     def _effective_chat_template_kwargs(
         self, request: ChatCompletionRequest
@@ -248,6 +261,9 @@ class OpenAIServingChat(GenerateBaseServing):
                 request.tools,
                 chat_template_kwargs=chat_template_kwargs,
                 model_config=self.model_config,
+                structured_output_in_reasoning=self._structured_output_in_reasoning(
+                    request
+                ),
             )
         result = await self.render_chat_request(request)
         if isinstance(result, ErrorResponse):
@@ -466,6 +482,9 @@ class OpenAIServingChat(GenerateBaseServing):
                         request.tools,
                         chat_template_kwargs=chat_template_kwargs,
                         model_config=self.model_config,
+                        structured_output_in_reasoning=self._structured_output_in_reasoning(
+                            request
+                        ),
                     )
                     for _ in range(num_choices)
                 ]

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -138,6 +138,7 @@ class OpenAIServingChat(GenerateBaseServing):
         enable_log_deltas: bool = True,
         default_chat_template_kwargs: dict[str, Any] | None = None,
         enable_per_request_metrics: bool = False,
+        structured_outputs_enable_in_reasoning: bool = False,
     ) -> None:
         super().__init__(
             engine_client=engine_client,
@@ -154,6 +155,9 @@ class OpenAIServingChat(GenerateBaseServing):
         self.default_chat_template_kwargs = default_chat_template_kwargs or {}
         self.enable_log_outputs = enable_log_outputs
         self.enable_log_deltas = enable_log_deltas
+        self.structured_outputs_enable_in_reasoning = (
+            structured_outputs_enable_in_reasoning
+        )
 
         self.enable_auto_tools: bool = enable_auto_tools
         self._include_reasoning_tokens_details = bool(reasoning_parser)
@@ -185,6 +189,15 @@ class OpenAIServingChat(GenerateBaseServing):
         # Please use the Responses API instead.
         self.supports_code_interpreter = False
         self.python_tool = None
+
+    def _structured_output_in_reasoning(self, request: ChatCompletionRequest) -> bool:
+        structured_outputs = request.extract_structured_outputs()
+        return (
+            self.structured_outputs_enable_in_reasoning
+            and not request.use_beam_search
+            and structured_outputs is not None
+            and structured_outputs.structural_tag is None
+        )
 
     def _effective_chat_template_kwargs(
         self, request: ChatCompletionRequest
@@ -271,6 +284,9 @@ class OpenAIServingChat(GenerateBaseServing):
                 request.tools,
                 chat_template_kwargs=chat_template_kwargs,
                 model_config=self.model_config,
+                structured_output_in_reasoning=self._structured_output_in_reasoning(
+                    request
+                ),
             )
         result = await self.render_chat_request(request)
         if isinstance(result, ErrorResponse):
@@ -494,6 +510,9 @@ class OpenAIServingChat(GenerateBaseServing):
                         request.tools,
                         chat_template_kwargs=chat_template_kwargs,
                         model_config=self.model_config,
+                        structured_output_in_reasoning=self._structured_output_in_reasoning(
+                            request
+                        ),
                     )
                     for _ in range(num_choices)
                 ]

--- a/vllm/parser/qwen3.py
+++ b/vllm/parser/qwen3.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import functools
 import json
+from dataclasses import replace
 from typing import TYPE_CHECKING
 
 import regex as re
@@ -224,16 +225,25 @@ class Qwen3Parser(ParserEngine):
     ) -> None:
         chat_kwargs = kwargs.get("chat_template_kwargs", {}) or {}
         self.thinking_enabled = chat_kwargs.get("enable_thinking", True)
+        structured_output_in_reasoning = kwargs.pop(
+            "structured_output_in_reasoning", False
+        )
+        parser_engine_config = qwen3_config(
+            thinking=self.thinking_enabled and not structured_output_in_reasoning,
+            name=self.CONFIG_NAME,
+            think_start=self.THINK_START,
+            think_end=self.THINK_END,
+            tool_start=self.TOOL_START,
+            tool_end=self.TOOL_END,
+        )
+        if structured_output_in_reasoning:
+            parser_engine_config = replace(
+                parser_engine_config,
+                transitions={},
+            )
         kwargs.setdefault(
             "parser_engine_config",
-            qwen3_config(
-                thinking=self.thinking_enabled,
-                name=self.CONFIG_NAME,
-                think_start=self.THINK_START,
-                think_end=self.THINK_END,
-                tool_start=self.TOOL_START,
-                tool_end=self.TOOL_END,
-            ),
+            parser_engine_config,
         )
         super().__init__(
             tokenizer,

--- a/vllm/parser/qwen3.py
+++ b/vllm/parser/qwen3.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import functools
 import json
+from dataclasses import replace
 from typing import TYPE_CHECKING
 
 import regex as re
@@ -228,17 +229,26 @@ class Qwen3Parser(ParserEngine):
     ) -> None:
         chat_kwargs = kwargs.get("chat_template_kwargs", {}) or {}
         self.thinking_enabled = chat_kwargs.get("enable_thinking", True)
+        structured_output_in_reasoning = kwargs.pop(
+            "structured_output_in_reasoning", False
+        )
+        parser_engine_config = qwen3_config(
+            thinking=self.thinking_enabled and not structured_output_in_reasoning,
+            name=self.CONFIG_NAME,
+            think_start=self.THINK_START,
+            think_end=self.THINK_END,
+            tool_start=self.TOOL_START,
+            tool_end=self.TOOL_END,
+            turn_boundary_tokens=self.TURN_BOUNDARIES,
+        )
+        if structured_output_in_reasoning:
+            parser_engine_config = replace(
+                parser_engine_config,
+                transitions={},
+            )
         kwargs.setdefault(
             "parser_engine_config",
-            qwen3_config(
-                thinking=self.thinking_enabled,
-                name=self.CONFIG_NAME,
-                think_start=self.THINK_START,
-                think_end=self.THINK_END,
-                tool_start=self.TOOL_START,
-                tool_end=self.TOOL_END,
-                turn_boundary_tokens=self.TURN_BOUNDARIES,
-            ),
+            parser_engine_config,
         )
         super().__init__(
             tokenizer,


### PR DESCRIPTION
# Summary

Fixes #50948.

When `enable_in_reasoning=true` applies a JSON grammar from the first generated token to a non-structural, non-beam structured-output request, Qwen3Parser now initializes the response as assistant content rather than reasoning. Structural-tag constraints and beam-search requests retain their existing behavior. Normal thinking-enabled Qwen responses continue to preserve separate reasoning and content.

# Non-duplicate check

No open PR references #50948. The related open PR #48116 takes a different approach: it converts JSON constraints into a reasoning-aware structural-tag grammar. This fix handles the explicit `enable_in_reasoning=true` mode, where the configured JSON grammar begins at token one and the generated JSON must be classified as content.

# Tests

```text
.venv/bin/python -m pytest \
  tests/parser/engine/test_qwen3_reasoning.py \
  tests/entrypoints/openai/chat_completion/test_serving_chat.py::test_structured_output_in_reasoning \
  -v
52 passed, 20 warnings in 3.24s

.venv/bin/pre-commit run --files $(git diff --name-only origin/main...HEAD)
All applicable hooks passed, including ruff, ruff format, typos, mypy-3.10,
SPDX, forbidden-import, and configuration validation checks.

git diff --check origin/main
Passed
```

# Serving Evaluation

Built the official ROCm image from this branch for `gfx1100` and served `cyankiwi/Qwen3.6-27B-AWQ-INT4` on an AMD Radeon RX 7900 XTX with:

```text
--reasoning-parser qwen3
--structured-outputs-config.enable_in_reasoning=True
```

Both a `json_object` request and a strict `json_schema` request returned valid JSON in `choices[0].message.content` with `reasoning: null`. An unconstrained thinking-enabled control request returned separate non-empty `reasoning` and `content` fields.

# Documentation

No documentation update is required. This corrects response classification for an existing configuration without changing the public request contract.

# AI Assistance

AI assistance was used to prepare this PR.
