### PR TITLE
[Perf][Hybrid] Skip redundant num_accepted_tokens H2D copy after preprocess_mamba

### DIFF
--- a/tests/v1/worker/test_mamba_utils.py
+++ b/tests/v1/worker/test_mamba_utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from collections.abc import Callable
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -150,6 +151,168 @@ def test_resumed_req_ids_cleared_from_mamba_state_idx():
         )
 
     assert mamba_state_idx == {"keep": 99}
+
+
+def _preprocess_reset_case(mamba_state_idx_map: dict[str, int]):
+    """Two requests, block_size=4, num_speculative_blocks=0.
+
+    ``no_cross`` decodes within its current block; ``cross`` advances past a
+    block boundary. Caller controls which of the two is registered in
+    ``mamba_state_idx`` -- an entry means "prior state exists", so its
+    absence forces the ``prev_state_idx == -1`` (fresh) branch.
+    """
+    req_ids = ["no_cross", "cross"]
+    scheduler_output = SimpleNamespace(
+        finished_req_ids=set(),
+        preempted_req_ids=set(),
+        scheduled_cached_reqs=SimpleNamespace(resumed_req_ids=set()),
+        num_scheduled_tokens={"no_cross": 1, "cross": 2},
+    )
+    input_batch = SimpleNamespace(
+        req_ids=req_ids,
+        num_accepted_tokens_cpu=np.array([3, 3], dtype=np.int32),
+    )
+    requests = {
+        # no_cross: num_computed=1, scheduled=1 => curr_state_idx = 0
+        "no_cross": SimpleNamespace(req_id="no_cross", num_computed_tokens=1),
+        # cross: num_computed=3, scheduled=2 => curr_state_idx = 1
+        "cross": SimpleNamespace(req_id="cross", num_computed_tokens=3),
+    }
+    return scheduler_output, input_batch, requests, dict(mamba_state_idx_map)
+
+
+def test_preprocess_mamba_returns_false_when_no_boundary_crossed(monkeypatch):
+    """No request crosses a block boundary => no reset, no follow-up H2D."""
+    from vllm.v1.worker import mamba_utils as worker_mamba_utils
+
+    monkeypatch.setattr(
+        worker_mamba_utils, "collect_mamba_copy_meta", lambda *a, **kw: None
+    )
+    monkeypatch.setattr(
+        worker_mamba_utils, "do_mamba_copy_block", lambda copy_bufs: None
+    )
+
+    mamba_spec = SimpleNamespace(block_size=4, num_speculative_blocks=0)
+    cache_config: Any = SimpleNamespace(enable_prefix_caching=True)
+    copy_bufs: Any = SimpleNamespace(
+        mamba_group_ids=[0], mamba_spec=mamba_spec, offset=0
+    )
+    # Both requests: prev == curr => no reset.
+    sched, batch, requests, state_idx = _preprocess_reset_case(
+        {"no_cross": 0, "cross": 1}
+    )
+    original_accepted = batch.num_accepted_tokens_cpu.copy()
+
+    any_reset = preprocess_mamba(
+        sched,
+        SimpleNamespace(),  # kv_cache_config
+        cache_config,
+        state_idx,
+        batch,
+        requests,
+        {},  # forward_context
+        (),  # mamba_state_copy_funcs
+        copy_bufs,
+    )
+
+    assert any_reset is False
+    np.testing.assert_array_equal(batch.num_accepted_tokens_cpu, original_accepted)
+
+
+def test_preprocess_mamba_returns_true_when_boundary_crossed(monkeypatch):
+    """A single boundary crossing must trip the reset flag and reset only
+    the affected request's ``num_accepted_tokens_cpu`` entry to 1."""
+    from vllm.v1.worker import mamba_utils as worker_mamba_utils
+
+    monkeypatch.setattr(
+        worker_mamba_utils, "collect_mamba_copy_meta", lambda *a, **kw: None
+    )
+    monkeypatch.setattr(
+        worker_mamba_utils, "do_mamba_copy_block", lambda copy_bufs: None
+    )
+
+    mamba_spec = SimpleNamespace(block_size=4, num_speculative_blocks=0)
+    cache_config: Any = SimpleNamespace(enable_prefix_caching=True)
+    copy_bufs: Any = SimpleNamespace(
+        mamba_group_ids=[0], mamba_spec=mamba_spec, offset=0
+    )
+    # cross: prev=0, curr=1 -> reset. no_cross: prev=0, curr=0 -> no reset.
+    sched, batch, requests, state_idx = _preprocess_reset_case(
+        {"no_cross": 0, "cross": 0}
+    )
+
+    any_reset = preprocess_mamba(
+        sched,
+        SimpleNamespace(),  # kv_cache_config
+        cache_config,
+        state_idx,
+        batch,
+        requests,
+        {},  # forward_context
+        (),  # mamba_state_copy_funcs
+        copy_bufs,
+    )
+
+    assert any_reset is True
+    # Only the crossing request gets reset to 1; the other is untouched.
+    np.testing.assert_array_equal(
+        batch.num_accepted_tokens_cpu, np.array([3, 1], dtype=np.int32)
+    )
+
+
+def test_preprocess_mamba_fresh_request_does_not_trigger_reset(monkeypatch):
+    """A fresh request (``num_computed_tokens == 0``) yields
+    ``prev_state_idx == -1`` and must skip the reset branch even when
+    ``curr_state_idx != -1``.
+    """
+    from vllm.v1.worker import mamba_utils as worker_mamba_utils
+
+    monkeypatch.setattr(
+        worker_mamba_utils, "collect_mamba_copy_meta", lambda *a, **kw: None
+    )
+    monkeypatch.setattr(
+        worker_mamba_utils, "do_mamba_copy_block", lambda copy_bufs: None
+    )
+
+    mamba_spec = SimpleNamespace(block_size=4, num_speculative_blocks=0)
+    cache_config: Any = SimpleNamespace(enable_prefix_caching=True)
+    copy_bufs: Any = SimpleNamespace(
+        mamba_group_ids=[0], mamba_spec=mamba_spec, offset=0
+    )
+    # num_computed=0, scheduled=1 -> curr_state_idx=0, prev derived as -1.
+    scheduler_output = SimpleNamespace(
+        finished_req_ids=set(),
+        preempted_req_ids=set(),
+        scheduled_cached_reqs=SimpleNamespace(resumed_req_ids=set()),
+        num_scheduled_tokens={"fresh": 1},
+    )
+    input_batch = SimpleNamespace(
+        req_ids=["fresh"],
+        num_accepted_tokens_cpu=np.array([2], dtype=np.int32),
+    )
+    requests = {
+        "fresh": SimpleNamespace(req_id="fresh", num_computed_tokens=0),
+    }
+    mamba_state_idx: dict[str, int] = {}  # no entry -> derived prev = -1
+
+    any_reset = preprocess_mamba(
+        scheduler_output,
+        SimpleNamespace(),  # kv_cache_config
+        cache_config,
+        mamba_state_idx,
+        input_batch,
+        requests,
+        {},  # forward_context
+        (),  # mamba_state_copy_funcs
+        copy_bufs,
+    )
+
+    assert any_reset is False
+    np.testing.assert_array_equal(
+        input_batch.num_accepted_tokens_cpu, np.array([2], dtype=np.int32)
+    )
+    # The fresh request now has its slot registered for next step.
+    assert mamba_state_idx == {"fresh": 0}
 
 
 # -----------------------------------------------------------------------------

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4321,7 +4321,7 @@ class GPUModelRunner(
                     deferred_state_corrections_fn()
                     deferred_state_corrections_fn = None
                 mamba_bufs = self._get_mamba_bufs()
-                mamba_utils.preprocess_mamba(
+                any_accepted_reset = mamba_utils.preprocess_mamba(
                     scheduler_output,
                     self.kv_cache_config,
                     self.cache_config,
@@ -4336,11 +4336,13 @@ class GPUModelRunner(
                 # preprocess_mamba resets num_accepted_tokens_cpu to 1
                 # for requests whose state was copied to a new block.
                 # Re-sync to GPU so the mamba kernel reads from the
-                # correct initial state slot (init_token_idx = 0).
-                self.num_accepted_tokens.np[:num_reqs] = (
-                    self.input_batch.num_accepted_tokens_cpu[:num_reqs]
-                )
-                self.num_accepted_tokens.copy_to_gpu(num_reqs)
+                # correct initial state slot (init_token_idx = 0). Skip
+                # when no request crossed a block boundary this step.
+                if any_accepted_reset:
+                    self.num_accepted_tokens.np[:num_reqs] = (
+                        self.input_batch.num_accepted_tokens_cpu[:num_reqs]
+                    )
+                    self.num_accepted_tokens.copy_to_gpu(num_reqs)
 
                 # Stage per-request inputs for the fused postprocess kernel
                 # only when that kernel will actually run. The kernel is

--- a/vllm/v1/worker/mamba_utils.py
+++ b/vllm/v1/worker/mamba_utils.py
@@ -1046,10 +1046,14 @@ def preprocess_mamba(
     mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...],
     copy_bufs: MambaCopyBuffers,
     align_ctx: MambaSpecDecodeGPUContext | None = None,
-):
+) -> bool:
     """
     Copy the mamba state of previous step to the last
     (1 + num_speculative_blocks) block.
+
+    Returns True if any request had its ``num_accepted_tokens_cpu`` reset to 1
+    (i.e. crossed a block boundary), so the caller can gate the follow-up
+    H2D sync of ``num_accepted_tokens``.
     """
     fused = _resolve_fused_precopy(align_ctx)
     mamba_group_ids = copy_bufs.mamba_group_ids
@@ -1065,7 +1069,7 @@ def preprocess_mamba(
 
     if fused is not None:
         if num_reqs == 0:
-            return
+            return False
         if not fused.ctx.is_initialized:
             fused.ctx.initialize_from_forward_context(
                 kv_cache_config,
@@ -1080,6 +1084,7 @@ def preprocess_mamba(
         fused.src_col.np[:num_reqs] = -1
         fused.token_bias.np[:num_reqs] = 0
 
+    any_reset = False
     for i, req_id in enumerate(input_batch.req_ids):
         req_state = requests[req_id]
         prev_state_idx = mamba_state_idx.get(req_id)
@@ -1126,6 +1131,7 @@ def preprocess_mamba(
                     forward_context,
                 )
             input_batch.num_accepted_tokens_cpu[i] = 1
+            any_reset = True
 
     if fused is not None:
         fused.state_idx.copy_to_gpu(num_reqs)
@@ -1140,6 +1146,8 @@ def preprocess_mamba(
         )
     else:
         do_mamba_copy_block(copy_bufs)
+
+    return any_reset
 
 
 def postprocess_mamba_all(


### PR DESCRIPTION


## Purpose

When prefix cache is enabled in align mode (with and without spec decoding enabled),  `preprocess_mamba` unconditionally triggers a follow-up H2D sync of `num_accepted_tokens` in `gpu_model_runner` (MRv1), even when the CPU-side array was not mutated. The copy is only required when at least one request had its `num_accepted_tokens_cpu` reset to 1 (i.e. crossed a mamba block boundary).

This PR returns a `bool` from `preprocess_mamba` indicating whether any request had its `num_accepted_tokens_cpu` reset to 1, and gates the follow-up `np[:]` slice-copy and `copy_to_gpu` on that flag. Since block-boundary crossings are rare (roughly once every `block_size` steps per request, with `block_size` in the order of _hundreds_ to _thousands_), so most of decode steps skip the H2D entirely.

why the copy is fully redundant when no reset happened:

Immediately before `preprocess_mamba` runs, `num_accepted_tokens.gpu` is already in sync with `input_batch.num_accepted_tokens_cpu` — the earlier update in `_prepare_inputs` does exactly that copy. `preprocess_mamba` only mutates the CPU-side array, and only at the specific indices where `prev_state_idx != -1 and prev_state_idx != curr_state_idx`. When no request crossed a boundary this step, `num_accepted_tokens.gpu` is still correct and the re-sync is just dead work.




### Changes

- `vllm/v1/worker/mamba_utils.py`: `preprocess_mamba` now returns `bool`
  (`True` iff at least one request was reset). No change to copy
  semantics or callback logic. Both early-return paths return `False`.
- `vllm/v1/worker/gpu_model_runner.py`: capture the return value and
  gate the `num_accepted_tokens` re-sync on it.
- `tests/v1/worker/test_mamba_utils.py`: three unit tests covering the
  distinct paths through the reset guard (steady-state, boundary
  crossed, fresh request with `prev_state_idx == -1`).

## Test Plan

- Unit tests:

```
.venv/bin/python -m pytest tests/v1/worker/test_mamba_utils.py -v
.venv/bin/python -m pytest tests/kernels/mamba/test_precopy_mamba_align.py -v
```

- Latency tests:

```
vllm bench latency    \
    --model Qwen/Qwen3.5-9B \
    --input-len 512 --output-len 2048 \
    --enable-prefix-caching
```

## Test Result

- all the unit tests are passing

- Uniform latency reduction of ~30 ms (≈0.2%) across all percentiles, consistent with removing a per-step host↔device synchronization overhead that accumulates over the 2048-token decode.


| Percentile | `main` (s) | `PR` (s) | Δ (ms) |
|---:|---:|---:|---:|
| avg | 15.506044 | 15.475566 | **−30.48** |
| p10 | 15.497208 | 15.470836 | −26.37 |
| p25 | 15.500323 | 15.471837 | −28.49 |
| p50 | 15.508696 | 15.474882 | −33.81 |
| p75 | 15.511152 | 15.477572 | −33.58 |
| p90 | 15.514488 | 15.479310 | −35.18 |
| p99 | 15.516007 | 15.496005 | −20.00 |

Δ = branch − main. Negative means the branch is faster.

## Duplicate work check

```
gh pr list --repo vllm-project/vllm --state open --search "preprocess_mamba num_accepted_tokens"
gh pr list --repo vllm-project/vllm --state open --search "mamba_cache_mode align preprocess"
```

#46424 — Mamba2 prefill-as-decode assert crash. Unrelated.
#40757 — deadlock in _mamba_block_aligned_split. Unrelated.
#39463 — GDN ngram spec decode output corruption. Unrelated.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
