### PR TITLE
[Bugfix][GPT-OSS] Match strict tool-call grammar to real Harmony renders

### DIFF
--- a/tests/parser/test_harmony.py
+++ b/tests/parser/test_harmony.py
@@ -897,21 +897,22 @@ class TestAdjustRequest:
     COMMENTARY = (
         "<|channel|>commentary<|message|>commentary message<|end|><|start|>assistant"
     )
+    # Harmony renders tool calls recipient-first with the channel attached
+    # directly to the function name and a bare `` json`` marker, matching
+    # ``openai_harmony`` output (see TestHarmonyGrammarAcceptsRealRenders).
     TOOL_CALL_1 = (
-        ANALYSIS + f"<|channel|>commentary to=functions.{TOOL_1_NAME} json<|message|>"
+        ANALYSIS + f" to=functions.{TOOL_1_NAME}<|channel|>commentary json<|message|>"
         "{}<|call|>"
     )
     TOOL_CALL_2 = (
-        ANALYSIS + f"<|channel|>commentary to=functions.{TOOL_2_NAME} json<|message|>"
+        ANALYSIS + f" to=functions.{TOOL_2_NAME}<|channel|>commentary json<|message|>"
         '{"city": "Tokyo"}<|call|>'
     )
     FINAL_JSON_SCHEMA = (
-        ANALYSIS
-        + '<|channel|>final <|constrain|>json<|message|>{"answer": "Tokyo"}<|end|>'
+        ANALYSIS + '<|channel|>final json<|message|>{"answer": "Tokyo"}<|end|>'
     )
     FINAL_JSON_OBJECT = (
-        ANALYSIS
-        + '<|channel|>final <|constrain|>json<|message|>{"city": "Tokyo"}<|end|>'
+        ANALYSIS + '<|channel|>final json<|message|>{"city": "Tokyo"}<|end|>'
     )
     FINAL_TEXT_ONLY = ANALYSIS + "<|channel|>final<|message|>any<|end|>"
     FINAL_REGEX = ANALYSIS + "<|channel|>final<|message|>regex<|end|>"
@@ -1194,3 +1195,50 @@ class TestAdjustRequest:
             adjusted_request,
             expected_admission,
         )
+
+
+class TestHarmonyGrammarAcceptsRealRenders:
+    """The strict tool-call grammar must accept the exact byte sequences that
+    ``openai_harmony`` renders; otherwise constrained decoding can never satisfy
+    it. Sourcing samples from the harmony encoder keeps this guard tied to
+    reality, unlike hand-written begin strings.
+    """
+
+    @staticmethod
+    def _auto_grammar(harmony_parser) -> Grammar:
+        request = TestAdjustRequest._build_request(
+            "chat", tool_choice="auto", strict_tools=True
+        )
+        adjusted = harmony_parser.adjust_request(request)
+        structural_tag = adjusted.structured_outputs.structural_tag
+        return Grammar.from_structural_tag(structural_tag)
+
+    @staticmethod
+    def _rendered_output(*response_messages: Message) -> str:
+        prompt = [Message.from_role_and_content(Role.USER, "Hi")]
+        tokens = get_model_output_tokens(prompt, list(response_messages))
+        return get_encoding().decode_utf8(tokens)
+
+    @pytest.mark.parametrize("content_type", ["json", "<|constrain|>json"])
+    def test_tool_call_render_accepted(self, harmony_parser, content_type):
+        output = self._rendered_output(
+            assistant("reasoning", "analysis"),
+            tool_call(
+                f"functions.{TestAdjustRequest.TOOL_2_NAME}",
+                '{"city": "Tokyo"}',
+                content_type=content_type,
+            ),
+        )
+        assert _is_grammar_accept_string(
+            self._auto_grammar(harmony_parser), output, require_termination=False
+        ), f"grammar rejected real harmony tool-call render: {output!r}"
+
+    @pytest.mark.parametrize("content_type", ["json", "<|constrain|>json"])
+    def test_json_final_render_accepted(self, harmony_parser, content_type):
+        final = assistant('{"answer": "Tokyo"}', "final").with_content_type(
+            content_type
+        )
+        output = self._rendered_output(assistant("reasoning", "analysis"), final)
+        assert _is_grammar_accept_string(
+            self._auto_grammar(harmony_parser), output, require_termination=False
+        ), f"grammar rejected real harmony json-final render: {output!r}"

