### PR TITLE
[Bugfix] [Build] Fix DeepGEMM SM90 paged mqa `prefix_sum` out of range

### DIFF
--- a/cmake/external_projects/deepgemm.cmake
+++ b/cmake/external_projects/deepgemm.cmake
@@ -28,9 +28,9 @@ if(DEEPGEMM_SRC_DIR)
   message(STATUS "DeepGEMM using local DEEPGEMM_SRC_DIR: ${deepgemm_SOURCE_DIR}")
 else()
   # Keep in sync with tools/install_deepgemm.sh
-  set(_DEEPGEMM_UPSTREAM_REPO "https://github.com/vllm-project/DeepGEMM.git")
+  set(_DEEPGEMM_UPSTREAM_REPO "https://github.com/cjackal/DeepGEMM.git")
   # TODO: switch to nv_dev branch after it support situ
-  set(_DEEPGEMM_UPSTREAM_TAG "e21c821f39a2056d68067a466c64ddc942200106")
+  set(_DEEPGEMM_UPSTREAM_TAG "9797377b026d61d9aee3c801e3154ecf1a069d6b")
 
   set(_deepgemm_fc_root "${FETCHCONTENT_BASE_DIR}")
   if(NOT _deepgemm_fc_root)

--- a/tools/install_deepgemm.sh
+++ b/tools/install_deepgemm.sh
@@ -6,9 +6,9 @@ set -e
 
 # Default values
 # Keep DEEPGEMM_GIT_REF in sync with cmake/external_projects/deepgemm.cmake
-DEEPGEMM_GIT_REPO="https://github.com/vllm-project/DeepGEMM.git"
+DEEPGEMM_GIT_REPO="https://github.com/cjackal/DeepGEMM.git"
 # NOTE: This is currently targeting nv-dev branch due to sm120 support
-DEEPGEMM_GIT_REF="e21c821f39a2056d68067a466c64ddc942200106"
+DEEPGEMM_GIT_REF="9797377b026d61d9aee3c801e3154ecf1a069d6b"
 WHEEL_DIR=""
 
 # Parse command line arguments


### PR DESCRIPTION



## Purpose

Fix #51181.

DeepGEMM SM90 paged mqa logit contains an out-of-index error which is easily hit in common device setup (DeepSeek V4 DSpark on H100 and common `max-num-seqs`). This PR prevents the out-of-index error (`CUDBG_EXCEPTION_WARP_OUT_OF_RANGE_ADDRESS` on CUDA coredump) by building DeepGEMM from bugfixed branch (vllm-project/DeepGEMM#2).

**TODO**: rollback the DeepGEMM repo to vllm-project after vllm-project/DeepGEMM#2 merged.

## Test Plan

Run the reproducer in #51181 and check that CUDA graph capture runs successfully.

## Test Result

I have checked the validity of the referred DeepGEMM fork branch by installing the source-built DeepGEMM wheel atop of latest(beca88e) main CI image and run the reproducer in #51181.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

