### PR TITLE
[ROCm][MLA] Dispatch gfx942 verify to Gluon

### DIFF
--- a/tests/kernels/attention/test_rocm_aiter_mla_causal_verify_mask.py
+++ b/tests/kernels/attention/test_rocm_aiter_mla_causal_verify_mask.py
@@ -186,9 +186,15 @@ def _run_verify_block():
 
     # The Gluon kernel only reads the metadata this test is about, so a spy in
     # its place keeps the assertions independent of the AITER build.
-    with patch(
-        "vllm.v1.attention.backends.mla.rocm_aiter_mla._get_mla_gluon",
-        lambda: spy,
+    with (
+        patch(
+            "vllm.v1.attention.backends.mla.rocm_aiter_mla._gluon_mla_decode_supported",
+            lambda: True,
+        ),
+        patch(
+            "vllm.v1.attention.backends.mla.rocm_aiter_mla._get_mla_gluon",
+            lambda: spy,
+        ),
     ):
         impl.forward_mqa((q_nope, q_pe), kv_cache, metadata, layer=None)
 

--- a/tests/v1/attention/test_rocm_aiter_mla_gfx942_gluon.py
+++ b/tests/v1/attention/test_rocm_aiter_mla_gfx942_gluon.py
@@ -1,0 +1,283 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+import torch
+
+from vllm.v1.attention.backends.mla import rocm_aiter_mla
+from vllm.v1.attention.backends.mla.rocm_aiter_mla import (
+    AiterMLAHelper,
+    AiterMLAImpl,
+    _prepare_gluon_gfx942_graph_inputs,
+)
+
+NUM_HEADS = 12
+KV_LORA_RANK = 4
+QK_ROPE_HEAD_DIM = 2
+QLEN = 4
+NUM_REQS = 2
+
+
+def _impl():
+    return SimpleNamespace(
+        num_heads=NUM_HEADS,
+        kv_lora_rank=KV_LORA_RANK,
+        qk_rope_head_dim=QK_ROPE_HEAD_DIM,
+        scale=0.125,
+    )
+
+
+def _metadata(
+    *,
+    qlen: int = QLEN,
+    num_reqs: int = NUM_REQS,
+    output_dtype: torch.dtype = torch.bfloat16,
+):
+    return SimpleNamespace(
+        decode=SimpleNamespace(
+            max_qo_len=qlen,
+            paged_kv_indptr=torch.arange(0, num_reqs + 1, dtype=torch.int32),
+            paged_kv_indices=torch.arange(num_reqs, dtype=torch.int32),
+            paged_kv_last_page_len=torch.ones(num_reqs, dtype=torch.int32),
+            qo_indptr=torch.arange(
+                0,
+                (num_reqs + 1) * qlen,
+                step=qlen,
+                dtype=torch.int32,
+            ),
+            attn_out_dtype=output_dtype,
+            use_gluon_decode=False,
+            has_persistent_metadata=False,
+        ),
+        work_meta_data=None,
+    )
+
+
+def _inputs(
+    *,
+    qlen: int = QLEN,
+    num_reqs: int = NUM_REQS,
+    dtype: torch.dtype = torch.bfloat16,
+):
+    num_tokens = qlen * num_reqs
+    q_nope = (
+        torch.arange(
+            num_tokens * NUM_HEADS * KV_LORA_RANK,
+            dtype=torch.float32,
+        )
+        .reshape(num_tokens, NUM_HEADS, KV_LORA_RANK)
+        .to(dtype)
+    )
+    q_pe = (
+        torch.arange(
+            num_tokens * NUM_HEADS * QK_ROPE_HEAD_DIM,
+            dtype=torch.float32,
+        )
+        .reshape(num_tokens, NUM_HEADS, QK_ROPE_HEAD_DIM)
+        .to(dtype)
+    )
+    kv_cache = (
+        torch.arange(
+            3 * 2 * (KV_LORA_RANK + QK_ROPE_HEAD_DIM),
+            dtype=torch.float32,
+        )
+        .reshape(3, 2, KV_LORA_RANK + QK_ROPE_HEAD_DIM)
+        .to(dtype)
+    )
+    return q_nope, q_pe, kv_cache
+
+
+@pytest.mark.parametrize(
+    ("num_heads", "qlen", "num_reqs", "expected"),
+    [
+        (12, 1, 1, False),
+        (12, 2, 1, True),
+        (12, 3, 2, False),
+        (12, 4, 1, True),
+        (12, 4, 16, True),
+        (12, 4, 17, False),
+        (12, 8, 1, True),
+        (12, 9, 1, False),
+        (8, 4, 1, False),
+        (16, 4, 1, False),
+    ],
+)
+def test_gfx942_gluon_graph_shape_gate(num_heads, qlen, num_reqs, expected):
+    assert AiterMLAHelper.use_gluon_gfx942_graph(num_heads, qlen, num_reqs) is expected
+
+
+def test_existing_single_token_gluon_requires_gfx950(monkeypatch):
+    monkeypatch.setattr(rocm_aiter_mla, "_gluon_mla_decode_supported", lambda: False)
+    assert not AiterMLAHelper.use_gluon_decode(NUM_HEADS, 1)
+
+    monkeypatch.setattr(rocm_aiter_mla, "_gluon_mla_decode_supported", lambda: True)
+    assert AiterMLAHelper.use_gluon_decode(NUM_HEADS, 1)
+
+
+def test_nondivisor_head_padding_and_unpadding():
+    q = torch.arange(2 * NUM_HEADS * 3).reshape(2, NUM_HEADS, 3)
+    padded = AiterMLAHelper.get_mla_padded_q(NUM_HEADS, q)
+
+    assert padded.shape == (2, 16, 3)
+    torch.testing.assert_close(padded[:, :NUM_HEADS], q)
+    assert torch.count_nonzero(padded[:, NUM_HEADS:]) == 0
+
+    output = torch.arange(2 * 16 * 3).reshape(2, 16, 3)
+    unpadded = AiterMLAHelper.get_mla_unpadded_o(NUM_HEADS, output)
+    torch.testing.assert_close(unpadded, output[:, :NUM_HEADS])
+
+
+def test_gfx942_gluon_graph_normalizes_q_and_flattens_cache():
+    q_nope, q_pe, kv_cache = _inputs()
+
+    prepared = _prepare_gluon_gfx942_graph_inputs(
+        (q_nope, q_pe),
+        kv_cache,
+        NUM_REQS,
+        QLEN,
+        NUM_HEADS,
+        KV_LORA_RANK,
+        QK_ROPE_HEAD_DIM,
+    )
+
+    assert prepared is not None
+    graph_q_nope, graph_q_pe, graph_kv = prepared
+    assert graph_q_nope.shape == (
+        NUM_REQS,
+        QLEN,
+        NUM_HEADS,
+        KV_LORA_RANK,
+    )
+    assert graph_q_pe.shape == (
+        NUM_REQS,
+        QLEN,
+        NUM_HEADS,
+        QK_ROPE_HEAD_DIM,
+    )
+    assert graph_kv.shape == (
+        kv_cache.shape[0] * kv_cache.shape[1],
+        kv_cache.shape[-1],
+    )
+    assert graph_q_nope.data_ptr() == q_nope.data_ptr()
+    assert graph_q_pe.data_ptr() == q_pe.data_ptr()
+    assert graph_kv.data_ptr() == kv_cache.data_ptr()
+
+
+def test_gfx942_gluon_graph_passes_ragged_metadata_directly(monkeypatch):
+    q_nope, q_pe, kv_cache = _inputs()
+    metadata = _metadata()
+    graph = mock.Mock(side_effect=lambda *args: args[3].fill_(7))
+
+    monkeypatch.setattr(rocm_aiter_mla, "_on_gfx942", lambda: True)
+    monkeypatch.setattr(
+        rocm_aiter_mla,
+        "_get_mla_gluon_gfx942_graph",
+        lambda: graph,
+    )
+
+    output, output_lse = AiterMLAImpl.forward_mqa(
+        _impl(),
+        (q_nope, q_pe),
+        kv_cache,
+        metadata,
+        layer=None,
+    )
+
+    assert output_lse is None
+    assert output.shape == (
+        NUM_REQS * QLEN,
+        NUM_HEADS,
+        KV_LORA_RANK,
+    )
+    assert torch.all(output == 7)
+    graph_q_nope, graph_q_pe, graph_kv, graph_o, page_table, seq_info, scale = (
+        graph.call_args.args
+    )
+    assert graph_q_nope.shape == (
+        NUM_REQS,
+        QLEN,
+        NUM_HEADS,
+        KV_LORA_RANK,
+    )
+    assert graph_q_pe.shape == (
+        NUM_REQS,
+        QLEN,
+        NUM_HEADS,
+        QK_ROPE_HEAD_DIM,
+    )
+    assert graph_kv.shape == (
+        kv_cache.shape[0] * kv_cache.shape[1],
+        kv_cache.shape[-1],
+    )
+    assert graph_o.shape == (
+        NUM_REQS,
+        QLEN,
+        NUM_HEADS,
+        KV_LORA_RANK,
+    )
+    assert page_table is metadata.decode.paged_kv_indices
+    assert seq_info is metadata.decode.paged_kv_indptr
+    assert scale == _impl().scale
+
+
+@pytest.mark.parametrize(
+    "unsupported",
+    ["architecture", "symbol", "dtype", "shape"],
+)
+def test_gfx942_gluon_graph_unsupported_cases_fall_back(monkeypatch, unsupported):
+    dtype = torch.float16 if unsupported == "dtype" else torch.bfloat16
+    q_nope, q_pe, kv_cache = _inputs(dtype=dtype)
+    if unsupported == "shape":
+        q_pe = q_pe[..., :-1]
+
+    graph = mock.Mock()
+    asm = mock.Mock()
+    monkeypatch.setattr(
+        rocm_aiter_mla,
+        "_on_gfx942",
+        lambda: unsupported != "architecture",
+    )
+    monkeypatch.setattr(
+        rocm_aiter_mla,
+        "_get_mla_gluon_gfx942_graph",
+        lambda: None if unsupported == "symbol" else graph,
+    )
+    monkeypatch.setattr(rocm_aiter_mla.rocm_aiter_ops, "mla_decode_fwd", asm)
+
+    AiterMLAImpl.forward_mqa(
+        _impl(),
+        (q_nope, q_pe),
+        kv_cache,
+        _metadata(),
+        layer=SimpleNamespace(_q_scale=None, _k_scale=None),
+    )
+
+    graph.assert_not_called()
+    asm.assert_called_once()
+
+
+def test_gfx942_gluon_graph_runtime_errors_propagate(monkeypatch):
+    q_nope, q_pe, kv_cache = _inputs()
+    asm = mock.Mock()
+
+    monkeypatch.setattr(rocm_aiter_mla, "_on_gfx942", lambda: True)
+    monkeypatch.setattr(
+        rocm_aiter_mla,
+        "_get_mla_gluon_gfx942_graph",
+        lambda: mock.Mock(side_effect=RuntimeError("kernel failed")),
+    )
+    monkeypatch.setattr(rocm_aiter_mla.rocm_aiter_ops, "mla_decode_fwd", asm)
+
+    with pytest.raises(RuntimeError, match="kernel failed"):
+        AiterMLAImpl.forward_mqa(
+            _impl(),
+            (q_nope, q_pe),
+            kv_cache,
+            _metadata(),
+            layer=SimpleNamespace(_q_scale=None, _k_scale=None),
+        )
+
+    asm.assert_not_called()

--- a/tests/v1/attention/test_rocm_aiter_mla_gfx942_gluon.py
+++ b/tests/v1/attention/test_rocm_aiter_mla_gfx942_gluon.py
@@ -109,21 +109,26 @@ def test_gfx942_gluon_graph_shape_gate(num_heads, qlen, num_reqs, expected):
     assert AiterMLAHelper.use_gluon_gfx942_graph(num_heads, qlen, num_reqs) is expected
 
 
-def test_existing_single_token_gluon_requires_gfx950(monkeypatch):
+def test_existing_single_token_gluon_respects_small_head_mode(monkeypatch):
     monkeypatch.setattr(rocm_aiter_mla, "_gluon_mla_decode_supported", lambda: False)
     assert not AiterMLAHelper.use_gluon_decode(NUM_HEADS, 1)
 
     monkeypatch.setattr(rocm_aiter_mla, "_gluon_mla_decode_supported", lambda: True)
+    monkeypatch.setattr(rocm_aiter_mla, "_aiter_mla_small_head_mode", lambda: "auto")
+    assert not AiterMLAHelper.use_gluon_decode(NUM_HEADS, 1)
+
+    monkeypatch.setattr(rocm_aiter_mla, "_aiter_mla_small_head_mode", lambda: "gluon")
     assert AiterMLAHelper.use_gluon_decode(NUM_HEADS, 1)
 
 
-def test_nondivisor_head_padding_and_unpadding():
+def test_nondivisor_head_tile_padding_and_unpadding():
     q = torch.arange(2 * NUM_HEADS * 3).reshape(2, NUM_HEADS, 3)
     padded = AiterMLAHelper.get_mla_padded_q(NUM_HEADS, q)
 
     assert padded.shape == (2, 16, 3)
+    assert padded.is_contiguous()
     torch.testing.assert_close(padded[:, :NUM_HEADS], q)
-    assert torch.count_nonzero(padded[:, NUM_HEADS:]) == 0
+    torch.testing.assert_close(padded[:, NUM_HEADS:], q[:, :4])
 
     output = torch.arange(2 * 16 * 3).reshape(2, 16, 3)
     unpadded = AiterMLAHelper.get_mla_unpadded_o(NUM_HEADS, output)

--- a/tests/v1/attention/test_rocm_aiter_mla_gfx942_gluon.py
+++ b/tests/v1/attention/test_rocm_aiter_mla_gfx942_gluon.py
@@ -180,7 +180,7 @@ def test_gfx942_gluon_graph_passes_ragged_metadata_directly(monkeypatch):
     monkeypatch.setattr(rocm_aiter_mla, "_aiter_mla_small_head_mode", lambda: "auto")
     monkeypatch.setattr(
         rocm_aiter_mla,
-        "_get_mla_gluon_gfx942_graph",
+        "_get_mla_gluon_gfx942",
         lambda: graph,
     )
 
@@ -253,7 +253,7 @@ def test_gfx942_gluon_graph_unsupported_cases_fall_back(monkeypatch, unsupported
     )
     monkeypatch.setattr(
         rocm_aiter_mla,
-        "_get_mla_gluon_gfx942_graph",
+        "_get_mla_gluon_gfx942",
         lambda: None if unsupported == "symbol" else graph,
     )
     monkeypatch.setattr(rocm_aiter_mla.rocm_aiter_ops, "mla_decode_fwd", asm)
@@ -278,7 +278,7 @@ def test_gfx942_gluon_graph_runtime_errors_propagate(monkeypatch):
     monkeypatch.setattr(rocm_aiter_mla, "_aiter_mla_small_head_mode", lambda: "auto")
     monkeypatch.setattr(
         rocm_aiter_mla,
-        "_get_mla_gluon_gfx942_graph",
+        "_get_mla_gluon_gfx942",
         lambda: mock.Mock(side_effect=RuntimeError("kernel failed")),
     )
     monkeypatch.setattr(rocm_aiter_mla.rocm_aiter_ops, "mla_decode_fwd", asm)

--- a/tests/v1/attention/test_rocm_aiter_mla_gfx942_gluon.py
+++ b/tests/v1/attention/test_rocm_aiter_mla_gfx942_gluon.py
@@ -177,6 +177,7 @@ def test_gfx942_gluon_graph_passes_ragged_metadata_directly(monkeypatch):
     graph = mock.Mock(side_effect=lambda *args: args[3].fill_(7))
 
     monkeypatch.setattr(rocm_aiter_mla, "_on_gfx942", lambda: True)
+    monkeypatch.setattr(rocm_aiter_mla, "_aiter_mla_small_head_mode", lambda: "auto")
     monkeypatch.setattr(
         rocm_aiter_mla,
         "_get_mla_gluon_gfx942_graph",
@@ -230,7 +231,7 @@ def test_gfx942_gluon_graph_passes_ragged_metadata_directly(monkeypatch):
 
 @pytest.mark.parametrize(
     "unsupported",
-    ["architecture", "symbol", "dtype", "shape"],
+    ["architecture", "symbol", "dtype", "shape", "force_asm"],
 )
 def test_gfx942_gluon_graph_unsupported_cases_fall_back(monkeypatch, unsupported):
     dtype = torch.float16 if unsupported == "dtype" else torch.bfloat16
@@ -244,6 +245,11 @@ def test_gfx942_gluon_graph_unsupported_cases_fall_back(monkeypatch, unsupported
         rocm_aiter_mla,
         "_on_gfx942",
         lambda: unsupported != "architecture",
+    )
+    monkeypatch.setattr(
+        rocm_aiter_mla,
+        "_aiter_mla_small_head_mode",
+        lambda: "asm" if unsupported == "force_asm" else "auto",
     )
     monkeypatch.setattr(
         rocm_aiter_mla,
@@ -269,6 +275,7 @@ def test_gfx942_gluon_graph_runtime_errors_propagate(monkeypatch):
     asm = mock.Mock()
 
     monkeypatch.setattr(rocm_aiter_mla, "_on_gfx942", lambda: True)
+    monkeypatch.setattr(rocm_aiter_mla, "_aiter_mla_small_head_mode", lambda: "auto")
     monkeypatch.setattr(
         rocm_aiter_mla,
         "_get_mla_gluon_gfx942_graph",

--- a/tests/v1/attention/test_rocm_aiter_mla_gfx942_gluon.py
+++ b/tests/v1/attention/test_rocm_aiter_mla_gfx942_gluon.py
@@ -27,6 +27,7 @@ def _impl():
         kv_lora_rank=KV_LORA_RANK,
         qk_rope_head_dim=QK_ROPE_HEAD_DIM,
         scale=0.125,
+        kv_cache_dtype="auto",
     )
 
 
@@ -111,14 +112,14 @@ def test_gfx942_gluon_graph_shape_gate(num_heads, qlen, num_reqs, expected):
 
 def test_existing_single_token_gluon_respects_small_head_mode(monkeypatch):
     monkeypatch.setattr(rocm_aiter_mla, "_gluon_mla_decode_supported", lambda: False)
-    assert not AiterMLAHelper.use_gluon_decode(NUM_HEADS, 1)
+    assert not AiterMLAHelper.use_gluon_decode(NUM_HEADS, 1, "auto")
 
     monkeypatch.setattr(rocm_aiter_mla, "_gluon_mla_decode_supported", lambda: True)
     monkeypatch.setattr(rocm_aiter_mla, "_aiter_mla_small_head_mode", lambda: "auto")
-    assert not AiterMLAHelper.use_gluon_decode(NUM_HEADS, 1)
+    assert not AiterMLAHelper.use_gluon_decode(NUM_HEADS, 1, "auto")
 
     monkeypatch.setattr(rocm_aiter_mla, "_aiter_mla_small_head_mode", lambda: "gluon")
-    assert AiterMLAHelper.use_gluon_decode(NUM_HEADS, 1)
+    assert AiterMLAHelper.use_gluon_decode(NUM_HEADS, 1, "auto")
 
 
 def test_nondivisor_head_tile_padding_and_unpadding():

--- a/tests/v1/attention/test_rocm_aiter_mla_gfx942_gluon.py
+++ b/tests/v1/attention/test_rocm_aiter_mla_gfx942_gluon.py
@@ -175,13 +175,13 @@ def test_gfx942_gluon_graph_normalizes_q_and_flattens_cache():
 def test_gfx942_gluon_graph_passes_ragged_metadata_directly(monkeypatch):
     q_nope, q_pe, kv_cache = _inputs()
     metadata = _metadata()
-    graph = mock.Mock(side_effect=lambda *args: args[3].fill_(7))
+    graph = mock.Mock(side_effect=lambda *args, **kwargs: args[2].fill_(7))
 
     monkeypatch.setattr(rocm_aiter_mla, "_on_gfx942", lambda: True)
     monkeypatch.setattr(rocm_aiter_mla, "_aiter_mla_small_head_mode", lambda: "auto")
     monkeypatch.setattr(
         rocm_aiter_mla,
-        "_get_mla_gluon_gfx942",
+        "_get_triton_mla_decode_fwd",
         lambda: graph,
     )
 
@@ -200,9 +200,11 @@ def test_gfx942_gluon_graph_passes_ragged_metadata_directly(monkeypatch):
         KV_LORA_RANK,
     )
     assert torch.all(output == 7)
-    graph_q_nope, graph_q_pe, graph_kv, graph_o, page_table, seq_info, scale = (
-        graph.call_args.args
-    )
+    _, graph_kv, graph_o, _, _, _, _, scale, _, _, _, _, _ = graph.call_args.args
+    graph_q_nope = graph.call_args.kwargs["q_nope"]
+    graph_q_pe = graph.call_args.kwargs["q_pe"]
+    page_table = graph.call_args.kwargs["page_table"]
+    seq_info = graph.call_args.kwargs["seq_info"]
     assert graph_q_nope.shape == (
         NUM_REQS,
         QLEN,
@@ -254,7 +256,7 @@ def test_gfx942_gluon_graph_unsupported_cases_fall_back(monkeypatch, unsupported
     )
     monkeypatch.setattr(
         rocm_aiter_mla,
-        "_get_mla_gluon_gfx942",
+        "_get_triton_mla_decode_fwd",
         lambda: None if unsupported == "symbol" else graph,
     )
     monkeypatch.setattr(rocm_aiter_mla.rocm_aiter_ops, "mla_decode_fwd", asm)
@@ -279,7 +281,7 @@ def test_gfx942_gluon_graph_runtime_errors_propagate(monkeypatch):
     monkeypatch.setattr(rocm_aiter_mla, "_aiter_mla_small_head_mode", lambda: "auto")
     monkeypatch.setattr(
         rocm_aiter_mla,
-        "_get_mla_gluon_gfx942",
+        "_get_triton_mla_decode_fwd",
         lambda: mock.Mock(side_effect=RuntimeError("kernel failed")),
     )
     monkeypatch.setattr(rocm_aiter_mla.rocm_aiter_ops, "mla_decode_fwd", asm)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1304,9 +1304,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # the Gluon small-head kernel or through the padded persistent-scheduling
     # (PS) ASM kernel. "auto" (default) keeps Gluon for head counts that divide
     # 16 where a Gluon build exists (gfx950/CDNA4) and otherwise uses the padded
-    # PS ASM decode; "gluon" forces the Gluon path wherever a build exists;
-    # "asm" forces the padded PS ASM decode. On gfx942/CDNA3 there is no Gluon
-    # build, so the ASM path is always used regardless of this setting.
+    # PS ASM decode, except for validated gfx942 12-head multi-token shapes that
+    # use the graph-safe Gluon path; "gluon" prefers available Gluon paths;
+    # "asm" forces the padded PS ASM decode for all shapes.
     "VLLM_ROCM_AITER_MLA_ASM_PADDING": env_with_choices(
         "VLLM_ROCM_AITER_MLA_ASM_PADDING",
         "auto",

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -895,7 +895,7 @@ def _prepare_gluon_gfx942_graph_inputs(
     kv_lora_rank: int,
     qk_rope_head_dim: int,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None:
-    if type(q) is tuple:
+    if isinstance(q, tuple):
         q_nope, q_pe = q
     else:
         expected_q_dim = kv_lora_rank + qk_rope_head_dim

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -43,7 +43,7 @@ def _on_gfx942() -> bool:
 @functools.lru_cache(maxsize=1)
 def _get_mla_gluon_gfx942_graph() -> Callable[..., torch.Tensor] | None:
     """Load the graph-safe gfx942 Gluon MLA entry point when available."""
-    module_name = "aiter.ops.triton.gluon.mla_gluon_gfx942"
+    module_name = "aiter.ops.triton.attention.mla"
     try:
         module = importlib.import_module(module_name)
     except ModuleNotFoundError as import_error:

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import functools
+import importlib
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import ClassVar, Final
 
@@ -32,6 +34,26 @@ logger = init_logger(__name__)
 
 
 @functools.lru_cache(maxsize=1)
+def _on_gfx942() -> bool:
+    from vllm.platforms.rocm import on_gfx942
+
+    return on_gfx942()
+
+
+@functools.lru_cache(maxsize=1)
+def _get_mla_gluon_gfx942_graph() -> Callable[..., torch.Tensor] | None:
+    """Load the graph-safe gfx942 Gluon MLA entry point when available."""
+    module_name = "aiter.ops.triton.gluon.mla_gluon_gfx942"
+    try:
+        module = importlib.import_module(module_name)
+    except ModuleNotFoundError as import_error:
+        if not module_name.startswith(import_error.name or ""):
+            raise
+        return None
+    return getattr(module, "mla_gluon_gfx942_graph", None)
+
+
+@functools.lru_cache(maxsize=1)
 def _get_mla_gluon():
     """Load the small-head Gluon MLA entry point."""
     unified_module = "aiter.ops.triton.gluon.mla_gluon"
@@ -55,6 +77,17 @@ def _get_mla_gluon():
                 "Gluon MLA kernel (mla_gluon or mla_decode_gluon) when decode "
                 "heads are fewer than 16."
             ) from unified_import_error
+
+
+@functools.lru_cache(maxsize=1)
+def _gluon_mla_decode_supported() -> bool:
+    """The existing small-head Gluon MLA kernel requires CDNA4."""
+    try:
+        from vllm.platforms.rocm import on_gfx950
+
+        return on_gfx950()
+    except ImportError:
+        return False
 
 
 @functools.lru_cache(maxsize=1)
@@ -781,12 +814,13 @@ def _expand_page_indices_kernel(
 
 class AiterMLAHelper:
     """
-    AITER MLA implementation requires num_heads >= 16. If num_heads < 16 and
-    16 % num_heads == 0, we can pad q to 16 heads; otherwise AITER has to fail.
+    AITER MLA implementation requires num_heads >= 16. Fewer heads use Gluon
+    where supported or are padded to 16 for persistent ASM decode.
     """
 
     _AITER_MIN_MLA_HEADS: Final = 16
     _AITER_UNSUPPORTED_HEADS: ClassVar[tuple[int, ...]] = ()
+    _GLUON_GFX942_GRAPH_HEADS: Final = 12
 
     @staticmethod
     def check_num_heads_validity(num_heads: int):
@@ -808,26 +842,83 @@ class AiterMLAHelper:
         return max(num_heads, AiterMLAHelper._AITER_MIN_MLA_HEADS)
 
     @staticmethod
+    def _pads_by_replication(num_heads: int) -> bool:
+        return AiterMLAHelper._AITER_MIN_MLA_HEADS % num_heads == 0
+
+    @staticmethod
     def get_mla_padded_q(num_heads: int, q: torch.Tensor) -> torch.Tensor:
-        return (
-            q
-            if num_heads >= AiterMLAHelper._AITER_MIN_MLA_HEADS
-            else q.repeat_interleave(
-                AiterMLAHelper._AITER_MIN_MLA_HEADS // num_heads, dim=1
-            )
-        )
+        min_heads = AiterMLAHelper._AITER_MIN_MLA_HEADS
+        if num_heads >= min_heads:
+            return q
+        if AiterMLAHelper._pads_by_replication(num_heads):
+            return q.repeat_interleave(min_heads // num_heads, dim=1)
+        return torch.nn.functional.pad(q, (0, 0, 0, min_heads - num_heads))
 
     @staticmethod
     def get_mla_unpadded_o(num_heads: int, o: torch.Tensor) -> torch.Tensor:
-        return (
-            o
-            if num_heads >= AiterMLAHelper._AITER_MIN_MLA_HEADS
-            else o[:, :: AiterMLAHelper._AITER_MIN_MLA_HEADS // num_heads, :]
-        )
+        min_heads = AiterMLAHelper._AITER_MIN_MLA_HEADS
+        if num_heads >= min_heads:
+            return o
+        if AiterMLAHelper._pads_by_replication(num_heads):
+            return o[:, :: min_heads // num_heads, :]
+        return o[:, :num_heads, :]
 
     @staticmethod
     def use_gluon_decode(num_heads: int, max_qo_len: int) -> bool:
-        return num_heads < AiterMLAHelper._AITER_MIN_MLA_HEADS and max_qo_len == 1
+        return (
+            num_heads < AiterMLAHelper._AITER_MIN_MLA_HEADS
+            and max_qo_len == 1
+            and _gluon_mla_decode_supported()
+        )
+
+    @staticmethod
+    def use_gluon_gfx942_graph(
+        num_heads: int,
+        max_qo_len: int,
+        num_reqs: int,
+    ) -> bool:
+        if num_heads != AiterMLAHelper._GLUON_GFX942_GRAPH_HEADS:
+            return False
+        if not 2 <= max_qo_len <= 8:
+            return False
+        if max_qo_len == 4:
+            return 1 <= num_reqs <= 16
+        return num_reqs == 1
+
+
+def _prepare_gluon_gfx942_graph_inputs(
+    q: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+    kv_c_and_k_pe_cache: torch.Tensor,
+    num_reqs: int,
+    qlen: int,
+    num_heads: int,
+    kv_lora_rank: int,
+    qk_rope_head_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None:
+    if type(q) is tuple:
+        q_nope, q_pe = q
+    else:
+        expected_q_dim = kv_lora_rank + qk_rope_head_dim
+        if q.ndim != 3 or q.shape[-1] != expected_q_dim:
+            return None
+        q_nope, q_pe = torch.split(q, [kv_lora_rank, qk_rope_head_dim], dim=-1)
+
+    num_tokens = num_reqs * qlen
+    if (
+        q_nope.shape != (num_tokens, num_heads, kv_lora_rank)
+        or q_pe.shape != (num_tokens, num_heads, qk_rope_head_dim)
+        or q_nope.dtype != torch.bfloat16
+        or q_pe.dtype != torch.bfloat16
+        or kv_c_and_k_pe_cache.dtype != torch.bfloat16
+        or kv_c_and_k_pe_cache.ndim < 2
+        or kv_c_and_k_pe_cache.shape[-1] != kv_lora_rank + qk_rope_head_dim
+    ):
+        return None
+
+    q_nope = q_nope.reshape(num_reqs, qlen, num_heads, kv_lora_rank)
+    q_pe = q_pe.reshape(num_reqs, qlen, num_heads, qk_rope_head_dim)
+    kv_buffer = kv_c_and_k_pe_cache.reshape(-1, kv_c_and_k_pe_cache.shape[-1])
+    return q_nope, q_pe, kv_buffer
 
 
 class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
@@ -1073,6 +1164,50 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
         assert decode.max_qo_len is not None
         assert decode.paged_kv_indptr is not None
         assert decode.paged_kv_indices is not None
+        qlen = int(decode.max_qo_len)
+        num_reqs = decode.paged_kv_indptr.shape[0] - 1
+        # Keep single-token decode on its existing path. This graph-safe kernel
+        # owns only the validated gfx942 BF16 multi-token shapes.
+        if (
+            _on_gfx942()
+            and decode.attn_out_dtype == torch.bfloat16
+            and AiterMLAHelper.use_gluon_gfx942_graph(self.num_heads, qlen, num_reqs)
+        ):
+            mla_gluon_gfx942_graph = _get_mla_gluon_gfx942_graph()
+            graph_inputs = _prepare_gluon_gfx942_graph_inputs(
+                q,
+                kv_c_and_k_pe_cache,
+                num_reqs,
+                qlen,
+                self.num_heads,
+                self.kv_lora_rank,
+                self.qk_rope_head_dim,
+            )
+            if mla_gluon_gfx942_graph is not None and graph_inputs is not None:
+                q_nope, q_pe, kv_buffer = graph_inputs
+                o = torch.empty(
+                    num_reqs,
+                    qlen,
+                    self.num_heads,
+                    self.kv_lora_rank,
+                    dtype=decode.attn_out_dtype,
+                    device=q_nope.device,
+                )
+                mla_gluon_gfx942_graph(
+                    q_nope,
+                    q_pe,
+                    kv_buffer,
+                    o,
+                    decode.paged_kv_indices,
+                    decode.paged_kv_indptr,
+                    self.scale,
+                )
+                return o.reshape(
+                    num_reqs * qlen,
+                    self.num_heads,
+                    self.kv_lora_rank,
+                ), None
+
         if decode.use_gluon_decode:
             if type(q) is tuple:
                 q_nope, q_pe = q
@@ -1116,6 +1251,7 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
         if (
             self.num_heads < AiterMLAHelper._AITER_MIN_MLA_HEADS
             and int(decode.max_qo_len) > 1
+            and _gluon_mla_decode_supported()
         ):
             qlen = int(decode.max_qo_len)
             if type(q) is tuple:

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -44,7 +44,7 @@ def _on_gfx942() -> bool:
 @functools.lru_cache(maxsize=1)
 def _get_mla_gluon_gfx942_graph() -> Callable[..., torch.Tensor] | None:
     """Load the graph-safe gfx942 Gluon MLA entry point when available."""
-    module_name = "aiter.ops.triton.gluon.mla_gluon_gfx942"
+    module_name = "aiter.ops.triton.attention.mla"
     try:
         module = importlib.import_module(module_name)
     except ModuleNotFoundError as import_error:

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -42,8 +42,8 @@ def _on_gfx942() -> bool:
 
 
 @functools.lru_cache(maxsize=1)
-def _get_mla_gluon_gfx942() -> Callable[..., torch.Tensor] | None:
-    """Load the graph-safe gfx942 Gluon MLA entry point when available."""
+def _get_triton_mla_decode_fwd() -> Callable[..., torch.Tensor] | None:
+    """Load the Triton MLA decode entry point when graph kwargs are available."""
     module_name = "aiter.ops.triton.attention.mla"
     try:
         module = importlib.import_module(module_name)
@@ -51,7 +51,14 @@ def _get_mla_gluon_gfx942() -> Callable[..., torch.Tensor] | None:
         if not module_name.startswith(import_error.name or ""):
             raise
         return None
-    return getattr(module, "mla_gluon_gfx942", None)
+    fn = getattr(module, "mla_decode_fwd", None)
+    if fn is None:
+        return None
+    import inspect
+
+    if "q_nope" not in inspect.signature(fn).parameters:
+        return None
+    return fn
 
 
 @functools.lru_cache(maxsize=1)
@@ -1320,7 +1327,7 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
             and decode.attn_out_dtype == torch.bfloat16
             and AiterMLAHelper.use_gluon_gfx942_graph(self.num_heads, qlen, num_reqs)
         ):
-            mla_gluon_gfx942 = _get_mla_gluon_gfx942()
+            triton_mla_decode_fwd = _get_triton_mla_decode_fwd()
             graph_inputs = _prepare_gluon_gfx942_graph_inputs(
                 q,
                 kv_c_and_k_pe_cache,
@@ -1330,7 +1337,7 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
                 self.kv_lora_rank,
                 self.qk_rope_head_dim,
             )
-            if mla_gluon_gfx942 is not None and graph_inputs is not None:
+            if triton_mla_decode_fwd is not None and graph_inputs is not None:
                 q_nope, q_pe, kv_buffer = graph_inputs
                 o = torch.empty(
                     num_reqs,
@@ -1340,14 +1347,24 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
                     dtype=decode.attn_out_dtype,
                     device=q_nope.device,
                 )
-                mla_gluon_gfx942(
-                    q_nope,
-                    q_pe,
+                triton_mla_decode_fwd(
+                    None,
                     kv_buffer,
                     o,
-                    decode.paged_kv_indices,
-                    decode.paged_kv_indptr,
+                    None,
+                    None,
+                    0,
+                    None,
                     self.scale,
+                    self.kv_lora_rank,
+                    self.qk_rope_head_dim,
+                    True,
+                    None,
+                    None,
+                    q_nope=q_nope,
+                    q_pe=q_pe,
+                    page_table=decode.paged_kv_indices,
+                    seq_info=decode.paged_kv_indptr,
                 )
                 return o.reshape(
                     num_reqs * qlen,

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -166,13 +166,14 @@ def _aiter_mla_small_head_mode() -> str:
 
     - ``"auto"`` (default): let the arch decide -- divisor head counts keep the
       Gluon decode where a build exists (gfx950), everything else (non-divisor
-      counts and all counts on gfx942) uses the padded persistent-scheduling
-      ASM decode.
+      counts and unsupported gfx942 shapes) uses the padded
+      persistent-scheduling ASM decode. Validated gfx942 12-head multi-token
+      shapes use the graph-safe Gluon path.
     - ``"gluon"``: prefer the Gluon path wherever a build exists.
-    - ``"asm"``: force the padded persistent-scheduling ASM decode.
+    - ``"asm"``: force the padded persistent-scheduling ASM decode, including
+      shapes supported by the gfx942 graph path.
 
-    On gfx942 (no Gluon build) the ASM path is always used regardless of this
-    setting; ``"gluon"`` there falls back to ASM with a one-time warning.
+    On gfx942, single-token and unsupported multi-token shapes use ASM.
     """
     import vllm.envs as envs
 
@@ -180,8 +181,9 @@ def _aiter_mla_small_head_mode() -> str:
     if mode == "gluon" and not _gluon_mla_decode_supported():
         logger.warning_once(
             "VLLM_ROCM_AITER_MLA_ASM_PADDING=gluon requested, but this device "
-            "has no Gluon MLA decode build (Gluon requires gfx950); using the "
-            "padded persistent-scheduling ASM decode instead."
+            "has no single-token Gluon MLA decode build (Gluon requires "
+            "gfx950); unsupported shapes use the padded "
+            "persistent-scheduling ASM decode."
         )
     return mode
 
@@ -1314,6 +1316,7 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
         # owns only the validated gfx942 BF16 multi-token shapes.
         if (
             _on_gfx942()
+            and _aiter_mla_small_head_mode() != "asm"
             and decode.attn_out_dtype == torch.bfloat16
             and AiterMLAHelper.use_gluon_gfx942_graph(self.num_heads, qlen, num_reqs)
         ):

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import functools
+import importlib
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import ClassVar, Final
@@ -30,6 +32,26 @@ from vllm.v1.attention.backend import (
 from vllm.v1.kv_cache_interface import AttentionSpec, is_quantized_kv_cache
 
 logger = init_logger(__name__)
+
+
+@functools.lru_cache(maxsize=1)
+def _on_gfx942() -> bool:
+    from vllm.platforms.rocm import on_gfx942
+
+    return on_gfx942()
+
+
+@functools.lru_cache(maxsize=1)
+def _get_mla_gluon_gfx942_graph() -> Callable[..., torch.Tensor] | None:
+    """Load the graph-safe gfx942 Gluon MLA entry point when available."""
+    module_name = "aiter.ops.triton.gluon.mla_gluon_gfx942"
+    try:
+        module = importlib.import_module(module_name)
+    except ModuleNotFoundError as import_error:
+        if not module_name.startswith(import_error.name or ""):
+            raise
+        return None
+    return getattr(module, "mla_gluon_gfx942_graph", None)
 
 
 @functools.lru_cache(maxsize=1)
@@ -898,6 +920,7 @@ class AiterMLAHelper:
     # fold that reaches a persistent one is gfx950-only.
     _ASM_PADDED_MAX_PS_QLEN: Final = 4
     _AITER_UNSUPPORTED_HEADS: ClassVar[tuple[int, ...]] = ()
+    _GLUON_GFX942_GRAPH_HEADS: Final = 12
 
     @staticmethod
     def check_num_heads_validity(num_heads: int):
@@ -991,6 +1014,55 @@ class AiterMLAHelper:
             return False
         # Same arch and mode gating as use_gluon_decode.
         return _aiter_mla_small_head_mode() != "asm" and _gluon_mla_decode_supported()
+
+    @staticmethod
+    def use_gluon_gfx942_graph(
+        num_heads: int,
+        max_qo_len: int,
+        num_reqs: int,
+    ) -> bool:
+        if num_heads != AiterMLAHelper._GLUON_GFX942_GRAPH_HEADS:
+            return False
+        if not 2 <= max_qo_len <= 8:
+            return False
+        if max_qo_len == 4:
+            return 1 <= num_reqs <= 16
+        return num_reqs == 1
+
+
+def _prepare_gluon_gfx942_graph_inputs(
+    q: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+    kv_c_and_k_pe_cache: torch.Tensor,
+    num_reqs: int,
+    qlen: int,
+    num_heads: int,
+    kv_lora_rank: int,
+    qk_rope_head_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None:
+    if type(q) is tuple:
+        q_nope, q_pe = q
+    else:
+        expected_q_dim = kv_lora_rank + qk_rope_head_dim
+        if q.ndim != 3 or q.shape[-1] != expected_q_dim:
+            return None
+        q_nope, q_pe = torch.split(q, [kv_lora_rank, qk_rope_head_dim], dim=-1)
+
+    num_tokens = num_reqs * qlen
+    if (
+        q_nope.shape != (num_tokens, num_heads, kv_lora_rank)
+        or q_pe.shape != (num_tokens, num_heads, qk_rope_head_dim)
+        or q_nope.dtype != torch.bfloat16
+        or q_pe.dtype != torch.bfloat16
+        or kv_c_and_k_pe_cache.dtype != torch.bfloat16
+        or kv_c_and_k_pe_cache.ndim < 2
+        or kv_c_and_k_pe_cache.shape[-1] != kv_lora_rank + qk_rope_head_dim
+    ):
+        return None
+
+    q_nope = q_nope.reshape(num_reqs, qlen, num_heads, kv_lora_rank)
+    q_pe = q_pe.reshape(num_reqs, qlen, num_heads, qk_rope_head_dim)
+    kv_buffer = kv_c_and_k_pe_cache.reshape(-1, kv_c_and_k_pe_cache.shape[-1])
+    return q_nope, q_pe, kv_buffer
 
 
 class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
@@ -1236,6 +1308,50 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
         assert decode.max_qo_len is not None
         assert decode.paged_kv_indptr is not None
         assert decode.paged_kv_indices is not None
+        qlen = int(decode.max_qo_len)
+        num_reqs = decode.paged_kv_indptr.shape[0] - 1
+        # Keep single-token decode on its existing path. This graph-safe kernel
+        # owns only the validated gfx942 BF16 multi-token shapes.
+        if (
+            _on_gfx942()
+            and decode.attn_out_dtype == torch.bfloat16
+            and AiterMLAHelper.use_gluon_gfx942_graph(self.num_heads, qlen, num_reqs)
+        ):
+            mla_gluon_gfx942_graph = _get_mla_gluon_gfx942_graph()
+            graph_inputs = _prepare_gluon_gfx942_graph_inputs(
+                q,
+                kv_c_and_k_pe_cache,
+                num_reqs,
+                qlen,
+                self.num_heads,
+                self.kv_lora_rank,
+                self.qk_rope_head_dim,
+            )
+            if mla_gluon_gfx942_graph is not None and graph_inputs is not None:
+                q_nope, q_pe, kv_buffer = graph_inputs
+                o = torch.empty(
+                    num_reqs,
+                    qlen,
+                    self.num_heads,
+                    self.kv_lora_rank,
+                    dtype=decode.attn_out_dtype,
+                    device=q_nope.device,
+                )
+                mla_gluon_gfx942_graph(
+                    q_nope,
+                    q_pe,
+                    kv_buffer,
+                    o,
+                    decode.paged_kv_indices,
+                    decode.paged_kv_indptr,
+                    self.scale,
+                )
+                return o.reshape(
+                    num_reqs * qlen,
+                    self.num_heads,
+                    self.kv_lora_rank,
+                ), None
+
         if decode.use_gluon_decode:
             if type(q) is tuple:
                 q_nope, q_pe = q

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -1039,7 +1039,7 @@ def _prepare_gluon_gfx942_graph_inputs(
     kv_lora_rank: int,
     qk_rope_head_dim: int,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None:
-    if type(q) is tuple:
+    if isinstance(q, tuple):
         q_nope, q_pe = q
     else:
         expected_q_dim = kv_lora_rank + qk_rope_head_dim

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -42,7 +42,7 @@ def _on_gfx942() -> bool:
 
 
 @functools.lru_cache(maxsize=1)
-def _get_mla_gluon_gfx942_graph() -> Callable[..., torch.Tensor] | None:
+def _get_mla_gluon_gfx942() -> Callable[..., torch.Tensor] | None:
     """Load the graph-safe gfx942 Gluon MLA entry point when available."""
     module_name = "aiter.ops.triton.attention.mla"
     try:
@@ -51,7 +51,7 @@ def _get_mla_gluon_gfx942_graph() -> Callable[..., torch.Tensor] | None:
         if not module_name.startswith(import_error.name or ""):
             raise
         return None
-    return getattr(module, "mla_gluon_gfx942_graph", None)
+    return getattr(module, "mla_gluon_gfx942", None)
 
 
 @functools.lru_cache(maxsize=1)
@@ -1320,7 +1320,7 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
             and decode.attn_out_dtype == torch.bfloat16
             and AiterMLAHelper.use_gluon_gfx942_graph(self.num_heads, qlen, num_reqs)
         ):
-            mla_gluon_gfx942_graph = _get_mla_gluon_gfx942_graph()
+            mla_gluon_gfx942 = _get_mla_gluon_gfx942()
             graph_inputs = _prepare_gluon_gfx942_graph_inputs(
                 q,
                 kv_c_and_k_pe_cache,
@@ -1330,7 +1330,7 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
                 self.kv_lora_rank,
                 self.qk_rope_head_dim,
             )
-            if mla_gluon_gfx942_graph is not None and graph_inputs is not None:
+            if mla_gluon_gfx942 is not None and graph_inputs is not None:
                 q_nope, q_pe, kv_buffer = graph_inputs
                 o = torch.empty(
                     num_reqs,
@@ -1340,7 +1340,7 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
                     dtype=decode.attn_out_dtype,
                     device=q_nope.device,
                 )
-                mla_gluon_gfx942_graph(
+                mla_gluon_gfx942(
                     q_nope,
                     q_pe,
                     kv_buffer,


### PR DESCRIPTION
## Summary

Dispatch validated gfx942 Kimi-K3 multi-token verification shapes to the graph-safe CDNA3 Gluon MLA kernel from [ROCm/aiter#4582](https://github.com/ROCm/aiter/pull/4582).

The dispatch is limited to 12 BF16 query heads. QLEN=4 is enabled through request batch 16, while other validated multi-token lengths remain single-request only. The backend passes existing ragged token metadata directly and flattens the physical KV cache before applying token-level indices, so the path remains capture-safe.

Single-token decode remains on persistent ASM for gfx942. Unsupported shapes also use ASM with 12 heads padded to 16. Existing gfx950 Gluon behavior is unchanged.

## Dependencies and scope

This draft depends on the gfx942 graph kwargs in `mla_decode_fwd` from [ROCm/aiter#4582](https://github.com/ROCm/aiter/pull/4582) (`maeehart/gfx942-gluon-mla`, commit `62dbc1af`).

The non-divisor padding and CDNA4 architecture gate from merged [#50578](https://github.com/vllm-project/vllm/pull/50578) are now consumed directly from current `main`. This PR only adds the gfx942 graph dispatch.

Full Kimi-K3 DSpark graph validation uses the causal Triton MLA support from [#51065](https://github.com/vllm-project/vllm/pull/51065).

The dispatch feature-probes `mla_decode_fwd` for graph kwargs (`q_nope`, `q_pe`, `page_table`, `seq_info`), so older AITER versions retain the existing path. This PR remains draft until ROCm/aiter#4582 is available in the tested AITER dependency and #51065 is available for full causal DSpark validation.

## Test plan

```bash
python -m pytest -q \
  tests/v1/attention/test_rocm_aiter_mla_gfx942_gluon.py

python -m pytest -q \
  tests/kernels/attention/test_rocm_aiter_mla_causal_verify_mask.py

python -m ruff check \
  vllm/v1/attention/backends/mla/rocm_aiter_mla.py \
  tests/v1/attention/test_rocm_aiter_mla_gfx942_gluon.py \
  tests/kernels/attention/test_rocm_aiter_mla_causal_verify_mask.py
```

Serving validation uses Kimi-K3 TP8 with DSpark k=3 on 8 MI325X GPUs, BF16 KV, expert parallelism, and `FULL_AND_PIECEWISE` graph capture. The workload uses 1,024 input tokens, 128 output tokens, and greedy target sampling.

## Results

The focused dispatch suite passes:

```text
20 passed
```

The dependent AITER gfx942 suite passes 12 tests covering graph replay, ragged paging, 768-token physical blocks, fused QLEN/head rows, and large-cache addressing.

Captured QLEN=4 kernel time on MI325X:

| Request batch | Persistent ASM | gfx942 Gluon | Speedup |
|---:|---:|---:|---:|
| 1 | 29.81 us | 18.87 us | 1.58x |
| 4 | 34.16 us | 22.89 us | 1.49x |
| 16 | 34.64 us | 33.04 us | 1.05x |

Full serving results:

| Concurrency | Persistent ASM | Candidate |
|---:|---:|---:|
| 1 | 60.02 output tok/s | 62.14 output tok/s |
| 16 | 299.42 output tok/s | 300.54 +/- 4.61 output tok/s |

The concurrency-16 candidate value is the mean of three runs: 295.35, 302.15, and 304.13 output tok/s. The end-to-end difference from persistent ASM is small relative to run variation, while the kernel path removes 16-head padding for the selected shapes.

Full graph capture completes without a downgrade or memory fault. A 200-question greedy GSM8K serving check scored 192/200, or 96.0%, matching the persistent ASM reference.
