### PR TITLE
[Bugfix][KV Connector] Align all-mode Mamba offload hits

### DIFF
--- a/tests/v1/kv_connector/unit/test_offloading_connector.py
+++ b/tests/v1/kv_connector/unit/test_offloading_connector.py
@@ -545,7 +545,10 @@ def test_fs_tiering_offloading(tmp_path) -> None:
         ("state-spaces/mamba-1.4b-hf", 16, 1)
     ],
 )
-def test_mamba_align_cpu_offload(model: str, block_size: int, tp_size: int):
+@pytest.mark.parametrize("mamba_cache_mode", ["align", "all"])
+def test_mamba_align_cpu_offload(
+    model: str, block_size: int, tp_size: int, mamba_cache_mode: str
+):
     kv_transfer_config = KVTransferConfig(
         kv_connector="OffloadingConnector",
         kv_role="kv_both",
@@ -562,7 +565,7 @@ def test_mamba_align_cpu_offload(model: str, block_size: int, tp_size: int):
         kv_transfer_config=kv_transfer_config,
         language_model_only=True,
         enable_prefix_caching=True,
-        mamba_cache_mode="align",
+        mamba_cache_mode=mamba_cache_mode,
         disable_hybrid_kv_cache_manager=False,
     )
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -145,14 +145,19 @@ def resolve_mamba_align_size(
     """Scan all KV cache groups in *spec* and return the single mamba alignment
     size, or None if no group requires mamba alignment.
 
-    For MambaSpec groups in "align" cache mode the hit window must be rounded
-    down to a multiple of the offloaded chunk size. Asserts that all such
-    groups agree on the same value.
+    For MambaSpec groups in "align" or "all" cache mode the hit window must
+    be rounded down to a multiple of the offloaded chunk size. Both modes
+    cache recurrent state at chunk boundaries, so resuming from a partial
+    chunk would recompute a token already included in that state. Asserts that
+    all such groups agree on the same value.
     """
     mamba_align_size: int | None = None
     for idx, tokens_per_block in enumerate(spec.tokens_per_block):
         kv_spec = kv_cache_config.kv_cache_groups[idx].kv_cache_spec
-        if isinstance(kv_spec, MambaSpec) and kv_spec.mamba_cache_mode == "align":
+        if isinstance(kv_spec, MambaSpec) and kv_spec.mamba_cache_mode in (
+            "align",
+            "all",
+        ):
             tokens_per_chunk = tokens_per_block * spec.blocks_per_chunk
             assert mamba_align_size is None or mamba_align_size == tokens_per_chunk
             mamba_align_size = tokens_per_chunk


### PR DESCRIPTION
﻿## Purpose

Fixes #51094.

OffloadingConnector aligns prefix hits for Mamba cache mode `align`, but not `all`. Both modes store recurrent state at offloaded chunk boundaries. At an exact boundary, prefix lookup is capped at `num_tokens - 1` so that the final prompt token can be recomputed for logits. Without alignment in `all` mode, the connector can restore a state that already includes that final token, then apply it again during recomputation, silently changing generation output.

Apply the same hit-window alignment to `mamba_cache_mode="all"` as to `align`. This rounds the reusable prefix down to a valid recurrent-state boundary before it is restored.

## Test Plan

- Parameterize the existing CUDA-only `test_mamba_align_cpu_offload` regression test with both `align` and `all` cache modes.
- For each mode, exercise both an exact offload-chunk-boundary prompt and a mid-chunk prompt, clearing only the GPU prefix cache between cold and CPU-refetch generations.
- Compare greedy output from cold execution and CPU-cache refetch.

## Test Result

Passed locally:

```text
python -m ruff check vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py tests/v1/kv_connector/unit/test_offloading_connector.py
All checks passed!

python -m ruff format --check vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py tests/v1/kv_connector/unit/test_offloading_connector.py
2 files already formatted
```

The targeted CUDA test is included in this PR but was not run locally: WSL setup detected an NVIDIA GeForce RTX 3050, but the WSL service subsequently failed to create a VM with Windows error `0x80070569` (logon policy). The Windows Python test environment also lacks `tblib`, preventing pytest collection.

## AI assistance

This change was developed with OpenAI Codex assistance. The submitter has reviewed and understands every changed line; the commit includes the required attribution.
