### PR TITLE
[Bugfix][MoE] Fall back to torch for unsupported expert counts in topk_softplus_sqrt

### DIFF
--- a/tests/kernels/moe/test_topk_softplus_sqrt.py
+++ b/tests/kernels/moe/test_topk_softplus_sqrt.py
@@ -11,6 +11,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     RoutingMethodType,
     get_routing_method_type,
 )
+from vllm.model_executor.layers.fused_moe.router import fused_topk_bias_router
 from vllm.model_executor.layers.fused_moe.router.dsv4_topk import dsv4_topk
 from vllm.model_executor.layers.fused_moe.router.fused_topk_bias_router import (
     fused_topk_bias,
@@ -125,6 +126,105 @@ def test_fused_topk_softplus_sqrt(
     sorted_w_ref = topk_weights_ref.gather(1, idx_ref)
     sorted_w = topk_weights.gather(1, idx_ops)
     torch.testing.assert_close(sorted_w_ref, sorted_w, atol=2e-2, rtol=1e-2)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="This test is skipped on non-CUDA platform.",
+)
+@pytest.mark.parametrize("num_tokens", [1, 33])
+@pytest.mark.parametrize("hidden_size", [1024])
+@pytest.mark.parametrize("num_experts", [160, 100, 200, 1000])
+@pytest.mark.parametrize("topk", [8])
+@pytest.mark.parametrize("renormalize", [True, False])
+@pytest.mark.parametrize("routed_scaling_factor", [1.0])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+def test_fused_topk_softplus_sqrt_unsupported_experts(
+    num_tokens: int,
+    hidden_size: int,
+    num_experts: int,
+    topk: int,
+    renormalize: bool,
+    routed_scaling_factor: float,
+    dtype: torch.dtype,
+):
+    """Expert counts not instantiated by the CUDA kernel (e.g. pruned/REAP
+    checkpoints with n_routed_experts=160) must fall back to the torch
+    implementation instead of crashing with "Unsupported expert number"."""
+    torch.manual_seed(0)
+    hidden_states = torch.randn((num_tokens, hidden_size), dtype=dtype, device="cuda")
+    gating_output = torch.randn((num_tokens, num_experts), dtype=dtype, device="cuda")
+    e_score_correction_bias = torch.randn(
+        (num_experts,), dtype=torch.float32, device="cuda"
+    )
+
+    topk_weights_ref, topk_ids_ref = _torch_topk_softplus_sqrt(
+        gating_output=gating_output,
+        topk=topk,
+        renormalize=renormalize,
+        routed_scaling_factor=routed_scaling_factor,
+        e_score_correction_bias=e_score_correction_bias,
+    )
+
+    topk_weights, topk_ids = fused_topk_bias(
+        hidden_states=hidden_states,
+        gating_output=gating_output,
+        scoring_func="sqrtsoftplus",
+        e_score_correction_bias=e_score_correction_bias,
+        topk=topk,
+        renormalize=renormalize,
+        routed_scaling_factor=routed_scaling_factor,
+    )
+
+    # Different kernels may return the topk experts in different orders when
+    # scores tie; sort by expert id before comparing.
+    sorted_ref_ids, idx_ref = topk_ids_ref.sort(dim=-1)
+    sorted_ids, idx_ops = topk_ids.sort(dim=-1)
+    torch.testing.assert_close(sorted_ref_ids, sorted_ids, atol=0, rtol=0)
+
+    sorted_w_ref = topk_weights_ref.gather(1, idx_ref)
+    sorted_w = topk_weights.gather(1, idx_ops)
+    torch.testing.assert_close(sorted_w_ref, sorted_w, atol=2e-5, rtol=2e-5)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="This test is skipped on non-CUDA platform.",
+)
+@pytest.mark.parametrize("num_experts", [8, 64, 256, 384])
+def test_supported_experts_use_kernel_path(num_experts: int, monkeypatch):
+    """Supported expert counts must route to the CUDA kernel, not the torch
+    fallback. This pins the Python whitelist (_SOFTPLUS_SQRT_SUPPORTED_EXPERTS)
+    to the kernel's switch: if the whitelist is missing a count the fallback is
+    called (boom fires), and if the C++ switch drops a count the kernel raises.
+    """
+
+    def boom(*args, **kwargs):
+        raise AssertionError(
+            f"num_experts={num_experts} should use the CUDA kernel, "
+            "not the torch fallback"
+        )
+
+    monkeypatch.setattr(fused_topk_bias_router, "_topk_softplus_sqrt_torch", boom)
+
+    torch.manual_seed(0)
+    hidden_states = torch.randn((1, 1024), dtype=torch.float32, device="cuda")
+    gating_output = torch.randn((1, num_experts), dtype=torch.float32, device="cuda")
+    e_score_correction_bias = torch.randn(
+        (num_experts,), dtype=torch.float32, device="cuda"
+    )
+
+    # topk=8 keeps us off the dsv4 fast path (which requires topk==6), so this
+    # exercises vllm_topk_softplus_sqrt -> CUDA kernel for supported counts.
+    fused_topk_bias(
+        hidden_states=hidden_states,
+        gating_output=gating_output,
+        scoring_func="sqrtsoftplus",
+        e_score_correction_bias=e_score_correction_bias,
+        topk=8,
+        renormalize=True,
+        routed_scaling_factor=1.0,
+    )
 
 
 @pytest.mark.skipif(

--- a/vllm/model_executor/layers/fused_moe/router/fused_topk_bias_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/fused_topk_bias_router.py
@@ -28,6 +28,15 @@ def _get_padding_mask(num_tokens: int) -> torch.Tensor | None:
     return None
 
 
+# Must stay in sync with the switch on num_experts in
+# csrc/libtorch_stable/moe/topk_softplus_sqrt_kernels.cu
+# (topkGatingSoftplusSqrtKernelLauncher): powers of two, plus multiples
+# of 64 in [192, 576]. Guarded by test_topk_softplus_sqrt.py.
+_SOFTPLUS_SQRT_SUPPORTED_EXPERTS = frozenset(
+    (1, 2, 4, 8, 16, 32, 64, 128, 192, 256, 320, 384, 448, 512, 576)
+)
+
+
 def vllm_topk_softmax(
     topk_weights: torch.Tensor,
     topk_indices: torch.Tensor,
@@ -131,33 +140,32 @@ def vllm_topk_softplus_sqrt(
 ) -> tuple[torch.Tensor, ...]:
     from vllm.platforms import current_platform
 
-    if current_platform.is_xpu():
-        return _topk_softplus_sqrt_torch(
+    n_experts = gating_output.shape[-1]
+    if not current_platform.is_xpu() and n_experts in _SOFTPLUS_SQRT_SUPPORTED_EXPERTS:
+        ops.topk_hash_softplus_sqrt(
             topk_weights,
             topk_indices,
             token_expert_indices,
             gating_output,
             renormalize,
+            routed_scaling_factor,
             e_score_correction_bias,
             input_tokens,
             hash_indices_table,
-            routed_scaling_factor,
+            is_padding=_get_padding_mask(topk_indices.shape[0]),
         )
-
-    ops.topk_hash_softplus_sqrt(
+        return topk_weights, topk_indices
+    return _topk_softplus_sqrt_torch(
         topk_weights,
         topk_indices,
         token_expert_indices,
         gating_output,
         renormalize,
-        routed_scaling_factor,
         e_score_correction_bias,
         input_tokens,
         hash_indices_table,
-        is_padding=_get_padding_mask(topk_indices.shape[0]),
+        routed_scaling_factor,
     )
-
-    return topk_weights, topk_indices
 
 
 @functools.lru_cache(maxsize=8)


### PR DESCRIPTION
## Summary

Fixes the load-time crash hit by pruned/REAP DeepSeek-V4-Flash checkpoints (e.g. `0xSero/DeepSeek-V4-Flash-0731-REAP`, `n_routed_experts=160`):

```
RuntimeError: topkGatingSoftplusSqrtKernelLauncher, topk_softplus_sqrt_kernels.cu:747, Unsupported expert number: 160
```

## Root cause

The CUDA kernel `topkGatingSoftplusSqrtKernelLauncher` (in `csrc/libtorch_stable/moe/topk_softplus_sqrt_kernels.cu`) only instantiates a fixed set of expert counts — `{1, 2, 4, 8, 16, 32, 64, 128, 192, 256, 320, 384, 448, 512, 576}` — and any other count falls into the `default:` branch, which calls `STD_TORCH_CHECK(false, "Unsupported expert number: ...")`. REAP/pruned checkpoints keep a non-instantiated `n_routed_experts` (160 for `0xSero/DeepSeek-V4-Flash-0731-REAP`), so the router kernel crashes at load.

## Fix

In `vllm_topk_softplus_sqrt` (`vllm/model_executor/layers/fused_moe/router/fused_topk_bias_router.py`), route any `gating_output.shape[-1]` outside the kernel's instantiated set to the existing `_topk_softplus_sqrt_torch` fallback — the same pure-PyTorch implementation already used for XPU. The `is_xpu` check is untouched and still first; XPU keeps its current behavior of always using the torch fallback. The supported set is a module-level `frozenset` constant with a comment pointing at the C++ switch.

## Tests

Added `test_fused_topk_softplus_sqrt_unsupported_experts` to `tests/kernels/moe/test_topk_softplus_sqrt.py`, parametrized over expert counts `[160, 100, 200, 1000]` (plus token count, renormalize, dtype), verifying:
- no crash, and
- output matches the file's existing `_torch_topk_softplus_sqrt` reference (sorted-index comparison, weight `atol=2e-5`), mirroring `test_fused_topk_softplus_sqrt`.

## Related

- Issue #50576 — this crash is documented in MidasMining's comment: the REAP checkpoint itself ships this exact fix as a runtime patch; routing non-standard counts to `_topk_softplus_sqrt_torch` in `vllm_topk_softplus_sqrt` is the in-tree equivalent.
- Issue #47141 (open, XPU/SYCL-only, adds a SYCL path for topk_softplus_sqrt) — **does not overlap**: we do not touch the `is_xpu` branch.
- PR #50759 (open, touches the same file for padding handling) — this change is additive and minimal; no conflict with the padding path.

## Verification status (honest)

- `python3 -m py_compile` passes on both changed files.
- A standalone numpy script replicating `_topk_softplus_sqrt_torch`'s math (softplus→sqrt→bias-for-selection-only→topk→renormalize→routed_scaling_factor) for a 160-expert synthetic gating output confirms finite outputs, valid top-k indices, correct renormalization, and true top-k selection.
- **CUDA test execution on A10 (sm_86)**: `tests/kernels/moe/test_topk_softplus_sqrt.py` run on vLLM release-0.26.0 with the two changed files applied — `test_fused_topk_softplus_sqrt_unsupported_experts[160/100/200/1000]` and `test_supported_experts_use_kernel_path[8/64/256/384]` all pass; the fallback matches the `_torch_topk_softplus_sqrt` reference (sorted-index comparison, weights `atol=2e-5`).

## Implementation notes

- **Single fast-path branch.** The dispatcher was restructured from the original two-branch shape (separate `is_xpu` early-return, then a whitelist check) into one condition: `not is_xpu AND num_experts in _SOFTPLUS_SQRT_SUPPORTED_EXPERTS` → CUDA kernel; everything else (including XPU and all non-instantiated counts) → the existing pure-PyTorch `_topk_softplus_sqrt_torch`. Same math, not bit-exact, slower. Semantically identical to the previous two-branch version.
- **The set is pinned by a drift guard.** New test `test_supported_experts_use_kernel_path` monkeypatches `_topk_softplus_sqrt_torch` to `boom` and asserts that supported counts `[8, 64, 256, 384]` reach the kernel. It catches both failure directions: a missing count in the Python whitelist (fallback called → boom fires) and a dropped count in the C++ switch (kernel raises "Unsupported expert number").
- **Honest perf note.** Pruned/REAP checkpoints (e.g. K160) route through the PyTorch fallback — ms-scale per routing call vs the kernel's µs-scale. This is the price of correctness until the kernel gains a 160 path; it is exactly the trade-off the reference torch implementation already carries on XPU.
- **Upstreaming the checkpoint author's runtime patch.** The REAP checkpoint ships this workaround as `runtime/patch_vllm_router_k160.py`, which hardcodes the tuple `(16, 32, 64, 128, 192, 256, 320, 384, 512)` — **not** the kernel's real set (it omits `1, 2, 4, 8, 448, 576`). This PR instead uses the kernel's actual instantiation set `{1, 2, 4, 8, 16, 32, 64, 128, 192, 256, 320, 384, 448, 512, 576}`, kept in sync by the drift-guard test above.

