### PR TITLE
[Bugfix][Spec Decode] Fix EAGLE3 DeepSeek draft crash on non-YaRN rope configs

### DIFF
--- a/vllm/model_executor/models/deepseek_eagle3.py
+++ b/vllm/model_executor/models/deepseek_eagle3.py
@@ -3,7 +3,6 @@
 
 """Eagle3 speculative decoding model for DeepseekV2/V3 with MLP (no MoE)."""
 
-import copy
 from collections.abc import Iterable
 
 import torch
@@ -58,7 +57,6 @@ class DeepseekV2Eagle3DecoderLayer(nn.Module):
         quant_config = get_draft_quant_config(vllm_config)
 
         self.hidden_size = config.hidden_size
-        rope_scaling = getattr(config, "rope_scaling", None)
         max_position_embeddings = getattr(config, "max_position_embeddings", 8192)
 
         self.layer_idx = layer_idx
@@ -68,13 +66,6 @@ class DeepseekV2Eagle3DecoderLayer(nn.Module):
         qk_rope_head_dim = getattr(config, "qk_rope_head_dim", 0)
         v_head_dim = getattr(config, "v_head_dim", 0)
         kv_lora_rank = getattr(config, "kv_lora_rank", 0)
-        config = copy.copy(config)
-        if rope_scaling:
-            rope_params = rope_scaling.copy()
-            rope_params["rope_type"] = "deepseek_yarn"
-        else:
-            rope_params = {"rope_type": "default"}
-        config.rope_parameters = rope_params
         self.self_attn = DeepseekV2MLAAttention(
             vllm_config=vllm_config,
             config=config,


### PR DESCRIPTION
## Purpose

`DeepseekV2Eagle3DecoderLayer.__init__` rebuilds `config.rope_parameters` from
`config.rope_scaling` before handing the config to `DeepseekV2MLAAttention`:

```python
rope_scaling = getattr(config, "rope_scaling", None)
...
config = copy.copy(config)
if rope_scaling:
    rope_params = rope_scaling.copy()
    rope_params["rope_type"] = "deepseek_yarn"
else:
    rope_params = {"rope_type": "default"}
config.rope_parameters = rope_params
```

`DeepseekV2MLAAttention` already performs exactly this normalization itself
([`deepseek_v2.py`](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/deepseek_v2.py#L1068-L1073)),
so for a YaRN draft the block is a no-op. But it is not harmless:

**1. It crashes plain-RoPE EAGLE3 drafts.** Under Transformers v5 `config.rope_scaling`
is a deprecated alias that returns the *same dict object* as `config.rope_parameters`,
and vLLM always populates `rope_parameters` (`set_default_rope_theta` /
`patch_rope_parameters`). So `if rope_scaling:` is **always** truthy — including for a
draft whose `config.json` has no `rope_scaling` at all, where vLLM produced
`{"rope_theta": ..., "rope_type": "default"}`. The block then force-rewrites `rope_type`
to `"deepseek_yarn"`, and model load dies in `get_rope`:

```
KeyError: 'factor'
```

**2. It ignores `apply_yarn_scaling`.** The hardcoded `"deepseek_yarn"` bypasses
`DeepseekV2MLAAttention`'s `deepseek_yarn` vs `deepseek_llama_scaling` selection.

**3. The `else` branch is dead.** It is only reachable when `rope_parameters` is empty,
in which case `DeepseekV2MLAAttention`'s own `config.rope_parameters["rope_type"]`
lookup would raise first.

Dropping the `copy.copy(config)` alongside it is safe: `DeepseekV2MLAAttention`'s
rewrite is idempotent (`"deepseek_yarn" != "default"` → `"deepseek_yarn"`), which is
exactly how the non-draft `DeepseekV2DecoderLayer` already shares one config object
across all layers.

## Test Plan

**1. Unit-level before/after** on the two config shapes that reach this code — a real
YaRN EAGLE3 draft ([`lightseekorg/kimi-k2.6-eagle3.1-mla`](https://huggingface.co/lightseekorg/kimi-k2.6-eagle3.1-mla))
and the same config with `rope_scaling` removed — running the deleted block followed by
`DeepseekV2MLAAttention`'s own rope normalization and `get_rope`.

**2. E2E acceptance rate**, to confirm the YaRN path is unchanged in a real serving run:

```
vllm serve nvidia/Kimi-K2.6-NVFP4 \
  --tensor-parallel-size 4 --trust-remote-code --language-model-only \
  --speculative-config '{"method": "eagle3", "model": "lightseekorg/kimi-k2.6-eagle3.1-mla", "num_speculative_tokens": 3}'

vllm bench serve --backend openai-chat --dataset-name hf \
  --dataset-path philschmid/mt-bench --hf-output-len 1024 --num-prompts 80
```

## Test Result

**1. Unit-level** — YaRN identical, plain-RoPE fixed:

```
=== draft WITH rope_scaling (yarn) ===
  before (with override): OK   DeepseekScalingRotaryEmbedding base=50000.0 rope_type=deepseek_yarn
  after  (this PR):       OK   DeepseekScalingRotaryEmbedding base=50000.0 rope_type=deepseek_yarn
=== draft WITHOUT rope_scaling (plain rope) ===
  before (with override): KeyError: 'factor'
  after  (this PR):       OK   RotaryEmbedding base=50000.0 rope_type=default
```

**2. E2E MT-Bench acceptance** — `nvidia/Kimi-K2.6-NVFP4` (TP4, 1x GB300 node, 4x B300)
+ `lightseekorg/kimi-k2.6-eagle3.1-mla`, 80/80 requests completed, `num_speculative_tokens=3`:

| metric | value |
| --- | --- |
| acceptance rate | **51.55 %** |
| acceptance length | **2.547** |
| per-position acceptance | 0.711 / 0.489 / 0.347 |
| accepted / drafted tokens | 41,642 / 80,772 over 26,924 drafts |
| output throughput | 1,305 tok/s |

The draft loads, spec decoding engages, and acceptance sits where an EAGLE3 MLA draft
should for this target -- no regression on the YaRN path this PR leaves untouched.
