### PR TITLE
[CI Bug] Fix `pydantic_core._pydantic_core.ValidationError: Input should be a valid integer`

### DIFF
--- a/vllm/transformers_utils/model_arch_config_convertor.py
+++ b/vllm/transformers_utils/model_arch_config_convertor.py
@@ -172,7 +172,10 @@ class ModelArchConfigConvertorBase:
             "moe_topk",
             "moe_top_k",
         ]
-        return getattr_iter(self.hf_text_config, names, 0) or 0
+        num_experts_per_token = getattr_iter(self.hf_text_config, names, 0)
+        if isinstance(num_experts_per_token, list):
+            return max(num_experts_per_token, default=0)
+        return num_experts_per_token or 0
 
     @final
     @classmethod


### PR DESCRIPTION
## Purpose

Introduced by https://github.com/vllm-project/vllm/pull/50940

Causing bug of https://buildkite.com/vllm/ci/builds/82455#019fd24f-5915-4781-9bc7-acb04aa9e04e

```bash
        """
>       can_initialize(model_arch, monkeypatch, HF_EXAMPLE_MODELS)

tests/models/test_initialization.py:200: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

args = ('HunYuanMoEV1ForCausalLM', <_pytest.monkeypatch.MonkeyPatch object at 0x7fc17a69a2a0>, <tests.models.registry.HfExampleModels object at 0x7fc1871853d0>)
kwargs = {}, Skipped = <class 'Skipped'>
exc_file = <tempfile._TemporaryFileWrapper object at 0x7fc17b32bce0>
delete_after = <contextlib.ExitStack object at 0x7fc17a8e4b30>
exc_file_path = '/tmp/vllm_test_can_initialize_290455_g4wo72cy.exc', pid = 291320
f = <_io.BufferedReader name='/tmp/vllm_test_can_initialize_290455_g4wo72cy.exc'>

    @functools.wraps(func)
    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> None:
        from _pytest.outcomes import Skipped
    
        # Create a unique temporary file to store exception info from child
        # process. Use test function name and process ID to avoid collisions.
        with (
            tempfile.NamedTemporaryFile(
                delete=False,
                mode="w+b",
                prefix=f"vllm_test_{func.__name__}_{os.getpid()}_",
                suffix=".exc",
            ) as exc_file,
            ExitStack() as delete_after,
        ):
            exc_file_path = exc_file.name
            delete_after.callback(os.remove, exc_file_path)
    
            pid = os.fork()
            print(f"Fork a new process to run a test {pid}")
            if pid == 0:
                # Make the child process the leader of its own process group
                # to avoid sending SIGTERM to the parent process
                os.setpgrp()
                # Parent process responsible for deleting, don't delete
                # in child.
                delete_after.pop_all()
                try:
                    func(*args, **kwargs)
                except Skipped as e:
                    # convert Skipped to exit code 0
                    print(str(e))
                    os._exit(0)
                except Exception as e:
                    import traceback
    
                    tb_string = traceback.format_exc()
    
                    # Try to serialize the exception object first
                    exc_to_serialize: dict[str, Any]
                    try:
                        # First, try to pickle the actual exception with
                        # its traceback.
                        exc_to_serialize = {"pickled_exception": e}
                        # Test if it can be pickled
                        cloudpickle.dumps(exc_to_serialize)
                    except (Exception, KeyboardInterrupt):
                        # Fall back to string-based approach.
                        exc_to_serialize = {
                            "exception_type": type(e).__name__,
                            "exception_msg": str(e),
                            "traceback": tb_string,
                        }
                    try:
                        with open(exc_file_path, "wb") as f:
                            cloudpickle.dump(exc_to_serialize, f)
                    except Exception:
                        # Fallback: just print the traceback.
                        print(tb_string)
                    os._exit(1)
                else:
                    os._exit(0)
            else:
                # After setpgrp(), the child's pgid equals its pid
                pgid = pid
                _pid, _exitcode = os.waitpid(pid, 0)
                # kill all child processes - but they may already have exited cleanly
                with contextlib.suppress(ProcessLookupError):
                    os.killpg(pgid, signal.SIGTERM)
                if _exitcode != 0:
                    # Try to read the exception from the child process
                    exc_info = {}
                    if os.path.exists(exc_file_path):
                        with (
                            contextlib.suppress(Exception),
                            open(exc_file_path, "rb") as f,
                        ):
                            exc_info = cloudpickle.load(f)
    
                    if (
                        original_exception := exc_info.get("pickled_exception")
                    ) is not None:
                        # Re-raise the actual exception object if it was
                        # successfully pickled.
                        assert isinstance(original_exception, Exception)
>                       raise original_exception
E                       pydantic_core._pydantic_core.ValidationError: 1 validation error for ModelConfig
E                       num_experts_per_token
E                         Input should be a valid integer [type=int_type, input_value=[8, 8, 8, 8, 8, 8, 8, 8, ... 8, 8, 8, 8, 8, 8, 8, 8], input_type=list]
E                           For further information visit https://errors.pydantic.dev/2.13/v/int_type
```

This PR fixes the issue
