### PR TITLE
[Bugfix] Forward SwiGLU clamp/alpha/beta in compressed-tensors W4A4 MXFP4 MoE

### DIFF
--- a/tests/quantization/test_compressed_tensors.py
+++ b/tests/quantization/test_compressed_tensors.py
@@ -22,6 +22,7 @@ from vllm.model_executor.kernels.linear import (
     Fp8BlockScaledMMLinearKernel,
 )
 from vllm.model_executor.layers.fused_moe import UnquantizedFusedMoEMethod
+from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import Mxfp4MoeBackend
 from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import (  # noqa: E501
     CompressedTensorsConfig,
     CompressedTensorsLinearMethod,
@@ -34,6 +35,9 @@ from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tenso
     CompressedTensorsW8A16Fp8,
     CompressedTensorsWNA8O8Int,
     CompressedTensorsWNA16,
+)
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe_w4a4_mxfp4 import (  # noqa: E501
+    CompressedTensorsW4A4Mxfp4MoEMethod,
 )
 from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
     find_matched_target,
@@ -343,6 +347,32 @@ def test_compressed_tensors_fp8(vllm_runner):
 
         output = llm.generate_greedy("Hello my name is", max_tokens=4)
         assert output
+
+
+def test_compressed_tensors_w4a4_mxfp4_moe_forwards_swiglu_params():
+    quant_method = object.__new__(CompressedTensorsW4A4Mxfp4MoEMethod)
+    quant_method.mxfp4_backend = Mxfp4MoeBackend.MARLIN
+
+    layer = Mock()
+    layer.w13_weight_scale = torch.ones(2, 8, 4)
+    layer.w2_weight_scale = torch.ones(2, 4, 8)
+    layer.swiglu_alpha = 1.702
+    layer.swiglu_beta = 1.0
+    layer.swiglu_limit = 7.0
+
+    # CUTLASS W4A4 branch.
+    quant_method.use_cutlass_mxfp4 = True
+    quant_config = quant_method.get_fused_moe_quant_config(layer)
+    assert quant_config.gemm1_alpha == 1.702
+    assert quant_config.gemm1_beta == 1.0
+    assert quant_config.gemm1_clamp_limit == 7.0
+
+    # Marlin W4A16 branch.
+    quant_method.use_cutlass_mxfp4 = False
+    quant_config = quant_method.get_fused_moe_quant_config(layer)
+    assert quant_config.gemm1_alpha == 1.702
+    assert quant_config.gemm1_beta == 1.0
+    assert quant_config.gemm1_clamp_limit == 7.0
 
 
 @pytest.mark.skipif(

--- a/tests/quantization/test_compressed_tensors.py
+++ b/tests/quantization/test_compressed_tensors.py
@@ -23,6 +23,7 @@ from vllm.model_executor.kernels.linear import (
 )
 from vllm.model_executor.layers.fused_moe import UnquantizedFusedMoEMethod
 from vllm.model_executor.layers.fused_moe.oracle.fp8 import Fp8MoeBackend
+from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import Mxfp4MoeBackend
 from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import (  # noqa: E501
     CompressedTensorsConfig,
     CompressedTensorsLinearMethod,
@@ -35,6 +36,9 @@ from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tenso
     CompressedTensorsW8A16Fp8,
     CompressedTensorsWNA8O8Int,
     CompressedTensorsWNA16,
+)
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe_w4a4_mxfp4 import (  # noqa: E501
+    CompressedTensorsW4A4Mxfp4MoEMethod,
 )
 from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe_w8a8_fp8 import (  # noqa: E501
     CompressedTensorsW8A8Fp8MoEMethod,
@@ -374,6 +378,32 @@ def test_compressed_tensors_w8a8_fp8_moe_forwards_swiglu_params():
 
     assert quant_config.gemm1_alpha == 1.702
     assert quant_config.gemm1_beta is None
+    assert quant_config.gemm1_clamp_limit == 7.0
+
+
+def test_compressed_tensors_w4a4_mxfp4_moe_forwards_swiglu_params():
+    quant_method = object.__new__(CompressedTensorsW4A4Mxfp4MoEMethod)
+    quant_method.mxfp4_backend = Mxfp4MoeBackend.MARLIN
+
+    layer = Mock()
+    layer.w13_weight_scale = torch.ones(2, 8, 4)
+    layer.w2_weight_scale = torch.ones(2, 4, 8)
+    layer.swiglu_alpha = 1.702
+    layer.swiglu_beta = 1.0
+    layer.swiglu_limit = 7.0
+
+    # CUTLASS W4A4 branch.
+    quant_method.use_cutlass_mxfp4 = True
+    quant_config = quant_method.get_fused_moe_quant_config(layer)
+    assert quant_config.gemm1_alpha == 1.702
+    assert quant_config.gemm1_beta == 1.0
+    assert quant_config.gemm1_clamp_limit == 7.0
+
+    # Marlin W4A16 branch.
+    quant_method.use_cutlass_mxfp4 = False
+    quant_config = quant_method.get_fused_moe_quant_config(layer)
+    assert quant_config.gemm1_alpha == 1.702
+    assert quant_config.gemm1_beta == 1.0
     assert quant_config.gemm1_clamp_limit == 7.0
 
 

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -844,6 +844,9 @@ def nvfp4_moe_quant_config(
 def mxfp4_moe_quant_config(
     w1_scale: torch.Tensor,
     w2_scale: torch.Tensor,
+    gemm1_alpha: float | None = None,
+    gemm1_beta: float | None = None,
+    gemm1_clamp_limit: float | None = None,
 ) -> FusedMoEQuantConfig:
     """
     Construct a quant config for MXFP4 x MXFP4 MoE.
@@ -857,6 +860,9 @@ def mxfp4_moe_quant_config(
         per_act_token_quant=False,
         per_out_ch_quant=False,
         block_shape=None,
+        gemm1_alpha=gemm1_alpha,
+        gemm1_beta=gemm1_beta,
+        gemm1_clamp_limit=gemm1_clamp_limit,
     )
 
 

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -840,6 +840,9 @@ def nvfp4_moe_quant_config(
 def mxfp4_moe_quant_config(
     w1_scale: torch.Tensor,
     w2_scale: torch.Tensor,
+    gemm1_alpha: float | None = None,
+    gemm1_beta: float | None = None,
+    gemm1_clamp_limit: float | None = None,
 ) -> FusedMoEQuantConfig:
     """
     Construct a quant config for MXFP4 x MXFP4 MoE.
@@ -853,6 +856,9 @@ def mxfp4_moe_quant_config(
         per_act_token_quant=False,
         per_out_ch_quant=False,
         block_shape=None,
+        gemm1_alpha=gemm1_alpha,
+        gemm1_beta=gemm1_beta,
+        gemm1_clamp_limit=gemm1_clamp_limit,
     )
 
 

--- a/vllm/model_executor/layers/fused_moe/experts/cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/cutlass_moe.py
@@ -824,6 +824,9 @@ def run_cutlass_moe_mxfp4(
     e: int,
     device: torch.device,
     apply_router_weight_on_input: bool = False,
+    clamp_limit: float | None = None,
+    alpha: float = 1.0,
+    beta: float = 0.0,
 ) -> None:
     """MXFP4 x MXFP4 MoE implementation using CUTLASS grouped GEMM."""
     is_gated = activation.is_gated
@@ -910,7 +913,9 @@ def run_cutlass_moe_mxfp4(
             c1, expert_offsets, blockscale_offsets, e, num_topk
         )
     else:
-        apply_moe_activation(activation, c2, c1)
+        apply_moe_activation(
+            activation, c2, c1, clamp_limit=clamp_limit, alpha=alpha, beta=beta
+        )
         int_fp4, int_blockscale = ops.mxfp4_experts_quant(
             c2, expert_offsets, blockscale_offsets, e, num_topk
         )
@@ -1021,6 +1026,7 @@ class CutlassExpertsMxfp4(mk.FusedMoEExpertsModular):
             MoEActivation.SILU,
             MoEActivation.GELU,
             MoEActivation.SWIGLUOAI,
+            MoEActivation.SWIGLUOAI_UNINTERLEAVE,
             MoEActivation.SWIGLUSTEP,
             MoEActivation.SILU_NO_MUL,
             MoEActivation.GELU_NO_MUL,
@@ -1080,6 +1086,10 @@ class CutlassExpertsMxfp4(mk.FusedMoEExpertsModular):
         e, m, n, k, _ = self.moe_problem_size(hidden_states, w1, w2, topk_ids)
         n = w2.shape[2] * 2
 
+        # Gated-activation params (used by SWIGLUOAI_UNINTERLEAVE on packed
+        # w13); configs that don't set them (plain silu) fall back to the
+        # silu identity (alpha=1, beta=0).
+        quant_config = self.quant_config
         run_cutlass_moe_mxfp4(
             output=output,
             a=hidden_states,
@@ -1098,6 +1108,9 @@ class CutlassExpertsMxfp4(mk.FusedMoEExpertsModular):
             e=e,
             device=hidden_states.device,
             apply_router_weight_on_input=apply_router_weight_on_input,
+            clamp_limit=quant_config.gemm1_clamp_limit,
+            alpha=1.0 if quant_config.gemm1_alpha is None else quant_config.gemm1_alpha,
+            beta=0.0 if quant_config.gemm1_beta is None else quant_config.gemm1_beta,
         )
 
 

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_mxfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_mxfp4.py
@@ -136,6 +136,9 @@ class CompressedTensorsW4A4Mxfp4MoEMethod(CompressedTensorsMoEMethod):
             return mxfp4_moe_quant_config(
                 w1_scale=layer.w13_weight_scale,
                 w2_scale=layer.w2_weight_scale,
+                gemm1_alpha=getattr(layer, "swiglu_alpha", None),
+                gemm1_beta=getattr(layer, "swiglu_beta", None),
+                gemm1_clamp_limit=getattr(layer, "swiglu_limit", None),
             )
         else:
             # W4A16: weight-only via Marlin
@@ -143,6 +146,9 @@ class CompressedTensorsW4A4Mxfp4MoEMethod(CompressedTensorsMoEMethod):
                 mxfp4_backend=self.mxfp4_backend,
                 w1_scale=layer.w13_weight_scale,
                 w2_scale=layer.w2_weight_scale,
+                gemm1_alpha=getattr(layer, "swiglu_alpha", None),
+                gemm1_beta=getattr(layer, "swiglu_beta", None),
+                swiglu_limit=getattr(layer, "swiglu_limit", None),
                 layer=layer,
             )
 


### PR DESCRIPTION
## Purpose

Fixes #51028

Models whose MoE uses the clamped SwiGLU-OAI activation (e.g. MiniMax-M3 in
compressed-tensors MXFP4 W4A4 form, `olka-fi/MiniMax-M3-MXFP4`) crash at
startup with:

```
RuntimeError: Worker failed with error 'SWIGLUOAI_UNINTERLEAVE requires clamp_limit'
```

`CompressedTensorsW4A4Mxfp4MoEMethod.get_fused_moe_quant_config` never forwards
the layer's `swiglu_limit` / `swiglu_alpha` / `swiglu_beta` into the
`FusedMoEQuantConfig`, so `gemm1_clamp_limit` / `gemm1_alpha` / `gemm1_beta`
stay `None` and the clamp assert in `apply_moe_activation`
(`vllm/model_executor/layers/fused_moe/activation.py`) trips. All four sibling
compressed-tensors MoE methods (`w4a4_nvfp4`, `w8a8_fp8`, `w8a8_mxfp8`,
`wna16`) already forward these via the `getattr(layer, "swiglu_*", None)`
idiom; only the W4A4 MXFP4 method was missed.

Branch-by-branch:

1. **Marlin / W4A16 branch**: `make_mxfp4_moe_quant_config`
   (`oracle/mxfp4.py`) already accepts `gemm1_alpha` / `gemm1_beta` /
   `swiglu_limit` and threads them into every backend config, and
   `MarlinExperts` already consumes them — the fix is to pass the three kwargs
   at the call site.
2. **CUTLASS W4A4 branch**: `mxfp4_moe_quant_config`
   (`fused_moe/config.py`) accepted only `w1_scale`/`w2_scale`. Extended its
   signature with `gemm1_alpha` / `gemm1_beta` / `gemm1_clamp_limit`
   (all defaulting to `None`, mirroring `nvfp4_w4a16_moe_quant_config` /
   `int4_w4a16_moe_quant_config` in the same file), passed through to
   `FusedMoEQuantConfig.make(...)`. Zero behavior change for the only other
   caller (`inc_mxfp4_moe.py`).

Consumption needs no changes on current main: `ApplyMoEActivationConfig`
already reads `gemm1_clamp_limit` / `gemm1_alpha` / `gemm1_beta` straight off
the quant config in `from_configs`, it is built centrally in
`FusedMoEModularKernel`, `run_cutlass_moe_mxfp4` already threads
`activation_config` into `apply_moe_activation`, and
`CutlassExpertsMxfp4._supports_activation` already delegates to
`apply_moe_activation_supported`, which includes
`SWIGLUOAI_UNINTERLEAVE`. So once the quant config carries the three values,
the existing activation plumbing picks them up end to end. (An earlier
revision of this PR wired those values through `cutlass_moe.py` by hand; the
`ApplyMoEActivationConfig` refactor has since made that redundant, and this
PR has been rebased down to construction-time plumbing only.)

Notes:

- Construction-time plumbing is the only reliable fix location: the config is
  consumed at kernel construction in `process_weights_after_loading`, so
  post-hoc mutation is not a viable workaround, and construction-time
  forwarding matches all sibling methods.
- The fused `SILU` + `silu_and_mul_mxfp4_experts_quant` fast path in
  `run_cutlass_moe_mxfp4` is deliberately left untouched; a hypothetical
  `SILU`-with-clamp config on this path is out of scope here and is the class
  of problem the per-activation `supports_swiglu_clamp_limit` interface
  (#43589) is designed to surface. This PR does not overlap #43589's files.
- Same fix family as #46845 (CT FP8, now merged — this PR's unit test sits
  directly alongside the one it added) and open PRs #47552 (int8), #49473
  (ModelOpt FP8), #49854 (ModelOpt NVFP4), plus closed issues #48493 / #45624.

## Test Plan

- New CPU unit test
  `tests/quantization/test_compressed_tensors.py::test_compressed_tensors_w4a4_mxfp4_moe_forwards_swiglu_params`,
  mirroring the pattern established by #46845: constructs the quant method
  directly and asserts both branches (CUTLASS W4A4 and Marlin W4A16) forward
  `gemm1_alpha` / `gemm1_beta` / `gemm1_clamp_limit` into the returned
  `FusedMoEQuantConfig`.
- `ruff check` / `ruff format --check` (ruff 0.14.0, matching
  `.pre-commit-config.yaml`) pass on all touched files.
- End-to-end: `vllm serve olka-fi/MiniMax-M3-MXFP4 --load-format instanttensor
  -tp 4 --distributed-executor-backend ray` on NVIDIA GB10 (`sm_121`,
  aarch64, DGX OS 7.5).

Maintainers: which CI label should be applied for the CUTLASS MXFP4 MoE path
(Blackwell runner)? Happy to adjust test placement if a kernels-level test is
preferred.

## Test Result

- Unit test asserts pass for both branches (CPU-only, no GPU required).
- Startup crash is gone and generation quality is correct with the fix applied:
  a functionally equivalent patch (same three values populated on the quant
  config) has been serving MiniMax-M3-MXFP4 in production on a GB10 cluster
  via the CUTLASS W4A4 branch since 2026-08-04 against
  `0.26.1rc1.dev247+ge92dc7a9c`, with correct outputs. Without the fix, the
  server crashes at startup with
  `RuntimeError: Worker failed with error 'SWIGLUOAI_UNINTERLEAVE requires clamp_limit'`.
