### PR TITLE
[Bugfix][Reasoning] Prevent Gemma4 pre-reasoning text from leaking into content

### DIFF
--- a/tests/reasoning/test_gemma4_reasoning_parser.py
+++ b/tests/reasoning/test_gemma4_reasoning_parser.py
@@ -86,7 +86,19 @@ EMPTY = {
     "content": None,
     "is_reasoning_end": True,
 }
+# Non-streaming parsing sees the complete output and can reattribute text
+# before an explicit reasoning opener. Streaming parsing cannot retroactively
+# retract a prefix that was already emitted as content.
 NEW_LINE_NONSTREAMING = {
+    "output": (
+        "Before\n<|channel>This is a reasoning section<channel|>\nThis is the rest"
+    ),
+    "reasoning": "Before\nThis is a reasoning section",
+    "content": "\nThis is the rest",
+    "is_reasoning_end": True,
+}
+
+NEW_LINE_STREAMING = {
     "output": (
         "Before\n<|channel>This is a reasoning section<channel|>\nThis is the rest"
     ),
@@ -94,12 +106,15 @@ NEW_LINE_NONSTREAMING = {
     "content": "Before\n\nThis is the rest",
     "is_reasoning_end": True,
 }
-NEW_LINE_STREAMING = {
+
+PREAMBLE_BEFORE_REASONING_NONSTREAMING = {
     "output": (
-        "Before\n<|channel>This is a reasoning section<channel|>\nThis is the rest"
+        "---\n"
+        "<|channel>thought\nActual reasoning here"
+        '<channel|>{"ok": true}'
     ),
-    "reasoning": "This is a reasoning section",
-    "content": "Before\n\nThis is the rest",
+    "reasoning": "---\nActual reasoning here",
+    "content": '{"ok": true}',
     "is_reasoning_end": True,
 }
 
@@ -156,6 +171,11 @@ TEST_CASES = [
     pytest.param(False, EMPTY, id="empty"),
     pytest.param(False, NEW_LINE_NONSTREAMING, id="new_line"),
     pytest.param(True, NEW_LINE_STREAMING, id="new_line_streaming"),
+    pytest.param(
+        False,
+        PREAMBLE_BEFORE_REASONING_NONSTREAMING,
+        id="preamble_before_reasoning",
+    ),
     pytest.param(False, THOUGHT_PREFIX, id="thought_prefix"),
     pytest.param(True, THOUGHT_PREFIX, id="thought_prefix_streaming"),
     pytest.param(False, THOUGHT_PREFIX_ONLY, id="thought_prefix_only"),

--- a/vllm/parser/gemma4.py
+++ b/vllm/parser/gemma4.py
@@ -574,10 +574,23 @@ class Gemma4Parser(ParserEngine):
         model_output: str,
         request: ChatCompletionRequest | ResponsesRequest,
     ) -> tuple[str | None, str | None]:
+        # In non-streaming mode, an explicit reasoning opener lets us
+        # identify preceding text as a reasoning preamble. Outputs without
+        # an opener remain plain content.
+        reasoning_start = model_output.find(CHANNEL_START)
+        preamble = ""
+        if reasoning_start > 0:
+            preamble = model_output[:reasoning_start]
+            model_output = model_output[reasoning_start:]
+
         reasoning, content = super().extract_reasoning(model_output, request)
         if reasoning:
             if reasoning.startswith(_GEMMA4_THOUGHT_PREFIX):
                 reasoning = reasoning[len(_GEMMA4_THOUGHT_PREFIX) :]
             elif reasoning == _GEMMA4_THOUGHT_PREFIX.rstrip():
                 reasoning = None
+
+        if preamble:
+            reasoning = preamble + (reasoning or "")
+
         return reasoning or None, content


### PR DESCRIPTION
## Purpose

Fixes #50938.

When Gemma4 emits text before an explicit `<|channel>` reasoning opener,
structured-output handling leaves that span unconstrained, while
`Gemma4Parser` returns it as user-visible `content`. As a result, a prefix
such as `---` can appear before an otherwise valid JSON object.

This PR changes non-streaming Gemma4 parsing so that text preceding an explicit
reasoning opener is attributed to `reasoning` rather than `content`.

Outputs without a reasoning opener retain the existing direct-content
behavior, and the existing `thought\n` prefix handling remains unchanged.

This fixes the attribution mismatch without modifying the chat template or
structured-output generation policy. Streaming behavior is unchanged;
supporting the same reattribution there would require buffering content until
the parser can determine whether a reasoning opener follows.

## Test Plan

```bash
python -m pytest -q \
  tests/reasoning/test_gemma4_reasoning_parser.py

python -m pytest -q \
  tests/parser/engine/test_gemma4_streaming_reasoning.py

python -m pytest -q \
  tests/tool_parsers/test_gemma4_tool_parser.py
```

Manual end-to-end validation used the reproducer and payload from #50938 with:

```bash
vllm serve nvidia/Gemma-4-26B-A4B-NVFP4 \
  --kv-cache-dtype bfloat16 \
  --reasoning-parser gemma4 \
  --gpu-memory-utilization 0.80 \
  --max-num-batched-tokens 12288 \
  --chat-template examples/tool_chat_template_gemma4.jinja
```

Environment:

- GPU: NVIDIA A100-SXM4-80GB
- Python: 3.12.3
- PyTorch: 2.13.0+cu129
- CUDA: 12.9

## Test Result

The new focused regression cases failed on the original implementation:

```text
2 failed, 1 passed
```

After the implementation:

```text
Focused regression cases:       3 passed
Gemma4 reasoning tests:        30 passed
Gemma4 streaming tests:        57 passed
Gemma4 tool parser tests:      54 passed
```

End-to-end results with reasoning enabled and
`response_format=json_schema`:

```text
Before: 4/5 runs leaked pre-reasoning text into content
After:  0/5 runs leaked pre-reasoning text into content
```

All five patched runs completed with `finish_reason=stop`. In every run,
`content` began with `{`, while the generated `---` prefix was preserved in
`reasoning`:

```text
preamble moved to reasoning: 5/5
```

The `enable_thinking=false` control retained the existing direct structured
output behavior:

```text
leak=0/1
reasoning_len=0
content_head='{\n...'
```