### PR TITLE
[Bugfix][Kimi-K3] Check op existence for FlashKDA dispatch

### DIFF
--- a/tests/models/kimi_k3/test_kda.py
+++ b/tests/models/kimi_k3/test_kda.py
@@ -6,6 +6,8 @@ Compares chunk_kda against a naive recurrent reference (float32).
 Uses torch.rand for q/k/v to match FLA's test pattern.
 """
 
+import sys
+
 import pytest
 import torch
 import torch.nn.functional as F
@@ -682,6 +684,15 @@ def test_fused_kda_decode_rejects_speculative_conv_state():
         input_dtype=torch.bfloat16,
         conv_state_dtype=torch.bfloat16,
     )
+
+
+def test_is_flashkda_supported_rejects_missing_extension(monkeypatch):
+    capability = torch.cuda.get_device_capability()
+    if capability[0] not in (9, 10, 12):
+        pytest.skip("Requires a FlashKDA-capable CUDA device")
+
+    monkeypatch.setitem(sys.modules, "vllm._flashkda_C", None)
+    assert not is_flashkda_supported(128, torch.bfloat16, -3.0)
 
 
 @torch.inference_mode()

--- a/vllm/models/kimi_k3/nvidia/kda.py
+++ b/vllm/models/kimi_k3/nvidia/kda.py
@@ -167,13 +167,19 @@ def is_flashkda_supported(
     if not current_platform.is_cuda():
         return False
     capability = current_platform.get_device_capability()
-    return (
+    if not (
         capability is not None
         and capability.major in (9, 10, 12)
         and head_dim == 128
         and dtype == torch.bfloat16
         and lower_bound is not None
-    )
+    ):
+        return False
+    try:
+        import vllm._flashkda_C  # noqa: F401
+    except ImportError:
+        return False
+    return hasattr(torch.ops._flashkda_C, "fwd")
 
 
 def _flashkda_prefill(


### PR DESCRIPTION
## Summary

`is_flashkda_supported()` in `vllm/models/kimi_k3/nvidia/kda.py` never checked that the optional `_flashkda_C` extension is loaded, so a build without it hits an `AttributeError` deep in `_flashkda_prefill` instead of falling back to Triton. Adds the same `hasattr` guard already used by `is_fused_kda_decode_supported()` in the same file (same pattern as #50567).

No duplicate work found for `flashkda_C` (checked #50909, #50001).

## Test plan

Run on RTX 5090 (SM120), includes new `test_is_flashkda_supported_rejects_missing_extension`:
```bash
.venv/bin/python -m pytest tests/models/kimi_k3/test_kda.py -v
## 40 passed, 30 warnings in 297.09s (0:04:57)
```