### PR TITLE
[Bugfix][Model] GraniteMoeHybrid: skip other ranks' weights under pipeline parallelism

### DIFF
--- a/tests/models/test_granitemoehybrid_pp_load.py
+++ b/tests/models/test_granitemoehybrid_pp_load.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""GraniteMoeHybrid weight loading under pipeline parallelism.
+
+Every rank iterates the full checkpoint, so the loader has to skip weights
+belonging to layers held by other ranks. `_load_shard`, `_load_expert` and
+`_load_quant_expert` do; `_load` did not, so the router-to-gate rename and the
+unstacked fallback raised `KeyError` on any rank that does not own layer 0.
+"""
+
+import pytest
+import torch
+
+from vllm.model_executor.models import granitemoehybrid
+from vllm.model_executor.models.granitemoehybrid import GraniteMoeHybridModel
+
+LOCAL_LAYER = "layers.20."
+REMOTE_LAYER = "layers.0."
+
+
+class _StubModel:
+    """Stands in for a PP shard owning a single layer's parameters."""
+
+    def __init__(self, params: dict[str, torch.Tensor]):
+        self._params = params
+
+    def named_parameters(self):
+        return list(self._params.items())
+
+    def get_expert_mapping(self):
+        return []
+
+
+@pytest.fixture
+def local_only_pp(monkeypatch):
+    """Report every parameter outside LOCAL_LAYER as owned by another rank."""
+    monkeypatch.setattr(
+        granitemoehybrid,
+        "is_pp_missing_parameter",
+        lambda name, model: not name.startswith(LOCAL_LAYER),
+    )
+
+
+def _load(params: dict[str, torch.Tensor], weights) -> set[str]:
+    return GraniteMoeHybridModel.load_weights(_StubModel(params), weights)
+
+
+def test_router_rename_skips_remote_layers(local_only_pp):
+    """The router-to-gate rename must not look up another rank's gate."""
+    gate = LOCAL_LAYER + "block_sparse_moe.gate.weight"
+    params = {gate: torch.zeros(4, 8)}
+    weights = [
+        (REMOTE_LAYER + "block_sparse_moe.router.layer.weight", torch.ones(4, 8)),
+        (LOCAL_LAYER + "block_sparse_moe.router.layer.weight", torch.full((4, 8), 2.0)),
+    ]
+
+    loaded = _load(params, weights)
+
+    assert loaded == {gate}
+    assert torch.equal(params[gate], torch.full((4, 8), 2.0))
+
+
+def test_unstacked_fallback_skips_remote_layers(local_only_pp):
+    """The catch-all path covers norms and mamba parameters."""
+    norm = LOCAL_LAYER + "input_layernorm.weight"
+    params = {norm: torch.zeros(8)}
+    weights = [
+        (REMOTE_LAYER + "input_layernorm.weight", torch.ones(8)),
+        (LOCAL_LAYER + "input_layernorm.weight", torch.full((8,), 3.0)),
+    ]
+
+    loaded = _load(params, weights)
+
+    assert loaded == {norm}
+    assert torch.equal(params[norm], torch.full((8,), 3.0))

--- a/vllm/model_executor/models/granitemoehybrid.py
+++ b/vllm/model_executor/models/granitemoehybrid.py
@@ -445,6 +445,9 @@ class GraniteMoeHybridModel(nn.Module):
         expert_params_mapping = self.get_expert_mapping()
 
         def _load(n, p):
+            # Skip layers on other devices.
+            if is_pp_missing_parameter(n, self):
+                return
             param = params_dict[n]
             weight_loader = getattr(param, "weight_loader", default_weight_loader)
             weight_loader(param, p)


### PR DESCRIPTION
## Purpose

Fixes #50961.

`GraniteMoeHybridForCausalLM` cannot be loaded with `pipeline_parallel_size > 1`. Every rank iterates the full checkpoint, and `GraniteMoeHybridModel.load_weights` has four load helpers of which only three skip parameters owned by another rank:

