### PR TITLE
[Frontend] Support repetition_detection as a server-side default

### DIFF
--- a/tests/entrypoints/openai/test_repetition_detection_defaults.py
+++ b/tests/entrypoints/openai/test_repetition_detection_defaults.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""
+Unit tests for repetition_detection propagation from default_sampling_params
+to SamplingParams in ChatCompletionRequest and CompletionRequest.
+
+Operators can set repetition_detection server-side via the model generation
+config or --override-generation-config to guard against degenerate repetition
+loops; the serving layer must apply it when a request does not set its own.
+"""
+
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+)
+from vllm.entrypoints.openai.completion.protocol import (
+    CompletionRequest,
+)
+from vllm.sampling_params import RepetitionDetectionParams
+
+SERVER_DEFAULT = RepetitionDetectionParams(max_pattern_size=8, min_count=4)
+REQUEST_OVERRIDE = RepetitionDetectionParams(max_pattern_size=1, min_count=10)
+
+
+class TestCompletionRepetitionDetection:
+    """repetition_detection fallback in CompletionRequest.to_sampling_params()."""
+
+    def test_server_default_applied(self):
+        """Server-default repetition_detection applies when request sends none."""
+        request = CompletionRequest(model="test-model", prompt="hello")
+
+        sampling_params = request.to_sampling_params(
+            max_tokens=100,
+            default_sampling_params={"repetition_detection": SERVER_DEFAULT},
+        )
+
+        assert sampling_params.repetition_detection == SERVER_DEFAULT
+
+    def test_request_value_wins(self):
+        """Request-specified repetition_detection overrides the server default."""
+        request = CompletionRequest(
+            model="test-model",
+            prompt="hello",
+            repetition_detection=REQUEST_OVERRIDE,
+        )
+
+        sampling_params = request.to_sampling_params(
+            max_tokens=100,
+            default_sampling_params={"repetition_detection": SERVER_DEFAULT},
+        )
+
+        assert sampling_params.repetition_detection == REQUEST_OVERRIDE
+
+    def test_no_repetition_detection_anywhere(self):
+        """With no server default and no request value, it stays disabled."""
+        request = CompletionRequest(model="test-model", prompt="hello")
+
+        sampling_params = request.to_sampling_params(
+            max_tokens=100,
+            default_sampling_params={},
+        )
+
+        assert sampling_params.repetition_detection is None
+
+
+class TestChatCompletionRepetitionDetection:
+    """repetition_detection fallback in ChatCompletionRequest.to_sampling_params()."""
+
+    def test_server_default_applied(self):
+        """Server-default repetition_detection applies when request sends none."""
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+
+        sampling_params = request.to_sampling_params(
+            max_tokens=100,
+            default_sampling_params={"repetition_detection": SERVER_DEFAULT},
+        )
+
+        assert sampling_params.repetition_detection == SERVER_DEFAULT
+
+    def test_request_value_wins(self):
+        """Request-specified repetition_detection overrides the server default."""
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "hello"}],
+            repetition_detection=REQUEST_OVERRIDE,
+        )
+
+        sampling_params = request.to_sampling_params(
+            max_tokens=100,
+            default_sampling_params={"repetition_detection": SERVER_DEFAULT},
+        )
+
+        assert sampling_params.repetition_detection == REQUEST_OVERRIDE
+
+    def test_no_repetition_detection_anywhere(self):
+        """With no server default and no request value, it stays disabled."""
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+
+        sampling_params = request.to_sampling_params(
+            max_tokens=100,
+            default_sampling_params={},
+        )
+
+        assert sampling_params.repetition_detection is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,6 +34,7 @@ from vllm.config.vllm import (
     OptimizationLevel,
 )
 from vllm.platforms import current_platform
+from vllm.sampling_params import RepetitionDetectionParams
 from vllm.v1.attention.backend import AttentionCGSupport
 
 DEVICE_TYPE = current_platform.device_type
@@ -782,6 +783,22 @@ def test_generation_config_loading():
     )
 
     assert model_config.get_diff_sampling_param() == override_generation_config
+
+    # repetition_detection is accepted as a server-side default and converted
+    # from the raw JSON dict into typed params for the serving layers.
+    model_config = ModelConfig(
+        model_id,
+        generation_config="vllm",
+        override_generation_config={
+            "repetition_detection": {"max_pattern_size": 8, "min_count": 4}
+        },
+    )
+
+    assert model_config.get_diff_sampling_param() == {
+        "repetition_detection": RepetitionDetectionParams(
+            max_pattern_size=8, min_count=4
+        )
+    }
 
 
 @pytest.mark.parametrize(

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1619,6 +1619,7 @@ class ModelConfig:
             "top_p",
             "min_p",
             "max_new_tokens",
+            "repetition_detection",
         ]
         if any(p in config for p in available_params):
             diff_sampling_param = {
@@ -1629,6 +1630,14 @@ class ModelConfig:
             if "max_new_tokens" in diff_sampling_param:
                 diff_sampling_param["max_tokens"] = diff_sampling_param.pop(
                     "max_new_tokens"
+                )
+            # repetition_detection arrives as a raw dict from JSON configs
+            repetition_detection = diff_sampling_param.get("repetition_detection")
+            if isinstance(repetition_detection, dict):
+                from vllm.sampling_params import RepetitionDetectionParams
+
+                diff_sampling_param["repetition_detection"] = RepetitionDetectionParams(
+                    **repetition_detection
                 )
         else:
             diff_sampling_param = {}

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -739,7 +739,8 @@ class ChatCompletionRequest(OpenAIBaseModel):
             allowed_token_ids=self.allowed_token_ids,
             extra_args=extra_args or None,
             skip_clone=True,  # Created fresh per request, safe to skip clone
-            repetition_detection=self.repetition_detection,
+            repetition_detection=self.repetition_detection
+            or default_sampling_params.get("repetition_detection"),
         )
 
     @model_validator(mode="before")

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -391,7 +391,8 @@ class CompletionRequest(OpenAIBaseModel):
             bad_words=self.bad_words,
             extra_args=extra_args or None,
             skip_clone=True,  # Created fresh per request, safe to skip clone
-            repetition_detection=self.repetition_detection,
+            repetition_detection=self.repetition_detection
+            or default_sampling_params.get("repetition_detection"),
             thinking_token_budget=self.thinking_token_budget,
         )
 


### PR DESCRIPTION
## Purpose

Enable `repetition_detection` as a **server-side default sampling parameter**. vLLM already ships the detector (`check_sequence_repetition` in `vllm/v1/core/sched/utils.py`, terminating with `FinishReason.REPETITION`) and exposes it per-request in the OpenAI API — but there is no way for an operator to turn it on for a whole deployment: the `get_diff_sampling_param` allowlist silently drops it from `--generation-config` / `--override-generation-config`, and the OpenAI protocols never fell back to `default_sampling_params` for it.

**Motivating failure:** on a `moonshotai/Kimi-K3` deployment, requests with large context (~240K tokens) degenerated into emitting a single repeated token on every step, never sampling EOS, and ran to `max_tokens` — keeping the server saturated for ~19 hours. A server-side repetition default would have terminated these requests within a few dozen tokens, containing the incident automatically. Today the only lever is asking every client to pass the parameter on every request.

With this PR, an operator sets it once:

```bash
vllm serve moonshotai/Kimi-K3 \
  --override-generation-config '{"repetition_detection": {"max_pattern_size": 8, "min_count": 4}}'
```

and every request that doesn't specify its own `repetition_detection` is guarded; requests can still override or disable it per-request.

Changes:
- `ModelConfig.get_diff_sampling_param`: add `repetition_detection` to `available_params`, and convert the raw JSON dict into typed `RepetitionDetectionParams` (deferred import — `vllm.sampling_params` already imports `vllm.config`, so a top-level import would be circular).
- `CompletionRequest.to_sampling_params` / `ChatCompletionRequest.to_sampling_params`: fall back to the server default when the request doesn't set the param — the same pattern previously fixed for `stop_token_ids` defaults (#22519, `tests/entrypoints/openai/test_stop_token_ids.py`).

**Not duplicating existing PRs** (searched 2026-08-04):
- #46700 caps the detection window to bound scheduler CPU — an orthogonal safeguard; composes cleanly with this PR.
- #41539 adds a rolling-hash detection algorithm — detector internals, not configuration plumbing.
- #40097 / #40099 auto-enable detection for grammar-constrained structured output — a hardcoded per-feature trigger, not an operator-facing server default.

No behavior change unless the operator opts in via generation config (off by default), so model-output evals are N/A.

AI assistance was used for this change; a human reviewed every line and ran the tests below.

## Test Plan

```bash
# New unit tests + touched suites (pure-Python, no GPU needed)
python -m pytest tests/entrypoints/openai/test_repetition_detection_defaults.py \
    tests/test_config.py::test_generation_config_loading \
    tests/entrypoints/openai/test_stop_token_ids.py -v

# Lint
pre-commit run --files vllm/config/model.py \
    vllm/entrypoints/openai/completion/protocol.py \
    vllm/entrypoints/openai/chat_completion/protocol.py \
    tests/test_config.py \
    tests/entrypoints/openai/test_repetition_detection_defaults.py
```

## Test Result

- 6 new protocol tests pass (server default applied / request value wins / stays disabled when neither is set — for both Completion and Chat).
- `test_generation_config_loading` (extended to cover the JSON→typed conversion) passes.
- 8 pre-existing `stop_token_ids` tests still pass (neighboring default-fallback path untouched).
- Tests are pinned against the bug: with the source changes reverted, `test_server_default_applied` (both protocols) and `test_generation_config_loading` fail; with the changes restored, all pass.
- `pre-commit` (ruff check + format, mypy 3.10, SPDX, forbidden-import checks): all passed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. (N/A — `repetition_detection` is already documented on the request schema; this PR only lets server operators set the same field as a default.)
</details>

