### PR TITLE
[CI] Prune redundant sequence-parallel test cases

### DIFF
--- a/.buildkite/test_areas/compile.yaml
+++ b/.buildkite/test_areas/compile.yaml
@@ -15,7 +15,8 @@ steps:
   - tests/compile/correctness_e2e/test_sequence_parallel.py
   commands:
   - export VLLM_TEST_CLEAN_GPU_MEMORY=1
-  - pytest -v -s tests/compile/correctness_e2e/test_sequence_parallel.py
+  - pytest -v -s tests/compile/correctness_e2e/test_sequence_parallel.py --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
+  parallelism: 2
 
 - label: Sequence Parallel Correctness Tests (2xH100)
   key: sequence-parallel-correctness-tests-2xh100

--- a/.buildkite/test_areas/compile.yaml
+++ b/.buildkite/test_areas/compile.yaml
@@ -15,8 +15,7 @@ steps:
   - tests/compile/correctness_e2e/test_sequence_parallel.py
   commands:
   - export VLLM_TEST_CLEAN_GPU_MEMORY=1
-  - pytest -v -s tests/compile/correctness_e2e/test_sequence_parallel.py --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
-  parallelism: 2
+  - pytest -v -s tests/compile/correctness_e2e/test_sequence_parallel.py
 
 - label: Sequence Parallel Correctness Tests (2xH100)
   key: sequence-parallel-correctness-tests-2xh100

--- a/tests/compile/correctness_e2e/test_sequence_parallel.py
+++ b/tests/compile/correctness_e2e/test_sequence_parallel.py
@@ -97,17 +97,16 @@ class SPTestSettings:
         parallel_setups = []
         for eager_mode_val in [False, True]:
             for pp_multiplier in [1, 2]:
-                for chunked_prefill_val in [False, True]:
-                    parallel_setups.append(
-                        ParallelSetup(
-                            tp_size=tp_base,
-                            pp_size=pp_multiplier * pp_base,
-                            fuse_norm_quant=False,
-                            fuse_act_quant=False,
-                            eager_mode=eager_mode_val,
-                            chunked_prefill=chunked_prefill_val,
-                        )
+                parallel_setups.append(
+                    ParallelSetup(
+                        tp_size=tp_base,
+                        pp_size=pp_multiplier * pp_base,
+                        fuse_norm_quant=False,
+                        fuse_act_quant=False,
+                        eager_mode=eager_mode_val,
+                        chunked_prefill=True,
                     )
+                )
         return SPTestSettings(
             parallel_setups=parallel_setups,
             distributed_backends=["mp", "ray"],


### PR DESCRIPTION
## Purpose

Reduce the runtime of the sequence-parallel correctness suite by pruning a redundant test dimension.

The last successful run took approximately 73.5 minutes. The 32-case tiny-Llama matrix accounted for roughly 63 minutes, while the prompt-embedding cases took about 10 minutes.

`SPTestSettings.fast()` previously crossed `chunked_prefill=False` and `True`. However, `False` only omitted the CLI flag; automatic configuration still enabled chunked prefill for this model. Both cases therefore exercised the same
effective configuration.

This change tests chunked prefill explicitly once while retaining:

- Pipeline parallelism with PP=1 and PP=2.
- CUDAGraph enabled and disabled.
- MP and Ray distributed backends.
- Inductor graph partitioning enabled and disabled.

The tiny-Llama matrix is reduced from 32 to 16 cases, and the complete suite from 45 to 29 cases, without adding GPU concurrency. FP8, prompt-embedding, NVFP4, and `SPTestSettings.detailed()` coverage remain unchanged.

## Test Plan

```bash
.venv/bin/python -m pytest --collect-only -q \
  tests/compile/correctness_e2e/test_sequence_parallel.py

.venv/bin/pre-commit run --files \
  tests/compile/correctness_e2e/test_sequence_parallel.py
```

## Test Results

```bash
Total collection: 29 tests, reduced from 45.
Tiny-Llama: 16 tests, reduced from 32.
FP8: 8 tests.
Prompt embeddings: 4 tests.
NVFP4: 1 test.
```