### PR TITLE
[Bugfix] Propagate decode SWA index width for DSpark + FLASHINFER_MLA_SPARSE_DSV4

### DIFF
--- a/tests/kernels/attention/test_flashmla_sparse.py
+++ b/tests/kernels/attention/test_flashmla_sparse.py
@@ -225,6 +225,7 @@ def test_flashinfer_sparse_indices_cache(monkeypatch):
             token_to_req_indices=torch.tensor([0, 1, 1], dtype=torch.int32),
             decode_swa_indices=torch.tensor([[5, 6, -1, -1]], dtype=torch.int32),
             decode_swa_lens=torch.tensor([2], dtype=torch.int32),
+            decode_swa_width=4,
             is_valid_token=torch.tensor([True], dtype=torch.bool),
             num_decodes=1,
             num_prefills=1,
@@ -331,3 +332,85 @@ def test_flashinfer_sparse_indices_cache(monkeypatch):
     assert builder_calls == 4
     assert sparse_indices_third is not sparse_indices_fourth
     assert sparse_lens_third is not sparse_lens_fourth
+
+
+def test_flashinfer_sparse_index_uses_decode_swa_width(monkeypatch):
+    from vllm.models.deepseek_v4.nvidia import flashinfer_sparse as flashinfer_mod
+    from vllm.v1.attention.backends.mla.sparse_swa import DeepseekSparseSWAMetadata
+
+    captured_widths: list[int] = []
+
+    def fake_build(*args, **kwargs):
+        # window_size is the 12th positional arg of
+        # build_flashinfer_mixed_sparse_indices.
+        captured_widths.append(args[11])
+        num_tokens = args[0].shape[0] + args[3].shape[0]
+        return (
+            torch.zeros((num_tokens, 1), dtype=torch.int32),
+            torch.zeros((num_tokens,), dtype=torch.int32),
+        )
+
+    monkeypatch.setattr(
+        flashinfer_mod, "build_flashinfer_mixed_sparse_indices", fake_build
+    )
+
+    attn = object.__new__(flashinfer_mod.DeepseekV4FlashInferMLAAttention)
+    attn.compress_ratio = 1
+    attn.window_size = 4
+    attn.topk_indices_buffer = torch.zeros((4, 0), dtype=torch.int32)
+
+    wide_width = 8
+    wide_indices = torch.full((1, wide_width), -1, dtype=torch.int32)
+    wide_indices[0, :2] = torch.tensor([5, 6], dtype=torch.int32)
+    wide_metadata = DeepseekSparseSWAMetadata(
+        block_table=torch.tensor([[0, 1]], dtype=torch.int32),
+        slot_mapping=torch.tensor([0], dtype=torch.int64),
+        block_size=64,
+        seq_lens=torch.tensor([8], dtype=torch.int32),
+        query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 1], dtype=torch.int32),
+        token_to_req_indices=torch.tensor([0], dtype=torch.int32),
+        decode_swa_indices=wide_indices,
+        decode_swa_lens=torch.tensor([2], dtype=torch.int32),
+        decode_swa_width=wide_width,
+        is_valid_token=torch.tensor([True], dtype=torch.bool),
+        num_decodes=1,
+        num_prefills=0,
+        num_decode_tokens=1,
+        num_prefill_tokens=0,
+    )
+    attn._build_sparse_index_metadata(
+        kv_cache=None,
+        swa_k_cache=torch.empty((1, 64, 512), dtype=torch.bfloat16),
+        swa_metadata=wide_metadata,
+        attn_metadata=None,
+        swa_only=True,
+    )
+    assert captured_widths == [wide_width]
+
+    empty_width = 8
+    empty_metadata = DeepseekSparseSWAMetadata(
+        block_table=torch.tensor([[0, 1]], dtype=torch.int32),
+        slot_mapping=torch.tensor([0, 1], dtype=torch.int64),
+        block_size=64,
+        seq_lens=torch.tensor([8], dtype=torch.int32),
+        query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 2], dtype=torch.int32),
+        token_to_req_indices=torch.tensor([0, 0], dtype=torch.int32),
+        decode_swa_indices=torch.empty((0, 1, empty_width), dtype=torch.int32),
+        decode_swa_lens=torch.empty((0,), dtype=torch.int32),
+        decode_swa_width=empty_width,
+        is_valid_token=torch.tensor([True, True], dtype=torch.bool),
+        num_decodes=0,
+        num_prefills=1,
+        num_decode_tokens=0,
+        num_prefill_tokens=2,
+    )
+    attn._build_sparse_index_metadata(
+        kv_cache=None,
+        swa_k_cache=torch.empty((1, 64, 512), dtype=torch.bfloat16),
+        swa_metadata=empty_metadata,
+        attn_metadata=None,
+        swa_only=True,
+    )
+    assert captured_widths == [wide_width, empty_width]

