### PR TITLE
[Bugfix][Gemma4] Align enable_thinking default with chat template

### DIFF
--- a/tests/parser/engine/test_gemma4_turn_end.py
+++ b/tests/parser/engine/test_gemma4_turn_end.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression tests for Gemma4 streaming end-of-turn handling."""
+
+from unittest.mock import MagicMock
+
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+)
+from vllm.parser.parser_manager import ParserManager
+
+CHANNEL_START_ID = 100
+CHANNEL_END_ID = 101
+TOOL_CALL_START_ID = 48
+TOOL_CALL_END_ID = 50
+TOOL_RESPONSE_START_ID = 102
+TOOL_RESPONSE_END_ID = 103
+TURN_END_ID = 106
+REGULAR_ID = 200
+
+SPECIAL_TOKEN_MAP = {
+    CHANNEL_START_ID: "<|channel>",
+    CHANNEL_END_ID: "<channel|>",
+    TOOL_CALL_START_ID: "<|tool_call>",
+    TOOL_CALL_END_ID: "<tool_call|>",
+    TOOL_RESPONSE_START_ID: "<|tool_response>",
+    TOOL_RESPONSE_END_ID: "<tool_response|>",
+    TURN_END_ID: "<turn|>",
+}
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "noop",
+            "description": "No-op tool",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+]
+
+
+def _make_tokenizer() -> MagicMock:
+    tokenizer = MagicMock()
+    tokenizer.get_vocab.return_value = {
+        text: token_id for token_id, text in SPECIAL_TOKEN_MAP.items()
+    }
+    tokenizer.all_special_tokens = list(SPECIAL_TOKEN_MAP.values())
+    tokenizer.all_special_ids = list(SPECIAL_TOKEN_MAP)
+
+    decode_map = {
+        **SPECIAL_TOKEN_MAP,
+        REGULAR_ID: ".",
+    }
+
+    def decode(token_ids, skip_special_tokens=False):
+        return "".join(
+            ""
+            if skip_special_tokens and token_id in SPECIAL_TOKEN_MAP
+            else decode_map[token_id]
+            for token_id in token_ids
+        )
+
+    tokenizer.decode.side_effect = decode
+    return tokenizer
+
+
+def _run_stream(enable_thinking: bool | None):
+    tokenizer = _make_tokenizer()
+    parser_cls = ParserManager.get_parser(
+        reasoning_parser_name="gemma4",
+        tool_parser_name="gemma4",
+        enable_auto_tools=True,
+        model_name="gemma4",
+    )
+    assert parser_cls is not None
+
+    request = ChatCompletionRequest(
+        model="gemma4",
+        messages=[{"role": "user", "content": "replay"}],
+        tools=TOOLS,
+        tool_choice="auto",
+        stream=True,
+    )
+
+    chat_template_kwargs = (
+        {} if enable_thinking is None else {"enable_thinking": enable_thinking}
+    )
+    parser = parser_cls(
+        tokenizer,
+        tools=request.tools,
+        chat_template_kwargs=chat_template_kwargs,
+    )
+    request = parser.adjust_request(request)
+
+    prompt_token_ids = [
+        TOOL_RESPONSE_START_ID,
+        REGULAR_ID,
+        TOOL_RESPONSE_END_ID,
+    ]
+    first_delta = parser.parse_delta(
+        delta_text=".",
+        delta_token_ids=[REGULAR_ID],
+        request=request,
+        prompt_token_ids=prompt_token_ids,
+        finished=False,
+    )
+    last_delta = parser.parse_delta(
+        delta_text="",
+        delta_token_ids=[TURN_END_ID],
+        request=request,
+        prompt_token_ids=None,
+        finished=True,
+    )
+    return parser, first_delta, last_delta
+
+
+def test_template_default_routes_turn_end_to_tool_parser():
+    parser, first_delta, last_delta = _run_stream(enable_thinking=None)
+
+    assert parser.tool_parser is not None
+    assert parser._stream_state.reasoning_ended
+    assert first_delta is not None
+    assert first_delta.content == "."
+    assert last_delta is None

--- a/tests/reasoning/test_gemma4_reasoning_parser.py
+++ b/tests/reasoning/test_gemma4_reasoning_parser.py
@@ -262,6 +262,17 @@ def test_gemma4_adjust_request(generic_tokenizer):
     assert result is request
 
 
+def test_gemma4_template_default_disables_thinking(generic_tokenizer):
+    output = (
+        "<|channel>thought\n1st thought<channel|>1st content<turn|>\n"
+        "<|turn>user\nThanks<|turn>model\n"
+    )
+    output_tokens = gemma4_encode_output(generic_tokenizer, output)
+    parser_cls = ReasoningParserManager.get_reasoning_parser(parser_name)
+    parser: ReasoningParser = parser_cls(generic_tokenizer)
+    assert parser.is_reasoning_end(output_tokens)
+
+
 def test_gemma4_previous_turn_reasoning_is_reasoning_end(generic_tokenizer):
     output = (
         "<|channel>thought\n1st thought<channel|>1st content<turn|>\n"
@@ -269,7 +280,8 @@ def test_gemma4_previous_turn_reasoning_is_reasoning_end(generic_tokenizer):
     )
     output_tokens = gemma4_encode_output(generic_tokenizer, output)
     parser: ReasoningParser = ReasoningParserManager.get_reasoning_parser(parser_name)(
-        generic_tokenizer
+        generic_tokenizer,
+        chat_template_kwargs={"enable_thinking": True},
     )
     is_reasoning_end = parser.is_reasoning_end(output_tokens)
     assert not is_reasoning_end

--- a/vllm/parser/gemma4.py
+++ b/vllm/parser/gemma4.py
@@ -400,7 +400,8 @@ class Gemma4Parser(ParserEngine):
         **kwargs,
     ) -> None:
         chat_kwargs = kwargs.get("chat_template_kwargs", {}) or {}
-        self._thinking_enabled = chat_kwargs.get("enable_thinking", True)
+        # Keep the parser default aligned with tool_chat_template_gemma4.jinja.
+        self._thinking_enabled = chat_kwargs.get("enable_thinking", False)
         super().__init__(
             tokenizer,
             tools,


### PR DESCRIPTION


## Purpose

Fixes #49955.

While investigating the trailing `<turn|>` token reported in #49955, I found an `enable_thinking` default mismatch between the bundled Gemma4 tool chat template and `Gemma4Parser`:

```python
# examples/tool_chat_template_gemma4.jinja
enable_thinking | default(false)

# Gemma4Parser
chat_kwargs.get("enable_thinking", True)
```

When `enable_thinking` is omitted, the chat template renders the prompt with thinking disabled, while the parser behaves as though thinking is enabled.

In the affected streaming path, this can leave the outer delegating parser and the inner Gemma4 parser engine in different states:

```text
outer DelegatingParser:
  reasoning_ended = false
  route = reasoning parser

inner Gemma4 parser engine:
  state = CONTENT
```

The model may then produce either an empty thought channel before the final content:

```text
<|channel>thought
<channel|>
final content
```

or produce the final content directly without channel markers:

```text
final content
```

I observed both forms during actual inference.

In the empty-channel case, `<channel|>` produces a real `REASONING_END` event and happens to correct the outer parser state before the final content is emitted. In the direct-content case, no such event is produced, so the stream remains incorrectly routed through the reasoning adapter.

This PR applies the narrow fix by aligning the parser default with the bundled chat template:

```python
chat_kwargs.get("enable_thinking", False)
```

This makes the initial parser state consistent with the prompt that was actually rendered, so correct routing no longer depends on whether the model happens to generate an empty thought channel.

Explicit `enable_thinking=true` behavior is unchanged.

I also verified that applying #48748 to v0.26.0 prevents the literal `<turn|>` token from becoming user-visible in the original reproduction. However, #48748 is a generic special-token safety net: it drops the terminal token after the parser has already entered the inconsistent state. It masks the visible token leakage but does not resolve the underlying Gemma4 default and parser-state mismatch fixed here.

This PR therefore does not add Gemma4-specific `<turn|>` suppression or modify generic `__DROP__` handling.

<details>
<summary>Broader alternative considered</summary>

There is a broader possible fix: make the outer parser derive its initial reasoning state from the same open-channel check used by `adjust_initial_state_from_prompt()`.

Relative to the current commit, the production-code change would be:

```diff
diff --git a/vllm/parser/gemma4.py b/vllm/parser/gemma4.py
--- a/vllm/parser/gemma4.py
+++ b/vllm/parser/gemma4.py
@@
     def __init__(
         self,
         tokenizer,
         tools: list[Tool] | None = None,
         **kwargs,
     ) -> None:
-        chat_kwargs = kwargs.get("chat_template_kwargs", {}) or {}
-        # Keep the parser default aligned with tool_chat_template_gemma4.jinja.
-        self._thinking_enabled = chat_kwargs.get("enable_thinking", False)
         super().__init__(
             tokenizer,
             tools,
             **kwargs,
         )

@@
     def is_reasoning_end(self, input_ids: list[int]) -> bool:
-        end_id = self._reasoning_end_token_id
-        start_id = self._reasoning_start_token_id
-        tool_call_id = self._tool_call_token_id
-        new_turn_id = self._new_turn_token_id
-        tool_response_id = self._tool_response_token_id
-
-        if end_id is not None and not input_ids:
-            return self.parser_engine_config.initial_state != ParserState.REASONING
-
-        for i in range(len(input_ids) - 1, -1, -1):
-            tid = input_ids[i]
-            if start_id is not None and tid == start_id:
-                return False
-            if tool_call_id is not None and tid == tool_call_id:
-                return True
-            if new_turn_id is not None and tid == new_turn_id:
-                return not self._thinking_enabled
-            if tool_response_id is not None and tid == tool_response_id:
-                return not self._thinking_enabled
-            if end_id is not None and tid == end_id:
-                return True
-        return True
+        # Keep outer routing aligned with adjust_initial_state_from_prompt().
+        return not self._prompt_ends_in_open_reasoning(input_ids)
```

This alternative removes the outer/inner mismatch more generally, including when `enable_thinking=true`, by treating reasoning as open only when the prompt actually ends inside an unmatched `<|channel>` block.

However, it also changes the meaning of `enable_thinking` in the initial routing decision. In particular, a thinking-enabled model turn may begin without an already-open channel and then generate `<|channel>` itself. I left this broader semantic change out of the submitted commit so that maintainers can decide whether configuration or the concrete prompt state should be the authoritative source for initial routing.

</details>

## Test Plan

Run the Gemma4 reasoning parser tests and the composed reasoning/tool streaming regression tests:

```bash
python -m pytest -q \
  tests/reasoning/test_gemma4_reasoning_parser.py \
  tests/parser/engine/test_gemma4_turn_end.py
```

The regression coverage verifies that:

* the parser default matches the bundled Gemma4 chat-template default when `enable_thinking` is omitted;
* explicit `enable_thinking=true` behavior remains unchanged;
* the outer delegating parser considers reasoning complete for a prompt rendered with thinking disabled;
* the configured tool parser is dispatched;
* normal streamed content is preserved;
* the final `<turn|>` token is not returned as user-visible content.

## Test Result

```text
...............................                                          [100%]
31 passed, 14 warnings in 23.44s
```

The warnings are unrelated existing PyTorch deprecation warnings for `torch.jit.script_method`.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

* [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
* [x] The test plan, such as providing test command.
* [x] The test results, such as pasting the results comparison before and after, or e2e results.
* [x] No documentation update is required because this change aligns parser behavior with the existing bundled chat-template default.

</details>

