### PR TITLE
[Bugfix][Core] Include cgroup root CPU quota

### DIFF
--- a/tests/utils_/test_torch_utils.py
+++ b/tests/utils_/test_torch_utils.py
@@ -1,10 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from io import StringIO
+
 import pytest
 import torch
 
 from vllm.utils.torch_utils import (
     OMP_NUM_THREADS_SET_BY_VLLM,
+    _cgroup_cpu_limit,
     available_cpu_count,
     common_broadcastable_dtype,
     current_stream,
@@ -137,6 +140,37 @@ def test_startup_omp_num_threads_divides_between_local_workers():
     assert startup_omp_num_threads(2) == available // 2
     # Never zero, however many workers share the node.
     assert startup_omp_num_threads(available * 4) == 1
+
+
+@pytest.mark.parametrize("version", [1, 2])
+def test_cgroup_cpu_limit_includes_mount_root(
+    monkeypatch: pytest.MonkeyPatch, version: int
+):
+    if version == 2:
+        files = {
+            "/proc/self/cgroup": "0::/team/job\n",
+            "/sys/fs/cgroup/team/job/cpu.max": "max 100000\n",
+            "/sys/fs/cgroup/team/cpu.max": "max 100000\n",
+            "/sys/fs/cgroup/cpu.max": "200000 100000\n",
+        }
+    else:
+        files = {
+            "/proc/self/cgroup": "2:cpu,cpuacct:/team/job\n",
+            "/sys/fs/cgroup/cpu/team/job/cpu.cfs_quota_us": "-1\n",
+            "/sys/fs/cgroup/cpu/team/cpu.cfs_quota_us": "-1\n",
+            "/sys/fs/cgroup/cpu/cpu.cfs_quota_us": "200000\n",
+            "/sys/fs/cgroup/cpu/cpu.cfs_period_us": "100000\n",
+        }
+
+    def fake_open(path, *args, **kwargs):
+        try:
+            return StringIO(files[path])
+        except KeyError:
+            raise FileNotFoundError(path) from None
+
+    monkeypatch.setattr("builtins.open", fake_open)
+
+    assert _cgroup_cpu_limit() == 2.0
 
 
 def test_set_torch_threads_for_runtime(restore_torch_threads):

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -164,12 +164,11 @@ def _cgroup_cpu_limit() -> float | None:
 
         def visit(base: str, rel_path: str, read_quota) -> None:
             nonlocal limit
-            path = rel_path
-            while path:
-                quota = read_quota(os.path.join(base, path.lstrip("/")))
+            parts = [part for part in rel_path.split("/") if part]
+            for depth in range(len(parts), -1, -1):
+                quota = read_quota(os.path.join(base, *parts[:depth]))
                 if quota is not None:
                     limit = quota if limit is None else min(limit, quota)
-                path = path.rsplit("/", 1)[0]
 
         def read_v2(cg_dir: str) -> float | None:
             try:


### PR DESCRIPTION
## Purpose

Fix a hierarchy traversal bug in the cgroup-aware CPU quota detection added by #49919.

`_cgroup_cpu_limit()` visited a nested process cgroup and its non-root ancestors, but stopped before the cgroup mount root. For a process in `/team/job`, it checked `/team/job` and `/team` but not `/sys/fs/cgroup` itself. If the child cgroups were unlimited and the effective quota was configured at the mount root, vLLM treated the process as unlimited and sized worker startup thread pools from CPU affinity alone.

The change walks path components by depth through zero, so both cgroup v1 and v2 include the mount root while preserving the existing tightest-ancestor-quota behavior.

## Duplicate Check

This does not duplicate an open PR. Searches for cgroup root quota, `_cgroup_cpu_limit`, and nested cgroup CPU limits found only the merged source change #49919. The two open PRs touching `torch_utils.py` are unrelated: #51064 restores dtype on exceptions and #50671 changes UVA handling.

## Test Plan

- Simulate nested cgroup v2: child and parent are unlimited, mount root limits the process to 2 CPUs.
- Simulate the equivalent cgroup v1 hierarchy.
- Run the complete `tests/utils_/test_torch_utils.py` suite.
- Run targeted Ruff, formatting, typos, mypy, and diff checks.

## Test Result

- Before: the minimal cgroup v2 reproduction returned `None` instead of the root quota `2.0`.
- After: `.venv/bin/python -m pytest tests/utils_/test_torch_utils.py -q` -> `33 passed, 1 skipped`.
- `ruff-check`, `ruff-format`, `typos`, Python 3.12 `mypy`, and `git diff --check` passed.
- Full `pre-commit run --files ...` could not initialize the unrelated `actionlint` environment because the machine Go toolchain is older than the hook dependencies require (Go 1.18/1.19+). The applicable code hooks were run individually and passed.

### Exact base/head reproduction and negative controls

The same filesystem-level reproduction was run at current `main`
`f2bfad9167a29e963f29f9ea79f2811513566ea6` and this PR's exact head
`8be30f4e05e753e40c17c529ac27ba4e51e56bc3`:

| cgroup case | current `main` | PR head |
| --- | ---: | ---: |
| v1 root-only quota | `None` | `2.0` |
| v2 root-only quota | `None` | `2.0` |
| v1/v2 tighter child quota | `1.0` | `1.0` |
| v1/v2 fully unlimited | `None` | `None` |

The child-quota control pins the existing tightest-ancestor behavior; the
unlimited control pins the no-limit behavior. The targeted regression test at
the PR head passes both v1 and v2 cases (`2 passed`).

CI routing is explicit: `.buildkite/test_areas/misc.yaml` lists both
`vllm/utils/` and `tests/utils_` as source dependencies for
`Async Engine, Inputs, Utils, Worker`, whose command runs
`pytest -v -s utils_`. The Intel and AMD mirrors also include `tests/utils_`.

## Impact

- Breaking change: no
- Affected path: Linux worker CPU-thread sizing under nested cgroups
- Performance: prevents thread oversubscription when the effective quota is inherited from the cgroup mount root
- Non-Linux behavior and CPU affinity handling are unchanged

## AI Assistance

TRAE assisted with discovery, implementation, and testing. I reviewed every changed line, reproduced the bug, verified the fix, and approved this submission.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR is explained.
- [x] The test plan and exact results are included.
- [x] The regression is demonstrated before and after the fix.
- [x] No documentation update is required for this internal correctness fix.
</details>

