### PR TITLE
[Bugfix][CPU] Fix CPU build on AppleClang: constexpr std::sqrt is a GCC extension

### DIFF
--- a/csrc/cpu/sgl-kernels/fla.cpp
+++ b/csrc/cpu/sgl-kernels/fla.cpp
@@ -101,7 +101,7 @@ struct l2norm_kernel {
     using bVec = at::vec::Vectorized<scalar_t>;
     using fVec = at::vec::Vectorized<float>;
     constexpr int bVecSize = bVec::size();
-    constexpr float scale = 1.f / std::sqrt(static_cast<float>(D));
+    const float scale = 1.f / std::sqrt(static_cast<float>(D));
 
     fVec sum_fvec0(0.f), sum_fvec1(0.f);
     int d = 0;
@@ -155,7 +155,7 @@ struct l2norm_kernel<at::BFloat16, D, has_scale> {
     __m512bh va[COLS];
     __m512 vrscale;
 
-    constexpr float scale = 1.f / std::sqrt(D);
+    const float scale = 1.f / std::sqrt(D);
     __m512 vscale = _mm512_set1_ps(scale);
 
     // step 1: load input and do reduce with avx512-bf16


### PR DESCRIPTION
## Purpose

Fix the CPU backend build on macOS ARM (AppleClang). `std::sqrt` is not `constexpr` until C++26; GCC accepts it in constant expressions as a builtin extension, but AppleClang/libc++ rejects it, so `VLLM_TARGET_DEVICE=cpu` builds fail with:

```
csrc/cpu/sgl-kernels/fla.cpp:104:21: error: constexpr variable 'scale' must be initialized by a constant expression
note: non-constexpr function 'sqrt' cannot be used in a constant expression
```

Fix: `constexpr` → `const` for the two `scale` variables (fla.cpp:104, fla.cpp:158). The value is still computed once per template instantiation; nothing depends on it being a compile-time constant, so there is no behavior or performance change on GCC builds.

## Test Plan

```
VLLM_TARGET_DEVICE=cpu uv pip install -e .
python -c "import vllm; from vllm.v1.pool import late_interaction"
```

on Apple M4 (macOS 26, AppleClang 17.0.0.17000013).

## Test Result

- Before: build fails with the constexpr errors above (8 instantiations of `l2norm_kernel`).
- After: build completes and `import vllm` succeeds (0.26.1rc1.dev304+g385d4c084).
- `pre-commit run clang-format` on the file: Passed.