### PR TITLE
[CI] Exclude KV-connector subtree from broad source dependencies

### DIFF
--- a/.buildkite/test_areas/basic_correctness.yaml
+++ b/.buildkite/test_areas/basic_correctness.yaml
@@ -8,6 +8,7 @@ steps:
   device: h200_18gb
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/basic_correctness/test_basic_correctness
   - tests/basic_correctness/test_cpu_offload
   - tests/basic_correctness/test_mem.py

--- a/.buildkite/test_areas/benchmarks.yaml
+++ b/.buildkite/test_areas/benchmarks.yaml
@@ -8,6 +8,7 @@ steps:
   device: h200_18gb
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/benchmarks/
   commands:
   - pytest -v -s benchmarks/

--- a/.buildkite/test_areas/distributed.yaml
+++ b/.buildkite/test_areas/distributed.yaml
@@ -9,6 +9,7 @@ steps:
   num_devices: 2
   source_file_dependencies:
   - vllm/distributed
+  - "!vllm/distributed/kv_transfer/"
   - tests/distributed
   commands:
   - pytest -v -s distributed/test_comm_ops.py
@@ -23,6 +24,7 @@ steps:
   num_devices: 2
   source_file_dependencies:
   - vllm/distributed/
+  - "!vllm/distributed/kv_transfer/"
   - vllm/engine/
   - vllm/executor/
   - vllm/worker/worker_base.py
@@ -46,6 +48,7 @@ steps:
       - image-build-amd
       source_file_dependencies:
       - vllm/distributed/
+      - "!vllm/distributed/kv_transfer/"
       - vllm/engine/
       - vllm/executor/
       - vllm/worker/worker_base.py
@@ -63,6 +66,7 @@ steps:
   source_file_dependencies:
   - vllm/compilation/
   - vllm/distributed/
+  - "!vllm/distributed/kv_transfer/"
   - vllm/engine/
   - vllm/executor/
   - vllm/worker/worker_base.py
@@ -85,6 +89,7 @@ steps:
   num_devices: 2
   source_file_dependencies:
   - vllm/distributed/
+  - "!vllm/distributed/kv_transfer/"
   - vllm/engine/
   - vllm/executor/
   - vllm/worker/worker_base.py
@@ -108,6 +113,7 @@ steps:
   num_devices: 4
   source_file_dependencies:
   - vllm/distributed/
+  - "!vllm/distributed/kv_transfer/"
   - tests/distributed/test_torchrun_example.py
   - tests/distributed/test_torchrun_example_moe.py
   - examples/rl/
@@ -140,6 +146,7 @@ steps:
   num_devices: 4
   source_file_dependencies:
   - vllm/distributed/
+  - "!vllm/distributed/kv_transfer/"
   - tests/v1/distributed
   - tests/v1/engine/test_engine_core_client.py
   - tests/distributed/test_utils
@@ -161,6 +168,7 @@ steps:
   num_devices: 4
   source_file_dependencies:
   - vllm/distributed/
+  - "!vllm/distributed/kv_transfer/"
   - tests/distributed/test_pynccl
   - tests/distributed/test_events
   - tests/compile/fullgraph/test_basic_correctness.py
@@ -186,6 +194,7 @@ steps:
   - examples/features/torchrun/torchrun_dp_example_offline.py
   - vllm/config/parallel.py
   - vllm/distributed/
+  - "!vllm/distributed/kv_transfer/"
   - vllm/v1/engine/llm_engine.py
   - vllm/v1/executor/uniproc_executor.py
   - vllm/v1/worker/gpu_worker.py
@@ -204,6 +213,7 @@ steps:
   num_devices: 4
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   commands:
   # NOTE: don't test llama model here, it seems hf implementation is buggy
   # see https://github.com/vllm-project/vllm/pull/5689 for details
@@ -251,6 +261,7 @@ steps:
   optional: true # TODO: revert once infra issue solved
   source_file_dependencies:
   - vllm/distributed/
+  - "!vllm/distributed/kv_transfer/"
   - vllm/engine/
   - vllm/executor/
   - vllm/model_executor/models/
@@ -266,6 +277,7 @@ steps:
   num_devices: 4
   source_file_dependencies:
   - vllm/distributed/
+  - "!vllm/distributed/kv_transfer/"
   - vllm/engine/
   - vllm/executor/
   - vllm/model_executor/models/

