### PR TITLE
[Hardware] Use torch.accelerator.empty_host_cache() for host cache cl…

### DIFF
--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -2182,7 +2182,7 @@ def cleanup_dist_env_and_memory(shutdown_ray: bool = False):
             torch.accelerator.empty_host_cache()
         except AttributeError:
             logger.warning(
-                "torch.accelerator.empty_host_cache() only available in Pytorch >=2.10"
+                "torch.accelerator.empty_host_cache() only available in Pytorch >=2.9"
             )
 
     logger.debug_once("[shutdown] Distributed: cleanup complete")

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -2179,10 +2179,10 @@ def cleanup_dist_env_and_memory(shutdown_ray: bool = False):
     if not current_platform.is_cpu():
         torch.accelerator.empty_cache()
         try:
-            torch._C._host_emptyCache()
+            torch.accelerator.empty_host_cache()
         except AttributeError:
             logger.warning(
-                "torch._C._host_emptyCache() only available in Pytorch >=2.5"
+                "torch.accelerator.empty_host_cache() only available in Pytorch >=2.10"
             )
 
     logger.debug_once("[shutdown] Distributed: cleanup complete")


### PR DESCRIPTION




## Purpose
`cleanup_dist_env_and_memory()` called `torch._C._host_emptyCache()` to free the host pinned-memory cache. That API is CUDA-specific and is not available on XPU, which triggered a warning on every shutdown. So this PR switches to the unified `torch.accelerator.empty_host_cache()` API.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

