### PR TITLE
[Doc] Clarify batch invariance Ampere support

### DIFF
--- a/docs/features/batch_invariance.md
+++ b/docs/features/batch_invariance.md
@@ -19,6 +19,12 @@ Batch invariance is crucial for several use cases:
 
 Batch invariance requires NVIDIA GPUs with compute capability 8.0 or higher.
 
+!!! note
+    Current releases support Ampere and newer NVIDIA GPUs for batch invariance.
+    If you are reading older vLLM v0.20.0-v0.22.0 documentation that says
+    compute capability 9.0 or higher is required, use the 8.0+ requirement
+    shown here instead.
+
 ## Enabling Batch Invariance
 
 Batch invariance can be enabled by setting the `VLLM_BATCH_INVARIANT` environment variable to `1`:


### PR DESCRIPTION
## Summary
- Add a hardware requirements note clarifying that current batch invariance support starts at NVIDIA compute capability 8.0.
- Point readers of older v0.20.0-v0.22.0 docs away from the stale 9.0+ requirement.

Fixes #48875

## Duplicate / overlap check
- No open PR references #48875.

## Test Plan
- `git diff --check`
- `pre-commit run markdownlint-cli2 --files docs/features/batch_invariance.md`
- Local doc assertions for 8.0+, the historical v0.20.0-v0.22.0 note, and Ampere wording