### PR TITLE
[Bugfix][Sampler] Keep exactly k tokens in top-k with tied logits

### DIFF
--- a/tests/v1/sample/test_topk_topp_sampler.py
+++ b/tests/v1/sample/test_topk_topp_sampler.py
@@ -355,10 +355,77 @@ class TestTritonTopkTopp:
 
         logits = torch.randn(32, 1024, generator=self.generator, dtype=torch.float32)
         logits_clone = logits.clone()
-
         result = apply_top_k_top_p_triton(logits_clone, k=None, p=None)
 
         assert torch.equal(result, logits), "Should be no-op when both k and p are None"
+
+    @pytest.mark.parametrize("num_tied", [2, 3, 5, 17])
+    def test_topk_keeps_exactly_k_with_ties(self, num_tied: int):
+        """Top-k must keep exactly k entries even when logits are tied.
+
+        A threshold comparison (`logits < kth_largest`) would keep *all* tokens
+        tied at the k-th largest logit, which can exceed k and diverge from the
+        Triton kernel. Both paths must keep exactly k entries (ties truncated),
+        matching `torch.topk` semantics.
+        """
+        from vllm.v1.sample.ops.topk_topp_triton import apply_top_k_top_p_triton
+
+        batch_size, vocab_size = 8, 64
+        k_val = 2
+        assert num_tied >= k_val
+        logits = torch.full((batch_size, vocab_size), -1.0, device=DEVICE_TYPE)
+        logits[:, :num_tied] = 10.0  # num_tied tokens tied at the top
+
+        k = torch.full((batch_size,), k_val, dtype=torch.int32, device=DEVICE_TYPE)
+
+        result_triton = apply_top_k_top_p_triton(logits.clone(), k, None)
+        result_pytorch = apply_top_k_top_p_pytorch(
+            logits.clone(), k.to(torch.long), None, allow_cpu_sync=True
+        )
+        result_pytorch_sort = apply_top_k_top_p_pytorch(
+            logits.clone(), k.to(torch.long), None, allow_cpu_sync=False
+        )
+
+        kept_triton = (result_triton != float("-inf")).sum(dim=-1)
+        kept_pytorch = (result_pytorch != float("-inf")).sum(dim=-1)
+        kept_pytorch_sort = (result_pytorch_sort != float("-inf")).sum(dim=-1)
+
+        assert torch.equal(kept_triton, kept_pytorch), (
+            f"top-k tie handling diverges: Triton kept {kept_triton.tolist()}, "
+            f"PyTorch (topk-only) kept {kept_pytorch.tolist()}"
+        )
+        assert torch.equal(kept_triton, kept_pytorch_sort), (
+            f"top-k tie handling diverges: Triton kept {kept_triton.tolist()}, "
+            f"PyTorch (sort path) kept {kept_pytorch_sort.tolist()}"
+        )
+        assert torch.equal(kept_triton, torch.full_like(kept_triton, k_val)), (
+            f"expected exactly {k_val} kept, got {kept_triton.tolist()}"
+        )
+
+    def test_topk_keeps_exactly_k_with_ties_and_topp(self):
+        """Top-k (with top-p) must keep exactly k entries when logits are tied."""
+        from vllm.v1.sample.ops.topk_topp_triton import apply_top_k_top_p_triton
+
+        batch_size, vocab_size = 8, 64
+        k_val = 2
+        num_tied = 5
+        logits = torch.full((batch_size, vocab_size), -1.0, device=DEVICE_TYPE)
+        logits[:, :num_tied] = 10.0
+
+        k = torch.full((batch_size,), k_val, dtype=torch.int32, device=DEVICE_TYPE)
+        p = torch.full((batch_size,), 0.9, dtype=torch.float32, device=DEVICE_TYPE)
+
+        result_triton = apply_top_k_top_p_triton(logits.clone(), k, p)
+        result_pytorch = apply_top_k_top_p_pytorch(
+            logits.clone(), k.to(torch.long), p, allow_cpu_sync=False
+        )
+
+        kept_triton = (result_triton != float("-inf")).sum(dim=-1)
+        kept_pytorch = (result_pytorch != float("-inf")).sum(dim=-1)
+        assert torch.equal(kept_triton, kept_pytorch), (
+            f"top_k+top_p tie handling diverges: Triton kept "
+            f"{kept_triton.tolist()}, PyTorch kept {kept_pytorch.tolist()}"
+        )
 
     def test_extreme_k_values(self):
         """Test edge cases for k values."""

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -388,11 +388,16 @@ def apply_top_k_top_p_pytorch(
     logits_sort, logits_idx = logits.sort(dim=-1, descending=False)
 
     if k is not None:
-        # Apply top-k.
-        top_k_mask = logits_sort.size(1) - k.to(torch.long)  # shape: B
-        # Get all the top_k values.
-        top_k_mask = logits_sort.gather(1, top_k_mask.unsqueeze(dim=1))
-        top_k_mask = logits_sort < top_k_mask
+        # Apply top-k. Keep exactly the k largest entries (matching the
+        # Triton kernel, which truncates tied entries to k). Using a strict
+        # threshold comparison would keep all tokens tied at the k-th largest
+        # logit, which can exceed k and diverge from the Triton path.
+        vocab_size = logits_sort.size(1)
+        k_arr = k.to(torch.long).clamp_(max=vocab_size)
+        # Positions [0, vocab_size - k) are below the top-k.
+        keep_from = (vocab_size - k_arr).unsqueeze(1)  # shape: B
+        pos = torch.arange(vocab_size, device=logits_sort.device).unsqueeze(0)
+        top_k_mask = pos < keep_from
         logits_sort.masked_fill_(top_k_mask, -float("inf"))
 
     if p is not None:
@@ -422,13 +427,17 @@ def apply_top_k_only(logits: torch.Tensor, k: torch.Tensor) -> torch.Tensor:
     # Set non-top-k rows to 1 so that we can gather.
     k = k.masked_fill(no_top_k_mask, 1)
     max_top_k = k.max()
-    # topk.values tensor has shape [batch_size, max_top_k].
-    # Convert top k to 0-based index in range [0, max_top_k).
-    k_index = k.sub_(1).unsqueeze(1)
-    top_k_mask = logits.topk(max_top_k, dim=1).values.gather(1, k_index.long())
-    # Handle non-topk rows.
-    top_k_mask.masked_fill_(no_top_k_mask.unsqueeze(1), -float("inf"))
-    return logits.masked_fill_(logits < top_k_mask, -float("inf"))
+    # Keep exactly the k largest entries. Using `topk.indices` truncates tied
+    # entries to k, matching the Triton kernel (which keeps exactly k entries).
+    # A threshold comparison would retain all tokens tied at the k-th largest
+    # logit, exceeding k.
+    topk_indices = logits.topk(max_top_k, dim=1).indices  # [B, max_top_k]
+    topk_pos = torch.arange(max_top_k, device=logits.device).unsqueeze(0)
+    keep_mask = topk_pos < k.unsqueeze(1)  # keep first k of each row
+    keep = torch.zeros_like(logits, dtype=torch.bool)
+    keep.scatter_(1, topk_indices, keep_mask)
+    keep = keep | no_top_k_mask.unsqueeze(1)
+    return logits.masked_fill_(~keep, -float("inf"))
 
 
 def empty_exponential_noise_like(


### PR DESCRIPTION
## Summary

The PyTorch top-k paths (`apply_top_k_top_p_pytorch` and `apply_top_k_only`) used a **strict threshold comparison** (`logits < k-th largest`), which keeps **all** tokens tied at the k-th largest logit — potentially more than `k` tokens. The Triton kernel keeps **exactly `k`** entries (truncating the tied group).

Because `apply_top_k_top_p` dispatches by batch size (`logits.shape[0] >= 8` → Triton, else PyTorch), the same request can produce different sampled tokens depending on whether it is run alone or in a batch of >= 8. This contradicts the project's determinism goals (`tests/v1/determinism/`).

Ties in model logits are not rare: with bf16 weights (e.g. Qwen3-0.6B), ties within the top-8 occur at a large fraction of sampled positions.

This aligns the PyTorch paths with the Triton kernel (`torch.topk` semantics: keep exactly `k`, truncate ties).

## Why this is not duplicating an existing PR

Searched GitHub for `top_k tie`, `top_k duplicate`, and related terms — no existing issue or PR covers this top-k tie-handling divergence between the PyTorch and Triton paths. The existing test `tests/v1/sample/test_topk_topp_sampler.py` asserts the paths match for random logits, where exact ties essentially never occur, so this divergence is not covered.

## Changes

- `vllm/v1/sample/ops/topk_topp_sampler.py`:
  - `apply_top_k_top_p_pytorch`: mask positions below the top-k (keep exactly `k` of the sorted logits) instead of threshold comparison.
  - `apply_top_k_only`: keep exactly the first `k` of `topk.indices` instead of threshold comparison.
- `tests/v1/sample/test_topk_topp_sampler.py`: add regression tests that construct tied logits and assert both paths keep exactly `k` entries.

## Test plan

```bash
# Before the fix, these new tests fail (Triton keeps 2, PyTorch kept 4+):
.venv/bin/python -m pytest tests/v1/sample/test_topk_topp_sampler.py -q -k "ties or exactly_k"
# -> 4 failed

# After the fix:
.venv/bin/python -m pytest tests/v1/sample/test_topk_topp_sampler.py -q
# -> 133 passed, 3 skipped
```

Full file: `128 passed, 3 skipped` before adding the new tests; `133 passed, 3 skipped` after.

Lint:
```bash
pre-commit run ruff-check --files vllm/v1/sample/ops/topk_topp_sampler.py tests/v1/sample/test_topk_topp_sampler.py  # Passed
pre-commit run ruff-format --files vllm/v1/sample/ops/topk_topp_sampler.py tests/v1/sample/test_topk_topp_sampler.py  # Passed
```

## Model evaluation

Sampling behavior for non-tied logits is unchanged (both paths already kept the same `k` entries when no ties were present at the boundary). No model weights or inference kernels were modified.

## AI assistance disclosure

This PR was developed with the assistance of an AI coding agent (opencode). All changed lines were reviewed by a human; tests were run locally as documented above.
