### PR TITLE
[Rust][Benchmark] Add vllm-startup-bench: process time-to-ready comparison tool

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5766,6 +5766,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "vllm-startup-bench"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "expect-test",
+ "libc",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "vllm-tracing",
+]
+
+[[package]]
 name = "vllm-text"
 version = "0.1.0"
 dependencies = [

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "src/parser",
     "src/parser/python",
     "src/server",
+    "src/startup-bench",
     "src/text",
     "src/tokenizer",
     "src/tracing",

--- a/rust/src/startup-bench/Cargo.toml
+++ b/rust/src/startup-bench/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "vllm-startup-bench"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "vllm-startup-bench"
+path = "src/main.rs"
+
+[dependencies]
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive"] }
+libc.workspace = true
+reqwest.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+tokio = { workspace = true, features = ["process"] }
+tracing.workspace = true
+vllm-tracing.workspace = true
+
+[dev-dependencies]
+expect-test.workspace = true
+
+[lints]
+workspace = true

--- a/rust/src/startup-bench/README.md
+++ b/rust/src/startup-bench/README.md
@@ -1,0 +1,107 @@
+# vllm-startup-bench
+
+`vllm-startup-bench` measures and compares process **startup latency**
+("time-to-ready": wall clock from process spawn until an HTTP readiness
+endpoint first responds successfully) across one or more `vllm serve`-style
+commands.
+
+It exists to give concrete, reproducible before/after numbers for changes on
+vLLM's startup path (e.g. Python frontend vs the Rust frontend, or two
+candidate implementations of a piece of startup logic), instead of relying on
+anecdotal impressions of "faster". It is not a load-testing tool — for
+steady-state serving throughput, use `vllm-bench` instead.
+
+## How it works
+
+For each `--variant NAME=COMMAND`, each run:
+
+1. Spawns `COMMAND` via `sh -c` in its own process group.
+2. Polls `--health-url` (default `http://127.0.0.1:8000/health`, matching
+   both the Python and Rust frontends' readiness endpoint) until it returns a
+   successful HTTP status, the process exits, or `--ready-timeout-secs`
+   elapses.
+3. Records the elapsed time, then terminates the whole process group
+   (SIGTERM, escalating to SIGKILL after `--shutdown-timeout-secs`) so the
+   next run starts from a clean slate.
+
+Runs are interleaved round-robin across variants (run 1 of A, run 1 of B, run
+2 of A, ...) rather than run back-to-back per variant, so that any
+systematic drift over the session (thermal throttling, filesystem cache
+state, etc.) is spread evenly across variants instead of confounding it with
+run order. `--warmup-runs` runs (default 1) execute first and are discarded,
+to avoid one-time cold-cache effects unrelated to the code under test
+skewing the timed samples.
+
+The first `--variant` given is treated as the baseline; the report shows
+each other variant's median time-to-ready relative to it, and explicitly
+flags a variant as a **regression** if it's slower, rather than only ever
+reporting speedups.
+
+## Usage
+
+Compare plain Python `vllm serve` against the Rust frontend for the same
+model (both bind the same port, so only one runs at a time):
+
+```bash
+vllm-startup-bench \
+  --variant "python=vllm serve Qwen/Qwen3-0.6B" \
+  --variant "rust=VLLM_USE_RUST_FRONTEND=1 vllm serve Qwen/Qwen3-0.6B" \
+  --runs 5 --warmup-runs 1
+```
+
+Illustrative output (actual numbers depend on model, hardware, and what's
+being compared):
+
+```text
+=== Startup time-to-ready (http://127.0.0.1:8000/health) ===
+
+variant             runs  failures    mean(s)  median(s)     min(s)     max(s)  stddev(s)
+python                 5         0     12.481     12.402     12.011     13.055      0.412
+rust                   5         0     11.803     11.769     11.520     12.244      0.271
+
+=== Comparison vs. baseline "python" (median) ===
+
+rust             1.05x faster  (-0.633s, -5.1%)
+```
+
+Use `--log-dir` to capture each run's stdout/stderr for debugging a variant
+that fails to become ready, and `--save-result` to write the full sample set
+and summary statistics as JSON for later analysis:
+
+```bash
+vllm-startup-bench \
+  --variant "python=vllm serve Qwen/Qwen3-0.6B" \
+  --variant "rust=VLLM_USE_RUST_FRONTEND=1 vllm serve Qwen/Qwen3-0.6B" \
+  --runs 10 --log-dir /tmp/startup-bench-logs --save-result results.json
+```
+
+Any two commands that expose an HTTP readiness endpoint work, not just
+`vllm serve` — e.g. to isolate just the frontend layer against an
+already-running headless engine (see `rust/README.md`'s "External Engine"
+section), or to compare two Rust implementations of some startup-path logic
+against each other directly.
+
+## CLI Reference
+
+| Flag | Default | Description |
+| ------ | --------- | ------------- |
+| `--variant NAME=COMMAND` | — | One variant to benchmark (repeatable, required, first = baseline) |
+| `--health-url` | `http://127.0.0.1:8000/health` | URL polled until it returns a successful status |
+| `--runs` | `5` | Timed runs per variant |
+| `--warmup-runs` | `1` | Untimed runs per variant, discarded, run before timed runs |
+| `--ready-timeout-secs` | `300` | Max time to wait for readiness per run |
+| `--poll-interval-ms` | `50` | Interval between readiness poll attempts |
+| `--shutdown-timeout-secs` | `15` | Grace period after SIGTERM before SIGKILL |
+| `--cooldown-secs` | `2` | Delay after a run's process exits before the next run starts |
+| `--log-dir` | — | Directory for per-run `<variant>-run<N>.log` files |
+| `--save-result` | — | Path to write the full result set as JSON |
+
+## Architecture
+
+- `src/main.rs` — Entry point, tokio runtime
+- `src/cli.rs` — clap derive CLI args
+- `src/lib.rs` — Orchestration: interleaved warmup/timed rounds, summarization, report printing
+- `src/runner.rs` — Spawn one command, poll for readiness, tear down the process group
+- `src/process_group.rs` — Process-group signal helpers (adapted from `vllm-managed-engine`)
+- `src/stats.rs` — Mean/median/min/max/stddev over a variant's samples
+- `src/variant.rs` — `NAME=COMMAND` parsing

--- a/rust/src/startup-bench/src/cli.rs
+++ b/rust/src/startup-bench/src/cli.rs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+//! CLI argument definitions for `vllm-startup-bench`.
+
+use std::path::PathBuf;
+
+use clap::Parser;
+
+use crate::variant::Variant;
+
+/// Measure and compare process-startup ("time-to-ready") latency across one
+/// or more `vllm serve`-style commands.
+///
+/// Each variant is spawned as a fresh child process (via `sh -c`), timed from
+/// spawn until an HTTP readiness endpoint starts responding successfully,
+/// then torn down before the next run. Runs are interleaved round-robin
+/// across variants (run 1 of A, run 1 of B, run 2 of A, ...) to spread out
+/// any systematic drift (thermal throttling, filesystem cache state, etc.)
+/// evenly across variants instead of confounding it with run order.
+#[derive(Debug, Parser)]
+#[command(
+    name = "vllm-startup-bench",
+    about = "Compare vLLM process startup (time-to-ready) across variants",
+    version
+)]
+pub struct Args {
+    /// One variant to benchmark, as `NAME=COMMAND`. The command is executed
+    /// with `sh -c`, so shell syntax (env var prefixes, `&&`, quoting) works.
+    /// Repeat this flag once per variant; at least one is required, and the
+    /// first one given is treated as the baseline for comparison.
+    ///
+    /// Example: --variant python="vllm serve Qwen/Qwen3-0.6B"
+    ///          --variant rust="VLLM_USE_RUST_FRONTEND=1 vllm serve Qwen/Qwen3-0.6B"
+    #[arg(long = "variant", required = true, value_parser = Variant::parse)]
+    pub variants: Vec<Variant>,
+
+    /// URL polled with HTTP GET until it returns a successful (2xx) status.
+    #[arg(long, default_value = "http://127.0.0.1:8000/health")]
+    pub health_url: String,
+
+    /// Number of timed runs per variant (in addition to `--warmup-runs`).
+    #[arg(long, default_value_t = 5)]
+    pub runs: usize,
+
+    /// Number of untimed warmup runs per variant, run before the timed runs.
+    /// Useful to prime OS/filesystem caches so the timed runs aren't skewed
+    /// by one-time cold-cache effects unrelated to the code under test.
+    #[arg(long, default_value_t = 1)]
+    pub warmup_runs: usize,
+
+    /// Maximum time to wait for the readiness endpoint per run, in seconds.
+    /// A run that times out is recorded as a failure and excluded from
+    /// latency statistics.
+    #[arg(long, default_value_t = 300)]
+    pub ready_timeout_secs: u64,
+
+    /// Interval between readiness poll attempts, in milliseconds.
+    #[arg(long, default_value_t = 50)]
+    pub poll_interval_ms: u64,
+
+    /// Grace period after SIGTERM before escalating to SIGKILL, in seconds.
+    #[arg(long, default_value_t = 15)]
+    pub shutdown_timeout_secs: u64,
+
+    /// Delay after a variant's process has fully exited before starting the
+    /// next run, in seconds. Gives the OS time to release the listening port.
+    #[arg(long, default_value_t = 2)]
+    pub cooldown_secs: u64,
+
+    /// Directory to write each run's stdout/stderr to, named
+    /// `<variant>-run<N>.log`. If unset, child output is discarded.
+    #[arg(long)]
+    pub log_dir: Option<PathBuf>,
+
+    /// Write the full result set (per-run samples and summary stats) as JSON
+    /// to this file.
+    #[arg(long)]
+    pub save_result: Option<PathBuf>,
+}

