### PR TITLE
Revert "[Mamba] enable prefix cache by default" (#50991)

### DIFF
--- a/tests/models/language/generation/test_hybrid.py
+++ b/tests/models/language/generation/test_hybrid.py
@@ -42,6 +42,11 @@ HYBRID_MODELS = [
     "tiny-random/qwen3-next-moe",
 ]
 
+HYBRID_MODELS_REQUIRING_CHUNKED_PREFILL = {
+    "LiquidAI/LFM2-1.2B",
+    "tiny-random/qwen3-next-moe",
+}
+
 FULL_CUDA_GRAPH_MODELS = [
     "ai21labs/Jamba-tiny-dev",
     "Zyphra/Zamba2-1.2B-instruct",
@@ -90,11 +95,15 @@ def test_models(
             example_prompts, max_tokens, num_logprobs
         )
 
+    extra_kwargs = {}
+    if model in HYBRID_MODELS_REQUIRING_CHUNKED_PREFILL:
+        extra_kwargs["enable_chunked_prefill"] = True
+
     with vllm_runner(
         model,
         max_num_seqs=MAX_NUM_SEQS,
         attention_backend=ATTN_BACKEND,
-        enable_chunked_prefill=True,
+        **extra_kwargs,
     ) as vllm_model:
         vllm_outputs = vllm_model.generate_greedy_logprobs(
             example_prompts, max_tokens, num_logprobs
@@ -131,9 +140,7 @@ def test_batching(
     _set_conv_state_layout(monkeypatch, conv_state_layout)
 
     for_loop_outputs = []
-    with vllm_runner(
-        model, max_num_seqs=MAX_NUM_SEQS, enable_chunked_prefill=True
-    ) as vllm_model:
+    with vllm_runner(model, max_num_seqs=MAX_NUM_SEQS) as vllm_model:
         for prompt in example_prompts:
             (single_output,) = vllm_model.generate_greedy_logprobs(
                 [prompt], max_tokens, num_logprobs
@@ -217,7 +224,7 @@ def test_mamba_cache_cg_padding(
         example_prompts.append(example_prompts[0])
 
     try:
-        with vllm_runner(model, enable_chunked_prefill=True) as vllm_model:
+        with vllm_runner(model) as vllm_model:
             vllm_model.generate_greedy(example_prompts, max_tokens)
     except RuntimeError:
         pytest.fail(
@@ -243,9 +250,7 @@ def test_fail_upon_inc_requests_and_finished_requests_lt_available_blocks(
     a single step.
     """
     try:
-        with vllm_runner(
-            model, max_num_seqs=MAX_NUM_SEQS, enable_chunked_prefill=True
-        ) as vllm_model:
+        with vllm_runner(model, max_num_seqs=MAX_NUM_SEQS) as vllm_model:
             vllm_model.generate_greedy([example_prompts[0]] * 100, 10)
     except ValueError:
         pytest.fail(
@@ -267,9 +272,7 @@ def test_state_cleanup(
     If it's not cleaned, an error would be expected.
     """
     try:
-        with vllm_runner(
-            model, max_num_seqs=MAX_NUM_SEQS, enable_chunked_prefill=True
-        ) as vllm_model:
+        with vllm_runner(model, max_num_seqs=MAX_NUM_SEQS) as vllm_model:
             for _ in range(10):
                 vllm_model.generate_greedy([example_prompts[0]] * 100, 1)
     except ValueError:
@@ -291,20 +294,14 @@ def test_distributed_correctness(
     num_logprobs: int,
 ) -> None:
     with vllm_runner(
-        model,
-        tensor_parallel_size=1,
-        max_num_seqs=MAX_NUM_SEQS,
-        enable_chunked_prefill=True,
+        model, tensor_parallel_size=1, max_num_seqs=MAX_NUM_SEQS
     ) as vllm_model:
         vllm_outputs_tp_1 = vllm_model.generate_greedy_logprobs(
             example_prompts, max_tokens, num_logprobs
         )
 
     with vllm_runner(
-        model,
-        tensor_parallel_size=2,
-        max_num_seqs=MAX_NUM_SEQS,
-        enable_chunked_prefill=True,
+        model, tensor_parallel_size=2, max_num_seqs=MAX_NUM_SEQS
     ) as vllm_model:
         vllm_outputs_tp_2 = vllm_model.generate_greedy_logprobs(
             example_prompts, max_tokens, num_logprobs
@@ -343,10 +340,7 @@ def test_full_cuda_graph(
         )
 
     with vllm_runner(
-        model,
-        max_num_seqs=MAX_NUM_SEQS,
-        attention_backend=ATTN_BACKEND,
-        enable_chunked_prefill=True,
+        model, max_num_seqs=MAX_NUM_SEQS, attention_backend=ATTN_BACKEND
     ) as vllm_model:
         vllm_outputs = vllm_model.generate_greedy_logprobs(
             example_prompts, max_tokens, num_logprobs
@@ -394,7 +388,6 @@ def test_fp32_cache_state(
         model,
         max_num_seqs=MAX_NUM_SEQS,
         gpu_memory_utilization=0.9,
-        enable_chunked_prefill=True,
         **{cache_dtype_param: "float32"},
     ) as vllm_model:
         vllm_outputs = vllm_model.generate_greedy_logprobs(

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -135,10 +135,10 @@ class CacheConfig:
     """The cache strategy for Mamba layers:
 
     - "none": set when prefix caching is disabled.
-    - "all": cache the mamba state of all tokens at position i * block_size.
+    - "all": cache the mamba state of all tokens at position i * block_size. This is
+      the default behavior (for models that support it) when prefix caching is enabled.
     - "align": only cache the mamba state of the last token of each scheduler step and
-      when the token is at position i * block_size. This is the default when prefix
-      caching is enabled.
+      when the token is at position i * block_size.
     """
     replayssm_buffer_len: int = Field(default=16, gt=0)
     """ReplaySSM history buffer length B: with use_replayssm, standard decode

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -2594,7 +2594,11 @@ class EngineArgs:
         self, model_config: ModelConfig
     ) -> None:
         default_chunked_prefill = model_config.is_chunked_prefill_supported
-        default_prefix_caching = model_config.is_prefix_caching_supported
+        # Hybrid models support prefix caching but keep it opt-in for now
+        # while the feature matures.
+        default_prefix_caching = (
+            model_config.is_prefix_caching_supported and not model_config.is_hybrid
+        )
 
         if self.enable_chunked_prefill is None:
             self.enable_chunked_prefill = default_chunked_prefill

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -595,8 +595,10 @@ class MambaModelConfig(VerifyAndUpdateConfig):
 
         if cache_config.enable_prefix_caching:
             if cache_config.mamba_cache_mode == "none":
-                cache_config.mamba_cache_mode = "align"
-                logger.info(
+                cache_config.mamba_cache_mode = (
+                    "all" if model_config.supports_mamba_prefix_caching else "align"
+                )
+                logger.warning(
                     "Mamba cache mode is set to '%s' for %s by default "
                     "when prefix caching is enabled",
                     cache_config.mamba_cache_mode,
@@ -616,6 +618,13 @@ class MambaModelConfig(VerifyAndUpdateConfig):
                 assert vllm_config.scheduler_config.enable_chunked_prefill, (
                     "Chunked prefill is required for mamba cache mode 'align'."
                 )
+            logger.info(
+                "Warning: Prefix caching in Mamba cache '%s' "
+                "mode is currently enabled. "
+                "Its support for Mamba layers is experimental. "
+                "Please report any issues you may observe.",
+                cache_config.mamba_cache_mode,
+            )
             # By default, mamba block size will be set to max_model_len (see
             # below). When enabling prefix caching, we align mamba block size
             # to the block size as the basic granularity for prefix caching.


### PR DESCRIPTION
## Purpose

Auto-revert of https://github.com/vllm-project/vllm/pull/50991 ("[Mamba] enable prefix cache by default", commit `f9c74b4`).

Nightly CI build [#82382](https://buildkite.com/vllm/ci/builds/82382) (commit `05b7876`) has **3 newly failing jobs** that all trace to this PR. All three passed at the previous analyzed nightly (#82083).

## Failures linked to this PR

| Job | Failure |
|---|---|
| `Language Models Test (PPL)` | `test_qwen.py::test_ppl[model_info2]` (`Qwen/Qwen3.5-0.8B`) — `ValidationError: Chunked prefill is required for mamba cache mode 'align'` |
| `Quantization` | `test_experts_int8.py::test_model_experts_int8_startup[4-bfloat16-ai21labs/Jamba-tiny-random]` — same `ValidationError` |
| `Extract Hidden States Integration` | `test_extract_hidden_states_qwen35_hybrid_smoke` — `AssertionError: Each KV cache group's real block_size must be divisible by hash_block_size. block_sizes=[544, 544, 544, 544, 181], hash_block_size=98464` in `HybridKVCacheCoordinator.__init__` |

## Root cause

The PR removed the `and not model_config.is_hybrid` guard in
`_set_default_chunked_prefill_and_prefix_caching_args` (`vllm/engine/arg_utils.py`), so prefix caching now
defaults to **on** for hybrid/Mamba models, and `vllm/model_executor/models/config.py` now unconditionally
defaults `mamba_cache_mode` to `"align"` instead of `"all"`.

Two consequences:

1. `"align"` mode asserts `scheduler_config.enable_chunked_prefill`. Any hybrid-model configuration that
   explicitly passes `enable_chunked_prefill=False` — previously valid, since prefix caching was off — now
   fails hard at `VllmConfig` validation. This is user-facing, not test-only: the two failing jobs above
   simply exercise that configuration. Logs confirm the new default firing:
   `config.py:599 Mamba cache mode is set to 'align' for Qwen3_5ForConditionalGeneration by default when prefix caching is enabled`.
2. Turning prefix caching on by default routes hybrid models through `HybridKVCacheCoordinator`, which then
   trips its own block-size divisibility assertion — a pre-existing defect that was unreachable while the
   feature stayed opt-in.

The PR updated `tests/models/language/generation/test_hybrid.py` to pass `enable_chunked_prefill=True`, but
other suites and real user configs were not covered.

Reverting restores the opt-in default. It touches only the 4 files the original PR touched and is an exact
inverse of `f9c74b4` (no conflicts, no manual resolution).

Opened as a **draft** so the author can instead land a forward fix if preferred.

---
Auto-generated by CI failure analyzer.
