### PR TITLE
[Doc] Clarify Docker image tag availability

### DIFF
--- a/docs/getting_started/installation/gpu.cuda.inc.md
+++ b/docs/getting_started/installation/gpu.cuda.inc.md
@@ -262,6 +262,13 @@ uv pip install -e .
 vLLM offers an official Docker image for deployment.
 The image can be used to run OpenAI compatible server and is available on Docker Hub as [vllm/vllm-openai](https://hub.docker.com/r/vllm/vllm-openai/tags).
 
+!!! note
+    Docker Hub's tag list is the source of truth for published image tags.
+    Model-specific or CUDA-variant tags mentioned by recipes may not exist for
+    every model and CUDA version. If a recipe tag is unavailable, use a published
+    generic tag such as `latest`, `nightly`, or a released `vX.Y.Z` tag, and pass
+    the target model with `--model`.
+
 ```bash
 docker run --runtime nvidia --gpus all \
     -v ~/.cache/huggingface:/root/.cache/huggingface \


### PR DESCRIPTION
## Summary
- Clarify that Docker Hub is the source of truth for published `vllm/vllm-openai` tags.
- Note that model-specific or CUDA-variant recipe tags may not exist for every model/version.
- Suggest using a published generic tag such as `latest`, `nightly`, or a release tag and passing the target model with `--model` when a recipe tag is unavailable.

Refs #50102

## Duplicate / overlap check
- No open PR references #50102.

## Validation
- Docker Hub API probe: `kimi-k3-cu129` returned 404, while `latest` and `nightly` returned 200.
- `git diff --check`
- `pre-commit run markdownlint-cli2 --files docs/getting_started/installation/gpu.cuda.inc.md`
- Local doc assertions for Docker Hub tag source-of-truth wording and preserved Docker command example