### PR TITLE
[Bugfix][KV Offload] Fall back when MADV_POPULATE_WRITE is unsupported

### DIFF
--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
@@ -3,6 +3,7 @@
 """Unit tests for SharedOffloadRegion."""
 
 import contextlib
+import errno
 import mmap
 import os
 import threading
@@ -403,6 +404,73 @@ def test_file_has_correct_size(iid):
     """The mmap file size on disk must equal total_size_bytes."""
     with _region(iid, num_blocks=4) as r:
         assert os.path.getsize(r.mmap_path) == 4 * PAGE_SIZE
+
+
+def test_madvise_einval_falls_back_for_ranked_region(iid, monkeypatch):
+    """Older kernels can reject MADV_POPULATE_WRITE with EINVAL."""
+    real_mmap = mmap.mmap
+
+    class EINVALMmap(real_mmap):
+
+        madvise_calls = []
+
+        def madvise(self, *args):
+            self.madvise_calls.append(args)
+            raise OSError(errno.EINVAL, "Invalid argument")
+
+    monkeypatch.setattr(mmap, "mmap", EINVALMmap)
+
+    with _region(iid, num_blocks=3, num_workers=2, rank=1) as r:
+        assert isinstance(r.mmap_obj, EINVALMmap)
+        assert len(EINVALMmap.madvise_calls) == 3
+
+
+def test_madvise_einval_falls_back_for_unranked_region(iid, monkeypatch):
+    """The scheduler mmap path also works when MADV_POPULATE_WRITE is absent."""
+    real_mmap = mmap.mmap
+
+    class EINVALMmap(real_mmap):
+
+        madvise_calls = []
+
+        def madvise(self, *args):
+            self.madvise_calls.append(args)
+            raise OSError(errno.EINVAL, "Invalid argument")
+
+    monkeypatch.setattr(mmap, "mmap", EINVALMmap)
+
+    region = SharedOffloadRegion(
+        instance_id=iid,
+        num_blocks=3,
+        rank=None,
+        kv_bytes_per_block=2 * PAGE_SIZE,
+        cpu_page_size=PAGE_SIZE,
+    )
+    try:
+        assert isinstance(region.mmap_obj, EINVALMmap)
+        assert len(EINVALMmap.madvise_calls) == 1
+    finally:
+        region.cleanup()
+        _cleanup_file(region.mmap_path)
+
+
+def test_madvise_unexpected_oserror_propagates(iid, monkeypatch):
+    """Only unsupported MADV_POPULATE_WRITE should use the fallback."""
+    real_mmap = mmap.mmap
+
+    class FailingMmap(real_mmap):
+
+        def madvise(self, *args):
+            raise OSError(errno.EIO, "I/O error")
+
+    monkeypatch.setattr(mmap, "mmap", FailingMmap)
+    path = f"/dev/shm/vllm_offload_{iid}.mmap"
+
+    with pytest.raises(OSError) as exc_info:
+        _make_region(iid)
+
+    assert exc_info.value.errno == errno.EIO
+    _cleanup_file(path)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
@@ -406,85 +406,103 @@ def test_file_has_correct_size(iid):
         assert os.path.getsize(r.mmap_path) == 4 * PAGE_SIZE
 
 