--- a/rust/src/startup-bench/src/lib.rs
+++ b/rust/src/startup-bench/src/lib.rs
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+//! Compare process-startup ("time-to-ready") latency across `vllm serve`-style
+//! commands, e.g. plain Python `vllm serve` vs `VLLM_USE_RUST_FRONTEND=1
+//! vllm serve`, or two arbitrary CLI invocations. Built to give concrete,
+//! reproducible before/after numbers for changes on vLLM's startup path,
+//! rather than relying on anecdotal impressions of "faster".
+//!
+//! See `README.md` for usage. Not a general HTTP load-testing tool — for
+//! steady-state serving throughput, use `vllm-bench` instead.
+
+mod cli;
+mod process_group;
+mod runner;
+mod stats;
+mod variant;
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+use tracing::info;
+
+pub use cli::Args;
+use runner::RunOutcome;
+use stats::Summary;
+use variant::Variant;
+
+/// Per-variant timed samples and derived summary statistics.
+#[derive(Debug, Serialize)]
+struct VariantResult {
+    name: String,
+    command: String,
+    runs: Vec<RunOutcome>,
+    summary: Option<Summary>,
+}
+
+/// Full result set, suitable for `--save-result`.
+#[derive(Debug, Serialize)]
+struct Results {
+    health_url: String,
+    variants: Vec<VariantResult>,
+}
+
+/// Run the full benchmark: warmups, interleaved timed runs, then print (and
+/// optionally save) a comparison report.
+pub async fn run(args: Args) -> Result<()> {
+    if let Some(dir) = &args.log_dir {
+        std::fs::create_dir_all(dir)
+            .with_context(|| format!("failed to create log dir {}", dir.display()))?;
+    }
+
+    let ready_timeout = Duration::from_secs(args.ready_timeout_secs);
+    let poll_interval = Duration::from_millis(args.poll_interval_ms);
+    let shutdown_timeout = Duration::from_secs(args.shutdown_timeout_secs);
+    let cooldown = Duration::from_secs(args.cooldown_secs);
+
+    let mut timed_runs: Vec<Vec<RunOutcome>> = vec![Vec::new(); args.variants.len()];
+
+    let total_rounds = args.warmup_runs + args.runs;
+    for round in 0..total_rounds {
+        let is_warmup = round < args.warmup_runs;
+        let kind = if is_warmup { "warmup" } else { "timed" };
+
+        for (idx, variant) in args.variants.iter().enumerate() {
+            info!(variant = %variant.name, round, kind, "starting run");
+
+            let log_path = args.log_dir.as_ref().map(|dir| {
+                let suffix = if is_warmup {
+                    format!("warmup{round}")
+                } else {
+                    format!("run{round}")
+                };
+                dir.join(format!("{}-{suffix}.log", variant.name))
+            });
+
+            let outcome = runner::run_once(
+                &variant.command,
+                &args.health_url,
+                ready_timeout,
+                poll_interval,
+                shutdown_timeout,
+                log_path.as_deref(),
+            )
+            .await
+            .with_context(|| format!("run failed for variant {:?}", variant.name))?;
+
+            match outcome.ready_secs {
+                Some(secs) => {
+                    info!(variant = %variant.name, round, kind, ready_secs = secs, "ready")
+                }
+                None => {
+                    tracing::warn!(variant = %variant.name, round, kind, "did not become ready")
+                }
+            }
+
+            if !is_warmup {
+                timed_runs[idx].push(outcome);
+            }
+
+            tokio::time::sleep(cooldown).await;
+        }
+    }
+
+    let results = summarize(&args.variants, timed_runs, &args.health_url);
+    print_report(&results);
+
+    if let Some(path) = &args.save_result {
+        let json = serde_json::to_string_pretty(&results).context("failed to serialize results")?;
+        std::fs::write(path, json)
+            .with_context(|| format!("failed to write results to {}", path.display()))?;
+        println!("\nSaved results to {}", path.display());
+    }
+
+    Ok(())
+}
+
+fn summarize(variants: &[Variant], timed_runs: Vec<Vec<RunOutcome>>, health_url: &str) -> Results {
+    let variants = variants
+        .iter()
+        .zip(timed_runs)
+        .map(|(variant, runs)| {
+            let (successes, failures): (Vec<_>, Vec<_>) =
+                runs.iter().partition(|r| r.ready_secs.is_some());
+            let samples: Vec<f64> = successes.iter().filter_map(|r| r.ready_secs).collect();
+            let summary = Summary::from_samples(samples, failures.len());
+            VariantResult {
+                name: variant.name.clone(),
+                command: variant.command.clone(),
+                runs,
+                summary,
+            }
+        })
+        .collect();
+
+    Results {
+        health_url: health_url.to_string(),
+        variants,
+    }
+}
+
+fn print_report(results: &Results) {
+    println!("\n=== Startup time-to-ready ({}) ===\n", results.health_url);
+    println!(
+        "{:<16} {:>7} {:>9} {:>10} {:>10} {:>10} {:>10} {:>10}",
+        "variant", "runs", "failures", "mean(s)", "median(s)", "min(s)", "max(s)", "stddev(s)"
+    );
+    for variant in &results.variants {
+        match &variant.summary {
+            Some(s) => println!(
+                "{:<16} {:>7} {:>9} {:>10.3} {:>10.3} {:>10.3} {:>10.3} {:>10.3}",
+                variant.name,
+                s.samples,
+                s.failures,
+                s.mean_secs,
+                s.median_secs,
+                s.min_secs,
+                s.max_secs,
+                s.stddev_secs
+            ),
+            None => println!(
+                "{:<16} {:>7} {:>9} {:>10} {:>10} {:>10} {:>10} {:>10}",
+                variant.name,
+                0,
+                variant.runs.len(),
+                "-",
+                "-",
+                "-",
+                "-",
+                "-"
+            ),
+        }
+    }
+
+    let Some(baseline) = results.variants.first() else {
+        return;
+    };
+    let Some(baseline_summary) = &baseline.summary else {
+        println!(
+            "\nBaseline variant {:?} never became ready; skipping comparison.",
+            baseline.name
+        );
+        return;
+    };
+
+    println!(
+        "\n=== Comparison vs. baseline {:?} (median) ===\n",
+        baseline.name
+    );
+    for variant in &results.variants[1..] {
+        let Some(summary) = &variant.summary else {
+            println!("{:<16} never became ready", variant.name);
+            continue;
+        };
+        let delta = summary.median_secs - baseline_summary.median_secs;
+        let pct = (delta / baseline_summary.median_secs) * 100.0;
+        if delta < 0.0 {
+            println!(
+                "{:<16} {:.2}x faster  ({:+.3}s, {:+.1}%)",
+                variant.name,
+                baseline_summary.median_secs / summary.median_secs,
+                delta,
+                pct
+            );
+        } else {
+            println!(
+                "{:<16} SLOWER by {:.2}x ({:+.3}s, {:+.1}%) -- regression vs. baseline",
+                variant.name,
+                summary.median_secs / baseline_summary.median_secs,
+                delta,
+                pct
+            );
+        }
+    }
+}

