### PR TITLE
Enable Speculative Decoding for NVIDIA-Nemotron-Parse-2.0

### DIFF
--- a/docs/features/speculative_decoding/README.md
+++ b/docs/features/speculative_decoding/README.md
@@ -89,6 +89,16 @@ only apply to model-based methods such as `draft_model`, `mtp`, `eagle3`, and
  | `use_heterogeneous_vocab` | `boolean` | `false` | Allow draft and target models with different vocabularies. Builds a token-level intersection at initialisation and constrains draft logits to shared tokens only. Only compatible with `method=draft_model`. Probabilistic draft sampling (`draft_sample_method='probabilistic'`) is not yet supported when this option is enabled. |
 
 !!! note
+    Nemotron Parse ships a single dependent auxiliary prediction head rather than
+    a transformer draft model. It is also activated with `"method": "mtp"` and is
+    routed to a lightweight, draft-model-free speculator:
+
+    ```bash
+    vllm serve nvidia/NVIDIA-Nemotron-Parse-2.0 \
+        --speculative-config '{"method":"mtp","num_speculative_tokens":1}'
+    ```
+
+!!! note
     Gemma 4 assistant checkpoints are handled as Gemma 4 MTP speculators, not
     as generic draft models. Use `"method": "mtp"` with the assistant
     checkpoint in `model`, as shown in the [MTP guide](mtp.md#gemma-4-assistant-models).

--- a/docs/features/speculative_decoding/README.md
+++ b/docs/features/speculative_decoding/README.md
@@ -93,6 +93,16 @@ only apply to model-based methods such as `draft_model`, `mtp`, `eagle3`, and
 | `use_heterogeneous_vocab` | `boolean` | `false` | Allow draft and target models with different vocabularies. Builds a token-level intersection at initialisation and constrains draft logits to shared tokens only. Only compatible with `method=draft_model`. Probabilistic draft sampling (`draft_sample_method='probabilistic'`) is not yet supported when this option is enabled. |
 
 !!! note
+    Nemotron Parse ships a single dependent auxiliary prediction head rather than
+    a transformer draft model. It is also activated with `"method": "mtp"` and is
+    routed to a lightweight, draft-model-free speculator:
+
+    ```bash
+    vllm serve nvidia/NVIDIA-Nemotron-Parse-2.0 \
+        --speculative-config '{"method":"mtp","num_speculative_tokens":1}'
+    ```
+
+!!! note
     Gemma 4 assistant checkpoints are handled as Gemma 4 MTP speculators, not
     as generic draft models. Use `"method": "mtp"` with the assistant
     checkpoint in `model`, as shown in the [MTP guide](mtp.md#gemma-4-assistant-models).

--- a/tests/models/multimodal/generation/test_nemotron_parse.py
+++ b/tests/models/multimodal/generation/test_nemotron_parse.py
@@ -88,6 +88,10 @@ def run_test(
                 num_logprobs=num_logprobs,
                 images=images,
                 tokenization_kwargs={"add_special_tokens": False},
+                # The model's generation config forces EOS at max_new_tokens.
+                # vLLM stops at the limit without replacing the model-selected
+                # final token, so disable forced EOS for a like-for-like check.
+                forced_eos_token_id=None,
             )
             for prompts, images in inputs
         ]

--- a/tests/models/multimodal/generation/test_nemotron_parse.py
+++ b/tests/models/multimodal/generation/test_nemotron_parse.py
@@ -60,13 +60,17 @@ def run_test(
     max_tokens: int,
     num_logprobs: int,
 ) -> None:
-    """Verify that the inference result is the same between hf and vllm."""
+    """Verify that vLLM MTP preserves the HF target model's output."""
     with vllm_runner(
         model,
         dtype=dtype,
         max_num_seqs=64,
         limit_mm_per_prompt={"image": 1},
         trust_remote_code=True,
+        speculative_config={
+            "method": "mtp",
+            "num_speculative_tokens": 1,
+        },
     ) as vllm_model:
         vllm_outputs_per_case = [
             vllm_model.generate_greedy_logprobs(
@@ -109,7 +113,7 @@ def run_test(
         )
 
 
-@pytest.mark.parametrize("model", ["nvidia/NVIDIA-Nemotron-Parse-v1.2"])
+@pytest.mark.parametrize("model", ["nvidia/NVIDIA-Nemotron-Parse-2.0"])
 @pytest.mark.parametrize("dtype", ["bfloat16"])
 @pytest.mark.parametrize("num_logprobs", [5])
 def test_models(

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -705,7 +705,10 @@ class SpeculativeConfig:
             self.method = "mtp"
 
         if self.model is None and self.num_speculative_tokens is not None:
-            if self.method == "mtp":
+            if self.method == "mtp" and self.use_nemotron_parse_mtp():
+                # Draft-model-free MTP; the target model owns the head.
+                pass
+            elif self.method == "mtp":
                 if self.target_model_config is None:
                     raise ValueError("target_model_config must be present for mtp")
                 if self.target_model_config.hf_text_config.model_type == "deepseek_v32":
@@ -796,6 +799,12 @@ class SpeculativeConfig:
             self.prompt_lookup_min = 0
             self.draft_model_config = self.target_model_config
             self.draft_parallel_config = self.target_parallel_config
+        elif self.method == "mtp" and self.use_nemotron_parse_mtp():
+            # No draft model to resolve.
+            self.prompt_lookup_max = 0
+            self.prompt_lookup_min = 0
+            self.draft_model_config = None
+            self.draft_parallel_config = None
         elif self.method == "extract_hidden_states":
             from vllm.transformers_utils.configs.extract_hidden_states import (
                 ExtractHiddenStatesConfig,
@@ -1419,11 +1428,29 @@ class SpeculativeConfig:
             == "step3p5_mtp"
         )
 
+    def use_nemotron_parse_mtp(self) -> bool:
+        """Nemotron Parse MTP: a lightweight, draft-model-free ``mtp`` variant.
+
+        The target owns a single dependent auxiliary prediction head rather than
+        a transformer draft model.
+        """
+        if self.method != "mtp" or self.target_model_config is None:
+            return False
+        hf_config = self.target_model_config.hf_config
+        architectures = getattr(hf_config, "architectures", ()) or ()
+        return "NemotronParseForConditionalGeneration" in architectures
+
     def use_eagle(self) -> bool:
         # NOTE: This method is usually a stand-in for "speculative decoding using
         # target model hidden states"
         # TODO(ben): Refactor this so the naming is clearer
-        return self.method in ("eagle", "eagle3", "mtp", "dflash", "dspark")
+        # Nemotron Parse MTP is a lightweight, draft-model-free head that must not
+        # take the eagle/draft-KV scheduling path (no shifted computed tokens, no
+        # draft KV cache), so it is excluded here.
+        return (
+            self.method in ("eagle", "eagle3", "mtp", "dflash", "dspark")
+            and not self.use_nemotron_parse_mtp()
+        )
 
     def use_dflash(self) -> bool:
         return self.method == "dflash"
@@ -1462,6 +1489,7 @@ class SpeculativeConfig:
                 "extract_hidden_states",
                 "custom_class",
             )
+            or self.use_nemotron_parse_mtp()
             else self.draft_model_config.model
         )
         num_spec_tokens = self.num_speculative_tokens

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1109,7 +1109,10 @@ class SpeculativeConfig:
             self.method = "mtp"
 
         if self.model is None and self.num_speculative_tokens is not None:
-            if self.method == "mtp":
+            if self.use_nemotron_parse_mtp():
+                # Draft-model-free MTP; the target model owns the head.
+                pass
+            elif self.method == "mtp":
                 if self.target_model_config is None:
                     raise ValueError("target_model_config must be present for mtp")
                 # use the draft model from the same model:
@@ -1203,6 +1206,11 @@ class SpeculativeConfig:
             self.prompt_lookup_min = 0
             self.draft_model_config = self.target_model_config
             self.draft_parallel_config = self.target_parallel_config
+        elif self.use_nemotron_parse_mtp():
+            # No draft model to resolve; draft_model_config and
+            # draft_parallel_config keep their class-level None defaults.
+            self.prompt_lookup_max = 0
+            self.prompt_lookup_min = 0
         elif self.method == "extract_hidden_states":
             from vllm.transformers_utils.configs.extract_hidden_states import (
                 ExtractHiddenStatesConfig,
@@ -1855,11 +1863,28 @@ class SpeculativeConfig:
             == "step3p5_mtp"
         )
 
+    def use_nemotron_parse_mtp(self) -> bool:
+        """Nemotron Parse MTP: a lightweight, draft-model-free ``mtp`` variant.
+
+        The target owns a single dependent auxiliary prediction head rather than
+        a transformer draft model.
+        """
+        if self.method != "mtp" or self.target_model_config is None:
+            return False
+        hf_config = self.target_model_config.hf_config
+        architectures = getattr(hf_config, "architectures", ()) or ()
+        return "NemotronParseForConditionalGeneration" in architectures
+
     def use_eagle(self) -> bool:
         # NOTE: This method is usually a stand-in for "speculative decoding using
         # target model hidden states"
         # TODO(ben): Refactor this so the naming is clearer
-        return self.method in ("eagle", "eagle3", "mtp", "dflash", "dspark")
+        # Nemotron Parse MTP has its own scheduling path (no shifted computed
+        # tokens, no draft KV cache), so it is excluded here.
+        return (
+            self.method in ("eagle", "eagle3", "mtp", "dflash", "dspark")
+            and not self.use_nemotron_parse_mtp()
+        )
 
     def use_eagle_block_drop(self) -> bool:
         """Whether volatile trailing cache blocks should be discarded."""
@@ -1902,6 +1927,7 @@ class SpeculativeConfig:
                 "extract_hidden_states",
                 "custom_class",
             )
+            or self.use_nemotron_parse_mtp()
             else self.draft_model_config.model
         )
         num_spec_tokens = self.num_speculative_tokens

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -634,7 +634,11 @@ class VllmConfig:
             # decoding instead of standard next-token sampling, so it has a query
             # for the last sampled token plus queries for each draft token.
             return self.num_speculative_tokens + 1
