### PR TITLE
[Bugfix][Frontend] Return 400 for invalid PyNvVideoCodec video input

### DIFF
--- a/tests/multimodal/media/test_video.py
+++ b/tests/multimodal/media/test_video.py
@@ -373,11 +373,17 @@ def test_pynvvideocodec_invalid_video_raises_value_error(
     class FakePyNvVCException(Exception):
         pass
 
-    fake_nvc = SimpleNamespace(PyNvVCException=FakePyNvVCException)
+    class FakePyNvVCExceptionUnsupported(Exception):
+        pass
+
+    fake_nvc = SimpleNamespace(
+        PyNvVCException=FakePyNvVCException,
+        PyNvVCExceptionUnsupported=FakePyNvVCExceptionUnsupported,
+    )
     monkeypatch.setitem(sys.modules, "PyNvVideoCodec", fake_nvc)
 
     def raise_invalid_video(cls, file_path, nvc):
-        raise FakePyNvVCException("Invalid data found when processing input")
+        raise FakePyNvVCExceptionUnsupported("Invalid data found when processing input")
 
     monkeypatch.setattr(
         PyNvVideoCodecVideoBackend,
@@ -394,7 +400,7 @@ def test_pynvvideocodec_invalid_video_raises_value_error(
         ).read_bytes()
         PyNvVideoCodecVideoBackend.decode_frames_pynvvideocodec(corrupted_video, None)
 
-    assert isinstance(exc_info.value.__cause__, FakePyNvVCException)
+    assert isinstance(exc_info.value.__cause__, FakePyNvVCExceptionUnsupported)
 
 
 def test_pynvvideocodec_unrelated_error_propagates(

--- a/tests/multimodal/media/test_video.py
+++ b/tests/multimodal/media/test_video.py
@@ -388,7 +388,10 @@ def test_pynvvideocodec_invalid_video_raises_value_error(
         ValueError,
         match=r"^Invalid or unsupported video file\.$",
     ) as exc_info:
-        PyNvVideoCodecVideoBackend.decode_frames_pynvvideocodec(b"not-a-video", None)
+        corrupted_video = (
+            Path(__file__).parent.parent / "assets" / "corrupted.mp4"
+        ).read_bytes()
+        PyNvVideoCodecVideoBackend.decode_frames_pynvvideocodec(corrupted_video, None)
 
     assert isinstance(exc_info.value.__cause__, FakePyNvVCException)
 

--- a/tests/multimodal/media/test_video.py
+++ b/tests/multimodal/media/test_video.py
@@ -367,42 +367,6 @@ def test_load_base64_jpeg_raises_on_zero_num_frames():
         videoio.load_base64("video/jpeg", data)
 
 
-def test_pynvvideocodec_invalid_video_raises_value_error(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    class FakePyNvVCException(Exception):
-        pass
-
-    class FakePyNvVCExceptionUnsupported(Exception):
-        pass
-
-    fake_nvc = SimpleNamespace(
-        PyNvVCException=FakePyNvVCException,
-        PyNvVCExceptionUnsupported=FakePyNvVCExceptionUnsupported,
-    )
-    monkeypatch.setitem(sys.modules, "PyNvVideoCodec", fake_nvc)
-
-    def raise_invalid_video(cls, file_path, nvc):
-        raise FakePyNvVCExceptionUnsupported("Invalid data found when processing input")
-
-    monkeypatch.setattr(
-        PyNvVideoCodecVideoBackend,
-        "_read_source_metadata",
-        classmethod(raise_invalid_video),
-    )
-
-    with pytest.raises(
-        ValueError,
-        match=r"^Invalid or unsupported video file\.$",
-    ) as exc_info:
-        corrupted_video = (
-            Path(__file__).parent.parent / "assets" / "corrupted.mp4"
-        ).read_bytes()
-        PyNvVideoCodecVideoBackend.decode_frames_pynvvideocodec(corrupted_video, None)
-
-    assert isinstance(exc_info.value.__cause__, FakePyNvVCExceptionUnsupported)
-
-
 def test_pynvvideocodec_unrelated_error_propagates(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/multimodal/media/test_video.py
+++ b/tests/multimodal/media/test_video.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import io
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import numpy as np
 import numpy.typing as npt
@@ -19,6 +21,7 @@ from vllm.multimodal.media import ImageMediaIO, VideoMediaIO
 from vllm.multimodal.video import (
     PYNVVIDEOCODEC_VIDEO_BACKEND,
     VIDEO_LOADER_REGISTRY,
+    PyNvVideoCodecVideoBackend,
     VideoLoader,
     _pynvvc_frames_to_nhwc,
 )
@@ -362,6 +365,58 @@ def test_load_base64_jpeg_raises_on_zero_num_frames():
 
     with pytest.raises(ValueError, match="num_frames must be greater than 0 or -1"):
         videoio.load_base64("video/jpeg", data)
+
+
+def test_pynvvideocodec_invalid_video_raises_value_error(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class FakePyNvVCException(Exception):
+        pass
+
+    fake_nvc = SimpleNamespace(PyNvVCException=FakePyNvVCException)
+    monkeypatch.setitem(sys.modules, "PyNvVideoCodec", fake_nvc)
+
+    def raise_invalid_video(cls, file_path, nvc):
+        raise FakePyNvVCException("Invalid data found when processing input")
+
+    monkeypatch.setattr(
+        PyNvVideoCodecVideoBackend,
+        "_read_source_metadata",
+        classmethod(raise_invalid_video),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"^Invalid or unsupported video file\.$",
+    ) as exc_info:
+        PyNvVideoCodecVideoBackend.decode_frames_pynvvideocodec(b"not-a-video", None)
+
+    assert isinstance(exc_info.value.__cause__, FakePyNvVCException)
+
+
+def test_pynvvideocodec_unrelated_error_propagates(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class FakePyNvVCException(Exception):
+        pass
+
+    fake_nvc = SimpleNamespace(PyNvVCException=FakePyNvVCException)
+    monkeypatch.setitem(sys.modules, "PyNvVideoCodec", fake_nvc)
+    original_error = RuntimeError("GPU decoder unavailable")
+
+    def raise_unrelated_error(cls, file_path, nvc):
+        raise original_error
+
+    monkeypatch.setattr(
+        PyNvVideoCodecVideoBackend,
+        "_read_source_metadata",
+        classmethod(raise_unrelated_error),
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        PyNvVideoCodecVideoBackend.decode_frames_pynvvideocodec(b"video", None)
+
+    assert exc_info.value is original_error
 
 
 # ---------------------------------------------------------------------------

--- a/tests/multimodal/media/test_video.py
+++ b/tests/multimodal/media/test_video.py
@@ -389,7 +389,10 @@ def test_pynvvideocodec_invalid_video_raises_value_error(
         ValueError,
         match=r"^Invalid or unsupported video file\.$",
     ) as exc_info:
-        PyNvVideoCodecVideoBackend.decode_frames_pynvvideocodec(b"not-a-video", None)
+        corrupted_video = (
+            Path(__file__).parent.parent / "assets" / "corrupted.mp4"
+        ).read_bytes()
+        PyNvVideoCodecVideoBackend.decode_frames_pynvvideocodec(corrupted_video, None)
 
     assert isinstance(exc_info.value.__cause__, FakePyNvVCException)
 

--- a/tests/multimodal/media/test_video.py
+++ b/tests/multimodal/media/test_video.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import io
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import numpy as np
 import numpy.typing as npt
@@ -19,6 +21,7 @@ from vllm.multimodal.media import ImageMediaIO, VideoMediaIO
 from vllm.multimodal.video import (
     PYNVVIDEOCODEC_VIDEO_BACKEND,
     VIDEO_LOADER_REGISTRY,
+    PyNvVideoCodecVideoBackend,
     VideoLoader,
 )
 
@@ -361,6 +364,58 @@ def test_load_base64_jpeg_raises_on_zero_num_frames():
 
     with pytest.raises(ValueError, match="num_frames must be greater than 0 or -1"):
         videoio.load_base64("video/jpeg", data)
+
+
+def test_pynvvideocodec_invalid_video_raises_value_error(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class FakePyNvVCException(Exception):
+        pass
+
+    fake_nvc = SimpleNamespace(PyNvVCException=FakePyNvVCException)
+    monkeypatch.setitem(sys.modules, "PyNvVideoCodec", fake_nvc)
+
+    def raise_invalid_video(cls, file_path, nvc):
+        raise FakePyNvVCException("Invalid data found when processing input")
+
+    monkeypatch.setattr(
+        PyNvVideoCodecVideoBackend,
+        "_read_source_metadata",
+        classmethod(raise_invalid_video),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"^Invalid or unsupported video file\.$",
+    ) as exc_info:
+        PyNvVideoCodecVideoBackend.decode_frames_pynvvideocodec(b"not-a-video", None)
+
+    assert isinstance(exc_info.value.__cause__, FakePyNvVCException)
+
+
+def test_pynvvideocodec_unrelated_error_propagates(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class FakePyNvVCException(Exception):
+        pass
+
+    fake_nvc = SimpleNamespace(PyNvVCException=FakePyNvVCException)
+    monkeypatch.setitem(sys.modules, "PyNvVideoCodec", fake_nvc)
+    original_error = RuntimeError("GPU decoder unavailable")
+
+    def raise_unrelated_error(cls, file_path, nvc):
+        raise original_error
+
+    monkeypatch.setattr(
+        PyNvVideoCodecVideoBackend,
+        "_read_source_metadata",
+        classmethod(raise_unrelated_error),
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        PyNvVideoCodecVideoBackend.decode_frames_pynvvideocodec(b"video", None)
+
+    assert exc_info.value is original_error
 
 
 # ---------------------------------------------------------------------------

--- a/tests/multimodal/test_video.py
+++ b/tests/multimodal/test_video.py
@@ -201,9 +201,10 @@ def test_pynvvideocodec_codec_uses_dynamic_sampling_strategy(
 
 
 @pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")
-def test_pynvvideocodec_corrupted_video_raises_value_error():
+def test_pynvvideocodec_corrupted_videos_raise_value_error():
     valid_video = create_long_gop_video(num_frames=2, width=64, height=64)
     corrupted_video = (ASSETS_DIR / "corrupted.mp4").read_bytes()
+    malformed_video = corrupted_video[:128]
 
     old_slots = PyNvVideoCodecVideoBackend._decoder_slots
     old_active_slots = PyNvVideoCodecVideoBackend._active_decoder_slots
@@ -219,6 +220,18 @@ def test_pynvvideocodec_corrupted_video_raises_value_error():
         with pytest.raises(
             ValueError,
             match=r"^Invalid or unsupported video file\.$",
+        ) as malformed_exc:
+            loader.load_bytes(
+                malformed_video,
+                num_frames=1,
+                hw_decoders=1,
+            )
+
+        assert malformed_exc.value.__cause__ is not None
+
+        with pytest.raises(
+            ValueError,
+            match=r"^Invalid or unsupported video file\.$",
         ) as exc_info:
             loader.load_bytes(
                 corrupted_video,
@@ -226,7 +239,7 @@ def test_pynvvideocodec_corrupted_video_raises_value_error():
                 hw_decoders=1,
             )
 
-        assert isinstance(exc_info.value.__cause__, IndexError)
+        assert exc_info.value.__cause__ is not None
 
         frames, _ = loader.load_bytes(
             valid_video,

--- a/tests/multimodal/test_video.py
+++ b/tests/multimodal/test_video.py
@@ -200,6 +200,47 @@ def test_pynvvideocodec_codec_uses_dynamic_sampling_strategy(
     assert metadata["frames_indices"] == [0, 9]
 
 
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")
+def test_pynvvideocodec_corrupted_video_raises_value_error():
+    valid_video = create_long_gop_video(num_frames=2, width=64, height=64)
+    corrupted_video = (ASSETS_DIR / "corrupted.mp4").read_bytes()
+
+    old_slots = PyNvVideoCodecVideoBackend._decoder_slots
+    old_active_slots = PyNvVideoCodecVideoBackend._active_decoder_slots
+    old_cond = PyNvVideoCodecVideoBackend._decoder_slot_cond
+    old_max_slots = PyNvVideoCodecVideoBackend._max_decoder_slots
+    try:
+        PyNvVideoCodecVideoBackend._decoder_slots = []
+        PyNvVideoCodecVideoBackend._active_decoder_slots = 0
+        PyNvVideoCodecVideoBackend._decoder_slot_cond = threading.Condition()
+        PyNvVideoCodecVideoBackend._max_decoder_slots = None
+
+        loader = VIDEO_LOADER_REGISTRY.load(PYNVVIDEOCODEC_VIDEO_BACKEND)
+        with pytest.raises(
+            ValueError,
+            match=r"^Invalid or unsupported video file\.$",
+        ) as exc_info:
+            loader.load_bytes(
+                corrupted_video,
+                num_frames=-1,
+                hw_decoders=1,
+            )
+
+        assert isinstance(exc_info.value.__cause__, IndexError)
+
+        frames, _ = loader.load_bytes(
+            valid_video,
+            num_frames=1,
+            hw_decoders=1,
+        )
+        assert frames.shape[0] == 1
+    finally:
+        PyNvVideoCodecVideoBackend._decoder_slots = old_slots
+        PyNvVideoCodecVideoBackend._active_decoder_slots = old_active_slots
+        PyNvVideoCodecVideoBackend._decoder_slot_cond = old_cond
+        PyNvVideoCodecVideoBackend._max_decoder_slots = old_max_slots
+
+
 @pytest.mark.parametrize("hw_decoders", [1, 3])
 def test_pynvvideocodec_decoder_slots_are_bounded(
     monkeypatch: pytest.MonkeyPatch,

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -854,7 +854,10 @@ class PyNvVideoCodecVideoBackendMixin:
             with os.fdopen(temp_fd, "wb") as temp_file:
                 temp_file.write(data)
 
-            gpu_source = cls._read_source_metadata(temp_path, nvc)
+            try:
+                gpu_source = cls._read_source_metadata(temp_path, nvc)
+            except nvc.PyNvVCException as exc:
+                raise ValueError("Invalid or unsupported video file.") from exc
             _check_frame_pixel_limit(gpu_source.width, gpu_source.height)
             source = cls._prepare_source(gpu_source.source)
             frame_idx = cls.compute_frames_index_to_sample(

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -234,6 +234,16 @@ def validate_pynvvideocodec_hw_decoders(hw_decoders: object) -> int:
     return hw_decoders
 
 
+def _pynvvideocodec_exception_types(nvc) -> tuple[type[Exception], ...]:
+    return tuple(
+        exception_type
+        for name in dir(nvc)
+        if name.startswith("PyNvVCException")
+        and isinstance((exception_type := getattr(nvc, name)), type)
+        and issubclass(exception_type, Exception)
+    )
+
+
 class PyNvVideoCodecDecoderSlot:
     """A retained PyNv decoder slot and its CUDA stream.
 
@@ -809,7 +819,15 @@ class PyNvVideoCodecVideoBackendMixin:
                 decoder = decoder_slot.get_decoder(
                     file_path, nvc, device_index=cls._DEVICE_INDEX
                 )
-                decoded_frames = decoder.get_batch_frames_by_index(frame_idx)
+                try:
+                    decoded_frames = decoder.get_batch_frames_by_index(frame_idx)
+                except Exception as exc:
+                    if not isinstance(
+                        exc,
+                        _pynvvideocodec_exception_types(nvc) + (IndexError,),
+                    ):
+                        raise
+                    raise ValueError("Invalid or unsupported video file.") from exc
                 if len(decoded_frames) < len(frame_idx):
                     logger.warning(
                         "pynvvideocodec video loading: expected %d frames but got %d.",
@@ -856,7 +874,9 @@ class PyNvVideoCodecVideoBackendMixin:
 
             try:
                 gpu_source = cls._read_source_metadata(temp_path, nvc)
-            except nvc.PyNvVCException as exc:
+            except Exception as exc:
+                if not isinstance(exc, _pynvvideocodec_exception_types(nvc)):
+                    raise
                 raise ValueError("Invalid or unsupported video file.") from exc
             _check_frame_pixel_limit(gpu_source.width, gpu_source.height)
             source = cls._prepare_source(gpu_source.source)

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -816,10 +816,10 @@ class PyNvVideoCodecVideoBackendMixin:
         with cls._borrow_decoder_slot() as decoder_slot:
             stream = decoder_slot.stream
             with cls._torch_stream_context(stream):
-                decoder = decoder_slot.get_decoder(
-                    file_path, nvc, device_index=cls._DEVICE_INDEX
-                )
                 try:
+                    decoder = decoder_slot.get_decoder(
+                        file_path, nvc, device_index=cls._DEVICE_INDEX
+                    )
                     decoded_frames = decoder.get_batch_frames_by_index(frame_idx)
                 except Exception as exc:
                     if not isinstance(

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -836,7 +836,10 @@ class PyNvVideoCodecVideoBackendMixin:
             with os.fdopen(temp_fd, "wb") as temp_file:
                 temp_file.write(data)
 
-            gpu_source = cls._read_source_metadata(temp_path, nvc)
+            try:
+                gpu_source = cls._read_source_metadata(temp_path, nvc)
+            except nvc.PyNvVCException as exc:
+                raise ValueError("Invalid or unsupported video file.") from exc
             _check_frame_pixel_limit(gpu_source.width, gpu_source.height)
             source = cls._prepare_source(gpu_source.source)
             frame_idx = cls.compute_frames_index_to_sample(


### PR DESCRIPTION
## Summary
- translate `PyNvVideoCodec.PyNvVCException` raised while opening malformed video into a sanitized `ValueError`
- rely on vLLM's existing `ValueError` handler to return `BadRequestError`/HTTP 400 instead of HTTP 500
- preserve the native exception as the cause and leave unrelated decoder exceptions unchanged

## Root cause
A malformed user-supplied video reaches `PyNvVideoCodec.SimpleDecoder` during multimodal request preprocessing. The native `PyNvVCException` previously escaped the media boundary, so the generic API exception handler classified it as `InternalServerError`.

The same request returned the same HTTP 500 response through both the public NIM endpoint and the internal vLLM endpoint, and the traceback remained entirely in `vllm/multimodal/video.py` / PyNvVideoCodec before model inference.

## Test plan
- [x] regression test fails before the patch because native `PyNvVCException` escapes
- [x] `pytest -q tests/multimodal/media/test_video.py` — 35 passed
- [x] Ruff lint and format checks
- [x] typos check
- [x] B200 end-to-end with vLLM 0.26.0 and PyNvVideoCodec backend:
  - corrupt MKV: HTTP 500 before, HTTP 400 after
  - valid MP4: HTTP 200
  - valid MKV: HTTP 200
  - four concurrent valid MP4 requests: all HTTP 200
  - health and basic text chat remain HTTP 200

## AI assistance disclosure
Cursor Agent (GPT-5.6 Sol) assisted with source exploration, test drafting, and implementation. I reviewed the changed lines and validated the behavior with focused unit tests and an end-to-end B200 reproduction.