### PR TITLE
Fix Mistral3 nested word embedding tying

### DIFF
--- a/tests/models/transformers/test_backend.py
+++ b/tests/models/transformers/test_backend.py
@@ -2,9 +2,12 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Test the functionality of the Transformers modeling backend."""
 
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
+
+from vllm.model_executor.models.transformers.base import Base
 
 from ...conftest import HfRunner, VllmRunner
 from ...utils import multi_gpu_test, prep_prompts
@@ -33,6 +36,16 @@ def get_num_fused(model) -> tuple[int, int]:
     glu = sum(isinstance(m, MergedColumnParallelLinear) for m in model.modules())
     qkv = sum(isinstance(m, QKVParallelLinear) for m in model.modules())
     return glu, qkv
+
+
+def test_mistral3_uses_text_config_for_word_embedding_tying() -> None:
+    """Mistral3's nested language model owns its embedding and lm_head."""
+    backend = SimpleNamespace(
+        config=SimpleNamespace(model_type="mistral3", tie_word_embeddings=True),
+        text_config=SimpleNamespace(tie_word_embeddings=False),
+    )
+
+    assert Base._get_tie_word_embeddings(backend) is False
 
 
 def check_implementation(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import pydantic
 import pytest
 from pydantic import ValidationError
+from transformers import Mistral3Config
 
 import vllm.config.vllm as vllm_config_module
 import vllm.envs as envs
@@ -364,6 +365,41 @@ def test_with_hf_config_leaves_unknown_model_type_without_architectures(
     updated = VllmConfig.with_hf_config(cfg, hf_config)
 
     assert updated.model_config.hf_config.architectures is None
+
+
+@pytest.mark.skip_global_cleanup
+@pytest.mark.parametrize(
+    ("copy_tie_word_embeddings", "expected_tie_word_embeddings"),
+    [(True, True), (False, False)],
+)
+def test_with_hf_config_respects_mistral3_text_config_tie_word_embeddings(
+    monkeypatch,
+    copy_tie_word_embeddings,
+    expected_tie_word_embeddings,
+):
+    monkeypatch.setattr(
+        vllm_config_module,
+        "replace",
+        lambda self, **kwargs: SimpleNamespace(**kwargs),
+    )
+    outer_config = Mistral3Config(text_config={"tie_word_embeddings": False})
+    cfg = SimpleNamespace(
+        model_config=SimpleNamespace(
+            is_multimodal_model=True,
+            hf_config=outer_config,
+            get_model_arch_config=lambda: "arch-config",
+        )
+    )
+    updated = VllmConfig.with_hf_config(
+        cfg,
+        outer_config.text_config,
+        copy_tie_word_embeddings=copy_tie_word_embeddings,
+    )
+
+    assert (
+        updated.model_config.hf_config.tie_word_embeddings
+        is expected_tie_word_embeddings
+    )
 
 
 def test_async_scheduling_with_pipeline_parallelism_is_allowed():

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -754,6 +754,7 @@ class VllmConfig:
         self,
         hf_config: PretrainedConfig,
         architectures: list[str] | None = None,
+        copy_tie_word_embeddings: bool = True,
     ) -> "VllmConfig":
         if architectures is not None:
             hf_config = copy.deepcopy(hf_config)
@@ -797,8 +798,10 @@ class VllmConfig:
         # Therefore, the presence of tie_word_embeddings in SomeVLTextConfig cannot
         # be used as a signal for whether tie_word_embeddings should be copied from
         # hf_config to the language_model config.
-        if model_config.is_multimodal_model and hasattr(
-            model_config.hf_config, "tie_word_embeddings"
+        if (
+            copy_tie_word_embeddings
+            and model_config.is_multimodal_model
+            and hasattr(model_config.hf_config, "tie_word_embeddings")
         ):
             tie_word_embeddings = model_config.hf_config.tie_word_embeddings
             hf_config.get_text_config().tie_word_embeddings = tie_word_embeddings

--- a/vllm/model_executor/models/mistral3.py
+++ b/vllm/model_executor/models/mistral3.py
@@ -439,6 +439,7 @@ class Mistral3ForConditionalGeneration(
             self.language_model = init_vllm_registered_model(
                 vllm_config=vllm_config,
                 hf_config=config.text_config,
+                copy_tie_word_embeddings=False,
                 prefix=maybe_prefix(prefix, "language_model"),
             )
 

--- a/vllm/model_executor/models/transformers/base.py
+++ b/vllm/model_executor/models/transformers/base.py
@@ -336,6 +336,12 @@ class Base(
         """
         Check if the model has tied word embeddings.
         """
+        # Mistral3Config has a top-level default that conflicts with its
+        # nested text config. The latter owns the embedding and lm_head, so
+        # it is authoritative for this model.
+        if self.config.model_type == "mistral3":
+            return self.text_config.tie_word_embeddings
+
         # Models created with Transformers v4 and v5 will store this in different places
         tie_word_embeddings_v4 = getattr(self.text_config, "tie_word_embeddings", False)
         tie_word_embeddings_v5 = getattr(self.config, "tie_word_embeddings", False)

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -540,6 +540,7 @@ def init_vllm_registered_model(
     prefix: str = "",
     hf_config: "PretrainedConfig | None" = None,
     architectures: list[str] | None = None,
+    copy_tie_word_embeddings: bool = True,
 ) -> nn.Module:
     """
     Helper function to initialize an inner model registered to vLLM,
@@ -552,7 +553,11 @@ def init_vllm_registered_model(
         hf_config = vllm_config.model_config.hf_config
 
     if hf_config is not None:
-        vllm_config = vllm_config.with_hf_config(hf_config, architectures=architectures)
+        vllm_config = vllm_config.with_hf_config(
+            hf_config,
+            architectures=architectures,
+            copy_tie_word_embeddings=copy_tie_word_embeddings,
+        )
 
     return initialize_model(vllm_config=vllm_config, prefix=prefix)
 


### PR DESCRIPTION
## Summary

Fixes #51063 by preserving the nested Mistral3 text config's `tie_word_embeddings` value when vLLM initializes the language model. This prevents the composite wrapper's `tie_word_embeddings=True` default from discarding an untied `lm_head.weight`.

The nested text config owns the language model's embedding and `lm_head`, so it is authoritative for Mistral3. The fix covers both implementations reported in #51063:

- vLLM's native `Mistral3ForConditionalGeneration` implementation
- the `model_impl=transformers` backend, whose prior v4/v5 compatibility check treated the outer `True` as sufficient to tie the head

The existing wrapper-to-text-config propagation remains the default for other multimodal models.

## Validation

- `ruff check vllm/config/vllm.py vllm/model_executor/models/utils.py vllm/model_executor/models/mistral3.py vllm/model_executor/models/transformers/base.py tests/test_config.py tests/models/transformers/test_backend.py`
- `python -m compileall -q` on the changed source and test files
- Regression tests cover both the native nested-config handoff and the Transformers-backend tie decision.
- Confirmed with Transformers' real `Mistral3Config` defaults that the wrapper defaults to `True` while its nested text config can be `False`.

The local Windows checkout cannot run pytest because it lacks vLLM's compiled extension. The focused tests are ready to run in the repository's standard CUDA environment:

```bash
python -m pytest -q tests/test_config.py tests/models/transformers/test_backend.py \
  -k 'mistral3_text_config_tie_word_embeddings or mistral3_uses_text_config_for_word_embedding_tying'
```

## Affected-checkpoint evidence

#51063 documents an end-to-end before/after evaluation by the issue reporter on the affected merged Ministral-3-8B checkpoint: aligning the language model's tying decision with its nested text config restored coherent output. This PR implements that alignment in both vLLM paths cited in the issue. I have asked for validation of this exact commit below.

## AI assistance

AI assistance was used to trace the configuration handoff, prepare the patch, and run the listed validation. The submitter reviewed the final changes.