-        if speculative_config.use_eagle() or speculative_config.uses_draft_model():
+        if (
+            speculative_config.use_eagle()
+            or speculative_config.uses_draft_model()
+            or speculative_config.use_nemotron_parse_mtp()
+        ):
             # DSpark (covered by use_eagle) drafts a block of num_speculative_tokens
             # query tokens in which the anchor itself is the first prediction
             # position (no separate bonus query), so it needs exactly

--- a/vllm/model_executor/models/nemotron_parse.py
+++ b/vllm/model_executor/models/nemotron_parse.py
@@ -490,6 +490,7 @@ class RadioWithNeck(nn.Module):
         self.sum_proj = ColumnParallelLinear(
             3840,
             last_hidden_state,
+            gather_output=True,
             quant_config=quant_config,
             prefix=f"{prefix}.sum_proj",
         )
@@ -549,8 +550,8 @@ class RadioWithNeck(nn.Module):
                 model_encoder_weights.append((".".join(name.split(".")[1:]), w))
             else:
                 param = adaptor_dict[name]
-                with torch.no_grad():
-                    default_weight_loader(param, w)
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, w)
 
         self.model_encoder.load_weights(model_encoder_weights)
 

--- a/vllm/model_executor/models/nemotron_parse.py
+++ b/vllm/model_executor/models/nemotron_parse.py
@@ -8,6 +8,7 @@
 # https://github.com/vllm-project/vllm/blob/v0.10.2/vllm/model_executor/models/bart.py
 
 import math
+import os
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Annotated, Literal
 
@@ -33,7 +34,12 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
 )
-from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.model_loader.weight_utils import (
+    default_weight_loader,
+    download_weights_from_hf,
+    maybe_download_from_modelscope,
+    safetensors_weights_iterator,
+)
 from vllm.model_executor.models.interfaces import (
     MultiModalEmbeddings,
     SupportsMultiModal,
@@ -59,6 +65,13 @@ from vllm.utils.tensor_schema import TensorSchema, TensorShape
 from vllm.v1.attention.backend import AttentionType
 
 logger = init_logger(__name__)
+
+_AUXILIARY_WEIGHTS_FILE = "auxiliary_prediction_heads.safetensors.extra"
+_AUXILIARY_DECODER_WEIGHT_NAMES = frozenset(
+    f"{module}.0.{parameter}"
+    for module in ("extra_proj", "extra_heads")
+    for parameter in ("weight", "bias")
+)
 
 
 class BartScaledWordEmbedding(VocabParallelEmbedding):
@@ -233,6 +246,7 @@ class MBartDecoderNoPos(nn.Module):
         quant_config: QuantizationConfig | None = None,
         lora_config: LoRAConfig | None = None,
         embed_tokens: nn.Embedding | None = None,
+        num_extra_heads: int = 0,
         prefix: str = "",
     ):
         super().__init__()
@@ -262,6 +276,16 @@ class MBartDecoderNoPos(nn.Module):
 
         self.layernorm_embedding = nn.LayerNorm(config.d_model)
         self.layer_norm = nn.LayerNorm(config.d_model)
+
+        self.num_extra_heads = num_extra_heads
+        self.extra_proj = nn.ModuleList(
+            nn.Linear(config.d_model, config.d_model, bias=True)
+            for _ in range(num_extra_heads)
+        )
+        self.extra_heads = nn.ModuleList(
+            nn.Linear(config.d_model, config.d_model, bias=True)
+            for _ in range(num_extra_heads)
+        )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
@@ -327,8 +351,13 @@ class MBartDecoderNoPos(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
+                # Skip weights with no destination parameter. In the baseline
+                # model (num_extra_heads=0) the auxiliary-head sidecar tensors
+                # (decoder.extra_proj/extra_heads.*) have no module to load into,
+                # so shipping the loadable sidecar in the public checkpoint must
+                # never break the baseline load path. (Also skips extra GPTQ
+                # bias.)
+                if name not in params_dict:
                     continue
 
                 param = params_dict[name]
@@ -576,21 +605,51 @@ class NemotronParseForConditionalGeneration(nn.Module, SupportsMultiModal):
                 config=config, quant_config=quant_config, prefix=f"{prefix}.encoder"
             )
 
