### PR TITLE
[Rust Frontend] Use fastokens for tiktoken models

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1260,16 +1260,18 @@ dependencies = [
 
 [[package]]
 name = "fastokens"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8728655e193e0d08d7a95d63cf1fdb9b768d282cab0a112ecb006615bae9f067"
+checksum = "35ff8cf975d8f772e7d4c3be439659b0b23b1ae1086ebee7204573807053ff7f"
 dependencies = [
  "daachorse",
  "fancy-regex 0.17.0",
  "icu_normalizer",
+ "libc",
  "memchr",
  "pcre2",
  "rayon",
+ "regex-syntax",
  "serde",
  "serde_json",
  "strum",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -42,7 +42,7 @@ easy-ext = "1.0.3"
 educe = "0.6.0"
 enum-as-inner = "0.7.0"
 expect-test = "1.5.1"
-fastokens = { version = "0.2.1", default-features = false }
+fastokens = { version = "0.3.1", default-features = false }
 futures = "0.3.31"
 half = { version = "2.7.1", features = ["bytemuck"] }
 hex = "0.4.3"

--- a/rust/src/tokenizer/benches/tiktoken.rs
+++ b/rust/src/tokenizer/benches/tiktoken.rs
@@ -22,6 +22,7 @@ struct BenchFixture {
     tiktoken_rs: TiktokenTokenizer,
     text: String,
     token_ids: Vec<u32>,
+    ordinary_token_ids: Vec<u32>,
 }
 
 impl BenchFixture {
@@ -74,6 +75,7 @@ impl BenchFixture {
             tiktoken_rs,
             text,
             token_ids: fastokens_token_ids,
+            ordinary_token_ids: fastokens_ordinary_token_ids,
         }
     }
 }
@@ -192,5 +194,53 @@ fn bench_decode(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_encode, bench_encode_ordinary, bench_decode);
+fn bench_decode_ordinary(c: &mut Criterion) {
+    let fixture = BenchFixture::load();
+    let mut group = c.benchmark_group("tiktoken_decode_ordinary");
+    group.throughput(Throughput::Elements(fixture.ordinary_token_ids.len() as u64));
+
+    group.bench_function("fastokens", |b| {
+        b.iter(|| {
+            fixture
+                .fastokens
+                .decode(
+                    black_box(fixture.ordinary_token_ids.as_slice()),
+                    black_box(false),
+                )
+                .expect("decode ordinary token ids with fastokens")
+        })
+    });
+    group.bench_function("riptoken", |b| {
+        b.iter(|| {
+            fixture
+                .riptoken
+                .decode(
+                    black_box(fixture.ordinary_token_ids.as_slice()),
+                    black_box(false),
+                )
+                .expect("decode ordinary token ids with riptoken")
+        })
+    });
+    group.bench_function("tiktoken_rs", |b| {
+        b.iter(|| {
+            fixture
+                .tiktoken_rs
+                .decode(
+                    black_box(fixture.ordinary_token_ids.as_slice()),
+                    black_box(false),
+                )
+                .expect("decode ordinary token ids with tiktoken-rs")
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_encode,
+    bench_encode_ordinary,
+    bench_decode,
+    bench_decode_ordinary
+);
 criterion_main!(benches);

--- a/rust/src/tokenizer/benches/tiktoken.rs
+++ b/rust/src/tokenizer/benches/tiktoken.rs
@@ -17,6 +17,7 @@ The service should stop cleanly at EOS, avoid leaking the next template turn, an
 ";
 
 struct BenchFixture {
+    fastokens: TiktokenTokenizer,
     riptoken: TiktokenTokenizer,
     tiktoken_rs: TiktokenTokenizer,
     text: String,
@@ -26,31 +27,53 @@ struct BenchFixture {
 impl BenchFixture {
     fn load() -> Self {
         let path = tiktoken_model();
+        let fastokens = TiktokenTokenizer::new_fastokens(&path).expect("load fastokens tokenizer");
         let riptoken = TiktokenTokenizer::new_riptoken(&path).expect("load riptoken tokenizer");
         let tiktoken_rs =
             TiktokenTokenizer::new_tiktoken_rs(&path).expect("load tiktoken-rs tokenizer");
 
         let text = SAMPLE_TEXT.repeat(32);
+        let fastokens_token_ids = fastokens
+            .encode(text.as_str(), false)
+            .expect("encode sample text with fastokens");
         let riptoken_token_ids =
             riptoken.encode(text.as_str(), false).expect("encode sample text with riptoken");
         let tiktoken_rs_token_ids = tiktoken_rs
             .encode(text.as_str(), false)
             .expect("encode sample text with tiktoken-rs");
-        assert_eq!(riptoken_token_ids, tiktoken_rs_token_ids);
+        assert_eq!(fastokens_token_ids, riptoken_token_ids);
+        assert_eq!(fastokens_token_ids, tiktoken_rs_token_ids);
 
+        let fastokens_ordinary_token_ids = fastokens
+            .encode_ordinary(text.as_str())
+            .expect("ordinary-encode sample text with fastokens");
+        let riptoken_ordinary_token_ids = riptoken
+            .encode_ordinary(text.as_str())
+            .expect("ordinary-encode sample text with riptoken");
+        let tiktoken_rs_ordinary_token_ids = tiktoken_rs
+            .encode_ordinary(text.as_str())
+            .expect("ordinary-encode sample text with tiktoken-rs");
+        assert_eq!(fastokens_ordinary_token_ids, riptoken_ordinary_token_ids);
+        assert_eq!(fastokens_ordinary_token_ids, tiktoken_rs_ordinary_token_ids);
+
+        let fastokens_decoded = fastokens
+            .decode(fastokens_token_ids.as_slice(), false)
+            .expect("decode sample token ids with fastokens");
         let riptoken_decoded = riptoken
-            .decode(riptoken_token_ids.as_slice(), false)
+            .decode(fastokens_token_ids.as_slice(), false)
             .expect("decode sample token ids with riptoken");
         let tiktoken_rs_decoded = tiktoken_rs
-            .decode(riptoken_token_ids.as_slice(), false)
+            .decode(fastokens_token_ids.as_slice(), false)
             .expect("decode sample token ids with tiktoken-rs");
-        assert_eq!(riptoken_decoded, tiktoken_rs_decoded);
+        assert_eq!(fastokens_decoded, riptoken_decoded);
+        assert_eq!(fastokens_decoded, tiktoken_rs_decoded);
 
         Self {
+            fastokens,
             riptoken,
             tiktoken_rs,
             text,
-            token_ids: riptoken_token_ids,
+            token_ids: fastokens_token_ids,
         }
     }
 }
@@ -75,6 +98,14 @@ fn bench_encode(c: &mut Criterion) {
     let mut group = c.benchmark_group("tiktoken_encode");
     group.throughput(Throughput::Bytes(fixture.text.len() as u64));
 
+    group.bench_function("fastokens", |b| {
+        b.iter(|| {
+            fixture
+                .fastokens
+                .encode(black_box(fixture.text.as_str()), black_box(false))
+                .expect("encode sample text with fastokens")
+        })
+    });
     group.bench_function("riptoken", |b| {
         b.iter(|| {
             fixture
@@ -95,11 +126,52 @@ fn bench_encode(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_encode_ordinary(c: &mut Criterion) {
+    let fixture = BenchFixture::load();
+    let mut group = c.benchmark_group("tiktoken_encode_ordinary");
+    group.throughput(Throughput::Bytes(fixture.text.len() as u64));
+
+    group.bench_function("fastokens", |b| {
+        b.iter(|| {
+            fixture
+                .fastokens
+                .encode_ordinary(black_box(fixture.text.as_str()))
+                .expect("ordinary-encode sample text with fastokens")
+        })
+    });
+    group.bench_function("riptoken", |b| {
+        b.iter(|| {
+            fixture
+                .riptoken
+                .encode_ordinary(black_box(fixture.text.as_str()))
+                .expect("ordinary-encode sample text with riptoken")
+        })
+    });
+    group.bench_function("tiktoken_rs", |b| {
+        b.iter(|| {
+            fixture
+                .tiktoken_rs
+                .encode_ordinary(black_box(fixture.text.as_str()))
+                .expect("ordinary-encode sample text with tiktoken-rs")
+        })
+    });
+
+    group.finish();
+}
+
 fn bench_decode(c: &mut Criterion) {
     let fixture = BenchFixture::load();
     let mut group = c.benchmark_group("tiktoken_decode");
     group.throughput(Throughput::Elements(fixture.token_ids.len() as u64));
 
+    group.bench_function("fastokens", |b| {
+        b.iter(|| {
+            fixture
+                .fastokens
+                .decode(black_box(fixture.token_ids.as_slice()), black_box(false))
+                .expect("decode sample token ids with fastokens")
+        })
+    });
     group.bench_function("riptoken", |b| {
         b.iter(|| {
             fixture
@@ -120,5 +192,5 @@ fn bench_decode(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_encode, bench_decode);
+criterion_group!(benches, bench_encode, bench_encode_ordinary, bench_decode);
 criterion_main!(benches);

--- a/rust/src/tokenizer/src/hf.rs
+++ b/rust/src/tokenizer/src/hf.rs
@@ -1,16 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-use std::borrow::Cow;
 use std::path::Path;
 use std::sync::{Arc, LazyLock};
 
 use fastokens::Tokenizer as FastokensTokenizer;
 use fastokens::decoders::Decoder as FastokensDecoder;
-use fastokens::pre_tokenized::{
-    PreTokenizedString as FastokensPreTokenizedString, Split as FastokensSplit,
-};
-use fastokens::{PreTokenizer as FastokensPreTokenizer, Split as FastokensSplitPreTokenizer};
 use thiserror_ext::AsReport as _;
 use tokenizers::{
     AddedVocabulary, Model as _, OffsetType, PreTokenizer as _, Tokenizer as HfTokenizer,
@@ -33,17 +28,20 @@ enum Backend {
     FastokensByteLevel(Box<FastokensTokenizer>),
 }
 
-/// True if `dec` is effectively a single `ByteLevel` stage — one `ByteLevel`
-/// leaf in a tree of `Sequence`s (fastokens represents `Fuse` as an empty
-/// `Sequence`, which is a no-op for our purposes).
+/// True if `dec` is effectively a single `ByteLevel` stage, optionally wrapped
+/// in `Sequence`s or followed by `Fuse`.
 fn is_byte_level_only(dec: &FastokensDecoder) -> bool {
-    fn count_byte_level(dec: &FastokensDecoder) -> usize {
+    fn count_byte_level(dec: &FastokensDecoder) -> Option<usize> {
         match dec {
-            FastokensDecoder::ByteLevel(_) => 1,
-            FastokensDecoder::Sequence(steps) => steps.iter().map(count_byte_level).sum(),
+            FastokensDecoder::ByteLevel(_) => Some(1),
+            FastokensDecoder::Fuse => Some(0),
+            FastokensDecoder::Sequence(steps) => {
+                steps.iter().try_fold(0, |count, step| Some(count + count_byte_level(step)?))
+            }
+            _ => None,
         }
     }
-    count_byte_level(dec) == 1
+    count_byte_level(dec) == Some(1)
 }
 
 fn decode_fastokens_byte_level(
@@ -73,72 +71,6 @@ fn encode_hf_ordinary(tokenizer: &HfTokenizer, text: &str) -> tokenizers::Result
     let encoding = pretokenized.into_encoding(None, 0, OffsetType::Byte)?;
     let encoding = tokenizer.post_process(encoding, None, false)?;
     Ok(encoding.get_ids().to_vec())
-}
-
-fn fastokens_fused_split(tokenizer: &FastokensTokenizer) -> Option<&FastokensSplitPreTokenizer> {
-    // Keep this predicate aligned with fastokens::Tokenizer::detect_fused_byte_level.
-    let FastokensPreTokenizer::Sequence(steps) = tokenizer.pre_tokenizer()? else {
-        return None;
-    };
-    let [
-        FastokensPreTokenizer::Split(split),
-        FastokensPreTokenizer::ByteLevel(byte_level),
-    ] = steps.as_slice()
-    else {
-        return None;
-    };
-    byte_level.is_bulk_only().then_some(split)
-}
-
-fn fastokens_pre_tokenized_ordinary(
-    tokenizer: &FastokensTokenizer,
-    text: &str,
-) -> FastokensPreTokenizedString {
-    // This is fastokens::Tokenizer::build_pre_tokenized with added_tokens = None.
-    let normalized = tokenizer
-        .normalizer()
-        .map_or(Cow::Borrowed(text), |normalizer| normalizer.normalize(text));
-    match normalized {
-        Cow::Borrowed(_) => FastokensPreTokenizedString::from_text(text),
-        Cow::Owned(text) => {
-            let len = text.len();
-            FastokensPreTokenizedString::new(
-                text,
-                vec![FastokensSplit {
-                    range: 0..len,
-                    token_id: None,
-                }],
-            )
-        }
-    }
-}
-
-fn encode_fastokens_ordinary(
-    tokenizer: &FastokensTokenizer,
-    text: &str,
-) -> std::result::Result<Vec<u32>, fastokens::Error> {
-    if text.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    let mut pretokenized = fastokens_pre_tokenized_ordinary(tokenizer, text);
-    let ids = if let Some(split) = fastokens_fused_split(tokenizer) {
-        split.pre_tokenize(&mut pretokenized)?;
-        pretokenized
-            .tokenize_batched(|buffer, splits, output| {
-                tokenizer.model().tokenize_batch_fused(buffer, splits, output)
-            })
-            .map_err(fastokens::Error::Model)?
-    } else {
-        if let Some(pre_tokenizer) = tokenizer.pre_tokenizer() {
-            pre_tokenizer.pre_tokenize(&mut pretokenized)?;
-        }
-        pretokenized
-            .tokenize(|text, output| tokenizer.model().tokenize_into(text, output))
-            .map_err(fastokens::Error::Model)?
-    };
-
-    Ok(tokenizer.post_process(ids, false))
 }
 
 /// Tokenizer from `tokenizer.json` in HuggingFace format.
@@ -248,10 +180,9 @@ impl Tokenizer for HuggingFaceTokenizer {
         match &self.backend {
             Backend::Hf(tokenizer) => encode_hf_ordinary(tokenizer, text)
                 .map_err(|error| tokenizer_error!("encoding failed: {}", error.as_report())),
-            Backend::Fastokens(tokenizer) | Backend::FastokensByteLevel(tokenizer) => {
-                encode_fastokens_ordinary(tokenizer, text)
-                    .map_err(|error| tokenizer_error!("encoding failed: {}", error.as_report()))
-            }
+            Backend::Fastokens(tokenizer) | Backend::FastokensByteLevel(tokenizer) => tokenizer
+                .encode_ordinary(text)
+                .map_err(|error| tokenizer_error!("encoding failed: {}", error.as_report())),
         }
     }
 
@@ -462,12 +393,6 @@ mod tests {
         );
         let tokenizer = constructor(&added_path).expect("load tokenizer with added tokens");
         let added_empty = constructor(&empty_path).expect("load tokenizer with empty added tokens");
-
-        if let super::Backend::Fastokens(inner) | super::Backend::FastokensByteLevel(inner) =
-            &tokenizer.backend
-        {
-            assert_eq!(super::fastokens_fused_split(inner).is_some(), fused);
-        }
 
         assert_eq!(
             tokenizer.encode(REGULAR_TOKEN, false).unwrap(),

--- a/rust/src/tokenizer/src/tiktoken.rs
+++ b/rust/src/tokenizer/src/tiktoken.rs
@@ -16,10 +16,10 @@ use crate::{Result, Tokenizer};
 /// Default regex pattern used when loading tiktoken from a BPE file. This is
 /// the same `cl100k_base` pattern that HuggingFace transformers uses as its
 /// default in `TikTokenConverter`.
-const CL100K_BASE_PATTERN: &str = r"(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\r\n\p{L}\p{N}]?\p{L}+|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+";
+const CL100K_BASE_PATTERN: &str = fastokens::tiktoken::CL100K_BASE_PATTERN;
 
 /// Kimi BPE pattern from `moonshotai/Kimi-K2-Instruct/tokenization_kimi.py`.
-const KIMI_PATTERN: &str = r"[\p{Han}]+|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]*[\p{Ll}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]+(?i:'s|'t|'re|'ve|'m|'ll|'d)?|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]+[\p{Ll}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]*(?i:'s|'t|'re|'ve|'m|'ll|'d)?|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+";
+const KIMI_PATTERN: &str = fastokens::tiktoken::KIMI_PATTERN;
 
 /// Fallback number of reserved special-token slots to assume when the model's
 /// `config.json` is not available (so we cannot read `vocab_size` directly).
@@ -36,6 +36,14 @@ const DISABLE_RIPTOKEN_ENV: &str = "VLLM_RS_DISABLE_RIPTOKEN";
 #[derive(Debug, Clone, Deserialize)]
 struct AddedToken {
     content: String,
+    #[serde(default)]
+    single_word: bool,
+    #[serde(default)]
+    lstrip: bool,
+    #[serde(default)]
+    rstrip: bool,
+    #[serde(default)]
+    normalized: bool,
     /// HuggingFace `added_tokens_decoder` entries can be marked `"special":
     /// true|false`. Special tokens are dropped from output when `decode` is
     /// called with `skip_special_tokens = true`. Defaults to `false` when
@@ -93,8 +101,13 @@ pub struct TiktokenTokenizer {
 }
 
 enum Backend {
+    Fastokens(FastokensBackend),
     Riptoken(RiptokenBackend),
     TiktokenRs(TiktokenRsBackend),
+}
+
+struct FastokensBackend {
+    inner: Box<fastokens::Tokenizer>,
 }
 
 struct RiptokenBackend {
@@ -124,16 +137,14 @@ struct TokenMetadata {
     /// vocab_upper_bound)` live in the special-token slots and are subject
     /// to `skip_special_tokens` filtering.
     num_base_tokens: u32,
-    /// Exclusive upper bound on token IDs that `inner` is guaranteed to know
+    /// Exclusive upper bound on token IDs every backend is guaranteed to know
     /// how to decode.
     ///
     /// The constructor registers every id in `[num_base_tokens,
-    /// vocab_upper_bound)` with the inner `CoreBPE` as a (named or
-    /// `<|reserved_token_{id}|>`) special token, and the BPE
-    /// encoder densely covers `[0, num_base_tokens)`. So any id below this
-    /// bound is in one of the inner `CoreBPE`'s decoder maps and
-    /// `_decode_native_and_split` will not panic on it. `decode` filters
-    /// out ids at or above this bound to keep that guarantee.
+    /// vocab_upper_bound)` as a named or `<|reserved_token_{id}|>` added token,
+    /// and the BPE encoder densely covers `[0, num_base_tokens)`. The
+    /// tiktoken-rs decode path filters ids at or above this bound before calling
+    /// `_decode_native_and_split`.
     vocab_upper_bound: u32,
     /// Ids in `[num_base_tokens, vocab_upper_bound)` whose
     /// `added_tokens_decoder` entry was explicitly marked `"special":
@@ -170,6 +181,21 @@ impl TokenMetadata {
 
     fn id_to_token(&self, token_id: u32) -> Option<String> {
         self.token_by_id.get(&token_id).cloned()
+    }
+}
+
+impl FastokensBackend {
+    fn token_to_id(&self, token: &str) -> Option<u32> {
+        if let Some(token_id) = self
+            .inner
+            .added_tokens()
+            .and_then(|added_tokens| added_tokens.token_to_id(token))
+        {
+            return Some(token_id);
+        }
+
+        let ids = self.inner.encode_ordinary(token).ok()?;
+        if ids.len() == 1 { Some(ids[0]) } else { None }
     }
 }
 
@@ -259,6 +285,17 @@ impl TiktokenTokenizer {
     /// directory when present. The `cl100k_base` regex pattern is used as a
     /// reasonable default.
     pub fn new(path: &Path) -> Result<Self> {
+        match Self::new_fastokens(path) {
+            Ok(tokenizer) => return Ok(tokenizer),
+            Err(error) => {
+                warn!(
+                    path = %path.display(),
+                    error = %error.as_report(),
+                    "failed to load tiktoken file with fastokens; falling back"
+                );
+            }
+        }
+
         if std::env::var_os(DISABLE_RIPTOKEN_ENV).is_some() {
             return Self::new_tiktoken_rs(path);
         }
@@ -274,6 +311,33 @@ impl TiktokenTokenizer {
                 Self::new_tiktoken_rs(path)
             }
         }
+    }
+
+    /// Load from `tiktoken.model` / `*.tiktoken` with fastokens.
+    pub fn new_fastokens(path: &Path) -> Result<Self> {
+        info!(path = %path.display(), "loading tokenizer with fastokens (BPE file)");
+
+        let config = LoadedTiktokenConfig::load(path)?;
+        let ranks: Vec<(Vec<u8>, u32)> = config.encoder.into_iter().collect();
+        let inner = fastokens::Tokenizer::from_tiktoken_ranks_with_added_tokens(
+            &ranks,
+            config.pattern,
+            &config.added_tokens,
+        )
+        .map_err(|error| {
+            tokenizer_error!(
+                "failed to create fastokens tokenizer from {}: {}",
+                path.display(),
+                error.as_report()
+            )
+        })?;
+
+        Ok(Self {
+            backend: Backend::Fastokens(FastokensBackend {
+                inner: Box::new(inner),
+            }),
+            metadata: config.metadata,
+        })
     }
 
     /// Load from `tiktoken.model` / `*.tiktoken` with riptoken.
@@ -335,6 +399,7 @@ impl TiktokenTokenizer {
 struct LoadedTiktokenConfig {
     encoder: FxHashMap<Vec<u8>, u32>,
     special_tokens_encoder: FxHashMap<String, u32>,
+    added_tokens: Vec<fastokens::AddedTokenConfig>,
     metadata: TokenMetadata,
     pattern: &'static str,
 }
@@ -411,18 +476,36 @@ impl LoadedTiktokenConfig {
                 (reserved_end - num_base_tokens) as usize,
                 Default::default(),
             );
+        let mut added_tokens = Vec::with_capacity((reserved_end - num_base_tokens) as usize);
         let mut non_special_added_ids: FxHashSet<u32> = FxHashSet::default();
         for id in num_base_tokens..reserved_end {
-            let name = match added_tokens_by_id.get(&id) {
+            let config = match added_tokens_by_id.get(&id) {
                 Some(token) => {
                     if !token.special {
                         non_special_added_ids.insert(id);
                     }
-                    token.content.clone()
+                    fastokens::AddedTokenConfig {
+                        id,
+                        content: token.content.clone(),
+                        single_word: token.single_word,
+                        lstrip: token.lstrip,
+                        rstrip: token.rstrip,
+                        normalized: token.normalized,
+                        special: token.special,
+                    }
                 }
-                None => format!("<|reserved_token_{id}|>"),
+                None => fastokens::AddedTokenConfig {
+                    id,
+                    content: format!("<|reserved_token_{id}|>"),
+                    single_word: false,
+                    lstrip: false,
+                    rstrip: false,
+                    normalized: false,
+                    special: true,
+                },
             };
-            special_tokens_encoder.insert(name, id);
+            special_tokens_encoder.insert(config.content.clone(), id);
+            added_tokens.push(config);
         }
 
         let mut token_by_id: FxHashMap<u32, String> = FxHashMap::with_capacity_and_hasher(
@@ -441,6 +524,7 @@ impl LoadedTiktokenConfig {
         Ok(Self {
             encoder,
             special_tokens_encoder,
+            added_tokens,
             metadata: TokenMetadata {
                 num_base_tokens,
                 vocab_upper_bound: reserved_end,
@@ -454,29 +538,37 @@ impl LoadedTiktokenConfig {
 
 impl Tokenizer for TiktokenTokenizer {
     fn encode(&self, text: &str, _add_special_tokens: bool) -> Result<Vec<u32>> {
-        // Tiktoken does not have a separate add_special_tokens toggle; both
-        // backends recognize registered special tokens in the input.
-        Ok(match &self.backend {
-            Backend::Riptoken(backend) => backend.encode(text),
-            Backend::TiktokenRs(backend) => backend.encode(text),
-        })
+        // Tiktoken does not have a separate add_special_tokens toggle; every
+        // backend recognizes registered special tokens in the input.
+        match &self.backend {
+            Backend::Fastokens(backend) => backend
+                .inner
+                .encode(text)
+                .map_err(|error| tokenizer_error!("encoding failed: {}", error.as_report())),
+            Backend::Riptoken(backend) => Ok(backend.encode(text)),
+            Backend::TiktokenRs(backend) => Ok(backend.encode(text)),
+        }
     }
 
     fn encode_ordinary(&self, text: &str) -> Result<Vec<u32>> {
-        Ok(match &self.backend {
-            Backend::Riptoken(backend) => backend.inner.encode_ordinary(text),
-            Backend::TiktokenRs(backend) => backend.inner.encode_ordinary(text),
-        })
+        match &self.backend {
+            Backend::Fastokens(backend) => backend
+                .inner
+                .encode_ordinary(text)
+                .map_err(|error| tokenizer_error!("encoding failed: {}", error.as_report())),
+            Backend::Riptoken(backend) => Ok(backend.inner.encode_ordinary(text)),
+            Backend::TiktokenRs(backend) => Ok(backend.inner.encode_ordinary(text)),
+        }
     }
 
     fn decode(&self, token_ids: &[u32], skip_special_tokens: bool) -> Result<String> {
         // Filter passes:
         //
-        // 1. The constructor registers every id in `[num_base_tokens, vocab_upper_bound)` as a
-        //    special token (named or `<|reserved_token_{id}|>` placeholder, matching
+        // 1. The constructor registers every id in `[num_base_tokens, vocab_upper_bound)` as an
+        //    added token (named or `<|reserved_token_{id}|>` placeholder, matching
         //    `tokenization_kimi.py`). The tiktoken-rs backend additionally drops ids at or above
-        //    that bound so `_decode_native_and_split` cannot panic; riptoken's `decode_bytes`
-        //    already skips unknown ids.
+        //    that bound before `_decode_native_and_split`; fastokens and riptoken skip unknown
+        //    ids during decode.
         //
         // 2. When `skip_special_tokens = true`, ids in `[num_base_tokens, vocab_upper_bound)` are
         //    dropped *unless* they were marked `"special": false` in `added_tokens_decoder`. This
@@ -493,14 +585,19 @@ impl Tokenizer for TiktokenTokenizer {
             token_ids
         };
 
-        Ok(match &self.backend {
-            Backend::Riptoken(backend) => backend.decode(ids),
-            Backend::TiktokenRs(backend) => backend.decode(ids, &self.metadata),
-        })
+        match &self.backend {
+            Backend::Fastokens(backend) => backend
+                .inner
+                .decode(ids, false)
+                .map_err(|error| tokenizer_error!("decoding failed: {}", error.as_report())),
+            Backend::Riptoken(backend) => Ok(backend.decode(ids)),
+            Backend::TiktokenRs(backend) => Ok(backend.decode(ids, &self.metadata)),
+        }
     }
 
     fn token_to_id(&self, token: &str) -> Option<u32> {
         match &self.backend {
+            Backend::Fastokens(backend) => backend.token_to_id(token),
             Backend::Riptoken(backend) => backend.token_to_id(token),
             Backend::TiktokenRs(backend) => backend.token_to_id(token),
         }
@@ -598,6 +695,7 @@ mod tests {
     /// `FALLBACK_NUM_RESERVED_SPECIAL_TOKENS` (256) path.
     fn explicit_backends(path: &Path) -> Vec<TiktokenTokenizer> {
         vec![
+            TiktokenTokenizer::new_fastokens(path).expect("load fastokens backend"),
             TiktokenTokenizer::new_riptoken(path).expect("load riptoken backend"),
             TiktokenTokenizer::new_tiktoken_rs(path).expect("load tiktoken-rs backend"),
         ]
@@ -695,7 +793,14 @@ mod tests {
         fs::write(dir.path().join("config.json"), r#"{"vocab_size": 1002}"#)
             .expect("write config.json");
 
-        for backend in explicit_backends(&bpe_path) {
+        // fastokens requires a contiguous, merge-decomposable rank table. The
+        // default constructor falls through to riptoken for this synthetic
+        // sparse table, while tiktoken-rs supports it directly.
+        assert!(TiktokenTokenizer::new_fastokens(&bpe_path).is_err());
+        for backend in [
+            TiktokenTokenizer::new(&bpe_path).expect("load fallback backend"),
+            TiktokenTokenizer::new_tiktoken_rs(&bpe_path).expect("load tiktoken-rs backend"),
+        ] {
             let sparse_id = backend.token_to_id("SPARSE");
             assert_eq!(sparse_id, Some(1000));
             assert_eq!(backend.id_to_token(1000).as_deref(), Some("SPARSE"));


### PR DESCRIPTION
## Purpose

Upgrade `fastokens` from 0.2.1 to 0.3.1 and prefer its native `tiktoken.model` backend in the Rust frontend. Kimi K3's typed-segment encoder calls `encode_ordinary` for text spans and writes control-token IDs directly, so this uses the optimized ordinary path without Python or FFI work.

The loader carries all declared added-token flags into fastokens. Unsupported rank tables retain the existing riptoken and tiktoken-rs fallbacks; the sparse-rank test explicitly verifies that fastokens construction fails before fallback succeeds. Hugging Face tokenizers now call fastokens 0.3.1's public `encode_ordinary` API instead of maintaining a vLLM-local copy of its internals.

The Criterion benchmark now covers fastokens, riptoken, and tiktoken-rs across mixed encode, ordinary encode, mixed decode, and ordinary decode. Each fixture loads `moonshotai/Kimi-K2.5` and asserts identical encode IDs and decoded output before timing.

I searched open upstream PRs for `fastokens`, `tiktoken tokenizer rust`, and `encode_ordinary fastokens`. The matches cover Docker packaging and incremental detokenization, with no overlapping tiktoken backend integration.

AI assistance was used for implementation review, benchmark execution, and PR preparation. The submitter directed the design and reviewed the changes during development; final human review remains required before this draft is marked ready.

## Test Plan

```bash
cd rust
cargo fmt --check
cargo nextest run -p vllm-tokenizer
cargo nextest run -p vllm-chat kimi_k3
cargo clippy -p vllm-tokenizer --all-targets -- -D warnings
taskset -c 70 cargo bench -p vllm-tokenizer --bench tiktoken -- --noplot
```

The experimental mixed-span measurement used the same source revision and benchmark in an isolated worktree with this dependency override:

```bash
taskset -c 70 cargo bench --config 'patch.crates-io.fastokens.path="/home/bugen/work/fastokens"' -p vllm-tokenizer --bench tiktoken -- 'tiktoken_encode/fastokens$' --noplot
```

## Test Result

- `vllm-tokenizer`: 62 passed
- Kimi K3 chat tests: 20 passed, 263 filtered
- fmt and clippy: passed
- Model-level tokenizer check: the real Kimi-K2.5 benchmark fixture produced identical mixed IDs, ordinary IDs, and decoded output across all three backends

Single-core Criterion results on CPU 70, using the 95% interval midpoint and a 11,776-byte mixed English/Chinese/control-marker input:

| Workload | Backend | Time | Throughput |
| --- | --- | ---: | ---: |
| mixed encode | fastokens 0.3.1 | 361.13 us | 31.098 MiB/s |
| mixed encode | fastokens 0.3.1 + local multi-span patch | 59.389 us | 189.10 MiB/s |
| mixed encode | riptoken | 190.63 us | 58.911 MiB/s |
| mixed encode | tiktoken-rs | 935.13 us | 12.009 MiB/s |
| ordinary encode | fastokens 0.3.1 | 44.243 us | 253.84 MiB/s |
| ordinary encode | riptoken | 197.91 us | 56.745 MiB/s |
| ordinary encode | tiktoken-rs | 1.0696 ms | 10.500 MiB/s |
| mixed decode | fastokens 0.3.1 | 122.48 us | 18.551 Mtoken/s |
| mixed decode | riptoken | 13.455 us | 168.86 Mtoken/s |
| mixed decode | tiktoken-rs | 90.969 us | 24.976 Mtoken/s |
| ordinary decode | fastokens 0.3.1 | 145.65 us | 18.895 Mtoken/s |
| ordinary decode | riptoken | 15.050 us | 182.86 Mtoken/s |
| ordinary decode | tiktoken-rs | 99.470 us | 27.667 Mtoken/s |

The local multi-span result uses [BugenZhao/fastokens@518cb8a](https://github.com/BugenZhao/fastokens/commit/518cb8a7f7735d9687c2a1a4c825dbc344256bb7); this vLLM branch remains on crates.io 0.3.1. That patch makes mixed encode 6.08x faster than released fastokens and 3.21x faster than riptoken in this single-core workload. The released ordinary path is 4.47x faster than riptoken and is the path used by Kimi K3 typed segments.
