### PR TITLE
[Bugfix][Frontend][Kimi K3]  Let /v1/responses disable spaces_between_special_tokens

### DIFF
--- a/tests/reasoning/test_kimi_k3_reasoning_parser.py
+++ b/tests/reasoning/test_kimi_k3_reasoning_parser.py
@@ -7,6 +7,7 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
 )
 from vllm.entrypoints.openai.engine.protocol import DeltaMessage
+from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.parser.kimi_k3 import KimiK3Parser
 from vllm.parser.parser_manager import ParserManager
 from vllm.reasoning.kimi_k3_reasoning_parser import KimiK3ReasoningParser
@@ -239,15 +240,35 @@ def test_delegating_parser_thinking_false_streams_response_content():
     assert closed is None
 
 
-def test_adjust_request_keeps_xtml_markers_contiguous():
-    parser = KimiK3ReasoningParser(DummyTokenizer())
-    request = ChatCompletionRequest(model="test-model", messages=[])
+@pytest.mark.parametrize(
+    "request_factory",
+    [
+        pytest.param(
+            lambda: ChatCompletionRequest(model="test-model", messages=[]),
+            id="chat_completions",
+        ),
+        pytest.param(
+            lambda: ResponsesRequest(model="test-model", input="test"),
+            id="responses",
+        ),
+    ],
+)
+def test_adjust_request_keeps_xtml_markers_contiguous(request_factory):
+    """Both flags must be off on every API surface that serves this model.
 
-    adjusted = parser.adjust_request(request)
+    The detokenizer couples them -- effective spacing is
+    ``skip_special_tokens or spaces_between_special_tokens`` -- so leaving
+    either one True re-inserts spaces between the XTML control tokens and
+    the channel name, and the parser's contiguous-literal matching stops
+    matching. ``/v1/responses`` regressed exactly this way while this test
+    only covered Chat Completions.
+    """
+    parser = KimiK3ReasoningParser(DummyTokenizer())
+
+    adjusted = parser.adjust_request(request_factory())
 
     assert adjusted.skip_special_tokens is False
-    if hasattr(adjusted, "spaces_between_special_tokens"):
-        assert adjusted.spaces_between_special_tokens is False
+    assert adjusted.spaces_between_special_tokens is False
 
 
 OPEN_IDS = [1, 2, 3]

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -183,6 +183,7 @@ class ResponsesRequest(OpenAIBaseModel):
     truncation: Literal["auto", "disabled"] | None = "disabled"
     user: str | None = None
     skip_special_tokens: bool = True
+    spaces_between_special_tokens: bool = True
     include_stop_str_in_output: bool = False
     presence_penalty: float | None = Field(
         default=None,
@@ -452,6 +453,7 @@ class ResponsesRequest(OpenAIBaseModel):
             extra_args=extra_args,
             skip_clone=True,  # Created fresh per request, safe to skip clone
             skip_special_tokens=self.skip_special_tokens,
+            spaces_between_special_tokens=self.spaces_between_special_tokens,
             include_stop_str_in_output=self.include_stop_str_in_output,
         )
 


### PR DESCRIPTION
## Purpose

`ResponsesRequest` has no `spaces_between_special_tokens` field, so a parser that needs special tokens to arrive contiguously cannot turn the spacing off on the Responses route.

Kimi K3's `adjust_request` already tries to, in both its reasoning and tool parsers:

```python
request.skip_special_tokens = False
if hasattr(request, "spaces_between_special_tokens"):
    request.spaces_between_special_tokens = False
```

On `ChatCompletionRequest` that works. On `ResponsesRequest` the `hasattr` guard silently no-ops and the flag keeps its `SamplingParams` default of `True`.

The detokenizer couples the two flags (`vllm/v1/engine/detokenizer.py`):

```python
self.spaces_between_special_tokens = (
    sampling_params.skip_special_tokens
    or sampling_params.spaces_between_special_tokens
)
```

so forcing only `skip_special_tokens=False` changes nothing — each special token is emitted as its own sub-text and joined with spaces. Measured with the real K3 tokenizer through `detokenize_incrementally`:

```
spaces_between_special_tokens=False -> '<|close|>think'
spaces_between_special_tokens=True  -> '<|close|> think'
```

K3's parsers match the contiguous literals (`f"{CLOSE}think{SEP}"`), so the spaced form matches nothing. Two user-visible effects on `/v1/responses`, both absent from Chat Completions:

1. **Structural markers leak into assistant text.** `<|open|>`/`<|close|>`/`<|sep|>` appear in `output_text`.
2. **String tool-call arguments gain a leading and trailing space.** Exact-value consumers then reject otherwise valid calls — an enum member arrives as `" require_escalated "` and fails validation before the tool runs.

The second is why `recipes.vllm.ai/moonshotai/Kimi-K3` currently advises callers to "do schema validation and retry" for K3 tool calling. With this fix that workaround is unnecessary.

### The change

Declare the field and pass it through `to_sampling_params`. No parser changes — the existing `adjust_request` code works once the attribute exists.

### Why the existing test missed it

`test_adjust_request_keeps_xtml_markers_contiguous` asserts exactly this behaviour, but only ever constructed a `ChatCompletionRequest` — which has the field — so it passed while the Responses route regressed. The `hasattr` guard in the test was defensive code for a type the test never exercised. Parameterized over both request types.

## Test Plan

```bash
pytest tests/reasoning/test_kimi_k3_reasoning_parser.py \
       tests/tool_use/test_kimi_k3_tool_parser.py
```

Served end-to-end on two accelerators running the 2.8T MXFP4 checkpoint at TP8: 8x AMD MI355X and 8x NVIDIA B300. On each platform a second identical server was left unpatched as a control and given the same requests.

## Test Result

**Unit:** 68 passed across the two K3 suites. `ruff check` and `ruff format` clean.

The new parameterization is load-bearing: with the two protocol lines reverted, `test_adjust_request_keeps_xtml_markers_contiguous[responses]` fails while `[chat_completions]` still passes.

**Served,** identical prompt and tool, only the endpoint differing:

| | control | this branch |
|---|---|---|
| `/v1/chat/completions` tool args | `{"city": "Tokyo", "mode": "require_escalated"}` | unchanged |
| `/v1/responses` tool args | `{"city": " Tokyo ", "mode": " require_escalated "}` | `{"city": "Tokyo", "mode": "require_escalated"}` |
| `/v1/responses` streamed `output_text` | `'  hello world  '` | `'hello world'` |
| streamed `reasoning_text` | `' The user wants me to…'` | `'The user wants me to…'` |

Identical before and after: no markers in either channel, answer emitted once, reasoning parsed into its own channel, a literal `<\|test\|>` in content passes through untouched, and ordinary prose spacing intact (turning off inter-special-token spacing does not affect normal text).

Eight distinct tool-call prompts returned unpadded arguments on both platforms.

**Model evaluation:** not applicable. Only the detokenizer's treatment of whitespace adjacent to special tokens changes; sampling, the engine and the generated token sequence are untouched.

## Related

#50367 patched the streaming hold-back in the K3 parsers to tolerate the spaced form. That treated the symptom; this addresses the cause, and also fixes the tool-argument padding, which a parser-side hold-back cannot. I have closed #50367 as superseded by this PR.

#50229 migrates K3 to the parser engine and carries the same `hasattr` guard, so it needs this fix too — the two do not conflict.

## AI assistance disclosure

AI assistance (Claude Code) was used to investigate this defect, author the change and tests, and run the verification above.