+        speculative_config = vllm_config.speculative_config
+        self.num_extra_heads = int(
+            speculative_config is not None
+            and speculative_config.use_nemotron_parse_mtp()
+        )
+
         with self._mark_language_model(vllm_config):
             self.decoder = MBartDecoderNoPos(
                 config.decoder,
                 cache_config=cache_config,
                 quant_config=quant_config,
+                num_extra_heads=self.num_extra_heads,
                 prefix=f"{prefix}.decoder",
             )
+        # Single source of truth for the MTP embedding scale: read the value the
+        # decoder's scaled word embedding already stores (BartScaledWordEmbedding.
+        # embed_scale = sqrt(d_model) when scale_embedding, else 1.0) instead of
+        # re-deriving it from config. Read AFTER the decoder is constructed.
+        self.mtp_embed_scale = self.decoder.embed_tokens.embed_scale
 
         self.vocab_size = config.decoder.vocab_size
         self.lm_head = ParallelLMHead(
             config.decoder.vocab_size, config.decoder.d_model, quant_config=quant_config
         )
+        self.tie_word_embeddings = bool(
+            getattr(config, "tie_word_embeddings", False)
+            or getattr(config.decoder, "tie_word_embeddings", False)
+        )
+        if self.tie_word_embeddings:
+            self.lm_head = self.lm_head.tie_weights(self.decoder.embed_tokens)
+        elif self.num_extra_heads > 0:
+            # The MTP auxiliary head projects through the decoder embedding via
+            # lm_head, so an untied lm_head (compact checkpoints ship no
+            # lm_head.weight, leaving it uninitialized) would silently produce
+            # invalid draft tokens. Fail loudly instead.
+            raise ValueError(
+                "Nemotron Parse MTP (num_extra_heads > 0) requires tied word "
+                "embeddings so lm_head shares the decoder embedding weight."
+            )
         self.logits_processor = LogitsProcessor(
             self.vocab_size, config.decoder.vocab_size
         )
+        self.model_name_or_path = vllm_config.model_config.model
+        self.revision = vllm_config.model_config.revision
+        self.load_config = vllm_config.load_config
 
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:
@@ -673,6 +732,75 @@ class NemotronParseForConditionalGeneration(nn.Module, SupportsMultiModal):
     ) -> torch.Tensor | None:
         return self.logits_processor(self.lm_head, hidden_states)
 
+    def has_mtp_heads(self) -> bool:
+        return self.num_extra_heads > 0
+
+    def _mtp_head_hidden_states(
+        self,
+        hidden_states: torch.Tensor,
+        d1_token_ids: torch.Tensor,
+        head_index: int = 0,
+    ) -> torch.Tensor:
+        if not self.has_mtp_heads():
+            raise RuntimeError("Nemotron Parse auxiliary heads are not loaded")
+        d1_embeds = self.decoder.embed_tokens(d1_token_ids.long())
+        return self.decoder.extra_heads[head_index](
+            hidden_states + self.decoder.extra_proj[head_index](d1_embeds)
+        )
+
+    def extra_head_logits(
+        self,
+        hidden_states: torch.Tensor,
+        d1_token_ids: torch.Tensor,
+        head_index: int = 0,
+    ) -> torch.Tensor:
+        hidden = self._mtp_head_hidden_states(
+            hidden_states, d1_token_ids, head_index
+        )
+        logits = self.logits_processor(self.lm_head, hidden)
+        if logits is None:
+            raise RuntimeError(
+                "Nemotron Parse MTP head logits are unavailable on this rank"
+            )
+        return logits
+
+    def propose_draft_token_ids(
+        self,
+        hidden_states: torch.Tensor,
+        d1_token_ids: torch.Tensor,
+        head_index: int = 0,
+    ) -> torch.Tensor:
+        """Propose one verified ``d2`` using the trained scaled-embedding head."""
+        hidden = self._mtp_head_hidden_states(
+            hidden_states, d1_token_ids, head_index
+        )
+        return self.logits_processor.get_top_tokens(self.lm_head, hidden)
+
+    def _auxiliary_weights(self) -> Iterable[tuple[str, torch.Tensor]]:
+        model_name_or_path = (
+            maybe_download_from_modelscope(self.model_name_or_path, self.revision)
+            or self.model_name_or_path
+        )
+        if os.path.isdir(model_name_or_path):
+            model_folder = model_name_or_path
+        else:
+            model_folder = download_weights_from_hf(
+                model_name_or_path,
+                self.load_config.download_dir,
+                [_AUXILIARY_WEIGHTS_FILE],
+                self.revision,
+                ignore_patterns=self.load_config.ignore_patterns,
+            )
+
+        auxiliary_path = os.path.join(model_folder, _AUXILIARY_WEIGHTS_FILE)
+        if not os.path.isfile(auxiliary_path):
+            return
+        yield from safetensors_weights_iterator(
+            [auxiliary_path],
+            self.load_config.use_tqdm_on_load,
+            self.load_config.safetensors_load_strategy,
+        )
+
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
         lm_head_dict = dict(self.lm_head.named_parameters())
 
@@ -688,19 +816,43 @@ class NemotronParseForConditionalGeneration(nn.Module, SupportsMultiModal):
         # Separate weights by component
         encoder_weights = []
         decoder_weights = []
+        loaded_auxiliary_weights: set[str] = set()
+
+        def add_decoder_weight(name: str, w: torch.Tensor) -> None:
+            trimmed_name = ".".join(name.split(".")[1:])
+            decoder_weights.append((trimmed_name, w))
+            if trimmed_name in _AUXILIARY_DECODER_WEIGHT_NAMES:
+                loaded_auxiliary_weights.add(trimmed_name)
 
         for name, w in weights:
             if is_encoder(name):
                 encoder_weights.append((".".join(name.split(".")[1:]), w))
             elif is_decoder(name):
-                decoder_weights.append((".".join(name.split(".")[1:]), w))
+                add_decoder_weight(name, w)
             elif is_lm_head(name):
+                if self.tie_word_embeddings:
+                    continue
                 trimmed_name = ".".join(name.split(".")[1:])
                 param = lm_head_dict[trimmed_name]
                 with torch.no_grad():
                     default_weight_loader(param, w)
             else:
                 logger.info("Found unexpected weight: %s", name)
