### PR TITLE
[Rust Frontend] Skip full OpenAI-server CLI schema for the managed headless engine

### DIFF
--- a/rust/src/managed-engine/src/process.rs
+++ b/rust/src/managed-engine/src/process.rs
@@ -31,7 +31,7 @@ pub fn allocate_handshake_port(host: &str) -> Result<u16> {
 /// Spawn configuration for one managed headless Python vLLM engine.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ManagedEngineConfig {
-    /// Python executable used to launch `vllm.entrypoints.cli.main`.
+    /// Python executable used to launch `vllm.entrypoints.cli.headless_engine`.
     pub python: String,
     /// Model identifier passed to `vllm ... serve <model>`.
     pub model: String,
@@ -55,14 +55,18 @@ impl ManagedEngineConfig {
     }
 
     /// Build the concrete Python command line for the managed headless engine.
+    ///
+    /// Uses `vllm.entrypoints.cli.headless_engine` instead of `vllm serve
+    /// --headless`, which skips building the full OpenAI-server CLI schema
+    /// that a headless engine never reads. See
+    /// `vllm/entrypoints/cli/headless_engine.py` for details.
     pub fn to_command(&self) -> StdCommand {
         let mut command = StdCommand::new(&self.python);
         command
             .arg("-m")
-            .arg("vllm.entrypoints.cli.main")
-            .arg("serve")
+            .arg("vllm.entrypoints.cli.headless_engine")
+            .arg("--model")
             .arg(&self.model)
-            .arg("--headless")
             .arg("--data-parallel-address")
             .arg(&self.handshake_host)
             .arg("--data-parallel-rpc-port")
@@ -235,10 +239,9 @@ mod tests {
         expect![[r#"
             [
                 "-m",
-                "vllm.entrypoints.cli.main",
-                "serve",
+                "vllm.entrypoints.cli.headless_engine",
+                "--model",
                 "Qwen/Qwen3-0.6B",
-                "--headless",
                 "--data-parallel-address",
                 "127.0.0.1",
                 "--data-parallel-rpc-port",

--- a/tests/entrypoints/unit_tests/test_headless_engine_cli.py
+++ b/tests/entrypoints/unit_tests/test_headless_engine_cli.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for `vllm.entrypoints.cli.headless_engine`."""
+
+from unittest.mock import patch
+
+import pytest
+
+from vllm.entrypoints.cli.headless_engine import main
+
+
+@pytest.fixture
+def run_headless_mock():
+    with patch("vllm.entrypoints.cli.serve.run_headless") as mock:
+        yield mock
+
+
+def test_main_calls_run_headless_with_parsed_engine_args(run_headless_mock):
+    main(
+        [
+            "--model",
+            "Qwen/Qwen3-0.6B",
+            "--data-parallel-address",
+            "127.0.0.1",
+            "--data-parallel-rpc-port",
+            "1234",
+            "--data-parallel-size",
+            "2",
+            "--max-model-len",
+            "512",
+        ]
+    )
+
+    run_headless_mock.assert_called_once()
+    args = run_headless_mock.call_args[0][0]
+    assert args.model == "Qwen/Qwen3-0.6B"
+    assert args.data_parallel_address == "127.0.0.1"
+    assert args.data_parallel_rpc_port == 1234
+    assert args.data_parallel_size == 2
+    # Real argparse type coercion: parsed as int, not the raw string.
+    assert args.max_model_len == 512
+
+
+def test_main_forces_api_server_count_to_zero(run_headless_mock):
+    main(["--model", "Qwen/Qwen3-0.6B"])
+
+    args = run_headless_mock.call_args[0][0]
+    assert args.api_server_count == 0
+
+
+def test_main_rejects_unknown_args(run_headless_mock):
+    # e.g. a typo'd flag, or a genuinely Frontend-only flag that doesn't
+    # apply to a headless engine -- both should fail fast rather than
+    # silently launch with the wrong (default) config.
+    with pytest.raises(SystemExit):
+        main(
+            [
+                "--model",
+                "Qwen/Qwen3-0.6B",
+                "--chat-template",
+                "some-template.jinja",
+            ]
+        )
+
+    run_headless_mock.assert_not_called()
+
+
+def test_main_applies_flexible_argument_parser_preprocessing(run_headless_mock):
+    # Underscore spelling and dotted-JSON option syntax are both handled by
+    # `FlexibleArgumentParser.parse_args`'s preprocessing, not by argparse
+    # itself -- this only works if `main` calls `parse_args`, not
+    # `parse_known_args` directly on the raw argv.
+    main(
+        [
+            "--model",
+            "Qwen/Qwen3-0.6B",
+            "--max_model_len",  # underscores, not dashes
+            "512",
+        ]
+    )
+
+    args = run_headless_mock.call_args[0][0]
+    assert args.max_model_len == 512
+
+
+def test_main_defaults_match_async_engine_args_defaults(run_headless_mock):
+    from vllm.engine.arg_utils import AsyncEngineArgs
+
+    main(["--model", "Qwen/Qwen3-0.6B"])
+
+    args = run_headless_mock.call_args[0][0]
+    defaults = AsyncEngineArgs()
+    assert args.enable_log_requests == defaults.enable_log_requests
+    assert args.disable_log_stats == defaults.disable_log_stats

--- a/tests/entrypoints/unit_tests/test_headless_engine_cli.py
+++ b/tests/entrypoints/unit_tests/test_headless_engine_cli.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for `vllm.entrypoints.cli.headless_engine`."""
+
+from unittest.mock import patch
+
+import pytest
+
+from vllm.entrypoints.cli.headless_engine import main
+
+
+@pytest.fixture
+def run_headless_mock():
+    with patch("vllm.entrypoints.cli.headless_engine.run_headless") as mock:
+        yield mock
+
+
+def test_main_calls_run_headless_with_parsed_engine_args(run_headless_mock):
+    main(
+        [
+            "--model",
+            "Qwen/Qwen3-0.6B",
+            "--data-parallel-address",
+            "127.0.0.1",
+            "--data-parallel-rpc-port",
+            "1234",
+            "--data-parallel-size",
+            "2",
+            "--max-model-len",
+            "512",
+        ]
+    )
+
+    run_headless_mock.assert_called_once()
+    args = run_headless_mock.call_args[0][0]
+    assert args.model == "Qwen/Qwen3-0.6B"
+    assert args.data_parallel_address == "127.0.0.1"
+    assert args.data_parallel_rpc_port == 1234
+    assert args.data_parallel_size == 2
+    # Real argparse type coercion: parsed as int, not the raw string.
+    assert args.max_model_len == 512
+
+
+def test_main_forces_api_server_count_to_zero(run_headless_mock):
+    main(["--model", "Qwen/Qwen3-0.6B"])
+
+    args = run_headless_mock.call_args[0][0]
+    assert args.api_server_count == 0
+
+
+def test_main_rejects_unknown_args(run_headless_mock):
+    # e.g. a typo'd flag, or a genuinely Frontend-only flag that doesn't
+    # apply to a headless engine -- both should fail fast rather than
+    # silently launch with the wrong (default) config.
+    with pytest.raises(SystemExit):
+        main(
+            [
+                "--model",
+                "Qwen/Qwen3-0.6B",
+                "--chat-template",
+                "some-template.jinja",
+            ]
+        )
+
+    run_headless_mock.assert_not_called()
+
+
+def test_main_applies_flexible_argument_parser_preprocessing(run_headless_mock):
+    # Underscore spelling and dotted-JSON option syntax are both handled by
+    # `FlexibleArgumentParser.parse_args`'s preprocessing, not by argparse
+    # itself -- this only works if `main` calls `parse_args`, not
+    # `parse_known_args` directly on the raw argv.
+    main(
+        [
+            "--model",
+            "Qwen/Qwen3-0.6B",
+            "--max_model_len",  # underscores, not dashes
+            "512",
+        ]
+    )
+
+    args = run_headless_mock.call_args[0][0]
+    assert args.max_model_len == 512
+
+
+def test_main_defaults_match_async_engine_args_defaults(run_headless_mock):
+    from vllm.engine.arg_utils import AsyncEngineArgs
+
+    main(["--model", "Qwen/Qwen3-0.6B"])
+
+    args = run_headless_mock.call_args[0][0]
+    defaults = AsyncEngineArgs()
+    assert args.enable_log_requests == defaults.enable_log_requests
+    assert args.disable_log_stats == defaults.disable_log_stats

--- a/vllm/entrypoints/cli/headless_engine.py
+++ b/vllm/entrypoints/cli/headless_engine.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Lean entrypoint for a headless vLLM engine (no API server).
+
+`vllm serve --headless` builds the full OpenAI-server CLI schema
+(tool/reasoning-parser plugins, MCP, chat templates, ...), none of which
+`run_headless` reads. This builds a parser from `AsyncEngineArgs.add_cli_args`
+only and calls the same `run_headless`, skipping that overhead.
+
+Uses `FlexibleArgumentParser.parse_args` (not `parse_known_args`) so
+`--config` files, dash/underscore normalization, and dotted-JSON options
+behave exactly like `vllm serve`, and unknown args still error.
+
+Not a public `vllm` subcommand; invoked via
+`python -m vllm.entrypoints.cli.headless_engine` by `vllm-rs serve`'s managed
+headless-engine mode (`rust/src/managed-engine`).
+"""
+
+
+def main(argv: list[str] | None = None) -> None:
+    from vllm.engine.arg_utils import AsyncEngineArgs
+    from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+    parser = FlexibleArgumentParser(
+        description="Launch a headless vLLM engine (no API server).",
+        add_json_tip=False,
+    )
+    parser = AsyncEngineArgs.add_cli_args(parser)
+
+    args = parser.parse_args(argv)
+
+    # Headless mode never starts API servers.
+    args.api_server_count = 0
+
+    from vllm.entrypoints.cli.serve import run_headless
+
+    run_headless(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/entrypoints/cli/headless_engine.py
+++ b/vllm/entrypoints/cli/headless_engine.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Lean entrypoint for a headless vLLM engine (no API server).
+
+`vllm serve --headless` builds the full OpenAI-server CLI schema
+(tool/reasoning-parser plugins, MCP, chat templates, ...), none of which a
+headless engine reads. This builds a parser from `AsyncEngineArgs.add_cli_args`
+only. `run_headless` is implemented here (and re-exported from
+`vllm.entrypoints.cli.serve` for `vllm serve --headless`) rather than the
+other way around, so this module never risks pulling in
+`vllm.entrypoints.cli.serve`'s OpenAI-server-only imports, even if more are
+added there in the future.
+
+Uses `FlexibleArgumentParser.parse_args` (not `parse_known_args`) so
+`--config` files, dash/underscore normalization, and dotted-JSON options
+behave exactly like `vllm serve`, and unknown args still error.
+
+Not a public `vllm` subcommand; invoked via
+`python -m vllm.entrypoints.cli.headless_engine` by `vllm-rs serve`'s managed
+headless-engine mode (`rust/src/managed-engine`).
+"""
+
+import argparse
+import signal
+
+import vllm
+from vllm.logger import init_logger
+from vllm.usage.usage_lib import UsageContext
+from vllm.utils.network_utils import get_tcp_uri
+from vllm.v1.engine.utils import CoreEngineProcManager
+from vllm.v1.executor import Executor
+from vllm.v1.executor.multiproc_executor import MultiprocExecutor
+
+logger = init_logger(__name__)
+
+
+def main(argv: list[str] | None = None) -> None:
+    from vllm.engine.arg_utils import AsyncEngineArgs
+    from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+    parser = FlexibleArgumentParser(
+        description="Launch a headless vLLM engine (no API server).",
+        add_json_tip=False,
+    )
+    parser = AsyncEngineArgs.add_cli_args(parser)
+
+    args = parser.parse_args(argv)
+
+    # Headless mode never starts API servers.
+    args.api_server_count = 0
+
+    run_headless(args)
+
+
+def run_headless(args: argparse.Namespace) -> None:
+    if args.api_server_count > 1:
+        raise ValueError("api_server_count can't be set in headless mode")
+
+    # Create the EngineConfig.
+    engine_args = vllm.AsyncEngineArgs.from_cli_args(args)
+    usage_context = UsageContext.OPENAI_API_SERVER
+    vllm_config = engine_args.create_engine_config(
+        usage_context=usage_context, headless=True
+    )
+
+    if engine_args.data_parallel_hybrid_lb:
+        raise ValueError("data_parallel_hybrid_lb is not applicable in headless mode")
+
+    parallel_config = vllm_config.parallel_config
+    local_engine_count = parallel_config.data_parallel_size_local
+
+    if local_engine_count <= 0:
+        raise ValueError("data_parallel_size_local must be > 0 in headless mode")
+
+    shutdown_requested = False
+
+    # Catch SIGTERM and SIGINT to allow graceful shutdown.
+    def signal_handler(signum, frame):
+        nonlocal shutdown_requested
+        logger.debug("Received %d signal.", signum)
+        if not shutdown_requested:
+            shutdown_requested = True
+            raise SystemExit
+
+    signal.signal(signal.SIGTERM, signal_handler)
+    signal.signal(signal.SIGINT, signal_handler)
+
+    if parallel_config.node_rank_within_dp > 0:
+        from vllm.version import __version__ as VLLM_VERSION
+
+        # Run headless workers (for multi-node PP/TP).
+        host = parallel_config.master_addr
+        head_node_address = f"{host}:{parallel_config.master_port}"
+        logger.info(
+            "Launching vLLM (v%s) headless multiproc executor, "
+            "with head node address %s for torch.distributed process group.",
+            VLLM_VERSION,
+            head_node_address,
+        )
+
+        executor = MultiprocExecutor(vllm_config, monitor_workers=False)
+        executor.start_worker_monitor(inline=True)
+        return
+
+    host = parallel_config.data_parallel_master_ip
+    port = parallel_config.data_parallel_rpc_port
+    handshake_address = get_tcp_uri(host, port)
+
+    logger.info(
+        "Launching %d data parallel engine(s) in headless mode, "
+        "with head node address %s.",
+        local_engine_count,
+        handshake_address,
+    )
+
+    # Create the engines.
+    engine_manager = CoreEngineProcManager(
+        local_engine_count=local_engine_count,
+        start_index=vllm_config.parallel_config.data_parallel_rank,
+        local_start_index=0,
+        vllm_config=vllm_config,
+        local_client=False,
+        handshake_address=handshake_address,
+        executor_class=Executor.get_class(vllm_config),
+        log_stats=not engine_args.disable_log_stats,
+    )
+
+    try:
+        engine_manager.monitor_engine_liveness()
+    finally:
+        timeout = None
+        if shutdown_requested:
+            timeout = vllm_config.shutdown_timeout
+            logger.info("Waiting up to %d seconds for processes to exit", timeout)
+        engine_manager.shutdown(timeout=timeout)
+        logger.info("Shutting down.")
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -10,25 +10,19 @@ import uvloop
 import vllm
 import vllm.envs as envs
 from vllm.entrypoints.cli.types import CLISubcommand
-from vllm.entrypoints.openai.api_server import run_server, setup_server
-from vllm.entrypoints.openai.cli_args import make_arg_parser, validate_parsed_serve_args
-from vllm.entrypoints.openai.dp_supervisor import (
-    run_dp_supervisor,
-)
 from vllm.entrypoints.serve.utils.api_utils import VLLM_SUBCMD_PARSER_EPILOG
 from vllm.logger import init_logger
 from vllm.usage.usage_lib import UsageContext
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 from vllm.utils.network_utils import get_tcp_uri
-from vllm.v1.engine.utils import CoreEngineProcManager, launch_core_engines
+from vllm.v1.engine.utils import CoreEngineProcManager
 from vllm.v1.executor import Executor
 from vllm.v1.executor.multiproc_executor import MultiprocExecutor
-from vllm.v1.metrics.prometheus import setup_multiprocess_prometheus
-from vllm.v1.utils import (
-    APIServerProcessManager,
-    RustFrontendProcessManager,
-    wait_for_completion_or_failure,
-)
+
+# NOTE: cli_args/api_server/dp_supervisor/v1.utils/v1.metrics.prometheus
+# imports live inside the functions that use them, not here, so
+# `run_headless` (used by `vllm.entrypoints.cli.headless_engine`) can be
+# imported without pulling in the OpenAI-server-only machinery it never uses.
 
 logger = init_logger(__name__)
 
@@ -141,6 +135,8 @@ class ServeSubcommand(CLISubcommand):
             args.api_server_count = 1
 
         if is_multi_port:
+            from vllm.entrypoints.openai.dp_supervisor import run_dp_supervisor
+
             run_dp_supervisor(args)
         elif args.api_server_count < 1:
             run_headless(args)
@@ -148,15 +144,21 @@ class ServeSubcommand(CLISubcommand):
             run_multi_api_server(args)
         else:
             # Single API server (this process).
+            from vllm.entrypoints.openai.api_server import run_server
+
             args.api_server_count = None
             uvloop.run(run_server(args))
 
     def validate(self, args: argparse.Namespace) -> None:
+        from vllm.entrypoints.openai.cli_args import validate_parsed_serve_args
+
         validate_parsed_serve_args(args)
 
     def subparser_init(
         self, subparsers: argparse._SubParsersAction
     ) -> FlexibleArgumentParser:
+        from vllm.entrypoints.openai.cli_args import make_arg_parser
+
         serve_parser = subparsers.add_parser(
             self.name,
             help="Launch a local OpenAI-compatible API server to serve LLM "
@@ -259,6 +261,14 @@ def run_headless(args: argparse.Namespace):
 
 
 def run_multi_api_server(args: argparse.Namespace):
+    from vllm.entrypoints.openai.api_server import setup_server
+    from vllm.v1.metrics.prometheus import setup_multiprocess_prometheus
+    from vllm.v1.utils import (
+        APIServerProcessManager,
+        RustFrontendProcessManager,
+        wait_for_completion_or_failure,
+    )
+
     assert not args.headless
     rust_frontend_path = (
         envs.VLLM_RUST_FRONTEND_PATH if envs.VLLM_USE_RUST_FRONTEND else None
@@ -312,7 +322,7 @@ def run_multi_api_server(args: argparse.Namespace):
         None
     )
 
-    from vllm.v1.engine.utils import get_engine_zmq_addresses
+    from vllm.v1.engine.utils import get_engine_zmq_addresses, launch_core_engines
 
     # Defer port allocation to the child's bind() to avoid TOCTOU, except
     # for Rust front-end and Ray DP, which can't see the post-bind rebind

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -9,24 +9,19 @@ import uvloop
 
 import vllm
 import vllm.envs as envs
+from vllm.entrypoints.cli.headless_engine import run_headless
 from vllm.entrypoints.cli.types import CLISubcommand
-from vllm.entrypoints.launchers.api_server.entry import run_server, setup_server
-from vllm.entrypoints.openai.cli_args import make_arg_parser, validate_parsed_serve_args
-from vllm.entrypoints.openai.dp_supervisor import run_dp_supervisor
 from vllm.entrypoints.serve.utils.api_utils import VLLM_SUBCMD_PARSER_EPILOG
 from vllm.logger import init_logger
 from vllm.usage.usage_lib import UsageContext
 from vllm.utils.argparse_utils import FlexibleArgumentParser
-from vllm.utils.network_utils import get_tcp_uri
-from vllm.v1.engine.utils import CoreEngineProcManager, launch_core_engines
 from vllm.v1.executor import Executor
-from vllm.v1.executor.multiproc_executor import MultiprocExecutor
-from vllm.v1.metrics.prometheus import setup_multiprocess_prometheus
-from vllm.v1.utils import (
-    APIServerProcessManager,
-    RustFrontendProcessManager,
-    wait_for_completion_or_failure,
-)
+
+# NOTE: cli_args/api_server/dp_supervisor/v1.utils/v1.metrics.prometheus
+# imports live inside the functions that use them, not here, so
+# `run_headless` (defined in `vllm.entrypoints.cli.headless_engine`, and
+# re-exported here for `vllm serve --headless`) can be imported without
+# pulling in the OpenAI-server-only machinery it never uses.
 
 logger = init_logger(__name__)
 
@@ -139,6 +134,8 @@ class ServeSubcommand(CLISubcommand):
             args.api_server_count = 1
 
         if is_multi_port:
+            from vllm.entrypoints.openai.dp_supervisor import run_dp_supervisor
+
             run_dp_supervisor(args)
         elif args.api_server_count < 1:
             run_headless(args)
@@ -146,15 +143,21 @@ class ServeSubcommand(CLISubcommand):
             run_multi_api_server(args)
         else:
             # Single API server (this process).
+            from vllm.entrypoints.launchers.api_server.entry import run_server
+
             args.api_server_count = None
             uvloop.run(run_server(args))
 
     def validate(self, args: argparse.Namespace) -> None:
+        from vllm.entrypoints.openai.cli_args import validate_parsed_serve_args
+
         validate_parsed_serve_args(args)
 
     def subparser_init(
         self, subparsers: argparse._SubParsersAction
     ) -> FlexibleArgumentParser:
+        from vllm.entrypoints.openai.cli_args import make_arg_parser
+
         serve_parser = subparsers.add_parser(
             self.name,
             help="Launch a local OpenAI-compatible API server to serve LLM "
@@ -172,91 +175,15 @@ def cmd_init() -> list[CLISubcommand]:
     return [ServeSubcommand()]
 
 
-def run_headless(args: argparse.Namespace):
-    if args.api_server_count > 1:
-        raise ValueError("api_server_count can't be set in headless mode")
-
-    # Create the EngineConfig.
-    engine_args = vllm.AsyncEngineArgs.from_cli_args(args)
-    usage_context = UsageContext.OPENAI_API_SERVER
-    vllm_config = engine_args.create_engine_config(
-        usage_context=usage_context, headless=True
-    )
-
-    if engine_args.data_parallel_hybrid_lb:
-        raise ValueError("data_parallel_hybrid_lb is not applicable in headless mode")
-
-    parallel_config = vllm_config.parallel_config
-    local_engine_count = parallel_config.data_parallel_size_local
-
-    if local_engine_count <= 0:
-        raise ValueError("data_parallel_size_local must be > 0 in headless mode")
-
-    shutdown_requested = False
-
-    # Catch SIGTERM and SIGINT to allow graceful shutdown.
-    def signal_handler(signum, frame):
-        nonlocal shutdown_requested
-        logger.debug("Received %d signal.", signum)
-        if not shutdown_requested:
-            shutdown_requested = True
-            raise SystemExit
-
-    signal.signal(signal.SIGTERM, signal_handler)
-    signal.signal(signal.SIGINT, signal_handler)
-
-    if parallel_config.node_rank_within_dp > 0:
-        from vllm.version import __version__ as VLLM_VERSION
-
-        # Run headless workers (for multi-node PP/TP).
-        host = parallel_config.master_addr
-        head_node_address = f"{host}:{parallel_config.master_port}"
-        logger.info(
-            "Launching vLLM (v%s) headless multiproc executor, "
-            "with head node address %s for torch.distributed process group.",
-            VLLM_VERSION,
-            head_node_address,
-        )
-
-        executor = MultiprocExecutor(vllm_config, monitor_workers=False)
-        executor.start_worker_monitor(inline=True)
-        return
-
-    host = parallel_config.data_parallel_master_ip
-    port = parallel_config.data_parallel_rpc_port
-    handshake_address = get_tcp_uri(host, port)
-
-    logger.info(
-        "Launching %d data parallel engine(s) in headless mode, "
-        "with head node address %s.",
-        local_engine_count,
-        handshake_address,
-    )
-
-    # Create the engines.
-    engine_manager = CoreEngineProcManager(
-        local_engine_count=local_engine_count,
-        start_index=vllm_config.parallel_config.data_parallel_rank,
-        local_start_index=0,
-        vllm_config=vllm_config,
-        local_client=False,
-        handshake_address=handshake_address,
-        executor_class=Executor.get_class(vllm_config),
-        log_stats=not engine_args.disable_log_stats,
-    )
-
-    try:
-        engine_manager.monitor_engine_liveness()
-    finally:
-        timeout = None
-        if shutdown_requested:
-            timeout = vllm_config.shutdown_timeout
-            logger.info("Waiting up to %d seconds for processes to exit", timeout)
-        engine_manager.shutdown(timeout=timeout)
-        logger.info("Shutting down.")
-
-
 def run_multi_api_server(args: argparse.Namespace):
+    from vllm.entrypoints.launchers.api_server.entry import setup_server
+    from vllm.v1.metrics.prometheus import setup_multiprocess_prometheus
+    from vllm.v1.utils import (
+        APIServerProcessManager,
+        RustFrontendProcessManager,
+        wait_for_completion_or_failure,
+    )
+
     assert not args.headless
     rust_frontend_path = (
         envs.VLLM_RUST_FRONTEND_PATH if envs.VLLM_USE_RUST_FRONTEND else None
@@ -310,7 +237,7 @@ def run_multi_api_server(args: argparse.Namespace):
         None
     )
 
-    from vllm.v1.engine.utils import get_engine_zmq_addresses
+    from vllm.v1.engine.utils import get_engine_zmq_addresses, launch_core_engines
 
     # Defer port allocation to the child's bind() to avoid TOCTOU, except
     # for Rust front-end and Ray DP, which can't see the post-bind rebind


### PR DESCRIPTION
## What

`vllm-rs serve`'s managed-engine mode spawns Python via `vllm serve
--headless`, which builds the full OpenAI-server CLI schema (tool/reasoning
parsers, MCP, chat templates, ...) and imports every CLI subcommand module
(`benchmark`, `launch`, `run_batch`, ...), even though the headless engine
process only ever reads `EngineArgs`/`AsyncEngineArgs` fields.

Adds `vllm/entrypoints/cli/headless_engine.py`: a lean entrypoint that
parses only `AsyncEngineArgs` and calls the existing `run_headless()`. Moves
the OpenAI-server-only imports in `serve.py` into the functions that use
them, so `run_headless` can be imported without pulling them in --
`vllm serve` itself is unaffected (same imports, just deferred to first
use). `ManagedEngineConfig::to_command()` now spawns the new entrypoint
instead of `vllm serve --headless`.

## Why this is safe

- Purely additive; only the one Rust spawn site changed.
- `vllm serve` / `vllm serve --headless` (direct use, or via
  `tests/utils.py::RemoteOpenAIServer`) are unaffected.
- Uses `FlexibleArgumentParser.parse_args` (strict, with full
  preprocessing), so behavior matches `vllm serve` exactly and unknown args
  still error -- see review discussion below.

## Not a duplicate

Checked for related open work; closest is #40064 (prototype to overlap
unavoidable imports with parent init), a different mechanism from
eliminating imports that are never needed.

## Testing

- `cargo test -p vllm-managed-engine` -- 2 tests, incl. updated snapshot
- `pytest tests/entrypoints/unit_tests/test_headless_engine_cli.py` -- 5
  tests (parsed args reach `run_headless` correctly typed, `api_server_count`
  forced to 0, unknown/misspelled args raise `SystemExit`, underscore-form
  flags normalize correctly, defaults match `AsyncEngineArgs()`)
- `pytest tests/entrypoints/openai/test_cli_args.py
  tests/entrypoints/unit_tests/test_launch_cli.py` -- 40 existing, unaffected
- `pre-commit run` on touched files -- clean
- **Real end-to-end GPU measurement**: built before/after `vllm-rs`
  binaries, ran `vllm-rs serve Qwen/Qwen3-0.6B --data-parallel-size-local 1`
  through both, measured wall-clock to the Rust frontend's `/health` with a
  local benchmarking tool (interleaved runs; not included in this PR):
  - `--enforce-eager`: 8 runs each, **24.47s -> 18.99s median (-22.4%)**
  - full compile + cudagraph (warm cache): 2 runs each, **26.74s -> 22.18s
    (-17.1%)**

  Root-caused via `python -X importtime`: importing
  `vllm.entrypoints.cli.main`'s full `CMD_MODULES` list costs ~2s by itself
  (`benchmark.main`/`launch`/`run_batch` are ~1.6-1.9s each), plus the
  OpenAI-server CLI schema's own tool/reasoning-parser/MCP imports.

No model output/accuracy is affected (startup-path only).

## AI assistance disclosure

Developed with AI assistance (OpenCode/Claude Sonnet), including the real
GPU measurements above. I reviewed every changed line and ran all
test/measurement commands myself.
