### PR TITLE
Revert "[R3] Unify routed expert shape configuration" (#50940)

### DIFF
--- a/tests/config/test_model_arch_config.py
+++ b/tests/config/test_model_arch_config.py
@@ -4,8 +4,6 @@
 
 import json
 from pathlib import Path
-from types import SimpleNamespace
-from typing import cast
 
 import pytest
 from transformers import PretrainedConfig
@@ -131,38 +129,6 @@ def test_head_size_falls_back_when_head_dim_is_zero():
     convertor = ModelArchConfigConvertorBase(hf_config, hf_config)
 
     assert convertor.get_head_size() == 128
-
-
-@pytest.mark.parametrize(
-    "attribute",
-    [
-        "num_experts_per_tok",
-        "num_experts_per_token",
-        "top_k_experts",
-        "moe_topk",
-        "moe_top_k",
-    ],
-)
-def test_num_experts_per_tok_aliases(attribute: str):
-    hf_config = PretrainedConfig(**{attribute: 4})
-    convertor = ModelArchConfigConvertorBase(hf_config, hf_config)
-    model_config = cast(
-        ModelConfig,
-        SimpleNamespace(
-            model_arch_config=SimpleNamespace(
-                num_experts_per_token=convertor.get_num_experts_per_token()
-            )
-        ),
-    )
-
-    assert ModelConfig.get_num_experts_per_tok(model_config) == 4
-
-
-def test_num_experts_per_tok_none_is_normalized():
-    hf_config = PretrainedConfig(top_k_experts=None)
-    convertor = ModelArchConfigConvertorBase(hf_config, hf_config)
-
-    assert convertor.get_num_experts_per_token() == 0
 
 
 def test_legacy_modelopt_config_without_producer_is_normalized():

--- a/tests/model_executor/test_routed_experts_capture.py
+++ b/tests/model_executor/test_routed_experts_capture.py
@@ -7,25 +7,16 @@ from unittest.mock import Mock, patch
 import pytest
 import torch
 
-from vllm.config import ModelConfig, VllmConfig
+from vllm.config import VllmConfig
 from vllm.config.compilation import CompilationMode
 from vllm.distributed.eplb.eplb_state import EplbLayerState
 from vllm.model_executor.layers.fused_moe.config import RoutingMethodType
 from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
     RoutedExpertsCapturer,
-    RoutedExpertsManager,
     bind_routed_experts_capturer,
     get_routed_experts_attn_gid,
 )
 from vllm.model_executor.layers.fused_moe.router.base_router import BaseRouter
-from vllm.transformers_utils.model_arch_config_convertor import (
-    ModelArchConfigConvertorBase,
-)
-from vllm.v1.kv_cache_interface import (
-    FullAttentionSpec,
-    KVCacheConfig,
-    KVCacheGroupSpec,
-)
 
 pytestmark = pytest.mark.cpu_test
 
@@ -83,72 +74,6 @@ def _make_modular_routed_experts():
     return types.SimpleNamespace(
         quant_method=types.SimpleNamespace(is_monolithic=False),
     )
-
-
-def _make_model_config(hf_config):
-    num_experts_per_token = ModelArchConfigConvertorBase(
-        hf_config, hf_config
-    ).get_num_experts_per_token()
-    model_config = SimpleNamespace(
-        hf_text_config=hf_config,
-        model_arch_config=SimpleNamespace(
-            num_experts_per_token=num_experts_per_token,
-        ),
-    )
-    model_config.get_num_experts = lambda: hf_config.num_experts
-    model_config.get_num_experts_per_tok = lambda: (
-        ModelConfig.get_num_experts_per_tok(model_config)
-    )
-    model_config.get_total_num_hidden_layers = lambda: hf_config.num_hidden_layers
-    return model_config
-
-
-def test_routed_experts_manager_uses_gemma4_top_k_experts():
-    hf_config = SimpleNamespace(
-        num_experts=8,
-        top_k_experts=2,
-        num_hidden_layers=3,
-    )
-    vllm_config = SimpleNamespace(model_config=_make_model_config(hf_config))
-    kv_cache_spec = FullAttentionSpec(
-        block_size=4,
-        num_kv_heads=1,
-        head_size=1,
-        dtype=torch.float32,
-    )
-    kv_cache_config = KVCacheConfig(
-        num_blocks=2,
-        kv_cache_tensors=[],
-        kv_cache_groups=[KVCacheGroupSpec(["layer"], kv_cache_spec)],
-    )
-
-    manager = RoutedExpertsManager(vllm_config, kv_cache_config)
-
-    assert manager.routed_experts_by_slot.shape == (8, 3, 2)
-
-
-def test_routed_experts_manager_uses_kimi_k3_experts_per_token():
-    hf_config = SimpleNamespace(
-        num_experts=8,
-        num_experts_per_token=2,
-        num_hidden_layers=3,
-    )
-    vllm_config = SimpleNamespace(model_config=_make_model_config(hf_config))
-    kv_cache_spec = FullAttentionSpec(
-        block_size=4,
-        num_kv_heads=1,
-        head_size=1,
-        dtype=torch.float32,
-    )
-    kv_cache_config = KVCacheConfig(
-        num_blocks=2,
-        kv_cache_tensors=[],
-        kv_cache_groups=[KVCacheGroupSpec(["layer"], kv_cache_spec)],
-    )
-
-    manager = RoutedExpertsManager(vllm_config, kv_cache_config)
-
-    assert manager.routed_experts_by_slot.shape == (8, 3, 2)
 
 
 def test_base_router_capture_pre_eplb_mapping():

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1436,9 +1436,6 @@ class ModelConfig:
     def get_num_experts(self) -> int:
         return self.model_arch_config.num_experts
 
