### PR TITLE
[Kernel] Enable CUTLASS MXFP4 W4A4 MoE on SM12x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -976,10 +976,16 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
     set(FP4_SM120_SRCS
       "csrc/libtorch_stable/quantization/fp4/nvfp4_quant_kernels.cu"
       "csrc/libtorch_stable/quantization/fp4/activation_nvfp4_quant_fusion_kernels.cu"
-      "csrc/libtorch_stable/quantization/fp4/nvfp4_experts_quant.cu"
+    "csrc/libtorch_stable/quantization/fp4/nvfp4_experts_quant.cu"
       "csrc/libtorch_stable/quantization/fp4/nvfp4_scaled_mm_sm120_kernels.cu"
       "csrc/libtorch_stable/quantization/fp4/nvfp4_blockwise_moe_kernel.cu"
+      "csrc/libtorch_stable/quantization/fp4/mxfp4_experts_quant.cu"
+   "csrc/libtorch_stable/quantization/fp4/mxfp4_blockwise_moe_kernel.cu"
       "csrc/libtorch_stable/nvfp4_kv_cache_kernels.cu")
+    if(NOT ${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.9)
+      message(STATUS
+        "Building mxfp4_experts_quant unsupported stubs for SM12x because CUDA compiler version is not >= 12.9 (found ${CMAKE_CUDA_COMPILER_VERSION}).")
+    endif()
     set_gencode_flags_for_srcs(
       SRCS "${FP4_SM120_SRCS}"
       CUDA_ARCHS "${FP4_SM120_ARCHS}")
@@ -991,8 +997,10 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
     message(STATUS "Not building SM12x NVFP4 as no compatible archs were found.")
   endif()
 
-  # SM10x/11x FP4 kernels. MXFP4 experts quantization is currently compiled
-  # only in this block; SM12x has separate NVFP4 matmul/MoE kernels above.
+  # SM10x/11x FP4 kernels. The MXFP4 experts-quant and grouped-GEMM sources
+  # are shared with the SM12x block above: CUTLASS resolves the same
+  # block-scaled scale-factor layout for arch::Sm100 and arch::Sm120, so a
+  # single SF swizzle serves both families.
   if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 13.0)
     cuda_archs_loose_intersection(FP4_SM100_ARCHS "10.0f;10.7f;11.0f" "${CUDA_ARCHS}")
   else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -976,11 +976,11 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
     set(FP4_SM120_SRCS
       "csrc/libtorch_stable/quantization/fp4/nvfp4_quant_kernels.cu"
       "csrc/libtorch_stable/quantization/fp4/activation_nvfp4_quant_fusion_kernels.cu"
-    "csrc/libtorch_stable/quantization/fp4/nvfp4_experts_quant.cu"
+      "csrc/libtorch_stable/quantization/fp4/nvfp4_experts_quant.cu"
       "csrc/libtorch_stable/quantization/fp4/nvfp4_scaled_mm_sm120_kernels.cu"
       "csrc/libtorch_stable/quantization/fp4/nvfp4_blockwise_moe_kernel.cu"
       "csrc/libtorch_stable/quantization/fp4/mxfp4_experts_quant.cu"
-   "csrc/libtorch_stable/quantization/fp4/mxfp4_blockwise_moe_kernel.cu"
+      "csrc/libtorch_stable/quantization/fp4/mxfp4_blockwise_moe_kernel.cu"
       "csrc/libtorch_stable/nvfp4_kv_cache_kernels.cu")
     if(NOT ${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.9)
       message(STATUS

--- a/csrc/libtorch_stable/quantization/fp4/mxfp4_blockwise_moe_kernel.cu
+++ b/csrc/libtorch_stable/quantization/fp4/mxfp4_blockwise_moe_kernel.cu
@@ -2,8 +2,9 @@
  * SPDX-License-Identifier: Apache-2.0
  * SPDX-FileCopyrightText: Copyright contributors to the vLLM project
  *
- * MXFP4 x MXFP4 block-scaled grouped GEMM kernel for MoE on SM100.
- * Uses Cutlass mx_float4_t operands, E8M0 block scales, and 32-element groups.
+ * MXFP4 x MXFP4 block-scaled grouped GEMM kernel for MoE on SM10x/11x and
+ * SM12x. Uses Cutlass mx_float4_t operands, E8M0 block scales, and
+ * 32-element groups.
  */
 
 #include <torch/csrc/stable/library.h>
@@ -166,8 +167,41 @@ void mxfp4_run_get_group_gemm_starts(
   }
 }
 
-template <typename OutType>
-void run_mxfp4_blockwise_scaled_group_mm_sm100(
+// Architecture-specific kernel configuration.
+//
+// SM100 (datacenter Blackwell) has a dedicated 1-SM MXFP4 Ptr-Array schedule
+// and a 2-SM cluster capable block-scaled MMA. SM120 (GeForce/RTX PRO
+// Blackwell) has no TMEM and no 2-SM block-scaled cluster, so it relies on
+// the generic cooperative Ptr-Array block-scaled schedule that CUTLASS
+// auto-selects from a pointer-typed StrideA.
+template <typename Arch>
+struct Mxfp4GroupGemmArchConfig;
+
+#if defined ENABLE_NVFP4_SM100 && ENABLE_NVFP4_SM100
+template <>
+struct Mxfp4GroupGemmArchConfig<cutlass::arch::Sm100> {
+  using ClusterShape = Shape<_1, _1, _1>;
+  using MmaTileShape = Shape<_128, _128, _128>;
+  using EpilogueTile = Shape<_128, _64>;
+  using KernelSchedule =
+  cutlass::gemm::KernelPtrArrayTmaWarpSpecialized1SmMxf4Sm100;
+  using EpilogueSchedule = cutlass::epilogue::PtrArrayTmaWarpSpecialized1Sm;
+};
+#endif
+
+#if defined ENABLE_NVFP4_SM120 && ENABLE_NVFP4_SM120
+template <>
+struct Mxfp4GroupGemmArchConfig<cutlass::arch::Sm120> {
+  using ClusterShape = Shape<_1, _1, _1>;
+  using MmaTileShape = Shape<_128, _128, _128>;
+  using EpilogueTile = cutlass::epilogue::collective::EpilogueTileAuto;
+  using KernelSchedule = cutlass::gemm::collective::KernelScheduleAuto;
+  using EpilogueSchedule = cutlass::epilogue::collective::EpilogueScheduleAuto;
+};
+#endif
+
+template <typename Arch, typename OutType>
+void run_mxfp4_blockwise_scaled_group_mm_impl(
     torch::stable::Tensor& output, const torch::stable::Tensor& a,
     const torch::stable::Tensor& b, const torch::stable::Tensor& a_blockscale,
     const torch::stable::Tensor& b_blockscales,
@@ -198,35 +232,31 @@ void run_mxfp4_blockwise_scaled_group_mm_sm100(
   static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
 
   // Architecture definitions
-  using ArchTag = cutlass::arch::Sm100;
+  using ArchTag = Arch;
   using EpilogueOperatorClass = cutlass::arch::OpClassTensorOp;
   using MainloopOperatorClass = cutlass::arch::OpClassBlockScaledTensorOp;
   using StageCountType = cutlass::gemm::collective::StageCountAuto;
 
-  using ClusterShape = Shape<_1, _1, _1>;
-  struct MMA1SMConfig {
-    using MmaTileShape = Shape<_128, _128, _128>;
-    using KernelSchedule =
-        cutlass::gemm::KernelPtrArrayTmaWarpSpecialized1SmMxf4Sm100;
-    using EpilogueSchedule = cutlass::epilogue::PtrArrayTmaWarpSpecialized1Sm;
-  };
+  using ArchConfig = Mxfp4GroupGemmArchConfig<Arch>;
+  using ClusterShape = typename ArchConfig::ClusterShape;
+  using MmaTileShape = typename ArchConfig::MmaTileShape;
 
   using CollectiveEpilogue =
-      typename cutlass::epilogue::collective::CollectiveBuilder<
-          ArchTag, EpilogueOperatorClass, typename MMA1SMConfig::MmaTileShape,
-          ClusterShape, Shape<_128, _64>, ElementAccumulator,
+ typename cutlass::epilogue::collective::CollectiveBuilder<
+          ArchTag, EpilogueOperatorClass, MmaTileShape, ClusterShape,
+          typename ArchConfig::EpilogueTile, ElementAccumulator,
           ElementAccumulator, ElementC, LayoutC*, AlignmentC, ElementD,
           LayoutC*, AlignmentD,
-          typename MMA1SMConfig::EpilogueSchedule>::CollectiveOp;
+          typename ArchConfig::EpilogueSchedule>::CollectiveOp;
 
   using CollectiveMainloop =
-      typename cutlass::gemm::collective::CollectiveBuilder<
+   typename cutlass::gemm::collective::CollectiveBuilder<
           ArchTag, MainloopOperatorClass, ElementA, LayoutA*, AlignmentA,
-          ElementB, LayoutB*, AlignmentB, ElementAccumulator,
-          typename MMA1SMConfig::MmaTileShape, ClusterShape,
-          cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
-              sizeof(typename CollectiveEpilogue::SharedStorage))>,
-          typename MMA1SMConfig::KernelSchedule>::CollectiveOp;
+          ElementB, LayoutB*, AlignmentB, ElementAccumulator, MmaTileShape,
+          ClusterShape,
+  cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+          sizeof(typename CollectiveEpilogue::SharedStorage))>,
+          typename ArchConfig::KernelSchedule>::CollectiveOp;
 
   using GemmKernel =
       cutlass::gemm::kernel::GemmUniversal<ProblemShape, CollectiveMainloop,
@@ -379,19 +409,29 @@ void run_mxfp4_blockwise_scaled_group_mm(
   int32_t version_num = get_sm_version_num();
 #if defined ENABLE_NVFP4_SM100 && ENABLE_NVFP4_SM100
   if (version_num >= 100 && version_num < 120) {
-    run_mxfp4_blockwise_scaled_group_mm_sm100<OutType>(
+    run_mxfp4_blockwise_scaled_group_mm_impl<cutlass::arch::Sm100, OutType>(
         output, a, b, a_blockscale, b_blockscales, problem_sizes,
         expert_offsets, sf_offsets, M, N, K);
+  return;
+  }
+#endif
+#if defined ENABLE_NVFP4_SM120 && ENABLE_NVFP4_SM120
+  if (version_num >= 120 && version_num < 130) {
+    run_mxfp4_blockwise_scaled_group_mm_impl<cutlass::arch::Sm120, OutType>(
+output, a, b, a_blockscale, b_blockscales, problem_sizes,
+      expert_offsets, sf_offsets, M, N, K);
     return;
   }
 #endif
   STD_TORCH_CHECK_NOT_IMPLEMENTED(
       false,
       "No compiled cutlass_mxfp4_group_mm kernel for CUDA device capability: ",
-      version_num, ". Required capability: 100");
+      version_num, ". Required capability: 100-119 (SM10x/11x) or 120-129 "
+      "(SM12x).");
 }
 
-#if defined ENABLE_NVFP4_SM100 && ENABLE_NVFP4_SM100
+#if (defined ENABLE_NVFP4_SM100 && ENABLE_NVFP4_SM100) || \
+    (defined ENABLE_NVFP4_SM120 && ENABLE_NVFP4_SM120)
 constexpr auto MXFP4_FLOAT4_E2M1X2 = torch::headeronly::ScalarType::Byte;
 // E8M0 scale factors stored as uint8
 constexpr auto MXFP4_SF_DTYPE = torch::headeronly::ScalarType::Byte;
@@ -417,8 +457,9 @@ void cutlass_mxfp4_group_mm(torch::stable::Tensor& output,
                             const torch::stable::Tensor& problem_sizes,
                             const torch::stable::Tensor& expert_offsets,
                             const torch::stable::Tensor& sf_offsets) {
-#if defined ENABLE_NVFP4_SM100 && ENABLE_NVFP4_SM100
-  // Input validation
+#if (defined ENABLE_NVFP4_SM100 && ENABLE_NVFP4_SM100) || \
+    (defined ENABLE_NVFP4_SM120 && ENABLE_NVFP4_SM120)
+// Input validation
   CHECK_INPUT(a, MXFP4_FLOAT4_E2M1X2, "a");
   CHECK_INPUT(b, MXFP4_FLOAT4_E2M1X2, "b");
   // MXFP4 uses E8M0 scale factors (stored as uint8)
@@ -462,8 +503,9 @@ void cutlass_mxfp4_group_mm(torch::stable::Tensor& output,
 #else
   STD_TORCH_CHECK_NOT_IMPLEMENTED(
       false,
-      "No compiled cutlass_mxfp4_group_mm kernel; build vLLM with "
-      "SM100 block-scaled FP4 MoE (ENABLE_NVFP4_SM100) and CUDA 12.8+.");
+    "No compiled cutlass_mxfp4_group_mm kernel; build vLLM with "
+   "SM10x/11x (ENABLE_NVFP4_SM100) or SM12x (ENABLE_NVFP4_SM120) "
+      "block-scaled FP4 MoE and CUDA 12.8+.");
 #endif
 }
 

--- a/csrc/libtorch_stable/quantization/fp4/mxfp4_blockwise_moe_kernel.cu
+++ b/csrc/libtorch_stable/quantization/fp4/mxfp4_blockwise_moe_kernel.cu
@@ -184,7 +184,7 @@ struct Mxfp4GroupGemmArchConfig<cutlass::arch::Sm100> {
   using MmaTileShape = Shape<_128, _128, _128>;
   using EpilogueTile = Shape<_128, _64>;
   using KernelSchedule =
-  cutlass::gemm::KernelPtrArrayTmaWarpSpecialized1SmMxf4Sm100;
+      cutlass::gemm::KernelPtrArrayTmaWarpSpecialized1SmMxf4Sm100;
   using EpilogueSchedule = cutlass::epilogue::PtrArrayTmaWarpSpecialized1Sm;
 };
 #endif
@@ -242,7 +242,7 @@ void run_mxfp4_blockwise_scaled_group_mm_impl(
   using MmaTileShape = typename ArchConfig::MmaTileShape;
 
   using CollectiveEpilogue =
- typename cutlass::epilogue::collective::CollectiveBuilder<
+      typename cutlass::epilogue::collective::CollectiveBuilder<
           ArchTag, EpilogueOperatorClass, MmaTileShape, ClusterShape,
           typename ArchConfig::EpilogueTile, ElementAccumulator,
           ElementAccumulator, ElementC, LayoutC*, AlignmentC, ElementD,
@@ -250,12 +250,12 @@ void run_mxfp4_blockwise_scaled_group_mm_impl(
           typename ArchConfig::EpilogueSchedule>::CollectiveOp;
 
   using CollectiveMainloop =
-   typename cutlass::gemm::collective::CollectiveBuilder<
+      typename cutlass::gemm::collective::CollectiveBuilder<
           ArchTag, MainloopOperatorClass, ElementA, LayoutA*, AlignmentA,
           ElementB, LayoutB*, AlignmentB, ElementAccumulator, MmaTileShape,
           ClusterShape,
-  cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
-          sizeof(typename CollectiveEpilogue::SharedStorage))>,
+          cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+              sizeof(typename CollectiveEpilogue::SharedStorage))>,
           typename ArchConfig::KernelSchedule>::CollectiveOp;
 
   using GemmKernel =
@@ -412,21 +412,22 @@ void run_mxfp4_blockwise_scaled_group_mm(
     run_mxfp4_blockwise_scaled_group_mm_impl<cutlass::arch::Sm100, OutType>(
         output, a, b, a_blockscale, b_blockscales, problem_sizes,
         expert_offsets, sf_offsets, M, N, K);
-  return;
+    return;
   }
 #endif
 #if defined ENABLE_NVFP4_SM120 && ENABLE_NVFP4_SM120
   if (version_num >= 120 && version_num < 130) {
     run_mxfp4_blockwise_scaled_group_mm_impl<cutlass::arch::Sm120, OutType>(
-output, a, b, a_blockscale, b_blockscales, problem_sizes,
-      expert_offsets, sf_offsets, M, N, K);
+        output, a, b, a_blockscale, b_blockscales, problem_sizes,
+        expert_offsets, sf_offsets, M, N, K);
     return;
   }
 #endif
   STD_TORCH_CHECK_NOT_IMPLEMENTED(
       false,
       "No compiled cutlass_mxfp4_group_mm kernel for CUDA device capability: ",
-      version_num, ". Required capability: 100-119 (SM10x/11x) or 120-129 "
+      version_num,
+      ". Required capability: 100-119 (SM10x/11x) or 120-129 "
       "(SM12x).");
 }
 