--- a/.buildkite/test_areas/engine.yaml
+++ b/.buildkite/test_areas/engine.yaml
@@ -98,6 +98,7 @@ steps:
     - vllm/compilation/
     - vllm/config/
     - vllm/distributed/
+    - "!vllm/distributed/kv_transfer/"
     - vllm/engine/
     - vllm/envs.py
     - vllm/forward_context.py

--- a/.buildkite/test_areas/entrypoints.yaml
+++ b/.buildkite/test_areas/entrypoints.yaml
@@ -22,6 +22,7 @@ steps:
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/entrypoints/llm
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
@@ -43,6 +44,7 @@ steps:
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/entrypoints/serve
   - tests/entrypoints/scale_out
   commands:
@@ -65,6 +67,7 @@ steps:
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/entrypoints/openai
   - tests/entrypoints/test_chat_utils
   commands:
@@ -85,6 +88,7 @@ steps:
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/entrypoints/openai
   - tests/entrypoints/test_chat_utils
   commands:
@@ -106,6 +110,7 @@ steps:
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/tool_use
   - tests/entrypoints/tool_parsers
   - tests/entrypoints/anthropic
@@ -130,6 +135,7 @@ steps:
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/entrypoints/openai/responses
   commands:
   - pytest -v -s entrypoints/openai/responses
@@ -141,6 +147,7 @@ steps:
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/entrypoints/speech_to_text
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
@@ -153,6 +160,7 @@ steps:
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/entrypoints/multimodal
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
@@ -165,6 +173,7 @@ steps:
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/entrypoints/pooling
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn

--- a/.buildkite/test_areas/expert_parallelism.yaml
+++ b/.buildkite/test_areas/expert_parallelism.yaml
@@ -47,6 +47,7 @@ steps:
   num_devices: 4
   source_file_dependencies:
   - vllm/distributed/
+  - "!vllm/distributed/kv_transfer/"
   - vllm/engine/
   - vllm/executor/
   - vllm/compilation/

--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -9,6 +9,7 @@ steps:
   source_file_dependencies:
     - vllm/config/
     - vllm/distributed/
+    - "!vllm/distributed/kv_transfer/"
     - vllm/engine/
     - vllm/inputs/
     - vllm/logger.py
@@ -45,6 +46,7 @@ steps:
   source_file_dependencies:
     - vllm/config/
     - vllm/distributed/
+    - "!vllm/distributed/kv_transfer/"
     - vllm/engine/
     - vllm/entrypoints/pooling/
     - vllm/inputs/
@@ -101,6 +103,7 @@ steps:
   source_file_dependencies:
     - vllm/config/
     - vllm/distributed/
+    - "!vllm/distributed/kv_transfer/"
     - vllm/engine/
     - vllm/inputs/
     - vllm/lora/
@@ -161,6 +164,7 @@ steps:
   source_file_dependencies:
   - vllm/config/
   - vllm/distributed/
+  - "!vllm/distributed/kv_transfer/"
   - vllm/engine/
   - vllm/inputs/
   - vllm/model_executor/
@@ -228,6 +232,7 @@ steps:
   source_file_dependencies:
   - vllm/config/
   - vllm/distributed/
+  - "!vllm/distributed/kv_transfer/"
   - vllm/engine/
   - vllm/inputs/
   - vllm/model_executor/
@@ -287,6 +292,7 @@ steps:
   - vllm/assets/
   - vllm/config/
   - vllm/distributed/
+  - "!vllm/distributed/kv_transfer/"
   - vllm/engine/
   - vllm/inputs/
   - vllm/model_executor/

--- a/.buildkite/test_areas/models_basic.yaml
+++ b/.buildkite/test_areas/models_basic.yaml
@@ -8,6 +8,7 @@ steps:
   device: h200_18gb
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/models/test_initialization.py
   - tests/models/registry.py
   commands:
@@ -35,6 +36,7 @@ steps:
   timeout_in_minutes: 35
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/models/test_terratorch.py
   - tests/models/transformers/test_backend.py
   - tests/models/test_registry.py
@@ -82,6 +84,7 @@ steps:
   timeout_in_minutes: 20
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/models/test_utils.py
   - tests/models/test_vision.py
   - tests/models/test_adapters.py

--- a/.buildkite/test_areas/models_language.yaml
+++ b/.buildkite/test_areas/models_language.yaml
@@ -8,6 +8,7 @@ steps:
   device: h200_18gb
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/models/language
   commands:
     # Test standard language models, excluding a subset of slow tests
