### PR TITLE
[AMD][K3] Write KDA decode output straight into the layer buffer

### DIFF
--- a/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
@@ -517,6 +517,9 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
 
         # ---------- non-spec path (prefill or plain decode) ----------
         core_attn_out_non_spec = None
+        # Set when the decode kernel writes straight into core_attn_out, so the
+        # merge below knows there is nothing left to copy.
+        decode_out: torch.Tensor | None = None
         if mixed_qkv_ns is not None:
             assert g1_ns is not None and beta_ns is not None
             if m.num_prefills > 0:
@@ -604,6 +607,11 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                     validate_data=True,
                     out=packed_conv_out,
                 )
+                # With no spec output to interleave, these tokens already occupy
+                # core_attn_out in order, so the kernel can target it directly
+                # rather than allocating and having the merge copy it across.
+                if core_attn_out_spec is None:
+                    decode_out = core_attn_out[:, :num_actual_tokens]
                 core_attn_out_non_spec, _ = fused_recurrent_kda_packed_decode(
                     mixed_qkv=mixed_qkv_ns,
                     raw_g=g1_ns,
@@ -613,6 +621,7 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                     lower_bound=self.gate_lower_bound,
                     initial_state=recurrent_state,
                     state_indices=decode_conv_indices,
+                    out=decode_out,
                 )
 
         # ---------- merge spec and non-spec outputs ----------
@@ -627,9 +636,10 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
             merged.index_copy_(1, non_spec_token_indx, core_attn_out_non_spec)
             core_attn_out[0, :num_actual_tokens] = merged[0, :num_actual_tokens]
         elif core_attn_out_non_spec is not None:
-            core_attn_out[0, :num_actual_tokens] = core_attn_out_non_spec[
-                0, :num_actual_tokens
-            ]
+            if decode_out is None:
+                core_attn_out[0, :num_actual_tokens] = core_attn_out_non_spec[
+                    0, :num_actual_tokens
+                ]
         else:
             assert core_attn_out_spec is not None
         core_attn_out.copy_(self.o_norm(core_attn_out, g2))

--- a/vllm/models/kimi_k3/amd/kda.py
+++ b/vllm/models/kimi_k3/amd/kda.py
@@ -365,6 +365,9 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
 
         # ---------- non-spec path (prefill or plain decode) ----------
         core_attn_out_non_spec = None
+        # Set when the decode kernel writes straight into core_attn_out, so the
+        # merge below knows there is nothing left to copy.
+        decode_out: torch.Tensor | None = None
         if mixed_qkv_ns is not None:
             assert g1_ns is not None and beta_ns is not None
             if m.num_prefills > 0:
@@ -499,6 +502,11 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
                     validate_data=True,
                     out=packed_conv_out,
                 )
+                # With no spec output to interleave, these tokens already occupy
+                # core_attn_out in order, so the kernel can target it directly
+                # rather than allocating and having the merge copy it across.
+                if core_attn_out_spec is None:
+                    decode_out = core_attn_out[:, :num_actual_tokens]
                 core_attn_out_non_spec, _ = fused_recurrent_kda_packed_decode(
                     mixed_qkv=mixed_qkv_ns,
                     raw_g=g1_ns,
@@ -508,6 +516,7 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
                     lower_bound=self.gate_lower_bound,
                     initial_state=recurrent_state,
                     state_indices=decode_conv_indices,
+                    out=decode_out,
                 )
 
         # ---------- merge spec and non-spec outputs ----------
@@ -522,9 +531,10 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
             merged.index_copy_(1, non_spec_token_indx, core_attn_out_non_spec)
             core_attn_out[0, :num_actual_tokens] = merged[0, :num_actual_tokens]
         elif core_attn_out_non_spec is not None:
-            core_attn_out[0, :num_actual_tokens] = core_attn_out_non_spec[
-                0, :num_actual_tokens
-            ]
+            if decode_out is None:
+                core_attn_out[0, :num_actual_tokens] = core_attn_out_non_spec[
+                    0, :num_actual_tokens
+                ]
         else:
             assert core_attn_out_spec is not None
         core_attn_out.copy_(self.o_norm(core_attn_out, g2))