-def test_madvise_einval_falls_back_for_ranked_region(iid, monkeypatch):
-    """Older kernels can reject MADV_POPULATE_WRITE with EINVAL.
-
-    We monkeypatch the module-level _madvise_populate_write helper to raise
-    EINVAL.  Subclassing mmap.mmap or patching the immutable mmap.mmap class
-    attribute does not work on Python 3.12+; the helper is the test seam.
-    """
-    monkeypatch.setattr(
-        "vllm.v1.kv_offload.cpu.shared_offload_region._madvise_populate_write",
-        lambda mm, off, ln: (_ for _ in ()).throw(
-            OSError(errno.EINVAL, "simulated unsupported kernel")
-        ),
-    )
-    num_blocks = 3
-    with _region(iid, num_blocks=num_blocks, num_workers=2, rank=1) as r:
-        raw = memoryview(r.mmap_obj)
-        # rank=1 occupies page 1, 3, 5 (the second column of each row).
-        for page in (1, 3, 5):
-            assert raw[page * PAGE_SIZE] == 0, (
-                f"fallback must touch rank-1 page {page} head"
-            )
-            assert all(
-                b == 0 for b in raw[page * PAGE_SIZE + 1 : (page + 1) * PAGE_SIZE]
-            ), f"fallback must fill page {page} (per-page write)"
-        # rank-0 pages (0, 2, 4) are untouched.
-        for page in (0, 2, 4):
-            assert raw[page * PAGE_SIZE] != 0 or True  # may be touched by mmap init
-        del raw
-
-
-def test_madvise_einval_falls_back_for_unranked_region(iid, monkeypatch):
-    """The scheduler mmap path (rank=None) also works when the advice is absent."""
-    monkeypatch.setattr(
-        "vllm.v1.kv_offload.cpu.shared_offload_region._madvise_populate_write",
-        lambda mm, off, ln: (_ for _ in ()).throw(
-            OSError(errno.EINVAL, "simulated unsupported kernel")
-        ),
-    )
-    with _region(iid, num_blocks=3, num_workers=2, rank=None) as r:
-        raw = memoryview(r.mmap_obj)
-        # Every page head must be 0 (fallback fills with zeros).
-        for page in range(6):
-            assert raw[page * PAGE_SIZE] == 0, (
-                f"fallback must touch page {page} head (unranked)"
-            )
-        del raw
-
-
 def test_madvise_success_selects_madvise_population(iid, monkeypatch):
     """A successful probe must keep using MADV_POPULATE_WRITE — the fallback
-    helper must never be invoked on a kernel that accepts the advice."""
+    helper must never be invoked on a kernel that accepts the advice.
+
+    Spies on both helpers so we can verify call counts: 1 probe call +
+    N populate calls, fallback 0 times.
+    """
+    from vllm.v1.kv_offload.cpu import shared_offload_region as sor
+
+    madvise_calls: list[tuple[int, int, int]] = []
     fallback_calls: list[tuple[int, int]] = []
 
     def _spy_madvise(mm, off, ln):
-        return None  # simulate a successful probe
+        madvise_calls.append((off, ln, id(mm)))
 
     def _spy_fallback(mm, off, ln):
         fallback_calls.append((off, ln))
 
-    monkeypatch.setattr(
-        "vllm.v1.kv_offload.cpu.shared_offload_region._madvise_populate_write",
-        _spy_madvise,
-    )
-    monkeypatch.setattr(
-        "vllm.v1.kv_offload.cpu.shared_offload_region._fallback_populate_write",
-        _spy_fallback,
-    )
-    with _region(iid, num_blocks=3, num_workers=2, rank=1):
+    monkeypatch.setattr(sor, "_madvise_populate_write", _spy_madvise)
+    monkeypatch.setattr(sor, "_fallback_populate_write", _spy_fallback)
+
+    num_blocks = 3
+    num_workers = 2
+    with _region(iid, num_blocks=num_blocks, num_workers=num_workers, rank=1):
+        # 1 probe (PAGESIZE) + N populate calls (one per block per worker column).
+        expected_populate = num_blocks  # ranked path: one call per block
+        assert len(madvise_calls) == 1 + expected_populate, (
+            f"expected 1 probe + {expected_populate} populate calls, "
+            f"got {len(madvise_calls)}: {madvise_calls}"
+        )
+        # Probe is the first call at offset 0, length PAGESIZE.
+        assert madvise_calls[0] == (0, mmap.PAGESIZE, madvise_calls[0][2])
         assert fallback_calls == [], (
             "native-path constructor must not invoke the fallback helper"
         )
+
+
+def test_madvise_einval_smoke(iid, monkeypatch):
+    """Smoke: when the probe raises EINVAL the constructor still completes
+    and reaches the fallback path.  We do not assert on touched bytes here —
+    see test_fallback_populate_write_preserves_existing_bytes for that."""
+    from vllm.v1.kv_offload.cpu import shared_offload_region as sor
+
+    monkeypatch.setattr(
+        sor,
+        "_madvise_populate_write",
+        lambda mm, off, ln: (_ for _ in ()).throw(
+            OSError(errno.EINVAL, "simulated unsupported kernel")
+        ),
+    )
+    with _region(iid, num_blocks=3, num_workers=2, rank=1) as r:
+        # Constructor completed; region is usable.
+        assert r.mmap_obj is not None
+        assert r.total_size_bytes == 3 * 2 * PAGE_SIZE
+
+
+def test_fallback_populate_write_preserves_existing_bytes(iid, monkeypatch):
+    """Direct unit test for _fallback_populate_write: it must not alter any
+    existing byte in the mmap.  A peer worker may have written KV data into
+    the same shared mmap before this fallback runs; an unconditional `= 0`
+    would silently corrupt that data.  The `|= 0` write is a no-op that still
+    triggers the page fault."""
+    from vllm.v1.kv_offload.cpu import shared_offload_region as sor
+
+    size = 3 * mmap.PAGESIZE
+    with _region(iid, num_blocks=size // PAGE_SIZE, num_workers=1, rank=0) as r:
+        # Plant non-zero sentinels at the head of each page.
+        mv = memoryview(r.mmap_obj)
+        sentinels = (0xAB, 0xCD, 0xEF)
+        try:
+            for page, sentinel in enumerate(sentinels):
+                mv[page * mmap.PAGESIZE] = sentinel
+        finally:
+            del mv
+
+        sor._fallback_populate_write(r.mmap_obj, 0, size)
+
+        mv = memoryview(r.mmap_obj)
+        try:
+            for page, sentinel in enumerate(sentinels):
+                assert mv[page * mmap.PAGESIZE] == sentinel, (
+                    f"page {page} head mutated: "
+                    f"got {mv[page * mmap.PAGESIZE]:#x}, want {sentinel:#x}"
+                )
+        finally:
+            del mv
 
 
 def test_madvise_unexpected_oserror_propagates(iid, monkeypatch):
     """Only EINVAL triggers the fallback.  Other OSErrors (e.g. EIO) must
     propagate out of __init__, not be silently masked by the fallback branch.
     """
+    from vllm.v1.kv_offload.cpu import shared_offload_region as sor
+
     monkeypatch.setattr(
-        "vllm.v1.kv_offload.cpu.shared_offload_region._madvise_populate_write",
+        sor,
+        "_madvise_populate_write",
         lambda mm, off, ln: (_ for _ in ()).throw(
             OSError(errno.EIO, "simulated I/O failure")
         ),

--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
@@ -407,122 +407,91 @@ def test_file_has_correct_size(iid):
 
 
 def test_madvise_einval_falls_back_for_ranked_region(iid, monkeypatch):
-    """Older kernels can reject MADV_POPULATE_WRITE with EINVAL."""
-    real_mmap = mmap.mmap
+    """Older kernels can reject MADV_POPULATE_WRITE with EINVAL.
 
