### PR TITLE
[Bugfix] Initialize per-token-head KV scale regions once per storage

### DIFF
--- a/tests/v1/attention/test_triton_attn_scale_init.py
+++ b/tests/v1/attention/test_triton_attn_scale_init.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Inline per-token-head KV scale regions must be initialized exactly once
+per storage.
+
+KV-sharing layers alias their target layer's cache tensor and build their
+scale views lazily on first forward, which can happen after the target layer
+has already written real per-token scales in the same pass; re-initializing
+on view creation wipes those scales and corrupts the first batch
+(#50702, #50749).
+"""
+
+import pytest
+import torch
+
+from vllm.v1.attention.backends.triton_attn import TritonAttentionImpl
+
+
+def _make_impl() -> TritonAttentionImpl:
+    impl = object.__new__(TritonAttentionImpl)
+    impl._k_scale_cache = None
+    impl._v_scale_cache = None
+    return impl
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    saved = TritonAttentionImpl._scale_initialized_storages.copy()
+    TritonAttentionImpl._scale_initialized_storages.clear()
+    yield
+    TritonAttentionImpl._scale_initialized_storages.clear()
+    TritonAttentionImpl._scale_initialized_storages.update(saved)
+
+
+def _kv_cache(num_blocks=4, nkv=1, block_size=16, head_size=256):
+    padded = head_size + 4
+    return torch.zeros(num_blocks, nkv, block_size, 2 * padded, dtype=torch.int8)
+
+
+def test_first_impl_initializes_scales_to_one():
+    impl = _make_impl()
+    impl._ensure_scale_caches(_kv_cache())
+    assert torch.all(impl._k_scale_cache == 1.0)
+    assert torch.all(impl._v_scale_cache == 1.0)
+
+
+def test_aliasing_impl_preserves_written_scales():
+    kv = _kv_cache()
+    writer = _make_impl()
+    writer._ensure_scale_caches(kv)
+    writer._k_scale_cache[1, 2, 0] = 0.123
+    writer._v_scale_cache[3, 5, 0] = 0.456
+
+    alias = _make_impl()
+    alias._ensure_scale_caches(kv)
+    assert alias._k_scale_cache[1, 2, 0].item() == pytest.approx(0.123)
+    assert alias._v_scale_cache[3, 5, 0].item() == pytest.approx(0.456)
+
+
+def test_new_storage_is_initialized():
+    first = _make_impl()
+    kv1 = _kv_cache()
+    first._ensure_scale_caches(kv1)
+
+    second = _make_impl()
+    kv2 = _kv_cache()
+    second._ensure_scale_caches(kv2)
+    assert torch.all(second._k_scale_cache == 1.0)
+    assert torch.all(second._v_scale_cache == 1.0)
+    del kv1, first

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -417,6 +417,11 @@ class TritonAttentionImpl(AttentionImpl):
     # Per-token-head quant: scale views carved from inline head padding.
     _k_scale_cache: torch.Tensor | None = None
     _v_scale_cache: torch.Tensor | None = None
+    # Storages whose inline scale regions have been initialized; keyed by
+    # (data_ptr, nbytes) so re-allocated caches (e.g. after sleep/wake_up)
+    # are re-initialized. Shared across impls because KV-sharing layers alias
+    # their target layer's storage.
+    _scale_initialized_storages: ClassVar[set[tuple[int, int]]] = set()
 
     def _ensure_scale_caches(self, kv_cache: torch.Tensor) -> None:
         """Extract per-head scale views from the padded content dimension.
@@ -470,7 +475,6 @@ class TritonAttentionImpl(AttentionImpl):
             stride=(block_f32, slot_f32, head_f32),
             storage_offset=k_scale_off_f32,
         )
-        self._k_scale_cache.fill_(1.0)
 
         # V scales (second content half)
         self._v_scale_cache = torch.as_strided(
@@ -479,7 +483,19 @@ class TritonAttentionImpl(AttentionImpl):
             stride=(block_f32, slot_f32, head_f32),
             storage_offset=v_scale_off_f32,
         )