--- a/vllm/models/kimi_k3/amd/ops/third_party/kda/fused_recurrent.py
+++ b/vllm/models/kimi_k3/amd/ops/third_party/kda/fused_recurrent.py
@@ -543,8 +543,14 @@ def fused_recurrent_kda_packed_decode(
     initial_state: torch.Tensor,
     state_indices: torch.Tensor,
     scale: float | None = None,
+    out: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Run one-token KDA decode directly from packed post-conv QKV."""
+    """Run one-token KDA decode directly from packed post-conv QKV.
+
+    Pass ``out`` to write the result into a caller-owned buffer instead of a
+    fresh allocation, which lets the layer skip a copy when its output tensor is
+    already the final destination.
+    """
     if mixed_qkv.ndim != 2 or mixed_qkv.stride(-1) != 1:
         raise ValueError("`mixed_qkv` must be 2D and contiguous in its last dim.")
     if raw_g.ndim != 4 or raw_g.shape[0] != 1:
@@ -591,7 +597,21 @@ def fused_recurrent_kda_packed_decode(
     if scale is None:
         scale = K**-0.5
 
-    out = torch.empty((1, B, H, V), dtype=mixed_qkv.dtype, device=device)
+    if out is None:
+        out = torch.empty((1, B, H, V), dtype=mixed_qkv.dtype, device=device)
+    else:
+        # The kernel addresses the output as one dense [B, H, V] block and takes
+        # no output stride, so a caller-supplied buffer must match that layout.
+        if out.shape != (1, B, H, V):
+            raise ValueError(
+                f"`out` must have shape {(1, B, H, V)}, got {tuple(out.shape)}."
+            )
+        if out.dtype != mixed_qkv.dtype:
+            raise ValueError("`out` must have the same dtype as `mixed_qkv`.")
+        if out.device != device:
+            raise ValueError("`out` must be on the same device as the inputs.")
+        if not out.is_contiguous():
+            raise ValueError("`out` must be contiguous.")
     grid = (cdiv(V, BV), B * H)
     fused_recurrent_kda_packed_decode_kernel[grid](
         mixed_qkv=mixed_qkv,

--- a/vllm/models/kimi_k3/nvidia/ops/third_party/kda/fused_recurrent.py
+++ b/vllm/models/kimi_k3/nvidia/ops/third_party/kda/fused_recurrent.py
@@ -591,8 +591,14 @@ def fused_recurrent_kda_packed_decode(
     initial_state: torch.Tensor,
     state_indices: torch.Tensor,
     scale: float | None = None,
+    out: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Run one-token KDA decode directly from packed post-conv QKV."""
+    """Run one-token KDA decode directly from packed post-conv QKV.
+
+    Pass ``out`` to write the result into a caller-owned buffer instead of a
+    fresh allocation, which lets the layer skip a copy when its output tensor is
+    already the final destination.
+    """
     if mixed_qkv.ndim != 2 or mixed_qkv.stride(-1) != 1:
         raise ValueError("`mixed_qkv` must be 2D and contiguous in its last dim.")
     if raw_g.ndim != 4 or raw_g.shape[0] != 1:
@@ -639,7 +645,21 @@ def fused_recurrent_kda_packed_decode(
     if scale is None:
         scale = K**-0.5
 
-    out = torch.empty((1, B, H, V), dtype=mixed_qkv.dtype, device=device)
+    if out is None:
+        out = torch.empty((1, B, H, V), dtype=mixed_qkv.dtype, device=device)
+    else:
+        # The kernel addresses the output as one dense [B, H, V] block and takes
+        # no output stride, so a caller-supplied buffer must match that layout.
+        if out.shape != (1, B, H, V):
+            raise ValueError(
+                f"`out` must have shape {(1, B, H, V)}, got {tuple(out.shape)}."
+            )
+        if out.dtype != mixed_qkv.dtype:
+            raise ValueError("`out` must have the same dtype as `mixed_qkv`.")
+        if out.device != device:
+            raise ValueError("`out` must be on the same device as the inputs.")
+        if not out.is_contiguous():
+            raise ValueError("`out` must be contiguous.")
     grid = (cdiv(V, BV), B * H)
     fused_recurrent_kda_packed_decode_kernel[grid](
         mixed_qkv=mixed_qkv,


### PR DESCRIPTION
## Purpose
fused_recurrent_kda_packed_decode allocated its own output, so the layer then copied it into the core_attn_out buffer it had already allocated. Give the op an out= parameter and pass core_attn_out on the plain-decode path, which drops one device-to-device copy per KDA layer.

Only safe when there is no spec-decode output to interleave: that path places both halves via index_copy_ into a separate tensor, so it keeps its own buffer. The sibling fused_recurrent_kda already took out= this way.

## Test Plan
E2E perf tests
accuracy test using aiperf recipe

## Test Result
Measured on Kimi-K3 MXFP4, 8xMI355X, ISL 131072 / conc 16 decode: 615 of 1445 copyBuffer kernels removed and the KDA epilogue drops from 47.8 to 42.6 us per layer. Output and the in-place recurrent state are bitwise identical to the allocating path.

E2E AgentX for 8k1k cocn 1,8,16. 
<img width="270" height="119" alt="image" src="https://github.com/user-attachments/assets/8a347da4-41ed-49ec-a713-ad0db6698abb" />

E2E AgentX for 128k1k conc 16
<img width="269" height="71" alt="image" src="https://github.com/user-attachments/assets/9d2da380-3956-4c0e-92e1-0afa1936c790" />

Accuracy 
n-samples: {"original": 1319, "effective": 1319}
<img width="619" height="116" alt="image" src="https://github.com/user-attachments/assets/57d306a9-f354-44ba-8fae-eae6a3f90cf1" />


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