+
+        if self.has_mtp_heads():
+            missing = _AUXILIARY_DECODER_WEIGHT_NAMES - loaded_auxiliary_weights
+            if missing:
+                for name, w in self._auxiliary_weights():
+                    if is_decoder(name):
+                        add_decoder_weight(name, w)
+                missing = _AUXILIARY_DECODER_WEIGHT_NAMES - loaded_auxiliary_weights
+            if missing:
+                raise ValueError(
+                    "Nemotron Parse MTP requires NVIDIA-Nemotron-Parse-2.0 or "
+                    "later with trained auxiliary weights. The checkpoint is "
+                    f"missing weights from {_AUXILIARY_WEIGHTS_FILE}: "
+                    + ", ".join(sorted(missing))
+                )
 
         # Load encoder weights
         self.encoder.load_weights(encoder_weights)

--- a/vllm/model_executor/models/nemotron_parse.py
+++ b/vllm/model_executor/models/nemotron_parse.py
@@ -471,6 +471,7 @@ class RadioWithNeck(nn.Module):
         self.sum_proj = ColumnParallelLinear(
             3840,
             last_hidden_state,
+            gather_output=True,
             quant_config=quant_config,
             prefix=f"{prefix}.sum_proj",
         )
@@ -530,8 +531,8 @@ class RadioWithNeck(nn.Module):
                 model_encoder_weights.append((".".join(name.split(".")[1:]), w))
             else:
                 param = adaptor_dict[name]
-                with torch.no_grad():
-                    default_weight_loader(param, w)
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, w)
 
         self.model_encoder.load_weights(model_encoder_weights)
 

--- a/vllm/model_executor/models/nemotron_parse.py
+++ b/vllm/model_executor/models/nemotron_parse.py
@@ -8,6 +8,7 @@
 # https://github.com/vllm-project/vllm/blob/v0.10.2/vllm/model_executor/models/bart.py
 
 import math
+import os
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Annotated, Literal
 
@@ -33,7 +34,12 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
 )
-from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.model_loader.weight_utils import (
+    default_weight_loader,
+    download_weights_from_hf,
+    maybe_download_from_modelscope,
+    safetensors_weights_iterator,
+)
 from vllm.model_executor.models.interfaces import (
     MultiModalEmbeddings,
     SupportsMultiModal,
@@ -59,6 +65,13 @@ from vllm.utils.tensor_schema import TensorSchema, TensorShape
 from vllm.v1.attention.backend import AttentionType
 
 logger = init_logger(__name__)
+
+_AUXILIARY_WEIGHTS_FILE = "auxiliary_prediction_heads.safetensors.extra"
+_AUXILIARY_DECODER_WEIGHT_NAMES = frozenset(
+    f"{module}.0.{parameter}"
+    for module in ("extra_proj", "extra_heads")
+    for parameter in ("weight", "bias")
+)
 
 
 class BartScaledWordEmbedding(VocabParallelEmbedding):
@@ -233,6 +246,7 @@ class MBartDecoderNoPos(nn.Module):
         quant_config: QuantizationConfig | None = None,
         lora_config: LoRAConfig | None = None,
         embed_tokens: nn.Embedding | None = None,
+        num_extra_heads: int = 0,
         prefix: str = "",
     ):
         super().__init__()
@@ -262,6 +276,16 @@ class MBartDecoderNoPos(nn.Module):
 
         self.layernorm_embedding = nn.LayerNorm(config.d_model)
         self.layer_norm = nn.LayerNorm(config.d_model)
+
+        self.num_extra_heads = num_extra_heads
+        self.extra_proj = nn.ModuleList(
+            nn.Linear(config.d_model, config.d_model, bias=True)
+            for _ in range(num_extra_heads)
+        )
+        self.extra_heads = nn.ModuleList(
+            nn.Linear(config.d_model, config.d_model, bias=True)
+            for _ in range(num_extra_heads)
+        )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
@@ -327,8 +351,13 @@ class MBartDecoderNoPos(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
+                # Skip weights with no destination parameter. In the baseline
+                # model (num_extra_heads=0) the auxiliary-head sidecar tensors
+                # (decoder.extra_proj/extra_heads.*) have no module to load into,
+                # so shipping the loadable sidecar in the public checkpoint must
+                # never break the baseline load path. (Also skips extra GPTQ
+                # bias.)
+                if name not in params_dict:
                     continue
 
                 param = params_dict[name]
@@ -557,21 +586,51 @@ class NemotronParseForConditionalGeneration(nn.Module, SupportsMultiModal):
                 config=config, quant_config=quant_config, prefix=f"{prefix}.encoder"
             )
 
+        speculative_config = vllm_config.speculative_config
+        self.num_extra_heads = int(
+            speculative_config is not None
+            and speculative_config.use_nemotron_parse_mtp()
+        )
+
         with self._mark_language_model(vllm_config):
             self.decoder = MBartDecoderNoPos(
                 config.decoder,
                 cache_config=cache_config,
                 quant_config=quant_config,
+                num_extra_heads=self.num_extra_heads,
                 prefix=f"{prefix}.decoder",
             )
+        # Single source of truth for the MTP embedding scale: read the value the
+        # decoder's scaled word embedding already stores (BartScaledWordEmbedding.
+        # embed_scale = sqrt(d_model) when scale_embedding, else 1.0) instead of
+        # re-deriving it from config. Read AFTER the decoder is constructed.
+        self.mtp_embed_scale = self.decoder.embed_tokens.embed_scale
 
         self.vocab_size = config.decoder.vocab_size
         self.lm_head = ParallelLMHead(
             config.decoder.vocab_size, config.decoder.d_model, quant_config=quant_config
         )
+        self.tie_word_embeddings = bool(
+            getattr(config, "tie_word_embeddings", False)
+            or getattr(config.decoder, "tie_word_embeddings", False)
+        )
+        if self.tie_word_embeddings:
+            self.lm_head = self.lm_head.tie_weights(self.decoder.embed_tokens)
+        elif self.num_extra_heads > 0:
+            # The MTP auxiliary head projects through the decoder embedding via
+            # lm_head, so an untied lm_head (compact checkpoints ship no
+            # lm_head.weight, leaving it uninitialized) would silently produce
+            # invalid draft tokens. Fail loudly instead.
+            raise ValueError(
+                "Nemotron Parse MTP (num_extra_heads > 0) requires tied word "
+                "embeddings so lm_head shares the decoder embedding weight."
+            )
         self.logits_processor = LogitsProcessor(
             self.vocab_size, config.decoder.vocab_size
         )
+        self.model_name_or_path = vllm_config.model_config.model
+        self.revision = vllm_config.model_config.revision
+        self.load_config = vllm_config.load_config
 
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:
@@ -654,6 +713,49 @@ class NemotronParseForConditionalGeneration(nn.Module, SupportsMultiModal):
     ) -> torch.Tensor | None:
         return self.logits_processor(self.lm_head, hidden_states)
 
