### PR TITLE
[CI] Run control-plane workflows on vLLM runners

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   pre-run-check:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, vllm-runners]
     steps:
     - name: Check PR label and author merge count
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/run-ci-command.yml
+++ b/.github/workflows/run-ci-command.yml
@@ -21,7 +21,7 @@ jobs:
       github.event.comment.body == '/ci run all' ||
       github.event.comment.body == '/ci run nightly' ||
       github.event.comment.body == '/ci retry')
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, vllm-runners]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
## Summary

- run the pre-commit `pre-run-check` gate on the `vllm-runners` self-hosted runner group
- run the PR-comment CI broker on the same `vllm-runners` group
- keep the existing self-hosted `pre-commit` runner labels unchanged

Both jobs now use the repository's established selector:

```yaml
runs-on: [self-hosted, linux, x64, vllm-runners]
```

## Why

The organization was at its 20/20 standard GitHub-hosted concurrency limit.

For the pre-commit workflow, waiting on the GitHub-hosted `pre-run-check` prevents the dependent self-hosted job from being created, so no `workflow_job` event reaches the AWS runner autoscaler.

Separately, [PR-comment workflow run 30981284643](https://github.com/vllm-project/vllm/actions/runs/30981284643) spent 15m 50s queued for `ubuntu-latest` before executing for 15s.

Routing both lightweight control-plane jobs through `vllm-runners` removes that dependency on the saturated standard hosted pool.

## Security

- `pre-run-check` does not check out or execute pull-request code; it only runs a pinned `actions/github-script` action against GitHub API metadata.
- `run-ci-command` explicitly checks out the repository default branch, not the pull-request head, and retains its existing authorization checks before dispatching Buildkite.

Because these runners are ephemeral, an eligible pre-commit workflow may use one runner for `pre-run-check` and a second runner for the dependent `pre-commit` job.

## Duplicate-work check

Searched open PRs for:

- `pre-run-check vllm-runners`
- `pre-commit self-hosted runner`
- `ubuntu-latest pre-run-check`
- `run-ci-command vllm-runners`
- `GitHub hosted runner queue issue_comment`

No other open PR addressing these workflow changes was found. The former standalone comment-broker change in #51128 has been folded into this PR.

## Validation

- `uvx --from pre-commit pre-commit run actionlint --files .github/workflows/pre-commit.yml` — passed
- `actionlint -config-file .github/actionlint.yaml /private/tmp/run-ci-command-vllm-runners-30981284643.yml` — passed
- Remote comparison against `main`: two workflow files changed, each with one addition and one deletion
- Model evaluations: not applicable; these changes only affect CI runner scheduling

## AI assistance

OpenAI Codex assisted with the queue diagnosis, changes, validation, and draft PR preparation. A human submitter must review and understand every changed line before marking this PR ready for review.