### PR TITLE
fix(security): bound kv_transfer_params to prevent OOM via unbounded tp_size

### DIFF
--- a/tests/entrypoints/openai/test_kv_transfer_validation.py
+++ b/tests/entrypoints/openai/test_kv_transfer_validation.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for kv_transfer_params validation at the API boundary."""
+
+import pytest
+from pydantic import ValidationError
+
+from vllm.entrypoints.openai.engine.protocol import (
+    _MAX_KV_TRANSFER_PP_SIZE,
+    _MAX_KV_TRANSFER_TP_SIZE,
+    validate_kv_transfer_params,
+)
+
+
+class TestValidateKvTransferParams:
+    """Unit tests for the shared validate_kv_transfer_params function."""
+
+    def test_none_passthrough(self):
+        assert validate_kv_transfer_params(None) is None
+
+    def test_valid_params(self):
+        params = {"tp_size": 4, "pp_size": 2, "remote_port": 8080}
+        assert validate_kv_transfer_params(params) is params
+
+    def test_missing_optional_fields(self):
+        params = {"do_remote_prefill": True}
+        assert validate_kv_transfer_params(params) is params
+
+    # --- tp_size ---
+
+    def test_tp_size_zero(self):
+        with pytest.raises(ValueError, match="tp_size"):
+            validate_kv_transfer_params({"tp_size": 0})
+
+    def test_tp_size_negative(self):
+        with pytest.raises(ValueError, match="tp_size"):
+            validate_kv_transfer_params({"tp_size": -1})
+
+    def test_tp_size_too_large(self):
+        with pytest.raises(ValueError, match="tp_size"):
+            validate_kv_transfer_params({"tp_size": _MAX_KV_TRANSFER_TP_SIZE + 1})
+
+    def test_tp_size_not_int(self):
+        with pytest.raises(ValueError, match="tp_size"):
+            validate_kv_transfer_params({"tp_size": "big"})
+
+    def test_tp_size_at_max(self):
+        params = {"tp_size": _MAX_KV_TRANSFER_TP_SIZE}
+        assert validate_kv_transfer_params(params) is params
+
+    # --- pp_size ---
+
+    def test_pp_size_zero(self):
+        with pytest.raises(ValueError, match="pp_size"):
+            validate_kv_transfer_params({"pp_size": 0})
+
+    def test_pp_size_too_large(self):
+        with pytest.raises(ValueError, match="pp_size"):
+            validate_kv_transfer_params({"pp_size": _MAX_KV_TRANSFER_PP_SIZE + 1})
+
+    def test_pp_size_at_max(self):
+        params = {"pp_size": _MAX_KV_TRANSFER_PP_SIZE}
+        assert validate_kv_transfer_params(params) is params
+
+    # --- remote_port ---
+
+    def test_port_zero(self):
+        with pytest.raises(ValueError, match="remote_port"):
+            validate_kv_transfer_params({"remote_port": 0})
+
+    def test_port_too_large(self):
+        with pytest.raises(ValueError, match="remote_port"):
+            validate_kv_transfer_params({"remote_port": 65536})
+
+    def test_port_valid_range(self):
+        for port in (1, 80, 443, 8080, 65535):
+            params = {"remote_port": port}
+            assert validate_kv_transfer_params(params) is params
+
+
+class TestCompletionRequestKvTransferValidation:
+    """Verify CompletionRequest rejects bad kv_transfer_params."""
+
+    def test_rejects_huge_tp_size(self):
+        from vllm.entrypoints.openai.completion.protocol import (
+            CompletionRequest,
+        )
+
+        with pytest.raises(ValidationError):
+            CompletionRequest(
+                model="test",
+                prompt="hello",
+                kv_transfer_params={"tp_size": 20_000_000},
+            )
+
+    def test_accepts_valid_params(self):
+        from vllm.entrypoints.openai.completion.protocol import (
+            CompletionRequest,
+        )
+
+        req = CompletionRequest(
+            model="test",
+            prompt="hello",
+            kv_transfer_params={"tp_size": 4, "remote_port": 8080},
+        )
+        assert req.kv_transfer_params["tp_size"] == 4
+
+    def test_accepts_none(self):
+        from vllm.entrypoints.openai.completion.protocol import (
+            CompletionRequest,
+        )
+
+        req = CompletionRequest(model="test", prompt="hello")
+        assert req.kv_transfer_params is None
+
+
+class TestChatCompletionRequestKvTransferValidation:
+    """Verify ChatCompletionRequest rejects bad kv_transfer_params."""
+
+    def test_rejects_huge_tp_size(self):
+        from vllm.entrypoints.openai.chat_completion.protocol import (
+            ChatCompletionRequest,
+        )
+
+        with pytest.raises(ValidationError):
+            ChatCompletionRequest(
+                model="test",
+                messages=[{"role": "user", "content": "hi"}],
+                kv_transfer_params={"tp_size": 20_000_000},
+            )
+
+    def test_rejects_invalid_port(self):
+        from vllm.entrypoints.openai.chat_completion.protocol import (
+            ChatCompletionRequest,
+        )
+
+        with pytest.raises(ValidationError):
+            ChatCompletionRequest(
+                model="test",
+                messages=[{"role": "user", "content": "hi"}],
+                kv_transfer_params={"remote_port": 0},
+            )
+
+
+class TestResponsesRequestKvTransferValidation:
+    """Verify ResponsesRequest rejects bad kv_transfer_params."""
+
+    def test_rejects_huge_tp_size(self):
+        from vllm.entrypoints.openai.responses.protocol import (
+            ResponsesRequest,
+        )
+
+        with pytest.raises(ValidationError):
+            ResponsesRequest(
+                model="test",
+                input="hello",
+                kv_transfer_params={"tp_size": 20_000_000},
+            )

--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -3325,3 +3325,123 @@ def test_explicit_kv_role_no_deprecation_warning(default_vllm_config, dist_init)
             mock_logger.warning_once.assert_not_called(),
             (f"kv_role={role!r} should not emit deprecation warning"),
         )
+
+
+class TestTransferTopologyBounds:
+    """Validate that tp_ratio rejects out-of-range remote_tp_size values."""
+
+    def _make_topo(self, tp_size: int = 1) -> TransferTopology:
+        vllm_config = create_vllm_config()
+        with set_current_vllm_config(vllm_config):
+            attn_backend = get_current_attn_backend()
+        return TransferTopology(
+            tp_rank=0,
+            tp_size=tp_size,
+            block_size=16,
+            engine_id="test-engine",
+            is_mla=False,
+            is_mamba=False,
+            total_num_kv_heads=1,
+            attn_backends=[attn_backend],
+        )
+
+    def test_tp_ratio_rejects_zero(self):
+        topo = self._make_topo()
+        with pytest.raises(ValueError, match="must be >= 1"):
+            topo.tp_ratio(0)
+
+    def test_tp_ratio_rejects_negative(self):
+        topo = self._make_topo()
+        with pytest.raises(ValueError, match="must be >= 1"):
+            topo.tp_ratio(-1)
+
+    def test_tp_ratio_rejects_huge_value(self):
+        topo = self._make_topo()
+        with pytest.raises(ValueError, match="exceeds maximum"):
+            topo.tp_ratio(20_000_000)
+
+    def test_tp_ratio_accepts_valid(self):
+        topo = self._make_topo(tp_size=4)
+        assert topo.tp_ratio(4) == 1
+        assert topo.tp_ratio(2) == 2
+        assert topo.tp_ratio(1) == 4
+
+    def test_handshake_target_ranks_bounded(self):
+        topo = self._make_topo()
+        with pytest.raises(ValueError, match="exceeds maximum"):
+            topo.handshake_target_ranks(20_000_000)
+
+    def test_handshake_target_ranks_valid(self):
+        topo = self._make_topo()
+        ranks = topo.handshake_target_ranks(1)
+        assert ranks == [0]
+
+
+class TestNixlMetadataValidation:
+    """Validate that NixlConnectorMetadata rejects invalid tp/pp_size."""
+
+    def test_add_new_req_rejects_huge_tp_size(self):
+        meta = NixlConnectorMetadata()
+        with pytest.raises(ValueError, match="Invalid tp_size"):
+            meta.add_new_req_to_recv(
+                request_id="test-req",
+                local_block_ids=[0, 1],
+                kv_transfer_params=dict(
+                    tp_size=20_000_000,
+                    remote_block_ids=[[0]],
+                    remote_engine_id="e",
+                    remote_request_id="r",
+                    remote_host="127.0.0.1",
+                    remote_port=1234,
+                ),
+            )
+
+    def test_add_new_req_rejects_zero_tp_size(self):
+        meta = NixlConnectorMetadata()
+        with pytest.raises(ValueError, match="Invalid tp_size"):
+            meta.add_new_req_to_recv(
+                request_id="test-req",
+                local_block_ids=[0, 1],
+                kv_transfer_params=dict(
+                    tp_size=0,
+                    remote_block_ids=[[0]],
+                    remote_engine_id="e",
+                    remote_request_id="r",
+                    remote_host="127.0.0.1",
+                    remote_port=1234,
+                ),
+            )
+
+    def test_add_new_req_rejects_huge_pp_size(self):
+        meta = NixlConnectorMetadata()
+        with pytest.raises(ValueError, match="Invalid pp_size"):
+            meta.add_new_req_to_recv(
+                request_id="test-req",
+                local_block_ids=[0, 1],
+                kv_transfer_params=dict(
+                    tp_size=1,
+                    pp_size=10_000,
+                    remote_block_ids=[[0]],
+                    remote_engine_id="e",
+                    remote_request_id="r",
+                    remote_host="127.0.0.1",
+                    remote_port=1234,
+                ),
+            )
+
+    def test_add_new_req_accepts_valid_params(self):
+        meta = NixlConnectorMetadata()
+        meta.add_new_req_to_recv(
+            request_id="test-req",
+            local_block_ids=[0, 1],
+            kv_transfer_params=dict(
+                tp_size=4,
+                pp_size=2,
+                remote_block_ids=[[0]],
+                remote_engine_id="e",
+                remote_request_id="r",
+                remote_host="127.0.0.1",
+                remote_port=1234,
+            ),
+        )
+        assert "test-req" in meta.reqs_to_recv

--- a/vllm/distributed/kv_transfer/kv_connector/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/utils.py
@@ -520,6 +520,8 @@ class TransferTopology:
     # Common methods
     # ============================================================
 
+    _MAX_REMOTE_TP_SIZE = 4096
+
     def tp_ratio(self, remote_tp_size: int) -> int:
         """Calculate the tensor parallel ratio between local and remote TP.
 
