### PR TITLE
[Bugfix][Build] Fix DeepGEMM CUDA 12.9 FP8 header visibility

### DIFF
--- a/cmake/external_projects/deepgemm.cmake
+++ b/cmake/external_projects/deepgemm.cmake
@@ -30,7 +30,7 @@ else()
   # Keep in sync with tools/install_deepgemm.sh
   set(_DEEPGEMM_UPSTREAM_REPO "https://github.com/vllm-project/DeepGEMM.git")
   # TODO: switch to nv_dev branch after it support situ
-  set(_DEEPGEMM_UPSTREAM_TAG "f5a76426fa084087169693fd0cd815223576d6e9")
+  set(_DEEPGEMM_UPSTREAM_TAG "e21c821f39a2056d68067a466c64ddc942200106")
 
   set(_deepgemm_fc_root "${FETCHCONTENT_BASE_DIR}")
   if(NOT _deepgemm_fc_root)

--- a/tools/install_deepgemm.sh
+++ b/tools/install_deepgemm.sh
@@ -8,7 +8,7 @@ set -e
 # Keep DEEPGEMM_GIT_REF in sync with cmake/external_projects/deepgemm.cmake
 DEEPGEMM_GIT_REPO="https://github.com/vllm-project/DeepGEMM.git"
 # NOTE: This is currently targeting nv-dev branch due to sm120 support
-DEEPGEMM_GIT_REF="f5a76426fa084087169693fd0cd815223576d6e9"
+DEEPGEMM_GIT_REF="e21c821f39a2056d68067a466c64ddc942200106"
 WHEEL_DIR=""
 
 # Parse command line arguments


### PR DESCRIPTION
## Purpose

Fix the CUDA 12.9 release build failure in DeepGEMM's host extension while preserving the exact DeepGEMM `f5a76426` code baseline.

The pinned `mqa_logits.cuh` directly names `__nv_fp8_e4m3`, but it does not include the CUDA header that declares the type. CUDA 12.9 host compilation therefore fails with:

```text
deep_gemm/layout/mqa_logits.cuh:16:61: error: '__nv_fp8_e4m3' was not declared in this scope
```

This updates both synchronized vLLM DeepGEMM pins from `f5a76426` to `e21c821f`. The new commit has `f5a76426` as its sole parent and adds exactly one line:

```cpp
#include <cuda_fp8.h>
```

DeepGEMM branch: https://github.com/vllm-project/DeepGEMM/tree/codex/f5a-cuda-fp8-include

DeepGEMM commit: https://github.com/vllm-project/DeepGEMM/commit/e21c821f39a2056d68067a466c64ddc942200106

## Duplicate-work check

No open PR references `e21c821f`, `mqa_logits.cuh`, or the missing `cuda_fp8.h` declaration.

PR #50796 is related but not a duplicate. It replaces `f5a76426` with the broader `5f33a180` SM120+SITU merge to restore scale-factor layout support on SM120. This change deliberately preserves the existing `f5a76426` dependency content and adds only the missing CUDA FP8 declaration needed by the CUDA 12.9 host compiler. The PRs touch the same two synchronized pin files, but they test different dependency changes and address different failures.

## Validation

Baseline release-v2 build 4680 pinned `f5a76426`; its two CUDA 12.9 wheels and four CUDA 12.9 release images failed in the DeepGEMM host extension.

Release-v2 build 4684 used this exact vLLM commit and pinned `e21c821f`. All six CUDA 12.9 targets passed:

| Target | Result |
| --- | --- |
| x86_64 wheel | Passed |
| aarch64 wheel | Passed |
| x86_64 release image | Passed |
| aarch64 release image | Passed |
| x86_64 Ubuntu 24.04 release image | Passed |
| aarch64 Ubuntu 24.04 release image | Passed |

Build: https://buildkite.com/vllm/release-v2/builds/4684

The x86 and aarch64 logs both checked out `e21c821f` and advanced through the DeepGEMM host-extension builds without the prior `mqa_logits.cuh` error. The overall pipeline is marked failing only because of the unrelated macOS arm64 CPU wheel job.

Additional checks:

```bash
git diff --check
bash -n tools/install_deepgemm.sh
```

Applicable pre-commit hooks, including shell lint, dependency-graph validation, configuration validation, and commit sign-off, passed.

No model evaluation was run because this changes dependency header visibility during compilation and does not change model output or serving behavior.

---

AI assistance was used for root-cause analysis, branch preparation, CI orchestration, and PR drafting with OpenAI Codex. This draft requires the human submitter to review every changed line and the validation evidence before marking it ready for review.
