### PR TITLE
[Rust][Benchmark] Fix multi-turn input token accounting

### DIFF
--- a/rust/src/bench/src/metrics/calculator.rs
+++ b/rust/src/bench/src/metrics/calculator.rs
@@ -392,7 +392,7 @@ pub fn calculate_multi_turn_metrics(
         for turn in &conv.turns {
             all_requests.push(SampleRequest {
                 prompt: std::sync::Arc::from(""),
-                prompt_len: turn.cumulative_input_tokens,
+                prompt_len: turn.request_output.prompt_len,
                 expected_output_len: turn.request_output.output_tokens,
                 request_id: None,
                 ..Default::default()
@@ -420,7 +420,7 @@ pub fn calculate_multi_turn_metrics(
             if let Some(turn) = conv.turns.get(turn_idx) {
                 turn_requests.push(SampleRequest {
                     prompt: std::sync::Arc::from(""),
-                    prompt_len: turn.cumulative_input_tokens,
+                    prompt_len: turn.request_output.prompt_len,
                     expected_output_len: turn.request_output.output_tokens,
                     request_id: None,
                     ..Default::default()
@@ -501,5 +501,42 @@ mod tests {
         let data: Vec<f64> = (0..100).map(|i| i as f64).collect();
         let p99 = percentile_sorted(&data, 99.0);
         assert!((p99 - 98.01).abs() < 0.1);
+    }
+
+    #[test]
+    fn test_multi_turn_metrics_use_request_prompt_lengths() {
+        let turn = |turn_index, prompt_len, output_tokens| crate::multi_turn::TurnOutput {
+            turn_index,
+            request_output: RequestFuncOutput {
+                success: true,
+                prompt_len,
+                output_tokens,
+                latency: 1.0,
+                ttft: 0.1,
+                ..Default::default()
+            },
+        };
+        let conversation_outputs = [ConversationOutput {
+            conversation_id: "conversation-0".to_string(),
+            turns: vec![turn(0, 500, 200), turn(1, 1200, 200)],
+            total_duration_ms: 2000.0,
+            all_success: true,
+        }];
+
+        let metrics = calculate_multi_turn_metrics(
+            &conversation_outputs,
+            2.0,
+            &[],
+            &GoodputConfig::default(),
+            2,
+        );
+
+        assert_eq!(metrics.overall.total_input, 1700);
+        assert_eq!(metrics.overall.total_output, 400);
+        assert_eq!(metrics.overall.input_throughput, 850.0);
+        assert_eq!(metrics.overall.total_token_throughput, 1050.0);
+        assert_eq!(metrics.per_turn.len(), 2);
+        assert_eq!(metrics.per_turn[0].total_input, 500);
+        assert_eq!(metrics.per_turn[1].total_input, 1200);
     }
 }

--- a/rust/src/bench/src/multi_turn.rs
+++ b/rust/src/bench/src/multi_turn.rs
@@ -29,7 +29,6 @@ use crate::output::json::{
 pub struct TurnOutput {
     pub turn_index: usize,
     pub request_output: RequestFuncOutput,
-    pub cumulative_input_tokens: usize,
 }
 
 /// Output from an entire conversation.
@@ -720,14 +719,12 @@ async fn run_conversation(
             turn_outputs.push(TurnOutput {
                 turn_index: turn_idx,
                 request_output: output,
-                cumulative_input_tokens: cumulative_tokens,
             });
         } else {
             all_success = false;
             turn_outputs.push(TurnOutput {
                 turn_index: turn_idx,
                 request_output: output,
-                cumulative_input_tokens: cumulative_tokens,
             });
             break; // Conversation stops on failure
         }


### PR DESCRIPTION



## Purpose

  Multi-turn benchmark metrics used a cumulative context length that already
  included the current turn's generated tokens as `prompt_len`.

  For a turn with 500 input tokens and 200 output tokens, the benchmark reported
  700 input tokens. Across successful turns, total input tokens were overstated
  by exactly the total generated tokens, causing input and total token throughput
  to be inflated.

  Use `RequestFuncOutput.prompt_len`, which records the prompt length at request
  time, for both overall and per-turn metrics. Remove the redundant cumulative
  input field so the request output remains the single source of truth.

  This makes multi-turn throughput results accurate and prevents longer outputs
  from unfairly inflating benchmark comparisons.

## Test Plan

```
  cargo test -p vllm-bench \
    metrics::calculator::tests::test_multi_turn_metrics_use_request_prompt_lengths \
    -- --exact --nocapture
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