--- a/vllm/parser/harmony.py
+++ b/vllm/parser/harmony.py
@@ -399,11 +399,18 @@ _TOOL_CALL_CHANNELS = [
     "<|channel|>analysis",
     "<|channel|>final",
 ]
+# Harmony renders a JSON-typed message as either a bare `` json`` marker or an
+# explicit `` <|constrain|>json`` marker (see ``openai_harmony`` render output).
+# Constrained decoding must accept both.
+_JSON_CONSTRAINTS = [" json", " <|constrain|>json"]
+# Harmony renders a tool call recipient-first with the channel attached directly
+# to the function name, e.g.
+# ``<|start|>assistant to=functions.foo<|channel|>commentary json<|message|>``.
+# The leading space follows ``<|start|>assistant``; the channel has no preceding
+# space.
 _FUNCTION_CALL_BEGINS = [
-    "to=functions.{name} {channel} json<|message|>",
-    "to=functions.{name} {channel} <|constrain|>json<|message|>",
-    "{channel} to=functions.{name} json<|message|>",
-    "{channel} to=functions.{name} <|constrain|>json<|message|>",
+    f" to=functions.{{name}}{{channel}}{constraint}<|message|>"
+    for constraint in _JSON_CONSTRAINTS
 ]
 _JSON_CONTENT = JSONSchemaFormat(json_schema={"type": "object"})
 _ANY_CONTENT = AnyTextFormat()
@@ -490,20 +497,14 @@ def get_harmony_structural_tag(
         ]
 
     if tool_choice == "auto":
