### PR TITLE
Fix Kimi-K3 MLA context-parallel state

### DIFF
--- a/tests/models/test_kimi_k3_nvidia_mla.py
+++ b/tests/models/test_kimi_k3_nvidia_mla.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+from vllm.models.kimi_k3.nvidia.mla import _configure_no_context_parallelism
+
+
+def test_configure_no_context_parallelism_uses_single_rank_state():
+    impl = SimpleNamespace(
+        dcp_world_size=-1,
+        dcp_rank=-1,
+        pcp_world_size=0,
+        pcp_rank=-1,
+        total_cp_world_size=0,
+        total_cp_rank=-1,
+        need_to_return_lse_for_decode=True,
+    )
+
+    _configure_no_context_parallelism(impl)
+
+    assert impl.dcp_world_size == 1
+    assert impl.dcp_rank == 0
+    assert impl.pcp_world_size == 1
+    assert impl.pcp_rank == 0
+    assert impl.total_cp_world_size == 1
+    assert impl.total_cp_rank == 0
+    assert not impl.need_to_return_lse_for_decode

--- a/vllm/models/kimi_k3/nvidia/mla.py
+++ b/vllm/models/kimi_k3/nvidia/mla.py
@@ -87,6 +87,18 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
+
+def _configure_no_context_parallelism(impl: MLAAttentionImpl) -> None:
+    """Set the canonical backend state for Kimi-K3's no-CP contract."""
+    impl.dcp_world_size = 1
+    impl.dcp_rank = 0
+    impl.pcp_world_size = 1
+    impl.pcp_rank = 0
+    impl.total_cp_world_size = 1
+    impl.total_cp_rank = 0
+    impl.need_to_return_lse_for_decode = False
+
+
 # Below this many tokens, overlap the g_proj GEMM on the aux stream with the
 # attention front-end (the GEMM is small and launch-bound, so the overlap
 # hides it); at or above it, run the gate on the main stream.
@@ -309,6 +321,11 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
             parallel_config.decode_context_parallel_size <= 1
             and parallel_config.prefill_context_parallel_size <= 1
         ), "Kimi-K3 MultiHeadLatentAttention does not support context parallelism."
+        # This layer constructs the backend directly instead of going through
+        # MLAAttention.forward_impl, which normally resolves the backend's lazy
+        # DCP sentinel. Canonicalize the explicitly unsupported CP state before
+        # the backend can forward it to FlashAttention.
+        _configure_no_context_parallelism(self.impl)
         self.prefill_backend = get_mla_prefill_backend(vllm_config)(
             num_heads=self.num_local_heads,
             scale=self.scale,


### PR DESCRIPTION
## Purpose

Kimi-K3 constructs its MLA backend directly and does not call `MLAAttention.forward_impl`, so the backend lazy DCP sentinel can reach FlashAttention. Since the Kimi-K3 NVIDIA MLA layer explicitly does not support DCP or PCP, canonicalize its backend state to the single-rank no-CP values during construction.

This keeps the shared MLA lazy-initialization contract unchanged and adds a focused regression test for all CP-related backend fields.

## Test Plan

- Run the focused CPU regression test in the vLLM runtime container.
- Run the repository-pinned Ruff check and format hooks.
- Initialize a Kimi-K3 V1 engine from a 12-layer, 56-expert dummy model on one H100 and request exactly one token through FLASH_ATTN_MLA.

## Test Result

- Focused regression test: 1 passed in 61.35 seconds.
- Repository-pinned Ruff 0.14.0 check: passed.
- Repository-pinned Ruff 0.14.0 format: passed.
- End-to-end engine run: completed successfully in 266 seconds and returned exactly one token (`token_id=29401`, `finish_reason=length`).

---

- [x] The purpose of the PR is described above.
- [x] The test plan is provided above.
- [x] The test results are provided above.
- [x] No documentation update is needed for this correctness fix.