### PR TITLE
[Docs] Fix two docs build warnings

### DIFF
--- a/docs/design/moe_kernel_features.md
+++ b/docs/design/moe_kernel_features.md
@@ -32,7 +32,7 @@ th {
 
 | Backend | Output act. format | Quant. types | Quant. format | Async | Apply Weight On Input | Subclass |
 | ------- | ------------------ | ------------ | ------------- | ----- | --------------------- | --------- |
-| naive | standard | all<sup>1</sup> | G,A,T | N | <sup>6</sup> | [layer.py][vllm.model_executor.layers.fused_moe.runner.MoERunner] |
+| naive | standard | all<sup>1</sup> | G,A,T | N | <sup>6</sup> | [`MoERunner`][vllm.model_executor.layers.fused_moe.runner.moe_runner.MoERunner] |
 | deepep_high_throughput | standard | fp8 | G(128),A,T<sup>2</sup> | Y | Y | [`DeepEPHTPrepareAndFinalize`][vllm.model_executor.layers.fused_moe.prepare_finalize.deepep_ht.DeepEPHTPrepareAndFinalize] |
 | deepep_low_latency | batched | fp8 | G(128),A,T<sup>3</sup> | Y | Y | [`DeepEPLLPrepareAndFinalize`][vllm.model_executor.layers.fused_moe.prepare_finalize.deepep_ll.DeepEPLLPrepareAndFinalize] |
 | flashinfer_nvlink_two_sided | standard | nvfp4,fp8 | G,A,T | N | N | [`FlashInferNVLinkTwoSidedPrepareAndFinalize`][vllm.model_executor.layers.fused_moe.prepare_finalize.flashinfer_nvlink_two_sided.FlashInferNVLinkTwoSidedPrepareAndFinalize] |

--- a/vllm/model_executor/kernels/linear/mxfp6/base.py
+++ b/vllm/model_executor/kernels/linear/mxfp6/base.py
@@ -18,7 +18,7 @@ class MxFp6LinearLayerConfig:
 
     Attributes:
         weight_quant_key: Identifies the weight quantization format. Can be
-        kMxfp6E2M3Static or kMxfp6E3M2Static.
+            kMxfp6E2M3Static or kMxfp6E3M2Static.
         activation_quant_key: Identifies the activation quantization format,
             or `None` when activations must not be quantized.
     """


### PR DESCRIPTION
## Purpose

Fixes two warnings emitted by `mkdocs build`:

```
WARNING -  griffe: vllm/model_executor/kernels/linear/mxfp6/base.py:21: Failed to get 'name: description' pair from 'kMxfp6E2M3Static or kMxfp6E3M2Static.'
WARNING -  mkdocs_autorefs: design/moe_kernel_features.md: Could not find cross-reference target 'vllm.model_executor.layers.fused_moe.runner.MoERunner'
```

1. **Broken cross-reference** in `docs/design/moe_kernel_features.md`. The `naive` row of the all2all backend table pointed at `vllm.model_executor.layers.fused_moe.runner.MoERunner`, but `runner/__init__.py` re-exports nothing — the class is defined in `runner/moe_runner.py`. The link rendered as plain text for readers. The link text (`layer.py`) was also stale from before the `FusedMoE` → `MoERunner` refactor, so it now uses the class name like every other row in the table.

2. **Malformed `Attributes:` docstring** in `MxFp6LinearLayerConfig`. The continuation line of the `weight_quant_key` description was not indented, so griffe parsed it as the start of a new attribute and dropped it from the rendered docs.

## Not a duplicate

Checked before opening:

```bash
gh pr list --repo vllm-project/vllm --state open --search "moe_kernel_features MoERunner"
gh pr list --repo vllm-project/vllm --state open --search "mxfp6 docstring"
gh pr list --repo vllm-project/vllm --state open --search "fix docs build warnings in:title"
gh pr list --repo vllm-project/vllm --state open --search "autorefs cross-reference docs"
```

No open PR touches either file or either warning.

## Test Plan

`mkdocs build` on the branch, then verify against the generated site.

## Test Result

Both warnings are resolved:

- **griffe** now parses two attributes with the full description attached, instead of failing on line 21:

  ```
  'weight_quant_key' -> Identifies the weight quantization format. Can be
  kMxfp6E2M3Static or kMxfp6E3M2Static.
  'activation_quant_key' -> Identifies the activation quantization format,
  or `None` when activations must not be quantized.
  ```

- **autorefs** now resolves the link. `site/design/moe_kernel_features/index.html` contains a real href instead of unresolved text:

  ```
  href=../../api/vllm/model_executor/layers/fused_moe/runner/moe_runner/#vllm.model_executor.layers.fused_moe.runner.moe_runner.MoERunner
  ```

  and the anchor exists in the target page (`id=vllm.model_executor.layers.fused_moe.runner.moe_runner.MoERunner`).

Docs-only change — no runtime behaviour is affected, so no model evaluation is applicable.

## Note

AI assistance (Claude Code) was used for this change. I have reviewed every changed line and verified the build output myself.