+    def has_mtp_heads(self) -> bool:
+        return self.num_extra_heads > 0
+
+    def propose_draft_token_ids(
+        self,
+        hidden_states: torch.Tensor,
+        d1_token_ids: torch.Tensor,
+        head_index: int = 0,
+    ) -> torch.Tensor:
+        """Propose one verified ``d2`` using the trained scaled-embedding head."""
+        if not self.has_mtp_heads():
+            raise RuntimeError("Nemotron Parse auxiliary heads are not loaded")
+        d1_embeds = self.decoder.embed_tokens(d1_token_ids.long())
+        hidden = self.decoder.extra_heads[head_index](
+            hidden_states + self.decoder.extra_proj[head_index](d1_embeds)
+        )
+        return self.logits_processor.get_top_tokens(self.lm_head, hidden)
+
+    def _auxiliary_weights(self) -> Iterable[tuple[str, torch.Tensor]]:
+        model_name_or_path = (
+            maybe_download_from_modelscope(self.model_name_or_path, self.revision)
+            or self.model_name_or_path
+        )
+        if os.path.isdir(model_name_or_path):
+            model_folder = model_name_or_path
+        else:
+            model_folder = download_weights_from_hf(
+                model_name_or_path,
+                self.load_config.download_dir,
+                [_AUXILIARY_WEIGHTS_FILE],
+                self.revision,
+                ignore_patterns=self.load_config.ignore_patterns,
+            )
+
+        auxiliary_path = os.path.join(model_folder, _AUXILIARY_WEIGHTS_FILE)
+        if not os.path.isfile(auxiliary_path):
+            return
+        yield from safetensors_weights_iterator(
+            [auxiliary_path],
+            self.load_config.use_tqdm_on_load,
+            self.load_config.safetensors_load_strategy,
+        )
+
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
         lm_head_dict = dict(self.lm_head.named_parameters())
 
@@ -669,19 +771,43 @@ class NemotronParseForConditionalGeneration(nn.Module, SupportsMultiModal):
         # Separate weights by component
         encoder_weights = []
         decoder_weights = []
+        loaded_auxiliary_weights: set[str] = set()
+
+        def add_decoder_weight(name: str, w: torch.Tensor) -> None:
+            trimmed_name = ".".join(name.split(".")[1:])
+            decoder_weights.append((trimmed_name, w))
+            if trimmed_name in _AUXILIARY_DECODER_WEIGHT_NAMES:
+                loaded_auxiliary_weights.add(trimmed_name)
 
         for name, w in weights:
             if is_encoder(name):
                 encoder_weights.append((".".join(name.split(".")[1:]), w))
             elif is_decoder(name):
-                decoder_weights.append((".".join(name.split(".")[1:]), w))
+                add_decoder_weight(name, w)
             elif is_lm_head(name):
+                if self.tie_word_embeddings:
+                    continue
                 trimmed_name = ".".join(name.split(".")[1:])
                 param = lm_head_dict[trimmed_name]
                 with torch.no_grad():
                     default_weight_loader(param, w)
             else:
                 logger.info("Found unexpected weight: %s", name)
+
+        if self.has_mtp_heads():
+            missing = _AUXILIARY_DECODER_WEIGHT_NAMES - loaded_auxiliary_weights
+            if missing:
+                for name, w in self._auxiliary_weights():
+                    if is_decoder(name):
+                        add_decoder_weight(name, w)
+                missing = _AUXILIARY_DECODER_WEIGHT_NAMES - loaded_auxiliary_weights
+            if missing:
+                raise ValueError(
+                    "Nemotron Parse MTP requires NVIDIA-Nemotron-Parse-2.0 or "
+                    "later with trained auxiliary weights. The checkpoint is "
+                    f"missing weights from {_AUXILIARY_WEIGHTS_FILE}: "
+                    + ", ".join(sorted(missing))
+                )
 
         # Load encoder weights
         self.encoder.load_weights(encoder_weights)

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -257,6 +257,10 @@ class Scheduler(SchedulerInterface):
             if speculative_config.use_eagle():
                 self.use_eagle = True
                 self.num_lookahead_tokens = self.num_spec_tokens
+            if speculative_config.use_nemotron_parse_mtp():
+                # Lightweight auxiliary-head MTP: schedule the lookahead slot but
+                # stay off the eagle path (no shifted computed tokens / draft KV).
+                self.num_lookahead_tokens = self.num_spec_tokens
             if speculative_config.uses_draft_model():
                 self.num_lookahead_tokens = self.num_spec_tokens
             if speculative_config.use_dflash():

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -124,7 +124,10 @@ from vllm.v1.worker.gpu.spec_decode.eagle.eagle3_utils import (
     set_eagle3_aux_hidden_state_layers,
 )
 from vllm.v1.worker.gpu.spec_decode.rejection_sampler import RejectionSampler
-from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
+from vllm.v1.worker.gpu.spec_decode.speculator import (
+    BaseSpeculator,
+    DraftModelSpeculator,
+)
 from vllm.v1.worker.gpu.spec_decode.utils import DraftTokensHandler
 from vllm.v1.worker.gpu.states import RequestState
 from vllm.v1.worker.gpu.structured_outputs import StructuredOutputsWorker
@@ -340,8 +343,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             if self.use_aux_hidden_state_outputs:
                 assert self.speculative_config is not None
                 set_eagle3_aux_hidden_state_layers(self.model, self.speculative_config)
-            if isinstance(self.speculator, DraftModelSpeculator):
+            if isinstance(self.speculator, BaseSpeculator):
                 self.speculator.load_model(self.model)
+            if isinstance(self.speculator, DraftModelSpeculator):
                 eplb_models_added = self.eplb.maybe_register_speculator(
                     self.speculator, self.speculative_config, load_dummy_weights
                 )

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -160,7 +160,10 @@ from vllm.v1.worker.gpu.spec_decode.rejection_sampler import (
     RejectionSampler,
     get_max_chunk_logits,
 )
-from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
+from vllm.v1.worker.gpu.spec_decode.speculator import (
+    BaseSpeculator,
+    DraftModelSpeculator,
+)
 from vllm.v1.worker.gpu.spec_decode.utils import DraftTokensHandler
 from vllm.v1.worker.gpu.states import RequestState
 from vllm.v1.worker.gpu.structured_outputs import StructuredOutputsWorker
@@ -412,12 +415,13 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                     )
                     assert self.pp_handler is not None
                     self.pp_handler.configure_aux_hidden_state_relay(self.model)
-            if isinstance(self.speculator, DraftModelSpeculator):
+            if isinstance(self.speculator, BaseSpeculator):
                 with use_workspace_lane(self._draft_workspace_lane):
                     self.speculator.load_model(self.model)
-                    eplb_models_added = self.eplb.maybe_register_speculator(
-                        self.speculator, self.speculative_config, load_dummy_weights
-                    )
+                    if isinstance(self.speculator, DraftModelSpeculator):
+                        eplb_models_added = self.eplb.maybe_register_speculator(
+                            self.speculator, self.speculative_config, load_dummy_weights
+                        )
         time_after_load = time.perf_counter()
 
         self.model_memory_usage = m.consumed_memory