--- a/rust/src/startup-bench/src/main.rs
+++ b/rust/src/startup-bench/src/main.rs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+use anyhow::{Context, Result};
+use clap::Parser as _;
+use vllm_startup_bench::Args;
+
+fn main() -> Result<()> {
+    vllm_tracing::init_tracing("StartupBench");
+
+    let args = Args::parse();
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .context("failed to build Tokio runtime")?;
+
+    runtime.block_on(vllm_startup_bench::run(args))
+}

--- a/rust/src/startup-bench/src/process_group.rs
+++ b/rust/src/startup-bench/src/process_group.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+//! Process-group helpers so a benchmarked command's entire subtree (e.g. a
+//! shell wrapping `vllm serve`, which may itself fork engine-core workers)
+//! can be torn down together, instead of leaking orphans that would keep the
+//! port bound or the GPU busy for the next run.
+//!
+//! Adapted from the equivalent helper in `vllm-managed-engine`; duplicated
+//! here rather than shared so this crate stays a small, dependency-light
+//! standalone tool.
+
+use std::io;
+
+use anyhow::{Context, Result};
+use tokio::process::Command;
+
+/// Place the child into its own process group so its whole subtree can be
+/// signaled together.
+pub fn configure(command: &mut Command) {
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setpgid(0, 0) != 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+}
+
+/// Send SIGTERM to the process group led by `pid`.
+pub fn terminate(pid: u32) -> Result<()> {
+    signal(pid, libc::SIGTERM)
+}
+
+/// Send SIGKILL to the process group led by `pid`.
+pub fn kill(pid: u32) -> Result<()> {
+    signal(pid, libc::SIGKILL)
+}
+
+/// Deliver one signal to the process group led by `pid`. A missing process
+/// (already exited) is treated as success.
+fn signal(pid: u32, signal: i32) -> Result<()> {
+    let rc = unsafe { libc::kill(-(pid as i32), signal) };
+    if rc == 0 {
+        return Ok(());
+    }
+
+    let error = io::Error::last_os_error();
+    if matches!(error.raw_os_error(), Some(code) if code == libc::ESRCH) {
+        return Ok(());
+    }
+    Err(error).context("failed to signal process group")
+}