-    def get_num_experts_per_tok(self) -> int:
-        return self.model_arch_config.num_experts_per_token
-
     def get_total_num_hidden_layers(self) -> int:
         return self.model_arch_config.total_num_hidden_layers
 

--- a/vllm/config/model_arch.py
+++ b/vllm/config/model_arch.py
@@ -47,9 +47,6 @@ class ModelArchitectureConfig:
     num_experts: int
     """Number of experts in the model."""
 
-    num_experts_per_token: int
-    """Number of routed experts selected per token."""
-
     quantization_config: dict[str, Any] | None
     """Quantization configuration dictionary containing quantization parameters."""
 

--- a/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py
@@ -20,18 +20,40 @@ from vllm.v1.outputs import RoutedExpertsTensors
 logger = logging.getLogger(__name__)
 
 
-def _get_routed_experts_shape(vllm_config: VllmConfig) -> tuple[int, int, int]:
-    model_config = vllm_config.model_config
-    num_layers = model_config.get_total_num_hidden_layers()
-    num_experts = model_config.get_num_experts()
-    num_experts_per_tok = model_config.get_num_experts_per_tok()
-    if num_layers <= 0 or num_experts <= 0 or num_experts_per_tok <= 0:
+def _get_num_experts_per_tok(hf_config) -> int:
+    """Resolve the per-token expert count from the HF config.
+
+    Different model families store this under different attribute names
+    (e.g. ``num_experts_per_tok`` for DeepSeek, ``top_k_experts`` for Gemma 4).
+    """
+    val = getattr(hf_config, "num_experts_per_tok", None)
+    if val is None:
+        val = getattr(hf_config, "top_k_experts", None)
+    if val is None:
         raise ValueError(
-            "Routed-experts capture requires positive layer, expert, and "
-            "experts-per-token counts, got "
-            f"{num_layers=}, {num_experts=}, {num_experts_per_tok=}."
+            "Cannot determine num_experts_per_tok: HF config has neither "
+            "'num_experts_per_tok' nor 'top_k_experts'"
         )
-    return num_layers, num_experts, num_experts_per_tok
+    return val
+
+
+def get_num_experts(hf_config) -> int:
+    """Resolve ``num_experts`` across HuggingFace config naming conventions.
+
+    Different MoE model families expose this under different keys:
+      - ``num_experts``: Mixtral, Qwen2-MoE, Qwen3-MoE
+      - ``n_routed_experts``: DeepSeek-V2/V3
+      - ``num_local_experts``: Mixtral (older exports)
+    """
+    for key in ("num_experts", "n_routed_experts", "num_local_experts"):
+        val = getattr(hf_config, key, None)
+        if val is not None:
+            return val
+    raise ValueError(
+        "Could not resolve num_experts from model config. "
+        "Expected one of 'num_experts', 'n_routed_experts', "
+        "or 'num_local_experts'."
+    )
 
 
 class RoutedExpertsCapturer:
@@ -67,7 +89,9 @@ class RoutedExpertsCapturer:
         vllm_config: VllmConfig,
         kv_cache_config: KVCacheConfig,
     ) -> None:
-        num_layers, _, num_experts_per_tok = _get_routed_experts_shape(vllm_config)
+        hf_config = vllm_config.model_config.hf_text_config
+        num_experts_per_tok = _get_num_experts_per_tok(hf_config)
+        num_layers = hf_config.num_hidden_layers
         logger.info(
             "RoutedExpertsCapturer: allocating buffer with "
             "max_tokens=%d, num_layers=%d, num_experts_per_tok=%d "
@@ -75,7 +99,7 @@ class RoutedExpertsCapturer:
             max_num_batched_tokens,
             num_layers,
             num_experts_per_tok,
-            vllm_config.model_config.hf_text_config.model_type,
+            getattr(hf_config, "model_type", "unknown"),
         )
         self.device_buffer = torch.zeros(
             (
@@ -320,9 +344,9 @@ class RoutedExpertsManager:
         # block IDs span [0, num_blocks) regardless of how many groups
         # exist. Sizing to the full pool avoids index-out-of-range
         # when different groups happen to land on the same block.
-        num_layers, num_experts, num_experts_per_tok = _get_routed_experts_shape(
-            vllm_config
-        )
+        hf_config = vllm_config.model_config.hf_text_config
+        num_experts = get_num_experts(hf_config)
+        num_experts_per_tok = _get_num_experts_per_tok(hf_config)
         max_num_slots = kv_cache_config.num_blocks * self.block_size
         # Expert IDs are 0..num_experts-1; uint8 fits 256 distinct
         # values so the boundary is ``<= 256`` (NOT ``< 256``). Keeping
@@ -332,7 +356,7 @@ class RoutedExpertsManager:
         self.routed_experts_by_slot = np.zeros(
             (
                 max_num_slots,
-                num_layers,
+                hf_config.num_hidden_layers,
                 num_experts_per_tok,
             ),
             dtype=expert_id_dtype,
@@ -342,8 +366,8 @@ class RoutedExpertsManager:
             "(slots=%d, layers=%d, top_k=%d, dtype=%s)",
             self.routed_experts_by_slot.nbytes / 1e9,
             max_num_slots,
-            num_layers,
-            num_experts_per_tok,
+            hf_config.num_hidden_layers,
+            hf_config.num_experts_per_tok,
             self.routed_experts_by_slot.dtype.name,
         )
 

--- a/vllm/transformers_utils/model_arch_config_convertor.py
+++ b/vllm/transformers_utils/model_arch_config_convertor.py
@@ -164,16 +164,6 @@ class ModelArchConfigConvertorBase:
             num_experts = self.get_num_experts_from_block_configs()
         return num_experts
 
-    def get_num_experts_per_token(self) -> int:
-        names = [
-            "num_experts_per_tok",
-            "num_experts_per_token",
-            "top_k_experts",
-            "moe_topk",
-            "moe_top_k",
-        ]
-        return getattr_iter(self.hf_text_config, names, 0) or 0
-
     @final
     @classmethod
     def get_torch_dtype(
@@ -389,7 +379,6 @@ class ModelArchConfigConvertorBase:
             vocab_size=self.get_vocab_size(),
             total_num_kv_heads=self.get_total_num_kv_heads(),
             num_experts=self.get_num_experts(),
-            num_experts_per_token=self.get_num_experts_per_token(),
             quantization_config=self.get_quantization_config(),
             is_deepseek_mla=self.is_deepseek_mla(),
             is_mm_prefix_lm=self.is_mm_prefix_lm(supports_multimodal),

--- a/vllm/v1/metrics/perf.py
+++ b/vllm/v1/metrics/perf.py
@@ -828,7 +828,9 @@ class BaseFfnConfigParser(Parser):
 
         # Try different naming conventions.
         args.num_experts = vllm_config.model_config.get_num_experts()
-        args.num_experts_per_tok = vllm_config.model_config.get_num_experts_per_tok()
+        args.num_experts_per_tok = getattr_from_list(
+            cfg, ["num_experts_per_tok", "moe_topk"], 0
+        )
         args.moe_intermediate_size = getattr_from_list(
             cfg, ["moe_intermediate_size", "intermediate_size"], 0
         )


### PR DESCRIPTION
Reverts https://github.com/vllm-project/vllm/pull/50940

### Why

Nightly CI build [#82455](https://buildkite.com/vllm/ci/builds/82455) (commit `50c5168`) newly failed `Basic Models Tests (Extra Initialization) 2`:

```
FAILED models/test_initialization.py::test_can_initialize_large_subset[HunYuanMoEV1ForCausalLM]
pydantic_core._pydantic_core.ValidationError: 1 validation error for ModelConfig
num_experts_per_token
  Input should be a valid integer [type=int_type, input_value=[8, 8, 8, ... 8, 8], input_type=list]
```

**Root cause:** #50940 added a required `num_experts_per_token: int` field to `ModelArchitectureConfig`, populated in `model_arch_config_convertor.py` via

```python
getattr_iter(self.hf_text_config, ["num_experts_per_tok", "num_experts_per_token", "top_k_experts", "moe_topk", "moe_top_k"], 0)
```

HunYuan MoE V1 configs specify `moe_topk` as a **per-layer list** (`[8, 8, ..., 8]`), so the converter returns a `list` and `ModelConfig` construction dies at pydantic validation.

This is not a test-only defect — `ModelArchitectureConfig` is built for every `ModelConfig`, so **any** HunYuan MoE V1 model (or any model whose `moe_topk`/`num_experts_per_tok` is expressed per layer) now fails at startup.

A forward fix is also viable (coerce list-valued configs to a scalar, or validate/normalize in `get_num_experts_per_token`). Reverting here to restore nightly green; happy to close this in favor of a targeted fix.

- Failures linked: 1 (`Basic Models Tests (Extra Initialization) 2`)
- Build: 82455
- No stacked dependents: #50940 is the only commit touching `model_arch_config_convertor.py` / `config/model_arch.py` in the range, and the revert applied cleanly with no conflicts (verified as an exact inverse of the original diff).

_Auto-generated by CI failure analyzer._