--- a/vllm/v1/worker/gpu/spec_decode/__init__.py
+++ b/vllm/v1/worker/gpu/spec_decode/__init__.py
@@ -26,6 +26,12 @@ def init_speculator(vllm_config: VllmConfig, device: torch.device):
         )
 
         return Gemma4Speculator(vllm_config, device)
+    elif speculative_config.use_nemotron_parse_mtp():
+        from vllm.v1.worker.gpu.spec_decode.nemotron_parse_mtp.speculator import (
+            NemotronParseMTPSpeculator,
+        )
+
+        return NemotronParseMTPSpeculator(vllm_config, device)
     elif speculative_config.method == "mtp":
         from vllm.v1.worker.gpu.spec_decode.mtp.speculator import MTPSpeculator
 

--- a/vllm/v1/worker/gpu/spec_decode/__init__.py
+++ b/vllm/v1/worker/gpu/spec_decode/__init__.py
@@ -44,6 +44,12 @@ def init_speculator(vllm_config: VllmConfig, device: torch.device):
         )
 
         return MultiModuleMTPSpeculator(vllm_config, device)
+    elif speculative_config.use_nemotron_parse_mtp():
+        from vllm.v1.worker.gpu.spec_decode.nemotron_parse_mtp.speculator import (
+            NemotronParseMTPSpeculator,
+        )
+
+        return NemotronParseMTPSpeculator(vllm_config, device)
     elif speculative_config.method == "mtp":
         from vllm.v1.worker.gpu.spec_decode.mtp.speculator import MTPSpeculator
 

