### PR TITLE
fix(missing_documentation): Class `SamplingType` in vllm/sampling_params.py has no docst

### DIFF
--- a/tests/test_sampling_params.py
+++ b/tests/test_sampling_params.py
@@ -49,3 +49,40 @@ def test_diffusion_accepts_top_k_top_p():
 def test_non_diffusion_models_unaffected():
     params = SamplingParams(temperature=0.7, top_k=10, seed=42)
     params.verify(MockModelConfig(), None, None, None)
+
+
+# ---------------------------------------------------------------------------
+# Tests for SamplingType enum
+# Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>
+# ---------------------------------------------------------------------------
+from vllm.sampling_params import SamplingType  # noqa: E402
+
+
+def test_sampling_type_greedy():
+    """temperature=0 should yield GREEDY sampling."""
+    p = SamplingParams(temperature=0.0)
+    assert p.sampling_type is SamplingType.GREEDY
+
+
+def test_sampling_type_random():
+    """Non-zero temperature with no seed should yield RANDOM sampling."""
+    p = SamplingParams(temperature=0.8)
+    assert p.sampling_type is SamplingType.RANDOM
+
+
+def test_sampling_type_random_seed():
+    """Non-zero temperature with a seed should yield RANDOM_SEED sampling."""
+    p = SamplingParams(temperature=0.8, seed=42)
+    assert p.sampling_type is SamplingType.RANDOM_SEED
+
+
+def test_sampling_type_values():
+    """Enum integer values must remain stable (they are used as array indices)."""
+    assert int(SamplingType.GREEDY) == 0
+    assert int(SamplingType.RANDOM) == 1
+    assert int(SamplingType.RANDOM_SEED) == 2
+
+
+def test_sampling_type_docstring():
+    """SamplingType must have a non-empty docstring."""
+    assert SamplingType.__doc__ and len(SamplingType.__doc__.strip()) > 0

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -62,6 +62,39 @@ ThinkingTokenBudget = Annotated[
 
 
 class SamplingType(IntEnum):
+    """Enum that categorises how tokens are selected during sampling.
+
+    This value is derived from the :class:`SamplingParams` that were supplied
+    for a request and controls which sampling kernel is used by the scheduler.
+
+    Members:
+        GREEDY: Deterministic argmax decoding.  Selected when
+            ``temperature`` is effectively zero (< 1e-5).
+        RANDOM: Non-deterministic multinomial sampling with no fixed seed.
+            Selected when ``temperature`` is non-zero and no ``seed`` is set.
+        RANDOM_SEED: Reproducible multinomial sampling driven by a user-
+            supplied ``seed``.  Selected when ``temperature`` is non-zero
+            *and* a ``seed`` value is provided.
+
+    Example::
+
+        >>> from vllm.sampling_params import SamplingParams, SamplingType
+        >>> # Greedy decoding (temperature = 0)
+        >>> p = SamplingParams(temperature=0.0)
+        >>> p.sampling_type
+        <SamplingType.GREEDY: 0>
+        >>> # Random sampling
+        >>> p = SamplingParams(temperature=0.8)
+        >>> p.sampling_type
+        <SamplingType.RANDOM: 1>
+        >>> # Seeded random sampling
+        >>> p = SamplingParams(temperature=0.8, seed=42)
+        >>> p.sampling_type
+        <SamplingType.RANDOM_SEED: 2>
+
+    # Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>
+    """
+
     GREEDY = 0
     RANDOM = 1
     RANDOM_SEED = 2


### PR DESCRIPTION
## TLDR

        **Gap:** Class `SamplingType` in vllm/sampling_params.py has no docstring — add parameter docs, return type, and example

        **Wedge type:** `missing_documentation`

        **Issue:** https://github.com/vllm-project/vllm/blob/main/vllm/sampling_params.py#L64

        ## Changes

        - `tests/test_sampling_params.py`
- `vllm/sampling_params.py`

        **Diff size:** 70 lines across 2 file(s)

        ## Pre-submission checklist

        - [x] Minimal change — touches at most 3 files
        - [x] Tests updated (if test suite present)
        - [x] No CI/CD, Dockerfile, or lock file modifications
        - [x] Diff reviewed for secrets

        ## AI Assistance Disclosure

        This contribution was AI-assisted using Hermes Agent (Nous Research).

        Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>