@@ -527,6 +529,13 @@ class TransferTopology:
         same remote worker in groups of size ``tp_ratio``).  Negative when
         remote_tp > local_tp (ratio is flipped).
         """
+        if remote_tp_size < 1:
+            raise ValueError(f"remote_tp_size must be >= 1, got {remote_tp_size}")
+        if remote_tp_size > self._MAX_REMOTE_TP_SIZE:
+            raise ValueError(
+                f"remote_tp_size {remote_tp_size} exceeds maximum "
+                f"allowed value {self._MAX_REMOTE_TP_SIZE}"
+            )
         if self.tp_size >= remote_tp_size:
             assert self.tp_size % remote_tp_size == 0, (
                 f"Local tensor parallel size {self.tp_size} is not divisible "

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
@@ -243,18 +243,26 @@ class NixlConnectorMetadata(KVConnectorMetadata):
         # against pending D registrations on the P worker.
         self.push_finished_blocks: dict[ReqId, BlockIds] = {}
 
+    _MAX_TP_SIZE = 4096
+    _MAX_PP_SIZE = 256
+
     def _add_new_req(
         self,
         local_block_ids: BlockIds,
         kv_transfer_params: dict[str, Any],
     ) -> ReqMeta:
+        tp_size = kv_transfer_params.get("tp_size", 1)
+        if not isinstance(tp_size, int) or tp_size < 1 or tp_size > self._MAX_TP_SIZE:
+            raise ValueError(f"Invalid tp_size in kv_transfer_params: {tp_size!r}")
+        pp_size = kv_transfer_params.get("pp_size", 1)
+        if not isinstance(pp_size, int) or pp_size < 1 or pp_size > self._MAX_PP_SIZE:
+            raise ValueError(f"Invalid pp_size in kv_transfer_params: {pp_size!r}")
         return ReqMeta(
             local_block_ids=local_block_ids,
             local_physical_block_ids=local_block_ids,
-            # P workers don't need to receive tp_size from proxy here.
-            tp_size=kv_transfer_params.get("tp_size", 1),
+            tp_size=tp_size,
             remote_block_size=kv_transfer_params.get("remote_block_size"),
-            pp_size=kv_transfer_params.get("pp_size", 1),
+            pp_size=pp_size,
         )
 
     def add_new_req_to_save(

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -34,6 +34,7 @@ from vllm.entrypoints.openai.engine.protocol import (
     ToolCall,
     UsageInfo,
     structured_outputs_from_response_format,
+    validate_kv_transfer_params,
     validate_structural_tag_response_format,
     validate_structured_outputs_structural_tag,
 )
@@ -1024,6 +1025,13 @@ class ChatCompletionRequest(OpenAIBaseModel):
                                     part_type,
                                 )
 
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_kv_transfer_params_fields(cls, data):
+        if isinstance(data, dict) and data.get("kv_transfer_params") is not None:
+            validate_kv_transfer_params(data["kv_transfer_params"])
         return data
 
 

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -17,6 +17,7 @@ from vllm.entrypoints.openai.engine.protocol import (
     StreamOptions,
     UsageInfo,
     structured_outputs_from_response_format,
+    validate_kv_transfer_params,
     validate_structural_tag_response_format,
     validate_structured_outputs_structural_tag,
 )
@@ -582,6 +583,13 @@ class CompletionRequest(OpenAIBaseModel):
                 parameter="prompt_embeds",
             )
 
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_kv_transfer_params_fields(cls, data):
+        if isinstance(data, dict) and data.get("kv_transfer_params") is not None:
+            validate_kv_transfer_params(data["kv_transfer_params"])
         return data
 
 

--- a/vllm/entrypoints/openai/engine/protocol.py
+++ b/vllm/entrypoints/openai/engine/protocol.py
@@ -281,6 +281,53 @@ def validate_structured_outputs_structural_tag(
         )
 
 
+_MAX_KV_TRANSFER_TP_SIZE = 4096
+_MAX_KV_TRANSFER_PP_SIZE = 256
+
+
+def validate_kv_transfer_params(
+    params: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Validate safety-critical fields in ``kv_transfer_params``.
+
+    Prevents attacker-controlled values (e.g. an arbitrarily large
+    ``tp_size``) from reaching the KV connector, where they could cause
+    unbounded memory allocation.
+    """
+    if params is None:
+        return None
+
+    tp_size = params.get("tp_size")
+    if tp_size is not None and (
+        not isinstance(tp_size, int)
+        or tp_size < 1
+        or tp_size > _MAX_KV_TRANSFER_TP_SIZE
+    ):
+        raise ValueError(
+            f"kv_transfer_params.tp_size must be a positive integer "
+            f"<= {_MAX_KV_TRANSFER_TP_SIZE}, got {tp_size!r}"
+        )
+
+    pp_size = params.get("pp_size")
+    if pp_size is not None and (
+        not isinstance(pp_size, int)
+        or pp_size < 1
+        or pp_size > _MAX_KV_TRANSFER_PP_SIZE
+    ):
+        raise ValueError(
+            f"kv_transfer_params.pp_size must be a positive integer "
+            f"<= {_MAX_KV_TRANSFER_PP_SIZE}, got {pp_size!r}"
+        )
+
+    port = params.get("remote_port")
+    if port is not None and (not isinstance(port, int) or port < 1 or port > 65535):
+        raise ValueError(
+            f"kv_transfer_params.remote_port must be in [1, 65535], got {port!r}"
+        )
+
+    return params
+
+
 class StreamOptions(OpenAIBaseModel):
     include_usage: bool | None = False
     continuous_usage_stats: bool | None = False

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -60,7 +60,10 @@ from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
     ChatTemplateContentFormatOption,
 )
