### PR TITLE
improve OOM error messages for low-VRAM scenarios

### DIFF
--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -736,10 +736,13 @@ def _check_enough_kv_cache_memory(
 ):
     if available_memory <= 0:
         raise ValueError(
-            "No available memory for the cache blocks. "
-            "Try increasing `gpu_memory_utilization` when initializing the engine "
-            "(this flag also controls CPU memory reservation on the CPU "
-            "backend, despite its name). "
+            "No available memory for the cache blocks after loading model "
+            "weights. The model is likely too large for the current GPU memory "
+            "budget. Consider: "
+            "(1) using a smaller or quantized model (AWQ/GPTQ), "
+            "(2) adding --cpu-offload-gb to offload weights to CPU RAM, or "
+            "(3) increasing --gpu-memory-utilization if free GPU memory is "
+            "available. "
             "See https://docs.vllm.ai/en/latest/configuration/conserving_memory/ "
             "for more details."
         )

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -416,14 +416,19 @@ def request_memory(init_snapshot: MemorySnapshot, cache_config: CacheConfig) -> 
     )
 
     if init_snapshot.free_memory < requested_memory:
+        max_safe = init_snapshot.free_memory / init_snapshot.total_memory
         raise ValueError(
             f"Free memory on device {init_snapshot.device_} "
             f"({format_gib(init_snapshot.free_memory)}/"
             f"{format_gib(init_snapshot.total_memory)} GiB) on startup "
             f"is less than desired GPU memory utilization "
             f"({cache_config.gpu_memory_utilization}, "
-            f"{format_gib(requested_memory)} GiB). Decrease GPU memory "
-            f"utilization or reduce GPU memory used by other processes."
+            f"{format_gib(requested_memory)} GiB). "
+            f"The maximum safe value for your current free memory is "
+            f"{max_safe:.2f} (e.g. --gpu-memory-utilization "
+            f"{max_safe - 0.02:.2f}). "
+            f"Decrease GPU memory utilization or reduce GPU memory "
+            f"used by other processes."
         )
 
     return requested_memory


### PR DESCRIPTION
## What this PR does
Improves two error messages that users encounter when running vLLM on
low-VRAM GPUs (e.g. 6GB laptop GPUs, WSL2 environments).

**Change 1: `vllm/v1/worker/utils.py`**
When `gpu_memory_utilization` is set too high, the error now includes
the computed maximum safe value based on actual free memory, so users
know exactly what value to use instead of guessing.

Before:
  "Decrease GPU memory utilization or reduce GPU memory used by other processes."

After:
  "The maximum safe value for your current free memory is 0.83
   (e.g. --gpu-memory-utilization 0.81). Decrease GPU memory
   utilization or reduce GPU memory used by other processes."

**Change 2: `vllm/v1/core/kv_cache_utils.py`**
When there is zero memory left for KV cache after loading model weights,
the previous message said "Try increasing gpu_memory_utilization" — which
is misleading because the model itself is too large and increasing
utilization would just trigger the error above. The new message explains
the real cause and suggests actionable alternatives.

## Why this is not a duplicate
Searched open issues and PRs. Related issues (#47292, #50261) address
the UVA/pinned-memory error on WSL2, not the error message quality for
these two OOM scenarios.

## Test
Verified both error messages manually on WSL2 with RTX 1000 Ada (6GB):
- Change 1: `--gpu-memory-utilization 0.95` on a 6GB GPU → new message
  shows suggested value 0.83
- Change 2: `Qwen2.5-3B` + `--gpu-memory-utilization 0.75` on 6GB GPU
  → new message shows actionable alternatives