-        self._v_scale_cache.fill_(1.0)
+
+        # Initialize the scale regions exactly once per underlying storage.
+        # KV-sharing layers alias their target layer's cache tensor and build
+        # their own views lazily on their first forward, which can happen
+        # AFTER the target layer has already written real per-token scales in
+        # the same pass; an unconditional fill here would wipe those scales
+        # and corrupt every request in the first batch (issues #50702/#50749).
+        storage = kv_cache.untyped_storage()
+        storage_key = (storage.data_ptr(), storage.nbytes())
+        if storage_key not in TritonAttentionImpl._scale_initialized_storages:
+            self._k_scale_cache.fill_(1.0)
+            self._v_scale_cache.fill_(1.0)
+            TritonAttentionImpl._scale_initialized_storages.add(storage_key)
 
     def fused_output_quant_supported(self, quant_key: QuantKey):
         return quant_key == kFp8StaticTensorSym


### PR DESCRIPTION
## Purpose

With `int8_per_token_head`/`fp8_per_token_head` KV cache on KV-sharing models (Gemma-4 family), **the first scheduled batch after engine start emits corrupted leading tokens**. Likely the root cause behind #50702 and #50749.

`TritonAttentionImpl._ensure_scale_caches` builds its inline-scale views lazily per impl and unconditionally `fill_(1.0)`s the storage's scale regions on first touch. KV-sharing layers alias their target layer's cache tensor; when warmup didn't exercise them, their first touch happens **mid-way through the first real forward pass — after the target layers already wrote real per-token scales for the prompt**. The fill wipes the scales (int8 codes stay intact), so prompt K/V dequantize against 1.0 instead of ~0.005: K inflated ~200×, first decode steps of every request in the first batch corrupted. Later batches are clean (views exist), which made the bug look stochastic under multiprocess serving and spuriously dependent on batch geometry / prefix caching / prompt-length residue — matching the confusing conditionals reported in both issues.

Fix: initialize each storage's scale regions exactly once (class-level registry keyed by `(data_ptr, nbytes)`, so caches re-allocated by sleep/wake_up are re-initialized).

## Evidence

Deterministic single-GPU repro: `google/gemma-4-E2B-it`, TRITON_ATTN, MRV1, in-process engine, 48 arithmetic-continuation prompts × 4 copies, greedy — output objectively checkable against the true sequence.

- Pre-fix: **exactly the first `max_num_seqs` requests damaged, every run** (mns=4 → requests 0–3, mns=6 → 0–5, mns=8 → 0–7); int8-only (bf16 clean).
- Instrumented `_ensure_scale_caches`: 33 fills wipe nothing (pre-write), **2 late fills wipe 22,384 / 13,394 written non-default scales** on an aliased storage mid-first-batch.
- Scale forensics: first-batch vs second-batch KV for identical prompts — int8 codes byte-identical, K scales differ ×~221, V ×~24 = exactly `1.0 / true_scale`.
- Post-fix: **zero damaged requests** across prefix-caching on/off, residues 4/12, mns 4/6/8, in-process and multiprocess modes; first-vs-later-batch KV bytes become identical; bf16 unchanged.

## Test Plan

```
pytest tests/v1/attention/test_triton_attn_scale_init.py   # 3 passed (new; red on main)
pre-commit: ruff-check, ruff-format, mypy-3.12             # passed
```

Repro harness (~100 s/run on one RTX 4090) available on request; happy to contribute it as an integration test if desired.

## Notes

- Not a duplicate: no open PR touches `_ensure_scale_caches` or this failure (searched 2026-08-04); #48842 fixes an unrelated int4 startup crash.
- The reporters of #50702/#50749 run v0.26.0 (which has this code path) on 31B/TP=2 — their confirmation on this patch would establish whether it fully explains their production rates.
- AI assistance was used (Claude Code); every changed line was human-reviewed and all tests/experiments above were run locally.


