### PR TITLE
fix(security): restore incremental marker search cursors in thinking budget state

### DIFF
--- a/tests/v1/logits_processors/test_correctness.py
+++ b/tests/v1/logits_processors/test_correctness.py
@@ -1785,3 +1785,57 @@ class TestThinkingBudgetNaturalEndReentry:
         )
 
     # --- Forced-end re-entry tests ---
+
+
+def test_marker_search_is_incremental_no_quadratic_rescan():
+    """Verify that marker search cursors advance, preventing O(L^2) scanning.
+
+    When no markers are generated, start_search_pos must advance to the
+    output length on each step so previously-scanned tokens are never
+    re-examined. This is the regression introduced by ed908cf0a and
+    reported in GHSA-497v-rww5-557q.
+    """
+
+    class FakeReasoningConfig:
+        reasoning_start_token_ids = [100]
+        reasoning_end_token_ids = [200]
+        enabled = True
+
+    holder = ThinkingBudgetStateHolder(
+        reasoning_config=FakeReasoningConfig(),
+        max_num_seqs=8,
+        num_spec_tokens=0,
+        device=torch.device("cpu"),
+        is_pin_memory=False,
+    )
+    holder.sync_batch(
+        BatchUpdate(
+            batch_size=1,
+            removed=(),
+            added=[(0, SamplingParams(thinking_token_budget=1), None, [])],
+            moved=(),
+        )
+    )
+
+    output: list[int] = []
+    non_marker_token = 13
+    num_steps = 1024
+
+    for step in range(1, num_steps + 1):
+        output.append(non_marker_token)
+        holder.update_state([output], None, None)
+
+        state = holder._state[0]
+        assert state["start_thinking"] == -1, (
+            f"Step {step}: start_thinking should remain -1 when no markers generated"
+        )
+        assert state["start_search_pos"] == step, (
+            f"Step {step}: start_search_pos must advance to current output length "
+            f"({step}), got {state['start_search_pos']}. "
+            "Failure here means the search cursor is not advancing, "
+            "causing quadratic re-scanning."
+        )
+        assert state["end_search_pos"] == step, (
+            f"Step {step}: end_search_pos must advance to current output length "
+            f"({step}), got {state['end_search_pos']}."
+        )

--- a/vllm/v1/sample/thinking_budget_state.py
+++ b/vllm/v1/sample/thinking_budget_state.py
@@ -168,6 +168,19 @@ class ThinkingBudgetStateHolder:
                 return i
         return -1
 
+    @staticmethod
+    def _find_last_sequence_index_from(
+        target_list: list[int], token_ids: list[int], search_start: int
+    ) -> int:
+        """Last occurrence of ``token_ids`` at or after ``search_start``."""
+        if not token_ids:
+            return -1
+        lo = max(0, search_start)
+        for i in range(len(target_list) - len(token_ids), lo - 1, -1):
+            if target_list[i : i + len(token_ids)] == token_ids:
+                return i
+        return -1
+
     def _init_state_entry(
         self, prompt_tok_ids: list[int] | None, thinking_token_budget: int
     ) -> dict[str, Any]:
@@ -221,6 +234,8 @@ class ThinkingBudgetStateHolder:
             "force_index": [],
             "start_thinking": start_thinking,
             "end_thinking": -1,
+            "start_search_pos": 0,
+            "end_search_pos": 0,
             "in_spec_mode": False,
             "bonus_token_forced": False,
             "continue_thinking": continue_thinking,
@@ -236,24 +251,29 @@ class ThinkingBudgetStateHolder:
             state["force_index"] = []
             return
 
+        output_tok_ids = state.get("output_tok_ids", [])
         if state["start_thinking"] == -1:
             scan_offset = state.get("scan_offset", 0)
-            output_slice = state.get("output_tok_ids", [])[scan_offset:]
-            start_thinking = self._find_last_sequence_index(
-                output_slice, self.think_start_token_ids
+            seq_len = len(self.think_start_token_ids)
+            start_thinking = self._find_last_sequence_index_from(
+                output_tok_ids,
+                self.think_start_token_ids,
+                max(scan_offset, state["start_search_pos"] - (seq_len - 1)),
             )
-            if start_thinking >= 0:
-                start_thinking += scan_offset
             state["start_thinking"] = start_thinking
+            if start_thinking == -1:
+                state["start_search_pos"] = len(output_tok_ids)
         if state["end_thinking"] == -1:
             scan_offset = state.get("scan_offset", 0)
-            output_slice = state.get("output_tok_ids", [])[scan_offset:]
-            end_thinking = self._find_last_sequence_index(
-                output_slice, self.think_end_token_ids
+            seq_len = len(self.think_end_token_ids)
+            end_thinking = self._find_last_sequence_index_from(
+                output_tok_ids,
+                self.think_end_token_ids,
+                max(scan_offset, state["end_search_pos"] - (seq_len - 1)),
             )
-            if end_thinking >= 0:
-                end_thinking += scan_offset
             state["end_thinking"] = end_thinking
+            if end_thinking == -1:
+                state["end_search_pos"] = len(output_tok_ids)
 
         if (
             not state.get("in_end", False)
@@ -268,6 +288,8 @@ class ThinkingBudgetStateHolder:
             state["start_thinking"] = -1
             state["end_thinking"] = -1
             state["scan_offset"] = len(state.get("output_tok_ids", []))
+            state["start_search_pos"] = state["scan_offset"]
+            state["end_search_pos"] = state["scan_offset"]
             state["check_count_down"] = state["thinking_token_budget"]
             return
 
@@ -380,6 +402,8 @@ class ThinkingBudgetStateHolder:
                     state["start_thinking"] = -1
                     state["end_thinking"] = -1
                     state["scan_offset"] = len(state.get("output_tok_ids", []))
+                    state["start_search_pos"] = state["scan_offset"]
+                    state["end_search_pos"] = state["scan_offset"]
 
             elif absolute_start_pos >= 0 and not state["continue_thinking"]:
                 # Found think start - entering think mode
@@ -395,6 +419,8 @@ class ThinkingBudgetStateHolder:
                 state["start_thinking"] = -1
                 state["end_thinking"] = -1
                 state["scan_offset"] = len(state.get("output_tok_ids", []))
+                state["start_search_pos"] = state["scan_offset"]
+                state["end_search_pos"] = state["scan_offset"]
 
             elif state["in_think"]:
                 # Continue thinking mode, increment count by new tokens
@@ -464,6 +490,7 @@ class ThinkingBudgetStateHolder:
                 state["end_count"] += 1
                 state["force_index"] = [0]
             if state["end_count"] >= len(self.think_end_token_ids):
+                new_offset = len(state.get("output_tok_ids", []))
                 state.update(
                     {
                         "in_end": False,
@@ -473,7 +500,9 @@ class ThinkingBudgetStateHolder:
                         "end_thinking": -1,
                         "think_count": 0,
                         "continue_thinking": False,
-                        "scan_offset": len(state.get("output_tok_ids", [])),
+                        "scan_offset": new_offset,
+                        "start_search_pos": new_offset,
+                        "end_search_pos": new_offset,
                     }
                 )
 


### PR DESCRIPTION

The thinking_token_budget state machine re-scans the entire output history on every decode step when markers are absent, resulting in O(L^2) total work. An unauthenticated client can exploit this via valid API parameters to degrade latency for co-tenant requests.

Restore independent per-marker search cursors that advance past already-searched tokens, bounding per-step work to O(delta) and total work to O(L).
