### PR TITLE
[Bugfix][Benchmark] Preserve SSE output across transport chunk boundaries

### DIFF
--- a/tests/benchmarks/test_endpoint_request_func.py
+++ b/tests/benchmarks/test_endpoint_request_func.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import asyncio
+import json
+from collections.abc import AsyncIterator, Awaitable, Callable
+from typing import Any
+
+import pytest
+
+from vllm.benchmarks.lib.endpoint_request_func import (
+    RequestFuncInput,
+    RequestFuncOutput,
+    async_request_openai_chat_completions,
+    async_request_openai_completions,
+)
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+RequestCall = Callable[[RequestFuncInput, Any], Awaitable[RequestFuncOutput]]
+
+_EXPECTED_TEXT = " leading 中 trailing "
+
+
+class _FakeContent:
+    def __init__(self, chunks: tuple[bytes, bytes]) -> None:
+        self._chunks = chunks
+
+    async def iter_any(self) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _FakeResponse:
+    status = 200
+    reason = "OK"
+
+    def __init__(self, chunks: tuple[bytes, bytes]) -> None:
+        self.content = _FakeContent(chunks)
+
+    async def __aenter__(self) -> "_FakeResponse":
+        return self
+
+    async def __aexit__(self, *_: object) -> bool:
+        return False
+
+
+class _FakeSession:
+    def __init__(self, chunks: tuple[bytes, bytes]) -> None:
+        self._chunks = chunks
+
+    def post(self, **_: Any) -> _FakeResponse:
+        return _FakeResponse(self._chunks)
+
+
+@pytest.mark.parametrize(
+    ("request_func", "api_url", "payload"),
+    [
+        (
+            async_request_openai_completions,
+            "http://localhost:8000/v1/completions",
+            {"choices": [{"text": _EXPECTED_TEXT}]},
+        ),
+        (
+            async_request_openai_chat_completions,
+            "http://localhost:8000/v1/chat/completions",
+            {"choices": [{"delta": {"content": _EXPECTED_TEXT}}]},
+        ),
+    ],
+)
+def test_streamed_output_is_invariant_to_transport_chunk_boundaries(
+    request_func: RequestCall,
+    api_url: str,
+    payload: dict[str, Any],
+) -> None:
+    """iter_any() yields arbitrary transport fragments, so parsing must
+    give the same result no matter where the byte stream is split."""
+    event = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+    stream = f"data: {event}\n\ndata: [DONE]\n\n".encode()
+
+    request = RequestFuncInput(
+        prompt="test",
+        api_url=api_url,
+        prompt_len=1,
+        output_len=8,
+        model="test-model",
+    )
+
+    async def run_all_splits() -> list[tuple[int, bool, str, str]]:
+        failures = []
+        for split_at in range(1, len(stream)):
+            session = _FakeSession((stream[:split_at], stream[split_at:]))
+            output = await request_func(request, session)
+            if not output.success or output.generated_text != _EXPECTED_TEXT:
+                error = output.error.splitlines()[-1] if output.error else ""
+                failures.append(
+                    (split_at, output.success, output.generated_text, error)
+                )
+        return failures
+
+    assert asyncio.run(run_all_splits()) == []

--- a/vllm/benchmarks/lib/endpoint_request_func.py
+++ b/vllm/benchmarks/lib/endpoint_request_func.py
@@ -204,7 +204,6 @@ async def async_request_openai_completions(
                 handler = StreamedResponseHandler()
 
                 async for chunk_bytes in response.content.iter_any():
-                    chunk_bytes = chunk_bytes.strip()
                     if not chunk_bytes:
                         continue
 
@@ -382,7 +381,6 @@ async def async_request_openai_chat_completions(
             if response.status == 200:
                 handler = StreamedResponseHandler()
                 async for chunk_bytes in response.content.iter_any():
-                    chunk_bytes = chunk_bytes.strip()
                     if not chunk_bytes:
                         continue
 
@@ -503,7 +501,6 @@ async def async_request_openai_audio(
                     handler = StreamedResponseHandler()
 
                     async for chunk_bytes in response.content.iter_any():
-                        chunk_bytes = chunk_bytes.strip()
                         if not chunk_bytes:
                             continue
 


### PR DESCRIPTION


## Purpose
Fix SSE parsing in the Python `vllm bench serve` clients so results do not depend on how the HTTP response is split into transport chunks.

The OpenAI completions, chat completions, and audio clients iterate streaming responses with `response.content.iter_any()` and call `bytes.strip()` on every returned chunk before passing it to `StreamedResponseHandler`. 

`iter_any()` returns arbitrary available transport data, not complete SSE records, so stripping each fragment mutates the stream before reassembly.

For example, a valid event may arrive as:

>     b"data:"
>     b' {"choices": ...}\n\ndata: [DONE]\n\n'

Stripping both fragments removes the required space after `data:`. The reassembled message becomes `data:{...}`, so `removeprefix("data: ")` no longer matches and JSON parsing fails. The request is marked failed.

A split immediately before whitespace inside a JSON string is worse: the request succeeds, but valid model-output whitespace is silently removed. When the backend omits streaming usage info, the benchmark tokenizes `generated_text` itself, so this can also shift measured output length and derived throughput/TPOT numbers.

The fix passes chunks returned by `iter_any()` unchanged to `StreamedResponseHandler` (three deleted lines). The message-level `.strip()` inside `StreamedResponseHandler` is unchanged: it runs only after a complete SSE boundary (`\n\n`) has been identified. The legacy `benchmarks/backend_request_func.py` loops are untouched; they iterate
`response.content` line-by-line, where per-line stripping is safe.

The per-chunk `.strip()` predates #24373, which switched these loops from line-based iteration (where stripping a complete line is harmless) to `iter_any()`. #50868 recently fixed the same invariant: transport boundaries must not alter output, in the Rust client; this is the Python-side equivalent.


## Test Plan
```
pytest tests/benchmarks/test_endpoint_request_func.py -v
pytest tests/benchmarks/test_audio_dataset.py -v
```

The new test invokes the real completion and chat request functions against a fake session and enumerates every possible two-piece split of an SSE stream containing the `data: ` prefix, leading/internal/trailing generated-text whitespace, a multibyte UTF-8 character, and the `[DONE]` event. For every split position, the request must succeed and return the exact original text.

## Test Result

Before the fix, 10 split positions fail per endpoint:

- splits inside `data: `: request fails with `json.decoder.JSONDecodeError: Expecting value: line 1 column 1`
- 8 splits adjacent to whitespace inside the JSON string: request succeeds but whitespace is silently deleted from the generated text, e.g. `' leading 中 trailing '` → `'leading 中 trailing '`

After the fix:
- tests/benchmarks/test_endpoint_request_func.py ..                  [100%] 2 passed
- tests/benchmarks/test_audio_dataset.py ........                    [100%] 8 passed

`pre-commit run --files` on both changed files: all hooks pass.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

