### PR TITLE
[compile] Remove layer_name from unified_kv_cache_update

### DIFF
--- a/tests/compile/passes/test_rocm_aiter_qk_norm_rope_kvcache_fusion.py
+++ b/tests/compile/passes/test_rocm_aiter_qk_norm_rope_kvcache_fusion.py
@@ -218,9 +218,7 @@ class QKNormRoPEKVCacheTestModel(torch.nn.Module):
         q = q.view(-1, self.num_heads, self.head_size)
         k = k.view(-1, self.num_kv_heads, self.head_size)
         v = v.view(-1, self.num_kv_heads, self.head_size)
-        kv_cache_dummy_dep = torch.ops.vllm.unified_kv_cache_update(
-            k, v, self.layer_name
-        )
+        kv_cache_dummy_dep = torch.ops.vllm.unified_kv_cache_update(k, v)
         return q, k, v, kv_cache_dummy_dep
 
     def ops_in_model_before(self) -> list[torch._ops.OpOverload]:

--- a/tests/compile/passes/test_rope_kvcache_fusion.py
+++ b/tests/compile/passes/test_rope_kvcache_fusion.py
@@ -32,7 +32,6 @@ from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.attention import attention as attention_module
 from vllm.model_executor.layers.rotary_embedding import RotaryEmbedding
 from vllm.platforms import current_platform
