### PR TITLE
[CI bug] Fix `Each KV cache group's real block_size must be divisible by has h_block_size`

### DIFF
--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -645,12 +645,9 @@ def resolve_kv_cache_block_sizes(
     if not (cache_config.enable_prefix_caching or connector_enabled):
         return scheduler_block_size, scheduler_block_size
 
-    # Mamba groups with block_size != cache_config.block_size
-    # (mamba_cache_mode != "align") break divisibility; back off to the
-    # scheduler block size.
     if any(
         isinstance(g.kv_cache_spec, MambaSpec)
-        and g.kv_cache_spec.block_size != cache_config.block_size
+        and g.kv_cache_spec.mamba_cache_mode != "align"
         for g in groups
     ):
         return scheduler_block_size, scheduler_block_size


### PR DESCRIPTION
## Purpose

Fixes https://buildkite.com/vllm/ci/builds/82455#019fd2a4-0c78-4fd7-8580-ac6d3ccaa8a8

```bash

(EngineCore pid=1580) INFO 08-05 15:59:27 [jit_monitor.py:79] Kernel JIT monitor activated; monitored JIT compilations during inference will use mode=warn.
--
  | (EngineCore pid=1580) INFO 08-05 15:59:27 [torch_utils.py:261] Reducing Torch threads from 88 to 1 for serving. Set OMP_NUM_THREADS in the external environment to override.
  | (EngineCore pid=1580) INFO 08-05 15:59:27 [core.py:351] init engine (profile, create kv cache, warmup model) took 22.09 s
  | (EngineCore pid=1580) INFO 08-05 15:59:27 [factory.py:62] Creating v1 connector with name: ExampleHiddenStatesConnector and engine_id: 000c1f86-681e-49f5-8d9f-58cf5b7ba6d1
  | (EngineCore pid=1580) WARNING 08-05 15:59:27 [base.py:202] Initializing KVConnectorBase_V1. This API is experimental and subject to change in the future as we iterate the design.
  | (EngineCore pid=1580) INFO 08-05 15:59:27 [example_hidden_states_connector.py:176] KVTransferConfig(kv_connector='ExampleHiddenStatesConnector', engine_id='000c1f86-681e-49f5-8d9f-58cf5b7ba6d1', kv_buffer_device='cuda', kv_buffer_size=1000000000.0, kv_role='kv_producer', kv_rank=None, kv_parallel_size=1, kv_ip='127.0.0.1', kv_port=14579, kv_connector_extra_config={'shared_storage_path': '/tmp/pytest-of-root/pytest-0/test_extract_hidden_states_qwe0'}, kv_connector_module_path=None, enable_permute_local_kv=False, kv_load_failure_policy='fail')
  | (EngineCore pid=1580) INFO 08-05 15:59:27 [example_hidden_states_connector.py:177] Shared storage path is /tmp/pytest-of-root/pytest-0/test_extract_hidden_states_qwe0
  | (EngineCore pid=1580) ERROR 08-05 15:59:27 [core.py:1345] EngineCore failed to start.
  | (EngineCore pid=1580) ERROR 08-05 15:59:27 [core.py:1345] Traceback (most recent call last):
  | (EngineCore pid=1580) ERROR 08-05 15:59:27 [core.py:1345]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 1314, in run_engine_core
  | (EngineCore pid=1580) ERROR 08-05 15:59:27 [core.py:1345]     engine_core = EngineCoreProc(*args, engine_index=dp_rank, **kwargs)
  | (EngineCore pid=1580) ERROR 08-05 15:59:27 [core.py:1345]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore pid=1580) ERROR 08-05 15:59:27 [core.py:1345]   File "/usr/local/lib/python3.12/dist-packages/vllm/tracing/otel.py", line 178, in sync_wrapper
  | (EngineCore pid=1580) ERROR 08-05 15:59:27 [core.py:1345]     return func(*args, **kwargs)
  | (EngineCore pid=1580) ERROR 08-05 15:59:27 [core.py:1345]            ^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore pid=1580) ERROR 08-05 15:59:27 [core.py:1345]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 1070, in __init__
  | (EngineCore pid=1580) ERROR 08-05 15:59:27 [core.py:1345]     super().__init__(
  | (EngineCore pid=1580) ERROR 08-05 15:59:27 [core.py:1345]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 160, in __init__
  | (EngineCore pid=1580) ERROR 08-05 15:59:27 [core.py:1345]     self.scheduler: SchedulerInterface = Scheduler(
  | (EngineCore pid=1580) ERROR 08-05 15:59:27 [core.py:1345]                                          ^^^^^^^^^^
  | (EngineCore pid=1580) ERROR 08-05 15:59:27 [core.py:1345]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/core/sched/async_scheduler.py", line 14, in __init__
  | (EngineCore pid=1580) ERROR 08-05 15:59:27 [core.py:1345]     super().__init__(*args, **kwargs)
  | (EngineCore pid=1580) ERROR 08-05 15:59:27 [core.py:1345]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/core/sched/scheduler.py", line 277, in __init__
  | (EngineCore pid=1580) ERROR 08-05 15:59:27 [core.py:1345]     self.kv_cache_manager = KVCacheManager(
  | (EngineCore pid=1580) ERROR 08-05 15:59:27 [core.py:1345]                             ^^^^^^^^^^^^^^^
  | (EngineCore pid=1580) ERROR 08-05 15:59:27 [core.py:1345]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/core/kv_cache_manager.py", line 151, in __init__
  | (EngineCore pid=1580) ERROR 08-05 15:59:27 [core.py:1345]     self.coordinator = get_kv_cache_coordinator(
  | (EngineCore pid=1580) ERROR 08-05 15:59:27 [core.py:1345]                        ^^^^^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore pid=1580) ERROR 08-05 15:59:27 [core.py:1345]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/core/kv_cache_coordinator.py", line 891, in get_kv_cache_coordinator
  | (EngineCore pid=1580) ERROR 08-05 15:59:27 [core.py:1345]     return HybridKVCacheCoordinator(
  | (EngineCore pid=1580) ERROR 08-05 15:59:27 [core.py:1345]            ^^^^^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore pid=1580) ERROR 08-05 15:59:27 [core.py:1345]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/core/kv_cache_coordinator.py", line 563, in __init__
  | (EngineCore pid=1580) ERROR 08-05 15:59:27 [core.py:1345]     assert all(
  | (EngineCore pid=1580) ERROR 08-05 15:59:27 [core.py:1345]            ^^^^
  | (EngineCore pid=1580) ERROR 08-05 15:59:27 [core.py:1345] AssertionError: Each KV cache group's real block_size must be divisible by hash_block_size. block_sizes=[544, 544, 544, 544, 181], hash_block_size=98464
  | (EngineCore pid=1580) Process EngineCore:
  | (EngineCore pid=1580) Traceback (most recent call last):
  | (EngineCore pid=1580)   File "/usr/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
  | (EngineCore pid=1580)     self.run()
  | (EngineCore pid=1580)   File "/usr/lib/python3.12/multiprocessing/process.py", line 108, in run
  | (EngineCore pid=1580)     self._target(*self._args, **self._kwargs)
  | (EngineCore pid=1580)   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 1349, in run_engine_core
  | (EngineCore pid=1580)     raise e
  | (EngineCore pid=1580)   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 1314, in run_engine_core
  | (EngineCore pid=1580)     engine_core = EngineCoreProc(*args, engine_index=dp_rank, **kwargs)
  | (EngineCore pid=1580)                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore pid=1580)   File "/usr/local/lib/python3.12/dist-packages/vllm/tracing/otel.py", line 178, in sync_wrapper
  | (EngineCore pid=1580)     return func(*args, **kwargs)
  | (EngineCore pid=1580)            ^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore pid=1580)   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 1070, in __init__
  | (EngineCore pid=1580)     super().__init__(
  | (EngineCore pid=1580)   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 160, in __init__
  | (EngineCore pid=1580)     self.scheduler: SchedulerInterface = Scheduler(
  | (EngineCore pid=1580)                                          ^^^^^^^^^^
  | (EngineCore pid=1580)   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/core/sched/async_scheduler.py", line 14, in __init__
  | (EngineCore pid=1580)     super().__init__(*args, **kwargs)
  | (EngineCore pid=1580)   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/core/sched/scheduler.py", line 277, in __init__
  | (EngineCore pid=1580)     self.kv_cache_manager = KVCacheManager(
  | (EngineCore pid=1580)                             ^^^^^^^^^^^^^^^
  | (EngineCore pid=1580)   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/core/kv_cache_manager.py", line 151, in __init__
  | (EngineCore pid=1580)     self.coordinator = get_kv_cache_coordinator(
  | (EngineCore pid=1580)                        ^^^^^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore pid=1580)   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/core/kv_cache_coordinator.py", line 891, in get_kv_cache_coordinator
  | (EngineCore pid=1580)     return HybridKVCacheCoordinator(
  | (EngineCore pid=1580)            ^^^^^^^^^^^^^^^^^^^^^^^^^
  | (EngineCore pid=1580)   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/core/kv_cache_coordinator.py", line 563, in __init__
  | (EngineCore pid=1580)     assert all(
  | (EngineCore pid=1580)            ^^^^
  | (EngineCore pid=1580) AssertionError: Each KV cache group's real block_size must be divisible by hash_block_size. block_sizes=[544, 544, 544, 544, 181], hash_block_size=98464
  | [rank0]:[W805 15:59:27.910053250 ProcessGroupNCCL.cpp:1624] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
  | INFO 08-05 15:59:28 [utils.py:612] [shutdown] Process manager: send sigterm to process EngineCore
  | FAILED
  | v1/kv_connector/extract_hidden_states_integration/test_extraction.py::test_extract_hidden_states_tp2 SKIPPED (Need at least 2 GPUs to run the test.)


```
