### PR TITLE
[ROCm][K3] Extend FP8 asm MLA prefill to non-divisor small head counts

### DIFF
--- a/tests/kernels/attention/test_rocm_aiter_mla_fp8_prefill.py
+++ b/tests/kernels/attention/test_rocm_aiter_mla_fp8_prefill.py
@@ -56,6 +56,10 @@ SCALE = 1.0 / math.sqrt(QK_HEAD_DIM)
 # elements.
 ATOL, RTOL = 1e-1, 5e-2
 
+# The assembly kernel writes bf16 through a raw output pointer. Keep its tensors
+# and workspace reservation on one dtype.
+ATTN_OUT_DTYPE = torch.bfloat16
+
 
 @pytest.fixture(autouse=True)
 def _workspace_manager():
@@ -88,8 +92,12 @@ def _make_impl():
     return impl
 
 
-def _build_prefill_metadata(seq_lens: list[int], device: torch.device):
-    """Build fp8_prefill_* metadata via the real builder (no hand-rolling)."""
+def _build_prefill_metadata(
+    seq_lens: list[int],
+    device: torch.device,
+    attn_out_dtype: torch.dtype = ATTN_OUT_DTYPE,
+):
+    """Build metadata with the production builder and output dtype."""
     from vllm.v1.attention.backends.mla.rocm_aiter_mla import AiterMLAMetadataBuilder
 
     qo_indptr_cpu = torch.zeros(len(seq_lens) + 1, dtype=torch.int32)
@@ -105,7 +113,7 @@ def _build_prefill_metadata(seq_lens: list[int], device: torch.device):
         max_num_reqs=len(seq_lens),
         max_prefill_qlen=max_q,
         max_num_batched_tokens=total_q,
-        attn_out_dtype=torch.bfloat16,
+        attn_out_dtype=attn_out_dtype,
         device=device,
     )
 
@@ -138,14 +146,14 @@ def test_fp8_prefill_matches_reference(seq_len: int) -> None:
     metadata, total_q = _build_prefill_metadata([seq_len], device)
 
     q = torch.randn(
-        total_q, NUM_HEADS, QK_HEAD_DIM, dtype=torch.bfloat16, device=device
+        total_q, NUM_HEADS, QK_HEAD_DIM, dtype=ATTN_OUT_DTYPE, device=device
     )
     k = torch.randn(
-        total_q, NUM_HEADS, QK_HEAD_DIM, dtype=torch.bfloat16, device=device
+        total_q, NUM_HEADS, QK_HEAD_DIM, dtype=ATTN_OUT_DTYPE, device=device
     )
-    v = torch.randn(total_q, NUM_HEADS, V_HEAD_DIM, dtype=torch.bfloat16, device=device)
+    v = torch.randn(total_q, NUM_HEADS, V_HEAD_DIM, dtype=ATTN_OUT_DTYPE, device=device)
     out = torch.zeros(
-        total_q, NUM_HEADS * V_HEAD_DIM, dtype=torch.bfloat16, device=device
+        total_q, NUM_HEADS * V_HEAD_DIM, dtype=ATTN_OUT_DTYPE, device=device
     )
 
     impl = _make_impl()

--- a/tests/kernels/attention/test_rocm_aiter_mla_fp8_prefill.py
+++ b/tests/kernels/attention/test_rocm_aiter_mla_fp8_prefill.py
@@ -105,6 +105,7 @@ def _build_prefill_metadata(seq_lens: list[int], device: torch.device):
         max_num_reqs=len(seq_lens),
         max_prefill_qlen=max_q,
         max_num_batched_tokens=total_q,
+        attn_out_dtype=torch.bfloat16,
         device=device,
     )
 

--- a/tests/kernels/attention/test_rocm_aiter_mla_fp8_prefill.py
+++ b/tests/kernels/attention/test_rocm_aiter_mla_fp8_prefill.py
@@ -43,8 +43,17 @@ pytestmark = pytest.mark.skipif(
 )
 
 # DeepSeek-style MLA head dims after kv_b_proj decompression (q/k carry the
-# nope+rope dims, v carries v_head_dim). FP8 prefill requires 16-aligned heads.
-NUM_HEADS = 16
+# nope+rope dims, v carries v_head_dim).
+#
+# The kernel requires 16-aligned heads, so _mla_fp8_prefill_attn replicate-pads
+# q/k/v up to get_fp8_prefill_num_heads(num_heads) and slices the output back.
+# Cover all three regimes -- a K3 rank sees 12 heads at TP8 and 24 at TP4:
+#   12 -> padded to 16 (non-divisor, tile+slice)
+#   16 -> no padding, output aliases the caller's buffer
+#   24 -> padded to 32 (only reachable above 16; the metadata sizing in
+#         _init_fp8_prefill_ps_buffers must agree with the forward, or the
+#         work/reduce maps describe a different head count than the kernel gets)
+HEAD_COUNTS = [12, 16, 24]
 QK_NOPE_HEAD_DIM = 128
 QK_ROPE_HEAD_DIM = 64
 QK_HEAD_DIM = QK_NOPE_HEAD_DIM + QK_ROPE_HEAD_DIM  # 192
@@ -77,14 +86,14 @@ def _workspace_manager():
     reset_workspace_manager()
 
 
-def _make_impl():
+def _make_impl(num_heads: int):
     """Minimal AiterMLAImpl exposing only what _mla_fp8_prefill_attn reads."""
     from aiter import mla_prefill_ps_asm_fwd, mla_reduce_v1
 
     from vllm.v1.attention.backends.mla.rocm_aiter_mla import AiterMLAImpl
 
     impl = object.__new__(AiterMLAImpl)
-    impl.num_heads = NUM_HEADS
+    impl.num_heads = num_heads
     impl.v_head_dim = V_HEAD_DIM
     impl.scale = SCALE
     impl._mla_prefill_ps_asm_fwd = mla_prefill_ps_asm_fwd
@@ -95,6 +104,7 @@ def _make_impl():
 def _build_prefill_metadata(
     seq_lens: list[int],
     device: torch.device,
+    num_heads: int,
     attn_out_dtype: torch.dtype = ATTN_OUT_DTYPE,
 ):
     """Build metadata with the production builder and output dtype."""
