### PR TITLE
[CI Failure]: Kimi-Linear-48B-A3B Disaggregated DP EP  #51072

### DIFF
--- a/vllm/models/kimi_k3/nvidia/mla.py
+++ b/vllm/models/kimi_k3/nvidia/mla.py
@@ -309,6 +309,10 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
             parallel_config.decode_context_parallel_size <= 1
             and parallel_config.prefill_context_parallel_size <= 1
         ), "Kimi-K3 MultiHeadLatentAttention does not support context parallelism."
+
+        self.impl.dcp_world_size = 1
+        self.impl.dcp_rank = 0
+
         self.prefill_backend = get_mla_prefill_backend(vllm_config)(
             num_heads=self.num_local_heads,
             scale=self.scale,


### PR DESCRIPTION
Fix Kimi K3 MLA DCP world size

THIS PR is still a DRAFT.

## Purpose

Resolves #51072 

Fixed Kimi K3 MLA decoding by initializing the DCP world size and rank to valid non-context-parallel values, preventing FlashAttention from receiving an invalid DCP configuration.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

