### PR TITLE
[Quantization][AutoRound] Add NVFP4 linear support

### DIFF
--- a/tests/quantization/test_auto_round.py
+++ b/tests/quantization/test_auto_round.py
@@ -23,6 +23,7 @@ from vllm.model_executor.layers.quantization.inc.inc_linear import INCLinearMeth
 from vllm.model_executor.layers.quantization.inc.schemes import (
     INCMxfp4Scheme,
     INCMxfp8Scheme,
+    INCNvfp4Scheme,
     INCWna16Scheme,
     resolve_scheme,
 )
@@ -450,6 +451,16 @@ def test_inc_layer_config_mx_fp_helpers() -> None:
     assert layer_config.is_mxfp8 is False
 
 
+def test_inc_layer_config_nv_fp_helpers() -> None:
+    layer_config = make_layer_config(
+        group_size=16,
+        data_type="nv_fp4_with_static_gs",
+    )
+
+    assert layer_config.is_nvfp4 is True
+    assert layer_config.is_mxfp4 is False
+
+
 def test_inc_resolve_scheme_selects_wna16() -> None:
     layer_config = INCLayerConfig(
         bits=4,
@@ -485,6 +496,95 @@ def test_inc_config_accepts_mxfp_family_llm_compressor() -> None:
     assert config.sym is True
     assert layer_config.is_mxfp4 is True
     assert isinstance(resolve_scheme(layer_config), INCMxfp4Scheme)
+
+
+def test_inc_config_accepts_nvfp4_family_llm_compressor() -> None:
+    config = INCConfig.from_config(
+        {
+            "quant_method": "auto-round",
+            "bits": 4,
+            "group_size": 16,
+            "sym": True,
+            "packing_format": "auto_round:llm_compressor",
+            "data_type": "nv_fp",
+            "act_bits": 4,
+            "act_group_size": 16,
+            "act_data_type": "nv_fp4_with_static_gs",
+            "act_dynamic": True,
+        }
+    )
+
+    layer_config = config.config_parser.resolve(
+        DummyLayer(), "model.layers.0.mlp.down_proj"
+    )
+
+    assert config.is_nvfp4 is True
+    assert layer_config.is_nvfp4 is True
+    assert isinstance(resolve_scheme(layer_config), INCNvfp4Scheme)
+
+
+def test_inc_nvfp4_linear_method_registers_and_processes_weights(
+    monkeypatch,
+) -> None:
+    captured = {}
+
+    class DummyKernel:
+        def input_quant_key(self):
+            return None
+
+        def process_weights_after_loading(self, layer) -> None:
+            captured["processed_layer"] = layer
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.inc.schemes."
+        "inc_nvfp4_linear.init_nvfp4_linear_kernel",
+        lambda: DummyKernel(),
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.parameter.get_tensor_model_parallel_rank",
+        lambda: 0,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.parameter.get_tensor_model_parallel_world_size",
+        lambda: 1,
+    )
+
+    from vllm.model_executor.layers.quantization.inc.schemes.inc_nvfp4_linear import (  # noqa: E501
+        INCNvfp4LinearMethod,
+    )
+
+    layer = torch.nn.Module()
+    method = INCNvfp4LinearMethod(make_layer_config(group_size=16, data_type="nv_fp"))
+    method.create_weights(
+        layer,
+        input_size_per_partition=64,
+        output_partition_sizes=[16, 32],
+        input_size=64,
+        output_size=48,
+        params_dtype=torch.bfloat16,
+    )
+
+    assert layer.weight_packed.shape == (48, 32)
+    assert layer.weight_packed.dtype is torch.uint8
+    assert layer.weight_scale.shape == (48, 4)
+    assert layer.weight_scale.dtype is torch.float8_e4m3fn
+    assert layer.weight_global_scale.shape == (2,)
+    assert layer.input_global_scale.shape == (2,)
+    assert layer.weight_global_scale.needs_scalar_to_array is True
+    assert layer.input_global_scale.needs_scalar_to_array is True
+
+    layer.weight_global_scale.data.copy_(torch.tensor([0.25, 0.25]))
+    layer.input_global_scale.data.copy_(torch.tensor([0.5, 0.5]))
+    packed_data = layer.weight_packed.data
+    method.process_weights_after_loading(layer)
+
+    assert layer.weight.data.data_ptr() == packed_data.data_ptr()
+    assert not hasattr(layer, "weight_packed")
+    torch.testing.assert_close(layer.weight_global_scale, torch.tensor(4.0))
+    torch.testing.assert_close(layer.input_global_scale, torch.tensor(2.0))
+    torch.testing.assert_close(layer.alpha, torch.tensor(8.0))
+    torch.testing.assert_close(layer.input_global_scale_inv, torch.tensor(0.5))
+    assert captured["processed_layer"] is layer
 
 
 def test_qwen3_1p7b_mxfp4_autoround_uses_mxfp4_linear_scheme(

--- a/vllm/model_executor/layers/quantization/inc/config_parser.py
+++ b/vllm/model_executor/layers/quantization/inc/config_parser.py
@@ -44,6 +44,10 @@ class INCLayerConfig:
     def is_mxfp8(self) -> bool:
         return "mx_fp" in self.data_type and self.bits == 8
 
+    @property
+    def is_nvfp4(self) -> bool:
+        return "nv_fp" in self.data_type and self.bits == 4
+
 
 class INCConfigParser:
     def __init__(self, config: "INCConfig") -> None:

--- a/vllm/model_executor/layers/quantization/inc/inc.py
+++ b/vllm/model_executor/layers/quantization/inc/inc.py
@@ -35,7 +35,7 @@ class INCConfig(QuantizationConfig):
     """
 
     SUPPORTED_BITS = {2, 3, 4, 8}
-    SUPPORTED_DTYPES = {"int", "mx_fp"}
+    SUPPORTED_DTYPES = {"int", "mx_fp", "nv_fp"}
     SUPPORTED_FORMATS = {
         "auto_round:auto_gptq",
         "auto_round:auto_awq",
@@ -54,6 +54,10 @@ class INCConfig(QuantizationConfig):
     MXFP8_DATA_TYPE = "mx_fp"
     MXFP8_PACKING_FORMAT = "auto_round:llm_compressor"
     MXFP8_SUPPORTED_ACT_DTYPES = {"mx_fp", "mx_fp_rceil"}
+    NVFP4_BITS = 4
+    NVFP4_GROUP_SIZE = 16
+    NVFP4_ACT_DATA_TYPE = "nv_fp4_with_static_gs"
+    NVFP4_PACKING_FORMAT = "auto_round:llm_compressor"
 
     def __init__(
         self,
@@ -72,10 +76,9 @@ class INCConfig(QuantizationConfig):
                 f"Unsupported weight_bits: {weight_bits}, "
                 f"currently only support {self.SUPPORTED_BITS}."
             )
-        # auto-round mxfp data_type is e.g. "mx_fp4" / "mx_fp4e2m1"; match the
-        # "mx_fp" family by substring like auto_round.compressors.is_mx_fp.
         is_mxfp = "mx_fp" in data_type
-        if data_type not in self.SUPPORTED_DTYPES and not is_mxfp:
+        is_nvfp = "nv_fp" in data_type
+        if data_type not in self.SUPPORTED_DTYPES and not (is_mxfp or is_nvfp):
             raise ValueError(
                 f"Unsupported data_type: {data_type}, "
                 f"currently only support {self.SUPPORTED_DTYPES}."
@@ -125,6 +128,10 @@ class INCConfig(QuantizationConfig):
         # MXFP4 and MXFP8 share data_type "mx_fp" and differ only by bit width.
         return self.is_mxfp and self.weight_bits == self.MXFP8_BITS
 
+    @property
+    def is_nvfp4(self) -> bool:
+        return "nv_fp" in self.data_type and self.weight_bits == self.NVFP4_BITS
+
     def _validate_supported_quantization(self) -> None:
         if self.is_mxfp8:
             assert self.group_size == self.MXFP8_GROUP_SIZE, (
@@ -141,29 +148,57 @@ class INCConfig(QuantizationConfig):
                 "INC MXFP8 only supports backend='auto', "
                 f"but found backend={self.backend!r}."
             )
-        elif self.packing_format == self.MXFP8_PACKING_FORMAT and not self.is_mxfp:
+        elif self.is_nvfp4:
+            assert self.group_size == self.NVFP4_GROUP_SIZE, (
+                "INC NVFP4 only supports group_size=16, "
+                f"but found group_size={self.group_size}."
+            )
+            assert self.sym, "INC NVFP4 only supports symmetric weights."
+            assert self.packing_format == self.NVFP4_PACKING_FORMAT, (
+                "INC NVFP4 only supports "
+                f"packing_format={self.NVFP4_PACKING_FORMAT!r}, "
+                f"but found {self.packing_format!r}."
+            )
+            assert self.backend == "auto", (
+                "INC NVFP4 only supports backend='auto', "
+                f"but found backend={self.backend!r}."
+            )
+        elif self.packing_format == self.MXFP8_PACKING_FORMAT and not (
+            self.is_mxfp or self.is_nvfp4
+        ):
             raise ValueError(
                 f"packing_format={self.MXFP8_PACKING_FORMAT!r} requires "
-                f"an {self.MXFP8_DATA_TYPE!r} data_type."
+                "an MXFP or NVFP data type."
             )
 
     def _validate_raw_config(self, config: dict[str, Any]) -> None:
-        if not self.is_mxfp8:
+        if self.is_nvfp4:
+            expected_fields = {
+                "act_bits": self.NVFP4_BITS,
+                "act_data_type": self.NVFP4_ACT_DATA_TYPE,
+                "act_group_size": self.NVFP4_GROUP_SIZE,
+                "act_sym": True,
+                "act_dynamic": True,
+                "enable_quanted_input": False,
+            }
+            error_prefix = "INC NVFP4 only supports "
+        elif self.is_mxfp8:
+            expected_fields = {
+                "act_bits": self.MXFP8_BITS,
+                "act_data_type": self.MXFP8_DATA_TYPE,
+                "act_group_size": self.MXFP8_GROUP_SIZE,
+                "act_sym": True,
+                "act_dynamic": True,
+                "enable_quanted_input": False,
+            }
+            error_prefix = "INC MXFP8 only supports "
+        else:
             return
 
-        expected_fields = {
-            "act_bits": self.MXFP8_BITS,
-            "act_data_type": self.MXFP8_DATA_TYPE,
-            "act_group_size": self.MXFP8_GROUP_SIZE,
-            "act_sym": True,
-            "act_dynamic": True,
-            "enable_quanted_input": False,
-        }
         for field_name, expected_value in expected_fields.items():
             actual_value = self.get_from_keys_or(config, [field_name], expected_value)
             assert actual_value == expected_value, (
-                "INC MXFP8 only supports "
-                f"{field_name}={expected_value!r}, "
+                error_prefix + f"{field_name}={expected_value!r}, "
                 f"but found {field_name}={actual_value!r}."
             )
 

--- a/vllm/model_executor/layers/quantization/inc/schemes/__init__.py
+++ b/vllm/model_executor/layers/quantization/inc/schemes/__init__.py
@@ -4,6 +4,7 @@
 from .factory import resolve_scheme
 from .inc_mxfp4_scheme import INCMxfp4Scheme
 from .inc_mxfp8_scheme import INCMxfp8Scheme
+from .inc_nvfp4_scheme import INCNvfp4Scheme
 from .inc_scheme import INCLinearScheme, INCScheme
 from .inc_wna16_scheme import INCWna16Scheme
 
@@ -11,6 +12,7 @@ __all__ = [
     "INCScheme",
     "INCLinearScheme",
     "INCMxfp8Scheme",
+    "INCNvfp4Scheme",
     "INCWna16Scheme",
     "INCMxfp4Scheme",
     "resolve_scheme",

--- a/vllm/model_executor/layers/quantization/inc/schemes/factory.py
+++ b/vllm/model_executor/layers/quantization/inc/schemes/factory.py
@@ -11,12 +11,14 @@ if TYPE_CHECKING:
 def resolve_scheme(layer_config: "INCLayerConfig") -> "INCScheme":
     from .inc_mxfp4_scheme import INCMxfp4Scheme
     from .inc_mxfp8_scheme import INCMxfp8Scheme
+    from .inc_nvfp4_scheme import INCNvfp4Scheme
     from .inc_wna16_scheme import INCWna16Scheme
 
     scheme_list: list[type[INCScheme]] = [
         INCMxfp8Scheme,
         INCWna16Scheme,
         INCMxfp4Scheme,
+        INCNvfp4Scheme,
     ]
 
     for scheme_cls in scheme_list:

--- a/vllm/model_executor/layers/quantization/inc/schemes/inc_nvfp4_linear.py
+++ b/vllm/model_executor/layers/quantization/inc/schemes/inc_nvfp4_linear.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import TYPE_CHECKING, Any
+
+import torch
+from torch.nn.parameter import Parameter
+
+from vllm.logger import init_logger
+from vllm.model_executor.kernels.linear import init_nvfp4_linear_kernel
+from vllm.model_executor.layers.fusion.quant_activation import (
+    expose_input_quant_key,
+)
+from vllm.model_executor.parameter import (
+    GroupQuantScaleParameter,
+    ModelWeightParameter,
+    PerTensorScaleParameter,
+)
+
+from .inc_scheme import INCLinearScheme
+
+if TYPE_CHECKING:
+    from ..config_parser import INCLayerConfig
+
+logger = init_logger(__name__)
+
+
+class INCNvfp4LinearMethod(INCLinearScheme):
+    """NVFP4 (W4A4) linear method for native AutoRound checkpoints.
+
+    AutoRound stores packed E2M1 weights, per-group FP8-E4M3 scales, and
+    reciprocal global scales for weights and activations.
+    """
+
+    def __init__(self, layer_config: "INCLayerConfig") -> None:
+        self.group_size = layer_config.group_size or 16
+        self.kernel = init_nvfp4_linear_kernel()
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return 75
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs: Any,
+    ) -> None:
+        del input_size, output_size
+        if input_size_per_partition % self.group_size != 0:
+            raise ValueError(
+                "NVFP4 requires the input size per partition to be "
+                f"a multiple of {self.group_size}."
+            )
+
+        output_size_per_partition = sum(output_partition_sizes)
+        weight_loader = extra_weight_attrs.get("weight_loader")
+        layer.logical_widths = output_partition_sizes
+        layer.input_size_per_partition = input_size_per_partition
+        layer.output_size_per_partition = output_size_per_partition
+        layer.params_dtype = params_dtype
+
+        weight = ModelWeightParameter(
+            data=torch.empty(
+                output_size_per_partition,
+                input_size_per_partition // 2,
+                dtype=torch.uint8,
+            ),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("weight_packed", weight)
+
+        weight_scale = GroupQuantScaleParameter(
+            data=torch.empty(
+                output_size_per_partition,
+                input_size_per_partition // self.group_size,
+                dtype=torch.float8_e4m3fn,
+            ),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("weight_scale", weight_scale)
+
+        weight_global_scale = PerTensorScaleParameter(
+            data=torch.empty(len(output_partition_sizes), dtype=torch.float32),
+            weight_loader=weight_loader,
+        )
+        weight_global_scale.needs_scalar_to_array = True
+        layer.register_parameter("weight_global_scale", weight_global_scale)
+
+        input_global_scale = PerTensorScaleParameter(
+            data=torch.empty(len(output_partition_sizes), dtype=torch.float32),
+            weight_loader=weight_loader,
+        )
+        input_global_scale.needs_scalar_to_array = True
+        layer.register_parameter("input_global_scale", input_global_scale)
+
+        expose_input_quant_key(layer, self.kernel)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if (
+            torch.unique(layer.input_global_scale).numel() != 1
+            or torch.unique(layer.weight_global_scale).numel() != 1
+        ):
+            logger.warning_once(
+                "In AutoRound NVFP4 linear, global scales differ across fused "
+                "parallel layers. This may reduce accuracy; consider using a "
+                "checkpoint with shared global scales."
+            )
+
+        layer.weight = Parameter(layer.weight_packed.data, requires_grad=False)
+        del layer.weight_packed
+        input_global_scale_inv = layer.input_global_scale.max().to(torch.float32)
+        weight_global_scale_inv = layer.weight_global_scale.max().to(torch.float32)
+        layer.input_global_scale = Parameter(
+            1.0 / input_global_scale_inv, requires_grad=False
+        )
+        layer.weight_global_scale = Parameter(
+            1.0 / weight_global_scale_inv, requires_grad=False
+        )
+        layer.alpha = Parameter(
+            layer.input_global_scale * layer.weight_global_scale,
+            requires_grad=False,
+        )
+        layer.input_global_scale_inv = Parameter(
+            input_global_scale_inv, requires_grad=False
+        )
+
+        self.kernel.process_weights_after_loading(layer)
+
+    def apply_weights(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        return self.kernel.apply_weights(layer, x, bias)

--- a/vllm/model_executor/layers/quantization/inc/schemes/inc_nvfp4_scheme.py
+++ b/vllm/model_executor/layers/quantization/inc/schemes/inc_nvfp4_scheme.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import TYPE_CHECKING
+
+from ..inc_linear import INCLinearMethod
+from .inc_scheme import INCScheme
+
+if TYPE_CHECKING:
+    import torch
+
+    from ..config_parser import INCLayerConfig
+    from ..inc import INCConfig
+
+
+class INCNvfp4Scheme(INCScheme):
+    """NVFP4 (W4A4) scheme for AutoRound checkpoints."""
+
+    @staticmethod
+    def can_handle(layer_config: "INCLayerConfig") -> bool:
+        return layer_config.is_nvfp4
+
+    def get_linear_method(
+        self,
+        config: "INCConfig",
+        layer: "torch.nn.Module",
+        prefix: str,
+        layer_config: "INCLayerConfig",
+    ):
+        del config, layer, prefix
+        from .inc_nvfp4_linear import INCNvfp4LinearMethod
+
+        return INCLinearMethod(INCNvfp4LinearMethod(layer_config))


### PR DESCRIPTION
Supports deployment of AutoRound-format NVFP4 W4A4 quantized models with dense linear layers on CUDA. This PR intentionally covers linear layers only; NVFP4 MoE support will be submitted separately.

### NVFP4 dense on CUDA

`vllm ({'pretrained': 'Qwen3-8B-AutoRound-NVFP4', 'tensor_parallel_size': 1}), gen_kwargs: ({}), limit: None, num_fewshot: 0, batch_size: auto`

|Tasks|Version|Filter|n-shot|Metric|||Value|Stderr|
|-----|------:|------|-----:|------|---|---:|----:|-----:|
|piqa|1|none|0|acc|↑|0.7655|±|0.0099|
|||none|0|acc_norm|↑|0.7715|±|0.0097|

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8688|±  |0.0093|
|     |       |strict-match    |     5|exact_match|↑  |0.8643|±  |0.0094|

