### PR TITLE
fix(security): eliminate O(n^2) Inkling tool-argument parsing DoS

### DIFF
--- a/tests/parser/engine/test_inkling.py
+++ b/tests/parser/engine/test_inkling.py
@@ -869,3 +869,69 @@ def test_content_tool_start_emits_reasoning_end_in_reasoning_pass():
         EventType.TEXT_CHUNK,
     ]
     assert events[1].value == TOOL_JSON
+
+
+class TestIncrementalArgParsing:
+    """Verify that the incremental arg-delta caching produces correct output
+    and avoids quadratic behaviour for large tool arguments."""
+
+    def test_large_arg_streaming_is_subquadratic(self, parser, mock_request):
+        """Stream a 10K-character tool argument one character at a time.
+
+        With the O(n^2) bug, this would take many seconds. With
+        incremental caching, it completes quickly.
+        """
+        import time
+
+        size = 10_000
+        data = "A" * size
+        wrapper = f'{{"name":"echo","args":{{"data":"{data}"}}}}'
+        text = f"{TOOL_JSON}{wrapper}{END_MESSAGE}"
+
+        start_time = time.monotonic()
+        results = _stream_text_only(parser, mock_request, text, chunk_size=1)
+        elapsed = time.monotonic() - start_time
+
+        args = collect_tool_arguments(results)
+        parsed = json.loads(args)
+        assert parsed == {"data": data}
+        assert elapsed < 5.0, (
+            f"Streaming {size}-char tool arg took {elapsed:.1f}s; "
+            f"expected < 5s with incremental parsing"
+        )
+
+    def test_cached_offset_matches_uncached(self, parser, mock_request):
+        """Verify that caching the wrapper offset produces identical output
+        to the full converter call for several wrapper shapes."""
+        cases = [
+            '{"name":"f","args":{"key":"value"}}',
+            '{"name":"args","args":{"k":1}}',
+            '{ "name" : "x" , "args" : {"a": 1, "b": "hello"} }',
+            '{"name":"get_weather","args":{"city":"SF","units":"metric"}}',
+        ]
+        for wrapper in cases:
+            text = f"{TOOL_JSON}{wrapper}{END_MESSAGE}"
+            results_chunked = _stream_text_only(
+                parser, mock_request, text, chunk_size=1
+            )
+            args_chunked = collect_tool_arguments(results_chunked)
+
+            parser2 = InklingParser(parser.model_tokenizer)
+            results_full = _stream_text_only(
+                parser2, mock_request, text, chunk_size=len(text)
+            )
+            args_full = collect_tool_arguments(results_full)
+
+            assert json.loads(args_chunked) == json.loads(args_full), (
+                f"Mismatch for wrapper: {wrapper}"
+            )
+
+    def test_structural_chars_gate_skips_nonstructural(self, parser, mock_request):
+        """Verify that the Inkling config has arg_structural_chars set,
+        which gates converter calls for non-structural content."""
+        from vllm.parser.inkling import inkling_config
+
+        config = inkling_config()
+        assert config.arg_structural_chars is not None
+        assert '"' in config.arg_structural_chars
+        assert "{" in config.arg_structural_chars

--- a/tests/parser/engine/test_inkling.py
+++ b/tests/parser/engine/test_inkling.py
@@ -533,3 +533,69 @@ class TestRegisteredAdapters:
         assert result.tools_called
         assert result.tool_calls[0].function.name == "f"
         assert json.loads(result.tool_calls[0].function.arguments) == {"a": 1}
