### PR TITLE
[Benchmark] Add cached tokens to vllm bench serve

### DIFF
--- a/docs/benchmarking/cli.md
+++ b/docs/benchmarking/cli.md
@@ -115,6 +115,8 @@ P99 ITL (ms):                            8.39
     Start the server with `--enable-prompt-tokens-details` to additionally
     report `Total cached tokens:` (prompt tokens served from the prefix cache)
     in the summary and a `total_cached_tokens` field in the saved result JSON.
+    Pass `--report-cached-tokens` to `vllm bench serve` to get a warning when
+    the server does not report this data.
 
 #### Understanding the Latency Metrics
 

--- a/docs/benchmarking/cli.md
+++ b/docs/benchmarking/cli.md
@@ -111,6 +111,11 @@ P99 ITL (ms):                            8.39
 ==================================================
 ```
 
+!!! tip
+    Start the server with `--enable-prompt-tokens-details` to additionally
+    report `Total cached tokens:` (prompt tokens served from the prefix cache)
+    in the summary and a `total_cached_tokens` field in the saved result JSON.
+
 #### Understanding the Latency Metrics
 
 `vllm bench serve` measures latency at the benchmark client:

--- a/docs/benchmarking/cli.md
+++ b/docs/benchmarking/cli.md
@@ -120,6 +120,11 @@ P99 ITL (ms):                            8.39
     If cache reuse is not intended, vary `--seed`, reset or restart the server,
     or use `vllm bench sweep serve`, which resets server caches between runs.
 
+!!! tip
+    Start the server with `--enable-prompt-tokens-details` to additionally
+    report `Total cached tokens:` (prompt tokens served from the prefix cache)
+    in the summary and a `total_cached_tokens` field in the saved result JSON.
+
 #### Understanding the Latency Metrics
 
 `vllm bench serve` measures latency at the benchmark client:

--- a/docs/benchmarking/cli.md
+++ b/docs/benchmarking/cli.md
@@ -124,6 +124,8 @@ P99 ITL (ms):                            8.39
     Start the server with `--enable-prompt-tokens-details` to additionally
     report `Total cached tokens:` (prompt tokens served from the prefix cache)
     in the summary and a `total_cached_tokens` field in the saved result JSON.
+    Pass `--report-cached-tokens` to `vllm bench serve` to get a warning when
+    the server does not report this data.
 
 #### Understanding the Latency Metrics
 

--- a/tests/benchmarks/test_serve_cached_tokens.py
+++ b/tests/benchmarks/test_serve_cached_tokens.py
@@ -10,6 +10,7 @@ must be omitted entirely.
 import argparse
 import asyncio
 import json
+import warnings
 from pathlib import Path
 
 import aiohttp
@@ -122,9 +123,13 @@ async def test_request_func_cached_tokens_none_without_details():
 
 
 def _serve_args(
-    dataset_path: str, base_url: str, result_dir: str
+    dataset_path: str,
+    base_url: str,
+    result_dir: str,
+    report_cached_tokens: bool = False,
 ) -> argparse.Namespace:
     return argparse.Namespace(
+        report_cached_tokens=report_cached_tokens,
         # dataset
         dataset_name="custom",
         dataset_path=dataset_path,
@@ -195,30 +200,65 @@ def _serve_args(
     )
 
 
+def _write_prompts(tmp_path: Path) -> Path:
+    dataset_path = tmp_path / "prompts.jsonl"
+    dataset_path.write_text(
+        "\n".join(json.dumps({"prompt": f"hello {i}"}) for i in range(3)) + "\n"
+    )
+    return dataset_path
+
+
 @pytest.mark.benchmark
 @pytest.mark.asyncio
 async def test_total_cached_tokens_saved_in_result_json(tmp_path: Path) -> None:
     """End to end: cached tokens reported per request must be summed and
-    written to the result JSON as total_cached_tokens."""
+    written to the result JSON as total_cached_tokens, without warning when
+    --report-cached-tokens is set and the data is present."""
     usage = {
         "prompt_tokens": 4,
         "completion_tokens": 2,
         "prompt_tokens_details": {"cached_tokens": 3},
     }
     runner, port = await _fake_completions_server(usage)
-
-    dataset_path = tmp_path / "prompts.jsonl"
-    dataset_path.write_text(
-        "\n".join(json.dumps({"prompt": f"hello {i}"}) for i in range(3)) + "\n"
+    dataset_path = _write_prompts(tmp_path)
+    args = _serve_args(
+        str(dataset_path),
+        f"http://127.0.0.1:{port}",
+        str(tmp_path),
+        report_cached_tokens=True,
     )
-    args = _serve_args(str(dataset_path), f"http://127.0.0.1:{port}", str(tmp_path))
 
     try:
-        result = await asyncio.wait_for(serve_module.main_async(args), timeout=30)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = await asyncio.wait_for(serve_module.main_async(args), timeout=30)
     finally:
         await runner.cleanup()
 
     assert result["total_cached_tokens"] == 9
+    assert not [w for w in caught if "prompt-tokens-details" in str(w.message)]
 
     saved = json.loads((tmp_path / "cached_result.json").read_text())
     assert saved["total_cached_tokens"] == 9
+
+
+@pytest.mark.benchmark
+@pytest.mark.asyncio
+async def test_report_cached_tokens_warns_when_server_does_not_report(
+    tmp_path: Path,
+) -> None:
+    usage = {"prompt_tokens": 4, "completion_tokens": 2}
+    runner, port = await _fake_completions_server(usage)
+    dataset_path = _write_prompts(tmp_path)
+    args = _serve_args(
+        str(dataset_path),
+        f"http://127.0.0.1:{port}",
+        str(tmp_path),
+        report_cached_tokens=True,
+    )
+
+    try:
+        with pytest.warns(UserWarning, match="enable-prompt-tokens-details"):
+            await asyncio.wait_for(serve_module.main_async(args), timeout=30)
+    finally:
+        await runner.cleanup()

--- a/tests/benchmarks/test_serve_cached_tokens.py
+++ b/tests/benchmarks/test_serve_cached_tokens.py
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for cached-token metrics in `vllm bench serve`.
+
+The server only reports usage.prompt_tokens_details.cached_tokens when
+launched with --enable-prompt-tokens-details; without it the new metrics
+must be omitted entirely.
+"""
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+
+import aiohttp
+import pytest
+from aiohttp import web
+
+import vllm.benchmarks.serve as serve_module
+from vllm.benchmarks.lib.endpoint_request_func import (
+    RequestFuncInput,
+    RequestFuncOutput,
+    async_request_openai_completions,
+)
+from vllm.benchmarks.serve import calculate_metrics
+
+
+def _output(cached_tokens: int | None) -> RequestFuncOutput:
+    return RequestFuncOutput(
+        success=True,
+        generated_text="hello",
+        output_tokens=8,
+        prompt_len=16,
+        cached_tokens=cached_tokens,
+        latency=1.0,
+        ttft=0.1,
+        itl=[0.01] * 7,
+        start_time=0.0,
+    )
+
+
+def _calculate_metrics(outputs: list[RequestFuncOutput]):
+    return calculate_metrics(
+        input_requests=[],
+        outputs=outputs,
+        dur_s=10.0,
+        tokenizer=None,
+        selected_percentiles=[99.0],
+        goodput_config_dict={},
+    )
+
+
+def test_cached_token_metrics_reported():
+    metrics, _ = _calculate_metrics([_output(12), _output(4), _output(0)])
+    assert metrics.total_cached == 16
+
+
+def test_cached_token_metrics_omitted_when_server_does_not_report():
+    metrics, _ = _calculate_metrics([_output(None), _output(None)])
+    assert metrics.total_cached is None
+
+
+async def _fake_completions_server(usage: dict):
+    async def handler(request: web.Request) -> web.StreamResponse:
+        resp = web.StreamResponse(headers={"Content-Type": "text/event-stream"})
+        await resp.prepare(request)
+        chunk = json.dumps({"choices": [{"text": "ok"}]})
+        await resp.write(f"data: {chunk}\n\n".encode())
+        await resp.write(f"data: {json.dumps({'usage': usage})}\n\n".encode())
+        await resp.write(b"data: [DONE]\n\n")
+        return resp
+
+    app = web.Application()
+    app.router.add_post("/v1/completions", handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    return runner, runner.addresses[0][1]
+
+
+async def _request_once(port: int) -> RequestFuncOutput:
+    async with aiohttp.ClientSession() as session:
+        return await async_request_openai_completions(
+            RequestFuncInput(
+                prompt="hello",
+                api_url=f"http://127.0.0.1:{port}/v1/completions",
+                prompt_len=4,
+                output_len=8,
+                model="test-model",
+            ),
+            session,
+        )
+
+
+@pytest.mark.asyncio
+async def test_request_func_parses_cached_tokens():
+    usage = {
+        "prompt_tokens": 4,
+        "completion_tokens": 8,
+        "prompt_tokens_details": {"cached_tokens": 3},
+    }
+    runner, port = await _fake_completions_server(usage)
+    try:
+        output = await _request_once(port)
+    finally:
+        await runner.cleanup()
+    assert output.success
+    assert output.cached_tokens == 3
+
+
+@pytest.mark.asyncio
+async def test_request_func_cached_tokens_none_without_details():
+    usage = {"prompt_tokens": 4, "completion_tokens": 8}
+    runner, port = await _fake_completions_server(usage)
+    try:
+        output = await _request_once(port)
+    finally:
+        await runner.cleanup()
+    assert output.success
+    assert output.cached_tokens is None
+
+
+def _serve_args(
+    dataset_path: str, base_url: str, result_dir: str
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        # dataset
+        dataset_name="custom",
+        dataset_path=dataset_path,
+        disable_shuffle=True,
+        num_prompts=3,
+        custom_output_len=8,
+        skip_chat_template=True,
+        chat_template_kwargs=None,
+        no_oversample=False,
+        seed=0,
+        request_id_prefix="bench-",
+        # model / tokenizer
+        model="test-model",
+        served_model_name=None,
+        tokenizer=None,
+        tokenizer_mode="auto",
+        trust_remote_code=False,
+        skip_tokenizer_init=True,
+        # backend / endpoint
+        backend="openai",
+        base_url=base_url,
+        host=None,
+        port=None,
+        endpoint="/v1/completions",
+        header=None,
+        insecure=False,
+        # traffic
+        request_rate=float("inf"),
+        burstiness=1.0,
+        max_concurrency=None,
+        probe_request_rate=0.0,
+        # misc serve args read by main_async
+        plot_timeline=False,
+        plot_dataset_stats=False,
+        self_timed=None,
+        metadata=None,
+        label=None,
+        logprobs=None,
+        use_beam_search=False,
+        ignore_eos=False,
+        goodput=None,
+        percentile_metrics="ttft,tpot,itl,e2el",
+        metric_percentiles="99",
+        save_result=True,
+        append_result=False,
+        result_dir=result_dir,
+        result_filename="cached_result.json",
+        num_warmups=0,
+        profile=False,
+        disable_tqdm=True,
+        lora_modules=None,
+        lora_assignment="random",
+        ramp_up_strategy=None,
+        ramp_up_start_rps=None,
+        ramp_up_end_rps=None,
+        ready_check_timeout_sec=0,
+        extra_body=None,
+        top_p=None,
+        top_k=None,
+        min_p=None,
+        temperature=None,
+        frequency_penalty=None,
+        presence_penalty=None,
+        repetition_penalty=None,
+        save_detailed=False,
+        input_len=None,
+        output_len=None,
+    )
+
+
+@pytest.mark.benchmark
+@pytest.mark.asyncio
+async def test_total_cached_tokens_saved_in_result_json(tmp_path: Path) -> None:
+    """End to end: cached tokens reported per request must be summed and
+    written to the result JSON as total_cached_tokens."""
+    usage = {
+        "prompt_tokens": 4,
+        "completion_tokens": 2,
+        "prompt_tokens_details": {"cached_tokens": 3},
+    }
+    runner, port = await _fake_completions_server(usage)
+
+    dataset_path = tmp_path / "prompts.jsonl"
+    dataset_path.write_text(
+        "\n".join(json.dumps({"prompt": f"hello {i}"}) for i in range(3)) + "\n"
+    )
+    args = _serve_args(str(dataset_path), f"http://127.0.0.1:{port}", str(tmp_path))
+
+    try:
+        result = await asyncio.wait_for(serve_module.main_async(args), timeout=30)
+    finally:
+        await runner.cleanup()
+
+    assert result["total_cached_tokens"] == 9
+
+    saved = json.loads((tmp_path / "cached_result.json").read_text())
+    assert saved["total_cached_tokens"] == 9

--- a/tests/benchmarks/test_serve_cached_tokens.py
+++ b/tests/benchmarks/test_serve_cached_tokens.py
@@ -10,6 +10,7 @@ must be omitted entirely.
 import argparse
 import asyncio
 import json
+import warnings
 from pathlib import Path
 
 import aiohttp
@@ -122,9 +123,13 @@ async def test_request_func_cached_tokens_none_without_details():
 
 
 def _serve_args(
-    dataset_path: str, base_url: str, result_dir: str
+    dataset_path: str,
+    base_url: str,
+    result_dir: str,
+    report_cached_tokens: bool = False,
 ) -> argparse.Namespace:
     return argparse.Namespace(
+        report_cached_tokens=report_cached_tokens,
         # dataset
         dataset_name="custom",
         dataset_path=dataset_path,
@@ -195,30 +200,100 @@ def _serve_args(
     )
 
 
+def _write_prompts(tmp_path: Path) -> Path:
+    dataset_path = tmp_path / "prompts.jsonl"
+    dataset_path.write_text(
+        "\n".join(json.dumps({"prompt": f"hello {i}"}) for i in range(3)) + "\n"
+    )
+    return dataset_path
+
+
 @pytest.mark.benchmark
 @pytest.mark.asyncio
 async def test_total_cached_tokens_saved_in_result_json(tmp_path: Path) -> None:
     """End to end: cached tokens reported per request must be summed and
-    written to the result JSON as total_cached_tokens."""
+    written to the result JSON as total_cached_tokens, without warning when
+    --report-cached-tokens is set and the data is present."""
     usage = {
         "prompt_tokens": 4,
         "completion_tokens": 2,
         "prompt_tokens_details": {"cached_tokens": 3},
     }
     runner, port = await _fake_completions_server(usage)
-
-    dataset_path = tmp_path / "prompts.jsonl"
-    dataset_path.write_text(
-        "\n".join(json.dumps({"prompt": f"hello {i}"}) for i in range(3)) + "\n"
+    dataset_path = _write_prompts(tmp_path)
+    args = _serve_args(
+        str(dataset_path),
+        f"http://127.0.0.1:{port}",
+        str(tmp_path),
+        report_cached_tokens=True,
     )
-    args = _serve_args(str(dataset_path), f"http://127.0.0.1:{port}", str(tmp_path))
 
     try:
-        result = await asyncio.wait_for(serve_module.main_async(args), timeout=30)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = await asyncio.wait_for(serve_module.main_async(args), timeout=30)
     finally:
         await runner.cleanup()
 
     assert result["total_cached_tokens"] == 9
+    assert not [w for w in caught if "prompt-tokens-details" in str(w.message)]
 
     saved = json.loads((tmp_path / "cached_result.json").read_text())
     assert saved["total_cached_tokens"] == 9
+
+
+@pytest.mark.benchmark
+@pytest.mark.asyncio
+async def test_report_cached_tokens_warns_when_server_does_not_report(
+    tmp_path: Path,
+) -> None:
+    usage = {"prompt_tokens": 4, "completion_tokens": 2}
+    runner, port = await _fake_completions_server(usage)
+    dataset_path = _write_prompts(tmp_path)
+    args = _serve_args(
+        str(dataset_path),
+        f"http://127.0.0.1:{port}",
+        str(tmp_path),
+        report_cached_tokens=True,
+    )
+
+    try:
+        with pytest.warns(UserWarning, match="enable-prompt-tokens-details"):
+            await asyncio.wait_for(serve_module.main_async(args), timeout=30)
+    finally:
+        await runner.cleanup()
+
+
+@pytest.mark.benchmark
+@pytest.mark.asyncio
+async def test_report_cached_tokens_does_not_warn_when_all_requests_fail(
+    tmp_path: Path,
+) -> None:
+    """When no request succeeded, missing cached-token data is not the server
+    flag's fault, so the --enable-prompt-tokens-details hint must not fire."""
+    app = web.Application()
+    app.router.add_post(
+        "/v1/completions", lambda request: web.Response(status=500)
+    )
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port = runner.addresses[0][1]
+
+    dataset_path = _write_prompts(tmp_path)
+    args = _serve_args(
+        str(dataset_path),
+        f"http://127.0.0.1:{port}",
+        str(tmp_path),
+        report_cached_tokens=True,
+    )
+
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            await asyncio.wait_for(serve_module.main_async(args), timeout=30)
+    finally:
+        await runner.cleanup()
+
+    assert not [w for w in caught if "prompt-tokens-details" in str(w.message)]

--- a/vllm/benchmarks/lib/endpoint_request_func.py
+++ b/vllm/benchmarks/lib/endpoint_request_func.py
@@ -97,6 +97,7 @@ class RequestFuncOutput:
     itl: list[float] = field(default_factory=list)  # list of inter-token latencies
     tpot: float = 0.0  # avg next-token latencies
     prompt_len: int = 0
+    cached_tokens: int | None = None  # prompt tokens served from prefix cache
     error: str = ""
     start_time: float = 0.0
     input_audio_duration: float = 0.0  # in seconds
@@ -245,6 +246,8 @@ async def async_request_openai_completions(
                                 output.output_tokens = usage.get("completion_tokens")
                                 if (pt := usage.get("prompt_tokens")) is not None:
                                     output.prompt_len = pt
+                                if details := usage.get("prompt_tokens_details"):
+                                    output.cached_tokens = details.get("cached_tokens")
                 if first_chunk_received:
                     output.success = True
                 else:
@@ -416,6 +419,8 @@ async def async_request_openai_chat_completions(
                                 output.output_tokens = usage.get("completion_tokens")
                                 if (pt := usage.get("prompt_tokens")) is not None:
                                     output.prompt_len = pt
+                                if details := usage.get("prompt_tokens_details"):
+                                    output.cached_tokens = details.get("cached_tokens")
 
                             most_recent_timestamp = timestamp
 

--- a/vllm/benchmarks/lib/endpoint_request_func.py
+++ b/vllm/benchmarks/lib/endpoint_request_func.py
@@ -97,6 +97,7 @@ class RequestFuncOutput:
     itl: list[float] = field(default_factory=list)  # list of inter-token latencies
     tpot: float = 0.0  # avg next-token latencies
     prompt_len: int = 0
+    cached_tokens: int | None = None  # prompt tokens served from prefix cache
     error: str = ""
     start_time: float = 0.0
     input_audio_duration: float = 0.0  # in seconds
@@ -246,6 +247,8 @@ async def async_request_openai_completions(
                                 output.output_tokens = usage.get("completion_tokens")
                                 if (pt := usage.get("prompt_tokens")) is not None:
                                     output.prompt_len = pt
+                                if details := usage.get("prompt_tokens_details"):
+                                    output.cached_tokens = details.get("cached_tokens")
                 if first_chunk_received:
                     output.success = True
                 else:
@@ -417,6 +420,8 @@ async def async_request_openai_chat_completions(
                                 output.output_tokens = usage.get("completion_tokens")
                                 if (pt := usage.get("prompt_tokens")) is not None:
                                     output.prompt_len = pt
+                                if details := usage.get("prompt_tokens_details"):
+                                    output.cached_tokens = details.get("cached_tokens")
 
                             most_recent_timestamp = timestamp
 

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -350,6 +350,9 @@ class BenchmarkMetrics:
     max_output_tokens_per_s: float
     max_concurrent_requests: int
     rtfx: float = 0.0  # Inverse Real-Time Factor for ASR benchmarks
+    # Only set when the server reports usage.prompt_tokens_details.cached_tokens
+    # (requires --enable-prompt-tokens-details on the vLLM server).
+    total_cached: int | None = None
 
 
 @dataclass
@@ -576,6 +579,7 @@ def calculate_metrics(
     """
     actual_output_lens: list[int] = []
     total_input = 0
+    total_cached: int | None = None
     completed = 0
     good_completed = 0
     itls: list[float] = []
@@ -604,6 +608,8 @@ def calculate_metrics(
                     )
             actual_output_lens.append(output_len)
             total_input += outputs[i].prompt_len
+            if (cached := outputs[i].cached_tokens) is not None:
+                total_cached = (total_cached or 0) + cached
             tpot = 0.0
             if output_len > 1:
                 latency_minus_ttft = outputs[i].latency - outputs[i].ttft
@@ -760,6 +766,7 @@ def calculate_metrics(
         max_output_tokens_per_s=max_output_tokens_per_s,
         max_concurrent_requests=max_concurrent_requests,
         rtfx=input_audio_duration / dur_s,
+        total_cached=total_cached,
     )
 
     return metrics, actual_output_lens
@@ -1174,6 +1181,8 @@ async def benchmark(
         print("{:<40} {:<10.2f}".format("Request rate configured (RPS):", request_rate))
     print("{:<40} {:<10.2f}".format("Benchmark duration (s):", benchmark_duration))
     print("{:<40} {:<10}".format("Total input tokens:", metrics.total_input))
+    if isinstance(metrics, BenchmarkMetrics) and metrics.total_cached is not None:
+        print("{:<40} {:<10}".format("Total cached tokens:", metrics.total_cached))
     if isinstance(metrics, BenchmarkMetrics) and tokenizer:
         print("{:<40} {:<10}".format("Total generated tokens:", metrics.total_output))
     print(
@@ -1289,6 +1298,9 @@ async def benchmark(
             "input_lens": [output.prompt_len for output in outputs],
             "errors": [output.error for output in outputs],
         }
+
+    if isinstance(metrics, BenchmarkMetrics) and metrics.total_cached is not None:
+        result["total_cached_tokens"] = metrics.total_cached
 
     if probe_stats is not None:
         result.update(probe_stats)

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -1729,6 +1729,13 @@ def add_cli_args(parser: FlexibleArgumentParser):
         help="Append the benchmark result to the existing json file.",
     )
     parser.add_argument(
+        "--report-cached-tokens",
+        action="store_true",
+        help="Expect the server to report cached prompt tokens in "
+        "usage.prompt_tokens_details and warn if it does not. For vLLM "
+        "servers, this requires --enable-prompt-tokens-details.",
+    )
+    parser.add_argument(
         "--metadata",
         metavar="KEY=VALUE",
         nargs="*",
@@ -2214,6 +2221,16 @@ async def main_async(args: argparse.Namespace) -> dict[str, Any]:
         self_timed=args.self_timed,
         probe_request_rate=args.probe_request_rate,
     )
+
+    report_cached_tokens = getattr(args, "report_cached_tokens", False)
+    if report_cached_tokens and "total_cached_tokens" not in benchmark_result:
+        warnings.warn(
+            "--report-cached-tokens was set but the server did not report "
+            "cached token counts (usage.prompt_tokens_details.cached_tokens). "
+            "If benchmarking a vLLM server, start it with "
+            "--enable-prompt-tokens-details.",
+            stacklevel=2,
+        )
 
     # Save config and results to json
     result_json: dict[str, Any] = {}

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -1743,6 +1743,13 @@ def add_cli_args(parser: FlexibleArgumentParser):
         help="Append the benchmark result to the existing json file.",
     )
     parser.add_argument(
+        "--report-cached-tokens",
+        action="store_true",
+        help="Expect the server to report cached prompt tokens in "
+        "usage.prompt_tokens_details and warn if it does not. For vLLM "
+        "servers, this requires --enable-prompt-tokens-details.",
+    )
+    parser.add_argument(
         "--metadata",
         metavar="KEY=VALUE",
         nargs="*",
@@ -2233,6 +2240,20 @@ async def main_async(args: argparse.Namespace) -> dict[str, Any]:
         self_timed=args.self_timed,
         probe_request_rate=args.probe_request_rate,
     )
+
+    report_cached_tokens = getattr(args, "report_cached_tokens", False)
+    if (
+        report_cached_tokens
+        and benchmark_result.get("completed", 0) > 0
+        and "total_cached_tokens" not in benchmark_result
+    ):
+        warnings.warn(
+            "--report-cached-tokens was set but the server did not report "
+            "cached token counts (usage.prompt_tokens_details.cached_tokens). "
+            "If benchmarking a vLLM server, start it with "
+            "--enable-prompt-tokens-details.",
+            stacklevel=2,
+        )
 
     # Save config and results to json
     result_json: dict[str, Any] = {}

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -350,6 +350,9 @@ class BenchmarkMetrics:
     max_output_tokens_per_s: float
     max_concurrent_requests: int
     rtfx: float = 0.0  # Inverse Real-Time Factor for ASR benchmarks
+    # Only set when the server reports usage.prompt_tokens_details.cached_tokens
+    # (requires --enable-prompt-tokens-details on the vLLM server).
+    total_cached: int | None = None
 
 
 @dataclass
@@ -582,6 +585,7 @@ def calculate_metrics(
     """
     actual_output_lens: list[int] = []
     total_input = 0
+    total_cached: int | None = None
     completed = 0
     good_completed = 0
     itls: list[float] = []
@@ -610,6 +614,8 @@ def calculate_metrics(
                     )
             actual_output_lens.append(output_len)
             total_input += outputs[i].prompt_len
+            if (cached := outputs[i].cached_tokens) is not None:
+                total_cached = (total_cached or 0) + cached
             tpot = 0.0
             if output_len > 1:
                 latency_minus_ttft = outputs[i].latency - outputs[i].ttft
@@ -766,6 +772,7 @@ def calculate_metrics(
         max_output_tokens_per_s=max_output_tokens_per_s,
         max_concurrent_requests=max_concurrent_requests,
         rtfx=input_audio_duration / dur_s,
+        total_cached=total_cached,
     )
 
     return metrics, actual_output_lens
@@ -1180,6 +1187,8 @@ async def benchmark(
         print("{:<40} {:<10.2f}".format("Request rate configured (RPS):", request_rate))
     print("{:<40} {:<10.2f}".format("Benchmark duration (s):", benchmark_duration))
     print("{:<40} {:<10}".format("Total input tokens:", metrics.total_input))
+    if isinstance(metrics, BenchmarkMetrics) and metrics.total_cached is not None:
+        print("{:<40} {:<10}".format("Total cached tokens:", metrics.total_cached))
     if isinstance(metrics, BenchmarkMetrics) and tokenizer:
         print("{:<40} {:<10}".format("Total generated tokens:", metrics.total_output))
     print(
@@ -1303,6 +1312,9 @@ async def benchmark(
             "input_lens": [output.prompt_len for output in outputs],
             "errors": [output.error for output in outputs],
         }
+
+    if isinstance(metrics, BenchmarkMetrics) and metrics.total_cached is not None:
+        result["total_cached_tokens"] = metrics.total_cached
 
     if probe_stats is not None:
         result.update(probe_stats)


### PR DESCRIPTION
## Purpose

`vllm bench serve` reports total input and generated tokens, but gives no visibility into how many prompt tokens were served from the prefix cache.

This PR captures `usage.prompt_tokens_details.cached_tokens` from each response (reported by the server when launched with `--enable-prompt-tokens-details`).

This PR adds:
- `cached_tokens` field on `RequestFuncOutput`, populated by the completions and chat-completions functions.
- optional `total_cached` on `BenchmarkMetrics`, a `Total cached tokens:` line in the console summary (printed right after `Total input tokens:`), and a `total_cached_tokens` field in the saved result JSON.
-  `--report-cached-tokens` flag which is off by default. Indeed in case the server was launched without `--enable-prompt-tokens-details` the cached tokens are anyway not available. So it's fully backward compatible.
- a tip about the flag in the documentation.

Not a duplicate: open PR #46938 reports the prefix cache hit rate by snapshotting the server's Prometheus counters around the run. This PR is complementary; it does client-side, per-request accounting via the OpenAI-standard usage field, works against any OpenAI-compatible endpoint that reports `cached_tokens`, and adds the token total rather than a rate.

## Test Plan

New test file `tests/benchmarks/test_serve_cached_tokens.py` (6 tests):
- `calculate_metrics` sums cached tokens across successful requests.
- `async_request_openai_completions` against a local streaming server, with and without `prompt_tokens_details` in usage.
- `main_async()` against the mocked server; asserts `total_cached_tokens` in the returned result and in the saved JSON, and that `--report-cached-tokens` does not warn when the data is present.
- test the warning when `--report-cached-tokens` against a server that omits `prompt_tokens_details` emits a `UserWarning` mentioning `--enable-prompt-tokens-details`.

## Test Result
pytest: 6 passed