### PR TITLE
[CI] Stabilize GLM-5.2 PCP evaluation

### DIFF
--- a/tests/evals/gsm8k/configs/GLM-5.2-NVFP4-TP1-PCP4-EP.yaml
+++ b/tests/evals/gsm8k/configs/GLM-5.2-NVFP4-TP1-PCP4-EP.yaml
@@ -13,5 +13,6 @@ server_args: >-
   --enable-expert-parallel
   --kv-cache-dtype fp8
 env:
+  PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"
   VLLM_LOGGING_LEVEL: "DEBUG"
   VLLM_USE_V2_MODEL_RUNNER: "1"


### PR DESCRIPTION
## Summary

- enable PyTorch expandable CUDA allocator segments for the GLM-5.2 TP1/PCP4 GSM8K evaluation;
- keep `--max-num-batched-tokens 32768`, which is needed to exercise the large-batch PCP path;
- scope the allocator change to the memory-tight TP1/PCP4 case; TP2/PCP2 is unchanged.

## Root cause

The pytest-level error in [Buildkite #81913](https://buildkite.com/vllm/ci/builds/81913#019fca13-8131-4f3f-bcfa-6636b1022f66) is only a 20-minute server-start timeout. The worker log shows the actual failure during the profile run:

```text
CUDA out of memory. Tried to allocate 24.43 GiB.
15.36 GiB is free
23.97 GiB is reserved by PyTorch but unallocated
```

The allocation comes from FlashInfer CUTLASS MoE's `FusedMoeRunner::getWorkspaceInfo`. The same signature is present in [Buildkite #80082](https://buildkite.com/vllm/ci/builds/80082#019f95ee-f9e7-4318-b8c8-1b9d66c30436), before the recent Kimi/K3 changes, so this is not a recent model-runner regression or a bad B200 node.

The TP1/PCP4 configuration became memory-tight when `--max-num-batched-tokens 32768` was added in #49294. Successful runs such as [Buildkite #80689](https://buildkite.com/vllm/ci/builds/80689#019fa750-64e9-4fea-a523-627445bed59c) show that the workload's real peak fits: 159.66 GiB total non-KV memory on a 178.35 GiB B200. The intermittent OOM occurs because a roughly 24 GiB cached allocator segment cannot satisfy the next slightly larger 24.43 GiB FlashInfer workspace request. Expandable segments let that reserved memory grow/reuse instead of requiring a second contiguous allocation.

## Duplicate-work check

No open PR was found for the GLM-5.2 PCP FlashInfer MoE startup OOM using searches for `GLM-5.2 PCP OOM`, `lm-eval-pcp-4xb200`, and `expandable_segments GLM`.

- #50791 sizes a different FlashInfer sparse-MLA attention workspace for DCP.
- #49196 is an automated draft revert for an older PCP accuracy regression, not this profile-run MoE OOM.
- #34553 concerns a GLM-5 sparse-attention indexer OOM under serving load, not the startup MoE workspace failure here.

## Testing

- `git diff --check`
- parsed the YAML and verified both the allocator setting and retained 32K batch limit with Ruby's YAML parser
- repository pre-commit hooks run by `git commit`: passed
- GitHub pre-commit workflow: passed
- [Buildkite #82253 — LM Eval PCP (4xB200)](https://buildkite.com/vllm/ci/builds/82253#019fcc6a-d072-4725-be6e-5a78fc7a6367): passed on `dgxB200-14` with exit status 0
  - unchanged TP2/PCP2 control: GSM8K passed
  - TP1/PCP4 with `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`: profile run passed with 130.49 GiB of weights and a 28.33–30.23 GiB torch peak, the server started, and all 1,319 GSM8K examples passed

The allocator-only change does not alter model inputs, kernels, or numerics. The B200 model evaluation passed on the first validation iteration.

## AI assistance

AI assistance was used for Buildkite log analysis, root-cause isolation, implementation, and drafting this description.

- [ ] The human submitter has reviewed the changed line and CI evidence before marking this PR ready.
