### PR TITLE
[Bugfix] compressed-tensors: allow format=dense sparsity_config to load

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -288,7 +288,13 @@ class CompressedTensorsConfig(QuantizationConfig):
         sparsity_ignore_list = sparsity_config.ignore or list()
 
         # Raise DeprecationError if non-empty sparse_scheme_map is detected
-        if sparse_scheme_map:
+        # A ``format: dense`` sparsity_config carries only vestigial sparsity
+        # metadata (weights are stored dense) and loads fine as a normal
+        # quantized model, so only reject actually-sparse (compressed) formats.
+        if (
+            sparse_scheme_map
+            and sparsity_config.format != CompressionFormat.dense.value
+        ):
             raise DeprecationWarning(
                 "Sparsity support has been removed from compressed-tensors. "
                 "Please use a model without sparsity configuration."


### PR DESCRIPTION
## Purpose

FIX #51188

`CompressedTensorsConfig._parse_sparsity_config` raises for **any** `sparsity_config`
with non-empty `targets`, including `format: "dense"` configs. A dense sparsity_config
carries only vestigial sparsity **metadata** (weights are stored dense), so the model is
an ordinary quantized model that would load fine — but it is rejected with:

```
DeprecationWarning: Sparsity support has been removed from compressed-tensors.
Please use a model without sparsity configuration.
```

Sparse *inference* was intentionally removed (#42889 / #43144); this PR does **not**
re-add it. `from_config` calls `_parse_sparsity_config` purely for the raise side-effect
and **discards** the returned scheme map, so gating the raise on
`sparsity_config.format != CompressionFormat.dense.value` lets dense-metadata models load
as normal quantized models while still rejecting genuinely-sparse (compressed) formats.

Affected example: `RedHatAI/granite-3.1-8b-instruct-quantized.w4a16` (a `pack-quantized`
w4a16 model whose `sparsity_config.format` is `dense`).

## Test Plan

Patched onto a built vLLM wheel and exercised the exact code path plus a full serve.

## Test Result

- `from_config` on granite's real config: **before** → `DeprecationWarning`; **after** → returns `CompressedTensorsConfig`.
- Guard intact: a synthetic `sparse-24-bitmask` (2:4) config still raises `DeprecationWarning` after the change.
- Full serve on A100-80GB: `vllm serve RedHatAI/granite-3.1-8b-instruct-quantized.w4a16` reaches `Application startup complete`, `GET /health` → `200`, and `"The capital of France is"` → `" Paris."` — with zero `Sparsity support has been removed` in the log.

---
AI assistance (Claude Code) was used to author this change and drive validation; a human
reviewed every line, ran the tests above, and owns the change end-to-end.