--- a/rust/src/startup-bench/src/runner.rs
+++ b/rust/src/startup-bench/src/runner.rs
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+//! Spawn one variant's command, time how long it takes to become ready, and
+//! tear it down again.
+
+use std::fs::File;
+use std::path::Path;
+use std::process::Stdio;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use tokio::process::Command;
+
+use crate::process_group;
+
+/// Outcome of a single timed (or warmup) run of one variant.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RunOutcome {
+    /// Wall-clock seconds from process spawn to the readiness endpoint first
+    /// responding successfully. `None` if the run failed (crashed or timed
+    /// out) before becoming ready.
+    pub ready_secs: Option<f64>,
+}
+
+/// Spawn `command` via `sh -c`, poll `health_url` until it responds
+/// successfully or `ready_timeout` elapses, then terminate the process group.
+///
+/// `log_path`, if given, receives the child's combined stdout/stderr — handy
+/// for diagnosing a run that fails to become ready.
+pub async fn run_once(
+    command: &str,
+    health_url: &str,
+    ready_timeout: Duration,
+    poll_interval: Duration,
+    shutdown_timeout: Duration,
+    log_path: Option<&Path>,
+) -> Result<RunOutcome> {
+    let mut cmd = Command::new("sh");
+    cmd.arg("-c").arg(command);
+
+    match log_path {
+        Some(path) => {
+            let out = File::create(path)
+                .with_context(|| format!("failed to create log file {}", path.display()))?;
+            let err = out.try_clone().context("failed to clone log file handle")?;
+            cmd.stdout(Stdio::from(out)).stderr(Stdio::from(err));
+        }
+        None => {
+            cmd.stdout(Stdio::null()).stderr(Stdio::null());
+        }
+    }
+    cmd.stdin(Stdio::null());
+    process_group::configure(&mut cmd);
+
+    let mut child = cmd.spawn().with_context(|| format!("failed to spawn command: {command}"))?;
+    let pid = child.id();
+
+    let ready_secs = wait_until_ready(&mut child, health_url, ready_timeout, poll_interval).await?;
+
+    if let Some(pid) = pid {
+        shut_down(&mut child, pid, shutdown_timeout).await;
+    }
+
+    Ok(RunOutcome { ready_secs })
+}
+
+/// Poll `health_url` until it returns a successful status, the process
+/// exits, or `timeout` elapses. Returns the elapsed seconds on success.
+async fn wait_until_ready(
+    child: &mut tokio::process::Child,
+    health_url: &str,
+    timeout: Duration,
+    poll_interval: Duration,
+) -> Result<Option<f64>> {
+    let start = Instant::now();
+    // Short per-request timeout: readiness polling relies on the outer retry
+    // loop, not on any single request hanging around.
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .context("failed to build HTTP client")?;
+
+    loop {
+        if let Some(status) = child.try_wait().context("failed to poll child status")? {
+            tracing::warn!(%status, "process exited before becoming ready");
+            return Ok(None);
+        }
+
+        if let Ok(response) = client.get(health_url).send().await
+            && response.status().is_success()
+        {
+            return Ok(Some(start.elapsed().as_secs_f64()));
+        }
+
+        if start.elapsed() >= timeout {
+            tracing::warn!(?timeout, "timed out waiting for readiness");
+            return Ok(None);
+        }
+
+        tokio::time::sleep(poll_interval).await;
+    }
+}
+
+/// Terminate the process group led by `pid`, escalating to SIGKILL if it
+/// doesn't exit within `timeout`.
+async fn shut_down(child: &mut tokio::process::Child, pid: u32, timeout: Duration) {
+    if let Err(error) = process_group::terminate(pid) {
+        tracing::warn!(?error, "failed to send SIGTERM to process group");
+    }
+
+    if tokio::time::timeout(timeout, child.wait()).await.is_ok() {
+        return;
+    }
+
+    tracing::warn!("process did not exit after SIGTERM, sending SIGKILL");
+    if let Err(error) = process_group::kill(pid) {
+        tracing::warn!(?error, "failed to send SIGKILL to process group");
+    }
+    let _ = child.wait().await;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::TcpListener;
+
+    use super::*;
+
+    /// Reserve an ephemeral port by binding then immediately releasing it.
+    /// Small TOCTOU race in theory; acceptable for these best-effort tests.
+    fn reserve_port() -> u16 {
+        TcpListener::bind("127.0.0.1:0").unwrap().local_addr().unwrap().port()
+    }
+
+    fn python_http_server_cmd(port: u16, delay_secs: f64) -> String {
+        format!(
+            "python3 -c \"import time, http.server, socketserver; \
+             time.sleep({delay_secs}); \
+             socketserver.TCPServer.allow_reuse_address = True; \
+             httpd = socketserver.TCPServer(('127.0.0.1', {port}), http.server.SimpleHTTPRequestHandler); \
+             httpd.serve_forever()\""
+        )
+    }
+
+    // Requires python3; run explicitly with `cargo test -- --ignored`.
+    #[tokio::test]
+    #[ignore]
+    async fn reports_ready_secs_once_endpoint_responds() {
+        let port = reserve_port();
+        let command = python_http_server_cmd(port, 0.0);
+        let health_url = format!("http://127.0.0.1:{port}/");
+
+        let outcome = run_once(
+            &command,
+            &health_url,
+            Duration::from_secs(10),
+            Duration::from_millis(20),
+            Duration::from_secs(5),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(outcome.ready_secs.is_some());
+    }
+
+    // Requires python3; run explicitly with `cargo test -- --ignored`.
+    #[tokio::test]
+    #[ignore]
+    async fn slower_variant_reports_larger_ready_secs() {
+        let fast_port = reserve_port();
+        let slow_port = reserve_port();
+        let fast_command = python_http_server_cmd(fast_port, 0.0);
+        let slow_command = python_http_server_cmd(slow_port, 1.0);
+        let fast_url = format!("http://127.0.0.1:{fast_port}/");
+        let slow_url = format!("http://127.0.0.1:{slow_port}/");
+
+        let fast = run_once(
+            &fast_command,
+            &fast_url,
+            Duration::from_secs(10),
+            Duration::from_millis(20),
+            Duration::from_secs(5),
+            None,
+        );
+        let slow = run_once(
+            &slow_command,
+            &slow_url,
+            Duration::from_secs(10),
+            Duration::from_millis(20),
+            Duration::from_secs(5),
+            None,
+        );
+
+        let (fast, slow) = tokio::join!(fast, slow);
+        let fast_secs = fast.unwrap().ready_secs.unwrap();
+        let slow_secs = slow.unwrap().ready_secs.unwrap();
+        assert!(slow_secs > fast_secs, "expected {slow_secs} > {fast_secs}");
+    }
+
+    // Requires python3; run explicitly with `cargo test -- --ignored`.
+    #[tokio::test]
+    #[ignore]
+    async fn process_that_exits_without_serving_reports_no_ready_secs() {
+        let outcome = run_once(
+            "python3 -c \"import time; time.sleep(0.1)\"",
+            "http://127.0.0.1:1/never-bound",
+            Duration::from_secs(5),
+            Duration::from_millis(20),
+            Duration::from_secs(5),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(outcome.ready_secs.is_none());
+    }
+}

--- a/rust/src/startup-bench/src/stats.rs
+++ b/rust/src/startup-bench/src/stats.rs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+//! Summary statistics over one variant's timed runs.
+
+/// Summary statistics for a variant's `ready_secs` samples.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct Summary {
+    pub samples: usize,
+    pub failures: usize,
+    pub mean_secs: f64,
+    pub median_secs: f64,
+    pub min_secs: f64,
+    pub max_secs: f64,
+    pub stddev_secs: f64,
+}
+
+impl Summary {
+    /// Compute summary statistics from successful-run samples; `failures`
+    /// is the count of runs that never became ready.
+    ///
+    /// Returns `None` if there are no successful samples to summarize.
+    pub fn from_samples(mut samples: Vec<f64>, failures: usize) -> Option<Self> {
+        if samples.is_empty() {
+            return None;
+        }
+        samples.sort_by(|a, b| a.total_cmp(b));
+
+        let n = samples.len();
+        let mean = samples.iter().sum::<f64>() / n as f64;
+        let median = if n.is_multiple_of(2) {
+            (samples[n / 2 - 1] + samples[n / 2]) / 2.0
+        } else {
+            samples[n / 2]
+        };
+        let variance = samples.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / n as f64;
+
+        Some(Self {
+            samples: n,
+            failures,
+            mean_secs: mean,
+            median_secs: median,
+            min_secs: samples[0],
+            max_secs: samples[n - 1],
+            stddev_secs: variance.sqrt(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Summary;
+
+    #[test]
+    fn computes_mean_median_min_max() {
+        let summary = Summary::from_samples(vec![1.0, 2.0, 3.0, 4.0], 0).unwrap();
+        assert_eq!(summary.samples, 4);
+        assert_eq!(summary.failures, 0);
+        assert_eq!(summary.mean_secs, 2.5);
+        assert_eq!(summary.median_secs, 2.5);
+        assert_eq!(summary.min_secs, 1.0);
+        assert_eq!(summary.max_secs, 4.0);
+    }
+
+    #[test]
+    fn odd_count_median_is_middle_sample() {
+        let summary = Summary::from_samples(vec![5.0, 1.0, 3.0], 0).unwrap();
+        assert_eq!(summary.median_secs, 3.0);
+    }
+
+    #[test]
+    fn no_successful_samples_returns_none() {
+        assert!(Summary::from_samples(vec![], 3).is_none());
+    }
+}

--- a/rust/src/startup-bench/src/variant.rs
+++ b/rust/src/startup-bench/src/variant.rs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+//! A single named `--variant NAME=COMMAND` entry.
+
+use std::fmt;
+
+/// One command to benchmark, identified by a short name used in output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Variant {
+    pub name: String,
+    pub command: String,
+}
+
+impl Variant {
+    /// Parse a `NAME=COMMAND` string into a [`Variant`].
+    ///
+    /// Only the first `=` is significant, since `COMMAND` is a full shell
+    /// command line that may itself contain `=` (e.g. `FOO=1 vllm serve ...`).
+    pub fn parse(s: &str) -> Result<Self, String> {
+        let (name, command) =
+            s.split_once('=').ok_or_else(|| format!("expected NAME=COMMAND, got {s:?}"))?;
+        if name.trim().is_empty() {
+            return Err(format!("variant name must not be empty, got {s:?}"));
+        }
+        if command.trim().is_empty() {
+            return Err(format!("variant command must not be empty, got {s:?}"));
+        }
+        Ok(Self {
+            name: name.to_string(),
+            command: command.to_string(),
+        })
+    }
+}
+
+impl fmt::Display for Variant {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Variant;
+
+    #[test]
+    fn parses_name_and_command() {
+        let variant = Variant::parse("python=vllm serve Qwen/Qwen3-0.6B").unwrap();
+        assert_eq!(variant.name, "python");
+        assert_eq!(variant.command, "vllm serve Qwen/Qwen3-0.6B");
+    }
+
+    #[test]
+    fn command_may_contain_equals_signs() {
+        let variant =
+            Variant::parse("rust=VLLM_USE_RUST_FRONTEND=1 vllm serve Qwen/Qwen3-0.6B").unwrap();
+        assert_eq!(variant.name, "rust");
+        assert_eq!(
+            variant.command,
+            "VLLM_USE_RUST_FRONTEND=1 vllm serve Qwen/Qwen3-0.6B"
+        );
+    }
+
+    #[test]
+    fn rejects_missing_equals() {
+        assert!(Variant::parse("no-equals-sign-here").is_err());
+    }
+
+    #[test]
+    fn rejects_empty_name() {
+        assert!(Variant::parse("=vllm serve foo").is_err());
+    }
+
+    #[test]
+    fn rejects_empty_command() {
+        assert!(Variant::parse("name=").is_err());
+    }
+}


### PR DESCRIPTION
## What

Adds `vllm-startup-bench`, a small standalone Rust CLI (`rust/src/startup-bench`)
that measures and compares process-startup latency ("time-to-ready": wall
clock from process spawn until the `/health` endpoint first responds
successfully) across `vllm serve`-style commands, e.g.:

```bash
vllm-startup-bench \
  --variant "python=vllm serve Qwen/Qwen3-0.6B" \
  --variant "rust=VLLM_USE_RUST_FRONTEND=1 vllm serve Qwen/Qwen3-0.6B" \
  --runs 5 --warmup-runs 1
```

For each variant it interleaves warmup + timed runs round-robin across
variants (to spread systematic drift evenly rather than confound it with run
order), tears down the whole process group between runs, and reports
mean/median/min/max/stddev plus an explicit speedup **or regression**
comparison against the first variant (baseline). See `rust/src/startup-bench/README.md`
for full usage and CLI reference.

## Why

I was asked to port more of vLLM's Python frontend to Rust with a hard
requirement: a *measurable* startup-time win with *no* disadvantages. Before
touching any port, I did a duplicate-work and scoping pass over the existing
Rust frontend (`rust/`) and its startup path:

- Every plausible candidate on the pre-engine startup path (CLI-arg/`EngineArgs`
  schema construction, `config.json`-derived defaults, DP-mode arg validation)
  either (a) risks duplicating/hand-syncing Python's ~300-field CLI surface —
  which `rust/src/cmd/src/cli/unsupported.rs` was deliberately designed to
  avoid — (b) risks parity bugs vs. full `transformers.AutoConfig` semantics,
  or (c) is too small to be measurable.
- Neither side currently has a tool to get an apples-to-apples time-to-ready
  number in the first place: Python's `vllm bench startup` only times model
  loading, and `vllm-bench` (Rust) is an HTTP load generator, not a
  process-lifecycle timer.

So rather than guess at a port and claim a win without evidence, this PR adds
the missing measurement tool first. It's infrastructure, not a port — future
PRs that do port startup-path logic to Rust can use this to show real
before/after numbers instead of anecdotal claims.

## Not a duplicate

Checked open/closed PRs and issues for `rust startup`, `startup benchmark`,
`cold start`, `time-to-ready`. Closest related work:

- #49037 — Python per-phase cold-start spans, scoped to model-loading phases
  (init device, load weights, capture, KV cache alloc, warmup), not
  process-level time-to-ready across frontend implementations.
- #48193 / #48194 — maintainer-tracked "Cold Start" roadmap, also scoped to
  model-weight download/loading, not CLI/config/frontend startup.

Neither overlaps with a generic, reusable time-to-ready comparison harness.

## Testing

- `cargo build -p vllm-startup-bench` / `--release`
- `cargo test -p vllm-startup-bench` — 8 unit tests (variant `NAME=COMMAND`
  parsing, mean/median/min/max/stddev stats)
- `cargo test -p vllm-startup-bench -- --ignored` — 3 integration tests that
  spawn real `python3 -m http.server`-style processes and assert readiness
  timing, relative ordering between a fast and an artificially-delayed
  variant, and the "process exits without ever serving" failure path
- `cargo clippy -p vllm-startup-bench --all-targets -- -D warnings` — clean
- `cargo +nightly fmt -p vllm-startup-bench --check` — clean (matches repo style)
- `cargo build --workspace` — no regressions to existing crates
- `cargo deny check bans` — clean, no new external dependencies (reuses
  workspace-pinned `reqwest`/`tokio`/`clap`/etc.)
- Manual end-to-end run against two dummy HTTP servers with a deliberate
  0.5s startup delay: confirmed correct timing, cooldown/port-reuse between
  runs, `--save-result` JSON output schema, and the regression-flagging
  comparison report (`SLOWER by ... -- regression vs. baseline`)
- Verified no orphaned child processes remain after a run (process-group
  SIGTERM/SIGKILL signaling, adapted from `vllm-managed-engine`)

No model output/accuracy is affected by this change (dev tooling only), so
no model-eval numbers apply.

## AI assistance disclosure

This change (scoping research, implementation, and tests) was developed with
AI assistance (OpenCode/Claude Sonnet). I reviewed every changed line and ran
all the test commands above myself before opening this PR.