@@ -60,6 +61,7 @@ steps:
   timeout_in_minutes: 65
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/models/language/generation
   commands:
     # Install fast path packages for testing against transformers
@@ -88,6 +90,7 @@ steps:
   timeout_in_minutes: 65
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/models/language/generation
   commands:
     - uv pip install --system --no-build-isolation 'git+https://github.com/state-spaces/mamba@v2.3.0'
@@ -101,6 +104,7 @@ steps:
   optional: true
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/models/language/generation
   commands:
     # Install fast path packages for testing against transformers
@@ -115,6 +119,7 @@ steps:
   optional: true
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/models/language/generation_ppl_test
   commands:
     - pytest -v -s models/language/generation_ppl_test
@@ -126,6 +131,7 @@ steps:
   optional: true
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/models/language/pooling
   commands:
     - pytest -v -s models/language/pooling -m 'not core_model'
@@ -144,6 +150,7 @@ steps:
   optional: true
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/models/language/pooling_mteb_test
   commands:
     - pytest -v -s models/language/pooling_mteb_test

--- a/.buildkite/test_areas/models_multimodal.yaml
+++ b/.buildkite/test_areas/models_multimodal.yaml
@@ -8,6 +8,7 @@ steps:
   device: h200_18gb
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/models/multimodal
   commands:
     - pytest -v -s models/multimodal/generation/test_common.py -m core_model -k "qwen2"
@@ -26,6 +27,7 @@ steps:
   device: h200_18gb
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/models/multimodal
   commands:
     - pytest -v -s models/multimodal/generation/test_common.py -m core_model -k "qwen3 or gemma"
@@ -45,6 +47,7 @@ steps:
   timeout_in_minutes: 40
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/models/multimodal
   commands:
     - pytest -v -s models/multimodal/generation/test_common.py -m core_model -k "not qwen2 and not qwen3 and not gemma"
@@ -62,6 +65,7 @@ steps:
   timeout_in_minutes: 75
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/models/multimodal
   commands:
     - pytest -v -s models/multimodal -m core_model --ignore models/multimodal/generation/test_common.py --ignore models/multimodal/generation/test_ultravox.py --ignore models/multimodal/generation/test_qwen2_5_vl.py --ignore models/multimodal/generation/test_qwen2_vl.py --ignore models/multimodal/generation/test_whisper.py --ignore models/multimodal/generation/test_mm_prefix_lm.py --ignore models/multimodal/generation/test_memory_leak.py --ignore models/multimodal/generation/test_vit_cudagraph.py --ignore models/multimodal/processing
@@ -83,6 +87,7 @@ steps:
   timeout_in_minutes: 125
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/models/multimodal
   - tests/models/registry.py
   device: cpu-medium
@@ -96,6 +101,7 @@ steps:
   device: h200_18gb
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/models/multimodal
   - tests/models/registry.py
   commands:
@@ -132,6 +138,7 @@ steps:
   optional: true
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/models/multimodal/generation
   - tests/models/multimodal/test_mapping.py
   commands:
@@ -168,6 +175,7 @@ steps:
   optional: true
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/models/multimodal/generation
   commands:
     - pytest -v -s models/multimodal/generation/test_common.py -m 'split(group=0) and not core_model'
@@ -178,6 +186,7 @@ steps:
   optional: true
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/models/multimodal/generation
   commands:
     - pytest -v -s models/multimodal/generation/test_common.py -m 'split(group=1) and not core_model'
@@ -188,6 +197,7 @@ steps:
   device: h200_18gb
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/models/multimodal/pooling
   commands:
     - pytest -v -s models/multimodal/pooling -m 'not core_model'
@@ -200,4 +210,5 @@ steps:
       - image-build-amd
       source_file_dependencies:
       - vllm/
+      - "!vllm/distributed/kv_transfer/"
       - tests/models/multimodal/pooling

--- a/.buildkite/test_areas/pytorch.yaml
+++ b/.buildkite/test_areas/pytorch.yaml
@@ -13,6 +13,7 @@ steps:
     - vllm/compilation/
     - vllm/config/
     - vllm/distributed/
+    - "!vllm/distributed/kv_transfer/"
     - vllm/engine/
     - vllm/env_override.py
     - vllm/envs.py
