### PR TITLE
Handle unavailable ROCm GCN architecture fallback

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -194,8 +194,12 @@ def _get_gcn_arch() -> str:
         return _query_gcn_arch_from_amdsmi()
     except Exception as e:
         logger.debug("Failed to get GCN arch via amdsmi: %s", e)
-    # Ultimate fallback: use torch.cuda (will initialize CUDA)
-    return torch.cuda.get_device_properties("cuda").gcnArchName
+    try:
+        # Ultimate fallback: use torch.cuda (will initialize CUDA/HIP).
+        return torch.cuda.get_device_properties("cuda").gcnArchName
+    except Exception as e:
+        logger.debug("Failed to get GCN arch via torch.cuda: %s", e)
+        return ""
 
 
 # Resolve once at module load. Uses amdsmi (no CUDA init) so Ray workers


### PR DESCRIPTION
## Summary
- Preserve the AMDSMI GCN-architecture probe and its existing `torch.cuda` fallback.
- Catch failures from the `torch.cuda` probe and return an empty GCN architecture on non-ROCm Torch builds such as XPU.
