### PR TITLE
[Bugfix][Multimodal] Validate dynamic video sampling metadata

### DIFF
--- a/tests/multimodal/test_dynamic_video_sampling.py
+++ b/tests/multimodal/test_dynamic_video_sampling.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.multimodal.video import (
+    DynamicVideoBackend,
+    VideoSourceMetadata,
+    VideoTargetMetadata,
+)
+
+pytestmark = [pytest.mark.cpu_test, pytest.mark.skip_global_cleanup]
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        VideoSourceMetadata(total_frames_num=0, original_fps=30, duration=1),
+        VideoSourceMetadata(total_frames_num=10, original_fps=0, duration=1),
+        VideoSourceMetadata(total_frames_num=10, original_fps=30, duration=0),
+    ],
+)
+def test_dynamic_video_sampling_rejects_invalid_source_metadata(
+    source: VideoSourceMetadata,
+):
+    target = VideoTargetMetadata(num_frames=-1, fps=1, max_duration=10)
+
+    with pytest.raises(ValueError, match="video .*metadata"):
+        DynamicVideoBackend.compute_frames_index_to_sample(source, target)
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        VideoTargetMetadata(num_frames=-1, fps=0, max_duration=10),
+        VideoTargetMetadata(num_frames=-1, fps=1, max_duration=0),
+    ],
+)
+def test_dynamic_video_sampling_rejects_invalid_target_metadata(
+    target: VideoTargetMetadata,
+):
+    source = VideoSourceMetadata(total_frames_num=10, original_fps=30, duration=1)
+
+    with pytest.raises(ValueError, match="video .*metadata"):
+        DynamicVideoBackend.compute_frames_index_to_sample(source, target)
+
+
+def test_dynamic_video_sampling_keeps_one_frame_for_short_video():
+    source = VideoSourceMetadata(total_frames_num=10, original_fps=30, duration=0.1)
+    target = VideoTargetMetadata(num_frames=-1, fps=1, max_duration=10)
+
+    assert DynamicVideoBackend.compute_frames_index_to_sample(source, target) == [0]

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -1359,6 +1359,27 @@ class DynamicVideoBackend(VideoBackend):
     _sampling_suffix: ClassVar[str] = "_dynamic"
 
     @classmethod
+    def _validate_sampling_metadata(
+        cls,
+        source: VideoSourceMetadata,
+        target: VideoTargetMetadata,
+    ) -> None:
+        if source.total_frames_num <= 0:
+            raise ValueError(
+                "video source metadata must include a positive frame count"
+            )
+        if source.original_fps <= 0:
+            raise ValueError("video source metadata must include a positive fps")
+        if source.duration <= 0:
+            raise ValueError("video source metadata must include a positive duration")
+        if target.fps <= 0:
+            raise ValueError("video target metadata must include a positive fps")
+        if target.max_duration <= 0:
+            raise ValueError(
+                "video target metadata must include a positive max duration"
+            )
+
+    @classmethod
     def _prepare_source(cls, source: VideoSourceMetadata) -> VideoSourceMetadata:
         # Estimate duration from frame count and fps when the container
         # does not report it (common for WebM/streaming inputs).
@@ -1380,6 +1401,7 @@ class DynamicVideoBackend(VideoBackend):
         target: VideoTargetMetadata,
         **kwargs,
     ) -> list[int]:
+        cls._validate_sampling_metadata(source, target)
         total_frames_num = source.total_frames_num
         duration = source.duration
         original_fps = source.original_fps
@@ -1391,7 +1413,7 @@ class DynamicVideoBackend(VideoBackend):
         # https://github.com/huggingface/transformers/blob/v4.55.4/src/transformers/models/glm4v/video_processing_glm4v.py#L103-L140
         frame_indices_list: list[int]
         if duration <= max_duration:
-            n = int(math.floor(duration * fps))
+            n = max(1, int(math.floor(duration * fps)))
             frame_indices_list = sorted(
                 {
                     min(max_frame_idx, int(math.ceil(i * original_fps / fps)))
@@ -1399,7 +1421,7 @@ class DynamicVideoBackend(VideoBackend):
                 }
             )
         else:
-            num_samples = int(max_duration * fps)
+            num_samples = max(1, int(max_duration * fps))
             if num_samples >= total_frames_num:
                 frame_indices_list = list(range(total_frames_num))
             else:


### PR DESCRIPTION
## Summary
- Reject non-positive dynamic video sampling metadata before computing frame indices.
- Keep valid ultra-short videos from producing an empty frame-index list.
- Add lightweight CPU regression tests for invalid source metadata, invalid target metadata, and short positive-duration sampling.

Fixes #48332

## Duplicate / overlap check
- No open PR references #48332.
- #48331 attempted the same issue but is closed and unmerged.

## Test Plan
- `pytest tests/multimodal/test_dynamic_video_sampling.py -q`
- `python -m ruff check vllm/multimodal/video.py tests/multimodal/test_dynamic_video_sampling.py`
- `python -m py_compile vllm/multimodal/video.py tests/multimodal/test_dynamic_video_sampling.py`
- `git diff --cached --check`