### PR TITLE
[Bugfix] compressed-tensors: allow format=dense sparsity_config to load (backport #51189 to v0.26.0)

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -288,7 +288,13 @@ class CompressedTensorsConfig(QuantizationConfig):
         sparsity_ignore_list = sparsity_config.ignore or list()
 
         # Raise DeprecationError if non-empty sparse_scheme_map is detected
-        if sparse_scheme_map:
+        # A ``format: dense`` sparsity_config carries only vestigial sparsity
+        # metadata (weights are stored dense) and loads fine as a normal
+        # quantized model, so only reject actually-sparse (compressed) formats.
+        if (
+            sparse_scheme_map
+            and sparsity_config.format != CompressionFormat.dense.value
+        ):
             raise DeprecationWarning(
                 "Sparsity support has been removed from compressed-tensors. "
                 "Please use a model without sparsity configuration."


### PR DESCRIPTION
## Purpose

Backport of #51189 to `releases/v0.26.0` (fixes #51188 on the 0.26.0 line).

`v0.26.0` includes the compressed-tensors sparse-inference removal, so
`_parse_sparsity_config` raises for **any** `sparsity_config` with non-empty
`targets` — including `format: "dense"` configs, which carry only vestigial
sparsity metadata (weights are stored dense). This rejects ordinary quantized
models such as `RedHatAI/granite-3.1-8b-instruct-quantized.w4a16`.

Identical one-file change as #51189: gate the raise on
`sparsity_config.format != CompressionFormat.dense.value`. It does not re-add
sparse inference (`from_config` discards the parsed sparse scheme map), so
dense-metadata models load as normal quantized models while genuinely-sparse
(compressed) formats are still rejected.

## Test Result (from #51189)
- `from_config` on granite's real config: before → `DeprecationWarning`; after → loads.
- Guard intact: synthetic `sparse-24-bitmask` (2:4) config still raises.
- Full serve on A100-80GB: `Application startup complete`, `/health` → 200, `"The capital of France is"` → `" Paris."`, zero sparsity errors.

---
AI assistance (Claude Code) was used to author this backport; a human reviewed
every line, ran the tests above, and owns the change end-to-end.