--- a/vllm/v1/worker/gpu/spec_decode/nemotron_parse_mtp/__init__.py
+++ b/vllm/v1/worker/gpu/spec_decode/nemotron_parse_mtp/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/v1/worker/gpu/spec_decode/nemotron_parse_mtp/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/nemotron_parse_mtp/speculator.py
@@ -1,0 +1,214 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Lightweight MTP speculator for models with a trained auxiliary head.
+
+This is the Model Runner V2 speculator behind ``method="mtp"`` for Nemotron
+Parse, which ships a single dependent auxiliary prediction head instead of a
+transformer draft model. It is selected via
+``SpeculativeConfig.use_nemotron_parse_mtp()`` and, unlike the draft-model MTP
+path, loads no separate model, allocates no draft KV cache, and runs no
+attention -- the target model owns all proposal math and weights. Tensor
+parallel execution uses the target model's vocab-parallel embedding and global
+draft-token reduction while keeping the auxiliary head replicated.
+"""
+
+from collections.abc import Callable
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from vllm.config import VllmConfig
+from vllm.config.compilation import CUDAGraphMode
+from vllm.logger import init_logger
+from vllm.v1.worker.gpu.cudagraph_utils import CudaGraphManager
+from vllm.v1.worker.gpu.dp_utils import dispatch_cg_and_sync_dp
+from vllm.v1.worker.gpu.input_batch import InputBatch
+from vllm.v1.worker.gpu.spec_decode.speculator import BaseSpeculator
+
+logger = init_logger(__name__)
+
+class NemotronParseMTPSpeculator(BaseSpeculator):
+    """A single-token, hidden-state-conditioned auxiliary-head speculator.
+
+    The target model owns all proposal math and weights. This adapter only
+    selects the hidden state that produced the latest sampled token and invokes
+    ``target_model.propose_draft_token_ids(hidden_states, token_ids)``.
+    """
+
+    supports_mm_inputs = False
+    draft_logits = None
+
+    def __init__(self, vllm_config: VllmConfig, device: torch.device):
+        speculative_config = vllm_config.speculative_config
+        assert speculative_config is not None
+        if speculative_config.num_speculative_tokens != 1:
+            raise ValueError(
+                "Nemotron Parse MTP speculation supports exactly one token"
+            )
+        if speculative_config.draft_sample_method != "greedy":
+            raise ValueError(
+                "Nemotron Parse MTP speculation supports greedy drafts only"
+            )
+        self.vllm_config = vllm_config
+        self.device = device
+        self.max_num_reqs = vllm_config.scheduler_config.max_num_seqs
+        self.hidden_size = vllm_config.model_config.get_hidden_size()
+        self.dtype = vllm_config.model_config.dtype
+        self.dp_size = vllm_config.parallel_config.data_parallel_size
+        self.dp_rank = vllm_config.parallel_config.data_parallel_rank
+        self.model: nn.Module | None = None
+        self.cudagraph_manager: CudaGraphManager | None = None
+
+        self.hidden_states = torch.zeros(
+            self.max_num_reqs,
+            self.hidden_size,
+            dtype=self.dtype,
+            device=device,
+        )
+        self.d1_token_ids = torch.zeros(
+            self.max_num_reqs, dtype=torch.int64, device=device
+        )
+        self.draft_tokens = torch.zeros(
+            self.max_num_reqs, dtype=torch.int64, device=device
+        )
+
+    def load_model(self, target_model: nn.Module) -> None:
+        propose = getattr(target_model, "propose_draft_token_ids", None)
+        if not callable(propose):
+            raise TypeError(
+                f"{type(target_model).__name__} does not implement "
+                "propose_draft_token_ids(hidden_states, token_ids)"
+            )
+        self.model = target_model
+
+    def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
+        if cudagraph_mode.decode_mode() == CUDAGraphMode.FULL:
+            cudagraph_mode = CUDAGraphMode.FULL_DECODE_ONLY
+        else:
+            # PIECEWISE graphs are not supported for this tiny head-only path.
+            cudagraph_mode = CUDAGraphMode.NONE
+        self.cudagraph_manager = CudaGraphManager(
+            self.vllm_config,
+            self.device,
+            cudagraph_mode,
+            decode_query_len=1,
+        )
+
+    def capture(self) -> None:
+        if self.cudagraph_manager is None or not self.cudagraph_manager.needs_capture():
+            return
+        logger.info("Capturing CUDA graphs for Nemotron Parse MTP speculator...")
+        self.hidden_states.zero_()
+        self.d1_token_ids.zero_()
+        self.draft_tokens.zero_()
+
+        def create_forward_fn(
+            desc,
+            warmup: bool,
+        ) -> Callable[[CUDAGraphMode], None]:
+            num_reqs_padded = desc.num_reqs or desc.num_tokens
+            return lambda cg_mode: self._run_mtp_head(num_reqs_padded)
+
+        self.cudagraph_manager.capture(
+            create_forward_fn,
+            progress_bar_desc="Capturing Nemotron Parse MTP CUDA graphs",
+        )
+
+    def _prepare_mtp_inputs(
+        self,
+        input_batch: InputBatch,
+        last_hidden_states: torch.Tensor,
+        num_sampled: torch.Tensor,
+        num_rejected: torch.Tensor,
+        last_sampled: torch.Tensor,
+        num_reqs: int,
+    ) -> torch.Tensor:
+        req_state_indices = input_batch.idx_mapping[:num_reqs]
+        sampled = num_sampled[:num_reqs] > 0
+
+        hidden_indices = (
+            input_batch.query_start_loc[1 : num_reqs + 1] - num_rejected[:num_reqs] - 1
+        ).clamp_min(0)
+        self.hidden_states[:num_reqs] = last_hidden_states[
+            hidden_indices.to(torch.long)
+        ]
+
+        d1 = last_sampled[req_state_indices].reshape(-1).to(torch.long)
+        self.d1_token_ids[:num_reqs] = torch.where(
+            sampled, d1, torch.zeros_like(d1)
+        )
+        return sampled
+
+    def _run_mtp_head(self, num_reqs_padded: int) -> None:
+        if self.model is None:
+            raise RuntimeError("target model has not been bound to the speculator")
+        h = self.hidden_states[:num_reqs_padded]
+        d1 = self.d1_token_ids[:num_reqs_padded]
+        self.draft_tokens[:num_reqs_padded] = self.model.propose_draft_token_ids(h, d1)
+
+    @torch.inference_mode()
+    def propose(
+        self,
+        input_batch: InputBatch,
+        attn_metadata: dict[str, Any],
+        slot_mappings: dict[str, torch.Tensor],
+        last_hidden_states: torch.Tensor,
+        aux_hidden_states: list[torch.Tensor] | None,
+        num_sampled: torch.Tensor,
+        num_rejected: torch.Tensor,
+        last_sampled: torch.Tensor,
+        next_prefill_tokens: torch.Tensor,
+        temperature: torch.Tensor,
+        seeds: torch.Tensor,
+        num_tokens_across_dp: torch.Tensor | None = None,
+        dummy_run: bool = False,
+        skip_attn_for_dummy_run: bool = False,
+        mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
+        is_profile: bool = False,
+    ) -> torch.Tensor:
+        del (
+            attn_metadata,
+            slot_mappings,
+            aux_hidden_states,
+            next_prefill_tokens,
+            temperature,
+            seeds,
+            num_tokens_across_dp,
+            dummy_run,
+            skip_attn_for_dummy_run,
+            mm_inputs,
+        )
+        if self.model is None:
+            raise RuntimeError("target model has not been bound to the speculator")
+
+        num_reqs = input_batch.num_reqs
+        batch_desc, _ = dispatch_cg_and_sync_dp(
+            self.cudagraph_manager,
+            num_reqs,
+            num_reqs,
+            uniform_token_count=1,
+            dp_size=self.dp_size,
+            dp_rank=self.dp_rank,
+            need_eager=is_profile,
+        )
+        num_reqs_padded = batch_desc.num_reqs or num_reqs
+
+        sampled = self._prepare_mtp_inputs(
+            input_batch,
+            last_hidden_states,
+            num_sampled,
+            num_rejected,
+            last_sampled,
+            num_reqs,
+        )
+
+        if batch_desc.cg_mode == CUDAGraphMode.FULL:
+            assert self.cudagraph_manager is not None
+            self.cudagraph_manager.run_fullgraph(batch_desc)
+        else:
+            self._run_mtp_head(num_reqs_padded)
+
+        proposed = self.draft_tokens[:num_reqs]
+        proposed = torch.where(sampled, proposed, torch.zeros_like(proposed))
+        return proposed.to(torch.long).view(num_reqs, 1)

--- a/vllm/v1/worker/gpu/spec_decode/nemotron_parse_mtp/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/nemotron_parse_mtp/speculator.py
@@ -1,0 +1,213 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Lightweight MTP speculator for models with a trained auxiliary head.
+
+This is the Model Runner V2 speculator behind ``method="mtp"`` for Nemotron
+Parse, which ships a single dependent auxiliary prediction head instead of a
+transformer draft model. It is selected via
+``SpeculativeConfig.use_nemotron_parse_mtp()`` and, unlike the draft-model MTP
+path, loads no separate model, allocates no draft KV cache, and runs no
+attention -- the target model owns all proposal math and weights. Tensor
+parallel execution uses the target model's vocab-parallel embedding and global
+draft-token reduction while keeping the auxiliary head replicated.
+"""
+
+from collections.abc import Callable
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from vllm.config import VllmConfig
+from vllm.config.compilation import CUDAGraphMode
+from vllm.logger import init_logger
+from vllm.v1.worker.gpu.cudagraph_utils import CudaGraphManager
+from vllm.v1.worker.gpu.dp_utils import DPSyncState, dispatch_cg_and_sync_dp
+from vllm.v1.worker.gpu.input_batch import InputBatch
+from vllm.v1.worker.gpu.spec_decode.speculator import BaseSpeculator
+
+logger = init_logger(__name__)
+
+
+class NemotronParseMTPSpeculator(BaseSpeculator):
+    """A single-token, hidden-state-conditioned auxiliary-head speculator.
+
+    The target model owns all proposal math and weights. This adapter only
+    selects the hidden state that produced the latest sampled token and invokes
+    ``target_model.propose_draft_token_ids(hidden_states, token_ids)``.
+    """
+
+    supports_mm_inputs = False
+    draft_logits = None
+
+    def __init__(self, vllm_config: VllmConfig, device: torch.device):
+        speculative_config = vllm_config.speculative_config
+        assert speculative_config is not None
+        if speculative_config.num_speculative_tokens != 1:
+            raise ValueError(
+                "Nemotron Parse MTP speculation supports exactly one token"
+            )
+        if speculative_config.draft_sample_method != "greedy":
+            raise ValueError(
+                "Nemotron Parse MTP speculation supports greedy drafts only"
+            )
+        self.vllm_config = vllm_config
+        self.device = device
+        self.max_num_reqs = vllm_config.scheduler_config.max_num_seqs
+        self.hidden_size = vllm_config.model_config.get_hidden_size()
+        self.dtype = vllm_config.model_config.dtype
+        self.dp_size = vllm_config.parallel_config.data_parallel_size
+        self.dp_rank = vllm_config.parallel_config.data_parallel_rank
+        self.model: nn.Module | None = None
+        self.cudagraph_manager: CudaGraphManager | None = None
+
+        self.hidden_states = torch.zeros(
+            self.max_num_reqs,
+            self.hidden_size,
+            dtype=self.dtype,
+            device=device,
+        )
+        self.d1_token_ids = torch.zeros(
+            self.max_num_reqs, dtype=torch.int64, device=device
+        )
+        self.draft_tokens = torch.zeros(
+            self.max_num_reqs, dtype=torch.int64, device=device
+        )
+
+    def load_model(self, target_model: nn.Module) -> None:
+        propose = getattr(target_model, "propose_draft_token_ids", None)
+        if not callable(propose):
+            raise TypeError(
+                f"{type(target_model).__name__} does not implement "
+                "propose_draft_token_ids(hidden_states, token_ids)"
+            )
+        self.model = target_model
+
+    def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
+        if cudagraph_mode.decode_mode() == CUDAGraphMode.FULL:
+            cudagraph_mode = CUDAGraphMode.FULL_DECODE_ONLY
+        else:
+            # PIECEWISE graphs are not supported for this tiny head-only path.
+            cudagraph_mode = CUDAGraphMode.NONE
+        self.cudagraph_manager = CudaGraphManager(
+            self.vllm_config,
+            self.device,
+            cudagraph_mode,
+            decode_query_len=1,
+        )
+
+    def capture(self) -> None:
+        if self.cudagraph_manager is None or not self.cudagraph_manager.needs_capture():
+            return
+        logger.info("Capturing CUDA graphs for Nemotron Parse MTP speculator...")
+        self.hidden_states.zero_()
+        self.d1_token_ids.zero_()
+        self.draft_tokens.zero_()
+
+        def create_forward_fn(
+            desc,
+            warmup: bool,
+        ) -> Callable[[CUDAGraphMode], None]:
+            num_reqs_padded = desc.num_reqs or desc.num_tokens
+            return lambda cg_mode: self._run_mtp_head(num_reqs_padded)
+
+        self.cudagraph_manager.capture(
+            create_forward_fn,
+            progress_bar_desc="Capturing Nemotron Parse MTP CUDA graphs",
+        )
+
+    def _prepare_mtp_inputs(
+        self,
+        input_batch: InputBatch,
+        last_hidden_states: torch.Tensor,
+        num_sampled: torch.Tensor,
+        num_rejected: torch.Tensor,
+        last_sampled: torch.Tensor,
+        num_reqs: int,
+    ) -> torch.Tensor:
+        req_state_indices = input_batch.idx_mapping[:num_reqs]
+        sampled = num_sampled[:num_reqs] > 0
+
+        hidden_indices = (
+            input_batch.query_start_loc[1 : num_reqs + 1] - num_rejected[:num_reqs] - 1
+        ).clamp_min(0)
+        self.hidden_states[:num_reqs] = last_hidden_states[
+            hidden_indices.to(torch.long)
+        ]
+
+        d1 = last_sampled[req_state_indices].reshape(-1).to(torch.long)
+        self.d1_token_ids[:num_reqs] = torch.where(sampled, d1, torch.zeros_like(d1))
+        return sampled
+
+    def _run_mtp_head(self, num_reqs_padded: int) -> None:
+        if self.model is None:
+            raise RuntimeError("target model has not been bound to the speculator")
+        h = self.hidden_states[:num_reqs_padded]
+        d1 = self.d1_token_ids[:num_reqs_padded]
+        self.draft_tokens[:num_reqs_padded] = self.model.propose_draft_token_ids(h, d1)
+
+    @torch.inference_mode()
+    def propose(
+        self,
+        input_batch: InputBatch,
+        attn_metadata: dict[str, Any],
+        slot_mappings: dict[str, torch.Tensor],
+        last_hidden_states: torch.Tensor,
+        aux_hidden_states: list[torch.Tensor] | None,
+        num_sampled: torch.Tensor,
+        num_rejected: torch.Tensor,
+        last_sampled: torch.Tensor,
+        next_prefill_tokens: torch.Tensor,
+        temperature: torch.Tensor,
+        seeds: torch.Tensor,
+        dp_sync: DPSyncState | None = None,
+        dummy_run: bool = False,
+        skip_attn_for_dummy_run: bool = False,
+        mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
+        is_profile: bool = False,
+    ) -> torch.Tensor:
+        del (
+            attn_metadata,
+            slot_mappings,
+            aux_hidden_states,
+            next_prefill_tokens,
+            temperature,
+            seeds,
+            dummy_run,
+            skip_attn_for_dummy_run,
+            mm_inputs,
+        )
+        if self.model is None:
+            raise RuntimeError("target model has not been bound to the speculator")
+
+        num_reqs = input_batch.num_reqs
+        batch_desc, _ = dispatch_cg_and_sync_dp(
+            self.cudagraph_manager,
+            num_reqs,
+            num_reqs,
+            uniform_token_count=1,
+            dp_size=self.dp_size,
+            dp_rank=self.dp_rank,
+            need_eager=is_profile,
+            dp_sync=dp_sync,
+        )
+        num_reqs_padded = batch_desc.num_reqs or num_reqs
+
+        sampled = self._prepare_mtp_inputs(
+            input_batch,
+            last_hidden_states,
+            num_sampled,
+            num_rejected,
+            last_sampled,
+            num_reqs,
+        )
+
+        if batch_desc.cg_mode == CUDAGraphMode.FULL:
+            assert self.cudagraph_manager is not None
+            self.cudagraph_manager.run_fullgraph(batch_desc)
+        else:
+            self._run_mtp_head(num_reqs_padded)
+
+        proposed = self.draft_tokens[:num_reqs]
+        proposed = torch.where(sampled, proposed, torch.zeros_like(proposed))
+        return proposed.to(torch.long).view(num_reqs, 1)

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -31,6 +31,11 @@ logger = init_logger(__name__)
 
 class BaseSpeculator(ABC):
     @abstractmethod