--- a/vllm/models/deepseek_v4/amd/rocm.py
+++ b/vllm/models/deepseek_v4/amd/rocm.py
@@ -410,7 +410,9 @@ class DeepseekV4ROCMAiterSparseSWAMetadataBuilder(DeepseekSparseSWAMetadataBuild
             and base.decode_swa_lens is not None
         ):
             ragged_indices, ragged_indptr = build_ragged_indices_from_dense(
-                base.decode_swa_indices.reshape(base.num_decode_tokens, -1),
+                base.decode_swa_indices.reshape(
+                    base.num_decode_tokens, base.decode_swa_width
+                ),
                 base.decode_swa_lens,
             )
             ragged_indices, ragged_indptr = _copy_ragged_to_graph_buffers(
@@ -419,9 +421,7 @@ class DeepseekV4ROCMAiterSparseSWAMetadataBuilder(DeepseekSparseSWAMetadataBuild
                 self.decode_swa_ragged_indices_buffer,
                 self.decode_swa_ragged_indptr_buffer,
                 base.num_decode_tokens,
-                # Actual dense width for this build: window_size (causal) or
-                # noncausal_index_width (DSpark non-causal draft).
-                base.decode_swa_indices.shape[-1],
+                base.decode_swa_width,
             )
 
         return DeepseekV4ROCMAiterSparseSWAMetadata(

--- a/vllm/models/deepseek_v4/nvidia/flashinfer_sparse.py
+++ b/vllm/models/deepseek_v4/nvidia/flashinfer_sparse.py
@@ -310,7 +310,7 @@ class DeepseekV4FlashInferMLAAttention(DeepseekV4Attention):
         assert swa_metadata.block_table is not None
 
         decode_swa_indices = swa_metadata.decode_swa_indices.reshape(
-            num_decode_tokens, self.window_size
+            num_decode_tokens, swa_metadata.decode_swa_width
         )
         decode_compressed_topk_lens = None
         decode_compressed_indices_are_local = False
@@ -405,7 +405,7 @@ class DeepseekV4FlashInferMLAAttention(DeepseekV4Attention):
                 swa_metadata.block_size,
                 compressed_block_table,
                 compressed_block_size,
-                self.window_size,
+                swa_metadata.decode_swa_width,
                 self.compress_ratio,
                 top_k,
                 decode_compressed_indices_are_local=decode_compressed_indices_are_local,

--- a/vllm/v1/attention/backends/mla/sparse_swa.py
+++ b/vllm/v1/attention/backends/mla/sparse_swa.py
@@ -170,8 +170,10 @@ class DeepseekSparseSWAMetadata:
 
     is_valid_token: torch.Tensor | None = None  # [num_tokens]
     token_to_req_indices: torch.Tensor | None = None  # [num_tokens]
-    decode_swa_indices: torch.Tensor | None = None  # [num_decode_tokens, window_size]
+    decode_swa_indices: torch.Tensor | None = None  # [num_decode_tokens, width]
     decode_swa_lens: torch.Tensor | None = None  # [num_decode_tokens]
+    # window_size (causal) or noncausal_index_width (DSpark non-causal).
+    decode_swa_width: int = 0
     # Paged-coordinate prefill SWA indices/lens (FP8 paged-direct prefill).
     prefill_swa_indices: torch.Tensor | None = (
         None  # [num_prefill_tokens, 1, window_size]
@@ -530,6 +532,9 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
         is_valid_token.copy_(slot_mapping >= 0)
 
         non_causal = not common_attn_metadata.causal
+        decode_swa_width = (
+            self.noncausal_index_width if non_causal else self.window_size
+        )
         decode_swa_indices = self.decode_swa_indices
         if num_decode_tokens > 0:
             self.decode_swa_lens[num_decode_tokens:] = 0
@@ -628,6 +633,7 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
             token_to_req_indices=token_to_req_indices,
             decode_swa_indices=decode_swa_indices[:num_decode_tokens],
             decode_swa_lens=self.decode_swa_lens[:num_decode_tokens],
+            decode_swa_width=decode_swa_width,
             prefill_swa_indices=(
                 self.prefill_swa_indices[:num_prefill_tokens]
                 if num_prefill_tokens > 0


### PR DESCRIPTION
DSpark non-causal draft batches allocate `decode_swa_indices` with
`noncausal_index_width` (wider than `window_size`). FlashInfer DSV4 sparse
MLA still reshaped / passed `self.window_size` into
`build_flashinfer_mixed_sparse_indices`, which crashes those drafts, e.g.:

```
RuntimeError: shape '[7, 128]' is invalid for input of size 1792
(at `flashinfer_sparse.py` `_build_sparse_index_metadata` when reshaping
`decode_swa_indices`).
```

- Add `decode_swa_width` to `DeepseekSparseSWAMetadata` and set it in the SWA
  builder (`window_size` or `noncausal_index_width`).
- Use that width in FlashInfer `_build_sparse_index_metadata` and the ROCM
  ragged conversion path.

## Test Plan
- [x] `pytest tests/kernels/attention/test_flashmla_sparse.py`
- [x] Manual: DeepSeek-V4-Pro-DSpark with `attention_backend: FLASHINFER_MLA_SPARSE_DSV4`

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

