### PR TITLE
[Bugfix][Frontend] Handle malformed Anthropic tool arguments

### DIFF
--- a/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
+++ b/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
@@ -13,6 +13,7 @@ Also covers cache usage computation in ``_build_anthropic_usage``.
 """
 
 import json
+import logging
 from argparse import Namespace
 from http import HTTPStatus
 from unittest.mock import MagicMock
@@ -41,7 +42,9 @@ from vllm.entrypoints.openai.engine.protocol import (
     DeltaFunctionCall,
     DeltaMessage,
     DeltaToolCall,
+    FunctionCall,
     PromptTokenUsageInfo,
+    ToolCall,
     UsageInfo,
 )
 from vllm.entrypoints.serve.utils.server_utils import validation_exception_handler
@@ -1372,6 +1375,32 @@ def _make_full_converter():
 
 
 class TestMessagesFullConverter:
+    @staticmethod
+    def _response_with_tool_arguments(arguments: str) -> ChatCompletionResponse:
+        return ChatCompletionResponse(
+            id="chatcmpl-tool",
+            model="test-model",
+            choices=[
+                ChatCompletionResponseChoice(
+                    index=0,
+                    message=ChatMessage(
+                        role="assistant",
+                        tool_calls=[
+                            ToolCall(
+                                id="call_1",
+                                function=FunctionCall(
+                                    name="lookup",
+                                    arguments=arguments,
+                                ),
+                            )
+                        ],
+                    ),
+                    finish_reason="tool_calls",
+                )
+            ],
+            usage=UsageInfo(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        )
+
     def test_empty_completion_emits_one_text_block(self):
         """An empty completion still yields exactly one (empty) text block."""
         generator = ChatCompletionResponse(
@@ -1392,6 +1421,34 @@ class TestMessagesFullConverter:
         assert len(result.content) == 1
         assert result.content[0].type == "text"
         assert result.content[0].text == ""
+
+    def test_tool_use_preserves_object_arguments(self):
+        generator = self._response_with_tool_arguments('{"query":"weather"}')
+
+        result = _make_full_converter().messages_full_converter(generator)
+
+        assert result.content[0].type == "tool_use"
+        assert result.content[0].input == {"query": "weather"}
+
+    @pytest.mark.parametrize(
+        "arguments",
+        [
+            '{"secret":"sensitive"',
+            '["sensitive"]',
+        ],
+    )
+    def test_tool_use_rejects_invalid_object_without_logging_arguments(
+        self, arguments: str, caplog: pytest.LogCaptureFixture
+    ):
+        generator = self._response_with_tool_arguments(arguments)
+
+        with caplog.at_level(logging.WARNING):
+            result = _make_full_converter().messages_full_converter(generator)
+
+        assert result.content[0].type == "tool_use"
+        assert result.content[0].input == {}
+        assert "call_1" in caplog.text
+        assert arguments not in caplog.text
 
 
 # ======================================================================

--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -652,11 +652,33 @@ class AnthropicServingMessages(OpenAIServingChat):
             )
 
         for tool_call in choice.message.tool_calls:
+            try:
+                tool_input = json.loads(tool_call.function.arguments)
+            except json.JSONDecodeError as exc:
+                logger.warning(
+                    "Ignoring malformed JSON arguments for Anthropic tool call "
+                    "%s (%s): %s",
+                    tool_call.id,
+                    tool_call.function.name,
+                    exc,
+                )
+                tool_input = {}
+
+            if not isinstance(tool_input, dict):
+                logger.warning(
+                    "Ignoring non-object arguments for Anthropic tool call %s "
+                    "(%s): got %s",
+                    tool_call.id,
+                    tool_call.function.name,
+                    type(tool_input).__name__,
+                )
+                tool_input = {}
+
             anthropic_tool_call = AnthropicContentBlock(
                 type="tool_use",
                 id=tool_call.id,
                 name=tool_call.function.name,
-                input=json.loads(tool_call.function.arguments),
+                input=tool_input,
             )
             content += [anthropic_tool_call]
 


### PR DESCRIPTION
## Purpose

Addresses the malformed-tool-arguments portion of #48273.

`messages_full_converter` currently calls `json.loads()` without guarding the
result. Malformed arguments raise `JSONDecodeError`, while valid JSON arrays or
scalars later fail `AnthropicContentBlock` validation because Anthropic
`tool_use.input` must be an object. Both paths turn an otherwise completed
response into HTTP 500.

This change keeps valid JSON objects unchanged and uses an empty object for
malformed or non-object arguments. The fallback preserves the required
Anthropic wire type without inventing non-standard fields. Warnings identify
the tool call and failure class but never log the raw model-generated
arguments.

## Duplicate Check

This does not duplicate an open PR. #48308 attempted a narrower JSON exception
guard but was closed by its author without maintainer rejection. Compared with
that closed change, this PR:

- covers valid non-object JSON as well as malformed JSON;
- adds focused regression tests;
- avoids logging raw tool arguments.

The open PR list was searched again immediately before submission for #48273,
`messages_full_converter`, and malformed Anthropic tool arguments. #50861 is
related but not overlapping: it validates inbound Chat Completions history in
`chat_utils.py`, while this PR hardens outbound Anthropic Messages response
conversion in `anthropic/serving.py` after model generation.

## Test Plan

- Exercise valid object arguments.
- Exercise malformed JSON arguments.
- Exercise valid non-object JSON arguments.
- Verify fallback warnings do not contain raw arguments.
- Run the complete Anthropic conversion test file and targeted lint hooks.

## Test Result

- Before: the minimal converter reproduction raises `JSONDecodeError`.
- After: `54 passed`:
  `VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest tests/entrypoints/anthropic/test_anthropic_messages_conversion.py -q`
- `ruff-check`, `ruff-format`, and `typos` passed for both changed files.
- `git diff --check` passed.

The full macOS editable build is currently blocked on unchanged `main` by the
known `std::sqrt` constant-expression failure in `fla.cpp`; #50915 contains the
active fix for that independent issue.

Model evaluation is not applicable because this only hardens API conversion
after generation and does not change model output, parsing, or accuracy.

## Impact

- Breaking change: no
- Affected module: Anthropic Messages API, non-streaming conversion
- Performance impact: none on the valid path beyond an object type check
- Documentation update: not required

## AI Assistance

TRAE was used to assist with repository discovery, implementation, and tests.
I reviewed every changed line, validated the behavior end to end, and approved
the final diff before submission.

## Checklist

- [x] The change is scoped to one conversion failure mode.
- [x] Regression tests cover the fix and the unchanged valid path.
- [x] Relevant tests and lint hooks pass locally.
- [x] The commit includes DCO sign-off and AI-assistance attribution.