### PR TITLE
[CI] Run comment broker on vllm runners

### DIFF
--- a/.github/workflows/run-ci-command.yml
+++ b/.github/workflows/run-ci-command.yml
@@ -21,7 +21,7 @@ jobs:
       github.event.comment.body == '/ci run all' ||
       github.event.comment.body == '/ci run nightly' ||
       github.event.comment.body == '/ci retry')
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, vllm-runners]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
## Summary

Route the PR-comment CI broker from the saturated standard GitHub-hosted runner pool to the existing vLLM self-hosted runner pool:

```yaml
runs-on: [self-hosted, linux, x64, vllm-runners]
```

This reuses the same runner selector already used by `.github/workflows/pre-commit.yml`.

## Why

[Workflow run 30981284643](https://github.com/vllm-project/vllm/actions/runs/30981284643) spent 15m 50s queued for `ubuntu-latest` before executing for 15s. The organization runner dashboard was at its 20/20 standard GitHub-hosted concurrency limit, with unrelated long-running jobs occupying the pool.

Moving this lightweight broker to `vllm-runners` avoids that organization-wide hosted-runner queue. The workflow still checks out the default branch explicitly and does not execute pull-request code.

## Duplicate check

Searched open PRs for:

- `run-ci-command vllm-runners`
- `GitHub hosted runner queue issue_comment`

No matching open PR was found.

## Validation

- `actionlint -config-file .github/actionlint.yaml /private/tmp/run-ci-command-vllm-runners-30981284643.yml` — passed
- Remote comparison against `main`: one workflow file changed, one addition and one deletion
- Model evaluations: not applicable; this only changes CI runner selection

## AI assistance

OpenAI Codex assisted with the queue diagnosis, patch, validation, and draft PR preparation. A human submitter must review and understand every changed line before marking this PR ready for review.