-from vllm.utils.torch_utils import _encode_layer_name
 from vllm.v1.attention.backend import (
     AttentionBackend,
     CommonAttentionMetadata,
@@ -48,11 +47,15 @@ def test_kv_cache_update_ops_fake_tensor_metadata(monkeypatch: pytest.MonkeyPatc
     query = torch.empty(1, dtype=torch.bfloat16)
     kv_cache = torch.empty(1, dtype=torch.uint8)
     context = (None, None, kv_cache, None)
-    monkeypatch.setattr(attention_module, "get_attention_context", lambda _: context)
-    monkeypatch.setattr(rope_kvcache_fusion, "get_attention_context", lambda _: context)
+    monkeypatch.setattr(
+        attention_module, "get_attention_context", lambda *args, **kwargs: context
+    )
+    monkeypatch.setattr(
+        rope_kvcache_fusion, "get_attention_context", lambda *args, **kwargs: context
+    )
 
-    runtime_output = attention_module.unified_kv_cache_update(query, query, "layer")
-    fake_output = attention_module.unified_kv_cache_update_fake(query, query, "layer")
+    runtime_output = attention_module.unified_kv_cache_update(query, query)
+    fake_output = attention_module.unified_kv_cache_update_fake(query, query)
     assert runtime_output.shape == fake_output.shape
     assert runtime_output.dtype == fake_output.dtype
     assert runtime_output.device == fake_output.device
@@ -212,9 +215,7 @@ class QKRoPEKVCacheTestModel(torch.nn.Module):
         q = q.view(-1, self.num_heads, self.head_size)
         k = k.view(-1, self.num_kv_heads, self.head_size)
         v = v.view(-1, self.num_kv_heads, self.head_size)
-        kv_cache_dummy_dep = torch.ops.vllm.unified_kv_cache_update(
-            k, v, _encode_layer_name(self.layer_name)
-        )
+        kv_cache_dummy_dep = torch.ops.vllm.unified_kv_cache_update(k, v)
         return q, k, v, kv_cache_dummy_dep
 
     def ops_in_model_before(self) -> list[torch._ops.OpOverload]:
@@ -257,9 +258,7 @@ class QKRoPEStaticQKVCacheTestModel(QKRoPEKVCacheTestModel):
         q = q_fp8.view(-1, self.num_heads, self.head_size)
         k = k.view(-1, self.num_kv_heads, self.head_size)
         v = v.view(-1, self.num_kv_heads, self.head_size)
-        kv_cache_dummy_dep = torch.ops.vllm.unified_kv_cache_update(
-            k, v, _encode_layer_name(self.layer_name)
-        )
+        kv_cache_dummy_dep = torch.ops.vllm.unified_kv_cache_update(k, v)
         return q, k, v, kv_cache_dummy_dep
 
     def ops_in_model_before(self) -> list[torch._ops.OpOverload]:

--- a/vllm/compilation/passes/fusion/qk_norm_rope_kvcache_fusion.py
+++ b/vllm/compilation/passes/fusion/qk_norm_rope_kvcache_fusion.py
@@ -191,7 +191,7 @@ class QkNormRopeKvCachePattern:
         q_rope = q_rope.view(-1, self.num_heads, self.head_size)
         k_rope = k_rope.view(-1, self.num_kv_heads, self.head_size)
         v = v.view(-1, self.num_kv_heads, self.head_size_v)
-        dummy = torch.ops.vllm.unified_kv_cache_update(k_rope, v, self.layer_name)
+        dummy = torch.ops.vllm.unified_kv_cache_update(k_rope, v)
         return dummy, q_rope, k_rope, v
 
     def replacement_non_fp8_quant_query(
@@ -269,7 +269,7 @@ class QkNormRopeKvCachePattern:
 
         k_rope = k_rope.view(-1, self.num_kv_heads, self.head_size)
         v = v.view(-1, self.num_kv_heads, self.head_size_v)
-        dummy = torch.ops.vllm.unified_kv_cache_update(k_rope, v, self.layer_name)
+        dummy = torch.ops.vllm.unified_kv_cache_update(k_rope, v)
         return dummy, q_rope_fp8, k_rope, v, q_scale_out
 
     def replacement_fp8_quant_query(

--- a/vllm/compilation/passes/fusion/rope_kvcache_fusion.py
+++ b/vllm/compilation/passes/fusion/rope_kvcache_fusion.py
@@ -155,9 +155,7 @@ class RopeStaticQQuantKVCachePattern:
             q_view = q_fp8.view(-1, self.num_heads, self.head_size)
             k_view = k.view(-1, self.num_kv_heads, self.head_size)
             v_view = v.view(-1, self.num_kv_heads, self.head_size_v)
-            kv_cache_dummy = torch.ops.vllm.unified_kv_cache_update(
-                k_view, v_view, layer_name
-            )
+            kv_cache_dummy = torch.ops.vllm.unified_kv_cache_update(k_view, v_view)
             return kv_cache_dummy, q_view, k_view, v_view
 
         def replacement(qkv, positions, cos_sin_cache, q_scale, layer_name):
@@ -213,7 +211,7 @@ class RopeStaticQQuantKVCachePattern:
             q_view = q_fp8.view(-1, self.num_heads, self.head_size)
             k_view = k.view(-1, self.num_kv_heads, self.head_size)
             v_view = v.view(-1, self.num_kv_heads, self.head_size_v)
-            kv_cache_dummy = torch.ops.vllm.unified_kv_cache_update(k_view, v_view, _ln)
+            kv_cache_dummy = torch.ops.vllm.unified_kv_cache_update(k_view, v_view)
             return kv_cache_dummy, q_view, k_view, v_view
 
         def replacement(qkv, positions, cos_sin_cache, q_scale):
@@ -334,7 +332,7 @@ class RopeReshapeKVCachePattern:
             q = q.view(-1, self.num_heads, self.head_size)
             k = k.view(-1, self.num_kv_heads, self.head_size)
             v = v.view(-1, self.num_kv_heads, self.head_size_v)
-            return torch.ops.vllm.unified_kv_cache_update(k, v, layer_name), q, k, v
+            return torch.ops.vllm.unified_kv_cache_update(k, v), q, k, v
 
         def replacement(qkv, positions, cos_sin_cache, layer_name):
             q, k, v = qkv.split([self.q_size, self.k_size, self.v_size], dim=-1)
@@ -364,7 +362,7 @@ class RopeReshapeKVCachePattern:
             q = q.view(-1, self.num_heads, self.head_size)
             k = k.view(-1, self.num_kv_heads, self.head_size)
             v = v.view(-1, self.num_kv_heads, self.head_size_v)
-            return torch.ops.vllm.unified_kv_cache_update(k, v, _ln), q, k, v
+            return torch.ops.vllm.unified_kv_cache_update(k, v), q, k, v
 
         def replacement(qkv, positions, cos_sin_cache):
             q, k, v = qkv.split([self.q_size, self.k_size, self.v_size], dim=-1)

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -759,6 +759,9 @@ class CompilationConfig:
     """The names of all the MOE layers in the model
     """
 
+    static_all_kv_layers: list[str] = field(default_factory=list, init=False)
+    """The names of all the attention KV layers in the model"""
+
     # Attention ops; used for piecewise cudagraphs
     # Use PyTorch operator format: "namespace::name"
     _attention_ops: ClassVar[list[str]] = [
@@ -1180,7 +1183,7 @@ class CompilationConfig:
                             "to enable QK-Norm+RoPE+KV cache fusion."
                         )
                         self.pass_config.fuse_qk_norm_rope_kvcache = False
-                    self.splitting_ops.append("vllm::unified_kv_cache_update")
+                    # self.splitting_ops.append("vllm::unified_kv_cache_update")
                     self.splitting_ops.append("vllm::unified_mla_kv_cache_update")
 
             elif len(self.splitting_ops) == 0:

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -185,6 +185,11 @@ class ForwardContext:
     all_moe_layers: list[str] | None = None
     moe_layer_index: int = 0
 
+    # For torch.compile cold start times, avoid hard-coding layer name strings
+    # in unified_kv_cache_update. See https://github.com/vllm-project/vllm/issues/33267
+    all_kv_layers: list[str] | None = None
+    kv_layer_index: int = 0
+
     additional_kwargs: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
@@ -226,9 +231,12 @@ def create_forward_context(
     else:
         all_moe_layers = None
 
+    all_kv_layers = vllm_config.compilation_config.static_all_kv_layers
+
     return ForwardContext(
         no_compile_layers=vllm_config.compilation_config.static_forward_context,
         all_moe_layers=all_moe_layers,
+        all_kv_layers=all_kv_layers,
         attn_metadata=attn_metadata,
         slot_mapping=slot_mapping or {},
         dp_metadata=dp_metadata,

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -433,6 +433,7 @@ class Attention(nn.Module, AttentionLayerBase):
         if prefix in compilation_config.static_forward_context:
             raise ValueError(f"Duplicate layer name: {prefix}")
         compilation_config.static_forward_context[prefix] = self
+        compilation_config.static_all_kv_layers.append(prefix)
         self.attn_type = attn_type
 
         if kv_sharing_target_layer_name is not None:
@@ -533,9 +534,7 @@ class Attention(nn.Module, AttentionLayerBase):
                 and key is not None
                 and value is not None
             ):
-                kv_cache_dummy_dep = unified_kv_cache_update(
-                    key, value, self.layer_name
-                )
+                kv_cache_dummy_dep = unified_kv_cache_update(key, value)
             unified_attention_with_output(
                 query,
                 key,
@@ -553,9 +552,7 @@ class Attention(nn.Module, AttentionLayerBase):
                 and key is not None
                 and value is not None
             ):
-                kv_cache_dummy_dep = torch.ops.vllm.unified_kv_cache_update(
-                    key, value, encoded
-                )
+                kv_cache_dummy_dep = torch.ops.vllm.unified_kv_cache_update(key, value)
             torch.ops.vllm.unified_attention_with_output(
                 query,
                 key,
@@ -668,7 +665,7 @@ class Attention(nn.Module, AttentionLayerBase):
 
 
 def get_attention_context(
-    layer_name: str,
+    layer_name: str | None = None,
 ) -> tuple[Any, "Attention | MLAAttention", torch.Tensor, torch.Tensor]:
     """Extract attention context for a given layer.
 
@@ -676,7 +673,8 @@ def get_attention_context(
     instance, KV cache tensor, and slot mapping for a specific layer.
 
     Args:
-        layer_name: The name/identifier of the attention layer.
+        layer_name: Optional name/identifier of the attention layer.
+            If None, retrieved dynamically from forward_context.
 
     Returns:
         A tuple containing:
@@ -690,6 +688,21 @@ def get_attention_context(
         extracted from the forward context.
     """
     forward_context: ForwardContext = get_forward_context()
+    if layer_name is None:
+        if forward_context.all_kv_layers is not None:
+            layer_name = forward_context.all_kv_layers[
+                forward_context.kv_layer_index % len(forward_context.all_kv_layers)
+            ]
+            forward_context.kv_layer_index += 1
+        else:
+            kv_layers = [
+                k
+                for k, v in forward_context.no_compile_layers.items()
+                if hasattr(v, "kv_cache")
+            ]
+            layer_name = kv_layers[forward_context.kv_layer_index % len(kv_layers)]
+            forward_context.kv_layer_index += 1
+
     attn_metadata_raw = forward_context.attn_metadata
     attn_metadata: AttentionMetadata
     if isinstance(attn_metadata_raw, dict):
@@ -713,14 +726,12 @@ def get_attention_context(
 def unified_kv_cache_update(
     key: torch.Tensor,
     value: torch.Tensor,
-    layer_name: LayerNameType,
 ) -> torch.Tensor:
     """
     Returns a dummy that is passed to unified_attention to signal a side effect and
     the data dependency between them to ensure torch.compile preserves ordering.
     """
-    layer_name = _resolve_layer_name(layer_name)
-    _, attn_layer, kv_cache, layer_slot_mapping = get_attention_context(layer_name)
+    _, attn_layer, kv_cache, layer_slot_mapping = get_attention_context()
     if layer_slot_mapping is not None:
         assert hasattr(attn_layer.impl, "do_kv_cache_update"), (
             f"{attn_layer.impl.__class__.__name__} does not support kv cache update"
@@ -739,7 +750,6 @@ def unified_kv_cache_update(
 def unified_kv_cache_update_fake(
     key: torch.Tensor,
     value: torch.Tensor,
-    layer_name: LayerNameType,
 ) -> torch.Tensor:
     return torch.empty(0, device=key.device, dtype=key.dtype)
 

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -433,7 +433,8 @@ class Attention(nn.Module, AttentionLayerBase):
         if prefix in compilation_config.static_forward_context:
             raise ValueError(f"Duplicate layer name: {prefix}")
         compilation_config.static_forward_context[prefix] = self
-        compilation_config.static_all_kv_layers.append(prefix)
+        if kv_sharing_target_layer_name is None:
+            compilation_config.static_all_kv_layers.append(prefix)
         self.attn_type = attn_type
 
         if kv_sharing_target_layer_name is not None:


### PR DESCRIPTION
## Summary
Passing `layer_name` as a string constant to `unified_kv_cache_update` forced PyTorch Dynamo to generate constant guards for every attention layer, splitting the compiled FX graph into 65 separate submodules and causing severe cold-start compilation overhead (~100s).

## Changes
- Remove `layer_name` string parameter from `unified_kv_cache_update` custom op signature.
- Track `static_all_kv_layers` in `CompilationConfig` / `ForwardContext` to sequentially resolve attention layer contexts.
- Add `hasattr(v, "kv_cache")` fallback filtering in `get_attention_context()` for hybrid models (e.g. `Qwen3.5-27B`).
- Remove `unified_kv_cache_update` from `splitting_ops`.

## Performance Impact
- Tested on `Qwen3.5-27B` (TP=4, 4x NVIDIA A100 80GB GPUs).
- Compilation Time: Reduced from **99.61s** to **87.56s** (⚡ **12.05s / 12.1% speedup**).
- Graph Compilation (1, 8192): Reduced from **67.57s** to **62.22s**.
- Zero runtime overhead; generate function verified at **17.91 toks/s**.

Ref #33267

<sub>*AI assistance was used for drafting unit test cases and code review.*</sub>