+    def load_model(self, target_model: nn.Module) -> None:
+        """Bind the loaded target model and initialize proposal weights."""
+        pass
+
+    @abstractmethod
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
         pass
 

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -47,6 +47,11 @@ def _target_feeds_hc_residual(vllm_config: VllmConfig) -> bool:
 
 class BaseSpeculator(ABC):
     @abstractmethod
+    def load_model(self, target_model: nn.Module) -> None:
+        """Bind the loaded target model and initialize proposal weights."""
+        pass
+
+    @abstractmethod
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
         pass
 


### PR DESCRIPTION
co autored with: @DenisOvchinnikov93
[NVIDIA-Nemotron-Parse-2.0](https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-2.0) ships:
> Auxiliary Prediction Head: One training-time decoder prediction head is preserved separately in auxiliary_prediction_heads.safetensors.extra for future multi-token prediction research. Standard generation uses the tied decoder input/output embeddings; the default model.safetensors, Transformers examples, and vLLM examples do not load this auxiliary head.

This PR leverages the auxiliary head to enable Speculative Decoding for Nemotron-Parse. Backward compatibility for older Nemotron-Parse versions is preserved (standard single-token decoding is only available for versions < 2.0).

This PR also switches tests to track regressions on the latest model with speculative-decoding enabled.

To measure throughput with vs without speculative decoding, I used ParseBench table and text_content (1,005 pages). That census has long target sequences, so MTP gains show up clearly. On H100, speculative-decoded vs baseline median output-throughput uplift was:

Concurrency | speculative-decoding throughput gain vs single-token-prediction
-- | --
1 | 45.65%
8 | 40.85%
32 | 39.60%

## Purpose
Enable spec-dec for nemotron-parse 2.0

## Test Plan
```
.venv/bin/python -m pytest \
    tests/models/multimodal/generation/test_nemotron_parse.py \
    -vv --tb=short
```

## Test Result
```
================== 1 passed, 32 warnings in 74.73s (0:01:14) ===================
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