+
+
+class TestIncrementalArgParsing:
+    """Verify that the incremental arg-delta caching produces correct output
+    and avoids quadratic behaviour for large tool arguments."""
+
+    def test_large_arg_streaming_is_subquadratic(self, parser, mock_request):
+        """Stream a 10K-character tool argument one character at a time.
+
+        With the O(n^2) bug, this would take many seconds. With
+        incremental caching, it completes quickly.
+        """
+        import time
+
+        size = 10_000
+        data = "A" * size
+        wrapper = f'{{"name":"echo","args":{{"data":"{data}"}}}}'
+        text = f"{TOOL_JSON}{wrapper}{END_MESSAGE}"
+
+        start_time = time.monotonic()
+        results = _stream_text_only(parser, mock_request, text, chunk_size=1)
+        elapsed = time.monotonic() - start_time
+
+        args = collect_tool_arguments(results)
+        parsed = json.loads(args)
+        assert parsed == {"data": data}
+        assert elapsed < 5.0, (
+            f"Streaming {size}-char tool arg took {elapsed:.1f}s; "
+            f"expected < 5s with incremental parsing"
+        )
+
+    def test_cached_offset_matches_uncached(self, parser, mock_request):
+        """Verify that caching the wrapper offset produces identical output
+        to the full converter call for several wrapper shapes."""
+        cases = [
+            '{"name":"f","args":{"key":"value"}}',
+            '{"name":"args","args":{"k":1}}',
+            '{ "name" : "x" , "args" : {"a": 1, "b": "hello"} }',
+            '{"name":"get_weather","args":{"city":"SF","units":"metric"}}',
+        ]
+        for wrapper in cases:
+            text = f"{TOOL_JSON}{wrapper}{END_MESSAGE}"
+            results_chunked = _stream_text_only(
+                parser, mock_request, text, chunk_size=1
+            )
+            args_chunked = collect_tool_arguments(results_chunked)
+
+            parser2 = InklingParser(parser.model_tokenizer)
+            results_full = _stream_text_only(
+                parser2, mock_request, text, chunk_size=len(text)
+            )
+            args_full = collect_tool_arguments(results_full)
+
+            assert json.loads(args_chunked) == json.loads(args_full), (
+                f"Mismatch for wrapper: {wrapper}"
+            )
+
+    def test_structural_chars_gate_skips_nonstructural(self, parser, mock_request):
+        """Verify that the Inkling config has arg_structural_chars set,
+        which gates converter calls for non-structural content."""
+        from vllm.parser.inkling import inkling_config
+
+        config = inkling_config()
+        assert config.arg_structural_chars is not None
+        assert '"' in config.arg_structural_chars
+        assert "{" in config.arg_structural_chars

