### PR TITLE
[MoE] Let Platforms select fused MoE router constructors

### DIFF
--- a/tests/kernels/moe/test_routing.py
+++ b/tests/kernels/moe/test_routing.py
@@ -9,8 +9,14 @@ import torch
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.distributed.eplb.eplb_state import EplbLayerState
 from vllm.model_executor.layers.fused_moe.config import RoutingMethodType
+from vllm.model_executor.layers.fused_moe.router import (
+    routing_backend as routing_backend_module,
+)
 from vllm.model_executor.layers.fused_moe.router.base_router import (
     eplb_map_to_physical_and_record,
+)
+from vllm.model_executor.layers.fused_moe.router.custom_routing_router import (
+    CustomRoutingRouter,
 )
 from vllm.model_executor.layers.fused_moe.router.fused_topk_bias_router import (
     FusedTopKBiasRouter,
@@ -24,8 +30,12 @@ from vllm.model_executor.layers.fused_moe.router.grouped_topk_router import (
 from vllm.model_executor.layers.fused_moe.router.router_factory import (
     create_fused_moe_router,
 )
+from vllm.model_executor.layers.fused_moe.router.routing_backend import (
+    FusedMoERoutingBackend,
+)
 from vllm.model_executor.models.llama4 import Llama4MoE
 from vllm.platforms import current_platform
+from vllm.platforms.interface import Platform, PlatformEnum
 
 
 def _is_aiter_capable() -> bool:
@@ -44,6 +54,152 @@ def _is_aiter_capable() -> bool:
 MK_S = [(32, 256), (64, 512)]
 TOP_KS = [2, 4, 6]
 NUM_EXPERTS = [8, 16, 64]
+
+
+class FakeFusedTopKRouter(FusedTopKRouter):
+    pass
+
+
+class FakeGroupedTopKRouter(GroupedTopKRouter):
+    pass
+
+
+class FakeFusedTopKBiasRouter(FusedTopKBiasRouter):
+    pass
+
+
+class FakeRoutingBackend(FusedMoERoutingBackend):
+    resolution_count = 0
+
+    @classmethod
+    def resolve_router_cls(cls, router_cls):
+        cls.resolution_count += 1
+        return {
+            FusedTopKRouter: FakeFusedTopKRouter,
+            GroupedTopKRouter: FakeGroupedTopKRouter,
+            FusedTopKBiasRouter: FakeFusedTopKBiasRouter,
+        }.get(router_cls, router_cls)
+
+
+class InvalidRouterBackend(FusedMoERoutingBackend):
+    @classmethod
+    def resolve_router_cls(cls, router_cls):
+        del router_cls
+        return object
+
+
+class FakeRoutingPlatform(Platform):
+    _enum = PlatformEnum.OOT
+    device_name = "fake-routing"
+    device_type = "fake-routing"
+    backend_resolution_count = 0
+
+    @classmethod
+    def get_fused_moe_routing_backend_cls(cls) -> str:
+        cls.backend_resolution_count += 1
+        return f"{__name__}.FakeRoutingBackend"
+
+
+class InvalidRouterPlatform(FakeRoutingPlatform):
+    @classmethod
+    def get_fused_moe_routing_backend_cls(cls) -> str:
+        return f"{__name__}.InvalidRouterBackend"
+
+
+class InvalidBackendPlatform(FakeRoutingPlatform):
+    @classmethod
+    def get_fused_moe_routing_backend_cls(cls) -> str:
+        return "builtins.object"
+
+
+@pytest.fixture
+def fake_routing_platform(monkeypatch: pytest.MonkeyPatch):
+    routing_backend_module.resolve_fused_moe_routing_backend_cls.cache_clear()
+    routing_backend_module.resolve_fused_moe_router_cls.cache_clear()
+    FakeRoutingBackend.resolution_count = 0
+    FakeRoutingPlatform.backend_resolution_count = 0
+    monkeypatch.setattr(
+        routing_backend_module,
+        "current_platform",
+        FakeRoutingPlatform(),
+    )
+    yield
+    routing_backend_module.resolve_fused_moe_routing_backend_cls.cache_clear()
+    routing_backend_module.resolve_fused_moe_router_cls.cache_clear()
+
+
+@pytest.mark.parametrize(
+    ("router_kwargs", "expected_cls"),
+    [
+        ({}, FakeFusedTopKRouter),
+        (
+            {
+                "use_grouped_topk": True,
+                "num_expert_group": 2,
+                "topk_group": 1,
+            },
+            FakeGroupedTopKRouter,
+        ),
+        (
+            {"e_score_correction_bias": torch.zeros(8)},
+            FakeFusedTopKBiasRouter,
+        ),
+        (
+            {"custom_routing_function": Llama4MoE.custom_routing_function},
+            CustomRoutingRouter,
+        ),
+    ],
+)
+def test_platform_routing_backend_preserves_factory_selection(
+    fake_routing_platform,
+    router_kwargs,
+    expected_cls,
+) -> None:
+    router = create_fused_moe_router(
+        top_k=2,
+        global_num_experts=8,
+        **router_kwargs,
+    )
+
+    assert type(router) is expected_cls
+
+
+def test_platform_routing_backend_caches_resolution(fake_routing_platform) -> None:
+    for _ in range(2):
+        create_fused_moe_router(top_k=2, global_num_experts=8)
+
+    assert FakeRoutingPlatform.backend_resolution_count == 1
+    assert FakeRoutingBackend.resolution_count == 1
+
+
+def test_platform_routing_backend_rejects_unrelated_router_class(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    routing_backend_module.resolve_fused_moe_routing_backend_cls.cache_clear()
+    routing_backend_module.resolve_fused_moe_router_cls.cache_clear()
+    monkeypatch.setattr(
+        routing_backend_module,
+        "current_platform",
+        InvalidRouterPlatform(),
+    )
+
+    with pytest.raises(TypeError, match="must resolve FusedTopKRouter"):
+        create_fused_moe_router(top_k=2, global_num_experts=8)
+
+
+def test_platform_routing_backend_rejects_unrelated_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    routing_backend_module.resolve_fused_moe_routing_backend_cls.cache_clear()
+    routing_backend_module.resolve_fused_moe_router_cls.cache_clear()
+    monkeypatch.setattr(
+        routing_backend_module,
+        "current_platform",
+        InvalidBackendPlatform(),
+    )
+
+    with pytest.raises(TypeError, match="must subclass FusedMoERoutingBackend"):
+        create_fused_moe_router(top_k=2, global_num_experts=8)
 
 
 def test_degenerate_grouped_config_uses_standard_topk() -> None:

--- a/vllm/model_executor/layers/fused_moe/router/router_factory.py
+++ b/vllm/model_executor/layers/fused_moe/router/router_factory.py
@@ -29,6 +29,9 @@ from vllm.model_executor.layers.fused_moe.router.fused_topk_router import (
 from vllm.model_executor.layers.fused_moe.router.grouped_topk_router import (
     GroupedTopKRouter,
 )
+from vllm.model_executor.layers.fused_moe.router.routing_backend import (
+    resolve_fused_moe_router_cls,
+)
 from vllm.model_executor.layers.fused_moe.router.routing_simulator_router import (
     RoutingSimulatorRouter,
 )
@@ -113,7 +116,7 @@ def create_fused_moe_router(
 
     routing_strategy = envs.VLLM_MOE_ROUTING_SIMULATION_STRATEGY
     if routing_strategy != "":
-        return RoutingSimulatorRouter(
+        return resolve_fused_moe_router_cls(RoutingSimulatorRouter)(
             top_k=top_k,
             global_num_experts=global_num_experts,
             eplb_state=eplb_state,
@@ -126,7 +129,7 @@ def create_fused_moe_router(
         assert e_score_correction_bias is not None, (
             "e_score_correction_bias is required when zero_expert_type is set"
         )
-        return ZeroExpertRouter(
+        return resolve_fused_moe_router_cls(ZeroExpertRouter)(
             top_k=top_k,
             global_num_experts=global_num_experts,
             eplb_state=eplb_state,
@@ -174,7 +177,7 @@ def create_fused_moe_router(
             and scaling_handled_downstream
             and routing_method_preserved
         ):
-            return GroupedTopKRouter(
+            return resolve_fused_moe_router_cls(GroupedTopKRouter)(
                 top_k=top_k,
                 global_num_experts=global_num_experts,
                 eplb_state=eplb_state,
@@ -189,7 +192,7 @@ def create_fused_moe_router(
         # Otherwise fall through to the non-grouped chain below.
 
     if custom_routing_function is not None:
-        return CustomRoutingRouter(
+        return resolve_fused_moe_router_cls(CustomRoutingRouter)(
             top_k=top_k,
             global_num_experts=global_num_experts,
             eplb_state=eplb_state,
@@ -200,7 +203,7 @@ def create_fused_moe_router(
     assert scoring_func in ["sigmoid", "softmax", "sqrtsoftplus"]
 
     if e_score_correction_bias is not None or hash_indices_table is not None:
-        return FusedTopKBiasRouter(
+        return resolve_fused_moe_router_cls(FusedTopKBiasRouter)(
             top_k=top_k,
             global_num_experts=global_num_experts,
             eplb_state=eplb_state,
@@ -218,7 +221,7 @@ def create_fused_moe_router(
         and scoring_func == "softmax"
         and rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()
     ):
-        return AiterSharedRoutedFusedMoERouter(
+        return resolve_fused_moe_router_cls(AiterSharedRoutedFusedMoERouter)(
             top_k=top_k,
             global_num_experts=global_num_experts,
             eplb_state=eplb_state,
@@ -227,7 +230,7 @@ def create_fused_moe_router(
             scoring_func=scoring_func,
         )
 
-    return FusedTopKRouter(
+    return resolve_fused_moe_router_cls(FusedTopKRouter)(
         top_k=top_k,
         global_num_experts=global_num_experts,
         eplb_state=eplb_state,

--- a/vllm/model_executor/layers/fused_moe/router/routing_backend.py
+++ b/vllm/model_executor/layers/fused_moe/router/routing_backend.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Platform extension interface for fused MoE routers."""
+
+from __future__ import annotations
+
+import functools
+from abc import ABC, abstractmethod
+from typing import TypeVar, cast
+
+from vllm.platforms import current_platform
+from vllm.utils.import_utils import resolve_obj_by_qualname
+
+from .fused_moe_router import FusedMoERouter
+
+RouterT = TypeVar("RouterT", bound=FusedMoERouter)
+
+
+class FusedMoERoutingBackend(ABC):
+    """Resolve upstream-selected routers to platform-specific subclasses."""
+
+    @classmethod
+    @abstractmethod
+    def resolve_router_cls(cls, router_cls: type[RouterT]) -> type[RouterT]:
+        """Return ``router_cls`` or a platform-specific subclass."""
+        raise NotImplementedError
+
+
+@functools.cache
+def resolve_fused_moe_routing_backend_cls() -> type[FusedMoERoutingBackend] | None:
+    """Resolve and validate the current Platform's routing backend class."""
+    backend_cls_qualname = current_platform.get_fused_moe_routing_backend_cls()
+    if backend_cls_qualname is None:
+        return None
+
+    backend_cls = resolve_obj_by_qualname(backend_cls_qualname)
+    if not isinstance(backend_cls, type) or not issubclass(
+        backend_cls, FusedMoERoutingBackend
+    ):
+        raise TypeError(
+            f"Fused MoE routing backend {backend_cls_qualname!r} must subclass "
+            "FusedMoERoutingBackend."
+        )
+    return backend_cls
+
+
+@functools.cache
+def resolve_fused_moe_router_cls(router_cls: type[RouterT]) -> type[RouterT]:
+    """Resolve the Platform subclass for an upstream-selected Router class."""
+    backend_cls = resolve_fused_moe_routing_backend_cls()
+    if backend_cls is None:
+        return router_cls
+
+    platform_router_cls = backend_cls.resolve_router_cls(router_cls)
+    if not isinstance(platform_router_cls, type) or not issubclass(
+        platform_router_cls, router_cls
+    ):
+        raise TypeError(
+            f"Fused MoE routing backend must resolve {router_cls.__name__} to "
+            "that class or one of its subclasses."
+        )
+    return cast(type[RouterT], platform_router_cls)

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -1050,6 +1050,11 @@ class Platform:
         return "vllm.distributed.device_communicators.base_device_communicator.DeviceCommunicatorBase"  # noqa
 
     @classmethod
+    def get_fused_moe_routing_backend_cls(cls) -> str | None:
+        """Return the class that resolves platform-specific fused MoE routers."""
+        return None
+
+    @classmethod
     def is_integrated_gpu(cls, device_id: int = 0) -> bool:
         """
         Returns whether the GPU is an integrated (UMA) device that shares


### PR DESCRIPTION
## Purpose

Refresh of the existing draft against current vLLM main. The upstream fused
MoE factory keeps its component-selection rules, then gives the Platform narrow
construction-time adaptation points for the selected components:

- `get_fused_moe_router_constructor()` selects a compatible router constructor.
- `get_fused_moe_routed_experts_cls()` adapts the selected routed-experts class.
- `get_fused_moe_runner_cls()` selects the runner class.

The routed-experts and runner hooks run after upstream or the model has selected
its class, so explicit model-specific choices such as `GptOssRoutedExperts` can
be composed with a device implementation instead of being bypassed. Returned
components are validated against their common `RoutedExperts`, `MoERunner`, or
`FusedMoERouter` contract.

These hooks are construction-only: they do not own EPLB lifecycle, placement,
weight transfer, or forward-time routing state. No registry, backend object,
cache, global factory replacement, or import-order workaround is introduced.
Related design discussion: #51005. This refreshes the existing draft rather
than opening a duplicate; no other open PR supplies these construction hooks.
EPLB state and runtime hooks are handled separately in #49700.

AI assistance was used for coding, test preparation, and drafting. The human
submitter must review every changed line, run relevant tests, and defend the
design before this draft is made ready.

## Test Plan

```bash
.venv/bin/python -m pytest -q tests/kernels/moe/test_routing.py \
  -k 'platform_router_constructor or platform_adapts_selected_fused_moe_component or platform_rejects_invalid_fused_moe_component'
pre-commit run --files vllm/platforms/interface.py \
  vllm/model_executor/layers/fused_moe/layer.py \
  vllm/model_executor/layers/fused_moe/router/router_factory.py \
  tests/kernels/moe/test_routing.py
```

An out-of-tree NPU integration and model-backed MoE correctness evaluation are
required before merge.

## Test Result

- Commit-time pre-commit hooks passed, including Ruff, formatting, mypy 3.10,
  configuration validation, forbidden-import checks, and DCO/sign-off checks.
- `git diff --check` and targeted Python compilation passed.
- Focused pytest did not collect locally because the existing `.venv` has no
  pytest or torch. Installing the checkout with the required `uv` workflow was
  attempted, but vLLM has no macOS arm64 precompiled wheel for this revision;
  the available aarch64 wheel is manylinux-only.
- Model evaluation and real Ascend NPU validation were not run.

This remains a draft. No hardware pass or human line-by-line review is claimed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] Purpose and related design discussion are described.
- [x] Test plan and current results are stated.
- [ ] Hardware/model evaluation and human review are complete.

</details>