@@ -107,7 +117,7 @@ def _build_prefill_metadata(
     max_q = max(seq_lens)
 
     builder = object.__new__(AiterMLAMetadataBuilder)
-    builder.num_heads = NUM_HEADS
+    builder.num_heads = num_heads
     builder.mla_dims = SimpleNamespace(v_head_dim=V_HEAD_DIM)
     builder._init_fp8_prefill_ps_buffers(
         max_num_reqs=len(seq_lens),
@@ -137,34 +147,51 @@ def _reference(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tenso
     return out.transpose(0, 1)  # [S, H, Dv]
 
 
+@pytest.mark.parametrize("num_heads", HEAD_COUNTS)
 @pytest.mark.parametrize("seq_len", [128, 512])
 @torch.inference_mode()
-def test_fp8_prefill_matches_reference(seq_len: int) -> None:
+def test_fp8_prefill_matches_reference(seq_len: int, num_heads: int) -> None:
     device = torch.device("cuda")
     torch.manual_seed(0)
 
-    metadata, total_q = _build_prefill_metadata([seq_len], device)
+    metadata, total_q = _build_prefill_metadata([seq_len], device, num_heads)
 
-    q = torch.randn(
-        total_q, NUM_HEADS, QK_HEAD_DIM, dtype=ATTN_OUT_DTYPE, device=device
-    )
-    k = torch.randn(
-        total_q, NUM_HEADS, QK_HEAD_DIM, dtype=ATTN_OUT_DTYPE, device=device
-    )
-    v = torch.randn(total_q, NUM_HEADS, V_HEAD_DIM, dtype=ATTN_OUT_DTYPE, device=device)
+    qkv_kwargs = dict(dtype=ATTN_OUT_DTYPE, device=device)
+    q = torch.randn(total_q, num_heads, QK_HEAD_DIM, **qkv_kwargs)
+    k = torch.randn(total_q, num_heads, QK_HEAD_DIM, **qkv_kwargs)
+    v = torch.randn(total_q, num_heads, V_HEAD_DIM, **qkv_kwargs)
     out = torch.zeros(
-        total_q, NUM_HEADS * V_HEAD_DIM, dtype=ATTN_OUT_DTYPE, device=device
+        total_q, num_heads * V_HEAD_DIM, dtype=ATTN_OUT_DTYPE, device=device
     )
 
-    impl = _make_impl()
+    impl = _make_impl(num_heads)
     impl._mla_fp8_prefill_attn(q, k, v, metadata, out)
 
     out_ref = _reference(q, k, v)
 
     assert torch.isfinite(out).all()
     torch.testing.assert_close(
-        out.view(total_q, NUM_HEADS, V_HEAD_DIM).float(),
+        out.view(total_q, num_heads, V_HEAD_DIM).float(),
         out_ref.float(),
         atol=ATOL,
         rtol=RTOL,
     )
+
+
+@pytest.mark.parametrize("num_heads", HEAD_COUNTS)
+def test_fp8_prefill_metadata_width_matches_forward(num_heads: int) -> None:
+    """The PS metadata must be built for the head count the kernel is handed.
+
+    ``_init_fp8_prefill_ps_buffers``/``build()`` size the work and reduce maps
+    from ``num_head_k``, while ``_mla_fp8_prefill_attn`` pads q/k/v to its own
+    target. If the two ever diverge the kernel silently reads maps describing a
+    different head count, so pin them to one another rather than to a literal.
+    """
+    from vllm.v1.attention.backends.mla.rocm_aiter_mla import AiterMLAHelper
+
+    width = AiterMLAHelper.get_fp8_prefill_num_heads(num_heads)
+    assert width % AiterMLAHelper._AITER_MIN_MLA_HEADS == 0
+    assert width >= num_heads
+    assert width - num_heads < AiterMLAHelper._AITER_MIN_MLA_HEADS
+    # Every count the enable gate accepts must have a usable padded width.
+    assert AiterMLAHelper.is_valid_num_heads(num_heads)

--- a/tests/kernels/attention/test_rocm_aiter_mla_fp8_prefill.py
+++ b/tests/kernels/attention/test_rocm_aiter_mla_fp8_prefill.py
@@ -47,12 +47,15 @@ pytestmark = pytest.mark.skipif(
 #
 # The kernel requires 16-aligned heads, so _mla_fp8_prefill_attn replicate-pads
 # q/k/v up to get_fp8_prefill_num_heads(num_heads) and slices the output back.
-# Cover all three regimes -- a K3 rank sees 12 heads at TP8 and 24 at TP4:
-#   12 -> padded to 16 (non-divisor, tile+slice)
-#   16 -> no padding, output aliases the caller's buffer
-#   24 -> padded to 32 (only reachable above 16; the metadata sizing in
-#         _init_fp8_prefill_ps_buffers must agree with the forward, or the
-#         work/reduce maps describe a different head count than the kernel gets)
+# Cover all three regimes:
+#   12 -> padded to 16 (non-divisor, tile+slice). Live case: a K3 rank at TP8.
+#   16 -> no padding, output aliases the caller's buffer.
+#   24 -> padded to 32. No current model and TP reaches this band (96 heads
+#         would need TP4, which does not fit in 288 GiB; 128-head models give
+#         128/64/32/16/8), so this case exists to keep the general path honest
+#         for future architectures: it is the only one of the three where
+#         padding above 16 actually happens, so it is what proves the
+#         replicate-pad/slice-back argument holds for a target other than 16.
 HEAD_COUNTS = [12, 16, 24]
 QK_NOPE_HEAD_DIM = 128
 QK_ROPE_HEAD_DIM = 64
@@ -134,7 +137,7 @@ def _build_prefill_metadata(
     metadata = SimpleNamespace(prefill=prefill, num_decodes=0)
     common = SimpleNamespace(query_start_loc_cpu=qo_indptr_cpu)
     builder._build_fp8_prefill_ps_metadata(metadata, common)
-    return metadata, total_q
+    return metadata, total_q, builder
 
 
 def _reference(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
@@ -154,7 +157,21 @@ def test_fp8_prefill_matches_reference(seq_len: int, num_heads: int) -> None:
     device = torch.device("cuda")
     torch.manual_seed(0)
 
-    metadata, total_q = _build_prefill_metadata([seq_len], device, num_heads)
+    metadata, total_q, _ = _build_prefill_metadata([seq_len], device, num_heads)
+
+    # Lock the workspace, as GPUModelRunner does after warmup, so the forward
+    # cannot quietly grow it. The builder reserves scratch at num_head_k and
+    # the forward requests it at its own padded width; if a future change makes
+    # the forward's width exceed the builder's, that is an under-reservation
+    # which is invisible on an unlocked workspace (it just grows) and fatal in
+    # a real serve. Locking turns it into a failure here.
+    #
+    # Note this does not catch the reverse -- a builder wider than the forward
+    # merely over-reserves -- so it would not have flagged the pre-PR
+    # max(16, num_heads) sizing, which over-reserves 2.8x at 24 heads.
+    from vllm.v1.worker.workspace import lock_workspace
+
+    lock_workspace()
 
     qkv_kwargs = dict(dtype=ATTN_OUT_DTYPE, device=device)
     q = torch.randn(total_q, num_heads, QK_HEAD_DIM, **qkv_kwargs)
@@ -184,8 +201,12 @@ def test_fp8_prefill_metadata_width_matches_forward(num_heads: int) -> None:
 
     ``_init_fp8_prefill_ps_buffers``/``build()`` size the work and reduce maps
     from ``num_head_k``, while ``_mla_fp8_prefill_attn`` pads q/k/v to its own
-    target. If the two ever diverge the kernel silently reads maps describing a
-    different head count, so pin them to one another rather than to a literal.
+    target. Divergence is not a numerical bug in either direction -- maps built
+    narrower than the kernel width still cover the real heads, since padding
+    only ever appends duplicate heads above them. It is a sizing bug: narrower
+    maps mean a lower head alignment, hence more partial tiles and a larger
+    reservation, while wider ones under-reserve the forward's scratch. Pin the
+    two to one helper rather than to independent expressions.
     """
     from vllm.v1.attention.backends.mla.rocm_aiter_mla import AiterMLAHelper
 
@@ -195,3 +216,29 @@ def test_fp8_prefill_metadata_width_matches_forward(num_heads: int) -> None:
     assert width - num_heads < AiterMLAHelper._AITER_MIN_MLA_HEADS
     # Every count the enable gate accepts must have a usable padded width.
     assert AiterMLAHelper.is_valid_num_heads(num_heads)
+
+    # The builder must actually size its maps at that width. Assert against the
+    # buffer it allocated rather than recomputing the width here, or the test
+    # passes no matter what _init_fp8_prefill_ps_buffers does.
+    #
+    # fp8_ps_reduce_partial_map is sized by the partial-tile count, which is
+    # gcd-driven and so is a sharp probe of the width used: a lower head
+    # alignment yields *more* tiles. At 24 heads, sizing at the unpadded count
+    # gives 4x the tiles (64 vs 16) and ~2.8x the scratch reservation (193.6
+    # vs 68.6 MiB at batch=1/qlen=512) -- not wrong numerically (the 24-wide
+    # maps still cover the real heads) but the reason to pin the widths
+    # together.
+    from aiter import get_ps_metadata_info_v1
+
+    from vllm.v1.attention.backends.mla.rocm_aiter_mla import _FP8_PREFILL_TILE_Q
+
+    def _tiles(nhk: int) -> int:
+        return get_ps_metadata_info_v1(
+            batch_size=1,
+            num_head_k=nhk,
+            max_qlen=512,
+            qlen_granularity=_FP8_PREFILL_TILE_Q,
+        )[5][0]
+
+    _, _, builder = _build_prefill_metadata([512], torch.device("cuda"), num_heads)
+    assert builder.fp8_ps_reduce_partial_map.numel() == _tiles(width)

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -329,9 +329,12 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
             device=device,
         )
 
-        # FP8 MLA prefill (kn_mla_reduce_v1) only supports 16-aligned heads.
+        # FP8 MLA prefill (kn_mla_reduce_v1) only supports 16-aligned heads, and
+        # only runs when the KV cache is FP8 (otherwise the bf16 path is used and
+        # the PS workspace must not be reserved).
         self._fp8_prefill_enabled = _fp8_mla_prefill_supported() and (
-            self.num_heads % 16 == 0 or 0 < self.num_heads < 16
+            kv_cache_dtype_str == "fp8"
+            and (self.num_heads % 16 == 0 or 0 < self.num_heads < 16)
         )
         if self._fp8_prefill_enabled:
             max_prefill_qlen = min(
@@ -902,10 +905,13 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
         self.flash_attn_varlen_func = flash_attn_varlen_func
 
         # FP8 MLA prefill kernel imports (lazy, only when enabled).
-        # Auto-enabled on gfx950 when AITER ships the kernels.
-        # FP8 MLA prefill (kn_mla_reduce_v1) only supports 16-aligned heads.
+        # Auto-enabled on gfx950 when AITER ships the kernels. Only runs when the
+        # KV cache is FP8, and supports non-divisor small head counts via pad-to-16.
+        from vllm.utils.torch_utils import is_quantized_kv_cache
+
         self._fp8_prefill_enabled = _fp8_mla_prefill_supported() and (
-            self.num_heads % 16 == 0 or 0 < self.num_heads < 16
+            is_quantized_kv_cache(kv_cache_dtype)
+            and (self.num_heads % 16 == 0 or 0 < self.num_heads < 16)
         )
         if self._fp8_prefill_enabled:
             from aiter import mla_prefill_ps_asm_fwd, mla_reduce_v1

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -330,8 +330,8 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         )
 
         # FP8 MLA prefill (kn_mla_reduce_v1) only supports 16-aligned heads.
-        self._fp8_prefill_enabled = (
-            _fp8_mla_prefill_supported() and self.num_heads % 16 == 0
+        self._fp8_prefill_enabled = _fp8_mla_prefill_supported() and (
+            self.num_heads % 16 == 0 or 0 < self.num_heads < 16
         )
         if self._fp8_prefill_enabled:
             max_prefill_qlen = min(
@@ -387,7 +387,11 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
 
         # After kv_b_proj decompression, K has num_heads heads (same as Q).
         # So gqa_ratio=1 and num_head_k=num_heads for the PS kernel.
-        num_head_k = self.num_heads
+        # Non-divisor head counts (e.g. K3's 12/rank at TP8) are padded to 16 in
+        # _mla_fp8_prefill_attn; build the PS metadata for the padded head count so
+        # the work/reduce maps match. This also lowers the partial-tile count:
+        # gcd(16, cu_num=256)=16 (~960 tiles) vs gcd(12,256)=4 (~4032), saving ~6 GiB.
+        num_head_k = max(16, self.num_heads)
         v_head_dim = self.mla_dims.v_head_dim
         # gqa_ratio = 1
         # qlen_granularity = _FP8_PREFILL_TILE_Q // max(gqa_ratio, 1)
@@ -481,7 +485,11 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         kv_indptr_cpu = qo_indptr_cpu.clone()
         seq_lens_cpu = (qo_indptr_cpu[1:] - qo_indptr_cpu[:-1]).to(torch.int32)
 
-        num_head_k = self.num_heads
+        # Non-divisor head counts (e.g. K3's 12/rank at TP8) are padded to 16 in
+        # _mla_fp8_prefill_attn; build the PS metadata for the padded head count so
+        # the work/reduce maps match. This also lowers the partial-tile count:
+        # gcd(16, cu_num=256)=16 (~960 tiles) vs gcd(12,256)=4 (~4032), saving ~6 GiB.
+        num_head_k = max(16, self.num_heads)
         # gqa_ratio = 1
         # qhead_granularity = max(gqa_ratio, 1)
         # qlen_granularity = _FP8_PREFILL_TILE_Q // qhead_granularity
@@ -781,8 +789,11 @@ def _expand_page_indices_kernel(
 
 class AiterMLAHelper:
     """
-    AITER MLA implementation requires num_heads >= 16. If num_heads < 16 and
-    16 % num_heads == 0, we can pad q to 16 heads; otherwise AITER has to fail.
+    AITER MLA persistent (asm) decode requires num_heads >= 16. Head counts
+    < 16 are padded up to exactly 16: divisors of 16 by repeat_interleave,
+    other counts (e.g. 12 heads/rank at TP8, 6 at TP16) by tiling the query
+    heads and slicing to 16. Non-divisor padded decodes take the asm path;
+    divisors and max_qo_len > 1 small-head verify still use Gluon.
     """
 
     _AITER_MIN_MLA_HEADS: Final = 16
@@ -791,8 +802,9 @@ class AiterMLAHelper:
     @staticmethod
     def check_num_heads_validity(num_heads: int):
         assert AiterMLAHelper.is_valid_num_heads(num_heads), (
-            "ROCM AITER MLA requires 1-15 heads for Gluon decode or a multiple "
-            f"of 16 heads for persistent decode, but got {num_heads}.\n"
+            "ROCM AITER MLA requires 1-15 heads (padded to 16 for asm "
+            "persistent decode; exact divisors of 16 may keep Gluon) or a "
+            f"multiple of 16 heads, but got {num_heads}.\n"
             f"Try adjusting tensor_parallel_size value."
         )
 
@@ -809,25 +821,42 @@ class AiterMLAHelper:
 
     @staticmethod
     def get_mla_padded_q(num_heads: int, q: torch.Tensor) -> torch.Tensor:
-        return (
-            q
-            if num_heads >= AiterMLAHelper._AITER_MIN_MLA_HEADS
-            else q.repeat_interleave(
-                AiterMLAHelper._AITER_MIN_MLA_HEADS // num_heads, dim=1
-            )
-        )
+        m = AiterMLAHelper._AITER_MIN_MLA_HEADS
+        if num_heads >= m:
+            return q
+        if m % num_heads == 0:
+            return q.repeat_interleave(m // num_heads, dim=1)
+        # Non-divisor head counts (e.g. 12 heads/rank at TP8, 6 at TP16) cannot
+        # be padded by repeat_interleave. Tile the query heads and slice to
+        # exactly m; this reaches m for any 0 < num_heads < m (unlike a single
+        # append, which under-pads when num_heads < m - num_heads). MLA
+        # attention is independent per query head over the shared KV, so the
+        # padding heads cannot affect heads [0:num_heads]; they are sliced back
+        # off in get_mla_unpadded_o.
+        reps = -(-m // num_heads)  # ceil(m / num_heads)
+        return q.repeat(1, reps, 1)[:, :m, :]
 
     @staticmethod
     def get_mla_unpadded_o(num_heads: int, o: torch.Tensor) -> torch.Tensor:
-        return (
-            o
-            if num_heads >= AiterMLAHelper._AITER_MIN_MLA_HEADS
-            else o[:, :: AiterMLAHelper._AITER_MIN_MLA_HEADS // num_heads, :]
-        )
+        m = AiterMLAHelper._AITER_MIN_MLA_HEADS
+        if num_heads >= m:
+            return o
+        if m % num_heads == 0:
+            return o[:, :: m // num_heads, :]
+        # Undo the tile-padding from get_mla_padded_q: the real heads are the
+        # first num_heads.
+        return o[:, :num_heads, :]
 
     @staticmethod
     def use_gluon_decode(num_heads: int, max_qo_len: int) -> bool:
-        return num_heads < AiterMLAHelper._AITER_MIN_MLA_HEADS and max_qo_len == 1
+        # Divisor head counts (<16) keep the Gluon decode. Non-divisor counts
+        # (e.g. 12 heads/rank at TP8) are padded to 16 in get_mla_padded_q and
+        # use the faster asm persistent decode instead of Gluon, which
+        # parallelizes only over heads and scales linearly with KV length.
+        m = AiterMLAHelper._AITER_MIN_MLA_HEADS
+        if num_heads >= m or max_qo_len != 1:
+            return False
+        return m % num_heads == 0
 
 
 class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
@@ -875,8 +904,8 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
         # FP8 MLA prefill kernel imports (lazy, only when enabled).
         # Auto-enabled on gfx950 when AITER ships the kernels.
         # FP8 MLA prefill (kn_mla_reduce_v1) only supports 16-aligned heads.
-        self._fp8_prefill_enabled = (
-            _fp8_mla_prefill_supported() and self.num_heads % 16 == 0
+        self._fp8_prefill_enabled = _fp8_mla_prefill_supported() and (
+            self.num_heads % 16 == 0 or 0 < self.num_heads < 16
         )
         if self._fp8_prefill_enabled:
             from aiter import mla_prefill_ps_asm_fwd, mla_reduce_v1
@@ -919,7 +948,19 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
 
         fp8_dtype = current_platform.fp8_dtype()
         total_q = q.shape[0]
-        nhead = self.num_heads
+        # PS asm prefill + mla_reduce_v1 require 16-aligned heads and the PS
+        # metadata is built for max(16, num_heads). For non-divisor small head
+        # counts (K3 = 12/rank at TP8) replicate-pad q/k/v to 16 — MLA attention
+        # is independent per query head over the shared KV, so the padding heads
+        # cannot affect the real ones (exact, same as the decode path) — then
+        # slice the output back to the real head count.
+        _real_nhead = self.num_heads
+        _pad16 = _real_nhead < 16
+        if _pad16:
+            q = AiterMLAHelper.get_mla_padded_q(_real_nhead, q)
+            k = AiterMLAHelper.get_mla_padded_q(_real_nhead, k)
+            v = AiterMLAHelper.get_mla_padded_q(_real_nhead, v)
+        nhead = 16 if _pad16 else self.num_heads
         v_head_dim = self.v_head_dim
         tile_q = _FP8_PREFILL_TILE_Q
 
@@ -946,7 +987,13 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
         # Reuse the caller's output buffer to skip the per-call alloc + copy.
         # The ASM and reduce kernels both write to a [total_q, nhead, v_head_dim]
         # view, which aliases the [total_q, nhead * v_head_dim] storage of out.
-        out_3d = out.view(total_q, nhead, v_head_dim)
+        if _pad16:
+            # Padded heads can't alias the real-head `out` storage; use scratch.
+            out_3d = torch.empty(
+                total_q, nhead, v_head_dim, dtype=out.dtype, device=out.device
+            )
+        else:
+            out_3d = out.view(total_q, nhead, v_head_dim)
 
         # Per-call scratch (logits, attn_lse, final_lse) is served from the
         # workspace manager so allocator churn in the prefill hot path is
@@ -992,6 +1039,11 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
             out_3d,
             final_lse,
         )
+
+        if _pad16:
+            out.view(total_q, _real_nhead, v_head_dim).copy_(
+                out_3d[:, :_real_nhead, :]
+            )
 
     def forward_mha(
         self,

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -430,6 +430,7 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
                 max_num_reqs,
                 max_prefill_qlen,
                 vllm_config.scheduler_config.max_num_batched_tokens,
+                vllm_config.model_config.dtype,
                 device,
             )
 
@@ -447,6 +448,7 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         max_num_reqs: int,
         max_prefill_qlen: int,
         max_num_batched_tokens: int,
+        attn_out_dtype: torch.dtype,
         device: torch.device,
     ) -> None:
         """Pre-allocate persistent buffers for FP8 MLA prefill PS metadata.
@@ -469,6 +471,8 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
                 is bounded by this budget rather than by a single request's
                 ``max_prefill_qlen`` — concurrent requests can sum to more than
                 ``max_model_len`` when ``max_model_len < max_num_batched_tokens``.
+            attn_out_dtype: Dtype of the attention output buffer, used to size
+                the padded-head output scratch (small head counts only).
             device: Target device for the buffers.
         """
         from aiter import get_ps_metadata_info_v1
@@ -523,7 +527,7 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         from vllm.v1.worker.workspace import current_workspace_manager
 
         max_num_partial_tiles = reduce_partial_map_size
-        current_workspace_manager().get_simultaneous(
+        reservations: list[tuple[tuple[int, ...], torch.dtype]] = [
             (
                 (max_num_partial_tiles * _FP8_PREFILL_TILE_Q, num_head_k, v_head_dim),
                 torch.float32,
@@ -533,7 +537,15 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
                 torch.float32,
             ),
             ((max_num_batched_tokens, num_head_k), torch.float32),
-        )
+        ]
+        if self.num_heads < num_head_k:
+            # Padded head counts also take their kernel output buffer from the
+            # workspace: the caller's [total_q, num_heads * v_head_dim] output
+            # cannot back a num_head_k-head view (see _mla_fp8_prefill_attn).
+            reservations.append(
+                ((max_num_batched_tokens, num_head_k, v_head_dim), attn_out_dtype)
+            )
+        current_workspace_manager().get_simultaneous(*reservations)
 
         logger.info(
             "FP8 MLA prefill PS buffers allocated "
@@ -1132,25 +1144,25 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
         num_partial_tiles = attn_metadata.fp8_prefill_num_partial_tiles
         assert num_partial_tiles is not None
 
-        # Reuse the caller's output buffer to skip the per-call alloc + copy.
-        # The ASM and reduce kernels both write to a [total_q, nhead, v_head_dim]
-        # view, which aliases the [total_q, nhead * v_head_dim] storage of out.
-        if _pad16:
-            # Padded heads can't alias the real-head `out` storage; use scratch.
-            out_3d = torch.empty(
-                total_q, nhead, v_head_dim, dtype=out.dtype, device=out.device
-            )
-        else:
-            out_3d = out.view(total_q, nhead, v_head_dim)
-
-        # Per-call scratch (logits, attn_lse, final_lse) is served from the
-        # workspace manager so allocator churn in the prefill hot path is
-        # bounded after warmup, matching the pattern in PR #41002.
-        logits, attn_lse, final_lse = current_workspace_manager().get_simultaneous(
+        # Per-call scratch is served from the workspace manager so allocator
+        # churn in the prefill hot path is bounded after warmup, matching the
+        # pattern in PR #41002.  The builder reserves the maximum shape of every
+        # tensor requested here before the workspace is locked.
+        scratch: list[tuple[tuple[int, ...], torch.dtype]] = [
             ((num_partial_tiles * tile_q, nhead, v_head_dim), torch.float32),
             ((num_partial_tiles * tile_q, nhead), torch.float32),
             ((total_q, nhead), torch.float32),
-        )
+        ]
+        if _pad16:
+            # The ASM and reduce kernels write a [total_q, nhead, v_head_dim]
+            # buffer.  With unpadded heads that aliases the caller's
+            # [total_q, nhead * v_head_dim] output, so write straight into it;
+            # padded heads do not fit that storage and need their own buffer.
+            scratch.append(((total_q, nhead, v_head_dim), out.dtype))
+
+        workspace = current_workspace_manager()
+        logits, attn_lse, final_lse, *pad_out = workspace.get_simultaneous(*scratch)
+        out_3d = pad_out[0] if _pad16 else out.view(total_q, nhead, v_head_dim)
 
         # Phase 1: persistent-scheduling assembly prefill kernel.
         self._mla_prefill_ps_asm_fwd(

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -414,9 +414,12 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
             device=device,
         )
 
-        # FP8 MLA prefill (kn_mla_reduce_v1) only supports 16-aligned heads.
-        self._fp8_prefill_enabled = (
-            _fp8_mla_prefill_supported() and self.num_heads % 16 == 0
+        # FP8 MLA prefill (kn_mla_reduce_v1) only supports 16-aligned heads, and
+        # only runs when the KV cache is FP8 (otherwise the bf16 path is used and
+        # the PS workspace must not be reserved).
+        self._fp8_prefill_enabled = _fp8_mla_prefill_supported() and (
+            kv_cache_dtype_str == "fp8"
+            and (self.num_heads % 16 == 0 or 0 < self.num_heads < 16)
         )
         if self._fp8_prefill_enabled:
             max_prefill_qlen = min(
@@ -472,7 +475,11 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
 
         # After kv_b_proj decompression, K has num_heads heads (same as Q).
         # So gqa_ratio=1 and num_head_k=num_heads for the PS kernel.
-        num_head_k = self.num_heads
+        # Non-divisor head counts (e.g. K3's 12/rank at TP8) are padded to 16 in
+        # _mla_fp8_prefill_attn; build the PS metadata for the padded head count so
+        # the work/reduce maps match. This also lowers the partial-tile count:
+        # gcd(16, cu_num=256)=16 (~960 tiles) vs gcd(12,256)=4 (~4032), saving ~6 GiB.
+        num_head_k = max(16, self.num_heads)
         v_head_dim = self.mla_dims.v_head_dim
         # gqa_ratio = 1
         # qlen_granularity = _FP8_PREFILL_TILE_Q // max(gqa_ratio, 1)
@@ -566,7 +573,11 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         kv_indptr_cpu = qo_indptr_cpu.clone()
         seq_lens_cpu = (qo_indptr_cpu[1:] - qo_indptr_cpu[:-1]).to(torch.int32)
 
-        num_head_k = self.num_heads
+        # Non-divisor head counts (e.g. K3's 12/rank at TP8) are padded to 16 in
+        # _mla_fp8_prefill_attn; build the PS metadata for the padded head count so
+        # the work/reduce maps match. This also lowers the partial-tile count:
+        # gcd(16, cu_num=256)=16 (~960 tiles) vs gcd(12,256)=4 (~4032), saving ~6 GiB.
+        num_head_k = max(16, self.num_heads)
         # gqa_ratio = 1
         # qhead_granularity = max(gqa_ratio, 1)
         # qlen_granularity = _FP8_PREFILL_TILE_Q // qhead_granularity
@@ -1036,10 +1047,13 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
         self.flash_attn_varlen_func = flash_attn_varlen_func
 
         # FP8 MLA prefill kernel imports (lazy, only when enabled).
-        # Auto-enabled on gfx950 when AITER ships the kernels.
-        # FP8 MLA prefill (kn_mla_reduce_v1) only supports 16-aligned heads.
-        self._fp8_prefill_enabled = (
-            _fp8_mla_prefill_supported() and self.num_heads % 16 == 0
+        # Auto-enabled on gfx950 when AITER ships the kernels. Only runs when the
+        # KV cache is FP8, and supports non-divisor small head counts via pad-to-16.
+        from vllm.utils.torch_utils import is_quantized_kv_cache
+
+        self._fp8_prefill_enabled = _fp8_mla_prefill_supported() and (
+            is_quantized_kv_cache(kv_cache_dtype)
+            and (self.num_heads % 16 == 0 or 0 < self.num_heads < 16)
         )
         if self._fp8_prefill_enabled:
             from aiter import mla_prefill_ps_asm_fwd, mla_reduce_v1
@@ -1082,7 +1096,19 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
 
         fp8_dtype = current_platform.fp8_dtype()
         total_q = q.shape[0]
-        nhead = self.num_heads
+        # PS asm prefill + mla_reduce_v1 require 16-aligned heads and the PS
+        # metadata is built for max(16, num_heads). For non-divisor small head
+        # counts (K3 = 12/rank at TP8) replicate-pad q/k/v to 16 — MLA attention
+        # is independent per query head over the shared KV, so the padding heads
+        # cannot affect the real ones (exact, same as the decode path) — then
+        # slice the output back to the real head count.
+        _real_nhead = self.num_heads
+        _pad16 = _real_nhead < 16
+        if _pad16:
+            q = AiterMLAHelper.get_mla_padded_q(_real_nhead, q)
+            k = AiterMLAHelper.get_mla_padded_q(_real_nhead, k)
+            v = AiterMLAHelper.get_mla_padded_q(_real_nhead, v)
+        nhead = 16 if _pad16 else self.num_heads
         v_head_dim = self.v_head_dim
         tile_q = _FP8_PREFILL_TILE_Q
 
@@ -1109,7 +1135,13 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
         # Reuse the caller's output buffer to skip the per-call alloc + copy.
         # The ASM and reduce kernels both write to a [total_q, nhead, v_head_dim]
         # view, which aliases the [total_q, nhead * v_head_dim] storage of out.
-        out_3d = out.view(total_q, nhead, v_head_dim)
+        if _pad16:
+            # Padded heads can't alias the real-head `out` storage; use scratch.
+            out_3d = torch.empty(
+                total_q, nhead, v_head_dim, dtype=out.dtype, device=out.device
+            )
+        else:
+            out_3d = out.view(total_q, nhead, v_head_dim)
 
         # Per-call scratch (logits, attn_lse, final_lse) is served from the
         # workspace manager so allocator churn in the prefill hot path is
@@ -1155,6 +1187,11 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
             out_3d,
             final_lse,
         )
+
+        if _pad16:
+            out.view(total_q, _real_nhead, v_head_dim).copy_(
+                out_3d[:, :_real_nhead, :]
+            )
 
     def forward_mha(
         self,

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -1189,9 +1189,7 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
         )
 
         if _pad16:
-            out.view(total_q, _real_nhead, v_head_dim).copy_(
-                out_3d[:, :_real_nhead, :]
-            )
+            out.view(total_q, _real_nhead, v_head_dim).copy_(out_3d[:, :_real_nhead, :])
 
     def forward_mha(
         self,

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -414,11 +414,12 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
             device=device,
         )
 
-        # FP8 MLA prefill (kn_mla_reduce_v1) only supports 16-aligned heads, and
-        # only runs when the KV cache is FP8 (otherwise the bf16 path is used and
-        # the PS workspace must not be reserved).
+        # The assembly prefill requires FP8 KV, bf16 output, and 16-aligned
+        # heads. It writes bf16 through a raw output pointer, so fp16 must use
+        # the standard prefill path.
         self._fp8_prefill_enabled = _fp8_mla_prefill_supported() and (
             kv_cache_dtype_str == "fp8"
+            and vllm_config.model_config.dtype == torch.bfloat16
             and (self.num_heads % 16 == 0 or 0 < self.num_heads < 16)
         )
         if self._fp8_prefill_enabled:

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -416,11 +416,13 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
 
         # The assembly prefill requires FP8 KV, bf16 output, and 16-aligned
         # heads. It writes bf16 through a raw output pointer, so fp16 must use
-        # the standard prefill path.
+        # the standard prefill path. Head counts that are not a multiple of 16
+        # are replicate-padded up to one in _mla_fp8_prefill_attn, so the gate
+        # is the same head-count predicate the decode path uses.
         self._fp8_prefill_enabled = _fp8_mla_prefill_supported() and (
             kv_cache_dtype_str == "fp8"
             and vllm_config.model_config.dtype == torch.bfloat16
-            and (self.num_heads % 16 == 0 or 0 < self.num_heads < 16)
+            and AiterMLAHelper.is_valid_num_heads(self.num_heads)
         )
         if self._fp8_prefill_enabled:
             max_prefill_qlen = min(
@@ -480,11 +482,13 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
 
         # After kv_b_proj decompression, K has num_heads heads (same as Q).
         # So gqa_ratio=1 and num_head_k=num_heads for the PS kernel.
-        # Non-divisor head counts (e.g. K3's 12/rank at TP8) are padded to 16 in
-        # _mla_fp8_prefill_attn; build the PS metadata for the padded head count so
-        # the work/reduce maps match. This also lowers the partial-tile count:
-        # gcd(16, cu_num=256)=16 (~960 tiles) vs gcd(12,256)=4 (~4032), saving ~6 GiB.
-        num_head_k = max(16, self.num_heads)
+        # Head counts that are not a multiple of 16 (K3: 12/rank at TP8,
+        # 24/rank at TP4) are replicate-padded up to one in
+        # _mla_fp8_prefill_attn; build the PS metadata for that padded head
+        # count so the work/reduce maps match what the kernel is handed. This
+        # also lowers the partial-tile count: gcd(16, cu_num=256)=16
+        # (~960 tiles) vs gcd(12,256)=4 (~4032), saving ~6 GiB.
+        num_head_k = AiterMLAHelper.get_fp8_prefill_num_heads(self.num_heads)
         v_head_dim = self.mla_dims.v_head_dim
         # gqa_ratio = 1
         # qlen_granularity = _FP8_PREFILL_TILE_Q // max(gqa_ratio, 1)
@@ -586,11 +590,13 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         kv_indptr_cpu = qo_indptr_cpu.clone()
         seq_lens_cpu = (qo_indptr_cpu[1:] - qo_indptr_cpu[:-1]).to(torch.int32)
 
-        # Non-divisor head counts (e.g. K3's 12/rank at TP8) are padded to 16 in
-        # _mla_fp8_prefill_attn; build the PS metadata for the padded head count so
-        # the work/reduce maps match. This also lowers the partial-tile count:
-        # gcd(16, cu_num=256)=16 (~960 tiles) vs gcd(12,256)=4 (~4032), saving ~6 GiB.
-        num_head_k = max(16, self.num_heads)
+        # Head counts that are not a multiple of 16 (K3: 12/rank at TP8,
+        # 24/rank at TP4) are replicate-padded up to one in
+        # _mla_fp8_prefill_attn; build the PS metadata for that padded head
+        # count so the work/reduce maps match what the kernel is handed. This
+        # also lowers the partial-tile count: gcd(16, cu_num=256)=16
+        # (~960 tiles) vs gcd(12,256)=4 (~4032), saving ~6 GiB.
+        num_head_k = AiterMLAHelper.get_fp8_prefill_num_heads(self.num_heads)
         # gqa_ratio = 1
         # qhead_granularity = max(gqa_ratio, 1)
         # qlen_granularity = _FP8_PREFILL_TILE_Q // qhead_granularity
@@ -951,8 +957,31 @@ class AiterMLAHelper:
         return -(-num_heads // m) * m
 
     @staticmethod
-    def get_mla_padded_q(num_heads: int, q: torch.Tensor) -> torch.Tensor:
-        m = AiterMLAHelper.get_actual_mla_num_heads(num_heads)
+    def get_fp8_prefill_num_heads(num_heads: int) -> int:
+        """Head count the FP8 PS asm prefill runs at: the next multiple of 16.
+
+        Deliberately *not* ``get_actual_mla_num_heads``. That one carves out
+        native H24 when ``_aiter_mla_native_h24_supported()``, which probes the
+        asm *decode* reducer and metadata. The prefill is a different kernel
+        pair (``mla_prefill_ps_asm_fwd`` + ``mla_reduce_v1``) with no such
+        probe, so 24 heads pad to 32 here even on a native-H24 build.
+
+        The PS metadata in ``_init_fp8_prefill_ps_buffers``/``build()`` must be
+        sized with this same function, or the work/reduce maps describe a
+        different head count than the kernel is handed.
+        """
+        m = AiterMLAHelper._AITER_MIN_MLA_HEADS
+        return -(-num_heads // m) * m
+
+    @staticmethod
+    def get_mla_padded_q(
+        num_heads: int, q: torch.Tensor, target_heads: int | None = None
+    ) -> torch.Tensor:
+        m = (
+            target_heads
+            if target_heads is not None
+            else AiterMLAHelper.get_actual_mla_num_heads(num_heads)
+        )
         if num_heads == m:
             return q
         if m % num_heads == 0:
@@ -1061,12 +1090,13 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
 
         # FP8 MLA prefill kernel imports (lazy, only when enabled).
         # Auto-enabled on gfx950 when AITER ships the kernels. Only runs when the
-        # KV cache is FP8, and supports non-divisor small head counts via pad-to-16.
+        # KV cache is FP8. Head counts that are not a multiple of 16 are
+        # replicate-padded up to one (see _mla_fp8_prefill_attn).
         from vllm.utils.torch_utils import is_quantized_kv_cache
 
         self._fp8_prefill_enabled = _fp8_mla_prefill_supported() and (
             is_quantized_kv_cache(kv_cache_dtype)
-            and (self.num_heads % 16 == 0 or 0 < self.num_heads < 16)
+            and AiterMLAHelper.is_valid_num_heads(self.num_heads)
         )
         if self._fp8_prefill_enabled:
             from aiter import mla_prefill_ps_asm_fwd, mla_reduce_v1
@@ -1109,19 +1139,25 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
 
         fp8_dtype = current_platform.fp8_dtype()
         total_q = q.shape[0]
-        # PS asm prefill + mla_reduce_v1 require 16-aligned heads and the PS
-        # metadata is built for max(16, num_heads). For non-divisor small head
-        # counts (K3 = 12/rank at TP8) replicate-pad q/k/v to 16 — MLA attention
-        # is independent per query head over the shared KV, so the padding heads
-        # cannot affect the real ones (exact, same as the decode path) — then
-        # slice the output back to the real head count.
+        # PS asm prefill + mla_reduce_v1 require 16-aligned heads, and the PS
+        # metadata is built for get_fp8_prefill_num_heads(num_heads). For head
+        # counts that are not a multiple of 16 (K3 = 12/rank at TP8, 24/rank at
+        # TP4) replicate-pad q/k/v up to that count, then slice the output back
+        # to the real head count.
+        #
+        # Exact, not approximate: after kv_b_proj gqa_ratio is 1, so q, k and v
+        # all carry num_heads heads and attention is independent per head.
+        # Padding all three identically makes padded head j a duplicate of real
+        # head j % num_heads, so the real heads [0:num_heads] are bit-identical
+        # to the unpadded result. Same argument as the decode path; only the
+        # target width differs.
         _real_nhead = self.num_heads
-        _pad16 = _real_nhead < 16
-        if _pad16:
-            q = AiterMLAHelper.get_mla_padded_q(_real_nhead, q)
-            k = AiterMLAHelper.get_mla_padded_q(_real_nhead, k)
-            v = AiterMLAHelper.get_mla_padded_q(_real_nhead, v)
-        nhead = 16 if _pad16 else self.num_heads
+        nhead = AiterMLAHelper.get_fp8_prefill_num_heads(_real_nhead)
+        _pad = nhead != _real_nhead
+        if _pad:
+            q = AiterMLAHelper.get_mla_padded_q(_real_nhead, q, nhead)
+            k = AiterMLAHelper.get_mla_padded_q(_real_nhead, k, nhead)
+            v = AiterMLAHelper.get_mla_padded_q(_real_nhead, v, nhead)
         v_head_dim = self.v_head_dim
         tile_q = _FP8_PREFILL_TILE_Q
 
@@ -1154,7 +1190,7 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
             ((num_partial_tiles * tile_q, nhead), torch.float32),
             ((total_q, nhead), torch.float32),
         ]
-        if _pad16:
+        if _pad:
             # The ASM and reduce kernels write a [total_q, nhead, v_head_dim]
             # buffer.  With unpadded heads that aliases the caller's
             # [total_q, nhead * v_head_dim] output, so write straight into it;
@@ -1163,7 +1199,7 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
 
         workspace = current_workspace_manager()
         logits, attn_lse, final_lse, *pad_out = workspace.get_simultaneous(*scratch)
-        out_3d = pad_out[0] if _pad16 else out.view(total_q, nhead, v_head_dim)
+        out_3d = pad_out[0] if _pad else out.view(total_q, nhead, v_head_dim)
 
         # Phase 1: persistent-scheduling assembly prefill kernel.
         self._mla_prefill_ps_asm_fwd(
@@ -1201,7 +1237,7 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
             final_lse,
         )
 
-        if _pad16:
+        if _pad:
             out.view(total_q, _real_nhead, v_head_dim).copy_(out_3d[:, :_real_nhead, :])
 
     def forward_mha(

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -482,12 +482,21 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
 
         # After kv_b_proj decompression, K has num_heads heads (same as Q).
         # So gqa_ratio=1 and num_head_k=num_heads for the PS kernel.
-        # Head counts that are not a multiple of 16 (K3: 12/rank at TP8,
-        # 24/rank at TP4) are replicate-padded up to one in
-        # _mla_fp8_prefill_attn; build the PS metadata for that padded head
-        # count so the work/reduce maps match what the kernel is handed. This
-        # also lowers the partial-tile count: gcd(16, cu_num=256)=16
-        # (~960 tiles) vs gcd(12,256)=4 (~4032), saving ~6 GiB.
+        # Head counts that are not a multiple of 16 (K3: 12/rank at TP8) are
+        # replicate-padded up to one in _mla_fp8_prefill_attn; build the PS
+        # metadata for that same padded count so the work/reduce maps and the
+        # scratch reservations describe the width the kernel is handed.
+        #
+        # This was previously max(16, num_heads), which agrees with the helper
+        # at every head count reachable today (12 and 16 both give 16) and
+        # differs only above 16: at 24 it leaves num_head_k=24 while the
+        # forward pads to 32. That is not a correctness bug -- the 24-wide work
+        # maps still cover head-tiles 0..23, which are the real heads -- but it
+        # is expensive, because a lower head alignment yields more partial
+        # tiles: gcd-driven, 24 heads -> 64 tiles vs 32 heads -> 16, i.e.
+        # 193.6 MiB of reservations instead of 68.6 MiB at batch=1/qlen=512
+        # (measured on gfx950). Sizing both from one helper keeps the widths
+        # equal and takes the cheaper tiling.
         num_head_k = AiterMLAHelper.get_fp8_prefill_num_heads(self.num_heads)
         v_head_dim = self.mla_dims.v_head_dim
         # gqa_ratio = 1
@@ -590,12 +599,21 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         kv_indptr_cpu = qo_indptr_cpu.clone()
         seq_lens_cpu = (qo_indptr_cpu[1:] - qo_indptr_cpu[:-1]).to(torch.int32)
 
-        # Head counts that are not a multiple of 16 (K3: 12/rank at TP8,
-        # 24/rank at TP4) are replicate-padded up to one in
-        # _mla_fp8_prefill_attn; build the PS metadata for that padded head
-        # count so the work/reduce maps match what the kernel is handed. This
-        # also lowers the partial-tile count: gcd(16, cu_num=256)=16
-        # (~960 tiles) vs gcd(12,256)=4 (~4032), saving ~6 GiB.
+        # Head counts that are not a multiple of 16 (K3: 12/rank at TP8) are
+        # replicate-padded up to one in _mla_fp8_prefill_attn; build the PS
+        # metadata for that same padded count so the work/reduce maps and the
+        # scratch reservations describe the width the kernel is handed.
+        #
+        # This was previously max(16, num_heads), which agrees with the helper
+        # at every head count reachable today (12 and 16 both give 16) and
+        # differs only above 16: at 24 it leaves num_head_k=24 while the
+        # forward pads to 32. That is not a correctness bug -- the 24-wide work
+        # maps still cover head-tiles 0..23, which are the real heads -- but it
+        # is expensive, because a lower head alignment yields more partial
+        # tiles: gcd-driven, 24 heads -> 64 tiles vs 32 heads -> 16, i.e.
+        # 193.6 MiB of reservations instead of 68.6 MiB at batch=1/qlen=512
+        # (measured on gfx950). Sizing both from one helper keeps the widths
+        # equal and takes the cheaper tiling.
         num_head_k = AiterMLAHelper.get_fp8_prefill_num_heads(self.num_heads)
         # gqa_ratio = 1
         # qhead_granularity = max(gqa_ratio, 1)
@@ -969,6 +987,14 @@ class AiterMLAHelper:
         The PS metadata in ``_init_fp8_prefill_ps_buffers``/``build()`` must be
         sized with this same function, or the work/reduce maps describe a
         different head count than the kernel is handed.
+
+        This function itself has no upper bound; the ceiling comes from the
+        ``is_valid_num_heads`` gate, which rejects counts above
+        ``_AITER_MAX_PADDED_MLA_HEADS`` (128) unless they are already
+        16-aligned. That bound was established for the asm *decode* padding, so
+        an architecture with, say, 136 heads per rank would be refused the
+        prefill here for a reason that was never measured against this kernel
+        pair. Revisit the constant rather than special-casing prefill.
         """
         m = AiterMLAHelper._AITER_MIN_MLA_HEADS
         return -(-num_heads // m) * m
@@ -1141,9 +1167,20 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
         total_q = q.shape[0]
         # PS asm prefill + mla_reduce_v1 require 16-aligned heads, and the PS
         # metadata is built for get_fp8_prefill_num_heads(num_heads). For head
-        # counts that are not a multiple of 16 (K3 = 12/rank at TP8, 24/rank at
-        # TP4) replicate-pad q/k/v up to that count, then slice the output back
-        # to the real head count.
+        # counts that are not a multiple of 16 (K3 = 12/rank at TP8)
+        # replicate-pad q/k/v up to that count, then slice the output back to
+        # the real head count.
+        #
+        # Counts above 16 that are not multiples of 16 (24, 40, ...) are
+        # handled by the same code but are not reached by any current model
+        # and TP that fits: 96 heads would need TP4, whose weights exceed a
+        # 288 GiB GPU, and 128-head models land on 128/64/32/16/8. The path is
+        # kept general for future architectures and its numerics are covered by
+        # test_fp8_prefill_matches_reference[num_heads=24]. Note the cost is
+        # (padded - real)/real extra FLOPs and q/k/v bytes, which is worst just
+        # above a multiple of 16 (17 heads pad to 32); a future arch landing
+        # there should measure against the flash_attn_varlen_func fallback
+        # rather than assume the asm path wins.
         #
         # Exact, not approximate: after kv_b_proj gqa_ratio is 1, so q, k and v
         # all carry num_heads heads and attention is independent per head.


### PR DESCRIPTION
## Context

The AITER FP8 MLA **prefill** path (`mla_prefill_ps_asm_fwd` + `mla_reduce_v1`) is gated on
`num_heads % 16 == 0`. Kimi-K3 has 96 heads over `kv_lora_rank=512` → **12 heads/rank at TP8**,
a non-divisor of 16, so its FP8 prefill falls back to the BF16 FMHA decompress path. That fallback
builds a bf16 working set not covered by the FP8 KV-pool accounting and exhausts the activation
arena at long context (K3 OOM'd at ~197k tokens, KV pool <4% used).

This is the **prefill counterpart to #50578** (asm decode pad 12→16). MLA attention is independent
per query head over the shared latent KV, so padding the query heads up to 16 and slicing the
result back is exact.

Rebased onto current `main` (includes merged #50578). Prefill-only diff: **+48 / −11**,
one file (`rocm_aiter_mla.py`).

## Changes

**FP8 prefill enablement (this PR):**
- Relax the `_fp8_prefill_enabled` gate to also allow `0 < num_heads < 16`, and **gate it on FP8 KV**
  (`kv_cache_dtype_str == "fp8"` in the metadata builder; `is_quantized_kv_cache(kv_cache_dtype)`
  in the impl). Without this, a bf16-KV serve would reserve PS workspace unnecessarily.
- In `_mla_fp8_prefill_attn`: replicate-pad Q/K/V to 16 via `AiterMLAHelper.get_mla_padded_q`
  (from #50578), run PS asm prefill + `mla_reduce_v1` at 16 heads, slice output back to `num_heads`.
- Set `num_head_k = max(16, num_heads)` in `_init_fp8_prefill_ps_buffers` and
  `_build_fp8_prefill_ps_metadata` so work/reduce maps match padded tensors — also cuts partial
  tiles (`gcd(16,256)=16` vs `gcd(12,256)=4`), reclaiming **~6 GiB** PS workspace.

Decode padding / Gluon routing is **not** in this PR — that is #50578 (merged).

## Dependencies / related

- **#50578** (merged) — `AiterMLAHelper.get_mla_padded_q` / asm decode for non-divisor heads.
- **ROCm/aiter#4452** (merged `a63ede724`) — 64-bit paged-KV byte offsets for >4 GB addressing.
- Composes with **#48712** (gate PS workspace on fp8 KV) — this PR includes the same gate locally.

## vllm serve command

**Hardware:** 8× MI355X (gfx950), TP8  
**Model:** `moonshotai/Kimi-K3` (mxfp4)

```bash
export VLLM_ROCM_USE_AITER=1
export VLLM_ROCM_USE_AITER_MOE=1
export VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4=1
export VLLM_USE_BREAKABLE_CUDAGRAPH=0
export AITER_SITUV2_A8W4=1
export SAFETENSORS_FAST_GPU=1
export GPU_ARCHS=gfx950
export HF_HUB_CACHE=/dev/shm/hf-cache HF_HOME=/dev/shm/hf-cache
export VLLM_ENGINE_READY_TIMEOUT_S=3600
export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=3600
export VLLM_HTTP_TIMEOUT_KEEP_ALIVE=900
export HIPBLASLT_WORKSPACE_SIZE=32768
export CUBLASLT_WORKSPACE_SIZE=32768

MODEL=/path/to/Kimi-K3   # e.g. /shared_nfs/models/Kimi-K3

vllm serve "$MODEL" --served-model-name moonshotai/Kimi-K3 \
  --host 0.0.0.0 --port 8888 --tensor-parallel-size 8 --async-scheduling \
  --distributed-executor-backend mp \
  --gpu-memory-utilization 0.95 \
  --max-num-seqs 64 --max-model-len 1048576 --max-num-batched-tokens 4096 \
  --trust-remote-code --load-format auto --moe-backend aiter \
  --kv-cache-dtype fp8 --attention-backend ROCM_AITER_MLA --mm-encoder-tp-mode data \
  --compilation-config '{"mode":3,"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["+fused_rms_norm_gated"]}' \
  --enable-prefix-caching --no-disable-hybrid-kv-cache-manager \
  --reasoning-parser kimi_k3 --tool-call-parser kimi_k3 --enable-auto-tool-choice \
  --enable-prompt-tokens-details --disable-uvicorn-access-log

## Test results

### Long-context prefill (functional)

| | Before PR-A | After PR-A |
|---|-------------|------------|
| Fresh prefill @ util 0.95 | OOM ~197k tokens (BF16 FMHA fallback, KV <4%) | **470k (68 s)**, **590k (28.6 s)** OK |
| PS workspace | ~4032 partial tiles (~12 heads) | ~960 partial tiles (~6 GiB saved) |

### Accuracy — GSM8K (lm-eval, full 1319-test split, 5-shot greedy, conc=32, ctx=16384)

Patches applied for this run: **#50578 + PR-A + #50618 only** (no cgmem/MoE/kv_b_proj). Server at
`gpu-memory-utilization 0.88`.

```bash
export HF_HUB_CACHE=/dev/shm/hf-cache HF_HOME=/dev/shm/hf-cache
export OPENAI_API_KEY=EMPTY

python3 -m lm_eval --model local-chat-completions --apply_chat_template \
  --include_path /path/to/InferenceX/utils/evals \
  --tasks /path/to/InferenceX/utils/evals/gsm8k.yaml \
  --output_path /tmp/eval_out --log_samples \
  --model_args "model=moonshotai/Kimi-K3,base_url=http://localhost:8888/v1/chat/completions,api_key=EMPTY,eos_string=</s>,max_retries=5,num_concurrent=32,timeout=1800,tokenized_requests=False,max_length=16384" \
  --gen_kwargs "max_tokens=12288,temperature=0,top_p=1"
```

| Run | n | strict-match EM | flexible-extract EM |
|-----|---|-----------------|---------------------|
| **With PR-A** (MI355X node 193, 2026-08-09) | 1319 | **97.04%** ± 0.47% | **96.97%** ± 0.47% |
| Prior stack (cgmem+MoE+PR-A, node 1319, util 0.95) | 1319 | 96.89% ± 0.48% | 96.89% ± 0.48% |
| Baseline replicate (stock + ASM deps, node 1319) | 1319 | 96.66% ± 0.49% | 96.66% ± 0.49% |

No accuracy regression vs baseline; delta within run noise.

