### PR TITLE
[Bugfix] Keep presence/frequency penalty in override-generation-config

### DIFF
--- a/tests/config/test_override_generation_config.py
+++ b/tests/config/test_override_generation_config.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from vllm.config.model import ModelConfig
+
+
+def test_override_generation_config_keeps_presence_and_frequency_penalty():
+    """Regression test for #50767: --override-generation-config must not
+    silently drop presence_penalty / frequency_penalty."""
+    model_config = object.__new__(ModelConfig)
+    model_config.generation_config = "vllm"
+    model_config.override_generation_config = {
+        "presence_penalty": 1.2,
+        "frequency_penalty": 0.8,
+        "temperature": 0.7,
+    }
+
+    assert model_config.get_diff_sampling_param() == {
+        "presence_penalty": 1.2,
+        "frequency_penalty": 0.8,
+        "temperature": 0.7,
+    }
+
+
+def test_generation_config_penalties_survive_diff_sampling_filter():
+    """Regression test for #50767: penalties read from the model's
+    generation_config.json must survive the diff-sampling whitelist."""
+    model_config = object.__new__(ModelConfig)
+    model_config.generation_config = "auto"
+    model_config.override_generation_config = {}
+    model_config.try_get_generation_config = lambda: {
+        "presence_penalty": 1.1,
+        "frequency_penalty": 0.7,
+        "temperature": 0.9,
+    }
+
+    assert model_config.get_diff_sampling_param() == {
+        "presence_penalty": 1.1,
+        "frequency_penalty": 0.7,
+        "temperature": 0.9,
+    }

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1648,6 +1648,8 @@ class ModelConfig:
             "top_k",
             "top_p",
             "min_p",
+            "presence_penalty",
+            "frequency_penalty",
             "max_new_tokens",
         ]
         if any(p in config for p in available_params):


### PR DESCRIPTION
## Summary

`--override-generation-config` silently dropped `presence_penalty` and `frequency_penalty`: `ModelConfig.get_diff_sampling_param()` filters the override through an `available_params` whitelist that did not list them, so the sampler always fell back to `0.0` for both, with no warning.

This is the same class of silent-drop bug as #45591 (`eos_token_id`), fixed here by adding both parameters to the whitelist.

Fixes #50767

## Test

- Added `tests/config/test_override_generation_config.py` covering both paths: the `--override-generation-config` override path (`--generation-config vllm`) and the `generation_config.json` diff path.
- Verified locally on macOS (CPU-only, no GPU needed for this config logic): both tests fail on `main` and pass with the fix:

```
2 passed
```

- `ruff check` and `ruff format --check` pass on both changed files.