### PR TITLE
[Bugfix] Validate cached QuTLASS revision before reuse

### DIFF
--- a/cmake/external_projects/qutlass.cmake
+++ b/cmake/external_projects/qutlass.cmake
@@ -32,7 +32,16 @@ else()
   set(_qutlass_bin "${_qutlass_fc_root}/qutlass-build")
   set(_qutlass_sub "${_qutlass_fc_root}/qutlass-subbuild")
 
-  if(EXISTS "${_qutlass_src}/qutlass/csrc/bindings.cpp")
+  find_package(Git REQUIRED)
+  execute_process(
+    COMMAND "${GIT_EXECUTABLE}" -C "${_qutlass_src}" rev-parse HEAD
+    RESULT_VARIABLE _qutlass_git_result
+    OUTPUT_VARIABLE _qutlass_git_revision
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  if(_qutlass_git_result EQUAL 0 AND
+     _qutlass_git_revision STREQUAL _QUTLASS_UPSTREAM_TAG)
     set(qutlass_SOURCE_DIR "${_qutlass_src}")
     set(qutlass_BINARY_DIR "${_qutlass_bin}")
   else()


### PR DESCRIPTION
## Purpose

The managed QuTLASS `FetchContent` cache was reused whenever one source file existed, without checking that the checkout matched `_QUTLASS_UPSTREAM_TAG`. After the pin changed, an older checkout could therefore survive reconfiguration and mix incompatible generated/source interfaces into the vLLM build.

This change reuses the managed cache only when its Git `HEAD` matches the pinned revision. A stale or non-Git directory is handed back to `FetchContent_Populate`, while an explicit `QUTLASS_SRC_DIR` remains unchanged. A correct cached checkout still takes the existing fast path and does not contact the remote.

I searched open pull requests for `qutlass FetchContent`, `QUTLASS_SRC_DIR`, and `qutlass cache` and found no duplicate.

AI assistance was used to prepare this change. The submitter is responsible for reviewing every changed line and the validation evidence before marking this PR ready.

## Test Plan

- Force the managed QuTLASS checkout to an older revision, configure through the real `qutlass.cmake`, and verify it advances to `_QUTLASS_UPSTREAM_TAG`.
- Configure again with the QuTLASS remote redirected to an invalid local URL and verify the correct cached checkout is reused offline.
- Build the locked vLLM workspace from the stale-cache state.
- Run the repository pre-commit checks for the changed file.

## Test Result

- Stale-cache configure probe: passed; QuTLASS advanced from `830d2c4537...` to `e74319e340...`, including its pinned CUTLASS submodule.
- Correct-cache offline probe: passed without a `Populating qutlass` step.
- `MAX_JOBS=32 pixi install --locked -e default`: passed; the stale cache was refreshed and the CUDA extension build completed.
- `prek run --files cmake/external_projects/qutlass.cmake`: passed.
- `git diff --check`: passed.
- Documentation is unchanged because this only repairs build dependency realization.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR is described above.
- [x] The test plan and commands are described above.
- [x] The test results are described above.
- [x] No documentation update is necessary for this build-system fix.
</details>