--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -27,7 +27,7 @@ from vllm.entrypoints.openai.engine.protocol import (
 from vllm.parser.abstract_parser import DelegatingParser
 from vllm.parser.engine.adapters import make_adapters
 from vllm.parser.engine.events import EventType, SemanticEvent
-from vllm.parser.engine.parser_engine import ParserEngine
+from vllm.parser.engine.parser_engine import ParserEngine, ToolCallSlot
 from vllm.parser.engine.parser_engine_config import (
     ParserEngineConfig,
     ParserState,
@@ -1694,3 +1694,56 @@ class TestDropSpecialTokens:
             e.value for e in events if e.type == EventType.REASONING_CHUNK
         )
         assert "<bos>" not in reasoning_text
+
+
+class TestIncrementalSafePrefix:
+    """Verify that ``_incremental_safe_prefix`` matches ``_safe_arg_prefix``
+    for the same input, and that caching produces correct results across
+    incremental calls."""
+
+    @pytest.mark.parametrize(
+        "json_str",
+        [
+            '{"a": 1}',
+            '{"a": 1, "b": 2}',
+            '{"a": "hello", "b": "world"}',
+            '{"obj": {"x": 1}, "b": 2}',
+            '{"k":1}',
+            '{"k":"value"}',
+            '{"k":"unterminated',
+            "{}",
+            "{",
+            "",
+            '{"a": 1',
+        ],
+    )
+    def test_matches_static_version(self, json_str):
+        slot = ToolCallSlot()
+        result = ParserEngine._incremental_safe_prefix(json_str, None, slot)
+        expected = ParserEngine._safe_arg_prefix(json_str)
+        assert result == expected, (
+            f"Mismatch for {json_str!r}: incremental={result!r}, static={expected!r}"
+        )
+
+    def test_incremental_accumulation(self):
+        """Feed a JSON string one character at a time, resetting slot state
+        each time, and verify the incremental prefix matches the static
+        version at each step."""
+        full = '{"name": "Alice", "age": 30, "city": "NYC"}'
+        for end in range(1, len(full) + 1):
+            partial = full[:end]
+            slot = ToolCallSlot()
+            inc = ParserEngine._incremental_safe_prefix(partial, None, slot)
+            static = ParserEngine._safe_arg_prefix(partial)
+            assert inc == static, f"Mismatch at position {end}: {partial!r}"
+
+    def test_true_incremental_across_calls(self):
+        """Feed JSON character by character using the *same* slot to verify
+        incremental state accumulation produces the correct result."""
+        full = '{"a": 1, "b": "hello"}'
+        slot = ToolCallSlot()
+        for end in range(1, len(full) + 1):
+            partial = full[:end]
+            result = ParserEngine._incremental_safe_prefix(partial, None, slot)
+            expected = ParserEngine._safe_arg_prefix(partial)
+            assert result == expected, f"Mismatch at position {end}: {partial!r}"

--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -27,7 +27,7 @@ from vllm.entrypoints.openai.engine.protocol import (
 from vllm.parser.abstract_parser import DelegatingParser
 from vllm.parser.engine.adapters import make_adapters
 from vllm.parser.engine.events import EventType, SemanticEvent
-from vllm.parser.engine.parser_engine import ParserEngine
+from vllm.parser.engine.parser_engine import ParserEngine, ToolCallSlot
 from vllm.parser.engine.parser_engine_config import (
     ParserEngineConfig,
     ParserState,
@@ -1779,3 +1779,56 @@ class TestDropSpecialTokens:
             e.value for e in events if e.type == EventType.REASONING_CHUNK
         )
         assert "<bos>" not in reasoning_text
+
+
+class TestIncrementalSafePrefix:
+    """Verify that ``_incremental_safe_prefix`` matches ``_safe_arg_prefix``
+    for the same input, and that caching produces correct results across
+    incremental calls."""
+
+    @pytest.mark.parametrize(
+        "json_str",
+        [
+            '{"a": 1}',
+            '{"a": 1, "b": 2}',
+            '{"a": "hello", "b": "world"}',
+            '{"obj": {"x": 1}, "b": 2}',
+            '{"k":1}',
+            '{"k":"value"}',
+            '{"k":"unterminated',
+            "{}",
+            "{",
+            "",
+            '{"a": 1',
+        ],
+    )
+    def test_matches_static_version(self, json_str):
+        slot = ToolCallSlot()
+        result = ParserEngine._incremental_safe_prefix(json_str, None, slot)
+        expected = ParserEngine._safe_arg_prefix(json_str)
+        assert result == expected, (
+            f"Mismatch for {json_str!r}: incremental={result!r}, static={expected!r}"
+        )
+
+    def test_incremental_accumulation(self):
+        """Feed a JSON string one character at a time, resetting slot state
+        each time, and verify the incremental prefix matches the static
+        version at each step."""
+        full = '{"name": "Alice", "age": 30, "city": "NYC"}'
+        for end in range(1, len(full) + 1):
+            partial = full[:end]
+            slot = ToolCallSlot()
+            inc = ParserEngine._incremental_safe_prefix(partial, None, slot)
+            static = ParserEngine._safe_arg_prefix(partial)
+            assert inc == static, f"Mismatch at position {end}: {partial!r}"
+
+    def test_true_incremental_across_calls(self):
+        """Feed JSON character by character using the *same* slot to verify
+        incremental state accumulation produces the correct result."""
+        full = '{"a": 1, "b": "hello"}'
+        slot = ToolCallSlot()
+        for end in range(1, len(full) + 1):
+            partial = full[:end]
+            result = ParserEngine._incremental_safe_prefix(partial, None, slot)
+            expected = ParserEngine._safe_arg_prefix(partial)
+            assert result == expected, f"Mismatch at position {end}: {partial!r}"

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -54,6 +54,15 @@ class ToolCallSlot:
         "name_sent",
         "string_keys",
         "streamed_json",
+        "_arg_value_start",
+        "_safe_prefix_cursor",
+        "_safe_prefix_last_colon",
+        "_safe_prefix_last_key",
+        "_safe_prefix_pending_key",
+        "_safe_prefix_depth",
+        "_safe_prefix_in_string",
+        "_safe_prefix_escape",
+        "_safe_prefix_string_start",
     )
 
     def __init__(self) -> None:
@@ -64,6 +73,15 @@ class ToolCallSlot:
         self.name_sent: bool = False
         self.string_keys: set[str] | None = None
         self.streamed_json: str = ""
+        self._arg_value_start: int | None = None
+        self._safe_prefix_cursor: int = 0
+        self._safe_prefix_last_colon: int = -1
+        self._safe_prefix_last_key: str | None = None
+        self._safe_prefix_pending_key: str | None = None
+        self._safe_prefix_depth: int = 0
+        self._safe_prefix_in_string: bool = False
+        self._safe_prefix_escape: bool = False
+        self._safe_prefix_string_start: int = -1
 
     @property
     def args(self) -> str:
@@ -339,6 +357,84 @@ class ParserEngine(Parser):
                 continue
             if c == "\\":
                 escape = True
+                continue
+            if c == '"':
+                return json_str[:i]
+        return json_str
+
+    @staticmethod
+    def _incremental_safe_prefix(
+        json_str: str,
+        string_keys: set[str] | None,
+        slot: ToolCallSlot,
+    ) -> str:
+        """Like ``_safe_arg_prefix`` but resumes from cached scanner state.
+
+        The first call on a slot scans from byte 0; subsequent calls
+        resume from ``slot._safe_prefix_cursor``, giving amortized O(delta)
+        work instead of O(n) per call.
+        """
+        cursor = slot._safe_prefix_cursor
+        last_colon = slot._safe_prefix_last_colon
+        last_key = slot._safe_prefix_last_key
+        pending_key = slot._safe_prefix_pending_key
+        depth = slot._safe_prefix_depth
+        in_string = slot._safe_prefix_in_string
+        escape = slot._safe_prefix_escape
+        string_start = slot._safe_prefix_string_start
+
+        for i in range(cursor, len(json_str)):
+            c = json_str[i]
+            if escape:
+                escape = False
+                continue
+            if in_string:
+                if c == "\\":
+                    escape = True
+                elif c == '"':
+                    in_string = False
+                    if depth == 1 and string_start >= 0:
+                        pending_key = json_str[string_start + 1 : i]
+                continue
+            if c == '"':
+                in_string = True
+                string_start = i
+            elif c in ("{", "["):
+                depth += 1
+            elif c in ("}", "]"):
+                depth -= 1
+            elif c == ":" and depth == 1:
+                last_colon = i
+                last_key = pending_key
+                pending_key = None
+
+        slot._safe_prefix_cursor = len(json_str)
+        slot._safe_prefix_last_colon = last_colon
+        slot._safe_prefix_last_key = last_key
+        slot._safe_prefix_pending_key = pending_key
+        slot._safe_prefix_depth = depth
+        slot._safe_prefix_in_string = in_string
+        slot._safe_prefix_escape = escape
+        slot._safe_prefix_string_start = string_start
+
+        if last_colon < 0:
+            return ""
+        end = last_colon + 1
+        while end < len(json_str) and json_str[end] in (" ", "\t", "\n", "\r"):
+            end += 1
+        if end >= len(json_str) or json_str[end] != '"':
+            return json_str[:end]
+        if string_keys is not None and last_key not in string_keys:
+            return json_str[:end]
+
+        esc = False
+        for i in range(end + 1, len(json_str)):
+            c = json_str[i]
+            if esc:
+                esc = False
+                continue
+            if c == "\\":
+                esc = True
                 continue
             if c == '"':
                 return json_str[:i]
@@ -945,11 +1041,20 @@ class ParserEngine(Parser):
             return None
 
         slot = self._tool_slots[idx]
-        try:
-            current_json = converter(slot.args, True)
-        except (json.JSONDecodeError, ValueError, TypeError):
-            logger.debug("arg converter failed (streaming): %s", slot.args[:80])
-            return None
+
+        if slot._arg_value_start is not None:
+            current_json = slot.args[slot._arg_value_start :]
+        else:
+            try:
+                current_json = converter(slot.args, True)
+            except (json.JSONDecodeError, ValueError, TypeError):
+                logger.debug("arg converter failed (streaming): %s", slot.args[:80])
+                return None
+
+            if current_json and slot._arg_value_start is None:
+                offset = len(slot.args) - len(current_json)
+                if offset >= 0 and slot.args[offset:] == current_json:
+                    slot._arg_value_start = offset
 
         if not current_json:
             return None
@@ -958,7 +1063,7 @@ class ParserEngine(Parser):
             current_json = self._fix_arg_types(current_json, slot.name)
 
         prev = slot.streamed_json
-        safe_json = self._safe_arg_prefix(current_json, slot.string_keys)
+        safe_json = self._incremental_safe_prefix(current_json, slot.string_keys, slot)
 
         if not safe_json or safe_json == prev:
             return None

--- a/vllm/parser/inkling.py
+++ b/vllm/parser/inkling.py
@@ -288,6 +288,7 @@ def inkling_config() -> ParserEngineConfig:
         arg_converter=_inkling_arg_converter,
         stream_arg_deltas=True,
         tool_args_json=True,
+        arg_structural_chars=frozenset('{}[]":,'),
         strip_trailing_reasoning_whitespace=True,
         drop_whitespace_only_content_before_tools=True,
         strip_content_whitespace_with_tools=False,

--- a/vllm/parser/inkling.py
+++ b/vllm/parser/inkling.py
@@ -295,6 +295,7 @@ def inkling_config() -> ParserEngineConfig:
         arg_converter=_inkling_arg_converter,
         stream_arg_deltas=True,
         tool_args_json=True,
+        arg_structural_chars=frozenset('{}[]":,'),
         strip_trailing_reasoning_whitespace=True,
         drop_whitespace_only_content_before_tools=True,
         strip_content_whitespace_with_tools=False,


### PR DESCRIPTION
The Inkling parser's _compute_arg_delta called the converter and _safe_arg_prefix from byte 0 on every streaming chunk, giving O(n^2) total work for n one-token chunks.  A single 32K-char tool argument could block the API event loop for ~102 seconds (GHSA-23f4-rc72-636c).

Three changes reduce per-delta work to amortized O(delta):

A. Cache the wrapper header offset on ToolCallSlot (_arg_value_start).
   After the first converter call, subsequent calls bypass the converter
   entirely by slicing slot.args at the cached offset.

B. Add _incremental_safe_prefix that resumes the JSON scanner from
   cached state on the slot instead of rescanning from byte 0.

C. Add arg_structural_chars to the Inkling ParserEngineConfig so that
   non-structural chunks (e.g. runs of 'A' in a string value) skip
   the converter entirely.