-from vllm.entrypoints.openai.engine.protocol import OpenAIBaseModel
+from vllm.entrypoints.openai.engine.protocol import (
+    OpenAIBaseModel,
+    validate_kv_transfer_params,
+)
 from vllm.exceptions import VLLMValidationError
 from vllm.logger import init_logger
 from vllm.renderers import ChatParams, TokenizeParams, merge_kwargs
@@ -630,6 +633,13 @@ class ResponsesRequest(OpenAIBaseModel):
                     parameter="tool_choice",
                 )
 
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_kv_transfer_params_fields(cls, data):
+        if isinstance(data, dict) and data.get("kv_transfer_params") is not None:
+            validate_kv_transfer_params(data["kv_transfer_params"])
         return data
 
 

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -748,6 +748,8 @@ class AsyncLLM(EngineClient):
         if self.log_requests:
             logger.info("Aborted request(s) %s.", ",".join(request_ids))
 
+    _MAX_KV_TRANSFER_TP_SIZE = 4096
+
     async def notify_kv_transfer_request_rejected(
         self,
         request_id: str,
@@ -758,6 +760,19 @@ class AsyncLLM(EngineClient):
         """Submit a pre-aborted request so the connector's request_finished
         hook runs to free any pre-admission KV-transfer resources (e.g. NIXL
         prefill blocks pinned on the P node)."""
+        tp_size = kv_transfer_params.get("tp_size", 1)
+        if (
+            not isinstance(tp_size, int)
+            or tp_size < 1
+            or tp_size > self._MAX_KV_TRANSFER_TP_SIZE
+        ):
+            logger.warning(
+                "Skipping KV transfer rejection cleanup for request %s: "
+                "invalid tp_size %r",
+                request_id,
+                tp_size,
+            )
+            return
         request = EngineCoreRequest(
             request_id=request_id,
             prompt_token_ids=[0],


### PR DESCRIPTION
An attacker-controlled tp_size in kv_transfer_params could cause unbounded memory allocation in TransferTopology.handshake_target_ranks, leading to OOM-killing the Decode EngineCore. This adds defense-in-depth validation at three layers:

- API boundary: Pydantic validators on CompletionRequest, ChatCompletionRequest, and ResponsesRequest reject tp_size, pp_size, and remote_port values outside safe bounds.
- KV connector internals: TransferTopology.tp_ratio and NIXL metadata construction validate tp_size positivity and upper bound before any list materialization.
- Rejection cleanup path: notify_kv_transfer_request_rejected skips submission when tp_size is invalid, preventing the abort_immediately path from triggering a dangerous handshake.