@@ -459,7 +460,7 @@ void cutlass_mxfp4_group_mm(torch::stable::Tensor& output,
                             const torch::stable::Tensor& sf_offsets) {
 #if (defined ENABLE_NVFP4_SM100 && ENABLE_NVFP4_SM100) || \
     (defined ENABLE_NVFP4_SM120 && ENABLE_NVFP4_SM120)
-// Input validation
+  // Input validation
   CHECK_INPUT(a, MXFP4_FLOAT4_E2M1X2, "a");
   CHECK_INPUT(b, MXFP4_FLOAT4_E2M1X2, "b");
   // MXFP4 uses E8M0 scale factors (stored as uint8)
@@ -503,8 +504,8 @@ void cutlass_mxfp4_group_mm(torch::stable::Tensor& output,
 #else
   STD_TORCH_CHECK_NOT_IMPLEMENTED(
       false,
-    "No compiled cutlass_mxfp4_group_mm kernel; build vLLM with "
-   "SM10x/11x (ENABLE_NVFP4_SM100) or SM12x (ENABLE_NVFP4_SM120) "
+      "No compiled cutlass_mxfp4_group_mm kernel; build vLLM with "
+      "SM10x/11x (ENABLE_NVFP4_SM100) or SM12x (ENABLE_NVFP4_SM120) "
       "block-scaled FP4 MoE and CUDA 12.8+.");
 #endif
 }

--- a/csrc/libtorch_stable/quantization/fp4/mxfp4_experts_quant.cu
+++ b/csrc/libtorch_stable/quantization/fp4/mxfp4_experts_quant.cu
@@ -377,7 +377,11 @@ static void validate_mxfp4_experts_quant_inputs(
 
 static bool mxfp4_experts_quant_sm_supported(int64_t cuda_device_capability) {
 #if VLLM_MXFP4_EXPERTS_QUANT_SUPPORTED
-  return cuda_device_capability >= 100 && cuda_device_capability < 120;
+  // SM10x/11x and SM12x share this kernel: CUTLASS resolves the same
+  // Sm1xxBlkScaledConfig scale-factor layout for cutlass::arch::Sm100 and
+  // cutlass::arch::Sm120, so the swizzle emitted by
+  // cvt_quant_to_fp4_get_sf_out_offset() is valid for both families.
+  return cuda_device_capability >= 100 && cuda_device_capability < 130;
 #else
   return false;
 #endif
@@ -393,7 +397,7 @@ void mxfp4_experts_quant(
   int32_t sm = get_sm_version_num();
   STD_TORCH_CHECK(mxfp4_experts_quant_sm_supported(sm),
                   "No compiled MXFP4 experts quant kernel for SM ", sm,
-                  ". Recompile with SM10x/11x FP4 support and CUDA >= 12.9.");
+                  ". Recompile with SM10x/11x or SM12x FP4 support and CUDA >= 12.9.");
 
   auto m_topk = input.size(0);
   auto k = input.size(1);
@@ -431,7 +435,7 @@ void silu_and_mul_mxfp4_experts_quant(
   int32_t sm = get_sm_version_num();
   STD_TORCH_CHECK(mxfp4_experts_quant_sm_supported(sm),
                   "No compiled SiLU+Mul MXFP4 experts quant kernel for SM ", sm,
-                  ". Recompile with SM10x/11x FP4 support and CUDA >= 12.9.");
+                  ". Recompile with SM10x/11x or SM12x FP4 support and CUDA >= 12.9.");
 
   auto m_topk = input.size(0);
   auto k_times_2 = input.size(1);

--- a/csrc/libtorch_stable/quantization/fp4/mxfp4_experts_quant.cu
+++ b/csrc/libtorch_stable/quantization/fp4/mxfp4_experts_quant.cu
@@ -395,9 +395,10 @@ void mxfp4_experts_quant(
     int64_t n_experts) {
 #if VLLM_MXFP4_EXPERTS_QUANT_SUPPORTED
   int32_t sm = get_sm_version_num();
-  STD_TORCH_CHECK(mxfp4_experts_quant_sm_supported(sm),
-                  "No compiled MXFP4 experts quant kernel for SM ", sm,
-                  ". Recompile with SM10x/11x or SM12x FP4 support and CUDA >= 12.9.");
+  STD_TORCH_CHECK(
+      mxfp4_experts_quant_sm_supported(sm),
+      "No compiled MXFP4 experts quant kernel for SM ", sm,
+      ". Recompile with SM10x/11x or SM12x FP4 support and CUDA >= 12.9.");
 
   auto m_topk = input.size(0);
   auto k = input.size(1);
@@ -433,9 +434,10 @@ void silu_and_mul_mxfp4_experts_quant(
     int64_t n_experts) {
 #if VLLM_MXFP4_EXPERTS_QUANT_SUPPORTED
   int32_t sm = get_sm_version_num();
-  STD_TORCH_CHECK(mxfp4_experts_quant_sm_supported(sm),
-                  "No compiled SiLU+Mul MXFP4 experts quant kernel for SM ", sm,
-                  ". Recompile with SM10x/11x or SM12x FP4 support and CUDA >= 12.9.");
+  STD_TORCH_CHECK(
+      mxfp4_experts_quant_sm_supported(sm),
+      "No compiled SiLU+Mul MXFP4 experts quant kernel for SM ", sm,
+      ". Recompile with SM10x/11x or SM12x FP4 support and CUDA >= 12.9.");
 
   auto m_topk = input.size(0);
   auto k_times_2 = input.size(1);

--- a/tests/kernels/moe/test_mxfp4_moe.py
+++ b/tests/kernels/moe/test_mxfp4_moe.py
@@ -31,8 +31,7 @@ def calc_diff(x, y):
 
 
 def is_mxfp4_moe_supported() -> bool:
-    """Ask the build which devices carry compiled MXFP4 MoE kernels.
-    """
+    """Ask the build which devices carry compiled MXFP4 MoE kernels."""
     capability = current_platform.get_device_capability()
     return (
         current_platform.is_cuda()

--- a/tests/kernels/moe/test_mxfp4_moe.py
+++ b/tests/kernels/moe/test_mxfp4_moe.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-"""Tests for SM100 CUTLASS MXFP4 x MXFP4 grouped MoE kernels."""
+"""Tests for CUTLASS MXFP4 x MXFP4 grouped MoE kernels (SM10x/11x and SM12x)."""
 
 import random
 
@@ -30,9 +30,14 @@ def calc_diff(x, y):
     return 1 - sim
 
 
-def is_sm100_supported() -> bool:
-    return current_platform.is_cuda() and current_platform.is_device_capability_family(
-        100
+def is_mxfp4_moe_supported() -> bool:
+    """Ask the build which devices carry compiled MXFP4 MoE kernels.
+    """
+    capability = current_platform.get_device_capability()
+    return (
+        current_platform.is_cuda()
+        and capability is not None
+        and ops.mxfp4_experts_quant_supported(capability.to_int())
     )
 
 
@@ -61,8 +66,8 @@ def compute_ref_output(
 
 
 @pytest.mark.skipif(
-    not is_sm100_supported(),
-    reason="cutlass_mxfp4_group_mm requires CUDA SM100",
+    not is_mxfp4_moe_supported(),
+    reason="cutlass_mxfp4_group_mm requires a build with MXFP4 MoE kernels",
 )
 @pytest.mark.parametrize("num_experts", [8, 16, 32])
 @pytest.mark.parametrize("out_dtype", [torch.bfloat16])
@@ -201,8 +206,8 @@ def test_cutlass_mxfp4_grouped_mm(num_experts, out_dtype):
 
 
 @pytest.mark.skipif(
-    not is_sm100_supported(),
-    reason="mxfp4_experts_quant requires CUDA SM100",
+    not is_mxfp4_moe_supported(),
+    reason="mxfp4_experts_quant requires a build with MXFP4 MoE kernels",
 )
 def test_mxfp4_experts_quant_basic():
     """
@@ -289,8 +294,8 @@ def compute_reference_e8m0_scale(block_max: float) -> int:
 
 
 @pytest.mark.skipif(
-    not is_sm100_supported(),
-    reason="mxfp4_experts_quant requires CUDA SM100",
+    not is_mxfp4_moe_supported(),
+    reason="mxfp4_experts_quant requires a build with MXFP4 MoE kernels",
 )
 @pytest.mark.parametrize("k", [256, 7168])
 @pytest.mark.parametrize("m", [16, 64])
@@ -412,8 +417,8 @@ def test_mxfp4_experts_quant_e8m0_scale_correctness(m, k):
 
 
 @pytest.mark.skipif(
-    not is_sm100_supported(),
-    reason="mxfp4_experts_quant requires CUDA SM100",
+    not is_mxfp4_moe_supported(),
+    reason="mxfp4_experts_quant requires a build with MXFP4 MoE kernels",
 )
 def test_mxfp4_experts_quant_no_saturation():
     """


### PR DESCRIPTION
## Purpose

Enable CUTLASS MXFP4 W4A4 MoE on SM12x (GeForce / RTX PRO Blackwell). Previously, MXFP4 experts-quant and grouped-GEMM kernels were compiled and gated for SM10x/11x only, so MXFP4 W4A4 MoE silently fell back to Marlin W4A16 on consumer / prosumer Blackwell parts.

## Changes 
- **`mxfp4_blockwise_moe_kernel.cu`**: Add `Mxfp4GroupGemmArchConfig<Arch>` trait.
  SM10x/11x keeps its dedicated 1-SM MXFP4 schedule unchanged. SM12x uses
  `KernelScheduleAuto` / `EpilogueScheduleAuto` / `EpilogueTileAuto` —
  the CUTLASS SM120 builder auto-selects the cooperative Ptr-Array
  block-scaled schedule from the pointer-typed `StrideA` and picks an
  epilogue tile that fits the tighter SMEM budget.

- **`mxfp4_experts_quant.cu`**: Widen capability guard `>= 100 && < 120` →
  `>= 100 && < 130`. SM100/SM120 share the same block-scaled SF layout.

- **`CMakeLists.txt`**: Add both MXFP4 sources to `FP4_SM120_SRCS`.

- **`test_mxfp4_moe.py`**: Replace hardcoded `is_device_capability_family(100)`
  skip with runtime `mxfp4_experts_quant_supported()` query, same predicate
  `CutlassExpertsMxfp4` uses.

## Test Result
**Environment:** RTX PRO 5000 (SM120), CUDA 13.0, Qwen3-30B-A3B-Instruct-2507 MXFP4
```bash
# serve
vllm serve Qwen3-30B-A3B-Instruct-2507-MXFP4 \
    --tensor-parallel-size 1 \
    --max-num-seqs 256 \
    --attention-backend FLEX_ATTENTION \
    --linear-backend humming \
    --max-num-batched-tokens 65536 \
    --gpu-memory-utilization 0.85 \
    --max-model-len 4096 \
    --no-enable-prefix-caching

# client (prefill)
vllm bench serve --backend vllm --dataset-name random \
    --random-input-len 1024 \
    --random-output-len 1 \
    --num-prompts 256 \
    --base-url http://127.0.0.1:8000/ \
    --max-concurrency $BS --request-rate $BS

# client (decode)
vllm bench serve --backend vllm --dataset-name random \
    --random-input-len 1024 \
    --random-output-len 128 \
    --num-prompts 256 \
    --base-url http://127.0.0.1:8000/ \
    --max-concurrency $BS --request-rate $BS
```
### Throughput
#### Prefill
| Concurrency | TTFT_mean(ms) | | Speedup |
|----|---------------|------|---------|
|    | W4A16 | W4A4 | |
| 1 | 79.06 | 69.53 | **1.14x** |
| 2 | 82.60 | 72.45 | **1.14x** |
| 4 | 91.72 | 79.64 | **1.15x** |
| 8 | 133.43 | 108.31 | **1.23x** |
| 16 | 582.27 | 353.79 | **1.65x** |
| 32 | 1719.19 | 1598.68 | 1.08x |
| 64 | 3339.33 | 3124.35 | 1.07x |
#### E2E
| Concurrency |  | Req/s | Out tok/s | Total tok/s | TTFT (ms) | TPOT (ms) |
|------|------|-------|-----------|-------------|-----------|-----------|
| **1** | w4a4 | 0.61 | 78.54 | 706.88 | 69.21 | 12.28 |
| | origin | 0.68 | 87.66 | 788.97 | 82.59 | 10.84 |
| **2** | w4a4 | 0.75 | 96.38 | 867.43 | 51.40 | 20.50 |
| | origin | 0.83 | 105.78 | 952.03 | 44.47 | 18.69 |
| **4** | w4a4 | 0.91 | 116.23 | 1046.05 | 90.22 | 33.94 |
| | origin | 0.96 | 123.24 | 1109.20 | 82.83 | 32.02 |
| **6** | w4a4 | 0.98 | 125.28 | 1127.52 | 123.79 | 46.98 |
| | origin | 1.02 | 130.55 | 1174.96 | 116.50 | 45.10 |
| **16** | w4a4 | 1.13 | 145.22 | 1307.00 | 273.55 | 108.24 |
| | origin | 1.15 | 147.02 | 1323.19 | 270.33 | 106.91 |
| **32** | w4a4 | 2.17 | 277.67 | 2499.03 | 305.72 | 111.20 |
| | origin | 2.18 | 279.36 | 2514.21 | 305.81 | 110.47 |
| **64** | w4a4 | 3.94 | 504.60 | 4541.38 | 344.31 | 116.62 |
| | origin | 3.99 | 510.92 | 4598.29 | 340.71 | 115.03 |


### Accuracy
- tests/kernels/moe/test_mxfp4_moe.py

<img width="1500" height="384" alt="image" src="https://github.com/user-attachments/assets/ec8f06e5-f3a2-49b7-848e-2e764136473a" />

- python tests/evals/gsm8k/gsm8k_eval.py
  Running GSM8K evaluation: 1319 questions, 5-shot
  Evaluating: 100%|███████████████████████████████████████████████████████████████████████████████████| 1319/1319 [02:13<00:00,  9.88it/s]
  Results:
  Accuracy: 0.875
  Invalid responses: 0.000
  Total latency: 133.454 s
  Questions per second: 9.884
  Total output tokens: 200389
  Output tokens per second: 1501.558
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

