### PR TITLE
[Bugfix] Restore default torch dtype on exception in set_default_torch_dtype

### DIFF
--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -147,8 +147,10 @@ def set_default_torch_dtype(dtype: torch.dtype):
     """Sets the default torch dtype to the given dtype."""
     old_dtype = torch.get_default_dtype()
     torch.set_default_dtype(dtype)
-    yield
-    torch.set_default_dtype(old_dtype)
+    try:
+        yield
+    finally:
+        torch.set_default_dtype(old_dtype)
 
 
 def _cgroup_cpu_limit() -> float | None:


### PR DESCRIPTION
## Purpose

`set_default_torch_dtype` in `vllm/utils/torch_utils.py` does not use `try`/`finally`, so if the body raises, the process-wide default torch dtype is never restored:

```python
@contextlib.contextmanager
def set_default_torch_dtype(dtype: torch.dtype):
    old_dtype = torch.get_default_dtype()
    torch.set_default_dtype(dtype)
    yield
    torch.set_default_dtype(old_dtype)
```

Failure mode: with an in-process engine (`VLLM_ENABLE_V1_MULTIPROCESSING=0`), an exception during model load (e.g. an OOM or a weight-loading error inside `with set_default_torch_dtype(model_dtype):`) leaves the process default dtype at the model dtype (e.g. `torch.bfloat16`). Any later fp32 work in the same process — subsequent tests in a pytest worker, retry logic, other libraries — then silently runs in bf16. We hit this in a downstream test suite where one failed vLLM load poisoned every later fp32 test in the worker.

Fix: wrap the `yield` in `try`/`finally` so the old dtype is always restored, matching the standard pattern for state-restoring context managers.

## Test Plan

```python
import pytest, torch
from vllm.utils.torch_utils import set_default_torch_dtype

assert torch.get_default_dtype() == torch.float32
with pytest.raises(RuntimeError):
    with set_default_torch_dtype(torch.bfloat16):
        raise RuntimeError("simulated load failure")
assert torch.get_default_dtype() == torch.float32  # fails before this PR: bfloat16
```

## Test Result

Before: the final assertion fails — default dtype is left at `torch.bfloat16`.
After: passes — default dtype restored to `torch.float32`.