| helper | guard |
|---|---|
| `_load_shard` | `if not is_pp_missing_parameter(n, self)` |
| `_load_quant_expert` | `if is_pp_missing_parameter(name_mapped, self): continue` |
| `_load_expert` | `if n not in params_dict: return` |
| **`_load`** | **none — indexes `params_dict[n]` directly** |

So the non-first rank dies during weight loading:

```
File "vllm/model_executor/models/granitemoehybrid.py", line 561, in load_weights
  _load(gate_name, p)
File "vllm/model_executor/models/granitemoehybrid.py", line 448, in _load
  param = params_dict[n]
KeyError: 'layers.0.block_sparse_moe.gate.weight'
```

`_load` serves two paths and both break: the router-to-gate rename (above), and the unstacked fallback that covers norms, embeddings and the mamba parameters — with the gate path fixed in isolation, that one raises `KeyError: 'layers.0.input_layernorm.weight'` next.

The model declares `SupportsPP` and builds its layers through `make_layers` with `start_layer`/`end_layer`, so PP is intended to work; only the loader lacks the filter. This adds the same `is_pp_missing_parameter` guard `_load_shard` already uses.

**Not a duplicate.** `gh pr list --state open --search "50961 in:body"` is empty; searches for `granitemoehybrid`, `is_pp_missing_parameter`, `block_sparse_moe gate` and `granite load_weights pipeline` surface no PR touching this path. The nearby open Granite PRs are unrelated: #47635 changes `get_mamba_state_shape_from_config`, #44739 loads FP8_DYNAMIC expert `weight_scale` tensors, #46247 adds `get_expert_mapping` for LoRA. No issue, open or closed, reported this before #50961.

## Test Plan

New `tests/models/test_granitemoehybrid_pp_load.py` drives the real `GraniteMoeHybridModel.load_weights` against a stub shard that owns one layer's parameters, so it needs no checkpoint, no GPU and no `VllmConfig`. It covers both `_load` callers — the router-to-gate rename and the unstacked fallback — and asserts the local weight still lands (i.e. the guard skips remote parameters without also skipping local ones).

```bash
pytest tests/models/test_granitemoehybrid_pp_load.py -q
```

End-to-end, 2 GPUs:

```python
import os
os.environ["VLLM_USE_V2_MODEL_RUNNER"] = "1"
from vllm import LLM
LLM(model="ibm-granite/granite-4.0-tiny-preview", pipeline_parallel_size=2,
    max_model_len=4096, enforce_eager=True, dtype="bfloat16")
```

## Test Result

Unit tests, before the source change (stashed) and after:

```
BEFORE  FAILED test_router_rename_skips_remote_layers
          - KeyError: 'layers.0.block_sparse_moe.gate.weight'
        FAILED test_unstacked_fallback_skips_remote_layers
          - KeyError: 'layers.0.input_layernorm.weight'
        2 failed in 1.65s

AFTER   2 passed in 1.05s
```

End-to-end on 2x B200, `pipeline_parallel_size=2`: on `main` the load fails on `Worker_PP1` with the `KeyError` above and `EngineCore` never starts. That crash is what #50961 reports and what this change removes.

Lint: `ruff-check`, `ruff-format`, `typos`, `check-spdx-header`, `check-filenames`, `check-forbidden-imports`, `check-torch-cuda-call`, `check-root-lazy-imports`, and `mypy-3.12` (`--hook-stage manual`) all pass on both files.

No accuracy evaluation is included: the change only skips checkpoint entries whose target parameter does not exist on the local rank, so single-rank loading is bit-identical, and the multi-rank path had no working baseline to compare against.

## Notes

Environment: Python 3.12 with dependencies installed through `uv` in a conda-managed prefix rather than the `.venv` layout in `AGENTS.md` (no system `python` or bare `pip` involved), `VLLM_USE_PRECOMPILED=1` editable install, torch 2.13.0+cu130.

---

AI assistance disclosure: this change was developed with the assistance of Claude (Claude Code). I reviewed every changed line, ran the tests and lint myself, and confirmed the before/after behaviour on real hardware. The commit carries a `Co-authored-by` trailer.
