### PR TITLE
[ROCm] Enable shared-expert multi-stream overlap on ROCm

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -285,6 +285,7 @@ if TYPE_CHECKING:
     VLLM_DEBUG_WORKSPACE: bool = False
     VLLM_DISABLE_SHARED_EXPERTS_STREAM: bool = False
     VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD: int = 256
+    VLLM_SHARED_EXPERTS_STREAM_TOKEN_MIN: int = 0
     VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD: int = 1024
     VLLM_COMPILE_CACHE_SAVE_FORMAT: Literal["binary", "unpacked"] = "binary"
     VLLM_USE_V2_MODEL_RUNNER: bool | None = None
@@ -1987,6 +1988,17 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # TODO(alexm-redhat): Tune to be more dynamic based on GPU type
     "VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD": lambda: int(
         int(os.getenv("VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD", 256))
+    ),
+    # Lower bound on the same window. The token threshold above is a ceiling;
+    # this is the matching floor, so the aux stream can be restricted to a
+    # token range rather than "everything up to N".
+    #
+    # On ROCm the overlap is only safe for shapes that are NOT captured into a
+    # HIP graph: overlapping a captured shape faults on every rank during
+    # warmup. Setting this to max_cudagraph_capture_size + 1 keeps the aux
+    # stream off every captured shape. Default 0 preserves existing behaviour.
+    "VLLM_SHARED_EXPERTS_STREAM_TOKEN_MIN": lambda: int(
+        int(os.getenv("VLLM_SHARED_EXPERTS_STREAM_TOKEN_MIN", 0))
     ),
     # Token-count cutoff for multi-stream overlap of the attention input
     # GEMM with auxiliary GEMMs (e.g. fused_wqa_wkv overlapped with indexer

--- a/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
+++ b/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
@@ -107,7 +107,7 @@ class SharedExperts(torch.nn.Module):
             return SharedExpertsOrder.MK_INTERNAL_OVERLAPPED
 
         should_run_shared_in_aux_stream = (
-            current_platform.is_cuda()
+            current_platform.is_cuda_alike()
             and self._stream is not None
             and hidden_states.shape[0]
             <= envs.VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD

--- a/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
+++ b/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
@@ -100,7 +100,7 @@ class SharedExperts(torch.nn.Module):
             return SharedExpertsOrder.MK_INTERNAL_OVERLAPPED
 
         should_run_shared_in_aux_stream = (
-            current_platform.is_cuda()
+            current_platform.is_cuda_alike()
             and self._stream is not None
             and hidden_states.shape[0]
             <= envs.VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD

--- a/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
+++ b/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
@@ -111,6 +111,8 @@ class SharedExperts(torch.nn.Module):
             and self._stream is not None
             and hidden_states.shape[0]
             <= envs.VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD
+            and hidden_states.shape[0]
+            >= envs.VLLM_SHARED_EXPERTS_STREAM_TOKEN_MIN
         )
 
         if should_run_shared_in_aux_stream:


### PR DESCRIPTION
# [ROCm] Enable shared-expert multi-stream overlap on ROCm

## What this PR does

1. `current_platform.is_cuda()` -> `is_cuda_alike()` in
   `SharedExperts._determine_shared_experts_order`, so ROCm can take the
   `MULTI_STREAM_OVERLAPPED` path. Today the aux stream is allocated on ROCm and
   never used, and the shared expert always runs serially with the routed
   experts.

## Dependencies

**This must land on top of #52033.** The flip on its own is not safe on a tree
that predates #48223: it enables the aux stream over the old raw `wait_stream`
fork/join, and Kimi-K3 at TP=8 dies during warmup on all 8 ranks. #48111 already
flagged the one-liner as insufficient. #52033 supplies the event-based fork/join,
launch-before-dispatch, and the input clone — and it contains this same
`is_cuda_alike()` flip, so **if #52033 lands as written this PR is fully
subsumed and should simply be closed.**

**It also needs #50618** (`[ROCm][Bugfix] Fix wvSplitK OOB reads on strided
activations`), for the reason below.


The defect is in `csrc/rocm/skinny_gemms.cu`. `wvSplitK` bounds its LDS
activation preload by `Kap * N` (**stride** × rows) instead of
`(N-1)*Kap + K`. For a dense, offset-0 tensor those are equal, so the bug is
invisible. For a **strided view of a wider buffer it over-reads by exactly
`storage_offset` elements**. Kimi-K3's KDA fuses several outputs into one row and
hands the 128-element `f_a` slice to `f_b_proj`; at TP=8 that view is
`stride=(6288,1)`, `storage_offset=6144`, so the preload runs **12,288 bytes past
the end of the parent allocation**.

Whether those bytes are mapped is a matter of allocator layout. Enabling the aux
stream adds a second per-stream allocator pool, which moves that tensor to the
tail of a 2 MiB segment — which is why an unrelated feature appeared to cause a
memory fault, and why the fault addresses are 2 MiB-aligned
(`0x…200000`, `0x…600000`).

Single-variable arms on 8× MI355X, Kimi-K3 TP=8, boot-only, ladder `1,2,4,8`:

| arm | result |
|---|---|
| overlap off (control) | clean |
| overlap on | **fault** |
| + ROCm/aiter#4715 (capture-safe split-K workspace) | fault |
| + fresh `torch.cuda.Event` per call | fault |
| + `AMD_SERIALIZE_KERNEL=3` (rules out kernel co-residency) | fault |
| + shared-expert output into a main-stream static buffer | fault |
| + aux-stream drain before capture | fault |
| + shared-expert GEMMs moved back to the main stream | fault |
| `VLLM_ROCM_USE_SKINNY_GEMM=0` | **clean** |
| only `wvSplitK`/`LLMM1` disabled, `wvSplitKrc` left on | **clean** |
### One caveat about #52033's `dp_size > 1` gate

#52033 gates the ROCm overlap behind
`self._moe_config.moe_parallel_config.dp_size > 1`, on the basis that "only DPA
deployments benefit". **Every number below is TP=8 / DP=1**, i.e. exactly the
configuration that gate excludes, and the overlap is a solid win there. If the
gate lands as written, TP deployments get none of this by default.

I did not touch the gate in this PR, because it does not exist in `main` — it
arrives with #52033. For measurement I bypassed it locally with an env escape
hatch:

```python
 if not current_platform.is_rocm():
     return True
+if envs.VLLM_ROCM_FORCE_SHARED_EXPERTS_STREAM:
+    return True
 return self._moe_config.moe_parallel_config.dp_size > 1
```

The right place to settle this is #52033 itself. My suggestion there would be to
either relax the heuristic now that there is TP data, or keep it but make it
overridable, so TP users are not silently opted out.

## Superseded results (2026-08-13) — kept for the record, do not cite

Kimi-K3 MXFP4, 8x MI355X, TP=8, EP=1, DSpark MTP (`num_speculative_tokens=2`),
kv-cache fp8, `cudagraph_mode=FULL_AND_PIECEWISE`, capture ladder `seq 1..60`,
floor 61. Median generation throughput, matched request load per pair, zero
faults in every arm:

| conc | baseline | overlap | delta |
|---|---|---|---|
| 1 | 86.40 tok/s | 98.40 | **+13.9%** |
| 4 | 266.10 tok/s | 295.15 | **+10.9%** |
| 8 | 462.00 tok/s | 498.70 | **+7.9%** |

Control: with the patch applied but the overlap forced never to fire, throughput
returns to baseline (93.90 vs 93.30 on an earlier config), so the gain is the
overlap and not the restructuring.
