### PR TITLE
[Doc] Add TTTPS Proof-of-Time provenance middleware example

### DIFF
--- a/examples/observability/tttps/README.md
+++ b/examples/observability/tttps/README.md
@@ -1,0 +1,71 @@
+# TTTPS Proof-of-Time Provenance Middleware
+
+[TTTPS](https://github.com/Helm-Protocol/OpenTTT) (OpenTTT) attaches a
+cryptographic audit-trail timestamp and integrity hash to model output, so a
+third party can later verify *when* a response was produced and that it
+hasn't been altered since. It does not certify legal/regulatory compliance
+(EU AI Act, FDA, etc.) or output correctness — it is a provenance receipt,
+not a compliance stamp.
+
+This example wires TTTPS into vLLM's OpenAI-compatible server using vLLM's
+existing [`--middleware`](../../../docs/configuration/serve_args.md) CLI
+flag — no changes to vLLM itself are required. `TTTPSMiddleware` is a
+regular Starlette `BaseHTTPMiddleware`, the same extension point other
+observability add-ons (see [`../opentelemetry`](../opentelemetry)) attach
+through.
+
+## Prerequisites
+
+Get a free API key from the public Provenance API (no card required):
+
+```bash
+curl -X POST https://kpp.kenosian.com/v1/keys \
+  -H "Content-Type: application/json" \
+  -d '{"email": "you@example.com", "use_case": "vllm middleware demo"}'
+```
+
+This returns a `kpp_prov_...` key with a starting quota of free seals.
+
+## Run
+
+```bash
+export KPP_API_KEY=kpp_prov_...
+
+vllm serve facebook/opt-125m \
+  --middleware tttps_middleware.TTTPSMiddleware
+```
+
+(Run this from the `examples/observability/tttps` directory, or otherwise
+make sure `tttps_middleware.py` is importable — e.g. by adding this
+directory to `PYTHONPATH`.)
+
+## Call it
+
+```bash
+curl -s http://localhost:8000/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model": "facebook/opt-125m", "prompt": "Hello,", "max_tokens": 8}' \
+  -D - -o /dev/null | grep -i x-tttps-receipt
+```
+
+The response includes an `X-TTTPS-Receipt` header, a JSON blob with a
+`receipt_id` you can independently re-verify:
+
+```bash
+curl -X POST https://kpp.kenosian.com/v1/verify \
+  -H "Content-Type: application/json" \
+  -d '{"receipt_id": "<receipt_id from the header>"}'
+```
+
+## Notes
+
+- **Fail-open**: any error talking to the Provenance API (timeout, quota
+  exhaustion, network failure) degrades to a `{"status": "degraded", ...}`
+  receipt. The underlying vLLM response body and status code are never
+  affected.
+- **Streaming (`stream=true`) is not covered** by this example.
+  `BaseHTTPMiddleware` buffers non-streaming bodies only; anchoring a live
+  SSE stream needs a different approach.
+- Tested against a locally built vLLM using this exact `--middleware`
+  invocation, confirming a live `X-TTTPS-Receipt` header on a real
+  `/v1/completions` round trip.

--- a/examples/observability/tttps/tttps_middleware.py
+++ b/examples/observability/tttps/tttps_middleware.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""TTTPS Proof-of-Time provenance middleware for vLLM's OpenAI-compatible
+server.
+
+TTTPS (OpenTTT) is a cryptographic audit-trail protocol: it timestamps and
+hashes model output so a third party can later verify *when* a response was
+produced and that it has not been altered, without vLLM needing any built-in
+support for it. This example wires it in purely through vLLM's existing
+`--middleware` CLI flag (see `vllm/entrypoints/openai/api_server.py`,
+`build_app()`): any dotted-path Starlette `BaseHTTPMiddleware` subclass
+passed via `--middleware` is added to the FastAPI app with
+`app.add_middleware(...)`, the same extension point Prometheus/OpenTelemetry
+style add-ons use.
+
+Honest scope note: this attaches a cryptographic timestamp + integrity hash
+("was this exact text produced at this time and unmodified since"). It does
+NOT certify legal/regulatory compliance (EU AI Act, FDA, etc.) and makes no
+claim about output correctness.
+
+Start the server with the middleware attached:
+
+    vllm serve facebook/opt-125m --middleware tttps_middleware.TTTPSMiddleware
+
+See README.md in this directory for the full walkthrough, including how to
+get a free API key from the public Provenance API this example calls.
+"""
+
+import hashlib
+import json
+import os
+import time
+
+import httpx
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response as StarletteResponse
+
+# Public self-serve Provenance API. Get a free key with:
+#   curl -X POST https://kpp.kenosian.com/v1/keys \
+#     -H "Content-Type: application/json" \
+#     -d '{"email": "you@example.com", "use_case": "vllm middleware demo"}'
+KPP_BASE = os.environ.get("KPP_BASE", "https://kpp.kenosian.com")
+KPP_API_KEY = os.environ.get("KPP_API_KEY", "")
+KPP_TIMEOUT_S = float(os.environ.get("KPP_TIMEOUT_S", "1.0"))
+
+_client = httpx.Client(timeout=KPP_TIMEOUT_S)
+
+
+def _anchor(text: str) -> dict:
+    """POST /v1/anchor against the public KPP endpoint. Fail-open: any
+    error (timeout, quota exhaustion, bad key, network failure) degrades to
+    a {"status": "degraded", ...} dict instead of raising, so a Provenance
+    API outage never blocks or alters the underlying vLLM response."""
+    content_hash = f"sha256:{hashlib.sha256(text.encode('utf-8')).hexdigest()}"
+    t0 = time.perf_counter()
+    try:
+        resp = _client.post(
+            f"{KPP_BASE}/v1/anchor",
+            json={"content_hash": content_hash, "key": KPP_API_KEY},
+        )
+        elapsed_ms = round((time.perf_counter() - t0) * 1000, 2)
+        if resp.status_code == 200:
+            body = resp.json()
+            return {
+                "status": "ok",
+                "content_hash": content_hash,
+                "receipt_id": body.get("receipt_id"),
+                "receipt": body.get("receipt"),
+                "time": body.get("time"),
+                "time_source": body.get("time_source"),
+                "verify_url": body.get("verify_url"),
+                "overhead_ms": elapsed_ms,
+            }
+        reason = {402: "quota_exhausted", 403: "unknown_api_key"}.get(
+            resp.status_code, f"http_{resp.status_code}"
+        )
+        return {"status": "degraded", "reason": reason, "overhead_ms": elapsed_ms}
+    except Exception as e:
+        elapsed_ms = round((time.perf_counter() - t0) * 1000, 2)
+        return {"status": "degraded", "reason": type(e).__name__, "overhead_ms": elapsed_ms}
+
+
+def _extract_text(body_bytes: bytes) -> str:
+    """Best-effort text extraction from an OpenAI-compatible chat/completions
+    JSON response body. Returns "" on any structural mismatch or on
+    streaming responses (SSE, not JSON) -- nothing gets anchored if empty."""
+    try:
+        data = json.loads(body_bytes)
+        choices = data.get("choices", [])
+        if not choices:
+            return ""
+        choice = choices[0]
+        if "message" in choice:
+            return choice["message"].get("content", "") or ""
+        if "text" in choice:
+            return choice["text"] or ""
+        return ""
+    except Exception:
+        return ""
+
+
+class TTTPSMiddleware(BaseHTTPMiddleware):
+    """Wraps `/v1/chat/completions` and `/v1/completions` responses with a
+    TTTPS Proof-of-Time anchor, exposed as the `X-TTTPS-Receipt` response
+    header. Fail-open: Provenance API errors or timeouts never affect the
+    underlying vLLM response body or status code.
+
+    Streaming (`stream=true`, SSE) responses are intentionally left
+    untouched -- `BaseHTTPMiddleware` buffers non-streaming bodies only;
+    anchoring a live SSE stream requires a different approach and is out of
+    scope for this example."""
+
+    async def dispatch(self, request: Request, call_next):
+        response = await call_next(request)
+
+        if request.url.path not in ("/v1/chat/completions", "/v1/completions"):
+            return response
+
+        content_type = response.headers.get("content-type", "")
+        if "text/event-stream" in content_type:
+            return response
+
+        try:
+            body = b"".join([chunk async for chunk in response.body_iterator])
+        except Exception:
+            return response
+
+        headers = dict(response.headers)
+        text = _extract_text(body)
+        if text:
+            headers["X-TTTPS-Receipt"] = json.dumps(_anchor(text))
+
+        return StarletteResponse(
+            content=body,
+            status_code=response.status_code,
+            headers=headers,
+            media_type=response.media_type,
+        )


### PR DESCRIPTION
## What this adds

A new self-contained example, `examples/observability/tttps/`, showing how to attach a third-party cryptographic audit-trail (TTTPS / OpenTTT Proof-of-Time) to vLLM's OpenAI-compatible server using vLLM's existing `--middleware` CLI flag. It follows the same shape as the existing `examples/observability/opentelemetry/` example (README + a small importable module), and adds no vLLM core code changes.

`TTTPSMiddleware` is a regular Starlette `BaseHTTPMiddleware`, registered exactly the way `build_app()` in `vllm/entrypoints/openai/api_server.py` supports (`for middleware in args.middleware: ... app.add_middleware(imported)`). It wraps `/v1/chat/completions` and `/v1/completions` responses and adds an `X-TTTPS-Receipt` response header (fail-open — any error talking to the Provenance API degrades to a `{"status": "degraded"}` receipt without touching the underlying response).

The example calls a public, free self-serve Provenance API (`kpp.kenosian.com`, no card required to get a key) so anyone can run it end-to-end from the README alone.

## Scope / honesty note

This attaches a cryptographic timestamp + integrity hash ("was this exact text produced at this time and unmodified since"). It does not certify legal/regulatory compliance (EU AI Act, FDA, etc.) or output correctness, and the README/docstrings say so explicitly.

## Testing

Tested locally against a source build of vLLM:

```
vllm serve facebook/opt-125m --middleware tttps_middleware.TTTPSMiddleware --enforce-eager
curl http://localhost:8000/v1/completions ...
```

confirmed a live `X-TTTPS-Receipt` header on a real `/v1/completions` round trip. The new file also passes `python -m py_compile`.

## AI assistance disclosure

Per `docs/contributing/README.md`'s AI Assisted Contributions section: this PR's code and description were drafted with AI assistance (Claude). The `--middleware` mechanism was verified directly against vLLM's own `build_app()` source, and the example's runtime behavior (the `X-TTTPS-Receipt` header appearing on a real response) was independently verified against a live `vllm serve` process before submission, not just asserted. Commit includes a `Co-authored-by: Claude` trailer.

Contributed by the OpenTTT / Helm-Protocol team.