### PR TITLE
[Bugfix] Size and iterate w13 by shard count for non-gated MoE

### DIFF
--- a/tests/quantization/test_auto_gptq.py
+++ b/tests/quantization/test_auto_gptq.py
@@ -65,6 +65,7 @@ def test_auto_gptq_moe_creates_zero_initialized_expert_biases():
     method.quant_config = AutoGPTQConfig(4, 128, False, True, False, {}, {})
     method.input_dtype = None
     method.experts_cls = None
+    method.moe = SimpleNamespace(w13_num_shards=2)
     layer = torch.nn.Module()
 
     method.create_weights(

--- a/tests/quantization/test_auto_round.py
+++ b/tests/quantization/test_auto_round.py
@@ -8,6 +8,7 @@ Validating the configuration and printing results for manual checking.
 Run `pytest tests/quantization/test_auto_round.py`.
 """
 
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
@@ -694,7 +695,8 @@ def test_inc_mxfp4_moe_method_registers_weights_and_builds_kernel(
         INCMxfp4MoEMethod,
     )
 
-    method = INCMxfp4MoEMethod(moe=cast(Any, "moe-config"))
+    expected_moe_config = SimpleNamespace(w13_num_shards=2)
+    method = INCMxfp4MoEMethod(moe=cast(Any, expected_moe_config))
     layer = torch.nn.Module()
     layer._expert_routing_tables = lambda: "routing-tables"
 
@@ -723,7 +725,7 @@ def test_inc_mxfp4_moe_method_registers_weights_and_builds_kernel(
     assert captured["quant_config_kwargs"]["w1_scale"] is layer.w13_weight_scale
     assert captured["quant_config_kwargs"]["w2_scale"] is layer.w2_weight_scale
     assert captured["kernel_kwargs"]["moe_quant_config"] is expected_quant_config
-    assert captured["kernel_kwargs"]["moe_config"] == "moe-config"
+    assert captured["kernel_kwargs"]["moe_config"] is expected_moe_config
     assert captured["kernel_kwargs"]["experts_cls"] is expected_experts_cls
     assert captured["kernel_kwargs"]["routing_tables"] == "routing-tables"
     assert method.moe_kernel is expected_kernel

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -1376,6 +1376,11 @@ class FusedMoEConfig:
         return self.activation.is_gated
 
     @property
+    def w13_num_shards(self) -> int:
+        """Number of shards fused into w13: gate and up for gated, up only."""
+        return 2 if self.is_act_and_mul else 1
+
+    @property
     def tp_size(self):
         return self.moe_parallel_config.tp_size
 

--- a/vllm/model_executor/layers/quantization/auto_awq.py
+++ b/vllm/model_executor/layers/quantization/auto_awq.py
@@ -592,7 +592,9 @@ class AutoAWQMoEMethod(FusedMoEMethodBase):
             torch.empty(
                 num_experts,
                 hidden_size,
-                2 * intermediate_size_per_partition // self.quant_config.pack_factor,
+                self.moe.w13_num_shards
+                * intermediate_size_per_partition
+                // self.quant_config.pack_factor,
                 dtype=torch.int32,
             ),
             requires_grad=False,
@@ -623,7 +625,7 @@ class AutoAWQMoEMethod(FusedMoEMethodBase):
             torch.empty(
                 num_experts,
                 num_groups_w13,
-                intermediate_size_per_partition * 2,
+                intermediate_size_per_partition * self.moe.w13_num_shards,
                 dtype=params_dtype,
             ),
             requires_grad=False,
@@ -644,7 +646,9 @@ class AutoAWQMoEMethod(FusedMoEMethodBase):
             torch.empty(
                 num_experts,
                 num_groups_w13,
-                2 * intermediate_size_per_partition // self.quant_config.pack_factor,
+                self.moe.w13_num_shards
+                * intermediate_size_per_partition
+                // self.quant_config.pack_factor,
                 dtype=torch.int32,
             ),
             requires_grad=False,

--- a/vllm/model_executor/layers/quantization/auto_gptq.py
+++ b/vllm/model_executor/layers/quantization/auto_gptq.py
@@ -541,7 +541,7 @@ class AutoGPTQMoEMethod(FusedMoEMethodBase):
             torch.empty(
                 num_experts,
                 hidden_size // self.quant_config.pack_factor,
-                2 * intermediate_size_per_partition,
+                self.moe.w13_num_shards * intermediate_size_per_partition,
                 dtype=torch.int32,
             ),
             requires_grad=False,
@@ -565,7 +565,7 @@ class AutoGPTQMoEMethod(FusedMoEMethodBase):
             torch.empty(
                 num_experts,
                 scales_size13,
-                2 * intermediate_size_per_partition,
+                self.moe.w13_num_shards * intermediate_size_per_partition,
                 dtype=params_dtype,
             ),
             requires_grad=False,
@@ -586,7 +586,9 @@ class AutoGPTQMoEMethod(FusedMoEMethodBase):
             torch.empty(
                 num_experts,
                 scales_size13,
-                2 * intermediate_size_per_partition // self.quant_config.pack_factor,
+                self.moe.w13_num_shards
+                * intermediate_size_per_partition
+                // self.quant_config.pack_factor,
                 dtype=torch.int32,
             ),
             requires_grad=False,
@@ -654,7 +656,7 @@ class AutoGPTQMoEMethod(FusedMoEMethodBase):
         w13_bias = torch.nn.Parameter(
             torch.zeros(
                 num_experts,
-                2 * intermediate_size_per_partition,
+                self.moe.w13_num_shards * intermediate_size_per_partition,
                 dtype=params_dtype,
             ),
             requires_grad=False,

--- a/vllm/model_executor/layers/quantization/bitsandbytes.py
+++ b/vllm/model_executor/layers/quantization/bitsandbytes.py
@@ -523,7 +523,7 @@ class BitsAndBytesMoEMethod(FusedMoEMethodBase):
         quant_ratio = calculate_quant_ratio(params_dtype)
         # Fused gate_up_proj (column parallel)
         w13_total_size = (
-            hidden_size * 2 * intermediate_size_per_partition
+            hidden_size * self.moe.w13_num_shards * intermediate_size_per_partition
         ) // quant_ratio
         w13_qweight = torch.nn.Parameter(
             torch.empty(
@@ -541,10 +541,10 @@ class BitsAndBytesMoEMethod(FusedMoEMethodBase):
             {
                 "num_experts": num_experts,
                 "input_dim": hidden_size,
-                "output_dim": 2 * intermediate_size_per_partition,
+                "output_dim": self.moe.w13_num_shards * intermediate_size_per_partition,
                 "experts_shape": (
                     num_experts,
-                    intermediate_size_per_partition * 2,
+                    intermediate_size_per_partition * self.moe.w13_num_shards,
                     hidden_size,
                 ),
                 "pack_factor": quant_ratio,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_mxfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_mxfp4.py
@@ -75,7 +75,7 @@ class CompressedTensorsW4A4Mxfp4MoEMethod(CompressedTensorsMoEMethod):
         w13_weight = torch.nn.Parameter(
             torch.empty(
                 num_experts,
-                2 * intermediate_size_per_partition,
+                self.moe.w13_num_shards * intermediate_size_per_partition,
                 # 2 fp4 items are packed in the input dimension
                 hidden_size // 2,
                 requires_grad=False,
@@ -102,7 +102,7 @@ class CompressedTensorsW4A4Mxfp4MoEMethod(CompressedTensorsMoEMethod):
         w13_weight_scale = torch.nn.Parameter(
             torch.empty(
                 num_experts,
-                2 * intermediate_size_per_partition,
+                self.moe.w13_num_shards * intermediate_size_per_partition,
                 # 2 fp4 items are packed in the input dimension
                 hidden_size // self.group_size,
                 dtype=torch.uint8,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a8_fp8.py
@@ -79,7 +79,7 @@ class CompressedTensorsW4A8Fp8MoEMethod(CompressedTensorsMoEMethod):
         w13_weight_packed = torch.nn.Parameter(
             torch.empty(
                 num_experts,
-                2 * intermediate_size_per_partition,
+                self.moe.w13_num_shards * intermediate_size_per_partition,
                 hidden_size // self.packed_factor,
                 dtype=params_dtype,
             ),
@@ -107,7 +107,7 @@ class CompressedTensorsW4A8Fp8MoEMethod(CompressedTensorsMoEMethod):
         w13_weight_scale = torch.nn.Parameter(
             torch.ones(
                 num_experts,
-                2 * intermediate_size_per_partition,
+                self.moe.w13_num_shards * intermediate_size_per_partition,
                 hidden_size // self.group_size,
                 dtype=layer.orig_dtype,
             ),
@@ -147,7 +147,7 @@ class CompressedTensorsW4A8Fp8MoEMethod(CompressedTensorsMoEMethod):
         w13_weight_chan_scale = torch.nn.Parameter(
             torch.ones(
                 num_experts,
-                2 * intermediate_size_per_partition,
+                self.moe.w13_num_shards * intermediate_size_per_partition,
                 dtype=torch.float32,
             ),
             requires_grad=False,

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -546,7 +546,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         w13_weight = torch.nn.Parameter(
             torch.empty(
                 num_experts,
-                2 * intermediate_size_per_partition,
+                self.moe.w13_num_shards * intermediate_size_per_partition,
                 hidden_size,
                 dtype=params_dtype,
             ),
@@ -572,7 +572,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             w13_bias = torch.nn.Parameter(
                 torch.zeros(
                     num_experts,
-                    2 * intermediate_size_per_partition,
+                    self.moe.w13_num_shards * intermediate_size_per_partition,
                     dtype=layer.orig_dtype,
                 ),
                 requires_grad=False,
@@ -589,13 +589,16 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         # WEIGHT_SCALES
         if not self.block_quant:
             # For per-tensor quant, the scales are per expert and weight.
-            w13_scale_data = torch.ones(num_experts, 2, dtype=torch.float32)
+            w13_scale_data = torch.ones(
+                num_experts, self.moe.w13_num_shards, dtype=torch.float32
+            )
             w2_scale_data = torch.ones(num_experts, dtype=torch.float32)
         else:
             # For block quant, the scales are per block (typically 128x128).
             w13_scale_data = torch.ones(
                 num_experts,
-                2 * ((intermediate_size_per_partition + block_n - 1) // block_n),
+                self.moe.w13_num_shards
+                * ((intermediate_size_per_partition + block_n - 1) // block_n),
                 (hidden_size + block_k - 1) // block_k,
                 dtype=torch.float32,
             )
@@ -723,7 +726,11 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         if not self.block_quant:
             shard_size = layer.intermediate_size_per_partition
             w13, w13_scale = process_fp8_weight_tensor_strategy_moe(
-                w13, w13_scale, shard_size, layer.local_num_experts
+                w13,
+                w13_scale,
+                shard_size,
+                layer.local_num_experts,
+                is_act_and_mul=self.moe.is_act_and_mul,
             )
 
         # Shuffle weights to runtime format and setup kernel.

--- a/vllm/model_executor/layers/quantization/humming.py
+++ b/vllm/model_executor/layers/quantization/humming.py
@@ -728,10 +728,10 @@ class HummingMoEMethod(FusedMoEMethodBase):
         # The weight names of sublayer start with the prefix "{sublayer_name}_"
         layer.sublayer_configs = {
             "w13": {
-                "shape_n": intermediate_size_per_partition * 2,
+                "shape_n": intermediate_size_per_partition * self.moe.w13_num_shards,
                 "shape_k": hidden_size,
                 "tensors_attrs": self.weight_schema.get_padded_tensors_attrs(
-                    shape_n=intermediate_size_per_partition * 2,
+                    shape_n=intermediate_size_per_partition * self.moe.w13_num_shards,
                     shape_k=hidden_size,
                     num_experts=num_experts,
                     param_dtype=params_dtype,

--- a/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_moe.py
+++ b/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_moe.py
@@ -88,7 +88,7 @@ class INCMxfp4MoEMethod(FusedMoEMethodBase):
         w13_weight = torch.nn.Parameter(
             torch.empty(
                 num_experts,
-                2 * intermediate_size_per_partition,
+                self.moe.w13_num_shards * intermediate_size_per_partition,
                 hidden_size // 2,
                 dtype=torch.uint8,
             ),
@@ -113,7 +113,7 @@ class INCMxfp4MoEMethod(FusedMoEMethodBase):
         w13_weight_scale = torch.nn.Parameter(
             torch.empty(
                 num_experts,
-                2 * intermediate_size_per_partition,
+                self.moe.w13_num_shards * intermediate_size_per_partition,
                 hidden_size // self.group_size,
                 dtype=torch.uint8,
             ),

--- a/vllm/model_executor/layers/quantization/moe_wna16.py
+++ b/vllm/model_executor/layers/quantization/moe_wna16.py
@@ -276,7 +276,7 @@ class MoeWNA16Method(FusedMoEMethodBase):
         w13_qweight = torch.nn.Parameter(
             torch.empty(
                 num_experts,
-                2 * intermediate_size_per_partition,
+                self.moe.w13_num_shards * intermediate_size_per_partition,
                 hidden_size // bit8_pack_factor,
                 dtype=torch.uint8,
             ),
@@ -301,7 +301,7 @@ class MoeWNA16Method(FusedMoEMethodBase):
         w13_scales = torch.nn.Parameter(
             torch.zeros(
                 num_experts,
-                2 * intermediate_size_per_partition,
+                self.moe.w13_num_shards * intermediate_size_per_partition,
                 hidden_size // group_size,
                 dtype=params_dtype,
             ),
@@ -326,7 +326,9 @@ class MoeWNA16Method(FusedMoEMethodBase):
             w13_qzeros = torch.nn.Parameter(
                 torch.zeros(
                     num_experts,
-                    2 * intermediate_size_per_partition // bit8_pack_factor,
+                    self.moe.w13_num_shards
+                    * intermediate_size_per_partition
+                    // bit8_pack_factor,
                     hidden_size // group_size,
                     dtype=torch.uint8,
                 ),

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -215,7 +215,7 @@ class GptOssMxfp4MoEMethod(FusedMoEMethodBase):
         w13_weight = torch.nn.Parameter(
             torch.zeros(
                 num_experts,
-                2 * intermediate_size_per_partition,
+                self.moe.w13_num_shards * intermediate_size_per_partition,
                 hidden_size // 2,
                 dtype=weight_dtype,
             ),
@@ -227,7 +227,7 @@ class GptOssMxfp4MoEMethod(FusedMoEMethodBase):
         w13_weight_scale = torch.nn.Parameter(
             torch.zeros(
                 num_experts,
-                2 * intermediate_size_per_partition,
+                self.moe.w13_num_shards * intermediate_size_per_partition,
                 hidden_size // mxfp4_block,
                 dtype=scale_dtype,
             ),
@@ -267,7 +267,7 @@ class GptOssMxfp4MoEMethod(FusedMoEMethodBase):
             w13_bias = torch.nn.Parameter(
                 torch.zeros(
                     num_experts,
-                    2 * intermediate_size_per_partition,
+                    self.moe.w13_num_shards * intermediate_size_per_partition,
                     dtype=torch.bfloat16,
                 ),
                 requires_grad=False,
@@ -305,13 +305,13 @@ class GptOssMxfp4MoEMethod(FusedMoEMethodBase):
         assert (
             w13.dim() == 3
             and w13.shape[0] == num_experts
-            and w13.shape[1] == intermediate_size * 2
+            and w13.shape[1] == intermediate_size * self.moe.w13_num_shards
             and w13.shape[2] == hidden_size // 2
         )
         assert (
             w13_scale.dim() == 3
             and w13_scale.shape[0] == num_experts
-            and w13_scale.shape[1] == intermediate_size * 2
+            and w13_scale.shape[1] == intermediate_size * self.moe.w13_num_shards
             and w13_scale.shape[2] == hidden_size // sf_block_size
         )
         assert (
@@ -329,7 +329,7 @@ class GptOssMxfp4MoEMethod(FusedMoEMethodBase):
             assert (
                 w13_bias.dim() == 2
                 and w13_bias.shape[0] == num_experts
-                and w13_bias.shape[1] == intermediate_size * 2
+                and w13_bias.shape[1] == intermediate_size * self.moe.w13_num_shards
             )
         if w2_bias is not None:
             assert (
@@ -599,7 +599,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         w13_weight = torch.nn.Parameter(
             torch.zeros(
                 num_experts,
-                2 * intermediate_size_per_partition,
+                self.moe.w13_num_shards * intermediate_size_per_partition,
                 hidden_size // 2,
                 dtype=weight_dtype,
             ),
@@ -611,7 +611,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         w13_weight_scale = torch.nn.Parameter(
             torch.zeros(
                 num_experts,
-                2 * intermediate_size_per_partition,
+                self.moe.w13_num_shards * intermediate_size_per_partition,
                 hidden_size // mxfp4_block,
                 dtype=scale_dtype,
             ),
@@ -651,7 +651,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             w13_bias = torch.nn.Parameter(
                 torch.zeros(
                     num_experts,
-                    2 * intermediate_size_per_partition,
+                    self.moe.w13_num_shards * intermediate_size_per_partition,
                     dtype=torch.bfloat16,
                 ),
                 requires_grad=False,
@@ -689,13 +689,13 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         assert (
             w13.dim() == 3
             and w13.shape[0] == num_experts
-            and w13.shape[1] == intermediate_size * 2
+            and w13.shape[1] == intermediate_size * self.moe.w13_num_shards
             and w13.shape[2] == hidden_size // 2
         )
         assert (
             w13_scale.dim() == 3
             and w13_scale.shape[0] == num_experts
-            and w13_scale.shape[1] == intermediate_size * 2
+            and w13_scale.shape[1] == intermediate_size * self.moe.w13_num_shards
             and w13_scale.shape[2] == hidden_size // sf_block_size
         )
         assert (
@@ -713,7 +713,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             assert (
                 w13_bias.dim() == 2
                 and w13_bias.shape[0] == num_experts
-                and w13_bias.shape[1] == intermediate_size * 2
+                and w13_bias.shape[1] == intermediate_size * self.moe.w13_num_shards
             )
         if w2_bias is not None:
             assert (

--- a/vllm/model_executor/layers/quantization/online/fp8.py
+++ b/vllm/model_executor/layers/quantization/online/fp8.py
@@ -582,12 +582,11 @@ class Fp8PerBlockOnlineMoEMethod(_Fp8OnlineMoEBase):
         hidden_size = layer.moe_config.hidden_dim_unpadded
         intermediate_size = layer.moe_config.intermediate_size_per_partition_unpadded
 
-        w13_half_size = layer.w13_weight.shape[1] // 2
-        if w13_half_size > intermediate_size:
-            layer.w13_weight[:, intermediate_size:w13_half_size, :] = 0
-            layer.w13_weight[
-                :, w13_half_size + intermediate_size : 2 * w13_half_size, :
-            ] = 0
+        w13_shard = layer.w13_weight.shape[1] // self.moe.w13_num_shards
+        if w13_shard > intermediate_size:
+            for shard in range(self.moe.w13_num_shards):
+                start = shard * w13_shard + intermediate_size
+                layer.w13_weight[:, start : (shard + 1) * w13_shard, :] = 0
         if layer.w13_weight.shape[2] > hidden_size:
             layer.w13_weight[:, :, hidden_size:] = 0
 
@@ -597,12 +596,11 @@ class Fp8PerBlockOnlineMoEMethod(_Fp8OnlineMoEBase):
             layer.w2_weight[:, :, intermediate_size:] = 0
 
         if getattr(layer, "w13_bias", None) is not None:
-            w13_bias_half_size = layer.w13_bias.shape[1] // 2
-            if w13_bias_half_size > intermediate_size:
-                layer.w13_bias[:, intermediate_size:w13_bias_half_size] = 0
-                layer.w13_bias[
-                    :, w13_bias_half_size + intermediate_size : 2 * w13_bias_half_size
-                ] = 0
+            w13_bias_shard = layer.w13_bias.shape[1] // self.moe.w13_num_shards
+            if w13_bias_shard > intermediate_size:
+                for shard in range(self.moe.w13_num_shards):
+                    start = shard * w13_bias_shard + intermediate_size
+                    layer.w13_bias[:, start : (shard + 1) * w13_bias_shard] = 0
 
         if (
             getattr(layer, "w2_bias", None) is not None

--- a/vllm/model_executor/layers/quantization/online/moe_base.py
+++ b/vllm/model_executor/layers/quantization/online/moe_base.py
@@ -41,7 +41,7 @@ class OnlineMoEMethodBase(FusedMoEMethodBase):
         w13_weight = torch.nn.Parameter(
             torch.empty(
                 num_experts,
-                2 * intermediate_size_per_partition,
+                self.moe.w13_num_shards * intermediate_size_per_partition,
                 hidden_size,
                 device="meta",
                 dtype=params_dtype,
@@ -70,7 +70,7 @@ class OnlineMoEMethodBase(FusedMoEMethodBase):
             w13_bias = torch.nn.Parameter(
                 torch.zeros(
                     num_experts,
-                    2 * intermediate_size_per_partition,
+                    self.moe.w13_num_shards * intermediate_size_per_partition,
                     device="meta",
                     dtype=layer.orig_dtype,
                 ),

--- a/vllm/model_executor/layers/quantization/quark/quark_moe.py
+++ b/vllm/model_executor/layers/quantization/quark/quark_moe.py
@@ -216,7 +216,7 @@ class QuarkW8A8Fp8MoEMethod(QuarkMoEMethod):
         w13_weight = torch.nn.Parameter(
             torch.zeros(
                 num_experts,
-                2 * intermediate_size_per_partition,
+                self.moe.w13_num_shards * intermediate_size_per_partition,
                 hidden_size,
                 dtype=params_dtype,
             ),
@@ -243,7 +243,10 @@ class QuarkW8A8Fp8MoEMethod(QuarkMoEMethod):
             # They are combined to a single scale after weight loading.
             if self.model_type != "gpt_oss":
                 w13_weight_scale = torch.nn.Parameter(
-                    torch.ones(num_experts, 2, dtype=torch.float32), requires_grad=False
+                    torch.ones(
+                        num_experts, self.moe.w13_num_shards, dtype=torch.float32
+                    ),
+                    requires_grad=False,
                 )
             else:
                 # For gpt_oss, the w1(gate) & w3(up) are fused as one.
@@ -267,7 +270,7 @@ class QuarkW8A8Fp8MoEMethod(QuarkMoEMethod):
             w13_weight_scale = torch.nn.Parameter(
                 torch.ones(
                     num_experts,
-                    2 * intermediate_size_per_partition,
+                    self.moe.w13_num_shards * intermediate_size_per_partition,
                     dtype=torch.float32,
                 ),
                 requires_grad=False,
@@ -306,7 +309,7 @@ class QuarkW8A8Fp8MoEMethod(QuarkMoEMethod):
             w13_bias = torch.nn.Parameter(
                 torch.zeros(
                     num_experts,
-                    2 * intermediate_size_per_partition,
+                    self.moe.w13_num_shards * intermediate_size_per_partition,
                     dtype=torch.float32,
                 ),
                 requires_grad=False,
@@ -400,7 +403,7 @@ class QuarkW8A8Fp8MoEMethod(QuarkMoEMethod):
                 # For non-gpt_oss, process w1 and w3 shards separately
                 for expert_id in range(layer.local_num_experts):
                     start = 0
-                    for shard_id in range(2):
+                    for shard_id in range(self.moe.w13_num_shards):
                         dq_weight = per_tensor_dequantize(
                             layer.w13_weight[expert_id][start : start + shard_size, :],
                             layer.w13_weight_scale[expert_id][shard_id],
@@ -560,7 +563,7 @@ class QuarkW8A8Int8MoEMethod(QuarkMoEMethod):
         w13_weight = torch.nn.Parameter(
             torch.empty(
                 num_experts,
-                2 * intermediate_size_per_partition,
+                self.moe.w13_num_shards * intermediate_size_per_partition,
                 hidden_size,
                 dtype=params_dtype,
             ),
@@ -586,7 +589,7 @@ class QuarkW8A8Int8MoEMethod(QuarkMoEMethod):
             w13_weight_scale = torch.nn.Parameter(
                 torch.ones(
                     num_experts,
-                    2 * intermediate_size_per_partition,
+                    self.moe.w13_num_shards * intermediate_size_per_partition,
                     dtype=torch.float32,
                 ),
                 requires_grad=False,
@@ -605,7 +608,7 @@ class QuarkW8A8Int8MoEMethod(QuarkMoEMethod):
         else:
             # per-tensor: one scalar per expert (two for the fused w1/w3)
             w13_weight_scale = torch.nn.Parameter(
-                torch.ones(num_experts, 2, dtype=torch.float32),
+                torch.ones(num_experts, self.moe.w13_num_shards, dtype=torch.float32),
                 requires_grad=False,
             )
             layer.register_parameter("w13_weight_scale", w13_weight_scale)
@@ -644,7 +647,7 @@ class QuarkW8A8Int8MoEMethod(QuarkMoEMethod):
 
         # ZERO POINTS (loaded but discarded after loading; kernel uses symmetric)
         w13_input_zero_point = torch.nn.Parameter(
-            torch.zeros(num_experts, 2, dtype=torch.int8),
+            torch.zeros(num_experts, self.moe.w13_num_shards, dtype=torch.int8),
             requires_grad=False,
         )
         layer.register_parameter("w13_input_zero_point", w13_input_zero_point)
@@ -661,7 +664,7 @@ class QuarkW8A8Int8MoEMethod(QuarkMoEMethod):
             w13_weight_zero_point = torch.nn.Parameter(
                 torch.zeros(
                     num_experts,
-                    2 * intermediate_size_per_partition,
+                    self.moe.w13_num_shards * intermediate_size_per_partition,
                     dtype=torch.int8,
                 ),
                 requires_grad=False,
@@ -672,7 +675,7 @@ class QuarkW8A8Int8MoEMethod(QuarkMoEMethod):
             )
         else:
             w13_weight_zero_point = torch.nn.Parameter(
-                torch.zeros(num_experts, 2, dtype=torch.int8),
+                torch.zeros(num_experts, self.moe.w13_num_shards, dtype=torch.int8),
                 requires_grad=False,
             )
             w2_weight_zero_point = torch.nn.Parameter(
@@ -689,7 +692,7 @@ class QuarkW8A8Int8MoEMethod(QuarkMoEMethod):
             w13_bias = torch.nn.Parameter(
                 torch.zeros(
                     num_experts,
-                    2 * intermediate_size_per_partition,
+                    self.moe.w13_num_shards * intermediate_size_per_partition,
                     dtype=torch.float32,
                 ),
                 requires_grad=False,
@@ -762,7 +765,7 @@ class QuarkW8A8Int8MoEMethod(QuarkMoEMethod):
 
             for expert_id in range(layer.local_num_experts):
                 start = 0
-                for shard_id in range(2):
+                for shard_id in range(self.moe.w13_num_shards):
                     dq_weight = per_tensor_dequantize(
                         layer.w13_weight[expert_id][start : start + shard_size, :],
                         layer.w13_weight_scale[expert_id][shard_id],
@@ -905,7 +908,7 @@ class QuarkW4A8Fp8MoEMethod(QuarkMoEMethod):
         w13_weight = torch.nn.Parameter(
             torch.zeros(
                 num_experts,
-                2 * intermediate_size_per_partition,
+                self.moe.w13_num_shards * intermediate_size_per_partition,
                 hidden_size // 8,  # INT32 packing for W4
                 dtype=params_dtype,
             ),
@@ -927,7 +930,8 @@ class QuarkW4A8Fp8MoEMethod(QuarkMoEMethod):
 
         # Per-tensor fp8 weight scales
         w13_weight_scale = torch.nn.Parameter(
-            torch.ones(num_experts, 2, dtype=torch.float32), requires_grad=False
+            torch.ones(num_experts, self.moe.w13_num_shards, dtype=torch.float32),
+            requires_grad=False,
         )
         w2_weight_scale = torch.nn.Parameter(
             torch.ones(num_experts, dtype=torch.float32), requires_grad=False
@@ -944,7 +948,7 @@ class QuarkW4A8Fp8MoEMethod(QuarkMoEMethod):
         w13_weight_scale_2 = torch.nn.Parameter(
             torch.ones(
                 num_experts,
-                2 * intermediate_size_per_partition,
+                self.moe.w13_num_shards * intermediate_size_per_partition,
                 dtype=torch.float32,
             ),
             requires_grad=False,
@@ -978,7 +982,7 @@ class QuarkW4A8Fp8MoEMethod(QuarkMoEMethod):
         for expert_id in range(layer.local_num_experts):
             start = 0
             max_w13_scale_fp8 = max_w13_scales[expert_id]
-            for shard_id in range(2):
+            for shard_id in range(self.moe.w13_num_shards):
                 if layer.w13_weight_scale[expert_id][shard_id] != max_w13_scale_fp8:
                     int4_rescale = (
                         layer.w13_weight_scale[expert_id][shard_id] / max_w13_scale_fp8
@@ -1193,7 +1197,7 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
         w13_weight = torch.nn.Parameter(
             torch.zeros(
                 num_experts,
-                2 * intermediate_size_per_partition,
+                self.moe.w13_num_shards * intermediate_size_per_partition,
                 self.get_packed_dim(hidden_size, self.weight_dtype),
                 dtype=params_dtype,
             ),
@@ -1220,7 +1224,7 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
         w13_weight_scale = torch.nn.Parameter(
             torch.ones(
                 num_experts,
-                2 * intermediate_size_per_partition,
+                self.moe.w13_num_shards * intermediate_size_per_partition,
                 hidden_size // OCP_MX_BLOCK_SIZE,
                 dtype=params_dtype,
             ),
@@ -1245,7 +1249,7 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
             w13_bias = torch.nn.Parameter(
                 torch.zeros(
                     num_experts,
-                    2 * intermediate_size_per_partition,
+                    self.moe.w13_num_shards * intermediate_size_per_partition,
                     dtype=torch.float32,
                 ),
                 requires_grad=False,
@@ -1499,13 +1503,12 @@ class QuarkNvfp4MoEMethod(QuarkMoEMethod):
         layer.quant_config = self.quant_config
         weight_dtype = torch.uint8
         weight_scale_dtype = torch.float8_e4m3fn
-        w13_num_shards = 2 if self.moe.is_act_and_mul else 1
 
         # GEMM 1 - w13 weight
         w13_weight = torch.nn.Parameter(
             torch.empty(
                 num_experts,
-                w13_num_shards * intermediate_size_per_partition,
+                self.moe.w13_num_shards * intermediate_size_per_partition,
                 # 2 fp4 items are packed in the input dimension
                 hidden_size // 2,
                 dtype=weight_dtype,
@@ -1533,7 +1536,7 @@ class QuarkNvfp4MoEMethod(QuarkMoEMethod):
         w13_weight_scale = torch.nn.Parameter(
             torch.empty(
                 num_experts,
-                w13_num_shards * intermediate_size_per_partition,
+                self.moe.w13_num_shards * intermediate_size_per_partition,
                 hidden_size // self.group_size,
                 dtype=weight_scale_dtype,
             ),
@@ -1563,7 +1566,7 @@ class QuarkNvfp4MoEMethod(QuarkMoEMethod):
         )
 
         w13_weight_scale_2 = torch.nn.Parameter(
-            torch.empty(num_experts, w13_num_shards, dtype=torch.float32),
+            torch.empty(num_experts, self.moe.w13_num_shards, dtype=torch.float32),
             requires_grad=False,
         )
         layer.register_parameter("w13_weight_scale_2", w13_weight_scale_2)
@@ -1578,7 +1581,7 @@ class QuarkNvfp4MoEMethod(QuarkMoEMethod):
 
         # Input global scales (per-tensor FP32 scales)
         w13_input_scale_2 = torch.nn.Parameter(
-            torch.empty(num_experts, w13_num_shards, dtype=torch.float32),
+            torch.empty(num_experts, self.moe.w13_num_shards, dtype=torch.float32),
             requires_grad=False,
         )
         layer.register_parameter("w13_input_scale_2", w13_input_scale_2)


### PR DESCRIPTION
## Purpose

Non-gated MoE (`is_act_and_mul=False`, e.g. NemotronH's `relu2_no_mul`) fuses
only the up projection into `w13`, so `w13` holds a **single**
`intermediate_size_per_partition` shard rather than two gate/up shards.

13 MoE quantization methods already conditionalize on this — `modelopt.py`,
`compressed_tensors_moe_*`, `flashinfer`, `unquantized_fused_moe_method.py`, … —
each with its own local `w13_num_shards = 2 if self.moe.is_act_and_mul else 1`.
**14 other methods hardcode 2.** For a non-gated model those:

1. **over-allocate `w13`** to `2 * I` rows when only `I` rows are ever written,
   so the second shard stays whatever the allocator handed back. On the online
   path `reload/meta.py` materializes with `torch.empty_strided`, so this is
   uninitialized memory that then flows into the block/per-tensor amax, the
   quantized weight, and the GEMM (`0 × NaN = NaN`);
2. **over-allocate the per-shard scale and bias tensors** (`torch.ones(E, 2)`,
   `torch.zeros(E, 2 * I)`, `(E, 2 * I // block, …)`);
3. **walk `w13` as two shards** when zeroing the roundup padding
   (`Fp8PerBlockOnlineMoEMethod._zero_padding`) or when requantizing
   (`for shard_id in range(2)` in `quark_moe.py`), so the pad band boundaries
   are computed from a half that is twice too small.

Failure mode 3 is the one that bites even where the allocation happens to be
tolerated: the pad rows are never zeroed, so uninitialized values contaminate
the *shared* per-block weight scale of real rows.

Rather than adding a 14th copy of the same local variable, this PR adds one
property next to `is_act_and_mul` and uses it everywhere:

```python
@property
def w13_num_shards(self) -> int:
    """Number of shards fused into w13: gate and up for gated, up only."""
    return 2 if self.is_act_and_mul else 1
```

**Gated models are bit-for-bit unaffected**: the property returns 2 and every
changed expression reduces to the one it replaced.

## Changes

`vllm/model_executor/layers/fused_moe/config.py` — add
`FusedMoEConfig.w13_num_shards`.

68 substitution sites across 13 files:

| file | sites | what |
|---|---:|---|
| `quantization/quark/quark_moe.py` | 24 | 4 methods' `w13` allocations, 5 per-shard `(E, 2)` scale/zero-point tensors, 3 `range(2)` requant loops |
| `quantization/mxfp4.py` | 12 | `GptOssMxfp4MoEMethod` + `Mxfp4MoEMethod` weights/scales/bias and the `_setup_kernel` shape asserts |
| `quantization/fp8.py` | 4 | `w13_weight`, `w13_bias`, per-tensor `torch.ones(E, 2)` scale, block scale, plus `is_act_and_mul=` passthrough to `process_fp8_weight_tensor_strategy_moe` |
| `quantization/auto_gptq.py` | 4 | qweight / qzeros / scales / g_idx |
| `quantization/online/fp8.py` | 4 | `Fp8PerBlockOnlineMoEMethod._zero_padding`, weight and bias |
| `quantization/auto_awq.py` | 3 | incl. the reversed `intermediate_size_per_partition * 2` spelling |
| `quantization/bitsandbytes.py` | 3 | |
| `quantization/moe_wna16.py` | 3 | |
| `compressed_tensors_moe_w4a8_fp8.py` | 3 | |
| `quantization/humming.py` | 2 | |
| `quantization/inc/schemes/inc_mxfp4_moe.py` | 2 | |
| `compressed_tensors_moe_w4a4_mxfp4.py` | 2 | |
| `quantization/online/moe_base.py` | 2 | shared online base: `w13_weight` + `w13_bias` |

Deliberately **not** changed:

- `w13_weight_shape` / `w2_weight_shape` `torch.empty(num_experts, 2)` in the
  compressed-tensors files — that `2` is a `(rows, cols)` shape descriptor, not
  a shard count.
- The 13 methods that already have a correct local `w13_num_shards`. Collapsing
  them onto the new property is a pure identity refactor and belongs in its own
  change, not in a bugfix.
- `moe_wna16.py`'s weight loader `param.data[expert_id, : shard_size // 2]` —
  that `2` is loader shard semantics, only reachable with `has_zp` *and*
  non-gated, and needs its own analysis.

## Why this does not duplicate an existing PR

Three open PRs touch part of this. This PR is a strict superset of their
substantive content in the **weight-allocation / post-load-zeroing** layer:

- **#44498** (`littlecircle0730`) — `Fp8MoEMethod` `w13_weight`, `w13_bias`,
  block scale. All three covered here, **plus** the per-tensor
  `torch.ones(num_experts, 2)` scale and the `is_act_and_mul` passthrough to
  `process_fp8_weight_tensor_strategy_moe` that it misses. Its second hunk adds
  an `Fp8OnlineMoEMethod(Fp8MoEMethod)` class that no longer exists after the
  `online/` refactor, so that part is not carried over.
- **#48028** (`puririshi98`) — `online/moe_base.py` and
  `_zero_padding`; both equivalent to the versions here (that PR merges the
  weight and bias loops, this one keeps the original two-block structure).
- **#50029** (`S1ro1`) — `online/moe_base.py`; equivalent.

All three authors are credited as co-authors.

Two adjacent problems are deliberately **left out of scope** because they are
independently reachable and already have owners:

- **`utils/marlin_utils_fp8.py`** (#50568 `mikekg`, #48028's second half) —
  `_moe_pad_shard_rows` hardcodes `view(e, 2, n, …)`, so a non-gated `w13`
  cannot be viewed as two shards when Marlin pads a tile-misaligned
  intermediate. Same root assumption, but a different layer (kernel-format
  conversion) and **live on `main` today via a path this PR does not touch**:
  `ModelOptFp8MoEMethod` is one of the 13 already-correct allocators, so the
  crash reproduces standalone (`shape '[128, 2, 464, 2688]' is invalid for
  input of size 159645696`). #50568 already validates its fix on the real
  `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8` checkpoint at TP4 including
  GSM8K; folding it in here would replace validated work with unvalidated work.
- **`online/nvfp4.py`** (#50029's second half) — folding the per-expert global
  scale into the weights rounds the product back through `weight.dtype` before
  quantizing, which is a *precision* bug, not a shard-count one. Separate PR.

The remaining 11 quantization files in the table above are covered by no open
PR.

Also checked and non-overlapping: #46795 (TPU config only), #48624
(`flashinfer_fp4_moe.py`), #50196 (`oracle/int_wna16.py`), #43386 / #47106
(non-gated activation kernels).

## Test Plan

Python-only diff, so it can be applied onto an installed `vllm` without a
rebuild. Every case loads a model, `collective_rpc`s a probe that dumps every
MoE expert-tensor shape and measures the `w13` padding band, then
greedy-generates; baseline and patched runs are compared shape-by-shape and
token-by-token.

```bash
# image: vllm/vllm-openai:nightly  sha256:40e504de8278
#        vLLM 0.26.1rc1.dev245+ge2fa28594, built 2026-08-02
# hosts: 8x H200 (SM90)

# non-gated, online per-block fp8, intermediate 1856 -> padded 1920
run_case.sh nemotron_h_nogated  {baseline,patched}

# gated regressions
run_case.sh qwen3_moe_fp8_block   {baseline,patched}   # Fp8MoEMethod block
run_case.sh gpt_oss_mxfp4         {baseline,patched}   # GptOssMxfp4MoEMethod
run_case.sh qwen3_moe_gptq_int4   {baseline,patched}   # AutoGPTQMoEMethod
run_case.sh mixtral_ct_fp8_tensor {baseline,patched}   # untouched-file control

# gated, real weights, TP1, greedy, 4+4 runs
RedHatAI/Mixtral-8x7B-Instruct-v0.1-FP8
```

Synthetic cases are real upstream `config.json`s with the layer and expert
counts shrunk, loaded with `--load-format dummy --skip-tokenizer-init`, which
exercises `create_weights` → `process_weights_after_loading` → kernel setup
without needing checkpoints.

## Test Result

**The fix does what it claims.** `nemotron_h` routed experts are non-gated
(`activation_without_mul("relu2")` → `relu2_no_mul`) and
`moe_intermediate_size=1856` is not a multiple of 128, so the online per-block
path rounds 1856 → 1920:

| | baseline | patched |
|---|---|---|
| `w13_weight` | `[8, 3840, 2688]` (2 × 1920) | `[8, 1920, 2688]` |
| `w13_weight_scale_inv` | `[8, 30, 21]` | `[8, 15, 21]` |
| `w13` pad band | 42,663,936 elems, **93.5 % nonzero** | 1,376,256 elems, **0 % nonzero** |

The patched band is exactly 8 experts × 64 rows × 2688 — the 1856→1920 padding
— and fully zeroed. Baseline allocates twice the rows, leaves the entire extra
shard uninitialized, and hands it to the block-FP8 quantizer and the GEMM. The
93.5 % figure reconciles: the old code's two 64-row bands account for 2,752,512
zeros against 2,752,599 measured, i.e. only 87 incidentally-zero elements out of
the 39.9 M it never touched.

Neither run crashes. With dummy weights nothing validates the shape, so this is
the silent-contamination failure mode rather than a load error — which is why
the probe checks the band directly.

**No regression on gated paths.** `status=ok`, MoE tensor shapes byte-identical
baseline vs patched, identical generated token ids:

| case | path exercised | result |
|---|---|---|
| `offline_fp8_block` | `Fp8MoEMethod` block branch | identical |
| `offline_mxfp4` | `GptOssMxfp4MoEMethod` incl. the new `_setup_kernel` asserts | identical |
| `offline_gptq_int4` | `AutoGPTQMoEMethod` | identical |
| `offline_ct_fp8_tensor` | `CompressedTensorsW8A8Fp8MoEMethod` (untouched file) | identical |

Real weights, `RedHatAI/Mixtral-8x7B-Instruct-v0.1-FP8`, TP1, greedy, 4
baseline + 4 patched: MoE shapes identical in all 8 runs; 7/8 produce identical
text. The one divergent patched run is vLLM's run-to-run greedy
nondeterminism, not the diff — that model's MoE method lives in a file this PR
does not touch, and 3 further baseline + 3 further patched runs all agreed.

Since gated shapes and outputs are unchanged and the non-gated path previously
consumed uninitialized memory, there is no accuracy delta to measure on a
supported configuration; the shape and pad-band evidence above stands in for a
model eval.

**Not covered on this hardware** (stated explicitly rather than implied):

- *Gated + padding on the online per-block path.* Four gated configs with
  `moe_intermediate_size % 128 != 0` (qwen3_moe, all-MoE qwen3_moe,
  glm4_moe_lite, deepseek_v2) fail **identically before and after** this diff,
  inside the *linear* block-scaled-mm kernel (`the last dimension of x … must
  be divisible by group_size 128`, plus a `triton_scaled_mm` scale-shape
  assert). Unrelated to this change. The gated `_zero_padding` slices are
  unchanged by construction — shard count 2 reproduces the same two bands.
- *quark (AMD), bitsandbytes MoE, humming, inc (Gaudi)* — no hardware.
- *AWQ MoE, compressed-tensors w4a4_mxfp4 / w4a8_fp8* — no checkpoint or config
  available locally. These are shape-only substitutions that reduce to the
  previous expression when gated.

Disclosure for reproducibility: the patched runs applied this diff together
with an unrelated `online/nvfp4.py` change (the #50029 follow-up mentioned
above). That change is inert here — `Nvfp4OnlineMoEMethod` refuses non-SM100
and H200 is SM90 — so it cannot affect any result reported above.

## AI assistance disclosure

This PR was developed with AI assistance (Claude Code), including the
cross-PR overlap analysis and the integration harness. The human submitter has
reviewed every changed line, ran the tests above, and can defend the change
end-to-end.
