### PR TITLE
[Bugfix][Frontend] Return 400 for invalid PyNvVideoCodec video input

### DIFF
--- a/tests/multimodal/media/test_video.py
+++ b/tests/multimodal/media/test_video.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import io
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import numpy as np
 import numpy.typing as npt
@@ -19,6 +21,7 @@ from vllm.multimodal.media import ImageMediaIO, VideoMediaIO
 from vllm.multimodal.video import (
     PYNVVIDEOCODEC_VIDEO_BACKEND,
     VIDEO_LOADER_REGISTRY,
+    PyNvVideoCodecVideoBackend,
     VideoLoader,
 )
 
@@ -361,6 +364,58 @@ def test_load_base64_jpeg_raises_on_zero_num_frames():
 
     with pytest.raises(ValueError, match="num_frames must be greater than 0 or -1"):
         videoio.load_base64("video/jpeg", data)
+
+
+def test_pynvvideocodec_invalid_video_raises_value_error(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class FakePyNvVCException(Exception):
+        pass
+
+    fake_nvc = SimpleNamespace(PyNvVCException=FakePyNvVCException)
+    monkeypatch.setitem(sys.modules, "PyNvVideoCodec", fake_nvc)
+
+    def raise_invalid_video(cls, file_path, nvc):
+        raise FakePyNvVCException("Invalid data found when processing input")
+
+    monkeypatch.setattr(
+        PyNvVideoCodecVideoBackend,
+        "_read_source_metadata",
+        classmethod(raise_invalid_video),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"^Invalid or unsupported video file\.$",
+    ) as exc_info:
+        PyNvVideoCodecVideoBackend.decode_frames_pynvvideocodec(b"not-a-video", None)
+
+    assert isinstance(exc_info.value.__cause__, FakePyNvVCException)
+
+
+def test_pynvvideocodec_unrelated_error_propagates(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class FakePyNvVCException(Exception):
+        pass
+
+    fake_nvc = SimpleNamespace(PyNvVCException=FakePyNvVCException)
+    monkeypatch.setitem(sys.modules, "PyNvVideoCodec", fake_nvc)
+    original_error = RuntimeError("GPU decoder unavailable")
+
+    def raise_unrelated_error(cls, file_path, nvc):
+        raise original_error
+
+    monkeypatch.setattr(
+        PyNvVideoCodecVideoBackend,
+        "_read_source_metadata",
+        classmethod(raise_unrelated_error),
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        PyNvVideoCodecVideoBackend.decode_frames_pynvvideocodec(b"video", None)
+
+    assert exc_info.value is original_error
 
 
 # ---------------------------------------------------------------------------

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -836,7 +836,10 @@ class PyNvVideoCodecVideoBackendMixin:
             with os.fdopen(temp_fd, "wb") as temp_file:
                 temp_file.write(data)
 
-            gpu_source = cls._read_source_metadata(temp_path, nvc)
+            try:
+                gpu_source = cls._read_source_metadata(temp_path, nvc)
+            except nvc.PyNvVCException as exc:
+                raise ValueError("Invalid or unsupported video file.") from exc
             _check_frame_pixel_limit(gpu_source.width, gpu_source.height)
             source = cls._prepare_source(gpu_source.source)
             frame_idx = cls.compute_frames_index_to_sample(


### PR DESCRIPTION
## Summary
- translate `PyNvVideoCodec.PyNvVCException` raised while opening malformed video into a sanitized `ValueError`
- rely on vLLM's existing `ValueError` handler to return `BadRequestError`/HTTP 400 instead of HTTP 500
- preserve the native exception as the cause and leave unrelated decoder exceptions unchanged

## Root cause
A malformed user-supplied video reaches `PyNvVideoCodec.SimpleDecoder` during multimodal request preprocessing. The native `PyNvVCException` previously escaped the media boundary, so the generic API exception handler classified it as `InternalServerError`.

The same request returned the same HTTP 500 response through both the public NIM endpoint and the internal vLLM endpoint, and the traceback remained entirely in `vllm/multimodal/video.py` / PyNvVideoCodec before model inference.

## Test plan
- [x] regression test fails before the patch because native `PyNvVCException` escapes
- [x] `pytest -q tests/multimodal/media/test_video.py` — 35 passed
- [x] Ruff lint and format checks
- [x] typos check
- [x] B200 end-to-end with vLLM 0.26.0 and PyNvVideoCodec backend:
  - corrupt MKV: HTTP 500 before, HTTP 400 after
  - valid MP4: HTTP 200
  - valid MKV: HTTP 200
  - four concurrent valid MP4 requests: all HTTP 200
  - health and basic text chat remain HTTP 200

## AI assistance disclosure
Cursor Agent (GPT-5.6 Sol) assisted with source exploration, test drafting, and implementation. I reviewed the changed lines and validated the behavior with focused unit tests and an end-to-end B200 reproduction.