-        tags.append(
-            TagFormat(
-                begin=_FINAL_BEGIN.format(constrain=" <|constrain|>json"),
-                content=_ANY_CONTENT,
-                end=_END_TAG,
+        for constraint in (*_JSON_CONSTRAINTS, ""):
+            tags.append(
+                TagFormat(
+                    begin=_FINAL_BEGIN.format(constrain=constraint),
+                    content=_ANY_CONTENT,
+                    end=_END_TAG,
+                )
             )
-        )
-        tags.append(
-            TagFormat(
-                begin=_FINAL_BEGIN.format(constrain=""),
-                content=_ANY_CONTENT,
-                end=_END_TAG,
-            )
-        )
 
     return _assemble_tag(
         allow_analysis=True, allow_commentary=True, content=OrFormat(elements=tags)
@@ -560,14 +561,27 @@ def _adjust_output_format(
         return request
 
     if isinstance(final_content, JSONSchemaFormat):
-        begin = _FINAL_BEGIN.format(constrain=" <|constrain|>json")
+        content: Format = OrFormat(
+            elements=[
+                TagFormat(
+                    begin=_FINAL_BEGIN.format(constrain=constraint),
+                    content=final_content,
+                    end=_END_TAG,
+                )
+                for constraint in _JSON_CONSTRAINTS
+            ]
+        )
     else:
-        begin = _FINAL_BEGIN.format(constrain="")
+        content = TagFormat(
+            begin=_FINAL_BEGIN.format(constrain=""),
+            content=final_content,
+            end=_END_TAG,
+        )
 
     structural_tag = _assemble_tag(
         allow_analysis=True,
         allow_commentary=False,
-        content=TagFormat(begin=begin, content=final_content, end=_END_TAG),
+        content=content,
     )
 
     request.structured_outputs = replace(


### PR DESCRIPTION
## Purpose

`VLLM_ENFORCE_STRICT_TOOL_CALLING` defaults to **True** (`vllm/envs.py`), so for GPT-OSS/Harmony every tool-calling request goes through the strict structural-tag grammar built in `vllm/parser/harmony.py`. That grammar's begin strings **do not match what `openai_harmony` actually renders**, so constrained decoding can never satisfy the grammar for a canonical tool call or JSON final message — strict tool calling is broken on the default path.

### What Harmony really renders (ground truth from `openai_harmony`)

```
tool call:   <|start|>assistant to=functions.foo<|channel|>commentary json<|message|>{...}<|call|>
tool call:   <|start|>assistant to=functions.foo<|channel|>commentary <|constrain|>json<|message|>{...}<|call|>
json final:  <|start|>assistant<|channel|>final json<|message|>{...}<|end|>
```

Recipient comes **first**, with a **leading space** after `<|start|>assistant`, the channel attached **directly** to the function name (no space), and the JSON marker is either a bare `` json`` or `` <|constrain|>json``.

### What the grammar produced (all four begins wrong)

```python
_FUNCTION_CALL_BEGINS = [
    "to=functions.{name} {channel} json<|message|>",              # no leading space; spurious space before channel
    "to=functions.{name} {channel} <|constrain|>json<|message|>", # same
    "{channel} to=functions.{name} json<|message|>",              # channel-first (never emitted)
    "{channel} to=functions.{name} <|constrain|>json<|message|>", # channel-first
]
```

None match the real render. The final-channel begins only accepted `<|constrain|>json`, dropping the bare `` json`` form.

I verified this against xgrammar (`Grammar.from_structural_tag` + `_is_grammar_accept_string`): every real `openai_harmony` render — tool call (both markers, all channels), JSON final — was **rejected**; only the hand-written shapes the test happened to encode were accepted.

## Fix

Rebuild the begins recipient-first with correct spacing and cover both JSON markers, for tool calls and for the final channel (both the `tool_choice="auto"` tags and the `response_format` path in `_adjust_output_format`). After the fix, all real renders are accepted and the channel-first garbage shape is still rejected (no over-acceptance).

## Why the original test missed it

`tests/parser/test_harmony.py::TestAdjustRequest` hand-wrote its admission samples in the **channel-first** shape (`<|channel|>commentary to=functions.NAME json...`), i.e. it asserted the grammar accepts the pattern shapes rather than what `render_conversation` produces — so it passed while the real format was rejected. This PR:

- corrects the `TOOL_CALL_*` / `FINAL_JSON_*` samples to the real render shapes, and
- adds `TestHarmonyGrammarAcceptsRealRenders`, which sources samples straight from `openai_harmony` (`render_conversation`) so the grammar can no longer drift from what the model emits.

## Not a duplicate

- `gh pr list --search "harmony strict tool call grammar"` / `"_FUNCTION_CALL_BEGINS structural tag"` / `"45560 in:body"` — no open PR addresses this mismatch. Adjacent PRs (#48116 xgrammar reasoning parser, #35906 Harmony token sanitization, #30557 gpt-oss `tool_choice=required` draft) are unrelated.

## Test plan

```
.venv/bin/python -m pytest tests/parser/test_harmony.py -q
# 68 passed
```

- `TestHarmonyGrammarAcceptsRealRenders` (new): 4 passed — grammar accepts live `openai_harmony` tool-call and JSON-final renders for both `` json`` and `` <|constrain|>json`` markers.
- Fix-absent/fix-present verified: with the fix reverted, the updated admission cases (all six `tool_*` cases **and** the `structured_outputs`/`structural_tag` JSON-final cases) **fail**; with the fix they pass.
- `ruff-check` / `ruff-format` / `mypy` on the changed files: clean.

The integration suite `tests/entrypoints/openai/responses/test_harmony.py` requires the `gpt_oss` package + a live server (unavailable in this environment); the parser-level tests above fully exercise the grammar change.

## AI assistance

AI assistance (Claude Code) was used to locate and analyze this issue and reproduce it against xgrammar; every changed line was reviewed and the tests were run locally by the submitter.