@@ -53,6 +54,7 @@ steps:
     - vllm/compilation/
     - vllm/config/
     - vllm/distributed/
+    - "!vllm/distributed/kv_transfer/"
     - vllm/engine/
     - vllm/env_override.py
     - vllm/envs.py
@@ -85,6 +87,7 @@ steps:
     - vllm/compilation/
     - vllm/config/
     - vllm/distributed/
+    - "!vllm/distributed/kv_transfer/"
     - vllm/engine/
     - vllm/env_override.py
     - vllm/envs.py
@@ -118,6 +121,7 @@ steps:
   - vllm/compilation/
   - vllm/config/
   - vllm/distributed/
+  - "!vllm/distributed/kv_transfer/"
   - vllm/engine/
   - vllm/env_override.py
   - vllm/envs.py
@@ -157,6 +161,7 @@ steps:
   - vllm/compilation/
   - vllm/config/
   - vllm/distributed/
+  - "!vllm/distributed/kv_transfer/"
   - vllm/engine/
   - vllm/env_override.py
   - vllm/envs.py

--- a/.buildkite/test_areas/rust_frontend.yaml
+++ b/.buildkite/test_areas/rust_frontend.yaml
@@ -102,6 +102,7 @@ steps:
   source_file_dependencies:
   - rust/
   - vllm/distributed/
+  - "!vllm/distributed/kv_transfer/"
   - vllm/engine/
   - vllm/executor/
   - vllm/v1/engine/

--- a/.buildkite/test_areas/weight_loading.yaml
+++ b/.buildkite/test_areas/weight_loading.yaml
@@ -10,6 +10,7 @@ steps:
   optional: true
   source_file_dependencies:
   - vllm/
+  - "!vllm/distributed/kv_transfer/"
   - tests/weight_loading
   commands:
     - bash weight_loading/run_model_weight_loading_test.sh -c weight_loading/models.txt


### PR DESCRIPTION
## Summary

Steps that declare the broad `vllm/` or `vllm/distributed/` `source_file_dependencies` run whenever **any** file under those trees changes. The KV connectors live at `vllm/distributed/kv_transfer/`, so a self-contained change there — already covered by the dedicated **Disaggregated** jobs — fans out to the entire model / multimodal / entrypoint / basic-correctness matrix.

Concretely, the small nixl push-connector fix in #49221 triggered **~70 CUDA steps**, almost none of them related to KV transfer.

This PR adds a single exclusion — `- "!vllm/distributed/kv_transfer/"` — to every broad deps block (62 lines across 13 `test_areas` files), using the exclusion operator added in **vllm-project/ci-infra#450**.

The exclusion is evaluated **per changed file**: it only drops matches confined to the connector subtree. Every other change — including generic `vllm/distributed/` changes — still selects these steps exactly as before, so there is **no coverage reduction** for non-connector work. It is also generic across all KV connectors, not just nixl.

## Depends on

- vllm-project/ci-infra#450 (adds the `"!"` exclusion operator). The `"!"` syntax is inert until that merges, so this must land after it.

## Relation to existing PRs

This is **not** a duplicate of the open per-file narrowing PRs (#42219, #42220, #42221, #42222, #42223). Those replace `vllm/` with import-scanned module allowlists (a broad coverage change that must be re-maintained whenever a new top-level package is added). This PR instead **surgically excludes only the connector subtree** and leaves all other coverage intact — a much smaller, lower-risk change that directly targets the reported fan-out. (Author will coordinate linking/relationship with those PRs.)

## Test plan / results

CI-only change; does not affect model output, accuracy, or serving, so no model eval is applicable.

- ci-infra unit tests for the new operator: `pytest tests/pipeline_generator/ -q` → **63 passed**.
- All edited `test_areas/*.yaml` parse; `pre-commit` clean.
- Selection simulation (mirroring the generator's prefix + exclusion matching) on the #49221 changed-file set: **~70 → 18 steps** — the 15 nixl-gated Disaggregated jobs plus the `v1/kv_connector/unit` runners that legitimately execute the modified test. No multimodal/language/entrypoint fan-out.
- Verified no over-exclusion: changes to `vllm/model_executor/*`, `vllm/multimodal/*`, `vllm/entrypoints/*`, and `vllm/distributed/parallel_state.py` still trigger their broad suites; a connector-only change no longer triggers the generic distributed suites.

## Note

AI assistance (Claude Code) was used to author this change; every line has been reviewed by the submitter.