### PR TITLE
[Bugfix][Spec Decode] Bound draft max_model_len by the target before logging

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -28,6 +28,7 @@ from vllm.config import (
 from vllm.config.compilation import CompilationMode, CUDAGraphMode
 from vllm.config.kernel import IrOpPriorityConfig
 from vllm.config.load import LoadConfig
+from vllm.config.model import _get_and_verify_max_len
 from vllm.config.utils import get_field
 from vllm.config.vllm import (
     OPTIMIZATION_LEVEL_TO_CONFIG,
@@ -820,6 +821,40 @@ def test_get_and_verify_max_len(
     else:
         actual_max_len = model_config.get_and_verify_max_len(max_model_len)
         assert actual_max_len == expected_max_len
+
+
+@pytest.mark.parametrize(
+    ("draft_derived_len", "target_max_len", "expected_max_len"),
+    [
+        (262144, 131072, 131072),
+        (131072, 131072, 131072),
+        (4096, 131072, 4096),
+    ],
+)
+def test_get_and_verify_max_len_bounds_draft_by_target(
+    draft_derived_len, target_max_len, expected_max_len
+):
+    """A draft model resolves to at most the target model's length.
+
+    Drafts whose checkpoint declares a longer context than the target used to
+    resolve to their own length and only get corrected afterwards, which made
+    the reported length differ from the one actually used.
+    """
+    resolved = _get_and_verify_max_len(
+        hf_config=SimpleNamespace(),
+        model_arch_config=SimpleNamespace(
+            derived_max_model_len_and_key=(
+                draft_derived_len,
+                "max_position_embeddings",
+            )
+        ),
+        tokenizer_config=None,
+        max_model_len=None,
+        disable_sliding_window=False,
+        sliding_window=None,
+        spec_target_max_model_len=target_max_len,
+    )
+    assert resolved == expected_max_len
 
 
 class MockConfig:

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -2358,6 +2358,12 @@ def _get_and_verify_max_len(
             )
         else:
             max_model_len = int(derived_max_model_len)
+        if spec_target_max_model_len is not None:
+            # A speculative draft model never serves sequences longer than the
+            # target model, so bound it here rather than after the fact. This
+            # keeps the resolved (and logged) length equal to the one actually
+            # used by the drafter.
+            max_model_len = min(max_model_len, spec_target_max_model_len)
         max_model_len = current_platform.check_max_model_len(max_model_len)
 
     # If the user specified a max length, make sure it is smaller than the


### PR DESCRIPTION
Fixes #29945

## The bug

With MTP or any other in-checkpoint drafter, startup prints two different max
model lengths for the same run:

```
[model.py:554] Resolved architecture: Qwen3_5ForConditionalGeneration
[model.py:1684] Using max model len 131072
[model.py:554] Resolved architecture: Qwen3_5MTP
[model.py:1684] Using max model len 262144
```

Users read the second line as the drafter being sized for a longer context than
the target and reasonably conclude that KV cache is being over-allocated. The
issue has collected repeat reports on Qwen3-Next, Qwen3.5 and GLM-4.5-Air since
December, including cases where an explicit `--max-model-len 8192` still printed
`Using max model len 262144` for the draft.

@benchislett investigated twice and confirmed there is no over-allocation, since
`SpeculativeConfig._maybe_override_draft_max_model_len` clamps the draft to the
target immediately after the model config is built, and invited a PR to fix the
log.

## Root cause

`ModelConfig` for the draft is constructed with
`spec_target_max_model_len=target_model_config.max_model_len`, but
`_get_and_verify_max_len` only consults that argument inside the
`derived_max_model_len == inf` branch, which is the fallback for checkpoints
that declare no length key at all. Every real MTP or EAGLE checkpoint does
declare one, so the argument is dead in practice and the draft resolves to its
own declared length, logs it, and is only corrected one step later by the
clamp in `SpeculativeConfig`.

So the bound exists twice, in two different places, and the value that gets
logged is the one from before the bound is applied.

## The fix

Apply `spec_target_max_model_len` as an upper bound in `_get_and_verify_max_len`
whenever the length is being derived, so the draft resolves and logs the value
it will actually run with. The later clamp in `SpeculativeConfig` becomes a
no-op, which also stops its `Overriding draft model max model len` line from
firing on a config that was never wrong.

The bound is applied only when the caller did not pass an explicit length. An
explicit `speculative_config.max_model_len` keeps flowing through
`_maybe_override_draft_max_model_len` and its existing validation, so the
`speculative_max_model_len cannot be larger than target_max_model_len` error
and the `VLLM_ALLOW_LONG_MAX_MODEL_LEN` escape hatch behave exactly as before.

`spec_target_max_model_len` is set on exactly one `ModelConfig` in the tree, the
speculative draft one, so the blast radius is the drafter and nothing else.

## Not a duplicate

`gh pr list --repo vllm-project/vllm --state open --search "29945 in:body"` and
`--search "spec_target_max_model_len"` both return nothing, and the issue has no
PR cross-references. The open PRs matching "draft max model len" are unrelated:
#43049 caps per-request ngram drafts, #47272 reserves the KV null block during
`max_model_len` validation, #44954 fixes a DP drafter hang. None of them touch
how the draft `ModelConfig` resolves its length.

## Testing

Added `test_get_and_verify_max_len_bounds_draft_by_target` to
`tests/test_config.py`, next to the existing `test_get_and_verify_max_len`. It
drives `_get_and_verify_max_len` directly with a stub arch config, so it needs
no network and no accelerator, and covers draft longer than target, equal, and
draft shorter than target.

```
pytest tests/test_config.py -k get_and_verify_max_len -q
```

I do not have a GPU, so I verified the behavior change by extracting the real
`_get_and_verify_max_len` source from both `HEAD` and the patched tree, running
both against the exact length pairs from the issue reports, and feeding each
result through a mirror of `_maybe_override_draft_max_model_len`:

```
case                              logged before  logged after    final  override-log
Qwen3.5 MTP (SurealCereal)               262144        131072   131072  before=True after=False
Qwen3-Next MTP (reporter)                262144          8192     8192  before=True after=False
GLM-4.5-Air (ruokee)                     131072         64000    64000  before=True after=False
draft shorter than target                  4096          4096     4096  before=False after=False
equal lengths                            131072        131072   131072  before=False after=False

final resolved length unchanged in every case: True
```

The final draft `max_model_len` is identical before and after in every case, so
this does not change generation, accuracy, or serving behavior. It only moves
an existing bound earlier so the reported value stops disagreeing with the
value in use. On that basis I did not run model evals, and I am happy to add
them if a reviewer disagrees with that reading.

`ruff check` and `ruff format --check` pass on both changed files.

## AI assistance

This change was written with AI assistance (Claude). I reviewed every changed
line, traced the two-step bound through `vllm/config/model.py` and
`vllm/config/speculative.py` myself, and ran the verification above. I will
respond to review feedback.
