### PR TITLE
[Performance][Hardware][RISC-V] Use RVV FMA in FP32Vec transcendentals and the INT4 GEMM

### DIFF
--- a/csrc/cpu/cpu_types_riscv_impl.hpp
+++ b/csrc/cpu/cpu_types_riscv_impl.hpp
@@ -525,22 +525,27 @@ struct FP32Vec8 : public Vec<FP32Vec8> {
     fixed_fp32x8_t r =
         RVVI(__riscv_vfsub_vv_f32, LMUL_256)(x_scaled, n_float, VEC_ELEM_NUM);
 
+    // Horner via vfmadd (vd = vd * vs1 + vs2): one instruction per step
+    // instead of vfmul + vfadd.  The coefficient splats are loop-invariant
+    // and hoist out of caller loops.
+    const fixed_fp32x8_t c1 =
+        RVVI(__riscv_vfmv_v_f_f32, LMUL_256)(0.009618129107628f, VEC_ELEM_NUM);
+    const fixed_fp32x8_t c2 =
+        RVVI(__riscv_vfmv_v_f_f32, LMUL_256)(0.055504108664821f, VEC_ELEM_NUM);
+    const fixed_fp32x8_t c3 =
+        RVVI(__riscv_vfmv_v_f_f32, LMUL_256)(0.240226506959101f, VEC_ELEM_NUM);
+    const fixed_fp32x8_t c4 =
+        RVVI(__riscv_vfmv_v_f_f32, LMUL_256)(0.693147180559945f, VEC_ELEM_NUM);
+    const fixed_fp32x8_t c5 =
+        RVVI(__riscv_vfmv_v_f_f32, LMUL_256)(1.0f, VEC_ELEM_NUM);
+
     fixed_fp32x8_t poly =
         RVVI(__riscv_vfmv_v_f_f32, LMUL_256)(0.001333355810164f, VEC_ELEM_NUM);
-    poly = RVVI(__riscv_vfmul_vv_f32, LMUL_256)(poly, r, VEC_ELEM_NUM);
-    poly = RVVI(__riscv_vfadd_vf_f32, LMUL_256)(poly, 0.009618129107628f,
-                                                VEC_ELEM_NUM);
-    poly = RVVI(__riscv_vfmul_vv_f32, LMUL_256)(poly, r, VEC_ELEM_NUM);
-    poly = RVVI(__riscv_vfadd_vf_f32, LMUL_256)(poly, 0.055504108664821f,
-                                                VEC_ELEM_NUM);
-    poly = RVVI(__riscv_vfmul_vv_f32, LMUL_256)(poly, r, VEC_ELEM_NUM);
-    poly = RVVI(__riscv_vfadd_vf_f32, LMUL_256)(poly, 0.240226506959101f,
-                                                VEC_ELEM_NUM);
-    poly = RVVI(__riscv_vfmul_vv_f32, LMUL_256)(poly, r, VEC_ELEM_NUM);
-    poly = RVVI(__riscv_vfadd_vf_f32, LMUL_256)(poly, 0.693147180559945f,
-                                                VEC_ELEM_NUM);
-    poly = RVVI(__riscv_vfmul_vv_f32, LMUL_256)(poly, r, VEC_ELEM_NUM);
-    poly = RVVI(__riscv_vfadd_vf_f32, LMUL_256)(poly, 1.0f, VEC_ELEM_NUM);
+    poly = RVVI(__riscv_vfmadd_vv_f32, LMUL_256)(poly, r, c1, VEC_ELEM_NUM);
+    poly = RVVI(__riscv_vfmadd_vv_f32, LMUL_256)(poly, r, c2, VEC_ELEM_NUM);
+    poly = RVVI(__riscv_vfmadd_vv_f32, LMUL_256)(poly, r, c3, VEC_ELEM_NUM);
+    poly = RVVI(__riscv_vfmadd_vv_f32, LMUL_256)(poly, r, c4, VEC_ELEM_NUM);
+    poly = RVVI(__riscv_vfmadd_vv_f32, LMUL_256)(poly, r, c5, VEC_ELEM_NUM);
 
     fixed_i32x8_t biased_exp =
         RVVI(__riscv_vadd_vx_i32, LMUL_256)(n_int, 127, VEC_ELEM_NUM);
@@ -576,25 +581,28 @@ struct FP32Vec8 : public Vec<FP32Vec8> {
     fixed_fp32x8_t abs_x =
         RVVI(__riscv_vfabs_v_f32, LMUL_256)(reg, VEC_ELEM_NUM);
 
-    fixed_fp32x8_t t = RVVI(__riscv_vfadd_vf_f32, LMUL_256)(
-        RVVI(__riscv_vfmul_vf_f32, LMUL_256)(abs_x, p, VEC_ELEM_NUM), 1.0f,
-        VEC_ELEM_NUM);
+    const fixed_fp32x8_t one =
+        RVVI(__riscv_vfmv_v_f_f32, LMUL_256)(1.0f, VEC_ELEM_NUM);
+    // 1 + p * abs_x  via vfmadd.vf (vd = vd * f + vs2)
+    fixed_fp32x8_t t =
+        RVVI(__riscv_vfmadd_vf_f32, LMUL_256)(abs_x, p, one, VEC_ELEM_NUM);
     t = RVVI(__riscv_vfrdiv_vf_f32, LMUL_256)(t, 1.0f, VEC_ELEM_NUM);
+
+    const fixed_fp32x8_t a4v =
+        RVVI(__riscv_vfmv_v_f_f32, LMUL_256)(a4, VEC_ELEM_NUM);
+    const fixed_fp32x8_t a3v =
+        RVVI(__riscv_vfmv_v_f_f32, LMUL_256)(a3, VEC_ELEM_NUM);
+    const fixed_fp32x8_t a2v =
+        RVVI(__riscv_vfmv_v_f_f32, LMUL_256)(a2, VEC_ELEM_NUM);
+    const fixed_fp32x8_t a1v =
+        RVVI(__riscv_vfmv_v_f_f32, LMUL_256)(a1, VEC_ELEM_NUM);
 
     fixed_fp32x8_t poly =
         RVVI(__riscv_vfmv_v_f_f32, LMUL_256)(a5, VEC_ELEM_NUM);
-    poly = RVVI(__riscv_vfadd_vf_f32, LMUL_256)(
-        RVVI(__riscv_vfmul_vv_f32, LMUL_256)(poly, t, VEC_ELEM_NUM), a4,
-        VEC_ELEM_NUM);
-    poly = RVVI(__riscv_vfadd_vf_f32, LMUL_256)(
-        RVVI(__riscv_vfmul_vv_f32, LMUL_256)(poly, t, VEC_ELEM_NUM), a3,
-        VEC_ELEM_NUM);
-    poly = RVVI(__riscv_vfadd_vf_f32, LMUL_256)(
-        RVVI(__riscv_vfmul_vv_f32, LMUL_256)(poly, t, VEC_ELEM_NUM), a2,
-        VEC_ELEM_NUM);
-    poly = RVVI(__riscv_vfadd_vf_f32, LMUL_256)(
-        RVVI(__riscv_vfmul_vv_f32, LMUL_256)(poly, t, VEC_ELEM_NUM), a1,
-        VEC_ELEM_NUM);
+    poly = RVVI(__riscv_vfmadd_vv_f32, LMUL_256)(poly, t, a4v, VEC_ELEM_NUM);
+    poly = RVVI(__riscv_vfmadd_vv_f32, LMUL_256)(poly, t, a3v, VEC_ELEM_NUM);
+    poly = RVVI(__riscv_vfmadd_vv_f32, LMUL_256)(poly, t, a2v, VEC_ELEM_NUM);
+    poly = RVVI(__riscv_vfmadd_vv_f32, LMUL_256)(poly, t, a1v, VEC_ELEM_NUM);
     poly = RVVI(__riscv_vfmul_vv_f32, LMUL_256)(poly, t, VEC_ELEM_NUM);
 
     fixed_fp32x8_t exp_val = FP32Vec8(RVVI(__riscv_vfneg_v_f32, LMUL_256)(
@@ -603,9 +611,9 @@ struct FP32Vec8 : public Vec<FP32Vec8> {
                                           VEC_ELEM_NUM))
                                  .exp()
                                  .reg;
-    fixed_fp32x8_t res = RVVI(__riscv_vfrsub_vf_f32, LMUL_256)(
-        RVVI(__riscv_vfmul_vv_f32, LMUL_256)(poly, exp_val, VEC_ELEM_NUM), 1.0f,
-        VEC_ELEM_NUM);
+    // 1 - poly * exp_val  via vfnmsac.vv (vd = vd - vs1 * vs2)
+    fixed_fp32x8_t res = RVVI(__riscv_vfnmsac_vv_f32, LMUL_256)(
+        one, poly, exp_val, VEC_ELEM_NUM);
 
     rvv_mask_f32x8_t mask = RVVIB(__riscv_vmflt_vf_f32, LMUL_256, BOOL_256)(
         reg, 0.0f, VEC_ELEM_NUM);
@@ -793,23 +801,27 @@ struct FP32Vec16 : public Vec<FP32Vec16> {
     fixed_fp32x16_t r =
         RVVI(__riscv_vfsub_vv_f32, LMUL_512)(x_scaled, n_float, VEC_ELEM_NUM);
 
+    // Horner via vfmadd (vd = vd * vs1 + vs2): one instruction per step
+    // instead of vfmul + vfadd.  The coefficient splats are loop-invariant
+    // and hoist out of caller loops.
+    const fixed_fp32x16_t c1 =
+        RVVI(__riscv_vfmv_v_f_f32, LMUL_512)(0.009618129107628f, VEC_ELEM_NUM);
+    const fixed_fp32x16_t c2 =
+        RVVI(__riscv_vfmv_v_f_f32, LMUL_512)(0.055504108664821f, VEC_ELEM_NUM);
+    const fixed_fp32x16_t c3 =
+        RVVI(__riscv_vfmv_v_f_f32, LMUL_512)(0.240226506959101f, VEC_ELEM_NUM);
+    const fixed_fp32x16_t c4 =
+        RVVI(__riscv_vfmv_v_f_f32, LMUL_512)(0.693147180559945f, VEC_ELEM_NUM);
+    const fixed_fp32x16_t c5 =
+        RVVI(__riscv_vfmv_v_f_f32, LMUL_512)(1.0f, VEC_ELEM_NUM);
+
     fixed_fp32x16_t poly =
         RVVI(__riscv_vfmv_v_f_f32, LMUL_512)(0.001333355810164f, VEC_ELEM_NUM);
-    poly = RVVI(__riscv_vfadd_vf_f32, LMUL_512)(
-        RVVI(__riscv_vfmul_vv_f32, LMUL_512)(poly, r, VEC_ELEM_NUM),
-        0.009618129107628f, VEC_ELEM_NUM);
-    poly = RVVI(__riscv_vfadd_vf_f32, LMUL_512)(
-        RVVI(__riscv_vfmul_vv_f32, LMUL_512)(poly, r, VEC_ELEM_NUM),
-        0.055504108664821f, VEC_ELEM_NUM);
-    poly = RVVI(__riscv_vfadd_vf_f32, LMUL_512)(
-        RVVI(__riscv_vfmul_vv_f32, LMUL_512)(poly, r, VEC_ELEM_NUM),
-        0.240226506959101f, VEC_ELEM_NUM);
-    poly = RVVI(__riscv_vfadd_vf_f32, LMUL_512)(
-        RVVI(__riscv_vfmul_vv_f32, LMUL_512)(poly, r, VEC_ELEM_NUM),
-        0.693147180559945f, VEC_ELEM_NUM);
-    poly = RVVI(__riscv_vfadd_vf_f32, LMUL_512)(
-        RVVI(__riscv_vfmul_vv_f32, LMUL_512)(poly, r, VEC_ELEM_NUM), 1.0f,
-        VEC_ELEM_NUM);
+    poly = RVVI(__riscv_vfmadd_vv_f32, LMUL_512)(poly, r, c1, VEC_ELEM_NUM);
+    poly = RVVI(__riscv_vfmadd_vv_f32, LMUL_512)(poly, r, c2, VEC_ELEM_NUM);
+    poly = RVVI(__riscv_vfmadd_vv_f32, LMUL_512)(poly, r, c3, VEC_ELEM_NUM);
+    poly = RVVI(__riscv_vfmadd_vv_f32, LMUL_512)(poly, r, c4, VEC_ELEM_NUM);
+    poly = RVVI(__riscv_vfmadd_vv_f32, LMUL_512)(poly, r, c5, VEC_ELEM_NUM);
 
     fixed_i32x16_t biased_exp = RVVI(__riscv_vmax_vx_i32, LMUL_512)(
         RVVI(__riscv_vadd_vx_i32, LMUL_512)(n_int, 127, VEC_ELEM_NUM), 0,
@@ -840,26 +852,28 @@ struct FP32Vec16 : public Vec<FP32Vec16> {
                 a3 = 1.421413741f, a4 = -1.453152027f, a5 = 1.061405429f;
     fixed_fp32x16_t abs_x =
         RVVI(__riscv_vfabs_v_f32, LMUL_512)(reg, VEC_ELEM_NUM);
-    fixed_fp32x16_t t = RVVI(__riscv_vfrdiv_vf_f32, LMUL_512)(
-        RVVI(__riscv_vfadd_vf_f32, LMUL_512)(
-            RVVI(__riscv_vfmul_vf_f32, LMUL_512)(abs_x, p, VEC_ELEM_NUM), 1.0f,
-            VEC_ELEM_NUM),
-        1.0f, VEC_ELEM_NUM);
+    const fixed_fp32x16_t one =
+        RVVI(__riscv_vfmv_v_f_f32, LMUL_512)(1.0f, VEC_ELEM_NUM);
+    // 1 + p * abs_x  via vfmadd.vf (vd = vd * f + vs2)
+    fixed_fp32x16_t t =
+        RVVI(__riscv_vfmadd_vf_f32, LMUL_512)(abs_x, p, one, VEC_ELEM_NUM);
+    t = RVVI(__riscv_vfrdiv_vf_f32, LMUL_512)(t, 1.0f, VEC_ELEM_NUM);
+
+    const fixed_fp32x16_t a4v =
+        RVVI(__riscv_vfmv_v_f_f32, LMUL_512)(a4, VEC_ELEM_NUM);
+    const fixed_fp32x16_t a3v =
+        RVVI(__riscv_vfmv_v_f_f32, LMUL_512)(a3, VEC_ELEM_NUM);
+    const fixed_fp32x16_t a2v =
+        RVVI(__riscv_vfmv_v_f_f32, LMUL_512)(a2, VEC_ELEM_NUM);
+    const fixed_fp32x16_t a1v =
+        RVVI(__riscv_vfmv_v_f_f32, LMUL_512)(a1, VEC_ELEM_NUM);
 
     fixed_fp32x16_t poly =
         RVVI(__riscv_vfmv_v_f_f32, LMUL_512)(a5, VEC_ELEM_NUM);
-    poly = RVVI(__riscv_vfadd_vf_f32, LMUL_512)(
-        RVVI(__riscv_vfmul_vv_f32, LMUL_512)(poly, t, VEC_ELEM_NUM), a4,
-        VEC_ELEM_NUM);
-    poly = RVVI(__riscv_vfadd_vf_f32, LMUL_512)(
-        RVVI(__riscv_vfmul_vv_f32, LMUL_512)(poly, t, VEC_ELEM_NUM), a3,
-        VEC_ELEM_NUM);
-    poly = RVVI(__riscv_vfadd_vf_f32, LMUL_512)(
-        RVVI(__riscv_vfmul_vv_f32, LMUL_512)(poly, t, VEC_ELEM_NUM), a2,
-        VEC_ELEM_NUM);
-    poly = RVVI(__riscv_vfadd_vf_f32, LMUL_512)(
-        RVVI(__riscv_vfmul_vv_f32, LMUL_512)(poly, t, VEC_ELEM_NUM), a1,
-        VEC_ELEM_NUM);
+    poly = RVVI(__riscv_vfmadd_vv_f32, LMUL_512)(poly, t, a4v, VEC_ELEM_NUM);
+    poly = RVVI(__riscv_vfmadd_vv_f32, LMUL_512)(poly, t, a3v, VEC_ELEM_NUM);
+    poly = RVVI(__riscv_vfmadd_vv_f32, LMUL_512)(poly, t, a2v, VEC_ELEM_NUM);
+    poly = RVVI(__riscv_vfmadd_vv_f32, LMUL_512)(poly, t, a1v, VEC_ELEM_NUM);
     poly = RVVI(__riscv_vfmul_vv_f32, LMUL_512)(poly, t, VEC_ELEM_NUM);
 
     fixed_fp32x16_t exp_val =
@@ -869,9 +883,9 @@ struct FP32Vec16 : public Vec<FP32Vec16> {
                       VEC_ELEM_NUM))
             .exp()
             .reg;
-    fixed_fp32x16_t res = RVVI(__riscv_vfrsub_vf_f32, LMUL_512)(
-        RVVI(__riscv_vfmul_vv_f32, LMUL_512)(poly, exp_val, VEC_ELEM_NUM), 1.0f,
-        VEC_ELEM_NUM);
+    // 1 - poly * exp_val  via vfnmsac.vv (vd = vd - vs1 * vs2)
+    fixed_fp32x16_t res = RVVI(__riscv_vfnmsac_vv_f32, LMUL_512)(
+        one, poly, exp_val, VEC_ELEM_NUM);
 
     rvv_mask_f32x16_t mask = RVVIB(__riscv_vmflt_vf_f32, LMUL_512, BOOL_512)(
         reg, 0.0f, VEC_ELEM_NUM);

--- a/csrc/cpu/sgl-kernels/gemm_int4.cpp
+++ b/csrc/cpu/sgl-kernels/gemm_int4.cpp
@@ -314,18 +314,18 @@ inline fixed_i32x8_t gemm_accum_uint8_int8_rvv(fixed_i32x8_t acc, uint8_t a, fix
   return RVVI(__riscv_vwmacc_vx_i32, LMUL_256)(acc, static_cast<int16_t>(a), b_i16, vl);
 }
 
+// Accumulates the raw sum_k a_k * b_k. The weight zero-point is not applied
+// here: it is loop-invariant in k, so
+//     sum_k a_k * (b_k - zb) = sum_k a_k * b_k - zb * sum_k a_k
+// and the correction is folded into the epilogue using sum_k a_k. That keeps
+// the qzeros load and the subtract out of the innermost loop.
 template <int64_t N, int64_t ldb, int group>
 inline fixed_i32x8_t gemm_accum_uint4_rvv(
     fixed_i32x8_t acc,
     const uint8_t* __restrict__ B,
-    const int8_t* __restrict__ qzeros_b,
     uint8_t a,
     int64_t k) {
-  constexpr int64_t n_group_size = 8;
   fixed_i8x8_t b = load_uint4_as_int8_rvv<N, ldb, group>(B, k);
-  fixed_i8x8_t qzeros =
-      RVVI(__riscv_vle8_v_i8, LMUL_64)(qzeros_b + group * n_group_size, n_group_size);
-  b = RVVI(__riscv_vsub_vv_i8, LMUL_64)(b, qzeros, n_group_size);
   return gemm_accum_uint8_int8_rvv(acc, a, b);
 }
 
@@ -336,28 +336,34 @@ inline void _dequant_and_store_rvv(
     const float* __restrict__ scales_a,
     const int32_t* __restrict__ qzeros_a,
     const float* __restrict__ scales_b,
+    const int8_t* __restrict__ qzeros_b,
     const int32_t* __restrict__ compensation,
+    int32_t asum,
     int64_t m,
     int64_t ldc) {
   constexpr int64_t n_group_size = 8;
   constexpr int64_t n = group * n_group_size;
   constexpr int64_t vl = n_group_size;
 
-  // Dequant compensation: remove activation zero-point contribution.
+  // Weight zero-point, hoisted out of the K loop: acc -= zb * sum_k a_k.
+  fixed_i32x8_t zb = RVVI(__riscv_vsext_vf4_i32, LMUL_256)(
+      RVVI(__riscv_vle8_v_i8, LMUL_64)(qzeros_b + n, vl), vl);
+  acc = RVVI(__riscv_vnmsac_vx_i32, LMUL_256)(acc, asum, zb, vl);
+
+  // Activation zero-point: acc -= compensation[n] * qzeros_a[m].
   fixed_i32x8_t comp = RVVI(__riscv_vle32_v_i32, LMUL_256)(compensation + n, vl);
-  fixed_i32x8_t zp_comp = RVVI(__riscv_vmul_vx_i32, LMUL_256)(comp, qzeros_a[m], vl);
-  acc = RVVI(__riscv_vsub_vv_i32, LMUL_256)(acc, zp_comp, vl);
+  acc = RVVI(__riscv_vnmsac_vx_i32, LMUL_256)(acc, qzeros_a[m], comp, vl);
 
   // Scale: convert int32 accumulators to fp32 and apply activation/weight scales.
   fixed_fp32x8_t acc_f = RVVI(__riscv_vfcvt_f_x_v_f32, LMUL_256)(acc, vl);
   acc_f = RVVI(__riscv_vfmul_vf_f32, LMUL_256)(acc_f, scales_a[m], vl);
   fixed_fp32x8_t scale_b = RVVI(__riscv_vle32_v_f32, LMUL_256)(scales_b + n, vl);
-  acc_f = RVVI(__riscv_vfmul_vv_f32, LMUL_256)(acc_f, scale_b, vl);
 
-  // Store: accumulate into the float scratch buffer that already holds bias/zero.
+  // Store: c += acc_f * scale_b, fused into the accumulate.
   float* c_ptr = C + m * ldc + n;
   fixed_fp32x8_t c_old = RVVI(__riscv_vle32_v_f32, LMUL_256)(c_ptr, vl);
-  fixed_fp32x8_t c_new = RVVI(__riscv_vfadd_vv_f32, LMUL_256)(c_old, acc_f, vl);
+  fixed_fp32x8_t c_new =
+      RVVI(__riscv_vfmacc_vv_f32, LMUL_256)(c_old, acc_f, scale_b, vl);
   RVVI(__riscv_vse32_v_f32, LMUL_256)(c_ptr, c_new, vl);
 }
 
@@ -385,21 +391,28 @@ void _dequant_gemm_accum_rvv(
     fixed_i32x8_t acc1 = RVVI(__riscv_vmv_v_x_i32, LMUL_256)(0, vl);
     fixed_i32x8_t acc2 = RVVI(__riscv_vmv_v_x_i32, LMUL_256)(0, vl);
     fixed_i32x8_t acc3 = RVVI(__riscv_vmv_v_x_i32, LMUL_256)(0, vl);
+    // sum_k a_k, used by the epilogue to apply the weight zero-point.
+    int32_t asum = 0;
     // A[m][k] @ B[k][0:32] -> acc[m][0:32]
     for (int64_t k = 0; k < K; ++k) {
       // GEMM K step: one scalar activation updates four 8-column RVV tiles.
       const uint8_t a = A[m * lda + k];
-      acc0 = gemm_accum_uint4_rvv<N, ldb, 0>(acc0, B, qzeros_b, a, k);
-      acc1 = gemm_accum_uint4_rvv<N, ldb, 1>(acc1, B, qzeros_b, a, k);
-      acc2 = gemm_accum_uint4_rvv<N, ldb, 2>(acc2, B, qzeros_b, a, k);
-      acc3 = gemm_accum_uint4_rvv<N, ldb, 3>(acc3, B, qzeros_b, a, k);
+      asum += a;
+      acc0 = gemm_accum_uint4_rvv<N, ldb, 0>(acc0, B, a, k);
+      acc1 = gemm_accum_uint4_rvv<N, ldb, 1>(acc1, B, a, k);
+      acc2 = gemm_accum_uint4_rvv<N, ldb, 2>(acc2, B, a, k);
+      acc3 = gemm_accum_uint4_rvv<N, ldb, 3>(acc3, B, a, k);
     }
 
     // Dequant/scale/store each 8-column group back into C.
-    _dequant_and_store_rvv<0>(C, acc0, scales_a, qzeros_a, scales_b, compensation, m, ldc);
-    _dequant_and_store_rvv<1>(C, acc1, scales_a, qzeros_a, scales_b, compensation, m, ldc);
-    _dequant_and_store_rvv<2>(C, acc2, scales_a, qzeros_a, scales_b, compensation, m, ldc);
-    _dequant_and_store_rvv<3>(C, acc3, scales_a, qzeros_a, scales_b, compensation, m, ldc);
+    _dequant_and_store_rvv<0>(
+        C, acc0, scales_a, qzeros_a, scales_b, qzeros_b, compensation, asum, m, ldc);
+    _dequant_and_store_rvv<1>(
+        C, acc1, scales_a, qzeros_a, scales_b, qzeros_b, compensation, asum, m, ldc);
+    _dequant_and_store_rvv<2>(
+        C, acc2, scales_a, qzeros_a, scales_b, qzeros_b, compensation, asum, m, ldc);
+    _dequant_and_store_rvv<3>(
+        C, acc3, scales_a, qzeros_a, scales_b, qzeros_b, compensation, asum, m, ldc);
   }
 }
 #endif


### PR DESCRIPTION



## Purpose

GCC does not contract explicit RVV intrinsic calls into FMAs, so hand-written `vfmul` + `vfadd` pairs cost two instructions and two dependent FP latencies.

**1. FP32Vec8/16 `exp()` and `er()`** — evaluate Horner with `vfmadd_vv`, one instruction per step instead of two. `er()` also folds `1 + p*|x|` into `vfmadd_vf` and `1 - poly*exp` into `vfnmsac_vv`. `exp()`'s inner loop drops from 22 to 18 vector instructions; the polynomial itself from 10 to 5. `tanh()` is unchanged — it contains no multiply-add of its own and improves only via the `exp()` it calls.

**2. INT4 GEMM** — the weight zero-point is loop-invariant in K, so

    `sum_k a_k * (b_k - zb) = sum_k a_k * b_k - zb * sum_k a_k`

The inner loop now accumulates the raw product and the epilogue applies `-zb * sum_k a_k` once. This reuses the existing `compensation` term, already computed as `sum_k (b_k - zb)`, so the weight packing path is unchanged. It removes a `vle8` and a `vsub` per K step per 8-column group. The epilogue also gains `vmul.vx`+`vsub.vv` -> `vnmsac.vx` and `vfmul.vv`+`vfadd.vv` -> `vfmacc.vv`.

## Test Result

### Activation ops (commit 1) — ns/element, 512x4096 output, best of 5

| op | fp32 | bf16 |
| :--- | :--- | :--- |
| silu_and_mul | 5.637 → 4.939 (1.14×) | 6.193 → 5.408 (1.15×) |
| gelu_and_mul | 6.761 → 5.881 (1.15×) | 7.075 → 6.201 (1.14×) |
| gelu_tanh_and_mul | 7.328 → 6.616 (1.11×) | 7.922 → 7.133 (1.11×) |

Accuracy unchanged — two of three fp32 ops bit-identical, all bf16 identical. Only gelu_tanh fp32 moves: 1.431e-06 → 1.550e-06, both at fp32 rounding noise.

### INT4 GEMM (commit 2) — GFLOP/s, `int4_scaled_mm_cpu`, best of 5

| M | K | N | before | after | speedup |
| ---: | ---: | ---: | ---: | ---: | :--- |
| 1 | 1024 | 1024 | 5.602 | 6.893 | 1.23× |
| 1 | 2048 | 2048 | 6.002 | 7.438 | 1.24× |
| 4 | 2048 | 2048 | 6.218 | 7.854 | 1.26× |
| 16 | 2048 | 2048 | 6.278 | 7.966 | 1.27× |
| 64 | 2048 | 2048 | 6.311 | 7.974 | 1.26× |
| 16 | 4096 | 4096 | 6.290 | 7.939 | 1.26× |

Relative error against a float reference is ~8e-3 in both builds (int4 quantization error, unchanged by the reordering).

### Correctness

`VLLM_CPU_INT4_W4A8=1 pytest tests/kernels/test_awq_int4_to_int8.py` → 16 passed, run both before and after the change.

Build: 0 errors.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