-    class EINVALMmap(real_mmap):
-
-        madvise_calls = []
-
-        def __new__(cls, *args, **kwargs):
-            obj = super().__new__(cls, *args, **kwargs)
-            obj[:] = b"\xff" * len(obj)
-            return obj
-
-        def madvise(self, *args):
-            self.madvise_calls.append(args)
-            raise OSError(errno.EINVAL, "Invalid argument")
-
-    monkeypatch.setattr(mmap, "mmap", EINVALMmap)
-
-    with _region(iid, num_blocks=3, num_workers=2, rank=1) as r:
-        assert isinstance(r.mmap_obj, EINVALMmap)
-        assert len(EINVALMmap.madvise_calls) == 1
-        touched_offsets = [
-            PAGE_SIZE,
-            3 * PAGE_SIZE,
-            5 * PAGE_SIZE,
-        ]
-        assert [r.mmap_obj[offset] for offset in touched_offsets] == [0, 0, 0]
-        assert r.mmap_obj[0] == 0xff
-        assert r.mmap_obj[PAGE_SIZE + 1] == 0xff
+    We monkeypatch the module-level _madvise_populate_write helper to raise
+    EINVAL.  Subclassing mmap.mmap or patching the immutable mmap.mmap class
+    attribute does not work on Python 3.12+; the helper is the test seam.
+    """
+    monkeypatch.setattr(
+        "vllm.v1.kv_offload.cpu.shared_offload_region._madvise_populate_write",
+        lambda mm, off, ln: (_ for _ in ()).throw(
+            OSError(errno.EINVAL, "simulated unsupported kernel")
+        ),
+    )
+    num_blocks = 3
+    with _region(iid, num_blocks=num_blocks, num_workers=2, rank=1) as r:
+        raw = memoryview(r.mmap_obj)
+        # rank=1 occupies page 1, 3, 5 (the second column of each row).
+        for page in (1, 3, 5):
+            assert raw[page * PAGE_SIZE] == 0, (
+                f"fallback must touch rank-1 page {page} head"
+            )
+            assert all(
+                b == 0 for b in raw[page * PAGE_SIZE + 1 : (page + 1) * PAGE_SIZE]
+            ), f"fallback must fill page {page} (per-page write)"
+        # rank-0 pages (0, 2, 4) are untouched.
+        for page in (0, 2, 4):
+            assert raw[page * PAGE_SIZE] != 0 or True  # may be touched by mmap init
+        del raw
 
 
 def test_madvise_einval_falls_back_for_unranked_region(iid, monkeypatch):
-    """The scheduler mmap path also works when MADV_POPULATE_WRITE is absent."""
-    real_mmap = mmap.mmap
-
-    class EINVALMmap(real_mmap):
-
-        madvise_calls = []
-
-        def __new__(cls, *args, **kwargs):
-            obj = super().__new__(cls, *args, **kwargs)
-            obj[:] = b"\xff" * len(obj)
-            return obj
-
-        def madvise(self, *args):
-            self.madvise_calls.append(args)
-            raise OSError(errno.EINVAL, "Invalid argument")
-
-    monkeypatch.setattr(mmap, "mmap", EINVALMmap)
-
-    region = SharedOffloadRegion(
-        instance_id=iid,
-        num_blocks=3,
-        rank=None,
-        kv_bytes_per_block=2 * PAGE_SIZE,
-        cpu_page_size=PAGE_SIZE,
+    """The scheduler mmap path (rank=None) also works when the advice is absent."""
+    monkeypatch.setattr(
+        "vllm.v1.kv_offload.cpu.shared_offload_region._madvise_populate_write",
+        lambda mm, off, ln: (_ for _ in ()).throw(
+            OSError(errno.EINVAL, "simulated unsupported kernel")
+        ),
     )
-    try:
-        assert isinstance(region.mmap_obj, EINVALMmap)
-        assert len(EINVALMmap.madvise_calls) == 1
-        touched_offsets = [
-            page * PAGE_SIZE for page in range(6)
-        ]
-        assert [region.mmap_obj[offset] for offset in touched_offsets] == [0] * 6
-        assert region.mmap_obj[1] == 0xff
-    finally:
-        region.cleanup()
-        _cleanup_file(region.mmap_path)
+    with _region(iid, num_blocks=3, num_workers=2, rank=None) as r:
+        raw = memoryview(r.mmap_obj)
+        # Every page head must be 0 (fallback fills with zeros).
+        for page in range(6):
+            assert raw[page * PAGE_SIZE] == 0, (
+                f"fallback must touch page {page} head (unranked)"
+            )
+        del raw
 
 
 def test_madvise_success_selects_madvise_population(iid, monkeypatch):
-    """A successful probe should keep using MADV_POPULATE_WRITE."""
-    real_mmap = mmap.mmap
+    """A successful probe must keep using MADV_POPULATE_WRITE — the fallback
+    helper must never be invoked on a kernel that accepts the advice."""
+    fallback_calls: list[tuple[int, int]] = []
 
-    class TrackingMmap(real_mmap):
+    def _spy_madvise(mm, off, ln):
+        return None  # simulate a successful probe
 
-        madvise_calls = []
+    def _spy_fallback(mm, off, ln):
+        fallback_calls.append((off, ln))
 
-        def __new__(cls, *args, **kwargs):
-            obj = super().__new__(cls, *args, **kwargs)
-            obj[:] = b"\xff" * len(obj)
-            return obj
-
-        def madvise(self, *args):
-            self.madvise_calls.append(args)
-
-    monkeypatch.setattr(mmap, "mmap", TrackingMmap)
-
-    with _region(iid, num_blocks=3, num_workers=2, rank=1) as r:
-        assert isinstance(r.mmap_obj, TrackingMmap)
-        assert TrackingMmap.madvise_calls == [
-            (23, 0, PAGE_SIZE),
-            (23, PAGE_SIZE, PAGE_SIZE),
-            (23, 3 * PAGE_SIZE, PAGE_SIZE),
-            (23, 5 * PAGE_SIZE, PAGE_SIZE),
-        ]
-        assert r.mmap_obj[PAGE_SIZE] == 0xff
+    monkeypatch.setattr(
+        "vllm.v1.kv_offload.cpu.shared_offload_region._madvise_populate_write",
+        _spy_madvise,
+    )
+    monkeypatch.setattr(
+        "vllm.v1.kv_offload.cpu.shared_offload_region._fallback_populate_write",
+        _spy_fallback,
+    )
+    with _region(iid, num_blocks=3, num_workers=2, rank=1):
+        assert fallback_calls == [], (
+            "native-path constructor must not invoke the fallback helper"
+        )
 
 
 def test_madvise_unexpected_oserror_propagates(iid, monkeypatch):
-    """Only unsupported MADV_POPULATE_WRITE should use the fallback."""
-    real_mmap = mmap.mmap
-
-    class FailingMmap(real_mmap):
-
-        def madvise(self, *args):
-            raise OSError(errno.EIO, "I/O error")
-
-    monkeypatch.setattr(mmap, "mmap", FailingMmap)
-    path = f"/dev/shm/vllm_offload_{iid}.mmap"
-
+    """Only EINVAL triggers the fallback.  Other OSErrors (e.g. EIO) must
+    propagate out of __init__, not be silently masked by the fallback branch.
+    """
+    monkeypatch.setattr(
+        "vllm.v1.kv_offload.cpu.shared_offload_region._madvise_populate_write",
+        lambda mm, off, ln: (_ for _ in ()).throw(
+            OSError(errno.EIO, "simulated I/O failure")
+        ),
+    )
     with pytest.raises(OSError) as exc_info:
         _make_region(iid)
-
     assert exc_info.value.errno == errno.EIO
-    _cleanup_file(path)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
@@ -3,6 +3,7 @@
 """Unit tests for SharedOffloadRegion."""
 
 import contextlib
+import ctypes
 import errno
 import mmap
 import os
@@ -56,6 +57,29 @@ def _cleanup_file(path: str) -> None:
     """Best-effort file removal for test teardown."""
     with contextlib.suppress(FileNotFoundError):
         os.unlink(path)
+
+
+def _page_residency(mmap_obj: mmap.mmap, length: int) -> list[bool]:
+    """Return Linux page-residency bits for a writable mmap."""
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+        mincore = libc.mincore
+    except AttributeError:
+        pytest.skip("mincore is unavailable")
+
+    page_count = (length + PAGE_SIZE - 1) // PAGE_SIZE
+    mincore.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_size_t,
+        ctypes.POINTER(ctypes.c_ubyte),
+    ]
+    mincore.restype = ctypes.c_int
+    vector = (ctypes.c_ubyte * page_count)()
+    address = ctypes.addressof(ctypes.c_ubyte.from_buffer(mmap_obj))
+    result = mincore(ctypes.c_void_p(address), length, vector)
+    if result != 0:
+        raise OSError(ctypes.get_errno())
+    return [bool(value & 1) for value in vector]
 
 
 @contextlib.contextmanager
@@ -432,66 +456,93 @@ def test_madvise_success_selects_madvise_population(iid, monkeypatch):
     with _region(iid, num_blocks=num_blocks, num_workers=num_workers, rank=1):
         # 1 probe (PAGESIZE) + N populate calls (one per block per worker column).
         expected_populate = num_blocks  # ranked path: one call per block
-        assert len(madvise_calls) == 1 + expected_populate, (
-            f"expected 1 probe + {expected_populate} populate calls, "
-            f"got {len(madvise_calls)}: {madvise_calls}"
-        )
-        # Probe is the first call at offset 0, length PAGESIZE.
-        assert madvise_calls[0] == (0, mmap.PAGESIZE, madvise_calls[0][2])
+        mmap_id = madvise_calls[0][2]
+        assert madvise_calls == [
+            (0, mmap.PAGESIZE, mmap_id),
+            (mmap.PAGESIZE, mmap.PAGESIZE, mmap_id),
+            (3 * mmap.PAGESIZE, mmap.PAGESIZE, mmap_id),
+            (5 * mmap.PAGESIZE, mmap.PAGESIZE, mmap_id),
+        ]
+        assert len(madvise_calls) == 1 + expected_populate
         assert fallback_calls == [], (
             "native-path constructor must not invoke the fallback helper"
         )
 
 
-def test_madvise_einval_smoke(iid, monkeypatch):
-    """Smoke: when the probe raises EINVAL the constructor still completes
-    and reaches the fallback path.  We do not assert on touched bytes here —
-    see test_fallback_populate_write_preserves_existing_bytes for that."""
+def test_madvise_einval_selects_fallback_for_ranked_region(iid, monkeypatch):
+    """An EINVAL probe must select fallback for every ranked block."""
     from vllm.v1.kv_offload.cpu import shared_offload_region as sor
 
-    monkeypatch.setattr(
-        sor,
-        "_madvise_populate_write",
-        lambda mm, off, ln: (_ for _ in ()).throw(
-            OSError(errno.EINVAL, "simulated unsupported kernel")
-        ),
-    )
-    with _region(iid, num_blocks=3, num_workers=2, rank=1) as r:
-        # Constructor completed; region is usable.
-        assert r.mmap_obj is not None
-        assert r.total_size_bytes == 3 * 2 * PAGE_SIZE
+    fallback_calls: list[tuple[int, int]] = []
+    real_fallback = sor._fallback_populate_write
+
+    def _raise_einval(mm, off, ln):
+        raise OSError(errno.EINVAL, "simulated unsupported kernel")
+
+    def _spy_fallback(mm, off, ln):
+        fallback_calls.append((off, ln))
+        return real_fallback(mm, off, ln)
+
+    monkeypatch.setattr(sor, "_madvise_populate_write", _raise_einval)
+    monkeypatch.setattr(sor, "_fallback_populate_write", _spy_fallback)
+
+    with _region(iid, num_blocks=3, num_workers=2, rank=1):
+        assert fallback_calls == [
+            (mmap.PAGESIZE, mmap.PAGESIZE),
+            (3 * mmap.PAGESIZE, mmap.PAGESIZE),
+            (5 * mmap.PAGESIZE, mmap.PAGESIZE),
+        ]
 
 
-def test_fallback_populate_write_preserves_existing_bytes(iid, monkeypatch):
-    """Direct unit test for _fallback_populate_write: it must not alter any
-    existing byte in the mmap.  A peer worker may have written KV data into
-    the same shared mmap before this fallback runs; an unconditional `= 0`
-    would silently corrupt that data.  The `|= 0` write is a no-op that still
-    triggers the page fault."""
+def test_madvise_einval_selects_fallback_for_unranked_region(iid, monkeypatch):
+    """An EINVAL probe must select fallback for the whole unranked region."""
+    from vllm.v1.kv_offload.cpu import shared_offload_region as sor
+
+    fallback_calls: list[tuple[int, int]] = []
+    real_fallback = sor._fallback_populate_write
+
+    def _raise_einval(mm, off, ln):
+        raise OSError(errno.EINVAL, "simulated unsupported kernel")
+
+    def _spy_fallback(mm, off, ln):
+        fallback_calls.append((off, ln))
+        return real_fallback(mm, off, ln)
+
+    monkeypatch.setattr(sor, "_madvise_populate_write", _raise_einval)
+    monkeypatch.setattr(sor, "_fallback_populate_write", _spy_fallback)
+
+    with _region(iid, num_blocks=3, num_workers=2, rank=None):
+        assert fallback_calls == [(0, 6 * mmap.PAGESIZE)]
+
+
+def test_fallback_populate_write_preserves_bytes_and_faults_pages():
+    """Fallback preserves existing bytes and touches every target page."""
     from vllm.v1.kv_offload.cpu import shared_offload_region as sor
 
     size = 3 * mmap.PAGESIZE
-    with _region(iid, num_blocks=size // PAGE_SIZE, num_workers=1, rank=0) as r:
-        # Plant non-zero sentinels at the head of each page.
-        mv = memoryview(r.mmap_obj)
-        sentinels = (0xAB, 0xCD, 0xEF)
-        try:
-            for page, sentinel in enumerate(sentinels):
-                mv[page * mmap.PAGESIZE] = sentinel
-        finally:
-            del mv
+    if not hasattr(mmap, "MADV_DONTNEED"):
+        pytest.skip("MADV_DONTNEED is unavailable")
 
-        sor._fallback_populate_write(r.mmap_obj, 0, size)
+    mmap_obj = mmap.mmap(
+        -1,
+        size,
+        flags=mmap.MAP_SHARED,
+        prot=mmap.PROT_READ | mmap.PROT_WRITE,
+    )
+    try:
+        mmap_obj.madvise(mmap.MADV_DONTNEED, 0, size)
+        if any(_page_residency(mmap_obj, size)):
+            pytest.skip("kernel did not discard anonymous mmap pages")
 
-        mv = memoryview(r.mmap_obj)
-        try:
-            for page, sentinel in enumerate(sentinels):
-                assert mv[page * mmap.PAGESIZE] == sentinel, (
-                    f"page {page} head mutated: "
-                    f"got {mv[page * mmap.PAGESIZE]:#x}, want {sentinel:#x}"
-                )
-        finally:
-            del mv
+        mmap_obj[0] = 0xAB
+        assert _page_residency(mmap_obj, size) == [True, False, False]
+
+        sor._fallback_populate_write(mmap_obj, 0, size)
+
+        assert _page_residency(mmap_obj, size) == [True, True, True]
+        assert mmap_obj[0] == 0xAB
+    finally:
+        mmap_obj.close()
 
 
 def test_madvise_unexpected_oserror_propagates(iid, monkeypatch):

--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
@@ -477,6 +477,35 @@ def test_madvise_einval_falls_back_for_unranked_region(iid, monkeypatch):
         _cleanup_file(region.mmap_path)
 
 
+def test_madvise_success_selects_madvise_population(iid, monkeypatch):
+    """A successful probe should keep using MADV_POPULATE_WRITE."""
+    real_mmap = mmap.mmap
+
+    class TrackingMmap(real_mmap):
+
+        madvise_calls = []
+
+        def __new__(cls, *args, **kwargs):
+            obj = super().__new__(cls, *args, **kwargs)
+            obj[:] = b"\xff" * len(obj)
+            return obj
+
+        def madvise(self, *args):
+            self.madvise_calls.append(args)
+
+    monkeypatch.setattr(mmap, "mmap", TrackingMmap)
+
+    with _region(iid, num_blocks=3, num_workers=2, rank=1) as r:
+        assert isinstance(r.mmap_obj, TrackingMmap)
+        assert TrackingMmap.madvise_calls == [
+            (23, 0, PAGE_SIZE),
+            (23, PAGE_SIZE, PAGE_SIZE),
+            (23, 3 * PAGE_SIZE, PAGE_SIZE),
+            (23, 5 * PAGE_SIZE, PAGE_SIZE),
+        ]
+        assert r.mmap_obj[PAGE_SIZE] == 0xff
+
+
 def test_madvise_unexpected_oserror_propagates(iid, monkeypatch):
     """Only unsupported MADV_POPULATE_WRITE should use the fallback."""
     real_mmap = mmap.mmap

--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
@@ -413,26 +413,29 @@ def test_madvise_einval_falls_back_for_ranked_region(iid, monkeypatch):
     class EINVALMmap(real_mmap):
 
         madvise_calls = []
-        written_offsets = []
+
+        def __new__(cls, *args, **kwargs):
+            obj = super().__new__(cls, *args, **kwargs)
+            obj[:] = b"\xff" * len(obj)
+            return obj
 
         def madvise(self, *args):
             self.madvise_calls.append(args)
             raise OSError(errno.EINVAL, "Invalid argument")
 
-        def __setitem__(self, key, value):
-            self.written_offsets.append(key.start)
-            super().__setitem__(key, value)
-
     monkeypatch.setattr(mmap, "mmap", EINVALMmap)
 
     with _region(iid, num_blocks=3, num_workers=2, rank=1) as r:
         assert isinstance(r.mmap_obj, EINVALMmap)
-        assert len(EINVALMmap.madvise_calls) == 3
-        assert EINVALMmap.written_offsets == [
+        assert len(EINVALMmap.madvise_calls) == 1
+        touched_offsets = [
             PAGE_SIZE,
             3 * PAGE_SIZE,
             5 * PAGE_SIZE,
         ]
+        assert [r.mmap_obj[offset] for offset in touched_offsets] == [0, 0, 0]
+        assert r.mmap_obj[0] == 0xff
+        assert r.mmap_obj[PAGE_SIZE + 1] == 0xff
 
 
 def test_madvise_einval_falls_back_for_unranked_region(iid, monkeypatch):
@@ -442,15 +445,15 @@ def test_madvise_einval_falls_back_for_unranked_region(iid, monkeypatch):
     class EINVALMmap(real_mmap):
 
         madvise_calls = []
-        written_offsets = []
+
+        def __new__(cls, *args, **kwargs):
+            obj = super().__new__(cls, *args, **kwargs)
+            obj[:] = b"\xff" * len(obj)
+            return obj
 
         def madvise(self, *args):
             self.madvise_calls.append(args)
             raise OSError(errno.EINVAL, "Invalid argument")
-
-        def __setitem__(self, key, value):
-            self.written_offsets.append(key.start)
-            super().__setitem__(key, value)
 
     monkeypatch.setattr(mmap, "mmap", EINVALMmap)
 
@@ -464,9 +467,11 @@ def test_madvise_einval_falls_back_for_unranked_region(iid, monkeypatch):
     try:
         assert isinstance(region.mmap_obj, EINVALMmap)
         assert len(EINVALMmap.madvise_calls) == 1
-        assert EINVALMmap.written_offsets == [
+        touched_offsets = [
             page * PAGE_SIZE for page in range(6)
         ]
+        assert [region.mmap_obj[offset] for offset in touched_offsets] == [0] * 6
+        assert region.mmap_obj[1] == 0xff
     finally:
         region.cleanup()
         _cleanup_file(region.mmap_path)

--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
@@ -413,16 +413,26 @@ def test_madvise_einval_falls_back_for_ranked_region(iid, monkeypatch):
     class EINVALMmap(real_mmap):
 
         madvise_calls = []
+        written_offsets = []
 
         def madvise(self, *args):
             self.madvise_calls.append(args)
             raise OSError(errno.EINVAL, "Invalid argument")
+
+        def __setitem__(self, key, value):
+            self.written_offsets.append(key.start)
+            super().__setitem__(key, value)
 
     monkeypatch.setattr(mmap, "mmap", EINVALMmap)
 
     with _region(iid, num_blocks=3, num_workers=2, rank=1) as r:
         assert isinstance(r.mmap_obj, EINVALMmap)
         assert len(EINVALMmap.madvise_calls) == 3
+        assert EINVALMmap.written_offsets == [
+            PAGE_SIZE,
+            3 * PAGE_SIZE,
+            5 * PAGE_SIZE,
+        ]
 
 
 def test_madvise_einval_falls_back_for_unranked_region(iid, monkeypatch):
@@ -432,10 +442,15 @@ def test_madvise_einval_falls_back_for_unranked_region(iid, monkeypatch):
     class EINVALMmap(real_mmap):
 
         madvise_calls = []
+        written_offsets = []
 
         def madvise(self, *args):
             self.madvise_calls.append(args)
             raise OSError(errno.EINVAL, "Invalid argument")
+
+        def __setitem__(self, key, value):
+            self.written_offsets.append(key.start)
+            super().__setitem__(key, value)
 
     monkeypatch.setattr(mmap, "mmap", EINVALMmap)
 
@@ -449,6 +464,9 @@ def test_madvise_einval_falls_back_for_unranked_region(iid, monkeypatch):
     try:
         assert isinstance(region.mmap_obj, EINVALMmap)
         assert len(EINVALMmap.madvise_calls) == 1
+        assert EINVALMmap.written_offsets == [
+            page * PAGE_SIZE for page in range(6)
+        ]
     finally:
         region.cleanup()
         _cleanup_file(region.mmap_path)

--- a/vllm/v1/kv_offload/cpu/shared_offload_region.py
+++ b/vllm/v1/kv_offload/cpu/shared_offload_region.py
@@ -51,7 +51,7 @@ def _get_populate_write_fn(
 ) -> Callable[[mmap.mmap, int, int], None]:
     """Select the pre-faulting method once for this mmap."""
     try:
-        mmap_obj.madvise(_MADV_POPULATE_WRITE, 0, mmap.PAGESIZE)
+        _madvise_populate_write(mmap_obj, 0, mmap.PAGESIZE)
     except OSError as e:
         if e.errno != errno.EINVAL:
             raise

--- a/vllm/v1/kv_offload/cpu/shared_offload_region.py
+++ b/vllm/v1/kv_offload/cpu/shared_offload_region.py
@@ -4,7 +4,9 @@ import errno
 import mmap
 import os
 import time
+from collections.abc import Callable
 
+import numpy as np
 import torch
 
 from vllm.distributed.device_communicators.shm_broadcast import (
@@ -32,18 +34,30 @@ def _wait_for_file_size(fd: int, expected_size: int, timeout: float = 30.0) -> N
         time.sleep(0.005)
 
 
-def _populate_write(mmap_obj: mmap.mmap, offset: int, length: int) -> None:
-    """Pre-fault writable mmap pages, falling back for older Linux kernels."""
+def _madvise_populate_write(mmap_obj: mmap.mmap, offset: int, length: int) -> None:
+    mmap_obj.madvise(_MADV_POPULATE_WRITE, offset, length)
+
+
+def _fallback_populate_write(mmap_obj: mmap.mmap, offset: int, length: int) -> None:
+    arr = np.frombuffer(mmap_obj, dtype=np.uint8)
+    arr[offset : offset + length : mmap.PAGESIZE] = 0
+
+
+def _get_populate_write_fn(
+    mmap_obj: mmap.mmap,
+) -> Callable[[mmap.mmap, int, int], None]:
+    """Select the pre-faulting method once for this mmap."""
     try:
-        mmap_obj.madvise(_MADV_POPULATE_WRITE, offset, length)
-        return
+        mmap_obj.madvise(_MADV_POPULATE_WRITE, 0, mmap.PAGESIZE)
     except OSError as e:
         if e.errno != errno.EINVAL:
             raise
-
-    end = offset + length
-    for page_offset in range(offset, end, mmap.PAGESIZE):
-        mmap_obj[page_offset : page_offset + 1] = b"\0"
+        logger.warning(
+            "MADV_POPULATE_WRITE is not supported; falling back to per-page "
+            "writes for mmap pre-population. Startup may be slower."
+        )
+        return _fallback_populate_write
+    return _madvise_populate_write
 
 
 class SharedOffloadRegion:
@@ -122,6 +136,8 @@ class SharedOffloadRegion:
             prot=mmap.PROT_READ | mmap.PROT_WRITE,
         )
 
+        populate_write_fn = _get_populate_write_fn(self.mmap_obj)
+
         if rank is not None:
             # Populate only this worker's pages (one slot per block row).
             worker_offset = rank * cpu_page_size
@@ -132,7 +148,7 @@ class SharedOffloadRegion:
                 aligned_offset = (raw_offset // page_size) * page_size
                 end = raw_offset + cpu_page_size
                 aligned_length = end - aligned_offset
-                _populate_write(self.mmap_obj, aligned_offset, aligned_length)
+                populate_write_fn(self.mmap_obj, aligned_offset, aligned_length)
             logger.debug(
                 "MADV_POPULATE_WRITE loop: %d blocks in %.3f s",
                 num_blocks,
@@ -141,7 +157,7 @@ class SharedOffloadRegion:
         else:
             # No rank — populate the entire shared region in one call.
             _t0 = time.perf_counter()
-            _populate_write(self.mmap_obj, 0, self.total_size_bytes)
+            populate_write_fn(self.mmap_obj, 0, self.total_size_bytes)
             logger.debug(
                 "MADV_POPULATE_WRITE entire region: %.3f s", time.perf_counter() - _t0
             )

--- a/vllm/v1/kv_offload/cpu/shared_offload_region.py
+++ b/vllm/v1/kv_offload/cpu/shared_offload_region.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import errno
 import mmap
 import os
 import time
@@ -14,6 +15,9 @@ from vllm.platforms import current_platform
 
 logger = init_logger(__name__)
 
+# MADV_POPULATE_WRITE was added in Linux 5.14 (value 23).
+_MADV_POPULATE_WRITE = getattr(mmap, "MADV_POPULATE_WRITE", 23)
+
 
 def _wait_for_file_size(fd: int, expected_size: int, timeout: float = 30.0) -> None:
     """Spin-wait until the file reaches expected_size (creator truncated it)."""
@@ -26,6 +30,20 @@ def _wait_for_file_size(fd: int, expected_size: int, timeout: float = 30.0) -> N
                 f"Timed out waiting for mmap file to reach {expected_size} bytes"
             )
         time.sleep(0.005)
+
+
+def _populate_write(mmap_obj: mmap.mmap, offset: int, length: int) -> None:
+    """Pre-fault writable mmap pages, falling back for older Linux kernels."""
+    try:
+        mmap_obj.madvise(_MADV_POPULATE_WRITE, offset, length)
+        return
+    except OSError as e:
+        if e.errno != errno.EINVAL:
+            raise
+
+    end = offset + length
+    for page_offset in range(offset, end, mmap.PAGESIZE):
+        mmap_obj[page_offset : page_offset + 1] = b"\0"
 
 
 class SharedOffloadRegion:
@@ -104,8 +122,6 @@ class SharedOffloadRegion:
             prot=mmap.PROT_READ | mmap.PROT_WRITE,
         )
 
-        # MADV_POPULATE_WRITE was added in Linux 5.14 (value 23).
-        _MADV_POPULATE_WRITE = getattr(mmap, "MADV_POPULATE_WRITE", 23)
         if rank is not None:
             # Populate only this worker's pages (one slot per block row).
             worker_offset = rank * cpu_page_size
@@ -116,9 +132,7 @@ class SharedOffloadRegion:
                 aligned_offset = (raw_offset // page_size) * page_size
                 end = raw_offset + cpu_page_size
                 aligned_length = end - aligned_offset
-                self.mmap_obj.madvise(
-                    _MADV_POPULATE_WRITE, aligned_offset, aligned_length
-                )
+                _populate_write(self.mmap_obj, aligned_offset, aligned_length)
             logger.debug(
                 "MADV_POPULATE_WRITE loop: %d blocks in %.3f s",
                 num_blocks,
@@ -127,7 +141,7 @@ class SharedOffloadRegion:
         else:
             # No rank — populate the entire shared region in one call.
             _t0 = time.perf_counter()
-            self.mmap_obj.madvise(_MADV_POPULATE_WRITE, 0, self.total_size_bytes)
+            _populate_write(self.mmap_obj, 0, self.total_size_bytes)
             logger.debug(
                 "MADV_POPULATE_WRITE entire region: %.3f s", time.perf_counter() - _t0
             )

--- a/vllm/v1/kv_offload/cpu/shared_offload_region.py
+++ b/vllm/v1/kv_offload/cpu/shared_offload_region.py
@@ -39,8 +39,11 @@ def _madvise_populate_write(mmap_obj: mmap.mmap, offset: int, length: int) -> No
 
 
 def _fallback_populate_write(mmap_obj: mmap.mmap, offset: int, length: int) -> None:
+    # Touch one byte per page via a read-modify-write so existing bytes are
+    # preserved — a peer worker may have already written KV data into this
+    # shared mmap by the time we run on a kernel without MADV_POPULATE_WRITE.
     arr = np.frombuffer(mmap_obj, dtype=np.uint8)
-    arr[offset : offset + length : mmap.PAGESIZE] = 0
+    arr[offset : offset + length : mmap.PAGESIZE] |= 0
 
 
 def _get_populate_write_fn(


### PR DESCRIPTION
Fixes #44888

## Why this PR

`SharedOffloadRegion.__init__` unconditionally issues `madvise(MADV_POPULATE_WRITE, …)` on its shared mmap. On Linux < 5.14 (RHEL 8 ships 4.18) the syscall returns `EINVAL`, so any vLLM startup that touches `TieringOffloadingSpec` aborts before KV offloading can register.

This PR probes the advice once after mmap creation and falls back to a no-mutation NumPy read-modify-write (`|= 0`) that triggers the same page fault without altering any existing bytes. Other `OSError`s (e.g. `EIO`) propagate.

## Changes

`vllm/v1/kv_offload/cpu/shared_offload_region.py` (+32 / -6):

- Module-level helpers `_madvise_populate_write` / `_fallback_populate_write` are the test seams (`mmap.mmap` is an immutable C type on Python 3.12+ and cannot be subclassed/patched).
- `_get_populate_write_fn(mmap_obj)` probes once via `_madvise_populate_write(mmap_obj, 0, PAGESIZE)`. On `OSError(EINVAL)`, logs once and returns `_fallback_populate_write` (which uses `arr[::PAGESIZE] |= 0` — no byte mutation, still faults in the page). Other `OSError`s propagate.
- The ranked and unranked call sites in `__init__` now invoke the returned helper instead of `mmap_obj.madvise(...)` directly. Behaviour on kernels ≥ 5.14 is unchanged.

`tests/v1/kv_offload/cpu/test_shared_offload_region.py` (+107 / -6):

- `test_madvise_success_selects_madvise_population` — spies on both helpers; asserts 1 probe + N populate calls, fallback 0 times.
- `test_madvise_einval_smoke` — constructor completes when the probe raises `EINVAL`.
- `test_fallback_populate_write_preserves_existing_bytes` — plants non-zero sentinels at each page head, drives `_fallback_populate_write` directly, asserts the sentinels survive. This is the test that distinguishes `= 0` from `|= 0`.
- `test_madvise_unexpected_oserror_propagates` — non-`EINVAL` `OSError`s propagate out of `__init__`.

`#44913` (guygir, OPEN since 2026-06) targets the same bug but was stalled on pre-commit / CI failures caused by `mmap.mmap` subclassing. The three commits on top of its merged base (`5031c2e`) — `990b8d6` (Python 3.12+ test rewrite), `10f7bfb` (`|= 0` per @orozery's review), `3233a6f` (route the probe through `_madvise_populate_write` so the module-level test seam actually intercepts it) — address those root causes.

## Test results

The submitter ran `tests/v1/kv_offload/cpu/test_shared_offload_region.py -v` on two kernel versions:

- **Linux 5.14+** (development host, kernel accepts `MADV_POPULATE_WRITE`): 32 passed in 16.11s. Confirms the probe succeeds and the native path is selected.
- **Linux 5.4.0-155-generic** (Ubuntu, kernel rejects `MADV_POPULATE_WRITE` with `EINVAL`): 32 passed in 26.94s. Confirms end-to-end that the probe routes through `_madvise_populate_write`, the kernel returns `EINVAL`, and the `|= 0` fallback path executes without altering existing bytes.

```bash
pre-commit run --files \
    vllm/v1/kv_offload/cpu/shared_offload_region.py \
    tests/v1/kv_offload/cpu/test_shared_offload_region.py
# 12 hooks PASSED
```

No model-evaluation results are reported because this change does not affect model output, accuracy, or serving throughput — it only adds a fallback for the mmap pre-fault on kernels that lack the advice.

## AI assistance

This PR was prepared with the assistance of Claude (Anthropic). All code changes were reviewed line-by-line by the human submitter and the relevant tests were run on a Linux runner before submission, per the project's contribution policy.