### PR TITLE
[Bugfix] Preserve non-logitproc entry points in tests

### DIFF
--- a/tests/v1/logits_processors/test_custom_offline.py
+++ b/tests/v1/logits_processors/test_custom_offline.py
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import importlib.metadata
 from typing import Any
 
 import pytest
 
+import tests.v1.logits_processors.utils as logitproc_test_utils
 from tests.utils import create_new_process_for_each_test, set_random_seed
 from tests.v1.logits_processors.utils import (
     DUMMY_LOGITPROC_ARG,
@@ -40,6 +42,32 @@ sampling_params_list = [
     ),
     SamplingParams(temperature=TEMP_GREEDY, max_tokens=MAX_TOKENS),
 ]
+
+
+def test_fake_entrypoint_preserves_other_groups(monkeypatch):
+    other_group_entrypoints = object()
+    monkeypatch.setattr(
+        importlib.metadata,
+        "entry_points",
+        lambda **kwargs: other_group_entrypoints,
+    )
+    monkeypatch.setattr(
+        logitproc_test_utils, "requires_spawn_multiprocessing", lambda: False
+    )
+
+    setup_fake_entrypoint(monkeypatch)
+
+    logitproc_entrypoints = importlib.metadata.entry_points(
+        group=logitproc_test_utils.LOGITSPROCS_GROUP
+    )
+    assert logitproc_entrypoints.names == [
+        logitproc_test_utils.DUMMY_LOGITPROC_ENTRYPOINT
+    ]
+    assert (
+        importlib.metadata.entry_points(group="another.entrypoint.group")
+        is other_group_entrypoints
+    )
+    assert importlib.metadata.entry_points() is other_group_entrypoints
 
 
 def _run_test(kwargs: dict, logitproc_loaded: bool) -> None:

--- a/tests/v1/logits_processors/utils.py
+++ b/tests/v1/logits_processors/utils.py
@@ -226,11 +226,6 @@ def register_fake_entrypoint(monkeypatch) -> str:
     return str(tmpdir)
 
 
-def fake_entry_points(group: str) -> EntryPoints:
-    """Fake version of importlib.metadata.entry_points."""
-    return EntryPoints(group)
-
-
 def setup_fake_entrypoint(monkeypatch) -> None:
     """Expose the dummy logitproc entrypoint for the current platform."""
     if requires_spawn_multiprocessing():
@@ -239,6 +234,14 @@ def setup_fake_entrypoint(monkeypatch) -> None:
         return
 
     import importlib.metadata
+
+    original_entry_points = importlib.metadata.entry_points
+
+    def fake_entry_points(**kwargs):
+        group = kwargs.get("group")
+        if group == LOGITSPROCS_GROUP:
+            return EntryPoints(group)
+        return original_entry_points(**kwargs)
 
     monkeypatch.setattr(importlib.metadata, "entry_points", fake_entry_points)
     monkeypatch.setenv("VLLM_WORKER_MULTIPROC_METHOD", "fork")


### PR DESCRIPTION
## Purpose

The fork-path logits processor test helper replaces `importlib.metadata.entry_points` process-wide and previously returned an empty result for every group other than `vllm.logits_processors`. PyTorch nightly now registers built-in distributed backends through `torch.distributed.backends`, so forked engine workers could not discover NCCL and failed with `Unknown c10d backend type NCCL`.

Delegate non-logitproc queries, including the no-argument metadata API, to the original implementation while continuing to inject the fake logits processor group. Add a focused regression test that covers both behaviors.

This addresses the vLLM failure reported in https://github.com/pytorch/pytorch/issues/192062.

Duplicate check: searched open vLLM issues and PRs for the PyTorch issue number, the NCCL error, `torch.distributed.backends`, and logits processor entry-point fixes; no matching work was open.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, and testing. The human submitter reviewed the changed lines and test results.

Model evaluation: Not applicable because this only changes test entry-point mocking and does not affect serving or model output.

## Test Plan

- `uv run --no-sync --python .venv/bin/python python -m pytest tests/v1/logits_processors/test_custom_offline.py -k fake_entrypoint_preserves_other_groups -v`
- `CUDA_VISIBLE_DEVICES=2 uv run --no-sync --python .venv/bin/python python -m pytest tests/v1/logits_processors/test_custom_offline.py::test_custom_logitsprocs[CustomLogitprocSource.LOGITPROC_SOURCE_ENTRYPOINT] -v -s`
- `CUDA_VISIBLE_DEVICES=2 uv run --no-sync --python .venv/bin/python python -m pytest tests/v1/logits_processors/test_custom_offline.py -k "test_rejects_custom_logitsprocs and LOGITPROC_SOURCE_ENTRYPOINT" -v`
- `uv run --no-sync --python .venv/bin/python pre-commit run --files tests/v1/logits_processors/utils.py tests/v1/logits_processors/test_custom_offline.py`

## Test Result

All commands passed with `torch 2.14.0.dev20260804+cu130`. The nightly end-to-end entry-point test passed both fresh NCCL engine initializations and generation; the two rejection-path variants also passed.